### PR TITLE
fix(review-disposition-verify): adopt shared parseArgs wrapper

### DIFF
--- a/scripts/review-disposition-verify.mjs
+++ b/scripts/review-disposition-verify.mjs
@@ -17,12 +17,14 @@ const MARKER_REJECTION_CONFIRMED_RE =
   /^\*\*Rejection confirmed by maintainer\*\*\s+—/;
 const MARKER_AMD_RE = /^\*\*Awaiting maintainer decision\*\*\s+—/;
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
-// `items:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
-// .mjs source text for quoted flag literals. See cli-args.mts's module
-// header for the full invariant. Declared above the import.meta.main
-// trigger below (not alongside parseArgs further down) because the
-// trigger calls parseArgs() synchronously at module-evaluation time, and a
-// `const` declared after that point is still in the temporal dead zone
+// `items:`), per cli-args.mts's key-shape invariant -- parseCliArgs itself
+// rejects a bare key at runtime via NODE_OPTION_KEY_PATTERN. `--items` is
+// local to this file (not one of tests/flag-name-matrix.test.mts's shared
+// cross-helper flag concepts), so that guard is the only enforcement here.
+// Declared above the import.meta.main trigger below (not alongside
+// parseArgs further down) because the trigger calls parseArgs()
+// synchronously at module-evaluation time, and a `const` declared after
+// that point is still in the temporal dead zone
 // when the trigger fires (see #1177's entry-order TDZ hardening for the
 // same class of bug).
 const REVIEW_DISPOSITION_VERIFY_FLAG_SPEC = {

--- a/scripts/review-disposition-verify.mjs
+++ b/scripts/review-disposition-verify.mjs
@@ -4,6 +4,8 @@
 // The scripts/review-disposition-verify.mjs copy is generated from the
 // .mts source named above by `pnpm run build`. Edit the .mts source,
 // never the generated .mjs. See docs/typescript-sources.md.
+import { parseCliArgs } from './cli-args.mjs';
+
 // Tolerate a single interior punctuation char `[.!:]` before the closing `**`
 // (`**Accepted.** — …`) so a punctuated marker still verifies, while keeping the
 // required `\s+—` separator (whitespace before the em-dash; nothing after it is
@@ -14,6 +16,19 @@ const MARKER_REJECTED_RE = /^\*\*Rejected[.!:]?\*\*\s+—/;
 const MARKER_REJECTION_CONFIRMED_RE =
   /^\*\*Rejection confirmed by maintainer\*\*\s+—/;
 const MARKER_AMD_RE = /^\*\*Awaiting maintainer decision\*\*\s+—/;
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `items:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals. See cli-args.mts's module
+// header for the full invariant. Declared above the import.meta.main
+// trigger below (not alongside parseArgs further down) because the
+// trigger calls parseArgs() synchronously at module-evaluation time, and a
+// `const` declared after that point is still in the temporal dead zone
+// when the trigger fires (see #1177's entry-order TDZ hardening for the
+// same class of bug).
+const REVIEW_DISPOSITION_VERIFY_FLAG_SPEC = {
+  '--items': { type: 'string' },
+  '--help': { type: 'boolean', short: 'h' },
+};
 if (import.meta.main) {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -313,28 +328,14 @@ function normalizeItem(item) {
   };
 }
 function parseArgs(argv) {
-  const parsed = {
-    items: null,
-    help: false,
+  const { values, help } = parseCliArgs(
+    argv,
+    REVIEW_DISPOSITION_VERIFY_FLAG_SPEC,
+  );
+  return {
+    items: values.items ?? null,
+    help,
   };
-  for (let index = 0; index < argv.length; index += 1) {
-    const token = argv[index];
-    const value = argv[index + 1];
-    if (token === '--items') {
-      if (value === undefined || value.startsWith('-')) {
-        throw new Error('--items requires a JSON value');
-      }
-      parsed.items = value;
-      index += 1;
-      continue;
-    }
-    if (token === '--help' || token === '-h') {
-      parsed.help = true;
-      continue;
-    }
-    throw new Error(`unknown argument: ${token}`);
-  }
-  return parsed;
 }
 function printHelp() {
   process.stdout.write(`Usage:

--- a/src/scripts/review-disposition-verify.mts
+++ b/src/scripts/review-disposition-verify.mts
@@ -5,6 +5,8 @@
 // .mts source named above by `pnpm run build`. Edit the .mts source,
 // never the generated .mjs. See docs/typescript-sources.md.
 
+import { parseCliArgs } from './cli-args.mts';
+
 // Tolerate a single interior punctuation char `[.!:]` before the closing `**`
 // (`**Accepted.** — …`) so a punctuated marker still verifies, while keeping the
 // required `\s+—` separator (whitespace before the em-dash; nothing after it is
@@ -48,6 +50,20 @@ interface VerifyResult {
   failedCount: number;
   items: ItemResult[];
 }
+
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `items:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals. See cli-args.mts's module
+// header for the full invariant. Declared above the import.meta.main
+// trigger below (not alongside parseArgs further down) because the
+// trigger calls parseArgs() synchronously at module-evaluation time, and a
+// `const` declared after that point is still in the temporal dead zone
+// when the trigger fires (see #1177's entry-order TDZ hardening for the
+// same class of bug).
+const REVIEW_DISPOSITION_VERIFY_FLAG_SPEC = {
+  '--items': { type: 'string' },
+  '--help': { type: 'boolean', short: 'h' },
+} as const;
 
 if (import.meta.main) {
   const args = parseArgs(process.argv.slice(2));
@@ -387,28 +403,14 @@ function normalizeItem(item: unknown): NormalizedItem {
 }
 
 function parseArgs(argv: string[]): { items: string | null; help: boolean } {
-  const parsed: { items: string | null; help: boolean } = {
-    items: null,
-    help: false,
+  const { values, help } = parseCliArgs(
+    argv,
+    REVIEW_DISPOSITION_VERIFY_FLAG_SPEC,
+  );
+  return {
+    items: (values.items as string | undefined) ?? null,
+    help,
   };
-  for (let index = 0; index < argv.length; index += 1) {
-    const token = argv[index];
-    const value = argv[index + 1];
-    if (token === '--items') {
-      if (value === undefined || value.startsWith('-')) {
-        throw new Error('--items requires a JSON value');
-      }
-      parsed.items = value;
-      index += 1;
-      continue;
-    }
-    if (token === '--help' || token === '-h') {
-      parsed.help = true;
-      continue;
-    }
-    throw new Error(`unknown argument: ${token}`);
-  }
-  return parsed;
 }
 
 function printHelp(): void {

--- a/src/scripts/review-disposition-verify.mts
+++ b/src/scripts/review-disposition-verify.mts
@@ -52,12 +52,14 @@ interface VerifyResult {
 }
 
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
-// `items:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
-// .mjs source text for quoted flag literals. See cli-args.mts's module
-// header for the full invariant. Declared above the import.meta.main
-// trigger below (not alongside parseArgs further down) because the
-// trigger calls parseArgs() synchronously at module-evaluation time, and a
-// `const` declared after that point is still in the temporal dead zone
+// `items:`), per cli-args.mts's key-shape invariant -- parseCliArgs itself
+// rejects a bare key at runtime via NODE_OPTION_KEY_PATTERN. `--items` is
+// local to this file (not one of tests/flag-name-matrix.test.mts's shared
+// cross-helper flag concepts), so that guard is the only enforcement here.
+// Declared above the import.meta.main trigger below (not alongside
+// parseArgs further down) because the trigger calls parseArgs()
+// synchronously at module-evaluation time, and a `const` declared after
+// that point is still in the temporal dead zone
 // when the trigger fires (see #1177's entry-order TDZ hardening for the
 // same class of bug).
 const REVIEW_DISPOSITION_VERIFY_FLAG_SPEC = {

--- a/tests/review-disposition-verify.test.mts
+++ b/tests/review-disposition-verify.test.mts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import {
   checkPathAItem,
@@ -7,6 +10,39 @@ import {
   classifyMarker,
   verifyDispositions,
 } from '../src/scripts/review-disposition-verify.mts';
+
+const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
+const CLI_PATH = join(REPO_ROOT, 'scripts/review-disposition-verify.mjs');
+
+/** Run the built CLI and return its trimmed stdout. */
+function runCli(args: string[]): string {
+  return execFileSync(process.execPath, [CLI_PATH, ...args], {
+    encoding: 'utf8',
+    timeout: 60_000,
+  }).trim();
+}
+
+/** Run the built CLI expecting a non-zero exit, and return its stderr. */
+function runCliExpectFailure(args: string[]): {
+  status: number;
+  stderr: string;
+} {
+  try {
+    execFileSync(process.execPath, [CLI_PATH, ...args], {
+      encoding: 'utf8',
+      timeout: 60_000,
+    });
+    throw new Error('expected the CLI to exit non-zero, but it succeeded');
+  } catch (error) {
+    const status = (error as { status?: number }).status;
+    const stderr = String((error as { stderr?: unknown }).stderr ?? '');
+    assert.ok(
+      typeof status === 'number' && status !== 0,
+      `expected a non-zero exit status, got ${String(status)}`,
+    );
+    return { status: status as number, stderr };
+  }
+}
 
 // ─── classifyMarker ───────────────────────────────────────────────────────────
 
@@ -454,4 +490,55 @@ test('verifyDispositions: unknown path → fail item', () => {
 test('verifyDispositions: throws on non-array input', () => {
   assert.throws(() => verifyDispositions(null), TypeError);
   assert.throws(() => verifyDispositions({ items: [] }), TypeError);
+});
+
+// ─── CLI parsing (#1501: migrated onto the shared parseCliArgs wrapper) ───────
+
+test('CLI: a correct --items invocation matches verifyDispositions directly', () => {
+  const items = [
+    {
+      id: 'p1',
+      path: 'A',
+      type: 'regular_comment',
+      decision: 'accepted',
+      markerReply: null,
+      threadResolved: null,
+    },
+  ];
+  const expected = `${JSON.stringify(verifyDispositions(items), null, 2)}\n`;
+  const actual = execFileSync(
+    process.execPath,
+    [CLI_PATH, '--items', JSON.stringify(items)],
+    { encoding: 'utf8', timeout: 60_000 },
+  );
+  assert.equal(actual, expected);
+});
+
+test('CLI: missing --items value exits non-zero', () => {
+  const { stderr } = runCliExpectFailure(['--items']);
+  assert.match(stderr, /missing value for argument: --items/);
+});
+
+test('CLI: a flag-shaped --items value exits non-zero', () => {
+  const { stderr } = runCliExpectFailure(['--items', '--help']);
+  assert.match(stderr, /missing value for argument: --items/);
+});
+
+test('CLI: an unknown flag exits non-zero', () => {
+  const { stderr } = runCliExpectFailure(['--bogus']);
+  assert.match(stderr, /unknown argument: --bogus/);
+});
+
+test('CLI: --items is required when omitted entirely', () => {
+  const { stderr } = runCliExpectFailure([]);
+  assert.match(stderr, /--items is required/);
+});
+
+test('CLI: --help prints usage and exits 0', () => {
+  const output = runCli(['--help']);
+  assert.match(output, /^Usage:/);
+  assert.match(
+    output,
+    /node scripts\/review-disposition-verify\.mjs --items '<json>' \[--help\]/,
+  );
 });


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Migrates `review-disposition-verify.mts`'s hand-rolled `parseArgs` loop
onto the shared `parseCliArgs` wrapper (`cli-args.mts`), the one file
roadmap #1445's own completion audit found absent from the original
39-parser survey. Adds parse-level tests for the missing-value,
flag-shaped-value, unknown-flag, and `--help` paths, none of which had
coverage before.

## Linked issue

Closes #1501

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Per the acceptance criteria, this deliberately adopts the wrapper's
uniform error-message shape rather than preserving the old exact text
(`--items requires a JSON value`) — no test or doc in the repo asserted
that string, so there was nothing to fight, matching #1451's precedent.

Two behavior changes worth flagging explicitly for review (both
mechanical consequences of adopting the shared wrapper, not scope creep):

- A single-dash-prefixed `--items` value that isn't a declared flag
  (e.g. `--items -3`) is no longer rejected at parse time. The wrapper's
  ambiguity preprocessing treats it as the flag's literal value instead
  (the same convention every other migrated helper already follows), so
  it now reaches `JSON.parse`/the items-key check downstream and fails
  there if not valid JSON.
- `--items=<value>` (equals form) is now accepted; the old hand-rolled
  loop rejected it as `unknown argument: --items=...` since it only
  matched the bare `--items` token.

A missing value, a flag-shaped value (e.g. `--items --help`), and an
unknown flag all still fail with a non-zero exit under the new shape —
verified manually and covered by the new tests.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
