### PR TITLE
fix(advisory-convergence): fail closed on IDD-shaped PRs with broken claim linkage and tighten reviewer identity

### DIFF
--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -165,6 +165,47 @@ name: IDD advisory-convergence gate
 # resulting stale display without a config change, so this workflow
 # keeps its current concurrency configuration rather than trading it for
 # an equally-racy alternative.
+#
+# Fail-closed on broken claim linkage under `idd-claimed` scope (#1686):
+# the readiness formula this check enforces
+# (`ready = scopeNotApplicable || converged || (deadline/terminal-passed
+# && waived)`) previously reached `scopeNotApplicable: true` (hence
+# `ready: true` with zero Copilot involvement) via THREE data-level
+# paths the executing session itself controls: (2) a PR closing two
+# actively-claimed issues, where disambiguation fails closed to no
+# resolved claim; (3) a PR head branch that no longer matches the
+# branch recorded on an active trusted claim; and (4) a claim whose
+# marker history is real but no longer resolves active (a stale or
+# released claim). `advisory-convergence.mts`'s `computeAdvisoryConvergenceVerdict`
+# now classifies each of these as `applicability.status: "indeterminate"`
+# instead of `"not_applicable"` -- a third outcome that, unlike
+# `not_applicable`, NEVER satisfies `ready` through the ordinary
+# convergence path; only the pre-existing deadline/terminal-plus-
+# maintainer-waiver escape hatch can still clear it, and for paths 2
+# and 4 no `activeClaimId` exists to bind a waiver to at all (see
+# `summarizeExternalCheckWaivers`'s fail-closed-on-empty-claim-id rule,
+# protocol-helpers.mts), so those two are effectively not waivable in
+# practice -- only path 3 (a real, resolvable active claim) stays
+# genuinely waivable.
+#
+# Known residual, deliberately NOT closed by #1686 (path 1): a PR body
+# that omits or mangles its `Closes #N` reference yields ZERO claim
+# candidates and ZERO claim-marker history for this PR -- indistinguishable,
+# from this check's own evidence, from a genuine external contribution
+# with no linked issue at all. Two candidate signals to force
+# applicability here were considered and rejected: (a) PR-author
+# membership in `trustedMarkerActors` would block a legitimate trusted
+# maintainer's own manual/non-IDD PR, which this scope must not touch;
+# (b) inferring a linked issue from the PR's branch name (e.g.
+# `issue/1234-*`) is itself a signal the executing session fully
+# controls -- it could name the branch anything, so it closes nothing a
+# careless/adversarial session could not simply avoid. No signal outside
+# the session's own control was found for path 1 within this issue's
+# scope; it remains the honor-system layer #1341 already names as
+# insufficient on its own, mitigated only by D3.5's closing-keyword
+# verification (`idd-pr-submit.instructions.md`) catching a missing
+# reference before merge in the ordinary IDD flow, and by CODEOWNERS
+# review as the general backstop for any PR that evades it.
 on:
   pull_request:
     types:

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -250,11 +250,20 @@ durations only; zero-length values and second-based values are invalid.
 Repositories may also customize `advisoryWait.convergenceScope` in
 `.github/idd/config.json`. The default `all-prs` keeps convergence on
 every PR. `idd-claimed` is opt-in and limits convergence to verified
-IDD-owned PRs. Under `idd-claimed`, PRs without a verified linked claim
-resolve to `not_applicable` instead of opening a new waiver path, so
-claimless/manual dependency PRs stay outside the gate. Invalid values
-are rejected by schema, and runtime normalization falls back to
-`all-prs` for untrusted config reads.
+IDD-owned PRs. Under `idd-claimed`, a PR with no verified linked claim
+AND no claim-marker history at all resolves to `not_applicable` instead
+of opening a new waiver path, so genuinely claimless/manual dependency
+PRs stay outside the gate. A PR that DOES carry evidence of IDD claim
+activity but whose claim linkage is currently broken or ambiguous
+(#1686 -- a branch mismatch against an active claim, two or more
+actively-claimed closing references, or a stale/released claim)
+resolves to `indeterminate` instead: this hard-blocks readiness through
+the ordinary convergence path, leaving only the existing
+deadline/terminal-plus-maintainer-waiver escape hatch (see
+`docs/idd-helper-scripts.md`'s `advisoryWait.convergenceScope` entry
+for the exact per-case waiver availability). Invalid values are
+rejected by schema, and runtime normalization falls back to `all-prs`
+for untrusted config reads.
 
 `advisoryWait.primaryBotLogin` selects the advisory bot whose review the
 advisory-wait gate tracks (default Copilot), and

--- a/docs/idd-advisory-wait-shell-fallback.md
+++ b/docs/idd-advisory-wait-shell-fallback.md
@@ -23,13 +23,13 @@ REPO=$(gh repo view --json name --jq '.name')
 LAST_COPILOT_COMMIT=$(
   gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/reviews" \
     --paginate \
-    --jq '.[] | select(.user.login | startswith("copilot-pull-request-reviewer")) |
+    --jq '.[] | select(.user.login == "copilot-pull-request-reviewer" or .user.login == "copilot-pull-request-reviewer[bot]") |
                {sa: .submitted_at, cid: .commit_id}' \
   | jq -rs 'sort_by(.sa) | last | .cid // ""'
 )
 
 COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
