### PR TITLE
docs(customization): add CI cost levers for a test-suite-heavy PR

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1244,9 +1244,9 @@ long job, and a single slow step or test file often dominates a suite.
 Fix the measured hot spot, not the assumed one.
 
 When the heaviest per-PR job is a **test suite**, the same
-integration-branch split applies:
+integration branch split applies:
 
-- **Coverage/reporting-only work runs on integration-branch pushes,
+- **Coverage/reporting-only work runs on integration branch pushes,
   not every PR head** — instrumenting every re-sync is pure overhead
   when no gate (a coverage threshold, a required check) consumes the
   result.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1251,7 +1251,7 @@ integration branch split applies:
   when no gate (a coverage threshold, a required check) consumes the
   result.
 - **Affected-only tests on PR heads, full suite on the integration
-  branch**, when the runner supports change-based selection and
+  branch**, when the test runner supports change-based selection and
   catching an out-of-range regression post-merge is acceptable.
 - **Fake or inject time in retry/backoff/polling tests** rather than
   sleeping in real time — one real-timer test can dominate suite

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1236,5 +1236,28 @@ per-PR multi-arch builds compound it. Levers to control the cost:
   merge-from-`main` freshness model trades CI minutes for merge safety, so tune
   the heavy jobs rather than loosening the freshness gate.
 
+**Attribute the cost before optimizing.** Rank jobs by `runs × billed-minutes`
+over a representative window before changing anything — billing rounds each job
+up to the whole minute, so a frequently-triggered workflow with many short jobs
+can outweigh one long job, and a single slow step or test file often dominates a
+suite. Fix the measured hot spot, not the assumed one.
+
+When the heaviest per-PR job is a **test suite**, the same integration-branch
+split applies:
+
+- **Coverage/reporting-only work runs on integration-branch pushes, not every
+  PR head** — instrumenting every re-sync is pure overhead when no gate (a
+  coverage threshold, a required check) consumes the result.
+- **Affected-only tests on PR heads, full suite on the integration branch**,
+  when the runner supports change-based selection and catching an out-of-range
+  regression post-merge is acceptable.
+- **Fake or inject time in retry/backoff/polling tests** rather than sleeping in
+  real time — one real-timer test can dominate suite wall-clock, and the fix is
+  behavior-preserving.
+
+**Right-size the runner to the job**: lightweight automation (label hygiene,
+stale sweeps, advisory gates) on the smallest runner class, standard or larger
+runners reserved for genuinely heavyweight build or test jobs.
+
 These are repository-local optimizations; they do not change the IDD merge gate
 or the cross-agent workflow.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1236,28 +1236,31 @@ per-PR multi-arch builds compound it. Levers to control the cost:
   merge-from-`main` freshness model trades CI minutes for merge safety, so tune
   the heavy jobs rather than loosening the freshness gate.
 
-**Attribute the cost before optimizing.** Rank jobs by `runs × billed-minutes`
-over a representative window before changing anything — billing rounds each job
-up to the whole minute, so a frequently-triggered workflow with many short jobs
-can outweigh one long job, and a single slow step or test file often dominates a
-suite. Fix the measured hot spot, not the assumed one.
+**Attribute the cost before optimizing.** Rank jobs by
+`runs × billed-minutes` over a representative window before changing
+anything — billing rounds each job up to the whole minute, so a
+frequently-triggered workflow with many short jobs can outweigh one
+long job, and a single slow step or test file often dominates a suite.
+Fix the measured hot spot, not the assumed one.
 
-When the heaviest per-PR job is a **test suite**, the same integration-branch
-split applies:
+When the heaviest per-PR job is a **test suite**, the same
+integration-branch split applies:
 
-- **Coverage/reporting-only work runs on integration-branch pushes, not every
-  PR head** — instrumenting every re-sync is pure overhead when no gate (a
-  coverage threshold, a required check) consumes the result.
-- **Affected-only tests on PR heads, full suite on the integration branch**,
-  when the runner supports change-based selection and catching an out-of-range
-  regression post-merge is acceptable.
-- **Fake or inject time in retry/backoff/polling tests** rather than sleeping in
-  real time — one real-timer test can dominate suite wall-clock, and the fix is
-  behavior-preserving.
+- **Coverage/reporting-only work runs on integration-branch pushes,
+  not every PR head** — instrumenting every re-sync is pure overhead
+  when no gate (a coverage threshold, a required check) consumes the
+  result.
+- **Affected-only tests on PR heads, full suite on the integration
+  branch**, when the runner supports change-based selection and
+  catching an out-of-range regression post-merge is acceptable.
+- **Fake or inject time in retry/backoff/polling tests** rather than
+  sleeping in real time — one real-timer test can dominate suite
+  wall-clock, and the fix is behavior-preserving.
 
-**Right-size the runner to the job**: lightweight automation (label hygiene,
-stale sweeps, advisory gates) on the smallest runner class, standard or larger
-runners reserved for genuinely heavyweight build or test jobs.
+**Right-size the runner to the job**: lightweight automation (label
+hygiene, stale sweeps, advisory gates) on the smallest runner class,
+standard or larger runners reserved for genuinely heavyweight build or
+test jobs.
 
 These are repository-local optimizations; they do not change the IDD merge gate
 or the cross-agent workflow.

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1244,9 +1244,9 @@ long job, and a single slow step or test file often dominates a suite.
 Fix the measured hot spot, not the assumed one.
 
 When the heaviest per-PR job is a **test suite**, the same
-integration-branch split applies:
+integration branch split applies:
 
