### PR TITLE
docs(customization): clarify canonical direction for source repos

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -960,7 +960,7 @@ for the `idd-template/`-sourced pairs — see the exception at the end of
 
 ## Where to Edit
 
-**Always edit canonical sources** in `docs/` and `.github/instructions/`, not the
+**Edit canonical sources** in `docs/` and `.github/instructions/`, not the
 template copies. This section assumes an **adopter repository**; see the
 [exception](#exception-this-repository-is-the-source-of-a-reusable-idd-distribution)
 at the end of this section when this repository is itself the source of a

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -970,7 +970,7 @@ reusable IDD distribution.
 location:
 
 - Policy guidance → `docs/customization.md`, `docs/policy-constants.md`, etc.
-- Instruction files → `.github/instructions/idd-*.md`
+- Instruction files → `.github/instructions/idd-*.instructions.md`
 
 **When working with template imports** (external repositories importing IDD):
 
@@ -989,8 +989,9 @@ imported IDD and has no local `idd-template/` directory, where editing
 is correct.
 
 When this repository **is** the source of a reusable IDD distribution (it
-ships its own `idd-template/` copy for adopters to import), `sync-manifest.json`
-reverses the direction for every pair whose `source` sits under
+ships its own `idd-template/` copy for adopters to import),
+`audit/sync-manifest.json` reverses the direction for every pair whose
+`source` sits under
 `idd-template/`: `idd-template/` holds the canonical text, and the
 corresponding `docs/`/`.github/instructions/` file is the generated
 target — matching the `idd-generated-from` banner already present on

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -999,7 +999,7 @@ target — matching the `idd-generated-from` banner already present on
 
 1. Edit the `idd-template/` copy, not the `docs/`/`.github/instructions/`
    target.
