### PR TITLE
fix(ci): don't conflate same-name checks from different producers

### DIFF
--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -45,26 +45,32 @@ import {
 // convention `gh pr checks` already surfaces and `isCompletedCiTimestamp`
 // (protocol-helpers.mts) already treats as "not completed".
 const ZERO_SENTINEL_TIMESTAMP = '0001-01-01T00:00:00Z';
-// Legacy commit-status `state` uses its own 4-value vocabulary (`error`,
-// `failure`, `pending`, `success`) that only partly overlaps the check-run
-// vocabulary `classifyCiChecks` understands (`FAILURE`, `CANCELLED`,
-// `QUEUED`, `IN_PROGRESS`, `WAITING`, `SUCCESS`, `SKIPPED`, `NEUTRAL`,
-// `NOT_APPLICABLE`, ...). `SUCCESS` and `FAILURE` already coincide, but
-// `ERROR` (a distinct "reporting error" state, not `FAILURE`) and
-// `PENDING` (a distinct "still running" state, not one of the check-run
-// pending tokens) have no direct match -- left unmapped, both would
-// silently fall into `classifyCiChecks`'s `unknown` bucket instead of the
-// `failed` / `pending` bucket a caller actually needs (PR review finding,
-// #1483: `gh pr checks`'s prior flattened read normalized both vocabularies
-// into one `state` field; this data-source swap makes normalizing them
-// this module's own responsibility). Map the two divergent tokens onto
-// their check-run equivalents before classification ever sees them; this
-// is a "still failing" / "still running" outcome, never a false pass, so
-// even an unmapped future commit-status token would only ever fail closed
-// into `unknown`, not `success`.
+// The commit-status `state` GraphQL enum (`StatusState`) has its own
+// 5-value vocabulary (`EXPECTED`, `ERROR`, `FAILURE`, `PENDING`,
+// `SUCCESS`; confirmed via schema introspection -- an earlier version of
+// this comment underclaimed 4, missing `EXPECTED`) that only partly
+// overlaps the check-run vocabulary `classifyCiChecks` understands
+// (`FAILURE`, `CANCELLED`, `QUEUED`, `IN_PROGRESS`, `WAITING`, `SUCCESS`,
+// `SKIPPED`, `NEUTRAL`, `NOT_APPLICABLE`, ...). `SUCCESS` and `FAILURE`
+// already coincide, but the other three have no direct match -- left
+// unmapped, each would silently fall into `classifyCiChecks`'s `unknown`
+// bucket instead of the `failed` / `pending` bucket a caller actually
+// needs (PR review finding, #1483: `gh pr checks`'s prior flattened read
+// normalized both vocabularies into one `state` field; this
+// data-source swap makes normalizing them this module's own
+// responsibility). Map every divergent token onto its check-run
+// equivalent before classification ever sees it: `ERROR` (a distinct
+// "reporting error" state, not `FAILURE`) maps to `FAILURE`; `PENDING`
+// (still running) and `EXPECTED` (a required status check configured for
+// this ref but not yet reported at all -- also still "not done", not a
+// failure) both map to `IN_PROGRESS`. This is always a "still failing" /
+// "still running" outcome, never a false pass, so even an unmapped
+// future commit-status token would only ever fail closed into `unknown`,
+// not `success`.
 const STATUS_CONTEXT_STATE_ALIASES = {
   ERROR: 'FAILURE',
   PENDING: 'IN_PROGRESS',
+  EXPECTED: 'IN_PROGRESS',
 };
 /**
  * Normalize one raw `statusCheckRollup` entry into the `CheckPayload`
@@ -79,7 +85,7 @@ const STATUS_CONTEXT_STATE_ALIASES = {
  * absent -- a missing status is never silently coerced to an empty
  * string, which `classifyCiChecks` would not recognize as any known
  * bucket); a legacy commit-status reports its `state`, translated through
- * `STATUS_CONTEXT_STATE_ALIASES` for the two tokens with no direct
+ * `STATUS_CONTEXT_STATE_ALIASES` for the three tokens with no direct
  * check-run equivalent. This keeps classification behavior identical to
  * before #1483 for every single-producer case that existed pre-#1483 --
  * only the producer-identity discriminator (`type` / `workflowName`) and

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -45,6 +45,27 @@ import {
 // convention `gh pr checks` already surfaces and `isCompletedCiTimestamp`
 // (protocol-helpers.mts) already treats as "not completed".
 const ZERO_SENTINEL_TIMESTAMP = '0001-01-01T00:00:00Z';
+// Legacy commit-status `state` uses its own 4-value vocabulary (`error`,
+// `failure`, `pending`, `success`) that only partly overlaps the check-run
+// vocabulary `classifyCiChecks` understands (`FAILURE`, `CANCELLED`,
+// `QUEUED`, `IN_PROGRESS`, `WAITING`, `SUCCESS`, `SKIPPED`, `NEUTRAL`,
+// `NOT_APPLICABLE`, ...). `SUCCESS` and `FAILURE` already coincide, but
+// `ERROR` (a distinct "reporting error" state, not `FAILURE`) and
+// `PENDING` (a distinct "still running" state, not one of the check-run
+// pending tokens) have no direct match -- left unmapped, both would
+// silently fall into `classifyCiChecks`'s `unknown` bucket instead of the
+// `failed` / `pending` bucket a caller actually needs (PR review finding,
+// #1483: `gh pr checks`'s prior flattened read normalized both vocabularies
+// into one `state` field; this data-source swap makes normalizing them
+// this module's own responsibility). Map the two divergent tokens onto
+// their check-run equivalents before classification ever sees them; this
+// is a "still failing" / "still running" outcome, never a false pass, so
+// even an unmapped future commit-status token would only ever fail closed
+// into `unknown`, not `success`.
+const STATUS_CONTEXT_STATE_ALIASES = {
+  ERROR: 'FAILURE',
+  PENDING: 'IN_PROGRESS',
+};
 /**
  * Normalize one raw `statusCheckRollup` entry into the `CheckPayload`
  * shape `classifyCiChecks` / `summarizeRequiredChecks` expect (#1483).
@@ -52,28 +73,41 @@ const ZERO_SENTINEL_TIMESTAMP = '0001-01-01T00:00:00Z';
  * `state` is derived to match what `gh pr checks --json state` already
  * reported for the same underlying data (verified empirically against
  * this repository's own live PRs across `SUCCESS` / `FAILURE` /
- * `IN_PROGRESS`): a completed check-run reports its `conclusion`; an
- * incomplete one reports its raw `status` (`QUEUED` / `IN_PROGRESS` /
- * `WAITING`); a legacy commit-status reports its `state` unchanged. This
- * keeps classification behavior identical to before #1483 for every
- * single-producer case -- only the producer-identity discriminator
- * (`type` / `workflowName`) is new.
+ * `IN_PROGRESS`): a completed check-run reports its `conclusion` (falling
+ * back to `UNKNOWN` if absent); an incomplete one reports its raw `status`
+ * (`QUEUED` / `IN_PROGRESS` / `WAITING`, also falling back to `UNKNOWN` if
+ * absent -- a missing status is never silently coerced to an empty
+ * string, which `classifyCiChecks` would not recognize as any known
+ * bucket); a legacy commit-status reports its `state`, translated through
+ * `STATUS_CONTEXT_STATE_ALIASES` for the two tokens with no direct
+ * check-run equivalent. This keeps classification behavior identical to
+ * before #1483 for every single-producer case that existed pre-#1483 --
+ * only the producer-identity discriminator (`type` / `workflowName`) and
+ * the commit-status vocabulary mapping are new.
  */
 export function normalizeStatusCheckRollupEntry(entry) {
-  if (String(entry?.__typename ?? '') === 'StatusContext') {
+  if (String(entry?.__typename ?? '').trim() === 'StatusContext') {
+    const rawState = String(entry?.state ?? '')
+      .trim()
+      .toUpperCase();
     return {
-      name: String(entry?.context ?? ''),
-      state: String(entry?.state ?? '').toUpperCase(),
+      name: String(entry?.context ?? '').trim(),
+      state: STATUS_CONTEXT_STATE_ALIASES[rawState] ?? rawState,
       completedAt: String(entry?.completedAt ?? ZERO_SENTINEL_TIMESTAMP),
       type: 'status-context',
       workflowName: '',
     };
   }
-  const status = String(entry?.status ?? '').toUpperCase();
-  const conclusion = String(entry?.conclusion ?? '').toUpperCase();
+  const status = String(entry?.status ?? '')
+    .trim()
+    .toUpperCase();
+  const conclusion = String(entry?.conclusion ?? '')
+    .trim()
+    .toUpperCase();
   return {
-    name: String(entry?.name ?? ''),
-    state: status === 'COMPLETED' ? conclusion || 'UNKNOWN' : status,
+    name: String(entry?.name ?? '').trim(),
+    state:
+      status === 'COMPLETED' ? conclusion || 'UNKNOWN' : status || 'UNKNOWN',
     completedAt: String(entry?.completedAt ?? ZERO_SENTINEL_TIMESTAMP),
     type: 'check-run',
     workflowName: String(entry?.workflowName ?? '').trim(),

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -39,6 +39,46 @@ import {
   selectCodeownersText,
 } from './protocol-helpers.mjs';
 
+// GitHub's GraphQL `DateTime` scalar can't be null, so a `CheckRun` that
+// has not completed yet (and a `StatusContext`, which has no completedAt
+// field at all) reports this zero-value sentinel instead -- the same
+// convention `gh pr checks` already surfaces and `isCompletedCiTimestamp`
+// (protocol-helpers.mts) already treats as "not completed".
+const ZERO_SENTINEL_TIMESTAMP = '0001-01-01T00:00:00Z';
+/**
+ * Normalize one raw `statusCheckRollup` entry into the `CheckPayload`
+ * shape `classifyCiChecks` / `summarizeRequiredChecks` expect (#1483).
+ *
+ * `state` is derived to match what `gh pr checks --json state` already
+ * reported for the same underlying data (verified empirically against
+ * this repository's own live PRs across `SUCCESS` / `FAILURE` /
+ * `IN_PROGRESS`): a completed check-run reports its `conclusion`; an
+ * incomplete one reports its raw `status` (`QUEUED` / `IN_PROGRESS` /
+ * `WAITING`); a legacy commit-status reports its `state` unchanged. This
+ * keeps classification behavior identical to before #1483 for every
+ * single-producer case -- only the producer-identity discriminator
+ * (`type` / `workflowName`) is new.
+ */
+export function normalizeStatusCheckRollupEntry(entry) {
+  if (String(entry?.__typename ?? '') === 'StatusContext') {
+    return {
+      name: String(entry?.context ?? ''),
+      state: String(entry?.state ?? '').toUpperCase(),
+      completedAt: String(entry?.completedAt ?? ZERO_SENTINEL_TIMESTAMP),
+      type: 'status-context',
+      workflowName: '',
+    };
+  }
+  const status = String(entry?.status ?? '').toUpperCase();
+  const conclusion = String(entry?.conclusion ?? '').toUpperCase();
+  return {
+    name: String(entry?.name ?? ''),
+    state: status === 'COMPLETED' ? conclusion || 'UNKNOWN' : status,
+    completedAt: String(entry?.completedAt ?? ZERO_SENTINEL_TIMESTAMP),
+    type: 'check-run',
+    workflowName: String(entry?.workflowName ?? '').trim(),
+  };
+}
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
 // .mjs source text for quoted flag literals such as the --pr spec key
@@ -125,7 +165,7 @@ export function collectPreMergeReadiness(argv) {
     '-R',
     repoRef,
     '--json',
-    'headRefOid,baseRefName,url,author,reviewDecision',
+    'headRefOid,baseRefName,url,author,reviewDecision,statusCheckRollup',
     '--jq',
     '.',
   ]);
@@ -135,19 +175,18 @@ export function collectPreMergeReadiness(argv) {
   const prAuthorLogin = String(pr.author?.login ?? '').toLowerCase();
   const reviewDecision = String(pr.reviewDecision ?? '');
   const encodedBaseRefName = encodeURIComponent(baseRefName);
-  const checks = ghJson(
-    [
-      'pr',
-      'checks',
-      String(args.prNumber),
-      '-R',
-      repoRef,
-      '--json',
-      'name,state,completedAt',
-      '--jq',
-      '.',
-    ],
-    { allowStatuses: [1, 8] },
+  // #1483: sourced from the same `gh pr view` call above (the
+  // `statusCheckRollup` field), not a separate `gh pr checks` call --
+  // `statusCheckRollup`'s GraphQL union already tags each entry with a
+  // real producer identity (`__typename`: `CheckRun` vs. `StatusContext`,
+  // plus `workflowName` for check-runs), which a flattened `gh pr checks`
+  // read cannot expose. Joining two separately-fetched lists by name would
+  // reintroduce the exact ambiguity this fix removes (confirmed live: two
+  // successive calls a few seconds apart returned different check-run
+  // counts for the same PR), so this is the single source of truth for
+  // both the check identity and its dedup discriminator.
+  const checks = (pr.statusCheckRollup ?? []).map(
+    normalizeStatusCheckRollupEntry,
   );
   const trustEmptyProtectionReads = readTrustEmptyProtectionReads();
   const branchRulesRead = fetchGovernanceJson(

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1323,11 +1323,12 @@ function selectLatestCheckInstance(group) {
   );
 }
 /**
- * Reduce a check-run list to a single representative instance per check
- * `name`, matching GitHub's own required-status-check semantics: only the
- * latest run for a given context governs, so a stale instance (e.g. a
- * cancelled or failed run superseded by a later successful rerun) can
- * never outvote the current, authoritative one that shares its name.
+ * Reduce a check-run list to a single representative instance per
+ * `(name, type, workflowName)` group, matching GitHub's own
+ * required-status-check semantics: only the latest run for a given
+ * producer governs, so a stale instance (e.g. a cancelled or failed run
+ * superseded by a later successful rerun) can never outvote the current,
+ * authoritative one from the *same* producer.
  *
  * A missing or empty `name` carries no identity to dedupe against, so
  * each such entry gets its own singleton group instead of collapsing
@@ -1335,15 +1336,27 @@ function selectLatestCheckInstance(group) {
  * could be discarded in favor of an unrelated unnamed success that
  * merely happens to also lack a name.
  *
- * Known limitation (tracked in #1483): `CheckLike` carries no
- * source/producer identity, so two genuinely independent checks that
- * happen to share an identical `name` (e.g. a check-run and a legacy
- * commit-status, or two different GitHub Apps) are indistinguishable
- * from reruns of one another here and will be grouped together. Fixing
- * this needs a source discriminator threaded through from data
- * collection (see `ci-wait-state.mts`'s `type` field) into `CheckLike`
- * itself — a data-collection-layer change out of scope for the
- * same-name-multiple-*rerun*-instances dedup this function performs.
+ * `type` (e.g. `'check-run'` vs. `'status-context'`) and `workflowName`
+ * are an optional producer-identity discriminator (#1483): two entries
+ * that share a `name` but differ on either one are never assumed to be
+ * reruns of each other (e.g. a check-run and a legacy commit-status, or
+ * two check-runs from different Actions workflows, that happen to share
+ * a display name both survive instead of one discarding the other). When
+ * `type`/`workflowName` are absent on every entry sharing a `name` (the
+ * pre-#1483 data shape, still produced by hand-built fixtures and any
+ * caller that predates the discriminator), there is no conflicting
+ * signal to split on, so the group dedupes by `name` alone exactly as
+ * #1471 established -- this keeps every pre-#1483 caller and test
+ * behavior-identical.
+ *
+ * Residual known limitation: two genuinely independent producers that
+ * share both a `name` and a `type` and both lack a `workflowName` (e.g.
+ * two different non-Actions GitHub Apps that each post a check-run
+ * directly, rather than through a workflow) remain indistinguishable
+ * here and will still be grouped together. Closing that fully needs a
+ * stronger producer identity (e.g. the owning GitHub App) than
+ * `gh`/GraphQL's `statusCheckRollup` exposes today; `ci-wait-state.mts`'s
+ * own `(checkName, workflowName)` key has the identical accepted gap.
  */
 function selectLatestCheckPerName(checks) {
   // A Map already iterates in first-insertion order, so grouping into one
@@ -1352,7 +1365,15 @@ function selectLatestCheckPerName(checks) {
   const groups = new Map();
   let unnamedCount = 0;
   for (const check of checks) {
-    const key = check.name ? String(check.name) : `\0unnamed:${unnamedCount++}`;
+    if (!check.name) {
+      groups.set(`\0unnamed:${unnamedCount++}`, [check]);
+      continue;
+    }
+    const type = check.type ? String(check.type).trim() : '';
+    const workflowName = check.workflowName
+      ? String(check.workflowName).trim()
+      : '';
+    const key = `${String(check.name)}\0${type}\0${workflowName}`;
     const group = groups.get(key);
     if (group) {
       group.push(check);
@@ -1367,6 +1388,8 @@ export function classifyCiChecks(checks) {
     name: check.name,
     state: String(check.state ?? '').toUpperCase(),
     completedAt: check.completedAt ?? null,
+    type: check.type ?? null,
+    workflowName: check.workflowName ?? null,
   }));
   // GitHub can report several check-run instances that share the same
   // check `name` (a manual or automatic re-run leaves the earlier instance
@@ -2949,6 +2972,11 @@ export function summarizeRequiredChecks(
       state,
       completedAt: String(check.completedAt ?? ''),
       coveredByWaiver,
+      // Producer-identity discriminator (#1483); see `CheckLike` and
+      // `selectLatestCheckPerName` for how it disambiguates a same-name
+      // rerun from a genuinely independent, differently-sourced check.
+      type: check.type ? String(check.type) : '',
+      workflowName: check.workflowName ? String(check.workflowName).trim() : '',
     };
   });
   const matchedRequiredChecks = normalizedChecks.filter((check) =>

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -114,26 +114,32 @@ interface StatusCheckRollupPayload {
 // (protocol-helpers.mts) already treats as "not completed".
 const ZERO_SENTINEL_TIMESTAMP = '0001-01-01T00:00:00Z';
 
-// Legacy commit-status `state` uses its own 4-value vocabulary (`error`,
-// `failure`, `pending`, `success`) that only partly overlaps the check-run
-// vocabulary `classifyCiChecks` understands (`FAILURE`, `CANCELLED`,
-// `QUEUED`, `IN_PROGRESS`, `WAITING`, `SUCCESS`, `SKIPPED`, `NEUTRAL`,
-// `NOT_APPLICABLE`, ...). `SUCCESS` and `FAILURE` already coincide, but
-// `ERROR` (a distinct "reporting error" state, not `FAILURE`) and
-// `PENDING` (a distinct "still running" state, not one of the check-run
-// pending tokens) have no direct match -- left unmapped, both would
-// silently fall into `classifyCiChecks`'s `unknown` bucket instead of the
-// `failed` / `pending` bucket a caller actually needs (PR review finding,
-// #1483: `gh pr checks`'s prior flattened read normalized both vocabularies
-// into one `state` field; this data-source swap makes normalizing them
-// this module's own responsibility). Map the two divergent tokens onto
-// their check-run equivalents before classification ever sees them; this
-// is a "still failing" / "still running" outcome, never a false pass, so
-// even an unmapped future commit-status token would only ever fail closed
-// into `unknown`, not `success`.
+// The commit-status `state` GraphQL enum (`StatusState`) has its own
+// 5-value vocabulary (`EXPECTED`, `ERROR`, `FAILURE`, `PENDING`,
+// `SUCCESS`; confirmed via schema introspection -- an earlier version of
+// this comment underclaimed 4, missing `EXPECTED`) that only partly
+// overlaps the check-run vocabulary `classifyCiChecks` understands
+// (`FAILURE`, `CANCELLED`, `QUEUED`, `IN_PROGRESS`, `WAITING`, `SUCCESS`,
+// `SKIPPED`, `NEUTRAL`, `NOT_APPLICABLE`, ...). `SUCCESS` and `FAILURE`
+// already coincide, but the other three have no direct match -- left
+// unmapped, each would silently fall into `classifyCiChecks`'s `unknown`
+// bucket instead of the `failed` / `pending` bucket a caller actually
+// needs (PR review finding, #1483: `gh pr checks`'s prior flattened read
+// normalized both vocabularies into one `state` field; this
+// data-source swap makes normalizing them this module's own
+// responsibility). Map every divergent token onto its check-run
+// equivalent before classification ever sees it: `ERROR` (a distinct
+// "reporting error" state, not `FAILURE`) maps to `FAILURE`; `PENDING`
+// (still running) and `EXPECTED` (a required status check configured for
+// this ref but not yet reported at all -- also still "not done", not a
+// failure) both map to `IN_PROGRESS`. This is always a "still failing" /
+// "still running" outcome, never a false pass, so even an unmapped
+// future commit-status token would only ever fail closed into `unknown`,
+// not `success`.
 const STATUS_CONTEXT_STATE_ALIASES: Record<string, string> = {
   ERROR: 'FAILURE',
   PENDING: 'IN_PROGRESS',
+  EXPECTED: 'IN_PROGRESS',
 };
 
 /**
@@ -149,7 +155,7 @@ const STATUS_CONTEXT_STATE_ALIASES: Record<string, string> = {
  * absent -- a missing status is never silently coerced to an empty
  * string, which `classifyCiChecks` would not recognize as any known
  * bucket); a legacy commit-status reports its `state`, translated through
- * `STATUS_CONTEXT_STATE_ALIASES` for the two tokens with no direct
+ * `STATUS_CONTEXT_STATE_ALIASES` for the three tokens with no direct
  * check-run equivalent. This keeps classification behavior identical to
  * before #1483 for every single-producer case that existed pre-#1483 --
  * only the producer-identity discriminator (`type` / `workflowName`) and

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -69,11 +69,86 @@ interface ReviewPayload {
   commit_id?: string | null;
 }
 
-/** CI status-check entry returned by `gh pr checks`. */
+/**
+ * Normalized CI status-check entry fed to `classifyCiChecks` /
+ * `summarizeRequiredChecks`. Produced by `normalizeStatusCheckRollupEntry`
+ * from a raw `statusCheckRollup` entry (see `StatusCheckRollupPayload`
+ * below), not fetched directly. `type` and `workflowName` are the
+ * producer-identity discriminator #1483 added so a check-run is never
+ * conflated with a same-named legacy commit-status (or a check-run from a
+ * different Actions workflow) -- see `CheckLike` in `protocol-helpers.mts`.
+ */
 interface CheckPayload {
   name?: string | null;
   state?: string | null;
   completedAt?: string | null;
+  type?: string | null;
+  workflowName?: string | null;
+}
+
+/**
+ * Raw `statusCheckRollup` entry as returned by
+ * `gh pr view --json statusCheckRollup` (a GraphQL union of `CheckRun` and
+ * `StatusContext`, discriminated by `__typename`). Mirrors the shape
+ * `ci-wait-state.mts` also derives this same GraphQL field from -- this
+ * type and `normalizeStatusCheckRollupEntry` below are declared
+ * independently rather than imported from that file, since the two
+ * modules are maintained separately (see #1478's own tracked dedup gap in
+ * that file).
+ */
+interface StatusCheckRollupPayload {
+  __typename?: string | null;
+  name?: string | null;
+  context?: string | null;
+  state?: string | null;
+  status?: string | null;
+  conclusion?: string | null;
+  completedAt?: string | null;
+  workflowName?: string | null;
+}
+
+// GitHub's GraphQL `DateTime` scalar can't be null, so a `CheckRun` that
+// has not completed yet (and a `StatusContext`, which has no completedAt
+// field at all) reports this zero-value sentinel instead -- the same
+// convention `gh pr checks` already surfaces and `isCompletedCiTimestamp`
+// (protocol-helpers.mts) already treats as "not completed".
+const ZERO_SENTINEL_TIMESTAMP = '0001-01-01T00:00:00Z';
+
+/**
+ * Normalize one raw `statusCheckRollup` entry into the `CheckPayload`
+ * shape `classifyCiChecks` / `summarizeRequiredChecks` expect (#1483).
+ *
+ * `state` is derived to match what `gh pr checks --json state` already
+ * reported for the same underlying data (verified empirically against
+ * this repository's own live PRs across `SUCCESS` / `FAILURE` /
+ * `IN_PROGRESS`): a completed check-run reports its `conclusion`; an
+ * incomplete one reports its raw `status` (`QUEUED` / `IN_PROGRESS` /
+ * `WAITING`); a legacy commit-status reports its `state` unchanged. This
+ * keeps classification behavior identical to before #1483 for every
+ * single-producer case -- only the producer-identity discriminator
+ * (`type` / `workflowName`) is new.
+ */
+export function normalizeStatusCheckRollupEntry(
+  entry: StatusCheckRollupPayload,
+): CheckPayload {
+  if (String(entry?.__typename ?? '') === 'StatusContext') {
+    return {
+      name: String(entry?.context ?? ''),
+      state: String(entry?.state ?? '').toUpperCase(),
+      completedAt: String(entry?.completedAt ?? ZERO_SENTINEL_TIMESTAMP),
+      type: 'status-context',
+      workflowName: '',
+    };
+  }
+  const status = String(entry?.status ?? '').toUpperCase();
+  const conclusion = String(entry?.conclusion ?? '').toUpperCase();
+  return {
+    name: String(entry?.name ?? ''),
+    state: status === 'COMPLETED' ? conclusion || 'UNKNOWN' : status,
+    completedAt: String(entry?.completedAt ?? ZERO_SENTINEL_TIMESTAMP),
+    type: 'check-run',
+    workflowName: String(entry?.workflowName ?? '').trim(),
+  };
 }
 
 /** Timeline event payload fields consumed by the Copilot coverage check. */
@@ -291,7 +366,7 @@ export function collectPreMergeReadiness(
     '-R',
     repoRef,
     '--json',
-    'headRefOid,baseRefName,url,author,reviewDecision',
+    'headRefOid,baseRefName,url,author,reviewDecision,statusCheckRollup',
     '--jq',
     '.',
   ]) as {
@@ -300,6 +375,7 @@ export function collectPreMergeReadiness(
     url?: unknown;
     author?: { login?: unknown } | null;
     reviewDecision?: unknown;
+    statusCheckRollup?: StatusCheckRollupPayload[] | null;
   };
   const prHeadSha = String(pr.headRefOid ?? '');
   const baseRefName = String(pr.baseRefName ?? '');
@@ -308,20 +384,19 @@ export function collectPreMergeReadiness(
   const reviewDecision = String(pr.reviewDecision ?? '');
   const encodedBaseRefName = encodeURIComponent(baseRefName);
 
-  const checks = ghJson(
-    [
-      'pr',
-      'checks',
-      String(args.prNumber),
-      '-R',
-      repoRef,
-      '--json',
-      'name,state,completedAt',
-      '--jq',
-      '.',
-    ],
-    { allowStatuses: [1, 8] },
-  ) as CheckPayload[];
+  // #1483: sourced from the same `gh pr view` call above (the
+  // `statusCheckRollup` field), not a separate `gh pr checks` call --
+  // `statusCheckRollup`'s GraphQL union already tags each entry with a
+  // real producer identity (`__typename`: `CheckRun` vs. `StatusContext`,
+  // plus `workflowName` for check-runs), which a flattened `gh pr checks`
+  // read cannot expose. Joining two separately-fetched lists by name would
+  // reintroduce the exact ambiguity this fix removes (confirmed live: two
+  // successive calls a few seconds apart returned different check-run
+  // counts for the same PR), so this is the single source of truth for
+  // both the check identity and its dedup discriminator.
+  const checks = (pr.statusCheckRollup ?? []).map(
+    normalizeStatusCheckRollupEntry,
+  );
   const trustEmptyProtectionReads = readTrustEmptyProtectionReads();
   const branchRulesRead = fetchGovernanceJson<BranchRulePayload[]>(
     `repos/${owner}/${repo}/rules/branches/${encodedBaseRefName}`,

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -114,6 +114,28 @@ interface StatusCheckRollupPayload {
 // (protocol-helpers.mts) already treats as "not completed".
 const ZERO_SENTINEL_TIMESTAMP = '0001-01-01T00:00:00Z';
 
+// Legacy commit-status `state` uses its own 4-value vocabulary (`error`,
+// `failure`, `pending`, `success`) that only partly overlaps the check-run
+// vocabulary `classifyCiChecks` understands (`FAILURE`, `CANCELLED`,
+// `QUEUED`, `IN_PROGRESS`, `WAITING`, `SUCCESS`, `SKIPPED`, `NEUTRAL`,
+// `NOT_APPLICABLE`, ...). `SUCCESS` and `FAILURE` already coincide, but
+// `ERROR` (a distinct "reporting error" state, not `FAILURE`) and
+// `PENDING` (a distinct "still running" state, not one of the check-run
+// pending tokens) have no direct match -- left unmapped, both would
+// silently fall into `classifyCiChecks`'s `unknown` bucket instead of the
+// `failed` / `pending` bucket a caller actually needs (PR review finding,
+// #1483: `gh pr checks`'s prior flattened read normalized both vocabularies
+// into one `state` field; this data-source swap makes normalizing them
+// this module's own responsibility). Map the two divergent tokens onto
+// their check-run equivalents before classification ever sees them; this
+// is a "still failing" / "still running" outcome, never a false pass, so
+// even an unmapped future commit-status token would only ever fail closed
+// into `unknown`, not `success`.
+const STATUS_CONTEXT_STATE_ALIASES: Record<string, string> = {
+  ERROR: 'FAILURE',
+  PENDING: 'IN_PROGRESS',
+};
+
 /**
  * Normalize one raw `statusCheckRollup` entry into the `CheckPayload`
  * shape `classifyCiChecks` / `summarizeRequiredChecks` expect (#1483).
@@ -121,30 +143,43 @@ const ZERO_SENTINEL_TIMESTAMP = '0001-01-01T00:00:00Z';
  * `state` is derived to match what `gh pr checks --json state` already
  * reported for the same underlying data (verified empirically against
  * this repository's own live PRs across `SUCCESS` / `FAILURE` /
- * `IN_PROGRESS`): a completed check-run reports its `conclusion`; an
- * incomplete one reports its raw `status` (`QUEUED` / `IN_PROGRESS` /
- * `WAITING`); a legacy commit-status reports its `state` unchanged. This
- * keeps classification behavior identical to before #1483 for every
- * single-producer case -- only the producer-identity discriminator
- * (`type` / `workflowName`) is new.
+ * `IN_PROGRESS`): a completed check-run reports its `conclusion` (falling
+ * back to `UNKNOWN` if absent); an incomplete one reports its raw `status`
+ * (`QUEUED` / `IN_PROGRESS` / `WAITING`, also falling back to `UNKNOWN` if
+ * absent -- a missing status is never silently coerced to an empty
+ * string, which `classifyCiChecks` would not recognize as any known
+ * bucket); a legacy commit-status reports its `state`, translated through
+ * `STATUS_CONTEXT_STATE_ALIASES` for the two tokens with no direct
+ * check-run equivalent. This keeps classification behavior identical to
+ * before #1483 for every single-producer case that existed pre-#1483 --
+ * only the producer-identity discriminator (`type` / `workflowName`) and
+ * the commit-status vocabulary mapping are new.
  */
 export function normalizeStatusCheckRollupEntry(
   entry: StatusCheckRollupPayload,
 ): CheckPayload {
-  if (String(entry?.__typename ?? '') === 'StatusContext') {
+  if (String(entry?.__typename ?? '').trim() === 'StatusContext') {
+    const rawState = String(entry?.state ?? '')
+      .trim()
+      .toUpperCase();
     return {
-      name: String(entry?.context ?? ''),
-      state: String(entry?.state ?? '').toUpperCase(),
+      name: String(entry?.context ?? '').trim(),
+      state: STATUS_CONTEXT_STATE_ALIASES[rawState] ?? rawState,
       completedAt: String(entry?.completedAt ?? ZERO_SENTINEL_TIMESTAMP),
       type: 'status-context',
       workflowName: '',
     };
   }
-  const status = String(entry?.status ?? '').toUpperCase();
-  const conclusion = String(entry?.conclusion ?? '').toUpperCase();
+  const status = String(entry?.status ?? '')
+    .trim()
+    .toUpperCase();
+  const conclusion = String(entry?.conclusion ?? '')
+    .trim()
+    .toUpperCase();
   return {
-    name: String(entry?.name ?? ''),
-    state: status === 'COMPLETED' ? conclusion || 'UNKNOWN' : status,
+    name: String(entry?.name ?? '').trim(),
+    state:
+      status === 'COMPLETED' ? conclusion || 'UNKNOWN' : status || 'UNKNOWN',
     completedAt: String(entry?.completedAt ?? ZERO_SENTINEL_TIMESTAMP),
     type: 'check-run',
     workflowName: String(entry?.workflowName ?? '').trim(),

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -105,11 +105,22 @@ interface ReviewLike {
   commit_id?: string | null;
 }
 
-/** CI status-check entry. */
+/**
+ * CI status-check entry. `type` and `workflowName` are an optional
+ * producer-identity discriminator (see #1483): `type` distinguishes a
+ * GitHub Actions check-run from a legacy commit-status context (or any
+ * other producer), and `workflowName` further distinguishes two
+ * check-runs of the same name from different Actions workflows. Both are
+ * optional so existing callers/fixtures that predate this discriminator
+ * (only `name`/`state`/`completedAt`) remain valid -- see
+ * `selectLatestCheckPerName` for how an absent discriminator is treated.
+ */
 interface CheckLike {
   name?: string | null;
   state?: string | null;
   completedAt?: string | null;
+  type?: string | null;
+  workflowName?: string | null;
 }
 
 /** PR timeline event as consumed by the Copilot-coverage helpers. */
@@ -1992,11 +2003,12 @@ function selectLatestCheckInstance<
 }
 
 /**
- * Reduce a check-run list to a single representative instance per check
- * `name`, matching GitHub's own required-status-check semantics: only the
- * latest run for a given context governs, so a stale instance (e.g. a
- * cancelled or failed run superseded by a later successful rerun) can
- * never outvote the current, authoritative one that shares its name.
+ * Reduce a check-run list to a single representative instance per
+ * `(name, type, workflowName)` group, matching GitHub's own
+ * required-status-check semantics: only the latest run for a given
+ * producer governs, so a stale instance (e.g. a cancelled or failed run
+ * superseded by a later successful rerun) can never outvote the current,
+ * authoritative one from the *same* producer.
  *
  * A missing or empty `name` carries no identity to dedupe against, so
  * each such entry gets its own singleton group instead of collapsing
@@ -2004,21 +2016,35 @@ function selectLatestCheckInstance<
  * could be discarded in favor of an unrelated unnamed success that
  * merely happens to also lack a name.
  *
- * Known limitation (tracked in #1483): `CheckLike` carries no
- * source/producer identity, so two genuinely independent checks that
- * happen to share an identical `name` (e.g. a check-run and a legacy
- * commit-status, or two different GitHub Apps) are indistinguishable
- * from reruns of one another here and will be grouped together. Fixing
- * this needs a source discriminator threaded through from data
- * collection (see `ci-wait-state.mts`'s `type` field) into `CheckLike`
- * itself — a data-collection-layer change out of scope for the
- * same-name-multiple-*rerun*-instances dedup this function performs.
+ * `type` (e.g. `'check-run'` vs. `'status-context'`) and `workflowName`
+ * are an optional producer-identity discriminator (#1483): two entries
+ * that share a `name` but differ on either one are never assumed to be
+ * reruns of each other (e.g. a check-run and a legacy commit-status, or
+ * two check-runs from different Actions workflows, that happen to share
+ * a display name both survive instead of one discarding the other). When
+ * `type`/`workflowName` are absent on every entry sharing a `name` (the
+ * pre-#1483 data shape, still produced by hand-built fixtures and any
+ * caller that predates the discriminator), there is no conflicting
+ * signal to split on, so the group dedupes by `name` alone exactly as
+ * #1471 established -- this keeps every pre-#1483 caller and test
+ * behavior-identical.
+ *
+ * Residual known limitation: two genuinely independent producers that
+ * share both a `name` and a `type` and both lack a `workflowName` (e.g.
+ * two different non-Actions GitHub Apps that each post a check-run
+ * directly, rather than through a workflow) remain indistinguishable
+ * here and will still be grouped together. Closing that fully needs a
+ * stronger producer identity (e.g. the owning GitHub App) than
+ * `gh`/GraphQL's `statusCheckRollup` exposes today; `ci-wait-state.mts`'s
+ * own `(checkName, workflowName)` key has the identical accepted gap.
  */
 function selectLatestCheckPerName<
   T extends {
     name?: string | null;
     state: string;
     completedAt?: string | null;
+    type?: string | null;
+    workflowName?: string | null;
   },
 >(checks: T[]): T[] {
   // A Map already iterates in first-insertion order, so grouping into one
@@ -2027,7 +2053,15 @@ function selectLatestCheckPerName<
   const groups = new Map<string, T[]>();
   let unnamedCount = 0;
   for (const check of checks) {
-    const key = check.name ? String(check.name) : `\0unnamed:${unnamedCount++}`;
+    if (!check.name) {
+      groups.set(`\0unnamed:${unnamedCount++}`, [check]);
+      continue;
+    }
+    const type = check.type ? String(check.type).trim() : '';
+    const workflowName = check.workflowName
+      ? String(check.workflowName).trim()
+      : '';
+    const key = `${String(check.name)}\0${type}\0${workflowName}`;
     const group = groups.get(key);
     if (group) {
       group.push(check);
@@ -2043,6 +2077,8 @@ export function classifyCiChecks(checks: CheckLike[]) {
     name: check.name,
     state: String(check.state ?? '').toUpperCase(),
     completedAt: check.completedAt ?? null,
+    type: check.type ?? null,
+    workflowName: check.workflowName ?? null,
   }));
   // GitHub can report several check-run instances that share the same
   // check `name` (a manual or automatic re-run leaves the earlier instance
@@ -3805,6 +3841,11 @@ export function summarizeRequiredChecks(
       state,
       completedAt: String(check.completedAt ?? ''),
       coveredByWaiver,
+      // Producer-identity discriminator (#1483); see `CheckLike` and
+      // `selectLatestCheckPerName` for how it disambiguates a same-name
+      // rerun from a genuinely independent, differently-sourced check.
+      type: check.type ? String(check.type) : '',
+      workflowName: check.workflowName ? String(check.workflowName).trim() : '',
     };
   });
 
@@ -3877,6 +3918,8 @@ function resolvePresentRunConclusion(
     state: string;
     completedAt: string;
     coveredByWaiver: boolean;
+    type: string;
+    workflowName: string;
   }[],
 ): string {
   if (normalizedChecks.length === 0) {

--- a/tests/advisory-wait.test.mts
+++ b/tests/advisory-wait.test.mts
@@ -312,6 +312,80 @@ test('classifyCiChecks: two check-runs sharing a name from different workflows n
   assert.equal(classifyCiChecks(checks).status, 'failed');
 });
 
+test('classifyCiChecks: same type, one entry with a workflowName and one without, same name -- never dedupe', () => {
+  // A narrower variant of the check-run/commit-status split: both entries
+  // are `type: 'check-run'` here, but only one carries a `workflowName`
+  // (e.g. an Actions-routed job vs. a check-run posted directly by a
+  // non-Actions GitHub App under the same display name). Presence vs.
+  // absence of workflowName is itself a producer-conflict signal, just
+  // like two differing non-empty values.
+  const checks = [
+    {
+      name: 'build',
+      state: 'FAILURE',
+      completedAt: '2026-07-18T03:45:56Z',
+      type: 'check-run',
+      workflowName: '',
+    },
+    {
+      name: 'build',
+      state: 'SUCCESS',
+      completedAt: '2026-07-18T03:47:01Z',
+      type: 'check-run',
+      workflowName: 'Some Workflow',
+    },
+  ];
+  const result = classifyCiChecks(checks);
+  assert.equal(result.status, 'failed');
+  assert.ok(
+    result.failed?.some(
+      (check) => check.workflowName === '' && check.state === 'FAILURE',
+    ),
+    'the workflowName-less FAILURE must be present in the failed list',
+  );
+});
+
+test('classifyCiChecks: the (name, type, workflowName) dedup key is deterministic regardless of input order', () => {
+  const checkRun = {
+    name: 'idd-advisory-convergence',
+    state: 'CANCELLED',
+    completedAt: '2026-07-18T03:45:56Z',
+    type: 'check-run',
+    workflowName: 'IDD advisory-convergence gate',
+  };
+  const rerun = {
+    ...checkRun,
+    state: 'SUCCESS',
+    completedAt: '2026-07-18T03:47:01Z',
+  };
+  const statusContext = {
+    name: 'idd-advisory-convergence',
+    state: 'FAILURE',
+    completedAt: '2026-07-18T03:46:00Z',
+    type: 'status-context',
+    workflowName: '',
+  };
+  const checkRunFirst = [checkRun, rerun, statusContext];
+  const statusContextFirst = [statusContext, rerun, checkRun];
+  const reversed = [statusContext, checkRun, rerun];
+  assert.equal(classifyCiChecks(checkRunFirst).status, 'failed');
+  assert.equal(classifyCiChecks(statusContextFirst).status, 'failed');
+  assert.equal(classifyCiChecks(reversed).status, 'failed');
+  // The check-run pair (same type + workflowName) must still dedupe to its
+  // latest (SUCCESS) instance regardless of order -- only the independent
+  // status-context FAILURE is what makes the overall result 'failed'.
+  for (const input of [checkRunFirst, statusContextFirst, reversed]) {
+    const checkRunEntries = classifyCiChecks(input).failed?.filter(
+      (check) => check.type === 'check-run',
+    );
+    assert.equal(
+      checkRunEntries?.length,
+      0,
+      'the check-run pair must dedupe to its passing latest instance, not appear in failed',
+    );
+  }
+});
+
 test('classifyCiChecks: characterization -- two same-name, same-type entries that both lack a workflowName still dedupe (accepted residual limitation)', () => {
   // Documents the deliberately-accepted residual gap: without a real
   // producer identity (e.g. the owning GitHub App) for two check-runs

--- a/tests/advisory-wait.test.mts
+++ b/tests/advisory-wait.test.mts
@@ -234,6 +234,112 @@ test('classifyCiChecks: two check-run entries with no name are never collapsed i
   assert.equal(classifyCiChecks(checks).status, 'failed');
 });
 
+// #1483: `classifyCiChecks` must not conflate two independently-sourced
+// checks that happen to share a display `name` -- e.g. a GitHub Actions
+// check-run and a legacy commit-status, or two check-runs from different
+// workflows -- by also grouping on the `type` / `workflowName` producer
+// discriminator (see `selectLatestCheckPerName` in protocol-helpers.mts).
+test('classifyCiChecks: two same-name instances sharing type and workflowName still dedupe to the latest (no #1471 regression)', () => {
+  const checks = [
+    {
+      name: 'idd-advisory-convergence',
+      state: 'CANCELLED',
+      completedAt: '2026-07-18T03:45:56Z',
+      type: 'check-run',
+      workflowName: 'IDD advisory-convergence gate',
+    },
+    {
+      name: 'idd-advisory-convergence',
+      state: 'SUCCESS',
+      completedAt: '2026-07-18T03:47:01Z',
+      type: 'check-run',
+      workflowName: 'IDD advisory-convergence gate',
+    },
+  ];
+  assert.equal(classifyCiChecks(checks).status, 'success');
+});
+
+test('classifyCiChecks: a check-run and a same-named commit-status never dedupe -- the commit-status FAILURE is never hidden by the check-run SUCCESS', () => {
+  // The issue's own motivating example: a check-run and a legacy commit
+  // status can report under an identical name/context string while being
+  // genuinely independent. `type` differs here ('check-run' vs.
+  // 'status-context'), so both must survive as separate groups.
+  const checks = [
+    {
+      name: 'build',
+      state: 'FAILURE',
+      completedAt: '2026-07-18T03:45:56Z',
+      type: 'status-context',
+      workflowName: '',
+    },
+    {
+      name: 'build',
+      state: 'SUCCESS',
+      completedAt: '2026-07-18T03:47:01Z',
+      type: 'check-run',
+      workflowName: 'Some Workflow',
+    },
+  ];
+  const result = classifyCiChecks(checks);
+  assert.equal(result.status, 'failed');
+  assert.ok(
+    result.failed?.some(
+      (check) => check.type === 'status-context' && check.state === 'FAILURE',
+    ),
+    'the commit-status FAILURE must be present in the failed list',
+  );
+});
+
+test('classifyCiChecks: two check-runs sharing a name from different workflows never dedupe', () => {
+  // Same `type` ('check-run') on both sides, but a different `workflowName`
+  // is just as strong a producer-conflict signal as a different `type`.
+  const checks = [
+    {
+      name: 'build',
+      state: 'FAILURE',
+      completedAt: '2026-07-18T03:45:56Z',
+      type: 'check-run',
+      workflowName: 'Workflow A',
+    },
+    {
+      name: 'build',
+      state: 'SUCCESS',
+      completedAt: '2026-07-18T03:47:01Z',
+      type: 'check-run',
+      workflowName: 'Workflow B',
+    },
+  ];
+  assert.equal(classifyCiChecks(checks).status, 'failed');
+});
+
+test('classifyCiChecks: characterization -- two same-name, same-type entries that both lack a workflowName still dedupe (accepted residual limitation)', () => {
+  // Documents the deliberately-accepted residual gap: without a real
+  // producer identity (e.g. the owning GitHub App) for two check-runs
+  // that are not routed through any Actions workflow, they remain
+  // indistinguishable from reruns of one another -- matching
+  // ci-wait-state.mts's own accepted `(checkName, workflowName)` gap. This
+  // is also what keeps every pre-#1483 `classifyCiChecks` caller (which
+  // never sets `type`/`workflowName` at all) behavior-identical: those
+  // callers hit this exact same uniformly-absent path.
+  const checks = [
+    {
+      name: 'legacy-check',
+      state: 'FAILURE',
+      completedAt: '2026-07-18T03:45:56Z',
+      type: 'check-run',
+      workflowName: '',
+    },
+    {
+      name: 'legacy-check',
+      state: 'SUCCESS',
+      completedAt: '2026-07-18T03:47:01Z',
+      type: 'check-run',
+      workflowName: '',
+    },
+  ];
+  assert.equal(classifyCiChecks(checks).status, 'success');
+});
+
 test('detects operational marker prefixes', () => {
   assert.equal(
     operationalMarkerPrefix(

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -4828,6 +4828,20 @@ test('normalizeStatusCheckRollupEntry: a StatusContext PENDING normalizes to IN_
   assert.equal(result.state, 'IN_PROGRESS');
 });
 
+// E10 follow-up (this PR's own critique pass): the commit-status `state`
+// GraphQL enum (`StatusState`) actually has 5 members, not the 4 the
+// original fix accounted for -- `EXPECTED` (a required status check
+// configured for this ref but not yet reported at all) is also still
+// "not done", not a failure, so it maps the same way PENDING does.
+test('normalizeStatusCheckRollupEntry: a StatusContext EXPECTED normalizes to IN_PROGRESS, not an unrecognized state', () => {
+  const result = normalizeStatusCheckRollupEntry({
+    __typename: 'StatusContext',
+    context: 'legacy-ci',
+    state: 'expected',
+  });
+  assert.equal(result.state, 'IN_PROGRESS');
+});
+
 test('normalizeStatusCheckRollupEntry: a StatusContext ERROR reaches classifyCiChecks as a genuine failure, end to end', () => {
   // The isolated mapping test above only proves the translation table
   // works; this proves the translated value actually makes

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -4,6 +4,7 @@ import { test } from 'node:test';
 import {
   fetchBranchRulesets,
   fetchGovernanceJson,
+  normalizeStatusCheckRollupEntry,
   parseArgs,
   resolveToleratedGhFailure,
 } from '../src/scripts/pre-merge-readiness.mts';
@@ -4734,6 +4735,87 @@ test('resolveToleratedGhFailure ignores non-JSON allowStatuses stdout and falls 
     resolveToleratedGhFailure(error, { allowStatuses: [1] }),
     undefined,
   );
+});
+
+// #1483: normalizeStatusCheckRollupEntry replaced the old `gh pr checks`
+// data source with `statusCheckRollup`, so its output must stay behaviorally
+// identical to what `gh pr checks --json name,state,completedAt` reported
+// for the same underlying data (verified empirically against this
+// repository's own live PRs before this change shipped) while also
+// surfacing the new `type` / `workflowName` producer-identity fields.
+test('normalizeStatusCheckRollupEntry: a completed CheckRun reports its conclusion as state', () => {
+  const result = normalizeStatusCheckRollupEntry({
+    __typename: 'CheckRun',
+    name: 'idd-advisory-convergence',
+    status: 'COMPLETED',
+    conclusion: 'SUCCESS',
+    completedAt: '2026-07-18T03:47:01Z',
+    workflowName: 'IDD advisory-convergence gate',
+  });
+  assert.deepEqual(result, {
+    name: 'idd-advisory-convergence',
+    state: 'SUCCESS',
+    completedAt: '2026-07-18T03:47:01Z',
+    type: 'check-run',
+    workflowName: 'IDD advisory-convergence gate',
+  });
+});
+
+test('normalizeStatusCheckRollupEntry: an in-progress CheckRun reports its raw status as state, not a stale conclusion', () => {
+  const result = normalizeStatusCheckRollupEntry({
+    __typename: 'CheckRun',
+    name: 'lint',
+    status: 'IN_PROGRESS',
+    conclusion: '',
+    completedAt: '0001-01-01T00:00:00Z',
+    workflowName: 'Linting workflow',
+  });
+  assert.equal(result.state, 'IN_PROGRESS');
+  assert.equal(result.completedAt, '0001-01-01T00:00:00Z');
+  assert.equal(result.type, 'check-run');
+});
+
+test('normalizeStatusCheckRollupEntry: a StatusContext reports its own state and name from context, with no workflowName', () => {
+  const result = normalizeStatusCheckRollupEntry({
+    __typename: 'StatusContext',
+    context: 'CodeRabbit',
+    state: 'success',
+  });
+  assert.deepEqual(result, {
+    name: 'CodeRabbit',
+    state: 'SUCCESS',
+    completedAt: '0001-01-01T00:00:00Z',
+    type: 'status-context',
+    workflowName: '',
+  });
+});
+
+test('normalizeStatusCheckRollupEntry: a StatusContext with no completedAt field defaults to the zero-value sentinel', () => {
+  // StatusContext has no completedAt in the GraphQL schema at all (only
+  // CheckRun does); the entry omits the field entirely rather than sending
+  // an empty string, so this covers the `?? ZERO_SENTINEL_TIMESTAMP`
+  // fallback path distinctly from an entry that sends `completedAt: ''`.
+  const result = normalizeStatusCheckRollupEntry({
+    __typename: 'StatusContext',
+    context: 'some-legacy-status',
+    state: 'PENDING',
+  });
+  assert.equal(result.completedAt, '0001-01-01T00:00:00Z');
+});
+
+test('normalizeStatusCheckRollupEntry: an unrecognized __typename falls back to the CheckRun shape', () => {
+  // Mirrors ci-wait-state.mts's own "StatusContext, else check-run" branch
+  // structure: any future GraphQL union member normalizes as a check-run
+  // rather than being silently dropped.
+  const result = normalizeStatusCheckRollupEntry({
+    __typename: 'SomeFutureUnionMember',
+    name: 'future-check',
+    status: 'COMPLETED',
+    conclusion: 'NEUTRAL',
+    completedAt: '2026-07-18T00:00:00Z',
+  });
+  assert.equal(result.type, 'check-run');
+  assert.equal(result.state, 'NEUTRAL');
 });
 
 test('parseArgs: valid --pr / --claim-issue parse to positive integers', () => {

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -13,6 +13,7 @@ import {
   buildAdvisoryWaitSummary,
   buildPreMergeReadinessSummary,
   CODERABBIT_SUMMARY_MARKER,
+  classifyCiChecks,
   classifyRegularBotComment,
   computePreMergeReadinessBlockers,
   deriveIddAgentLogins,
@@ -4801,6 +4802,78 @@ test('normalizeStatusCheckRollupEntry: a StatusContext with no completedAt field
     state: 'PENDING',
   });
   assert.equal(result.completedAt, '0001-01-01T00:00:00Z');
+});
+
+// PR #1506 review findings (Copilot, on #1483's implementation): the
+// commit-status vocabulary (`error`/`failure`/`pending`/`success`) only
+// partly overlaps the check-run vocabulary `classifyCiChecks` understands.
+// `gh pr checks`'s prior flattened read normalized both vocabularies into
+// one `state` field; this data-source swap makes that this module's own
+// responsibility, so cover the two divergent tokens explicitly.
+test('normalizeStatusCheckRollupEntry: a StatusContext ERROR normalizes to FAILURE, not an unrecognized state', () => {
+  const result = normalizeStatusCheckRollupEntry({
+    __typename: 'StatusContext',
+    context: 'legacy-ci',
+    state: 'error',
+  });
+  assert.equal(result.state, 'FAILURE');
+});
+
+test('normalizeStatusCheckRollupEntry: a StatusContext PENDING normalizes to IN_PROGRESS, not an unrecognized state', () => {
+  const result = normalizeStatusCheckRollupEntry({
+    __typename: 'StatusContext',
+    context: 'legacy-ci',
+    state: 'pending',
+  });
+  assert.equal(result.state, 'IN_PROGRESS');
+});
+
+test('normalizeStatusCheckRollupEntry: a StatusContext ERROR reaches classifyCiChecks as a genuine failure, end to end', () => {
+  // The isolated mapping test above only proves the translation table
+  // works; this proves the translated value actually makes
+  // classifyCiChecks treat it as failing rather than silently landing in
+  // its 'unknown' bucket (unrecognized state literals fall through every
+  // bucket check).
+  const normalized = normalizeStatusCheckRollupEntry({
+    __typename: 'StatusContext',
+    context: 'legacy-ci',
+    state: 'error',
+  });
+  assert.equal(classifyCiChecks([normalized]).status, 'failed');
+});
+
+test('normalizeStatusCheckRollupEntry: a CheckRun with no status field at all defaults to UNKNOWN, not an empty string', () => {
+  // Distinct from the existing "in-progress" test: this entry omits
+  // `status` entirely (a malformed/unexpected entry), which previously
+  // fell through to state: '' -- a value classifyCiChecks does not
+  // recognize as any bucket, unlike the explicit 'UNKNOWN' fallback the
+  // completed-with-no-conclusion branch already had.
+  const result = normalizeStatusCheckRollupEntry({
+    __typename: 'CheckRun',
+    name: 'malformed-entry',
+  });
+  assert.equal(result.state, 'UNKNOWN');
+});
+
+test('normalizeStatusCheckRollupEntry: whitespace-padded fields are trimmed consistently', () => {
+  const checkRun = normalizeStatusCheckRollupEntry({
+    __typename: 'CheckRun',
+    name: '  padded-name  ',
+    status: '  COMPLETED  ',
+    conclusion: '  SUCCESS  ',
+    workflowName: '  Some Workflow  ',
+  });
+  assert.equal(checkRun.name, 'padded-name');
+  assert.equal(checkRun.state, 'SUCCESS');
+  assert.equal(checkRun.workflowName, 'Some Workflow');
+
+  const statusContext = normalizeStatusCheckRollupEntry({
+    __typename: 'StatusContext',
+    context: '  padded-context  ',
+    state: '  success  ',
+  });
+  assert.equal(statusContext.name, 'padded-context');
+  assert.equal(statusContext.state, 'SUCCESS');
 });
 
 test('normalizeStatusCheckRollupEntry: an unrecognized __typename falls back to the CheckRun shape', () => {

--- a/tests/required-checks-summary.test.mts
+++ b/tests/required-checks-summary.test.mts
@@ -154,3 +154,31 @@ test('protected branch: requiredChecksPassing is true when the required check’
   assert.equal(r.requiredChecksPassing, true);
   assert.equal(r.status, 'success');
 });
+
+// #1483: summarizeRequiredChecks must inherit classifyCiChecks's producer-
+// identity discriminator, so a required check name is never falsely
+// reported as passing because an independently-sourced entry sharing that
+// name reported success.
+test('protected branch: requiredChecksPassing stays false when a same-named commit-status success cannot supersede the check-run FAILURE (different producers, #1483)', () => {
+  const r = summarize(
+    [
+      {
+        name: 'lint',
+        state: 'FAILURE',
+        completedAt: '2026-07-17T16:00:06Z',
+        type: 'check-run',
+        workflowName: 'Linting workflow',
+      },
+      {
+        name: 'lint',
+        state: 'SUCCESS',
+        completedAt: '2026-07-17T16:25:47Z',
+        type: 'status-context',
+        workflowName: '',
+      },
+    ],
+    protectedRules,
+  );
+  assert.equal(r.requiredChecksPassing, false);
+  assert.equal(r.status, 'failed');
+});


### PR DESCRIPTION
# Summary

`classifyCiChecks`'s #1471 fix deduped check-run instances sharing a
display `name`, assuming same-name entries are reruns of one another.
That assumption breaks when a GitHub Actions check-run and a legacy
commit-status (or two different producers) report under an identical
name: a genuine FAILURE from one producer could be silently discarded
in favor of an unrelated SUCCESS reported later under the same name by
a different producer, letting pre-merge readiness report CI-passing
while a real failure was hidden.

- `CheckLike` (`protocol-helpers.mts`) gains an optional `type` /
  `workflowName` producer-identity discriminator. `selectLatestCheckPerName`
  now keys dedup groups on `(name, type, workflowName)` instead of `name`
  alone, so two entries sharing a name but differing on either field are
  never assumed to be reruns of each other. When every entry sharing a
  name uniformly lacks the discriminator (every pre-#1483 caller/fixture),
  the group still dedupes by name alone -- #1471's own fix and test suite
  stay behavior-identical, verified by running the full existing suite
  unmodified.
- `classifyCiChecks`, `summarizeRequiredChecks`, and
  `resolvePresentRunConclusion` all thread the two new fields through so
  neither internal call site silently drops them before classification.
- `pre-merge-readiness.mts` now sources checks from
  `gh pr view --json statusCheckRollup` (folded into the existing `gh pr
  view` call, not a new round-trip) instead of the flattened `gh pr
  checks`. `statusCheckRollup`'s GraphQL union already tags each entry's
  real `__typename` (`CheckRun` vs. `StatusContext`) and, for check-runs,
  its owning `workflowName` -- data a flattened `gh pr checks` read cannot
  expose at all. A new `normalizeStatusCheckRollupEntry` derives
  `name`/`state`/`completedAt` to match `gh pr checks`'s prior output
  exactly (verified empirically against this repo's own live PRs across
  SUCCESS/FAILURE/IN_PROGRESS/CANCELLED/QUEUED), so classification
  behavior is unchanged for every existing single-producer scenario --
  only the producer-identity discriminator is new.

A join between two separately-fetched lists (keep `gh pr checks` for
data, add a second call just for the discriminator) was considered and
rejected during design: two live calls a few seconds apart returned
*different* check-run counts for the identical PR, proving cross-call
name correlation is exactly as unreliable as the bug this fixes. Making
`statusCheckRollup` the single source for both the check data and its
discriminator removes the join entirely.

**Accepted residual limitation** (documented in code, not a regression):
two genuinely independent producers that share both a `name` and a
`type` (`'check-run'`) and both lack a `workflowName` -- e.g. two
different non-Actions GitHub Apps that each post a check-run directly,
rather than through a workflow -- remain indistinguishable and still
dedupe together. Closing that fully needs a stronger producer identity
(e.g. the owning GitHub App) than `statusCheckRollup` exposes today;
`ci-wait-state.mts`'s own `(checkName, workflowName)` key has the
identical accepted gap. A characterization test documents this
explicitly rather than leaving it implicit.

## Linked issue

Closes #1483

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The initial implementation plan (see the issue's first plan comment)
proposed a lighter-weight `workflow`-field proxy sourced from `gh pr
checks --json ...,workflow`. A self-review critique pass caught that
this proxy could not actually distinguish two different non-Actions
producers (both report an empty `workflow`), which is this issue's own
headline motivating example -- so the design was revised (see the
issue's second/refined plan comment) to source real `__typename`-based
discrimination from `statusCheckRollup` instead, as described above.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

The merge-readiness *gate logic* itself (required-check discovery/pinning,
`advisory-convergence.mts`'s `converged` computation) is unchanged -- only
the underlying CI-check data source and its dedup precision changed, which
feeds into that existing gate's inputs. Confirmed by grep that
`advisory-convergence.mts` imports nothing this PR touches.

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (2373 passed, 0 failed, including 12 new tests for this fix)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed, 4 pre-existing environment-only warnings unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
