### PR TITLE
fix(ci-helpers): narrow bot-gated-skip and surface CI-rollup divergence

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -217,6 +217,22 @@ The check also self-heals on the next non-bot trigger — a push or a
 **review-thread** reply, not a regular PR comment (no `issue_comment`
 subscription).
 
+**If rerunning the passing non-bot instance alone does not clear the
+rollup (`#1745`)**: a HEAD can carry several `idd-advisory-convergence`
+check-run instances at once (the check fires on `pull_request` plus
+`pull_request_review`/`pull_request_review_comment`, and
+`cancel-in-progress` cancels most of them), and GitHub's own required-check
+rollup can stay pinned to a bot-triggered instance whose **conclusion** is
+`CANCELLED` — distinct from the `action_required` case above. Unlike
+`action_required`, a `CANCELLED`-conclusion bot-triggered instance is
+**not** gated: rerunning it completes normally and does not re-enter
+`action_required` (confirmed by direct experiment, `#1745`). If the
+non-bot rerun above does not clear the block, rerun every
+`CANCELLED`-conclusion bot-triggered sibling instance for the same HEAD
+next (`gh run rerun <run-id>` on each, one at a time, per the sequential
+rule in the helper-first plan below) — only an `action_required`-conclusion
+instance stays withheld from rerun.
+
 **Helper-first**: prints this diagnosis and ordered rerun plan, read-only.
 
 ```sh

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1283,6 +1283,16 @@ to post it is the consuming track's job.
   is a `branch-currency` merge-gate blocker (see below); `UNKNOWN` is the
   async-still-computing state F1 and the E-phase branch-sync check
   already re-poll, not a blocker here.
+- `ci.discardedNonPassingRequiredChecks` (#1745) surfaces a same-name/type/
+  workflowName required-check instance discarded by the latest-per-producer
+  dedup while the surviving representative is pass-equivalent -- e.g. a
+  `CANCELLED` bot-triggered instance sitting alongside the `SUCCESS`
+  instance the dedup selected as "latest", the live PR #1741 divergence
+  where `ci.status: "success"` disagreed with GitHub's own
+  `statusCheckRollup.state: "FAILURE"` for the same commit. Evidence only
+  (empty array, never omitted, when nothing was discarded) -- it does not
+  itself gate F2/F3; a non-empty list is a prompt to double-check the live
+  GitHub rollup directly rather than trusting a bare `ci.status: "success"`.
 - Authoritative phase role: the live `pre-merge-readiness` run on the
   current HEAD is the **authoritative source for the final-merge CI and
   activity fields** at F2/F3. The `review-activity-snapshot` helper builds

--- a/fixtures/pre-merge-readiness/ack-only-current.json
+++ b/fixtures/pre-merge-readiness/ack-only-current.json
@@ -305,6 +305,7 @@
         "lint"
       ],
       "missingRequiredCheckNames": [],
+      "discardedNonPassingRequiredChecks": [],
       "checks": [
         {
           "name": "lint",

--- a/fixtures/pre-merge-readiness/changes-requested.json
+++ b/fixtures/pre-merge-readiness/changes-requested.json
@@ -239,6 +239,7 @@
         "lint"
       ],
       "missingRequiredCheckNames": [],
+      "discardedNonPassingRequiredChecks": [],
       "checks": [
         {
           "name": "lint",

--- a/fixtures/pre-merge-readiness/ci-not-ready.json
+++ b/fixtures/pre-merge-readiness/ci-not-ready.json
@@ -243,6 +243,7 @@
       "missingRequiredCheckNames": [
         "test"
       ],
+      "discardedNonPassingRequiredChecks": [],
       "checks": [
         {
           "name": "lint",

--- a/fixtures/pre-merge-readiness/claim-lost.json
+++ b/fixtures/pre-merge-readiness/claim-lost.json
@@ -267,6 +267,7 @@
         "lint"
       ],
       "missingRequiredCheckNames": [],
+      "discardedNonPassingRequiredChecks": [],
       "checks": [
         {
           "name": "lint",

--- a/fixtures/pre-merge-readiness/clean.json
+++ b/fixtures/pre-merge-readiness/clean.json
@@ -267,6 +267,7 @@
         "lint"
       ],
       "missingRequiredCheckNames": [],
+      "discardedNonPassingRequiredChecks": [],
       "checks": [
         {
           "name": "lint",

--- a/fixtures/pre-merge-readiness/stale-watermark.json
+++ b/fixtures/pre-merge-readiness/stale-watermark.json
@@ -267,6 +267,7 @@
         "lint"
       ],
       "missingRequiredCheckNames": [],
+      "discardedNonPassingRequiredChecks": [],
       "checks": [
         {
           "name": "lint",

--- a/fixtures/pre-merge-readiness/unreplied-comment.json
+++ b/fixtures/pre-merge-readiness/unreplied-comment.json
@@ -253,6 +253,7 @@
         "lint"
       ],
       "missingRequiredCheckNames": [],
+      "discardedNonPassingRequiredChecks": [],
       "checks": [
         {
           "name": "lint",

--- a/fixtures/pre-merge-readiness/unresolved-thread.json
+++ b/fixtures/pre-merge-readiness/unresolved-thread.json
@@ -267,6 +267,7 @@
         "lint"
       ],
       "missingRequiredCheckNames": [],
+      "discardedNonPassingRequiredChecks": [],
       "checks": [
         {
           "name": "lint",

--- a/fixtures/schemas/pre-merge-readiness.valid.json
+++ b/fixtures/schemas/pre-merge-readiness.valid.json
@@ -146,6 +146,7 @@
       "lint"
     ],
     "missingRequiredCheckNames": [],
+    "discardedNonPassingRequiredChecks": [],
     "checks": [
       {
         "name": "lint",

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -212,6 +212,22 @@ The check also self-heals on the next non-bot trigger — a push or a
 **review-thread** reply, not a regular PR comment (no `issue_comment`
 subscription).
 
+**If rerunning the passing non-bot instance alone does not clear the
+rollup (`#1745`)**: a HEAD can carry several `idd-advisory-convergence`
+check-run instances at once (the check fires on `pull_request` plus
+`pull_request_review`/`pull_request_review_comment`, and
+`cancel-in-progress` cancels most of them), and GitHub's own required-check
+rollup can stay pinned to a bot-triggered instance whose **conclusion** is
+`CANCELLED` — distinct from the `action_required` case above. Unlike
+`action_required`, a `CANCELLED`-conclusion bot-triggered instance is
+**not** gated: rerunning it completes normally and does not re-enter
+`action_required` (confirmed by direct experiment, `#1745`). If the
+non-bot rerun above does not clear the block, rerun every
+`CANCELLED`-conclusion bot-triggered sibling instance for the same HEAD
+next (`gh run rerun <run-id>` on each, one at a time, per the sequential
+rule in the helper-first plan below) — only an `action_required`-conclusion
+instance stays withheld from rerun.
+
 **Helper-first**: prints this diagnosis and ordered rerun plan, read-only.
 
 ```sh

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1283,6 +1283,16 @@ to post it is the consuming track's job.
   is a `branch-currency` merge-gate blocker (see below); `UNKNOWN` is the
   async-still-computing state F1 and the E-phase branch-sync check
   already re-poll, not a blocker here.
+- `ci.discardedNonPassingRequiredChecks` (#1745) surfaces a same-name/type/
+  workflowName required-check instance discarded by the latest-per-producer
+  dedup while the surviving representative is pass-equivalent -- e.g. a
+  `CANCELLED` bot-triggered instance sitting alongside the `SUCCESS`
+  instance the dedup selected as "latest", the live PR #1741 divergence
+  where `ci.status: "success"` disagreed with GitHub's own
+  `statusCheckRollup.state: "FAILURE"` for the same commit. Evidence only
+  (empty array, never omitted, when nothing was discarded) -- it does not
+  itself gate F2/F3; a non-empty list is a prompt to double-check the live
+  GitHub rollup directly rather than trusting a bare `ci.status: "success"`.
 - Authoritative phase role: the live `pre-merge-readiness` run on the
   current HEAD is the **authoritative source for the final-merge CI and
   activity fields** at F2/F3. The `review-activity-snapshot` helper builds

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -713,6 +713,7 @@
         "requiredChecksPassing",
         "requiredCheckNames",
         "missingRequiredCheckNames",
+        "discardedNonPassingRequiredChecks",
         "checks"
       ],
       "additionalProperties": false,
@@ -769,6 +770,48 @@
           "items": {
             "type": "string",
             "minLength": 1
+          }
+        },
+        "discardedNonPassingRequiredChecks": {
+          "type": "array",
+          "description": "#1745: same-name/type/workflowName required-check instances discarded by the latest-per-producer dedup while the dedup-selected representative for that group is pass-equivalent -- surfaces the exact PR #1741 divergence, where a CANCELLED idd-advisory-convergence instance was masked by a same-name SUCCESS instance even though GitHub's own statusCheckRollup.state disagreed. Empty (never omitted) when no such discarded sibling exists.",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "type",
+              "workflowName",
+              "selectedState",
+              "selectedCompletedAt",
+              "discardedState",
+              "discardedCompletedAt"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "workflowName": {
+                "type": "string"
+              },
+              "selectedState": {
+                "type": "string",
+                "minLength": 1
+              },
+              "selectedCompletedAt": {
+                "type": ["string", "null"]
+              },
+              "discardedState": {
+                "type": "string",
+                "minLength": 1
+              },
+              "discardedCompletedAt": {
+                "type": ["string", "null"]
+              }
+            }
           }
         },
         "checks": {

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1428,7 +1428,15 @@ export function selectLatestCheckInstance(group) {
  * `gh`/GraphQL's `statusCheckRollup` exposes today; `ci-wait-state.mts`'s
  * own `(checkName, workflowName)` key has the identical accepted gap.
  */
-function selectLatestCheckPerName(checks) {
+/**
+ * Group check-run instances by the same `(name, type, workflowName)`
+ * producer-identity key `selectLatestCheckPerName` reduces to one
+ * representative -- shared here so a caller that needs to inspect the
+ * DISCARDED siblings, not just the survivor (see
+ * {@link findDiscardedNonPassingSiblings}), can never drift out of sync
+ * with that grouping.
+ */
+function groupChecksByProducer(checks) {
   // A Map already iterates in first-insertion order, so grouping into one
   // is enough to preserve stable output order with no separate order array
   // (see the same pattern in `findDuplicateBasenames` in audit-docs.mts).
@@ -1451,7 +1459,72 @@ function selectLatestCheckPerName(checks) {
       groups.set(key, [check]);
     }
   }
-  return [...groups.values()].map((group) => selectLatestCheckInstance(group));
+  return groups;
+}
+function selectLatestCheckPerName(checks) {
+  return [...groupChecksByProducer(checks).values()].map((group) =>
+    selectLatestCheckInstance(group),
+  );
+}
+/** Check-run states {@link findDiscardedNonPassingSiblings} treats as
+ * "genuinely non-passing": every `CI_FAILURE_CONCLUSION_STATES` member plus
+ * `CANCELLED` (deliberately excluded from that set itself -- see its own
+ * doc comment -- but still evidence-worthy here: a discarded `CANCELLED`
+ * sibling is exactly the #1745 finding, a stale/gated instance masked by a
+ * same-name `SUCCESS`). Pending states are excluded on purpose: a discarded
+ * still-running sibling in favor of an already-completed one is ordinary,
+ * expected dedup behavior, not a discrepancy worth flagging. */
+const GENUINELY_NON_PASSING_STATES = new Set([
+  ...CI_FAILURE_CONCLUSION_STATES,
+  'CANCELLED',
+]);
+/**
+ * Detect same-producer `(name, type, workflowName)` groups whose
+ * dedup-selected "latest" instance (`selectLatestCheckInstance`) is
+ * pass-equivalent (SUCCESS/SKIPPED/NEUTRAL/NOT_APPLICABLE) while a
+ * DISCARDED sibling in that same group is genuinely non-passing (see
+ * {@link GENUINELY_NON_PASSING_STATES}) -- the live discrepancy PR #1741
+ * exhibited (#1745): `classifyCiChecks` reported `success` for a commit
+ * whose GitHub `statusCheckRollup.state` was `FAILURE`, because a
+ * `CANCELLED` bot-triggered `idd-advisory-convergence` instance existed
+ * alongside the `SUCCESS` instance this dedup selected as "latest".
+ * Confirming the exact internal GitHub selection is not possible after the
+ * fact (see #1745's evidence-durability note), so this reports the
+ * discarded-sibling FACT itself -- a same-name non-passing instance existed
+ * and was NOT counted -- rather than asserting why GitHub's own rollup
+ * disagreed. Pure and read-only: never changes which instance
+ * `selectLatestCheckPerName` selects, only reports when a discarded sibling
+ * makes that selection's "success" verdict less certain than it looks.
+ */
+function findDiscardedNonPassingSiblings(checks) {
+  const divergences = [];
+  for (const group of groupChecksByProducer(checks).values()) {
+    if (group.length < 2) continue;
+    const selected = selectLatestCheckInstance(group);
+    if (
+      !['SUCCESS', 'SKIPPED', 'NEUTRAL', 'NOT_APPLICABLE'].includes(
+        selected.state,
+      )
+    ) {
+      continue;
+    }
+    for (const sibling of group) {
+      if (sibling === selected) continue;
+      if (!GENUINELY_NON_PASSING_STATES.has(sibling.state)) continue;
+      divergences.push({
+        name: String(selected.name ?? ''),
+        type: selected.type ? String(selected.type) : '',
+        workflowName: selected.workflowName
+          ? String(selected.workflowName)
+          : '',
+        selectedState: selected.state,
+        selectedCompletedAt: selected.completedAt ?? null,
+        discardedState: sibling.state,
+        discardedCompletedAt: sibling.completedAt ?? null,
+      });
+    }
+  }
+  return divergences;
 }
 export function classifyCiChecks(checks) {
   const normalized = checks.map((check) => ({
@@ -1467,6 +1540,12 @@ export function classifyCiChecks(checks) {
   // name before classifying pass/fail/pending, so a stale instance never
   // outvotes the current one for the same name (see #1471).
   const deduped = selectLatestCheckPerName(normalized);
+  // #1745: computed unconditionally (not just for the 'success' path) so
+  // every returned shape below carries the same field -- a discarded
+  // non-passing sibling is evidence worth surfacing even when the overall
+  // status already reads 'failed'/'pending' for an unrelated check name.
+  const discardedNonPassingInstances =
+    findDiscardedNonPassingSiblings(normalized);
   // #1688: widened from a literal 'FAILURE' match to every
   // CI_FAILURE_CONCLUSION_STATES member, so a TIMED_OUT/ACTION_REQUIRED/
   // STARTUP_FAILURE/STALE/ERROR conclusion classifies as a genuine failure
@@ -1477,7 +1556,7 @@ export function classifyCiChecks(checks) {
     CI_FAILURE_CONCLUSION_STATES.has(check.state),
   );
   if (failed.length > 0) {
-    return { status: 'failed', failed };
+    return { status: 'failed', failed, discardedNonPassingInstances };
   }
   const pending = deduped.filter((check) => {
     return (
@@ -1487,7 +1566,7 @@ export function classifyCiChecks(checks) {
     );
   });
   if (pending.length > 0) {
-    return { status: 'pending', pending };
+    return { status: 'pending', pending, discardedNonPassingInstances };
   }
   const passing = deduped.filter((check) => {
     return ['SUCCESS', 'SKIPPED', 'NEUTRAL', 'NOT_APPLICABLE'].includes(
@@ -1498,6 +1577,7 @@ export function classifyCiChecks(checks) {
     status: passing.length === deduped.length ? 'success' : 'unknown',
     passing,
     unknown: deduped.filter((check) => !passing.includes(check)),
+    discardedNonPassingInstances,
   };
 }
 /**
@@ -3139,6 +3219,17 @@ export function summarizeRequiredChecks(
     (name) => !presentNames.has(name),
   );
   let status = 'unknown';
+  // #1745: discarded non-passing same-name siblings among the REQUIRED
+  // checks, e.g. a CANCELLED idd-advisory-convergence instance sitting
+  // alongside the SUCCESS instance selectLatestCheckPerName picked as
+  // "latest" -- surfaced regardless of the final `status` below so a
+  // 'success' verdict here is never silently opaque about a discarded
+  // non-passing sibling GitHub's own statusCheckRollup may have weighed
+  // differently (the live PR #1741 divergence this field exists to make
+  // visible; see classifyCiChecks's own findDiscardedNonPassingSiblings
+  // doc comment for the full rationale). Empty (never omitted) when no
+  // required checks are configured.
+  let discardedNonPassingRequiredChecks = [];
   if (requiredCheckNames.length > 0) {
     const effectiveChecks = matchedRequiredChecks.map((c) =>
       c.coveredByWaiver ? { ...c, state: 'SKIPPED' } : c,
@@ -3154,6 +3245,8 @@ export function summarizeRequiredChecks(
     ) {
       status = 'unknown';
     }
+    discardedNonPassingRequiredChecks =
+      ciClassification.discardedNonPassingInstances;
   }
   return {
     status,
@@ -3174,6 +3267,10 @@ export function summarizeRequiredChecks(
       requiredCheckNames.length > 0 && status === 'success',
     requiredCheckNames,
     missingRequiredCheckNames,
+    // #1745: see the field's own inline comment above -- reported
+    // unconditionally (empty array, never omitted) so a consumer never has
+    // to special-case "field absent" vs. "field empty".
+    discardedNonPassingRequiredChecks,
     checks: normalizedChecks.map((check) => ({
       name: check.name,
       state: check.state,

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -30,18 +30,28 @@
 //   - `pass`: conclusion is success/neutral/skipped -- no action needed.
 //   - `pending`: still queued/in_progress (no conclusion yet) -- reported,
 //     excluded from the plan (rerunning a live run cancels it, not helps).
-//   - `bot-gated-skip`: conclusion is `action_required`, OR the underlying
-//     workflow run's actor/triggering_actor is a bot (`type === "Bot"` is
-//     the primary signal; a configured advisory-bot login is a defensive
-//     fallback) -- rerunning re-enters `action_required` per #1424, so this
-//     needs a non-bot trigger or maintainer approval, never a rerun.
+//   - `bot-gated-skip`: conclusion is `action_required` -- rerunning
+//     without a non-bot trigger or maintainer approval re-enters
+//     `action_required` per #1424, so this needs a non-bot trigger or
+//     maintainer approval, never a rerun. Whether the underlying workflow
+//     run's actor/triggering_actor is a bot (`type === "Bot"` is the
+//     primary signal; a configured advisory-bot login is a defensive
+//     fallback) is reported in the reason text when it applies, but no
+//     longer gates BY ITSELF (narrowed by #1745): #1424 only established
+//     that an `action_required`-conclusion Copilot-triggered run is gated
+//     by GitHub, never that every bot-triggered instance regardless of its
+//     own conclusion is unsafe to rerun. A direct experiment on PR #1741
+//     confirmed a `CANCELLED`-conclusion bot-triggered instance reran and
+//     completed normally, never re-entering `action_required` -- the prior,
+//     over-broad `|| botTriggered` condition withheld exactly that working
+//     recovery action from the plan.
 //   - `unresolved`: the run id could not be parsed from the check-run's
 //     URL, or the per-run lookup itself failed -- reported for manual
 //     inspection, never silently dropped and never placed in the plan
 //     (fail-closed: an instance this helper cannot positively verify as
 //     safe is never recommended for rerun).
-//   - `rerun-eligible`: non-pass, terminal, non-bot, resolved -- goes into
-//     the ordered rerun plan.
+//   - `rerun-eligible`: non-pass, terminal, resolved -- goes into the
+//     ordered rerun plan (bot-triggered or not, unless gated per above).
 //
 // Reuse map (no duplicated identity/config logic):
 //   - `resolveAdvisoryPrimaryBotLogin`, `isCopilotReviewerLogin`,
@@ -448,19 +458,23 @@ function classifyInstance(instance, options) {
       reason: `status "${status}" has not concluded yet; rerunning a live run would cancel it instead of recovering it`,
     };
   }
-  // 3. Bot-gated: action_required conclusion, or a bot-triggered actor.
-  // Either signal alone is sufficient (matches the issue's literal
-  // "bot-triggered / action_required" acceptance wording).
+  // 3. Bot-gated: `action_required` conclusion ONLY (#1745 narrowed this
+  // from the prior "action_required OR bot-triggered actor" rule -- #1424
+  // established just the action_required case; a bot-triggered instance
+  // with any other conclusion, e.g. CANCELLED, reruns and completes
+  // normally, per #1745's direct experiment on PR #1741). `botTriggered` is
+  // still computed here (and reused at step 7 below) purely to annotate the
+  // reason text and to feed `selectRecoveryRefreshCandidates`, which still
+  // must exclude a bot-triggered PASS instance from the refresh
+  // suggestion -- it no longer decides this instance's classification by
+  // itself.
   const botTriggered = isBotTriggered(instance, options);
-  if (conclusion === 'action_required' || botTriggered) {
-    const actorDescription =
-      instance.triggeringActorLogin ?? instance.actorLogin ?? 'unknown actor';
-    const reason =
-      conclusion === 'action_required' && botTriggered
-        ? `conclusion is "action_required" and the triggering actor (${actorDescription}) is a bot; rerunning re-enters action_required (#1424) -- needs a non-bot trigger or maintainer approval`
-        : conclusion === 'action_required'
-          ? 'conclusion is "action_required"; rerunning without a non-bot trigger or maintainer approval re-enters action_required (#1424)'
-          : `triggering actor (${actorDescription}) is a bot; rerunning re-enters action_required (#1424) -- needs a non-bot trigger or maintainer approval`;
+  const actorDescription =
+    instance.triggeringActorLogin ?? instance.actorLogin ?? 'unknown actor';
+  if (conclusion === 'action_required') {
+    const reason = botTriggered
+      ? `conclusion is "action_required" and the triggering actor (${actorDescription}) is a bot; rerunning re-enters action_required (#1424) -- needs a non-bot trigger or maintainer approval`
+      : 'conclusion is "action_required"; rerunning without a non-bot trigger or maintainer approval re-enters action_required (#1424)';
     return { ...instance, classification: 'bot-gated-skip', reason };
   }
   // 4. Fail closed on an unresolvable run identity -- never guess.
@@ -505,12 +519,18 @@ function classifyInstance(instance, options) {
         : 'triggering event is unknown; inspect manually rather than assuming it is safe to rerun',
     };
   }
