### PR TITLE
feat: enable repository-local advisory convergence scope

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -30,6 +30,9 @@
   },
   "issueScope": "roadmap-first",
   "orphanFirstPolicy": "none",
+  "advisoryWait": {
+    "convergenceScope": "idd-claimed"
+  },
   "discover": {
     "selectionDesync": "session-offset"
   },

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -249,8 +249,11 @@ durations only; zero-length values and second-based values are invalid.
 Repositories may also customize `advisoryWait.convergenceScope` in
 `.github/idd/config.json`. The default `all-prs` keeps convergence on
 every PR. `idd-claimed` is opt-in and limits convergence to verified
-IDD-owned PRs; invalid values are rejected by schema, and runtime
-normalization falls back to `all-prs` for untrusted config reads.
+IDD-owned PRs. Under `idd-claimed`, PRs without a verified linked claim
+resolve to `not_applicable` instead of opening a new waiver path, so
+claimless/manual dependency PRs stay outside the gate. Invalid values
+are rejected by schema, and runtime normalization falls back to
+`all-prs` for untrusted config reads.
 
 `advisoryWait.primaryBotLogin` selects the advisory bot whose review the
 advisory-wait gate tracks (default Copilot), and

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1408,6 +1408,13 @@ Interpretation rules:
 - Fail closed: if helper execution fails, output is invalid JSON, or
   required fields are missing, discard helper output and apply the
   written F2 advisory/disposition sub-gate check manually.
+- `advisoryWait.convergenceScope` controls whether advisory convergence
+  applies to every PR or only verified IDD-owned PRs. The default
+  `all-prs` keeps the helper applicable everywhere; `idd-claimed`
+  narrows it so PRs without a verified linked claim resolve to
+  `not_applicable`, leaving the gate out of the way outside IDD-owned
+  work. Invalid or unreadable config values still normalize back to
+  `all-prs` in trusted config reads.
 
 #### Bounded same-HEAD advisory reroll (AW6, #1511)
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1410,11 +1410,16 @@ Interpretation rules:
   written F2 advisory/disposition sub-gate check manually.
 - `advisoryWait.convergenceScope` controls whether advisory convergence
   applies to every PR or only verified IDD-owned PRs. The default
