### PR TITLE
feat(advisory-wait): implement bounded stale-request recovery

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -294,8 +294,10 @@ recovery-cycle cap from the
 
 **Eligibility.** Run `advisory-wait-state` **with `--claim-id`/`--agent-id`
 set to the active claim** (omitting either makes the budget read as the
-full un-decremented cap — never trust an unbound `"attempt"` to
-authorize a mutation) and read `staleRequestRecovery`:
+full un-decremented cap; the classifier itself fails this closed to
+`"not-applicable"` / `active-claim-not-provided` rather than relying on the
+caller to remember not to trust an unbound `"attempt"`) and read
+`staleRequestRecovery`:
 
 - `"not-applicable"` → does not apply; use ordinary handling unchanged.
 - `"cap-exhausted"` → do **not** remove or re-request; handle like

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -315,12 +315,30 @@ and that HEAD has not moved since this attempt started; either failure
 aborts without mutating or counting a cycle — discard state and restart
 from E1 against the new HEAD.
 
-1. **Remove** the stale request (E14's gh-then-REST fallback). If it
-   fails because the bot is no longer pending, re-run AW1-AW3 and
+1. **Remove** the stale request, gh-then-REST (`{primary-advisory-bot}` /
+   `{primary-advisory-bot-rest-login}` substitution per
+   `idd-review-fix.instructions.md`'s E14 **Primary advisory bot** section):
+
+   ```sh
+   gh pr edit {pr-number} --remove-reviewer "@{primary-advisory-bot}"
+   # on a GraphQL login-resolution failure:
+   gh api repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers \
+     -X DELETE -f "reviewers[]={primary-advisory-bot-rest-login}"
+   ```
+
+   If it fails because the bot is no longer pending, re-run AW1-AW3 and
    re-evaluate `staleRequestRecovery` fresh; any other failure posts the
    `AW4` pending-refresh-failed hold and stops — no cycle counted.
 2. **Verify** removal and current HEAD before proceeding.
-3. **Request** Copilot again, same gh-then-REST fallback.
+3. **Request** Copilot again, same gh-then-REST fallback:
+
+   ```sh
+   gh pr edit {pr-number} --add-reviewer "@{primary-advisory-bot}"
+   # on a GraphQL login-resolution failure:
+   gh api repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers \
+     -X POST -f "reviewers[]={primary-advisory-bot-rest-login}"
+   ```
+
 4. **Verify association**: re-fetch the PR timeline and confirm the
    fresh request's `review_requested` now follows HEAD's `committed`
    event (the same proof `COPILOT_PENDING_COVERS_HEAD` uses). If not yet

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -324,10 +324,17 @@ from E1 against the new HEAD.
 4. **Verify association**: re-fetch the PR timeline and confirm the
    fresh request's `review_requested` now follows HEAD's `committed`
    event (the same proof `COPILOT_PENDING_COVERS_HEAD` uses). If not yet
-   true (timeline lag), do **not** post the marker or count a cycle;
-   retry from step 1 with fresh state — a retry that never reaches a
-   verified marker never consumes budget, so re-entry after a partial
-   failure is naturally idempotent.
+   true, this is ordinary eventual-consistency lag, not a failed
+   request — do **not** redo steps 1-3 (the request already made is
+   still valid; removing and re-requesting again only churns it).
+   Re-check this step alone after a brief pause, up to a small bounded
+   number of attempts (distributed default: 3, a few seconds apart). If
+   it still cannot be proven after that budget, do **not** post the
+   marker or count a cycle: abort the whole attempt and return to the
+   polling loop (or E1) to re-evaluate fresh at the next interval — never
+   tight-loop steps 1-4 on unresolved timeline lag. An attempt that never
+   reaches a verified marker never consumes budget either way, so
+   re-entry after a partial failure is naturally idempotent.
 5. **Post exactly one** bound marker, only once every prior step is
    verified:
 

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -280,6 +280,73 @@ Rules:
 - advisory clock starts from marker comment `created_at`
 - if marker cannot be posted/read, route to `AW4` recovery-failed hold
 
+### AW3-S — Bounded stale-request recovery (`#1571`)
+
+**Distinct from `AW3-R`**: `AW3-R` fires when the pending request is
+already **proven** to cover HEAD and only anchors a missing marker.
+`AW3-S` fires for the **opposite**, unproven case PR #1562 identified
+(`COPILOT_PENDING_COVERS_HEAD = false`, no same-head marker) — the
+`REQUEST_NEEDED`-with-pending sub-case (E14). It bounds the
+remove-then-re-request sequence with the independent, per-HEAD
+recovery-cycle cap from the
+[terminal contract](#terminal-copilot-stall-recovery-contract-state-policy-markers-clock)
+(default 2) instead of the far larger ordinary `REQUEST_CAP` (30).
+
+**Eligibility.** Run `advisory-wait-state` **with `--claim-id`/`--agent-id`
+set to the active claim** (omitting either makes the budget read as the
+full un-decremented cap — never trust an unbound `"attempt"` to
+authorize a mutation) and read `staleRequestRecovery`:
+
+- `"not-applicable"` → does not apply; use ordinary handling unchanged.
+- `"cap-exhausted"` → do **not** remove or re-request; handle like
+  `CAP_EXHAUSTED` (`CAP_EXHAUSTED_ROUTE`) instead of looping.
+- `"attempt"` → run the cycle below.
+
+Without helper runtime, derive the same decision from AW1-AW2 plus the
+terminal contract's `remaining budget` (`max(cap - completedCycleCount,
+0)`, trusted bound `advisory-wait-recovery:` markers only).
+
+**Bounded cycle** (only when `"attempt"`). Before each mutating step,
+re-verify the active claim
+([claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate))
+and that HEAD has not moved since this attempt started; either failure
+aborts without mutating or counting a cycle — discard state and restart
+from E1 against the new HEAD.
+
+1. **Remove** the stale request (E14's gh-then-REST fallback). If it
+   fails because the bot is no longer pending, re-run AW1-AW3 and
+   re-evaluate `staleRequestRecovery` fresh; any other failure posts the
+   `AW4` pending-refresh-failed hold and stops — no cycle counted.
+2. **Verify** removal and current HEAD before proceeding.
+3. **Request** Copilot again, same gh-then-REST fallback.
+4. **Verify association**: re-fetch the PR timeline and confirm the
+   fresh request's `review_requested` now follows HEAD's `committed`
+   event (the same proof `COPILOT_PENDING_COVERS_HEAD` uses). If not yet
+   true (timeline lag), do **not** post the marker or count a cycle;
+   retry from step 1 with fresh state — a retry that never reaches a
+   verified marker never consumes budget, so re-entry after a partial
+   failure is naturally idempotent.
+5. **Post exactly one** bound marker, only once every prior step is
+   verified:
+
+   ```sh
+   node scripts/post-idd-marker.mjs --type advisory-recovery --target pr <pr-number> \
+     --agent-id <id> --claim-id <id> --head-sha <PR_HEAD_SHA> \
+     --attempt <n> --timestamp <ISO8601> --apply
+   ```
+
+   `<n>` is `completedCycleCount + 1`. Posting last is what prevents
+   double-counting: `buildCopilotRecoverySummary` counts trusted marker
+   **presence**, so a retried-but-unmarked attempt never consumes budget.
+
+**Ordinary counters are untouched.** The bound marker is excluded from
+`requestMarkerCount` (only `advisory-wait:` markers count there) and from
+`#1511`'s reroll accounting. It **does** count as a same-head marker for
+the AW2 clock, which is what naturally blocks a second mutation for the
+_same_ verified HEAD within one pass (`staleRequestRecovery` reads
+`"not-applicable"` once a same-head marker exists), with no extra guard
+needed.
+
 ### AW3-H — Hide superseded advisory-wait markers
 
 After any new `advisory-wait` or `advisory-wait-recovery` marker is
@@ -368,11 +435,15 @@ failure).
 ## Terminal Copilot stall-recovery contract (state, policy, markers, clock)
 
 `#1572` defines state/policy/marker/schema **contracts** for a terminal
-`COPILOT_UNAVAILABLE` signal, for the execution (`#1571`, requesting
-reviews and posting recovery markers) and routing (`#1570`, F2/F3/
-convergence/waiver integration) tracks to build against. This file does
-not itself change E14/F2/F3 routing; no caller yet acts on
-`COPILOT_UNAVAILABLE`.
+`COPILOT_UNAVAILABLE` signal. `#1571` (`AW3-S` above) builds the
+execution track against this contract: the bounded remove/re-request/
+verify/mark recovery cycle, and the `staleRequestRecovery` eligibility
+classification that gates it. Routing (`#1570`: wiring
+`COPILOT_UNAVAILABLE` into F2/F3/convergence/waiver decisions) remains
+unbuilt — no caller yet treats `COPILOT_UNAVAILABLE` as anything beyond
+waiver _eligibility_, and `AW3-S`'s `"cap-exhausted"` result still falls
+back to the existing `CAP_EXHAUSTED_ROUTE` handling rather than any new
+terminal routing.
 
 **Policy** (`advisory-wait-policy.mts`, resolved/read like every other
 `advisoryWait.*` knob, independent counters from `requestCap` and `#1511`'s

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -274,30 +274,9 @@ real account login.
      if `CAP_EXHAUSTED_ROUTE` is `hold`, post the hold comment from
      **AW4** and stop. Otherwise (`phase-specific`, the default), skip
      the advisory wait entirely and proceed directly to E15.
-   - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, or
-     `COPILOT_PENDING` is `"true"` but current-head coverage is not
-     proven; request cap < `REQUEST_CAP`): request the primary advisory
-     bot's review and immediately post a plain-text marker. If
-     `COPILOT_PENDING` is `"true"` in this branch, first remove the
-     stale/unproven pending reviewer request:
-
-     ```sh
-     gh pr edit {pr-number} --remove-reviewer "@{primary-advisory-bot}"
-     ```
-
-     On a GraphQL login-resolution failure (see above), retry via REST
-     instead:
-
-     ```sh
-     gh api repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers \
-       -X DELETE -f "reviewers[]={primary-advisory-bot-rest-login}"
-     ```
-
-     If removal fails because the bot is no longer pending, re-run
-     AW1–AW3. If removal fails for any other reason, post the AW4
-     pending-refresh-failed hold comment and stop. After removal
-     succeeds, request the primary advisory bot's review the same
-     gh-then-REST way:
+   - **REQUEST_NEEDED**, `COPILOT_PENDING` is `"false"` (request cap <
+     `REQUEST_CAP`): request the primary advisory bot's review and
+     immediately post a plain-text marker:
 
      ```sh
      gh pr edit {pr-number} --add-reviewer "@{primary-advisory-bot}"
@@ -312,8 +291,22 @@ real account login.
 
      Use `PR_HEAD_SHA` as `{head-SHA}`. Post as plain text, not an HTML
      comment block.
-   - **WAIT**, or after a **REQUEST_NEEDED** or **RECOVERY_NEEDED**
-     marker is posted: enter the active polling loop below.
+   - **REQUEST_NEEDED**, `COPILOT_PENDING` is `"true"` (current-head
+     coverage is not proven — the stale/unproven pending request PR
+     #1562 identified): consult **`AW3-S`**'s `staleRequestRecovery`
+     classification (`idd-advisory-wait.instructions.md`) before doing
+     anything else:
+     - `"attempt"` → run **AW3-S**'s bounded remove/re-request/verify/mark
+       recovery cycle (independently capped; do **not** use the plain
+       `advisory-wait:` marker or the ordinary `REQUEST_CAP` for this
+       sub-case).
+     - `"cap-exhausted"` → do not remove or re-request; handle exactly
+       like **CAP_EXHAUSTED** below (`CAP_EXHAUSTED_ROUTE`).
+     - `"not-applicable"` → a same-head marker already anchors this HEAD;
+       fall through to the polling loop below unchanged.
+   - **WAIT**, or after a **REQUEST_NEEDED** or **RECOVERY_NEEDED** marker,
+     or an **AW3-S** recovery marker, is posted: enter the active polling
+     loop below.
 5. **Optional secondary advisory bot (non-gating).** When the helper reports
    `secondaryRequestNeeded: true` — or, in the shell fallback, when AW3 yields
    **CAP_EXHAUSTED** or a stalled / rate-limited **SATISFIED** (closed by the

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -293,7 +293,7 @@
         ".github/instructions/idd-overview-core.instructions.md",
         ".github/instructions/idd-pre-merge.instructions.md"
       ],
-      "limitBytes": 109600
+      "limitBytes": 116100
     }
   ],
   "docBudgetGuard": {

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1106,6 +1106,16 @@ Interpretation rules:
   `pendingWindowMinutes`, `settledWindowMinutes`,
   `pollIntervalMinutes`, `capExhaustedRoute`, and
   `trustedMarkerSummary`
+- Optional `--claim-id <id> --agent-id <id>` (kurone-kito/idd-skill#1572):
+  when both are supplied, binds two independent, claim/HEAD-scoped
+  evidence objects to the active claim: `copilotRecovery` (the terminal
+  `COPILOT_UNAVAILABLE` stall-recovery state) and `staleRequestRecovery`
+  (kurone-kito/idd-skill#1571; `AW3-S`'s bounded stale-request recovery
+  eligibility — `attempt` / `cap-exhausted` / `not-applicable`). Omitting
+  either flag leaves `copilotRecovery.state` at `NOT_TERMINAL` and makes
+  the recovery-cycle budget read as the full un-decremented cap — always
+  pass both when consulting `staleRequestRecovery` for a mutation
+  decision (see `idd-advisory-wait.instructions.md`'s `AW3-S`).
 
 ### CI wait policy resolution
 

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -275,6 +275,73 @@ Rules:
 - advisory clock starts from marker comment `created_at`
 - if marker cannot be posted/read, route to `AW4` recovery-failed hold
 
+### AW3-S — Bounded stale-request recovery (`#1571`)
+
+**Distinct from `AW3-R`**: `AW3-R` fires when the pending request is
+already **proven** to cover HEAD and only anchors a missing marker.
+`AW3-S` fires for the **opposite**, unproven case PR #1562 identified
+(`COPILOT_PENDING_COVERS_HEAD = false`, no same-head marker) — the
+`REQUEST_NEEDED`-with-pending sub-case (E14). It bounds the
+remove-then-re-request sequence with the independent, per-HEAD
+recovery-cycle cap from the
+[terminal contract](#terminal-copilot-stall-recovery-contract-state-policy-markers-clock)
+(default 2) instead of the far larger ordinary `REQUEST_CAP` (30).
+
+**Eligibility.** Run `advisory-wait-state` **with `--claim-id`/`--agent-id`
+set to the active claim** (omitting either makes the budget read as the
+full un-decremented cap — never trust an unbound `"attempt"` to
+authorize a mutation) and read `staleRequestRecovery`:
+
+- `"not-applicable"` → does not apply; use ordinary handling unchanged.
+- `"cap-exhausted"` → do **not** remove or re-request; handle like
+  `CAP_EXHAUSTED` (`CAP_EXHAUSTED_ROUTE`) instead of looping.
+- `"attempt"` → run the cycle below.
+
+Without helper runtime, derive the same decision from AW1-AW2 plus the
+terminal contract's `remaining budget` (`max(cap - completedCycleCount,
+0)`, trusted bound `advisory-wait-recovery:` markers only).
+
+**Bounded cycle** (only when `"attempt"`). Before each mutating step,
+re-verify the active claim
+([claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate))
+and that HEAD has not moved since this attempt started; either failure
+aborts without mutating or counting a cycle — discard state and restart
+from E1 against the new HEAD.
+
+1. **Remove** the stale request (E14's gh-then-REST fallback). If it
+   fails because the bot is no longer pending, re-run AW1-AW3 and
+   re-evaluate `staleRequestRecovery` fresh; any other failure posts the
+   `AW4` pending-refresh-failed hold and stops — no cycle counted.
+2. **Verify** removal and current HEAD before proceeding.
+3. **Request** Copilot again, same gh-then-REST fallback.
+4. **Verify association**: re-fetch the PR timeline and confirm the
+   fresh request's `review_requested` now follows HEAD's `committed`
+   event (the same proof `COPILOT_PENDING_COVERS_HEAD` uses). If not yet
+   true (timeline lag), do **not** post the marker or count a cycle;
+   retry from step 1 with fresh state — a retry that never reaches a
+   verified marker never consumes budget, so re-entry after a partial
+   failure is naturally idempotent.
+5. **Post exactly one** bound marker, only once every prior step is
+   verified:
+
+   ```sh
+   node scripts/post-idd-marker.mjs --type advisory-recovery --target pr <pr-number> \
+     --agent-id <id> --claim-id <id> --head-sha <PR_HEAD_SHA> \
+     --attempt <n> --timestamp <ISO8601> --apply
+   ```
+
+   `<n>` is `completedCycleCount + 1`. Posting last is what prevents
+   double-counting: `buildCopilotRecoverySummary` counts trusted marker
+   **presence**, so a retried-but-unmarked attempt never consumes budget.
+
+**Ordinary counters are untouched.** The bound marker is excluded from
+`requestMarkerCount` (only `advisory-wait:` markers count there) and from
+`#1511`'s reroll accounting. It **does** count as a same-head marker for
+the AW2 clock, which is what naturally blocks a second mutation for the
+_same_ verified HEAD within one pass (`staleRequestRecovery` reads
+`"not-applicable"` once a same-head marker exists), with no extra guard
+needed.
+
 ### AW3-H — Hide superseded advisory-wait markers
 
 After any new `advisory-wait` or `advisory-wait-recovery` marker is
@@ -363,11 +430,15 @@ failure).
 ## Terminal Copilot stall-recovery contract (state, policy, markers, clock)
 
 `#1572` defines state/policy/marker/schema **contracts** for a terminal
