### PR TITLE
docs(workflow): split model capability into two axes

### DIFF
--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -53,14 +53,36 @@ issue-authoring skill's
 **frontier**, **middle-tier cloud**, and **lightweight local or
 compact cloud**.
 
+Classify models on **two independent axes**, not context size alone:
+
+1. **Context sufficiency** — can the window hold the entry file,
+   `idd-overview-core.instructions.md`, the routed phase file, and tool
+   schemas at once?
+2. **Self-direction capability** — can the model plan and track a
+   multi-turn loop across claim / work / PR / review steps, not merely
+   answer one well-specified prompt?
+
+A large context window does **not** imply self-direction. Field
+experience has included models that clear a 100K+ context bar yet fail
+to drive a multi-step agentic loop without external orchestration.
+Likewise, self-direction and **local runtime speed** on the adopter's
+hardware are separate considerations: a model that clears both
+capability axes can still be impractical if it is too slow on
+CPU-only (or other constrained) local hardware. This guide does not
+pin a normative tokens-per-second floor; operators should measure on
+their own targets.
+
 - **Frontier** and **middle-tier cloud** classes need no additional
   guardrails beyond the rest of this guide; this is the assumed
-  default for every phase file above.
+  default for every phase file above. They are expected to clear both
+  axes under normal operator hardware.
 - **Lightweight local or compact cloud** (the supported low tier):
