### PR TITLE
fix(rerun-advisory-convergence): stop dropping recovery-refresh

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -110,11 +110,14 @@ In the idd-skill source repository, the following optional helpers were adopted:
   ordered, deduplicated `gh run rerun <id>` recovery plan for the
   rerun-eligible instances (each command includes `-R owner/repo` when
   the repository is known) — referenced from `idd-ci.instructions.md`
-  §Rerun mechanics as the preferred way to produce that plan. When no
-  instance is rerun-eligible but the rollup is stuck on a bot-gated
-  instance alongside an already-passing non-bot pull_request-family
-  instance, it additionally offers a `recoveryRefreshPlan`: rerunning
-  that already-passing instance is the documented way to force a fresh
+  §Rerun mechanics as the preferred way to produce that plan. When the
+  rollup is stuck on a bot-gated instance alongside an already-passing
+  non-bot pull_request-family instance, it additionally offers a
+  `recoveryRefreshPlan` — populated even alongside a non-empty rerun plan
+  when every rerun-eligible instance there is itself bot-triggered (#1745;
+  rerunning a bot-triggered instance does not supply the non-bot trigger
+  the recovery-refresh option exists to provide): rerunning the
+  already-passing instance is the documented way to force a fresh
   non-bot evaluation and clear the stale rollup. Never calls
   `gh run rerun` itself; a mutating `--apply` mode is a deliberate
   follow-up.
@@ -1221,10 +1224,14 @@ to post it is the consuming track's job.
   recovery plan for the rerun-eligible instances -- referenced from
   `idd-ci.instructions.md` §Rerun mechanics as the preferred way to produce
   that plan
-- Also reports a `recoveryRefreshPlan` when no instance is rerun-eligible but
-  the rollup is stuck on a bot-gated instance alongside an already-passing
-  non-bot pull_request-family instance, and honors the resolved
-  `ciWait.rerunPolicy`: a `"hold"` policy, or an instance whose own
+- Also reports a `recoveryRefreshPlan` when the rollup is stuck on a
+  bot-gated instance alongside an already-passing non-bot
+  pull_request-family instance — populated even alongside a non-empty
+  sequential rerun plan when every rerun-eligible instance there is itself
+  bot-triggered (#1745; rerunning a bot-triggered instance does not supply
+  the non-bot trigger the recovery-refresh option exists to provide) — and
+  honors the resolved `ciWait.rerunPolicy`: a `"hold"` policy, or an
+  instance whose own
   `runAttempt` already exhausted the `"rerun-once"` budget, withholds the
   corresponding plan entries with an explanatory `rerunPolicyHoldNotice`
   instead of silently omitting them

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -110,11 +110,14 @@ In the idd-skill source repository, the following optional helpers were adopted:
   ordered, deduplicated `gh run rerun <id>` recovery plan for the
   rerun-eligible instances (each command includes `-R owner/repo` when
   the repository is known) — referenced from `idd-ci.instructions.md`
-  §Rerun mechanics as the preferred way to produce that plan. When no
-  instance is rerun-eligible but the rollup is stuck on a bot-gated
-  instance alongside an already-passing non-bot pull_request-family
-  instance, it additionally offers a `recoveryRefreshPlan`: rerunning
-  that already-passing instance is the documented way to force a fresh
+  §Rerun mechanics as the preferred way to produce that plan. When the
+  rollup is stuck on a bot-gated instance alongside an already-passing
+  non-bot pull_request-family instance, it additionally offers a
+  `recoveryRefreshPlan` — populated even alongside a non-empty rerun plan
+  when every rerun-eligible instance there is itself bot-triggered (#1745;
+  rerunning a bot-triggered instance does not supply the non-bot trigger
+  the recovery-refresh option exists to provide): rerunning the
+  already-passing instance is the documented way to force a fresh
   non-bot evaluation and clear the stale rollup. Never calls
   `gh run rerun` itself; a mutating `--apply` mode is a deliberate
   follow-up.
@@ -1221,10 +1224,14 @@ to post it is the consuming track's job.
   recovery plan for the rerun-eligible instances -- referenced from
   `idd-ci.instructions.md` §Rerun mechanics as the preferred way to produce
   that plan
