### PR TITLE
fix(protocol-helpers): anchor dispositionNamesAdvisoryBot's bot match

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1114,10 +1114,32 @@ export function advisoryBotIdentityToken(login) {
     .toLowerCase()
     .replace(/\[bot\]$/, '');
 }
-// True when a non-review-notice disposition body names the given advisory bot's
-// GitHub login, so the gate can attribute a carry-forward to exactly one bot
-// even when several advisory bots are configured. Fail-closed: an empty token or
-// a disposition that does not contain the login carries nothing forward.
+// Captures the span where a bot login structurally appears in each canonical
+// disposition template `dispositionNamesAdvisoryBot` recognizes -- between the
+// marker (tolerating the same single interior-punctuation variant as
+// `DISPOSITION_REJECTED_PREFIX_RE` / `DISPOSITION_ACCEPTED_PREFIX_RE`) and the
+// phrase that names the template. Non-greedy so a body with the phrase
+// appearing once still captures the shortest, correct span. Anchored to the
+// first bytes (`^`, matching the marker-first-bytes contract every other
+// disposition predicate in this file enforces), so this never matches a
+// marker quoted mid-prose.
+const REJECTED_NOTICE_LOGIN_SPAN_RE =
+  /^\*\*Rejected[.!:]?\*\*\s+—\s+([\s\S]*?)\s+did not review HEAD\b/i;
+const ACCEPTED_SUMMARY_LOGIN_SPAN_RE =
+  /^\*\*Accepted[.!:]?\*\*\s+—\s+([\s\S]*?)\s+summary walkthrough\b/i;
+// True when a non-review-notice or summary-walkthrough disposition body names
+// the given advisory bot's GitHub login, so the gate can attribute a
+// carry-forward to exactly one bot even when several advisory bots are
+// configured. Matches only within the anchored span where a canonical
+// template places the bot login -- never a whole-body substring search --
+// so a bot whose identity token equals a word from the template's own fixed
+// text (e.g. "review", "head", or the #1482 "issuecomment" suffix) cannot
+// falsely match a disposition naming a different bot. A body naming several
+// bots in one span (a disposition that improperly covers more than one
+// notice) still matches each of them, matching the existing 1:1 consumption
+// contract at the call sites. Fail-closed: an empty token, or a disposition
+// body that does not structurally match either canonical template, names no
+// bot.
 export function dispositionNamesAdvisoryBot(
   dispositionBody,
   noticeAuthorLogin,
@@ -1126,9 +1148,14 @@ export function dispositionNamesAdvisoryBot(
   if (!token) {
     return false;
   }
-  return String(dispositionBody ?? '')
-    .toLowerCase()
-    .includes(token);
+  const body = String(dispositionBody ?? '').trimStart();
+  const span =
+    REJECTED_NOTICE_LOGIN_SPAN_RE.exec(body)?.[1] ??
+    ACCEPTED_SUMMARY_LOGIN_SPAN_RE.exec(body)?.[1];
+  if (span === undefined) {
+    return false;
+  }
+  return span.toLowerCase().includes(token);
 }
 // #1182 Match trusted machine advisory dispositions to the advisory-bot stickies
 // they address, so a disposition posted by a trusted-marker actor who is NOT a

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1119,10 +1119,13 @@ export function advisoryBotIdentityToken(login) {
 // marker (tolerating the same single interior-punctuation variant as
 // `DISPOSITION_REJECTED_PREFIX_RE` / `DISPOSITION_ACCEPTED_PREFIX_RE`) and the
 // phrase that names the template. Non-greedy so a body with the phrase
-// appearing once still captures the shortest, correct span. Anchored to the
-// first bytes (`^`, matching the marker-first-bytes contract every other
-// disposition predicate in this file enforces), so this never matches a
-// marker quoted mid-prose.
+// appearing once still captures the shortest, correct span. The `^` anchor
+// applies after the caller's `trimStart()` below, so it tolerates leading
+// whitespace the same way `isNonReviewNoticeDisposition` /
+// `isReviewSummaryDisposition` already do -- not the stricter, untrimmed
+// marker-first-bytes contract `isDispositionComment` enforces -- so this
+// never matches a marker quoted mid-prose, but a leading blank line or space
+// before the marker does not defeat it either.
 const REJECTED_NOTICE_LOGIN_SPAN_RE =
   /^\*\*Rejected[.!:]?\*\*\s+—\s+([\s\S]*?)\s+did not review HEAD\b/i;
 const ACCEPTED_SUMMARY_LOGIN_SPAN_RE =

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1782,10 +1782,13 @@ export function advisoryBotIdentityToken(login: unknown): string {
 // marker (tolerating the same single interior-punctuation variant as
 // `DISPOSITION_REJECTED_PREFIX_RE` / `DISPOSITION_ACCEPTED_PREFIX_RE`) and the
 // phrase that names the template. Non-greedy so a body with the phrase
-// appearing once still captures the shortest, correct span. Anchored to the
-// first bytes (`^`, matching the marker-first-bytes contract every other
-// disposition predicate in this file enforces), so this never matches a
-// marker quoted mid-prose.
+// appearing once still captures the shortest, correct span. The `^` anchor
+// applies after the caller's `trimStart()` below, so it tolerates leading
+// whitespace the same way `isNonReviewNoticeDisposition` /
+// `isReviewSummaryDisposition` already do -- not the stricter, untrimmed
+// marker-first-bytes contract `isDispositionComment` enforces -- so this
+// never matches a marker quoted mid-prose, but a leading blank line or space
+// before the marker does not defeat it either.
 const REJECTED_NOTICE_LOGIN_SPAN_RE =
   /^\*\*Rejected[.!:]?\*\*\s+—\s+([\s\S]*?)\s+did not review HEAD\b/i;
 const ACCEPTED_SUMMARY_LOGIN_SPAN_RE =

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1777,10 +1777,33 @@ export function advisoryBotIdentityToken(login: unknown): string {
     .replace(/\[bot\]$/, '');
 }
 
-// True when a non-review-notice disposition body names the given advisory bot's
-// GitHub login, so the gate can attribute a carry-forward to exactly one bot
-// even when several advisory bots are configured. Fail-closed: an empty token or
-// a disposition that does not contain the login carries nothing forward.
+// Captures the span where a bot login structurally appears in each canonical
+// disposition template `dispositionNamesAdvisoryBot` recognizes -- between the
+// marker (tolerating the same single interior-punctuation variant as
+// `DISPOSITION_REJECTED_PREFIX_RE` / `DISPOSITION_ACCEPTED_PREFIX_RE`) and the
+// phrase that names the template. Non-greedy so a body with the phrase
+// appearing once still captures the shortest, correct span. Anchored to the
+// first bytes (`^`, matching the marker-first-bytes contract every other
+// disposition predicate in this file enforces), so this never matches a
+// marker quoted mid-prose.
+const REJECTED_NOTICE_LOGIN_SPAN_RE =
+  /^\*\*Rejected[.!:]?\*\*\s+—\s+([\s\S]*?)\s+did not review HEAD\b/i;
+const ACCEPTED_SUMMARY_LOGIN_SPAN_RE =
+  /^\*\*Accepted[.!:]?\*\*\s+—\s+([\s\S]*?)\s+summary walkthrough\b/i;
+
+// True when a non-review-notice or summary-walkthrough disposition body names
+// the given advisory bot's GitHub login, so the gate can attribute a
+// carry-forward to exactly one bot even when several advisory bots are
+// configured. Matches only within the anchored span where a canonical
+// template places the bot login -- never a whole-body substring search --
+// so a bot whose identity token equals a word from the template's own fixed
+// text (e.g. "review", "head", or the #1482 "issuecomment" suffix) cannot
+// falsely match a disposition naming a different bot. A body naming several
+// bots in one span (a disposition that improperly covers more than one
+// notice) still matches each of them, matching the existing 1:1 consumption
+// contract at the call sites. Fail-closed: an empty token, or a disposition
+// body that does not structurally match either canonical template, names no
+// bot.
 export function dispositionNamesAdvisoryBot(
   dispositionBody: unknown,
   noticeAuthorLogin: string,
@@ -1789,9 +1812,14 @@ export function dispositionNamesAdvisoryBot(
   if (!token) {
     return false;
   }
-  return String(dispositionBody ?? '')
-    .toLowerCase()
-    .includes(token);
+  const body = String(dispositionBody ?? '').trimStart();
+  const span =
+    REJECTED_NOTICE_LOGIN_SPAN_RE.exec(body)?.[1] ??
+    ACCEPTED_SUMMARY_LOGIN_SPAN_RE.exec(body)?.[1];
+  if (span === undefined) {
+    return false;
+  }
+  return span.toLowerCase().includes(token);
 }
 
 // #1182 Match trusted machine advisory dispositions to the advisory-bot stickies

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -152,6 +152,76 @@ test('isDispositionComment and dispositionNamesAdvisoryBot recognize the extende
   assert.ok(dispositionNamesAdvisoryBot(body, CODERABBIT));
 });
 
+test('dispositionNamesAdvisoryBot does not falsely match a bot identity equal to a fixed template word', () => {
+  // A bot whose identity token equals a word from the notice template's own
+  // fixed text ("review", "head") must not falsely match a disposition that
+  // actually names a different bot -- the whole-body substring search this
+  // replaced would incorrectly return true for both.
+  const body = buildDispositionBody(
+    CODERABBIT,
+    'abc1234',
+    'review limit reached',
+    999,
+  );
+  assert.equal(dispositionNamesAdvisoryBot(body, 'review[bot]'), false);
+  assert.equal(dispositionNamesAdvisoryBot(body, 'head[bot]'), false);
+  // The real bot the body actually names still matches.
+  assert.equal(dispositionNamesAdvisoryBot(body, CODERABBIT), true);
+});
+
+test('dispositionNamesAdvisoryBot does not falsely match the #1482 source-notice-id suffix', () => {
+  // #1482 appends "(source: #issuecomment-{id})" to every notice disposition.
+  // A bot configured with an identity token equal to "issuecomment" must not
+  // falsely match on that suffix, which lives outside the anchored
+  // bot-login span.
+  const body = buildDispositionBody(
+    CODERABBIT,
+    'abc1234',
+    'review limit reached',
+    999,
+  );
+  assert.match(body, /\(source: #issuecomment-999\)$/);
+  assert.equal(dispositionNamesAdvisoryBot(body, 'issuecomment[bot]'), false);
+});
+
+test('dispositionNamesAdvisoryBot does not falsely match a fixed template word in the summary-walkthrough shape', () => {
+  const body = buildSummaryDispositionBody(CODERABBIT, 'abc1234');
+  assert.equal(dispositionNamesAdvisoryBot(body, 'walkthrough[bot]'), false);
+  assert.equal(dispositionNamesAdvisoryBot(body, 'head[bot]'), false);
+  assert.equal(dispositionNamesAdvisoryBot(body, CODERABBIT), true);
+});
+
+test('dispositionNamesAdvisoryBot matches the canonical template case-insensitively', () => {
+  // isNonReviewNoticeDisposition/isReviewSummaryDisposition match the "did
+  // not review HEAD"/"summary walkthrough" phrase case-insensitively; the
+  // anchored span regexes must do the same, or a mixed-case body that
+  // passes the shape gate would silently fail to name its bot here.
+  const body = buildDispositionBody(
+    CODERABBIT,
+    'abc1234',
+    'review limit reached',
+    999,
+  ).replace('did not review HEAD', 'Did Not Review HEAD');
+  assert.equal(dispositionNamesAdvisoryBot(body, CODERABBIT), true);
+});
+
+test('dispositionNamesAdvisoryBot returns false for a body matching neither canonical template', () => {
+  // An ordinary rejection of reviewer feedback that happens to mention a
+  // bot's login in prose is not a structured notice/summary disposition, so
+  // it must not be attributed to that bot -- callers gate on
+  // isNonReviewNoticeDisposition/isReviewSummaryDisposition first, but this
+  // function must independently fail closed too.
+  assert.equal(
+    dispositionNamesAdvisoryBot(
+      `**Rejected** — as ${CODERABBIT} noted, this needs a fix`,
+      CODERABBIT,
+    ),
+    false,
+  );
+  assert.equal(dispositionNamesAdvisoryBot('', CODERABBIT), false);
+  assert.equal(dispositionNamesAdvisoryBot(null, CODERABBIT), false);
+});
+
 test('gate agreement: the extended **Rejected** body still clears a notice from missingRegularComments', () => {
   // #1482: the embedded source-notice id must not break the F2/F3 gate's real
   // recognition path (isNonReviewNoticeDisposition + dispositionNamesAdvisoryBot,


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Hardens `dispositionNamesAdvisoryBot` (`src/scripts/protocol-helpers.mts`)
against misattributing a disposition reply to the wrong advisory bot. The
prior implementation was a whole-body substring search, so a bot whose
identity token equals a fixed word in the disposition template's own text
(`review`, `head`, or the newer `issuecomment` source-notice suffix from
#1482) would falsely match a disposition that actually names a different
bot.

## Linked issue

Closes #1495

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The fix anchors two regexes to the canonical disposition template shapes
(`**Rejected** — {bot} did not review HEAD …` and `**Accepted** — {bot}
summary walkthrough …`) and extracts only the bot-login span between the
marker and the naming phrase, then does the substring/token check within
that narrowed span only — never against the whole body.

This is deliberately a substring check within the span, not exact
equality, to preserve two existing behaviors verified by existing tests:

- A decorated login (`coderabbitai[bot] (CodeRabbit) did not review
  HEAD …`) still matches.
- A single disposition naming several bots in one span (`chatgpt-codex-
  connector[bot] and coderabbitai[bot] did not review HEAD …`) still
  matches each bot when queried separately, matching the existing 1:1
  consumption contract at the call sites (`buildDispositionPlan`,
  `summarizeDispositionEvidenceForGate`, `hasExplicitDispositionAfter`).

Per the issue's risk note (this function backs the F2/F3 merge gate,
consumed by `pre-merge-readiness.mjs` and `idd-merge-execute.mjs`), the
full test suite was run (not just the touched-file subset), and the
existing #1018 (notice carry-forward), #1122/#1182 (summary sticky
matching), and #1191 (`hasExplicitDispositionAfter`) test coverage was
specifically re-verified to still pass unchanged — all green, 2387/2387
tests.

An independent critique pass also caught a case-sensitivity mismatch
(the anchored regexes were case-sensitive while the sibling shape
predicates already match case-insensitively) — fixed in the same PR with
an added regression test.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved advisory bot identification in disposition notices and summary walkthroughs.
  * Prevented incidental matches against fixed template wording, issue references, or unrelated text.
  * Added case-insensitive validation for supported canonical formats.
  * Safely rejects empty, malformed, or unsupported disposition content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->