### PR TITLE
docs(idd): extend the phase-size audit glob to idd-template copies

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -557,8 +557,9 @@ emits this order.
 **High-contention shared-file overlap (advisory).** Concurrent
 autopilot sessions tend to edit the same F-phase bundle instruction
 files (`bundle-review` / `bundle-merge`) and `audit/sync-manifest.json`.
-As a **soft** tie-breaker after score / desync / effort / lowest-number,
-prefer a candidate whose `## Candidate files` do **not** overlap an
+As a **soft** tie-breaker evaluated after score / desync / effort but
+before the final lowest-issue-number tie-break, prefer a candidate
+whose `## Candidate files` do **not** overlap an
 actively-claimed or open-PR issue on one of those files; the optional
 `discover-shared-file-overlap` helper (see
 [IDD helper scripts](../../docs/idd-helper-scripts.md)) reports each

--- a/audit/README.md
+++ b/audit/README.md
@@ -79,6 +79,39 @@ mirror-generation logic. Adding only the `syncPairs` and
 `bundleBudgets` entries above is not enough; skipping the
 `generatedBlocks[].paths` edit still fails the audit.
 
+## Instruction Size Budgets
+
+`instructionSizeBudgets` is an array of one entry per audited glob, each
+with its own `id`, `glob`, `alwaysLoadedPattern`,
+`alwaysLoadedLimitBytes`, and `phaseLimitBytes`. Two entries currently
+run against the same caps: `instruction-size-budgets-dogfood` measures
+this repo's own generated `.github/instructions/idd-*.instructions.md`
+copies, and `instruction-size-budgets-idd-template` measures the
+canonical `idd-template/.github/instructions/idd-*.instructions.md`
+source adopters actually receive. The two copies of a `structure`-mode
+sync pair (see Sync Modes above) may carry different prose and
+therefore different byte counts, so without a dedicated entry per copy
+one side could silently exceed the shared cap while only the other side
+is ever measured (#1667).
+
+Each entry's own `id` is the scope/label that keeps a violation message
+unambiguous about which file set tripped it — the audited path's own
+`.github/instructions/` vs `idd-template/.github/instructions/` prefix
+disambiguates it a second time. Add a new entry (with its own `id`) for
+any future glob that needs the same per-file byte cap, rather than
+widening an existing entry's `glob` to cover unrelated files.
+
+Like `checkFileSets`'s changed-file scoping, each entry only measures
+files that changed against the resolved git comparison base (skipped
+with a notice, never an error, when no base resolves — for example a
+shallow clone without `origin/main`) — an unrelated PR never fails on a
+pre-existing oversized file it did not touch. Widening a glob only
+protects a copy going forward, from the next time someone actually
+edits it; it does not retroactively re-audit every unchanged file on
+every run. A one-time audit across every current file (not just changed
+ones) is still worth running by hand after adding a new entry, to catch
+any divergence that already exists.
+
 ## Bundle Budgets
 
 The `bundleBudgets` entries cap the combined byte size of the

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -171,13 +171,22 @@
       "stripPrefix": "skills/issue-authoring/"
     }
   ],
