### PR TITLE
fix(idd-doctor): match the hyphenated copilot-advisory literal

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -721,6 +721,7 @@ export function checkPolicySignals(root, report) {
   }
   const reviewPolicySignals = [
     'copilot-advisory',
+    'copilot advisory',
     'no-advisory',
     'human-required',
     'external-bot',

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -693,7 +693,7 @@ function findToolchainResidueToken(value) {
 function escapeRegex(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
-function checkPolicySignals(root, report) {
+export function checkPolicySignals(root, report) {
   const files = [
     'README.md',
     'README.ja.md',
@@ -720,7 +720,7 @@ function checkPolicySignals(root, report) {
     report.passes.push('merge policy signal found');
   }
   const reviewPolicySignals = [
-    'copilot advisory',
+    'copilot-advisory',
     'no-advisory',
     'human-required',
     'external-bot',

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -837,7 +837,7 @@ function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function checkPolicySignals(root: string, report: DoctorReport) {
+export function checkPolicySignals(root: string, report: DoctorReport) {
   const files = [
     'README.md',
     'README.ja.md',
@@ -866,7 +866,7 @@ function checkPolicySignals(root: string, report: DoctorReport) {
   }
 
   const reviewPolicySignals = [
-    'copilot advisory',
+    'copilot-advisory',
     'no-advisory',
     'human-required',
     'external-bot',

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -867,6 +867,7 @@ export function checkPolicySignals(root: string, report: DoctorReport) {
 
   const reviewPolicySignals = [
     'copilot-advisory',
+    'copilot advisory',
     'no-advisory',
     'human-required',
     'external-bot',

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -2339,6 +2339,34 @@ test('checkPolicySignals recognizes the hyphenated copilot-advisory literal (#18
   }
 });
 
+test('checkPolicySignals still recognizes the unhyphenated prose form "copilot advisory"', () => {
+  // Two adopter repositories worked around the pre-fix bug by rewording
+  // their docs to read naturally as "the Copilot advisory review
+  // profile" (#1827 Background) instead of recording the canonical
+  // hyphenated value. The hyphenated-literal fix must not regress this
+  // prose-only case for those repositories.
+  const dir = mkdtempSync(join(tmpdir(), 'idd-policy-signals-'));
+  try {
+    mkdirSync(join(dir, 'docs'), { recursive: true });
+    writeFileSync(
+      join(dir, 'docs/idd-policy.md'),
+      '# Review policy\n\nThis repository uses the Copilot advisory review profile.\n',
+    );
+    writeFileSync(
+      join(dir, 'AGENTS.md'),
+      'mergePolicy: fully_autonomous_merge\n',
+    );
+
+    const report = emptyReport(dir);
+    checkPolicySignals(dir, report);
+    assert.deepEqual(report.errors, []);
+    assert.deepEqual(report.warnings, []);
+    assert.ok(report.passes.includes('review policy signal found'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('checkPolicySignals still warns when no recognized review-policy signal is present', () => {
   const dir = mkdtempSync(join(tmpdir(), 'idd-policy-signals-'));
   try {

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -9,6 +9,7 @@ import {
   checkClaimTimingConsistency,
   checkDependencyVersionDrift,
   checkLiveConfigSchema,
+  checkPolicySignals,
   checkProjectCommands,
   classifyBacklog,
   classifyClaimTimingConsistency,
@@ -2308,6 +2309,55 @@ test('checkClaimTimingConsistency pushes no warning when config and prose agree,
     checkClaimTimingConsistency(dir, missingConfigReport);
     assert.equal(missingConfigReport.warnings.length, 0);
     assert.equal(missingConfigReport.errors.length, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('checkPolicySignals recognizes the hyphenated copilot-advisory literal (#1827)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-policy-signals-'));
+  try {
+    mkdirSync(join(dir, 'docs'), { recursive: true });
+    writeFileSync(
+      join(dir, 'docs/idd-policy.md'),
+      '# Review policy\n\nThis repository uses the copilot-advisory review policy profile.\n',
+    );
+    // A merge-policy signal must also be present so only the review-policy
+    // branch is under test here.
+    writeFileSync(
+      join(dir, 'AGENTS.md'),
+      'mergePolicy: fully_autonomous_merge\n',
+    );
+
+    const report = emptyReport(dir);
+    checkPolicySignals(dir, report);
+    assert.deepEqual(report.errors, []);
+    assert.deepEqual(report.warnings, []);
+    assert.ok(report.passes.includes('review policy signal found'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('checkPolicySignals still warns when no recognized review-policy signal is present', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-policy-signals-'));
+  try {
+    mkdirSync(join(dir, 'docs'), { recursive: true });
+    writeFileSync(
+      join(dir, 'docs/idd-policy.md'),
+      '# Review policy\n\nNo recognized signal here.\n',
+    );
+    writeFileSync(
+      join(dir, 'AGENTS.md'),
+      'mergePolicy: fully_autonomous_merge\n',
+    );
+
+    const report = emptyReport(dir);
+    checkPolicySignals(dir, report);
+    assert.deepEqual(report.errors, []);
+    assert.deepEqual(report.warnings, [
+      'review policy signal not found in docs or entry files',
+    ]);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
# Summary

`checkPolicySignals` in `src/scripts/idd-doctor.mts` warned even when a
repository's `docs/idd-policy.md` recorded the canonical, hyphenated
`copilot-advisory` review-policy value, because its own signal literal
used a space (`'copilot advisory'`) instead of a hyphen -- the only one
of five signals not matching the `reviewPolicy` schema enum's actual
form. Adopters who kept the default profile and recorded it verbatim
received a spurious `WARN review policy signal not found in docs or
entry files`.

- Widen `reviewPolicySignals` to match **both** the hyphenated
  `copilot-advisory` literal and the pre-existing unhyphenated prose
  form `copilot advisory` (per the issue's own Proposed change, which
  explicitly permits this widening). Two real adopter repositories
  already worked around the bug by rewording their docs to the prose
  form, so replacing rather than widening the literal would have
  silently regressed them.
- Export `checkPolicySignals` so it can be unit tested directly,
  matching the established pattern for sibling `(root, report)` checks
  in this file (`checkClaimTimingConsistency`, `checkLiveConfigSchema`,
  `checkDependencyVersionDrift`).
- Add regression tests: hyphenated-literal-only fixture passes,
  prose-only fixture still passes, and the no-signal fixture still
  warns (unchanged behavior). Confirmed the hyphenated-literal test
  fails against the pre-fix code (reverted the literal locally, saw the
  expected assertion failure, restored it).

## Linked issue

Closes #1827

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The issue's Proposed change explicitly sanctions widening the match to
accept both the hyphenated and natural-prose forms "if that is a
trivial addition" while noting the plain one-line literal fix alone
also resolves the reported false positive. This PR takes the widening
option: replacing the space literal outright, rather than adding the
hyphenated form alongside it, would have silently dropped matching for
the prose form that the issue's own Background documents two adopter
repositories already depend on as their workaround.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (not applicable -- no docs changed)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

Full `pre-push-validate` command chain (biome, dprint, markdownlint,
cspell, audit-docs, audit-code-span-wrap, `pnpm run build:check`,
`node scripts/idd-doctor.mjs`) passes with the same 4 pre-existing
warnings as before this change, and `PASS review policy signal found`.
Full test suite: `node --test tests/*.test.mts` -- 3103 tests, all
pass.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