-  large-context, low-reasoning models such as the phi-4-mini class
-  (roughly 128K context, tool calling supported, but weak adherence to
-  long multi-file instruction sets). Confine this tier to
-  narrowly-scoped roles under operator supervision:
+  models that have **both** sufficient context **and** demonstrated
+  self-direction for contained, fully-specified tasks, but still show
+  weak adherence to long multi-file instruction sets (the phi-4-mini
+  class — roughly 128K context, tool calling supported — is the
+  reference example). Confine this tier to narrowly-scoped roles under
+  operator supervision:
   - executing a single, fully-specified `idd:ready` issue rather than
     Discover's open-ended candidate selection;
   - preferring a deterministic helper command (see
@@ -68,13 +90,22 @@ compact cloud**.
     judgment wherever one exists for the current step;
   - drafting output for human review rather than running the
     autonomous merge phases.
-- **Unsupported**: a model whose context window cannot hold the entry
-  file, `idd-overview-core.instructions.md`, the routed phase file, and
-  tool schemas at the same time — the qwen2.5-coder-1.5b class (roughly
-  32K context) is the practical cutoff example. Below this floor, IDD
-  execution is out of scope; such a model can still be a downstream
-  _consumer_ of an artifact this workflow produces, just not an IDD
-  execution agent.
+- **Large-context, non-self-directing** (named out-of-band class):
+  models that clear the context-sufficiency bar but cannot reliably
+  self-direct a multi-turn execution loop. They are **not** admitted
+  into the supported lightweight tier by context size alone. Prefer a
+  harness-orchestrated execution mode for this class (the model stays a
+  step-level worker; the harness owns phase routing, tool selection,
+  and acceptance gates). That path is an open investigation rather than
+  a shipped workflow profile — track
+  [#1555](https://github.com/kurone-kito/idd-skill/issues/1555).
+- **Unsupported (context floor)**: a model whose context window cannot
+  hold the entry file, `idd-overview-core.instructions.md`, the routed
+  phase file, and tool schemas at the same time — the
+  qwen2.5-coder-1.5b class (roughly 32K context) is the practical
+  cutoff example. Below this floor, IDD execution is out of scope; such
+  a model can still be a downstream _consumer_ of an artifact this
+  workflow produces, just not an IDD execution agent.
 
 ### Weak-model guardrails
 

--- a/docs/weak-model-lite-profile-design.md
+++ b/docs/weak-model-lite-profile-design.md
@@ -23,14 +23,27 @@ below for the evidence.
 
 This design reuses the model-capability taxonomy published by
 [#1415](https://github.com/kurone-kito/idd-skill/issues/1415) in
-[Model capability expectations](idd-workflow.md#model-capability-expectations)
-verbatim, rather than inventing a parallel one:
+[Model capability expectations](idd-workflow.md#model-capability-expectations),
+rather than inventing a parallel one. That taxonomy was later refined
+by [#1549](https://github.com/kurone-kito/idd-skill/issues/1549) into
+**two independent axes** — **context sufficiency** and
+**self-direction capability** — so a large context window alone no
+longer admits a model into the supported lightweight tier. This design
+still targets only the **supported lightweight local or compact cloud**
+tier under that refined taxonomy (models that clear **both** axes but
+remain weak on long multi-file instruction adherence). The named
+**large-context, non-self-directing** class is intentionally out of
+scope here; that class points at a harness-orchestrated execution-mode
+investigation rather than a condensed self-directed instruction
+profile.
 
-- **Target tier**: **lightweight local or compact cloud** — large-context,
-  low-reasoning models such as the phi-4-mini class (roughly 128K
-  context, tool calling supported, but weak adherence to long
-  multi-file instruction sets). #1415 already confines this tier to
-  narrowly-scoped roles under operator supervision:
+- **Target tier**: **lightweight local or compact cloud** — models with
+  **both** sufficient context **and** demonstrated self-direction for
+  contained tasks, that still show weak adherence to long multi-file
+  instruction sets (the phi-4-mini class — roughly 128K context, tool
+  calling supported — remains the reference example). The workflow
+  guide already confines this tier to narrowly-scoped roles under
+  operator supervision:
   - executing a single, fully-specified `idd:ready` issue rather than
     Discover's open-ended candidate selection;
   - preferring a deterministic helper command over prose judgment
@@ -45,9 +58,15 @@ verbatim, rather than inventing a parallel one:
 
 - **Non-goal: no ~32K-token squeeze.** The roadmap's operator decision
   explicitly puts the qwen2.5-coder-1.5b class (roughly 32K context) out
-  of scope — "the practical cutoff example" for **unsupported**, per
-  #1415. A lite profile is not an exercise in fitting the whole loop
-  into a tiny window; the target tier already has ample context.
+  of scope — "the practical cutoff example" for **unsupported (context
+  floor)**, per the workflow taxonomy. A lite profile is not an
+  exercise in fitting the whole loop into a tiny window; the target
+  tier already has ample context.
+- **Non-goal: no large-context, non-self-directing coverage.** Models
+  that clear the context bar but cannot self-direct a multi-turn loop
+  are a separate named class in the workflow taxonomy; they need
+  harness orchestration, not a condensed self-directed profile. See
+  [#1555](https://github.com/kurone-kito/idd-skill/issues/1555).
 - **Non-goal: no semantic changes to the standard profile.** A lite
   profile changes instruction **shape** only — how the same rules are
   packaged and phrased — never the underlying claim, gate, or merge

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -53,14 +53,36 @@ your repository installed that companion, its specificity target
 documents these three classes in detail; the terminology here stands
 on its own otherwise.)
 
+Classify models on **two independent axes**, not context size alone:
+
+1. **Context sufficiency** — can the window hold the entry file,
+   `idd-overview-core.instructions.md`, the routed phase file, and tool
+   schemas at once?
+2. **Self-direction capability** — can the model plan and track a
+   multi-turn loop across claim / work / PR / review steps, not merely
+   answer one well-specified prompt?
+
+A large context window does **not** imply self-direction. Field
+experience has included models that clear a 100K+ context bar yet fail
+to drive a multi-step agentic loop without external orchestration.
+Likewise, self-direction and **local runtime speed** on the adopter's
+hardware are separate considerations: a model that clears both
+capability axes can still be impractical if it is too slow on
+CPU-only (or other constrained) local hardware. This guide does not
+pin a normative tokens-per-second floor; operators should measure on
+their own targets.
+
 - **Frontier** and **middle-tier cloud** classes need no additional
   guardrails beyond the rest of this guide; this is the assumed
-  default for every phase file above.
+  default for every phase file above. They are expected to clear both
+  axes under normal operator hardware.
 - **Lightweight local or compact cloud** (the supported low tier):
-  large-context, low-reasoning models such as the phi-4-mini class
-  (roughly 128K context, tool calling supported, but weak adherence to
-  long multi-file instruction sets). Confine this tier to
-  narrowly-scoped roles under operator supervision:
+  models that have **both** sufficient context **and** demonstrated
+  self-direction for contained, fully-specified tasks, but still show
+  weak adherence to long multi-file instruction sets (the phi-4-mini
+  class — roughly 128K context, tool calling supported — is the
+  reference example). Confine this tier to narrowly-scoped roles under
+  operator supervision:
   - executing a single, fully-specified `idd:ready` issue rather than
     Discover's open-ended candidate selection;
   - preferring a deterministic helper command (see
@@ -68,13 +90,24 @@ on its own otherwise.)
     judgment wherever one exists for the current step;
   - drafting output for human review rather than running the
     autonomous merge phases.
-- **Unsupported**: a model whose context window cannot hold the entry
-  file, `idd-overview-core.instructions.md`, the routed phase file, and
-  tool schemas at the same time — the qwen2.5-coder-1.5b class (roughly
-  32K context) is the practical cutoff example. Below this floor, IDD
-  execution is out of scope; such a model can still be a downstream
-  _consumer_ of an artifact this workflow produces, just not an IDD
-  execution agent.
+- **Large-context, non-self-directing** (named out-of-band class):
+  models that clear the context-sufficiency bar but cannot reliably
+  self-direct a multi-turn execution loop. They are **not** admitted
+  into the supported lightweight tier by context size alone. Prefer a
+  harness-orchestrated execution mode for this class (the model stays a
+  step-level worker; the harness owns phase routing, tool selection,
+  and acceptance gates). That path is an open investigation rather than
+  a shipped workflow profile — track the corresponding investigation
+  issue in the repository that filed it (for example
+  [kurone-kito/idd-skill#1555](https://github.com/kurone-kito/idd-skill/issues/1555)
+  in the source repository).
+- **Unsupported (context floor)**: a model whose context window cannot
+  hold the entry file, `idd-overview-core.instructions.md`, the routed
+  phase file, and tool schemas at the same time — the
+  qwen2.5-coder-1.5b class (roughly 32K context) is the practical
+  cutoff example. Below this floor, IDD execution is out of scope; such
+  a model can still be a downstream _consumer_ of an artifact this
+  workflow produces, just not an IDD execution agent.
 
 ### Weak-model guardrails
 


### PR DESCRIPTION
## Summary
- Split model capability taxonomy into **context sufficiency** and **self-direction** axes in `docs/idd-workflow.md` and the template mirror.
- Define the supported lightweight tier as requiring **both** axes; name the **large-context, non-self-directing** class and point it at harness orchestration (#1555).
- Note that self-direction and local runtime speed are separate considerations (no normative tokens/s floor).
- Update `docs/weak-model-lite-profile-design.md` so its taxonomy cross-reference tracks the refined axes without inventing a parallel classification.

Closes #1549

## Test plan
- [x] `node scripts/audit-docs.mjs --check`
- [x] `npx dprint check "**/*.md"` / `npx markdownlint-cli2 "**/*.md"`
- [x] `npx cspell lint "**" --no-progress`
- [x] `node scripts/idd-doctor.mjs` (pass with existing warnings only)
- [ ] CI green on the PR