### PR TITLE
chore(idd): wire the drift checks into the validate command sets

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -22,8 +22,8 @@
   "commands": {
     "install-deps": "node scripts/verify-install-deps.mjs --key-binary node_modules/.bin/tsc --install-command \"pnpm install --frozen-lockfile\"",
     "fix-validate": "npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\"",
-    "pre-push-validate": "npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/idd-doctor.mjs",
-    "post-fix-validate": "npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress"
+    "pre-push-validate": "npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check && pnpm run build:check && node scripts/idd-doctor.mjs",
+    "post-fix-validate": "npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check"
   },
   "helperRuntime": {
     "profile": "package-manager"

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -267,8 +267,8 @@ enabled and default approval actors to
 | Name | Commands |
 | --- | --- |
 | **fix-validate** | `npx biome check --write && npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"` |
-| **pre-push-validate** | `npx biome check && npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress && node scripts/idd-doctor.mjs` |
-| **post-fix-validate** | `npx biome check --write && npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` |
+| **pre-push-validate** | `npx biome check && npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress && node scripts/audit-docs.mjs --check && pnpm run build:check && node scripts/idd-doctor.mjs` |
+| **post-fix-validate** | `npx biome check --write && npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress && node scripts/audit-docs.mjs --check` |
 | **install-deps** | `node scripts/verify-install-deps.mjs --key-binary node_modules/.bin/tsc --install-command "pnpm install --frozen-lockfile"` |
 | **issue-scope** | `roadmap-first` |
 | **orphan-first-policy** | `none` |

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,8 +2,9 @@
 # -*- mode: sh -*-
 # vim: set ft=sh :
 
-# Fast, commit-safe checks only. The full suite (typecheck, build:check,
-# tests, workshop integrity, cspell) runs in CI; pre-push-validate adds
-# docs lint + cspell at push time. Running build:check's `git diff` here
-# deadlocked against the in-progress commit's index.lock (see #1007).
+# Fast, commit-safe checks only. The full suite (typecheck, tests,
+# workshop integrity) runs in CI; pre-push-validate adds docs lint,
+# cspell, mirror-drift, and build:check at push time (post-fix-validate
+# adds mirror-drift only). build:check's `git diff` deadlocked here
+# against the in-progress commit's index.lock (see #1007).
 pnpm run lint:precommit

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -482,11 +482,11 @@
         },
         {
           "from": "| **pre-push-validate** | `{{PRE_PUSH_VALIDATE_COMMANDS}}` |",
-          "to": "| **pre-push-validate** | `npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/idd-doctor.mjs` |"
+          "to": "| **pre-push-validate** | `npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check && pnpm run build:check && node scripts/idd-doctor.mjs` |"
         },
         {
           "from": "| **post-fix-validate** | `{{POST_FIX_VALIDATE_COMMANDS}}` |",
-          "to": "| **post-fix-validate** | `npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress` |"
+          "to": "| **post-fix-validate** | `npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check` |"
         },
         {
           "from": "| **install-deps** | `{{INSTALL_DEPS_COMMAND}}` |",

--- a/tests/helper-runtime-manifest.test.mts
+++ b/tests/helper-runtime-manifest.test.mts
@@ -597,6 +597,16 @@ function readInstructionFiles(): { name: string; source: string }[] {
 //     idd-template's own row stays the generic `{{INSTALL_DEPS_COMMAND}}`
 //     placeholder, so an idd-template adopter never sees this concrete
 //     invocation either unless they deliberately choose to replicate it.
+//   - scripts/audit-docs.mjs: the concreted Project commands table's
+//     pre-push-validate and post-fix-validate rows invoke it directly
+//     (see .github/idd/config.json / idd-overview-core.instructions.md)
+//     to catch this repo's own mirror-copy drift against
+//     audit/sync-manifest.json. idd-template's own rows stay the generic
+//     `{{PRE_PUSH_VALIDATE_COMMANDS}}` / `{{POST_FIX_VALIDATE_COMMANDS}}`
+//     placeholders, so an idd-template adopter never sees this concrete
+//     invocation, and the check is scoped to this repo's own
+//     idd-template/ pairing, not a tool an adopter repo could run as-is
+//     (idd-skill#1726).
 // Every other dev tool (build-ts, verify-workshop-integrity, …) is excluded by
 // ABSENCE — it is never `node`-invoked in the instructions — so it is NOT added
 // here on purpose: adding it would let a future accidental `node scripts/X.mjs`
@@ -606,6 +616,7 @@ function readInstructionFiles(): { name: string; source: string }[] {
 const DOGFOOD_ONLY_CONCRETE_TOOLS = new Set([
   'scripts/sync-docs.mjs',
   'scripts/verify-install-deps.mjs',
+  'scripts/audit-docs.mjs',
 ]);
 
 // Collect every helper the instruction files tell adopters to RUN as
@@ -714,16 +725,18 @@ test('the registration guard scopes out instruction-referenced libraries and dev
   // Dev/CI tooling and the maintainer-only post-merge sweep are likewise never
   // adopter-run commands, so they stay unregistered too. build-ts /
   // verify-workshop-integrity / merged-pr-feedback-sweep are excluded by
-  // absence (never `node`-invoked in the instructions); sync-docs and
-  // verify-install-deps are `node`-invoked in the dogfood instructions
-  // (banner / concreted install-deps row, respectively) but excluded via
-  // DOGFOOD_ONLY_CONCRETE_TOOLS, so the guard still scopes both out.
+  // absence (never `node`-invoked in the instructions); sync-docs,
+  // verify-install-deps, and audit-docs are `node`-invoked in the dogfood
+  // instructions (banner / concreted install-deps row / concreted
+  // pre-push-validate+post-fix-validate rows, respectively) but excluded
+  // via DOGFOOD_ONLY_CONCRETE_TOOLS, so the guard still scopes all three out.
   for (const nonAdopterTool of [
     'scripts/build-ts.mjs',
     'scripts/sync-docs.mjs',
     'scripts/verify-workshop-integrity.mjs',
     'scripts/verify-install-deps.mjs',
     'scripts/merged-pr-feedback-sweep.mjs',
+    'scripts/audit-docs.mjs',
   ]) {
     assert.equal(
       documentedCliHelpers.has(nonAdopterTool),


### PR DESCRIPTION
# Summary

`node scripts/audit-docs.mjs --check` (0.29s, mirror-copy drift) and
`pnpm run build:check` (4.1s, generated-artifact drift) previously ran
only in CI and in the contributor-facing `pnpm run lint` suite — both
reached only by pushing, which is what triggers a billed advisory
review round. Neither was wired into any of the three IDD `commands.*`
validate sets the phase files actually invoke, even though
`pre-push-validate` already spends 129.6s on `idd-doctor.mjs`.

This PR wires both fast drift checks into the command sets:

- `commands.pre-push-validate` now also runs
  `node scripts/audit-docs.mjs --check` and `pnpm run build:check`
  (placed before the slower `idd-doctor.mjs`, fail-fast order).
- `commands.post-fix-validate` now also runs
  `node scripts/audit-docs.mjs --check` only — `build:check`'s `git
  diff` step trips on the uncommitted regenerated output that
  `post-fix-validate` itself is documented to leave staged, so it
  stays out of that command set.
- `commands.fix-validate` is unchanged (keeps the per-commit loop
  fast).
- `audit/sync-manifest.json`'s `replacements[].to` entries for the
  `idd-overview-core-instructions` `syncPairs` target were updated to
  match, and `.github/instructions/idd-overview-core.instructions.md`
  was regenerated via `node scripts/sync-docs.mjs --apply` (never
  hand-edited).
- `idd-template/.github/idd/config.json` is untouched — its rows stay
  the generic `{{PRE_PUSH_VALIDATE_COMMANDS}}` /
  `{{POST_FIX_VALIDATE_COMMANDS}}` placeholders, so these
  repository-local dogfooding commands are not exported to
  `idd-template/`.
- `.husky/pre-commit`'s comment is corrected to describe the new
  local/CI split (the hook itself still only runs
  `pnpm run lint:precommit`, unchanged — `build:check`'s `git diff`
  still deadlocks against the in-progress commit's `index.lock`,
  #1007, so it stays out of the hook).
- `tests/helper-runtime-manifest.test.mts`: registered
  `scripts/audit-docs.mjs` in `DOGFOOD_ONLY_CONCRETE_TOOLS` alongside
  `scripts/sync-docs.mjs` and `scripts/verify-install-deps.mjs`. The
  new `node scripts/audit-docs.mjs --check` invocation in the
  concreted Project commands table made the existing "documented CLI
  adopter helper" registration test fail — `audit-docs.mjs` is
  `node`-invoked in this repo's own dogfood instructions but never
  seen by an `idd-template` adopter (their row stays the generic
  placeholder) and is scoped to this repo's own
  `audit/sync-manifest.json` / `idd-template/` pairing, so it is not a
  distributable adopter-facing CLI helper.

Roadmap #1679 already lists this issue in its `## Tracks` list and its
mirror-drift paragraph already records that the mechanical surface was
unwired rather than merely under-used (both landed with #1726's
authoring on 2026-07-29), so no further edit to #1679 was needed.

## Linked issue

Closes #1726

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Cost context from the issue: measured on the 30 most recent merged
PRs on 2026-07-29, advisory review ran 4.80 rounds per PR, and 46.5%
of those rounds returned no findings. A defect class that reaches
review costs at least one billed round to report and another to
confirm the fix — mirror-copy drift was the largest recurring finding
category (78 findings in the audited window) despite already having a
mechanical check; the check just never ran locally.

#1707 separately revised `build:check`'s own definition (untracked-
artifact guard) before this PR was authored — this PR wires in
`build:check` as currently defined on `main`, with no ordering
conflict.

## IDD impact

- [x] Instruction files changed (`idd-overview-core.instructions.md`,
      regenerated only)
- [ ] Template files changed
- [ ] Helper scripts changed
- [x] Config schema changed (`.github/idd/config.json` command
      values only — no schema shape change)
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`lint:minimum`): 2692/2692 tests pass, 0 CSpell
      issues, 0 markdownlint errors
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`node scripts/sync-docs.mjs
      --check`: "All mirrored artifacts are up to date.")
- [x] `node scripts/idd-doctor.mjs` (ran as part of
      `pre-push-validate`; result: passed, 4 pre-existing warnings
      unrelated to this change)

### Acceptance-criteria evidence

`idd-overview-core.instructions.md` byte size after regeneration:
16,059 bytes, within the 20,000-byte always-loaded budget.
`audit-docs.mjs --check` reports no bundle over its limit (only
pre-existing `context-ceiling-128k` notices, all below their error
threshold).

**`audit-docs.mjs --check` against a working tree where the generated
mirror was edited without its `idd-template/` source** (a trailing
HTML comment appended directly to
`.github/instructions/idd-overview-core.instructions.md`, then
reverted before committing):

```text
documentation audit failed:
- idd-overview-core-instructions: idd-template/.github/instructions/idd-overview-core.instructions.md and .github/instructions/idd-overview-core.instructions.md differ in concreted mode

remediation:
- run `pnpm run docs:sync` to refresh mirrored files from canonical sources
- re-run `node scripts/audit-docs.mjs --check`
```

Exit code 1.

**`build:check` against a working tree where a `src/**/*.mts` source
was changed without committing regenerated output** (a trailing
comment appended to `src/scripts/audit-docs.mts`, then reverted before
committing):

```text
$ pnpm run build && git diff HEAD --exit-code -- scripts bin .gitattributes && node scripts/check-untracked-artifacts.mjs
$ node scripts/build-ts.mjs
Checked 107 files in 331ms. Fixed 107 files.
diff --git a/scripts/audit-docs.mjs b/scripts/audit-docs.mjs
index 57749ff4..e605532e 100644
--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -932,3 +932,4 @@ function uniqueSorted(values) {
 function escapeRegExp(value) {
   return value.replace(/[\\^$+?.()|[\]{}]/g, '\\$&');
 }
+// injected drift for PR demonstration
[ELIFECYCLE] Command failed with exit code 1.
```

Exit code 1 (`pnpm run build` regenerates `scripts/audit-docs.mjs`
from the changed source, then the `git diff HEAD` step sees the
regenerated-but-uncommitted output and fails).

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (no change to merge policy itself;
      adds two fast local gates ahead of push)
- [x] Context budget impact reviewed (regenerated file: 16,059 /
      20,000 always-loaded bytes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Validation workflows now consistently include documentation audits and build checks before changes are pushed.
  - Post-fix validation also performs documentation checks for more reliable results.
  - Local pre-commit guidance now clearly distinguishes fast checks from broader CI and push-time validation.

- **Tests**
  - Helper discovery checks now correctly exclude internal documentation-audit tooling from adopter-facing helper listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->