### PR TITLE
fix(advisory-wait): recognize advisory-reroll markers in trust discovery

### DIFF
--- a/scripts/advisory-wait-state.mjs
+++ b/scripts/advisory-wait-state.mjs
@@ -538,11 +538,12 @@ function resolveTrustedCollaboratorMarkerLogins(owner, repo, comments) {
     );
   });
 }
-function advisoryMarkerComment(body) {
+export function advisoryMarkerComment(body) {
   const normalized = String(body ?? '');
   return (
     normalized.startsWith('advisory-wait:') ||
     normalized.startsWith('advisory-wait-recovery:') ||
+    normalized.startsWith('advisory-reroll:') ||
     normalized.startsWith('<!-- advisory-wait:')
   );
 }

--- a/src/scripts/advisory-wait-state.mts
+++ b/src/scripts/advisory-wait-state.mts
@@ -775,11 +775,12 @@ function resolveTrustedCollaboratorMarkerLogins(
   });
 }
 
-function advisoryMarkerComment(body: string): boolean {
+export function advisoryMarkerComment(body: string): boolean {
   const normalized = String(body ?? '');
   return (
     normalized.startsWith('advisory-wait:') ||
     normalized.startsWith('advisory-wait-recovery:') ||
+    normalized.startsWith('advisory-reroll:') ||
     normalized.startsWith('<!-- advisory-wait:')
   );
 }

--- a/tests/advisory-wait-state.test.mts
+++ b/tests/advisory-wait-state.test.mts
@@ -2,6 +2,7 @@ import { strict as assert } from 'node:assert';
 import { test } from 'node:test';
 
 import {
+  advisoryMarkerComment,
   buildCopilotRecoverySummary,
   parseArgs,
 } from '../src/scripts/advisory-wait-state.mts';
@@ -753,4 +754,34 @@ test('a full CLI output shape (summary fields + copilotRecovery) validates clean
     copilotRecovery,
   };
   assert.deepEqual(validate(fullOutput, advisoryWaitStateSchema), []);
+});
+
+// --- #1742: collaborator-trust discovery must recognize advisory-reroll: ---
+//
+// resolveTrustedCollaboratorMarkerLogins() (not exported: it shells out to
+// `gh api .../collaborators/.../permission`, which none of this file's other
+// gh-backed helpers unit-test either) pre-filters candidate comments through
+// this exported predicate before checking collaborator permission. A
+// reroll-only-authored comment must pass the pre-filter -- otherwise its
+// author is never even considered as a collaborator-trust candidate,
+// regardless of their actual repository permission.
+
+test('advisoryMarkerComment: recognizes an advisory-reroll: marker as a candidate', () => {
+  assert.equal(
+    advisoryMarkerComment(
+      'advisory-reroll: agent-id abc123 2026-07-30T00:00:00Z',
+    ),
+    true,
+  );
+});
+
+test('advisoryMarkerComment: still recognizes advisory-wait: and advisory-wait-recovery:', () => {
+  assert.equal(advisoryMarkerComment('advisory-wait: agent-id'), true);
+  assert.equal(advisoryMarkerComment('advisory-wait-recovery: agent-id'), true);
+  assert.equal(advisoryMarkerComment('<!-- advisory-wait: agent-id -->'), true);
+});
+
+test('advisoryMarkerComment: rejects unrelated comment bodies', () => {
+  assert.equal(advisoryMarkerComment('just a regular comment'), false);
+  assert.equal(advisoryMarkerComment(''), false);
 });


### PR DESCRIPTION
## Summary

`advisoryMarkerComment()` in `src/scripts/advisory-wait-state.mts` only
matched `advisory-wait:` / `advisory-wait-recovery:` (plain and HTML-comment
forms). A collaborator whose only prior marker comment was an
`advisory-reroll:` marker (AW6, #1511) was never surfaced as a candidate
for `resolveTrustedCollaboratorMarkerLogins()` under
`IDD_TRUST_COLLABORATOR_MARKERS`, even though `marker-helpers.mts`'s
canonical `OPERATIONAL_MARKERS` table already treats `advisory-reroll:` as
a first-class operational marker (plain-text only, per `#1511`).

- Added `normalized.startsWith('advisory-reroll:')` to
  `advisoryMarkerComment()`.
- Exported `advisoryMarkerComment` (previously private) so the fix is
  directly unit-testable, matching this file's existing pattern of only
  unit-testing pure functions — `resolveTrustedCollaboratorMarkerLogins()`
  itself shells out to `gh api .../collaborators/.../permission`, and no
  other `gh`-backed helper in this file is unit-tested either, so its
  network-dependent half is exercised the same way it already was
  (indirectly, through the CLI).
- Added three cases to `tests/advisory-wait-state.test.mts` covering the
  new `advisory-reroll:` prefix, the pre-existing prefixes (regression),
  and an unrelated-body negative case.
- `pnpm run build` regenerated `scripts/advisory-wait-state.mjs`
  (`bin/idd-advisory-wait-state.mjs` is an unaffected thin wrapper; this
  file has no `idd-template/scripts/` mirror to sync).

## Test plan

- [x] `node --test tests/advisory-wait-state.test.mts` — 41/41 pass
- [x] `node --test tests/*.test.mts` — 2730/2730 pass
- [x] `pnpm run build:check` — no drift
- [x] `node scripts/idd-doctor.mjs` — passed (pre-existing warnings only)
- [x] pre-push-validate (biome, dprint, markdownlint, cspell, audit-docs,
      audit-code-span-wrap, build:check, idd-doctor)

Closes #1742

Refs #1705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing `advisory-reroll:` comments alongside existing advisory markers.

* **Bug Fixes**
  * Improved comment marker validation to reject unrelated or empty comments while preserving existing formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->