### PR TITLE
fix(discover): mask code-quoted autopilot-suitability markers

### DIFF
--- a/scripts/autopilot-suitability.mjs
+++ b/scripts/autopilot-suitability.mjs
@@ -55,9 +55,10 @@ export function parseAutopilotSuitabilityMarker(
     'gi',
   );
   const text = stripMarkdownCodeRegions(String(body ?? ''));
-  // Stream matches with regex.exec so an untrusted, marker-heavy body
-  // stays O(1) memory (no per-match arrays), and fail fast on the first
-  // invalid token or first value that conflicts with an earlier one.
+  // Stream matches with regex.exec instead of matchAll so an untrusted,
+  // marker-heavy body avoids per-match array allocation, and fail fast
+  // on the first invalid token or first value that conflicts with an
+  // earlier one.
   let present = false;
   let value = null;
   let match = regex.exec(text);

--- a/scripts/autopilot-suitability.mjs
+++ b/scripts/autopilot-suitability.mjs
@@ -15,6 +15,8 @@
 // advisory ranking/routing hint only — it never replaces the A4.5
 // suitability gate or the A5 claim safety checks, which still run on
 // whatever candidate is selected.
+import { stripMarkdownCodeRegions } from './markdown-code.mjs';
+
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 export const DEFAULT_AUTOPILOT_SUITABILITY_FLOOR = 3;
 /**
@@ -32,6 +34,13 @@ export const DEFAULT_AUTOPILOT_SUITABILITY_FLOOR = 3;
  * `parseAutopilotSuitability` and `idd-doctor` both parse the marker
  * through this one implementation so the regex and fail-safe rules never
  * drift between the discovery rankers and the doctor consistency check.
+ *
+ * The body is masked with {@link stripMarkdownCodeRegions} before the
+ * scan, so a marker merely *quoted* in prose (inside backticks or a
+ * fenced block — for example an issue describing this marker's own
+ * syntax) cannot be mistaken for a real one and poison an otherwise
+ * valid footer marker elsewhere in the body (#1614, mirroring #1121's
+ * identical fix for the `roadmap-id` marker).
  */
 export function parseAutopilotSuitabilityMarker(
   body,
@@ -45,7 +54,7 @@ export function parseAutopilotSuitabilityMarker(
     `<!--\\s*${escapeRegex(prefix)}-autopilot-suitability:\\s*([^\\s>]+)\\s*-->`,
     'gi',
   );
-  const text = String(body ?? '');
+  const text = stripMarkdownCodeRegions(String(body ?? ''));
   // Stream matches with regex.exec so an untrusted, marker-heavy body
   // stays O(1) memory (no per-match arrays), and fail fast on the first
   // invalid token or first value that conflicts with an earlier one.

--- a/src/scripts/autopilot-suitability.mts
+++ b/src/scripts/autopilot-suitability.mts
@@ -16,6 +16,8 @@
 // suitability gate or the A5 claim safety checks, which still run on
 // whatever candidate is selected.
 
+import { stripMarkdownCodeRegions } from './markdown-code.mts';
+
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 export const DEFAULT_AUTOPILOT_SUITABILITY_FLOOR = 3;
 
@@ -52,6 +54,13 @@ export interface AutopilotSuitabilityMarkerDetection {
  * `parseAutopilotSuitability` and `idd-doctor` both parse the marker
  * through this one implementation so the regex and fail-safe rules never
  * drift between the discovery rankers and the doctor consistency check.
+ *
+ * The body is masked with {@link stripMarkdownCodeRegions} before the
+ * scan, so a marker merely *quoted* in prose (inside backticks or a
+ * fenced block — for example an issue describing this marker's own
+ * syntax) cannot be mistaken for a real one and poison an otherwise
+ * valid footer marker elsewhere in the body (#1614, mirroring #1121's
+ * identical fix for the `roadmap-id` marker).
  */
 export function parseAutopilotSuitabilityMarker(
   body: unknown,
@@ -65,7 +74,7 @@ export function parseAutopilotSuitabilityMarker(
     `<!--\\s*${escapeRegex(prefix)}-autopilot-suitability:\\s*([^\\s>]+)\\s*-->`,
     'gi',
   );
-  const text = String(body ?? '');
+  const text = stripMarkdownCodeRegions(String(body ?? ''));
   // Stream matches with regex.exec so an untrusted, marker-heavy body
   // stays O(1) memory (no per-match arrays), and fail fast on the first
   // invalid token or first value that conflicts with an earlier one.

--- a/src/scripts/autopilot-suitability.mts
+++ b/src/scripts/autopilot-suitability.mts
@@ -75,9 +75,10 @@ export function parseAutopilotSuitabilityMarker(
     'gi',
   );
   const text = stripMarkdownCodeRegions(String(body ?? ''));
-  // Stream matches with regex.exec so an untrusted, marker-heavy body
-  // stays O(1) memory (no per-match arrays), and fail fast on the first
-  // invalid token or first value that conflicts with an earlier one.
+  // Stream matches with regex.exec instead of matchAll so an untrusted,
+  // marker-heavy body avoids per-match array allocation, and fail fast
+  // on the first invalid token or first value that conflicts with an
+  // earlier one.
   let present = false;
   let value: number | null = null;
   let match = regex.exec(text);

--- a/tests/autopilot-suitability.test.mts
+++ b/tests/autopilot-suitability.test.mts
@@ -123,6 +123,51 @@ test('parseAutopilotSuitabilityMarker reports present/value/malformed per case',
   );
 });
 
+test('parseAutopilotSuitabilityMarker ignores a marker quoted inside code regions (#1614)', () => {
+  // The #1614 shape (mirroring #1121's identical fix for the roadmap-id
+  // marker): an issue *about* the marker syntax that quotes an example —
+  // including an invalid one — inside code, alongside a real footer
+  // marker elsewhere in the body. The code-quoted example must not be
+  // read as a real marker and must not poison the real one to malformed.
+  const inlineQuoted = [
+    '## Background',
+    '',
+    `A drafted issue must end with a trailing \`${marker('N')}\` marker.`,
+    '',
+    marker(3),
+  ].join('\n');
+  assert.deepEqual(parseAutopilotSuitabilityMarker(inlineQuoted), {
+    present: true,
+    value: 3,
+    malformed: false,
+  });
+
+  // Same for a marker quoted inside a fenced code block.
+  const fencedQuoted = [
+    'Example marker:',
+    '',
+    '```html',
+    marker('N'),
+    '```',
+    '',
+    marker(5),
+  ].join('\n');
+  assert.deepEqual(parseAutopilotSuitabilityMarker(fencedQuoted), {
+    present: true,
+    value: 5,
+    malformed: false,
+  });
+
+  // A code-quoted marker alone (no real marker elsewhere) still reports
+  // absent, not malformed -- the quoted example is masked out entirely.
+  const onlyQuoted = `See the \`${marker('N')}\` format.`;
+  assert.deepEqual(parseAutopilotSuitabilityMarker(onlyQuoted), {
+    present: false,
+    value: null,
+    malformed: false,
+  });
+});
+
 test('parseAutopilotSuitabilityMarker is prefix-aware', () => {
   assert.deepEqual(
     parseAutopilotSuitabilityMarker(marker(4, 'my-org'), 'my-org'),


### PR DESCRIPTION
# Summary

`parseAutopilotSuitabilityMarker` scanned the raw issue body for the
`<!-- {prefix}-autopilot-suitability: N -->` marker, so a marker
merely quoted as an example inside backticks or a fenced block (e.g.
an issue describing the marker's own syntax) could poison a real
footer marker elsewhere in the same body to `malformed`/`null`. This
is the same failure mode #1121 already fixed for the `roadmap-id`
marker, and `audit-authored-issue.mts` already guards against it via
`stripMarkdownCodeRegions` — but that protection was never extended
to the `autopilot-suitability` marker, leaving every discovery/ranking
call site through the shared parser
(`discover-orphan-filter.mts`, `discover-roadmap-graph.mts`,
`discover-readiness-check.mts`) vulnerable.

Reproduced empirically against issue #1556's real body before the
fix: `discover-orphan-filter.mjs --autopilot` reported
`autopilotSuitability: null` even though the issue carried a real,
valid `<!-- idd-skill-autopilot-suitability: 3 -->` footer marker,
because the body's prose also quoted the marker syntax as an example
inside backticks.

## Linked issue

Closes #1614

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Moves the `stripMarkdownCodeRegions` call inside
`parseAutopilotSuitabilityMarker` itself, so every current and future
caller is protected automatically rather than relying on each call
site to remember to strip first — the "caller remembers to strip"
pattern had already been independently forgotten in three separate
files.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
