### PR TITLE
fix(tests): suppress commit signing in createTwoCommitRepo fixture

### DIFF
--- a/tests/branch-conflict-state.test.mts
+++ b/tests/branch-conflict-state.test.mts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -81,11 +81,11 @@ function createTwoCommitRepo(): { dir: string; older: string; newer: string } {
   git(['config', 'user.name', 'Test']);
   writeFileSync(join(dir, 'a.txt'), 'a\n');
   git(['add', 'a.txt']);
-  git(['commit', '-q', '-m', 'older']);
+  gitNoSign(dir, ['commit', '-q', '-m', 'older']);
   const older = git(['rev-parse', 'HEAD']);
   writeFileSync(join(dir, 'b.txt'), 'b\n');
   git(['add', 'b.txt']);
-  git(['commit', '-q', '-m', 'newer']);
+  gitNoSign(dir, ['commit', '-q', '-m', 'newer']);
   const newer = git(['rev-parse', 'HEAD']);
   sharedTwoCommitRepo = { dir, older, newer };
   return sharedTwoCommitRepo;
@@ -443,6 +443,42 @@ test('classifyBranchConflictState: post-push merge recommendation for BEHIND is 
   });
   assert.equal(result.syncRecommendation, 'merge-main');
   assert.equal(result.baseAdvancedSinceMergeBase, true);
+});
+
+test('createTwoCommitRepo: commits succeed even with global commit signing forced on', () => {
+  // Regression test for #1628: createTwoCommitRepo()'s two commit calls
+  // must go through gitNoSign() (or an equivalent `-c commit.gpgsign=false`)
+  // instead of the raw git() helper, so they never attempt a real GPG
+  // signature. Simulate a machine with a real, interactively-signed global
+  // GPG key by pointing GIT_CONFIG_GLOBAL at a temporary config that forces
+  // signing on and points gpg.program at a binary that always fails --
+  // the exact pattern tests/worktree-guard-hook.test.mts already uses for
+  // this same condition. Reset the memoized shared repo first so this test
+  // actually forces a rebuild under the poisoned config, rather than
+  // silently reusing an already-built repo from an earlier test and
+  // passing for the wrong reason.
+  const configDir = mkdtempSync(
+    join(tmpdir(), 'idd-branch-conflict-state-gitconfig-'),
+  );
+  const configPath = join(configDir, 'gitconfig');
+  const previousGlobal = process.env.GIT_CONFIG_GLOBAL;
+  writeFileSync(
+    configPath,
+    '[commit]\n\tgpgsign = true\n[gpg]\n\tprogram = /bin/false\n',
+  );
+  sharedTwoCommitRepo = null;
+  try {
+    process.env.GIT_CONFIG_GLOBAL = configPath;
+    // Any signing attempt would invoke /bin/false and throw, failing this.
+    assert.doesNotThrow(() => createTwoCommitRepo());
+  } finally {
+    if (previousGlobal === undefined) {
+      delete process.env.GIT_CONFIG_GLOBAL;
+    } else {
+      process.env.GIT_CONFIG_GLOBAL = previousGlobal;
+    }
+    rmSync(configDir, { recursive: true, force: true });
+  }
 });
 
 test('classifyBranchConflictState: CLEAN with base advanced past merge-base reports true with an advisory note', async () => {


### PR DESCRIPTION
# Summary

`createTwoCommitRepo()` in `tests/branch-conflict-state.test.mts` called
the raw, unwrapped `git()` helper for its two commits instead of the
`gitNoSign()` helper defined immediately after it. `gitNoSign()` exists
specifically because this repository's own ambient global
`commit.gpgsign=true` makes a raw `git commit` attempt a real GPG
signature, which can hang or fail on pinentry/gpg-agent contention under
concurrent sessions — exactly the failure mode `createTwoCommitRepo()`
remained exposed to.

This PR:

- Routes both commit calls in `createTwoCommitRepo()` through
  `gitNoSign()` instead of the raw `git()` closure. The `init` /
  `config` / `add` / `rev-parse` calls stay on the local `git()`
  closure unchanged (only the two commit calls were in scope per the
  issue). `sharedTwoCommitRepo` memoization is unchanged.
- Adds a regression test that simulates a machine with a real,
  interactively-signed global GPG key — a temporary global git config
  forcing `commit.gpgsign=true` with `gpg.program=/bin/false` — matching
  the exact pattern already used by
  `tests/worktree-guard-hook.test.mts`'s `fixture commits ignore a
  signing-enabled global git config` test. The new test resets the
  memoized `sharedTwoCommitRepo` cache first so it actually forces a
  rebuild under the poisoned config, rather than silently reusing an
  already-built repo and passing for the wrong reason.

Verified the new test actually catches the regression: temporarily
reverting the fix locally reproduced a genuine GPG signing failure
(`gpg: signing failed`) from this repository's own ambient
`commit.gpgsign=true`, then reproduced the same failure hermetically
via the injected `gpg.program=/bin/false` config once the ambient
signing was accounted for — confirming the test is not a false-positive
pass.

## Linked issue

Closes #1628

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

PR #1610 (`idd-spec-audit` dry run) and #1592/PR #1605 both already
flagged this same bug once in their own follow-up checklists; it
remained unfixed until now. A full `node --test tests/*.test.mts` run
on 2026-07-22 independently hit 3 `classifyBranchConflictState`-related
test failures matching this exact fixture, confirming it is a live,
reproducing issue rather than a theoretical one.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
