### PR TITLE
chore(ci): close five workflow hardening gaps

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -311,11 +311,18 @@ Before any mutating action in F3, apply the
    **Duplicate-success-record skip rule**: before posting any evidence
    comment below, skip it if the PR already carries a
    `<!-- idd-cleanup-evidence:` comment recording a successful outcome
-   (`applied` or `clean`) — for example one the `post-merge-cleanup`
-   workflow posted within seconds of the merge — to avoid a duplicate
-   success record; otherwise post (a fresh success record, or a
-   correction of an existing `failed` / `incomplete` /
-   `permission-blocked` record).
+   (`applied` or `clean`) **whose author is a trusted marker actor**
+   (`github-actions[bot]`, the identity `post-merge-cleanup.yml` posts
+   under, or a configured `trustedMarkerActors` login) — for example one
+   the `post-merge-cleanup` workflow posted within seconds of the merge —
+   to avoid a duplicate success record. An untrusted commenter's
+   marker-prefixed comment never counts as evidence and must not suppress
+   this post — the same trust-scoping every other IDD operational marker
+   already applies (see the shared
+   [Trusted marker actors](idd-overview-core.instructions.md#trusted-marker-actors)
+   rule). Otherwise post (a fresh success record, or a correction of an
+   existing `failed` / `incomplete` / `permission-blocked` record, or a
+   correction of an untrusted-author record).
 
    Evaluate the dry-run `status` field (this is a dry-run status; apply
    mode emits different values and is never invoked unless dry-run

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -250,4 +250,10 @@ jobs:
       - name: Run advisory-convergence verdict (--assert)
         env:
           GH_TOKEN: ${{ github.token }}
-        run: node scripts/advisory-convergence.mjs --pr ${{ github.event.pull_request.number || inputs.pr_number }} --assert
+          # workflow_dispatch's `pr_number` input is `type: number` in the
+          # UI, but that constraint is not strictly enforced for direct API
+          # dispatches, so route it through env: and reference it as a
+          # quoted shell variable rather than interpolating the `${{ }}`
+          # expression directly into the run: script.
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: node scripts/advisory-convergence.mjs --pr "$PR_NUMBER" --assert

--- a/.github/workflows/idd-doctor.yml
+++ b/.github/workflows/idd-doctor.yml
@@ -37,5 +37,30 @@ jobs:
           fetch-depth: 0
           # Read-only health check: no need to persist the token in git config.
           persist-credentials: false
+      - name: Assert Node.js floor
+        run: |
+          # This required-check workflow relies on the runner's
+          # preinstalled Node. idd-doctor.mjs's `if (import.meta.main)`
+          # entry guard is silently falsy (not an error) on Node
+          # 24.0.x/24.1.x (#1447), which would make this check pass
+          # having checked nothing. Matches lint.yml's and
+          # idd-advisory-convergence.yml's own Node-floor guard. Exact
+          # match to package.json's engines.node (^22.22.2 || >=24.2.0),
+          # including the patch/minor digits, so the error message's
+          # claimed range is actually what the check enforces.
+          node -e '
+            const [major, minor, patch] = process.versions.node.split(".").map(Number);
+            const ok =
+              (major === 22 && (minor > 22 || (minor === 22 && patch >= 2))) ||
+              (major === 24 && minor >= 2) ||
+              major > 24;
+            if (!ok) {
+              console.error(
+                "Node " + process.version + " does not satisfy this " +
+                "repository'"'"'s engines.node range (^22.22.2 || >=24.2.0).",
+              );
+              process.exit(1);
+            }
+          '
       - name: Run idd-doctor repository-health check
         run: node scripts/idd-doctor.mjs

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -146,6 +146,15 @@ jobs:
               echo 'github-actions[bot]'
             } | tr '[:upper:]' '[:lower:]'
           )
