### PR TITLE
docs(idd-design-rationale): clarify instructions-citation scope

### DIFF
--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -609,6 +609,19 @@ reads as a deliberate statement rather than an omission.
 The convention applies **forward**, to new or edited passages only.
 Retrofitting an existing passage with a citation is in scope on
 budget-exempt `docs/` surfaces, but out of scope for
-`.github/instructions/` files — do not edit an instruction file
-solely to add a citation; those bundle budgets already sit near their
-ceiling (see the headroom review in #1525).
+`.github/instructions/` files: do not edit an instruction file solely
+to add a citation. That exemption is not retrofit-only — a brand-new
+`.github/instructions/` passage that names an anti-pattern or failure
+mode is exempt from the citation requirement too, for the same
+reason: those bundle budgets already sit near their ceiling (see the
+headroom review in #1525; scope clarified by #1647 after CodeRabbit
+read the original wording as covering only retrofits).
+
+When an instruction passage's motivating incident is worth recording
+in full, put the date-plus-reference in a paired
+`docs/idd-design-rationale.md` entry and link to it by section anchor,
+as most cited passages already do. A bare issue-number aside directly
+in the instruction text remains acceptable in place of that link when
+no paired entry exists — both forms fit inside the tight
+instruction-bundle budget that motivates the exemption; neither is
+required.

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -591,6 +591,20 @@ reads as a deliberate statement rather than an omission.
 The convention applies **forward**, to new or edited passages only.
 Retrofitting an existing passage with a citation is in scope on
 budget-exempt `docs/` surfaces, but out of scope for
-`.github/instructions/` files — do not edit an instruction file
-solely to add a citation; those bundle budgets already sit near their
-ceiling (see the headroom review in kurone-kito/idd-skill#1525).
+`.github/instructions/` files: do not edit an instruction file solely
+to add a citation. That exemption is not retrofit-only — a brand-new
+`.github/instructions/` passage that names an anti-pattern or failure
+mode is exempt from the citation requirement too, for the same
+reason: those bundle budgets already sit near their ceiling (see the
+headroom review in kurone-kito/idd-skill#1525; scope clarified by
+kurone-kito/idd-skill#1647 after CodeRabbit read the original wording
+as covering only retrofits).
+
+When an instruction passage's motivating incident is worth recording
+in full, put the date-plus-reference in a paired
+`docs/idd-design-rationale.md` entry and link to it by section anchor,
+as most cited passages already do. A bare issue-number aside directly
+in the instruction text remains acceptable in place of that link when
+no paired entry exists — both forms fit inside the tight
+instruction-bundle budget that motivates the exemption; neither is
+required.


### PR DESCRIPTION
# Summary

Clarifies `docs/idd-design-rationale.md`'s "Cite the observed incident"
section: a **new** (non-retrofit) `.github/instructions/` passage that
names an anti-pattern or failure mode is exempt from the citation
requirement, the same as a retrofit — not just retrofits, as the prior
wording could be read (PR #1646 / #1570 surfaced the ambiguity).

## Linked issue

Closes #1647

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Two readings were textually defensible before this change: CodeRabbit
read the forward-only scope (sentence 1) as already covering brand-new
passages everywhere, with the `.github/instructions/` carve-out
(sentence 2) narrowly about retrofitting pre-existing passages only —
so a newly authored passage naming a failure mode inside
`.github/instructions/` would still need a citation under that reading.
The issue author's original reading treated the carve-out as covering
the whole file class regardless of new-vs-retrofit, given the explicit
budget-headroom rationale (#1525).

Before picking a resolution, I grepped `.github/instructions/*.instructions.md`
for existing citation forms. The dominant pattern (20 occurrences across
8 files) is a `docs/idd-design-rationale.md` rationale-entry
cross-reference; a smaller set of bare `(#NNNN)` asides also exists,
some of which are provenance tags (which issue introduced a mechanism)
rather than incident citations. At least one anti-pattern passage
(`idd-pr-submit.instructions.md`'s closing-keyword detection) carries no
citation at all — but it documents GitHub product behavior rather than
an incident-motivated prohibition, so it's outside the convention's own
scope, not a counter-example.

This grounds the resolution in both the dominant existing pattern and
the issue author's own stated intent: `.github/instructions/` is
exempt from the citation requirement for both new and retrofitted
passages. The new text also documents (as optional, not required) the
two citation forms the corpus already uses, so authors who want to cite
anyway have guidance without a new obligation.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [ ] `pnpm test` (no code change; docs-only)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
