### PR TITLE
feat(template): mirror post-merge-cleanup.yml into idd-template

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -59,6 +59,7 @@
       "stripPrefix": "idd-template/",
       "sourceGlobs": [
         "idd-template/.github/idd/*.json",
+        "idd-template/.github/workflows/post-merge-cleanup.yml",
         "idd-template/.githooks/*",
         "idd-template/.github/instructions/idd-*.instructions.md",
         "idd-template/.github/instructions/lite/idd-*.instructions.md",
@@ -75,6 +76,7 @@
       ],
       "paths": [
         "idd-template/.github/idd/config.json",
+        "idd-template/.github/workflows/post-merge-cleanup.yml",
         "idd-template/.githooks/_idd-worktree-guard.sh",
         "idd-template/.githooks/pre-commit",
         "idd-template/.githooks/pre-push",

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -151,12 +151,22 @@ It then parses the report and posts the canonical
 PR receives evidence within a few minutes even when the agent did
 not run F4 manually.
 
-The template (`idd-template/`) does **not** ship this workflow
-because `scripts/audit-pr-cleanup.mjs` is part of the optional
-helper bundle and is not present in default instructions-only
-installs. Adopters who install the helper can copy the source
-workflow file as-is; permissions required are
-`contents: read`, `issues: write`, and `pull-requests: write`, plus
+The template (`idd-template/`) ships a generic counterpart at
+`idd-template/.github/workflows/post-merge-cleanup.yml`, part of the
+core file set `idd-onboard.mjs --import` copies automatically.
+Earlier template versions omitted this file because
+`scripts/audit-pr-cleanup.mjs` is part of the optional `vendored-node`
+helper bundle and is not present in default `instructions-only`
+installs, so a literal copy would only ever work for one profile. The
+template copy instead resolves the cleanup-audit invocation through
+the repository's configured `helperRuntime.profile` (see
+[Helper Runtime Profiles](idd-helper-scripts.md#helper-runtime-profiles)):
+it runs the equivalent invocation under `vendored-node`,
+`package-manager`, and `ephemeral-npx`, and skips the audit and
+evidence-comment steps entirely under `instructions-only` (or when no
+profile is configured), where no runnable helper command exists for
+any profile. Permissions required are `contents: read`,
+`issues: write`, and `pull-requests: write`, plus
 `pull_request_target` (not `pull_request`) so that fork PRs can
 post comments under a writeable `GITHUB_TOKEN`.
 

--- a/idd-template/.github/workflows/post-merge-cleanup.yml
+++ b/idd-template/.github/workflows/post-merge-cleanup.yml
@@ -1,0 +1,316 @@
+# Trust model: this workflow triggers on `pull_request_target`, which runs
+# with base-repository permissions and secrets even for pull requests from
+# forks. That is safe here only because all of the following hold, and any
+# future edit to this file must preserve them:
+#   - No unreviewed PR-head content is ever checked out: the sole
+#     `actions/checkout` step below carries no `ref:` override, so it
+#     resolves to the `pull_request_target` default -- the base branch's
+#     tip at event time. Because the job only proceeds when
+#     `merged == true`, that tip already includes this PR's own merge
+#     (a repository that merges via merge commits typically sees that
+#     merge commit itself) -- it is never the PR's own head SHA, and
+#     never content that has not already passed through the merge
+#     decision.
+#   - No PR-head code, workflow, or action is ever executed. Only this
+#     repository's own base-branch-tracked content runs: the
+#     cleanup-audit invocation resolved below always names a script or
+#     package this base branch already tracks or has already declared as
+#     a dependency, never anything from the PR diff. Under the
+#     `package-manager` profile specifically, that base-branch content
+#     includes the repository's own declared install lifecycle (its
+#     lockfile-driven `npm ci` / `pnpm install --frozen-lockfile` /
+#     `yarn install --frozen-lockfile`) -- that is the adopter's own
+#     already-reviewed, already-merged dependency tree, not PR-head
+#     content, but it is a wider execution surface than this source
+#     repository's own dogfooded copy (which only ever runs its single
+#     tracked `scripts/audit-pr-cleanup.mjs`), so it is called out here
+#     explicitly.
+#   - The `pr_number` value (a `workflow_dispatch` number input, not
+#     strictly enforced as numeric for direct API dispatches) is passed
+#     through `env:` and referenced as a quoted shell variable, never
+#     interpolated directly into a `run:` script.
+#   - The `cleanup` job only runs when
+#     `github.event.pull_request.merged == true`, or via an explicit,
+#     human-triggered `workflow_dispatch` -- never against an open or
+#     unmerged pull request.
+#   - `permissions:` stays least-privilege: `contents: read`,
+#     `issues: write`, `pull-requests: write` -- no `contents: write` and
+#     no elevated or secret-bearing scopes.
+# If a future change adds a `ref:` override on the checkout step, downloads
+# or executes PR-head content, widens `permissions:`, or removes the
+# merged-only guard, re-review this trust model before merging that change.
+#
+# Profile resolution: unlike this source repository's own dogfooded copy
+# (kurone-kito/idd-skill's own `.github/workflows/post-merge-cleanup.yml`),
+# which always invokes the vendored-node `scripts/audit-pr-cleanup.mjs`
+# directly, this template copy resolves the cleanup-audit invocation
+# through the repository's configured `helperRuntime.profile`
+# (`.github/idd/config.json`, falling back to the legacy top-level
+# `idd-policy.json` filename with the same first-present-file precedence
+# idd-doctor.mjs's own resolver uses) -- see docs/idd-helper-scripts.md's
+# "Helper Runtime Profiles" section. Under `instructions-only` (no runnable
+# helper command exists for any profile), or when no profile can be
+# resolved at all, the audit and evidence-comment steps are skipped
+# entirely and nothing is posted: the agent's own F4 cleanup step in
+# idd-merge.instructions.md remains the canonical, mandatory contract in
+# every profile, including this one.
+name: Post-merge cleanup
+on:
+  pull_request_target:
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to clean up
+        required: true
+        type: number
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+concurrency:
+  group: post-merge-cleanup-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: false
+jobs:
+  cleanup:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Resolve helper-runtime profile
+        id: profile
+        run: |
+          # Fail-closed default, mirroring idd-doctor.mjs's
+          # resolveConfiguredHelperRuntime: an absent, unreadable, or
+          # invalid config -- or one that simply omits helperRuntime --
+          # resolves to instructions-only (no runnable command), never a
+          # guess at a runnable profile.
+          PROFILE="instructions-only"
+          PACKAGE_SPEC=""
+          for CANDIDATE in .github/idd/config.json idd-policy.json; do
+            if [ -f "$CANDIDATE" ]; then
+              if RESOLVED=$(jq -r '.helperRuntime.profile // empty' "$CANDIDATE" 2>/dev/null); then
+                case "$RESOLVED" in
+                  vendored-node | package-manager | ephemeral-npx | instructions-only)
+                    PROFILE="$RESOLVED"
+                    PACKAGE_SPEC=$(jq -r '.helperRuntime.packageSpec // empty' "$CANDIDATE" 2>/dev/null || echo "")
+                    ;;
+                esac
+              fi
+              # First present candidate file wins outright, valid or not
+              # -- never fall through to the legacy idd-policy.json name
+              # once the canonical file has been evaluated.
+              break
+            fi
+          done
+          echo "profile=$PROFILE" >> "$GITHUB_OUTPUT"
+          echo "package-spec=$PACKAGE_SPEC" >> "$GITHUB_OUTPUT"
+      - name: Setup Node.js
+        if: steps.profile.outputs.profile != 'instructions-only'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - name: Detect package manager
+        id: manager
+        if: steps.profile.outputs.profile == 'package-manager'
+        run: |
+          # Same precedence as helper-runtime-manifest.mts's own
+          # detector: an explicit package.json "packageManager" field
+          # wins, then lockfile presence (pnpm-lock.yaml, then
+          # package-lock.json, then yarn.lock), defaulting to npm when
+          # nothing else matches.
+          MANAGER=$(node -e "
+            const fs = require('node:fs');
+            let declared = '';
+            try {
+              const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+              declared = String(pkg.packageManager || '').split('@')[0];
+            } catch {
+              // No readable package.json: fall through to lockfile detection.
+            }
+            if (['npm', 'pnpm', 'yarn'].includes(declared)) {
+              console.log(declared);
+            } else if (fs.existsSync('pnpm-lock.yaml')) {
+              console.log('pnpm');
+            } else if (fs.existsSync('package-lock.json')) {
+              console.log('npm');
+            } else if (fs.existsSync('yarn.lock')) {
+              console.log('yarn');
+            } else {
+              console.log('npm');
+            }
+          ")
+          echo "manager=$MANAGER" >> "$GITHUB_OUTPUT"
+      - name: Install dependencies (package-manager profile)
+        if: steps.profile.outputs.profile == 'package-manager'
+        env:
+          MANAGER: ${{ steps.manager.outputs.manager }}
+        run: |
+          case "$MANAGER" in
+            pnpm)
+              corepack enable
+              pnpm install --frozen-lockfile
+              ;;
+            yarn)
+              corepack enable
+              yarn install --frozen-lockfile
+              ;;
+            *)
+              npm ci
+              ;;
+          esac
+      - name: Run F4 cleanup (server-side fallback)
+        id: cleanup
+        if: steps.profile.outputs.profile != 'instructions-only'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # workflow_dispatch's `pr_number` input is `type: number` in the
+          # UI, but that constraint is not strictly enforced for direct API
+          # dispatches, so route it through env: and reference it as a
+          # quoted shell variable rather than interpolating the `${{ }}`
+          # expression directly into the run: script.
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          PROFILE: ${{ steps.profile.outputs.profile }}
+          PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}
+          MANAGER: ${{ steps.manager.outputs.manager }}
+        run: |
+          set +e
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::PR_NUMBER is empty"
+            exit 1
+          fi
+          ARGS="--pr $PR_NUMBER --apply --skip-claim-check --format json"
+          case "$PROFILE" in
+            vendored-node)
+              # shellcheck disable=SC2086
+              JSON=$(node scripts/audit-pr-cleanup.mjs $ARGS 2>cleanup-stderr.log)
+              ;;
+            package-manager)
+              case "$MANAGER" in
+                pnpm)
+                  # shellcheck disable=SC2086
+                  JSON=$(pnpm exec idd-audit-pr-cleanup $ARGS 2>cleanup-stderr.log)
+                  ;;
+                yarn)
+                  # shellcheck disable=SC2086
+                  JSON=$(yarn idd-audit-pr-cleanup $ARGS 2>cleanup-stderr.log)
+                  ;;
+                *)
+                  # npm requires a literal `--` before forwarded flags;
+                  # pnpm/yarn above do not.
+                  # shellcheck disable=SC2086
+                  JSON=$(npm exec idd-audit-pr-cleanup -- $ARGS 2>cleanup-stderr.log)
+                  ;;
+              esac
+              ;;
+            ephemeral-npx)
+              SPEC="${PACKAGE_SPEC:-https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main}"
+              # shellcheck disable=SC2086
+              JSON=$(npx --yes --package "$SPEC" idd-audit-pr-cleanup $ARGS 2>cleanup-stderr.log)
+              ;;
+          esac
+          HELPER_EXIT=$?
+          set -e
+          # Prefer the helper's JSON report when it is parseable, even on
+          # non-zero exit (the helper writes the report then exits 1 when
+          # failed.length > 0, so the report is still authoritative).
+          PARSED_STATUS=""
+          if [ -n "$JSON" ]; then
+            PARSED_STATUS=$(printf '%s' "$JSON" | jq -r '.status // ""' 2>/dev/null || echo "")
+          fi
+          if [ -n "$PARSED_STATUS" ]; then
+            printf '%s\n' "$JSON" > cleanup-report.json
+            STATUS="$PARSED_STATUS"
+            APPLIED=$(printf '%s' "$JSON" | jq -r '(.applied // []) | length')
+            FAILED=$(printf '%s' "$JSON" | jq -r '(.failed // []) | length')
+            SKIPPED=$(printf '%s' "$JSON" | jq -r '(.skipped // []) | length')
+            BLOCKED=$(printf '%s' "$JSON" | jq -r '[(.skipped // [])[] | select(.isMinimized==false and .viewerCanMinimize==false)] | length')
+            if [ "$HELPER_EXIT" -ne 0 ]; then
+              echo "::warning::audit-pr-cleanup exited $HELPER_EXIT but emitted a valid JSON report; using helper status \"$STATUS\""
+            fi
+          else
+            echo "::warning::audit-pr-cleanup exited $HELPER_EXIT with no parseable JSON; posting helper-error evidence"
+            STATUS="helper-error"
+            APPLIED=0
+            FAILED=0
+            SKIPPED=0
+            BLOCKED=0
+          fi
+          {
+            echo "pr_number=$PR_NUMBER"
+            echo "status=$STATUS"
+            echo "applied=$APPLIED"
+            echo "failed=$FAILED"
+            echo "skipped=$SKIPPED"
+            echo "blocked=$BLOCKED"
+          } >> "$GITHUB_OUTPUT"
+      - name: Post cleanup evidence comment
+        if: steps.profile.outputs.profile != 'instructions-only'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.cleanup.outputs.pr_number }}
+          STATUS: ${{ steps.cleanup.outputs.status }}
+          APPLIED: ${{ steps.cleanup.outputs.applied }}
+          FAILED: ${{ steps.cleanup.outputs.failed }}
+          SKIPPED: ${{ steps.cleanup.outputs.skipped }}
+          BLOCKED: ${{ steps.cleanup.outputs.blocked }}
+        run: |
+          # Avoid duplicate evidence comments. Workflow-level concurrency
+          # only serialises this workflow's own runs; an agent F4 (or a
+          # maintainer rerunning workflow_dispatch on the same PR) can
+          # still have posted an evidence comment outside this run. Skip
+          # if a <!-- idd-cleanup-evidence: ... --> comment already on the
+          # PR was posted by a trusted author -- this workflow's own posts
+          # are authored by `github-actions[bot]` (the GITHUB_TOKEN actor),
+          # and an agent's local F4 post is authored by a configured
+          # `trustedMarkerActors` login. An untrusted commenter pre-posting
+          # this marker prefix must never suppress the genuine evidence
+          # post or be treated as a completed cleanup record (this is the
+          # same trust-scoping every other IDD operational marker already
+          # applies).
+          TRUSTED_LOGINS=$(
+            {
+              jq -r '(.trustedMarkerActors // [])[]' .github/idd/config.json 2>/dev/null
+              echo 'github-actions[bot]'
+            } | tr '[:upper:]' '[:lower:]'
+          )
+          # Capture into a variable (not process substitution): a failure
+          # inside `< <(gh api ...)` does not reliably propagate to this
+          # shell's default `-e`/`pipefail`, which could leave EXISTING
+          # empty and post a duplicate evidence comment on a transient
+          # `gh api` failure (rate limit/network). A plain command
+          # substitution assignment does trip `-e` on failure.
+          COMMENTS_TSV=$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login] | @tsv')
+          EXISTING=""
+          while IFS=$'\t' read -r candidate_id candidate_login; do
+            [ -z "$candidate_id" ] && continue
+            lower_login=$(printf '%s' "$candidate_login" | tr '[:upper:]' '[:lower:]')
+            if printf '%s\n' "$TRUSTED_LOGINS" | grep -Fxq "$lower_login"; then
+              EXISTING="$candidate_id"
+              break
+            fi
+          done <<< "$COMMENTS_TSV"
+          if [ -n "$EXISTING" ]; then
+            echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment (id: ${EXISTING}); skipping workflow post."
+            exit 0
+          fi
+          BODY=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+            "<!-- idd-cleanup-evidence: ${STATUS} applied:${APPLIED} failed:${FAILED} skipped:${SKIPPED} viewer-cannot-minimize:${BLOCKED} -->" \
+            "**F4 Cleanup Evidence** (server-side fallback via \`post-merge-cleanup.yml\`)" \
+            "| Field              | Value |" \
+            "| ------------------ | ----- |" \
+            "| Status             | ${STATUS} |" \
+            "| Applied            | ${APPLIED} |" \
+            "| Failed             | ${FAILED} |" \
+            "| Skipped            | ${SKIPPED} |" \
+            "| Permission-blocked | ${BLOCKED} |" \
+            "| Posted by          | post-merge-cleanup workflow |" \
+          )
+          printf '%s' "$BODY" | gh pr comment "$PR_NUMBER" --body-file -

