### PR TITLE
refactor(suitability-triage): extract supersession-detection kernel

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -71,6 +71,7 @@ scripts/review-disposition-verify.mjs linguist-generated=true
 scripts/select-desynced-index.mjs linguist-generated=true
 scripts/stalled-session-quiet-check.mjs linguist-generated=true
 scripts/suitability-triage.mjs linguist-generated=true
+scripts/supersession-detection.mjs linguist-generated=true
 scripts/sync-docs.mjs linguist-generated=true
 scripts/update-fixtures.mjs linguist-generated=true
 scripts/validate-schemas.mjs linguist-generated=true

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -892,8 +892,13 @@ Output schema:
   "passed": true,
   "outcome": "ready|unclear|needs-decision|blocked-by-human|duplicate|out-of-scope|invalid",
   "failedCheck": "repository_fit|...|null",
-  "checks": [{"id":"repository_fit","name":"Repository Fit","result":"pass|fail","evidence":"...","tier":"high-confidence|weak"}]
+  "checks": [{"id":"repository_fit","name":"Repository Fit","result":"pass|fail","evidence":"..."}]
 }
+
+Each checks[] entry may also carry "tier":"high-confidence|weak" -- present
+only on a duplicate_or_superseded fail (absent on every pass and on every
+other check), distinguishing a high-confidence mechanical hit from the weak
+title/declaration heuristic.
 `);
 }
 function normalizeIssue(issue) {

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -9,57 +9,35 @@ import { resolve } from 'node:path';
 import { parseCliArgs } from './cli-args.mjs';
 import {
   DEFAULT_BUNDLE_IDS,
-  DEFAULT_EXTRA_FILES,
   DEFAULT_MANIFEST_PATH,
   ghJson as ghJsonArray,
-  normalizeContentionPath,
   parseCandidateFiles,
   resolveHighContentionFiles,
 } from './discover-shared-file-overlap.mjs';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
 import { loadPolicyConfig } from './idd-config.mjs';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
+import {
+  buildClosedByMergedPrArgs,
+  buildMergedPrListArgs,
+  buildPrFilesArgs,
+  evaluateHighConfidenceDuplicate,
+} from './supersession-detection.mjs';
 
-/** Upper bound on the #1484 bounded merged-PR scan (mirrors B2.0's own
- * documented `gh pr list --limit 50`). */
-const MERGED_PR_SCAN_LIMIT = 50;
 /**
  * Wall-clock budget for the #1484 merged-PR file-overlap scan (CodeRabbit
- * review finding on this PR): up to MERGED_PR_SCAN_LIMIT sequential
- * `gh pr view` calls at 30s each could otherwise take ~25 minutes in the
- * worst case (a degraded/rate-limited GitHub API). Stop early and return
- * whatever has been collected once this budget elapses, rather than
- * blocking the whole A4.5 evaluation on a slow scan. Referenced from inside
- * `fetchMergedPrFileOverlapEvidence`, which the `import.meta.main` trigger
- * below can reach synchronously, so this must stay declared above that
- * trigger for the same temporal-dead-zone reason as `CLOSED_BY_MERGED_PR_QUERY`.
+ * review finding on this PR): up to `supersession-detection.mts`'s own
+ * merged-PR-scan limit (50, mirroring B2.0's own documented `gh pr list
+ * --limit 50`) sequential `gh pr view` calls at 30s each could otherwise
+ * take ~25 minutes in the worst case (a degraded/rate-limited GitHub API).
+ * Stop early and return whatever has been collected once this budget
+ * elapses, rather than blocking the whole A4.5 evaluation on a slow scan.
+ * (#1499: that limit is baked into `buildMergedPrListArgs`'s own argv,
+ * which this file now only calls rather than builds -- this comment stays
+ * prose-only rather than importing the value, since nothing here needs it
+ * as a live binding.)
  */
 const MERGED_PR_SCAN_DEADLINE_MS = 2 * 60 * 1000;
-/**
- * GraphQL query for the closed-by-merged-PR read (#1484), bounded to the
- * first 50 closing-PR references. A later page could theoretically hold an
- * additional MERGED reference this misses, but that only makes the tier
- * under-detect (fall back to the weak heuristic) rather than over-detect --
- * the safe fail direction for a check that must never fail TOWARD a false
- * positive, so a full pagination loop (as `idd-roadmap-audit-execute.mts`'s
- * `hasOpenClosingPr` implements for its own different, block-a-close use
- * case) is not required here. Declared here, above the `import.meta.main`
- * trigger below, rather than alongside the other #1484 CLI glue further
- * down: the trigger calls `runCli()` synchronously at module-evaluation
- * time, and a `const` declared after that point is still in the temporal
- * dead zone when the trigger fires (see `discover-shared-file-overlap.mts`'s
- * identical note on its own flag-spec constant).
- */
-const CLOSED_BY_MERGED_PR_QUERY = `query($owner:String!,$repo:String!,$number:Int!){
-  repository(owner:$owner,name:$repo){
-    issue(number:$number){
-      state
-      closedByPullRequestsReferences(first:50){
-        nodes { number state }
-      }
-    }
-  }
-}`;
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `issue:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
 // .mjs source text for quoted flag literals such as the --issue spec key
@@ -79,6 +57,8 @@ const SUITABILITY_TRIAGE_FLAG_SPEC = {
   '--owner': { type: 'string', default: '' },
   '--repo': { type: 'string', default: '' },
   '--policy': { type: 'string', default: '' },
+  '--manifest': { type: 'string', default: DEFAULT_MANIFEST_PATH },
+  '--bundles': { type: 'string' },
   '--verbose': { type: 'boolean', default: false },
   '--help': { type: 'boolean', short: 'h' },
 };
