### PR TITLE
fix(docs-tooling): unify generatedBlocks file resolution

### DIFF
--- a/audit/README.md
+++ b/audit/README.md
@@ -73,11 +73,15 @@ Step 3 is required for the audit check to pass — it compares `paths`
 against the files each block's `sourceGlobs` actually match, and fails
 by naming the block and the glob-matched file missing from `paths` (the
 error has the form `<block-id>: manifest paths omit <path>`, where
-`<block-id>` and `<path>` stand for the actual block id and file path)
-— even though `paths` plays no role in `sync-docs.mjs`'s own
-mirror-generation logic. Adding only the `syncPairs` and
-`bundleBudgets` entries above is not enough; skipping the
-`generatedBlocks[].paths` edit still fails the audit.
+`<block-id>` and `<path>` stand for the actual block id and file path).
+`sync-docs.mjs` shares this exact `paths`-first, `sourceGlobs`-fallback
+resolution rule with `audit-docs.mjs` (one function, imported by both):
+`paths` is the only input it consults when present, and `sourceGlobs` is
+used only as a fallback when `paths` is absent — so skipping the
+`generatedBlocks[].paths` edit does not regenerate an empty block, but
+it still fails this `paths`/`sourceGlobs` consistency check. Adding only
+the `syncPairs` and `bundleBudgets` entries above is not enough;
+skipping the `generatedBlocks[].paths` edit still fails the audit.
 
 ## Instruction Size Budgets
 

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -16,8 +16,11 @@ import {
   collectPolicyConfigDrift,
   collectRootMarkdownAllowlistViolations,
   collectTypeSuppressionViolations,
+  globFiles,
   isBannerScopedInstructionTarget,
+  resolveGeneratedBlockFiles,
   stripGeneratedFromBanner,
+  uniqueSorted,
 } from './consistency-helpers.mjs';
 
 const root = process.cwd();
