### PR TITLE
fix(idd-doctor): scope cleanup-backlog scan to IDD branches

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1677,6 +1677,38 @@ export function readCleanupEvidenceTrustedLogins(root) {
   });
   return new Set([...actors, 'github-actions[bot]']);
 }
+/**
+ * Filter a `gh pr list --json number,headRefName` result down to entries
+ * whose head ref matches the IDD branch-naming convention -- the same
+ * `worktreeGuard.branchPatterns` globs (`issue/*`, `roadmap-audit/*` by
+ * default; see `readWorktreeGuardBranchPatterns`) that `classifyPrimaryHead`
+ * already matches elsewhere in this file. A routine non-IDD merge (a
+ * Dependabot dependency bump, for example) never created a branch the
+ * post-merge cleanup backlog scan is responsible for, so it is dropped here
+ * before the backlog count, evidence-fetch loop, or `Examples: ...` list
+ * ever sees it (idd-skill#1829). Pure (no I/O) so it can be unit-tested
+ * without mocking `gh`.
+ */
+export function filterIddBranchMergedPrs(
+  prs,
+  patterns = DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS,
+) {
+  const matchers = patterns.map((pattern) => branchGlobToRegExp(pattern));
+  const filtered = [];
+  for (const pr of Array.isArray(prs) ? prs : []) {
+    const number = pr?.number;
+    const headRefName = pr?.headRefName;
+    if (
+      !Number.isInteger(number) ||
+      typeof headRefName !== 'string' ||
+      !matchers.some((matcher) => matcher.test(headRefName))
+    ) {
+      continue;
+    }
+    filtered.push({ number: number });
+  }
+  return filtered;
+}
 function checkPostMergeCleanupBacklog(root, options, report) {
   const windowDays = options.windowDays;
   const warnThreshold = options.warnThreshold;
@@ -1733,7 +1765,7 @@ function checkPostMergeCleanupBacklog(root, options, report) {
       '--search',
       `merged:>=${sinceIso}`,
       '--json',
-      'number',
+      'number,headRefName',
       '--limit',
       '1000',
     ],
@@ -1755,24 +1787,32 @@ function checkPostMergeCleanupBacklog(root, options, report) {
   if (!Array.isArray(mergedPrs) || mergedPrs.length === 0) {
     return;
   }
+  // Scope the scan to IDD-branch merged PRs only (idd-skill#1829) -- a
+  // routine non-IDD merge (Dependabot dependency bumps, for example) never
+  // created a branch the F4 cleanup-evidence contract applies to, so it
+  // must not count toward the backlog total or the `Examples: ...` list.
+  const iddMergedPrs = filterIddBranchMergedPrs(
+    mergedPrs,
+    readWorktreeGuardBranchPatterns(root),
+  );
+  if (iddMergedPrs.length === 0) {
+    return;
+  }
   // Stream per-PR progress to stderr so a slow, serial, network-bound scan of a
   // large merge burst is distinguishable from a hang. Progress must stay on
   // stderr so the `--json` report on stdout is never polluted.
   emitCleanupBacklogProgress(
-    formatCleanupBacklogScanPreamble(mergedPrs.length),
+    formatCleanupBacklogScanPreamble(iddMergedPrs.length),
   );
   const trustedLogins = readCleanupEvidenceTrustedLogins(root);
   const missing = [];
   const evidenceFailures = [];
   let scanned = 0;
-  for (const pr of mergedPrs) {
-    const number = pr?.number;
-    if (!Number.isInteger(number)) {
-      continue;
-    }
+  for (const pr of iddMergedPrs) {
+    const number = pr.number;
     scanned += 1;
     emitCleanupBacklogProgress(
-      formatCleanupBacklogScanProgress(scanned, mergedPrs.length, number),
+      formatCleanupBacklogScanProgress(scanned, iddMergedPrs.length, number),
     );
     const evidence = runCommand(
       'gh',

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1974,6 +1974,39 @@ export function readCleanupEvidenceTrustedLogins(root: string): Set<string> {
   return new Set([...actors, 'github-actions[bot]']);
 }
 
+/**
+ * Filter a `gh pr list --json number,headRefName` result down to entries
+ * whose head ref matches the IDD branch-naming convention -- the same
+ * `worktreeGuard.branchPatterns` globs (`issue/*`, `roadmap-audit/*` by
+ * default; see `readWorktreeGuardBranchPatterns`) that `classifyPrimaryHead`
+ * already matches elsewhere in this file. A routine non-IDD merge (a
+ * Dependabot dependency bump, for example) never created a branch the
+ * post-merge cleanup backlog scan is responsible for, so it is dropped here
+ * before the backlog count, evidence-fetch loop, or `Examples: ...` list
+ * ever sees it (idd-skill#1829). Pure (no I/O) so it can be unit-tested
+ * without mocking `gh`.
+ */
+export function filterIddBranchMergedPrs(
+  prs: unknown,
+  patterns: string[] = DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS,
+): { number: number }[] {
+  const matchers = patterns.map((pattern) => branchGlobToRegExp(pattern));
+  const filtered: { number: number }[] = [];
+  for (const pr of Array.isArray(prs) ? prs : []) {
+    const number = (pr as { number?: unknown } | null)?.number;
+    const headRefName = (pr as { headRefName?: unknown } | null)?.headRefName;
+    if (
+      !Number.isInteger(number) ||
+      typeof headRefName !== 'string' ||
+      !matchers.some((matcher) => matcher.test(headRefName))
+    ) {
+      continue;
+    }
+    filtered.push({ number: number as number });
+  }
+  return filtered;
+}
+
 function checkPostMergeCleanupBacklog(
   root: string,
   options: {
@@ -2042,7 +2075,7 @@ function checkPostMergeCleanupBacklog(
       '--search',
       `merged:>=${sinceIso}`,
       '--json',
-      'number',
+      'number,headRefName',
       '--limit',
       '1000',
     ],
@@ -2065,29 +2098,34 @@ function checkPostMergeCleanupBacklog(
     return;
   }
 
+  // Scope the scan to IDD-branch merged PRs only (idd-skill#1829) -- a
+  // routine non-IDD merge (Dependabot dependency bumps, for example) never
+  // created a branch the F4 cleanup-evidence contract applies to, so it
+  // must not count toward the backlog total or the `Examples: ...` list.
+  const iddMergedPrs = filterIddBranchMergedPrs(
+    mergedPrs,
+    readWorktreeGuardBranchPatterns(root),
+  );
+  if (iddMergedPrs.length === 0) {
+    return;
+  }
+
   // Stream per-PR progress to stderr so a slow, serial, network-bound scan of a
   // large merge burst is distinguishable from a hang. Progress must stay on
   // stderr so the `--json` report on stdout is never polluted.
   emitCleanupBacklogProgress(
-    formatCleanupBacklogScanPreamble(mergedPrs.length),
+    formatCleanupBacklogScanPreamble(iddMergedPrs.length),
   );
 
   const trustedLogins = readCleanupEvidenceTrustedLogins(root);
   const missing: number[] = [];
   const evidenceFailures: number[] = [];
   let scanned = 0;
-  for (const pr of mergedPrs) {
-    const number = (pr as { number?: unknown } | null)?.number;
-    if (!Number.isInteger(number)) {
-      continue;
-    }
+  for (const pr of iddMergedPrs) {
+    const number = pr.number;
     scanned += 1;
     emitCleanupBacklogProgress(
-      formatCleanupBacklogScanProgress(
-        scanned,
-        mergedPrs.length,
-        number as number,
-      ),
+      formatCleanupBacklogScanProgress(scanned, iddMergedPrs.length, number),
     );
     const evidence = runCommand(
       'gh',
@@ -2101,7 +2139,7 @@ function checkPostMergeCleanupBacklog(
       root,
     );
     if (!evidence.ok) {
-      evidenceFailures.push(number as number);
+      evidenceFailures.push(number);
       continue;
     }
     // Only a trusted-author match counts as genuine cleanup evidence (see
@@ -2124,7 +2162,7 @@ function checkPostMergeCleanupBacklog(
         return trustedLogins.has(login);
       });
     if (!hasTrustedEvidence) {
-      missing.push(number as number);
+      missing.push(number);
     }
   }
 

--- a/tests/idd-doctor-cleanup-backlog-cli-smoke.test.mts
+++ b/tests/idd-doctor-cleanup-backlog-cli-smoke.test.mts
@@ -50,11 +50,20 @@ function buildCleanupBacklogStubGh(config: {
   mergedPrNumbers: number[];
   evidenceByPr: Map<number, string>;
   failEvidenceFor?: Set<number>;
+  // idd-skill#1829: per-PR head ref, defaulting to an `issue/*`-shaped
+  // branch so the pre-existing tests below (authored before the
+  // `headRefName` scoping fix) keep exercising an IDD-branch PR without
+  // being rewritten.
+  headRefNameByPr?: Map<number, string>;
 }): string {
   const owner = JSON.stringify(config.owner);
   const repo = JSON.stringify(config.repo);
+  const headRefNameByPr = config.headRefNameByPr ?? new Map();
   const prListJson = JSON.stringify(
-    config.mergedPrNumbers.map((number) => ({ number })),
+    config.mergedPrNumbers.map((number) => ({
+      number,
+      headRefName: headRefNameByPr.get(number) ?? `issue/${number}-fixture`,
+    })),
   );
   const evidenceTable = JSON.stringify([...config.evidenceByPr.entries()]);
   const failingNumbers = JSON.stringify([...(config.failEvidenceFor ?? [])]);
@@ -219,5 +228,42 @@ test('checkPostMergeCleanupBacklog CLI: a per-PR evidence-fetch failure is repor
       !report.warnings.some((w) => w.includes(BACKLOG_WARNING_SUBSTRING)),
       `evidence-fetch failures must not be folded into the missing-evidence backlog warning, got: ${JSON.stringify(report.warnings)}`,
     );
+  });
+});
+
+// idd-skill#1829: a Dependabot-style (or any other non-IDD) branch must
+// never count toward the backlog total or the `Examples: ...` list -- only
+// `checkPostMergeCleanupBacklog`'s IDD-branch-naming scoping fix
+// distinguishes the two; the pre-fix code counted both merged PRs
+// regardless of head ref, which this test would fail against (count 2,
+// #802 present).
+test('checkPostMergeCleanupBacklog CLI: excludes a merged PR whose head ref is not an IDD branch (idd-skill#1829)', () => {
+  withTempCwd((cwd) => {
+    const report = runIddDoctorReport(
+      cwd,
+      buildCleanupBacklogStubGh({
+        owner: 'o',
+        repo: 'r',
+        mergedPrNumbers: [801, 802],
+        evidenceByPr: new Map(),
+        headRefNameByPr: new Map([
+          [801, 'issue/801-fix-foo'],
+          [802, 'dependabot/npm_and_yarn/lodash-4.17.21'],
+        ]),
+      }),
+    );
+    const backlogWarning = report.warnings.find((w) =>
+      w.includes(BACKLOG_WARNING_SUBSTRING),
+    );
+    assert.ok(
+      backlogWarning,
+      `expected a cleanup-backlog warning, got: ${JSON.stringify(report.warnings)}`,
+    );
+    assert.match(
+      backlogWarning ?? '',
+      /^post-merge cleanup backlog: 1 merged PRs/,
+    );
+    assert.match(backlogWarning ?? '', /#801/);
+    assert.doesNotMatch(backlogWarning ?? '', /#802/);
   });
 });

--- a/tests/idd-doctor-cleanup-backlog-cli-smoke.test.mts
+++ b/tests/idd-doctor-cleanup-backlog-cli-smoke.test.mts
@@ -259,9 +259,12 @@ test('checkPostMergeCleanupBacklog CLI: excludes a merged PR whose head ref is n
       backlogWarning,
       `expected a cleanup-backlog warning, got: ${JSON.stringify(report.warnings)}`,
     );
+    // Match both "1 merged PR" and "1 merged PRs" -- this assertion targets
+    // the count/scoping behavior, not the production message's pluralization
+    // (idd-skill#1846 review).
     assert.match(
       backlogWarning ?? '',
-      /^post-merge cleanup backlog: 1 merged PRs/,
+      /^post-merge cleanup backlog: 1 merged PRs?\b/,
     );
     assert.match(backlogWarning ?? '', /#801/);
     assert.doesNotMatch(backlogWarning ?? '', /#802/);

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -28,6 +28,7 @@ import {
   evaluateDependencyVersionDrift,
   evaluateMarkerPrefixConsistency,
   extractMarkerPrefixes,
+  filterIddBranchMergedPrs,
   findMissingWorkshopReferences,
   findMissingWorktreeHardening,
   findPlaceholders,
@@ -456,6 +457,42 @@ test('classifyPrimaryHead handles empty or non-string input as unknown', () => {
     isB1Violation: false,
     kind: 'unknown',
   });
+});
+
+test('filterIddBranchMergedPrs keeps issue/* and roadmap-audit/* head refs and drops a Dependabot-style branch (idd-skill#1829)', () => {
+  const result = filterIddBranchMergedPrs([
+    { number: 101, headRefName: 'issue/101-fix-foo' },
+    { number: 102, headRefName: 'roadmap-audit/45-bar' },
+    { number: 103, headRefName: 'dependabot/npm_and_yarn/lodash-4.17.21' },
+  ]);
+  assert.deepEqual(result, [{ number: 101 }, { number: 102 }]);
+});
+
+test('filterIddBranchMergedPrs drops malformed entries (missing headRefName, non-integer number)', () => {
+  const result = filterIddBranchMergedPrs([
+    { number: 201, headRefName: 'issue/201-ok' },
+    { number: 202 },
+    { headRefName: 'issue/203-no-number' },
+    { number: 'not-a-number', headRefName: 'issue/204-bad-number' },
+    null,
+  ]);
+  assert.deepEqual(result, [{ number: 201 }]);
+});
+
+test('filterIddBranchMergedPrs returns an empty array for non-array input', () => {
+  assert.deepEqual(filterIddBranchMergedPrs(undefined), []);
+  assert.deepEqual(filterIddBranchMergedPrs(null), []);
+  assert.deepEqual(filterIddBranchMergedPrs('not-an-array'), []);
+});
+
+test('filterIddBranchMergedPrs honors a custom pattern list instead of the default', () => {
+  const prs = [
+    { number: 301, headRefName: 'issue/301-fix' },
+    { number: 302, headRefName: 'chore/302-bump' },
+  ];
+  assert.deepEqual(filterIddBranchMergedPrs(prs, ['chore/*']), [
+    { number: 302 },
+  ]);
 });
 
 test('classifyWorktreeHeadFinding returns null when HEAD is not a violation', () => {


### PR DESCRIPTION
# Summary

`checkPostMergeCleanupBacklog` (`src/scripts/idd-doctor.mts`) listed
merged PRs lacking F4 cleanup evidence by calling `gh pr list` scoped
only by merge-time window and `--json number` -- it never fetched or
filtered on `headRefName`, so every merged PR in the window counted
toward the backlog total and the `--cleanup-backlog-warn-threshold`
comparison, including PRs the IDD loop never claimed, worked, or was
responsible for cleaning up (routine Dependabot dependency-bump PRs,
for example).

This fetches `headRefName` alongside `number` from `gh pr list` and
filters the scanned PR set through a new pure `filterIddBranchMergedPrs`
helper before it ever reaches the backlog count, the evidence-fetch
loop, or the warning's `Examples: ...` list. The filter reuses the
existing `branchGlobToRegExp` matcher `classifyPrimaryHead` already
applies to the same globs, and reads patterns through the existing
`readWorktreeGuardBranchPatterns(root)` config reader, so a
repository-customized `worktreeGuard.branchPatterns` list is honored
too, not just the hardcoded `issue/*` / `roadmap-audit/*` defaults.

## Linked issue

Closes #1829

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Reported from an adopter repository (`kurone-kito/web-toybox`) during
its first IDD onboarding: in a repository with routine non-IDD merge
traffic, the backlog warning's signal was partly determined by noise
unrelated to IDD hygiene. Distinct from #1718 (remediation-command
resolution) and #1145 (progress streaming) -- both closed, both about a
different aspect of the same #732 feature, neither about scan-scope
false positives from non-IDD PRs.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs touched by this change)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
