### PR TITLE
fix(ci): dedupe check-run instances by name in ci-wait-state

### DIFF
--- a/scripts/ci-wait-state.mjs
+++ b/scripts/ci-wait-state.mjs
@@ -27,6 +27,7 @@ import { ghText } from './gh-exec.mjs';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import {
   parsePaginatedGhNdjson,
+  selectLatestCheckInstance,
   summarizeBranchReviewRequirements,
 } from './protocol-helpers.mjs';
 
@@ -216,6 +217,59 @@ function bucketState(state) {
   if (SUCCESS_STATES.has(state)) return 'success';
   return 'unknown';
 }
+/**
+ * Reduce `entries` to one representative per `checkName`, matching the
+ * per-name dedup #1471 added to `classifyCiChecks` in
+ * `protocol-helpers.mts`: GitHub can report several check-run instances
+ * sharing one required check name (a manual or automatic rerun leaves the
+ * earlier instance in the fetched rollup alongside the new one), and only
+ * the latest instance per name should govern pass/fail/pending (#1478).
+ * Reuses the exported `selectLatestCheckInstance` for the actual
+ * same-name reduction (still-incomplete wins over completed; else latest
+ * `completedAt` wins; a same-instant tie prefers `FAILURE`, then
+ * non-`CANCELLED`) so this file does not maintain a second,
+ * independently-drifting copy of that tie-break logic. Only the
+ * name-keyed grouping below is local to this file, because
+ * `CiWaitCheckEntry` uses `checkName` where `protocol-helpers.mts`'s
+ * `CheckLike` uses `name`.
+ *
+ * Deliberately keyed by `checkName` alone, not the `(checkName,
+ * workflowName)` pair this file otherwise disambiguates entries by (see
+ * the module header): GitHub's own required-status-check gate matches by
+ * check name alone, independent of which workflow produced a given
+ * instance, so any rerun whose `workflowName` happens to differ from the
+ * instance it supersedes would not be deduped under a workflow-qualified
+ * key, leaving the defect only partially fixed. (The live PR #1434
+ * reproduction this fix targets happens to share one `workflowName`
+ * across every instance, so a composite key would also fix that specific
+ * case -- but not the general one, and not as directly as matching
+ * GitHub's own name-only semantics.) `required` itself is already
+ * computed by `checkName` alone (see `normalizeCheckEntry`), so this
+ * does not newly conflate anything the required-checks rollup did not
+ * already conflate. Two genuinely independent, same-named required
+ * checks that happen to complete in the same instant remain an accepted
+ * limitation shared with `classifyCiChecks` (tracked in #1483).
+ *
+ * `entries` itself may be empty (e.g. no required check has been
+ * reported yet), in which case `groups` simply ends up with zero
+ * entries. What is guaranteed is that every group `selectLatestCheckInstance`
+ * receives has at least one member: a group is only ever created by
+ * pushing the entry that introduced its key (see the `Map` construction
+ * below), so the seedless `reduce` inside `selectLatestCheckInstance`
+ * never runs on an empty array.
+ */
+function selectLatestCheckEntryPerName(entries) {
+  const groups = new Map();
+  for (const entry of entries) {
+    const group = groups.get(entry.checkName);
+    if (group) {
+      group.push(entry);
+    } else {
+      groups.set(entry.checkName, [entry]);
+    }
+  }
+  return [...groups.values()].map((group) => selectLatestCheckInstance(group));
+}
 function buildRequiredChecksRollup(
   checks,
   requiredCheckNameSet,
@@ -246,18 +300,26 @@ function buildRequiredChecksRollup(
   const presentNames = new Set(requiredEntries.map((check) => check.checkName));
   const missingNames = names.filter((name) => !presentNames.has(name));
   const allRequiredPresent = missingNames.length === 0;
-  const anyRequiredFailing = requiredEntries.some(
+  // #1478: dedupe multiple check-run instances sharing one required check
+  // name down to the latest instance before classifying, so a stale
+  // CANCELLED/FAILURE instance never outvotes a later SUCCESS for the
+  // same name (the identical defect shape #1471 fixed in
+  // classifyCiChecks). presentNames/missingNames/allRequiredPresent above
+  // are unaffected: they only test *presence* by name via a Set, which is
+  // already naturally deduped.
+  const dedupedRequiredEntries = selectLatestCheckEntryPerName(requiredEntries);
+  const anyRequiredFailing = dedupedRequiredEntries.some(
     (check) => check.status === 'failure',
   );
-  const anyRequiredPending = requiredEntries.some(
+  const anyRequiredPending = dedupedRequiredEntries.some(
     (check) => check.status === 'pending',
   );
-  const anyRequiredUnknown = requiredEntries.some(
+  const anyRequiredUnknown = dedupedRequiredEntries.some(
     (check) => check.status === 'unknown',
   );
   const namedChecksPassing =
     allRequiredPresent &&
-    requiredEntries.every((check) => check.status === 'success');
+    dedupedRequiredEntries.every((check) => check.status === 'success');
   let status;
   if (!allRequiredPresent) {
     status = 'missing';

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1313,11 +1313,17 @@ function isNewerCheckInstance(candidate, current) {
   return candidate.state !== current.state && candidate.state < current.state;
 }
 /**
- * Reduce a group of same-name check-run instances to the single instance
- * that represents the current truth for that name. See
- * `isNewerCheckInstance` for the selection rule.
+ * Reduce a group of check-run instances that share one grouping key
+ * (typically a check name) to the single instance that represents the
+ * current truth for that key. See `isNewerCheckInstance` for the
+ * selection rule. Exported so other same-name dedup call sites (e.g.
+ * `ci-wait-state.mts`'s `buildCiWaitStateSummary`, #1478) can reuse this
+ * tie-break instead of maintaining an independent copy. `group` is
+ * always non-empty in every current caller (each group comes from
+ * bucketing a non-empty input list by key), so the seedless `reduce`
+ * below never hits its empty-array throw path.
  */
-function selectLatestCheckInstance(group) {
+export function selectLatestCheckInstance(group) {
   return group.reduce((latest, candidate) =>
     isNewerCheckInstance(candidate, latest) ? candidate : latest,
   );

--- a/src/scripts/ci-wait-state.mts
+++ b/src/scripts/ci-wait-state.mts
@@ -29,6 +29,7 @@ import { ghText } from './gh-exec.mts';
 import { deriveGhHttpStatus } from './gh-http-status.mts';
 import {
   parsePaginatedGhNdjson,
+  selectLatestCheckInstance,
   summarizeBranchReviewRequirements,
 } from './protocol-helpers.mts';
 
@@ -371,6 +372,62 @@ function bucketState(state: string): CiWaitCheckEntry['status'] {
   return 'unknown';
 }
 
+/**
+ * Reduce `entries` to one representative per `checkName`, matching the
+ * per-name dedup #1471 added to `classifyCiChecks` in
+ * `protocol-helpers.mts`: GitHub can report several check-run instances
+ * sharing one required check name (a manual or automatic rerun leaves the
+ * earlier instance in the fetched rollup alongside the new one), and only
+ * the latest instance per name should govern pass/fail/pending (#1478).
+ * Reuses the exported `selectLatestCheckInstance` for the actual
+ * same-name reduction (still-incomplete wins over completed; else latest
+ * `completedAt` wins; a same-instant tie prefers `FAILURE`, then
+ * non-`CANCELLED`) so this file does not maintain a second,
+ * independently-drifting copy of that tie-break logic. Only the
+ * name-keyed grouping below is local to this file, because
+ * `CiWaitCheckEntry` uses `checkName` where `protocol-helpers.mts`'s
+ * `CheckLike` uses `name`.
+ *
+ * Deliberately keyed by `checkName` alone, not the `(checkName,
+ * workflowName)` pair this file otherwise disambiguates entries by (see
+ * the module header): GitHub's own required-status-check gate matches by
+ * check name alone, independent of which workflow produced a given
+ * instance, so any rerun whose `workflowName` happens to differ from the
+ * instance it supersedes would not be deduped under a workflow-qualified
+ * key, leaving the defect only partially fixed. (The live PR #1434
+ * reproduction this fix targets happens to share one `workflowName`
+ * across every instance, so a composite key would also fix that specific
+ * case -- but not the general one, and not as directly as matching
+ * GitHub's own name-only semantics.) `required` itself is already
+ * computed by `checkName` alone (see `normalizeCheckEntry`), so this
+ * does not newly conflate anything the required-checks rollup did not
+ * already conflate. Two genuinely independent, same-named required
+ * checks that happen to complete in the same instant remain an accepted
+ * limitation shared with `classifyCiChecks` (tracked in #1483).
+ *
+ * `entries` itself may be empty (e.g. no required check has been
+ * reported yet), in which case `groups` simply ends up with zero
+ * entries. What is guaranteed is that every group `selectLatestCheckInstance`
+ * receives has at least one member: a group is only ever created by
+ * pushing the entry that introduced its key (see the `Map` construction
+ * below), so the seedless `reduce` inside `selectLatestCheckInstance`
+ * never runs on an empty array.
+ */
+function selectLatestCheckEntryPerName(
+  entries: CiWaitCheckEntry[],
+): CiWaitCheckEntry[] {
+  const groups = new Map<string, CiWaitCheckEntry[]>();
+  for (const entry of entries) {
+    const group = groups.get(entry.checkName);
+    if (group) {
+      group.push(entry);
+    } else {
+      groups.set(entry.checkName, [entry]);
+    }
+  }
+  return [...groups.values()].map((group) => selectLatestCheckInstance(group));
+}
+
 function buildRequiredChecksRollup(
   checks: CiWaitCheckEntry[],
   requiredCheckNameSet: Set<string>,
@@ -403,18 +460,27 @@ function buildRequiredChecksRollup(
   const missingNames = names.filter((name) => !presentNames.has(name));
   const allRequiredPresent = missingNames.length === 0;
 
-  const anyRequiredFailing = requiredEntries.some(
+  // #1478: dedupe multiple check-run instances sharing one required check
+  // name down to the latest instance before classifying, so a stale
+  // CANCELLED/FAILURE instance never outvotes a later SUCCESS for the
+  // same name (the identical defect shape #1471 fixed in
+  // classifyCiChecks). presentNames/missingNames/allRequiredPresent above
+  // are unaffected: they only test *presence* by name via a Set, which is
+  // already naturally deduped.
+  const dedupedRequiredEntries = selectLatestCheckEntryPerName(requiredEntries);
+
+  const anyRequiredFailing = dedupedRequiredEntries.some(
     (check) => check.status === 'failure',
   );
-  const anyRequiredPending = requiredEntries.some(
+  const anyRequiredPending = dedupedRequiredEntries.some(
     (check) => check.status === 'pending',
   );
-  const anyRequiredUnknown = requiredEntries.some(
+  const anyRequiredUnknown = dedupedRequiredEntries.some(
     (check) => check.status === 'unknown',
   );
   const namedChecksPassing =
     allRequiredPresent &&
-    requiredEntries.every((check) => check.status === 'success');
+    dedupedRequiredEntries.every((check) => check.status === 'success');
 
   let status: CiWaitRequiredChecksRollup['status'];
   if (!allRequiredPresent) {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1979,11 +1979,17 @@ function isNewerCheckInstance<
 }
 
 /**
- * Reduce a group of same-name check-run instances to the single instance
- * that represents the current truth for that name. See
- * `isNewerCheckInstance` for the selection rule.
+ * Reduce a group of check-run instances that share one grouping key
+ * (typically a check name) to the single instance that represents the
+ * current truth for that key. See `isNewerCheckInstance` for the
+ * selection rule. Exported so other same-name dedup call sites (e.g.
+ * `ci-wait-state.mts`'s `buildCiWaitStateSummary`, #1478) can reuse this
+ * tie-break instead of maintaining an independent copy. `group` is
+ * always non-empty in every current caller (each group comes from
+ * bucketing a non-empty input list by key), so the seedless `reduce`
+ * below never hits its empty-array throw path.
  */
-function selectLatestCheckInstance<
+export function selectLatestCheckInstance<
   T extends { state: string; completedAt?: string | null },
 >(group: T[]): T {
   return group.reduce((latest, candidate) =>

--- a/tests/ci-wait-state.test.mts
+++ b/tests/ci-wait-state.test.mts
@@ -156,6 +156,106 @@ test('required-checks rollup: a failing required check reports anyRequiredFailin
   assert.equal(summary.requiredChecks.status, 'failing');
 });
 
+// #1478: buildCiWaitStateSummary had the same multi-instance stale-rollup
+// defect #1471 fixed in classifyCiChecks (protocol-helpers.mts). Timestamps
+// below deliberately mirror required-checks-summary.test.mts's #1471
+// regression tests (strictly increasing, distinct `completedAt` values) so
+// these exercise latest-completedAt selection, not the FAILURE/CANCELLED
+// same-instant tie-break — a tied `completedAt` would pass or fail these
+// scenarios for the wrong reason.
+test('required-checks rollup: a stale cancelled instance superseded by a later success no longer reports failing', () => {
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [
+        checkRun({
+          name: 'idd-advisory-convergence',
+          workflowName: 'ci',
+          conclusion: 'CANCELLED',
+          completedAt: '2026-07-17T15:59:36Z',
+        }),
+        checkRun({
+          name: 'idd-advisory-convergence',
+          workflowName: 'ci',
+          conclusion: 'SUCCESS',
+          completedAt: '2026-07-17T16:25:47Z',
+        }),
+      ],
+    },
+    { requiredCheckNames: ['idd-advisory-convergence'] },
+  );
+
+  assert.equal(summary.requiredChecks.anyRequiredFailing, false);
+  assert.equal(summary.requiredChecks.allRequiredPassing, true);
+  assert.equal(summary.requiredChecks.status, 'success');
+});
+
+test('required-checks rollup: a genuinely failing latest instance still reports failing', () => {
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [
+        checkRun({
+          name: 'idd-advisory-convergence',
+          workflowName: 'ci',
+          conclusion: 'SUCCESS',
+          completedAt: '2026-07-17T15:59:36Z',
+        }),
+        checkRun({
+          name: 'idd-advisory-convergence',
+          workflowName: 'ci',
+          conclusion: 'FAILURE',
+          completedAt: '2026-07-17T16:25:47Z',
+        }),
+      ],
+    },
+    { requiredCheckNames: ['idd-advisory-convergence'] },
+  );
+
+  assert.equal(summary.requiredChecks.anyRequiredFailing, true);
+  assert.equal(summary.requiredChecks.allRequiredPassing, false);
+  assert.equal(summary.requiredChecks.status, 'failing');
+});
+
+test('required-checks rollup: the PR #1434 real-world shape (2 cancelled, 1 failure, 1 success, same name) reports success', () => {
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [
+        checkRun({
+          name: 'idd-advisory-convergence',
+          workflowName: 'ci',
+          conclusion: 'CANCELLED',
+          completedAt: '2026-07-17T15:59:36Z',
+        }),
+        checkRun({
+          name: 'idd-advisory-convergence',
+          workflowName: 'ci',
+          conclusion: 'CANCELLED',
+          completedAt: '2026-07-17T15:59:51Z',
+        }),
+        checkRun({
+          name: 'idd-advisory-convergence',
+          workflowName: 'ci',
+          conclusion: 'FAILURE',
+          completedAt: '2026-07-17T16:00:06Z',
+        }),
+        checkRun({
+          name: 'idd-advisory-convergence',
+          workflowName: 'ci',
+          conclusion: 'SUCCESS',
+          completedAt: '2026-07-17T16:25:47Z',
+        }),
+      ],
+    },
+    { requiredCheckNames: ['idd-advisory-convergence'] },
+  );
+
+  assert.equal(summary.requiredChecks.anyRequiredFailing, false);
+  assert.equal(summary.requiredChecks.allRequiredPassing, true);
+  assert.equal(summary.requiredChecks.status, 'success');
+});
+
 test('required-checks rollup: a not-yet-generated required check reports missing, not vacuously passing', () => {
   const summary = buildCiWaitStateSummary(
     {


### PR DESCRIPTION
# Summary

`buildCiWaitStateSummary` in `src/scripts/ci-wait-state.mts` computed
`anyRequiredFailing` / `anyRequiredPending` / `anyRequiredUnknown` from a
raw, non-deduped-by-name `requiredEntries` list, so a stale
`CANCELLED`/`FAILURE` check-run instance for a required check name
sitting alongside a later `SUCCESS` instance for that same name falsely
reported the branch as failing even after the check had converged — the
identical defect shape #1471 fixed in `classifyCiChecks`
(`protocol-helpers.mts`, shipped in PR #1479), which that PR's own body
explicitly scoped away from this file as a follow-up.

Add a local `selectLatestCheckEntryPerName` helper in `ci-wait-state.mts`
that groups `requiredEntries` by `checkName` and reuses
`protocol-helpers.mts`'s already-tested `selectLatestCheckInstance` (now
exported, body unchanged) for the actual same-name reduction (still-
incomplete wins over completed; else latest `completedAt` wins; a
same-instant tie prefers `FAILURE`, then non-`CANCELLED`), so this file
does not maintain a second, independently-drifting copy of that
tie-break logic — PR #1479's own C1 pass caught a real ordering bug in
this exact logic, so reuse avoids reintroducing it. `classifyCiChecks`
and `resolvePresentRunConclusion` are untouched (only visibility of the
already-existing `selectLatestCheckInstance` helper changes), per the
issue's acceptance criteria.

Verified live against the real PR #1434 reproduction post-fix: it
genuinely has 2 `idd-advisory-convergence` check-run instances
(`CANCELLED` at `15:59:51Z`, `SUCCESS` at `16:25:47Z`), and
`node scripts/ci-wait-state.mjs --pr 1434` now reports
`anyRequiredFailing: false` / `status: "success"` for that PR, where the
pre-fix code would have reported `anyRequiredFailing: true` since the
raw list still contains the `CANCELLED` (bucketed `'failure'`) instance.

## Linked issue

Closes #1478

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

**Dedup key is deliberately `checkName` alone, not the `(checkName,
workflowName)` pair this file otherwise disambiguates entries by** (see
the file's own module header): GitHub's own required-status-check gate
matches by check name alone, independent of which workflow produced a
given instance, so a workflow-qualified key could leave a rerun
undeduped whenever its `workflowName` differs from the instance it
supersedes. `required` itself is already computed by `checkName` alone
(`normalizeCheckEntry`), so this does not newly conflate anything the
required-checks rollup did not already conflate. Two genuinely
independent, same-named required checks that complete in the same
instant remain an accepted limitation shared with `classifyCiChecks`
(tracked in #1483, currently in progress on a sibling branch — not
touched here).

Two independent C1 critique passes ran on this diff (0 High, 0 Medium,
3 Low total across both rounds — all addressed: two doc-comment
precision fixes, one wording change for a cspell false-positive on an
invented compound word). Full test suite (2358 tests) and typecheck are
green on top of current `main`.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (2358/2358 pass)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed, 4 pre-existing warnings unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — application code + tests only, no instruction/template changes)
- [x] Context budget impact reviewed (none — no instruction file changes)
