### PR TITLE
fix(advisory-convergence): reject non-boolean claim-evidence inputs

### DIFF
--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -178,8 +178,22 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   // the applicability gate can tell a genuinely non-IDD PR apart from an
   // IDD-shaped PR whose claim linkage is currently broken. See each field's
   // own doc comment on `AdvisoryConvergenceInputs` for the full rationale.
-  const claimMarkerHistoryPresent = inputs.claimMarkerHistoryPresent === true;
-  const claimCandidateAmbiguous = inputs.claimCandidateAmbiguous === true;
+  //
+  // #1821: the TS type already requires both fields at compile time, but
+  // that guard is erased at emit -- an untyped caller of the exported
+  // `.mjs` (or a hand-written JS caller) can still pass `undefined` or a
+  // non-boolean value through. Reject that here instead of silently
+  // coercing it to `false`, matching this function's existing
+  // error-handling convention for invalid inputs (see the `now` /
+  // `prHeadSha` validation above).
+  if (typeof inputs.claimMarkerHistoryPresent !== 'boolean') {
+    throw new Error('claimMarkerHistoryPresent must be a boolean');
+  }
+  if (typeof inputs.claimCandidateAmbiguous !== 'boolean') {
+    throw new Error('claimCandidateAmbiguous must be a boolean');
+  }
+  const claimMarkerHistoryPresent = inputs.claimMarkerHistoryPresent;
+  const claimCandidateAmbiguous = inputs.claimCandidateAmbiguous;
   const applicability =
     convergenceScope === 'idd-claimed'
       ? !claim.activeClaimPresent

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -425,7 +425,11 @@ export interface AdvisoryConvergenceInputs {
    * reason wins -- an ambiguous set of candidates trivially also has claim
    * history (an active claim cannot exist without a valid marker), so the
    * two fields are not mutually exclusive; the check order is what makes
-   * the reported `reason` precise. */
+   * the reported `reason` precise. Validated the same way
+   * `claimMarkerHistoryPresent` is -- an untyped `.mjs` caller that omits
+   * it (or passes a non-boolean) is rejected at runtime with a thrown
+   * `Error` instead of silently coercing to `false`
+   * (kurone-kito/idd-skill#1821). */
   claimCandidateAmbiguous: boolean;
 }
 

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -409,8 +409,9 @@ export interface AdvisoryConvergenceInputs {
    * `resolveClaimEvidence`, so an omitted field on this typed interface
    * would signal a broken forwarding path, not a legitimate "no history"
    * case (kurone-kito/idd-skill#1814). An untyped JS caller of the emitted
-   * `.mjs` that still omits it gets the same effective `false` at runtime,
-   * since it is read below as `inputs.claimMarkerHistoryPresent === true`. */
+   * `.mjs` that omits it (or passes a non-boolean) is rejected at runtime
+   * with a thrown `Error` instead of silently coercing to `false`
+   * (kurone-kito/idd-skill#1821). */
   claimMarkerHistoryPresent: boolean;
   /** #1686: true when two or more of the PR's candidate claim issues each
    * independently resolve an ACTIVE trusted claim -- the disambiguation
@@ -569,8 +570,22 @@ export function computeAdvisoryConvergenceVerdict(
   // the applicability gate can tell a genuinely non-IDD PR apart from an
   // IDD-shaped PR whose claim linkage is currently broken. See each field's
   // own doc comment on `AdvisoryConvergenceInputs` for the full rationale.
-  const claimMarkerHistoryPresent = inputs.claimMarkerHistoryPresent === true;
-  const claimCandidateAmbiguous = inputs.claimCandidateAmbiguous === true;
+  //
+  // #1821: the TS type already requires both fields at compile time, but
+  // that guard is erased at emit -- an untyped caller of the exported
+  // `.mjs` (or a hand-written JS caller) can still pass `undefined` or a
+  // non-boolean value through. Reject that here instead of silently
+  // coercing it to `false`, matching this function's existing
+  // error-handling convention for invalid inputs (see the `now` /
+  // `prHeadSha` validation above).
+  if (typeof inputs.claimMarkerHistoryPresent !== 'boolean') {
+    throw new Error('claimMarkerHistoryPresent must be a boolean');
+  }
+  if (typeof inputs.claimCandidateAmbiguous !== 'boolean') {
+    throw new Error('claimCandidateAmbiguous must be a boolean');
+  }
+  const claimMarkerHistoryPresent = inputs.claimMarkerHistoryPresent;
+  const claimCandidateAmbiguous = inputs.claimCandidateAmbiguous;
   const applicability: AdvisoryConvergenceApplicability =
     convergenceScope === 'idd-claimed'
       ? !claim.activeClaimPresent

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -349,6 +349,53 @@ test('idd-claimed scope: a stale trusted claim (claim-marker history present, no
   assert.equal(verdict.ready, false);
 });
 
+// --- claim-evidence runtime validation (#1821) ------------------------------
+// `claimMarkerHistoryPresent` / `claimCandidateAmbiguous` are required
+// `boolean` fields at the TS level (#1814), but that guard is erased at
+// emit -- an untyped caller of the exported `.mjs` can still pass
+// `undefined` or a non-boolean value through. These cases pin the runtime
+// rejection this issue adds, so it cannot silently regress back to the old
+// `=== true` coercion. `as never` bypasses the TS type that already
+// forbids constructing these bad inputs directly.
+
+test('computeAdvisoryConvergenceVerdict: rejects a non-boolean claimMarkerHistoryPresent instead of coercing it to false', () => {
+  assert.throws(
+    () =>
+      computeAdvisoryConvergenceVerdict(
+        baseInputs({ claimMarkerHistoryPresent: undefined as never }),
+        baseOptions(),
+      ),
+    { message: 'claimMarkerHistoryPresent must be a boolean' },
+  );
+  assert.throws(
+    () =>
+      computeAdvisoryConvergenceVerdict(
+        baseInputs({ claimMarkerHistoryPresent: 'true' as never }),
+        baseOptions(),
+      ),
+    { message: 'claimMarkerHistoryPresent must be a boolean' },
+  );
+});
+
+test('computeAdvisoryConvergenceVerdict: rejects a non-boolean claimCandidateAmbiguous instead of coercing it to false', () => {
+  assert.throws(
+    () =>
+      computeAdvisoryConvergenceVerdict(
+        baseInputs({ claimCandidateAmbiguous: undefined as never }),
+        baseOptions(),
+      ),
+    { message: 'claimCandidateAmbiguous must be a boolean' },
+  );
+  assert.throws(
+    () =>
+      computeAdvisoryConvergenceVerdict(
+        baseInputs({ claimCandidateAmbiguous: 1 as never }),
+        baseOptions(),
+      ),
+    { message: 'claimCandidateAmbiguous must be a boolean' },
+  );
+});
+
 test('idd-claimed scope: a PR without a verified linked claim is not applicable', () => {
   const verdict = computeAdvisoryConvergenceVerdict(
     baseInputs({ reviews: [], claimEvents: [] }),


### PR DESCRIPTION
# Summary

`computeAdvisoryConvergenceVerdict` (`src/scripts/advisory-convergence.mts`)
previously coerced a missing or non-boolean
`claimMarkerHistoryPresent`/`claimCandidateAmbiguous` input to `false` via
`=== true`, silently treating a broken forwarding path the same as a
legitimate "no claim history" case. This PR validates both fields are
strict booleans at the point they are first read — right before
`applicability` is computed — and throws `Error('claimMarkerHistoryPresent
must be a boolean')` / `Error('claimCandidateAmbiguous must be a
boolean')` otherwise, matching this function's existing error-handling
convention for its other two inputs (`now` must be an ISO 8601 UTC
timestamp, `prHeadSha` must be a 40-character hex SHA — both already
`throw new Error(...)` near the top of the same function). The existing
ambiguity-first branch order in the `applicability` computation is
unchanged.

This is defense in depth for #1814/#1819 (CodeRabbit's finding on
[PR #1819](https://github.com/kurone-kito/idd-skill/pull/1819#discussion_r3697624277)):
the TS-level `boolean` requirement those PRs added is erased at emit, so
an untyped caller of the exported `scripts/advisory-convergence.mjs` (or
a hand-written JS caller) could still pass `undefined` or a non-boolean
value through unnoticed. Today's only production caller
(`collectFromGitHub` via `runAdvisoryConvergence`/`resolveClaimEvidence`)
already always forwards real booleans, so there is no live behavior
change for the current codebase — only a new runtime error for a
hypothetical broken/external caller.

Also updated the `claimMarkerHistoryPresent` doc comment, which
previously stated the old coercion behavior explicitly ("an untyped JS
caller ... gets the same effective `false` at runtime") — that sentence
is now false, so it was rewritten to describe the new throw.

Added two `assert.throws` cases to `tests/advisory-convergence.test.mts`
(matching the house pattern in `tests/cli-args.test.mts`) covering an
omitted value and a non-boolean truthy/falsy value for each field.

## Linked issue

Closes #1821

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

See Summary above — this closes the compile-time-only gap CodeRabbit
flagged on PR #1819.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`pnpm run lint:minimum`: typecheck, build:check, biome,
      dprint, `node --test tests/*.test.mts` (3060 pass), cspell,
      markdownlint — all clean)
- [x] `pnpm test` (covered by `pnpm lint` above)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs changed by this PR)
- [x] `node scripts/idd-doctor.mjs` (pre-existing warnings only, unrelated
      to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
