### PR TITLE
docs(idd): require orchestrator-side verification of worker outcomes

### DIFF
--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -608,6 +608,22 @@ Running this variant safely requires:
   never as something to trust or silently discard; then delegate a fresh
   subagent with a resume-specific briefing rather than resuming the dead
   worker's own context.
+- **Independently verify a worker's reported terminal outcome before
+  trusting it.** A worker's final-turn text describes what it
+  _attempted_, not proof of what actually landed on the forge. Before
+  dispatching the next worker or otherwise acting on a reported "merged"
+  outcome, confirm live GitHub state directly — for example
+  `gh pr view <n> --json state,mergedAt` and
+  `gh issue view <n> --json state,closedAt` — rather than trusting the
+  worker's own narrative.
+- **Check for dangling or broken state after an ambiguous worker
+  dispatch.** When a worker's turn ends without a clean final report
+  (stalled, killed, timed out) — especially if its last visible action
+  was a mutating step such as an F3 merge-execution command — check for
+  a PR left in a failed-merge-attempt state (e.g.
+  `gh pr view <n> --json mergeable,mergeStateStatus`) or an orphaned
+  claim before dispatching further workers, rather than assuming success
+  or failure either way.
 
 ## Live Status Digests
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -585,6 +585,22 @@ Running this variant safely requires:
   never as something to trust or silently discard; then delegate a fresh
   subagent with a resume-specific briefing rather than resuming the dead
   worker's own context.
+- **Independently verify a worker's reported terminal outcome before
+  trusting it.** A worker's final-turn text describes what it
+  _attempted_, not proof of what actually landed on the forge. Before
+  dispatching the next worker or otherwise acting on a reported "merged"
+  outcome, confirm live GitHub state directly — for example
+  `gh pr view <n> --json state,mergedAt` and
+  `gh issue view <n> --json state,closedAt` — rather than trusting the
+  worker's own narrative.
+- **Check for dangling or broken state after an ambiguous worker
+  dispatch.** When a worker's turn ends without a clean final report
+  (stalled, killed, timed out) — especially if its last visible action
+  was a mutating step such as an F3 merge-execution command — check for
+  a PR left in a failed-merge-attempt state (e.g.
+  `gh pr view <n> --json mergeable,mergeStateStatus`) or an orphaned
+  claim before dispatching further workers, rather than assuming success
+  or failure either way.
 
 ## Live Status Digests
 


### PR DESCRIPTION
# Summary

The orchestrator fan-out variant's "Running this variant safely requires"
list said nothing about what the orchestrator should do once a delegated
worker's turn *ends*. Adds two bullets to `docs/idd-workflow.md` (and the
`idd-template/docs/idd-workflow.md` mirror) closing that gap:

- Independently verify a worker's reported terminal outcome (in
  particular a "merged" outcome) against live GitHub state before
  trusting it, with a concrete verification-read example
  (`gh pr view <n> --json state,mergedAt` /
  `gh issue view <n> --json state,closedAt`).
- Check for dangling or broken state (e.g. a PR left in a failed-merge
  attempt, an orphaned claim) after an ambiguous/stalled worker dispatch,
  before dispatching further workers.

## Linked issue

Closes #1642

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

A worker's final-turn text describes what it *attempted*, not proof of
what actually landed on the forge — the same caveat that applies to any
subagent summary in general. This is distinct from the existing
"Resume-specific recovery when a worker dies mid-turn" bullet, which is
about re-establishing claim/worktree state to *continue* a dead worker's
unfinished issue; the gap here is about a worker that *did* produce a
final report (or reached an ambiguous stop) and whether the orchestrator
should take that report at face value before moving on.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

(`docs/idd-workflow.md` is documentation, not a `.github/instructions/`
IDD instruction file, but it is part of the IDD workflow guide, so
checking this box for transparency.)

## Verification

- [x] `pnpm lint` (via `fix-validate` / `pre-push-validate`: biome,
      dprint, markdownlint, cspell)
- [x] `pnpm test` (2533/2533 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed; pre-existing environmental
      warnings unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
