### PR TITLE
fix(protocol-helpers): surface waived non-passing CI siblings

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3245,8 +3245,22 @@ export function summarizeRequiredChecks(
     ) {
       status = 'unknown';
     }
-    discardedNonPassingRequiredChecks =
-      ciClassification.discardedNonPassingInstances;
+    // #1753: computed from the RAW matchedRequiredChecks -- deliberately
+    // NOT ciClassification.discardedNonPassingInstances above, which is
+    // derived from the waiver-adjusted effectiveChecks. A valid waiver
+    // rewrites a waived non-passing instance's `state` to 'SKIPPED' (pass-
+    // equivalent, outside GENUINELY_NON_PASSING_STATES), so computing this
+    // evidence field from effectiveChecks would let a waived CANCELLED
+    // sibling silently drop out of this field the moment it is waived --
+    // exactly the divergence-masking scenario #1745 exists to surface, and
+    // exactly the check this repo's own `idd-advisory-convergence` waivable
+    // policy can trigger. `status` above intentionally keeps using the
+    // waiver-adjusted effectiveChecks -- a valid waiver legitimately makes
+    // a check pass for merge-gate purposes; only this evidence-only
+    // computation needs the pre-waiver truth.
+    discardedNonPassingRequiredChecks = findDiscardedNonPassingSiblings(
+      matchedRequiredChecks,
+    );
   }
   return {
     status,

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4178,8 +4178,22 @@ export function summarizeRequiredChecks(
     ) {
       status = 'unknown';
     }
-    discardedNonPassingRequiredChecks =
-      ciClassification.discardedNonPassingInstances;
+    // #1753: computed from the RAW matchedRequiredChecks -- deliberately
+    // NOT ciClassification.discardedNonPassingInstances above, which is
+    // derived from the waiver-adjusted effectiveChecks. A valid waiver
+    // rewrites a waived non-passing instance's `state` to 'SKIPPED' (pass-
+    // equivalent, outside GENUINELY_NON_PASSING_STATES), so computing this
+    // evidence field from effectiveChecks would let a waived CANCELLED
+    // sibling silently drop out of this field the moment it is waived --
+    // exactly the divergence-masking scenario #1745 exists to surface, and
+    // exactly the check this repo's own `idd-advisory-convergence` waivable
+    // policy can trigger. `status` above intentionally keeps using the
+    // waiver-adjusted effectiveChecks -- a valid waiver legitimately makes
+    // a check pass for merge-gate purposes; only this evidence-only
+    // computation needs the pre-waiver truth.
+    discardedNonPassingRequiredChecks = findDiscardedNonPassingSiblings(
+      matchedRequiredChecks,
+    );
   }
 
   return {

--- a/tests/required-checks-summary.test.mts
+++ b/tests/required-checks-summary.test.mts
@@ -147,8 +147,11 @@ test('surfaces a discarded CANCELLED sibling for a required check via discardedN
 // classifyCiChecks runs -- so a waived CANCELLED sibling silently dropped
 // out of this evidence field the moment a maintainer authorized a waiver
 // for it. That is exactly the divergence-masking scenario #1745 exists to
-// surface, and exactly the check (`idd-advisory-convergence`) this repo's
-// own `.github/idd/config.json` marks waivable.
+// surface. This is a generic waiver + discarded-sibling test using the
+// same 'lint' stand-in check name as its neighbors above; the real-world
+// motivating check is `idd-advisory-convergence`, which this repo's own
+// `.github/idd/config.json` marks waivable, but this fixture does not
+// exercise that specific check name/config.
 test('discardedNonPassingRequiredChecks still surfaces a waived CANCELLED sibling even though the waiver rewrites it to SKIPPED for status purposes', () => {
   const waivers = {
     valid: [

--- a/tests/required-checks-summary.test.mts
+++ b/tests/required-checks-summary.test.mts
@@ -140,6 +140,75 @@ test('surfaces a discarded CANCELLED sibling for a required check via discardedN
   assert.equal(r.discardedNonPassingRequiredChecks[0]?.name, 'lint');
 });
 
+// Regression (#1753): a Codex review on PR #1749 (#1745's own PR) found
+// that summarizeRequiredChecks computed discardedNonPassingRequiredChecks
+// from the waiver-adjusted effectiveChecks -- where a waived non-passing
+// instance's `state` is rewritten to 'SKIPPED' (pass-equivalent) before
+// classifyCiChecks runs -- so a waived CANCELLED sibling silently dropped
+// out of this evidence field the moment a maintainer authorized a waiver
+// for it. That is exactly the divergence-masking scenario #1745 exists to
+// surface, and exactly the check (`idd-advisory-convergence`) this repo's
+// own `.github/idd/config.json` marks waivable.
+test('discardedNonPassingRequiredChecks still surfaces a waived CANCELLED sibling even though the waiver rewrites it to SKIPPED for status purposes', () => {
+  const waivers = {
+    valid: [
+      {
+        authorLogin: 'kurone-kito',
+        checkSelector: 'lint',
+        reason: 'known-flaky-cancel',
+        expiresAt: '2099-01-01T00:00:00Z',
+      },
+    ],
+    expired: [],
+    wrongHead: [],
+    wrongClaim: [],
+    unauthorized: [],
+    malformed: [],
+  };
+  const r = summarizeRequiredChecks(
+    [
+      {
+        name: 'lint',
+        state: 'CANCELLED',
+        completedAt: '2026-07-18T03:45:56Z',
+        type: 'check-run',
+        workflowName: 'Lint gate',
+      },
+      {
+        name: 'lint',
+        state: 'SUCCESS',
+        completedAt: '2026-07-18T03:47:01Z',
+        type: 'check-run',
+        workflowName: 'Lint gate',
+      },
+    ],
+    protectedRules,
+    {},
+    { waivers },
+  );
+  // status/requiredChecksPassing must keep honoring the waiver exactly as
+  // before this fix -- no regression to existing waiver behavior.
+  assert.equal(r.status, 'success');
+  assert.equal(r.requiredChecksPassing, true);
+  assert.equal(
+    r.checks.find((c) => c.state === 'CANCELLED')?.coveredByWaiver,
+    true,
+  );
+  // The discarded CANCELLED sibling must still be visible even though the
+  // waiver rewrote its `state` to 'SKIPPED' in the effectiveChecks used by
+  // `status` above.
+  assert.equal(r.discardedNonPassingRequiredChecks.length, 1);
+  assert.equal(
+    r.discardedNonPassingRequiredChecks[0]?.discardedState,
+    'CANCELLED',
+  );
+  assert.equal(
+    r.discardedNonPassingRequiredChecks[0]?.selectedState,
+    'SUCCESS',
+  );
+  assert.equal(r.discardedNonPassingRequiredChecks[0]?.name, 'lint');
+});
+
 test('discardedNonPassingRequiredChecks is empty when nothing was discarded', () => {
   const r = summarize([{ name: 'lint', state: 'SUCCESS' }], protectedRules);
   assert.deepEqual(r.discardedNonPassingRequiredChecks, []);


### PR DESCRIPTION
# Summary

`summarizeRequiredChecks` (`src/scripts/protocol-helpers.mts`) computed
its `discardedNonPassingRequiredChecks` evidence field from
`effectiveChecks` -- the array where each valid-waiver-covered
non-passing check-run instance has its `state` rewritten to `'SKIPPED'`
before `classifyCiChecks` runs. `SKIPPED` is itself pass-equivalent
(outside `GENUINELY_NON_PASSING_STATES`), so a waived `CANCELLED`
sibling silently dropped out of this evidence field the moment a
maintainer authorized a waiver for it -- exactly the CI-evidence-vs-
rollup divergence #1745 shipped this field to surface, and exactly the
check (`idd-advisory-convergence`) this repository's own
`.github/idd/config.json` marks waivable.

This PR computes `discardedNonPassingRequiredChecks` from the raw
`matchedRequiredChecks` instead (calling the already-extracted
`findDiscardedNonPassingSiblings` helper directly, before waiver
substitution), while `status`/`requiredChecksPassing` keep using the
waiver-adjusted `effectiveChecks` unchanged -- a valid waiver still
legitimately makes a check pass for merge-gate purposes; only this
evidence-only computation needed the pre-waiver truth.

`resolvePresentRunConclusion` has the same `coveredByWaiver -> SKIPPED`
substitution shape but only reads `.status` from its `classifyCiChecks`
call, never `.discardedNonPassingInstances`, so it is unaffected by
this bug and is left unchanged.

## Linked issue

Closes #1753

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Refs #1745 (Codex review on PR #1749 found this gap post-merge; #1745
itself already merged, so no closing keyword targets it here).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

Additionally verified the new regression test is load-bearing: checked
out the pre-fix `src/scripts/protocol-helpers.mts` against the new test
and confirmed it fails (`0 !== 1`) while the pre-existing #1745 test
still passes, then restored the fix.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (evidence-only field; `status`/
      `requiredChecksPassing` merge-gate logic unchanged)
- [x] Context budget impact reviewed (no instruction files changed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved required-check reporting so waived, non-passing checks remain visible in evidence while waiver rules continue to affect the overall CI status.
* **Tests**
  * Added regression coverage for cancelled required checks that have been waived.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->