### PR TITLE
fix(cli): validate required write-path flags with field-named errors

### DIFF
--- a/scripts/cli-args.mjs
+++ b/scripts/cli-args.mjs
@@ -295,3 +295,37 @@ export function parseCanonicalIntegerOrThrow(token, flagName, min = 1) {
 export function parseCanonicalIntegerOrNull(token, min = 1) {
   return parseCanonicalIntegerToken(token, min);
 }
+/**
+ * Validate that a required CLI flag's value is present and non-empty,
+ * returning it narrowed to `string`. Throws this repository's established
+ * `--flag is required` shape -- the same wording `branch-name.mts`'s
+ * `--number`/`--title` checks, `claim-lock.mts`'s `--worktree` check,
+ * `verify-install-deps.mts`'s `--key-binary`/`--install-command` checks, and
+ * many other hand-rolled parsers across `src/scripts/` already use verbatim
+ * -- when `value` is `undefined`, an empty string, or any non-string (e.g. a
+ * boolean flag's value passed where a value-flag was expected).
+ *
+ * Deliberately separate from {@link parseCliArgs}: several write-path
+ * helpers (`emit-marker.mts`, `post-idd-marker.mts`) collect a
+ * marker-type-dependent, dynamically-keyed field set that `parseCliArgs`'s
+ * static, declared spec cannot express -- see each of those files' own
+ * `parseArgs` doc comment for the full reasoning behind that exclusion. This
+ * function is the narrow, spec-free primitive those hand-rolled parsers can
+ * still reuse to report a missing required field BY NAME, instead of
+ * deferring to an aggregate downstream guard (a renderer's own payload
+ * validation) that only ever reports an unattributed "invalid ... payload"
+ * error with no indication of which flag was missing (#1722).
+ *
+ * Checks `value === ''` explicitly rather than `!value`: several required
+ * fields this function guards are numeric-looking strings that are falsy as
+ * a *number* but a perfectly valid, present string value -- e.g.
+ * `--total-item-count '0'` (emit-marker.mts / post-idd-marker.mts's
+ * watermark type). A bare `!value` truthiness check would reject that `'0'`
+ * as if the flag were missing.
+ */
+export function requireFlag(value, flagName) {
+  if (typeof value !== 'string' || value === '') {
+    throw new Error(`${flagName} is required`);
+  }
+  return value;
+}

--- a/scripts/emit-marker.mjs
+++ b/scripts/emit-marker.mjs
@@ -10,6 +10,7 @@
 // ready-to-post body string to stdout and performs NO network write; the
 // agent posts it via the documented HTTP path. The render logic lives in
 // protocol-helpers; this is the thin CLI surface.
+import { requireFlag } from './cli-args.mjs';
 import {
   renderClaimedByMarker,
   renderReviewBaselineMarker,
@@ -32,29 +33,47 @@ function runCli() {
       `--type is required and must be one of: ${MARKER_TYPES.join(', ')}`,
     );
   }
+  // #1722: validate every flag THIS marker type requires, by name, before
+  // the renderer ever sees the payload -- previously only --type was
+  // checked here, so a missing per-type flag (e.g. --timestamp for
+  // claimed-by) fell through to the renderer's own aggregate guard, which
+  // reports only an unattributed "invalid ... marker payload" with no
+  // indication of which flag was absent. requireFlag (cli-args.mts) reports
+  // the exact missing flag, matching the shape the --type check above
+  // already uses. --supersedes / --max-activity-at / --ci-completed-at are
+  // deliberately NOT required here: the renderers themselves default an
+  // absent or empty value to the `none` sentinel, so requiring them here
+  // would reject input the renderer accepts. The renderer's own aggregate
+  // guard stays in place as defense-in-depth for any other direct caller of
+  // renderClaimedByMarker / renderReviewWatermarkMarker /
+  // renderReviewBaselineMarker (e.g. protocol-helpers.mts consumers outside
+  // this CLI).
   let body;
   if (type === 'claimed-by') {
     body = renderClaimedByMarker({
-      agentId: args['agent-id'],
-      claimId: args['claim-id'],
+      agentId: requireFlag(args['agent-id'], '--agent-id'),
+      claimId: requireFlag(args['claim-id'], '--claim-id'),
       supersedes: args.supersedes,
-      timestamp: args.timestamp,
-      branch: args.branch,
+      timestamp: requireFlag(args.timestamp, '--timestamp'),
+      branch: requireFlag(args.branch, '--branch'),
     });
   } else if (type === 'review-watermark') {
     body = renderReviewWatermarkMarker({
-      agentId: args['agent-id'],
-      claimId: args['claim-id'],
-      headSha: args['head-sha'],
+      agentId: requireFlag(args['agent-id'], '--agent-id'),
+      claimId: requireFlag(args['claim-id'], '--claim-id'),
+      headSha: requireFlag(args['head-sha'], '--head-sha'),
       maxActivityAt: args['max-activity-at'],
-      totalItemCount: args['total-item-count'],
+      totalItemCount: requireFlag(
+        args['total-item-count'],
+        '--total-item-count',
+      ),
       ciCompletedAt: args['ci-completed-at'],
     });
   } else {
     body = renderReviewBaselineMarker({
-      agentId: args['agent-id'],
-      claimId: args['claim-id'],
-      sha: args.sha,
+      agentId: requireFlag(args['agent-id'], '--agent-id'),
+      claimId: requireFlag(args['claim-id'], '--claim-id'),
+      sha: requireFlag(args.sha, '--sha'),
     });
   }
   process.stdout.write(`${body}\n`);

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -18,6 +18,7 @@
 // manual POST path it replaces already requires.
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
+import { requireFlag } from './cli-args.mjs';
 import { ghText } from './gh-exec.mjs';
 import {
   renderActivationNonceMarker,
@@ -41,6 +42,43 @@ export const MARKER_TYPES = [
   'advisory-reroll',
   'copilot-unavailable',
 ];
+/**
+ * The kebab-case `--flag` field names each marker `type` requires, keyed
+ * the same way {@link buildMarkerBody}'s own switch reads `fields` --
+ * consulted by the `import.meta.main` CLI entry point below to report a
+ * missing required field BY NAME (via `requireFlag`, cli-args.mts) before
+ * `buildMarkerBody` is ever called, instead of surfacing that renderer's
+ * own aggregate "invalid ... marker payload" guard with no indication of
+ * which flag was absent (#1722). `supersedes` (claim), `max-activity-at` /
+ * `ci-completed-at` (watermark) are deliberately OMITTED: the underlying
+ * renderers default an absent or empty value to the `none` sentinel, so
+ * requiring them here would reject input the renderer itself accepts.
+ * `advisory-recovery`'s optional `claim-id` / `attempt` pair is also
+ * omitted for the same reason -- passing neither renders the legacy
+ * 3-field form; the renderer's own "must both be provided together"
+ * message already names that half-bound case precisely. This CLI-layer
+ * check stays defense-in-depth-complementary to, never a replacement for,
+ * `buildMarkerBody`'s own per-type validation -- a direct caller of
+ * `buildMarkerBody` (bypassing this CLI) still gets that renderer's
+ * aggregate guard.
+ */
+const REQUIRED_FIELDS_BY_TYPE = {
+  claim: ['agent-id', 'claim-id', 'timestamp', 'branch'],
+  unclaim: ['agent-id', 'claim-id', 'timestamp'],
+  'activation-nonce': ['agent-id', 'claim-id', 'nonce', 'timestamp'],
+  watermark: ['agent-id', 'claim-id', 'head-sha', 'total-item-count'],
+  baseline: ['agent-id', 'claim-id', 'sha'],
+  advisory: ['agent-id', 'head-sha', 'timestamp'],
+  'advisory-recovery': ['agent-id', 'head-sha', 'timestamp'],
+  'advisory-reroll': ['agent-id', 'head-sha', 'timestamp'],
+  'copilot-unavailable': [
+    'agent-id',
+    'claim-id',
+    'head-sha',
+    'attempt',
+    'timestamp',
+  ],
+};
 export const TARGET_KINDS = ['issue', 'pr'];
 /**
  * Build the canonical ready-to-post body for one operational marker type.
@@ -500,6 +538,16 @@ if (import.meta.main) {
   }
   let body;
   try {
+    // #1722: report a missing required field BY NAME before buildMarkerBody
+    // (and the renderer it dispatches to) ever sees the payload -- runs
+    // AFTER --from-pr derivation above, so a watermark's --head-sha /
+    // --total-item-count are already populated by the time this checks
+    // them in that mode. See REQUIRED_FIELDS_BY_TYPE's own doc comment for
+    // which fields are deliberately excluded (renderer-defaulted or
+    // half-bound-optional).
+    for (const field of REQUIRED_FIELDS_BY_TYPE[args.type]) {
+      requireFlag(args.fields[field], `--${field}`);
+    }
     body = buildMarkerBody(args.type, args.fields);
   } catch (error) {
     process.stderr.write(`${error.message}\n`);

--- a/src/scripts/cli-args.mts
+++ b/src/scripts/cli-args.mts
@@ -383,3 +383,38 @@ export function parseCanonicalIntegerOrNull(
 ): number | null {
   return parseCanonicalIntegerToken(token, min);
 }
+
+/**
+ * Validate that a required CLI flag's value is present and non-empty,
+ * returning it narrowed to `string`. Throws this repository's established
+ * `--flag is required` shape -- the same wording `branch-name.mts`'s
+ * `--number`/`--title` checks, `claim-lock.mts`'s `--worktree` check,
+ * `verify-install-deps.mts`'s `--key-binary`/`--install-command` checks, and
+ * many other hand-rolled parsers across `src/scripts/` already use verbatim
+ * -- when `value` is `undefined`, an empty string, or any non-string (e.g. a
+ * boolean flag's value passed where a value-flag was expected).
+ *
+ * Deliberately separate from {@link parseCliArgs}: several write-path
+ * helpers (`emit-marker.mts`, `post-idd-marker.mts`) collect a
+ * marker-type-dependent, dynamically-keyed field set that `parseCliArgs`'s
+ * static, declared spec cannot express -- see each of those files' own
+ * `parseArgs` doc comment for the full reasoning behind that exclusion. This
+ * function is the narrow, spec-free primitive those hand-rolled parsers can
+ * still reuse to report a missing required field BY NAME, instead of
+ * deferring to an aggregate downstream guard (a renderer's own payload
+ * validation) that only ever reports an unattributed "invalid ... payload"
+ * error with no indication of which flag was missing (#1722).
+ *
+ * Checks `value === ''` explicitly rather than `!value`: several required
+ * fields this function guards are numeric-looking strings that are falsy as
+ * a *number* but a perfectly valid, present string value -- e.g.
+ * `--total-item-count '0'` (emit-marker.mts / post-idd-marker.mts's
+ * watermark type). A bare `!value` truthiness check would reject that `'0'`
+ * as if the flag were missing.
+ */
+export function requireFlag(value: unknown, flagName: string): string {
+  if (typeof value !== 'string' || value === '') {
+    throw new Error(`${flagName} is required`);
+  }
+  return value;
+}

--- a/src/scripts/emit-marker.mts
+++ b/src/scripts/emit-marker.mts
@@ -11,6 +11,7 @@
 // agent posts it via the documented HTTP path. The render logic lives in
 // protocol-helpers; this is the thin CLI surface.
 
+import { requireFlag } from './cli-args.mts';
 import {
   renderClaimedByMarker,
   renderReviewBaselineMarker,
@@ -36,29 +37,47 @@ function runCli(): void {
     );
   }
 
+  // #1722: validate every flag THIS marker type requires, by name, before
+  // the renderer ever sees the payload -- previously only --type was
+  // checked here, so a missing per-type flag (e.g. --timestamp for
+  // claimed-by) fell through to the renderer's own aggregate guard, which
+  // reports only an unattributed "invalid ... marker payload" with no
+  // indication of which flag was absent. requireFlag (cli-args.mts) reports
+  // the exact missing flag, matching the shape the --type check above
+  // already uses. --supersedes / --max-activity-at / --ci-completed-at are
+  // deliberately NOT required here: the renderers themselves default an
+  // absent or empty value to the `none` sentinel, so requiring them here
+  // would reject input the renderer accepts. The renderer's own aggregate
+  // guard stays in place as defense-in-depth for any other direct caller of
+  // renderClaimedByMarker / renderReviewWatermarkMarker /
+  // renderReviewBaselineMarker (e.g. protocol-helpers.mts consumers outside
+  // this CLI).
   let body: string;
   if (type === 'claimed-by') {
     body = renderClaimedByMarker({
-      agentId: args['agent-id'],
-      claimId: args['claim-id'],
+      agentId: requireFlag(args['agent-id'], '--agent-id'),
+      claimId: requireFlag(args['claim-id'], '--claim-id'),
       supersedes: args.supersedes,
-      timestamp: args.timestamp,
-      branch: args.branch,
+      timestamp: requireFlag(args.timestamp, '--timestamp'),
+      branch: requireFlag(args.branch, '--branch'),
     });
   } else if (type === 'review-watermark') {
     body = renderReviewWatermarkMarker({
-      agentId: args['agent-id'],
-      claimId: args['claim-id'],
-      headSha: args['head-sha'],
+      agentId: requireFlag(args['agent-id'], '--agent-id'),
+      claimId: requireFlag(args['claim-id'], '--claim-id'),
+      headSha: requireFlag(args['head-sha'], '--head-sha'),
       maxActivityAt: args['max-activity-at'],
-      totalItemCount: args['total-item-count'],
+      totalItemCount: requireFlag(
+        args['total-item-count'],
+        '--total-item-count',
+      ),
       ciCompletedAt: args['ci-completed-at'],
     });
   } else {
     body = renderReviewBaselineMarker({
-      agentId: args['agent-id'],
-      claimId: args['claim-id'],
-      sha: args.sha,
+      agentId: requireFlag(args['agent-id'], '--agent-id'),
+      claimId: requireFlag(args['claim-id'], '--claim-id'),
+      sha: requireFlag(args.sha, '--sha'),
     });
   }
 

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -20,6 +20,7 @@
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 
+import { requireFlag } from './cli-args.mts';
 import { ghText } from './gh-exec.mts';
 import {
   renderActivationNonceMarker,
@@ -46,6 +47,44 @@ export const MARKER_TYPES = [
 ] as const;
 
 export type MarkerType = (typeof MARKER_TYPES)[number];
+
+/**
+ * The kebab-case `--flag` field names each marker `type` requires, keyed
+ * the same way {@link buildMarkerBody}'s own switch reads `fields` --
+ * consulted by the `import.meta.main` CLI entry point below to report a
+ * missing required field BY NAME (via `requireFlag`, cli-args.mts) before
+ * `buildMarkerBody` is ever called, instead of surfacing that renderer's
+ * own aggregate "invalid ... marker payload" guard with no indication of
+ * which flag was absent (#1722). `supersedes` (claim), `max-activity-at` /
+ * `ci-completed-at` (watermark) are deliberately OMITTED: the underlying
+ * renderers default an absent or empty value to the `none` sentinel, so
+ * requiring them here would reject input the renderer itself accepts.
+ * `advisory-recovery`'s optional `claim-id` / `attempt` pair is also
+ * omitted for the same reason -- passing neither renders the legacy
+ * 3-field form; the renderer's own "must both be provided together"
+ * message already names that half-bound case precisely. This CLI-layer
+ * check stays defense-in-depth-complementary to, never a replacement for,
+ * `buildMarkerBody`'s own per-type validation -- a direct caller of
+ * `buildMarkerBody` (bypassing this CLI) still gets that renderer's
+ * aggregate guard.
+ */
+const REQUIRED_FIELDS_BY_TYPE: Record<MarkerType, readonly string[]> = {
+  claim: ['agent-id', 'claim-id', 'timestamp', 'branch'],
+  unclaim: ['agent-id', 'claim-id', 'timestamp'],
+  'activation-nonce': ['agent-id', 'claim-id', 'nonce', 'timestamp'],
+  watermark: ['agent-id', 'claim-id', 'head-sha', 'total-item-count'],
+  baseline: ['agent-id', 'claim-id', 'sha'],
+  advisory: ['agent-id', 'head-sha', 'timestamp'],
+  'advisory-recovery': ['agent-id', 'head-sha', 'timestamp'],
+  'advisory-reroll': ['agent-id', 'head-sha', 'timestamp'],
+  'copilot-unavailable': [
+    'agent-id',
+    'claim-id',
+    'head-sha',
+    'attempt',
+    'timestamp',
+  ],
+};
 
 export const TARGET_KINDS = ['issue', 'pr'] as const;
 export type TargetKind = (typeof TARGET_KINDS)[number];
@@ -569,6 +608,16 @@ if (import.meta.main) {
 
   let body: string;
   try {
+    // #1722: report a missing required field BY NAME before buildMarkerBody
+    // (and the renderer it dispatches to) ever sees the payload -- runs
+    // AFTER --from-pr derivation above, so a watermark's --head-sha /
+    // --total-item-count are already populated by the time this checks
+    // them in that mode. See REQUIRED_FIELDS_BY_TYPE's own doc comment for
+    // which fields are deliberately excluded (renderer-defaulted or
+    // half-bound-optional).
+    for (const field of REQUIRED_FIELDS_BY_TYPE[args.type as MarkerType]) {
+      requireFlag(args.fields[field], `--${field}`);
+    }
     body = buildMarkerBody(args.type, args.fields);
   } catch (error) {
     process.stderr.write(`${(error as Error).message}\n`);

--- a/tests/cli-args.test.mts
+++ b/tests/cli-args.test.mts
@@ -5,6 +5,7 @@ import {
   parseCanonicalIntegerOrNull,
   parseCanonicalIntegerOrThrow,
   parseCliArgs,
+  requireFlag,
 } from '../src/scripts/cli-args.mts';
 
 const SAMPLE_SPEC = {
@@ -195,4 +196,38 @@ test('parseCanonicalIntegerOrNull: resolves a canonical positive integer token',
 
 test('parseCanonicalIntegerOrNull: honors an explicit min of 0', () => {
   assert.equal(parseCanonicalIntegerOrNull('0', 0), 0);
+});
+
+// --- requireFlag (#1722) -----------------------------------------------------
+
+test('requireFlag: returns a present, non-empty string value unchanged', () => {
+  assert.equal(requireFlag('claude-417b737f', '--agent-id'), 'claude-417b737f');
+});
+
+test('requireFlag: throws "--flag is required" on undefined', () => {
+  assert.throws(() => requireFlag(undefined, '--timestamp'), {
+    message: '--timestamp is required',
+  });
+});
+
+test('requireFlag: throws "--flag is required" on an empty string', () => {
+  assert.throws(() => requireFlag('', '--branch'), {
+    message: '--branch is required',
+  });
+});
+
+test('requireFlag: accepts the numeric-string "0" (checks === \'\', not truthiness)', () => {
+  // A bare `!value` truthiness check would reject '0' as if the flag were
+  // missing -- e.g. --total-item-count '0' (emit-marker.mts /
+  // post-idd-marker.mts's watermark type is a legitimate, present value.
+  assert.equal(requireFlag('0', '--total-item-count'), '0');
+});
+
+test('requireFlag: throws "--flag is required" on a non-string value (e.g. a boolean)', () => {
+  assert.throws(() => requireFlag(true, '--head-sha'), {
+    message: '--head-sha is required',
+  });
+  assert.throws(() => requireFlag(null, '--head-sha'), {
+    message: '--head-sha is required',
+  });
 });

--- a/tests/emit-marker.test.mts
+++ b/tests/emit-marker.test.mts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import {
   parseClaimComment,
@@ -12,6 +14,11 @@ import {
 // A real 40-hex commit SHA — the watermark/claim parsers and the published
 // schemas require this exact shape, so the tests must use one.
 const SHA = '0123456789abcdef0123456789abcdef01234567';
+const TS = '2026-06-17T09:47:08Z';
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+const EMIT_MARKER_CLI = fileURLToPath(
+  new URL('../scripts/emit-marker.mjs', import.meta.url),
+);
 
 test('renderClaimedByMarker emits the exact claimed-by body', () => {
   assert.equal(
@@ -238,4 +245,122 @@ test('renderers reject payloads that would not round-trip', () => {
   assert.throws(() =>
     renderReviewBaselineMarker({ agentId: 'a', claimId: 'c', sha: 'deadbeef' }),
   );
+});
+
+// --- CLI-layer required-flag validation (#1722) -----------------------------
+//
+// Before #1722, `idd-emit-marker` validated only --type by name; every other
+// missing flag fell through to the renderer's aggregate guard, surfacing
+// only an unattributed "invalid ... marker payload" with no indication of
+// which flag was absent. These tests spawn the compiled CLI directly (the
+// same pattern tests/post-idd-marker.test.mts already uses) and assert the
+// exit code and error text name the specific missing flag, for every
+// required flag of every marker type the CLI supports.
+
+/** Run the compiled emit-marker CLI, returning its combined error text
+ * (Node writes an uncaught Error's stack -- including its `Error: <message>`
+ * line -- to stderr; this helper does not care which stream carries it, only
+ * that the flag name appears somewhere in the failure output). Asserts the
+ * process exited non-zero. */
+function runEmitMarkerExpectingFailure(argv: string[]): string {
+  try {
+    execFileSync(process.execPath, [EMIT_MARKER_CLI, ...argv], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
+  } catch (error) {
+    const failure = error as { status?: number; stderr?: string };
+    assert.notEqual(failure.status, 0);
+    return failure.stderr ?? '';
+  }
+  throw new Error('expected the CLI to exit non-zero');
+}
+
+/** A complete, valid flag set per marker type, keyed by the flag names the
+ * CLI's own required-field validation should demand for that type. */
+const FULL_FLAGS_BY_TYPE: Record<string, Record<string, string>> = {
+  'claimed-by': {
+    'agent-id': 'a',
+    'claim-id': 'c',
+    timestamp: TS,
+    branch: 'issue/1722-fix',
+  },
+  'review-watermark': {
+    'agent-id': 'a',
+    'claim-id': 'c',
+    'head-sha': SHA,
+    'total-item-count': '0',
+  },
+  'review-baseline': {
+    'agent-id': 'a',
+    'claim-id': 'c',
+    sha: SHA,
+  },
+};
+
+function toArgv(type: string, fields: Record<string, string>): string[] {
+  const argv = ['--type', type];
+  for (const [flag, value] of Object.entries(fields)) {
+    argv.push(`--${flag}`, value);
+  }
+  return argv;
+}
+
+test('emit-marker CLI: the full flag set for every marker type succeeds', () => {
+  for (const [type, fields] of Object.entries(FULL_FLAGS_BY_TYPE)) {
+    const output = execFileSync(
+      process.execPath,
+      [EMIT_MARKER_CLI, ...toArgv(type, fields)],
+      { cwd: REPO_ROOT, encoding: 'utf8' },
+    );
+    assert.match(output, /^<!--/, `${type} should print a marker body`);
+  }
+});
+
+test('emit-marker CLI: claimed-by without --timestamp names --timestamp (issue example)', () => {
+  const { timestamp: _omit, ...rest } = FULL_FLAGS_BY_TYPE['claimed-by'];
+  const stderr = runEmitMarkerExpectingFailure(toArgv('claimed-by', rest));
+  assert.match(stderr, /--timestamp is required/);
+});
+
+test('emit-marker CLI: every required flag of every marker type is rejected by name when omitted', () => {
+  for (const [type, fields] of Object.entries(FULL_FLAGS_BY_TYPE)) {
+    for (const omittedFlag of Object.keys(fields)) {
+      const partial = Object.fromEntries(
+        Object.entries(fields).filter(([flag]) => flag !== omittedFlag),
+      );
+      const stderr = runEmitMarkerExpectingFailure(toArgv(type, partial));
+      assert.match(
+        stderr,
+        new RegExp(`--${omittedFlag} is required`),
+        `${type} without --${omittedFlag} should name --${omittedFlag}`,
+      );
+    }
+  }
+});
+
+test('emit-marker CLI: --supersedes / --max-activity-at / --ci-completed-at stay optional (renderer-defaulted, not CLI-required)', () => {
+  // These three are deliberately excluded from CLI-layer requireFlag
+  // validation: the renderers default an absent/empty value to the `none`
+  // sentinel, so requiring them here would reject input the renderer itself
+  // accepts (see emit-marker.mts's own comment above the requireFlag calls).
+  const claimedByOutput = execFileSync(
+    process.execPath,
+    [
+      EMIT_MARKER_CLI,
+      ...toArgv('claimed-by', FULL_FLAGS_BY_TYPE['claimed-by']),
+    ],
+    { cwd: REPO_ROOT, encoding: 'utf8' },
+  );
+  assert.match(claimedByOutput, /supersedes: none /);
+
+  const watermarkOutput = execFileSync(
+    process.execPath,
+    [
+      EMIT_MARKER_CLI,
+      ...toArgv('review-watermark', FULL_FLAGS_BY_TYPE['review-watermark']),
+    ],
+    { cwd: REPO_ROOT, encoding: 'utf8' },
+  );
+  assert.match(watermarkOutput, new RegExp(`${SHA} none 0 none `));
 });

--- a/tests/minimize-superseded-markers.test.mts
+++ b/tests/minimize-superseded-markers.test.mts
@@ -184,6 +184,33 @@ test('an explicit empty --subject-ids value is rejected at parse time', () => {
   assert.equal(result.stderr.trim(), 'error: --subject-ids requires a value');
 });
 
+// #1722: an omitted --subject-ids is a DIFFERENT code path than the empty
+// value case above (values['subject-ids'] defaults to '' via parseArgs'
+// own declared default, then splits/filters to an empty array, then hits
+// the post-parse length check below -- not the requires-a-value branch),
+// and produces a different, still flag-named message. This is the
+// write-path helper's own required-flag case named in #1722's acceptance
+// criteria (one missing-required-flag case per covered helper, asserted on
+// the flag name).
+test('an omitted --subject-ids is rejected by name, distinctly from the empty-value case', () => {
+  const script = join(
+    dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'scripts',
+    'minimize-superseded-markers.mjs',
+  );
+  const result = spawnSync(process.execPath, [script, '--allow-untrusted'], {
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout, '');
+  assert.equal(
+    result.stderr.trim(),
+    'error: --subject-ids must contain at least one ID',
+  );
+});
+
 test('an explicit empty --trusted-marker-logins value is accepted, unlike --subject-ids', () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-minimize-'));
   try {

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -1150,6 +1150,117 @@ test('--from-pr fails closed on an explicit non-pr --target', () => {
   assert.match(stderr, /--from-pr always targets the PR/);
 });
 
+// --- CLI-layer required-flag validation (#1722) -----------------------------
+//
+// Before #1722, only --type/--target/the positional number were validated by
+// name; a missing per-type renderer field (e.g. --timestamp for --type
+// claim) fell through to buildMarkerBody's aggregate guard, surfacing only
+// an unattributed "invalid ... marker payload" with no indication of which
+// flag was absent. These tests spawn the compiled CLI (reusing
+// runCliExpectingFailure above, which also proves the rejection happens
+// before any `gh` call by removing `gh` from PATH) and assert the exit code
+// and error text name the specific missing flag, for every required flag of
+// every marker type the CLI supports.
+
+/** A complete, valid renderer-field set per marker type (excluding the
+ * structural --type / --target / positional-number flags), matching
+ * REQUIRED_FIELDS_BY_TYPE in post-idd-marker.mts. */
+const FULL_FIELDS_BY_TYPE: Record<string, Record<string, string>> = {
+  claim: {
+    'agent-id': 'a',
+    'claim-id': 'c',
+    timestamp: TS,
+    branch: 'issue/1722-fix',
+  },
+  unclaim: { 'agent-id': 'a', 'claim-id': 'c', timestamp: TS },
+  'activation-nonce': {
+    'agent-id': 'a',
+    'claim-id': 'c',
+    nonce: 'n-1',
+    timestamp: TS,
+  },
+  watermark: {
+    'agent-id': 'a',
+    'claim-id': 'c',
+    'head-sha': SHA,
+    'total-item-count': '0',
+  },
+  baseline: { 'agent-id': 'a', 'claim-id': 'c', sha: SHA },
+  advisory: { 'agent-id': 'a', 'head-sha': SHA, timestamp: TS },
+  'advisory-recovery': { 'agent-id': 'a', 'head-sha': SHA, timestamp: TS },
+  'advisory-reroll': { 'agent-id': 'a', 'head-sha': SHA, timestamp: TS },
+  'copilot-unavailable': {
+    'agent-id': 'a',
+    'claim-id': 'c',
+    'head-sha': SHA,
+    attempt: '1',
+    timestamp: TS,
+  },
+};
+
+function postIddMarkerArgv(
+  type: string,
+  fields: Record<string, string>,
+): string[] {
+  const argv = [
+    join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+    '--type',
+    type,
+    '--target',
+    'pr',
+    '1722',
+  ];
+  for (const [flag, value] of Object.entries(fields)) {
+    argv.push(`--${flag}`, value);
+  }
+  return argv;
+}
+
+test('post-idd-marker CLI: the full flag set for every marker type succeeds (dry-run)', () => {
+  for (const [type, fields] of Object.entries(FULL_FIELDS_BY_TYPE)) {
+    const output = execFileSync(
+      process.execPath,
+      postIddMarkerArgv(type, fields),
+      { cwd: REPO_ROOT, encoding: 'utf8' },
+    );
+    const parsed = JSON.parse(output);
+    assert.equal(parsed.mode, 'dry-run', `${type} should dry-run cleanly`);
+    assert.equal(parsed.type, type);
+  }
+});
+
+test('post-idd-marker CLI: claim without --timestamp names --timestamp (issue example)', () => {
+  const { timestamp: _omit, ...rest } = FULL_FIELDS_BY_TYPE.claim;
+  const stderr = runCliExpectingFailure(postIddMarkerArgv('claim', rest));
+  assert.match(stderr, /--timestamp is required/);
+});
+
+test('post-idd-marker CLI: every required flag of every marker type is rejected by name when omitted', () => {
+  for (const [type, fields] of Object.entries(FULL_FIELDS_BY_TYPE)) {
+    for (const omittedFlag of Object.keys(fields)) {
+      const partial = Object.fromEntries(
+        Object.entries(fields).filter(([flag]) => flag !== omittedFlag),
+      );
+      const stderr = runCliExpectingFailure(postIddMarkerArgv(type, partial));
+      assert.match(
+        stderr,
+        new RegExp(`--${omittedFlag} is required`),
+        `${type} without --${omittedFlag} should name --${omittedFlag}`,
+      );
+    }
+  }
+});
+
+test('post-idd-marker CLI: --supersedes stays optional (renderer-defaulted, not CLI-required)', () => {
+  const output = execFileSync(
+    process.execPath,
+    postIddMarkerArgv('claim', FULL_FIELDS_BY_TYPE.claim),
+    { cwd: REPO_ROOT, encoding: 'utf8' },
+  );
+  const parsed = JSON.parse(output);
+  assert.match(parsed.body, /supersedes: none /);
+});
+
 test('--expected-head-sha is rejected without --from-pr (before any gh call)', () => {
   // In manual mode the caller already supplies --head-sha directly; there is
   // nothing for --expected-head-sha to compare it against.


### PR DESCRIPTION
# Summary

`idd-emit-marker` and `post-idd-marker` previously validated only
`--type` by name at the CLI layer; every other missing required flag
(e.g. `--timestamp` for a `claimed-by` marker) fell through to the
renderer's own aggregate guard in `marker-helpers.mts`, which reports
only an unattributed `invalid ... marker payload` with no indication
of which flag was absent.

- Adds `requireFlag(value, flagName)` to `src/scripts/cli-args.mts`, a
  spec-free primitive that reports a missing/empty required flag by
  name, matching this repository's established `--flag is required`
  error shape.
- Applies it in `emit-marker.mts` for every flag each of the three
  marker types (`claimed-by`, `review-watermark`, `review-baseline`)
  requires, before the renderer is called. `--supersedes`,
  `--max-activity-at`, and `--ci-completed-at` are deliberately left
  optional — the renderers themselves default an absent/empty value
  to the `none` sentinel, so requiring them would reject input the
  renderer already accepts.
- Applies the same treatment in `post-idd-marker.mts` for all nine
  marker types it can POST, via a new `REQUIRED_FIELDS_BY_TYPE` map
  consulted in the CLI entry point before `buildMarkerBody` (and thus
  before any `--apply` mutation). `advisory-recovery`'s optional
  `claim-id`/`attempt` pair is left out for the same defaulting
  reason — the renderer's own "must both be provided together"
  message already names that half-bound case precisely.
- The renderer's own aggregate guard stays in place unchanged as
  defense-in-depth for any direct caller that bypasses the CLI.

## Linked issue

Closes #1722

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The issue named four other write-path helpers that read `process.argv`
directly without going through `parseCliArgs`: `post-idd-marker`,
`minimize-superseded-markers`, `idd-merge-execute`, and
`rerun-advisory-convergence`. Auditing the other three found they
already validate their required flags by name before any mutation, so
no source changes were needed there:

- `idd-merge-execute.mts`: `runMergeExecute` throws
  `missing required --pr <number> argument` before `deps.collect(...)`
  is ever called (existing coverage:
  `tests/idd-merge-execute.test.mts:589`). `--claim-issue` and the rest
  of its passthrough flags are already enforced downstream via
  `pre-merge-readiness.mts`'s own `parseCliArgs`-based parser, which
  runs inside that same `collect()` call — still before the merge.
- `rerun-advisory-convergence.mts`: the same `--pr`-required guard runs
  before `deps.collect(...)` and long before `--apply`'s
  `gh run rerun` (existing coverage:
  `tests/rerun-advisory-convergence.test.mts:1868`).
- `minimize-superseded-markers.mts`: an omitted `--subject-ids`
  already produces `error: --subject-ids must contain at least one ID`
  before any `gh` call (existing coverage:
  `tests/minimize-superseded-markers.test.mts:184`, for the sibling
  explicit-empty-string case). This PR adds one more test for the
  *omitted* case specifically, since it is a structurally different
  code path with a different message than the explicit-empty case.
  This file intentionally keeps calling `node:util`'s `parseArgs`
  directly rather than the shared `cli-args.mts` wrapper — it must stay
  self-contained so the `idd-template/scripts/` mirror works without
  `protocol-helpers.mjs` (see the file's own comment, and
  kurone-kito/idd-skill#1486).

`audit-docs`, `sync-docs`, and `update-fixtures` are left out of
scope, per the issue's proposed change: they are read-only,
source-repo-internal tools that are not distributed to adopters and do
not mutate remote GitHub state.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs changed)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
