### PR TITLE
fix(advisory-convergence): require claim-evidence input fields

### DIFF
--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -403,17 +403,23 @@ export interface AdvisoryConvergenceInputs {
    * non-IDD PR (no linked issue, no claim history ever -- `false`, stays
    * `not_applicable`) from an IDD-shaped PR whose claim linkage is
    * currently broken (a stale or released claim -- `true`, becomes
-   * `indeterminate`). Defaults to `false` when omitted, preserving prior
-   * `not_applicable` behavior for every fixture/caller that predates this
-   * field. */
+   * `indeterminate`). Required: every construction site must state the
+   * value explicitly (`false` for a PR with no claim history to report) --
+   * `collectFromGitHub` always computes and forwards it via
+   * `resolveClaimEvidence`, so an omitted field on this typed interface
+   * would signal a broken forwarding path, not a legitimate "no history"
+   * case (kurone-kito/idd-skill#1814). An untyped JS caller of the emitted
+   * `.mjs` that still omits it gets the same effective `false` at runtime,
+   * since it is read below as `inputs.claimMarkerHistoryPresent === true`. */
   claimMarkerHistoryPresent: boolean;
   /** #1686: true when two or more of the PR's candidate claim issues each
    * independently resolve an ACTIVE trusted claim -- the disambiguation
    * failure `pickResolvingClaimEvents` already fails closed to `[]` for
    * (module header path 2). An explicit `--claim-issue` target has no
    * ambiguity to resolve, so the CLI-collection layer always reports
-   * `false` for it (see `classifyClaimCandidateAmbiguity`). Defaults to
-   * `false` when omitted. Checked BEFORE `claimMarkerHistoryPresent` in the
+   * `false` for it (see `classifyClaimCandidateAmbiguity`). Required for the
+   * same reason as `claimMarkerHistoryPresent` above (kurone-kito/idd-skill#1814).
+   * Checked BEFORE `claimMarkerHistoryPresent` in the
    * applicability computation so the more specific "which failure mode"
    * reason wins -- an ambiguous set of candidates trivially also has claim
    * history (an active claim cannot exist without a valid marker), so the

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -406,7 +406,7 @@ export interface AdvisoryConvergenceInputs {
    * `indeterminate`). Defaults to `false` when omitted, preserving prior
    * `not_applicable` behavior for every fixture/caller that predates this
    * field. */
-  claimMarkerHistoryPresent?: boolean;
+  claimMarkerHistoryPresent: boolean;
   /** #1686: true when two or more of the PR's candidate claim issues each
    * independently resolve an ACTIVE trusted claim -- the disambiguation
    * failure `pickResolvingClaimEvents` already fails closed to `[]` for
@@ -419,7 +419,7 @@ export interface AdvisoryConvergenceInputs {
    * history (an active claim cannot exist without a valid marker), so the
    * two fields are not mutually exclusive; the check order is what makes
    * the reported `reason` precise. */
-  claimCandidateAmbiguous?: boolean;
+  claimCandidateAmbiguous: boolean;
 }
 
 /** Pure options accepted by {@link computeAdvisoryConvergenceVerdict}. */

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -55,6 +55,8 @@ function baseInputs(
     threads: [],
     comments: [],
     claimEvents: [],
+    claimMarkerHistoryPresent: false,
+    claimCandidateAmbiguous: false,
     ...overrides,
   };
 }

--- a/tests/schema-output-roundtrip.test.mts
+++ b/tests/schema-output-roundtrip.test.mts
@@ -345,6 +345,8 @@ test('advisory-convergence: computeAdvisoryConvergenceVerdict output validates a
     threads: [],
     comments: [],
     claimEvents: [],
+    claimMarkerHistoryPresent: false,
+    claimCandidateAmbiguous: false,
   };
   const options: AdvisoryConvergenceOptions = {
     now: NOW,


### PR DESCRIPTION
# Summary

`AdvisoryConvergenceInputs.claimMarkerHistoryPresent` and
`claimCandidateAmbiguous` were declared optional. That let
`collectFromGitHub`'s forwarding of either field into the returned
`inputs` object be silently dropped without breaking `pnpm run
typecheck` or the full test suite -- defaulting the applicability
verdict to `not_applicable`/`ready: true` instead of the intended
`indeterminate`/`ready: false` (the exact fail-open #1686 exists to
close). This was reproduced twice via re-audits of #1712, past a prior
partial backfill (#1804/#1810).

Making both fields required turns that drop into a compile-time
`TS2739` error instead of a silent behavior change. No runtime
behavior changes: `collectFromGitHub` already forwards both fields
correctly today; this only makes the forwarding compiler-enforced.

- `src/scripts/advisory-convergence.mts`: changed both fields on
  `AdvisoryConvergenceInputs` from optional to required, and rewrote
  each field's doc comment to describe the required contract instead
  of a "defaults when omitted" one.
- `tests/advisory-convergence.test.mts`: added explicit
  `claimMarkerHistoryPresent: false, claimCandidateAmbiguous: false`
  to the `baseInputs()` fixture helper, preserving every existing call
  site's effective behavior.
- `tests/schema-output-roundtrip.test.mts`: same two explicit fields
  added to a standalone `AdvisoryConvergenceInputs` literal.

## Linked issue

Closes #1814

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Roadmap #1712 has been through three audit rounds over #1686's
`collectFromGitHub` claim-evidence wiring; this closes the gap for
good by making the compiler the permanent guard, rather than depending
on a test author remembering to assert the forwarded values on every
future touch of `collectFromGitHub`. See the issue body for the full
investigation, including the exact `TS2739` reproduction it verified
before filing.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs changed by this PR)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

Also independently reproduced the audit's exact mutation: deleting the
two forwarding lines from `collectFromGitHub`'s returned `inputs`
object makes `pnpm run typecheck` fail with `TS2739: ... missing the
following properties from type 'AdvisoryConvergenceInputs':
claimMarkerHistoryPresent, claimCandidateAmbiguous`; restoring the
lines makes it pass again. `pnpm run build:check` confirms the
generated `scripts/advisory-convergence.mjs` mirror is byte-identical
-- this is a type-only source change.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved advisory convergence validation by requiring explicit claim-history and candidate-ambiguity values.
  * Ensured advisory verdict calculations handle these inputs consistently.

* **Tests**
  * Updated validation and roundtrip coverage to include the new required values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->