-  // 7. Non-pass, terminal, non-bot, resolved, pull_request-family --
-  // safe to rerun.
+  // 7. Non-pass, terminal, resolved, pull_request-family -- safe to rerun.
+  // A bot-triggered actor does not withhold this instance by itself
+  // (#1745) -- only a genuinely `action_required` conclusion does, handled
+  // in step 3 above -- so the reason notes bot-triggering when present
+  // instead of asserting "non-bot" for an instance that may well be one.
+  const botNote = botTriggered
+    ? ` (triggering actor ${actorDescription} is a bot, but conclusion "${conclusion}" is not action_required-gated)`
+    : '';
   return {
     ...instance,
     classification: 'rerun-eligible',
-    reason: `conclusion "${conclusion}" is non-passing, non-bot, and resolved (event "${runEvent}"); safe to rerun`,
+    reason: `conclusion "${conclusion}" is non-passing and resolved (event "${runEvent}")${botNote}; safe to rerun`,
   };
 }
 /**

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -207,51 +207,69 @@ export function computeRerunPlan(input, options) {
       resolveInstanceRerunDecision(instance, rerunPolicy),
     ]),
   );
-  const plan = buildOrderedPlan(
-    eligibleInstances.filter(
-      (instance) =>
-        eligibleDecisions.get(instance.checkRunId)?.action === 'rerun',
-    ),
-    owner,
-    repo,
+  const reRunningEligibleInstances = eligibleInstances.filter(
+    (instance) =>
+      eligibleDecisions.get(instance.checkRunId)?.action === 'rerun',
   );
+  const plan = buildOrderedPlan(reRunningEligibleInstances, owner, repo);
   const recoveryRefreshCandidates = selectRecoveryRefreshCandidates(
     instances,
     classifyOptions,
   );
-  // Gated on `eligibleInstances.length === 0` -- NOT `plan.length === 0`
-  // (this file's own prior bug, CodeRabbit review, #1434): those two are
-  // NOT equivalent. `plan` can be empty either because no instance was
-  // ever rerun-eligible, OR because a genuine rerun-eligible instance
-  // existed but its budget was exhausted/unconfirmed. Gating on
-  // `plan.length === 0` alone let a budget-held instance silently fall
-  // through to recovery-refresh, which would then recommend rerunning a
-  // DIFFERENT, already-passing instance instead -- circumventing the
-  // "one rerun, then a human reviews it" boundary the budget hold exists
-  // to enforce. `eligibleInstances.length === 0` only takes this path
-  // when there was never a real rerun-eligible instance to begin with
-  // (the scenario recoveryRefreshPlan's own doc comment describes:
-  // bot-gated-only, nothing else to trigger a fresh evaluation).
-  const refreshDecisions =
-    eligibleInstances.length === 0
-      ? new Map(
-          recoveryRefreshCandidates.map((instance) => [
-            instance.checkRunId,
-            resolveInstanceRerunDecision(instance, rerunPolicy),
-          ]),
-        )
-      : new Map();
-  const recoveryRefreshPlan =
-    eligibleInstances.length === 0
-      ? buildOrderedPlan(
-          recoveryRefreshCandidates.filter(
-            (instance) =>
-              refreshDecisions.get(instance.checkRunId)?.action === 'rerun',
-          ),
-          owner,
-          repo,
-        )
-      : [];
+  // Two independent conditions gate recoveryRefreshPlan, both preserved
+  // from the reasoning that produced them:
+  //
+  // 1. `!anyEligibleHeld` (CodeRabbit review, #1434): a genuine
+  //    rerun-eligible instance whose OWN budget is exhausted/unconfirmed
+  //    must never silently fall through to recovery-refresh, which would
+  //    recommend rerunning a DIFFERENT, already-passing instance instead --
+  //    circumventing the "one rerun, then a human reviews it" boundary the
+  //    budget hold exists to enforce.
+  // 2. `everyReRunningEligibleIsBotTriggered` (#1745 Codex review, this
+  //    PR): pre-#1745, EVERY bot-triggered non-pass instance was
+  //    `bot-gated-skip`, so `eligibleInstances.length === 0` alone
+  //    correctly meant "bot-gated-only, nothing else to trigger a fresh
+  //    evaluation" -- the scenario recoveryRefreshPlan's own doc comment
+  //    describes. #1745 narrowed `bot-gated-skip` to a genuine
+  //    `action_required` conclusion only, so a bot-triggered `CANCELLED`
+  //    sibling can now be BOTH independently `rerun-eligible` (goes into
+  //    `plan`) AND coexist with a still-genuinely-gated `action_required`
+  //    instance that ALSO needs the passing-instance refresh -- rerunning
+  //    the bot-triggered eligible instance does not itself supply the
+  //    "fresh NON-BOT-triggered evaluation" the refresh mechanism exists
+  //    to force (a rerun preserves its original run's triggering actor),
+  //    so it must not suppress recoveryRefreshPlan the way a genuinely
+  //    NON-bot rerun-eligible instance legitimately does (that instance's
+  //    own rerun already IS the needed non-bot trigger). Vacuously `true`
+  //    when there is nothing in `plan` to begin with, preserving the
+  //    original bot-gated-only case unchanged.
+  const anyEligibleHeld = eligibleInstances.some(
+    (instance) =>
+      eligibleDecisions.get(instance.checkRunId)?.action !== 'rerun',
+  );
+  const everyReRunningEligibleIsBotTriggered = reRunningEligibleInstances.every(
+    (instance) => isBotTriggered(instance, classifyOptions),
+  );
+  const allowRecoveryRefresh =
+    !anyEligibleHeld && everyReRunningEligibleIsBotTriggered;
+  const refreshDecisions = allowRecoveryRefresh
+    ? new Map(
+        recoveryRefreshCandidates.map((instance) => [
+          instance.checkRunId,
+          resolveInstanceRerunDecision(instance, rerunPolicy),
+        ]),
+      )
+    : new Map();
+  const recoveryRefreshPlan = allowRecoveryRefresh
+    ? buildOrderedPlan(
+        recoveryRefreshCandidates.filter(
+          (instance) =>
+            refreshDecisions.get(instance.checkRunId)?.action === 'rerun',
+        ),
+        owner,
+        repo,
+      )
+    : [];
   const heldEligibleCount = [...eligibleDecisions.values()].filter(
     (decision) => decision.action === 'hold',
   ).length;

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2118,15 +2118,21 @@ export function selectLatestCheckInstance<
  * `gh`/GraphQL's `statusCheckRollup` exposes today; `ci-wait-state.mts`'s
  * own `(checkName, workflowName)` key has the identical accepted gap.
  */