@@ -225,6 +205,7 @@ export function evaluateSuitability(issue, options = {}) {
       name: check.name,
       result: result.pass ? 'pass' : 'fail',
       evidence: result.evidence,
+      ...(result.tier ? { tier: result.tier } : {}),
     });
     if (!result.pass) {
       return {
@@ -405,73 +386,6 @@ export function checkTrustSafety(context) {
     evidence: 'No trust/safety blockers detected.',
   };
 }
-/**
- * High-confidence Check 4 tier (#1484): evaluate the mechanical B2.0-style
- * signals -- a merged closing-PR reference on the candidate issue itself, or
- * a merged PR that already changed one of the issue's own declared
- * `## Candidate files` (excluding high-contention/shared files, which many
- * unrelated issues touch and so are not on their own high-confidence
- * evidence that THIS issue was superseded). Returns `null` -- never a
- * synthesized verdict of its own -- whenever no strong signal fires, so the
- * caller falls through to the existing weak title/declaration heuristic
- * unchanged. This is the fail-safe contract the issue requires: never fail
- * TOWARD a false high-confidence flag. `input` may be `undefined` (evidence
- * not collected by the caller) or a partially malformed shape; both degrade
- * to "no verdict" rather than a crash or a false hit.
- */
-export function evaluateHighConfidenceDuplicate(input) {
-  if (!input) {
-    return null;
-  }
-  const closedByMergedPrNumbers = (
-    Array.isArray(input.closedByMergedPrNumbers)
-      ? input.closedByMergedPrNumbers
-      : []
-  ).filter((n) => Number.isInteger(n) && n > 0);
-  if (closedByMergedPrNumbers.length > 0) {
-    return {
-      pass: false,
-      evidence: `High-confidence duplicate: issue is already referenced by merged closing PR(s) #${closedByMergedPrNumbers.join(', #')} (closedByPullRequestsReferences).`,
-    };
-  }
-  const highContention = new Set(
-    (Array.isArray(input.highContentionFiles)
-      ? input.highContentionFiles
-      : []
-    ).map((file) => normalizeContentionPath(file)),
-  );
-  const candidateFiles = [
-    ...new Set(
-      (Array.isArray(input.candidateFiles) ? input.candidateFiles : [])
-        .map((file) => normalizeContentionPath(file))
-        .filter((file) => file.length > 0 && !highContention.has(file)),
-    ),
-  ];
-  if (candidateFiles.length === 0) {
-    return null;
-  }
-  const candidateSet = new Set(candidateFiles);
-  const mergedPrs = Array.isArray(input.mergedPrs) ? input.mergedPrs : [];
-  for (const raw of mergedPrs) {
-    const pr = raw ?? {};
-    const number = Number(pr.number);
-    if (!Number.isInteger(number) || number <= 0) {
-      continue;
-    }
-    const files = Array.isArray(pr.files) ? pr.files : [];
-    const overlap = [
-      ...new Set(files.map((file) => normalizeContentionPath(file))),
-    ].filter((file) => candidateSet.has(file));
-    if (overlap.length > 0) {
-      const mergedAt = String(pr.mergedAt ?? '');
-      return {
-        pass: false,
-        evidence: `High-confidence duplicate: merged PR #${number}${mergedAt ? ` (merged ${mergedAt})` : ''} already changed candidate file(s): ${overlap.sort().join(', ')}.`,
-      };
-    }
-  }
-  return null;
-}
 export function checkDuplicateOrSuperseded(context) {
   const highConfidence = evaluateHighConfidenceDuplicate(
     context.highConfidenceDuplicate,
@@ -499,6 +413,7 @@ export function checkDuplicateOrSuperseded(context) {
       return {
         pass: false,
         evidence: `Exact-title duplicate found: #${degradedExactMatch.number}`,
+        tier: 'weak',
       };
     }
     return {
@@ -519,6 +434,7 @@ export function checkDuplicateOrSuperseded(context) {
     return {
       pass: false,
       evidence: `Issue body declares duplicate/superseded status: ${matched}`,
+      tier: 'weak',
     };
   }
   const exactTitle = normalizeText(issue.title);
@@ -532,6 +448,7 @@ export function checkDuplicateOrSuperseded(context) {
     return {
       pass: false,
       evidence: `Exact-title duplicate found: #${duplicate.number}`,
+      tier: 'weak',
     };
   }
   // Near-duplicate detection: check for high similarity (>80% Levenshtein match)
@@ -549,6 +466,7 @@ export function checkDuplicateOrSuperseded(context) {
     return {
       pass: false,
       evidence: `Near-duplicate found: #${nearDuplicate.number} ("${nearDuplicate.title}"). Title similarity >80%.`,
+      tier: 'weak',
     };
   }
   return {
@@ -813,7 +731,12 @@ function runCli() {
     // against -- most issues have none, and the result would otherwise be
     // discarded.
     const resolvedHighContentionFiles =
-      candidateFiles.length > 0 ? loadHighContentionFiles() : null;
+      candidateFiles.length > 0
+        ? loadHighContentionFiles(
+            args.manifest,
+            args.bundles ?? DEFAULT_BUNDLE_IDS,
+          )
+        : null;
     const shouldScanMergedPrs =
       candidateFiles.length > 0 &&
       resolvedHighContentionFiles !== null &&
@@ -889,6 +812,10 @@ function runCli() {
           id: check.id,
           name: check.name,
           result: check.result,
+          // #1499: carried through even in non-verbose mode -- the typed
+          // tier signal exists precisely so a consumer can branch on it
+          // without asking for full evidence prose.
+          ...(check.tier ? { tier: check.tier } : {}),
         })),
   };
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
@@ -922,6 +849,17 @@ export function parseArgs(argv) {
     owner: values.owner,
     repo: values.repo,
     policy: values.policy,
+    manifest: values.manifest,
+    // #1499: mirrors `discover-shared-file-overlap.mts`'s own `--bundles`
+    // parsing exactly -- absent means "not passed" (`null`), present is a
+    // comma-split, trimmed, empty-token-filtered list.
+    bundles:
+      values.bundles === undefined
+        ? null
+        : String(values.bundles)
+            .split(',')
+            .map((part) => part.trim())
+            .filter(Boolean),
     verbose: values.verbose,
     help,
   };
@@ -939,7 +877,13 @@ function loadPolicy(policyPath) {
 }
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/suitability-triage.mjs --issue <number> [--token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--verbose] [--help]
+  node scripts/suitability-triage.mjs --issue <number> [--token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--manifest <path>] [--bundles <id1,id2>] [--verbose] [--help]
+
+--manifest / --bundles override the Check 4 high-confidence tier's
+high-contention exclusion set (default: the same manifest path and bundle
+IDs as discover-shared-file-overlap.mjs's own --manifest/--bundles), so a
+repository that customizes its A4 Step 2 contention bundles gets a matching
+Check-4 exclusion set instead of a stale hardcoded default.
 
 Output schema:
 {
@@ -948,7 +892,7 @@ Output schema:
   "passed": true,
   "outcome": "ready|unclear|needs-decision|blocked-by-human|duplicate|out-of-scope|invalid",
   "failedCheck": "repository_fit|...|null",
-  "checks": [{"id":"repository_fit","name":"Repository Fit","result":"pass|fail","evidence":"..."}]
+  "checks": [{"id":"repository_fit","name":"Repository Fit","result":"pass|fail","evidence":"...","tier":"high-confidence|weak"}]
 }
 `);
 }
@@ -1089,74 +1033,12 @@ function fetchDuplicateCandidates(repoRef, issue) {
   return normalizeDuplicateCandidates(payload.items ?? []);
 }
 // --- #1484: high-confidence Check 4 tier CLI glue ---------------------------
-// Read-only: every function below only ever calls `gh api graphql` (with a
-// `query` operation, never `mutation`), `gh pr list`, or `gh pr view` (no
-// -X/--method, no issue/PR mutation subcommand).
-// #1484 is detect-only by design; do not add a mutating gh call here -- a
-// later gated-close follow-up (#1485) is a separate, human-gated change.
-// The argv-builders are exported so tests can assert the exact read-only
-// verb without shelling out (a compiled-text grep for mutating verb
-// literals would miss a `gh api ... -X POST`-shaped mutation, since none of
-// this file's own calls use one).
-/**
- * Argv for the closed-by-merged-PR read. Uses `gh api graphql` rather than
- * `gh issue view --json closedByPullRequestsReferences`: the latter's
- * REST-shimmed shape carries no per-PR `state`, and the connection includes
- * OPEN (not yet merged) PRs, not only merged ones -- confirmed empirically
- * against this repo's own issue #1489 (OPEN) / PR #1497 (OPEN), and matches
- * `idd-roadmap-audit-execute.mts`'s documented note that the field "returns
- * merged PRs even with `includeClosedPrs:false`" (i.e. state alone
- * determines relevance, not that flag). Filtering to `state === 'MERGED'`
- * happens in `fetchClosedByMergedPrNumbers` below, after this fetch --
- * without it, an issue with only an in-progress unmerged closing PR would
- * wrongly read as "already referenced by a merged closing PR".
- */
-export function buildClosedByMergedPrArgs(owner, repo, issueNumber) {
-  return [
-    'api',
-    'graphql',
-    '-f',
-    `query=${CLOSED_BY_MERGED_PR_QUERY}`,
-    '-f',
-    `owner=${owner}`,
-    '-f',
-    `repo=${repo}`,
-    '-F',
-    `number=${issueNumber}`,
-  ];
-}
-/** Argv for the bounded merged-PR list scan (mirrors B2.0's own documented
- * `gh pr list --search "merged:>=<since>"` shape). */
-export function buildMergedPrListArgs(repoRef, sinceIso) {
-  return [
-    'pr',
-    'list',
-    '--repo',
-    repoRef,
-    '--state',
-    'merged',
-    '--search',
-    `merged:>=${sinceIso}`,
-    '--json',
-    'number,mergedAt',
-    '--limit',
-    String(MERGED_PR_SCAN_LIMIT),
-  ];
-}
-/** Argv for one merged PR's changed-file list. */
-export function buildPrFilesArgs(repoRef, prNumber) {
-  return [
-    'pr',
-    'view',
-    String(prNumber),
-    '--repo',
-    repoRef,
-    '--json',
-    'files',
-    '--jq',
-    '.files[].path',
-  ];
-}
+// The pure argv-builders (`buildClosedByMergedPrArgs`, `buildMergedPrListArgs`,
+// `buildPrFilesArgs`) and the evaluation kernel (`evaluateHighConfidenceDuplicate`)
+// moved to `supersession-detection.mts` (#1499); this file keeps only the
+// `gh`-executing orchestration below (fetch, try/catch, deadline budget,
+// `collectionWarnings`), which the issue does not name as part of the
+// extraction.
 /**
  * Fetch the candidate issue's own merged closing-PR references. Throws (via
  * `runGh`, no try/catch here) on a `gh` error rather than silently reading a
@@ -1269,20 +1151,23 @@ function fetchMergedPrFileOverlapEvidence(repoRef, sinceIso) {
  * same way. `closedByPullRequestsReferences` is a separate, independent
  * signal and is unaffected by either fallback.
  */
-function loadHighContentionFiles() {
+export function loadHighContentionFiles(manifestPath, bundleIds) {
   try {
     const manifest = JSON.parse(
-      readFileSync(resolve(process.cwd(), DEFAULT_MANIFEST_PATH), 'utf8'),
+      readFileSync(resolve(process.cwd(), manifestPath), 'utf8'),
     );
     // Codex P2 review finding: a manifest that parses but lacks usable
     // `bundleBudgets` entries for one or both target bundle IDs (an empty
     // object, or an older schema) doesn't throw here -- `resolveHighContentionFiles`
-    // degrades gracefully to just `DEFAULT_EXTRA_FILES` for A4 Step 2's own,
-    // lower-stakes de-prioritization use. But for this tier, an incomplete
-    // exclusion set can miss a genuinely high-contention file, so a shared
-    // bundle/instruction file could be misread as specific overlap evidence
-    // -- exactly the false high-confidence flag Check 4 must never produce.
-    // Require both configured bundle IDs to actually resolve before
+    // degrades gracefully to just the manifest path itself for A4 Step 2's
+    // own, lower-stakes de-prioritization use. But for this tier, an
+    // incomplete exclusion set can miss a genuinely high-contention file, so
+    // a shared bundle/instruction file could be misread as specific overlap
+    // evidence -- exactly the false high-confidence flag Check 4 must never
+    // produce. Require every requested bundle ID (#1499: the caller's own
+    // `--bundles` override when given, not the hardcoded default -- a
+    // repository that customizes its bundle set must have THOSE bundles
+    // validated, not `DEFAULT_BUNDLE_IDS`) to actually resolve before
     // accepting the set; otherwise treat it the same as an unreadable
     // manifest (return null, which the caller already records as a
     // collection warning and degrades to exact-title-only).
@@ -1303,7 +1188,7 @@ function loadHighContentionFiles() {
     // above yet still let `resolveHighContentionFiles` silently omit that
     // bundle's real shared files -- the same false-flag risk as a missing
     // bundle id entirely, so it must degrade the same way.
-    const allBundleIdsResolved = DEFAULT_BUNDLE_IDS.every((id) =>
+    const allBundleIdsResolved = bundleIds.every((id) =>
       nonEmptyFilesBundleIds.has(id),
     );
     if (!allBundleIdsResolved) {
@@ -1312,8 +1197,12 @@ function loadHighContentionFiles() {
     return [
       ...resolveHighContentionFiles({
         manifest,
-        bundleIds: DEFAULT_BUNDLE_IDS,
-        extraFiles: DEFAULT_EXTRA_FILES,
+        bundleIds,
+        // #1499: mirrors `discover-shared-file-overlap.mts`'s own `runCli`
+        // pattern -- the manifest path actually in use is the file reported
+        // (and matched) as high-contention, not a hardcoded default that
+        // silently stops tracking a customized manifest.
+        extraFiles: [manifestPath],
       }),
     ];
   } catch {

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -1157,6 +1157,18 @@ function fetchMergedPrFileOverlapEvidence(repoRef, sinceIso) {
  * signal and is unaffected by either fallback.
  */
 export function loadHighContentionFiles(manifestPath, bundleIds) {
+  // Copilot review finding on this PR: `[].every(...)` is vacuously `true`,
+  // so an explicitly-empty (or whitespace-only, after --bundles parsing)
+  // override would otherwise sail through the completeness check below and
+  // resolve to a high-contention set containing only `extraFiles` (just the
+  // manifest path) -- the opposite of this tier's fail-safe contract, since
+  // a smaller exclusion set makes the overlap scan MORE permissive, not
+  // less. Treat an empty list the same as any other invalid/incomplete
+  // request: degrade to null (collection warning, exact-title-only) rather
+  // than silently accepting zero bundles as "all resolved".
+  if (bundleIds.length === 0) {
+    return null;
+  }
   try {
     const manifest = JSON.parse(
       readFileSync(resolve(process.cwd(), manifestPath), 'utf8'),

--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -1,0 +1,187 @@
+// idd-generated-from: src/scripts/supersession-detection.mts
+//
+// The scripts/supersession-detection.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// The #1484 high-confidence supersession-detection kernel (#1499): a
+// mechanical "is this issue already superseded by a merged PR" evaluator,
+// plus its read-only `gh` argv-builders, extracted out of
+// `suitability-triage.mts` so a future B2.0 mechanization
+// (`idd-work.instructions.md`'s post-claim supersession re-check, currently
+// prose-only) can reuse this kernel directly instead of duplicating it in a
+// second file. `suitability-triage.mts` is Check 4's only current consumer;
+// nothing here depends on it, so this module carries no import back to it
+// (a future consumer never needs to pull in suitability-triage.mts's whole
+// 7-check CLI just to reuse the kernel).
+//
+// Pure and I/O-free: `evaluateHighConfidenceDuplicate` only evaluates
+// already-collected evidence, and the argv-builders only build `gh` command
+// arrays -- neither executes anything. The actual `gh` fetch/orchestration
+// (`fetchClosedByMergedPrNumbers`, `fetchMergedPrFileOverlapEvidence`, the
+// `MERGED_PR_SCAN_DEADLINE_MS` wall-clock budget) stays in
+// `suitability-triage.mts`'s own CLI glue, which the issue does not name as
+// part of the extraction.
+import { normalizeContentionPath } from './discover-shared-file-overlap.mjs';
+
+/** Upper bound on the #1484 bounded merged-PR scan (mirrors B2.0's own
+ * documented `gh pr list --limit 50`). */
+const MERGED_PR_SCAN_LIMIT = 50;
+/**
+ * GraphQL query for the closed-by-merged-PR read (#1484), bounded to the
+ * first 50 closing-PR references. A later page could theoretically hold an
+ * additional MERGED reference this misses, but that only makes the tier
+ * under-detect (fall back to the weak heuristic) rather than over-detect --
+ * the safe fail direction for a check that must never fail TOWARD a false
+ * positive, so a full pagination loop (as `idd-roadmap-audit-execute.mts`'s
+ * `hasOpenClosingPr` implements for its own different, block-a-close use
+ * case) is not required here.
+ */
+const CLOSED_BY_MERGED_PR_QUERY = `query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      state
+      closedByPullRequestsReferences(first:50){
+        nodes { number state }
+      }
+    }
+  }
+}`;
+/**
+ * High-confidence Check 4 tier (#1484): evaluate the mechanical B2.0-style
+ * signals -- a merged closing-PR reference on the candidate issue itself, or
+ * a merged PR that already changed one of the issue's own declared
+ * `## Candidate files` (excluding high-contention/shared files, which many
+ * unrelated issues touch and so are not on their own high-confidence
+ * evidence that THIS issue was superseded). Returns `null` -- never a
+ * synthesized verdict of its own -- whenever no strong signal fires, so the
+ * caller falls through to its own existing weak title/declaration heuristic
+ * unchanged. This is the fail-safe contract the issue requires: never fail
+ * TOWARD a false high-confidence flag. `input` may be `undefined` (evidence
+ * not collected by the caller) or a partially malformed shape; both degrade
+ * to "no verdict" rather than a crash or a false hit.
+ */
+export function evaluateHighConfidenceDuplicate(input) {
+  if (!input) {
+    return null;
+  }
+  const closedByMergedPrNumbers = (
+    Array.isArray(input.closedByMergedPrNumbers)
+      ? input.closedByMergedPrNumbers
+      : []
+  ).filter((n) => Number.isInteger(n) && n > 0);
+  if (closedByMergedPrNumbers.length > 0) {
+    return {
+      pass: false,
+      evidence: `High-confidence duplicate: issue is already referenced by merged closing PR(s) #${closedByMergedPrNumbers.join(', #')} (closedByPullRequestsReferences).`,
+      tier: 'high-confidence',
+    };
+  }
+  const highContention = new Set(
+    (Array.isArray(input.highContentionFiles)
+      ? input.highContentionFiles
+      : []
+    ).map((file) => normalizeContentionPath(file)),
+  );
+  const candidateFiles = [
+    ...new Set(
+      (Array.isArray(input.candidateFiles) ? input.candidateFiles : [])
+        .map((file) => normalizeContentionPath(file))
+        .filter((file) => file.length > 0 && !highContention.has(file)),
+    ),
+  ];
+  if (candidateFiles.length === 0) {
+    return null;
+  }
+  const candidateSet = new Set(candidateFiles);
+  const mergedPrs = Array.isArray(input.mergedPrs) ? input.mergedPrs : [];
+  for (const raw of mergedPrs) {
+    const pr = raw ?? {};
+    const number = Number(pr.number);
+    if (!Number.isInteger(number) || number <= 0) {
+      continue;
+    }
+    const files = Array.isArray(pr.files) ? pr.files : [];
+    const overlap = [
+      ...new Set(files.map((file) => normalizeContentionPath(file))),
+    ].filter((file) => candidateSet.has(file));
+    if (overlap.length > 0) {
+      const mergedAt = String(pr.mergedAt ?? '');
+      return {
+        pass: false,
+        evidence: `High-confidence duplicate: merged PR #${number}${mergedAt ? ` (merged ${mergedAt})` : ''} already changed candidate file(s): ${overlap.sort().join(', ')}.`,
+        tier: 'high-confidence',
+      };
+    }
+  }
+  return null;
+}
+// --- #1484: high-confidence Check 4 tier CLI glue ---------------------------
+// Read-only: every function below only ever builds argv for `gh api graphql`
+// (with a `query` operation, never `mutation`), `gh pr list`, or `gh pr view`
+// (no -X/--method, no issue/PR mutation subcommand) -- none of them execute
+// anything themselves. #1484 is detect-only by design; do not add a mutating
+// argv-builder here -- a later gated-close follow-up (#1485) is a separate,
+// human-gated change. The argv-builders are exported so tests can assert the
+// exact read-only verb without shelling out (a compiled-text grep for
+// mutating verb literals would miss a `gh api ... -X POST`-shaped mutation,
+// since none of these builders produce one).
+/**
+ * Argv for the closed-by-merged-PR read. Uses `gh api graphql` rather than
+ * `gh issue view --json closedByPullRequestsReferences`: the latter's
+ * REST-shimmed shape carries no per-PR `state`, and the connection includes
+ * OPEN (not yet merged) PRs, not only merged ones -- confirmed empirically
+ * against this repo's own issue #1489 (OPEN) / PR #1497 (OPEN), and matches
+ * `idd-roadmap-audit-execute.mts`'s documented note that the field "returns
+ * merged PRs even with `includeClosedPrs:false`" (i.e. state alone
+ * determines relevance, not that flag). Filtering to `state === 'MERGED'`
+ * happens in the caller, after this fetch -- without it, an issue with only
+ * an in-progress unmerged closing PR would wrongly read as "already
+ * referenced by a merged closing PR".
+ */
+export function buildClosedByMergedPrArgs(owner, repo, issueNumber) {
+  return [
+    'api',
+    'graphql',
+    '-f',
+    `query=${CLOSED_BY_MERGED_PR_QUERY}`,
+    '-f',
+    `owner=${owner}`,
+    '-f',
+    `repo=${repo}`,
+    '-F',
+    `number=${issueNumber}`,
+  ];
+}
+/** Argv for the bounded merged-PR list scan (mirrors B2.0's own documented
+ * `gh pr list --search "merged:>=<since>"` shape). */
+export function buildMergedPrListArgs(repoRef, sinceIso) {
+  return [
+    'pr',
+    'list',
+    '--repo',
+    repoRef,
+    '--state',
+    'merged',
+    '--search',
+    `merged:>=${sinceIso}`,
+    '--json',
+    'number,mergedAt',
+    '--limit',
+    String(MERGED_PR_SCAN_LIMIT),
+  ];
+}
+/** Argv for one merged PR's changed-file list. */
+export function buildPrFilesArgs(repoRef, prNumber) {
+  return [
+    'pr',
+    'view',
+    String(prNumber),
+    '--repo',
+    repoRef,
+    '--json',
+    'files',
+    '--jq',
+    '.files[].path',
+  ];
+}

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -11,59 +11,38 @@ import { resolve } from 'node:path';
 import { parseCliArgs } from './cli-args.mts';
 import {
   DEFAULT_BUNDLE_IDS,
-  DEFAULT_EXTRA_FILES,
   DEFAULT_MANIFEST_PATH,
   ghJson as ghJsonArray,
-  normalizeContentionPath,
   parseCandidateFiles,
   resolveHighContentionFiles,
 } from './discover-shared-file-overlap.mts';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mts';
 import { loadPolicyConfig } from './idd-config.mts';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
