### PR TITLE
feat(advisory-convergence): explain why sameHeadReroll.eligible is false

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1484,6 +1484,18 @@ to post it is the consuming track's job.
   state alone never sets `ready: true`. Observed incident:
   kurone-kito/idd-skill#1562. See `idd-advisory-wait.instructions.md`'s
   Terminal routing section for the full hold/rerun sequence.
+- **Eligibility-relevant disposition-evidence counters (`#1719`)**: the
+  verdict also reports a `dispositionEvidence` field —
+  `{ missingRegularCommentCount, missingThreadCount }` — a narrow,
+  counters-only projection of the same evidence
+  `summarizeDispositionEvidenceForGate` already computes for this gate. It
+  exposes the numeric input behind `sameHeadReroll.eligible`'s
+  `missing-regular-comment-disposition` term (see below) directly on the
+  report, instead of only its pass/fail verdict. Not the same shape as
+  `pre-merge-readiness.mjs`'s own `dispositionEvidence` field (which
+  additionally carries `route` / `blockingCount` / full missing-item lists
+  for the F2 merge gate) — this gate's `dispositionEvidence` never gates
+  anything by itself.
 - Reuses the existing evidence modules — `isCopilotReviewerLogin` /
   `readAdvisoryPrimaryBotLogin`, `resolveAdvisoryBotLogins`,
   `resolveTrustedMarkerActors`, `summarizeDispositionEvidenceForGate`,
@@ -1542,21 +1554,50 @@ evidence, purely additively: `converged` / `waived` / `ready` are
 computed with **no reference to it at all**, so it can never let the
 gate pass on anything but the primary bot's own real signal.
 