--- a/idd-template/.github/workflows/post-merge-cleanup.yml
+++ b/idd-template/.github/workflows/post-merge-cleanup.yml
@@ -11,20 +11,28 @@
 #     merge commit itself) -- it is never the PR's own head SHA, and
 #     never content that has not already passed through the merge
 #     decision.
-#   - No PR-head code, workflow, or action is ever executed. Only this
-#     repository's own base-branch-tracked content runs: the
-#     cleanup-audit invocation resolved below always names a script or
-#     package this base branch already tracks or has already declared as
-#     a dependency, never anything from the PR diff. Under the
-#     `package-manager` profile specifically, that base-branch content
-#     includes the repository's own declared install lifecycle (its
-#     lockfile-driven `npm ci` / `pnpm install --frozen-lockfile` /
+#   - No PR-head code, workflow, or action is ever executed; nothing from
+#     the PR diff ever runs. Under `vendored-node` and `package-manager`,
+#     the cleanup-audit invocation names only a script or package this
+#     base branch already tracks or has already declared as a
+#     dependency. Under `package-manager` specifically, that base-branch
+#     content includes the repository's own declared install lifecycle
+#     (its lockfile-driven `npm ci` / `pnpm install --frozen-lockfile` /
 #     `yarn install --frozen-lockfile`) -- that is the adopter's own
 #     already-reviewed, already-merged dependency tree, not PR-head
 #     content, but it is a wider execution surface than this source
 #     repository's own dogfooded copy (which only ever runs its single
 #     tracked `scripts/audit-pr-cleanup.mjs`), so it is called out here
