### PR TITLE
docs: add OKF frontmatter to source-repo-only docs pages

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -828,30 +828,7 @@
         "investigation",
         "tutorial"
       ],
-      "exemptPaths": [
-        "docs/ai-strategy.md",
-        "docs/claude-skill-strategy.md",
-        "docs/harness-orchestrated-execution-investigation.md",
-        "docs/issue-authoring-skill.md",
-        "docs/pages-strategy.md",
-        "docs/positioning.md",
-        "docs/pr-cleanup-backlog-batch-001.md",
-        "docs/skills-delivery-investigation.md",
-        "docs/stalled-session-quiet-check.md",
-        "docs/typescript-sources.md",
-        "docs/weak-model-authoring-lite-profile-design.md",
-        "docs/weak-model-lite-profile-design.md",
-        "docs/workshop/assets/recordings/README.md",
-        "docs/workshop/bonus-defang-deployment.md",
-        "docs/workshop/LOG-FORMAT.md",
-        "docs/workshop/log-segments/01-bootstrap.md",
-        "docs/workshop/log-segments/02-infrastructure.md",
-        "docs/workshop/log-segments/03-data-layer.md",
-        "docs/workshop/log-segments/04-backend-api.md",
-        "docs/workshop/log-segments/05-frontend-quality.md",
-        "docs/workshop/README.md",
-        "docs/workshop/workshop-log.md"
-      ]
+      "exemptPaths": []
     }
   ]
 }

--- a/docs/ai-strategy.md
+++ b/docs/ai-strategy.md
@@ -1,3 +1,10 @@
+---
+type: design
+title: AI tooling strategy
+description: Explains why this repository prioritizes GitHub Copilot and how the other agent compatibility entry files should stay in sync with it.
+tags: [ai-strategy, copilot]
+---
+
 # AI tooling strategy
 
 This repository currently prioritizes GitHub Copilot because it

--- a/docs/claude-skill-strategy.md
+++ b/docs/claude-skill-strategy.md
@@ -1,3 +1,10 @@
+---
+type: design
+title: Claude Code Skill Strategy for the IDD Execution Loop
+description: Records the design evaluation and no-go decision for packaging the IDD execution loop as a Claude Code skill.
+tags: [claude-code, skill-strategy]
+---
+
 # Claude Code Skill Strategy for the IDD Execution Loop
 
 This page records the design evaluation for packaging the IDD execution

--- a/docs/harness-orchestrated-execution-investigation.md
+++ b/docs/harness-orchestrated-execution-investigation.md
@@ -1,3 +1,10 @@
+---
+type: investigation
+title: "Investigation: Harness-Orchestrated Execution Mode for Weak Local Models"
+description: Records the findings and recommendation on whether to define a harness-orchestrated execution mode for weak local models.
+tags: [investigation, weak-model]
+---
+
 # Investigation: Harness-Orchestrated Execution Mode for Weak Local Models
 
 This document records the findings and recommendation for

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,9 @@
+---
+type: index
+title: IDD Reference Manual
+description: Is the entry point and topic map for the idd-skill deeper reference manual.
+---
+
 # IDD Reference Manual
 
 <!-- cspell:words VRC VRChat -->

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: Issue Authoring Skill Contract and Schema
+description: Defines the stable contract and output schema for the agent-facing issue authoring skill that prepares IDD-ready issues.
+tags: [issue-authoring, skill-contract]
+---
+
 # Issue Authoring Skill Contract and Schema
 
 This document defines the stable contract and output schema for an

--- a/docs/pages-strategy.md
+++ b/docs/pages-strategy.md
@@ -1,3 +1,10 @@
+---
+type: design
+title: GitHub Pages Readiness Strategy
+description: Records the low-cost path and deferred decisions for turning the docs reference manual into a public GitHub Pages site.
+tags: [github-pages, docs-strategy]
+---
+
 # GitHub Pages Readiness Strategy
 
 This page records the low-cost path for turning the `docs/` reference

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -1,3 +1,10 @@
+---
+type: investigation
+title: IDD Skill — Competitive Landscape and Positioning
+description: Analyzes the competitive landscape for idd-skill and summarizes its strategic position relative to adjacent tools.
+tags: [positioning, competitive-analysis]
+---
+
 # IDD Skill — Competitive Landscape and Positioning
 
 Analysis date: 2026-05-07

--- a/docs/pr-cleanup-backlog-batch-001.md
+++ b/docs/pr-cleanup-backlog-batch-001.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: PR Cleanup Backlog — Batch Run 001
+description: Records the first batch execution of the historical merged-PR cleanup backlog campaign and how to continue subsequent batches.
+tags: [pr-cleanup, backlog]
+---
+
 # PR Cleanup Backlog — Batch Run 001
 
 This document records the first batch execution of the historical

