### PR TITLE
feat(pre-merge): hint at missing-disposition phrase and stale watermark

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1176,6 +1176,20 @@ Interpretation rules:
   (exits non-zero, no `gh` call) when passed without `--from-pr`, since manual
   mode already supplies `--head-sha` directly with nothing to compare it
   against.
+- `--from-pr` unaddressed-activity warning (`warnings`, kurone-kito/idd-skill#1833):
+  the JSON envelope (dry-run and `--apply` alike) carries an optional
+  `warnings` string array, present only when the fresh snapshot's
+  `dispositionEvidence.missingRegularCommentCount` /
+  `.missingThreadCount` are non-zero — comments or threads with **no**
+  disposition reply at all, whose activity this watermark's
+  `max-activity-at` / `total-item-count` are about to fold in as if
+  already reviewed. Surfaces the same evidence
+  `missing-disposition-evidence` blocks on at F2, but at watermark-post
+  time instead of only later via the readiness report. Diagnostic-only:
+  never blocks the post or changes `mode` / `body`. Deliberately **not**
+  based on the snapshot's `ackOnly` evidence, which is the carve-out that
+  marks post-disposition advisory-bot courtesy acks safe to fold in —
+  warning on that would fire on the routine, benign path.
 - **No claim/state gating** (the `emit-marker` philosophy): this is a
   single-marker render+POST primitive, so the calling phase must run its
   claim-revalidation gate before `--apply`, exactly as the manual POST path it
@@ -1406,6 +1420,16 @@ to post it is the consuming track's job.
   on them. The semantic residual stays with the agent per the
   courtesy-ack convergence rule, and the disposition-evidence and
   unreplied-comment gates are unaffected
+- Disposition-evidence counters (kurone-kito/idd-skill#1833): the
+  snapshot also emits `dispositionEvidence` (`missingRegularCommentCount`,
+  `missingThreadCount`) — the same `summarizeDispositionEvidenceForGate`
+  evidence the F2 `missing-disposition-evidence` gate uses, trimmed to
+  its two counters (mirrors `advisory-convergence.mjs`'s own trimmed
+  projection of the same evidence, not `pre-merge-readiness.mjs`'s
+  richer field). A `--from-pr` watermark post
+  (`node scripts/post-idd-marker.mjs`) reads these to warn, in its own
+  success output, when the watermark it is about to post already covers
+  comments/threads that were never actually dispositioned
 - Readiness command: `node scripts/pre-merge-readiness.mjs`
   with `--pr <pr-number>`, `--claim-issue <issue-number>`,
   `--claim-id <claim-id>`, optional `--nonce <token>` (this session's own

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1180,8 +1180,8 @@ Interpretation rules:
   the JSON envelope (dry-run and `--apply` alike) carries an optional
   `warnings` string array, present only when the fresh snapshot's
   `dispositionEvidence.missingRegularCommentCount` /
-  `.missingThreadCount` are non-zero — comments or threads with **no**
-  disposition reply at all, whose activity this watermark's
+  `dispositionEvidence.missingThreadCount` are non-zero — comments or
+  threads with **no** disposition reply at all, whose activity this watermark's
   `max-activity-at` / `total-item-count` are about to fold in as if
   already reviewed. Surfaces the same evidence
   `missing-disposition-evidence` blocks on at F2, but at watermark-post

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1176,6 +1176,20 @@ Interpretation rules:
   (exits non-zero, no `gh` call) when passed without `--from-pr`, since manual
   mode already supplies `--head-sha` directly with nothing to compare it
   against.
+- `--from-pr` unaddressed-activity warning (`warnings`, kurone-kito/idd-skill#1833):
+  the JSON envelope (dry-run and `--apply` alike) carries an optional
+  `warnings` string array, present only when the fresh snapshot's
+  `dispositionEvidence.missingRegularCommentCount` /
+  `.missingThreadCount` are non-zero — comments or threads with **no**
+  disposition reply at all, whose activity this watermark's
+  `max-activity-at` / `total-item-count` are about to fold in as if
+  already reviewed. Surfaces the same evidence
+  `missing-disposition-evidence` blocks on at F2, but at watermark-post
+  time instead of only later via the readiness report. Diagnostic-only:
+  never blocks the post or changes `mode` / `body`. Deliberately **not**
+  based on the snapshot's `ackOnly` evidence, which is the carve-out that
+  marks post-disposition advisory-bot courtesy acks safe to fold in —
+  warning on that would fire on the routine, benign path.
 - **No claim/state gating** (the `emit-marker` philosophy): this is a
   single-marker render+POST primitive, so the calling phase must run its
   claim-revalidation gate before `--apply`, exactly as the manual POST path it
@@ -1406,6 +1420,16 @@ to post it is the consuming track's job.
   on them. The semantic residual stays with the agent per the
   courtesy-ack convergence rule, and the disposition-evidence and
   unreplied-comment gates are unaffected
+- Disposition-evidence counters (kurone-kito/idd-skill#1833): the
+  snapshot also emits `dispositionEvidence` (`missingRegularCommentCount`,
+  `missingThreadCount`) — the same `summarizeDispositionEvidenceForGate`
+  evidence the F2 `missing-disposition-evidence` gate uses, trimmed to
+  its two counters (mirrors `advisory-convergence.mjs`'s own trimmed
+  projection of the same evidence, not `pre-merge-readiness.mjs`'s
+  richer field). A `--from-pr` watermark post
+  (`node scripts/post-idd-marker.mjs`) reads these to warn, in its own
+  success output, when the watermark it is about to post already covers
+  comments/threads that were never actually dispositioned
 - Readiness command: `node scripts/pre-merge-readiness.mjs`
   with `--pr <pr-number>`, `--claim-issue <issue-number>`,
   `--claim-id <claim-id>`, optional `--nonce <token>` (this session's own

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1180,8 +1180,8 @@ Interpretation rules:
   the JSON envelope (dry-run and `--apply` alike) carries an optional
   `warnings` string array, present only when the fresh snapshot's
   `dispositionEvidence.missingRegularCommentCount` /
-  `.missingThreadCount` are non-zero — comments or threads with **no**
-  disposition reply at all, whose activity this watermark's
+  `dispositionEvidence.missingThreadCount` are non-zero — comments or
+  threads with **no** disposition reply at all, whose activity this watermark's
   `max-activity-at` / `total-item-count` are about to fold in as if
   already reviewed. Surfaces the same evidence
   `missing-disposition-evidence` blocks on at F2, but at watermark-post

--- a/schemas/post-idd-marker.schema.json
+++ b/schemas/post-idd-marker.schema.json
@@ -41,6 +41,12 @@
     },
     "url": {
       "type": "string"
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "additionalProperties": false

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -1005,6 +1005,9 @@
               },
               "bodyPreview": {
                 "type": "string"
+              },
+              "hint": {
+                "type": "string"
               }
             }
           }

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -259,11 +259,12 @@ export function describeUnaddressedActivity(snapshot) {
   }
   const itemTotal = commentCount + threadCount;
   const verb = itemTotal === 1 ? 'has' : 'have';
+  const pronoun = itemTotal === 1 ? 'it' : 'them';
   return [
     `${parts.join(' and ')} ${verb} no disposition evidence as of this ` +
-      'watermark, but its max-activity-at/total-item-count already cover ' +
-      'them -- dispose them (or re-run --from-pr after doing so) before ' +
-      'relying on this watermark.',
+      `watermark, but its max-activity-at/total-item-count already cover ` +
+      `${pronoun} -- dispose ${pronoun} (or re-run --from-pr after doing ` +
+      'so) before relying on this watermark.',
   ];
 }
 /**

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -212,6 +212,61 @@ export function watermarkFieldsFromSnapshot(snapshot) {
   };
 }
 /**
+ * #1833: diagnostic-only warnings for a `--from-pr` watermark whose fresh
+ * `review-activity-snapshot` already carries `dispositionEvidence` evidence
+ * -- comments and/or threads with NO disposition reply at all, per the same
+ * `summarizeDispositionEvidenceForGate` the F2 `missing-disposition-evidence`
+ * gate uses. This is deliberately NOT `ackOnly.items`: that evidence is the
+ * carve-out `diffReviewSnapshot` reads to treat post-disposition advisory-bot
+ * courtesy acks as safe to fold into the watermark, so it is populated on
+ * the routine, benign path (an ack after a correct disposition) and would
+ * warn on exactly the cases that are fine. `dispositionEvidence`'s counters
+ * are the opposite: genuinely undispositioned items, which the watermark is
+ * about to silently mark "already reviewed" by folding their activity into
+ * its `max-activity-at` / `total-item-count` fields. Surfacing that now, in
+ * this command's own success output, lets the caller see it at post time
+ * instead of discovering it only later via the readiness report's
+ * `missing-disposition-evidence` route (or, if the item happens to look
+ * ack-only-shaped, via `reviewCurrency.comparisonRoute`).
+ *
+ * Returns `[]` when the snapshot carries no such evidence, including when
+ * `dispositionEvidence` is absent or malformed (diagnostic-only: fails open,
+ * never blocks or alters what gets POSTed).
+ */
+export function describeUnaddressedActivity(snapshot) {
+  const snap = snapshot ?? {};
+  const missingComments = Number(
+    snap.dispositionEvidence?.missingRegularCommentCount ?? 0,
+  );
+  const missingThreads = Number(
+    snap.dispositionEvidence?.missingThreadCount ?? 0,
+  );
+  const commentCount =
+    Number.isInteger(missingComments) && missingComments > 0
+      ? missingComments
+      : 0;
+  const threadCount =
+    Number.isInteger(missingThreads) && missingThreads > 0 ? missingThreads : 0;
+  if (commentCount === 0 && threadCount === 0) {
+    return [];
+  }
+  const parts = [];
+  if (commentCount > 0) {
+    parts.push(`${commentCount} comment${commentCount === 1 ? '' : 's'}`);
+  }
+  if (threadCount > 0) {
+    parts.push(`${threadCount} thread${threadCount === 1 ? '' : 's'}`);
+  }
+  const itemTotal = commentCount + threadCount;
+  const verb = itemTotal === 1 ? 'has' : 'have';
+  return [
+    `${parts.join(' and ')} ${verb} no disposition evidence as of this ` +
+      'watermark, but its max-activity-at/total-item-count already cover ' +
+      'them -- dispose them (or re-run --from-pr after doing so) before ' +
+      'relying on this watermark.',
+  ];
+}
+/**
  * Parse a whole-token positive integer, failing closed on a suffixed typo
  * (`1047abc`), a non-numeric token, or a non-positive / unsafe magnitude — a
  * mis-parsed target number could POST a marker to the wrong issue/PR.
@@ -419,6 +474,9 @@ if (import.meta.main) {
     process.exit(1);
     throw error;
   }
+  // #1833: populated only by the `--from-pr` snapshot-derivation branch
+  // below; carried into both the dry-run and `--apply` result envelopes.
+  let warnings = [];
   if (args.help) {
     process.stdout.write(USAGE);
     process.exit(0);
@@ -502,6 +560,7 @@ if (import.meta.main) {
         args.advisoryBotLogins,
       );
       Object.assign(args.fields, watermarkFieldsFromSnapshot(snapshot));
+      warnings = describeUnaddressedActivity(snapshot);
     } catch (error) {
       process.stderr.write(
         `failed to derive watermark fields from PR ${args.fromPr}: ${error.message}\n`,
@@ -561,6 +620,7 @@ if (import.meta.main) {
       target: args.target,
       number,
       body,
+      ...(warnings.length > 0 ? { warnings } : {}),
     };
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     process.exit(0);
@@ -578,6 +638,7 @@ if (import.meta.main) {
     number,
     commentId: posted.id,
     url: posted.html_url,
+    ...(warnings.length > 0 ? { warnings } : {}),
   };
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
   process.exit(0);

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1072,6 +1072,17 @@ export function isNonReviewNoticeDisposition(comment) {
     /\bdid not review HEAD\b/i.test(body)
   );
 }
+// #1833 diagnostic-only hint text: single-sourced so
+// `summarizeDispositionEvidenceForGate`'s `missingRegularComments[].hint`
+// names the exact phrase `isNonReviewNoticeDisposition` requires, instead of
+// forcing an agent to source-dive this file to discover it. Never consumed by
+// any routing decision -- see the `hint` field's own doc comment on
+// `DispositionEvidenceSummary`.
+export const NON_REVIEW_NOTICE_DISPOSITION_HINT =
+  'disposition reply is missing the required non-review-notice phrase: it ' +
+  'must start with "**Rejected**" and match /\\bdid not review HEAD\\b/i -- ' +
+  'canonical form: "**Rejected** — {bot} did not review HEAD {sha} ' +
+  '({reason}); this is not a completed review"';
 // #1122 CodeRabbit summary-walkthrough auto-disposition classifiers.
 //
 // The CodeRabbit summary walkthrough is a regular comment whose body starts with
@@ -2692,6 +2703,32 @@ export function summarizeDispositionEvidenceForGate(
   const noticeDispositions = dispositionComments.filter((comment) =>
     isNonReviewNoticeDisposition({ body: comment.body }),
   );
+  // #1833 diagnostic-only (see `NON_REVIEW_NOTICE_DISPOSITION_HINT` /
+  // `DispositionEvidenceSummary.missingRegularComments[].hint`): IDD-agent
+  // replies that start with `**Rejected**` -- so `isDispositionComment` and
+  // the generic 1:1 pairing both accept them as SOME disposition -- but that
+  // do not match `isNonReviewNoticeDisposition`'s stricter `did not review
+  // HEAD` phrase requirement, so they can never satisfy the notice-specific
+  // carry-forward above. Kept separate from `noticeDispositions` (its exact
+  // complement within `**Rejected**`-prefixed replies) purely to power the
+  // hint; never feeds `carriedNoticeIndexes`, `dispositionTimes`, or any
+  // other routing input.
+  //
+  // Deliberately NOT attributed per-bot: `dispositionNamesAdvisoryBot`
+  // (the carry-forward's own bot-attribution helper) can only anchor on the
+  // canonical `did not review HEAD` template's span, so a wrong-phrase
+  // reply -- missing that exact phrase by definition -- can never be
+  // attributed to one bot over another by construction. In a multi-bot
+  // scenario (e.g. CodeRabbit's notice correctly dispositioned, Codex's
+  // still missing) the hint below attaches to every still-missing notice
+  // that ANY wrong-phrase reply postdates, not just the one it may have
+  // been intended for. Advisory-only, so this is a diagnostic false
+  // positive at worst, never a routing change.
+  const wrongPhraseRejectedDispositions = dispositionComments.filter(
+    (comment) =>
+      DISPOSITION_REJECTED_PREFIX_RE.test(comment.body.trimStart()) &&
+      !isNonReviewNoticeDisposition({ body: comment.body }),
+  );
   const outstandingNotices = outstandingComments.filter(
     (comment) =>
       isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins) &&
@@ -2761,12 +2798,40 @@ export function summarizeDispositionEvidenceForGate(
       missing.push(comment);
     }
   }
-  const missingRegularComments = missing.map((comment) => ({
-    id: comment.id || `comment-${comment.sortedIndex + 1}`,
-    authorLogin: comment.authorLogin || 'unknown',
-    createdAt: comment.createdAt,
-    bodyPreview: buildBodyPreview(comment.body),
-  }));
+  const missingRegularComments = missing.map((comment) => {
+    // #1833: only hint when this missing item is itself a recognized
+    // advisory non-review notice AND a wrong-phrase `**Rejected**` attempt
+    // exists that postdates the notice's original `createdAt` -- so the hint
+    // targets the specific comment a human/agent plausibly already tried
+    // (and mis-phrased) rather than every unrelated missing item whenever any
+    // wrong-phrase reply exists anywhere. Deliberately compares against
+    // `createdAt`, not the notice's (possibly bumped) `activityAt`: the
+    // motivating scenario is a wrong-phrase reply posted right after the
+    // notice first appeared, followed by a re-triggered bot bumping
+    // `updatedAt` past that reply -- which is exactly what strands the item
+    // in `missing` in the first place (see the `activityAt`-based general 1:1
+    // pairing above), so requiring the attempt to postdate the bumped
+    // `activityAt` would always be false in the one case this hint exists
+    // for.
+    const isNoticeComment =
+      isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins) &&
+      isAdvisoryNonReviewNotice(comment.body);
+    const hasWrongPhraseAttempt =
+      isNoticeComment &&
+      wrongPhraseRejectedDispositions.some(
+        (disposition) =>
+          compareIsoTimestamps(disposition.activityAt, comment.createdAt) > 0,
+      );
+    return {
+      id: comment.id || `comment-${comment.sortedIndex + 1}`,
+      authorLogin: comment.authorLogin || 'unknown',
+      createdAt: comment.createdAt,
+      bodyPreview: buildBodyPreview(comment.body),
+      ...(hasWrongPhraseAttempt
+        ? { hint: NON_REVIEW_NOTICE_DISPOSITION_HINT }
+        : {}),
+    };
+  });
   // #978 advisory-only diagnostic: a blocking resolved thread is
   // "ack-only-post-disposition" when a thread-local IDD disposition exists and
   // EVERY external comment newer than BOTH the snapshot boundary (so it re-blocks

--- a/scripts/review-activity-snapshot.mjs
+++ b/scripts/review-activity-snapshot.mjs
@@ -12,6 +12,7 @@ import {
   parsePaginatedGhNdjson,
   resolveAdvisoryBotLogins,
   resolveTrustedMarkerActors,
+  summarizeDispositionEvidenceForGate,
 } from './protocol-helpers.mjs';
 
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
@@ -69,17 +70,30 @@ function main() {
       envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
       config: iddConfig,
     });
-  const headSha = ghText([
+  // #1833: also reads `author.login` (not just `headRefOid`) in this same
+  // call -- `summarizeDispositionEvidenceForGate` below needs the PR
+  // author's login to exclude the author's own comments/thread replies from
+  // "missing disposition" (they never require one), the same way
+  // `buildPreMergeReadinessSummary`'s own call to that function does.
+  // `ghJson`'s empty-response fallback is `'[]'` (array-shaped, tuned for
+  // the paginated `checks` call above); on this object-shaped `pr view`
+  // call an empty response would leave `headRefOid`/`author` both
+  // undefined, so `headSha` below becomes `''` and
+  // `watermarkFieldsFromSnapshot` (post-idd-marker.mts) throws "missing a
+  // usable headSha" downstream -- fail-closed, not a silent bad watermark.
+  const prView = ghJson([
     'pr',
     'view',
     String(args.prNumber),
     '-R',
     repoRef,
     '--json',
-    'headRefOid',
-    '--jq',
-    '.headRefOid',
+    'headRefOid,author',
   ]);
+  const headSha = String(prView.headRefOid ?? '');
+  const prAuthorLogin = String(prView.author?.login ?? '')
+    .trim()
+    .toLowerCase();
   const checks = ghJson(
     [
       'pr',
@@ -103,11 +117,13 @@ function main() {
     true,
   );
   const threads = fetchReviewThreads(owner, repo, args.prNumber);
+  const normalizedComments = comments.map(normalizeComment);
+  const normalizedThreads = threads.map(normalizeThread);
   const summary = buildActivitySnapshotSummary(
     {
-      comments: comments.map(normalizeComment),
+      comments: normalizedComments,
       reviews: reviews.map(normalizeReview),
-      threads: threads.map(normalizeThread),
+      threads: normalizedThreads,
       checks,
     },
     {
@@ -117,6 +133,27 @@ function main() {
       // Advisory bots are excluded from disposition authorship inside the
       // summary builder, so the trusted-marker set is a safe default here.
       dispositionAuthorLogins: trustedMarkerLogins,
+    },
+  );
+  // #1833: exposed so a `--from-pr` watermark post (post-idd-marker.mts) can
+  // warn, in its own success output, when the fresh snapshot it is about to
+  // become the watermark still has comments/threads lacking disposition
+  // evidence -- instead of that only surfacing later via the readiness
+  // report's `reviewCurrency.comparisonRoute`. Trimmed to the two counters,
+  // mirroring `AdvisoryConvergenceDispositionEvidence`
+  // (advisory-convergence.mts) rather than re-exporting the full
+  // `DispositionEvidenceSummary` shape (`pre-merge-readiness.mjs`'s own
+  // richer `dispositionEvidence` field) -- no `snapshotBoundaryAt` is
+  // available here (no watermark exists yet at snapshot time), so the
+  // advisory-only ack sub-flags this function also returns would be
+  // meaningless; only the two counters are stable to expose.
+  const dispositionEvidence = summarizeDispositionEvidenceForGate(
+    { comments: normalizedComments, threads: normalizedThreads },
+    {
+      iddAgentLogins: trustedMarkerLogins,
+      advisoryBotLogins,
+      trustedMarkerLogins,
+      prAuthorLogin,
     },
   );
   process.stdout.write(
@@ -132,6 +169,11 @@ function main() {
         counts: summary.counts,
         ackOnly: summary.ackOnly,
         effective: summary.effective,
+        dispositionEvidence: {
+          missingRegularCommentCount:
+            dispositionEvidence.missingRegularCommentCount,
+          missingThreadCount: dispositionEvidence.missingThreadCount,
+        },
       },
       null,
       2,

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -104,6 +104,17 @@ export interface PostIddMarkerResult {
   commentId?: number;
   /** Present in `--apply`: the created comment URL. */
   url?: string;
+  /**
+   * #1833: present (non-empty) only for a `--from-pr` watermark whose fresh
+   * snapshot already carries diagnostic evidence worth surfacing at post
+   * time -- e.g. comments/threads with no disposition evidence at all
+   * (`dispositionEvidence.missingRegularCommentCount` /
+   * `.missingThreadCount`), which this watermark's `max-activity-at` /
+   * `total-item-count` are about to fold in as if already reviewed.
+   * Diagnostic-only: never changes `mode`, `body`, or whether the marker
+   * gets POSTed.
+   */
+  warnings?: string[];
 }
 
 /**
@@ -237,6 +248,67 @@ export function watermarkFieldsFromSnapshot(snapshot: unknown): MarkerFields {
     'total-item-count': String(totalItemCount),
     'ci-completed-at': isoOrNone(snap.latestPassingCiCompletedAt),
   };
+}
+
+/**
+ * #1833: diagnostic-only warnings for a `--from-pr` watermark whose fresh
+ * `review-activity-snapshot` already carries `dispositionEvidence` evidence
+ * -- comments and/or threads with NO disposition reply at all, per the same
+ * `summarizeDispositionEvidenceForGate` the F2 `missing-disposition-evidence`
+ * gate uses. This is deliberately NOT `ackOnly.items`: that evidence is the
+ * carve-out `diffReviewSnapshot` reads to treat post-disposition advisory-bot
+ * courtesy acks as safe to fold into the watermark, so it is populated on
+ * the routine, benign path (an ack after a correct disposition) and would
+ * warn on exactly the cases that are fine. `dispositionEvidence`'s counters
+ * are the opposite: genuinely undispositioned items, which the watermark is
+ * about to silently mark "already reviewed" by folding their activity into
+ * its `max-activity-at` / `total-item-count` fields. Surfacing that now, in
+ * this command's own success output, lets the caller see it at post time
+ * instead of discovering it only later via the readiness report's
+ * `missing-disposition-evidence` route (or, if the item happens to look
+ * ack-only-shaped, via `reviewCurrency.comparisonRoute`).
+ *
+ * Returns `[]` when the snapshot carries no such evidence, including when
+ * `dispositionEvidence` is absent or malformed (diagnostic-only: fails open,
+ * never blocks or alters what gets POSTed).
+ */
+export function describeUnaddressedActivity(snapshot: unknown): string[] {
+  const snap = (snapshot ?? {}) as {
+    dispositionEvidence?: {
+      missingRegularCommentCount?: unknown;
+      missingThreadCount?: unknown;
+    } | null;
+  };
+  const missingComments = Number(
+    snap.dispositionEvidence?.missingRegularCommentCount ?? 0,
+  );
+  const missingThreads = Number(
+    snap.dispositionEvidence?.missingThreadCount ?? 0,
+  );
+  const commentCount =
+    Number.isInteger(missingComments) && missingComments > 0
+      ? missingComments
+      : 0;
+  const threadCount =
+    Number.isInteger(missingThreads) && missingThreads > 0 ? missingThreads : 0;
+  if (commentCount === 0 && threadCount === 0) {
+    return [];
+  }
+  const parts: string[] = [];
+  if (commentCount > 0) {
+    parts.push(`${commentCount} comment${commentCount === 1 ? '' : 's'}`);
+  }
+  if (threadCount > 0) {
+    parts.push(`${threadCount} thread${threadCount === 1 ? '' : 's'}`);
+  }
+  const itemTotal = commentCount + threadCount;
+  const verb = itemTotal === 1 ? 'has' : 'have';
+  return [
+    `${parts.join(' and ')} ${verb} no disposition evidence as of this ` +
+      'watermark, but its max-activity-at/total-item-count already cover ' +
+      'them -- dispose them (or re-run --from-pr after doing so) before ' +
+      'relying on this watermark.',
+  ];
 }
 
 // ---------------------------------------------------------------------------
@@ -485,6 +557,9 @@ if (import.meta.main) {
     process.exit(1);
     throw error;
   }
+  // #1833: populated only by the `--from-pr` snapshot-derivation branch
+  // below; carried into both the dry-run and `--apply` result envelopes.
+  let warnings: string[] = [];
 
   if (args.help) {
     process.stdout.write(USAGE);
@@ -570,6 +645,7 @@ if (import.meta.main) {
         args.advisoryBotLogins,
       );
       Object.assign(args.fields, watermarkFieldsFromSnapshot(snapshot));
+      warnings = describeUnaddressedActivity(snapshot);
     } catch (error) {
       process.stderr.write(
         `failed to derive watermark fields from PR ${args.fromPr}: ${(error as Error).message}\n`,
@@ -632,6 +708,7 @@ if (import.meta.main) {
       target: args.target as TargetKind,
       number,
       body,
+      ...(warnings.length > 0 ? { warnings } : {}),
     };
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     process.exit(0);
@@ -651,6 +728,7 @@ if (import.meta.main) {
     number,
     commentId: posted.id,
     url: posted.html_url,
+    ...(warnings.length > 0 ? { warnings } : {}),
   };
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
   process.exit(0);

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -303,11 +303,12 @@ export function describeUnaddressedActivity(snapshot: unknown): string[] {
   }
   const itemTotal = commentCount + threadCount;
   const verb = itemTotal === 1 ? 'has' : 'have';
+  const pronoun = itemTotal === 1 ? 'it' : 'them';
   return [
     `${parts.join(' and ')} ${verb} no disposition evidence as of this ` +
-      'watermark, but its max-activity-at/total-item-count already cover ' +
-      'them -- dispose them (or re-run --from-pr after doing so) before ' +
-      'relying on this watermark.',
+      `watermark, but its max-activity-at/total-item-count already cover ` +
+      `${pronoun} -- dispose ${pronoun} (or re-run --from-pr after doing ` +
+      'so) before relying on this watermark.',
   ];
 }
 

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -413,6 +413,17 @@ export interface DispositionEvidenceSummary {
     authorLogin: string;
     createdAt: string;
     bodyPreview: string;
+    // #1833 diagnostic-only (present only when applicable): set when this
+    // missing comment is itself a recognized advisory non-review notice
+    // (`isAdvisoryNonReviewNotice`) AND a later IDD-agent reply starting with
+    // `**Rejected**` exists but does not match `isNonReviewNoticeDisposition`
+    // -- an attempted disposition that used the wrong phrase, so the generic
+    // 1:1 disposition pairing accepted it as SOME disposition while the
+    // notice-specific carry-forward still rejects it and the item stays
+    // blocking. Names the exact required phrase so an agent does not have to
+    // source-dive `isNonReviewNoticeDisposition` to discover it. Never
+    // changes `route`, `reason`, or any count above.
+    hint?: string;
   }[];
   // `ackOnlyPostDisposition` is advisory-only: true when this blocking resolved
   // thread blocks solely because of post-disposition advisory-bot ack-only
@@ -1736,6 +1747,18 @@ export function isNonReviewNoticeDisposition(comment: {
     /\bdid not review HEAD\b/i.test(body)
   );
 }
+
+// #1833 diagnostic-only hint text: single-sourced so
+// `summarizeDispositionEvidenceForGate`'s `missingRegularComments[].hint`
+// names the exact phrase `isNonReviewNoticeDisposition` requires, instead of
+// forcing an agent to source-dive this file to discover it. Never consumed by
+// any routing decision -- see the `hint` field's own doc comment on
+// `DispositionEvidenceSummary`.
+export const NON_REVIEW_NOTICE_DISPOSITION_HINT =
+  'disposition reply is missing the required non-review-notice phrase: it ' +
+  'must start with "**Rejected**" and match /\\bdid not review HEAD\\b/i -- ' +
+  'canonical form: "**Rejected** — {bot} did not review HEAD {sha} ' +
+  '({reason}); this is not a completed review"';
 
 // #1122 CodeRabbit summary-walkthrough auto-disposition classifiers.
 //
@@ -3578,6 +3601,32 @@ export function summarizeDispositionEvidenceForGate(
   const noticeDispositions = dispositionComments.filter((comment) =>
     isNonReviewNoticeDisposition({ body: comment.body }),
   );
+  // #1833 diagnostic-only (see `NON_REVIEW_NOTICE_DISPOSITION_HINT` /
+  // `DispositionEvidenceSummary.missingRegularComments[].hint`): IDD-agent
+  // replies that start with `**Rejected**` -- so `isDispositionComment` and
+  // the generic 1:1 pairing both accept them as SOME disposition -- but that
+  // do not match `isNonReviewNoticeDisposition`'s stricter `did not review
+  // HEAD` phrase requirement, so they can never satisfy the notice-specific
+  // carry-forward above. Kept separate from `noticeDispositions` (its exact
+  // complement within `**Rejected**`-prefixed replies) purely to power the
+  // hint; never feeds `carriedNoticeIndexes`, `dispositionTimes`, or any
+  // other routing input.
+  //
+  // Deliberately NOT attributed per-bot: `dispositionNamesAdvisoryBot`
+  // (the carry-forward's own bot-attribution helper) can only anchor on the
+  // canonical `did not review HEAD` template's span, so a wrong-phrase
+  // reply -- missing that exact phrase by definition -- can never be
+  // attributed to one bot over another by construction. In a multi-bot
+  // scenario (e.g. CodeRabbit's notice correctly dispositioned, Codex's
+  // still missing) the hint below attaches to every still-missing notice
+  // that ANY wrong-phrase reply postdates, not just the one it may have
+  // been intended for. Advisory-only, so this is a diagnostic false
+  // positive at worst, never a routing change.
+  const wrongPhraseRejectedDispositions = dispositionComments.filter(
+    (comment) =>
+      DISPOSITION_REJECTED_PREFIX_RE.test(comment.body.trimStart()) &&
+      !isNonReviewNoticeDisposition({ body: comment.body }),
+  );
   const outstandingNotices = outstandingComments.filter(
     (comment) =>
       isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins) &&
@@ -3650,12 +3699,40 @@ export function summarizeDispositionEvidenceForGate(
     }
   }
 
-  const missingRegularComments = missing.map((comment) => ({
-    id: comment.id || `comment-${comment.sortedIndex + 1}`,
-    authorLogin: comment.authorLogin || 'unknown',
-    createdAt: comment.createdAt,
-    bodyPreview: buildBodyPreview(comment.body),
-  }));
+  const missingRegularComments = missing.map((comment) => {
+    // #1833: only hint when this missing item is itself a recognized
+    // advisory non-review notice AND a wrong-phrase `**Rejected**` attempt
+    // exists that postdates the notice's original `createdAt` -- so the hint
+    // targets the specific comment a human/agent plausibly already tried
+    // (and mis-phrased) rather than every unrelated missing item whenever any
+    // wrong-phrase reply exists anywhere. Deliberately compares against
+    // `createdAt`, not the notice's (possibly bumped) `activityAt`: the
+    // motivating scenario is a wrong-phrase reply posted right after the
+    // notice first appeared, followed by a re-triggered bot bumping
+    // `updatedAt` past that reply -- which is exactly what strands the item
+    // in `missing` in the first place (see the `activityAt`-based general 1:1
+    // pairing above), so requiring the attempt to postdate the bumped
+    // `activityAt` would always be false in the one case this hint exists
+    // for.
+    const isNoticeComment =
+      isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins) &&
+      isAdvisoryNonReviewNotice(comment.body);
+    const hasWrongPhraseAttempt =
+      isNoticeComment &&
+      wrongPhraseRejectedDispositions.some(
+        (disposition) =>
+          compareIsoTimestamps(disposition.activityAt, comment.createdAt) > 0,
+      );
+    return {
+      id: comment.id || `comment-${comment.sortedIndex + 1}`,
+      authorLogin: comment.authorLogin || 'unknown',
+      createdAt: comment.createdAt,
+      bodyPreview: buildBodyPreview(comment.body),
+      ...(hasWrongPhraseAttempt
+        ? { hint: NON_REVIEW_NOTICE_DISPOSITION_HINT }
+        : {}),
+    };
+  });
 
   // #978 advisory-only diagnostic: a blocking resolved thread is
   // "ack-only-post-disposition" when a thread-local IDD disposition exists and

--- a/src/scripts/review-activity-snapshot.mts
+++ b/src/scripts/review-activity-snapshot.mts
@@ -13,6 +13,7 @@ import {
   parsePaginatedGhNdjson,
   resolveAdvisoryBotLogins,
   resolveTrustedMarkerActors,
+  summarizeDispositionEvidenceForGate,
 } from './protocol-helpers.mts';
 
 /** Author reference embedded in GitHub REST/GraphQL payloads. */
@@ -143,17 +144,33 @@ function main(): void {
       config: iddConfig,
     });
 
