### PR TITLE
docs(merge): document pr-only bypass gap for solo-codeowner merges

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -189,6 +189,14 @@ Before any mutating action in F3, apply the
    SHA. This post-merge digest update is not a merge gate and must not
    happen before the successful merge command.
 5. If merge fails:
+   - `gh pr merge --merge` fails with "the base branch policy
+     prohibits the merge" despite a passing Gate checklist and a
+     configured pull-request-only bypass actor → that scoped bypass
+     alone may not clear a solo-maintainer self-approval deadlock (see
+     `docs/permissions.md`'s "Pull-request-only ruleset bypass"). Do
+     not retry the plain command or add `--admin` automatically; post
+     a hold comment with the GitHub error text and stop for a
+     maintainer decision (kurone-kito/idd-skill#1493).
    - Base branch updated or conflict → return to
      `idd-pre-merge.instructions.md` F1
    - CI condition no longer met → return to

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -216,7 +216,7 @@
         ".github/instructions/idd-overview-core.instructions.md",
         ".github/instructions/idd-pre-merge.instructions.md"
       ],
-      "limitBytes": 96700
+      "limitBytes": 97300
     }
   ],
   "docBudgetGuard": {

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -80,7 +80,15 @@ merges:
   audit trail and should be used only after IDD's branch freshness, CI,
   review, advisory, unresolved-thread, and claim gates pass. Prefer this
   over broad `always` or `exempt` bypass unless a maintainer explicitly
-  accepts the wider risk.
+  accepts the wider risk. In observed practice, this scoped bypass alone
+  may not make a plain `gh pr merge` call succeed for a solo-maintainer
+  repository's self-approval deadlock: GitHub can still reject the merge
+  with "the base branch policy prohibits the merge" and suggest
+  `--admin`, a stronger repository-admin privilege escalation than this
+  bypass mode grants. See `idd-merge.instructions.md` F3 for the
+  required hold-and-report response, and kurone-kito/idd-skill#1493 —
+  the idd-skill source repository's own tracked decision — for whether
+  autonomous `--admin` use is ever authorized.
 - **Deliberate CODEOWNERS policy change**: narrow CODEOWNERS coverage,
   add another eligible owner, or move a repository to `human_merge` when
   human review is the intended gate. Treat this as a repository policy

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -184,6 +184,14 @@ Before any mutating action in F3, apply the
    SHA. This post-merge digest update is not a merge gate and must not
    happen before the successful merge command.
 5. If merge fails:
+   - `gh pr merge --merge` fails with "the base branch policy
+     prohibits the merge" despite a passing Gate checklist and a
+     configured pull-request-only bypass actor → that scoped bypass
+     alone may not clear a solo-maintainer self-approval deadlock (see
+     `docs/permissions.md`'s "Pull-request-only ruleset bypass"). Do
+     not retry the plain command or add `--admin` automatically; post
+     a hold comment with the GitHub error text and stop for a
+     maintainer decision (kurone-kito/idd-skill#1493).
    - Base branch updated or conflict → return to
      `idd-pre-merge.instructions.md` F1
    - CI condition no longer met → return to

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -80,7 +80,15 @@ merges:
   audit trail and should be used only after IDD's branch freshness, CI,
   review, advisory, unresolved-thread, and claim gates pass. Prefer this
   over broad `always` or `exempt` bypass unless a maintainer explicitly
-  accepts the wider risk.
+  accepts the wider risk. In observed practice, this scoped bypass alone
+  may not make a plain `gh pr merge` call succeed for a solo-maintainer
+  repository's self-approval deadlock: GitHub can still reject the merge
+  with "the base branch policy prohibits the merge" and suggest
+  `--admin`, a stronger repository-admin privilege escalation than this
+  bypass mode grants. See `idd-merge.instructions.md` F3 for the
+  required hold-and-report response, and kurone-kito/idd-skill#1493 —
+  the idd-skill source repository's own tracked decision — for whether
+  autonomous `--admin` use is ever authorized.
 - **Deliberate CODEOWNERS policy change**: narrow CODEOWNERS coverage,
   add another eligible owner, or move a repository to `human_merge` when
   human review is the intended gate. Treat this as a repository policy


### PR DESCRIPTION
# Summary

While merging PR #1487 this session, `pre-merge-readiness` reported
`ready: true` with an empty blockers list, but the plain
`gh pr merge --merge` command still failed with "the base branch
policy prohibits the merge" even though a pull-request-only ruleset
bypass actor was already configured for this solo-CODEOWNER
repository. GitHub only accepted the merge after adding `--admin`, a
stronger repository-admin privilege escalation than the ruleset's own
scoped bypass grants. Neither `idd-merge.instructions.md`'s F3 gate
nor `permissions.md`'s "Pull-request-only ruleset bypass" section
warned about this, so this PR documents the observed gap and directs
F3 to hold and report instead of retrying or auto-escalating.

- `idd-template/.github/instructions/idd-merge.instructions.md`: new
  F3 "if merge fails" case for this exact error, pointing to
  `kurone-kito/idd-skill#1493` (open, needs-decision) for whether
  autonomous `--admin` use is ever authorized -- not resolved here.
- `idd-template/docs/permissions.md`: matching note on the
  "Pull-request-only ruleset bypass" bullet.
- Regenerated mirrors (`.github/instructions/idd-merge.instructions.md`,
  `docs/permissions.md`) via `node scripts/sync-docs.mjs --apply`.

## Linked issue

Closes #1494

## Follow-up issues (if any)

- [ ] none (the open authorization question is already tracked as
      #1493, out of scope here by design)

## Background / rationale (if material)

**Byte-budget ratchet in `audit/sync-manifest.json`**: the
`bundle-merge` byte budget was already at ~99.8% of its prior
96700-byte limit before this change (only ~215 bytes of headroom). Per
the near-ceiling guidance in `docs/policy-constants.md`, I first
trimmed the new instructions text to its essential wording and moved
the fuller explanation into `permissions.md` (outside this budget) --
both halves of "trim or split". Even after that, the acceptance
criteria require the gap to be documented directly in
`idd-merge.instructions.md` itself, and that irreducible remainder
still needed a small amount of headroom. I ratcheted `limitBytes` from
`96700` to `97300` -- a deliberately **minimal** bump (not the usual
~10% convention) since this bundle is the always-resident floor every
F-phase session pays, leaving ~291 bytes of margin post-change.

**Portability of the `kurone-kito/idd-skill#1493` reference**:
`idd-template/` ships to arbitrary adopter repos, where a bare `#1493`
would resolve to the wrong issue. I used the fully-qualified
`kurone-kito/idd-skill#1493` form, matching the precedent in
`idd-template/docs/idd-design-rationale.md` (e.g.
`kurone-kito/idd-skill#909`) for this repository's own self-referential
decision pointers.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
