### PR TITLE
chore(helpers): align three outlier helpers on shared conventions

### DIFF
--- a/scripts/claim-approval-gate.mjs
+++ b/scripts/claim-approval-gate.mjs
@@ -8,6 +8,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { parseCliArgs } from './cli-args.mjs';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
+import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import { normalizePolicyConfig } from './policy-helpers.mjs';
 
 const APPROVAL_POLICIES = new Set([
@@ -720,19 +721,47 @@ function ghApiJsonWithStatus(path) {
     const body = JSON.parse(runGh(['api', path]).trim() || '{}');
     return { status: 200, body };
   } catch (error) {
-    const stderr = String(error?.stderr ?? '');
-    const httpStatus = Number.parseInt(
-      /HTTP\s+(\d+)/.exec(stderr)?.[1] ?? '0',
-      10,
-    );
-    if (httpStatus > 0) {
-      return { status: httpStatus, body: null };
-    }
-    return { status: 0, body: null };
+    // #1693: derive the real HTTP status via the shared gh-http-status.mts
+    // helper instead of grepping stderr only with a bespoke `/HTTP\s+(\d+)/`
+    // pattern -- that missed the JSON-error-body-in-stdout fallback
+    // deriveGhHttpStatus already applies (stdout now survives runGh's error
+    // wrapping too; see wrapGhError below). `0` preserves this function's
+    // existing "status could not be determined" sentinel (unchanged
+    // downstream contract: callers already treat any non-200/404 status,
+    // including 0, as "permission lookup failed").
+    const status = deriveGhHttpStatus(error);
+    return { status: status ?? 0, body: null };
   }
 }
 function ghJson(args) {
   return JSON.parse(runGh(args).trim() || '{}');
+}
+/**
+ * Pure wrap step for {@link runGh}'s catch branch, exported so tests can
+ * inject a raw execFileSync-shaped error directly instead of shelling out
+ * to a real `gh` invocation (matching the mock-free-subprocess convention
+ * documented in `tests/collaborator-permission.test.mts`).
+ *
+ * When stderr is present, wraps it into a fresh Error carrying both
+ * `.stderr` and `.stdout`. #1693: the previous wrap carried `.stderr` only,
+ * which silently dropped `.stdout` and defeated `deriveGhHttpStatus`'s
+ * JSON-error-body-in-stdout fallback for every caller downstream of
+ * `runGh` (this file's `ghApiJsonWithStatus`) -- `gh api` can print a JSON
+ * error body to stdout even as it writes its human-readable diagnostic to
+ * stderr. When stderr is empty, returns the original error unchanged: the
+ * raw execFileSync error already carries `.stdout`/`.stderr`/`.status`
+ * natively, so wrapping would only lose information.
+ */
+export function wrapGhError(error) {
+  const stderr = String(error?.stderr ?? '').trim();
+  if (!stderr) {
+    return error;
+  }
+  const stdout = String(error?.stdout ?? '').trim();
+  const wrapped = new Error(`gh command failed: ${stderr}`);
+  wrapped.stderr = stderr;
+  wrapped.stdout = stdout;
+  return wrapped;
 }
 function runGh(args) {
   try {
@@ -742,12 +771,6 @@ function runGh(args) {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
   } catch (error) {
-    const stderr = String(error?.stderr ?? '').trim();
-    if (stderr) {
-      const wrapped = new Error(`gh command failed: ${stderr}`);
-      wrapped.stderr = stderr;
-      throw wrapped;
-    }
-    throw error;
+    throw wrapGhError(error);
   }
 }

--- a/scripts/collaborator-permission.mjs
+++ b/scripts/collaborator-permission.mjs
@@ -18,6 +18,7 @@
 // behavioural change lands in one place rather than five.
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { operationalMarkerPrefix } from './marker-helpers.mjs';
 import { normalizePolicyConfig } from './policy-helpers.mjs';
 
 const DEFAULT_POLICY_PATH = '.github/idd/config.json';
@@ -157,4 +158,70 @@ export function readForcedHandoffAuthorityPolicy(
   configPath = DEFAULT_POLICY_PATH,
 ) {
   return readForcedHandoffPolicy(configPath).authorityPolicy;
+}
+/**
+ * Resolve collaborator-marker-trust logins from a comment stream:
+ * marker-authors-first (#1693). Only comment authors whose comment body is
+ * itself marker-shaped per `isMarkerShaped` (default: any recognized
+ * operational-marker prefix via `operationalMarkerPrefix`) are even
+ * candidates; only those candidates get a collaborator-permission lookup,
+ * and only Write/Maintain/Admin permission earns trust.
+ *
+ * Checking every unique comment author regardless of whether they ever
+ * posted anything marker-shaped over-trusts ordinary commenters (anyone
+ * with write+ access who merely left an unrelated comment would be treated
+ * as a trusted marker actor) and wastes a permission lookup per unique
+ * commenter. This mirrors `pre-merge-readiness.mts` /
+ * `advisory-convergence.mts`'s identically-named local function (kept
+ * local there rather than migrated here: both call `safeGhText` with
+ * `GH_TEXT_LOOP_OPTIONS` loop-safety timeouts that this shared
+ * `collaboratorPermission`-based implementation does not apply, and
+ * `advisory-wait-state.mts`'s local variant intentionally narrows the
+ * marker-shape predicate to advisory-wait markers only). New consumers
+ * (`force-handoff.mts`, `external-check-waiver.mts`) call this instead of
+ * hand-rolling a fourth/fifth "check every comment author" copy.
+ *
+ * Deliberately checks only the legacy `permission` field (admin/maintain/
+ * write), matching the sibling implementations' `--jq '.permission'`
+ * shape exactly rather than also checking `role_name` -- parity with the
+ * sibling filter is an explicit acceptance criterion, and GitHub's legacy
+ * `permission` field already collapses a `maintain` role to `write` (see
+ * `collaboratorPermission`'s doc comment above), so a `role_name` check
+ * would only widen trust, never narrow it, and would make "parity"
+ * untestable against a real HTTP response shape.
+ */
+export function resolveTrustedCollaboratorMarkerLogins(
+  owner,
+  repo,
+  comments,
+  options = {},
+) {
+  const isMarkerShaped =
+    options.isMarkerShaped ??
+    ((body) => operationalMarkerPrefix(body) !== null);
+  const markerAuthors = [
+    ...new Set(
+      comments
+        .filter((comment) => isMarkerShaped(String(comment.body ?? '')))
+        .map((comment) =>
+          String(comment.author?.login ?? comment.user?.login ?? '')
+            .trim()
+            .toLowerCase(),
+        )
+        .filter(Boolean),
+    ),
+  ];
+  return markerAuthors.filter((login) => {
+    const { permission } = collaboratorPermission(
+      owner,
+      repo,
+      login,
+      options.cache,
+    );
+    return (
+      permission === 'admin' ||
+      permission === 'maintain' ||
+      permission === 'write'
+    );
+  });
 }

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -7,6 +7,7 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { parseCliArgs } from './cli-args.mjs';
+import { resolveTrustedCollaboratorMarkerLogins } from './collaborator-permission.mjs';
 import { resolveHelperActiveClaim } from './forced-handoff-marker.mjs';
 import { ghText, safeGhText } from './gh-exec.mjs';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
@@ -693,33 +694,18 @@ export function buildTrustedMarkerLogins({
   ) {
     return trusted;
   }
-  const uniqueLogins = new Set(
-    (issueComments ?? [])
-      .map((comment) =>
-        String(comment.user?.login ?? comment.author?.login ?? '')
-          .trim()
-          .toLowerCase(),
-      )
-      .filter(Boolean),
-  );
-  for (const login of uniqueLogins) {
-    if (trusted.has(login)) {
-      continue;
-    }
-    const authority = resolveCollaboratorAuthority({
-      owner,
-      repo,
-      actor: login,
-    });
-    if (
-      authority.roleName === 'admin' ||
-      authority.roleName === 'maintain' ||
-      authority.permission === 'admin' ||
-      authority.permission === 'maintain' ||
-      authority.permission === 'write'
-    ) {
-      trusted.add(login);
-    }
+  // #1693: marker-authors-first -- only comment authors whose comment is
+  // itself operational-marker-shaped are permission-checked, matching
+  // pre-merge-readiness.mts / advisory-convergence.mts /
+  // advisory-wait-state.mts (and force-handoff.mts as of this change).
+  // Checking every unique comment author (the prior local loop here)
+  // over-trusted ordinary commenters.
+  for (const login of resolveTrustedCollaboratorMarkerLogins(
+    owner,
+    repo,
+    issueComments ?? [],
+  )) {
+    trusted.add(login);
   }
   return trusted;
 }

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -9,6 +9,7 @@ import { readFileSync } from 'node:fs';
 import { parseCliArgs } from './cli-args.mjs';
 import { resolveHelperActiveClaim } from './forced-handoff-marker.mjs';
 import { ghText, safeGhText } from './gh-exec.mjs';
+import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import {
   normalizePolicyConfig,
   parseIsoDurationToMs,
@@ -749,6 +750,29 @@ function ghJson(args, slurp = false) {
   }
   return JSON.parse(execFileSync('gh', finalArgs, { encoding: 'utf8' }));
 }
+/**
+ * Pure derivation step for {@link ghApiJsonWithStatus}'s catch branch,
+ * exported so tests can inject an error shape directly instead of shelling
+ * out to a real `gh` invocation (matching the mock-free-subprocess
+ * convention documented in `tests/collaborator-permission.test.mts`).
+ *
+ * #1693: derives the real HTTP status via the shared gh-http-status.mts
+ * helpers (stderr `(HTTP NNN)` pattern, then a JSON-body `"status"` field
+ * fallback across stderr/stdout/message) instead of the prior local
+ * `extractGhHttpStatus`, which fell back to the child-process exit code
+ * when no HTTP-status text was found -- `gh` exits 1 for 401/403/404
+ * alike, so that fallback could misreport a 404 or an auth failure as
+ * "status 1". `deriveGhHttpStatus` returns null (not 0) when no status can
+ * be determined at all; 500 preserves this function's existing
+ * "definitely not 200, not 404" fail-closed fallback for that case.
+ */
+export function deriveGhApiStatusFromError(error) {
+  const status = deriveGhHttpStatus(error);
+  return {
+    status: status ?? 500,
+    body: {},
+  };
+}
 function ghApiJsonWithStatus(path) {
   try {
     return {
@@ -756,22 +780,8 @@ function ghApiJsonWithStatus(path) {
       body: JSON.parse(execFileSync('gh', ['api', path], { encoding: 'utf8' })),
     };
   } catch (error) {
-    const status = extractGhHttpStatus(error);
-    return {
-      status: status || 500,
-      body: {},
-    };
+    return deriveGhApiStatusFromError(error);
   }
-}
-export function extractGhHttpStatus(error) {
-  const e = error;
-  const stderr = String(e?.stderr ?? '');
-  const httpStatusMatch = stderr.match(/\(HTTP\s+(\d{3})\)/i);
-  if (httpStatusMatch) {
-    return Number(httpStatusMatch[1]);
-  }
-  const exitStatus = Number(e?.status ?? e?.exitCode ?? 0);
-  return Number.isInteger(exitStatus) && exitStatus > 0 ? exitStatus : 0;
 }
 function renderReport(report, format) {
   if (format === 'text') {

--- a/scripts/force-handoff.mjs
+++ b/scripts/force-handoff.mjs
@@ -10,6 +10,7 @@ import {
   isAuthorizedForcedHandoffActor,
   readForcedHandoffAuthorityPolicy,
   readForcedHandoffMode,
+  resolveTrustedCollaboratorMarkerLogins,
 } from './collaborator-permission.mjs';
 import { planHandoff } from './forced-handoff-marker.mjs';
 import { ghText, safeGhText } from './gh-exec.mjs';
@@ -203,7 +204,13 @@ function ghJson(args, slurp = false) {
   }
   return JSON.parse(execFileSync('gh', finalArgs, { encoding: 'utf8' }));
 }
-function buildTrustedMarkerLogins(owner, repo, viewerLogin, issueComments) {
+export function buildTrustedMarkerLogins(
+  owner,
+  repo,
+  viewerLogin,
+  issueComments,
+  cache,
+) {
   const configuredActors = readTrustedMarkerActorsFromConfig();
   const configured = [
     viewerLogin,
@@ -216,36 +223,18 @@ function buildTrustedMarkerLogins(owner, repo, viewerLogin, issueComments) {
   if (!readCollaboratorTrustEnabled()) {
     return trusted;
   }
-  const permissionCache = new Map();
-  const uniqueLogins = new Set(
-    issueComments
-      .map((comment) =>
-        String(
-          comment.user?.login ?? comment.author?.login ?? '',
-        ).toLowerCase(),
-      )
-      .filter(Boolean),
-  );
-  for (const login of uniqueLogins) {
-    if (trusted.has(login)) {
-      continue;
-    }
-    const permission =
-      permissionCache.get(login) ??
-      safeGhText([
-        'api',
-        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-        '--jq',
-        '.permission',
-      ]).toLowerCase();
-    permissionCache.set(login, permission);
-    if (
-      permission === 'admin' ||
-      permission === 'maintain' ||
-      permission === 'write'
-    ) {
-      trusted.add(login);
-    }
+  // #1693: marker-authors-first -- only comment authors whose comment is
+  // itself operational-marker-shaped are permission-checked, matching
+  // pre-merge-readiness.mts / advisory-convergence.mts /
+  // advisory-wait-state.mts. Checking every unique comment author (the
+  // prior local loop here) over-trusted ordinary commenters.
+  for (const login of resolveTrustedCollaboratorMarkerLogins(
+    owner,
+    repo,
+    issueComments,
+    { cache },
+  )) {
+    trusted.add(login);
   }
   return trusted;
 }

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -771,7 +771,15 @@ export function parseReviewWatermarkComment(body, createdAt) {
   return {
     agentId: match[1],
     claimId: match[2],
-    headSha: match[3],
+    // #1693: the `i` flag accepts an uppercase-hex SHA (the documented
+    // manual hand-composed fallback path), but downstream comparisons
+    // (diffReviewSnapshot in protocol-helpers.mts) match exactly against
+    // the always-lowercase live head SHA. Returning match[3] verbatim let a
+    // hand-composed uppercase watermark parse as valid yet never satisfy
+    // the F2 currency check, producing an unexplained head-changed
+    // repost loop. Lowercase here, matching parseExternalCheckWaiverComment's
+    // existing headSha.toLowerCase() below.
+    headSha: match[3].toLowerCase(),
     maxActivityUpdatedAt,
     totalItemCount,
     latestCiCompletedAt,

--- a/src/scripts/claim-approval-gate.mts
+++ b/src/scripts/claim-approval-gate.mts
@@ -10,6 +10,7 @@ import { readFileSync } from 'node:fs';
 
 import { parseCliArgs } from './cli-args.mts';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mts';
+import { deriveGhHttpStatus } from './gh-http-status.mts';
 import { normalizePolicyConfig } from './policy-helpers.mts';
 
 const APPROVAL_POLICIES = new Set([
@@ -945,20 +946,52 @@ function ghApiJsonWithStatus(path: string): {
     const body = JSON.parse(runGh(['api', path]).trim() || '{}');
     return { status: 200, body };
   } catch (error) {
-    const stderr = String((error as { stderr?: unknown })?.stderr ?? '');
-    const httpStatus = Number.parseInt(
-      /HTTP\s+(\d+)/.exec(stderr)?.[1] ?? '0',
-      10,
-    );
-    if (httpStatus > 0) {
-      return { status: httpStatus, body: null };
-    }
-    return { status: 0, body: null };
+    // #1693: derive the real HTTP status via the shared gh-http-status.mts
+    // helper instead of grepping stderr only with a bespoke `/HTTP\s+(\d+)/`
+    // pattern -- that missed the JSON-error-body-in-stdout fallback
+    // deriveGhHttpStatus already applies (stdout now survives runGh's error
+    // wrapping too; see wrapGhError below). `0` preserves this function's
+    // existing "status could not be determined" sentinel (unchanged
+    // downstream contract: callers already treat any non-200/404 status,
+    // including 0, as "permission lookup failed").
+    const status = deriveGhHttpStatus(error);
+    return { status: status ?? 0, body: null };
   }
 }
 
 function ghJson(args: string[]): unknown {
   return JSON.parse(runGh(args).trim() || '{}');
+}
+
+/**
+ * Pure wrap step for {@link runGh}'s catch branch, exported so tests can
+ * inject a raw execFileSync-shaped error directly instead of shelling out
+ * to a real `gh` invocation (matching the mock-free-subprocess convention
+ * documented in `tests/collaborator-permission.test.mts`).
+ *
+ * When stderr is present, wraps it into a fresh Error carrying both
+ * `.stderr` and `.stdout`. #1693: the previous wrap carried `.stderr` only,
+ * which silently dropped `.stdout` and defeated `deriveGhHttpStatus`'s
+ * JSON-error-body-in-stdout fallback for every caller downstream of
+ * `runGh` (this file's `ghApiJsonWithStatus`) -- `gh api` can print a JSON
+ * error body to stdout even as it writes its human-readable diagnostic to
+ * stderr. When stderr is empty, returns the original error unchanged: the
+ * raw execFileSync error already carries `.stdout`/`.stderr`/`.status`
+ * natively, so wrapping would only lose information.
+ */
+export function wrapGhError(error: unknown): unknown {
+  const stderr = String((error as { stderr?: unknown })?.stderr ?? '').trim();
+  if (!stderr) {
+    return error;
+  }
+  const stdout = String((error as { stdout?: unknown })?.stdout ?? '').trim();
+  const wrapped = new Error(`gh command failed: ${stderr}`) as Error & {
+    stderr?: string;
+    stdout?: string;
+  };
+  wrapped.stderr = stderr;
+  wrapped.stdout = stdout;
+  return wrapped;
 }
 
 function runGh(args: string[]): string {
@@ -969,14 +1002,6 @@ function runGh(args: string[]): string {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
   } catch (error) {
-    const stderr = String((error as { stderr?: unknown })?.stderr ?? '').trim();
-    if (stderr) {
-      const wrapped = new Error(`gh command failed: ${stderr}`) as Error & {
-        stderr?: string;
-      };
-      wrapped.stderr = stderr;
-      throw wrapped;
-    }
-    throw error;
+    throw wrapGhError(error);
   }
 }

--- a/src/scripts/collaborator-permission.mts
+++ b/src/scripts/collaborator-permission.mts
@@ -20,6 +20,7 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
+import { operationalMarkerPrefix } from './marker-helpers.mts';
 import { normalizePolicyConfig } from './policy-helpers.mts';
 
 const DEFAULT_POLICY_PATH = '.github/idd/config.json';
@@ -188,4 +189,82 @@ export function readForcedHandoffAuthorityPolicy(
   configPath: string = DEFAULT_POLICY_PATH,
 ): string {
   return readForcedHandoffPolicy(configPath).authorityPolicy;
+}
+
+/** Minimal comment shape the marker-authors-first filter needs. */
+export interface MarkerTrustCommentLike {
+  body?: string | null;
+  user?: { login?: string | null } | null;
+  author?: { login?: string | null } | null;
+}
+
+/**
+ * Resolve collaborator-marker-trust logins from a comment stream:
+ * marker-authors-first (#1693). Only comment authors whose comment body is
+ * itself marker-shaped per `isMarkerShaped` (default: any recognized
+ * operational-marker prefix via `operationalMarkerPrefix`) are even
+ * candidates; only those candidates get a collaborator-permission lookup,
+ * and only Write/Maintain/Admin permission earns trust.
+ *
+ * Checking every unique comment author regardless of whether they ever
+ * posted anything marker-shaped over-trusts ordinary commenters (anyone
+ * with write+ access who merely left an unrelated comment would be treated
+ * as a trusted marker actor) and wastes a permission lookup per unique
+ * commenter. This mirrors `pre-merge-readiness.mts` /
+ * `advisory-convergence.mts`'s identically-named local function (kept
+ * local there rather than migrated here: both call `safeGhText` with
+ * `GH_TEXT_LOOP_OPTIONS` loop-safety timeouts that this shared
+ * `collaboratorPermission`-based implementation does not apply, and
+ * `advisory-wait-state.mts`'s local variant intentionally narrows the
+ * marker-shape predicate to advisory-wait markers only). New consumers
+ * (`force-handoff.mts`, `external-check-waiver.mts`) call this instead of
+ * hand-rolling a fourth/fifth "check every comment author" copy.
+ *
+ * Deliberately checks only the legacy `permission` field (admin/maintain/
+ * write), matching the sibling implementations' `--jq '.permission'`
+ * shape exactly rather than also checking `role_name` -- parity with the
+ * sibling filter is an explicit acceptance criterion, and GitHub's legacy
+ * `permission` field already collapses a `maintain` role to `write` (see
+ * `collaboratorPermission`'s doc comment above), so a `role_name` check
+ * would only widen trust, never narrow it, and would make "parity"
+ * untestable against a real HTTP response shape.
+ */
+export function resolveTrustedCollaboratorMarkerLogins(
+  owner: string,
+  repo: string,
+  comments: MarkerTrustCommentLike[],
+  options: {
+    cache?: CollaboratorPermissionCache;
+    isMarkerShaped?: (body: string) => boolean;
+  } = {},
+): string[] {
+  const isMarkerShaped =
+    options.isMarkerShaped ??
+    ((body: string) => operationalMarkerPrefix(body) !== null);
+  const markerAuthors = [
+    ...new Set(
+      comments
+        .filter((comment) => isMarkerShaped(String(comment.body ?? '')))
+        .map((comment) =>
+          String(comment.author?.login ?? comment.user?.login ?? '')
+            .trim()
+            .toLowerCase(),
+        )
+        .filter(Boolean),
+    ),
+  ];
+
+  return markerAuthors.filter((login) => {
+    const { permission } = collaboratorPermission(
+      owner,
+      repo,
+      login,
+      options.cache,
+    );
+    return (
+      permission === 'admin' ||
+      permission === 'maintain' ||
+      permission === 'write'
+    );
+  });
 }

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -11,6 +11,7 @@ import { readFileSync } from 'node:fs';
 import { parseCliArgs } from './cli-args.mts';
 import { resolveHelperActiveClaim } from './forced-handoff-marker.mts';
 import { ghText, safeGhText } from './gh-exec.mts';
+import { deriveGhHttpStatus } from './gh-http-status.mts';
 import {
   normalizePolicyConfig,
   parseIsoDurationToMs,
@@ -1088,6 +1089,30 @@ function ghJson(args: string[], slurp = false): unknown {
   return JSON.parse(execFileSync('gh', finalArgs, { encoding: 'utf8' }));
 }
 
+/**
+ * Pure derivation step for {@link ghApiJsonWithStatus}'s catch branch,
+ * exported so tests can inject an error shape directly instead of shelling
+ * out to a real `gh` invocation (matching the mock-free-subprocess
+ * convention documented in `tests/collaborator-permission.test.mts`).
+ *
+ * #1693: derives the real HTTP status via the shared gh-http-status.mts
+ * helpers (stderr `(HTTP NNN)` pattern, then a JSON-body `"status"` field
+ * fallback across stderr/stdout/message) instead of the prior local
+ * `extractGhHttpStatus`, which fell back to the child-process exit code
+ * when no HTTP-status text was found -- `gh` exits 1 for 401/403/404
+ * alike, so that fallback could misreport a 404 or an auth failure as
+ * "status 1". `deriveGhHttpStatus` returns null (not 0) when no status can
+ * be determined at all; 500 preserves this function's existing
+ * "definitely not 200, not 404" fail-closed fallback for that case.
+ */
+export function deriveGhApiStatusFromError(error: unknown): GhApiStatusResult {
+  const status = deriveGhHttpStatus(error);
+  return {
+    status: status ?? 500,
+    body: {},
+  };
+}
+
 function ghApiJsonWithStatus(path: string): GhApiStatusResult {
   try {
     return {
@@ -1097,28 +1122,8 @@ function ghApiJsonWithStatus(path: string): GhApiStatusResult {
       ) as GhApiStatusResult['body'],
     };
   } catch (error) {
-    const status = extractGhHttpStatus(error);
-    return {
-      status: status || 500,
-      body: {},
-    };
+    return deriveGhApiStatusFromError(error);
   }
-}
-
-export function extractGhHttpStatus(error: unknown): number {
-  const e = error as {
-    stderr?: unknown;
-    status?: unknown;
-    exitCode?: unknown;
-  } | null;
-  const stderr = String(e?.stderr ?? '');
-  const httpStatusMatch = stderr.match(/\(HTTP\s+(\d{3})\)/i);
-  if (httpStatusMatch) {
-    return Number(httpStatusMatch[1]);
-  }
-
-  const exitStatus = Number(e?.status ?? e?.exitCode ?? 0);
-  return Number.isInteger(exitStatus) && exitStatus > 0 ? exitStatus : 0;
 }
 
 function renderReport(report: ExternalCheckWaiverReport, format: string): void {

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -9,6 +9,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
 import { parseCliArgs } from './cli-args.mts';
+import { resolveTrustedCollaboratorMarkerLogins } from './collaborator-permission.mts';
 import { resolveHelperActiveClaim } from './forced-handoff-marker.mts';
 import { ghText, safeGhText } from './gh-exec.mts';
 import { deriveGhHttpStatus } from './gh-http-status.mts';
@@ -1027,33 +1028,18 @@ export function buildTrustedMarkerLogins({
     return trusted;
   }
 
-  const uniqueLogins = new Set(
-    (issueComments ?? [])
-      .map((comment) =>
-        String(comment.user?.login ?? comment.author?.login ?? '')
-          .trim()
-          .toLowerCase(),
-      )
-      .filter(Boolean),
-  );
-  for (const login of uniqueLogins) {
-    if (trusted.has(login)) {
-      continue;
-    }
-    const authority = resolveCollaboratorAuthority({
-      owner,
-      repo,
-      actor: login,
-    });
-    if (
-      authority.roleName === 'admin' ||
-      authority.roleName === 'maintain' ||
-      authority.permission === 'admin' ||
-      authority.permission === 'maintain' ||
-      authority.permission === 'write'
-    ) {
-      trusted.add(login);
-    }
+  // #1693: marker-authors-first -- only comment authors whose comment is
+  // itself operational-marker-shaped are permission-checked, matching
+  // pre-merge-readiness.mts / advisory-convergence.mts /
+  // advisory-wait-state.mts (and force-handoff.mts as of this change).
+  // Checking every unique comment author (the prior local loop here)
+  // over-trusted ordinary commenters.
+  for (const login of resolveTrustedCollaboratorMarkerLogins(
+    owner,
+    repo,
+    issueComments ?? [],
+  )) {
+    trusted.add(login);
   }
   return trusted;
 }

--- a/src/scripts/force-handoff.mts
+++ b/src/scripts/force-handoff.mts
@@ -12,6 +12,7 @@ import {
   isAuthorizedForcedHandoffActor,
   readForcedHandoffAuthorityPolicy,
   readForcedHandoffMode,
+  resolveTrustedCollaboratorMarkerLogins,
 } from './collaborator-permission.mts';
 import { planHandoff } from './forced-handoff-marker.mts';
 import { ghText, safeGhText } from './gh-exec.mts';
@@ -290,11 +291,12 @@ function ghJson(args: string[], slurp = false): unknown {
   return JSON.parse(execFileSync('gh', finalArgs, { encoding: 'utf8' }));
 }
 
-function buildTrustedMarkerLogins(
+export function buildTrustedMarkerLogins(
   owner: string,
   repo: string,
   viewerLogin: string,
   issueComments: IssueCommentPayload[],
+  cache?: CollaboratorPermissionCache,
 ): Set<string> {
   const configuredActors = readTrustedMarkerActorsFromConfig();
   const configured = [
@@ -310,36 +312,18 @@ function buildTrustedMarkerLogins(
     return trusted;
   }
 
-  const permissionCache = new Map<string, string>();
-  const uniqueLogins = new Set(
-    issueComments
-      .map((comment) =>
-        String(
-          comment.user?.login ?? comment.author?.login ?? '',
-        ).toLowerCase(),
-      )
-      .filter(Boolean),
-  );
-  for (const login of uniqueLogins) {
-    if (trusted.has(login)) {
-      continue;
-    }
-    const permission =
-      permissionCache.get(login) ??
-      safeGhText([
-        'api',
-        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-        '--jq',
-        '.permission',
-      ]).toLowerCase();
-    permissionCache.set(login, permission);
-    if (
-      permission === 'admin' ||
-      permission === 'maintain' ||
-      permission === 'write'
-    ) {
-      trusted.add(login);
-    }
+  // #1693: marker-authors-first -- only comment authors whose comment is
+  // itself operational-marker-shaped are permission-checked, matching
+  // pre-merge-readiness.mts / advisory-convergence.mts /
+  // advisory-wait-state.mts. Checking every unique comment author (the
+  // prior local loop here) over-trusted ordinary commenters.
+  for (const login of resolveTrustedCollaboratorMarkerLogins(
+    owner,
+    repo,
+    issueComments,
+    { cache },
+  )) {
+    trusted.add(login);
   }
   return trusted;
 }

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -1081,7 +1081,15 @@ export function parseReviewWatermarkComment(
   return {
     agentId: match[1],
     claimId: match[2],
-    headSha: match[3],
+    // #1693: the `i` flag accepts an uppercase-hex SHA (the documented
+    // manual hand-composed fallback path), but downstream comparisons
+    // (diffReviewSnapshot in protocol-helpers.mts) match exactly against
+    // the always-lowercase live head SHA. Returning match[3] verbatim let a
+    // hand-composed uppercase watermark parse as valid yet never satisfy
+    // the F2 currency check, producing an unexplained head-changed
+    // repost loop. Lowercase here, matching parseExternalCheckWaiverComment's
+    // existing headSha.toLowerCase() below.
+    headSha: match[3].toLowerCase(),
     maxActivityUpdatedAt,
     totalItemCount,
     latestCiCompletedAt,

--- a/tests/claim-approval-gate.test.mts
+++ b/tests/claim-approval-gate.test.mts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { evaluateClaimApprovalGate } from '../src/scripts/claim-approval-gate.mts';
+import {
+  evaluateClaimApprovalGate,
+  wrapGhError,
+} from '../src/scripts/claim-approval-gate.mts';
+import { deriveGhHttpStatus } from '../src/scripts/gh-http-status.mts';
 
 const BASE_ISSUE = {
   number: 393,
@@ -478,4 +482,53 @@ test('check ids stay deterministic and ordered', () => {
       'ambiguity_guard',
     ],
   );
+});
+
+// --- #1693: shared gh-http-status.mts wiring --------------------------
+
+// wrapGhError is runGh's catch-branch pure step, exported so these tests
+// can inject a raw execFileSync-shaped error directly instead of shelling
+// out to a real `gh` invocation (#1212's mock-free-subprocess convention).
+// Composing it with deriveGhHttpStatus (the same composition
+// ghApiJsonWithStatus's catch branch performs internally) proves the full
+// wiring, not just the underlying shared helper in isolation.
+
+test('wrapGhError preserves stdout on the wrapped error (previously dropped)', () => {
+  const wrapped = wrapGhError({
+    status: 1,
+    stderr: 'gh: Not Found (HTTP 404)',
+    stdout: '{"message":"Not Found","status":"404"}',
+  }) as { stderr?: string; stdout?: string };
+  assert.equal(wrapped.stderr, 'gh: Not Found (HTTP 404)');
+  assert.equal(wrapped.stdout, '{"message":"Not Found","status":"404"}');
+});
+
+test('wrapGhError returns the original error unchanged when stderr is empty', () => {
+  const original = { status: 1, stderr: '', stdout: 'irrelevant' };
+  assert.equal(wrapGhError(original), original);
+});
+
+test('wrapGhError + deriveGhHttpStatus never surfaces a bare exit code as the HTTP status', () => {
+  // gh exits 1 for 401/403/404 alike; the removed status-derivation logic
+  // in ghApiJsonWithStatus greped stderr only for /HTTP\s+(\d+)/ and fell
+  // through to a "status could not be determined" 0 when absent -- so an
+  // exit code never leaked through this specific path even before the
+  // fix. This test locks in that invariant against the new composition.
+  const wrapped = wrapGhError({ status: 1, stderr: 'connect ETIMEDOUT' });
+  assert.equal(deriveGhHttpStatus(wrapped), null);
+});
+
+test('wrapGhError + deriveGhHttpStatus recovers a status from a JSON error body on stdout', () => {
+  // #1693: the prior local ghApiJsonWithStatus implementation greped
+  // stderr only, and even wrapGhError's predecessor dropped .stdout on the
+  // wrapped error -- so a JSON error body written to stdout (with no
+  // "(HTTP NNN)" text in stderr) was invisible end to end. Both defects
+  // are fixed together: wrapGhError now preserves .stdout, and
+  // deriveGhHttpStatus already knows how to fall back to it.
+  const wrapped = wrapGhError({
+    status: 1,
+    stderr: 'gh: Not Found',
+    stdout: '{"message":"Not Found","status":"404"}',
+  });
+  assert.equal(deriveGhHttpStatus(wrapped), 404);
 });

--- a/tests/collaborator-permission.test.mts
+++ b/tests/collaborator-permission.test.mts
@@ -11,6 +11,7 @@ import {
   readForcedHandoffAuthorityPolicy,
   readForcedHandoffMode,
   readForcedHandoffPolicy,
+  resolveTrustedCollaboratorMarkerLogins,
 } from '../src/scripts/collaborator-permission.mts';
 
 // collaboratorPermission and isAuthorizedForcedHandoffActor's UNCACHED path
@@ -222,3 +223,93 @@ for (const [permission, roleName, expected] of LOOSE_POLICY_CASES) {
     );
   });
 }
+
+// --- resolveTrustedCollaboratorMarkerLogins (#1693) ---------------------
+//
+// #1693: this is the single canonical "marker-authors-first" filter
+// force-handoff.mts and external-check-waiver.mts now call instead of
+// each hand-rolling a copy that permission-checked every unique comment
+// author regardless of whether they ever posted anything marker-shaped.
+// Coverage stays on the cache-seeding seam (#1212: no `gh` subprocess
+// mocking), which also proves a non-marker-shaped author's comment never
+// even reaches a permission lookup: seeding the cache for a login that is
+// never queried would go unnoticed, but seeding it and asserting the
+// login is still excluded (cases below) proves the filter, not the cache.
+
+const ADVISORY_WAIT_SHA = 'a'.repeat(40);
+const MARKER_BODY = `advisory-wait: some-agent ${ADVISORY_WAIT_SHA} 2026-05-10T00:00:00Z`;
+
+test('resolveTrustedCollaboratorMarkerLogins excludes a write+ author whose comment is not marker-shaped', () => {
+  const cache = seededCache('o', 'r', 'random-write-actor', 'write', 'write');
+  const trusted = resolveTrustedCollaboratorMarkerLogins(
+    'o',
+    'r',
+    [
+      {
+        body: 'just an ordinary comment',
+        user: { login: 'random-write-actor' },
+      },
+    ],
+    { cache },
+  );
+  assert.deepEqual(trusted, []);
+});
+
+test('resolveTrustedCollaboratorMarkerLogins includes a write+ author whose comment is marker-shaped', () => {
+  const cache = seededCache('o', 'r', 'marker-author', 'write', 'write');
+  const trusted = resolveTrustedCollaboratorMarkerLogins(
+    'o',
+    'r',
+    [{ body: MARKER_BODY, author: { login: 'marker-author' } }],
+    { cache },
+  );
+  assert.deepEqual(trusted, ['marker-author']);
+});
+
+test('resolveTrustedCollaboratorMarkerLogins still excludes a marker-shaped author without write+ permission', () => {
+  const cache = seededCache('o', 'r', 'read-only-actor', 'read', 'read');
+  const trusted = resolveTrustedCollaboratorMarkerLogins(
+    'o',
+    'r',
+    [{ body: MARKER_BODY, user: { login: 'read-only-actor' } }],
+    { cache },
+  );
+  assert.deepEqual(trusted, []);
+});
+
+test('resolveTrustedCollaboratorMarkerLogins dedupes repeated marker-shaped authors to one permission lookup', () => {
+  const cache = seededCache('o', 'r', 'repeat-author', 'admin', 'admin');
+  const trusted = resolveTrustedCollaboratorMarkerLogins(
+    'o',
+    'r',
+    [
+      { body: MARKER_BODY, user: { login: 'repeat-author' } },
+      { body: MARKER_BODY, user: { login: 'Repeat-Author' } },
+    ],
+    { cache },
+  );
+  assert.deepEqual(trusted, ['repeat-author']);
+});
+
+test('resolveTrustedCollaboratorMarkerLogins accepts a custom isMarkerShaped predicate', () => {
+  const cache = seededCache('o', 'r', 'advisory-actor', 'write', 'write');
+  const trusted = resolveTrustedCollaboratorMarkerLogins(
+    'o',
+    'r',
+    [
+      { body: MARKER_BODY, user: { login: 'advisory-actor' } },
+      // A different recognized operational marker (claimed-by-shaped) that
+      // the narrower custom predicate below must reject even though the
+      // default operationalMarkerPrefix predicate would accept it.
+      {
+        body: '<!-- claimed-by: agent claim-1 supersedes: none 2026-05-10T00:00:00Z branch: issue/1 -->',
+        user: { login: 'claim-actor' },
+      },
+    ],
+    {
+      cache,
+      isMarkerShaped: (body) => body.startsWith('advisory-wait:'),
+    },
+  );
+  assert.deepEqual(trusted, ['advisory-actor']);
+});

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -298,6 +298,37 @@ test('buildTrustedMarkerLogins always trusts the repository owner', () => {
   assert.ok(trusted.has('maintainer-user'));
 });
 
+// #1693: buildTrustedMarkerLogins previously permission-checked every
+// unique comment author (not just marker-shaped ones) whenever collaborator
+// marker trust is enabled, over-trusting an ordinary write+ commenter who
+// never posted an operational marker. Collaborator-marker-trust widening
+// requires a live gh collaborator-permission lookup with no injection seam
+// here, and #1212 forbids mocking the `gh` subprocess -- so this regresses
+// against the disabled-widening path instead: with collaborator marker
+// trust left at its default (disabled), no comment author is ever
+// permission-checked regardless of shape, proving the widening loop no
+// longer runs unconditionally over every comment author the way the prior
+// implementation did (the buildTrustedMarkerLogins/resolveTrustedCollaboratorMarkerLogins
+// unit coverage in tests/force-handoff.test.mts and
+// tests/collaborator-permission.test.mts exercises the enabled marker-shape
+// filter itself via cache-seeding).
+test('buildTrustedMarkerLogins does not trust a non-marker-shaped comment author (collaborator trust disabled by default)', () => {
+  const trusted = buildTrustedMarkerLogins({
+    owner: 'repo-owner',
+    repo: 'example',
+    rawConfig: normalizePolicyConfig({}),
+    viewerLogin: 'maintainer-user',
+    issueComments: [
+      {
+        body: 'just an ordinary comment',
+        user: { login: 'random-write-actor' },
+      },
+    ],
+  });
+
+  assert.ok(!trusted.has('random-write-actor'));
+});
+
 // #1693: exit-code-never-surfaces-as-HTTP-status + JSON-body status
 // recovery, proven against the actual wired catch-branch function (not
 // just the underlying gh-http-status.mts helper it delegates to -- see

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -3,7 +3,7 @@ import { test } from 'node:test';
 
 import {
   buildTrustedMarkerLogins,
-  extractGhHttpStatus,
+  deriveGhApiStatusFromError,
   parseArgs,
   planExternalCheckWaiver,
 } from '../src/scripts/external-check-waiver.mts';
@@ -298,16 +298,41 @@ test('buildTrustedMarkerLogins always trusts the repository owner', () => {
   assert.ok(trusted.has('maintainer-user'));
 });
 
-test('extractGhHttpStatus prefers HTTP status codes from gh stderr', () => {
+// #1693: exit-code-never-surfaces-as-HTTP-status + JSON-body status
+// recovery, proven against the actual wired catch-branch function (not
+// just the underlying gh-http-status.mts helper it delegates to -- see
+// tests/gh-http-status.test.mts for that direct coverage).
+test('deriveGhApiStatusFromError never surfaces a bare process exit code as the HTTP status', () => {
+  // gh exits 1 for 401/403/404 alike; the removed extractGhHttpStatus used
+  // to fall back to this exit code when no `(HTTP NNN)` text was present,
+  // silently reporting e.g. a 404 as "status 1". The fixed function must
+  // fail closed to 500 instead.
   assert.equal(
-    extractGhHttpStatus({
+    deriveGhApiStatusFromError({ status: 1, stderr: '', stdout: '' }).status,
+    500,
+  );
+});
+
+test('deriveGhApiStatusFromError recovers a status from a JSON error body on stdout', () => {
+  assert.equal(
+    deriveGhApiStatusFromError({
       status: 1,
-      stderr: 'gh: definitely-not-a-user is not a user (HTTP 404)\n',
-    }),
+      stderr: '',
+      stdout: '{"message":"Not Found","status":"404"}',
+    }).status,
     404,
   );
-  assert.equal(extractGhHttpStatus({ status: 1, stderr: '' }), 1);
-  assert.equal(extractGhHttpStatus({ status: 0, stderr: '' }), 0);
+});
+
+test('deriveGhApiStatusFromError still prefers the (HTTP NNN) stderr signal', () => {
+  assert.equal(
+    deriveGhApiStatusFromError({
+      status: 1,
+      stderr: 'gh: definitely-not-a-user is not a user (HTTP 404)\n',
+      stdout: '',
+    }).status,
+    404,
+  );
 });
 
 test('parseExternalCheckWaiverComment returns null for empty or non-marker bodies', () => {

--- a/tests/force-handoff.test.mts
+++ b/tests/force-handoff.test.mts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { runHandoff } from '../src/scripts/force-handoff.mts';
+import type { CollaboratorPermissionCache } from '../src/scripts/collaborator-permission.mts';
+import { resolveTrustedCollaboratorMarkerLogins } from '../src/scripts/collaborator-permission.mts';
+import {
+  buildTrustedMarkerLogins,
+  runHandoff,
+} from '../src/scripts/force-handoff.mts';
 
 type RunHandoffOptions = NonNullable<Parameters<typeof runHandoff>[0]>;
 
@@ -185,4 +190,95 @@ test('runHandoff reports posted: true and returns successorIds and commentUrl', 
     /^claim-[0-9a-f]{16}$/,
     'claim ID should match expected format',
   );
+});
+
+// --- #1693: buildTrustedMarkerLogins trusts only operational-marker -------
+// authors, matching the sibling filter ------------------------------------
+//
+// Previously buildTrustedMarkerLogins permission-checked every unique
+// issue-comment author (once collaborator marker trust is enabled),
+// over-trusting an ordinary write+ commenter who never posted an
+// operational marker. It now delegates that widening step to
+// resolveTrustedCollaboratorMarkerLogins (collaborator-permission.mts) --
+// the same marker-authors-first filter pre-merge-readiness.mts and
+// advisory-convergence.mts already use. This test proves parity by calling
+// both with the identical comment/permission inputs and asserting matching
+// membership, rather than trusting that "delegates to" claim by
+// inspection alone.
+
+const MARKER_AUTHORS_FIRST_BODY = [
+  '<!-- claimed-by: some-agent claim-marker-parity supersedes: none 2026-05-13T10:00:00Z branch: issue/9001-parity -->',
+  '',
+  '_some-agent: issue claim — IDD automation marker. Do not edit._',
+].join('\n');
+
+test('buildTrustedMarkerLogins trusts only operational-marker-shaped comment authors when collaborator marker trust is enabled', () => {
+  const previousEnv = process.env.IDD_TRUST_COLLABORATOR_MARKERS;
+  process.env.IDD_TRUST_COLLABORATOR_MARKERS = 'true';
+  try {
+    const comments = [
+      { body: MARKER_AUTHORS_FIRST_BODY, user: { login: 'marker-author' } },
+      {
+        body: 'just an ordinary comment',
+        user: { login: 'ordinary-commenter' },
+      },
+    ];
+    const seed: CollaboratorPermissionCache = new Map([
+      ['o/r:marker-author', { permission: 'write', roleName: 'write' }],
+      ['o/r:ordinary-commenter', { permission: 'write', roleName: 'write' }],
+    ]);
+
+    const trusted = buildTrustedMarkerLogins(
+      'o',
+      'r',
+      'viewer',
+      comments,
+      new Map(seed),
+    );
+    const siblingFilterResult = resolveTrustedCollaboratorMarkerLogins(
+      'o',
+      'r',
+      comments,
+      { cache: new Map(seed) },
+    );
+
+    // Parity, per-login: force-handoff's decision for each comment author
+    // exactly matches the sibling filter's own decision for that same
+    // author (comparing whole sets directly would also pick up
+    // config-sourced base actors this repo's own .github/idd/config.json
+    // declares, which are unrelated to the marker-shape filter under
+    // test).
+    for (const login of ['marker-author', 'ordinary-commenter']) {
+      assert.equal(
+        trusted.has(login),
+        siblingFilterResult.includes(login),
+        `parity mismatch for ${login}`,
+      );
+    }
+    assert.ok(trusted.has('marker-author'));
+    assert.ok(!trusted.has('ordinary-commenter'));
+  } finally {
+    if (previousEnv === undefined) {
+      delete process.env.IDD_TRUST_COLLABORATOR_MARKERS;
+    } else {
+      process.env.IDD_TRUST_COLLABORATOR_MARKERS = previousEnv;
+    }
+  }
+});
+
+test('buildTrustedMarkerLogins leaves comment authors untouched when collaborator marker trust is disabled', () => {
+  const previousEnv = process.env.IDD_TRUST_COLLABORATOR_MARKERS;
+  delete process.env.IDD_TRUST_COLLABORATOR_MARKERS;
+  try {
+    const trusted = buildTrustedMarkerLogins('o', 'r', 'viewer', [
+      { body: MARKER_AUTHORS_FIRST_BODY, user: { login: 'marker-author' } },
+    ]);
+    assert.ok(!trusted.has('marker-author'));
+  } finally {
+    if (previousEnv === undefined) {
+      delete process.env.IDD_TRUST_COLLABORATOR_MARKERS;
+    } else {
+      process.env.IDD_TRUST_COLLABORATOR_MARKERS = previousEnv;
+    }
+  }
 });

--- a/tests/review-gate.test.mts
+++ b/tests/review-gate.test.mts
@@ -4,6 +4,7 @@ import { test } from 'node:test';
 import {
   classifyReviewThreadForGate,
   diffReviewSnapshot,
+  resolveLatestReviewWatermark,
   routeRejectedChangesRequestedReview,
   summarizeReviewThreadsForGate,
 } from '../src/scripts/protocol-helpers.mts';
@@ -37,6 +38,67 @@ test('routes F2/F3 snapshot-vs-live diff scenarios', () => {
       fixture.name,
     );
   }
+});
+
+// #1693: parseReviewWatermarkComment's `i` flag accepts an uppercase-hex
+// head SHA (the documented manual hand-composed fallback path), but used to
+// return it verbatim. diffReviewSnapshot's very first check is an exact
+// string comparison of the watermark's headSha against the live head
+// (always lowercase -- see protocol-helpers.mts's own prHeadSha validation
+// upstream), so a hand-composed uppercase watermark parsed as valid yet
+// never satisfied that check: every F2 pass reported `head-changed` and
+// looped back to E1, even though the head genuinely had not moved. This is
+// the two-layer proof the fix actually closes that loop: not just that the
+// parser lowercases (a parser-only assertion would not prove the F2 gate
+// itself is satisfied), but that the full resolveLatestReviewWatermark ->
+// diffReviewSnapshot round trip no longer routes to head-changed for the
+// same head.
+test('an uppercase-authored review-watermark satisfies the F2 currency check for the same head', () => {
+  const lowerSha = 'a'.repeat(40);
+  const upperSha = lowerSha.toUpperCase();
+  const watermarkBody = [
+    `<!-- review-watermark: claude-x claim-1 ${upperSha} none 0 none -->`,
+    '',
+    '_claude-x: review triage snapshot — IDD automation marker. Do not edit._',
+  ].join('\n');
+
+  const watermark = resolveLatestReviewWatermark(
+    [
+      {
+        author: { login: 'claude-x' },
+        body: watermarkBody,
+        createdAt: '2026-05-10T00:00:00Z',
+      },
+    ],
+    { expectedClaimId: 'claim-1', isTrustedAuthor: () => true },
+  );
+
+  assert.ok(watermark, 'expected the uppercase-SHA watermark to parse');
+  // The parser must normalize the case-insensitively matched SHA to
+  // lowercase before it ever reaches diffReviewSnapshot's exact comparison.
+  assert.equal(watermark?.headSha, lowerSha);
+
+  const route = diffReviewSnapshot(
+    {
+      headSha: watermark?.headSha,
+      maxActivityUpdatedAt: watermark?.maxActivityUpdatedAt,
+      totalItemCount: watermark?.totalItemCount,
+      latestCiCompletedAt: watermark?.latestCiCompletedAt,
+    },
+    {
+      // Live head SHA is always lowercase (upstream validation in this
+      // file requires it); the bug this test guards against is the
+      // watermark side failing to match it after a hand-composed
+      // uppercase post.
+      headSha: lowerSha,
+      maxActivityUpdatedAt: 'none',
+      totalItemCount: 0,
+      latestCiCompletedAt: 'none',
+    },
+  );
+
+  assert.equal(route.route, 'proceed');
+  assert.notEqual(route.reason, 'head-changed');
 });
 
 test('classifies unresolved threads for awaiting-reviewer and conversation-resolution gates', () => {


### PR DESCRIPTION
# Summary

Aligns three "outlier" helpers on shared conventions already established
elsewhere in the fleet:

1. **gh HTTP-status derivation.** `external-check-waiver.mts`'s local
   `extractGhHttpStatus` fell back to the child-process exit code when no
   `(HTTP NNN)` pattern was found in stderr (`gh` exits 1 for 401/403/404
   alike, so this could silently misreport a real 404 as "status 1").
   `claim-approval-gate.mts` only grepped stderr, missing the JSON-error-
   body-on-stdout fallback. Both now derive status via the shared
   `deriveGhHttpStatus`/`ghErrorText` from `gh-http-status.mts`. Along the
   way, `claim-approval-gate.mts`'s `runGh` error-wrapping catch was also
   dropping `.stdout` on the wrapped `Error` it threw, independently
   defeating that stdout fallback for every downstream caller — fixed
   additively via a newly exported pure `wrapGhError` step (the original
   "rethrow unwrapped when stderr is empty" branch is unchanged).

2. **Watermark head-SHA case asymmetry.**
   `parseReviewWatermarkComment` matched the head SHA with a
   case-insensitive regex (accepting the documented hand-composed
   uppercase fallback) but returned the captured group verbatim, while
   `diffReviewSnapshot` compares it with an exact string match against
   the always-lowercase live head. A hand-composed uppercase-SHA
   watermark parsed as valid yet never satisfied the F2 currency check,
   producing an unexplained `head-changed` repost loop. Lowercased the
   captured SHA, matching `parseExternalCheckWaiverComment`'s existing
   behavior. Audited every other `i`-flag parser in `marker-helpers.mts`
   for the same asymmetry — none of the rest capture a hex SHA field, so
   no further fix was needed.

3. **Wider collaborator-marker trust in `force-handoff.mts`.**
   `buildTrustedMarkerLogins` permission-checked *every* unique comment
   author once collaborator marker trust is enabled, over-trusting an
   ordinary write+ commenter who never posted an operational marker —
   whereas `pre-merge-readiness.mts`/`advisory-convergence.mts` already
   filter to operational-marker-shaped comment authors first.
   `external-check-waiver.mts`'s own `buildTrustedMarkerLogins` had the
   identical defect. Extracted the shared marker-authors-first filter
   into `collaborator-permission.mts` as
   `resolveTrustedCollaboratorMarkerLogins` (that file already exists
   specifically to be the single source of truth for this class of
   logic) and pointed both outlier helpers at it instead of each
   hand-rolling a fourth/fifth "check every comment author" copy.

   `pre-merge-readiness.mts`, `advisory-convergence.mts`, and
   `advisory-wait-state.mts`'s own local copies are deliberately left
   unmigrated: the first two call `safeGhText` with
   `GH_TEXT_LOOP_OPTIONS` loop-safety timeouts this shared
   `collaboratorPermission`-based implementation does not apply, and
   `advisory-wait-state.mts` intentionally narrows its marker-shape
   predicate to advisory-wait markers only — migrating any of the three
   would be a distinct behavioral change, not a pure refactor.

   The shared filter deliberately checks only the legacy `permission`
   field (admin/maintain/write), matching the sibling filters' `--jq
   '.permission'` shape exactly rather than also checking `role_name` —
   parity with the sibling filter is an explicit acceptance criterion,
   and GitHub's legacy `permission` field already collapses a `maintain`
   role to `write`, so a `role_name` check would only widen trust, never
   narrow it.

Three atomic commits, one per alignment above.

## Linked issue

Closes #1693

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

None of the three original behaviors was a security hole (each failed
closed), but each produced misleading diagnostics or fail-closed churn.
See the issue body for the full background and the 2026-07-28 fresh-model
audit this traces to.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (biome, dprint, markdownlint)
- [x] `pnpm test` (2745/2745 pass)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run build:check`
- [x] `node scripts/idd-doctor.mjs` (pre-existing warnings only)

Added unit tests for each of the three fixes, including two proving the
fix against the actually-wired functions (not just the underlying shared
helper in isolation): an exit-code-only error never surfaces as the HTTP
status, a JSON error body on stdout recovers the real status, an
uppercase-authored watermark satisfies the F2 currency check end to end
(`resolveLatestReviewWatermark` -> `diffReviewSnapshot`), and
`force-handoff.mts`'s trust decision has parity with the extracted
sibling filter for identical input.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — read-only helper behavior)
- [x] Context budget impact reviewed (no instruction files touched)
