### PR TITLE
fix(disposition-non-review-notices): disambiguate repeat rejections

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -662,7 +662,7 @@ The adopted helper boundaries are intentionally narrow:
   `isAdvisoryNonReviewNotice` classifier (`protocol-helpers`) recognizes
   (rate-limit / usage-limit), and emits / posts the canonical
   `**Rejected** — {bot-login} did not review HEAD {sha} ({reason}); this
-  is not a completed review (source: #issuecomment-{notice-comment-id})` —
+  is not a completed review (source: #issuecomment-{id})` —
   marker-first, one comment per notice, naming the bot login so the
   carry-forward attributes it author-scoped. The trailing
   `(source: #issuecomment-{id})` names the source notice's own comment id

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -662,8 +662,13 @@ The adopted helper boundaries are intentionally narrow:
   `isAdvisoryNonReviewNotice` classifier (`protocol-helpers`) recognizes
   (rate-limit / usage-limit), and emits / posts the canonical
   `**Rejected** — {bot-login} did not review HEAD {sha} ({reason}); this
-  is not a completed review` — marker-first, one comment per notice,
-  naming the bot login so the carry-forward attributes it author-scoped.
+  is not a completed review (source: #issuecomment-{notice-comment-id})` —
+  marker-first, one comment per notice, naming the bot login so the
+  carry-forward attributes it author-scoped. The trailing
+  `(source: #issuecomment-{id})` names the source notice's own comment id
+  so repeat notices from the same bot at the same HEAD stay
+  byte-distinguishable (#1482); it is a human-readable disambiguator only
+  and plays no part in gate recognition or pairing.
 - **Idempotent**: per advisory bot, existing trusted
   `isNonReviewNoticeDisposition` comments naming that bot already cover
   that many of its notices, so a re-run posts nothing new.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -662,7 +662,7 @@ The adopted helper boundaries are intentionally narrow:
   `isAdvisoryNonReviewNotice` classifier (`protocol-helpers`) recognizes
   (rate-limit / usage-limit), and emits / posts the canonical
   `**Rejected** — {bot-login} did not review HEAD {sha} ({reason}); this
-  is not a completed review (source: #issuecomment-{notice-comment-id})` —
+  is not a completed review (source: #issuecomment-{id})` —
   marker-first, one comment per notice, naming the bot login so the
   carry-forward attributes it author-scoped. The trailing
   `(source: #issuecomment-{id})` names the source notice's own comment id

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -662,8 +662,13 @@ The adopted helper boundaries are intentionally narrow:
   `isAdvisoryNonReviewNotice` classifier (`protocol-helpers`) recognizes
   (rate-limit / usage-limit), and emits / posts the canonical
   `**Rejected** — {bot-login} did not review HEAD {sha} ({reason}); this
-  is not a completed review` — marker-first, one comment per notice,
-  naming the bot login so the carry-forward attributes it author-scoped.
+  is not a completed review (source: #issuecomment-{notice-comment-id})` —
+  marker-first, one comment per notice, naming the bot login so the
+  carry-forward attributes it author-scoped. The trailing
+  `(source: #issuecomment-{id})` names the source notice's own comment id
+  so repeat notices from the same bot at the same HEAD stay
+  byte-distinguishable (#1482); it is a human-readable disambiguator only
+  and plays no part in gate recognition or pairing.
 - **Idempotent**: per advisory bot, existing trusted
   `isNonReviewNoticeDisposition` comments naming that bot already cover
   that many of its notices, so a re-run posts nothing new.

--- a/scripts/disposition-non-review-notices.mjs
+++ b/scripts/disposition-non-review-notices.mjs
@@ -8,12 +8,17 @@
 // Auto-disposition advisory non-review notices on a PR (E6 PATH B). Every
 // autopilot PR draws advisory-bot rate-limit / usage-limit notices that are
 // dispositioned deterministically as `**Rejected** — {bot} did not review HEAD
-// {sha} ({reason}); this is not a completed review` — marker-first (#1038), one
-// per notice (the F2/F3 gate pairs 1:1 by count), naming the bot's login so the
-// #1018 author-scoped carry-forward attributes it. This helper detects those
-// notices with the single-sourced `isAdvisoryNonReviewNotice` classifier and
-// emits (dry-run) or posts (`--apply`) the canonical disposition, skipping
-// notices already dispositioned so a re-run is idempotent.
+// {sha} ({reason}); this is not a completed review (source: #issuecomment-{id})`
+// — marker-first (#1038), one per notice (the F2/F3 gate pairs 1:1 by count),
+// naming the bot's login so the #1018 author-scoped carry-forward attributes
+// it. The trailing `(source: #issuecomment-{id})` names the source notice's
+// own comment id, so repeat notices from the same bot at the same HEAD (which
+// otherwise render byte-identical) stay distinguishable in the PR history
+// (#1482); it is a human-readable disambiguator only, never a pairing key.
+// This helper detects those notices with the single-sourced
+// `isAdvisoryNonReviewNotice` classifier and emits (dry-run) or posts
+// (`--apply`) the canonical disposition, skipping notices already
+// dispositioned so a re-run is idempotent.
 //
 // It also auto-dispositions the CodeRabbit summary walkthrough (#1122): a
 // completed-review regular comment that recurs on every autopilot PR and the
@@ -70,11 +75,19 @@ export function noticeReason(body) {
 }
 /**
  * Build the canonical E6 non-review-notice disposition body: marker-first,
- * naming the bot's GitHub login (for the #1018 author-scoped carry-forward) and
- * the current head SHA.
+ * naming the bot's GitHub login (for the #1018 author-scoped carry-forward),
+ * the current head SHA, and the source notice's own comment id (#1482) so
+ * repeat notices from the same bot at the same HEAD and reason category still
+ * produce byte-distinguishable replies. The `(source: #issuecomment-{id})`
+ * suffix is a human-readable disambiguator only: recognition
+ * (`isDispositionComment` / `isNonReviewNoticeDisposition` /
+ * `dispositionNamesAdvisoryBot`) matches on the leading marker and the bot
+ * login substring, never on exact body equality, so this addition cannot
+ * break gate recognition; it also never becomes a machine-readable pairing
+ * key for `summarizeDispositionEvidenceForGate`'s count-based carry-forward.
  */
-export function buildDispositionBody(botLogin, headSha, reason) {
-  return `**Rejected** — ${botLogin} did not review HEAD ${headSha} (${reason}); this is not a completed review`;
+export function buildDispositionBody(botLogin, headSha, reason, noticeId) {
+  return `**Rejected** — ${botLogin} did not review HEAD ${headSha} (${reason}); this is not a completed review (source: #issuecomment-${noticeId})`;
 }
 /**
  * Build the canonical `**Accepted**` disposition body for a CodeRabbit summary
@@ -212,7 +225,7 @@ export function buildDispositionPlan(input, options = {}) {
       noticeId: comment.id,
       botLogin: comment.login,
       reason,
-      body: buildDispositionBody(comment.login, headSha, reason),
+      body: buildDispositionBody(comment.login, headSha, reason, comment.id),
     });
   }
   // CodeRabbit summary walkthrough auto-disposition (#1122). Separate from the
@@ -485,11 +498,15 @@ function viewerCommentIds(owner, repo, pr, viewerLogin) {
 }
 /**
  * After a failed create, find a viewer-authored comment with this exact body
- * whose id is NOT in `knownIds` — i.e., one created since posting began. Two
- * notices from the same bot on the same HEAD share an identical canonical body,
- * so keying recovery on a NEW comment id (not body uniqueness) is what stops the
- * helper from mistaking an earlier notice's marker for a failed create, which
- * would under-count the markers the F2/F3 1:1 pairing needs.
+ * whose id is NOT in `knownIds` — i.e., one created since posting began. Before
+ * #1482, two notices from the same bot on the same HEAD shared an identical
+ * canonical body, which is why this keys on a NEW comment id rather than body
+ * uniqueness. Since #1482 each body also embeds its own source notice's
+ * comment id, so bodies are now unique per notice too — but the NEW-id guard
+ * still matters: it stops the helper from matching some other pre-existing
+ * viewer comment that happens to carry this exact text instead of the create
+ * that just ran, which would under-count the markers the F2/F3 1:1 pairing
+ * needs.
  */
 function recoverPostedDisposition(
   owner,
@@ -653,7 +670,8 @@ if (import.meta.main) {
   const failed = [];
   // Track every viewer-authored comment id we know about (pre-existing plus the
   // ones we post), so a post-failure recovery attributes a NEW comment to the
-  // current notice instead of an earlier notice with an identical body.
+  // current notice's own post instead of some other pre-existing comment that
+  // happens to carry the identical (now per-notice-unique, #1482) body text.
   const knownViewerCommentIds = viewerCommentIds(owner, repo, pr, viewerLogin);
   let claimLost = false;
   for (let index = 0; index < plan.planned.length; index += 1) {

--- a/src/scripts/disposition-non-review-notices.mts
+++ b/src/scripts/disposition-non-review-notices.mts
@@ -8,12 +8,17 @@
 // Auto-disposition advisory non-review notices on a PR (E6 PATH B). Every
 // autopilot PR draws advisory-bot rate-limit / usage-limit notices that are
 // dispositioned deterministically as `**Rejected** — {bot} did not review HEAD
-// {sha} ({reason}); this is not a completed review` — marker-first (#1038), one
-// per notice (the F2/F3 gate pairs 1:1 by count), naming the bot's login so the
-// #1018 author-scoped carry-forward attributes it. This helper detects those
-// notices with the single-sourced `isAdvisoryNonReviewNotice` classifier and
-// emits (dry-run) or posts (`--apply`) the canonical disposition, skipping
-// notices already dispositioned so a re-run is idempotent.
+// {sha} ({reason}); this is not a completed review (source: #issuecomment-{id})`
+// — marker-first (#1038), one per notice (the F2/F3 gate pairs 1:1 by count),
+// naming the bot's login so the #1018 author-scoped carry-forward attributes
+// it. The trailing `(source: #issuecomment-{id})` names the source notice's
+// own comment id, so repeat notices from the same bot at the same HEAD (which
+// otherwise render byte-identical) stay distinguishable in the PR history
+// (#1482); it is a human-readable disambiguator only, never a pairing key.
+// This helper detects those notices with the single-sourced
+// `isAdvisoryNonReviewNotice` classifier and emits (dry-run) or posts
+// (`--apply`) the canonical disposition, skipping notices already
+// dispositioned so a re-run is idempotent.
 //
 // It also auto-dispositions the CodeRabbit summary walkthrough (#1122): a
 // completed-review regular comment that recurs on every autopilot PR and the
@@ -126,15 +131,24 @@ export function noticeReason(body: unknown): string {
 
 /**
  * Build the canonical E6 non-review-notice disposition body: marker-first,
- * naming the bot's GitHub login (for the #1018 author-scoped carry-forward) and
- * the current head SHA.
+ * naming the bot's GitHub login (for the #1018 author-scoped carry-forward),
+ * the current head SHA, and the source notice's own comment id (#1482) so
+ * repeat notices from the same bot at the same HEAD and reason category still
+ * produce byte-distinguishable replies. The `(source: #issuecomment-{id})`
+ * suffix is a human-readable disambiguator only: recognition
+ * (`isDispositionComment` / `isNonReviewNoticeDisposition` /
+ * `dispositionNamesAdvisoryBot`) matches on the leading marker and the bot
+ * login substring, never on exact body equality, so this addition cannot
+ * break gate recognition; it also never becomes a machine-readable pairing
+ * key for `summarizeDispositionEvidenceForGate`'s count-based carry-forward.
  */
 export function buildDispositionBody(
   botLogin: string,
   headSha: string,
   reason: string,
+  noticeId: number,
 ): string {
-  return `**Rejected** — ${botLogin} did not review HEAD ${headSha} (${reason}); this is not a completed review`;
+  return `**Rejected** — ${botLogin} did not review HEAD ${headSha} (${reason}); this is not a completed review (source: #issuecomment-${noticeId})`;
 }
 
 /**
@@ -286,7 +300,7 @@ export function buildDispositionPlan(
       noticeId: comment.id,
       botLogin: comment.login,
       reason,
-      body: buildDispositionBody(comment.login, headSha, reason),
+      body: buildDispositionBody(comment.login, headSha, reason, comment.id),
     });
   }
 
@@ -607,11 +621,15 @@ function viewerCommentIds(
 
 /**
  * After a failed create, find a viewer-authored comment with this exact body
- * whose id is NOT in `knownIds` — i.e., one created since posting began. Two
- * notices from the same bot on the same HEAD share an identical canonical body,
- * so keying recovery on a NEW comment id (not body uniqueness) is what stops the
- * helper from mistaking an earlier notice's marker for a failed create, which
- * would under-count the markers the F2/F3 1:1 pairing needs.
+ * whose id is NOT in `knownIds` — i.e., one created since posting began. Before
+ * #1482, two notices from the same bot on the same HEAD shared an identical
+ * canonical body, which is why this keys on a NEW comment id rather than body
+ * uniqueness. Since #1482 each body also embeds its own source notice's
+ * comment id, so bodies are now unique per notice too — but the NEW-id guard
+ * still matters: it stops the helper from matching some other pre-existing
+ * viewer comment that happens to carry this exact text instead of the create
+ * that just ran, which would under-count the markers the F2/F3 1:1 pairing
+ * needs.
  */
 function recoverPostedDisposition(
   owner: string,
@@ -788,7 +806,8 @@ if (import.meta.main) {
   const failed: FailedDisposition[] = [];
   // Track every viewer-authored comment id we know about (pre-existing plus the
   // ones we post), so a post-failure recovery attributes a NEW comment to the
-  // current notice instead of an earlier notice with an identical body.
+  // current notice's own post instead of some other pre-existing comment that
+  // happens to carry the identical (now per-notice-unique, #1482) body text.
   const knownViewerCommentIds = viewerCommentIds(owner, repo, pr, viewerLogin);
   let claimLost = false;
   for (let index = 0; index < plan.planned.length; index += 1) {

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -9,7 +9,11 @@ import {
   noticeReason,
   parseArgs,
 } from '../src/scripts/disposition-non-review-notices.mts';
-import { summarizeDispositionEvidenceForGate } from '../src/scripts/protocol-helpers.mts';
+import {
+  dispositionNamesAdvisoryBot,
+  isDispositionComment,
+  summarizeDispositionEvidenceForGate,
+} from '../src/scripts/protocol-helpers.mts';
 import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
 
 const planSchema = loadJson(
@@ -98,14 +102,115 @@ test('buildDispositionBody is marker-first and names the bot login + head sha', 
     CODERABBIT,
     'abc1234',
     'review limit reached',
+    501,
   );
   assert.ok(body.startsWith('**Rejected**'), 'marker must be first bytes');
   assert.match(body, /coderabbitai\[bot\] did not review HEAD abc1234/);
-  // Canonical E6 text ends at "completed review" with no trailing punctuation.
+  // #1482: the canonical E6 text is followed by a trailing human-readable
+  // disambiguator naming the source notice's own comment id.
   assert.match(
     body,
-    /\(review limit reached\); this is not a completed review$/,
+    /\(review limit reached\); this is not a completed review \(source: #issuecomment-501\)$/,
   );
+});
+
+test('buildDispositionPlan produces distinguishable bodies for two same-bot, same-HEAD, same-reason notices', () => {
+  // #1482 regression: before this fix, two notices from the same bot at the
+  // same HEAD with the same noticeReason() category rendered byte-identical
+  // **Rejected** replies -- the false "duplicate bug" alarm this issue
+  // describes. The actual fix is the call-site wiring (comment.id threaded
+  // into buildDispositionBody's new 4th arg), so exercise it through
+  // buildDispositionPlan rather than calling buildDispositionBody directly.
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(101, CODERABBIT, CODERABBIT_NOTICE, '2026-05-12T00:00:01Z'),
+        notice(102, CODERABBIT, CODERABBIT_NOTICE, '2026-05-12T00:00:02Z'),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.equal(plan.planned.length, 2);
+  const [first, second] = plan.planned;
+  assert.notEqual(first?.body, second?.body);
+  assert.match(first?.body ?? '', /\(source: #issuecomment-101\)$/);
+  assert.match(second?.body ?? '', /\(source: #issuecomment-102\)$/);
+});
+
+test('isDispositionComment and dispositionNamesAdvisoryBot recognize the extended body', () => {
+  // #1482: confirm the F2/F3 gate's underlying recognition predicates -- both
+  // prefix/substring-based, never exact-body equality -- still accept a body
+  // carrying the new trailing source-notice disambiguator.
+  const body = buildDispositionBody(
+    CODERABBIT,
+    'abc1234',
+    'review limit reached',
+    999,
+  );
+  assert.ok(isDispositionComment({ body }));
+  assert.ok(dispositionNamesAdvisoryBot(body, CODERABBIT));
+});
+
+test('gate agreement: the extended **Rejected** body still clears a notice from missingRegularComments', () => {
+  // #1482: the embedded source-notice id must not break the F2/F3 gate's real
+  // recognition path (isNonReviewNoticeDisposition + dispositionNamesAdvisoryBot,
+  // both exercised inside summarizeDispositionEvidenceForGate's #1018
+  // carry-forward), mirroring the existing summary-path gate-agreement tests
+  // below.
+  const noticeComment = {
+    id: 201,
+    author: { login: CODERABBIT },
+    body: CODERABBIT_NOTICE,
+    createdAt: '2026-05-12T00:00:00Z',
+    updatedAt: '2026-05-12T00:00:00Z',
+  };
+  const gateOptions = {
+    iddAgentLogins: ['kurone-kito'],
+    advisoryBotLogins: [CODERABBIT, CODEX],
+  };
+  // Before: the gate flags the undispositioned notice.
+  const before = summarizeDispositionEvidenceForGate(
+    { comments: [noticeComment], threads: [] },
+    gateOptions,
+  );
+  assert.equal(before.missingRegularCommentCount, 1);
+
+  // The helper plans the extended **Rejected** body (with the embedded source
+  // comment id); post it as an IDD-agent disposition, matching the existing
+  // tests' `kurone-kito` iddAgentLogins setup so this exercises the #1018
+  // carry-forward path specifically (not the separate sticky-matching path).
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(
+          201,
+          CODERABBIT,
+          CODERABBIT_NOTICE,
+          '2026-05-12T00:00:00Z',
+          '2026-05-12T00:00:00Z',
+        ),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.equal(plan.planned.length, 1);
+  assert.match(plan.planned[0]?.body ?? '', /\(source: #issuecomment-201\)$/);
+  const disposition = {
+    id: 202,
+    author: { login: 'kurone-kito' },
+    body: plan.planned[0]?.body ?? '',
+    createdAt: '2026-05-12T01:00:00Z',
+    updatedAt: '2026-05-12T01:00:00Z',
+  };
+  // After: the gate no longer flags the notice, proving the extended body is
+  // still recognized as a valid, bot-attributed disposition.
+  const after = summarizeDispositionEvidenceForGate(
+    { comments: [noticeComment, disposition], threads: [] },
+    gateOptions,
+  );
+  assert.equal(after.missingRegularCommentCount, 0);
 });
 
 test('noticeReason derives the category-specific reason', () => {


### PR DESCRIPTION
# Summary

`buildDispositionBody` now includes the source notice's own comment id
in the generated `**Rejected**` reply, so two advisory non-review
notices from the same bot at the same HEAD with the same
`noticeReason()` category no longer render byte-identical dispositions.
This previously caused a real false "duplicate bug" investigation
during the #1431 review cycle (8 near-identical replies posted seconds
apart, each genuinely distinct). The embedded id is a human-readable
`(source: #issuecomment-{id})` disambiguator only; `isDispositionComment`,
`isNonReviewNoticeDisposition`, and `dispositionNamesAdvisoryBot` all
match on the leading marker or a bot-login substring, never on exact
body equality, so the F2/F3 gate's recognition and #1018 carry-forward
pairing are unaffected, and dispositions already posted before this
change stay recognized.

## Linked issue

Closes #1482

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`buildSummaryDispositionBody` and the CodeRabbit summary-walkthrough
path are intentionally untouched — that path has one notice per HEAD,
so the ambiguity this issue fixes does not occur there.

`idd-review-triage.instructions.md` also quotes the pre-change body
verbatim, but is deliberately left unedited: it is a phase-scoped
instruction file already at 35,489 of its 35,500-byte
`instructionSizeBudgets.phaseLimitBytes` budget (`audit/sync-manifest.json`),
so any added note would fail `audit-docs.mjs --check`. That quote is
also only the manual-fallback template a human/agent types by hand
without the helper, and recognition is suffix-agnostic, so the
existing unedited template still produces a fully gate-recognized
disposition without the id.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
