### PR TITLE
docs(customization): correct template sync direction in two sections

### DIFF
--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -138,11 +138,15 @@ suppression, schema strictness parity) in
 
 ## Template sync
 
-`idd-template/` is the canonical source of the distributed IDD
-template. When modifying any `idd-*.instructions.md` file,
+When this repository is itself the source of a reusable IDD
+distribution (it ships its own `idd-template/` copy for adopters to
+import), `idd-template/` is the canonical source, not the live copy
+below. When modifying any `idd-*.instructions.md` file,
 `docs/idd-workflow.md`, or `docs/customization.md`, edit the
 corresponding file in `idd-template/` first, then regenerate the live
-target with `node scripts/sync-docs.mjs --apply`. For the live ↔
+target with `node scripts/sync-docs.mjs --apply` (`structure`/
+`contains` pairs such as `docs/idd-workflow.md` need the equivalent
+change applied to the live file by hand instead). For the live ↔
 template placeholder mapping and the full rationale, see
 [`docs/customization.md` → Template sync mapping](../../docs/customization.md#template-sync-mapping).
 

--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -150,6 +150,6 @@ change applied to the live file by hand instead). For the live ↔
 template placeholder mapping and the full rationale, see
 [`docs/customization.md` → Template sync mapping](../../docs/customization.md#template-sync-mapping).
 
-Commits that modify the `idd-template/` source without regenerating the
-live target are incomplete; include both changes in the same atomic
-commit.
+Commits that modify the `idd-template/` source without syncing the
+live target (regenerating or hand-mirroring, per its mode above) are
+incomplete; include both changes in the same atomic commit.

--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -138,12 +138,14 @@ suppression, schema strictness parity) in
 
 ## Template sync
 