-#     explicitly.
+#     explicitly. Under `ephemeral-npx` specifically, when the repository
+#     has not configured `helperRuntime.packageSpec`, the invocation
+#     falls back to fetching a **mutable** default archive URL
+#     (`https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main`)
+#     over the network at run time -- not base-branch-tracked content and
+#     not a declared dependency either. This is a real, wider execution
+#     surface than the other profiles; adopters on `ephemeral-npx` should
+#     pin `helperRuntime.packageSpec` to a reviewed tarball or mirror URL
+#     (see docs/idd-helper-scripts.md's "Profile Wiring Surface" section)
+#     to close this gap.
 #   - The `pr_number` value (a `workflow_dispatch` number input, not
 #     strictly enforced as numeric for direct API dispatches) is passed
 #     through `env:` and referenced as a quoted shell variable, never
@@ -184,34 +192,41 @@ jobs:
             echo "::error::PR_NUMBER is empty"
             exit 1
           fi
-          ARGS="--pr $PR_NUMBER --apply --skip-claim-check --format json"
+          # FLAGS holds only fixed, non-attacker-controlled literal
+          # tokens -- unquoted word-splitting below is safe for it.
+          # PR_NUMBER is untrusted (a workflow_dispatch number input is
+          # not strictly enforced as numeric for direct API dispatches)
+          # and is always passed as its own separately quoted argument,
+          # never folded into a word-split string, so a crafted value
+          # cannot inject extra flags/args into the helper invocation.
+          FLAGS="--apply --skip-claim-check --format json"
           case "$PROFILE" in
             vendored-node)
               # shellcheck disable=SC2086
