### PR TITLE
fix(idd-pre-merge): broaden F2's own-agent-comment carve-out

### DIFF
--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -162,8 +162,9 @@ nonce was recorded for the active claim.
   convergence activity too, though the branch-sync route's own
   refresh does not independently re-cover it. If a return-to-E1 is
   triggered solely by disposition replies, other own-agent
-  procedural comments of that kind, or both, refresh the watermark
-  directly instead; every other F2 trigger and gate is unaffected.
+  procedural or status comments of that kind, or both, refresh the
+  watermark directly instead; every other F2 trigger and gate is
+  unaffected.
 - **Advisory bot wait** (restart-safe enforcement): schedule a wake, or
   background only if the topology-safety condition holds (confirmed to
   route completion back to this turn) — otherwise wait synchronously:

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -155,8 +155,15 @@ nonce was recorded for the active claim.
   A current-claim agent's own post-watermark disposition replies are
   expected convergence activity, not reviewer input, and the watermark
   refresh on the E-phase branch-sync `clean` / `behind-no-conflict`
-  route already re-covers them. If a return-to-E1 is triggered solely by
-  those replies, refresh the watermark instead.
+  route already re-covers them. The same holds for any other
+  own-agent-authored procedural or status comment posted after the
+  watermark (for example, a hold comment explaining a blocker) that
+  introduces no reviewer or bot finding of its own — it is expected
+  convergence activity too, though the branch-sync route's own
+  refresh does not independently re-cover it. If a return-to-E1 is
+  triggered solely by disposition replies, other own-agent
+  procedural comments of that kind, or both, refresh the watermark
+  directly instead; every other F2 trigger and gate is unaffected.
 - **Advisory bot wait** (restart-safe enforcement): schedule a wake, or
   background only if the topology-safety condition holds (confirmed to
   route completion back to this turn) — otherwise wait synchronously:

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -157,8 +157,9 @@ nonce was recorded for the active claim.
   convergence activity too, though the branch-sync route's own
   refresh does not independently re-cover it. If a return-to-E1 is
   triggered solely by disposition replies, other own-agent
-  procedural comments of that kind, or both, refresh the watermark
-  directly instead; every other F2 trigger and gate is unaffected.
+  procedural or status comments of that kind, or both, refresh the
+  watermark directly instead; every other F2 trigger and gate is
+  unaffected.
 - **Advisory bot wait** (restart-safe enforcement): schedule a wake, or
   background only if the topology-safety condition holds (confirmed to
   route completion back to this turn) — otherwise wait synchronously:

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -150,8 +150,15 @@ nonce was recorded for the active claim.
   A current-claim agent's own post-watermark disposition replies are
   expected convergence activity, not reviewer input, and the watermark
   refresh on the E-phase branch-sync `clean` / `behind-no-conflict`
-  route already re-covers them. If a return-to-E1 is triggered solely by
-  those replies, refresh the watermark instead.
+  route already re-covers them. The same holds for any other
+  own-agent-authored procedural or status comment posted after the
+  watermark (for example, a hold comment explaining a blocker) that
+  introduces no reviewer or bot finding of its own — it is expected
+  convergence activity too, though the branch-sync route's own
+  refresh does not independently re-cover it. If a return-to-E1 is
+  triggered solely by disposition replies, other own-agent
+  procedural comments of that kind, or both, refresh the watermark
+  directly instead; every other F2 trigger and gate is unaffected.
 - **Advisory bot wait** (restart-safe enforcement): schedule a wake, or
   background only if the topology-safety condition holds (confirmed to
   route completion back to this turn) — otherwise wait synchronously:

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -1285,6 +1285,36 @@ test('merge Duplicate-success-record skip rule still requires a trusted marker a
   }
 });
 
