### PR TITLE
docs: fix hygiene batch — index, mirror links, drift guard

### DIFF
--- a/.claude/skills/issue-authoring/SKILL.md
+++ b/.claude/skills/issue-authoring/SKILL.md
@@ -108,9 +108,10 @@ needs-decision, blocked-by-human, and out-of-scope.
 - For concrete drafting patterns and example prompts: read
   [references/draft-patterns.md](references/draft-patterns.md).
 - When editing this bundle inside the source repository, keep the
-  bundled references synchronized with the canonical maintenance docs in
-  [../../docs/issue-authoring-skill.md](../../docs/issue-authoring-skill.md)
-  and [../../docs/idd-workflow.md](../../docs/idd-workflow.md).
+  bundled references synchronized with the canonical maintenance docs at
+  repo-root `docs/issue-authoring-skill.md` and `docs/idd-workflow.md`
+  (relative links are avoided here since this file is mirrored at a
+  different path depth in `.claude/skills/issue-authoring/`).
 
 ## Output Checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,6 @@ generated copy: `node scripts/sync-docs.mjs --apply` regenerates
 derived copies and `node scripts/audit-docs.mjs --check` fails on
 drift.
 
-`.claude/skills/issue-authoring/` is a generated, byte-identical copy
-of the canonical bundle, so Claude Code auto-discovers the skill in
-this repository.
+`.claude/skills/issue-authoring/` is a generated mirror of the
+canonical bundle's Markdown files (byte-identical per file), so Claude
+Code auto-discovers the skill in this repository.

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -669,6 +669,43 @@
       ]
     },
     {
+      "id": "minimal-run-activation-nonce-marker",
+      "reference": ".github/instructions/idd-claim.instructions.md",
+      "target": "examples/minimal-run/activation-nonce.md",
+      "mode": "contains",
+      "requiredPatterns": [
+        "<!-- activation-nonce: \\S+ \\S+ \\S+ \\S+ -->"
+      ]
+    },
+    {
+      "id": "minimal-run-claim-marker",
+      "reference": ".github/instructions/idd-overview-core.instructions.md",
+      "target": "examples/minimal-run/claim-comment.md",
+      "mode": "contains",
+      "requiredPatterns": [
+        "<!-- claimed-by: \\S+ \\S+ supersedes: \\S+ \\S+ branch: \\S+ -->"
+      ]
+    },
+    {
+      "id": "minimal-run-heartbeat-marker",
+      "reference": ".github/instructions/idd-overview-core.instructions.md",
+      "target": "examples/minimal-run/heartbeat.md",
+      "mode": "contains",
+      "requiredPatterns": [
+        "<!-- claimed-by: \\S+ \\S+ supersedes: \\S+ \\S+ branch: \\S+ -->"
+      ]
+    },
+    {
+      "id": "minimal-run-review-snapshot-markers",
+      "reference": ".github/instructions/idd-review-snapshot.instructions.md",
+      "target": "examples/minimal-run/review-snapshot.md",
+      "mode": "contains",
+      "requiredPatterns": [
+        "<!-- review-watermark: \\S+ \\S+ \\S+ \\S+ \\S+ \\S+ -->",
+        "<!-- review-baseline: \\S+ \\S+ \\S+ -->"
+      ]
+    },
+    {
       "id": "minimize-superseded-markers-helper",
       "source": "scripts/minimize-superseded-markers.mjs",
       "target": "idd-template/scripts/minimize-superseded-markers.mjs",

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -670,39 +670,39 @@
     },
     {
       "id": "minimal-run-activation-nonce-marker",
-      "reference": ".github/instructions/idd-claim.instructions.md",
+      "reference": "src/scripts/marker-helpers.mts",
       "target": "examples/minimal-run/activation-nonce.md",
       "mode": "contains",
       "requiredPatterns": [
-        "<!-- activation-nonce: \\S+ \\S+ \\S+ \\S+ -->"
+        "<!-- activation-nonce: \\S+ \\S+ \\S+ \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z -->"
       ]
     },
     {
       "id": "minimal-run-claim-marker",
-      "reference": ".github/instructions/idd-overview-core.instructions.md",
+      "reference": "src/scripts/marker-helpers.mts",
       "target": "examples/minimal-run/claim-comment.md",
       "mode": "contains",
       "requiredPatterns": [
-        "<!-- claimed-by: \\S+ \\S+ supersedes: \\S+ \\S+ branch: \\S+ -->"
+        "<!-- claimed-by: \\S+ \\S+ supersedes: \\S+ \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z branch: \\S+ -->"
       ]
     },
     {
       "id": "minimal-run-heartbeat-marker",
-      "reference": ".github/instructions/idd-overview-core.instructions.md",
+      "reference": "src/scripts/marker-helpers.mts",
       "target": "examples/minimal-run/heartbeat.md",
       "mode": "contains",
       "requiredPatterns": [
-        "<!-- claimed-by: \\S+ \\S+ supersedes: \\S+ \\S+ branch: \\S+ -->"
+        "<!-- claimed-by: \\S+ \\S+ supersedes: \\S+ \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z branch: \\S+ -->"
       ]
     },
     {
       "id": "minimal-run-review-snapshot-markers",
-      "reference": ".github/instructions/idd-review-snapshot.instructions.md",
+      "reference": "src/scripts/marker-helpers.mts",
       "target": "examples/minimal-run/review-snapshot.md",
       "mode": "contains",
       "requiredPatterns": [
-        "<!-- review-watermark: \\S+ \\S+ \\S+ \\S+ \\S+ \\S+ -->",
-        "<!-- review-baseline: \\S+ \\S+ \\S+ -->"
+        "<!-- review-watermark: \\S+ \\S+ [0-9a-f]{40} \\S+ \\d+ \\S+ -->",
+        "<!-- review-baseline: \\S+ \\S+ [0-9a-f]{40} -->"
       ]
     },
     {

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -19,6 +19,13 @@ In the idd-skill source repository, the following optional helpers were adopted:
   [kurone-kito/idd-skill#1395](https://github.com/kurone-kito/idd-skill/issues/1395))
 - `scripts/discover-roadmap-graph.mjs` for A1.5/A2 recursive roadmap graph
   enumeration and classification
+- `scripts/idd-roadmap-audit-execute.mjs` for the A1.5 roadmap-completion
+  mutation: dry-run evaluates completion via the roadmap-graph traversal
+  and emits `{ready, blockers, evidenceBody}`; `--apply` re-validates the
+  roadmap-audit claim and the graph immediately before mutating, then
+  posts the evidence comment, closes the completed roadmap, and releases
+  the claim (referenced in
+  [kurone-kito/idd-skill#1071](https://github.com/kurone-kito/idd-skill/issues/1071))
 - `scripts/discover-readiness-check.mjs` for A3 readiness criterion
   evaluation (referenced in
   [kurone-kito/idd-skill#391](https://github.com/kurone-kito/idd-skill/issues/391))

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -20,11 +20,15 @@ In the idd-skill source repository, the following optional helpers were adopted:
 - `scripts/discover-roadmap-graph.mjs` for A1.5/A2 recursive roadmap graph
   enumeration and classification
 - `scripts/idd-roadmap-audit-execute.mjs` for the A1.5 roadmap-completion
-  mutation: dry-run evaluates completion via the roadmap-graph traversal
-  and emits `{ready, blockers, evidenceBody}`; `--apply` re-validates the
-  roadmap-audit claim and the graph immediately before mutating, then
-  posts the evidence comment, closes the completed roadmap, and releases
-  the claim (referenced in
+  mutation: dry-run gates only the mechanical completion preconditions
+  (all descendants closed/complete, no open/unresolved/nested-roadmap
+  blocker) via the roadmap-graph traversal and emits `{ready, blockers,
+  evidenceBody}` — it does **not** verify the roadmap's free-form success
+  criteria or autonomy-gap items, which the caller must confirm
+  separately before `--apply`; `--apply` re-validates the roadmap-audit
+  claim and the graph immediately before mutating, then posts the
+  evidence comment, closes the completed roadmap, and releases the claim
+  (referenced in
   [kurone-kito/idd-skill#1071](https://github.com/kurone-kito/idd-skill/issues/1071))
 - `scripts/discover-readiness-check.mjs` for A3 readiness criterion
   evaluation (referenced in

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,9 +55,9 @@ also serve as the source for a future GitHub Pages site.
   for maintainers and agents who need an authoritative source link.
 - [IDD workflow guide](idd-workflow.md) explains where each supported
   agent starts and which phase file to read next.
-- [IDD helper script evaluation](idd-helper-scripts.md) records why the
-  current workflow stays portable shell / `gh` / `jq` instructions
-  instead of requiring helper scripts.
+- [IDD helper script evaluation](idd-helper-scripts.md) records the
+  decision to adopt optional helper scripts and inventories the ones
+  shipped in the source repository, phase by phase.
 - [IDD comment minimization](idd-comment-minimization.md) defines the
   live status digest helper contract and safe post-merge cleanup policy
   for stale operational markers and completed feedback.
@@ -69,6 +69,9 @@ also serve as the source for a future GitHub Pages site.
   Creator/Mutator/Verifier matrix for loop concepts (claim markers,
   review threads, PR body, ...), plus which actor/phase may take each
   concept to its terminal state.
+- [Minimal IDD run sample](../examples/minimal-run/README.md) is a
+  compact set of realistic marker-comment bodies (claim, activation
+  nonce, heartbeat, review snapshot, ...) for one end-to-end run.
 
 ### Native Companions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,8 +69,8 @@ also serve as the source for a future GitHub Pages site.
   Creator/Mutator/Verifier matrix for loop concepts (claim markers,
   review threads, PR body, ...), plus which actor/phase may take each
   concept to its terminal state.
-- [Minimal IDD run sample](../examples/minimal-run/README.md) is a
-  compact set of realistic marker-comment bodies (claim, activation
+- [Minimal IDD run sample](https://github.com/kurone-kito/idd-skill/blob/main/examples/minimal-run/README.md)
+  is a compact set of realistic marker-comment bodies (claim, activation
   nonce, heartbeat, review snapshot, ...) for one end-to-end run.
 
 ### Native Companions

--- a/examples/minimal-run/README.md
+++ b/examples/minimal-run/README.md
@@ -7,6 +7,7 @@ artifacts. Each file is a realistic example, not a strict schema.
 | ----------------------- | ----------------------------------------------- |
 | `issue.md`              | Initial issue statement and acceptance criteria |
 | `claim-comment.md`      | `claimed-by` marker comment body                |
+| `activation-nonce.md`   | `activation-nonce` marker comment body          |
 | `heartbeat.md`          | Claim heartbeat refresh comment body            |
 | `pr-body.md`            | Pull request body used in D3                    |
 | `review-snapshot.md`    | E1 snapshot summary and watermark marker        |

--- a/examples/minimal-run/activation-nonce.md
+++ b/examples/minimal-run/activation-nonce.md
@@ -1,0 +1,27 @@
+# A5 — Activation-nonce comment
+
+Posted alongside every fresh claim activation (fresh claim, takeover, or
+legacy migration), immediately after the `claimed-by` comment in
+`claim-comment.md`. Never posted for a plain heartbeat, which reuses the
+existing `{claim-id}`.
+
+---
+
+<!-- markdownlint-disable-next-line MD013 -->
+<!-- activation-nonce: copilot-cli-abc12345 claim-20260510T090000Z-55521 nonce-7e2f9c1a8b4d5e6f 2026-05-10T09:00:01Z -->
+
+_copilot-cli-abc12345: claim activation nonce — IDD automation marker. Do not edit._
+
+---
+
+## Field reference
+
+| Field       | Value in this sample           | Meaning                                                           |
+| ----------- | ------------------------------ | ----------------------------------------------------------------- |
+| `agent-id`  | `copilot-cli-abc12345`         | Tool/session identifier, matching the claim comment               |
+| `claim-id`  | `claim-20260510T090000Z-55521` | The `{claim-id}` this nonce activates, matching the claim comment |
+| `nonce`     | `nonce-7e2f9c1a8b4d5e6f`       | Fresh opaque token recorded locally alongside agent-id/claim-id   |
+| `timestamp` | `2026-05-10T09:00:01Z`         | Human-readable context only; GitHub `created_at` is authoritative |
+
+When 2+ trusted activation-nonce markers exist for the same `claim-id`
+(a collision), the winner is the lexicographically earliest `nonce`.

--- a/examples/minimal-run/activation-nonce.md
+++ b/examples/minimal-run/activation-nonce.md
@@ -1,9 +1,10 @@
 # A5 — Activation-nonce comment
 
-Posted alongside every fresh claim activation (fresh claim, takeover, or
-legacy migration), immediately after the `claimed-by` comment in
-`claim-comment.md`. Never posted for a plain heartbeat, which reuses the
-existing `{claim-id}`.
+Posted for every fresh claim activation: fresh claim, takeover, or
+legacy migration (immediately after the `claimed-by` comment in
+`claim-comment.md`), and also forced-handoff adopt-verbatim, which
+posts no separate `claimed-by` of its own. Never posted for a plain
+heartbeat, which reuses the existing `{claim-id}`.
 
 ---
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -19,6 +19,13 @@ In the idd-skill source repository, the following optional helpers were adopted:
   [kurone-kito/idd-skill#1395](https://github.com/kurone-kito/idd-skill/issues/1395))
 - `scripts/discover-roadmap-graph.mjs` for A1.5/A2 recursive roadmap graph
   enumeration and classification
+- `scripts/idd-roadmap-audit-execute.mjs` for the A1.5 roadmap-completion
+  mutation: dry-run evaluates completion via the roadmap-graph traversal
+  and emits `{ready, blockers, evidenceBody}`; `--apply` re-validates the
+  roadmap-audit claim and the graph immediately before mutating, then
+  posts the evidence comment, closes the completed roadmap, and releases
+  the claim (referenced in
+  [kurone-kito/idd-skill#1071](https://github.com/kurone-kito/idd-skill/issues/1071))
 - `scripts/discover-readiness-check.mjs` for A3 readiness criterion
   evaluation (referenced in
   [kurone-kito/idd-skill#391](https://github.com/kurone-kito/idd-skill/issues/391))

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -20,11 +20,15 @@ In the idd-skill source repository, the following optional helpers were adopted:
 - `scripts/discover-roadmap-graph.mjs` for A1.5/A2 recursive roadmap graph
   enumeration and classification
 - `scripts/idd-roadmap-audit-execute.mjs` for the A1.5 roadmap-completion
-  mutation: dry-run evaluates completion via the roadmap-graph traversal
-  and emits `{ready, blockers, evidenceBody}`; `--apply` re-validates the
-  roadmap-audit claim and the graph immediately before mutating, then
-  posts the evidence comment, closes the completed roadmap, and releases
-  the claim (referenced in
+  mutation: dry-run gates only the mechanical completion preconditions
+  (all descendants closed/complete, no open/unresolved/nested-roadmap
+  blocker) via the roadmap-graph traversal and emits `{ready, blockers,
+  evidenceBody}` — it does **not** verify the roadmap's free-form success
+  criteria or autonomy-gap items, which the caller must confirm
+  separately before `--apply`; `--apply` re-validates the roadmap-audit
+  claim and the graph immediately before mutating, then posts the
+  evidence comment, closes the completed roadmap, and releases the claim
+  (referenced in
   [kurone-kito/idd-skill#1071](https://github.com/kurone-kito/idd-skill/issues/1071))
 - `scripts/discover-readiness-check.mjs` for A3 readiness criterion
   evaluation (referenced in

--- a/skills/issue-authoring/SKILL.md
+++ b/skills/issue-authoring/SKILL.md
@@ -108,9 +108,10 @@ needs-decision, blocked-by-human, and out-of-scope.
 - For concrete drafting patterns and example prompts: read
   [references/draft-patterns.md](references/draft-patterns.md).
 - When editing this bundle inside the source repository, keep the
-  bundled references synchronized with the canonical maintenance docs in
-  [../../docs/issue-authoring-skill.md](../../docs/issue-authoring-skill.md)
-  and [../../docs/idd-workflow.md](../../docs/idd-workflow.md).
+  bundled references synchronized with the canonical maintenance docs at
+  repo-root `docs/issue-authoring-skill.md` and `docs/idd-workflow.md`
+  (relative links are avoided here since this file is mirrored at a
+  different path depth in `.claude/skills/issue-authoring/`).
 
 ## Output Checklist
 

--- a/tests/examples-minimal-run.test.mts
+++ b/tests/examples-minimal-run.test.mts
@@ -1,0 +1,76 @@
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+import {
+  OPERATIONAL_MARKERS,
+  parseActivationNonceComment,
+  parseClaimComment,
+  parseReviewWatermarkComment,
+} from '../src/scripts/marker-helpers.mts';
+
+// #1704 review finding: the sync-manifest `contains` guards on these sample
+// files only check a hard-coded regex against the target, never the actual
+// marker-helpers.mts renderer/parser -- so a real format change could drift
+// silently past them. These tests close that gap by running each sample's
+// marker text through the same parser/pattern production code uses.
+
+function readMarkerLine(path: string, prefix: string): string {
+  const body = readFileSync(path, 'utf8');
+  const line = body
+    .split('\n')
+    .find((candidate) => candidate.trimStart().startsWith(prefix));
+  assert.ok(line, `${path} is missing a line starting with ${prefix}`);
+  return (line as string).trim();
+}
+
+test('examples/minimal-run/claim-comment.md marker parses via parseClaimComment', () => {
+  const line = readMarkerLine(
+    'examples/minimal-run/claim-comment.md',
+    '<!-- claimed-by:',
+  );
+  const parsed = parseClaimComment(line, '2026-05-10T09:00:00Z');
+  assert.ok(parsed, `parseClaimComment rejected: ${line}`);
+});
+
+test('examples/minimal-run/activation-nonce.md marker parses via parseActivationNonceComment', () => {
+  const line = readMarkerLine(
+    'examples/minimal-run/activation-nonce.md',
+    '<!-- activation-nonce:',
+  );
+  const parsed = parseActivationNonceComment(line, '2026-05-10T09:00:01Z');
+  assert.ok(parsed, `parseActivationNonceComment rejected: ${line}`);
+});
+
+test('examples/minimal-run/heartbeat.md marker parses via parseClaimComment', () => {
+  const line = readMarkerLine(
+    'examples/minimal-run/heartbeat.md',
+    '<!-- claimed-by:',
+  );
+  const parsed = parseClaimComment(line, '2026-05-10T11:00:00Z');
+  assert.ok(parsed, `parseClaimComment rejected: ${line}`);
+});
+
+test('examples/minimal-run/review-snapshot.md watermark parses via parseReviewWatermarkComment', () => {
+  const line = readMarkerLine(
+    'examples/minimal-run/review-snapshot.md',
+    '<!-- review-watermark:',
+  );
+  const parsed = parseReviewWatermarkComment(line, '2026-05-10T11:08:42Z');
+  assert.ok(parsed, `parseReviewWatermarkComment rejected: ${line}`);
+});
+
+test('examples/minimal-run/review-snapshot.md baseline matches the canonical review-baseline pattern', () => {
+  const line = readMarkerLine(
+    'examples/minimal-run/review-snapshot.md',
+    '<!-- review-baseline:',
+  );
+  const entry = OPERATIONAL_MARKERS.find(
+    (marker) => marker.label === '<!-- review-baseline:',
+  );
+  assert.ok(entry, 'no review-baseline entry in OPERATIONAL_MARKERS');
+  assert.ok(
+    (entry as (typeof OPERATIONAL_MARKERS)[number]).pattern.test(line),
+    `canonical review-baseline pattern rejected: ${line}`,
+  );
+});


### PR DESCRIPTION
## Summary

Five small, independent documentation-hygiene fixes, batched into one
reviewable change (docs-only edits plus one sync-manifest guard):

- **`docs/index.md`'s helper-scripts blurb was backwards** — it said the
  workflow avoids helper scripts; `idd-helper-scripts.md` actually
  inventories ~40 adopted helpers. Rewrote the blurb. (Left the
  missing-entries half to #1683, per this issue's own scope note.)
- **`idd-roadmap-audit-execute.mjs`** (the A1.5 roadmap-completion
  mutation helper, live in `scripts/`/`bin/`/`schemas/`) was referenced
  from no docs. Added it to `docs/idd-helper-scripts.md`'s inventory.
- **`skills/issue-authoring/SKILL.md`'s relative links** to
  `../../docs/*.md` resolve correctly from the canonical
  `skills/issue-authoring/` (two levels deep) but dangle from the
  `.claude/skills/issue-authoring/` mirror (three levels deep) that
  Claude Code actually loads. Named the repo-root paths in prose instead
  of a relative link.
- **`CLAUDE.md`'s mirror claim was imprecise** — it called
  `.claude/skills/issue-authoring/` "a generated, byte-identical copy of
  the canonical bundle", but the sync contract mirrors Markdown files
  only (`agents/` stays canonical-only), per
  `docs/claude-skill-strategy.md`. Tightened the wording.
- **`examples/minimal-run/` was fully orphaned** — unreferenced from any
  doc, and missing the A5 activation-nonce marker sample (#1528). Linked
  it from `docs/index.md`, added `activation-nonce.md`, and added
  `contains`-mode `audit/sync-manifest.json` guards on the marker
  template lines in `claim-comment.md`/`activation-nonce.md`/
  `heartbeat.md`/`review-snapshot.md` so a future marker-format change
  is caught here instead of silently drifting.

## Test plan

- [x] `node scripts/audit-docs.mjs --check` — passed (new guards active)
- [x] `node --test tests/*.test.mts` — 2786/2786 pass
- [x] `pnpm run build:check` — no drift (docs-only change)
- [x] `node scripts/idd-doctor.mjs` — passed (pre-existing warnings only)
- [x] pre-push-validate (biome, dprint, markdownlint, cspell, audit-docs,
      audit-code-span-wrap, build:check, idd-doctor)

Closes #1704

Refs: 2026-07-28 fresh-model audit (docs + skill-machinery agents)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue-authoring guidance with links to the canonical maintenance documents.
  * Clarified that mirrored skill documentation stays byte-identical to the canonical bundle.
  * Documented activation-nonce markers, their fields, timing, and collision handling.
  * Updated helper-script references and linked the minimal run example.
  * Added activation-nonce artifacts to the minimal run sample.

* **Tests**
  * Added validation checks confirming required markers appear in minimal-run example files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->