### PR TITLE
fix(idd-ci): require extended timeout on CI-wait watch command

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -306,8 +306,16 @@ condition below accounts for this.
   collapse, the no-required-checks route, and the
   `ciWait.runningTimeout`/`generationTimeout` bound all stay with the
   algorithm above — track elapsed time and apply its rerun-or-hold
-  decision if a watch outlasts it. Neither watches Copilot review
-  state — see `idd-advisory-wait.instructions.md`. A bare `sleep` may
+  decision if a watch outlasts it. Issue that blocking call with an
+  execution-timeout override set at or near the calling tool's own
+  execution-timeout ceiling, not the tool's default, which can
+  hard-kill the wait well short of `ciWait.runningTimeout`; a
+  tool-timeout kill of the watch call is not a CI verdict — re-issue
+  the same blocking watch, keep accumulating elapsed time against the
+  bound above, and do not fall back to `run_in_background` or another
+  detached/backgrounded mechanism just because of the kill. Neither
+  watches Copilot review state — see
+  `idd-advisory-wait.instructions.md`. A bare `sleep` may
   be sandboxed or blocked in some runtimes (preventive; no observed
   incident yet); a `run_in_background` Bash task or other
   detached/backgrounded mechanism must not be used for this wait

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -301,8 +301,16 @@ condition below accounts for this.
   collapse, the no-required-checks route, and the
   `ciWait.runningTimeout`/`generationTimeout` bound all stay with the
   algorithm above — track elapsed time and apply its rerun-or-hold
-  decision if a watch outlasts it. Neither watches Copilot review
-  state — see `idd-advisory-wait.instructions.md`. A bare `sleep` may
+  decision if a watch outlasts it. Issue that blocking call with an
+  execution-timeout override set at or near the calling tool's own
+  execution-timeout ceiling, not the tool's default, which can
+  hard-kill the wait well short of `ciWait.runningTimeout`; a
+  tool-timeout kill of the watch call is not a CI verdict — re-issue
+  the same blocking watch, keep accumulating elapsed time against the
+  bound above, and do not fall back to `run_in_background` or another
+  detached/backgrounded mechanism just because of the kill. Neither
+  watches Copilot review state — see
+  `idd-advisory-wait.instructions.md`. A bare `sleep` may
   be sandboxed or blocked in some runtimes (preventive; no observed
   incident yet); a `run_in_background` Bash task or other
   detached/backgrounded mechanism must not be used for this wait


### PR DESCRIPTION
# Summary

`idd-ci.instructions.md`'s Wake-up discipline section told a worker to
block synchronously on CI with `gh pr checks --watch --required`,
budgeting up to `ciWait.runningTimeout` (default 30 min), but never
told the caller to raise the *execution* timeout of the tool actually
running that blocking command. Real coding-agent environments hard-kill
a shell command with no explicit extended timeout well short of that
window, which stalled two prior dogfooding sessions mid-CI-wait (#1675,
#1731).

This adds two linked points to the same section: (1) issue the blocking
watch call with an execution-timeout override set at or near the
calling tool's own ceiling, not the tool's default; (2) a tool-timeout
kill of that call is not itself a CI verdict — re-issue the same
blocking watch and keep accumulating elapsed time against the existing
`ciWait.runningTimeout`/`generationTimeout` bound instead of falling
back to a detached/background mechanism.

## Linked issue

Closes #1807

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The addition is phrased as a general principle + rough magnitude (not
one product's exact parameter name) to stay portable across the
different coding-agent products this instruction bundle is distributed
to, consistent with the section's existing "advisory, tool-agnostic"
framing. The change is scoped to the Wake-up discipline section only —
the section's separate existing note about a bare `sleep` being
"sandboxed or blocked in some runtimes" is left untouched, and the
`idd-ci-lite.instructions.md` variant is a separate, independently
authored file not listed in the issue's Candidate files, so it is
unchanged.

Byte-budget check: `idd-ci.instructions.md` is part of two
byte-budgeted bundles in `audit/sync-manifest.json`
(`instruction-size-budgets`); `bundle-review` (120000-byte cap) is the
tighter of the two, with ~2959 bytes of headroom before this change.
The added text measures 481 bytes, leaving ample headroom
(`node scripts/audit-docs.mjs --check` confirms zero drift and reports
the expected under-threshold notice only).

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (via fix-validate: biome, dprint, markdownlint)
- [ ] `pnpm test` (no test surface for a docs-only instruction change)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`node scripts/sync-docs.mjs --apply`
      leaves zero drift)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
