### PR TITLE
docs(audit): document the 3-manifest-edit checklist for new lite files

### DIFF
--- a/audit/README.md
+++ b/audit/README.md
@@ -57,6 +57,25 @@ new allowed concrete mapping, add a `concreted` sync pair with a
 file lists, update the manifest paths or globs first, then rerun the
 audit so the marked block can be refreshed deliberately.
 
+Adding a single new file under an existing `generatedBlocks[].sourceGlobs`
+match — for example, a new lite instruction file under
+`idd-template/.github/instructions/lite/` — touches three separate
+manifest edits, not one, for `node scripts/audit-docs.mjs --check` to
+pass:
+
+1. A `syncPairs` entry (source/target and mode) so the mirrored copy is
+   generated and compared.
+2. A `bundleBudgets` entry when the file participates in a phase bundle,
+   so the phase's context ceiling covers it.
+3. The file's path added to the matching `generatedBlocks[].paths` list.
+
+Step 3 is required for the audit check to pass — it compares `paths`
+against the files each block's `sourceGlobs` actually match, and fails
+with "manifest paths omit `<file>`" on a mismatch — even though `paths`
+plays no role in `sync-docs.mjs`'s own mirror-generation logic. Adding
+only the `syncPairs` and `bundleBudgets` entries above is not enough;
+skipping the `generatedBlocks[].paths` edit still fails the audit.
+
 ## Bundle Budgets
 
 The `bundleBudgets` entries cap the combined byte size of the

--- a/audit/README.md
+++ b/audit/README.md
@@ -71,10 +71,13 @@ pass:
 
 Step 3 is required for the audit check to pass — it compares `paths`
 against the files each block's `sourceGlobs` actually match, and fails
-with "manifest paths omit `<file>`" on a mismatch — even though `paths`
-plays no role in `sync-docs.mjs`'s own mirror-generation logic. Adding
-only the `syncPairs` and `bundleBudgets` entries above is not enough;
-skipping the `generatedBlocks[].paths` edit still fails the audit.
+by naming the block and the glob-matched file missing from `paths` (the
+error has the form `<block-id>: manifest paths omit <path>`, where
+`<block-id>` and `<path>` stand for the actual block id and file path)
+— even though `paths` plays no role in `sync-docs.mjs`'s own
+mirror-generation logic. Adding only the `syncPairs` and
+`bundleBudgets` entries above is not enough; skipping the
+`generatedBlocks[].paths` edit still fails the audit.
 
 ## Bundle Budgets
 

--- a/docs/weak-model-lite-profile-design.md
+++ b/docs/weak-model-lite-profile-design.md
@@ -277,7 +277,13 @@ generated pair rather than a third _kind_ of surface:
   needs — is driven by `syncPairs`. (`sync-docs.mjs` also reads
   `generatedBlocks` / `shellFileLists` for its separate
   consolidated-reference-block generation, e.g. `ONBOARDING.md`, but
-  that path is not relevant here; across every generation path,
+  that generation path is not relevant here — this is a statement
+  about `sync-docs.mjs` generation only, not about
+  `audit-docs.mjs --check`: a new lite file that matches the
+  `idd-template-core-files` block's `sourceGlobs` still needs its path
+  added to that block's `paths` list, or the audit fails (see
+  `audit/README.md`'s Intentional Exceptions section for the full
+  three-manifest-edit checklist). Across every generation path,
   `sync-docs.mjs` never reads `fileSets` at all.) So one new
   `syncPairs` entry per lite file (the same pattern the existing
   dogfood set already follows) is what actually produces each


### PR DESCRIPTION
# Summary

Documents the three separate `audit/sync-manifest.json` edits that
`node scripts/audit-docs.mjs --check` actually requires when a new file
is added under an existing `generatedBlocks[].sourceGlobs` match (for
example, a new lite instruction file under
`idd-template/.github/instructions/lite/`): a `syncPairs` entry, a
`bundleBudgets` entry when the file joins a phase bundle, and the file's
path added to the matching `generatedBlocks[].paths` list. That third
edit plays no role in `sync-docs.mjs`'s own mirror-generation logic, so
it was previously undocumented and easy to miss.

Also corrects an existing note in
`docs/weak-model-lite-profile-design.md` that read as an unqualified
"`generatedBlocks` ... is not relevant here" — the note is scoped to
`sync-docs.mjs` generation only; the same block's `paths` list is still
enforced by `audit-docs.mjs --check`.

This is a documentation-only change: no script, schema, or manifest
structure/behavior changes, only correcting/completing existing prose.

## Linked issue

Closes #1650

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Issue #1650 traces this gap to a real prior incident: while decomposing
#1617's lite `idd-review-snapshot-lite.instructions.md` work, adding the
`syncPairs` and `bundleBudgets` entries alone still left
`audit-docs.mjs --check` failing until the `generatedBlocks[0].paths`
list was also updated. `audit/README.md`'s "Intentional Exceptions"
section already documents the individual sync modes and the "update the
manifest paths or globs first" rule for generated file lists, but never
previously stated that authoring one new lite file touches all three
manifest locations together.

Verified against `scripts/audit-docs.mjs`'s `resolveBlockFiles`: a
`generatedBlocks` entry with both `paths` and `sourceGlobs` set errors
with `<block-id>: manifest paths omit <path>` when a glob-matched file
is absent from `paths` — confirming the audit-check-vs-generation
distinction the new prose draws.

**Update**: a Copilot review thread on this PR correctly flagged that
the first commit's quoted error text dropped the `<block-id>:` prefix
and read as if `<file>` were literal output rather than a placeholder.
Fixed in the second commit — see the thread for the exact wording
change.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
