### PR TITLE
fix(ci): grant idd-doctor.yml GitHub API read scopes + GH_TOKEN

### DIFF
--- a/.github/workflows/idd-doctor.yml
+++ b/.github/workflows/idd-doctor.yml
@@ -15,6 +15,8 @@ on:
   pull_request:
 permissions:
   contents: read
+  issues: read
+  pull-requests: read
 jobs:
   idd-doctor:
     runs-on: ubuntu-slim
@@ -63,4 +65,6 @@ jobs:
             }
           '
       - name: Run idd-doctor repository-health check
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: node scripts/idd-doctor.mjs


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`.github/workflows/idd-doctor.yml`'s `permissions:` block only granted
`contents: read`, and its "Run idd-doctor repository-health check" step
had no `env:` block, so `gh` had no credential inside the job regardless
of `permissions:` scope. Every run degraded idd-doctor's GitHub-API-backed
checks (post-merge cleanup backlog, branch protection,
autopilot-suitability signals) to a single
`WARN github checks skipped: gh repo view unavailable` line, even though
the job still reported `success` (idd-doctor's graceful-degradation
design is correct and stays unchanged here).

This adds `issues: read` and `pull-requests: read` to the `permissions:`
block, and `env: GH_TOKEN: ${{ github.token }}` to the health-check step
— mirroring the already-correct, already-proven pattern in
`.github/workflows/idd-advisory-convergence.yml`. No other changes to the
workflow file.

## Linked issue

Closes #1828

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Verified live against the most recent run on `main` before this change
(run `30732209552`, conclusion `success`, log line
`WARN  github checks skipped: gh repo view unavailable`). This
repository's own `idd-advisory-convergence.yml` already documents, in
its header comment, why `issues: read` specifically is required even
for PR-shaped GitHub API reads (the issue-comments REST endpoint is
gated under the Issues permission category).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
