### PR TITLE
chore(audit): wire lite instruction drift-control scaffolding

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -37,6 +37,13 @@
       "requireSyncPairs": true
     },
     {
+      "id": "idd-lite-instruction-template-set",
+      "sourceGlob": "idd-template/.github/instructions/lite/idd-*.instructions.md",
+      "targetGlob": ".github/instructions/lite/idd-*.instructions.md",
+      "match": "basename",
+      "requireSyncPairs": true
+    },
+    {
       "id": "idd-template-docs-set",
       "sourceGlob": "idd-template/docs/idd-*.md",
       "targetGlob": "docs/idd-*.md",
@@ -189,6 +196,12 @@
         ".github/instructions/idd-work.instructions.md"
       ],
       "limitBytes": 45000
+    },
+    {
+      "id": "bundle-work-lite",
+      "description": "Lite work path (weak-model condensed profile): .github/instructions/lite/idd-work-lite.instructions.md only — self-contained; no overview/appendix. Scaffolding for #1541; files filled when #1542 lands.",
+      "files": [],
+      "limitBytes": 24000
     },
     {
       "id": "bundle-review",

--- a/docs/weak-model-lite-profile-design.md
+++ b/docs/weak-model-lite-profile-design.md
@@ -314,7 +314,8 @@ generated pair rather than a third _kind_ of surface:
   proposes; a future follow-up could investigate a mechanical
   semantic-parity check, but this design does not assume one exists.
 
-**Status (scaffolding live).** [#1541](https://github.com/kurone-kito/idd-skill/issues/1541)
+**Status (scaffolding live).**
+[#1541](https://github.com/kurone-kito/idd-skill/issues/1541)
 wired the audit surface before any lite content exists:
 
 - `fileSets` entry `idd-lite-instruction-template-set` —
@@ -341,7 +342,8 @@ pass. Titles and one-line scopes only — filing them is out of scope for
 this design issue.
 
 - **~~Wire sync-manifest drift control for lite instruction files~~** —
-  **done in [#1541](https://github.com/kurone-kito/idd-skill/issues/1541)**
+  **done in**
+  [#1541](https://github.com/kurone-kito/idd-skill/issues/1541)
   (see [Drift control](#drift-control) status note). The `fileSets` and
   `bundle-work-lite` scaffolding is live; per-file `syncPairs` still
   arrive with each later content track.

--- a/docs/weak-model-lite-profile-design.md
+++ b/docs/weak-model-lite-profile-design.md
@@ -314,6 +314,26 @@ generated pair rather than a third _kind_ of surface:
   proposes; a future follow-up could investigate a mechanical
   semantic-parity check, but this design does not assume one exists.
 
+**Status (scaffolding live).** [#1541](https://github.com/kurone-kito/idd-skill/issues/1541)
+wired the audit surface before any lite content exists:
+
+- `fileSets` entry `idd-lite-instruction-template-set` —
+  `idd-template/.github/instructions/lite/idd-*.instructions.md` →
+  `.github/instructions/lite/idd-*.instructions.md`, `match: "basename"`,
+  `requireSyncPairs: true`. Zero matching files is fine; a later track
+  that adds a lite file without a generatable `syncPairs` row fails
+  `audit-docs.mjs --check`.
+- `bundleBudgets` entry `bundle-work-lite` with an independent
+  `limitBytes` of **24000** and an empty `files` list until the work-phase
+  pilot (#1542) lands the path
+  `.github/instructions/lite/idd-work-lite.instructions.md`. Later lite
+  content tracks should append their paths (and raise the ceiling only
+  when measured content needs it) — do not treat 24000 as a fraction of
+  the standard `bundle-work` budget.
+
+Per-file `syncPairs` rows still arrive with each content issue; this
+scaffolding does not invent them in advance.
+
 ## Decomposition proposal
 
 The following follow-up issues are proposed scope for a later authoring

--- a/docs/weak-model-lite-profile-design.md
+++ b/docs/weak-model-lite-profile-design.md
@@ -340,13 +340,11 @@ The following follow-up issues are proposed scope for a later authoring
 pass. Titles and one-line scopes only — filing them is out of scope for
 this design issue.
 
-- **Wire sync-manifest drift control for lite instruction files** — add
-  the `fileSets` entry, its required per-file `syncPairs` entries, and a
-  new `bundleBudgets` entry, all described in
-  [Drift control](#drift-control), so `audit-docs.mjs --check` enforces
-  parity for the new surface before any lite content lands; sequence
-  this first so every subsequent lite file is drift-checked from its
-  first commit.
+- **~~Wire sync-manifest drift control for lite instruction files~~** —
+  **done in [#1541](https://github.com/kurone-kito/idd-skill/issues/1541)**
+  (see [Drift control](#drift-control) status note). The `fileSets` and
+  `bundle-work-lite` scaffolding is live; per-file `syncPairs` still
+  arrive with each later content track.
 - **Author the lite instruction set for the work phase (B1-C6) —
   narrowest pilot** — condense `idd-work.instructions.md` into a
   self-contained lite file following all five content principles; the

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -307,7 +307,13 @@ const DOC_BUDGET_SIZE = {
   alwaysLoadedLimitBytes: 20_000,
   phaseLimitBytes: 35_500,
 };
-const DOC_BUDGET_BUNDLES = [{ limitBytes: 112_700 }, { limitBytes: 45_000 }];
+// Keep representative of live audit/sync-manifest.json bundleBudgets
+// (includes independent lite work budget from #1541).
+const DOC_BUDGET_BUNDLES = [
+  { limitBytes: 112_700 },
+  { limitBytes: 45_000 },
+  { limitBytes: 24_000 },
+];
 
 test('doc budget guard passes when documented values match the manifest', () => {
   const texts: Record<string, string> = {
@@ -337,7 +343,7 @@ test('doc budget guard flags a value that drifted from every manifest budget', (
   assert.equal(result.errors.length, 1);
   assert.match(
     result.errors[0],
-    /doc-budget-drift: README\.md states 30,000 bytes, which is not a current sync-manifest budget value \(valid: 20000, 35500, 45000, 112700\)/,
+    /doc-budget-drift: README\.md states 30,000 bytes, which is not a current sync-manifest budget value \(valid: 20000, 24000, 35500, 45000, 112700\)/,
   );
 });
 


### PR DESCRIPTION
## Summary
- Add `fileSets` entry `idd-lite-instruction-template-set` so lite instruction globs require per-file generatable `syncPairs` before content lands.
- Add independent `bundleBudgets` entry `bundle-work-lite` (24 000-byte ceiling, empty `files` until #1542).
- Document live scaffolding status under the design doc Drift control section.

Closes #1541

## Test plan
- [x] `node scripts/audit-docs.mjs --check` passes with no lite files present
- [x] `node scripts/idd-doctor.mjs`
- [ ] CI green on the PR

## Reviewer note (semantic parity)
Manifest scaffolding only — no lite instruction content and no change to standard-profile semantics.