### PR TITLE
fix(idd-doctor): resolve cleanup-backlog remediation via helper profile

### DIFF
--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -438,6 +438,47 @@ const HELPER_COMMANDS = [
       'Evaluate A4.5 suitability checks and map deterministic outcomes.',
   },
 ];
+/**
+ * Resolve the invocation string for one helper command under one
+ * `helperRuntime.profile`, so a helper-emitted remediation hint (for
+ * example idd-doctor's post-merge-cleanup-backlog warning) never
+ * hard-codes a single profile's command form. Mirrors
+ * `buildProfileCatalog`'s per-profile command mapping for a single helper
+ * id instead of building the full multi-helper catalog, so callers that
+ * only need one command avoid the catalog's package-manager
+ * detection / vendored-file filesystem walk.
+ *
+ * Returns `null` for `instructions-only` (no runnable command exists),
+ * an unrecognized helper `id`, or an unrecognized `profile` -- callers
+ * fall back to a documentation pointer alone in all three cases.
+ */
+export function resolveHelperCommandForProfile({
+  helperId,
+  profile,
+  packageSpec = '',
+}) {
+  const command = HELPER_COMMANDS.find((entry) => entry.id === helperId);
+  if (!command) {
+    return null;
+  }
+  switch (profile) {
+    case 'vendored-node':
+      return command.vendoredCommand;
+    case 'package-manager':
+      // The bare bin name -- matches `buildProfileCatalog`'s own
+      // `package-manager` `commands` value, not a `<manager> run
+      // <scriptName>` form: argument forwarding after `run` differs
+      // across managers (npm requires a literal `--` before flags; pnpm
+      // and yarn do not), so a manager-agnostic emitted string would be
+      // wrong for at least one manager, which is worse than the bug this
+      // resolver exists to fix.
+      return command.binName;
+    case 'ephemeral-npx':
+      return `npx --yes --package ${normalizePackageSpec(packageSpec)} ${command.binName}`;
+    default:
+      return null;
+  }
+}
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `profile:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
 // .mjs source text for quoted flag literals such as the --profile spec key

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -779,15 +779,28 @@ const LIVE_CONFIG_ERRORS_SHOWN = 10;
  * Resolve the repository's configured `helperRuntime.profile` for building
  * profile-aware remediation text (see `formatCleanupBacklogRemediation`
  * below), trying the same live-config candidates as
- * `checkHelperRuntimeConfig` in declaration order and returning the first
- * one that declares a valid profile.
+ * `checkHelperRuntimeConfig` in declaration order.
+ *
+ * The **first present candidate wins outright** -- whether it declares a
+ * valid profile, leaves `helperRuntime` absent, or is malformed -- and the
+ * search never falls through to a later (legacy) candidate once a present
+ * file has been evaluated. A present canonical `.github/idd/config.json`
+ * that omits `helperRuntime` is an intentional `instructions-only`
+ * declaration, not an invitation to consult a stale `idd-policy.json` left
+ * over from before a migration to the canonical filename -- silently
+ * picking up the legacy file's profile there would build a remediation
+ * command for a runtime the repository no longer uses (idd-skill#1718
+ * review: both Copilot and the secondary advisory bot flagged this
+ * independently). Only an *absent* (nonexistent) candidate file is
+ * skipped in favor of the next one.
  *
  * Defaults to `'instructions-only'` -- the safe, no-runnable-command
- * fallback -- when no candidate exists, none is valid JSON, or none
- * declares a valid `helperRuntime.profile`; those cases are already
- * surfaced as their own findings by `checkHelperRuntimeConfig` /
- * `checkLiveConfigSchema`; this resolver only needs a fail-closed profile
- * to build remediation text from, not a second diagnostic.
+ * fallback -- when no candidate file exists at all, the first present one
+ * is not valid JSON, or it does not declare a valid
+ * `helperRuntime.profile`; those cases are already surfaced as their own
+ * findings by `checkHelperRuntimeConfig` / `checkLiveConfigSchema`; this
+ * resolver only needs a fail-closed profile to build remediation text
+ * from, not a second diagnostic.
  */
 export function resolveConfiguredHelperRuntimeProfile(root) {
   for (const file of LIVE_CONFIG_CANDIDATE_FILES) {
@@ -799,12 +812,12 @@ export function resolveConfiguredHelperRuntimeProfile(root) {
     try {
       config = JSON.parse(readFileSync(absolutePath, 'utf8'));
     } catch {
-      continue;
+      return 'instructions-only';
     }
     const helperRuntime = inspectHelperRuntimeConfig(config);
-    if (helperRuntime.status === 'ok') {
-      return helperRuntime.profile;
-    }
+    return helperRuntime.status === 'ok'
+      ? helperRuntime.profile
+      : 'instructions-only';
   }
   return 'instructions-only';
 }

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -12,6 +12,7 @@ import {
   parseAutopilotSuitabilityMarker,
 } from './autopilot-suitability.mjs';
 import { parseCliArgs } from './cli-args.mjs';
+import { resolveHelperCommandForProfile } from './helper-runtime-manifest.mjs';
 import {
   inspectHelperRuntimeConfig,
   POLICY_DEFAULTS,
@@ -774,6 +775,39 @@ const LIVE_CONFIG_CANDIDATE_FILES = [
   'idd-policy.json',
 ];
 const LIVE_CONFIG_ERRORS_SHOWN = 10;
+/**
+ * Resolve the repository's configured `helperRuntime.profile` for building
+ * profile-aware remediation text (see `formatCleanupBacklogRemediation`
+ * below), trying the same live-config candidates as
+ * `checkHelperRuntimeConfig` in declaration order and returning the first
+ * one that declares a valid profile.
+ *
+ * Defaults to `'instructions-only'` -- the safe, no-runnable-command
+ * fallback -- when no candidate exists, none is valid JSON, or none
+ * declares a valid `helperRuntime.profile`; those cases are already
+ * surfaced as their own findings by `checkHelperRuntimeConfig` /
+ * `checkLiveConfigSchema`; this resolver only needs a fail-closed profile
+ * to build remediation text from, not a second diagnostic.
+ */
+export function resolveConfiguredHelperRuntimeProfile(root) {
+  for (const file of LIVE_CONFIG_CANDIDATE_FILES) {
+    const absolutePath = join(root, file);
+    if (!exists(absolutePath)) {
+      continue;
+    }
+    let config;
+    try {
+      config = JSON.parse(readFileSync(absolutePath, 'utf8'));
+    } catch {
+      continue;
+    }
+    const helperRuntime = inspectHelperRuntimeConfig(config);
+    if (helperRuntime.status === 'ok') {
+      return helperRuntime.profile;
+    }
+  }
+  return 'instructions-only';
+}
 /**
  * Decide whether a parsed live-config document is a schema finding, given
  * the canonical policy schema and the file it was read from (for the
@@ -1539,6 +1573,36 @@ export function formatCleanupBacklogScanProgress(scanned, total, prNumber) {
 export function emitCleanupBacklogProgress(line, stream = process.stderr) {
   stream.write(`${line}\n`);
 }
+// `helper-runtime-manifest.mts`'s HELPER_COMMANDS id for `audit-pr-cleanup`
+// -- the helper the cleanup-backlog remediation hint below points at.
+const CLEANUP_BACKLOG_HELPER_ID = 'audit-pr-cleanup';
+const CLEANUP_BACKLOG_REMEDIATION_ARGS = '--pr <N> --apply --skip-claim-check';
+const CLEANUP_BACKLOG_DOCS_POINTER = 'docs/idd-comment-minimization.md';
+/**
+ * Build the post-merge-cleanup-backlog warning's remediation clause for one
+ * resolved `helperRuntime.profile`, resolving the `audit-pr-cleanup`
+ * invocation through `resolveHelperCommandForProfile` instead of
+ * hard-coding the `vendored-node` form (idd-skill#1718) -- a
+ * `vendored-node`-only command fails immediately under any other profile
+ * (for example `ephemeral-npx`, which has no `scripts/` directory to
+ * invoke). Pure (no I/O) so it can be unit-tested for every profile
+ * without mocking `gh` or the filesystem.
+ *
+ * The `docs/idd-comment-minimization.md` pointer stays in every profile,
+ * including `instructions-only`, which has no runnable command at all --
+ * the pointer alone is then the whole remediation clause.
+ */
+export function formatCleanupBacklogRemediation(profile) {
+  const docsClause = `see ${CLEANUP_BACKLOG_DOCS_POINTER}`;
+  const command = resolveHelperCommandForProfile({
+    helperId: CLEANUP_BACKLOG_HELPER_ID,
+    profile,
+  });
+  if (!command) {
+    return `Remediation: ${docsClause}.`;
+  }
+  return `Remediation: ${docsClause} or run \`${command} ${CLEANUP_BACKLOG_REMEDIATION_ARGS}\`.`;
+}
 function checkPostMergeCleanupBacklog(root, options, report) {
   const windowDays = options.windowDays;
   const warnThreshold = options.warnThreshold;
@@ -1677,8 +1741,10 @@ function checkPostMergeCleanupBacklog(root, options, report) {
     return;
   }
   const examplesText = verdict.examples.map((n) => `#${n}`).join(', ');
+  const profile = resolveConfiguredHelperRuntimeProfile(root);
+  const remediation = formatCleanupBacklogRemediation(profile);
   report.warnings.push(
-    `post-merge cleanup backlog: ${verdict.count} merged PRs in the last ${windowDays} days lack F4 cleanup evidence (warn threshold: ${warnThreshold}). Examples: ${examplesText}. Remediation: see docs/idd-comment-minimization.md or run \`node scripts/audit-pr-cleanup.mjs --pr <N> --apply --skip-claim-check\`.`,
+    `post-merge cleanup backlog: ${verdict.count} merged PRs in the last ${windowDays} days lack F4 cleanup evidence (warn threshold: ${warnThreshold}). Examples: ${examplesText}. ${remediation}`,
   );
 }
 // Default drift thresholds (idd-skill#1269): warn when the checked-out HEAD

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -511,6 +511,52 @@ const HELPER_COMMANDS: HelperCommand[] = [
   },
 ];
 
