### PR TITLE
docs(copilot-instructions): fix unrecorded-merge-policy contradiction

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -100,15 +100,16 @@ dogfooding policy. The setting applies only to `kurone-kito/idd-skill`
 and does not change the exported template default for adopter
 repositories.
 
-An IDD session may continue through F3 merge execution only when the
-resolved merge policy is `fully_autonomous_merge` and the normal
-claim, freshness, CI, advisory, review, and unresolved-thread gates
-pass. A missing recorded policy resolves to `fully_autonomous_merge`
-(the distributed default); a recorded `human_merge`,
-`separate_merge_agent` without a qualifying session, or an
-unrecognized value instead stops at the F3 handoff gate for a
-hand-off or hold — see `idd-merge-handoff.instructions.md` for the
-full per-policy routing.
+F2.5 (`idd-merge-handoff.instructions.md`) resolves the recorded
+merge policy before F3 merge execution: a missing recorded policy
+resolves to `fully_autonomous_merge` (the distributed default) and
+continues; `human_merge` always stops for a human handoff;
+`separate_merge_agent` continues only when the current session is
+the designated, qualifying merge-capable actor, and otherwise stops;
+an unrecognized recorded value stops with a maintainer hold. An IDD
+session may continue through F3 merge execution only after F2.5
+clears it this way and the normal claim, freshness, CI, advisory,
+review, and unresolved-thread gates pass.
 
 ## Local discover policy
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -104,9 +104,10 @@ F2.5 (`idd-merge-handoff.instructions.md`) resolves the recorded
 merge policy before F3 merge execution: a missing recorded policy
 resolves to `fully_autonomous_merge` (the distributed default) and
 continues; `human_merge` always stops for a human handoff;
-`separate_merge_agent` continues only when the current session is
-the designated, qualifying merge-capable actor, and otherwise stops;
-an unrecognized recorded value stops with a maintainer hold. An IDD
+`separate_merge_agent` continues only when repository documentation
+designates the current session as the merge-capable actor and its
+documented resume condition is satisfied, and otherwise stops; an
+unrecognized recorded value stops with a maintainer hold. An IDD
 session may continue through F3 merge execution only after F2.5
 clears it this way and the normal claim, freshness, CI, advisory,
 review, and unresolved-thread gates pass.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -102,8 +102,10 @@ repositories.
 
 An IDD session may continue through F3 merge execution only after the
 normal claim, freshness, CI, advisory, review, and unresolved-thread
-gates pass. Repositories without a recorded `fully_autonomous_merge`
-policy still stop at the F3 handoff gate.
+gates pass. A repository with no recorded merge policy is treated as
+`fully_autonomous_merge` (the distributed default); only an unknown
+_recorded_ policy value stops at the F3 handoff gate with a hold
+comment requesting a maintainer decision.
 
 ## Local discover policy
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -100,12 +100,15 @@ dogfooding policy. The setting applies only to `kurone-kito/idd-skill`
 and does not change the exported template default for adopter
 repositories.
 
-An IDD session may continue through F3 merge execution only after the
-normal claim, freshness, CI, advisory, review, and unresolved-thread
-gates pass. A repository with no recorded merge policy is treated as
-`fully_autonomous_merge` (the distributed default); only an unknown
-_recorded_ policy value stops at the F3 handoff gate with a hold
-comment requesting a maintainer decision.
+An IDD session may continue through F3 merge execution only when the
+resolved merge policy is `fully_autonomous_merge` and the normal
+claim, freshness, CI, advisory, review, and unresolved-thread gates
+pass. A missing recorded policy resolves to `fully_autonomous_merge`
+(the distributed default); a recorded `human_merge`,
+`separate_merge_agent` without a qualifying session, or an
+unrecognized value instead stops at the F3 handoff gate for a
+hand-off or hold — see `idd-merge-handoff.instructions.md` for the
+full per-policy routing.
 
 ## Local discover policy
 


### PR DESCRIPTION
# Summary

`.github/copilot-instructions.md`'s "Local merge policy" section
claimed repositories without a recorded `fully_autonomous_merge`
policy still stop at the F3 handoff gate. The phase files say the
opposite: `idd-merge-handoff.instructions.md` and
`idd-merge.instructions.md` both resolve a missing recorded policy to
`fully_autonomous_merge` (the distributed default). The sentence was
written when the exported template default was still `human_merge`
and was never updated after the default flipped, so it reversed the
failure direction of the single most irreversible action in the
pipeline: a reader relying on the documented stop that no longer
exists could get an unattended merge.

This PR rewrites the paragraph to match shipped phase behavior: a
missing recorded policy resolves to `fully_autonomous_merge`; a
recorded `human_merge`, `separate_merge_agent` without a qualifying
session, or an unrecognized value stops at the F3 handoff gate
instead, with a pointer to `idd-merge-handoff.instructions.md` for the
full per-policy routing.

`CLAUDE.md`/`AGENTS.md`/`GEMINI.md` were checked for a copy of the
same stale sentence — none found, so no other file needed an edit.

**Two commits**: the first replaces the stale sentence; the second
fixes an overclaim introduced by the first (self-caught by an
independent C1 critique pass) — the first draft said "only an unknown
recorded policy value stops," which itself understated the phase
files' behavior (a recorded `human_merge` or an unqualified
`separate_merge_agent` also stop). Left as one commit would have
reintroduced a milder version of the same risk this issue exists to
close, so the correction is kept as its own atomic commit rather than
squashed, for an accurate audit trail.

**Out-of-scope alternative** (per the issue's proposal item 3): if a
maintainer instead wants stop-by-default for adopters with no
recorded policy, that would be a phase-file behavior change, not a
documentation fix, and is out of scope for this PR.

## Linked issue

Closes #1695

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Refs: 2026-07-28 fresh-model corpus audit (highest-severity finding
that surfaced this contradiction); flip commit trail visible via
`git log -S "still stop at the F3" -- .github/copilot-instructions.md`.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

(Documentation-only correction of the merge-policy _description_; no
change to the merge-policy phase files' actual behavior.)

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
