### PR TITLE
test(disposition): extract and test the apply write loop

### DIFF
--- a/scripts/disposition-non-review-notices.mjs
+++ b/scripts/disposition-non-review-notices.mjs
@@ -572,7 +572,12 @@ export function applyDispositionPlan(plan, deps) {
       try {
         posted = deps.postDisposition(item.body);
       } catch (error) {
-        lastError = error;
+        // A non-Error throw (a plain string/object, e.g. from a mocked or
+        // non-standard failure) must not collapse the diagnostic down to a
+        // generic 'unknown error' -- coerce it the same way the rest of this
+        // repo does (see idd-onboard.mts, discover-shared-file-overlap.mts,
+        // rerun-advisory-convergence.mts).
+        lastError = error instanceof Error ? error.message : String(error);
         // The create may have landed server-side despite the nonzero exit;
         // re-read (by NEW comment id) before any retry so we never
         // double-post.
@@ -588,7 +593,7 @@ export function applyDispositionPlan(plan, deps) {
     } else {
       failed.push({
         noticeId: item.noticeId,
-        error: lastError?.message ?? 'unknown error',
+        error: lastError ?? 'unknown error',
       });
     }
   }

--- a/scripts/disposition-non-review-notices.mjs
+++ b/scripts/disposition-non-review-notices.mjs
@@ -528,6 +528,72 @@ function recoverPostedDisposition(
   }
   return null;
 }