-- **Coverage/reporting-only work runs on integration-branch pushes,
+- **Coverage/reporting-only work runs on integration branch pushes,
   not every PR head** — instrumenting every re-sync is pure overhead
   when no gate (a coverage threshold, a required check) consumes the
   result.

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1251,7 +1251,7 @@ integration branch split applies:
   when no gate (a coverage threshold, a required check) consumes the
   result.
 - **Affected-only tests on PR heads, full suite on the integration
-  branch**, when the runner supports change-based selection and
+  branch**, when the test runner supports change-based selection and
   catching an out-of-range regression post-merge is acceptable.
 - **Fake or inject time in retry/backoff/polling tests** rather than
   sleeping in real time — one real-timer test can dominate suite

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1236,5 +1236,28 @@ per-PR multi-arch builds compound it. Levers to control the cost:
   merge-from-`main` freshness model trades CI minutes for merge safety, so tune
   the heavy jobs rather than loosening the freshness gate.
 
+**Attribute the cost before optimizing.** Rank jobs by `runs × billed-minutes`
+over a representative window before changing anything — billing rounds each job
+up to the whole minute, so a frequently-triggered workflow with many short jobs
+can outweigh one long job, and a single slow step or test file often dominates a
+suite. Fix the measured hot spot, not the assumed one.
+
+When the heaviest per-PR job is a **test suite**, the same integration-branch
+split applies:
+
+- **Coverage/reporting-only work runs on integration-branch pushes, not every
+  PR head** — instrumenting every re-sync is pure overhead when no gate (a
+  coverage threshold, a required check) consumes the result.
+- **Affected-only tests on PR heads, full suite on the integration branch**,
+  when the runner supports change-based selection and catching an out-of-range
+  regression post-merge is acceptable.
+- **Fake or inject time in retry/backoff/polling tests** rather than sleeping in
+  real time — one real-timer test can dominate suite wall-clock, and the fix is
+  behavior-preserving.
+
+**Right-size the runner to the job**: lightweight automation (label hygiene,
+stale sweeps, advisory gates) on the smallest runner class, standard or larger
+runners reserved for genuinely heavyweight build or test jobs.
+
 These are repository-local optimizations; they do not change the IDD merge gate
 or the cross-agent workflow.

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1236,28 +1236,31 @@ per-PR multi-arch builds compound it. Levers to control the cost:
   merge-from-`main` freshness model trades CI minutes for merge safety, so tune
   the heavy jobs rather than loosening the freshness gate.
 
-**Attribute the cost before optimizing.** Rank jobs by `runs × billed-minutes`
-over a representative window before changing anything — billing rounds each job
-up to the whole minute, so a frequently-triggered workflow with many short jobs
-can outweigh one long job, and a single slow step or test file often dominates a
-suite. Fix the measured hot spot, not the assumed one.
+**Attribute the cost before optimizing.** Rank jobs by
+`runs × billed-minutes` over a representative window before changing
+anything — billing rounds each job up to the whole minute, so a
+frequently-triggered workflow with many short jobs can outweigh one
+long job, and a single slow step or test file often dominates a suite.
+Fix the measured hot spot, not the assumed one.
 
-When the heaviest per-PR job is a **test suite**, the same integration-branch
-split applies:
+When the heaviest per-PR job is a **test suite**, the same
+integration-branch split applies:
 
-- **Coverage/reporting-only work runs on integration-branch pushes, not every
-  PR head** — instrumenting every re-sync is pure overhead when no gate (a
-  coverage threshold, a required check) consumes the result.
-- **Affected-only tests on PR heads, full suite on the integration branch**,
-  when the runner supports change-based selection and catching an out-of-range
-  regression post-merge is acceptable.
-- **Fake or inject time in retry/backoff/polling tests** rather than sleeping in
-  real time — one real-timer test can dominate suite wall-clock, and the fix is
-  behavior-preserving.
+- **Coverage/reporting-only work runs on integration-branch pushes,
+  not every PR head** — instrumenting every re-sync is pure overhead
+  when no gate (a coverage threshold, a required check) consumes the
+  result.
+- **Affected-only tests on PR heads, full suite on the integration
+  branch**, when the runner supports change-based selection and
+  catching an out-of-range regression post-merge is acceptable.
+- **Fake or inject time in retry/backoff/polling tests** rather than
+  sleeping in real time — one real-timer test can dominate suite
+  wall-clock, and the fix is behavior-preserving.
 
-**Right-size the runner to the job**: lightweight automation (label hygiene,
-stale sweeps, advisory gates) on the smallest runner class, standard or larger
-runners reserved for genuinely heavyweight build or test jobs.
+**Right-size the runner to the job**: lightweight automation (label
+hygiene, stale sweeps, advisory gates) on the smallest runner class,
+standard or larger runners reserved for genuinely heavyweight build or
+test jobs.
 
 These are repository-local optimizations; they do not change the IDD merge gate
 or the cross-agent workflow.


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Lands the previously-stashed Actions cost-lever additions to the "CI
cost discipline" appendix, extending it to cover the case where the
heaviest per-PR job is a test suite rather than a build.

## Linked issue

Closes #1507

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The prior draft (see the issue body for the retrieved content) hand-edited
`docs/customization.md` and `idd-template/docs/customization.md`
identically. This PR instead edits only the canonical source
(`idd-template/docs/customization.md`) and regenerates
`docs/customization.md` via `node scripts/sync-docs.mjs --apply`,
matching this repo's edit-canonical-then-sync convention. Verified the
three new levers don't duplicate the existing build-focused bullets in
the same section before adding them.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