--- a/docs/skills-delivery-investigation.md
+++ b/docs/skills-delivery-investigation.md
@@ -1,3 +1,10 @@
+---
+type: investigation
+title: "Investigation: Skills-Based On-Demand Delivery of IDD Phase Instructions"
+description: Records the findings and recommendation on whether to deliver IDD phase instructions as on-demand skill bundles.
+tags: [investigation, skills-delivery]
+---
+
 # Investigation: Skills-Based On-Demand Delivery of IDD Phase Instructions
 
 This document records the findings and recommendation for

--- a/docs/stalled-session-quiet-check.md
+++ b/docs/stalled-session-quiet-check.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: Stalled Session Quiet-Check Helper
+description: Documents the CLI usage, output schema, and required live rechecks for the Resume/S2 stalled-session quiet-check helper.
+tags: [helper-scripts, resume]
+---
+
 # Stalled Session Quiet-Check Helper
 
 Detects quiet windows for the Resume/S2 stalled-session recovery path.

--- a/docs/typescript-sources.md
+++ b/docs/typescript-sources.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: TypeScript helper sources
+description: Explains the generated .mjs-from-.mts helper source layout, build commands, and drift guards this repository enforces.
+tags: [typescript, build-tooling]
+---
+
 # TypeScript helper sources
 
 The IDD helper migration to TypeScript is **complete**: every

--- a/docs/weak-model-authoring-lite-profile-design.md
+++ b/docs/weak-model-authoring-lite-profile-design.md
@@ -1,3 +1,10 @@
+---
+type: design
+title: Weak-Model Authoring Lite Profile — Design
+description: Records the design for a lite authoring profile that improves weak local model conformance with the issue-authoring skill.
+tags: [weak-model, issue-authoring]
+---
+
 # Weak-Model Authoring Lite Profile — Design
 
 This page records the design for

--- a/docs/weak-model-lite-profile-design.md
+++ b/docs/weak-model-lite-profile-design.md
@@ -1,3 +1,10 @@
+---
+type: design
+title: Weak-Model Lite Instruction Profile — Design
+description: Records the design for a condensed IDD instruction profile targeting weak local models with ample context but low adherence.
+tags: [weak-model, lite-profile]
+---
+
 # Weak-Model Lite Instruction Profile — Design
 
 This page records the design for

--- a/docs/workshop/LOG-FORMAT.md
+++ b/docs/workshop/LOG-FORMAT.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: Workshop Log Format
+description: Defines the conventions workshop log segments follow so they can be assembled and reviewed without reformatting.
+tags: [workshop, log-format]
+---
+
 # Workshop Log Format
 
 Workshop logs use the conventions below so separately captured segments

--- a/docs/workshop/README.md
+++ b/docs/workshop/README.md
@@ -1,3 +1,10 @@
+---
+type: tutorial
+title: Build a VRChat Event Calendar with IDD
+description: Walks through an end-to-end IDD workshop session that builds a VRChat event calendar example from an empty repository.
+tags: [workshop, tutorial]
+---
+
 # Build a VRChat Event Calendar with IDD
 
 <!-- cspell:words Defang VRChat -->

--- a/docs/workshop/assets/recordings/README.md
+++ b/docs/workshop/assets/recordings/README.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: Workshop Recording Toolchain
+description: Explains how to store and reproduce source tapes for workshop terminal recordings.
+tags: [workshop, recordings]
+---
+
 # Workshop Recording Toolchain
 
 This directory stores source tapes for workshop terminal recordings.

--- a/docs/workshop/bonus-defang-deployment.md
+++ b/docs/workshop/bonus-defang-deployment.md
@@ -1,3 +1,10 @@
+---
+type: tutorial
+title: "Bonus: Deploy with Defang"
+description: Walks through the optional bonus path of deploying the workshop app from local Docker Compose to a Defang deployment.
+tags: [workshop, defang]
+---
+
 <!-- cspell:words BYOC Defang DigitalOcean dotenv Postgres PostgreSQL -->
 <!-- cspell:words Pulumi Redis whoami -->
 

--- a/docs/workshop/log-segments/01-bootstrap.md
+++ b/docs/workshop/log-segments/01-bootstrap.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: Bootstrap Log Segment
+description: Captures the timestamped bootstrap log segment of the VRChat Event Calendar IDD workshop session.
+tags: [workshop, log-segment]
+---
+
 # Bootstrap Log Segment
 
 > **Note:** This segment combines verbatim shell capture from the