-              JSON=$(node scripts/audit-pr-cleanup.mjs $ARGS 2>cleanup-stderr.log)
+              JSON=$(node scripts/audit-pr-cleanup.mjs --pr "$PR_NUMBER" $FLAGS 2>cleanup-stderr.log)
               ;;
             package-manager)
               case "$MANAGER" in
                 pnpm)
                   # shellcheck disable=SC2086
-                  JSON=$(pnpm exec idd-audit-pr-cleanup $ARGS 2>cleanup-stderr.log)
+                  JSON=$(pnpm exec idd-audit-pr-cleanup --pr "$PR_NUMBER" $FLAGS 2>cleanup-stderr.log)
                   ;;
                 yarn)
                   # shellcheck disable=SC2086
-                  JSON=$(yarn idd-audit-pr-cleanup $ARGS 2>cleanup-stderr.log)
+                  JSON=$(yarn idd-audit-pr-cleanup --pr "$PR_NUMBER" $FLAGS 2>cleanup-stderr.log)
                   ;;
                 *)
                   # npm requires a literal `--` before forwarded flags;
                   # pnpm/yarn above do not.
                   # shellcheck disable=SC2086
-                  JSON=$(npm exec idd-audit-pr-cleanup -- $ARGS 2>cleanup-stderr.log)
+                  JSON=$(npm exec idd-audit-pr-cleanup -- --pr "$PR_NUMBER" $FLAGS 2>cleanup-stderr.log)
                   ;;
               esac
               ;;
             ephemeral-npx)
               SPEC="${PACKAGE_SPEC:-https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main}"
               # shellcheck disable=SC2086
