### PR TITLE
fix(onboarding): honor runtime-native issue-authoring paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,3 +108,14 @@ The canonical issue-authoring skill bundle lives at
 generated copy: `node scripts/sync-docs.mjs --apply` regenerates
 derived copies and `node scripts/audit-docs.mjs --check` fails on
 drift.
+
+## Codex issue-authoring route
+
+For Codex CLI, read the canonical issue-authoring bundle explicitly from
+`skills/issue-authoring/`, or install one selected copy under
+`.agents/skills/issue-authoring/` when the target runtime supports native
+skill discovery there. The existing `.claude/skills/issue-authoring/` copy is
+the dogfood route for Claude Code and OpenCode compatibility; it is not the
+canonical source. Do not add checked-in `.agents/skills/` or
+`.opencode/skills/` mirrors by default, and do not assume the source path is
+automatically discovered by Codex.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,5 +117,5 @@ For Codex CLI, read the canonical issue-authoring bundle explicitly from
 skill discovery there. The existing `.claude/skills/issue-authoring/` copy is
 the dogfood route for Claude Code and OpenCode compatibility; it is not the
 canonical source. Do not add checked-in `.agents/skills/` or
-`.opencode/skills/` mirrors by default, and do not assume the source path is
-automatically discovered by Codex.
+`.opencode/skills/` mirrors by default (preventive; no observed incident yet),
+and do not assume the source path is automatically discovered by Codex.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -381,11 +381,16 @@ remote-fetch examples, see
 
 The issue-authoring skill is available as an optional companion artifact
 from `skills/issue-authoring/` in the idd-skill source repository. That path is
-the canonical source bundle; when you install it in a target repository,
-place the copied bundle in the agent-specific skill directory your
-runtime reads, such as `.github/skills/`, `.claude/skills/`, or
-`.agents/skills/`. Install it only when the operator explicitly wants
-pre-execution issue drafting or roadmap decomposition support.
+the canonical source bundle, not the target repository's discovery path.
+When you install it in a target repository, choose one agent-specific native
+skill directory that the selected runtime reads, such as `.agents/skills/`
+for Codex CLI, `.claude/skills/` for Claude Code, or `.opencode/skills/` for
+OpenCode. The examples below use the Codex destination
+`.agents/skills/issue-authoring/`; change `SKILL_DEST` to the one selected
+destination before running any example. Do not install the same skill ID in
+multiple roots unless the operator explicitly accepts identical duplicates.
+Install it only when the operator explicitly wants pre-execution issue
+drafting or roadmap decomposition support.
 
 Before importing files, re-check the policy choices confirmed in Step 1B:
 merge policy, PR review profile, review-thread resolution policy,
@@ -569,16 +574,19 @@ do
 done
 ```
 
-If the operator opts into the issue-authoring companion, fetch it
-separately and then move or copy it into the runtime-specific skill
-directory the target agent expects:
+If the operator opts into the issue-authoring companion, fetch its canonical
+source files separately and write them directly to the selected native skill
+destination. The Codex CLI example below uses `.agents/skills/`; set
+`SKILL_DEST` to a different single native destination when the target runtime
+requires it:
 
 <!-- audit:shell-list id=issue-authoring-companion-gh-api-loop -->
 
 ```sh
 DEST="."  # root of the target repository
+SKILL_DEST="${DEST}/.agents/skills/issue-authoring"  # Codex example; choose one native destination
 
-mkdir -p "${DEST}/skills/issue-authoring/references"
+mkdir -p "${SKILL_DEST}/references"
 
 for FILE in \
   "SKILL.md" \
@@ -588,7 +596,7 @@ for FILE in \
 do
   gh api -H "Accept: application/vnd.github.raw+json" \
     "repos/kurone-kito/idd-skill/contents/skills/issue-authoring/${FILE}" \
-    > "${DEST}/skills/issue-authoring/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
+    > "${SKILL_DEST}/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
 done
 ```
 
@@ -669,16 +677,17 @@ do
 done
 ```
 
