### PR TITLE
docs(issue-authoring): sharpen effort hint with scope/uncertainty axes

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -799,9 +799,9 @@ itself: model speed shifts release to release, and concurrent agent
 runs distort wall-clock comparison. Do not anchor a hint to a specific
 token count or duration.
 
-**Scope-mismatch routing.** An estimate that does not fit even the `L`
-row's scope-and-uncertainty definition is a signal that the draft
-bundles multiple intents. Return to
+**Mis-scope routing.** An estimate that does not fit even the `L`
+row's scope-and-uncertainty definition is a mis-scope smell: the draft
+likely bundles multiple intents. Return to
 [Decompose and Draft](#2-decompose-and-draft) and split at intent level
 instead of publishing one oversized issue labeled `L`.
 

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -786,11 +786,24 @@ Effort is distinct from the autopilot-suitability score: suitability
 captures _autonomy_ (can an agent finish unattended), while effort
 captures _size_ (a fully-autonomous issue can still be large).
 
-| Hint | Meaning | Typical signals                                                                                     |
-| ---- | ------- | --------------------------------------------------------------------------------------------------- |
-| S    | Small   | One module / a few files; a single reviewable change; little or no review back-and-forth expected   |
-| M    | Medium  | A helper plus its callers, or one instruction surface with mirrors and tests                        |
-| L    | Large   | A new helper family, multi-file instruction rewrites, or work that tends to span many review rounds |
+| Hint         | Scope                                                                                             | Uncertainty                                                                                        | Example signals                                                                                     |
+| ------------ | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| **S** Small  | Touches one module or a small, contained file set                                                 | Little to no open design decision remains once the plan is drafted                                 | One module / a few files; a single reviewable change; little or no review back-and-forth expected   |
+| **M** Medium | Touches a helper plus its callers, or one instruction surface together with its mirrors and tests | At most one open design decision remains, resolvable during planning without a separate hold       | A helper plus its callers, or one instruction surface with mirrors and tests                        |
+| **L** Large  | Touches a new helper family, or spans a multi-file rewrite across several instruction surfaces    | Two or more open design decisions remain, or one decision whose resolution could reshape the scope | A new helper family, multi-file instruction rewrites, or work that tends to span many review rounds |
+
+**Calibration note.** Observed agent token usage or wall-clock duration
+from previously completed issues may be used to sanity-check a chosen
+band, but those are calibration observations only, never the unit
+itself: model speed shifts release to release, and concurrent agent
+runs distort wall-clock comparison. Do not anchor a hint to a specific
+token count or duration.
+
+**Scope-mismatch routing.** An estimate that does not fit even the `L`
+row's scope-and-uncertainty definition is a signal that the draft
+bundles multiple intents. Return to
+[Decompose and Draft](#2-decompose-and-draft) and split at intent level
+instead of publishing one oversized issue labeled `L`.
 
 The hint is recorded as a **footer at the end of the issue body** — a
 visible line paired with a hidden, prefix-aware machine marker, beside

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -184,9 +184,8 @@ rules.
   is drafted). Observed agent token usage or wall-clock duration is a
   calibration sanity-check only, never the unit.
 - An estimate that does not fit even `L`'s scope-and-uncertainty
-  definition signals a bundled-intent draft: return to Decompose and
-  Draft and split at intent level instead of publishing one oversized
-  issue.
+  definition is a mis-scope smell: return to Decompose and Draft and
+  split at intent level instead of publishing one oversized issue.
 - The hint only reorders candidates **within** one suitability-score
   band (after the score and optional desync rules, before the
   lowest-issue-number tie-break); it never skips, gates, crosses a score

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -178,7 +178,15 @@ first and leave large ones for a fresh session. See the
 section of the contract for the rubric, footer format, and binding
 rules.
 
-- `S` small · `M` medium · `L` large.
+- `S` small · `M` medium · `L` large — each band is now defined on two
+  axes: **scope** (how many files or subsystems the change touches) and
+  **uncertainty** (how many design decisions remain open once the plan
+  is drafted). Observed agent token usage or wall-clock duration is a
+  calibration sanity-check only, never the unit.
+- An estimate that does not fit even `L`'s scope-and-uncertainty
+  definition signals a bundled-intent draft: return to Decompose and
+  Draft and split at intent level instead of publishing one oversized
+  issue.
 - The hint only reorders candidates **within** one suitability-score
   band (after the score and optional desync rules, before the
   lowest-issue-number tie-break); it never skips, gates, crosses a score

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -799,9 +799,9 @@ itself: model speed shifts release to release, and concurrent agent
 runs distort wall-clock comparison. Do not anchor a hint to a specific
 token count or duration.
 
-**Scope-mismatch routing.** An estimate that does not fit even the `L`
-row's scope-and-uncertainty definition is a signal that the draft
-bundles multiple intents. Return to
+**Mis-scope routing.** An estimate that does not fit even the `L`
+row's scope-and-uncertainty definition is a mis-scope smell: the draft
+likely bundles multiple intents. Return to
 [Decompose and Draft](#2-decompose-and-draft) and split at intent level
 instead of publishing one oversized issue labeled `L`.
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -786,11 +786,24 @@ Effort is distinct from the autopilot-suitability score: suitability
 captures _autonomy_ (can an agent finish unattended), while effort
 captures _size_ (a fully-autonomous issue can still be large).
 
-| Hint | Meaning | Typical signals                                                                                     |
-| ---- | ------- | --------------------------------------------------------------------------------------------------- |
-| S    | Small   | One module / a few files; a single reviewable change; little or no review back-and-forth expected   |
-| M    | Medium  | A helper plus its callers, or one instruction surface with mirrors and tests                        |
-| L    | Large   | A new helper family, multi-file instruction rewrites, or work that tends to span many review rounds |
+| Hint         | Scope                                                                                             | Uncertainty                                                                                        | Example signals                                                                                     |
+| ------------ | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| **S** Small  | Touches one module or a small, contained file set                                                 | Little to no open design decision remains once the plan is drafted                                 | One module / a few files; a single reviewable change; little or no review back-and-forth expected   |
+| **M** Medium | Touches a helper plus its callers, or one instruction surface together with its mirrors and tests | At most one open design decision remains, resolvable during planning without a separate hold       | A helper plus its callers, or one instruction surface with mirrors and tests                        |
+| **L** Large  | Touches a new helper family, or spans a multi-file rewrite across several instruction surfaces    | Two or more open design decisions remain, or one decision whose resolution could reshape the scope | A new helper family, multi-file instruction rewrites, or work that tends to span many review rounds |
+
+**Calibration note.** Observed agent token usage or wall-clock duration
+from previously completed issues may be used to sanity-check a chosen
+band, but those are calibration observations only, never the unit
+itself: model speed shifts release to release, and concurrent agent
+runs distort wall-clock comparison. Do not anchor a hint to a specific
+token count or duration.
+
+**Scope-mismatch routing.** An estimate that does not fit even the `L`
+row's scope-and-uncertainty definition is a signal that the draft
+bundles multiple intents. Return to
+[Decompose and Draft](#2-decompose-and-draft) and split at intent level
+instead of publishing one oversized issue labeled `L`.
 
 The hint is recorded as a **footer at the end of the issue body** — a
 visible line paired with a hidden, prefix-aware machine marker, beside


### PR DESCRIPTION
# Summary

Sharpens the issue-authoring contract's effort-hint rubric
(`skills/issue-authoring/references/contract.md`, "Effort hint"
section):

- Redefines the `S`/`M`/`L` rows on two explicit axes — **scope**
  (files/subsystems touched) and **uncertainty** (open design
  decisions remaining) — while keeping the existing example signals
  as a third table column.
- Adds a **calibration note**: observed agent token/wall-clock ranges
  are sanity-check observations only, never the unit (model speed
  shifts release to release, and concurrent agent runs distort
  wall-clock comparison).
- Adds a **mis-scope routing note**: an estimate that doesn't fit even
  `L`'s definition is a mis-scope smell — return to Decompose and
  Draft and split at intent level instead of publishing one oversized
  `L` issue.

Applies the equivalent wording to the canonical maintenance mirror
`docs/issue-authoring-skill.md` (a short summary that links to the
contract's full section, extended in place rather than duplicating
the table) and regenerates the `.claude/skills/issue-authoring/`
copy with `node scripts/sync-docs.mjs --apply`.

## Linked issue

Closes #1594

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Part of the `soloscrum-spec-quality-adoption` roadmap (#1598), which
adopts several non-breaking practices from an evaluation of
`mew-ton/soloscrum`. This track anchors the effort rubric on the same
two axes soloscrum uses (scope x uncertainty) instead of example
surfaces alone, and keeps observed token/wall-clock data as a
calibration check rather than the unit, since model speed and
concurrent-run wall-clock both shift independently of true task size.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

Note: "Instruction files changed" here refers to the issue-authoring
**skill bundle** (`skills/issue-authoring/references/contract.md` and
its generated `.claude/` mirror) and the `docs/` maintenance mirror —
doc-only content. No `.github/instructions/` phase file, `scripts/`
file, or `bin/` file is touched. The `<!-- {marker-prefix}-effort:
S|M|L -->` marker grammar, the fail-safe-on-absence rule, and the
soft-tie-breaker consumption semantics are unchanged — verified by
diff review (the "Binding rules" list and footer template are outside
every changed hunk).

## Verification

- [x] `pnpm lint` (via `fix-validate` / `pre-push-validate`: biome,
      dprint, markdownlint, cspell)
- [ ] `pnpm test` (no test-covered code changed; doc-only diff)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (via `sync-docs.mjs --apply`,
      re-run to confirm no drift)
- [x] `node scripts/idd-doctor.mjs` (if applicable) — passed with 5
      pre-existing warnings unrelated to this diff

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — doc-only)
- [x] Context budget impact reviewed (targets budget-exempt
      `skills/` / `docs/` / `.claude/` surfaces per roadmap #1598's
      constraint 2; no `.github/instructions/` bundle touched)
