### PR TITLE
fix(lite): route lite E1 return-paths to review-snapshot-lite

### DIFF
--- a/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -380,7 +380,8 @@ than the run it supersedes. Once both have completed, the later
    finished — and resume polling. If it is `hold`, or the timeout
    recurs after a rerun, stop per the condition above and post a hold
    note.
-7. **`success`**: proceed to `idd-review-snapshot.instructions.md` (E1).
+7. **`success`**: proceed to `idd-review-snapshot-lite.instructions.md`
+   (E1).
 8. **Exception**: if `idd-advisory-convergence` is the only
    non-passing required check, and that check's own run-log JSON verdict
    reports `pending: false` with outstanding review reasons (thread

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -292,7 +292,7 @@ other GitHub side effect, confirm all of the following:
    exists, stop polling and return to E1 to create one.
 8. Poll on the interval from the helper's `pollIntervalMinutes`. Each
    cycle: re-fetch the current head; if it differs from `PR_HEAD_SHA`,
-   stop polling and return to `idd-review-snapshot.instructions.md`
+   stop polling and return to `idd-review-snapshot-lite.instructions.md`
    (E1). Otherwise re-read threads, review bodies, and regular comments
    (excluding trusted operational markers); if anything has `updatedAt`
    newer than the polling watermark, stop polling and return to E1.
@@ -341,8 +341,8 @@ other GitHub side effect, confirm all of the following:
    routing for this phase.
 3. If new review threads or comments arrive during the wait, note them
    but keep waiting for CI.
-4. On success: return to `idd-review-snapshot.instructions.md` (E1) —
-   do not skip triage.
+4. On success: return to `idd-review-snapshot-lite.instructions.md`
+   (E1) — do not skip triage.
 5. On failure that is code-caused: fix it, run `fix-validate`, commit
    atomically, then return to E11.
 6. On failure that is infra-flaky or pre-existing (also failing on

--- a/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -375,7 +375,8 @@ than the run it supersedes. Once both have completed, the later
    finished — and resume polling. If it is `hold`, or the timeout
    recurs after a rerun, stop per the condition above and post a hold
    note.
-7. **`success`**: proceed to `idd-review-snapshot.instructions.md` (E1).
+7. **`success`**: proceed to `idd-review-snapshot-lite.instructions.md`
+   (E1).
 8. **Exception**: if `idd-advisory-convergence` is the only
    non-passing required check, and that check's own run-log JSON verdict
    reports `pending: false` with outstanding review reasons (thread

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -287,7 +287,7 @@ other GitHub side effect, confirm all of the following:
    exists, stop polling and return to E1 to create one.
 8. Poll on the interval from the helper's `pollIntervalMinutes`. Each
    cycle: re-fetch the current head; if it differs from `PR_HEAD_SHA`,
-   stop polling and return to `idd-review-snapshot.instructions.md`
+   stop polling and return to `idd-review-snapshot-lite.instructions.md`
    (E1). Otherwise re-read threads, review bodies, and regular comments
    (excluding trusted operational markers); if anything has `updatedAt`
    newer than the polling watermark, stop polling and return to E1.
@@ -336,8 +336,8 @@ other GitHub side effect, confirm all of the following:
    routing for this phase.
 3. If new review threads or comments arrive during the wait, note them
    but keep waiting for CI.
-4. On success: return to `idd-review-snapshot.instructions.md` (E1) —
-   do not skip triage.
+4. On success: return to `idd-review-snapshot-lite.instructions.md`
+   (E1) — do not skip triage.
 5. On failure that is code-caused: fix it, run `fix-validate`, commit
    atomically, then return to E11.
 6. On failure that is infra-flaky or pre-existing (also failing on


### PR DESCRIPTION
# Summary

Three lite-profile E1 return-path call sites pointed back into the
full-size `idd-review-snapshot.instructions.md` instead of its lite
sibling `idd-review-snapshot-lite.instructions.md`, defeating the lite
profile's design goal of never requiring a lite session to leave the
lite instruction bundle:

- `idd-review-fix-lite.instructions.md` step 8 (polling-loop return)
- `idd-review-fix-lite.instructions.md` E15 step 4 (on-success return)
- `idd-pr-submit-lite.instructions.md` step 7 (success routing)

This edits the two `idd-template/` canonical sources and regenerates
their exact-mode `.github/instructions/lite/` mirrors via
`sync-docs.mjs`. Bare `E1` phase-anchor mentions in the same files, and
`docs/` references describing the standard profile's own E1-E3 phase,
are left untouched, as scoped by the issue.

## Linked issue

Closes #1805

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Filed as a follow-up from a completion audit of roadmap #1713 (which
closed the #1695-#1703 batch fixing instruction-corpus drift found by
a 2026-07-28 fresh-model audit). That audit deliberately left this
narrower defect out of scope for filing separately: unlike #1701
(which redirected a lite E3-empty branch away from an *excluded* file),
this is a session landing on the correct phase but the wrong-size
sibling of it — the full-size `idd-review-snapshot.instructions.md` is
written in the standard style and may itself cross-reference other
full-size files, silently reintroducing the citation-chain-depth
problem the lite profile exists to avoid.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (includes the full `node --test tests/*.test.mts` suite: 3043/3043 pass)
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated lite workflow guidance to consistently link to the lite review snapshot instructions.
  * Clarified routing for successful submissions, polling completion, and CI-success flows.
  * Applied the same documentation updates across the main and template instruction sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->