-| Field         | Meaning                                                                                                                                                                                                                                                                                                                               |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `eligible`    | `matchesHead: true`, `itemCount > 0`, every Copilot-authored thread resolved or validly dispositioned, AND no outstanding regular-comment disposition evidence (`dispositionEvidence.missingRegularCommentCount === 0`) -- the static count is the ONLY thing keeping `converged` false, with no other triage work still outstanding. |
-| `count`       | Trusted `advisory-reroll:` marker count matching the current HEAD (resets on a new push, since a new HEAD's markers start over).                                                                                                                                                                                                      |
-| `cap`         | Configured bounded budget, `advisoryWait.sameHeadRerollCap` (default 2, deliberately conservative but > 1: same-SHA re-review is not a guaranteed one-shot off-ramp).                                                                                                                                                                 |
-| `exhausted`   | `count >= cap`: stop rerolling, fall through to the existing deadline-plus-maintainer-waiver backstop (#1512) or hold.                                                                                                                                                                                                                |
-| `latestAt`    | GitHub `created_at` of the latest trusted same-HEAD reroll marker, or `''` -- **never** the marker's embedded, agent-supplied timestamp (same anchor rule AW2 already states for `advisory-wait:`).                                                                                                                                   |
-| `inFlight`    | `true` while a reroll marker exists, no primary-bot review has been submitted after it yet, **and** the configured `advisoryWait.pendingWindow` has not yet elapsed since it was posted. Recomputed fresh from GitHub state on every call (never in-session memory), so a crash mid-poll can never cause a duplicate reroll request.  |
-| `requestable` | `eligible && !exhausted && !inFlight` -- the exact instant it is safe to request a fresh same-HEAD reroll.                                                                                                                                                                                                                            |
+| Field               | Meaning                                                                                                                                                                                                                                                                                                                               |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `eligible`          | `matchesHead: true`, `itemCount > 0`, every Copilot-authored thread resolved or validly dispositioned, AND no outstanding regular-comment disposition evidence (`dispositionEvidence.missingRegularCommentCount === 0`) -- the static count is the ONLY thing keeping `converged` false, with no other triage work still outstanding. |
+| `ineligibleReasons` | `#1719`: one stable, machine-readable token per failing term of the `eligible` conjunction above (empty exactly when `eligible` is `true`), so a caller can self-diagnose a stuck reroll without re-deriving the rule by hand. See below for the token list and the report-mode example.                                              |
+| `count`             | Trusted `advisory-reroll:` marker count matching the current HEAD (resets on a new push, since a new HEAD's markers start over).                                                                                                                                                                                                      |
+| `cap`               | Configured bounded budget, `advisoryWait.sameHeadRerollCap` (default 2, deliberately conservative but > 1: same-SHA re-review is not a guaranteed one-shot off-ramp).                                                                                                                                                                 |
+| `exhausted`         | `count >= cap`: stop rerolling, fall through to the existing deadline-plus-maintainer-waiver backstop (#1512) or hold.                                                                                                                                                                                                                |
+| `latestAt`          | GitHub `created_at` of the latest trusted same-HEAD reroll marker, or `''` -- **never** the marker's embedded, agent-supplied timestamp (same anchor rule AW2 already states for `advisory-wait:`).                                                                                                                                   |
+| `inFlight`          | `true` while a reroll marker exists, no primary-bot review has been submitted after it yet, **and** the configured `advisoryWait.pendingWindow` has not yet elapsed since it was posted. Recomputed fresh from GitHub state on every call (never in-session memory), so a crash mid-poll can never cause a duplicate reroll request.  |
+| `requestable`       | `eligible && !exhausted && !inFlight` -- the exact instant it is safe to request a fresh same-HEAD reroll.                                                                                                                                                                                                                            |
+
+**`ineligibleReasons` tokens (`#1719`)**: one entry per failing term, in
+the same order the `eligible` conjunction is written in
+`advisory-convergence.mts`. Computed from the exact same six terms
+`eligible` itself reduces from -- the array and the boolean are
+structurally unable to disagree.
+
+<!-- dprint-ignore-start -->
+| Token                                    | Fires when...                                                                                                                                          |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `scope-not-applicable`                    | `applicability.status` is `not_applicable` (`advisoryWait.convergenceScope: "idd-claimed"` and this PR has no matching verified linked claim/branch).   |
+| `review-pending`                          | The primary bot has not yet reviewed current HEAD (`pending: true`). Always co-occurs with `review-item-count-unknown` below, since an off-HEAD review reports no usable item count. |
+| `unresolved-copilot-threads`              | `threads.satisfied` is `false` -- at least one Copilot-authored thread is neither resolved nor validly dispositioned.                                   |
+| `missing-regular-comment-disposition`     | `dispositionEvidence.missingRegularCommentCount` is non-zero -- an outstanding regular (non-thread) PR comment still lacks a fresh disposition marker.  |
+| `review-item-count-unknown`               | The latest review is on current HEAD but its comment count is unavailable (a GraphQL nullable-field edge case).                                         |
+| `review-item-count-not-positive`          | The latest review's `itemCount` is a known, non-positive value (i.e. exactly `0` -- already fully converged, nothing to reroll).                        |
+<!-- dprint-ignore-end -->
+
+When `review-item-count-not-positive` is absent but `converged` is still
+`false` with `threads.satisfied: true` (every visible Copilot-authored
+thread already resolved) and `review.itemCount > 0`, the top-level
+`reasons` array's item-count entry is itself extended with a pointer to
+check the review body directly -- the shape of the reported adopter
+incident: a "Comments suppressed due to low confidence" item embedded in
+the review's own body text counts toward `itemCount` but never surfaces
+as a review thread, so no thread query can ever explain it.
 
 **AW6 procedure** (`idd-advisory-wait.instructions.md`), invoked only
 from F2 on a non-zero `--assert` exit:
 
 1. If `sameHeadReroll.eligible` is `false`, the carve-out does not
-   apply; fall through to F2's normal route-to-E1/E4.
+   apply; fall through to F2's normal route-to-E1/E4. `ineligibleReasons`
+   names the failing term(s) directly, without re-deriving the rule by
+   hand.
 2. If `requestable` is `true`: **post the marker before requesting the
    review**, as plain text (no HTML comment, matching `advisory-wait:`'s
    shape):

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1578,7 +1578,7 @@ structurally unable to disagree.
 | `review-pending`                          | The primary bot has not yet reviewed current HEAD (`pending: true`). Always co-occurs with `review-item-count-unknown` below, since an off-HEAD review reports no usable item count. |
 | `unresolved-copilot-threads`              | `threads.satisfied` is `false` -- at least one Copilot-authored thread is neither resolved nor validly dispositioned.                                   |
 | `missing-regular-comment-disposition`     | `dispositionEvidence.missingRegularCommentCount` is non-zero -- an outstanding regular (non-thread) PR comment still lacks a fresh disposition marker.  |
-| `review-item-count-unknown`               | The latest review is on current HEAD but its comment count is unavailable (a GraphQL nullable-field edge case).                                         |
+| `review-item-count-unknown`               | The latest review's comment count is unavailable -- either the review is off-HEAD (co-firing with `review-pending` above, since `resolveLatestCopilotReviewClause` reports `itemCount: null` for any non-matching-HEAD review), or it is on current HEAD but the count itself is unavailable (a GraphQL nullable-field edge case). |
 | `review-item-count-not-positive`          | The latest review's `itemCount` is a known, non-positive value (i.e. exactly `0` -- already fully converged, nothing to reroll).                        |
 <!-- dprint-ignore-end -->
 

--- a/fixtures/schemas/advisory-convergence.valid.json
+++ b/fixtures/schemas/advisory-convergence.valid.json
@@ -37,8 +37,13 @@
     "activeClaimId": "",
     "validCount": 0
   },
+  "dispositionEvidence": {
+    "missingRegularCommentCount": 0,
+    "missingThreadCount": 0
+  },
   "sameHeadReroll": {
     "eligible": false,
+    "ineligibleReasons": ["review-item-count-not-positive"],
     "count": 0,
     "cap": 2,
     "exhausted": false,

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1484,6 +1484,18 @@ to post it is the consuming track's job.
   state alone never sets `ready: true`. Observed incident:
   kurone-kito/idd-skill#1562. See `idd-advisory-wait.instructions.md`'s
   Terminal routing section for the full hold/rerun sequence.
+- **Eligibility-relevant disposition-evidence counters (`#1719`)**: the
+  verdict also reports a `dispositionEvidence` field —
+  `{ missingRegularCommentCount, missingThreadCount }` — a narrow,
+  counters-only projection of the same evidence
+  `summarizeDispositionEvidenceForGate` already computes for this gate. It
+  exposes the numeric input behind `sameHeadReroll.eligible`'s
+  `missing-regular-comment-disposition` term (see below) directly on the
+  report, instead of only its pass/fail verdict. Not the same shape as
+  `pre-merge-readiness.mjs`'s own `dispositionEvidence` field (which
+  additionally carries `route` / `blockingCount` / full missing-item lists
+  for the F2 merge gate) — this gate's `dispositionEvidence` never gates
+  anything by itself.
 - Reuses the existing evidence modules — `isCopilotReviewerLogin` /
   `readAdvisoryPrimaryBotLogin`, `resolveAdvisoryBotLogins`,
   `resolveTrustedMarkerActors`, `summarizeDispositionEvidenceForGate`,
@@ -1542,21 +1554,50 @@ evidence, purely additively: `converged` / `waived` / `ready` are
 computed with **no reference to it at all**, so it can never let the
 gate pass on anything but the primary bot's own real signal.
 
-| Field         | Meaning                                                                                                                                                                                                                                                                                                                               |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `eligible`    | `matchesHead: true`, `itemCount > 0`, every Copilot-authored thread resolved or validly dispositioned, AND no outstanding regular-comment disposition evidence (`dispositionEvidence.missingRegularCommentCount === 0`) -- the static count is the ONLY thing keeping `converged` false, with no other triage work still outstanding. |
-| `count`       | Trusted `advisory-reroll:` marker count matching the current HEAD (resets on a new push, since a new HEAD's markers start over).                                                                                                                                                                                                      |
-| `cap`         | Configured bounded budget, `advisoryWait.sameHeadRerollCap` (default 2, deliberately conservative but > 1: same-SHA re-review is not a guaranteed one-shot off-ramp).                                                                                                                                                                 |
-| `exhausted`   | `count >= cap`: stop rerolling, fall through to the existing deadline-plus-maintainer-waiver backstop (#1512) or hold.                                                                                                                                                                                                                |
-| `latestAt`    | GitHub `created_at` of the latest trusted same-HEAD reroll marker, or `''` -- **never** the marker's embedded, agent-supplied timestamp (same anchor rule AW2 already states for `advisory-wait:`).                                                                                                                                   |
-| `inFlight`    | `true` while a reroll marker exists, no primary-bot review has been submitted after it yet, **and** the configured `advisoryWait.pendingWindow` has not yet elapsed since it was posted. Recomputed fresh from GitHub state on every call (never in-session memory), so a crash mid-poll can never cause a duplicate reroll request.  |
-| `requestable` | `eligible && !exhausted && !inFlight` -- the exact instant it is safe to request a fresh same-HEAD reroll.                                                                                                                                                                                                                            |
+| Field               | Meaning                                                                                                                                                                                                                                                                                                                               |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `eligible`          | `matchesHead: true`, `itemCount > 0`, every Copilot-authored thread resolved or validly dispositioned, AND no outstanding regular-comment disposition evidence (`dispositionEvidence.missingRegularCommentCount === 0`) -- the static count is the ONLY thing keeping `converged` false, with no other triage work still outstanding. |
+| `ineligibleReasons` | `#1719`: one stable, machine-readable token per failing term of the `eligible` conjunction above (empty exactly when `eligible` is `true`), so a caller can self-diagnose a stuck reroll without re-deriving the rule by hand. See below for the token list and the report-mode example.                                              |
+| `count`             | Trusted `advisory-reroll:` marker count matching the current HEAD (resets on a new push, since a new HEAD's markers start over).                                                                                                                                                                                                      |
+| `cap`               | Configured bounded budget, `advisoryWait.sameHeadRerollCap` (default 2, deliberately conservative but > 1: same-SHA re-review is not a guaranteed one-shot off-ramp).                                                                                                                                                                 |
+| `exhausted`         | `count >= cap`: stop rerolling, fall through to the existing deadline-plus-maintainer-waiver backstop (#1512) or hold.                                                                                                                                                                                                                |
+| `latestAt`          | GitHub `created_at` of the latest trusted same-HEAD reroll marker, or `''` -- **never** the marker's embedded, agent-supplied timestamp (same anchor rule AW2 already states for `advisory-wait:`).                                                                                                                                   |
+| `inFlight`          | `true` while a reroll marker exists, no primary-bot review has been submitted after it yet, **and** the configured `advisoryWait.pendingWindow` has not yet elapsed since it was posted. Recomputed fresh from GitHub state on every call (never in-session memory), so a crash mid-poll can never cause a duplicate reroll request.  |
+| `requestable`       | `eligible && !exhausted && !inFlight` -- the exact instant it is safe to request a fresh same-HEAD reroll.                                                                                                                                                                                                                            |
+
+**`ineligibleReasons` tokens (`#1719`)**: one entry per failing term, in
+the same order the `eligible` conjunction is written in
+`advisory-convergence.mts`. Computed from the exact same six terms
+`eligible` itself reduces from -- the array and the boolean are
+structurally unable to disagree.
+
+<!-- dprint-ignore-start -->
+| Token                                    | Fires when...                                                                                                                                          |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `scope-not-applicable`                    | `applicability.status` is `not_applicable` (`advisoryWait.convergenceScope: "idd-claimed"` and this PR has no matching verified linked claim/branch).   |
+| `review-pending`                          | The primary bot has not yet reviewed current HEAD (`pending: true`). Always co-occurs with `review-item-count-unknown` below, since an off-HEAD review reports no usable item count. |
+| `unresolved-copilot-threads`              | `threads.satisfied` is `false` -- at least one Copilot-authored thread is neither resolved nor validly dispositioned.                                   |
+| `missing-regular-comment-disposition`     | `dispositionEvidence.missingRegularCommentCount` is non-zero -- an outstanding regular (non-thread) PR comment still lacks a fresh disposition marker.  |
+| `review-item-count-unknown`               | The latest review is on current HEAD but its comment count is unavailable (a GraphQL nullable-field edge case).                                         |
+| `review-item-count-not-positive`          | The latest review's `itemCount` is a known, non-positive value (i.e. exactly `0` -- already fully converged, nothing to reroll).                        |
+<!-- dprint-ignore-end -->
+
+When `review-item-count-not-positive` is absent but `converged` is still
+`false` with `threads.satisfied: true` (every visible Copilot-authored
+thread already resolved) and `review.itemCount > 0`, the top-level
+`reasons` array's item-count entry is itself extended with a pointer to
+check the review body directly -- the shape of the reported adopter
+incident: a "Comments suppressed due to low confidence" item embedded in
+the review's own body text counts toward `itemCount` but never surfaces
+as a review thread, so no thread query can ever explain it.
 
 **AW6 procedure** (`idd-advisory-wait.instructions.md`), invoked only
 from F2 on a non-zero `--assert` exit:
 
 1. If `sameHeadReroll.eligible` is `false`, the carve-out does not
-   apply; fall through to F2's normal route-to-E1/E4.
+   apply; fall through to F2's normal route-to-E1/E4. `ineligibleReasons`
+   names the failing term(s) directly, without re-deriving the rule by
+   hand.
 2. If `requestable` is `true`: **post the marker before requesting the
    review**, as plain text (no HTML comment, matching `advisory-wait:`'s
    shape):

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1578,7 +1578,7 @@ structurally unable to disagree.
 | `review-pending`                          | The primary bot has not yet reviewed current HEAD (`pending: true`). Always co-occurs with `review-item-count-unknown` below, since an off-HEAD review reports no usable item count. |
 | `unresolved-copilot-threads`              | `threads.satisfied` is `false` -- at least one Copilot-authored thread is neither resolved nor validly dispositioned.                                   |
 | `missing-regular-comment-disposition`     | `dispositionEvidence.missingRegularCommentCount` is non-zero -- an outstanding regular (non-thread) PR comment still lacks a fresh disposition marker.  |
-| `review-item-count-unknown`               | The latest review is on current HEAD but its comment count is unavailable (a GraphQL nullable-field edge case).                                         |
+| `review-item-count-unknown`               | The latest review's comment count is unavailable -- either the review is off-HEAD (co-firing with `review-pending` above, since `resolveLatestCopilotReviewClause` reports `itemCount: null` for any non-matching-HEAD review), or it is on current HEAD but the count itself is unavailable (a GraphQL nullable-field edge case). |
 | `review-item-count-not-positive`          | The latest review's `itemCount` is a known, non-positive value (i.e. exactly `0` -- already fully converged, nothing to reroll).                        |
 <!-- dprint-ignore-end -->
 

--- a/schemas/advisory-convergence.schema.json
+++ b/schemas/advisory-convergence.schema.json
@@ -156,7 +156,17 @@
         "ineligibleReasons": {
           "type": "array",
           "description": "#1719: one stable, machine-readable token per failing term of the eligible conjunction (in conjunction order); empty exactly when eligible is true.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string",
+            "enum": [
+              "scope-not-applicable",
+              "review-pending",
+              "unresolved-copilot-threads",
+              "missing-regular-comment-disposition",
+              "review-item-count-unknown",
+              "review-item-count-not-positive"
+            ]
+          }
         },
         "count": { "type": "integer", "minimum": 0 },
         "cap": { "type": "integer", "minimum": 1 },

--- a/schemas/advisory-convergence.schema.json
+++ b/schemas/advisory-convergence.schema.json
@@ -17,6 +17,7 @@
     "pending",
     "deadline",
     "waiver",
+    "dispositionEvidence",
     "sameHeadReroll",
     "terminal",
     "converged",
@@ -127,10 +128,21 @@
         "validCount": { "type": "integer", "minimum": 0 }
       }
     },
+    "dispositionEvidence": {
+      "type": "object",
+      "description": "#1719: eligibility-relevant disposition-evidence counters feeding sameHeadReroll.eligible's missing-regular-comment-disposition term, exposed so the numeric input is visible and not only its pass/fail verdict. A narrow, counters-only view for THIS gate -- not the same shape as pre-merge-readiness's own dispositionEvidence object (which additionally carries route/blockingCount/full missing-item lists for the F2 merge gate).",
+      "required": ["missingRegularCommentCount", "missingThreadCount"],
+      "additionalProperties": false,
+      "properties": {
+        "missingRegularCommentCount": { "type": "integer", "minimum": 0 },
+        "missingThreadCount": { "type": "integer", "minimum": 0 }
+      }
+    },
     "sameHeadReroll": {
       "type": "object",
       "required": [
         "eligible",
+        "ineligibleReasons",
         "count",
         "cap",
         "exhausted",
@@ -141,6 +153,11 @@
       "additionalProperties": false,
       "properties": {
         "eligible": { "type": "boolean" },
+        "ineligibleReasons": {
+          "type": "array",
+          "description": "#1719: one stable, machine-readable token per failing term of the eligible conjunction (in conjunction order); empty exactly when eligible is true.",
+          "items": { "type": "string" }
+        },
         "count": { "type": "integer", "minimum": 0 },
         "cap": { "type": "integer", "minimum": 1 },
         "exhausted": { "type": "boolean" },

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -108,6 +108,22 @@ import {
  * and value are unchanged for existing consumers. */
 export const ADVISORY_CONVERGENCE_CHECK_SELECTOR =
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR;
+/** #1719: stable, machine-readable tokens for `sameHeadReroll.-
+ * ineligibleReasons` -- one per boolean term of the `eligible` conjunction,
+ * in the same order the conjunction is written in
+ * `computeAdvisoryConvergenceVerdict` below, so a report-mode caller can
+ * self-diagnose a stuck AW6 reroll without re-deriving the eligibility rule
+ * from `idd-advisory-wait.instructions.md` by hand. Exported (rather than
+ * inlined as string literals at each call site) so tests reference the same
+ * single source of truth the implementation does. */
+export const SAME_HEAD_REROLL_INELIGIBLE_REASON = {
+  SCOPE_NOT_APPLICABLE: 'scope-not-applicable',
+  REVIEW_PENDING: 'review-pending',
+  UNRESOLVED_COPILOT_THREADS: 'unresolved-copilot-threads',
+  MISSING_REGULAR_COMMENT_DISPOSITION: 'missing-regular-comment-disposition',
+  REVIEW_ITEM_COUNT_UNKNOWN: 'review-item-count-unknown',
+  REVIEW_ITEM_COUNT_NOT_POSITIVE: 'review-item-count-not-positive',
+};
 /**
  * Compute the deterministic advisory-convergence verdict from already-
  * fetched PR evidence. Pure (no I/O), so it is directly unit-testable with
@@ -207,12 +223,6 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
         ? `latest ${primaryBotLogin} review (commit ${review.commitId || '<unknown>'}) does not cover current HEAD ${prHeadSha}`
         : `${primaryBotLogin} has not reviewed this pull request yet`,
     );
-  } else if (!scopeNotApplicable && !review.satisfied) {
-    reasons.push(
-      review.itemCount === null
-        ? `latest ${primaryBotLogin} review on current HEAD carries an unknown number of actionable items (comment count unavailable)`
-        : `latest ${primaryBotLogin} review on current HEAD carries ${review.itemCount} actionable item(s)`,
-    );
   }
   // --- Clause 2: every current Copilot-authored thread is resolved or ---
   // --- validly dispositioned (reusing summarizeDispositionEvidenceForGate)
@@ -266,11 +276,49 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     blockingCount: copilotBlocking.length,
     satisfied: copilotBlocking.length === 0,
   };
+  // Clause 1's "review is not clean" reason is pushed here, after Clause 2's
+  // `threadClause` is available -- deliberately deferred from the `pending`
+  // check above (which already returned via that `if`, so `reasons` order is
+  // unaffected: pending and not-satisfied are mutually exclusive, and this
+  // still precedes Clause 2's own thread-blocking reason below).
+  //
+  // #1719: reported adopter incident -- the primary bot's review on current
+  // HEAD carried `itemCount: 1` while every visible GraphQL review thread
+  // was already `isResolved: true`; the actual cause was a "Comments
+  // suppressed due to low confidence" item embedded in the review's
+  // top-level BODY TEXT rather than posted as a review thread -- it
+  // contributes to `itemCount` but is invisible to any `reviewThreads`
+  // query, so it can never be resolved the normal way, and nothing in this
+  // gate's output pointed there. When every visible Copilot-authored thread
+  // is already resolved and `itemCount` is still positive, no thread query
+  // can explain it -- point directly at the review body instead of leaving
+  // an agent to re-derive this by hand a second time.
+  if (!scopeNotApplicable && !pending && !review.satisfied) {
+    const itemCountReason =
+      review.itemCount === null
+        ? `latest ${primaryBotLogin} review on current HEAD carries an unknown number of actionable items (comment count unavailable)`
+        : `latest ${primaryBotLogin} review on current HEAD carries ${review.itemCount} actionable item(s)`;
+    reasons.push(
+      threadClause.satisfied &&
+        review.itemCount !== null &&
+        review.itemCount > 0
+        ? `${itemCountReason} -- no unresolved ${primaryBotLogin}-authored thread accounts for them; check the review body directly for an item suppressed due to low confidence, which counts toward itemCount but never appears in reviewThreads`
+        : itemCountReason,
+    );
+  }
   if (!scopeNotApplicable && !threadClause.satisfied) {
     reasons.push(
       `${threadClause.blockingCount} ${primaryBotLogin}-authored review thread(s) are neither resolved nor validly dispositioned: ${threadClause.blockingIds.join(', ')}`,
     );
   }
+  // #1719: eligibility-relevant `dispositionEvidence` counters, exposed on
+  // the report object -- see `AdvisoryConvergenceDispositionEvidence`'s doc
+  // comment for why this is a narrow counters-only projection, not the same
+  // shape as `pre-merge-readiness.mjs`'s own `dispositionEvidence` field.
+  const dispositionEvidenceReport = {
+    missingRegularCommentCount: dispositionEvidence.missingRegularCommentCount,
+    missingThreadCount: dispositionEvidence.missingThreadCount,
+  };
   const converged =
     !scopeNotApplicable &&
     !pending &&
@@ -290,21 +338,63 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   // was not actually done yet -- and if the bot does not answer quickly,
   // that attempt is permanently consumed before the real blocker is even
   // cleared (PR #1517 review).
-  const sameHeadRerollEligible =
-    !scopeNotApplicable &&
-    !pending &&
-    threadClause.satisfied &&
-    dispositionEvidence.missingRegularCommentCount === 0 &&
-    review.itemCount !== null &&
-    review.itemCount > 0;
-  // Both guards require `> 0` (not merely `Number.isFinite`/`Number.is-
-  // Integer`), matching `normalizePositiveInteger` / `normalizePositiveNumber`
-  // (advisory-wait-policy.mts) exactly: this function is exported and pure,
-  // so a direct caller (a test, or future code bypassing the CLI's own
-  // schema-validated config read) could otherwise pass `0` or a negative
-  // value and silently corrupt behavior -- `cap: 0` makes `exhausted`
-  // trivially true (`count >= 0`), and `pendingWindowMinutes <= 0` breaks
-  // the `inFlight` elapsed-time comparison (PR #1517 review).
+  //
+  // #1719: each of the six conjuncts above is ALSO computed as its own named
+  // boolean, paired with a stable token in `sameHeadRerollTerms` --
+  // `sameHeadRerollEligible` (`.every()`) and `sameHeadRerollIneligible-
+  // Reasons` (`.filter().map()`) are BOTH derived from that one array, so
+  // they cannot disagree; a term added to the conjunction without a paired
+  // token here would be a compile-time array-literal edit, not a
+  // hand-maintained parallel expression. `reviewItemCountPositiveTerm` is
+  // deliberately written as "unknown counts as satisfied"
+  // (`itemCount === null || itemCount > 0`), not the bare `itemCount > 0`
+  // the original two-line conjunct implied standalone: this keeps the two
+  // item-count terms mutually exclusive in `ineligibleReasons` (an unknown
+  // count reports ONLY `review-item-count-unknown`, never also
+  // `review-item-count-not-positive`), while `reviewItemCountKnownTerm &&
+  // reviewItemCountPositiveTerm` together still reduce to exactly the
+  // original `itemCount !== null && itemCount > 0` conjunct.
+  const scopeApplicableTerm = !scopeNotApplicable;
+  const reviewNotPendingTerm = !pending;
+  const threadsSatisfiedTerm = threadClause.satisfied;
+  const noMissingRegularCommentsTerm =
+    dispositionEvidence.missingRegularCommentCount === 0;
+  const reviewItemCountKnownTerm = review.itemCount !== null;
+  const reviewItemCountPositiveTerm =
+    review.itemCount === null || review.itemCount > 0;
+  const sameHeadRerollTerms = [
+    {
+      token: SAME_HEAD_REROLL_INELIGIBLE_REASON.SCOPE_NOT_APPLICABLE,
+      satisfied: scopeApplicableTerm,
+    },
+    {
+      token: SAME_HEAD_REROLL_INELIGIBLE_REASON.REVIEW_PENDING,
+      satisfied: reviewNotPendingTerm,
+    },
+    {
+      token: SAME_HEAD_REROLL_INELIGIBLE_REASON.UNRESOLVED_COPILOT_THREADS,
+      satisfied: threadsSatisfiedTerm,
+    },
+    {
+      token:
+        SAME_HEAD_REROLL_INELIGIBLE_REASON.MISSING_REGULAR_COMMENT_DISPOSITION,
+      satisfied: noMissingRegularCommentsTerm,
+    },
+    {
+      token: SAME_HEAD_REROLL_INELIGIBLE_REASON.REVIEW_ITEM_COUNT_UNKNOWN,
+      satisfied: reviewItemCountKnownTerm,
+    },
+    {
+      token: SAME_HEAD_REROLL_INELIGIBLE_REASON.REVIEW_ITEM_COUNT_NOT_POSITIVE,
+      satisfied: reviewItemCountPositiveTerm,
+    },
+  ];
+  const sameHeadRerollEligible = sameHeadRerollTerms.every(
+    (term) => term.satisfied,
+  );
+  const sameHeadRerollIneligibleReasons = sameHeadRerollTerms
+    .filter((term) => !term.satisfied)
+    .map((term) => term.token);
   const sameHeadRerollCap =
     Number.isInteger(options.sameHeadRerollCap) &&
     Number(options.sameHeadRerollCap) > 0
@@ -355,6 +445,7 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   const sameHeadRerollExhausted = rerollMarkers.count >= sameHeadRerollCap;
   const sameHeadReroll = {
     eligible: sameHeadRerollEligible,
+    ineligibleReasons: sameHeadRerollIneligibleReasons,
     count: rerollMarkers.count,
     cap: sameHeadRerollCap,
     exhausted: sameHeadRerollExhausted,
@@ -499,6 +590,7 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     pending,
     deadline,
     waiver,
+    dispositionEvidence: dispositionEvidenceReport,
     sameHeadReroll,
     terminal,
     converged,

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -278,9 +278,10 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   };
   // Clause 1's "review is not clean" reason is pushed here, after Clause 2's
   // `threadClause` is available -- deliberately deferred from the `pending`
-  // check above (which already returned via that `if`, so `reasons` order is
-  // unaffected: pending and not-satisfied are mutually exclusive, and this
-  // still precedes Clause 2's own thread-blocking reason below).
+  // check above (whose own `if` already exhausts the pending case, so
+  // `reasons` order is unaffected: pending and not-satisfied are mutually
+  // exclusive, and this still precedes Clause 2's own thread-blocking
+  // reason below).
   //
   // #1719: reported adopter incident -- the primary bot's review on current
   // HEAD carried `itemCount: 1` while every visible GraphQL review thread
@@ -339,8 +340,8 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   // that attempt is permanently consumed before the real blocker is even
   // cleared (PR #1517 review).
   //
-  // #1719: each of the six conjuncts above is ALSO computed as its own named
-  // boolean, paired with a stable token in `sameHeadRerollTerms` --
+  // #1719: each of the six eligibility terms above is ALSO computed as its
+  // own named boolean, paired with a stable token in `sameHeadRerollTerms` --
   // `sameHeadRerollEligible` (`.every()`) and
   // `sameHeadRerollIneligibleReasons` (`.filter().map()`) are BOTH derived
   // from that one array, so they cannot disagree; a term added to the

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -108,9 +108,9 @@ import {
  * and value are unchanged for existing consumers. */
 export const ADVISORY_CONVERGENCE_CHECK_SELECTOR =
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR;
-/** #1719: stable, machine-readable tokens for `sameHeadReroll.-
- * ineligibleReasons` -- one per boolean term of the `eligible` conjunction,
- * in the same order the conjunction is written in
+/** #1719: stable, machine-readable tokens for
+ * `sameHeadReroll.ineligibleReasons` -- one per boolean term of the
+ * `eligible` conjunction, in the same order the conjunction is written in
  * `computeAdvisoryConvergenceVerdict` below, so a report-mode caller can
  * self-diagnose a stuck AW6 reroll without re-deriving the eligibility rule
  * from `idd-advisory-wait.instructions.md` by hand. Exported (rather than
@@ -341,10 +341,11 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   //
   // #1719: each of the six conjuncts above is ALSO computed as its own named
   // boolean, paired with a stable token in `sameHeadRerollTerms` --
-  // `sameHeadRerollEligible` (`.every()`) and `sameHeadRerollIneligible-
-  // Reasons` (`.filter().map()`) are BOTH derived from that one array, so
-  // they cannot disagree; a term added to the conjunction without a paired
-  // token here would be a compile-time array-literal edit, not a
+  // `sameHeadRerollEligible` (`.every()`) and
+  // `sameHeadRerollIneligibleReasons` (`.filter().map()`) are BOTH derived
+  // from that one array, so they cannot disagree; a term added to the
+  // conjunction without a paired token here would be a compile-time
+  // array-literal edit, not a
   // hand-maintained parallel expression. `reviewItemCountPositiveTerm` is
   // deliberately written as "unknown counts as satisfied"
   // (`itemCount === null || itemCount > 0`), not the bare `itemCount > 0`

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -115,6 +115,23 @@ import {
 export const ADVISORY_CONVERGENCE_CHECK_SELECTOR =
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR;
 
+/** #1719: stable, machine-readable tokens for `sameHeadReroll.-
+ * ineligibleReasons` -- one per boolean term of the `eligible` conjunction,
+ * in the same order the conjunction is written in
+ * `computeAdvisoryConvergenceVerdict` below, so a report-mode caller can
+ * self-diagnose a stuck AW6 reroll without re-deriving the eligibility rule
+ * from `idd-advisory-wait.instructions.md` by hand. Exported (rather than
+ * inlined as string literals at each call site) so tests reference the same
+ * single source of truth the implementation does. */
+export const SAME_HEAD_REROLL_INELIGIBLE_REASON = {
+  SCOPE_NOT_APPLICABLE: 'scope-not-applicable',
+  REVIEW_PENDING: 'review-pending',
+  UNRESOLVED_COPILOT_THREADS: 'unresolved-copilot-threads',
+  MISSING_REGULAR_COMMENT_DISPOSITION: 'missing-regular-comment-disposition',
+  REVIEW_ITEM_COUNT_UNKNOWN: 'review-item-count-unknown',
+  REVIEW_ITEM_COUNT_NOT_POSITIVE: 'review-item-count-not-positive',
+} as const;
+
 /** Author reference embedded in GitHub REST/GraphQL payloads. */
 interface GhAuthorPayload {
   login?: string | null;
@@ -223,6 +240,30 @@ export interface AdvisoryConvergenceApplicability {
   reason: string;
 }
 
+/** #1719: eligibility-relevant `dispositionEvidence` counters, exposed so
+ * the numeric input behind `sameHeadReroll`'s
+ * `missing-regular-comment-disposition` term is visible on the report
+ * object and not only its pass/fail verdict. A narrow, counters-only
+ * projection of `DispositionEvidenceSummary` (protocol-helpers.mts) --
+ * deliberately NOT the same shape as `pre-merge-readiness.mjs`'s own
+ * `dispositionEvidence` field (which additionally carries `route` /
+ * `blockingCount` / full missing-item lists for the F2 merge gate); this
+ * gate's `dispositionEvidence` never gates anything by itself and has no
+ * `route` field. */
+export interface AdvisoryConvergenceDispositionEvidence {
+  /** Outstanding non-thread regular PR comments (from a non-agent author)
+   * lacking a fresh disposition marker. The exact counter `sameHeadReroll.
+   * eligible`'s `missing-regular-comment-disposition` term reads. */
+  missingRegularCommentCount: number;
+  /** Review threads (resolved or unresolved, any authorship) still lacking
+   * a fresh disposition marker. Adjacent evidence -- not itself one of the
+   * six `sameHeadReroll.eligible` terms (Clause 2's Copilot-scoped subset
+   * is `threads.blockingCount` above), but cheap to expose alongside its
+   * sibling counter since both come from the same already-computed
+   * `dispositionEvidence` summary. */
+  missingThreadCount: number;
+}
+
 /** Bounded same-HEAD advisory reroll evidence (#1511) -- see the module
  * header for the full rationale. Purely additive: never referenced by the
  * `converged` / `waived` / `ready` computation. */
@@ -233,6 +274,14 @@ export interface AdvisoryConvergenceSameHeadReroll {
    * === 0`) -- the static item count is the ONLY thing keeping `converged`
    * false for this HEAD, with no other triage work still outstanding. */
   eligible: boolean;
+  /** #1719: one stable, machine-readable token per failing term of the
+   * six-term `eligible` conjunction above (`SAME_HEAD_REROLL_INELIGIBLE_-
+   * REASON`), in conjunction order; empty exactly when `eligible` is
+   * `true`. Computed from the SAME six terms `eligible` itself reduces
+   * from (see the computation below), so the two can never disagree --
+   * a report-mode caller no longer has to re-derive the eligibility rule
+   * by hand to self-diagnose a stuck AW6 reroll. */
+  ineligibleReasons: string[];
   /** Trusted `advisory-reroll:` marker count whose embedded HEAD SHA
    * matches the current HEAD (resets naturally on a new push, since a new
    * HEAD's markers start over). */
@@ -276,6 +325,8 @@ export interface AdvisoryConvergenceVerdict {
   pending: boolean;
   deadline: AdvisoryConvergenceDeadline;
   waiver: AdvisoryConvergenceWaiver;
+  /** #1719: see {@link AdvisoryConvergenceDispositionEvidence}. */
+  dispositionEvidence: AdvisoryConvergenceDispositionEvidence;
   sameHeadReroll: AdvisoryConvergenceSameHeadReroll;
   /** #1570: `#1572`'s terminal Copilot stall-recovery state
    * (`buildCopilotRecoverySummary`, advisory-wait-state.mts), reported here
@@ -493,12 +544,6 @@ export function computeAdvisoryConvergenceVerdict(
         ? `latest ${primaryBotLogin} review (commit ${review.commitId || '<unknown>'}) does not cover current HEAD ${prHeadSha}`
         : `${primaryBotLogin} has not reviewed this pull request yet`,
     );
-  } else if (!scopeNotApplicable && !review.satisfied) {
-    reasons.push(
-      review.itemCount === null
-        ? `latest ${primaryBotLogin} review on current HEAD carries an unknown number of actionable items (comment count unavailable)`
-        : `latest ${primaryBotLogin} review on current HEAD carries ${review.itemCount} actionable item(s)`,
-    );
   }
 
   // --- Clause 2: every current Copilot-authored thread is resolved or ---
@@ -553,11 +598,51 @@ export function computeAdvisoryConvergenceVerdict(
     blockingCount: copilotBlocking.length,
     satisfied: copilotBlocking.length === 0,
   };
+
+  // Clause 1's "review is not clean" reason is pushed here, after Clause 2's
+  // `threadClause` is available -- deliberately deferred from the `pending`
+  // check above (which already returned via that `if`, so `reasons` order is
+  // unaffected: pending and not-satisfied are mutually exclusive, and this
+  // still precedes Clause 2's own thread-blocking reason below).
+  //
+  // #1719: reported adopter incident -- the primary bot's review on current
+  // HEAD carried `itemCount: 1` while every visible GraphQL review thread
+  // was already `isResolved: true`; the actual cause was a "Comments
+  // suppressed due to low confidence" item embedded in the review's
+  // top-level BODY TEXT rather than posted as a review thread -- it
+  // contributes to `itemCount` but is invisible to any `reviewThreads`
+  // query, so it can never be resolved the normal way, and nothing in this
+  // gate's output pointed there. When every visible Copilot-authored thread
+  // is already resolved and `itemCount` is still positive, no thread query
+  // can explain it -- point directly at the review body instead of leaving
+  // an agent to re-derive this by hand a second time.
+  if (!scopeNotApplicable && !pending && !review.satisfied) {
+    const itemCountReason =
+      review.itemCount === null
+        ? `latest ${primaryBotLogin} review on current HEAD carries an unknown number of actionable items (comment count unavailable)`
+        : `latest ${primaryBotLogin} review on current HEAD carries ${review.itemCount} actionable item(s)`;
+    reasons.push(
+      threadClause.satisfied &&
+        review.itemCount !== null &&
+        review.itemCount > 0
+        ? `${itemCountReason} -- no unresolved ${primaryBotLogin}-authored thread accounts for them; check the review body directly for an item suppressed due to low confidence, which counts toward itemCount but never appears in reviewThreads`
+        : itemCountReason,
+    );
+  }
   if (!scopeNotApplicable && !threadClause.satisfied) {
     reasons.push(
       `${threadClause.blockingCount} ${primaryBotLogin}-authored review thread(s) are neither resolved nor validly dispositioned: ${threadClause.blockingIds.join(', ')}`,
     );
   }
+
+  // #1719: eligibility-relevant `dispositionEvidence` counters, exposed on
+  // the report object -- see `AdvisoryConvergenceDispositionEvidence`'s doc
+  // comment for why this is a narrow counters-only projection, not the same
+  // shape as `pre-merge-readiness.mjs`'s own `dispositionEvidence` field.
+  const dispositionEvidenceReport: AdvisoryConvergenceDispositionEvidence = {
+    missingRegularCommentCount: dispositionEvidence.missingRegularCommentCount,
+    missingThreadCount: dispositionEvidence.missingThreadCount,
+  };
 
   const converged =
     !scopeNotApplicable &&
@@ -579,21 +664,63 @@ export function computeAdvisoryConvergenceVerdict(
   // was not actually done yet -- and if the bot does not answer quickly,
   // that attempt is permanently consumed before the real blocker is even
   // cleared (PR #1517 review).
-  const sameHeadRerollEligible =
-    !scopeNotApplicable &&
-    !pending &&
-    threadClause.satisfied &&
-    dispositionEvidence.missingRegularCommentCount === 0 &&
-    review.itemCount !== null &&
-    review.itemCount > 0;
-  // Both guards require `> 0` (not merely `Number.isFinite`/`Number.is-
-  // Integer`), matching `normalizePositiveInteger` / `normalizePositiveNumber`
-  // (advisory-wait-policy.mts) exactly: this function is exported and pure,
-  // so a direct caller (a test, or future code bypassing the CLI's own
-  // schema-validated config read) could otherwise pass `0` or a negative
-  // value and silently corrupt behavior -- `cap: 0` makes `exhausted`
-  // trivially true (`count >= 0`), and `pendingWindowMinutes <= 0` breaks
-  // the `inFlight` elapsed-time comparison (PR #1517 review).
+  //
+  // #1719: each of the six conjuncts above is ALSO computed as its own named
+  // boolean, paired with a stable token in `sameHeadRerollTerms` --
+  // `sameHeadRerollEligible` (`.every()`) and `sameHeadRerollIneligible-
+  // Reasons` (`.filter().map()`) are BOTH derived from that one array, so
+  // they cannot disagree; a term added to the conjunction without a paired
+  // token here would be a compile-time array-literal edit, not a
+  // hand-maintained parallel expression. `reviewItemCountPositiveTerm` is
+  // deliberately written as "unknown counts as satisfied"
+  // (`itemCount === null || itemCount > 0`), not the bare `itemCount > 0`
+  // the original two-line conjunct implied standalone: this keeps the two
+  // item-count terms mutually exclusive in `ineligibleReasons` (an unknown
+  // count reports ONLY `review-item-count-unknown`, never also
+  // `review-item-count-not-positive`), while `reviewItemCountKnownTerm &&
+  // reviewItemCountPositiveTerm` together still reduce to exactly the
+  // original `itemCount !== null && itemCount > 0` conjunct.
+  const scopeApplicableTerm = !scopeNotApplicable;
+  const reviewNotPendingTerm = !pending;
+  const threadsSatisfiedTerm = threadClause.satisfied;
+  const noMissingRegularCommentsTerm =
+    dispositionEvidence.missingRegularCommentCount === 0;
+  const reviewItemCountKnownTerm = review.itemCount !== null;
+  const reviewItemCountPositiveTerm =
+    review.itemCount === null || review.itemCount > 0;
+  const sameHeadRerollTerms: { token: string; satisfied: boolean }[] = [
+    {
+      token: SAME_HEAD_REROLL_INELIGIBLE_REASON.SCOPE_NOT_APPLICABLE,
+      satisfied: scopeApplicableTerm,
+    },
+    {
+      token: SAME_HEAD_REROLL_INELIGIBLE_REASON.REVIEW_PENDING,
+      satisfied: reviewNotPendingTerm,
+    },
+    {
+      token: SAME_HEAD_REROLL_INELIGIBLE_REASON.UNRESOLVED_COPILOT_THREADS,
+      satisfied: threadsSatisfiedTerm,
+    },
+    {
+      token:
+        SAME_HEAD_REROLL_INELIGIBLE_REASON.MISSING_REGULAR_COMMENT_DISPOSITION,
+      satisfied: noMissingRegularCommentsTerm,
+    },
+    {
+      token: SAME_HEAD_REROLL_INELIGIBLE_REASON.REVIEW_ITEM_COUNT_UNKNOWN,
+      satisfied: reviewItemCountKnownTerm,
+    },
+    {
+      token: SAME_HEAD_REROLL_INELIGIBLE_REASON.REVIEW_ITEM_COUNT_NOT_POSITIVE,
+      satisfied: reviewItemCountPositiveTerm,
+    },
+  ];
+  const sameHeadRerollEligible = sameHeadRerollTerms.every(
+    (term) => term.satisfied,
+  );
+  const sameHeadRerollIneligibleReasons = sameHeadRerollTerms
+    .filter((term) => !term.satisfied)
+    .map((term) => term.token);
   const sameHeadRerollCap =
     Number.isInteger(options.sameHeadRerollCap) &&
     Number(options.sameHeadRerollCap) > 0
@@ -644,6 +771,7 @@ export function computeAdvisoryConvergenceVerdict(
   const sameHeadRerollExhausted = rerollMarkers.count >= sameHeadRerollCap;
   const sameHeadReroll: AdvisoryConvergenceSameHeadReroll = {
     eligible: sameHeadRerollEligible,
+    ineligibleReasons: sameHeadRerollIneligibleReasons,
     count: rerollMarkers.count,
     cap: sameHeadRerollCap,
     exhausted: sameHeadRerollExhausted,
@@ -793,6 +921,7 @@ export function computeAdvisoryConvergenceVerdict(
     pending,
     deadline,
     waiver,
+    dispositionEvidence: dispositionEvidenceReport,
     sameHeadReroll,
     terminal,
     converged,

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -132,6 +132,16 @@ export const SAME_HEAD_REROLL_INELIGIBLE_REASON = {
   REVIEW_ITEM_COUNT_NOT_POSITIVE: 'review-item-count-not-positive',
 } as const;
 
+/** The exact token union `sameHeadReroll.ineligibleReasons` may contain
+ * (#1719 PR review). Narrowing the field from a bare `string[]` to this
+ * union at the type level, and the schema's `items` to the matching
+ * `enum`, makes the "stable, machine-readable token" contract
+ * self-documenting and catches an accidental new/typo'd token at compile
+ * time or schema-validation time instead of silently widening the
+ * contract. */
+export type SameHeadRerollIneligibleReasonToken =
+  (typeof SAME_HEAD_REROLL_INELIGIBLE_REASON)[keyof typeof SAME_HEAD_REROLL_INELIGIBLE_REASON];
+
 /** Author reference embedded in GitHub REST/GraphQL payloads. */
 interface GhAuthorPayload {
   login?: string | null;
@@ -283,7 +293,7 @@ export interface AdvisoryConvergenceSameHeadReroll {
    * two can never disagree -- a report-mode caller no longer has to
    * re-derive the eligibility rule by hand to self-diagnose a stuck AW6
    * reroll. */
-  ineligibleReasons: string[];
+  ineligibleReasons: SameHeadRerollIneligibleReasonToken[];
   /** Trusted `advisory-reroll:` marker count whose embedded HEAD SHA
    * matches the current HEAD (resets naturally on a new push, since a new
    * HEAD's markers start over). */
@@ -603,9 +613,10 @@ export function computeAdvisoryConvergenceVerdict(
 
   // Clause 1's "review is not clean" reason is pushed here, after Clause 2's
   // `threadClause` is available -- deliberately deferred from the `pending`
-  // check above (which already returned via that `if`, so `reasons` order is
-  // unaffected: pending and not-satisfied are mutually exclusive, and this
-  // still precedes Clause 2's own thread-blocking reason below).
+  // check above (whose own `if` already exhausts the pending case, so
+  // `reasons` order is unaffected: pending and not-satisfied are mutually
+  // exclusive, and this still precedes Clause 2's own thread-blocking
+  // reason below).
   //
   // #1719: reported adopter incident -- the primary bot's review on current
   // HEAD carried `itemCount: 1` while every visible GraphQL review thread
@@ -667,8 +678,8 @@ export function computeAdvisoryConvergenceVerdict(
   // that attempt is permanently consumed before the real blocker is even
   // cleared (PR #1517 review).
   //
-  // #1719: each of the six conjuncts above is ALSO computed as its own named
-  // boolean, paired with a stable token in `sameHeadRerollTerms` --
+  // #1719: each of the six eligibility terms above is ALSO computed as its
+  // own named boolean, paired with a stable token in `sameHeadRerollTerms` --
   // `sameHeadRerollEligible` (`.every()`) and
   // `sameHeadRerollIneligibleReasons` (`.filter().map()`) are BOTH derived
   // from that one array, so they cannot disagree; a term added to the
@@ -691,7 +702,10 @@ export function computeAdvisoryConvergenceVerdict(
   const reviewItemCountKnownTerm = review.itemCount !== null;
   const reviewItemCountPositiveTerm =
     review.itemCount === null || review.itemCount > 0;
-  const sameHeadRerollTerms: { token: string; satisfied: boolean }[] = [
+  const sameHeadRerollTerms: {
+    token: SameHeadRerollIneligibleReasonToken;
+    satisfied: boolean;
+  }[] = [
     {
       token: SAME_HEAD_REROLL_INELIGIBLE_REASON.SCOPE_NOT_APPLICABLE,
       satisfied: scopeApplicableTerm,

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -115,9 +115,9 @@ import {
 export const ADVISORY_CONVERGENCE_CHECK_SELECTOR =
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR;
 
-/** #1719: stable, machine-readable tokens for `sameHeadReroll.-
- * ineligibleReasons` -- one per boolean term of the `eligible` conjunction,
- * in the same order the conjunction is written in
+/** #1719: stable, machine-readable tokens for
+ * `sameHeadReroll.ineligibleReasons` -- one per boolean term of the
+ * `eligible` conjunction, in the same order the conjunction is written in
  * `computeAdvisoryConvergenceVerdict` below, so a report-mode caller can
  * self-diagnose a stuck AW6 reroll without re-deriving the eligibility rule
  * from `idd-advisory-wait.instructions.md` by hand. Exported (rather than
@@ -252,8 +252,9 @@ export interface AdvisoryConvergenceApplicability {
  * `route` field. */
 export interface AdvisoryConvergenceDispositionEvidence {
   /** Outstanding non-thread regular PR comments (from a non-agent author)
-   * lacking a fresh disposition marker. The exact counter `sameHeadReroll.
-   * eligible`'s `missing-regular-comment-disposition` term reads. */
+   * lacking a fresh disposition marker. The exact counter
+   * `sameHeadReroll.eligible`'s `missing-regular-comment-disposition`
+   * term reads. */
   missingRegularCommentCount: number;
   /** Review threads (resolved or unresolved, any authorship) still lacking
    * a fresh disposition marker. Adjacent evidence -- not itself one of the
@@ -275,12 +276,13 @@ export interface AdvisoryConvergenceSameHeadReroll {
    * false for this HEAD, with no other triage work still outstanding. */
   eligible: boolean;
   /** #1719: one stable, machine-readable token per failing term of the
-   * six-term `eligible` conjunction above (`SAME_HEAD_REROLL_INELIGIBLE_-
-   * REASON`), in conjunction order; empty exactly when `eligible` is
-   * `true`. Computed from the SAME six terms `eligible` itself reduces
-   * from (see the computation below), so the two can never disagree --
-   * a report-mode caller no longer has to re-derive the eligibility rule
-   * by hand to self-diagnose a stuck AW6 reroll. */
+   * six-term `eligible` conjunction above
+   * (`SAME_HEAD_REROLL_INELIGIBLE_REASON`), in conjunction order; empty
+   * exactly when `eligible` is `true`. Computed from the SAME six terms
+   * `eligible` itself reduces from (see the computation below), so the
+   * two can never disagree -- a report-mode caller no longer has to
+   * re-derive the eligibility rule by hand to self-diagnose a stuck AW6
+   * reroll. */
   ineligibleReasons: string[];
   /** Trusted `advisory-reroll:` marker count whose embedded HEAD SHA
    * matches the current HEAD (resets naturally on a new push, since a new
@@ -667,10 +669,11 @@ export function computeAdvisoryConvergenceVerdict(
   //
   // #1719: each of the six conjuncts above is ALSO computed as its own named
   // boolean, paired with a stable token in `sameHeadRerollTerms` --
-  // `sameHeadRerollEligible` (`.every()`) and `sameHeadRerollIneligible-
-  // Reasons` (`.filter().map()`) are BOTH derived from that one array, so
-  // they cannot disagree; a term added to the conjunction without a paired
-  // token here would be a compile-time array-literal edit, not a
+  // `sameHeadRerollEligible` (`.every()`) and
+  // `sameHeadRerollIneligibleReasons` (`.filter().map()`) are BOTH derived
+  // from that one array, so they cannot disagree; a term added to the
+  // conjunction without a paired token here would be a compile-time
+  // array-literal edit, not a
   // hand-maintained parallel expression. `reviewItemCountPositiveTerm` is
   // deliberately written as "unknown counts as satisfied"
   // (`itemCount === null || itemCount > 0`), not the bare `itemCount > 0`

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -11,6 +11,7 @@ import {
   parseArgs,
   pickResolvingClaimEvents,
   runAdvisoryConvergence,
+  SAME_HEAD_REROLL_INELIGIBLE_REASON,
   viewerProbeGhOptions,
 } from '../src/scripts/advisory-convergence.mts';
 import {
@@ -1366,6 +1367,247 @@ test('regression: converged/waived/ready are identical with and without advisory
   assert.equal(without.pending, with_.pending);
   assert.deepEqual(without.review, with_.review);
   assert.deepEqual(without.threads, with_.threads);
+});
+
+// --- 9b. sameHeadReroll.ineligibleReasons / dispositionEvidence (#1719) -----
+// --- `eligible` is a conjunction of six boolean terms (see the computation
+// --- in advisory-convergence.mts); `ineligibleReasons` is derived from the
+// --- SAME six terms (`.every()` / `.filter().map()` over one shared array),
+// --- so the two can never disagree. This section proves: the known-token
+// --- set stays pinned to exactly six (so a term added to the conjunction
+// --- without a paired token trips a test), the array is empty exactly when
+// --- eligible is true, each term produces its own token when it is the
+// --- (sole, where isolable) failing one, and the `dispositionEvidence`
+// --- counters that feed one of those terms are exposed on the report.
+
+test('ineligibleReasons: the known-token set is pinned to exactly the six eligibility terms', () => {
+  // A 7th conjunct added to `sameHeadRerollEligible` without a paired token
+  // in `SAME_HEAD_REROLL_INELIGIBLE_REASON` would leave this set at 6,
+  // failing this pin -- the reviewer must touch this test to add one.
+  assert.deepEqual(
+    Object.values(SAME_HEAD_REROLL_INELIGIBLE_REASON).sort(),
+    [
+      'missing-regular-comment-disposition',
+      'review-item-count-not-positive',
+      'review-item-count-unknown',
+      'review-pending',
+      'scope-not-applicable',
+      'unresolved-copilot-threads',
+    ].sort(),
+  );
+});
+
+test('ineligibleReasons: empty exactly when eligible is true', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [copilotReview({ itemCount: 2 })] }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.sameHeadReroll.eligible, true);
+  assert.deepEqual(verdict.sameHeadReroll.ineligibleReasons, []);
+});
+
+test('ineligibleReasons: scope-not-applicable fires alone when only the applicability term fails', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview({ itemCount: 2 })],
+      claimEvents: [claimComment()],
+    }),
+    baseOptions({
+      convergenceScope: 'idd-claimed',
+      prHeadRefName: 'issue/1234-different',
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.applicability.status, 'not_applicable');
+  assert.deepEqual(verdict.sameHeadReroll.ineligibleReasons, [
+    SAME_HEAD_REROLL_INELIGIBLE_REASON.SCOPE_NOT_APPLICABLE,
+  ]);
+});
+
+test('ineligibleReasons: review-pending co-fires with review-item-count-unknown (matchesHead false forces itemCount null)', () => {
+  // Not isolable to a single token: `resolveLatestCopilotReviewClause`
+  // always reports `itemCount: null` off-HEAD, so these two terms always
+  // fail together -- this test documents that coupling rather than
+  // asserting an unreachable single-token result.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview({ commitId: OTHER_SHA, itemCount: 2 })],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.pending, true);
+  assert.deepEqual(verdict.sameHeadReroll.ineligibleReasons, [
+    SAME_HEAD_REROLL_INELIGIBLE_REASON.REVIEW_PENDING,
+    SAME_HEAD_REROLL_INELIGIBLE_REASON.REVIEW_ITEM_COUNT_UNKNOWN,
+  ]);
+});
+
+test('ineligibleReasons: unresolved-copilot-threads fires alone when only the thread term fails', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview({ itemCount: 2 })],
+      threads: [
+        {
+          id: 'PRT_ISOLATE_THREAD',
+          isResolved: false,
+          comments: {
+            nodes: [
+              {
+                author: { login: COPILOT_LOGIN },
+                body: 'nit: consider extracting this into a helper',
+                createdAt: OLD,
+                updatedAt: OLD,
+              },
+            ],
+          },
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.threads.satisfied, false);
+  assert.deepEqual(verdict.sameHeadReroll.ineligibleReasons, [
+    SAME_HEAD_REROLL_INELIGIBLE_REASON.UNRESOLVED_COPILOT_THREADS,
+  ]);
+});
+
+test('ineligibleReasons: missing-regular-comment-disposition fires alone when only the disposition term fails', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview({ itemCount: 2 })],
+      comments: [
+        {
+          id: 1,
+          createdAt: OLD,
+          body: 'please double check this edge case',
+          author: { login: 'some-reviewer' },
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.dispositionEvidence.missingRegularCommentCount, 1);
+  assert.deepEqual(verdict.sameHeadReroll.ineligibleReasons, [
+    SAME_HEAD_REROLL_INELIGIBLE_REASON.MISSING_REGULAR_COMMENT_DISPOSITION,
+  ]);
+});
+
+test('ineligibleReasons: review-item-count-unknown fires alone when itemCount is unavailable on a matching-HEAD review', () => {
+  // No `itemCount` key at all (rather than an explicit `undefined`
+  // override): `Number.isFinite(undefined)` is false, so
+  // `resolveLatestCopilotReviewClause` reports `itemCount: null` even
+  // though `matchesHead` is true -- unlike the review-pending case above,
+  // `review-item-count-not-positive` is deliberately designed NOT to
+  // co-fire here (see its "unknown counts as satisfied" doc comment).
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        {
+          author: { login: COPILOT_LOGIN },
+          submittedAt: RECENT,
+          commitId: HEAD,
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.pending, false);
+  assert.equal(verdict.review.itemCount, null);
+  assert.deepEqual(verdict.sameHeadReroll.ineligibleReasons, [
+    SAME_HEAD_REROLL_INELIGIBLE_REASON.REVIEW_ITEM_COUNT_UNKNOWN,
+  ]);
+});
+
+test('ineligibleReasons: review-item-count-not-positive fires alone when itemCount is exactly zero', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [copilotReview()] }), // itemCount: 0 default
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.converged, true); // already fully converged
+  assert.deepEqual(verdict.sameHeadReroll.ineligibleReasons, [
+    SAME_HEAD_REROLL_INELIGIBLE_REASON.REVIEW_ITEM_COUNT_NOT_POSITIVE,
+  ]);
+});
+
+test('reasons: itemCount > 0 with every visible Copilot thread resolved points at the review body (#1719 incident shape)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [copilotReview({ itemCount: 1 })] }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.threads.satisfied, true);
+  assert.equal(verdict.review.itemCount, 1);
+  assert.match(
+    verdict.reasons.join('\n'),
+    /check the review body directly for an item suppressed due to low confidence/,
+  );
+});
+
+test('reasons: itemCount > 0 with an unresolved blocking thread does NOT add the review-body pointer (a real thread already explains it)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview({ itemCount: 2 })],
+      threads: [
+        {
+          id: 'PRT_REAL_BLOCK',
+          isResolved: false,
+          comments: {
+            nodes: [
+              {
+                author: { login: COPILOT_LOGIN },
+                body: 'nit: consider extracting this into a helper',
+                createdAt: OLD,
+                updatedAt: OLD,
+              },
+            ],
+          },
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.threads.satisfied, false);
+  assert.doesNotMatch(
+    verdict.reasons.join('\n'),
+    /check the review body directly/,
+  );
+  assert.match(verdict.reasons.join('\n'), /2 actionable item/);
+});
+
+test('dispositionEvidence: exposes missingRegularCommentCount feeding sameHeadReroll.eligible, plus its missingThreadCount sibling', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview({ itemCount: 2 })],
+      comments: [
+        {
+          id: 1,
+          createdAt: OLD,
+          body: 'please double check this edge case',
+          author: { login: 'some-reviewer' },
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.dispositionEvidence.missingRegularCommentCount, 1);
+  assert.equal(typeof verdict.dispositionEvidence.missingThreadCount, 'number');
+});
+
+test('dispositionEvidence: missingRegularCommentCount is zero when nothing is outstanding', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [copilotReview({ itemCount: 2 })] }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.dispositionEvidence.missingRegularCommentCount, 0);
 });
 
 // --- 10. terminal Copilot unavailability (#1570/#1572) ----------------------

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -255,6 +255,7 @@ export const advisoryConvergenceKeys = [
   'pending',
   'deadline',
   'waiver',
+  'dispositionEvidence',
   'sameHeadReroll',
   'terminal',
   'converged',
@@ -581,8 +582,13 @@ const advisoryConvergenceFixture = {
     activeClaimId: '',
     validCount: 0,
   },
+  dispositionEvidence: {
+    missingRegularCommentCount: 0,
+    missingThreadCount: 0,
+  },
   sameHeadReroll: {
     eligible: false,
+    ineligibleReasons: ['review-item-count-not-positive'],
     count: 0,
     cap: 2,
     exhausted: false,


### PR DESCRIPTION
# Summary

`idd-advisory-convergence`'s report mode reported `sameHeadReroll.eligible: false`
with nothing in the output explaining why. This PR makes the verdict explain
itself without changing `eligible`'s value.

- Add `sameHeadReroll.ineligibleReasons`: one stable, machine-readable token
  per failing term of the six-term eligibility conjunction, empty exactly
  when `eligible` is `true`. All six named booleans and the token array are
  computed once and derived from the same array (`.every()` / `.filter().
  map()`), so the boolean and the array cannot disagree.
- Expose `dispositionEvidence.{missingRegularCommentCount,
  missingThreadCount}` on the report object, so the numeric input behind
  one of those six terms is visible directly, not only its pass/fail
  verdict.
- When `itemCount > 0` while every visible Copilot-authored thread is
  already resolved, extend the existing top-level `reasons` entry to point
  at the review body directly -- the observed shape of the reported adopter
  incident where a "Comments suppressed due to low confidence" item counted
  toward `itemCount` but never surfaced as a review thread, so no thread
  query could ever explain it.
- Update `schemas/advisory-convergence.schema.json` and its valid fixture,
  plus the schema/type reconciliation test, for the new fields.
- Document the new fields in AW6 (`docs/idd-helper-scripts.md` and its
  `idd-template/` mirror).
- Add tests: `ineligibleReasons` empty iff `eligible`, a pinned six-token
  set (so a term added to the conjunction without a paired token fails a
  test), one isolation test per term (two terms are documented as always
  co-firing, since an off-HEAD review always reports an unknown item
  count), and the review-body pointer text.

## Linked issue

Closes #1719

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`eligible` itself is unchanged -- this only makes the existing verdict
explicable. See the module header and inline comments in
`src/scripts/advisory-convergence.mts` for the full design rationale,
including why `review-item-count-not-positive` is deliberately written as
"unknown counts as satisfied" to keep it mutually exclusive with
`review-item-count-unknown` in the reported token list.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [ ] No secret-bearing examples
- [ ] No private repo names / URLs
- [ ] Merge policy impact reviewed
- [ ] Context budget impact reviewed
