### PR TITLE
docs(workflow): prefer Codex reviewer subagents

### DIFF
--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -889,9 +889,12 @@ agent; only the mechanism differs.
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | Copilot         | Launch a subagent in Agent mode; use the calling phase's critique checklist as the prompt                                                  |
 | Claude Code     | `Agent(subagent_type="general-purpose")` with the calling phase's critique checklist                                                       |
-| Codex CLI       | Self-critique: add a "review the above for issues" step in the next response                                                               |
+| Codex CLI       | Use bounded read-only native subagent review if suitable; parent waits for result. Fallback: structured self-critique if delegation fails. |
 | OpenCode        | Launch a subagent via OpenCode's Task tool (e.g. the built-in `general` subagent, or a `subtask: true` command) — an independent mechanism |
 | Antigravity CLI | Self-critique or use Antigravity's native multi-step task mechanism if available                                                           |
+
+For Codex delegation, the parent collects the reviewer result before
+continuing; if delegation fails, use the structured fallback.
 
 When a phase file says "run a critique pass", apply the row for your
 agent above. If no subagent mechanism is available, perform the critique

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -885,13 +885,13 @@ produces a list of issues with severity, correctness, and coverage
 assessment. The goal and expected output are the same regardless of
 agent; only the mechanism differs.
 
-| Agent           | How to run a critique pass                                                                                                                 |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Copilot         | Launch a subagent in Agent mode; use the calling phase's critique checklist as the prompt                                                  |
-| Claude Code     | `Agent(subagent_type="general-purpose")` with the calling phase's critique checklist                                                       |
-| Codex CLI       | Use bounded read-only native subagent review if suitable; parent waits for result. Fallback: structured self-critique if delegation fails. |
-| OpenCode        | Launch a subagent via OpenCode's Task tool (e.g. the built-in `general` subagent, or a `subtask: true` command) — an independent mechanism |
-| Antigravity CLI | Self-critique or use Antigravity's native multi-step task mechanism if available                                                           |
+| Agent           | How to run a critique pass                                                                                                                                                                                                 |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Copilot         | Launch a subagent in Agent mode; use the calling phase's critique checklist as the prompt                                                                                                                                  |
+| Claude Code     | `Agent(subagent_type="general-purpose")` with the calling phase's critique checklist                                                                                                                                       |
+| Codex CLI       | Use one bounded read-only native subagent review when supported and suitable; parent waits for and collects the result. Fallback: structured self-critique when delegation is unavailable, disabled, unsuitable, or fails. |
+| OpenCode        | Launch a subagent via OpenCode's Task tool (e.g. the built-in `general` subagent, or a `subtask: true` command) — an independent mechanism                                                                                 |
+| Antigravity CLI | Self-critique or use Antigravity's native multi-step task mechanism if available                                                                                                                                           |
 
 For Codex delegation, the parent collects the reviewer result before
 continuing; if delegation fails, use the structured fallback.

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -858,13 +858,13 @@ produces a list of issues with severity, correctness, and coverage
 assessment. The goal and expected output are the same regardless of
 agent; only the mechanism differs.
 
-| Agent           | How to run a critique pass                                                                                                                 |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Copilot         | Launch a subagent in Agent mode; use the calling phase's critique checklist as the prompt                                                  |
-| Claude Code     | `Agent(subagent_type="general-purpose")` with the calling phase's critique checklist                                                       |
-| Codex CLI       | Use bounded read-only native subagent review if suitable; parent waits for result. Fallback: structured self-critique if delegation fails. |
-| OpenCode        | Launch a subagent via OpenCode's Task tool (e.g. the built-in `general` subagent, or a `subtask: true` command) — an independent mechanism |
-| Antigravity CLI | Self-critique or use Antigravity's native multi-step task mechanism if available                                                           |
+| Agent           | How to run a critique pass                                                                                                                                                                                                 |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Copilot         | Launch a subagent in Agent mode; use the calling phase's critique checklist as the prompt                                                                                                                                  |
+| Claude Code     | `Agent(subagent_type="general-purpose")` with the calling phase's critique checklist                                                                                                                                       |
+| Codex CLI       | Use one bounded read-only native subagent review when supported and suitable; parent waits for and collects the result. Fallback: structured self-critique when delegation is unavailable, disabled, unsuitable, or fails. |
+| OpenCode        | Launch a subagent via OpenCode's Task tool (e.g. the built-in `general` subagent, or a `subtask: true` command) — an independent mechanism                                                                                 |
+| Antigravity CLI | Self-critique or use Antigravity's native multi-step task mechanism if available                                                                                                                                           |
 
 For Codex delegation, the parent collects the reviewer result before
 continuing; if delegation fails, use the structured fallback.

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -862,9 +862,12 @@ agent; only the mechanism differs.
 | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | Copilot         | Launch a subagent in Agent mode; use the calling phase's critique checklist as the prompt                                                  |
 | Claude Code     | `Agent(subagent_type="general-purpose")` with the calling phase's critique checklist                                                       |
