### PR TITLE
docs(ci): warn against advisory job name overrides

### DIFF
--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -238,6 +238,10 @@ jobs:
   # docs/policy-constants.md (ADVISORY_CONVERGENCE_CHECK_SELECTOR in
   # advisory-convergence.mts) -- keep all three in sync if this id ever
   # changes.
+  # Do not add a `name:` display-name key here: GitHub would use it as the
+  # check-run context instead of this job id, so the rerun helper,
+  # advisory-wait policy, required status check, and external-check waiver
+  # selector would no longer match `idd-advisory-convergence`.
   idd-advisory-convergence:
     runs-on: ubuntu-slim
     # No observed run history yet (new workflow). Bounds pathological

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -238,10 +238,11 @@ jobs:
   # docs/policy-constants.md (ADVISORY_CONVERGENCE_CHECK_SELECTOR in
   # advisory-convergence.mts) -- keep all three in sync if this id ever
   # changes.
-  # Do not add a `name:` display-name key here: GitHub would use it as the
-  # check-run context instead of this job id, so the rerun helper,
-  # advisory-wait policy, required status check, and external-check waiver
-  # selector would no longer match `idd-advisory-convergence`.
+  # Adding a `name:` display-name key or changing this job id changes the
+  # literal check-run context. This warning is preventive; no observed
+  # incident yet. If either edit is intentional, update every rerun-helper,
+  # advisory-wait, required-status-check, and external-check-waiver consumer
+  # to the new literal context together.
   idd-advisory-convergence:
     runs-on: ubuntu-slim
     # No observed run history yet (new workflow). Bounds pathological

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -41,6 +41,11 @@ permissions:
   issues: read
   pull-requests: read
 jobs:
+  # The job id `idd-advisory-convergence` is the exact check-run context
+  # consumed by the rerun helper, advisory-wait policy, required status
+  # check, and external-check waiver selector. Do not add a `name:`
+  # display-name key here: GitHub would use it as the check-run context
+  # instead of this job id, so those consumers would no longer match.
   idd-advisory-convergence:
     runs-on: ubuntu-latest
     # Bounds pathological hangs; adjust to your own observed run duration

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -43,9 +43,10 @@ permissions:
 jobs:
   # The job id `idd-advisory-convergence` is the exact check-run context
   # consumed by the rerun helper, advisory-wait policy, required status
-  # check, and external-check waiver selector. Do not add a `name:`
-  # display-name key here: GitHub would use it as the check-run context
-  # instead of this job id, so those consumers would no longer match.
+  # check, and external-check waiver selector. Adding a `name:` display-name
+  # key or changing the job id changes that literal context. This warning is
+  # preventive; no observed incident yet. If either edit is intentional,
+  # update every consumer to the new literal context together.
   idd-advisory-convergence:
     runs-on: ubuntu-latest
     # Bounds pathological hangs; adjust to your own observed run duration


### PR DESCRIPTION
## Summary
- document that the advisory job id is the exact check-run context
- warn against adding a `name:` display-name key that changes the context
- keep source and template workflow guidance aligned

Closes #1834

## Verification
- [x] node scripts/audit-docs.mjs --check
- [x] pnpm run docs:sync:check
- [x] pnpm lint (3127 tests passing)
- [x] git diff --check

## Signing
- configured GPG signing was attempted once but interrupted without useful stderr
- gpg-agent restart was skipped because the environment had no SSH_AUTH_SOCK and SSH fallback was available
- project-blessed git commit-ssh produced an SSH-signed commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added workflow documentation clarifying that the advisory convergence check must retain its required check-run context identifier.
  * Documented that replacing the identifier with a display name could disrupt related automation and policy checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->