-function selectLatestCheckPerName<
+/**
+ * Group check-run instances by the same `(name, type, workflowName)`
+ * producer-identity key `selectLatestCheckPerName` reduces to one
+ * representative -- shared here so a caller that needs to inspect the
+ * DISCARDED siblings, not just the survivor (see
+ * {@link findDiscardedNonPassingSiblings}), can never drift out of sync
+ * with that grouping.
+ */
+function groupChecksByProducer<
   T extends {
     name?: string | null;
-    state: string;
-    completedAt?: string | null;
     type?: string | null;
     workflowName?: string | null;
   },
->(checks: T[]): T[] {
+>(checks: T[]): Map<string, T[]> {
   // A Map already iterates in first-insertion order, so grouping into one
   // is enough to preserve stable output order with no separate order array
   // (see the same pattern in `findDuplicateBasenames` in audit-docs.mts).
@@ -2149,7 +2155,103 @@ function selectLatestCheckPerName<
       groups.set(key, [check]);
     }
   }
-  return [...groups.values()].map((group) => selectLatestCheckInstance(group));
+  return groups;
+}
+
+function selectLatestCheckPerName<
+  T extends {
+    name?: string | null;
+    state: string;
+    completedAt?: string | null;
+    type?: string | null;
+    workflowName?: string | null;
+  },
+>(checks: T[]): T[] {
+  return [...groupChecksByProducer(checks).values()].map((group) =>
+    selectLatestCheckInstance(group),
+  );
+}
+
+/** Check-run states {@link findDiscardedNonPassingSiblings} treats as
+ * "genuinely non-passing": every `CI_FAILURE_CONCLUSION_STATES` member plus
+ * `CANCELLED` (deliberately excluded from that set itself -- see its own
+ * doc comment -- but still evidence-worthy here: a discarded `CANCELLED`
+ * sibling is exactly the #1745 finding, a stale/gated instance masked by a
+ * same-name `SUCCESS`). Pending states are excluded on purpose: a discarded
+ * still-running sibling in favor of an already-completed one is ordinary,
+ * expected dedup behavior, not a discrepancy worth flagging. */
+const GENUINELY_NON_PASSING_STATES = new Set([
+  ...CI_FAILURE_CONCLUSION_STATES,
+  'CANCELLED',
+]);
+
+/** One divergence {@link classifyCiChecks} reports on its
+ * `discardedNonPassingInstances` field. */
+export interface CiCheckDiscardedSibling {
+  name: string;
+  type: string;
+  workflowName: string;
+  selectedState: string;
+  selectedCompletedAt: string | null;
+  discardedState: string;
+  discardedCompletedAt: string | null;
+}
+
+/**
+ * Detect same-producer `(name, type, workflowName)` groups whose
+ * dedup-selected "latest" instance (`selectLatestCheckInstance`) is
+ * pass-equivalent (SUCCESS/SKIPPED/NEUTRAL/NOT_APPLICABLE) while a
+ * DISCARDED sibling in that same group is genuinely non-passing (see
+ * {@link GENUINELY_NON_PASSING_STATES}) -- the live discrepancy PR #1741
+ * exhibited (#1745): `classifyCiChecks` reported `success` for a commit
+ * whose GitHub `statusCheckRollup.state` was `FAILURE`, because a
+ * `CANCELLED` bot-triggered `idd-advisory-convergence` instance existed
+ * alongside the `SUCCESS` instance this dedup selected as "latest".
+ * Confirming the exact internal GitHub selection is not possible after the
+ * fact (see #1745's evidence-durability note), so this reports the
+ * discarded-sibling FACT itself -- a same-name non-passing instance existed
+ * and was NOT counted -- rather than asserting why GitHub's own rollup
+ * disagreed. Pure and read-only: never changes which instance
+ * `selectLatestCheckPerName` selects, only reports when a discarded sibling
+ * makes that selection's "success" verdict less certain than it looks.
+ */
+function findDiscardedNonPassingSiblings<
+  T extends {
+    name?: string | null;
+    state: string;
+    completedAt?: string | null;
+    type?: string | null;
+    workflowName?: string | null;
+  },
+>(checks: T[]): CiCheckDiscardedSibling[] {
+  const divergences: CiCheckDiscardedSibling[] = [];
+  for (const group of groupChecksByProducer(checks).values()) {
+    if (group.length < 2) continue;
+    const selected = selectLatestCheckInstance(group);
+    if (
+      !['SUCCESS', 'SKIPPED', 'NEUTRAL', 'NOT_APPLICABLE'].includes(
+        selected.state,
+      )
+    ) {
+      continue;
+    }
+    for (const sibling of group) {
+      if (sibling === selected) continue;
+      if (!GENUINELY_NON_PASSING_STATES.has(sibling.state)) continue;
+      divergences.push({
+        name: String(selected.name ?? ''),
+        type: selected.type ? String(selected.type) : '',
+        workflowName: selected.workflowName
+          ? String(selected.workflowName)
+          : '',
+        selectedState: selected.state,
+        selectedCompletedAt: selected.completedAt ?? null,
+        discardedState: sibling.state,
+        discardedCompletedAt: sibling.completedAt ?? null,
+      });
+    }
+  }
+  return divergences;
 }
 
 export function classifyCiChecks(checks: CheckLike[]) {
@@ -2167,6 +2269,13 @@ export function classifyCiChecks(checks: CheckLike[]) {
   // outvotes the current one for the same name (see #1471).
   const deduped = selectLatestCheckPerName(normalized);
 
+  // #1745: computed unconditionally (not just for the 'success' path) so
+  // every returned shape below carries the same field -- a discarded
+  // non-passing sibling is evidence worth surfacing even when the overall
+  // status already reads 'failed'/'pending' for an unrelated check name.
+  const discardedNonPassingInstances =
+    findDiscardedNonPassingSiblings(normalized);
+
   // #1688: widened from a literal 'FAILURE' match to every
   // CI_FAILURE_CONCLUSION_STATES member, so a TIMED_OUT/ACTION_REQUIRED/
   // STARTUP_FAILURE/STALE/ERROR conclusion classifies as a genuine failure
@@ -2177,7 +2286,7 @@ export function classifyCiChecks(checks: CheckLike[]) {
     CI_FAILURE_CONCLUSION_STATES.has(check.state),
   );
   if (failed.length > 0) {
-    return { status: 'failed', failed };
+    return { status: 'failed', failed, discardedNonPassingInstances };
   }
 
   const pending = deduped.filter((check) => {
@@ -2188,7 +2297,7 @@ export function classifyCiChecks(checks: CheckLike[]) {
     );
   });
   if (pending.length > 0) {
-    return { status: 'pending', pending };
+    return { status: 'pending', pending, discardedNonPassingInstances };
   }
 
   const passing = deduped.filter((check) => {
@@ -2201,6 +2310,7 @@ export function classifyCiChecks(checks: CheckLike[]) {
     status: passing.length === deduped.length ? 'success' : 'unknown',
     passing,
     unknown: deduped.filter((check) => !passing.includes(check)),
+    discardedNonPassingInstances,
   };
 }
 
@@ -4042,6 +4152,17 @@ export function summarizeRequiredChecks(
   );
 
   let status = 'unknown';
+  // #1745: discarded non-passing same-name siblings among the REQUIRED
+  // checks, e.g. a CANCELLED idd-advisory-convergence instance sitting
+  // alongside the SUCCESS instance selectLatestCheckPerName picked as
+  // "latest" -- surfaced regardless of the final `status` below so a
+  // 'success' verdict here is never silently opaque about a discarded
+  // non-passing sibling GitHub's own statusCheckRollup may have weighed
+  // differently (the live PR #1741 divergence this field exists to make
+  // visible; see classifyCiChecks's own findDiscardedNonPassingSiblings
+  // doc comment for the full rationale). Empty (never omitted) when no
+  // required checks are configured.
+  let discardedNonPassingRequiredChecks: CiCheckDiscardedSibling[] = [];
   if (requiredCheckNames.length > 0) {
     const effectiveChecks = matchedRequiredChecks.map((c) =>
       c.coveredByWaiver ? { ...c, state: 'SKIPPED' } : c,
@@ -4057,6 +4178,8 @@ export function summarizeRequiredChecks(
     ) {
       status = 'unknown';
     }
+    discardedNonPassingRequiredChecks =
+      ciClassification.discardedNonPassingInstances;
   }
 
   return {
@@ -4078,6 +4201,10 @@ export function summarizeRequiredChecks(
       requiredCheckNames.length > 0 && status === 'success',
     requiredCheckNames,
     missingRequiredCheckNames,
+    // #1745: see the field's own inline comment above -- reported
+    // unconditionally (empty array, never omitted) so a consumer never has
+    // to special-case "field absent" vs. "field empty".
+    discardedNonPassingRequiredChecks,
     checks: normalizedChecks.map((check) => ({
       name: check.name,
       state: check.state,

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -30,18 +30,28 @@
 //   - `pass`: conclusion is success/neutral/skipped -- no action needed.
 //   - `pending`: still queued/in_progress (no conclusion yet) -- reported,
 //     excluded from the plan (rerunning a live run cancels it, not helps).
-//   - `bot-gated-skip`: conclusion is `action_required`, OR the underlying
-//     workflow run's actor/triggering_actor is a bot (`type === "Bot"` is
-//     the primary signal; a configured advisory-bot login is a defensive
-//     fallback) -- rerunning re-enters `action_required` per #1424, so this
-//     needs a non-bot trigger or maintainer approval, never a rerun.
+//   - `bot-gated-skip`: conclusion is `action_required` -- rerunning
+//     without a non-bot trigger or maintainer approval re-enters
+//     `action_required` per #1424, so this needs a non-bot trigger or
+//     maintainer approval, never a rerun. Whether the underlying workflow
+//     run's actor/triggering_actor is a bot (`type === "Bot"` is the
+//     primary signal; a configured advisory-bot login is a defensive
+//     fallback) is reported in the reason text when it applies, but no
+//     longer gates BY ITSELF (narrowed by #1745): #1424 only established
+//     that an `action_required`-conclusion Copilot-triggered run is gated
+//     by GitHub, never that every bot-triggered instance regardless of its
+//     own conclusion is unsafe to rerun. A direct experiment on PR #1741
+//     confirmed a `CANCELLED`-conclusion bot-triggered instance reran and
+//     completed normally, never re-entering `action_required` -- the prior,
+//     over-broad `|| botTriggered` condition withheld exactly that working
+//     recovery action from the plan.
 //   - `unresolved`: the run id could not be parsed from the check-run's
 //     URL, or the per-run lookup itself failed -- reported for manual
 //     inspection, never silently dropped and never placed in the plan
 //     (fail-closed: an instance this helper cannot positively verify as
 //     safe is never recommended for rerun).
-//   - `rerun-eligible`: non-pass, terminal, non-bot, resolved -- goes into
-//     the ordered rerun plan.
+//   - `rerun-eligible`: non-pass, terminal, resolved -- goes into the
+//     ordered rerun plan (bot-triggered or not, unless gated per above).
 //
 // Reuse map (no duplicated identity/config logic):
 //   - `resolveAdvisoryPrimaryBotLogin`, `isCopilotReviewerLogin`,
@@ -686,19 +696,23 @@ function classifyInstance(
     };
   }
 
-  // 3. Bot-gated: action_required conclusion, or a bot-triggered actor.
-  // Either signal alone is sufficient (matches the issue's literal
-  // "bot-triggered / action_required" acceptance wording).
+  // 3. Bot-gated: `action_required` conclusion ONLY (#1745 narrowed this
+  // from the prior "action_required OR bot-triggered actor" rule -- #1424
+  // established just the action_required case; a bot-triggered instance
+  // with any other conclusion, e.g. CANCELLED, reruns and completes
+  // normally, per #1745's direct experiment on PR #1741). `botTriggered` is
+  // still computed here (and reused at step 7 below) purely to annotate the
+  // reason text and to feed `selectRecoveryRefreshCandidates`, which still
+  // must exclude a bot-triggered PASS instance from the refresh
+  // suggestion -- it no longer decides this instance's classification by
+  // itself.
   const botTriggered = isBotTriggered(instance, options);
-  if (conclusion === 'action_required' || botTriggered) {
-    const actorDescription =
-      instance.triggeringActorLogin ?? instance.actorLogin ?? 'unknown actor';
-    const reason =
-      conclusion === 'action_required' && botTriggered
-        ? `conclusion is "action_required" and the triggering actor (${actorDescription}) is a bot; rerunning re-enters action_required (#1424) -- needs a non-bot trigger or maintainer approval`
-        : conclusion === 'action_required'
-          ? 'conclusion is "action_required"; rerunning without a non-bot trigger or maintainer approval re-enters action_required (#1424)'
-          : `triggering actor (${actorDescription}) is a bot; rerunning re-enters action_required (#1424) -- needs a non-bot trigger or maintainer approval`;
+  const actorDescription =
+    instance.triggeringActorLogin ?? instance.actorLogin ?? 'unknown actor';
+  if (conclusion === 'action_required') {
+    const reason = botTriggered
+      ? `conclusion is "action_required" and the triggering actor (${actorDescription}) is a bot; rerunning re-enters action_required (#1424) -- needs a non-bot trigger or maintainer approval`
+      : 'conclusion is "action_required"; rerunning without a non-bot trigger or maintainer approval re-enters action_required (#1424)';
     return { ...instance, classification: 'bot-gated-skip', reason };
   }
 
@@ -747,12 +761,18 @@ function classifyInstance(
     };
   }
 
-  // 7. Non-pass, terminal, non-bot, resolved, pull_request-family --
-  // safe to rerun.
+  // 7. Non-pass, terminal, resolved, pull_request-family -- safe to rerun.
+  // A bot-triggered actor does not withhold this instance by itself
+  // (#1745) -- only a genuinely `action_required` conclusion does, handled
+  // in step 3 above -- so the reason notes bot-triggering when present
+  // instead of asserting "non-bot" for an instance that may well be one.
+  const botNote = botTriggered
+    ? ` (triggering actor ${actorDescription} is a bot, but conclusion "${conclusion}" is not action_required-gated)`
+    : '';
   return {
     ...instance,
     classification: 'rerun-eligible',
-    reason: `conclusion "${conclusion}" is non-passing, non-bot, and resolved (event "${runEvent}"); safe to rerun`,
+    reason: `conclusion "${conclusion}" is non-passing and resolved (event "${runEvent}")${botNote}; safe to rerun`,
   };
 }
 

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -277,18 +277,28 @@ export interface RerunAdvisoryConvergencePlan {
    * caller does not need to re-derive it from prose elsewhere. */
   planCaveat: string;
   /**
-   * Populated only when `plan` is empty AND at least one instance is
-   * `bot-gated-skip` AND at least one already-passing, non-bot,
-   * pull_request-family instance exists for the same SHA. Rerunning that
+   * Populated when at least one instance is `bot-gated-skip` AND at least
+   * one already-passing, non-bot, pull_request-family instance exists for
+   * the same SHA -- UNLESS `plan` already contains a genuinely NON-bot
+   * rerun-eligible instance (that instance's own rerun already forces the
+   * same "fresh non-bot-triggered evaluation" this recovery exists to
+   * provide, so a redundant already-passing rerun is not suggested on top
+   * of it), or a genuinely rerun-eligible instance was excluded from
+   * `plan` purely by rerun-budget exhaustion (#1434 review, Codex P1 --
+   * recovery-refresh must never become a loophole around that instance's
+   * own "one rerun, then a human reviews it" boundary). A bot-triggered
+   * rerun-eligible instance in `plan` (e.g. a `CANCELLED`-conclusion
+   * sibling, #1745) does NOT by itself suppress this field: rerunning it
+   * preserves its original triggering actor, so it does not supply the
+   * non-bot trigger a still-`action_required`-gated sibling separately
+   * needs (#1745 Codex review) -- `plan` and `recoveryRefreshPlan` can
+   * both be non-empty at once in that combined scenario. Rerunning the
    * ALREADY-PASSING instance is the documented recovery
    * (`idd-ci.instructions.md` §Rerun mechanics) for a required-check
    * rollup pinned to a stale bot-gated `action_required` entry -- the
    * rerun does not need to change that instance's own outcome; it only
    * needs to trigger a fresh non-bot-triggered evaluation that replaces
-   * the pinned bot-gated state (#1434 review, Codex P1). Empty whenever
-   * `plan` already has entries: a genuine rerun-eligible instance already
-   * triggers the same non-bot refresh, so no redundant rerun of an
-   * already-passing instance is suggested on top of it.
+   * the pinned bot-gated state.
    */
   recoveryRefreshPlan: RerunPlanCommand[];
   /** Guidance for `recoveryRefreshPlan`, printed only when it is
@@ -415,55 +425,73 @@ export function computeRerunPlan(
         ] as const,
     ),
   );
-  const plan = buildOrderedPlan(
-    eligibleInstances.filter(
-      (instance) =>
-        eligibleDecisions.get(instance.checkRunId)?.action === 'rerun',
-    ),
-    owner,
-    repo,
+  const reRunningEligibleInstances = eligibleInstances.filter(
+    (instance) =>
+      eligibleDecisions.get(instance.checkRunId)?.action === 'rerun',
   );
+  const plan = buildOrderedPlan(reRunningEligibleInstances, owner, repo);
 
   const recoveryRefreshCandidates = selectRecoveryRefreshCandidates(
     instances,
     classifyOptions,
   );
-  // Gated on `eligibleInstances.length === 0` -- NOT `plan.length === 0`
-  // (this file's own prior bug, CodeRabbit review, #1434): those two are
-  // NOT equivalent. `plan` can be empty either because no instance was
-  // ever rerun-eligible, OR because a genuine rerun-eligible instance
-  // existed but its budget was exhausted/unconfirmed. Gating on
-  // `plan.length === 0` alone let a budget-held instance silently fall
-  // through to recovery-refresh, which would then recommend rerunning a
-  // DIFFERENT, already-passing instance instead -- circumventing the
-  // "one rerun, then a human reviews it" boundary the budget hold exists
-  // to enforce. `eligibleInstances.length === 0` only takes this path
-  // when there was never a real rerun-eligible instance to begin with
-  // (the scenario recoveryRefreshPlan's own doc comment describes:
-  // bot-gated-only, nothing else to trigger a fresh evaluation).
-  const refreshDecisions =
-    eligibleInstances.length === 0
-      ? new Map(
-          recoveryRefreshCandidates.map(
-            (instance) =>
-              [
-                instance.checkRunId,
-                resolveInstanceRerunDecision(instance, rerunPolicy),
-              ] as const,
-          ),
-        )
-      : new Map<string, ReturnType<typeof resolveCiRerunDecision>>();
-  const recoveryRefreshPlan =
-    eligibleInstances.length === 0
-      ? buildOrderedPlan(
-          recoveryRefreshCandidates.filter(
-            (instance) =>
-              refreshDecisions.get(instance.checkRunId)?.action === 'rerun',
-          ),
-          owner,
-          repo,
-        )
-      : [];
+  // Two independent conditions gate recoveryRefreshPlan, both preserved
+  // from the reasoning that produced them:
+  //
+  // 1. `!anyEligibleHeld` (CodeRabbit review, #1434): a genuine
+  //    rerun-eligible instance whose OWN budget is exhausted/unconfirmed
+  //    must never silently fall through to recovery-refresh, which would
+  //    recommend rerunning a DIFFERENT, already-passing instance instead --
+  //    circumventing the "one rerun, then a human reviews it" boundary the
+  //    budget hold exists to enforce.
+  // 2. `everyReRunningEligibleIsBotTriggered` (#1745 Codex review, this
+  //    PR): pre-#1745, EVERY bot-triggered non-pass instance was
+  //    `bot-gated-skip`, so `eligibleInstances.length === 0` alone
+  //    correctly meant "bot-gated-only, nothing else to trigger a fresh
+  //    evaluation" -- the scenario recoveryRefreshPlan's own doc comment
+  //    describes. #1745 narrowed `bot-gated-skip` to a genuine
+  //    `action_required` conclusion only, so a bot-triggered `CANCELLED`
+  //    sibling can now be BOTH independently `rerun-eligible` (goes into
+  //    `plan`) AND coexist with a still-genuinely-gated `action_required`
+  //    instance that ALSO needs the passing-instance refresh -- rerunning
+  //    the bot-triggered eligible instance does not itself supply the
+  //    "fresh NON-BOT-triggered evaluation" the refresh mechanism exists
+  //    to force (a rerun preserves its original run's triggering actor),
+  //    so it must not suppress recoveryRefreshPlan the way a genuinely
+  //    NON-bot rerun-eligible instance legitimately does (that instance's
+  //    own rerun already IS the needed non-bot trigger). Vacuously `true`
+  //    when there is nothing in `plan` to begin with, preserving the
+  //    original bot-gated-only case unchanged.
+  const anyEligibleHeld = eligibleInstances.some(
+    (instance) =>
+      eligibleDecisions.get(instance.checkRunId)?.action !== 'rerun',
+  );
+  const everyReRunningEligibleIsBotTriggered = reRunningEligibleInstances.every(
+    (instance) => isBotTriggered(instance, classifyOptions),
+  );
+  const allowRecoveryRefresh =
+    !anyEligibleHeld && everyReRunningEligibleIsBotTriggered;
+  const refreshDecisions = allowRecoveryRefresh
+    ? new Map(
+        recoveryRefreshCandidates.map(
+          (instance) =>
+            [
+              instance.checkRunId,
+              resolveInstanceRerunDecision(instance, rerunPolicy),
+            ] as const,
+        ),
+      )
+    : new Map<string, ReturnType<typeof resolveCiRerunDecision>>();
+  const recoveryRefreshPlan = allowRecoveryRefresh
+    ? buildOrderedPlan(
+        recoveryRefreshCandidates.filter(
+          (instance) =>
+            refreshDecisions.get(instance.checkRunId)?.action === 'rerun',
+        ),
+        owner,
+        repo,
+      )
+    : [];
 
   const heldEligibleCount = [...eligibleDecisions.values()].filter(
     (decision) => decision.action === 'hold',

--- a/tests/advisory-wait.test.mts
+++ b/tests/advisory-wait.test.mts
@@ -492,6 +492,71 @@ test('classifyCiChecks: the (name, type, workflowName) dedup key is deterministi
   }
 });
 
+// Regression (#1745): live on PR #1741, classifyCiChecks reported
+// ci.status: "success" for a HEAD whose GitHub statusCheckRollup.state was
+// "FAILURE" -- the dedup path resolved an idd-advisory-convergence
+// check-run group to a SUCCESS "latest" instance while a CANCELLED
+// bot-triggered sibling for the same (name, type, workflowName) also
+// existed in the same group, and nothing in classifyCiChecks's own output
+// surfaced that a non-passing instance had been discarded. This asserts the
+// discrepancy is now visible in the output itself, not just the final
+// 'success' status.
+test('classifyCiChecks: surfaces a discarded CANCELLED sibling when the dedup-selected latest instance is SUCCESS', () => {
+  const cancelled = {
+    name: 'idd-advisory-convergence',
+    state: 'CANCELLED',
+    completedAt: '2026-07-18T03:45:56Z',
+    type: 'check-run',
+    workflowName: 'IDD advisory-convergence gate',
+  };
+  const success = {
+    ...cancelled,
+    state: 'SUCCESS',
+    completedAt: '2026-07-18T03:47:01Z',
+  };
+  const result = classifyCiChecks([cancelled, success]);
+  assert.equal(result.status, 'success');
+  assert.equal(result.discardedNonPassingInstances?.length, 1);
+  assert.deepEqual(result.discardedNonPassingInstances?.[0], {
+    name: 'idd-advisory-convergence',
+    type: 'check-run',
+    workflowName: 'IDD advisory-convergence gate',
+    selectedState: 'SUCCESS',
+    selectedCompletedAt: '2026-07-18T03:47:01Z',
+    discardedState: 'CANCELLED',
+    discardedCompletedAt: '2026-07-18T03:45:56Z',
+  });
+});
+
+test('classifyCiChecks: reports an empty discardedNonPassingInstances list when nothing was discarded', () => {
+  const result = classifyCiChecks([
+    { name: 'lint', state: 'SUCCESS', completedAt: '2026-07-18T03:45:56Z' },
+  ]);
+  assert.deepEqual(result.discardedNonPassingInstances, []);
+});
+
+test('classifyCiChecks: does not flag a discarded pass-equivalent sibling as a discrepancy', () => {
+  // A discarded NEUTRAL sibling in favor of a later SUCCESS is two
+  // pass-equivalent instances, not a masked failure -- only a genuinely
+  // non-passing discarded sibling (CI_FAILURE_CONCLUSION_STATES or
+  // CANCELLED) is worth flagging.
+  const older = {
+    name: 'idd-advisory-convergence',
+    state: 'NEUTRAL',
+    completedAt: '2026-07-18T03:45:56Z',
+    type: 'check-run',
+    workflowName: 'IDD advisory-convergence gate',
+  };
+  const newer = {
+    ...older,
+    state: 'SUCCESS',
+    completedAt: '2026-07-18T03:47:01Z',
+  };
+  const result = classifyCiChecks([older, newer]);
+  assert.equal(result.status, 'success');
+  assert.deepEqual(result.discardedNonPassingInstances, []);
+});
+
 test('classifyCiChecks: characterization -- two same-name, same-type entries that both lack a workflowName still dedupe (accepted residual limitation)', () => {
   // Documents the deliberately-accepted residual gap: without a real
   // producer identity (e.g. the owning GitHub App) for two check-runs

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -181,6 +181,7 @@ test('required check summaries block when no merge-gate policy evidence exists',
     requiredChecksPassing: false,
     requiredCheckNames: [],
     missingRequiredCheckNames: [],
+    discardedNonPassingRequiredChecks: [],
     checks: [],
   });
 });

--- a/tests/required-checks-summary.test.mts
+++ b/tests/required-checks-summary.test.mts
@@ -100,6 +100,75 @@ test('a genuinely protected branch reports protectionReadsUnreadable: false even
   assert.equal(r.protectionReadsUnreadable, false);
 });
 
+// Regression (#1745): live on PR #1741, the F2/F3 authoritative CI read
+// reported ci.status: "success" for a HEAD GitHub itself blocked on --
+// summarizeRequiredChecks must forward classifyCiChecks's
+// discardedNonPassingInstances onto its own discardedNonPassingRequiredChecks
+// field (scoped to required checks only) so a 'success' verdict is never
+// silently opaque about a discarded non-passing same-name sibling.
+test('surfaces a discarded CANCELLED sibling for a required check via discardedNonPassingRequiredChecks', () => {
+  const r = summarize(
+    [
+      {
+        name: 'lint',
+        state: 'CANCELLED',
+        completedAt: '2026-07-18T03:45:56Z',
+        type: 'check-run',
+        workflowName: 'Lint gate',
+      },
+      {
+        name: 'lint',
+        state: 'SUCCESS',
+        completedAt: '2026-07-18T03:47:01Z',
+        type: 'check-run',
+        workflowName: 'Lint gate',
+      },
+    ],
+    protectedRules,
+  );
+  assert.equal(r.status, 'success');
+  assert.equal(r.requiredChecksPassing, true);
+  assert.equal(r.discardedNonPassingRequiredChecks.length, 1);
+  assert.equal(
+    r.discardedNonPassingRequiredChecks[0]?.discardedState,
+    'CANCELLED',
+  );
+  assert.equal(
+    r.discardedNonPassingRequiredChecks[0]?.selectedState,
+    'SUCCESS',
+  );
+  assert.equal(r.discardedNonPassingRequiredChecks[0]?.name, 'lint');
+});
+
+test('discardedNonPassingRequiredChecks is empty when nothing was discarded', () => {
+  const r = summarize([{ name: 'lint', state: 'SUCCESS' }], protectedRules);
+  assert.deepEqual(r.discardedNonPassingRequiredChecks, []);
+});
+
+test('discardedNonPassingRequiredChecks is empty when no required checks are configured', () => {
+  const r = summarize(
+    [
+      {
+        name: 'build',
+        state: 'CANCELLED',
+        completedAt: '2026-07-18T03:45:56Z',
+        type: 'check-run',
+        workflowName: 'Build gate',
+      },
+      {
+        name: 'build',
+        state: 'SUCCESS',
+        completedAt: '2026-07-18T03:47:01Z',
+        type: 'check-run',
+        workflowName: 'Build gate',
+      },
+    ],
+    [],
+  );
+  assert.equal(r.noRequiredChecksConfigured, true);
+  assert.deepEqual(r.discardedNonPassingRequiredChecks, []);
+});
+
 // #1471: a stale check-run instance for a name must not falsely block
 // pre-merge readiness once a later instance for that same name converged.
 test('unprotected: presentRunConclusion reflects the latest instance, not a stale instance sharing its name', () => {

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -647,6 +647,91 @@ test('does not offer a recovery-refresh plan when a genuine rerun-eligible insta
   assert.equal(plan.recoveryRefreshCaveat, '');
 });
 
+// Regression (#1745 Codex review on this same PR, P2): a bot-triggered
+// rerun-eligible instance (e.g. a CANCELLED sibling, narrowed out of
+// bot-gated-skip by this same PR) does NOT itself supply the "fresh
+// non-bot-triggered evaluation" the recovery-refresh mechanism exists to
+// force -- its rerun preserves the original triggering actor. When a
+// still-genuinely-gated action_required instance ALSO exists in the same
+// batch, both plan (rerun the bot-triggered CANCELLED instance) and
+// recoveryRefreshPlan (rerun the already-passing non-bot instance) must be
+// offered together; suppressing recoveryRefreshPlan just because *some*
+// instance is rerun-eligible would silently omit the documented first
+// recovery step when GitHub's rollup happens to still be pinned to the
+// action_required entry.
+test('offers both plan and recoveryRefreshPlan when a bot-triggered rerun-eligible instance coexists with a genuinely gated action_required instance', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: 'gated',
+          runId: '7001',
+          conclusion: 'action_required',
+        }),
+        baseInstance({
+          checkRunId: 'cancelled-bot',
+          runId: '7004',
+          conclusion: 'cancelled',
+          actorLogin: 'copilot-pull-request-reviewer[bot]',
+          actorType: 'Bot',
+          triggeringActorLogin: 'copilot-pull-request-reviewer[bot]',
+          triggeringActorType: 'Bot',
+        }),
+        baseInstance({
+          checkRunId: 'passing',
+          runId: '7002',
+          conclusion: 'success',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.deepEqual(
+    plan.plan.map((entry) => entry.runId),
+    ['7004'],
+  );
+  assert.deepEqual(
+    plan.recoveryRefreshPlan.map((entry) => entry.runId),
+    ['7002'],
+  );
+  assert.notEqual(plan.recoveryRefreshCaveat, '');
+});
+
+// A genuinely NON-bot rerun-eligible instance is the mirror-opposite case:
+// its own rerun already forces the same "fresh non-bot evaluation" the
+// refresh mechanism exists to provide, so recoveryRefreshPlan stays
+// suppressed even though a bot-gated action_required instance also exists
+// -- unchanged from the pre-#1745 behavior (the prior test above).
+test('still suppresses recoveryRefreshPlan when the coexisting rerun-eligible instance is non-bot', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: 'gated',
+          runId: '7001',
+          conclusion: 'action_required',
+        }),
+        baseInstance({
+          checkRunId: 'failed-non-bot',
+          runId: '7005',
+          conclusion: 'failure',
+        }),
+        baseInstance({
+          checkRunId: 'passing',
+          runId: '7002',
+          conclusion: 'success',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.deepEqual(
+    plan.plan.map((entry) => entry.runId),
+    ['7005'],
+  );
+  assert.deepEqual(plan.recoveryRefreshPlan, []);
+});
+
 test('does not offer a recovery-refresh plan without a bot-gated-skip instance present', () => {
   const plan = computeRerunPlan(
     baseInput({

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -141,7 +141,15 @@ test('classifies an action_required conclusion as bot-gated-skip', () => {
   assert.equal(plan.plan.length, 0);
 });
 
-test('classifies a bot-triggered failure (actor.type === Bot) as bot-gated-skip even without action_required', () => {
+// Regression (#1745): a CANCELLED-conclusion bot-triggered instance is no
+// longer classified bot-gated-skip. #1424 only established that an
+// action_required-conclusion Copilot-triggered run is gated by GitHub; a
+// direct experiment on PR #1741 confirmed a CANCELLED-conclusion
+// bot-triggered instance reran and completed normally, never re-entering
+// action_required. The prior, over-broad "action_required OR botTriggered"
+// rule withheld exactly this working recovery action from the plan and
+// contributed to a false CODEOWNER-deadlock misdiagnosis (issue #1745).
+test('classifies a CANCELLED, bot-triggered instance as rerun-eligible, not bot-gated-skip', () => {
   const plan = computeRerunPlan(
     baseInput({
       instances: [
@@ -156,16 +164,35 @@ test('classifies a bot-triggered failure (actor.type === Bot) as bot-gated-skip 
     }),
     baseOptions(),
   );
-  assert.equal(plan.instances[0]?.classification, 'bot-gated-skip');
-  assert.match(plan.instances[0]?.reason ?? '', /bot/);
+  assert.equal(plan.instances[0]?.classification, 'rerun-eligible');
+  assert.equal(plan.counts.rerunEligible, 1);
+  assert.equal(plan.counts.botGatedSkip, 0);
+  assert.equal(plan.plan.length, 1);
+  assert.match(plan.instances[0]?.reason ?? '', /is a bot/);
 });
 
-test('classifies a bot-triggered run via configured advisoryBotLogins fallback (type missing)', () => {
+// The isBotTriggered login-normalization fallbacks below (#1434 review,
+// Codex P2) no longer affect classifyInstance's own bot-gated-skip
+// decision post-#1745 (only an action_required conclusion gates now), but
+// they still matter for selectRecoveryRefreshCandidates: an already-PASSING
+// instance must still be excluded from the recovery-refresh plan when it is
+// itself bot-triggered (rerunning it would not force a genuinely fresh
+// non-bot evaluation). These tests retarget the same fixtures to that
+// surviving usage site instead of losing the regression coverage.
+
+test('excludes a bot-triggered passing instance from the recovery-refresh plan via configured advisoryBotLogins fallback (type missing)', () => {
   const plan = computeRerunPlan(
     baseInput({
       instances: [
         baseInstance({
-          conclusion: 'failure',
+          checkRunId: 'gated',
+          runId: '7001',
+          conclusion: 'action_required',
+        }),
+        baseInstance({
+          checkRunId: 'bot-passing',
+          runId: '7002',
+          conclusion: 'success',
           actorLogin: 'coderabbitai[bot]',
           actorType: null,
           triggeringActorLogin: 'coderabbitai[bot]',
@@ -175,20 +202,27 @@ test('classifies a bot-triggered run via configured advisoryBotLogins fallback (
     }),
     baseOptions(),
   );
-  assert.equal(plan.instances[0]?.classification, 'bot-gated-skip');
+  assert.deepEqual(plan.recoveryRefreshPlan, []);
 });
 
 // Regression (#1434 review, Codex P2): a repository can configure a bare
 // login (`my-bot`) while the Actions payload reports the GitHub-appended
 // `[bot]`-suffixed form (`my-bot[bot]`), or vice versa. An un-normalized
-// set lookup would miss that match and let a bot-triggered run fall
-// through as rerun-eligible.
-test('classifies a bot-triggered run when the configured login is bare but the actual actor login is [bot]-suffixed', () => {
+// set lookup would miss that match and let a bot-triggered passing instance
+// fall through as a recovery-refresh candidate.
+test('excludes a bot-triggered passing instance from the recovery-refresh plan when the configured login is bare but the actual actor login is [bot]-suffixed', () => {
   const plan = computeRerunPlan(
     baseInput({
       instances: [
         baseInstance({
-          conclusion: 'failure',
+          checkRunId: 'gated',
+          runId: '7001',
+          conclusion: 'action_required',
+        }),
+        baseInstance({
+          checkRunId: 'bot-passing',
+          runId: '7002',
+          conclusion: 'success',
           actorLogin: 'coderabbitai[bot]',
           actorType: null,
           triggeringActorLogin: 'coderabbitai[bot]',
@@ -198,15 +232,22 @@ test('classifies a bot-triggered run when the configured login is bare but the a
     }),
     baseOptions({ advisoryBotLogins: ['coderabbitai'] }),
   );
-  assert.equal(plan.instances[0]?.classification, 'bot-gated-skip');
+  assert.deepEqual(plan.recoveryRefreshPlan, []);
 });
 
-test('classifies a bot-triggered run when the configured login is [bot]-suffixed but the actual actor login is bare', () => {
+test('excludes a bot-triggered passing instance from the recovery-refresh plan when the configured login is [bot]-suffixed but the actual actor login is bare', () => {
   const plan = computeRerunPlan(
     baseInput({
       instances: [
         baseInstance({
-          conclusion: 'failure',
+          checkRunId: 'gated',
+          runId: '7001',
+          conclusion: 'action_required',
+        }),
+        baseInstance({
+          checkRunId: 'bot-passing',
+          runId: '7002',
+          conclusion: 'success',
           actorLogin: 'coderabbitai',
           actorType: null,
           triggeringActorLogin: 'coderabbitai',
@@ -216,7 +257,7 @@ test('classifies a bot-triggered run when the configured login is [bot]-suffixed
     }),
     baseOptions({ advisoryBotLogins: ['coderabbitai[bot]'] }),
   );
-  assert.equal(plan.instances[0]?.classification, 'bot-gated-skip');
+  assert.deepEqual(plan.recoveryRefreshPlan, []);
 });
 
 // Regression (#1434 review, Codex P2, second occurrence): the sibling gap
@@ -224,13 +265,21 @@ test('classifies a bot-triggered run when the configured login is [bot]-suffixed
 // primaryBotLogin path -- isCopilotReviewerLogin's non-default branch does
 // an exact, un-normalized comparison, so a configured custom primary bot
 // login whose [bot]-suffix form doesn't match the actual actor login
-// (or vice versa) would otherwise fall through as rerun-eligible.
-test('classifies a bot-triggered run when a custom primaryBotLogin is bare but the actual actor login is [bot]-suffixed', () => {
+// (or vice versa) would otherwise fall through as a recovery-refresh
+// candidate.
+test('excludes a bot-triggered passing instance from the recovery-refresh plan when a custom primaryBotLogin is bare but the actual actor login is [bot]-suffixed', () => {
   const plan = computeRerunPlan(
     baseInput({
       instances: [
         baseInstance({
-          conclusion: 'failure',
+          checkRunId: 'gated',
+          runId: '7001',
+          conclusion: 'action_required',
+        }),
+        baseInstance({
+          checkRunId: 'bot-passing',
+          runId: '7002',
+          conclusion: 'success',
           actorLogin: 'my-bot[bot]',
           actorType: null,
           triggeringActorLogin: 'my-bot[bot]',
@@ -240,15 +289,22 @@ test('classifies a bot-triggered run when a custom primaryBotLogin is bare but t
     }),
     baseOptions({ primaryBotLogin: 'my-bot', advisoryBotLogins: [] }),
   );
-  assert.equal(plan.instances[0]?.classification, 'bot-gated-skip');
+  assert.deepEqual(plan.recoveryRefreshPlan, []);
 });
 
-test('classifies a bot-triggered run when a custom primaryBotLogin is [bot]-suffixed but the actual actor login is bare', () => {
+test('excludes a bot-triggered passing instance from the recovery-refresh plan when a custom primaryBotLogin is [bot]-suffixed but the actual actor login is bare', () => {
   const plan = computeRerunPlan(
     baseInput({
       instances: [
         baseInstance({
-          conclusion: 'failure',
+          checkRunId: 'gated',
+          runId: '7001',
+          conclusion: 'action_required',
+        }),
+        baseInstance({
+          checkRunId: 'bot-passing',
+          runId: '7002',
+          conclusion: 'success',
           actorLogin: 'my-bot',
           actorType: null,
           triggeringActorLogin: 'my-bot',
@@ -258,7 +314,7 @@ test('classifies a bot-triggered run when a custom primaryBotLogin is [bot]-suff
     }),
     baseOptions({ primaryBotLogin: 'my-bot[bot]', advisoryBotLogins: [] }),
   );
-  assert.equal(plan.instances[0]?.classification, 'bot-gated-skip');
+  assert.deepEqual(plan.recoveryRefreshPlan, []);
 });
 
 test('does not classify a plain human failure as bot-gated-skip', () => {

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -1027,6 +1027,7 @@ const preMergeReadinessFixture = {
     requiredChecksPassing: true,
     requiredCheckNames: ['lint'],
     missingRequiredCheckNames: [],
+    discardedNonPassingRequiredChecks: [],
     checks: [
       {
         name: 'lint',


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Live on PR #1741, `pre-merge-readiness.mjs` reported `ci.status:
"success"` for a HEAD whose GitHub `statusCheckRollup.state` was
`"FAILURE"`. That contradiction misdirected diagnosis toward a
(disproved) solo-CODEOWNER self-approval deadlock theory (#1743).
Direct investigation found two compounding gaps in the CI helpers
and fixes both:

- `rerun-advisory-convergence.mts`'s `bot-gated-skip` classifier
  withheld *any* bot-triggered check-run instance from the rerun
  plan, regardless of its conclusion. #1424 only established that an
  `action_required`-conclusion Copilot-triggered run is gated by
  GitHub — a direct experiment on PR #1741 confirmed a
  `CANCELLED`-conclusion bot-triggered `idd-advisory-convergence`
  instance reran and completed normally, never re-entering
  `action_required`. The over-broad rule withheld exactly that
  working recovery action. Narrowed the gate to a genuine
  `action_required` conclusion only.
- `classifyCiChecks` (`protocol-helpers.mts`) dedupes same-name
  check-run instances to one "latest" representative per producer.
  When the surviving representative is pass-equivalent while a
  discarded sibling is genuinely non-passing (e.g. the `CANCELLED`
  instance above), nothing in the output surfaced that discrepancy —
  a fail-open condition. Added `discardedNonPassingInstances` /
  `ci.discardedNonPassingRequiredChecks` so this divergence is now
  visible in the JSON output instead of silently opaque.

Also updates `idd-ci.instructions.md`'s Rerun mechanics section with
the "rerun CANCELLED bot-triggered siblings" follow-up step.

## Linked issue

Closes #1745

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

See the issue body for the full investigation writeup, including the
evidence-durability caveat (the original `CANCELLED` instances were
consumed by the investigating session's own recovery reruns, so this
fix is grounded in code reading plus the timing evidence captured
before that, not a re-confirmed live repro).

Relationship to prior issues:

- #1424 (closed): established the `action_required`-gated case this
  narrows the classifier's over-generalization of. Not disputed —
  the classifier grew a wider precondition than #1424 itself
  established.
- #1688 (closed): the `CANCELLED`-exclusion from
  `CI_FAILURE_CONCLUSION_STATES` this issue's finding traces through,
  scoped there to a different same-second tie-break case.
- #1471 (closed): the mirror-opposite false-**block** this issue's
  false-**pass** is not a re-file of (different direction).
- #1743 (open, `status:needs-decision`): the false diagnosis this gap
  caused, already corrected via issue comment; expected to be closed
  as superseded once this PR/issue lands (separate follow-up action).
- #1742 (separately claimed): different file/mechanism
  (`advisory-wait-state.mts` collaborator-trust discovery) — no
  overlap, confirmed no dependency edge needed.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

(`idd-ci.instructions.md` is a generated mirror of
`idd-template/.github/instructions/idd-ci.instructions.md`, edited at
the source and regenerated via `node scripts/sync-docs.mjs --apply`;
same for `docs/idd-helper-scripts.md`.)

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
