### PR TITLE
docs(spec-audit): add a restatement-discipline audit dimension

### DIFF
--- a/.claude/skills/idd-spec-audit/SKILL.md
+++ b/.claude/skills/idd-spec-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: idd-spec-audit
-description: Repo-local, dogfood-only semantic audit of the IDD instruction corpus for leaked session context, cross-file contradictions, fresh-memory completability gaps, and automation blockers. Use only in the kurone-kito/idd-skill source repository, on request, to audit .github/instructions, skills/issue-authoring, CLAUDE.md, or .github/copilot-instructions.md. Read-only — never edits files or mutates issues.
+description: Repo-local, dogfood-only semantic audit of the IDD instruction corpus for leaked session context, cross-file contradictions, fresh-memory completability gaps, automation blockers, and restatement-discipline drift. Use only in the kurone-kito/idd-skill source repository, on request, to audit .github/instructions, skills/issue-authoring, CLAUDE.md, or .github/copilot-instructions.md. Read-only — never edits files or mutates issues.
 ---
 
 # IDD Spec Audit
@@ -51,7 +51,7 @@ model.
 
 ## Rule sets
 
-Run all four rule sets on every pass; do not skip one to save time. A
+Run all five rule sets on every pass; do not skip one to save time. A
 finding names the rule set, the file, the line or section, and a short
 quote of the offending text.
 
@@ -110,6 +110,34 @@ A mutation with no row in the contract falls back to the contract's own
 default (irreversible); that default governs the contract itself; do
 not extend R4 to independently police no-row mutations beyond the two
 cases above.