-If the operator opts into the issue-authoring companion with `curl`,
-fetch it separately:
+If the operator opts into the issue-authoring companion with `curl`, fetch
+the same canonical source files to the selected native skill destination:
 
 <!-- audit:shell-list id=issue-authoring-companion-curl-loop -->
 
 ```sh
 BASE="https://raw.githubusercontent.com/kurone-kito/idd-skill/main/skills/issue-authoring"
 DEST="."  # root of the target repository
+SKILL_DEST="${DEST}/.agents/skills/issue-authoring"  # Codex example; choose one native destination
 
-mkdir -p "${DEST}/skills/issue-authoring/references"
+mkdir -p "${SKILL_DEST}/references"
 
 for FILE in \
   "SKILL.md" \
@@ -686,7 +695,7 @@ for FILE in \
   "references/draft-patterns.md" \
   "references/workflow-boundary.md"
 do
-  curl -fsSL "${BASE}/${FILE}" -o "${DEST}/skills/issue-authoring/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
+  curl -fsSL "${BASE}/${FILE}" -o "${SKILL_DEST}/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
 done
 ```
 
@@ -696,9 +705,21 @@ If you have cloned `https://github.com/kurone-kito/idd-skill`, copy
 the files from `idd-template/` into the target repository preserving
 their relative paths.
 
-If the operator opts into the issue-authoring companion, also copy
-`skills/issue-authoring/` from the idd-skill source repository to
-`skills/issue-authoring/` in the target repository.
+If the operator opts into the issue-authoring companion, copy the canonical
+`skills/issue-authoring/` source bundle from the idd-skill checkout to one
+selected native destination in the target repository. For example, from the
+idd-skill checkout:
+
+```sh
+SOURCE="skills/issue-authoring"
+TARGET_REPO="../target-repository"
+SKILL_DEST="${TARGET_REPO}/.agents/skills/issue-authoring"  # Codex example; choose one native destination
+
+mkdir -p "${SKILL_DEST}/references"
+cp -R "${SOURCE}/." "${SKILL_DEST}/"
+```
+
+Do not copy the same skill ID into additional runtime roots by default.
 
 ### Optional companion boundary
 
@@ -708,9 +729,13 @@ publishing issues, editing GitHub issues, or starting the Discover →
 Claim → Work loop unless the operator explicitly asks for that next
 step.
 
-Keep the companion separate from the execution instructions:
+Keep the companion separate from the execution instructions and distinguish
+its source from its installed destination:
 
-- `skills/issue-authoring/` is a helper for drafting issue sets.
+- `skills/issue-authoring/` is the canonical source helper for drafting issue
+  sets.
+- The selected native `SKILL_DEST` is the target repository's installed
+  destination; it is not another canonical source.
 - `.github/instructions/*.instructions.md` execute approved issues
   through the IDD loop.
 - In the source `idd-skill` repository, maintainers must keep

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -386,8 +386,8 @@ from `skills/issue-authoring/` in the idd-skill source repository. That path is
 the canonical source bundle, not the target repository's discovery path.
 When you install it in a target repository, choose one agent-specific native
 skill directory that the selected runtime reads, such as `.agents/skills/`
-for Codex CLI, `.claude/skills/` for Claude Code, or `.opencode/skills/` for
-OpenCode. The examples below use the Codex destination
+for Codex CLI or OpenCode, `.claude/skills/` for Claude Code, or
+`.opencode/skills/` for OpenCode. The examples below use the Codex destination
 `.agents/skills/issue-authoring/`; change `SKILL_DEST` to the one selected
 destination before running any example. Do not install the same skill ID in
 multiple roots unless the operator explicitly accepts identical duplicates

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -251,7 +251,9 @@ require explicit operator confirmation:
    explicit config opt-out via `skipIssueAuthorApprovalGate: true`)
 9. maintainer approval actor policy (`owners-and-maintainers-only` by
    default, or `all-write-permission-actors`)
