### PR TITLE
docs(idd): include advisory-reroll markers in F4 cleanup and AW3-H scans

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -275,11 +275,14 @@ verified HEAD within one pass).
 ### AW3-H — Hide superseded advisory-wait markers
 
 After a new `advisory-wait`/`advisory-wait-recovery` marker is verified
-for the current `PR_HEAD_SHA`, minimize every trusted prior
-`advisory-wait*` marker whose embedded HEAD SHA does **not** match, as
-`OUTDATED` (cuts F4 backlog and review-page noise). Find candidate IDs
-(trusted `advisory-wait*` markers with a differing embedded SHA), then
-call the minimize-markers command:
+for the current `PR_HEAD_SHA`, minimize every trusted prior marker of
+the `advisory-wait:`/`advisory-wait-recovery:`/`advisory-reroll:`
+family whose embedded HEAD SHA does **not** match, as `OUTDATED` (cuts
+F4 backlog and review-page noise; the reroll prefix is included because
+it anchors the same Copilot advisory-wait clock, so a stale-HEAD reroll
+marker is exactly as much noise as a stale advisory-wait one). Find
+candidate IDs (trusted markers of that family with a differing embedded
+SHA), then call the minimize-markers command:
 [shell fallback AW3-H](../../docs/idd-advisory-wait-shell-fallback.md#aw3-h).
 
 Skip entirely if the new marker was not verified, the candidate set is

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -278,11 +278,10 @@ After a new `advisory-wait`/`advisory-wait-recovery` marker is verified
 for the current `PR_HEAD_SHA`, minimize every trusted prior marker of
 the `advisory-wait:`/`advisory-wait-recovery:`/`advisory-reroll:`
 family whose embedded HEAD SHA does **not** match, as `OUTDATED` (cuts
-F4 backlog and review-page noise; the reroll prefix is included because
-it anchors the same Copilot advisory-wait clock, so a stale-HEAD reroll
-marker is exactly as much noise as a stale advisory-wait one). Find
-candidate IDs (trusted markers of that family with a differing embedded
-SHA), then call the minimize-markers command:
+F4 backlog and review-page noise — a stale-HEAD `advisory-reroll:`
+marker is exactly as much operational noise as a stale advisory-wait
+one). Find candidate IDs (trusted markers of that family with a
+differing embedded SHA), then call the minimize-markers command:
 [shell fallback AW3-H](../../docs/idd-advisory-wait-shell-fallback.md#aw3-h).
 
 Skip entirely if the new marker was not verified, the candidate set is

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -291,7 +291,8 @@ Before any mutating action in F3, apply the
      `OUTDATED` only after merge, once the marker is no longer needed
      for resume, advisory wait, or review-currency checks. Candidate
      prefixes: `<!-- review-watermark:`, `<!-- review-baseline:`,
-     `advisory-wait:`, `advisory-wait-recovery:`, `<!-- advisory-wait:`.
+     `advisory-wait:`, `advisory-wait-recovery:`, `<!-- advisory-wait:`,
+     `advisory-reroll:`.
    - Do not minimize comments with unresolved maintainer decisions,
      active holds, failed-CI context maintainers still need,
      non-operational human discussion, or content still in active F2/F3

--- a/docs/idd-advisory-wait-shell-fallback.md
+++ b/docs/idd-advisory-wait-shell-fallback.md
@@ -70,7 +70,7 @@ TRUSTED_MARKER_LOGIN_JSON=$(
     printf '%s\n' "$TRUSTED_MARKER_ACTORS" | tr ',' '\n'
     if printf '%s\n' "$TRUST_COLLABORATOR_MARKERS" | grep -Eiq '^(1|true|yes)$'; then
       printf '%s\n' "$ADVISORY_COMMENTS_JSON" \
-        | jq -r '.[] | select((.body // "") | test("^advisory-wait:|^advisory-wait-recovery:|^<!-- advisory-wait:")) | .user.login // empty' \
+        | jq -r '.[] | select((.body // "") | test("^advisory-wait:|^advisory-wait-recovery:|^<!-- advisory-wait:|^advisory-reroll:")) | .user.login // empty' \
         | sort -fu \
         | while IFS= read -r login; do
           permission=$(

--- a/docs/idd-autonomy-contract.md
+++ b/docs/idd-autonomy-contract.md
@@ -117,14 +117,14 @@ claim, scoped to the roadmap issue only.
 
 ### Advisory-wait markers (AW1-AW6)
 
-| Mutation                                                      | Reversible / Irreversible | Undo path / Governing gate                                                  | Source                                                   |
-| ------------------------------------------------------------- | ------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------- |
-| Post `advisory-wait:` request marker                          | Reversible                | Superseded by the next marker for a later HEAD, or by the SATISFIED outcome | AW3 REQUEST_NEEDED (`idd-advisory-wait.instructions.md`) |
-| Post `advisory-wait-recovery:` marker                         | Reversible                | Same as above                                                               | AW3-R (`idd-advisory-wait.instructions.md`)              |
-| Post `advisory-reroll:` marker                                | Reversible                | Same as above                                                               | AW6 (`idd-advisory-wait.instructions.md`)                |
-| Request/remove primary or secondary bot reviewer              | Reversible                | `gh pr edit --remove-reviewer` / re-request                                 | E14 (`idd-review-fix.instructions.md`)                   |
-| Hide superseded `advisory-wait*` markers (`OUTDATED`)         | Irreversible              | See GitHub-minimize convention above                                        | AW3-H (`idd-advisory-wait.instructions.md`)              |
-| Approve a gated Actions run (bot-triggered `action_required`) | Reversible                | Does not destroy state; only unblocks a run                                 | `idd-ci.instructions.md` Rerun mechanics                 |
+| Mutation                                                                                        | Reversible / Irreversible | Undo path / Governing gate                                                  | Source                                                   |
+| ----------------------------------------------------------------------------------------------- | ------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Post `advisory-wait:` request marker                                                            | Reversible                | Superseded by the next marker for a later HEAD, or by the SATISFIED outcome | AW3 REQUEST_NEEDED (`idd-advisory-wait.instructions.md`) |
+| Post `advisory-wait-recovery:` marker                                                           | Reversible                | Same as above                                                               | AW3-R (`idd-advisory-wait.instructions.md`)              |
+| Post `advisory-reroll:` marker                                                                  | Reversible                | Same as above                                                               | AW6 (`idd-advisory-wait.instructions.md`)                |
+| Request/remove primary or secondary bot reviewer                                                | Reversible                | `gh pr edit --remove-reviewer` / re-request                                 | E14 (`idd-review-fix.instructions.md`)                   |
+| Hide superseded `advisory-wait`/`advisory-wait-recovery`/`advisory-reroll` markers (`OUTDATED`) | Irreversible              | See GitHub-minimize convention above                                        | AW3-H (`idd-advisory-wait.instructions.md`)              |
+| Approve a gated Actions run (bot-triggered `action_required`)                                   | Reversible                | Does not destroy state; only unblocks a run                                 | `idd-ci.instructions.md` Rerun mechanics                 |
 
 ### Merge execution (F2.5-F3)
 

--- a/docs/idd-autonomy-contract.md
+++ b/docs/idd-autonomy-contract.md
@@ -117,14 +117,14 @@ claim, scoped to the roadmap issue only.
 
 ### Advisory-wait markers (AW1-AW6)
 
-| Mutation                                                                                        | Reversible / Irreversible | Undo path / Governing gate                                                  | Source                                                   |
-| ----------------------------------------------------------------------------------------------- | ------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------- |
-| Post `advisory-wait:` request marker                                                            | Reversible                | Superseded by the next marker for a later HEAD, or by the SATISFIED outcome | AW3 REQUEST_NEEDED (`idd-advisory-wait.instructions.md`) |
-| Post `advisory-wait-recovery:` marker                                                           | Reversible                | Same as above                                                               | AW3-R (`idd-advisory-wait.instructions.md`)              |
-| Post `advisory-reroll:` marker                                                                  | Reversible                | Same as above                                                               | AW6 (`idd-advisory-wait.instructions.md`)                |
-| Request/remove primary or secondary bot reviewer                                                | Reversible                | `gh pr edit --remove-reviewer` / re-request                                 | E14 (`idd-review-fix.instructions.md`)                   |
-| Hide superseded `advisory-wait`/`advisory-wait-recovery`/`advisory-reroll` markers (`OUTDATED`) | Irreversible              | See GitHub-minimize convention above                                        | AW3-H (`idd-advisory-wait.instructions.md`)              |
-| Approve a gated Actions run (bot-triggered `action_required`)                                   | Reversible                | Does not destroy state; only unblocks a run                                 | `idd-ci.instructions.md` Rerun mechanics                 |
+| Mutation                                                                                           | Reversible / Irreversible | Undo path / Governing gate                                                  | Source                                                   |
+| -------------------------------------------------------------------------------------------------- | ------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Post `advisory-wait:` request marker                                                               | Reversible                | Superseded by the next marker for a later HEAD, or by the SATISFIED outcome | AW3 REQUEST_NEEDED (`idd-advisory-wait.instructions.md`) |
+| Post `advisory-wait-recovery:` marker                                                              | Reversible                | Same as above                                                               | AW3-R (`idd-advisory-wait.instructions.md`)              |
+| Post `advisory-reroll:` marker                                                                     | Reversible                | Same as above                                                               | AW6 (`idd-advisory-wait.instructions.md`)                |
+| Request/remove primary or secondary bot reviewer                                                   | Reversible                | `gh pr edit --remove-reviewer` / re-request                                 | E14 (`idd-review-fix.instructions.md`)                   |
+| Hide superseded `advisory-wait:`/`advisory-wait-recovery:`/`advisory-reroll:` markers (`OUTDATED`) | Irreversible              | See GitHub-minimize convention above                                        | AW3-H (`idd-advisory-wait.instructions.md`)              |
+| Approve a gated Actions run (bot-triggered `action_required`)                                      | Reversible                | Does not destroy state; only unblocks a run                                 | `idd-ci.instructions.md` Rerun mechanics                 |
 
 ### Merge execution (F2.5-F3)
 

--- a/docs/idd-concept-ownership.md
+++ b/docs/idd-concept-ownership.md
@@ -77,7 +77,7 @@ matrix's general "who mutates" column above.
 | Branch and worktree | Deleted | Worker or merge-capable session, F4 — only after F3 merge succeeds |
 | Review thread | Resolved | Worker session, immediately after posting a disposition reply (E6/E13) — **except** an `**Awaiting maintainer decision**` reply, which leaves the thread unresolved until a maintainer responds (F2's unresolved-threads gate relies on this); or a human reviewer resolving their own thread |
 | PR | Merged | Merge-capable session, F3, only once the full F2/F2.5 gate checklist holds |
-| `review-watermark` / `review-baseline` / `advisory-wait` / `advisory-wait-recovery` / `advisory-reroll` markers | Superseded / minimized as `OUTDATED` | Worker session, after a newer valid marker of the same kind exists for the same claim or HEAD |
+| `review-watermark` / `review-baseline` / `advisory-wait:` / `advisory-wait-recovery:` / `advisory-reroll:` markers | Superseded / minimized as `OUTDATED` | Worker session, after a newer valid marker of the same kind exists for the same claim or HEAD |
 | Claim-marker chain (`claimed-by`/`unclaimed-by`/heartbeat) | Superseded / minimized as `OUTDATED` | Worker session, but **only** the prior claim-id's chain after a verified `supersedes: <prior-id>` takeover — a same-claim heartbeat chain must never be hidden; it is the active-claim audit trail |
 | External-check waiver | Expired, or consumed | Worker session, rerunning the waived check so it reflects the waiver; expiry itself is a time-driven transition (`expiresAt`) that needs no actor |
 | Blocked-by-human / needs-decision label | Removed | Human maintainer only, after resolving the underlying blocker |

--- a/docs/idd-concept-ownership.md
+++ b/docs/idd-concept-ownership.md
@@ -77,7 +77,7 @@ matrix's general "who mutates" column above.
 | Branch and worktree | Deleted | Worker or merge-capable session, F4 — only after F3 merge succeeds |
 | Review thread | Resolved | Worker session, immediately after posting a disposition reply (E6/E13) — **except** an `**Awaiting maintainer decision**` reply, which leaves the thread unresolved until a maintainer responds (F2's unresolved-threads gate relies on this); or a human reviewer resolving their own thread |
 | PR | Merged | Merge-capable session, F3, only once the full F2/F2.5 gate checklist holds |
-| `review-watermark` / `review-baseline` / `advisory-wait*` markers | Superseded / minimized as `OUTDATED` | Worker session, after a newer valid marker of the same kind exists for the same claim or HEAD |
+| `review-watermark` / `review-baseline` / `advisory-wait` / `advisory-wait-recovery` / `advisory-reroll` markers | Superseded / minimized as `OUTDATED` | Worker session, after a newer valid marker of the same kind exists for the same claim or HEAD |
 | Claim-marker chain (`claimed-by`/`unclaimed-by`/heartbeat) | Superseded / minimized as `OUTDATED` | Worker session, but **only** the prior claim-id's chain after a verified `supersedes: <prior-id>` takeover — a same-claim heartbeat chain must never be hidden; it is the active-claim audit trail |
 | External-check waiver | Expired, or consumed | Worker session, rerunning the waived check so it reflects the waiver; expiry itself is a time-driven transition (`expiresAt`) that needs no actor |
 | Blocked-by-human / needs-decision label | Removed | Human maintainer only, after resolving the underlying blocker |

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -123,9 +123,9 @@ In the idd-skill source repository, the following optional helpers were adopted:
 - `scripts/audit-pr-cleanup.mjs` for post-merge comment cleanup auditing
 - `scripts/minimize-superseded-markers.mjs` for in-flight per-marker
   `minimizeComment` of strictly superseded `review-watermark`,
-  `advisory-wait`, or `claimed-by` markers — called by E1 (Step 2),
-  advisory-wait AW3-H, and claim takeover after the replacement
-  marker is verified
+  `advisory-wait`/`advisory-reroll`, or `claimed-by` markers — called by
+  E1 (Step 2), advisory-wait AW3-H, and claim takeover after the
+  replacement marker is verified
 
   Per-helper trust model: `minimize-superseded-markers` resolves its
   trusted-author gate with the same `flag > env > config` ladder as the

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -122,10 +122,10 @@ In the idd-skill source repository, the following optional helpers were adopted:
   discovery, rendering, dry-run, and claim-checked upsert
 - `scripts/audit-pr-cleanup.mjs` for post-merge comment cleanup auditing
 - `scripts/minimize-superseded-markers.mjs` for in-flight per-marker
-  `minimizeComment` of strictly superseded `review-watermark`,
-  `advisory-wait`/`advisory-reroll`, or `claimed-by` markers — called by
-  E1 (Step 2), advisory-wait AW3-H, and claim takeover after the
-  replacement marker is verified
+  `minimizeComment` of strictly superseded markers — `review-watermark`/
+  `review-baseline` (E1 Step 2), `advisory-wait`/`advisory-wait-recovery`/
+  `advisory-reroll` (advisory-wait AW3-H), or `claimed-by` (claim
+  takeover) — after the replacement marker is verified
 
   Per-helper trust model: `minimize-superseded-markers` resolves its
   trusted-author gate with the same `flag > env > config` ladder as the

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -270,11 +270,14 @@ verified HEAD within one pass).
 ### AW3-H — Hide superseded advisory-wait markers
 
 After a new `advisory-wait`/`advisory-wait-recovery` marker is verified
-for the current `PR_HEAD_SHA`, minimize every trusted prior
-`advisory-wait*` marker whose embedded HEAD SHA does **not** match, as
-`OUTDATED` (cuts F4 backlog and review-page noise). Find candidate IDs
-(trusted `advisory-wait*` markers with a differing embedded SHA), then
-call the minimize-markers command:
+for the current `PR_HEAD_SHA`, minimize every trusted prior marker of
+the `advisory-wait:`/`advisory-wait-recovery:`/`advisory-reroll:`
+family whose embedded HEAD SHA does **not** match, as `OUTDATED` (cuts
+F4 backlog and review-page noise; the reroll prefix is included because
+it anchors the same Copilot advisory-wait clock, so a stale-HEAD reroll
+marker is exactly as much noise as a stale advisory-wait one). Find
+candidate IDs (trusted markers of that family with a differing embedded
+SHA), then call the minimize-markers command:
 [shell fallback AW3-H](../../docs/idd-advisory-wait-shell-fallback.md#aw3-h).
 
 Skip entirely if the new marker was not verified, the candidate set is

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -273,11 +273,10 @@ After a new `advisory-wait`/`advisory-wait-recovery` marker is verified
 for the current `PR_HEAD_SHA`, minimize every trusted prior marker of
 the `advisory-wait:`/`advisory-wait-recovery:`/`advisory-reroll:`
 family whose embedded HEAD SHA does **not** match, as `OUTDATED` (cuts
-F4 backlog and review-page noise; the reroll prefix is included because
-it anchors the same Copilot advisory-wait clock, so a stale-HEAD reroll
-marker is exactly as much noise as a stale advisory-wait one). Find
-candidate IDs (trusted markers of that family with a differing embedded
-SHA), then call the minimize-markers command:
+F4 backlog and review-page noise — a stale-HEAD `advisory-reroll:`
+marker is exactly as much operational noise as a stale advisory-wait
+one). Find candidate IDs (trusted markers of that family with a
+differing embedded SHA), then call the minimize-markers command:
 [shell fallback AW3-H](../../docs/idd-advisory-wait-shell-fallback.md#aw3-h).
 
 Skip entirely if the new marker was not verified, the candidate set is

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -286,7 +286,8 @@ Before any mutating action in F3, apply the
      `OUTDATED` only after merge, once the marker is no longer needed
      for resume, advisory wait, or review-currency checks. Candidate
      prefixes: `<!-- review-watermark:`, `<!-- review-baseline:`,
-     `advisory-wait:`, `advisory-wait-recovery:`, `<!-- advisory-wait:`.
+     `advisory-wait:`, `advisory-wait-recovery:`, `<!-- advisory-wait:`,
+     `advisory-reroll:`.
    - Do not minimize comments with unresolved maintainer decisions,
      active holds, failed-CI context maintainers still need,
      non-operational human discussion, or content still in active F2/F3

--- a/idd-template/docs/idd-advisory-wait-shell-fallback.md
+++ b/idd-template/docs/idd-advisory-wait-shell-fallback.md
@@ -70,7 +70,7 @@ TRUSTED_MARKER_LOGIN_JSON=$(
     printf '%s\n' "$TRUSTED_MARKER_ACTORS" | tr ',' '\n'
     if printf '%s\n' "$TRUST_COLLABORATOR_MARKERS" | grep -Eiq '^(1|true|yes)$'; then
       printf '%s\n' "$ADVISORY_COMMENTS_JSON" \
-        | jq -r '.[] | select((.body // "") | test("^advisory-wait:|^advisory-wait-recovery:|^<!-- advisory-wait:")) | .user.login // empty' \
+        | jq -r '.[] | select((.body // "") | test("^advisory-wait:|^advisory-wait-recovery:|^<!-- advisory-wait:|^advisory-reroll:")) | .user.login // empty' \
         | sort -fu \
         | while IFS= read -r login; do
           permission=$(

--- a/idd-template/docs/idd-autonomy-contract.md
+++ b/idd-template/docs/idd-autonomy-contract.md
@@ -117,14 +117,14 @@ claim, scoped to the roadmap issue only.
 
 ### Advisory-wait markers (AW1-AW6)
 
-| Mutation                                                      | Reversible / Irreversible | Undo path / Governing gate                                                  | Source                                                   |
-| ------------------------------------------------------------- | ------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------- |
-| Post `advisory-wait:` request marker                          | Reversible                | Superseded by the next marker for a later HEAD, or by the SATISFIED outcome | AW3 REQUEST_NEEDED (`idd-advisory-wait.instructions.md`) |
-| Post `advisory-wait-recovery:` marker                         | Reversible                | Same as above                                                               | AW3-R (`idd-advisory-wait.instructions.md`)              |
-| Post `advisory-reroll:` marker                                | Reversible                | Same as above                                                               | AW6 (`idd-advisory-wait.instructions.md`)                |
-| Request/remove primary or secondary bot reviewer              | Reversible                | `gh pr edit --remove-reviewer` / re-request                                 | E14 (`idd-review-fix.instructions.md`)                   |
-| Hide superseded `advisory-wait*` markers (`OUTDATED`)         | Irreversible              | See GitHub-minimize convention above                                        | AW3-H (`idd-advisory-wait.instructions.md`)              |
-| Approve a gated Actions run (bot-triggered `action_required`) | Reversible                | Does not destroy state; only unblocks a run                                 | `idd-ci.instructions.md` Rerun mechanics                 |
+| Mutation                                                                                        | Reversible / Irreversible | Undo path / Governing gate                                                  | Source                                                   |
+| ----------------------------------------------------------------------------------------------- | ------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Post `advisory-wait:` request marker                                                            | Reversible                | Superseded by the next marker for a later HEAD, or by the SATISFIED outcome | AW3 REQUEST_NEEDED (`idd-advisory-wait.instructions.md`) |
+| Post `advisory-wait-recovery:` marker                                                           | Reversible                | Same as above                                                               | AW3-R (`idd-advisory-wait.instructions.md`)              |
+| Post `advisory-reroll:` marker                                                                  | Reversible                | Same as above                                                               | AW6 (`idd-advisory-wait.instructions.md`)                |
+| Request/remove primary or secondary bot reviewer                                                | Reversible                | `gh pr edit --remove-reviewer` / re-request                                 | E14 (`idd-review-fix.instructions.md`)                   |
+| Hide superseded `advisory-wait`/`advisory-wait-recovery`/`advisory-reroll` markers (`OUTDATED`) | Irreversible              | See GitHub-minimize convention above                                        | AW3-H (`idd-advisory-wait.instructions.md`)              |
+| Approve a gated Actions run (bot-triggered `action_required`)                                   | Reversible                | Does not destroy state; only unblocks a run                                 | `idd-ci.instructions.md` Rerun mechanics                 |
 
 ### Merge execution (F2.5-F3)
 

--- a/idd-template/docs/idd-autonomy-contract.md
+++ b/idd-template/docs/idd-autonomy-contract.md
@@ -117,14 +117,14 @@ claim, scoped to the roadmap issue only.
 
 ### Advisory-wait markers (AW1-AW6)
 
-| Mutation                                                                                        | Reversible / Irreversible | Undo path / Governing gate                                                  | Source                                                   |
-| ----------------------------------------------------------------------------------------------- | ------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------- |
-| Post `advisory-wait:` request marker                                                            | Reversible                | Superseded by the next marker for a later HEAD, or by the SATISFIED outcome | AW3 REQUEST_NEEDED (`idd-advisory-wait.instructions.md`) |
-| Post `advisory-wait-recovery:` marker                                                           | Reversible                | Same as above                                                               | AW3-R (`idd-advisory-wait.instructions.md`)              |
-| Post `advisory-reroll:` marker                                                                  | Reversible                | Same as above                                                               | AW6 (`idd-advisory-wait.instructions.md`)                |
-| Request/remove primary or secondary bot reviewer                                                | Reversible                | `gh pr edit --remove-reviewer` / re-request                                 | E14 (`idd-review-fix.instructions.md`)                   |
-| Hide superseded `advisory-wait`/`advisory-wait-recovery`/`advisory-reroll` markers (`OUTDATED`) | Irreversible              | See GitHub-minimize convention above                                        | AW3-H (`idd-advisory-wait.instructions.md`)              |
-| Approve a gated Actions run (bot-triggered `action_required`)                                   | Reversible                | Does not destroy state; only unblocks a run                                 | `idd-ci.instructions.md` Rerun mechanics                 |
+| Mutation                                                                                           | Reversible / Irreversible | Undo path / Governing gate                                                  | Source                                                   |
+| -------------------------------------------------------------------------------------------------- | ------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Post `advisory-wait:` request marker                                                               | Reversible                | Superseded by the next marker for a later HEAD, or by the SATISFIED outcome | AW3 REQUEST_NEEDED (`idd-advisory-wait.instructions.md`) |
+| Post `advisory-wait-recovery:` marker                                                              | Reversible                | Same as above                                                               | AW3-R (`idd-advisory-wait.instructions.md`)              |
+| Post `advisory-reroll:` marker                                                                     | Reversible                | Same as above                                                               | AW6 (`idd-advisory-wait.instructions.md`)                |
+| Request/remove primary or secondary bot reviewer                                                   | Reversible                | `gh pr edit --remove-reviewer` / re-request                                 | E14 (`idd-review-fix.instructions.md`)                   |
+| Hide superseded `advisory-wait:`/`advisory-wait-recovery:`/`advisory-reroll:` markers (`OUTDATED`) | Irreversible              | See GitHub-minimize convention above                                        | AW3-H (`idd-advisory-wait.instructions.md`)              |
+| Approve a gated Actions run (bot-triggered `action_required`)                                      | Reversible                | Does not destroy state; only unblocks a run                                 | `idd-ci.instructions.md` Rerun mechanics                 |
 
 ### Merge execution (F2.5-F3)
 

--- a/idd-template/docs/idd-concept-ownership.md
+++ b/idd-template/docs/idd-concept-ownership.md
@@ -77,7 +77,7 @@ matrix's general "who mutates" column above.
 | Branch and worktree | Deleted | Worker or merge-capable session, F4 — only after F3 merge succeeds |
 | Review thread | Resolved | Worker session, immediately after posting a disposition reply (E6/E13) — **except** an `**Awaiting maintainer decision**` reply, which leaves the thread unresolved until a maintainer responds (F2's unresolved-threads gate relies on this); or a human reviewer resolving their own thread |
 | PR | Merged | Merge-capable session, F3, only once the full F2/F2.5 gate checklist holds |
-| `review-watermark` / `review-baseline` / `advisory-wait` / `advisory-wait-recovery` / `advisory-reroll` markers | Superseded / minimized as `OUTDATED` | Worker session, after a newer valid marker of the same kind exists for the same claim or HEAD |
+| `review-watermark` / `review-baseline` / `advisory-wait:` / `advisory-wait-recovery:` / `advisory-reroll:` markers | Superseded / minimized as `OUTDATED` | Worker session, after a newer valid marker of the same kind exists for the same claim or HEAD |
 | Claim-marker chain (`claimed-by`/`unclaimed-by`/heartbeat) | Superseded / minimized as `OUTDATED` | Worker session, but **only** the prior claim-id's chain after a verified `supersedes: <prior-id>` takeover — a same-claim heartbeat chain must never be hidden; it is the active-claim audit trail |
 | External-check waiver | Expired, or consumed | Worker session, rerunning the waived check so it reflects the waiver; expiry itself is a time-driven transition (`expiresAt`) that needs no actor |
 | Blocked-by-human / needs-decision label | Removed | Human maintainer only, after resolving the underlying blocker |

--- a/idd-template/docs/idd-concept-ownership.md
+++ b/idd-template/docs/idd-concept-ownership.md
@@ -77,7 +77,7 @@ matrix's general "who mutates" column above.
 | Branch and worktree | Deleted | Worker or merge-capable session, F4 — only after F3 merge succeeds |
 | Review thread | Resolved | Worker session, immediately after posting a disposition reply (E6/E13) — **except** an `**Awaiting maintainer decision**` reply, which leaves the thread unresolved until a maintainer responds (F2's unresolved-threads gate relies on this); or a human reviewer resolving their own thread |
 | PR | Merged | Merge-capable session, F3, only once the full F2/F2.5 gate checklist holds |
-| `review-watermark` / `review-baseline` / `advisory-wait*` markers | Superseded / minimized as `OUTDATED` | Worker session, after a newer valid marker of the same kind exists for the same claim or HEAD |
+| `review-watermark` / `review-baseline` / `advisory-wait` / `advisory-wait-recovery` / `advisory-reroll` markers | Superseded / minimized as `OUTDATED` | Worker session, after a newer valid marker of the same kind exists for the same claim or HEAD |
 | Claim-marker chain (`claimed-by`/`unclaimed-by`/heartbeat) | Superseded / minimized as `OUTDATED` | Worker session, but **only** the prior claim-id's chain after a verified `supersedes: <prior-id>` takeover — a same-claim heartbeat chain must never be hidden; it is the active-claim audit trail |
 | External-check waiver | Expired, or consumed | Worker session, rerunning the waived check so it reflects the waiver; expiry itself is a time-driven transition (`expiresAt`) that needs no actor |
 | Blocked-by-human / needs-decision label | Removed | Human maintainer only, after resolving the underlying blocker |

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -123,9 +123,9 @@ In the idd-skill source repository, the following optional helpers were adopted:
 - `scripts/audit-pr-cleanup.mjs` for post-merge comment cleanup auditing
 - `scripts/minimize-superseded-markers.mjs` for in-flight per-marker
   `minimizeComment` of strictly superseded `review-watermark`,
-  `advisory-wait`, or `claimed-by` markers — called by E1 (Step 2),
-  advisory-wait AW3-H, and claim takeover after the replacement
-  marker is verified
+  `advisory-wait`/`advisory-reroll`, or `claimed-by` markers — called by
+  E1 (Step 2), advisory-wait AW3-H, and claim takeover after the
+  replacement marker is verified
 
   Per-helper trust model: `minimize-superseded-markers` resolves its
   trusted-author gate with the same `flag > env > config` ladder as the

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -122,10 +122,10 @@ In the idd-skill source repository, the following optional helpers were adopted:
   discovery, rendering, dry-run, and claim-checked upsert
 - `scripts/audit-pr-cleanup.mjs` for post-merge comment cleanup auditing
 - `scripts/minimize-superseded-markers.mjs` for in-flight per-marker
-  `minimizeComment` of strictly superseded `review-watermark`,
-  `advisory-wait`/`advisory-reroll`, or `claimed-by` markers — called by
-  E1 (Step 2), advisory-wait AW3-H, and claim takeover after the
-  replacement marker is verified
+  `minimizeComment` of strictly superseded markers — `review-watermark`/
+  `review-baseline` (E1 Step 2), `advisory-wait`/`advisory-wait-recovery`/
+  `advisory-reroll` (advisory-wait AW3-H), or `claimed-by` (claim
+  takeover) — after the replacement marker is verified
 
   Per-helper trust model: `minimize-superseded-markers` resolves its
   trusted-author gate with the same `flag > env > config` ladder as the


### PR DESCRIPTION
## Summary

F4's OUTDATED candidate-prefix list and AW3-H's superseded-marker scan
predate AW6's `advisory-reroll:` marker (#1511/#1623) and never picked
it up, even though `docs/idd-comment-minimization.md`'s own canonical
"Candidate prefixes" list already covers it. Result: PRs that exercise
AW6 accumulate permanent un-minimized reroll markers, and F4's "no path
may exit without a recorded reason" cleanup reports `clean` while
operational noise remains.

- `idd-merge.instructions.md` F4: add `advisory-reroll:` to the
  OUTDATED candidate-prefix list.
- `idd-advisory-wait.instructions.md` AW3-H: replace the `advisory-wait*`
  glob (which structurally does not match `advisory-reroll:`, a
  distinct prefix, not an `advisory-wait`-prefixed variant) with an
  explicit one-time enumeration of the three prefixes it scans for and
  hides, back-referencing "that family" for the second mention to avoid
  a wrap-hostile repeated triple code-span run.
  - Scope note: this only widens AW3-H's **candidate/target** set, not
    its **trigger** clause — the trigger still fires on a fresh
    `advisory-wait`/`advisory-wait-recovery` marker. AW6 does not
    currently route to AW3-H, so extending the trigger too would
    introduce a call edge nothing exercises; out of this issue's stated
    scope. The fix still resolves reroll-marker accumulation because
    the next ordinary advisory-wait/-recovery sweep now also hides
    stale-HEAD reroll markers.
- Also aligned three more docs describing this identical hide/cleanup
  operation that carried the same stale glob or omission:
  `idd-helper-scripts.md`'s `minimize-superseded-markers.mjs`
  description, `idd-autonomy-contract.md`'s "Hide superseded" row, and
  `idd-concept-ownership.md`'s terminal-state-gating row. (Left
  `idd-concept-ownership.md`'s separate "who mutates"
  ownership-matrix row for `advisory-wait`/`advisory-wait-recovery`
  untouched — that row is about marker-**posting** ownership, a
  different, pre-existing concern unrelated to this issue's
  superseded-marker-**hide** scope.)

All edits land in `idd-template/` sources; mirrors regenerated via
`node scripts/sync-docs.mjs --apply` (all five are `mode: "exact"`
sync pairs per `audit/sync-manifest.json`).

## Verification (acceptance criterion 4)

Verified via code reading, no code change needed:

- `src/scripts/minimize-superseded-markers.mts` (the actual
  `--classifier OUTDATED` helper) has **no** internal marker-prefix
  list — it operates purely on caller-supplied `--subject-ids`
  (GraphQL node IDs) and is content-agnostic.
- The real "helper-side marker list" is
  `src/scripts/marker-helpers.mts`'s `OPERATIONAL_MARKERS` /
  `IDD_AGENT_DERIVED_MARKERS` tables, which **already** include
  `advisory-reroll:` (added for #1511/AW6) and are what
  `audit-pr-cleanup.mts`'s `operationalMarkerPrefix()` actually
  consults for the F4 cleanup code path — this already worked
  correctly.
- Confirmed `idd-review-snapshot.instructions.md` E1 (Step 2) — the
  other caller named in `idd-helper-scripts.md`'s
  `minimize-superseded-markers.mjs` description — only ever minimizes
  `review-watermark`/`review-baseline` (lines 164-166), so that doc
  edit is scoped to the AW3-H-paired marker types only, not a claim
  that E1 also handles reroll markers.

## Byte budgets

Measured on `main` before this change: `bundle-merge` sync-manifest
budget was 100,579 / 108,000 bytes (~7.4 KB headroom);
`idd-merge.instructions.md` and `idd-advisory-wait.instructions.md`
were ~19.9 KB / ~18.9 KB against the 33,000-byte per-file phase cap.
The additions here are a few dozen bytes per file — no trimming
needed. `bundle-review`'s pre-existing 95%+ utilization notice (from
`node scripts/audit-docs.mjs --check`) predates this change (96.24% on
`main`, 96.43% after) and is unaffected by it.

## Test plan

- [x] `npx biome check`
- [x] `npx dprint check "**/*.md"`
- [x] `npx markdownlint-cli2 "**/*.md"`
- [x] `npx cspell lint "**" --no-progress`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `pnpm run build:check`
- [x] `node scripts/idd-doctor.mjs`

No `.mts`/`.mjs` source changes and no test changes — documentation
consistency fix only.

Closes #1705


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified handling of advisory-wait, recovery, and reroll markers.
  * Documented stale-marker cleanup when markers reference an outdated pull request revision.
  * Expanded helper guidance to cover review baselines, watermarks, and takeover-related markers.
* **Bug Fixes**
  * Improved detection and cleanup of stale advisory-reroll markers across supported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->