-- Also reports a `recoveryRefreshPlan` when no instance is rerun-eligible but
-  the rollup is stuck on a bot-gated instance alongside an already-passing
-  non-bot pull_request-family instance, and honors the resolved
-  `ciWait.rerunPolicy`: a `"hold"` policy, or an instance whose own
+- Also reports a `recoveryRefreshPlan` when the rollup is stuck on a
+  bot-gated instance alongside an already-passing non-bot
+  pull_request-family instance — populated even alongside a non-empty
+  sequential rerun plan when every rerun-eligible instance there is itself
+  bot-triggered (#1745; rerunning a bot-triggered instance does not supply
+  the non-bot trigger the recovery-refresh option exists to provide) — and
+  honors the resolved `ciWait.rerunPolicy`: a `"hold"` policy, or an
+  instance whose own
   `runAttempt` already exhausted the `"rerun-once"` budget, withholds the
   corresponding plan entries with an explanatory `rerunPolicyHoldNotice`
   instead of silently omitting them

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -147,8 +147,15 @@ const PULL_REQUEST_FAMILY_EVENTS = new Set([
 ]);
 const PLAN_CAVEAT =
   'Rerun the rerun-eligible instances ONE AT A TIME, in the order listed below, waiting for each `gh run rerun` to finish before starting the next -- rerunning several concurrently makes them cancel each other via the shared concurrency group.';
+// Deliberately does NOT open with "No rerun-eligible instance exists": since
+// #1745, recoveryRefreshPlan can be populated alongside a non-empty `plan`
+// (a bot-triggered rerun-eligible instance, e.g. a CANCELLED sibling, does
+// not itself supply the non-bot trigger a separately bot-gated instance
+// still needs), so that claim is not always true. `plan`'s own emptiness or
+// non-emptiness is already visible in the JSON document; this text sticks to
+// the technical gating condition, which holds regardless (#1752).
 const RECOVERY_REFRESH_CAVEAT =
