### PR TITLE
refactor(scripts): migrate minimize-superseded-markers onto parseArgs

### DIFF
--- a/idd-template/scripts/minimize-superseded-markers.mjs
+++ b/idd-template/scripts/minimize-superseded-markers.mjs
@@ -6,6 +6,7 @@
 // never the generated .mjs. See docs/typescript-sources.md.
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
 
 // Deliberately NOT importing the shared config-loader module (see #1208's
 // PR discussion): docs/idd-helper-scripts.md documents that this helper
@@ -55,7 +56,7 @@ const NODE_ID_CONVERSION_COMMANDS = [
 if (import.meta.main) {
   let args;
   try {
-    args = parseArgs(process.argv.slice(2));
+    args = parseMinimizeArgs(process.argv.slice(2));
   } catch (error) {
     console.error(`error: ${error.message}`);
     process.exit(2);
@@ -443,72 +444,81 @@ function runGh(argv) {
     };
   }
 }
-function parseArgs(argv) {
-  const args = {
-    subjectIds: [],
-    classifier: 'OUTDATED',
-    trustedMarkerLogins: '',
-    apply: false,
-    allowUntrusted: false,
-    format: 'json',
-    help: false,
-  };
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === '--help' || arg === '-h') {
-      args.help = true;
-      continue;
+// Calls node:util's parseArgs directly rather than the shared
+// src/scripts/cli-args.mts wrapper: cli-args.mts is a `./`-relative
+// import, which would break this file's self-contained invariant (see the
+// loadIddConfig() comment above) — node:util is a built-in, so it does
+// not. This file has zero integer flags, so it needs none of the
+// wrapper's extra canonical-integer / single-dash-disambiguation helpers.
+// See kurone-kito/idd-skill#1486 for the full disposition writeup.
+//
+// Narrow, deliberate behavior deltas from the previous hand-rolled
+// for/switch loop (none is exercised by tests/minimize-superseded-markers.test.mts,
+// and docs/idd-helper-scripts.md does not name any of their exact wording —
+// the same class of accepted delta already shipped for this file's
+// if (!value)-cohort siblings idd-doctor.mts / verify-workshop-integrity.mts
+// in kurone-kito/idd-skill#1467). All still exit 2 via the unchanged outer
+// try/catch below, same as the behavior they replace:
+//   - A value-taking flag with genuinely nothing after it (end of argv)
+//     now throws parseArgs' own "Option '--x <value>' argument missing"
+//     instead of this file's old per-flag `--x requires a value` text.
+//     (The *empty-string* case -- `--x ''` -- is unaffected: the explicit
+//     post-parse check below still throws the exact original message for
+//     that case, which is the behavior kurone-kito/idd-skill#1451 was
+//     actually concerned with.)
+//   - An unknown flag or unexpected bare argument now surfaces parseArgs'
+//     own "Unknown option '--x'" / "Unexpected argument 'x'..." text
+//     instead of this file's old uniform `unknown argument: <token>`.
+//   - A dash-shaped value passed to a string flag (e.g.
+//     `--subject-ids --apply`) is now rejected up front ("argument is
+//     ambiguous", exit 2) where the old loop silently accepted it as a
+//     literal string value -- previously this often still failed, but
+//     later and indirectly, once the bogus value's `gh` probe lookup
+//     failed (a per-item failure, exit 1 via computeExitCode).
+//   - `--apply=<value>` (or any other boolean flag with `=`) now throws
+//     "does not take an argument" instead of falling through to
+//     `unknown argument: --apply=<value>`.
+function parseMinimizeArgs(argv) {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      help: { type: 'boolean', short: 'h' },
+      apply: { type: 'boolean' },
+      'allow-untrusted': { type: 'boolean' },
+      'subject-ids': { type: 'string' },
+      classifier: { type: 'string', default: 'OUTDATED' },
+      // '--trusted-marker-logins' is the one flag whose empty string is a
+      // meaningful, accepted value (an explicit empty override in
+      // resolveTrustedActors()'s flag > env > config ladder) -- unlike
+      // the three flags checked below, it gets no post-parse empty-string
+      // rejection; parseArgs' own "argument missing" error already covers
+      // the genuinely-absent case.
+      'trusted-marker-logins': { type: 'string', default: '' },
+      format: { type: 'string', default: 'json' },
+    },
+    strict: true,
+  });
+  // parseArgs accepts an explicit empty string for every string flag (only
+  // a genuinely missing value throws), but --subject-ids/--classifier/
+  // --format never treated '' as meaningful -- reproduce that rejection
+  // explicitly, matching the original `if (!value)` guards' exact message.
+  for (const flag of ['subject-ids', 'classifier', 'format']) {
+    if (values[flag] === '') {
+      throw new Error(`--${flag} requires a value`);
     }
-    if (arg === '--apply') {
-      args.apply = true;
-      continue;
-    }
-    if (arg === '--allow-untrusted') {
-      args.allowUntrusted = true;
-      continue;
-    }
-    if (arg === '--subject-ids') {
-      const value = argv[index + 1];
-      if (!value) {
-        throw new Error('--subject-ids requires a value');
-      }
-      args.subjectIds = value
-        .split(',')
-        .map((id) => id.trim())
-        .filter((id) => id.length > 0);
-      index += 1;
-      continue;
-    }
-    if (arg === '--classifier') {
-      const value = argv[index + 1];
-      if (!value) {
-        throw new Error('--classifier requires a value');
-      }
-      args.classifier = value;
-      index += 1;
-      continue;
-    }
-    if (arg === '--trusted-marker-logins') {
-      const value = argv[index + 1];
-      if (value === undefined) {
-        throw new Error('--trusted-marker-logins requires a value');
-      }
-      args.trustedMarkerLogins = value;
-      index += 1;
-      continue;
-    }
-    if (arg === '--format') {
-      const value = argv[index + 1];
-      if (!value) {
-        throw new Error('--format requires a value');
-      }
-      args.format = value;
-      index += 1;
-      continue;
-    }
-    throw new Error(`unknown argument: ${arg}`);
   }
