### PR TITLE
test(idd-doctor,advisory-convergence): cover two gate-integrity call sites

### DIFF
--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -1039,33 +1039,18 @@ function collectFromGitHub(args) {
         ])
       : []),
   ]);
-  const claimEvents = pickResolvingClaimEvents(
-    claimCandidates,
-    trustedMarkerLogins,
-    Boolean(args.claimIssueNumber),
-  );
-  // #1686: ambiguity is a distinct signal from `claimEvents` above --
-  // `pickResolvingClaimEvents` deliberately collapses BOTH "zero candidates
-  // resolve" and "two or more candidates resolve" to `[]` (see its own doc
-  // comment), so this must be computed separately over the same
-  // `claimCandidates`/`trustedMarkerLogins` inputs rather than re-derived
-  // from the already-collapsed `claimEvents`.
-  const claimCandidateAmbiguous = classifyClaimCandidateAmbiguity(
-    claimCandidates,
-    trustedMarkerLogins,
-    Boolean(args.claimIssueNumber),
-  );
-  // #1686: true when ANY candidate claim issue ever carried a trusted,
-  // syntactically valid `claimed-by` marker -- computed over the union of
-  // every candidate's RAW comment stream (`claimCandidates`, not the
-  // resolved-and-possibly-emptied `claimEvents`), so a stale, released, or
-  // otherwise no-longer-active claim still counts as genuine IDD claim
-  // history. See `hasTrustedClaimMarkerHistory`'s doc comment for the full
-  // rationale and the module header's path 4.
-  const claimMarkerHistoryPresent = hasTrustedClaimMarkerHistory(
-    claimCandidates,
-    trustedMarkerLogins,
-  );
+  // #1810: delegates to `resolveClaimEvidence` (below `hasTrustedClaimMarker-
+  // History`'s definition) instead of calling `pickResolvingClaimEvents` /
+  // `classifyClaimCandidateAmbiguity` / `hasTrustedClaimMarkerHistory`
+  // separately here -- see that function's doc comment for why this call
+  // site's own compute-and-forward wiring needed a direct test, not just
+  // the three underlying helpers.
+  const { claimEvents, claimCandidateAmbiguous, claimMarkerHistoryPresent } =
+    resolveClaimEvidence(
+      claimCandidates,
+      trustedMarkerLogins,
+      Boolean(args.claimIssueNumber),
+    );
   const primaryBotLogin = readAdvisoryPrimaryBotLogin();
   const deadlineMinutes = readAdvisoryConvergenceDeadlineMinutes();
   // #1511: bounded same-HEAD reroll cap, plus the existing pendingWindow
@@ -1342,6 +1327,54 @@ export function hasTrustedClaimMarkerHistory(candidates, trustedMarkerLogins) {
       );
     }),
   );