-  'No rerun-eligible instance exists, but at least one check-run is bot-gated-skip and at least one already-PASSING non-bot pull_request-family instance exists for this SHA. Per idd-ci.instructions.md Rerun mechanics, rerunning that already-passing instance (not the bot-gated one) is the documented way to force a fresh non-bot-triggered evaluation and clear a required-check rollup pinned to the stale bot-gated state -- the instance itself does not need to change its outcome.';
+  'At least one check-run is bot-gated-skip and at least one already-PASSING non-bot pull_request-family instance exists for this SHA. Per idd-ci.instructions.md Rerun mechanics, rerunning that already-passing instance (not the bot-gated one) is the documented way to force a fresh non-bot-triggered evaluation and clear a required-check rollup pinned to the stale bot-gated state -- the instance itself does not need to change its outcome.';
 /**
  * Compute the deterministic rerun-plan verdict from already-fetched and
  * already-enriched check-run instances. Pure (no I/O), so it is directly
@@ -877,6 +884,77 @@ export function describeNoActionState(plan) {
   }
   return `No rerun-eligible instance and no recovery-refresh option, but this is not a clean "nothing to do": ${notes}.`;
 }
+/**
+ * Header line introducing the recovery-refresh section of the CLI's stderr
+ * summary. Two independent conditions ({@link
+ * RerunAdvisoryConvergencePlan.plan} and {@link
+ * RerunAdvisoryConvergencePlan.recoveryRefreshPlan}) can both be non-empty
+ * at once since #1745 (a bot-triggered rerun-eligible instance in `plan`,
+ * e.g. a CANCELLED sibling, does not itself supply the non-bot trigger a
+ * separately bot-gated instance still needs from `recoveryRefreshPlan`) --
+ * a hardcoded "No rerun-eligible instances" header became false in that
+ * combined case (#1752, post-merge Codex review on #1749/#1745).
+ * `idd-ci.instructions.md` §Rerun mechanics documents the recovery-refresh
+ * rerun as the recommended FIRST step in that combined scenario (rerun the
+ * already-passing non-bot instance; only rerun the CANCELLED-conclusion
+ * bot-triggered sibling(s) next if that alone does not clear the rollup),
+ * so the combined-case wording says so explicitly rather than relying on
+ * {@link buildRerunPlanTextSections}'s print order alone.
+ */
+export function describeRecoveryRefreshHeader(plan) {
+  return plan.plan.length > 0
+    ? 'A recovery-refresh option is also available -- try this FIRST, per idd-ci.instructions.md §Rerun mechanics; only fall back to the sequential recovery plan below if it does not clear the rollup:'
+    : 'No rerun-eligible instances, but a recovery-refresh option is available:';
+}
+/**
+ * Ordered, fully-rendered stderr sections for the recovery-refresh option
+ * and the sequential rerun-eligible plan, selected and formatted
+ * independently of each other -- the CLI entry point below previously
+ * treated these as mutually exclusive (`if`/`else if`), so whenever both
+ * `plan.recoveryRefreshPlan` and `plan.plan` were non-empty at once (#1745
+ * made that possible), only the first-checked one ever printed, silently
+ * dropping the other's recovery command from the human-readable summary an
+ * operator actually follows even though the JSON document above already
+ * carried both correctly (#1752). Extracted as its own pure, directly
+ * unit-testable function -- mirroring {@link describeOutstandingStates} /
+ * {@link describeNoActionState} -- so SECTION SELECTION (which sections
+ * appear, and in what order), not just wording, has direct test coverage
+ * instead of being reachable only through the `import.meta.main` CLI entry
+ * point.
+ *
+ * Order: the recoveryRefreshPlan section prints first when both are
+ * present, matching `idd-ci.instructions.md` §Rerun mechanics' documented
+ * recovery order for this exact combined scenario (see {@link
+ * describeRecoveryRefreshHeader}). Each returned entry is pre-joined with
+ * internal newlines; the caller wraps each in the same single leading and
+ * trailing blank line every other CLI-summary section already uses.
+ */
+export function buildRerunPlanTextSections(plan) {
+  const sections = [];
+  if (plan.recoveryRefreshPlan.length > 0) {
+    sections.push(
+      [
+        describeRecoveryRefreshHeader(plan),
+        ...plan.recoveryRefreshPlan.map(
+          (entry, index) => `  ${index + 1}. ${entry.command}`,
+        ),
+        '',
+        plan.recoveryRefreshCaveat,
+      ].join('\n'),
+    );
+  }
+  if (plan.plan.length > 0) {
+    sections.push(
+      [
+        'Sequential recovery plan (run one at a time; wait for each to finish before the next):',
+        ...plan.plan.map((entry, index) => `  ${index + 1}. ${entry.command}`),
+        '',
+        plan.planCaveat,
+      ].join('\n'),
+    );
+  }
+  return sections;
+}
 function printHelp() {
   process.stdout.write(`Usage:
   node scripts/rerun-advisory-convergence.mjs --pr <number> [--owner <owner> --repo <repo>] [--now <ISO8601>] [--help]
@@ -1346,24 +1424,23 @@ if (import.meta.main) {
     // despite the stream *starting* with a well-formed document
     // (#1434 review, Copilot).
     process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
-    if (plan.plan.length > 0) {
-      process.stderr.write(
-        '\nSequential recovery plan (run one at a time; wait for each to finish before the next):\n',
-      );
-      plan.plan.forEach((entry, index) => {
-        process.stderr.write(`  ${index + 1}. ${entry.command}\n`);
-      });
-      process.stderr.write(`\n${plan.planCaveat}\n`);
-    } else if (plan.recoveryRefreshPlan.length > 0) {
-      process.stderr.write(
-        '\nNo rerun-eligible instances, but a recovery-refresh option is available:\n',
-      );
-      plan.recoveryRefreshPlan.forEach((entry, index) => {
-        process.stderr.write(`  ${index + 1}. ${entry.command}\n`);
-      });
-      process.stderr.write(`\n${plan.recoveryRefreshCaveat}\n`);
+    // plan.recoveryRefreshPlan and plan.plan are printed as two
+    // INDEPENDENT sections (never else-if): #1745 made it possible for
+    // both to be non-empty at once (a bot-triggered rerun-eligible
+    // instance in `plan` does not itself supply the non-bot trigger a
+    // separately bot-gated instance still needs from
+    // `recoveryRefreshPlan`), and an `else if` here previously printed
+    // only whichever section was checked first, silently dropping the
+    // other's recovery command from this human-readable summary even
+    // though the JSON document above already carried both correctly
+    // (#1752, post-merge Codex review on #1749/#1745). Section selection
+    // and order are delegated to buildRerunPlanTextSections so the
+    // combined case has direct unit-test coverage instead of being
+    // reachable only through this CLI entry point.
+    for (const section of buildRerunPlanTextSections(plan)) {
+      process.stderr.write(`\n${section}\n`);
     }
-    // Independent of whichever branch above fired: rerunPolicyHoldNotice
+    // Independent of whichever section(s) above fired: rerunPolicyHoldNotice
     // describes a policy-held or budget-held instance, which is a
     // DIFFERENT instance than whichever one just populated `plan` or
     // `recoveryRefreshPlan` above -- printing it only in an `else if`

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -327,8 +327,15 @@ export interface RerunAdvisoryConvergencePlan {
 const PLAN_CAVEAT =
   'Rerun the rerun-eligible instances ONE AT A TIME, in the order listed below, waiting for each `gh run rerun` to finish before starting the next -- rerunning several concurrently makes them cancel each other via the shared concurrency group.';
 
+// Deliberately does NOT open with "No rerun-eligible instance exists": since
+// #1745, recoveryRefreshPlan can be populated alongside a non-empty `plan`
+// (a bot-triggered rerun-eligible instance, e.g. a CANCELLED sibling, does
+// not itself supply the non-bot trigger a separately bot-gated instance
+// still needs), so that claim is not always true. `plan`'s own emptiness or
+// non-emptiness is already visible in the JSON document; this text sticks to
+// the technical gating condition, which holds regardless (#1752).
 const RECOVERY_REFRESH_CAVEAT =
-  'No rerun-eligible instance exists, but at least one check-run is bot-gated-skip and at least one already-PASSING non-bot pull_request-family instance exists for this SHA. Per idd-ci.instructions.md Rerun mechanics, rerunning that already-passing instance (not the bot-gated one) is the documented way to force a fresh non-bot-triggered evaluation and clear a required-check rollup pinned to the stale bot-gated state -- the instance itself does not need to change its outcome.';
+  'At least one check-run is bot-gated-skip and at least one already-PASSING non-bot pull_request-family instance exists for this SHA. Per idd-ci.instructions.md Rerun mechanics, rerunning that already-passing instance (not the bot-gated one) is the documented way to force a fresh non-bot-triggered evaluation and clear a required-check rollup pinned to the stale bot-gated state -- the instance itself does not need to change its outcome.';
 
 /** Pure inputs to {@link computeRerunPlan} (already fetched; this function
  * performs no I/O). */
@@ -1167,6 +1174,83 @@ export function describeNoActionState(
   return `No rerun-eligible instance and no recovery-refresh option, but this is not a clean "nothing to do": ${notes}.`;
 }
 
+/**
+ * Header line introducing the recovery-refresh section of the CLI's stderr
+ * summary. Two independent conditions ({@link
+ * RerunAdvisoryConvergencePlan.plan} and {@link
+ * RerunAdvisoryConvergencePlan.recoveryRefreshPlan}) can both be non-empty
+ * at once since #1745 (a bot-triggered rerun-eligible instance in `plan`,
+ * e.g. a CANCELLED sibling, does not itself supply the non-bot trigger a
+ * separately bot-gated instance still needs from `recoveryRefreshPlan`) --
+ * a hardcoded "No rerun-eligible instances" header became false in that
+ * combined case (#1752, post-merge Codex review on #1749/#1745).
+ * `idd-ci.instructions.md` §Rerun mechanics documents the recovery-refresh
+ * rerun as the recommended FIRST step in that combined scenario (rerun the
+ * already-passing non-bot instance; only rerun the CANCELLED-conclusion
+ * bot-triggered sibling(s) next if that alone does not clear the rollup),
+ * so the combined-case wording says so explicitly rather than relying on
+ * {@link buildRerunPlanTextSections}'s print order alone.
+ */
+export function describeRecoveryRefreshHeader(
+  plan: RerunAdvisoryConvergencePlan,
+): string {
+  return plan.plan.length > 0
+    ? 'A recovery-refresh option is also available -- try this FIRST, per idd-ci.instructions.md §Rerun mechanics; only fall back to the sequential recovery plan below if it does not clear the rollup:'
+    : 'No rerun-eligible instances, but a recovery-refresh option is available:';
+}
+
+/**
+ * Ordered, fully-rendered stderr sections for the recovery-refresh option
+ * and the sequential rerun-eligible plan, selected and formatted
+ * independently of each other -- the CLI entry point below previously
+ * treated these as mutually exclusive (`if`/`else if`), so whenever both
+ * `plan.recoveryRefreshPlan` and `plan.plan` were non-empty at once (#1745
+ * made that possible), only the first-checked one ever printed, silently
+ * dropping the other's recovery command from the human-readable summary an
+ * operator actually follows even though the JSON document above already
+ * carried both correctly (#1752). Extracted as its own pure, directly
+ * unit-testable function -- mirroring {@link describeOutstandingStates} /
+ * {@link describeNoActionState} -- so SECTION SELECTION (which sections
+ * appear, and in what order), not just wording, has direct test coverage
+ * instead of being reachable only through the `import.meta.main` CLI entry
+ * point.
+ *
+ * Order: the recoveryRefreshPlan section prints first when both are
+ * present, matching `idd-ci.instructions.md` §Rerun mechanics' documented
+ * recovery order for this exact combined scenario (see {@link
+ * describeRecoveryRefreshHeader}). Each returned entry is pre-joined with
+ * internal newlines; the caller wraps each in the same single leading and
+ * trailing blank line every other CLI-summary section already uses.
+ */
+export function buildRerunPlanTextSections(
+  plan: RerunAdvisoryConvergencePlan,
+): string[] {
+  const sections: string[] = [];
+  if (plan.recoveryRefreshPlan.length > 0) {
+    sections.push(
+      [
+        describeRecoveryRefreshHeader(plan),
+        ...plan.recoveryRefreshPlan.map(
+          (entry, index) => `  ${index + 1}. ${entry.command}`,
+        ),
+        '',
+        plan.recoveryRefreshCaveat,
+      ].join('\n'),
+    );
+  }
+  if (plan.plan.length > 0) {
+    sections.push(
+      [
+        'Sequential recovery plan (run one at a time; wait for each to finish before the next):',
+        ...plan.plan.map((entry, index) => `  ${index + 1}. ${entry.command}`),
+        '',
+        plan.planCaveat,
+      ].join('\n'),
+    );
+  }
+  return sections;
+}
+
 function printHelp(): void {
   process.stdout.write(`Usage:
   node scripts/rerun-advisory-convergence.mjs --pr <number> [--owner <owner> --repo <repo>] [--now <ISO8601>] [--help]
@@ -1733,24 +1817,23 @@ if (import.meta.main) {
     // despite the stream *starting* with a well-formed document
     // (#1434 review, Copilot).
     process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
-    if (plan.plan.length > 0) {
-      process.stderr.write(
-        '\nSequential recovery plan (run one at a time; wait for each to finish before the next):\n',
-      );
-      plan.plan.forEach((entry, index) => {
-        process.stderr.write(`  ${index + 1}. ${entry.command}\n`);
-      });
-      process.stderr.write(`\n${plan.planCaveat}\n`);
-    } else if (plan.recoveryRefreshPlan.length > 0) {
-      process.stderr.write(
-        '\nNo rerun-eligible instances, but a recovery-refresh option is available:\n',
-      );
-      plan.recoveryRefreshPlan.forEach((entry, index) => {
-        process.stderr.write(`  ${index + 1}. ${entry.command}\n`);
-      });
-      process.stderr.write(`\n${plan.recoveryRefreshCaveat}\n`);
+    // plan.recoveryRefreshPlan and plan.plan are printed as two
+    // INDEPENDENT sections (never else-if): #1745 made it possible for
+    // both to be non-empty at once (a bot-triggered rerun-eligible
+    // instance in `plan` does not itself supply the non-bot trigger a
+    // separately bot-gated instance still needs from
+    // `recoveryRefreshPlan`), and an `else if` here previously printed
+    // only whichever section was checked first, silently dropping the
+    // other's recovery command from this human-readable summary even
+    // though the JSON document above already carried both correctly
+    // (#1752, post-merge Codex review on #1749/#1745). Section selection
+    // and order are delegated to buildRerunPlanTextSections so the
+    // combined case has direct unit-test coverage instead of being
+    // reachable only through this CLI entry point.
+    for (const section of buildRerunPlanTextSections(plan)) {
+      process.stderr.write(`\n${section}\n`);
     }
-    // Independent of whichever branch above fired: rerunPolicyHoldNotice
+    // Independent of whichever section(s) above fired: rerunPolicyHoldNotice
     // describes a policy-held or budget-held instance, which is a
     // DIFFERENT instance than whichever one just populated `plan` or
     // `recoveryRefreshPlan` above -- printing it only in an `else if`

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -4,9 +4,11 @@ import { test } from 'node:test';
 import {
   buildCheckRunsForRefArgs,
   buildIddConfigContentsArgs,
+  buildRerunPlanTextSections,
   computeRerunPlan,
   describeNoActionState,
   describeOutstandingStates,
+  describeRecoveryRefreshHeader,
   parseArgs,
   parseRunIdFromUrl,
   RERUN_PLAN_CHECK_NAME,
@@ -1182,6 +1184,147 @@ test('describeOutstandingStates reports a pending instance even when a genuine r
     describeOutstandingStates(plan),
     /1 instance\(s\) are still running/,
   );
+});
+
+// --- describeRecoveryRefreshHeader / buildRerunPlanTextSections
+// (regression: #1752, post-merge Codex review on PR #1749/#1745) ---------
+//
+// The CLI's stderr renderer previously treated plan.plan and
+// plan.recoveryRefreshPlan as mutually exclusive (`if`/`else if`), so
+// whenever #1745 made both non-empty at once (a bot-triggered
+// rerun-eligible instance in `plan` does not itself supply the non-bot
+// trigger a separately bot-gated instance still needs from
+// `recoveryRefreshPlan`), only the first-checked section ever printed,
+// silently dropping the other's recovery command. These tests cover
+// SECTION SELECTION directly (not just wording), matching the same
+// combined-instance fixture as the existing computeRerunPlan-level
+// regression test above ("offers both plan and recoveryRefreshPlan ...").
+
+function combinedCasePlan() {
+  return computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: 'gated',
+          runId: '7001',
+          conclusion: 'action_required',
+        }),
+        baseInstance({
+          checkRunId: 'cancelled-bot',
+          runId: '7004',
+          conclusion: 'cancelled',
+          actorLogin: 'copilot-pull-request-reviewer[bot]',
+          actorType: 'Bot',
+          triggeringActorLogin: 'copilot-pull-request-reviewer[bot]',
+          triggeringActorType: 'Bot',
+        }),
+        baseInstance({
+          checkRunId: 'passing',
+          runId: '7002',
+          conclusion: 'success',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+}
+
+test('describeRecoveryRefreshHeader: sole case still says no rerun-eligible instances exist', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: 'gated',
+          runId: '7001',
+          conclusion: 'action_required',
+        }),
+        baseInstance({
+          checkRunId: 'passing',
+          runId: '7002',
+          conclusion: 'success',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.plan.length, 0);
+  assert.equal(plan.recoveryRefreshPlan.length, 1);
+  assert.match(
+    describeRecoveryRefreshHeader(plan),
+    /No rerun-eligible instances/,
+  );
+});
+
+test('describeRecoveryRefreshHeader: combined case no longer claims no rerun-eligible instances exist', () => {
+  const plan = combinedCasePlan();
+  assert.equal(plan.plan.length, 1);
+  assert.equal(plan.recoveryRefreshPlan.length, 1);
+  const header = describeRecoveryRefreshHeader(plan);
+  assert.doesNotMatch(header, /No rerun-eligible instances/);
+  // Per idd-ci.instructions.md §Rerun mechanics, the recovery-refresh
+  // rerun is the documented FIRST step in this exact combined scenario.
+  assert.match(header, /try this FIRST/);
+});
+
+test('buildRerunPlanTextSections: sole sequential-plan case prints only that section', () => {
+  const plan = computeRerunPlan(
+    baseInput({ instances: [baseInstance({ conclusion: 'failure' })] }),
+    baseOptions(),
+  );
+  assert.equal(plan.plan.length, 1);
+  assert.equal(plan.recoveryRefreshPlan.length, 0);
+  const sections = buildRerunPlanTextSections(plan);
+  assert.equal(sections.length, 1);
+  assert.match(sections[0] ?? '', /^Sequential recovery plan/);
+});
+
+test('buildRerunPlanTextSections: sole recovery-refresh case prints only that section', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: 'gated',
+          runId: '7001',
+          conclusion: 'action_required',
+        }),
+        baseInstance({
+          checkRunId: 'passing',
+          runId: '7002',
+          conclusion: 'success',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.plan.length, 0);
+  assert.equal(plan.recoveryRefreshPlan.length, 1);
+  const sections = buildRerunPlanTextSections(plan);
+  assert.equal(sections.length, 1);
+  assert.match(sections[0] ?? '', /No rerun-eligible instances/);
+});
+
+test('buildRerunPlanTextSections: combined case prints BOTH sections, recovery-refresh first', () => {
+  const plan = combinedCasePlan();
+  const sections = buildRerunPlanTextSections(plan);
+  assert.equal(sections.length, 2);
+  // Recovery-refresh section prints first (matches idd-ci.instructions.md
+  // §Rerun mechanics' documented recovery order for this scenario: rerun
+  // the already-passing non-bot instance first, and only fall back to the
+  // bot-triggered sequential reruns if that alone doesn't clear the
+  // rollup).
+  assert.match(sections[0] ?? '', /recovery-refresh option/);
+  assert.doesNotMatch(sections[0] ?? '', /No rerun-eligible instances/);
+  assert.match(sections[0] ?? '', /gh run rerun 7002/);
+  assert.match(sections[1] ?? '', /^Sequential recovery plan/);
+  assert.match(sections[1] ?? '', /gh run rerun 7004/);
+});
+
+test('buildRerunPlanTextSections: returns no sections when both plan and recoveryRefreshPlan are empty', () => {
+  const plan = computeRerunPlan(
+    baseInput({ instances: [baseInstance({ conclusion: 'success' })] }),
+    baseOptions(),
+  );
+  assert.deepEqual(buildRerunPlanTextSections(plan), []);
 });
 
 // --- Empty case -----------------------------------------------------------


