### PR TITLE
fix(template): stop marker-prefix leak, document helper delivery

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -60,7 +60,6 @@
       "sourceGlobs": [
         "idd-template/.github/idd/*.json",
         "idd-template/.githooks/*",
-        "idd-template/scripts/*.mjs",
         "idd-template/.github/instructions/idd-*.instructions.md",
         "idd-template/.github/instructions/lite/idd-*.instructions.md",
         "idd-template/docs/idd-*.md",
@@ -78,7 +77,6 @@
         "idd-template/.githooks/_idd-worktree-guard.sh",
         "idd-template/.githooks/pre-commit",
         "idd-template/.githooks/pre-push",
-        "idd-template/scripts/minimize-superseded-markers.mjs",
         "idd-template/.github/instructions/idd-overview-core.instructions.md",
         "idd-template/.github/instructions/idd-overview-appendix.instructions.md",
         "idd-template/.github/instructions/idd-discover.instructions.md",

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -60,6 +60,7 @@
       "sourceGlobs": [
         "idd-template/.github/idd/*.json",
         "idd-template/.githooks/*",
+        "idd-template/scripts/*.mjs",
         "idd-template/.github/instructions/idd-*.instructions.md",
         "idd-template/.github/instructions/lite/idd-*.instructions.md",
         "idd-template/docs/idd-*.md",
@@ -77,6 +78,7 @@
         "idd-template/.githooks/_idd-worktree-guard.sh",
         "idd-template/.githooks/pre-commit",
         "idd-template/.githooks/pre-push",
+        "idd-template/scripts/minimize-superseded-markers.mjs",
         "idd-template/.github/instructions/idd-overview-core.instructions.md",
         "idd-template/.github/instructions/idd-overview-appendix.instructions.md",
         "idd-template/.github/instructions/idd-discover.instructions.md",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,9 +79,9 @@ the loop starts:
 
 For broad requests, use the optional issue-authoring companion to draft
 a roadmap and focused child issues before starting the execution loop.
-Use task-list links to group active roadmap work. Reserve
-`idd-skill-blocked-by` markers for true sequential dependencies on a
-separate roadmap.
+Use task-list links to group active roadmap work. Reserve the
+blocked-by marker (using your configured prefix) for true sequential
+dependencies on a separate roadmap.
 
 When a project has genuine parallel tracks or multi-session coordination
 boundaries, nested roadmap hierarchies let each track close

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -362,6 +362,12 @@ every accepted argument.
 
 You need the following core execution and profile artifact files in the
 target repository. Use whichever method applies to your situation.
+This file list is identical across every helper runtime profile; it does
+not include the `vendored-node` profile's profile-conditional helper
+script bundle (for example `scripts/minimize-superseded-markers.mjs`) —
+see
+[Profile-conditional helper files](docs/onboarding/template-distribution.md#profile-conditional-helper-files-vendored-node)
+for why that bundle is out of scope here and how to get it anyway.
 For `idd-skill` maintainers working on this generated file list and the
 remote-fetch examples, see
 [Template distribution maintainer reference](docs/onboarding/template-distribution.md).
@@ -394,7 +400,6 @@ recording template you will apply in Step 3.
 .githooks/_idd-worktree-guard.sh
 .githooks/pre-commit
 .githooks/pre-push
-scripts/minimize-superseded-markers.mjs
 .github/instructions/idd-overview-core.instructions.md
 .github/instructions/idd-overview-appendix.instructions.md
 .github/instructions/idd-discover.instructions.md
@@ -489,7 +494,6 @@ for FILE in \
   ".githooks/_idd-worktree-guard.sh" \
   ".githooks/pre-commit" \
   ".githooks/pre-push" \
-  "scripts/minimize-superseded-markers.mjs" \
   ".github/instructions/idd-overview-core.instructions.md" \
   ".github/instructions/idd-overview-appendix.instructions.md" \
   ".github/instructions/idd-discover.instructions.md" \
@@ -592,7 +596,6 @@ for FILE in \
   ".githooks/_idd-worktree-guard.sh" \
   ".githooks/pre-commit" \
   ".githooks/pre-push" \
-  "scripts/minimize-superseded-markers.mjs" \
   ".github/instructions/idd-overview-core.instructions.md" \
   ".github/instructions/idd-overview-appendix.instructions.md" \
   ".github/instructions/idd-discover.instructions.md" \

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -394,6 +394,7 @@ recording template you will apply in Step 3.
 .githooks/_idd-worktree-guard.sh
 .githooks/pre-commit
 .githooks/pre-push
+scripts/minimize-superseded-markers.mjs
 .github/instructions/idd-overview-core.instructions.md
 .github/instructions/idd-overview-appendix.instructions.md
 .github/instructions/idd-discover.instructions.md
@@ -488,6 +489,7 @@ for FILE in \
   ".githooks/_idd-worktree-guard.sh" \
   ".githooks/pre-commit" \
   ".githooks/pre-push" \
+  "scripts/minimize-superseded-markers.mjs" \
   ".github/instructions/idd-overview-core.instructions.md" \
   ".github/instructions/idd-overview-appendix.instructions.md" \
   ".github/instructions/idd-discover.instructions.md" \
@@ -590,6 +592,7 @@ for FILE in \
   ".githooks/_idd-worktree-guard.sh" \
   ".githooks/pre-commit" \
   ".githooks/pre-push" \
+  "scripts/minimize-superseded-markers.mjs" \
   ".github/instructions/idd-overview-core.instructions.md" \
   ".github/instructions/idd-overview-appendix.instructions.md" \
   ".github/instructions/idd-discover.instructions.md" \

--- a/idd-template/docs/getting-started.md
+++ b/idd-template/docs/getting-started.md
@@ -79,9 +79,9 @@ the loop starts:
 
 For broad requests, use the optional issue-authoring companion to draft
 a roadmap and focused child issues before starting the execution loop.
-Use task-list links to group active roadmap work. Reserve
-`idd-skill-blocked-by` markers for true sequential dependencies on a
-separate roadmap.
+Use task-list links to group active roadmap work. Reserve the
+blocked-by marker (using your configured prefix) for true sequential
+dependencies on a separate roadmap.
 
 When a project has genuine parallel tracks or multi-session coordination
 boundaries, nested roadmap hierarchies let each track close

--- a/idd-template/docs/onboarding/template-distribution.md
+++ b/idd-template/docs/onboarding/template-distribution.md
@@ -88,6 +88,7 @@ and wants this helper without cloning the repository can fetch the single
 file directly, the same way Option A fetches every other file:
 
 ```sh
+mkdir -p scripts
 curl -fsSL \
   "https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/scripts/minimize-superseded-markers.mjs" \
   -o scripts/minimize-superseded-markers.mjs
@@ -98,8 +99,16 @@ helper) a genuine cross-profile core dependency, resolve the
 core/profile-conditional overlap in `idd-onboard.mts` and
 `helper-runtime-manifest.mts` first — do not add it to
 `idd-template-core-files` while the disjointness invariant above still
-holds; `checkGeneratedBlocks`/`resolveImportFiles` will not catch the
-resulting drift by themselves, so this needs a maintainer decision.
+holds. `node scripts/audit-docs.mjs --check` (which `checkGeneratedBlocks`
+backs) only compares this doc's generated file list against
+`audit/sync-manifest.json`; it has no awareness of the `vendored-node`
+bundle in `helper-runtime-manifest.mts`, so it will not catch the
+overlap. `resolveImportFiles`'s `manifest drift: duplicate target path`
+hard-fail does catch it, but only under `pnpm run lint`'s full test
+suite (`node --test`), which `pre-push-validate` does not run — so a
+change that only satisfies `audit-docs.mjs --check` can still break
+`idd-onboard.mjs`. This needs a maintainer decision, not a mechanical
+file-list edit.
 
 ## Remote fetch examples
 

--- a/idd-template/docs/onboarding/template-distribution.md
+++ b/idd-template/docs/onboarding/template-distribution.md
@@ -57,9 +57,11 @@ requires every adopter to receive them.
 `idd-template/scripts/minimize-superseded-markers.mjs` by the
 `minimize-superseded-markers-helper` syncPair) is invoked from four
 template instruction files, but it is deliberately **not** part of the
-`idd-template-core-files` block or Option A's remote-fetch loops, even
-though every other file those four instruction files reference is core.
-This is intentional, not an oversight:
+`idd-template-core-files` block or Option A's remote-fetch loops — every
+`idd-template/**` doc and instruction file those four instruction files
+reference is core, but a `scripts/*.mjs` helper reference (this one
+included) is not, since every helper script is `vendored-node`
+profile-conditional. This is intentional, not an oversight:
 
 - `idd-onboard.mjs`'s `resolveImportFiles` hard-fails with a "manifest
   drift: duplicate target path" error if a file's target path appears in

--- a/idd-template/docs/onboarding/template-distribution.md
+++ b/idd-template/docs/onboarding/template-distribution.md
@@ -86,10 +86,9 @@ copy (copying the `idd-template/` tree) actually supplies — Option B
 does **not** ship the rest of the `vendored-node` bundle, since none of
 the other files `collectVendoredFiles` manages under the source
 repository's own `scripts/` have an `idd-template/` mirror. Getting the
-**complete** `vendored-node` bundle requires, run from the cloned
-`idd-skill` tree, `node scripts/idd-onboard.mjs --import --source
-<path-to-a-cloned-idd-skill-tree> --target <target-repo> --profile
-vendored-node` (see
+**complete** `vendored-node` bundle requires running `node
+scripts/idd-onboard.mjs --import --source <path-to-a-cloned-idd-skill-tree>
+--target <target-repo> --profile vendored-node` from the clone (see
 [CLI-assisted onboarding](../../ONBOARDING.md#cli-assisted-onboarding)),
 which reads from the clone's repository-root `scripts/`, not
 `idd-template/scripts/` — a full `idd-skill` clone, not just the

--- a/idd-template/docs/onboarding/template-distribution.md
+++ b/idd-template/docs/onboarding/template-distribution.md
@@ -55,10 +55,10 @@ requires every adopter to receive them.
 
 `scripts/minimize-superseded-markers.mjs` (mirrored to
 `idd-template/scripts/minimize-superseded-markers.mjs` by the
-`minimize-superseded-markers-helper` syncPair) is invoked from four
-template instruction files, but it is deliberately **not** part of the
+`minimize-superseded-markers-helper` syncPair) is invoked from template
+instruction files, but it is deliberately **not** part of the
 `idd-template-core-files` block or Option A's remote-fetch loops — every
-`idd-template/**` doc and instruction file those four instruction files
+`idd-template/**` doc and instruction file those instruction files
 reference is core, but a `scripts/*.mjs` helper reference (this one
 included) is not, since every helper script is `vendored-node`
 profile-conditional. This is intentional, not an oversight:
@@ -68,29 +68,36 @@ profile-conditional. This is intentional, not an oversight:
   both the always-shipped core set and the `vendored-node`
   profile-conditional helper bundle (`collectVendoredFiles` in
   `helper-runtime-manifest.mts`, which already vendors this file for
-  that profile). The core set and the profile-conditional bundle must
-  stay disjoint by construction.
+  that profile) — observed 2026-07-31, #1698, when adding this file to
+  the core set tripped exactly that guard. The core set and the
+  profile-conditional bundle must stay disjoint by construction.
 - Putting it in the core set would also make `buildSwitchPlan` (used to
   compute add/remove diffs when an adopter switches profiles) list it
   under `removeFiles` on a `vendored-node` → non-`vendored-node` switch,
   deleting a file the adopter still needs — a real data-loss hazard, not
-  just a manifest-consistency one.
+  just a manifest-consistency one (preventive; no observed incident
+  yet).
 - Every instruction-file call site degrades gracefully ("Skip entirely
   if … the helper is unavailable"), so the practical effect of the
   exclusion is bounded capability on some install paths, not breakage.
 
-**What this means for adopters**: only this **one** helper is mirrored
-into `idd-template/` (via the `minimize-superseded-markers-helper`
-syncPair), so it is the only `vendored-node` helper a plain Option B
+**What this means for adopters**: this helper is mirrored into
+`idd-template/` (via the `minimize-superseded-markers-helper`
+syncPair), but it is the only `vendored-node` helper a plain Option B
 copy (copying the `idd-template/` tree) actually supplies — Option B
 does **not** ship the rest of the `vendored-node` bundle, since none of
 the other files `collectVendoredFiles` manages under the source
 repository's own `scripts/` have an `idd-template/` mirror. Getting the
-**complete** `vendored-node` bundle requires running `node
-scripts/idd-onboard.mjs --import --source <path-to-a-cloned-idd-skill-tree>
---target <target-repo> --profile vendored-node` from the clone (see
-[CLI-assisted onboarding](../../ONBOARDING.md#cli-assisted-onboarding)),
-which reads from the clone's repository-root `scripts/`, not
+**complete** `vendored-node` bundle requires running this from the clone
+(see
+[CLI-assisted onboarding](../../ONBOARDING.md#cli-assisted-onboarding)):
+
+```sh
+node scripts/idd-onboard.mjs --import --source <path-to-a-cloned-idd-skill-tree> \
+  --target <target-repo> --profile vendored-node
+```
+
+This reads from the clone's repository-root `scripts/`, not
 `idd-template/scripts/` — a full `idd-skill` clone, not just the
 `idd-template/` subtree. Neither path is available to a pure Option A
 remote-fetch install with no local clone. An Option A adopter who
@@ -115,11 +122,11 @@ backs) only compares this doc's generated file list against
 `audit/sync-manifest.json`; it has no awareness of the `vendored-node`
 bundle in `helper-runtime-manifest.mts`, so it will not catch the
 overlap. `resolveImportFiles`'s `manifest drift: duplicate target path`
-hard-fail does catch it, but only under `pnpm run lint`'s full test
-suite (`node --test`), which `pre-push-validate` does not run — so a
-change that only satisfies `audit-docs.mjs --check` can still break
-`idd-onboard.mjs`. This needs a maintainer decision, not a mechanical
-file-list edit.
+hard-fail does catch it (the same #1698 incident cited above), but only
+under `pnpm run lint`'s full test suite (`node --test`), which
+`pre-push-validate` does not run — so a change that only satisfies
+`audit-docs.mjs --check` can still break `idd-onboard.mjs`. This needs a
+maintainer decision, not a mechanical file-list edit.
 
 ## Remote fetch examples
 

--- a/idd-template/docs/onboarding/template-distribution.md
+++ b/idd-template/docs/onboarding/template-distribution.md
@@ -51,6 +51,56 @@ When adding an optional issue-authoring companion file, update the
 companion files in the core template list unless the execution loop
 requires every adopter to receive them.
 
+## Profile-conditional helper files (`vendored-node`)
+
+`scripts/minimize-superseded-markers.mjs` (mirrored to
+`idd-template/scripts/minimize-superseded-markers.mjs` by the
+`minimize-superseded-markers-helper` syncPair) is invoked from four
+template instruction files, but it is deliberately **not** part of the
+`idd-template-core-files` block or Option A's remote-fetch loops, even
+though every other file those four instruction files reference is core.
+This is intentional, not an oversight:
+
+- `idd-onboard.mjs`'s `resolveImportFiles` hard-fails with a "manifest
+  drift: duplicate target path" error if a file's target path appears in
+  both the always-shipped core set and the `vendored-node`
+  profile-conditional helper bundle (`collectVendoredFiles` in
+  `helper-runtime-manifest.mts`, which already vendors this file for
+  that profile). The core set and the profile-conditional bundle must
+  stay disjoint by construction.
+- Putting it in the core set would also make `buildSwitchPlan` (used to
+  compute add/remove diffs when an adopter switches profiles) list it
+  under `removeFiles` on a `vendored-node` → non-`vendored-node` switch,
+  deleting a file the adopter still needs — a real data-loss hazard, not
+  just a manifest-consistency one.
+- Every instruction-file call site degrades gracefully ("Skip entirely
+  if … the helper is unavailable"), so the practical effect of the
+  exclusion is bounded capability on some install paths, not breakage.
+
+**What this means for adopters**: the `vendored-node` profile's helper
+bundle — including this file — ships only through Option B (local copy),
+or through `node scripts/idd-onboard.mjs --import --profile
+vendored-node`, which requires `--source <path-to-a-cloned-idd-skill-tree>`
+(see [CLI-assisted onboarding](../../ONBOARDING.md#cli-assisted-onboarding)).
+Neither path is available to a pure Option A remote-fetch install with no
+local clone. An Option A adopter who selected the `vendored-node` profile
+and wants this helper without cloning the repository can fetch the single
+file directly, the same way Option A fetches every other file:
+
+```sh
+curl -fsSL \
+  "https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template/scripts/minimize-superseded-markers.mjs" \
+  -o scripts/minimize-superseded-markers.mjs
+```
+
+If a future change makes this helper (or another `vendored-node`
+helper) a genuine cross-profile core dependency, resolve the
+core/profile-conditional overlap in `idd-onboard.mts` and
+`helper-runtime-manifest.mts` first — do not add it to
+`idd-template-core-files` while the disjointness invariant above still
+holds; `checkGeneratedBlocks`/`resolveImportFiles` will not catch the
+resulting drift by themselves, so this needs a maintainer decision.
+
 ## Remote fetch examples
 
 The `gh api` and `curl` loops in `idd-template/ONBOARDING.md` intentionally

--- a/idd-template/docs/onboarding/template-distribution.md
+++ b/idd-template/docs/onboarding/template-distribution.md
@@ -86,9 +86,10 @@ copy (copying the `idd-template/` tree) actually supplies — Option B
 does **not** ship the rest of the `vendored-node` bundle, since none of
 the other files `collectVendoredFiles` manages under the source
 repository's own `scripts/` have an `idd-template/` mirror. Getting the
-**complete** `vendored-node` bundle requires `node scripts/idd-onboard.mjs
---import --profile vendored-node --source <path-to-a-cloned-idd-skill-tree>`
-(see
+**complete** `vendored-node` bundle requires, run from the cloned
+`idd-skill` tree, `node scripts/idd-onboard.mjs --import --source
+<path-to-a-cloned-idd-skill-tree> --target <target-repo> --profile
+vendored-node` (see
 [CLI-assisted onboarding](../../ONBOARDING.md#cli-assisted-onboarding)),
 which reads from the clone's repository-root `scripts/`, not
 `idd-template/scripts/` — a full `idd-skill` clone, not just the

--- a/idd-template/docs/onboarding/template-distribution.md
+++ b/idd-template/docs/onboarding/template-distribution.md
@@ -77,15 +77,24 @@ This is intentional, not an oversight:
   if … the helper is unavailable"), so the practical effect of the
   exclusion is bounded capability on some install paths, not breakage.
 
-**What this means for adopters**: the `vendored-node` profile's helper
-bundle — including this file — ships only through Option B (local copy),
-or through `node scripts/idd-onboard.mjs --import --profile
-vendored-node`, which requires `--source <path-to-a-cloned-idd-skill-tree>`
-(see [CLI-assisted onboarding](../../ONBOARDING.md#cli-assisted-onboarding)).
-Neither path is available to a pure Option A remote-fetch install with no
-local clone. An Option A adopter who selected the `vendored-node` profile
-and wants this helper without cloning the repository can fetch the single
-file directly, the same way Option A fetches every other file:
+**What this means for adopters**: only this **one** helper is mirrored
+into `idd-template/` (via the `minimize-superseded-markers-helper`
+syncPair), so it is the only `vendored-node` helper a plain Option B
+copy (copying the `idd-template/` tree) actually supplies — Option B
+does **not** ship the rest of the `vendored-node` bundle, since none of
+the other files `collectVendoredFiles` manages under the source
+repository's own `scripts/` have an `idd-template/` mirror. Getting the
+**complete** `vendored-node` bundle requires `node scripts/idd-onboard.mjs
+--import --profile vendored-node --source <path-to-a-cloned-idd-skill-tree>`
+(see
+[CLI-assisted onboarding](../../ONBOARDING.md#cli-assisted-onboarding)),
+which reads from the clone's repository-root `scripts/`, not
+`idd-template/scripts/` — a full `idd-skill` clone, not just the
+`idd-template/` subtree. Neither path is available to a pure Option A
+remote-fetch install with no local clone. An Option A adopter who
+selected the `vendored-node` profile and wants this one self-contained
+helper without cloning the repository can fetch it directly, the same
+way Option A fetches every other file:
 
 ```sh
 mkdir -p scripts


### PR DESCRIPTION
# Summary

Fixes two adopter-harming template-delivery defects:

1. **Marker-prefix leak.** `idd-template/docs/getting-started.md`
   (exact-synced to `docs/getting-started.md`) named this source
   repository's concrete `idd-skill-blocked-by` marker prefix instead
   of the generic form every other template file uses. A fresh
   adopter following the guide would author markers their own
   Discover silently ignores, breaking dependency ordering with no
   error. Replaced with prose naming "the blocked-by marker (using
   your configured prefix)" and regenerated the exact-mode mirror.
2. **Remote-fetch delivery asymmetry.** `scripts/minimize-superseded-markers.mjs`
   is invoked by four template instruction files but was missing from
   the `idd-template-core-files` generated block, so Option A
   remote-fetch adopters never received it while Option B local-copy
   adopters did. See Background below for why this PR documents the
   exclusion instead of adding the file to the core block.

A repo-wide grep for other leaked `idd-skill-` marker-prefix
occurrences under `idd-template/**` found none outside a legitimate
source-repo-scoped sync-mapping table in
`idd-template/docs/customization.md` (documents the live↔template
substitution rule itself, not adopter-facing guidance).

## Linked issue

Closes #1698

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Item 1 matches the issue's proposed fix directly, including its note
that the `getting-started-doc` syncPair is `exact` mode, so a literal
`{{PROJECT_MARKER_PREFIX}}-blocked-by` placeholder would surface
verbatim in this repo's own `docs/getting-started.md` — prose is used
instead.

Item 2 diverges from the issue's default suggestion ("add the file to
`idd-template-core-files`"). That was implemented first, but the full
`pnpm run lint` test suite (`node --test`, not covered by
`pre-push-validate`) caught 3 failures in `tests/idd-onboard.test.mts`:
`scripts/minimize-superseded-markers.mjs` is already vended for the
`vendored-node` helper-runtime profile via `collectVendoredFiles` in
`helper-runtime-manifest.mts`. Adding it to the always-shipped core set
too makes `idd-onboard.mts`'s `resolveImportFiles` hard-fail with
`manifest drift: duplicate target path` — the core file set and the
`vendored-node` profile-conditional bundle must stay disjoint by
construction — and would make `buildSwitchPlan` list the file under
`removeFiles` on a `vendored-node` → non-`vendored-node` profile
switch, deleting a file the adopter still needs (a data-loss hazard,
not just a manifest-consistency issue).

The issue's own acceptance criteria explicitly allows the alternative
("or — if the exclusion is deliberate — document it in the
template-distribution doc instead"), and the codebase's guard rails
confirm the exclusion is architecturally deliberate. This PR documents
it in a new "Profile-conditional helper files (`vendored-node`)"
section in `idd-template/docs/onboarding/template-distribution.md`
(rationale, adopter impact, and a single-file `curl` fetch for an
Option A adopter on the `vendored-node` profile who wants the helper
without cloning), with a one-sentence pointer from
`idd-template/ONBOARDING.md` Step 2. Full reasoning and the
now-reverted first attempt are recorded on the issue.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (2727 tests, 0 failures)
- [x] `pnpm test` (covered by `pnpm lint`'s `node --test` step)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how configured blocked-by markers identify true sequential dependencies, while task-list links group roadmap work.
  * Documented shared core files across helper profiles and profile-specific exceptions.
  * Added maintainer guidance for installing and validating profile-conditional helper files, including duplicate-target and profile-switch considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->