-`COPILOT_UNAVAILABLE` signal, for the execution (`#1571`, requesting
-reviews and posting recovery markers) and routing (`#1570`, F2/F3/
-convergence/waiver integration) tracks to build against. This file does
-not itself change E14/F2/F3 routing; no caller yet acts on
-`COPILOT_UNAVAILABLE`.
+`COPILOT_UNAVAILABLE` signal. `#1571` (`AW3-S` above) builds the
+execution track against this contract: the bounded remove/re-request/
+verify/mark recovery cycle, and the `staleRequestRecovery` eligibility
+classification that gates it. Routing (`#1570`: wiring
+`COPILOT_UNAVAILABLE` into F2/F3/convergence/waiver decisions) remains
+unbuilt — no caller yet treats `COPILOT_UNAVAILABLE` as anything beyond
+waiver _eligibility_, and `AW3-S`'s `"cap-exhausted"` result still falls
+back to the existing `CAP_EXHAUSTED_ROUTE` handling rather than any new
+terminal routing.
 
 **Policy** (`advisory-wait-policy.mts`, resolved/read like every other
 `advisoryWait.*` knob, independent counters from `requestCap` and `#1511`'s

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -319,10 +319,17 @@ from E1 against the new HEAD.
 4. **Verify association**: re-fetch the PR timeline and confirm the
    fresh request's `review_requested` now follows HEAD's `committed`
    event (the same proof `COPILOT_PENDING_COVERS_HEAD` uses). If not yet
-   true (timeline lag), do **not** post the marker or count a cycle;
-   retry from step 1 with fresh state — a retry that never reaches a
-   verified marker never consumes budget, so re-entry after a partial
-   failure is naturally idempotent.
+   true, this is ordinary eventual-consistency lag, not a failed
+   request — do **not** redo steps 1-3 (the request already made is
+   still valid; removing and re-requesting again only churns it).
+   Re-check this step alone after a brief pause, up to a small bounded
+   number of attempts (distributed default: 3, a few seconds apart). If
+   it still cannot be proven after that budget, do **not** post the
+   marker or count a cycle: abort the whole attempt and return to the
+   polling loop (or E1) to re-evaluate fresh at the next interval — never
+   tight-loop steps 1-4 on unresolved timeline lag. An attempt that never
+   reaches a verified marker never consumes budget either way, so
+   re-entry after a partial failure is naturally idempotent.
 5. **Post exactly one** bound marker, only once every prior step is
    verified:
 

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -310,12 +310,30 @@ and that HEAD has not moved since this attempt started; either failure
 aborts without mutating or counting a cycle — discard state and restart
 from E1 against the new HEAD.
 
-1. **Remove** the stale request (E14's gh-then-REST fallback). If it
-   fails because the bot is no longer pending, re-run AW1-AW3 and
+1. **Remove** the stale request, gh-then-REST (`{primary-advisory-bot}` /
+   `{primary-advisory-bot-rest-login}` substitution per
+   `idd-review-fix.instructions.md`'s E14 **Primary advisory bot** section):
+
+   ```sh
+   gh pr edit {pr-number} --remove-reviewer "@{primary-advisory-bot}"
+   # on a GraphQL login-resolution failure:
+   gh api repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers \
+     -X DELETE -f "reviewers[]={primary-advisory-bot-rest-login}"
+   ```
+
+   If it fails because the bot is no longer pending, re-run AW1-AW3 and
    re-evaluate `staleRequestRecovery` fresh; any other failure posts the
    `AW4` pending-refresh-failed hold and stops — no cycle counted.
 2. **Verify** removal and current HEAD before proceeding.
-3. **Request** Copilot again, same gh-then-REST fallback.
+3. **Request** Copilot again, same gh-then-REST fallback:
+
+   ```sh
+   gh pr edit {pr-number} --add-reviewer "@{primary-advisory-bot}"
+   # on a GraphQL login-resolution failure:
+   gh api repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers \
+     -X POST -f "reviewers[]={primary-advisory-bot-rest-login}"
+   ```
+
 4. **Verify association**: re-fetch the PR timeline and confirm the
    fresh request's `review_requested` now follows HEAD's `committed`
    event (the same proof `COPILOT_PENDING_COVERS_HEAD` uses). If not yet

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -289,8 +289,10 @@ recovery-cycle cap from the
 
 **Eligibility.** Run `advisory-wait-state` **with `--claim-id`/`--agent-id`
 set to the active claim** (omitting either makes the budget read as the
-full un-decremented cap — never trust an unbound `"attempt"` to
-authorize a mutation) and read `staleRequestRecovery`:
+full un-decremented cap; the classifier itself fails this closed to
+`"not-applicable"` / `active-claim-not-provided` rather than relying on the
+caller to remember not to trust an unbound `"attempt"`) and read
+`staleRequestRecovery`:
 
 - `"not-applicable"` → does not apply; use ordinary handling unchanged.
 - `"cap-exhausted"` → do **not** remove or re-request; handle like

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -269,30 +269,9 @@ real account login.
      if `CAP_EXHAUSTED_ROUTE` is `hold`, post the hold comment from
      **AW4** and stop. Otherwise (`phase-specific`, the default), skip
      the advisory wait entirely and proceed directly to E15.
-   - **REQUEST_NEEDED** (`COPILOT_PENDING` is `"false"`, or
-     `COPILOT_PENDING` is `"true"` but current-head coverage is not
-     proven; request cap < `REQUEST_CAP`): request the primary advisory
-     bot's review and immediately post a plain-text marker. If
-     `COPILOT_PENDING` is `"true"` in this branch, first remove the
-     stale/unproven pending reviewer request:
-
-     ```sh
-     gh pr edit {pr-number} --remove-reviewer "@{primary-advisory-bot}"
-     ```
-
-     On a GraphQL login-resolution failure (see above), retry via REST
-     instead:
-
-     ```sh
-     gh api repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers \
-       -X DELETE -f "reviewers[]={primary-advisory-bot-rest-login}"
-     ```
-
-     If removal fails because the bot is no longer pending, re-run
-     AW1–AW3. If removal fails for any other reason, post the AW4
-     pending-refresh-failed hold comment and stop. After removal
-     succeeds, request the primary advisory bot's review the same
-     gh-then-REST way:
+   - **REQUEST_NEEDED**, `COPILOT_PENDING` is `"false"` (request cap <
+     `REQUEST_CAP`): request the primary advisory bot's review and
+     immediately post a plain-text marker:
 
      ```sh
      gh pr edit {pr-number} --add-reviewer "@{primary-advisory-bot}"
@@ -307,8 +286,22 @@ real account login.
 
      Use `PR_HEAD_SHA` as `{head-SHA}`. Post as plain text, not an HTML
      comment block.
-   - **WAIT**, or after a **REQUEST_NEEDED** or **RECOVERY_NEEDED**
-     marker is posted: enter the active polling loop below.
+   - **REQUEST_NEEDED**, `COPILOT_PENDING` is `"true"` (current-head
+     coverage is not proven — the stale/unproven pending request PR
+     #1562 identified): consult **`AW3-S`**'s `staleRequestRecovery`
+     classification (`idd-advisory-wait.instructions.md`) before doing
+     anything else:
+     - `"attempt"` → run **AW3-S**'s bounded remove/re-request/verify/mark
+       recovery cycle (independently capped; do **not** use the plain
+       `advisory-wait:` marker or the ordinary `REQUEST_CAP` for this
+       sub-case).
+     - `"cap-exhausted"` → do not remove or re-request; handle exactly
+       like **CAP_EXHAUSTED** below (`CAP_EXHAUSTED_ROUTE`).
+     - `"not-applicable"` → a same-head marker already anchors this HEAD;
+       fall through to the polling loop below unchanged.
+   - **WAIT**, or after a **REQUEST_NEEDED** or **RECOVERY_NEEDED** marker,
+     or an **AW3-S** recovery marker, is posted: enter the active polling
+     loop below.
 5. **Optional secondary advisory bot (non-gating).** When the helper reports
    `secondaryRequestNeeded: true` — or, in the shell fallback, when AW3 yields
    **CAP_EXHAUSTED** or a stalled / rate-limited **SATISFIED** (closed by the

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1106,6 +1106,16 @@ Interpretation rules:
   `pendingWindowMinutes`, `settledWindowMinutes`,
   `pollIntervalMinutes`, `capExhaustedRoute`, and
   `trustedMarkerSummary`
+- Optional `--claim-id <id> --agent-id <id>` (kurone-kito/idd-skill#1572):
+  when both are supplied, binds two independent, claim/HEAD-scoped
+  evidence objects to the active claim: `copilotRecovery` (the terminal
+  `COPILOT_UNAVAILABLE` stall-recovery state) and `staleRequestRecovery`
+  (kurone-kito/idd-skill#1571; `AW3-S`'s bounded stale-request recovery
+  eligibility — `attempt` / `cap-exhausted` / `not-applicable`). Omitting
+  either flag leaves `copilotRecovery.state` at `NOT_TERMINAL` and makes
+  the recovery-cycle budget read as the full un-decremented cap — always
+  pass both when consulting `staleRequestRecovery` for a mutation
+  decision (see `idd-advisory-wait.instructions.md`'s `AW3-S`).
 
 ### CI wait policy resolution
 

--- a/schemas/advisory-wait-state.schema.json
+++ b/schemas/advisory-wait-state.schema.json
@@ -243,6 +243,24 @@
         }
       },
       "additionalProperties": false
+    },
+    "staleRequestRecovery": {
+      "type": "object",
+      "description": "#1571 bounded stale-request recovery eligibility. Independent of outcome/f3Outcome and of copilotRecovery above: distinguishes the unproven-coverage (copilotPendingCoversHead=false) case PR #1562 identified from the pre-existing RECOVERY_NEEDED/AW3-R marker-anchor-only path (copilotPendingCoversHead=true). Consumed only by E14's REQUEST_NEEDED-with-pending sub-path (AW3-S) to decide whether the bounded remove/re-request/verify/mark cycle may run.",
+      "required": ["action", "reason"],
+      "properties": {
+        "action": {
+          "type": "string",
+          "enum": ["attempt", "cap-exhausted", "not-applicable"],
+          "description": "'attempt': unproven pending request, no same-head marker, recovery-cycle budget remains -- run AW3-S. 'cap-exhausted': same unproven condition, but the independent #1572 recovery-cycle cap is exhausted for this HEAD -- do not mutate; fall back to CAP_EXHAUSTED_ROUTE. 'not-applicable': no stale-request recovery decision applies."
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Machine-readable reason: not-pending, same-head-marker-present, proven-covers-head, recovery-cap-exhausted, or recovery-attempt-eligible."
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/schemas/advisory-wait-state.schema.json
+++ b/schemas/advisory-wait-state.schema.json
@@ -257,7 +257,7 @@
         "reason": {
           "type": "string",
           "minLength": 1,
-          "description": "Machine-readable reason: not-pending, same-head-marker-present, proven-covers-head, recovery-cap-exhausted, or recovery-attempt-eligible."
+          "description": "Machine-readable reason: active-claim-not-provided, not-pending, same-head-marker-present, proven-covers-head, recovery-cap-exhausted, or recovery-attempt-eligible."
         }
       },
       "additionalProperties": false

--- a/scripts/advisory-wait-policy.mjs
+++ b/scripts/advisory-wait-policy.mjs
@@ -10,6 +10,13 @@ export const DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES = 30;
 export const DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES = 10;
 export const DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES = 2;
 export const DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN = 'copilot';
+// #1571: the default primary bot's GraphQL login (`copilot`) and its REST
+// `requested_reviewers` account login differ -- `gh pr edit --add-reviewer`/
+// `--remove-reviewer` resolve bot logins via GraphQL and some `gh` versions
+// reject the bot login outright, so E14 falls back to this REST identity
+// (see idd-review-fix.instructions.md's gh-then-REST fallback).
+export const DEFAULT_ADVISORY_PRIMARY_BOT_REST_LOGIN =
+  'copilot-pull-request-reviewer[bot]';
 // Shared last-resort fallback for the plural `advisoryBotLogins` config key
 // (distinct from the singular primary-bot-login default above): used by both
 // `merged-pr-feedback-sweep.mts` and `disposition-non-review-notices.mts` so
@@ -122,6 +129,25 @@ export function readAdvisoryPrimaryBotLogin(path = '.github/idd/config.json') {
   } catch {
     return DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
   }
+}
+/**
+ * Resolve the REST API identity for the configured primary advisory bot
+ * (#1571), used only when the `gh pr edit --add-reviewer` /
+ * `--remove-reviewer` GraphQL mutation fails to resolve a bot login (E14's
+ * documented gh-then-REST fallback; see
+ * idd-review-fix.instructions.md#e14). For the default Copilot bot, the REST
+ * identity differs from the GraphQL login; a configured non-default bot's
+ * REST login equals its GraphQL login, since a configured login is already a
+ * real account login. Pure and fails closed to the default REST login when
+ * `primaryBotLogin` is blank.
+ */
+export function resolveAdvisoryBotRestLogin(
+  primaryBotLogin = DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
+) {
+  const normalized = normalizeConfiguredPrimaryBotLogin(primaryBotLogin);
+  return normalized === DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN
+    ? DEFAULT_ADVISORY_PRIMARY_BOT_REST_LOGIN
+    : normalized;
 }
 /**
  * Normalize a configured secondary advisory bot login. Unlike the primary

--- a/scripts/advisory-wait-state.mjs
+++ b/scripts/advisory-wait-state.mjs
@@ -20,6 +20,7 @@ import { loadIddConfig } from './idd-config.mjs';
 import {
   buildAdvisoryWaitSummary,
   compareIsoTimestamps,
+  computeCopilotPendingCoversHead,
   isValidIsoTimestamp,
   normalizeTrustedMarkerLogins,
   parseAdvisoryRecoveryComment,
@@ -186,6 +187,90 @@ export function buildCopilotRecoverySummary(
     reason,
   };
 }
+const STALE_REQUEST_RECOVERY_REASONS = {
+  notPending: 'not-pending',
+  sameHeadMarkerPresent: 'same-head-marker-present',
+  provenCoversHead: 'proven-covers-head',
+  capExhausted: 'recovery-cap-exhausted',
+  attemptEligible: 'recovery-attempt-eligible',
+};
+export function evaluateStaleRequestRecoveryAction(input) {
+  if (!input.copilotPending) {
+    return {
+      action: 'not-applicable',
+      reason: STALE_REQUEST_RECOVERY_REASONS.notPending,
+    };
+  }
+  // A same-head marker (ordinary `advisory-wait:` OR a prior recovery cycle's
+  // `advisory-wait-recovery:`) already anchors this HEAD's clock -- mirrors
+  // evaluateAdvisoryWaitOutcome's own `!sameHeadMarkerPresent` gate for both
+  // its RECOVERY_NEEDED and REQUEST_NEEDED/CAP_EXHAUSTED branches, so this
+  // classifier never contradicts the shared outcome machine's routing.
+  if (input.sameHeadMarkerPresent) {
+    return {
+      action: 'not-applicable',
+      reason: STALE_REQUEST_RECOVERY_REASONS.sameHeadMarkerPresent,
+    };
+  }
+  if (input.copilotPendingCoversHead) {
+    return {
+      action: 'not-applicable',
+      reason: STALE_REQUEST_RECOVERY_REASONS.provenCoversHead,
+    };
+  }
+  if (input.remainingBudget <= 0) {
+    return {
+      action: 'cap-exhausted',
+      reason: STALE_REQUEST_RECOVERY_REASONS.capExhausted,
+    };
+  }
+  return {
+    action: 'attempt',
+    reason: STALE_REQUEST_RECOVERY_REASONS.attemptEligible,
+  };
+}
+/**
+ * `#1571` head-race guard: a pure, string-normalized comparison an E14/F2
+ * caller must re-run immediately before every mutating step of the bounded
+ * recovery cycle (removal, re-request, association verification, marker
+ * post) -- see `idd-advisory-wait.instructions.md`'s `AW3-S`. A `true` result
+ * means the branch moved between the last-known HEAD and this check: the
+ * caller must abort the current attempt without mutating or counting a
+ * cycle, and restart evaluation fresh (return to E1) against the new HEAD.
+ */
+export function detectRecoveryHeadRace(expectedHeadSha, currentHeadSha) {
+  const expected = String(expectedHeadSha ?? '')
+    .trim()
+    .toLowerCase();
+  const current = String(currentHeadSha ?? '')
+    .trim()
+    .toLowerCase();
+  return expected !== current;
+}
+/**
+ * `#1571` post-mutation association proof: after a recovery cycle's
+ * remove-then-re-request completes, re-fetch the PR timeline for the current
+ * HEAD and call this to verify the fresh request is provably associated with
+ * it (a `review_requested` event for the configured primary bot strictly
+ * after the current HEAD's `committed` event) before posting the bound
+ * `advisory-recovery` marker. Delegates to the same proof
+ * {@link evaluateStaleRequestRecoveryAction}'s caller uses to detect
+ * staleness in the first place (`computeCopilotPendingCoversHead`) -- reusing
+ * one proof for both directions keeps them from silently diverging. Returns
+ * `false` (fails closed, do not post the marker or count a cycle) on missing
+ * or ambiguous timeline evidence, exactly like the staleness check.
+ */
+export function verifyRecoveryRequestCoversHead(
+  timelineEvents,
+  prHeadSha,
+  primaryBotLogin,
+) {
+  return computeCopilotPendingCoversHead(
+    timelineEvents,
+    prHeadSha,
+    primaryBotLogin,
+  );
+}
 function normalizePositiveIntegerOption(value, fallback) {
   const number = Number(value);
   return Number.isInteger(number) && number > 0 ? number : fallback;
@@ -336,6 +421,16 @@ function main() {
       terminalWindowMinutes: readAdvisoryTerminalWindowMinutes(),
     },
   );
+  // #1571: bounded stale-request recovery eligibility, derived from the
+  // already-computed AW1-AW3 evidence (summary) plus the #1572 recovery-cycle
+  // budget (copilotRecovery). See evaluateStaleRequestRecoveryAction's own
+  // doc comment for why this is independent of RECOVERY_NEEDED/AW3-R.
+  const staleRequestRecovery = evaluateStaleRequestRecoveryAction({
+    copilotPending: summary.copilotPending,
+    copilotPendingCoversHead: summary.copilotPendingCoversHead,
+    sameHeadMarkerPresent: summary.sameHeadMarkerPresent,
+    remainingBudget: copilotRecovery.remainingBudget,
+  });
   process.stdout.write(
     `${JSON.stringify(
       {
@@ -343,6 +438,7 @@ function main() {
         trustedMarkerActors: configuredTrustedActors,
         trustedMarkerActorsSource,
         copilotRecovery,
+        staleRequestRecovery,
       },
       null,
       2,

--- a/scripts/advisory-wait-state.mjs
+++ b/scripts/advisory-wait-state.mjs
@@ -188,6 +188,7 @@ export function buildCopilotRecoverySummary(
   };
 }
 const STALE_REQUEST_RECOVERY_REASONS = {
+  activeClaimNotProvided: 'active-claim-not-provided',
   notPending: 'not-pending',
   sameHeadMarkerPresent: 'same-head-marker-present',
   provenCoversHead: 'proven-covers-head',
@@ -195,6 +196,12 @@ const STALE_REQUEST_RECOVERY_REASONS = {
   attemptEligible: 'recovery-attempt-eligible',
 };
 export function evaluateStaleRequestRecoveryAction(input) {
+  if (!input.activeClaimProvided) {
+    return {
+      action: 'not-applicable',
+      reason: STALE_REQUEST_RECOVERY_REASONS.activeClaimNotProvided,
+    };
+  }
   if (!input.copilotPending) {
     return {
       action: 'not-applicable',
@@ -234,9 +241,12 @@ export function evaluateStaleRequestRecoveryAction(input) {
  * caller must re-run immediately before every mutating step of the bounded
  * recovery cycle (removal, re-request, association verification, marker
  * post) -- see `idd-advisory-wait.instructions.md`'s `AW3-S`. A `true` result
- * means the branch moved between the last-known HEAD and this check: the
- * caller must abort the current attempt without mutating or counting a
- * cycle, and restart evaluation fresh (return to E1) against the new HEAD.
+ * means either the branch moved between the last-known HEAD and this check,
+ * or a comparison side is missing or not a full 40-hex commit SHA (fails
+ * closed on ambiguous evidence the same way an equal-but-abbreviated or
+ * equal-but-empty pair would otherwise misread as "unchanged"): the caller
+ * must abort the current attempt without mutating or counting a cycle, and
+ * restart evaluation fresh (return to E1) against the new HEAD.
  */
 export function detectRecoveryHeadRace(expectedHeadSha, currentHeadSha) {
   const expected = String(expectedHeadSha ?? '')
@@ -245,12 +255,15 @@ export function detectRecoveryHeadRace(expectedHeadSha, currentHeadSha) {
   const current = String(currentHeadSha ?? '')
     .trim()
     .toLowerCase();
-  // Fail closed on missing evidence: an empty comparison side (even when
-  // BOTH sides are empty, so a naive equality would read as "unchanged")
-  // is not proof HEAD is stable -- it is proof the caller never resolved
-  // one side, and treating that as "no race" would let a recovery mutation
-  // proceed on an unknown HEAD (kurone-kito/idd-skill#1645 review).
-  if (expected === '' || current === '') {
+  // Fail closed on missing OR ambiguous evidence: a comparison side that is
+  // empty, or that is not a full 40-hex commit SHA (e.g. an abbreviated
+  // SHA), is not proof HEAD is stable -- even when both sides are identical
+  // non-full-SHA strings, so a naive equality would misread it as
+  // "unchanged". Treating either case as "no race" would let a recovery
+  // mutation proceed on an unresolved or ambiguous HEAD value
+  // (kurone-kito/idd-skill#1645 review).
+  const fullShaPattern = /^[0-9a-f]{40}$/;
+  if (!fullShaPattern.test(expected) || !fullShaPattern.test(current)) {
     return true;
   }
   return expected !== current;
@@ -438,6 +451,7 @@ function main() {
     copilotPendingCoversHead: summary.copilotPendingCoversHead,
     sameHeadMarkerPresent: summary.sameHeadMarkerPresent,
     remainingBudget: copilotRecovery.remainingBudget,
+    activeClaimProvided: copilotRecovery.activeClaimProvided,
   });
   process.stdout.write(
     `${JSON.stringify(

--- a/scripts/advisory-wait-state.mjs
+++ b/scripts/advisory-wait-state.mjs
@@ -245,6 +245,14 @@ export function detectRecoveryHeadRace(expectedHeadSha, currentHeadSha) {
   const current = String(currentHeadSha ?? '')
     .trim()
     .toLowerCase();
+  // Fail closed on missing evidence: an empty comparison side (even when
+  // BOTH sides are empty, so a naive equality would read as "unchanged")
+  // is not proof HEAD is stable -- it is proof the caller never resolved
+  // one side, and treating that as "no race" would let a recovery mutation
+  // proceed on an unknown HEAD (kurone-kito/idd-skill#1645 review).
+  if (expected === '' || current === '') {
+    return true;
+  }
   return expected !== current;
 }
 /**

--- a/src/scripts/advisory-wait-policy.mts
+++ b/src/scripts/advisory-wait-policy.mts
@@ -13,6 +13,13 @@ export const DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES = 30;
 export const DEFAULT_ADVISORY_SETTLED_WINDOW_MINUTES = 10;
 export const DEFAULT_ADVISORY_POLL_INTERVAL_MINUTES = 2;
 export const DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN = 'copilot';
+// #1571: the default primary bot's GraphQL login (`copilot`) and its REST
+// `requested_reviewers` account login differ -- `gh pr edit --add-reviewer`/
+// `--remove-reviewer` resolve bot logins via GraphQL and some `gh` versions
+// reject the bot login outright, so E14 falls back to this REST identity
+// (see idd-review-fix.instructions.md's gh-then-REST fallback).
+export const DEFAULT_ADVISORY_PRIMARY_BOT_REST_LOGIN =
+  'copilot-pull-request-reviewer[bot]';
 // Shared last-resort fallback for the plural `advisoryBotLogins` config key
 // (distinct from the singular primary-bot-login default above): used by both
 // `merged-pr-feedback-sweep.mts` and `disposition-non-review-notices.mts` so
@@ -147,6 +154,26 @@ export function readAdvisoryPrimaryBotLogin(
   } catch {
     return DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
   }
+}
+
+/**
+ * Resolve the REST API identity for the configured primary advisory bot
+ * (#1571), used only when the `gh pr edit --add-reviewer` /
+ * `--remove-reviewer` GraphQL mutation fails to resolve a bot login (E14's
+ * documented gh-then-REST fallback; see
+ * idd-review-fix.instructions.md#e14). For the default Copilot bot, the REST
+ * identity differs from the GraphQL login; a configured non-default bot's
+ * REST login equals its GraphQL login, since a configured login is already a
+ * real account login. Pure and fails closed to the default REST login when
+ * `primaryBotLogin` is blank.
+ */
+export function resolveAdvisoryBotRestLogin(
+  primaryBotLogin: string = DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
+): string {
+  const normalized = normalizeConfiguredPrimaryBotLogin(primaryBotLogin);
+  return normalized === DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN
+    ? DEFAULT_ADVISORY_PRIMARY_BOT_REST_LOGIN
+    : normalized;
 }
 
 /**

--- a/src/scripts/advisory-wait-state.mts
+++ b/src/scripts/advisory-wait-state.mts
@@ -23,6 +23,7 @@ import type { TrustedMarkerActorResolution } from './protocol-helpers.mts';
 import {
   buildAdvisoryWaitSummary,
   compareIsoTimestamps,
+  computeCopilotPendingCoversHead,
   isValidIsoTimestamp,
   normalizeTrustedMarkerLogins,
   parseAdvisoryRecoveryComment,
@@ -313,6 +314,142 @@ export function buildCopilotRecoverySummary(
   };
 }
 
+/**
+ * `#1571` bounded stale-request recovery classification: whether the current
+ * pending Copilot request should be recovered (removed and re-requested) by
+ * an E14/F2 caller right now. Pure and network-free -- takes already-computed
+ * evidence (the shared AW1-AW3 fields plus the `#1572` recovery-cycle budget)
+ * and returns a decision only; it performs no `gh` mutation itself. Deliberately
+ * distinct from the pre-existing `RECOVERY_NEEDED` outcome (`AW3-R` in
+ * idd-advisory-wait.instructions.md), which anchors a missing same-head marker
+ * for a request the timeline already PROVES covers the current HEAD -- this
+ * function targets the opposite, unproven-coverage case PR #1562 identified
+ * (`copilotPendingCoversHead: false`), where the pending request itself may be
+ * stale and mutating it (remove + re-request) is the correct recovery.
+ */
+export interface StaleRequestRecoveryAction {
+  /**
+   * `'attempt'` -- the pending request is unproven for the current HEAD, no
+   * same-head marker anchors it yet, and recovery-cycle budget remains: an
+   * E14/F2 caller may run the bounded remove/re-request/verify/mark cycle
+   * (`AW3-S`).
+   * `'cap-exhausted'` -- the same unproven condition holds, but the
+   * independent recovery-cycle cap (`#1572`) is already exhausted for this
+   * HEAD: do not remove or re-request; fall back to the ordinary
+   * `CAP_EXHAUSTED_ROUTE` handling instead.
+   * `'not-applicable'` -- no stale-request recovery decision applies (not
+   * pending, request is already proven to cover HEAD, or a same-head marker
+   * already anchors the clock).
+   */
+  action: 'attempt' | 'cap-exhausted' | 'not-applicable';
+  /** Machine-readable reason for `action`. */
+  reason: string;
+}
+
+const STALE_REQUEST_RECOVERY_REASONS = {
+  notPending: 'not-pending',
+  sameHeadMarkerPresent: 'same-head-marker-present',
+  provenCoversHead: 'proven-covers-head',
+  capExhausted: 'recovery-cap-exhausted',
+  attemptEligible: 'recovery-attempt-eligible',
+} as const;
+
+export function evaluateStaleRequestRecoveryAction(input: {
+  copilotPending: boolean;
+  copilotPendingCoversHead: boolean;
+  sameHeadMarkerPresent: boolean;
+  remainingBudget: number;
+}): StaleRequestRecoveryAction {
+  if (!input.copilotPending) {
+    return {
+      action: 'not-applicable',
+      reason: STALE_REQUEST_RECOVERY_REASONS.notPending,
+    };
+  }
+  // A same-head marker (ordinary `advisory-wait:` OR a prior recovery cycle's
+  // `advisory-wait-recovery:`) already anchors this HEAD's clock -- mirrors
+  // evaluateAdvisoryWaitOutcome's own `!sameHeadMarkerPresent` gate for both
+  // its RECOVERY_NEEDED and REQUEST_NEEDED/CAP_EXHAUSTED branches, so this
+  // classifier never contradicts the shared outcome machine's routing.
+  if (input.sameHeadMarkerPresent) {
+    return {
+      action: 'not-applicable',
+      reason: STALE_REQUEST_RECOVERY_REASONS.sameHeadMarkerPresent,
+    };
+  }
+  if (input.copilotPendingCoversHead) {
+    return {
+      action: 'not-applicable',
+      reason: STALE_REQUEST_RECOVERY_REASONS.provenCoversHead,
+    };
+  }
+  if (input.remainingBudget <= 0) {
+    return {
+      action: 'cap-exhausted',
+      reason: STALE_REQUEST_RECOVERY_REASONS.capExhausted,
+    };
+  }
+  return {
+    action: 'attempt',
+    reason: STALE_REQUEST_RECOVERY_REASONS.attemptEligible,
+  };
+}
+
+/**
+ * `#1571` head-race guard: a pure, string-normalized comparison an E14/F2
+ * caller must re-run immediately before every mutating step of the bounded
+ * recovery cycle (removal, re-request, association verification, marker
+ * post) -- see `idd-advisory-wait.instructions.md`'s `AW3-S`. A `true` result
+ * means the branch moved between the last-known HEAD and this check: the
+ * caller must abort the current attempt without mutating or counting a
+ * cycle, and restart evaluation fresh (return to E1) against the new HEAD.
+ */
+export function detectRecoveryHeadRace(
+  expectedHeadSha: string,
+  currentHeadSha: string,
+): boolean {
+  const expected = String(expectedHeadSha ?? '')
+    .trim()
+    .toLowerCase();
+  const current = String(currentHeadSha ?? '')
+    .trim()
+    .toLowerCase();
+  return expected !== current;
+}
+
+/** Minimal timeline event shape consumed by {@link verifyRecoveryRequestCoversHead}. */
+interface RecoveryTimelineEventLike {
+  event?: string | null;
+  sha?: string | null;
+  commit_id?: string | null;
+  requested_reviewer?: { login?: string | null } | null;
+}
+
+/**
+ * `#1571` post-mutation association proof: after a recovery cycle's
+ * remove-then-re-request completes, re-fetch the PR timeline for the current
+ * HEAD and call this to verify the fresh request is provably associated with
+ * it (a `review_requested` event for the configured primary bot strictly
+ * after the current HEAD's `committed` event) before posting the bound
+ * `advisory-recovery` marker. Delegates to the same proof
+ * {@link evaluateStaleRequestRecoveryAction}'s caller uses to detect
+ * staleness in the first place (`computeCopilotPendingCoversHead`) -- reusing
+ * one proof for both directions keeps them from silently diverging. Returns
+ * `false` (fails closed, do not post the marker or count a cycle) on missing
+ * or ambiguous timeline evidence, exactly like the staleness check.
+ */
+export function verifyRecoveryRequestCoversHead(
+  timelineEvents: RecoveryTimelineEventLike[],
+  prHeadSha: string,
+  primaryBotLogin?: string,
+): boolean {
+  return computeCopilotPendingCoversHead(
+    timelineEvents,
+    prHeadSha,
+    primaryBotLogin,
+  );
+}
+
 function normalizePositiveIntegerOption(
   value: unknown,
   fallback: number,
@@ -339,6 +476,7 @@ export type AdvisoryWaitStateReport = ReturnType<
   trustedMarkerActors: string[];
   trustedMarkerActorsSource: TrustedMarkerActorResolution['source'];
   copilotRecovery: CopilotRecoverySummary;
+  staleRequestRecovery: StaleRequestRecoveryAction;
 };
 
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
@@ -492,6 +630,17 @@ function main(): void {
     },
   );
 
+  // #1571: bounded stale-request recovery eligibility, derived from the
+  // already-computed AW1-AW3 evidence (summary) plus the #1572 recovery-cycle
+  // budget (copilotRecovery). See evaluateStaleRequestRecoveryAction's own
+  // doc comment for why this is independent of RECOVERY_NEEDED/AW3-R.
+  const staleRequestRecovery = evaluateStaleRequestRecoveryAction({
+    copilotPending: summary.copilotPending,
+    copilotPendingCoversHead: summary.copilotPendingCoversHead,
+    sameHeadMarkerPresent: summary.sameHeadMarkerPresent,
+    remainingBudget: copilotRecovery.remainingBudget,
+  });
+
   process.stdout.write(
     `${JSON.stringify(
       {
@@ -499,6 +648,7 @@ function main(): void {
         trustedMarkerActors: configuredTrustedActors,
         trustedMarkerActorsSource,
         copilotRecovery,
+        staleRequestRecovery,
       },
       null,
       2,

--- a/src/scripts/advisory-wait-state.mts
+++ b/src/scripts/advisory-wait-state.mts
@@ -414,6 +414,14 @@ export function detectRecoveryHeadRace(
   const current = String(currentHeadSha ?? '')
     .trim()
     .toLowerCase();
+  // Fail closed on missing evidence: an empty comparison side (even when
+  // BOTH sides are empty, so a naive equality would read as "unchanged")
+  // is not proof HEAD is stable -- it is proof the caller never resolved
+  // one side, and treating that as "no race" would let a recovery mutation
+  // proceed on an unknown HEAD (kurone-kito/idd-skill#1645 review).
+  if (expected === '' || current === '') {
+    return true;
+  }
   return expected !== current;
 }
 

--- a/src/scripts/advisory-wait-state.mts
+++ b/src/scripts/advisory-wait-state.mts
@@ -337,9 +337,9 @@ export interface StaleRequestRecoveryAction {
    * independent recovery-cycle cap (`#1572`) is already exhausted for this
    * HEAD: do not remove or re-request; fall back to the ordinary
    * `CAP_EXHAUSTED_ROUTE` handling instead.
-   * `'not-applicable'` -- no stale-request recovery decision applies (not
-   * pending, request is already proven to cover HEAD, or a same-head marker
-   * already anchors the clock).
+   * `'not-applicable'` -- no stale-request recovery decision applies (no
+   * claim-bound evidence, not pending, request is already proven to cover
+   * HEAD, or a same-head marker already anchors the clock).
    */
   action: 'attempt' | 'cap-exhausted' | 'not-applicable';
   /** Machine-readable reason for `action`. */
@@ -347,6 +347,7 @@ export interface StaleRequestRecoveryAction {
 }
 
 const STALE_REQUEST_RECOVERY_REASONS = {
+  activeClaimNotProvided: 'active-claim-not-provided',
   notPending: 'not-pending',
   sameHeadMarkerPresent: 'same-head-marker-present',
   provenCoversHead: 'proven-covers-head',
@@ -359,7 +360,24 @@ export function evaluateStaleRequestRecoveryAction(input: {
   copilotPendingCoversHead: boolean;
   sameHeadMarkerPresent: boolean;
   remainingBudget: number;
+  /**
+   * Mirrors {@link CopilotRecoverySummary.activeClaimProvided}: `true` only
+   * when the caller supplied both `--claim-id` and `--agent-id` so the
+   * recovery-cycle budget in `remainingBudget` is actually derived from
+   * claim-bound marker evidence, not just defaulted to the full cap. AW3-S
+   * requires claim binding to authorize a mutation (kurone-kito/idd-skill#1645
+   * review); omitting this check would let an unbound `remainingBudget`
+   * (which reads as the full cap when no evidence was ever counted) produce
+   * `"attempt"` without proof no cycle has already run.
+   */
+  activeClaimProvided: boolean;
 }): StaleRequestRecoveryAction {
+  if (!input.activeClaimProvided) {
+    return {
+      action: 'not-applicable',
+      reason: STALE_REQUEST_RECOVERY_REASONS.activeClaimNotProvided,
+    };
+  }
   if (!input.copilotPending) {
     return {
       action: 'not-applicable',
@@ -400,9 +418,12 @@ export function evaluateStaleRequestRecoveryAction(input: {
  * caller must re-run immediately before every mutating step of the bounded
  * recovery cycle (removal, re-request, association verification, marker
  * post) -- see `idd-advisory-wait.instructions.md`'s `AW3-S`. A `true` result
- * means the branch moved between the last-known HEAD and this check: the
- * caller must abort the current attempt without mutating or counting a
- * cycle, and restart evaluation fresh (return to E1) against the new HEAD.
+ * means either the branch moved between the last-known HEAD and this check,
+ * or a comparison side is missing or not a full 40-hex commit SHA (fails
+ * closed on ambiguous evidence the same way an equal-but-abbreviated or
+ * equal-but-empty pair would otherwise misread as "unchanged"): the caller
+ * must abort the current attempt without mutating or counting a cycle, and
+ * restart evaluation fresh (return to E1) against the new HEAD.
  */
 export function detectRecoveryHeadRace(
   expectedHeadSha: string,
@@ -414,12 +435,15 @@ export function detectRecoveryHeadRace(
   const current = String(currentHeadSha ?? '')
     .trim()
     .toLowerCase();
-  // Fail closed on missing evidence: an empty comparison side (even when
-  // BOTH sides are empty, so a naive equality would read as "unchanged")
-  // is not proof HEAD is stable -- it is proof the caller never resolved
-  // one side, and treating that as "no race" would let a recovery mutation
-  // proceed on an unknown HEAD (kurone-kito/idd-skill#1645 review).
-  if (expected === '' || current === '') {
+  // Fail closed on missing OR ambiguous evidence: a comparison side that is
+  // empty, or that is not a full 40-hex commit SHA (e.g. an abbreviated
+  // SHA), is not proof HEAD is stable -- even when both sides are identical
+  // non-full-SHA strings, so a naive equality would misread it as
+  // "unchanged". Treating either case as "no race" would let a recovery
+  // mutation proceed on an unresolved or ambiguous HEAD value
+  // (kurone-kito/idd-skill#1645 review).
+  const fullShaPattern = /^[0-9a-f]{40}$/;
+  if (!fullShaPattern.test(expected) || !fullShaPattern.test(current)) {
     return true;
   }
   return expected !== current;
@@ -647,6 +671,7 @@ function main(): void {
     copilotPendingCoversHead: summary.copilotPendingCoversHead,
     sameHeadMarkerPresent: summary.sameHeadMarkerPresent,
     remainingBudget: copilotRecovery.remainingBudget,
+    activeClaimProvided: copilotRecovery.activeClaimProvided,
   });
 
   process.stdout.write(

--- a/tests/advisory-wait-recovery.test.mts
+++ b/tests/advisory-wait-recovery.test.mts
@@ -82,6 +82,51 @@ function recoveryComment(overrides: {
   };
 }
 
+// --- 0. Active-claim gating (fail closed without claim-bound evidence) -----
+
+test('evaluateStaleRequestRecoveryAction: not-applicable when no active claim was provided, even though every other condition looks attempt-eligible', () => {
+  // kurone-kito/idd-skill#1645 review: without --claim-id/--agent-id,
+  // buildCopilotRecoverySummary's remainingBudget defaults to the full cap
+  // (no marker evidence was ever counted), which must NOT be trusted as
+  // "budget available" -- the claim-not-provided signal takes precedence
+  // over every other field, including a stale-looking pending request.
+  const decision = evaluateStaleRequestRecoveryAction({
+    copilotPending: true,
+    copilotPendingCoversHead: false,
+    sameHeadMarkerPresent: false,
+    remainingBudget: 2,
+    activeClaimProvided: false,
+  });
+  assert.deepEqual(decision, {
+    action: 'not-applicable',
+    reason: 'active-claim-not-provided',
+  });
+});
+
+test('integration: an unbound advisory-wait-state invocation (no --claim-id/--agent-id) never reports "attempt"', () => {
+  const copilotRecovery = buildCopilotRecoverySummary(
+    { comments: [], prHeadSha: SHA, lastCopilotCommit: '' },
+    { ...BASE_RECOVERY_OPTIONS, claimId: '', agentId: '' },
+  );
+  // The #1572 contract already fails this closed to NOT_TERMINAL, but
+  // remainingBudget alone still reads as the full un-decremented cap --
+  // exactly the unbound-evidence trap the #1571 review caught.
+  assert.equal(copilotRecovery.activeClaimProvided, false);
+  assert.equal(copilotRecovery.remainingBudget, 2);
+
+  const decision = evaluateStaleRequestRecoveryAction({
+    copilotPending: true,
+    copilotPendingCoversHead: false,
+    sameHeadMarkerPresent: false,
+    remainingBudget: copilotRecovery.remainingBudget,
+    activeClaimProvided: copilotRecovery.activeClaimProvided,
+  });
+  assert.deepEqual(decision, {
+    action: 'not-applicable',
+    reason: 'active-claim-not-provided',
+  });
+});
+
 // --- 1. Stale (unproven) versus current-head (proven) pending requests -----
 
 test('evaluateStaleRequestRecoveryAction: attempt-eligible for an unproven pending request (PR #1562 shape)', () => {
@@ -109,6 +154,7 @@ test('evaluateStaleRequestRecoveryAction: attempt-eligible for an unproven pendi
     copilotPendingCoversHead: summary.copilotPendingCoversHead,
     sameHeadMarkerPresent: summary.sameHeadMarkerPresent,
     remainingBudget: 2,
+    activeClaimProvided: true,
   });
   assert.deepEqual(decision, {
     action: 'attempt',
@@ -139,6 +185,7 @@ test('evaluateStaleRequestRecoveryAction: not-applicable when the request is alr
     copilotPendingCoversHead: summary.copilotPendingCoversHead,
     sameHeadMarkerPresent: summary.sameHeadMarkerPresent,
     remainingBudget: 2,
+    activeClaimProvided: true,
   });
   assert.deepEqual(decision, {
     action: 'not-applicable',
@@ -152,6 +199,7 @@ test('evaluateStaleRequestRecoveryAction: not-applicable when Copilot is not pen
     copilotPendingCoversHead: false,
     sameHeadMarkerPresent: false,
     remainingBudget: 2,
+    activeClaimProvided: true,
   });
   assert.deepEqual(decision, {
     action: 'not-applicable',
@@ -165,6 +213,7 @@ test("evaluateStaleRequestRecoveryAction: not-applicable once a same-head marker
     copilotPendingCoversHead: false,
     sameHeadMarkerPresent: true,
     remainingBudget: 2,
+    activeClaimProvided: true,
   });
   assert.deepEqual(decision, {
     action: 'not-applicable',
@@ -263,6 +312,17 @@ test('detectRecoveryHeadRace: fails closed even when BOTH HEADs are missing (kur
   assert.equal(detectRecoveryHeadRace('   ', '   '), true);
 });
 
+test('detectRecoveryHeadRace: fails closed on an abbreviated (non-full-length) SHA, even when both sides match (kurone-kito/idd-skill#1645 review)', () => {
+  const abbreviated = SHA.slice(0, 7);
+  assert.equal(detectRecoveryHeadRace(abbreviated, abbreviated), true);
+  assert.equal(detectRecoveryHeadRace(abbreviated, SHA), true);
+});
+
+test('detectRecoveryHeadRace: fails closed on a non-hex or wrong-length value, even when both sides match', () => {
+  assert.equal(detectRecoveryHeadRace('not-a-sha', 'not-a-sha'), true);
+  assert.equal(detectRecoveryHeadRace(`${SHA}extra`, `${SHA}extra`), true);
+});
+
 // --- 4. Retry-cap exhaustion -------------------------------------------------
 
 test('evaluateStaleRequestRecoveryAction: cap-exhausted when the independent #1572 recovery-cycle budget is spent, even though the ordinary request path would still allow more attempts', () => {
@@ -271,6 +331,7 @@ test('evaluateStaleRequestRecoveryAction: cap-exhausted when the independent #15
     copilotPendingCoversHead: false,
     sameHeadMarkerPresent: false,
     remainingBudget: 0,
+    activeClaimProvided: true,
   });
   assert.deepEqual(decision, {
     action: 'cap-exhausted',
@@ -284,6 +345,7 @@ test('evaluateStaleRequestRecoveryAction: attempt-eligible with exactly one cycl
     copilotPendingCoversHead: false,
     sameHeadMarkerPresent: false,
     remainingBudget: 1,
+    activeClaimProvided: true,
   });
   assert.equal(decision.action, 'attempt');
 });
@@ -313,6 +375,7 @@ test('integration: a full recovery-cap exhaustion sequence via buildCopilotRecov
     copilotPendingCoversHead: false,
     sameHeadMarkerPresent: false,
     remainingBudget: copilotRecovery.remainingBudget,
+    activeClaimProvided: copilotRecovery.activeClaimProvided,
   });
   assert.deepEqual(decision, {
     action: 'cap-exhausted',
@@ -339,6 +402,7 @@ test('integration: re-entering after a partial failure (no marker posted yet) do
     copilotPendingCoversHead: false,
     sameHeadMarkerPresent: false,
     remainingBudget: copilotRecovery.remainingBudget,
+    activeClaimProvided: copilotRecovery.activeClaimProvided,
   });
   assert.equal(decision.action, 'attempt');
 });
@@ -376,6 +440,7 @@ test("integration: once one cycle's marker is verified and posted, re-evaluating
     copilotPendingCoversHead: false,
     sameHeadMarkerPresent: summary.sameHeadMarkerPresent,
     remainingBudget: copilotRecovery.remainingBudget,
+    activeClaimProvided: copilotRecovery.activeClaimProvided,
   });
   assert.deepEqual(decision, {
     action: 'not-applicable',
@@ -488,6 +553,7 @@ test('a full CLI output shape (summary + copilotRecovery + staleRequestRecovery)
     copilotPendingCoversHead: summary.copilotPendingCoversHead,
     sameHeadMarkerPresent: summary.sameHeadMarkerPresent,
     remainingBudget: copilotRecovery.remainingBudget,
+    activeClaimProvided: copilotRecovery.activeClaimProvided,
   });
 
   const fullOutput = {
@@ -507,6 +573,7 @@ test('the schema rejects a staleRequestRecovery object missing a required field 
     copilotPendingCoversHead: false,
     sameHeadMarkerPresent: false,
     remainingBudget: 2,
+    activeClaimProvided: true,
   });
 
   const { reason: _omitted, ...missingReason } = decision;

--- a/tests/advisory-wait-recovery.test.mts
+++ b/tests/advisory-wait-recovery.test.mts
@@ -258,6 +258,11 @@ test('detectRecoveryHeadRace: fails closed (reports a race) when either HEAD is 
   assert.equal(detectRecoveryHeadRace(SHA, ''), true);
 });
 
+test('detectRecoveryHeadRace: fails closed even when BOTH HEADs are missing (kurone-kito/idd-skill#1645 review: a naive equality would misread this as "no race")', () => {
+  assert.equal(detectRecoveryHeadRace('', ''), true);
+  assert.equal(detectRecoveryHeadRace('   ', '   '), true);
+});
+
 // --- 4. Retry-cap exhaustion -------------------------------------------------
 
 test('evaluateStaleRequestRecoveryAction: cap-exhausted when the independent #1572 recovery-cycle budget is spent, even though the ordinary request path would still allow more attempts', () => {

--- a/tests/advisory-wait-recovery.test.mts
+++ b/tests/advisory-wait-recovery.test.mts
@@ -1,0 +1,531 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
+  DEFAULT_ADVISORY_PRIMARY_BOT_REST_LOGIN,
+  resolveAdvisoryBotRestLogin,
+} from '../src/scripts/advisory-wait-policy.mts';
+import {
+  buildCopilotRecoverySummary,
+  detectRecoveryHeadRace,
+  evaluateStaleRequestRecoveryAction,
+  verifyRecoveryRequestCoversHead,
+} from '../src/scripts/advisory-wait-state.mts';
+import {
+  buildAdvisoryWaitSummary,
+  renderAdvisoryWaitRecoveryMarker,
+} from '../src/scripts/protocol-helpers.mts';
+import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
+import { readJson } from './test-utils.mts';
+
+// =============================================================================
+// #1571: bounded stale-request recovery -- the execution layer that consumes
+// the #1572 state contract (buildCopilotRecoverySummary) to decide whether a
+// pending-but-unproven Copilot request should be removed and re-requested.
+//
+// Deliberately distinct from the pre-existing RECOVERY_NEEDED/AW3-R path
+// (recovery-needed.json: copilotPendingCoversHead=true, a proven request
+// missing only its own anchor marker). #1571 targets the OPPOSITE,
+// unproven-coverage case PR #1562 identified
+// (pending-covers-head-force-push.json: copilotPendingCoversHead=false).
+// =============================================================================
+
+const advisoryWaitStateSchema = loadJson(
+  'schemas/advisory-wait-state.schema.json',
+);
+const relaxedAdvisoryWaitStateSchema = {
+  ...(advisoryWaitStateSchema as Record<string, unknown>),
+  required: [],
+};
+
+const SHA = '0123456789abcdef0123456789abcdef01234567';
+const OTHER_SHA = 'fedcba9876543210fedcba9876543210fedcba98';
+const AGENT = 'claude-b8bb632d';
+const CLAIM = 'clm-2d1b106e486d';
+const TRUSTED = [AGENT];
+
+const BASE_RECOVERY_OPTIONS = {
+  now: '2026-07-22T12:00:00Z',
+  trustedMarkerLogins: TRUSTED,
+  claimId: CLAIM,
+  agentId: AGENT,
+  recoveryCycleCap: 2,
+  terminalWindowMinutes: 720,
+};
+
+function recoveryComment(overrides: {
+  login?: string;
+  createdAt: string;
+  agentId?: string;
+  headSha?: string;
+  claimId?: string | null;
+  attempt?: number | null;
+  timestamp?: string;
+}) {
+  const {
+    login = AGENT,
+    createdAt,
+    agentId = AGENT,
+    headSha = SHA,
+    claimId = CLAIM,
+    attempt = 1,
+    timestamp = '2026-07-20T00:00:00Z',
+  } = overrides;
+  const payload: Record<string, unknown> = { agentId, headSha, timestamp };
+  if (claimId !== null) payload.claimId = claimId;
+  if (attempt !== null) payload.attempt = attempt;
+  return {
+    author: { login },
+    body: renderAdvisoryWaitRecoveryMarker(payload),
+    createdAt,
+  };
+}
+
+// --- 1. Stale (unproven) versus current-head (proven) pending requests -----
+
+test('evaluateStaleRequestRecoveryAction: attempt-eligible for an unproven pending request (PR #1562 shape)', () => {
+  const fixture = readJson(
+    'fixtures/advisory-wait/pending-covers-head-force-push.json',
+  );
+  const summary = buildAdvisoryWaitSummary(
+    {
+      prHeadSha: fixture.input.prHeadSha,
+      reviews: fixture.input.reviews,
+      requestedReviewers: fixture.input.requestedReviewers,
+      timelineEvents: fixture.input.timelineEvents,
+      comments: fixture.input.comments,
+    },
+    {
+      now: fixture.input.now,
+      trustedMarkerLogins: fixture.input.trustedMarkerLogins,
+    },
+  );
+  assert.equal(summary.copilotPending, true);
+  assert.equal(summary.copilotPendingCoversHead, false);
+
+  const decision = evaluateStaleRequestRecoveryAction({
+    copilotPending: summary.copilotPending,
+    copilotPendingCoversHead: summary.copilotPendingCoversHead,
+    sameHeadMarkerPresent: summary.sameHeadMarkerPresent,
+    remainingBudget: 2,
+  });
+  assert.deepEqual(decision, {
+    action: 'attempt',
+    reason: 'recovery-attempt-eligible',
+  });
+});
+
+test('evaluateStaleRequestRecoveryAction: not-applicable when the request is already proven to cover HEAD (the pre-existing RECOVERY_NEEDED/AW3-R case is untouched)', () => {
+  const fixture = readJson('fixtures/advisory-wait/recovery-needed.json');
+  const summary = buildAdvisoryWaitSummary(
+    {
+      prHeadSha: fixture.input.prHeadSha,
+      reviews: fixture.input.reviews,
+      requestedReviewers: fixture.input.requestedReviewers,
+      timelineEvents: fixture.input.timelineEvents,
+      comments: fixture.input.comments,
+    },
+    {
+      now: fixture.input.now,
+      trustedMarkerLogins: fixture.input.trustedMarkerLogins,
+    },
+  );
+  assert.equal(summary.outcome, 'RECOVERY_NEEDED');
+  assert.equal(summary.copilotPendingCoversHead, true);
+
+  const decision = evaluateStaleRequestRecoveryAction({
+    copilotPending: summary.copilotPending,
+    copilotPendingCoversHead: summary.copilotPendingCoversHead,
+    sameHeadMarkerPresent: summary.sameHeadMarkerPresent,
+    remainingBudget: 2,
+  });
+  assert.deepEqual(decision, {
+    action: 'not-applicable',
+    reason: 'proven-covers-head',
+  });
+});
+
+test('evaluateStaleRequestRecoveryAction: not-applicable when Copilot is not pending at all', () => {
+  const decision = evaluateStaleRequestRecoveryAction({
+    copilotPending: false,
+    copilotPendingCoversHead: false,
+    sameHeadMarkerPresent: false,
+    remainingBudget: 2,
+  });
+  assert.deepEqual(decision, {
+    action: 'not-applicable',
+    reason: 'not-pending',
+  });
+});
+
+test("evaluateStaleRequestRecoveryAction: not-applicable once a same-head marker already anchors the clock (mirrors evaluateAdvisoryWaitOutcome's own gate, never contradicts it)", () => {
+  const decision = evaluateStaleRequestRecoveryAction({
+    copilotPending: true,
+    copilotPendingCoversHead: false,
+    sameHeadMarkerPresent: true,
+    remainingBudget: 2,
+  });
+  assert.deepEqual(decision, {
+    action: 'not-applicable',
+    reason: 'same-head-marker-present',
+  });
+});
+
+// --- 2. Missing/ambiguous timeline evidence (fail-closed) -------------------
+
+test('verifyRecoveryRequestCoversHead: fails closed (false) when the timeline has no committed event for the current HEAD', () => {
+  const covers = verifyRecoveryRequestCoversHead(
+    [
+      {
+        event: 'review_requested',
+        requested_reviewer: { login: 'copilot' },
+      },
+    ],
+    SHA,
+  );
+  assert.equal(covers, false);
+});
+
+test('verifyRecoveryRequestCoversHead: fails closed (false) when the timeline has no review_requested event at all', () => {
+  const covers = verifyRecoveryRequestCoversHead(
+    [{ event: 'committed', sha: SHA }],
+    SHA,
+  );
+  assert.equal(covers, false);
+});
+
+test('verifyRecoveryRequestCoversHead: fails closed (false) when the review_requested event precedes the HEAD commit (stale/ambiguous ordering)', () => {
+  const covers = verifyRecoveryRequestCoversHead(
+    [
+      {
+        event: 'review_requested',
+        requested_reviewer: { login: 'copilot' },
+      },
+      { event: 'committed', sha: SHA },
+    ],
+    SHA,
+  );
+  assert.equal(covers, false);
+});
+
+test('verifyRecoveryRequestCoversHead: true only when review_requested strictly follows the current HEAD commit event -- the post-mutation association proof', () => {
+  const covers = verifyRecoveryRequestCoversHead(
+    [
+      { event: 'committed', sha: SHA },
+      {
+        event: 'review_requested',
+        requested_reviewer: { login: 'copilot' },
+      },
+    ],
+    SHA,
+  );
+  assert.equal(covers, true);
+});
+
+test('verifyRecoveryRequestCoversHead: respects a configured non-default primary bot login', () => {
+  const covers = verifyRecoveryRequestCoversHead(
+    [
+      { event: 'committed', sha: SHA },
+      { event: 'review_requested', requested_reviewer: { login: 'my-bot' } },
+    ],
+    SHA,
+    'my-bot',
+  );
+  assert.equal(covers, true);
+});
+
+// --- 3. Head movement races --------------------------------------------------
+
+test('detectRecoveryHeadRace: no race when the expected and current HEAD match', () => {
+  assert.equal(detectRecoveryHeadRace(SHA, SHA), false);
+});
+
+test('detectRecoveryHeadRace: race detected when HEAD moved between the staleness check and a mutating step', () => {
+  assert.equal(detectRecoveryHeadRace(SHA, OTHER_SHA), true);
+});
+
+test('detectRecoveryHeadRace: case-insensitive comparison (a mixed-case SHA is not itself a race)', () => {
+  assert.equal(detectRecoveryHeadRace(SHA, SHA.toUpperCase()), false);
+});
+
+test('detectRecoveryHeadRace: trims incidental whitespace before comparing', () => {
+  assert.equal(detectRecoveryHeadRace(` ${SHA} `, SHA), false);
+});
+
+test('detectRecoveryHeadRace: fails closed (reports a race) when either HEAD is missing', () => {
+  assert.equal(detectRecoveryHeadRace('', SHA), true);
+  assert.equal(detectRecoveryHeadRace(SHA, ''), true);
+});
+
+// --- 4. Retry-cap exhaustion -------------------------------------------------
+
+test('evaluateStaleRequestRecoveryAction: cap-exhausted when the independent #1572 recovery-cycle budget is spent, even though the ordinary request path would still allow more attempts', () => {
+  const decision = evaluateStaleRequestRecoveryAction({
+    copilotPending: true,
+    copilotPendingCoversHead: false,
+    sameHeadMarkerPresent: false,
+    remainingBudget: 0,
+  });
+  assert.deepEqual(decision, {
+    action: 'cap-exhausted',
+    reason: 'recovery-cap-exhausted',
+  });
+});
+
+test('evaluateStaleRequestRecoveryAction: attempt-eligible with exactly one cycle of budget remaining', () => {
+  const decision = evaluateStaleRequestRecoveryAction({
+    copilotPending: true,
+    copilotPendingCoversHead: false,
+    sameHeadMarkerPresent: false,
+    remainingBudget: 1,
+  });
+  assert.equal(decision.action, 'attempt');
+});
+
+test('integration: a full recovery-cap exhaustion sequence via buildCopilotRecoverySummary -> evaluateStaleRequestRecoveryAction', () => {
+  // Two completed, verified recovery cycles for this exact HEAD already
+  // exist -- the independent #1572 cap (default 2) is now exhausted.
+  const comments = [
+    recoveryComment({ createdAt: '2026-07-22T09:00:00Z', attempt: 1 }),
+    recoveryComment({ createdAt: '2026-07-22T10:00:00Z', attempt: 2 }),
+  ];
+  const copilotRecovery = buildCopilotRecoverySummary(
+    { comments, prHeadSha: SHA, lastCopilotCommit: '' },
+    BASE_RECOVERY_OPTIONS,
+  );
+  assert.equal(copilotRecovery.completedCycleCount, 2);
+  assert.equal(copilotRecovery.remainingBudget, 0);
+
+  // A same-head marker is naturally present too (the posted recovery
+  // markers themselves anchor the clock) -- either reason independently
+  // routes away from a third mutation; assert the cap reason specifically
+  // by isolating the marker-presence signal a caller would compute fresh
+  // from a re-fetched PR (no NEW same-head marker beyond the recovery ones
+  // already counted above).
+  const decision = evaluateStaleRequestRecoveryAction({
+    copilotPending: true,
+    copilotPendingCoversHead: false,
+    sameHeadMarkerPresent: false,
+    remainingBudget: copilotRecovery.remainingBudget,
+  });
+  assert.deepEqual(decision, {
+    action: 'cap-exhausted',
+    reason: 'recovery-cap-exhausted',
+  });
+});
+
+// --- 5. Idempotent restart after a partial failure --------------------------
+
+test('integration: re-entering after a partial failure (no marker posted yet) does not double-count or block the retry', () => {
+  // No advisory-recovery marker has been posted yet for this HEAD (the
+  // prior attempt failed before reaching the "post exactly one marker"
+  // step) -- the budget must read as fully available, and the classifier
+  // must still say "attempt", not something stricter.
+  const copilotRecovery = buildCopilotRecoverySummary(
+    { comments: [], prHeadSha: SHA, lastCopilotCommit: '' },
+    BASE_RECOVERY_OPTIONS,
+  );
+  assert.equal(copilotRecovery.completedCycleCount, 0);
+  assert.equal(copilotRecovery.remainingBudget, 2);
+
+  const decision = evaluateStaleRequestRecoveryAction({
+    copilotPending: true,
+    copilotPendingCoversHead: false,
+    sameHeadMarkerPresent: false,
+    remainingBudget: copilotRecovery.remainingBudget,
+  });
+  assert.equal(decision.action, 'attempt');
+});
+
+test("integration: once one cycle's marker is verified and posted, re-evaluating the SAME evidence does not re-trigger a second mutation for that HEAD", () => {
+  const comments = [
+    recoveryComment({ createdAt: '2026-07-22T09:00:00Z', attempt: 1 }),
+  ];
+  const copilotRecovery = buildCopilotRecoverySummary(
+    { comments, prHeadSha: SHA, lastCopilotCommit: '' },
+    BASE_RECOVERY_OPTIONS,
+  );
+  assert.equal(copilotRecovery.completedCycleCount, 1);
+  assert.equal(copilotRecovery.remainingBudget, 1);
+
+  // A fresh re-fetch of the PR now sees the just-posted recovery marker as
+  // a same-head marker (advisoryWaitMarkerMatchesHead recognizes the bound
+  // advisory-wait-recovery: form) -- this is what naturally stops a second
+  // removal/re-request attempt for the SAME HEAD within the same pass, even
+  // though one cycle of budget remains for a genuinely later recurrence.
+  const summary = buildAdvisoryWaitSummary(
+    {
+      prHeadSha: SHA,
+      reviews: [],
+      requestedReviewers: [{ login: 'copilot' }],
+      timelineEvents: [],
+      comments,
+    },
+    { now: BASE_RECOVERY_OPTIONS.now, trustedMarkerLogins: TRUSTED },
+  );
+  assert.equal(summary.sameHeadMarkerPresent, true);
+
+  const decision = evaluateStaleRequestRecoveryAction({
+    copilotPending: true,
+    copilotPendingCoversHead: false,
+    sameHeadMarkerPresent: summary.sameHeadMarkerPresent,
+    remainingBudget: copilotRecovery.remainingBudget,
+  });
+  assert.deepEqual(decision, {
+    action: 'not-applicable',
+    reason: 'same-head-marker-present',
+  });
+});
+
+// --- 6. CLI/REST fallback identity resolution -------------------------------
+
+test('resolveAdvisoryBotRestLogin: the default Copilot bot resolves to its distinct REST identity', () => {
+  assert.equal(
+    resolveAdvisoryBotRestLogin(DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN),
+    DEFAULT_ADVISORY_PRIMARY_BOT_REST_LOGIN,
+  );
+  assert.equal(
+    DEFAULT_ADVISORY_PRIMARY_BOT_REST_LOGIN,
+    'copilot-pull-request-reviewer[bot]',
+  );
+});
+
+test('resolveAdvisoryBotRestLogin: defaults to the Copilot REST login when called with no argument', () => {
+  assert.equal(
+    resolveAdvisoryBotRestLogin(),
+    DEFAULT_ADVISORY_PRIMARY_BOT_REST_LOGIN,
+  );
+});
+
+test('resolveAdvisoryBotRestLogin: a configured non-default bot login is already a real account login -- its REST login equals itself', () => {
+  assert.equal(resolveAdvisoryBotRestLogin('my-review-bot'), 'my-review-bot');
+});
+
+test('resolveAdvisoryBotRestLogin: normalizes case and surrounding whitespace before comparing against the default', () => {
+  assert.equal(
+    resolveAdvisoryBotRestLogin(' Copilot '),
+    DEFAULT_ADVISORY_PRIMARY_BOT_REST_LOGIN,
+  );
+});
+
+test('resolveAdvisoryBotRestLogin: fails closed to the default REST login for a blank/absent configured login', () => {
+  assert.equal(
+    resolveAdvisoryBotRestLogin(''),
+    DEFAULT_ADVISORY_PRIMARY_BOT_REST_LOGIN,
+  );
+});
+
+// --- 7. Preservation of ordinary request/reroll counters --------------------
+
+test('a bound advisory-recovery marker anchors the same-head clock but does NOT consume the ordinary request-cap counter', () => {
+  const comments = [
+    recoveryComment({ createdAt: '2026-07-22T09:00:00Z', attempt: 1 }),
+  ];
+  const summary = buildAdvisoryWaitSummary(
+    {
+      prHeadSha: SHA,
+      reviews: [],
+      requestedReviewers: [{ login: 'copilot' }],
+      timelineEvents: [],
+      comments,
+    },
+    {
+      now: '2026-07-22T09:05:00Z',
+      trustedMarkerLogins: TRUSTED,
+      requestCap: 30,
+    },
+  );
+  assert.equal(summary.sameHeadMarkerPresent, true);
+  assert.equal(summary.sameHeadMarkerCount, 1);
+  // The independence this satisfies: requestMarkerCount (which CAP_EXHAUSTED
+  // gates against requestCap) only counts `advisory-wait:`-prefixed markers,
+  // never `advisory-wait-recovery:` ones -- so a stale-request recovery
+  // cycle never burns the ordinary 30-request budget.
+  assert.equal(summary.requestMarkerCount, 0);
+});
+
+test('integration: the independent recovery-cycle cap accounts correctly even when the caller also supplies an unrelated requestCap-shaped option (accounting stays independent of both requestCap and sameHeadRerollCap)', () => {
+  const comments = [
+    recoveryComment({ createdAt: '2026-07-22T09:00:00Z', attempt: 1 }),
+  ];
+  const copilotRecovery = buildCopilotRecoverySummary(
+    { comments, prHeadSha: SHA, lastCopilotCommit: '' },
+    { ...BASE_RECOVERY_OPTIONS, recoveryCycleCap: 2 },
+  );
+  assert.equal(copilotRecovery.cap, 2);
+  assert.equal(copilotRecovery.completedCycleCount, 1);
+  assert.equal(copilotRecovery.remainingBudget, 1);
+});
+
+// --- Schema round-trip: staleRequestRecovery composes with the rest of the CLI output ---
+
+test('a full CLI output shape (summary + copilotRecovery + staleRequestRecovery) validates cleanly together', () => {
+  const comments = [
+    recoveryComment({ createdAt: '2026-07-21T00:00:00Z', attempt: 1 }),
+  ];
+  const summary = buildAdvisoryWaitSummary(
+    {
+      prHeadSha: SHA,
+      reviews: [],
+      requestedReviewers: [{ login: 'copilot' }],
+      timelineEvents: [],
+      comments,
+    },
+    { now: BASE_RECOVERY_OPTIONS.now, trustedMarkerLogins: TRUSTED },
+  );
+  const copilotRecovery = buildCopilotRecoverySummary(
+    { comments, prHeadSha: SHA, lastCopilotCommit: summary.lastCopilotCommit },
+    BASE_RECOVERY_OPTIONS,
+  );
+  const staleRequestRecovery = evaluateStaleRequestRecoveryAction({
+    copilotPending: summary.copilotPending,
+    copilotPendingCoversHead: summary.copilotPendingCoversHead,
+    sameHeadMarkerPresent: summary.sameHeadMarkerPresent,
+    remainingBudget: copilotRecovery.remainingBudget,
+  });
+
+  const fullOutput = {
+    ...summary,
+    trustedMarkerActors: [] as string[],
+    trustedMarkerActorsSource: 'none' as const,
+    copilotRecovery,
+    staleRequestRecovery,
+  };
+
+  assert.deepEqual(validate(fullOutput, advisoryWaitStateSchema), []);
+});
+
+test('the schema rejects a staleRequestRecovery object missing a required field or an unknown field', () => {
+  const decision = evaluateStaleRequestRecoveryAction({
+    copilotPending: true,
+    copilotPendingCoversHead: false,
+    sameHeadMarkerPresent: false,
+    remainingBudget: 2,
+  });
+
+  const { reason: _omitted, ...missingReason } = decision;
+  assert.notDeepEqual(
+    validate(
+      { staleRequestRecovery: missingReason },
+      relaxedAdvisoryWaitStateSchema,
+    ),
+    [],
+  );
+
+  assert.notDeepEqual(
+    validate(
+      { staleRequestRecovery: { ...decision, extraField: 'nope' } },
+      relaxedAdvisoryWaitStateSchema,
+    ),
+    [],
+  );
+
+  assert.notDeepEqual(
+    validate(
+      { staleRequestRecovery: { ...decision, action: 'bogus-action' } },
+      relaxedAdvisoryWaitStateSchema,
+    ),
+    [],
+  );
+});

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -287,6 +287,7 @@ export const advisoryWaitStateKeys = [
   'trustedMarkerActors',
   'trustedMarkerActorsSource',
   'copilotRecovery',
+  'staleRequestRecovery',
 ] as const satisfies readonly (keyof AdvisoryWaitStateReport)[];
 
 export const branchConflictStateKeys = [
@@ -639,6 +640,10 @@ const advisoryWaitStateFixture = {
     activeClaimProvided: false,
     state: 'NOT_TERMINAL',
     reason: 'active-claim-not-provided',
+  },
+  staleRequestRecovery: {
+    action: 'not-applicable',
+    reason: 'not-pending',
   },
 } satisfies AdvisoryWaitStateReport;
 

--- a/tests/schema-validation.test.mts
+++ b/tests/schema-validation.test.mts
@@ -491,6 +491,48 @@ test('advisory-wait-state schema rejects an incomplete or malformed copilotRecov
   );
 });
 
+// --- #1571: advisory-wait-state.schema.json's staleRequestRecovery object -
+
+test('advisory-wait-state schema accepts each staleRequestRecovery.action value', () => {
+  const schema = loadJson('schemas/advisory-wait-state.schema.json');
+  for (const action of ['attempt', 'cap-exhausted', 'not-applicable']) {
+    const instance = JSON.parse(
+      JSON.stringify(
+        loadJson('fixtures/schemas/advisory-wait-state.valid.json'),
+      ),
+    );
+    instance.staleRequestRecovery = {
+      action,
+      reason: 'recovery-attempt-eligible',
+    };
+    assert.deepEqual(validate(instance, schema), []);
+  }
+});
+
+test('advisory-wait-state schema rejects an incomplete or malformed staleRequestRecovery object', () => {
+  const schema = loadJson('schemas/advisory-wait-state.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/advisory-wait-state.valid.json')),
+  );
+  instance.staleRequestRecovery = {
+    // action deliberately omitted -- a required nested field.
+    reason: 'not-pending',
+  };
+  assert.ok(
+    validate(instance, schema).length > 0,
+    'expected a staleRequestRecovery object missing action to be rejected',
+  );
+
+  instance.staleRequestRecovery = {
+    action: 'somehow-eligible', // not in the enum
+    reason: 'not-pending',
+  };
+  assert.ok(
+    validate(instance, schema).length > 0,
+    'expected an out-of-enum staleRequestRecovery.action to be rejected',
+  );
+});
+
 test('policy schema accepts missing mergeGate (runtime normalization supplies the default) (#1521)', () => {
   const schema = loadJson('schemas/policy.schema.json');
   const instance = JSON.parse(


### PR DESCRIPTION
# Summary

Implements the #1571 execution track for the roadmap #1569 stall-recovery
initiative: a bounded, claim/HEAD-revalidated recovery cycle for a pending
Copilot review request whose PR timeline does not prove it follows the
current HEAD (the recoverable condition PR #1562 first identified).

Previously, E14's `REQUEST_NEEDED`-with-`COPILOT_PENDING=true` sub-case
already removed and re-requested Copilot, but gated only by the ordinary
`REQUEST_CAP` (default 30) and without any post-mutation verification that
the fresh request actually landed against the current HEAD. This PR bounds
that sequence with the independent, per-HEAD recovery-cycle cap the #1572
contract track already defined (default 2), adds head-race and
active-claim revalidation immediately before every mutating step, adds a
new association-verification step after the re-request, and posts the
bound `advisory-recovery` marker only once every step is verified — making
a partial-failure retry idempotent (no double-counted cycle, no duplicate
request).

This is deliberately distinct from the pre-existing `RECOVERY_NEEDED`/
`AW3-R` path, which fires when the pending request is already **proven**
to cover the current HEAD and only anchors a missing marker; it never
touches the reviewer request. The new `AW3-S` path fires for the
**opposite**, unproven-coverage case.

## Linked issue

Closes #1571

## Follow-up issues (if any)

- [ ] none — #1570 (routing `COPILOT_UNAVAILABLE` into F2/F3/convergence/
      waiver decisions) remains the next track in roadmap #1569 and is
      unaffected by this PR's scope.

## Background / rationale (if material)

- `evaluateStaleRequestRecoveryAction`'s eligibility check gates on
  `sameHeadMarkerPresent` the same way the pre-existing
  `evaluateAdvisoryWaitOutcome` state machine already does, so the new
  path never contradicts the shared outcome machine's routing.
- The independent cap accounting is not something new to build: the bound
  `advisory-wait-recovery:` marker is already excluded from
  `requestMarkerCount` (only plain `advisory-wait:` markers count there),
  so the recovery-cycle cap and the ordinary request cap were already
  structurally independent once the marker type existed (#1572). This PR
  is the first caller that actually posts the *bound* form for this
  scenario and reads the resulting budget back.
- Per the issue's explicit scope note, same-HEAD reroll is out of scope
  here, and no path in this change invokes `gh pr merge --admin` or any
  autonomous merge bypass.
- `outcome` / `f3Outcome` enums are intentionally unchanged — #1570 (still
  blocked on this PR) owns wiring `COPILOT_UNAVAILABLE` into gate routing;
  this PR only surfaces `staleRequestRecovery`'s exhausted state and falls
  back to the existing `CAP_EXHAUSTED_ROUTE` handling, per the roadmap's
  stated track boundaries.
- `audit/sync-manifest.json`'s `bundle-merge` budget was raised from
  109600 to 116100 bytes to fit the new `AW3-S` protocol section
  (measured bundle total is now ~112.7 KB; the new limit keeps the same
  ~3% headroom convention already used by sibling bundle budgets). Flagging
  this explicitly per the ratchet-rule callout requirement in
  `audit/sync-manifest.json`.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