+
+### R5 — restatement discipline (closed v1 concept index)
+
+Flag a passage that restates a rule defined canonically elsewhere in
+the corpus when the restatement's scope does not match the canonical
+rule's scope: broader than the canonical rule, narrower than it, or
+phrased as unconditional where the canonical rule is conditional (has
+stated exceptions, applies only under a named runtime profile, or only
+within a bounded phase range).
+
+**Scope is the same closed v1 concept index R2 uses** — reuse the
+exact list in [R2](#r2--cross-file-contradictions-closed-v1-concept-index)
+above rather than introduce a second, open-ended index. A restatement
+of a concept outside that index is out of R5's scope; do not flag it,
+no matter how sloppily it is worded. This keeps R5 from treating every
+emphatic sentence in the corpus as a finding — the rule exists to
+catch a scope drift on the seven concepts already load-bearing enough
+to have a closed index, not to police prose style generally.
+
+**Preferred remedy**: cite the canonical section instead of restating
+it inline. Prefer `See [<section>](<path>#<anchor>)` (or an equivalent
+plain-text pointer to the file/section) over reproducing a
+multi-clause rule's conditions in a second location — inline
+restatement of a multi-clause rule is the exact failure mode this rule
+set exists to catch, and the instruction bundles are already close to
+their byte budgets, so citing is also the cheaper fix. Note the
+preferred remedy in the finding so the reader does not have to
+re-derive it.
 
 ## Execution model
 

--- a/.claude/skills/idd-spec-audit/references/report-template.md
+++ b/.claude/skills/idd-spec-audit/references/report-template.md
@@ -58,9 +58,25 @@ was skipped.
   to an unneeded confirmation gate qualify]`
 - **Appeared in**: `[K]/[N]`
 
+## R5 — Restatement discipline (closed v1 concept index)
+
+`[repeat per finding; write "No findings." if empty]`
+
+- **File**: `[path]`
+- **Location**: `[line number or section heading of the restatement]`
+- **Restatement quote**: `[short quote of the restating text]`
+- **Canonical rule**: `[path#section or line the restatement diverges
+  from]`
+- **Canonical quote**: `[short quote of the canonical rule]`
+- **Scope divergence**: `[broader / narrower / unconditional-vs-conditional
+  — one line]`
+- **Recommended remedy**: `[cite the canonical section instead of
+  restating it inline]`
+- **Appeared in**: `[K]/[N]`
+
 ## Summary
 
-- **Total findings**: `[count across all four rule sets]`
+- **Total findings**: `[count across all five rule sets]`
 - **Files touched by at least one finding**: `[count]`
 - **Notable patterns across passes**: `[one or two lines, or "None."]`
 


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Add R5, a fifth rule set, to the repo-local `idd-spec-audit` skill
(`.claude/skills/idd-spec-audit/SKILL.md`): restatement discipline.
R5 flags a passage that restates a rule defined canonically elsewhere
in the corpus when the restatement's scope no longer matches the
canonical rule's scope — broader, narrower, or phrased as unconditional
where the canonical rule is conditional.

- R5 is explicitly bound to the **same closed v1 concept index R2
  already uses** (the seven concepts listed under R2) rather than a
  new, open-ended index; a restatement of a concept outside that index
  is out of R5's scope.
- R5 states its preferred remedy in the rule text: cite the canonical
  section instead of restating it inline.
- `references/report-template.md` gets a matching `R5` section with
  the same shape as the existing R1-R4 sections (restatement quote,
  canonical rule/quote it diverges from, scope-divergence
  description, recommended remedy).
- "Run all four rule sets" is now "Run all five rule sets", and the
  skill's frontmatter `description` now names restatement-discipline
  drift as a fifth audited dimension.

Nothing under `idd-template/` was touched, and no canonical
`skills/idd-spec-audit/` copy was created — this skill has no sync-pair
entry in `audit/sync-manifest.json` and stays repo-local per its
existing "Dogfood-only" status.

## Linked issue

Closes #1678

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

An audit of accepted review findings across merged PRs at PR >= 1200
counted 52 findings in 26 PRs restating an existing rule more strongly
or more broadly than the canonical rule — the single largest pattern
in that window. It is not mechanically detectable by keyword: the
corpus uses absolute quantifiers 447 times across 29
`.github/instructions/` files, and nearly all of those uses are
correct, so a grep-based lint would be almost entirely false positives.
R5 makes this a semantic-audit dimension instead.

### Trial run against the live corpus (acceptance criterion)

A manual R5 trial pass read the full text of all 29
`.github/instructions/*.instructions.md` files (18 standard + 11
`lite/`, ~8,450 lines), scoped strictly to R2's closed 7-concept index,
and produced **2 candidate findings** — not "none found":

1. **Stale-by-the-time-of-verification** — an early trial pass (run
   against this branch's pre-rebase tree) flagged
   `idd-claim-lite.instructions.md`'s forced-handoff author-match check
   as an unqualified restatement of `idd-claim.instructions.md`'s
   opt-in `requireAuthorMatchesForcedBy` rule. Re-checked against the
   current file (after this branch rebased onto `main`, which by then
   included #1701/PR #1781): the paragraph now explicitly says
   "unconditionally, a deliberately stricter bind than the full spec's
   opt-in (`requireAuthorMatchesForcedBy`)" and explains why (blocks a
   same-identity self-signed hijack) — R5's own preferred-remedy
   framing satisfied by that same PR. **No live finding here**: this
   confirms R5 is checking a real, previously-flagged pattern, and that
   the pattern's later fix is legible to the rule.
2. **Live finding, confirmed against current `main`**: five
   `lite/*.instructions.md` files (`idd-pr-submit-lite`,
   `idd-review-snapshot-lite`, `idd-merge-handoff-lite`,
   `idd-work-lite`, `idd-review-fix-lite`) each restate
   `idd-overview-core.instructions.md`'s "Claim revalidation gate"
   activation-nonce recheck as one numbered step in an exhaustive
   "Pre-mutation guard" checklist ("confirm **all** of the following …
   If any check fails, stop"). Three of the five include the nonce
   step; `idd-work-lite.instructions.md` and
   `idd-review-fix-lite.instructions.md` silently omit it, narrower
   than the canonical gate with no documented lite-profile carve-out.
   Traced to a partial fix (`3fbb512b`) that only patched
   `idd-pr-submit-lite.instructions.md`. Filed as
   kurone-kito/idd-skill#1794 rather than fixed in this PR (different
   files, separate concern from R5 itself).

This demonstrates R5 as specified: applicable to the live corpus,
correctly scoped to the closed concept index (both findings map to
"claim-marker and activation-nonce semantics"), and correctly silent
once a flagged pattern is actually fixed.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (ran the constituent `pre-push-validate` commands:
      `biome check`, `dprint check "**/*.md"`,
      `markdownlint-cli2 "**/*.md"`, `cspell lint "**"`)
- [ ] `pnpm test` (docs-only change; no test suite exercises this
      skill bundle)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (this skill bundle is intentionally
      outside `audit/sync-manifest.json`; nothing to sync)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — docs-only skill-bundle change)
- [x] Context budget impact reviewed (this skill bundle carries no
      `audit/sync-manifest.json` byte budget; `audit-docs.mjs --check`
      passes with only pre-existing, unrelated notices)

