### PR TITLE
docs(idd-review-triage): cross-reference rerun-advisory-convergence.mjs from the livelock note

### DIFF
--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -543,7 +543,7 @@ stales it, failing `--apply` closed on `review-currency` regardless
 of CI color; re-post before retrying. Same precondition as E1 Step
 2 — easy to satisfy early, forgotten by `--apply` time. A stale
 `idd-advisory-convergence` rollup: rerun via
-`rerun-advisory-convergence.mjs`
+`scripts/rerun-advisory-convergence.mjs`
 ([rerun mechanics](idd-ci.instructions.md#rerun-mechanics)).
 
 ## Zero-Accepted-PATH-A advisory re-review gate

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -531,20 +531,20 @@ Route based on `branchState` from the helper (or `mergeable` /
 
 ## Merge-main livelock under fast-moving `main`
 
-Under heavy concurrent-session load, `main` can advance again before
-one full {sync path → E1 → F1/F2} cycle finishes, re-triggering
-`behind-no-conflict` next pass; naive repetition can livelock,
-failing to reach F3 for as long as `main` keeps moving (observed
-2026-07-22, PR #1612).
+Under heavy concurrent-session load, `main` can advance before one
+{sync path → E1 → F1/F2} cycle finishes, re-triggering
+`behind-no-conflict`; naive repetition livelocks, never reaching F3
+while `main` keeps moving (observed 2026-07-22, PR #1612).
 
-**Rule**: post the watermark as the **last** action before the F3
-`idd-merge-execute.mjs --apply` attempt, every pass. Anything after it
-(a CI rerun settling, a new disposition reply, another `main` advance)
-makes it stale again and `--apply` fails closed on `review-currency`
-regardless of CI color — re-post before retrying. Same CI-completion
-precondition as E1 Step 2 (`idd-review-snapshot.instructions.md`); it
-is just easy to satisfy once early in a multi-pass loop and assume it
-still holds by the time `--apply` runs.
+**Rule**: post the watermark as the **last** action before F3's
+`idd-merge-execute.mjs --apply`, every pass — anything after (a CI
+rerun settling, a new disposition reply, another `main` advance)
+stales it, failing `--apply` closed on `review-currency` regardless
+of CI color; re-post before retrying. Same precondition as E1 Step
+2 — easy to satisfy early, forgotten by `--apply` time. A stale
+`idd-advisory-convergence` rollup: rerun via
+`rerun-advisory-convergence.mjs`
+([rerun mechanics](idd-ci.instructions.md#rerun-mechanics)).
 
 ## Zero-Accepted-PATH-A advisory re-review gate
 

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -538,7 +538,7 @@ stales it, failing `--apply` closed on `review-currency` regardless
 of CI color; re-post before retrying. Same precondition as E1 Step
 2 — easy to satisfy early, forgotten by `--apply` time. A stale
 `idd-advisory-convergence` rollup: rerun via
-`rerun-advisory-convergence.mjs`
+`scripts/rerun-advisory-convergence.mjs`
 ([rerun mechanics](idd-ci.instructions.md#rerun-mechanics)).
 
 ## Zero-Accepted-PATH-A advisory re-review gate

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -526,20 +526,20 @@ Route based on `branchState` from the helper (or `mergeable` /
 
 ## Merge-main livelock under fast-moving `main`
 
-Under heavy concurrent-session load, `main` can advance again before
-one full {sync path → E1 → F1/F2} cycle finishes, re-triggering
-`behind-no-conflict` next pass; naive repetition can livelock,
-failing to reach F3 for as long as `main` keeps moving (observed
-2026-07-22, PR #1612).
+Under heavy concurrent-session load, `main` can advance before one
+{sync path → E1 → F1/F2} cycle finishes, re-triggering
+`behind-no-conflict`; naive repetition livelocks, never reaching F3
+while `main` keeps moving (observed 2026-07-22, PR #1612).
 
-**Rule**: post the watermark as the **last** action before the F3
-`idd-merge-execute.mjs --apply` attempt, every pass. Anything after it
-(a CI rerun settling, a new disposition reply, another `main` advance)
-makes it stale again and `--apply` fails closed on `review-currency`
-regardless of CI color — re-post before retrying. Same CI-completion
-precondition as E1 Step 2 (`idd-review-snapshot.instructions.md`); it
-is just easy to satisfy once early in a multi-pass loop and assume it
-still holds by the time `--apply` runs.
+**Rule**: post the watermark as the **last** action before F3's
+`idd-merge-execute.mjs --apply`, every pass — anything after (a CI
+rerun settling, a new disposition reply, another `main` advance)
+stales it, failing `--apply` closed on `review-currency` regardless
+of CI color; re-post before retrying. Same precondition as E1 Step
+2 — easy to satisfy early, forgotten by `--apply` time. A stale
+`idd-advisory-convergence` rollup: rerun via
+`rerun-advisory-convergence.mjs`
+([rerun mechanics](idd-ci.instructions.md#rerun-mechanics)).
 
 ## Zero-Accepted-PATH-A advisory re-review gate
 


### PR DESCRIPTION
# Summary

Add a one-line cross-reference to `rerun-advisory-convergence.mjs`
inside the "Merge-main livelock under fast-moving `main`" note in
`idd-review-triage.instructions.md`, pointing at
`idd-ci.instructions.md`'s rerun-mechanics section, so an agent
staring at a stale `idd-advisory-convergence` rollup during F3 merge
work has a signpost to the existing helper instead of hand-tracing
check-run IDs. Mirrored in the `idd-template/` source (canonical) and
its generated `.github/instructions/` copy via `sync-docs --apply`.

`bundle-review` (`audit/sync-manifest.json`) measured only 3 bytes of
headroom under its 143,000-byte limit on `main` before this change, so
a pure addition would have overflowed it. Per the near-ceiling policy
in `docs/policy-constants.md` (bundle at ≥95% utilization → prefer
trim/split over a ratchet bump), the surrounding note is tightened at
the same time — no normative content dropped, just phrased more
compactly — landing at 28 bytes of headroom post-format instead of a
budget bump.

## Linked issue

Closes #1648

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

See the plan comment on #1648 for the full premise verification and
the budget-constraint rationale (why this touches more of the note
than a literal one-line addition).

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
