### PR TITLE
docs(template): publish the OKF bundle convention to adopters

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -62,6 +62,7 @@
         "idd-template/.githooks/*",
         "idd-template/.github/instructions/idd-*.instructions.md",
         "idd-template/.github/instructions/lite/idd-*.instructions.md",
+        "idd-template/docs/index.md",
         "idd-template/docs/idd-*.md",
         "idd-template/docs/permissions.md",
         "idd-template/docs/getting-started.md",
@@ -106,6 +107,7 @@
         "idd-template/.github/instructions/lite/idd-resume-stall-lite.instructions.md",
         "idd-template/.github/instructions/lite/idd-ci-lite.instructions.md",
         "idd-template/.github/instructions/lite/idd-advisory-wait-lite.instructions.md",
+        "idd-template/docs/index.md",
         "idd-template/docs/idd-workflow.md",
         "idd-template/docs/idd-review-policy-profiles.md",
         "idd-template/docs/idd-helper-scripts.md",
@@ -191,6 +193,29 @@
       ],
       "sourceGlobs": [
         "docs/**/*.md"
+      ]
+    },
+    {
+      "id": "idd-template-docs-index-okf-table",
+      "_comment": "OKF frontmatter index table for idd-template/docs/index.md (#1684). Same generator as docs-index-okf-table (#1683), reused unmodified and scoped to the exported template bundle at idd-template/docs/** so an adopter's agent has an entry point into the imported docs/ bundle.",
+      "file": "idd-template/docs/index.md",
+      "kind": "okf-table",
+      "linkBase": "idd-template/docs",
+      "typeOrder": [
+        "index",
+        "guide",
+        "concept",
+        "reference",
+        "workflow",
+        "design",
+        "investigation",
+        "tutorial"
+      ],
+      "excludePaths": [
+        "idd-template/docs/index.md"
+      ],
+      "sourceGlobs": [
+        "idd-template/docs/**/*.md"
       ]
     }
   ],

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1073,18 +1073,21 @@ when the repository is the source of a reusable IDD distribution.
 
 ## Docs Bundle Frontmatter Convention (OKF)
 
-Every page under this repository's `docs/` bundle (imported from
-`idd-template/docs/**`) carries [OKF](https://okf.md/) (Open Knowledge
-Format v0.1) frontmatter: a small `type`/`title`/`description`/`tags`
-block that a generated index table (`docs/index.md`) turns into a
-drift-guarded topic map, so an agent with no prior familiarity with the
-bundle has an entry point to read instead of listing the directory.
+Every non-reserved page under this repository's `docs/` bundle
+(imported from `idd-template/docs/**`) carries [OKF](https://okf.md/)
+(Open Knowledge Format v0.1) frontmatter — `index.md` and `log.md` are
+the reserved exceptions, see below: a small
+`type`/`title`/`description`/`tags` block that a generated index table
+(`docs/index.md`) turns into a drift-guarded topic map, so an agent
+with no prior familiarity with the bundle has an entry point to read
+instead of listing the directory.
 
 **Field profile** (four fields): `type` (required, one value from the
 closed vocabulary below), `title` (required, matches the page's `# H1`
 heading exactly), `description` (required, one sentence ending in a
-period), and `tags` (optional, a YAML list of lowercase-hyphen
-strings).
+period), and `tags` (optional, a YAML list of non-empty strings;
+lowercase-hyphen is the authoring convention, though only
+non-emptiness is mechanically enforced).
 
 **Closed `type` vocabulary**: `index`, `guide`, `concept`, `reference`,
 `workflow`, `design`, `investigation`, `tutorial`.
@@ -1102,14 +1105,15 @@ frontmatter-bearing page.
 **Deliberately not extended to `.github/instructions/**`**: instruction
 files already carry a different, consumer-specific frontmatter contract
 (`applyTo:`, `excludeAgent:`) that GitHub Copilot's custom instructions
