### PR TITLE
docs(workflow): document the weak-tier tool/retrieval contract

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -37,6 +37,7 @@ words:
   - kuron
   - kurone
   - kuroné
+  - ONNX
   - pylint
   - pytest
   - pyproject

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -81,8 +81,14 @@ their own targets.
   self-direction for contained, fully-specified tasks, but still show
   weak adherence to long multi-file instruction sets (the phi-4-mini
   class — roughly 128K context, tool calling supported — is the
-  reference example). Confine this tier to narrowly-scoped roles under
-  operator supervision:
+  reference example). Treat "tool calling supported" as a
+  runtime-specific claim, not a guarantee: field evidence found that a
+  local ONNX serving stack silently degraded structured tool-calls to
+  plain text with no error, so a model's stated capability listing tool
+  calling does not mean structured tool-calls are reliably available in
+  practice — see [Weak-model guardrails](#weak-model-guardrails) for
+  the harness-owned mitigation. Confine this tier to narrowly-scoped
+  roles under operator supervision:
   - executing a single, fully-specified `idd:ready` issue rather than
     Discover's open-ended candidate selection;
   - preferring a deterministic helper command (see
@@ -120,6 +126,25 @@ When a lightweight-tier model runs any part of this loop:
   profile, following the documented Markdown / `gh` / `jq` procedure
   directly is the normal, supported path for this tier too, not a stop
   condition.
+- **Weak-tier tool/retrieval contract**: have the harness — not the
+  model — own tool execution, query construction, and input-slice
+  quality (a clean, column-labeled, minimal slice rather than a raw
+  dump), and gate tool/retrieval use on a cheap uncertainty signal (for
+  example, self-consistency sampling: sample k responses, treat
+  unanimity as sufficient to skip retrieval and disagreement as the
+  trigger to search) rather than firing augmentation unconditionally.
+  Field evidence found unconditional "always augment on failure"
+  net-negative on a weak model (3/7 correct, below a 4/7
+  no-augmentation baseline) because retrieval corrupted facts the model
+  already knew, while a harness-owned self-consistency gate recovered
+  "don't retrieve what you already know" and a harness-owned web search
+  took a weak model from 1/4 to 4/4 correct on factual questions.
+- Retrieval augmentation is more reliably useful for a QA/spec step —
+  two conditions must hold: a knowledge gap exists, and the needed fact
+  is in the returned snippet — than for a mid-code-fix step, which
+  chains a third condition (the model must also transcribe the fact
+  correctly into code). It is not a substitute for fixing logic or
+  truncation failures, which retrieval cannot address.
 - Narrow the question before adding judges: when a weak model has to
   judge semantic quality, ask a narrow, falsifiable check instead of an
   open-ended review. The failure mode is correlated bias, not

--- a/docs/weak-model-lite-profile-design.md
+++ b/docs/weak-model-lite-profile-design.md
@@ -41,9 +41,14 @@ profile.
   **both** sufficient context **and** demonstrated self-direction for
   contained tasks, that still show weak adherence to long multi-file
   instruction sets (the phi-4-mini class — roughly 128K context, tool
-  calling supported — remains the reference example). The workflow
-  guide already confines this tier to narrowly-scoped roles under
-  operator supervision:
+  calling supported — remains the reference example; treat that
+  tool-calling claim as runtime-specific, not a guarantee — see
+  [Model capability expectations](idd-workflow.md#model-capability-expectations)
+  for the local/ONNX reliability caveat and
+  [Weak-model guardrails](idd-workflow.md#weak-model-guardrails) for the
+  harness-owned tool/retrieval mitigation). The workflow guide already
+  confines this tier to narrowly-scoped roles under operator
+  supervision:
   - executing a single, fully-specified `idd:ready` issue rather than
     Discover's open-ended candidate selection;
   - preferring a deterministic helper command over prose judgment

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -81,8 +81,14 @@ their own targets.
   self-direction for contained, fully-specified tasks, but still show
   weak adherence to long multi-file instruction sets (the phi-4-mini
   class — roughly 128K context, tool calling supported — is the
-  reference example). Confine this tier to narrowly-scoped roles under
-  operator supervision:
+  reference example). Treat "tool calling supported" as a
+  runtime-specific claim, not a guarantee: field evidence found that a
+  local ONNX serving stack silently degraded structured tool-calls to
+  plain text with no error, so a model's stated capability listing tool
+  calling does not mean structured tool-calls are reliably available in
+  practice — see [Weak-model guardrails](#weak-model-guardrails) for
+  the harness-owned mitigation. Confine this tier to narrowly-scoped
+  roles under operator supervision:
   - executing a single, fully-specified `idd:ready` issue rather than
     Discover's open-ended candidate selection;
   - preferring a deterministic helper command (see
@@ -122,6 +128,25 @@ When a lightweight-tier model runs any part of this loop:
   profile, following the documented Markdown / `gh` / `jq` procedure
   directly is the normal, supported path for this tier too, not a stop
   condition.
+- **Weak-tier tool/retrieval contract**: have the harness — not the
+  model — own tool execution, query construction, and input-slice
+  quality (a clean, column-labeled, minimal slice rather than a raw
+  dump), and gate tool/retrieval use on a cheap uncertainty signal (for
+  example, self-consistency sampling: sample k responses, treat
+  unanimity as sufficient to skip retrieval and disagreement as the
+  trigger to search) rather than firing augmentation unconditionally.
+  Field evidence found unconditional "always augment on failure"
+  net-negative on a weak model (3/7 correct, below a 4/7
+  no-augmentation baseline) because retrieval corrupted facts the model
+  already knew, while a harness-owned self-consistency gate recovered
+  "don't retrieve what you already know" and a harness-owned web search
+  took a weak model from 1/4 to 4/4 correct on factual questions.
+- Retrieval augmentation is more reliably useful for a QA/spec step —
+  two conditions must hold: a knowledge gap exists, and the needed fact
+  is in the returned snippet — than for a mid-code-fix step, which
+  chains a third condition (the model must also transcribe the fact
+  correctly into code). It is not a substitute for fixing logic or
+  truncation failures, which retrieval cannot address.
 - Narrow the question before adding judges: when a weak model has to
   judge semantic quality, ask a narrow, falsifiable check instead of an
   open-ended review. The failure mode is correlated bias, not


### PR DESCRIPTION
# Summary

Documents the weak-tier tool/retrieval contract in `docs/idd-workflow.md`
(and its `idd-template/docs/idd-workflow.md` mirror) and
`docs/weak-model-lite-profile-design.md`:

- Caveats the "tool calling supported" phrasing for the phi-4-mini-class
  low tier as runtime-specific, not a guarantee — field evidence found
  that a local ONNX serving stack silently degraded structured
  tool-calls to plain text with no error.
  `docs/weak-model-lite-profile-design.md`
  carries the caveat by cross-reference back to `idd-workflow.md`,
  consistent with its own stated principle of reusing the taxonomy
  "rather than inventing a parallel one."
- Adds a "Weak-tier tool/retrieval contract" bullet to "Weak-model
  guardrails": the harness — not the model — should own tool execution,
  query construction, and input-slice quality, gated on a cheap
  uncertainty signal (e.g. self-consistency sampling) rather than
  firing unconditionally.
- Adds a bullet noting retrieval augmentation is more reliable for a
  QA/spec step than a mid-code-fix step, and is not a substitute for
  fixing logic or truncation bugs.
- Adds "ONNX" to the cspell word list.

Both `docs/idd-workflow.md` and `idd-template/docs/idd-workflow.md` are
edited together because `audit/sync-manifest.json`'s `idd-workflow-doc`
sync pair uses `structure` mode, which only requires identical heading
text/level/order between the source-repo copy and the portable template
copy (body content may differ per repo) — sync-docs does not
auto-propagate prose for this pair.

## Linked issue

Closes #1551

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Sourced from issue #1551's cited independent field PoC
(<https://gist.github.com/kurone-kito/8f45ee1ec0c07e8a7fdc8c1f04e83654>):
a harness-owned web search took a weak model from 1/4 to 4/4 correct on
factual questions, while unconditional "always augment on failure" was
net-negative (3/7 vs. a 4/7 no-augmentation baseline) because retrieval
corrupted facts the model already knew — a harness-owned self-consistency
gate recovered "don't retrieve what you already know." Both new bullets
are framed as adopter-facing guidance for whoever specifies a weak-tier
execution contract, not a change to this repository's own tooling.

This PR's insertion point in "Weak-model guardrails" (after the
"Prefer a documented helper command" bullet) does not collide with
sibling PR #1588 (`Closes #1550`), which appended its own two bullets
at the end of the same list; both landed cleanly on rebase.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (includes the full `node --test` suite: 2525 pass, 0 fail)
- [x] `pnpm test` (docs-only change; ran as part of `pnpm lint` above)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed with 5 pre-existing,
      environment-only warnings unrelated to this diff)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
