### PR TITLE
feat(suitability): add high-confidence duplicate tier to A4.5 Check 4

### DIFF
--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -97,6 +97,33 @@ or configured needs-decision label from `labels.needsDecisionLabelName`
   progress (including draft PRs)
 - **Outcome on fail**: `duplicate`
 
+#### High-confidence tier (#1484)
+
+Before the weak heuristic above, check two mechanical signals reused
+from B2.0's post-claim re-check (`idd-work.instructions.md`): (1) the
+issue's own `closedByPullRequestsReferences` is non-empty (a merged PR
+already references it via a closing keyword), or (2) a PR merged
+at/after the issue's own `createdAt` (the pre-claim analogue of B2.0's
+claim-`created_at` anchor) changed a file under its `## Candidate
+files` section — excluding A4 Step 2's high-contention set
+(`discover-shared-file-overlap`'s bundle + manifest files), since a
+broadly-shared file alone isn't evidence _this_ issue shipped.
+
+Either signal is high-confidence: classify as `duplicate` (no new
+outcome value), and the diagnostic comment MUST carry
+**machine-derivable evidence** (PR number(s) and/or overlapping file
+path(s)), not prose alone. With neither signal established, fall back
+to the weak heuristic unchanged — never fail _toward_ a false flag; a
+collection failure follows the "Timeout on duplicate detection" Edge
+Case below.
+
+Same **detect-only** boundary as the rest of A4.5 (label + comment
+only). The acceptance-criteria-hold-on-`main` bullet is deferred to
+the gated-close follow-up (pairs with a close decision this gate
+never takes).
+
+`suitability-triage.mjs` evaluates both signals as part of Check 4.
+
 ### Check 5: Actionability
 
 Does the issue describe concrete, actionable work?
@@ -247,7 +274,8 @@ can correct the issue.
 
 **Timeout on duplicate detection**: If duplicate detection (Check 4)
 times out or becomes expensive, fall back to exact title match only. If
-exact match is not found, PASS the check and continue.
+exact match is not found, PASS the check and continue. Also covers the
+High-confidence tier's evidence collection (#1484).
 
 **Agent-specific limitations**: All seven checks should be agent-agnostic
 (work for Copilot, Claude, Codex, Antigravity CLI (formerly Gemini CLI)).

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -101,9 +101,10 @@ or configured needs-decision label from `labels.needsDecisionLabelName`
 
 Before the weak heuristic above, check two mechanical signals reused
 from B2.0's post-claim re-check (`idd-work.instructions.md`): (1) the
-issue's own `closedByPullRequestsReferences` is non-empty (a merged PR
-already references it via a closing keyword), or (2) a PR merged
-at/after the issue's own `createdAt` (the pre-claim analogue of B2.0's
+issue's own `closedByPullRequestsReferences` includes a `MERGED`-state
+PR (this connection can include OPEN PRs too, so state is the signal,
+not non-emptiness alone), or (2) a PR merged at/after the issue's own
+`createdAt` (the pre-claim analogue of B2.0's
 claim-`created_at` anchor) changed a file under its `## Candidate
 files` section — excluding A4 Step 2's high-contention set
 (`discover-shared-file-overlap`'s bundle + manifest files), since a
@@ -119,8 +120,7 @@ Case below.
 
 Same **detect-only** boundary as the rest of A4.5 (label + comment
 only). The acceptance-criteria-hold-on-`main` bullet is deferred to
-the gated-close follow-up (pairs with a close decision this gate
-never takes).
+the gated-close follow-up.
 
 `suitability-triage.mjs` evaluates both signals as part of Check 4.
 

--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -102,9 +102,9 @@ or configured needs-decision label from `labels.needsDecisionLabelName`
 Before the weak heuristic above, check two mechanical signals reused
 from B2.0's post-claim re-check (`idd-work.instructions.md`): (1) the
 issue's own `closedByPullRequestsReferences` includes a `MERGED`-state
-PR (this connection can include OPEN PRs too, so state is the signal,
-not non-emptiness alone), or (2) a PR merged at/after the issue's own
-`createdAt` (the pre-claim analogue of B2.0's
+PR **and** the issue is `CLOSED` (matches B2.0's gate; a reopened
+issue keeps its old merged PR), or (2) a PR merged at/after the
+issue's own `createdAt` (the pre-claim analogue of B2.0's
 claim-`created_at` anchor) changed a file under its `## Candidate
 files` section — excluding A4 Step 2's high-contention set
 (`discover-shared-file-overlap`'s bundle + manifest files), since a

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -37,7 +37,11 @@ In the idd-skill source repository, the following optional helpers were adopted:
   [kurone-kito/idd-skill#1397](https://github.com/kurone-kito/idd-skill/issues/1397))
 - `scripts/suitability-triage.mjs` for A4.5 seven-check suitability
   evaluation (referenced in
-  [kurone-kito/idd-skill#392](https://github.com/kurone-kito/idd-skill/issues/392))
+  [kurone-kito/idd-skill#392](https://github.com/kurone-kito/idd-skill/issues/392)),
+  including Check 4's high-confidence duplicate/superseded tier
+  (closing-PR reference and same-candidate-files overlap, excluding
+  high-contention files) (referenced in
+  [kurone-kito/idd-skill#1484](https://github.com/kurone-kito/idd-skill/issues/1484))
 - `scripts/claim-approval-gate.mjs` for A5(a) issue-author approval
   verification; A5(d) open-PR conflict checks remain manual by design
   (referenced in

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -97,9 +97,9 @@ or configured needs-decision label from `labels.needsDecisionLabelName`
 Before the weak heuristic above, check two mechanical signals reused
 from B2.0's post-claim re-check (`idd-work.instructions.md`): (1) the
 issue's own `closedByPullRequestsReferences` includes a `MERGED`-state
-PR (this connection can include OPEN PRs too, so state is the signal,
-not non-emptiness alone), or (2) a PR merged at/after the issue's own
-`createdAt` (the pre-claim analogue of B2.0's
+PR **and** the issue is `CLOSED` (matches B2.0's gate; a reopened
+issue keeps its old merged PR), or (2) a PR merged at/after the
+issue's own `createdAt` (the pre-claim analogue of B2.0's
 claim-`created_at` anchor) changed a file under its `## Candidate
 files` section — excluding A4 Step 2's high-contention set
 (`discover-shared-file-overlap`'s bundle + manifest files), since a

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -96,9 +96,10 @@ or configured needs-decision label from `labels.needsDecisionLabelName`
 
 Before the weak heuristic above, check two mechanical signals reused
 from B2.0's post-claim re-check (`idd-work.instructions.md`): (1) the
-issue's own `closedByPullRequestsReferences` is non-empty (a merged PR
-already references it via a closing keyword), or (2) a PR merged
-at/after the issue's own `createdAt` (the pre-claim analogue of B2.0's
+issue's own `closedByPullRequestsReferences` includes a `MERGED`-state
+PR (this connection can include OPEN PRs too, so state is the signal,
+not non-emptiness alone), or (2) a PR merged at/after the issue's own
+`createdAt` (the pre-claim analogue of B2.0's
 claim-`created_at` anchor) changed a file under its `## Candidate
 files` section — excluding A4 Step 2's high-contention set
 (`discover-shared-file-overlap`'s bundle + manifest files), since a
@@ -114,8 +115,7 @@ Case below.
 
 Same **detect-only** boundary as the rest of A4.5 (label + comment
 only). The acceptance-criteria-hold-on-`main` bullet is deferred to
-the gated-close follow-up (pairs with a close decision this gate
-never takes).
+the gated-close follow-up.
 
 `suitability-triage.mjs` evaluates both signals as part of Check 4.
 

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -92,6 +92,33 @@ or configured needs-decision label from `labels.needsDecisionLabelName`
   progress (including draft PRs)
 - **Outcome on fail**: `duplicate`
 
+#### High-confidence tier (#1484)
+
+Before the weak heuristic above, check two mechanical signals reused
+from B2.0's post-claim re-check (`idd-work.instructions.md`): (1) the
+issue's own `closedByPullRequestsReferences` is non-empty (a merged PR
+already references it via a closing keyword), or (2) a PR merged
+at/after the issue's own `createdAt` (the pre-claim analogue of B2.0's
+claim-`created_at` anchor) changed a file under its `## Candidate
+files` section — excluding A4 Step 2's high-contention set
+(`discover-shared-file-overlap`'s bundle + manifest files), since a
+broadly-shared file alone isn't evidence _this_ issue shipped.
+
+Either signal is high-confidence: classify as `duplicate` (no new
+outcome value), and the diagnostic comment MUST carry
+**machine-derivable evidence** (PR number(s) and/or overlapping file
+path(s)), not prose alone. With neither signal established, fall back
+to the weak heuristic unchanged — never fail _toward_ a false flag; a
+collection failure follows the "Timeout on duplicate detection" Edge
+Case below.
+
+Same **detect-only** boundary as the rest of A4.5 (label + comment
+only). The acceptance-criteria-hold-on-`main` bullet is deferred to
+the gated-close follow-up (pairs with a close decision this gate
+never takes).
+
+`suitability-triage.mjs` evaluates both signals as part of Check 4.
+
 ### Check 5: Actionability
 
 Does the issue describe concrete, actionable work?
@@ -242,7 +269,8 @@ can correct the issue.
 
 **Timeout on duplicate detection**: If duplicate detection (Check 4)
 times out or becomes expensive, fall back to exact title match only. If
-exact match is not found, PASS the check and continue.
+exact match is not found, PASS the check and continue. Also covers the
+High-confidence tier's evidence collection (#1484).
 
 **Agent-specific limitations**: All seven checks should be agent-agnostic
 (work for Copilot, Claude, Codex, Antigravity CLI (formerly Gemini CLI)).

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -37,7 +37,11 @@ In the idd-skill source repository, the following optional helpers were adopted:
   [kurone-kito/idd-skill#1397](https://github.com/kurone-kito/idd-skill/issues/1397))
 - `scripts/suitability-triage.mjs` for A4.5 seven-check suitability
   evaluation (referenced in
-  [kurone-kito/idd-skill#392](https://github.com/kurone-kito/idd-skill/issues/392))
+  [kurone-kito/idd-skill#392](https://github.com/kurone-kito/idd-skill/issues/392)),
+  including Check 4's high-confidence duplicate/superseded tier
+  (closing-PR reference and same-candidate-files overlap, excluding
+  high-contention files) (referenced in
+  [kurone-kito/idd-skill#1484](https://github.com/kurone-kito/idd-skill/issues/1484))
 - `scripts/claim-approval-gate.mjs` for A5(a) issue-author approval
   verification; A5(d) open-PR conflict checks remain manual by design
   (referenced in

--- a/scripts/discover-shared-file-overlap.mjs
+++ b/scripts/discover-shared-file-overlap.mjs
@@ -25,11 +25,14 @@ import {
 } from './protocol-helpers.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
-const DEFAULT_MANIFEST_PATH = 'audit/sync-manifest.json';
+// Exported (#1484) so suitability-triage.mts's high-confidence Check 4 tier
+// can build the identical high-contention set this module uses for A4 Step 2,
+// instead of re-declaring its own copy of these defaults.
+export const DEFAULT_MANIFEST_PATH = 'audit/sync-manifest.json';
 /** F-phase bundles whose member instruction files concentrate concurrent edits. */
-const DEFAULT_BUNDLE_IDS = ['bundle-review', 'bundle-merge'];
+export const DEFAULT_BUNDLE_IDS = ['bundle-review', 'bundle-merge'];
 /** Append-mostly shared surfaces that are not bundle members. */
-const DEFAULT_EXTRA_FILES = [DEFAULT_MANIFEST_PATH];
+export const DEFAULT_EXTRA_FILES = [DEFAULT_MANIFEST_PATH];
 const DEFAULT_AUTOPILOT_SUITABILITY_FLOOR = 3;
 const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 /** Upper bound on the best-effort open-PR scan (a `gh pr list --limit`). */
@@ -696,7 +699,10 @@ when it is outside the unclaimed candidate set being ranked. A claim whose
 branch is not yet pushed is picked up once it appears remotely.
 `);
 }
-function ghJson(args) {
+// Exported (#1484) as the array-safe `gh` JSON parser: suitability-triage.mts
+// reuses it (aliased at the import site to avoid colliding with that file's
+// own object-shaped `ghJson`) instead of re-declaring an equivalent helper.
+export function ghJson(args) {
   const parsed = JSON.parse(runGh(args).trim() || '[]');
   return Array.isArray(parsed) ? parsed : [];
 }

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -1171,13 +1171,16 @@ export function buildPrFilesArgs(repoRef, prNumber) {
  * Fetch the candidate issue's own merged closing-PR references. Throws (via
  * `runGh`, no try/catch here) on a `gh` error rather than silently reading a
  * broken fetch as "no evidence" -- the latter would make a real duplicate
- * look clean. The caller (`runCli`) wraps this and its sibling fetches below
- * in one try/catch so a failure here degrades the optional high-confidence
- * tier (Check 4's own documented "Timeout on duplicate detection... fall
- * back to exact title match only" Edge Case) without aborting the other six
- * checks (Codex review finding on this PR: an earlier version let this
- * throw uncaught all the way out of `runCli`, crashing the whole
- * evaluation).
+ * look clean. The caller (`runCli`) wraps this in its own try/catch,
+ * separate from the same-candidate-files scan's try/catch below (Copilot
+ * review finding on this PR: an earlier version described both as sharing
+ * one try/catch, which stopped being accurate once they were split so a
+ * failure in one signal's collection couldn't discard an already-successful
+ * sibling), so a failure here degrades the optional high-confidence tier
+ * (Check 4's own documented "Timeout on duplicate detection... fall back to
+ * exact title match only" Edge Case) without aborting the other six checks
+ * (Codex review finding on this PR: an earlier version let this throw
+ * uncaught all the way out of `runCli`, crashing the whole evaluation).
  */
 function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
   const parsed = ghJson(buildClosedByMergedPrArgs(owner, repo, issueNumber));

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -24,6 +24,18 @@ import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
  * documented `gh pr list --limit 50`). */
 const MERGED_PR_SCAN_LIMIT = 50;
 /**
+ * Wall-clock budget for the #1484 merged-PR file-overlap scan (CodeRabbit
+ * review finding on this PR): up to MERGED_PR_SCAN_LIMIT sequential
+ * `gh pr view` calls at 30s each could otherwise take ~25 minutes in the
+ * worst case (a degraded/rate-limited GitHub API). Stop early and return
+ * whatever has been collected once this budget elapses, rather than
+ * blocking the whole A4.5 evaluation on a slow scan. Referenced from inside
+ * `fetchMergedPrFileOverlapEvidence`, which the `import.meta.main` trigger
+ * below can reach synchronously, so this must stay declared above that
+ * trigger for the same temporal-dead-zone reason as `CLOSED_BY_MERGED_PR_QUERY`.
+ */
+const MERGED_PR_SCAN_DEADLINE_MS = 2 * 60 * 1000;
+/**
  * GraphQL query for the closed-by-merged-PR read (#1484), bounded to the
  * first 50 closing-PR references. A later page could theoretically hold an
  * additional MERGED reference this misses, but that only makes the tier
@@ -727,58 +739,71 @@ function runCli() {
   const issue = fetchIssue(repoRef, args.issue);
   const duplicateCandidates = fetchDuplicateCandidates(repoRef, issue);
   const labelsPolicy = normalizePolicyConfig(loadPolicy(args.policy)).labels;
-  // #1484: high-confidence Check 4 tier evidence. closedByPullRequestsReferences
-  // is always attempted -- cheap, independent of '## Candidate files'. The
-  // same-candidate-files scan only runs when the issue declares
-  // '## Candidate files' AND the high-contention exclusion set actually
-  // resolved -- see loadHighContentionFiles's doc comment for why an
-  // unresolved manifest skips the scan rather than proceeding with zero
-  // exclusions.
-  //
-  // The whole block is wrapped in one try/catch (Codex review finding on
-  // this PR): an uncaught `gh` failure here previously aborted the entire
-  // 7-check evaluation, contradicting Check 4's own documented Edge Case
-  // ("Timeout on duplicate detection... fall back to exact title match
-  // only") -- this tier is an optional enhancement layered onto Check 4, and
-  // its collection failing must not take down Checks 1-3 and 5-7 too. A
-  // collection failure is never silently reported as "no evidence" (that
-  // would mask a genuinely broken collector as a clean pass) -- it is
-  // surfaced explicitly via `highConfidenceDuplicateCollectionError` in the
-  // JSON output below, while `highConfidenceDuplicate` itself is left
-  // `undefined` so Check 4 falls through to the weak heuristic exactly as if
-  // no evidence had been collected.
-  let highConfidenceDuplicate;
-  let highConfidenceDuplicateCollectionError = null;
+  // #1484: high-confidence Check 4 tier evidence. The two mechanical signals
+  // (closedByPullRequestsReferences, and the same-candidate-files merged-PR
+  // scan) are collected in two SEPARATE try/catch blocks (CodeRabbit review
+  // finding on this PR): an earlier version wrapped both in one block, so a
+  // failure collecting the second signal discarded an already-successful
+  // first signal too. Each block's own failure is recorded independently in
+  // `collectionWarnings` and degrades only that one signal to empty/absent
+  // -- never silently reported as "no evidence" (that would mask a
+  // genuinely broken collector as a clean pass), and never discarding a
+  // sibling signal that already collected cleanly. `gh`/API fetch failures
+  // in either block are always recorded here; a manifest-unavailable
+  // same-candidate-files skip is a distinct, deliberate degradation
+  // documented on `loadHighContentionFiles` itself, not a fetch failure, so
+  // it is not added to this list (Copilot review finding on this PR: an
+  // earlier comment overclaimed that every degradation path surfaces here).
+  // This is also why an uncaught failure no longer aborts the entire
+  // 7-check evaluation (Codex review finding on this PR) -- this tier is an
+  // optional enhancement layered onto Check 4, and Check 4's own documented
+  // Edge Case ("Timeout on duplicate detection... fall back to exact title
+  // match only") already anticipates exactly this degradation.
+  const collectionWarnings = [];
+  let closedByMergedPrNumbers = [];
   try {
-    const closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
+    closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
       owner,
       repo,
       args.issue,
     );
-    const candidateFiles = parseCandidateFiles(issue.body);
+  } catch (error) {
+    collectionWarnings.push(
+      `closedByPullRequestsReferences: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  let candidateFiles = [];
+  let highContentionFiles = [];
+  let mergedPrs = [];
+  try {
+    candidateFiles = parseCandidateFiles(issue.body);
     // Only resolve the high-contention exclusion set (a file read + JSON
     // parse) when there is a '## Candidate files' section to check it
     // against -- most issues have none, and the result would otherwise be
     // discarded.
-    const highContentionFiles =
+    const resolvedHighContentionFiles =
       candidateFiles.length > 0 ? loadHighContentionFiles() : null;
     const shouldScanMergedPrs =
       candidateFiles.length > 0 &&
-      highContentionFiles !== null &&
+      resolvedHighContentionFiles !== null &&
       issue.createdAt.length > 0;
-    const mergedPrs = shouldScanMergedPrs
+    highContentionFiles = resolvedHighContentionFiles ?? [];
+    mergedPrs = shouldScanMergedPrs
       ? fetchMergedPrFileOverlapEvidence(repoRef, issue.createdAt)
       : [];
-    highConfidenceDuplicate = {
-      closedByMergedPrNumbers,
-      candidateFiles,
-      highContentionFiles: highContentionFiles ?? [],
-      mergedPrs,
-    };
   } catch (error) {
-    highConfidenceDuplicateCollectionError =
-      error instanceof Error ? error.message : String(error);
+    collectionWarnings.push(
+      `same-candidate-files scan: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    candidateFiles = [];
+    mergedPrs = [];
   }
+  const highConfidenceDuplicate = {
+    closedByMergedPrNumbers,
+    candidateFiles,
+    highContentionFiles,
+    mergedPrs,
+  };
   const result = evaluateSuitability(issue, {
     repository: { owner, repo },
     duplicateCandidates,
@@ -797,8 +822,8 @@ function runCli() {
     passed: result.passed,
     outcome: result.outcome,
     failedCheck: result.failedCheck,
-    ...(highConfidenceDuplicateCollectionError
-      ? { highConfidenceDuplicateCollectionError }
+    ...(collectionWarnings.length > 0
+      ? { highConfidenceDuplicateCollectionWarnings: collectionWarnings }
       : {}),
     checks: args.verbose
       ? result.checks
@@ -1113,16 +1138,24 @@ function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
  * `number`) is skipped rather than shelled out to `gh pr view` (Copilot
  * review finding on this PR: `ghJsonArray` intentionally returns
  * `unknown[]`, so an unexpected API shape should degrade this one entry,
- * not become a hard `gh pr view NaN`/`gh pr view 0` failure). A genuine `gh`
- * error on a well-formed entry still throws -- the caller (`runCli`) wraps
- * this and its sibling fetch above in one try/catch so that surfaces as the
- * documented Check 4 Edge Case fallback rather than crashing the whole
- * evaluation.
+ * not become a hard `gh pr view NaN`/`gh pr view 0` failure). Also stops
+ * early, returning whatever has been collected so far, once
+ * `MERGED_PR_SCAN_DEADLINE_MS` elapses (CodeRabbit review finding on this
+ * PR: up to `MERGED_PR_SCAN_LIMIT` sequential `gh pr view` calls with no
+ * overall cap could otherwise run for tens of minutes under a
+ * degraded/rate-limited GitHub API). A genuine `gh` error on a well-formed
+ * entry still throws -- the caller (`runCli`) wraps this and its sibling
+ * fetch in a separate try/catch so that surfaces as the documented Check 4
+ * Edge Case fallback for just this signal, without discarding the other.
  */
 function fetchMergedPrFileOverlapEvidence(repoRef, sinceIso) {
   const list = ghJsonArray(buildMergedPrListArgs(repoRef, sinceIso));
   const results = [];
+  const deadline = Date.now() + MERGED_PR_SCAN_DEADLINE_MS;
   for (const entry of list) {
+    if (Date.now() >= deadline) {
+      break;
+    }
     const pr = entry ?? {};
     const number = Number.parseInt(String(pr.number ?? ''), 10);
     if (!Number.isInteger(number) || number <= 0) {

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -818,9 +818,24 @@ function runCli() {
       resolvedHighContentionFiles !== null &&
       issue.createdAt.length > 0;
     highContentionFiles = resolvedHighContentionFiles ?? [];
-    mergedPrs = shouldScanMergedPrs
-      ? fetchMergedPrFileOverlapEvidence(repoRef, issue.createdAt)
-      : [];
+    if (shouldScanMergedPrs) {
+      const scanResult = fetchMergedPrFileOverlapEvidence(
+        repoRef,
+        issue.createdAt,
+      );
+      mergedPrs = scanResult.mergedPrs;
+      if (scanResult.truncatedByDeadline) {
+        // Codex P2 review finding: a deadline-truncated scan returns
+        // normally (not a throw), so it must record its own warning here --
+        // otherwise Check 4 would run the full weak heuristic on
+        // incomplete evidence instead of degrading to exact-title-only.
+        collectionWarnings.push(
+          'same-candidate-files scan: truncated by MERGED_PR_SCAN_DEADLINE_MS before scanning every merged PR in the window',
+        );
+      }
+    } else {
+      mergedPrs = [];
+    }
   } catch (error) {
     collectionWarnings.push(
       `same-candidate-files scan: ${error instanceof Error ? error.message : String(error)}`,
@@ -1183,21 +1198,31 @@ function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
  * review finding on this PR: `ghJsonArray` intentionally returns
  * `unknown[]`, so an unexpected API shape should degrade this one entry,
  * not become a hard `gh pr view NaN`/`gh pr view 0` failure). Also stops
- * early, returning whatever has been collected so far, once
- * `MERGED_PR_SCAN_DEADLINE_MS` elapses (CodeRabbit review finding on this
- * PR: up to `MERGED_PR_SCAN_LIMIT` sequential `gh pr view` calls with no
- * overall cap could otherwise run for tens of minutes under a
- * degraded/rate-limited GitHub API). A genuine `gh` error on a well-formed
- * entry still throws -- the caller (`runCli`) wraps this and its sibling
- * fetch in a separate try/catch so that surfaces as the documented Check 4
- * Edge Case fallback for just this signal, without discarding the other.
+ * early, returning whatever has been collected so far plus
+ * `truncatedByDeadline: true`, once `MERGED_PR_SCAN_DEADLINE_MS` elapses
+ * (CodeRabbit review finding on this PR: up to `MERGED_PR_SCAN_LIMIT`
+ * sequential `gh pr view` calls with no overall cap could otherwise run for
+ * tens of minutes under a degraded/rate-limited GitHub API). The
+ * `truncatedByDeadline` flag matters because this early exit returns
+ * normally rather than throwing (Codex P2 review finding on this PR): an
+ * earlier version left the caller unable to distinguish "scanned
+ * everything, found nothing" from "gave up partway through", so a
+ * deadline-truncated scan silently ran the FULL weak heuristic (including
+ * the near-duplicate fuzzy match) on incomplete evidence instead of
+ * degrading to the documented exact-title-only fallback the way a thrown
+ * `gh` error already does. A genuine `gh` error on a well-formed entry
+ * still throws -- the caller (`runCli`) wraps this and its sibling fetch in
+ * a separate try/catch so that surfaces as the same documented Check 4 Edge
+ * Case fallback for just this signal, without discarding the other.
  */
 function fetchMergedPrFileOverlapEvidence(repoRef, sinceIso) {
   const list = ghJsonArray(buildMergedPrListArgs(repoRef, sinceIso));
-  const results = [];
+  const mergedPrs = [];
   const deadline = Date.now() + MERGED_PR_SCAN_DEADLINE_MS;
+  let truncatedByDeadline = false;
   for (const entry of list) {
     if (Date.now() >= deadline) {
+      truncatedByDeadline = true;
       break;
     }
     const pr = entry ?? {};
@@ -1209,9 +1234,9 @@ function fetchMergedPrFileOverlapEvidence(repoRef, sinceIso) {
       .split('\n')
       .map((line) => line.trim())
       .filter(Boolean);
-    results.push({ number, mergedAt: String(pr.mergedAt ?? ''), files });
+    mergedPrs.push({ number, mergedAt: String(pr.mergedAt ?? ''), files });
   }
-  return results;
+  return { mergedPrs, truncatedByDeadline };
 }
 /**
  * Resolve the high-contention exclusion set the same way A4 Step 2's

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -1273,6 +1273,31 @@ function loadHighContentionFiles() {
     const manifest = JSON.parse(
       readFileSync(resolve(process.cwd(), DEFAULT_MANIFEST_PATH), 'utf8'),
     );
+    // Codex P2 review finding: a manifest that parses but lacks usable
+    // `bundleBudgets` entries for one or both target bundle IDs (an empty
+    // object, or an older schema) doesn't throw here -- `resolveHighContentionFiles`
+    // degrades gracefully to just `DEFAULT_EXTRA_FILES` for A4 Step 2's own,
+    // lower-stakes de-prioritization use. But for this tier, an incomplete
+    // exclusion set can miss a genuinely high-contention file, so a shared
+    // bundle/instruction file could be misread as specific overlap evidence
+    // -- exactly the false high-confidence flag Check 4 must never produce.
+    // Require both configured bundle IDs to actually resolve before
+    // accepting the set; otherwise treat it the same as an unreadable
+    // manifest (return null, which the caller already records as a
+    // collection warning and degrades to exact-title-only).
+    const bundles = manifest?.bundleBudgets;
+    if (!Array.isArray(bundles)) {
+      return null;
+    }
+    const resolvedBundleIds = new Set(
+      bundles.map((bundle) => String(bundle?.id ?? '')),
+    );
+    const allBundleIdsResolved = DEFAULT_BUNDLE_IDS.every((id) =>
+      resolvedBundleIds.has(id),
+    );
+    if (!allBundleIdsResolved) {
+      return null;
+    }
     return [
       ...resolveHighContentionFiles({
         manifest,

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -53,6 +53,7 @@ const MERGED_PR_SCAN_DEADLINE_MS = 2 * 60 * 1000;
 const CLOSED_BY_MERGED_PR_QUERY = `query($owner:String!,$repo:String!,$number:Int!){
   repository(owner:$owner,name:$repo){
     issue(number:$number){
+      state
       closedByPullRequestsReferences(first:50){
         nodes { number state }
       }
@@ -1181,6 +1182,14 @@ export function buildPrFilesArgs(repoRef, prNumber) {
  * exact title match only" Edge Case) without aborting the other six checks
  * (Codex review finding on this PR: an earlier version let this throw
  * uncaught all the way out of `runCli`, crashing the whole evaluation).
+ *
+ * Also requires the candidate issue's own current `state` to be `CLOSED`,
+ * mirroring B2.0's identical gate on this same signal
+ * (`idd-work.instructions.md`'s "Closed-by-a-merged-PR signal": `select(.state
+ * == "CLOSED")`). `closedByPullRequestsReferences` is not cleared when an
+ * issue is reopened, so without this gate a reopened issue with genuine
+ * remaining work would still show its old merged closing PR and get
+ * misclassified as a completed duplicate (Codex review finding on this PR).
  */
 function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
   const parsed = ghJson(buildClosedByMergedPrArgs(owner, repo, issueNumber));
@@ -1196,6 +1205,9 @@ function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
     throw new Error(
       `closedByPullRequestsReferences GraphQL response returned errors: ${JSON.stringify(parsed.errors)}`,
     );
+  }
+  if (String(parsed.data?.repository?.issue?.state ?? '') !== 'CLOSED') {
+    return [];
   }
   const nodes =
     parsed.data?.repository?.issue?.closedByPullRequestsReferences?.nodes ?? [];
@@ -1289,11 +1301,21 @@ function loadHighContentionFiles() {
     if (!Array.isArray(bundles)) {
       return null;
     }
-    const resolvedBundleIds = new Set(
-      bundles.map((bundle) => String(bundle?.id ?? '')),
+    const nonEmptyFilesBundleIds = new Set(
+      bundles
+        .filter((bundle) => {
+          const files = bundle?.files;
+          return Array.isArray(files) && files.length > 0;
+        })
+        .map((bundle) => String(bundle?.id ?? '')),
     );
+    // Codex P2 review finding: a bundle entry whose id matched but whose
+    // `files` was missing, non-array, or empty passed the id-only check
+    // above yet still let `resolveHighContentionFiles` silently omit that
+    // bundle's real shared files -- the same false-flag risk as a missing
+    // bundle id entirely, so it must degrade the same way.
     const allBundleIdsResolved = DEFAULT_BUNDLE_IDS.every((id) =>
-      resolvedBundleIds.has(id),
+      nonEmptyFilesBundleIds.has(id),
     );
     if (!allBundleIdsResolved) {
       return null;

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -818,6 +818,17 @@ function runCli() {
       resolvedHighContentionFiles !== null &&
       issue.createdAt.length > 0;
     highContentionFiles = resolvedHighContentionFiles ?? [];
+    if (candidateFiles.length > 0 && resolvedHighContentionFiles === null) {
+      // Codex P2 review finding: an unreadable/missing high-contention
+      // manifest silently skipped the same-candidate-files scan without
+      // recording a warning -- but from Check 4's perspective this is the
+      // same class of "high-confidence evidence could not be collected" as
+      // a genuine gh/API failure, and must degrade the same way (exact
+      // title match only), not let the full weak heuristic run.
+      collectionWarnings.push(
+        'same-candidate-files scan: high-contention manifest unavailable, skipping the scan',
+      );
+    }
     if (shouldScanMergedPrs) {
       const scanResult = fetchMergedPrFileOverlapEvidence(
         repoRef,
@@ -1247,8 +1258,12 @@ function fetchMergedPrFileOverlapEvidence(repoRef, sinceIso) {
  * scan entirely in that case rather than proceeding with zero exclusions --
  * an empty exclusion set would make that signal MORE permissive, which is
  * the wrong fail direction for "never fail toward a false high-confidence
- * flag". `closedByPullRequestsReferences` is a separate, independent signal
- * and is unaffected by this fallback.
+ * flag". `runCli` also records this as a `collectionWarnings` entry (Codex
+ * P2 review finding on this PR): from Check 4's perspective, "manifest
+ * unavailable" and "gh/API fetch failed" are the same class of "evidence
+ * could not be collected" and must degrade the weak-heuristic fallback the
+ * same way. `closedByPullRequestsReferences` is a separate, independent
+ * signal and is unaffected by either fallback.
  */
 function loadHighContentionFiles() {
   try {

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -728,43 +728,63 @@ function runCli() {
   const duplicateCandidates = fetchDuplicateCandidates(repoRef, issue);
   const labelsPolicy = normalizePolicyConfig(loadPolicy(args.policy)).labels;
   // #1484: high-confidence Check 4 tier evidence. closedByPullRequestsReferences
-  // is always attempted -- cheap, independent of '## Candidate files', and
-  // fails loud on a gh error like every other fetch in this file (a broken
-  // fetch must surface, not silently read as "no evidence"; see
-  // fetchClosedByMergedPrNumbers's doc comment). The same-candidate-files scan
-  // only runs when the issue declares '## Candidate files' AND the
-  // high-contention exclusion set actually resolved -- see
-  // loadHighContentionFiles's doc comment for why an unresolved manifest
-  // skips the scan rather than proceeding with zero exclusions.
-  const closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
-    owner,
-    repo,
-    args.issue,
-  );
-  const candidateFiles = parseCandidateFiles(issue.body);
-  // Only resolve the high-contention exclusion set (a file read + JSON parse)
-  // when there is a '## Candidate files' section to check it against --
-  // most issues have none, and the result would otherwise be discarded.
-  const highContentionFiles =
-    candidateFiles.length > 0 ? loadHighContentionFiles() : null;
-  const shouldScanMergedPrs =
-    candidateFiles.length > 0 &&
-    highContentionFiles !== null &&
-    issue.createdAt.length > 0;
-  const mergedPrs = shouldScanMergedPrs
-    ? fetchMergedPrFileOverlapEvidence(repoRef, issue.createdAt)
-    : [];
+  // is always attempted -- cheap, independent of '## Candidate files'. The
+  // same-candidate-files scan only runs when the issue declares
+  // '## Candidate files' AND the high-contention exclusion set actually
+  // resolved -- see loadHighContentionFiles's doc comment for why an
+  // unresolved manifest skips the scan rather than proceeding with zero
+  // exclusions.
+  //
+  // The whole block is wrapped in one try/catch (Codex review finding on
+  // this PR): an uncaught `gh` failure here previously aborted the entire
+  // 7-check evaluation, contradicting Check 4's own documented Edge Case
+  // ("Timeout on duplicate detection... fall back to exact title match
+  // only") -- this tier is an optional enhancement layered onto Check 4, and
+  // its collection failing must not take down Checks 1-3 and 5-7 too. A
+  // collection failure is never silently reported as "no evidence" (that
+  // would mask a genuinely broken collector as a clean pass) -- it is
+  // surfaced explicitly via `highConfidenceDuplicateCollectionError` in the
+  // JSON output below, while `highConfidenceDuplicate` itself is left
+  // `undefined` so Check 4 falls through to the weak heuristic exactly as if
+  // no evidence had been collected.
+  let highConfidenceDuplicate;
+  let highConfidenceDuplicateCollectionError = null;
+  try {
+    const closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
+      owner,
+      repo,
+      args.issue,
+    );
+    const candidateFiles = parseCandidateFiles(issue.body);
+    // Only resolve the high-contention exclusion set (a file read + JSON
+    // parse) when there is a '## Candidate files' section to check it
+    // against -- most issues have none, and the result would otherwise be
+    // discarded.
+    const highContentionFiles =
+      candidateFiles.length > 0 ? loadHighContentionFiles() : null;
+    const shouldScanMergedPrs =
+      candidateFiles.length > 0 &&
+      highContentionFiles !== null &&
+      issue.createdAt.length > 0;
+    const mergedPrs = shouldScanMergedPrs
+      ? fetchMergedPrFileOverlapEvidence(repoRef, issue.createdAt)
+      : [];
+    highConfidenceDuplicate = {
+      closedByMergedPrNumbers,
+      candidateFiles,
+      highContentionFiles: highContentionFiles ?? [],
+      mergedPrs,
+    };
+  } catch (error) {
+    highConfidenceDuplicateCollectionError =
+      error instanceof Error ? error.message : String(error);
+  }
   const result = evaluateSuitability(issue, {
     repository: { owner, repo },
     duplicateCandidates,
     blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
     needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
-    highConfidenceDuplicate: {
-      closedByMergedPrNumbers,
-      candidateFiles,
-      highContentionFiles: highContentionFiles ?? [],
-      mergedPrs,
-    },
+    highConfidenceDuplicate,
   });
   const output = {
     repository: { owner, repo },
@@ -777,6 +797,9 @@ function runCli() {
     passed: result.passed,
     outcome: result.outcome,
     failedCheck: result.failedCheck,
+    ...(highConfidenceDuplicateCollectionError
+      ? { highConfidenceDuplicateCollectionError }
+      : {}),
     checks: args.verbose
       ? result.checks
       : result.checks.map((check) => ({
@@ -1063,14 +1086,16 @@ export function buildPrFilesArgs(repoRef, prNumber) {
   ];
 }
 /**
- * Fetch the candidate issue's own merged closing-PR references. Fails loud
- * (via `runGh`, no try/catch here) on a `gh` error, matching this file's
- * existing `fetchIssue` / `fetchDuplicateCandidates` convention: a broken
- * fetch must surface as an error, not silently read as "no evidence" -- the
- * latter would be a much worse failure mode than a thrown error, since it
- * would make a real duplicate look clean. A CLI-level failure is already
- * covered by Check 4's documented Edge Case ("Timeout on duplicate
- * detection... fall back to exact title match only").
+ * Fetch the candidate issue's own merged closing-PR references. Throws (via
+ * `runGh`, no try/catch here) on a `gh` error rather than silently reading a
+ * broken fetch as "no evidence" -- the latter would make a real duplicate
+ * look clean. The caller (`runCli`) wraps this and its sibling fetches below
+ * in one try/catch so a failure here degrades the optional high-confidence
+ * tier (Check 4's own documented "Timeout on duplicate detection... fall
+ * back to exact title match only" Edge Case) without aborting the other six
+ * checks (Codex review finding on this PR: an earlier version let this
+ * throw uncaught all the way out of `runCli`, crashing the whole
+ * evaluation).
  */
 function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
   const parsed = ghJson(buildClosedByMergedPrArgs(owner, repo, issueNumber));
@@ -1084,22 +1109,32 @@ function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
 /**
  * Bounded two-step merged-PR file-overlap scan (list, then per-PR file
  * list), mirroring B2.0's own documented commands exactly rather than a new
- * query shape. Fails loud like `fetchClosedByMergedPrNumbers` above -- once
- * the caller has decided to run this scan (see `shouldScanMergedPrs` in
- * `runCli`), a mid-scan `gh` error surfaces rather than degrading to "no
- * overlap found".
+ * query shape. A malformed list entry (non-positive-integer or absent
+ * `number`) is skipped rather than shelled out to `gh pr view` (Copilot
+ * review finding on this PR: `ghJsonArray` intentionally returns
+ * `unknown[]`, so an unexpected API shape should degrade this one entry,
+ * not become a hard `gh pr view NaN`/`gh pr view 0` failure). A genuine `gh`
+ * error on a well-formed entry still throws -- the caller (`runCli`) wraps
+ * this and its sibling fetch above in one try/catch so that surfaces as the
+ * documented Check 4 Edge Case fallback rather than crashing the whole
+ * evaluation.
  */
 function fetchMergedPrFileOverlapEvidence(repoRef, sinceIso) {
   const list = ghJsonArray(buildMergedPrListArgs(repoRef, sinceIso));
-  return list.map((entry) => {
+  const results = [];
+  for (const entry of list) {
     const pr = entry ?? {};
     const number = Number.parseInt(String(pr.number ?? ''), 10);
+    if (!Number.isInteger(number) || number <= 0) {
+      continue;
+    }
     const files = runGh(buildPrFilesArgs(repoRef, number))
       .split('\n')
       .map((line) => line.trim())
       .filter(Boolean);
-    return { number, mergedAt: String(pr.mergedAt ?? ''), files };
-  });
+    results.push({ number, mergedAt: String(pr.mergedAt ?? ''), files });
+  }
+  return results;
 }
 /**
  * Resolve the high-contention exclusion set the same way A4 Step 2's

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -8,9 +8,45 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { parseCliArgs } from './cli-args.mjs';
+import {
+  DEFAULT_BUNDLE_IDS,
+  DEFAULT_EXTRA_FILES,
+  DEFAULT_MANIFEST_PATH,
+  ghJson as ghJsonArray,
+  normalizeContentionPath,
+  parseCandidateFiles,
+  resolveHighContentionFiles,
+} from './discover-shared-file-overlap.mjs';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
 
+/** Upper bound on the #1484 bounded merged-PR scan (mirrors B2.0's own
+ * documented `gh pr list --limit 50`). */
+const MERGED_PR_SCAN_LIMIT = 50;
+/**
+ * GraphQL query for the closed-by-merged-PR read (#1484), bounded to the
+ * first 50 closing-PR references. A later page could theoretically hold an
+ * additional MERGED reference this misses, but that only makes the tier
+ * under-detect (fall back to the weak heuristic) rather than over-detect --
+ * the safe fail direction for a check that must never fail TOWARD a false
+ * positive, so a full pagination loop (as `idd-roadmap-audit-execute.mts`'s
+ * `hasOpenClosingPr` implements for its own different, block-a-close use
+ * case) is not required here. Declared here, above the `import.meta.main`
+ * trigger below, rather than alongside the other #1484 CLI glue further
+ * down: the trigger calls `runCli()` synchronously at module-evaluation
+ * time, and a `const` declared after that point is still in the temporal
+ * dead zone when the trigger fires (see `discover-shared-file-overlap.mts`'s
+ * identical note on its own flag-spec constant).
+ */
+const CLOSED_BY_MERGED_PR_QUERY = `query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      closedByPullRequestsReferences(first:50){
+        nodes { number state }
+      }
+    }
+  }
+}`;
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `issue:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
 // .mjs source text for quoted flag literals such as the --issue spec key
@@ -160,6 +196,9 @@ export function evaluateSuitability(issue, options = {}) {
     needsDecisionLabelName: normalizeConfiguredLabelName(
       options.needsDecisionLabelName,
       POLICY_DEFAULTS.labels.needsDecisionLabelName,
+    ),
+    highConfidenceDuplicate: normalizeHighConfidenceDuplicateInput(
+      options.highConfidenceDuplicate,
     ),
   };
   const checks = [];
@@ -350,7 +389,80 @@ export function checkTrustSafety(context) {
     evidence: 'No trust/safety blockers detected.',
   };
 }
+/**
+ * High-confidence Check 4 tier (#1484): evaluate the mechanical B2.0-style
+ * signals -- a merged closing-PR reference on the candidate issue itself, or
+ * a merged PR that already changed one of the issue's own declared
+ * `## Candidate files` (excluding high-contention/shared files, which many
+ * unrelated issues touch and so are not on their own high-confidence
+ * evidence that THIS issue was superseded). Returns `null` -- never a
+ * synthesized verdict of its own -- whenever no strong signal fires, so the
+ * caller falls through to the existing weak title/declaration heuristic
+ * unchanged. This is the fail-safe contract the issue requires: never fail
+ * TOWARD a false high-confidence flag. `input` may be `undefined` (evidence
+ * not collected by the caller) or a partially malformed shape; both degrade
+ * to "no verdict" rather than a crash or a false hit.
+ */
+export function evaluateHighConfidenceDuplicate(input) {
+  if (!input) {
+    return null;
+  }
+  const closedByMergedPrNumbers = (
+    Array.isArray(input.closedByMergedPrNumbers)
+      ? input.closedByMergedPrNumbers
+      : []
+  ).filter((n) => Number.isInteger(n) && n > 0);
+  if (closedByMergedPrNumbers.length > 0) {
+    return {
+      pass: false,
+      evidence: `High-confidence duplicate: issue is already referenced by merged closing PR(s) #${closedByMergedPrNumbers.join(', #')} (closedByPullRequestsReferences).`,
+    };
+  }
+  const highContention = new Set(
+    (Array.isArray(input.highContentionFiles)
+      ? input.highContentionFiles
+      : []
+    ).map((file) => normalizeContentionPath(file)),
+  );
+  const candidateFiles = [
+    ...new Set(
+      (Array.isArray(input.candidateFiles) ? input.candidateFiles : [])
+        .map((file) => normalizeContentionPath(file))
+        .filter((file) => file.length > 0 && !highContention.has(file)),
+    ),
+  ];
+  if (candidateFiles.length === 0) {
+    return null;
+  }
+  const candidateSet = new Set(candidateFiles);
+  const mergedPrs = Array.isArray(input.mergedPrs) ? input.mergedPrs : [];
+  for (const raw of mergedPrs) {
+    const pr = raw ?? {};
+    const number = Number(pr.number);
+    if (!Number.isInteger(number) || number <= 0) {
+      continue;
+    }
+    const files = Array.isArray(pr.files) ? pr.files : [];
+    const overlap = [
+      ...new Set(files.map((file) => normalizeContentionPath(file))),
+    ].filter((file) => candidateSet.has(file));
+    if (overlap.length > 0) {
+      const mergedAt = String(pr.mergedAt ?? '');
+      return {
+        pass: false,
+        evidence: `High-confidence duplicate: merged PR #${number}${mergedAt ? ` (merged ${mergedAt})` : ''} already changed candidate file(s): ${overlap.sort().join(', ')}.`,
+      };
+    }
+  }
+  return null;
+}
 export function checkDuplicateOrSuperseded(context) {
+  const highConfidence = evaluateHighConfidenceDuplicate(
+    context.highConfidenceDuplicate,
+  );
+  if (highConfidence) {
+    return highConfidence;
+  }
   const { issue, duplicateCandidates } = context;
   const body = issue.body;
   const declarations = [...body.matchAll(DUPLICATE_DECLARATION_PATTERN)];
@@ -615,11 +727,44 @@ function runCli() {
   const issue = fetchIssue(repoRef, args.issue);
   const duplicateCandidates = fetchDuplicateCandidates(repoRef, issue);
   const labelsPolicy = normalizePolicyConfig(loadPolicy(args.policy)).labels;
+  // #1484: high-confidence Check 4 tier evidence. closedByPullRequestsReferences
+  // is always attempted -- cheap, independent of '## Candidate files', and
+  // fails loud on a gh error like every other fetch in this file (a broken
+  // fetch must surface, not silently read as "no evidence"; see
+  // fetchClosedByMergedPrNumbers's doc comment). The same-candidate-files scan
+  // only runs when the issue declares '## Candidate files' AND the
+  // high-contention exclusion set actually resolved -- see
+  // loadHighContentionFiles's doc comment for why an unresolved manifest
+  // skips the scan rather than proceeding with zero exclusions.
+  const closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
+    owner,
+    repo,
+    args.issue,
+  );
+  const candidateFiles = parseCandidateFiles(issue.body);
+  // Only resolve the high-contention exclusion set (a file read + JSON parse)
+  // when there is a '## Candidate files' section to check it against --
+  // most issues have none, and the result would otherwise be discarded.
+  const highContentionFiles =
+    candidateFiles.length > 0 ? loadHighContentionFiles() : null;
+  const shouldScanMergedPrs =
+    candidateFiles.length > 0 &&
+    highContentionFiles !== null &&
+    issue.createdAt.length > 0;
+  const mergedPrs = shouldScanMergedPrs
+    ? fetchMergedPrFileOverlapEvidence(repoRef, issue.createdAt)
+    : [];
   const result = evaluateSuitability(issue, {
     repository: { owner, repo },
     duplicateCandidates,
     blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
     needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+    highConfidenceDuplicate: {
+      closedByMergedPrNumbers,
+      candidateFiles,
+      highContentionFiles: highContentionFiles ?? [],
+      mergedPrs,
+    },
   });
   const output = {
     repository: { owner, repo },
@@ -721,7 +866,61 @@ function normalizeIssue(issue) {
     state: String(i.state ?? ''),
     labels: normalizeLabels(i.labels),
     url: String(i.url ?? i.html_url ?? ''),
+    createdAt: String(i.created_at ?? ''),
   };
+}
+/**
+ * Normalize the `evaluateSuitability` options-boundary input for #1484's
+ * high-confidence tier. Returns `undefined` for anything that isn't a
+ * plausible object (existing callers that don't know about this field never
+ * pass it, which must resolve to "absent", not an empty-but-present shape --
+ * `evaluateHighConfidenceDuplicate` special-cases `undefined` for exactly
+ * this reason). Every array field defaults to `[]` on a malformed shape.
+ */
+function normalizeHighConfidenceDuplicateInput(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return undefined;
+  }
+  const r = raw;
+  return {
+    closedByMergedPrNumbers: normalizePositiveIntArray(
+      r.closedByMergedPrNumbers,
+    ),
+    candidateFiles: normalizeStringArray(r.candidateFiles),
+    highContentionFiles: normalizeStringArray(r.highContentionFiles),
+    mergedPrs: normalizeHighConfidenceMergedPrs(r.mergedPrs),
+  };
+}
+function normalizePositiveIntArray(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => Number(entry))
+    .filter((entry) => Number.isInteger(entry) && entry > 0);
+}
+function normalizeStringArray(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => String(entry ?? ''))
+    .filter((entry) => entry.length > 0);
+}
+function normalizeHighConfidenceMergedPrs(value) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => {
+      const e = entry ?? {};
+      return {
+        number: Number(e.number),
+        mergedAt: String(e.mergedAt ?? ''),
+        files: normalizeStringArray(e.files),
+      };
+    })
+    .filter((entry) => Number.isInteger(entry.number) && entry.number > 0);
 }
 /**
  * Resolve one configured `labels.*` name (#1273), falling back to the given
@@ -793,6 +992,142 @@ function fetchDuplicateCandidates(repoRef, issue) {
     `search/issues?q=${encodeURIComponent(query)}&per_page=50`,
   ]);
   return normalizeDuplicateCandidates(payload.items ?? []);
+}
+// --- #1484: high-confidence Check 4 tier CLI glue ---------------------------
+// Read-only: every function below only ever calls `gh api graphql` (with a
+// `query` operation, never `mutation`), `gh pr list`, or `gh pr view` (no
+// -X/--method, no issue/PR mutation subcommand).
+// #1484 is detect-only by design; do not add a mutating gh call here -- a
+// later gated-close follow-up (#1485) is a separate, human-gated change.
+// The argv-builders are exported so tests can assert the exact read-only
+// verb without shelling out (a compiled-text grep for mutating verb
+// literals would miss a `gh api ... -X POST`-shaped mutation, since none of
+// this file's own calls use one).
+/**
+ * Argv for the closed-by-merged-PR read. Uses `gh api graphql` rather than
+ * `gh issue view --json closedByPullRequestsReferences`: the latter's
+ * REST-shimmed shape carries no per-PR `state`, and the connection includes
+ * OPEN (not yet merged) PRs, not only merged ones -- confirmed empirically
+ * against this repo's own issue #1489 (OPEN) / PR #1497 (OPEN), and matches
+ * `idd-roadmap-audit-execute.mts`'s documented note that the field "returns
+ * merged PRs even with `includeClosedPrs:false`" (i.e. state alone
+ * determines relevance, not that flag). Filtering to `state === 'MERGED'`
+ * happens in `fetchClosedByMergedPrNumbers` below, after this fetch --
+ * without it, an issue with only an in-progress unmerged closing PR would
+ * wrongly read as "already referenced by a merged closing PR".
+ */
+export function buildClosedByMergedPrArgs(owner, repo, issueNumber) {
+  return [
+    'api',
+    'graphql',
+    '-f',
+    `query=${CLOSED_BY_MERGED_PR_QUERY}`,
+    '-f',
+    `owner=${owner}`,
+    '-f',
+    `repo=${repo}`,
+    '-F',
+    `number=${issueNumber}`,
+  ];
+}
+/** Argv for the bounded merged-PR list scan (mirrors B2.0's own documented
+ * `gh pr list --search "merged:>=<since>"` shape). */
+export function buildMergedPrListArgs(repoRef, sinceIso) {
+  return [
+    'pr',
+    'list',
+    '--repo',
+    repoRef,
+    '--state',
+    'merged',
+    '--search',
+    `merged:>=${sinceIso}`,
+    '--json',
+    'number,mergedAt',
+    '--limit',
+    String(MERGED_PR_SCAN_LIMIT),
+  ];
+}
+/** Argv for one merged PR's changed-file list. */
+export function buildPrFilesArgs(repoRef, prNumber) {
+  return [
+    'pr',
+    'view',
+    String(prNumber),
+    '--repo',
+    repoRef,
+    '--json',
+    'files',
+    '--jq',
+    '.files[].path',
+  ];
+}
+/**
+ * Fetch the candidate issue's own merged closing-PR references. Fails loud
+ * (via `runGh`, no try/catch here) on a `gh` error, matching this file's
+ * existing `fetchIssue` / `fetchDuplicateCandidates` convention: a broken
+ * fetch must surface as an error, not silently read as "no evidence" -- the
+ * latter would be a much worse failure mode than a thrown error, since it
+ * would make a real duplicate look clean. A CLI-level failure is already
+ * covered by Check 4's documented Edge Case ("Timeout on duplicate
+ * detection... fall back to exact title match only").
+ */
+function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
+  const parsed = ghJson(buildClosedByMergedPrArgs(owner, repo, issueNumber));
+  const nodes =
+    parsed.data?.repository?.issue?.closedByPullRequestsReferences?.nodes ?? [];
+  return nodes
+    .filter((node) => String(node?.state ?? '') === 'MERGED')
+    .map((node) => Number.parseInt(String(node?.number ?? ''), 10))
+    .filter((n) => Number.isInteger(n) && n > 0);
+}
+/**
+ * Bounded two-step merged-PR file-overlap scan (list, then per-PR file
+ * list), mirroring B2.0's own documented commands exactly rather than a new
+ * query shape. Fails loud like `fetchClosedByMergedPrNumbers` above -- once
+ * the caller has decided to run this scan (see `shouldScanMergedPrs` in
+ * `runCli`), a mid-scan `gh` error surfaces rather than degrading to "no
+ * overlap found".
+ */
+function fetchMergedPrFileOverlapEvidence(repoRef, sinceIso) {
+  const list = ghJsonArray(buildMergedPrListArgs(repoRef, sinceIso));
+  return list.map((entry) => {
+    const pr = entry ?? {};
+    const number = Number.parseInt(String(pr.number ?? ''), 10);
+    const files = runGh(buildPrFilesArgs(repoRef, number))
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    return { number, mergedAt: String(pr.mergedAt ?? ''), files };
+  });
+}
+/**
+ * Resolve the high-contention exclusion set the same way A4 Step 2's
+ * `discover-shared-file-overlap` does, so the #1484 same-candidate-files
+ * signal never treats a broadly-shared bundle/manifest file as
+ * high-confidence evidence on its own. Returns `null` (not `[]`) when the
+ * manifest cannot be loaded, so `runCli` can skip the same-candidate-files
+ * scan entirely in that case rather than proceeding with zero exclusions --
+ * an empty exclusion set would make that signal MORE permissive, which is
+ * the wrong fail direction for "never fail toward a false high-confidence
+ * flag". `closedByPullRequestsReferences` is a separate, independent signal
+ * and is unaffected by this fallback.
+ */
+function loadHighContentionFiles() {
+  try {
+    const manifest = JSON.parse(
+      readFileSync(resolve(process.cwd(), DEFAULT_MANIFEST_PATH), 'utf8'),
+    );
+    return [
+      ...resolveHighContentionFiles({
+        manifest,
+        bundleIds: DEFAULT_BUNDLE_IDS,
+        extraFiles: DEFAULT_EXTRA_FILES,
+      }),
+    ];
+  } catch {
+    return null;
+  }
 }
 function ghJson(args) {
   return JSON.parse(runGh(args).trim() || '{}');

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -212,6 +212,9 @@ export function evaluateSuitability(issue, options = {}) {
     highConfidenceDuplicate: normalizeHighConfidenceDuplicateInput(
       options.highConfidenceDuplicate,
     ),
+    highConfidenceCollectionDegraded: Boolean(
+      options.highConfidenceCollectionDegraded,
+    ),
   };
   const checks = [];
   for (const check of CHECKS) {
@@ -476,6 +479,33 @@ export function checkDuplicateOrSuperseded(context) {
     return highConfidence;
   }
   const { issue, duplicateCandidates } = context;
+  // #1484 (Codex P2 review finding): a genuine high-confidence
+  // evidence-collection failure -- not "checked, found nothing" -- degrades
+  // to exact-title matching ONLY, per the documented "Timeout on duplicate
+  // detection... fall back to exact title match only" Edge Case. Skips the
+  // free-text declaration scan and the near-duplicate fuzzy (>80%
+  // Levenshtein) check entirely: a merely similarly-titled but genuinely
+  // distinct issue must never read as a false duplicate just because
+  // evidence collection broke.
+  if (context.highConfidenceCollectionDegraded) {
+    const degradedExactTitle = normalizeText(issue.title);
+    const degradedExactMatch = duplicateCandidates.find(
+      (candidate) =>
+        candidate.number !== issue.number &&
+        normalizeText(candidate.title) === degradedExactTitle,
+    );
+    if (degradedExactMatch) {
+      return {
+        pass: false,
+        evidence: `Exact-title duplicate found: #${degradedExactMatch.number}`,
+      };
+    }
+    return {
+      pass: true,
+      evidence:
+        'High-confidence evidence collection failed; degraded to exact-title match only per the documented "Timeout on duplicate detection" Edge Case. No exact-title duplicate found.',
+    };
+  }
   const body = issue.body;
   const declarations = [...body.matchAll(DUPLICATE_DECLARATION_PATTERN)];
   for (const declaration of declarations) {
@@ -810,6 +840,7 @@ function runCli() {
     blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
     needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
     highConfidenceDuplicate,
+    highConfidenceCollectionDegraded: collectionWarnings.length > 0,
   });
   const output = {
     repository: { owner, repo },

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -1124,6 +1124,19 @@ export function buildPrFilesArgs(repoRef, prNumber) {
  */
 function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
   const parsed = ghJson(buildClosedByMergedPrArgs(owner, repo, issueNumber));
+  // `gh api graphql` exits non-zero (throwing via runGh) on a schema-level
+  // query error, but a GraphQL response can also return HTTP 200 with a
+  // non-empty top-level `errors` array alongside partial/null `data` (a
+  // resolver-level failure on a nullable field) -- verified empirically
+  // that gh's own exit code does not always catch this shape. Treating that
+  // silently as "no evidence" would suppress a real collection failure
+  // (Copilot review finding on this PR); throw explicitly so the caller's
+  // try/catch records it in `collectionWarnings` instead.
+  if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
+    throw new Error(
+      `closedByPullRequestsReferences GraphQL response returned errors: ${JSON.stringify(parsed.errors)}`,
+    );
+  }
   const nodes =
     parsed.data?.repository?.issue?.closedByPullRequestsReferences?.nodes ?? [];
   return nodes

--- a/src/scripts/discover-shared-file-overlap.mts
+++ b/src/scripts/discover-shared-file-overlap.mts
@@ -27,11 +27,14 @@ import {
 } from './protocol-helpers.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
-const DEFAULT_MANIFEST_PATH = 'audit/sync-manifest.json';
+// Exported (#1484) so suitability-triage.mts's high-confidence Check 4 tier
+// can build the identical high-contention set this module uses for A4 Step 2,
+// instead of re-declaring its own copy of these defaults.
+export const DEFAULT_MANIFEST_PATH = 'audit/sync-manifest.json';
 /** F-phase bundles whose member instruction files concentrate concurrent edits. */
-const DEFAULT_BUNDLE_IDS = ['bundle-review', 'bundle-merge'];
+export const DEFAULT_BUNDLE_IDS = ['bundle-review', 'bundle-merge'];
 /** Append-mostly shared surfaces that are not bundle members. */
-const DEFAULT_EXTRA_FILES = [DEFAULT_MANIFEST_PATH];
+export const DEFAULT_EXTRA_FILES = [DEFAULT_MANIFEST_PATH];
 const DEFAULT_AUTOPILOT_SUITABILITY_FLOOR = 3;
 const DEFAULT_CLAIM_STALE_AGE_MS = 24 * 60 * 60 * 1000;
 /** Upper bound on the best-effort open-PR scan (a `gh pr list --limit`). */
@@ -861,7 +864,10 @@ branch is not yet pushed is picked up once it appears remotely.
 `);
 }
 
-function ghJson(args: string[]): unknown[] {
+// Exported (#1484) as the array-safe `gh` JSON parser: suitability-triage.mts
+// reuses it (aliased at the import site to avoid colliding with that file's
+// own object-shaped `ghJson`) instead of re-declaring an equivalent helper.
+export function ghJson(args: string[]): unknown[] {
   const parsed = JSON.parse(runGh(args).trim() || '[]');
   return Array.isArray(parsed) ? parsed : [];
 }

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1395,7 +1395,21 @@ function fetchClosedByMergedPrNumbers(
         } | null;
       } | null;
     };
+    errors?: unknown;
   };
+  // `gh api graphql` exits non-zero (throwing via runGh) on a schema-level
+  // query error, but a GraphQL response can also return HTTP 200 with a
+  // non-empty top-level `errors` array alongside partial/null `data` (a
+  // resolver-level failure on a nullable field) -- verified empirically
+  // that gh's own exit code does not always catch this shape. Treating that
+  // silently as "no evidence" would suppress a real collection failure
+  // (Copilot review finding on this PR); throw explicitly so the caller's
+  // try/catch records it in `collectionWarnings` instead.
+  if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
+    throw new Error(
+      `closedByPullRequestsReferences GraphQL response returned errors: ${JSON.stringify(parsed.errors)}`,
+    );
+  }
   const nodes =
     parsed.data?.repository?.issue?.closedByPullRequestsReferences?.nodes ?? [];
   return nodes

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -162,6 +162,20 @@ interface Context {
   needsDecisionLabelName?: string;
   /** #1484: high-confidence duplicate/superseded mechanical evidence. */
   highConfidenceDuplicate?: HighConfidenceDuplicateInput;
+  /**
+   * #1484 (Codex P2 review finding): `true` when a high-confidence evidence
+   * collector genuinely failed (recorded in `collectionWarnings` by
+   * `runCli`), as opposed to running cleanly and finding nothing. Before
+   * this tier existed, any Check 4 collector failure crashed the whole
+   * evaluation; this tier's own try/catch introduced the first scenario
+   * where a collector can fail yet Check 4 still runs -- which must
+   * degrade to the documented "Timeout on duplicate detection... fall back
+   * to exact title match only" Edge Case, not the full weak heuristic
+   * (specifically, not the near-duplicate fuzzy match, which could
+   * otherwise flag a merely similarly-titled but genuinely distinct issue
+   * as a false duplicate precisely because evidence collection broke).
+   */
+  highConfidenceCollectionDegraded?: boolean;
 }
 
 interface CheckOutcome {
@@ -191,6 +205,8 @@ interface SuitabilityOptions {
   needsDecisionLabelName?: unknown;
   /** #1484 */
   highConfidenceDuplicate?: unknown;
+  /** #1484 */
+  highConfidenceCollectionDegraded?: unknown;
 }
 
 const CHECKS: {
@@ -336,6 +352,9 @@ export function evaluateSuitability(
     ),
     highConfidenceDuplicate: normalizeHighConfidenceDuplicateInput(
       options.highConfidenceDuplicate,
+    ),
+    highConfidenceCollectionDegraded: Boolean(
+      options.highConfidenceCollectionDegraded,
     ),
   };
 
@@ -630,6 +649,35 @@ export function checkDuplicateOrSuperseded(context: Context): CheckOutcome {
   }
 
   const { issue, duplicateCandidates } = context;
+
+  // #1484 (Codex P2 review finding): a genuine high-confidence
+  // evidence-collection failure -- not "checked, found nothing" -- degrades
+  // to exact-title matching ONLY, per the documented "Timeout on duplicate
+  // detection... fall back to exact title match only" Edge Case. Skips the
+  // free-text declaration scan and the near-duplicate fuzzy (>80%
+  // Levenshtein) check entirely: a merely similarly-titled but genuinely
+  // distinct issue must never read as a false duplicate just because
+  // evidence collection broke.
+  if (context.highConfidenceCollectionDegraded) {
+    const degradedExactTitle = normalizeText(issue.title);
+    const degradedExactMatch = duplicateCandidates.find(
+      (candidate) =>
+        candidate.number !== issue.number &&
+        normalizeText(candidate.title) === degradedExactTitle,
+    );
+    if (degradedExactMatch) {
+      return {
+        pass: false,
+        evidence: `Exact-title duplicate found: #${degradedExactMatch.number}`,
+      };
+    }
+    return {
+      pass: true,
+      evidence:
+        'High-confidence evidence collection failed; degraded to exact-title match only per the documented "Timeout on duplicate detection" Edge Case. No exact-title duplicate found.',
+    };
+  }
+
   const body = issue.body;
 
   const declarations = [...body.matchAll(DUPLICATE_DECLARATION_PATTERN)];
@@ -996,6 +1044,7 @@ function runCli(): void {
     blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
     needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
     highConfidenceDuplicate,
+    highConfidenceCollectionDegraded: collectionWarnings.length > 0,
   });
 
   const output = {

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1019,9 +1019,24 @@ function runCli(): void {
       resolvedHighContentionFiles !== null &&
       issue.createdAt.length > 0;
     highContentionFiles = resolvedHighContentionFiles ?? [];
-    mergedPrs = shouldScanMergedPrs
-      ? fetchMergedPrFileOverlapEvidence(repoRef, issue.createdAt)
-      : [];
+    if (shouldScanMergedPrs) {
+      const scanResult = fetchMergedPrFileOverlapEvidence(
+        repoRef,
+        issue.createdAt,
+      );
+      mergedPrs = scanResult.mergedPrs;
+      if (scanResult.truncatedByDeadline) {
+        // Codex P2 review finding: a deadline-truncated scan returns
+        // normally (not a throw), so it must record its own warning here --
+        // otherwise Check 4 would run the full weak heuristic on
+        // incomplete evidence instead of degrading to exact-title-only.
+        collectionWarnings.push(
+          'same-candidate-files scan: truncated by MERGED_PR_SCAN_DEADLINE_MS before scanning every merged PR in the window',
+        );
+      }
+    } else {
+      mergedPrs = [];
+    }
   } catch (error) {
     collectionWarnings.push(
       `same-candidate-files scan: ${error instanceof Error ? error.message : String(error)}`,
@@ -1467,6 +1482,14 @@ function fetchClosedByMergedPrNumbers(
     .filter((n) => Number.isInteger(n) && n > 0);
 }
 
+/** Return shape for {@link fetchMergedPrFileOverlapEvidence} (#1484): pairs
+ * the collected evidence with whether the scan was cut short by
+ * `MERGED_PR_SCAN_DEADLINE_MS` before finishing. */
+interface MergedPrFileOverlapScanResult {
+  mergedPrs: HighConfidenceMergedPr[];
+  truncatedByDeadline: boolean;
+}
+
 /**
  * Bounded two-step merged-PR file-overlap scan (list, then per-PR file
  * list), mirroring B2.0's own documented commands exactly rather than a new
@@ -1475,24 +1498,34 @@ function fetchClosedByMergedPrNumbers(
  * review finding on this PR: `ghJsonArray` intentionally returns
  * `unknown[]`, so an unexpected API shape should degrade this one entry,
  * not become a hard `gh pr view NaN`/`gh pr view 0` failure). Also stops
- * early, returning whatever has been collected so far, once
- * `MERGED_PR_SCAN_DEADLINE_MS` elapses (CodeRabbit review finding on this
- * PR: up to `MERGED_PR_SCAN_LIMIT` sequential `gh pr view` calls with no
- * overall cap could otherwise run for tens of minutes under a
- * degraded/rate-limited GitHub API). A genuine `gh` error on a well-formed
- * entry still throws -- the caller (`runCli`) wraps this and its sibling
- * fetch in a separate try/catch so that surfaces as the documented Check 4
- * Edge Case fallback for just this signal, without discarding the other.
+ * early, returning whatever has been collected so far plus
+ * `truncatedByDeadline: true`, once `MERGED_PR_SCAN_DEADLINE_MS` elapses
+ * (CodeRabbit review finding on this PR: up to `MERGED_PR_SCAN_LIMIT`
+ * sequential `gh pr view` calls with no overall cap could otherwise run for
+ * tens of minutes under a degraded/rate-limited GitHub API). The
+ * `truncatedByDeadline` flag matters because this early exit returns
+ * normally rather than throwing (Codex P2 review finding on this PR): an
+ * earlier version left the caller unable to distinguish "scanned
+ * everything, found nothing" from "gave up partway through", so a
+ * deadline-truncated scan silently ran the FULL weak heuristic (including
+ * the near-duplicate fuzzy match) on incomplete evidence instead of
+ * degrading to the documented exact-title-only fallback the way a thrown
+ * `gh` error already does. A genuine `gh` error on a well-formed entry
+ * still throws -- the caller (`runCli`) wraps this and its sibling fetch in
+ * a separate try/catch so that surfaces as the same documented Check 4 Edge
+ * Case fallback for just this signal, without discarding the other.
  */
 function fetchMergedPrFileOverlapEvidence(
   repoRef: string,
   sinceIso: string,
-): HighConfidenceMergedPr[] {
+): MergedPrFileOverlapScanResult {
   const list = ghJsonArray(buildMergedPrListArgs(repoRef, sinceIso));
-  const results: HighConfidenceMergedPr[] = [];
+  const mergedPrs: HighConfidenceMergedPr[] = [];
   const deadline = Date.now() + MERGED_PR_SCAN_DEADLINE_MS;
+  let truncatedByDeadline = false;
   for (const entry of list) {
     if (Date.now() >= deadline) {
+      truncatedByDeadline = true;
       break;
     }
     const pr = (entry ?? {}) as { number?: unknown; mergedAt?: unknown };
@@ -1504,9 +1537,9 @@ function fetchMergedPrFileOverlapEvidence(
       .split('\n')
       .map((line) => line.trim())
       .filter(Boolean);
-    results.push({ number, mergedAt: String(pr.mergedAt ?? ''), files });
+    mergedPrs.push({ number, mergedAt: String(pr.mergedAt ?? ''), files });
   }
-  return results;
+  return { mergedPrs, truncatedByDeadline };
 }
 
 /**

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -57,6 +57,7 @@ const MERGED_PR_SCAN_DEADLINE_MS = 2 * 60 * 1000;
 const CLOSED_BY_MERGED_PR_QUERY = `query($owner:String!,$repo:String!,$number:Int!){
   repository(owner:$owner,name:$repo){
     issue(number:$number){
+      state
       closedByPullRequestsReferences(first:50){
         nodes { number state }
       }
@@ -1455,6 +1456,14 @@ export function buildPrFilesArgs(repoRef: string, prNumber: number): string[] {
  * exact title match only" Edge Case) without aborting the other six checks
  * (Codex review finding on this PR: an earlier version let this throw
  * uncaught all the way out of `runCli`, crashing the whole evaluation).
+ *
+ * Also requires the candidate issue's own current `state` to be `CLOSED`,
+ * mirroring B2.0's identical gate on this same signal
+ * (`idd-work.instructions.md`'s "Closed-by-a-merged-PR signal": `select(.state
+ * == "CLOSED")`). `closedByPullRequestsReferences` is not cleared when an
+ * issue is reopened, so without this gate a reopened issue with genuine
+ * remaining work would still show its old merged closing PR and get
+ * misclassified as a completed duplicate (Codex review finding on this PR).
  */
 function fetchClosedByMergedPrNumbers(
   owner: string,
@@ -1467,6 +1476,7 @@ function fetchClosedByMergedPrNumbers(
     data?: {
       repository?: {
         issue?: {
+          state?: unknown;
           closedByPullRequestsReferences?: {
             nodes?: { number?: unknown; state?: unknown }[] | null;
           } | null;
@@ -1487,6 +1497,9 @@ function fetchClosedByMergedPrNumbers(
     throw new Error(
       `closedByPullRequestsReferences GraphQL response returned errors: ${JSON.stringify(parsed.errors)}`,
     );
+  }
+  if (String(parsed.data?.repository?.issue?.state ?? '') !== 'CLOSED') {
+    return [];
   }
   const nodes =
     parsed.data?.repository?.issue?.closedByPullRequestsReferences?.nodes ?? [];
@@ -1594,11 +1607,21 @@ function loadHighContentionFiles(): string[] | null {
     if (!Array.isArray(bundles)) {
       return null;
     }
-    const resolvedBundleIds = new Set(
-      bundles.map((bundle) => String((bundle as { id?: unknown })?.id ?? '')),
+    const nonEmptyFilesBundleIds = new Set(
+      bundles
+        .filter((bundle) => {
+          const files = (bundle as { files?: unknown } | null)?.files;
+          return Array.isArray(files) && files.length > 0;
+        })
+        .map((bundle) => String((bundle as { id?: unknown })?.id ?? '')),
     );
+    // Codex P2 review finding: a bundle entry whose id matched but whose
+    // `files` was missing, non-array, or empty passed the id-only check
+    // above yet still let `resolveHighContentionFiles` silently omit that
+    // bundle's real shared files -- the same false-flag risk as a missing
+    // bundle id entirely, so it must degrade the same way.
     const allBundleIdsResolved = DEFAULT_BUNDLE_IDS.every((id) =>
-      resolvedBundleIds.has(id),
+      nonEmptyFilesBundleIds.has(id),
     );
     if (!allBundleIdsResolved) {
       return null;

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -27,6 +27,19 @@ import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
 const MERGED_PR_SCAN_LIMIT = 50;
 
 /**
+ * Wall-clock budget for the #1484 merged-PR file-overlap scan (CodeRabbit
+ * review finding on this PR): up to MERGED_PR_SCAN_LIMIT sequential
+ * `gh pr view` calls at 30s each could otherwise take ~25 minutes in the
+ * worst case (a degraded/rate-limited GitHub API). Stop early and return
+ * whatever has been collected once this budget elapses, rather than
+ * blocking the whole A4.5 evaluation on a slow scan. Referenced from inside
+ * `fetchMergedPrFileOverlapEvidence`, which the `import.meta.main` trigger
+ * below can reach synchronously, so this must stay declared above that
+ * trigger for the same temporal-dead-zone reason as `CLOSED_BY_MERGED_PR_QUERY`.
+ */
+const MERGED_PR_SCAN_DEADLINE_MS = 2 * 60 * 1000;
+
+/**
  * GraphQL query for the closed-by-merged-PR read (#1484), bounded to the
  * first 50 closing-PR references. A later page could theoretically hold an
  * additional MERGED reference this misses, but that only makes the tier
@@ -908,58 +921,74 @@ function runCli(): void {
   const duplicateCandidates = fetchDuplicateCandidates(repoRef, issue);
   const labelsPolicy = normalizePolicyConfig(loadPolicy(args.policy)).labels;
 
-  // #1484: high-confidence Check 4 tier evidence. closedByPullRequestsReferences
-  // is always attempted -- cheap, independent of '## Candidate files'. The
-  // same-candidate-files scan only runs when the issue declares
-  // '## Candidate files' AND the high-contention exclusion set actually
-  // resolved -- see loadHighContentionFiles's doc comment for why an
-  // unresolved manifest skips the scan rather than proceeding with zero
-  // exclusions.
-  //
-  // The whole block is wrapped in one try/catch (Codex review finding on
-  // this PR): an uncaught `gh` failure here previously aborted the entire
-  // 7-check evaluation, contradicting Check 4's own documented Edge Case
-  // ("Timeout on duplicate detection... fall back to exact title match
-  // only") -- this tier is an optional enhancement layered onto Check 4, and
-  // its collection failing must not take down Checks 1-3 and 5-7 too. A
-  // collection failure is never silently reported as "no evidence" (that
-  // would mask a genuinely broken collector as a clean pass) -- it is
-  // surfaced explicitly via `highConfidenceDuplicateCollectionError` in the
-  // JSON output below, while `highConfidenceDuplicate` itself is left
-  // `undefined` so Check 4 falls through to the weak heuristic exactly as if
-  // no evidence had been collected.
-  let highConfidenceDuplicate: SuitabilityOptions['highConfidenceDuplicate'];
-  let highConfidenceDuplicateCollectionError: string | null = null;
+  // #1484: high-confidence Check 4 tier evidence. The two mechanical signals
+  // (closedByPullRequestsReferences, and the same-candidate-files merged-PR
+  // scan) are collected in two SEPARATE try/catch blocks (CodeRabbit review
+  // finding on this PR): an earlier version wrapped both in one block, so a
+  // failure collecting the second signal discarded an already-successful
+  // first signal too. Each block's own failure is recorded independently in
+  // `collectionWarnings` and degrades only that one signal to empty/absent
+  // -- never silently reported as "no evidence" (that would mask a
+  // genuinely broken collector as a clean pass), and never discarding a
+  // sibling signal that already collected cleanly. `gh`/API fetch failures
+  // in either block are always recorded here; a manifest-unavailable
+  // same-candidate-files skip is a distinct, deliberate degradation
+  // documented on `loadHighContentionFiles` itself, not a fetch failure, so
+  // it is not added to this list (Copilot review finding on this PR: an
+  // earlier comment overclaimed that every degradation path surfaces here).
+  // This is also why an uncaught failure no longer aborts the entire
+  // 7-check evaluation (Codex review finding on this PR) -- this tier is an
+  // optional enhancement layered onto Check 4, and Check 4's own documented
+  // Edge Case ("Timeout on duplicate detection... fall back to exact title
+  // match only") already anticipates exactly this degradation.
+  const collectionWarnings: string[] = [];
+  let closedByMergedPrNumbers: number[] = [];
   try {
-    const closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
+    closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
       owner,
       repo,
       args.issue,
     );
-    const candidateFiles = parseCandidateFiles(issue.body);
+  } catch (error) {
+    collectionWarnings.push(
+      `closedByPullRequestsReferences: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  let candidateFiles: string[] = [];
+  let highContentionFiles: string[] = [];
+  let mergedPrs: HighConfidenceMergedPr[] = [];
+  try {
+    candidateFiles = parseCandidateFiles(issue.body);
     // Only resolve the high-contention exclusion set (a file read + JSON
     // parse) when there is a '## Candidate files' section to check it
     // against -- most issues have none, and the result would otherwise be
     // discarded.
-    const highContentionFiles =
+    const resolvedHighContentionFiles =
       candidateFiles.length > 0 ? loadHighContentionFiles() : null;
     const shouldScanMergedPrs =
       candidateFiles.length > 0 &&
-      highContentionFiles !== null &&
+      resolvedHighContentionFiles !== null &&
       issue.createdAt.length > 0;
-    const mergedPrs = shouldScanMergedPrs
+    highContentionFiles = resolvedHighContentionFiles ?? [];
+    mergedPrs = shouldScanMergedPrs
       ? fetchMergedPrFileOverlapEvidence(repoRef, issue.createdAt)
       : [];
-    highConfidenceDuplicate = {
+  } catch (error) {
+    collectionWarnings.push(
+      `same-candidate-files scan: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    candidateFiles = [];
+    mergedPrs = [];
+  }
+
+  const highConfidenceDuplicate: SuitabilityOptions['highConfidenceDuplicate'] =
+    {
       closedByMergedPrNumbers,
       candidateFiles,
-      highContentionFiles: highContentionFiles ?? [],
+      highContentionFiles,
       mergedPrs,
     };
-  } catch (error) {
-    highConfidenceDuplicateCollectionError =
-      error instanceof Error ? error.message : String(error);
-  }
 
   const result = evaluateSuitability(issue, {
     repository: { owner, repo },
@@ -980,8 +1009,8 @@ function runCli(): void {
     passed: result.passed,
     outcome: result.outcome,
     failedCheck: result.failedCheck,
-    ...(highConfidenceDuplicateCollectionError
-      ? { highConfidenceDuplicateCollectionError }
+    ...(collectionWarnings.length > 0
+      ? { highConfidenceDuplicateCollectionWarnings: collectionWarnings }
       : {}),
     checks: args.verbose
       ? result.checks
@@ -1382,11 +1411,15 @@ function fetchClosedByMergedPrNumbers(
  * `number`) is skipped rather than shelled out to `gh pr view` (Copilot
  * review finding on this PR: `ghJsonArray` intentionally returns
  * `unknown[]`, so an unexpected API shape should degrade this one entry,
- * not become a hard `gh pr view NaN`/`gh pr view 0` failure). A genuine `gh`
- * error on a well-formed entry still throws -- the caller (`runCli`) wraps
- * this and its sibling fetch above in one try/catch so that surfaces as the
- * documented Check 4 Edge Case fallback rather than crashing the whole
- * evaluation.
+ * not become a hard `gh pr view NaN`/`gh pr view 0` failure). Also stops
+ * early, returning whatever has been collected so far, once
+ * `MERGED_PR_SCAN_DEADLINE_MS` elapses (CodeRabbit review finding on this
+ * PR: up to `MERGED_PR_SCAN_LIMIT` sequential `gh pr view` calls with no
+ * overall cap could otherwise run for tens of minutes under a
+ * degraded/rate-limited GitHub API). A genuine `gh` error on a well-formed
+ * entry still throws -- the caller (`runCli`) wraps this and its sibling
+ * fetch in a separate try/catch so that surfaces as the documented Check 4
+ * Edge Case fallback for just this signal, without discarding the other.
  */
 function fetchMergedPrFileOverlapEvidence(
   repoRef: string,
@@ -1394,7 +1427,11 @@ function fetchMergedPrFileOverlapEvidence(
 ): HighConfidenceMergedPr[] {
   const list = ghJsonArray(buildMergedPrListArgs(repoRef, sinceIso));
   const results: HighConfidenceMergedPr[] = [];
+  const deadline = Date.now() + MERGED_PR_SCAN_DEADLINE_MS;
   for (const entry of list) {
+    if (Date.now() >= deadline) {
+      break;
+    }
     const pr = (entry ?? {}) as { number?: unknown; mergedAt?: unknown };
     const number = Number.parseInt(String(pr.number ?? ''), 10);
     if (!Number.isInteger(number) || number <= 0) {

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -10,8 +10,46 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { parseCliArgs } from './cli-args.mts';
+import {
+  DEFAULT_BUNDLE_IDS,
+  DEFAULT_EXTRA_FILES,
+  DEFAULT_MANIFEST_PATH,
+  ghJson as ghJsonArray,
+  normalizeContentionPath,
+  parseCandidateFiles,
+  resolveHighContentionFiles,
+} from './discover-shared-file-overlap.mts';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mts';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
+
+/** Upper bound on the #1484 bounded merged-PR scan (mirrors B2.0's own
+ * documented `gh pr list --limit 50`). */
+const MERGED_PR_SCAN_LIMIT = 50;
+
+/**
+ * GraphQL query for the closed-by-merged-PR read (#1484), bounded to the
+ * first 50 closing-PR references. A later page could theoretically hold an
+ * additional MERGED reference this misses, but that only makes the tier
+ * under-detect (fall back to the weak heuristic) rather than over-detect --
+ * the safe fail direction for a check that must never fail TOWARD a false
+ * positive, so a full pagination loop (as `idd-roadmap-audit-execute.mts`'s
+ * `hasOpenClosingPr` implements for its own different, block-a-close use
+ * case) is not required here. Declared here, above the `import.meta.main`
+ * trigger below, rather than alongside the other #1484 CLI glue further
+ * down: the trigger calls `runCli()` synchronously at module-evaluation
+ * time, and a `const` declared after that point is still in the temporal
+ * dead zone when the trigger fires (see `discover-shared-file-overlap.mts`'s
+ * identical note on its own flag-spec constant).
+ */
+const CLOSED_BY_MERGED_PR_QUERY = `query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      closedByPullRequestsReferences(first:50){
+        nodes { number state }
+      }
+    }
+  }
+}`;
 
 /** Parsed CLI arguments. */
 interface SuitabilityTriageArgs {
@@ -54,6 +92,8 @@ interface NormalizedIssue {
   state: string;
   labels: string[];
   url: string;
+  /** #1484: the merged-PR scan window start (no claim exists yet at A4.5). */
+  createdAt: string;
 }
 
 interface Repository {
@@ -68,6 +108,36 @@ interface DuplicateCandidate {
   url: string;
 }
 
+/** One merged PR's changed-file evidence for the high-confidence tier (#1484). */
+export interface HighConfidenceMergedPr {
+  number: number;
+  mergedAt: string;
+  files: string[];
+}
+
+/**
+ * Mechanical B2.0-style evidence for the Check 4 high-confidence tier
+ * (#1484): a candidate issue's own `closedByPullRequestsReferences`, plus a
+ * bounded merged-PR-vs-`## Candidate files` overlap scan. Reuses
+ * `discover-shared-file-overlap.mts`'s path normalization and high-contention
+ * set instead of re-implementing either. Every field is defensively
+ * re-validated by `evaluateHighConfidenceDuplicate` itself (not just at the
+ * `evaluateSuitability` options boundary), so a caller that hand-builds a
+ * `Context` directly -- as several existing tests already do, bypassing
+ * normalization -- can never crash it or manufacture a false hit from a
+ * malformed shape; a missing or malformed field just falls through to
+ * today's weak heuristic unchanged.
+ */
+export interface HighConfidenceDuplicateInput {
+  closedByMergedPrNumbers: number[];
+  candidateFiles: string[];
+  /** High-contention files (bundle + manifest) excluded from the overlap
+   * check -- a coincidental hit on a broadly-shared file is not on its own
+   * high-confidence evidence that THIS issue was superseded. */
+  highContentionFiles: string[];
+  mergedPrs: HighConfidenceMergedPr[];
+}
+
 interface Context {
   issue: NormalizedIssue;
   repository: Repository | null;
@@ -77,6 +147,8 @@ interface Context {
   blockedByHumanLabelName?: string;
   /** Configured `labels.needsDecisionLabelName` (#1273). */
   needsDecisionLabelName?: string;
+  /** #1484: high-confidence duplicate/superseded mechanical evidence. */
+  highConfidenceDuplicate?: HighConfidenceDuplicateInput;
 }
 
 interface CheckOutcome {
@@ -104,6 +176,8 @@ interface SuitabilityOptions {
   trustSafetyAmbiguous?: unknown;
   blockedByHumanLabelName?: unknown;
   needsDecisionLabelName?: unknown;
+  /** #1484 */
+  highConfidenceDuplicate?: unknown;
 }
 
 const CHECKS: {
@@ -246,6 +320,9 @@ export function evaluateSuitability(
     needsDecisionLabelName: normalizeConfiguredLabelName(
       options.needsDecisionLabelName,
       POLICY_DEFAULTS.labels.needsDecisionLabelName,
+    ),
+    highConfidenceDuplicate: normalizeHighConfidenceDuplicateInput(
+      options.highConfidenceDuplicate,
     ),
   };
 
@@ -451,7 +528,94 @@ export function checkTrustSafety(context: Context): CheckOutcome {
   };
 }
 
+/**
+ * High-confidence Check 4 tier (#1484): evaluate the mechanical B2.0-style
+ * signals -- a merged closing-PR reference on the candidate issue itself, or
+ * a merged PR that already changed one of the issue's own declared
+ * `## Candidate files` (excluding high-contention/shared files, which many
+ * unrelated issues touch and so are not on their own high-confidence
+ * evidence that THIS issue was superseded). Returns `null` -- never a
+ * synthesized verdict of its own -- whenever no strong signal fires, so the
+ * caller falls through to the existing weak title/declaration heuristic
+ * unchanged. This is the fail-safe contract the issue requires: never fail
+ * TOWARD a false high-confidence flag. `input` may be `undefined` (evidence
+ * not collected by the caller) or a partially malformed shape; both degrade
+ * to "no verdict" rather than a crash or a false hit.
+ */
+export function evaluateHighConfidenceDuplicate(
+  input: HighConfidenceDuplicateInput | undefined,
+): CheckOutcome | null {
+  if (!input) {
+    return null;
+  }
+
+  const closedByMergedPrNumbers = (
+    Array.isArray(input.closedByMergedPrNumbers)
+      ? input.closedByMergedPrNumbers
+      : []
+  ).filter((n) => Number.isInteger(n) && n > 0);
+  if (closedByMergedPrNumbers.length > 0) {
+    return {
+      pass: false,
+      evidence: `High-confidence duplicate: issue is already referenced by merged closing PR(s) #${closedByMergedPrNumbers.join(', #')} (closedByPullRequestsReferences).`,
+    };
+  }
+
+  const highContention = new Set(
+    (Array.isArray(input.highContentionFiles)
+      ? input.highContentionFiles
+      : []
+    ).map((file) => normalizeContentionPath(file)),
+  );
+  const candidateFiles = [
+    ...new Set(
+      (Array.isArray(input.candidateFiles) ? input.candidateFiles : [])
+        .map((file) => normalizeContentionPath(file))
+        .filter((file) => file.length > 0 && !highContention.has(file)),
+    ),
+  ];
+  if (candidateFiles.length === 0) {
+    return null;
+  }
+  const candidateSet = new Set(candidateFiles);
+
+  const mergedPrs: unknown[] = Array.isArray(input.mergedPrs)
+    ? input.mergedPrs
+    : [];
+  for (const raw of mergedPrs) {
+    const pr = (raw ?? {}) as {
+      number?: unknown;
+      mergedAt?: unknown;
+      files?: unknown;
+    };
+    const number = Number(pr.number);
+    if (!Number.isInteger(number) || number <= 0) {
+      continue;
+    }
+    const files = Array.isArray(pr.files) ? pr.files : [];
+    const overlap = [
+      ...new Set(files.map((file) => normalizeContentionPath(file))),
+    ].filter((file) => candidateSet.has(file));
+    if (overlap.length > 0) {
+      const mergedAt = String(pr.mergedAt ?? '');
+      return {
+        pass: false,
+        evidence: `High-confidence duplicate: merged PR #${number}${mergedAt ? ` (merged ${mergedAt})` : ''} already changed candidate file(s): ${overlap.sort().join(', ')}.`,
+      };
+    }
+  }
+
+  return null;
+}
+
 export function checkDuplicateOrSuperseded(context: Context): CheckOutcome {
+  const highConfidence = evaluateHighConfidenceDuplicate(
+    context.highConfidenceDuplicate,
+  );
+  if (highConfidence) {
+    return highConfidence;
+  }
+
   const { issue, duplicateCandidates } = context;
   const body = issue.body;
 
@@ -743,11 +907,46 @@ function runCli(): void {
   const issue = fetchIssue(repoRef, args.issue);
   const duplicateCandidates = fetchDuplicateCandidates(repoRef, issue);
   const labelsPolicy = normalizePolicyConfig(loadPolicy(args.policy)).labels;
+
+  // #1484: high-confidence Check 4 tier evidence. closedByPullRequestsReferences
+  // is always attempted -- cheap, independent of '## Candidate files', and
+  // fails loud on a gh error like every other fetch in this file (a broken
+  // fetch must surface, not silently read as "no evidence"; see
+  // fetchClosedByMergedPrNumbers's doc comment). The same-candidate-files scan
+  // only runs when the issue declares '## Candidate files' AND the
+  // high-contention exclusion set actually resolved -- see
+  // loadHighContentionFiles's doc comment for why an unresolved manifest
+  // skips the scan rather than proceeding with zero exclusions.
+  const closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
+    owner,
+    repo,
+    args.issue,
+  );
+  const candidateFiles = parseCandidateFiles(issue.body);
+  // Only resolve the high-contention exclusion set (a file read + JSON parse)
+  // when there is a '## Candidate files' section to check it against --
+  // most issues have none, and the result would otherwise be discarded.
+  const highContentionFiles =
+    candidateFiles.length > 0 ? loadHighContentionFiles() : null;
+  const shouldScanMergedPrs =
+    candidateFiles.length > 0 &&
+    highContentionFiles !== null &&
+    issue.createdAt.length > 0;
+  const mergedPrs = shouldScanMergedPrs
+    ? fetchMergedPrFileOverlapEvidence(repoRef, issue.createdAt)
+    : [];
+
   const result = evaluateSuitability(issue, {
     repository: { owner, repo },
     duplicateCandidates,
     blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
     needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+    highConfidenceDuplicate: {
+      closedByMergedPrNumbers,
+      candidateFiles,
+      highContentionFiles: highContentionFiles ?? [],
+      mergedPrs,
+    },
   });
 
   const output = {
@@ -856,6 +1055,7 @@ function normalizeIssue(issue: unknown): NormalizedIssue {
     labels?: unknown;
     url?: unknown;
     html_url?: unknown;
+    created_at?: unknown;
   };
   return {
     number: Number.parseInt(String(i.number), 10),
@@ -864,7 +1064,78 @@ function normalizeIssue(issue: unknown): NormalizedIssue {
     state: String(i.state ?? ''),
     labels: normalizeLabels(i.labels),
     url: String(i.url ?? i.html_url ?? ''),
+    createdAt: String(i.created_at ?? ''),
   };
+}
+
+/**
+ * Normalize the `evaluateSuitability` options-boundary input for #1484's
+ * high-confidence tier. Returns `undefined` for anything that isn't a
+ * plausible object (existing callers that don't know about this field never
+ * pass it, which must resolve to "absent", not an empty-but-present shape --
+ * `evaluateHighConfidenceDuplicate` special-cases `undefined` for exactly
+ * this reason). Every array field defaults to `[]` on a malformed shape.
+ */
+function normalizeHighConfidenceDuplicateInput(
+  raw: unknown,
+): HighConfidenceDuplicateInput | undefined {
+  if (!raw || typeof raw !== 'object') {
+    return undefined;
+  }
+  const r = raw as {
+    closedByMergedPrNumbers?: unknown;
+    candidateFiles?: unknown;
+    highContentionFiles?: unknown;
+    mergedPrs?: unknown;
+  };
+  return {
+    closedByMergedPrNumbers: normalizePositiveIntArray(
+      r.closedByMergedPrNumbers,
+    ),
+    candidateFiles: normalizeStringArray(r.candidateFiles),
+    highContentionFiles: normalizeStringArray(r.highContentionFiles),
+    mergedPrs: normalizeHighConfidenceMergedPrs(r.mergedPrs),
+  };
+}
+
+function normalizePositiveIntArray(value: unknown): number[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => Number(entry))
+    .filter((entry) => Number.isInteger(entry) && entry > 0);
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => String(entry ?? ''))
+    .filter((entry) => entry.length > 0);
+}
+
+function normalizeHighConfidenceMergedPrs(
+  value: unknown,
+): HighConfidenceMergedPr[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value
+    .map((entry) => {
+      const e = (entry ?? {}) as {
+        number?: unknown;
+        mergedAt?: unknown;
+        files?: unknown;
+      };
+      return {
+        number: Number(e.number),
+        mergedAt: String(e.mergedAt ?? ''),
+        files: normalizeStringArray(e.files),
+      };
+    })
+    .filter((entry) => Number.isInteger(entry.number) && entry.number > 0);
 }
 
 /**
@@ -961,6 +1232,175 @@ function fetchDuplicateCandidates(
     `search/issues?q=${encodeURIComponent(query)}&per_page=50`,
   ]) as { items?: unknown };
   return normalizeDuplicateCandidates(payload.items ?? []);
+}
+
+// --- #1484: high-confidence Check 4 tier CLI glue ---------------------------
+// Read-only: every function below only ever calls `gh api graphql` (with a
+// `query` operation, never `mutation`), `gh pr list`, or `gh pr view` (no
+// -X/--method, no issue/PR mutation subcommand).
+// #1484 is detect-only by design; do not add a mutating gh call here -- a
+// later gated-close follow-up (#1485) is a separate, human-gated change.
+// The argv-builders are exported so tests can assert the exact read-only
+// verb without shelling out (a compiled-text grep for mutating verb
+// literals would miss a `gh api ... -X POST`-shaped mutation, since none of
+// this file's own calls use one).
+
+/**
+ * Argv for the closed-by-merged-PR read. Uses `gh api graphql` rather than
+ * `gh issue view --json closedByPullRequestsReferences`: the latter's
+ * REST-shimmed shape carries no per-PR `state`, and the connection includes
+ * OPEN (not yet merged) PRs, not only merged ones -- confirmed empirically
+ * against this repo's own issue #1489 (OPEN) / PR #1497 (OPEN), and matches
+ * `idd-roadmap-audit-execute.mts`'s documented note that the field "returns
+ * merged PRs even with `includeClosedPrs:false`" (i.e. state alone
+ * determines relevance, not that flag). Filtering to `state === 'MERGED'`
+ * happens in `fetchClosedByMergedPrNumbers` below, after this fetch --
+ * without it, an issue with only an in-progress unmerged closing PR would
+ * wrongly read as "already referenced by a merged closing PR".
+ */
+export function buildClosedByMergedPrArgs(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): string[] {
+  return [
+    'api',
+    'graphql',
+    '-f',
+    `query=${CLOSED_BY_MERGED_PR_QUERY}`,
+    '-f',
+    `owner=${owner}`,
+    '-f',
+    `repo=${repo}`,
+    '-F',
+    `number=${issueNumber}`,
+  ];
+}
+
+/** Argv for the bounded merged-PR list scan (mirrors B2.0's own documented
+ * `gh pr list --search "merged:>=<since>"` shape). */
+export function buildMergedPrListArgs(
+  repoRef: string,
+  sinceIso: string,
+): string[] {
+  return [
+    'pr',
+    'list',
+    '--repo',
+    repoRef,
+    '--state',
+    'merged',
+    '--search',
+    `merged:>=${sinceIso}`,
+    '--json',
+    'number,mergedAt',
+    '--limit',
+    String(MERGED_PR_SCAN_LIMIT),
+  ];
+}
+
+/** Argv for one merged PR's changed-file list. */
+export function buildPrFilesArgs(repoRef: string, prNumber: number): string[] {
+  return [
+    'pr',
+    'view',
+    String(prNumber),
+    '--repo',
+    repoRef,
+    '--json',
+    'files',
+    '--jq',
+    '.files[].path',
+  ];
+}
+
+/**
+ * Fetch the candidate issue's own merged closing-PR references. Fails loud
+ * (via `runGh`, no try/catch here) on a `gh` error, matching this file's
+ * existing `fetchIssue` / `fetchDuplicateCandidates` convention: a broken
+ * fetch must surface as an error, not silently read as "no evidence" -- the
+ * latter would be a much worse failure mode than a thrown error, since it
+ * would make a real duplicate look clean. A CLI-level failure is already
+ * covered by Check 4's documented Edge Case ("Timeout on duplicate
+ * detection... fall back to exact title match only").
+ */
+function fetchClosedByMergedPrNumbers(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): number[] {
+  const parsed = ghJson(
+    buildClosedByMergedPrArgs(owner, repo, issueNumber),
+  ) as {
+    data?: {
+      repository?: {
+        issue?: {
+          closedByPullRequestsReferences?: {
+            nodes?: { number?: unknown; state?: unknown }[] | null;
+          } | null;
+        } | null;
+      } | null;
+    };
+  };
+  const nodes =
+    parsed.data?.repository?.issue?.closedByPullRequestsReferences?.nodes ?? [];
+  return nodes
+    .filter((node) => String(node?.state ?? '') === 'MERGED')
+    .map((node) => Number.parseInt(String(node?.number ?? ''), 10))
+    .filter((n) => Number.isInteger(n) && n > 0);
+}
+
+/**
+ * Bounded two-step merged-PR file-overlap scan (list, then per-PR file
+ * list), mirroring B2.0's own documented commands exactly rather than a new
+ * query shape. Fails loud like `fetchClosedByMergedPrNumbers` above -- once
+ * the caller has decided to run this scan (see `shouldScanMergedPrs` in
+ * `runCli`), a mid-scan `gh` error surfaces rather than degrading to "no
+ * overlap found".
+ */
+function fetchMergedPrFileOverlapEvidence(
+  repoRef: string,
+  sinceIso: string,
+): HighConfidenceMergedPr[] {
+  const list = ghJsonArray(buildMergedPrListArgs(repoRef, sinceIso));
+  return list.map((entry) => {
+    const pr = (entry ?? {}) as { number?: unknown; mergedAt?: unknown };
+    const number = Number.parseInt(String(pr.number ?? ''), 10);
+    const files = runGh(buildPrFilesArgs(repoRef, number))
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    return { number, mergedAt: String(pr.mergedAt ?? ''), files };
+  });
+}
+
+/**
+ * Resolve the high-contention exclusion set the same way A4 Step 2's
+ * `discover-shared-file-overlap` does, so the #1484 same-candidate-files
+ * signal never treats a broadly-shared bundle/manifest file as
+ * high-confidence evidence on its own. Returns `null` (not `[]`) when the
+ * manifest cannot be loaded, so `runCli` can skip the same-candidate-files
+ * scan entirely in that case rather than proceeding with zero exclusions --
+ * an empty exclusion set would make that signal MORE permissive, which is
+ * the wrong fail direction for "never fail toward a false high-confidence
+ * flag". `closedByPullRequestsReferences` is a separate, independent signal
+ * and is unaffected by this fallback.
+ */
+function loadHighContentionFiles(): string[] | null {
+  try {
+    const manifest = JSON.parse(
+      readFileSync(resolve(process.cwd(), DEFAULT_MANIFEST_PATH), 'utf8'),
+    );
+    return [
+      ...resolveHighContentionFiles({
+        manifest,
+        bundleIds: DEFAULT_BUNDLE_IDS,
+        extraFiles: DEFAULT_EXTRA_FILES,
+      }),
+    ];
+  } catch {
+    return null;
+  }
 }
 
 function ghJson(args: string[]): unknown {

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1445,13 +1445,16 @@ export function buildPrFilesArgs(repoRef: string, prNumber: number): string[] {
  * Fetch the candidate issue's own merged closing-PR references. Throws (via
  * `runGh`, no try/catch here) on a `gh` error rather than silently reading a
  * broken fetch as "no evidence" -- the latter would make a real duplicate
- * look clean. The caller (`runCli`) wraps this and its sibling fetches below
- * in one try/catch so a failure here degrades the optional high-confidence
- * tier (Check 4's own documented "Timeout on duplicate detection... fall
- * back to exact title match only" Edge Case) without aborting the other six
- * checks (Codex review finding on this PR: an earlier version let this
- * throw uncaught all the way out of `runCli`, crashing the whole
- * evaluation).
+ * look clean. The caller (`runCli`) wraps this in its own try/catch,
+ * separate from the same-candidate-files scan's try/catch below (Copilot
+ * review finding on this PR: an earlier version described both as sharing
+ * one try/catch, which stopped being accurate once they were split so a
+ * failure in one signal's collection couldn't discard an already-successful
+ * sibling), so a failure here degrades the optional high-confidence tier
+ * (Check 4's own documented "Timeout on duplicate detection... fall back to
+ * exact title match only" Edge Case) without aborting the other six checks
+ * (Codex review finding on this PR: an earlier version let this throw
+ * uncaught all the way out of `runCli`, crashing the whole evaluation).
  */
 function fetchClosedByMergedPrNumbers(
   owner: string,

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -909,44 +909,64 @@ function runCli(): void {
   const labelsPolicy = normalizePolicyConfig(loadPolicy(args.policy)).labels;
 
   // #1484: high-confidence Check 4 tier evidence. closedByPullRequestsReferences
-  // is always attempted -- cheap, independent of '## Candidate files', and
-  // fails loud on a gh error like every other fetch in this file (a broken
-  // fetch must surface, not silently read as "no evidence"; see
-  // fetchClosedByMergedPrNumbers's doc comment). The same-candidate-files scan
-  // only runs when the issue declares '## Candidate files' AND the
-  // high-contention exclusion set actually resolved -- see
-  // loadHighContentionFiles's doc comment for why an unresolved manifest
-  // skips the scan rather than proceeding with zero exclusions.
-  const closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
-    owner,
-    repo,
-    args.issue,
-  );
-  const candidateFiles = parseCandidateFiles(issue.body);
-  // Only resolve the high-contention exclusion set (a file read + JSON parse)
-  // when there is a '## Candidate files' section to check it against --
-  // most issues have none, and the result would otherwise be discarded.
-  const highContentionFiles =
-    candidateFiles.length > 0 ? loadHighContentionFiles() : null;
-  const shouldScanMergedPrs =
-    candidateFiles.length > 0 &&
-    highContentionFiles !== null &&
-    issue.createdAt.length > 0;
-  const mergedPrs = shouldScanMergedPrs
-    ? fetchMergedPrFileOverlapEvidence(repoRef, issue.createdAt)
-    : [];
+  // is always attempted -- cheap, independent of '## Candidate files'. The
+  // same-candidate-files scan only runs when the issue declares
+  // '## Candidate files' AND the high-contention exclusion set actually
+  // resolved -- see loadHighContentionFiles's doc comment for why an
+  // unresolved manifest skips the scan rather than proceeding with zero
+  // exclusions.
+  //
+  // The whole block is wrapped in one try/catch (Codex review finding on
+  // this PR): an uncaught `gh` failure here previously aborted the entire
+  // 7-check evaluation, contradicting Check 4's own documented Edge Case
+  // ("Timeout on duplicate detection... fall back to exact title match
+  // only") -- this tier is an optional enhancement layered onto Check 4, and
+  // its collection failing must not take down Checks 1-3 and 5-7 too. A
+  // collection failure is never silently reported as "no evidence" (that
+  // would mask a genuinely broken collector as a clean pass) -- it is
+  // surfaced explicitly via `highConfidenceDuplicateCollectionError` in the
+  // JSON output below, while `highConfidenceDuplicate` itself is left
+  // `undefined` so Check 4 falls through to the weak heuristic exactly as if
+  // no evidence had been collected.
+  let highConfidenceDuplicate: SuitabilityOptions['highConfidenceDuplicate'];
+  let highConfidenceDuplicateCollectionError: string | null = null;
+  try {
+    const closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
+      owner,
+      repo,
+      args.issue,
+    );
+    const candidateFiles = parseCandidateFiles(issue.body);
+    // Only resolve the high-contention exclusion set (a file read + JSON
+    // parse) when there is a '## Candidate files' section to check it
+    // against -- most issues have none, and the result would otherwise be
+    // discarded.
+    const highContentionFiles =
+      candidateFiles.length > 0 ? loadHighContentionFiles() : null;
+    const shouldScanMergedPrs =
+      candidateFiles.length > 0 &&
+      highContentionFiles !== null &&
+      issue.createdAt.length > 0;
+    const mergedPrs = shouldScanMergedPrs
+      ? fetchMergedPrFileOverlapEvidence(repoRef, issue.createdAt)
+      : [];
+    highConfidenceDuplicate = {
+      closedByMergedPrNumbers,
+      candidateFiles,
+      highContentionFiles: highContentionFiles ?? [],
+      mergedPrs,
+    };
+  } catch (error) {
+    highConfidenceDuplicateCollectionError =
+      error instanceof Error ? error.message : String(error);
+  }
 
   const result = evaluateSuitability(issue, {
     repository: { owner, repo },
     duplicateCandidates,
     blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
     needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
-    highConfidenceDuplicate: {
-      closedByMergedPrNumbers,
-      candidateFiles,
-      highContentionFiles: highContentionFiles ?? [],
-      mergedPrs,
-    },
+    highConfidenceDuplicate,
   });
 
   const output = {
@@ -960,6 +980,9 @@ function runCli(): void {
     passed: result.passed,
     outcome: result.outcome,
     failedCheck: result.failedCheck,
+    ...(highConfidenceDuplicateCollectionError
+      ? { highConfidenceDuplicateCollectionError }
+      : {}),
     checks: args.verbose
       ? result.checks
       : result.checks.map((check) => ({
@@ -1315,14 +1338,16 @@ export function buildPrFilesArgs(repoRef: string, prNumber: number): string[] {
 }
 
 /**
- * Fetch the candidate issue's own merged closing-PR references. Fails loud
- * (via `runGh`, no try/catch here) on a `gh` error, matching this file's
- * existing `fetchIssue` / `fetchDuplicateCandidates` convention: a broken
- * fetch must surface as an error, not silently read as "no evidence" -- the
- * latter would be a much worse failure mode than a thrown error, since it
- * would make a real duplicate look clean. A CLI-level failure is already
- * covered by Check 4's documented Edge Case ("Timeout on duplicate
- * detection... fall back to exact title match only").
+ * Fetch the candidate issue's own merged closing-PR references. Throws (via
+ * `runGh`, no try/catch here) on a `gh` error rather than silently reading a
+ * broken fetch as "no evidence" -- the latter would make a real duplicate
+ * look clean. The caller (`runCli`) wraps this and its sibling fetches below
+ * in one try/catch so a failure here degrades the optional high-confidence
+ * tier (Check 4's own documented "Timeout on duplicate detection... fall
+ * back to exact title match only" Edge Case) without aborting the other six
+ * checks (Codex review finding on this PR: an earlier version let this
+ * throw uncaught all the way out of `runCli`, crashing the whole
+ * evaluation).
  */
 function fetchClosedByMergedPrNumbers(
   owner: string,
@@ -1353,25 +1378,35 @@ function fetchClosedByMergedPrNumbers(
 /**
  * Bounded two-step merged-PR file-overlap scan (list, then per-PR file
  * list), mirroring B2.0's own documented commands exactly rather than a new
- * query shape. Fails loud like `fetchClosedByMergedPrNumbers` above -- once
- * the caller has decided to run this scan (see `shouldScanMergedPrs` in
- * `runCli`), a mid-scan `gh` error surfaces rather than degrading to "no
- * overlap found".
+ * query shape. A malformed list entry (non-positive-integer or absent
+ * `number`) is skipped rather than shelled out to `gh pr view` (Copilot
+ * review finding on this PR: `ghJsonArray` intentionally returns
+ * `unknown[]`, so an unexpected API shape should degrade this one entry,
+ * not become a hard `gh pr view NaN`/`gh pr view 0` failure). A genuine `gh`
+ * error on a well-formed entry still throws -- the caller (`runCli`) wraps
+ * this and its sibling fetch above in one try/catch so that surfaces as the
+ * documented Check 4 Edge Case fallback rather than crashing the whole
+ * evaluation.
  */
 function fetchMergedPrFileOverlapEvidence(
   repoRef: string,
   sinceIso: string,
 ): HighConfidenceMergedPr[] {
   const list = ghJsonArray(buildMergedPrListArgs(repoRef, sinceIso));
-  return list.map((entry) => {
+  const results: HighConfidenceMergedPr[] = [];
+  for (const entry of list) {
     const pr = (entry ?? {}) as { number?: unknown; mergedAt?: unknown };
     const number = Number.parseInt(String(pr.number ?? ''), 10);
+    if (!Number.isInteger(number) || number <= 0) {
+      continue;
+    }
     const files = runGh(buildPrFilesArgs(repoRef, number))
       .split('\n')
       .map((line) => line.trim())
       .filter(Boolean);
-    return { number, mergedAt: String(pr.mergedAt ?? ''), files };
-  });
+    results.push({ number, mergedAt: String(pr.mergedAt ?? ''), files });
+  }
+  return results;
 }
 
 /**

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1577,6 +1577,32 @@ function loadHighContentionFiles(): string[] | null {
     const manifest = JSON.parse(
       readFileSync(resolve(process.cwd(), DEFAULT_MANIFEST_PATH), 'utf8'),
     );
+    // Codex P2 review finding: a manifest that parses but lacks usable
+    // `bundleBudgets` entries for one or both target bundle IDs (an empty
+    // object, or an older schema) doesn't throw here -- `resolveHighContentionFiles`
+    // degrades gracefully to just `DEFAULT_EXTRA_FILES` for A4 Step 2's own,
+    // lower-stakes de-prioritization use. But for this tier, an incomplete
+    // exclusion set can miss a genuinely high-contention file, so a shared
+    // bundle/instruction file could be misread as specific overlap evidence
+    // -- exactly the false high-confidence flag Check 4 must never produce.
+    // Require both configured bundle IDs to actually resolve before
+    // accepting the set; otherwise treat it the same as an unreadable
+    // manifest (return null, which the caller already records as a
+    // collection warning and degrades to exact-title-only).
+    const bundles = (manifest as { bundleBudgets?: unknown } | null)
+      ?.bundleBudgets;
+    if (!Array.isArray(bundles)) {
+      return null;
+    }
+    const resolvedBundleIds = new Set(
+      bundles.map((bundle) => String((bundle as { id?: unknown })?.id ?? '')),
+    );
+    const allBundleIdsResolved = DEFAULT_BUNDLE_IDS.every((id) =>
+      resolvedBundleIds.has(id),
+    );
+    if (!allBundleIdsResolved) {
+      return null;
+    }
     return [
       ...resolveHighContentionFiles({
         manifest,

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1019,6 +1019,17 @@ function runCli(): void {
       resolvedHighContentionFiles !== null &&
       issue.createdAt.length > 0;
     highContentionFiles = resolvedHighContentionFiles ?? [];
+    if (candidateFiles.length > 0 && resolvedHighContentionFiles === null) {
+      // Codex P2 review finding: an unreadable/missing high-contention
+      // manifest silently skipped the same-candidate-files scan without
+      // recording a warning -- but from Check 4's perspective this is the
+      // same class of "high-confidence evidence could not be collected" as
+      // a genuine gh/API failure, and must degrade the same way (exact
+      // title match only), not let the full weak heuristic run.
+      collectionWarnings.push(
+        'same-candidate-files scan: high-contention manifest unavailable, skipping the scan',
+      );
+    }
     if (shouldScanMergedPrs) {
       const scanResult = fetchMergedPrFileOverlapEvidence(
         repoRef,
@@ -1551,8 +1562,12 @@ function fetchMergedPrFileOverlapEvidence(
  * scan entirely in that case rather than proceeding with zero exclusions --
  * an empty exclusion set would make that signal MORE permissive, which is
  * the wrong fail direction for "never fail toward a false high-confidence
- * flag". `closedByPullRequestsReferences` is a separate, independent signal
- * and is unaffected by this fallback.
+ * flag". `runCli` also records this as a `collectionWarnings` entry (Codex
+ * P2 review finding on this PR): from Check 4's perspective, "manifest
+ * unavailable" and "gh/API fetch failed" are the same class of "evidence
+ * could not be collected" and must degrade the weak-heuristic fallback the
+ * same way. `closedByPullRequestsReferences` is a separate, independent
+ * signal and is unaffected by either fallback.
  */
 function loadHighContentionFiles(): string[] | null {
   try {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -784,6 +784,68 @@ test('checkDuplicateOrSuperseded: omitting highConfidenceDuplicate leaves the we
   assert.equal(result.pass, true);
 });
 
+test('checkDuplicateOrSuperseded: degraded mode skips near-duplicate fuzzy matching', () => {
+  // Regression guard for a Codex P2 review finding: a genuine collector
+  // failure must degrade to exact-title matching only, per the documented
+  // "Timeout on duplicate detection" Edge Case -- a merely SIMILAR title
+  // (>80% Levenshtein, the near-duplicate check) must not read as a false
+  // duplicate just because evidence collection broke.
+  const nearDuplicateTitle = `${BASE_ISSUE.title} extra`;
+  const result = checkDuplicateOrSuperseded({
+    issue: BASE_ISSUE,
+    duplicateCandidates: [
+      { number: 2, title: nearDuplicateTitle, state: 'OPEN' },
+    ] as Context['duplicateCandidates'],
+    highConfidenceCollectionDegraded: true,
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('checkDuplicateOrSuperseded: degraded mode still catches an exact-title match', () => {
+  const result = checkDuplicateOrSuperseded({
+    issue: BASE_ISSUE,
+    duplicateCandidates: [
+      { number: 3, title: BASE_ISSUE.title, state: 'OPEN' },
+    ] as Context['duplicateCandidates'],
+    highConfidenceCollectionDegraded: true,
+  } as Context);
+  assert.equal(result.pass, false);
+  assert.match(result.evidence, /Exact-title duplicate found: #3/);
+});
+
+test('checkDuplicateOrSuperseded: degraded mode skips the free-text declaration scan too', () => {
+  const result = checkDuplicateOrSuperseded({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThis is a duplicate of #123.`,
+    },
+    duplicateCandidates: [] as Context['duplicateCandidates'],
+    highConfidenceCollectionDegraded: true,
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('checkDuplicateOrSuperseded: not degraded still runs the full weak heuristic', () => {
+  const nearDuplicateTitle = `${BASE_ISSUE.title} extra`;
+  const result = checkDuplicateOrSuperseded({
+    issue: BASE_ISSUE,
+    duplicateCandidates: [
+      { number: 2, title: nearDuplicateTitle, state: 'OPEN' },
+    ] as Context['duplicateCandidates'],
+  } as Context);
+  assert.equal(result.pass, false);
+  assert.match(result.evidence, /Near-duplicate found/);
+});
+
+test('evaluateSuitability: a genuine collection failure degrades Check 4 to exact-title only', () => {
+  const nearDuplicateTitle = `${BASE_ISSUE.title} extra`;
+  const result = evaluateSuitability(BASE_ISSUE, {
+    duplicateCandidates: [{ number: 2, title: nearDuplicateTitle }],
+    highConfidenceCollectionDegraded: true,
+  });
+  assert.equal(result.outcome, 'ready');
+});
+
 test('evaluateSuitability: high-confidence duplicate evidence maps to the duplicate outcome', () => {
   const result = evaluateSuitability(BASE_ISSUE, {
     highConfidenceDuplicate: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -92,6 +92,10 @@ Implement helper behavior.
 `,
   labels: ['enhancement'],
   state: 'OPEN',
+  // #1484: NormalizedIssue.createdAt is required; keep this fixture fully
+  // satisfying that type so an `as Context` cast elsewhere in this file
+  // never trips TypeScript's "insufficient overlap" cast-safety check.
+  createdAt: '2026-01-01T00:00:00Z',
   url: 'https://example.com/issues/1',
 };
 
@@ -751,6 +755,10 @@ test('evaluateHighConfidenceDuplicate: closing-PR-reference is checked before th
 });
 
 test('checkDuplicateOrSuperseded: high-confidence tier takes priority over the weak heuristic', () => {
+  // Three supplied Context fields (vs. this file's usual one or two) makes
+  // TypeScript's structural-cast "sufficient overlap" check reject a direct
+  // `as Context`; route through `unknown` first, as the compiler itself
+  // suggests, rather than fabricating the remaining unused Context fields.
   const result = checkDuplicateOrSuperseded({
     issue: BASE_ISSUE,
     duplicateCandidates: [] as Context['duplicateCandidates'],
@@ -760,7 +768,7 @@ test('checkDuplicateOrSuperseded: high-confidence tier takes priority over the w
       highContentionFiles: [],
       mergedPrs: [],
     },
-  } as Context);
+  } as unknown as Context);
   assert.equal(result.pass, false);
   assert.match(result.evidence, /High-confidence duplicate/);
 });

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2,6 +2,9 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  buildClosedByMergedPrArgs,
+  buildMergedPrListArgs,
+  buildPrFilesArgs,
   checkActionability,
   checkAutonomy,
   checkCoherence,
@@ -9,6 +12,7 @@ import {
   checkRepositoryFit,
   checkTrustSafety,
   checkVerifiability,
+  evaluateHighConfidenceDuplicate,
   evaluateSuitability,
   parseArgs,
 } from '../src/scripts/suitability-triage.mts';
@@ -612,4 +616,256 @@ test('duplicate check detects a URL-form duplicate declaration', () => {
     duplicateCandidates: [] as Context['duplicateCandidates'],
   } as Context);
   assert.equal(result.pass, false);
+});
+
+// --- #1484: high-confidence Check 4 tier ------------------------------------
+
+test('evaluateHighConfidenceDuplicate: undefined input is absent, not a hit', () => {
+  assert.equal(evaluateHighConfidenceDuplicate(undefined), null);
+});
+
+test('evaluateHighConfidenceDuplicate: empty arrays fall through (fail-safe)', () => {
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: [],
+    candidateFiles: [],
+    highContentionFiles: [],
+    mergedPrs: [],
+  });
+  assert.equal(result, null);
+});
+
+test('evaluateHighConfidenceDuplicate: malformed (non-array) fields never crash and never hit', () => {
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: 'not-an-array',
+    candidateFiles: null,
+    highContentionFiles: undefined,
+    mergedPrs: 42,
+  } as unknown as Context['highConfidenceDuplicate']);
+  assert.equal(result, null);
+});
+
+test('evaluateHighConfidenceDuplicate: closing-PR-reference hit cites the PR number', () => {
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: [123],
+    candidateFiles: [],
+    highContentionFiles: [],
+    mergedPrs: [],
+  });
+  assert.equal(result?.pass, false);
+  assert.match(result?.evidence ?? '', /#123/);
+  assert.match(result?.evidence ?? '', /closedByPullRequestsReferences/);
+});
+
+test('evaluateHighConfidenceDuplicate: same-candidate-files hit cites the PR number and file', () => {
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: [],
+    candidateFiles: ['scripts/foo.mjs'],
+    highContentionFiles: [],
+    mergedPrs: [
+      {
+        number: 456,
+        mergedAt: '2026-07-10T00:00:00Z',
+        files: ['scripts/foo.mjs', 'docs/unrelated.md'],
+      },
+    ],
+  });
+  assert.equal(result?.pass, false);
+  assert.match(result?.evidence ?? '', /#456/);
+  assert.match(result?.evidence ?? '', /scripts\/foo\.mjs/);
+  assert.doesNotMatch(result?.evidence ?? '', /unrelated\.md/);
+});
+
+test('evaluateHighConfidenceDuplicate: reuses normalizeContentionPath so mirrored instruction paths still match', () => {
+  // Same basename cited two different ways: the issue's own '## Candidate
+  // files' style (idd-template source path) vs. the merged PR's actual
+  // changed-file path (generated mirror). Proves real reuse of
+  // discover-shared-file-overlap's normalization, not a re-implementation
+  // that only matches identical strings.
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: [],
+    candidateFiles: [
+      'idd-template/.github/instructions/idd-work.instructions.md',
+    ],
+    highContentionFiles: [],
+    mergedPrs: [
+      {
+        number: 789,
+        mergedAt: '2026-07-11T00:00:00Z',
+        files: ['.github/instructions/idd-work.instructions.md'],
+      },
+    ],
+  });
+  assert.equal(result?.pass, false);
+  assert.match(result?.evidence ?? '', /#789/);
+});
+
+test('evaluateHighConfidenceDuplicate: a high-contention-only overlap is not high-confidence evidence', () => {
+  // The only shared file is in the high-contention exclusion set, so this
+  // must fall through (null), not fire -- a coincidental hit on a
+  // broadly-shared file is not evidence THIS issue was superseded.
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: [],
+    candidateFiles: ['audit/sync-manifest.json'],
+    highContentionFiles: ['audit/sync-manifest.json'],
+    mergedPrs: [
+      {
+        number: 999,
+        mergedAt: '2026-07-12T00:00:00Z',
+        files: ['audit/sync-manifest.json'],
+      },
+    ],
+  });
+  assert.equal(result, null);
+});
+
+test('evaluateHighConfidenceDuplicate: a genuine file still hits when a co-listed file is high-contention', () => {
+  // Regression guard for the exclusion filter being too aggressive: a
+  // candidate list with one high-contention file and one genuine file must
+  // still fire on the genuine file's overlap.
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: [],
+    candidateFiles: ['audit/sync-manifest.json', 'scripts/genuine.mjs'],
+    highContentionFiles: ['audit/sync-manifest.json'],
+    mergedPrs: [
+      {
+        number: 1000,
+        mergedAt: '2026-07-13T00:00:00Z',
+        files: ['audit/sync-manifest.json', 'scripts/genuine.mjs'],
+      },
+    ],
+  });
+  assert.equal(result?.pass, false);
+  assert.match(result?.evidence ?? '', /scripts\/genuine\.mjs/);
+  assert.doesNotMatch(result?.evidence ?? '', /sync-manifest\.json/);
+});
+
+test('evaluateHighConfidenceDuplicate: closing-PR-reference is checked before the file-overlap scan', () => {
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: [111],
+    candidateFiles: ['scripts/foo.mjs'],
+    highContentionFiles: [],
+    mergedPrs: [{ number: 222, mergedAt: '', files: ['unrelated.mjs'] }],
+  });
+  assert.match(result?.evidence ?? '', /#111/);
+  assert.doesNotMatch(result?.evidence ?? '', /#222/);
+});
+
+test('checkDuplicateOrSuperseded: high-confidence tier takes priority over the weak heuristic', () => {
+  const result = checkDuplicateOrSuperseded({
+    issue: BASE_ISSUE,
+    duplicateCandidates: [] as Context['duplicateCandidates'],
+    highConfidenceDuplicate: {
+      closedByMergedPrNumbers: [42],
+      candidateFiles: [],
+      highContentionFiles: [],
+      mergedPrs: [],
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+  assert.match(result.evidence, /High-confidence duplicate/);
+});
+
+test('checkDuplicateOrSuperseded: omitting highConfidenceDuplicate leaves the weak heuristic unchanged', () => {
+  // No new field at all (as every pre-#1484 caller would omit it) must
+  // behave byte-for-byte as before: BASE_ISSUE's own title is not present in
+  // duplicateCandidates here, so this should pass.
+  const result = checkDuplicateOrSuperseded({
+    issue: BASE_ISSUE,
+    duplicateCandidates: [] as Context['duplicateCandidates'],
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('evaluateSuitability: high-confidence duplicate evidence maps to the duplicate outcome', () => {
+  const result = evaluateSuitability(BASE_ISSUE, {
+    highConfidenceDuplicate: {
+      closedByMergedPrNumbers: [42],
+      candidateFiles: [],
+      highContentionFiles: [],
+      mergedPrs: [],
+    },
+  });
+  assert.equal(result.outcome, 'duplicate');
+  assert.equal(result.failedCheck, 'duplicate_or_superseded');
+});
+
+test('evaluateSuitability: a malformed highConfidenceDuplicate option is neutralized, not thrown', () => {
+  assert.doesNotThrow(() => {
+    const result = evaluateSuitability(BASE_ISSUE, {
+      duplicateCandidates: [{ number: 1, title: BASE_ISSUE.title }],
+      highConfidenceDuplicate: 'not-an-object',
+    });
+    assert.equal(result.passed, true);
+  });
+});
+
+// --- #1484: detect-only boundary (argv-builder read-verb assertions) -------
+// A compiled-text grep for mutating verb literals would miss a
+// `gh api ... -X POST`-shaped mutation, since none of this file's own calls
+// use one. Instead, assert directly on the argv each builder produces: the
+// gh subcommand-verb position (index 1) must be an allow-listed read verb,
+// and no mutating flag/verb literal appears anywhere in the argv.
+const READ_VERBS = new Set(['view', 'list']);
+const FORBIDDEN_TOKENS = new Set([
+  'close',
+  'comment',
+  'edit',
+  'merge',
+  'reopen',
+  'delete',
+  '-X',
+  '--method',
+]);
+
+function assertReadOnlyArgv(args: string[]): void {
+  if (args[0] === 'api') {
+    // gh api graphql: the payload must be a `query` operation, never a
+    // `mutation`, so check the actual `-f query=...` value rather than an
+    // allow-listed subcommand-verb position.
+    assert.equal(args[1], 'graphql');
+    const queryArg = args.find((arg) => arg.startsWith('query='));
+    assert.equal(typeof queryArg, 'string');
+    assert.match(queryArg ?? '', /^query=\s*query[\s(]/);
+    assert.doesNotMatch(queryArg ?? '', /\bmutation\b/);
+  } else {
+    assert.equal(args[0] === 'issue' || args[0] === 'pr', true);
+    assert.equal(READ_VERBS.has(args[1]), true);
+  }
+  for (const token of args) {
+    assert.equal(
+      FORBIDDEN_TOKENS.has(token),
+      false,
+      `unexpected mutating token "${token}" in argv: ${JSON.stringify(args)}`,
+    );
+  }
+}
+
+test('buildClosedByMergedPrArgs is read-only', () => {
+  assertReadOnlyArgv(
+    buildClosedByMergedPrArgs('kurone-kito', 'idd-skill', 1484),
+  );
+});
+
+test('buildClosedByMergedPrArgs requests state so callers can filter to MERGED', () => {
+  // Regression guard for a real bug caught by review: the REST-shimmed `gh
+  // issue view --json closedByPullRequestsReferences` carries no per-PR
+  // `state` and includes OPEN (not yet merged) PRs, not only merged ones.
+  // The GraphQL query built here must request `state` explicitly so
+  // fetchClosedByMergedPrNumbers can filter to MERGED before treating a hit
+  // as high-confidence evidence.
+  const args = buildClosedByMergedPrArgs('kurone-kito', 'idd-skill', 1484);
+  const queryArg = args.find((arg) => arg.startsWith('query=')) ?? '';
+  assert.match(queryArg, /closedByPullRequestsReferences/);
+  assert.match(queryArg, /\bstate\b/);
+  assert.match(queryArg, /\bnumber\b/);
+});
+
+test('buildMergedPrListArgs is read-only', () => {
+  assertReadOnlyArgv(
+    buildMergedPrListArgs('kurone-kito/idd-skill', '2026-07-01T00:00:00Z'),
+  );
+});
+
+test('buildPrFilesArgs is read-only', () => {
+  assertReadOnlyArgv(buildPrFilesArgs('kurone-kito/idd-skill', 1492));
 });

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -773,6 +773,28 @@ test('checkDuplicateOrSuperseded: high-confidence tier takes priority over the w
   assert.match(result.evidence, /High-confidence duplicate/);
 });
 
+test('checkDuplicateOrSuperseded: a real high-confidence hit still fires even when the run is otherwise degraded', () => {
+  // Composition guard (E2 incremental critique on this PR): a genuine
+  // closedByPullRequestsReferences hit collected before the sibling
+  // same-candidate-files signal failed must still fire -- degraded mode
+  // only narrows the WEAK heuristic fallback, never suppresses an
+  // already-established high-confidence mechanical hit.
+  const result = checkDuplicateOrSuperseded({
+    issue: BASE_ISSUE,
+    duplicateCandidates: [] as Context['duplicateCandidates'],
+    highConfidenceDuplicate: {
+      closedByMergedPrNumbers: [99],
+      candidateFiles: [],
+      highContentionFiles: [],
+      mergedPrs: [],
+    },
+    highConfidenceCollectionDegraded: true,
+  } as unknown as Context);
+  assert.equal(result.pass, false);
+  assert.match(result.evidence, /High-confidence duplicate/);
+  assert.match(result.evidence, /#99/);
+});
+
 test('checkDuplicateOrSuperseded: omitting highConfidenceDuplicate leaves the weak heuristic unchanged', () => {
   // No new field at all (as every pre-#1484 caller would omit it) must
   // behave byte-for-byte as before: BASE_ISSUE's own title is not present in


### PR DESCRIPTION
# Summary

Adds a high-confidence duplicate/superseded tier to A4.5 Check 4
(`checkDuplicateOrSuperseded` in `src/scripts/suitability-triage.mts`).
Today Check 4 only runs a weak title/declaration heuristic pre-claim,
which can miss an issue that frames already-shipped work from a
different angle than a sibling. Before falling back to that weak
heuristic, the new tier checks two mechanical signals -- reused from
B2.0's own post-claim supersession re-check (`idd-work.instructions.md`),
not re-invented:

- the candidate issue's own `closedByPullRequestsReferences` is
  non-empty and `MERGED`, or
- a PR merged at/after the issue's own `createdAt` changed a file
  under its `## Candidate files` section, excluding A4 Step 2's
  high-contention set (`discover-shared-file-overlap`'s bundle +
  manifest files).

Either signal firing surfaces the same `duplicate` outcome (no new
outcome value), but callers now get machine-derivable evidence (PR
number(s) and/or overlapping file path(s)) instead of prose alone.
With neither signal established, Check 4 falls back to exactly
today's weak heuristic, unchanged.

An 8-angle review round (line-by-line, removed-behavior, cross-file,
reuse, simplification, efficiency, altitude, and CLAUDE.md-conventions
passes, each independently verified) caught a real false-positive risk
before merge: `gh issue view --json closedByPullRequestsReferences`
carries no per-PR `state` and includes OPEN (not yet merged) PRs --
confirmed empirically against this repo's own issue #1489 (open, with
open PR #1497 referencing it), which would otherwise have been flagged
as a high-confidence "merged duplicate" despite nothing having merged.
Fixed by switching that fetch to a `gh api graphql` query that requests
`state` explicitly and filters to `MERGED` only, then re-verified
end-to-end against #1489 (now correctly falls through to the weak
heuristic, which passes) and against #1484 itself.

## Linked issue

Closes #1484

## Follow-up issues (if any)

- [x] #1499 (held under `status:authoring`) -- two lower-priority
  findings from the same review round: eager evidence-collection
  ordering in `runCli` (fetches run before `evaluateSuitability`'s
  cheaper Check 1-3 could short-circuit), and extracting the
  detection kernel into a shared module for B2.0's eventual
  mechanization. Deliberately deferred rather than expanding this
  change's risk surface.

## Background / rationale (if material)

Stays strictly **detect-only**, matching #1484's explicit scope: no
code path here closes an issue, posts a claim/operational marker, or
creates a branch/worktree (every new `gh` call is a read -- `gh api
graphql` with a `query` operation, `gh pr list`, `gh pr view` --
verified by dedicated argv-level tests, not a fragile compiled-text
grep). The "acceptance criteria already hold on `main`" bullet from
the original issue body is deliberately not implemented here -- it
pairs with the close decision this gate never takes, so it's deferred
to the separate gated-close follow-up (#1485, held).

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (biome, dprint, markdownlint, cspell all clean; one
  pre-existing biome schema-version info notice, unrelated)
- [x] `pnpm test` (2372/2372 passing)
- [x] `node scripts/audit-docs.mjs --check` (passes; instruction-doc
  addition trimmed to fit the `bundle-discovery` byte budget)
- [x] `pnpm run docs:sync:check` (via `node scripts/sync-docs.mjs
  --apply`, no drift)
- [x] `node scripts/idd-doctor.mjs` (passes, 4 pre-existing
  environment-only warnings unrelated to this change)
- [x] End-to-end: `node scripts/suitability-triage.mjs --issue 1489
  --verbose` and `--issue 1484` run against live GitHub state to
  confirm the false-positive fix and no regression

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none -- read-only evidence
  collection, no new merge-time behavior)
- [x] Context budget impact reviewed (instruction-doc addition kept
  under the `bundle-discovery` manifest byte budget)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new high-confidence Check 4 duplicate/superseded tier using merged closing pull requests and candidate-file overlap (excluding high-contention files).
  * Duplicate results now require machine-verifiable evidence (PR numbers and/or file paths).
  * Added resilient collection with degradation behavior and non-blocking warnings when evidence can’t be gathered.

* **Documentation**
  * Updated Suitability Triage and helper-script documentation to explain the new high-confidence tier and evidence rules.

* **Tests**
  * Expanded test coverage for input validation, precedence, high-contention exclusions, fallback/degraded behavior, and read-only CLI argument generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->