### PR TITLE
fix(docs): correct the dangling inPlaceEditOnly F2 pointer

### DIFF
--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -626,10 +626,9 @@ override the `return-to-e1` and proceed on the current HEAD SHA (see
 non-ack blocking cause makes it `false`, so the backstop still holds for every
 other case.
 
-The narrower, informational-only `inPlaceEditOnly` /
-`soleCauseInPlaceEditOnly` sibling is documented in
-`idd-pre-merge.instructions.md` F2 (#1313) — it is not a second override
-path.
+The narrower `inPlaceEditOnly` / `soleCauseInPlaceEditOnly` sibling
+(#1313, `summarizeDispositionEvidenceForGate`) is a strict subset of
+`soleCauseAckOnlyPostDisposition`, not an override path.
 
 ## Review item classes
 

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -621,10 +621,9 @@ override the `return-to-e1` and proceed on the current HEAD SHA (see
 non-ack blocking cause makes it `false`, so the backstop still holds for every
 other case.
 
-The narrower, informational-only `inPlaceEditOnly` /
-`soleCauseInPlaceEditOnly` sibling is documented in
-`idd-pre-merge.instructions.md` F2 (#1313) — it is not a second override
-path.
+The narrower `inPlaceEditOnly` / `soleCauseInPlaceEditOnly` sibling
+(#1313, `summarizeDispositionEvidenceForGate`) is a strict subset of
+`soleCauseAckOnlyPostDisposition`, not an override path.
 
 ## Review item classes
 


### PR DESCRIPTION
## Summary

`idd-review-triage.instructions.md` claimed the `inPlaceEditOnly` /
`soleCauseInPlaceEditOnly` signal "is documented in
`idd-pre-merge.instructions.md` F2 (#1313)" — verified zero matches
for either name, or `#1313`, anywhere in that file.

## Investigation

The field is real and live: computed by
`summarizeDispositionEvidenceForGate` in
`src/scripts/protocol-helpers.mts` alongside its sibling
`soleCauseAckOnlyPostDisposition`, and flows into
`pre-merge-readiness`'s `dispositionEvidence` output (visible in this
session's own PR merges as `"soleCauseInPlaceEditOnly": false`).

But by its own description it's "informational-only… not a second
override path" — it gates nothing in F2. A phase-gate file has no
normative reason to define a signal that drives no gate decision, so
the fix is a pointer correction, not new phase-gate documentation:
reworded the sentence to attribute the signal inline (function name +
issue number) instead of pointing at a section that doesn't discuss
it.

## Related finding (not fixed here)

While investigating, found that the sibling signal's own pointer —
`soleCauseAckOnlyPostDisposition`, which by contrast **does** claim to
grant a live autonomous override of `return-to-e1` ("see
`idd-pre-merge.instructions.md` F2") — is also not documented
anywhere in F2's actual text (grepped for
`override`/`ack-only`/`missingThreads`/`soleCauseAckOnlyPostDisposition`:
zero matches beyond the unrelated `reviewCurrency` ack-only
carve-out). That's a materially heavier finding than this issue's
scope — resolving it may require a decision about whether F2 should
gain override text, not just a pointer reword — so it's filed as a
separate follow-up rather than folded into this fix.

## Test plan

- [x] `node scripts/audit-docs.mjs --check` passes
- [x] `node scripts/sync-docs.mjs --apply` — mirror in sync, no drift
- [x] cspell / markdownlint pass on both changed files

Closes #1622

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>