### PR TITLE
perf(suitability-triage): defer eager evidence collection until Check 4

### DIFF
--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -22,6 +22,8 @@ import {
   buildMergedPrListArgs,
   buildPrFilesArgs,
   evaluateHighConfidenceDuplicate,
+  findCandidateFileOverlap,
+  resolveCandidateFileSet,
 } from './supersession-detection.mjs';
 
 /**
@@ -688,6 +690,30 @@ function runCli() {
   const issue = fetchIssue(repoRef, args.issue);
   const duplicateCandidates = fetchDuplicateCandidates(repoRef, issue);
   const labelsPolicy = normalizePolicyConfig(loadPolicy(args.policy)).labels;
+  // #1815: repository_fit, coherence, and trust_safety are cheap, local,
+  // no-I/O checks that run before duplicate_or_superseded (Check 4) in
+  // evaluateSuitability's own CHECKS order, which short-circuits the whole
+  // 7-check loop on the first failure -- so collecting Check 4's
+  // network-heavy evidence below (closedByPullRequestsReferences, plus the
+  // up-to-50-sequential merged-PR file-overlap scan) is wasted work
+  // whenever one of the three already fails. Evaluate them here, against
+  // the same Context shape evaluateSuitability builds internally, purely to
+  // decide whether to collect that evidence at all -- evaluateSuitability
+  // below still re-runs all three (cheap, no I/O) as part of its own normal
+  // 7-check loop, so this changes only which network calls happen, never a
+  // check's pass/fail outcome (fetchDuplicateCandidates above stays eager:
+  // a single `gh api search/issues` call, not the network cost this issue
+  // targets).
+  const preEvidenceContext = {
+    issue,
+    repository: normalizeRepository({ owner, repo }),
+    duplicateCandidates: [],
+    trustSafetyAmbiguous: false,
+  };
+  const shouldCollectEvidence =
+    checkRepositoryFit(preEvidenceContext).pass &&
+    checkCoherence(preEvidenceContext).pass &&
+    checkTrustSafety(preEvidenceContext).pass;
   // #1484: high-confidence Check 4 tier evidence. The two mechanical signals
   // (closedByPullRequestsReferences, and the same-candidate-files merged-PR
   // scan) are collected in two SEPARATE try/catch blocks (CodeRabbit review
@@ -707,76 +733,84 @@ function runCli() {
   // 7-check evaluation (Codex review finding on this PR) -- this tier is an
   // optional enhancement layered onto Check 4, and Check 4's own documented
   // Edge Case ("Timeout on duplicate detection... fall back to exact title
-  // match only") already anticipates exactly this degradation.
+  // match only") already anticipates exactly this degradation. Both blocks
+  // below run only when `shouldCollectEvidence` is true (#1815) -- when it
+  // is false, Check 4 is never reached anyway, so `collectionWarnings`
+  // correctly stays empty (this is a deliberate skip, not a collection
+  // failure).
   const collectionWarnings = [];
   let closedByMergedPrNumbers = [];
-  try {
-    closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
-      owner,
-      repo,
-      args.issue,
-    );
-  } catch (error) {
-    collectionWarnings.push(
-      `closedByPullRequestsReferences: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
   let candidateFiles = [];
   let highContentionFiles = [];
   let mergedPrs = [];
-  try {
-    candidateFiles = parseCandidateFiles(issue.body);
-    // Only resolve the high-contention exclusion set (a file read + JSON
-    // parse) when there is a '## Candidate files' section to check it
-    // against -- most issues have none, and the result would otherwise be
-    // discarded.
-    const resolvedHighContentionFiles =
-      candidateFiles.length > 0
-        ? loadHighContentionFiles(
-            args.manifest,
-            args.bundles ?? DEFAULT_BUNDLE_IDS,
-          )
-        : null;
-    const shouldScanMergedPrs =
-      candidateFiles.length > 0 &&
-      resolvedHighContentionFiles !== null &&
-      issue.createdAt.length > 0;
-    highContentionFiles = resolvedHighContentionFiles ?? [];
-    if (candidateFiles.length > 0 && resolvedHighContentionFiles === null) {
-      // Codex P2 review finding: an unreadable/missing high-contention
-      // manifest silently skipped the same-candidate-files scan without
-      // recording a warning -- but from Check 4's perspective this is the
-      // same class of "high-confidence evidence could not be collected" as
-      // a genuine gh/API failure, and must degrade the same way (exact
-      // title match only), not let the full weak heuristic run.
+  if (shouldCollectEvidence) {
+    try {
+      closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
+        owner,
+        repo,
+        args.issue,
+      );
+    } catch (error) {
       collectionWarnings.push(
-        'same-candidate-files scan: high-contention manifest unavailable, skipping the scan',
+        `closedByPullRequestsReferences: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
-    if (shouldScanMergedPrs) {
-      const scanResult = fetchMergedPrFileOverlapEvidence(
-        repoRef,
-        issue.createdAt,
-      );
-      mergedPrs = scanResult.mergedPrs;
-      if (scanResult.truncatedByDeadline) {
-        // Codex P2 review finding: a deadline-truncated scan returns
-        // normally (not a throw), so it must record its own warning here --
-        // otherwise Check 4 would run the full weak heuristic on
-        // incomplete evidence instead of degrading to exact-title-only.
+    try {
+      candidateFiles = parseCandidateFiles(issue.body);
+      // Only resolve the high-contention exclusion set (a file read + JSON
+      // parse) when there is a '## Candidate files' section to check it
+      // against -- most issues have none, and the result would otherwise be
+      // discarded.
+      const resolvedHighContentionFiles =
+        candidateFiles.length > 0
+          ? loadHighContentionFiles(
+              args.manifest,
+              args.bundles ?? DEFAULT_BUNDLE_IDS,
+            )
+          : null;
+      const shouldScanMergedPrs =
+        candidateFiles.length > 0 &&
+        resolvedHighContentionFiles !== null &&
+        issue.createdAt.length > 0;
+      highContentionFiles = resolvedHighContentionFiles ?? [];
+      if (candidateFiles.length > 0 && resolvedHighContentionFiles === null) {
+        // Codex P2 review finding: an unreadable/missing high-contention
+        // manifest silently skipped the same-candidate-files scan without
+        // recording a warning -- but from Check 4's perspective this is the
+        // same class of "high-confidence evidence could not be collected" as
+        // a genuine gh/API failure, and must degrade the same way (exact
+        // title match only), not let the full weak heuristic run.
         collectionWarnings.push(
-          'same-candidate-files scan: truncated by MERGED_PR_SCAN_DEADLINE_MS before scanning every merged PR in the window',
+          'same-candidate-files scan: high-contention manifest unavailable, skipping the scan',
         );
       }
-    } else {
+      if (shouldScanMergedPrs) {
+        const scanResult = fetchMergedPrFileOverlapEvidence(
+          repoRef,
+          issue.createdAt,
+          candidateFiles,
+          highContentionFiles,
+        );
+        mergedPrs = scanResult.mergedPrs;
+        if (scanResult.truncatedByDeadline) {
+          // Codex P2 review finding: a deadline-truncated scan returns
+          // normally (not a throw), so it must record its own warning here --
+          // otherwise Check 4 would run the full weak heuristic on
+          // incomplete evidence instead of degrading to exact-title-only.
+          collectionWarnings.push(
+            'same-candidate-files scan: truncated by MERGED_PR_SCAN_DEADLINE_MS before scanning every merged PR in the window',
+          );
+        }
+      } else {
+        mergedPrs = [];
+      }
+    } catch (error) {
+      collectionWarnings.push(
+        `same-candidate-files scan: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      candidateFiles = [];
       mergedPrs = [];
     }
-  } catch (error) {
-    collectionWarnings.push(
-      `same-candidate-files scan: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    candidateFiles = [];
-    mergedPrs = [];
   }
   const highConfidenceDuplicate = {
     closedByMergedPrNumbers,
@@ -1116,12 +1150,35 @@ function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
  * still throws -- the caller (`runCli`) wraps this and its sibling fetch in
  * a separate try/catch so that surfaces as the same documented Check 4 Edge
  * Case fallback for just this signal, without discarding the other.
+ *
+ * `candidateFiles` / `highContentionFiles` (#1815) let the scan stop early:
+ * `evaluateHighConfidenceDuplicate` only needs the FIRST merged PR (in scan
+ * order) whose changed files overlap the exclusion-adjusted candidate set
+ * to return a high-confidence fail -- every PR after it would otherwise be
+ * fetched and then ignored. `resolveCandidateFileSet` /
+ * `findCandidateFileOverlap` (`supersession-detection.mts`) are the exact
+ * same helpers `evaluateHighConfidenceDuplicate` itself now uses, so the
+ * PR this loop stops on is provably the same PR the downstream evaluation
+ * would stop on -- no evidence-content change, only fewer PRs fetched.
+ * Exported (not just called) so `fetchMergedPrFileOverlapEvidence` can be
+ * unit-tested directly against a stubbed `gh` on `PATH`, the way this
+ * repo's other `gh`-calling functions are exercised (see
+ * `tests/gh-exec.test.mts` / `tests/discover-roadmap-graph.test.mts`).
  */