-              JSON=$(npx --yes --package "$SPEC" idd-audit-pr-cleanup $ARGS 2>cleanup-stderr.log)
+              JSON=$(npx --yes --package "$SPEC" idd-audit-pr-cleanup --pr "$PR_NUMBER" $FLAGS 2>cleanup-stderr.log)
               ;;
           esac
           HELPER_EXIT=$?
@@ -273,9 +288,18 @@ jobs:
           # post or be treated as a completed cleanup record (this is the
           # same trust-scoping every other IDD operational marker already
           # applies).
+          # This step runs under the default GitHub Actions bash flags
+          # (-eo pipefail), so a plain `jq ... .github/idd/config.json`
+          # would abort the whole step under `set -e` when the file is
+          # missing or unreadable (a repo still using only the legacy
+          # `idd-policy.json` name, or a non-template install) --
+          # `|| true` keeps that a soft "no extra trusted logins" read
+          # instead of a hard failure, preserving the fail-closed
+          # trust-only-github-actions-bot behavior below rather than
+          # silently skipping the whole duplicate-evidence check.
           TRUSTED_LOGINS=$(
             {
-              jq -r '(.trustedMarkerActors // [])[]' .github/idd/config.json 2>/dev/null
+              jq -r '(.trustedMarkerActors // [])[]' .github/idd/config.json 2>/dev/null || true
               echo 'github-actions[bot]'
             } | tr '[:upper:]' '[:lower:]'
           )

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -409,6 +409,7 @@ for the frontmatter convention its generated table follows.
 
 ```text
 .github/idd/config.json
+.github/workflows/post-merge-cleanup.yml
 .githooks/_idd-worktree-guard.sh
 .githooks/pre-commit
 .githooks/pre-push
@@ -498,11 +499,12 @@ Fetch all files with `gh api` (recommended — handles auth automatically):
 ```sh
 DEST="."  # root of the target repository
 