-10. issue-authoring companion status (`installed` or `not installed`)
+10. issue-authoring companion status (`installed` or `not installed`); when
+    installed, the selected native destination (`.agents/skills/`,
+    `.claude/skills/`, or `.opencode/skills/`)
 11. helper runtime profile (`instructions-only` by default, or an
     evidence-based helper profile recommendation that still requires
     explicit operator confirmation`)
@@ -388,7 +390,8 @@ for Codex CLI, `.claude/skills/` for Claude Code, or `.opencode/skills/` for
 OpenCode. The examples below use the Codex destination
 `.agents/skills/issue-authoring/`; change `SKILL_DEST` to the one selected
 destination before running any example. Do not install the same skill ID in
-multiple roots unless the operator explicitly accepts identical duplicates.
+multiple roots unless the operator explicitly accepts identical duplicates
+(preventive; no observed incident yet).
 Install it only when the operator explicitly wants pre-execution issue
 drafting or roadmap decomposition support.
 
@@ -594,6 +597,7 @@ for FILE in \
   "references/draft-patterns.md" \
   "references/workflow-boundary.md"
 do
+  mkdir -p "$(dirname "${SKILL_DEST}/${FILE}")"
   gh api -H "Accept: application/vnd.github.raw+json" \
     "repos/kurone-kito/idd-skill/contents/skills/issue-authoring/${FILE}" \
     > "${SKILL_DEST}/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
@@ -695,6 +699,7 @@ for FILE in \
   "references/draft-patterns.md" \
   "references/workflow-boundary.md"
 do
+  mkdir -p "$(dirname "${SKILL_DEST}/${FILE}")"
   curl -fsSL "${BASE}/${FILE}" -o "${SKILL_DEST}/${FILE}" || { echo "Failed: ${FILE}" >&2; exit 1; }
 done
 ```
@@ -719,7 +724,8 @@ mkdir -p "${SKILL_DEST}/references"
 cp -R "${SOURCE}/." "${SKILL_DEST}/"
 ```
 
-Do not copy the same skill ID into additional runtime roots by default.
+Do not copy the same skill ID into additional runtime roots by default
+(preventive; no observed incident yet).
 
 ### Optional companion boundary
 
@@ -1174,7 +1180,7 @@ After completing the steps above, confirm each item:
       maintainer approval actor policy, and helper runtime profile are
       explicitly recorded.
 - [ ] If the operator opted into issue authoring, the companion skill
-      files are present.
+      files are present under the native destination recorded in the policy.
 - [ ] No `{{...}}` placeholders remain, the `Project commands` table is
       correct, and any `orphan-first` scope choice has a valid policy
       value.

--- a/idd-template/docs/onboarding/agent-entry-and-verification.md
+++ b/idd-template/docs/onboarding/agent-entry-and-verification.md
@@ -177,18 +177,34 @@ workflow stub above to every session; the steps below are an
   ```
 
 - If the operator installs the optional `issue-authoring` companion
-  from Step 2 under a directory OpenCode reads natively —
-  `.claude/skills/` or `.opencode/skills/` — it is already available to
-  OpenCode without extra configuration. Step 2 also allows other
-  runtime-specific locations (for example `.github/skills/`); OpenCode
-  does not discover a bundle placed only in one of those, so copy or
-  symlink it into `.claude/skills/` or `.opencode/skills/` as well when
-  OpenCode also needs it.
+  from Step 2 under one of the native roots OpenCode reads —
+  `.claude/skills/`, `.opencode/skills/`, or `.agents/skills/` — it is
+  already available without an additional copy. Keep the selected
+  destination recorded in the onboarding policy; do not add the same skill
+  ID to another root merely to support a second runtime.
 - If a target repository runs OpenCode as an autonomous worker under
   its own GitHub identity (not just an interactive assistant), add
   that login to `trustedMarkerActors` (and the advisory-bot lists if
   it also reviews) in `.github/idd/config.json` — a config-values edit
   only; `schemas/policy.schema.json` stays agent-agnostic.
+
+### Issue-authoring companion verification
+
+When the optional companion is installed, verify the source-versus-
+destination contract separately from the entry-file checks:
+
+- The canonical source inventory remains `skills/issue-authoring/` in the
+  idd-skill checkout and includes `SKILL.md` plus all bundled references.
+- The selected target destination is recorded alongside the `installed`
+  decision in the policy record. The Codex example is
+  `.agents/skills/issue-authoring/SKILL.md`.
+- The `gh api`, `curl`, and local-copy examples write every source file under
+  that selected destination and do not fall back to target
+  `skills/issue-authoring/`.
+- A default onboarding import adds no checked-in `.agents/skills/` or
+  `.opencode/skills/` mirror. A mixed-runtime target uses one native copy
+  plus an explicit manual route unless the operator deliberately accepts
+  identical duplicates.
 
 ### GEMINI.md
 

--- a/idd-template/docs/onboarding/agent-entry-and-verification.md
+++ b/idd-template/docs/onboarding/agent-entry-and-verification.md
@@ -181,7 +181,8 @@ workflow stub above to every session; the steps below are an
   `.claude/skills/`, `.opencode/skills/`, or `.agents/skills/` — it is
   already available without an additional copy. Keep the selected
   destination recorded in the onboarding policy; do not add the same skill
-  ID to another root merely to support a second runtime.
+  ID to another root merely to support a second runtime (preventive; no
+  observed incident yet).
 - If a target repository runs OpenCode as an autonomous worker under
   its own GitHub identity (not just an interactive assistant), add
   that login to `trustedMarkerActors` (and the advisory-bot lists if
@@ -204,7 +205,7 @@ destination contract separately from the entry-file checks:
 - A default onboarding import adds no checked-in `.agents/skills/` or
   `.opencode/skills/` mirror. A mixed-runtime target uses one native copy
   plus an explicit manual route unless the operator deliberately accepts
-  identical duplicates.
+  identical duplicates (preventive; no observed incident yet).
 
 ### GEMINI.md
 
@@ -305,9 +306,9 @@ checks, confirm the detailed items below.
 - [ ] The selected helper runtime profile is recorded, including whether
       the repository stays on `instructions-only` or opted into
       `package-manager`, `vendored-node`, or `ephemeral-npx`.
-- [ ] If the operator opted into issue authoring,
-      `skills/issue-authoring/SKILL.md` and the
-      `skills/issue-authoring/references/` files are present.
+- [ ] If the operator opted into issue authoring, the native destination
+      recorded in the policy contains `SKILL.md` and every bundled reference
+      file.
 
 ### Placeholder, marker, and config alignment
 

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -164,8 +164,9 @@ runtime:
 
 - `installed`: copy the canonical source bundle at
   `skills/issue-authoring/` into one selected native skill directory, such as
-  `.agents/skills/issue-authoring/` for Codex CLI, `.claude/skills/issue-authoring/`
-  for Claude Code, or `.opencode/skills/issue-authoring/` for OpenCode. Record
+  `.agents/skills/issue-authoring/` for Codex CLI or OpenCode,
+  `.claude/skills/issue-authoring/` for Claude Code, or
+  `.opencode/skills/issue-authoring/` for OpenCode. Record
   the selected destination alongside the `installed` status.
 - `not installed`: continue without the companion
 

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -171,7 +171,8 @@ runtime:
 
 The canonical source path and the installed destination are separate values:
 the destination is not a second source-of-truth copy. Do not add the same
-skill ID to multiple runtime roots by default; a mixed-runtime target should
+skill ID to multiple runtime roots by default (preventive; no observed incident
+yet); a mixed-runtime target should
 use one native copy plus an explicit manual route unless the operator
 deliberately accepts identical duplicates. The companion helps draft
 IDD-ready issues and roadmaps. It does not authorize publishing issues or
@@ -381,14 +382,14 @@ This repository uses the following IDD policies:
 - **Missing-approval behavior**:
   `{explicit-target stop-before-claim + discovery approval-needed fallback bucket}`
 
-  ### Issue-Authoring Companion
+### Issue-Authoring Companion
 
-  **Status**: `{installed | not installed}`
+**Status**: `{installed | not installed}`
 
-  **Native destination**: `{.agents/skills/issue-authoring/ | .claude/skills/issue-authoring/ | .opencode/skills/issue-authoring/ | not applicable}`
+**Native destination**: `{.agents/skills/issue-authoring/ | .claude/skills/issue-authoring/ | .opencode/skills/issue-authoring/ | not applicable}`
 
-  - **`issueAuthoring.maxClarificationRounds`**:
-    `{3 | custom finite bound}`
+- **`issueAuthoring.maxClarificationRounds`**:
+  `{3 | custom finite bound}`
 ```
 
 When the repository uses a non-default merge, review, or thread policy,

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -158,14 +158,24 @@ runtime does not enforce that explicit allowlist yet.
 
 ### Issue-authoring companion
 
-Confirm whether the operator wants the optional issue-authoring skill:
+Confirm whether the operator wants the optional issue-authoring skill and,
+when installed, record the one native destination selected for the target
+runtime:
 
-- `installed`: copy `skills/issue-authoring/` into the target repository
+- `installed`: copy the canonical source bundle at
+  `skills/issue-authoring/` into one selected native skill directory, such as
+  `.agents/skills/issue-authoring/` for Codex CLI, `.claude/skills/issue-authoring/`
+  for Claude Code, or `.opencode/skills/issue-authoring/` for OpenCode. Record
+  the selected destination alongside the `installed` status.
 - `not installed`: continue without the companion
 
-The companion helps draft IDD-ready issues and roadmaps. It does not
-authorize publishing issues or starting the main execution loop on its
-own.
+The canonical source path and the installed destination are separate values:
+the destination is not a second source-of-truth copy. Do not add the same
+skill ID to multiple runtime roots by default; a mixed-runtime target should
+use one native copy plus an explicit manual route unless the operator
+deliberately accepts identical duplicates. The companion helps draft
+IDD-ready issues and roadmaps. It does not authorize publishing issues or
+starting the main execution loop on its own.
 
 ### Helper runtime profile
 
@@ -371,12 +381,14 @@ This repository uses the following IDD policies:
 - **Missing-approval behavior**:
   `{explicit-target stop-before-claim + discovery approval-needed fallback bucket}`
 
-### Issue-Authoring Companion
+  ### Issue-Authoring Companion
 
-**Status**: `{installed | not installed}`
+  **Status**: `{installed | not installed}`
 
-- **`issueAuthoring.maxClarificationRounds`**:
-  `{3 | custom finite bound}`
+  **Native destination**: `{.agents/skills/issue-authoring/ | .claude/skills/issue-authoring/ | .opencode/skills/issue-authoring/ | not applicable}`
+
+  - **`issueAuthoring.maxClarificationRounds`**:
+    `{3 | custom finite bound}`
 ```
 
 When the repository uses a non-default merge, review, or thread policy,

--- a/idd-template/docs/onboarding/template-distribution.md
+++ b/idd-template/docs/onboarding/template-distribution.md
@@ -42,7 +42,7 @@ the idd-skill checkout. It is not a target installation path: the onboarding
 examples use a separate `SKILL_DEST` value, with
 `.agents/skills/issue-authoring/` as the Codex example. Record the selected
 destination in the onboarding policy and do not add a second same-named
-runtime mirror by default.
+runtime mirror by default (preventive; no observed incident yet).
 
 ## Generated file lists
 

--- a/idd-template/docs/onboarding/template-distribution.md
+++ b/idd-template/docs/onboarding/template-distribution.md
@@ -25,8 +25,9 @@ The template has three distribution surfaces:
 1. **Core template files** copied from `idd-template/` into the adopter
    repository. These include `.github/idd/`, `.github/instructions/`,
    `docs/`, and `profiles/`.
-2. **Optional issue-authoring companion files** copied from
-   `skills/issue-authoring/` only when the operator explicitly opts into
+2. **Optional issue-authoring companion files** read from the canonical
+   `skills/issue-authoring/` source bundle and installed under one selected
+   runtime-native destination only when the operator explicitly opts into
    pre-execution issue drafting.
 3. **Local-copy installs** where an agent copies the full
    `idd-template/` directory from a cloned `idd-skill` checkout instead
@@ -35,6 +36,13 @@ The template has three distribution surfaces:
 `idd-template/ONBOARDING.md` keeps the executable import snippets for
 the first two surfaces so a raw-URL onboarding run can still complete
 without opening this reference first.
+
+The companion generated block describes canonical source paths relative to
+the idd-skill checkout. It is not a target installation path: the onboarding
+examples use a separate `SKILL_DEST` value, with
+`.agents/skills/issue-authoring/` as the Codex example. Record the selected
+destination in the onboarding policy and do not add a second same-named
+runtime mirror by default.
 
 ## Generated file lists
 
@@ -164,8 +172,10 @@ maintainer decision, not a mechanical file-list edit.
 ## Remote fetch examples
 
 The `gh api` and `curl` loops in `idd-template/ONBOARDING.md` intentionally
-list every file instead of fetching directories. This keeps raw-content
-imports deterministic and makes missing files visible during onboarding.
+list every canonical source file instead of fetching directories. This keeps
+raw-content imports deterministic and makes missing files visible during
+onboarding. Their `SKILL_DEST` variable is deliberately separate from the
+source path and controls the selected runtime-native target directory.
 
 For a new core file, ensure that both loops include the path after the
 generated list is updated. The audit checks the shell lists against the
@@ -180,9 +190,12 @@ for each nested docs directory.
 ## Local-copy installs
 
 The local-copy path is intentionally broader than the remote-fetch path:
-copy the contents of `idd-template/` while preserving relative paths.
-That means new core files under `idd-template/` are automatically covered
-by local-copy installs after they are committed.
+copy the contents of `idd-template/` while preserving relative paths. That
+means new core files under `idd-template/` are automatically covered by
+local-copy installs after they are committed. The optional companion is
+different: copy its canonical `skills/issue-authoring/` source contents into
+the one selected native `SKILL_DEST`, rather than into a target
+`skills/issue-authoring/` directory by assumption.
 
 Keep the local-copy prose in `idd-template/ONBOARDING.md` short. Use this
 reference for maintenance details and the generated remote-fetch snippets
@@ -208,3 +221,5 @@ Before merging a distribution-surface change, verify:
   `idd-template/` path (its core half needs no manifest edit — a new
   `idd-template/**/*` path is picked up automatically).
 - `node scripts/audit-docs.mjs --check` passes.
+- the policy record names the selected companion destination when the
+  optional issue-authoring bundle is installed.

--- a/tests/idd-onboarding-companion-paths.test.mts
+++ b/tests/idd-onboarding-companion-paths.test.mts
@@ -96,6 +96,11 @@ test('companion policy and source-repository routing distinguish source from des
   );
   assert.match(verification, /source-versus-\s*destination contract/iu);
   assert.match(verification, /\.agents\/skills\/issue-authoring\/SKILL\.md/u);
+  assert.match(verification, /native destination[\s\S]*contains `SKILL\.md`/iu);
+  assert.doesNotMatch(
+    verification,
+    /`skills\/issue-authoring\/SKILL\.md`[\s\S]*`skills\/issue-authoring\/references\//u,
+  );
   assert.match(agents, /## Codex issue-authoring route/u);
   assert.match(agents, /canonical issue-authoring bundle/u);
   assert.match(agents, /\.claude\/skills\/issue-authoring\//u);

--- a/tests/idd-onboarding-companion-paths.test.mts
+++ b/tests/idd-onboarding-companion-paths.test.mts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { readText } from './test-utils.mts';
+
+const ONBOARDING = readText('idd-template/ONBOARDING.md');
+
+function extractShellList(id: string): string {
+  const marker = `<!-- audit:shell-list id=${id} -->`;
+  const markerIndex = ONBOARDING.indexOf(marker);
+  assert.notEqual(markerIndex, -1, `missing shell-list marker: ${id}`);
+  const fenceStart = ONBOARDING.indexOf('```sh', markerIndex);
+  assert.notEqual(fenceStart, -1, `missing shell block: ${id}`);
+  const fenceEnd = ONBOARDING.indexOf('\n```', fenceStart);
+  assert.notEqual(fenceEnd, -1, `unterminated shell block: ${id}`);
+  return ONBOARDING.slice(fenceStart, fenceEnd);
+}
+
+function assertNativeDestination(shell: string, label: string): void {
+  assert.match(
+    shell,
+    /SKILL_DEST="\$\{DEST\}\/\.agents\/skills\/issue-authoring"/u,
+    `${label} must show the Codex native destination example`,
+  );
+  assert.match(
+    shell,
+    /\$\{SKILL_DEST\}\/\$\{FILE\}/u,
+    `${label} must write every source file through SKILL_DEST`,
+  );
+  assert.doesNotMatch(
+    shell,
+    /\$\{DEST\}\/skills\/issue-authoring/u,
+    `${label} must not fall back to target skills/issue-authoring`,
+  );
+}
+
+test('remote companion fetches keep canonical source paths separate from the native destination', () => {
+  const ghApi = extractShellList('issue-authoring-companion-gh-api-loop');
+  const curl = extractShellList('issue-authoring-companion-curl-loop');
+
+  for (const [label, shell] of [
+    ['gh api', ghApi],
+    ['curl', curl],
+  ] as const) {
+    assert.match(
+      shell,
+      /skills\/issue-authoring/u,
+      `${label} must fetch from the canonical source bundle`,
+    );
+    assertNativeDestination(shell, label);
+  }
+});
+
+test('local companion copy uses the selected native destination', () => {
+  const optionBStart = ONBOARDING.indexOf('### Option B — Local copy');
+  const boundary = ONBOARDING.indexOf(
+    '### Optional companion boundary',
+    optionBStart,
+  );
+  assert.notEqual(optionBStart, -1, 'missing local-copy section');
+  assert.notEqual(boundary, -1, 'missing companion boundary section');
+  const localCopy = ONBOARDING.slice(optionBStart, boundary);
+
+  assert.match(localCopy, /SOURCE="skills\/issue-authoring"/u);
+  assert.match(localCopy, /TARGET_REPO=/u);
+  assert.match(
+    localCopy,
+    /SKILL_DEST="\$\{TARGET_REPO\}\/\.agents\/skills\/issue-authoring"/u,
+  );
+  assert.match(localCopy, /cp -R "\$\{SOURCE\}\/\." "\$\{SKILL_DEST\}\/"/u);
+  assert.doesNotMatch(
+    localCopy,
+    /\$\{TARGET_REPO\}\/skills\/issue-authoring/u,
+    'local copy must not assume target skills/issue-authoring is native',
+  );
+});
+
+test('companion policy and source-repository routing distinguish source from destination', () => {
+  const policy = readText('idd-template/docs/onboarding/policy-decisions.md');
+  const verification = readText(
+    'idd-template/docs/onboarding/agent-entry-and-verification.md',
+  );
+  const agents = readText('AGENTS.md');
+
+  assert.match(policy, /selected destination alongside/iu);
+  assert.match(policy, /\*\*Native destination\*\*:/u);
+  assert.match(policy, /canonical source path and the installed destination/iu);
+  assert.match(verification, /source-versus-\s*destination contract/iu);
+  assert.match(verification, /\.agents\/skills\/issue-authoring\/SKILL\.md/u);
+  assert.match(agents, /## Codex issue-authoring route/u);
+  assert.match(agents, /canonical issue-authoring bundle/u);
+  assert.match(agents, /\.claude\/skills\/issue-authoring\//u);
+  assert.match(agents, /\.agents\/skills\/issue-authoring\//u);
+});
+
+test('the generated companion inventory remains canonical-source-only', () => {
+  const startMarker =
+    '<!-- audit:generated id=issue-authoring-companion-files -->';
+  const endMarker = '<!-- /audit:generated -->';
+  const start = ONBOARDING.indexOf(startMarker);
+  assert.notEqual(start, -1, 'missing companion generated block');
+  const end = ONBOARDING.indexOf(endMarker, start);
+  assert.notEqual(end, -1, 'unterminated companion generated block');
+  const inventory = ONBOARDING.slice(start, end);
+
+  for (const path of [
+    'skills/issue-authoring/SKILL.md',
+    'skills/issue-authoring/references/contract.md',
+    'skills/issue-authoring/references/draft-patterns.md',
+    'skills/issue-authoring/references/workflow-boundary.md',
+  ]) {
+    assert.ok(
+      inventory.includes(path),
+      `missing canonical source path: ${path}`,
+    );
+  }
+  assert.doesNotMatch(inventory, /\.agents\/skills|\.opencode\/skills/u);
+});

--- a/tests/idd-onboarding-companion-paths.test.mts
+++ b/tests/idd-onboarding-companion-paths.test.mts
@@ -42,13 +42,18 @@ test('remote companion fetches keep canonical source paths separate from the nat
     ['gh api', ghApi],
     ['curl', curl],
   ] as const) {
-    assert.match(
-      shell,
-      /skills\/issue-authoring/u,
-      `${label} must fetch from the canonical source bundle`,
-    );
     assertNativeDestination(shell, label);
   }
+  assert.match(
+    ghApi,
+    /contents\/skills\/issue-authoring\/\$\{FILE\}/u,
+    'gh api must request the canonical source bundle',
+  );
+  assert.match(
+    curl,
+    /BASE="https:\/\/raw\.githubusercontent\.com\/kurone-kito\/idd-skill\/main\/skills\/issue-authoring"/u,
+    'curl must fetch from the canonical source bundle',
+  );
 });
 
 test('local companion copy uses the selected native destination', () => {
@@ -85,6 +90,10 @@ test('companion policy and source-repository routing distinguish source from des
   assert.match(policy, /selected destination alongside/iu);
   assert.match(policy, /\*\*Native destination\*\*:/u);
   assert.match(policy, /canonical source path and the installed destination/iu);
+  assert.match(
+    ONBOARDING,
+    /issue-authoring companion status[\s\S]*selected native destination/iu,
+  );
   assert.match(verification, /source-versus-\s*destination contract/iu);
   assert.match(verification, /\.agents\/skills\/issue-authoring\/SKILL\.md/u);
   assert.match(agents, /## Codex issue-authoring route/u);
@@ -114,5 +123,5 @@ test('the generated companion inventory remains canonical-source-only', () => {
       `missing canonical source path: ${path}`,
     );
   }
-  assert.doesNotMatch(inventory, /\.agents\/skills|\.opencode\/skills/u);
+  assert.doesNotMatch(inventory, /\.(?:agents|claude|opencode)\/skills/u);
 });


### PR DESCRIPTION
# Summary

Update onboarding so the optional issue-authoring companion keeps its canonical source bundle separate from the selected runtime-native install destination. The gh api, curl, and local-copy examples now route through SKILL_DEST, with a Codex .agents/skills/issue-authoring/ example and explicit one-native-copy guidance.

## Linked issue

Closes #1850

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The source repository keeps skills/issue-authoring/ as the canonical bundle and the existing .claude/skills/issue-authoring/ dogfood copy. This change documents the explicit Codex route in AGENTS.md without adding checked-in .agents/skills or .opencode/skills mirrors. The policy template now records both companion status and native destination.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] focused onboarding and entry tests: 95/95
- [x] pnpm run lint:minimum: 3,126 tests passed
- [x] node scripts/audit-docs.mjs --check
- [x] pnpm run docs:sync:check
- [x] node scripts/idd-doctor.mjs (passed with 4 existing environment or repository warnings)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified installation guidance for the optional issue-authoring companion across supported coding agents.
  * Added instructions for selecting and recording a single native destination while avoiding duplicate installations.
  * Improved onboarding, distribution, verification, and policy guidance by distinguishing canonical sources from installed copies.

* **Tests**
  * Added coverage for companion paths, native destinations, local-copy installation, documentation requirements, and duplicate-path prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->