+test('pre-merge F2 own-agent-comment carve-out covers procedural/status comments beyond disposition replies (idd-skill#1811)', () => {
+  const preMerge = readFileSync(
+    new URL(
+      '../.github/instructions/idd-pre-merge.instructions.md',
+      import.meta.url,
+    ),
+    'utf8',
+  );
+  const templatePreMerge = readFileSync(
+    new URL(
+      '../idd-template/.github/instructions/idd-pre-merge.instructions.md',
+      import.meta.url,
+    ),
+    'utf8',
+  );
+
+  for (const text of [preMerge, templatePreMerge]) {
+    // \s+ between words tolerates a Markdown reflow (dprint) that moves a
+    // wrap point mid-phrase without changing the semantic content.
+    assert.match(
+      text,
+      /own-agent-authored\s+procedural\s+or\s+status\s+comment/,
+    );
+    assert.match(text, /hold\s+comment\s+explaining\s+a\s+blocker/);
+    // Guards against silently swallowing a mixed-cause trigger: the
+    // refresh-instead sentence must still be gated on "solely".
+    assert.match(text, /triggered\s+solely\s+by\s+disposition\s+replies/);
+  }
+});
+
 test('recursive roadmap audit guidance stays aligned across instruction and docs surfaces', () => {
   const audit = readFileSync(ROADMAP_AUDIT_PATH, 'utf8');
   const workflow = readFileSync(WORKFLOW_PATH, 'utf8');

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -1309,6 +1309,12 @@ test('pre-merge F2 own-agent-comment carve-out covers procedural/status comments
       /own-agent-authored\s+procedural\s+or\s+status\s+comment/,
     );
     assert.match(text, /hold\s+comment\s+explaining\s+a\s+blocker/);
+    // Guards the carve-out's no-finding condition: it only covers a
+    // comment that introduces no reviewer or bot finding of its own.
+    assert.match(
+      text,
+      /introduces\s+no\s+reviewer\s+or\s+bot\s+finding\s+of\s+its\s+own/,
+    );
     // Guards against silently swallowing a mixed-cause trigger: the
     // refresh-instead sentence must still be gated on "solely".
     assert.match(text, /triggered\s+solely\s+by\s+disposition\s+replies/);


### PR DESCRIPTION
# Summary

Broadens the F2 review-currency own-agent-comment carve-out in
`idd-pre-merge.instructions.md` beyond disposition replies. The
carve-out previously only named a current-claim agent's own
post-watermark **disposition replies** as expected convergence
activity that need not send the workflow back to a full E1
round-trip. During PR #1808's F2/F3 merge resume (which had already
closed out issue #1805 by that point), a worker hit a return-to-E1
trigger caused by its own **hold comment**
— a procedural status comment, not a disposition reply — and had to
extend the carve-out by analogy to avoid an unnecessary E1 loop. This
PR closes that textual gap so a future session doesn't have to make
the same analogical leap (or a wrong one).

The paragraph now explicitly covers any other own-agent-authored
procedural or status comment (a hold comment is the named example)
that introduces no reviewer or bot finding of its own, while
preserving the "solely" qualifier so a mixed-cause trigger (the
agent's own comment plus a genuine reviewer/bot comment) still
returns to E1 normally. The CI-`completedAt` trigger and
`idd-review-triage.instructions.md` are deliberately left unchanged
— see "Explicitly out of scope" in the issue.

Changes:

- `idd-template/.github/instructions/idd-pre-merge.instructions.md`
  (source of truth) — replaced the carve-out paragraph.
- `.github/instructions/idd-pre-merge.instructions.md` — regenerated
  mirror via `node scripts/sync-docs.mjs --apply` (byte-identical
  diff to the source, `mode: exact` per `audit/sync-manifest.json`).
- `tests/consistency.test.mts` — new regression test asserting the
  broadened wording is present in both surfaces, following the
  existing phrase-assertion pattern (idd-skill#1690/PR#1796,
  idd-skill#1691/PR#1759).

The `idd-template/.github/instructions/lite/idd-pre-merge-lite.instructions.md`
surface does not carry this carve-out paragraph at all (confirmed via
grep), so it is unaffected and intentionally untouched — out of scope
per the issue.

## Linked issue

Closes #1811

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

See Summary above; full rationale is in the issue body (idd-skill#1811),
including the pre-publish duplicate scan confirming this is not a
duplicate of #1005, #1038, or #1636.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed (file grows ~468 bytes per
      surface; both stay well inside the 33,000-byte
      `phaseLimitBytes` budget in `audit/sync-manifest.json`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pre-merge review guidance to recognize current-agent procedural and status comments as normal review activity when they introduce no new findings.
  * Review status can now be refreshed directly in these cases, while other review triggers and safeguards remain unchanged.
  * Applied the guidance consistently in both repository and template instructions.

* **Tests**
  * Added consistency coverage for procedural comments, blocker explanations, and disposition-only refresh conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->