-| Codex CLI       | Self-critique: add a "review the above for issues" step in the next response                                                               |
+| Codex CLI       | Use bounded read-only native subagent review if suitable; parent waits for result. Fallback: structured self-critique if delegation fails. |
 | OpenCode        | Launch a subagent via OpenCode's Task tool (e.g. the built-in `general` subagent, or a `subtask: true` command) — an independent mechanism |
 | Antigravity CLI | Self-critique or use Antigravity's native multi-step task mechanism if available                                                           |
+
+For Codex delegation, the parent collects the reviewer result before
+continuing; if delegation fails, use the structured fallback.
 
 When a phase file says "run a critique pass", apply the row for your
 agent above. If no subagent mechanism is available, perform the critique

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -1237,9 +1237,13 @@ test('Codex critique guidance prefers a bounded reviewer with an explicit fallba
   );
 
   const codexRows = [workflow, templateWorkflow].map((text) => {
-    const critiqueSection = text.slice(
-      text.indexOf('## Critique pass invocation'),
+    const critiqueSectionStart = text.indexOf('## Critique pass invocation');
+    assert.notEqual(
+      critiqueSectionStart,
+      -1,
+      'the workflow must keep the critique section header',
     );
+    const critiqueSection = text.slice(critiqueSectionStart);
     const codexRow = critiqueSection.match(
       /^\| Codex CLI\s+\|([^\n]+)\|$/m,
     )?.[1];

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -1243,7 +1243,11 @@ test('Codex critique guidance prefers a bounded reviewer with an explicit fallba
       -1,
       'the workflow must keep the critique section header',
     );
-    const critiqueSection = text.slice(critiqueSectionStart);
+    const nextSectionStart = text.indexOf('\n## ', critiqueSectionStart + 1);
+    const critiqueSection = text.slice(
+      critiqueSectionStart,
+      nextSectionStart === -1 ? undefined : nextSectionStart,
+    );
     const codexRow = critiqueSection.match(
       /^\| Codex CLI\s+\|([^\n]+)\|$/m,
     )?.[1];

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -1236,7 +1236,7 @@ test('Codex critique guidance prefers a bounded reviewer with an explicit fallba
     'utf8',
   );
 
-  const codexRows = [workflow, templateWorkflow].map((text) => {
+  const critiqueSections = [workflow, templateWorkflow].map((text) => {
     const critiqueSectionStart = text.indexOf('## Critique pass invocation');
     assert.notEqual(
       critiqueSectionStart,
@@ -1250,30 +1250,39 @@ test('Codex critique guidance prefers a bounded reviewer with an explicit fallba
     assert.ok(codexRow, 'the workflow must keep a Codex critique row');
     assert.match(
       codexRow,
-      /Use bounded read-only native subagent review if suitable/,
+      /Use one bounded read-only native subagent review when supported and suitable/,
     );
-    assert.match(codexRow, /parent waits for result/);
+    assert.match(codexRow, /parent waits for and collects the result/);
     assert.match(codexRow, /structured self-critique/);
-    assert.match(codexRow, /delegation fails/);
+    assert.match(
+      codexRow,
+      /delegation is unavailable, disabled, unsuitable, or fails/,
+    );
     assert.doesNotMatch(
       codexRow,
       /Self-critique: add a "review the above for issues"/,
     );
+    assert.match(critiqueSection, /objective diff validation floor/);
     assert.match(
-      text,
-      /uniform C-phase\s+objective diff(?:-|\s+)validation floor/,
+      critiqueSection,
+      /This floor applies \*\*uniformly\*\* to every runtime/,
     );
     assert.match(
-      text,
+      critiqueSection,
       /parent collects the reviewer result before\s+continuing/,
     );
-    return codexRow.trim();
+    return { codexRow: codexRow.trim(), critiqueSection };
   });
 
   assert.deepEqual(
-    codexRows[0],
-    codexRows[1],
+    critiqueSections[0].codexRow,
+    critiqueSections[1].codexRow,
     'source and template Codex critique rows must stay equivalent',
+  );
+  assert.equal(
+    critiqueSections[0].critiqueSection,
+    critiqueSections[1].critiqueSection,
+    'source and template critique guidance must remain equivalent',
   );
 });
 

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -1229,6 +1229,50 @@ test('discover A2 roadmap node classification guidance is present in instruction
   assert.match(templateWorkflow, /classify roadmap/i);
 });
 
+test('Codex critique guidance prefers a bounded reviewer with an explicit fallback (idd-skill#1851)', () => {
+  const workflow = readFileSync(WORKFLOW_PATH, 'utf8');
+  const templateWorkflow = readFileSync(
+    new URL('../idd-template/docs/idd-workflow.md', import.meta.url),
+    'utf8',
+  );
+
+  const codexRows = [workflow, templateWorkflow].map((text) => {
+    const critiqueSection = text.slice(
+      text.indexOf('## Critique pass invocation'),
+    );
+    const codexRow = critiqueSection.match(
+      /^\| Codex CLI\s+\|([^\n]+)\|$/m,
+    )?.[1];
+    assert.ok(codexRow, 'the workflow must keep a Codex critique row');
+    assert.match(
+      codexRow,
+      /Use bounded read-only native subagent review if suitable/,
+    );
+    assert.match(codexRow, /parent waits for result/);
+    assert.match(codexRow, /structured self-critique/);
+    assert.match(codexRow, /delegation fails/);
+    assert.doesNotMatch(
+      codexRow,
+      /Self-critique: add a "review the above for issues"/,
+    );
+    assert.match(
+      text,
+      /uniform C-phase\s+objective diff(?:-|\s+)validation floor/,
+    );
+    assert.match(
+      text,
+      /parent collects the reviewer result before\s+continuing/,
+    );
+    return codexRow.trim();
+  });
+
+  assert.deepEqual(
+    codexRows[0],
+    codexRows[1],
+    'source and template Codex critique rows must stay equivalent',
+  );
+});
+
 test('review-triage PATH A verify-before-accept and actor-permission-cap guidance is present in instruction and template surfaces (idd-skill#1690, PR#1796)', () => {
   const reviewTriage = readFileSync(
     new URL(


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读下列文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

The Codex CLI row in the cross-agent critique guidance now prefers one
bounded, read-only native reviewer subagent when the current surface supports
it. The parent explicitly waits for and collects the result, with structured
self-critique as the fallback when delegation is unavailable or unsuitable.

The source and template workflow documents remain semantically equivalent, and
the consistency test protects the preferred mechanism, fallback, parent wait,
and existing objective diff-validation floor.

## Linked issue

Closes #1851

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The issue-authoring contract already prefers an independent critique when the
current Codex surface exposes native subagents. This update documents that
capability without requiring custom `.codex/agents/` configuration and keeps
the objective validation floor unchanged for every runtime.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [x] `node --test tests/consistency.test.mts`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check`
- [x] `pnpm run lint:minimum`
- [x] D2 `pre-push-validate` (including build:check and `node scripts/idd-doctor.mjs`)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated critique-pass guidance to prioritize bounded, read-only review with clear result collection before proceeding.
  * Clarified structured self-critique as the fallback when delegated review is unavailable.
  * Standardized validation and fallback instructions across workflow documentation.

* **Tests**
  * Added consistency checks to ensure the source and template workflow guidance remain aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->