### PR TITLE
docs(idd): document soleCauseAckOnlyPostDisposition override in F2

### DIFF
--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -308,14 +308,17 @@ claim.
   (`ready: true`) satisfies this condition.
   Separately, require `dispositionEvidence.route` to be `proceed`
   (`dispositionEvidence.blockingCount == 0` — both
-  `missingRegularComments`, ad hoc advisory-bot or reviewer comments
-  outside a review thread, and `missingThreads`, resolved or unresolved
-  threads still lacking a fresh disposition marker, are empty; neither is
-  covered by the helper above); treat absent, malformed, or non-list
-  `dispositionEvidence`/`missingRegularComments`/`missingThreads` as
-  unmet, not as vacuously satisfied. A `route: return-to-e1` result
-  routes to E1/E4 with that evidence — except the ack-only override
-  below.
+  `missingRegularComments` (ad hoc advisory-bot or reviewer comments
+  outside a review thread) and `missingThreads` (resolved or unresolved
+  threads still lacking a fresh disposition marker) are empty). The
+  `advisory-convergence.mjs --assert` check above only covers the
+  Copilot-authored subset of `missingThreads`; it never covers a
+  non-Copilot-authored thread or any `missingRegularComments` entry, so
+  this check stays necessary even when that one passes. Treat a missing
+  or malformed `dispositionEvidence` object, or a non-list
+  `missingRegularComments`/`missingThreads`, as unmet, not as vacuously
+  satisfied. A `route: return-to-e1` result routes to E1/E4 with that
+  evidence — except the ack-only override below.
 
   Disposition-evidence ack-only override: when
   `dispositionEvidence.soleCauseAckOnlyPostDisposition` is `true` — every

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -326,8 +326,8 @@ claim.
 
   Disposition-evidence ack-only override: when
   `dispositionEvidence.soleCauseAckOnlyPostDisposition` is `true` — every
