### PR TITLE
fix(helpers): rank failure-family states above SUCCESS in CI tie-break

### DIFF
--- a/scripts/ci-wait-state.mjs
+++ b/scripts/ci-wait-state.mjs
@@ -26,6 +26,7 @@ import { parseCliArgs } from './cli-args.mjs';
 import { ghText } from './gh-exec.mjs';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import {
+  CI_FAILURE_CONCLUSION_STATES,
   parsePaginatedGhNdjson,
   selectLatestCheckInstance,
   summarizeBranchReviewRequirements,
@@ -50,18 +51,25 @@ const PENDING_STATES = new Set([
   'EXPECTED',
   'REQUESTED',
 ]);
-const FAILURE_STATES = new Set([
-  'FAILURE',
-  'CANCELLED',
-  'TIMED_OUT',
-  'ACTION_REQUIRED',
-  'STARTUP_FAILURE',
-  'STALE',
-  // Commit-status contexts (StatusContext) report `error` as a state
-  // distinct from `failure`; bucket it as failure too, or a clearly
-  // failing required check would misleadingly read as "unknown".
-  'ERROR',
-]);
+// Derived from the shared `CI_FAILURE_CONCLUSION_STATES` (protocol-helpers.mts)
+// plus `CANCELLED`, rather than an independently hand-maintained literal
+// (#1688): `CI_FAILURE_CONCLUSION_STATES` already carries `TIMED_OUT`,
+// `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE`, and the commit-status-only
+// `ERROR` (a StatusContext `error` state distinct from `failure`; bucket it
+// as failure too, or a clearly failing required check would misleadingly
+// read as "unknown"). `CANCELLED` is added locally because this file's own
+// required-checks *bucketing* treats a cancelled run as failing for wait-gate
+// purposes, even though `ciStateTieRank`'s same-instant tie-break (in
+// `protocol-helpers.mts`) deliberately keeps `CANCELLED` at a lower rank
+// than every other member here -- a cancelled run reached no real verdict,
+// so it still loses a tie against a genuine success, but it must not be
+// treated as passing outright once it is the sole/latest instance for a
+// required check name. Deriving from the shared set (instead of maintaining
+// a second, separately-updated literal) is what keeps this file's wider
+// vocabulary from silently drifting away from `classifyCiChecks`'s again,
+// which is exactly how #1504's local-only fix diverged from the shared
+// `ciStateTieRank` in the first place.
+const FAILURE_STATES = new Set([...CI_FAILURE_CONCLUSION_STATES, 'CANCELLED']);
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
 // .mjs source text for quoted flag literals such as the --pr spec key
@@ -226,24 +234,29 @@ function bucketState(state) {
  * the latest instance per name should govern pass/fail/pending (#1478).
  * Reuses the exported `selectLatestCheckInstance` for the actual
  * same-name reduction (still-incomplete wins over completed; else latest
- * `completedAt` wins; a same-instant tie prefers `FAILURE`, then
- * non-`CANCELLED`) so this file does not maintain a second,
- * independently-drifting copy of that tie-break logic. Only the
+ * `completedAt` wins; a same-instant tie prefers any
+ * `CI_FAILURE_CONCLUSION_STATES` member, then non-`CANCELLED`) so this file
+ * does not maintain a second, independently-drifting copy of that
+ * tie-break logic. Only the
  * name-keyed grouping below is local to this file, because
  * `CiWaitCheckEntry` uses `checkName` where `protocol-helpers.mts`'s
  * `CheckLike` uses `name`.
  *
- * `selectLatestCheckInstance`'s shared `ciStateTieRank` special-cases only
- * the two literal strings `'FAILURE'` and `'CANCELLED'`; every other raw
- * state -- including this file's own wider `FAILURE_STATES` additions
- * `TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE`, and `ERROR`
- * -- falls into the shared tie-break's generic rank-1 bucket, where a
- * same-instant tie against a success-family state resolves by raw
+ * `selectLatestCheckInstance`'s shared `ciStateTieRank` originally
+ * special-cased only the two literal strings `'FAILURE'` and `'CANCELLED'`;
+ * every other raw state -- including this file's own wider `FAILURE_STATES`
+ * additions `TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE`, and
+ * `ERROR` -- fell into the shared tie-break's generic rank-1 bucket, where a
+ * same-instant tie against a success-family state resolved by raw
  * lexicographic string comparison instead of "the failure should win"
- * (#1504). Rather than widening `ciStateTieRank` itself -- shared,
- * upstream of `classifyCiChecks`, and out of scope for this fix -- see
- * `selectLatestCheckEntry` for how each group applies a tie-break-only
- * state normalization that stays entirely local to this file.
+ * (#1504). That was fixed locally only, in this file, at the time (a
+ * tie-break-only state normalization applied by `selectLatestCheckEntry`
+ * before calling `selectLatestCheckInstance`) -- widening `ciStateTieRank`
+ * itself was left out of scope as "shared, upstream of `classifyCiChecks`".
+ * #1688 closed that shared corner: `ciStateTieRank` now ranks every
+ * `CI_FAILURE_CONCLUSION_STATES` member (which this file's `FAILURE_STATES`
+ * is derived from) at 0 directly, so `selectLatestCheckEntry` no longer
+ * needs a local normalization step at all -- see that function.
  *
  * Deliberately keyed by `checkName` alone, not the `(checkName,
  * workflowName)` pair this file otherwise disambiguates entries by (see
@@ -284,29 +297,28 @@ function selectLatestCheckEntryPerName(entries) {
 }
 /**
  * Reduce one name-keyed group to its representative instance via the
- * shared `selectLatestCheckInstance`, using a *tie-break-only* normalized
- * state (#1504) so this file's wider `FAILURE_STATES` vocabulary still
- * wins a same-instant tie against a success-family state, the same way a
- * literal `FAILURE` conclusion already does. `entry.state` itself is never
- * mutated: each group member is wrapped with `tieBreakState(entry)` for
- * selection purposes only, and the winning wrapper is unwrapped back to
- * its original `entry` before returning, so the returned `CiWaitCheckEntry`
- * always carries its real, unmodified `state`.
+ * shared `selectLatestCheckInstance`, comparing each entry's own real
+ * `state` directly -- no local tie-break-only normalization needed
+ * (#1688; pre-#1688 this wrapped every entry through a *tie-break-only*
+ * normalized state before calling `selectLatestCheckInstance`, since the
+ * shared `ciStateTieRank` only recognized the literal `'FAILURE'` string;
+ * now that `ciStateTieRank` itself ranks every `CI_FAILURE_CONCLUSION_STATES`
+ * member -- which is exactly this file's `FAILURE_STATES` minus `CANCELLED`
+ * -- at 0, this file's own wider vocabulary already wins a same-instant tie
+ * against a success-family state with no local help).
  *
- * Sorted by the original `entry.state` (ascending) before wrapping, so a
- * same-instant tie between two *distinct* raw states that both normalize
- * to the same tie-break state (e.g. `TIMED_OUT` and `STARTUP_FAILURE`,
- * both normalized to `'FAILURE'`) still resolves deterministically
- * (Copilot review, PR #1530). Without the sort, `selectLatestCheckInstance`'s
- * last-resort comparison (`candidate.state !== current.state && ...`) sees
- * two *equal* normalized states and always keeps whichever entry
- * `reduce` saw first -- an input-order artifact, not a value-based choice.
- * Pre-fix, distinct raw states made that same comparison a genuine
- * lexicographic argmin, independent of input order; sorting restores
- * exactly that: `reduce` starts from (and keeps) the lexicographically
- * smallest raw state whenever normalized states tie. This sort changes
- * nothing else -- the `completedAt`-primary and rank-primary comparisons
- * in `isNewerCheckInstance` are already order-independent.
+ * A same-instant tie between two *distinct* raw failure states (e.g.
+ * `TIMED_OUT` and `STARTUP_FAILURE`, both now rank 0) still resolves
+ * deterministically regardless of input order, because
+ * `isNewerCheckInstance`'s residual same-rank fallback
+ * (`candidate.state !== current.state && candidate.state < current.state`)
+ * is a genuine lexicographic argmin over the two *distinct* raw state
+ * strings -- symmetric and order-independent by construction, unlike the
+ * pre-#1688 wrapped comparison (which needed an explicit pre-sort, Copilot
+ * review PR #1530, because two distinct raw states could normalize to the
+ * *same* wrapped string and make the residual comparison see a false tie).
+ * With no normalization step left, that failure mode no longer exists, so
+ * the pre-sort is gone too.
  *
  * Exported (like `protocol-helpers.mts`'s own `selectLatestCheckInstance`)
  * so the determinism property above is directly unit-testable: the winning
@@ -317,36 +329,14 @@ function selectLatestCheckEntryPerName(entries) {
  * instance wins a tie.
  */
 export function selectLatestCheckEntry(group) {
-  const sorted = [...group].sort((a, b) =>
-    a.state < b.state ? -1 : a.state > b.state ? 1 : 0,
-  );
   const winner = selectLatestCheckInstance(
-    sorted.map((entry) => ({
+    group.map((entry) => ({
       entry,
-      state: tieBreakState(entry),
+      state: entry.state,
       completedAt: entry.completedAt,
     })),
   );
   return winner.entry;
-}
-/**
- * The state the shared tie-break in `selectLatestCheckInstance` should
- * compare for `entry`, which is not always `entry.state` itself (#1504).
- * `CANCELLED` is left as `CANCELLED`: a cancelled run reached no verdict,
- * so it must keep losing a same-instant tie exactly as it does today.
- * Every other entry already bucketed as `status === 'failure'` by
- * `bucketState` -- the literal `FAILURE` conclusion plus this file's wider
- * `FAILURE_STATES` additions (`TIMED_OUT`, `ACTION_REQUIRED`,
- * `STARTUP_FAILURE`, `STALE`, the StatusContext-only `ERROR`) -- normalizes
- * to the literal `'FAILURE'` so `ciStateTieRank` ranks it 0 (always wins)
- * instead of falling into its generic rank-1 bucket. Every non-failure
- * entry (success, pending, unknown) is returned unchanged: the existing
- * lexicographic fallback within that shared rank is correct as-is and out
- * of scope for this fix.
- */
-function tieBreakState(entry) {
-  if (entry.state === 'CANCELLED') return 'CANCELLED';
-  return entry.status === 'failure' ? 'FAILURE' : entry.state;
 }
 function buildRequiredChecksRollup(
   checks,

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1285,23 +1285,55 @@ function parseCompletedAt(value) {
   return isCompletedCiTimestamp(timestamp) ? Date.parse(timestamp) : null;
 }
 /**
+ * Failure-family *conclusion* states that must win a same-instant
+ * tie-break and classify as a genuine `classifyCiChecks` failure (#1688).
+ * Deliberately excludes `CANCELLED`: a cancelled run reached no real
+ * verdict at all (unlike these six, which are all concrete failure
+ * conclusions), so it keeps its own separate, lower tie-break rank in
+ * `ciStateTieRank` below and stays out of `classifyCiChecks`'s `failed`
+ * bucket — see that function and `ci-wait-state.mts`'s `FAILURE_STATES`
+ * (which is deliberately *derived from* this set plus `CANCELLED`, not
+ * independently maintained, so the two files cannot silently drift apart
+ * again the way #1504's local-only fix did).
+ *
+ * `ERROR` is StatusContext-only (a CheckRun conclusion never reports it);
+ * included here so a caller that feeds a raw, un-translated commit-status
+ * state directly into `classifyCiChecks` or `ciStateTieRank` still gets
+ * failure-family treatment, matching `normalizeStatusCheckRollupEntry`'s
+ * translation of StatusContext `error` to the literal `'FAILURE'` for the
+ * one call path that already normalizes it upstream.
+ */
+export const CI_FAILURE_CONCLUSION_STATES = new Set([
+  'FAILURE',
+  'TIMED_OUT',
+  'ACTION_REQUIRED',
+  'STARTUP_FAILURE',
+  'STALE',
+  'ERROR',
+]);
+/**
  * Tie-break precedence for two check-run instances that complete at the
- * same (or an equally unusable) instant. `FAILURE` always wins (rank 0):
- * a same-instant tie must never hide a real failure behind ordering
- * happenstance (the exact regression `classifyCiChecks`'s unconditional
- * "any FAILURE anywhere" rule existed to prevent, and not a case a rerun
- * can plausibly land in — GitHub `completedAt` has only second resolution,
- * and a rerun must trigger, queue, and execute before it can complete,
- * which practically never lands in the exact same recorded second as the
- * run it supersedes). `CANCELLED` always loses (rank 2): a cancelled run
- * reached no real verdict, so it defers to any conclusion that did.
- * Every other state — including pending states, which practically never
- * reach this tie path since they have no completed timestamp to tie on —
- * shares the middle rank (1).
+ * same (or an equally unusable) instant. Every `CI_FAILURE_CONCLUSION_STATES`
+ * member always wins (rank 0): a same-instant tie must never hide a real
+ * failure behind ordering happenstance (the exact regression
+ * `classifyCiChecks`'s unconditional "any FAILURE anywhere" rule existed
+ * to prevent, and not a case a rerun can plausibly land in — GitHub
+ * `completedAt` has only second resolution, and a rerun must trigger,
+ * queue, and execute before it can complete, which practically never
+ * lands in the exact same recorded second as the run it supersedes).
+ * Pre-#1688, only the literal `'FAILURE'` string won this way; `TIMED_OUT`,
+ * `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE`, and `ERROR` fell into the
+ * generic rank-1 bucket below and could lose a tie to `SUCCESS` by
+ * lexicographic happenstance (#1688's reproduction: `SUCCESS` vs
+ * `TIMED_OUT`, `'SUCCESS' < 'TIMED_OUT'`). `CANCELLED` always loses (rank
+ * 2): a cancelled run reached no real verdict, so it defers to any
+ * conclusion that did. Every other state — including pending states,
+ * which practically never reach this tie path since they have no
+ * completed timestamp to tie on — shares the middle rank (1).
  */
 function ciStateTieRank(state) {
-  if (state === 'FAILURE') return 0;
   if (state === 'CANCELLED') return 2;
+  if (CI_FAILURE_CONCLUSION_STATES.has(state)) return 0;
   return 1;
 }
 /**
@@ -1435,7 +1467,15 @@ export function classifyCiChecks(checks) {
   // name before classifying pass/fail/pending, so a stale instance never
   // outvotes the current one for the same name (see #1471).
   const deduped = selectLatestCheckPerName(normalized);
-  const failed = deduped.filter((check) => check.state === 'FAILURE');
+  // #1688: widened from a literal 'FAILURE' match to every
+  // CI_FAILURE_CONCLUSION_STATES member, so a TIMED_OUT/ACTION_REQUIRED/
+  // STARTUP_FAILURE/STALE/ERROR conclusion classifies as a genuine failure
+  // here too, matching ci-wait-state.mts's own bucketing for the same
+  // conclusion states instead of silently falling through to 'unknown'.
+  // CANCELLED is deliberately not included -- see CI_FAILURE_CONCLUSION_STATES.
+  const failed = deduped.filter((check) =>
+    CI_FAILURE_CONCLUSION_STATES.has(check.state),
+  );
   if (failed.length > 0) {
     return { status: 'failed', failed };
   }

--- a/src/scripts/ci-wait-state.mts
+++ b/src/scripts/ci-wait-state.mts
@@ -28,6 +28,7 @@ import { parseCliArgs } from './cli-args.mts';
 import { ghText } from './gh-exec.mts';
 import { deriveGhHttpStatus } from './gh-http-status.mts';
 import {
+  CI_FAILURE_CONCLUSION_STATES,
   parsePaginatedGhNdjson,
   selectLatestCheckInstance,
   summarizeBranchReviewRequirements,
@@ -176,18 +177,25 @@ const PENDING_STATES = new Set([
   'EXPECTED',
   'REQUESTED',
 ]);
-const FAILURE_STATES = new Set([
-  'FAILURE',
-  'CANCELLED',
-  'TIMED_OUT',
-  'ACTION_REQUIRED',
-  'STARTUP_FAILURE',
-  'STALE',
-  // Commit-status contexts (StatusContext) report `error` as a state
-  // distinct from `failure`; bucket it as failure too, or a clearly
-  // failing required check would misleadingly read as "unknown".
-  'ERROR',
-]);
+// Derived from the shared `CI_FAILURE_CONCLUSION_STATES` (protocol-helpers.mts)
+// plus `CANCELLED`, rather than an independently hand-maintained literal
+// (#1688): `CI_FAILURE_CONCLUSION_STATES` already carries `TIMED_OUT`,
+// `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE`, and the commit-status-only
+// `ERROR` (a StatusContext `error` state distinct from `failure`; bucket it
+// as failure too, or a clearly failing required check would misleadingly
+// read as "unknown"). `CANCELLED` is added locally because this file's own
+// required-checks *bucketing* treats a cancelled run as failing for wait-gate
+// purposes, even though `ciStateTieRank`'s same-instant tie-break (in
+// `protocol-helpers.mts`) deliberately keeps `CANCELLED` at a lower rank
+// than every other member here -- a cancelled run reached no real verdict,
+// so it still loses a tie against a genuine success, but it must not be
+// treated as passing outright once it is the sole/latest instance for a
+// required check name. Deriving from the shared set (instead of maintaining
+// a second, separately-updated literal) is what keeps this file's wider
+// vocabulary from silently drifting away from `classifyCiChecks`'s again,
+// which is exactly how #1504's local-only fix diverged from the shared
+// `ciStateTieRank` in the first place.
+const FAILURE_STATES = new Set([...CI_FAILURE_CONCLUSION_STATES, 'CANCELLED']);
 
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
@@ -381,24 +389,29 @@ function bucketState(state: string): CiWaitCheckEntry['status'] {
  * the latest instance per name should govern pass/fail/pending (#1478).
  * Reuses the exported `selectLatestCheckInstance` for the actual
  * same-name reduction (still-incomplete wins over completed; else latest
- * `completedAt` wins; a same-instant tie prefers `FAILURE`, then
- * non-`CANCELLED`) so this file does not maintain a second,
- * independently-drifting copy of that tie-break logic. Only the
+ * `completedAt` wins; a same-instant tie prefers any
+ * `CI_FAILURE_CONCLUSION_STATES` member, then non-`CANCELLED`) so this file
+ * does not maintain a second, independently-drifting copy of that
+ * tie-break logic. Only the
  * name-keyed grouping below is local to this file, because
  * `CiWaitCheckEntry` uses `checkName` where `protocol-helpers.mts`'s
  * `CheckLike` uses `name`.
  *
- * `selectLatestCheckInstance`'s shared `ciStateTieRank` special-cases only
- * the two literal strings `'FAILURE'` and `'CANCELLED'`; every other raw
- * state -- including this file's own wider `FAILURE_STATES` additions
- * `TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE`, and `ERROR`
- * -- falls into the shared tie-break's generic rank-1 bucket, where a
- * same-instant tie against a success-family state resolves by raw
+ * `selectLatestCheckInstance`'s shared `ciStateTieRank` originally
+ * special-cased only the two literal strings `'FAILURE'` and `'CANCELLED'`;
+ * every other raw state -- including this file's own wider `FAILURE_STATES`
+ * additions `TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE`, and
+ * `ERROR` -- fell into the shared tie-break's generic rank-1 bucket, where a
+ * same-instant tie against a success-family state resolved by raw
  * lexicographic string comparison instead of "the failure should win"
- * (#1504). Rather than widening `ciStateTieRank` itself -- shared,
- * upstream of `classifyCiChecks`, and out of scope for this fix -- see
- * `selectLatestCheckEntry` for how each group applies a tie-break-only
- * state normalization that stays entirely local to this file.
+ * (#1504). That was fixed locally only, in this file, at the time (a
+ * tie-break-only state normalization applied by `selectLatestCheckEntry`
+ * before calling `selectLatestCheckInstance`) -- widening `ciStateTieRank`
+ * itself was left out of scope as "shared, upstream of `classifyCiChecks`".
+ * #1688 closed that shared corner: `ciStateTieRank` now ranks every
+ * `CI_FAILURE_CONCLUSION_STATES` member (which this file's `FAILURE_STATES`
+ * is derived from) at 0 directly, so `selectLatestCheckEntry` no longer
+ * needs a local normalization step at all -- see that function.
  *
  * Deliberately keyed by `checkName` alone, not the `(checkName,
  * workflowName)` pair this file otherwise disambiguates entries by (see
@@ -442,29 +455,28 @@ function selectLatestCheckEntryPerName(
 
 /**
  * Reduce one name-keyed group to its representative instance via the
- * shared `selectLatestCheckInstance`, using a *tie-break-only* normalized
- * state (#1504) so this file's wider `FAILURE_STATES` vocabulary still
- * wins a same-instant tie against a success-family state, the same way a
- * literal `FAILURE` conclusion already does. `entry.state` itself is never
- * mutated: each group member is wrapped with `tieBreakState(entry)` for
- * selection purposes only, and the winning wrapper is unwrapped back to
- * its original `entry` before returning, so the returned `CiWaitCheckEntry`
- * always carries its real, unmodified `state`.
+ * shared `selectLatestCheckInstance`, comparing each entry's own real
+ * `state` directly -- no local tie-break-only normalization needed
+ * (#1688; pre-#1688 this wrapped every entry through a *tie-break-only*
+ * normalized state before calling `selectLatestCheckInstance`, since the
+ * shared `ciStateTieRank` only recognized the literal `'FAILURE'` string;
+ * now that `ciStateTieRank` itself ranks every `CI_FAILURE_CONCLUSION_STATES`
+ * member -- which is exactly this file's `FAILURE_STATES` minus `CANCELLED`
+ * -- at 0, this file's own wider vocabulary already wins a same-instant tie
+ * against a success-family state with no local help).
  *
- * Sorted by the original `entry.state` (ascending) before wrapping, so a
- * same-instant tie between two *distinct* raw states that both normalize
- * to the same tie-break state (e.g. `TIMED_OUT` and `STARTUP_FAILURE`,
- * both normalized to `'FAILURE'`) still resolves deterministically
- * (Copilot review, PR #1530). Without the sort, `selectLatestCheckInstance`'s
- * last-resort comparison (`candidate.state !== current.state && ...`) sees
- * two *equal* normalized states and always keeps whichever entry
- * `reduce` saw first -- an input-order artifact, not a value-based choice.
- * Pre-fix, distinct raw states made that same comparison a genuine
- * lexicographic argmin, independent of input order; sorting restores
- * exactly that: `reduce` starts from (and keeps) the lexicographically
- * smallest raw state whenever normalized states tie. This sort changes
- * nothing else -- the `completedAt`-primary and rank-primary comparisons
- * in `isNewerCheckInstance` are already order-independent.
+ * A same-instant tie between two *distinct* raw failure states (e.g.
+ * `TIMED_OUT` and `STARTUP_FAILURE`, both now rank 0) still resolves
+ * deterministically regardless of input order, because
+ * `isNewerCheckInstance`'s residual same-rank fallback
+ * (`candidate.state !== current.state && candidate.state < current.state`)
+ * is a genuine lexicographic argmin over the two *distinct* raw state
+ * strings -- symmetric and order-independent by construction, unlike the
+ * pre-#1688 wrapped comparison (which needed an explicit pre-sort, Copilot
+ * review PR #1530, because two distinct raw states could normalize to the
+ * *same* wrapped string and make the residual comparison see a false tie).
+ * With no normalization step left, that failure mode no longer exists, so
+ * the pre-sort is gone too.
  *
  * Exported (like `protocol-helpers.mts`'s own `selectLatestCheckInstance`)
  * so the determinism property above is directly unit-testable: the winning
@@ -477,37 +489,14 @@ function selectLatestCheckEntryPerName(
 export function selectLatestCheckEntry(
   group: CiWaitCheckEntry[],
 ): CiWaitCheckEntry {
-  const sorted = [...group].sort((a, b) =>
-    a.state < b.state ? -1 : a.state > b.state ? 1 : 0,
-  );
   const winner = selectLatestCheckInstance(
-    sorted.map((entry) => ({
+    group.map((entry) => ({
       entry,
-      state: tieBreakState(entry),
+      state: entry.state,
       completedAt: entry.completedAt,
     })),
   );
   return winner.entry;
-}
-
-/**
- * The state the shared tie-break in `selectLatestCheckInstance` should
- * compare for `entry`, which is not always `entry.state` itself (#1504).
- * `CANCELLED` is left as `CANCELLED`: a cancelled run reached no verdict,
- * so it must keep losing a same-instant tie exactly as it does today.
- * Every other entry already bucketed as `status === 'failure'` by
- * `bucketState` -- the literal `FAILURE` conclusion plus this file's wider
- * `FAILURE_STATES` additions (`TIMED_OUT`, `ACTION_REQUIRED`,
- * `STARTUP_FAILURE`, `STALE`, the StatusContext-only `ERROR`) -- normalizes
- * to the literal `'FAILURE'` so `ciStateTieRank` ranks it 0 (always wins)
- * instead of falling into its generic rank-1 bucket. Every non-failure
- * entry (success, pending, unknown) is returned unchanged: the existing
- * lexicographic fallback within that shared rank is correct as-is and out
- * of scope for this fix.
- */
-function tieBreakState(entry: CiWaitCheckEntry): string {
-  if (entry.state === 'CANCELLED') return 'CANCELLED';
-  return entry.status === 'failure' ? 'FAILURE' : entry.state;
 }
 
 function buildRequiredChecksRollup(

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1967,23 +1967,56 @@ function parseCompletedAt(value: string | null | undefined): number | null {
 }
 
 /**
+ * Failure-family *conclusion* states that must win a same-instant
+ * tie-break and classify as a genuine `classifyCiChecks` failure (#1688).
+ * Deliberately excludes `CANCELLED`: a cancelled run reached no real
+ * verdict at all (unlike these six, which are all concrete failure
+ * conclusions), so it keeps its own separate, lower tie-break rank in
+ * `ciStateTieRank` below and stays out of `classifyCiChecks`'s `failed`
+ * bucket — see that function and `ci-wait-state.mts`'s `FAILURE_STATES`
+ * (which is deliberately *derived from* this set plus `CANCELLED`, not
+ * independently maintained, so the two files cannot silently drift apart
+ * again the way #1504's local-only fix did).
+ *
+ * `ERROR` is StatusContext-only (a CheckRun conclusion never reports it);
+ * included here so a caller that feeds a raw, un-translated commit-status
+ * state directly into `classifyCiChecks` or `ciStateTieRank` still gets
+ * failure-family treatment, matching `normalizeStatusCheckRollupEntry`'s
+ * translation of StatusContext `error` to the literal `'FAILURE'` for the
+ * one call path that already normalizes it upstream.
+ */
+export const CI_FAILURE_CONCLUSION_STATES = new Set([
+  'FAILURE',
+  'TIMED_OUT',
+  'ACTION_REQUIRED',
+  'STARTUP_FAILURE',
+  'STALE',
+  'ERROR',
+]);
+
+/**
  * Tie-break precedence for two check-run instances that complete at the
- * same (or an equally unusable) instant. `FAILURE` always wins (rank 0):
- * a same-instant tie must never hide a real failure behind ordering
- * happenstance (the exact regression `classifyCiChecks`'s unconditional
- * "any FAILURE anywhere" rule existed to prevent, and not a case a rerun
- * can plausibly land in — GitHub `completedAt` has only second resolution,
- * and a rerun must trigger, queue, and execute before it can complete,
- * which practically never lands in the exact same recorded second as the
- * run it supersedes). `CANCELLED` always loses (rank 2): a cancelled run
- * reached no real verdict, so it defers to any conclusion that did.
- * Every other state — including pending states, which practically never
- * reach this tie path since they have no completed timestamp to tie on —
- * shares the middle rank (1).
+ * same (or an equally unusable) instant. Every `CI_FAILURE_CONCLUSION_STATES`
+ * member always wins (rank 0): a same-instant tie must never hide a real
+ * failure behind ordering happenstance (the exact regression
+ * `classifyCiChecks`'s unconditional "any FAILURE anywhere" rule existed
+ * to prevent, and not a case a rerun can plausibly land in — GitHub
+ * `completedAt` has only second resolution, and a rerun must trigger,
+ * queue, and execute before it can complete, which practically never
+ * lands in the exact same recorded second as the run it supersedes).
+ * Pre-#1688, only the literal `'FAILURE'` string won this way; `TIMED_OUT`,
+ * `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE`, and `ERROR` fell into the
+ * generic rank-1 bucket below and could lose a tie to `SUCCESS` by
+ * lexicographic happenstance (#1688's reproduction: `SUCCESS` vs
+ * `TIMED_OUT`, `'SUCCESS' < 'TIMED_OUT'`). `CANCELLED` always loses (rank
+ * 2): a cancelled run reached no real verdict, so it defers to any
+ * conclusion that did. Every other state — including pending states,
+ * which practically never reach this tie path since they have no
+ * completed timestamp to tie on — shares the middle rank (1).
  */
 function ciStateTieRank(state: string): number {
-  if (state === 'FAILURE') return 0;
   if (state === 'CANCELLED') return 2;
+  if (CI_FAILURE_CONCLUSION_STATES.has(state)) return 0;
   return 1;
 }
 
@@ -2134,7 +2167,15 @@ export function classifyCiChecks(checks: CheckLike[]) {
   // outvotes the current one for the same name (see #1471).
   const deduped = selectLatestCheckPerName(normalized);
 
-  const failed = deduped.filter((check) => check.state === 'FAILURE');
+  // #1688: widened from a literal 'FAILURE' match to every
+  // CI_FAILURE_CONCLUSION_STATES member, so a TIMED_OUT/ACTION_REQUIRED/
+  // STARTUP_FAILURE/STALE/ERROR conclusion classifies as a genuine failure
+  // here too, matching ci-wait-state.mts's own bucketing for the same
+  // conclusion states instead of silently falling through to 'unknown'.
+  // CANCELLED is deliberately not included -- see CI_FAILURE_CONCLUSION_STATES.
+  const failed = deduped.filter((check) =>
+    CI_FAILURE_CONCLUSION_STATES.has(check.state),
+  );
   if (failed.length > 0) {
     return { status: 'failed', failed };
   }

--- a/tests/advisory-wait.test.mts
+++ b/tests/advisory-wait.test.mts
@@ -170,6 +170,106 @@ test('classifyCiChecks: a same-instant cancelled/success tie for one name prefer
   assert.equal(classifyCiChecks(successFirst).status, 'success');
 });
 
+// #1688: ciStateTieRank previously ranked only the literal 'FAILURE'
+// conclusion at 0; TIMED_OUT (and the other failure-family conclusions
+// below) shared the generic rank-1 bucket with SUCCESS, so a same-instant
+// tie fell back to lexicographic string comparison -- and 'SUCCESS' <
+// 'TIMED_OUT', so SUCCESS won. This is the issue's own reproduction.
+test('classifyCiChecks: #1688 repro -- a same-instant SUCCESS/TIMED_OUT tie now reports failed, not success', () => {
+  const tiedAt = '2026-07-17T16:00:06Z';
+  const timedOutFirst = [
+    { name: 'lint', state: 'TIMED_OUT', completedAt: tiedAt },
+    { name: 'lint', state: 'SUCCESS', completedAt: tiedAt },
+  ];
+  const successFirst = [
+    { name: 'lint', state: 'SUCCESS', completedAt: tiedAt },
+    { name: 'lint', state: 'TIMED_OUT', completedAt: tiedAt },
+  ];
+  assert.equal(classifyCiChecks(timedOutFirst).status, 'failed');
+  assert.equal(classifyCiChecks(successFirst).status, 'failed');
+});
+
+// Note on test teeth: TIMED_OUT is the only state in this loop where the
+// rank-0 promotion actually flips the tie's outcome pre- vs. post-#1688 --
+// ACTION_REQUIRED/ERROR/STALE/STARTUP_FAILURE already happened to win a
+// same-instant tie against every SUCCESS-family state pre-fix, purely by
+// lexicographic accident (each starts with a letter earlier than 'S'/'N').
+// This loop still asserts all five deliberately, as a regression guard
+// against a future SUCCESS-family addition ever breaking that alphabetical
+// happenstance (matching the equivalent ACTION_REQUIRED comment in
+// tests/ci-wait-state.test.mts); the "sole, non-tied" test below is what
+// actually exercises the classifyCiChecks vocabulary-widening fix for the
+// four non-TIMED_OUT states.
+test('classifyCiChecks: a same-instant tie against SUCCESS now reports failed for every newly-ranked failure-family state', () => {
+  const tiedAt = '2026-07-17T16:00:06Z';
+  for (const failureState of [
+    'TIMED_OUT',
+    'ACTION_REQUIRED',
+    'STARTUP_FAILURE',
+    'STALE',
+    'ERROR',
+  ]) {
+    const failureFirst = [
+      { name: 'gated', state: failureState, completedAt: tiedAt },
+      { name: 'gated', state: 'SUCCESS', completedAt: tiedAt },
+    ];
+    const successFirst = [
+      { name: 'gated', state: 'SUCCESS', completedAt: tiedAt },
+      { name: 'gated', state: failureState, completedAt: tiedAt },
+    ];
+    assert.equal(
+      classifyCiChecks(failureFirst).status,
+      'failed',
+      `expected a same-instant ${failureState} vs SUCCESS tie to report failed (failure-first order)`,
+    );
+    assert.equal(
+      classifyCiChecks(successFirst).status,
+      'failed',
+      `expected a same-instant ${failureState} vs SUCCESS tie to report failed (success-first order)`,
+    );
+  }
+});
+
+test('classifyCiChecks: a sole, non-tied failure-family conclusion classifies as failed, not unknown', () => {
+  // Distinct from the tie-break fix above: even with only one instance (no
+  // competing SUCCESS at all), TIMED_OUT/ACTION_REQUIRED/STARTUP_FAILURE/
+  // STALE/ERROR previously fell into 'unknown' because only the literal
+  // 'FAILURE' string matched classifyCiChecks's `failed` filter -- the
+  // "vocabulary drift" #1688 also fixes, independent of the tie-break path.
+  for (const failureState of [
+    'TIMED_OUT',
+    'ACTION_REQUIRED',
+    'STARTUP_FAILURE',
+    'STALE',
+    'ERROR',
+  ]) {
+    const checks = [
+      {
+        name: 'gated',
+        state: failureState,
+        completedAt: '2026-07-17T16:00:06Z',
+      },
+    ];
+    assert.equal(
+      classifyCiChecks(checks).status,
+      'failed',
+      `expected a sole ${failureState} conclusion to classify as failed`,
+    );
+  }
+});
+
+test('classifyCiChecks: CANCELLED alone still classifies as unknown, not failed (deliberate carve-out, unchanged)', () => {
+  // CANCELLED is deliberately excluded from CI_FAILURE_CONCLUSION_STATES: a
+  // cancelled run reached no real verdict, unlike the concrete failure
+  // conclusions above. This guards the existing `ciMixed` fixture behavior
+  // (see "classifies CI check states for advisory wait decisions" above)
+  // against a future over-broad widening.
+  const checks = [
+    { name: 'gated', state: 'CANCELLED', completedAt: '2026-07-17T16:00:06Z' },
+  ];
+  assert.equal(classifyCiChecks(checks).status, 'unknown');
+});
+
 test('classifyCiChecks: a same-instant tie between two non-failure/non-cancelled states is deterministic regardless of input order', () => {
   // PR review finding: the reducer previously kept whichever instance
   // was listed first for any tie not involving FAILURE or CANCELLED

--- a/tests/ci-wait-state.test.mts
+++ b/tests/ci-wait-state.test.mts
@@ -565,13 +565,18 @@ test('required-checks rollup: a same-instant literal FAILURE vs SUCCESS tie stil
 // same instances)". Feeds identical {name, state, completedAt} check
 // instances into both classifyCiChecks (protocol-helpers.mts) and
 // buildCiWaitStateSummary (this file) and asserts both report a failing
-// outcome for every genuine failure-family conclusion. CANCELLED is fed
-// too, but asserted as the deliberate, documented exception: ci-wait-state
-// still buckets a lone CANCELLED as failing for wait-gate purposes (its
-// own local FAILURE_STATES includes it), while classifyCiChecks
-// deliberately does not (CI_FAILURE_CONCLUSION_STATES excludes it, since a
-// cancelled run reached no real verdict) -- so this pins the carve-out
-// itself as a tested contract instead of only documenting it in prose.
+// outcome for every genuine failure-family conclusion (all six
+// CI_FAILURE_CONCLUSION_STATES members: FAILURE, TIMED_OUT,
+// ACTION_REQUIRED, STARTUP_FAILURE, STALE via the shared loop below, and
+// ERROR via its own StatusContext-shaped assertion after the loop, since
+// ERROR is StatusContext-only and the loop's CheckRun fixture cannot
+// exercise it). CANCELLED is fed too, but asserted as the deliberate,
+// documented exception: ci-wait-state still buckets a lone CANCELLED as
+// failing for wait-gate purposes (its own local FAILURE_STATES includes
+// it), while classifyCiChecks deliberately does not
+// (CI_FAILURE_CONCLUSION_STATES excludes it, since a cancelled run reached
+// no real verdict) -- so this pins the carve-out itself as a tested
+// contract instead of only documenting it in prose.
 test('classifyCiChecks and ci-wait-state agree on the failure-family vocabulary (fed the same instances)', () => {
   const completedAt = '2026-07-17T16:00:06Z';
   for (const failureState of [
@@ -642,6 +647,45 @@ test('classifyCiChecks and ci-wait-state agree on the failure-family vocabulary 
     'ci-wait-state deliberately still buckets a sole CANCELLED as failing',
   );
   assert.equal(waitCancelled.requiredChecks.status, 'failing');
+
+  // ERROR: StatusContext-only (a CheckRun conclusion never reports it), so
+  // it needs its own assertion outside the loop above -- the loop's
+  // checkRun() fixture always builds a CheckRun-shaped entry (via
+  // `conclusion`), which never exercises ci-wait-state's StatusContext
+  // branch (`normalizeCheckEntry`'s `__typename === 'StatusContext'` path;
+  // see the "a same-instant StatusContext ERROR..." test above). Copilot
+  // review, PR #1735: the loop originally omitted ERROR from the
+  // cross-module agreement claim entirely.
+  const classifyError = classifyCiChecks([
+    { name: 'gated', state: 'ERROR', completedAt },
+  ]);
+  assert.equal(
+    classifyError.status,
+    'failed',
+    'expected classifyCiChecks to bucket a sole ERROR as failed',
+  );
+
+  const waitError = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [
+        {
+          __typename: 'StatusContext',
+          context: 'gated',
+          state: 'ERROR',
+          targetUrl: '',
+          completedAt,
+        },
+      ],
+    },
+    { requiredCheckNames: ['gated'] },
+  );
+  assert.equal(
+    waitError.requiredChecks.anyRequiredFailing,
+    true,
+    'expected ci-wait-state to bucket a sole StatusContext ERROR as failing',
+  );
+  assert.equal(waitError.requiredChecks.status, 'failing');
 });
 
 test('required-checks rollup: a not-yet-generated required check reports missing, not vacuously passing', () => {

--- a/tests/ci-wait-state.test.mts
+++ b/tests/ci-wait-state.test.mts
@@ -6,6 +6,7 @@ import {
   parseArgs,
   selectLatestCheckEntry,
 } from '../src/scripts/ci-wait-state.mts';
+import { classifyCiChecks } from '../src/scripts/protocol-helpers.mts';
 
 // --- #1450: migration onto the shared cli-args.mts wrapper -----------------
 
@@ -257,16 +258,20 @@ test('required-checks rollup: the PR #1434 real-world shape (2 cancelled, 1 fail
   assert.equal(summary.requiredChecks.status, 'success');
 });
 
-// #1504: ciStateTieRank (protocol-helpers.mts) special-cases only the two
-// literal strings 'FAILURE' and 'CANCELLED'; this file's own wider
-// FAILURE_STATES vocabulary (TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE,
-// STALE, ERROR) fell into the shared tie-break's generic rank-1 bucket, so a
-// same-instant completedAt tie against a success-family state resolved by
-// raw lexicographic comparison instead of "the failure should win". These
-// tests deliberately tie every pair at the identical completedAt to exercise
-// that same-instant fallback specifically, unlike the #1478 tests above
-// (which use strictly increasing timestamps to exercise latest-completedAt
-// selection instead).
+// #1504: at the time, ciStateTieRank (protocol-helpers.mts) special-cased
+// only the two literal strings 'FAILURE' and 'CANCELLED'; this file's own
+// wider FAILURE_STATES vocabulary (TIMED_OUT, ACTION_REQUIRED,
+// STARTUP_FAILURE, STALE, ERROR) fell into the shared tie-break's generic
+// rank-1 bucket, so a same-instant completedAt tie against a success-family
+// state resolved by raw lexicographic comparison instead of "the failure
+// should win". #1688 closed that shared corner: ciStateTieRank now ranks
+// every CI_FAILURE_CONCLUSION_STATES member (which FAILURE_STATES above is
+// derived from) at 0 directly, so these tests -- originally written to pin
+// the #1504 local-only workaround -- now exercise the shared fix instead and
+// still pass unchanged. These tests deliberately tie every pair at the
+// identical completedAt to exercise that same-instant fallback specifically,
+// unlike the #1478 tests above (which use strictly increasing timestamps to
+// exercise latest-completedAt selection instead).
 test('required-checks rollup: a same-instant TIMED_OUT vs success-family tie still reports failing', () => {
   for (const successConclusion of [
     'SUCCESS',
@@ -444,16 +449,21 @@ test('required-checks rollup: a same-instant StatusContext ERROR vs (CheckRun) s
 });
 
 test('selectLatestCheckEntry: a same-instant tie between two distinct FAILURE_STATES members resolves deterministically regardless of input order', () => {
-  // Copilot review, PR #1530: tieBreakState() normalizes every failure-
-  // bucketed entry to the same literal 'FAILURE' for tie-break purposes,
-  // so two *different* raw failure states (e.g. TIMED_OUT and
-  // STARTUP_FAILURE) now tie on both completedAt and normalized state.
-  // selectLatestCheckEntry sorts the group by the original entry.state
-  // before reducing so this still resolves to a fixed winner (the
-  // lexicographically smallest raw state, matching this tie-break's
-  // pre-#1504 argmin-by-value behavior for two non-'FAILURE' failure
-  // states) regardless of which order the two instances arrive in. The
-  // winning instance's identity is not observable through
+  // Originally added for Copilot review, PR #1530, when selectLatestCheckEntry
+  // still normalized every failure-bucketed entry to the same literal
+  // 'FAILURE' string before comparing (tieBreakState(), removed by #1688):
+  // two *different* raw failure states (e.g. TIMED_OUT and STARTUP_FAILURE)
+  // tied on both completedAt and normalized state, so an explicit pre-sort
+  // was needed to keep the winner deterministic regardless of input order.
+  // #1688 widened the shared `ciStateTieRank` itself to rank every
+  // CI_FAILURE_CONCLUSION_STATES member at 0 directly, so selectLatestCheckEntry
+  // no longer normalizes or pre-sorts at all -- it compares each entry's own
+  // real `state`. The two raw states below now tie at rank 0 without ever
+  // colliding on a shared normalized string, so the existing residual
+  // fallback (lexicographically smallest raw state wins, matching this
+  // tie-break's pre-#1504 argmin-by-value behavior) is naturally
+  // order-independent again, and this test still pins that same fixed
+  // winner. The winning instance's identity is not observable through
   // buildCiWaitStateSummary's public shape (see the note on the ERROR
   // test above), so this calls the exported reducer directly instead.
   const timedOut = {
@@ -548,6 +558,90 @@ test('required-checks rollup: a same-instant literal FAILURE vs SUCCESS tie stil
   assert.equal(summary.requiredChecks.anyRequiredFailing, true);
   assert.equal(summary.requiredChecks.allRequiredPassing, false);
   assert.equal(summary.requiredChecks.status, 'failing');
+});
+
+// #1688 acceptance criterion: "ci-wait-state and classifyCiChecks agree on
+// the failure-family vocabulary (asserted by a test that feeds both the
+// same instances)". Feeds identical {name, state, completedAt} check
+// instances into both classifyCiChecks (protocol-helpers.mts) and
+// buildCiWaitStateSummary (this file) and asserts both report a failing
+// outcome for every genuine failure-family conclusion. CANCELLED is fed
+// too, but asserted as the deliberate, documented exception: ci-wait-state
+// still buckets a lone CANCELLED as failing for wait-gate purposes (its
+// own local FAILURE_STATES includes it), while classifyCiChecks
+// deliberately does not (CI_FAILURE_CONCLUSION_STATES excludes it, since a
+// cancelled run reached no real verdict) -- so this pins the carve-out
+// itself as a tested contract instead of only documenting it in prose.
+test('classifyCiChecks and ci-wait-state agree on the failure-family vocabulary (fed the same instances)', () => {
+  const completedAt = '2026-07-17T16:00:06Z';
+  for (const failureState of [
+    'FAILURE',
+    'TIMED_OUT',
+    'ACTION_REQUIRED',
+    'STARTUP_FAILURE',
+    'STALE',
+  ]) {
+    const classifyResult = classifyCiChecks([
+      { name: 'gated', state: failureState, completedAt },
+    ]);
+    assert.equal(
+      classifyResult.status,
+      'failed',
+      `expected classifyCiChecks to bucket a sole ${failureState} as failed`,
+    );
+
+    const waitSummary = buildCiWaitStateSummary(
+      {
+        headRefOid: HEAD_SHA,
+        statusCheckRollup: [
+          checkRun({
+            name: 'gated',
+            workflowName: 'ci',
+            conclusion: failureState,
+            completedAt,
+          }),
+        ],
+      },
+      { requiredCheckNames: ['gated'] },
+    );
+    assert.equal(
+      waitSummary.requiredChecks.anyRequiredFailing,
+      true,
+      `expected ci-wait-state to bucket a sole ${failureState} as failing`,
+    );
+    assert.equal(waitSummary.requiredChecks.status, 'failing');
+  }
+
+  // CANCELLED: deliberate divergence, not agreement -- pin both sides.
+  const classifyCancelled = classifyCiChecks([
+    { name: 'gated', state: 'CANCELLED', completedAt },
+  ]);
+  assert.equal(
+    classifyCancelled.status,
+    'unknown',
+    'classifyCiChecks deliberately does not bucket a sole CANCELLED as failed',
+  );
+
+  const waitCancelled = buildCiWaitStateSummary(
+    {
+      headRefOid: HEAD_SHA,
+      statusCheckRollup: [
+        checkRun({
+          name: 'gated',
+          workflowName: 'ci',
+          conclusion: 'CANCELLED',
+          completedAt,
+        }),
+      ],
+    },
+    { requiredCheckNames: ['gated'] },
+  );
+  assert.equal(
+    waitCancelled.requiredChecks.anyRequiredFailing,
+    true,
+    'ci-wait-state deliberately still buckets a sole CANCELLED as failing',
+  );
+  assert.equal(waitCancelled.requiredChecks.status, 'failing');
 });
 
 test('required-checks rollup: a not-yet-generated required check reports missing, not vacuously passing', () => {


### PR DESCRIPTION
# Summary

`ciStateTieRank` (`protocol-helpers.mts`) previously ranked only the
literal `'FAILURE'` string at rank 0 (always wins a same-`completedAt`
tie); `CANCELLED` stayed at rank 2; every other failure-family
conclusion (`TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE`,
`ERROR`) shared the generic rank-1 bucket with `SUCCESS`, so a
same-second tie could resolve by lexicographic string luck instead of
"the failure should win" — the reproduction in #1504
(`'SUCCESS' < 'TIMED_OUT'`). `#1504` fixed the fallout **locally only**
in `ci-wait-state.mts`, explicitly leaving the shared `ciStateTieRank`
out of scope. `classifyCiChecks`'s `failed` bucket had a related
vocabulary drift: only literal `FAILURE` matched, so even a *lone*
(non-tied) `TIMED_OUT`/etc. classified as `'unknown'`, not `'failed'`.

This PR:

1. Adds an exported `CI_FAILURE_CONCLUSION_STATES` (6 members: `FAILURE`,
   `TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE`, `ERROR`)
   in `protocol-helpers.mts` and widens both `ciStateTieRank` (rank 0)
   and `classifyCiChecks`'s `failed` filter to use it.
2. `CANCELLED` is **deliberately excluded** from that set: a cancelled
   run reached no real verdict at all, unlike the six concrete failure
   conclusions above, and two pre-existing anti-regression tests titled
   `(unchanged)` pin a same-instant `CANCELLED` vs `SUCCESS` tie
   resolving to success — that behavior is untouched.
3. `ci-wait-state.mts`'s own local `FAILURE_STATES` (used by its
   required-checks bucketing) is now **derived from**
   `CI_FAILURE_CONCLUSION_STATES` plus `CANCELLED`, instead of an
   independently hand-maintained literal — the exact drift mechanism
   that let #1504's local fix diverge from the shared tie-break in the
   first place.
4. `ci-wait-state.mts`'s local `tieBreakState()` normalization and the
   pre-sort inside `selectLatestCheckEntry` (added for #1504 to work
   around `ciStateTieRank` only recognizing the literal `'FAILURE'`
   string) are removed as redundant, now that the shared function ranks
   the wider vocabulary directly.
5. Regenerated `scripts/protocol-helpers.mjs` / `scripts/ci-wait-state.mjs`
   via `pnpm run build`.

Fixes #1688.

## Linked issue

Fixes #1688

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

**Why `CANCELLED` stays excluded** (a deliberate scope decision, not an
oversight): the issue's own vocabulary-drift paragraph names exactly
four states (`TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`,
`STALE`) and never `CANCELLED`. `CANCELLED` means "reached no verdict,"
distinct from a genuine failure conclusion, and this is pinned by two
existing tests (`tests/advisory-wait.test.mts`, `tests/ci-wait-state.test.mts`)
explicitly titled `(unchanged)`.

**No F2/F3 merge-gate behavior change beyond the intended fix**: traced
`summarizeRequiredChecks` (F2's CI-gate input) and
`resolvePresentRunConclusion` (the no-required-checks fallback) by hand
— both already treat `'unknown'` and `'failed'` identically as
not-passing (`resolvePresentRunConclusion` collapses both into
`'some-failing'`; F2 only checks `status === 'success'`). So widening
`classifyCiChecks`'s `failed` bucket only sharpens which diagnostic
bucket a check lands in; it does not change any existing pass/fail gate
outcome.

**Existing tests intentionally left unchanged, confirmed by running
them, not just by reasoning**: the full `#1504` regression suite in
`tests/ci-wait-state.test.mts` (same-instant `TIMED_OUT`/
`STARTUP_FAILURE`/`STALE`/`ACTION_REQUIRED`/`ERROR` vs. success-family
ties, plus the `selectLatestCheckEntry` cross-state determinism test)
passes byte-for-byte unchanged against the new implementation — no
expectations needed updating.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`npx biome check`, `npx dprint check`, `npx markdownlint-cli2`, `npx cspell lint` — all clean)
- [x] `pnpm test` (2697/2697 pass)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passes, only pre-existing unrelated warnings)
- [x] `pnpm run build:check` (generated `scripts/*.mjs` match source, no drift)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — diagnostic/tie-break precision fix only, no gate behavior change; see Background above)
- [x] Context budget impact reviewed (no instruction files touched)
