### PR TITLE
fix(discover): enforce open-dependent-issue check in orphan filter

### DIFF
--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -118,7 +118,6 @@ export function classifyIssue(issue, options) {
     return { orphan: true, reason: 'orphan' };
   }
   const unresolved = [];
-  let anyReferenceNonBlocking = false;
   for (const ref of blockedRefs) {
     const state = resolveIssueState(
       ref,
@@ -134,8 +133,6 @@ export function classifyIssue(issue, options) {
     }
     if (state === 'UNRESOLVABLE') {
       unresolved.push(ref);
-    } else {
-      anyReferenceNonBlocking = true;
     }
   }
   for (const ref of dependencyRefs) {
@@ -146,7 +143,6 @@ export function classifyIssue(issue, options) {
     );
     if ((state ?? '').toUpperCase() === 'OPEN') {
       if (isDependencyEpicExempt(ref, options)) {
-        anyReferenceNonBlocking = true;
         continue;
       }
       return {
@@ -157,8 +153,6 @@ export function classifyIssue(issue, options) {
     }
     if (state === 'UNRESOLVABLE') {
       unresolved.push(ref);
-    } else {
-      anyReferenceNonBlocking = true;
     }
   }
   if (unresolved.length > 0) {
@@ -168,9 +162,11 @@ export function classifyIssue(issue, options) {
       details: [...new Set(unresolved)],
     };
   }
-  return anyReferenceNonBlocking
-    ? { orphan: true, reason: 'blocked_references_closed' }
-    : { orphan: true, reason: 'orphan' };
+  // Reaching here means blockedRefs/dependencyRefs was non-empty (the
+  // earlier both-empty check already returned `orphan`) and every ref
+  // resolved to a non-open, non-unresolvable state (closed, or an
+  // exempt open parent epic) -- never "no refs at all" again.
+  return { orphan: true, reason: 'blocked_references_closed' };
 }
 /**
  * Resolve whether an **open** dependency reference is exempt as a parent

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -17,7 +17,11 @@ import {
   parseAutopilotSuitability,
   rankAndRouteBySuitability,
 } from './autopilot-suitability.mjs';
-import { extractBlockedByIssueNumbers } from './discover-readiness-check.mjs';
+import {
+  extractBlockedByIssueNumbers,
+  extractDependencyIssueNumbers,
+  isParentEpicIssue,
+} from './discover-readiness-check.mjs';
 import {
   annotateLeafClaimState,
   buildClaimStateResolution,
@@ -96,12 +100,26 @@ export function classifyIssue(issue, options) {
       details: authoringLabelName,
     };
   }
-  const refs = extractBlockedByReferences(body);
-  if (refs.length === 0) {
+  // Two independent reference families, matching A3's own dependency check
+  // in `discover-readiness-check.mts` (#1536): visible `Blocked by #NNN`
+  // lines (a hard sequential dependency, no exemption) and `Depends on
+  // #NNN` / task-list dependency references (which exempt an open parent
+  // epic / aggregate issue, mirroring `isParentEpicIssue`). A0-O passes
+  // survivors directly to A3.5 and skips A3 entirely, so without this
+  // second family a helper-driven run could select an orphan whose only
+  // open blocker is a dependency reference, even though the roadmap path
+  // would already filter it out. `Blocked by` is checked first (matching
+  // the original single-list order) so an issue that carries both kinds
+  // reports the same `blocked_by_open_reference` / `unresolvable_reference`
+  // reason it always has when that reference alone already blocks.
+  const blockedRefs = extractBlockedByReferences(body);
+  const dependencyRefs = extractDependencyIssueNumbers(body);
+  if (blockedRefs.length === 0 && dependencyRefs.length === 0) {
     return { orphan: true, reason: 'orphan' };
   }
   const unresolved = [];
-  for (const ref of refs) {
+  let anyReferenceNonBlocking = false;
+  for (const ref of blockedRefs) {
     const state = resolveIssueState(
       ref,
       options.issueStateByNumber,
@@ -116,16 +134,65 @@ export function classifyIssue(issue, options) {
     }
     if (state === 'UNRESOLVABLE') {
       unresolved.push(ref);
+    } else {
+      anyReferenceNonBlocking = true;
+    }
+  }
+  for (const ref of dependencyRefs) {
+    const state = resolveIssueState(
+      ref,
+      options.issueStateByNumber,
+      options.fetchIssueStateByNumber,
+    );
+    if ((state ?? '').toUpperCase() === 'OPEN') {
+      if (isDependencyEpicExempt(ref, options)) {
+        anyReferenceNonBlocking = true;
+        continue;
+      }
+      return {
+        orphan: false,
+        reason: 'open_dependency_reference',
+        details: ref,
+      };
+    }
+    if (state === 'UNRESOLVABLE') {
+      unresolved.push(ref);
+    } else {
+      anyReferenceNonBlocking = true;
     }
   }
   if (unresolved.length > 0) {
     return {
       orphan: false,
       reason: 'unresolvable_reference',
-      details: unresolved,
+      details: [...new Set(unresolved)],
     };
   }
-  return { orphan: true, reason: 'blocked_references_closed' };
+  return anyReferenceNonBlocking
+    ? { orphan: true, reason: 'blocked_references_closed' }
+    : { orphan: true, reason: 'orphan' };
+}
+/**
+ * Resolve whether an **open** dependency reference is exempt as a parent
+ * epic / aggregate issue (#1536), reusing `isParentEpicIssue` from
+ * `discover-readiness-check.mts` rather than re-implementing the exemption.
+ * Only ever consulted for `Depends on` / task-list references, never for
+ * `Blocked by` references, matching A3's asymmetry. Fails closed (not
+ * exempt) when `openIssueDetailsByNumber` is absent or does not carry the
+ * referenced issue's details.
+ */
+function isDependencyEpicExempt(ref, options) {
+  const detail = options.openIssueDetailsByNumber?.get(ref);
+  if (!detail) {
+    return false;
+  }
+  return isParentEpicIssue(
+    {
+      title: String(detail.title ?? ''),
+      labels: new Set(normalizeLabels(detail.labels)),
+    },
+    normalizeRoadmapLabelName(options.roadmapLabelName),
+  );
 }
 export async function filterOrphanIssues(issues, options = {}) {
   const issueStateByNumber = new Map(options.issueStateByNumber ?? []);
@@ -139,11 +206,25 @@ export async function filterOrphanIssues(issues, options = {}) {
     blocked_label: [],
     authoring_label: [],
     blocked_by_open_reference: [],
+    open_dependency_reference: [],
     unresolvable_reference: [],
   };
   const orphans = [];
   const unresolvable = [];
   const warnings = [];
+  // Self-batch lookup for the dependency parent-epic exemption (#1536): in
+  // the CLI wiring `issues` is always the full open-issue batch
+  // (`fetchOpenIssues`), so any `Depends on` / task-list reference that
+  // resolves OPEN is guaranteed to already be present here — zero extra
+  // GitHub API calls. A reference outside this batch (e.g. a partial list
+  // passed directly to `filterOrphanIssues`, such as in a test) fails
+  // closed via `isDependencyEpicExempt`'s own absent-entry handling.
+  const openIssueDetailsByNumber = new Map(
+    issues.map((candidate) => [
+      candidate.number,
+      { title: candidate.title, labels: candidate.labels },
+    ]),
+  );
   for (const issue of issues) {
     const result = classifyIssue(issue, {
       issueStateByNumber,
@@ -152,6 +233,8 @@ export async function filterOrphanIssues(issues, options = {}) {
       authoringLabelName: options.authoringLabelName,
       blockedByHumanLabelName: options.blockedByHumanLabelName,
       needsDecisionLabelName: options.needsDecisionLabelName,
+      roadmapLabelName: options.roadmapLabelName,
+      openIssueDetailsByNumber,
     });
     if (result.reason === 'unresolvable_reference') {
       for (const number of result.details ?? []) {
@@ -322,6 +405,7 @@ async function runCli() {
     authoringStaleAgeMs: policy.authoringStaleAgeMs,
     blockedByHumanLabelName: policy.blockedByHumanLabelName,
     needsDecisionLabelName: policy.needsDecisionLabelName,
+    roadmapLabelName: policy.roadmapLabelName,
     autopilotSuitabilityFloor: policy.autopilotSuitabilityFloor,
     autopilotSuitabilityEnabled: policy.autopilotSuitabilityEnabled,
     autopilot: args.autopilot,
@@ -442,12 +526,25 @@ Output schema:
     "blocked_label": [...],
     "authoring_label": [...],
     "blocked_by_open_reference": [...],
+    "open_dependency_reference": [...],
     "unresolvable_reference": [...]
   },
   "unresolvable": [{"issue": 1, "reference": 2, "reason": "issue-not-found-or-inaccessible"}],
   "warnings": [{"issueNumber": 1, "message": "Warning: ..."}],
   "counts": {"scanned": 0, "orphans": 0, "routed_to_human": 0, "filtered": {...}, "unresolvable": 0}
 }
+
+"filtered.open_dependency_reference" (#1536) mirrors A3's own dependency
+check in discover-readiness-check.mjs: a candidate whose body contains an
+open "Depends on #NNN" line or an open task-list "- [ ] #NNN" reference is
+excluded, UNLESS that referenced issue is itself a parent epic / aggregate
+issue (title starting with "roadmap", or carrying the configured roadmap
+label) -- matching A3's exemption exactly. This exemption never applies to
+"Blocked by #NNN" references (filtered.blocked_by_open_reference), which
+stay a hard sequential dependency with no exemption. An unresolvable
+dependency reference (issue not found or inaccessible) is treated as
+blocking, the same fail-safe "unresolvable_reference" applies to an
+unresolvable "Blocked by" reference.
 
 orphans are always ranked by authored autopilot-suitability score (high
 first; equal scores tie-break by lowest issue number). With --autopilot
@@ -499,6 +596,7 @@ function loadPolicy(policyPath) {
       authoringStaleAgeMs: authoringPolicy.staleAgeMs,
       blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
       needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+      roadmapLabelName: labelsPolicy.roadmapLabelName,
       autopilotSuitabilityFloor: resolveAutopilotSuitabilityFloor(config),
       autopilotSuitabilityEnabled: resolveAutopilotSuitabilityEnabled(config),
       // Passed through verbatim (raw, un-normalized) for
@@ -519,6 +617,7 @@ function loadPolicy(policyPath) {
       authoringStaleAgeMs: authoringPolicy.staleAgeMs,
       blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
       needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+      roadmapLabelName: labelsPolicy.roadmapLabelName,
       autopilotSuitabilityFloor: DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
       autopilotSuitabilityEnabled: true,
       // No config was readable, so buildClaimStateResolution falls back to
@@ -664,6 +763,16 @@ function normalizeNeedsDecisionLabelName(labelName) {
   return typeof labelName === 'string' && labelName.length > 0
     ? labelName
     : POLICY_DEFAULTS.labels.needsDecisionLabelName;
+}
+/**
+ * Resolve the configured `labels.roadmapLabelName` for the dependency
+ * parent-epic exemption (#1536), following this file's established
+ * defensive-default pattern for the other configurable label names.
+ */
+function normalizeRoadmapLabelName(labelName) {
+  return typeof labelName === 'string' && labelName.length > 0
+    ? labelName
+    : POLICY_DEFAULTS.labels.roadmapLabelName;
 }
 function fetchOpenIssues(repoRef) {
   const issues = [];

--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -617,7 +617,18 @@ function normalizeLabels(labelsInput) {
   }
   return new Set();
 }
-function isParentEpicIssue(
+/**
+ * Parent-epic / aggregate-issue exemption for the dependency check (#1536):
+ * an open dependency issue does not block when it is itself a roadmap/epic.
+ * Exported so `discover-orphan-filter.mts` can reuse this exact exemption for
+ * A0-O's own dependency check instead of re-implementing it (#1536). The
+ * parameter type is intentionally the minimal structural shape this function
+ * actually reads (not the full `NormalizedIssue`), so a reusing caller can
+ * pass any object with these two fields without constructing a full
+ * `NormalizedIssue` (`NormalizedIssue` itself stays structurally assignable,
+ * so this widening does not affect the call site below).
+ */
+export function isParentEpicIssue(
   issue,
   roadmapLabelName = POLICY_DEFAULTS.labels.roadmapLabelName,
 ) {

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -268,7 +268,6 @@ export function classifyIssue(
   }
 
   const unresolved: number[] = [];
-  let anyReferenceNonBlocking = false;
 
   for (const ref of blockedRefs) {
     const state = resolveIssueState(
@@ -285,8 +284,6 @@ export function classifyIssue(
     }
     if (state === 'UNRESOLVABLE') {
       unresolved.push(ref);
-    } else {
-      anyReferenceNonBlocking = true;
     }
   }
 
@@ -298,7 +295,6 @@ export function classifyIssue(
     );
     if ((state ?? '').toUpperCase() === 'OPEN') {
       if (isDependencyEpicExempt(ref, options)) {
-        anyReferenceNonBlocking = true;
         continue;
       }
       return {
@@ -309,8 +305,6 @@ export function classifyIssue(
     }
     if (state === 'UNRESOLVABLE') {
       unresolved.push(ref);
-    } else {
-      anyReferenceNonBlocking = true;
     }
   }
 
@@ -322,9 +316,11 @@ export function classifyIssue(
     };
   }
 
-  return anyReferenceNonBlocking
-    ? { orphan: true, reason: 'blocked_references_closed' }
-    : { orphan: true, reason: 'orphan' };
+  // Reaching here means blockedRefs/dependencyRefs was non-empty (the
+  // earlier both-empty check already returned `orphan`) and every ref
+  // resolved to a non-open, non-unresolvable state (closed, or an
+  // exempt open parent epic) -- never "no refs at all" again.
+  return { orphan: true, reason: 'blocked_references_closed' };
 }
 
 /**

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -19,7 +19,11 @@ import {
   parseAutopilotSuitability,
   rankAndRouteBySuitability,
 } from './autopilot-suitability.mts';
-import { extractBlockedByIssueNumbers } from './discover-readiness-check.mts';
+import {
+  extractBlockedByIssueNumbers,
+  extractDependencyIssueNumbers,
+  isParentEpicIssue,
+} from './discover-readiness-check.mts';
 import {
   annotateLeafClaimState,
   buildClaimStateResolution,
@@ -40,6 +44,7 @@ export type OrphanFilteredReason =
   | 'blocked_label'
   | 'authoring_label'
   | 'blocked_by_open_reference'
+  | 'open_dependency_reference'
   | 'unresolvable_reference';
 
 /** Classification verdict for one issue in the orphan filter. */
@@ -60,6 +65,7 @@ export type OrphanClassification =
       details: string;
     }
   | { orphan: false; reason: 'blocked_by_open_reference'; details: number }
+  | { orphan: false; reason: 'open_dependency_reference'; details: number }
   | { orphan: false; reason: 'unresolvable_reference'; details: number[] };
 
 interface OrphanIssueInput {
@@ -79,6 +85,16 @@ interface ClassifyIssueOptions {
   authoringLabelName?: unknown;
   blockedByHumanLabelName?: unknown;
   needsDecisionLabelName?: unknown;
+  roadmapLabelName?: unknown;
+  /**
+   * Lookup used **only** to resolve an open `Depends on #NNN` / task-list
+   * dependency reference's title/labels for the parent-epic exemption
+   * (#1536) — never for `Blocked by` references, which have no exemption,
+   * matching A3's own asymmetry in `discover-readiness-check.mts`. A
+   * reference absent from this map (or the map itself absent) fails
+   * closed: treated as not epic-exempt, so it still blocks.
+   */
+  openIssueDetailsByNumber?: Map<number, { title: unknown; labels: unknown }>;
 }
 
 interface FilterOrphanIssuesOptions {
@@ -89,6 +105,7 @@ interface FilterOrphanIssuesOptions {
   authoringLabelName?: unknown;
   blockedByHumanLabelName?: unknown;
   needsDecisionLabelName?: unknown;
+  roadmapLabelName?: unknown;
   authoringStaleAgeMs?: number;
   autopilotSuitabilityFloor?: number;
   autopilotSuitabilityEnabled?: boolean;
@@ -232,13 +249,28 @@ export function classifyIssue(
     };
   }
 
-  const refs = extractBlockedByReferences(body);
-  if (refs.length === 0) {
+  // Two independent reference families, matching A3's own dependency check
+  // in `discover-readiness-check.mts` (#1536): visible `Blocked by #NNN`
+  // lines (a hard sequential dependency, no exemption) and `Depends on
+  // #NNN` / task-list dependency references (which exempt an open parent
+  // epic / aggregate issue, mirroring `isParentEpicIssue`). A0-O passes
+  // survivors directly to A3.5 and skips A3 entirely, so without this
+  // second family a helper-driven run could select an orphan whose only
+  // open blocker is a dependency reference, even though the roadmap path
+  // would already filter it out. `Blocked by` is checked first (matching
+  // the original single-list order) so an issue that carries both kinds
+  // reports the same `blocked_by_open_reference` / `unresolvable_reference`
+  // reason it always has when that reference alone already blocks.
+  const blockedRefs = extractBlockedByReferences(body);
+  const dependencyRefs = extractDependencyIssueNumbers(body);
+  if (blockedRefs.length === 0 && dependencyRefs.length === 0) {
     return { orphan: true, reason: 'orphan' };
   }
 
   const unresolved: number[] = [];
-  for (const ref of refs) {
+  let anyReferenceNonBlocking = false;
+
+  for (const ref of blockedRefs) {
     const state = resolveIssueState(
       ref,
       options.issueStateByNumber,
@@ -253,6 +285,32 @@ export function classifyIssue(
     }
     if (state === 'UNRESOLVABLE') {
       unresolved.push(ref);
+    } else {
+      anyReferenceNonBlocking = true;
+    }
+  }
+
+  for (const ref of dependencyRefs) {
+    const state = resolveIssueState(
+      ref,
+      options.issueStateByNumber,
+      options.fetchIssueStateByNumber,
+    );
+    if ((state ?? '').toUpperCase() === 'OPEN') {
+      if (isDependencyEpicExempt(ref, options)) {
+        anyReferenceNonBlocking = true;
+        continue;
+      }
+      return {
+        orphan: false,
+        reason: 'open_dependency_reference',
+        details: ref,
+      };
+    }
+    if (state === 'UNRESOLVABLE') {
+      unresolved.push(ref);
+    } else {
+      anyReferenceNonBlocking = true;
     }
   }
 
@@ -260,11 +318,39 @@ export function classifyIssue(
     return {
       orphan: false,
       reason: 'unresolvable_reference',
-      details: unresolved,
+      details: [...new Set(unresolved)],
     };
   }
 
-  return { orphan: true, reason: 'blocked_references_closed' };
+  return anyReferenceNonBlocking
+    ? { orphan: true, reason: 'blocked_references_closed' }
+    : { orphan: true, reason: 'orphan' };
+}
+
+/**
+ * Resolve whether an **open** dependency reference is exempt as a parent
+ * epic / aggregate issue (#1536), reusing `isParentEpicIssue` from
+ * `discover-readiness-check.mts` rather than re-implementing the exemption.
+ * Only ever consulted for `Depends on` / task-list references, never for
+ * `Blocked by` references, matching A3's asymmetry. Fails closed (not
+ * exempt) when `openIssueDetailsByNumber` is absent or does not carry the
+ * referenced issue's details.
+ */
+function isDependencyEpicExempt(
+  ref: number,
+  options: ClassifyIssueOptions,
+): boolean {
+  const detail = options.openIssueDetailsByNumber?.get(ref);
+  if (!detail) {
+    return false;
+  }
+  return isParentEpicIssue(
+    {
+      title: String(detail.title ?? ''),
+      labels: new Set(normalizeLabels(detail.labels)),
+    },
+    normalizeRoadmapLabelName(options.roadmapLabelName),
+  );
 }
 
 export async function filterOrphanIssues(
@@ -282,6 +368,7 @@ export async function filterOrphanIssues(
     blocked_label: [],
     authoring_label: [],
     blocked_by_open_reference: [],
+    open_dependency_reference: [],
     unresolvable_reference: [],
   };
   const orphans: OrphanCandidate[] = [];
@@ -292,6 +379,22 @@ export async function filterOrphanIssues(
   }[] = [];
   const warnings: NonNullable<ReturnType<typeof buildAuthoringLabelWarning>>[] =
     [];
+  // Self-batch lookup for the dependency parent-epic exemption (#1536): in
+  // the CLI wiring `issues` is always the full open-issue batch
+  // (`fetchOpenIssues`), so any `Depends on` / task-list reference that
+  // resolves OPEN is guaranteed to already be present here — zero extra
+  // GitHub API calls. A reference outside this batch (e.g. a partial list
+  // passed directly to `filterOrphanIssues`, such as in a test) fails
+  // closed via `isDependencyEpicExempt`'s own absent-entry handling.
+  const openIssueDetailsByNumber = new Map(
+    issues.map(
+      (candidate) =>
+        [
+          candidate.number,
+          { title: candidate.title, labels: candidate.labels },
+        ] as const,
+    ),
+  );
 
   for (const issue of issues) {
     const result = classifyIssue(issue, {
@@ -301,6 +404,8 @@ export async function filterOrphanIssues(
       authoringLabelName: options.authoringLabelName,
       blockedByHumanLabelName: options.blockedByHumanLabelName,
       needsDecisionLabelName: options.needsDecisionLabelName,
+      roadmapLabelName: options.roadmapLabelName,
+      openIssueDetailsByNumber,
     });
 
     if (result.reason === 'unresolvable_reference') {
@@ -485,6 +590,7 @@ async function runCli() {
     authoringStaleAgeMs: policy.authoringStaleAgeMs,
     blockedByHumanLabelName: policy.blockedByHumanLabelName,
     needsDecisionLabelName: policy.needsDecisionLabelName,
+    roadmapLabelName: policy.roadmapLabelName,
     autopilotSuitabilityFloor: policy.autopilotSuitabilityFloor,
     autopilotSuitabilityEnabled: policy.autopilotSuitabilityEnabled,
     autopilot: args.autopilot,
@@ -610,12 +716,25 @@ Output schema:
     "blocked_label": [...],
     "authoring_label": [...],
     "blocked_by_open_reference": [...],
+    "open_dependency_reference": [...],
     "unresolvable_reference": [...]
   },
   "unresolvable": [{"issue": 1, "reference": 2, "reason": "issue-not-found-or-inaccessible"}],
   "warnings": [{"issueNumber": 1, "message": "Warning: ..."}],
   "counts": {"scanned": 0, "orphans": 0, "routed_to_human": 0, "filtered": {...}, "unresolvable": 0}
 }
+
+"filtered.open_dependency_reference" (#1536) mirrors A3's own dependency
+check in discover-readiness-check.mjs: a candidate whose body contains an
+open "Depends on #NNN" line or an open task-list "- [ ] #NNN" reference is
+excluded, UNLESS that referenced issue is itself a parent epic / aggregate
+issue (title starting with "roadmap", or carrying the configured roadmap
+label) -- matching A3's exemption exactly. This exemption never applies to
+"Blocked by #NNN" references (filtered.blocked_by_open_reference), which
+stay a hard sequential dependency with no exemption. An unresolvable
+dependency reference (issue not found or inaccessible) is treated as
+blocking, the same fail-safe "unresolvable_reference" applies to an
+unresolvable "Blocked by" reference.
 
 orphans are always ranked by authored autopilot-suitability score (high
 first; equal scores tie-break by lowest issue number). With --autopilot
@@ -672,6 +791,7 @@ function loadPolicy(policyPath: string) {
       authoringStaleAgeMs: authoringPolicy.staleAgeMs,
       blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
       needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+      roadmapLabelName: labelsPolicy.roadmapLabelName,
       autopilotSuitabilityFloor: resolveAutopilotSuitabilityFloor(config),
       autopilotSuitabilityEnabled: resolveAutopilotSuitabilityEnabled(config),
       // Passed through verbatim (raw, un-normalized) for
@@ -692,6 +812,7 @@ function loadPolicy(policyPath: string) {
       authoringStaleAgeMs: authoringPolicy.staleAgeMs,
       blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
       needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+      roadmapLabelName: labelsPolicy.roadmapLabelName,
       autopilotSuitabilityFloor: DEFAULT_AUTOPILOT_SUITABILITY_FLOOR,
       autopilotSuitabilityEnabled: true,
       // No config was readable, so buildClaimStateResolution falls back to
@@ -873,6 +994,17 @@ function normalizeNeedsDecisionLabelName(labelName: unknown): string {
   return typeof labelName === 'string' && labelName.length > 0
     ? labelName
     : POLICY_DEFAULTS.labels.needsDecisionLabelName;
+}
+
+/**
+ * Resolve the configured `labels.roadmapLabelName` for the dependency
+ * parent-epic exemption (#1536), following this file's established
+ * defensive-default pattern for the other configurable label names.
+ */
+function normalizeRoadmapLabelName(labelName: unknown): string {
+  return typeof labelName === 'string' && labelName.length > 0
+    ? labelName
+    : POLICY_DEFAULTS.labels.roadmapLabelName;
 }
 
 function fetchOpenIssues(repoRef: string) {

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -779,8 +779,19 @@ function normalizeLabels(labelsInput: unknown): Set<string> {
   return new Set();
 }
 
-function isParentEpicIssue(
-  issue: NormalizedIssue,
+/**
+ * Parent-epic / aggregate-issue exemption for the dependency check (#1536):
+ * an open dependency issue does not block when it is itself a roadmap/epic.
+ * Exported so `discover-orphan-filter.mts` can reuse this exact exemption for
+ * A0-O's own dependency check instead of re-implementing it (#1536). The
+ * parameter type is intentionally the minimal structural shape this function
+ * actually reads (not the full `NormalizedIssue`), so a reusing caller can
+ * pass any object with these two fields without constructing a full
+ * `NormalizedIssue` (`NormalizedIssue` itself stays structurally assignable,
+ * so this widening does not affect the call site below).
+ */
+export function isParentEpicIssue(
+  issue: { title: string; labels: Set<string> },
   roadmapLabelName: string = POLICY_DEFAULTS.labels.roadmapLabelName,
 ): boolean {
   // Title heuristic is intentionally independent of the configured roadmap

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -882,3 +882,167 @@ test('heartbeatOverdue:false when a later trusted heartbeat repost refreshes the
   });
   assert.equal(leaf701?.claimEligible, false);
 });
+
+test('filterOrphanIssues excludes an open non-epic Depends-on reference (#1536)', async () => {
+  const issues = [
+    {
+      number: 70,
+      title: 'candidate with an open dependency',
+      state: 'OPEN',
+      labels: [],
+      body: 'Depends on #71',
+      url: 'https://example.com/70',
+    },
+  ];
+
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map([[71, 'OPEN']]),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+  });
+
+  assert.equal(result.orphans.length, 0);
+  assert.equal(result.filtered.open_dependency_reference.length, 1);
+  assert.equal(result.filtered.open_dependency_reference[0].number, 70);
+});
+
+test('filterOrphanIssues excludes an open non-epic task-list dependency reference (#1536)', async () => {
+  const issues = [
+    {
+      number: 72,
+      title: 'candidate with an open task-list dependency',
+      state: 'OPEN',
+      labels: [],
+      body: '- [ ] #73',
+      url: 'https://example.com/72',
+    },
+  ];
+
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map([[73, 'OPEN']]),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+  });
+
+  assert.equal(result.orphans.length, 0);
+  assert.equal(result.filtered.open_dependency_reference.length, 1);
+  assert.equal(result.filtered.open_dependency_reference[0].number, 72);
+});
+
+test('filterOrphanIssues exempts an open Depends-on reference to a parent epic by title (#1536)', async () => {
+  const issues = [
+    {
+      number: 80,
+      title: 'candidate depending on a roadmap',
+      state: 'OPEN',
+      labels: [],
+      body: 'Depends on #81',
+      url: 'https://example.com/80',
+    },
+    {
+      number: 81,
+      title: 'roadmap: parent',
+      state: 'OPEN',
+      labels: [],
+      body: '',
+      url: 'https://example.com/81',
+    },
+  ];
+
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map([[81, 'OPEN']]),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+  });
+
+  assert.equal(result.filtered.open_dependency_reference.length, 0);
+  assert.deepEqual(
+    result.orphans.map((o) => o.number),
+    [80, 81],
+  );
+  assert.equal(
+    result.orphans.find((o) => o.number === 80)?.reason,
+    'blocked_references_closed',
+  );
+});
+
+test('filterOrphanIssues exempts an open Depends-on reference to a configured roadmap label (#1536)', async () => {
+  const issues = [
+    {
+      number: 90,
+      title: 'candidate depending on an epic',
+      state: 'OPEN',
+      labels: [],
+      body: 'Depends on #91',
+      url: 'https://example.com/90',
+    },
+    {
+      // Title deliberately does NOT start with "roadmap" so this exercises
+      // only the configured-label path, not the independent title heuristic.
+      number: 91,
+      title: 'parent epic',
+      state: 'OPEN',
+      labels: [{ name: 'epic' }],
+      body: '',
+      url: 'https://example.com/91',
+    },
+  ];
+
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map([[91, 'OPEN']]),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    roadmapLabelName: 'epic',
+  });
+
+  assert.equal(result.filtered.open_dependency_reference.length, 0);
+  assert.equal(
+    result.orphans.find((o) => o.number === 90)?.reason,
+    'blocked_references_closed',
+  );
+});
+
+test('filterOrphanIssues treats an unresolvable Depends-on reference as blocking (#1536)', async () => {
+  const issues = [
+    {
+      number: 92,
+      title: 'candidate with a missing dependency',
+      state: 'OPEN',
+      labels: [],
+      body: 'Depends on #999',
+      url: 'https://example.com/92',
+    },
+  ];
+
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+  });
+
+  assert.equal(result.orphans.length, 0);
+  assert.equal(result.filtered.unresolvable_reference.length, 1);
+  assert.deepEqual(result.unresolvable, [
+    {
+      issue: 92,
+      reference: 999,
+      reason: 'issue-not-found-or-inaccessible',
+    },
+  ]);
+});
+
+test('filterOrphanIssues keeps a closed Depends-on reference as an orphan candidate (#1536)', async () => {
+  const issues = [
+    {
+      number: 93,
+      title: 'candidate with a closed dependency',
+      state: 'OPEN',
+      labels: [],
+      body: 'Depends on #94',
+      url: 'https://example.com/93',
+    },
+  ];
+
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map([[94, 'CLOSED']]),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+  });
+
+  assert.equal(result.orphans.length, 1);
+  assert.equal(result.orphans[0].reason, 'blocked_references_closed');
+});


### PR DESCRIPTION
# Summary

`discover-orphan-filter` only checked labels/markers and visible
`Blocked by` references before returning `orphan`, so a helper-driven
A0-O run could select and claim an issue whose only open blocker was a
`Depends on #NNN` line or task-list reference, even though the same
issue reached via the roadmap path (A3, `discover-readiness-check.mjs`)
would already be filtered out. Export `isParentEpicIssue` from
`discover-readiness-check.mts` and reuse it (alongside the
already-exported `extractDependencyIssueNumbers`) in
`discover-orphan-filter.mts`, so both paths enforce the same
open-dependency check, including the parent-epic exemption and the
unresolvable-reference fail-safe.

## Linked issue

Closes #1536

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Refs #1524, whose own "Proposed change" section deliberately left this
helper-side enforcement open as a follow-up question.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (2522/2525 pass; the 3 failures in
      `tests/branch-conflict-state.test.mts` are a pre-existing,
      unrelated local-environment GPG-signing timeout in that file's
      `createTwoCommitRepo` fixture, which doesn't route through the
      file's own `gitNoSign` helper -- not touched by this PR)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (result: passed, pre-existing
      warnings only)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed