### PR TITLE
docs(idd): point idd-resume.instructions.md's §W1-§W8 pointer at §FH too

### DIFF
--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -145,7 +145,8 @@ sub-procedure and run **install-deps** as specified there.
 | no             | no            | clean, unpushed            | → D1     |
 | no             | no            | clean, no unpushed         | → B2     |
 
-Section numbers §W1–§W8 are detail entries in `docs/idd-resume-detail.md`.
+Section numbers §W1–§W8 and §FH are detail entries in
+`docs/idd-resume-detail.md`.
 
 After routing, refresh the digest only when the route materially changes what
 a human should expect next (e.g., `Phase: resume → B3`, `Phase: resume → D1`,

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -140,7 +140,8 @@ sub-procedure and run **install-deps** as specified there.
 | no             | no            | clean, unpushed            | → D1     |
 | no             | no            | clean, no unpushed         | → B2     |
 
-Section numbers §W1–§W8 are detail entries in `docs/idd-resume-detail.md`.
+Section numbers §W1–§W8 and §FH are detail entries in
+`docs/idd-resume-detail.md`.
 
 After routing, refresh the digest only when the route materially changes what
 a human should expect next (e.g., `Phase: resume → B3`, `Phase: resume → D1`,


### PR DESCRIPTION
## Summary

`idd-resume.instructions.md`'s Step 1 table cites "Forced-handoff
recovery confirmed (§FH)", and `docs/idd-resume-detail.md` defines a
real `## §FH — Forced-Handoff Recovery` detail entry, but unlike its
siblings §W1-§W8, the file's own pointer sentence never mentioned §FH.
This left nothing in-scope to tell a cold reader where §FH is actually
defined.

Updates the pointer sentence in both the canonical template source
(`idd-template/.github/instructions/idd-resume.instructions.md`) and
its generated mirror (`.github/instructions/idd-resume.instructions.md`)
to read "Section numbers §W1–§W8 and §FH are detail entries in
`docs/idd-resume-detail.md`."

Closes #1625

## Verification

- `node scripts/sync-docs.mjs --apply` (regenerated the mirrored copy)
- `node scripts/audit-docs.mjs --check` — documentation audit passed
- `node scripts/idd-doctor.mjs` — passed (4 pre-existing, unrelated
  environmental warnings)
- fix-validate / pre-push-validate command set — all clean
