### PR TITLE
docs(idd): adopt observed-incident citation convention

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,6 +33,9 @@ layout.
 - Avoid hard-coded repository file counts in docs unless the number is
   mechanically maintained. If count-based wording is necessary, update
   every mirrored reference in the same commit.
+- When documentation or instruction text names an anti-pattern or
+  failure mode, cite the observed incident per
+  [docs/idd-design-rationale.md](../docs/idd-design-rationale.md#cite-the-observed-incident).
 - If uncertainties, concerns, or other implementation issues arise while
   running in Agent mode, promptly switch to Plan mode and ask the user
   questions. In such cases, provide one or more recommended response

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -395,8 +395,9 @@ decided trade-off rather than re-running the investigation.
 
 Issue #1596 adopted this convention after observing that
 `mew-ton/soloscrum` cites a concrete incident for each entry in its
-anti-pattern lists (for example, "Observed 2026-05-09 on issues `#8`
-and `#9`"). A citation raises the authority of a documented prohibition for
+anti-pattern lists (for example, "Observed 2026-05-09 on issues 8 and
+9" in that project's own tracker — not this repository's). A citation
+raises the authority of a documented prohibition for
 both humans and weak models — the rule reads as field evidence, not
 authorial preference — and lets a later session check whether the
 cited incident still motivates the rule.

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -388,3 +388,30 @@ adopter demand for skill-form delivery with a concrete use case the
 routing table does not already serve. A future audit that re-discovers
 this question (see issues #1413, #1414, and #1416) should treat it as a
 decided trade-off rather than re-running the investigation.
+
+## Documentation conventions
+
+### Cite the observed incident
+
+Issue #1596 adopted this convention after observing that
+`mew-ton/soloscrum` cites a concrete incident for each entry in its
+anti-pattern lists (for example, "Observed 2026-05-09 on issues `#8`
+and `#9`"). A citation raises the authority of a documented prohibition for
+both humans and weak models — the rule reads as field evidence, not
+authorial preference — and lets a later session check whether the
+cited incident still motivates the rule.
+
+When documentation or instruction text names an anti-pattern or
+failure mode, cite the concrete incident that motivated it: a date
+plus an issue or PR reference, when one exists. When no such incident
+exists — the rule is preventive rather than a response to something
+that already happened — say so explicitly, using the phrase
+"preventive; no observed incident yet", so the absence of a citation
+reads as a deliberate statement rather than an omission.
+
+The convention applies **forward**, to new or edited passages only.
+Retrofitting an existing passage with a citation is in scope on
+budget-exempt `docs/` surfaces, but out of scope for
+`.github/instructions/` files — do not edit an instruction file
+solely to add a citation; those bundle budgets already sit near their
+ceiling (see the headroom review in #1525).

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -372,3 +372,30 @@ adopter demand for skill-form delivery with a concrete use case the
 routing table does not already serve. A project that reaches this same
 conclusion independently should record it here rather than re-running
 the investigation.
+
+## Documentation conventions
+
+### Cite the observed incident
+
+kurone-kito/idd-skill#1596 adopted this convention after observing that
+`mew-ton/soloscrum` cites a concrete incident for each entry in its
+anti-pattern lists (for example, "Observed 2026-05-09 on issues `#8`
+and `#9`"). A citation raises the authority of a documented prohibition for
+both humans and weak models — the rule reads as field evidence, not
+authorial preference — and lets a later session check whether the
+cited incident still motivates the rule.
+
+When documentation or instruction text names an anti-pattern or
+failure mode, cite the concrete incident that motivated it: a date
+plus an issue or PR reference, when one exists. When no such incident
+exists — the rule is preventive rather than a response to something
+that already happened — say so explicitly, using the phrase
+"preventive; no observed incident yet", so the absence of a citation
+reads as a deliberate statement rather than an omission.
+
+The convention applies **forward**, to new or edited passages only.
+Retrofitting an existing passage with a citation is in scope on
+budget-exempt `docs/` surfaces, but out of scope for
+`.github/instructions/` files — do not edit an instruction file
+solely to add a citation; those bundle budgets already sit near their
+ceiling (see the headroom review in kurone-kito/idd-skill#1525).

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -379,8 +379,9 @@ the investigation.
 
 kurone-kito/idd-skill#1596 adopted this convention after observing that
 `mew-ton/soloscrum` cites a concrete incident for each entry in its
-anti-pattern lists (for example, "Observed 2026-05-09 on issues `#8`
-and `#9`"). A citation raises the authority of a documented prohibition for
+anti-pattern lists (for example, "Observed 2026-05-09 on issues 8 and
+9" in that project's own tracker — not this repository's). A citation
+raises the authority of a documented prohibition for
 both humans and weak models — the rule reads as field evidence, not
 authorial preference — and lets a later session check whether the
 cited incident still motivates the rule.


### PR DESCRIPTION
# Summary

Add a "Documentation conventions" > "Cite the observed incident"
section to `idd-template/docs/idd-design-rationale.md` and its
`docs/idd-design-rationale.md` mirror, plus a one-line pointer to it
from `.github/copilot-instructions.md`.

## Linked issue

Closes #1596

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`mew-ton/soloscrum` cites a concrete incident (date plus issue
reference) for each entry in its anti-pattern lists. This repository's
own `idd-design-rationale.md` already does the same informally in
several entries (for example, the A0-O trigger (c) roadmap-#1445
citation) without ever stating it as a convention. The new section
makes that practice explicit: cite the concrete incident when one
exists; when none exists, say so with the literal phrase "preventive;
no observed incident yet" so a missing citation reads as deliberate,
not an omission.

The sync-manifest pair for this doc (`idd-design-rationale-doc`) uses
`structure` mode, so only heading text/levels need to match between
the canonical template and this repo's own mirror — body content is
expected to diverge, exactly as every other section in the file
already does (the canonical copy stays portable/generic; the mirror
carries this repo's own citation style, `#NNNN` instead of
`kurone-kito/idd-skill#NNNN`).

The convention is scoped **forward** only: retrofitting existing
passages is in scope on budget-exempt `docs/` surfaces, but explicitly
out of scope for `.github/instructions/` files, whose bundle budgets
already sit near their ceiling (see #1525's headroom review). No
`.github/instructions/` file is touched by this PR.

## IDD impact

- [x] Instruction files changed (`.github/copilot-instructions.md`
      one-line pointer only; no `.github/instructions/*.instructions.md`
      phase file touched)
- [x] Template files changed (`idd-template/docs/idd-design-rationale.md`)
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (hosted CI's `lint` job, which runs
      `pnpm run lint:minimum`, passed; a local run saw 3 flaky test
      failures under this machine's heavy concurrent-session load,
      resolved per hosted-CI-is-authoritative)
- [x] `pnpm test` (covered by the same hosted `lint` job/`lint:minimum`
      run above, which includes `node --test tests/*.test.mts`)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
