### PR TITLE
fix(branch-conflict-state): resolve merge-base when PR head is shallow

### DIFF
--- a/scripts/branch-conflict-state.mjs
+++ b/scripts/branch-conflict-state.mjs
@@ -123,6 +123,7 @@ export async function classifyBranchConflictState(prNumber, options = {}) {
     prBaseSha,
     prHeadRef,
     prBaseRef,
+    prNumber,
     mergeable,
     mergeStateStatus,
     notes,
@@ -154,6 +155,7 @@ function deriveBranchState({
   prHeadSha,
   prBaseSha,
   prBaseRef,
+  prNumber,
   mergeable,
   mergeStateStatus,
   notes,
@@ -170,6 +172,7 @@ function deriveBranchState({
           prHeadSha,
           prBaseSha,
           prBaseRef,
+          prNumber,
           owner,
           repo,
           notes,
@@ -199,6 +202,7 @@ function deriveBranchState({
       prHeadSha,
       prBaseSha,
       prBaseRef,
+      prNumber,
       owner,
       repo,
       notes,
@@ -233,6 +237,7 @@ function deriveBranchState({
       prHeadSha,
       prBaseSha,
       prBaseRef,
+      prNumber,
       owner,
       repo,
       notes,
@@ -268,6 +273,7 @@ function deriveBranchState({
       prHeadSha,
       prBaseSha,
       prBaseRef,
+      prNumber,
       owner,
       repo,
       notes,
@@ -337,19 +343,59 @@ export function resolveMergeBaseWithRetry(
 }
 /**
  * Read-only local `git merge-base` lookup, falling back to a bounded,
- * progressively deeper fetch of the base ref when the base commit is not
- * yet present locally (e.g. a shallow CI checkout that only has the PR
- * head, or an agent worktree that has not fetched recent base history).
+ * progressively deeper fetch of the base ref **and** the PR head ref when
+ * the merge-base is not yet resolvable locally. Two genuinely different
+ * shallow-history gaps can block `git merge-base` here, and #1535 added the
+ * second one alongside #1519's original base-ref fix:
+ *
+ * - The base commit is missing (e.g. an agent worktree that has not fetched
+ *   recent base history) -- {@link tryFetchBase} handles this, unchanged
+ *   since #1519.
+ * - The PR **head**'s own ancestry is missing (e.g. a shallow CI checkout of
+ *   just the PR head, or a fork PR whose head commits were never fetched at
+ *   all) -- {@link tryFetchHead} handles this by fetching/deepening
+ *   `refs/pull/<prNumber>/head` from the same base-repository remote
+ *   {@link tryFetchBase} already targets. GitHub mirrors every PR head onto
+ *   the base repository under that ref (confirmed empirically against real
+ *   GitHub-hosted repos, including a genuine fork PR, for #1535 -- see the
+ *   PR description), so no separate fork remote URL is needed even when the
+ *   head lives in a fork: `classifyBranchConflictState`'s existing
+ *   `owner`/`repo` (the base repository) plus `prNumber` are sufficient.
+ *
+ * Each retry step attempts **both** fetches at the same escalating
+ * depth/deepen args and widens history if **either** succeeds, so a
+ * structural block on one side (e.g. a missing `prBaseRef`) does not stop
+ * the other side's retries, and the loop only gives up early when neither
+ * side can plausibly help.
+ *
  * Returns `null` when the merge-base still cannot be resolved after
  * exhausting {@link MERGE_BASE_FETCH_STEPS}; callers decide how to report
  * that indeterminate outcome, since "conflict probe" and "base-advancement"
  * callers need different diagnostics wording for the same underlying null.
  */
-function computeMergeBase(prHeadSha, prBaseSha, prBaseRef, owner, repo, notes) {
+function computeMergeBase(
+  prHeadSha,
+  prBaseSha,
+  prBaseRef,
+  prNumber,
+  owner,
+  repo,
+  notes,
+) {
   return resolveMergeBaseWithRetry(
     () => gitText(['merge-base', prHeadSha, prBaseSha]),
-    (step) =>
-      tryFetchBase(prBaseRef, owner, repo, notes, MERGE_BASE_FETCH_STEPS[step]),
+    (step) => {
+      const fetchArgs = MERGE_BASE_FETCH_STEPS[step];
+      const baseFetched = tryFetchBase(
+        prBaseRef,
+        owner,
+        repo,
+        notes,
+        fetchArgs,
+      );
+      const headFetched = tryFetchHead(prNumber, owner, repo, notes, fetchArgs);
+      return baseFetched || headFetched;
+    },
     MERGE_BASE_FETCH_STEPS.length,
   );
 }
@@ -365,6 +411,7 @@ function computeBaseAdvanced(
   prHeadSha,
   prBaseSha,
   prBaseRef,
+  prNumber,
   owner,
   repo,
   notes,
@@ -376,6 +423,7 @@ function computeBaseAdvanced(
       prHeadSha,
       prBaseSha,
       prBaseRef,
+      prNumber,
       owner,
       repo,
       notes,
@@ -398,6 +446,7 @@ function probeConflictFilesReadOnly(
   prHeadSha,
   prBaseSha,
   prBaseRef,
+  prNumber,
   owner,
   repo,
   notes,
@@ -407,6 +456,7 @@ function probeConflictFilesReadOnly(
       prHeadSha,
       prBaseSha,
       prBaseRef,
+      prNumber,
       owner,
       repo,
       notes,
@@ -599,6 +649,72 @@ function tryFetchBase(prBaseRef, owner, repo, notes, fetchArgs) {
   } catch {
     notes.push(
       `Could not fetch base ref ${prBaseRef} (git fetch ${fetchArgs.join(' ')}); merge-base probe may be incomplete.`,
+    );
+    return false;
+  }
+}
+/**
+ * Attempt one fetch of the PR **head** side at the given depth/deepen args,
+ * for {@link computeMergeBase}'s bounded retry loop (via {@link
+ * resolveMergeBaseWithRetry}) -- the #1535 sibling of {@link tryFetchBase}.
+ *
+ * Fetches `refs/pull/<prNumber>/head` from the same base-repository remote
+ * `tryFetchBase` already targets, rather than the PR's own `headRefName` or
+ * a fork's own remote URL. GitHub creates and keeps this ref updated on the
+ * **base** repository for every pull request -- including from a fork, and
+ * even when the fork remote has since been renamed, made private, or
+ * deleted -- so it is fetchable with the exact same remote URL, the exact
+ * same (anonymous, credential-helper-backed) auth, and the exact same
+ * escalating depth/deepen args as the base-ref fetch, with no separate
+ * fork-remote resolution required. Confirmed empirically for #1535 against
+ * real GitHub-hosted repos (both a same-repository PR and a genuine
+ * cross-repository/fork PR): `git ls-remote <repo> refs/pull/<n>/head`
+ * matches `gh pr view --json headRefOid` exactly, and fetching that ref
+ * (progressively deepened, mirroring {@link MERGE_BASE_FETCH_STEPS}) lets a
+ * shallow clone that never had the PR head's ancestry at all resolve
+ * `git merge-base` against it -- see the PR description for the full
+ * experiment. Because this always fetches a normally-advertised ref (never
+ * a bare, unadvertised SHA), it needs no server-side
+ * `uploadpack.allow*SHA1InWant` support either.
+ *
+ * Returns `true` when the `git fetch` call itself succeeded, so the
+ * caller's retry loop knows a deeper next step could plausibly still help;
+ * returns `false` when preconditions (`prNumber`, `owner`, `repo`) are
+ * missing or malformed, or when the fetch itself failed (network, auth,
+ * unknown ref, etc.) -- in either case a further attempt against the same
+ * unreachable/absent target would not change the outcome.
+ */
+function tryFetchHead(prNumber, owner, repo, notes, fetchArgs) {
+  // Mirrors parseArgs's own canonical-positive-integer check: a malformed or
+  // missing PR number is a structural skip, not an error -- callers that
+  // never had a resolvable PR number (e.g. this file's own hermetic tests)
+  // must not reach the real `git fetch` below.
+  const prNumberText = String(prNumber ?? '');
+  if (!/^[1-9]\d*$/.test(prNumberText)) return false;
+  if (!owner || !repo) {
+    notes.push(
+      'Skipped head-ref fetch fallback: owner/repo not provided; merge-base probe may be incomplete.',
+    );
+    return false;
+  }
+  const headRef = `refs/pull/${prNumberText}/head`;
+  try {
+    // Deliberately untested at this call site -- see tryFetchBase's own
+    // doc comment for why (this file's hermetic-test convention never lets
+    // a test reach a live network fetch); the retry-loop shape this feeds
+    // is covered directly via resolveMergeBaseWithRetry against a real
+    // local shallow-clone fixture instead (see
+    // tests/branch-conflict-state.test.mts's head-side-shallow test).
+    const { scheme, host } = resolveFetchOrigin();
+    const remote = `${scheme}://${host}/${owner}/${repo}.git`;
+    execFileSync('git', ['fetch', '--no-tags', ...fetchArgs, remote, headRef], {
+      stdio: 'ignore',
+      encoding: 'utf8',
+    });
+    return true;
+  } catch {
+    notes.push(
+      `Could not fetch head ref ${headRef} (git fetch ${fetchArgs.join(' ')}); merge-base probe may be incomplete.`,
     );
     return false;
   }

--- a/src/scripts/branch-conflict-state.mts
+++ b/src/scripts/branch-conflict-state.mts
@@ -186,6 +186,7 @@ export async function classifyBranchConflictState(
     prBaseSha,
     prHeadRef,
     prBaseRef,
+    prNumber,
     mergeable,
     mergeStateStatus,
     notes,
@@ -219,6 +220,7 @@ function deriveBranchState({
   prHeadSha,
   prBaseSha,
   prBaseRef,
+  prNumber,
   mergeable,
   mergeStateStatus,
   notes,
@@ -230,6 +232,7 @@ function deriveBranchState({
   prBaseSha: string;
   prHeadRef?: string;
   prBaseRef: string;
+  prNumber: unknown;
   mergeable: unknown;
   mergeStateStatus: unknown;
   notes: string[];
@@ -247,6 +250,7 @@ function deriveBranchState({
           prHeadSha,
           prBaseSha,
           prBaseRef,
+          prNumber,
           owner,
           repo,
           notes,
@@ -278,6 +282,7 @@ function deriveBranchState({
       prHeadSha,
       prBaseSha,
       prBaseRef,
+      prNumber,
       owner,
       repo,
       notes,
@@ -313,6 +318,7 @@ function deriveBranchState({
       prHeadSha,
       prBaseSha,
       prBaseRef,
+      prNumber,
       owner,
       repo,
       notes,
@@ -349,6 +355,7 @@ function deriveBranchState({
       prHeadSha,
       prBaseSha,
       prBaseRef,
+      prNumber,
       owner,
       repo,
       notes,
@@ -422,9 +429,31 @@ export function resolveMergeBaseWithRetry(
 
 /**
  * Read-only local `git merge-base` lookup, falling back to a bounded,
- * progressively deeper fetch of the base ref when the base commit is not
- * yet present locally (e.g. a shallow CI checkout that only has the PR
- * head, or an agent worktree that has not fetched recent base history).
+ * progressively deeper fetch of the base ref **and** the PR head ref when
+ * the merge-base is not yet resolvable locally. Two genuinely different
+ * shallow-history gaps can block `git merge-base` here, and #1535 added the
+ * second one alongside #1519's original base-ref fix:
+ *
+ * - The base commit is missing (e.g. an agent worktree that has not fetched
+ *   recent base history) -- {@link tryFetchBase} handles this, unchanged
+ *   since #1519.
+ * - The PR **head**'s own ancestry is missing (e.g. a shallow CI checkout of
+ *   just the PR head, or a fork PR whose head commits were never fetched at
+ *   all) -- {@link tryFetchHead} handles this by fetching/deepening
+ *   `refs/pull/<prNumber>/head` from the same base-repository remote
+ *   {@link tryFetchBase} already targets. GitHub mirrors every PR head onto
+ *   the base repository under that ref (confirmed empirically against real
+ *   GitHub-hosted repos, including a genuine fork PR, for #1535 -- see the
+ *   PR description), so no separate fork remote URL is needed even when the
+ *   head lives in a fork: `classifyBranchConflictState`'s existing
+ *   `owner`/`repo` (the base repository) plus `prNumber` are sufficient.
+ *
+ * Each retry step attempts **both** fetches at the same escalating
+ * depth/deepen args and widens history if **either** succeeds, so a
+ * structural block on one side (e.g. a missing `prBaseRef`) does not stop
+ * the other side's retries, and the loop only gives up early when neither
+ * side can plausibly help.
+ *
  * Returns `null` when the merge-base still cannot be resolved after
  * exhausting {@link MERGE_BASE_FETCH_STEPS}; callers decide how to report
  * that indeterminate outcome, since "conflict probe" and "base-advancement"
@@ -434,14 +463,25 @@ function computeMergeBase(
   prHeadSha: string,
   prBaseSha: string,
   prBaseRef: string,
+  prNumber: unknown,
   owner: string | undefined,
   repo: string | undefined,
   notes: string[],
 ): string | null {
   return resolveMergeBaseWithRetry(
     () => gitText(['merge-base', prHeadSha, prBaseSha]),
-    (step) =>
-      tryFetchBase(prBaseRef, owner, repo, notes, MERGE_BASE_FETCH_STEPS[step]),
+    (step) => {
+      const fetchArgs = MERGE_BASE_FETCH_STEPS[step];
+      const baseFetched = tryFetchBase(
+        prBaseRef,
+        owner,
+        repo,
+        notes,
+        fetchArgs,
+      );
+      const headFetched = tryFetchHead(prNumber, owner, repo, notes, fetchArgs);
+      return baseFetched || headFetched;
+    },
     MERGE_BASE_FETCH_STEPS.length,
   );
 }
@@ -458,6 +498,7 @@ function computeBaseAdvanced(
   prHeadSha: string,
   prBaseSha: string,
   prBaseRef: string,
+  prNumber: unknown,
   owner: string | undefined,
   repo: string | undefined,
   notes: string[],
@@ -469,6 +510,7 @@ function computeBaseAdvanced(
       prHeadSha,
       prBaseSha,
       prBaseRef,
+      prNumber,
       owner,
       repo,
       notes,
@@ -492,6 +534,7 @@ function probeConflictFilesReadOnly(
   prHeadSha: string,
   prBaseSha: string,
   prBaseRef: string,
+  prNumber: unknown,
   owner: string | undefined,
   repo: string | undefined,
   notes: string[],
@@ -501,6 +544,7 @@ function probeConflictFilesReadOnly(
       prHeadSha,
       prBaseSha,
       prBaseRef,
+      prNumber,
       owner,
       repo,
       notes,
@@ -728,6 +772,79 @@ function tryFetchBase(
   } catch {
     notes.push(
       `Could not fetch base ref ${prBaseRef} (git fetch ${fetchArgs.join(' ')}); merge-base probe may be incomplete.`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Attempt one fetch of the PR **head** side at the given depth/deepen args,
+ * for {@link computeMergeBase}'s bounded retry loop (via {@link
+ * resolveMergeBaseWithRetry}) -- the #1535 sibling of {@link tryFetchBase}.
+ *
+ * Fetches `refs/pull/<prNumber>/head` from the same base-repository remote
+ * `tryFetchBase` already targets, rather than the PR's own `headRefName` or
+ * a fork's own remote URL. GitHub creates and keeps this ref updated on the
+ * **base** repository for every pull request -- including from a fork, and
+ * even when the fork remote has since been renamed, made private, or
+ * deleted -- so it is fetchable with the exact same remote URL, the exact
+ * same (anonymous, credential-helper-backed) auth, and the exact same
+ * escalating depth/deepen args as the base-ref fetch, with no separate
+ * fork-remote resolution required. Confirmed empirically for #1535 against
+ * real GitHub-hosted repos (both a same-repository PR and a genuine
+ * cross-repository/fork PR): `git ls-remote <repo> refs/pull/<n>/head`
+ * matches `gh pr view --json headRefOid` exactly, and fetching that ref
+ * (progressively deepened, mirroring {@link MERGE_BASE_FETCH_STEPS}) lets a
+ * shallow clone that never had the PR head's ancestry at all resolve
+ * `git merge-base` against it -- see the PR description for the full
+ * experiment. Because this always fetches a normally-advertised ref (never
+ * a bare, unadvertised SHA), it needs no server-side
+ * `uploadpack.allow*SHA1InWant` support either.
+ *
+ * Returns `true` when the `git fetch` call itself succeeded, so the
+ * caller's retry loop knows a deeper next step could plausibly still help;
+ * returns `false` when preconditions (`prNumber`, `owner`, `repo`) are
+ * missing or malformed, or when the fetch itself failed (network, auth,
+ * unknown ref, etc.) -- in either case a further attempt against the same
+ * unreachable/absent target would not change the outcome.
+ */
+function tryFetchHead(
+  prNumber: unknown,
+  owner: string | undefined,
+  repo: string | undefined,
+  notes: string[],
+  fetchArgs: readonly string[],
+): boolean {
+  // Mirrors parseArgs's own canonical-positive-integer check: a malformed or
+  // missing PR number is a structural skip, not an error -- callers that
+  // never had a resolvable PR number (e.g. this file's own hermetic tests)
+  // must not reach the real `git fetch` below.
+  const prNumberText = String(prNumber ?? '');
+  if (!/^[1-9]\d*$/.test(prNumberText)) return false;
+  if (!owner || !repo) {
+    notes.push(
+      'Skipped head-ref fetch fallback: owner/repo not provided; merge-base probe may be incomplete.',
+    );
+    return false;
+  }
+  const headRef = `refs/pull/${prNumberText}/head`;
+  try {
+    // Deliberately untested at this call site -- see tryFetchBase's own
+    // doc comment for why (this file's hermetic-test convention never lets
+    // a test reach a live network fetch); the retry-loop shape this feeds
+    // is covered directly via resolveMergeBaseWithRetry against a real
+    // local shallow-clone fixture instead (see
+    // tests/branch-conflict-state.test.mts's head-side-shallow test).
+    const { scheme, host } = resolveFetchOrigin();
+    const remote = `${scheme}://${host}/${owner}/${repo}.git`;
+    execFileSync('git', ['fetch', '--no-tags', ...fetchArgs, remote, headRef], {
+      stdio: 'ignore',
+      encoding: 'utf8',
+    });
+    return true;
+  } catch {
+    notes.push(
+      `Could not fetch head ref ${headRef} (git fetch ${fetchArgs.join(' ')}); merge-base probe may be incomplete.`,
     );
     return false;
   }

--- a/tests/branch-conflict-state.test.mts
+++ b/tests/branch-conflict-state.test.mts
@@ -112,18 +112,38 @@ let sharedUpstreamRepo: {
   dir: string;
   branch: string;
   commits: string[];
+  featureBranch: string;
+  featureCommits: string[];
 } | null = null;
 
 /**
  * Builds (once, memoized) a real "upstream" repo with several sequential
- * commits -- oldest first in the returned `commits` array. Immutable after
- * creation (nothing below ever fetches into or otherwise mutates this
- * directory), so sharing one instance across tests is safe.
+ * commits on its main line -- oldest first in the returned `commits` array
+ * -- plus a second, divergent `featureBranch` that branches off
+ * `commits[2]` and adds its own commits (`featureCommits`, oldest first).
+ * `featureBranch` models a real PR head that shares an ancestor with the
+ * base branch but has since diverged -- used by the head-side-shallow retry
+ * test below (#1535), which needs a commit reachable only through a ref
+ * *different* from whichever one was already shallow-cloned, unlike the
+ * single-branch `commits` array (which only proves that deepening the
+ * *same* already-shallow ref works, already covered by the pre-existing
+ * "deepened-success" test).
+ *
+ * HEAD is restored to `branch` (the main line) before returning:
+ * `createFreshShallowClone` below clones whatever branch is currently
+ * checked out here (no explicit `--branch`), and the pre-existing
+ * "deepened-success" test depends on that default being the main line, not
+ * `featureBranch`.
+ *
+ * Immutable after creation (nothing below ever fetches into or otherwise
+ * mutates this directory), so sharing one instance across tests is safe.
  */
 function createUpstreamRepo(): {
   dir: string;
   branch: string;
   commits: string[];
+  featureBranch: string;
+  featureCommits: string[];
 } {
   if (sharedUpstreamRepo) return sharedUpstreamRepo;
   const dir = mkdtempSync(join(tmpdir(), 'idd-branch-conflict-upstream-'));
@@ -138,7 +158,19 @@ function createUpstreamRepo(): {
     commits.push(gitNoSign(dir, ['rev-parse', 'HEAD']));
   }
   const branch = gitNoSign(dir, ['rev-parse', '--abbrev-ref', 'HEAD']);
-  sharedUpstreamRepo = { dir, branch, commits };
+
+  const featureBranch = 'feature';
+  gitNoSign(dir, ['checkout', '-q', '-b', featureBranch, commits[2]]);
+  const featureCommits: string[] = [];
+  for (let i = 0; i < 3; i += 1) {
+    writeFileSync(join(dir, `g${i}.txt`), `${i}\n`);
+    gitNoSign(dir, ['add', `g${i}.txt`]);
+    gitNoSign(dir, ['commit', '-q', '-m', `feature commit ${i}`]);
+    featureCommits.push(gitNoSign(dir, ['rev-parse', 'HEAD']));
+  }
+  gitNoSign(dir, ['checkout', '-q', branch]);
+
+  sharedUpstreamRepo = { dir, branch, commits, featureBranch, featureCommits };
   return sharedUpstreamRepo;
 }
 
@@ -501,12 +533,23 @@ test('classifyBranchConflictState: bare MERGEABLE (non-CLEAN state) also compute
 
 test('classifyBranchConflictState: CLEAN with an unresolvable merge-base reports false with an undetermined note, never a silent false-negative', async () => {
   const fixture = loadFixture('clean');
-  const result = await classifyBranchConflictState(fixture.prData.number, {
+  // The prNumber argument is deliberately `0` (not the fixture's real
+  // `101`), not just `fixture.prData.baseRefName: ''` below: since #1535,
+  // computeMergeBase also tries a head-ref fetch fallback
+  // (refs/pull/<prNumber>/head), gated on prNumber looking like a real
+  // positive-integer PR number. A real-looking prNumber here would let that
+  // new fetch attempt reach the network (test-owner/test-repo is not a real
+  // remote) even with baseRefName short-circuiting the base-ref fetch --
+  // `0` fails the same canonical-positive-integer check tryFetchHead uses,
+  // short-circuiting the head-ref fetch too, so this test stays hermetic.
+  // This test does not assert on `result.prNumber`, so the substitution is
+  // safe.
+  const result = await classifyBranchConflictState(0, {
     owner: 'test-owner',
     repo: 'test-repo',
     // Deliberately no _skipGitProbe: the fixture's placeholder SHAs are not
     // real git objects, so the initial merge-base lookup fails.
-    // baseRefName is overridden to '' so the fallback-fetch guard
+    // baseRefName is overridden to '' so the base-ref fallback-fetch guard
     // (`if (!prBaseRef) return;`) short-circuits before attempting a real
     // network fetch -- keeping this test hermetic and fast -- while still
     // exercising the "merge-base not found" path: baseAdvancedSinceMergeBase
@@ -562,6 +605,67 @@ test('resolveMergeBaseWithRetry: a genuinely shallow checkout resolves after a d
     MERGE_BASE_FETCH_STEPS.length,
   );
   assert.equal(result, baseSha);
+  assert.ok(
+    widenedSteps.length >= 1 &&
+      widenedSteps.length < MERGE_BASE_FETCH_STEPS.length,
+    `expected resolution after a deepening step and before exhausting the cap, got ${JSON.stringify(widenedSteps)}`,
+  );
+});
+
+// #1535: #1519's retry above only re-fetches the *base* ref, so it cannot
+// help when the PR **head**'s own ancestry is missing from the local
+// object store entirely (e.g. a fork PR, or a checkout that only ever
+// fetched the base branch) -- deepening the base side can never retrieve
+// commits that were never fetched from any remote in the first place.
+// tryFetchHead (production code) fetches `refs/pull/<prNumber>/head` from
+// the same base-repository remote to close this gap; the test below proves
+// the same underlying shallow-git mechanism against a *real* local fixture,
+// mirroring tryFetchHead's exact fetch shape without going through its own
+// (deliberately untested, per its doc comment) network-URL assembly.
+
+test('resolveMergeBaseWithRetry: a genuinely shallow PR head, entirely absent locally, resolves after deepening the head-side ref', () => {
+  const {
+    dir: upstreamDir,
+    commits,
+    featureBranch,
+    featureCommits,
+  } = createUpstreamRepo();
+  // A --depth=1 clone of the *base* branch only -- this checkout already
+  // has the base ref (mirroring a checkout that already benefits from
+  // #1519's base-ref retry), but has never fetched featureBranch (standing
+  // in for the PR head's own ref/remote) at all: the head commit is not
+  // merely shallow, it is completely absent from the local object
+  // database, the exact #1535 gap.
+  const shallowDir = createFreshShallowClone(upstreamDir);
+  const headSha = featureCommits[featureCommits.length - 1];
+  const baseSha = commits[commits.length - 1];
+  assert.equal(
+    mergeBaseText(shallowDir, headSha, baseSha),
+    '',
+    'fixture setup bug: the PR head commit must be entirely unresolvable before any head-side fetch',
+  );
+  const widenedSteps: number[] = [];
+  const result = resolveMergeBaseWithRetry(
+    () => mergeBaseText(shallowDir, headSha, baseSha),
+    (step) => {
+      widenedSteps.push(step);
+      // Mirrors tryFetchHead: fetch/deepen the head-side ref (here,
+      // featureBranch stands in for refs/pull/<prNumber>/head) at the same
+      // escalating depth/deepen args tryFetchBase already uses for the
+      // base side.
+      return fetchShallowFixtureStep(
+        shallowDir,
+        featureBranch,
+        MERGE_BASE_FETCH_STEPS[step],
+      );
+    },
+    MERGE_BASE_FETCH_STEPS.length,
+  );
+  // The true shared ancestor is commits[2] (where featureBranch forked from
+  // the main line) -- reachable only once the head-side ref is deepened far
+  // enough to expose it, since a first depth=1 fetch of featureBranch only
+  // brings its own tip commit with no parent history yet.
+  assert.equal(result, commits[2]);
   assert.ok(
     widenedSteps.length >= 1 &&
       widenedSteps.length < MERGE_BASE_FETCH_STEPS.length,

--- a/tests/branch-conflict-state.test.mts
+++ b/tests/branch-conflict-state.test.mts
@@ -129,11 +129,13 @@ let sharedUpstreamRepo: {
  * *same* already-shallow ref works, already covered by the pre-existing
  * "deepened-success" test).
  *
- * HEAD is restored to `branch` (the main line) before returning:
- * `createFreshShallowClone` below clones whatever branch is currently
- * checked out here (no explicit `--branch`), and the pre-existing
- * "deepened-success" test depends on that default being the main line, not
- * `featureBranch`.
+ * `featureBranch` is built in a separate, temporary `git worktree` rather
+ * than by checking it out directly in `dir` (add commits, then checkout
+ * back to `branch`): `dir`'s own HEAD/working tree never has to leave
+ * `branch` at any point this way, so there is no window -- even a
+ * same-process one -- where a concurrent reader of `dir` (or a future test
+ * added to this file) could observe it mid-switch. The scratch worktree is
+ * removed again once `featureBranch`'s commits exist as a plain ref.
  *
  * Immutable after creation (nothing below ever fetches into or otherwise
  * mutates this directory), so sharing one instance across tests is safe.
@@ -160,15 +162,31 @@ function createUpstreamRepo(): {
   const branch = gitNoSign(dir, ['rev-parse', '--abbrev-ref', 'HEAD']);
 
   const featureBranch = 'feature';
-  gitNoSign(dir, ['checkout', '-q', '-b', featureBranch, commits[2]]);
+  const featureWorktreeDir = mkdtempSync(
+    join(tmpdir(), 'idd-branch-conflict-feature-wt-'),
+  );
+  gitNoSign(dir, [
+    'worktree',
+    'add',
+    '-q',
+    featureWorktreeDir,
+    '-b',
+    featureBranch,
+    commits[2],
+  ]);
   const featureCommits: string[] = [];
   for (let i = 0; i < 3; i += 1) {
-    writeFileSync(join(dir, `g${i}.txt`), `${i}\n`);
-    gitNoSign(dir, ['add', `g${i}.txt`]);
-    gitNoSign(dir, ['commit', '-q', '-m', `feature commit ${i}`]);
-    featureCommits.push(gitNoSign(dir, ['rev-parse', 'HEAD']));
+    writeFileSync(join(featureWorktreeDir, `g${i}.txt`), `${i}\n`);
+    gitNoSign(featureWorktreeDir, ['add', `g${i}.txt`]);
+    gitNoSign(featureWorktreeDir, [
+      'commit',
+      '-q',
+      '-m',
+      `feature commit ${i}`,
+    ]);
+    featureCommits.push(gitNoSign(featureWorktreeDir, ['rev-parse', 'HEAD']));
   }
-  gitNoSign(dir, ['checkout', '-q', branch]);
+  gitNoSign(dir, ['worktree', 'remove', '--force', featureWorktreeDir]);
 
   sharedUpstreamRepo = { dir, branch, commits, featureBranch, featureCommits };
   return sharedUpstreamRepo;
@@ -622,20 +640,28 @@ test('resolveMergeBaseWithRetry: a genuinely shallow checkout resolves after a d
 // the same underlying shallow-git mechanism against a *real* local fixture,
 // mirroring tryFetchHead's exact fetch shape without going through its own
 // (deliberately untested, per its doc comment) network-URL assembly.
+//
+// The widen step below explicitly deepens *both* `branch` (the base line)
+// and `featureBranch` (standing in for the PR head) at every retry step --
+// mirroring computeMergeBase's actual combined step (`baseFetched ||
+// headFetched`) exactly, rather than deepening only one side and relying on
+// git's shallow-boundary bookkeeping to have incidentally widened the
+// other. Each explicit `--deepen` targets its own named ref directly, so
+// this does not depend on any cross-ref widening side effect.
 
-test('resolveMergeBaseWithRetry: a genuinely shallow PR head, entirely absent locally, resolves after deepening the head-side ref', () => {
+test('resolveMergeBaseWithRetry: a genuinely shallow PR head, entirely absent locally, resolves once both sides are deepened', () => {
   const {
     dir: upstreamDir,
+    branch,
     commits,
     featureBranch,
     featureCommits,
   } = createUpstreamRepo();
-  // A --depth=1 clone of the *base* branch only -- this checkout already
-  // has the base ref (mirroring a checkout that already benefits from
-  // #1519's base-ref retry), but has never fetched featureBranch (standing
-  // in for the PR head's own ref/remote) at all: the head commit is not
-  // merely shallow, it is completely absent from the local object
-  // database, the exact #1535 gap.
+  // A --depth=1 clone of the *base* branch only -- this checkout has the
+  // base ref's tip, but has never fetched featureBranch (standing in for
+  // the PR head's own ref/remote) at all: the head commit is not merely
+  // shallow, it is completely absent from the local object database, the
+  // exact #1535 gap.
   const shallowDir = createFreshShallowClone(upstreamDir);
   const headSha = featureCommits[featureCommits.length - 1];
   const baseSha = commits[commits.length - 1];
@@ -649,22 +675,30 @@ test('resolveMergeBaseWithRetry: a genuinely shallow PR head, entirely absent lo
     () => mergeBaseText(shallowDir, headSha, baseSha),
     (step) => {
       widenedSteps.push(step);
-      // Mirrors tryFetchHead: fetch/deepen the head-side ref (here,
-      // featureBranch stands in for refs/pull/<prNumber>/head) at the same
-      // escalating depth/deepen args tryFetchBase already uses for the
-      // base side.
-      return fetchShallowFixtureStep(
+      const fetchArgs = MERGE_BASE_FETCH_STEPS[step];
+      // Mirrors computeMergeBase's real combined widen step: attempt both
+      // tryFetchBase's shape (deepen `branch`) and tryFetchHead's shape
+      // (deepen `featureBranch`) at the same escalating depth/deepen args,
+      // widening if either succeeds.
+      const baseWidened = fetchShallowFixtureStep(
+        shallowDir,
+        branch,
+        fetchArgs,
+      );
+      const headWidened = fetchShallowFixtureStep(
         shallowDir,
         featureBranch,
-        MERGE_BASE_FETCH_STEPS[step],
+        fetchArgs,
       );
+      return baseWidened || headWidened;
     },
     MERGE_BASE_FETCH_STEPS.length,
   );
   // The true shared ancestor is commits[2] (where featureBranch forked from
-  // the main line) -- reachable only once the head-side ref is deepened far
-  // enough to expose it, since a first depth=1 fetch of featureBranch only
-  // brings its own tip commit with no parent history yet.
+  // the main line) -- reachable only once *both* sides are deepened enough
+  // to expose it: a first depth=1 fetch of featureBranch only brings its
+  // own tip commit with no parent history yet, and baseSha's own shallow
+  // boundary must also widen back far enough to reach commits[2].
   assert.equal(result, commits[2]);
   assert.ok(
     widenedSteps.length >= 1 &&


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`computeMergeBase`'s bounded retry (#1519) only re-fetched the PR **base**
ref. It could not resolve a merge-base when the PR **head**'s own ancestry
was missing entirely from the local object store -- e.g. a shallow CI
checkout of just the PR head, or a fork PR whose head commits were never
fetched at all -- because deepening the base ref can never retrieve commits
that were never fetched from any remote in the first place. This gap was
found during #1519's review (PR #1532,
[discussion](https://github.com/kurone-kito/idd-skill/pull/1532#discussion_r3608872876))
and deliberately scoped out at the time.

This adds a symmetric head-side fetch step, `tryFetchHead`, alongside the
existing `tryFetchBase`:

- Fetches and progressively deepens `refs/pull/<prNumber>/head` from the
  same base-repository remote `tryFetchBase` already targets, using the
  identical bounded `--depth=1` / `--deepen=20` / `--deepen=200` escalation
  from `MERGE_BASE_FETCH_STEPS`.
- `computeMergeBase`'s retry loop now attempts **both** the base-ref and
  head-ref fetch at each step and widens history if **either** succeeds, so
  a structural block on one side (e.g. a missing `prBaseRef`) does not stop
  the other side's retries.
- `prNumber` is threaded through `deriveBranchState` /
  `computeBaseAdvanced` / `probeConflictFilesReadOnly` / `computeMergeBase`
  to reach the new fetch step (it was already available at the top of
  `classifyBranchConflictState`, just not passed down).

## Investigation findings (the issue's three open questions)

**1. What ref/SHA to fetch for the head side.** `refs/pull/<prNumber>/head`
on the **base repository's own remote** -- not the PR's `headRefName`
branch, and not a separate fork remote URL. GitHub creates and keeps this
ref updated on the base repository for every pull request, including from
a fork, even if the fork is later renamed, made private, or deleted. This
means `classifyBranchConflictState`'s existing inputs (`owner`/`repo` for
the base repository, plus `prNumber`, already a parameter) are sufficient
-- no new input is needed, and the "fork's own remote URL" concern the
issue raised turns out not to be necessary.

**2. Whether GitHub supports fetching a SHA not advertised by a ref.**
Not needed either way: `refs/pull/<n>/head` is a normally **advertised**
ref (confirmed via plain `git ls-remote`), so this fetch never needs
`uploadpack.allowAnySHA1InWant` / `allowReachableSHA1InWant` at all.

**3. Whether current inputs are sufficient.** Yes -- see (1). No new input
needed, so no constraint to document as a blocker.

**Verification performed** (real GitHub-hosted repos, not simulated):

- `git ls-remote https://github.com/kurone-kito/idd-skill.git
  refs/pull/1532/head` returned exactly the SHA `gh pr view 1532 --json
  headRefOid` reports.
- Same check repeated against three genuine **cross-repository (fork)**
  PRs on `expressjs/express` (a public repo with real fork PRs, since this
  repo has never had one): all three `refs/pull/<n>/head` values matched
  `gh pr list --json headRefOid` exactly.
- Reproduced the actual bug end-to-end against this repo's live head:
  cloned `--depth=1 --branch main`, confirmed `git merge-base` fails
  against a real open PR's (unmerged, so unreachable via the base line)
  head SHA even after fully repeating the existing base-only retry
  (`--depth=1`, `--deepen=20`, `--deepen=200` on `main`) -- reproducing
  #1535's premise. Then fetched/deepened `refs/pull/<n>/head` alone (no
  base-ref changes) and confirmed `git merge-base` resolved correctly.
  Also discovered along the way that `--deepen=N` widens **all** existing
  shallow boundaries in the repo relative to their own frontier, not just
  the newly fetched ref's own history -- which is why deepening only the
  head side was sufficient here.
- The one thing this sandbox genuinely cannot verify: real GitHub Actions
  fork-PR `pull_request`-triggered checkout ref-availability shape. This
  does not block the fix, though, because `tryFetchHead` (like the
  pre-existing `tryFetchBase`) always performs its **own** independent
  `git fetch` against a freshly reconstructed remote URL
  (`resolveFetchOrigin()` + `owner`/`repo`) -- it never relies on whatever
  the ambient CI checkout already fetched or configured.

**Conclusion: fixable, and implemented** -- not a "not fixable here" outcome.

## Tests

- New: `resolveMergeBaseWithRetry: a genuinely shallow PR head, entirely
  absent locally, resolves after deepening the head-side ref` -- extends
  `createUpstreamRepo`'s fixture with a divergent `featureBranch` (models a
  PR head sharing an ancestor with, but diverged from, the base line) and
  proves the exact real-shallow-git mechanism validated above, mirroring
  the existing base-ref retry test's fixture style
  (`tests/branch-conflict-state.test.mts`).
- Updated: the pre-existing "CLEAN with an unresolvable merge-base" test
  now also passes an invalid `prNumber` (`0`) so the new head-ref fetch
  guard stays hermetic (no live network attempt), alongside the existing
  `baseRefName: ''` short-circuit for the base-ref guard.
- Full suite: 2531/2531 tests pass; `pre-push-validate` passes (`biome
  check`, `dprint check`, `markdownlint-cli2`, `cspell lint`,
  `scripts/idd-doctor.mjs`); `pnpm run build` regenerated
  `scripts/branch-conflict-state.mjs` from the `.mts` source and it is
  committed.

## Scope

Touches only `src/scripts/branch-conflict-state.mts` (+ generated
`scripts/branch-conflict-state.mjs`) and
`tests/branch-conflict-state.test.mts`, per the issue's stated scope. No
unrelated fixes bundled in.

Closes #1535

Refs #1519
