### PR TITLE
docs(review-triage): add source-comment-id to E6 fallback template

### DIFF
--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -339,14 +339,14 @@ ack / error, as defined in E4):
   re-request, no wait.** The notice item itself is **always rejected**,
   because it carries no advisory result — never record `**Accepted**` on
   the notice: `**Rejected** — {bot} did not review HEAD {sha}
-  ({reason}); this is not a completed review`. Write `{bot}` as the bot's
-  **GitHub login** (e.g. `coderabbitai[bot]`, `chatgpt-codex-connector[bot]`)
-  so the carry-forward below can attribute the rejection to exactly that bot
-  when several advisory bots are configured. A separate _completed_
-  review of the current HEAD, if one is present, is a **distinct**
+  ({reason}); this is not a completed review (source: #issuecomment-{id})`.
+  Write `{bot}` as the bot's GitHub login (e.g. `coderabbitai[bot]`,
+  `chatgpt-codex-connector[bot]`) so the carry-forward below can attribute
+  the rejection to that bot when several bots are configured. A separate
+  _completed_ review of the current HEAD, if one is present, is a distinct
   ReviewItems_snapshot item dispositioned `**Accepted**` under the
   completed-review rules above — accept that review, not the notice.
-  **Re-validate just before posting the rejection**: a completed review
+  **Re-validate before posting the rejection**: a completed review
   can race in after the E1 snapshot but before this rejection. If one
   has, disposition that review (Accepted) and take a fresh E1 snapshot,
   so the rejection's later timestamp does not filter the completed

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -334,14 +334,14 @@ ack / error, as defined in E4):
   re-request, no wait.** The notice item itself is **always rejected**,
   because it carries no advisory result — never record `**Accepted**` on
   the notice: `**Rejected** — {bot} did not review HEAD {sha}
-  ({reason}); this is not a completed review`. Write `{bot}` as the bot's
-  **GitHub login** (e.g. `coderabbitai[bot]`, `chatgpt-codex-connector[bot]`)
-  so the carry-forward below can attribute the rejection to exactly that bot
-  when several advisory bots are configured. A separate _completed_
-  review of the current HEAD, if one is present, is a **distinct**
+  ({reason}); this is not a completed review (source: #issuecomment-{id})`.
+  Write `{bot}` as the bot's GitHub login (e.g. `coderabbitai[bot]`,
+  `chatgpt-codex-connector[bot]`) so the carry-forward below can attribute
+  the rejection to that bot when several bots are configured. A separate
+  _completed_ review of the current HEAD, if one is present, is a distinct
   ReviewItems_snapshot item dispositioned `**Accepted**` under the
   completed-review rules above — accept that review, not the notice.
-  **Re-validate just before posting the rejection**: a completed review
+  **Re-validate before posting the rejection**: a completed review
   can race in after the E1 snapshot but before this rejection. If one
   has, disposition that review (Accepted) and take a fresh E1 snapshot,
   so the rejection's later timestamp does not filter the completed


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`idd-review-triage.instructions.md`'s canonical E6 non-review-notice
disposition template still showed the pre-#1482 body shape, without the
`(source: #issuecomment-{id})` disambiguator that
`buildDispositionBody` actually emits. #1482 deliberately left this
file unedited because it sat at 35,489 of its 35,500-byte
`instructionSizeBudgets.phaseLimitBytes`, only 11 bytes of headroom —
not enough for the ~29-byte suffix.

This PR adds the suffix to the written template and trims redundant
wording in the same paragraph (an unneeded "exactly" / "advisory" /
"just", and non-essential bold emphasis around "GitHub login" /
"distinct") so the net byte change is **-1 byte**: the file now sits at
35,488 bytes, one byte smaller than before, with 12 bytes of headroom
instead of 11. No example, rule, or substantive meaning was cut — only
redundant intensifiers/emphasis were trimmed.

The canonical source is `idd-template/.github/instructions/idd-review-triage.instructions.md`;
the `.github/instructions/` mirror is regenerated via
`node scripts/sync-docs.mjs --apply`. Checked `docs/idd-helper-scripts.md`
too — it already documents the helper's real (post-#1482) output shape,
so no other file needed a change; the other "…"-truncated references in
`idd-review-triage.instructions.md` / `idd-review-fix.instructions.md`
are informal paraphrases, not the canonical template, and are correctly
left as-is.

## Linked issue

Closes #1496

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Also verified acceptance criterion #2 (bundle budget): this file
belongs to the `bundle-review` bundle in `audit/sync-manifest.json`
(`limitBytes: 129900`); the bundle currently totals 128,795 bytes
(banner-stripped), so it has ample headroom and was never the binding
constraint — the per-file `phaseLimitBytes` was.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
