### PR TITLE
docs(idd): define the F3 awaiting-reviewer restart-F2 path at its source

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -266,7 +266,8 @@ Before any mutating action in F3, apply the
      acknowledgement reply then resolve it directly, then **restart
      `idd-pre-merge.instructions.md` F2**; **(d)** thread with
      `**Awaiting maintainer decision**` reply → post a hold comment and
-     stop.
+     stop. Cases **(b)**-**(c)** together are the **F3 awaiting-reviewer
+     restart-F2 path** cited elsewhere in this bundle.
 
    When a merge failure routes to F1, D4, E1, or a hold, update the
    digest after recording the failure evidence. Set `Phase` to

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -261,7 +261,8 @@ Before any mutating action in F3, apply the
      acknowledgement reply then resolve it directly, then **restart
      `idd-pre-merge.instructions.md` F2**; **(d)** thread with
      `**Awaiting maintainer decision**` reply → post a hold comment and
-     stop.
+     stop. Cases **(b)**-**(c)** together are the **F3 awaiting-reviewer
+     restart-F2 path** cited elsewhere in this bundle.
 
    When a merge failure routes to F1, D4, E1, or a hold, update the
    digest after recording the failure evidence. Set `Phase` to


### PR DESCRIPTION
## Summary

`idd-overview-appendix.instructions.md` (~line 52) and
`idd-review-snapshot.instructions.md` (~line 218) both cite "The F3
awaiting-reviewer restart-F2 path" as an established term, but
`idd-merge.instructions.md` — where cases (b)/(c) of F3's
conversation-resolution routing actually define this mechanism —
never used that compound label, only "restart
`idd-pre-merge.instructions.md` F2". Both citing files are read
earlier than `idd-merge.instructions.md` in normal phase-routing
order, so a cold reader hits the undefined term before ever reaching
a file that could define it.

Surfaced by the completion audit of roadmap #1598 (`idd-spec-audit`
dry run, #1597 / PR #1610).

## Change

Named cases (b)-(c) at their source in `idd-merge.instructions.md`
instead of rewording the two forward citations — the label describes
exactly that pair (resolve an awaiting-reviewer thread, then restart
F2), and both citing passages already use wording consistent with
this definition, so they resolve correctly once the term actually
exists.

## Test plan

- [x] `node scripts/audit-docs.mjs --check` passes
- [x] `node scripts/sync-docs.mjs --apply` — mirror in sync, no drift
- [x] cspell / markdownlint pass on both changed files

Closes #1624

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>