### PR TITLE
fix(ci): widen ci-wait-state's tie-break failure vocabulary

### DIFF
--- a/scripts/ci-wait-state.mjs
+++ b/scripts/ci-wait-state.mjs
@@ -292,10 +292,36 @@ function selectLatestCheckEntryPerName(entries) {
  * selection purposes only, and the winning wrapper is unwrapped back to
  * its original `entry` before returning, so the returned `CiWaitCheckEntry`
  * always carries its real, unmodified `state`.
+ *
+ * Sorted by the original `entry.state` (ascending) before wrapping, so a
+ * same-instant tie between two *distinct* raw states that both normalize
+ * to the same tie-break state (e.g. `TIMED_OUT` and `STARTUP_FAILURE`,
+ * both normalized to `'FAILURE'`) still resolves deterministically
+ * (Copilot review, PR #1530). Without the sort, `selectLatestCheckInstance`'s
+ * last-resort comparison (`candidate.state !== current.state && ...`) sees
+ * two *equal* normalized states and always keeps whichever entry
+ * `reduce` saw first -- an input-order artifact, not a value-based choice.
+ * Pre-fix, distinct raw states made that same comparison a genuine
+ * lexicographic argmin, independent of input order; sorting restores
+ * exactly that: `reduce` starts from (and keeps) the lexicographically
+ * smallest raw state whenever normalized states tie. This sort changes
+ * nothing else -- the `completedAt`-primary and rank-primary comparisons
+ * in `isNewerCheckInstance` are already order-independent.
+ *
+ * Exported (like `protocol-helpers.mts`'s own `selectLatestCheckInstance`)
+ * so the determinism property above is directly unit-testable: the winning
+ * *raw* instance's identity is not observable through
+ * `buildCiWaitStateSummary`'s public return shape at all -- `checks` there
+ * is the raw, not-deduped list, and `requiredChecks` only exposes aggregate
+ * pass/fail booleans that stay identical regardless of which same-rank
+ * instance wins a tie.
  */
-function selectLatestCheckEntry(group) {
+export function selectLatestCheckEntry(group) {
+  const sorted = [...group].sort((a, b) =>
+    a.state < b.state ? -1 : a.state > b.state ? 1 : 0,
+  );
   const winner = selectLatestCheckInstance(
-    group.map((entry) => ({
+    sorted.map((entry) => ({
       entry,
       state: tieBreakState(entry),
       completedAt: entry.completedAt,

--- a/scripts/ci-wait-state.mjs
+++ b/scripts/ci-wait-state.mjs
@@ -233,6 +233,18 @@ function bucketState(state) {
  * `CiWaitCheckEntry` uses `checkName` where `protocol-helpers.mts`'s
  * `CheckLike` uses `name`.
  *
+ * `selectLatestCheckInstance`'s shared `ciStateTieRank` special-cases only
+ * the two literal strings `'FAILURE'` and `'CANCELLED'`; every other raw
+ * state -- including this file's own wider `FAILURE_STATES` additions
+ * `TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE`, and `ERROR`
+ * -- falls into the shared tie-break's generic rank-1 bucket, where a
+ * same-instant tie against a success-family state resolves by raw
+ * lexicographic string comparison instead of "the failure should win"
+ * (#1504). Rather than widening `ciStateTieRank` itself -- shared,
+ * upstream of `classifyCiChecks`, and out of scope for this fix -- see
+ * `selectLatestCheckEntry` for how each group applies a tie-break-only
+ * state normalization that stays entirely local to this file.
+ *
  * Deliberately keyed by `checkName` alone, not the `(checkName,
  * workflowName)` pair this file otherwise disambiguates entries by (see
  * the module header): GitHub's own required-status-check gate matches by
@@ -252,7 +264,7 @@ function bucketState(state) {
  *
  * `entries` itself may be empty (e.g. no required check has been
  * reported yet), in which case `groups` simply ends up with zero
- * entries. What is guaranteed is that every group `selectLatestCheckInstance`
+ * entries. What is guaranteed is that every group `selectLatestCheckEntry`
  * receives has at least one member: a group is only ever created by
  * pushing the entry that introduced its key (see the `Map` construction
  * below), so the seedless `reduce` inside `selectLatestCheckInstance`
@@ -268,7 +280,47 @@ function selectLatestCheckEntryPerName(entries) {
       groups.set(entry.checkName, [entry]);
     }
   }
-  return [...groups.values()].map((group) => selectLatestCheckInstance(group));
+  return [...groups.values()].map((group) => selectLatestCheckEntry(group));
+}
+/**
+ * Reduce one name-keyed group to its representative instance via the
+ * shared `selectLatestCheckInstance`, using a *tie-break-only* normalized
+ * state (#1504) so this file's wider `FAILURE_STATES` vocabulary still
+ * wins a same-instant tie against a success-family state, the same way a
+ * literal `FAILURE` conclusion already does. `entry.state` itself is never
+ * mutated: each group member is wrapped with `tieBreakState(entry)` for
+ * selection purposes only, and the winning wrapper is unwrapped back to
+ * its original `entry` before returning, so the returned `CiWaitCheckEntry`
+ * always carries its real, unmodified `state`.
+ */
+function selectLatestCheckEntry(group) {
+  const winner = selectLatestCheckInstance(
+    group.map((entry) => ({
+      entry,
+      state: tieBreakState(entry),
+      completedAt: entry.completedAt,
+    })),
+  );
+  return winner.entry;
+}
+/**
+ * The state the shared tie-break in `selectLatestCheckInstance` should
+ * compare for `entry`, which is not always `entry.state` itself (#1504).
+ * `CANCELLED` is left as `CANCELLED`: a cancelled run reached no verdict,
+ * so it must keep losing a same-instant tie exactly as it does today.
+ * Every other entry already bucketed as `status === 'failure'` by
+ * `bucketState` -- the literal `FAILURE` conclusion plus this file's wider
+ * `FAILURE_STATES` additions (`TIMED_OUT`, `ACTION_REQUIRED`,
+ * `STARTUP_FAILURE`, `STALE`, the StatusContext-only `ERROR`) -- normalizes
+ * to the literal `'FAILURE'` so `ciStateTieRank` ranks it 0 (always wins)
+ * instead of falling into its generic rank-1 bucket. Every non-failure
+ * entry (success, pending, unknown) is returned unchanged: the existing
+ * lexicographic fallback within that shared rank is correct as-is and out
+ * of scope for this fix.
+ */
+function tieBreakState(entry) {
+  if (entry.state === 'CANCELLED') return 'CANCELLED';
+  return entry.status === 'failure' ? 'FAILURE' : entry.state;
 }
 function buildRequiredChecksRollup(
   checks,

--- a/src/scripts/ci-wait-state.mts
+++ b/src/scripts/ci-wait-state.mts
@@ -388,6 +388,18 @@ function bucketState(state: string): CiWaitCheckEntry['status'] {
  * `CiWaitCheckEntry` uses `checkName` where `protocol-helpers.mts`'s
  * `CheckLike` uses `name`.
  *
+ * `selectLatestCheckInstance`'s shared `ciStateTieRank` special-cases only
+ * the two literal strings `'FAILURE'` and `'CANCELLED'`; every other raw
+ * state -- including this file's own wider `FAILURE_STATES` additions
+ * `TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE`, and `ERROR`
+ * -- falls into the shared tie-break's generic rank-1 bucket, where a
+ * same-instant tie against a success-family state resolves by raw
+ * lexicographic string comparison instead of "the failure should win"
+ * (#1504). Rather than widening `ciStateTieRank` itself -- shared,
+ * upstream of `classifyCiChecks`, and out of scope for this fix -- see
+ * `selectLatestCheckEntry` for how each group applies a tie-break-only
+ * state normalization that stays entirely local to this file.
+ *
  * Deliberately keyed by `checkName` alone, not the `(checkName,
  * workflowName)` pair this file otherwise disambiguates entries by (see
  * the module header): GitHub's own required-status-check gate matches by
@@ -407,7 +419,7 @@ function bucketState(state: string): CiWaitCheckEntry['status'] {
  *
  * `entries` itself may be empty (e.g. no required check has been
  * reported yet), in which case `groups` simply ends up with zero
- * entries. What is guaranteed is that every group `selectLatestCheckInstance`
+ * entries. What is guaranteed is that every group `selectLatestCheckEntry`
  * receives has at least one member: a group is only ever created by
  * pushing the entry that introduced its key (see the `Map` construction
  * below), so the seedless `reduce` inside `selectLatestCheckInstance`
@@ -425,7 +437,49 @@ function selectLatestCheckEntryPerName(
       groups.set(entry.checkName, [entry]);
     }
   }
-  return [...groups.values()].map((group) => selectLatestCheckInstance(group));
+  return [...groups.values()].map((group) => selectLatestCheckEntry(group));
+}
+
+/**
+ * Reduce one name-keyed group to its representative instance via the
+ * shared `selectLatestCheckInstance`, using a *tie-break-only* normalized
+ * state (#1504) so this file's wider `FAILURE_STATES` vocabulary still
+ * wins a same-instant tie against a success-family state, the same way a
+ * literal `FAILURE` conclusion already does. `entry.state` itself is never
+ * mutated: each group member is wrapped with `tieBreakState(entry)` for
+ * selection purposes only, and the winning wrapper is unwrapped back to
+ * its original `entry` before returning, so the returned `CiWaitCheckEntry`
+ * always carries its real, unmodified `state`.
+ */
+function selectLatestCheckEntry(group: CiWaitCheckEntry[]): CiWaitCheckEntry {
+  const winner = selectLatestCheckInstance(
+    group.map((entry) => ({
+      entry,
+      state: tieBreakState(entry),
+      completedAt: entry.completedAt,
+    })),
+  );
+  return winner.entry;
+}
+
+/**
+ * The state the shared tie-break in `selectLatestCheckInstance` should
+ * compare for `entry`, which is not always `entry.state` itself (#1504).
+ * `CANCELLED` is left as `CANCELLED`: a cancelled run reached no verdict,
+ * so it must keep losing a same-instant tie exactly as it does today.
+ * Every other entry already bucketed as `status === 'failure'` by
+ * `bucketState` -- the literal `FAILURE` conclusion plus this file's wider
+ * `FAILURE_STATES` additions (`TIMED_OUT`, `ACTION_REQUIRED`,
+ * `STARTUP_FAILURE`, `STALE`, the StatusContext-only `ERROR`) -- normalizes
+ * to the literal `'FAILURE'` so `ciStateTieRank` ranks it 0 (always wins)
+ * instead of falling into its generic rank-1 bucket. Every non-failure
+ * entry (success, pending, unknown) is returned unchanged: the existing
+ * lexicographic fallback within that shared rank is correct as-is and out
+ * of scope for this fix.
+ */
+function tieBreakState(entry: CiWaitCheckEntry): string {
+  if (entry.state === 'CANCELLED') return 'CANCELLED';
+  return entry.status === 'failure' ? 'FAILURE' : entry.state;
 }
 
 function buildRequiredChecksRollup(

--- a/src/scripts/ci-wait-state.mts
+++ b/src/scripts/ci-wait-state.mts
@@ -450,10 +450,38 @@ function selectLatestCheckEntryPerName(
  * selection purposes only, and the winning wrapper is unwrapped back to
  * its original `entry` before returning, so the returned `CiWaitCheckEntry`
  * always carries its real, unmodified `state`.
+ *
+ * Sorted by the original `entry.state` (ascending) before wrapping, so a
+ * same-instant tie between two *distinct* raw states that both normalize
+ * to the same tie-break state (e.g. `TIMED_OUT` and `STARTUP_FAILURE`,
+ * both normalized to `'FAILURE'`) still resolves deterministically
+ * (Copilot review, PR #1530). Without the sort, `selectLatestCheckInstance`'s
+ * last-resort comparison (`candidate.state !== current.state && ...`) sees
+ * two *equal* normalized states and always keeps whichever entry
+ * `reduce` saw first -- an input-order artifact, not a value-based choice.
+ * Pre-fix, distinct raw states made that same comparison a genuine
+ * lexicographic argmin, independent of input order; sorting restores
+ * exactly that: `reduce` starts from (and keeps) the lexicographically
+ * smallest raw state whenever normalized states tie. This sort changes
+ * nothing else -- the `completedAt`-primary and rank-primary comparisons
+ * in `isNewerCheckInstance` are already order-independent.
+ *
+ * Exported (like `protocol-helpers.mts`'s own `selectLatestCheckInstance`)
+ * so the determinism property above is directly unit-testable: the winning
+ * *raw* instance's identity is not observable through
+ * `buildCiWaitStateSummary`'s public return shape at all -- `checks` there
+ * is the raw, not-deduped list, and `requiredChecks` only exposes aggregate
+ * pass/fail booleans that stay identical regardless of which same-rank
+ * instance wins a tie.
  */
-function selectLatestCheckEntry(group: CiWaitCheckEntry[]): CiWaitCheckEntry {
+export function selectLatestCheckEntry(
+  group: CiWaitCheckEntry[],
+): CiWaitCheckEntry {
+  const sorted = [...group].sort((a, b) =>
+    a.state < b.state ? -1 : a.state > b.state ? 1 : 0,
+  );
   const winner = selectLatestCheckInstance(
-    group.map((entry) => ({
+    sorted.map((entry) => ({
       entry,
       state: tieBreakState(entry),
       completedAt: entry.completedAt,

--- a/tests/ci-wait-state.test.mts
+++ b/tests/ci-wait-state.test.mts
@@ -256,6 +256,194 @@ test('required-checks rollup: the PR #1434 real-world shape (2 cancelled, 1 fail
   assert.equal(summary.requiredChecks.status, 'success');
 });
 
+// #1504: ciStateTieRank (protocol-helpers.mts) special-cases only the two
+// literal strings 'FAILURE' and 'CANCELLED'; this file's own wider
+// FAILURE_STATES vocabulary (TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE,
+// STALE, ERROR) fell into the shared tie-break's generic rank-1 bucket, so a
+// same-instant completedAt tie against a success-family state resolved by
+// raw lexicographic comparison instead of "the failure should win". These
+// tests deliberately tie every pair at the identical completedAt to exercise
+// that same-instant fallback specifically, unlike the #1478 tests above
+// (which use strictly increasing timestamps to exercise latest-completedAt
+// selection instead).
+test('required-checks rollup: a same-instant TIMED_OUT vs success-family tie still reports failing', () => {
+  for (const successConclusion of [
+    'SUCCESS',
+    'NEUTRAL',
+    'SKIPPED',
+    'NOT_APPLICABLE',
+  ]) {
+    const summary = buildCiWaitStateSummary(
+      {
+        headRefOid: HEAD_SHA,
+        statusCheckRollup: [
+          checkRun({
+            name: 'idd-advisory-convergence',
+            workflowName: 'ci',
+            conclusion: 'TIMED_OUT',
+            completedAt: '2026-07-17T16:25:47Z',
+          }),
+          checkRun({
+            name: 'idd-advisory-convergence',
+            workflowName: 'ci',
+            conclusion: successConclusion,
+            completedAt: '2026-07-17T16:25:47Z',
+          }),
+        ],
+      },
+      { requiredCheckNames: ['idd-advisory-convergence'] },
+    );
+
+    assert.equal(
+      summary.requiredChecks.anyRequiredFailing,
+      true,
+      `expected a same-instant TIMED_OUT vs ${successConclusion} tie to report failing`,
+    );
+    assert.equal(summary.requiredChecks.allRequiredPassing, false);
+    assert.equal(summary.requiredChecks.status, 'failing');
+  }
+});
+
+test('required-checks rollup: a same-instant STARTUP_FAILURE/STALE vs success-family tie still reports failing', () => {
+  for (const failureConclusion of ['STARTUP_FAILURE', 'STALE']) {
+    for (const successConclusion of ['NEUTRAL', 'SKIPPED', 'NOT_APPLICABLE']) {
+      const summary = buildCiWaitStateSummary(
+        {
+          headRefOid: HEAD_SHA,
+          statusCheckRollup: [
+            checkRun({
+              name: 'idd-advisory-convergence',
+              workflowName: 'ci',
+              conclusion: failureConclusion,
+              completedAt: '2026-07-17T16:25:47Z',
+            }),
+            checkRun({
+              name: 'idd-advisory-convergence',
+              workflowName: 'ci',
+              conclusion: successConclusion,
+              completedAt: '2026-07-17T16:25:47Z',
+            }),
+          ],
+        },
+        { requiredCheckNames: ['idd-advisory-convergence'] },
+      );
+
+      assert.equal(
+        summary.requiredChecks.anyRequiredFailing,
+        true,
+        `expected a same-instant ${failureConclusion} vs ${successConclusion} tie to report failing`,
+      );
+      assert.equal(summary.requiredChecks.status, 'failing');
+    }
+  }
+});
+
+test('required-checks rollup: a same-instant ACTION_REQUIRED/ERROR vs success-family tie still reports failing', () => {
+  // The issue's own hand analysis found ACTION_REQUIRED and the
+  // StatusContext-only ERROR already won a same-instant tie against every
+  // success-family state before this fix, by lexicographic happenstance
+  // (both start with a letter earlier than every success state's first
+  // letter). Covered here too for completeness/symmetry with the other
+  // FAILURE_STATES members above, and as a regression guard in case a
+  // future success-family addition ever breaks that happenstance.
+  for (const failureConclusion of ['ACTION_REQUIRED', 'ERROR']) {
+    for (const successConclusion of [
+      'SUCCESS',
+      'NEUTRAL',
+      'SKIPPED',
+      'NOT_APPLICABLE',
+    ]) {
+      const summary = buildCiWaitStateSummary(
+        {
+          headRefOid: HEAD_SHA,
+          statusCheckRollup: [
+            checkRun({
+              name: 'idd-advisory-convergence',
+              workflowName: 'ci',
+              conclusion: failureConclusion,
+              completedAt: '2026-07-17T16:25:47Z',
+            }),
+            checkRun({
+              name: 'idd-advisory-convergence',
+              workflowName: 'ci',
+              conclusion: successConclusion,
+              completedAt: '2026-07-17T16:25:47Z',
+            }),
+          ],
+        },
+        { requiredCheckNames: ['idd-advisory-convergence'] },
+      );
+
+      assert.equal(
+        summary.requiredChecks.anyRequiredFailing,
+        true,
+        `expected a same-instant ${failureConclusion} vs ${successConclusion} tie to report failing`,
+      );
+      assert.equal(summary.requiredChecks.status, 'failing');
+    }
+  }
+});
+
+test('required-checks rollup: a same-instant CANCELLED vs SUCCESS tie still resolves to success (unchanged)', () => {
+  // Guard against a regression in the #1504 fix: CANCELLED must keep
+  // losing a same-instant tie exactly as it did before this fix (a
+  // cancelled run reached no verdict, so it defers to a real success).
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [
+        checkRun({
+          name: 'idd-advisory-convergence',
+          workflowName: 'ci',
+          conclusion: 'CANCELLED',
+          completedAt: '2026-07-17T16:25:47Z',
+        }),
+        checkRun({
+          name: 'idd-advisory-convergence',
+          workflowName: 'ci',
+          conclusion: 'SUCCESS',
+          completedAt: '2026-07-17T16:25:47Z',
+        }),
+      ],
+    },
+    { requiredCheckNames: ['idd-advisory-convergence'] },
+  );
+
+  assert.equal(summary.requiredChecks.anyRequiredFailing, false);
+  assert.equal(summary.requiredChecks.allRequiredPassing, true);
+  assert.equal(summary.requiredChecks.status, 'success');
+});
+
+test('required-checks rollup: a same-instant literal FAILURE vs SUCCESS tie still reports failing (unchanged)', () => {
+  // Guard against a regression in the #1504 fix: the literal 'FAILURE'
+  // conclusion already won a same-instant tie before this fix and must
+  // still win it after.
+  const summary = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [
+        checkRun({
+          name: 'idd-advisory-convergence',
+          workflowName: 'ci',
+          conclusion: 'FAILURE',
+          completedAt: '2026-07-17T16:25:47Z',
+        }),
+        checkRun({
+          name: 'idd-advisory-convergence',
+          workflowName: 'ci',
+          conclusion: 'SUCCESS',
+          completedAt: '2026-07-17T16:25:47Z',
+        }),
+      ],
+    },
+    { requiredCheckNames: ['idd-advisory-convergence'] },
+  );
+
+  assert.equal(summary.requiredChecks.anyRequiredFailing, true);
+  assert.equal(summary.requiredChecks.allRequiredPassing, false);
+  assert.equal(summary.requiredChecks.status, 'failing');
+});
+
 test('required-checks rollup: a not-yet-generated required check reports missing, not vacuously passing', () => {
   const summary = buildCiWaitStateSummary(
     {

--- a/tests/ci-wait-state.test.mts
+++ b/tests/ci-wait-state.test.mts
@@ -4,6 +4,7 @@ import { test } from 'node:test';
 import {
   buildCiWaitStateSummary,
   parseArgs,
+  selectLatestCheckEntry,
 } from '../src/scripts/ci-wait-state.mts';
 
 // --- #1450: migration onto the shared cli-args.mts wrapper -----------------
@@ -338,50 +339,155 @@ test('required-checks rollup: a same-instant STARTUP_FAILURE/STALE vs success-fa
   }
 });
 
-test('required-checks rollup: a same-instant ACTION_REQUIRED/ERROR vs success-family tie still reports failing', () => {
-  // The issue's own hand analysis found ACTION_REQUIRED and the
-  // StatusContext-only ERROR already won a same-instant tie against every
-  // success-family state before this fix, by lexicographic happenstance
-  // (both start with a letter earlier than every success state's first
-  // letter). Covered here too for completeness/symmetry with the other
-  // FAILURE_STATES members above, and as a regression guard in case a
-  // future success-family addition ever breaks that happenstance.
-  for (const failureConclusion of ['ACTION_REQUIRED', 'ERROR']) {
-    for (const successConclusion of [
-      'SUCCESS',
-      'NEUTRAL',
-      'SKIPPED',
-      'NOT_APPLICABLE',
-    ]) {
-      const summary = buildCiWaitStateSummary(
-        {
-          headRefOid: HEAD_SHA,
-          statusCheckRollup: [
-            checkRun({
-              name: 'idd-advisory-convergence',
-              workflowName: 'ci',
-              conclusion: failureConclusion,
-              completedAt: '2026-07-17T16:25:47Z',
-            }),
-            checkRun({
-              name: 'idd-advisory-convergence',
-              workflowName: 'ci',
-              conclusion: successConclusion,
-              completedAt: '2026-07-17T16:25:47Z',
-            }),
-          ],
-        },
-        { requiredCheckNames: ['idd-advisory-convergence'] },
-      );
+test('required-checks rollup: a same-instant ACTION_REQUIRED vs success-family tie still reports failing', () => {
+  // The issue's own hand analysis found ACTION_REQUIRED already won a
+  // same-instant tie against every success-family state before this fix,
+  // by lexicographic happenstance (it starts with a letter earlier than
+  // every success state's first letter). Covered here too for
+  // completeness/symmetry with the other FAILURE_STATES members above,
+  // and as a regression guard in case a future success-family addition
+  // ever breaks that happenstance.
+  for (const successConclusion of [
+    'SUCCESS',
+    'NEUTRAL',
+    'SKIPPED',
+    'NOT_APPLICABLE',
+  ]) {
+    const summary = buildCiWaitStateSummary(
+      {
+        headRefOid: HEAD_SHA,
+        statusCheckRollup: [
+          checkRun({
+            name: 'idd-advisory-convergence',
+            workflowName: 'ci',
+            conclusion: 'ACTION_REQUIRED',
+            completedAt: '2026-07-17T16:25:47Z',
+          }),
+          checkRun({
+            name: 'idd-advisory-convergence',
+            workflowName: 'ci',
+            conclusion: successConclusion,
+            completedAt: '2026-07-17T16:25:47Z',
+          }),
+        ],
+      },
+      { requiredCheckNames: ['idd-advisory-convergence'] },
+    );
 
-      assert.equal(
-        summary.requiredChecks.anyRequiredFailing,
-        true,
-        `expected a same-instant ${failureConclusion} vs ${successConclusion} tie to report failing`,
-      );
-      assert.equal(summary.requiredChecks.status, 'failing');
-    }
+    assert.equal(
+      summary.requiredChecks.anyRequiredFailing,
+      true,
+      `expected a same-instant ACTION_REQUIRED vs ${successConclusion} tie to report failing`,
+    );
+    assert.equal(summary.requiredChecks.status, 'failing');
   }
+});
+
+test('required-checks rollup: a same-instant StatusContext ERROR vs (CheckRun) success-family tie still reports failing', () => {
+  // ERROR is StatusContext-only (a CheckRun never reports it as a
+  // conclusion), so this exercises the actual StatusContext normalization
+  // path -- and, since the paired success entry is a CheckRun, a genuine
+  // cross-type tie under the same checkName (Copilot review, PR #1530;
+  // the original version of this test fed ERROR through the generic
+  // checkRun() CheckRun fixture, which never exercises the StatusContext
+  // branch at all). completedAt must be set explicitly and identically on
+  // both entries: normalizeCheckEntry defaults a StatusContext's
+  // completedAt to '' when absent, which parses to a *missing* timestamp
+  // -- isNewerCheckInstance's incomplete-always-wins branch would then
+  // make ERROR win for the wrong reason (treated as still-running, never
+  // reaching the #1504 tie-break rank comparison this test means to
+  // cover) regardless of whether the tie-break fix works at all.
+  for (const successConclusion of [
+    'SUCCESS',
+    'NEUTRAL',
+    'SKIPPED',
+    'NOT_APPLICABLE',
+  ]) {
+    const summary = buildCiWaitStateSummary(
+      {
+        headRefOid: HEAD_SHA,
+        statusCheckRollup: [
+          {
+            __typename: 'StatusContext',
+            context: 'idd-advisory-convergence',
+            state: 'ERROR',
+            targetUrl: '',
+            completedAt: '2026-07-17T16:25:47Z',
+          },
+          checkRun({
+            name: 'idd-advisory-convergence',
+            workflowName: 'ci',
+            conclusion: successConclusion,
+            completedAt: '2026-07-17T16:25:47Z',
+          }),
+        ],
+      },
+      { requiredCheckNames: ['idd-advisory-convergence'] },
+    );
+
+    assert.equal(
+      summary.requiredChecks.anyRequiredFailing,
+      true,
+      `expected a same-instant ERROR vs ${successConclusion} tie to report failing`,
+    );
+    assert.equal(summary.requiredChecks.status, 'failing');
+    // Note: `summary.checks` is the raw, *not-deduped* list (dedup happens
+    // only inside buildRequiredChecksRollup's internal
+    // selectLatestCheckEntryPerName call), so it always has both entries
+    // here regardless of which one wins the tie -- not a signal of which
+    // instance was selected. The completedAt values above are explicit
+    // and identical on both entries by construction, which is what
+    // guarantees this exercises the rank-based tie-break rather than the
+    // incomplete-always-wins path (see the comment at the top of this
+    // test), independent of anything observable at runtime here.
+  }
+});
+
+test('selectLatestCheckEntry: a same-instant tie between two distinct FAILURE_STATES members resolves deterministically regardless of input order', () => {
+  // Copilot review, PR #1530: tieBreakState() normalizes every failure-
+  // bucketed entry to the same literal 'FAILURE' for tie-break purposes,
+  // so two *different* raw failure states (e.g. TIMED_OUT and
+  // STARTUP_FAILURE) now tie on both completedAt and normalized state.
+  // selectLatestCheckEntry sorts the group by the original entry.state
+  // before reducing so this still resolves to a fixed winner (the
+  // lexicographically smallest raw state, matching this tie-break's
+  // pre-#1504 argmin-by-value behavior for two non-'FAILURE' failure
+  // states) regardless of which order the two instances arrive in. The
+  // winning instance's identity is not observable through
+  // buildCiWaitStateSummary's public shape (see the note on the ERROR
+  // test above), so this calls the exported reducer directly instead.
+  const timedOut = {
+    checkName: 'idd-advisory-convergence',
+    workflowName: 'ci',
+    type: 'check-run' as const,
+    state: 'TIMED_OUT',
+    status: 'failure' as const,
+    required: true,
+    url: 'https://example/timed-out',
+    startedAt: '2026-07-17T16:00:00Z',
+    completedAt: '2026-07-17T16:25:47Z',
+  };
+  const startupFailure = {
+    checkName: 'idd-advisory-convergence',
+    workflowName: 'ci',
+    type: 'check-run' as const,
+    state: 'STARTUP_FAILURE',
+    status: 'failure' as const,
+    required: true,
+    url: 'https://example/startup-failure',
+    startedAt: '2026-07-17T16:00:00Z',
+    completedAt: '2026-07-17T16:25:47Z',
+  };
+
+  // 'STARTUP_FAILURE' < 'TIMED_OUT' lexicographically ('S' < 'T').
+  assert.equal(
+    selectLatestCheckEntry([timedOut, startupFailure]).state,
+    'STARTUP_FAILURE',
+  );
+  assert.equal(
+    selectLatestCheckEntry([startupFailure, timedOut]).state,
+    'STARTUP_FAILURE',
+  );
 });
 
 test('required-checks rollup: a same-instant CANCELLED vs SUCCESS tie still resolves to success (unchanged)', () => {


### PR DESCRIPTION
# Summary

`ci-wait-state.mts`'s own `FAILURE_STATES` set is wider than the two
literal strings (`'FAILURE'`, `'CANCELLED'`) that
`protocol-helpers.mts`'s shared `ciStateTieRank` special-cases when two
check-run instances for one required check name complete at the
identical recorded second. Every other raw state — including this
file's own additions `TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`,
`STALE`, and the StatusContext-only `ERROR` — fell into the shared
tie-break's generic rank-1 bucket, where a same-instant tie against a
success-family state resolved by raw lexicographic string comparison
instead of the failure winning. `TIMED_OUT` lost such a tie against
every success-family state; `STARTUP_FAILURE` and `STALE` each lost
against three of the four.

Widening the shared `ciStateTieRank` itself would sit upstream of
`classifyCiChecks`, needing its own blast-radius review — out of scope
here, per the issue's own deferred proposed-change note. This PR keeps
the fix entirely local to `ci-wait-state.mts` instead: each
`CiWaitCheckEntry` is wrapped with a tie-break-only normalized state
before calling the shared `selectLatestCheckInstance`, then the winner
is unwrapped back to its original entry. `CANCELLED` stays `CANCELLED`
(it must keep losing a tie — a cancelled run reached no verdict); every
other entry already bucketed as `status === 'failure'` normalizes to
the literal `'FAILURE'` so it wins the tie the same way a literal
`FAILURE` conclusion already does; every non-failure entry is left
unchanged. `protocol-helpers.mts` itself is untouched, so
`classifyCiChecks` and every existing caller keep an unchanged call
path and inputs — zero blast radius by construction.

Adds regression tests covering same-instant ties between every
`FAILURE_STATES` member and each success-family state, plus guards
confirming `CANCELLED` and the literal `FAILURE` still resolve exactly
as before (verified these are real regression tests, not vacuous, by
temporarily reverting the fix locally and confirming the new
failure-vocabulary tests fail against pre-fix code).

## Linked issue

Closes #1504

## Follow-up issues (if any)

- [x] none

The issue's alternative option (widening `protocol-helpers.mts`'s own
`ciStateTieRank` vocabulary) remains available if a future need arises
to fix this at the shared-helper layer too, but is out of scope here
per the issue's own narrow-reachability/blast-radius rationale.

## Background / rationale (if material)

Surfaced during an E2 critique pass on PR #1502 (#1478's fix for the
same file's multi-instance stale-rollup defect). `buildCiWaitStateSummary`
has no caller outside its own CLI entry point and test file —
`pre-merge-readiness.mts` does not call it, so F2's actual merge gate
(via `classifyCiChecks` / `summarizeRequiredChecks`) is unaffected by
both the original defect and this fix; the blast radius is confined to
the D-phase polling/snapshot helper, matching the accepted rarity class
of the cross-referenced `#1483` limitation.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

`pnpm lint` / `pnpm test` are unchecked because the literal commands do
not cleanly exit in this local sandbox: `tests/branch-conflict-state.test.mts`
(byte-identical to `main`, untouched by this diff) has 3 subtests that
fail on `git commit` GPG-signing pinentry timeouts under concurrent
local session load — a pre-existing local-environment limitation, not a
regression from this change. Every constituent step was instead run
individually and passed: `tsc -p tsconfig.json`, `pnpm run build` (no
generated-file drift), `biome check`, `dprint check`, `markdownlint-cli2`,
`cspell lint`, `verify-workshop-integrity.mjs`, and the full
`node --test tests/*.test.mts` (2434/2437 passing; the only 3 failures
are the unrelated GPG-signing ones above — `tests/ci-wait-state.test.mts`
itself is 30/30 green). Hosted CI (this PR's own checks) does not carry
this machine's local gpg-agent/pinentry state and is the authoritative
signal for this diagnosis.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