+          # Capture into a variable (not process substitution): a failure
+          # inside `< <(gh api ...)` does not reliably propagate to this
+          # shell's default `-e`/`pipefail`, which could leave EXISTING
+          # empty and post a duplicate evidence comment on a transient
+          # `gh api` failure (rate limit/network). A plain command
+          # substitution assignment does trip `-e` on failure.
+          COMMENTS_TSV=$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login] | @tsv')
           EXISTING=""
           while IFS=$'\t' read -r candidate_id candidate_login; do
             [ -z "$candidate_id" ] && continue
@@ -154,9 +163,7 @@ jobs:
               EXISTING="$candidate_id"
               break
             fi
-          done < <(gh api --paginate \
-            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login] | @tsv')
+          done <<< "$COMMENTS_TSV"
           if [ -n "$EXISTING" ]; then
             echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment (id: ${EXISTING}); skipping workflow post."
             exit 0

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -14,8 +14,10 @@
 #   - No PR-head code, workflow, or action is ever executed: the only
 #     script that runs is this repository's own tracked
 #     `scripts/audit-pr-cleanup.mjs`, invoked with the PR number as inert
-#     numeric data (interpolated into a single-quoted shell variable, not
-#     evaluated).
+#     numeric data. The `pr_number` value (a `workflow_dispatch` number
+#     input, not strictly enforced as numeric for direct API dispatches)
+#     is passed through `env:` and referenced as a quoted shell variable,
+#     never interpolated directly into a `run:` script.
 #   - The `cleanup` job only runs when
 #     `github.event.pull_request.merged == true`, or via an explicit,
 #     human-triggered `workflow_dispatch` -- never against an open or
@@ -63,9 +65,14 @@ jobs:
         id: cleanup
         env:
           GH_TOKEN: ${{ github.token }}
+          # workflow_dispatch's `pr_number` input is `type: number` in the
+          # UI, but that constraint is not strictly enforced for direct API
+          # dispatches, so route it through env: and reference it as a
+          # quoted shell variable rather than interpolating the `${{ }}`
+          # expression directly into the run: script.
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
         run: |
           set +e
-          PR_NUMBER='${{ github.event.pull_request.number || github.event.inputs.pr_number }}'
           if [ -z "$PR_NUMBER" ]; then
             echo "::error::PR_NUMBER is empty"
             exit 1
@@ -124,14 +131,34 @@ jobs:
           # only serialises this workflow's own runs; an agent F4 (or a
           # maintainer rerunning workflow_dispatch on the same PR) can
           # still have posted an evidence comment outside this run. Skip