### PR DESCRIPTION
# Summary

The `rerun-advisory-convergence.mjs` CLI's stderr summary treated
`plan.plan` and `plan.recoveryRefreshPlan` as mutually exclusive
(`if`/`else if`). Issue #1745 made it possible for both arrays to be
non-empty at once (a bot-triggered rerun-eligible instance, e.g. a
`CANCELLED` sibling, populates `plan`, while a still-genuinely-gated
`action_required` sibling independently populates `recoveryRefreshPlan`
in the same batch). The JSON document already carried both arrays
correctly, but the human-readable stderr summary an operator actually
follows only ever printed one section, silently dropping the
recovery-refresh command whenever a rerun-eligible instance also
existed.

- Print both sections independently through a new
  `buildRerunPlanTextSections` helper (recovery-refresh section prints
  first when both are present, matching `idd-ci.instructions.md`
  §Rerun mechanics' documented recovery order: rerun the already-passing
  non-bot instance first, and only fall back to the sequential
  bot-triggered reruns if that alone doesn't clear the rollup).
- Reword the recovery-refresh header (new `describeRecoveryRefreshHeader`
  helper) and the `RECOVERY_REFRESH_CAVEAT` constant so neither asserts
  "no rerun-eligible instances" when that's false.
- Sync `docs/idd-helper-scripts.md`'s own copy of the same now-outdated
  claim, and its `idd-template/docs/idd-helper-scripts.md` mirror (kept
  byte-identical by an existing test).
- Add regression tests covering the sole-sequential-plan, sole-recovery-refresh,
  and combined cases for both new helpers.

## Linked issue

Closes #1752

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Post-merge Codex review on PR #1749 (issue #1745) flagged this as a
follow-up. The bug mirrors a prior, already-fixed instance of the same
exclusive-branching pattern in this file (`rerunPolicyHoldNotice`,
documented at its own call site, from issue #1434's Copilot review).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