@@ -80,7 +83,7 @@ function checkGeneratedSourcePairs() {
   const bannerPattern = /^\/\/ idd-generated-from:\s*(\S+)/m;
   const repoFileSet = new Set(repoFiles);
   // Forward direction: each source has its generated counterpart.
-  for (const source of globFiles('src/**/*.mts')) {
+  for (const source of globFiles('src/**/*.mts', repoFiles)) {
     const emitted = emittedPathForSource(source);
     if (!emitted) {
       errors.push(
@@ -97,8 +100,8 @@ function checkGeneratedSourcePairs() {
   // Reverse direction: each banner-marked artifact has its source, and the
   // banner resolves back to this exact file.
   for (const emitted of [
-    ...globFiles('scripts/**/*.mjs'),
-    ...globFiles('bin/**/*.mjs'),
+    ...globFiles('scripts/**/*.mjs', repoFiles),
+    ...globFiles('bin/**/*.mjs', repoFiles),
   ]) {
     const match = bannerPattern.exec(readText(emitted));
     if (!match) {
@@ -179,8 +182,8 @@ function checkFileSets(fileSets, syncPairs) {
     syncPairs.map((pair) => `${pair.source}\0${pair.target}`),
   );
   for (const fileSet of fileSets) {
-    const sourceFiles = globFiles(fileSet.sourceGlob);
-    const targetFiles = globFiles(fileSet.targetGlob);
+    const sourceFiles = globFiles(fileSet.sourceGlob, repoFiles);
+    const targetFiles = globFiles(fileSet.targetGlob, repoFiles);
     if (fileSet.match !== 'basename') {
       errors.push(
         `${fileSet.id}: unsupported file set match mode ${fileSet.match}`,
@@ -320,11 +323,10 @@ function renderGeneratedBlock(block) {
   return `\n\n\`\`\`${block.language ?? 'text'}\n${renderedFiles.join('\n')}\n\`\`\`\n\n`;
 }
 function resolveBlockFiles(block) {
-  const files = block.paths
-    ? [...block.paths]
-    : uniqueSorted((block.sourceGlobs ?? []).flatMap(globFiles));
+  const blockGlobFiles = (pattern) => globFiles(pattern, repoFiles);
+  const files = resolveGeneratedBlockFiles(block, blockGlobFiles);
   const actualFiles = uniqueSorted(
-    (block.sourceGlobs ?? []).flatMap(globFiles),
+    (block.sourceGlobs ?? []).flatMap(blockGlobFiles),
   );
   if (block.paths && block.sourceGlobs) {
     const expectedSet = new Set(block.paths);
@@ -418,7 +420,7 @@ function checkContainsPair(pair) {
 function checkForbiddenPatterns(patterns) {
   for (const pattern of patterns) {
     const regex = new RegExp(pattern.pattern, 'i');
-    const files = globFiles(pattern.glob);
+    const files = globFiles(pattern.glob, repoFiles);
     for (const file of files) {
       const text = readText(file);
       if (regex.test(stripGeneratedBlocks(text))) {
@@ -454,7 +456,9 @@ function checkTypeSuppressionBudgets(config) {
     );
     return;
   }
-  const files = uniqueSorted(globs.flatMap(globFiles)).map((path) => ({
+  const files = uniqueSorted(
+    globs.flatMap((glob) => globFiles(glob, repoFiles)),
+  ).map((path) => ({
     path,
     text: readText(path),
   }));
@@ -515,18 +519,30 @@ function checkConfigInstructionDrift() {
   }
 }
 function buildRemediation(currentErrors) {
-  if (!containsMirrorDrift(currentErrors)) {
+  const hasMirrorDrift = containsMirrorDrift(currentErrors);
+  const hasManifestListMismatch = containsManifestListMismatch(currentErrors);
+  if (!hasMirrorDrift && !hasManifestListMismatch) {
     return [];
   }
-  const syncCommand = detectSyncCommand();
   const lines = [];
-  if (syncCommand) {
+  if (hasMirrorDrift) {
+    const syncCommand = detectSyncCommand();
+    if (syncCommand) {
+      lines.push(
+        `run \`${syncCommand}\` to refresh mirrored files from canonical sources`,
+      );
+    } else {
+      lines.push(
+        'align canonical files and their mirrored counterparts for the reported drift paths',
+      );
+    }
+  }
+  if (hasManifestListMismatch) {
+    // A manifest-list mismatch is not mirror drift: `docs:sync` reads
+    // `generatedBlocks[].paths` as-is, so it cannot resolve a disagreement
+    // between `paths` and what `sourceGlobs` actually matches (#1703).
     lines.push(
-      `run \`${syncCommand}\` to refresh mirrored files from canonical sources`,
-    );
-  } else {
-    lines.push(
-      'align canonical files and their mirrored counterparts for the reported drift paths',
+      "edit `audit/sync-manifest.json`'s `generatedBlocks[].paths` to match the reported `sourceGlobs` result -- `docs:sync` cannot fix a manifest-list mismatch",
     );
   }
   lines.push('re-run `node scripts/audit-docs.mjs --check`');
@@ -534,7 +550,14 @@ function buildRemediation(currentErrors) {
 }
 function containsMirrorDrift(currentErrors) {
   return currentErrors.some((error) =>
-    /generated block .* is stale|shell file list .* is stale| and .* differ in (exact|concreted) mode|heading structure differs between|target is missing|target has unexpected|is missing a syncPairs entry|manifest paths omit|manifest path does not exist or match globs/.test(
+    /generated block .* is stale|shell file list .* is stale| and .* differ in (exact|concreted) mode|heading structure differs between|target is missing|target has unexpected|is missing a syncPairs entry/.test(
+      error,
+    ),
+  );
+}
+function containsManifestListMismatch(currentErrors) {
+  return currentErrors.some((error) =>
+    /manifest paths omit|manifest path does not exist or match globs/.test(
       error,
     ),
   );
@@ -629,7 +652,10 @@ function checkInstructionSizeBudgets(configs) {
       config,
       changedFiles,
       () =>
-        globFiles(config.glob ?? '.github/instructions/idd-*.instructions.md'),
+        globFiles(
+          config.glob ?? '.github/instructions/idd-*.instructions.md',
+          repoFiles,
+        ),
       readText,
     );
     errors.push(...result.errors);
@@ -751,39 +777,10 @@ function listRepoFiles() {
   ]);
   return output.split(/\r?\n/).filter(Boolean).sort();
 }
-// Excluded from the node-core-builtins roadmap's (#1445) built-in swaps:
-// this matches `pattern` against `repoFiles`, an in-memory list already
-// fetched from `git ls-files --cached --others --exclude-standard` (see
-// `listRepoFiles`), which correctly excludes gitignored and untracked
-// files. Swapping this for `fs.globSync` would instead search the real
-// filesystem and widen the matched set to files `git ls-files` deliberately
-// omits.
-function globFiles(pattern) {
-  const regex = globToRegExp(pattern);
-  return repoFiles.filter((file) => regex.test(file)).sort();
-}
-function globToRegExp(pattern) {
-  let source = '^';
-  for (let index = 0; index < pattern.length; index += 1) {
-    const char = pattern[index];
-    if (char === '*') {
-      if (pattern[index + 1] === '*') {
-        if (pattern[index + 2] === '/') {
-          source += '(?:.*/)?';
-          index += 2;
-        } else {
-          source += '.*';
-          index += 1;
-        }
-      } else {
-        source += '[^/]*';
-      }
-      continue;
-    }
-    source += escapeRegExp(char);
-  }
-  return new RegExp(`${source}$`);
-}
+// glob matching against `repoFiles` (an in-memory list already fetched
+// from `git ls-files --cached --others --exclude-standard`, see
+// `listRepoFiles`) is shared with sync-docs.mts via consistency-helpers.mts
+// (#1703) as `globFiles`/`globToRegExp`, imported above.
 function headingSignature(text, { levelsOnly }) {
   const headings = [];
   let inFence = false;
@@ -925,10 +922,4 @@ function findDuplicateBasenames(files) {
     }
   }
   return duplicates;
-}
-function uniqueSorted(values) {
-  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
-}
-function escapeRegExp(value) {
-  return value.replace(/[\\^$+?.()|[\]{}]/g, '\\$&');
 }

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -835,3 +835,48 @@ export function collectDuplicateSyncPairTargets(syncPairs) {
   }
   return violations;
 }
+export function uniqueSorted(values) {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+export function globToRegExp(pattern) {
+  let source = '^';
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    if (char === '*') {
+      if (pattern[index + 1] === '*') {
+        if (pattern[index + 2] === '/') {
+          source += '(?:.*/)?';
+          index += 2;
+        } else {
+          source += '.*';
+          index += 1;
+        }
+      } else {
+        source += '[^/]*';
+      }
+      continue;
+    }
+    source += escapeRegExpChar(char);
+  }
+  return new RegExp(`${source}$`);
+}
+function escapeRegExpChar(value) {
+  return value.replace(/[\\^$+?.()|[\]{}]/g, '\\$&');
+}
+/** Matches `pattern` against a caller-supplied repo file list. */
+export function globFiles(pattern, repoFiles) {
+  const regex = globToRegExp(pattern);
+  return repoFiles.filter((file) => regex.test(file)).sort();
+}
+/**
+ * Resolves a `generatedBlocks[]` entry's file list: the static `paths`
+ * list when present, otherwise every repo file matching `sourceGlobs`
+ * (deduped and sorted). `globFilesFn` is injected so each caller supplies
+ * its own file listing instead of re-implementing the glob walk.
+ */
+export function resolveGeneratedBlockFiles(block, globFilesFn) {
+  if (block.paths) {
+    return [...block.paths];
+  }
+  return uniqueSorted((block.sourceGlobs ?? []).flatMap(globFilesFn));
+}

--- a/scripts/sync-docs.mjs
+++ b/scripts/sync-docs.mjs
@@ -54,11 +54,20 @@ let repoFilesCache = null;
 // Lazy: only shelled out to when a block actually falls back to
 // sourceGlobs (today's manifest sets `paths` on every entry), so a normal
 // run with no sourceGlobs-only blocks never pays for this git call.
+//
+// Deliberately omits `--full-name`: `sourceGlobs` patterns are written
+// relative to `root` (the nearest `package.json`, not necessarily the
+// git worktree's top level -- e.g. an adopter monorepo with a nested
+// `package.json`), and `git ls-files` without `--full-name` already
+// prints paths relative to its own `cwd`, which is `root` below. Adding
+// `--full-name` would instead force paths relative to the git project
+// top, silently mismatching every `sourceGlobs` pattern whenever `root`
+// differs from that top level (#1748 review).
 function getRepoFiles() {
   if (!repoFilesCache) {
     const output = execFileSync(
       'git',
-      ['ls-files', '--cached', '--others', '--exclude-standard', '--full-name'],
+      ['ls-files', '--cached', '--others', '--exclude-standard'],
       { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
     );
     repoFilesCache = output.split(/\r?\n/).filter(Boolean).sort();
@@ -363,6 +372,15 @@ function resolveBlockFiles(block) {
   // paths-first, sourceGlobs-fallback -- shared with audit-docs.mjs via
   // consistency-helpers.mts's resolveGeneratedBlockFiles (#1703) so the two
   // tools cannot drift on this resolution rule again.
+  //
+  // Known limitation (#1748 review): getRepoFiles() caches a single
+  // git-ls-files snapshot taken before this run's writes are applied
+  // (this script queues every diff, then writes them all at the end). A
+  // sourceGlobs-only block whose pattern would match a file a syncPairs
+  // entry creates in this SAME --apply run won't see that not-yet-written
+  // file until a second --apply pass. No current manifest entry combines
+  // sourceGlobs-only resolution with a same-run syncPairs target this
+  // way; re-running --apply converges if one ever does.
   return resolveGeneratedBlockFiles(block, (pattern) =>
     globFiles(pattern, getRepoFiles()),
   );

--- a/scripts/sync-docs.mjs
+++ b/scripts/sync-docs.mjs
@@ -19,11 +19,14 @@
  *   structure  — only heading structure is checked; no source to copy
  *   contains   — only text-presence is checked; no source to copy
  */
+import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import {
+  globFiles,
   injectGeneratedFromBanner,
   isBannerScopedInstructionTarget,
+  resolveGeneratedBlockFiles,
 } from './consistency-helpers.mjs';
 
 // Resolve the repository root by walking up to the nearest package.json,
@@ -47,6 +50,21 @@ function resolveRepoRoot(fromDir) {
 }
 const root = resolveRepoRoot(import.meta.dirname);
 const manifestPath = 'audit/sync-manifest.json';
+let repoFilesCache = null;
+// Lazy: only shelled out to when a block actually falls back to
+// sourceGlobs (today's manifest sets `paths` on every entry), so a normal
+// run with no sourceGlobs-only blocks never pays for this git call.
+function getRepoFiles() {
+  if (!repoFilesCache) {
+    const output = execFileSync(
+      'git',
+      ['ls-files', '--cached', '--others', '--exclude-standard', '--full-name'],
+      { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+    repoFilesCache = output.split(/\r?\n/).filter(Boolean).sort();
+  }
+  return repoFilesCache;
+}
 const args = process.argv.slice(2);
 const apply = args.includes('--apply');
 const manifest = JSON.parse(readText(manifestPath));
@@ -342,8 +360,12 @@ function renderGeneratedBlock(block) {
   return `\n\n\`\`\`${block.language ?? 'text'}\n${renderedFiles.join('\n')}\n\`\`\`\n\n`;
 }
 function resolveBlockFiles(block) {
-  // Use the static paths list when present; this matches audit-docs.mjs behaviour.
-  return block.paths ? [...block.paths] : [];
+  // paths-first, sourceGlobs-fallback -- shared with audit-docs.mjs via
+  // consistency-helpers.mts's resolveGeneratedBlockFiles (#1703) so the two
+  // tools cannot drift on this resolution rule again.
+  return resolveGeneratedBlockFiles(block, (pattern) =>
+    globFiles(pattern, getRepoFiles()),
+  );
 }
 function applyReplacements(text, replacements) {
   let result = text;

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -25,8 +25,11 @@ import {
   collectPolicyConfigDrift,
   collectRootMarkdownAllowlistViolations,
   collectTypeSuppressionViolations,
+  globFiles,
   isBannerScopedInstructionTarget,
+  resolveGeneratedBlockFiles,
   stripGeneratedFromBanner,
+  uniqueSorted,
 } from './consistency-helpers.mts';
 
 interface ReadmePair {
@@ -172,7 +175,7 @@ function checkGeneratedSourcePairs() {
   const repoFileSet = new Set(repoFiles);
 
   // Forward direction: each source has its generated counterpart.
-  for (const source of globFiles('src/**/*.mts')) {
+  for (const source of globFiles('src/**/*.mts', repoFiles)) {
     const emitted = emittedPathForSource(source);
     if (!emitted) {
       errors.push(
@@ -190,8 +193,8 @@ function checkGeneratedSourcePairs() {
   // Reverse direction: each banner-marked artifact has its source, and the
   // banner resolves back to this exact file.
   for (const emitted of [
-    ...globFiles('scripts/**/*.mjs'),
-    ...globFiles('bin/**/*.mjs'),
+    ...globFiles('scripts/**/*.mjs', repoFiles),
+    ...globFiles('bin/**/*.mjs', repoFiles),
   ]) {
     const match = bannerPattern.exec(readText(emitted));
     if (!match) {
@@ -281,8 +284,8 @@ function checkFileSets(fileSets: FileSet[], syncPairs: SyncPair[]) {
   );
 
   for (const fileSet of fileSets) {
-    const sourceFiles = globFiles(fileSet.sourceGlob);
-    const targetFiles = globFiles(fileSet.targetGlob);
+    const sourceFiles = globFiles(fileSet.sourceGlob, repoFiles);
+    const targetFiles = globFiles(fileSet.targetGlob, repoFiles);
 
     if (fileSet.match !== 'basename') {
       errors.push(
@@ -440,11 +443,10 @@ function renderGeneratedBlock(block: GeneratedBlock): string {
 }
 
 function resolveBlockFiles(block: GeneratedBlock): string[] {
-  const files = block.paths
-    ? [...block.paths]
-    : uniqueSorted((block.sourceGlobs ?? []).flatMap(globFiles));
+  const blockGlobFiles = (pattern: string) => globFiles(pattern, repoFiles);
+  const files = resolveGeneratedBlockFiles(block, blockGlobFiles);
   const actualFiles = uniqueSorted(
-    (block.sourceGlobs ?? []).flatMap(globFiles),
+    (block.sourceGlobs ?? []).flatMap(blockGlobFiles),
   );
 
   if (block.paths && block.sourceGlobs) {
@@ -549,7 +551,7 @@ function checkContainsPair(pair: SyncPair) {
 function checkForbiddenPatterns(patterns: ForbiddenPattern[]) {
   for (const pattern of patterns) {
     const regex = new RegExp(pattern.pattern, 'i');
-    const files = globFiles(pattern.glob);
+    const files = globFiles(pattern.glob, repoFiles);
     for (const file of files) {
       const text = readText(file);
       if (regex.test(stripGeneratedBlocks(text))) {
@@ -592,7 +594,9 @@ function checkTypeSuppressionBudgets(
     );
     return;
   }
-  const files = uniqueSorted(globs.flatMap(globFiles)).map((path) => ({
+  const files = uniqueSorted(
+    globs.flatMap((glob) => globFiles(glob, repoFiles)),
+  ).map((path) => ({
     path,
     text: readText(path),
   }));
@@ -659,18 +663,30 @@ function checkConfigInstructionDrift() {
 }
 
 function buildRemediation(currentErrors: string[]): string[] {
-  if (!containsMirrorDrift(currentErrors)) {
+  const hasMirrorDrift = containsMirrorDrift(currentErrors);
+  const hasManifestListMismatch = containsManifestListMismatch(currentErrors);
+  if (!hasMirrorDrift && !hasManifestListMismatch) {
     return [];
   }
-  const syncCommand = detectSyncCommand();
   const lines: string[] = [];
-  if (syncCommand) {
+  if (hasMirrorDrift) {
+    const syncCommand = detectSyncCommand();
+    if (syncCommand) {
+      lines.push(
+        `run \`${syncCommand}\` to refresh mirrored files from canonical sources`,
+      );
+    } else {
+      lines.push(
+        'align canonical files and their mirrored counterparts for the reported drift paths',
+      );
+    }
+  }
+  if (hasManifestListMismatch) {
+    // A manifest-list mismatch is not mirror drift: `docs:sync` reads
+    // `generatedBlocks[].paths` as-is, so it cannot resolve a disagreement
+    // between `paths` and what `sourceGlobs` actually matches (#1703).
     lines.push(
-      `run \`${syncCommand}\` to refresh mirrored files from canonical sources`,
-    );
-  } else {
-    lines.push(
-      'align canonical files and their mirrored counterparts for the reported drift paths',
+      "edit `audit/sync-manifest.json`'s `generatedBlocks[].paths` to match the reported `sourceGlobs` result -- `docs:sync` cannot fix a manifest-list mismatch",
     );
   }
   lines.push('re-run `node scripts/audit-docs.mjs --check`');
@@ -679,7 +695,15 @@ function buildRemediation(currentErrors: string[]): string[] {
 
 function containsMirrorDrift(currentErrors: string[]): boolean {
   return currentErrors.some((error) =>
-    /generated block .* is stale|shell file list .* is stale| and .* differ in (exact|concreted) mode|heading structure differs between|target is missing|target has unexpected|is missing a syncPairs entry|manifest paths omit|manifest path does not exist or match globs/.test(
+    /generated block .* is stale|shell file list .* is stale| and .* differ in (exact|concreted) mode|heading structure differs between|target is missing|target has unexpected|is missing a syncPairs entry/.test(
+      error,
+    ),
+  );
+}
+
+function containsManifestListMismatch(currentErrors: string[]): boolean {
+  return currentErrors.some((error) =>
+    /manifest paths omit|manifest path does not exist or match globs/.test(
       error,
     ),
   );
@@ -780,7 +804,10 @@ function checkInstructionSizeBudgets(configs: unknown) {
       config,
       changedFiles,
       () =>
-        globFiles(config.glob ?? '.github/instructions/idd-*.instructions.md'),
+        globFiles(
+          config.glob ?? '.github/instructions/idd-*.instructions.md',
+          repoFiles,
+        ),
       readText,
     );
     errors.push(...result.errors);
@@ -923,40 +950,10 @@ function listRepoFiles(): string[] {
   return output.split(/\r?\n/).filter(Boolean).sort();
 }
 
-// Excluded from the node-core-builtins roadmap's (#1445) built-in swaps:
-// this matches `pattern` against `repoFiles`, an in-memory list already
-// fetched from `git ls-files --cached --others --exclude-standard` (see
-// `listRepoFiles`), which correctly excludes gitignored and untracked
-// files. Swapping this for `fs.globSync` would instead search the real
-// filesystem and widen the matched set to files `git ls-files` deliberately
-// omits.
-function globFiles(pattern: string): string[] {
-  const regex = globToRegExp(pattern);
-  return repoFiles.filter((file) => regex.test(file)).sort();
-}
-
-function globToRegExp(pattern: string): RegExp {
-  let source = '^';
-  for (let index = 0; index < pattern.length; index += 1) {
-    const char = pattern[index];
-    if (char === '*') {
-      if (pattern[index + 1] === '*') {
-        if (pattern[index + 2] === '/') {
-          source += '(?:.*/)?';
-          index += 2;
-        } else {
-          source += '.*';
-          index += 1;
-        }
-      } else {
-        source += '[^/]*';
-      }
-      continue;
-    }
-    source += escapeRegExp(char);
-  }
-  return new RegExp(`${source}$`);
-}
+// glob matching against `repoFiles` (an in-memory list already fetched
+// from `git ls-files --cached --others --exclude-standard`, see
+// `listRepoFiles`) is shared with sync-docs.mts via consistency-helpers.mts
+// (#1703) as `globFiles`/`globToRegExp`, imported above.
 
 function headingSignature(
   text: string,
@@ -1122,12 +1119,4 @@ function findDuplicateBasenames(files: string[]): Map<string, string[]> {
     }
   }
   return duplicates;
-}
-
-function uniqueSorted(values: string[]): string[] {
-  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[\\^$+?.()|[\]{}]/g, '\\$&');
 }

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -993,3 +993,70 @@ export function collectDuplicateSyncPairTargets(
   }
   return violations;
 }
+
+// --- generatedBlocks file resolution (#1703) --------------------------------
+//
+// sync-docs.mts and audit-docs.mts each independently decided how a
+// `generatedBlocks[]` manifest entry resolves to a file list, and drifted:
+// audit-docs.mts fell back to globbing `sourceGlobs` when `paths` was
+// absent, sync-docs.mts silently returned an empty list. Sharing this one
+// function pins the resolution rule in a single place so the two tools
+// cannot diverge on it again.
+
+export interface GeneratedBlockFileSource {
+  paths?: string[];
+  sourceGlobs?: string[];
+}
+
+export function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
+export function globToRegExp(pattern: string): RegExp {
+  let source = '^';
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    if (char === '*') {
+      if (pattern[index + 1] === '*') {
+        if (pattern[index + 2] === '/') {
+          source += '(?:.*/)?';
+          index += 2;
+        } else {
+          source += '.*';
+          index += 1;
+        }
+      } else {
+        source += '[^/]*';
+      }
+      continue;
+    }
+    source += escapeRegExpChar(char);
+  }
+  return new RegExp(`${source}$`);
+}
+
+function escapeRegExpChar(value: string): string {
+  return value.replace(/[\\^$+?.()|[\]{}]/g, '\\$&');
+}
+
+/** Matches `pattern` against a caller-supplied repo file list. */
+export function globFiles(pattern: string, repoFiles: string[]): string[] {
+  const regex = globToRegExp(pattern);
+  return repoFiles.filter((file) => regex.test(file)).sort();
+}
+
+/**
+ * Resolves a `generatedBlocks[]` entry's file list: the static `paths`
+ * list when present, otherwise every repo file matching `sourceGlobs`
+ * (deduped and sorted). `globFilesFn` is injected so each caller supplies
+ * its own file listing instead of re-implementing the glob walk.
+ */
+export function resolveGeneratedBlockFiles(
+  block: GeneratedBlockFileSource,
+  globFilesFn: (pattern: string) => string[],
+): string[] {
+  if (block.paths) {
+    return [...block.paths];
+  }
+  return uniqueSorted((block.sourceGlobs ?? []).flatMap(globFilesFn));
+}

--- a/src/scripts/sync-docs.mts
+++ b/src/scripts/sync-docs.mts
@@ -98,11 +98,20 @@ let repoFilesCache: string[] | null = null;
 // Lazy: only shelled out to when a block actually falls back to
 // sourceGlobs (today's manifest sets `paths` on every entry), so a normal
 // run with no sourceGlobs-only blocks never pays for this git call.
+//
+// Deliberately omits `--full-name`: `sourceGlobs` patterns are written
+// relative to `root` (the nearest `package.json`, not necessarily the
+// git worktree's top level -- e.g. an adopter monorepo with a nested
+// `package.json`), and `git ls-files` without `--full-name` already
+// prints paths relative to its own `cwd`, which is `root` below. Adding
+// `--full-name` would instead force paths relative to the git project
+// top, silently mismatching every `sourceGlobs` pattern whenever `root`
+// differs from that top level (#1748 review).
 function getRepoFiles(): string[] {
   if (!repoFilesCache) {
     const output = execFileSync(
       'git',
-      ['ls-files', '--cached', '--others', '--exclude-standard', '--full-name'],
+      ['ls-files', '--cached', '--others', '--exclude-standard'],
       { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
     );
     repoFilesCache = output.split(/\r?\n/).filter(Boolean).sort();
@@ -455,6 +464,15 @@ function resolveBlockFiles(block: GeneratedBlock): string[] {
   // paths-first, sourceGlobs-fallback -- shared with audit-docs.mjs via
   // consistency-helpers.mts's resolveGeneratedBlockFiles (#1703) so the two
   // tools cannot drift on this resolution rule again.
+  //
+  // Known limitation (#1748 review): getRepoFiles() caches a single
+  // git-ls-files snapshot taken before this run's writes are applied
+  // (this script queues every diff, then writes them all at the end). A
+  // sourceGlobs-only block whose pattern would match a file a syncPairs
+  // entry creates in this SAME --apply run won't see that not-yet-written
+  // file until a second --apply pass. No current manifest entry combines
+  // sourceGlobs-only resolution with a same-run syncPairs target this
+  // way; re-running --apply converges if one ever does.
   return resolveGeneratedBlockFiles(block, (pattern) =>
     globFiles(pattern, getRepoFiles()),
   );

--- a/src/scripts/sync-docs.mts
+++ b/src/scripts/sync-docs.mts
@@ -21,11 +21,14 @@
  *   contains   — only text-presence is checked; no source to copy
  */
 
+import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import {
+  globFiles,
   injectGeneratedFromBanner,
   isBannerScopedInstructionTarget,
+  resolveGeneratedBlockFiles,
 } from './consistency-helpers.mts';
 
 interface SyncPair {
@@ -42,6 +45,7 @@ interface GeneratedBlock {
   language?: string;
   stripPrefix?: string;
   paths?: string[];
+  sourceGlobs?: string[];
 }
 
 interface ShellFileList {
@@ -88,6 +92,23 @@ function resolveRepoRoot(fromDir: string): string {
 
 const root = resolveRepoRoot(import.meta.dirname);
 const manifestPath = 'audit/sync-manifest.json';
+
+let repoFilesCache: string[] | null = null;
+
+// Lazy: only shelled out to when a block actually falls back to
+// sourceGlobs (today's manifest sets `paths` on every entry), so a normal
+// run with no sourceGlobs-only blocks never pays for this git call.
+function getRepoFiles(): string[] {
+  if (!repoFilesCache) {
+    const output = execFileSync(
+      'git',
+      ['ls-files', '--cached', '--others', '--exclude-standard', '--full-name'],
+      { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+    repoFilesCache = output.split(/\r?\n/).filter(Boolean).sort();
+  }
+  return repoFilesCache;
+}
 
 const args = process.argv.slice(2);
 const apply = args.includes('--apply');
@@ -431,8 +452,12 @@ function renderGeneratedBlock(block: GeneratedBlock): string {
 }
 
 function resolveBlockFiles(block: GeneratedBlock): string[] {
-  // Use the static paths list when present; this matches audit-docs.mjs behaviour.
-  return block.paths ? [...block.paths] : [];
+  // paths-first, sourceGlobs-fallback -- shared with audit-docs.mjs via
+  // consistency-helpers.mts's resolveGeneratedBlockFiles (#1703) so the two
+  // tools cannot drift on this resolution rule again.
+  return resolveGeneratedBlockFiles(block, (pattern) =>
+    globFiles(pattern, getRepoFiles()),
+  );
 }
 
 function applyReplacements(

--- a/tests/audit-docs-file-sets.test.mts
+++ b/tests/audit-docs-file-sets.test.mts
@@ -1,10 +1,12 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { devNull, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
+
+import { fixtureEnv } from './test-utils.mts';
 
 // checkFileSets in src/scripts/audit-docs.mts is not exported (the module
 // runs as a top-level side-effecting CLI script, including a `process.exit`
@@ -23,51 +25,12 @@ import { fileURLToPath } from 'node:url';
 // file's target and syncPairs entry. checkFileSets now fails closed on any
 // such collision instead of guessing which path a basename "really" refers
 // to.
+//
+// `fixtureEnv()` (sanitized git env so this subprocess never touches the
+// host repo's GIT_DIR / ignore config) lives in `./test-utils.mts`, shared
+// with `tests/sync-docs.test.mts`'s own git-backed fixture (#1703).
 
 const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
-
-// Fixture invariant: fixture git processes (and the audit-docs.mjs
-// subprocess, which itself shells out to `git ls-files`) must never read
-// the ambient GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE state. A caller that
-// runs this suite from inside a git hook exports those variables, and an
-// unsanitized fixture would then operate on (and could mutate) the host
-// repository instead of the temp fixture, despite `cwd` pointing at the
-// fixture. Same pattern as tests/worktree-guard-hook.test.mts.
-//
-// `git ls-files --exclude-standard` also honors `core.excludesFile`, which
-// git resolves from the global/system config file *or*, when that key is
-// entirely unset (as it is once GIT_CONFIG_GLOBAL/SYSTEM point at
-// /dev/null below), falls back to git's own hardcoded default
-// `$XDG_CONFIG_HOME/git/ignore`. An operator's real personal ignore file
-// there can exclude fixture paths for reasons that have nothing to do with
-// this suite (for example a `.claude/*` entry with a narrower allowlist
-// than this fixture's directory names need), silently dropping fixture
-// files from `git ls-files` and making the suite flaky depending on who
-// runs it. Force `core.excludesFile` itself to `/dev/null` via the
-// `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_n`/`GIT_CONFIG_VALUE_n` env
-// injection (which git honors regardless of file-based config, and unlike
-// leaving the key unset, does not trigger the XDG-default fallback) so
-// fixture file discovery can never be influenced by the host's ignore
-// patterns.
-function fixtureEnv(): NodeJS.ProcessEnv {
-  const env = { ...process.env };
-  for (const key of Object.keys(env)) {
-    if (key.startsWith('GIT_CONFIG')) {
-      delete env[key];
-    }
-  }
-  delete env.GIT_DIR;
-  delete env.GIT_INDEX_FILE;
-  delete env.GIT_WORK_TREE;
-  delete env.GIT_COMMON_DIR;
-  delete env.GIT_OBJECT_DIRECTORY;
-  env.GIT_CONFIG_GLOBAL = devNull;
-  env.GIT_CONFIG_SYSTEM = devNull;
-  env.GIT_CONFIG_COUNT = '1';
-  env.GIT_CONFIG_KEY_0 = 'core.excludesFile';
-  env.GIT_CONFIG_VALUE_0 = devNull;
-  return env;
-}
 
 interface RunResult {
   status: number;

--- a/tests/audit-docs-generated-blocks.test.mts
+++ b/tests/audit-docs-generated-blocks.test.mts
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { fixtureEnv } from './test-utils.mts';
+
+// Coverage for #1703's remediation-text split: a `generatedBlocks` entry
+// carrying both `paths` and `sourceGlobs` that disagree produces a
+// `manifest paths omit …` / `manifest path does not exist or match globs`
+// error, which `docs:sync` cannot fix (it reads `paths` as-is). Before
+// #1703, `containsMirrorDrift` treated these as generic mirror drift and
+// suggested `docs:sync` regardless; this suite pins the corrected
+// behavior and guards the still-legitimate `docs:sync` suggestion for a
+// genuinely stale generated block.
+//
+// Same subprocess-fixture pattern as tests/audit-docs-file-sets.test.mts
+// (checkGeneratedBlocks is not exported; the module is a top-level
+// side-effecting CLI script).
+
+const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runAuditDocs(cwd: string): RunResult {
+  try {
+    const stdout = execFileSync(
+      process.execPath,
+      [join(REPO_ROOT, 'scripts', 'audit-docs.mjs'), '--check'],
+      {
+        cwd,
+        env: fixtureEnv(),
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    return { status: 0, stdout, stderr: '' };
+  } catch (error) {
+    const e = error as { status?: unknown; stdout?: unknown; stderr?: unknown };
+    return {
+      status: typeof e.status === 'number' ? e.status : 1,
+      stdout: typeof e.stdout === 'string' ? e.stdout : '',
+      stderr: typeof e.stderr === 'string' ? e.stderr : '',
+    };
+  }
+}
+
+function makeFixture(manifest: unknown): { dir: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), 'audit-docs-generated-blocks-'));
+  execFileSync('git', ['init', '--quiet'], { cwd: dir, env: fixtureEnv() });
+  mkdirSync(join(dir, 'audit'), { recursive: true });
+  writeFileSync(
+    join(dir, 'audit', 'sync-manifest.json'),
+    JSON.stringify(manifest),
+    'utf8',
+  );
+  // detectSyncCommand() needs this to name an actual `docs:sync` command in
+  // remediation output; without it a mirror-drift remediation line still
+  // fires but falls back to a generic "align files" sentence instead.
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify({
+      scripts: { 'docs:sync': 'node scripts/sync-docs.mjs --apply' },
+      packageManager: 'pnpm@10.0.0',
+    }),
+    'utf8',
+  );
+  return {
+    dir,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+// The exact marker-block content renderGeneratedBlock(block) produces for
+// paths (no stripPrefix, `text` language) -- used to keep a fixture's
+// on-disk marker content already in sync, so a test can isolate a single
+// error class instead of also tripping the unrelated "is stale" check.
+function markerDoc(id: string, paths: string[]): string {
+  return `<!-- audit:generated id=${id} -->\n\n\`\`\`text\n${paths.join('\n')}\n\`\`\`\n\n<!-- /audit:generated -->\n`;
+}
+
+test('manifest paths/sourceGlobs mismatch: remediation names the manifest, not docs:sync', (t) => {
+  const { dir, cleanup } = makeFixture({
+    generatedBlocks: [
+      {
+        id: 'blk',
+        file: 'doc.md',
+        language: 'text',
+        paths: ['content/a.md'],
+        sourceGlobs: ['content/*.md'],
+      },
+    ],
+  });
+  t.after(cleanup);
+
+  mkdirSync(join(dir, 'content'), { recursive: true });
+  writeFileSync(join(dir, 'content', 'a.md'), '# a\n');
+  // Present on disk (matches sourceGlobs) but missing from paths.
+  writeFileSync(join(dir, 'content', 'b.md'), '# b\n');
+  // Marker content already matches `paths` exactly, so the only error this
+  // fixture can produce is the paths/sourceGlobs cross-check below -- not
+  // a coincidental "generated block is stale" mirror-drift error.
+  writeFileSync(join(dir, 'doc.md'), markerDoc('blk', ['content/a.md']));
+
+  const result = runAuditDocs(dir);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /blk: manifest paths omit content\/b\.md/);
+  assert.doesNotMatch(result.stderr, /generated block .* is stale/);
+
+  assert.match(result.stderr, /remediation:/);
+  assert.match(
+    result.stderr,
+    /edit `audit\/sync-manifest\.json`'s `generatedBlocks\[\]\.paths`/,
+  );
+  // No mirror-drift line: the suggestion never tells the operator to run
+  // docs:sync (only explains, in the manifest-fix line above, why it can't
+  // fix this specific error class).
+  assert.doesNotMatch(result.stderr, /run `.*` to refresh mirrored files/);
+});
+
+test('a genuinely stale generated block still recommends docs:sync', (t) => {
+  const { dir, cleanup } = makeFixture({
+    generatedBlocks: [
+      { id: 'blk', file: 'doc.md', language: 'text', paths: ['a.md', 'b.md'] },
+    ],
+  });
+  t.after(cleanup);
+
+  writeFileSync(join(dir, 'a.md'), '# a\n');
+  writeFileSync(join(dir, 'b.md'), '# b\n');
+  // Marker content lists only one of the two configured paths -- stale.
+  writeFileSync(join(dir, 'doc.md'), markerDoc('blk', ['a.md']));
+
+  const result = runAuditDocs(dir);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /blk: generated block in doc\.md is stale/);
+
+  assert.match(result.stderr, /remediation:/);
+  assert.match(result.stderr, /docs:sync/);
+  assert.doesNotMatch(result.stderr, /manifest paths omit/);
+});

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -18,6 +18,7 @@ import {
   normalizePolicyConfig,
   parseGeneratedFromBannerSource,
   resolveCollaboratorMarkerTrust,
+  resolveGeneratedBlockFiles,
   stripGeneratedFromBanner,
 } from '../src/scripts/consistency-helpers.mts';
 import { findPlaceholders } from '../src/scripts/idd-doctor.mts';
@@ -1186,4 +1187,46 @@ test('audit/sync-manifest.json guards the .claude issue-authoring markdown mirro
     match: 'basename',
     requireSyncPairs: true,
   });
+});
+
+// =============================================================================
+// resolveGeneratedBlockFiles (#1703) -- the shared paths-first,
+// sourceGlobs-fallback resolution rule for a generatedBlocks manifest
+// entry, previously duplicated (and drifted) between sync-docs.mts and
+// audit-docs.mts.
+// =============================================================================
+
+test('resolveGeneratedBlockFiles: paths present takes precedence, globFilesFn is never called', () => {
+  const files = resolveGeneratedBlockFiles(
+    { paths: ['b.md', 'a.md'], sourceGlobs: ['ignored/**'] },
+    () => {
+      throw new Error('globFilesFn must not be invoked when paths is set');
+    },
+  );
+  // paths is returned verbatim (not sorted) -- only the sourceGlobs
+  // fallback dedupes/sorts.
+  assert.deepEqual(files, ['b.md', 'a.md']);
+});
+
+test('resolveGeneratedBlockFiles: falls back to sourceGlobs when paths is absent, deduped and sorted', () => {
+  const seenPatterns: string[] = [];
+  const files = resolveGeneratedBlockFiles(
+    { sourceGlobs: ['src/*.mts', 'lib/*.mts'] },
+    (pattern) => {
+      seenPatterns.push(pattern);
+      if (pattern === 'src/*.mts') {
+        return ['src/b.mts', 'src/a.mts', 'src/a.mts'];
+      }
+      return ['lib/z.mts'];
+    },
+  );
+  assert.deepEqual(seenPatterns, ['src/*.mts', 'lib/*.mts']);
+  assert.deepEqual(files, ['lib/z.mts', 'src/a.mts', 'src/b.mts']);
+});
+
+test('resolveGeneratedBlockFiles: neither paths nor sourceGlobs resolves to an empty list', () => {
+  assert.deepEqual(
+    resolveGeneratedBlockFiles({}, () => []),
+    [],
+  );
 });

--- a/tests/sync-docs.test.mts
+++ b/tests/sync-docs.test.mts
@@ -1,10 +1,13 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
-import { makeScaffoldedSyncRepo } from './test-utils.mts';
+import { fixtureEnv, makeScaffoldedSyncRepo } from './test-utils.mts';
+
+const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
 
 interface RunResult {
   status: number;
@@ -21,7 +24,39 @@ function run(dir: string, ...args: string[]): RunResult {
     const stdout = execFileSync(
       process.execPath,
       [join(dir, 'scripts', 'sync-docs.mjs'), ...args],
-      { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+      {
+        cwd: dir,
+        env: fixtureEnv(),
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    return { status: 0, stdout, stderr: '' };
+  } catch (error) {
+    const e = error as { status?: unknown; stdout?: unknown; stderr?: unknown };
+    return {
+      status: typeof e.status === 'number' ? e.status : 1,
+      stdout: typeof e.stdout === 'string' ? e.stdout : '',
+      stderr: typeof e.stderr === 'string' ? e.stderr : '',
+    };
+  }
+}
+
+// Runs the REAL repo's built audit-docs.mjs (not copied into the fixture,
+// following audit-docs-file-sets.test.mts's pattern) against the fixture
+// dir as its cwd -- used to prove sync-docs and audit-docs agree on a
+// sourceGlobs-only block's resolved content (#1703 acceptance criterion 1).
+function runAuditDocs(dir: string): RunResult {
+  try {
+    const stdout = execFileSync(
+      process.execPath,
+      [join(REPO_ROOT, 'scripts', 'audit-docs.mjs'), '--check'],
+      {
+        cwd: dir,
+        env: fixtureEnv(),
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
     );
     return { status: 0, stdout, stderr: '' };
   } catch (error) {
@@ -130,9 +165,50 @@ test('generatedBlock resolves explicit paths (prefix-stripped); absent paths ren
   // stripPrefix removed the leading "src/".
   assert.ok(!doc.includes('src/one.mts'), 'prefix should be stripped');
 
-  // resolveBlockFiles uses block.paths only; with no paths the list is empty.
+  // Neither paths nor sourceGlobs is set, so there's nothing to resolve.
   const doc2 = read(dir, 'doc2.md');
   assert.match(doc2, /```text\n\n```/);
+});
+
+test('generatedBlock falls back to sourceGlobs when paths is absent, agreeing with audit-docs.mjs (#1703)', (t) => {
+  const dir = makeScaffoldedSyncRepo(
+    (cleanup) => t.after(cleanup),
+    {
+      generatedBlocks: [
+        {
+          id: 'blk',
+          file: 'doc.md',
+          language: 'text',
+          sourceGlobs: ['content/*.md'],
+        },
+      ],
+    },
+    {
+      'doc.md': blockFixture('blk'),
+      'content/b.md': '# b\n',
+      'content/a.md': '# a\n',
+    },
+  );
+
+  const applied = run(dir, '--apply');
+  assert.equal(applied.status, 0, applied.stderr);
+
+  // Before #1703 this rendered an empty block; the sourceGlobs fallback
+  // now matches both untracked-but-not-ignored files, deduped and sorted.
+  const doc = read(dir, 'doc.md');
+  assert.match(doc, /```text\ncontent\/a\.md\ncontent\/b\.md\n```/);
+
+  // Direct cross-tool parity check: audit-docs.mjs independently resolves
+  // the same sourceGlobs-only block and must see the content sync-docs.mjs
+  // just wrote as already up to date, not stale. Drop the copied
+  // sync-docs.mjs dependency closure first -- those real, banner-carrying
+  // .mjs files trip audit-docs.mjs's unrelated generated-source-pairing
+  // check (their paired .mts sources don't exist in this minimal fixture),
+  // which has nothing to do with the generatedBlocks resolution this test
+  // is about.
+  rmSync(join(dir, 'scripts'), { recursive: true, force: true });
+  const audited = runAuditDocs(dir);
+  assert.equal(audited.status, 0, audited.stderr || audited.stdout);
 });
 
 test('shell-file-list rewrites the "for FILE in" block from its source generatedBlock', (t) => {

--- a/tests/sync-docs.test.mts
+++ b/tests/sync-docs.test.mts
@@ -1,6 +1,14 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { readFileSync, rmSync } from 'node:fs';
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -8,6 +16,8 @@ import { fileURLToPath } from 'node:url';
 import { fixtureEnv, makeScaffoldedSyncRepo } from './test-utils.mts';
 
 const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
+const SYNC_DOCS_SCRIPT = join(REPO_ROOT, 'scripts/sync-docs.mjs');
+const SYNC_DOCS_DEPS = ['consistency-helpers.mjs', 'policy-helpers.mjs'];
 
 interface RunResult {
   status: number;
@@ -209,6 +219,62 @@ test('generatedBlock falls back to sourceGlobs when paths is absent, agreeing wi
   rmSync(join(dir, 'scripts'), { recursive: true, force: true });
   const audited = runAuditDocs(dir);
   assert.equal(audited.status, 0, audited.stderr || audited.stdout);
+});
+
+test('sourceGlobs fallback resolves relative to package.json root, not the git worktree top (#1748 review)', (t) => {
+  // Reproduces the adopter-monorepo shape a review comment on #1748
+  // flagged: the git top-level and resolveRepoRoot's nearest-package.json
+  // root are different directories. `git ls-files` must be read relative
+  // to `root` (the package dir), not the git project top, or a
+  // sourceGlobs-only block silently resolves to an empty list here.
+  const gitRoot = mkdtempSync(join(tmpdir(), 'sync-docs-monorepo-'));
+  t.after(() => rmSync(gitRoot, { recursive: true, force: true }));
+  execFileSync('git', ['init', '--quiet'], { cwd: gitRoot, env: fixtureEnv() });
+
+  const pkgDir = join(gitRoot, 'pkg');
+  mkdirSync(join(pkgDir, 'scripts'), { recursive: true });
+  mkdirSync(join(pkgDir, 'content'), { recursive: true });
+  cpSync(SYNC_DOCS_SCRIPT, join(pkgDir, 'scripts', 'sync-docs.mjs'));
+  for (const dep of SYNC_DOCS_DEPS) {
+    cpSync(join(REPO_ROOT, 'scripts', dep), join(pkgDir, 'scripts', dep));
+  }
+  writeFileSync(join(pkgDir, 'package.json'), '{}\n', 'utf8');
+  mkdirSync(join(pkgDir, 'audit'), { recursive: true });
+  writeFileSync(
+    join(pkgDir, 'audit', 'sync-manifest.json'),
+    JSON.stringify({
+      generatedBlocks: [
+        {
+          id: 'blk',
+          file: 'doc.md',
+          language: 'text',
+          sourceGlobs: ['content/*.md'],
+        },
+      ],
+    }),
+    'utf8',
+  );
+  writeFileSync(join(pkgDir, 'doc.md'), blockFixture('blk'), 'utf8');
+  writeFileSync(join(pkgDir, 'content', 'a.md'), '# a\n', 'utf8');
+
+  const applied = execFileSync(
+    process.execPath,
+    [join(pkgDir, 'scripts', 'sync-docs.mjs'), '--apply'],
+    {
+      cwd: pkgDir,
+      env: fixtureEnv(),
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  assert.match(applied, /Synced 1 file\(s\)\./);
+
+  const doc = readFileSync(join(pkgDir, 'doc.md'), 'utf8');
+  // Before the #1748 review fix, `--full-name` made this resolve to the
+  // empty list (the glob-matched file's git-top-relative path,
+  // "pkg/content/a.md", never matched the root-relative "content/*.md"
+  // pattern).
+  assert.match(doc, /```text\ncontent\/a\.md\n```/);
 });
 
 test('shell-file-list rewrites the "for FILE in" block from its source generatedBlock', (t) => {

--- a/tests/test-utils.mts
+++ b/tests/test-utils.mts
@@ -158,16 +158,21 @@ function writeScaffoldedFile(dir: string, rel: string, content: string): void {
 
 /**
  * A sanitized environment for spawning `git` (or a script that itself
- * shells out to `git ls-files`) against a temp fixture repo. Strips every
- * ambient `GIT_*` variable a caller running inside a git hook may have
- * exported (which would otherwise point the fixture's `git` invocations at
- * the *host* repository instead of the temp fixture despite `cwd` being
- * set correctly) and pins `core.excludesFile` to `/dev/null` so an
- * operator's personal global ignore file can never drop fixture paths
- * from `git ls-files --exclude-standard`. Shared by every suite that
- * scaffolds a git-backed fixture (originally local to
- * `audit-docs-file-sets.test.mts`; lifted out for `sync-docs.test.mts` too
- * per #1703, so the sanitization logic itself has one copy).
+ * shells out to `git ls-files`) against a temp fixture repo. Deletes the
+ * repo-location override variables (`GIT_DIR`, `GIT_INDEX_FILE`,
+ * `GIT_WORK_TREE`, `GIT_COMMON_DIR`, `GIT_OBJECT_DIRECTORY`) a caller
+ * running inside a git hook may have exported -- which would otherwise
+ * point the fixture's `git` invocations at the *host* repository instead
+ * of the temp fixture despite `cwd` being set correctly -- and every
+ * ambient `GIT_CONFIG*` variable, replacing them with a fixed
+ * `GIT_CONFIG_COUNT`/`KEY`/`VALUE` triple that pins `core.excludesFile`
+ * to `os.devNull` (the platform null device, not necessarily the literal
+ * path `/dev/null`) so an operator's personal global ignore file can
+ * never drop fixture paths from `git ls-files --exclude-standard`. Other
+ * `GIT_*` variables outside these two groups are left untouched. Shared
+ * by every suite that scaffolds a git-backed fixture (originally local
+ * to `audit-docs-file-sets.test.mts`; lifted out for `sync-docs.test.mts`
+ * too per #1703, so the sanitization logic itself has one copy).
  */
 export function fixtureEnv(): NodeJS.ProcessEnv {
   const env = { ...process.env };

--- a/tests/test-utils.mts
+++ b/tests/test-utils.mts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import {
   cpSync,
   mkdirSync,
@@ -7,7 +8,7 @@ import {
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { devNull, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -156,11 +157,46 @@ function writeScaffoldedFile(dir: string, rel: string, content: string): void {
 }
 
 /**
+ * A sanitized environment for spawning `git` (or a script that itself
+ * shells out to `git ls-files`) against a temp fixture repo. Strips every
+ * ambient `GIT_*` variable a caller running inside a git hook may have
+ * exported (which would otherwise point the fixture's `git` invocations at
+ * the *host* repository instead of the temp fixture despite `cwd` being
+ * set correctly) and pins `core.excludesFile` to `/dev/null` so an
+ * operator's personal global ignore file can never drop fixture paths
+ * from `git ls-files --exclude-standard`. Shared by every suite that
+ * scaffolds a git-backed fixture (originally local to
+ * `audit-docs-file-sets.test.mts`; lifted out for `sync-docs.test.mts` too
+ * per #1703, so the sanitization logic itself has one copy).
+ */
+export function fixtureEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('GIT_CONFIG')) {
+      delete env[key];
+    }
+  }
+  delete env.GIT_DIR;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_COMMON_DIR;
+  delete env.GIT_OBJECT_DIRECTORY;
+  env.GIT_CONFIG_GLOBAL = devNull;
+  env.GIT_CONFIG_SYSTEM = devNull;
+  env.GIT_CONFIG_COUNT = '1';
+  env.GIT_CONFIG_KEY_0 = 'core.excludesFile';
+  env.GIT_CONFIG_VALUE_0 = devNull;
+  return env;
+}
+
+/**
  * Builds a self-contained sync-docs fixture repo: `package.json` (so
  * `resolveRepoRoot` stops here), a copy of the real `sync-docs.mjs` under
  * `scripts/` plus its import closure, the fixture manifest, and any
  * referenced source/target files. `register` is called with a cleanup
- * callback (e.g. `(cleanup) => t.after(cleanup)`).
+ * callback (e.g. `(cleanup) => t.after(cleanup)`). Git-initializes the
+ * fixture (sanitized via `fixtureEnv()`) so a `sourceGlobs` block can
+ * resolve through `sync-docs.mjs`'s own `git ls-files` call (#1703).
  */
 export function makeScaffoldedSyncRepo(
   register: (cleanup: () => void) => void,
@@ -170,6 +206,7 @@ export function makeScaffoldedSyncRepo(
   const dir = mkdtempSync(join(tmpdir(), 'sync-docs-'));
   register(() => rmSync(dir, { recursive: true, force: true }));
 
+  execFileSync('git', ['init', '--quiet'], { cwd: dir, env: fixtureEnv() });
   writeScaffoldedFile(dir, 'package.json', '{}\n');
   mkdirSync(join(dir, 'scripts'), { recursive: true });
   cpSync(SYNC_DOCS_SCRIPT, join(dir, 'scripts', 'sync-docs.mjs'));


### PR DESCRIPTION
# Summary

`sync-docs.mts` and `audit-docs.mts` each independently decided how a
`generatedBlocks[]` manifest entry resolves to a file list, and drifted:
`audit-docs.mts` fell back to globbing `sourceGlobs` when `paths` was
absent; `sync-docs.mts` silently returned an empty list, and
`audit/README.md` documented the relationship backwards.

- Share one `resolveGeneratedBlockFiles` resolution rule (`paths`-first,
  `sourceGlobs`-fallback) via `consistency-helpers.mts`, imported by both
  tools, and fully migrate `audit-docs.mts`'s private
  `globFiles`/`globToRegExp`/`uniqueSorted` onto the same shared exports
  so the file-matching engine has one implementation instead of two that
  can drift again.
- `sync-docs.mts` gains a lazy `sourceGlobs` fallback (only shells out to
  `git ls-files` when a block actually needs it — no current manifest
  entry does, so this is behavior-preserving for `main` today).
- Stop suggesting `docs:sync` as the fix for a `manifest paths omit …` /
  `manifest path does not exist or match globs` error — that command
  reads `paths` as-is and cannot resolve a disagreement with what
  `sourceGlobs` actually matches; the remediation now names the manifest
  edit instead.
- Correct `audit/README.md`'s backwards claim that `paths` plays no role
  in `sync-docs.mjs`.

No current `generatedBlocks` entry in `audit/sync-manifest.json` is
`sourceGlobs`-only (both existing entries set `paths` today), so this is
a pure bug fix with no behavior change for the committed manifest.

## Linked issue

Closes #1703

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Two failure scenarios motivated this (from the issue): (a) a maintainer
trusting the README adds a `generatedBlocks` entry with only
`sourceGlobs`; `audit-docs` behaves, but `sync-docs --apply` silently
rewrites that generated block to an empty file list. (b) a maintainer
updates `sourceGlobs` without `paths`; the audit fails, the printed
remediation says run `docs:sync`, sync regenerates from the stale
`paths`, the audit fails again — an operator loop only a manual manifest
edit exits.

`audit-docs.mts`'s other ~8 `globFiles` call sites, its `stripPrefix`
mismatch handling (both tools already error on a prefix mismatch today,
just with different message text), and unrelated `globToRegExp` copies
in other unrelated helpers are out of scope.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Generated documentation now correctly falls back to configured source patterns when explicit file paths are not provided.
  - Audits now distinguish outdated generated content from mismatched file manifests and provide more targeted corrective guidance.
  - File matching is limited to repository files for more reliable documentation synchronization and consistency checks.

- **Documentation**
  - Updated documentation to clarify generated-block resolution and audit behavior.

- **Tests**
  - Expanded coverage for source-pattern fallback, audit parity, and repository-root handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->