-mkdir -p "${DEST}/.github/idd" "${DEST}/.github/instructions" "${DEST}/docs" \
-  "${DEST}/docs/onboarding"
+mkdir -p "${DEST}/.github/idd" "${DEST}/.github/workflows" \
+  "${DEST}/.github/instructions" "${DEST}/docs" "${DEST}/docs/onboarding"
 
 for FILE in \
   ".github/idd/config.json" \
+  ".github/workflows/post-merge-cleanup.yml" \
   ".githooks/_idd-worktree-guard.sh" \
   ".githooks/pre-commit" \
   ".githooks/pre-push" \
@@ -599,11 +601,12 @@ repository):
 BASE="https://raw.githubusercontent.com/kurone-kito/idd-skill/main/idd-template"
 DEST="."  # root of the target repository
 
-mkdir -p "${DEST}/.github/idd" "${DEST}/.github/instructions" "${DEST}/docs" \
-  "${DEST}/docs/onboarding"
+mkdir -p "${DEST}/.github/idd" "${DEST}/.github/workflows" \
+  "${DEST}/.github/instructions" "${DEST}/docs" "${DEST}/docs/onboarding"
 
 for FILE in \
   ".github/idd/config.json" \
+  ".github/workflows/post-merge-cleanup.yml" \
   ".githooks/_idd-worktree-guard.sh" \
   ".githooks/pre-commit" \
   ".githooks/pre-push" \

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -138,6 +138,7 @@ generated separately in `ONBOARDING.md`.
 .github/instructions/lite/idd-review-snapshot-lite.instructions.md
 .github/instructions/lite/idd-work-lite.instructions.md
 .github/workflows/idd-advisory-convergence.yml
+.github/workflows/post-merge-cleanup.yml
 docs/concepts.md
 docs/customization.md
 docs/getting-started.md

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -151,12 +151,22 @@ It then parses the report and posts the canonical
 PR receives evidence within a few minutes even when the agent did
 not run F4 manually.
 
