### PR TITLE
fix(gitignore): re-include .claude/agents/ and .claude/commands/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,8 @@ pnpm-lock.yaml.*
 # the tracked curated permission allow/deny baseline (see issue #1595).
 .claude/*
 !.claude/skills/
+!.claude/agents/
+!.claude/commands/
 !.claude/settings.json
 
 # OpenAI Codex sandbox


### PR DESCRIPTION
## Summary

- Add `!.claude/agents/` and `!.claude/commands/` to the `.claude/*`
  gitignore block, alongside the existing `!.claude/skills/` and
  `!.claude/settings.json` re-includes.
- No current data loss (this repo doesn't use either directory yet),
  but the gap was latent: adding either later would leave it silently
  untracked under `.claude/*` unless someone remembered the matching
  `!` line first.

Closes #1778.

## Test plan

- [x] `git status --porcelain` / `git add --dry-run` confirm scratch
      files under `.claude/agents/` and `.claude/commands/` are no
      longer ignored (verified, then removed before commit).
- [x] `.claude/settings.local.json` and an arbitrary file directly
      under `.claude/` remain ignored (rescue scope unchanged beyond
      the four named subpaths).
- [x] `biome check`, `dprint check`, `markdownlint-cli2`, `cspell lint`,
      `audit-docs.mjs --check`, `audit-code-span-wrap.mjs`,
      `build:check`, and `idd-doctor.mjs` all pass.