### PR TITLE
fix(lite): restore activation-nonce recheck in work/review-fix lite

### DIFF
--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -74,16 +74,19 @@ Before any commit, push, merge, reply, resolve, reviewer request, or
 other GitHub side effect, confirm all of the following:
 
 1. The active claim still uses this session's claim id.
-2. The current directory is the sibling worktree for the claimed branch.
-3. `git branch --show-current` equals the claimed branch.
-4. Acquire the worktree-local claim lock with the profile-selected
+2. If this session posted an activation nonce for the current claim,
+   confirm it still wins (no later trusted marker for this claim id
+   won the tie-break instead).
+3. The current directory is the sibling worktree for the claimed branch.
+4. `git branch --show-current` equals the claimed branch.
+5. Acquire the worktree-local claim lock with the profile-selected
    `claim-lock` helper (`node scripts/claim-lock.mjs --acquire
    --worktree <this-worktree-path> --agent-id <id> --claim-id <id>`, or
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed.
-5. If any check fails, stop.
+6. If any check fails, stop.
 
 ## E9 — Fix accepted issues
 

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -37,10 +37,19 @@ Before any commit, push, rebase, claim heartbeat, reply, resolve, reviewer
 request, or other GitHub side effect, confirm all of the following:
 
 1. The active claim still uses this session's claim id.
-2. The current directory is the sibling worktree for the claimed branch.
-3. `git branch --show-current` equals the claimed branch.
-4. The worktree-local claim lock is held.
-5. If any check fails, stop.
+2. If this session posted an activation nonce for the current claim,
+   confirm it still wins (no later trusted marker for this claim id
+   won the tie-break instead).
+3. The current directory is the sibling worktree for the claimed branch.
+4. `git branch --show-current` equals the claimed branch.
+5. Acquire the worktree-local claim lock with the profile-selected
+   `claim-lock` helper (`node scripts/claim-lock.mjs --acquire
+   --worktree <this-worktree-path> --agent-id <id> --claim-id <id>`, or
+   the package-manager-profile `idd:claim-lock` command with the same
+   arguments — resolve the exact command from
+   `docs/idd-helper-scripts.md` if unsure). A `collision` result is
+   fail-closed: stop rather than proceed.
+6. If any check fails, stop.
 
 ## B1 — Create worktree
 

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -69,16 +69,19 @@ Before any commit, push, merge, reply, resolve, reviewer request, or
 other GitHub side effect, confirm all of the following:
 
 1. The active claim still uses this session's claim id.
-2. The current directory is the sibling worktree for the claimed branch.
-3. `git branch --show-current` equals the claimed branch.
-4. Acquire the worktree-local claim lock with the profile-selected
+2. If this session posted an activation nonce for the current claim,
+   confirm it still wins (no later trusted marker for this claim id
+   won the tie-break instead).
+3. The current directory is the sibling worktree for the claimed branch.
+4. `git branch --show-current` equals the claimed branch.
+5. Acquire the worktree-local claim lock with the profile-selected
    `claim-lock` helper (`node scripts/claim-lock.mjs --acquire
    --worktree <this-worktree-path> --agent-id <id> --claim-id <id>`, or
    the package-manager-profile `idd:claim-lock` command with the same
    arguments — resolve the exact command from
    `docs/idd-helper-scripts.md` if unsure). A `collision` result is
    fail-closed: stop rather than proceed.
-5. If any check fails, stop.
+6. If any check fails, stop.
 
 ## E9 — Fix accepted issues
 

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -32,10 +32,19 @@ Before any commit, push, rebase, claim heartbeat, reply, resolve, reviewer
 request, or other GitHub side effect, confirm all of the following:
 
 1. The active claim still uses this session's claim id.
-2. The current directory is the sibling worktree for the claimed branch.
-3. `git branch --show-current` equals the claimed branch.
-4. The worktree-local claim lock is held.
-5. If any check fails, stop.
+2. If this session posted an activation nonce for the current claim,
+   confirm it still wins (no later trusted marker for this claim id
+   won the tie-break instead).
+3. The current directory is the sibling worktree for the claimed branch.
+4. `git branch --show-current` equals the claimed branch.
+5. Acquire the worktree-local claim lock with the profile-selected
+   `claim-lock` helper (`node scripts/claim-lock.mjs --acquire
+   --worktree <this-worktree-path> --agent-id <id> --claim-id <id>`, or
+   the package-manager-profile `idd:claim-lock` command with the same
+   arguments — resolve the exact command from
+   `docs/idd-helper-scripts.md` if unsure). A `collision` result is
+   fail-closed: stop rather than proceed.
+6. If any check fails, stop.
 
 ## B1 — Create worktree
 


### PR DESCRIPTION
# Summary

Two of the five lite-profile "Pre-mutation guard" restatements of the
standard claim revalidation gate
(`idd-overview-core.instructions.md`'s activation-nonce recheck) were
silently missing that step, even though both files present themselves
as an exhaustive numbered checklist and both claim "Same semantics as"
their standard counterpart.

- `idd-work-lite.instructions.md` had only 4 checks (claim id, sibling
  worktree, branch match, lock **held**) — no nonce step, and the lock
  check used the passive "is held" wording instead of active
  acquisition.
- `idd-review-fix-lite.instructions.md` had 5 checks (it already
  carried the correct active lock-acquisition wording) but still no
  nonce step.

This traces to a partial fix: commit `3fbb512b` diagnosed this exact
defect class but only applied it to `idd-pr-submit-lite.instructions.md`.
`idd-review-fix-lite.instructions.md` later picked up the
lock-acquisition half but not the nonce half; `idd-work-lite.instructions.md`
picked up neither half.

## Linked issue

Closes #1794

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Inserted the same nonce-recheck step the three sibling lite files
(`idd-pr-submit-lite`, `idd-review-snapshot-lite`,
`idd-merge-handoff-lite`) already use, immediately after each file's
existing claim-id check and before the worktree/branch checks,
renumbering the remaining steps. Also upgraded
`idd-work-lite.instructions.md`'s lock check to the active-acquisition
wording the other four files already use.

Edited the canonical `idd-template/` sources and regenerated the
`.github/instructions/lite/` mirrors with
`node scripts/sync-docs.mjs --apply` in the same change.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [ ] `pnpm test` (no test suite exercises prose instruction files)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