-  --jq '.users | any(.login == "Copilot" or (.login | startswith("copilot-pull-request-reviewer")))')
+  --jq '.users | any(.login == "Copilot" or .login == "copilot-pull-request-reviewer" or .login == "copilot-pull-request-reviewer[bot]")')
 
 COPILOT_PENDING_COVERS_HEAD=$(
   gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/timeline" \
@@ -44,7 +44,9 @@ COPILOT_PENDING_COVERS_HEAD=$(
         | (map(select(.value.event == "review_requested"
              and (((.value.requested_reviewer.login // "") == "Copilot")
                   or ((.value.requested_reviewer.login // "")
-                      | startswith("copilot-pull-request-reviewer")))))
+                      == "copilot-pull-request-reviewer")
+                  or ((.value.requested_reviewer.login // "")
+                      == "copilot-pull-request-reviewer[bot]"))))
            | last | .key // null) as $request_index
         | ($head_index != null and $request_index != null and
            $request_index > $head_index)

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1544,14 +1544,31 @@ to post it is the consuming track's job.
   applies to every PR or only verified IDD-owned PRs. The default
   `all-prs` keeps the helper applicable everywhere. `idd-claimed`
   narrows it so a verified linked claim with a matching PR head branch
-  is `applicable`; a verified linked claim with a branch mismatch is
-  `not_applicable`; a verified linked claim still stays `applicable`
-  when branch data is unavailable; and PRs without a verified linked
-  claim, including manual/dependency PRs, are `not_applicable`.
+  is `applicable`; a verified linked claim still stays `applicable`
+  when branch data is unavailable; and a PR with no verified linked
+  claim AND no claim-marker history at all (a genuine non-IDD
+  contribution, including manual/dependency PRs) is `not_applicable`.
   Claimless maintainer waivers stay outside this conditional scope; the
   normal deadline-based waiver path still applies only to applicable,
   verified IDD-owned PRs. Invalid or unreadable config values still
   normalize back to `all-prs` in trusted config reads.
+  - `status: "indeterminate"` (#1686): a third outcome, distinct from
+    both `applicable` and `not_applicable`, for a PR that carries real
+    evidence of IDD claim activity but whose claim linkage cannot be
+    resolved cleanly right now -- a claim-branch mismatch against an
+    active trusted claim, closing references ambiguous between two or
+    more actively-claimed issues, or a stale/released claim (claim
+    marker history exists, but no claim currently resolves active).
+    Unlike `not_applicable`, `indeterminate` never lets `ready` become
+    `true` through ordinary convergence -- only the existing
+    deadline/terminal-plus-maintainer-waiver escape hatch can still
+    clear it (and, for the ambiguous/stale-history cases, no
+    `activeClaimId` exists to bind a waiver to in the first place, so
+    those two are effectively not waivable in practice; the
+    branch-mismatch case does have a real `activeClaimId` and stays
+    genuinely waivable). See
+    `computeAdvisoryConvergenceVerdict`'s `AdvisoryConvergenceApplicability`
+    doc comment (advisory-convergence.mts) for the full contract.
 
 #### Bounded same-HEAD advisory reroll (AW6, #1511)
 
@@ -1592,7 +1609,7 @@ structurally unable to disagree.
 <!-- dprint-ignore-start -->
 | Token                                    | Fires when...                                                                                                                                          |
 | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `scope-not-applicable`                    | `applicability.status` is `not_applicable` (`advisoryWait.convergenceScope: "idd-claimed"` and this PR has no matching verified linked claim/branch).   |
+| `scope-not-applicable`                    | `applicability.status` is `not_applicable` OR `indeterminate` (#1686) -- `advisoryWait.convergenceScope: "idd-claimed"` and this PR either has no verified linked claim/branch, or has a broken/ambiguous claim linkage. Offering a same-HEAD reroll is pointless in either case. |
 | `review-pending`                          | The primary bot has not yet reviewed current HEAD (`pending: true`). Always co-occurs with `review-item-count-unknown` below, since an off-HEAD review reports no usable item count. |
 | `unresolved-copilot-threads`              | `threads.satisfied` is `false` -- at least one Copilot-authored thread is neither resolved nor validly dispositioned.                                   |
 | `missing-regular-comment-disposition`     | `dispositionEvidence.missingRegularCommentCount` is non-zero -- an outstanding regular (non-thread) PR comment still lacks a fresh disposition marker.  |

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -235,9 +235,12 @@ gate by making them `not_applicable` instead of creating a waiver path.
 A PR that carries claim-activity evidence but whose linkage is broken or
 ambiguous (#1686) resolves `indeterminate` instead -- a hard block on
 ordinary convergence, not a bypass. The maintainer waiver escape hatch
-still applies only to applicable PRs after the deadline (and, for
-`indeterminate`, only when the case has a real `activeClaimId` to bind
-to -- see `docs/idd-helper-scripts.md`).
+requires a real, bindable `activeClaimId` after the deadline: an
+applicable PR always has one, and so does the `indeterminate`
+branch-mismatch case specifically, so it stays genuinely waivable; the
+`indeterminate` ambiguous/stale-history cases have no `activeClaimId`
+to bind to and are effectively not waivable in practice -- see
+`docs/idd-helper-scripts.md`.
 
 ## CI Wait Defaults
 

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -230,10 +230,14 @@ install without a requestable-reviewer event cannot be tracked once per HEAD.
 | Advisory-convergence enforcement scope           | `all-prs` (`advisoryWait.convergenceScope`)                                                                                                                                                                                                                                                                                                                  | [Pre-merge](../.github/instructions/idd-pre-merge.instructions.md), [Helper scripts](idd-helper-scripts.md), [Customizing IDD](customization.md#policy-constants)                                                    | Keep `all-prs` for existing behavior; switch to `idd-claimed` only when the repository wants convergence to apply solely to verified IDD-owned PRs.             |
 | Advisory-convergence required-check registration | Not registered by default (hosting the `idd-advisory-convergence` workflow is itself an opt-in step — see [ONBOARDING](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#optional--host-idd-advisory-convergence-as-a-required-check-ci-workflow); once hosted, a required-status-check Ruleset entry is a separate manual step) | [Customizing IDD](customization.md#policy-constants), [Helper scripts](idd-helper-scripts.md)                                                                                                                        | Register `idd-advisory-convergence` as a required status check to make convergence non-bypassable; this is a maintainer GitHub-settings action, not agent work. |
 
-`idd-claimed` keeps claimless/manual dependency PRs out of the gate by
-making them `not_applicable` instead of creating a waiver path. The
-maintainer waiver escape hatch still applies only to applicable,
-verified IDD-owned PRs after the deadline.
+`idd-claimed` keeps genuinely claimless/manual dependency PRs out of the
+gate by making them `not_applicable` instead of creating a waiver path.
+A PR that carries claim-activity evidence but whose linkage is broken or
+ambiguous (#1686) resolves `indeterminate` instead -- a hard block on
+ordinary convergence, not a bypass. The maintainer waiver escape hatch
+still applies only to applicable PRs after the deadline (and, for
+`indeterminate`, only when the case has a real `activeClaimId` to bind
+to -- see `docs/idd-helper-scripts.md`).
 
 ## CI Wait Defaults
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -250,11 +250,20 @@ durations only; zero-length values and second-based values are invalid.
 Repositories may also customize `advisoryWait.convergenceScope` in
 `.github/idd/config.json`. The default `all-prs` keeps convergence on
 every PR. `idd-claimed` is opt-in and limits convergence to verified
-IDD-owned PRs. Under `idd-claimed`, PRs without a verified linked claim
-resolve to `not_applicable` instead of opening a new waiver path, so
-claimless/manual dependency PRs stay outside the gate. Invalid values
-are rejected by schema, and runtime normalization falls back to
-`all-prs` for untrusted config reads.
+IDD-owned PRs. Under `idd-claimed`, a PR with no verified linked claim
+AND no claim-marker history at all resolves to `not_applicable` instead
+of opening a new waiver path, so genuinely claimless/manual dependency
+PRs stay outside the gate. A PR that DOES carry evidence of IDD claim
+activity but whose claim linkage is currently broken or ambiguous
+(#1686 -- a branch mismatch against an active claim, two or more
+actively-claimed closing references, or a stale/released claim)
+resolves to `indeterminate` instead: this hard-blocks readiness through
+the ordinary convergence path, leaving only the existing
+deadline/terminal-plus-maintainer-waiver escape hatch (see
+`docs/idd-helper-scripts.md`'s `advisoryWait.convergenceScope` entry
+for the exact per-case waiver availability). Invalid values are
+rejected by schema, and runtime normalization falls back to `all-prs`
+for untrusted config reads.
 
 `advisoryWait.primaryBotLogin` selects the advisory bot whose review the
 advisory-wait gate tracks (default Copilot), and

--- a/idd-template/docs/idd-advisory-wait-shell-fallback.md
+++ b/idd-template/docs/idd-advisory-wait-shell-fallback.md
@@ -23,13 +23,13 @@ REPO=$(gh repo view --json name --jq '.name')
 LAST_COPILOT_COMMIT=$(
   gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/reviews" \
     --paginate \
-    --jq '.[] | select(.user.login | startswith("copilot-pull-request-reviewer")) |
+    --jq '.[] | select(.user.login == "copilot-pull-request-reviewer" or .user.login == "copilot-pull-request-reviewer[bot]") |
                {sa: .submitted_at, cid: .commit_id}' \
   | jq -rs 'sort_by(.sa) | last | .cid // ""'
 )
 
 COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
-  --jq '.users | any(.login == "Copilot" or (.login | startswith("copilot-pull-request-reviewer")))')
+  --jq '.users | any(.login == "Copilot" or .login == "copilot-pull-request-reviewer" or .login == "copilot-pull-request-reviewer[bot]")')
 
 COPILOT_PENDING_COVERS_HEAD=$(
   gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/timeline" \
@@ -44,7 +44,9 @@ COPILOT_PENDING_COVERS_HEAD=$(
         | (map(select(.value.event == "review_requested"
              and (((.value.requested_reviewer.login // "") == "Copilot")
                   or ((.value.requested_reviewer.login // "")
-                      | startswith("copilot-pull-request-reviewer")))))
+                      == "copilot-pull-request-reviewer")
+                  or ((.value.requested_reviewer.login // "")
+                      == "copilot-pull-request-reviewer[bot]"))))
            | last | .key // null) as $request_index
         | ($head_index != null and $request_index != null and
            $request_index > $head_index)

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1544,14 +1544,31 @@ to post it is the consuming track's job.
   applies to every PR or only verified IDD-owned PRs. The default
   `all-prs` keeps the helper applicable everywhere. `idd-claimed`
   narrows it so a verified linked claim with a matching PR head branch
-  is `applicable`; a verified linked claim with a branch mismatch is
-  `not_applicable`; a verified linked claim still stays `applicable`
-  when branch data is unavailable; and PRs without a verified linked
-  claim, including manual/dependency PRs, are `not_applicable`.
+  is `applicable`; a verified linked claim still stays `applicable`
+  when branch data is unavailable; and a PR with no verified linked
+  claim AND no claim-marker history at all (a genuine non-IDD
+  contribution, including manual/dependency PRs) is `not_applicable`.
   Claimless maintainer waivers stay outside this conditional scope; the
   normal deadline-based waiver path still applies only to applicable,
   verified IDD-owned PRs. Invalid or unreadable config values still
   normalize back to `all-prs` in trusted config reads.
+  - `status: "indeterminate"` (#1686): a third outcome, distinct from
+    both `applicable` and `not_applicable`, for a PR that carries real
+    evidence of IDD claim activity but whose claim linkage cannot be
+    resolved cleanly right now -- a claim-branch mismatch against an
+    active trusted claim, closing references ambiguous between two or
+    more actively-claimed issues, or a stale/released claim (claim
+    marker history exists, but no claim currently resolves active).
+    Unlike `not_applicable`, `indeterminate` never lets `ready` become
+    `true` through ordinary convergence -- only the existing
+    deadline/terminal-plus-maintainer-waiver escape hatch can still
+    clear it (and, for the ambiguous/stale-history cases, no
+    `activeClaimId` exists to bind a waiver to in the first place, so
+    those two are effectively not waivable in practice; the
+    branch-mismatch case does have a real `activeClaimId` and stays
+    genuinely waivable). See
+    `computeAdvisoryConvergenceVerdict`'s `AdvisoryConvergenceApplicability`
+    doc comment (advisory-convergence.mts) for the full contract.
 
 #### Bounded same-HEAD advisory reroll (AW6, #1511)
 
@@ -1592,7 +1609,7 @@ structurally unable to disagree.
 <!-- dprint-ignore-start -->
 | Token                                    | Fires when...                                                                                                                                          |
 | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `scope-not-applicable`                    | `applicability.status` is `not_applicable` (`advisoryWait.convergenceScope: "idd-claimed"` and this PR has no matching verified linked claim/branch).   |
+| `scope-not-applicable`                    | `applicability.status` is `not_applicable` OR `indeterminate` (#1686) -- `advisoryWait.convergenceScope: "idd-claimed"` and this PR either has no verified linked claim/branch, or has a broken/ambiguous claim linkage. Offering a same-HEAD reroll is pointless in either case. |
 | `review-pending`                          | The primary bot has not yet reviewed current HEAD (`pending: true`). Always co-occurs with `review-item-count-unknown` below, since an off-HEAD review reports no usable item count. |
 | `unresolved-copilot-threads`              | `threads.satisfied` is `false` -- at least one Copilot-authored thread is neither resolved nor validly dispositioned.                                   |
 | `missing-regular-comment-disposition`     | `dispositionEvidence.missingRegularCommentCount` is non-zero -- an outstanding regular (non-thread) PR comment still lacks a fresh disposition marker.  |

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -235,9 +235,12 @@ gate by making them `not_applicable` instead of creating a waiver path.
 A PR that carries claim-activity evidence but whose linkage is broken or
 ambiguous (#1686) resolves `indeterminate` instead -- a hard block on
 ordinary convergence, not a bypass. The maintainer waiver escape hatch
-still applies only to applicable PRs after the deadline (and, for
-`indeterminate`, only when the case has a real `activeClaimId` to bind
-to -- see `docs/idd-helper-scripts.md`).
+requires a real, bindable `activeClaimId` after the deadline: an
+applicable PR always has one, and so does the `indeterminate`
+branch-mismatch case specifically, so it stays genuinely waivable; the
+`indeterminate` ambiguous/stale-history cases have no `activeClaimId`
+to bind to and are effectively not waivable in practice -- see
+`docs/idd-helper-scripts.md`.
 
 ## CI Wait Defaults
 

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -230,10 +230,14 @@ install without a requestable-reviewer event cannot be tracked once per HEAD.
 | Advisory-convergence enforcement scope           | `all-prs` (`advisoryWait.convergenceScope`)                                                                                                                                                                                                                                                                                                                  | [Pre-merge](../.github/instructions/idd-pre-merge.instructions.md), [Helper scripts](idd-helper-scripts.md), [Customizing IDD](customization.md#policy-constants)                                                    | Keep `all-prs` for existing behavior; switch to `idd-claimed` only when the repository wants convergence to apply solely to verified IDD-owned PRs.             |
 | Advisory-convergence required-check registration | Not registered by default (hosting the `idd-advisory-convergence` workflow is itself an opt-in step — see [ONBOARDING](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#optional--host-idd-advisory-convergence-as-a-required-check-ci-workflow); once hosted, a required-status-check Ruleset entry is a separate manual step) | [Customizing IDD](customization.md#policy-constants), [Helper scripts](idd-helper-scripts.md)                                                                                                                        | Register `idd-advisory-convergence` as a required status check to make convergence non-bypassable; this is a maintainer GitHub-settings action, not agent work. |
 
-`idd-claimed` keeps claimless/manual dependency PRs out of the gate by
-making them `not_applicable` instead of creating a waiver path. The
-maintainer waiver escape hatch still applies only to applicable,
-verified IDD-owned PRs after the deadline.
+`idd-claimed` keeps genuinely claimless/manual dependency PRs out of the
+gate by making them `not_applicable` instead of creating a waiver path.
+A PR that carries claim-activity evidence but whose linkage is broken or
+ambiguous (#1686) resolves `indeterminate` instead -- a hard block on
+ordinary convergence, not a bypass. The maintainer waiver escape hatch
+still applies only to applicable PRs after the deadline (and, for
+`indeterminate`, only when the case has a real `activeClaimId` to bind
+to -- see `docs/idd-helper-scripts.md`).
 
 ## CI Wait Defaults
 

--- a/schemas/advisory-convergence.schema.json
+++ b/schemas/advisory-convergence.schema.json
@@ -63,7 +63,7 @@
         },
         "status": {
           "type": "string",
-          "enum": ["applicable", "not_applicable"]
+          "enum": ["applicable", "not_applicable", "indeterminate"]
         },
         "reason": {
           "type": "string",

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -79,7 +79,7 @@ import {
   safeGhText,
 } from './gh-exec.mjs';
 import { loadIddConfig } from './idd-config.mjs';
-import { isValidIsoTimestamp } from './marker-helpers.mjs';
+import { isValidIsoTimestamp, parseClaimComment } from './marker-helpers.mjs';
 import {
   normalizePolicyConfig,
   parseIsoDurationToMs,
@@ -173,14 +173,33 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     options.convergenceScope === 'idd-claimed' ? 'idd-claimed' : 'all-prs';
   const prHeadRefName = String(options.prHeadRefName ?? '').trim();
   const activeClaimBranch = String(claim.activeClaim?.branch ?? '').trim();
+  // #1686: evidence the CLI-collection layer computes over EVERY candidate
+  // claim issue (not just whichever one -- if any -- ended up "active"), so
+  // the applicability gate can tell a genuinely non-IDD PR apart from an
+  // IDD-shaped PR whose claim linkage is currently broken. See each field's
+  // own doc comment on `AdvisoryConvergenceInputs` for the full rationale.
+  const claimMarkerHistoryPresent = inputs.claimMarkerHistoryPresent === true;
+  const claimCandidateAmbiguous = inputs.claimCandidateAmbiguous === true;
   const applicability =
     convergenceScope === 'idd-claimed'
       ? !claim.activeClaimPresent
-        ? {
-            scope: convergenceScope,
-            status: 'not_applicable',
-            reason: 'idd-claimed-no-verified-linked-issue-claim',
-          }
+        ? claimCandidateAmbiguous
+          ? {
+              scope: convergenceScope,
+              status: 'indeterminate',
+              reason: 'idd-claimed-multiple-resolving-claim-candidates',
+            }
+          : claimMarkerHistoryPresent
+            ? {
+                scope: convergenceScope,
+                status: 'indeterminate',
+                reason: 'idd-claimed-claim-history-without-active-claim',
+              }
+            : {
+                scope: convergenceScope,
+                status: 'not_applicable',
+                reason: 'idd-claimed-no-verified-linked-issue-claim',
+              }
         : !prHeadRefName
           ? {
               scope: convergenceScope,
@@ -196,7 +215,7 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
             : activeClaimBranch !== prHeadRefName
               ? {
                   scope: convergenceScope,
-                  status: 'not_applicable',
+                  status: 'indeterminate',
                   reason: 'idd-claimed-branch-mismatch',
                 }
               : {
@@ -209,15 +228,37 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
           status: 'applicable',
           reason: 'all-prs',
         };
+  // `scopeNotApplicable` keeps its pre-#1686 meaning EXACTLY -- `status ===
+  // 'not_applicable'` only -- since it still gates the waiver-evidence
+  // bookkeeping (`waived` below) and the unconditional `ready` pass for a
+  // genuinely non-IDD PR. `scopeIndeterminate` is the new third state:
+  // unlike `not_applicable`, it must NEVER let `ready` become true through
+  // the ordinary convergence path (`converged` below is forced `false` for
+  // it, same as `not_applicable` blocks evaluating convergence at all) --
+  // only the existing deadline/terminal-plus-maintainer-waiver escape hatch
+  // can still clear it (`waived` stays gated by `scopeNotApplicable` alone,
+  // deliberately NOT `scopeBlocksConvergenceEval`, so a trusted maintainer
+  // marker can still resolve an indeterminate verdict same as any other
+  // non-converged one -- see the module header and PR discussion for why
+  // hard-blocking indeterminate with no waiver escape at all would leave a
+  // required check with no recovery path for a repository under
+  // `required_approving_review_count: 0`).
   const scopeNotApplicable = applicability.status === 'not_applicable';
+  const scopeIndeterminate = applicability.status === 'indeterminate';
+  const scopeBlocksConvergenceEval = scopeNotApplicable || scopeIndeterminate;
+  if (scopeIndeterminate) {
+    reasons.push(
+      `applicability is indeterminate (${applicability.reason}): this PR carries evidence of IDD claim activity but its claim linkage cannot be resolved cleanly -- repair the claim/PR-body linkage (or, for a confirmed benign case, have a trusted maintainer post an idd-external-check-waiver marker) before this check can converge`,
+    );
+  }
   // --- Clause 1: latest Copilot review is clean on the current HEAD -----
   const review = resolveLatestCopilotReviewClause(
     reviews,
     prHeadSha,
     primaryBotLogin,
   );
-  const pending = scopeNotApplicable ? false : !review.matchesHead;
-  if (!scopeNotApplicable && pending) {
+  const pending = scopeBlocksConvergenceEval ? false : !review.matchesHead;
+  if (!scopeBlocksConvergenceEval && pending) {
     reasons.push(
       review.found
         ? `latest ${primaryBotLogin} review (commit ${review.commitId || '<unknown>'}) does not cover current HEAD ${prHeadSha}`
@@ -294,7 +335,7 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   // is already resolved and `itemCount` is still positive, no thread query
   // can explain it -- point directly at the review body instead of leaving
   // an agent to re-derive this by hand a second time.
-  if (!scopeNotApplicable && !pending && !review.satisfied) {
+  if (!scopeBlocksConvergenceEval && !pending && !review.satisfied) {
     const itemCountReason =
       review.itemCount === null
         ? `latest ${primaryBotLogin} review on current HEAD carries an unknown number of actionable items (comment count unavailable)`
@@ -307,7 +348,7 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
         : itemCountReason,
     );
   }
-  if (!scopeNotApplicable && !threadClause.satisfied) {
+  if (!scopeBlocksConvergenceEval && !threadClause.satisfied) {
     reasons.push(
       `${threadClause.blockingCount} ${primaryBotLogin}-authored review thread(s) are neither resolved nor validly dispositioned: ${threadClause.blockingIds.join(', ')}`,
     );
@@ -321,7 +362,7 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     missingThreadCount: dispositionEvidence.missingThreadCount,
   };
   const converged =
-    !scopeNotApplicable &&
+    !scopeBlocksConvergenceEval &&
     !pending &&
     review.satisfied &&
     threadClause.satisfied;
@@ -356,7 +397,12 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   // `review-item-count-not-positive`), while `reviewItemCountKnownTerm &&
   // reviewItemCountPositiveTerm` together still reduce to exactly the
   // original `itemCount !== null && itemCount > 0` conjunct.
-  const scopeApplicableTerm = !scopeNotApplicable;
+  // #1686: `indeterminate` now also disqualifies a same-HEAD reroll --
+  // offering to reroll Copilot is pointless while the underlying claim
+  // linkage itself is broken/ambiguous, so this term (and its
+  // `SCOPE_NOT_APPLICABLE` token; see that token's doc row in
+  // docs/idd-helper-scripts.md) fires for either non-`applicable` status.
+  const scopeApplicableTerm = !scopeBlocksConvergenceEval;
   const reviewNotPendingTerm = !pending;
   const threadsSatisfiedTerm = threadClause.satisfied;
   const noMissingRegularCommentsTerm =
@@ -440,7 +486,7 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   // answered reroll self-describes as no-longer-in-flight once the window
   // elapses, instead of blocking a retry forever if the bot goes silent.
   const sameHeadRerollInFlight =
-    !scopeNotApplicable &&
+    !scopeBlocksConvergenceEval &&
     rerollMarkers.latestAt !== '' &&
     !hasFreshReviewSinceLastReroll &&
     rerollElapsedMinutes < pendingWindowMinutesForReroll;
@@ -601,6 +647,34 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     reasons,
   };
 }
+/**
+ * #1686: defense-in-depth on top of `isCopilotReviewerLogin`'s login-string
+ * check. GitHub's GraphQL API reports `__typename: "Bot"` consistently for
+ * every App/bot account regardless of login spelling, and a real human
+ * account can never report it -- so a *registrable* login lookalike (e.g. a
+ * human account named `copilot-pull-request-reviewer`, distinct from the
+ * real bot's own `[bot]`-suffixed login) still fails this check even though
+ * it passes the login-string comparison. This file's own GraphQL queries
+ * (`fetchReviewsAndHeadCommit` / `fetchReviewThreads` /
+ * `fetchThreadCommentPages`) request `__typename` on every `author` field,
+ * so every LIVE payload this gate evaluates carries it; a payload that
+ * omits it (an older fixture, or a future caller not routed through this
+ * file's own queries) is treated as "unknown" and does NOT fail the check
+ * -- this stays a narrowing on top of the login match, never a new
+ * blocking requirement for a caller this field predates. Deliberately kept
+ * local to this file (mirroring `rerun-advisory-convergence.mts`'s own
+ * "closes it locally without widening that shared function's behavior"
+ * precedent) rather than folded into `isCopilotReviewerLogin` itself, which
+ * many REST-payload callers across the codebase rely on and which has no
+ * `__typename` to check.
+ */
+function isVerifiedCopilotAuthor(author, primaryBotLogin) {
+  if (!isCopilotReviewerLogin(author?.login ?? '', primaryBotLogin)) {
+    return false;
+  }
+  const typename = author?.__typename;
+  return typename === undefined || typename === null || typename === 'Bot';
+}
 /** Evaluate Clause 1 against the single, absolute-latest Copilot review --
  * per the issue's literal wording ("the latest Copilot review's commit_id
  * equals current HEAD"), not "the latest review among those that happen to
@@ -625,9 +699,7 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
  * let an earlier, differently-ordered review win by comparator accident. */
 function resolveLatestCopilotReviewClause(reviews, prHeadSha, primaryBotLogin) {
   const latest = reviews
-    .filter((review) =>
-      isCopilotReviewerLogin(review.author?.login ?? '', primaryBotLogin),
-    )
+    .filter((review) => isVerifiedCopilotAuthor(review.author, primaryBotLogin))
     .at(-1);
   if (!latest) {
     return {
@@ -677,7 +749,7 @@ export function classifyCopilotAuthoredThreadIds(threads, primaryBotLogin) {
     const originating = (thread.comments?.nodes ?? [])[0];
     if (
       originating &&
-      isCopilotReviewerLogin(originating.author?.login ?? '', primaryBotLogin)
+      isVerifiedCopilotAuthor(originating.author, primaryBotLogin)
     ) {
       // Match `summarizeDispositionEvidenceForGate`'s own
       // `missingThreads[].id` fallback exactly (protocol-helpers.mts) so a
@@ -972,6 +1044,28 @@ function collectFromGitHub(args) {
     trustedMarkerLogins,
     Boolean(args.claimIssueNumber),
   );
+  // #1686: ambiguity is a distinct signal from `claimEvents` above --
+  // `pickResolvingClaimEvents` deliberately collapses BOTH "zero candidates
+  // resolve" and "two or more candidates resolve" to `[]` (see its own doc
+  // comment), so this must be computed separately over the same
+  // `claimCandidates`/`trustedMarkerLogins` inputs rather than re-derived
+  // from the already-collapsed `claimEvents`.
+  const claimCandidateAmbiguous = classifyClaimCandidateAmbiguity(
+    claimCandidates,
+    trustedMarkerLogins,
+    Boolean(args.claimIssueNumber),
+  );
+  // #1686: true when ANY candidate claim issue ever carried a trusted,
+  // syntactically valid `claimed-by` marker -- computed over the union of
+  // every candidate's RAW comment stream (`claimCandidates`, not the
+  // resolved-and-possibly-emptied `claimEvents`), so a stale, released, or
+  // otherwise no-longer-active claim still counts as genuine IDD claim
+  // history. See `hasTrustedClaimMarkerHistory`'s doc comment for the full
+  // rationale and the module header's path 4.
+  const claimMarkerHistoryPresent = hasTrustedClaimMarkerHistory(
+    claimCandidates,
+    trustedMarkerLogins,
+  );
   const primaryBotLogin = readAdvisoryPrimaryBotLogin();
   const deadlineMinutes = readAdvisoryConvergenceDeadlineMinutes();
   // #1511: bounded same-HEAD reroll cap, plus the existing pendingWindow
@@ -1029,6 +1123,8 @@ function collectFromGitHub(args) {
       threads,
       comments,
       claimEvents,
+      claimMarkerHistoryPresent,
+      claimCandidateAmbiguous,
     },
     options: {
       now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
@@ -1126,6 +1222,19 @@ function fetchClaimEventCandidates(owner, repo, explicitIssueNumber, refs) {
     fetchClaimComments(owner, repo, issueNumber),
   );
 }
+/** Candidate claim-issue comment streams whose *active claim* actually
+ * resolves (`summarizeClaimValidation`). Shared by
+ * {@link pickResolvingClaimEvents} and {@link classifyClaimCandidateAmbiguity}
+ * (#1686) so both read the identical disambiguation result instead of two
+ * independently-maintained filters that could drift. */
+function filterResolvingClaimCandidates(candidates, trustedMarkerLogins) {
+  return candidates.filter((comments) =>
+    Boolean(
+      summarizeClaimValidation(comments, { trustedMarkerLogins })
+        .activeClaimPresent,
+    ),
+  );
+}
 /**
  * Resolve the linked (claim) issue's comment stream for waiver-claim
  * binding, given already-fetched candidate comment streams
@@ -1141,7 +1250,14 @@ function fetchClaimEventCandidates(owner, repo, explicitIssueNumber, refs) {
  * own `selectLinkedIssueCandidate` disambiguates multiple linked issues by
  * active-claim presence rather than requiring a single closing reference.
  * Zero or multiple resolving candidates fail closed to `[]` (no waiver
- * claim can bind unambiguously), same as before #1344/#1347.
+ * claim can bind unambiguously), same as before #1344/#1347 -- and
+ * unchanged by #1686: {@link classifyClaimCandidateAmbiguity} below is the
+ * new, separate signal that lets a caller tell the "zero resolving" and
+ * "multiple resolving" cases apart without touching this function's own
+ * fail-closed-to-`[]` contract (pinned by
+ * "pickResolvingClaimEvents: zero or multiple resolving candidates still
+ * fail closed to [] (unchanged from pre-#1344/#1347 behavior)" in
+ * tests/advisory-convergence.test.mts).
  */
 export function pickResolvingClaimEvents(
   candidates,
@@ -1151,13 +1267,81 @@ export function pickResolvingClaimEvents(
   if (isExplicit) {
     return candidates[0] ?? [];
   }
-  const resolving = candidates.filter((comments) =>
-    Boolean(
-      summarizeClaimValidation(comments, { trustedMarkerLogins })
-        .activeClaimPresent,
-    ),
+  const resolving = filterResolvingClaimCandidates(
+    candidates,
+    trustedMarkerLogins,
   );
   return resolving.length === 1 ? resolving[0] : [];
+}
+/**
+ * #1686: true when two or more claim-issue candidates each independently
+ * resolve an active trusted claim -- the specific disambiguation-failure
+ * case {@link pickResolvingClaimEvents} already fails closed to `[]` for
+ * (see its own doc comment above and the module header's path 2). Surfaced
+ * as an explicit signal so the `idd-claimed` applicability gate
+ * (`computeAdvisoryConvergenceVerdict`) can distinguish "this PR's closing
+ * references are ambiguous between two actively-claimed issues" from the
+ * ordinary "no candidate resolves at all" case, which
+ * `pickResolvingClaimEvents`'s own collapsed `[]` output cannot
+ * distinguish by itself. An explicit `--claim-issue` target has no
+ * ambiguity to resolve -- always `false`, mirroring
+ * `pickResolvingClaimEvents`'s own `isExplicit` short-circuit.
+ */
+export function classifyClaimCandidateAmbiguity(
+  candidates,
+  trustedMarkerLogins,
+  isExplicit,
+) {
+  if (isExplicit) {
+    return false;
+  }
+  return (
+    filterResolvingClaimCandidates(candidates, trustedMarkerLogins).length > 1
+  );
+}
+/**
+ * #1686: true when at least one TRUSTED, syntactically valid `claimed-by`
+ * marker exists anywhere in `candidates`' raw comment streams -- regardless
+ * of whether it currently resolves to an ACTIVE claim. A released
+ * (`unclaimed-by`), superseded-without-a-qualifying-takeover, or otherwise
+ * no-longer-current claim still counts: this function answers "did real IDD
+ * claim activity ever happen here", not "is a claim active right now" (that
+ * question is `summarizeClaimValidation(...).activeClaimPresent`, already
+ * computed elsewhere).
+ *
+ * Note on *why* this function is needed rather than an age comparison:
+ * `resolveActiveClaim` (protocol-helpers.mts) has no `now` parameter and
+ * never expires a claim by elapsed time alone -- staleness there only
+ * matters when a LATER claim event attempts to supersede the active one
+ * (`claim.supersedes === activeClaim.claimId && isStale(...)`). A claim
+ * that goes stale on a long-open PR with no subsequent takeover event stays
+ * `activeClaimPresent: true` forever in this codebase; time by itself never
+ * clears it. So the concrete way `activeClaimPresent` becomes `false` while
+ * genuine claim history exists is an explicit release/handoff event (or a
+ * disambiguation failure -- see {@link classifyClaimCandidateAmbiguity}
+ * instead), not a bare age computation -- this function's own test fixtures
+ * demonstrate that shape rather than asserting on elapsed time. See the
+ * module header's path 4 and `AdvisoryConvergenceInputs.claimMarkerHistoryPresent`'s
+ * doc comment.
+ */
+export function hasTrustedClaimMarkerHistory(candidates, trustedMarkerLogins) {
+  const trusted = new Set(trustedMarkerLogins);
+  return candidates.some((candidateComments) =>
+    candidateComments.some((event) => {
+      const login = String(event.author?.login ?? event.user?.login ?? '')
+        .trim()
+        .toLowerCase();
+      if (!trusted.has(login)) {
+        return false;
+      }
+      return (
+        parseClaimComment(
+          event.body ?? '',
+          event.createdAt ?? event.created_at ?? '',
+        ) !== null
+      );
+    }),
+  );
 }
 /**
  * Candidate collaborator-marker-trust logins: comment authors whose comment
@@ -1238,7 +1422,7 @@ function fetchReviewsAndHeadCommit(owner, repo, prNumber) {
                 nodes {
                   commit { oid }
                   submittedAt
-                  author { login }
+                  author { login __typename }
                   comments { totalCount }
                 }
               }
@@ -1291,7 +1475,7 @@ function fetchReviewThreads(owner, repo, prNumber) {
                       body
                       createdAt
                       updatedAt
-                      author { login }
+                      author { login __typename }
                       pullRequestReview { id }
                     }
                   }
@@ -1343,7 +1527,7 @@ function fetchThreadCommentPages(threadId, afterCursor) {
                   body
                   createdAt
                   updatedAt
-                  author { login }
+                  author { login __typename }
                   pullRequestReview { id }
                 }
               }

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1581,14 +1581,33 @@ export function classifyCiChecks(checks) {
   };
 }
 /**
+ * #1686: the exact, closed set of logins recognized for the *default*
+ * Copilot primary advisory bot -- the human-facing `copilot` slash-command
+ * actor plus the two known GitHub-App review-bot login forms. Previously
+ * matched via `normalized.startsWith('copilot-pull-request-reviewer')`,
+ * which a *registrable* GitHub username lookalike (for example
+ * `copilot-pull-request-reviewer1`) could also satisfy on a public
+ * repository: any account can submit a PR review, so a lookalike login
+ * could post an empty review of the current HEAD and masquerade as the
+ * real bot's convergence signal (Clause 1 of `advisory-convergence.mts`'s
+ * verdict: `matchesHead: true, itemCount: 0`). An exact set closes that
+ * gap without narrowing the two genuine login forms GitHub actually uses.
+ */
+const EXACT_COPILOT_REVIEWER_LOGINS = new Set([
+  'copilot',
+  'copilot-pull-request-reviewer',
+  'copilot-pull-request-reviewer[bot]',
+]);
+/**
  * Match a review/reviewer login against the configured primary advisory bot.
  *
  * `primaryBotLogin` defaults to Copilot so existing callers stay behavior-
- * preserving. For the Copilot default the historical dual match is kept
- * (the exact `copilot` actor plus the `copilot-pull-request-reviewer*` GitHub
- * App login family). A non-Copilot configured login is matched by exact
- * normalized (trimmed, lower-cased) equality, since an arbitrary bot login has
- * no analogous prefix family.
+ * preserving. For the Copilot default, the login must be an exact member of
+ * {@link EXACT_COPILOT_REVIEWER_LOGINS} (#1686 -- previously a broader
+ * `copilot-pull-request-reviewer*` prefix match; see that constant's doc
+ * comment for why it was narrowed). A non-Copilot configured login is
+ * matched by exact normalized (trimmed, lower-cased) equality, since an
+ * arbitrary bot login has no analogous prefix family.
  */
 export function isCopilotReviewerLogin(
   login,
@@ -1602,10 +1621,7 @@ export function isCopilotReviewerLogin(
       .trim()
       .toLowerCase() || DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
   if (configured === DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN) {
-    return (
-      normalized === 'copilot' ||
-      normalized.startsWith('copilot-pull-request-reviewer')
-    );
+    return EXACT_COPILOT_REVIEWER_LOGINS.has(normalized);
   }
   return normalized === configured;
 }

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -577,8 +577,10 @@ function classifyInstance(instance, options) {
  * through as rerun-eligible (#1434 review, Codex P2).
  *
  * `isCopilotReviewerLogin` itself only normalizes this way for the
- * *default* Copilot login (a `copilot`/`copilot-pull-request-reviewer*`
- * prefix match); once a repository configures a non-default
+ * *default* Copilot login (an exact-set match against `copilot`/
+ * `copilot-pull-request-reviewer`/`copilot-pull-request-reviewer[bot]` --
+ * #1686 narrowed this from a `copilot-pull-request-reviewer*` prefix
+ * match); once a repository configures a non-default
  * `primaryBotLogin`, it falls back to an exact `normalized === configured`
  * comparison with no `[bot]`-suffix handling -- the same gap the
  * `advisoryBotLogins` fallback already closed for its own set, just on

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -83,7 +83,7 @@ import {
   safeGhText,
 } from './gh-exec.mts';
 import { loadIddConfig } from './idd-config.mts';
-import { isValidIsoTimestamp } from './marker-helpers.mts';
+import { isValidIsoTimestamp, parseClaimComment } from './marker-helpers.mts';
 import {
   normalizePolicyConfig,
   parseIsoDurationToMs,
@@ -142,9 +142,16 @@ export const SAME_HEAD_REROLL_INELIGIBLE_REASON = {
 export type SameHeadRerollIneligibleReasonToken =
   (typeof SAME_HEAD_REROLL_INELIGIBLE_REASON)[keyof typeof SAME_HEAD_REROLL_INELIGIBLE_REASON];
 
-/** Author reference embedded in GitHub REST/GraphQL payloads. */
+/** Author reference embedded in GitHub REST/GraphQL payloads.
+ * `__typename` (#1686) is GraphQL-only -- this file's own `reviews` /
+ * `reviewThreads` / thread-comment-page queries request it explicitly (see
+ * `fetchReviewsAndHeadCommit` / `fetchReviewThreads` /
+ * `fetchThreadCommentPages`), so every LIVE payload this gate evaluates
+ * carries it; a fixture/test payload that omits it is treated as
+ * "unknown", never as a rejection -- see {@link isVerifiedCopilotAuthor}. */
 interface GhAuthorPayload {
   login?: string | null;
+  __typename?: string | null;
 }
 
 /** Issue/PR comment payload fields consumed by this helper. */
@@ -243,10 +250,27 @@ export interface AdvisoryConvergenceWaiver {
   validCount: number;
 }
 
-/** Scope gate evidence for the advisory-convergence verdict. */
+/** Scope gate evidence for the advisory-convergence verdict.
+ *
+ * `status: 'indeterminate'` (#1686) is a third, deliberately distinct
+ * outcome from `not_applicable`: it means this PR carries real evidence of
+ * IDD claim activity (a trusted `claimed-by` marker exists somewhere in its
+ * candidate claim-issue history, or its closing references are ambiguous
+ * between two or more actively-claimed issues, or its linked issue has an
+ * active claim whose recorded branch does not match the PR's own head
+ * branch) but the claim linkage the `idd-claimed` scope needs cannot be
+ * resolved cleanly right now. Unlike `not_applicable`, `indeterminate`
+ * NEVER makes the verdict `ready` on its own (see `converged`/`ready`
+ * below) -- it still falls through the existing deadline+maintainer-waiver
+ * escape hatch like any other non-converged verdict, so a human can either
+ * repair the claim linkage or explicitly waive this check, but the
+ * executing session cannot manufacture readiness by omitting, duplicating,
+ * or letting its own claim linkage go missing. `not_applicable` stays
+ * reserved for a PR with NO such evidence at all -- a genuine non-IDD
+ * contribution this scope must not block. */
 export interface AdvisoryConvergenceApplicability {
   scope: 'all-prs' | 'idd-claimed';
-  status: 'applicable' | 'not_applicable';
+  status: 'applicable' | 'not_applicable' | 'indeterminate';
   reason: string;
 }
 
@@ -367,6 +391,35 @@ export interface AdvisoryConvergenceInputs {
    * active claim for waiver validation; the `converged` computation itself
    * never depends on a claim. */
   claimEvents?: IssueCommentPayload[];
+  /** #1686: true when at least one trusted, syntactically valid
+   * `claimed-by` marker was ever posted on ANY of the PR's candidate claim
+   * issues -- computed by the CLI-collection layer over the union of every
+   * candidate's raw comment stream, independent of whether that history
+   * currently resolves to an ACTIVE claim. `claimEvents` above can be `[]`
+   * even when this is `true`: `pickResolvingClaimEvents` fails closed to
+   * `[]` both when zero candidates resolve and when the linkage is
+   * ambiguous, collapsing exactly the distinction this field restores (see
+   * the module header's path 2 and path 4). Distinguishes a genuinely
+   * non-IDD PR (no linked issue, no claim history ever -- `false`, stays
+   * `not_applicable`) from an IDD-shaped PR whose claim linkage is
+   * currently broken (a stale or released claim -- `true`, becomes
+   * `indeterminate`). Defaults to `false` when omitted, preserving prior
+   * `not_applicable` behavior for every fixture/caller that predates this
+   * field. */
+  claimMarkerHistoryPresent?: boolean;
+  /** #1686: true when two or more of the PR's candidate claim issues each
+   * independently resolve an ACTIVE trusted claim -- the disambiguation
+   * failure `pickResolvingClaimEvents` already fails closed to `[]` for
+   * (module header path 2). An explicit `--claim-issue` target has no
+   * ambiguity to resolve, so the CLI-collection layer always reports
+   * `false` for it (see `classifyClaimCandidateAmbiguity`). Defaults to
+   * `false` when omitted. Checked BEFORE `claimMarkerHistoryPresent` in the
+   * applicability computation so the more specific "which failure mode"
+   * reason wins -- an ambiguous set of candidates trivially also has claim
+   * history (an active claim cannot exist without a valid marker), so the
+   * two fields are not mutually exclusive; the check order is what makes
+   * the reported `reason` precise. */
+  claimCandidateAmbiguous?: boolean;
 }
 
 /** Pure options accepted by {@link computeAdvisoryConvergenceVerdict}. */
@@ -505,14 +558,33 @@ export function computeAdvisoryConvergenceVerdict(
     options.convergenceScope === 'idd-claimed' ? 'idd-claimed' : 'all-prs';
   const prHeadRefName = String(options.prHeadRefName ?? '').trim();
   const activeClaimBranch = String(claim.activeClaim?.branch ?? '').trim();
+  // #1686: evidence the CLI-collection layer computes over EVERY candidate
+  // claim issue (not just whichever one -- if any -- ended up "active"), so
+  // the applicability gate can tell a genuinely non-IDD PR apart from an
+  // IDD-shaped PR whose claim linkage is currently broken. See each field's
+  // own doc comment on `AdvisoryConvergenceInputs` for the full rationale.
+  const claimMarkerHistoryPresent = inputs.claimMarkerHistoryPresent === true;
+  const claimCandidateAmbiguous = inputs.claimCandidateAmbiguous === true;
   const applicability: AdvisoryConvergenceApplicability =
     convergenceScope === 'idd-claimed'
       ? !claim.activeClaimPresent
-        ? {
-            scope: convergenceScope,
-            status: 'not_applicable',
-            reason: 'idd-claimed-no-verified-linked-issue-claim',
-          }
+        ? claimCandidateAmbiguous
+          ? {
+              scope: convergenceScope,
+              status: 'indeterminate',
+              reason: 'idd-claimed-multiple-resolving-claim-candidates',
+            }
+          : claimMarkerHistoryPresent
+            ? {
+                scope: convergenceScope,
+                status: 'indeterminate',
+                reason: 'idd-claimed-claim-history-without-active-claim',
+              }
+            : {
+                scope: convergenceScope,
+                status: 'not_applicable',
+                reason: 'idd-claimed-no-verified-linked-issue-claim',
+              }
         : !prHeadRefName
           ? {
               scope: convergenceScope,
@@ -528,7 +600,7 @@ export function computeAdvisoryConvergenceVerdict(
             : activeClaimBranch !== prHeadRefName
               ? {
                   scope: convergenceScope,
-                  status: 'not_applicable',
+                  status: 'indeterminate',
                   reason: 'idd-claimed-branch-mismatch',
                 }
               : {
@@ -541,7 +613,29 @@ export function computeAdvisoryConvergenceVerdict(
           status: 'applicable',
           reason: 'all-prs',
         };
+  // `scopeNotApplicable` keeps its pre-#1686 meaning EXACTLY -- `status ===
+  // 'not_applicable'` only -- since it still gates the waiver-evidence
+  // bookkeeping (`waived` below) and the unconditional `ready` pass for a
+  // genuinely non-IDD PR. `scopeIndeterminate` is the new third state:
+  // unlike `not_applicable`, it must NEVER let `ready` become true through
+  // the ordinary convergence path (`converged` below is forced `false` for
+  // it, same as `not_applicable` blocks evaluating convergence at all) --
+  // only the existing deadline/terminal-plus-maintainer-waiver escape hatch
+  // can still clear it (`waived` stays gated by `scopeNotApplicable` alone,
+  // deliberately NOT `scopeBlocksConvergenceEval`, so a trusted maintainer
+  // marker can still resolve an indeterminate verdict same as any other
+  // non-converged one -- see the module header and PR discussion for why
+  // hard-blocking indeterminate with no waiver escape at all would leave a
+  // required check with no recovery path for a repository under
+  // `required_approving_review_count: 0`).
   const scopeNotApplicable = applicability.status === 'not_applicable';
+  const scopeIndeterminate = applicability.status === 'indeterminate';
+  const scopeBlocksConvergenceEval = scopeNotApplicable || scopeIndeterminate;
+  if (scopeIndeterminate) {
+    reasons.push(
+      `applicability is indeterminate (${applicability.reason}): this PR carries evidence of IDD claim activity but its claim linkage cannot be resolved cleanly -- repair the claim/PR-body linkage (or, for a confirmed benign case, have a trusted maintainer post an idd-external-check-waiver marker) before this check can converge`,
+    );
+  }
 
   // --- Clause 1: latest Copilot review is clean on the current HEAD -----
   const review = resolveLatestCopilotReviewClause(
@@ -549,8 +643,8 @@ export function computeAdvisoryConvergenceVerdict(
     prHeadSha,
     primaryBotLogin,
   );
-  const pending = scopeNotApplicable ? false : !review.matchesHead;
-  if (!scopeNotApplicable && pending) {
+  const pending = scopeBlocksConvergenceEval ? false : !review.matchesHead;
+  if (!scopeBlocksConvergenceEval && pending) {
     reasons.push(
       review.found
         ? `latest ${primaryBotLogin} review (commit ${review.commitId || '<unknown>'}) does not cover current HEAD ${prHeadSha}`
@@ -629,7 +723,7 @@ export function computeAdvisoryConvergenceVerdict(
   // is already resolved and `itemCount` is still positive, no thread query
   // can explain it -- point directly at the review body instead of leaving
   // an agent to re-derive this by hand a second time.
-  if (!scopeNotApplicable && !pending && !review.satisfied) {
+  if (!scopeBlocksConvergenceEval && !pending && !review.satisfied) {
     const itemCountReason =
       review.itemCount === null
         ? `latest ${primaryBotLogin} review on current HEAD carries an unknown number of actionable items (comment count unavailable)`
@@ -642,7 +736,7 @@ export function computeAdvisoryConvergenceVerdict(
         : itemCountReason,
     );
   }
-  if (!scopeNotApplicable && !threadClause.satisfied) {
+  if (!scopeBlocksConvergenceEval && !threadClause.satisfied) {
     reasons.push(
       `${threadClause.blockingCount} ${primaryBotLogin}-authored review thread(s) are neither resolved nor validly dispositioned: ${threadClause.blockingIds.join(', ')}`,
     );
@@ -658,7 +752,7 @@ export function computeAdvisoryConvergenceVerdict(
   };
 
   const converged =
-    !scopeNotApplicable &&
+    !scopeBlocksConvergenceEval &&
     !pending &&
     review.satisfied &&
     threadClause.satisfied;
@@ -694,7 +788,12 @@ export function computeAdvisoryConvergenceVerdict(
   // `review-item-count-not-positive`), while `reviewItemCountKnownTerm &&
   // reviewItemCountPositiveTerm` together still reduce to exactly the
   // original `itemCount !== null && itemCount > 0` conjunct.
-  const scopeApplicableTerm = !scopeNotApplicable;
+  // #1686: `indeterminate` now also disqualifies a same-HEAD reroll --
+  // offering to reroll Copilot is pointless while the underlying claim
+  // linkage itself is broken/ambiguous, so this term (and its
+  // `SCOPE_NOT_APPLICABLE` token; see that token's doc row in
+  // docs/idd-helper-scripts.md) fires for either non-`applicable` status.
+  const scopeApplicableTerm = !scopeBlocksConvergenceEval;
   const reviewNotPendingTerm = !pending;
   const threadsSatisfiedTerm = threadClause.satisfied;
   const noMissingRegularCommentsTerm =
@@ -781,7 +880,7 @@ export function computeAdvisoryConvergenceVerdict(
   // answered reroll self-describes as no-longer-in-flight once the window
   // elapses, instead of blocking a retry forever if the bot goes silent.
   const sameHeadRerollInFlight =
-    !scopeNotApplicable &&
+    !scopeBlocksConvergenceEval &&
     rerollMarkers.latestAt !== '' &&
     !hasFreshReviewSinceLastReroll &&
     rerollElapsedMinutes < pendingWindowMinutesForReroll;
@@ -948,6 +1047,38 @@ export function computeAdvisoryConvergenceVerdict(
   };
 }
 
+/**
+ * #1686: defense-in-depth on top of `isCopilotReviewerLogin`'s login-string
+ * check. GitHub's GraphQL API reports `__typename: "Bot"` consistently for
+ * every App/bot account regardless of login spelling, and a real human
+ * account can never report it -- so a *registrable* login lookalike (e.g. a
+ * human account named `copilot-pull-request-reviewer`, distinct from the
+ * real bot's own `[bot]`-suffixed login) still fails this check even though
+ * it passes the login-string comparison. This file's own GraphQL queries
+ * (`fetchReviewsAndHeadCommit` / `fetchReviewThreads` /
+ * `fetchThreadCommentPages`) request `__typename` on every `author` field,
+ * so every LIVE payload this gate evaluates carries it; a payload that
+ * omits it (an older fixture, or a future caller not routed through this
+ * file's own queries) is treated as "unknown" and does NOT fail the check
+ * -- this stays a narrowing on top of the login match, never a new
+ * blocking requirement for a caller this field predates. Deliberately kept
+ * local to this file (mirroring `rerun-advisory-convergence.mts`'s own
+ * "closes it locally without widening that shared function's behavior"
+ * precedent) rather than folded into `isCopilotReviewerLogin` itself, which
+ * many REST-payload callers across the codebase rely on and which has no
+ * `__typename` to check.
+ */
+function isVerifiedCopilotAuthor(
+  author: GhAuthorPayload | null | undefined,
+  primaryBotLogin: string,
+): boolean {
+  if (!isCopilotReviewerLogin(author?.login ?? '', primaryBotLogin)) {
+    return false;
+  }
+  const typename = author?.__typename;
+  return typename === undefined || typename === null || typename === 'Bot';
+}
+
 /** Evaluate Clause 1 against the single, absolute-latest Copilot review --
  * per the issue's literal wording ("the latest Copilot review's commit_id
  * equals current HEAD"), not "the latest review among those that happen to
@@ -976,9 +1107,7 @@ function resolveLatestCopilotReviewClause(
   primaryBotLogin: string,
 ): AdvisoryConvergenceReviewClause {
   const latest = reviews
-    .filter((review) =>
-      isCopilotReviewerLogin(review.author?.login ?? '', primaryBotLogin),
-    )
+    .filter((review) => isVerifiedCopilotAuthor(review.author, primaryBotLogin))
     .at(-1);
   if (!latest) {
     return {
@@ -1032,7 +1161,7 @@ export function classifyCopilotAuthoredThreadIds(
     const originating = (thread.comments?.nodes ?? [])[0];
     if (
       originating &&
-      isCopilotReviewerLogin(originating.author?.login ?? '', primaryBotLogin)
+      isVerifiedCopilotAuthor(originating.author, primaryBotLogin)
     ) {
       // Match `summarizeDispositionEvidenceForGate`'s own
       // `missingThreads[].id` fallback exactly (protocol-helpers.mts) so a
@@ -1385,6 +1514,28 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
     trustedMarkerLogins,
     Boolean(args.claimIssueNumber),
   );
+  // #1686: ambiguity is a distinct signal from `claimEvents` above --
+  // `pickResolvingClaimEvents` deliberately collapses BOTH "zero candidates
+  // resolve" and "two or more candidates resolve" to `[]` (see its own doc
+  // comment), so this must be computed separately over the same
+  // `claimCandidates`/`trustedMarkerLogins` inputs rather than re-derived
+  // from the already-collapsed `claimEvents`.
+  const claimCandidateAmbiguous = classifyClaimCandidateAmbiguity(
+    claimCandidates,
+    trustedMarkerLogins,
+    Boolean(args.claimIssueNumber),
+  );
+  // #1686: true when ANY candidate claim issue ever carried a trusted,
+  // syntactically valid `claimed-by` marker -- computed over the union of
+  // every candidate's RAW comment stream (`claimCandidates`, not the
+  // resolved-and-possibly-emptied `claimEvents`), so a stale, released, or
+  // otherwise no-longer-active claim still counts as genuine IDD claim
+  // history. See `hasTrustedClaimMarkerHistory`'s doc comment for the full
+  // rationale and the module header's path 4.
+  const claimMarkerHistoryPresent = hasTrustedClaimMarkerHistory(
+    claimCandidates,
+    trustedMarkerLogins,
+  );
 
   const primaryBotLogin = readAdvisoryPrimaryBotLogin();
   const deadlineMinutes = readAdvisoryConvergenceDeadlineMinutes();
@@ -1445,6 +1596,8 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
       threads,
       comments,
       claimEvents,
+      claimMarkerHistoryPresent,
+      claimCandidateAmbiguous,
     },
     options: {
       now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
@@ -1556,6 +1709,23 @@ function fetchClaimEventCandidates(
   );
 }
 
+/** Candidate claim-issue comment streams whose *active claim* actually
+ * resolves (`summarizeClaimValidation`). Shared by
+ * {@link pickResolvingClaimEvents} and {@link classifyClaimCandidateAmbiguity}
+ * (#1686) so both read the identical disambiguation result instead of two
+ * independently-maintained filters that could drift. */
+function filterResolvingClaimCandidates(
+  candidates: IssueCommentPayload[][],
+  trustedMarkerLogins: string[],
+): IssueCommentPayload[][] {
+  return candidates.filter((comments) =>
+    Boolean(
+      summarizeClaimValidation(comments, { trustedMarkerLogins })
+        .activeClaimPresent,
+    ),
+  );
+}
+
 /**
  * Resolve the linked (claim) issue's comment stream for waiver-claim
  * binding, given already-fetched candidate comment streams
@@ -1571,7 +1741,14 @@ function fetchClaimEventCandidates(
  * own `selectLinkedIssueCandidate` disambiguates multiple linked issues by
  * active-claim presence rather than requiring a single closing reference.
  * Zero or multiple resolving candidates fail closed to `[]` (no waiver
- * claim can bind unambiguously), same as before #1344/#1347.
+ * claim can bind unambiguously), same as before #1344/#1347 -- and
+ * unchanged by #1686: {@link classifyClaimCandidateAmbiguity} below is the
+ * new, separate signal that lets a caller tell the "zero resolving" and
+ * "multiple resolving" cases apart without touching this function's own
+ * fail-closed-to-`[]` contract (pinned by
+ * "pickResolvingClaimEvents: zero or multiple resolving candidates still
+ * fail closed to [] (unchanged from pre-#1344/#1347 behavior)" in
+ * tests/advisory-convergence.test.mts).
  */
 export function pickResolvingClaimEvents(
   candidates: IssueCommentPayload[][],
@@ -1581,13 +1758,86 @@ export function pickResolvingClaimEvents(
   if (isExplicit) {
     return candidates[0] ?? [];
   }
-  const resolving = candidates.filter((comments) =>
-    Boolean(
-      summarizeClaimValidation(comments, { trustedMarkerLogins })
-        .activeClaimPresent,
-    ),
+  const resolving = filterResolvingClaimCandidates(
+    candidates,
+    trustedMarkerLogins,
   );
   return resolving.length === 1 ? resolving[0] : [];
+}
+
+/**
+ * #1686: true when two or more claim-issue candidates each independently
+ * resolve an active trusted claim -- the specific disambiguation-failure
+ * case {@link pickResolvingClaimEvents} already fails closed to `[]` for
+ * (see its own doc comment above and the module header's path 2). Surfaced
+ * as an explicit signal so the `idd-claimed` applicability gate
+ * (`computeAdvisoryConvergenceVerdict`) can distinguish "this PR's closing
+ * references are ambiguous between two actively-claimed issues" from the
+ * ordinary "no candidate resolves at all" case, which
+ * `pickResolvingClaimEvents`'s own collapsed `[]` output cannot
+ * distinguish by itself. An explicit `--claim-issue` target has no
+ * ambiguity to resolve -- always `false`, mirroring
+ * `pickResolvingClaimEvents`'s own `isExplicit` short-circuit.
+ */
+export function classifyClaimCandidateAmbiguity(
+  candidates: IssueCommentPayload[][],
+  trustedMarkerLogins: string[],
+  isExplicit: boolean,
+): boolean {
+  if (isExplicit) {
+    return false;
+  }
+  return (
+    filterResolvingClaimCandidates(candidates, trustedMarkerLogins).length > 1
+  );
+}
+
+/**
+ * #1686: true when at least one TRUSTED, syntactically valid `claimed-by`
+ * marker exists anywhere in `candidates`' raw comment streams -- regardless
+ * of whether it currently resolves to an ACTIVE claim. A released
+ * (`unclaimed-by`), superseded-without-a-qualifying-takeover, or otherwise
+ * no-longer-current claim still counts: this function answers "did real IDD
+ * claim activity ever happen here", not "is a claim active right now" (that
+ * question is `summarizeClaimValidation(...).activeClaimPresent`, already
+ * computed elsewhere).
+ *
+ * Note on *why* this function is needed rather than an age comparison:
+ * `resolveActiveClaim` (protocol-helpers.mts) has no `now` parameter and
+ * never expires a claim by elapsed time alone -- staleness there only
+ * matters when a LATER claim event attempts to supersede the active one
+ * (`claim.supersedes === activeClaim.claimId && isStale(...)`). A claim
+ * that goes stale on a long-open PR with no subsequent takeover event stays
+ * `activeClaimPresent: true` forever in this codebase; time by itself never
+ * clears it. So the concrete way `activeClaimPresent` becomes `false` while
+ * genuine claim history exists is an explicit release/handoff event (or a
+ * disambiguation failure -- see {@link classifyClaimCandidateAmbiguity}
+ * instead), not a bare age computation -- this function's own test fixtures
+ * demonstrate that shape rather than asserting on elapsed time. See the
+ * module header's path 4 and `AdvisoryConvergenceInputs.claimMarkerHistoryPresent`'s
+ * doc comment.
+ */
+export function hasTrustedClaimMarkerHistory(
+  candidates: IssueCommentPayload[][],
+  trustedMarkerLogins: string[],
+): boolean {
+  const trusted = new Set(trustedMarkerLogins);
+  return candidates.some((candidateComments) =>
+    candidateComments.some((event) => {
+      const login = String(event.author?.login ?? event.user?.login ?? '')
+        .trim()
+        .toLowerCase();
+      if (!trusted.has(login)) {
+        return false;
+      }
+      return (
+        parseClaimComment(
+          event.body ?? '',
+          event.createdAt ?? event.created_at ?? '',
+        ) !== null
+      );
+    }),
+  );
 }
 
 /**
@@ -1688,7 +1938,7 @@ function fetchReviewsAndHeadCommit(
                 nodes {
                   commit { oid }
                   submittedAt
-                  author { login }
+                  author { login __typename }
                   comments { totalCount }
                 }
               }
@@ -1764,7 +2014,7 @@ function fetchReviewThreads(
                       body
                       createdAt
                       updatedAt
-                      author { login }
+                      author { login __typename }
                       pullRequestReview { id }
                     }
                   }
@@ -1832,7 +2082,7 @@ function fetchThreadCommentPages(
                   body
                   createdAt
                   updatedAt
-                  author { login }
+                  author { login __typename }
                   pullRequestReview { id }
                 }
               }

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2315,14 +2315,34 @@ export function classifyCiChecks(checks: CheckLike[]) {
 }
 
 /**
+ * #1686: the exact, closed set of logins recognized for the *default*
+ * Copilot primary advisory bot -- the human-facing `copilot` slash-command
+ * actor plus the two known GitHub-App review-bot login forms. Previously
+ * matched via `normalized.startsWith('copilot-pull-request-reviewer')`,
+ * which a *registrable* GitHub username lookalike (for example
+ * `copilot-pull-request-reviewer1`) could also satisfy on a public
+ * repository: any account can submit a PR review, so a lookalike login
+ * could post an empty review of the current HEAD and masquerade as the
+ * real bot's convergence signal (Clause 1 of `advisory-convergence.mts`'s
+ * verdict: `matchesHead: true, itemCount: 0`). An exact set closes that
+ * gap without narrowing the two genuine login forms GitHub actually uses.
+ */
+const EXACT_COPILOT_REVIEWER_LOGINS: ReadonlySet<string> = new Set([
+  'copilot',
+  'copilot-pull-request-reviewer',
+  'copilot-pull-request-reviewer[bot]',
+]);
+
+/**
  * Match a review/reviewer login against the configured primary advisory bot.
  *
  * `primaryBotLogin` defaults to Copilot so existing callers stay behavior-
- * preserving. For the Copilot default the historical dual match is kept
- * (the exact `copilot` actor plus the `copilot-pull-request-reviewer*` GitHub
- * App login family). A non-Copilot configured login is matched by exact
- * normalized (trimmed, lower-cased) equality, since an arbitrary bot login has
- * no analogous prefix family.
+ * preserving. For the Copilot default, the login must be an exact member of
+ * {@link EXACT_COPILOT_REVIEWER_LOGINS} (#1686 -- previously a broader
+ * `copilot-pull-request-reviewer*` prefix match; see that constant's doc
+ * comment for why it was narrowed). A non-Copilot configured login is
+ * matched by exact normalized (trimmed, lower-cased) equality, since an
+ * arbitrary bot login has no analogous prefix family.
  */
 export function isCopilotReviewerLogin(
   login: unknown,
@@ -2336,10 +2356,7 @@ export function isCopilotReviewerLogin(
       .trim()
       .toLowerCase() || DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
   if (configured === DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN) {
-    return (
-      normalized === 'copilot' ||
-      normalized.startsWith('copilot-pull-request-reviewer')
-    );
+    return EXACT_COPILOT_REVIEWER_LOGINS.has(normalized);
   }
   return normalized === configured;
 }

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -830,8 +830,10 @@ function classifyInstance(
  * through as rerun-eligible (#1434 review, Codex P2).
  *
  * `isCopilotReviewerLogin` itself only normalizes this way for the
- * *default* Copilot login (a `copilot`/`copilot-pull-request-reviewer*`
- * prefix match); once a repository configures a non-default
+ * *default* Copilot login (an exact-set match against `copilot`/
+ * `copilot-pull-request-reviewer`/`copilot-pull-request-reviewer[bot]` --
+ * #1686 narrowed this from a `copilot-pull-request-reviewer*` prefix
+ * match); once a repository configures a non-default
  * `primaryBotLogin`, it falls back to an exact `normalized === configured`
  * comparison with no `[bot]`-suffix handling -- the same gap the
  * `advisoryBotLogins` fallback already closed for its own set, just on

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -6,8 +6,10 @@ import {
   type AdvisoryConvergenceDeps,
   type AdvisoryConvergenceInputs,
   type AdvisoryConvergenceOptions,
+  classifyClaimCandidateAmbiguity,
   classifyCopilotAuthoredThreadIds,
   computeAdvisoryConvergenceVerdict,
+  hasTrustedClaimMarkerHistory,
   parseArgs,
   pickResolvingClaimEvents,
   runAdvisoryConvergence,
@@ -19,6 +21,7 @@ import {
   renderExternalCheckWaiverComment,
 } from '../src/scripts/marker-helpers.mts';
 import { normalizePolicyConfig } from '../src/scripts/policy-helpers.mts';
+import { summarizeClaimValidation } from '../src/scripts/protocol-helpers.mts';
 import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
 
 const SCHEMA = loadJson('schemas/advisory-convergence.schema.json');
@@ -216,7 +219,7 @@ test('idd-claimed scope: matching linked-claim branch keeps the gate applicable'
   assert.equal(verdict.ready, true);
 });
 
-test('idd-claimed scope: a branch mismatch short-circuits the gate as not applicable', () => {
+test('idd-claimed scope: a branch mismatch against an active trusted claim makes the gate indeterminate, not not_applicable (#1686 path 3)', () => {
   const verdict = computeAdvisoryConvergenceVerdict(
     baseInputs({
       reviews: [copilotReview()],
@@ -230,12 +233,117 @@ test('idd-claimed scope: a branch mismatch short-circuits the gate as not applic
   assertValidVerdict(verdict);
   assert.deepEqual(verdict.applicability, {
     scope: 'idd-claimed',
-    status: 'not_applicable',
+    status: 'indeterminate',
     reason: 'idd-claimed-branch-mismatch',
   });
+  assert.equal(verdict.pending, false);
   assert.equal(verdict.converged, false);
+  // Indeterminate must never let `ready` become true through the ordinary
+  // convergence path -- only a maintainer waiver (tested separately below)
+  // can clear it, unlike the pre-#1686 not_applicable behavior this test
+  // used to assert (`ready: true` unconditionally).
+  assert.equal(verdict.ready, false);
+  assert.match(
+    verdict.reasons.join('\n'),
+    /applicability is indeterminate \(idd-claimed-branch-mismatch\)/,
+  );
+});
+
+test('idd-claimed scope: an indeterminate branch mismatch still falls through the existing maintainer-waiver escape hatch (#1686)', () => {
+  // The active claim here has a real, non-empty claimId, so a waiver CAN
+  // bind to it -- unlike paths 2/4 below, where `activeClaimId` stays ''
+  // and `summarizeExternalCheckWaivers` fails closed on an unbound waiver.
+  const waiverBody = renderExternalCheckWaiverComment({
+    agentId: AGENT_ID,
+    claimId: CLAIM_ID,
+    headSha: HEAD,
+    checkSelector: 'idd-advisory-convergence',
+    reason: 'confirmed benign branch-name mismatch (#1686)',
+    expiresAt: '2026-07-12T00:00:00Z',
+    actor: TRUSTED,
+  });
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview()],
+      claimEvents: [claimComment()],
+      comments: [
+        { author: { login: TRUSTED }, body: waiverBody, createdAt: RECENT },
+      ],
+    }),
+    baseOptions({
+      convergenceScope: 'idd-claimed',
+      prHeadRefName: 'issue/1234-different',
+      headCommittedAt: OLD,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.applicability.status, 'indeterminate');
+  assert.equal(verdict.deadline.passed, true);
+  assert.equal(verdict.waived, true);
   assert.equal(verdict.ready, true);
-  assert.deepEqual(verdict.reasons, []);
+});
+
+test('idd-claimed scope: multiple resolving claim candidates make the gate indeterminate, not not_applicable (#1686 path 2)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview()],
+      // Disambiguation already failed closed to [] upstream (mirrors
+      // `pickResolvingClaimEvents`'s own contract) -- `claimCandidateAmbiguous`
+      // is the separate signal that tells this apart from "no claim at all".
+      claimEvents: [],
+      claimCandidateAmbiguous: true,
+    }),
+    baseOptions({
+      convergenceScope: 'idd-claimed',
+      prHeadRefName: 'issue/1234-test',
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.deepEqual(verdict.applicability, {
+    scope: 'idd-claimed',
+    status: 'indeterminate',
+    reason: 'idd-claimed-multiple-resolving-claim-candidates',
+  });
+  assert.equal(verdict.pending, false);
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.ready, false);
+  // No activeClaimId exists to bind a waiver to -- summarizeExternalCheckWaivers
+  // fails closed on an unbound waiver, so this path is not waivable in practice
+  // even with waiverMode: 'maintainer-authorized' (unlike the branch-mismatch
+  // path above, which has a real activeClaimId).
+});
+
+test('idd-claimed scope: a stale trusted claim (claim-marker history present, no currently active claim) yields a failing outcome, not not_applicable (#1686 path 4)', () => {
+  // `resolveActiveClaim` (protocol-helpers.mts) has no `now` and never
+  // expires a claim by elapsed time alone; staleness there only matters when
+  // a LATER event attempts to supersede the active claim. So the concrete
+  // way `activeClaimPresent` becomes false while claim history genuinely
+  // exists is an explicit release, not a bare age check -- this fixture
+  // demonstrates that shape (a stale, well-past-staleAge claimed-by marker,
+  // explicitly released) rather than asserting on elapsed time. See
+  // `hasTrustedClaimMarkerHistory`'s doc comment for the full finding.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview()],
+      claimEvents: [],
+      claimMarkerHistoryPresent: true,
+    }),
+    baseOptions({
+      convergenceScope: 'idd-claimed',
+      prHeadRefName: 'issue/1234-test',
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.deepEqual(verdict.applicability, {
+    scope: 'idd-claimed',
+    status: 'indeterminate',
+    reason: 'idd-claimed-claim-history-without-active-claim',
+  });
+  assert.equal(verdict.pending, false);
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.ready, false);
 });
 
 test('idd-claimed scope: a PR without a verified linked claim is not applicable', () => {
@@ -1407,7 +1515,22 @@ test('ineligibleReasons: empty exactly when eligible is true', () => {
   assert.deepEqual(verdict.sameHeadReroll.ineligibleReasons, []);
 });
 
-test('ineligibleReasons: scope-not-applicable fires alone when only the applicability term fails', () => {
+test('ineligibleReasons: scope-not-applicable fires alone when applicability is not_applicable', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [copilotReview({ itemCount: 2 })], claimEvents: [] }),
+    baseOptions({
+      convergenceScope: 'idd-claimed',
+      prHeadRefName: 'feature/no-claim',
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.applicability.status, 'not_applicable');
+  assert.deepEqual(verdict.sameHeadReroll.ineligibleReasons, [
+    SAME_HEAD_REROLL_INELIGIBLE_REASON.SCOPE_NOT_APPLICABLE,
+  ]);
+});
+
+test('ineligibleReasons: scope-not-applicable also fires alone when applicability is indeterminate (#1686)', () => {
   const verdict = computeAdvisoryConvergenceVerdict(
     baseInputs({
       reviews: [copilotReview({ itemCount: 2 })],
@@ -1419,7 +1542,7 @@ test('ineligibleReasons: scope-not-applicable fires alone when only the applicab
     }),
   );
   assertValidVerdict(verdict);
-  assert.equal(verdict.applicability.status, 'not_applicable');
+  assert.equal(verdict.applicability.status, 'indeterminate');
   assert.deepEqual(verdict.sameHeadReroll.ineligibleReasons, [
     SAME_HEAD_REROLL_INELIGIBLE_REASON.SCOPE_NOT_APPLICABLE,
   ]);
@@ -2005,6 +2128,183 @@ test('classifyCopilotAuthoredThreadIds: a thread counts only when its ORIGINATIN
     'copilot',
   );
   assert.deepEqual([...ids].sort(), ['A']);
+});
+
+test('classifyCopilotAuthoredThreadIds: #1686 -- a login-matching author is excluded when __typename proves it is not a Bot', () => {
+  const ids = classifyCopilotAuthoredThreadIds(
+    [
+      {
+        id: 'A',
+        comments: {
+          nodes: [
+            {
+              author: { login: COPILOT_LOGIN, __typename: 'User' },
+              createdAt: OLD,
+            },
+          ],
+        },
+      },
+      {
+        id: 'B',
+        comments: {
+          nodes: [
+            {
+              author: { login: COPILOT_LOGIN, __typename: 'Bot' },
+              createdAt: OLD,
+            },
+          ],
+        },
+      },
+      {
+        id: 'C',
+        comments: {
+          // No __typename on the payload at all: treated as unknown, not a
+          // rejection -- preserves every pre-#1686 fixture/caller.
+          nodes: [{ author: { login: COPILOT_LOGIN }, createdAt: OLD }],
+        },
+      },
+    ],
+    'copilot',
+  );
+  assert.deepEqual([...ids].sort(), ['B', 'C']);
+});
+
+test('#1686: Clause 1 rejects a login-matching review whose __typename proves it is not a Bot', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({ author: { login: COPILOT_LOGIN, __typename: 'User' } }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.found, false);
+  assert.equal(verdict.pending, true);
+});
+
+test('#1686: Clause 1 still accepts a login-matching review whose __typename is Bot or absent', () => {
+  const withBotTypename = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({ author: { login: COPILOT_LOGIN, __typename: 'Bot' } }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(withBotTypename);
+  assert.equal(withBotTypename.converged, true);
+
+  const withoutTypename = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [copilotReview()] }),
+    baseOptions(),
+  );
+  assertValidVerdict(withoutTypename);
+  assert.equal(withoutTypename.converged, true);
+});
+
+// --- classifyClaimCandidateAmbiguity (#1686 path 2) -------------------------
+
+test('classifyClaimCandidateAmbiguity: false when zero or exactly one candidate resolves', () => {
+  const noClaim = [
+    { author: { login: TRUSTED }, body: 'not a claim', createdAt: OLD },
+  ];
+  const claimA = [claimComment('claim-a')];
+  assert.equal(
+    classifyClaimCandidateAmbiguity([noClaim], [TRUSTED], false),
+    false,
+  );
+  assert.equal(
+    classifyClaimCandidateAmbiguity([claimA], [TRUSTED], false),
+    false,
+  );
+  assert.equal(
+    classifyClaimCandidateAmbiguity([noClaim, claimA], [TRUSTED], false),
+    false,
+  );
+});
+
+test('classifyClaimCandidateAmbiguity: true when two or more candidates each resolve an active claim', () => {
+  const claimA = [claimComment('claim-a')];
+  const claimB = [claimComment('claim-b')];
+  assert.equal(
+    classifyClaimCandidateAmbiguity([claimA, claimB], [TRUSTED], false),
+    true,
+  );
+});
+
+test('classifyClaimCandidateAmbiguity: an explicit candidate (--claim-issue) is never ambiguous', () => {
+  const claimA = [claimComment('claim-a')];
+  const claimB = [claimComment('claim-b')];
+  assert.equal(
+    classifyClaimCandidateAmbiguity([claimA, claimB], [TRUSTED], true),
+    false,
+  );
+});
+
+// --- hasTrustedClaimMarkerHistory (#1686 path 4) ----------------------------
+
+test('hasTrustedClaimMarkerHistory: false when no candidate ever carried a trusted claim marker', () => {
+  assert.equal(hasTrustedClaimMarkerHistory([], [TRUSTED]), false);
+  assert.equal(
+    hasTrustedClaimMarkerHistory(
+      [
+        [
+          {
+            author: { login: TRUSTED },
+            body: 'just a comment',
+            createdAt: OLD,
+          },
+        ],
+      ],
+      [TRUSTED],
+    ),
+    false,
+  );
+});
+
+test('hasTrustedClaimMarkerHistory: false when the only claim marker is from an untrusted author', () => {
+  assert.equal(
+    hasTrustedClaimMarkerHistory(
+      [[{ ...claimComment(), author: { login: 'random-account' } }]],
+      [TRUSTED],
+    ),
+    false,
+  );
+});
+
+test('hasTrustedClaimMarkerHistory: true for a still-active trusted claim (the ordinary case)', () => {
+  assert.equal(
+    hasTrustedClaimMarkerHistory([[claimComment()]], [TRUSTED]),
+    true,
+  );
+});
+
+test('hasTrustedClaimMarkerHistory: true for a STALE trusted claim -- a claimed-by marker well past staleAge with no active claim resolving', () => {
+  // Ground truth for path 4: `resolveActiveClaim` never expires a claim by
+  // elapsed time alone (see this function's own doc comment) -- the
+  // concrete way `activeClaimPresent` becomes false while history exists is
+  // an explicit release. This fixture is exactly that shape: an old
+  // `claimed-by` (`OLD`, well past the 24h staleAge default relative to
+  // `NOW`) followed by a trusted `unclaimed-by` release for the SAME
+  // agent/claim -- `summarizeClaimValidation` resolves no active claim, but
+  // the claim marker history is unambiguously real.
+  const claimId = 'stale-claim-1';
+  const agentId = 'claude-test';
+  const released = [
+    claimComment(claimId),
+    {
+      author: { login: TRUSTED },
+      body: `<!-- unclaimed-by: ${agentId} ${claimId} ${RECENT} -->\n\n_${agentId}: issue claim released — IDD automation marker. Do not edit._`,
+      createdAt: RECENT,
+    },
+  ];
+  assert.equal(
+    summarizeClaimValidation(released, { trustedMarkerLogins: [TRUSTED] })
+      .activeClaimPresent,
+    false,
+  );
+  assert.equal(hasTrustedClaimMarkerHistory([released], [TRUSTED]), true);
 });
 
 // --- parseArgs ---------------------------------------------------------------

--- a/tests/advisory-wait.test.mts
+++ b/tests/advisory-wait.test.mts
@@ -916,6 +916,34 @@ test('isCopilotReviewerLogin keeps the dual Copilot match by default and matches
   assert.equal(isCopilotReviewerLogin('copilot', '   '), true);
 });
 
+test('#1686: isCopilotReviewerLogin matches only the exact Copilot login set and rejects a registrable lookalike', () => {
+  // The three exact logins the default Copilot match now recognizes.
+  assert.equal(isCopilotReviewerLogin('copilot'), true);
+  assert.equal(isCopilotReviewerLogin('Copilot'), true);
+  assert.equal(isCopilotReviewerLogin('copilot-pull-request-reviewer'), true);
+  assert.equal(
+    isCopilotReviewerLogin('copilot-pull-request-reviewer[bot]'),
+    true,
+  );
+  assert.equal(
+    isCopilotReviewerLogin('Copilot-Pull-Request-Reviewer[Bot]'),
+    true,
+  );
+  // The acceptance-criterion regression: a GitHub username is alphanumeric-
+  // plus-hyphen, so `copilot-pull-request-reviewer1` is a REGISTRABLE login
+  // distinct from the real bot's own two forms above. The pre-#1686 prefix
+  // match (`startsWith('copilot-pull-request-reviewer')`) accepted it; the
+  // exact-set match must not.
+  assert.equal(isCopilotReviewerLogin('copilot-pull-request-reviewer1'), false);
+  // A handful of other lookalike shapes a prefix match would also have let
+  // through.
+  assert.equal(
+    isCopilotReviewerLogin('copilot-pull-request-reviewer-fake'),
+    false,
+  );
+  assert.equal(isCopilotReviewerLogin('copilot-impersonator'), false);
+});
+
 test('advisory wait summary resolves coverage against a configured primary bot', () => {
   const headSha = 'b'.repeat(40);
   const input = {


### PR DESCRIPTION
# Summary

The `idd-advisory-convergence` required check exists to stay robust
"against a weak or careless execution model tampering with its own
gate," but under `advisoryWait.convergenceScope: "idd-claimed"` its
readiness formula could reach `not_applicable` (`ready: true`, zero
Copilot involvement) via inputs the executing session itself
controls:

1. **Path 2 — ambiguous claim linkage**: a PR closing two
   actively-claimed issues made `pickResolvingClaimEvents` fail
   closed to `[]`, flipping `activeClaimPresent` to `false` and the
   gate green.
2. **Path 3 — claim-branch mismatch**: a PR head branch that no
   longer matches the branch recorded on an active trusted claim
   resolved `not_applicable`.
3. **Path 4 — stale/released claim**: a claim whose marker history is
   real but no longer resolves active (explicit release, or a
   superseded-without-takeover chain) also resolved `not_applicable`.

`computeAdvisoryConvergenceVerdict` now classifies each of these as a
new `applicability.status: "indeterminate"` — distinct from both
`applicable` and `not_applicable`. Unlike `not_applicable`,
`indeterminate` never satisfies `ready` through the ordinary
convergence path; only the existing deadline/terminal-plus-
maintainer-waiver escape hatch can still clear it. For paths 2 and 4
no `activeClaimId` exists to bind a waiver to at all
(`summarizeExternalCheckWaivers` fails closed on an empty claim id),
so those two are effectively not waivable in practice — only path 3
(a real, resolvable active claim) stays genuinely waivable by a
trusted maintainer. A genuinely non-IDD PR (no linked issue, no claim
history anywhere) is unaffected and still resolves `not_applicable`.

Path 1 (a PR body that omits or mangles its `Closes #N` reference) is
a **known, documented residual**, not closed by this PR — see the new
header comment in `.github/workflows/idd-advisory-convergence.yml`
for the two candidate signals considered (PR-author trusted-actor
membership, branch-name inference) and why both were rejected (the
first blocks legitimate non-IDD maintainer PRs; the second is itself
session-controlled). It remains the honor-system layer #1341 already
names as insufficient alone, mitigated by D3.5's closing-keyword
verification and CODEOWNERS review as the general backstop.

Separately, `isCopilotReviewerLogin`'s
`startsWith('copilot-pull-request-reviewer')` prefix match let a
*registrable* GitHub username lookalike (e.g.
`copilot-pull-request-reviewer1`) satisfy Clause 1's reviewer-identity
check on a public repository. It is now an exact three-login set
(`copilot`, `copilot-pull-request-reviewer`,
`copilot-pull-request-reviewer[bot]`), and `advisory-convergence.mts`
additionally requires the GraphQL `author.__typename === 'Bot'`
signal where the payload provides it (this file's own GraphQL queries
now request it explicitly; an absent `__typename` is treated as
unknown, never a rejection, so every pre-existing fixture/caller
stays behavior-preserving). The same prefix pattern in the AW1
shell-fallback docs (`docs/idd-advisory-wait-shell-fallback.md`) is
fixed too.

## Linked issue

Closes #1686

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`src/scripts/advisory-convergence.mts` changes:

- Three-state applicability (`applicable` / `not_applicable` /
  `indeterminate`), new `classifyClaimCandidateAmbiguity` and
  `hasTrustedClaimMarkerHistory` pure helpers, `isVerifiedCopilotAuthor`
  (`__typename` hardening), GraphQL queries extended to request
  `__typename`.
- `pickResolvingClaimEvents`'s existing fail-closed-to-`[]` contract
  is unchanged and still pinned by its own pre-#1344/#1347 regression
  test; `classifyClaimCandidateAmbiguity` is new, separate evidence
  computed from the same candidate set.

`src/scripts/protocol-helpers.mts`: `isCopilotReviewerLogin` exact-set
match.

`src/scripts/rerun-advisory-convergence.mts`: stale doc-comment fix
only (already reuses `isCopilotReviewerLogin`, no behavior change).

Docs (`docs/idd-helper-scripts.md`, `docs/customization.md`,
`docs/policy-constants.md`, `docs/idd-advisory-wait-shell-fallback.md`)
are edited via their `idd-template/docs/` sources, since these four
are template→docs sync pairs (`audit/sync-manifest.json`); regenerated
with `node scripts/sync-docs.mjs --apply`.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed (`idd-template/docs/*` sync sources for
      the four doc pairs above)
- [x] Helper scripts changed (`advisory-convergence.mts`,
      `protocol-helpers.mts`; generated `.mjs` committed)
- [x] Config schema changed (`schemas/advisory-convergence.schema.json`
      — `applicability.status` enum gains `"indeterminate"`)
- [x] Security / credential / merge behavior changed (this is the
      point of the PR: closes three fail-open paths in a required
      merge gate, and tightens reviewer-identity matching)

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (2853 tests)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (pre-existing warnings only)
- [x] `pnpm run build:check` (generated `scripts/*.mjs` matches the
      `.mts` sources)

New tests cover every acceptance criterion in #1686: multiple
resolving claim candidates → non-zero `--assert` exit; a claim-branch
mismatch against an active claim → non-zero exit (and separately,
that it still falls through the existing maintainer-waiver hatch
where a real `activeClaimId` exists); a stale trusted claim (marker
history present, no active claim) → failing, not `not_applicable`
(with a fixture demonstrating that `resolveActiveClaim` never expires
a claim by elapsed time alone — the concrete mechanism is an explicit
release, documented in the test and the new helper's doc comment); a
PR with no linked issue and no claim history → unaffected, still
`not_applicable`; `isCopilotReviewerLogin('copilot-pull-request-reviewer1')`
→ `false`, the three exact logins still match; a login-matching
review/thread author whose `__typename` is `User` → rejected.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (tightens the gate; no relaxation)
- [x] Context budget impact reviewed (no instruction-file changes)