-          # if any <!-- idd-cleanup-evidence: ... --> comment is already
-          # on the PR.
-          EXISTING=$(gh api --paginate \
+          # if a <!-- idd-cleanup-evidence: ... --> comment already on the
+          # PR was posted by a trusted author -- this workflow's own posts
+          # are authored by `github-actions[bot]` (the GITHUB_TOKEN actor),
+          # and an agent's local F4 post is authored by a configured
+          # `trustedMarkerActors` login. An untrusted commenter pre-posting
+          # this marker prefix must never suppress the genuine evidence
+          # post or be treated as a completed cleanup record (this is the
+          # same trust-scoping every other IDD operational marker already
+          # applies).
+          TRUSTED_LOGINS=$(
+            {
+              jq -r '(.trustedMarkerActors // [])[]' .github/idd/config.json 2>/dev/null
+              echo 'github-actions[bot]'
+            } | tr '[:upper:]' '[:lower:]'
+          )
+          EXISTING=""
+          while IFS=$'\t' read -r candidate_id candidate_login; do
+            [ -z "$candidate_id" ] && continue
+            lower_login=$(printf '%s' "$candidate_login" | tr '[:upper:]' '[:lower:]')
+            if printf '%s\n' "$TRUSTED_LOGINS" | grep -Fxq "$lower_login"; then
+              EXISTING="$candidate_id"
+              break
+            fi
+          done < <(gh api --paginate \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | .id' \
-            | head -n1)
+            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login] | @tsv')
           if [ -n "$EXISTING" ]; then
-            echo "::notice::PR #${PR_NUMBER} already has an idd-cleanup-evidence comment (id: ${EXISTING}); skipping workflow post."
+            echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment (id: ${EXISTING}); skipping workflow post."
             exit 0
           fi
           BODY=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \

--- a/.github/workflows/strip-untrusted-labels.yml
+++ b/.github/workflows/strip-untrusted-labels.yml
@@ -1,43 +1,68 @@
-# Trust model: this workflow triggers on `issues: labeled`, which fires once
-# per label application and carries both `label.name` and `sender.login` (the
-# actor who applied that specific label) in the event payload -- no extra API
+# Trust model: this workflow triggers on `issues: labeled` and
+# `pull_request_target: labeled`, which each fire once per label
+# application and carry both `label.name` and `sender.login` (the actor
+# who applied that specific label) in the event payload -- no extra API
 # call is needed to attribute the mutation to an actor.
+#   - `pull_request_target`, not `pull_request`, for the PR branch: this
+#     is a public repository, so a label applied to a fork-originated PR
+#     is a realistic case, and a `pull_request`-triggered workflow gets an
+#     automatically read-only `GITHUB_TOKEN` for fork PRs regardless of
+#     the declared `permissions:` block below -- the label-removal call
+#     would silently 403 with no visible failure. `pull_request_target`
+#     grants the base-repository token scopes declared below regardless
+#     of fork origin. This is safe here for the same reason it is safe in
+#     `post-merge-cleanup.yml`: no repository content is ever checked out
+#     (see below), so there is no PR-supplied workflow or code to run
+#     with the elevated token.
 #   - The job runs only when BOTH hold for this one event:
-#     `github.event.sender.login` equals `coderabbitai[bot]` (the actor that
-#     applied *this* label, confirmed via the REST simple-user object's
-#     `login` + `type: Bot` fields directly on `sender` -- not the
-#     GraphQL-rendered login some `gh` read paths shorten), AND
-#     `github.event.label.name` is a reserved IDD
-#     operational label: the exact `roadmap` label, or any label whose name
-#     starts with `status:`.
+#     `github.event.sender.login` is one of the repository's configured
+#     advisory-bot logins (`.github/idd/config.json` `advisoryBotLogins`;
+#     currently `coderabbitai[bot]` and `chatgpt-codex-connector[bot]` --
+#     keep this hardcoded list in sync with that config array if it ever
+#     changes, confirmed via the REST simple-user object's `login` +
+#     `type: Bot` fields directly on `sender` -- not the GraphQL-rendered
+#     login some `gh` read paths shorten), AND `github.event.label.name` is
+#     a reserved IDD operational label: the exact `roadmap` label, or any
+#     label whose name starts with `status:`. The list is hardcoded rather
+#     than read from the config file because the `if:` condition evaluates
+#     before any step runs, and this workflow deliberately never checks out
+#     repository content (see below).
 #   - This is fail-safe by construction against ever re-fighting a human: a
 #     human re-adding the same label afterward is a *separate* `labeled`
-#     event whose `sender.login` is the human, not `coderabbitai[bot]`, so
-#     the condition above does not match and the human's re-add is left
-#     untouched. The guard never diffs current label state against a human
-#     decision -- it only ever reacts to the one label-add event it already
-#     fail-closed-matched by actor and label name.
+#     event whose `sender.login` is the human, not a configured advisory
+#     bot, so the condition above does not match and the human's re-add is
+#     left untouched. The guard never diffs current label state against a
+#     human decision -- it only ever reacts to the one label-add event it
+#     already fail-closed-matched by actor and label name.
 #   - No repository content is checked out (this job never runs
-#     `actions/checkout`) and no code from the issue body, comments, or
+#     `actions/checkout`) and no code from the issue/PR body, comments, or
 #     label metadata is executed. The job's only action is a single `gh`
 #     call that removes one already-known label from one already-known
-#     issue via the REST API; both values come from the trusted event
-#     payload and are passed through environment variables, never
-#     interpolated directly into a shell command string.
-#   - `permissions:` stays least-privilege: `issues: write` only -- no
-#     `contents`, `pull-requests`, or other elevated scopes.
+#     issue or pull request via the REST/GraphQL API; both values come
+#     from the trusted event payload and are passed through environment
+#     variables, never interpolated directly into a shell command string.
+#   - `permissions:` stays least-privilege: `issues: write` and
+#     `pull-requests: write` only -- no `contents` or other elevated
+#     scopes. `pull-requests: write` is required for the PR branch (`gh pr
+#     edit --remove-label` uses the PullRequest GraphQL type, distinct
+#     from the Issues-scoped REST path `gh issue edit` uses for the issue
+#     branch), in addition to `issues: write` for the issue branch.
 # If a future change widens the trigger, adds repository checkout, executes
-# issue-supplied content, or broadens `permissions:`, re-review this trust
-# model before merging that change.
+# issue/PR-supplied content, or broadens `permissions:`, re-review this
+# trust model before merging that change.
 name: Strip untrusted reserved IDD labels
 on:
   issues:
     types:
       - labeled
+  pull_request_target:
+    types:
+      - labeled
 permissions:
   issues: write
+  pull-requests: write
 concurrency:
-  group: strip-untrusted-labels-${{ github.event.issue.number }}-${{ github.event.label.name }}
+  group: strip-untrusted-labels-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event.label.name }}
   cancel-in-progress: true
 jobs:
   strip-label:
@@ -46,17 +71,25 @@ jobs:
     # `status:blocked-by-human`; the prefix match also covers any future
     # `status:*` label without needing to edit this condition).
     if: |-
-      github.event.sender.login == 'coderabbitai[bot]' && (github.event.label.name == 'roadmap' || startsWith(github.event.label.name, 'status:'))
+      contains(fromJSON('["coderabbitai[bot]", "chatgpt-codex-connector[bot]"]'), github.event.sender.login) && (github.event.label.name == 'roadmap' || startsWith(github.event.label.name, 'status:'))
     runs-on: ubuntu-slim
-    # A single `gh issue edit` REST call; observed comparable single-call
-    # jobs in this repository complete in well under a minute. 5 min bounds
-    # a pathological hang with generous headroom.
+    # A single `gh issue edit`/`gh pr edit` REST/GraphQL call; observed
+    # comparable single-call jobs in this repository complete in well
+    # under a minute. 5 min bounds a pathological hang with generous
+    # headroom.
     timeout-minutes: 5
     steps:
-      - name: Remove reserved label applied by CodeRabbit
+      - name: Remove reserved label applied by an advisory bot
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           LABEL_NAME: ${{ github.event.label.name }}
         run: |
-          gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "$LABEL_NAME"
+          # GITHUB_EVENT_NAME is one of the default environment variables
+          # GitHub Actions sets for every step -- no need to declare it above.
+          if [ "$GITHUB_EVENT_NAME" = "pull_request_target" ]; then
+            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "$LABEL_NAME"
+          else
+            gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "$LABEL_NAME"
+          fi

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -158,11 +158,15 @@ canonical, mandatory contract. The server-side workflow is a
 backstop, not a replacement: same helper, same candidate rules,
 same evidence comment shape, non-blocking on errors. Double-posting is
 prevented by the cleanup-evidence record itself, not by Actions
