### PR TITLE
feat(ci): enable the advisory-convergence maintainer-waiver backstop

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -112,6 +112,29 @@ same-score tie band by a per-session offset instead of every session
 converging on the same lowest-numbered issue, cutting claim races
 under this repository's heavy concurrent-session load.
 
+## Local external-check-waiver policy
+
+This source repository also records a local IDD dogfooding policy:
+`ciGate.externalCheckWaivers.mode: "maintainer-authorized"` with
+`idd-advisory-convergence` registered under
+`ciGate.externalChecks.waivable`. The setting applies only to
+`kurone-kito/idd-skill` and does not change the exported template
+default (`disabled` mode, empty `waivable` list) for adopter
+repositories.
+
+This is the human-maintainer off-ramp for the residual state where the
+autonomous advisory-convergence loop cannot converge on its own (see
+issue #1465): once the configured convergence deadline (default 24h)
+has elapsed since the current PR HEAD's own commit timestamp, a trusted
+maintainer can post a valid external-check waiver for
+`idd-advisory-convergence` to unblock the gate. Treat this the same as
+any other merge-gate bypass — a deliberate, short-lived,
+maintainer-authorized exception for a genuinely stuck check, not a
+routine substitute for a fresh Copilot review. See
+[Customizing IDD](../docs/customization.md) and
+[`docs/idd-helper-scripts.md`](../docs/idd-helper-scripts.md#external-check-waiver-contract)
+for the general mechanism.
+
 ## Commit rules
 
 This project follows

--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -44,6 +44,16 @@
     "enabled": true
   },
   "ciGate": {
-    "trustEmptyProtectionReads": true
+    "trustEmptyProtectionReads": true,
+    "externalChecks": {
+      "waivable": [
+        { "selector": "idd-advisory-convergence", "matchMode": "exact" }
+      ]
+    },
+    "externalCheckWaivers": {
+      "mode": "maintainer-authorized",
+      "authorityPolicy": "owners-and-maintainers-only",
+      "maxValidity": "PT24H"
+    }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,15 @@ own interaction model rather than following product terms literally.
   a same-score tie band instead of every session converging on the
   same lowest-numbered issue, to cut claim races under this
   repository's heavy concurrent-session load.
+- **Advisory-convergence waiver backstop**: This source repository
+  also records `ciGate.externalCheckWaivers.mode:
+  "maintainer-authorized"` with `idd-advisory-convergence` registered
+  under `ciGate.externalChecks.waivable` as a local IDD dogfooding
+  policy (applies only to `kurone-kito/idd-skill`), giving a trusted
+  maintainer a human off-ramp when the autonomous advisory-convergence
+  loop cannot converge on its own (Refs #1465). See
+  [`.github/copilot-instructions.md`](.github/copilot-instructions.md#local-external-check-waiver-policy)
+  for the full rationale.
 
 ## For IDD work
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,15 @@ terms literally.
   a same-score tie band instead of every session converging on the
   same lowest-numbered issue, to cut claim races under this
   repository's heavy concurrent-session load.
+- **Advisory-convergence waiver backstop**: This source repository
+  also records `ciGate.externalCheckWaivers.mode:
+  "maintainer-authorized"` with `idd-advisory-convergence` registered
+  under `ciGate.externalChecks.waivable` as a local IDD dogfooding
+  policy (applies only to `kurone-kito/idd-skill`), giving a trusted
+  maintainer a human off-ramp when the autonomous advisory-convergence
+  loop cannot converge on its own (Refs #1465). See
+  [`.github/copilot-instructions.md`](.github/copilot-instructions.md#local-external-check-waiver-policy)
+  for the full rationale.
 
 ## For IDD work
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -73,6 +73,15 @@ own interaction model rather than following product terms literally.
   a same-score tie band instead of every session converging on the
   same lowest-numbered issue, to cut claim races under this
   repository's heavy concurrent-session load.
+- **Advisory-convergence waiver backstop**: This source repository
+  also records `ciGate.externalCheckWaivers.mode:
+  "maintainer-authorized"` with `idd-advisory-convergence` registered
+  under `ciGate.externalChecks.waivable` as a local IDD dogfooding
+  policy (applies only to `kurone-kito/idd-skill`), giving a trusted
+  maintainer a human off-ramp when the autonomous advisory-convergence
+  loop cannot converge on its own (Refs #1465). See
+  [`.github/copilot-instructions.md`](.github/copilot-instructions.md#local-external-check-waiver-policy)
+  for the full rationale.
 
 ## For IDD work
 

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -448,6 +448,7 @@ test("#1512: this repository's own .github/idd/config.json wires the maintainer-
       headCommittedAt: OLD,
       waiverMode: repoPolicy.ciGate.externalCheckWaivers.mode,
       waivableSelectors: repoPolicy.ciGate.externalChecks.waivable,
+      waiverMaxValidity: repoPolicy.ciGate.externalCheckWaivers.maxValidity,
     }),
   );
   assertValidVerdict(verdict);

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -13,6 +13,7 @@ import {
   viewerProbeGhOptions,
 } from '../src/scripts/advisory-convergence.mts';
 import { renderExternalCheckWaiverComment } from '../src/scripts/marker-helpers.mts';
+import { normalizePolicyConfig } from '../src/scripts/policy-helpers.mts';
 import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
 
 const SCHEMA = loadJson('schemas/advisory-convergence.schema.json');
@@ -411,6 +412,48 @@ test('deadline-passed-with-waiver: an otherwise-valid marker does not waive unle
   assert.equal(verdict.waiver.validCount, 0);
   assert.equal(verdict.waived, false);
   assert.equal(verdict.ready, false);
+});
+
+test("#1512: this repository's own .github/idd/config.json wires the maintainer-waiver backstop end to end", () => {
+  // Unlike the tests above (which supply a hand-rolled waiver policy),
+  // this one normalizes the REAL repo-committed config and threads its
+  // `ciGate.externalCheckWaivers.mode` / `ciGate.externalChecks.waivable`
+  // straight into the pure verdict function -- proving the actual
+  // shipped config (not just the mechanism in the abstract) makes a
+  // post-deadline maintainer waiver for `idd-advisory-convergence` flip
+  // `ready` true. See #1512 and #1465.
+  const repoPolicy = normalizePolicyConfig(loadJson('.github/idd/config.json'));
+  assert.equal(
+    repoPolicy.ciGate.externalCheckWaivers.mode,
+    'maintainer-authorized',
+  );
+  const waiverBody = renderExternalCheckWaiverComment({
+    agentId: AGENT_ID,
+    claimId: CLAIM_ID,
+    headSha: HEAD,
+    checkSelector: 'idd-advisory-convergence',
+    reason: 'repo config regression coverage (#1512)',
+    expiresAt: '2026-07-12T00:00:00Z',
+    actor: TRUSTED,
+  });
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment()],
+      comments: [
+        { author: { login: TRUSTED }, body: waiverBody, createdAt: RECENT },
+      ],
+    }),
+    baseOptions({
+      headCommittedAt: OLD,
+      waiverMode: repoPolicy.ciGate.externalCheckWaivers.mode,
+      waivableSelectors: repoPolicy.ciGate.externalChecks.waivable,
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.deadline.passed, true);
+  assert.equal(verdict.waived, true);
+  assert.equal(verdict.ready, true);
 });
 
 // --- 7. deadline-passed-no-waiver -----------------------------------------

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -4,6 +4,7 @@ import { join, relative } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
+import { ADVISORY_CONVERGENCE_CHECK_SELECTOR } from '../src/scripts/advisory-convergence.mts';
 import {
   collectDocBudgetDriftViolations,
   collectDuplicateSyncPairTargets,
@@ -1001,6 +1002,27 @@ test('package.json version stays aligned with iddVersion in the shipped and temp
         `(${config.iddVersion}) in ${configPath}`,
     );
   }
+});
+
+test('#1512: this repository opts into the advisory-convergence maintainer-waiver backstop, while the distributed template config stays disabled', () => {
+  const repoPolicy = normalizePolicyConfig(readJson('.github/idd/config.json'));
+  assert.equal(
+    repoPolicy.ciGate.externalCheckWaivers.mode,
+    'maintainer-authorized',
+  );
+  assert.ok(
+    repoPolicy.ciGate.externalChecks.waivable.some(
+      (entry) => entry.selector === ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+    ),
+    `expected ${ADVISORY_CONVERGENCE_CHECK_SELECTOR} to be registered under ` +
+      'ciGate.externalChecks.waivable in .github/idd/config.json',
+  );
+
+  const templatePolicy = normalizePolicyConfig(
+    readJson('idd-template/.github/idd/config.json'),
+  );
+  assert.equal(templatePolicy.ciGate.externalCheckWaivers.mode, 'disabled');
+  assert.deepEqual(templatePolicy.ciGate.externalChecks.waivable, []);
 });
 
 test('collectDuplicateSyncPairTargets flags repeated targets and ignores unique ones', () => {

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -1012,10 +1012,13 @@ test('#1512: this repository opts into the advisory-convergence maintainer-waive
   );
   assert.ok(
     repoPolicy.ciGate.externalChecks.waivable.some(
-      (entry) => entry.selector === ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      (entry) =>
+        entry.selector === ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
+        entry.matchMode === 'exact',
     ),
     `expected ${ADVISORY_CONVERGENCE_CHECK_SELECTOR} to be registered under ` +
-      'ciGate.externalChecks.waivable in .github/idd/config.json',
+      'ciGate.externalChecks.waivable with matchMode "exact" (not a ' +
+      'broader glob) in .github/idd/config.json',
   );
 
   const templatePolicy = normalizePolicyConfig(


### PR DESCRIPTION
## Summary

- Register `idd-advisory-convergence` as an exact-match waivable check
  and flip `ciGate.externalCheckWaivers.mode` to
  `"maintainer-authorized"` in this repository's own
  `.github/idd/config.json`, giving a trusted maintainer a human
  off-ramp when the autonomous advisory-convergence loop cannot
  converge on its own (the `#1465` permanent-block state).
- The distributed `idd-template/` config and `POLICY_DEFAULTS` keep
  the `disabled` / empty-`waivable` defaults untouched, so adopter
  repositories are unaffected.
- Add a test in `tests/advisory-convergence.test.mts` that normalizes
  this repo's real config and threads it through
  `computeAdvisoryConvergenceVerdict` end to end (a post-deadline
  maintainer waiver flips `ready` to `true`), plus a test in
  `tests/consistency.test.mts` asserting the repo config enables the
  waiver while the template config stays disabled. The existing
  generic waiver-mechanism tests never touched either real config
  file, so this closes that gap.
- Document the opt-in as a new "Local external-check-waiver policy"
  section in `.github/copilot-instructions.md` (mirroring the existing
  "Local merge policy" / "Local discover policy" sections) and mirror
  a matching bullet into `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`'s "Key
  workflow rules".

No changes to `src/scripts/advisory-convergence.mts` or its schema:
the deadline + waiver mechanism (`ready = converged || (deadlinePassed
&& waived)`) already existed and was already unit-tested generically;
the gap was purely that this repo's own config never turned it on.

## Test plan

- [x] `node --test tests/advisory-convergence.test.mts
      tests/consistency.test.mts` — both new tests pass, along with
      all existing tests in these files
- [x] `pnpm run typecheck`
- [x] `node scripts/idd-doctor.mjs` — passes, config validates against
      `policy.schema.json`, same 4 pre-existing baseline warnings
- [x] `pnpm run lint:minimum` (biome, dprint, markdownlint, cspell,
      `audit-docs --check`, `build:check`, full `node --test
      tests/*.test.mts` suite) — full green run
- [x] Rebased onto latest `main` before this first push (no file
      overlap with the intervening `docs/customization.md` commits)

Closes #1512

Refs #1465

🤖 Generated with [Claude Code](https://claude.com/claude-code)