-This repository is the canonical source of the IDD template distributed
-via `idd-template/`. When modifying any `idd-*.instructions.md` file,
-`docs/idd-workflow.md`, or `docs/customization.md`, apply the equivalent
-change to the corresponding file in `idd-template/`. For the live ↔
-template placeholder mapping, see
+`idd-template/` is the canonical source of the distributed IDD
+template. When modifying any `idd-*.instructions.md` file,
+`docs/idd-workflow.md`, or `docs/customization.md`, edit the
+corresponding file in `idd-template/` first, then regenerate the live
+target with `node scripts/sync-docs.mjs --apply`. For the live ↔
+template placeholder mapping and the full rationale, see
 [`docs/customization.md` → Template sync mapping](../../docs/customization.md#template-sync-mapping).
 
-Commits that modify live instruction files without updating the template
-are incomplete; include both changes in the same atomic commit.
+Commits that modify the `idd-template/` source without regenerating the
+live target are incomplete; include both changes in the same atomic
+commit.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -555,8 +555,8 @@ command prefix, to avoid confusing commands that share the same
 executable.
 
 Commits that modify the `idd-template/` source without syncing the
-live target (regenerating or hand-mirroring, per its mode above) are
-incomplete; include both changes in the same atomic commit.
+live target (regenerating or hand-mirroring, per the Exception section
+above) are incomplete; include both changes in the same atomic commit.
 
 ## Tooling Boundary
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -529,11 +529,15 @@ and no relevant script exists; else use `true`. For other tools, use
 
 ### Template sync mapping
 
-This repository is the canonical source of the IDD template distributed
-via `idd-template/`. When modifying any `idd-*.instructions.md` file,
-`docs/idd-workflow.md`, or `docs/customization.md`, apply the equivalent
-change to the corresponding file in `idd-template/`, replacing resolved
-project-specific values with their `{{placeholder}}` forms:
+`idd-template/` is the canonical source of the distributed IDD template
+(see [Exception: this repository is the source of a reusable IDD
+distribution](#exception-this-repository-is-the-source-of-a-reusable-idd-distribution)).
+When modifying any `idd-*.instructions.md` file, `docs/idd-workflow.md`,
+or `docs/customization.md`, edit the corresponding file in
+`idd-template/` first, using `{{placeholder}}` forms for
+project-specific values, then regenerate the live target with `node
+scripts/sync-docs.mjs --apply`, which resolves each placeholder to its
+concrete live value:
 
 | Live value (`.github/instructions/`)                                | Template form (`idd-template/`)  |
 | ------------------------------------------------------------------- | -------------------------------- |
@@ -548,8 +552,9 @@ Match by the named command row in the Project commands table, not by
 command prefix, to avoid confusing commands that share the same
 executable.
 
-Commits that modify live instruction files without updating the template
-are incomplete; include both changes in the same atomic commit.
+Commits that modify the `idd-template/` source without regenerating the
+live target are incomplete; include both changes in the same atomic
+commit.
 
 ## Tooling Boundary
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -529,15 +529,21 @@ and no relevant script exists; else use `true`. For other tools, use
 
 ### Template sync mapping
 
-`idd-template/` is the canonical source of the distributed IDD template
-(see [Exception: this repository is the source of a reusable IDD
-distribution](#exception-this-repository-is-the-source-of-a-reusable-idd-distribution)).
-When modifying any `idd-*.instructions.md` file, `docs/idd-workflow.md`,
-or `docs/customization.md`, edit the corresponding file in
-`idd-template/` first, using `{{placeholder}}` forms for
-project-specific values, then regenerate the live target with `node
-scripts/sync-docs.mjs --apply`, which resolves each placeholder to its
-concrete live value:
+`idd-template/` is the canonical source of the distributed IDD
+template. When modifying any `idd-*.instructions.md` file,
+`docs/idd-workflow.md`, or `docs/customization.md`, edit the
+corresponding file in `idd-template/` first, using `{{placeholder}}`
+forms for project-specific values where the target pair is
+`concreted` (see the table below). Then apply the matching
+regeneration step from
+[Exception: this repository is the source of a reusable IDD
+distribution](#exception-this-repository-is-the-source-of-a-reusable-idd-distribution):
+`node scripts/sync-docs.mjs --apply` regenerates `exact`/`concreted`
+pairs (resolving `{{placeholder}}` forms for `concreted` pairs); a
+`structure`/`contains` pair such as `docs/idd-workflow.md` needs the
+equivalent change applied to the live file by hand instead, since
+`sync-docs.mjs` only checks heading/text presence for those and does
+not auto-generate their content:
 
 | Live value (`.github/instructions/`)                                | Template form (`idd-template/`)  |
 | ------------------------------------------------------------------- | -------------------------------- |

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -529,21 +529,17 @@ and no relevant script exists; else use `true`. For other tools, use
 
 ### Template sync mapping
 
-`idd-template/` is the canonical source of the distributed IDD
-template. When modifying any `idd-*.instructions.md` file,
-`docs/idd-workflow.md`, or `docs/customization.md`, edit the
-corresponding file in `idd-template/` first, using `{{placeholder}}`
-forms for project-specific values where the target pair is
-`concreted` (see the table below). Then apply the matching
-regeneration step from
+When this repository is itself the source of a reusable IDD
+distribution (it ships its own `idd-template/` copy for adopters to
+import), `idd-template/` is the canonical source of the distributed
+IDD template. When modifying any `idd-*.instructions.md` file,
+`docs/idd-workflow.md`, or `docs/customization.md` in that scenario,
+edit the corresponding file in `idd-template/` first, then sync the
+live target following
 [Exception: this repository is the source of a reusable IDD
-distribution](#exception-this-repository-is-the-source-of-a-reusable-idd-distribution):
-`node scripts/sync-docs.mjs --apply` regenerates `exact`/`concreted`
-pairs (resolving `{{placeholder}}` forms for `concreted` pairs); a
-`structure`/`contains` pair such as `docs/idd-workflow.md` needs the
-equivalent change applied to the live file by hand instead, since
-`sync-docs.mjs` only checks heading/text presence for those and does
-not auto-generate their content:
+distribution](#exception-this-repository-is-the-source-of-a-reusable-idd-distribution).
+Where an `idd-template/` source expresses a project-specific value as
+a `{{placeholder}}`, this table gives the live ↔ template mapping:
 
 | Live value (`.github/instructions/`)                                | Template form (`idd-template/`)  |
 | ------------------------------------------------------------------- | -------------------------------- |
@@ -558,9 +554,9 @@ Match by the named command row in the Project commands table, not by
 command prefix, to avoid confusing commands that share the same
 executable.
 
-Commits that modify the `idd-template/` source without regenerating the
-live target are incomplete; include both changes in the same atomic
-commit.
+Commits that modify the `idd-template/` source without syncing the
+live target (regenerating or hand-mirroring, per its mode above) are
+incomplete; include both changes in the same atomic commit.
 
 ## Tooling Boundary
 

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -145,6 +145,6 @@ change applied to the live file by hand instead). For the live ↔
 template placeholder mapping and the full rationale, see
 [`docs/customization.md` → Template sync mapping](../../docs/customization.md#template-sync-mapping).
 
-Commits that modify the `idd-template/` source without regenerating the
-live target are incomplete; include both changes in the same atomic
-commit.
+Commits that modify the `idd-template/` source without syncing the
+live target (regenerating or hand-mirroring, per its mode above) are
+incomplete; include both changes in the same atomic commit.

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -133,12 +133,14 @@ suppression, schema strictness parity) in
 
 ## Template sync
 
-This repository is the canonical source of the IDD template distributed
-via `idd-template/`. When modifying any `idd-*.instructions.md` file,
-`docs/idd-workflow.md`, or `docs/customization.md`, apply the equivalent
-change to the corresponding file in `idd-template/`. For the live ↔
-template placeholder mapping, see
+`idd-template/` is the canonical source of the distributed IDD
+template. When modifying any `idd-*.instructions.md` file,
+`docs/idd-workflow.md`, or `docs/customization.md`, edit the
+corresponding file in `idd-template/` first, then regenerate the live
+target with `node scripts/sync-docs.mjs --apply`. For the live ↔
+template placeholder mapping and the full rationale, see
 [`docs/customization.md` → Template sync mapping](../../docs/customization.md#template-sync-mapping).
 
-Commits that modify live instruction files without updating the template
-are incomplete; include both changes in the same atomic commit.
+Commits that modify the `idd-template/` source without regenerating the
+live target are incomplete; include both changes in the same atomic
+commit.

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -133,11 +133,15 @@ suppression, schema strictness parity) in
 
 ## Template sync
 
-`idd-template/` is the canonical source of the distributed IDD
-template. When modifying any `idd-*.instructions.md` file,
+When this repository is itself the source of a reusable IDD
+distribution (it ships its own `idd-template/` copy for adopters to
+import), `idd-template/` is the canonical source, not the live copy
+below. When modifying any `idd-*.instructions.md` file,
 `docs/idd-workflow.md`, or `docs/customization.md`, edit the
 corresponding file in `idd-template/` first, then regenerate the live
-target with `node scripts/sync-docs.mjs --apply`. For the live ↔
+target with `node scripts/sync-docs.mjs --apply` (`structure`/
+`contains` pairs such as `docs/idd-workflow.md` need the equivalent
+change applied to the live file by hand instead). For the live ↔
 template placeholder mapping and the full rationale, see
 [`docs/customization.md` → Template sync mapping](../../docs/customization.md#template-sync-mapping).
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -555,8 +555,8 @@ command prefix, to avoid confusing commands that share the same
 executable.
 
 Commits that modify the `idd-template/` source without syncing the
-live target (regenerating or hand-mirroring, per its mode above) are
-incomplete; include both changes in the same atomic commit.
+live target (regenerating or hand-mirroring, per the Exception section
+above) are incomplete; include both changes in the same atomic commit.
 
 ## Tooling Boundary
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -529,11 +529,15 @@ and no relevant script exists; else use `true`. For other tools, use
 
 ### Template sync mapping
 
-This repository is the canonical source of the IDD template distributed
-via `idd-template/`. When modifying any `idd-*.instructions.md` file,
-`docs/idd-workflow.md`, or `docs/customization.md`, apply the equivalent
-change to the corresponding file in `idd-template/`, replacing resolved
-project-specific values with their `{{placeholder}}` forms:
+`idd-template/` is the canonical source of the distributed IDD template
+(see [Exception: this repository is the source of a reusable IDD
+distribution](#exception-this-repository-is-the-source-of-a-reusable-idd-distribution)).
+When modifying any `idd-*.instructions.md` file, `docs/idd-workflow.md`,
+or `docs/customization.md`, edit the corresponding file in
+`idd-template/` first, using `{{placeholder}}` forms for
+project-specific values, then regenerate the live target with `node
+scripts/sync-docs.mjs --apply`, which resolves each placeholder to its
+concrete live value:
 
 | Live value (`.github/instructions/`)                                | Template form (`idd-template/`)  |
 | ------------------------------------------------------------------- | -------------------------------- |
@@ -548,8 +552,9 @@ Match by the named command row in the Project commands table, not by
 command prefix, to avoid confusing commands that share the same
 executable.
 
-Commits that modify live instruction files without updating the template
-are incomplete; include both changes in the same atomic commit.
+Commits that modify the `idd-template/` source without regenerating the
+live target are incomplete; include both changes in the same atomic
+commit.
 
 ## Tooling Boundary
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -529,15 +529,21 @@ and no relevant script exists; else use `true`. For other tools, use
 
 ### Template sync mapping
 
-`idd-template/` is the canonical source of the distributed IDD template
-(see [Exception: this repository is the source of a reusable IDD
-distribution](#exception-this-repository-is-the-source-of-a-reusable-idd-distribution)).
-When modifying any `idd-*.instructions.md` file, `docs/idd-workflow.md`,
-or `docs/customization.md`, edit the corresponding file in
-`idd-template/` first, using `{{placeholder}}` forms for
-project-specific values, then regenerate the live target with `node
-scripts/sync-docs.mjs --apply`, which resolves each placeholder to its
-concrete live value:
+`idd-template/` is the canonical source of the distributed IDD
+template. When modifying any `idd-*.instructions.md` file,
+`docs/idd-workflow.md`, or `docs/customization.md`, edit the
+corresponding file in `idd-template/` first, using `{{placeholder}}`
+forms for project-specific values where the target pair is
+`concreted` (see the table below). Then apply the matching
+regeneration step from
+[Exception: this repository is the source of a reusable IDD
+distribution](#exception-this-repository-is-the-source-of-a-reusable-idd-distribution):
+`node scripts/sync-docs.mjs --apply` regenerates `exact`/`concreted`
+pairs (resolving `{{placeholder}}` forms for `concreted` pairs); a
+`structure`/`contains` pair such as `docs/idd-workflow.md` needs the
+equivalent change applied to the live file by hand instead, since
+`sync-docs.mjs` only checks heading/text presence for those and does
+not auto-generate their content:
 
 | Live value (`.github/instructions/`)                                | Template form (`idd-template/`)  |
 | ------------------------------------------------------------------- | -------------------------------- |

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -529,21 +529,17 @@ and no relevant script exists; else use `true`. For other tools, use
 
 ### Template sync mapping
 
-`idd-template/` is the canonical source of the distributed IDD
-template. When modifying any `idd-*.instructions.md` file,
-`docs/idd-workflow.md`, or `docs/customization.md`, edit the
-corresponding file in `idd-template/` first, using `{{placeholder}}`
-forms for project-specific values where the target pair is
-`concreted` (see the table below). Then apply the matching
-regeneration step from
+When this repository is itself the source of a reusable IDD
+distribution (it ships its own `idd-template/` copy for adopters to
+import), `idd-template/` is the canonical source of the distributed
+IDD template. When modifying any `idd-*.instructions.md` file,
+`docs/idd-workflow.md`, or `docs/customization.md` in that scenario,
+edit the corresponding file in `idd-template/` first, then sync the
+live target following
 [Exception: this repository is the source of a reusable IDD
-distribution](#exception-this-repository-is-the-source-of-a-reusable-idd-distribution):
-`node scripts/sync-docs.mjs --apply` regenerates `exact`/`concreted`
-pairs (resolving `{{placeholder}}` forms for `concreted` pairs); a
-`structure`/`contains` pair such as `docs/idd-workflow.md` needs the
-equivalent change applied to the live file by hand instead, since
-`sync-docs.mjs` only checks heading/text presence for those and does
-not auto-generate their content:
+distribution](#exception-this-repository-is-the-source-of-a-reusable-idd-distribution).
+Where an `idd-template/` source expresses a project-specific value as
+a `{{placeholder}}`, this table gives the live ↔ template mapping:
 
 | Live value (`.github/instructions/`)                                | Template form (`idd-template/`)  |
 | ------------------------------------------------------------------- | -------------------------------- |
@@ -558,9 +554,9 @@ Match by the named command row in the Project commands table, not by
 command prefix, to avoid confusing commands that share the same
 executable.
 
-Commits that modify the `idd-template/` source without regenerating the
-live target are incomplete; include both changes in the same atomic
-commit.
+Commits that modify the `idd-template/` source without syncing the
+live target (regenerating or hand-mirroring, per its mode above) are
+incomplete; include both changes in the same atomic commit.
 
 ## Tooling Boundary
 


### PR DESCRIPTION
## Summary

`idd-template/docs/customization.md`'s "Template sync mapping" section
and `idd-template/.github/instructions/idd-overview-appendix.instructions.md`'s
"Template sync" section both stated that the live `docs/`/
`.github/instructions/` file is canonical and should be edited first,
then mirrored into `idd-template/` — the opposite of
`audit/sync-manifest.json`'s actual sync direction for these two
`exact`-mode pairs (`idd-template/` as `source`). This is the same
class of bug #1670 fixed for "Canonical Asset Map", surfaced by PR
#1671's Codex review.

## Changes

- Reworded both sections so `idd-template/` is named as the edit
  surface and the live target is regenerated via
  `node scripts/sync-docs.mjs --apply`, matching the existing
  "Exception: this repository is the source of a reusable IDD
  distribution" pattern in `docs/customization.md`.
- Kept the live-value ↔ template-form mapping table unchanged (it's a
  value-substitution reference, not directional prose).
- De-duplicated the appendix section's near-identical prose against
  the fuller `customization.md` explanation, while keeping the
  corrected direction stated independently in both sections (per the
  issue's acceptance criteria).
- Regenerated `docs/customization.md` and
  `.github/instructions/idd-overview-appendix.instructions.md` via
  `sync-docs.mjs --apply`.

Closes #1672

## Test plan

- [x] `node scripts/audit-docs.mjs --check` passes
- [x] `pre-push-validate` (biome, dprint, markdownlint, cspell, idd-doctor) passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `idd-template/` is the canonical source for distributed IDD documentation.
  * Added guidance for editing templates with placeholders and regenerating live documentation.
  * Clarified that template changes and regenerated targets must be included together in the same commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->