-2. For `exact`/`concreted` `sync-manifest.json` pairs, run `node
+2. For `exact`/`concreted` `audit/sync-manifest.json` pairs, run `node
    scripts/sync-docs.mjs --apply` to regenerate the target from the
    edited source. For `structure`/`contains` pairs, `sync-docs.mjs`
    only checks headings or text presence and does not auto-generate

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -999,8 +999,12 @@ target — matching the `idd-generated-from` banner already present on
 
 1. Edit the `idd-template/` copy, not the `docs/`/`.github/instructions/`
    target.
-2. Run `node scripts/sync-docs.mjs --apply` to regenerate the target from
-   the edited source.
+2. For `exact`/`concreted` `sync-manifest.json` pairs, run `node
+   scripts/sync-docs.mjs --apply` to regenerate the target from the
+   edited source. For `structure`/`contains` pairs, `sync-docs.mjs`
+   only checks headings or text presence and does not auto-generate
+   target content, so also apply the equivalent content change to the
+   target file by hand.
 3. Run `node scripts/audit-docs.mjs --check` to confirm the pair is back
    in sync.
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -952,29 +952,25 @@ copies.
 - Contributor tooling should guide edits toward canonical sources instead of
   editing mirrors first.
 
+The canonical/generated roles above are described from an **adopter's**
+perspective (IDD imported, no local `idd-template/`). When this repository
+is instead the source of a reusable IDD distribution, those roles reverse
+for the `idd-template/`-sourced pairs — see the exception at the end of
+[Where to Edit](#where-to-edit) below.
+
 ## Where to Edit
 
 **Always edit canonical sources** in `docs/` and `.github/instructions/`, not the
-template copies.
+template copies. This section assumes an **adopter repository**; see the
+[exception](#exception-this-repository-is-the-source-of-a-reusable-idd-distribution)
+at the end of this section when this repository is itself the source of a
+reusable IDD distribution.
 
-**When editing canonical sources**:
+**When editing canonical sources**, update the file in its canonical
+location:
 
-1. Update the file in its canonical location:
-   - Policy guidance → `docs/customization.md`, `docs/policy-constants.md`, etc.
-   - Instruction files → `.github/instructions/idd-*.md`
-
-2. If the repository distributes IDD as a template (source of a reusable IDD
-   distribution), run the documentation audit check:
-
-   ```sh
-   node scripts/audit-docs.mjs --check
-   ```
-
-   This verifies canonical/template pairs and placeholder substitutions stay
-   consistent.
-
-3. Do **not** edit files in `idd-template/` first. Update canonical sources
-   before mirroring equivalent template changes in the same commit.
+- Policy guidance → `docs/customization.md`, `docs/policy-constants.md`, etc.
+- Instruction files → `.github/instructions/idd-*.md`
 
 **When working with template imports** (external repositories importing IDD):
 
@@ -984,6 +980,28 @@ template copies.
     canonical sources only
   - Never manually edit idd-template/ files — they represent the source
     template and may be re-imported
+
+### Exception: this repository is the source of a reusable IDD distribution
+
+The guidance above assumes an **adopter repository** — one that has
+imported IDD and has no local `idd-template/` directory, where editing
+`docs/` and `.github/instructions/` directly, as this section instructs,
+is correct.
+
+When this repository **is** the source of a reusable IDD distribution (it
+ships its own `idd-template/` copy for adopters to import), `sync-manifest.json`
+reverses the direction for every pair whose `source` sits under
+`idd-template/`: `idd-template/` holds the canonical text, and the
+corresponding `docs/`/`.github/instructions/` file is the generated
+target — matching the `idd-generated-from` banner already present on
+`.github/instructions/idd-*.instructions.md` targets. In that scenario:
+
+1. Edit the `idd-template/` copy, not the `docs/`/`.github/instructions/`
+   target.
+2. Run `node scripts/sync-docs.mjs --apply` to regenerate the target from
+   the edited source.
+3. Run `node scripts/audit-docs.mjs --check` to confirm the pair is back
+   in sync.
 
 ## Repository-local IDD policy
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -960,7 +960,7 @@ for the `idd-template/`-sourced pairs — see the exception at the end of
 
 ## Where to Edit
 
-**Always edit canonical sources** in `docs/` and `.github/instructions/`, not the
+**Edit canonical sources** in `docs/` and `.github/instructions/`, not the
 template copies. This section assumes an **adopter repository**; see the
 [exception](#exception-this-repository-is-the-source-of-a-reusable-idd-distribution)
 at the end of this section when this repository is itself the source of a

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -970,7 +970,7 @@ reusable IDD distribution.
 location:
 
 - Policy guidance → `docs/customization.md`, `docs/policy-constants.md`, etc.
-- Instruction files → `.github/instructions/idd-*.md`
+- Instruction files → `.github/instructions/idd-*.instructions.md`
 
 **When working with template imports** (external repositories importing IDD):
 
@@ -989,8 +989,9 @@ imported IDD and has no local `idd-template/` directory, where editing
 is correct.
 
 When this repository **is** the source of a reusable IDD distribution (it
-ships its own `idd-template/` copy for adopters to import), `sync-manifest.json`
-reverses the direction for every pair whose `source` sits under
+ships its own `idd-template/` copy for adopters to import),
+`audit/sync-manifest.json` reverses the direction for every pair whose
+`source` sits under
 `idd-template/`: `idd-template/` holds the canonical text, and the
 corresponding `docs/`/`.github/instructions/` file is the generated
 target — matching the `idd-generated-from` banner already present on

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -999,7 +999,7 @@ target — matching the `idd-generated-from` banner already present on
 
 1. Edit the `idd-template/` copy, not the `docs/`/`.github/instructions/`
    target.
-2. For `exact`/`concreted` `sync-manifest.json` pairs, run `node
+2. For `exact`/`concreted` `audit/sync-manifest.json` pairs, run `node
    scripts/sync-docs.mjs --apply` to regenerate the target from the
    edited source. For `structure`/`contains` pairs, `sync-docs.mjs`
    only checks headings or text presence and does not auto-generate

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -999,8 +999,12 @@ target — matching the `idd-generated-from` banner already present on
 
 1. Edit the `idd-template/` copy, not the `docs/`/`.github/instructions/`
    target.
-2. Run `node scripts/sync-docs.mjs --apply` to regenerate the target from
-   the edited source.
+2. For `exact`/`concreted` `sync-manifest.json` pairs, run `node
+   scripts/sync-docs.mjs --apply` to regenerate the target from the
+   edited source. For `structure`/`contains` pairs, `sync-docs.mjs`
+   only checks headings or text presence and does not auto-generate
+   target content, so also apply the equivalent content change to the
+   target file by hand.
 3. Run `node scripts/audit-docs.mjs --check` to confirm the pair is back
    in sync.
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -952,29 +952,25 @@ copies.
 - Contributor tooling should guide edits toward canonical sources instead of
   editing mirrors first.
 