-  "instructionSizeBudgets": {
-    "id": "instruction-size-budgets",
-    "glob": ".github/instructions/idd-*.instructions.md",
-    "alwaysLoadedPattern": "applyTo:\\s*\"\\*\\*\"",
-    "alwaysLoadedLimitBytes": 20000,
-    "phaseLimitBytes": 33000
-  },
+  "instructionSizeBudgets": [
+    {
+      "id": "instruction-size-budgets-dogfood",
+      "glob": ".github/instructions/idd-*.instructions.md",
+      "alwaysLoadedPattern": "applyTo:\\s*\"\\*\\*\"",
+      "alwaysLoadedLimitBytes": 20000,
+      "phaseLimitBytes": 33000
+    },
+    {
+      "id": "instruction-size-budgets-idd-template",
+      "glob": "idd-template/.github/instructions/idd-*.instructions.md",
+      "alwaysLoadedPattern": "applyTo:\\s*\"\\*\\*\"",
+      "alwaysLoadedLimitBytes": 20000,
+      "phaseLimitBytes": 33000
+    }
+  ],
   "bundleBudgets": [
     {
       "id": "bundle-discovery",

--- a/docs/skills-delivery-investigation.md
+++ b/docs/skills-delivery-investigation.md
@@ -83,8 +83,8 @@ were not evaluated by the prior note.
 ## 1. Candidate skill-boundary mapping
 
 `idd-overview-core.instructions.md` (16,239 bytes; the one file matching
-`applyTo: "**"`, capped at 20,000 bytes by
-`instructionSizeBudgets.alwaysLoadedLimitBytes`) and
+`applyTo: "**"`, capped at 20,000 bytes by the dogfooding entry's
+`alwaysLoadedLimitBytes` in `instructionSizeBudgets`) and
 `idd-overview-appendix.instructions.md` (8,297 bytes) are loaded in
 **every** phase bundle in `audit/sync-manifest.json`'s `bundleBudgets`.
 They are categorically **not** skill candidates: something that must

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -472,8 +472,9 @@ order:
   single-issue `resume-claim-routing.mjs --fresh-claim-gate` resolver
   per candidate, or apply the full parsing rules manually. A candidate
   is **ineligible** when parsing yields an active claim whose latest
-  valid `claimed-by` comment has GitHub `created_at` newer than
-  `claim-stale-age` (`docs/policy-constants.md`; distributed default:
+  valid `claimed-by` comment has GitHub `created_at` within
+  `claim-stale-age` of now (equivalently, `created_at > now -
+  claim-stale-age`; `docs/policy-constants.md`; distributed default:
   `24 h`); otherwise it **remains eligible**.
 
 After scanning the current batch:
@@ -559,8 +560,9 @@ emits this order.
 **High-contention shared-file overlap (advisory).** Concurrent
 autopilot sessions tend to edit the same F-phase bundle instruction
 files (`bundle-review` / `bundle-merge`) and `audit/sync-manifest.json`.
-As a **soft** tie-breaker after score / desync / effort / lowest-number,
-prefer a candidate whose `## Candidate files` do **not** overlap an
+As a **soft** tie-breaker evaluated after score / desync / effort but
+before the final lowest-issue-number tie-break, prefer a candidate
+whose `## Candidate files` do **not** overlap an
 actively-claimed or open-PR issue on one of those files; the optional
 `discover-shared-file-overlap` helper (see
 [IDD helper scripts](../../docs/idd-helper-scripts.md)) reports each

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -1,9 +1,9 @@
 # IDD — Discover Phase (A0-T–A4)
 
-Read this file when starting a new task. It covers finding and selecting
-the next issue to work on, including an operator-provided exact issue
-target, roadmap-audit handoff, candidate selection, and handoff to A4.5
-and claim. After selecting a viable candidate (A4), run suitability triage via
+Read this file when starting a new task: finding and selecting the next
+issue to work on, including an operator-provided exact issue target,
+roadmap-audit handoff, candidate selection, and handoff to A4.5 and
+claim. After A4 selects a viable candidate, run suitability triage via
 `idd-suitability.instructions.md` (A4.5), then proceed to
 `idd-claim.instructions.md` to claim it.
 
@@ -89,21 +89,16 @@ Read the **issue-scope** value from the Project commands table in
 
 - If `issue-scope` is `roadmap`: skip A0-O and proceed to A1 as normal.
 - If `issue-scope` is `roadmap-first` (the default): proceed to A1 as
-  normal. Fall back to **A0-O** before entering the A3 decision tree when
-  the roadmap path yields **no viable, startable, unclaimed candidate** —
-  via **trigger (a)** (zero candidates reach A3.5 — A2 enumerated no open
-  execution leaves, or A3 filtered them all out as blocked), **trigger
-  (b)** (candidates reach A3.5 but none is workable — A4 Step 1 viability
-  discards every A3.5-startable candidate, or A4 Step 1.5 eliminates the
-  last one), or **trigger (c)** (A1 finds no roadmap issues). Run A0-O
-  **at most once** as this fallback per Discover pass; once spent, a
-  later A4 exhaustion reports and stops per A4 Step 1 / Step 1.5 (not an
-  abort) without re-entering A0-O. This reuses A0-O **only** as a
-  `roadmap-first` fallback; the roadmap path stays primary (unlike
-  `orphan-first`). If candidates
-  reach A3.5 but it holds them all as approval-needed, do **not** fall
-  back: the approval hold governs and a non-empty approval-needed bucket
-  is not a true zero. See
+  normal, falling back to **A0-O** before the A3 decision tree when the
+  roadmap path yields **no viable, startable, unclaimed candidate** —
+  **trigger (a)** (zero candidates reach A3.5: A2 found none, or A3
+  filtered them all), **trigger (b)** (candidates reach A3.5 but A4
+  Step 1 or Step 1.5 discards every one), or **trigger (c)** (A1 finds
+  no roadmap issues). A0-O runs **at most once** per Discover pass as
+  this fallback; once spent, a later A4 exhaustion reports and stops
+  (not an abort) without re-entering A0-O. A non-empty A3.5
+  approval-needed bucket is not a true zero and never triggers this
+  fallback. See
   [A0-O fallback triggers](../../docs/idd-design-rationale.md#a0-o-roadmap-first-fallback-triggers).
 - If `issue-scope` is `orphan-first`: proceed to A0-O.
 
@@ -113,12 +108,11 @@ Read the **orphan-first-policy** value from the Project commands table
 in `idd-overview-core.instructions.md` before any repo-wide orphan issue
 search.
 
-When A0-O runs as the `roadmap-first` fallback (not the `orphan-first`
-primary path), every exit below that would re-enter **A1** or reach the
-**A3 decision tree** is redirected by the invoking trigger instead —
-trigger (a) or (c) to the A3 decision tree, trigger (b) (A4 exhaustion)
-to the A4 **"report and stop (not an abort)"** terminal — since A1
-already ran and must not be re-entered (no A1 ↔ A0-O or A4 ↔ A0-O loop).
+When A0-O runs as the `roadmap-first` fallback, every exit below that
+would re-enter **A1** or reach the **A3 decision tree** is redirected by
+the invoking trigger instead — (a)/(c) to the A3 decision tree, (b) (A4
+exhaustion) to the A4 **"report and stop"** terminal — since A1 already
+ran and must not be re-entered (no A1 ↔ A0-O or A4 ↔ A0-O loop).
 
 - If `orphan-first-policy` is `public-disabled`: for a public repository
   (or when visibility cannot be determined), skip A0-O without searching
@@ -161,11 +155,9 @@ A0-O:
   guard atop A0-O.
 
 The A3 decision tree (abort / ask operator in unattended mode) is
-reached when the active discovery path(s) produce zero results: for
-`orphan-first`, both the orphan path and the roadmap fallback returned
-zero; for `roadmap-first`, both the roadmap path and the orphan fallback
-returned zero; for `roadmap`, only the roadmap path runs and A3 applies
-when it returns zero.
+reached only when every active discovery path returns zero: both paths
+for `orphan-first` and `roadmap-first` (orphan + roadmap fallback,
+either order); just the roadmap path for `roadmap`.
 
 **Claim-state annotation (optional).** When helper support is enabled,
 `discover-orphan-filter` accepts an opt-in `--with-claim-state` flag
@@ -173,17 +165,16 @@ when it returns zero.
 active-claim eligibility, mirroring `discover-roadmap-graph`'s flag of
 the same name — see `docs/idd-helper-scripts.md`. This lets an A0-O
 caller fold live claim state into its output the same way the roadmap
-path already can, instead of discovering a concurrent claim only at the
-A5 pre-check.
+path already can.
 
 ## A1 — Find the roadmap
 
-Use GH CLI or GH MCP to find the roadmap among open issues. Identify it
+Use GH CLI or GH MCP to find the roadmap among open issues, identified
 by the configured roadmap label (project field) from
 `labels.roadmapLabelName` (default: `roadmap`) or by recognizing it as
-an umbrella issue. Under `roadmap` or `orphan-first` scope, if no roadmap
-issue exists, report and abort. Under `roadmap-first` scope, this is
-**trigger (c)**: fall back to **A0-O** instead of aborting.
+an umbrella issue. Under `roadmap` or `orphan-first` scope, report and
+abort if no roadmap issue exists. Under `roadmap-first` scope, this is
+**trigger (c)**: fall back to **A0-O** instead.
 
 **Autopilot cross-roadmap mode (optional, additive).** When several
 roadmaps run in parallel and the active autopilot-suitable work may live
@@ -191,23 +182,16 @@ under **sibling** epics, do not commit to a single umbrella here. Instead,
 enumerate the open execution leaves across **all** open roadmap roots and
 rank them by autopilot-suitability (see A2), then carry the top-ranked
 candidate through the normal A3/A4/A4.5/A5 gates. This is additive: the
-single-root selection above stays the default, and orphan-first
-filtering still applies only to true orphans — cross-roadmap leaves are
+single-root selection above stays the default; orphan-first filtering
+still applies only to true orphans, since cross-roadmap leaves are
 reached via a parent roadmap's task list and never carry their own
-`{{PROJECT_MARKER_PREFIX}}-roadmap-id` marker, so orphan-first filtering
-(which targets issues with no roadmap linkage at all) does not apply to
-them.
+`{{PROJECT_MARKER_PREFIX}}-roadmap-id` marker.
 
-**Legacy roots without a label or marker.** `--all-roadmaps` root
-discovery (see `docs/idd-helper-scripts.md`) finds roots only by the
-configured roadmap label and the
-`{{PROJECT_MARKER_PREFIX}}-roadmap-id` marker, so a legacy umbrella
-issue predating both is never discovered as a root. Mitigate with
-either **retro-label** (add the configured roadmap label to the
-umbrella) or configure **`discover.legacyRoots`** — an array of issue
-numbers unioned into root discovery and deduped against label/marker
-roots, for when retro-labeling is undesirable. A missing or invalid
-`legacyRoots` value fails safe to no extra roots.
+**Legacy roots**: `--all-roadmaps` finds roots only by label or
+`{{PROJECT_MARKER_PREFIX}}-roadmap-id` marker. Retro-label a legacy
+umbrella, or configure **`discover.legacyRoots`** (issue numbers,
+deduped against label/marker roots; invalid fails safe to none). See
+`docs/idd-helper-scripts.md`.
 
 **Note**: Repo-wide or label-based issue queries are permitted only in
 the scoped contexts A2 enumerates below (**A0-T**, **A0-O**, **A1**,
@@ -229,40 +213,27 @@ referenced issues. Collect only **open** issues.
 
 **Allowed traversal sources** (outbound references only):
 
-- Task-list entries in the roadmap or in any recursively discovered
-  issue
-- Issue cross-references that indicate a work dependency or task
+- Task-list entries in the roadmap or any recursively discovered issue
+- Issue cross-references indicating a work dependency or task
   relationship (e.g., `Closes #NNN`, `Refs #NNN`, explicit sub-issue
-  lines in the issue body)
+  lines)
 - GitHub sub-issue relationships (parent → child)
 
 **Excluded from traversal**:
 
-- Inbound backlinks (issues that reference the roadmap but are not
+- Inbound backlinks (issues referencing the roadmap without being
   referenced by it)
-- Incidental narrative mentions (e.g., "Similar to #NNN") without an
+- Incidental narrative mentions (e.g., "Similar to #NNN") lacking an
   explicit task, sub-issue, or dependency relationship
 
-Traverse referenced issues regardless of their open/closed state.
-
-**Roadmap node classification**: any issue carrying the configured
-roadmap label or containing an
-`<!-- {{PROJECT_MARKER_PREFIX}}-roadmap-id: ... -->` marker is a
-**roadmap node**, not an execution leaf. Roadmap nodes are
-traversal-only coordination nodes:
-
-- Continue walking their outbound references to reach execution leaf
-  issues below them.
-- Do **not** add roadmap nodes to the A2 candidate set, even when open.
-- Closed intermediate roadmap nodes must still be traversed so open
-  descendants cannot be hidden behind a closed parent.
-- Only non-roadmap open issues (execution leaves) advance to
-  A3/A4/A4.5/A5.
-- Track open roadmap nodes separately and report them alongside the A2
-  execution candidates.
-- The root roadmap selected by A1 is the traversal starting point and
-  is not added to the roadmap-node set; only issues discovered through
-  its outbound references are classified and reported.
+Traverse referenced issues regardless of open/closed state. Issues
+carrying the configured roadmap label or an
+`<!-- {{PROJECT_MARKER_PREFIX}}-roadmap-id: ... -->` marker are
+**roadmap nodes**; any other issue is an **execution leaf**. Include
+only open execution leaves in the candidate set; never advance roadmap
+nodes to A3/A4/A4.5/A5, but traverse closed nodes too (so descendants
+aren't hidden). The A1 root roadmap starts the traversal and is
+excluded from the open roadmap-node set.
 
 **Permitted repo-wide queries** — only the following scoped lookups may
 touch issues outside the roadmap traversal graph:
@@ -323,14 +294,14 @@ Report every A2 execution candidate with its provenance path (e.g.
 references before passing to A3.
 
 **Autopilot cross-roadmap union (optional, additive).** When A1 elected
-the cross-roadmap mode, enumerate from **each** open roadmap root and take
-the **union** of open execution leaves. De-duplicate a leaf reached from
-several roots (record every source root as provenance; never double-count
-it). Rank the union by autopilot-suitability **descending**, tie-broken by
-issue number **ascending**; treat a missing or out-of-range score as the
-configured floor, but never rank an unscored leaf above genuinely scored
-work at the same effective value. The `discover-roadmap-graph` helper's
-`--all-roadmaps` mode produces exactly this ranked union (see
+the cross-roadmap mode, enumerate from **each** open roadmap root and
+take the **union** of open execution leaves, de-duplicating a leaf
+reached from several roots (record every source root as provenance;
+never double-count). Rank by autopilot-suitability **descending**,
+tie-broken by issue number **ascending**, using the same
+scored-vs-unscored floor tie-breaker as A4 Step 2. The
+`discover-roadmap-graph` helper's `--all-roadmaps` mode produces exactly
+this ranked union (see
 [IDD helper script evaluation](../../docs/idd-helper-scripts.md)). The
 score is an advisory ranking hint only — A3/A4/A4.5/A5 still run on the
 selected candidate.
@@ -338,10 +309,10 @@ selected candidate.
 ## A3 — Filter to ready-to-start
 
 Under concurrency, check a candidate's **active-claim eligibility** (the
-non-stale claim filter below) **first**, before investing in its viability
-or scope analysis: a parallel agent may already hold the issue, and scope
-work that displaces the claim check produces redundant PRs. The claim check
-is cheap — run it first per candidate.
+non-stale claim filter below) **first**, before investing in its
+viability or scope analysis: a parallel agent may already hold the
+issue, and scope work that displaces the claim check produces redundant
+PRs. The claim check is cheap — run it first per candidate.
 
 From A2, keep only issues that satisfy **all** of the following:
 
@@ -349,39 +320,31 @@ From A2, keep only issues that satisfy **all** of the following:
 - No configured authoring label
 - No open dependent issues (parent epics / aggregate issues that are
   still open are acceptable)
-- All dependency issues are closed or otherwise completed. Check both
-  forms of dependency: (a) visible `Blocked by #NNN` lines in the issue
-  body — if any referenced issue is open, treat as blocked; if a
-  reference cannot be resolved (issue not found or inaccessible), treat
-  as blocked (fail-safe); (b) hidden
-  `<!-- {{PROJECT_MARKER_PREFIX}}-blocked-by: {roadmap-id} -->` markers
-  — for each `{roadmap-id}`, find the issue whose body contains
-  `<!-- {{PROJECT_MARKER_PREFIX}}-roadmap-id: {roadmap-id} -->`. If that
-  issue is open, treat as blocked. If no issue matches the roadmap-id,
-  treat as blocked (fail-safe — an unmatched marker indicates a
+- All dependency issues are closed or otherwise completed. Two forms:
+  (a) visible `Blocked by #NNN` lines — an open or unresolvable
+  reference is treated as blocked (fail-safe); (b) hidden
+  `<!-- {{PROJECT_MARKER_PREFIX}}-blocked-by: {roadmap-id} -->` markers —
+  find the issue whose body contains a matching
+  `<!-- {{PROJECT_MARKER_PREFIX}}-roadmap-id: {roadmap-id} -->`; treat as
+  blocked if that issue is open, if no issue matches (fail-safe — a
   migration integrity problem such as a typo, deleted issue, or
-  incomplete migration). If multiple issues match, treat as blocked if
-  any is open.
+  incomplete migration), or if any matching issue is open.
 - No external human coordination required to start; otherwise keep
   scanning
 
-**When A2 finds zero candidates, or when zero issues survive A3
-filtering**, apply the following decision tree — do not silently expand
-scope:
+**When A2 finds zero candidates, or zero issues survive A3 filtering**,
+apply this decision tree — do not silently expand scope:
 
-1. **A2 enumeration failure** (infrastructure or tool issue — see A2 for
-   the definition): abort immediately and report. No fallback.
-   (Unresolvable individual references are already pruned in A2 and do
-   not trigger this step.)
+1. **A2 enumeration failure** (infrastructure or tool issue — see A2):
+   abort immediately and report. No fallback. (Unresolvable individual
+   references are already pruned in A2 and do not trigger this step.)
 
-2. **A2 empty — only open roadmap nodes remain** (all reachable open
-   issues are roadmap nodes, not execution leaves): report the node
-   list with provenance paths. These nested roadmaps need A1.5 audit
-   or further leaf-issue population. Do not treat them as candidates.
-   Proceed to step 5.
+2. **A2 empty — only open roadmap nodes remain**: report each node and
+   its provenance path (A1.5 audit needed); do not treat them as
+   candidates. Proceed to step 5.
 
-3. **A2 empty** (no open candidates, no roadmap nodes): report zero
-   open candidates and skipped references; proceed to step 5.
+3. **A2 empty — no candidates** (no roadmap nodes either): report zero
+   open candidates and any skipped references, then proceed to step 5.
 
 4. **A3 filtered to zero** (A2 found execution candidates but all were
    filtered out): report each candidate and the filter criterion it
@@ -393,13 +356,12 @@ scope:
 5. **Request explicit opt-in** — ask the operator: "No roadmap-scoped
    issues are available. Do you want to expand the search scope for this
    run? If so, specify the alternate scope." An agent is **unattended**
-   if it cannot wait for and receive a same-run operator reply. Then:
+   if it cannot wait for and receive a same-run operator reply.
 
-   - **Unattended mode**: abort and report. Do not infer opt-in from
-     prior or standing instructions.
-   - **Operator declines or does not respond**: abort and report.
+   - **Unattended mode, or the operator declines/does not respond**:
+     abort and report.
    - **Operator grants opt-in**: use the operator-specified scope for
-     this run only. Prior or standing instructions do not count as
+     this run only — prior or standing instructions never count as
      opt-in.
 
 ## A3.5 — Apply issue-author approval gate
@@ -482,10 +444,8 @@ criteria. Fail any one → discard the issue.
 
 If **no issue** survives the gate:
 
-- if the approval-needed fallback bucket from A3.5 is non-empty, report
-  that only approval-needed issues remain and stop without claim in
-  unattended mode. In attended mode, ask the operator whether to obtain
-  approval or opt out explicitly;
+- if the approval-needed fallback bucket from A3.5 is non-empty, apply
+  A3.5's own approval-needed routing (above) instead of falling back;
 - otherwise, apply the **exhaustion-exit routing** defined here: under
   **`roadmap-first`** scope in the roadmap-traversal flow (A2→A3→A4; not
   the A0-T gate, which stops a failed target with no fallback), route to
@@ -497,31 +457,24 @@ If **no issue** survives the gate:
 
 ### Step 1.5 — Active-claim pre-scan
 
-Before selecting from the surviving viable issues, eliminate
-candidates that already carry a concurrent active non-stale claim,
-in ascending issue-number order:
+Before selecting from the surviving viable issues, eliminate candidates
+carrying a concurrent active non-stale claim, in ascending issue-number
+order:
 
 - Scan the **top N** survivors (ordered by ascending issue number),
   where `N` is `.github/idd/config.json`
   `discover.activeClaimPreScanBatchSize` (distributed default: `10`).
 - For each candidate, fetch the issue and parse comments per the
-  shared claim-state rules in `idd-claim.instructions.md` — including
+  shared claim-state rules in `idd-claim.instructions.md`, including
   forced-handoff and legacy markers, not just
-  `claimed-by`/`unclaimed-by`. No current bulk helper
-  (`discover-roadmap-graph.mjs --with-claim-state` /
-  `discover-orphan-filter.mjs --with-claim-state`) is
-  forced-handoff-aware, so a multi-candidate
-  survey here must either loop the single-issue
-  `resume-claim-routing.mjs --fresh-claim-gate` resolver per candidate
-  or apply `idd-claim.instructions.md`'s full parsing rules manually. A
-  candidate is **ineligible** when parsing yields an **active claim**
-  whose latest valid `claimed-by` comment (matching the documented
-  format, authored by a trusted marker actor) has GitHub `created_at`
-  newer than the `claim-stale-age` policy default
-  (`docs/policy-constants.md`; distributed default: `24 h`).
-  Otherwise (no active claim, the active claim is already stale, or
-  no comment satisfies the trusted-marker + format requirements) the
-  candidate **remains eligible**.
+  `claimed-by`/`unclaimed-by`. No current bulk helper's
+  `--with-claim-state` flag is forced-handoff-aware, so loop the
+  single-issue `resume-claim-routing.mjs --fresh-claim-gate` resolver
+  per candidate, or apply the full parsing rules manually. A candidate
+  is **ineligible** when parsing yields an active claim whose latest
+  valid `claimed-by` comment has GitHub `created_at` newer than
+  `claim-stale-age` (`docs/policy-constants.md`; distributed default:
+  `24 h`); otherwise it **remains eligible**.
 
 After scanning the current batch:
 
@@ -535,49 +488,45 @@ After scanning the current batch:
   below).
 
 When the entire viable candidate set is exhausted (the last bullet
-above): if the A3.5 approval-needed bucket is non-empty, report both the
-claimed-survivor exhaustion and the approval-needed hold, then stop (the
-approval hold takes precedence — not a true zero); otherwise apply Step 1's
-**exhaustion-exit routing** above, reporting that all viable issues are
-currently claimed in place of a discard criterion. Retry later.
+above): if the A3.5 approval-needed bucket is non-empty, apply A3.5's
+own approval-needed routing, also reporting the claimed-survivor
+exhaustion (the approval hold takes precedence — not a true zero);
+otherwise apply Step 1's **exhaustion-exit routing** above, reporting
+that all viable issues are currently claimed in place of a discard
+criterion. Retry later.
 
 See [Discover — A4 Step 1.5 Rationale](../../docs/idd-design-rationale.md#a4-step-15--rationale-active-claim-pre-scan)
 for why this pre-scan exists.
 
 ### Step 2 — Select
 
-Among the surviving viable and unclaimed issues (after Step 1.5), pick the
-**highest authored autopilot-suitability score** (the
+Among the surviving viable and unclaimed issues (after Step 1.5), pick
+the **highest authored autopilot-suitability score** (the
 `<!-- {{PROJECT_MARKER_PREFIX}}-autopilot-suitability: N -->` footer, or the
 `discover-roadmap-graph` node's `autopilotSuitability`), tie-broken by
 **lowest issue number**. In autopilot runs, skip scores below
-`autopilotSuitability.floor` (default `3`) as human-oriented; a missing or
-out-of-range score is treated as no score — ranked at the floor and never
-skipped, so the unscored backlog flows as before, subject to the
-scored-vs-unscored tie-breaker below when it ties against a
-genuinely-scored candidate at the same value. Advisory only: the pick
-still passes A4.5/A5 unchanged and the score never bypasses a gate. When
-`autopilotSuitability.enabled` is `false`, ignore the score entirely —
-neither skip below-floor candidates nor reorder by score — and select by
-**lowest issue number**.
+`autopilotSuitability.floor` (default `3`) as human-oriented; a missing
+or out-of-range score defaults to the floor and is never skipped
+(subject to the scored-vs-unscored tie-breaker below). Advisory only —
+the pick still passes A4.5/A5 unchanged and never bypasses a gate. When
+`autopilotSuitability.enabled` is `false`, ignore the score entirely and
+select by **lowest issue number**.
 
-**Scored-vs-unscored floor tie-breaker.** When the highest-score tie band
-pairs an unscored candidate (missing or out-of-range score, defaulted to
-the floor as defined above) against a candidate genuinely scored exactly
-at the floor value, the genuinely-scored candidate wins the tie: an explicit
-author judgment outranks a default fallback. Apply this rule first,
-before the concurrent-selection desync, effort-hint, and
-lowest-issue-number tie-breakers below, which still apply in unchanged
-relative order to any tie that remains afterward.
+**Scored-vs-unscored floor tie-breaker.** When the highest-score tie
+band pairs an unscored candidate (missing or out-of-range score,
+defaulted to the floor as defined above) against a candidate genuinely
+scored exactly at the floor value, the genuinely-scored candidate wins
+the tie: an explicit author judgment outranks a default fallback. See
+[rationale](../../docs/idd-design-rationale.md#a4--scored-vs-unscored-floor-tie-breaker-what-still-ties-afterward)
+for how the remaining tie-breakers below apply after this rule.
 
 **Concurrent-selection desync (opt-in, off by default).** When
-`.github/idd/config.json` `discover.selectionDesync` is `session-offset`
-(default `off`) and the chosen highest-score tie band has more than one
-eligible candidate, pick the band entry at index
-`selectDesyncedIndex(session-token, band-size)` instead of index 0 (a
-pure, deterministic `hash(session-token) mod band-size`, over the band
-ordered by ascending issue number, `session-token` being this session's
-`{agent-id}`). Compute it with the CLI instead of hand-tracing
+`discover.selectionDesync` is `session-offset` (default `off`) and the
+highest-score tie band has more than one eligible candidate, pick the
+band entry at index `selectDesyncedIndex(session-token, band-size)`
+instead of index 0 — a pure `hash(session-token) mod band-size` over
+the band ordered by ascending issue number, `session-token` being this
+session's `{agent-id}`. Compute it with the CLI instead of hand-tracing
 `scripts/policy-helpers.mjs`:
 
 ```sh
@@ -589,38 +538,37 @@ node scripts/select-desynced-index.mjs --token <session-token> --band-size <band
 ```
 
 Resolve `<profile-selected-select-desynced-index-command>` from
-`docs/idd-helper-scripts.md`; do not hardcode `node scripts/...` for
-non-vendored profiles. The formula above remains the canonical spec and
-fallback when the helper is unavailable. It reorders **only within** a
-single score tie band, never across score bands, and never bypasses
-A4.5/A5. With `off`, a single-entry band, or no applicable score, keep
-the deterministic **lowest issue number** pick. See
+`docs/idd-helper-scripts.md` (do not hardcode `node scripts/...` for
+non-vendored profiles); the formula above is the canonical fallback
+when the helper is unavailable. It reorders **only within** a single
+score tie band, never across bands, and never bypasses A4.5/A5. With
+`off`, a single-entry band, or no applicable score, keep the
+deterministic **lowest issue number** pick. See
 [rationale](../../docs/idd-design-rationale.md#a4-step-2--rationale-concurrent-selection-desync).
 
-**Author-recorded effort hint (soft tie-breaker).** When candidates remain
-tied after the score and optional desync rules, prefer the **lower-effort**
-candidate **before** the lowest-issue-number tie-break. Read the authored
-`<!-- {{PROJECT_MARKER_PREFIX}}-effort: S|M|L -->` footer (or the
-`discover-roadmap-graph` node's `effort`): order `S` < `M` < `L`, and a
-missing or invalid hint is treated as the **neutral middle** (as-if `M`), so a
-band with no effort hints keeps the lowest-issue-number order exactly as
-before. This is a **soft** rule: it reorders **only within** a single score
-tie band, never skips, gates, or crosses a score band; the
-`discover-roadmap-graph` union already emits this order.
+**Author-recorded effort hint (soft tie-breaker).** When candidates
+remain tied after the score and optional desync rules, prefer the
+**lower-effort** candidate before the lowest-issue-number tie-break.
+Read the authored `<!-- {{PROJECT_MARKER_PREFIX}}-effort: S|M|L -->` footer
+(or the `discover-roadmap-graph` node's `effort`): `S` < `M` < `L`, with
+a missing or invalid hint as the **neutral middle** (`M`). **Soft**
+rule: reorders only within a single score tie band, never skips,
+gates, or crosses a band; the `discover-roadmap-graph` union already
+emits this order.
 
-**High-contention shared-file overlap (advisory).** Concurrent autopilot
-sessions tend to edit the same F-phase bundle instruction files
-(`bundle-review` / `bundle-merge`) and `audit/sync-manifest.json`. As a
-**soft** tie-breaker layered after the score / desync / effort /
-lowest-number rules, prefer a candidate whose `## Candidate files` do
-**not** overlap an actively-claimed or open-PR issue on one of those files;
-the optional `discover-shared-file-overlap` helper (see
-[IDD helper scripts](../../docs/idd-helper-scripts.md)) reports each candidate's
-`overlapFlag` and a `recommendedOrder`. This is **never a hard gate** —
-overlap never overrides the score or crosses a score band. See the
+**High-contention shared-file overlap (advisory).** Concurrent
+autopilot sessions tend to edit the same F-phase bundle instruction
+files (`bundle-review` / `bundle-merge`) and `audit/sync-manifest.json`.
+As a **soft** tie-breaker after score / desync / effort / lowest-number,
+prefer a candidate whose `## Candidate files` do **not** overlap an
+actively-claimed or open-PR issue on one of those files; the optional
+`discover-shared-file-overlap` helper (see
+[IDD helper scripts](../../docs/idd-helper-scripts.md)) reports each
+candidate's `overlapFlag` and `recommendedOrder`. **Never a hard gate**
+— overlap never overrides the score or crosses a band. See the
 [high-contention shared-file convention](../../docs/policy-constants.md#high-contention-shared-files).
 
-After picking, continue to **A4.5** (`idd-suitability.instructions.md`).
+After picking, proceed to **A4.5** (`idd-suitability.instructions.md`).
 
 ## A4.5 — Pre-Claim Issue-Suitability Triage
 
@@ -633,27 +581,27 @@ mutation policy, coordination rules, decision flow, and edge cases.
 Two hidden HTML comment markers are used in issue bodies to support the
 discover phase:
 
-- **Roadmap identity** (`{{PROJECT_MARKER_PREFIX}}-roadmap-id`): placed
-  in the roadmap issue body. A3 uses this marker to resolve `blocked-by`
-  dependency lookups. A1 identifies the roadmap by its configured
-  roadmap label or umbrella structure — not by this marker.
-- **Sequential dependency** (`{{PROJECT_MARKER_PREFIX}}-blocked-by`):
-  placed in an issue body to express a hard dependency — this issue
-  **cannot start until** the roadmap with the matching `roadmap-id` is
-  closed.
+- **Roadmap identity** (`{{PROJECT_MARKER_PREFIX}}-roadmap-id`): placed in
+  the roadmap issue body; A3 uses it to resolve `blocked-by` dependency
+  lookups. A1 identifies the roadmap by its configured label or umbrella
+  structure, not by this marker.
+- **Sequential dependency** (`{{PROJECT_MARKER_PREFIX}}-blocked-by`): placed
+  in an issue body to express a hard dependency — this issue **cannot
+  start until** the roadmap with the matching `roadmap-id` is closed.
 
-**Do not use `{{PROJECT_MARKER_PREFIX}}-blocked-by` to group sub-tasks
-under an active roadmap.** Sub-tasks that should be worked on while the
+**Do not use `{{PROJECT_MARKER_PREFIX}}-blocked-by` to group sub-tasks under
+an active roadmap.** Sub-tasks that should be worked on while the
 roadmap is open belong in the roadmap's task list as `- [ ] #NNN`
-entries. The `blocked-by` marker is reserved for issues that must wait
-for a separate, prior roadmap to close before they can start (cross-
-phase sequential dependency). Using it for grouping causes A3 to block
-every sub-task for the entire lifetime of the roadmap.
+entries; `blocked-by` is reserved for issues that must wait for a
+separate, prior roadmap to close (cross-phase sequential dependency) —
+see the
+[A3 diagnostic](../../docs/idd-design-rationale.md#a3---diagnostic-all-candidates-blocked-by-an-open-roadmap)
+for the resulting deadlock pattern.
 
 ## Scope invariant (summary)
 
 Do not widen issue-selection scope beyond the roadmap traversal except
 for the explicit query allowlist already defined in A0-T, A0-O, A1,
-A1.5, A3, and A4.5, or for a same-run operator opt-in after a
-zero-result report. A single explicit target authorizes only that issue;
-prior or standing instructions do not count as opt-in.
+A1.5, A3, and A4.5, or for a same-run operator opt-in per A3 step 5
+(never inferred from prior or standing instructions). A single explicit
+target authorizes only that issue.

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -610,8 +610,15 @@ function checkInstructionSizeBudgets(configs) {
     // Each array entry is still unvalidated JSON: a `null` (or other
     // non-object) entry would throw on `config.glob` below before the
     // pure helper's own `!config` guard ever runs. Reject it here with a
-    // readable error instead of crashing the whole audit run.
-    if (rawConfig === null || typeof rawConfig !== 'object') {
+    // readable error instead of crashing the whole audit run. Arrays pass
+    // `typeof === 'object'` too, so reject them explicitly — otherwise an
+    // entry like `[[]]` would silently fall through and audit under the
+    // default glob instead of erroring.
+    if (
+      rawConfig === null ||
+      typeof rawConfig !== 'object' ||
+      Array.isArray(rawConfig)
+    ) {
       errors.push(
         `instructionSizeBudgets: each entry must be an object, got ${JSON.stringify(rawConfig)}`,
       );

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -606,7 +606,18 @@ function checkInstructionSizeBudgets(configs) {
   // supplies the changed file set, a glob lister, and a reader. The helper
   // reads only changed files, so unchanged instruction files are never
   // loaded from disk.
-  for (const config of configs) {
+  for (const rawConfig of configs) {
+    // Each array entry is still unvalidated JSON: a `null` (or other
+    // non-object) entry would throw on `config.glob` below before the
+    // pure helper's own `!config` guard ever runs. Reject it here with a
+    // readable error instead of crashing the whole audit run.
+    if (rawConfig === null || typeof rawConfig !== 'object') {
+      errors.push(
+        `instructionSizeBudgets: each entry must be an object, got ${JSON.stringify(rawConfig)}`,
+      );
+      continue;
+    }
+    const config = rawConfig;
     const result = collectInstructionSizeBudgetViolations(
       config,
       changedFiles,

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -41,7 +41,7 @@ checkShellFileLists(
 );
 checkSyncPairs(manifest.syncPairs ?? []);
 checkGeneratedFromBanners(manifest.syncPairs ?? []);
-checkInstructionSizeBudgets(manifest.instructionSizeBudgets ?? null);
+checkInstructionSizeBudgets(manifest.instructionSizeBudgets ?? []);
 checkContextCeiling(
   manifest.contextCeiling ?? null,
   checkBundleBudgets(manifest.bundleBudgets ?? []),
@@ -576,20 +576,33 @@ function docsSyncCommandByPackageManager(packageManager) {
       return '';
   }
 }
-function checkInstructionSizeBudgets(config) {
-  // The scope/skip decision and budget evaluation live in the pure helper
-  // so they can be unit-tested; the audit pipeline supplies the changed
-  // file set, a glob lister, and a reader. The helper reads only changed
-  // files, so unchanged instruction files are never loaded from disk.
-  const result = collectInstructionSizeBudgetViolations(
-    config,
-    changedFiles,
-    () =>
-      globFiles(config?.glob ?? '.github/instructions/idd-*.instructions.md'),
-    readText,
-  );
-  errors.push(...result.errors);
-  notices.push(...result.notices);
+function checkInstructionSizeBudgets(configs) {
+  // One entry per audited glob: the dogfooding `.github/instructions/`
+  // copy and the canonical `idd-template/.github/instructions/` source are
+  // separate entries so a `structure`-mode divergence between them (prose
+  // free to differ, byte size free to drift) cannot silently exceed the
+  // cap on one side while only the other side is measured (#1667). Each
+  // entry's own `id` — plus the audited path's own prefix in every error
+  // message the helper emits — is the scope/label that keeps output
+  // unambiguous about which copy violated its budget; see
+  // `audit/README.md#instruction-size-budgets`.
+  //
+  // The scope/skip decision and budget evaluation for each entry live in
+  // the pure helper so they can be unit-tested; the audit pipeline
+  // supplies the changed file set, a glob lister, and a reader. The helper
+  // reads only changed files, so unchanged instruction files are never
+  // loaded from disk.
+  for (const config of configs) {
+    const result = collectInstructionSizeBudgetViolations(
+      config,
+      changedFiles,
+      () =>
+        globFiles(config.glob ?? '.github/instructions/idd-*.instructions.md'),
+      readText,
+    );
+    errors.push(...result.errors);
+    notices.push(...result.notices);
+  }
 }
 // Returns the measured per-bundle stats so `checkContextCeiling` can reuse
 // this same summation instead of re-reading and re-stripping every bundle

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -41,7 +41,7 @@ checkShellFileLists(
 );
 checkSyncPairs(manifest.syncPairs ?? []);
 checkGeneratedFromBanners(manifest.syncPairs ?? []);
-checkInstructionSizeBudgets(manifest.instructionSizeBudgets ?? []);
+checkInstructionSizeBudgets(manifest.instructionSizeBudgets);
 checkContextCeiling(
   manifest.contextCeiling ?? null,
   checkBundleBudgets(manifest.bundleBudgets ?? []),
@@ -587,6 +587,20 @@ function checkInstructionSizeBudgets(configs) {
   // unambiguous about which copy violated its budget; see
   // `audit/README.md#instruction-size-budgets`.
   //
+  // `configs` is declared `unknown` (rather than trusting the manifest's
+  // declared type) because it comes straight from `JSON.parse`: a manifest
+  // left in the pre-#1667 single-object shape, or otherwise malformed,
+  // must fail closed with a readable audit error instead of throwing
+  // "configs is not iterable" out of the `for` loop below.
+  if (configs == null) {
+    return;
+  }
+  if (!Array.isArray(configs)) {
+    errors.push(
+      'instructionSizeBudgets: must be an array of per-glob budget entries, one per audited glob (see audit/README.md#instruction-size-budgets); got the pre-#1667 single-object shape or another non-array value',
+    );
+    return;
+  }
   // The scope/skip decision and budget evaluation for each entry live in
   // the pure helper so they can be unit-tested; the audit pipeline
   // supplies the changed file set, a glob lister, and a reader. The helper

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -727,6 +727,14 @@ export function collectInstructionSizeBudgetViolations(
  * value mislabeled with a *different* budget's number still passes — acceptable
  * for the drift this guards.
  *
+ * `sizeBudgets` accepts either a single budget object (legacy shape) or an
+ * array of them — `instructionSizeBudgets` in `audit/sync-manifest.json` is
+ * an array of one entry per audited glob (dogfooding copy, `idd-template`
+ * source, …; see `audit/README.md#instruction-size-budgets`) — and unions
+ * every entry's `alwaysLoadedLimitBytes` / `phaseLimitBytes` into the same
+ * valid-value set, so a doc may cite any configured glob's limit without
+ * drifting.
+ *
  * Matching requires a `bytes` suffix, so a doc that reads its limits live via
  * `jq` carries no hardcoded number and is never flagged. The configured
  * `files` must therefore not contain non-budget "N bytes" prose, or it would
@@ -746,11 +754,18 @@ export function collectDocBudgetDriftViolations(
   // never re-apply a default (a `?? 30000` fallback would let the set hold a
   // value the manifest no longer declares, producing a false positive).
   const validValues = new Set();
-  if (typeof sizeBudgets?.alwaysLoadedLimitBytes === 'number') {
-    validValues.add(sizeBudgets.alwaysLoadedLimitBytes);
-  }
-  if (typeof sizeBudgets?.phaseLimitBytes === 'number') {
-    validValues.add(sizeBudgets.phaseLimitBytes);
+  const budgetEntries = Array.isArray(sizeBudgets)
+    ? sizeBudgets
+    : sizeBudgets
+      ? [sizeBudgets]
+      : [];
+  for (const budget of budgetEntries) {
+    if (typeof budget?.alwaysLoadedLimitBytes === 'number') {
+      validValues.add(budget.alwaysLoadedLimitBytes);
+    }
+    if (typeof budget?.phaseLimitBytes === 'number') {
+      validValues.add(budget.phaseLimitBytes);
+    }
   }
   for (const budget of bundleBudgets ?? []) {
     const limit = Number(budget.limitBytes);

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -129,7 +129,7 @@ checkShellFileLists(
 );
 checkSyncPairs(manifest.syncPairs ?? []);
 checkGeneratedFromBanners(manifest.syncPairs ?? []);
-checkInstructionSizeBudgets(manifest.instructionSizeBudgets ?? []);
+checkInstructionSizeBudgets(manifest.instructionSizeBudgets);
 checkContextCeiling(
   manifest.contextCeiling ?? null,
   checkBundleBudgets(manifest.bundleBudgets ?? []),
@@ -727,9 +727,7 @@ function docsSyncCommandByPackageManager(packageManager: unknown): string {
   }
 }
 
-function checkInstructionSizeBudgets(
-  configs: readonly InstructionSizeBudgetConfig[],
-) {
+function checkInstructionSizeBudgets(configs: unknown) {
   // One entry per audited glob: the dogfooding `.github/instructions/`
   // copy and the canonical `idd-template/.github/instructions/` source are
   // separate entries so a `structure`-mode divergence between them (prose
@@ -740,12 +738,26 @@ function checkInstructionSizeBudgets(
   // unambiguous about which copy violated its budget; see
   // `audit/README.md#instruction-size-budgets`.
   //
+  // `configs` is declared `unknown` (rather than trusting the manifest's
+  // declared type) because it comes straight from `JSON.parse`: a manifest
+  // left in the pre-#1667 single-object shape, or otherwise malformed,
+  // must fail closed with a readable audit error instead of throwing
+  // "configs is not iterable" out of the `for` loop below.
+  if (configs == null) {
+    return;
+  }
+  if (!Array.isArray(configs)) {
+    errors.push(
+      'instructionSizeBudgets: must be an array of per-glob budget entries, one per audited glob (see audit/README.md#instruction-size-budgets); got the pre-#1667 single-object shape or another non-array value',
+    );
+    return;
+  }
   // The scope/skip decision and budget evaluation for each entry live in
   // the pure helper so they can be unit-tested; the audit pipeline
   // supplies the changed file set, a glob lister, and a reader. The helper
   // reads only changed files, so unchanged instruction files are never
   // loaded from disk.
-  for (const config of configs) {
+  for (const config of configs as InstructionSizeBudgetConfig[]) {
     const result = collectInstructionSizeBudgetViolations(
       config,
       changedFiles,

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -761,8 +761,15 @@ function checkInstructionSizeBudgets(configs: unknown) {
     // Each array entry is still unvalidated JSON: a `null` (or other
     // non-object) entry would throw on `config.glob` below before the
     // pure helper's own `!config` guard ever runs. Reject it here with a
-    // readable error instead of crashing the whole audit run.
-    if (rawConfig === null || typeof rawConfig !== 'object') {
+    // readable error instead of crashing the whole audit run. Arrays pass
+    // `typeof === 'object'` too, so reject them explicitly — otherwise an
+    // entry like `[[]]` would silently fall through and audit under the
+    // default glob instead of erroring.
+    if (
+      rawConfig === null ||
+      typeof rawConfig !== 'object' ||
+      Array.isArray(rawConfig)
+    ) {
       errors.push(
         `instructionSizeBudgets: each entry must be an object, got ${JSON.stringify(rawConfig)}`,
       );

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -93,7 +93,10 @@ interface AuditManifest {
   generatedBlocks?: GeneratedBlock[];
   shellFileLists?: ShellFileList[];
   syncPairs?: SyncPair[];
-  instructionSizeBudgets?: InstructionSizeBudgetConfig | null;
+  // One entry per audited glob (dogfooding `.github/instructions/` copy,
+  // canonical `idd-template/.github/instructions/` source, …); see
+  // `checkInstructionSizeBudgets` and `audit/README.md#instruction-size-budgets`.
+  instructionSizeBudgets?: InstructionSizeBudgetConfig[] | null;
   bundleBudgets?: BundleBudget[];
   contextCeiling?: ContextCeilingConfig | null;
   docBudgetGuard?: DocBudgetGuardConfig | null;
@@ -126,7 +129,7 @@ checkShellFileLists(
 );
 checkSyncPairs(manifest.syncPairs ?? []);
 checkGeneratedFromBanners(manifest.syncPairs ?? []);
-checkInstructionSizeBudgets(manifest.instructionSizeBudgets ?? null);
+checkInstructionSizeBudgets(manifest.instructionSizeBudgets ?? []);
 checkContextCeiling(
   manifest.contextCeiling ?? null,
   checkBundleBudgets(manifest.bundleBudgets ?? []),
@@ -725,21 +728,34 @@ function docsSyncCommandByPackageManager(packageManager: unknown): string {
 }
 
 function checkInstructionSizeBudgets(
-  config: InstructionSizeBudgetConfig | null,
+  configs: readonly InstructionSizeBudgetConfig[],
 ) {
-  // The scope/skip decision and budget evaluation live in the pure helper
-  // so they can be unit-tested; the audit pipeline supplies the changed
-  // file set, a glob lister, and a reader. The helper reads only changed
-  // files, so unchanged instruction files are never loaded from disk.
-  const result = collectInstructionSizeBudgetViolations(
-    config,
-    changedFiles,
-    () =>
-      globFiles(config?.glob ?? '.github/instructions/idd-*.instructions.md'),
-    readText,
-  );
-  errors.push(...result.errors);
-  notices.push(...result.notices);
+  // One entry per audited glob: the dogfooding `.github/instructions/`
+  // copy and the canonical `idd-template/.github/instructions/` source are
+  // separate entries so a `structure`-mode divergence between them (prose
+  // free to differ, byte size free to drift) cannot silently exceed the
+  // cap on one side while only the other side is measured (#1667). Each
+  // entry's own `id` — plus the audited path's own prefix in every error
+  // message the helper emits — is the scope/label that keeps output
+  // unambiguous about which copy violated its budget; see
+  // `audit/README.md#instruction-size-budgets`.
+  //
+  // The scope/skip decision and budget evaluation for each entry live in
+  // the pure helper so they can be unit-tested; the audit pipeline
+  // supplies the changed file set, a glob lister, and a reader. The helper
+  // reads only changed files, so unchanged instruction files are never
+  // loaded from disk.
+  for (const config of configs) {
+    const result = collectInstructionSizeBudgetViolations(
+      config,
+      changedFiles,
+      () =>
+        globFiles(config.glob ?? '.github/instructions/idd-*.instructions.md'),
+      readText,
+    );
+    errors.push(...result.errors);
+    notices.push(...result.notices);
+  }
 }
 
 // Returns the measured per-bundle stats so `checkContextCeiling` can reuse

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -757,7 +757,18 @@ function checkInstructionSizeBudgets(configs: unknown) {
   // supplies the changed file set, a glob lister, and a reader. The helper
   // reads only changed files, so unchanged instruction files are never
   // loaded from disk.
-  for (const config of configs as InstructionSizeBudgetConfig[]) {
+  for (const rawConfig of configs) {
+    // Each array entry is still unvalidated JSON: a `null` (or other
+    // non-object) entry would throw on `config.glob` below before the
+    // pure helper's own `!config` guard ever runs. Reject it here with a
+    // readable error instead of crashing the whole audit run.
+    if (rawConfig === null || typeof rawConfig !== 'object') {
+      errors.push(
+        `instructionSizeBudgets: each entry must be an object, got ${JSON.stringify(rawConfig)}`,
+      );
+      continue;
+    }
+    const config = rawConfig as InstructionSizeBudgetConfig;
     const result = collectInstructionSizeBudgetViolations(
       config,
       changedFiles,

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -876,6 +876,14 @@ export interface DocBudgetGuardConfig {
  * value mislabeled with a *different* budget's number still passes — acceptable
  * for the drift this guards.
  *
+ * `sizeBudgets` accepts either a single budget object (legacy shape) or an
+ * array of them — `instructionSizeBudgets` in `audit/sync-manifest.json` is
+ * an array of one entry per audited glob (dogfooding copy, `idd-template`
+ * source, …; see `audit/README.md#instruction-size-budgets`) — and unions
+ * every entry's `alwaysLoadedLimitBytes` / `phaseLimitBytes` into the same
+ * valid-value set, so a doc may cite any configured glob's limit without
+ * drifting.
+ *
  * Matching requires a `bytes` suffix, so a doc that reads its limits live via
  * `jq` carries no hardcoded number and is never flagged. The configured
  * `files` must therefore not contain non-budget "N bytes" prose, or it would
@@ -884,6 +892,7 @@ export interface DocBudgetGuardConfig {
 export function collectDocBudgetDriftViolations(
   config: DocBudgetGuardConfig | null | undefined,
   sizeBudgets:
+    | readonly { alwaysLoadedLimitBytes?: number; phaseLimitBytes?: number }[]
     | { alwaysLoadedLimitBytes?: number; phaseLimitBytes?: number }
     | null
     | undefined,
@@ -899,11 +908,18 @@ export function collectDocBudgetDriftViolations(
   // never re-apply a default (a `?? 30000` fallback would let the set hold a
   // value the manifest no longer declares, producing a false positive).
   const validValues = new Set<number>();
-  if (typeof sizeBudgets?.alwaysLoadedLimitBytes === 'number') {
-    validValues.add(sizeBudgets.alwaysLoadedLimitBytes);
-  }
-  if (typeof sizeBudgets?.phaseLimitBytes === 'number') {
-    validValues.add(sizeBudgets.phaseLimitBytes);
+  const budgetEntries = Array.isArray(sizeBudgets)
+    ? sizeBudgets
+    : sizeBudgets
+      ? [sizeBudgets]
+      : [];
+  for (const budget of budgetEntries) {
+    if (typeof budget?.alwaysLoadedLimitBytes === 'number') {
+      validValues.add(budget.alwaysLoadedLimitBytes);
+    }
+    if (typeof budget?.phaseLimitBytes === 'number') {
+      validValues.add(budget.phaseLimitBytes);
+    }
   }
   for (const budget of bundleBudgets ?? []) {
     const limit = Number(budget.limitBytes);

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -372,6 +372,66 @@ test('doc budget guard is a no-op without config and notices on empty budgets', 
   assert.match(noBudgets.notices[0], /skipped doc budget guard/);
 });
 
+test('doc budget guard unions size budgets across an array of per-glob entries', () => {
+  // instructionSizeBudgets in audit/sync-manifest.json is an array — one
+  // entry per audited glob (#1667) — so the drift guard must union every
+  // entry's limits into the same valid-value set instead of only reading
+  // a single object's fields.
+  const arrayBudgets = [
+    { id: 'instruction-size-budgets-dogfood', ...DOC_BUDGET_SIZE },
+    {
+      id: 'instruction-size-budgets-idd-template',
+      alwaysLoadedLimitBytes: 20_000,
+      phaseLimitBytes: 33_000,
+    },
+  ];
+  const passing = collectDocBudgetDriftViolations(
+    { id: 'doc-budget-drift', files: ['README.md'] },
+    arrayBudgets,
+    DOC_BUDGET_BUNDLES,
+    () => '| Phase instruction file | 33,000 bytes |',
+  );
+  assert.deepEqual(passing, { errors: [], notices: [] });
+
+  const drifted = collectDocBudgetDriftViolations(
+    { id: 'doc-budget-drift', files: ['README.md'] },
+    arrayBudgets,
+    DOC_BUDGET_BUNDLES,
+    () => '| Phase instruction file | 30,000 bytes |',
+  );
+  assert.equal(drifted.errors.length, 1);
+  assert.match(
+    drifted.errors[0],
+    /doc-budget-drift: README\.md states 30,000 bytes/,
+  );
+});
+
+test('live manifest instructionSizeBudgets covers both the dogfooding and idd-template instruction globs', () => {
+  // Regression guard for #1667: the manifest must keep a dedicated entry
+  // for the canonical idd-template source, not just the dogfooding copy,
+  // or a future structure-mode divergence can silently exceed the shared
+  // byte cap on the idd-template side again.
+  const manifest = readJson('audit/sync-manifest.json') as {
+    instructionSizeBudgets?: { id?: string; glob?: string }[];
+  };
+  const budgets = manifest.instructionSizeBudgets;
+  assert.ok(
+    Array.isArray(budgets),
+    'instructionSizeBudgets must be an array of per-glob budget entries',
+  );
+  const globs = budgets.map((budget) => budget.glob).sort();
+  assert.deepEqual(globs, [
+    '.github/instructions/idd-*.instructions.md',
+    'idd-template/.github/instructions/idd-*.instructions.md',
+  ]);
+  const ids = budgets.map((budget) => budget.id);
+  assert.equal(
+    new Set(ids).size,
+    ids.length,
+    'each instructionSizeBudgets entry needs a distinct id to disambiguate audit output',
+  );
+});
+
 test('config drift scenarios detect mismatches between config and overview defaults', () => {
   const overview = readText('tests/fixtures/consistency/config/overview.txt');
   const missingRowOverview = readText(

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -419,11 +419,19 @@ test('live manifest instructionSizeBudgets covers both the dogfooding and idd-te
     Array.isArray(budgets),
     'instructionSizeBudgets must be an array of per-glob budget entries',
   );
-  const globs = budgets.map((budget) => budget.glob).sort();
-  assert.deepEqual(globs, [
+  // Assert inclusion, not an exact-array match: audit/README.md explicitly
+  // encourages adding further per-glob entries later, and this guard must
+  // not start failing the day a third one lands.
+  const globs = budgets.map((budget) => budget.glob);
+  for (const requiredGlob of [
     '.github/instructions/idd-*.instructions.md',
     'idd-template/.github/instructions/idd-*.instructions.md',
-  ]);
+  ]) {
+    assert.ok(
+      globs.includes(requiredGlob),
+      `instructionSizeBudgets is missing an entry for ${requiredGlob}`,
+    );
+  }
   const ids = budgets.map((budget) => budget.id);
   assert.ok(
     ids.every((id) => typeof id === 'string' && id.trim().length > 0),

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -425,6 +425,10 @@ test('live manifest instructionSizeBudgets covers both the dogfooding and idd-te
     'idd-template/.github/instructions/idd-*.instructions.md',
   ]);
   const ids = budgets.map((budget) => budget.id);
+  assert.ok(
+    ids.every((id) => typeof id === 'string' && id.trim().length > 0),
+    'each instructionSizeBudgets entry needs a non-empty id',
+  );
   assert.equal(
     new Set(ids).size,
     ids.length,


### PR DESCRIPTION
# Summary

`audit/sync-manifest.json`'s `instructionSizeBudgets` audited only this
dogfooding repo's own generated `.github/instructions/idd-*.instructions.md`
copies. The canonical `idd-template/.github/instructions/idd-*.instructions.md`
source -- what adopters actually receive -- was never measured, even
though the pair syncs with `mode: "structure"` (heading shape only), so
prose and byte size are free to diverge. `idd-discover.instructions.md`
had drifted to 33,303 raw bytes on the `idd-template` side, over the
33,000-byte `phaseLimitBytes` cap #1658 ratcheted down (that ratchet
only verified the dogfooding copy).

- `instructionSizeBudgets` is now an array of one entry per audited
  glob: `instruction-size-budgets-dogfood` (unchanged) and the new
  `instruction-size-budgets-idd-template`. Each entry's own `id` is the
  scope/label that keeps a violation message unambiguous about which
  copy tripped it -- the audited path's own prefix disambiguates it a
  second time. Documented in `audit/README.md`'s new "Instruction Size
  Budgets" section.
- `collectDocBudgetDriftViolations` now accepts either a single budget
  object or an array, unioning every entry's limits, so the doc-budget
  drift guard keeps working unchanged.
- `idd-template/.github/instructions/idd-discover.instructions.md` is
  trimmed from 33,303 to 30,193 bytes by porting the same tightenings
  already applied to the dogfooding copy: dedupe repeated phrasing,
  collapse verbose bullet lists into compact paragraphs, and relocate
  two rationale asides into their existing
  `docs/idd-design-rationale.md` anchors instead of restating them
  inline. No decision-relevant rule, marker, threshold, or edge case
  is dropped; every heading stays byte-identical in position and text
  so the `structure`-mode sync check keeps passing, and the
  byte-locked A3.5 section (checked verbatim-equal against the
  dogfooding copy by `tests/issue-author-approval-gate.test.mts`) is
  untouched.
- Manually re-measured every other `idd-template/.github/instructions/idd-*.instructions.md`
  file against the same caps: all 17 remaining phase files were already
  under the 33,000-byte cap (closest: `idd-claim.instructions.md` at
  29,897 bytes), and the one always-loaded file
  (`idd-overview-core.instructions.md`) was already under its
  20,000-byte cap at 15,294 bytes. No further trims were needed.
  (`node scripts/audit-docs.mjs --check` itself only audits files
  changed in a given PR, by design -- see the new `audit/README.md`
  section -- so this manual sweep is the acceptance evidence for that
  criterion.)
- Added tests: a regression guard asserting the live manifest's
  `instructionSizeBudgets` covers both globs with distinct ids, and a
  unit test for `collectDocBudgetDriftViolations`'s array-union
  support.

## Linked issue

Closes #1667

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Found by `chatgpt-codex-connector`'s automated review on PR #1666
(#1658's PR). See #1667 for the full background.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added expanded guidance for per-glob “Instruction Size Budgets,” including scoping behavior and when manual full audits are recommended.
  - Tightened Discover-phase instructions for roadmap handling, routing, eligibility, and candidate selection semantics.
  - Refined advisory tie-break wording and clarified a skills-delivery byte-cap note.

- **Improvements**
  - Added support for multiple instruction-size budget entries with distinct audit identifiers.
  - Improved audit consistency checking and validation for malformed budget configurations.

- **Tests**
  - Added coverage for multi-entry budget union behavior and manifest wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->