### PR TITLE
fix(marker-helpers): make byStart case-consistent with pattern

### DIFF
--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -22,11 +22,12 @@
 // single-marker parse/render primitives move in this wave.
 const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
 const OPTIONAL_IDD_VISIBLE_NOTE_PATTERN = String.raw`(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)`;
-const OPERATIONAL_MARKERS = [
+export const OPERATIONAL_MARKERS = [
   {
     label: '<!-- claimed-by:',
     pattern:
       /^<!--\s*claimed-by:\s+\S+\s+\S+\s+supersedes:\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s+branch:\s+[^\s>]+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    startPattern: /^<!--\s*claimed-by:/i,
     malformedPrefixPattern:
       /^<!--\s*claimed-by:\s+\S+\s+\S+\s+supersedes:\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s+branch:\s+[^\s>]+\s*-->/i,
   },
@@ -34,6 +35,7 @@ const OPERATIONAL_MARKERS = [
     label: '<!-- unclaimed-by:',
     pattern:
       /^<!--\s*unclaimed-by:\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    startPattern: /^<!--\s*unclaimed-by:/i,
     malformedPrefixPattern:
       /^<!--\s*unclaimed-by:\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->/i,
   },
@@ -41,6 +43,7 @@ const OPERATIONAL_MARKERS = [
     label: '<!-- activation-nonce:',
     pattern:
       /^<!--\s*activation-nonce:\s+\S+\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    startPattern: /^<!--\s*activation-nonce:/i,
     malformedPrefixPattern:
       /^<!--\s*activation-nonce:\s+\S+\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->/i,
   },
@@ -48,6 +51,7 @@ const OPERATIONAL_MARKERS = [
     label: '<!-- review-watermark:',
     pattern:
       /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    startPattern: /^<!--\s*review-watermark:/i,
     malformedPrefixPattern:
       /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->/i,
   },
@@ -55,12 +59,18 @@ const OPERATIONAL_MARKERS = [
     label: '<!-- review-baseline:',
     pattern:
       /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    startPattern: /^<!--\s*review-baseline:/i,
     malformedPrefixPattern: /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->/i,
   },
   {
     label: 'advisory-wait:',
     pattern:
       /^advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
+    // Case-sensitive on purpose (#1720): `pattern` above has no `/i`, so
+    // `startPattern` must not gain one either -- widening this one would
+    // loosen a marker family the issue explicitly requires to stay
+    // case-sensitive on both paths.
+    startPattern: /^advisory-wait:/,
   },
   {
     // #1572: the trailing ` claim:{claimId} attempt:{n}` suffix is OPTIONAL
@@ -79,10 +89,19 @@ const OPERATIONAL_MARKERS = [
     label: 'advisory-wait-recovery:',
     pattern:
       /^advisory-wait-recovery:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z(?:\s+claim:\S+\s+attempt:[1-9]\d*)?\s*$/,
+    // Case-sensitive on purpose (#1720), same reasoning as advisory-wait:
+    // above; also structurally distinct from it (the literal `:` sits right
+    // after `-recovery`, so this never matches an `advisory-wait:` body).
+    startPattern: /^advisory-wait-recovery:/,
   },
   {
     label: '<!-- advisory-wait:',
     pattern: /^<!--\s*advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\S+\s*-->\s*$/,
+    // Case-sensitive on purpose (#1720): not one of the issue's four named
+    // plain-text markers, but `pattern` above has no `/i` either, so this
+    // must not gain case-insensitivity -- only the same internal-whitespace
+    // tolerance after `<!--` that `pattern` already allows.
+    startPattern: /^<!--\s*advisory-wait:/,
   },
   {
     // #1511: bounded same-HEAD advisory reroll request marker. PLAIN-TEXT,
@@ -97,6 +116,8 @@ const OPERATIONAL_MARKERS = [
     label: 'advisory-reroll:',
     pattern:
       /^advisory-reroll:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
+    // Case-sensitive on purpose (#1720), same reasoning as advisory-wait:.
+    startPattern: /^advisory-reroll:/,
   },
   {
     // #1572: brand-new terminal marker type, no legacy form to preserve, so
@@ -109,6 +130,8 @@ const OPERATIONAL_MARKERS = [
     label: 'copilot-unavailable:',
     pattern:
       /^copilot-unavailable:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s+claim:\S+\s+attempt:[1-9]\d*\s*$/,
+    // Case-sensitive on purpose (#1720), same reasoning as advisory-wait:.
+    startPattern: /^copilot-unavailable:/,
   },
   {
     label: '<!-- forced-handoff:',
@@ -830,10 +853,8 @@ export function operationalMarkerPrefix(body) {
 }
 export function operationalMarkerPrefixByStart(body) {
   const normalized = body.trimStart();
-  const marker = OPERATIONAL_MARKERS.find(
-    (candidate) =>
-      candidate.startPattern?.test(normalized) ??
-      normalized.startsWith(candidate.label),
+  const marker = OPERATIONAL_MARKERS.find((candidate) =>
+    candidate.startPattern.test(normalized),
   );
   if (!marker) {
     return null;

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -116,7 +116,8 @@ const OPERATIONAL_MARKER_ENTRIES = [
     label: 'advisory-reroll:',
     pattern:
       /^advisory-reroll:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
-    // Case-sensitive on purpose (#1720), same reasoning as advisory-wait:.
+    // Case-sensitive on purpose (#1720), same reasoning as the
+    // advisory-wait: entry above.
     startPattern: /^advisory-reroll:/,
   },
   {
@@ -130,7 +131,8 @@ const OPERATIONAL_MARKER_ENTRIES = [
     label: 'copilot-unavailable:',
     pattern:
       /^copilot-unavailable:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s+claim:\S+\s+attempt:[1-9]\d*\s*$/,
-    // Case-sensitive on purpose (#1720), same reasoning as advisory-wait:.
+    // Case-sensitive on purpose (#1720), same reasoning as the
+    // advisory-wait: entry above.
     startPattern: /^copilot-unavailable:/,
   },
   {

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -22,7 +22,7 @@
 // single-marker parse/render primitives move in this wave.
 const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
 const OPTIONAL_IDD_VISIBLE_NOTE_PATTERN = String.raw`(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)`;
-export const OPERATIONAL_MARKERS = [
+const OPERATIONAL_MARKER_ENTRIES = [
   {
     label: '<!-- claimed-by:',
     pattern:
@@ -145,6 +145,22 @@ export const OPERATIONAL_MARKERS = [
     startPattern: /^<!--\s*idd-external-check-waiver:/i,
   },
 ];
+/**
+ * Frozen, exported view of {@link OPERATIONAL_MARKER_ENTRIES}. This array is
+ * exported (and re-exported transitively via `protocol-helpers.mts`'s
+ * `export * from './marker-helpers.mts'`) so tests can iterate every entry
+ * for the case-flag-parity / label-correspondence invariants (#1720). The
+ * `readonly OperationalMarker[]` type is compile-time only and does not
+ * stop a JS consumer -- or a TS call site that casts around the type --
+ * from mutating the array or an entry at runtime, which would silently
+ * change marker recognition for every `operationalMarkerPrefix*` call
+ * process-wide (this module's own three call sites included). `Object.freeze`
+ * on both the array and each entry makes that mutation a no-op (throwing in
+ * strict mode) instead of a silent, shared-state corruption.
+ */
+export const OPERATIONAL_MARKERS = Object.freeze(
+  OPERATIONAL_MARKER_ENTRIES.map((marker) => Object.freeze(marker)),
+);
 export const IDD_AGENT_DERIVED_MARKERS = new Set([
   '<!-- claimed-by:',
   '<!-- unclaimed-by:',

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -22,10 +22,25 @@
 // single-marker parse/render primitives move in this wave.
 
 /** Operational marker matcher entry. */
-interface OperationalMarker {
+export interface OperationalMarker {
   label: string;
   pattern: RegExp;
-  startPattern?: RegExp;
+  /**
+   * Anchored `^` at the same position as `pattern`'s token, but token-only
+   * (no field validation, no trailing anchor): matches whenever the body's
+   * first bytes (after `operationalMarkerPrefixByStart`'s `trimStart()`)
+   * are this marker's literal label, regardless of what -- if anything --
+   * follows it or how its fields are shaped. Required on every entry (#1720)
+   * so `operationalMarkerPrefixByStart()` never needs a lower-fidelity
+   * case-sensitive `label.startsWith` fallback; must carry the exact same
+   * `i` flag as `pattern` -- a dedicated test asserts that parity for every
+   * `OPERATIONAL_MARKERS` entry. Deliberately **not** the same regex as
+   * `malformedPrefixPattern` below: that field validates the full field
+   * grammar, which is stricter than the token-only match this field
+   * replaces, and reusing it here would newly un-filter field-broken
+   * bodies (e.g. `<!-- claimed-by: -->`) that are filtered today.
+   */
+  startPattern: RegExp;
   /**
    * Anchored at the same `^` position as `pattern`, with the same field
    * validation, but without the trailing `OPTIONAL_IDD_VISIBLE_NOTE_PATTERN`
@@ -50,9 +65,9 @@ interface OperationalMarker {
    *     require the token to be the literal first bytes of the body, so a
    *     preamble before it defeats both).
    * Only defined for the note-bearing markers (`claimed-by`, `unclaimed-by`,
-   * `review-watermark`, `review-baseline`); `advisory-wait`,
-   * `forced-handoff`, and `idd-external-check-waiver` do not use the shared
-   * note-optional grammar this field targets.
+   * `activation-nonce`, `review-watermark`, `review-baseline`);
+   * `advisory-wait`, `forced-handoff`, and `idd-external-check-waiver` do
+   * not use the shared note-optional grammar this field targets.
    */
   malformedPrefixPattern?: RegExp;
 }
@@ -165,11 +180,12 @@ export interface ParsedCopilotUnavailableMarker {
 const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
 const OPTIONAL_IDD_VISIBLE_NOTE_PATTERN = String.raw`(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)`;
 
-const OPERATIONAL_MARKERS: OperationalMarker[] = [
+export const OPERATIONAL_MARKERS: readonly OperationalMarker[] = [
   {
     label: '<!-- claimed-by:',
     pattern:
       /^<!--\s*claimed-by:\s+\S+\s+\S+\s+supersedes:\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s+branch:\s+[^\s>]+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    startPattern: /^<!--\s*claimed-by:/i,
     malformedPrefixPattern:
       /^<!--\s*claimed-by:\s+\S+\s+\S+\s+supersedes:\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s+branch:\s+[^\s>]+\s*-->/i,
   },
@@ -177,6 +193,7 @@ const OPERATIONAL_MARKERS: OperationalMarker[] = [
     label: '<!-- unclaimed-by:',
     pattern:
       /^<!--\s*unclaimed-by:\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    startPattern: /^<!--\s*unclaimed-by:/i,
     malformedPrefixPattern:
       /^<!--\s*unclaimed-by:\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->/i,
   },
@@ -184,6 +201,7 @@ const OPERATIONAL_MARKERS: OperationalMarker[] = [
     label: '<!-- activation-nonce:',
     pattern:
       /^<!--\s*activation-nonce:\s+\S+\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    startPattern: /^<!--\s*activation-nonce:/i,
     malformedPrefixPattern:
       /^<!--\s*activation-nonce:\s+\S+\s+\S+\s+\S+\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*-->/i,
   },
@@ -191,6 +209,7 @@ const OPERATIONAL_MARKERS: OperationalMarker[] = [
     label: '<!-- review-watermark:',
     pattern:
       /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    startPattern: /^<!--\s*review-watermark:/i,
     malformedPrefixPattern:
       /^<!--\s*review-watermark:\s+\S+\s+\S+\s+\S+\s+\S+\s+\d+\s+\S+\s*-->/i,
   },
@@ -198,12 +217,18 @@ const OPERATIONAL_MARKERS: OperationalMarker[] = [
     label: '<!-- review-baseline:',
     pattern:
       /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)$/i,
+    startPattern: /^<!--\s*review-baseline:/i,
     malformedPrefixPattern: /^<!--\s*review-baseline:\s+\S+\s+\S+\s+\S+\s*-->/i,
   },
   {
     label: 'advisory-wait:',
     pattern:
       /^advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
+    // Case-sensitive on purpose (#1720): `pattern` above has no `/i`, so
+    // `startPattern` must not gain one either -- widening this one would
+    // loosen a marker family the issue explicitly requires to stay
+    // case-sensitive on both paths.
+    startPattern: /^advisory-wait:/,
   },
   {
     // #1572: the trailing ` claim:{claimId} attempt:{n}` suffix is OPTIONAL
@@ -222,10 +247,19 @@ const OPERATIONAL_MARKERS: OperationalMarker[] = [
     label: 'advisory-wait-recovery:',
     pattern:
       /^advisory-wait-recovery:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z(?:\s+claim:\S+\s+attempt:[1-9]\d*)?\s*$/,
+    // Case-sensitive on purpose (#1720), same reasoning as advisory-wait:
+    // above; also structurally distinct from it (the literal `:` sits right
+    // after `-recovery`, so this never matches an `advisory-wait:` body).
+    startPattern: /^advisory-wait-recovery:/,
   },
   {
     label: '<!-- advisory-wait:',
     pattern: /^<!--\s*advisory-wait:\s+\S+\s+[0-9a-f]{40}\s+\S+\s*-->\s*$/,
+    // Case-sensitive on purpose (#1720): not one of the issue's four named
+    // plain-text markers, but `pattern` above has no `/i` either, so this
+    // must not gain case-insensitivity -- only the same internal-whitespace
+    // tolerance after `<!--` that `pattern` already allows.
+    startPattern: /^<!--\s*advisory-wait:/,
   },
   {
     // #1511: bounded same-HEAD advisory reroll request marker. PLAIN-TEXT,
@@ -240,6 +274,8 @@ const OPERATIONAL_MARKERS: OperationalMarker[] = [
     label: 'advisory-reroll:',
     pattern:
       /^advisory-reroll:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
+    // Case-sensitive on purpose (#1720), same reasoning as advisory-wait:.
+    startPattern: /^advisory-reroll:/,
   },
   {
     // #1572: brand-new terminal marker type, no legacy form to preserve, so
@@ -252,6 +288,8 @@ const OPERATIONAL_MARKERS: OperationalMarker[] = [
     label: 'copilot-unavailable:',
     pattern:
       /^copilot-unavailable:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s+claim:\S+\s+attempt:[1-9]\d*\s*$/,
+    // Case-sensitive on purpose (#1720), same reasoning as advisory-wait:.
+    startPattern: /^copilot-unavailable:/,
   },
   {
     label: '<!-- forced-handoff:',
@@ -1143,10 +1181,8 @@ export function operationalMarkerPrefix(body: string): string | null {
 
 export function operationalMarkerPrefixByStart(body: string): string | null {
   const normalized = body.trimStart();
-  const marker = OPERATIONAL_MARKERS.find(
-    (candidate) =>
-      candidate.startPattern?.test(normalized) ??
-      normalized.startsWith(candidate.label),
+  const marker = OPERATIONAL_MARKERS.find((candidate) =>
+    candidate.startPattern.test(normalized),
   );
   if (!marker) {
     return null;

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -32,13 +32,14 @@ export interface OperationalMarker {
    * are this marker's literal label, regardless of what -- if anything --
    * follows it or how its fields are shaped. Required on every entry (#1720)
    * so `operationalMarkerPrefixByStart()` never needs a lower-fidelity
-   * case-sensitive `label.startsWith` fallback; must carry the exact same
-   * `i` flag as `pattern` -- a dedicated test asserts that parity for every
-   * `OPERATIONAL_MARKERS` entry. Deliberately **not** the same regex as
-   * `malformedPrefixPattern` below: that field validates the full field
-   * grammar, which is stricter than the token-only match this field
-   * replaces, and reusing it here would newly un-filter field-broken
-   * bodies (e.g. `<!-- claimed-by: -->`) that are filtered today.
+   * case-sensitive `normalized.startsWith(candidate.label)` fallback; must
+   * carry the exact same `i` flag as `pattern` -- a dedicated test asserts
+   * that parity for every `OPERATIONAL_MARKERS` entry. Deliberately **not**
+   * the same regex as `malformedPrefixPattern` below: that field validates
+   * the full field grammar, which is stricter than the token-only match
+   * this field replaces, and reusing it here would newly un-filter
+   * field-broken bodies (e.g. `<!-- claimed-by: -->`) that are filtered
+   * today.
    */
   startPattern: RegExp;
   /**
@@ -274,7 +275,8 @@ const OPERATIONAL_MARKER_ENTRIES: OperationalMarker[] = [
     label: 'advisory-reroll:',
     pattern:
       /^advisory-reroll:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
-    // Case-sensitive on purpose (#1720), same reasoning as advisory-wait:.
+    // Case-sensitive on purpose (#1720), same reasoning as the
+    // advisory-wait: entry above.
     startPattern: /^advisory-reroll:/,
   },
   {
@@ -288,7 +290,8 @@ const OPERATIONAL_MARKER_ENTRIES: OperationalMarker[] = [
     label: 'copilot-unavailable:',
     pattern:
       /^copilot-unavailable:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s+claim:\S+\s+attempt:[1-9]\d*\s*$/,
-    // Case-sensitive on purpose (#1720), same reasoning as advisory-wait:.
+    // Case-sensitive on purpose (#1720), same reasoning as the
+    // advisory-wait: entry above.
     startPattern: /^copilot-unavailable:/,
   },
   {

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -180,7 +180,7 @@ export interface ParsedCopilotUnavailableMarker {
 const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
 const OPTIONAL_IDD_VISIBLE_NOTE_PATTERN = String.raw`(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)`;
 
-export const OPERATIONAL_MARKERS: readonly OperationalMarker[] = [
+const OPERATIONAL_MARKER_ENTRIES: OperationalMarker[] = [
   {
     label: '<!-- claimed-by:',
     pattern:
@@ -303,6 +303,23 @@ export const OPERATIONAL_MARKERS: readonly OperationalMarker[] = [
     startPattern: /^<!--\s*idd-external-check-waiver:/i,
   },
 ];
+
+/**
+ * Frozen, exported view of {@link OPERATIONAL_MARKER_ENTRIES}. This array is
+ * exported (and re-exported transitively via `protocol-helpers.mts`'s
+ * `export * from './marker-helpers.mts'`) so tests can iterate every entry
+ * for the case-flag-parity / label-correspondence invariants (#1720). The
+ * `readonly OperationalMarker[]` type is compile-time only and does not
+ * stop a JS consumer -- or a TS call site that casts around the type --
+ * from mutating the array or an entry at runtime, which would silently
+ * change marker recognition for every `operationalMarkerPrefix*` call
+ * process-wide (this module's own three call sites included). `Object.freeze`
+ * on both the array and each entry makes that mutation a no-op (throwing in
+ * strict mode) instead of a silent, shared-state corruption.
+ */
+export const OPERATIONAL_MARKERS: readonly OperationalMarker[] = Object.freeze(
+  OPERATIONAL_MARKER_ENTRIES.map((marker) => Object.freeze(marker)),
+);
 
 export const IDD_AGENT_DERIVED_MARKERS: ReadonlySet<string> = new Set([
   '<!-- claimed-by:',

--- a/tests/claim-parser.test.mts
+++ b/tests/claim-parser.test.mts
@@ -8,10 +8,20 @@ import {
   isStaleAt,
   isStaleByAge,
   operationalMarkerPrefix,
+  operationalMarkerPrefixByStart,
   parseActivationNonceComment,
   parseClaimComment,
   parseReleaseComment,
   parseReviewWatermarkComment,
+  renderActivationNonceMarker,
+  renderAdvisoryRerollMarker,
+  renderAdvisoryWaitMarker,
+  renderAdvisoryWaitRecoveryMarker,
+  renderClaimedByMarker,
+  renderCopilotUnavailableMarker,
+  renderReviewBaselineMarker,
+  renderReviewWatermarkMarker,
+  renderUnclaimedByMarker,
 } from '../src/scripts/protocol-helpers.mts';
 import { readText } from './test-utils.mts';
 
@@ -345,6 +355,10 @@ test('a marker quoted mid-prose is neither a live marker nor flagged malformed (
     '_copilot: issue claim — IDD automation marker. Do not edit._';
   assert.equal(parseClaimComment(body, '2026-05-23T10:00:00Z'), null);
   assert.equal(detectMalformedOperationalMarker(body), null);
+  // #1720 AC5: the token is not the literal first bytes for either prefix
+  // function -- both must keep failing closed, not just the parser above.
+  assert.equal(operationalMarkerPrefix(body), null);
+  assert.equal(operationalMarkerPrefixByStart(body), null);
 });
 
 test('a code-fenced marker is neither a live marker nor flagged malformed (anti-spoofing)', () => {
@@ -352,4 +366,135 @@ test('a code-fenced marker is neither a live marker nor flagged malformed (anti-
     '```\n<!-- claimed-by: copilot claim-A supersedes: none 2026-05-23T10:00:00Z branch: issue/100-task -->\n```';
   assert.equal(parseClaimComment(body, '2026-05-23T10:00:00Z'), null);
   assert.equal(detectMalformedOperationalMarker(body), null);
+  // #1720 AC5: same anti-spoofing floor as above, for the fenced-block case.
+  assert.equal(operationalMarkerPrefix(body), null);
+  assert.equal(operationalMarkerPrefixByStart(body), null);
+});
+
+// #1720: operationalMarkerPrefix() matches each entry's `pattern` (case-
+// insensitive for the five note-bearing markers below), while
+// operationalMarkerPrefixByStart() used to fall back to a case-SENSITIVE
+// `startsWith` check when an entry had no `startPattern` -- so a
+// correctly-shaped marker written with different casing resolved to a
+// label under one function but `null` under the other. Every entry now
+// defines a `startPattern` carrying the same case flag as `pattern`, so
+// both functions must agree. Each case below uppercases ONLY the marker
+// token (not the hex SHA / ISO timestamp fields, which stay
+// case-sensitive by their own `[0-9a-f]{40}` / literal-digit grammar) in a
+// body built from the real renderer, so the fixture is a realistic,
+// well-formed marker rather than a hand-typed approximation.
+test('a case-variant CLAIMED-BY marker resolves to the same label on both prefix functions', () => {
+  const body = renderClaimedByMarker({
+    agentId: 'copilot',
+    claimId: 'claim-A',
+    supersedes: 'none',
+    timestamp: '2026-05-23T10:00:00Z',
+    branch: 'issue/100-task',
+  }).replace('claimed-by:', 'CLAIMED-BY:');
+  assert.equal(operationalMarkerPrefix(body), '<!-- claimed-by:');
+  assert.equal(operationalMarkerPrefixByStart(body), '<!-- claimed-by:');
+});
+
+test('a case-variant UNCLAIMED-BY marker resolves to the same label on both prefix functions', () => {
+  const body = renderUnclaimedByMarker({
+    agentId: 'copilot',
+    claimId: 'claim-A',
+    timestamp: '2026-05-23T10:00:00Z',
+  }).replace('unclaimed-by:', 'UNCLAIMED-BY:');
+  assert.equal(operationalMarkerPrefix(body), '<!-- unclaimed-by:');
+  assert.equal(operationalMarkerPrefixByStart(body), '<!-- unclaimed-by:');
+});
+
+test('a case-variant ACTIVATION-NONCE marker resolves to the same label on both prefix functions', () => {
+  const body = renderActivationNonceMarker({
+    agentId: 'copilot',
+    claimId: 'claim-A',
+    nonce: 'nonce-1',
+    timestamp: '2026-05-23T10:00:00Z',
+  }).replace('activation-nonce:', 'ACTIVATION-NONCE:');
+  assert.equal(operationalMarkerPrefix(body), '<!-- activation-nonce:');
+  assert.equal(operationalMarkerPrefixByStart(body), '<!-- activation-nonce:');
+});
+
+test('a case-variant REVIEW-WATERMARK marker resolves to the same label on both prefix functions', () => {
+  const sha = 'a'.repeat(40);
+  const body = renderReviewWatermarkMarker({
+    agentId: 'copilot',
+    claimId: 'claim-A',
+    headSha: sha,
+    maxActivityAt: 'none',
+    totalItemCount: 0,
+    ciCompletedAt: 'none',
+  }).replace('review-watermark:', 'REVIEW-WATERMARK:');
+  assert.equal(operationalMarkerPrefix(body), '<!-- review-watermark:');
+  assert.equal(operationalMarkerPrefixByStart(body), '<!-- review-watermark:');
+});
+
+test('a case-variant REVIEW-BASELINE marker resolves to the same label on both prefix functions', () => {
+  const sha = 'b'.repeat(40);
+  const body = renderReviewBaselineMarker({
+    agentId: 'copilot',
+    claimId: 'claim-A',
+    sha,
+  }).replace('review-baseline:', 'REVIEW-BASELINE:');
+  assert.equal(operationalMarkerPrefix(body), '<!-- review-baseline:');
+  assert.equal(operationalMarkerPrefixByStart(body), '<!-- review-baseline:');
+});
+
+// #1720 AC: the four plain-text marker families (plus the fifth,
+// HTML-wrapped `<!-- advisory-wait:` entry, not literally named in the
+// issue body but sharing the same case-sensitive `pattern`) must NOT gain
+// case-insensitivity from this fix -- both prefix functions must keep
+// returning `null` for an uppercased token.
+test('a case-variant ADVISORY-WAIT marker is rejected by both prefix functions', () => {
+  const sha = 'c'.repeat(40);
+  const body = renderAdvisoryWaitMarker({
+    agentId: 'copilot',
+    headSha: sha,
+    timestamp: '2026-05-23T10:00:00Z',
+  }).replace('advisory-wait:', 'ADVISORY-WAIT:');
+  assert.equal(operationalMarkerPrefix(body), null);
+  assert.equal(operationalMarkerPrefixByStart(body), null);
+});
+
+test('a case-variant ADVISORY-WAIT-RECOVERY marker is rejected by both prefix functions', () => {
+  const sha = 'd'.repeat(40);
+  const body = renderAdvisoryWaitRecoveryMarker({
+    agentId: 'copilot',
+    headSha: sha,
+    timestamp: '2026-05-23T10:00:00Z',
+  }).replace('advisory-wait-recovery:', 'ADVISORY-WAIT-RECOVERY:');
+  assert.equal(operationalMarkerPrefix(body), null);
+  assert.equal(operationalMarkerPrefixByStart(body), null);
+});
+
+test('a case-variant HTML-wrapped <!-- ADVISORY-WAIT: marker is rejected by both prefix functions', () => {
+  const sha = 'e'.repeat(40);
+  const body = `<!-- ADVISORY-WAIT: copilot ${sha} 2026-05-23T10:00:00Z -->`;
+  assert.equal(operationalMarkerPrefix(body), null);
+  assert.equal(operationalMarkerPrefixByStart(body), null);
+});
+
+test('a case-variant ADVISORY-REROLL marker is rejected by both prefix functions', () => {
+  const sha = 'f'.repeat(40);
+  const body = renderAdvisoryRerollMarker({
+    agentId: 'copilot',
+    headSha: sha,
+    timestamp: '2026-05-23T10:00:00Z',
+  }).replace('advisory-reroll:', 'ADVISORY-REROLL:');
+  assert.equal(operationalMarkerPrefix(body), null);
+  assert.equal(operationalMarkerPrefixByStart(body), null);
+});
+
+test('a case-variant COPILOT-UNAVAILABLE marker is rejected by both prefix functions', () => {
+  const sha = '1234567890abcdef1234567890abcdef12345678';
+  const body = renderCopilotUnavailableMarker({
+    agentId: 'copilot',
+    claimId: 'claim-A',
+    headSha: sha,
+    attempt: 1,
+    timestamp: '2026-05-23T10:00:00Z',
+  }).replace('copilot-unavailable:', 'COPILOT-UNAVAILABLE:');
+  assert.equal(operationalMarkerPrefix(body), null);
+  assert.equal(operationalMarkerPrefixByStart(body), null);
 });

--- a/tests/marker-helpers-facade.test.mts
+++ b/tests/marker-helpers-facade.test.mts
@@ -38,6 +38,7 @@ const SAMPLE_NAMES = [
   'detectMalformedOperationalMarker',
   'IDD_AGENT_DERIVED_MARKERS',
   'isValidIsoTimestamp',
+  'OPERATIONAL_MARKERS',
 ] as const;
 
 test('protocol-helpers re-exports every sampled marker-helpers name by identity', () => {

--- a/tests/operational-marker-start-pattern.test.mts
+++ b/tests/operational-marker-start-pattern.test.mts
@@ -21,20 +21,28 @@ test('every OPERATIONAL_MARKERS entry carries the same /i flag on pattern and st
   }
 });
 
-test('every OPERATIONAL_MARKERS entry startPattern is ^-anchored and not global', () => {
+test('every OPERATIONAL_MARKERS entry startPattern is ^-anchored and not global or sticky', () => {
   for (const marker of OPERATIONAL_MARKERS) {
     assert.ok(
       marker.startPattern.source.startsWith('^'),
       `${marker.label}: startPattern "${marker.startPattern.source}" must anchor at ^`,
     );
-    // A `g`-flagged RegExp is `lastIndex`-stateful across repeated `.test()`
-    // calls in `OPERATIONAL_MARKERS.find(...)` -- a shared instance reused
-    // across many `operationalMarkerPrefixByStart()` calls would then give
-    // inconsistent results depending on call history.
+    // A `g`- or `y`-flagged RegExp is `lastIndex`-stateful across repeated
+    // `.test()` calls in `OPERATIONAL_MARKERS.find(...)` -- a shared
+    // instance reused across many `operationalMarkerPrefixByStart()` calls
+    // would then give inconsistent results depending on call history.
+    // Sticky (`/y`) is the same hazard as global (`/g`) here: both advance
+    // `lastIndex` on a match, they just differ in where the match is
+    // required to start.
     assert.equal(
       marker.startPattern.global,
       false,
       `${marker.label}: startPattern must not carry the /g flag`,
+    );
+    assert.equal(
+      marker.startPattern.sticky,
+      false,
+      `${marker.label}: startPattern must not carry the /y flag`,
     );
   }
 });

--- a/tests/operational-marker-start-pattern.test.mts
+++ b/tests/operational-marker-start-pattern.test.mts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { OPERATIONAL_MARKERS } from '../src/scripts/marker-helpers.mts';
+
+// #1720: `startPattern` is now a required field on every `OPERATIONAL_MARKERS`
+// entry, replacing `operationalMarkerPrefixByStart()`'s old case-sensitive
+// `normalized.startsWith(candidate.label)` fallback. These tests protect the
+// two invariants a future entry (or a hand-edit of an existing one) could
+// silently violate without either failing to compile or failing an existing
+// test: case-flag parity with `pattern`, and correspondence with the
+// entry's own `label` (as opposed to some other entry's).
+
+test('every OPERATIONAL_MARKERS entry carries the same /i flag on pattern and startPattern', () => {
+  for (const marker of OPERATIONAL_MARKERS) {
+    assert.equal(
+      marker.startPattern.flags.includes('i'),
+      marker.pattern.flags.includes('i'),
+      `${marker.label}: pattern flags "${marker.pattern.flags}" vs startPattern flags "${marker.startPattern.flags}"`,
+    );
+  }
+});
+
+test('every OPERATIONAL_MARKERS entry startPattern is ^-anchored and not global', () => {
+  for (const marker of OPERATIONAL_MARKERS) {
+    assert.ok(
+      marker.startPattern.source.startsWith('^'),
+      `${marker.label}: startPattern "${marker.startPattern.source}" must anchor at ^`,
+    );
+    // A `g`-flagged RegExp is `lastIndex`-stateful across repeated `.test()`
+    // calls in `OPERATIONAL_MARKERS.find(...)` -- a shared instance reused
+    // across many `operationalMarkerPrefixByStart()` calls would then give
+    // inconsistent results depending on call history.
+    assert.equal(
+      marker.startPattern.global,
+      false,
+      `${marker.label}: startPattern must not carry the /g flag`,
+    );
+  }
+});
+
+test('every OPERATIONAL_MARKERS entry startPattern matches its own label and no other entry label', () => {
+  for (const marker of OPERATIONAL_MARKERS) {
+    assert.ok(
+      marker.startPattern.test(marker.label),
+      `${marker.label}: startPattern must match its own label`,
+    );
+    for (const other of OPERATIONAL_MARKERS) {
+      if (other === marker) {
+        continue;
+      }
+      assert.equal(
+        marker.startPattern.test(other.label),
+        false,
+        `${marker.label}: startPattern must not match ${other.label}`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
# Summary

`operationalMarkerPrefix()` and `operationalMarkerPrefixByStart()` in
`src/scripts/marker-helpers.mts` disagreed about case for five markers
(`claimed-by`, `unclaimed-by`, `activation-nonce`, `review-watermark`,
`review-baseline`): the former matches each entry's case-insensitive
`pattern`, while the latter fell back to a case-sensitive
`normalized.startsWith(candidate.label)` whenever an entry had no
`startPattern` (only `forced-handoff` and `idd-external-check-waiver`
defined one). A correctly-shaped marker posted with different casing
(e.g. `<!-- CLAIMED-BY: ... -->`) therefore resolved to a marker prefix
under one function but `null` under the other. `protocol-helpers.mts`
uses the `byStart` variant to filter trusted-actor operational comments
out of disposition-window / review-currency computation, so a
case-variant marker survived that filter and was silently counted as an
ordinary comment — the opposite of the carve-out's intent.

This PR makes `startPattern` a **required** field on `OperationalMarker`
and gives every `OPERATIONAL_MARKERS` entry a token-only `startPattern`
carrying the exact same case flag as its `pattern`, then deletes the
`startsWith` fallback from `operationalMarkerPrefixByStart()`.

## Widening, explicitly (per the issue's item 6)

- **What widened**: the five note-bearing markers' `startPattern` is now
  case-insensitive (matching `pattern`'s `/i`) and, because it is anchored
  on `<!--\s*{token}:` rather than a literal `startsWith`, also tolerates
  internal whitespace variants like `<!--   claimed-by:` that the old
  literal `startsWith` rejected — the point, since those bodies already
  match `pattern`, so `byStart` now agrees with it.
- **What did NOT widen**: `startPattern` is **token-only** on every entry,
  not the fuller field-validated `malformedPrefixPattern` shape. Reusing
  `malformedPrefixPattern` would have been *stricter* than the fallback it
  replaces — the old `startsWith` matched any body starting with the
  literal token, including field-broken ones (e.g. `<!-- claimed-by:
  -->`). Swapping in the field-validated version would have flipped those
  currently-filtered malformed bodies into unfiltered ordinary comments —
  the same bug class this issue fixes, in the opposite direction. So
  `byStart`'s field-grammar strictness is unchanged; nothing it previously
  filtered as malformed/broken stops being filtered.
- The four plain-text marker families the issue names (`advisory-wait:`,
  `advisory-wait-recovery:`, `advisory-reroll:`, `copilot-unavailable:`)
  remain case-sensitive on both paths, covered by new tests. A fifth entry
  not literally named in the issue body, the HTML-wrapped `<!--
  advisory-wait:` legacy form (also no `/i` on its `pattern`), got the
  same whitespace-tolerance-only treatment and also stays case-sensitive.

## Other changes

- Drive-by doc fix: `malformedPrefixPattern`'s JSDoc listed the
  note-bearing markers as "`claimed-by`, `unclaimed-by`,
  `review-watermark`, `review-baseline`", omitting `activation-nonce`
  even though that entry already defines `malformedPrefixPattern` today —
  corrected while touching this interface.
- `OPERATIONAL_MARKERS` is now exported (`readonly OperationalMarker[]`)
  so tests can iterate every entry directly for the parity assertions
  below; the `.find()` call sites all stay compatible since `find` exists
  on `ReadonlyArray`.
- `pnpm run build` regenerated `scripts/marker-helpers.mjs` from the
  `.mts` source; both are committed together.

## Tests added

- `tests/operational-marker-start-pattern.test.mts` (new): for every
  `OPERATIONAL_MARKERS` entry, asserts the `/i` flag matches between
  `pattern` and `startPattern`, `startPattern` is `^`-anchored and not
  `/g`-flagged, and `startPattern` matches its own `label` but no other
  entry's `label` (a full correspondence matrix — this is what actually
  protects against a future entry with a wrong or mismatched
  `startPattern`, since flag/anchor checks alone would not catch that).
- `tests/claim-parser.test.mts`: five positive case-variant regression
  tests (one per note-bearing marker, built from the real renderer with
  only the token uppercased — `renderClaimedByMarker`,
  `renderUnclaimedByMarker`, `renderActivationNonceMarker`,
  `renderReviewWatermarkMarker`, `renderReviewBaselineMarker`) asserting
  `operationalMarkerPrefix` and `operationalMarkerPrefixByStart` return
  the same non-null label; five negative case-variant tests confirming
  the case-sensitive markers still return `null` from both; extended the
  existing mid-prose and code-fenced anti-spoofing tests to also assert
  both prefix functions return `null` (previously they only checked
  `parseClaimComment` / `detectMalformedOperationalMarker`).
- `tests/marker-helpers-facade.test.mts`: added `OPERATIONAL_MARKERS` to
  the sampled re-export identity check.

## Linked issue

Closes #1720

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

A critique pass (`Agent(subagent_type="general-purpose")`, per this
repo's B2 convention) reviewed the plan before implementation and caught
that reusing `malformedPrefixPattern` as `startPattern` — the initial
instinct — would have introduced the mirror-image bug (see "What did NOT
widen" above), plus two test-coverage gaps (the AC4 negative case, and
the label-correspondence matrix) that are now covered.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (not applicable — no docs/template files changed)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a public, immutable registry of operational markers.
  - Improved marker-prefix detection with explicit, case-aware matching rules.

- **Bug Fixes**
  - Prevented operational markers embedded in prose or code blocks from being incorrectly recognized.
  - Preserved correct handling of case-sensitive advisory and availability markers.

- **Tests**
  - Expanded coverage for marker matching, anti-spoofing behavior, case sensitivity, and registry consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->