### PR TITLE
test(review-triage,idd-doctor): backfill regression tests for two gate-integrity-hardening fixes

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1661,7 +1661,7 @@ export function formatCleanupBacklogRemediation(profile, packageSpec = '') {
  * `github-actions[bot]` alone (config unreadable/malformed never widens
  * trust).
  */
-function readCleanupEvidenceTrustedLogins(root) {
+export function readCleanupEvidenceTrustedLogins(root) {
   let trustedMarkerActors;
   try {
     const config = JSON.parse(

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1957,7 +1957,7 @@ export function formatCleanupBacklogRemediation(
  * `github-actions[bot]` alone (config unreadable/malformed never widens
  * trust).
  */
-function readCleanupEvidenceTrustedLogins(root: string): Set<string> {
+export function readCleanupEvidenceTrustedLogins(root: string): Set<string> {
   let trustedMarkerActors: unknown;
   try {
     const config = JSON.parse(

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -1246,12 +1246,14 @@ test('review-triage PATH A verify-before-accept and actor-permission-cap guidanc
   );
 
   for (const text of [reviewTriage, templateReviewTriage]) {
-    assert.match(text, /Verify before accept/);
-    assert.match(text, /actor-permission cap/i);
+    // \s+ between words tolerates a Markdown reflow (dprint) that moves a
+    // wrap point mid-phrase without changing the semantic content.
+    assert.match(text, /Verify\s+before\s+accept/);
+    assert.match(text, /actor-permission\s+cap/i);
     // Guards against reverting the PR#1796 hardening: an unprivileged
     // commenter's assertion alone must never force an Accept.
     assert.match(text, /collaborators\/\{username\}\/permission/);
-    assert.match(text, /assertion alone never reaches Accept forced/);
+    assert.match(text, /assertion\s+alone\s+never\s+reaches\s+Accept\s+forced/);
   }
 });
 
@@ -1272,11 +1274,13 @@ test('merge Duplicate-success-record skip rule still requires a trusted marker a
   );
 
   for (const text of [merge, templateMerge]) {
-    assert.match(text, /Duplicate-success-record skip rule/);
-    assert.match(text, /whose author is a trusted marker actor/);
+    // \s+ between words tolerates a Markdown reflow (dprint) that moves a
+    // wrap point mid-phrase without changing the semantic content.
+    assert.match(text, /Duplicate-success-record\s+skip\s+rule/);
+    assert.match(text, /whose\s+author\s+is\s+a\s+trusted\s+marker\s+actor/);
     assert.match(
       text,
-      /An untrusted commenter's\s+marker-prefixed comment never counts as evidence/,
+      /An\s+untrusted\s+commenter's\s+marker-prefixed\s+comment\s+never\s+counts\s+as\s+evidence/,
     );
   }
 });

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -1229,6 +1229,58 @@ test('discover A2 roadmap node classification guidance is present in instruction
   assert.match(templateWorkflow, /classify roadmap/i);
 });
 
+test('review-triage PATH A verify-before-accept and actor-permission-cap guidance is present in instruction and template surfaces (idd-skill#1690, PR#1796)', () => {
+  const reviewTriage = readFileSync(
+    new URL(
+      '../.github/instructions/idd-review-triage.instructions.md',
+      import.meta.url,
+    ),
+    'utf8',
+  );
+  const templateReviewTriage = readFileSync(
+    new URL(
+      '../idd-template/.github/instructions/idd-review-triage.instructions.md',
+      import.meta.url,
+    ),
+    'utf8',
+  );
+
+  for (const text of [reviewTriage, templateReviewTriage]) {
+    assert.match(text, /Verify before accept/);
+    assert.match(text, /actor-permission cap/i);
+    // Guards against reverting the PR#1796 hardening: an unprivileged
+    // commenter's assertion alone must never force an Accept.
+    assert.match(text, /collaborators\/\{username\}\/permission/);
+    assert.match(text, /assertion alone never reaches Accept forced/);
+  }
+});
+
+test('merge Duplicate-success-record skip rule still requires a trusted marker actor is present in instruction and template surfaces (idd-skill#1691, PR#1759)', () => {
+  const merge = readFileSync(
+    new URL(
+      '../.github/instructions/idd-merge.instructions.md',
+      import.meta.url,
+    ),
+    'utf8',
+  );
+  const templateMerge = readFileSync(
+    new URL(
+      '../idd-template/.github/instructions/idd-merge.instructions.md',
+      import.meta.url,
+    ),
+    'utf8',
+  );
+
+  for (const text of [merge, templateMerge]) {
+    assert.match(text, /Duplicate-success-record skip rule/);
+    assert.match(text, /whose author is a trusted marker actor/);
+    assert.match(
+      text,
+      /An untrusted commenter's\s+marker-prefixed comment never counts as evidence/,
+    );
+  }
+});
+
 test('recursive roadmap audit guidance stays aligned across instruction and docs surfaces', () => {
   const audit = readFileSync(ROADMAP_AUDIT_PATH, 'utf8');
   const workflow = readFileSync(WORKFLOW_PATH, 'utf8');

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -1235,12 +1235,11 @@ test('readCleanupEvidenceTrustedLogins includes configured trustedMarkerActors p
       JSON.stringify({ trustedMarkerActors: ['kurone-kito'] }),
     );
     const logins = readCleanupEvidenceTrustedLogins(dir);
-    assert.ok(logins.has('kurone-kito'));
-    assert.ok(logins.has('github-actions[bot]'));
-    assert.ok(
-      !logins.has('some-untrusted-commenter'),
-      'an untrusted login must not be present in the trusted set',
-    );
+    // Exact-set assertion (not just membership): a regression that
+    // accidentally widens the trusted set with an extra login must fail
+    // this test even though it would still contain 'kurone-kito' and
+    // 'github-actions[bot]' (Copilot review, PR#1809).
+    assert.deepEqual(logins, new Set(['kurone-kito', 'github-actions[bot]']));
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -1257,11 +1256,22 @@ test('readCleanupEvidenceTrustedLogins fails closed to github-actions[bot] alone
       new Set(['github-actions[bot]']),
     );
 
-    // Present but empty trustedMarkerActors array -- a distinct code
-    // branch (Array.isArray true, then empty) from the try/catch
-    // failure cases below, even though the observable result is the
-    // same fail-closed set.
+    // Config present, valid JSON, but the trustedMarkerActors key is
+    // entirely absent -- a distinct code path (config?.trustedMarkerActors
+    // resolves via optional chaining to undefined, no throw at all) from
+    // both the missing-file case above and the malformed-JSON case below
+    // (Copilot review, PR#1809).
     mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(join(dir, '.github/idd/config.json'), JSON.stringify({}));
+    assert.deepEqual(
+      readCleanupEvidenceTrustedLogins(dir),
+      new Set(['github-actions[bot]']),
+    );
+
+    // Present but empty trustedMarkerActors array -- a further distinct
+    // code branch (Array.isArray true, then empty) from the case above
+    // (Array.isArray false on undefined), even though the observable
+    // result is the same fail-closed set.
     writeFileSync(
       join(dir, '.github/idd/config.json'),
       JSON.stringify({ trustedMarkerActors: [] }),

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -40,6 +40,7 @@ import {
   parsePrimaryWorktreePath,
   parseProjectCommandRows,
   parseThresholdsProseHours,
+  readCleanupEvidenceTrustedLogins,
   readWorktreeGuardBranchPatterns,
   readWorktreeGuardEnabled,
   resolveConfiguredHelperRuntimePackageSpec,
@@ -1223,6 +1224,62 @@ test('formatCleanupBacklogRemediation uses a configured packageSpec under epheme
     /pinned-idd-skill\.tgz/,
     'no configured pin should fall back to the default archive URL',
   );
+});
+
+test('readCleanupEvidenceTrustedLogins includes configured trustedMarkerActors plus github-actions[bot], excludes untrusted logins (idd-skill#1691, PR#1759)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-doctor-cleanup-evidence-trust-'));
+  try {
+    mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(
+      join(dir, '.github/idd/config.json'),
+      JSON.stringify({ trustedMarkerActors: ['kurone-kito'] }),
+    );
+    const logins = readCleanupEvidenceTrustedLogins(dir);
+    assert.ok(logins.has('kurone-kito'));
+    assert.ok(logins.has('github-actions[bot]'));
+    assert.ok(
+      !logins.has('some-untrusted-commenter'),
+      'an untrusted login must not be present in the trusted set',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readCleanupEvidenceTrustedLogins fails closed to github-actions[bot] alone when config is missing, empty, or malformed (idd-skill#1691, PR#1759)', () => {
+  const dir = mkdtempSync(
+    join(tmpdir(), 'idd-doctor-cleanup-evidence-trust-fail-closed-'),
+  );
+  try {
+    // No config file at all.
+    assert.deepEqual(
+      readCleanupEvidenceTrustedLogins(dir),
+      new Set(['github-actions[bot]']),
+    );
+
+    // Present but empty trustedMarkerActors array -- a distinct code
+    // branch (Array.isArray true, then empty) from the try/catch
+    // failure cases below, even though the observable result is the
+    // same fail-closed set.
+    mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(
+      join(dir, '.github/idd/config.json'),
+      JSON.stringify({ trustedMarkerActors: [] }),
+    );
+    assert.deepEqual(
+      readCleanupEvidenceTrustedLogins(dir),
+      new Set(['github-actions[bot]']),
+    );
+
+    // Malformed JSON must never widen trust beyond the safe default.
+    writeFileSync(join(dir, '.github/idd/config.json'), '{ not json');
+    assert.deepEqual(
+      readCleanupEvidenceTrustedLogins(dir),
+      new Set(['github-actions[bot]']),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('computeWindowStartIso returns null for windows that overflow Date range', () => {


### PR DESCRIPTION
# Summary

Test-only backfill for two already-shipped fixes that the 2026-08-01
completion audit of roadmap #1712 found had zero regression coverage
(the fixes themselves already merged; only the regression test was
missing):

- **`readCleanupEvidenceTrustedLogins`** (`src/scripts/idd-doctor.mts`,
  PR#1759 item 4): direct unit tests for the trust-scoped set
  (configured `trustedMarkerActors` + `github-actions[bot]`), the
  untrusted-login exclusion, and the fail-closed default when
  `.github/idd/config.json` is missing, present-but-empty, or
  malformed. The function is now `export`ed (visibility-only; matches
  the existing `classify*`/`format*`/`parse*` exported-helper
  convention already used by `tests/idd-doctor.test.mts`) so it is
  directly testable.
- **PATH A verify-before-accept + actor-permission-cap prose**
  (`.github/instructions/idd-review-triage.instructions.md`, PR#1796):
  a phrase-assertion test against both the live instructions file and
  its `idd-template/` mirror, reusing the existing
  "guidance is present in instruction and docs surfaces" pattern.
- **Duplicate-success-record skip rule trusted-author scoping**
  (`.github/instructions/idd-merge.instructions.md`): a matching
  phrase-assertion test against both surfaces.

I manually confirmed each new test fails red against the pre-fix
behavior it backfills (simulated the pre-PR#1759 unscoped trust set,
and separately stripped each guarded phrase from the instruction
files) and restored cleanly afterward — not included in the diff,
verification only.

A follow-up C1 self-review pass hardened the two new phrase-assertion
tests to use `\s+` between words instead of literal spaces, so a
future `dprint` Markdown reflow that moves a wrap point mid-phrase
cannot silently defeat the regression guard.

**Scope note**: per the issue's explicit scope, this covers direct
unit coverage of `readCleanupEvidenceTrustedLogins` itself. The
function's consumer (`checkPostMergeCleanupBacklog`'s
`hasTrustedEvidence` block, which parses `gh` output and calls this
helper) is not separately covered here — that remains a candidate for
a future follow-up if deeper end-to-end coverage of the consumer's
GitHub-output parsing is wanted.

## Linked issue

Closes #1804

## Follow-up issues (if any)

- [x] none opened; see the scope note above for a possible future
      follow-up (not filed)

## Background / rationale (if material)

Refs #1712, #1690, #1690's fix in PR#1796, #1691, #1691's fix in
PR#1759.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (3047 tests, 0 failures)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
