### PR TITLE
fix(lite): restore fail-closed recovery bounds and A5 pre-checks

### DIFF
--- a/.github/instructions/lite/idd-advisory-wait-lite.instructions.md
+++ b/.github/instructions/lite/idd-advisory-wait-lite.instructions.md
@@ -115,7 +115,7 @@ no `advisoryWait.*` config are: `requestCap` 30,
 | Outcome | E14 action |
 | --- | --- |
 | `SATISFIED` | proceed to CI wait |
-| `REQUEST_NEEDED` | pending false: request Copilot + marker, poll. pending true (unproven): no lite `AW3-S` cycle — poll only |
+| `REQUEST_NEEDED` | `copilotPending`: false → request Copilot + marker, poll; true (no marker) → no `AW3-S` here — stop and ask |
 | `RECOVERY_NEEDED` | post the recovery marker (do not request another review), then poll |
 | `CAP_EXHAUSTED` | `phase-specific` (default): proceed to CI wait. `hold`: stop and ask (`HOLD`'s only route; see above) |
 | `WAIT` | keep polling |

--- a/.github/instructions/lite/idd-advisory-wait-lite.instructions.md
+++ b/.github/instructions/lite/idd-advisory-wait-lite.instructions.md
@@ -115,7 +115,7 @@ no `advisoryWait.*` config are: `requestCap` 30,
 | Outcome | E14 action |
 | --- | --- |
 | `SATISFIED` | proceed to CI wait |
-| `REQUEST_NEEDED` | remove the stale pending request if one exists, request Copilot, post the request marker, then poll |
+| `REQUEST_NEEDED` | pending false: request Copilot + marker, poll. pending true (unproven): no lite `AW3-S` cycle — poll only |
 | `RECOVERY_NEEDED` | post the recovery marker (do not request another review), then poll |
 | `CAP_EXHAUSTED` | `phase-specific` (default): proceed to CI wait. `hold`: stop and ask (`HOLD`'s only route; see above) |
 | `WAIT` | keep polling |

--- a/.github/instructions/lite/idd-resume-stall-lite.instructions.md
+++ b/.github/instructions/lite/idd-resume-stall-lite.instructions.md
@@ -84,14 +84,14 @@ gate.
 
 ## S4 — Race-safe recheck (immediately before write)
 
-1. Re-run `resume-claim-routing.mjs --issue <N>`.
-2. Active claim still the same non-owned `{claim-id}`.
-3. Still stale (≥ 24 h) now.
-4. Fresh server `NOW` + re-run quiet-check; if new activity, STOP and
-   restart from resume discovery.
-5. Issue still open; PR not merged.
-6. Run `idd-claim-lite.instructions.md` pre-checks (d)/(e); either
+1. Run `idd-claim-lite.instructions.md` pre-checks (d)/(e); either
    failing → STOP.
+2. Re-run `resume-claim-routing.mjs --issue <N>`.
+3. Active claim still the same non-owned `{claim-id}`.
+4. Still stale (≥ 24 h) now.
+5. Fresh server `NOW` + re-run quiet-check; if new activity, STOP and
+   restart from resume discovery.
+6. Issue still open; PR not merged.
 7. Plan A5 takeover with settle delay (`claim.verifySettleDelay`, default
    `PT5S`) and same-second claim-id tie-break.
 

--- a/.github/instructions/lite/idd-resume-stall-lite.instructions.md
+++ b/.github/instructions/lite/idd-resume-stall-lite.instructions.md
@@ -97,12 +97,16 @@ Any failure → STOP and restart. Do not post takeover on stale evidence.
 
 ## S5 — Takeover
 
-1. Post claim with fresh `{claim-id}` and `supersedes: <prior-claim-id>`
-   via `post-idd-marker --type claim ... --apply` (or equivalent).
-2. Wait settle delay; re-parse; confirm active claim is yours.
-3. If lost: STOP.
-4. If verified: return to `idd-resume-lite.instructions.md` Step 1, then
-   Step 2/3.
+1. Run `idd-claim-lite.instructions.md` pre-checks (d)/(e); either
+   failing → STOP.
+2. Post claim (fresh `{claim-id}`, `supersedes: <prior-claim-id>`) via
+   `post-idd-marker --type claim ... --apply`, then an
+   activation-nonce for the same `{claim-id}` (same file's step 5).
+3. Wait settle delay; re-parse; confirm claim and nonce winner are
+   yours.
+4. If lost: STOP.
+5. If verified: return to `idd-resume-lite.instructions.md` Step 1,
+   then Step 2/3.
 
 ## Hold behavior
 

--- a/.github/instructions/lite/idd-resume-stall-lite.instructions.md
+++ b/.github/instructions/lite/idd-resume-stall-lite.instructions.md
@@ -90,22 +90,22 @@ gate.
 4. Fresh server `NOW` + re-run quiet-check; if new activity, STOP and
    restart from resume discovery.
 5. Issue still open; PR not merged.
-6. Plan A5 takeover with settle delay (`claim.verifySettleDelay`, default
+6. Run `idd-claim-lite.instructions.md` pre-checks (d)/(e); either
+   failing → STOP.
+7. Plan A5 takeover with settle delay (`claim.verifySettleDelay`, default
    `PT5S`) and same-second claim-id tie-break.
 
 Any failure → STOP and restart. Do not post takeover on stale evidence.
 
 ## S5 — Takeover
 
-1. Run `idd-claim-lite.instructions.md` pre-checks (d)/(e); either
-   failing → STOP.
-2. Post claim (fresh `{claim-id}`, `supersedes: <prior-claim-id>`) via
+1. Post claim (fresh `{claim-id}`, `supersedes: <prior-claim-id>`) via
    `post-idd-marker --type claim ... --apply`, then an
-   activation-nonce for the same `{claim-id}` (same file's step 5).
-3. Wait settle delay; re-parse; confirm claim and nonce winner are
+   activation-nonce (`idd-claim-lite.instructions.md` step 5).
+2. Wait settle delay; re-parse; confirm claim and nonce winner are
    yours.
-4. If lost: STOP.
-5. If verified: return to `idd-resume-lite.instructions.md` Step 1,
+3. If lost: STOP.
+4. If verified: return to `idd-resume-lite.instructions.md` Step 1,
    then Step 2/3.
 
 ## Hold behavior

--- a/.github/instructions/lite/idd-resume-stall-lite.instructions.md
+++ b/.github/instructions/lite/idd-resume-stall-lite.instructions.md
@@ -104,9 +104,8 @@ Any failure → STOP and restart. Do not post takeover on stale evidence.
    activation-nonce (`idd-claim-lite.instructions.md` step 5).
 2. Wait settle delay; re-parse; confirm claim and nonce winner are
    yours.
-3. If lost: STOP.
-4. If verified: return to `idd-resume-lite.instructions.md` Step 1,
-   then Step 2/3.
+3. Lost → STOP. Verified → record nonce; return to
+   `idd-resume-lite.instructions.md` Step 1, Step 2/3.
 
 ## Hold behavior
 

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -239,21 +239,19 @@ other GitHub side effect, confirm all of the following:
      `advisory-wait-recovery: {agent-id} {PR_HEAD_SHA}
      {ISO8601-recovery-time}` as plain text. Do not request another
      review. Then go to the polling loop below.
-   - `REQUEST_NEEDED`: if `copilotPending` is true, first remove the
-     stale pending request with `gh pr edit {pr-number}
-     --remove-reviewer "@{primary-advisory-bot}"` (on a GraphQL
-     login-resolution failure, retry via `gh api
-     repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers -X
-     DELETE -f "reviewers[]={primary-advisory-bot-rest-login}"`; if
-     removal fails because the bot is no longer pending, re-run this
-     step from the top; if it fails for any other reason, post a hold
-     comment and stop). Then request the review with `gh pr edit
-     {pr-number} --add-reviewer "@{primary-advisory-bot}"` (on the same
-     GraphQL failure, retry via `gh api
+   - `REQUEST_NEEDED`, `copilotPending` `false`: request the review with
+     `gh pr edit {pr-number} --add-reviewer "@{primary-advisory-bot}"`
+     (on a GraphQL login-resolution failure, retry via `gh api
      repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers -X POST
      -f "reviewers[]={primary-advisory-bot-rest-login}"`). Immediately
      post `advisory-wait: {agent-id} {PR_HEAD_SHA}
      {ISO8601-requested-at}` as plain text, not an HTML comment. Then go
+     to the polling loop below.
+   - `REQUEST_NEEDED`, `copilotPending` `true` (a request is already
+     pending but unproven for current HEAD): lite does not track the
+     claim-id/agent-id the full protocol's bounded `AW3-S`
+     remove/re-request cycle requires — mirror its fail-closed
+     `not-applicable` default: do not remove or re-request; go straight
      to the polling loop below.
    - `CAP_EXHAUSTED`: apply step 10 below (the secondary-bot check)
      first — it is a non-gating supplement that fires on cap exhaustion

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -248,11 +248,11 @@ other GitHub side effect, confirm all of the following:
      {ISO8601-requested-at}` as plain text, not an HTML comment. Then go
      to the polling loop below.
    - `REQUEST_NEEDED`, `copilotPending` `true` (a request is already
-     pending but unproven for current HEAD): lite does not track the
-     claim-id/agent-id the full protocol's bounded `AW3-S`
-     remove/re-request cycle requires — mirror its fail-closed
-     `not-applicable` default: do not remove or re-request; go straight
-     to the polling loop below.
+     pending but unproven for current HEAD, no same-head marker to
+     anchor polling): lite does not track the claim-id/agent-id the
+     full protocol's bounded `AW3-S` remove/re-request cycle requires —
+     stop and ask rather than remove, re-request, or enter the
+     marker-based polling loop below with no marker.
    - `CAP_EXHAUSTED`: apply step 10 below (the secondary-bot check)
      first — it is a non-gating supplement that fires on cap exhaustion
      independent of the cap-exhausted route. Then, if the helper's

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -243,9 +243,10 @@ other GitHub side effect, confirm all of the following:
      `gh pr edit {pr-number} --add-reviewer "@{primary-advisory-bot}"`
      (on a GraphQL login-resolution failure, retry via `gh api
      repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers -X POST
-     -f "reviewers[]={primary-advisory-bot-rest-login}"`). Immediately
-     post `advisory-wait: {agent-id} {PR_HEAD_SHA}
-     {ISO8601-requested-at}` as plain text, not an HTML comment. Then go
+     -f "reviewers[]={primary-advisory-bot-rest-login}"`). If both
+     attempts fail, stop and ask instead of posting a marker. On
+     success, immediately post `advisory-wait: {agent-id} {PR_HEAD_SHA}
+     {ISO8601-requested-at}` as plain text, not an HTML comment, then go
      to the polling loop below.
    - `REQUEST_NEEDED`, `copilotPending` `true` (a request is already
      pending but unproven for current HEAD, no same-head marker to

--- a/idd-template/.github/instructions/lite/idd-advisory-wait-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-advisory-wait-lite.instructions.md
@@ -110,7 +110,7 @@ no `advisoryWait.*` config are: `requestCap` 30,
 | Outcome | E14 action |
 | --- | --- |
 | `SATISFIED` | proceed to CI wait |
-| `REQUEST_NEEDED` | remove the stale pending request if one exists, request Copilot, post the request marker, then poll |
+| `REQUEST_NEEDED` | pending false: request Copilot + marker, poll. pending true (unproven): no lite `AW3-S` cycle — poll only |
 | `RECOVERY_NEEDED` | post the recovery marker (do not request another review), then poll |
 | `CAP_EXHAUSTED` | `phase-specific` (default): proceed to CI wait. `hold`: stop and ask (`HOLD`'s only route; see above) |
 | `WAIT` | keep polling |

--- a/idd-template/.github/instructions/lite/idd-advisory-wait-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-advisory-wait-lite.instructions.md
@@ -110,7 +110,7 @@ no `advisoryWait.*` config are: `requestCap` 30,
 | Outcome | E14 action |
 | --- | --- |
 | `SATISFIED` | proceed to CI wait |
-| `REQUEST_NEEDED` | pending false: request Copilot + marker, poll. pending true (unproven): no lite `AW3-S` cycle — poll only |
+| `REQUEST_NEEDED` | `copilotPending`: false → request Copilot + marker, poll; true (no marker) → no `AW3-S` here — stop and ask |
 | `RECOVERY_NEEDED` | post the recovery marker (do not request another review), then poll |
 | `CAP_EXHAUSTED` | `phase-specific` (default): proceed to CI wait. `hold`: stop and ask (`HOLD`'s only route; see above) |
 | `WAIT` | keep polling |

--- a/idd-template/.github/instructions/lite/idd-resume-stall-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-resume-stall-lite.instructions.md
@@ -92,12 +92,16 @@ Any failure → STOP and restart. Do not post takeover on stale evidence.
 
 ## S5 — Takeover
 
-1. Post claim with fresh `{claim-id}` and `supersedes: <prior-claim-id>`
-   via `post-idd-marker --type claim ... --apply` (or equivalent).
-2. Wait settle delay; re-parse; confirm active claim is yours.
-3. If lost: STOP.
-4. If verified: return to `idd-resume-lite.instructions.md` Step 1, then
-   Step 2/3.
+1. Run `idd-claim-lite.instructions.md` pre-checks (d)/(e); either
+   failing → STOP.
+2. Post claim (fresh `{claim-id}`, `supersedes: <prior-claim-id>`) via
+   `post-idd-marker --type claim ... --apply`, then an
+   activation-nonce for the same `{claim-id}` (same file's step 5).
+3. Wait settle delay; re-parse; confirm claim and nonce winner are
+   yours.
+4. If lost: STOP.
+5. If verified: return to `idd-resume-lite.instructions.md` Step 1,
+   then Step 2/3.
 
 ## Hold behavior
 

--- a/idd-template/.github/instructions/lite/idd-resume-stall-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-resume-stall-lite.instructions.md
@@ -99,9 +99,8 @@ Any failure → STOP and restart. Do not post takeover on stale evidence.
    activation-nonce (`idd-claim-lite.instructions.md` step 5).
 2. Wait settle delay; re-parse; confirm claim and nonce winner are
    yours.
-3. If lost: STOP.
-4. If verified: return to `idd-resume-lite.instructions.md` Step 1,
-   then Step 2/3.
+3. Lost → STOP. Verified → record nonce; return to
+   `idd-resume-lite.instructions.md` Step 1, Step 2/3.
 
 ## Hold behavior
 

--- a/idd-template/.github/instructions/lite/idd-resume-stall-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-resume-stall-lite.instructions.md
@@ -85,22 +85,22 @@ gate.
 4. Fresh server `NOW` + re-run quiet-check; if new activity, STOP and
    restart from resume discovery.
 5. Issue still open; PR not merged.
-6. Plan A5 takeover with settle delay (`claim.verifySettleDelay`, default
+6. Run `idd-claim-lite.instructions.md` pre-checks (d)/(e); either
+   failing → STOP.
+7. Plan A5 takeover with settle delay (`claim.verifySettleDelay`, default
    `PT5S`) and same-second claim-id tie-break.
 
 Any failure → STOP and restart. Do not post takeover on stale evidence.
 
 ## S5 — Takeover
 
-1. Run `idd-claim-lite.instructions.md` pre-checks (d)/(e); either
-   failing → STOP.
-2. Post claim (fresh `{claim-id}`, `supersedes: <prior-claim-id>`) via
+1. Post claim (fresh `{claim-id}`, `supersedes: <prior-claim-id>`) via
    `post-idd-marker --type claim ... --apply`, then an
-   activation-nonce for the same `{claim-id}` (same file's step 5).
-3. Wait settle delay; re-parse; confirm claim and nonce winner are
+   activation-nonce (`idd-claim-lite.instructions.md` step 5).
+2. Wait settle delay; re-parse; confirm claim and nonce winner are
    yours.
-4. If lost: STOP.
-5. If verified: return to `idd-resume-lite.instructions.md` Step 1,
+3. If lost: STOP.
+4. If verified: return to `idd-resume-lite.instructions.md` Step 1,
    then Step 2/3.
 
 ## Hold behavior

--- a/idd-template/.github/instructions/lite/idd-resume-stall-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-resume-stall-lite.instructions.md
@@ -79,14 +79,14 @@ gate.
 
 ## S4 — Race-safe recheck (immediately before write)
 
-1. Re-run `resume-claim-routing.mjs --issue <N>`.
-2. Active claim still the same non-owned `{claim-id}`.
-3. Still stale (≥ 24 h) now.
-4. Fresh server `NOW` + re-run quiet-check; if new activity, STOP and
-   restart from resume discovery.
-5. Issue still open; PR not merged.
-6. Run `idd-claim-lite.instructions.md` pre-checks (d)/(e); either
+1. Run `idd-claim-lite.instructions.md` pre-checks (d)/(e); either
    failing → STOP.
+2. Re-run `resume-claim-routing.mjs --issue <N>`.
+3. Active claim still the same non-owned `{claim-id}`.
+4. Still stale (≥ 24 h) now.
+5. Fresh server `NOW` + re-run quiet-check; if new activity, STOP and
+   restart from resume discovery.
+6. Issue still open; PR not merged.
 7. Plan A5 takeover with settle delay (`claim.verifySettleDelay`, default
    `PT5S`) and same-second claim-id tie-break.
 

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -243,11 +243,11 @@ other GitHub side effect, confirm all of the following:
      {ISO8601-requested-at}` as plain text, not an HTML comment. Then go
      to the polling loop below.
    - `REQUEST_NEEDED`, `copilotPending` `true` (a request is already
-     pending but unproven for current HEAD): lite does not track the
-     claim-id/agent-id the full protocol's bounded `AW3-S`
-     remove/re-request cycle requires — mirror its fail-closed
-     `not-applicable` default: do not remove or re-request; go straight
-     to the polling loop below.
+     pending but unproven for current HEAD, no same-head marker to
+     anchor polling): lite does not track the claim-id/agent-id the
+     full protocol's bounded `AW3-S` remove/re-request cycle requires —
+     stop and ask rather than remove, re-request, or enter the
+     marker-based polling loop below with no marker.
    - `CAP_EXHAUSTED`: apply step 10 below (the secondary-bot check)
      first — it is a non-gating supplement that fires on cap exhaustion
      independent of the cap-exhausted route. Then, if the helper's

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -234,21 +234,19 @@ other GitHub side effect, confirm all of the following:
      `advisory-wait-recovery: {agent-id} {PR_HEAD_SHA}
      {ISO8601-recovery-time}` as plain text. Do not request another
      review. Then go to the polling loop below.
-   - `REQUEST_NEEDED`: if `copilotPending` is true, first remove the
-     stale pending request with `gh pr edit {pr-number}
-     --remove-reviewer "@{primary-advisory-bot}"` (on a GraphQL
-     login-resolution failure, retry via `gh api
-     repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers -X
-     DELETE -f "reviewers[]={primary-advisory-bot-rest-login}"`; if
-     removal fails because the bot is no longer pending, re-run this
-     step from the top; if it fails for any other reason, post a hold
-     comment and stop). Then request the review with `gh pr edit
-     {pr-number} --add-reviewer "@{primary-advisory-bot}"` (on the same
-     GraphQL failure, retry via `gh api
+   - `REQUEST_NEEDED`, `copilotPending` `false`: request the review with
+     `gh pr edit {pr-number} --add-reviewer "@{primary-advisory-bot}"`
+     (on a GraphQL login-resolution failure, retry via `gh api
      repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers -X POST
      -f "reviewers[]={primary-advisory-bot-rest-login}"`). Immediately
      post `advisory-wait: {agent-id} {PR_HEAD_SHA}
      {ISO8601-requested-at}` as plain text, not an HTML comment. Then go
+     to the polling loop below.
+   - `REQUEST_NEEDED`, `copilotPending` `true` (a request is already
+     pending but unproven for current HEAD): lite does not track the
+     claim-id/agent-id the full protocol's bounded `AW3-S`
+     remove/re-request cycle requires — mirror its fail-closed
+     `not-applicable` default: do not remove or re-request; go straight
      to the polling loop below.
    - `CAP_EXHAUSTED`: apply step 10 below (the secondary-bot check)
      first — it is a non-gating supplement that fires on cap exhaustion

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -238,9 +238,10 @@ other GitHub side effect, confirm all of the following:
      `gh pr edit {pr-number} --add-reviewer "@{primary-advisory-bot}"`
      (on a GraphQL login-resolution failure, retry via `gh api
      repos/{owner}/{repo}/pulls/{pr-number}/requested_reviewers -X POST
-     -f "reviewers[]={primary-advisory-bot-rest-login}"`). Immediately
-     post `advisory-wait: {agent-id} {PR_HEAD_SHA}
-     {ISO8601-requested-at}` as plain text, not an HTML comment. Then go
+     -f "reviewers[]={primary-advisory-bot-rest-login}"`). If both
+     attempts fail, stop and ask instead of posting a marker. On
+     success, immediately post `advisory-wait: {agent-id} {PR_HEAD_SHA}
+     {ISO8601-requested-at}` as plain text, not an HTML comment, then go
      to the polling loop below.
    - `REQUEST_NEEDED`, `copilotPending` `true` (a request is already
      pending but unproven for current HEAD, no same-head marker to


### PR DESCRIPTION
## Summary

Two lite-profile files replaced fail-closed full-protocol behavior with
un-gated mutations, both files' own "same semantics as the full
protocol" disclaimers notwithstanding:

- **Lite E14 stale-request recovery was uncapped and un-gated.**
  `lite/idd-review-fix-lite.instructions.md`'s `REQUEST_NEEDED` handling
  unconditionally removed a stale pending Copilot review request and
  re-requested whenever `copilotPending` was true -- with no cap, no
  claim-binding, and no `attempt:{n}` marker. The full protocol
  (`idd-review-fix.instructions.md`) only performs that mutation via the
  claim-bound, capped `AW3-S` cycle; when claim-id/agent-id aren't
  available, it falls through to its `not-applicable` fail-closed
  default (poll, don't mutate). Since lite tracks no claim-id/agent-id
  for this path, it now mirrors that same fail-closed default instead
  of running the unbounded mutation on every poll. Mirrored the same fix
  into `lite/idd-advisory-wait-lite.instructions.md`'s outcome table.
- **Lite S5 stalled-takeover bypassed the A5 pipeline.**
  `lite/idd-resume-stall-lite.instructions.md` S5 posted the takeover
  claim directly via `post-idd-marker`, with no A5(d) open-PR check, no
  A5(e) branch-collision check, and no activation-nonce post -- although
  `idd-claim-lite.instructions.md` requires the nonce on every fresh
  activation and both claim files require A5's race-safe branch-collision
  and open-PR checks even on a re-claim. S5 now runs those two
  pre-checks from `idd-claim-lite.instructions.md` before posting the
  takeover claim, and posts the activation-nonce alongside it.

All edits were made to the canonical `idd-template/` sources and
regenerated into `.github/instructions/lite/` via
`node scripts/sync-docs.mjs --apply`, per this repository's sync
convention.

## Byte budget

`idd-advisory-wait-lite.instructions.md` and
`idd-resume-stall-lite.instructions.md` both sit in tight
`context-ceiling-128k` bundle budgets (bundle-review-fix-lite,
bundle-review-snapshot-lite, bundle-resume-lite). The added pre-check
and nonce text was offset by trimming the mutation prose it replaced,
so all three bundles stay under their 98% hard ceiling after this
change (`node scripts/audit-docs.mjs --check` passes; only the
pre-existing ≥95% notices remain).

## Test plan

- [x] `node scripts/audit-docs.mjs --check` -- passed (bundle budgets
      hold)
- [x] `node scripts/audit-code-span-wrap.mjs` -- no mid-token wraps
- [x] `npx cspell lint "**"` -- 0 issues
- [x] `node --test tests/*.test.mts` -- 2727/2727 pass
- [x] `pnpm run build:check` -- no drift
- [x] `node scripts/idd-doctor.mjs` -- passed (pre-existing warnings
      only)
- [x] pre-push-validate (biome, dprint, markdownlint, cspell,
      audit-docs, audit-code-span-wrap, build:check, idd-doctor)

Closes #1700

Refs #1572, #1528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Workflow Improvements**
  * Improved advisory request handling to prevent duplicate requests when one is already pending.
  * Added clearer stop-and-ask behavior when required advisory markers are missing.
  * Strengthened resume and takeover checks by revalidating stale claims and confirming the winning activation before continuing.
  * Applied these workflow updates consistently across the primary instructions and their templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->