-  return args;
+  return {
+    subjectIds: (values['subject-ids'] ?? '')
+      .split(',')
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0),
+    classifier: values.classifier ?? 'OUTDATED',
+    trustedMarkerLogins: values['trusted-marker-logins'] ?? '',
+    apply: values.apply ?? false,
+    allowUntrusted: values['allow-untrusted'] ?? false,
+    format: values.format ?? 'json',
+    help: values.help ?? false,
+  };
 }
 function printUsage() {
   console.log(`Usage: minimize-superseded-markers --subject-ids <id1,id2,...> [--classifier OUTDATED|RESOLVED] [--trusted-marker-logins login1,login2] [--allow-untrusted] [--apply] [--format json|table]

--- a/idd-template/scripts/minimize-superseded-markers.mjs
+++ b/idd-template/scripts/minimize-superseded-markers.mjs
@@ -478,6 +478,13 @@ function runGh(argv) {
 //   - `--apply=<value>` (or any other boolean flag with `=`) now throws
 //     "does not take an argument" instead of falling through to
 //     `unknown argument: --apply=<value>`.
+//   - Conversely, `--subject-ids=<value>` (or `=` on any other string
+//     flag) is now silently *accepted* as an alternate value syntax; the
+//     old loop's exact `arg === '--subject-ids'` comparison never matched
+//     the `=`-joined form, so it fell through to
+//     `unknown argument: --subject-ids=<value>`. The empty-string form
+//     (`--subject-ids=`) is unaffected either way -- it still hits the
+//     post-parse check below exactly like `--subject-ids ''` does.
 function parseMinimizeArgs(argv) {
   const { values } = parseArgs({
     args: argv,

--- a/idd-template/scripts/minimize-superseded-markers.mjs
+++ b/idd-template/scripts/minimize-superseded-markers.mjs
@@ -457,8 +457,9 @@ function runGh(argv) {
 // and docs/idd-helper-scripts.md does not name any of their exact wording —
 // the same class of accepted delta already shipped for this file's
 // if (!value)-cohort siblings idd-doctor.mts / verify-workshop-integrity.mts
-// in kurone-kito/idd-skill#1467). All still exit 2 via the unchanged outer
-// try/catch below, same as the behavior they replace:
+// in kurone-kito/idd-skill#1467). All still exit 2 via the unchanged
+// try/catch in the import.meta.main entrypoint above (which calls this
+// function), same as the behavior they replace:
 //   - A value-taking flag with genuinely nothing after it (end of argv)
 //     now throws parseArgs' own "Option '--x <value>' argument missing"
 //     instead of this file's old per-flag `--x requires a value` text.

--- a/idd-template/scripts/minimize-superseded-markers.mjs
+++ b/idd-template/scripts/minimize-superseded-markers.mjs
@@ -485,6 +485,12 @@ function runGh(argv) {
 //     `unknown argument: --subject-ids=<value>`. The empty-string form
 //     (`--subject-ids=`) is unaffected either way -- it still hits the
 //     post-parse check below exactly like `--subject-ids ''` does.
+//   - A bare trailing `--` (the POSIX end-of-options marker) is now
+//     silently accepted as a no-op, where the old loop's exact-match
+//     fallthrough rejected it as `unknown argument: --`. Not expected to
+//     matter in practice: this helper is only ever invoked from fixed,
+//     known argument lists (CI workflows, documented manual commands),
+//     never arbitrary/untrusted argv.
 function parseMinimizeArgs(argv) {
   const { values } = parseArgs({
     args: argv,

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -6,6 +6,7 @@
 // never the generated .mjs. See docs/typescript-sources.md.
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
 
 // Deliberately NOT importing the shared config-loader module (see #1208's
 // PR discussion): docs/idd-helper-scripts.md documents that this helper
@@ -55,7 +56,7 @@ const NODE_ID_CONVERSION_COMMANDS = [
 if (import.meta.main) {
   let args;
   try {
-    args = parseArgs(process.argv.slice(2));
+    args = parseMinimizeArgs(process.argv.slice(2));
   } catch (error) {
     console.error(`error: ${error.message}`);
     process.exit(2);
@@ -443,72 +444,81 @@ function runGh(argv) {
     };
   }
 }
-function parseArgs(argv) {
-  const args = {
-    subjectIds: [],
-    classifier: 'OUTDATED',
-    trustedMarkerLogins: '',
-    apply: false,
-    allowUntrusted: false,
-    format: 'json',
-    help: false,
-  };
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === '--help' || arg === '-h') {
-      args.help = true;
-      continue;
+// Calls node:util's parseArgs directly rather than the shared
+// src/scripts/cli-args.mts wrapper: cli-args.mts is a `./`-relative
+// import, which would break this file's self-contained invariant (see the
+// loadIddConfig() comment above) — node:util is a built-in, so it does
+// not. This file has zero integer flags, so it needs none of the
+// wrapper's extra canonical-integer / single-dash-disambiguation helpers.
+// See kurone-kito/idd-skill#1486 for the full disposition writeup.
+//
+// Narrow, deliberate behavior deltas from the previous hand-rolled
+// for/switch loop (none is exercised by tests/minimize-superseded-markers.test.mts,
+// and docs/idd-helper-scripts.md does not name any of their exact wording —
+// the same class of accepted delta already shipped for this file's
+// if (!value)-cohort siblings idd-doctor.mts / verify-workshop-integrity.mts
+// in kurone-kito/idd-skill#1467). All still exit 2 via the unchanged outer
+// try/catch below, same as the behavior they replace:
+//   - A value-taking flag with genuinely nothing after it (end of argv)
+//     now throws parseArgs' own "Option '--x <value>' argument missing"
+//     instead of this file's old per-flag `--x requires a value` text.
+//     (The *empty-string* case -- `--x ''` -- is unaffected: the explicit
+//     post-parse check below still throws the exact original message for
+//     that case, which is the behavior kurone-kito/idd-skill#1451 was
+//     actually concerned with.)
+//   - An unknown flag or unexpected bare argument now surfaces parseArgs'
+//     own "Unknown option '--x'" / "Unexpected argument 'x'..." text
+//     instead of this file's old uniform `unknown argument: <token>`.
+//   - A dash-shaped value passed to a string flag (e.g.
+//     `--subject-ids --apply`) is now rejected up front ("argument is
+//     ambiguous", exit 2) where the old loop silently accepted it as a
+//     literal string value -- previously this often still failed, but
+//     later and indirectly, once the bogus value's `gh` probe lookup
+//     failed (a per-item failure, exit 1 via computeExitCode).
+//   - `--apply=<value>` (or any other boolean flag with `=`) now throws
+//     "does not take an argument" instead of falling through to
+//     `unknown argument: --apply=<value>`.
+function parseMinimizeArgs(argv) {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      help: { type: 'boolean', short: 'h' },
+      apply: { type: 'boolean' },
+      'allow-untrusted': { type: 'boolean' },
+      'subject-ids': { type: 'string' },
+      classifier: { type: 'string', default: 'OUTDATED' },
+      // '--trusted-marker-logins' is the one flag whose empty string is a
+      // meaningful, accepted value (an explicit empty override in
+      // resolveTrustedActors()'s flag > env > config ladder) -- unlike
+      // the three flags checked below, it gets no post-parse empty-string
+      // rejection; parseArgs' own "argument missing" error already covers
+      // the genuinely-absent case.
+      'trusted-marker-logins': { type: 'string', default: '' },
+      format: { type: 'string', default: 'json' },
+    },
+    strict: true,
+  });
+  // parseArgs accepts an explicit empty string for every string flag (only
+  // a genuinely missing value throws), but --subject-ids/--classifier/
+  // --format never treated '' as meaningful -- reproduce that rejection
+  // explicitly, matching the original `if (!value)` guards' exact message.
+  for (const flag of ['subject-ids', 'classifier', 'format']) {
+    if (values[flag] === '') {
+      throw new Error(`--${flag} requires a value`);
     }
-    if (arg === '--apply') {
-      args.apply = true;
-      continue;
-    }
-    if (arg === '--allow-untrusted') {
-      args.allowUntrusted = true;
-      continue;
-    }
-    if (arg === '--subject-ids') {
-      const value = argv[index + 1];
-      if (!value) {
-        throw new Error('--subject-ids requires a value');
-      }
-      args.subjectIds = value
-        .split(',')
-        .map((id) => id.trim())
-        .filter((id) => id.length > 0);
-      index += 1;
-      continue;
-    }
-    if (arg === '--classifier') {
-      const value = argv[index + 1];
-      if (!value) {
-        throw new Error('--classifier requires a value');
-      }
-      args.classifier = value;
-      index += 1;
-      continue;
-    }
-    if (arg === '--trusted-marker-logins') {
-      const value = argv[index + 1];
-      if (value === undefined) {
-        throw new Error('--trusted-marker-logins requires a value');
-      }
-      args.trustedMarkerLogins = value;
-      index += 1;
-      continue;
-    }
-    if (arg === '--format') {
-      const value = argv[index + 1];
-      if (!value) {
-        throw new Error('--format requires a value');
-      }
-      args.format = value;
-      index += 1;
-      continue;
-    }
-    throw new Error(`unknown argument: ${arg}`);
   }
-  return args;
+  return {
+    subjectIds: (values['subject-ids'] ?? '')
+      .split(',')
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0),
+    classifier: values.classifier ?? 'OUTDATED',
+    trustedMarkerLogins: values['trusted-marker-logins'] ?? '',
+    apply: values.apply ?? false,
+    allowUntrusted: values['allow-untrusted'] ?? false,
+    format: values.format ?? 'json',
+    help: values.help ?? false,
+  };
 }
 function printUsage() {
   console.log(`Usage: minimize-superseded-markers --subject-ids <id1,id2,...> [--classifier OUTDATED|RESOLVED] [--trusted-marker-logins login1,login2] [--allow-untrusted] [--apply] [--format json|table]

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -478,6 +478,13 @@ function runGh(argv) {
 //   - `--apply=<value>` (or any other boolean flag with `=`) now throws
 //     "does not take an argument" instead of falling through to
 //     `unknown argument: --apply=<value>`.
+//   - Conversely, `--subject-ids=<value>` (or `=` on any other string
+//     flag) is now silently *accepted* as an alternate value syntax; the
+//     old loop's exact `arg === '--subject-ids'` comparison never matched
+//     the `=`-joined form, so it fell through to
+//     `unknown argument: --subject-ids=<value>`. The empty-string form
+//     (`--subject-ids=`) is unaffected either way -- it still hits the
+//     post-parse check below exactly like `--subject-ids ''` does.
 function parseMinimizeArgs(argv) {
   const { values } = parseArgs({
     args: argv,

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -457,8 +457,9 @@ function runGh(argv) {
 // and docs/idd-helper-scripts.md does not name any of their exact wording —
 // the same class of accepted delta already shipped for this file's
 // if (!value)-cohort siblings idd-doctor.mts / verify-workshop-integrity.mts
-// in kurone-kito/idd-skill#1467). All still exit 2 via the unchanged outer
-// try/catch below, same as the behavior they replace:
+// in kurone-kito/idd-skill#1467). All still exit 2 via the unchanged
+// try/catch in the import.meta.main entrypoint above (which calls this
+// function), same as the behavior they replace:
 //   - A value-taking flag with genuinely nothing after it (end of argv)
 //     now throws parseArgs' own "Option '--x <value>' argument missing"
 //     instead of this file's old per-flag `--x requires a value` text.

--- a/scripts/minimize-superseded-markers.mjs
+++ b/scripts/minimize-superseded-markers.mjs
@@ -485,6 +485,12 @@ function runGh(argv) {
 //     `unknown argument: --subject-ids=<value>`. The empty-string form
 //     (`--subject-ids=`) is unaffected either way -- it still hits the
 //     post-parse check below exactly like `--subject-ids ''` does.
+//   - A bare trailing `--` (the POSIX end-of-options marker) is now
+//     silently accepted as a no-op, where the old loop's exact-match
+//     fallthrough rejected it as `unknown argument: --`. Not expected to
+//     matter in practice: this helper is only ever invoked from fixed,
+//     known argument lists (CI workflows, documented manual commands),
+//     never arbitrary/untrusted argv.
 function parseMinimizeArgs(argv) {
   const { values } = parseArgs({
     args: argv,

--- a/src/scripts/minimize-superseded-markers.mts
+++ b/src/scripts/minimize-superseded-markers.mts
@@ -609,6 +609,12 @@ function runGh(argv: string[]): GhResult {
 //     `unknown argument: --subject-ids=<value>`. The empty-string form
 //     (`--subject-ids=`) is unaffected either way -- it still hits the
 //     post-parse check below exactly like `--subject-ids ''` does.
+//   - A bare trailing `--` (the POSIX end-of-options marker) is now
+//     silently accepted as a no-op, where the old loop's exact-match
+//     fallthrough rejected it as `unknown argument: --`. Not expected to
+//     matter in practice: this helper is only ever invoked from fixed,
+//     known argument lists (CI workflows, documented manual commands),
+//     never arbitrary/untrusted argv.
 function parseMinimizeArgs(argv: string[]): MinimizeArgs {
   const { values } = parseArgs({
     args: argv,

--- a/src/scripts/minimize-superseded-markers.mts
+++ b/src/scripts/minimize-superseded-markers.mts
@@ -602,6 +602,13 @@ function runGh(argv: string[]): GhResult {
 //   - `--apply=<value>` (or any other boolean flag with `=`) now throws
 //     "does not take an argument" instead of falling through to
 //     `unknown argument: --apply=<value>`.
+//   - Conversely, `--subject-ids=<value>` (or `=` on any other string
+//     flag) is now silently *accepted* as an alternate value syntax; the
+//     old loop's exact `arg === '--subject-ids'` comparison never matched
+//     the `=`-joined form, so it fell through to
+//     `unknown argument: --subject-ids=<value>`. The empty-string form
+//     (`--subject-ids=`) is unaffected either way -- it still hits the
+//     post-parse check below exactly like `--subject-ids ''` does.
 function parseMinimizeArgs(argv: string[]): MinimizeArgs {
   const { values } = parseArgs({
     args: argv,

--- a/src/scripts/minimize-superseded-markers.mts
+++ b/src/scripts/minimize-superseded-markers.mts
@@ -7,6 +7,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { parseArgs } from 'node:util';
 
 // Deliberately NOT importing the shared config-loader module (see #1208's
 // PR discussion): docs/idd-helper-scripts.md documents that this helper
@@ -109,7 +110,7 @@ interface MinimizeArgs {
 if (import.meta.main) {
   let args: MinimizeArgs;
   try {
-    args = parseArgs(process.argv.slice(2));
+    args = parseMinimizeArgs(process.argv.slice(2));
   } catch (error) {
     console.error(`error: ${(error as Error).message}`);
     process.exit(2);
@@ -567,74 +568,83 @@ function runGh(argv: string[]): GhResult {
   }
 }
 
-function parseArgs(argv: string[]): MinimizeArgs {
-  const args: MinimizeArgs = {
-    subjectIds: [],
-    classifier: 'OUTDATED',
-    trustedMarkerLogins: '',
-    apply: false,
-    allowUntrusted: false,
-    format: 'json',
-    help: false,
-  };
+// Calls node:util's parseArgs directly rather than the shared
+// src/scripts/cli-args.mts wrapper: cli-args.mts is a `./`-relative
+// import, which would break this file's self-contained invariant (see the
+// loadIddConfig() comment above) — node:util is a built-in, so it does
+// not. This file has zero integer flags, so it needs none of the
+// wrapper's extra canonical-integer / single-dash-disambiguation helpers.
+// See kurone-kito/idd-skill#1486 for the full disposition writeup.
+//
+// Narrow, deliberate behavior deltas from the previous hand-rolled
+// for/switch loop (none is exercised by tests/minimize-superseded-markers.test.mts,
+// and docs/idd-helper-scripts.md does not name any of their exact wording —
+// the same class of accepted delta already shipped for this file's
+// if (!value)-cohort siblings idd-doctor.mts / verify-workshop-integrity.mts
+// in kurone-kito/idd-skill#1467). All still exit 2 via the unchanged outer
+// try/catch below, same as the behavior they replace:
+//   - A value-taking flag with genuinely nothing after it (end of argv)
+//     now throws parseArgs' own "Option '--x <value>' argument missing"
+//     instead of this file's old per-flag `--x requires a value` text.
+//     (The *empty-string* case -- `--x ''` -- is unaffected: the explicit
+//     post-parse check below still throws the exact original message for
+//     that case, which is the behavior kurone-kito/idd-skill#1451 was
+//     actually concerned with.)
+//   - An unknown flag or unexpected bare argument now surfaces parseArgs'
+//     own "Unknown option '--x'" / "Unexpected argument 'x'..." text
+//     instead of this file's old uniform `unknown argument: <token>`.
+//   - A dash-shaped value passed to a string flag (e.g.
+//     `--subject-ids --apply`) is now rejected up front ("argument is
+//     ambiguous", exit 2) where the old loop silently accepted it as a
+//     literal string value -- previously this often still failed, but
+//     later and indirectly, once the bogus value's `gh` probe lookup
+//     failed (a per-item failure, exit 1 via computeExitCode).
+//   - `--apply=<value>` (or any other boolean flag with `=`) now throws
+//     "does not take an argument" instead of falling through to
+//     `unknown argument: --apply=<value>`.
+function parseMinimizeArgs(argv: string[]): MinimizeArgs {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      help: { type: 'boolean', short: 'h' },
+      apply: { type: 'boolean' },
+      'allow-untrusted': { type: 'boolean' },
+      'subject-ids': { type: 'string' },
+      classifier: { type: 'string', default: 'OUTDATED' },
+      // '--trusted-marker-logins' is the one flag whose empty string is a
+      // meaningful, accepted value (an explicit empty override in
+      // resolveTrustedActors()'s flag > env > config ladder) -- unlike
+      // the three flags checked below, it gets no post-parse empty-string
+      // rejection; parseArgs' own "argument missing" error already covers
+      // the genuinely-absent case.
+      'trusted-marker-logins': { type: 'string', default: '' },
+      format: { type: 'string', default: 'json' },
+    },
+    strict: true,
+  });
 
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === '--help' || arg === '-h') {
-      args.help = true;
-      continue;
+  // parseArgs accepts an explicit empty string for every string flag (only
+  // a genuinely missing value throws), but --subject-ids/--classifier/
+  // --format never treated '' as meaningful -- reproduce that rejection
+  // explicitly, matching the original `if (!value)` guards' exact message.
+  for (const flag of ['subject-ids', 'classifier', 'format'] as const) {
+    if (values[flag] === '') {
+      throw new Error(`--${flag} requires a value`);
     }
-    if (arg === '--apply') {
-      args.apply = true;
-      continue;
-    }
-    if (arg === '--allow-untrusted') {
-      args.allowUntrusted = true;
-      continue;
-    }
-    if (arg === '--subject-ids') {
-      const value = argv[index + 1];
-      if (!value) {
-        throw new Error('--subject-ids requires a value');
-      }
-      args.subjectIds = value
-        .split(',')
-        .map((id) => id.trim())
-        .filter((id) => id.length > 0);
-      index += 1;
-      continue;
-    }
-    if (arg === '--classifier') {
-      const value = argv[index + 1];
-      if (!value) {
-        throw new Error('--classifier requires a value');
-      }
-      args.classifier = value;
-      index += 1;
-      continue;
-    }
-    if (arg === '--trusted-marker-logins') {
-      const value = argv[index + 1];
-      if (value === undefined) {
-        throw new Error('--trusted-marker-logins requires a value');
-      }
-      args.trustedMarkerLogins = value;
-      index += 1;
-      continue;
-    }
-    if (arg === '--format') {
-      const value = argv[index + 1];
-      if (!value) {
-        throw new Error('--format requires a value');
-      }
-      args.format = value;
-      index += 1;
-      continue;
-    }
-    throw new Error(`unknown argument: ${arg}`);
   }
 
-  return args;
+  return {
+    subjectIds: (values['subject-ids'] ?? '')
+      .split(',')
+      .map((id) => id.trim())
+      .filter((id) => id.length > 0),
+    classifier: values.classifier ?? 'OUTDATED',
+    trustedMarkerLogins: values['trusted-marker-logins'] ?? '',
+    apply: values.apply ?? false,
+    allowUntrusted: values['allow-untrusted'] ?? false,
+    format: values.format ?? 'json',
+    help: values.help ?? false,
+  };
 }
 
 function printUsage(): void {

--- a/src/scripts/minimize-superseded-markers.mts
+++ b/src/scripts/minimize-superseded-markers.mts
@@ -581,8 +581,9 @@ function runGh(argv: string[]): GhResult {
 // and docs/idd-helper-scripts.md does not name any of their exact wording —
 // the same class of accepted delta already shipped for this file's
 // if (!value)-cohort siblings idd-doctor.mts / verify-workshop-integrity.mts
-// in kurone-kito/idd-skill#1467). All still exit 2 via the unchanged outer
-// try/catch below, same as the behavior they replace:
+// in kurone-kito/idd-skill#1467). All still exit 2 via the unchanged
+// try/catch in the import.meta.main entrypoint above (which calls this
+// function), same as the behavior they replace:
 //   - A value-taking flag with genuinely nothing after it (end of argv)
 //     now throws parseArgs' own "Option '--x <value>' argument missing"
 //     instead of this file's old per-flag `--x requires a value` text.

--- a/tests/minimize-superseded-markers.test.mts
+++ b/tests/minimize-superseded-markers.test.mts
@@ -159,6 +159,81 @@ test('config-only resolution passes the author gate end to end', () => {
   }
 });
 
+// These two tests demonstrate the one deliberate parseArgs-migration
+// asymmetry kurone-kito/idd-skill#1451/#1486 were concerned with: parseArgs
+// itself accepts an explicit empty string for every string flag (only a
+// genuinely missing value throws), so --subject-ids/--classifier/--format
+// need an explicit post-parse check to keep rejecting '', while
+// --trusted-marker-logins deliberately keeps accepting '' as a meaningful
+// value (see resolveTrustedActors()'s flag > env > config ladder).
+test('an explicit empty --subject-ids value is rejected at parse time', () => {
+  const script = join(
+    dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'scripts',
+    'minimize-superseded-markers.mjs',
+  );
+  const result = spawnSync(
+    process.execPath,
+    [script, '--subject-ids', '', '--allow-untrusted'],
+    { encoding: 'utf8' },
+  );
+
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout, '');
+  assert.equal(result.stderr.trim(), 'error: --subject-ids requires a value');
+});
+
+test('an explicit empty --trusted-marker-logins value is accepted, unlike --subject-ids', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-minimize-'));
+  try {
+    // Stub gh to fail deterministically and offline: a per-item failure
+    // (exit 1) proves the empty string reached resolveTrustedActors()
+    // instead of being rejected at parse time (which would be exit 2 with
+    // the "requires a value" message, before any gh call happens at all).
+    const binDir = join(sandbox, 'bin');
+    mkdirSync(binDir);
+    writeFileSync(join(binDir, 'gh'), '#!/bin/sh\nexit 1\n');
+    chmodSync(join(binDir, 'gh'), 0o755);
+
+    const script = join(
+      dirname(fileURLToPath(import.meta.url)),
+      '..',
+      'scripts',
+      'minimize-superseded-markers.mjs',
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        script,
+        '--subject-ids',
+        'IC_test',
+        '--trusted-marker-logins',
+        '',
+        '--allow-untrusted',
+        '--format',
+        'json',
+      ],
+      {
+        cwd: sandbox,
+        env: {
+          ...process.env,
+          PATH: binDir,
+          IDD_TRUSTED_MARKER_ACTORS: '',
+        },
+        encoding: 'utf8',
+      },
+    );
+
+    assert.equal(result.status, 1, result.stderr);
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.trustedMarkerActorsSource, 'none');
+    assert.deepEqual(report.trustedMarkerActors, []);
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
 // cspell:ignore Wpaqs
 // Shared by the three "unresolvable node id" tests below, so each test only
 // supplies its --subject-ids value and assertions instead of repeating the


### PR DESCRIPTION
# Summary

Migrates `src/scripts/minimize-superseded-markers.mts` (and its two
generated `.mjs` mirrors) from a hand-rolled `for`/`switch` CLI-argument
dispatch loop onto `node:util`'s `parseArgs` (called directly, `strict:
true`), implementing the maintainer's option-1 pick from #1486 rather than
the shared `src/scripts/cli-args.mts` wrapper the rest of the roadmap
migrated onto in #1467. `node:util` is a Node built-in, not a
`./`-relative import, so it preserves this file's separate,
pre-existing, self-contained-template-mirror invariant
(`idd-template/scripts/` ships only this one file, zero cross-file
imports) — confirmed structurally by `tests/standalone-mirror-imports.test.mts`,
which asserts the exact-mode `idd-template/scripts/` mirror source
imports only `node:`-prefixed specifiers.

The CLI contract (flag names, help text, defaults, exit codes) is
preserved exactly for every path any existing test or doc names,
including the one behavior nuance #1451 called out specifically: three
string flags (`--subject-ids`, `--classifier`, `--format`) keep
rejecting an explicit empty string via an added post-parse check
(`parseArgs` itself accepts `''` natively), while `--trusted-marker-logins`
keeps accepting an explicit empty override, relying on `parseArgs`'
own missing-value rejection for the genuinely-absent case. Verified
byte-for-byte before/after CLI output for every preserved path. A
handful of edge cases with **no** test or doc coverage (a genuinely-missing
value's exact wording, unknown-flag/positional wording, a dash-shaped
value now being rejected instead of silently accepted, `--flag=value`
on a boolean, and conversely `--flag=value` on a string flag now being
silently accepted where it previously was not) intentionally now
surface `parseArgs`' own message text instead of this file's old text —
documented inline in a code comment, matching the precedent already
shipped for this same cohort's other two files
(`idd-doctor.mts` / `verify-workshop-integrity.mts`) in #1467.

An independent C1 critique pass on the first commit found two gaps
(documented delta list omitted the string-flag `=`-syntax acceptance;
no test directly exercised the empty-string-vs-missing asymmetry) — both
fixed in the second commit with a comment addition and two new focused
tests.

## Linked issue

Closes #1486

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

#1451 migrated 16 of 17 hand-rolled parsers onto `cli-args.mts`;
this file was deliberately left unmigrated pending a maintainer
decision among three options (see #1486). This PR is the last piece —
merging it lets #1451 close.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (2347 tests pass)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
