### PR TITLE
feat(claim): detect activation-nonce collisions at the merge gate

### DIFF
--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -214,10 +214,13 @@ unit-tested, anticipating Resume Step 1 wiring — but the documented Resume
 Step 1 invocation (`idd-resume.instructions.md`) never threads either flag
 through, and a resumed process has no local memory of which nonce was its
 own to compare against in the first place. That cold-recovery design
-(kurone-kito/idd-skill#1529), plus the still-unwired merge write-gate
-(`summarizeClaimValidation`, kurone-kito/idd-skill#1528), are natural
-fast-follows (the same shared parse/render primitives already support them)
-— not silent design gaps.
+(kurone-kito/idd-skill#1529) is a natural fast-follow (the same shared
+parse/render primitives already support it) — not a silent design gap.
+The merge write-gate half landed separately: `summarizeClaimValidation`
+(`protocol-helpers.mts`) now shares the same `findActivationNonceWinner`
+primitive via `pre-merge-readiness.mjs`'s `--nonce` flag
+(kurone-kito/idd-skill#1528), closing the one AC-adjacent surface #1522
+deliberately deferred.
 
 ## Advisory wait
 

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -215,10 +215,13 @@ unit-tested, anticipating Resume Step 1 wiring — but the documented Resume
 Step 1 invocation (`idd-resume.instructions.md`) never threads either flag
 through, and a resumed process has no local memory of which nonce was its
 own to compare against in the first place. That cold-recovery design
-(kurone-kito/idd-skill#1529), plus the still-unwired merge write-gate
-(`summarizeClaimValidation`, kurone-kito/idd-skill#1528), are natural
-fast-follows (the same shared parse/render primitives already support them)
-— not silent design gaps.
+(kurone-kito/idd-skill#1529) is a natural fast-follow (the same shared
+parse/render primitives already support it) — not a silent design gap.
+The merge write-gate half landed separately: `summarizeClaimValidation`
+(`protocol-helpers.mts`) now shares the same `findActivationNonceWinner`
+primitive via `pre-merge-readiness.mjs`'s `--nonce` flag
+(kurone-kito/idd-skill#1528), closing the one AC-adjacent surface #1522
+deliberately deferred.
 
 ## Advisory wait
 

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -149,6 +149,28 @@ export function parseActivationNonceComment(body, createdAt) {
     createdAt,
   };
 }
+/**
+ * Resolve the winning activation nonce among `events` for `claimId`: the
+ * lexicographically earliest nonce (`.sort()`) among every trusted
+ * `activation-nonce` marker parsed from `events` whose `claimId` matches.
+ * This is a pure function of the observed nonce *set* (not post order or
+ * timestamp), so two sessions that both activated the same claim-id compute
+ * the identical winner once each has re-read the same trusted comment
+ * stream (#1522). `events` must already be trust-filtered by the caller --
+ * this function does no author checks of its own. Returns `null` when no
+ * matching `activation-nonce` marker exists -- callers must treat that as
+ * "no comparison possible," not a mismatch (#1522 AC3).
+ */
+export function findActivationNonceWinner(events, claimId) {
+  const nonces = events
+    .map((event) =>
+      parseActivationNonceComment(event.body ?? '', event.createdAt ?? ''),
+    )
+    .filter((marker) => Boolean(marker) && marker?.claimId === claimId)
+    .map((marker) => marker.nonce)
+    .sort();
+  return nonces.length > 0 ? nonces[0] : null;
+}
 export function parseReleaseComment(body) {
   const match = body
     .trimEnd()

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -139,6 +139,7 @@ const PRE_MERGE_READINESS_FLAG_SPEC = {
   '--expected-claim-id': { type: 'string' },
   '--agent-id': { type: 'string' },
   '--expected-agent-id': { type: 'string' },
+  '--nonce': { type: 'string' },
   '--now': { type: 'string' },
   '--help': { type: 'boolean', short: 'h' },
 };
@@ -391,6 +392,7 @@ export function collectPreMergeReadiness(argv) {
       prAuthorLogin,
       expectedClaimId: args.expectedClaimId,
       expectedAgentId: args.expectedAgentId,
+      expectedNonce: args.nonce,
       includeDispositionEvidence: true,
       requestCap: advisoryWaitPolicy.requestCap,
       pendingWindowMinutes: advisoryWaitPolicy.pendingWindowMinutes,
@@ -544,14 +546,23 @@ export function parseArgs(argv) {
     advisoryBotLogins: values['advisory-bot-logins'] ?? '',
     expectedClaimId: claimId ?? '',
     expectedAgentId: agentId ?? '',
+    nonce: values.nonce ?? '',
     now: values.now ?? '',
     help,
   };
 }
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/pre-merge-readiness.mjs --pr <number> --claim-issue <number> [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--idd-agent-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--claim-id <claim-id>] [--agent-id <agent-id>] [--now <ISO8601>]
+  node scripts/pre-merge-readiness.mjs --pr <number> --claim-issue <number> [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--idd-agent-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--claim-id <claim-id>] [--agent-id <agent-id>] [--nonce <token>] [--now <ISO8601>]
   Deprecated aliases (one release): --expected-claim-id -> --claim-id, --expected-agent-id -> --agent-id
+
+  --nonce <token>  this session's own recorded activation-nonce (#1522): when
+                    given alongside --claim-id, the merge-time write-gate also
+                    requires it to equal the winning trusted <!-- activation-
+                    nonce: ... --> marker for that claim-id, catching a second,
+                    independent activation of the same claim-id as a collision.
+                    Omit --nonce, or leave it empty, to skip this comparison
+                    entirely (backward compatible).
 `);
 }
 function normalizeComment(comment) {

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -558,11 +558,11 @@ function printHelp() {
 
   --nonce <token>  this session's own recorded activation-nonce (#1522): when
                     given alongside --claim-id, the merge-time write-gate also
-                    requires it to equal the winning trusted <!-- activation-
-                    nonce: ... --> marker for that claim-id, catching a second,
-                    independent activation of the same claim-id as a collision.
-                    Omit --nonce, or leave it empty, to skip this comparison
-                    entirely (backward compatible).
+                    requires it to equal the winning trusted
+                    <!-- activation-nonce: ... --> marker for that claim-id,
+                    catching a second, independent activation of the same
+                    claim-id as a collision. Omit --nonce, or leave it empty,
+                    to skip this comparison entirely (backward compatible).
 `);
 }
 function normalizeComment(comment) {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3912,22 +3912,7 @@ export function summarizeClaimValidation(claimEvents = [], options = {}) {
           },
     isStale: resolveStalePredicate(options.staleAgeMs),
   });
-  // #1528: mirrors evaluateResumeClaimRouting's activation-nonce-mismatch
-  // check (resume-claim-routing.mts) -- only meaningful once claim-id and
-  // agent-id already match, since claim-id alone cannot distinguish a
-  // second, independent activation of the same id. Trust-filter first
-  // (findActivationNonceWinner does no author checks of its own), matching
-  // how the resume-side caller pre-filters before calling the same shared
-  // primitive.
   const expectedNonce = String(options.expectedNonce ?? '').trim();
-  const activationNonceWinner = activeClaim
-    ? findActivationNonceWinner(
-        claimEvents.filter((event) =>
-          trustedAuthorPredicate(event.author?.login ?? ''),
-        ),
-        activeClaim.claimId,
-      )
-    : null;
   let reason = 'match';
   if (!activeClaim) {
     reason = 'missing-active-claim';
@@ -3935,13 +3920,28 @@ export function summarizeClaimValidation(claimEvents = [], options = {}) {
     reason = 'claim-id-mismatch';
   } else if (expectedAgentId && activeClaim.agentId !== expectedAgentId) {
     reason = 'agent-id-mismatch';
-  } else if (
-    expectedClaimId &&
-    activationNonceWinner !== null &&
-    expectedNonce &&
-    activationNonceWinner !== expectedNonce
-  ) {
-    reason = 'activation-nonce-mismatch';
+  } else if (expectedClaimId && expectedNonce) {
+    // #1528: mirrors evaluateResumeClaimRouting's activation-nonce-mismatch
+    // check (resume-claim-routing.mts) -- only meaningful once claim-id and
+    // agent-id already match, since claim-id alone cannot distinguish a
+    // second, independent activation of the same id. Computed lazily, here,
+    // so every pre-#1528 caller that never passes expectedNonce (the
+    // default) pays no parsing/sorting cost for it. Trust-filter first
+    // (findActivationNonceWinner does no author checks of its own), matching
+    // how the resume-side caller pre-filters before calling the same shared
+    // primitive.
+    const activationNonceWinner = findActivationNonceWinner(
+      claimEvents.filter((event) =>
+        trustedAuthorPredicate(event.author?.login ?? ''),
+      ),
+      activeClaim.claimId,
+    );
+    if (
+      activationNonceWinner !== null &&
+      activationNonceWinner !== expectedNonce
+    ) {
+      reason = 'activation-nonce-mismatch';
+    }
   }
   return {
     expectedClaimId,

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -24,6 +24,7 @@ export { DEFAULT_ADVISORY_BOT_LOGINS } from './advisory-wait-policy.mjs';
 export * from './marker-helpers.mjs';
 
 import {
+  findActivationNonceWinner,
   IDD_AGENT_DERIVED_MARKERS,
   isValidIsoTimestamp,
   operationalMarkerPrefix,
@@ -3911,6 +3912,22 @@ export function summarizeClaimValidation(claimEvents = [], options = {}) {
           },
     isStale: resolveStalePredicate(options.staleAgeMs),
   });
+  // #1528: mirrors evaluateResumeClaimRouting's activation-nonce-mismatch
+  // check (resume-claim-routing.mts) -- only meaningful once claim-id and
+  // agent-id already match, since claim-id alone cannot distinguish a
+  // second, independent activation of the same id. Trust-filter first
+  // (findActivationNonceWinner does no author checks of its own), matching
+  // how the resume-side caller pre-filters before calling the same shared
+  // primitive.
+  const expectedNonce = String(options.expectedNonce ?? '').trim();
+  const activationNonceWinner = activeClaim
+    ? findActivationNonceWinner(
+        claimEvents.filter((event) =>
+          trustedAuthorPredicate(event.author?.login ?? ''),
+        ),
+        activeClaim.claimId,
+      )
+    : null;
   let reason = 'match';
   if (!activeClaim) {
     reason = 'missing-active-claim';
@@ -3918,6 +3935,13 @@ export function summarizeClaimValidation(claimEvents = [], options = {}) {
     reason = 'claim-id-mismatch';
   } else if (expectedAgentId && activeClaim.agentId !== expectedAgentId) {
     reason = 'agent-id-mismatch';
+  } else if (
+    expectedClaimId &&
+    activationNonceWinner !== null &&
+    expectedNonce &&
+    activationNonceWinner !== expectedNonce
+  ) {
+    reason = 'activation-nonce-mismatch';
   }
   return {
     expectedClaimId,
@@ -4241,6 +4265,7 @@ export function buildPreMergeReadinessSummary(
     isForcedHandoffEnabled: options.isForcedHandoffEnabled,
     expectedClaimId: options.expectedClaimId,
     expectedAgentId: options.expectedAgentId,
+    expectedNonce: options.expectedNonce,
     staleAgeMs: options.staleAgeMs,
   });
   const waivableCheckSelectors = options.waivableCheckSelectors ?? null;

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3932,7 +3932,7 @@ export function summarizeClaimValidation(claimEvents = [], options = {}) {
     // primitive.
     const activationNonceWinner = findActivationNonceWinner(
       claimEvents.filter((event) =>
-        trustedAuthorPredicate(event.author?.login ?? ''),
+        trustedAuthorPredicate(event.author?.login ?? event.user?.login ?? ''),
       ),
       activeClaim.claimId,
     );

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -14,9 +14,9 @@ import { normalizePolicyConfig } from './policy-helpers.mjs';
 import {
   buildForcedHandoffEnableGate,
   DEFAULT_STALE_AGE_MS,
+  findActivationNonceWinner,
   isStaleByAge,
   normalizeLinkedPrReference,
-  parseActivationNonceComment,
   parseClaimComment,
   resolveActiveClaim,
 } from './protocol-helpers.mjs';
@@ -527,25 +527,10 @@ function findLaterCompetingClaim(events, activeClaim) {
     created_at: contenders[0].createdAt,
   };
 }
-/**
- * Resolve the winning activation nonce among trusted `activation-nonce`
- * events for `claimId`: the lexicographically earliest nonce (`.sort()`),
- * mirroring how `findSameSecondContenders` above already sorts colliding
- * claim-ids the same way. This is a pure function of the
- * observed nonce *set* (not post order or timestamp), so two sessions that
- * both activated the same claim-id compute the identical winner once each
- * has re-read the same trusted comment stream. Returns `null` when no
- * trusted `activation-nonce` marker exists for `claimId` -- callers must
- * treat that as "no comparison possible," not a mismatch (#1522 AC3).
- */
-function findActivationNonceWinner(events, claimId) {
-  const nonces = events
-    .map((event) => parseActivationNonceComment(event.body, event.createdAt))
-    .filter((marker) => Boolean(marker) && marker?.claimId === claimId)
-    .map((marker) => marker.nonce)
-    .sort();
-  return nonces.length > 0 ? nonces[0] : null;
-}
+// `findActivationNonceWinner` moved to marker-helpers.mts (#1528) so the
+// F2/F3 merge-time write-gate (`summarizeClaimValidation` in
+// protocol-helpers.mts) can share the identical primitive instead of
+// forking its own copy. Imported above from './protocol-helpers.mts'.
 function parseLegacyClaimComment(body, createdAt) {
   const match = String(body ?? '')
     .trimEnd()

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -264,6 +264,41 @@ export function parseActivationNonceComment(
   };
 }
 
+/** Minimal comment shape consumed by {@link findActivationNonceWinner}. */
+export interface NonceEventLike {
+  body?: string | null;
+  createdAt?: string | null;
+}
+
+/**
+ * Resolve the winning activation nonce among `events` for `claimId`: the
+ * lexicographically earliest nonce (`.sort()`) among every trusted
+ * `activation-nonce` marker parsed from `events` whose `claimId` matches.
+ * This is a pure function of the observed nonce *set* (not post order or
+ * timestamp), so two sessions that both activated the same claim-id compute
+ * the identical winner once each has re-read the same trusted comment
+ * stream (#1522). `events` must already be trust-filtered by the caller --
+ * this function does no author checks of its own. Returns `null` when no
+ * matching `activation-nonce` marker exists -- callers must treat that as
+ * "no comparison possible," not a mismatch (#1522 AC3).
+ */
+export function findActivationNonceWinner(
+  events: NonceEventLike[],
+  claimId: string,
+): string | null {
+  const nonces = events
+    .map((event) =>
+      parseActivationNonceComment(event.body ?? '', event.createdAt ?? ''),
+    )
+    .filter(
+      (marker): marker is ParsedActivationNonceMarker =>
+        Boolean(marker) && marker?.claimId === claimId,
+    )
+    .map((marker) => marker.nonce)
+    .sort();
+  return nonces.length > 0 ? nonces[0] : null;
+}
+
 export function parseReleaseComment(body: string): ParsedReleaseMarker | null {
   const match = body
     .trimEnd()

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -301,6 +301,11 @@ interface PreMergeReadinessArgs {
   advisoryBotLogins: string;
   expectedClaimId: string;
   expectedAgentId: string;
+  // #1528: this caller's own recorded activation-nonce (#1522), forwarded
+  // to buildPreMergeReadinessSummary's activation-nonce collision check.
+  // Empty when omitted, which skips that check entirely (backward
+  // compatible).
+  nonce: string;
   now: string;
   help: boolean;
 }
@@ -325,6 +330,7 @@ const PRE_MERGE_READINESS_FLAG_SPEC = {
   '--expected-claim-id': { type: 'string' },
   '--agent-id': { type: 'string' },
   '--expected-agent-id': { type: 'string' },
+  '--nonce': { type: 'string' },
   '--now': { type: 'string' },
   '--help': { type: 'boolean', short: 'h' },
 } as const;
@@ -606,6 +612,7 @@ export function collectPreMergeReadiness(
       prAuthorLogin,
       expectedClaimId: args.expectedClaimId,
       expectedAgentId: args.expectedAgentId,
+      expectedNonce: args.nonce,
       includeDispositionEvidence: true,
       requestCap: advisoryWaitPolicy.requestCap,
       pendingWindowMinutes: advisoryWaitPolicy.pendingWindowMinutes,
@@ -780,6 +787,7 @@ export function parseArgs(argv: string[]): PreMergeReadinessArgs {
       (values['advisory-bot-logins'] as string | undefined) ?? '',
     expectedClaimId: claimId ?? '',
     expectedAgentId: agentId ?? '',
+    nonce: (values.nonce as string | undefined) ?? '',
     now: (values.now as string | undefined) ?? '',
     help,
   };
@@ -787,8 +795,16 @@ export function parseArgs(argv: string[]): PreMergeReadinessArgs {
 
 function printHelp(): void {
   process.stdout.write(`Usage:
-  node scripts/pre-merge-readiness.mjs --pr <number> --claim-issue <number> [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--idd-agent-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--claim-id <claim-id>] [--agent-id <agent-id>] [--now <ISO8601>]
+  node scripts/pre-merge-readiness.mjs --pr <number> --claim-issue <number> [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--idd-agent-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--claim-id <claim-id>] [--agent-id <agent-id>] [--nonce <token>] [--now <ISO8601>]
   Deprecated aliases (one release): --expected-claim-id -> --claim-id, --expected-agent-id -> --agent-id
+
+  --nonce <token>  this session's own recorded activation-nonce (#1522): when
+                    given alongside --claim-id, the merge-time write-gate also
+                    requires it to equal the winning trusted <!-- activation-
+                    nonce: ... --> marker for that claim-id, catching a second,
+                    independent activation of the same claim-id as a collision.
+                    Omit --nonce, or leave it empty, to skip this comparison
+                    entirely (backward compatible).
 `);
 }
 

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -800,11 +800,11 @@ function printHelp(): void {
 
   --nonce <token>  this session's own recorded activation-nonce (#1522): when
                     given alongside --claim-id, the merge-time write-gate also
-                    requires it to equal the winning trusted <!-- activation-
-                    nonce: ... --> marker for that claim-id, catching a second,
-                    independent activation of the same claim-id as a collision.
-                    Omit --nonce, or leave it empty, to skip this comparison
-                    entirely (backward compatible).
+                    requires it to equal the winning trusted
+                    <!-- activation-nonce: ... --> marker for that claim-id,
+                    catching a second, independent activation of the same
+                    claim-id as a collision. Omit --nonce, or leave it empty,
+                    to skip this comparison entirely (backward compatible).
 `);
 }
 

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4989,7 +4989,7 @@ export function summarizeClaimValidation(
     // primitive.
     const activationNonceWinner = findActivationNonceWinner(
       claimEvents.filter((event) =>
-        trustedAuthorPredicate(event.author?.login ?? ''),
+        trustedAuthorPredicate(event.author?.login ?? event.user?.login ?? ''),
       ),
       activeClaim.claimId,
     );

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4968,22 +4968,7 @@ export function summarizeClaimValidation(
     isStale: resolveStalePredicate(options.staleAgeMs),
   });
 
-  // #1528: mirrors evaluateResumeClaimRouting's activation-nonce-mismatch
-  // check (resume-claim-routing.mts) -- only meaningful once claim-id and
-  // agent-id already match, since claim-id alone cannot distinguish a
-  // second, independent activation of the same id. Trust-filter first
-  // (findActivationNonceWinner does no author checks of its own), matching
-  // how the resume-side caller pre-filters before calling the same shared
-  // primitive.
   const expectedNonce = String(options.expectedNonce ?? '').trim();
-  const activationNonceWinner = activeClaim
-    ? findActivationNonceWinner(
-        claimEvents.filter((event) =>
-          trustedAuthorPredicate(event.author?.login ?? ''),
-        ),
-        activeClaim.claimId,
-      )
-    : null;
 
   let reason = 'match';
   if (!activeClaim) {
@@ -4992,13 +4977,28 @@ export function summarizeClaimValidation(
     reason = 'claim-id-mismatch';
   } else if (expectedAgentId && activeClaim.agentId !== expectedAgentId) {
     reason = 'agent-id-mismatch';
-  } else if (
-    expectedClaimId &&
-    activationNonceWinner !== null &&
-    expectedNonce &&
-    activationNonceWinner !== expectedNonce
-  ) {
-    reason = 'activation-nonce-mismatch';
+  } else if (expectedClaimId && expectedNonce) {
+    // #1528: mirrors evaluateResumeClaimRouting's activation-nonce-mismatch
+    // check (resume-claim-routing.mts) -- only meaningful once claim-id and
+    // agent-id already match, since claim-id alone cannot distinguish a
+    // second, independent activation of the same id. Computed lazily, here,
+    // so every pre-#1528 caller that never passes expectedNonce (the
+    // default) pays no parsing/sorting cost for it. Trust-filter first
+    // (findActivationNonceWinner does no author checks of its own), matching
+    // how the resume-side caller pre-filters before calling the same shared
+    // primitive.
+    const activationNonceWinner = findActivationNonceWinner(
+      claimEvents.filter((event) =>
+        trustedAuthorPredicate(event.author?.login ?? ''),
+      ),
+      activeClaim.claimId,
+    );
+    if (
+      activationNonceWinner !== null &&
+      activationNonceWinner !== expectedNonce
+    ) {
+      reason = 'activation-nonce-mismatch';
+    }
   }
 
   return {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -31,6 +31,7 @@ import type {
   ParsedReviewWatermark,
 } from './marker-helpers.mts';
 import {
+  findActivationNonceWinner,
   IDD_AGENT_DERIVED_MARKERS,
   isValidIsoTimestamp,
   operationalMarkerPrefix,
@@ -4881,6 +4882,15 @@ export function summarizeClaimValidation(
     prFirstCommitAt?: string | null;
     expectedClaimId?: unknown;
     expectedAgentId?: unknown;
+    // #1528: this session's own recorded activation-nonce (#1522), so the
+    // merge-time write-gate can detect a second, independent activation of
+    // the same claim-id -- the sticky forced-handoff adopt-verbatim
+    // collision -- the same way resume-claim-routing.mts's A5(c) resume
+    // check already does. Omitted (or no trusted activation-nonce marker
+    // exists for the active claim-id) skips the comparison entirely,
+    // keeping the claim-id/agent-id-only outcome (#1522 AC3, backward
+    // compatible with every caller that predates this option).
+    expectedNonce?: unknown;
     isTrustedAuthor?: (login: string) => boolean;
     forcedHandoffEnabled?: boolean;
     isForcedHandoffEnabled?: (
@@ -4958,6 +4968,23 @@ export function summarizeClaimValidation(
     isStale: resolveStalePredicate(options.staleAgeMs),
   });
 
+  // #1528: mirrors evaluateResumeClaimRouting's activation-nonce-mismatch
+  // check (resume-claim-routing.mts) -- only meaningful once claim-id and
+  // agent-id already match, since claim-id alone cannot distinguish a
+  // second, independent activation of the same id. Trust-filter first
+  // (findActivationNonceWinner does no author checks of its own), matching
+  // how the resume-side caller pre-filters before calling the same shared
+  // primitive.
+  const expectedNonce = String(options.expectedNonce ?? '').trim();
+  const activationNonceWinner = activeClaim
+    ? findActivationNonceWinner(
+        claimEvents.filter((event) =>
+          trustedAuthorPredicate(event.author?.login ?? ''),
+        ),
+        activeClaim.claimId,
+      )
+    : null;
+
   let reason = 'match';
   if (!activeClaim) {
     reason = 'missing-active-claim';
@@ -4965,6 +4992,13 @@ export function summarizeClaimValidation(
     reason = 'claim-id-mismatch';
   } else if (expectedAgentId && activeClaim.agentId !== expectedAgentId) {
     reason = 'agent-id-mismatch';
+  } else if (
+    expectedClaimId &&
+    activationNonceWinner !== null &&
+    expectedNonce &&
+    activationNonceWinner !== expectedNonce
+  ) {
+    reason = 'activation-nonce-mismatch';
   }
 
   return {
@@ -5261,6 +5295,10 @@ export function buildPreMergeReadinessSummary(
     prAuthorLogin?: string | null;
     expectedClaimId?: unknown;
     expectedAgentId?: unknown;
+    // #1528: forwarded to summarizeClaimValidation's activation-nonce
+    // collision check below. Omitted by every caller that predates this
+    // option (unchanged pre-#1528 behavior).
+    expectedNonce?: unknown;
     viewerLogin?: string | null;
     viewerTeamSlugs?: unknown[];
     viewerAppSlug?: string | null;
@@ -5430,6 +5468,7 @@ export function buildPreMergeReadinessSummary(
     isForcedHandoffEnabled: options.isForcedHandoffEnabled,
     expectedClaimId: options.expectedClaimId,
     expectedAgentId: options.expectedAgentId,
+    expectedNonce: options.expectedNonce,
     staleAgeMs: options.staleAgeMs,
   });
   const waivableCheckSelectors = options.waivableCheckSelectors ?? null;

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -14,16 +14,15 @@ import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mts';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mts';
 import { normalizePolicyConfig } from './policy-helpers.mts';
 import type {
-  ParsedActivationNonceMarker,
   ParsedClaimMarker,
   ParsedForcedHandoffMarker,
 } from './protocol-helpers.mts';
 import {
   buildForcedHandoffEnableGate,
   DEFAULT_STALE_AGE_MS,
+  findActivationNonceWinner,
   isStaleByAge,
   normalizeLinkedPrReference,
-  parseActivationNonceComment,
   parseClaimComment,
   resolveActiveClaim,
 } from './protocol-helpers.mts';
@@ -720,31 +719,10 @@ function findLaterCompetingClaim(
   };
 }
 
-/**
- * Resolve the winning activation nonce among trusted `activation-nonce`
- * events for `claimId`: the lexicographically earliest nonce (`.sort()`),
- * mirroring how `findSameSecondContenders` above already sorts colliding
- * claim-ids the same way. This is a pure function of the
- * observed nonce *set* (not post order or timestamp), so two sessions that
- * both activated the same claim-id compute the identical winner once each
- * has re-read the same trusted comment stream. Returns `null` when no
- * trusted `activation-nonce` marker exists for `claimId` -- callers must
- * treat that as "no comparison possible," not a mismatch (#1522 AC3).
- */
-function findActivationNonceWinner(
-  events: NormalizedClaimEvent[],
-  claimId: string,
-): string | null {
-  const nonces = events
-    .map((event) => parseActivationNonceComment(event.body, event.createdAt))
-    .filter(
-      (marker): marker is ParsedActivationNonceMarker =>
-        Boolean(marker) && marker?.claimId === claimId,
-    )
-    .map((marker) => marker.nonce)
-    .sort();
-  return nonces.length > 0 ? nonces[0] : null;
-}
+// `findActivationNonceWinner` moved to marker-helpers.mts (#1528) so the
+// F2/F3 merge-time write-gate (`summarizeClaimValidation` in
+// protocol-helpers.mts) can share the identical primitive instead of
+// forking its own copy. Imported above from './protocol-helpers.mts'.
 
 function parseLegacyClaimComment(
   body: string,

--- a/tests/marker-helpers-facade.test.mts
+++ b/tests/marker-helpers-facade.test.mts
@@ -18,6 +18,7 @@ const SAMPLE_NAMES = [
   'renderUnclaimedByMarker',
   'renderActivationNonceMarker',
   'parseActivationNonceComment',
+  'findActivationNonceWinner',
   'renderReviewWatermarkMarker',
   'renderReviewBaselineMarker',
   'renderAdvisoryWaitMarker',

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -3408,6 +3408,118 @@ test('summarizeClaimValidation does not trust all authors when trusted marker se
   assert.equal(summary.reason, 'missing-active-claim');
 });
 
+// #1528: the F2/F3 merge-time write-gate's activation-nonce collision
+// check, mirroring evaluateResumeClaimRouting's own activation-nonce
+// coverage in tests/resume-claim-routing.test.mts (same shared
+// findActivationNonceWinner primitive, same #1522 marker format).
+test('summarizeClaimValidation: matching nonce keeps match (no collision)', () => {
+  const claimEvents = [
+    {
+      body: '<!-- claimed-by: copilot claim-abc supersedes: none 2026-05-12T09:00:00Z branch: issue/1-task -->',
+      createdAt: '2026-05-12T09:00:00Z',
+      author: { login: 'maintainer' },
+    },
+    {
+      body: '<!-- activation-nonce: copilot claim-abc nonce-mine 2026-05-12T09:00:05Z -->',
+      createdAt: '2026-05-12T09:00:05Z',
+      author: { login: 'maintainer' },
+    },
+  ];
+
+  const summary = summarizeClaimValidation(claimEvents, {
+    trustedMarkerLogins: ['maintainer'],
+    expectedClaimId: 'claim-abc',
+    expectedAgentId: 'copilot',
+    expectedNonce: 'nonce-mine',
+  });
+
+  assert.equal(summary.claimLost, false);
+  assert.equal(summary.reason, 'match');
+});
+
+test('summarizeClaimValidation: mismatched nonce routes to the contested/stop path', () => {
+  const claimEvents = [
+    {
+      body: '<!-- claimed-by: copilot claim-abc supersedes: none 2026-05-12T09:00:00Z branch: issue/1-task -->',
+      createdAt: '2026-05-12T09:00:00Z',
+      author: { login: 'maintainer' },
+    },
+    {
+      body: '<!-- activation-nonce: copilot claim-abc nonce-aaa 2026-05-12T09:00:05Z -->',
+      createdAt: '2026-05-12T09:00:05Z',
+      author: { login: 'maintainer' },
+    },
+    {
+      body: '<!-- activation-nonce: copilot claim-abc nonce-zzz 2026-05-12T09:00:07Z -->',
+      createdAt: '2026-05-12T09:00:07Z',
+      author: { login: 'maintainer' },
+    },
+  ];
+
+  // "nonce-aaa" sorts first ASCII and wins; the displaced session's own
+  // recorded nonce ("nonce-zzz") loses, the same second-activation
+  // collision resume-claim-routing.mts already catches at claim time.
+  const summary = summarizeClaimValidation(claimEvents, {
+    trustedMarkerLogins: ['maintainer'],
+    expectedClaimId: 'claim-abc',
+    expectedAgentId: 'copilot',
+    expectedNonce: 'nonce-zzz',
+  });
+
+  assert.equal(summary.claimLost, true);
+  assert.equal(summary.reason, 'activation-nonce-mismatch');
+  assert.equal(summary.matchesExpectedClaim, false);
+});
+
+test('summarizeClaimValidation: no activation-nonce marker skips the comparison (AC3 backward compatibility)', () => {
+  const claimEvents = [
+    {
+      body: '<!-- claimed-by: copilot claim-abc supersedes: none 2026-05-12T09:00:00Z branch: issue/1-task -->',
+      createdAt: '2026-05-12T09:00:00Z',
+      author: { login: 'maintainer' },
+    },
+  ];
+
+  const summary = summarizeClaimValidation(claimEvents, {
+    trustedMarkerLogins: ['maintainer'],
+    expectedClaimId: 'claim-abc',
+    expectedAgentId: 'copilot',
+    expectedNonce: 'nonce-mine',
+  });
+
+  assert.equal(summary.claimLost, false);
+  assert.equal(summary.reason, 'match');
+});
+
+test('summarizeClaimValidation: omitting expectedNonce opts out of the comparison entirely', () => {
+  const claimEvents = [
+    {
+      body: '<!-- claimed-by: copilot claim-abc supersedes: none 2026-05-12T09:00:00Z branch: issue/1-task -->',
+      createdAt: '2026-05-12T09:00:00Z',
+      author: { login: 'maintainer' },
+    },
+    {
+      body: '<!-- activation-nonce: copilot claim-abc nonce-aaa 2026-05-12T09:00:05Z -->',
+      createdAt: '2026-05-12T09:00:05Z',
+      author: { login: 'maintainer' },
+    },
+    {
+      body: '<!-- activation-nonce: copilot claim-abc nonce-zzz 2026-05-12T09:00:07Z -->',
+      createdAt: '2026-05-12T09:00:07Z',
+      author: { login: 'maintainer' },
+    },
+  ];
+
+  const summary = summarizeClaimValidation(claimEvents, {
+    trustedMarkerLogins: ['maintainer'],
+    expectedClaimId: 'claim-abc',
+    expectedAgentId: 'copilot',
+  });
+
+  assert.equal(summary.claimLost, false);
+  assert.equal(summary.reason, 'match');
+});
+
 test('summarizeClaimValidation requires linked-pr match for issue-plus-pr handoff', () => {
   const claimEvents = [
     {
@@ -5231,6 +5343,21 @@ test('parseArgs: valid --pr / --claim-issue parse to positive integers', () => {
   const args = parseArgs(['--pr', '1082', '--claim-issue', '1076']);
   assert.equal(args.prNumber, 1082);
   assert.equal(args.claimIssueNumber, 1076);
+});
+
+test('parseArgs: --nonce (#1528) defaults to empty and round-trips when given', () => {
+  const withoutNonce = parseArgs(['--pr', '1082', '--claim-issue', '1076']);
+  assert.equal(withoutNonce.nonce, '');
+
+  const withNonce = parseArgs([
+    '--pr',
+    '1082',
+    '--claim-issue',
+    '1076',
+    '--nonce',
+    'nonce-mine',
+  ]);
+  assert.equal(withNonce.nonce, 'nonce-mine');
 });
 
 test('parseArgs: a flag-shaped value throws instead of consuming the flag', () => {


### PR DESCRIPTION
# Summary

Adds an activation-nonce collision check to `summarizeClaimValidation` (the
F2/F3 merge-time claim-state check), mirroring the check
`evaluateResumeClaimRouting` (A5(c) resume claim check) already performs.
#1522's design rationale named this the merge write-gate's deliberately
deferred fast-follow, not a design gap.

## Linked issue

Closes #1528

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`findActivationNonceWinner` moved from `resume-claim-routing.mts` (private,
unexported) to `marker-helpers.mts` (exported, re-exported through
`protocol-helpers.mts`'s facade) so both the resume-side and merge-side
callers share the identical primitive instead of forking a copy.
`summarizeClaimValidation` gained an `expectedNonce` option: when the active
claim-id already matches and a trusted `activation-nonce` marker exists for
it, a mismatch against `expectedNonce` now routes through the same
`claimLost`/contested path an existing claim-id or agent-id mismatch already
uses. No marker for the active claim-id, or no `expectedNonce` passed, skips
the comparison entirely (#1522 AC3, backward compatible with every existing
caller). `pre-merge-readiness.mjs` gained a `--nonce` flag threading this
through; `idd-merge-execute.mjs` picks it up automatically via its existing
verbatim flag passthrough (no changes needed there). Instruction-level
wiring (having an E14/F2 session actually pass its own recorded nonce) is
deliberately out of scope here, mirroring how the resume-side flag also
predates its own Resume Step 1 wiring (#1529) -- this PR builds the
mechanism and makes it CLI-reachable, per the issue's acceptance criteria.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

3 pre-existing `branch-conflict-state.test.mts` failures
(`classifyBranchConflictState`) reproduce identically on a clean `main`
checkout, under both `node --test` and `npx tsx --test` -- unrelated to this
change (tracked separately by #1535).

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
