### PR TITLE
fix(skill): correct draft-patterns' orphan-eligibility chooser and guard it in the sync manifest

### DIFF
--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -16,10 +16,12 @@ chooser for output shapes.
 ## Output chooser
 
 Draft an orphan issue only when one autonomous task can finish the work
-and the target repository is discoverable through `issue-scope:
-orphan-first`. If the repository uses `orphan-first-policy:
+and the target repository discovers orphans (`issue-scope:
+roadmap-first`, the default, via the orphan fallback, or
+`orphan-first`). If the repository uses `orphan-first-policy:
 maintainer-approved`, include a post-publication approval step after the
-final issue content is stable. If a public repository uses
+final issue content is stable. If the repository sets `issue-scope:
+roadmap` (roadmap-only) or a public repository uses
 `orphan-first-policy: public-disabled`, draft a roadmap package instead.
 
 If the repository keeps the broader secure-by-default issue-author

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -658,6 +658,17 @@
       ]
     },
     {
+      "id": "issue-authoring-draft-patterns-reference",
+      "reference": "docs/issue-authoring-skill.md",
+      "target": "skills/issue-authoring/references/draft-patterns.md",
+      "mode": "contains",
+      "requiredText": [
+        "the target repository discovers orphans (`issue-scope:",
+        "via the orphan fallback",
+        "can actually discover orphan"
+      ]
+    },
+    {
       "id": "minimize-superseded-markers-helper",
       "source": "scripts/minimize-superseded-markers.mjs",
       "target": "idd-template/scripts/minimize-superseded-markers.mjs",

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -16,10 +16,12 @@ chooser for output shapes.
 ## Output chooser
 
 Draft an orphan issue only when one autonomous task can finish the work
-and the target repository is discoverable through `issue-scope:
-orphan-first`. If the repository uses `orphan-first-policy:
+and the target repository discovers orphans (`issue-scope:
+roadmap-first`, the default, via the orphan fallback, or
+`orphan-first`). If the repository uses `orphan-first-policy:
 maintainer-approved`, include a post-publication approval step after the
-final issue content is stable. If a public repository uses
+final issue content is stable. If the repository sets `issue-scope:
+roadmap` (roadmap-only) or a public repository uses
 `orphan-first-policy: public-disabled`, draft a roadmap package instead.
 
 If the repository keeps the broader secure-by-default issue-author


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`skills/issue-authoring/references/draft-patterns.md`'s "Output
chooser" paragraph wrongly said orphan issues are discoverable only
under `issue-scope: orphan-first`, contradicting `contract.md`,
`SKILL.md`, `docs/issue-authoring-skill.md`, and draft-patterns' own
"Example orphan issue" section. Following the old chooser in any
default-configured repository (including this one,
`issueScope: "roadmap-first"`) wrongly concluded orphans were
undiscoverable and forced single-task work into a one-item roadmap
package.

- Rewrite the chooser to state the correct rule: orphans are
  discoverable under `roadmap-first` (the default, via the orphan
  fallback) or `orphan-first`, and add the previously-missing
  `issue-scope: roadmap` (roadmap-only) exclusion so the chooser and
  the Example orphan issue section state the same eligibility rule.
- Add a `contains`-mode syncPair guard in `audit/sync-manifest.json`
  so `audit-docs --check` mechanically catches this wording drifting
  again, mirroring the existing `contract.md`/`workflow-boundary.md`
  guards. Verified locally by temporarily reverting the wording and
  confirming `audit-docs --check` fails on the new guard, then
  restoring the fix.
- Regenerate the `.claude/skills/issue-authoring/` mirror via
  `node scripts/sync-docs.mjs --apply` (byte-identical to canonical).

## Linked issue

Closes #1702

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Contributing cause noted in the issue: `draft-patterns.md` was the
only reference file in the bundle with no `contains`-mode guard in
`audit/sync-manifest.json` (guards already existed for
`workflow-boundary.md` and `contract.md`), so this drift was invisible
to `audit-docs --check`.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