-The template (`idd-template/`) does **not** ship this workflow
-because `scripts/audit-pr-cleanup.mjs` is part of the optional
-helper bundle and is not present in default instructions-only
-installs. Adopters who install the helper can copy the source
-workflow file as-is; permissions required are
-`contents: read`, `issues: write`, and `pull-requests: write`, plus
+The template (`idd-template/`) ships a generic counterpart at
+`idd-template/.github/workflows/post-merge-cleanup.yml`, part of the
+core file set `idd-onboard.mjs --import` copies automatically.
+Earlier template versions omitted this file because
+`scripts/audit-pr-cleanup.mjs` is part of the optional `vendored-node`
+helper bundle and is not present in default `instructions-only`
+installs, so a literal copy would only ever work for one profile. The
+template copy instead resolves the cleanup-audit invocation through
+the repository's configured `helperRuntime.profile` (see
+[Helper Runtime Profiles](idd-helper-scripts.md#helper-runtime-profiles)):
+it runs the equivalent invocation under `vendored-node`,
+`package-manager`, and `ephemeral-npx`, and skips the audit and
+evidence-comment steps entirely under `instructions-only` (or when no
+profile is configured), where no runnable helper command exists for
+any profile. Permissions required are `contents: read`,
+`issues: write`, and `pull-requests: write`, plus
 `pull_request_target` (not `pull_request`) so that fork PRs can
 post comments under a writeable `GITHUB_TOKEN`.
 

--- a/idd-template/docs/onboarding/template-distribution.md
+++ b/idd-template/docs/onboarding/template-distribution.md
@@ -56,8 +56,15 @@ The authoritative generated lists are configured in
   match against every file under `idd-template/` (`idd-template/**/*`),
   deliberately including files the core import list excludes by design
   — `scripts/minimize-superseded-markers.mjs` (see the
-  profile-conditional section below), `.github/workflows/*.yml`, and
-  `.claude/settings.json`. Because it has no `paths` list, adding a new
+  profile-conditional section below), `.github/workflows/idd-advisory-convergence.yml`,
+  and `.claude/settings.json`. `post-merge-cleanup.yml` is **not** in
+  this exclusion list — it moved into the core `idd-template-core-files`
+  set once its cleanup-audit invocation became profile-portable (no
+  longer `vendored-node`-only), unlike `idd-advisory-convergence.yml`,
+  which stays opt-in-only for an unrelated reason: hosting it as a
+  required-status-check is a deliberate adopter decision with its own
+  ruleset-registration step, not a helper-portability question. Because
+  the readme inventory block has no `paths` list, adding a new
   `idd-template/` file never requires a manual edit here — running
   `node scripts/sync-docs.mjs --apply` picks it up automatically. Keep
   the issue-authoring companion

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -658,6 +658,35 @@ test('resolveCoreTemplateFiles matches the ONBOARDING.md idd-template-core-files
   );
 });
 
