### PR TITLE
fix(lite): step 5 no longer stops on a merely-pending sibling

### DIFF
--- a/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -329,17 +329,19 @@ than the run it supersedes. Once both have completed, the later
    exists but cannot be enumerated by name): always stop per the
    condition above — this is a real gating check, never treat it like
    `no-required-checks`.
-5. **`failing`**: in the same helper's `checks[]` array, check every
-   entry where `required` is true and its `checkName` field (not
-   `name`, which this array does not have) is not
-   `idd-advisory-convergence`. If
-   **all** of those are `success`,
-   `idd-advisory-convergence` is the sole non-passing required check —
-   go to step 8's exception instead of stopping here. If **any** of
-   those is not yet `success` (whether `failing` or still
-   `pending`/`missing`/`unknown`), that does not qualify: stop per the
-   condition above rather than continuing to poll (fixing or rerunning
-   it is outside this file's mechanical scope).
+5. **`failing`**: check every `checks[]` entry where `required` is
+   true and its `checkName` is not `idd-advisory-convergence`
+   (`requiredChecks.missingNames` is always empty for this status —
+   see step 6's `missing` route for that case). If **all** are
+   `success`, `idd-advisory-convergence` is the sole non-passing
+   required check — go to step 8's exception instead of stopping
+   here. If **any** has `status: "failure"`, stop per the condition
+   above (outside this file's mechanical scope to fix or rerun).
+   Otherwise — none failed, but at least one is still
+   `pending`/`unknown` — apply step 6's timeout/on-timeout handling to
+   just those unsettled entries, never `idd-advisory-convergence`
+   itself (already completed), then re-read this step once they
+   settle.
 6. **`pending`** or **`missing`** (an expected required check has not
    posted a result yet), or any `pending`/`unknown` entry reached via
    step 3's fallback: keep polling until `success`, `failing`, or a

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -248,7 +248,7 @@
       "files": [
         ".github/instructions/lite/idd-pr-submit-lite.instructions.md"
       ],
-      "limitBytes": 23500
+      "limitBytes": 23700
     },
     {
       "id": "bundle-review-fix-lite",

--- a/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -324,17 +324,19 @@ than the run it supersedes. Once both have completed, the later
    exists but cannot be enumerated by name): always stop per the
    condition above — this is a real gating check, never treat it like
    `no-required-checks`.
-5. **`failing`**: in the same helper's `checks[]` array, check every
-   entry where `required` is true and its `checkName` field (not
-   `name`, which this array does not have) is not
-   `idd-advisory-convergence`. If
-   **all** of those are `success`,
-   `idd-advisory-convergence` is the sole non-passing required check —
-   go to step 8's exception instead of stopping here. If **any** of
-   those is not yet `success` (whether `failing` or still
-   `pending`/`missing`/`unknown`), that does not qualify: stop per the
-   condition above rather than continuing to poll (fixing or rerunning
-   it is outside this file's mechanical scope).
+5. **`failing`**: check every `checks[]` entry where `required` is
+   true and its `checkName` is not `idd-advisory-convergence`
+   (`requiredChecks.missingNames` is always empty for this status —
+   see step 6's `missing` route for that case). If **all** are
+   `success`, `idd-advisory-convergence` is the sole non-passing
+   required check — go to step 8's exception instead of stopping
+   here. If **any** has `status: "failure"`, stop per the condition
+   above (outside this file's mechanical scope to fix or rerun).
+   Otherwise — none failed, but at least one is still
+   `pending`/`unknown` — apply step 6's timeout/on-timeout handling to
+   just those unsettled entries, never `idd-advisory-convergence`
+   itself (already completed), then re-read this step once they
+   settle.
 6. **`pending`** or **`missing`** (an expected required check has not
    posted a result yet), or any `pending`/`unknown` entry reached via
    step 3's fallback: keep polling until `success`, `failing`, or a


### PR DESCRIPTION
## Summary

D4 step 5 of the lite PR-submit instructions previously conflated two
different sibling-check shapes under one "stop" branch: a required
check that genuinely failed, and one that was simply still running.
This mattered in practice: `idd-advisory-convergence` typically
reaches its by-design "no reviews yet" FAILURE state well before
slower siblings like `lint` finish, so the old text would
spuriously stop-and-ask on a large share of brand-new PRs whenever a
poll happened to land in that window.

Caught empirically while running D4 for PR #1619 (issue #1589):
`idd-advisory-convergence` reached FAILURE ~11 seconds after PR
creation, while `lint`/`pnpm-boundary` were still `IN_PROGRESS` for
roughly another 30-40 seconds. The window closed before any poll
landed inside it that time — but a session polling on a tighter
interval, or simply unlucky timing, would spuriously stop.

## Change

Split step 5's second branch in two:

- A sibling that itself has `status: "failure"` — stop, unchanged.
- A sibling that's merely `pending`/`unknown` — keep polling instead,
  applying step 6's timeout math only to the still-unsettled sibling
  entries, never to `idd-advisory-convergence` itself (already
  reached its own terminal state, nothing to time out).

A first draft also folded `requiredChecks.missingNames` into step 5's
entry set, mirroring step 6. Verified against
`buildRequiredChecksRollup` in `src/scripts/ci-wait-state.mts` that
`status` is only ever `"failing"` when `allRequiredPresent` is `true`
— i.e. `missingNames` is always empty by construction whenever step 5
is reached. Dropped that clause as dead code rather than keep it for
false symmetry with step 6 (where `missingNames` is genuinely
reachable).

The standard (non-lite) `idd-pr-submit.instructions.md` does not have
an analogous gap: it delegates polling mechanics entirely to
`idd-ci.instructions.md`'s canonical Interpretation table, which
already routes a still-running required check to "continue waiting"
rather than re-deriving this logic by hand.

## Byte budget

`bundleBudgets["bundle-pr-submit-lite"].limitBytes` raised from 22000
to 23700 in `audit/sync-manifest.json` in two increments this cycle
(23500 for #1589/PR #1619, then 23700 here), each with an explicit
ratchet callout per that field's own documented rule. Current size:
23352 bytes (source) / 23573 bytes (mirror).

## Self-review

Went through a pre-implementation plan critique (caught two real
gaps before any code was written: the fix needed to scope timeout
math away from `idd-advisory-convergence` itself, and needed to
handle `missingNames`/`unknown` states, not just `pending`) and a
post-implementation critique (confirmed the fix correctly satisfies
both, and separately surfaced that the `missingNames` clause I'd
added was provably dead code — removed).

## Test plan

- [x] `pnpm run lint` — cspell/markdownlint/audit-docs all pass;
      `node --test` shows the same 3 pre-existing
      `tests/branch-conflict-state.test.mts` failures present on a
      clean `main` (unrelated — this diff touches zero source files)
- [x] `node scripts/audit-docs.mjs --check` passes
- [x] `node scripts/sync-docs.mjs --apply` — mirror in sync, no drift
- [x] Rebased cleanly onto current `main`

Closes #1620

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>