--- a/docs/workshop/log-segments/02-infrastructure.md
+++ b/docs/workshop/log-segments/02-infrastructure.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: Infrastructure Setup Log Segment
+description: Captures the timestamped infrastructure-setup log segment of the VRChat Event Calendar IDD workshop session.
+tags: [workshop, log-segment]
+---
+
 # Infrastructure Setup Log Segment
 
 > **Note:** This segment is reconstructed from the preserved claim,

--- a/docs/workshop/log-segments/03-data-layer.md
+++ b/docs/workshop/log-segments/03-data-layer.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: Data Layer Log Segment
+description: Captures the timestamped data-layer log segment of the VRChat Event Calendar IDD workshop session.
+tags: [workshop, log-segment]
+---
+
 # Data Layer Log Segment
 
 > **Note:** This segment is reconstructed from the preserved claim,

--- a/docs/workshop/log-segments/04-backend-api.md
+++ b/docs/workshop/log-segments/04-backend-api.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: Backend API Log Segment
+description: Captures the timestamped backend-API log segment of the VRChat Event Calendar IDD workshop session.
+tags: [workshop, log-segment]
+---
+
 # Backend API Log Segment
 
 > **Note:** This segment is reconstructed from the preserved claim,

--- a/docs/workshop/log-segments/05-frontend-quality.md
+++ b/docs/workshop/log-segments/05-frontend-quality.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: Frontend and Quality Hardening Log Segment
+description: Captures the timestamped frontend-and-quality-hardening log segment of the VRChat Event Calendar IDD workshop session.
+tags: [workshop, log-segment]
+---
+
 # Frontend and Quality Hardening Log Segment
 
 > **Note:** This segment is reconstructed from the preserved claim,

--- a/docs/workshop/workshop-log.md
+++ b/docs/workshop/workshop-log.md
@@ -1,3 +1,10 @@
+---
+type: reference
+title: VRChat Event Calendar IDD Workshop Log
+description: Is the complete timestamped record of the IDD session that built the VRChat Event Calendar from an empty repository to a working MVP.
+tags: [workshop, session-log]
+---
+
 <!-- cspell:words Defang defang VRChat -->
 
 # VRChat Event Calendar IDD Workshop Log


### PR DESCRIPTION
# Summary

Adds a conforming OKF frontmatter block (`type`/`title`/`description`/
`tags`) to every one of the 23 `docs/**` pages that are not sync
targets of `idd-template/docs/**`, removing the corresponding 22
entries from the `okfBundles` `exemptPaths` list in
`audit/sync-manifest.json`. `docs/okf-frontmatter.md` already conforms
from the foundation track (#1680) and is unaffected.

## Linked issue

Closes #1682

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

- Sibling roadmap children #1683/#1684 cover the remaining tracks
  (mirrored `idd-template/docs/` <-> `docs/` pairs and any residual
  work) and are out of scope here; this PR touches only the
  source-repo-only half of the corpus (#1682's own scope).
- `docs/index.md` gets `type: index` and a matching
  `title`/`description` per the issue's explicit acceptance criteria,
  even though `index.md` is a reserved filename that
  `node scripts/audit-docs.mjs --check` never enforces for OKF
  conformance (see `docs/okf-frontmatter.md`'s "Reserved filenames"
  section). Its body content is otherwise unchanged — the generated
  entry listing is a later track's scope.
- Two workshop pages (`docs/workshop/bonus-defang-deployment.md`,
  `docs/workshop/workshop-log.md`) open with `cspell:words` HTML
  comments rather than the page's `# H1`; the frontmatter block is
  inserted as the literal first bytes of the file (before those
  comments), since OKF/YAML frontmatter must open the document.
- `type` assignment: `design` for decision/trade-off planning notes
  (`ai-strategy`, `claude-skill-strategy`, `pages-strategy`, both
  weak-model lite-profile design pages), `investigation` for
  research-and-recommendation documents (`positioning`,
  `harness-orchestrated-execution-investigation`,
  `skills-delivery-investigation`), `reference` for contract/lookup/log
  material (`issue-authoring-skill`, `pr-cleanup-backlog-batch-001`,
  `stalled-session-quiet-check`, `typescript-sources`, the workshop log
  format page, all five workshop log segments, the workshop session
  log, and the workshop recordings toolchain README), and `tutorial`
  for the two workshop walkthrough pages (`README.md`,
  `bonus-defang-deployment.md`). All eight `type` values already exist
  in the closed vocabulary, so no vocabulary extension was needed.
- No body prose, heading, or filename changes outside the added
  frontmatter blocks and the manifest edit — verified via
  `git diff --stat` (24 files changed, every doc file a clean
  frontmatter-block insertion, plus the manifest's `exemptPaths`
  removal).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