-
-/** Upper bound on the #1484 bounded merged-PR scan (mirrors B2.0's own
- * documented `gh pr list --limit 50`). */
-const MERGED_PR_SCAN_LIMIT = 50;
+import {
+  buildClosedByMergedPrArgs,
+  buildMergedPrListArgs,
+  buildPrFilesArgs,
+  type CheckOutcome,
+  evaluateHighConfidenceDuplicate,
+  type HighConfidenceDuplicateInput,
+  type HighConfidenceMergedPr,
+} from './supersession-detection.mts';
 
 /**
  * Wall-clock budget for the #1484 merged-PR file-overlap scan (CodeRabbit
- * review finding on this PR): up to MERGED_PR_SCAN_LIMIT sequential
- * `gh pr view` calls at 30s each could otherwise take ~25 minutes in the
- * worst case (a degraded/rate-limited GitHub API). Stop early and return
- * whatever has been collected once this budget elapses, rather than
- * blocking the whole A4.5 evaluation on a slow scan. Referenced from inside
- * `fetchMergedPrFileOverlapEvidence`, which the `import.meta.main` trigger
- * below can reach synchronously, so this must stay declared above that
- * trigger for the same temporal-dead-zone reason as `CLOSED_BY_MERGED_PR_QUERY`.
+ * review finding on this PR): up to `supersession-detection.mts`'s own
+ * merged-PR-scan limit (50, mirroring B2.0's own documented `gh pr list
+ * --limit 50`) sequential `gh pr view` calls at 30s each could otherwise
+ * take ~25 minutes in the worst case (a degraded/rate-limited GitHub API).
+ * Stop early and return whatever has been collected once this budget
+ * elapses, rather than blocking the whole A4.5 evaluation on a slow scan.
+ * (#1499: that limit is baked into `buildMergedPrListArgs`'s own argv,
+ * which this file now only calls rather than builds -- this comment stays
+ * prose-only rather than importing the value, since nothing here needs it
+ * as a live binding.)
  */
 const MERGED_PR_SCAN_DEADLINE_MS = 2 * 60 * 1000;
