### PR TITLE
docs(idd-helper-scripts): add merged-pr-feedback-sweep operator runbook

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -57,3 +57,4 @@ words:
   - GHES
   - WHATWG
   - dedup
+  - deprioritize

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1452,13 +1452,17 @@ Interpretation rules:
   by design, not an oversight.
   - **Intent**: it exists as a spot-check for runs where a lightweight
     model (for example a GPT-5.4-mini or Haiku-class model) has been
-    driving the IDD loop and may have fail-opened the E-phase disposition
-    net, letting a merge complete — by whichever actor was authorized to
-    run it — with review feedback still unaddressed. (Per this project's
+    driving the IDD loop and may have left feedback with **no E-phase
+    disposition at all, or a thread left unresolved**, letting a merge
+    complete — by whichever actor was authorized to run it — with that
+    feedback unaddressed. (Per this project's
     [Weak-model guardrails](idd-workflow.md#weak-model-guardrails), a
     lightweight-tier session must not itself run the autonomous merge
     phases, so the sweep audits the aftermath of that policy, not a
-    weak-model self-merge.)
+    weak-model self-merge.) The sweep detects exactly those two gaps —
+    it has **no backstop** for a _false-but-present_ disposition or an
+    already-resolved thread; see the boundary recorded in
+    `idd-design-rationale.md`.
   - **When to run it** (non-binding trigger guidance, not a policy gate):
     after a weak-model-driven backlog drain, on a periodic spot-audit
     cadence, or when a fail-open is suspected on a specific PR (via

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1450,22 +1450,35 @@ Interpretation rules:
 - **Operator runbook**: this helper is a **manual spot-check audit**, not a
   phase step — its absence from the executable phase instruction files is
   by design, not an oversight.
-  - **Intent**: it exists to backstop merges driven by a lightweight model
-    (for example a GPT-5.4-mini or Haiku-class model), where the E-phase
-    disposition net may have fail-opened and let a merge complete with
-    review feedback still unaddressed.
+  - **Intent**: it exists as a spot-check for runs where a lightweight
+    model (for example a GPT-5.4-mini or Haiku-class model) has been
+    driving the IDD loop and may have fail-opened the E-phase disposition
+    net, letting a merge complete — by whichever actor was authorized to
+    run it — with review feedback still unaddressed. (Per this project's
+    [Weak-model guardrails](idd-workflow.md#weak-model-guardrails), a
+    lightweight-tier session must not itself run the autonomous merge
+    phases, so the sweep audits the aftermath of that policy, not a
+    weak-model self-merge.)
   - **When to run it** (non-binding trigger guidance, not a policy gate):
-    after a weak-model backlog drain, on a periodic spot-audit cadence, or
-    when a fail-open is suspected on a specific PR (via `--pr` / `--prs`).
+    after a weak-model-driven backlog drain, on a periodic spot-audit
+    cadence, or when a fail-open is suspected on a specific PR (via
+    `--pr` / `--prs`). For a drain larger than the default `--limit`
+    (100), pass the drained PR numbers via `--pr` / `--prs`, or an
+    explicit `--since` with an adequate `--limit`, so older PRs are not
+    silently omitted.
   - **Reading the output**: prioritize `summary.unresolvedThreadCount` —
     the higher-value signal — over `summary.unaddressedCommentCount`, and
     use each finding's `advisoryBot` flag to deprioritize capricious
     advisory-bot items in favor of human feedback. Triage the output this
     way before the **Handoff** step above hands it to the issue-authoring
     skill for re-verification.
-  - **Scope boundary**: per the maintainer decision recorded in #909 and
-    reaffirmed in #1352, this sweep is a detection aid only — never an
-    automatic recovery path or a retroactive merge gate.
+  - **Scope boundary**: per the maintainer decision recorded in
+    [kurone-kito/idd-skill#909](https://github.com/kurone-kito/idd-skill/issues/909)
+    and reaffirmed in
+    [kurone-kito/idd-skill#1352](https://github.com/kurone-kito/idd-skill/issues/1352)
+    — decisions specific to this repository's own configuration, not a
+    universal adopter policy — this sweep is a detection aid only: never
+    an automatic recovery path or a retroactive merge gate.
 
 ## Friction Inventory
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1447,6 +1447,25 @@ Interpretation rules:
   `main` (reuse-first / not-already-fixed) and drafts follow-up issues
   bucketed by readiness. The helper does deterministic detection; the
   judgment-heavy re-verification, drafting, and publish stay operator-gated.
+- **Operator runbook**: this helper is a **manual spot-check audit**, not a
+  phase step — its absence from the executable phase instruction files is
+  by design, not an oversight.
+  - **Intent**: it exists to backstop merges driven by a lightweight model
+    (for example a GPT-5.4-mini or Haiku-class model), where the E-phase
+    disposition net may have fail-opened and let a merge complete with
+    review feedback still unaddressed.
+  - **When to run it** (non-binding trigger guidance, not a policy gate):
+    after a weak-model backlog drain, on a periodic spot-audit cadence, or
+    when a fail-open is suspected on a specific PR (via `--pr` / `--prs`).
+  - **Reading the output**: prioritize `summary.unresolvedThreadCount` —
+    the higher-value signal — over `summary.unaddressedCommentCount`, and
+    use each finding's `advisoryBot` flag to deprioritize capricious
+    advisory-bot items in favor of human feedback. Triage the output this
+    way before the **Handoff** step above hands it to the issue-authoring
+    skill for re-verification.
+  - **Scope boundary**: per the maintainer decision recorded in #909 and
+    reaffirmed in #1352, this sweep is a detection aid only — never an
+    automatic recovery path or a retroactive merge gate.
 
 ## Friction Inventory
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1452,13 +1452,17 @@ Interpretation rules:
   by design, not an oversight.
   - **Intent**: it exists as a spot-check for runs where a lightweight
     model (for example a GPT-5.4-mini or Haiku-class model) has been
-    driving the IDD loop and may have fail-opened the E-phase disposition
-    net, letting a merge complete — by whichever actor was authorized to
-    run it — with review feedback still unaddressed. (Per this project's
+    driving the IDD loop and may have left feedback with **no E-phase
+    disposition at all, or a thread left unresolved**, letting a merge
+    complete — by whichever actor was authorized to run it — with that
+    feedback unaddressed. (Per this project's
     [Weak-model guardrails](idd-workflow.md#weak-model-guardrails), a
     lightweight-tier session must not itself run the autonomous merge
     phases, so the sweep audits the aftermath of that policy, not a
-    weak-model self-merge.)
+    weak-model self-merge.) The sweep detects exactly those two gaps —
+    it has **no backstop** for a _false-but-present_ disposition or an
+    already-resolved thread; see the boundary recorded in
+    `idd-design-rationale.md`.
   - **When to run it** (non-binding trigger guidance, not a policy gate):
     after a weak-model-driven backlog drain, on a periodic spot-audit
     cadence, or when a fail-open is suspected on a specific PR (via

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1450,22 +1450,35 @@ Interpretation rules:
 - **Operator runbook**: this helper is a **manual spot-check audit**, not a
   phase step — its absence from the executable phase instruction files is
   by design, not an oversight.
-  - **Intent**: it exists to backstop merges driven by a lightweight model
-    (for example a GPT-5.4-mini or Haiku-class model), where the E-phase
-    disposition net may have fail-opened and let a merge complete with
-    review feedback still unaddressed.
+  - **Intent**: it exists as a spot-check for runs where a lightweight
+    model (for example a GPT-5.4-mini or Haiku-class model) has been
+    driving the IDD loop and may have fail-opened the E-phase disposition
+    net, letting a merge complete — by whichever actor was authorized to
+    run it — with review feedback still unaddressed. (Per this project's
+    [Weak-model guardrails](idd-workflow.md#weak-model-guardrails), a
+    lightweight-tier session must not itself run the autonomous merge
+    phases, so the sweep audits the aftermath of that policy, not a
+    weak-model self-merge.)
   - **When to run it** (non-binding trigger guidance, not a policy gate):
-    after a weak-model backlog drain, on a periodic spot-audit cadence, or
-    when a fail-open is suspected on a specific PR (via `--pr` / `--prs`).
+    after a weak-model-driven backlog drain, on a periodic spot-audit
+    cadence, or when a fail-open is suspected on a specific PR (via
+    `--pr` / `--prs`). For a drain larger than the default `--limit`
+    (100), pass the drained PR numbers via `--pr` / `--prs`, or an
+    explicit `--since` with an adequate `--limit`, so older PRs are not
+    silently omitted.
   - **Reading the output**: prioritize `summary.unresolvedThreadCount` —
     the higher-value signal — over `summary.unaddressedCommentCount`, and
     use each finding's `advisoryBot` flag to deprioritize capricious
     advisory-bot items in favor of human feedback. Triage the output this
     way before the **Handoff** step above hands it to the issue-authoring
     skill for re-verification.
-  - **Scope boundary**: per the maintainer decision recorded in #909 and
-    reaffirmed in #1352, this sweep is a detection aid only — never an
-    automatic recovery path or a retroactive merge gate.
+  - **Scope boundary**: per the maintainer decision recorded in
+    [kurone-kito/idd-skill#909](https://github.com/kurone-kito/idd-skill/issues/909)
+    and reaffirmed in
+    [kurone-kito/idd-skill#1352](https://github.com/kurone-kito/idd-skill/issues/1352)
+    — decisions specific to this repository's own configuration, not a
+    universal adopter policy — this sweep is a detection aid only: never
+    an automatic recovery path or a retroactive merge gate.
 
 ## Friction Inventory
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1447,6 +1447,25 @@ Interpretation rules:
   `main` (reuse-first / not-already-fixed) and drafts follow-up issues
   bucketed by readiness. The helper does deterministic detection; the
   judgment-heavy re-verification, drafting, and publish stay operator-gated.
+- **Operator runbook**: this helper is a **manual spot-check audit**, not a
+  phase step — its absence from the executable phase instruction files is
+  by design, not an oversight.
+  - **Intent**: it exists to backstop merges driven by a lightweight model
+    (for example a GPT-5.4-mini or Haiku-class model), where the E-phase
+    disposition net may have fail-opened and let a merge complete with
+    review feedback still unaddressed.
+  - **When to run it** (non-binding trigger guidance, not a policy gate):
+    after a weak-model backlog drain, on a periodic spot-audit cadence, or
+    when a fail-open is suspected on a specific PR (via `--pr` / `--prs`).
+  - **Reading the output**: prioritize `summary.unresolvedThreadCount` —
+    the higher-value signal — over `summary.unaddressedCommentCount`, and
+    use each finding's `advisoryBot` flag to deprioritize capricious
+    advisory-bot items in favor of human feedback. Triage the output this
+    way before the **Handoff** step above hands it to the issue-authoring
+    skill for re-verification.
+  - **Scope boundary**: per the maintainer decision recorded in #909 and
+    reaffirmed in #1352, this sweep is a detection aid only — never an
+    automatic recovery path or a retroactive merge gate.
 
 ## Friction Inventory
 


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`merged-pr-feedback-sweep` ships and works, but nothing documents its
operational intent, so operators (and the weak models it exists to
backstop) have no guidance on when to run it or how to triage its output.
Add an **Operator runbook** bullet to the "Merged-PR feedback sweep"
section of `docs/idd-helper-scripts.md` covering:

- the weak-model spot-check intent (backstopping a possible E-phase
  disposition fail-open) and the by-design disconnection from the
  executable phase loop
- non-binding invocation-trigger / cadence guidance
- output-reading priorities (`summary.unresolvedThreadCount` over
  `summary.unaddressedCommentCount`, and the `advisoryBot` flag)
- the decided-risk boundary from #909 / #1352 — a detection aid only,
  never an automatic recovery path or a retroactive merge gate

No code or behavior change.

## Linked issue

Closes #1489

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

**Canonical-file correction**: the issue body says to edit
`docs/idd-helper-scripts.md`, but per `audit/sync-manifest.json`'s
`idd-helper-scripts-doc` pair, `idd-template/docs/idd-helper-scripts.md`
is the actual **source** and `docs/idd-helper-scripts.md` is the
generated **target/mirror**. This PR edits the template source and
regenerates the mirror via `node scripts/sync-docs.mjs --apply`, so both
copies stay identical without a later `sync-docs` run silently
overwriting the new content.

**Structure note**: the initial plan considered a new `#### Operator
runbook` (h4) heading, but this file has zero existing h4 headings across
all 30 of its h3 sections — every sub-facet already uses a top-level
bullet with a bold lead-in instead. This PR follows that existing
convention (one new top-level bullet with nested sub-bullets) rather than
introducing the file's first heading-level outlier.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (biome check, dprint check, markdownlint-cli2)
- [x] `pnpm test` (`pnpm run test:scripts`, 2348 passed / 0 failed)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passes; 4 pre-existing warnings
      unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (docs-only, no merge-gate change)
- [x] Context budget impact reviewed (39-line addition to one doc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the manual merged-PR feedback sweep runbook, including when to run it and how to interpret its results.
  * Added guidance to prioritize unresolved discussion threads, distinguish advisory signals, and reduce noise.
  * Documented that the sweep is detection-only and does not trigger automatic recovery or retroactive merge decisions.
  * Updated the corresponding template documentation for consistency.

* **Chores**
  * Updated spell-checking terminology to recognize “deprioritize.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->