### PR TITLE
fix(discover): require a per-session-unique desync token

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -529,10 +529,12 @@ the band ordered by ascending issue number.
 `{agent-id}` from `idd-overview-core.instructions.md` alone is **not** a
 compliant token. Use the session-suffixed `{agent-id}` (e.g.,
 `copilot-8122ca35`) when this session already appends one; otherwise
-generate a session-local token once at Discover entry — a short random
-or timestamp-derived string is sufficient — and reuse that same value
-for every A4 Step 2 selection this session makes, including re-entry
-after a collision. See
+generate a session-local token once at Discover entry — it must carry
+enough entropy to stay distinct across sessions launched at the same
+moment (a random or UUID-derived value; a bare timestamp alone is not
+sufficient, since same-second concurrent launches would still collide)
+— and reuse that same value for every A4 Step 2 selection this session
+makes, including re-entry after a collision. See
 [rationale](../../docs/idd-design-rationale.md#a4-step-2--rationale-concurrent-selection-desync)
 for why a bare shared token defeats this mechanism. Compute the index
 with the CLI instead of hand-tracing `scripts/policy-helpers.mjs`:

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -523,9 +523,19 @@ for how the remaining tie-breakers below apply after this rule.
 highest-score tie band has more than one eligible candidate, pick the
 band entry at index `selectDesyncedIndex(session-token, band-size)`
 instead of index 0 — a pure `hash(session-token) mod band-size` over
-the band ordered by ascending issue number, `session-token` being this
-session's `{agent-id}`. Compute it with the CLI instead of hand-tracing
-`scripts/policy-helpers.mjs`:
+the band ordered by ascending issue number.
+
+`session-token` **must be per-session-unique**: the bare, session-shared
+`{agent-id}` from `idd-overview-core.instructions.md` alone is **not** a
+compliant token. Use the session-suffixed `{agent-id}` (e.g.,
+`copilot-8122ca35`) when this session already appends one; otherwise
+generate a session-local token once at Discover entry — a short random
+or timestamp-derived string is sufficient — and reuse that same value
+for every A4 Step 2 selection this session makes, including re-entry
+after a collision. See
+[rationale](../../docs/idd-design-rationale.md#a4-step-2--rationale-concurrent-selection-desync)
+for why a bare shared token defeats this mechanism. Compute the index
+with the CLI instead of hand-tracing `scripts/policy-helpers.mjs`:
 
 ```sh
 # source repo / vendored-node

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -123,9 +123,20 @@ then re-collided on the next lowest number.
 The opt-in `discover.selectionDesync: session-offset` knob adds a
 **proactive** desync: within a single highest-score tie band it picks the
 entry at `selectDesyncedIndex(session-token, band-size)` (a pure
-`hash(session-token) mod band-size`, the token being the selection-time
-`{agent-id}`) instead of always index 0, spreading concurrent sessions
-across _different_ eligible issues up front.
+`hash(session-token) mod band-size`) instead of always index 0, spreading
+concurrent sessions across _different_ eligible issues up front.
+
+`session-token` must be a per-session-unique value, never the bare,
+session-shared `{agent-id}` alone: `idd-overview-core.instructions.md`
+defines `{agent-id}` as shared across concurrent sessions of the same
+agent type, with a unique session suffix only recommended, not required.
+Sessions that follow that core definition literally and omit the suffix
+all hash to the identical index and converge on the same issue — the
+exact collision this mechanism exists to prevent, and the same failure
+mode as the 3-way race above. `idd-discover.instructions.md` closes the
+gap by requiring the session-suffixed `{agent-id}` or, when the agent-id
+carries no unique component, a session-local fallback token generated
+once at Discover entry and reused for the session.
 
 It is off by default and reorders **only within** a same-score tie band so
 the documented score-then-lowest-number ranking is the unchanged single-

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -138,8 +138,8 @@ identified it by inspection of the two files' definitions, not from a
 collision that already happened. `idd-discover.instructions.md` closes
 the gap by requiring the session-suffixed `{agent-id}` or, when the
 agent-id carries no unique component, a session-local fallback token
-generated
-once at Discover entry and reused for the session — with enough entropy
+generated once at Discover entry and reused for the session — with
+enough entropy
 (random or UUID-derived) to stay distinct across sessions launched at
 the same moment, since a bare timestamp alone would not.
 

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -132,11 +132,16 @@ defines `{agent-id}` as shared across concurrent sessions of the same
 agent type, with a unique session suffix only recommended, not required.
 Sessions that follow that core definition literally and omit the suffix
 all hash to the identical index and converge on the same issue — the
-exact collision this mechanism exists to prevent, and the same failure
-mode as the 3-way race above. `idd-discover.instructions.md` closes the
-gap by requiring the session-suffixed `{agent-id}` or, when the agent-id
-carries no unique component, a session-local fallback token generated
-once at Discover entry and reused for the session.
+same converge-and-collide shape as the 3-way race above. This specific
+bare-agent-id collapse is preventive; no observed incident yet — #1694
+identified it by inspection of the two files' definitions, not from a
+collision that already happened. `idd-discover.instructions.md` closes
+the gap by requiring the session-suffixed `{agent-id}` or, when the
+agent-id carries no unique component, a session-local fallback token
+generated
+once at Discover entry and reused for the session — with enough entropy
+(random or UUID-derived) to stay distinct across sessions launched at
+the same moment, since a bare timestamp alone would not.
 
 It is off by default and reorders **only within** a same-score tie band so
 the documented score-then-lowest-number ranking is the unchanged single-

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -532,10 +532,12 @@ the band ordered by ascending issue number.
 `{agent-id}` from `idd-overview-core.instructions.md` alone is **not** a
 compliant token. Use the session-suffixed `{agent-id}` (e.g.,
 `copilot-8122ca35`) when this session already appends one; otherwise
-generate a session-local token once at Discover entry — a short random
-or timestamp-derived string is sufficient — and reuse that same value
-for every A4 Step 2 selection this session makes, including re-entry
-after a collision. See
+generate a session-local token once at Discover entry — it must carry
+enough entropy to stay distinct across sessions launched at the same
+moment (a random or UUID-derived value; a bare timestamp alone is not
+sufficient, since same-second concurrent launches would still collide)
+— and reuse that same value for every A4 Step 2 selection this session
+makes, including re-entry after a collision. See
 [rationale](../../docs/idd-design-rationale.md#a4-step-2--rationale-concurrent-selection-desync)
 for why a bare shared token defeats this mechanism. Compute the index
 with the CLI instead of hand-tracing `scripts/policy-helpers.mjs`:

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -526,9 +526,19 @@ for how the remaining tie-breakers below apply after this rule.
 highest-score tie band has more than one eligible candidate, pick the
 band entry at index `selectDesyncedIndex(session-token, band-size)`
 instead of index 0 — a pure `hash(session-token) mod band-size` over
-the band ordered by ascending issue number, `session-token` being this
-session's `{agent-id}`. Compute it with the CLI instead of hand-tracing
-`scripts/policy-helpers.mjs`:
+the band ordered by ascending issue number.
+
+`session-token` **must be per-session-unique**: the bare, session-shared
+`{agent-id}` from `idd-overview-core.instructions.md` alone is **not** a
+compliant token. Use the session-suffixed `{agent-id}` (e.g.,
+`copilot-8122ca35`) when this session already appends one; otherwise
+generate a session-local token once at Discover entry — a short random
+or timestamp-derived string is sufficient — and reuse that same value
+for every A4 Step 2 selection this session makes, including re-entry
+after a collision. See
+[rationale](../../docs/idd-design-rationale.md#a4-step-2--rationale-concurrent-selection-desync)
+for why a bare shared token defeats this mechanism. Compute the index
+with the CLI instead of hand-tracing `scripts/policy-helpers.mjs`:
 
 ```sh
 # source repo / vendored-node

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -124,9 +124,20 @@ then re-collided on the next lowest number.
 The opt-in `discover.selectionDesync: session-offset` knob adds a
 **proactive** desync: within a single highest-score tie band it picks the
 entry at `selectDesyncedIndex(session-token, band-size)` (a pure
-`hash(session-token) mod band-size`, the token being the selection-time
-`{agent-id}`) instead of always index 0, spreading concurrent sessions
-across _different_ eligible issues up front.
+`hash(session-token) mod band-size`) instead of always index 0, spreading
+concurrent sessions across _different_ eligible issues up front.
+
+`session-token` must be a per-session-unique value, never the bare,
+session-shared `{agent-id}` alone: `idd-overview-core.instructions.md`
+defines `{agent-id}` as shared across concurrent sessions of the same
+agent type, with a unique session suffix only recommended, not required.
+Sessions that follow that core definition literally and omit the suffix
+all hash to the identical index and converge on the same issue — the
+exact collision this mechanism exists to prevent, and the same failure
+mode as the 3-way race above. `idd-discover.instructions.md` closes the
+gap by requiring the session-suffixed `{agent-id}` or, when the agent-id
+carries no unique component, a session-local fallback token generated
+once at Discover entry and reused for the session.
 
 It is off by default and reorders **only within** a same-score tie band so
 the documented score-then-lowest-number ranking is the unchanged single-

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -134,13 +134,13 @@ agent type, with a unique session suffix only recommended, not required.
 Sessions that follow that core definition literally and omit the suffix
 all hash to the identical index and converge on the same issue — the
 same converge-and-collide shape as the 3-way race above. This specific
-bare-agent-id collapse is preventive; no observed incident yet — #1694
-identified it by inspection of the two files' definitions, not from a
-collision that already happened. `idd-discover.instructions.md` closes
-the gap by requiring the session-suffixed `{agent-id}` or, when the
-agent-id carries no unique component, a session-local fallback token
-generated
-once at Discover entry and reused for the session — with enough entropy
+bare-agent-id collapse is preventive; no observed incident yet —
+kurone-kito/idd-skill#1694 identified it by inspection of the two
+files' definitions, not from a collision that already happened.
+`idd-discover.instructions.md` closes the gap by requiring the
+session-suffixed `{agent-id}` or, when the agent-id carries no unique
+component, a session-local fallback token generated once at Discover
+entry and reused for the session — with enough entropy
 (random or UUID-derived) to stay distinct across sessions launched at
 the same moment, since a bare timestamp alone would not.
 

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -133,11 +133,16 @@ defines `{agent-id}` as shared across concurrent sessions of the same
 agent type, with a unique session suffix only recommended, not required.
 Sessions that follow that core definition literally and omit the suffix
 all hash to the identical index and converge on the same issue — the
-exact collision this mechanism exists to prevent, and the same failure
-mode as the 3-way race above. `idd-discover.instructions.md` closes the
-gap by requiring the session-suffixed `{agent-id}` or, when the agent-id
-carries no unique component, a session-local fallback token generated
-once at Discover entry and reused for the session.
+same converge-and-collide shape as the 3-way race above. This specific
+bare-agent-id collapse is preventive; no observed incident yet — #1694
+identified it by inspection of the two files' definitions, not from a
+collision that already happened. `idd-discover.instructions.md` closes
+the gap by requiring the session-suffixed `{agent-id}` or, when the
+agent-id carries no unique component, a session-local fallback token
+generated
+once at Discover entry and reused for the session — with enough entropy
+(random or UUID-derived) to stay distinct across sessions launched at
+the same moment, since a bare timestamp alone would not.
 
 It is off by default and reorders **only within** a same-score tie band so
 the documented score-then-lowest-number ranking is the unchanged single-


### PR DESCRIPTION
# Summary

`discover.selectionDesync: session-offset` (#1331, dogfooded on this repo)
spreads concurrent-session A4 Step 2 candidate selection across a
same-score tie band via `hash(session-token) mod band-size`, with
`session-token` documented as "this session's `{agent-id}`". But
`idd-overview-core.instructions.md` defines `{agent-id}` as shared across
concurrent sessions of the same agent type, with a unique session suffix
only recommended, not required. Sessions that follow that core
definition literally all hash to the identical band index and converge
on the same issue -- exactly the collision this mechanism exists to
prevent, and the same failure mode the design rationale already cites
(a 3-way claim race).

This PR requires `session-token` to be per-session-unique in the desync
rule: use the session-suffixed `{agent-id}` when this session already
appends one, otherwise generate a session-local fallback token once at
Discover entry and reuse it for the whole session. The bare, shared
`{agent-id}` alone is no longer a compliant token.

Docs/instructions only -- no `.mts`/`.mjs` change. The CLI helper
(`select-desynced-index.mjs` / `selectDesyncedIndex`) already accepts a
generic `session-token` string and has no way to verify whether a
caller-supplied token is actually session-unique, so this requirement
can only be enforced at the spec/prose level, not in code.

## Linked issue

Closes #1694

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`idd-overview-core.instructions.md`'s `{agent-id}` definition is
intentionally left unchanged -- narrowing it there would ripple into
claim-marker semantics well beyond this desync mechanism. The fix is
scoped to the desync rule's own token requirement instead.

`docs/idd-design-rationale.md`'s "A4 Step 2 -- Rationale:
concurrent-selection desync" section is updated to state the same
per-session-unique requirement and explain why a bare shared token
degenerates the mechanism, so the rule and its rationale agree.
`idd-template/.github/instructions/idd-discover.instructions.md` and
`idd-template/docs/idd-design-rationale.md` carry the matching edits in
the same change (the discover-instructions and rationale-doc sync pairs
are `structure`-mode in `audit/sync-manifest.json` -- validated by
heading-signature equality, not byte-copied by `sync-docs.mjs`, so both
the `.github/instructions/` and `idd-template/` copies needed direct,
manual edits; `sync-docs.mjs --apply` was still run afterward and
reported no drift on the exact-mode pairs).

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (via fix-validate / pre-push-validate: biome, dprint,
      markdownlint-cli2, cspell)
- [x] `pnpm test` (targeted: `tests/select-desynced-index.test.mts`
      41/41, `tests/consistency.test.mts` 31/31)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`node scripts/sync-docs.mjs --apply`;
      reports "All mirrored artifacts are up to date")
- [x] `node scripts/idd-doctor.mjs` (passed with 4 pre-existing,
      unrelated warnings: missing non-default profile READMEs,
      husky hooksPath, release-tag drift, branch protection
      unreadable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none -- docs/instructions only)
- [x] Context budget impact reviewed (`bundle-discovery` byte budget:
      ~95.1 KB / 104 KB limit, ~8.9 KB headroom remaining after this
      change; the four pre-existing lite-bundle 95%+ notices are
      unchanged from baseline since none include the discover file)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that concurrent-selection sessions require a unique session token.
  * Added guidance to use a session-specific agent ID or a high-entropy generated token.
  * Documented token reuse across selections and collision re-entry.
  * Added rationale explaining why shared tokens can undermine desynchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->