+test('resolveCoreTemplateFiles includes post-merge-cleanup.yml in the core (auto-imported) file set (idd-skill#1832)', () => {
+  const resolved = resolveCoreTemplateFiles(REPO_ROOT);
+  const workflowFile = resolved.find(
+    (file) => file.targetPath === '.github/workflows/post-merge-cleanup.yml',
+  );
+  assert.ok(
+    workflowFile,
+    'expected .github/workflows/post-merge-cleanup.yml in the core template file set, so a fresh `idd-onboard.mjs --import` copies it without a separate opt-in step',
+  );
+  assert.equal(
+    workflowFile?.sourcePath,
+    'idd-template/.github/workflows/post-merge-cleanup.yml',
+  );
+
+  // resolveImportFiles vends the same core set for every profile
+  // (including no profile at all) -- unlike the vendored-node-only
+  // helper bundle, this file is not profile-conditional.
+  for (const profile of [undefined, ...PROFILE_NAMES]) {
+    const files = resolveImportFiles(REPO_ROOT, profile).files;
+    assert.ok(
+      files.some(
+        (file) =>
+          file.targetPath === '.github/workflows/post-merge-cleanup.yml',
+      ),
+      `expected post-merge-cleanup.yml in resolveImportFiles output for profile ${String(profile)}`,
+    );
+  }
+});
+
 test('resolveCoreTemplateFiles rejects a source tree without a readable manifest', () => {
   assert.throws(
     () => resolveCoreTemplateFiles(makeFixtureDir()),


### PR DESCRIPTION
# Summary

Adopters who import `idd-template/` never received the server-side
`post-merge-cleanup.yml` fallback that this repository's own CI already
runs, because a literal copy would only work under the `vendored-node`
helper-runtime profile (the workflow invoked `scripts/audit-pr-cleanup.mjs`
directly by its vendored source path).

- Add `idd-template/.github/workflows/post-merge-cleanup.yml`, derived
  from this repository's own workflow: same `pull_request_target` closed
  + `merged == true` trigger, same least-privilege `permissions:`
  (`contents: read`, `issues: write`, `pull-requests: write`), same
  concurrency group, and the same inline trust-model comment
  (re-verified and extended to cover the new profile-branching step).
- The new copy resolves the cleanup-audit invocation through the
  repository's configured `helperRuntime.profile` instead of
  hard-coding the vendored-node path: it runs the equivalent invocation
  under `vendored-node`, `package-manager` (detecting npm/pnpm/yarn from
  `package.json`/lockfile, matching the exec forms ONBOARDING.md's
  existing "run idd-doctor as a CI health gate" section already
  documents for this profile), and `ephemeral-npx`; it skips the audit
  and evidence-comment steps entirely under `instructions-only` (or when
  no profile is configured), where no runnable helper command exists for
  any profile.
- Wire the new file into `idd-onboard.mjs --import`'s core file set
  (`audit/sync-manifest.json`'s `idd-template-core-files` block, by
  exact path rather than a `.github/workflows/*.yml` wildcard, so
  `idd-advisory-convergence.yml` stays opt-in-only as before) so a fresh
  import receives it automatically — verified by a new test in
  `tests/idd-onboard.test.mts`.
- Regenerate `idd-template/ONBOARDING.md` and `idd-template/README.md`
  via `node scripts/sync-docs.mjs --apply` (Step 2 file list, both
  gh-api/curl fetch loops, and the README Files inventory), plus a
  manual addition of `.github/workflows` to the two `mkdir -p`
  convenience lines above those loops.
- Narrow the "workflow files are excluded from the core import set by
  design" note in `idd-template/docs/onboarding/template-distribution.md`
  and the "template does not ship this workflow" note in
  `idd-template/docs/idd-comment-minimization.md` (mirrored to
  `docs/idd-comment-minimization.md`): that exclusion was specific to
  the vendored-node-only invocation this change removes, not a blanket
  rule — `idd-advisory-convergence.yml` stays opt-in for the unrelated
  reason of being a deliberate required-status-check adoption decision
  with its own ruleset-registration step.
- `idd-merge.instructions.md`'s F4 fallback wording was verified against
  the new distribution and needs no change: it already hedges ("for
  example one the post-merge-cleanup workflow posted", "in adopter
  repositories, skip to the GraphQL fallback ... unless the helper
  scripts were explicitly installed") rather than asserting universal
  availability.

## Linked issue

Closes #1832

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Design notes for review:

- `audit/sync-manifest.json`'s `idd-template-core-files.paths` /
  `sourceGlobs` gained the new file's *exact* path, not a
  `.github/workflows/*.yml` glob — a wildcard would have also pulled
  `idd-advisory-convergence.yml` into the auto-imported core set, which
  must stay opt-in (hosting it as a required-status-check is a separate,
  deliberate adopter decision).
- Confirmed `tests/helper-invocation-profile.test.mts` only scans `.md`
  files under four prefixes and never scans `.yml`/workflow files, so
  the new workflow's shell invocation strings are not subject to that
  mechanical guard; the two prose docs I edited *are* in scope for it
  and use only already-backed invocation forms.
- `idd-template/docs/permissions.md`'s "Ask-First Shared-State Actions"
  gate (`.github/workflows/**`) is scoped to this repository's own live
  CI (real credentials, shapes this repo's own merge gates), not
  `idd-template/.github/workflows/**`, which is inert distributed
  content — same category as any other `idd-template/**` file. This
  addition is also explicitly pre-authorized by the issue's own
  proposed-change item 1.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed (new template CI workflow file — least-privilege permissions, pull_request_target + merged==true guard, trust-model comment carried over and extended; see Background/rationale above)

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)
- [x] `actionlint idd-template/.github/workflows/post-merge-cleanup.yml`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated post-merge cleanup workflow with optional helper-runtime profiles.
  * Supports manual execution, cleanup auditing, and deduplicated evidence comments when configured.
  * Automatically includes the workflow in newly generated template projects.

* **Documentation**
  * Updated onboarding, template inventories, and cleanup guidance to reflect automatic workflow inclusion and supported runtime options.

* **Tests**
  * Added coverage confirming the workflow is included across all supported configuration profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->