### PR TITLE
docs(weak-model-authoring): record localization is out of scope

### DIFF
--- a/docs/weak-model-authoring-lite-profile-design.md
+++ b/docs/weak-model-authoring-lite-profile-design.md
@@ -140,6 +140,16 @@ design does not conflate them.
   linter-checked schema, the claim-state precondition, or the
   Publication/Approval boundary. Any disagreement between a lite
   profile and the canonical contract is a defect in the lite profile.
+- **Non-goal: operator-language translation.** A later field PoC on
+  this same tier (qwen3.5, ministral-3-3b) tested an in-loop
+  English-input/Japanese-output translation wrapper around issue
+  authoring specifically. IDD's operator-facing surfaces stay
+  English-only by design across every model tier, not just this one —
+  the gap is a project-wide scope boundary, not a weak-tier hardening
+  item this design (or #1419's) is meant to close. See
+  [#1557](https://github.com/kurone-kito/idd-skill/issues/1557) for
+  the retained field evidence; no action pending an actual
+  localization surface being proposed.
 
 ## Content principles
 


### PR DESCRIPTION
## Summary

- Adds a one-line "Non-goal: operator-language translation" pointer to `docs/weak-model-authoring-lite-profile-design.md`'s "Target model class and non-goals" section, so a future reader lands on #1557's retained field evidence without re-discovering the question from scratch.

## Background

#1557 recorded field evidence (Foundry Local PoC, small local models incl. ministral-3-3b / qwen3.5) that OpenCode paired with small local models struggles to converse in Japanese, and evaluated an in-loop translation wrapper for issue authoring. It was closed `not planned`: IDD's operator-facing surfaces stay English-only by design across every model tier, so this is a project-wide scope boundary the weak-tier hardening effort (#1540 and its shipped children #1549-#1556) was never meant to close, not a hardening gap in this tier. The source PoC's own priority assessment also ranked it lowest of nine proposals, conditional on a localization surface that does not exist.

This PR is the only follow-through from that closure: a discoverability pointer, not new guidance content.

## Test plan

- [x] `npx dprint check` on the changed file
- [x] `npx markdownlint-cli2` on the changed file
- [x] `npx cspell lint` on the changed file
- [x] pre-commit hook (`biome check && dprint check && markdownlint-cli2`) passed on commit

Refs #1557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that operator-facing surfaces remain English-only across all model tiers.
  * Noted that localization follow-up is tracked separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->