-  const headSha = ghText([
+  // #1833: also reads `author.login` (not just `headRefOid`) in this same
+  // call -- `summarizeDispositionEvidenceForGate` below needs the PR
+  // author's login to exclude the author's own comments/thread replies from
+  // "missing disposition" (they never require one), the same way
+  // `buildPreMergeReadinessSummary`'s own call to that function does.
+  // `ghJson`'s empty-response fallback is `'[]'` (array-shaped, tuned for
+  // the paginated `checks` call above); on this object-shaped `pr view`
+  // call an empty response would leave `headRefOid`/`author` both
+  // undefined, so `headSha` below becomes `''` and
+  // `watermarkFieldsFromSnapshot` (post-idd-marker.mts) throws "missing a
+  // usable headSha" downstream -- fail-closed, not a silent bad watermark.
+  const prView = ghJson([
     'pr',
     'view',
     String(args.prNumber),
     '-R',
     repoRef,
     '--json',
-    'headRefOid',
-    '--jq',
-    '.headRefOid',
-  ]);
+    'headRefOid,author',
+  ]) as {
+    headRefOid?: string | null;
+    author?: { login?: string | null } | null;
+  };
+  const headSha = String(prView.headRefOid ?? '');
+  const prAuthorLogin = String(prView.author?.login ?? '')
+    .trim()
+    .toLowerCase();
   const checks = ghJson(
     [
       'pr',
@@ -177,12 +194,14 @@ function main(): void {
     true,
   ) as IssueCommentPayload[];
   const threads = fetchReviewThreads(owner, repo, args.prNumber);
+  const normalizedComments = comments.map(normalizeComment);
+  const normalizedThreads = threads.map(normalizeThread);
 
   const summary = buildActivitySnapshotSummary(
     {
-      comments: comments.map(normalizeComment),
+      comments: normalizedComments,
       reviews: reviews.map(normalizeReview),
-      threads: threads.map(normalizeThread),
+      threads: normalizedThreads,
       checks,
     },
     {
@@ -192,6 +211,28 @@ function main(): void {
       // Advisory bots are excluded from disposition authorship inside the
       // summary builder, so the trusted-marker set is a safe default here.
       dispositionAuthorLogins: trustedMarkerLogins,
+    },
+  );
+
+  // #1833: exposed so a `--from-pr` watermark post (post-idd-marker.mts) can
+  // warn, in its own success output, when the fresh snapshot it is about to
+  // become the watermark still has comments/threads lacking disposition
+  // evidence -- instead of that only surfacing later via the readiness
+  // report's `reviewCurrency.comparisonRoute`. Trimmed to the two counters,
+  // mirroring `AdvisoryConvergenceDispositionEvidence`
+  // (advisory-convergence.mts) rather than re-exporting the full
+  // `DispositionEvidenceSummary` shape (`pre-merge-readiness.mjs`'s own
+  // richer `dispositionEvidence` field) -- no `snapshotBoundaryAt` is
+  // available here (no watermark exists yet at snapshot time), so the
+  // advisory-only ack sub-flags this function also returns would be
+  // meaningless; only the two counters are stable to expose.
+  const dispositionEvidence = summarizeDispositionEvidenceForGate(
+    { comments: normalizedComments, threads: normalizedThreads },
+    {
+      iddAgentLogins: trustedMarkerLogins,
+      advisoryBotLogins,
+      trustedMarkerLogins,
+      prAuthorLogin,
     },
   );
 
@@ -208,6 +249,11 @@ function main(): void {
         counts: summary.counts,
         ackOnly: summary.ackOnly,
         effective: summary.effective,
+        dispositionEvidence: {
+          missingRegularCommentCount:
+            dispositionEvidence.missingRegularCommentCount,
+          missingThreadCount: dispositionEvidence.missingThreadCount,
+        },
       },
       null,
       2,

--- a/tests/gh-pagination-parsing-smoke.test.mts
+++ b/tests/gh-pagination-parsing-smoke.test.mts
@@ -212,6 +212,9 @@ test('stalled-session-quiet-check.mjs CLI: parses multi-line NDJSON output from 
 test('review-activity-snapshot.mjs CLI: parses multi-line NDJSON output from paginated review/comment endpoints', () => {
   const responses = new Map<string, string>([
     [
+      // #1833: review-activity-snapshot.mts now reads `author.login`
+      // alongside `headRefOid` in this same call (no `--jq`, so the
+      // response is the whole JSON object, not a bare SHA string).
       JSON.stringify([
         'pr',
         'view',
@@ -219,11 +222,9 @@ test('review-activity-snapshot.mjs CLI: parses multi-line NDJSON output from pag
         '-R',
         REPO_REF,
         '--json',
-        'headRefOid',
-        '--jq',
-        '.headRefOid',
+        'headRefOid,author',
       ]),
-      HEAD_SHA,
+      JSON.stringify({ headRefOid: HEAD_SHA, author: { login: 'pr-author' } }),
     ],
     [
       JSON.stringify([

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -8,6 +8,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   buildMarkerBody,
+  describeUnaddressedActivity,
   MARKER_TYPES,
   parseArgs,
   watermarkFieldsFromSnapshot,
@@ -30,6 +31,14 @@ import {
 // A real 40-hex SHA — the watermark/baseline/advisory renderers require it.
 const SHA = '0123456789abcdef0123456789abcdef01234567';
 const TS = '2026-06-17T09:47:08Z';
+
+// #1833: the exact `describeUnaddressedActivity` warning text for the
+// `writeReviewActivitySnapshotGhStub` / inline "--from-pr CLI composes..."
+// fixture's one plain, never-dispositioned comment (`body: 'hi'`).
+const NO_DISPOSITION_EVIDENCE_WARNING_ONE_COMMENT =
+  '1 comment has no disposition evidence as of this watermark, but its ' +
+  'max-activity-at/total-item-count already cover them -- dispose them ' +
+  '(or re-run --from-pr after doing so) before relying on this watermark.';
 
 const schema = loadJson('schemas/post-idd-marker.schema.json');
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
@@ -871,6 +880,88 @@ test('parseArgs reads --expected-head-sha as a structural flag, not a renderer f
   assert.deepEqual(args.fields, { 'agent-id': 'a', 'claim-id': 'c' });
 });
 
+// --- #1833: describeUnaddressedActivity (the --from-pr watermark warning) ---
+
+test('describeUnaddressedActivity returns [] when dispositionEvidence is absent', () => {
+  assert.deepEqual(describeUnaddressedActivity({}), []);
+  assert.deepEqual(describeUnaddressedActivity(null), []);
+  assert.deepEqual(describeUnaddressedActivity(undefined), []);
+});
+
+test('describeUnaddressedActivity returns [] when both counters are zero', () => {
+  assert.deepEqual(
+    describeUnaddressedActivity({
+      dispositionEvidence: {
+        missingRegularCommentCount: 0,
+        missingThreadCount: 0,
+      },
+    }),
+    [],
+  );
+});
+
+test('describeUnaddressedActivity warns (singular) for exactly one missing comment', () => {
+  const warnings = describeUnaddressedActivity({
+    dispositionEvidence: {
+      missingRegularCommentCount: 1,
+      missingThreadCount: 0,
+    },
+  });
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /^1 comment has no disposition evidence/);
+});
+
+test('describeUnaddressedActivity warns (plural) for multiple missing comments', () => {
+  const warnings = describeUnaddressedActivity({
+    dispositionEvidence: {
+      missingRegularCommentCount: 3,
+      missingThreadCount: 0,
+    },
+  });
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /^3 comments have no disposition evidence/);
+});
+
+test('describeUnaddressedActivity reports both comments and threads together', () => {
+  const warnings = describeUnaddressedActivity({
+    dispositionEvidence: {
+      missingRegularCommentCount: 2,
+      missingThreadCount: 1,
+    },
+  });
+  assert.equal(warnings.length, 1);
+  assert.equal(
+    warnings[0],
+    '2 comments and 1 thread have no disposition evidence as of this ' +
+      'watermark, but its max-activity-at/total-item-count already cover ' +
+      'them -- dispose them (or re-run --from-pr after doing so) before ' +
+      'relying on this watermark.',
+  );
+});
+
+test('describeUnaddressedActivity reports threads alone (singular)', () => {
+  const warnings = describeUnaddressedActivity({
+    dispositionEvidence: {
+      missingRegularCommentCount: 0,
+      missingThreadCount: 1,
+    },
+  });
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /^1 thread has no disposition evidence/);
+});
+
+test('describeUnaddressedActivity fails open on negative/non-numeric counters (never throws)', () => {
+  assert.deepEqual(
+    describeUnaddressedActivity({
+      dispositionEvidence: {
+        missingRegularCommentCount: -1,
+        missingThreadCount: 'not-a-number',
+      },
+    }),
+    [],
+  );
+});
+
 test('--from-pr CLI composes review-activity-snapshot and prints the derived watermark (dry-run)', () => {
   // Stub `gh` on PATH so the real subprocess composition runs offline: the
   // post-idd-marker.mjs CLI resolves its sibling review-activity-snapshot.mjs,
@@ -883,7 +974,7 @@ test('--from-pr CLI composes review-activity-snapshot and prints the derived wat
 const fs = require('node:fs');
 const args = process.argv.slice(2);
 const out = (s) => { fs.writeSync(1, s); process.exit(0); };
-if (args[0] === 'pr' && args[1] === 'view') out('${SHA}\\n');
+if (args[0] === 'pr' && args[1] === 'view') out(JSON.stringify({ headRefOid: '${SHA}', author: { login: 'someone' } }));
 if (args[0] === 'pr' && args[1] === 'checks') {
   out(JSON.stringify([{ name: 'ci', state: 'SUCCESS', completedAt: '2026-06-25T11:00:00Z' }]));
 }
@@ -937,7 +1028,69 @@ process.exit(1);
       'total-item-count': '1',
       'ci-completed-at': '2026-06-25T11:00:00Z',
     }),
+    // #1833: the stub's one plain (never-dispositioned) comment has no
+    // disposition evidence, so the diagnostic warning fires -- see the
+    // dedicated `describeUnaddressedActivity` tests below for the field's
+    // own coverage.
+    warnings: [NO_DISPOSITION_EVIDENCE_WARNING_ONE_COMMENT],
   });
+});
+
+// #1833: end-to-end negative -- when the live snapshot has NO comments at
+// all, `dispositionEvidence`'s counters are both zero, so no `warnings` key
+// appears in the CLI's own success output (proving the wiring does not fire
+// on the routine/empty-PR path, not just that `describeUnaddressedActivity`
+// returns `[]` in isolation).
+test('--from-pr CLI omits warnings when the live snapshot has nothing missing a disposition', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-from-pr-no-warning-'));
+  const ghPath = join(tempRoot, 'gh');
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const out = (s) => { fs.writeSync(1, s); process.exit(0); };
+if (args[0] === 'pr' && args[1] === 'view') out(JSON.stringify({ headRefOid: '${SHA}', author: { login: 'someone' } }));
+if (args[0] === 'pr' && args[1] === 'checks') {
+  out(JSON.stringify([{ name: 'ci', state: 'SUCCESS', completedAt: '2026-06-25T11:00:00Z' }]));
+}
+if (args[0] === 'api' && args[1] === 'graphql') {
+  out(JSON.stringify({ data: { repository: { pullRequest: { reviewThreads: { pageInfo: { hasNextPage: false }, nodes: [] } } } } }));
+}
+if (args[0] === 'api' && /\\/reviews$/.test(args[1])) out('[]');
+if (args[0] === 'api' && /\\/comments$/.test(args[1])) out('[]');
+fs.writeSync(2, 'unexpected gh invocation: ' + args.join(' '));
+process.exit(1);
+`,
+  );
+  chmodSync(ghPath, 0o755);
+
+  const output = execFileSync(
+    process.execPath,
+    [
+      join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+      '--type',
+      'watermark',
+      '--from-pr',
+      '1200',
+      '--owner',
+      'o',
+      '--repo',
+      'r',
+      '--agent-id',
+      'claude-02f8159e',
+      '--claim-id',
+      'claim-1134-02f8159e',
+    ],
+    {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      env: { ...process.env, PATH: `${tempRoot}:${process.env.PATH ?? ''}` },
+    },
+  );
+
+  const parsed = JSON.parse(output);
+  assert.equal('warnings' in parsed, false);
 });
 
 /**
@@ -957,7 +1110,7 @@ function writeReviewActivitySnapshotGhStub(
 const fs = require('node:fs');
 const args = process.argv.slice(2);
 const out = (s) => { fs.writeSync(1, s); process.exit(0); };
-if (args[0] === 'pr' && args[1] === 'view') out('${headSha}\\n');
+if (args[0] === 'pr' && args[1] === 'view') out(JSON.stringify({ headRefOid: '${headSha}', author: { login: 'someone' } }));
 if (args[0] === 'pr' && args[1] === 'checks') {
   out(JSON.stringify([{ name: 'ci', state: 'SUCCESS', completedAt: '2026-06-25T11:00:00Z' }]));
 }
@@ -1024,6 +1177,9 @@ test('--expected-head-sha lets a matching (even differently-cased) --from-pr sna
       'total-item-count': '1',
       'ci-completed-at': '2026-06-25T11:00:00Z',
     }),
+    // #1833: same one-plain-comment fixture as the "--from-pr CLI
+    // composes..." test above (shared stub function).
+    warnings: [NO_DISPOSITION_EVIDENCE_WARNING_ONE_COMMENT],
   };
 
   assert.deepEqual(runDryRun(SHA), expected);

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -37,7 +37,7 @@ const TS = '2026-06-17T09:47:08Z';
 // fixture's one plain, never-dispositioned comment (`body: 'hi'`).
 const NO_DISPOSITION_EVIDENCE_WARNING_ONE_COMMENT =
   '1 comment has no disposition evidence as of this watermark, but its ' +
-  'max-activity-at/total-item-count already cover them -- dispose them ' +
+  'max-activity-at/total-item-count already cover it -- dispose it ' +
   '(or re-run --from-pr after doing so) before relying on this watermark.';
 
 const schema = loadJson('schemas/post-idd-marker.schema.json');
@@ -909,6 +909,10 @@ test('describeUnaddressedActivity warns (singular) for exactly one missing comme
   });
   assert.equal(warnings.length, 1);
   assert.match(warnings[0], /^1 comment has no disposition evidence/);
+  // #1833: pronoun must agree with the singular count too (Copilot review on
+  // PR #1848 caught the original "cover them -- dispose them" mismatch).
+  assert.match(warnings[0], /cover it -- dispose it\b/);
+  assert.doesNotMatch(warnings[0], /cover them|dispose them/);
 });
 
 test('describeUnaddressedActivity warns (plural) for multiple missing comments', () => {
@@ -948,6 +952,7 @@ test('describeUnaddressedActivity reports threads alone (singular)', () => {
   });
   assert.equal(warnings.length, 1);
   assert.match(warnings[0], /^1 thread has no disposition evidence/);
+  assert.match(warnings[0], /cover it -- dispose it\b/);
 });
 
 test('describeUnaddressedActivity fails open on negative/non-numeric counters (never throws)', () => {

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -3260,6 +3260,96 @@ test('disposition evidence still blocks an undispositioned non-review notice', (
 
   assert.equal(summary.route, 'return-to-e1');
   assert.equal(summary.missingRegularCommentCount, 1);
+  // #1833: no wrong-phrase `**Rejected**` reply exists at all here, so no
+  // hint is attached -- confirms the hint is not a blanket default on every
+  // missing notice.
+  assert.equal(summary.missingRegularComments[0].hint, undefined);
+});
+
+// #1833: a disposition reply starting with `**Rejected**` but missing the
+// required `did not review HEAD` phrase passes the generic `isDispositionComment`
+// check (so the general 1:1 pairing accepts it as SOME disposition), but the
+// notice-specific carry-forward still rejects it. When the bot later re-triggers
+// (bumping `updatedAt` past the wrong-phrase reply -- the reported real-world
+// shape, kurone-kito/idd-skill#1833), the notice is stranded in `missing`
+// indefinitely with no diagnostic explaining why. The `hint` field names the
+// exact required phrase instead of forcing a source-dive.
+test('disposition evidence hints at the required phrase when a wrong-phrase **Rejected** reply exists', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          // Re-triggered after the wrong-phrase reply below, so the general
+          // 1:1 pairing can no longer consume it either.
+          updatedAt: '2026-05-12T03:00:00Z',
+          body: 'You have reached your Codex usage limits for code reviews.',
+          author: { login: 'chatgpt-codex-connector[bot]' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T00:00:30Z',
+          // Starts with `**Rejected**` (a real disposition attempt, per the
+          // issue's own example) but never says "did not review HEAD".
+          body: '**Rejected** — CodeRabbit rate-limited, no findings to triage.',
+          author: { login: 'idd-bot' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['chatgpt-codex-connector[bot]'],
+    },
+  );
+
+  // Existing pass/fail routing is unchanged -- only the diagnostic is added.
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.reason, 'missing-disposition-evidence');
+  assert.equal(summary.missingRegularCommentCount, 1);
+  assert.match(
+    summary.missingRegularComments[0].hint ?? '',
+    /did not review HEAD/,
+  );
+  assert.match(
+    summary.missingRegularComments[0].hint ?? '',
+    /\*\*Rejected\*\*/,
+  );
+});
+
+// #1833: a wrong-phrase reply posted BEFORE the notice's own original
+// `createdAt` cannot be the notice's disposition attempt (nothing can reply
+// to a comment before it exists), so no hint is attached even though a
+// wrong-phrase reply exists somewhere in the thread.
+test('disposition evidence does not hint from a wrong-phrase reply that predates the notice', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:30Z',
+          body: '**Rejected** — an unrelated earlier rejection, not this notice.',
+          author: { login: 'idd-bot' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T01:00:00Z',
+          body: 'You have reached your Codex usage limits for code reviews.',
+          author: { login: 'chatgpt-codex-connector[bot]' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['chatgpt-codex-connector[bot]'],
+    },
+  );
+
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.missingRegularCommentCount, 1);
+  assert.equal(summary.missingRegularComments[0].hint, undefined);
 });
 
 // No regression (multi-bot): a disposition naming one advisory bot must NOT

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -3352,6 +3352,54 @@ test('disposition evidence does not hint from a wrong-phrase reply that predates
   assert.equal(summary.missingRegularComments[0].hint, undefined);
 });
 
+// #1833: `missingRegularComments[].hint` must validate against
+// `schemas/pre-merge-readiness.schema.json` -- that schema's
+// `dispositionEvidence.missingRegularComments[]` item shape is
+// `additionalProperties: false`, so an unaccounted-for new field on the
+// TypeScript side would be silently rejected by any schema-validating
+// consumer even though `summarizeDispositionEvidenceForGate` itself is happy
+// to emit it (caught by Copilot review on PR #1848 -- the schema was missed
+// in the original change).
+test('a hinted missingRegularComments entry validates against pre-merge-readiness.schema.json', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T03:00:00Z',
+          body: 'You have reached your Codex usage limits for code reviews.',
+          author: { login: 'chatgpt-codex-connector[bot]' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T00:00:30Z',
+          body: '**Rejected** — CodeRabbit rate-limited, no findings to triage.',
+          author: { login: 'idd-bot' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['chatgpt-codex-connector[bot]'],
+    },
+  );
+  assert.ok(summary.missingRegularComments[0].hint);
+
+  const schema = loadJson('schemas/pre-merge-readiness.schema.json') as {
+    properties: {
+      dispositionEvidence: {
+        properties: { missingRegularComments: { items: unknown } };
+      };
+    };
+  };
+  const itemSchema =
+    schema.properties.dispositionEvidence.properties.missingRegularComments
+      .items;
+  assert.deepEqual(validate(summary.missingRegularComments[0], itemSchema), []);
+});
+
 // No regression (multi-bot): a disposition naming one advisory bot must NOT
 // carry forward another bot's still-undispositioned notice. The repo can
 // configure several advisory bots at once, so an order/count-only pairing would

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -1177,6 +1177,7 @@ const postIddMarkerKeys = [
   'body',
   'commentId',
   'url',
+  'warnings',
 ] as const satisfies readonly (keyof PostIddMarkerResult)[];
 
 const postIddMarkerFixture = {


### PR DESCRIPTION
## Summary

Two related F2 pre-merge-readiness evidence checks correctly block the
merge but gave no actionable diagnostic about why, forcing a
source-dive into `src/scripts/protocol-helpers.mts` to discover the
real requirement. This PR adds diagnostic-only fields to both — no
existing pass/fail routing changes.

1. **`missing-disposition-evidence` hint.** When the routing reason is
   `missing-disposition-evidence` and a missing item is itself a
   recognized advisory non-review notice, and an IDD-agent reply
   starting with `**Rejected**` exists but fails
   `isNonReviewNoticeDisposition`'s stricter `did not review HEAD`
   phrase requirement (the "correct-sounding but wrong phrase"
   scenario from the issue), that item's entry in
   `DispositionEvidenceSummary.missingRegularComments[]` now carries a
   `hint` field naming the exact required phrase.
2. **Watermark unaddressed-activity warning.** `review-activity-snapshot.mjs`
   now also computes `dispositionEvidence`
   (`missingRegularCommentCount` / `missingThreadCount`) — the same
   `summarizeDispositionEvidenceForGate` evidence the F2 gate uses —
   and emits it in its JSON output. `post-idd-marker.mjs --from-pr`
   reads those counters and, when non-zero, adds a `warnings: string[]`
   array to its own dry-run/`--apply` success output, so an agent sees
   "N comment(s)/thread(s) have no disposition evidence" **at
   watermark-post time**, instead of discovering it later only via
   `reviewCurrency.comparisonRoute`.

### Why not `ackOnly.items` for (2)?

The obvious first candidate signal was the snapshot's existing
`ackOnly.items` (advisory-bot activity newer than the last
disposition). That was rejected after review: `ackOnly` is exactly the
carve-out `diffReviewSnapshot` already treats as *safe* to fold into
the watermark (post-disposition courtesy acks), so warning on it would
fire on the routine, benign path and be anti-correlated with the
actual problem. `dispositionEvidence`'s counters are the correct
signal — genuinely undispositioned items — mirroring
`advisory-convergence.mjs`'s existing trimmed
`AdvisoryConvergenceDispositionEvidence` projection of the same
evidence.

## Linked issue

Closes #1833

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Reported from a private adopter repository running a multi-agent
autopilot loop (orchestrator + delegated background workers): both
sub-findings were independently hit by more than one agent in the same
session, each costing several minutes re-deriving the requirement from
source.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (`node --test tests/*.test.mts` — 3110/3110 passing;
      2 new `summarizeDispositionEvidenceForGate` hint tests, 8 new
      `describeUnaddressedActivity` unit tests, 1 new end-to-end CLI
      negative test; 3 pre-existing fixtures updated for the widened
      `gh pr view --json headRefOid,author` call and 2 for the new
      `warnings` field their fixture genuinely triggers)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`docs/idd-helper-scripts.md`
      regenerated from `idd-template/docs/idd-helper-scripts.md` via
      `node scripts/sync-docs.mjs --apply`, in sync)
- [x] `node scripts/idd-doctor.mjs` (passed; only pre-existing
      environmental warnings unrelated to this change)

Also verified: `pnpm run build:check` (generated `scripts/*.mjs` match
the `.mts` sources).

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (diagnostic-only fields; no routing
      change)
- [x] Context budget impact reviewed (new fields are small, optional,
      and only populated on the already-blocking / already-diagnostic
      paths)