-function fetchMergedPrFileOverlapEvidence(repoRef, sinceIso) {
+export function fetchMergedPrFileOverlapEvidence(
+  repoRef,
+  sinceIso,
+  candidateFiles,
+  highContentionFiles,
+) {
   const list = ghJsonArray(buildMergedPrListArgs(repoRef, sinceIso));
   const mergedPrs = [];
   const deadline = Date.now() + MERGED_PR_SCAN_DEADLINE_MS;
   let truncatedByDeadline = false;
+  const candidateSet = resolveCandidateFileSet(
+    candidateFiles,
+    highContentionFiles,
+  );
   for (const entry of list) {
     if (Date.now() >= deadline) {
       truncatedByDeadline = true;
@@ -1137,6 +1194,16 @@ function fetchMergedPrFileOverlapEvidence(repoRef, sinceIso) {
       .map((line) => line.trim())
       .filter(Boolean);
     mergedPrs.push({ number, mergedAt: String(pr.mergedAt ?? ''), files });
+    if (findCandidateFileOverlap(files, candidateSet).length > 0) {
+      // Qualifying overlap found (#1815): stop -- see the doc comment
+      // above. Deliberately a plain `break`, NOT `truncatedByDeadline =
+      // true`: this is a complete, successful scan that found its answer
+      // early, not a scan cut short before finishing. Setting the flag
+      // here would wrongly push a `collectionWarnings` entry in `runCli`,
+      // which degrades Check 4 to exact-title-only -- silently turning a
+      // genuine high-confidence hit into a false pass.
+      break;
+    }
   }
   return { mergedPrs, truncatedByDeadline };
 }

--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -48,6 +48,44 @@ const CLOSED_BY_MERGED_PR_QUERY = `query($owner:String!,$repo:String!,$number:In
   }
 }`;
 /**
+ * Resolve the exclusion-adjusted candidate-file set: `candidateFiles`
+ * normalized via `normalizeContentionPath`, with `highContentionFiles`
+ * (bundle + manifest files many unrelated issues touch) removed. This is
+ * the same filter chain `evaluateHighConfidenceDuplicate` applies before its
+ * own merged-PR loop, extracted (#1815) so
+ * `suitability-triage.mts`'s `fetchMergedPrFileOverlapEvidence` scan can
+ * reuse the identical resolution to detect a qualifying overlap PR-by-PR --
+ * and stop fetching further PRs' file lists once one is found -- instead of
+ * duplicating this normalize-then-exclude logic in a second copy that could
+ * silently drift from this one.
+ */
+export function resolveCandidateFileSet(candidateFiles, highContentionFiles) {
+  const highContention = new Set(
+    highContentionFiles.map((file) => normalizeContentionPath(file)),
+  );
+  return new Set(
+    candidateFiles
+      .map((file) => normalizeContentionPath(file))
+      .filter((file) => file.length > 0 && !highContention.has(file)),
+  );
+}
+/**
+ * Return the subset of `files` present in `candidateSet`, normalized via
+ * `normalizeContentionPath` (the same normalization `resolveCandidateFileSet`
+ * builds the set with). Always empty when `candidateSet` is empty, mirroring
+ * `evaluateHighConfidenceDuplicate`'s own "no exclusion-adjusted candidate
+ * files at all" early return -- a caller never needs to special-case an
+ * empty set itself.
+ */
+export function findCandidateFileOverlap(files, candidateSet) {
+  if (candidateSet.size === 0) {
+    return [];
+  }
+  return [
+    ...new Set(files.map((file) => normalizeContentionPath(file))),
+  ].filter((file) => candidateSet.has(file));
+}
+/**
  * High-confidence Check 4 tier (#1484): evaluate the mechanical B2.0-style
  * signals -- a merged closing-PR reference on the candidate issue itself, or
  * a merged PR that already changed one of the issue's own declared
@@ -77,23 +115,13 @@ export function evaluateHighConfidenceDuplicate(input) {
       tier: 'high-confidence',
     };
   }
-  const highContention = new Set(
-    (Array.isArray(input.highContentionFiles)
-      ? input.highContentionFiles
-      : []
-    ).map((file) => normalizeContentionPath(file)),
+  const candidateSet = resolveCandidateFileSet(
+    Array.isArray(input.candidateFiles) ? input.candidateFiles : [],
+    Array.isArray(input.highContentionFiles) ? input.highContentionFiles : [],
   );
-  const candidateFiles = [
-    ...new Set(
-      (Array.isArray(input.candidateFiles) ? input.candidateFiles : [])
-        .map((file) => normalizeContentionPath(file))
-        .filter((file) => file.length > 0 && !highContention.has(file)),
-    ),
-  ];
-  if (candidateFiles.length === 0) {
+  if (candidateSet.size === 0) {
     return null;
   }
-  const candidateSet = new Set(candidateFiles);
   const mergedPrs = Array.isArray(input.mergedPrs) ? input.mergedPrs : [];
   for (const raw of mergedPrs) {
     const pr = raw ?? {};
@@ -102,9 +130,7 @@ export function evaluateHighConfidenceDuplicate(input) {
       continue;
     }
     const files = Array.isArray(pr.files) ? pr.files : [];
-    const overlap = [
-      ...new Set(files.map((file) => normalizeContentionPath(file))),
-    ].filter((file) => candidateSet.has(file));
+    const overlap = findCandidateFileOverlap(files, candidateSet);
     if (overlap.length > 0) {
       const mergedAt = String(pr.mergedAt ?? '');
       return {

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -25,8 +25,10 @@ import {
   buildPrFilesArgs,
   type CheckOutcome,
   evaluateHighConfidenceDuplicate,
+  findCandidateFileOverlap,
   type HighConfidenceDuplicateInput,
   type HighConfidenceMergedPr,
+  resolveCandidateFileSet,
 } from './supersession-detection.mts';
 
 /**
@@ -854,6 +856,31 @@ function runCli(): void {
   const duplicateCandidates = fetchDuplicateCandidates(repoRef, issue);
   const labelsPolicy = normalizePolicyConfig(loadPolicy(args.policy)).labels;
 
+  // #1815: repository_fit, coherence, and trust_safety are cheap, local,
+  // no-I/O checks that run before duplicate_or_superseded (Check 4) in
+  // evaluateSuitability's own CHECKS order, which short-circuits the whole
+  // 7-check loop on the first failure -- so collecting Check 4's
+  // network-heavy evidence below (closedByPullRequestsReferences, plus the
+  // up-to-50-sequential merged-PR file-overlap scan) is wasted work
+  // whenever one of the three already fails. Evaluate them here, against
+  // the same Context shape evaluateSuitability builds internally, purely to
+  // decide whether to collect that evidence at all -- evaluateSuitability
+  // below still re-runs all three (cheap, no I/O) as part of its own normal
+  // 7-check loop, so this changes only which network calls happen, never a
+  // check's pass/fail outcome (fetchDuplicateCandidates above stays eager:
+  // a single `gh api search/issues` call, not the network cost this issue
+  // targets).
+  const preEvidenceContext: Context = {
+    issue,
+    repository: normalizeRepository({ owner, repo }),
+    duplicateCandidates: [],
+    trustSafetyAmbiguous: false,
+  };
+  const shouldCollectEvidence =
+    checkRepositoryFit(preEvidenceContext).pass &&
+    checkCoherence(preEvidenceContext).pass &&
+    checkTrustSafety(preEvidenceContext).pass;
+
   // #1484: high-confidence Check 4 tier evidence. The two mechanical signals
   // (closedByPullRequestsReferences, and the same-candidate-files merged-PR
   // scan) are collected in two SEPARATE try/catch blocks (CodeRabbit review
@@ -873,77 +900,86 @@ function runCli(): void {
   // 7-check evaluation (Codex review finding on this PR) -- this tier is an
   // optional enhancement layered onto Check 4, and Check 4's own documented
   // Edge Case ("Timeout on duplicate detection... fall back to exact title
-  // match only") already anticipates exactly this degradation.
+  // match only") already anticipates exactly this degradation. Both blocks
+  // below run only when `shouldCollectEvidence` is true (#1815) -- when it
+  // is false, Check 4 is never reached anyway, so `collectionWarnings`
+  // correctly stays empty (this is a deliberate skip, not a collection
+  // failure).
   const collectionWarnings: string[] = [];
   let closedByMergedPrNumbers: number[] = [];
-  try {
-    closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
-      owner,
-      repo,
-      args.issue,
-    );
-  } catch (error) {
-    collectionWarnings.push(
-      `closedByPullRequestsReferences: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-
   let candidateFiles: string[] = [];
   let highContentionFiles: string[] = [];
   let mergedPrs: HighConfidenceMergedPr[] = [];
-  try {
-    candidateFiles = parseCandidateFiles(issue.body);
-    // Only resolve the high-contention exclusion set (a file read + JSON
-    // parse) when there is a '## Candidate files' section to check it
-    // against -- most issues have none, and the result would otherwise be
-    // discarded.
-    const resolvedHighContentionFiles =
-      candidateFiles.length > 0
-        ? loadHighContentionFiles(
-            args.manifest,
-            args.bundles ?? DEFAULT_BUNDLE_IDS,
-          )
-        : null;
-    const shouldScanMergedPrs =
-      candidateFiles.length > 0 &&
-      resolvedHighContentionFiles !== null &&
-      issue.createdAt.length > 0;
-    highContentionFiles = resolvedHighContentionFiles ?? [];
-    if (candidateFiles.length > 0 && resolvedHighContentionFiles === null) {
-      // Codex P2 review finding: an unreadable/missing high-contention
-      // manifest silently skipped the same-candidate-files scan without
-      // recording a warning -- but from Check 4's perspective this is the
-      // same class of "high-confidence evidence could not be collected" as
-      // a genuine gh/API failure, and must degrade the same way (exact
-      // title match only), not let the full weak heuristic run.
+
+  if (shouldCollectEvidence) {
+    try {
+      closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
+        owner,
+        repo,
+        args.issue,
+      );
+    } catch (error) {
       collectionWarnings.push(
-        'same-candidate-files scan: high-contention manifest unavailable, skipping the scan',
+        `closedByPullRequestsReferences: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
-    if (shouldScanMergedPrs) {
-      const scanResult = fetchMergedPrFileOverlapEvidence(
-        repoRef,
-        issue.createdAt,
-      );
-      mergedPrs = scanResult.mergedPrs;
-      if (scanResult.truncatedByDeadline) {
-        // Codex P2 review finding: a deadline-truncated scan returns
-        // normally (not a throw), so it must record its own warning here --
-        // otherwise Check 4 would run the full weak heuristic on
-        // incomplete evidence instead of degrading to exact-title-only.
+
+    try {
+      candidateFiles = parseCandidateFiles(issue.body);
+      // Only resolve the high-contention exclusion set (a file read + JSON
+      // parse) when there is a '## Candidate files' section to check it
+      // against -- most issues have none, and the result would otherwise be
+      // discarded.
+      const resolvedHighContentionFiles =
+        candidateFiles.length > 0
+          ? loadHighContentionFiles(
+              args.manifest,
+              args.bundles ?? DEFAULT_BUNDLE_IDS,
+            )
+          : null;
+      const shouldScanMergedPrs =
+        candidateFiles.length > 0 &&
+        resolvedHighContentionFiles !== null &&
+        issue.createdAt.length > 0;
+      highContentionFiles = resolvedHighContentionFiles ?? [];
+      if (candidateFiles.length > 0 && resolvedHighContentionFiles === null) {
+        // Codex P2 review finding: an unreadable/missing high-contention
+        // manifest silently skipped the same-candidate-files scan without
+        // recording a warning -- but from Check 4's perspective this is the
+        // same class of "high-confidence evidence could not be collected" as
+        // a genuine gh/API failure, and must degrade the same way (exact
+        // title match only), not let the full weak heuristic run.
         collectionWarnings.push(
-          'same-candidate-files scan: truncated by MERGED_PR_SCAN_DEADLINE_MS before scanning every merged PR in the window',
+          'same-candidate-files scan: high-contention manifest unavailable, skipping the scan',
         );
       }
-    } else {
+      if (shouldScanMergedPrs) {
+        const scanResult = fetchMergedPrFileOverlapEvidence(
+          repoRef,
+          issue.createdAt,
+          candidateFiles,
+          highContentionFiles,
+        );
+        mergedPrs = scanResult.mergedPrs;
+        if (scanResult.truncatedByDeadline) {
+          // Codex P2 review finding: a deadline-truncated scan returns
+          // normally (not a throw), so it must record its own warning here --
+          // otherwise Check 4 would run the full weak heuristic on
+          // incomplete evidence instead of degrading to exact-title-only.
+          collectionWarnings.push(
+            'same-candidate-files scan: truncated by MERGED_PR_SCAN_DEADLINE_MS before scanning every merged PR in the window',
+          );
+        }
+      } else {
+        mergedPrs = [];
+      }
+    } catch (error) {
+      collectionWarnings.push(
+        `same-candidate-files scan: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      candidateFiles = [];
       mergedPrs = [];
     }
-  } catch (error) {
-    collectionWarnings.push(
-      `same-candidate-files scan: ${error instanceof Error ? error.message : String(error)}`,
-    );
-    candidateFiles = [];
-    mergedPrs = [];
   }
 
   const highConfidenceDuplicate: SuitabilityOptions['highConfidenceDuplicate'] =
@@ -1373,15 +1409,35 @@ interface MergedPrFileOverlapScanResult {
  * still throws -- the caller (`runCli`) wraps this and its sibling fetch in
  * a separate try/catch so that surfaces as the same documented Check 4 Edge
  * Case fallback for just this signal, without discarding the other.
+ *
+ * `candidateFiles` / `highContentionFiles` (#1815) let the scan stop early:
+ * `evaluateHighConfidenceDuplicate` only needs the FIRST merged PR (in scan
+ * order) whose changed files overlap the exclusion-adjusted candidate set
+ * to return a high-confidence fail -- every PR after it would otherwise be
+ * fetched and then ignored. `resolveCandidateFileSet` /
+ * `findCandidateFileOverlap` (`supersession-detection.mts`) are the exact
+ * same helpers `evaluateHighConfidenceDuplicate` itself now uses, so the
+ * PR this loop stops on is provably the same PR the downstream evaluation
+ * would stop on -- no evidence-content change, only fewer PRs fetched.
+ * Exported (not just called) so `fetchMergedPrFileOverlapEvidence` can be
+ * unit-tested directly against a stubbed `gh` on `PATH`, the way this
+ * repo's other `gh`-calling functions are exercised (see
+ * `tests/gh-exec.test.mts` / `tests/discover-roadmap-graph.test.mts`).
  */
-function fetchMergedPrFileOverlapEvidence(
+export function fetchMergedPrFileOverlapEvidence(
   repoRef: string,
   sinceIso: string,
+  candidateFiles: string[],
+  highContentionFiles: string[],
 ): MergedPrFileOverlapScanResult {
   const list = ghJsonArray(buildMergedPrListArgs(repoRef, sinceIso));
   const mergedPrs: HighConfidenceMergedPr[] = [];
   const deadline = Date.now() + MERGED_PR_SCAN_DEADLINE_MS;
   let truncatedByDeadline = false;
+  const candidateSet = resolveCandidateFileSet(
+    candidateFiles,
+    highContentionFiles,
+  );
   for (const entry of list) {
     if (Date.now() >= deadline) {
       truncatedByDeadline = true;
@@ -1397,6 +1453,16 @@ function fetchMergedPrFileOverlapEvidence(
       .map((line) => line.trim())
       .filter(Boolean);
     mergedPrs.push({ number, mergedAt: String(pr.mergedAt ?? ''), files });
+    if (findCandidateFileOverlap(files, candidateSet).length > 0) {
+      // Qualifying overlap found (#1815): stop -- see the doc comment
+      // above. Deliberately a plain `break`, NOT `truncatedByDeadline =
+      // true`: this is a complete, successful scan that found its answer
+      // early, not a scan cut short before finishing. Setting the flag
+      // here would wrongly push a `collectionWarnings` entry in `runCli`,
+      // which degrades Check 4 to exact-title-only -- silently turning a
+      // genuine high-confidence hit into a false pass.
+      break;
+    }
   }
   return { mergedPrs, truncatedByDeadline };
 }

--- a/src/scripts/supersession-detection.mts
+++ b/src/scripts/supersession-detection.mts
@@ -98,6 +98,52 @@ export interface CheckOutcome {
 }
 
 /**
+ * Resolve the exclusion-adjusted candidate-file set: `candidateFiles`
+ * normalized via `normalizeContentionPath`, with `highContentionFiles`
+ * (bundle + manifest files many unrelated issues touch) removed. This is
+ * the same filter chain `evaluateHighConfidenceDuplicate` applies before its
+ * own merged-PR loop, extracted (#1815) so
+ * `suitability-triage.mts`'s `fetchMergedPrFileOverlapEvidence` scan can
+ * reuse the identical resolution to detect a qualifying overlap PR-by-PR --
+ * and stop fetching further PRs' file lists once one is found -- instead of
+ * duplicating this normalize-then-exclude logic in a second copy that could
+ * silently drift from this one.
+ */
+export function resolveCandidateFileSet(
+  candidateFiles: string[],
+  highContentionFiles: string[],
+): Set<string> {
+  const highContention = new Set(
+    highContentionFiles.map((file) => normalizeContentionPath(file)),
+  );
+  return new Set(
+    candidateFiles
+      .map((file) => normalizeContentionPath(file))
+      .filter((file) => file.length > 0 && !highContention.has(file)),
+  );
+}
+
+/**
+ * Return the subset of `files` present in `candidateSet`, normalized via
+ * `normalizeContentionPath` (the same normalization `resolveCandidateFileSet`
+ * builds the set with). Always empty when `candidateSet` is empty, mirroring
+ * `evaluateHighConfidenceDuplicate`'s own "no exclusion-adjusted candidate
+ * files at all" early return -- a caller never needs to special-case an
+ * empty set itself.
+ */
+export function findCandidateFileOverlap(
+  files: string[],
+  candidateSet: Set<string>,
+): string[] {
+  if (candidateSet.size === 0) {
+    return [];
+  }
+  return [
+    ...new Set(files.map((file) => normalizeContentionPath(file))),
+  ].filter((file) => candidateSet.has(file));
+}
+
+/**
  * High-confidence Check 4 tier (#1484): evaluate the mechanical B2.0-style
  * signals -- a merged closing-PR reference on the candidate issue itself, or
  * a merged PR that already changed one of the issue's own declared
@@ -131,23 +177,13 @@ export function evaluateHighConfidenceDuplicate(
     };
   }
 
-  const highContention = new Set(
-    (Array.isArray(input.highContentionFiles)
-      ? input.highContentionFiles
-      : []
-    ).map((file) => normalizeContentionPath(file)),
+  const candidateSet = resolveCandidateFileSet(
+    Array.isArray(input.candidateFiles) ? input.candidateFiles : [],
+    Array.isArray(input.highContentionFiles) ? input.highContentionFiles : [],
   );
-  const candidateFiles = [
-    ...new Set(
-      (Array.isArray(input.candidateFiles) ? input.candidateFiles : [])
-        .map((file) => normalizeContentionPath(file))
-        .filter((file) => file.length > 0 && !highContention.has(file)),
-    ),
-  ];
-  if (candidateFiles.length === 0) {
+  if (candidateSet.size === 0) {
     return null;
   }
-  const candidateSet = new Set(candidateFiles);
 
   const mergedPrs: unknown[] = Array.isArray(input.mergedPrs)
     ? input.mergedPrs
@@ -163,9 +199,7 @@ export function evaluateHighConfidenceDuplicate(
       continue;
     }
     const files = Array.isArray(pr.files) ? pr.files : [];
-    const overlap = [
-      ...new Set(files.map((file) => normalizeContentionPath(file))),
-    ].filter((file) => candidateSet.has(file));
+    const overlap = findCandidateFileOverlap(files, candidateSet);
     if (overlap.length > 0) {
       const mergedAt = String(pr.mergedAt ?? '');
       return {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
 
 import {
@@ -15,9 +17,50 @@ import {
   checkTrustSafety,
   checkVerifiability,
   evaluateSuitability,
+  fetchMergedPrFileOverlapEvidence,
   loadHighContentionFiles,
   parseArgs,
 } from '../src/scripts/suitability-triage.mts';
+
+// Stub `gh` on PATH with an invocation counter (the discover-roadmap-graph.
+// test.mts / gh-exec.test.mts pattern) so fetchMergedPrFileOverlapEvidence's
+// early exit (#1815) can be exercised against real argv without network
+// access, and so the test can assert exactly how many `gh` invocations
+// happened.
+function stubGhWithCounter(scriptBody: string): {
+  restore: () => void;
+  readCount: () => number;
+} {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-suitability-triage-test-'));
+  const ghPath = join(tempRoot, 'gh');
+  const counterFile = join(tempRoot, 'count');
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const counterFile = ${JSON.stringify(counterFile)};
+let count = 0;
+try {
+  count = Number(fs.readFileSync(counterFile, 'utf8').trim()) || 0;
+} catch {}
+count += 1;
+fs.writeFileSync(counterFile, String(count));
+const args = process.argv.slice(2);
+${scriptBody}
+process.stderr.write('unexpected gh invocation: ' + args.join(' ') + '\\n');
+process.exit(1);
+`,
+  );
+  chmodSync(ghPath, 0o755);
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${tempRoot}:${originalPath ?? ''}`;
+  return {
+    restore: () => {
+      process.env.PATH = originalPath;
+    },
+    readCount: () => Number(readFileSync(counterFile, 'utf8').trim()),
+  };
+}
 
 // --- #1450: migration onto the shared cli-args.mts wrapper -----------------
 
@@ -971,4 +1014,164 @@ test('runCli forwards args.manifest / args.bundles into loadHighContentionFiles 
     source,
     /loadHighContentionFiles\(\s*args\.manifest,\s*args\.bundles\s*\?\?\s*DEFAULT_BUNDLE_IDS,?\s*\)/,
   );
+});
+
+// --- #1815: defer Check 4 evidence collection until Check 4 is reached -----
+// runCli itself isn't unit-tested (real gh I/O, same rationale as the two
+// wiring checks above), so this is the same source-text structural pin
+// pattern: prove the two Check 4 evidence fetches (closedByPullRequestsReferences
+// and the same-candidate-files merged-PR scan) sit inside the
+// `shouldCollectEvidence` gate, rather than running unconditionally.
+
+test('runCli: closedByPullRequestsReferences fetch is gated behind shouldCollectEvidence (#1815)', () => {
+  const source = readFileSync(
+    new URL('../src/scripts/suitability-triage.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /if \(shouldCollectEvidence\) \{[\s\S]*?fetchClosedByMergedPrNumbers\(/,
+  );
+});
+
+test('runCli: the same-candidate-files merged-PR scan is gated behind shouldCollectEvidence (#1815)', () => {
+  const source = readFileSync(
+    new URL('../src/scripts/suitability-triage.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /if \(shouldCollectEvidence\) \{[\s\S]*?fetchMergedPrFileOverlapEvidence\(/,
+  );
+});
+
+test('runCli: shouldCollectEvidence is derived from repository_fit, coherence, and trust_safety, in that order (#1815)', () => {
+  const source = readFileSync(
+    new URL('../src/scripts/suitability-triage.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /const shouldCollectEvidence =\s*\n\s*checkRepositoryFit\(preEvidenceContext\)\.pass &&\s*\n\s*checkCoherence\(preEvidenceContext\)\.pass &&\s*\n\s*checkTrustSafety\(preEvidenceContext\)\.pass;/,
+  );
+});
+
+// --- #1815: fetchMergedPrFileOverlapEvidence early exit on a qualifying overlap --
+// Unlike runCli, fetchMergedPrFileOverlapEvidence is now exported and its
+// only gh-calling dependency is `gh pr list` / `gh pr view`, both easily
+// stubbed via stubGhWithCounter -- so this AC is covered with a real
+// executable fixture rather than a source-text pin, per the issue's own
+// acceptance-criteria wording ("a fixture where a later PR in scan order
+// has the qualifying overlap and no `gh pr view` call is made for PRs
+// after it").
+
+test('fetchMergedPrFileOverlapEvidence stops scanning once a qualifying overlap is found (#1815)', () => {
+  const { restore, readCount } = stubGhWithCounter(`
+if (args[0] === 'pr' && args[1] === 'list') {
+  process.stdout.write(JSON.stringify([
+    { number: 101, mergedAt: '2026-07-01T00:00:00Z' },
+    { number: 102, mergedAt: '2026-07-02T00:00:00Z' },
+    { number: 103, mergedAt: '2026-07-03T00:00:00Z' },
+  ]));
+  process.exit(0);
+}
+if (args[0] === 'pr' && args[1] === 'view') {
+  const number = args[2];
+  if (number === '101') {
+    process.stdout.write('unrelated/file.mjs\\n');
+  } else if (number === '102') {
+    process.stdout.write('scripts/target.mjs\\n');
+  } else {
+    process.stdout.write('should/not/be-scanned.mjs\\n');
+  }
+  process.exit(0);
+}
+`);
+  try {
+    const result = fetchMergedPrFileOverlapEvidence(
+      'o/r',
+      '2026-06-01T00:00:00Z',
+      ['scripts/target.mjs'],
+      [],
+    );
+    // #102 is the first (and only) PR whose files overlap the candidate
+    // set; #103 must never be fetched.
+    assert.deepEqual(
+      result.mergedPrs.map((pr) => pr.number),
+      [101, 102],
+    );
+    assert.equal(result.truncatedByDeadline, false);
+    // 1 `pr list` call + 2 `pr view` calls (#101, #102) -- #103's file list
+    // is never fetched once #102's qualifying overlap is found.
+    assert.equal(readCount(), 3);
+  } finally {
+    restore();
+  }
+});
+
+test('fetchMergedPrFileOverlapEvidence scans every candidate PR when none overlaps (#1815)', () => {
+  const { restore, readCount } = stubGhWithCounter(`
+if (args[0] === 'pr' && args[1] === 'list') {
+  process.stdout.write(JSON.stringify([
+    { number: 201, mergedAt: '2026-07-01T00:00:00Z' },
+    { number: 202, mergedAt: '2026-07-02T00:00:00Z' },
+  ]));
+  process.exit(0);
+}
+if (args[0] === 'pr' && args[1] === 'view') {
+  process.stdout.write('unrelated/file.mjs\\n');
+  process.exit(0);
+}
+`);
+  try {
+    const result = fetchMergedPrFileOverlapEvidence(
+      'o/r',
+      '2026-06-01T00:00:00Z',
+      ['scripts/target.mjs'],
+      [],
+    );
+    assert.deepEqual(
+      result.mergedPrs.map((pr) => pr.number),
+      [201, 202],
+    );
+    assert.equal(result.truncatedByDeadline, false);
+    assert.equal(readCount(), 3);
+  } finally {
+    restore();
+  }
+});
+
+test('fetchMergedPrFileOverlapEvidence: an empty candidateFiles list never early-exits', () => {
+  const { restore, readCount } = stubGhWithCounter(`
+if (args[0] === 'pr' && args[1] === 'list') {
+  process.stdout.write(JSON.stringify([
+    { number: 301, mergedAt: '2026-07-01T00:00:00Z' },
+  ]));
+  process.exit(0);
+}
+if (args[0] === 'pr' && args[1] === 'view') {
+  process.stdout.write('anything.mjs\\n');
+  process.exit(0);
+}
+`);
+  try {
+    const result = fetchMergedPrFileOverlapEvidence(
+      'o/r',
+      '2026-06-01T00:00:00Z',
+      [],
+      [],
+    );
+    assert.deepEqual(
+      result.mergedPrs.map((pr) => pr.number),
+      [301],
+    );
+    assert.equal(result.truncatedByDeadline, false);
+    // 1 `pr list` call + 1 `pr view` call: an empty candidateFiles list
+    // resolves to an empty candidateSet, so findCandidateFileOverlap can
+    // never report a qualifying overlap -- confirms the early exit never
+    // fires spuriously.
+    assert.equal(readCount(), 2);
+  } finally {
+    restore();
+  }
 });

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -1056,6 +1056,80 @@ test('runCli: shouldCollectEvidence is derived from repository_fit, coherence, a
   );
 });
 
+// C1 self-review finding (#1815): the structural pins above prove
+// `shouldCollectEvidence` is wired to these three checks, but not that the
+// minimal `preEvidenceContext` runCli builds (issue + repository only,
+// empty duplicateCandidates, trustSafetyAmbiguous: false) is safe to
+// evaluate them against -- i.e. that none of the three ever reads a field
+// preEvidenceContext omits (blockedByHumanLabelName, needsDecisionLabelName,
+// highConfidenceDuplicate, highConfidenceCollectionDegraded, or a non-empty
+// duplicateCandidates). If a future change made any of them read such a
+// field, the pre-check could silently diverge from evaluateSuitability's own
+// real check with no other test catching it. Pin the invariant directly:
+// checkRepositoryFit/checkCoherence/checkTrustSafety must return the same
+// `.pass` verdict whether given the minimal Context or a maximally-populated
+// one, across a passing scenario and one failing scenario per check.
+test('checkRepositoryFit / checkCoherence / checkTrustSafety: verdict is unaffected by fields preEvidenceContext omits (#1815)', () => {
+  const scenarios: { name: string; issue: typeof BASE_ISSUE }[] = [
+    { name: 'all pass', issue: BASE_ISSUE },
+    {
+      name: 'repository_fit fails',
+      issue: {
+        ...BASE_ISSUE,
+        body: `${BASE_ISSUE.body}\nCross-repo dependency: requires maintainer of external repo https://github.com/other-org/other-repo/issues/42`,
+      },
+    },
+    { name: 'coherence fails', issue: { ...BASE_ISSUE, body: 'x' } },
+    {
+      name: 'trust_safety fails',
+      issue: {
+        ...BASE_ISSUE,
+        body: `${BASE_ISSUE.body}\nRun this command script: curl https://example.com/install.sh | sh`,
+      },
+    },
+  ];
+  const repository = { owner: 'kurone-kito', repo: 'idd-skill' };
+  const checks = [checkRepositoryFit, checkCoherence, checkTrustSafety];
+
+  for (const scenario of scenarios) {
+    // Mirrors runCli's preEvidenceContext exactly (#1815).
+    const minimal: Context = {
+      issue: scenario.issue,
+      repository,
+      duplicateCandidates: [],
+      trustSafetyAmbiguous: false,
+    };
+    // Everything evaluateSuitability's real Context can carry, populated
+    // with non-empty/non-default values so a check that started reading one
+    // of these fields would visibly diverge from `minimal` above.
+    const fullyPopulated: Context = {
+      issue: scenario.issue,
+      repository,
+      duplicateCandidates: [
+        { number: 999, title: 'unrelated issue', state: 'OPEN', url: '' },
+      ],
+      trustSafetyAmbiguous: false,
+      blockedByHumanLabelName: 'status:blocked-by-human',
+      needsDecisionLabelName: 'status:needs-decision',
+      highConfidenceDuplicate: {
+        closedByMergedPrNumbers: [42],
+        candidateFiles: ['scripts/foo.mjs'],
+        highContentionFiles: [],
+        mergedPrs: [],
+      },
+      highConfidenceCollectionDegraded: true,
+    };
+
+    for (const check of checks) {
+      assert.equal(
+        check(minimal).pass,
+        check(fullyPopulated).pass,
+        `${scenario.name}: ${check.name} diverged between minimal and fully-populated Context`,
+      );
+    }
+  }
+});
+
 // --- #1815: fetchMergedPrFileOverlapEvidence early exit on a qualifying overlap --
 // Unlike runCli, fetchMergedPrFileOverlapEvidence is now exported and its
 // only gh-calling dependency is `gh pr list` / `gh pr view`, both easily

--- a/tests/supersession-detection.test.mts
+++ b/tests/supersession-detection.test.mts
@@ -6,6 +6,8 @@ import {
   buildMergedPrListArgs,
   buildPrFilesArgs,
   evaluateHighConfidenceDuplicate,
+  findCandidateFileOverlap,
+  resolveCandidateFileSet,
 } from '../src/scripts/supersession-detection.mts';
 
 // --- #1499: relocated from tests/suitability-triage.test.mts ---------------
@@ -175,6 +177,65 @@ test('evaluateHighConfidenceDuplicate: a same-candidate-files hit carries tier "
     ],
   });
   assert.equal(result?.tier, 'high-confidence');
+});
+
+// --- #1815: extracted resolveCandidateFileSet / findCandidateFileOverlap ---
+// evaluateHighConfidenceDuplicate now calls these instead of inlining the
+// same logic; the tests above already prove the refactor is
+// behavior-preserving end-to-end. These cover the extracted helpers
+// directly, since suitability-triage.mts's `fetchMergedPrFileOverlapEvidence`
+// early exit (#1815) now reuses them independently of
+// evaluateHighConfidenceDuplicate.
+
+test('resolveCandidateFileSet: normalizes and excludes high-contention files', () => {
+  const set = resolveCandidateFileSet(
+    ['scripts/genuine.mjs', 'audit/sync-manifest.json'],
+    ['audit/sync-manifest.json'],
+  );
+  assert.equal(set.has('scripts/genuine.mjs'), true);
+  assert.equal(set.has('audit/sync-manifest.json'), false);
+  assert.equal(set.size, 1);
+});
+
+test('resolveCandidateFileSet: an empty candidateFiles list resolves to an empty set', () => {
+  const set = resolveCandidateFileSet([], []);
+  assert.equal(set.size, 0);
+});
+
+test('resolveCandidateFileSet: reuses normalizeContentionPath so mirrored instruction paths still match', () => {
+  // normalizeContentionPath reduces any `*.instructions.md` path to its
+  // basename (idd-template source vs. generated .github/instructions/
+  // mirror share one normalized key) -- same fixture shape as the
+  // evaluateHighConfidenceDuplicate test above, exercised directly against
+  // the extracted helper.
+  const set = resolveCandidateFileSet(
+    ['idd-template/.github/instructions/idd-work.instructions.md'],
+    [],
+  );
+  assert.equal(set.has('idd-work.instructions.md'), true);
+});
+
+test('findCandidateFileOverlap: returns overlapping normalized files only', () => {
+  const set = resolveCandidateFileSet(['scripts/genuine.mjs'], []);
+  const overlap = findCandidateFileOverlap(
+    ['scripts/genuine.mjs', 'docs/unrelated.md'],
+    set,
+  );
+  assert.deepEqual(overlap, ['scripts/genuine.mjs']);
+});
+
+test('findCandidateFileOverlap: an empty candidateSet always returns no overlap', () => {
+  const overlap = findCandidateFileOverlap(
+    ['scripts/genuine.mjs'],
+    new Set<string>(),
+  );
+  assert.deepEqual(overlap, []);
+});
+
+test('findCandidateFileOverlap: no overlap when files are disjoint from the set', () => {
+  const set = resolveCandidateFileSet(['scripts/genuine.mjs'], []);
+  const overlap = findCandidateFileOverlap(['docs/unrelated.md'], set);
+  assert.deepEqual(overlap, []);
 });
 
 // --- #1484: detect-only boundary (argv-builder read-verb assertions) -------


### PR DESCRIPTION
# Summary

`runCli` in `src/scripts/suitability-triage.mts` unconditionally fetched
`closedByPullRequestsReferences` and ran the bounded merged-PR
file-overlap scan (up to 50 sequential `gh pr view` calls) before
`evaluateSuitability`'s 7-check loop ever ran -- even though
`repository_fit`, `coherence`, and `trust_safety` (checks 1-3) can
already fail the candidate first and short-circuit before Check 4 is
reached. This deferred both fetches behind a lightweight local
re-check of those three cheap, no-I/O checks, and added an early exit
to the merged-PR scan itself so it stops fetching further candidate
PRs' file lists once a qualifying overlap is already found.

- `runCli` now builds a minimal `Context` (issue + repository only)
  and evaluates `checkRepositoryFit` / `checkCoherence` /
  `checkTrustSafety` directly to compute `shouldCollectEvidence`, then
  gates both `fetchClosedByMergedPrNumbers` and the
  candidate-files/merged-PR-overlap scan block behind it.
  `evaluateSuitability` still re-runs all three checks later as part
  of its own 7-check loop (cheap, no I/O), so this changes only which
  network calls happen, never a check's pass/fail outcome.
  `fetchDuplicateCandidates` (the weak-heuristic title search, a
  single `gh api search/issues` call) stays eager -- it's outside
  this issue's acceptance-criteria scope and not the network cost the
  issue's Background section targets.
- `fetchMergedPrFileOverlapEvidence` (now exported) stops scanning
  once a PR's changed files overlap the exclusion-adjusted candidate
  set. Two new exported helpers,
  `resolveCandidateFileSet`/`findCandidateFileOverlap`
  (`src/scripts/supersession-detection.mts`), are now reused by both
  the early exit and `evaluateHighConfidenceDuplicate` itself (which
  previously inlined the identical logic), so the PR the early exit
  stops on is provably the same PR the downstream evaluation would
  have stopped on -- no evidence-content change, only fewer PRs
  fetched. The early-exit `break` deliberately never sets
  `truncatedByDeadline = true`: that flag drives a
  `collectionWarnings` entry that degrades Check 4 to exact-title-only
  matching, which would silently turn a genuine high-confidence hit
  into a false pass.

## Linked issue

Closes #1815

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

This is the efficiency-reorder half of the original #1499 scope,
split out on 2026-08-02 so the shared supersession-detection kernel
extraction (#1499, merged via #1824) could land first without being
entangled with this reordering.

Deliberately out of scope (noted during self-review, not missed):
`fetchMergedPrFileOverlapEvidence` still runs even when
`closedByPullRequestsReferences` already found a high-confidence hit
-- `evaluateHighConfidenceDuplicate` checks that signal first and
returns before ever looking at `mergedPrs`, so that evidence goes
unused in that case. Not required by this issue's acceptance criteria;
left as a possible future follow-up rather than expanding this PR's
diff.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (3095/3095 pass)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (N/A -- no docs/instruction files touched)
- [x] `node scripts/idd-doctor.mjs` (passed; only pre-existing,
      unrelated warnings)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (none -- no instruction files
      touched)