-  blocking item is a `missingThreads` entry with `ackOnlyPostDisposition:
-  true`, and `missingRegularComments` is empty (see
+  blocking item is a `missingThreads` entry whose `ackOnlyPostDisposition`
+  is `true`, and `missingRegularComments` is empty (see
   `idd-review-triage.instructions.md`'s "Disposition-evidence parity
   (advisory-only)" paragraph for the full condition) — autopilot may
   deterministically override the `return-to-e1` and treat this condition

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -306,12 +306,32 @@ claim.
   is a hard merge block — route to E1/E4 (check **AW6** first when
   `sameHeadReroll.eligible`) using the `reasons`; a zero exit
   (`ready: true`) satisfies this condition.
-  Separately, require `dispositionEvidence.missingRegularComments.length
-  == 0` (ad hoc advisory-bot or reviewer comments outside a review
-  thread, which the helper above does not cover); treat absent,
-  malformed, or non-list `dispositionEvidence`/`missingRegularComments`
-  as unmet, not as vacuously satisfied. A non-empty (or unusable) result
-  routes to E1/E4 with that evidence.
+  Separately, require `dispositionEvidence.route` to be `proceed`
+  (`dispositionEvidence.blockingCount == 0` — both
+  `missingRegularComments`, ad hoc advisory-bot or reviewer comments
+  outside a review thread, and `missingThreads`, resolved or unresolved
+  threads still lacking a fresh disposition marker, are empty; neither is
+  covered by the helper above); treat absent, malformed, or non-list
+  `dispositionEvidence`/`missingRegularComments`/`missingThreads` as
+  unmet, not as vacuously satisfied. A `route: return-to-e1` result
+  routes to E1/E4 with that evidence — except the ack-only override
+  below.
+
+  Disposition-evidence ack-only override: when
+  `dispositionEvidence.soleCauseAckOnlyPostDisposition` is `true` — every
+  blocking item is a `missingThreads` entry with `ackOnlyPostDisposition:
+  true`, and `missingRegularComments` is empty (see
+  `idd-review-triage.instructions.md`'s "Disposition-evidence parity
+  (advisory-only)" paragraph for the full condition) — autopilot may
+  deterministically override the `return-to-e1` and treat this condition
+  as satisfied, proceeding on the current HEAD SHA instead of returning
+  to E1. This is a distinct signal from the `reviewCurrency`-based
+  structural ack-only carve-out in the Review currency check above (that
+  one covers E1-snapshot staleness; this one covers disposition evidence
+  on already-resolved threads), and `pre-merge-readiness`'s own
+  `ready`/`blockers` rollup does not apply it — the agent applies it
+  here. The signal never changes `route`; any other blocking cause makes
+  it `false`, and the gate still routes to E1/E4.
   Fails closed per the shared default: if either check cannot run or its
   output is unusable, treat this condition as unmet.
 

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -308,14 +308,18 @@ claim.
   (`ready: true`) satisfies this condition.
   Separately, require `dispositionEvidence.route` to be `proceed`
   (`dispositionEvidence.blockingCount == 0` — both
-  `missingRegularComments` (ad hoc advisory-bot or reviewer comments
-  outside a review thread) and `missingThreads` (resolved or unresolved
-  threads still lacking a fresh disposition marker) are empty). The
-  `advisory-convergence.mjs --assert` check above only covers the
-  Copilot-authored subset of `missingThreads`; it never covers a
-  non-Copilot-authored thread or any `missingRegularComments` entry, so
-  this check stays necessary even when that one passes. Treat a missing
-  or malformed `dispositionEvidence` object, or a non-list
+  `missingRegularComments` (any outstanding regular PR comment outside a
+  review thread, from any non-agent author including the PR author, that
+  lacks a fresh disposition marker) and `missingThreads` (any review
+  thread, resolved or unresolved, still lacking a fresh disposition
+  marker) are empty). The `advisory-convergence.mjs --assert` check
+  above only enforces the _unresolved_ Copilot-authored subset of
+  `missingThreads` (a resolved Copilot-authored thread without a fresh
+  disposition does not block there — resolution alone already satisfies
+  that check's own Clause 2); it never covers a non-Copilot-authored
+  thread or any `missingRegularComments` entry, so this check stays
+  necessary even when that one passes. Treat a missing or malformed
+  `dispositionEvidence` object, or a non-list
   `missingRegularComments`/`missingThreads`, as unmet, not as vacuously
   satisfied. A `route: return-to-e1` result routes to E1/E4 with that
   evidence — except the ack-only override below.

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -321,8 +321,8 @@ claim.
 
   Disposition-evidence ack-only override: when
   `dispositionEvidence.soleCauseAckOnlyPostDisposition` is `true` — every
-  blocking item is a `missingThreads` entry with `ackOnlyPostDisposition:
-  true`, and `missingRegularComments` is empty (see
+  blocking item is a `missingThreads` entry whose `ackOnlyPostDisposition`
+  is `true`, and `missingRegularComments` is empty (see
   `idd-review-triage.instructions.md`'s "Disposition-evidence parity
   (advisory-only)" paragraph for the full condition) — autopilot may
   deterministically override the `return-to-e1` and treat this condition

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -303,14 +303,18 @@ claim.
   (`ready: true`) satisfies this condition.
   Separately, require `dispositionEvidence.route` to be `proceed`
   (`dispositionEvidence.blockingCount == 0` — both
-  `missingRegularComments` (ad hoc advisory-bot or reviewer comments
-  outside a review thread) and `missingThreads` (resolved or unresolved
-  threads still lacking a fresh disposition marker) are empty). The
-  `advisory-convergence.mjs --assert` check above only covers the
-  Copilot-authored subset of `missingThreads`; it never covers a
-  non-Copilot-authored thread or any `missingRegularComments` entry, so
-  this check stays necessary even when that one passes. Treat a missing
-  or malformed `dispositionEvidence` object, or a non-list
+  `missingRegularComments` (any outstanding regular PR comment outside a
+  review thread, from any non-agent author including the PR author, that
+  lacks a fresh disposition marker) and `missingThreads` (any review
+  thread, resolved or unresolved, still lacking a fresh disposition
+  marker) are empty). The `advisory-convergence.mjs --assert` check
+  above only enforces the _unresolved_ Copilot-authored subset of
+  `missingThreads` (a resolved Copilot-authored thread without a fresh
+  disposition does not block there — resolution alone already satisfies
+  that check's own Clause 2); it never covers a non-Copilot-authored
+  thread or any `missingRegularComments` entry, so this check stays
+  necessary even when that one passes. Treat a missing or malformed
+  `dispositionEvidence` object, or a non-list
   `missingRegularComments`/`missingThreads`, as unmet, not as vacuously
   satisfied. A `route: return-to-e1` result routes to E1/E4 with that
   evidence — except the ack-only override below.

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -303,14 +303,17 @@ claim.
   (`ready: true`) satisfies this condition.
   Separately, require `dispositionEvidence.route` to be `proceed`
   (`dispositionEvidence.blockingCount == 0` — both
-  `missingRegularComments`, ad hoc advisory-bot or reviewer comments
-  outside a review thread, and `missingThreads`, resolved or unresolved
-  threads still lacking a fresh disposition marker, are empty; neither is
-  covered by the helper above); treat absent, malformed, or non-list
-  `dispositionEvidence`/`missingRegularComments`/`missingThreads` as
-  unmet, not as vacuously satisfied. A `route: return-to-e1` result
-  routes to E1/E4 with that evidence — except the ack-only override
-  below.
+  `missingRegularComments` (ad hoc advisory-bot or reviewer comments
+  outside a review thread) and `missingThreads` (resolved or unresolved
+  threads still lacking a fresh disposition marker) are empty). The
+  `advisory-convergence.mjs --assert` check above only covers the
+  Copilot-authored subset of `missingThreads`; it never covers a
+  non-Copilot-authored thread or any `missingRegularComments` entry, so
+  this check stays necessary even when that one passes. Treat a missing
+  or malformed `dispositionEvidence` object, or a non-list
+  `missingRegularComments`/`missingThreads`, as unmet, not as vacuously
+  satisfied. A `route: return-to-e1` result routes to E1/E4 with that
+  evidence — except the ack-only override below.
 
   Disposition-evidence ack-only override: when
   `dispositionEvidence.soleCauseAckOnlyPostDisposition` is `true` — every

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -301,12 +301,32 @@ claim.
   is a hard merge block — route to E1/E4 (check **AW6** first when
   `sameHeadReroll.eligible`) using the `reasons`; a zero exit
   (`ready: true`) satisfies this condition.
-  Separately, require `dispositionEvidence.missingRegularComments.length
-  == 0` (ad hoc advisory-bot or reviewer comments outside a review
-  thread, which the helper above does not cover); treat absent,
-  malformed, or non-list `dispositionEvidence`/`missingRegularComments`
-  as unmet, not as vacuously satisfied. A non-empty (or unusable) result
-  routes to E1/E4 with that evidence.
+  Separately, require `dispositionEvidence.route` to be `proceed`
+  (`dispositionEvidence.blockingCount == 0` — both
+  `missingRegularComments`, ad hoc advisory-bot or reviewer comments
+  outside a review thread, and `missingThreads`, resolved or unresolved
+  threads still lacking a fresh disposition marker, are empty; neither is
+  covered by the helper above); treat absent, malformed, or non-list
+  `dispositionEvidence`/`missingRegularComments`/`missingThreads` as
+  unmet, not as vacuously satisfied. A `route: return-to-e1` result
+  routes to E1/E4 with that evidence — except the ack-only override
+  below.
+
+  Disposition-evidence ack-only override: when
+  `dispositionEvidence.soleCauseAckOnlyPostDisposition` is `true` — every
+  blocking item is a `missingThreads` entry with `ackOnlyPostDisposition:
+  true`, and `missingRegularComments` is empty (see
+  `idd-review-triage.instructions.md`'s "Disposition-evidence parity
+  (advisory-only)" paragraph for the full condition) — autopilot may
+  deterministically override the `return-to-e1` and treat this condition
+  as satisfied, proceeding on the current HEAD SHA instead of returning
+  to E1. This is a distinct signal from the `reviewCurrency`-based
+  structural ack-only carve-out in the Review currency check above (that
+  one covers E1-snapshot staleness; this one covers disposition evidence
+  on already-resolved threads), and `pre-merge-readiness`'s own
+  `ready`/`blockers` rollup does not apply it — the agent applies it
+  here. The signal never changes `route`; any other blocking cause makes
+  it `false`, and the gate still routes to E1/E4.
   Fails closed per the shared default: if either check cannot run or its
   output is unusable, treat this condition as unmet.
 


### PR DESCRIPTION
# Summary

Document the `soleCauseAckOnlyPostDisposition` override in F2's
"Advisory convergence" bullet, so the override
`idd-review-triage.instructions.md` already describes as live has a
real home in `idd-pre-merge.instructions.md`.

## Linked issue

Closes #1636

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

F2's "Advisory convergence" bullet only narrated
`dispositionEvidence.missingRegularComments.length == 0` as a hard,
unconditional requirement — it never mentioned `missingThreads`,
`route`, or the override, even though `pre-merge-readiness`'s
`ready`/`blockers` rollup already folds `missingThreads` into the
enforced gate and its own schema explicitly documents that it does
**not** apply the `soleCauseAckOnlyPostDisposition` override itself
("a separate flag the F2 checklist layers on top"). That left the F2
instructions as the only place the override described in
`idd-review-triage.instructions.md`'s "Disposition-evidence parity
(advisory-only)" paragraph could be applied, but F2 never mentioned it.

This PR:

- Extends F2's "Advisory convergence" bullet to require
  `dispositionEvidence.route === "proceed"` (covering both
  `missingRegularComments` and `missingThreads`, not just the former).
- Adds a "Disposition-evidence ack-only override" paragraph
  documenting the `soleCauseAckOnlyPostDisposition` condition and its
  effect — proceeding on the current HEAD SHA instead of returning to
  E1 — mirroring the style of the existing `reviewCurrency`-based
  structural ack-only carve-out already documented under "Review
  currency" (a distinct signal about E1-snapshot staleness, not
  disposition evidence).

Field names (`route`, `blockingCount`, `missingThreads`,
`missingRegularComments`, `soleCauseAckOnlyPostDisposition`) are
verified against `summarizeDispositionEvidenceForGate` in
`src/scripts/protocol-helpers.mts` and
`schemas/pre-merge-readiness.schema.json`.

Documentation-only — no helper or gate behavior changes.

I checked whether `idd-review-triage.instructions.md`'s cross-reference
to F2 needed an anchor now that F2 has real content, and whether
`idd-pre-merge-lite.instructions.md` independently restates this gate
the way `idd-pr-submit-lite.instructions.md` drifted on D4 (#1589/#1620
pattern). Neither needed a change: the review-triage cross-reference
already resolves to real content without an anchor (an anchor-link
upgrade was tried but reverted — it pushed
`idd-review-triage.instructions.md` over its `instruction-size-budgets`
phase limit), and the lite pre-merge file deliberately defers all
per-blocker routing (including disposition-evidence routing) to the
standard file's prose rather than restating it, so there is nothing
there to drift.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [ ] `pnpm test` (no test-relevant code changed; documentation-only)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified pre-merge disposition-evidence requirements, including separate route and blocking-count checks.
  * Added fail-closed handling for missing or malformed evidence and comment lists.
  * Documented routing behavior for unresolved evidence and the deterministic acknowledgment-only exception.
  * Clarified that non-Copilot missing threads and regular comments must still be addressed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->