+}
+/**
+ * Resolve all three claim-evidence fields `collectFromGitHub` forwards into
+ * {@link AdvisoryConvergenceInputs} from already-fetched claim candidates and
+ * resolved trust -- pure (no I/O), so it is directly unit-testable, mirroring
+ * {@link filterResolvingClaimCandidates}'s existing shared-helper extraction
+ * pattern. `collectFromGitHub` previously called
+ * {@link pickResolvingClaimEvents}, {@link classifyClaimCandidateAmbiguity},
+ * and {@link hasTrustedClaimMarkerHistory} separately and forwarded their
+ * results inline; that compute-and-forward wiring is itself the #1810 gap --
+ * each of the three helpers has direct unit tests, but nothing proved the
+ * real call site actually threads their outputs into the verdict inputs.
+ * Collapsing all three into one exported step makes the call site a trivial,
+ * visually obvious delegation and gives the wiring itself a direct test.
+ */
+export function resolveClaimEvidence(
+  candidates,
+  trustedMarkerLogins,
+  isExplicit,
+) {
+  const claimEvents = pickResolvingClaimEvents(
+    candidates,
+    trustedMarkerLogins,
+    isExplicit,
+  );
+  // #1686: ambiguity is a distinct signal from `claimEvents` above --
+  // `pickResolvingClaimEvents` deliberately collapses BOTH "zero candidates
+  // resolve" and "two or more candidates resolve" to `[]` (see its own doc
+  // comment), so this must be computed separately over the same
+  // `candidates`/`trustedMarkerLogins` inputs rather than re-derived from the
+  // already-collapsed `claimEvents`.
+  const claimCandidateAmbiguous = classifyClaimCandidateAmbiguity(
+    candidates,
+    trustedMarkerLogins,
+    isExplicit,
+  );
+  // #1686: true when ANY candidate claim issue ever carried a trusted,
+  // syntactically valid `claimed-by` marker -- computed over the union of
+  // every candidate's RAW comment stream (`candidates`, not the
+  // resolved-and-possibly-emptied `claimEvents`), so a stale, released, or
+  // otherwise no-longer-active claim still counts as genuine IDD claim
+  // history. See `hasTrustedClaimMarkerHistory`'s doc comment for the full
+  // rationale and the module header's path 4.
+  const claimMarkerHistoryPresent = hasTrustedClaimMarkerHistory(
+    candidates,
+    trustedMarkerLogins,
+  );
+  return { claimEvents, claimCandidateAmbiguous, claimMarkerHistoryPresent };
 }
 /**
  * Candidate collaborator-marker-trust logins: comment authors whose comment

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -1509,33 +1509,18 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
       : []),
   ]);
 
-  const claimEvents = pickResolvingClaimEvents(
-    claimCandidates,
-    trustedMarkerLogins,
-    Boolean(args.claimIssueNumber),
-  );
-  // #1686: ambiguity is a distinct signal from `claimEvents` above --
-  // `pickResolvingClaimEvents` deliberately collapses BOTH "zero candidates
-  // resolve" and "two or more candidates resolve" to `[]` (see its own doc
-  // comment), so this must be computed separately over the same
-  // `claimCandidates`/`trustedMarkerLogins` inputs rather than re-derived
-  // from the already-collapsed `claimEvents`.
-  const claimCandidateAmbiguous = classifyClaimCandidateAmbiguity(
-    claimCandidates,
-    trustedMarkerLogins,
-    Boolean(args.claimIssueNumber),
-  );
-  // #1686: true when ANY candidate claim issue ever carried a trusted,
-  // syntactically valid `claimed-by` marker -- computed over the union of
-  // every candidate's RAW comment stream (`claimCandidates`, not the
-  // resolved-and-possibly-emptied `claimEvents`), so a stale, released, or
-  // otherwise no-longer-active claim still counts as genuine IDD claim
-  // history. See `hasTrustedClaimMarkerHistory`'s doc comment for the full
-  // rationale and the module header's path 4.
-  const claimMarkerHistoryPresent = hasTrustedClaimMarkerHistory(
-    claimCandidates,
-    trustedMarkerLogins,
-  );
+  // #1810: delegates to `resolveClaimEvidence` (below `hasTrustedClaimMarker-
+  // History`'s definition) instead of calling `pickResolvingClaimEvents` /
+  // `classifyClaimCandidateAmbiguity` / `hasTrustedClaimMarkerHistory`
+  // separately here -- see that function's doc comment for why this call
+  // site's own compute-and-forward wiring needed a direct test, not just
+  // the three underlying helpers.
+  const { claimEvents, claimCandidateAmbiguous, claimMarkerHistoryPresent } =
+    resolveClaimEvidence(
+      claimCandidates,
+      trustedMarkerLogins,
+      Boolean(args.claimIssueNumber),
+    );
 
   const primaryBotLogin = readAdvisoryPrimaryBotLogin();
   const deadlineMinutes = readAdvisoryConvergenceDeadlineMinutes();
@@ -1838,6 +1823,59 @@ export function hasTrustedClaimMarkerHistory(
       );
     }),
   );
+}
+
+/**
+ * Resolve all three claim-evidence fields `collectFromGitHub` forwards into
+ * {@link AdvisoryConvergenceInputs} from already-fetched claim candidates and
+ * resolved trust -- pure (no I/O), so it is directly unit-testable, mirroring
+ * {@link filterResolvingClaimCandidates}'s existing shared-helper extraction
+ * pattern. `collectFromGitHub` previously called
+ * {@link pickResolvingClaimEvents}, {@link classifyClaimCandidateAmbiguity},
+ * and {@link hasTrustedClaimMarkerHistory} separately and forwarded their
+ * results inline; that compute-and-forward wiring is itself the #1810 gap --
+ * each of the three helpers has direct unit tests, but nothing proved the
+ * real call site actually threads their outputs into the verdict inputs.
+ * Collapsing all three into one exported step makes the call site a trivial,
+ * visually obvious delegation and gives the wiring itself a direct test.
+ */
+export function resolveClaimEvidence(
+  candidates: IssueCommentPayload[][],
+  trustedMarkerLogins: string[],
+  isExplicit: boolean,
+): {
+  claimEvents: IssueCommentPayload[];
+  claimCandidateAmbiguous: boolean;
+  claimMarkerHistoryPresent: boolean;
+} {
+  const claimEvents = pickResolvingClaimEvents(
+    candidates,
+    trustedMarkerLogins,
+    isExplicit,
+  );
+  // #1686: ambiguity is a distinct signal from `claimEvents` above --
+  // `pickResolvingClaimEvents` deliberately collapses BOTH "zero candidates
+  // resolve" and "two or more candidates resolve" to `[]` (see its own doc
+  // comment), so this must be computed separately over the same
+  // `candidates`/`trustedMarkerLogins` inputs rather than re-derived from the
+  // already-collapsed `claimEvents`.
+  const claimCandidateAmbiguous = classifyClaimCandidateAmbiguity(
+    candidates,
+    trustedMarkerLogins,
+    isExplicit,
+  );
+  // #1686: true when ANY candidate claim issue ever carried a trusted,
+  // syntactically valid `claimed-by` marker -- computed over the union of
+  // every candidate's RAW comment stream (`candidates`, not the
+  // resolved-and-possibly-emptied `claimEvents`), so a stale, released, or
+  // otherwise no-longer-active claim still counts as genuine IDD claim
+  // history. See `hasTrustedClaimMarkerHistory`'s doc comment for the full
+  // rationale and the module header's path 4.
+  const claimMarkerHistoryPresent = hasTrustedClaimMarkerHistory(
+    candidates,
+    trustedMarkerLogins,
+  );
+  return { claimEvents, claimCandidateAmbiguous, claimMarkerHistoryPresent };
 }
 
 /**

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -12,6 +12,7 @@ import {
   hasTrustedClaimMarkerHistory,
   parseArgs,
   pickResolvingClaimEvents,
+  resolveClaimEvidence,
   runAdvisoryConvergence,
   SAME_HEAD_REROLL_INELIGIBLE_REASON,
   viewerProbeGhOptions,
@@ -2305,6 +2306,166 @@ test('hasTrustedClaimMarkerHistory: true for a STALE trusted claim -- a claimed-
     false,
   );
   assert.equal(hasTrustedClaimMarkerHistory([released], [TRUSTED]), true);
+});
+
+// --- resolveClaimEvidence (idd-skill#1810: collectFromGitHub's call-site
+// wiring, not just the three helpers above in isolation) --------------------
+//
+// #1810's audit found that `pickResolvingClaimEvents`,
+// `classifyClaimCandidateAmbiguity`, and `hasTrustedClaimMarkerHistory` each
+// have direct unit tests (above), and `computeAdvisoryConvergenceVerdict`'s
+// own `indeterminate` handling is directly tested too (the "idd-claimed
+// scope" tests earlier in this file) -- but nothing proved the real
+// `collectFromGitHub` call site actually COMPUTES and FORWARDS the two
+// #1686 fields from raw claim-candidate data, as opposed to those fields
+// silently defaulting to `false` (the exact fail-open #1686 exists to
+// close). `resolveClaimEvidence` is the extracted, directly-testable form of
+// that call site's wiring; the tests below exercise it with the same
+// realistic candidate shapes `classifyClaimCandidateAmbiguity` (path 2) and
+// `hasTrustedClaimMarkerHistory` (path 4) use above, then -- unlike the
+// "idd-claimed scope" tests earlier, which hand-supply
+// `claimCandidateAmbiguous`/`claimMarkerHistoryPresent` as booleans -- feed
+// `resolveClaimEvidence`'s own COMPUTED output straight into
+// `computeAdvisoryConvergenceVerdict`, proving the end-to-end wire.
+
+test('resolveClaimEvidence: happy path -- a lone candidate resolves cleanly, unambiguous', () => {
+  const claimA = [claimComment('claim-a')];
+  // `claimMarkerHistoryPresent` is `true` here too -- a resolving active
+  // claim always carries a trusted `claimed-by` marker, so the two are not
+  // mutually exclusive (see `AdvisoryConvergenceInputs.claimCandidateAmbiguous`'s
+  // doc comment); `claimCandidateAmbiguous: false` is what actually
+  // distinguishes this happy path from #1686 path 2 below.
+  assert.deepEqual(resolveClaimEvidence([claimA], [TRUSTED], false), {
+    claimEvents: claimA,
+    claimCandidateAmbiguous: false,
+    claimMarkerHistoryPresent: true,
+  });
+});
+
+test('resolveClaimEvidence: reproduces #1686 path 2 -- two candidates each independently resolve an active claim', () => {
+  const claimA = [claimComment('claim-a')];
+  const claimB = [claimComment('claim-b')];
+  assert.deepEqual(resolveClaimEvidence([claimA, claimB], [TRUSTED], false), {
+    claimEvents: [],
+    claimCandidateAmbiguous: true,
+    claimMarkerHistoryPresent: true,
+  });
+});
+
+test('resolveClaimEvidence: reproduces #1686 path 4 -- a stale/released trusted claim marker with no currently active claim', () => {
+  // Same fixture shape as the `hasTrustedClaimMarkerHistory` STALE test
+  // above: an old `claimed-by` followed by a trusted `unclaimed-by` release
+  // for the same agent/claim, so `activeClaimPresent` is false but genuine
+  // claim history exists.
+  const claimId = 'stale-claim-resolve-1';
+  const agentId = 'claude-test';
+  const released = [
+    claimComment(claimId),
+    {
+      author: { login: TRUSTED },
+      body: `<!-- unclaimed-by: ${agentId} ${claimId} ${RECENT} -->\n\n_${agentId}: issue claim released — IDD automation marker. Do not edit._`,
+      createdAt: RECENT,
+    },
+  ];
+  assert.deepEqual(resolveClaimEvidence([released], [TRUSTED], false), {
+    claimEvents: [],
+    claimCandidateAmbiguous: false,
+    claimMarkerHistoryPresent: true,
+  });
+});
+
+test('resolveClaimEvidence: an explicit --claim-issue candidate is returned unconditionally, never ambiguous', () => {
+  const untrustedOnlyClaim = [
+    {
+      author: { login: 'nobody-trusted' },
+      body: `<!-- claimed-by: ${AGENT_ID} ${CLAIM_ID} supersedes: none ${OLD} branch: issue/1234-test -->\n\n_${AGENT_ID}: issue claim — IDD automation marker. Do not edit._`,
+      createdAt: OLD,
+    },
+  ];
+  assert.deepEqual(
+    resolveClaimEvidence([untrustedOnlyClaim], [TRUSTED], true),
+    {
+      claimEvents: untrustedOnlyClaim,
+      claimCandidateAmbiguous: false,
+      claimMarkerHistoryPresent: false,
+    },
+  );
+});
+
+test('resolveClaimEvidence end-to-end: its COMPUTED path-2 output (not hand-supplied booleans) drives computeAdvisoryConvergenceVerdict to indeterminate', () => {
+  const claimA = [claimComment('claim-a')];
+  const claimB = [claimComment('claim-b')];
+  const evidence = resolveClaimEvidence([claimA, claimB], [TRUSTED], false);
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview()],
+      claimEvents: evidence.claimEvents,
+      claimCandidateAmbiguous: evidence.claimCandidateAmbiguous,
+      claimMarkerHistoryPresent: evidence.claimMarkerHistoryPresent,
+    }),
+    baseOptions({
+      convergenceScope: 'idd-claimed',
+      prHeadRefName: 'issue/1234-test',
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.deepEqual(verdict.applicability, {
+    scope: 'idd-claimed',
+    status: 'indeterminate',
+    reason: 'idd-claimed-multiple-resolving-claim-candidates',
+  });
+  assert.equal(verdict.ready, false);
+});
+
+test('resolveClaimEvidence end-to-end: its COMPUTED path-4 output (not hand-supplied booleans) drives computeAdvisoryConvergenceVerdict to indeterminate', () => {
+  const claimId = 'stale-claim-e2e-1';
+  const agentId = 'claude-test';
+  const released = [
+    claimComment(claimId),
+    {
+      author: { login: TRUSTED },
+      body: `<!-- unclaimed-by: ${agentId} ${claimId} ${RECENT} -->\n\n_${agentId}: issue claim released — IDD automation marker. Do not edit._`,
+      createdAt: RECENT,
+    },
+  ];
+  const evidence = resolveClaimEvidence([released], [TRUSTED], false);
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview()],
+      claimEvents: evidence.claimEvents,
+      claimCandidateAmbiguous: evidence.claimCandidateAmbiguous,
+      claimMarkerHistoryPresent: evidence.claimMarkerHistoryPresent,
+    }),
+    baseOptions({
+      convergenceScope: 'idd-claimed',
+      prHeadRefName: 'issue/1234-test',
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.deepEqual(verdict.applicability, {
+    scope: 'idd-claimed',
+    status: 'indeterminate',
+    reason: 'idd-claimed-claim-history-without-active-claim',
+  });
+  assert.equal(verdict.ready, false);
+});
+
+test('collectFromGitHub sources claimEvents/claimCandidateAmbiguous/claimMarkerHistoryPresent from resolveClaimEvidence (idd-skill#1810: pins the call-site forwarding shape)', () => {
+  // A lightweight structural pin, in the same spirit as this file's existing
+  // `forbiddenInvocation` source-text check: `resolveClaimEvidence` itself
+  // is proven correct above, so the one remaining risk at the real call
+  // site is someone re-inlining separate calls (or dropping the forward)
+  // instead of destructuring this single delegated call -- a regression
+  // that would otherwise have no test coverage at all, matching #1810's own
+  // "cover the call site, not just the extracted helper" framing.
+  const source = readFileSync(
+    new URL('../src/scripts/advisory-convergence.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /const \{ claimEvents, claimCandidateAmbiguous, claimMarkerHistoryPresent \} =\s*\n?\s*resolveClaimEvidence\(/,
+  );
 });
 
 // --- parseArgs ---------------------------------------------------------------

--- a/tests/idd-doctor-cleanup-backlog-cli-smoke.test.mts
+++ b/tests/idd-doctor-cleanup-backlog-cli-smoke.test.mts
@@ -1,0 +1,223 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import type { DoctorReport } from '../src/scripts/idd-doctor.mts';
+
+const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
+const IDD_DOCTOR_SCRIPT = join(REPO_ROOT, 'scripts/idd-doctor.mjs');
+
+// ---------------------------------------------------------------------------
+// idd-skill#1810: `checkPostMergeCleanupBacklog` (idd-doctor.mts) is the only
+// production caller of `readCleanupEvidenceTrustedLogins`, which itself has
+// had direct unit tests since idd-skill#1804/PR#1809 -- but no test before
+// this file exercised the caller's own `hasTrustedEvidence` trust-check
+// logic (idd-skill#1691, fixed by PR#1759) with realistic
+// `gh api .../comments` TSV-shaped output. Reverting that check back to its
+// pre-#1759 fail-open shape (`return login.length > 0`) left the full suite
+// green before this backfill -- see idd-skill#1810's issue body for the
+// empirical verification this file locks in.
+//
+// `checkPostMergeCleanupBacklog` shells out via the module's private
+// `runCommand`/`execFileSync('gh', ...)`, with no dependency-injection seam,
+// so this reuses the stubbed-`gh`-on-`PATH` CLI-smoke pattern
+// `tests/gh-pagination-parsing-smoke.test.mts` (#1692) established, spawning
+// the real generated `scripts/idd-doctor.mjs`.
+//
+// Unlike that file's exact-argv stub table, this stub matches by CALL SHAPE
+// (subcommand + a targeted regex over the `gh api` resource path) rather
+// than full argv equality: `checkPostMergeCleanupBacklog`'s own merged-PR
+// search embeds `merged:>=<sinceIso>`, computed from `Date.now()` at
+// doctor-run time, so an exact-argv table could never be pinned to a fixed
+// literal.
+//
+// A near-empty `--repo-root` also makes idd-doctor's *other* checks (missing
+// required IDD files, missing Project commands table, etc.) report real
+// errors unrelated to this backfill's target, which makes the CLI process
+// exit non-zero. `runIddDoctorReport` below tolerates that and reads the
+// `--json` report off the caught error's `stdout` (`execFileSync` still
+// captures it); every test here asserts only the specific backlog-related
+// warning strings it cares about, ignoring the rest of the report.
+// ---------------------------------------------------------------------------
+
+function buildCleanupBacklogStubGh(config: {
+  owner: string;
+  repo: string;
+  mergedPrNumbers: number[];
+  evidenceByPr: Map<number, string>;
+  failEvidenceFor?: Set<number>;
+}): string {
+  const owner = JSON.stringify(config.owner);
+  const repo = JSON.stringify(config.repo);
+  const prListJson = JSON.stringify(
+    config.mergedPrNumbers.map((number) => ({ number })),
+  );
+  const evidenceTable = JSON.stringify([...config.evidenceByPr.entries()]);
+  const failingNumbers = JSON.stringify([...(config.failEvidenceFor ?? [])]);
+  return `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === 'repo' && args[1] === 'view') {
+  process.stdout.write(JSON.stringify({ owner: { login: ${owner} }, name: ${repo} }));
+  process.exit(0);
+}
+if (args[0] === 'pr' && args[1] === 'list') {
+  process.stdout.write(${JSON.stringify(prListJson)});
+  process.exit(0);
+}
+if (args[0] === 'api' && args[1] === '--paginate') {
+  const match = /issues\\/(\\d+)\\/comments/.exec(args[2] ?? '');
+  const number = match ? Number(match[1]) : null;
+  const failing = new Set(${failingNumbers});
+  if (number !== null && failing.has(number)) {
+    process.stderr.write('stubbed evidence-fetch failure for PR #' + number + '\\n');
+    process.exit(1);
+  }
+  const table = new Map(${evidenceTable});
+  process.stdout.write(number !== null ? (table.get(number) ?? '') : '');
+  process.exit(0);
+}
+process.stderr.write('unexpected gh invocation: ' + args.join(' ') + '\\n');
+process.exit(1);
+`;
+}
+
+function runIddDoctorReport(cwd: string, stubGhSource: string): DoctorReport {
+  const stubRoot = mkdtempSync(join(tmpdir(), 'idd-doctor-cleanup-gh-'));
+  try {
+    const ghPath = join(stubRoot, 'gh');
+    writeFileSync(ghPath, stubGhSource);
+    chmodSync(ghPath, 0o755);
+    const argv = [
+      IDD_DOCTOR_SCRIPT,
+      '--json',
+      '--repo-root',
+      cwd,
+      '--cleanup-backlog-warn-threshold',
+      '0',
+    ];
+    const options = {
+      encoding: 'utf8' as const,
+      env: { ...process.env, PATH: `${stubRoot}:${process.env.PATH ?? ''}` },
+      timeout: 60_000,
+    };
+    try {
+      return JSON.parse(
+        execFileSync(process.execPath, argv, options),
+      ) as DoctorReport;
+    } catch (error) {
+      // idd-doctor.mjs exits 1 whenever report.errors is non-empty -- a
+      // near-empty --repo-root always trips the unrelated "missing required
+      // IDD files" / "missing Project commands table" checks, so a
+      // non-zero exit here is expected and irrelevant to this file's
+      // target. execFileSync still captures full stdout on the thrown
+      // error.
+      const stdout = (error as { stdout?: string } | null)?.stdout;
+      if (typeof stdout === 'string' && stdout.length > 0) {
+        return JSON.parse(stdout) as DoctorReport;
+      }
+      throw error;
+    }
+  } finally {
+    rmSync(stubRoot, { recursive: true, force: true });
+  }
+}
+
+function withTempCwd(run: (cwd: string) => void): void {
+  const cwd = mkdtempSync(join(tmpdir(), 'idd-doctor-cleanup-cwd-'));
+  try {
+    run(cwd);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+const BACKLOG_WARNING_SUBSTRING = 'lack F4 cleanup evidence';
+
+// Paired tests: identical merged-PR numbers and comment IDs, differing only
+// in the evidence comment's author login -- a positive control proving the
+// "no warning" case below is because the trust check evaluated true, not
+// because the scan silently failed to run at all.
+const MERGED_PR_NUMBERS = [601, 602];
+
+test("checkPostMergeCleanupBacklog CLI: a trusted author's idd-cleanup-evidence marker suppresses the backlog warning", () => {
+  withTempCwd((cwd) => {
+    const report = runIddDoctorReport(
+      cwd,
+      buildCleanupBacklogStubGh({
+        owner: 'o',
+        repo: 'r',
+        mergedPrNumbers: MERGED_PR_NUMBERS,
+        evidenceByPr: new Map([
+          [601, '5001\tgithub-actions[bot]\n'],
+          [602, '5002\tgithub-actions[bot]\n'],
+        ]),
+      }),
+    );
+    assert.ok(
+      !report.warnings.some((w) => w.includes(BACKLOG_WARNING_SUBSTRING)),
+      `expected no cleanup-backlog warning, got: ${JSON.stringify(report.warnings)}`,
+    );
+  });
+});
+
+test("checkPostMergeCleanupBacklog CLI: an untrusted author's identically-shaped marker does NOT suppress the backlog warning (idd-skill#1691, PR#1759 regression guard)", () => {
+  withTempCwd((cwd) => {
+    const report = runIddDoctorReport(
+      cwd,
+      buildCleanupBacklogStubGh({
+        owner: 'o',
+        repo: 'r',
+        mergedPrNumbers: MERGED_PR_NUMBERS,
+        evidenceByPr: new Map([
+          [601, '5001\tuntrusted-user\n'],
+          [602, '5002\tanother-untrusted-user\n'],
+        ]),
+      }),
+    );
+    const backlogWarning = report.warnings.find((w) =>
+      w.includes(BACKLOG_WARNING_SUBSTRING),
+    );
+    assert.ok(
+      backlogWarning,
+      `expected a cleanup-backlog warning, got: ${JSON.stringify(report.warnings)}`,
+    );
+    assert.match(
+      backlogWarning ?? '',
+      /^post-merge cleanup backlog: 2 merged PRs/,
+    );
+    assert.match(backlogWarning ?? '', /#601/);
+    assert.match(backlogWarning ?? '', /#602/);
+  });
+});
+
+test('checkPostMergeCleanupBacklog CLI: a per-PR evidence-fetch failure is reported separately and never silently counted as missing evidence', () => {
+  withTempCwd((cwd) => {
+    const report = runIddDoctorReport(
+      cwd,
+      buildCleanupBacklogStubGh({
+        owner: 'o',
+        repo: 'r',
+        mergedPrNumbers: [701],
+        evidenceByPr: new Map(),
+        failEvidenceFor: new Set([701]),
+      }),
+    );
+    assert.ok(
+      report.warnings.some(
+        (w) =>
+          w.includes(
+            'post-merge cleanup evidence query failed for 1 merged PR(s)',
+          ) && w.includes('#701'),
+      ),
+      `expected an evidence-fetch-failure warning, got: ${JSON.stringify(report.warnings)}`,
+    );
+    assert.ok(
+      !report.warnings.some((w) => w.includes(BACKLOG_WARNING_SUBSTRING)),
+      `evidence-fetch failures must not be folded into the missing-evidence backlog warning, got: ${JSON.stringify(report.warnings)}`,
+    );
+  });
+});


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Test-only backfill for two gate-integrity call sites that a 2026-08-02
re-audit of roadmap #1712 found untested end to end, even though the
helpers they call already had direct unit tests:

1. `checkPostMergeCleanupBacklog`'s `hasTrustedEvidence` trust check
   (`src/scripts/idd-doctor.mts`) — the only caller of
   `readCleanupEvidenceTrustedLogins` (#1691, PR#1759; helper tests since
   #1804/PR#1809). Added a stubbed-`gh`-on-`PATH` CLI-smoke test file
   (mirroring the #1692 pagination-smoke pattern) that spawns the real
   generated `scripts/idd-doctor.mjs` and proves a trusted evidence
   author suppresses the backlog warning while an identically-shaped
   marker from an untrusted author does not.
2. `collectFromGitHub`'s claim-evidence wiring
   (`src/scripts/advisory-convergence.mts`) — the real-GitHub I/O layer
   that computes `claimCandidateAmbiguous` /
   `claimMarkerHistoryPresent` (#1686) from raw claim-candidate data and
   forwards them into `computeAdvisoryConvergenceVerdict`'s inputs.
   Extracted a small pure `resolveClaimEvidence` helper (mirroring the
   existing `filterResolvingClaimCandidates` extraction pattern) so the
   call site collapses into one delegated call, then added direct tests
   plus two end-to-end tests that feed its **computed** output (not
   hand-supplied booleans) into `computeAdvisoryConvergenceVerdict`.

No production behavior changes. `src/scripts/advisory-convergence.mts`
is touched only by a pure, behavior-preserving extraction — all 102
pre-existing tests in that file pass unchanged, both before and after
the extraction.

**Scope note on AC bullet 2** ("would fail if the computation *or*
forwarding … were dropped"): the *computation* half is covered by
tests verified red when `resolveClaimEvidence` drops the two
`#1686` fields. The *forwarding* half (the one-line destructure at the
real `collectFromGitHub` call site) is covered by a lightweight
structural pin, in the same spirit as this file's existing
`forbiddenInvocation` source-text check, rather than by exercising
`collectFromGitHub`'s full I/O surface (repo/PR/review/thread/claim
fetches) — `tests/advisory-convergence.test.mts` still documents that
function as "I/O layer, not under test here" (line ~930, pre-existing
convention), and stubbing its entire `gh` surface was judged a much
larger diff for the same coverage the extraction already buys.

## Linked issue

Closes #1810

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Both target call sites were empirically verified per the issue's own
audit standard: temporarily reverted to their pre-fix (fail-open)
behavior, confirmed the new regression test goes red, then restored
and confirmed green, with `git status --porcelain` clean after each
cycle. For the idd-doctor case this required rebuilding the generated
`scripts/idd-doctor.mjs` in both directions, since the CLI-smoke test
spawns compiled output rather than importing the `.mts` source.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