+The canonical/generated roles above are described from an **adopter's**
+perspective (IDD imported, no local `idd-template/`). When this repository
+is instead the source of a reusable IDD distribution, those roles reverse
+for the `idd-template/`-sourced pairs — see the exception at the end of
+[Where to Edit](#where-to-edit) below.
+
 ## Where to Edit
 
 **Always edit canonical sources** in `docs/` and `.github/instructions/`, not the
-template copies.
+template copies. This section assumes an **adopter repository**; see the
+[exception](#exception-this-repository-is-the-source-of-a-reusable-idd-distribution)
+at the end of this section when this repository is itself the source of a
+reusable IDD distribution.
 
-**When editing canonical sources**:
+**When editing canonical sources**, update the file in its canonical
+location:
 
-1. Update the file in its canonical location:
-   - Policy guidance → `docs/customization.md`, `docs/policy-constants.md`, etc.
-   - Instruction files → `.github/instructions/idd-*.md`
-
-2. If the repository distributes IDD as a template (source of a reusable IDD
-   distribution), run the documentation audit check:
-
-   ```sh
-   node scripts/audit-docs.mjs --check
-   ```
-
-   This verifies canonical/template pairs and placeholder substitutions stay
-   consistent.
-
-3. Do **not** edit files in `idd-template/` first. Update canonical sources
-   before mirroring equivalent template changes in the same commit.
+- Policy guidance → `docs/customization.md`, `docs/policy-constants.md`, etc.
+- Instruction files → `.github/instructions/idd-*.md`
 
 **When working with template imports** (external repositories importing IDD):
 
@@ -984,6 +980,28 @@ template copies.
     canonical sources only
   - Never manually edit idd-template/ files — they represent the source
     template and may be re-imported
+
+### Exception: this repository is the source of a reusable IDD distribution
+
+The guidance above assumes an **adopter repository** — one that has
+imported IDD and has no local `idd-template/` directory, where editing
+`docs/` and `.github/instructions/` directly, as this section instructs,
+is correct.
+
+When this repository **is** the source of a reusable IDD distribution (it
+ships its own `idd-template/` copy for adopters to import), `sync-manifest.json`
+reverses the direction for every pair whose `source` sits under
+`idd-template/`: `idd-template/` holds the canonical text, and the
+corresponding `docs/`/`.github/instructions/` file is the generated
+target — matching the `idd-generated-from` banner already present on
+`.github/instructions/idd-*.instructions.md` targets. In that scenario:
+
+1. Edit the `idd-template/` copy, not the `docs/`/`.github/instructions/`
+   target.
+2. Run `node scripts/sync-docs.mjs --apply` to regenerate the target from
+   the edited source.
+3. Run `node scripts/audit-docs.mjs --check` to confirm the pair is back
+   in sync.
 
 ## Repository-local IDD policy
 


### PR DESCRIPTION
# Summary

`docs/customization.md`'s "Canonical Asset Map" and "Where to Edit"
sections claimed `docs/` and `.github/instructions/` are always canonical
and `idd-template/` only holds generated copies. `audit/sync-manifest.json`
actually reverses that direction for pairs whose `source` is under
`idd-template/` (including `customization.md`'s own sync pair), matching
the `idd-generated-from` banner already present on
`.github/instructions/idd-*.instructions.md` targets. Following the old
guidance in this source repository edits a generated target that the next
`sync-docs.mjs --apply` silently overwrites.

Edits `idd-template/docs/customization.md` (the true canonical source per
its own `sync-manifest.json` pair) to add an explicit adopter-vs-source-repo
distinction, moves the source-repo-specific edit steps into a new
"Exception" subsection so the adopter-facing numbered list no longer states
anything false for a source repo, and regenerates `docs/customization.md`
via `sync-docs.mjs --apply` to keep both copies byte-identical.

## Linked issue

Closes #1670

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`sync-manifest.json`'s sync direction and the existing `idd-generated-from`
banner mechanism are unchanged by this PR — only the prose in
`customization.md` is corrected to match them. `docs/*.md` sync targets
carry no inline generation-banner warning the way
`.github/instructions/*.instructions.md` targets do, so this doc-only
correction is the safe fix; adding banners to `docs/*.md` targets would be
a separate, larger change and is explicitly out of scope here.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified canonical and generated asset guidance for adopting repositories.
  * Simplified instructions for where to make documentation and policy updates.
  * Added guidance for repositories that serve as reusable distribution sources.
  * Documented commands to synchronize generated content and verify consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->