-concurrency: the workflow skips when any `<!-- idd-cleanup-evidence:`
-comment already exists, and the agent F4 step skips its own post when a
-prior success record is already present — including the one the workflow
-posted. The workflow's PR-keyed `concurrency` group only serializes
-workflow runs against each other; it does not gate the agent's local F4.
+concurrency: the workflow skips when a trusted-author
+`<!-- idd-cleanup-evidence:` comment already exists (posted by
+`github-actions[bot]` or a configured `trustedMarkerActors` login — an
+untrusted commenter's marker-prefixed comment never counts), and the
+agent F4 step skips its own post under the same trusted-author rule when
+a prior success record is already present — including the one the
+workflow posted. The workflow's PR-keyed `concurrency` group only
+serializes workflow runs against each other; it does not gate the
+agent's local F4.
 
 ## GitHub mechanism
 

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -306,11 +306,18 @@ Before any mutating action in F3, apply the
    **Duplicate-success-record skip rule**: before posting any evidence
    comment below, skip it if the PR already carries a
    `<!-- idd-cleanup-evidence:` comment recording a successful outcome
-   (`applied` or `clean`) — for example one the `post-merge-cleanup`
-   workflow posted within seconds of the merge — to avoid a duplicate
-   success record; otherwise post (a fresh success record, or a
-   correction of an existing `failed` / `incomplete` /
-   `permission-blocked` record).
+   (`applied` or `clean`) **whose author is a trusted marker actor**
+   (`github-actions[bot]`, the identity `post-merge-cleanup.yml` posts
+   under, or a configured `trustedMarkerActors` login) — for example one
+   the `post-merge-cleanup` workflow posted within seconds of the merge —
+   to avoid a duplicate success record. An untrusted commenter's
+   marker-prefixed comment never counts as evidence and must not suppress
+   this post — the same trust-scoping every other IDD operational marker
+   already applies (see the shared
+   [Trusted marker actors](idd-overview-core.instructions.md#trusted-marker-actors)
+   rule). Otherwise post (a fresh success record, or a correction of an
+   existing `failed` / `incomplete` / `permission-blocked` record, or a
+   correction of an untrusted-author record).
 
    Evaluate the dry-run `status` field (this is a dry-run status; apply
    mode emits different values and is never invoked unless dry-run

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -15,6 +15,14 @@ name: IDD advisory-convergence gate
 # `ubuntu-latest` + `@v4` forms rather than a repository-specific
 # pinned SHA or custom runner label, unlike this source repository's
 # own dogfooded copy at .github/workflows/idd-advisory-convergence.yml.
+concurrency:
+  cancel-in-progress: true
+  # Grouped by PR number, not github.ref: pull_request_review and
+  # pull_request_review_comment are not pull_request-family events, so
+  # github.ref does not resolve the same way for them as it does for a
+  # pull_request-only workflow. workflow_dispatch has no pull_request
+  # context either, so it falls back to its own input.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -35,6 +43,10 @@ permissions:
 jobs:
   idd-advisory-convergence:
     runs-on: ubuntu-latest
+    # Bounds pathological hangs; adjust to your own observed run duration
+    # once you have history (see idd-doctor.yml/lint.yml in the source
+    # repository for the pattern of sizing this from real run durations).
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -61,4 +73,10 @@ jobs:
           node-version: 24.x
       - env:
           GH_TOKEN: ${{ github.token }}
-        run: node scripts/advisory-convergence.mjs --pr ${{ github.event.pull_request.number || inputs.pr_number }} --assert
+          # workflow_dispatch's `pr_number` input is `type: number` in the
+          # UI, but that constraint is not strictly enforced for direct API
+          # dispatches, so route it through env: and reference it as a
+          # quoted shell variable rather than interpolating the `${{ }}`
+          # expression directly into the run: script.
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: node scripts/advisory-convergence.mjs --pr "$PR_NUMBER" --assert

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -158,11 +158,15 @@ canonical, mandatory contract. The server-side workflow is a
 backstop, not a replacement: same helper, same candidate rules,
 same evidence comment shape, non-blocking on errors. Double-posting is
 prevented by the cleanup-evidence record itself, not by Actions
-concurrency: the workflow skips when any `<!-- idd-cleanup-evidence:`
-comment already exists, and the agent F4 step skips its own post when a
-prior success record is already present — including the one the workflow
-posted. The workflow's PR-keyed `concurrency` group only serializes
-workflow runs against each other; it does not gate the agent's local F4.
+concurrency: the workflow skips when a trusted-author
+`<!-- idd-cleanup-evidence:` comment already exists (posted by
+`github-actions[bot]` or a configured `trustedMarkerActors` login — an
+untrusted commenter's marker-prefixed comment never counts), and the
+agent F4 step skips its own post under the same trusted-author rule when
+a prior success record is already present — including the one the
+workflow posted. The workflow's PR-keyed `concurrency` group only
+serializes workflow runs against each other; it does not gate the
+agent's local F4.
 
 ## GitHub mechanism
 

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -18,6 +18,7 @@ import {
   POLICY_DEFAULTS,
   parseProjectCommandRows,
 } from './policy-helpers.mjs';
+import { resolveTrustedMarkerActors } from './protocol-helpers.mjs';
 import { loadJson, validate } from './validate-schemas.mjs';
 
 const WORKSHOP_ENTRY_POINTS = ['README.md', 'README.ja.md', 'docs/index.md'];
@@ -1616,6 +1617,32 @@ export function formatCleanupBacklogRemediation(profile) {
   }
   return `Remediation: ${docsClause} or run \`${command} ${CLEANUP_BACKLOG_REMEDIATION_ARGS}\`.`;
 }
+/**
+ * Trusted authors for `<!-- idd-cleanup-evidence: ... -->` comments: the
+ * repository's configured `trustedMarkerActors` (`.github/idd/config.json`)
+ * plus `github-actions[bot]`, the identity `post-merge-cleanup.yml` posts
+ * under via `GITHUB_TOKEN`. Any commenter outside this set can pre-post the
+ * marker prefix on a public repo, so an untrusted-author match must never
+ * count as genuine cleanup evidence -- the same trust-scoping every other
+ * IDD operational marker already applies. Fails closed to
+ * `github-actions[bot]` alone (config unreadable/malformed never widens
+ * trust).
+ */
+function readCleanupEvidenceTrustedLogins(root) {
+  let trustedMarkerActors;
+  try {
+    const config = JSON.parse(
+      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
+    );
+    trustedMarkerActors = config?.trustedMarkerActors;
+  } catch {
+    trustedMarkerActors = undefined;
+  }
+  const { actors } = resolveTrustedMarkerActors({
+    config: { trustedMarkerActors },
+  });
+  return new Set([...actors, 'github-actions[bot]']);
+}
 function checkPostMergeCleanupBacklog(root, options, report) {
   const windowDays = options.windowDays;
   const warnThreshold = options.warnThreshold;
@@ -1700,6 +1727,7 @@ function checkPostMergeCleanupBacklog(root, options, report) {
   emitCleanupBacklogProgress(
     formatCleanupBacklogScanPreamble(mergedPrs.length),
   );
+  const trustedLogins = readCleanupEvidenceTrustedLogins(root);
   const missing = [];
   const evidenceFailures = [];
   let scanned = 0;
@@ -1719,7 +1747,7 @@ function checkPostMergeCleanupBacklog(root, options, report) {
         '--paginate',
         `repos/${owner}/${repo}/issues/${number}/comments`,
         '--jq',
-        '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | .id',
+        '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login] | @tsv',
       ],
       root,
     );
@@ -1727,11 +1755,26 @@ function checkPostMergeCleanupBacklog(root, options, report) {
       evidenceFailures.push(number);
       continue;
     }
-    const matchLines = String(evidence.stdout)
+    // Only a trusted-author match counts as genuine cleanup evidence (see
+    // readCleanupEvidenceTrustedLogins) -- an untrusted commenter's
+    // pre-posted marker-prefixed comment must not suppress this backlog
+    // warning.
+    const hasTrustedEvidence = String(evidence.stdout)
       .split(/\r?\n/)
       .map((line) => line.trim())
-      .filter((line) => line.length > 0);
-    if (matchLines.length === 0) {
+      .filter((line) => line.length > 0)
+      .some((line) => {
+        const tabIndex = line.indexOf('\t');
+        if (tabIndex === -1) {
+          return false;
+        }
+        const login = line
+          .slice(tabIndex + 1)
+          .trim()
+          .toLowerCase();
+        return trustedLogins.has(login);
+      });
+    if (!hasTrustedEvidence) {
       missing.push(number);
     }
   }

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -19,6 +19,7 @@ import {
   POLICY_DEFAULTS,
   parseProjectCommandRows,
 } from './policy-helpers.mts';
+import { resolveTrustedMarkerActors } from './protocol-helpers.mts';
 import { loadJson, validate } from './validate-schemas.mts';
 
 const WORKSHOP_ENTRY_POINTS = ['README.md', 'README.ja.md', 'docs/index.md'];
@@ -1902,6 +1903,33 @@ export function formatCleanupBacklogRemediation(profile: string): string {
   return `Remediation: ${docsClause} or run \`${command} ${CLEANUP_BACKLOG_REMEDIATION_ARGS}\`.`;
 }
 
+/**
+ * Trusted authors for `<!-- idd-cleanup-evidence: ... -->` comments: the
+ * repository's configured `trustedMarkerActors` (`.github/idd/config.json`)
+ * plus `github-actions[bot]`, the identity `post-merge-cleanup.yml` posts
+ * under via `GITHUB_TOKEN`. Any commenter outside this set can pre-post the
+ * marker prefix on a public repo, so an untrusted-author match must never
+ * count as genuine cleanup evidence -- the same trust-scoping every other
+ * IDD operational marker already applies. Fails closed to
+ * `github-actions[bot]` alone (config unreadable/malformed never widens
+ * trust).
+ */
+function readCleanupEvidenceTrustedLogins(root: string): Set<string> {
+  let trustedMarkerActors: unknown;
+  try {
+    const config = JSON.parse(
+      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
+    ) as { trustedMarkerActors?: unknown } | null;
+    trustedMarkerActors = config?.trustedMarkerActors;
+  } catch {
+    trustedMarkerActors = undefined;
+  }
+  const { actors } = resolveTrustedMarkerActors({
+    config: { trustedMarkerActors },
+  });
+  return new Set([...actors, 'github-actions[bot]']);
+}
+
 function checkPostMergeCleanupBacklog(
   root: string,
   options: {
@@ -2000,6 +2028,7 @@ function checkPostMergeCleanupBacklog(
     formatCleanupBacklogScanPreamble(mergedPrs.length),
   );
 
+  const trustedLogins = readCleanupEvidenceTrustedLogins(root);
   const missing: number[] = [];
   const evidenceFailures: number[] = [];
   let scanned = 0;
@@ -2023,7 +2052,7 @@ function checkPostMergeCleanupBacklog(
         '--paginate',
         `repos/${owner}/${repo}/issues/${number}/comments`,
         '--jq',
-        '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | .id',
+        '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login] | @tsv',
       ],
       root,
     );
@@ -2031,11 +2060,26 @@ function checkPostMergeCleanupBacklog(
       evidenceFailures.push(number as number);
       continue;
     }
-    const matchLines = String(evidence.stdout)
+    // Only a trusted-author match counts as genuine cleanup evidence (see
+    // readCleanupEvidenceTrustedLogins) -- an untrusted commenter's
+    // pre-posted marker-prefixed comment must not suppress this backlog
+    // warning.
+    const hasTrustedEvidence = String(evidence.stdout)
       .split(/\r?\n/)
       .map((line) => line.trim())
-      .filter((line) => line.length > 0);
-    if (matchLines.length === 0) {
+      .filter((line) => line.length > 0)
+      .some((line) => {
+        const tabIndex = line.indexOf('\t');
+        if (tabIndex === -1) {
+          return false;
+        }
+        const login = line
+          .slice(tabIndex + 1)
+          .trim()
+          .toLowerCase();
+        return trustedLogins.has(login);
+      });
+    if (!hasTrustedEvidence) {
       missing.push(number as number);
     }
   }


### PR DESCRIPTION
# Summary

Close five small, independent hardening gaps a security-focused audit
found in `.github/workflows/` (and their `idd-template/` mirrors where
a mirror exists):

1. `idd-doctor.yml` lacked the #1447 Node-floor guard `lint.yml` and
   `idd-advisory-convergence.yml` already carry. Added the same guard.
2. `strip-untrusted-labels.yml` only matched `coderabbitai[bot]` on
   `issues: labeled`. It now matches the full configured advisory-bot
   set (`coderabbitai[bot]`, `chatgpt-codex-connector[bot]`) and adds
   a `pull_request_target: labeled` trigger (`pull_request_target`,
   not `pull_request`: this is a public repo, so a fork-originated PR
   would otherwise get a silently read-only `GITHUB_TOKEN` and 403 on
   removal).
3. `workflow_dispatch` number inputs
   (`idd-advisory-convergence.yml`, `post-merge-cleanup.yml`, and the
   `idd-template` convergence mirror) were interpolated directly into
   `run:` blocks; `type: number` is UI-enforced only, not for direct
   API dispatches. Routed through `env:` and referenced as quoted
   shell variables instead.
4. The F4 cleanup-evidence marker was forgeable: any commenter could
   pre-post a `<!-- idd-cleanup-evidence:` comment to suppress the
   genuine evidence post and plant forged counts. `idd-doctor`'s
   cleanup-backlog scan and `idd-merge.instructions.md`'s
   duplicate-success-record rule both consumed marker *presence*
   without checking authorship too. Scoped dedup/consumption in all
   three to trusted authors (`github-actions[bot]` and configured
   `trustedMarkerActors`), matching every other IDD operational
   marker.
5. The `idd-template` convergence workflow shipped with no
   `timeout-minutes` and no `concurrency` group, so an adopter's copy
   would inherit the 360-minute default timeout with no debouncing.
   Added both; kept the documented floating-tag portability choice
   untouched.

## Linked issue

Closes #1691

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Refs: 2026-07-28 fresh-model audit; #1447 (Node-floor incident class).

Item 4 turned out to span three consumers of the same marker, not
just the workflow: `post-merge-cleanup.yml`'s dedup-skip check,
`idd-doctor.mts`'s cleanup-backlog evidence scan
(`checkPostMergeCleanupBacklog`, regenerated to `scripts/idd-doctor.mjs`
via `pnpm run build`), and the F4 "Duplicate-success-record skip rule"
in `idd-merge.instructions.md` (edited at its canonical
`idd-template/` source, then `node scripts/sync-docs.mjs --apply`).
All three now require the marker's author to be `github-actions[bot]`
or a configured `trustedMarkerActors` login.

For item 2, `strip-untrusted-labels.yml`'s advisory-bot login list is
hardcoded (with a keep-in-sync comment against
`.github/idd/config.json`'s `advisoryBotLogins`) rather than read from
config at runtime, because the `if:` condition evaluates before any
step runs and this workflow deliberately never checks out repository
content.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (ran the constituent `pre-push-validate` commands:
      `biome check`, `dprint check`, `markdownlint-cli2`, `cspell
      lint`)
- [x] `pnpm test` (`node --test tests/*.test.mts`: 2771 passed)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`node scripts/sync-docs.mjs --apply`
      run; `audit-docs.mjs --check` confirms mirrors are in sync)
- [x] `node scripts/idd-doctor.mjs` (passed with only pre-existing,
      unrelated warnings)
- [x] `actionlint` against every modified workflow file (0 issues)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