-
-/**
- * GraphQL query for the closed-by-merged-PR read (#1484), bounded to the
- * first 50 closing-PR references. A later page could theoretically hold an
- * additional MERGED reference this misses, but that only makes the tier
- * under-detect (fall back to the weak heuristic) rather than over-detect --
- * the safe fail direction for a check that must never fail TOWARD a false
- * positive, so a full pagination loop (as `idd-roadmap-audit-execute.mts`'s
- * `hasOpenClosingPr` implements for its own different, block-a-close use
- * case) is not required here. Declared here, above the `import.meta.main`
- * trigger below, rather than alongside the other #1484 CLI glue further
- * down: the trigger calls `runCli()` synchronously at module-evaluation
- * time, and a `const` declared after that point is still in the temporal
- * dead zone when the trigger fires (see `discover-shared-file-overlap.mts`'s
- * identical note on its own flag-spec constant).
- */
-const CLOSED_BY_MERGED_PR_QUERY = `query($owner:String!,$repo:String!,$number:Int!){
-  repository(owner:$owner,name:$repo){
-    issue(number:$number){
-      state
-      closedByPullRequestsReferences(first:50){
-        nodes { number state }
-      }
-    }
-  }
-}`;
 
 /** Parsed CLI arguments. */
 interface SuitabilityTriageArgs {
@@ -72,6 +51,15 @@ interface SuitabilityTriageArgs {
   owner: string;
   repo: string;
   policy: string;
+  /** #1499: high-contention manifest override, mirroring
+   * `discover-shared-file-overlap.mts`'s own `--manifest` flag so a
+   * repository that customizes its A4 Step 2 manifest path gets a matching
+   * Check-4 exclusion set instead of the hardcoded default. */
+  manifest: string;
+  /** #1499: high-contention bundle-id override, mirroring
+   * `discover-shared-file-overlap.mts`'s own `--bundles` flag. `null` means
+   * "not passed" -- the caller falls back to `DEFAULT_BUNDLE_IDS`. */
+  bundles: string[] | null;
   verbose: boolean;
   help: boolean;
 }
@@ -95,6 +83,8 @@ const SUITABILITY_TRIAGE_FLAG_SPEC = {
   '--owner': { type: 'string', default: '' },
   '--repo': { type: 'string', default: '' },
   '--policy': { type: 'string', default: '' },
+  '--manifest': { type: 'string', default: DEFAULT_MANIFEST_PATH },
+  '--bundles': { type: 'string' },
   '--verbose': { type: 'boolean', default: false },
   '--help': { type: 'boolean', short: 'h' },
 } as const;
@@ -120,36 +110,6 @@ interface DuplicateCandidate {
   title: string;
   state: string;
   url: string;
-}
-
-/** One merged PR's changed-file evidence for the high-confidence tier (#1484). */
-export interface HighConfidenceMergedPr {
-  number: number;
-  mergedAt: string;
-  files: string[];
-}
-
-/**
- * Mechanical B2.0-style evidence for the Check 4 high-confidence tier
- * (#1484): a candidate issue's own `closedByPullRequestsReferences`, plus a
- * bounded merged-PR-vs-`## Candidate files` overlap scan. Reuses
- * `discover-shared-file-overlap.mts`'s path normalization and high-contention
- * set instead of re-implementing either. Every field is defensively
- * re-validated by `evaluateHighConfidenceDuplicate` itself (not just at the
- * `evaluateSuitability` options boundary), so a caller that hand-builds a
- * `Context` directly -- as several existing tests already do, bypassing
- * normalization -- can never crash it or manufacture a false hit from a
- * malformed shape; a missing or malformed field just falls through to
- * today's weak heuristic unchanged.
- */
-export interface HighConfidenceDuplicateInput {
-  closedByMergedPrNumbers: number[];
-  candidateFiles: string[];
-  /** High-contention files (bundle + manifest) excluded from the overlap
-   * check -- a coincidental hit on a broadly-shared file is not on its own
-   * high-confidence evidence that THIS issue was superseded. */
-  highContentionFiles: string[];
-  mergedPrs: HighConfidenceMergedPr[];
 }
 
 interface Context {
@@ -179,16 +139,15 @@ interface Context {
   highConfidenceCollectionDegraded?: boolean;
 }
 
-interface CheckOutcome {
-  pass: boolean;
-  evidence: string;
-}
-
 interface CheckResult {
   id: string;
   name: string;
   result: string;
   evidence: string;
+  /** #1499: present only for a fail whose evidence came from the
+   * high-confidence mechanical kernel vs. the weak title/declaration
+   * heuristic -- see `CheckOutcome` in `supersession-detection.mts`. */
+  tier?: 'high-confidence' | 'weak';
 }
 
 interface SuitabilityResult {
@@ -367,6 +326,7 @@ export function evaluateSuitability(
       name: check.name,
       result: result.pass ? 'pass' : 'fail',
       evidence: result.evidence,
+      ...(result.tier ? { tier: result.tier } : {}),
     });
     if (!result.pass) {
       return {
@@ -561,86 +521,6 @@ export function checkTrustSafety(context: Context): CheckOutcome {
   };
 }
 
-/**
- * High-confidence Check 4 tier (#1484): evaluate the mechanical B2.0-style
- * signals -- a merged closing-PR reference on the candidate issue itself, or
- * a merged PR that already changed one of the issue's own declared
- * `## Candidate files` (excluding high-contention/shared files, which many
- * unrelated issues touch and so are not on their own high-confidence
- * evidence that THIS issue was superseded). Returns `null` -- never a
- * synthesized verdict of its own -- whenever no strong signal fires, so the
- * caller falls through to the existing weak title/declaration heuristic
- * unchanged. This is the fail-safe contract the issue requires: never fail
- * TOWARD a false high-confidence flag. `input` may be `undefined` (evidence
- * not collected by the caller) or a partially malformed shape; both degrade
- * to "no verdict" rather than a crash or a false hit.
- */
-export function evaluateHighConfidenceDuplicate(
-  input: HighConfidenceDuplicateInput | undefined,
-): CheckOutcome | null {
-  if (!input) {
-    return null;
-  }
-
-  const closedByMergedPrNumbers = (
-    Array.isArray(input.closedByMergedPrNumbers)
-      ? input.closedByMergedPrNumbers
-      : []
-  ).filter((n) => Number.isInteger(n) && n > 0);
-  if (closedByMergedPrNumbers.length > 0) {
-    return {
-      pass: false,
-      evidence: `High-confidence duplicate: issue is already referenced by merged closing PR(s) #${closedByMergedPrNumbers.join(', #')} (closedByPullRequestsReferences).`,
-    };
-  }
-
-  const highContention = new Set(
-    (Array.isArray(input.highContentionFiles)
-      ? input.highContentionFiles
-      : []
-    ).map((file) => normalizeContentionPath(file)),
-  );
-  const candidateFiles = [
-    ...new Set(
-      (Array.isArray(input.candidateFiles) ? input.candidateFiles : [])
-        .map((file) => normalizeContentionPath(file))
-        .filter((file) => file.length > 0 && !highContention.has(file)),
-    ),
-  ];
-  if (candidateFiles.length === 0) {
-    return null;
-  }
-  const candidateSet = new Set(candidateFiles);
-
-  const mergedPrs: unknown[] = Array.isArray(input.mergedPrs)
-    ? input.mergedPrs
-    : [];
-  for (const raw of mergedPrs) {
-    const pr = (raw ?? {}) as {
-      number?: unknown;
-      mergedAt?: unknown;
-      files?: unknown;
-    };
-    const number = Number(pr.number);
-    if (!Number.isInteger(number) || number <= 0) {
-      continue;
-    }
-    const files = Array.isArray(pr.files) ? pr.files : [];
-    const overlap = [
-      ...new Set(files.map((file) => normalizeContentionPath(file))),
-    ].filter((file) => candidateSet.has(file));
-    if (overlap.length > 0) {
-      const mergedAt = String(pr.mergedAt ?? '');
-      return {
-        pass: false,
-        evidence: `High-confidence duplicate: merged PR #${number}${mergedAt ? ` (merged ${mergedAt})` : ''} already changed candidate file(s): ${overlap.sort().join(', ')}.`,
-      };
-    }
-  }
-
-  return null;
-}
-
 export function checkDuplicateOrSuperseded(context: Context): CheckOutcome {
   const highConfidence = evaluateHighConfidenceDuplicate(
     context.highConfidenceDuplicate,
@@ -670,6 +550,7 @@ export function checkDuplicateOrSuperseded(context: Context): CheckOutcome {
       return {
         pass: false,
         evidence: `Exact-title duplicate found: #${degradedExactMatch.number}`,
+        tier: 'weak',
       };
     }
     return {
@@ -692,6 +573,7 @@ export function checkDuplicateOrSuperseded(context: Context): CheckOutcome {
     return {
       pass: false,
       evidence: `Issue body declares duplicate/superseded status: ${matched}`,
+      tier: 'weak',
     };
   }
 
@@ -706,6 +588,7 @@ export function checkDuplicateOrSuperseded(context: Context): CheckOutcome {
     return {
       pass: false,
       evidence: `Exact-title duplicate found: #${duplicate.number}`,
+      tier: 'weak',
     };
   }
 
@@ -724,6 +607,7 @@ export function checkDuplicateOrSuperseded(context: Context): CheckOutcome {
     return {
       pass: false,
       evidence: `Near-duplicate found: #${nearDuplicate.number} ("${nearDuplicate.title}"). Title similarity >80%.`,
+      tier: 'weak',
     };
   }
 
@@ -1014,7 +898,12 @@ function runCli(): void {
     // against -- most issues have none, and the result would otherwise be
     // discarded.
     const resolvedHighContentionFiles =
-      candidateFiles.length > 0 ? loadHighContentionFiles() : null;
+      candidateFiles.length > 0
+        ? loadHighContentionFiles(
+            args.manifest,
+            args.bundles ?? DEFAULT_BUNDLE_IDS,
+          )
+        : null;
     const shouldScanMergedPrs =
       candidateFiles.length > 0 &&
       resolvedHighContentionFiles !== null &&
@@ -1094,6 +983,10 @@ function runCli(): void {
           id: check.id,
           name: check.name,
           result: check.result,
+          // #1499: carried through even in non-verbose mode -- the typed
+          // tier signal exists precisely so a consumer can branch on it
+          // without asking for full evidence prose.
+          ...(check.tier ? { tier: check.tier } : {}),
         })),
   };
 
@@ -1130,6 +1023,17 @@ export function parseArgs(argv: string[]): SuitabilityTriageArgs {
     owner: values.owner as string,
     repo: values.repo as string,
     policy: values.policy as string,
+    manifest: values.manifest as string,
+    // #1499: mirrors `discover-shared-file-overlap.mts`'s own `--bundles`
+    // parsing exactly -- absent means "not passed" (`null`), present is a
+    // comma-split, trimmed, empty-token-filtered list.
+    bundles:
+      values.bundles === undefined
+        ? null
+        : String(values.bundles as string)
+            .split(',')
+            .map((part) => part.trim())
+            .filter(Boolean),
     verbose: values.verbose as boolean,
     help,
   };
@@ -1149,7 +1053,13 @@ function loadPolicy(policyPath: string): unknown {
 
 function printHelp(): void {
   process.stdout.write(`Usage:
-  node scripts/suitability-triage.mjs --issue <number> [--token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--verbose] [--help]
+  node scripts/suitability-triage.mjs --issue <number> [--token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--manifest <path>] [--bundles <id1,id2>] [--verbose] [--help]
+
+--manifest / --bundles override the Check 4 high-confidence tier's
+high-contention exclusion set (default: the same manifest path and bundle
+IDs as discover-shared-file-overlap.mjs's own --manifest/--bundles), so a
+repository that customizes its A4 Step 2 contention bundles gets a matching
+Check-4 exclusion set instead of a stale hardcoded default.
 
 Output schema:
 {
@@ -1158,7 +1068,7 @@ Output schema:
   "passed": true,
   "outcome": "ready|unclear|needs-decision|blocked-by-human|duplicate|out-of-scope|invalid",
   "failedCheck": "repository_fit|...|null",
-  "checks": [{"id":"repository_fit","name":"Repository Fit","result":"pass|fail","evidence":"..."}]
+  "checks": [{"id":"repository_fit","name":"Repository Fit","result":"pass|fail","evidence":"...","tier":"high-confidence|weak"}]
 }
 `);
 }
@@ -1352,84 +1262,12 @@ function fetchDuplicateCandidates(
 }
 
 // --- #1484: high-confidence Check 4 tier CLI glue ---------------------------
-// Read-only: every function below only ever calls `gh api graphql` (with a
-// `query` operation, never `mutation`), `gh pr list`, or `gh pr view` (no
-// -X/--method, no issue/PR mutation subcommand).
-// #1484 is detect-only by design; do not add a mutating gh call here -- a
-// later gated-close follow-up (#1485) is a separate, human-gated change.
-// The argv-builders are exported so tests can assert the exact read-only
-// verb without shelling out (a compiled-text grep for mutating verb
-// literals would miss a `gh api ... -X POST`-shaped mutation, since none of
-// this file's own calls use one).
-
-/**
- * Argv for the closed-by-merged-PR read. Uses `gh api graphql` rather than
- * `gh issue view --json closedByPullRequestsReferences`: the latter's
- * REST-shimmed shape carries no per-PR `state`, and the connection includes
- * OPEN (not yet merged) PRs, not only merged ones -- confirmed empirically
- * against this repo's own issue #1489 (OPEN) / PR #1497 (OPEN), and matches
- * `idd-roadmap-audit-execute.mts`'s documented note that the field "returns
- * merged PRs even with `includeClosedPrs:false`" (i.e. state alone
- * determines relevance, not that flag). Filtering to `state === 'MERGED'`
- * happens in `fetchClosedByMergedPrNumbers` below, after this fetch --
- * without it, an issue with only an in-progress unmerged closing PR would
- * wrongly read as "already referenced by a merged closing PR".
- */
-export function buildClosedByMergedPrArgs(
-  owner: string,
-  repo: string,
-  issueNumber: number,
-): string[] {
-  return [
-    'api',
-    'graphql',
-    '-f',
-    `query=${CLOSED_BY_MERGED_PR_QUERY}`,
-    '-f',
-    `owner=${owner}`,
-    '-f',
-    `repo=${repo}`,
-    '-F',
-    `number=${issueNumber}`,
-  ];
-}
-
-/** Argv for the bounded merged-PR list scan (mirrors B2.0's own documented
- * `gh pr list --search "merged:>=<since>"` shape). */
-export function buildMergedPrListArgs(
-  repoRef: string,
-  sinceIso: string,
-): string[] {
-  return [
-    'pr',
-    'list',
-    '--repo',
-    repoRef,
-    '--state',
-    'merged',
-    '--search',
-    `merged:>=${sinceIso}`,
-    '--json',
-    'number,mergedAt',
-    '--limit',
-    String(MERGED_PR_SCAN_LIMIT),
-  ];
-}
-
-/** Argv for one merged PR's changed-file list. */
-export function buildPrFilesArgs(repoRef: string, prNumber: number): string[] {
-  return [
-    'pr',
-    'view',
-    String(prNumber),
-    '--repo',
-    repoRef,
-    '--json',
-    'files',
-    '--jq',
-    '.files[].path',
-  ];
-}
+// The pure argv-builders (`buildClosedByMergedPrArgs`, `buildMergedPrListArgs`,
+// `buildPrFilesArgs`) and the evaluation kernel (`evaluateHighConfidenceDuplicate`)
+// moved to `supersession-detection.mts` (#1499); this file keeps only the
+// `gh`-executing orchestration below (fetch, try/catch, deadline budget,
+// `collectionWarnings`), which the issue does not name as part of the
+// extraction.
 
 /**
  * Fetch the candidate issue's own merged closing-PR references. Throws (via
@@ -1574,20 +1412,26 @@ function fetchMergedPrFileOverlapEvidence(
  * same way. `closedByPullRequestsReferences` is a separate, independent
  * signal and is unaffected by either fallback.
  */
-function loadHighContentionFiles(): string[] | null {
+export function loadHighContentionFiles(
+  manifestPath: string,
+  bundleIds: string[],
+): string[] | null {
   try {
     const manifest = JSON.parse(
-      readFileSync(resolve(process.cwd(), DEFAULT_MANIFEST_PATH), 'utf8'),
+      readFileSync(resolve(process.cwd(), manifestPath), 'utf8'),
     );
     // Codex P2 review finding: a manifest that parses but lacks usable
     // `bundleBudgets` entries for one or both target bundle IDs (an empty
     // object, or an older schema) doesn't throw here -- `resolveHighContentionFiles`
-    // degrades gracefully to just `DEFAULT_EXTRA_FILES` for A4 Step 2's own,
-    // lower-stakes de-prioritization use. But for this tier, an incomplete
-    // exclusion set can miss a genuinely high-contention file, so a shared
-    // bundle/instruction file could be misread as specific overlap evidence
-    // -- exactly the false high-confidence flag Check 4 must never produce.
-    // Require both configured bundle IDs to actually resolve before
+    // degrades gracefully to just the manifest path itself for A4 Step 2's
+    // own, lower-stakes de-prioritization use. But for this tier, an
+    // incomplete exclusion set can miss a genuinely high-contention file, so
+    // a shared bundle/instruction file could be misread as specific overlap
+    // evidence -- exactly the false high-confidence flag Check 4 must never
+    // produce. Require every requested bundle ID (#1499: the caller's own
+    // `--bundles` override when given, not the hardcoded default -- a
+    // repository that customizes its bundle set must have THOSE bundles
+    // validated, not `DEFAULT_BUNDLE_IDS`) to actually resolve before
     // accepting the set; otherwise treat it the same as an unreadable
     // manifest (return null, which the caller already records as a
     // collection warning and degrades to exact-title-only).
@@ -1609,7 +1453,7 @@ function loadHighContentionFiles(): string[] | null {
     // above yet still let `resolveHighContentionFiles` silently omit that
     // bundle's real shared files -- the same false-flag risk as a missing
     // bundle id entirely, so it must degrade the same way.
-    const allBundleIdsResolved = DEFAULT_BUNDLE_IDS.every((id) =>
+    const allBundleIdsResolved = bundleIds.every((id) =>
       nonEmptyFilesBundleIds.has(id),
     );
     if (!allBundleIdsResolved) {
@@ -1618,8 +1462,12 @@ function loadHighContentionFiles(): string[] | null {
     return [
       ...resolveHighContentionFiles({
         manifest,
-        bundleIds: DEFAULT_BUNDLE_IDS,
-        extraFiles: DEFAULT_EXTRA_FILES,
+        bundleIds,
+        // #1499: mirrors `discover-shared-file-overlap.mts`'s own `runCli`
+        // pattern -- the manifest path actually in use is the file reported
+        // (and matched) as high-contention, not a hardcoded default that
+        // silently stops tracking a customized manifest.
+        extraFiles: [manifestPath],
       }),
     ];
   } catch {

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1068,8 +1068,13 @@ Output schema:
   "passed": true,
   "outcome": "ready|unclear|needs-decision|blocked-by-human|duplicate|out-of-scope|invalid",
   "failedCheck": "repository_fit|...|null",
-  "checks": [{"id":"repository_fit","name":"Repository Fit","result":"pass|fail","evidence":"...","tier":"high-confidence|weak"}]
+  "checks": [{"id":"repository_fit","name":"Repository Fit","result":"pass|fail","evidence":"..."}]
 }
+
+Each checks[] entry may also carry "tier":"high-confidence|weak" -- present
+only on a duplicate_or_superseded fail (absent on every pass and on every
+other check), distinguishing a high-confidence mechanical hit from the weak
+title/declaration heuristic.
 `);
 }
 

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1421,6 +1421,18 @@ export function loadHighContentionFiles(
   manifestPath: string,
   bundleIds: string[],
 ): string[] | null {
+  // Copilot review finding on this PR: `[].every(...)` is vacuously `true`,
+  // so an explicitly-empty (or whitespace-only, after --bundles parsing)
+  // override would otherwise sail through the completeness check below and
+  // resolve to a high-contention set containing only `extraFiles` (just the
+  // manifest path) -- the opposite of this tier's fail-safe contract, since
+  // a smaller exclusion set makes the overlap scan MORE permissive, not
+  // less. Treat an empty list the same as any other invalid/incomplete
+  // request: degrade to null (collection warning, exact-title-only) rather
+  // than silently accepting zero bundles as "all resolved".
+  if (bundleIds.length === 0) {
+    return null;
+  }
   try {
     const manifest = JSON.parse(
       readFileSync(resolve(process.cwd(), manifestPath), 'utf8'),

--- a/src/scripts/supersession-detection.mts
+++ b/src/scripts/supersession-detection.mts
@@ -1,0 +1,260 @@
+// idd-generated-from: src/scripts/supersession-detection.mts
+//
+// The scripts/supersession-detection.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// The #1484 high-confidence supersession-detection kernel (#1499): a
+// mechanical "is this issue already superseded by a merged PR" evaluator,
+// plus its read-only `gh` argv-builders, extracted out of
+// `suitability-triage.mts` so a future B2.0 mechanization
+// (`idd-work.instructions.md`'s post-claim supersession re-check, currently
+// prose-only) can reuse this kernel directly instead of duplicating it in a
+// second file. `suitability-triage.mts` is Check 4's only current consumer;
+// nothing here depends on it, so this module carries no import back to it
+// (a future consumer never needs to pull in suitability-triage.mts's whole
+// 7-check CLI just to reuse the kernel).
+//
+// Pure and I/O-free: `evaluateHighConfidenceDuplicate` only evaluates
+// already-collected evidence, and the argv-builders only build `gh` command
+// arrays -- neither executes anything. The actual `gh` fetch/orchestration
+// (`fetchClosedByMergedPrNumbers`, `fetchMergedPrFileOverlapEvidence`, the
+// `MERGED_PR_SCAN_DEADLINE_MS` wall-clock budget) stays in
+// `suitability-triage.mts`'s own CLI glue, which the issue does not name as
+// part of the extraction.
+
+import { normalizeContentionPath } from './discover-shared-file-overlap.mts';
+
+/** Upper bound on the #1484 bounded merged-PR scan (mirrors B2.0's own
+ * documented `gh pr list --limit 50`). */
+const MERGED_PR_SCAN_LIMIT = 50;
+
+/**
+ * GraphQL query for the closed-by-merged-PR read (#1484), bounded to the
+ * first 50 closing-PR references. A later page could theoretically hold an
+ * additional MERGED reference this misses, but that only makes the tier
+ * under-detect (fall back to the weak heuristic) rather than over-detect --
+ * the safe fail direction for a check that must never fail TOWARD a false
+ * positive, so a full pagination loop (as `idd-roadmap-audit-execute.mts`'s
+ * `hasOpenClosingPr` implements for its own different, block-a-close use
+ * case) is not required here.
+ */
+const CLOSED_BY_MERGED_PR_QUERY = `query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      state
+      closedByPullRequestsReferences(first:50){
+        nodes { number state }
+      }
+    }
+  }
+}`;
+
+/** One merged PR's changed-file evidence for the high-confidence tier (#1484). */
+export interface HighConfidenceMergedPr {
+  number: number;
+  mergedAt: string;
+  files: string[];
+}
+
+/**
+ * Mechanical B2.0-style evidence for the Check 4 high-confidence tier
+ * (#1484): a candidate issue's own `closedByPullRequestsReferences`, plus a
+ * bounded merged-PR-vs-`## Candidate files` overlap scan. Reuses
+ * `discover-shared-file-overlap.mts`'s path normalization and high-contention
+ * set instead of re-implementing either. Every field is defensively
+ * re-validated by `evaluateHighConfidenceDuplicate` itself (not just at the
+ * caller's own options boundary), so a caller that hand-builds this shape
+ * directly can never crash it or manufacture a false hit from a malformed
+ * shape; a missing or malformed field just falls through to the caller's own
+ * weak heuristic unchanged.
+ */
+export interface HighConfidenceDuplicateInput {
+  closedByMergedPrNumbers: number[];
+  candidateFiles: string[];
+  /** High-contention files (bundle + manifest) excluded from the overlap
+   * check -- a coincidental hit on a broadly-shared file is not on its own
+   * high-confidence evidence that THIS issue was superseded. */
+  highContentionFiles: string[];
+  mergedPrs: HighConfidenceMergedPr[];
+}
+
+/**
+ * The result of evaluating one suitability check: whether it passed, the
+ * human-readable evidence, and -- for a fail -- an optional `tier`
+ * distinguishing a high-confidence mechanical hit (this kernel) from a weak
+ * heuristic hit (title/declaration matching). `tier` is only ever set on a
+ * fail; a pass has nothing to classify. Declared here rather than in
+ * `suitability-triage.mts` so this kernel's own return type and the caller's
+ * other six (non-Check-4) checks share one type instead of two
+ * structurally-identical ones, without `suitability-triage.mts` importing
+ * anything back into this module (which would create the exact circular
+ * import #1499 asks this extraction to avoid).
+ */
+export interface CheckOutcome {
+  pass: boolean;
+  evidence: string;
+  tier?: 'high-confidence' | 'weak';
+}
+
+/**
+ * High-confidence Check 4 tier (#1484): evaluate the mechanical B2.0-style
+ * signals -- a merged closing-PR reference on the candidate issue itself, or
+ * a merged PR that already changed one of the issue's own declared
+ * `## Candidate files` (excluding high-contention/shared files, which many
+ * unrelated issues touch and so are not on their own high-confidence
+ * evidence that THIS issue was superseded). Returns `null` -- never a
+ * synthesized verdict of its own -- whenever no strong signal fires, so the
+ * caller falls through to its own existing weak title/declaration heuristic
+ * unchanged. This is the fail-safe contract the issue requires: never fail
+ * TOWARD a false high-confidence flag. `input` may be `undefined` (evidence
+ * not collected by the caller) or a partially malformed shape; both degrade
+ * to "no verdict" rather than a crash or a false hit.
+ */
+export function evaluateHighConfidenceDuplicate(
+  input: HighConfidenceDuplicateInput | undefined,
+): CheckOutcome | null {
+  if (!input) {
+    return null;
+  }
+
+  const closedByMergedPrNumbers = (
+    Array.isArray(input.closedByMergedPrNumbers)
+      ? input.closedByMergedPrNumbers
+      : []
+  ).filter((n) => Number.isInteger(n) && n > 0);
+  if (closedByMergedPrNumbers.length > 0) {
+    return {
+      pass: false,
+      evidence: `High-confidence duplicate: issue is already referenced by merged closing PR(s) #${closedByMergedPrNumbers.join(', #')} (closedByPullRequestsReferences).`,
+      tier: 'high-confidence',
+    };
+  }
+
+  const highContention = new Set(
+    (Array.isArray(input.highContentionFiles)
+      ? input.highContentionFiles
+      : []
+    ).map((file) => normalizeContentionPath(file)),
+  );
+  const candidateFiles = [
+    ...new Set(
+      (Array.isArray(input.candidateFiles) ? input.candidateFiles : [])
+        .map((file) => normalizeContentionPath(file))
+        .filter((file) => file.length > 0 && !highContention.has(file)),
+    ),
+  ];
+  if (candidateFiles.length === 0) {
+    return null;
+  }
+  const candidateSet = new Set(candidateFiles);
+
+  const mergedPrs: unknown[] = Array.isArray(input.mergedPrs)
+    ? input.mergedPrs
+    : [];
+  for (const raw of mergedPrs) {
+    const pr = (raw ?? {}) as {
+      number?: unknown;
+      mergedAt?: unknown;
+      files?: unknown;
+    };
+    const number = Number(pr.number);
+    if (!Number.isInteger(number) || number <= 0) {
+      continue;
+    }
+    const files = Array.isArray(pr.files) ? pr.files : [];
+    const overlap = [
+      ...new Set(files.map((file) => normalizeContentionPath(file))),
+    ].filter((file) => candidateSet.has(file));
+    if (overlap.length > 0) {
+      const mergedAt = String(pr.mergedAt ?? '');
+      return {
+        pass: false,
+        evidence: `High-confidence duplicate: merged PR #${number}${mergedAt ? ` (merged ${mergedAt})` : ''} already changed candidate file(s): ${overlap.sort().join(', ')}.`,
+        tier: 'high-confidence',
+      };
+    }
+  }
+
+  return null;
+}
+
+// --- #1484: high-confidence Check 4 tier CLI glue ---------------------------
+// Read-only: every function below only ever builds argv for `gh api graphql`
+// (with a `query` operation, never `mutation`), `gh pr list`, or `gh pr view`
+// (no -X/--method, no issue/PR mutation subcommand) -- none of them execute
+// anything themselves. #1484 is detect-only by design; do not add a mutating
+// argv-builder here -- a later gated-close follow-up (#1485) is a separate,
+// human-gated change. The argv-builders are exported so tests can assert the
+// exact read-only verb without shelling out (a compiled-text grep for
+// mutating verb literals would miss a `gh api ... -X POST`-shaped mutation,
+// since none of these builders produce one).
+
+/**
+ * Argv for the closed-by-merged-PR read. Uses `gh api graphql` rather than
+ * `gh issue view --json closedByPullRequestsReferences`: the latter's
+ * REST-shimmed shape carries no per-PR `state`, and the connection includes
+ * OPEN (not yet merged) PRs, not only merged ones -- confirmed empirically
+ * against this repo's own issue #1489 (OPEN) / PR #1497 (OPEN), and matches
+ * `idd-roadmap-audit-execute.mts`'s documented note that the field "returns
+ * merged PRs even with `includeClosedPrs:false`" (i.e. state alone
+ * determines relevance, not that flag). Filtering to `state === 'MERGED'`
+ * happens in the caller, after this fetch -- without it, an issue with only
+ * an in-progress unmerged closing PR would wrongly read as "already
+ * referenced by a merged closing PR".
+ */
+export function buildClosedByMergedPrArgs(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): string[] {
+  return [
+    'api',
+    'graphql',
+    '-f',
+    `query=${CLOSED_BY_MERGED_PR_QUERY}`,
+    '-f',
+    `owner=${owner}`,
+    '-f',
+    `repo=${repo}`,
+    '-F',
+    `number=${issueNumber}`,
+  ];
+}
+
+/** Argv for the bounded merged-PR list scan (mirrors B2.0's own documented
+ * `gh pr list --search "merged:>=<since>"` shape). */
+export function buildMergedPrListArgs(
+  repoRef: string,
+  sinceIso: string,
+): string[] {
+  return [
+    'pr',
+    'list',
+    '--repo',
+    repoRef,
+    '--state',
+    'merged',
+    '--search',
+    `merged:>=${sinceIso}`,
+    '--json',
+    'number,mergedAt',
+    '--limit',
+    String(MERGED_PR_SCAN_LIMIT),
+  ];
+}
+
+/** Argv for one merged PR's changed-file list. */
+export function buildPrFilesArgs(repoRef: string, prNumber: number): string[] {
+  return [
+    'pr',
+    'view',
+    String(prNumber),
+    '--repo',
+    repoRef,
+    '--json',
+    'files',
+    '--jq',
+    '.files[].path',
+  ];
+}

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -934,6 +934,17 @@ test('loadHighContentionFiles: a bundle ID absent from the manifest returns null
   assert.equal(resolved, null);
 });
 
+test('loadHighContentionFiles: an empty bundleIds list returns null, not a vacuously-"complete" empty set', () => {
+  // Regression guard for a Copilot review finding on this PR: `[].every(...)`
+  // is vacuously true, so an empty list must not sail through the
+  // completeness check below and resolve to a set containing only
+  // extraFiles (the manifest path itself) -- that would make the
+  // high-confidence overlap scan MORE permissive, the opposite of this
+  // tier's fail-safe contract.
+  const resolved = loadHighContentionFiles(DEFAULT_MANIFEST_PATH, []);
+  assert.equal(resolved, null);
+});
+
 test('loadHighContentionFiles: an unreadable manifest path returns null', () => {
   const resolved = loadHighContentionFiles(
     'no/such/manifest.json',

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -1,10 +1,12 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 import {
-  buildClosedByMergedPrArgs,
-  buildMergedPrListArgs,
-  buildPrFilesArgs,
+  DEFAULT_BUNDLE_IDS,
+  DEFAULT_MANIFEST_PATH,
+} from '../src/scripts/discover-shared-file-overlap.mts';
+import {
   checkActionability,
   checkAutonomy,
   checkCoherence,
@@ -12,8 +14,8 @@ import {
   checkRepositoryFit,
   checkTrustSafety,
   checkVerifiability,
-  evaluateHighConfidenceDuplicate,
   evaluateSuitability,
+  loadHighContentionFiles,
   parseArgs,
 } from '../src/scripts/suitability-triage.mts';
 
@@ -71,6 +73,28 @@ test('parseArgs: rejects an unknown flag', () => {
 test('parseArgs: --help is recognized without requiring --issue', () => {
   const args = parseArgs(['--help']);
   assert.equal(args.help, true);
+});
+
+// --- #1499: --manifest / --bundles override surface -------------------------
+
+test('parseArgs: --manifest defaults to the shared DEFAULT_MANIFEST_PATH', () => {
+  const args = parseArgs([]);
+  assert.equal(args.manifest, DEFAULT_MANIFEST_PATH);
+});
+
+test('parseArgs: --manifest accepts an explicit override', () => {
+  const args = parseArgs(['--manifest', 'custom/manifest.json']);
+  assert.equal(args.manifest, 'custom/manifest.json');
+});
+
+test('parseArgs: --bundles is absent by default (null, not DEFAULT_BUNDLE_IDS)', () => {
+  const args = parseArgs([]);
+  assert.equal(args.bundles, null);
+});
+
+test('parseArgs: --bundles is comma-split and trimmed, mirroring discover-shared-file-overlap.mjs', () => {
+  const args = parseArgs(['--bundles', ' bundle-a, bundle-b ,,bundle-c']);
+  assert.deepEqual(args.bundles, ['bundle-a', 'bundle-b', 'bundle-c']);
 });
 
 // The check helpers only read the context fields each test supplies, so
@@ -622,138 +646,6 @@ test('duplicate check detects a URL-form duplicate declaration', () => {
   assert.equal(result.pass, false);
 });
 
-// --- #1484: high-confidence Check 4 tier ------------------------------------
-
-test('evaluateHighConfidenceDuplicate: undefined input is absent, not a hit', () => {
-  assert.equal(evaluateHighConfidenceDuplicate(undefined), null);
-});
-
-test('evaluateHighConfidenceDuplicate: empty arrays fall through (fail-safe)', () => {
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: [],
-    candidateFiles: [],
-    highContentionFiles: [],
-    mergedPrs: [],
-  });
-  assert.equal(result, null);
-});
-
-test('evaluateHighConfidenceDuplicate: malformed (non-array) fields never crash and never hit', () => {
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: 'not-an-array',
-    candidateFiles: null,
-    highContentionFiles: undefined,
-    mergedPrs: 42,
-  } as unknown as Context['highConfidenceDuplicate']);
-  assert.equal(result, null);
-});
-
-test('evaluateHighConfidenceDuplicate: closing-PR-reference hit cites the PR number', () => {
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: [123],
-    candidateFiles: [],
-    highContentionFiles: [],
-    mergedPrs: [],
-  });
-  assert.equal(result?.pass, false);
-  assert.match(result?.evidence ?? '', /#123/);
-  assert.match(result?.evidence ?? '', /closedByPullRequestsReferences/);
-});
-
-test('evaluateHighConfidenceDuplicate: same-candidate-files hit cites the PR number and file', () => {
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: [],
-    candidateFiles: ['scripts/foo.mjs'],
-    highContentionFiles: [],
-    mergedPrs: [
-      {
-        number: 456,
-        mergedAt: '2026-07-10T00:00:00Z',
-        files: ['scripts/foo.mjs', 'docs/unrelated.md'],
-      },
-    ],
-  });
-  assert.equal(result?.pass, false);
-  assert.match(result?.evidence ?? '', /#456/);
-  assert.match(result?.evidence ?? '', /scripts\/foo\.mjs/);
-  assert.doesNotMatch(result?.evidence ?? '', /unrelated\.md/);
-});
-
-test('evaluateHighConfidenceDuplicate: reuses normalizeContentionPath so mirrored instruction paths still match', () => {
-  // Same basename cited two different ways: the issue's own '## Candidate
-  // files' style (idd-template source path) vs. the merged PR's actual
-  // changed-file path (generated mirror). Proves real reuse of
-  // discover-shared-file-overlap's normalization, not a re-implementation
-  // that only matches identical strings.
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: [],
-    candidateFiles: [
-      'idd-template/.github/instructions/idd-work.instructions.md',
-    ],
-    highContentionFiles: [],
-    mergedPrs: [
-      {
-        number: 789,
-        mergedAt: '2026-07-11T00:00:00Z',
-        files: ['.github/instructions/idd-work.instructions.md'],
-      },
-    ],
-  });
-  assert.equal(result?.pass, false);
-  assert.match(result?.evidence ?? '', /#789/);
-});
-
-test('evaluateHighConfidenceDuplicate: a high-contention-only overlap is not high-confidence evidence', () => {
-  // The only shared file is in the high-contention exclusion set, so this
-  // must fall through (null), not fire -- a coincidental hit on a
-  // broadly-shared file is not evidence THIS issue was superseded.
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: [],
-    candidateFiles: ['audit/sync-manifest.json'],
-    highContentionFiles: ['audit/sync-manifest.json'],
-    mergedPrs: [
-      {
-        number: 999,
-        mergedAt: '2026-07-12T00:00:00Z',
-        files: ['audit/sync-manifest.json'],
-      },
-    ],
-  });
-  assert.equal(result, null);
-});
-
-test('evaluateHighConfidenceDuplicate: a genuine file still hits when a co-listed file is high-contention', () => {
-  // Regression guard for the exclusion filter being too aggressive: a
-  // candidate list with one high-contention file and one genuine file must
-  // still fire on the genuine file's overlap.
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: [],
-    candidateFiles: ['audit/sync-manifest.json', 'scripts/genuine.mjs'],
-    highContentionFiles: ['audit/sync-manifest.json'],
-    mergedPrs: [
-      {
-        number: 1000,
-        mergedAt: '2026-07-13T00:00:00Z',
-        files: ['audit/sync-manifest.json', 'scripts/genuine.mjs'],
-      },
-    ],
-  });
-  assert.equal(result?.pass, false);
-  assert.match(result?.evidence ?? '', /scripts\/genuine\.mjs/);
-  assert.doesNotMatch(result?.evidence ?? '', /sync-manifest\.json/);
-});
-
-test('evaluateHighConfidenceDuplicate: closing-PR-reference is checked before the file-overlap scan', () => {
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: [111],
-    candidateFiles: ['scripts/foo.mjs'],
-    highContentionFiles: [],
-    mergedPrs: [{ number: 222, mergedAt: '', files: ['unrelated.mjs'] }],
-  });
-  assert.match(result?.evidence ?? '', /#111/);
-  assert.doesNotMatch(result?.evidence ?? '', /#222/);
-});
-
 test('checkDuplicateOrSuperseded: high-confidence tier takes priority over the weak heuristic', () => {
   // Three supplied Context fields (vs. this file's usual one or two) makes
   // TypeScript's structural-cast "sufficient overlap" check reject a direct
@@ -891,73 +783,149 @@ test('evaluateSuitability: a malformed highConfidenceDuplicate option is neutral
   });
 });
 
-// --- #1484: detect-only boundary (argv-builder read-verb assertions) -------
-// A compiled-text grep for mutating verb literals would miss a
-// `gh api ... -X POST`-shaped mutation, since none of this file's own calls
-// use one. Instead, assert directly on the argv each builder produces: the
-// gh subcommand-verb position (index 1) must be an allow-listed read verb,
-// and no mutating flag/verb literal appears anywhere in the argv.
-const READ_VERBS = new Set(['view', 'list']);
-const FORBIDDEN_TOKENS = new Set([
-  'close',
-  'comment',
-  'edit',
-  'merge',
-  'reopen',
-  'delete',
-  '-X',
-  '--method',
-]);
+// --- #1499: typed tier field on the weak-heuristic fail paths --------------
+// evaluateHighConfidenceDuplicate's own tier: 'high-confidence' output is
+// covered directly in tests/supersession-detection.test.mts; these cover
+// the tier: 'weak' branches that stay local to checkDuplicateOrSuperseded
+// (declaration scan, exact-title, near-duplicate, degraded exact-title).
 
-function assertReadOnlyArgv(args: string[]): void {
-  if (args[0] === 'api') {
-    // gh api graphql: the payload must be a `query` operation, never a
-    // `mutation`, so check the actual `-f query=...` value rather than an
-    // allow-listed subcommand-verb position.
-    assert.equal(args[1], 'graphql');
-    const queryArg = args.find((arg) => arg.startsWith('query='));
-    assert.equal(typeof queryArg, 'string');
-    assert.match(queryArg ?? '', /^query=\s*query[\s(]/);
-    assert.doesNotMatch(queryArg ?? '', /\bmutation\b/);
-  } else {
-    assert.equal(args[0] === 'issue' || args[0] === 'pr', true);
-    assert.equal(READ_VERBS.has(args[1]), true);
-  }
-  for (const token of args) {
-    assert.equal(
-      FORBIDDEN_TOKENS.has(token),
-      false,
-      `unexpected mutating token "${token}" in argv: ${JSON.stringify(args)}`,
-    );
-  }
-}
+test('checkDuplicateOrSuperseded: an exact-title duplicate fail carries tier "weak"', () => {
+  const result = checkDuplicateOrSuperseded({
+    issue: BASE_ISSUE,
+    duplicateCandidates: [
+      { number: 9, title: BASE_ISSUE.title, state: 'OPEN' },
+    ] as Context['duplicateCandidates'],
+  } as Context);
+  assert.equal(result.pass, false);
+  assert.equal(result.tier, 'weak');
+});
 
-test('buildClosedByMergedPrArgs is read-only', () => {
-  assertReadOnlyArgv(
-    buildClosedByMergedPrArgs('kurone-kito', 'idd-skill', 1484),
+test('checkDuplicateOrSuperseded: a near-duplicate fail carries tier "weak"', () => {
+  const nearDuplicateTitle = `${BASE_ISSUE.title} extra`;
+  const result = checkDuplicateOrSuperseded({
+    issue: BASE_ISSUE,
+    duplicateCandidates: [
+      { number: 10, title: nearDuplicateTitle, state: 'OPEN' },
+    ] as Context['duplicateCandidates'],
+  } as Context);
+  assert.equal(result.pass, false);
+  assert.equal(result.tier, 'weak');
+});
+
+test('checkDuplicateOrSuperseded: a free-text declaration fail carries tier "weak"', () => {
+  const result = checkDuplicateOrSuperseded({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThis is a duplicate of #321.`,
+    },
+    duplicateCandidates: [] as Context['duplicateCandidates'],
+  } as Context);
+  assert.equal(result.pass, false);
+  assert.equal(result.tier, 'weak');
+});
+
+test('checkDuplicateOrSuperseded: a degraded exact-title fail carries tier "weak"', () => {
+  const result = checkDuplicateOrSuperseded({
+    issue: BASE_ISSUE,
+    duplicateCandidates: [
+      { number: 11, title: BASE_ISSUE.title, state: 'OPEN' },
+    ] as Context['duplicateCandidates'],
+    highConfidenceCollectionDegraded: true,
+  } as Context);
+  assert.equal(result.pass, false);
+  assert.equal(result.tier, 'weak');
+});
+
+test('checkDuplicateOrSuperseded: a pass carries no tier at all', () => {
+  const result = checkDuplicateOrSuperseded({
+    issue: BASE_ISSUE,
+    duplicateCandidates: [] as Context['duplicateCandidates'],
+  } as Context);
+  assert.equal(result.pass, true);
+  assert.equal(result.tier, undefined);
+});
+
+test('evaluateSuitability: non-verbose checks[] output still carries tier through', () => {
+  const result = evaluateSuitability(BASE_ISSUE, {
+    duplicateCandidates: [{ number: 12, title: BASE_ISSUE.title }],
+  });
+  const duplicateCheck = result.checks.find(
+    (check) => check.id === 'duplicate_or_superseded',
   );
+  assert.equal(duplicateCheck?.tier, 'weak');
 });
 
-test('buildClosedByMergedPrArgs requests state so callers can filter to MERGED', () => {
-  // Regression guard for a real bug caught by review: the REST-shimmed `gh
-  // issue view --json closedByPullRequestsReferences` carries no per-PR
-  // `state` and includes OPEN (not yet merged) PRs, not only merged ones.
-  // The GraphQL query built here must request `state` explicitly so
-  // fetchClosedByMergedPrNumbers can filter to MERGED before treating a hit
-  // as high-confidence evidence.
-  const args = buildClosedByMergedPrArgs('kurone-kito', 'idd-skill', 1484);
-  const queryArg = args.find((arg) => arg.startsWith('query=')) ?? '';
-  assert.match(queryArg, /closedByPullRequestsReferences/);
-  assert.match(queryArg, /\bstate\b/);
-  assert.match(queryArg, /\bnumber\b/);
-});
+// --- #1499: --manifest / --bundles override surface (loadHighContentionFiles) ----
+// loadHighContentionFiles reads a real file (readFileSync), so these exercise
+// it against this repository's own real audit/sync-manifest.json rather than
+// an in-memory fixture -- `bundle-discovery` is a real, non-default bundle
+// whose file set is disjoint enough from DEFAULT_BUNDLE_IDS
+// (bundle-review/bundle-merge) to prove the override genuinely changes the
+// resolved exclusion set, not just accepts the flag syntactically.
 
-test('buildMergedPrListArgs is read-only', () => {
-  assertReadOnlyArgv(
-    buildMergedPrListArgs('kurone-kito/idd-skill', '2026-07-01T00:00:00Z'),
+test('loadHighContentionFiles: default bundle IDs resolve merge-bundle files, not discovery-bundle files', () => {
+  const resolved = loadHighContentionFiles(
+    DEFAULT_MANIFEST_PATH,
+    DEFAULT_BUNDLE_IDS,
   );
+  assert.notEqual(resolved, null);
+  assert.equal(resolved?.includes('idd-merge.instructions.md'), true);
+  assert.equal(resolved?.includes('idd-discover.instructions.md'), false);
 });
 
-test('buildPrFilesArgs is read-only', () => {
-  assertReadOnlyArgv(buildPrFilesArgs('kurone-kito/idd-skill', 1492));
+test('loadHighContentionFiles: a --bundles override resolves that bundle instead of the default', () => {
+  // Regression guard for the #1499 bug: this must validate against the
+  // REQUESTED bundle ID (bundle-discovery), not the hardcoded
+  // DEFAULT_BUNDLE_IDS -- with the pre-#1499 hardcoded validation this would
+  // incorrectly return null (bundle-discovery is absent from
+  // DEFAULT_BUNDLE_IDS's completeness check).
+  const resolved = loadHighContentionFiles(DEFAULT_MANIFEST_PATH, [
+    'bundle-discovery',
+  ]);
+  assert.notEqual(resolved, null);
+  assert.equal(resolved?.includes('idd-discover.instructions.md'), true);
+  assert.equal(resolved?.includes('idd-merge.instructions.md'), false);
+});
+
+test('loadHighContentionFiles: the manifest path itself is treated as high-contention (extraFiles: [manifestPath])', () => {
+  const resolved = loadHighContentionFiles(
+    DEFAULT_MANIFEST_PATH,
+    DEFAULT_BUNDLE_IDS,
+  );
+  assert.equal(resolved?.includes(DEFAULT_MANIFEST_PATH), true);
+});
+
+test('loadHighContentionFiles: a bundle ID absent from the manifest returns null (fail-safe, not an empty set)', () => {
+  const resolved = loadHighContentionFiles(DEFAULT_MANIFEST_PATH, [
+    'bundle-does-not-exist',
+  ]);
+  assert.equal(resolved, null);
+});
+
+test('loadHighContentionFiles: an unreadable manifest path returns null', () => {
+  const resolved = loadHighContentionFiles(
+    'no/such/manifest.json',
+    DEFAULT_BUNDLE_IDS,
+  );
+  assert.equal(resolved, null);
+});
+
+// --- #1499: wiring call-site pin --------------------------------------------
+// loadHighContentionFiles is proven correct in isolation above; the one
+// remaining risk is the real runCli call site silently reverting to the
+// hardcoded defaults instead of forwarding args.manifest / args.bundles --
+// a regression with no other test coverage. Mirrors this repo's own
+// established "cover the call site, not just the extracted helper" pattern
+// (see idd-skill#1810's resolveClaimEvidence structural pin in
+// tests/advisory-convergence.test.mts).
+
+test('runCli forwards args.manifest / args.bundles into loadHighContentionFiles (wiring check)', () => {
+  const source = readFileSync(
+    new URL('../src/scripts/suitability-triage.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /loadHighContentionFiles\(\s*args\.manifest,\s*args\.bundles\s*\?\?\s*DEFAULT_BUNDLE_IDS,?\s*\)/,
+  );
 });

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -845,7 +845,13 @@ test('checkDuplicateOrSuperseded: a pass carries no tier at all', () => {
   assert.equal(result.tier, undefined);
 });
 
-test('evaluateSuitability: non-verbose checks[] output still carries tier through', () => {
+test('evaluateSuitability: checks[] threads tier through from the failing check', () => {
+  // Note: evaluateSuitability's own return shape (SuitabilityResult.checks)
+  // is what this asserts -- not runCli's separate verbose/non-verbose JSON
+  // output mapping, which is covered by the two tests below instead (E2
+  // self-review finding: an earlier version of this test's name implied it
+  // covered the non-verbose mapping, but it only exercised the pre-mapping
+  // checks[] array).
   const result = evaluateSuitability(BASE_ISSUE, {
     duplicateCandidates: [{ number: 12, title: BASE_ISSUE.title }],
   });
@@ -853,6 +859,32 @@ test('evaluateSuitability: non-verbose checks[] output still carries tier throug
     (check) => check.id === 'duplicate_or_superseded',
   );
   assert.equal(duplicateCheck?.tier, 'weak');
+});
+
+// --- #1499: runCli's verbose/non-verbose JSON mapping (wiring check) -------
+// runCli itself isn't unit-tested (real gh I/O), so -- mirroring the
+// loadHighContentionFiles wiring pin above -- these are structural pins on
+// the source text proving both mapping branches actually carry `tier`
+// through, rather than only the pre-mapping evaluateSuitability output
+// tested above.
+
+test('runCli: verbose output passes result.checks through unchanged (tier included)', () => {
+  const source = readFileSync(
+    new URL('../src/scripts/suitability-triage.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(source, /checks: args\.verbose\s*\n\s*\? result\.checks/);
+});
+
+test('runCli: non-verbose output mapping still spreads tier when present', () => {
+  const source = readFileSync(
+    new URL('../src/scripts/suitability-triage.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /result: check\.result,[\s\S]{0,400}\.\.\.\(check\.tier \? \{ tier: check\.tier \} : \{\}\)/,
+  );
 });
 
 // --- #1499: --manifest / --bundles override surface (loadHighContentionFiles) ----

--- a/tests/supersession-detection.test.mts
+++ b/tests/supersession-detection.test.mts
@@ -1,0 +1,249 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  buildClosedByMergedPrArgs,
+  buildMergedPrListArgs,
+  buildPrFilesArgs,
+  evaluateHighConfidenceDuplicate,
+} from '../src/scripts/supersession-detection.mts';
+
+// --- #1499: relocated from tests/suitability-triage.test.mts ---------------
+// evaluateHighConfidenceDuplicate and the three argv-builders moved out of
+// suitability-triage.mts into this shared module (#1499); these tests move
+// with them -- import path only, assertion bodies unchanged (#1499's own
+// acceptance criteria explicitly allow this). checkDuplicateOrSuperseded /
+// evaluateSuitability integration tests that exercise Check 4 through the
+// still-local checkDuplicateOrSuperseded stay in
+// tests/suitability-triage.test.mts.
+
+// --- #1484: high-confidence Check 4 tier ------------------------------------
+
+test('evaluateHighConfidenceDuplicate: undefined input is absent, not a hit', () => {
+  assert.equal(evaluateHighConfidenceDuplicate(undefined), null);
+});
+
+test('evaluateHighConfidenceDuplicate: empty arrays fall through (fail-safe)', () => {
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: [],
+    candidateFiles: [],
+    highContentionFiles: [],
+    mergedPrs: [],
+  });
+  assert.equal(result, null);
+});
+
+test('evaluateHighConfidenceDuplicate: malformed (non-array) fields never crash and never hit', () => {
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: 'not-an-array',
+    candidateFiles: null,
+    highContentionFiles: undefined,
+    mergedPrs: 42,
+  } as unknown as Parameters<typeof evaluateHighConfidenceDuplicate>[0]);
+  assert.equal(result, null);
+});
+
+test('evaluateHighConfidenceDuplicate: closing-PR-reference hit cites the PR number', () => {
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: [123],
+    candidateFiles: [],
+    highContentionFiles: [],
+    mergedPrs: [],
+  });
+  assert.equal(result?.pass, false);
+  assert.match(result?.evidence ?? '', /#123/);
+  assert.match(result?.evidence ?? '', /closedByPullRequestsReferences/);
+});
+
+test('evaluateHighConfidenceDuplicate: same-candidate-files hit cites the PR number and file', () => {
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: [],
+    candidateFiles: ['scripts/foo.mjs'],
+    highContentionFiles: [],
+    mergedPrs: [
+      {
+        number: 456,
+        mergedAt: '2026-07-10T00:00:00Z',
+        files: ['scripts/foo.mjs', 'docs/unrelated.md'],
+      },
+    ],
+  });
+  assert.equal(result?.pass, false);
+  assert.match(result?.evidence ?? '', /#456/);
+  assert.match(result?.evidence ?? '', /scripts\/foo\.mjs/);
+  assert.doesNotMatch(result?.evidence ?? '', /unrelated\.md/);
+});
+
+test('evaluateHighConfidenceDuplicate: reuses normalizeContentionPath so mirrored instruction paths still match', () => {
+  // Same basename cited two different ways: the issue's own '## Candidate
+  // files' style (idd-template source path) vs. the merged PR's actual
+  // changed-file path (generated mirror). Proves real reuse of
+  // discover-shared-file-overlap's normalization, not a re-implementation
+  // that only matches identical strings.
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: [],
+    candidateFiles: [
+      'idd-template/.github/instructions/idd-work.instructions.md',
+    ],
+    highContentionFiles: [],
+    mergedPrs: [
+      {
+        number: 789,
+        mergedAt: '2026-07-11T00:00:00Z',
+        files: ['.github/instructions/idd-work.instructions.md'],
+      },
+    ],
+  });
+  assert.equal(result?.pass, false);
+  assert.match(result?.evidence ?? '', /#789/);
+});
+
+test('evaluateHighConfidenceDuplicate: a high-contention-only overlap is not high-confidence evidence', () => {
+  // The only shared file is in the high-contention exclusion set, so this
+  // must fall through (null), not fire -- a coincidental hit on a
+  // broadly-shared file is not evidence THIS issue was superseded.
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: [],
+    candidateFiles: ['audit/sync-manifest.json'],
+    highContentionFiles: ['audit/sync-manifest.json'],
+    mergedPrs: [
+      {
+        number: 999,
+        mergedAt: '2026-07-12T00:00:00Z',
+        files: ['audit/sync-manifest.json'],
+      },
+    ],
+  });
+  assert.equal(result, null);
+});
+
+test('evaluateHighConfidenceDuplicate: a genuine file still hits when a co-listed file is high-contention', () => {
+  // Regression guard for the exclusion filter being too aggressive: a
+  // candidate list with one high-contention file and one genuine file must
+  // still fire on the genuine file's overlap.
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: [],
+    candidateFiles: ['audit/sync-manifest.json', 'scripts/genuine.mjs'],
+    highContentionFiles: ['audit/sync-manifest.json'],
+    mergedPrs: [
+      {
+        number: 1000,
+        mergedAt: '2026-07-13T00:00:00Z',
+        files: ['audit/sync-manifest.json', 'scripts/genuine.mjs'],
+      },
+    ],
+  });
+  assert.equal(result?.pass, false);
+  assert.match(result?.evidence ?? '', /scripts\/genuine\.mjs/);
+  assert.doesNotMatch(result?.evidence ?? '', /sync-manifest\.json/);
+});
+
+test('evaluateHighConfidenceDuplicate: closing-PR-reference is checked before the file-overlap scan', () => {
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: [111],
+    candidateFiles: ['scripts/foo.mjs'],
+    highContentionFiles: [],
+    mergedPrs: [{ number: 222, mergedAt: '', files: ['unrelated.mjs'] }],
+  });
+  assert.match(result?.evidence ?? '', /#111/);
+  assert.doesNotMatch(result?.evidence ?? '', /#222/);
+});
+
+// --- #1499: typed tier field -------------------------------------------------
+
+test('evaluateHighConfidenceDuplicate: a closing-PR-reference hit carries tier "high-confidence"', () => {
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: [42],
+    candidateFiles: [],
+    highContentionFiles: [],
+    mergedPrs: [],
+  });
+  assert.equal(result?.tier, 'high-confidence');
+});
+
+test('evaluateHighConfidenceDuplicate: a same-candidate-files hit carries tier "high-confidence"', () => {
+  const result = evaluateHighConfidenceDuplicate({
+    closedByMergedPrNumbers: [],
+    candidateFiles: ['scripts/foo.mjs'],
+    highContentionFiles: [],
+    mergedPrs: [
+      {
+        number: 456,
+        mergedAt: '2026-07-10T00:00:00Z',
+        files: ['scripts/foo.mjs'],
+      },
+    ],
+  });
+  assert.equal(result?.tier, 'high-confidence');
+});
+
+// --- #1484: detect-only boundary (argv-builder read-verb assertions) -------
+// A compiled-text grep for mutating verb literals would miss a
+// `gh api ... -X POST`-shaped mutation, since none of this file's own calls
+// use one. Instead, assert directly on the argv each builder produces: the
+// gh subcommand-verb position (index 1) must be an allow-listed read verb,
+// and no mutating flag/verb literal appears anywhere in the argv.
+const READ_VERBS = new Set(['view', 'list']);
+const FORBIDDEN_TOKENS = new Set([
+  'close',
+  'comment',
+  'edit',
+  'merge',
+  'reopen',
+  'delete',
+  '-X',
+  '--method',
+]);
+
+function assertReadOnlyArgv(args: string[]): void {
+  if (args[0] === 'api') {
+    // gh api graphql: the payload must be a `query` operation, never a
+    // `mutation`, so check the actual `-f query=...` value rather than an
+    // allow-listed subcommand-verb position.
+    assert.equal(args[1], 'graphql');
+    const queryArg = args.find((arg) => arg.startsWith('query='));
+    assert.equal(typeof queryArg, 'string');
+    assert.match(queryArg ?? '', /^query=\s*query[\s(]/);
+    assert.doesNotMatch(queryArg ?? '', /\bmutation\b/);
+  } else {
+    assert.equal(args[0] === 'issue' || args[0] === 'pr', true);
+    assert.equal(READ_VERBS.has(args[1]), true);
+  }
+  for (const token of args) {
+    assert.equal(
+      FORBIDDEN_TOKENS.has(token),
+      false,
+      `unexpected mutating token "${token}" in argv: ${JSON.stringify(args)}`,
+    );
+  }
+}
+
+test('buildClosedByMergedPrArgs is read-only', () => {
+  assertReadOnlyArgv(
+    buildClosedByMergedPrArgs('kurone-kito', 'idd-skill', 1484),
+  );
+});
+
+test('buildClosedByMergedPrArgs requests state so callers can filter to MERGED', () => {
+  // Regression guard for a real bug caught by review: the REST-shimmed `gh
+  // issue view --json closedByPullRequestsReferences` carries no per-PR
+  // `state` and includes OPEN (not yet merged) PRs, not only merged ones.
+  // The GraphQL query built here must request `state` explicitly so the
+  // caller can filter to MERGED before treating a hit as high-confidence
+  // evidence.
+  const args = buildClosedByMergedPrArgs('kurone-kito', 'idd-skill', 1484);
+  const queryArg = args.find((arg) => arg.startsWith('query=')) ?? '';
+  assert.match(queryArg, /closedByPullRequestsReferences/);
+  assert.match(queryArg, /\bstate\b/);
+  assert.match(queryArg, /\bnumber\b/);
+});
+
+test('buildMergedPrListArgs is read-only', () => {
+  assertReadOnlyArgv(
+    buildMergedPrListArgs('kurone-kito/idd-skill', '2026-07-01T00:00:00Z'),
+  );
+});
+
+test('buildPrFilesArgs is read-only', () => {
+  assertReadOnlyArgv(buildPrFilesArgs('kurone-kito/idd-skill', 1492));
+});


### PR DESCRIPTION
## Summary

`evaluateHighConfidenceDuplicate` and its three `gh` argv-builders
(`buildClosedByMergedPrArgs`, `buildMergedPrListArgs`,
`buildPrFilesArgs`) implement a general-purpose "is this issue already
superseded by a merged PR" algorithm but lived entirely inside
`src/scripts/suitability-triage.mts`, whose public contract is Check
4's shape. This PR:

- Extracts that kernel (plus its supporting types and the
  `CheckOutcome` shape) into a new `src/scripts/supersession-detection.mts`
  module that `suitability-triage.mts` now imports from, so a future
  B2.0 mechanization (`idd-work.instructions.md`'s post-claim
  supersession re-check, currently prose-only) can reuse it directly
  instead of duplicating it in a second file.
- Fixes a real correctness-drift bug: `loadHighContentionFiles()`
  hardcoded `DEFAULT_MANIFEST_PATH`/`DEFAULT_BUNDLE_IDS` with no
  override, so a repository that customizes its A4 Step 2
  high-contention bundles silently got a stale Check-4 exclusion set.
  New `--manifest`/`--bundles` CLI flags (mirroring
  `discover-shared-file-overlap.mjs`'s own) fix this, and
  `loadHighContentionFiles` now validates completeness against the
  *requested* bundle IDs instead of the hardcoded default.
- Adds a typed `tier: 'high-confidence' | 'weak'` field to the
  check-result shape so a future consumer can branch on Check 4's
  confidence level without parsing evidence prose.

### Module-location decision

The issue offered two options: a new neutral shared module, or
promoting `discover-shared-file-overlap.mts` into that shared home
("whichever keeps the diff smaller and avoids a circular import"). I
initially leaned toward promoting `discover-shared-file-overlap.mts`
(zero new files), but that file is already the thing the issue's own
Background section names as the *problem* — "the high-contention-file
concept crossed from `discover-shared-file-overlap.mts` into
`suitability-triage.mts` via three bare exported constants rather than
a shared config/concept module." Piling the duplicate-detection kernel
into `discover-shared-file-overlap.mts` too would extend that same
complaint to a second, unrelated concept living in a file whose name
and identity is specific to A4 Step 2's overlap detection.

This PR creates `src/scripts/supersession-detection.mts` instead. It
imports `normalizeContentionPath` from `discover-shared-file-overlap.mts`
(one directional edge, no cycle back). The high-contention-file
constants (`DEFAULT_MANIFEST_PATH` / `DEFAULT_BUNDLE_IDS` /
`DEFAULT_EXTRA_FILES`, `resolveHighContentionFiles`) stay where they
already are in `discover-shared-file-overlap.mts` — that reuse path
was not the part of the design the issue flagged as a problem.

## Test plan

- [x] `pnpm exec tsc -p tsconfig.build.json --noEmit` and
      `tsconfig.json --noEmit` — clean
- [x] `pnpm run build` / `pnpm run build:check` — no drift
- [x] `pnpm run test` — 3076/3076 passing
- [x] `pre-push-validate` (biome, dprint, markdownlint, cspell,
      audit-docs, audit-code-span-wrap, build:check, idd-doctor) —
      passes with only pre-existing environment warnings
- [x] Existing `tests/suitability-triage.test.mts` and
      `tests/discover-shared-file-overlap.test.mts` assertions pass
      unmodified (only import paths moved for the relocated
      `evaluateHighConfidenceDuplicate`/argv-builder tests, now in a
      new `tests/supersession-detection.test.mts`)
- [x] New tests cover: the extraction (imported directly from the
      shared module), the `--manifest`/`--bundles` override surface
      (including a structural pin proving `runCli` actually forwards
      `args.manifest`/`args.bundles` into `loadHighContentionFiles`),
      and the `tier` field on both the high-confidence and weak fail
      paths

Closes #1499

Refs #1484, #1815

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDax6DgRUhGyzEg23mpk6B
