### PR TITLE
chore(issue-authoring): drop agents/openai.yaml from distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ from 0.2.0 onward is also published as an annotated `v<iddVersion>`
 git tag once its release pull request merges; 0.1.0 predates the tag
 discipline and has no tag.
 
+## [Unreleased]
+
+### Removed
+
+- `skills/issue-authoring/agents/openai.yaml` is no longer part of the
+  distributed issue-authoring skill bundle: the file, its references in
+  `audit/sync-manifest.json`, and its mentions in `ONBOARDING.md`,
+  `README.md`, and the onboarding verification checklist have all been
+  removed. No repository doc named a consumer runtime for its
+  `$issue-authoring` macro syntax, and it had gone untouched since the
+  skill's scaffold commit. Adopters who already installed a copy of this
+  file may remove it manually; it is safe to delete.
+
 ## [0.4.0] - 2026-07-04
 
 TypeScript helper toolchain, autopilot-discovery, and merge-gate

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -142,7 +142,6 @@
       ],
       "paths": [
         "skills/issue-authoring/SKILL.md",
-        "skills/issue-authoring/agents/openai.yaml",
         "skills/issue-authoring/references/contract.md",
         "skills/issue-authoring/references/draft-patterns.md",
         "skills/issue-authoring/references/workflow-boundary.md"
@@ -166,7 +165,6 @@
       ],
       "paths": [
         "skills/issue-authoring/SKILL.md",
-        "skills/issue-authoring/agents/openai.yaml",
         "skills/issue-authoring/references/contract.md",
         "skills/issue-authoring/references/draft-patterns.md",
         "skills/issue-authoring/references/workflow-boundary.md"

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -475,7 +475,6 @@ Optional companion files:
 
 ```text
 skills/issue-authoring/SKILL.md
-skills/issue-authoring/agents/openai.yaml
 skills/issue-authoring/references/contract.md
 skills/issue-authoring/references/draft-patterns.md
 skills/issue-authoring/references/workflow-boundary.md
@@ -577,12 +576,10 @@ directory the target agent expects:
 ```sh
 DEST="."  # root of the target repository
 
-mkdir -p "${DEST}/skills/issue-authoring/agents" \
-  "${DEST}/skills/issue-authoring/references"
+mkdir -p "${DEST}/skills/issue-authoring/references"
 
 for FILE in \
   "SKILL.md" \
-  "agents/openai.yaml" \
   "references/contract.md" \
   "references/draft-patterns.md" \
   "references/workflow-boundary.md"
@@ -678,12 +675,10 @@ fetch it separately:
 BASE="https://raw.githubusercontent.com/kurone-kito/idd-skill/main/skills/issue-authoring"
 DEST="."  # root of the target repository
 
-mkdir -p "${DEST}/skills/issue-authoring/agents" \
-  "${DEST}/skills/issue-authoring/references"
+mkdir -p "${DEST}/skills/issue-authoring/references"
 
 for FILE in \
   "SKILL.md" \
-  "agents/openai.yaml" \
   "references/contract.md" \
   "references/draft-patterns.md" \
   "references/workflow-boundary.md"

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -175,7 +175,6 @@ Optional companion artifact:
 
 ```text
 skills/issue-authoring/SKILL.md
-skills/issue-authoring/agents/openai.yaml
 skills/issue-authoring/references/contract.md
 skills/issue-authoring/references/draft-patterns.md
 skills/issue-authoring/references/workflow-boundary.md

--- a/idd-template/docs/onboarding/agent-entry-and-verification.md
+++ b/idd-template/docs/onboarding/agent-entry-and-verification.md
@@ -290,8 +290,7 @@ checks, confirm the detailed items below.
       the repository stays on `instructions-only` or opted into
       `package-manager`, `vendored-node`, or `ephemeral-npx`.
 - [ ] If the operator opted into issue authoring,
-      `skills/issue-authoring/SKILL.md`,
-      `skills/issue-authoring/agents/openai.yaml`, and the
+      `skills/issue-authoring/SKILL.md` and the
       `skills/issue-authoring/references/` files are present.
 
 ### Placeholder, marker, and config alignment

--- a/skills/issue-authoring/agents/openai.yaml
+++ b/skills/issue-authoring/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Issue Authoring"
-  short_description: "Draft IDD-ready issues and roadmaps"
-  default_prompt: "Use $issue-authoring to draft an IDD-ready issue set for this request."


### PR DESCRIPTION
# Summary

Removes `skills/issue-authoring/agents/openai.yaml` from the
distribution surface entirely, per the maintainer decision recorded on
the issue: the file has been untouched since the skill's scaffold
commit, no repository doc names a consumer runtime for its
`$issue-authoring` macro syntax, and it is excluded from the
`.claude/skills/` mirror, so it had no drift guard covering it.

- `audit/sync-manifest.json`: removed the path from the `paths` arrays
  of the `issue-authoring-companion-files` and
  `idd-template-readme-issue-authoring-files` entries.
- `idd-template/docs/onboarding/agent-entry-and-verification.md`:
  dropped the `agents/openai.yaml` mention from the onboarding
  checklist item.
- Deleted `skills/issue-authoring/agents/openai.yaml`.
- Regenerated `idd-template/ONBOARDING.md` and `idd-template/README.md`
  via `node scripts/sync-docs.mjs --apply`, then hand-fixed two
  `mkdir -p ".../agents"` lines in ONBOARDING.md's shell-loop code
  fences that sit outside the generator's regenerated range (caught by
  an independent critique pass before implementation).
- Added a `CHANGELOG.md [Unreleased]` entry (no such heading existed
  yet; the prior top entry was `[0.4.0]`) documenting the removal for
  adopters who already installed a copy of the file.
- Left `docs/weak-model-authoring-lite-profile-design.md`'s historical
  mention untouched, as the issue specifies.

## Linked issue

Closes #1711

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The removal decision was already recorded on the issue by the
maintainer (Option 2: drop from distribution rather than
document/refresh it), converting the issue into ready execution work.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [ ] `pnpm test` (no test surface touched; text/JSON-only change)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

Additionally:
`grep -rn "openai.yaml" --include="*.md" --include="*.json" .`
(excluding `CHANGELOG.md` and
`docs/weak-model-authoring-lite-profile-design.md`) returns zero hits.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
