### PR TITLE
docs(onboarding): warn about hook-manager coexistence + shellEmulator

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -747,21 +747,25 @@ An existing hook manager (Husky or similar) can silently reset
 `core.hooksPath` back to its own hooks directory on every
 install/prepare lifecycle run — Husky v9's default `prepare: "husky"`
 script repoints `core.hooksPath` at `.husky/_` unconditionally, so a
-routine `pnpm install` after activation un-wires this guard again with
-no error. `idd-doctor`'s enabled-but-inert detection (below) correctly
+routine `pnpm install` after activation leaves this guard unwired
+again with no error. `idd-doctor`'s enabled-but-inert detection (below) correctly
 flags this again, but nothing about the reset itself is a bug — do not
 assume `core.hooksPath` is free to claim outright. Chain the existing
-hook to `exec` the corresponding `.githooks/*` script instead:
+hook to `exec` the corresponding `.githooks/*` script instead: append
+(don't replace) the existing hook file with a line that resolves the
+repository root explicitly, so the hook still works when git invokes
+it from a subdirectory:
 
 ```sh
-# .husky/pre-push
-exec .githooks/pre-push "$@"
+# Add as the last line of the existing .husky/pre-push:
+exec "$(git rev-parse --show-toplevel)/.githooks/pre-push" "$@"
 ```
 
 Fully replacing (not chaining) an existing hook manager under pnpm's
 `shellEmulator: true` needs a POSIX-control-flow-free replacement
 lifecycle script — no `if`/`then`/`fi`, which `shellEmulator`'s reduced
-grammar cannot parse. Use a short-circuit instead:
+grammar cannot parse. For example, a replacement `package.json`
+`"prepare"` script needs a short-circuit instead:
 
 ```sh
 git rev-parse --git-dir > /dev/null 2>&1 || exit 0; git config core.hooksPath .githooks && chmod +x .githooks/pre-commit .githooks/pre-push

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -741,6 +741,32 @@ primary-worktree mistake leaves no trace in the pushed history — so
 this local hook, together with `idd-doctor --strict`, is the practical
 enforcement surface.
 
+#### Coexisting with an existing hook manager
+
+An existing hook manager (Husky or similar) can silently reset
+`core.hooksPath` back to its own hooks directory on every
+install/prepare lifecycle run — Husky v9's default `prepare: "husky"`
+script repoints `core.hooksPath` at `.husky/_` unconditionally, so a
+routine `pnpm install` after activation un-wires this guard again with
+no error. `idd-doctor`'s enabled-but-inert detection (below) correctly
+flags this again, but nothing about the reset itself is a bug — do not
+assume `core.hooksPath` is free to claim outright. Chain the existing
+hook to `exec` the corresponding `.githooks/*` script instead:
+
+```sh
+# .husky/pre-push
+exec .githooks/pre-push "$@"
+```
+
+Fully replacing (not chaining) an existing hook manager under pnpm's
+`shellEmulator: true` needs a POSIX-control-flow-free replacement
+lifecycle script — no `if`/`then`/`fi`, which `shellEmulator`'s reduced
+grammar cannot parse. Use a short-circuit instead:
+
+```sh
+git rev-parse --git-dir > /dev/null 2>&1 || exit 0; git config core.hooksPath .githooks && chmod +x .githooks/pre-commit .githooks/pre-push
+```
+
 #### Activation in a coding-agent / ephemeral environment
 
 The `git config core.hooksPath` step above is **local and uncommitted**, so


### PR DESCRIPTION
## Summary

Adds a "Coexisting with an existing hook manager" subsection to the
worktree-guard activation guidance in `idd-template/ONBOARDING.md`,
covering two field-reported gaps:

- **Silent reset**: an existing hook manager such as Husky can
  silently repoint `core.hooksPath` back to its own hooks directory
  on every install/prepare lifecycle run (Husky v9's default
  `prepare: "husky"` script does this unconditionally), un-wiring the
  guard again after a routine `pnpm install`. The fix documented here
  is to chain the existing hook to `exec` the corresponding
  `.githooks/*` script instead of assuming `core.hooksPath` is free
  to claim outright.
- **`shellEmulator` gap**: a one-line pointer that fully replacing
  (not chaining) an existing hook manager under pnpm's
  `shellEmulator: true` needs a POSIX-control-flow-free replacement
  lifecycle script (no `if`/`then`/`fi`), with the working
  `|| exit 0; ...` short-circuit form shown as an example.

Both `docs/` and `README*.md` were checked and confirmed to have no
mirrored copy of this content, so the change is scoped to the single
source file.

Closes #1831

## Test plan

- [x] `npx biome check` / `npx dprint check "**/*.md"` /
      `npx markdownlint-cli2 "**/*.md"` — pass
- [x] `npx cspell lint "**" --no-progress` — pass
- [x] `node scripts/audit-docs.mjs --check` — pass (byte-budget /
      bundle checks unaffected, `ONBOARDING.md` is outside every
      `instructionSizeBudgets` / `bundleBudgets` glob)
- [x] `node scripts/audit-code-span-wrap.mjs` — pass (new commands
      kept in fenced blocks, no mid-token wraps)
- [x] `pnpm run build:check` — pass
- [x] `node scripts/idd-doctor.mjs` — pass (pre-existing warnings only,
      unrelated to this change)
