### PR TITLE
chore(audit): fully enforce the 128k ceiling and ratchet caps down

### DIFF
--- a/audit/README.md
+++ b/audit/README.md
@@ -133,7 +133,7 @@ roadmap's finalize track
 `exemptBundles` is empty: every bundle that entered the roadmap over
 `maxBundleLimitBytes` or above `maxUtilizationPct` cleared both checks —
 `bundle-review`, `bundle-work`, and `bundle-merge` via the sibling
-content diets and this issue's limit-lowering ratchet;
+content diets and #1658's own limit-lowering ratchet;
 `bundle-pr-submit-lite` via a margin-restoring limit _raise_ instead,
 since it was never over the byte ceiling, only briefly above the
 utilization threshold. Keep the list empty going forward — add an entry

--- a/audit/README.md
+++ b/audit/README.md
@@ -128,9 +128,13 @@ is itself an audit error (a typo or a bundle rename left behind).
 
 As of the #1659 128K-ceiling roadmap's finalize track (#1658),
 `exemptBundles` is empty: every bundle that entered the roadmap over
-`maxBundleLimitBytes` or above `maxUtilizationPct` was either ratcheted
-down or dieted back under both checks. Keep the list empty going
-forward — add an entry only alongside a maintainer-authorized exception
-(the same PR-description callout the ratchet's own raise convention
-requires), and shrink it back to empty in the same PR or a tracked
-follow-up once that exception resolves.
+`maxBundleLimitBytes` or above `maxUtilizationPct` cleared both checks —
+`bundle-review`, `bundle-work`, and `bundle-merge` via the sibling
+content diets and this issue's limit-lowering ratchet;
+`bundle-pr-submit-lite` via a margin-restoring limit _raise_ instead,
+since it was never over the byte ceiling, only briefly above the
+utilization threshold. Keep the list empty going forward — add an entry
+only alongside a maintainer-authorized exception (the same
+PR-description callout the ratchet's own raise convention requires),
+and shrink it back to empty in the same PR or a tracked follow-up once
+that exception resolves.

--- a/audit/README.md
+++ b/audit/README.md
@@ -125,3 +125,12 @@ adopter-repo instructions, and working context.
 
 An id in `exemptBundles` that does not match any `bundleBudgets` entry
 is itself an audit error (a typo or a bundle rename left behind).
+
+As of the #1659 128K-ceiling roadmap's finalize track (#1658),
+`exemptBundles` is empty: every bundle that entered the roadmap over
+`maxBundleLimitBytes` or above `maxUtilizationPct` was either ratcheted
+down or dieted back under both checks. Keep the list empty going
+forward — add an entry only alongside a maintainer-authorized exception
+(the same PR-description callout the ratchet's own raise convention
+requires), and shrink it back to empty in the same PR or a tracked
+follow-up once that exception resolves.

--- a/audit/README.md
+++ b/audit/README.md
@@ -126,7 +126,10 @@ adopter-repo instructions, and working context.
 An id in `exemptBundles` that does not match any `bundleBudgets` entry
 is itself an audit error (a typo or a bundle rename left behind).
 
-As of the #1659 128K-ceiling roadmap's finalize track (#1658),
+As of the
+[#1659](https://github.com/kurone-kito/idd-skill/issues/1659) 128K-ceiling
+roadmap's finalize track
+([#1658](https://github.com/kurone-kito/idd-skill/issues/1658)),
 `exemptBundles` is empty: every bundle that entered the roadmap over
 `maxBundleLimitBytes` or above `maxUtilizationPct` cleared both checks —
 `bundle-review`, `bundle-work`, and `bundle-merge` via the sibling

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -176,7 +176,7 @@
     "glob": ".github/instructions/idd-*.instructions.md",
     "alwaysLoadedPattern": "applyTo:\\s*\"\\*\\*\"",
     "alwaysLoadedLimitBytes": 20000,
-    "phaseLimitBytes": 38000
+    "phaseLimitBytes": 33000
   },
   "bundleBudgets": [
     {
@@ -189,7 +189,7 @@
         ".github/instructions/idd-overview-core.instructions.md",
         ".github/instructions/idd-suitability.instructions.md"
       ],
-      "limitBytes": 112700
+      "limitBytes": 104000
     },
     {
       "id": "bundle-resume",
@@ -251,7 +251,7 @@
       "files": [
         ".github/instructions/lite/idd-pr-submit-lite.instructions.md"
       ],
-      "limitBytes": 23700
+      "limitBytes": 26000
     },
     {
       "id": "bundle-review-fix-lite",
@@ -284,7 +284,7 @@
         ".github/instructions/idd-review-snapshot.instructions.md",
         ".github/instructions/idd-review-triage.instructions.md"
       ],
-      "limitBytes": 143000
+      "limitBytes": 120000
     },
     {
       "id": "bundle-merge",
@@ -298,7 +298,7 @@
         ".github/instructions/idd-overview-core.instructions.md",
         ".github/instructions/idd-pre-merge.instructions.md"
       ],
-      "limitBytes": 116100
+      "limitBytes": 108000
     }
   ],
   "contextCeiling": {
@@ -306,12 +306,7 @@
     "maxBundleLimitBytes": 120000,
     "maxUtilizationPct": 98,
     "noticeUtilizationPct": 95,
-    "exemptBundles": [
-      "bundle-review",
-      "bundle-work",
-      "bundle-merge",
-      "bundle-pr-submit-lite"
-    ]
+    "exemptBundles": []
   },
   "docBudgetGuard": {
     "id": "doc-budget-drift",

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -350,7 +350,10 @@ measure the combined byte length of all listed files.
 128K-context-derived cap on top of the per-bundle ratchet below, so a
 future exact-fit bump errors instead of drifting past the ~10%-margin
 convention the ratchet alone allows — see the regression history under
-"Context ceiling" in `audit/README.md`.
+"Context ceiling" in
+[kurone-kito/idd-skill's own dogfooded `audit/README.md`](https://github.com/kurone-kito/idd-skill/blob/main/audit/README.md#context-ceiling)
+(the `audit/` directory is source-repo-only; it is not part of this
+copied template).
 
 - **Ceiling derivation**: no non-exempt bundle's `limitBytes` may exceed
   **120,000 bytes** (`maxBundleLimitBytes`) — a 128K-context-derived cap

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -322,7 +322,7 @@ files, or express it without the `bytes` suffix.
 | Limit type    | Value        | Applies to                                                                 | Rationale                                                                                                                                                                                               |
 | ------------- | ------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Always-loaded | 20,000 bytes | Files with `applyTo: "**"` in `.github/instructions/idd-*.instructions.md` | These files load on every phase regardless of which is active, so this is the strictest ceiling — it bounds the fixed floor cost every session pays before any phase-specific content is even selected. |
-| Phase         | 38,000 bytes | Other files in `.github/instructions/idd-*.instructions.md`                | Only the one file matching the active phase loads at a time, so this ceiling can run larger than the always-loaded one without raising a session's floor cost.                                          |
+| Phase         | 33,000 bytes | Other files in `.github/instructions/idd-*.instructions.md`                | Only the one file matching the active phase loads at a time, so this ceiling can run larger than the always-loaded one without raising a session's floor cost.                                          |
 
 ### Bundle limits
 
@@ -343,6 +343,39 @@ manifest. Read the live limits with
 
 Bundle checks run unconditionally (not filtered by changed files) and
 measure the combined byte length of all listed files.
+
+### Context ceiling
+
+`audit/sync-manifest.json` `contextCeiling` layers an absolute,
+128K-context-derived cap on top of the per-bundle ratchet below, so a
+future exact-fit bump errors instead of drifting past the ~10%-margin
+convention the ratchet alone allows — see the regression history under
+"Context ceiling" in `audit/README.md`.
+
+- **Ceiling derivation**: no non-exempt bundle's `limitBytes` may exceed
+  **120,000 bytes** (`maxBundleLimitBytes`) — a 128K-context-derived cap
+  of ≈ 30,000–37,000 tokens at this corpus's observed 3.25–4.0
+  bytes/token, ≤ ~29% of a 128K context window, leaving the remainder
+  for the harness system prompt, tool schemas, adopter-repo
+  instructions, and working context.
+- **`maxUtilizationPct` = 98%**: no non-exempt bundle's measured
+  (banner-stripped) byte total may exceed this percentage of its own
+  `limitBytes`. This is what stops a future exact-fit landing even for
+  a bundle that stays under `maxBundleLimitBytes`.
+- **`noticeUtilizationPct` = 95%**: any bundle (exempt or not) reaching
+  this utilization prints a CI notice, making the near-ceiling band
+  visible before a bundle tips over either error check above.
+
+**Exemption lifecycle**: `exemptBundles` temporarily excuses listed
+bundle ids from the two error checks above while a content diet is in
+flight across a sequence of sibling issues. The distributed default —
+and the state a completed diet sequence returns the list to — is an
+**empty list**: a bundle enters it only alongside the issue that
+regresses past `maxBundleLimitBytes` or `maxUtilizationPct`, and leaves
+it once the ratchet or trim resolves the violation, not by editing the
+exemption away in isolation. Keep the list empty absent an active diet;
+re-adding an entry needs the same maintainer-authorized PR-description
+callout the ratchet's own raise convention requires below.
 
 ### Bundle-budget growth
 

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -356,11 +356,11 @@ convention the ratchet alone allows — see the regression history under
 copied template).
 
 - **Ceiling derivation**: no non-exempt bundle's `limitBytes` may exceed
-  **120,000 bytes** (`maxBundleLimitBytes`) — a 128K-context-derived cap
-  of ≈ 30,000–37,000 tokens at this corpus's observed 3.25–4.0
-  bytes/token, ≤ ~29% of a 128K context window, leaving the remainder
-  for the harness system prompt, tool schemas, adopter-repo
-  instructions, and working context.
+  the **120,000-byte** `maxBundleLimitBytes` ceiling — a
+  128K-context-derived cap of ≈ 30,000–37,000 tokens at this corpus's
+  observed 3.25–4.0 bytes/token, ≤ ~29% of a 128K context window,
+  leaving the remainder for the harness system prompt, tool schemas,
+  adopter-repo instructions, and working context.
 - **`maxUtilizationPct` = 98%**: no non-exempt bundle's measured
   (banner-stripped) byte total may exceed this percentage of its own
   `limitBytes`. This is what stops a future exact-fit landing even for

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -350,7 +350,10 @@ measure the combined byte length of all listed files.
 128K-context-derived cap on top of the per-bundle ratchet below, so a
 future exact-fit bump errors instead of drifting past the ~10%-margin
 convention the ratchet alone allows — see the regression history under
-"Context ceiling" in `audit/README.md`.
+"Context ceiling" in
+[kurone-kito/idd-skill's own dogfooded `audit/README.md`](https://github.com/kurone-kito/idd-skill/blob/main/audit/README.md#context-ceiling)
+(the `audit/` directory is source-repo-only; it is not part of this
+copied template).
 
 - **Ceiling derivation**: no non-exempt bundle's `limitBytes` may exceed
   **120,000 bytes** (`maxBundleLimitBytes`) — a 128K-context-derived cap

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -322,7 +322,7 @@ files, or express it without the `bytes` suffix.
 | Limit type    | Value        | Applies to                                                                 | Rationale                                                                                                                                                                                               |
 | ------------- | ------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Always-loaded | 20,000 bytes | Files with `applyTo: "**"` in `.github/instructions/idd-*.instructions.md` | These files load on every phase regardless of which is active, so this is the strictest ceiling — it bounds the fixed floor cost every session pays before any phase-specific content is even selected. |
-| Phase         | 38,000 bytes | Other files in `.github/instructions/idd-*.instructions.md`                | Only the one file matching the active phase loads at a time, so this ceiling can run larger than the always-loaded one without raising a session's floor cost.                                          |
+| Phase         | 33,000 bytes | Other files in `.github/instructions/idd-*.instructions.md`                | Only the one file matching the active phase loads at a time, so this ceiling can run larger than the always-loaded one without raising a session's floor cost.                                          |
 
 ### Bundle limits
 
@@ -343,6 +343,39 @@ manifest. Read the live limits with
 
 Bundle checks run unconditionally (not filtered by changed files) and
 measure the combined byte length of all listed files.
+
+### Context ceiling
+
+`audit/sync-manifest.json` `contextCeiling` layers an absolute,
+128K-context-derived cap on top of the per-bundle ratchet below, so a
+future exact-fit bump errors instead of drifting past the ~10%-margin
+convention the ratchet alone allows — see the regression history under
+"Context ceiling" in `audit/README.md`.
+
+- **Ceiling derivation**: no non-exempt bundle's `limitBytes` may exceed
+  **120,000 bytes** (`maxBundleLimitBytes`) — a 128K-context-derived cap
+  of ≈ 30,000–37,000 tokens at this corpus's observed 3.25–4.0
+  bytes/token, ≤ ~29% of a 128K context window, leaving the remainder
+  for the harness system prompt, tool schemas, adopter-repo
+  instructions, and working context.
+- **`maxUtilizationPct` = 98%**: no non-exempt bundle's measured
+  (banner-stripped) byte total may exceed this percentage of its own
+  `limitBytes`. This is what stops a future exact-fit landing even for
+  a bundle that stays under `maxBundleLimitBytes`.
+- **`noticeUtilizationPct` = 95%**: any bundle (exempt or not) reaching
+  this utilization prints a CI notice, making the near-ceiling band
+  visible before a bundle tips over either error check above.
+
+**Exemption lifecycle**: `exemptBundles` temporarily excuses listed
+bundle ids from the two error checks above while a content diet is in
+flight across a sequence of sibling issues. The distributed default —
+and the state a completed diet sequence returns the list to — is an
+**empty list**: a bundle enters it only alongside the issue that
+regresses past `maxBundleLimitBytes` or `maxUtilizationPct`, and leaves
+it once the ratchet or trim resolves the violation, not by editing the
+exemption away in isolation. Keep the list empty absent an active diet;
+re-adding an entry needs the same maintainer-authorized PR-description
+callout the ratchet's own raise convention requires below.
 
 ### Bundle-budget growth
 

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -356,11 +356,11 @@ convention the ratchet alone allows — see the regression history under
 copied template).
 
 - **Ceiling derivation**: no non-exempt bundle's `limitBytes` may exceed
-  **120,000 bytes** (`maxBundleLimitBytes`) — a 128K-context-derived cap
-  of ≈ 30,000–37,000 tokens at this corpus's observed 3.25–4.0
-  bytes/token, ≤ ~29% of a 128K context window, leaving the remainder
-  for the harness system prompt, tool schemas, adopter-repo
-  instructions, and working context.
+  the **120,000-byte** `maxBundleLimitBytes` ceiling — a
+  128K-context-derived cap of ≈ 30,000–37,000 tokens at this corpus's
+  observed 3.25–4.0 bytes/token, ≤ ~29% of a 128K context window,
+  leaving the remainder for the harness system prompt, tool schemas,
+  adopter-repo instructions, and working context.
 - **`maxUtilizationPct` = 98%**: no non-exempt bundle's measured
   (banner-stripped) byte total may exceed this percentage of its own
   `limitBytes`. This is what stops a future exact-fit landing even for

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -314,7 +314,7 @@ const DOC_BUDGET_BUNDLES = [
   { limitBytes: 45_000 },
   { limitBytes: 24_000 },
   { limitBytes: 16_000 },
-  { limitBytes: 19_500 },
+  { limitBytes: 26_000 },
 ];
 
 test('doc budget guard passes when documented values match the manifest', () => {
@@ -345,7 +345,7 @@ test('doc budget guard flags a value that drifted from every manifest budget', (
   assert.equal(result.errors.length, 1);
   assert.match(
     result.errors[0],
-    /doc-budget-drift: README\.md states 30,000 bytes, which is not a current sync-manifest budget value \(valid: 16000, 19500, 20000, 24000, 33000, 45000, 104000\)/,
+    /doc-budget-drift: README\.md states 30,000 bytes, which is not a current sync-manifest budget value \(valid: 16000, 20000, 24000, 26000, 33000, 45000, 104000\)/,
   );
 });
 

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -305,12 +305,12 @@ test('instruction size budget excludes the generated-from banner from the measur
 
 const DOC_BUDGET_SIZE = {
   alwaysLoadedLimitBytes: 20_000,
-  phaseLimitBytes: 38_000,
+  phaseLimitBytes: 33_000,
 };
 // Keep representative of live audit/sync-manifest.json bundleBudgets
 // (standard + lite independent ceilings currently on main).
 const DOC_BUDGET_BUNDLES = [
-  { limitBytes: 112_700 },
+  { limitBytes: 104_000 },
   { limitBytes: 45_000 },
   { limitBytes: 24_000 },
   { limitBytes: 16_000 },
@@ -319,9 +319,9 @@ const DOC_BUDGET_BUNDLES = [
 
 test('doc budget guard passes when documented values match the manifest', () => {
   const texts: Record<string, string> = {
-    'README.md': '| Phase | 38,000 bytes |\n| Always | 20,000 bytes |',
+    'README.md': '| Phase | 33,000 bytes |\n| Always | 20,000 bytes |',
     // a hardcoded bundle value that still matches the manifest is allowed
-    'strategy.md': 'discovery bundle is 112,700 bytes',
+    'strategy.md': 'discovery bundle is 104,000 bytes',
     // a doc that reads limits live via jq carries no number → never flagged
     'jq.md':
       "read the live values with jq '.bundleBudgets' audit/sync-manifest.json",
@@ -345,7 +345,7 @@ test('doc budget guard flags a value that drifted from every manifest budget', (
   assert.equal(result.errors.length, 1);
   assert.match(
     result.errors[0],
-    /doc-budget-drift: README\.md states 30,000 bytes, which is not a current sync-manifest budget value \(valid: 16000, 19500, 20000, 24000, 38000, 45000, 112700\)/,
+    /doc-budget-drift: README\.md states 30,000 bytes, which is not a current sync-manifest budget value \(valid: 16000, 19500, 20000, 24000, 33000, 45000, 104000\)/,
   );
 });
 


### PR DESCRIPTION
# Summary

Finalize track of roadmap #1659: lowers `bundle-review` / `bundle-merge`
/ `bundle-discovery` `limitBytes` and `phaseLimitBytes` to lock in the
headroom the sibling content diets (#1654, #1655, #1656, #1525)
already recovered, raises `bundle-pr-submit-lite`'s margin, and empties
`contextCeiling.exemptBundles` now that none of the four listed bundles
still violate either ceiling check. Documents the 128K derivation, the
two utilization thresholds, and the exemption lifecycle in
`docs/policy-constants.md` (canonical source:
`idd-template/docs/policy-constants.md`), and records the now-empty
exemption list in `audit/README.md`.

**Ratchet callout (raise)**: `bundle-pr-submit-lite.limitBytes` goes
23,700 -> 26,000 bytes. This is a raise, not a lowering, and needs a
callout under the repo's own ratchet rule. Its measured content
(23,352 bytes) sat at 98.53% utilization -- above the 98%
`maxUtilizationPct` ceiling and near the exemption's originating cause
-- so it was one of the four `exemptBundles` entries. Rather than trim
this already-lean, self-contained lite file further, this issue
restores the ~10%-headroom margin convention with a raise (23,352 /
26,000 = 89.82%), which is the issue's own specified acceptance path
and exits the exemption without touching instruction content.

Every other change in this PR is a lowering (`bundle-discovery`
112,700 -> 104,000; `bundle-merge` 116,100 -> 108,000; `bundle-review`
143,000 -> 120,000; `phaseLimitBytes` 38,000 -> 33,000), which needs no
callout under the same rule.

**No instruction-file content was trimmed in this PR.** Measured
against current `main` before any edit, every bundle already cleared
its target with margin thanks to the prior sibling diets
(banner-stripped, audit-equivalent bytes): `bundle-review` 112,333
(target <= 114,000), `bundle-merge` 96,976 (target <= 102,600),
`bundle-discovery` 93,667 (target <= 98,800), `bundle-work` 39,861
(target <= 42,750, limit unchanged). The largest post-diet phase file
(`idd-discover.instructions.md`, 29,905 bytes) is already
<= 30,000 bytes, and <= 31,350 bytes (95% of the new 33,000
`phaseLimitBytes`). The residual-trim mandate in the issue therefore
did not apply.

## Linked issue

Closes #1658

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

This is the last track of roadmap #1659. Once this merges, #1659's own
success criteria will be re-verified live (all tracks closed,
`contextCeiling` live with empty exemptions, `bundle-review`
<= 114,000, `phaseLimitBytes` = 33,000, lite loop no longer referencing
full-size advisory-wait/CI files) before closing it.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`biome check`, `dprint check`, `markdownlint-cli2`)
- [x] `pnpm test` (2656 tests, `node --test tests/*.test.mts`)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed; pre-existing warnings only,
      unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated policy guidance for instruction-size limits, including a reduced per-file phase cap.
  * Documented the global context ceiling, utilization thresholds, and temporary exemption rules.
  * Clarified that context-ceiling exemptions should remain empty unless an authorized exception is documented.

* **Configuration**
  * Adjusted byte-budget limits across several bundles and instruction phases.
  * Removed existing context-ceiling bundle exemptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->