-  `all-prs` keeps the helper applicable everywhere; `idd-claimed`
-  narrows it so PRs without a verified linked claim resolve to
-  `not_applicable`, leaving the gate out of the way outside IDD-owned
-  work. Invalid or unreadable config values still normalize back to
-  `all-prs` in trusted config reads.
+  `all-prs` keeps the helper applicable everywhere. `idd-claimed`
+  narrows it so a verified linked claim with a matching PR head branch
+  is `applicable`; a verified linked claim with a branch mismatch is
+  `not_applicable`; a verified linked claim still stays `applicable`
+  when branch data is unavailable; and PRs without a verified linked
+  claim, including manual/dependency PRs, are `not_applicable`.
+  Claimless maintainer waivers stay outside this conditional scope; the
+  normal deadline-based waiver path still applies only to applicable,
+  verified IDD-owned PRs. Invalid or unreadable config values still
+  normalize back to `all-prs` in trusted config reads.
 
 #### Bounded same-HEAD advisory reroll (AW6, #1511)
 

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -219,6 +219,11 @@ install without a requestable-reviewer event cannot be tracked once per HEAD.
 | Advisory-convergence enforcement scope           | `all-prs` (`advisoryWait.convergenceScope`)                                                                                                                                                                                                                                                                                                                  | [Pre-merge](../.github/instructions/idd-pre-merge.instructions.md), [Helper scripts](idd-helper-scripts.md), [Customizing IDD](customization.md#policy-constants)                                                    | Keep `all-prs` for existing behavior; switch to `idd-claimed` only when the repository wants convergence to apply solely to verified IDD-owned PRs.             |
 | Advisory-convergence required-check registration | Not registered by default (hosting the `idd-advisory-convergence` workflow is itself an opt-in step — see [ONBOARDING](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#optional--host-idd-advisory-convergence-as-a-required-check-ci-workflow); once hosted, a required-status-check Ruleset entry is a separate manual step) | [Customizing IDD](customization.md#policy-constants), [Helper scripts](idd-helper-scripts.md)                                                                                                                        | Register `idd-advisory-convergence` as a required status check to make convergence non-bypassable; this is a maintainer GitHub-settings action, not agent work. |
 
+`idd-claimed` keeps claimless/manual dependency PRs out of the gate by
+making them `not_applicable` instead of creating a waiver path. The
+maintainer waiver escape hatch still applies only to applicable,
+verified IDD-owned PRs after the deadline.
+
 ## CI Wait Defaults
 
 | Policy default                                         | Distributed value                                                                   | Owning surface                                                                                                                                                                                         | Onboarding expectation                                                                      |

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -249,8 +249,11 @@ durations only; zero-length values and second-based values are invalid.
 Repositories may also customize `advisoryWait.convergenceScope` in
 `.github/idd/config.json`. The default `all-prs` keeps convergence on
 every PR. `idd-claimed` is opt-in and limits convergence to verified
-IDD-owned PRs; invalid values are rejected by schema, and runtime
-normalization falls back to `all-prs` for untrusted config reads.
+IDD-owned PRs. Under `idd-claimed`, PRs without a verified linked claim
+resolve to `not_applicable` instead of opening a new waiver path, so
+claimless/manual dependency PRs stay outside the gate. Invalid values
+are rejected by schema, and runtime normalization falls back to
+`all-prs` for untrusted config reads.
 
 `advisoryWait.primaryBotLogin` selects the advisory bot whose review the
 advisory-wait gate tracks (default Copilot), and

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1408,6 +1408,13 @@ Interpretation rules:
 - Fail closed: if helper execution fails, output is invalid JSON, or
   required fields are missing, discard helper output and apply the
   written F2 advisory/disposition sub-gate check manually.
+- `advisoryWait.convergenceScope` controls whether advisory convergence
+  applies to every PR or only verified IDD-owned PRs. The default
+  `all-prs` keeps the helper applicable everywhere; `idd-claimed`
+  narrows it so PRs without a verified linked claim resolve to
+  `not_applicable`, leaving the gate out of the way outside IDD-owned
+  work. Invalid or unreadable config values still normalize back to
+  `all-prs` in trusted config reads.
 
 #### Bounded same-HEAD advisory reroll (AW6, #1511)
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1410,11 +1410,16 @@ Interpretation rules:
   written F2 advisory/disposition sub-gate check manually.
 - `advisoryWait.convergenceScope` controls whether advisory convergence
   applies to every PR or only verified IDD-owned PRs. The default
-  `all-prs` keeps the helper applicable everywhere; `idd-claimed`
-  narrows it so PRs without a verified linked claim resolve to
-  `not_applicable`, leaving the gate out of the way outside IDD-owned
-  work. Invalid or unreadable config values still normalize back to
-  `all-prs` in trusted config reads.
+  `all-prs` keeps the helper applicable everywhere. `idd-claimed`
+  narrows it so a verified linked claim with a matching PR head branch
+  is `applicable`; a verified linked claim with a branch mismatch is
+  `not_applicable`; a verified linked claim still stays `applicable`
+  when branch data is unavailable; and PRs without a verified linked
+  claim, including manual/dependency PRs, are `not_applicable`.
+  Claimless maintainer waivers stay outside this conditional scope; the
+  normal deadline-based waiver path still applies only to applicable,
+  verified IDD-owned PRs. Invalid or unreadable config values still
+  normalize back to `all-prs` in trusted config reads.
 
 #### Bounded same-HEAD advisory reroll (AW6, #1511)
 

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -219,6 +219,11 @@ install without a requestable-reviewer event cannot be tracked once per HEAD.
 | Advisory-convergence enforcement scope           | `all-prs` (`advisoryWait.convergenceScope`)                                                                                                                                                                                                                                                                                                                  | [Pre-merge](../.github/instructions/idd-pre-merge.instructions.md), [Helper scripts](idd-helper-scripts.md), [Customizing IDD](customization.md#policy-constants)                                                    | Keep `all-prs` for existing behavior; switch to `idd-claimed` only when the repository wants convergence to apply solely to verified IDD-owned PRs.             |
 | Advisory-convergence required-check registration | Not registered by default (hosting the `idd-advisory-convergence` workflow is itself an opt-in step — see [ONBOARDING](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#optional--host-idd-advisory-convergence-as-a-required-check-ci-workflow); once hosted, a required-status-check Ruleset entry is a separate manual step) | [Customizing IDD](customization.md#policy-constants), [Helper scripts](idd-helper-scripts.md)                                                                                                                        | Register `idd-advisory-convergence` as a required status check to make convergence non-bypassable; this is a maintainer GitHub-settings action, not agent work. |
 
+`idd-claimed` keeps claimless/manual dependency PRs out of the gate by
+making them `not_applicable` instead of creating a waiver path. The
+maintainer waiver escape hatch still applies only to applicable,
+verified IDD-owned PRs after the deadline.
+
 ## CI Wait Defaults
 
 | Policy default                                         | Distributed value                                                                   | Owning surface                                                                                                                                                                                         | Onboarding expectation                                                                      |

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -490,6 +490,7 @@ test("#1512: this repository's own .github/idd/config.json wires the maintainer-
   // post-deadline maintainer waiver for `idd-advisory-convergence` flip
   // `ready` true. See #1512 and #1465.
   const repoPolicy = normalizePolicyConfig(loadJson('.github/idd/config.json'));
+  assert.equal(repoPolicy.advisoryWait.convergenceScope, 'idd-claimed');
   assert.equal(
     repoPolicy.ciGate.externalCheckWaivers.mode,
     'maintainer-authorized',


### PR DESCRIPTION
# Summary

- Scope advisory convergence to `idd-claimed` for this repository.
- Document the scope knob in the helper docs.
- Add a repo-specific regression assertion for the shipped config.

## Linked issue

Closes #1567

## Follow-up issues (if any)

- none

## Background / rationale (if material)

`idd-claimed` keeps advisory convergence limited to verified IDD-owned PRs while the template default stays `all-prs`.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `node scripts/audit-docs.mjs --check`
- [x] `node --test tests/advisory-convergence.test.mts tests/policy-helpers.test.mts tests/schema-validation.test.mts`
- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configuration option to limit advisory convergence checks to verified IDD-owned pull requests.
  - Pull requests without a verified linked claim can now be marked as not applicable under this setting.

- **Documentation**
  - Documented configuration options, defaults, and fail-safe behavior for invalid or unreadable values.

- **Tests**
  - Added coverage verifying the new advisory convergence scope configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->