### PR TITLE
feat(claim): define orchestrator delegation as a third activation path

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -480,19 +480,20 @@ fresh claim or being treated as claim-less; see the ownership-proof
 exception in [Claim-state parsing](#claim-state-parsing). No separate
 `claimed-by` post is required for the delegation itself.
 
-**Carry the nonce, don't mint one.** The brief must also carry the
-orchestrator's current activation nonce verbatim. A worker that mints
-its own nonce for the same `{claim-id}` creates the exact two-nonce
-collision step 5 above exists to catch, flagging legitimate delegation
-as a second activation. Carrying the same nonce means the worker holds
-the identical winner the orchestrator already verified — no new marker
-to post, no new check to add. The Claim revalidation gate
-(`idd-overview-core.instructions.md`) already covers this correctly
-unchanged: its nonce comparison only applies when a session posted its
-own marker, and a worker that carries rather than posts falls through
-to "no marker posted: treat as passed" — the primary `{claim-id}` match
-in the same gate is what actually protects a delegated worker's
-mutations.
+**Carry the nonce, don't mint one — and still revalidate it.** The
+brief must also carry the orchestrator's current activation nonce
+verbatim. A worker that mints its own nonce for the same `{claim-id}`
+creates the exact two-nonce collision that step 5 above exists to
+catch, flagging legitimate delegation as a second activation. Carrying
+rather than minting avoids that false collision, but the worker still
+performs the Claim revalidation gate's nonce check
+(`idd-overview-core.instructions.md`) using the carried value in place
+of a self-posted one: before each mutation, recompute the nonce winner
+for the `{claim-id}` and confirm it still equals the carried nonce. A
+different winner (for example, a later forced-handoff adopt-verbatim
+collision the orchestrator never saw) means the worker is no longer
+the winning activation, even though the `{claim-id}` still matches —
+treat that the same as any other lost claim.
 
 ### Hide displaced claim chain on takeover
 

--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -469,6 +469,31 @@ sticky pair (and, to be safe, the displaced original pair too) using each
 pair's exact recorded `{agent-id}` / `{claim-id}`, then post a fresh
 `claimed-by supersedes: none` with a self-chosen pair.
 
+### Orchestrator delegation
+
+An orchestrating session that has itself posted and verified a claim's
+`{agent-id}` / `{claim-id}` pair may delegate that pair verbatim to an
+isolated subagent worker as part of the worker's delegation brief. The
+worker adopts both fields verbatim as its own claim token for the rest
+of its run — mirroring adopt-verbatim above — instead of minting a
+fresh claim or being treated as claim-less; see the ownership-proof
+exception in [Claim-state parsing](#claim-state-parsing). No separate
+`claimed-by` post is required for the delegation itself.
+
+**Carry the nonce, don't mint one.** The brief must also carry the
+orchestrator's current activation nonce verbatim. A worker that mints
+its own nonce for the same `{claim-id}` creates the exact two-nonce
+collision step 5 above exists to catch, flagging legitimate delegation
+as a second activation. Carrying the same nonce means the worker holds
+the identical winner the orchestrator already verified — no new marker
+to post, no new check to add. The Claim revalidation gate
+(`idd-overview-core.instructions.md`) already covers this correctly
+unchanged: its nonce comparison only applies when a session posted its
+own marker, and a worker that carries rather than posts falls through
+to "no marker posted: treat as passed" — the primary `{claim-id}` match
+in the same gate is what actually protects a delegated worker's
+mutations.
+
 ### Hide displaced claim chain on takeover
 
 When the verified new claim was posted with `supersedes: <prior-id>`
@@ -591,7 +616,11 @@ the active `{claim-id}` before this check, continue with that same token
 and use heartbeats; do not post a fresh takeover claim. If the session
 cannot prove ownership of the active `{claim-id}`, the active claim is
 treated as owned by another live session until it is released or stale,
-even when `{agent-id}` matches.
+even when `{agent-id}` matches. **Exception**: a worker that received
+the pair through a documented
+[orchestrator delegation](#orchestrator-delegation) is treated as
+having proven ownership through the orchestrator's own recorded
+verification, not as an unproven "even when `{agent-id}` matches" case.
 Self-signed forced-handoff markers from the same identity never
 transfer ownership: rule 7 rejects them unless the author is itself
 an authorized maintainer.

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -359,6 +359,14 @@ Running this variant safely requires:
   reports its final result back to the orchestrator instead of
   independently entering F5's Discover step, so Discover/Claim ownership
   stays with the orchestrator alone.
+- **The delegation brief carries the claim token verbatim, nonce
+  included.** The worker adopts the orchestrator's already-verified
+  `{agent-id}` / `{claim-id}` pair as its own for the run (mirroring
+  forced-handoff adopt-verbatim), carrying the orchestrator's current
+  activation nonce rather than minting a new one — a minted nonce would
+  collide with the orchestrator's for the same `{claim-id}` and flag
+  legitimate delegation as a second activation. See
+  [Orchestrator delegation](../.github/instructions/idd-claim.instructions.md#orchestrator-delegation).
 - **Serialized worktree/clone lifecycle operations when workers share
   one clone.** Concurrent `git fetch` / `git worktree add` / `git
   worktree remove` / local-`main` updates from the same primary clone

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -360,12 +360,15 @@ Running this variant safely requires:
   independently entering F5's Discover step, so Discover/Claim ownership
   stays with the orchestrator alone.
 - **The delegation brief carries the claim token verbatim, nonce
-  included.** The worker adopts the orchestrator's already-verified
-  `{agent-id}` / `{claim-id}` pair as its own for the run (mirroring
-  forced-handoff adopt-verbatim), carrying the orchestrator's current
-  activation nonce rather than minting a new one — a minted nonce would
-  collide with the orchestrator's for the same `{claim-id}` and flag
-  legitimate delegation as a second activation. See
+  included — and the worker actively revalidates it.** The worker
+  adopts the orchestrator's already-verified `{agent-id}` / `{claim-id}`
+  pair as its own for the run (mirroring forced-handoff adopt-verbatim),
+  carrying the orchestrator's current activation nonce rather than
+  minting a new one — a minted nonce would collide with the
+  orchestrator's for the same `{claim-id}` and flag legitimate
+  delegation as a second activation. Before each mutation, the worker
+  recomputes the nonce winner and confirms it still matches the carried
+  value, the same safety check a self-posting session performs. See
   [Orchestrator delegation](../.github/instructions/idd-claim.instructions.md#orchestrator-delegation).
 - **Serialized worktree/clone lifecycle operations when workers share
   one clone.** Concurrent `git fetch` / `git worktree add` / `git

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -464,6 +464,31 @@ sticky pair (and, to be safe, the displaced original pair too) using each
 pair's exact recorded `{agent-id}` / `{claim-id}`, then post a fresh
 `claimed-by supersedes: none` with a self-chosen pair.
 
+### Orchestrator delegation
+
+An orchestrating session that has itself posted and verified a claim's
+`{agent-id}` / `{claim-id}` pair may delegate that pair verbatim to an
+isolated subagent worker as part of the worker's delegation brief. The
+worker adopts both fields verbatim as its own claim token for the rest
+of its run — mirroring adopt-verbatim above — instead of minting a
+fresh claim or being treated as claim-less; see the ownership-proof
+exception in [Claim-state parsing](#claim-state-parsing). No separate
+`claimed-by` post is required for the delegation itself.
+
+**Carry the nonce, don't mint one.** The brief must also carry the
+orchestrator's current activation nonce verbatim. A worker that mints
+its own nonce for the same `{claim-id}` creates the exact two-nonce
+collision step 5 above exists to catch, flagging legitimate delegation
+as a second activation. Carrying the same nonce means the worker holds
+the identical winner the orchestrator already verified — no new marker
+to post, no new check to add. The Claim revalidation gate
+(`idd-overview-core.instructions.md`) already covers this correctly
+unchanged: its nonce comparison only applies when a session posted its
+own marker, and a worker that carries rather than posts falls through
+to "no marker posted: treat as passed" — the primary `{claim-id}` match
+in the same gate is what actually protects a delegated worker's
+mutations.
+
 ### Hide displaced claim chain on takeover
 
 When the verified new claim was posted with `supersedes: <prior-id>`
@@ -586,7 +611,11 @@ the active `{claim-id}` before this check, continue with that same token
 and use heartbeats; do not post a fresh takeover claim. If the session
 cannot prove ownership of the active `{claim-id}`, the active claim is
 treated as owned by another live session until it is released or stale,
-even when `{agent-id}` matches.
+even when `{agent-id}` matches. **Exception**: a worker that received
+the pair through a documented
+[orchestrator delegation](#orchestrator-delegation) is treated as
+having proven ownership through the orchestrator's own recorded
+verification, not as an unproven "even when `{agent-id}` matches" case.
 Self-signed forced-handoff markers from the same identity never
 transfer ownership: rule 7 rejects them unless the author is itself
 an authorized maintainer.

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -475,19 +475,20 @@ fresh claim or being treated as claim-less; see the ownership-proof
 exception in [Claim-state parsing](#claim-state-parsing). No separate
 `claimed-by` post is required for the delegation itself.
 
-**Carry the nonce, don't mint one.** The brief must also carry the
-orchestrator's current activation nonce verbatim. A worker that mints
-its own nonce for the same `{claim-id}` creates the exact two-nonce
-collision step 5 above exists to catch, flagging legitimate delegation
-as a second activation. Carrying the same nonce means the worker holds
-the identical winner the orchestrator already verified — no new marker
-to post, no new check to add. The Claim revalidation gate
-(`idd-overview-core.instructions.md`) already covers this correctly
-unchanged: its nonce comparison only applies when a session posted its
-own marker, and a worker that carries rather than posts falls through
-to "no marker posted: treat as passed" — the primary `{claim-id}` match
-in the same gate is what actually protects a delegated worker's
-mutations.
+**Carry the nonce, don't mint one — and still revalidate it.** The
+brief must also carry the orchestrator's current activation nonce
+verbatim. A worker that mints its own nonce for the same `{claim-id}`
+creates the exact two-nonce collision that step 5 above exists to
+catch, flagging legitimate delegation as a second activation. Carrying
+rather than minting avoids that false collision, but the worker still
+performs the Claim revalidation gate's nonce check
+(`idd-overview-core.instructions.md`) using the carried value in place
+of a self-posted one: before each mutation, recompute the nonce winner
+for the `{claim-id}` and confirm it still equals the carried nonce. A
+different winner (for example, a later forced-handoff adopt-verbatim
+collision the orchestrator never saw) means the worker is no longer
+the winning activation, even though the `{claim-id}` still matches —
+treat that the same as any other lost claim.
 
 ### Hide displaced claim chain on takeover
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -338,12 +338,15 @@ Running this variant safely requires:
   independently entering F5's Discover step, so Discover/Claim ownership
   stays with the orchestrator alone.
 - **The delegation brief carries the claim token verbatim, nonce
-  included.** The worker adopts the orchestrator's already-verified
-  `{agent-id}` / `{claim-id}` pair as its own for the run (mirroring
-  forced-handoff adopt-verbatim), carrying the orchestrator's current
-  activation nonce rather than minting a new one — a minted nonce would
-  collide with the orchestrator's for the same `{claim-id}` and flag
-  legitimate delegation as a second activation. See
+  included — and the worker actively revalidates it.** The worker
+  adopts the orchestrator's already-verified `{agent-id}` / `{claim-id}`
+  pair as its own for the run (mirroring forced-handoff adopt-verbatim),
+  carrying the orchestrator's current activation nonce rather than
+  minting a new one — a minted nonce would collide with the
+  orchestrator's for the same `{claim-id}` and flag legitimate
+  delegation as a second activation. Before each mutation, the worker
+  recomputes the nonce winner and confirms it still matches the carried
+  value, the same safety check a self-posting session performs. See
   [Orchestrator delegation](../.github/instructions/idd-claim.instructions.md#orchestrator-delegation).
 - **Serialized worktree/clone lifecycle operations when workers share
   one clone.** Concurrent `git fetch` / `git worktree add` / `git

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -337,6 +337,14 @@ Running this variant safely requires:
   reports its final result back to the orchestrator instead of
   independently entering F5's Discover step, so Discover/Claim ownership
   stays with the orchestrator alone.
+- **The delegation brief carries the claim token verbatim, nonce
+  included.** The worker adopts the orchestrator's already-verified
+  `{agent-id}` / `{claim-id}` pair as its own for the run (mirroring
+  forced-handoff adopt-verbatim), carrying the orchestrator's current
+  activation nonce rather than minting a new one — a minted nonce would
+  collide with the orchestrator's for the same `{claim-id}` and flag
+  legitimate delegation as a second activation. See
+  [Orchestrator delegation](../.github/instructions/idd-claim.instructions.md#orchestrator-delegation).
 - **Serialized worktree/clone lifecycle operations when workers share
   one clone.** Concurrent `git fetch` / `git worktree add` / `git
   worktree remove` / local-`main` updates from the same primary clone


### PR DESCRIPTION
# Summary

Defines the orchestrator-fan-out delegation exception `idd-claim.instructions.md`
was missing: today a delegated subagent worker never itself posts or
verifies a `claimed-by` marker, so Claim-state parsing's ownership-proof
rule reads it as claim-less even though its orchestrator already
verified the pair.

- New `### Orchestrator delegation` subsection in
  `idd-claim.instructions.md`, mirroring the existing forced-handoff
  adopt-verbatim mechanic: the worker adopts the orchestrator's
  already-verified `{agent-id}` / `{claim-id}` pair verbatim, no new
  `claimed-by` post required.
- Cross-referenced exception added to the Claim-state parsing
  ownership-proof paragraph (the "even when `{agent-id}` matches"
  rule).
- **Reconciled with #1522's activation-nonce check**: the worker
  carries the orchestrator's nonce verbatim rather than minting its
  own. A minted nonce would create the exact two-nonce collision
  #1522's winner rule exists to catch, flagging legitimate delegation
  as a second activation.
- `idd-overview-core.instructions.md`'s Claim revalidation gate needed
  **no change** (confirmed, not amended -- see Background below).
- `docs/idd-workflow.md`'s Orchestrator fan-out variant section (and
  its `idd-template/` mirror) documents the resolved mechanism as a
  new bullet.

## Linked issue

Closes #1439

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

**Why the Claim revalidation gate needs no change.** Its nonce
comparison (`idd-overview-core.instructions.md`) is phrased as "if you
posted an activation nonce" -- first-person, keyed to the checking
session having posted its own marker. A delegated worker carries
rather than posts the orchestrator's nonce, so it correctly falls
through to the gate's existing "no marker posted: treat as passed"
branch. That's not a gap: the gate's primary `{claim-id}` match (which
the worker legitimately holds, unchanged) is what actually protects a
delegated worker's mutations; the nonce check is a second layer that
simply has nothing new to compare for this path, exactly as it already
behaves for any session with no locally-posted nonce.

**Why carry-verbatim, not mint-own.** #1439's own body left this as an
open choice ("carry the orchestrator's current activation nonce (or
the worker mints its own delegation-specific nonce)... whichever
#1522's actual implementation makes cheaper to check"). Tracing
`findActivationNonceWinner` (`resume-claim-routing.mts`): two trusted
nonce markers for one `{claim-id}` is treated as a collision regardless
of *why* two exist, so mint-own is self-defeating -- it would make the
mechanism flag the exact legitimate case it needs to allow. Carry-verbatim
is the only correct choice, and it mirrors the adopt-verbatim precedent
already shipped in #1522.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed (claim-ownership proof for a new activation path)

## Verification

- [x] `pnpm lint:precommit` (`biome check`, `dprint check`, `markdownlint-cli2` all clean)
- [x] `node scripts/audit-docs.mjs --check` (zero drift)
- [x] `node scripts/idd-doctor.mjs` (passed, only pre-existing environmental warnings)
- No code changed (`.mts`/`.mjs`/tests untouched), so the full `pnpm test` suite is unaffected by this diff.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (adds a new claim-ownership-proof path; does not change the merge write-gate or any existing path's behavior)
- [x] Context budget impact reviewed (see below)

### Context budget impact

No ratchet needed. `bundle-discovery` (which includes
`idd-claim.instructions.md`) has 8227 bytes of headroom after this
PR's addition (92.70% utilized, up from ~91%).
`docs/idd-workflow.md` is not byte-budget-gated.