+/**
+ * Resolve the invocation string for one helper command under one
+ * `helperRuntime.profile`, so a helper-emitted remediation hint (for
+ * example idd-doctor's post-merge-cleanup-backlog warning) never
+ * hard-codes a single profile's command form. Mirrors
+ * `buildProfileCatalog`'s per-profile command mapping for a single helper
+ * id instead of building the full multi-helper catalog, so callers that
+ * only need one command avoid the catalog's package-manager
+ * detection / vendored-file filesystem walk.
+ *
+ * Returns `null` for `instructions-only` (no runnable command exists),
+ * an unrecognized helper `id`, or an unrecognized `profile` -- callers
+ * fall back to a documentation pointer alone in all three cases.
+ */
+export function resolveHelperCommandForProfile({
+  helperId,
+  profile,
+  packageSpec = '',
+}: {
+  helperId: string;
+  profile: string;
+  packageSpec?: string;
+}): string | null {
+  const command = HELPER_COMMANDS.find((entry) => entry.id === helperId);
+  if (!command) {
+    return null;
+  }
+  switch (profile) {
+    case 'vendored-node':
+      return command.vendoredCommand;
+    case 'package-manager':
+      // The bare bin name -- matches `buildProfileCatalog`'s own
+      // `package-manager` `commands` value, not a `<manager> run
+      // <scriptName>` form: argument forwarding after `run` differs
+      // across managers (npm requires a literal `--` before flags; pnpm
+      // and yarn do not), so a manager-agnostic emitted string would be
+      // wrong for at least one manager, which is worse than the bug this
+      // resolver exists to fix.
+      return command.binName;
+    case 'ephemeral-npx':
+      return `npx --yes --package ${normalizePackageSpec(packageSpec)} ${command.binName}`;
+    default:
+      return null;
+  }
+}
+
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `profile:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
 // .mjs source text for quoted flag literals such as the --profile spec key

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -931,15 +931,28 @@ const LIVE_CONFIG_ERRORS_SHOWN = 10;
  * Resolve the repository's configured `helperRuntime.profile` for building
  * profile-aware remediation text (see `formatCleanupBacklogRemediation`
  * below), trying the same live-config candidates as
- * `checkHelperRuntimeConfig` in declaration order and returning the first
- * one that declares a valid profile.
+ * `checkHelperRuntimeConfig` in declaration order.
+ *
+ * The **first present candidate wins outright** -- whether it declares a
+ * valid profile, leaves `helperRuntime` absent, or is malformed -- and the
+ * search never falls through to a later (legacy) candidate once a present
+ * file has been evaluated. A present canonical `.github/idd/config.json`
+ * that omits `helperRuntime` is an intentional `instructions-only`
+ * declaration, not an invitation to consult a stale `idd-policy.json` left
+ * over from before a migration to the canonical filename -- silently
+ * picking up the legacy file's profile there would build a remediation
+ * command for a runtime the repository no longer uses (idd-skill#1718
+ * review: both Copilot and the secondary advisory bot flagged this
+ * independently). Only an *absent* (nonexistent) candidate file is
+ * skipped in favor of the next one.
  *
  * Defaults to `'instructions-only'` -- the safe, no-runnable-command
- * fallback -- when no candidate exists, none is valid JSON, or none
- * declares a valid `helperRuntime.profile`; those cases are already
- * surfaced as their own findings by `checkHelperRuntimeConfig` /
- * `checkLiveConfigSchema`; this resolver only needs a fail-closed profile
- * to build remediation text from, not a second diagnostic.
+ * fallback -- when no candidate file exists at all, the first present one
+ * is not valid JSON, or it does not declare a valid
+ * `helperRuntime.profile`; those cases are already surfaced as their own
+ * findings by `checkHelperRuntimeConfig` / `checkLiveConfigSchema`; this
+ * resolver only needs a fail-closed profile to build remediation text
+ * from, not a second diagnostic.
  */
 export function resolveConfiguredHelperRuntimeProfile(root: string): string {
   for (const file of LIVE_CONFIG_CANDIDATE_FILES) {
@@ -951,12 +964,12 @@ export function resolveConfiguredHelperRuntimeProfile(root: string): string {
     try {
       config = JSON.parse(readFileSync(absolutePath, 'utf8'));
     } catch {
-      continue;
+      return 'instructions-only';
     }
     const helperRuntime = inspectHelperRuntimeConfig(config);
-    if (helperRuntime.status === 'ok') {
-      return helperRuntime.profile;
-    }
+    return helperRuntime.status === 'ok'
+      ? helperRuntime.profile
+      : 'instructions-only';
   }
   return 'instructions-only';
 }

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -13,6 +13,7 @@ import {
   parseAutopilotSuitabilityMarker,
 } from './autopilot-suitability.mts';
 import { parseCliArgs } from './cli-args.mts';
+import { resolveHelperCommandForProfile } from './helper-runtime-manifest.mts';
 import {
   inspectHelperRuntimeConfig,
   POLICY_DEFAULTS,
@@ -927,6 +928,40 @@ const LIVE_CONFIG_CANDIDATE_FILES = [
 const LIVE_CONFIG_ERRORS_SHOWN = 10;
 
 /**
+ * Resolve the repository's configured `helperRuntime.profile` for building
+ * profile-aware remediation text (see `formatCleanupBacklogRemediation`
+ * below), trying the same live-config candidates as
+ * `checkHelperRuntimeConfig` in declaration order and returning the first
+ * one that declares a valid profile.
+ *
+ * Defaults to `'instructions-only'` -- the safe, no-runnable-command
+ * fallback -- when no candidate exists, none is valid JSON, or none
+ * declares a valid `helperRuntime.profile`; those cases are already
+ * surfaced as their own findings by `checkHelperRuntimeConfig` /
+ * `checkLiveConfigSchema`; this resolver only needs a fail-closed profile
+ * to build remediation text from, not a second diagnostic.
+ */
+export function resolveConfiguredHelperRuntimeProfile(root: string): string {
+  for (const file of LIVE_CONFIG_CANDIDATE_FILES) {
+    const absolutePath = join(root, file);
+    if (!exists(absolutePath)) {
+      continue;
+    }
+    let config: unknown;
+    try {
+      config = JSON.parse(readFileSync(absolutePath, 'utf8'));
+    } catch {
+      continue;
+    }
+    const helperRuntime = inspectHelperRuntimeConfig(config);
+    if (helperRuntime.status === 'ok') {
+      return helperRuntime.profile;
+    }
+  }
+  return 'instructions-only';
+}
+
+/**
  * Decide whether a parsed live-config document is a schema finding, given
  * the canonical policy schema and the file it was read from (for the
  * message). Pure (no I/O) so it can be unit-tested directly. Returns `null`
@@ -1822,6 +1857,38 @@ export function emitCleanupBacklogProgress(
   stream.write(`${line}\n`);
 }
 
+// `helper-runtime-manifest.mts`'s HELPER_COMMANDS id for `audit-pr-cleanup`
+// -- the helper the cleanup-backlog remediation hint below points at.
+const CLEANUP_BACKLOG_HELPER_ID = 'audit-pr-cleanup';
+const CLEANUP_BACKLOG_REMEDIATION_ARGS = '--pr <N> --apply --skip-claim-check';
+const CLEANUP_BACKLOG_DOCS_POINTER = 'docs/idd-comment-minimization.md';
+
+/**
+ * Build the post-merge-cleanup-backlog warning's remediation clause for one
+ * resolved `helperRuntime.profile`, resolving the `audit-pr-cleanup`
+ * invocation through `resolveHelperCommandForProfile` instead of
+ * hard-coding the `vendored-node` form (idd-skill#1718) -- a
+ * `vendored-node`-only command fails immediately under any other profile
+ * (for example `ephemeral-npx`, which has no `scripts/` directory to
+ * invoke). Pure (no I/O) so it can be unit-tested for every profile
+ * without mocking `gh` or the filesystem.
+ *
+ * The `docs/idd-comment-minimization.md` pointer stays in every profile,
+ * including `instructions-only`, which has no runnable command at all --
+ * the pointer alone is then the whole remediation clause.
+ */
+export function formatCleanupBacklogRemediation(profile: string): string {
+  const docsClause = `see ${CLEANUP_BACKLOG_DOCS_POINTER}`;
+  const command = resolveHelperCommandForProfile({
+    helperId: CLEANUP_BACKLOG_HELPER_ID,
+    profile,
+  });
+  if (!command) {
+    return `Remediation: ${docsClause}.`;
+  }
+  return `Remediation: ${docsClause} or run \`${command} ${CLEANUP_BACKLOG_REMEDIATION_ARGS}\`.`;
+}
+
 function checkPostMergeCleanupBacklog(
   root: string,
   options: {
@@ -1981,8 +2048,10 @@ function checkPostMergeCleanupBacklog(
   }
 
   const examplesText = verdict.examples.map((n) => `#${n}`).join(', ');
+  const profile = resolveConfiguredHelperRuntimeProfile(root);
+  const remediation = formatCleanupBacklogRemediation(profile);
   report.warnings.push(
-    `post-merge cleanup backlog: ${verdict.count} merged PRs in the last ${windowDays} days lack F4 cleanup evidence (warn threshold: ${warnThreshold}). Examples: ${examplesText}. Remediation: see docs/idd-comment-minimization.md or run \`node scripts/audit-pr-cleanup.mjs --pr <N> --apply --skip-claim-check\`.`,
+    `post-merge cleanup backlog: ${verdict.count} merged PRs in the last ${windowDays} days lack F4 cleanup evidence (warn threshold: ${warnThreshold}). Examples: ${examplesText}. ${remediation}`,
   );
 }
 

--- a/src/scripts/policy-helpers.mts
+++ b/src/scripts/policy-helpers.mts
@@ -243,7 +243,12 @@ export function parseProjectCommandRows(text: string): Map<string, string> {
   return commands;
 }
 
-export function inspectHelperRuntimeConfig(config: unknown) {
+export function inspectHelperRuntimeConfig(
+  config: unknown,
+):
+  | { status: 'invalid'; reason: string }
+  | { status: 'absent' }
+  | { status: 'ok'; profile: string } {
   if (typeof config !== 'object' || config === null || Array.isArray(config)) {
     return { status: 'invalid', reason: 'config must be a non-null object' };
   }

--- a/tests/helper-runtime-manifest.test.mts
+++ b/tests/helper-runtime-manifest.test.mts
@@ -18,6 +18,7 @@ import {
   collectVendoredFiles,
   detectPackageManager,
   recommendHelperRuntimeProfile,
+  resolveHelperCommandForProfile,
   resolveSourcePackageMetadata,
 } from '../src/scripts/helper-runtime-manifest.mts';
 
@@ -735,4 +736,63 @@ test('the registration guard scopes out instruction-referenced libraries and dev
       `${nonAdopterTool} is not an adopter CLI helper and must not be registered in HELPER_COMMANDS`,
     );
   }
+});
+
+test('resolveHelperCommandForProfile resolves the audit-pr-cleanup invocation for every profile (idd-skill#1718)', () => {
+  assert.equal(
+    resolveHelperCommandForProfile({
+      helperId: 'audit-pr-cleanup',
+      profile: 'vendored-node',
+    }),
+    'node scripts/audit-pr-cleanup.mjs',
+  );
+  assert.equal(
+    resolveHelperCommandForProfile({
+      helperId: 'audit-pr-cleanup',
+      profile: 'package-manager',
+    }),
+    'idd-audit-pr-cleanup',
+  );
+  assert.equal(
+    resolveHelperCommandForProfile({
+      helperId: 'audit-pr-cleanup',
+      profile: 'ephemeral-npx',
+    }),
+    `npx --yes --package ${DEFAULT_PACKAGE_SPEC} idd-audit-pr-cleanup`,
+  );
+  assert.equal(
+    resolveHelperCommandForProfile({
+      helperId: 'audit-pr-cleanup',
+      profile: 'instructions-only',
+    }),
+    null,
+  );
+});
+
+test('resolveHelperCommandForProfile honors an explicit --package-spec pin under ephemeral-npx', () => {
+  assert.equal(
+    resolveHelperCommandForProfile({
+      helperId: 'audit-pr-cleanup',
+      profile: 'ephemeral-npx',
+      packageSpec: 'https://example.com/pinned-idd-skill.tgz',
+    }),
+    'npx --yes --package https://example.com/pinned-idd-skill.tgz idd-audit-pr-cleanup',
+  );
+});
+
+test('resolveHelperCommandForProfile returns null for an unknown helper id or profile', () => {
+  assert.equal(
+    resolveHelperCommandForProfile({
+      helperId: 'not-a-real-helper',
+      profile: 'vendored-node',
+    }),
+    null,
+  );
+  assert.equal(
+    resolveHelperCommandForProfile({
+      helperId: 'audit-pr-cleanup',
+      profile: 'not-a-real-profile',
+    }),
+    null,
+  );
 });

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -30,6 +30,7 @@ import {
   findMissingWorkshopReferences,
   findMissingWorktreeHardening,
   findPlaceholders,
+  formatCleanupBacklogRemediation,
   formatCleanupBacklogScanPreamble,
   formatCleanupBacklogScanProgress,
   hookWiresWorktreeGuard,
@@ -41,6 +42,7 @@ import {
   parseThresholdsProseHours,
   readWorktreeGuardBranchPatterns,
   readWorktreeGuardEnabled,
+  resolveConfiguredHelperRuntimeProfile,
   scanFileForPlaceholders,
   stripMarkdownNonText,
 } from '../src/scripts/idd-doctor.mts';
@@ -994,6 +996,115 @@ test('classifyBacklog coerces non-numeric / NaN / negative thresholds to 0', () 
   assert.equal(classifyBacklog([1], -5).warn, true);
   // Zero count must not warn even with a broken threshold.
   assert.equal(classifyBacklog([], NaN).warn, false);
+});
+
+test('formatCleanupBacklogRemediation resolves the audit-pr-cleanup invocation per profile (idd-skill#1718)', () => {
+  // vendored-node: unchanged from the pre-#1718 hard-coded text.
+  assert.equal(
+    formatCleanupBacklogRemediation('vendored-node'),
+    'Remediation: see docs/idd-comment-minimization.md or run `node scripts/audit-pr-cleanup.mjs --pr <N> --apply --skip-claim-check`.',
+  );
+
+  // package-manager: the bare `idd-audit-pr-cleanup` bin name -- the same
+  // form buildProfileCatalog already emits as this profile's `commands`
+  // value (docs/idd-helper-scripts.md's "profile-selected `idd:<name>`"
+  // convention), deliberately not a `<manager> run <scriptName>` form: arg
+  // forwarding after `run` differs across managers (npm needs a literal
+  // `--` before flags; pnpm/yarn don't), so a manager-agnostic emitted
+  // string would be wrong for at least one manager.
+  assert.equal(
+    formatCleanupBacklogRemediation('package-manager'),
+    'Remediation: see docs/idd-comment-minimization.md or run `idd-audit-pr-cleanup --pr <N> --apply --skip-claim-check`.',
+  );
+
+  // ephemeral-npx: names the idd-* bin via npx, no scripts/ path -- this is
+  // the exact profile the reported adopter repo was on (idd-skill#1718).
+  const ephemeralNpxText = formatCleanupBacklogRemediation('ephemeral-npx');
+  assert.match(
+    ephemeralNpxText,
+    /\bnpx --yes --package \S+ idd-audit-pr-cleanup /,
+  );
+  assert.doesNotMatch(ephemeralNpxText, /scripts\/audit-pr-cleanup\.mjs/);
+
+  // instructions-only: prescribes no command, docs pointer only.
+  assert.equal(
+    formatCleanupBacklogRemediation('instructions-only'),
+    'Remediation: see docs/idd-comment-minimization.md.',
+  );
+});
+
+test('formatCleanupBacklogRemediation falls back to the docs-only clause for an unrecognized profile', () => {
+  assert.equal(
+    formatCleanupBacklogRemediation('not-a-real-profile'),
+    'Remediation: see docs/idd-comment-minimization.md.',
+  );
+});
+
+test('resolveConfiguredHelperRuntimeProfile reads the live helperRuntime.profile', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-doctor-helper-profile-'));
+  try {
+    mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(
+      join(dir, '.github/idd/config.json'),
+      JSON.stringify({ helperRuntime: { profile: 'ephemeral-npx' } }),
+    );
+    assert.equal(resolveConfiguredHelperRuntimeProfile(dir), 'ephemeral-npx');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveConfiguredHelperRuntimeProfile also reads the legacy idd-policy.json path', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-doctor-helper-profile-legacy-'));
+  try {
+    writeFileSync(
+      join(dir, 'idd-policy.json'),
+      JSON.stringify({ helperRuntime: { profile: 'package-manager' } }),
+    );
+    assert.equal(resolveConfiguredHelperRuntimeProfile(dir), 'package-manager');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveConfiguredHelperRuntimeProfile defaults to instructions-only when unset, absent, or malformed', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-doctor-helper-profile-absent-'));
+  try {
+    // No config file at all.
+    assert.equal(
+      resolveConfiguredHelperRuntimeProfile(dir),
+      'instructions-only',
+    );
+
+    // Config present but helperRuntime unset.
+    mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(join(dir, '.github/idd/config.json'), JSON.stringify({}));
+    assert.equal(
+      resolveConfiguredHelperRuntimeProfile(dir),
+      'instructions-only',
+    );
+
+    // Malformed JSON -- already reported elsewhere by
+    // checkHelperRuntimeConfig / checkLiveConfigSchema; this resolver just
+    // fails closed to the safe no-command default.
+    writeFileSync(join(dir, '.github/idd/config.json'), '{ not json');
+    assert.equal(
+      resolveConfiguredHelperRuntimeProfile(dir),
+      'instructions-only',
+    );
+
+    // Invalid profile value.
+    writeFileSync(
+      join(dir, '.github/idd/config.json'),
+      JSON.stringify({ helperRuntime: { profile: 'bun' } }),
+    );
+    assert.equal(
+      resolveConfiguredHelperRuntimeProfile(dir),
+      'instructions-only',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('computeWindowStartIso returns null for windows that overflow Date range', () => {

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -1107,6 +1107,33 @@ test('resolveConfiguredHelperRuntimeProfile defaults to instructions-only when u
   }
 });
 
+test('resolveConfiguredHelperRuntimeProfile never falls through a present canonical config to a legacy one (idd-skill#1718 review)', () => {
+  // A present .github/idd/config.json that omits helperRuntime is an
+  // intentional instructions-only declaration -- it must not fall through
+  // to a stale idd-policy.json left over from before a migration to the
+  // canonical filename, even though idd-policy.json alone (with no
+  // canonical file present) is still a supported legacy path on its own
+  // (see the test above). Flagged independently by both Copilot and the
+  // secondary advisory bot on PR #1730.
+  const dir = mkdtempSync(
+    join(tmpdir(), 'idd-doctor-helper-profile-no-fallthrough-'),
+  );
+  try {
+    mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(join(dir, '.github/idd/config.json'), JSON.stringify({}));
+    writeFileSync(
+      join(dir, 'idd-policy.json'),
+      JSON.stringify({ helperRuntime: { profile: 'package-manager' } }),
+    );
+    assert.equal(
+      resolveConfiguredHelperRuntimeProfile(dir),
+      'instructions-only',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('computeWindowStartIso returns null for windows that overflow Date range', () => {
   const now = Date.UTC(2026, 4, 21, 12, 0, 0);
   // ~1e9 days is well past the ±100,000,000-day toISOString limit and


### PR DESCRIPTION
# Summary

`idd-doctor`'s post-merge-cleanup-backlog warning always told operators to
run `node scripts/audit-pr-cleanup.mjs --pr <N> --apply --skip-claim-check`,
even when the repository's configured `helperRuntime.profile` isn't
`vendored-node`. Under `ephemeral-npx` there is no `scripts/` directory at
all, so copy-pasting the suggested command fails immediately. Reported live
from an adopter repository on that profile.

This PR routes the warning's remediation text through the configured
profile instead of a hard-coded literal:

- `helper-runtime-manifest.mts` gains a small, exported resolver
  `resolveHelperCommandForProfile({ helperId, profile, packageSpec })` that
  maps one helper id + one `helperRuntime.profile` to its invocation
  string: `vendored-node` -> the manifest's `vendoredCommand`;
  `package-manager` -> the bin name; `ephemeral-npx` -> the one-shot
  `npx --yes --package <spec> <bin>` form; anything else (including
  `instructions-only`) -> `null`.
- `idd-doctor.mts` gains `resolveConfiguredHelperRuntimeProfile` (reads the
  same live-config candidates `checkHelperRuntimeConfig` already reads,
  defaulting fail-closed to `instructions-only`) and
  `formatCleanupBacklogRemediation` (builds the warning's remediation
  clause through the resolver above, keeping the
  `docs/idd-comment-minimization.md` pointer in every profile).

**`package-manager` form — a deliberate deviation from the issue's proposed
text.** The issue's step 1 suggested "the package-manager script form built
from `scriptName`" (i.e. something like `<manager> run
idd:audit-pr-cleanup`). This PR instead emits the bare `idd-audit-pr-cleanup`
bin name — the same form `buildProfileCatalog` already emits as this
profile's `commands` value — because argument forwarding after `run` differs
across package managers (npm needs a literal `--` before flags; pnpm/yarn do
not), so a manager-agnostic `<manager> run <scriptName> ...` string would be
wrong for at least one manager. That's strictly worse than the bug this PR
fixes, so I kept the already-established bin-name form instead. Flagging
this explicitly in case a maintainer prefers otherwise.

**Sweep result (issue step 3):** the cleanup-backlog warning is the only
place in `idd-doctor.mts` that hard-codes a profile-specific invocation for
a different helper. The file's only other `node scripts/...` mention is its
own `--help` usage banner (`node scripts/idd-doctor.mjs [options]`), which
describes invoking idd-doctor itself, not a remediation pointer at a
different helper — out of scope.

**Known adjacent gap, deliberately not fixed here:**
`docs/idd-comment-minimization.md` still hard-codes the `node
scripts/audit-pr-cleanup.mjs ...` form in its own prose (the doc this PR's
remediation hint still points operators at). The issue explicitly carves
Markdown-authored invocation strings out to #1674 (which already validates
those against the same manifest), so I left that doc untouched.

**Incidental fix:** `policy-helpers.mts`'s `inspectHelperRuntimeConfig` had
no explicit return type, so TypeScript widened its `status: "ok"` branch's
`.profile` field to `string | undefined` at any call site outside a
template-literal interpolation. `resolveConfiguredHelperRuntimeProfile` is
the first caller to assign that field to a `string`-typed return value,
which surfaced the gap as a typecheck error. Fixed with an explicit
discriminated-union return type (no behavior change — verified against
every existing call site and `consistency.test.mts`'s assertions, which
already match the same three return shapes). Landed as its own commit.

## Linked issue

Closes #1718

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

See the plan comment posted on the issue
(https://github.com/kurone-kito/idd-skill/issues/1718#issuecomment-5138806334)
for the full implementation plan, including a disclosed ordering
deviation: implementation code was written before that plan comment was
posted. No functional harm resulted (the B2.0 supersession re-check found
no hit before implementation began), but the plan was transcribed
retroactively per `idd-work.instructions.md` B3's recovery path, and this
PR's diff is what the retroactive C1 critique pass reviewed.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs changed by this PR)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