-loader parses, so mixing in OKF keys would collide with it. Instruction
-files are also this repository's tightest byte-budget surface — every
-byte loads verbatim into an agent's context on every session (see
+loader parses, so mixing in OKF keys would collide with it (preventive;
+no observed incident yet). Instruction files are also this repository's
+tightest byte-budget surface — every byte loads verbatim into an
+agent's context on every session (see
 [Policy constants](policy-constants.md)) — so frontmatter metadata with
 no runtime value is not worth spending that budget on. Do not replicate
 this convention under your own `.github/instructions/**`; doing so
 risks breaching your own instruction bundle's byte budget for no
-retrieval benefit.
+retrieval benefit (preventive; no observed incident yet).
 
 ## Canonical Asset Map
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1071,6 +1071,46 @@ changing merge gates, changing discovery scope, or altering validation
 commands. Keep live instruction files and the exported template in sync
 when the repository is the source of a reusable IDD distribution.
 
+## Docs Bundle Frontmatter Convention (OKF)
+
+Every page under this repository's `docs/` bundle (imported from
+`idd-template/docs/**`) carries [OKF](https://okf.md/) (Open Knowledge
+Format v0.1) frontmatter: a small `type`/`title`/`description`/`tags`
+block that a generated index table (`docs/index.md`) turns into a
+drift-guarded topic map, so an agent with no prior familiarity with the
+bundle has an entry point to read instead of listing the directory.
+
+**Field profile** (four fields): `type` (required, one value from the
+closed vocabulary below), `title` (required, matches the page's `# H1`
+heading exactly), `description` (required, one sentence ending in a
+period), and `tags` (optional, a YAML list of lowercase-hyphen
+strings).
+
+**Closed `type` vocabulary**: `index`, `guide`, `concept`, `reference`,
+`workflow`, `design`, `investigation`, `tutorial`.
+
+You may add pages of your own to this `docs/` bundle. Give each new
+page frontmatter conforming to the profile above. Adding a new value to
+the `type` vocabulary is a deliberate local edit to your own checker
+configuration, not something to invent ad hoc for one page.
+
+**Reserved filenames**: `index.md` and `log.md` are reserved —
+`index.md` lists a bundle's contents and `log.md` records a scope's
+change history — and must not be repurposed for a normal
+frontmatter-bearing page.
+
+**Deliberately not extended to `.github/instructions/**`**: instruction
+files already carry a different, consumer-specific frontmatter contract
+(`applyTo:`, `excludeAgent:`) that GitHub Copilot's custom instructions
+loader parses, so mixing in OKF keys would collide with it. Instruction
+files are also this repository's tightest byte-budget surface — every
+byte loads verbatim into an agent's context on every session (see
+[Policy constants](policy-constants.md)) — so frontmatter metadata with
+no runtime value is not worth spending that budget on. Do not replicate
+this convention under your own `.github/instructions/**`; doing so
+risks breaching your own instruction bundle's byte budget for no
+retrieval benefit.
+
 ## Canonical Asset Map
 
 IDD distributes documentation, instruction files, and policy guidance in

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1075,12 +1075,14 @@ when the repository is the source of a reusable IDD distribution.
 
 Every non-reserved page under this repository's `docs/` bundle
 (imported from `idd-template/docs/**`) carries [OKF](https://okf.md/)
-(Open Knowledge Format v0.1) frontmatter — `index.md` and `log.md` are
-the reserved exceptions, see below: a small
+(Open Knowledge Format v0.1) frontmatter: a small
 `type`/`title`/`description`/`tags` block that a generated index table
 (`docs/index.md`) turns into a drift-guarded topic map, so an agent
 with no prior familiarity with the bundle has an entry point to read
-instead of listing the directory.
+instead of listing the directory. `index.md` and `log.md` are exempt
+from this checker's enforcement (see Reserved filenames below) — this
+bundle's own index page carries conforming frontmatter anyway, for
+consistency.
 
 **Field profile** (four fields): `type` (required, one value from the
 closed vocabulary below), `title` (required, matches the page's `# H1`

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1086,10 +1086,11 @@ consistency.
 
 **Field profile** (four fields): `type` (required, one value from the
 closed vocabulary below), `title` (required, matches the page's `# H1`
-heading exactly), `description` (required, one sentence ending in a
-period), and `tags` (optional, a YAML list of non-empty strings;
-lowercase-hyphen is the authoring convention, though only
-non-emptiness is mechanically enforced).
+heading exactly), `description` (required, a non-empty string; one
+sentence ending in a period is the authoring convention, though only
+non-emptiness is mechanically enforced), and `tags` (optional, a YAML
+list of non-empty strings; lowercase-hyphen is the authoring
+convention, though only non-emptiness is mechanically enforced).
 
 **Closed `type` vocabulary**: `index`, `guide`, `concept`, `reference`,
 `workflow`, `design`, `investigation`, `tutorial`.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -39,16 +39,17 @@ or [Core concepts](concepts.md) before using this reference.
 
 ## Policy and Support Pages
 
-| Topic                                  | Read                                                        |
-| -------------------------------------- | ----------------------------------------------------------- |
-| Cross-agent entry path                 | [IDD workflow guide](idd-workflow.md)                       |
-| Review policy choices                  | [IDD review policy profiles](idd-review-policy-profiles.md) |
-| Distributed policy defaults            | [IDD policy constants](policy-constants.md)                 |
-| Credential boundaries and threat model | [Permissions](permissions.md)                               |
-| Safe adopter customization surfaces    | [Customization](customization.md)                           |
-| Live digest and comment cleanup        | [IDD comment minimization](idd-comment-minimization.md)     |
-| Helper-script adoption policy          | [IDD helper script evaluation](idd-helper-scripts.md)       |
-| Reversible vs. gated mutations         | [IDD autonomy contract](idd-autonomy-contract.md)           |
+| Topic                                  | Read                                                                                                                  |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Cross-agent entry path                 | [IDD workflow guide](idd-workflow.md)                                                                                 |
+| Review policy choices                  | [IDD review policy profiles](idd-review-policy-profiles.md)                                                           |
+| Distributed policy defaults            | [IDD policy constants](policy-constants.md)                                                                           |
+| Credential boundaries and threat model | [Permissions](permissions.md)                                                                                         |
+| Safe adopter customization surfaces    | [Customization](customization.md)                                                                                     |
+| Live digest and comment cleanup        | [IDD comment minimization](idd-comment-minimization.md)                                                               |
+| Helper-script adoption policy          | [IDD helper script evaluation](idd-helper-scripts.md)                                                                 |
+| Reversible vs. gated mutations         | [IDD autonomy contract](idd-autonomy-contract.md)                                                                     |
+| Docs bundle frontmatter convention     | [Customizing IDD § Docs Bundle Frontmatter Convention (OKF)](customization.md#docs-bundle-frontmatter-convention-okf) |
 
 ## Maintainer Note
 

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -400,6 +400,11 @@ recording template you will apply in Step 3.
 
 ### File list
 
+This list includes `docs/index.md`, the entry point and topic map for
+the imported `docs/` bundle — see
+[Customizing IDD § Docs Bundle Frontmatter Convention (OKF)](docs/customization.md#docs-bundle-frontmatter-convention-okf)
+for the frontmatter convention its generated table follows.
+
 <!-- audit:generated id=idd-template-core-files -->
 
 ```text
@@ -436,6 +441,7 @@ recording template you will apply in Step 3.
 .github/instructions/lite/idd-resume-stall-lite.instructions.md
 .github/instructions/lite/idd-ci-lite.instructions.md
 .github/instructions/lite/idd-advisory-wait-lite.instructions.md
+docs/index.md
 docs/idd-workflow.md
 docs/idd-review-policy-profiles.md
 docs/idd-helper-scripts.md
@@ -530,6 +536,7 @@ for FILE in \
   ".github/instructions/lite/idd-resume-stall-lite.instructions.md" \
   ".github/instructions/lite/idd-ci-lite.instructions.md" \
   ".github/instructions/lite/idd-advisory-wait-lite.instructions.md" \
+  "docs/index.md" \
   "docs/idd-workflow.md" \
   "docs/idd-review-policy-profiles.md" \
   "docs/idd-helper-scripts.md" \
@@ -632,6 +639,7 @@ for FILE in \
   ".github/instructions/lite/idd-resume-stall-lite.instructions.md" \
   ".github/instructions/lite/idd-ci-lite.instructions.md" \
   ".github/instructions/lite/idd-advisory-wait-lite.instructions.md" \
+  "docs/index.md" \
   "docs/idd-workflow.md" \
   "docs/idd-review-policy-profiles.md" \
   "docs/idd-helper-scripts.md" \

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -150,6 +150,7 @@ docs/idd-helper-scripts.md
 docs/idd-resume-detail.md
 docs/idd-review-policy-profiles.md
 docs/idd-workflow.md
+docs/index.md
 docs/onboarding/agent-entry-and-verification.md
 docs/onboarding/placeholders.md
 docs/onboarding/policy-decisions.md

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1073,18 +1073,21 @@ when the repository is the source of a reusable IDD distribution.
 
 ## Docs Bundle Frontmatter Convention (OKF)
 
-Every page under this repository's `docs/` bundle (imported from
-`idd-template/docs/**`) carries [OKF](https://okf.md/) (Open Knowledge
-Format v0.1) frontmatter: a small `type`/`title`/`description`/`tags`
-block that a generated index table (`docs/index.md`) turns into a
-drift-guarded topic map, so an agent with no prior familiarity with the
-bundle has an entry point to read instead of listing the directory.
+Every non-reserved page under this repository's `docs/` bundle
+(imported from `idd-template/docs/**`) carries [OKF](https://okf.md/)
+(Open Knowledge Format v0.1) frontmatter — `index.md` and `log.md` are
+the reserved exceptions, see below: a small
+`type`/`title`/`description`/`tags` block that a generated index table
+(`docs/index.md`) turns into a drift-guarded topic map, so an agent
+with no prior familiarity with the bundle has an entry point to read
+instead of listing the directory.
 
 **Field profile** (four fields): `type` (required, one value from the
 closed vocabulary below), `title` (required, matches the page's `# H1`
 heading exactly), `description` (required, one sentence ending in a
-period), and `tags` (optional, a YAML list of lowercase-hyphen
-strings).
+period), and `tags` (optional, a YAML list of non-empty strings;
+lowercase-hyphen is the authoring convention, though only
+non-emptiness is mechanically enforced).
 
 **Closed `type` vocabulary**: `index`, `guide`, `concept`, `reference`,
 `workflow`, `design`, `investigation`, `tutorial`.
@@ -1102,14 +1105,15 @@ frontmatter-bearing page.
 **Deliberately not extended to `.github/instructions/**`**: instruction
 files already carry a different, consumer-specific frontmatter contract
 (`applyTo:`, `excludeAgent:`) that GitHub Copilot's custom instructions
-loader parses, so mixing in OKF keys would collide with it. Instruction
-files are also this repository's tightest byte-budget surface — every
-byte loads verbatim into an agent's context on every session (see
+loader parses, so mixing in OKF keys would collide with it (preventive;
+no observed incident yet). Instruction files are also this repository's
+tightest byte-budget surface — every byte loads verbatim into an
+agent's context on every session (see
 [Policy constants](policy-constants.md)) — so frontmatter metadata with
 no runtime value is not worth spending that budget on. Do not replicate
 this convention under your own `.github/instructions/**`; doing so
 risks breaching your own instruction bundle's byte budget for no
-retrieval benefit.
+retrieval benefit (preventive; no observed incident yet).
 
 ## Canonical Asset Map
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1071,6 +1071,46 @@ changing merge gates, changing discovery scope, or altering validation
 commands. Keep live instruction files and the exported template in sync
 when the repository is the source of a reusable IDD distribution.
 
+## Docs Bundle Frontmatter Convention (OKF)
+
+Every page under this repository's `docs/` bundle (imported from
+`idd-template/docs/**`) carries [OKF](https://okf.md/) (Open Knowledge
+Format v0.1) frontmatter: a small `type`/`title`/`description`/`tags`
+block that a generated index table (`docs/index.md`) turns into a
+drift-guarded topic map, so an agent with no prior familiarity with the
+bundle has an entry point to read instead of listing the directory.
+
+**Field profile** (four fields): `type` (required, one value from the
+closed vocabulary below), `title` (required, matches the page's `# H1`
+heading exactly), `description` (required, one sentence ending in a
+period), and `tags` (optional, a YAML list of lowercase-hyphen
+strings).
+
+**Closed `type` vocabulary**: `index`, `guide`, `concept`, `reference`,
+`workflow`, `design`, `investigation`, `tutorial`.
+
+You may add pages of your own to this `docs/` bundle. Give each new
+page frontmatter conforming to the profile above. Adding a new value to
+the `type` vocabulary is a deliberate local edit to your own checker
+configuration, not something to invent ad hoc for one page.
+
+**Reserved filenames**: `index.md` and `log.md` are reserved —
+`index.md` lists a bundle's contents and `log.md` records a scope's
+change history — and must not be repurposed for a normal
+frontmatter-bearing page.
+
+**Deliberately not extended to `.github/instructions/**`**: instruction
+files already carry a different, consumer-specific frontmatter contract
+(`applyTo:`, `excludeAgent:`) that GitHub Copilot's custom instructions
+loader parses, so mixing in OKF keys would collide with it. Instruction
+files are also this repository's tightest byte-budget surface — every
+byte loads verbatim into an agent's context on every session (see
+[Policy constants](policy-constants.md)) — so frontmatter metadata with
+no runtime value is not worth spending that budget on. Do not replicate
+this convention under your own `.github/instructions/**`; doing so
+risks breaching your own instruction bundle's byte budget for no
+retrieval benefit.
+
 ## Canonical Asset Map
 
 IDD distributes documentation, instruction files, and policy guidance in

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1075,12 +1075,14 @@ when the repository is the source of a reusable IDD distribution.
 
 Every non-reserved page under this repository's `docs/` bundle
 (imported from `idd-template/docs/**`) carries [OKF](https://okf.md/)
-(Open Knowledge Format v0.1) frontmatter — `index.md` and `log.md` are
-the reserved exceptions, see below: a small
+(Open Knowledge Format v0.1) frontmatter: a small
 `type`/`title`/`description`/`tags` block that a generated index table
 (`docs/index.md`) turns into a drift-guarded topic map, so an agent
 with no prior familiarity with the bundle has an entry point to read
-instead of listing the directory.
+instead of listing the directory. `index.md` and `log.md` are exempt
+from this checker's enforcement (see Reserved filenames below) — this
+bundle's own index page carries conforming frontmatter anyway, for
+consistency.
 
 **Field profile** (four fields): `type` (required, one value from the
 closed vocabulary below), `title` (required, matches the page's `# H1`

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1086,10 +1086,11 @@ consistency.
 
 **Field profile** (four fields): `type` (required, one value from the
 closed vocabulary below), `title` (required, matches the page's `# H1`
-heading exactly), `description` (required, one sentence ending in a
-period), and `tags` (optional, a YAML list of non-empty strings;
-lowercase-hyphen is the authoring convention, though only
-non-emptiness is mechanically enforced).
+heading exactly), `description` (required, a non-empty string; one
+sentence ending in a period is the authoring convention, though only
+non-emptiness is mechanically enforced), and `tags` (optional, a YAML
+list of non-empty strings; lowercase-hyphen is the authoring
+convention, though only non-emptiness is mechanically enforced).
 
 **Closed `type` vocabulary**: `index`, `guide`, `concept`, `reference`,
 `workflow`, `design`, `investigation`, `tutorial`.

--- a/idd-template/docs/index.md
+++ b/idd-template/docs/index.md
@@ -1,0 +1,48 @@
+---
+type: index
+title: IDD Documentation Index
+description: Is the entry point and topic map for the IDD documentation bundle this repository imports into its own docs/.
+---
+
+# IDD Documentation Index
+
+Use this page as the entry point to this documentation bundle. If you
+are an agent working in this repository for the first time, start with
+[Getting started](getting-started.md) or [Core concepts](concepts.md);
+otherwise use the table below to find a page by topic.
+
+Every page in this bundle follows the OKF (Open Knowledge Format)
+frontmatter convention this table is generated from — see
+[Customizing IDD § Docs Bundle Frontmatter Convention
+(OKF)](customization.md#docs-bundle-frontmatter-convention-okf) before
+adding a page of your own.
+
+## Reference Map
+
+<!-- audit:generated id=idd-template-docs-index-okf-table -->
+
+<!-- dprint-ignore-start -->
+| Type | Page | Description |
+| ---- | ---- | ----------- |
+| guide | [Customizing IDD](customization.md) | Lists which IDD surfaces adopters can safely customize and points to the authoritative file for each policy. |
+| guide | [Getting Started with IDD](getting-started.md) | Walks a new adopter through the shortest safe path from deciding to adopt IDD to running the first Issue-Driven Development loop. |
+| guide | [IDD Review Policy Profiles](idd-review-policy-profiles.md) | Names the supported PR review policy profiles and the instruction files an adopter must edit to select one other than the Copilot-advisory default. |
+| guide | [Permissions and Threat Model](permissions.md) | Defines the credential profiles, merge-policy boundaries, and threat model an operator must choose before granting IDD agents GitHub access. |
+| concept | [Core IDD Concepts](concepts.md) | Introduces the loop-engineering vocabulary and mental model behind the IDD phase instructions before diving into phase-by-phase rules. |
+| reference | [IDD — Advisory-Wait Shell Fallback (AW1 / AW2 / AW3-R / AW3-S / AW3-H detail)](idd-advisory-wait-shell-fallback.md) | Provides the verbatim gh, gh api, jq, and curl commands the advisory-wait shell fallback uses when helper support cannot be trusted. |
+| reference | [IDD Autonomy Contract](idd-autonomy-contract.md) | Classifies every externally visible IDD mutation as reversible or irreversible and names the gate or undo path for each. |
+| reference | [IDD Comment Minimization](idd-comment-minimization.md) | Defines the live status digest contract and the safe procedure for minimizing completed review feedback and stale operational markers after merge. |
+| reference | [IDD — Concept Ownership Matrix](idd-concept-ownership.md) | Answers which actor may touch a given IDD concept at a given phase without re-reading every instruction file. |
+| reference | [IDD Resume — Detail Reference](idd-resume-detail.md) | Provides the full narrative detail behind idd-resume.instructions.md's compact routing tables for branches that need careful judgment. |
+| reference | [Onboarding Reference — Agent Entry and Verification](onboarding/agent-entry-and-verification.md) | Provides the detailed agent-entry examples and verification checklist referenced by ONBOARDING.md steps 5 and 6. |
+| reference | [Onboarding Reference — Placeholder Values](onboarding/placeholders.md) | Provides the full derivation and replacement rules for every template placeholder used during onboarding. |
+| reference | [Onboarding Reference — Policy Decisions](onboarding/policy-decisions.md) | Provides the detailed policy-decision guidance behind ONBOARDING.md's operator-confirmation steps. |
+| reference | [Template Distribution Maintainer Reference](onboarding/template-distribution.md) | Explains how the template's generated file-distribution lists in ONBOARDING.md stay correct as files are added, removed, or moved. |
+| reference | [IDD Policy Constants](policy-constants.md) | Inventories the distributed IDD policy defaults and names which configuration surface owns each one. |
+| reference | [IDD Detailed Reference](reference.md) | Maps each operational question to the authoritative phase file or policy page that answers it. |
+| workflow | [IDD workflow guide](idd-workflow.md) | Routes each agent to its entry file and the phase file matching its current state. |
+| design | [IDD — Design Rationale and Maintainer Notes](idd-design-rationale.md) | Collects maintainer-facing rationale for why IDD phase rules exist as they do, organized by phase file. |
+| design | [IDD Helper Script Evaluation](idd-helper-scripts.md) | Records the current adoption decision and trade-offs for IDD's optional helper scripts so future reviews do not re-evaluate them from scratch. |
+<!-- dprint-ignore-end -->
+
+<!-- /audit:generated -->

--- a/idd-template/docs/reference.md
+++ b/idd-template/docs/reference.md
@@ -39,16 +39,17 @@ or [Core concepts](concepts.md) before using this reference.
 
 ## Policy and Support Pages
 
-| Topic                                  | Read                                                        |
-| -------------------------------------- | ----------------------------------------------------------- |
-| Cross-agent entry path                 | [IDD workflow guide](idd-workflow.md)                       |
-| Review policy choices                  | [IDD review policy profiles](idd-review-policy-profiles.md) |
-| Distributed policy defaults            | [IDD policy constants](policy-constants.md)                 |
-| Credential boundaries and threat model | [Permissions](permissions.md)                               |
-| Safe adopter customization surfaces    | [Customization](customization.md)                           |
-| Live digest and comment cleanup        | [IDD comment minimization](idd-comment-minimization.md)     |
-| Helper-script adoption policy          | [IDD helper script evaluation](idd-helper-scripts.md)       |
-| Reversible vs. gated mutations         | [IDD autonomy contract](idd-autonomy-contract.md)           |
+| Topic                                  | Read                                                                                                                  |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Cross-agent entry path                 | [IDD workflow guide](idd-workflow.md)                                                                                 |
+| Review policy choices                  | [IDD review policy profiles](idd-review-policy-profiles.md)                                                           |
+| Distributed policy defaults            | [IDD policy constants](policy-constants.md)                                                                           |
+| Credential boundaries and threat model | [Permissions](permissions.md)                                                                                         |
+| Safe adopter customization surfaces    | [Customization](customization.md)                                                                                     |
+| Live digest and comment cleanup        | [IDD comment minimization](idd-comment-minimization.md)                                                               |
+| Helper-script adoption policy          | [IDD helper script evaluation](idd-helper-scripts.md)                                                                 |
+| Reversible vs. gated mutations         | [IDD autonomy contract](idd-autonomy-contract.md)                                                                     |
+| Docs bundle frontmatter convention     | [Customizing IDD § Docs Bundle Frontmatter Convention (OKF)](customization.md#docs-bundle-frontmatter-convention-okf) |
 
 ## Maintainer Note
 


### PR DESCRIPTION
## Summary

`idd-template/docs/**` already ships OKF frontmatter and the drift-guarded
index generator (#1683), but the template bundle itself had no `index.md`
and nothing told adopters the convention existed. This track (the last in
roadmap #1685) closes both gaps:

- Adds `idd-template/docs/index.md` — `type: index`, a short orientation
  paragraph, and a generated OKF index table sourced from
  `idd-template/docs/**`, reusing the #1683 generator unmodified via a new
  `idd-template-docs-index-okf-table` entry in `audit/sync-manifest.json`.
- Documents the convention for adopters in a new "Docs Bundle Frontmatter
  Convention (OKF)" section of `idd-template/docs/customization.md`: the
  four-field profile, the closed `type` vocabulary, the reserved
  `index.md`/`log.md` filenames, the adopter's freedom to add conforming
  pages, and the deliberate `.github/instructions/**` exclusion with its
  byte-budget reason.
- Adds a matching one-line pointer in `idd-template/docs/reference.md` and
  a mention of the new `index.md` in `idd-template/ONBOARDING.md`'s file
  list.
- Regenerates every `docs/` counterpart via `node scripts/sync-docs.mjs
  --apply`; `docs/index.md`'s own generated block stays byte-identical
  (verified — zero diff on that file).

No audit rules, closed `type` set, or existing `docs/index.md` rendering
changed — this track is documentation and the template index only.

Closes #1684

## Verification

- `node scripts/audit-docs.mjs --check` fails when the new generated block
  is made stale and passes again after `--apply` (verified manually).
- `pnpm run lint`, `pnpm run typecheck`, `pnpm run test` (3028 tests),
  `pnpm run build:check`, and `node scripts/audit-docs.mjs --check` all
  pass.
- `git diff` confirms `docs/index.md` has zero changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a documentation index with categorized links to guides, concepts, references, workflows, and design documents.
  * Added a standardized frontmatter convention for documentation pages, including required metadata and supported page types.
  * Added documentation references to the new frontmatter convention.

* **Documentation**
  * Updated template onboarding and file inventories to include the documentation index.
  * Added automated auditing for documentation frontmatter and index entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->