### PR TITLE
docs(onboarding): complete package-manager/ephemeral-npx CI + allowBuilds guidance

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -770,10 +770,13 @@ adopter default stays opt-in **off**.
 
 ### Optional — run idd-doctor as a CI health gate
 
-For repositories that vendor the IDD helper scripts, running `idd-doctor`
-in CI catches repository-health regressions (config/schema drift,
-unresolved placeholders, marker-prefix inconsistency, missing required
-files) on every change. It is opt-in — add a workflow such as:
+Running `idd-doctor` in CI catches repository-health regressions
+(config/schema drift, unresolved placeholders, marker-prefix
+inconsistency, missing required files) on every change. It is opt-in —
+add a workflow such as one of the profile-specific examples below,
+matching the repository's confirmed helper-runtime profile.
+
+**`vendored-node`** — the helper bundle is copied into `scripts/`:
 
 ```yaml
 name: IDD doctor health gate
@@ -792,12 +795,67 @@ jobs:
       - run: node scripts/idd-doctor.mjs
 ```
 
-Adjust the command to your helper-runtime profile. This gate checks
-repository **health**, not the disposable-worktree rule: CI cannot detect
-a primary-worktree B1 violation (it leaves no trace in pushed history and
-CI checks out a detached HEAD), so worktree enforcement stays local — the
-`core.hooksPath` hook above, the cwd-vs-claim gate, and
-`idd-doctor --strict` run on a developer's machine.
+**`package-manager`** — the helper ships as an installed
+`devDependency` invoked through the repository's package manager. This
+example uses pnpm; swap the `pnpm/action-setup` step and the install /
+invoke commands for npm or yarn equivalents if the repository uses a
+different package manager:
+
+```yaml
+name: IDD doctor health gate
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  idd-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }} # detached HEAD keeps the worktree check inert
+          persist-credentials: false
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec idd-doctor
+```
+
+**`ephemeral-npx`** — no helper files or `devDependency` are vendored;
+resolve the helper command one-shot instead. Replace
+`<reviewed-helper-spec>` with the same reviewed spec the repository's
+other helper invocations use (see
+[Onboarding Reference — Policy Decisions](docs/onboarding/policy-decisions.md#helper-runtime-profile)):
+
+```yaml
+name: IDD doctor health gate
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  idd-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }} # detached HEAD keeps the worktree check inert
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - run: npx --yes --package <reviewed-helper-spec> idd-doctor
+```
+
+This gate checks repository **health**, not the disposable-worktree rule:
+CI cannot detect a primary-worktree B1 violation (it leaves no trace in
+pushed history and CI checks out a detached HEAD), so worktree
+enforcement stays local — the `core.hooksPath` hook above, the
+cwd-vs-claim gate, and `idd-doctor --strict` run on a developer's
+machine.
 
 **Branch-glob vs CI-trigger.** Put PR-gating checks in the
 `pull_request`-triggered workflow (as above). A `push` workflow filtered to a

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -203,6 +203,41 @@ emit a reviewed tag, commit, tarball, or internal mirror URL. Treat
 `refs/heads/main` as a manual opt-in when the repository explicitly
 wants a mutable helper source instead of a reviewed pinned spec.
 
+**pnpm `allowBuilds` requirement for a git-hosted pinned spec.** When a
+`package-manager` repository using pnpm pins the `devDependencies` entry
+to a git-hosted spec (for example
+`"@kurone-kito/idd-skill": "github:kurone-kito/idd-skill#v0.4.0"`), a
+clean `pnpm install` fails:
+
+```text
+[ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED] Failed to prepare git-hosted
+package fetched from "https://codeload.github.com/kurone-kito/idd-skill/
+tar.gz/<sha>": The git-hosted package "@kurone-kito/idd-skill@0.4.0"
+needs to execute build scripts but is not in the "allowBuilds"
+allowlist.
+```
+
+pnpm treats a git-hosted dependency's build scripts as untrusted by
+default and refuses to run them until the repository explicitly allows
+it. Add an `allowBuilds` entry for the helper package to
+`pnpm-workspace.yaml` to unblock the install:
+
+```yaml
+allowBuilds:
+  "@kurone-kito/idd-skill@https://codeload.github.com/kurone-kito/idd-skill/tar.gz/<sha>": true
+```
+
+The allowlist key form differs for a git-hosted dependency. A
+**registry** dependency only needs the bare package name (for example
+`"@biomejs/biome": true`), but a **git-hosted** dependency needs the
+full `<name>@<resolved-tarball-url>` key — the bare package name alone
+silently does not match and reproduces the same
+`ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` error. Copy the exact
+`fetched from "..."` URL from pnpm's own error output above rather than
+guessing the resolved-tarball-URL shape; it is not the same as the
+`github:owner/repo#ref` shorthand written in `devDependencies`, and it
+changes per resolved commit.
+
 ### IDD label names
 
 Confirm whether the repository keeps the three distributed IDD label


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Adopters on the `package-manager` or `ephemeral-npx` helperRuntime
profile had no complete, working `idd-doctor` CI health-gate example and
no `allowBuilds`-equivalent guidance for a pinned git-hosted helper
dependency — both gaps surfaced by a real fresh-onboarding adopter
session, since this source repository's own dogfooding only exercises
`vendored-node`/`package-manager` locally and never structurally
surfaces the CI-example gap for the other profiles.

- `idd-template/ONBOARDING.md`'s "Optional — run idd-doctor as a CI
  health gate" section now shows a complete, runnable example per
  profile (`vendored-node`, `package-manager`, `ephemeral-npx`:
  checkout, setup, install, invoke) instead of a bare "adjust the
  command to your helper-runtime profile" note.
- `idd-template/docs/onboarding/policy-decisions.md`'s "Helper runtime
  profile" section now documents the pnpm `allowBuilds` requirement for
  a pinned git-hosted `devDependencies` spec (the exact
  `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` failure, the
  `pnpm-workspace.yaml` fix, and the registry-vs-git-hosted
  `allowBuilds` key-form gotcha — a bare package name works for a
  registry dependency but silently does not match a git-hosted one).

No `docs/` mirror exists for `idd-template/docs/onboarding/*.md`
(`audit/sync-manifest.json`'s `syncPairs` has no entry for it; it only
appears in the `idd-template-core-files` generated file-listing block),
so `idd-template/docs/onboarding/policy-decisions.md` is the sole
canonical copy. `node scripts/sync-docs.mjs --apply` confirms no drift.

## Linked issue

Closes #1830

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Both gaps were hit in the same adopter session
(`kurone-kito/web-toybox`, first-import onboarding), per the issue body.
The `package-manager` profile is the auto-propose first choice for any
repository with a supported lockfile (per
`docs/onboarding/policy-decisions.md`'s own ordering), so this is likely
the most common adopter profile gap.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
