### PR TITLE
fix(rerun-advisory): skip reruns for uncovered-HEAD verdicts

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -124,25 +124,31 @@ In the idd-skill source repository, the following optional helpers were adopted:
   diagnosis of stuck `idd-advisory-convergence` check-run rollups,
   read-only by default: fetches every check-run instance for a PR's
   current HEAD SHA (paged commit check-runs API), classifies each as
-  `pass` / `pending` / `bot-gated-skip` / `unresolved` / `rerun-eligible`,
-  and prints the ordered, deduplicated `gh run rerun <id>` recovery plan
-  for the rerun-eligible instances (each command includes `-R owner/repo`
-  when the repository is known) — referenced from
-  `idd-ci.instructions.md` §Rerun mechanics as the preferred way to
-  produce that plan. When the rollup is stuck on a bot-gated instance
-  alongside an already-passing non-bot pull_request-family instance, it
-  additionally offers a `recoveryRefreshPlan` — populated even alongside
-  a non-empty rerun plan when every rerun-eligible instance there is
-  itself bot-triggered (#1745; rerunning a bot-triggered instance does
-  not supply the non-bot trigger the recovery-refresh option exists to
-  provide): rerunning the already-passing instance is the documented way
-  to force a fresh non-bot evaluation and clear the stale rollup. Pass
-  `--apply` (#1766) to execute that same plan instead of only diagnosing
-  it: reruns each rerun-eligible instance in order (recovery-refresh
-  first when one applies), waits for each to reach a genuinely new
-  completed attempt before starting the next, and stops early once the
-  recomputed plan is fully resolved — never a `bot-gated-skip` or
-  rerun-budget-held instance.
+  `pass` / `pending` / `bot-gated-skip` / `unresolved` /
+  `awaiting-fresh-review` / `rerun-eligible`, and prints the ordered,
+  deduplicated `gh run rerun <id>` recovery plan for the rerun-eligible
+  instances (each command includes `-R owner/repo` when the repository
+  is known) — referenced from `idd-ci.instructions.md` §Rerun mechanics
+  as the preferred way to produce that plan. An instance whose own
+  advisory-convergence job-log verdict reports that the latest Copilot
+  review does not cover the current HEAD is classified
+  `awaiting-fresh-review` rather than `rerun-eligible` (#1775), so the
+  diagnosis (and `--apply`) never burn the rerun-once budget on a
+  failure only a fresh review can clear. When the rollup is stuck on a
+  bot-gated instance alongside an already-passing non-bot
+  pull_request-family instance, it additionally offers a
+  `recoveryRefreshPlan` — populated even alongside a non-empty rerun
+  plan when every rerun-eligible instance there is itself bot-triggered
+  (#1745; rerunning a bot-triggered instance does not supply the
+  non-bot trigger the recovery-refresh option exists to provide):
+  rerunning the already-passing instance is the documented way to force
+  a fresh non-bot evaluation and clear the stale rollup. Pass `--apply`
+  (#1766) to execute that same plan instead of only diagnosing it:
+  reruns each rerun-eligible instance in order (recovery-refresh first
+  when one applies), waits for each to reach a genuinely new completed
+  attempt before starting the next, and stops early once the recomputed
+  plan is fully resolved — never a `bot-gated-skip`,
+  `awaiting-fresh-review`, or rerun-budget-held instance.
 - `scripts/live-status-digest.mjs` for issue or PR live status digest
   discovery, rendering, dry-run, and claim-checked upsert
 - `scripts/audit-pr-cleanup.mjs` for post-merge comment cleanup auditing
@@ -1275,10 +1281,15 @@ to post it is the consuming track's job.
   required-check rollup, read-only by default: fetches every check-run
   instance for the PR's current HEAD SHA (paged commit check-runs API,
   `filter=all`), classifies each as `pass` / `pending` / `bot-gated-skip` /
-  `unresolved` / `rerun-eligible`, and prints the ordered, deduplicated
-  `gh run rerun <id>` recovery plan for the rerun-eligible instances --
-  referenced from `idd-ci.instructions.md` §Rerun mechanics as the
-  preferred way to produce that plan
+  `unresolved` / `awaiting-fresh-review` / `rerun-eligible`, and prints
+  the ordered, deduplicated `gh run rerun <id>` recovery plan for the
+  rerun-eligible instances -- referenced from `idd-ci.instructions.md`
+  §Rerun mechanics as the preferred way to produce that plan. An
+  instance whose own advisory-convergence job-log verdict reports that
+  the latest Copilot review does not cover the current HEAD is
+  classified `awaiting-fresh-review` rather than `rerun-eligible`
+  (#1775), so neither the diagnosis nor `--apply` burns the rerun-once
+  budget on a failure only a fresh review can clear
 - Also reports a `recoveryRefreshPlan` when the rollup is stuck on a
   bot-gated instance alongside an already-passing non-bot
   pull_request-family instance — populated even alongside a non-empty
@@ -1297,7 +1308,8 @@ to post it is the consuming track's job.
   attempt (polled via the actions/runs API, not `gh run watch`, to avoid
   racing a just-issued rerun's stale pre-rerun status) before starting
   the next, and stops early once the recomputed plan is fully resolved --
-  a `bot-gated-skip` or rerun-budget-held instance is never rerun
+  a `bot-gated-skip`, `awaiting-fresh-review`, or rerun-budget-held
+  instance is never rerun
 
 ### Merge-gate evidence
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -124,25 +124,31 @@ In the idd-skill source repository, the following optional helpers were adopted:
   diagnosis of stuck `idd-advisory-convergence` check-run rollups,
   read-only by default: fetches every check-run instance for a PR's
   current HEAD SHA (paged commit check-runs API), classifies each as
-  `pass` / `pending` / `bot-gated-skip` / `unresolved` / `rerun-eligible`,
-  and prints the ordered, deduplicated `gh run rerun <id>` recovery plan
-  for the rerun-eligible instances (each command includes `-R owner/repo`
-  when the repository is known) — referenced from
-  `idd-ci.instructions.md` §Rerun mechanics as the preferred way to
-  produce that plan. When the rollup is stuck on a bot-gated instance
-  alongside an already-passing non-bot pull_request-family instance, it
-  additionally offers a `recoveryRefreshPlan` — populated even alongside
-  a non-empty rerun plan when every rerun-eligible instance there is
-  itself bot-triggered (#1745; rerunning a bot-triggered instance does
-  not supply the non-bot trigger the recovery-refresh option exists to
-  provide): rerunning the already-passing instance is the documented way
-  to force a fresh non-bot evaluation and clear the stale rollup. Pass
-  `--apply` (#1766) to execute that same plan instead of only diagnosing
-  it: reruns each rerun-eligible instance in order (recovery-refresh
-  first when one applies), waits for each to reach a genuinely new
-  completed attempt before starting the next, and stops early once the
-  recomputed plan is fully resolved — never a `bot-gated-skip` or
-  rerun-budget-held instance.
+  `pass` / `pending` / `bot-gated-skip` / `unresolved` /
+  `awaiting-fresh-review` / `rerun-eligible`, and prints the ordered,
+  deduplicated `gh run rerun <id>` recovery plan for the rerun-eligible
+  instances (each command includes `-R owner/repo` when the repository
+  is known) — referenced from `idd-ci.instructions.md` §Rerun mechanics
+  as the preferred way to produce that plan. An instance whose own
+  advisory-convergence job-log verdict reports that the latest Copilot
+  review does not cover the current HEAD is classified
+  `awaiting-fresh-review` rather than `rerun-eligible` (#1775), so the
+  diagnosis (and `--apply`) never burn the rerun-once budget on a
+  failure only a fresh review can clear. When the rollup is stuck on a
+  bot-gated instance alongside an already-passing non-bot
+  pull_request-family instance, it additionally offers a
+  `recoveryRefreshPlan` — populated even alongside a non-empty rerun
+  plan when every rerun-eligible instance there is itself bot-triggered
+  (#1745; rerunning a bot-triggered instance does not supply the
+  non-bot trigger the recovery-refresh option exists to provide):
+  rerunning the already-passing instance is the documented way to force
+  a fresh non-bot evaluation and clear the stale rollup. Pass `--apply`
+  (#1766) to execute that same plan instead of only diagnosing it:
+  reruns each rerun-eligible instance in order (recovery-refresh first
+  when one applies), waits for each to reach a genuinely new completed
+  attempt before starting the next, and stops early once the recomputed
+  plan is fully resolved — never a `bot-gated-skip`,
+  `awaiting-fresh-review`, or rerun-budget-held instance.
 - `scripts/live-status-digest.mjs` for issue or PR live status digest
   discovery, rendering, dry-run, and claim-checked upsert
 - `scripts/audit-pr-cleanup.mjs` for post-merge comment cleanup auditing
@@ -1275,10 +1281,15 @@ to post it is the consuming track's job.
   required-check rollup, read-only by default: fetches every check-run
   instance for the PR's current HEAD SHA (paged commit check-runs API,
   `filter=all`), classifies each as `pass` / `pending` / `bot-gated-skip` /
-  `unresolved` / `rerun-eligible`, and prints the ordered, deduplicated
-  `gh run rerun <id>` recovery plan for the rerun-eligible instances --
-  referenced from `idd-ci.instructions.md` §Rerun mechanics as the
-  preferred way to produce that plan
+  `unresolved` / `awaiting-fresh-review` / `rerun-eligible`, and prints
+  the ordered, deduplicated `gh run rerun <id>` recovery plan for the
+  rerun-eligible instances -- referenced from `idd-ci.instructions.md`
+  §Rerun mechanics as the preferred way to produce that plan. An
+  instance whose own advisory-convergence job-log verdict reports that
+  the latest Copilot review does not cover the current HEAD is
+  classified `awaiting-fresh-review` rather than `rerun-eligible`
+  (#1775), so neither the diagnosis nor `--apply` burns the rerun-once
+  budget on a failure only a fresh review can clear
 - Also reports a `recoveryRefreshPlan` when the rollup is stuck on a
   bot-gated instance alongside an already-passing non-bot
   pull_request-family instance — populated even alongside a non-empty
@@ -1297,7 +1308,8 @@ to post it is the consuming track's job.
   attempt (polled via the actions/runs API, not `gh run watch`, to avoid
   racing a just-issued rerun's stale pre-rerun status) before starting
   the next, and stops early once the recomputed plan is fully resolved --
-  a `bot-gated-skip` or rerun-budget-held instance is never rerun
+  a `bot-gated-skip`, `awaiting-fresh-review`, or rerun-budget-held
+  instance is never rerun
 
 ### Merge-gate evidence
 

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -1268,71 +1268,29 @@ export function formatApplySummary(result) {
  * {@link parsePaginatedGhNdjson} parser `ghApiJson` uses internally.
  */
 /**
- * Args for listing jobs of one workflow run -- used to locate the
- * `idd-advisory-convergence` job whose log carries the JSON verdict
- * {@link extractAdvisoryVerdictReasonsFromLog} parses (#1775).
- * `--paginate` is required: the Actions "list jobs for a workflow run"
- * endpoint pages at 30 jobs, and a busy multi-job run can place the
- * advisory-convergence job beyond the first page -- missing it would
- * leave `verdictReasons` null and misclassify an uncovered-HEAD failure
- * as `rerun-eligible` (Copilot review on #1790).
+ * Args for downloading one workflow run's combined job logs as plain
+ * text via `gh run view --log`. Prefer this over
+ * `GET /repos/.../actions/jobs/{id}/logs`, which redirects to a ZIP
+ * archive that `ghText` would decode as garbage UTF-8 and leave
+ * `verdictReasons` null (Copilot review on #1790). Scoped with `-R
+ * owner/repo` so a cross-repository diagnosis still hits the right
+ * run.
  */
-export function buildRunJobsArgs(owner, repo, runId) {
-  return [
-    'api',
-    `repos/${owner}/${repo}/actions/runs/${runId}/jobs`,
-    '--paginate',
-    '--jq',
-    '.jobs[]',
-  ];
-}
-/**
- * Args for downloading one job's logs. `--allow-escape-sequences` is
- * required: Actions job logs routinely embed ANSI color codes, and `gh
- * api` refuses to print them to a non-TTY without this flag (confirmed
- * empirically while implementing #1775).
- */
-export function buildJobLogsArgs(owner, repo, jobId) {
-  return [
-    'api',
-    `repos/${owner}/${repo}/actions/jobs/${jobId}/logs`,
-    '--allow-escape-sequences',
-  ];
+export function buildRunViewLogArgs(owner, repo, runId) {
+  return ['run', 'view', runId, '-R', `${owner}/${repo}`, '--log'];
 }
 /**
  * Fetch and parse the advisory-convergence `reasons` array for one
- * workflow run, or `null` when the log cannot be read / parsed. Looks up
- * the job whose name matches {@link RERUN_PLAN_CHECK_NAME}. When every
- * job in the payload is missing a name (or names are blank), falls back
- * to the first job with an id -- the Actions jobs API normally always
- * returns `name`, so this fallback is only for a truncated/malformed
- * payload, never for "name present but did not match" (that would read
- * an unrelated job's log and could invent an `awaiting-fresh-review`
- * hold; CodeRabbit review on #1790). Failures are swallowed into `null`
- * so a flaky log API cannot invent an uncovered-HEAD hold or abort the
- * whole diagnosis (#1775).
+ * workflow run, or `null` when the log cannot be read / parsed. Uses
+ * {@link buildRunViewLogArgs} (`gh run view --log`) for plain-text logs
+ * and feeds them to {@link extractAdvisoryVerdictReasonsFromLog}.
+ * Failures are swallowed into `null` so a flaky log download cannot
+ * invent an uncovered-HEAD hold or abort the whole diagnosis (#1775).
  */
 function fetchAdvisoryVerdictReasonsForRun(owner, repo, runId) {
   try {
-    const jobsRaw = ghText(
-      buildRunJobsArgs(owner, repo, runId),
-      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-    );
-    const jobs = parsePaginatedGhNdjson(jobsRaw);
-    if (jobs.length === 0) return null;
-    const named = jobs.find(
-      (job) =>
-        String(job.name ?? '').trim() === RERUN_PLAN_CHECK_NAME &&
-        job.id != null,
-    );
-    const namesAllBlank = jobs.every(
-      (job) => String(job.name ?? '').trim() === '',
-    );
-    const selected =
-      named ?? (namesAllBlank ? jobs.find((job) => job.id != null) : undefined);
-    if (!selected || selected.id == null) return null;
     const logText = ghText(
-      buildJobLogsArgs(owner, repo, String(selected.id)),
+      buildRunViewLogArgs(owner, repo, runId),
       GH_TEXT_LOOP_TIMEOUT_OPTIONS,
     );
     return extractAdvisoryVerdictReasonsFromLog(logText);

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -1272,7 +1272,7 @@ export function formatApplySummary(result) {
  * `idd-advisory-convergence` job whose log carries the JSON verdict
  * {@link extractAdvisoryVerdictReasonsFromLog} parses (#1775).
  * `--paginate` is required: the Actions "list jobs for a workflow run"
- * endpoint pages at 30 jobs, and a busy matrixed run can place the
+ * endpoint pages at 30 jobs, and a busy multi-job run can place the
  * advisory-convergence job beyond the first page -- missing it would
  * leave `verdictReasons` null and misclassify an uncovered-HEAD failure
  * as `rerun-eligible` (Copilot review on #1790).

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -21,12 +21,14 @@
 // command) itself; a mutating `--apply` mode is a deliberate follow-up
 // (out of scope here).
 //
-// Classification (five states -- the issue's three named buckets, `pass` /
-// `rerun-eligible` / `bot-gated-skip`, are a subset here; `pending` and
-// `unresolved` are additional fail-safe states so a live run is never
-// force-classified into either "skip forever" or "safe to rerun", and an
-// unresolvable run identity is reported instead of silently guessed or
-// silently dropped):
+// Classification (six states -- the issue's three named buckets, `pass` /
+// `rerun-eligible` / `bot-gated-skip`, are a subset here; `pending`,
+// `unresolved`, and `awaiting-fresh-review` are additional fail-safe
+// states so a live run is never force-classified into either "skip
+// forever" or "safe to rerun", an unresolvable run identity is reported
+// instead of silently guessed or dropped, and a failure whose own
+// advisory-convergence verdict is "review does not cover HEAD" is never
+// recommended for a rerun that cannot change that outcome -- #1775):
 //   - `pass`: conclusion is success/neutral/skipped -- no action needed.
 //   - `pending`: still queued/in_progress (no conclusion yet) -- reported,
 //     excluded from the plan (rerunning a live run cancels it, not helps).
@@ -50,6 +52,12 @@
 //     inspection, never silently dropped and never placed in the plan
 //     (fail-closed: an instance this helper cannot positively verify as
 //     safe is never recommended for rerun).
+//   - `awaiting-fresh-review`: the instance's own advisory-convergence
+//     JSON verdict (from the workflow job log) reports that the latest
+//     Copilot review does not cover the current HEAD. No number of
+//     `gh run rerun` invocations changes that outcome -- only a fresh
+//     review does -- so this is never placed in the plan and never
+//     spends the rerun-once budget (#1775, observed on PR #1772).
 //   - `rerun-eligible`: non-pass, terminal, resolved -- goes into the
 //     ordered rerun plan (bot-triggered or not, unless gated per above).
 //
@@ -145,6 +153,15 @@ const PULL_REQUEST_FAMILY_EVENTS = new Set([
   'pull_request_review',
   'pull_request_review_comment',
 ]);
+/**
+ * Stable phrase shared with `advisory-convergence.mts` Clause 1's reason
+ * text (`latest <bot> review (commit <sha>) does not cover current HEAD
+ * <head>`). Matching on this substring (not the whole templated string)
+ * keeps the classifier independent of the configured primary bot login
+ * and of either SHA, while still sourcing the decision from the
+ * workflow's own verdict rather than re-deriving coverage (#1775).
+ */
+export const UNCOVERED_HEAD_REASON_MARKER = 'does not cover current HEAD';
 const PLAN_CAVEAT =
   'Rerun the rerun-eligible instances ONE AT A TIME, in the order listed below, waiting for each `gh run rerun` to finish before starting the next -- rerunning several concurrently makes them cancel each other via the shared concurrency group.';
 // Deliberately does NOT open with "No rerun-eligible instance exists": since
@@ -319,6 +336,7 @@ export function computeRerunPlan(input, options) {
     pending: 0,
     botGatedSkip: 0,
     unresolved: 0,
+    awaitingFreshReview: 0,
     rerunEligible: 0,
     rerunBudgetHeld: budgetHeldCheckRunIds.size,
     total: instances.length,
@@ -329,6 +347,8 @@ export function computeRerunPlan(input, options) {
     else if (instance.classification === 'bot-gated-skip')
       counts.botGatedSkip += 1;
     else if (instance.classification === 'unresolved') counts.unresolved += 1;
+    else if (instance.classification === 'awaiting-fresh-review')
+      counts.awaitingFreshReview += 1;
     else counts.rerunEligible += 1;
   }
   return {
@@ -544,7 +564,24 @@ function classifyInstance(instance, options) {
         : 'triggering event is unknown; inspect manually rather than assuming it is safe to rerun',
     };
   }
-  // 7. Non-pass, terminal, resolved, pull_request-family -- safe to rerun.
+  // 7. Uncovered-HEAD hold (#1775): the instance's own
+  // advisory-convergence JSON verdict (from the workflow job log) says
+  // the latest Copilot review does not cover the current HEAD. Rerunning
+  // cannot change that -- only a fresh review can -- so never place this
+  // in the plan and never spend the rerun-once budget on it. Only fires
+  // when `verdictReasons` was actually consulted and matched; a missing
+  // / unparsed log leaves classification unchanged (no invented hold).
+  if (hasUncoveredHeadVerdictReason(instance.verdictReasons)) {
+    const matched =
+      instance.verdictReasons?.find(isUncoveredHeadVerdictReason) ??
+      UNCOVERED_HEAD_REASON_MARKER;
+    return {
+      ...instance,
+      classification: 'awaiting-fresh-review',
+      reason: `advisory-convergence verdict reports "${matched}"; rerunning cannot clear this -- wait for a fresh review covering the current HEAD rather than spending the rerun-once budget (#1775)`,
+    };
+  }
+  // 8. Non-pass, terminal, resolved, pull_request-family -- safe to rerun.
   // A bot-triggered actor does not withhold this instance by itself
   // (#1745) -- only a genuinely `action_required` conclusion does, handled
   // in step 3 above -- so the reason notes bot-triggering when present
@@ -557,6 +594,101 @@ function classifyInstance(instance, options) {
     classification: 'rerun-eligible',
     reason: `conclusion "${conclusion}" is non-passing and resolved (event "${runEvent}")${botNote}; safe to rerun`,
   };
+}
+/**
+ * `true` when `reason` is an advisory-convergence Clause 1
+ * uncovered-HEAD reason (see {@link UNCOVERED_HEAD_REASON_MARKER}).
+ */
+export function isUncoveredHeadVerdictReason(reason) {
+  return String(reason ?? '')
+    .toLowerCase()
+    .includes(UNCOVERED_HEAD_REASON_MARKER.toLowerCase());
+}
+/**
+ * `true` when a consulted `reasons` list contains an uncovered-HEAD
+ * reason. A `null` / `undefined` list means "not consulted" and never
+ * matches -- so a missing log cannot invent an `awaiting-fresh-review`
+ * hold (#1775).
+ */
+export function hasUncoveredHeadVerdictReason(reasons) {
+  if (!reasons) return false;
+  return reasons.some((reason) => isUncoveredHeadVerdictReason(reason));
+}
+/**
+ * Extract the advisory-convergence JSON verdict's `reasons` array from a
+ * workflow job log (`gh run view --log` / Actions job-logs API output).
+ * Returns `null` when no well-formed verdict JSON is found, so callers
+ * can leave `verdictReasons` unset rather than inventing an empty list
+ * that would look like "fetched, no reasons". Pure and unit-testable;
+ * production collection feeds it the log text for each non-pass run.
+ *
+ * The log lines are typically prefixed with a job/step/timestamp column
+ * (and may carry ANSI color codes); both are stripped before brace-
+ * matching so the same parser works on raw job logs and on
+ * `gh run view --log` output.
+ */
+export function extractAdvisoryVerdictReasonsFromLog(logText) {
+  // Strip ANSI CSI color sequences without a control-character regex
+  // (Biome disallows `\u001b` in regex literals). ESC is code 27.
+  const esc = String.fromCharCode(27);
+  const text = String(logText ?? '')
+    .split(esc)
+    .map((chunk, index) =>
+      index === 0 ? chunk : chunk.replace(/^\[[0-9;]*m/, ''),
+    )
+    .join('');
+  if (!text) return null;
+  // Rebuild candidate JSON payloads by walking braces across lines after
+  // stripping the `gh run view --log` prefix (everything through the
+  // first `Z ` timestamp marker on each line, when present). Prefer the
+  // LAST well-formed advisory-convergence verdict in the log -- a single
+  // job can echo intermediate output, and the final `--assert` document
+  // is what actually determined the check-run conclusion.
+  const payloadChunks = [];
+  let depth = 0;
+  let buf = [];
+  for (const rawLine of text.split(/\r?\n/)) {
+    const timestampMatch = rawLine.match(/Z (.*)$/);
+    const line =
+      timestampMatch && timestampMatch[1] !== undefined
+        ? timestampMatch[1]
+        : rawLine;
+    for (const ch of line) {
+      if (ch === '{') {
+        if (depth === 0) buf = ['{'];
+        else buf.push(ch);
+        depth += 1;
+      } else if (ch === '}') {
+        if (depth === 0) continue;
+        buf.push(ch);
+        depth -= 1;
+        if (depth === 0) {
+          payloadChunks.push(buf.join(''));
+          buf = [];
+        }
+      } else if (depth > 0) {
+        buf.push(ch);
+      }
+    }
+  }
+  let lastReasons = null;
+  for (const chunk of payloadChunks) {
+    if (!chunk.includes('"reasons"') || !chunk.includes('"ready"')) continue;
+    try {
+      const parsed = JSON.parse(chunk);
+      if (!Array.isArray(parsed.reasons) || typeof parsed.ready !== 'boolean') {
+        continue;
+      }
+      const reasons = parsed.reasons
+        .filter((entry) => typeof entry === 'string')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0);
+      lastReasons = reasons;
+    } catch {
+      // not valid JSON -- skip
+    }
+  }
+  return lastReasons;
 }
 /**
  * `true` when the check-run instance's underlying workflow run was
@@ -843,12 +975,12 @@ export function parseArgs(argv) {
   };
 }
 /**
- * Describe outstanding `pending` / `bot-gated-skip` / `unresolved`
- * instance counts, or `''` when none exist. Extracted from
- * {@link describeNoActionState} so the CLI can surface these states
- * independently of whether a rerun plan, recovery-refresh plan, or hold
- * notice ALSO exists for a different instance in the same run --
- * previously these were only ever shown when NONE of those three
+ * Describe outstanding `pending` / `bot-gated-skip` / `unresolved` /
+ * `awaiting-fresh-review` instance counts, or `''` when none exist.
+ * Extracted from {@link describeNoActionState} so the CLI can surface
+ * these states independently of whether a rerun plan, recovery-refresh
+ * plan, or hold notice ALSO exists for a different instance in the same
+ * run -- previously these were only ever shown when NONE of those three
  * existed, silently hiding e.g. 2 still-pending instances whenever the
  * output happened to also have a rerun plan for a different instance
  * (CodeRabbit review, #1434).
@@ -870,20 +1002,26 @@ export function describeOutstandingStates(plan) {
       `${plan.counts.unresolved} instance(s) could not be resolved -- inspect each instance's "reason" above manually`,
     );
   }
+  if (plan.counts.awaitingFreshReview > 0) {
+    notes.push(
+      `${plan.counts.awaitingFreshReview} instance(s) are awaiting a fresh review covering the current HEAD -- wait for Copilot (or the configured primary bot) to re-review rather than rerunning (#1775)`,
+    );
+  }
   return notes.join('; ');
 }
 /**
  * Describe the terminal state when there is truly nothing to report:
  * no rerun plan, no recovery-refresh plan, no hold notice, AND no
- * outstanding `pending` / `unresolved` / `bot-gated-skip` instance (see
- * {@link describeOutstandingStates}, which the CLI now also consults
- * independently of this function). "Nothing to do" would be accurate
- * only when every instance is `pass` (or there are no instances at all)
- * -- `pending`, `unresolved`, and `bot-gated-skip` all still require an
- * operator action (waiting, manual inspection, approval, or a non-bot
- * trigger, per each instance's own `reason`), so presenting them as
- * no-action risked leaving a genuinely stuck required check unresolved
- * (#1434 review, Codex P2).
+ * outstanding `pending` / `unresolved` / `bot-gated-skip` /
+ * `awaiting-fresh-review` instance (see {@link describeOutstandingStates},
+ * which the CLI now also consults independently of this function).
+ * "Nothing to do" would be accurate only when every instance is `pass`
+ * (or there are no instances at all) -- `pending`, `unresolved`,
+ * `bot-gated-skip`, and `awaiting-fresh-review` all still require an
+ * operator action (waiting, manual inspection, approval, a non-bot
+ * trigger, or a fresh review, per each instance's own `reason`), so
+ * presenting them as no-action risked leaving a genuinely stuck required
+ * check unresolved (#1434 review, Codex P2; #1775).
  */
 export function describeNoActionState(plan) {
   if (plan.counts.total === 0) {
@@ -974,22 +1112,28 @@ By default (without --apply): read-only. Fetches every
 "${RERUN_PLAN_CHECK_NAME}" check-run instance for the PR's current HEAD SHA
 (commit check-runs API, paged -- not the recent-runs list, which can page
 the target run out of view), classifies each as pass / pending /
-bot-gated-skip / unresolved / rerun-eligible, and prints the ordered
-sequential "gh run rerun <id>" recovery plan for the rerun-eligible
-instances (each command includes "-R <owner>/<repo>" when the repository
-is known, so the plan is safe to run outside this checkout). Never calls
-"gh run rerun" (or any other mutating command) itself.
+bot-gated-skip / unresolved / awaiting-fresh-review / rerun-eligible, and
+prints the ordered sequential "gh run rerun <id>" recovery plan for the
+rerun-eligible instances (each command includes "-R <owner>/<repo>" when
+the repository is known, so the plan is safe to run outside this
+checkout). An instance whose own advisory-convergence verdict reports
+that the latest review does not cover the current HEAD is classified
+awaiting-fresh-review (not rerun-eligible) so the diagnosis tells the
+operator to wait for a fresh review rather than burning the rerun-once
+budget (#1775). Never calls "gh run rerun" (or any other mutating
+command) itself.
 
 With --apply: after printing the same diagnostic plan as above, executes
-it -- "gh run rerun"-ing each rerun-eligible (never bot-gated-skip or
-rerun-budget-held) instance one at a time, waiting for each to reach a
-terminal state before starting the next, exactly as "planCaveat" already
-documents. Prefers the recovery-refresh plan first when one exists,
-matching idd-ci.instructions.md's documented recovery order. After each
-rerun, the plan is recomputed from fresh evidence and the loop stops early
-as soon as it resolves (no rerun-eligible or recovery-refresh instance
-remains) instead of running the rest of the original plan. A final summary
-of what ran and whether the target state resolved is printed to stderr.
+it -- "gh run rerun"-ing each rerun-eligible (never bot-gated-skip,
+awaiting-fresh-review, or rerun-budget-held) instance one at a time,
+waiting for each to reach a terminal state before starting the next,
+exactly as "planCaveat" already documents. Prefers the recovery-refresh
+plan first when one exists, matching idd-ci.instructions.md's documented
+recovery order. After each rerun, the plan is recomputed from fresh
+evidence and the loop stops early as soon as it resolves (no
+rerun-eligible or recovery-refresh instance remains) instead of running
+the rest of the original plan. A final summary of what ran and whether
+the target state resolved is printed to stderr.
 
 --owner and --repo must be given together (to inspect a PR outside the
 current checkout) or omitted together (to auto-detect the current
@@ -1047,10 +1191,11 @@ const MAX_APPLY_RERUNS = 20;
  * are non-empty, matching {@link describeRecoveryRefreshHeader}'s
  * documented recovery order (try the recovery-refresh rerun first; only
  * fall back to the sequential plan if it does not clear the rollup).
- * `bot-gated-skip` and rerun-budget-held instances are never candidates
- * here: neither `plan` nor `recoveryRefreshPlan` ever contains them (see
- * {@link computeRerunPlan}), so this loop cannot reach them regardless of
- * `deps.recomputePlan`'s output.
+ * `bot-gated-skip`, `awaiting-fresh-review`, and rerun-budget-held
+ * instances are never candidates here: neither `plan` nor
+ * `recoveryRefreshPlan` ever contains them (see {@link computeRerunPlan}),
+ * so this loop cannot reach them regardless of `deps.recomputePlan`'s
+ * output (#1775 keeps uncovered-HEAD failures out of both plans).
  */
 export function applyRerunPlan(initialPlan, deps) {
   const executed = [];
@@ -1122,6 +1267,65 @@ export function formatApplySummary(result) {
  * function passes `--jq '.check_runs[]'` directly and reuses the same
  * {@link parsePaginatedGhNdjson} parser `ghApiJson` uses internally.
  */
+/**
+ * Args for listing jobs of one workflow run -- used to locate the
+ * `idd-advisory-convergence` job whose log carries the JSON verdict
+ * {@link extractAdvisoryVerdictReasonsFromLog} parses (#1775).
+ */
+export function buildRunJobsArgs(owner, repo, runId) {
+  return [
+    'api',
+    `repos/${owner}/${repo}/actions/runs/${runId}/jobs`,
+    '--jq',
+    '.jobs[]',
+  ];
+}
+/**
+ * Args for downloading one job's logs. `--allow-escape-sequences` is
+ * required: Actions job logs routinely embed ANSI color codes, and `gh
+ * api` refuses to print them to a non-TTY without this flag (confirmed
+ * empirically while implementing #1775).
+ */
+export function buildJobLogsArgs(owner, repo, jobId) {
+  return [
+    'api',
+    `repos/${owner}/${repo}/actions/jobs/${jobId}/logs`,
+    '--allow-escape-sequences',
+  ];
+}
+/**
+ * Fetch and parse the advisory-convergence `reasons` array for one
+ * workflow run, or `null` when the log cannot be read / parsed. Looks up
+ * the job whose name matches {@link RERUN_PLAN_CHECK_NAME} (falling back
+ * to the first job when names are unavailable) and feeds its log to
+ * {@link extractAdvisoryVerdictReasonsFromLog}. Failures are swallowed
+ * into `null` so a flaky log API cannot invent an uncovered-HEAD hold
+ * or abort the whole diagnosis (#1775).
+ */
+function fetchAdvisoryVerdictReasonsForRun(owner, repo, runId) {
+  try {
+    const jobsRaw = ghText(
+      buildRunJobsArgs(owner, repo, runId),
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+    const jobs = parsePaginatedGhNdjson(jobsRaw);
+    if (jobs.length === 0) return null;
+    const named =
+      jobs.find(
+        (job) =>
+          String(job.name ?? '').trim() === RERUN_PLAN_CHECK_NAME &&
+          job.id != null,
+      ) ?? jobs.find((job) => job.id != null);
+    if (!named || named.id == null) return null;
+    const logText = ghText(
+      buildJobLogsArgs(owner, repo, String(named.id)),
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+    return extractAdvisoryVerdictReasonsFromLog(logText);
+  } catch {
+    return null;
+  }
+}
 export function buildCheckRunsForRefArgs(owner, repo, ref, checkName) {
   const path = `repos/${owner}/${repo}/commits/${ref}/check-runs`;
   return [
@@ -1408,6 +1612,30 @@ function collectFromGitHub(args) {
       runMetaById.set(runId, null);
     }
   }
+  // Per-run advisory-convergence verdict reasons (#1775). Only non-pass
+  // terminal check-runs need them -- pass / pending never reach the
+  // uncovered-HEAD classifier, so skipping those saves a log download
+  // per green instance. Failures to fetch or parse leave the map entry
+  // absent (`null` on the instance) rather than inventing an empty list,
+  // so a flaky log API cannot invent an awaiting-fresh-review hold.
+  const runIdsNeedingVerdict = new Set(
+    rawCheckRuns
+      .map((run) => {
+        const conclusion = run.conclusion
+          ? String(run.conclusion).trim().toLowerCase()
+          : '';
+        if (!conclusion || PASS_CONCLUSIONS.has(conclusion)) return null;
+        return parseRunIdFromUrl(resolveCheckRunUrl(run));
+      })
+      .filter((id) => id !== null),
+  );
+  const verdictReasonsByRunId = new Map();
+  for (const runId of runIdsNeedingVerdict) {
+    verdictReasonsByRunId.set(
+      runId,
+      fetchAdvisoryVerdictReasonsForRun(owner, repo, runId),
+    );
+  }
   const instances = rawCheckRuns.map((run) => {
     const url = resolveCheckRunUrl(run);
     const runId = parseRunIdFromUrl(url);
@@ -1427,6 +1655,8 @@ function collectFromGitHub(args) {
       triggeringActorLogin: meta?.triggeringActorLogin ?? null,
       triggeringActorType: meta?.triggeringActorType ?? null,
       runAttempt: meta?.runAttempt ?? null,
+      verdictReasons:
+        runId !== null ? (verdictReasonsByRunId.get(runId) ?? null) : null,
     };
   });
   // Fetched from owner/repo's TRUSTED DEFAULT BRANCH, unconditionally --

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -1271,11 +1271,17 @@ export function formatApplySummary(result) {
  * Args for listing jobs of one workflow run -- used to locate the
  * `idd-advisory-convergence` job whose log carries the JSON verdict
  * {@link extractAdvisoryVerdictReasonsFromLog} parses (#1775).
+ * `--paginate` is required: the Actions "list jobs for a workflow run"
+ * endpoint pages at 30 jobs, and a busy matrixed run can place the
+ * advisory-convergence job beyond the first page -- missing it would
+ * leave `verdictReasons` null and misclassify an uncovered-HEAD failure
+ * as `rerun-eligible` (Copilot review on #1790).
  */
 export function buildRunJobsArgs(owner, repo, runId) {
   return [
     'api',
     `repos/${owner}/${repo}/actions/runs/${runId}/jobs`,
+    '--paginate',
     '--jq',
     '.jobs[]',
   ];
@@ -1296,11 +1302,15 @@ export function buildJobLogsArgs(owner, repo, jobId) {
 /**
  * Fetch and parse the advisory-convergence `reasons` array for one
  * workflow run, or `null` when the log cannot be read / parsed. Looks up
- * the job whose name matches {@link RERUN_PLAN_CHECK_NAME} (falling back
- * to the first job when names are unavailable) and feeds its log to
- * {@link extractAdvisoryVerdictReasonsFromLog}. Failures are swallowed
- * into `null` so a flaky log API cannot invent an uncovered-HEAD hold
- * or abort the whole diagnosis (#1775).
+ * the job whose name matches {@link RERUN_PLAN_CHECK_NAME}. When every
+ * job in the payload is missing a name (or names are blank), falls back
+ * to the first job with an id -- the Actions jobs API normally always
+ * returns `name`, so this fallback is only for a truncated/malformed
+ * payload, never for "name present but did not match" (that would read
+ * an unrelated job's log and could invent an `awaiting-fresh-review`
+ * hold; CodeRabbit review on #1790). Failures are swallowed into `null`
+ * so a flaky log API cannot invent an uncovered-HEAD hold or abort the
+ * whole diagnosis (#1775).
  */
 function fetchAdvisoryVerdictReasonsForRun(owner, repo, runId) {
   try {
@@ -1310,15 +1320,19 @@ function fetchAdvisoryVerdictReasonsForRun(owner, repo, runId) {
     );
     const jobs = parsePaginatedGhNdjson(jobsRaw);
     if (jobs.length === 0) return null;
-    const named =
-      jobs.find(
-        (job) =>
-          String(job.name ?? '').trim() === RERUN_PLAN_CHECK_NAME &&
-          job.id != null,
-      ) ?? jobs.find((job) => job.id != null);
-    if (!named || named.id == null) return null;
+    const named = jobs.find(
+      (job) =>
+        String(job.name ?? '').trim() === RERUN_PLAN_CHECK_NAME &&
+        job.id != null,
+    );
+    const namesAllBlank = jobs.every(
+      (job) => String(job.name ?? '').trim() === '',
+    );
+    const selected =
+      named ?? (namesAllBlank ? jobs.find((job) => job.id != null) : undefined);
+    if (!selected || selected.id == null) return null;
     const logText = ghText(
-      buildJobLogsArgs(owner, repo, String(named.id)),
+      buildJobLogsArgs(owner, repo, String(selected.id)),
       GH_TEXT_LOOP_TIMEOUT_OPTIONS,
     );
     return extractAdvisoryVerdictReasonsFromLog(logText);

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -1705,59 +1705,29 @@ interface RawWorkflowRunPayload {
  * {@link parsePaginatedGhNdjson} parser `ghApiJson` uses internally.
  */
 /**
- * Args for listing jobs of one workflow run -- used to locate the
- * `idd-advisory-convergence` job whose log carries the JSON verdict
- * {@link extractAdvisoryVerdictReasonsFromLog} parses (#1775).
- * `--paginate` is required: the Actions "list jobs for a workflow run"
- * endpoint pages at 30 jobs, and a busy multi-job run can place the
- * advisory-convergence job beyond the first page -- missing it would
- * leave `verdictReasons` null and misclassify an uncovered-HEAD failure
- * as `rerun-eligible` (Copilot review on #1790).
+ * Args for downloading one workflow run's combined job logs as plain
+ * text via `gh run view --log`. Prefer this over
+ * `GET /repos/.../actions/jobs/{id}/logs`, which redirects to a ZIP
+ * archive that `ghText` would decode as garbage UTF-8 and leave
+ * `verdictReasons` null (Copilot review on #1790). Scoped with `-R
+ * owner/repo` so a cross-repository diagnosis still hits the right
+ * run.
  */
-export function buildRunJobsArgs(
+export function buildRunViewLogArgs(
   owner: string,
   repo: string,
   runId: string,
 ): string[] {
-  return [
-    'api',
-    `repos/${owner}/${repo}/actions/runs/${runId}/jobs`,
-    '--paginate',
-    '--jq',
-    '.jobs[]',
-  ];
-}
-
-/**
- * Args for downloading one job's logs. `--allow-escape-sequences` is
- * required: Actions job logs routinely embed ANSI color codes, and `gh
- * api` refuses to print them to a non-TTY without this flag (confirmed
- * empirically while implementing #1775).
- */
-export function buildJobLogsArgs(
-  owner: string,
-  repo: string,
-  jobId: string,
-): string[] {
-  return [
-    'api',
-    `repos/${owner}/${repo}/actions/jobs/${jobId}/logs`,
-    '--allow-escape-sequences',
-  ];
+  return ['run', 'view', runId, '-R', `${owner}/${repo}`, '--log'];
 }
 
 /**
  * Fetch and parse the advisory-convergence `reasons` array for one
- * workflow run, or `null` when the log cannot be read / parsed. Looks up
- * the job whose name matches {@link RERUN_PLAN_CHECK_NAME}. When every
- * job in the payload is missing a name (or names are blank), falls back
- * to the first job with an id -- the Actions jobs API normally always
- * returns `name`, so this fallback is only for a truncated/malformed
- * payload, never for "name present but did not match" (that would read
- * an unrelated job's log and could invent an `awaiting-fresh-review`
- * hold; CodeRabbit review on #1790). Failures are swallowed into `null`
- * so a flaky log API cannot invent an uncovered-HEAD hold or abort the
- * whole diagnosis (#1775).
+ * workflow run, or `null` when the log cannot be read / parsed. Uses
+ * {@link buildRunViewLogArgs} (`gh run view --log`) for plain-text logs
+ * and feeds them to {@link extractAdvisoryVerdictReasonsFromLog}.
+ * Failures are swallowed into `null` so a flaky log download cannot
+ * invent an uncovered-HEAD hold or abort the whole diagnosis (#1775).
  */
 function fetchAdvisoryVerdictReasonsForRun(
   owner: string,
@@ -1765,28 +1735,8 @@ function fetchAdvisoryVerdictReasonsForRun(
   runId: string,
 ): string[] | null {
   try {
-    const jobsRaw = ghText(
-      buildRunJobsArgs(owner, repo, runId),
-      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-    );
-    const jobs = parsePaginatedGhNdjson(jobsRaw) as Array<{
-      id?: number | string | null;
-      name?: string | null;
-    }>;
-    if (jobs.length === 0) return null;
-    const named = jobs.find(
-      (job) =>
-        String(job.name ?? '').trim() === RERUN_PLAN_CHECK_NAME &&
-        job.id != null,
-    );
-    const namesAllBlank = jobs.every(
-      (job) => String(job.name ?? '').trim() === '',
-    );
-    const selected =
-      named ?? (namesAllBlank ? jobs.find((job) => job.id != null) : undefined);
-    if (!selected || selected.id == null) return null;
     const logText = ghText(
-      buildJobLogsArgs(owner, repo, String(selected.id)),
+      buildRunViewLogArgs(owner, repo, runId),
       GH_TEXT_LOOP_TIMEOUT_OPTIONS,
     );
     return extractAdvisoryVerdictReasonsFromLog(logText);

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -1709,7 +1709,7 @@ interface RawWorkflowRunPayload {
  * `idd-advisory-convergence` job whose log carries the JSON verdict
  * {@link extractAdvisoryVerdictReasonsFromLog} parses (#1775).
  * `--paginate` is required: the Actions "list jobs for a workflow run"
- * endpoint pages at 30 jobs, and a busy matrixed run can place the
+ * endpoint pages at 30 jobs, and a busy multi-job run can place the
  * advisory-convergence job beyond the first page -- missing it would
  * leave `verdictReasons` null and misclassify an uncovered-HEAD failure
  * as `rerun-eligible` (Copilot review on #1790).

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -21,12 +21,14 @@
 // command) itself; a mutating `--apply` mode is a deliberate follow-up
 // (out of scope here).
 //
-// Classification (five states -- the issue's three named buckets, `pass` /
-// `rerun-eligible` / `bot-gated-skip`, are a subset here; `pending` and
-// `unresolved` are additional fail-safe states so a live run is never
-// force-classified into either "skip forever" or "safe to rerun", and an
-// unresolvable run identity is reported instead of silently guessed or
-// silently dropped):
+// Classification (six states -- the issue's three named buckets, `pass` /
+// `rerun-eligible` / `bot-gated-skip`, are a subset here; `pending`,
+// `unresolved`, and `awaiting-fresh-review` are additional fail-safe
+// states so a live run is never force-classified into either "skip
+// forever" or "safe to rerun", an unresolvable run identity is reported
+// instead of silently guessed or dropped, and a failure whose own
+// advisory-convergence verdict is "review does not cover HEAD" is never
+// recommended for a rerun that cannot change that outcome -- #1775):
 //   - `pass`: conclusion is success/neutral/skipped -- no action needed.
 //   - `pending`: still queued/in_progress (no conclusion yet) -- reported,
 //     excluded from the plan (rerunning a live run cancels it, not helps).
@@ -50,6 +52,12 @@
 //     inspection, never silently dropped and never placed in the plan
 //     (fail-closed: an instance this helper cannot positively verify as
 //     safe is never recommended for rerun).
+//   - `awaiting-fresh-review`: the instance's own advisory-convergence
+//     JSON verdict (from the workflow job log) reports that the latest
+//     Copilot review does not cover the current HEAD. No number of
+//     `gh run rerun` invocations changes that outcome -- only a fresh
+//     review does -- so this is never placed in the plan and never
+//     spends the rerun-once budget (#1775, observed on PR #1772).
 //   - `rerun-eligible`: non-pass, terminal, resolved -- goes into the
 //     ordered rerun plan (bot-triggered or not, unless gated per above).
 //
@@ -161,7 +169,18 @@ export type RerunPlanClassification =
   | 'pending'
   | 'bot-gated-skip'
   | 'unresolved'
+  | 'awaiting-fresh-review'
   | 'rerun-eligible';
+
+/**
+ * Stable phrase shared with `advisory-convergence.mts` Clause 1's reason
+ * text (`latest <bot> review (commit <sha>) does not cover current HEAD
+ * <head>`). Matching on this substring (not the whole templated string)
+ * keeps the classifier independent of the configured primary bot login
+ * and of either SHA, while still sourcing the decision from the
+ * workflow's own verdict rather than re-deriving coverage (#1775).
+ */
+export const UNCOVERED_HEAD_REASON_MARKER = 'does not cover current HEAD';
 
 /**
  * One check-run instance, already normalized and (when resolvable) already
@@ -200,6 +219,17 @@ export interface RerunPlanRawInstance {
    * rerun-once budget (not just its policy string) can be honored per
    * instance. */
   runAttempt: number | null;
+  /**
+   * `reasons` array from this instance's own advisory-convergence JSON
+   * verdict (parsed out of the workflow job log), or `null` when the log
+   * was not consulted or could not be parsed. A `null` leaves
+   * classification unchanged (no invented hold); a non-null list that
+   * contains an {@link UNCOVERED_HEAD_REASON_MARKER} reason classifies
+   * the instance as `awaiting-fresh-review` instead of `rerun-eligible`
+   * (#1775). Tests inject this directly; production
+   * {@link collectFromGitHub} fills it for non-pass terminal instances.
+   */
+  verdictReasons?: string[] | null;
 }
 
 /** {@link RerunPlanRawInstance} plus the assigned classification and a
@@ -259,6 +289,10 @@ export interface RerunAdvisoryConvergencePlan {
     pending: number;
     botGatedSkip: number;
     unresolved: number;
+    /** Instances whose own advisory-convergence verdict reported that
+     * the latest Copilot review does not cover the current HEAD -- not
+     * rerun-eligible; wait for a fresh review (#1775). */
+    awaitingFreshReview: number;
     rerunEligible: number;
     /** How many instances (across `rerun-eligible` classifications and
      * recovery-refresh candidates alike) were excluded from their
@@ -544,6 +578,7 @@ export function computeRerunPlan(
     pending: 0,
     botGatedSkip: 0,
     unresolved: 0,
+    awaitingFreshReview: 0,
     rerunEligible: 0,
     rerunBudgetHeld: budgetHeldCheckRunIds.size,
     total: instances.length,
@@ -554,6 +589,8 @@ export function computeRerunPlan(
     else if (instance.classification === 'bot-gated-skip')
       counts.botGatedSkip += 1;
     else if (instance.classification === 'unresolved') counts.unresolved += 1;
+    else if (instance.classification === 'awaiting-fresh-review')
+      counts.awaitingFreshReview += 1;
     else counts.rerunEligible += 1;
   }
 
@@ -796,7 +833,25 @@ function classifyInstance(
     };
   }
 
-  // 7. Non-pass, terminal, resolved, pull_request-family -- safe to rerun.
+  // 7. Uncovered-HEAD hold (#1775): the instance's own
+  // advisory-convergence JSON verdict (from the workflow job log) says
+  // the latest Copilot review does not cover the current HEAD. Rerunning
+  // cannot change that -- only a fresh review can -- so never place this
+  // in the plan and never spend the rerun-once budget on it. Only fires
+  // when `verdictReasons` was actually consulted and matched; a missing
+  // / unparsed log leaves classification unchanged (no invented hold).
+  if (hasUncoveredHeadVerdictReason(instance.verdictReasons)) {
+    const matched =
+      instance.verdictReasons?.find(isUncoveredHeadVerdictReason) ??
+      UNCOVERED_HEAD_REASON_MARKER;
+    return {
+      ...instance,
+      classification: 'awaiting-fresh-review',
+      reason: `advisory-convergence verdict reports "${matched}"; rerunning cannot clear this -- wait for a fresh review covering the current HEAD rather than spending the rerun-once budget (#1775)`,
+    };
+  }
+
+  // 8. Non-pass, terminal, resolved, pull_request-family -- safe to rerun.
   // A bot-triggered actor does not withhold this instance by itself
   // (#1745) -- only a genuinely `action_required` conclusion does, handled
   // in step 3 above -- so the reason notes bot-triggering when present
@@ -809,6 +864,113 @@ function classifyInstance(
     classification: 'rerun-eligible',
     reason: `conclusion "${conclusion}" is non-passing and resolved (event "${runEvent}")${botNote}; safe to rerun`,
   };
+}
+
+/**
+ * `true` when `reason` is an advisory-convergence Clause 1
+ * uncovered-HEAD reason (see {@link UNCOVERED_HEAD_REASON_MARKER}).
+ */
+export function isUncoveredHeadVerdictReason(reason: string): boolean {
+  return String(reason ?? '')
+    .toLowerCase()
+    .includes(UNCOVERED_HEAD_REASON_MARKER.toLowerCase());
+}
+
+/**
+ * `true` when a consulted `reasons` list contains an uncovered-HEAD
+ * reason. A `null` / `undefined` list means "not consulted" and never
+ * matches -- so a missing log cannot invent an `awaiting-fresh-review`
+ * hold (#1775).
+ */
+export function hasUncoveredHeadVerdictReason(
+  reasons: readonly string[] | null | undefined,
+): boolean {
+  if (!reasons) return false;
+  return reasons.some((reason) => isUncoveredHeadVerdictReason(reason));
+}
+
+/**
+ * Extract the advisory-convergence JSON verdict's `reasons` array from a
+ * workflow job log (`gh run view --log` / Actions job-logs API output).
+ * Returns `null` when no well-formed verdict JSON is found, so callers
+ * can leave `verdictReasons` unset rather than inventing an empty list
+ * that would look like "fetched, no reasons". Pure and unit-testable;
+ * production collection feeds it the log text for each non-pass run.
+ *
+ * The log lines are typically prefixed with a job/step/timestamp column
+ * (and may carry ANSI color codes); both are stripped before brace-
+ * matching so the same parser works on raw job logs and on
+ * `gh run view --log` output.
+ */
+export function extractAdvisoryVerdictReasonsFromLog(
+  logText: string,
+): string[] | null {
+  // Strip ANSI CSI color sequences without a control-character regex
+  // (Biome disallows `\u001b` in regex literals). ESC is code 27.
+  const esc = String.fromCharCode(27);
+  const text = String(logText ?? '')
+    .split(esc)
+    .map((chunk, index) =>
+      index === 0 ? chunk : chunk.replace(/^\[[0-9;]*m/, ''),
+    )
+    .join('');
+  if (!text) return null;
+
+  // Rebuild candidate JSON payloads by walking braces across lines after
+  // stripping the `gh run view --log` prefix (everything through the
+  // first `Z ` timestamp marker on each line, when present). Prefer the
+  // LAST well-formed advisory-convergence verdict in the log -- a single
+  // job can echo intermediate output, and the final `--assert` document
+  // is what actually determined the check-run conclusion.
+  const payloadChunks: string[] = [];
+  let depth = 0;
+  let buf: string[] = [];
+  for (const rawLine of text.split(/\r?\n/)) {
+    const timestampMatch = rawLine.match(/Z (.*)$/);
+    const line =
+      timestampMatch && timestampMatch[1] !== undefined
+        ? timestampMatch[1]
+        : rawLine;
+    for (const ch of line) {
+      if (ch === '{') {
+        if (depth === 0) buf = ['{'];
+        else buf.push(ch);
+        depth += 1;
+      } else if (ch === '}') {
+        if (depth === 0) continue;
+        buf.push(ch);
+        depth -= 1;
+        if (depth === 0) {
+          payloadChunks.push(buf.join(''));
+          buf = [];
+        }
+      } else if (depth > 0) {
+        buf.push(ch);
+      }
+    }
+  }
+
+  let lastReasons: string[] | null = null;
+  for (const chunk of payloadChunks) {
+    if (!chunk.includes('"reasons"') || !chunk.includes('"ready"')) continue;
+    try {
+      const parsed = JSON.parse(chunk) as {
+        reasons?: unknown;
+        ready?: unknown;
+      };
+      if (!Array.isArray(parsed.reasons) || typeof parsed.ready !== 'boolean') {
+        continue;
+      }
+      const reasons = parsed.reasons
+        .filter((entry): entry is string => typeof entry === 'string')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0);
+      lastReasons = reasons;
+    } catch {
+      // not valid JSON -- skip
+    }
+  }
+  return lastReasons;
 }
 
 /**
@@ -1131,12 +1293,12 @@ export function parseArgs(argv: string[]): RerunPlanArgs {
 }
 
 /**
- * Describe outstanding `pending` / `bot-gated-skip` / `unresolved`
- * instance counts, or `''` when none exist. Extracted from
- * {@link describeNoActionState} so the CLI can surface these states
- * independently of whether a rerun plan, recovery-refresh plan, or hold
- * notice ALSO exists for a different instance in the same run --
- * previously these were only ever shown when NONE of those three
+ * Describe outstanding `pending` / `bot-gated-skip` / `unresolved` /
+ * `awaiting-fresh-review` instance counts, or `''` when none exist.
+ * Extracted from {@link describeNoActionState} so the CLI can surface
+ * these states independently of whether a rerun plan, recovery-refresh
+ * plan, or hold notice ALSO exists for a different instance in the same
+ * run -- previously these were only ever shown when NONE of those three
  * existed, silently hiding e.g. 2 still-pending instances whenever the
  * output happened to also have a rerun plan for a different instance
  * (CodeRabbit review, #1434).
@@ -1160,21 +1322,27 @@ export function describeOutstandingStates(
       `${plan.counts.unresolved} instance(s) could not be resolved -- inspect each instance's "reason" above manually`,
     );
   }
+  if (plan.counts.awaitingFreshReview > 0) {
+    notes.push(
+      `${plan.counts.awaitingFreshReview} instance(s) are awaiting a fresh review covering the current HEAD -- wait for Copilot (or the configured primary bot) to re-review rather than rerunning (#1775)`,
+    );
+  }
   return notes.join('; ');
 }
 
 /**
  * Describe the terminal state when there is truly nothing to report:
  * no rerun plan, no recovery-refresh plan, no hold notice, AND no
- * outstanding `pending` / `unresolved` / `bot-gated-skip` instance (see
- * {@link describeOutstandingStates}, which the CLI now also consults
- * independently of this function). "Nothing to do" would be accurate
- * only when every instance is `pass` (or there are no instances at all)
- * -- `pending`, `unresolved`, and `bot-gated-skip` all still require an
- * operator action (waiting, manual inspection, approval, or a non-bot
- * trigger, per each instance's own `reason`), so presenting them as
- * no-action risked leaving a genuinely stuck required check unresolved
- * (#1434 review, Codex P2).
+ * outstanding `pending` / `unresolved` / `bot-gated-skip` /
+ * `awaiting-fresh-review` instance (see {@link describeOutstandingStates},
+ * which the CLI now also consults independently of this function).
+ * "Nothing to do" would be accurate only when every instance is `pass`
+ * (or there are no instances at all) -- `pending`, `unresolved`,
+ * `bot-gated-skip`, and `awaiting-fresh-review` all still require an
+ * operator action (waiting, manual inspection, approval, a non-bot
+ * trigger, or a fresh review, per each instance's own `reason`), so
+ * presenting them as no-action risked leaving a genuinely stuck required
+ * check unresolved (#1434 review, Codex P2; #1775).
  */
 export function describeNoActionState(
   plan: RerunAdvisoryConvergencePlan,
@@ -1274,22 +1442,28 @@ By default (without --apply): read-only. Fetches every
 "${RERUN_PLAN_CHECK_NAME}" check-run instance for the PR's current HEAD SHA
 (commit check-runs API, paged -- not the recent-runs list, which can page
 the target run out of view), classifies each as pass / pending /
-bot-gated-skip / unresolved / rerun-eligible, and prints the ordered
-sequential "gh run rerun <id>" recovery plan for the rerun-eligible
-instances (each command includes "-R <owner>/<repo>" when the repository
-is known, so the plan is safe to run outside this checkout). Never calls
-"gh run rerun" (or any other mutating command) itself.
+bot-gated-skip / unresolved / awaiting-fresh-review / rerun-eligible, and
+prints the ordered sequential "gh run rerun <id>" recovery plan for the
+rerun-eligible instances (each command includes "-R <owner>/<repo>" when
+the repository is known, so the plan is safe to run outside this
+checkout). An instance whose own advisory-convergence verdict reports
+that the latest review does not cover the current HEAD is classified
+awaiting-fresh-review (not rerun-eligible) so the diagnosis tells the
+operator to wait for a fresh review rather than burning the rerun-once
+budget (#1775). Never calls "gh run rerun" (or any other mutating
+command) itself.
 
 With --apply: after printing the same diagnostic plan as above, executes
-it -- "gh run rerun"-ing each rerun-eligible (never bot-gated-skip or
-rerun-budget-held) instance one at a time, waiting for each to reach a
-terminal state before starting the next, exactly as "planCaveat" already
-documents. Prefers the recovery-refresh plan first when one exists,
-matching idd-ci.instructions.md's documented recovery order. After each
-rerun, the plan is recomputed from fresh evidence and the loop stops early
-as soon as it resolves (no rerun-eligible or recovery-refresh instance
-remains) instead of running the rest of the original plan. A final summary
-of what ran and whether the target state resolved is printed to stderr.
+it -- "gh run rerun"-ing each rerun-eligible (never bot-gated-skip,
+awaiting-fresh-review, or rerun-budget-held) instance one at a time,
+waiting for each to reach a terminal state before starting the next,
+exactly as "planCaveat" already documents. Prefers the recovery-refresh
+plan first when one exists, matching idd-ci.instructions.md's documented
+recovery order. After each rerun, the plan is recomputed from fresh
+evidence and the loop stops early as soon as it resolves (no
+rerun-eligible or recovery-refresh instance remains) instead of running
+the rest of the original plan. A final summary of what ran and whether
+the target state resolved is printed to stderr.
 
 --owner and --repo must be given together (to inspect a PR outside the
 current checkout) or omitted together (to auto-detect the current
@@ -1410,10 +1584,11 @@ export interface RerunApplyDeps {
  * are non-empty, matching {@link describeRecoveryRefreshHeader}'s
  * documented recovery order (try the recovery-refresh rerun first; only
  * fall back to the sequential plan if it does not clear the rollup).
- * `bot-gated-skip` and rerun-budget-held instances are never candidates
- * here: neither `plan` nor `recoveryRefreshPlan` ever contains them (see
- * {@link computeRerunPlan}), so this loop cannot reach them regardless of
- * `deps.recomputePlan`'s output.
+ * `bot-gated-skip`, `awaiting-fresh-review`, and rerun-budget-held
+ * instances are never candidates here: neither `plan` nor
+ * `recoveryRefreshPlan` ever contains them (see {@link computeRerunPlan}),
+ * so this loop cannot reach them regardless of `deps.recomputePlan`'s
+ * output (#1775 keeps uncovered-HEAD failures out of both plans).
  */
 export function applyRerunPlan(
   initialPlan: RerunAdvisoryConvergencePlan,
@@ -1529,6 +1704,83 @@ interface RawWorkflowRunPayload {
  * function passes `--jq '.check_runs[]'` directly and reuses the same
  * {@link parsePaginatedGhNdjson} parser `ghApiJson` uses internally.
  */
+/**
+ * Args for listing jobs of one workflow run -- used to locate the
+ * `idd-advisory-convergence` job whose log carries the JSON verdict
+ * {@link extractAdvisoryVerdictReasonsFromLog} parses (#1775).
+ */
+export function buildRunJobsArgs(
+  owner: string,
+  repo: string,
+  runId: string,
+): string[] {
+  return [
+    'api',
+    `repos/${owner}/${repo}/actions/runs/${runId}/jobs`,
+    '--jq',
+    '.jobs[]',
+  ];
+}
+
+/**
+ * Args for downloading one job's logs. `--allow-escape-sequences` is
+ * required: Actions job logs routinely embed ANSI color codes, and `gh
+ * api` refuses to print them to a non-TTY without this flag (confirmed
+ * empirically while implementing #1775).
+ */
+export function buildJobLogsArgs(
+  owner: string,
+  repo: string,
+  jobId: string,
+): string[] {
+  return [
+    'api',
+    `repos/${owner}/${repo}/actions/jobs/${jobId}/logs`,
+    '--allow-escape-sequences',
+  ];
+}
+
+/**
+ * Fetch and parse the advisory-convergence `reasons` array for one
+ * workflow run, or `null` when the log cannot be read / parsed. Looks up
+ * the job whose name matches {@link RERUN_PLAN_CHECK_NAME} (falling back
+ * to the first job when names are unavailable) and feeds its log to
+ * {@link extractAdvisoryVerdictReasonsFromLog}. Failures are swallowed
+ * into `null` so a flaky log API cannot invent an uncovered-HEAD hold
+ * or abort the whole diagnosis (#1775).
+ */
+function fetchAdvisoryVerdictReasonsForRun(
+  owner: string,
+  repo: string,
+  runId: string,
+): string[] | null {
+  try {
+    const jobsRaw = ghText(
+      buildRunJobsArgs(owner, repo, runId),
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+    const jobs = parsePaginatedGhNdjson(jobsRaw) as Array<{
+      id?: number | string | null;
+      name?: string | null;
+    }>;
+    if (jobs.length === 0) return null;
+    const named =
+      jobs.find(
+        (job) =>
+          String(job.name ?? '').trim() === RERUN_PLAN_CHECK_NAME &&
+          job.id != null,
+      ) ?? jobs.find((job) => job.id != null);
+    if (!named || named.id == null) return null;
+    const logText = ghText(
+      buildJobLogsArgs(owner, repo, String(named.id)),
+      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+    );
+    return extractAdvisoryVerdictReasonsFromLog(logText);
+  } catch {
+    return null;
+  }
+}
+
 export function buildCheckRunsForRefArgs(
   owner: string,
   repo: string,
@@ -1860,6 +2112,31 @@ function collectFromGitHub(args: RerunPlanArgs): {
     }
   }
 
+  // Per-run advisory-convergence verdict reasons (#1775). Only non-pass
+  // terminal check-runs need them -- pass / pending never reach the
+  // uncovered-HEAD classifier, so skipping those saves a log download
+  // per green instance. Failures to fetch or parse leave the map entry
+  // absent (`null` on the instance) rather than inventing an empty list,
+  // so a flaky log API cannot invent an awaiting-fresh-review hold.
+  const runIdsNeedingVerdict = new Set(
+    rawCheckRuns
+      .map((run) => {
+        const conclusion = run.conclusion
+          ? String(run.conclusion).trim().toLowerCase()
+          : '';
+        if (!conclusion || PASS_CONCLUSIONS.has(conclusion)) return null;
+        return parseRunIdFromUrl(resolveCheckRunUrl(run));
+      })
+      .filter((id): id is string => id !== null),
+  );
+  const verdictReasonsByRunId = new Map<string, string[] | null>();
+  for (const runId of runIdsNeedingVerdict) {
+    verdictReasonsByRunId.set(
+      runId,
+      fetchAdvisoryVerdictReasonsForRun(owner, repo, runId),
+    );
+  }
+
   const instances: RerunPlanRawInstance[] = rawCheckRuns.map((run) => {
     const url = resolveCheckRunUrl(run);
     const runId = parseRunIdFromUrl(url);
@@ -1879,6 +2156,8 @@ function collectFromGitHub(args: RerunPlanArgs): {
       triggeringActorLogin: meta?.triggeringActorLogin ?? null,
       triggeringActorType: meta?.triggeringActorType ?? null,
       runAttempt: meta?.runAttempt ?? null,
+      verdictReasons:
+        runId !== null ? (verdictReasonsByRunId.get(runId) ?? null) : null,
     };
   });
 

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -1708,6 +1708,11 @@ interface RawWorkflowRunPayload {
  * Args for listing jobs of one workflow run -- used to locate the
  * `idd-advisory-convergence` job whose log carries the JSON verdict
  * {@link extractAdvisoryVerdictReasonsFromLog} parses (#1775).
+ * `--paginate` is required: the Actions "list jobs for a workflow run"
+ * endpoint pages at 30 jobs, and a busy matrixed run can place the
+ * advisory-convergence job beyond the first page -- missing it would
+ * leave `verdictReasons` null and misclassify an uncovered-HEAD failure
+ * as `rerun-eligible` (Copilot review on #1790).
  */
 export function buildRunJobsArgs(
   owner: string,
@@ -1717,6 +1722,7 @@ export function buildRunJobsArgs(
   return [
     'api',
     `repos/${owner}/${repo}/actions/runs/${runId}/jobs`,
+    '--paginate',
     '--jq',
     '.jobs[]',
   ];
@@ -1743,11 +1749,15 @@ export function buildJobLogsArgs(
 /**
  * Fetch and parse the advisory-convergence `reasons` array for one
  * workflow run, or `null` when the log cannot be read / parsed. Looks up
- * the job whose name matches {@link RERUN_PLAN_CHECK_NAME} (falling back
- * to the first job when names are unavailable) and feeds its log to
- * {@link extractAdvisoryVerdictReasonsFromLog}. Failures are swallowed
- * into `null` so a flaky log API cannot invent an uncovered-HEAD hold
- * or abort the whole diagnosis (#1775).
+ * the job whose name matches {@link RERUN_PLAN_CHECK_NAME}. When every
+ * job in the payload is missing a name (or names are blank), falls back
+ * to the first job with an id -- the Actions jobs API normally always
+ * returns `name`, so this fallback is only for a truncated/malformed
+ * payload, never for "name present but did not match" (that would read
+ * an unrelated job's log and could invent an `awaiting-fresh-review`
+ * hold; CodeRabbit review on #1790). Failures are swallowed into `null`
+ * so a flaky log API cannot invent an uncovered-HEAD hold or abort the
+ * whole diagnosis (#1775).
  */
 function fetchAdvisoryVerdictReasonsForRun(
   owner: string,
@@ -1764,15 +1774,19 @@ function fetchAdvisoryVerdictReasonsForRun(
       name?: string | null;
     }>;
     if (jobs.length === 0) return null;
-    const named =
-      jobs.find(
-        (job) =>
-          String(job.name ?? '').trim() === RERUN_PLAN_CHECK_NAME &&
-          job.id != null,
-      ) ?? jobs.find((job) => job.id != null);
-    if (!named || named.id == null) return null;
+    const named = jobs.find(
+      (job) =>
+        String(job.name ?? '').trim() === RERUN_PLAN_CHECK_NAME &&
+        job.id != null,
+    );
+    const namesAllBlank = jobs.every(
+      (job) => String(job.name ?? '').trim() === '',
+    );
+    const selected =
+      named ?? (namesAllBlank ? jobs.find((job) => job.id != null) : undefined);
+    if (!selected || selected.id == null) return null;
     const logText = ghText(
-      buildJobLogsArgs(owner, repo, String(named.id)),
+      buildJobLogsArgs(owner, repo, String(selected.id)),
       GH_TEXT_LOOP_TIMEOUT_OPTIONS,
     );
     return extractAdvisoryVerdictReasonsFromLog(logText);

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -5,9 +5,8 @@ import {
   applyRerunPlan,
   buildCheckRunsForRefArgs,
   buildIddConfigContentsArgs,
-  buildJobLogsArgs,
   buildRerunPlanTextSections,
-  buildRunJobsArgs,
+  buildRunViewLogArgs,
   computeRerunPlan,
   describeNoActionState,
   describeOutstandingStates,
@@ -569,18 +568,14 @@ test('#1775: extractAdvisoryVerdictReasonsFromLog returns null when no verdict J
   );
 });
 
-test('#1775: buildRunJobsArgs / buildJobLogsArgs pin the Actions endpoints', () => {
-  assert.deepEqual(buildRunJobsArgs('o', 'r', '99'), [
-    'api',
-    'repos/o/r/actions/runs/99/jobs',
-    '--paginate',
-    '--jq',
-    '.jobs[]',
-  ]);
-  assert.deepEqual(buildJobLogsArgs('o', 'r', '42'), [
-    'api',
-    'repos/o/r/actions/jobs/42/logs',
-    '--allow-escape-sequences',
+test('#1775: buildRunViewLogArgs pins the plain-text run-log command', () => {
+  assert.deepEqual(buildRunViewLogArgs('o', 'r', '99'), [
+    'run',
+    'view',
+    '99',
+    '-R',
+    'o/r',
+    '--log',
   ]);
 });
 

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -5,12 +5,17 @@ import {
   applyRerunPlan,
   buildCheckRunsForRefArgs,
   buildIddConfigContentsArgs,
+  buildJobLogsArgs,
   buildRerunPlanTextSections,
+  buildRunJobsArgs,
   computeRerunPlan,
   describeNoActionState,
   describeOutstandingStates,
   describeRecoveryRefreshHeader,
+  extractAdvisoryVerdictReasonsFromLog,
   formatApplySummary,
+  hasUncoveredHeadVerdictReason,
+  isUncoveredHeadVerdictReason,
   parseArgs,
   parseRunIdFromUrl,
   RERUN_PLAN_CHECK_NAME,
@@ -20,6 +25,7 @@ import {
   resolveCheckRunUrl,
   runRerunAdvisoryConvergence,
   sanitizeRemoteConfig,
+  UNCOVERED_HEAD_REASON_MARKER,
 } from '../src/scripts/rerun-advisory-convergence.mts';
 
 const HEAD = '1111111111111111111111111111111111111111';
@@ -433,6 +439,150 @@ for (const event of [
   });
 }
 
+// --- Classification: awaiting-fresh-review (#1775) -----------------------
+
+test('#1775: classifies an uncovered-HEAD verdict reason as awaiting-fresh-review, not rerun-eligible', () => {
+  const uncovered =
+    'latest copilot review (commit dd0360511785c070a41da94f51de14aa2f2951f8) does not cover current HEAD a479827a75a92962222ce702a3467d1725135c1e';
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          conclusion: 'failure',
+          verdictReasons: [uncovered],
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.instances[0]?.classification, 'awaiting-fresh-review');
+  assert.equal(plan.counts.awaitingFreshReview, 1);
+  assert.equal(plan.counts.rerunEligible, 0);
+  assert.equal(plan.plan.length, 0);
+  assert.match(plan.instances[0]?.reason ?? '', /wait for a fresh review/);
+  assert.match(
+    describeOutstandingStates(plan),
+    /awaiting a fresh review covering the current HEAD/,
+  );
+});
+
+test('#1775: a missing verdictReasons leaves a terminal failure rerun-eligible (no invented hold)', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          conclusion: 'failure',
+          verdictReasons: null,
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.instances[0]?.classification, 'rerun-eligible');
+  assert.equal(plan.counts.rerunEligible, 1);
+  assert.equal(plan.plan.length, 1);
+});
+
+test('#1775: non-coverage reasons (e.g. unresolved threads) stay rerun-eligible', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          conclusion: 'failure',
+          verdictReasons: [
+            '1 copilot-authored review thread(s) are neither resolved nor validly dispositioned',
+          ],
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.instances[0]?.classification, 'rerun-eligible');
+  assert.equal(plan.plan.length, 1);
+});
+
+test('#1775: applyRerunPlan never spends budget on an awaiting-fresh-review instance', () => {
+  const initialPlan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          conclusion: 'failure',
+          verdictReasons: [
+            `latest copilot review (commit ${HEAD}) does not cover current HEAD ${HEAD}`,
+          ],
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(initialPlan.plan.length, 0);
+
+  let rerunCalled = false;
+  const result = applyRerunPlan(initialPlan, {
+    rerunAndWait: () => {
+      rerunCalled = true;
+    },
+    recomputePlan: () => {
+      throw new Error('recomputePlan should not be called');
+    },
+  });
+
+  assert.equal(rerunCalled, false);
+  assert.equal(result.executed.length, 0);
+  assert.equal(result.resolved, true);
+});
+
+// --- extractAdvisoryVerdictReasonsFromLog / uncovered-HEAD helpers ------
+
+test('#1775: extractAdvisoryVerdictReasonsFromLog parses gh-run-view-shaped logs', () => {
+  const log = [
+    'idd-advisory-convergence\tRun advisory-convergence verdict (--assert)\t2026-08-01T11:13:10.0000000Z {',
+    'idd-advisory-convergence\tRun advisory-convergence verdict (--assert)\t2026-08-01T11:13:10.0000001Z   "protocolVersion": "1",',
+    'idd-advisory-convergence\tRun advisory-convergence verdict (--assert)\t2026-08-01T11:13:10.0000002Z   "ready": false,',
+    'idd-advisory-convergence\tRun advisory-convergence verdict (--assert)\t2026-08-01T11:13:10.0000003Z   "reasons": [',
+    'idd-advisory-convergence\tRun advisory-convergence verdict (--assert)\t2026-08-01T11:13:10.0000004Z     "latest copilot review (commit abc) does not cover current HEAD def"',
+    'idd-advisory-convergence\tRun advisory-convergence verdict (--assert)\t2026-08-01T11:13:10.0000005Z   ]',
+    'idd-advisory-convergence\tRun advisory-convergence verdict (--assert)\t2026-08-01T11:13:10.0000006Z }',
+  ].join('\n');
+  const reasons = extractAdvisoryVerdictReasonsFromLog(log);
+  assert.deepEqual(reasons, [
+    'latest copilot review (commit abc) does not cover current HEAD def',
+  ]);
+  assert.equal(hasUncoveredHeadVerdictReason(reasons), true);
+  const firstReason = reasons?.[0] ?? '';
+  assert.equal(isUncoveredHeadVerdictReason(firstReason), true);
+  assert.equal(
+    isUncoveredHeadVerdictReason(
+      'copilot has not reviewed this pull request yet',
+    ),
+    false,
+  );
+  assert.equal(hasUncoveredHeadVerdictReason(null), false);
+  assert.match(UNCOVERED_HEAD_REASON_MARKER, /does not cover current HEAD/);
+});
+
+test('#1775: extractAdvisoryVerdictReasonsFromLog returns null when no verdict JSON is present', () => {
+  assert.equal(extractAdvisoryVerdictReasonsFromLog(''), null);
+  assert.equal(
+    extractAdvisoryVerdictReasonsFromLog('Process completed with exit code 1.'),
+    null,
+  );
+});
+
+test('#1775: buildRunJobsArgs / buildJobLogsArgs pin the Actions endpoints', () => {
+  assert.deepEqual(buildRunJobsArgs('o', 'r', '99'), [
+    'api',
+    'repos/o/r/actions/runs/99/jobs',
+    '--jq',
+    '.jobs[]',
+  ]);
+  assert.deepEqual(buildJobLogsArgs('o', 'r', '42'), [
+    'api',
+    'repos/o/r/actions/jobs/42/logs',
+    '--allow-escape-sequences',
+  ]);
+});
+
 // --- Classification: rerun-eligible + ordered plan -----------------------
 
 test('classifies a resolved, non-bot, terminal failure as rerun-eligible and includes it in the plan', () => {
@@ -454,16 +604,17 @@ test('classifies a resolved, non-bot, terminal failure as rerun-eligible and inc
   ]);
 });
 
-// #1570: this helper classifies purely on check-run/run-instance shape
-// (conclusion, actor, event, run_attempt) -- it never inspects WHY the
-// underlying `idd-advisory-convergence` verdict was non-passing. A stale
-// instance whose non-passing conclusion traces to a terminal
-// `COPILOT_UNAVAILABLE`-without-waiver hold (advisory-convergence.mts) is
-// therefore classified and planned identically to any other non-bot,
-// terminal, resolved failure: once a maintainer posts a valid terminal
-// waiver, rerunning THIS SAME existing PR-associated run (`gh run rerun`,
-// never `workflow_dispatch`) re-evaluates the verdict fresh and observes
-// the now-`ready: true` result -- no separate rerun code path is needed.
+// #1570: absent an explicit uncovered-HEAD verdict reason (#1775), this
+// helper classifies on check-run/run-instance shape (conclusion, actor,
+// event, run_attempt) and does not re-derive the underlying
+// `idd-advisory-convergence` verdict. A stale instance whose non-passing
+// conclusion traces to a terminal `COPILOT_UNAVAILABLE`-without-waiver
+// hold (advisory-convergence.mts) is therefore classified and planned
+// identically to any other non-bot, terminal, resolved failure: once a
+// maintainer posts a valid terminal waiver, rerunning THIS SAME existing
+// PR-associated run (`gh run rerun`, never `workflow_dispatch`)
+// re-evaluates the verdict fresh and observes the now-`ready: true`
+// result -- no separate rerun code path is needed.
 test('#1570: a terminal-unavailable-without-waiver failure is classified rerun-eligible the same as any other resolved non-bot failure', () => {
   const plan = computeRerunPlan(
     baseInput({

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -573,6 +573,7 @@ test('#1775: buildRunJobsArgs / buildJobLogsArgs pin the Actions endpoints', () 
   assert.deepEqual(buildRunJobsArgs('o', 'r', '99'), [
     'api',
     'repos/o/r/actions/runs/99/jobs',
+    '--paginate',
     '--jq',
     '.jobs[]',
   ]);


### PR DESCRIPTION
## Summary

- Add an `awaiting-fresh-review` classification for `idd-advisory-convergence` check-run instances whose own workflow job-log verdict reports that the latest Copilot review does not cover the current HEAD.
- Keep those instances out of the sequential rerun plan and recovery-refresh path so `--apply` never burns the rerun-once budget on a failure only a fresh review can clear (#1775 / observed on PR #1772).
- Surface the state in the human-readable diagnosis and document it in the helper scripts reference (template + synced mirror).

## Test plan

- [x] `npx tsx --test tests/rerun-advisory-convergence.test.mts` (127 pass)
- [x] `pnpm run build` regenerates `scripts/rerun-advisory-convergence.mjs`
- [x] biome / dprint / markdownlint / cspell / audit-docs / audit-code-span-wrap on touched paths
- [ ] CI green on this PR
- [ ] Manual smoke (optional): on a PR stuck with an uncovered-HEAD failure, diagnosis reports `awaiting-fresh-review` and `--apply` executes 0 reruns for that instance

Closes #1775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `awaiting-fresh-review` status for reviews that do not cover the latest changes.
  - These cases are shown separately in plans and command-line output.

- **Bug Fixes**
  - Prevented outdated reviews from being rerun or incorrectly marked as resolved.
  - Preserved rerun capacity for cases that can be recovered.

- **Documentation**
  - Updated rerun-plan guidance and CLI help to explain the new status and behavior.

- **Tests**
  - Added coverage for classification, log parsing, safeguards, and rerun-plan handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->