### PR TITLE
chore(deps): point biome.json's $schema at the local Biome schema

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "extends": [
     "@kurone-kito/biome-config"
   ],

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
   "extends": [
     "@kurone-kito/biome-config"
   ],


### PR DESCRIPTION
# Summary

`biome.json`'s `$schema` field pointed at a version-pinned remote URL
(`2.4.16`) that had drifted behind the pinned and installed CLI
(`2.5.2`). This PR was originally a version-string bump to
`https://biomejs.dev/schemas/2.5.2/schema.json`, but on review the
maintainer proposed avoiding the same drift on every future Biome
bump by pointing `$schema` at the local, version-tracking path
`./node_modules/@biomejs/biome/configuration_schema.json` instead
([review discussion](https://github.com/kurone-kito/idd-skill/pull/1651#discussion_r3634235933)).
Issue #1649 was amended by the maintainer to reflect this, and this
PR now implements the local-path approach.

`biome.json` is confirmed not distributed to other repositories (no
entry in `audit/sync-manifest.json`, not present under
`idd-template/`), and the repository already requires `pnpm install`,
so `node_modules` is always present in any working checkout.

## Linked issue

Closes #1649

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

See the review discussion linked above for the maintainer's reasoning
and the verification performed before adopting the local-path
approach (file existence after `pnpm install`, valid JSON, no
`biome check` regression).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (ran as `npx biome check` via fix-validate /
      pre-push-validate — passes with no new warnings)
- [ ] `pnpm test` (no test surface touched by this change)
- [ ] `node scripts/audit-docs.mjs --check` (not applicable — no docs
      changed)
- [ ] `pnpm run docs:sync:check` (not applicable — no synced docs
      changed)
- [x] `node scripts/idd-doctor.mjs` (ran via pre-push-validate — passed
      with 4 pre-existing, unrelated warnings)
- [x] Confirmed `node_modules/@biomejs/biome/configuration_schema.json`
      exists after `pnpm install` and is valid JSON

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — config-value change only)
- [x] Context budget impact reviewed (none — one file, one line)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Biome configuration schema reference to version 2.5.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
