### PR TITLE
fix(protocol-helpers): gate reviewDecision APPROVED bypass on data

### DIFF
--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -425,6 +425,15 @@ export function collectPreMergeReadiness(argv) {
       codeownersText,
       eligibleCodeownerUserLogins,
       eligibleCodeownerUserLoginsUnreadable,
+      // #1837: `reviews` above is fetched by the uncaught `ghApiJson` call
+      // a few lines up (no `fetchGovernanceJson`-style tolerance) -- a
+      // fetch failure throws and crashes this whole CLI invocation rather
+      // than reaching `buildPreMergeReadinessSummary` with partial data.
+      // This caller therefore never has genuinely-unclassifiable review
+      // data; pass `false` explicitly (rather than relying on the default)
+      // so the reason is documented at the one real call site instead of
+      // only in protocol-helpers.mts's option comment.
+      reviewsUnreadable: false,
       reviewDecision,
       mergeStateStatus,
       mergeable,

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3458,6 +3458,7 @@ export function summarizeReviewerStates(
     changedFiles = [],
     eligibleCodeownerUserLogins = null,
     eligibleCodeownerUserLoginsUnreadable = false,
+    reviewsUnreadable = false,
     advisoryBotLogins = [],
     prAuthorLogin = '',
     viewerLogin = '',
@@ -3552,6 +3553,16 @@ export function summarizeReviewerStates(
         if ((requirement.minimumApprovals ?? 0) <= 0) {
           return true;
         }
+        // #1837: deliberately NOT gated by `reviewsUnreadable` (unlike the
+        // `codeownerApprovalSatisfied`/`requiredApprovalsSatisfied` bypasses
+        // fixed below). A team-identity requirement (`requirement.identity`
+        // contains `/`, checked immediately below) can never be resolved to
+        // a reviewing login from `reviews` data -- this code has no team
+        // membership lookup at all -- so GitHub's own aggregate decision is
+        // the only signal available for it regardless of whether the caller
+        // fetched full review data. See "required reviewer rule objects
+        // stay blocking until GitHub marks approval satisfied" in
+        // tests/pre-merge-readiness.test.mts, which locks this in.
         if (normalizedReviewDecision === 'APPROVED') {
           return true;
         }
@@ -3561,13 +3572,26 @@ export function summarizeReviewerStates(
         return latestByLogin.get(requirement.identity)?.state === 'APPROVED';
       },
     );
+  // #1837: `normalizedReviewDecision === 'APPROVED'` alone used to be an
+  // unconditional bypass here, letting GitHub's own aggregate `reviewDecision`
+  // (which can resolve APPROVED from a bot-only review -- GitHub shipped
+  // bot-review-state support 2026-08-01, see #1818's background) satisfy this
+  // gate even when the classified data this function already computed
+  // (`codeownerApproved`) shows the approval came only from a bot. When the
+  // caller genuinely could not fetch/classify individual reviews
+  // (`reviewsUnreadable`), GitHub's aggregate is still the only available
+  // signal and stays a bypass. When review data IS available (the normal
+  // `collectPreMergeReadiness` path, which fails closed by throwing rather
+  // than ever reaching this function with partial data), the classified
+  // `codeownerApproved` check must also agree -- GitHub's `APPROVED` decision
+  // no longer overrides it on its own.
   const codeownerSelfApproval = summarizeCodeownerSelfApproval({
     requireCodeOwnerReview: branchReviewRequirements.requireCodeOwnerReview,
     codeownerApprovalSatisfied:
       !branchReviewRequirements.requireCodeOwnerReview ||
       !hasExplicitCodeownerMatches ||
       codeownerApproved ||
-      normalizedReviewDecision === 'APPROVED',
+      (reviewsUnreadable && normalizedReviewDecision === 'APPROVED'),
     hasExplicitCodeownerMatches,
     codeownerUserLogins: codeowners.codeownerUserLogins,
     eligibleCodeownerUserLogins:
@@ -3607,10 +3631,21 @@ export function summarizeReviewerStates(
     unmatchedCodeownerFiles: codeowners.unmatchedFiles,
     latestByAuthor,
     humanApprovedCount,
+    // #1837: see the comment above `codeownerSelfApproval` for the shared
+    // rationale. `reviewsUnreadable` keeps the pre-fix blanket-trust bypass
+    // (first disjunct) only when review data genuinely could not be
+    // classified. Otherwise (the normal, classifiable path -- the second
+    // disjunct), an `APPROVED` aggregate is treated the same as an empty
+    // one: it still must be corroborated by the classified
+    // `humanApprovedCount` reaching the required threshold (or the
+    // threshold being `0`, i.e. no approvals required at all -- nothing is
+    // missing, so this stays a pass by design, not a gap).
     requiredApprovalsSatisfied:
       requiredReviewerApprovalsSatisfied &&
-      (normalizedReviewDecision === 'APPROVED' ||
-        (!normalizedReviewDecision &&
+      ((reviewsUnreadable && normalizedReviewDecision === 'APPROVED') ||
+        (!reviewsUnreadable &&
+          (normalizedReviewDecision === 'APPROVED' ||
+            !normalizedReviewDecision) &&
           (branchReviewRequirements.requiredApprovingReviewCount === 0 ||
             humanApprovedCount >=
               branchReviewRequirements.requiredApprovingReviewCount))),
@@ -3618,7 +3653,7 @@ export function summarizeReviewerStates(
       !branchReviewRequirements.requireCodeOwnerReview ||
       !hasExplicitCodeownerMatches ||
       codeownerApproved ||
-      normalizedReviewDecision === 'APPROVED',
+      (reviewsUnreadable && normalizedReviewDecision === 'APPROVED'),
     codeownerSelfApproval,
     humanChangesRequestedCount: blockingChangesRequestedLogins.length,
     blockingChangesRequestedLogins,
@@ -4421,6 +4456,7 @@ export function buildPreMergeReadinessSummary(
     codeownersText = '',
     eligibleCodeownerUserLogins = null,
     eligibleCodeownerUserLoginsUnreadable = false,
+    reviewsUnreadable = false,
     reviewDecision = '',
     mergeStateStatus = '',
     mergeable = '',
@@ -4547,6 +4583,7 @@ export function buildPreMergeReadinessSummary(
     changedFiles,
     eligibleCodeownerUserLogins,
     eligibleCodeownerUserLoginsUnreadable,
+    reviewsUnreadable,
     advisoryBotLogins: reviewerStateAdvisoryBotLogins,
     prAuthorLogin,
     viewerLogin: options.viewerLogin,

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -646,6 +646,15 @@ export function collectPreMergeReadiness(
       codeownersText,
       eligibleCodeownerUserLogins,
       eligibleCodeownerUserLoginsUnreadable,
+      // #1837: `reviews` above is fetched by the uncaught `ghApiJson` call
+      // a few lines up (no `fetchGovernanceJson`-style tolerance) -- a
+      // fetch failure throws and crashes this whole CLI invocation rather
+      // than reaching `buildPreMergeReadinessSummary` with partial data.
+      // This caller therefore never has genuinely-unclassifiable review
+      // data; pass `false` explicitly (rather than relying on the default)
+      // so the reason is documented at the one real call site instead of
+      // only in protocol-helpers.mts's option comment.
+      reviewsUnreadable: false,
       reviewDecision,
       mergeStateStatus,
       mergeable,

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4439,6 +4439,7 @@ export function summarizeReviewerStates(
     changedFiles = [],
     eligibleCodeownerUserLogins = null,
     eligibleCodeownerUserLoginsUnreadable = false,
+    reviewsUnreadable = false,
     advisoryBotLogins = [],
     prAuthorLogin = '',
     viewerLogin = '',
@@ -4456,6 +4457,8 @@ export function summarizeReviewerStates(
     eligibleCodeownerUserLogins?: unknown[] | null;
     // #1521: see `buildPreMergeReadinessSummary`'s option of the same name.
     eligibleCodeownerUserLoginsUnreadable?: boolean;
+    // #1837: see `buildPreMergeReadinessSummary`'s option of the same name.
+    reviewsUnreadable?: boolean;
     advisoryBotLogins?: unknown[];
     prAuthorLogin?: string | null;
     viewerLogin?: string | null;
@@ -4553,6 +4556,16 @@ export function summarizeReviewerStates(
         if ((requirement.minimumApprovals ?? 0) <= 0) {
           return true;
         }
+        // #1837: deliberately NOT gated by `reviewsUnreadable` (unlike the
+        // `codeownerApprovalSatisfied`/`requiredApprovalsSatisfied` bypasses
+        // fixed below). A team-identity requirement (`requirement.identity`
+        // contains `/`, checked immediately below) can never be resolved to
+        // a reviewing login from `reviews` data -- this code has no team
+        // membership lookup at all -- so GitHub's own aggregate decision is
+        // the only signal available for it regardless of whether the caller
+        // fetched full review data. See "required reviewer rule objects
+        // stay blocking until GitHub marks approval satisfied" in
+        // tests/pre-merge-readiness.test.mts, which locks this in.
         if (normalizedReviewDecision === 'APPROVED') {
           return true;
         }
@@ -4562,13 +4575,26 @@ export function summarizeReviewerStates(
         return latestByLogin.get(requirement.identity)?.state === 'APPROVED';
       },
     );
+  // #1837: `normalizedReviewDecision === 'APPROVED'` alone used to be an
+  // unconditional bypass here, letting GitHub's own aggregate `reviewDecision`
+  // (which can resolve APPROVED from a bot-only review -- GitHub shipped
+  // bot-review-state support 2026-08-01, see #1818's background) satisfy this
+  // gate even when the classified data this function already computed
+  // (`codeownerApproved`) shows the approval came only from a bot. When the
+  // caller genuinely could not fetch/classify individual reviews
+  // (`reviewsUnreadable`), GitHub's aggregate is still the only available
+  // signal and stays a bypass. When review data IS available (the normal
+  // `collectPreMergeReadiness` path, which fails closed by throwing rather
+  // than ever reaching this function with partial data), the classified
+  // `codeownerApproved` check must also agree -- GitHub's `APPROVED` decision
+  // no longer overrides it on its own.
   const codeownerSelfApproval = summarizeCodeownerSelfApproval({
     requireCodeOwnerReview: branchReviewRequirements.requireCodeOwnerReview,
     codeownerApprovalSatisfied:
       !branchReviewRequirements.requireCodeOwnerReview ||
       !hasExplicitCodeownerMatches ||
       codeownerApproved ||
-      normalizedReviewDecision === 'APPROVED',
+      (reviewsUnreadable && normalizedReviewDecision === 'APPROVED'),
     hasExplicitCodeownerMatches,
     codeownerUserLogins: codeowners.codeownerUserLogins,
     eligibleCodeownerUserLogins:
@@ -4609,10 +4635,21 @@ export function summarizeReviewerStates(
     unmatchedCodeownerFiles: codeowners.unmatchedFiles,
     latestByAuthor,
     humanApprovedCount,
+    // #1837: see the comment above `codeownerSelfApproval` for the shared
+    // rationale. `reviewsUnreadable` keeps the pre-fix blanket-trust bypass
+    // (first disjunct) only when review data genuinely could not be
+    // classified. Otherwise (the normal, classifiable path -- the second
+    // disjunct), an `APPROVED` aggregate is treated the same as an empty
+    // one: it still must be corroborated by the classified
+    // `humanApprovedCount` reaching the required threshold (or the
+    // threshold being `0`, i.e. no approvals required at all -- nothing is
+    // missing, so this stays a pass by design, not a gap).
     requiredApprovalsSatisfied:
       requiredReviewerApprovalsSatisfied &&
-      (normalizedReviewDecision === 'APPROVED' ||
-        (!normalizedReviewDecision &&
+      ((reviewsUnreadable && normalizedReviewDecision === 'APPROVED') ||
+        (!reviewsUnreadable &&
+          (normalizedReviewDecision === 'APPROVED' ||
+            !normalizedReviewDecision) &&
           (branchReviewRequirements.requiredApprovingReviewCount === 0 ||
             humanApprovedCount >=
               branchReviewRequirements.requiredApprovingReviewCount))),
@@ -4620,7 +4657,7 @@ export function summarizeReviewerStates(
       !branchReviewRequirements.requireCodeOwnerReview ||
       !hasExplicitCodeownerMatches ||
       codeownerApproved ||
-      normalizedReviewDecision === 'APPROVED',
+      (reviewsUnreadable && normalizedReviewDecision === 'APPROVED'),
     codeownerSelfApproval,
     humanChangesRequestedCount: blockingChangesRequestedLogins.length,
     blockingChangesRequestedLogins,
@@ -5583,6 +5620,7 @@ export function buildPreMergeReadinessSummary(
     codeownersText = '',
     eligibleCodeownerUserLogins = null,
     eligibleCodeownerUserLoginsUnreadable = false,
+    reviewsUnreadable = false,
     reviewDecision = '',
     mergeStateStatus = '',
     mergeable = '',
@@ -5627,6 +5665,15 @@ export function buildPreMergeReadinessSummary(
     // vacuously fire on an unread co-owner. Omitted by unit callers
     // (default `false`, unchanged pre-`#1521` behavior).
     eligibleCodeownerUserLoginsUnreadable?: boolean;
+    // #1837: true when the caller genuinely could not fetch/classify
+    // individual reviews (see `summarizeReviewerStates`'s option of the
+    // same name for the full rationale). `collectPreMergeReadiness` always
+    // passes `false` explicitly: its `reviews` fetch is an uncaught
+    // `ghApiJson` call, so a genuine failure crashes the whole CLI
+    // invocation rather than reaching here with partial data. Omitted by
+    // unit callers (default `false`, unchanged pre-`#1837` classified-data
+    // behavior).
+    reviewsUnreadable?: boolean;
     reviewDecision?: string | null;
     // #1513: live `gh pr view --json mergeable,mergeStateStatus` values for
     // the PR HEAD, paired with `branchRules`/`branchProtection` above to
@@ -5824,6 +5871,7 @@ export function buildPreMergeReadinessSummary(
     changedFiles,
     eligibleCodeownerUserLogins,
     eligibleCodeownerUserLoginsUnreadable,
+    reviewsUnreadable,
     advisoryBotLogins: reviewerStateAdvisoryBotLogins,
     prAuthorLogin,
     viewerLogin: options.viewerLogin,

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -794,6 +794,97 @@ test('buildPreMergeReadinessSummary: a default-recognized advisory bot (CodeRabb
   assert.equal(reviewerStates.codeownerApprovalSatisfied, false);
 });
 
+// #1837: unlike the tests above (which all deliberately use
+// `reviewDecision: 'REVIEW_REQUIRED'` so `codeownerApprovalSatisfied` cannot
+// be trivially satisfied by the aggregate alone), this test uses the exact
+// scenario the issue describes: GitHub's own `reviewDecision` resolves
+// `APPROVED` purely because a bot's review carries `state: 'APPROVED'` (the
+// 2026-08-01 GitHub rollout described in #1818's background), with a
+// `required_approving_review_count: 1` repo config -- the scenario the issue
+// itself names as the one that actually needs this fix. Full review data is
+// available to the caller (the normal `collectPreMergeReadiness` path,
+// `reviewsUnreadable` omitted/defaulted false), so the classified data
+// (`humanApprovedCount: 0`) must still block both gates despite the
+// `APPROVED` aggregate.
+test('buildPreMergeReadinessSummary: a bot-only APPROVED review does not satisfy codeowner/required-approval gates via the reviewDecision aggregate bypass when review data is classifiable', () => {
+  const prHeadSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const botLogin = 'coderabbitai[bot]';
+  const summary = buildPreMergeReadinessSummary(
+    {
+      prHeadSha,
+      reviews: [
+        {
+          author: { login: botLogin },
+          state: 'APPROVED',
+          commitId: prHeadSha,
+          submittedAt: '2026-08-02T00:00:00Z',
+        },
+      ],
+      changedFiles: ['README.md'],
+      codeownersText: `* @${botLogin}\n`,
+      branchRules: [
+        {
+          type: 'pull_request',
+          parameters: {
+            required_approving_review_count: 1,
+            require_code_owner_review: true,
+          },
+        },
+      ],
+      // GitHub's own aggregate says APPROVED, but the only review backing
+      // it is the bot's -- this is the bug scenario, not a legitimate pass.
+      reviewDecision: 'APPROVED',
+    },
+    {
+      now: '2026-08-02T00:05:00Z',
+      advisoryBotLogins: [],
+    },
+  );
+
+  const reviewerStates = summary.reviewerStates as Record<string, unknown>;
+  assert.equal(reviewerStates.humanApprovedCount, 0);
+  assert.equal(reviewerStates.codeownerApprovalSatisfied, false);
+  assert.equal(reviewerStates.requiredApprovalsSatisfied, false);
+});
+
+// #1837: the mirror case -- when the caller genuinely could not
+// fetch/classify individual reviews (`reviewsUnreadable: true`, `reviews`
+// empty even though a bot approval exists server-side), GitHub's own
+// aggregate `reviewDecision` remains the only available signal and must
+// still satisfy both gates, exactly as it did before this fix. This proves
+// the new signal is a real fallback, not a blanket removal of the bypass.
+test('buildPreMergeReadinessSummary: reviewsUnreadable lets the reviewDecision aggregate satisfy codeowner/required-approval gates when the caller could not classify reviews', () => {
+  const prHeadSha = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  const botLogin = 'coderabbitai[bot]';
+  const summary = buildPreMergeReadinessSummary(
+    {
+      prHeadSha,
+      reviews: [],
+      changedFiles: ['README.md'],
+      codeownersText: `* @${botLogin}\n`,
+      branchRules: [
+        {
+          type: 'pull_request',
+          parameters: {
+            required_approving_review_count: 1,
+            require_code_owner_review: true,
+          },
+        },
+      ],
+      reviewDecision: 'APPROVED',
+      reviewsUnreadable: true,
+    },
+    {
+      now: '2026-08-02T00:05:00Z',
+      advisoryBotLogins: [],
+    },
+  );
+
+  const reviewerStates = summary.reviewerStates as Record<string, unknown>;
+  assert.equal(reviewerStates.codeownerApprovalSatisfied, true);
+  assert.equal(reviewerStates.requiredApprovalsSatisfied, true);
+});
+
 test('email-only CODEOWNERS rules still block codeowner approval', () => {
   const summary = summarizeReviewerStates([], {
     branchRules: [


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`summarizeReviewerStates` in `src/scripts/protocol-helpers.mts` computed
`codeownerApprovalSatisfied` and `requiredApprovalsSatisfied` with an
unconditional `normalizedReviewDecision === 'APPROVED'` disjunct.
GitHub's own aggregate `reviewDecision` can resolve `APPROVED` from a
bot-only review (GitHub started letting bot review state resolve the
aggregate on 2026-08-01, per #1818's background), so this trusted the
aggregate as a blanket bypass even when the classified per-review data
these same functions already compute (`codeownerApproved`,
`humanApprovedCount`) showed the approval came only from an advisory
bot — a gap CodeRabbit flagged during #1826's review but which was
out of scope there (unconfirmed live on that PR, and needing its own
design decision).

This PR closes that gap with the minimal, correctly-scoped change:

- Adds a `reviewsUnreadable` option (default `false`) to
  `summarizeReviewerStates` / `buildPreMergeReadinessSummary`, following
  the existing sibling-option pattern (`branchRulesetsUnreadable`,
  `eligibleCodeownerUserLoginsUnreadable`).
- The blanket `reviewDecision === 'APPROVED'` bypass now fires
  unconditionally only when `reviewsUnreadable` is `true` — i.e. the
  caller genuinely could not fetch/classify individual reviews, so
  GitHub's aggregate is the only available signal.
- When review data is classifiable (the normal, default path — every
  real caller today), an `APPROVED` aggregate must be corroborated by
  the classified data (`codeownerApproved` for the codeowner gate;
  `humanApprovedCount` reaching the required threshold, or the
  threshold being `0`, for the required-approvals gate).
- `collectPreMergeReadiness` (`pre-merge-readiness.mts`) passes
  `reviewsUnreadable: false` explicitly with a comment: its `reviews`
  fetch is an uncaught `ghApiJson` call, so a genuine failure crashes
  the whole CLI invocation rather than reaching
  `buildPreMergeReadinessSummary` with partial data — this caller
  never produces `true` today, by design.
- Left `requiredReviewerApprovalsSatisfied`'s own, separate
  `reviewDecision === 'APPROVED'` bypass (used only for team-identity
  `required_reviewers` rules) untouched, with an explanatory comment:
  team membership cannot be resolved from review-author logins at
  all, so GitHub's aggregate is genuinely the only available signal
  there, independent of caller data availability. This is a
  structurally different case from the two gates this PR fixes, and
  an existing test already locks in that behavior.

## Linked issue

Closes #1837

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Full analysis and the accepted fix design are recorded in the issue
body and in the implementation-plan comment posted before B3
(<https://github.com/kurone-kito/idd-skill/issues/1837#issuecomment-5155869656>).
Key design decisions, in case a reviewer wants the "why" without
re-deriving it:

- The fix intentionally does **not** touch
  `requiredReviewerApprovalsSatisfied`'s team-reviewer bypass (see
  above) — narrower scope than a blanket removal, and the existing
  test `required reviewer rule objects stay blocking until GitHub
  marks approval satisfied` in `tests/pre-merge-readiness.test.mts`
  would fail if that path changed.
- `required_approving_review_count: 0` (no approvals required at all)
  still passes by design under the new classified-count check —
  nothing is missing, so there is nothing to block. The new
  regression test below deliberately uses
  `required_approving_review_count: 1` to exercise the scenario the
  issue names as the one that actually needs this fix.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (via `pre-push-validate`: biome, dprint, markdownlint,
      cspell)
- [x] `pnpm test` (`node --test tests/pre-merge-readiness.test.mts` — all
      237 tests pass, including two new regression tests for this fix;
      `tests/pre-merge-readiness-collection-smoke.test.mts` also passes
      unaffected)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (no docs touched by this change)
- [x] `node scripts/idd-doctor.mjs` (passed with 4 pre-existing,
      unrelated warnings)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed — this directly fixes a merge-gate
      correctness gap; both directions (bypass closed when
      classifiable, bypass preserved when genuinely unclassifiable)
      are covered by new regression tests, and no existing test
      changed.
- [x] Context budget impact reviewed (no instruction/template files
      touched)