+/**
+ * Orchestrate the `--apply` write loop with injected side effects, so the
+ * per-post claim revalidation, 2-attempt retry, and post-failure recovery
+ * are testable without the network -- mirrors `applyResolveReviewThread`'s
+ * (`resolve-review-thread.mts`) injectable-deps extraction pattern for this
+ * file's sibling write loop.
+ *
+ * Re-validates the active claim before EACH post: a claim lost mid-loop
+ * stops writing immediately and fail-marks the current item plus every
+ * remaining planned item, rather than posting under a claim no longer held.
+ * A create that throws is retried once via `recoverPostedDisposition`
+ * (never a blind second POST) before falling through to a second raw
+ * attempt, so a create that actually landed server-side despite a nonzero
+ * exit is never double-posted; a recovered id is folded into the running
+ * `knownViewerCommentIds` set immediately, so a later item in the same loop
+ * can never re-attribute it.
+ */
+export function applyDispositionPlan(plan, deps) {
+  const knownViewerCommentIds = new Set(deps.knownViewerCommentIds);
+  const applied = [];
+  const failed = [];
+  let claimLost = false;
+  for (let index = 0; index < plan.planned.length; index += 1) {
+    const item = plan.planned[index];
+    if (!deps.revalidateClaim()) {
+      // Claim lost mid-loop: stop writing and surface the current AND all
+      // remaining notices as failed rather than posting them under a claim we
+      // no longer hold, so the apply report names every notice left
+      // un-dispositioned.
+      claimLost = true;
+      for (const remaining of plan.planned.slice(index)) {
+        failed.push({
+          noticeId: remaining.noticeId,
+          error: 'claim revalidation failed before post',
+        });
+      }
+      break;
+    }
+    let posted = null;
+    let lastError = null;
+    for (let attempt = 0; attempt < 2 && !posted; attempt += 1) {
+      try {
+        posted = deps.postDisposition(item.body);
+      } catch (error) {
+        lastError = error;
+        // The create may have landed server-side despite the nonzero exit;
+        // re-read (by NEW comment id) before any retry so we never
+        // double-post.
+        posted = deps.recoverPostedDisposition(
+          item.body,
+          knownViewerCommentIds,
+        );
+      }
+    }
+    if (posted) {
+      knownViewerCommentIds.add(posted.id);
+      applied.push({ noticeId: item.noticeId, commentId: posted.id });
+    } else {
+      failed.push({
+        noticeId: item.noticeId,
+        error: lastError?.message ?? 'unknown error',
+      });
+    }
+  }
+  return { applied, failed, claimLost, knownViewerCommentIds };
+}
 if (import.meta.main) {
   const args = parseArgs(process.argv.slice(2));
   if (args.help || !Number.isInteger(args.pr) || (args.pr ?? 0) <= 0) {
@@ -662,58 +728,19 @@ if (import.meta.main) {
   // Re-plan from a fresh read AFTER claim revalidation, so the post loop never
   // re-posts a disposition that raced in since the dry-run.
   const plan = planNow();
-  const applied = [];
-  const failed = [];
-  // Track every viewer-authored comment id we know about (pre-existing plus the
-  // ones we post), so a post-failure recovery attributes a NEW comment to the
-  // current notice's own post instead of some other pre-existing comment that
-  // happens to carry the identical (now per-notice-unique, #1482) body text.
+  // Seed the viewer-authored comment ids known before this run (pre-existing
+  // plus, once applyDispositionPlan runs, the ones it posts), so a
+  // post-failure recovery attributes a NEW comment to the current notice's
+  // own post instead of some other pre-existing comment that happens to
+  // carry the identical (now per-notice-unique, #1482) body text.
   const knownViewerCommentIds = viewerCommentIds(owner, repo, pr, viewerLogin);
-  let claimLost = false;
-  for (let index = 0; index < plan.planned.length; index += 1) {
-    const item = plan.planned[index];
-    if (!revalidateClaim()) {
-      // Claim lost mid-loop: stop writing and surface the current AND all
-      // remaining notices as failed rather than posting them under a claim we no
-      // longer hold, so the apply report names every notice left un-dispositioned.
-      claimLost = true;
-      for (const remaining of plan.planned.slice(index)) {
-        failed.push({
-          noticeId: remaining.noticeId,
-          error: 'claim revalidation failed before post',
-        });
-      }
-      break;
-    }
-    let posted = null;
-    let lastError = null;
-    for (let attempt = 0; attempt < 2 && !posted; attempt += 1) {
-      try {
-        posted = postDisposition(owner, repo, pr, item.body);
-      } catch (error) {
-        lastError = error;
-        // The create may have landed server-side despite the nonzero exit;
-        // re-read (by NEW comment id) before any retry so we never double-post.
-        posted = recoverPostedDisposition(
-          owner,
-          repo,
-          pr,
-          item.body,
-          viewerLogin,
-          knownViewerCommentIds,
-        );
-      }
-    }
-    if (posted) {
-      knownViewerCommentIds.add(posted.id);
-      applied.push({ noticeId: item.noticeId, commentId: posted.id });
-    } else {
-      failed.push({
-        noticeId: item.noticeId,
-        error: lastError?.message ?? 'unknown error',
-      });
-    }
-  }
+  const { applied, failed, claimLost } = applyDispositionPlan(plan, {
+    revalidateClaim,
+    postDisposition: (body) => postDisposition(owner, repo, pr, body),
+    recoverPostedDisposition: (body, knownIds) =>
+      recoverPostedDisposition(owner, repo, pr, body, viewerLogin, knownIds),
+    knownViewerCommentIds,
+  });
   const status = failed.length > 0 ? 'failed' : 'applied';
   process.stdout.write(
     `${JSON.stringify({ mode: 'apply', prNumber: pr, headSha: plan.headSha, status, applied, failed, skipped: plan.skipped }, null, 2)}\n`,

--- a/src/scripts/disposition-non-review-notices.mts
+++ b/src/scripts/disposition-non-review-notices.mts
@@ -633,7 +633,7 @@ function recoverPostedDisposition(
   pr: number,
   body: string,
   viewerLogin: string,
-  knownIds: Set<number>,
+  knownIds: ReadonlySet<number>,
 ): { id: number } | null {
   const comments = ghJsonPaginated([
     'api',
@@ -650,6 +650,114 @@ function recoverPostedDisposition(
     }
   }
   return null;
+}
+
+/** Injected side effects for {@link applyDispositionPlan}, mirroring
+ * `applyResolveReviewThread`'s (`resolve-review-thread.mts`) injectable-deps
+ * shape so this write loop is testable without the network. */
+export interface ApplyDispositionPlanDeps {
+  /** Re-check the active claim; `false` means the claim was lost. */
+  revalidateClaim: () => boolean;
+  /** Post one disposition comment; throws when the create fails. */
+  postDisposition: (body: string) => { id: number };
+  /**
+   * Recover a disposition that may have landed despite a thrown create, by
+   * finding a NEW viewer-authored comment (id not in `knownIds`) with this
+   * exact body. `null` when no such comment is found.
+   */
+  recoverPostedDisposition: (
+    body: string,
+    knownIds: ReadonlySet<number>,
+  ) => { id: number } | null;
+  /**
+   * Ids of comments already known to be authored by the viewer before this
+   * call (the CLI's pre-loop `viewerCommentIds` fetch). Read-only from the
+   * caller's side: `applyDispositionPlan` owns the mutable bookkeeping
+   * internally and returns the final state, so a later item's recovery in
+   * the same loop never re-matches an id this loop already attributed.
+   */
+  knownViewerCommentIds: ReadonlySet<number>;
+}
+
+export interface ApplyDispositionPlanResult {
+  applied: AppliedDisposition[];
+  failed: FailedDisposition[];
+  /** `true` when the claim was lost mid-loop, stopping further posts. */
+  claimLost: boolean;
+  /** Every viewer-authored comment id known by the end of the run: the
+   * `deps.knownViewerCommentIds` seed plus every id posted or recovered
+   * this run. */
+  knownViewerCommentIds: Set<number>;
+}
+
+/**
+ * Orchestrate the `--apply` write loop with injected side effects, so the
+ * per-post claim revalidation, 2-attempt retry, and post-failure recovery
+ * are testable without the network -- mirrors `applyResolveReviewThread`'s
+ * (`resolve-review-thread.mts`) injectable-deps extraction pattern for this
+ * file's sibling write loop.
+ *
+ * Re-validates the active claim before EACH post: a claim lost mid-loop
+ * stops writing immediately and fail-marks the current item plus every
+ * remaining planned item, rather than posting under a claim no longer held.
+ * A create that throws is retried once via `recoverPostedDisposition`
+ * (never a blind second POST) before falling through to a second raw
+ * attempt, so a create that actually landed server-side despite a nonzero
+ * exit is never double-posted; a recovered id is folded into the running
+ * `knownViewerCommentIds` set immediately, so a later item in the same loop
+ * can never re-attribute it.
+ */
+export function applyDispositionPlan(
+  plan: DispositionPlan,
+  deps: ApplyDispositionPlanDeps,
+): ApplyDispositionPlanResult {
+  const knownViewerCommentIds = new Set(deps.knownViewerCommentIds);
+  const applied: AppliedDisposition[] = [];
+  const failed: FailedDisposition[] = [];
+  let claimLost = false;
+  for (let index = 0; index < plan.planned.length; index += 1) {
+    const item = plan.planned[index];
+    if (!deps.revalidateClaim()) {
+      // Claim lost mid-loop: stop writing and surface the current AND all
+      // remaining notices as failed rather than posting them under a claim we
+      // no longer hold, so the apply report names every notice left
+      // un-dispositioned.
+      claimLost = true;
+      for (const remaining of plan.planned.slice(index)) {
+        failed.push({
+          noticeId: remaining.noticeId,
+          error: 'claim revalidation failed before post',
+        });
+      }
+      break;
+    }
+    let posted: { id: number } | null = null;
+    let lastError: Error | null = null;
+    for (let attempt = 0; attempt < 2 && !posted; attempt += 1) {
+      try {
+        posted = deps.postDisposition(item.body);
+      } catch (error) {
+        lastError = error as Error;
+        // The create may have landed server-side despite the nonzero exit;
+        // re-read (by NEW comment id) before any retry so we never
+        // double-post.
+        posted = deps.recoverPostedDisposition(
+          item.body,
+          knownViewerCommentIds,
+        );
+      }
+    }
+    if (posted) {
+      knownViewerCommentIds.add(posted.id);
+      applied.push({ noticeId: item.noticeId, commentId: posted.id });
+    } else {
+      failed.push({
+        noticeId: item.noticeId,
+        error: lastError?.message ?? 'unknown error',
+      });
+    }
+  }
+  return { applied, failed, claimLost, knownViewerCommentIds };
 }
 
 if (import.meta.main) {
@@ -798,58 +906,19 @@ if (import.meta.main) {
   // Re-plan from a fresh read AFTER claim revalidation, so the post loop never
   // re-posts a disposition that raced in since the dry-run.
   const plan = planNow();
-  const applied: AppliedDisposition[] = [];
-  const failed: FailedDisposition[] = [];
-  // Track every viewer-authored comment id we know about (pre-existing plus the
-  // ones we post), so a post-failure recovery attributes a NEW comment to the
-  // current notice's own post instead of some other pre-existing comment that
-  // happens to carry the identical (now per-notice-unique, #1482) body text.
+  // Seed the viewer-authored comment ids known before this run (pre-existing
+  // plus, once applyDispositionPlan runs, the ones it posts), so a
+  // post-failure recovery attributes a NEW comment to the current notice's
+  // own post instead of some other pre-existing comment that happens to
+  // carry the identical (now per-notice-unique, #1482) body text.
   const knownViewerCommentIds = viewerCommentIds(owner, repo, pr, viewerLogin);
-  let claimLost = false;
-  for (let index = 0; index < plan.planned.length; index += 1) {
-    const item = plan.planned[index];
-    if (!revalidateClaim()) {
-      // Claim lost mid-loop: stop writing and surface the current AND all
-      // remaining notices as failed rather than posting them under a claim we no
-      // longer hold, so the apply report names every notice left un-dispositioned.
-      claimLost = true;
-      for (const remaining of plan.planned.slice(index)) {
-        failed.push({
-          noticeId: remaining.noticeId,
-          error: 'claim revalidation failed before post',
-        });
-      }
-      break;
-    }
-    let posted: { id: number } | null = null;
-    let lastError: Error | null = null;
-    for (let attempt = 0; attempt < 2 && !posted; attempt += 1) {
-      try {
-        posted = postDisposition(owner, repo, pr, item.body);
-      } catch (error) {
-        lastError = error as Error;
-        // The create may have landed server-side despite the nonzero exit;
-        // re-read (by NEW comment id) before any retry so we never double-post.
-        posted = recoverPostedDisposition(
-          owner,
-          repo,
-          pr,
-          item.body,
-          viewerLogin,
-          knownViewerCommentIds,
-        );
-      }
-    }
-    if (posted) {
-      knownViewerCommentIds.add(posted.id);
-      applied.push({ noticeId: item.noticeId, commentId: posted.id });
-    } else {
-      failed.push({
-        noticeId: item.noticeId,
-        error: lastError?.message ?? 'unknown error',
-      });
-    }
-  }
+  const { applied, failed, claimLost } = applyDispositionPlan(plan, {
+    revalidateClaim,
+    postDisposition: (body) => postDisposition(owner, repo, pr, body),
+    recoverPostedDisposition: (body, knownIds) =>
+      recoverPostedDisposition(owner, repo, pr, body, viewerLogin, knownIds),
+    knownViewerCommentIds,
+  });
 
   const status = failed.length > 0 ? 'failed' : 'applied';
   process.stdout.write(

--- a/src/scripts/disposition-non-review-notices.mts
+++ b/src/scripts/disposition-non-review-notices.mts
@@ -732,12 +732,17 @@ export function applyDispositionPlan(
       break;
     }
     let posted: { id: number } | null = null;
-    let lastError: Error | null = null;
+    let lastError: string | null = null;
     for (let attempt = 0; attempt < 2 && !posted; attempt += 1) {
       try {
         posted = deps.postDisposition(item.body);
       } catch (error) {
-        lastError = error as Error;
+        // A non-Error throw (a plain string/object, e.g. from a mocked or
+        // non-standard failure) must not collapse the diagnostic down to a
+        // generic 'unknown error' -- coerce it the same way the rest of this
+        // repo does (see idd-onboard.mts, discover-shared-file-overlap.mts,
+        // rerun-advisory-convergence.mts).
+        lastError = error instanceof Error ? error.message : String(error);
         // The create may have landed server-side despite the nonzero exit;
         // re-read (by NEW comment id) before any retry so we never
         // double-post.
@@ -753,7 +758,7 @@ export function applyDispositionPlan(
     } else {
       failed.push({
         noticeId: item.noticeId,
-        error: lastError?.message ?? 'unknown error',
+        error: lastError ?? 'unknown error',
       });
     }
   }

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -2,9 +2,12 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  type ApplyDispositionPlanDeps,
+  applyDispositionPlan,
   buildDispositionBody,
   buildDispositionPlan,
   buildSummaryDispositionBody,
+  type DispositionPlan,
   type NoticeComment,
   noticeReason,
   parseArgs,
@@ -930,4 +933,209 @@ test('the dry-run and apply output envelopes validate against the schema', () =>
     skipped: plan.skipped,
   };
   assert.equal(validate(apply, planSchema).length, 0, 'apply output');
+});
+
+// --- #1709: applyDispositionPlan (extracted --apply write loop) -----------
+// Mirrors resolve-review-thread.test.mts's applyResolveReviewThread suite:
+// fake in-memory deps, no network, exercising the per-post claim
+// revalidation, 2-attempt post/recover retry, and knownViewerCommentIds
+// bookkeeping in isolation.
+
+function fakePlan(plannedIds: number[]): DispositionPlan {
+  return {
+    headSha: 'abc1234',
+    planned: plannedIds.map((noticeId) => ({
+      noticeId,
+      botLogin: CODERABBIT,
+      reason: 'review limit reached / rate limited',
+      body: buildDispositionBody(
+        CODERABBIT,
+        'abc1234',
+        'review limit reached / rate limited',
+        noticeId,
+      ),
+    })),
+    skipped: [],
+  };
+}
+
+test('applyDispositionPlan: happy path posts every item and reports accurate attribution', () => {
+  const calls: string[] = [];
+  const plan = fakePlan([101, 102]);
+  const deps: ApplyDispositionPlanDeps = {
+    revalidateClaim: () => {
+      calls.push('claim');
+      return true;
+    },
+    postDisposition: (body) => {
+      calls.push(`post:${body.includes('101') ? 101 : 102}`);
+      return { id: body.includes('101') ? 9101 : 9102 };
+    },
+    recoverPostedDisposition: () => {
+      calls.push('recover');
+      return null;
+    },
+    knownViewerCommentIds: new Set([1]),
+  };
+  const result = applyDispositionPlan(plan, deps);
+  assert.equal(result.claimLost, false);
+  assert.deepEqual(result.failed, []);
+  assert.deepEqual(result.applied, [
+    { noticeId: 101, commentId: 9101 },
+    { noticeId: 102, commentId: 9102 },
+  ]);
+  // The seed id plus both newly posted ids.
+  assert.deepEqual(
+    [...result.knownViewerCommentIds].sort((a, b) => a - b),
+    [1, 9101, 9102],
+  );
+  // A claim check precedes each post; no recovery needed on the happy path.
+  assert.deepEqual(calls, ['claim', 'post:101', 'claim', 'post:102']);
+});
+
+test('applyDispositionPlan: an empty plan is a no-op that touches no dep', () => {
+  const calls: string[] = [];
+  const plan = fakePlan([]);
+  const deps: ApplyDispositionPlanDeps = {
+    revalidateClaim: () => {
+      calls.push('claim');
+      return true;
+    },
+    postDisposition: () => {
+      calls.push('post');
+      return { id: 1 };
+    },
+    recoverPostedDisposition: () => {
+      calls.push('recover');
+      return null;
+    },
+    knownViewerCommentIds: new Set([7]),
+  };
+  const result = applyDispositionPlan(plan, deps);
+  assert.deepEqual(result, {
+    applied: [],
+    failed: [],
+    claimLost: false,
+    knownViewerCommentIds: new Set([7]),
+  });
+  assert.deepEqual(calls, []);
+});
+
+test('applyDispositionPlan: claim lost mid-loop stops posting and fail-marks every remaining item', () => {
+  const postCalls: number[] = [];
+  const plan = fakePlan([201, 202, 203]);
+  let claimChecks = 0;
+  const deps: ApplyDispositionPlanDeps = {
+    revalidateClaim: () => {
+      claimChecks += 1;
+      // The first item's claim check passes; the second fails (handoff /
+      // release raced in mid-loop).
+      return claimChecks === 1;
+    },
+    postDisposition: (body) => {
+      const noticeId = /issuecomment-(\d+)/.exec(body)?.[1];
+      postCalls.push(Number(noticeId));
+      return { id: 8000 + Number(noticeId) };
+    },
+    recoverPostedDisposition: () => null,
+    knownViewerCommentIds: new Set(),
+  };
+  const result = applyDispositionPlan(plan, deps);
+  assert.equal(result.claimLost, true);
+  // Only the first item (whose claim check passed) ever reaches postDisposition.
+  assert.deepEqual(postCalls, [201]);
+  assert.deepEqual(result.applied, [{ noticeId: 201, commentId: 8201 }]);
+  assert.deepEqual(result.failed, [
+    { noticeId: 202, error: 'claim revalidation failed before post' },
+    { noticeId: 203, error: 'claim revalidation failed before post' },
+  ]);
+});
+
+test('applyDispositionPlan: a post failure recovers via a NEW comment id without a second post (no double-post)', () => {
+  const postCalls: number[] = [];
+  const plan = fakePlan([301]);
+  const deps: ApplyDispositionPlanDeps = {
+    revalidateClaim: () => true,
+    postDisposition: (body) => {
+      const noticeId = Number(/issuecomment-(\d+)/.exec(body)?.[1]);
+      postCalls.push(noticeId);
+      throw new Error(`create failed for ${noticeId}`);
+    },
+    recoverPostedDisposition: (_body, knownIds) => {
+      // Simulates finding the comment the failed create actually posted.
+      return knownIds.has(7301) ? null : { id: 7301 };
+    },
+    knownViewerCommentIds: new Set(),
+  };
+  const result = applyDispositionPlan(plan, deps);
+  assert.deepEqual(result.applied, [{ noticeId: 301, commentId: 7301 }]);
+  assert.deepEqual(result.failed, []);
+  // Recovery succeeded on the first attempt, so postDisposition is called
+  // exactly once for this item -- the second raw attempt never runs.
+  assert.deepEqual(postCalls, [301]);
+  // The recovered id lands in the returned knownViewerCommentIds.
+  assert.ok(result.knownViewerCommentIds.has(7301));
+});
+
+test('applyDispositionPlan: a recovered id cannot be double-attributed across items', () => {
+  // Two items whose creates both fail; the fake recovery would find the SAME
+  // candidate id for both, but only the first item may claim it (the id
+  // becomes "known" once attributed) -- proving no double-attribution.
+  const plan = fakePlan([401, 402]);
+  const deps: ApplyDispositionPlanDeps = {
+    revalidateClaim: () => true,
+    postDisposition: () => {
+      throw new Error('create failed');
+    },
+    recoverPostedDisposition: (_body, knownIds) =>
+      knownIds.has(9999) ? null : { id: 9999 },
+    knownViewerCommentIds: new Set(),
+  };
+  const result = applyDispositionPlan(plan, deps);
+  assert.deepEqual(result.applied, [{ noticeId: 401, commentId: 9999 }]);
+  assert.deepEqual(result.failed, [{ noticeId: 402, error: 'create failed' }]);
+  assert.ok(result.knownViewerCommentIds.has(9999));
+});
+
+test('applyDispositionPlan: retries the raw post once when recovery finds nothing, then succeeds', () => {
+  const plan = fakePlan([501]);
+  let postAttempts = 0;
+  const deps: ApplyDispositionPlanDeps = {
+    revalidateClaim: () => true,
+    postDisposition: () => {
+      postAttempts += 1;
+      if (postAttempts === 1) {
+        throw new Error('transient failure');
+      }
+      return { id: 6501 };
+    },
+    recoverPostedDisposition: () => null,
+    knownViewerCommentIds: new Set(),
+  };
+  const result = applyDispositionPlan(plan, deps);
+  assert.equal(postAttempts, 2);
+  assert.deepEqual(result.applied, [{ noticeId: 501, commentId: 6501 }]);
+  assert.deepEqual(result.failed, []);
+});
+
+test('applyDispositionPlan: reports the LAST attempt error when both attempts and recovery are exhausted', () => {
+  const plan = fakePlan([601]);
+  let postAttempts = 0;
+  const deps: ApplyDispositionPlanDeps = {
+    revalidateClaim: () => true,
+    postDisposition: () => {
+      postAttempts += 1;
+      throw new Error(`attempt ${postAttempts} failed`);
+    },
+    recoverPostedDisposition: () => null,
+    knownViewerCommentIds: new Set(),
+  };
+  const result = applyDispositionPlan(plan, deps);
+  assert.equal(postAttempts, 2);
+  assert.deepEqual(result.applied, []);
+  // lastError is reassigned on each attempt, so only attempt 2's message
+  // survives into the failure report.
+  assert.deepEqual(result.failed, [
+    { noticeId: 601, error: 'attempt 2 failed' },
+  ]);
 });

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -1139,3 +1139,25 @@ test('applyDispositionPlan: reports the LAST attempt error when both attempts an
     { noticeId: 601, error: 'attempt 2 failed' },
   ]);
 });
+
+test('applyDispositionPlan: preserves a non-Error thrown value instead of collapsing to "unknown error"', () => {
+  // A thrown string/object (not an Error instance) must still surface its
+  // own diagnostic via String() coercion, matching this repo's
+  // `error instanceof Error ? error.message : String(error)` convention
+  // elsewhere (idd-onboard.mts, discover-shared-file-overlap.mts,
+  // rerun-advisory-convergence.mts) -- not report a generic 'unknown error'.
+  const plan = fakePlan([701]);
+  const deps: ApplyDispositionPlanDeps = {
+    revalidateClaim: () => true,
+    postDisposition: () => {
+      throw 'rate limited: retry after 30s';
+    },
+    recoverPostedDisposition: () => null,
+    knownViewerCommentIds: new Set(),
+  };
+  const result = applyDispositionPlan(plan, deps);
+  assert.deepEqual(result.applied, []);
+  assert.deepEqual(result.failed, [
+    { noticeId: 701, error: 'rate limited: retry after 30s' },
+  ]);
+});

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -968,8 +968,13 @@ test('applyDispositionPlan: happy path posts every item and reports accurate att
       return true;
     },
     postDisposition: (body) => {
-      calls.push(`post:${body.includes('101') ? 101 : 102}`);
-      return { id: body.includes('101') ? 9101 : 9102 };
+      // Identify the item by its notice-id token (same pattern the other
+      // tests in this file use), not a bare substring match, which could
+      // otherwise misfire against another field (e.g. the head SHA) that
+      // happens to contain the same digits.
+      const noticeId = Number(/issuecomment-(\d+)/.exec(body)?.[1]);
+      calls.push(`post:${noticeId}`);
+      return { id: 9000 + noticeId };
     },
     recoverPostedDisposition: () => {
       calls.push('recover');


### PR DESCRIPTION
# Summary

`disposition-non-review-notices --apply`'s write loop lived inline in
`import.meta.main` with no dependency-injection seam, leaving per-post
claim revalidation, the 2-attempt post/recover retry, and
`knownViewerCommentIds` attribution entirely untested. This extracts
the loop into an exported `applyDispositionPlan(plan, deps)`,
mirroring `resolve-review-thread.mts`'s `applyResolveReviewThread`
injectable-deps pattern, and delegates the CLI apply path to it
unchanged (same flags, same output envelope).

## Linked issue

Closes #1709

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`applyDispositionPlan` owns the `knownViewerCommentIds` bookkeeping
internally (seeded from a `ReadonlySet<number>` in `deps`, returned as
part of the result), rather than requiring the caller to pre-mutate a
shared `Set` and thread it separately into
`recoverPostedDisposition` — refined this way after an independent
critique pass on the B2 plan flagged the caller-mutated-Set design as
avoidable indirection.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when applying disposition plans.
  * Rechecks authorization before each post and safely stops remaining actions if access is lost.
  * Added recovery and retry handling for failed posts, helping prevent duplicate comments.
  * Improved reporting of successfully applied and failed items, including final claim status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->