### PR TITLE
docs(schema): describe pre-merge readiness evidence properties

### DIFF
--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -25,7 +25,7 @@
   "properties": {
     "protocolVersion": {
       "type": "string",
-      "description": "Schema protocol version for this readiness report. Only \"1\" has ever been emitted.",
+      "description": "Schema protocol version for this pre-merge readiness document.",
       "enum": [
         "1"
       ]
@@ -589,7 +589,7 @@
           "properties": {
             "status": {
               "type": "string",
-              "description": "Overall self-approval deadlock status: not_applicable, clear, possible_deadlock, or deadlock.",
+              "description": "Overall self-approval deadlock status, escalating from not applicable through a resolvable or unverifiable bypass to a genuine deadlock.",
               "enum": [
                 "not_applicable",
                 "clear",
@@ -636,7 +636,7 @@
             },
             "bypassMode": {
               "type": "string",
-              "description": "Kind of bypass detected: none, pull_request, always, exempt, or mixed across the relevant rulesets.",
+              "description": "Kind of pull-request bypass detected across the relevant rulesets, or none when no applicable bypass is configured.",
               "enum": [
                 "none",
                 "pull_request",
@@ -712,7 +712,7 @@
       "properties": {
         "outcome": {
           "type": "string",
-          "description": "E14/F2 advisory-wait outcome: SATISFIED, WAIT, REQUEST_NEEDED, RECOVERY_NEEDED, or CAP_EXHAUSTED.",
+          "description": "E14/F2 advisory-wait state machine's current outcome, evaluated from Copilot's pending/reviewed state, same-head markers, and the elapsed/settled windows below.",
           "enum": [
             "SATISFIED",
             "WAIT",
@@ -830,7 +830,7 @@
       "properties": {
         "status": {
           "type": "string",
-          "description": "Overall classification of the required checks: missing, success, pending, failed, or unknown.",
+          "description": "Rollup classification of the required checks, accounting for missing checks and the source-pinned downgrade of an otherwise-passing result.",
           "enum": [
             "missing",
             "success",
@@ -1064,7 +1064,7 @@
         },
         "reason": {
           "type": "string",
-          "description": "Specific reason the claim matched or did not: match, missing-active-claim, claim-id-mismatch, or agent-id-mismatch.",
+          "description": "Why claim-ownership resolution matched or failed.",
           "enum": [
             "match",
             "missing-active-claim",
@@ -1194,7 +1194,7 @@
               },
               "reason": {
                 "type": "string",
-                "description": "Why this thread is still outstanding: incomplete-thread-comments, missing-fresh-disposition, or unresolved-without-fresh-disposition.",
+                "description": "Why this thread is still outstanding, distinguishing an incomplete comment page from a missing or stale disposition.",
                 "enum": [
                   "incomplete-thread-comments",
                   "missing-fresh-disposition",
@@ -1432,7 +1432,7 @@
       "properties": {
         "mergeStateStatus": {
           "type": "string",
-          "description": "Live GitHub merge-state status for the PR head (e.g. CLEAN, BEHIND, BLOCKED), used to detect a stale head requiring an update before merge.",
+          "description": "Live GitHub merge-state status for the PR head, used to detect a stale head requiring an update before merge.",
           "enum": [
             "",
             "BEHIND",

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -25,27 +25,32 @@
   "properties": {
     "protocolVersion": {
       "type": "string",
+      "description": "Schema protocol version for this readiness report. Only \"1\" has ever been emitted.",
       "enum": [
         "1"
       ]
     },
     "decisionAuthority": {
       "type": "string",
+      "description": "Declares that this document is read-only evidence for the instructions-layer decision logic, never a decision by itself.",
       "enum": [
         "instructions"
       ]
     },
     "prHeadSha": {
       "type": "string",
+      "description": "Commit SHA of the PR head this readiness snapshot was collected for.",
       "pattern": "^[0-9a-f]{40}$"
     },
     "now": {
       "type": "string",
+      "description": "Timestamp the snapshot was collected at; the reference point for every elapsed-time and staleness calculation in this report.",
       "format": "date-time",
       "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
     },
     "reviewCurrency": {
       "type": "object",
+      "description": "Comparison between the last posted review-watermark snapshot and current live PR activity, deciding whether cached review findings are still safe to rely on or the gate must return to E1 for a fresh review pass.",
       "required": [
         "watermarkPresent",
         "watermark",
@@ -56,10 +61,12 @@
       "additionalProperties": false,
       "properties": {
         "watermarkPresent": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether a trusted review-watermark marker for the expected claim was found on the PR."
         },
         "watermark": {
           "type": "object",
+          "description": "The most recent trusted review-watermark marker's recorded fields, or empty/\"none\" placeholders when watermarkPresent is false.",
           "required": [
             "agentId",
             "claimId",
@@ -72,35 +79,43 @@
           "additionalProperties": false,
           "properties": {
             "agentId": {
-              "type": "string"
+              "type": "string",
+              "description": "Agent identifier recorded on the watermark marker."
             },
             "claimId": {
-              "type": "string"
+              "type": "string",
+              "description": "Claim identifier the watermark marker was posted under."
             },
             "headSha": {
               "type": "string",
+              "description": "PR head commit SHA recorded at watermark time.",
               "pattern": "^$|^[0-9a-f]{40}$"
             },
             "maxActivityUpdatedAt": {
               "type": "string",
+              "description": "Latest comment/review/thread activity timestamp recorded at watermark time, or \"none\".",
               "pattern": "^(none|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z)$"
             },
             "totalItemCount": {
               "type": "integer",
+              "description": "Total comment, review, and thread count recorded at watermark time.",
               "minimum": 0
             },
             "latestCiCompletedAt": {
               "type": "string",
+              "description": "Latest completed CI check timestamp recorded at watermark time, or \"none\".",
               "pattern": "^(none|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z)$"
             },
             "createdAt": {
               "type": "string",
+              "description": "GitHub creation timestamp of the watermark marker comment, or \"none\".",
               "pattern": "^(none|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z)$"
             }
           }
         },
         "live": {
           "type": "object",
+          "description": "Freshly computed activity snapshot for the current PR state, compared against the watermark above.",
           "required": [
             "totalItemCount",
             "maxActivityUpdatedAt",
@@ -114,22 +129,27 @@
           "properties": {
             "totalItemCount": {
               "type": "integer",
+              "description": "Current total comment, review, and thread count, after filtering out trusted operational-marker comments.",
               "minimum": 0
             },
             "maxActivityUpdatedAt": {
               "type": "string",
+              "description": "Current latest comment/review/thread activity timestamp, or \"none\".",
               "pattern": "^(none|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z)$"
             },
             "latestCiCompletedAt": {
               "type": "string",
+              "description": "Current latest completed CI check timestamp across all checks, or \"none\".",
               "pattern": "^(none|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z)$"
             },
             "latestPassingCiCompletedAt": {
               "type": "string",
+              "description": "Current latest completed CI check timestamp restricted to pass-equivalent states, or \"none\".",
               "pattern": "^(none|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z)$"
             },
             "counts": {
               "type": "object",
+              "description": "Current raw item counts feeding totalItemCount.",
               "required": [
                 "comments",
                 "reviews",
@@ -139,20 +159,24 @@
               "properties": {
                 "comments": {
                   "type": "integer",
+                  "description": "Current count of non-operational-marker issue/PR comments.",
                   "minimum": 0
                 },
                 "reviews": {
                   "type": "integer",
+                  "description": "Current count of PR reviews.",
                   "minimum": 0
                 },
                 "threads": {
                   "type": "integer",
+                  "description": "Current count of review threads.",
                   "minimum": 0
                 }
               }
             },
             "ackOnly": {
               "type": "object",
+              "description": "Structural ack-only evidence: advisory-bot activity newer than the latest recognized disposition, which can explain new activity without reopening review.",
               "required": [
                 "advisoryBotLogins",
                 "source",
@@ -164,6 +188,7 @@
               "properties": {
                 "advisoryBotLogins": {
                   "type": "array",
+                  "description": "Configured advisory-bot logins considered for ack-only classification.",
                   "items": {
                     "type": "string",
                     "minLength": 1
@@ -171,6 +196,7 @@
                 },
                 "source": {
                   "type": "string",
+                  "description": "Provenance of the advisory-bot login list: an explicit flag, an environment variable, repository config, or none configured.",
                   "enum": [
                     "flag",
                     "env",
@@ -179,14 +205,17 @@
                   ]
                 },
                 "dispositionsPresent": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "description": "Whether at least one disposition comment or thread reply by a recognized disposition author was found."
                 },
                 "latestDispositionAt": {
                   "type": "string",
+                  "description": "Timestamp of the latest recognized disposition, or \"none\".",
                   "pattern": "^(none|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z)$"
                 },
                 "items": {
                   "type": "array",
+                  "description": "Individual ack-only comments and thread replies posted after the latest disposition.",
                   "items": {
                     "type": "object",
                     "required": [
@@ -200,23 +229,28 @@
                     "properties": {
                       "kind": {
                         "type": "string",
+                        "description": "Whether the ack-only item is a regular comment or a review-thread reply.",
                         "enum": [
                           "comment",
                           "thread-reply"
                         ]
                       },
                       "id": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Identifier of the ack-only comment or thread reply."
                       },
                       "author": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Login of the advisory bot that posted the ack-only item."
                       },
                       "activityAt": {
                         "type": "string",
+                        "description": "Timestamp of the ack-only item's activity, or \"none\".",
                         "pattern": "^(none|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z)$"
                       },
                       "bodyPreview": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Truncated preview of the ack-only item's body."
                       }
                     }
                   }
@@ -225,6 +259,7 @@
             },
             "effective": {
               "type": "object",
+              "description": "Live activity recomputed with ack-only items excluded, used to decide whether activity newer than the watermark is substantive.",
               "required": [
                 "maxActivityUpdatedAt",
                 "totalItemCount"
@@ -233,10 +268,12 @@
               "properties": {
                 "maxActivityUpdatedAt": {
                   "type": "string",
+                  "description": "Latest activity timestamp after excluding ack-only items, or \"none\".",
                   "pattern": "^(none|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z)$"
                 },
                 "totalItemCount": {
                   "type": "integer",
+                  "description": "Total item count after excluding ack-only items.",
                   "minimum": 0
                 }
               }
@@ -245,6 +282,7 @@
         },
         "comparisonRoute": {
           "type": "string",
+          "description": "Whether the watermark still covers current activity (\"proceed\") or the gate must return to E1 for a fresh review pass (\"return-to-e1\").",
           "enum": [
             "proceed",
             "return-to-e1"
@@ -252,12 +290,14 @@
         },
         "comparisonReason": {
           "type": "string",
+          "description": "Specific reason the comparison chose comparisonRoute, e.g. missing-watermark, head-changed, newer-activity, ci-pass-drift, ack-only-post-disposition, or snapshot-current.",
           "minLength": 1
         }
       }
     },
     "threads": {
       "type": "object",
+      "description": "Review-thread classification counts and per-thread detail consumed by the unresolved-threads merge gate.",
       "required": [
         "unresolvedCount",
         "actionableCount",
@@ -271,30 +311,37 @@
       "properties": {
         "unresolvedCount": {
           "type": "integer",
+          "description": "Total count of review threads not marked resolved on GitHub, before gate-specific classification.",
           "minimum": 0
         },
         "actionableCount": {
           "type": "integer",
+          "description": "Count of unresolved threads classified as blocking the merge gate (actionable-blocking, amd-blocking, or conversation-resolve-agent/author).",
           "minimum": 0
         },
         "awaitingReviewerCount": {
           "type": "integer",
+          "description": "Count of unresolved threads whose latest comment is from an IDD agent or the PR author and are waiting on a human reviewer; does not block the gate.",
           "minimum": 0
         },
         "amdBlockingCount": {
           "type": "integer",
+          "description": "Count of unresolved threads awaiting a maintainer decision: an IDD-agent reply starting \"Awaiting maintainer decision\" with no later reply.",
           "minimum": 0
         },
         "conversationResolveAgentCount": {
           "type": "integer",
+          "description": "Count of unresolved threads blocking only because the base branch requires conversation resolution and the latest reply is from an IDD agent.",
           "minimum": 0
         },
         "conversationResolveAuthorCount": {
           "type": "integer",
+          "description": "Count of unresolved threads blocking only because the base branch requires conversation resolution and the latest reply is from the PR author.",
           "minimum": 0
         },
         "classifications": {
           "type": "array",
+          "description": "Per-thread gate classification for every unresolved thread.",
           "items": {
             "type": "object",
             "required": [
@@ -305,10 +352,12 @@
             "properties": {
               "id": {
                 "type": "string",
+                "description": "Review thread's GraphQL node id.",
                 "minLength": 1
               },
               "classification": {
                 "type": "string",
+                "description": "Gate classification assigned to this unresolved thread.",
                 "enum": [
                   "actionable-blocking",
                   "amd-blocking",
@@ -324,6 +373,7 @@
     },
     "unrepliedComments": {
       "type": "object",
+      "description": "Regular PR comments from a non-IDD-agent author with no later IDD-agent reply or recognized disposition. Feeds the F2 unreplied-comments check, not the readiness rollup.",
       "required": [
         "count",
         "items"
@@ -332,10 +382,12 @@
       "properties": {
         "count": {
           "type": "integer",
+          "description": "Count of unreplied regular comments.",
           "minimum": 0
         },
         "items": {
           "type": "array",
+          "description": "Individual unreplied regular comments.",
           "items": {
             "type": "object",
             "required": [
@@ -348,19 +400,23 @@
             "properties": {
               "id": {
                 "type": "string",
+                "description": "Comment identifier.",
                 "minLength": 1
               },
               "authorLogin": {
                 "type": "string",
+                "description": "Login of the comment's author.",
                 "minLength": 1
               },
               "createdAt": {
                 "type": "string",
+                "description": "Comment creation timestamp.",
                 "format": "date-time",
                 "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
               },
               "bodyPreview": {
-                "type": "string"
+                "type": "string",
+                "description": "Truncated preview of the comment body."
               }
             }
           }
@@ -369,6 +425,7 @@
     },
     "reviewerStates": {
       "type": "object",
+      "description": "Required-review and CODEOWNER approval state derived from PR reviews, branch protection/ruleset requirements, and CODEOWNERS.",
       "required": [
         "reviewDecision",
         "requiredApprovingReviewCount",
@@ -390,20 +447,25 @@
       "additionalProperties": false,
       "properties": {
         "reviewDecision": {
-          "type": "string"
+          "type": "string",
+          "description": "GitHub's own aggregate review decision for the PR."
         },
         "requiredApprovingReviewCount": {
           "type": "integer",
+          "description": "Configured minimum number of approving reviews required by branch protection/ruleset.",
           "minimum": 0
         },
         "requireCodeOwnerReview": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether branch protection/ruleset requires a CODEOWNER approval."
         },
         "requiresConversationResolution": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether branch protection/ruleset requires all review threads to be resolved before merge."
         },
         "requiredReviewerLogins": {
           "type": "array",
+          "description": "User logins required as reviewers by branch protection/ruleset.",
           "items": {
             "type": "string",
             "minLength": 1
@@ -411,6 +473,7 @@
         },
         "requiredReviewerTeams": {
           "type": "array",
+          "description": "Team slugs required as reviewers by branch protection/ruleset.",
           "items": {
             "type": "string",
             "minLength": 1
@@ -418,6 +481,7 @@
         },
         "codeownerUserLogins": {
           "type": "array",
+          "description": "User logins matched as CODEOWNERS for the PR's changed files.",
           "items": {
             "type": "string",
             "minLength": 1
@@ -425,6 +489,7 @@
         },
         "codeownerTeamSlugs": {
           "type": "array",
+          "description": "Team slugs matched as CODEOWNERS for the PR's changed files.",
           "items": {
             "type": "string",
             "minLength": 1
@@ -432,6 +497,7 @@
         },
         "unmatchedCodeownerFiles": {
           "type": "array",
+          "description": "Changed files that matched no CODEOWNERS rule.",
           "items": {
             "type": "string",
             "minLength": 1
@@ -439,6 +505,7 @@
         },
         "latestByAuthor": {
           "type": "array",
+          "description": "Each reviewer's latest gating review, one entry per author.",
           "items": {
             "type": "object",
             "required": [
@@ -454,44 +521,55 @@
             "properties": {
               "login": {
                 "type": "string",
+                "description": "Reviewer's login.",
                 "minLength": 1
               },
               "state": {
                 "type": "string",
+                "description": "Reviewer's latest review state (e.g. APPROVED, CHANGES_REQUESTED).",
                 "minLength": 1
               },
               "submittedAt": {
                 "type": "string",
+                "description": "Timestamp the reviewer's latest review was submitted.",
                 "format": "date-time",
                 "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
               },
               "isHuman": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Whether the reviewer is not a recognized advisory bot."
               },
               "isAdvisoryBot": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Whether the reviewer is a recognized advisory bot."
               },
               "isCodeowner": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Whether the reviewer is an eligible CODEOWNER for the PR's changed files."
               },
               "isRequiredReviewer": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Whether the reviewer is named as a required reviewer by branch protection/ruleset."
               }
             }
           }
         },
         "humanApprovedCount": {
           "type": "integer",
+          "description": "Count of distinct non-bot reviewers whose latest review state is APPROVED.",
           "minimum": 0
         },
         "requiredApprovalsSatisfied": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether the required-approving-review-count and any per-reviewer requirements are all satisfied."
         },
         "codeownerApprovalSatisfied": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether CODEOWNER approval is satisfied: not required, no explicit CODEOWNERS match, a human codeowner approved, or GitHub's aggregate decision stands in because individual reviews could not be classified."
         },
         "codeownerSelfApproval": {
           "type": "object",
+          "description": "Diagnostic for the case where the PR author is also the sole eligible CODEOWNER for the changed files, which can otherwise deadlock the CODEOWNER-approval gate.",
           "required": [
             "status",
             "reason",
@@ -511,6 +589,7 @@
           "properties": {
             "status": {
               "type": "string",
+              "description": "Overall self-approval deadlock status: not_applicable, clear, possible_deadlock, or deadlock.",
               "enum": [
                 "not_applicable",
                 "clear",
@@ -520,13 +599,16 @@
             },
             "reason": {
               "type": "string",
+              "description": "Specific reason behind status, e.g. why a bypass, deadlock, or ambiguity was found.",
               "minLength": 1
             },
             "prAuthorLogin": {
-              "type": "string"
+              "type": "string",
+              "description": "PR author's login, normalized to lowercase."
             },
             "directCodeownerUserLogins": {
               "type": "array",
+              "description": "All direct-user CODEOWNERS logins matched for the changed files, before eligibility filtering.",
               "items": {
                 "type": "string",
                 "minLength": 1
@@ -534,22 +616,27 @@
             },
             "codeownerTeamSlugs": {
               "type": "array",
+              "description": "Team-based CODEOWNERS slugs matched for the changed files.",
               "items": {
                 "type": "string",
                 "minLength": 1
               }
             },
             "requireCodeOwnerReview": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Whether CODEOWNER review is required by branch protection/ruleset (mirrors reviewerStates.requireCodeOwnerReview)."
             },
             "codeownerApprovalSatisfied": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Whether CODEOWNER approval is currently satisfied (mirrors reviewerStates.codeownerApprovalSatisfied)."
             },
             "bypassDetected": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Whether an applicable pull-request bypass actor (classic protection or ruleset) is configured for the current viewer."
             },
             "bypassMode": {
               "type": "string",
+              "description": "Kind of bypass detected: none, pull_request, always, exempt, or mixed across the relevant rulesets.",
               "enum": [
                 "none",
                 "pull_request",
@@ -560,6 +647,7 @@
             },
             "currentUserCanBypass": {
               "type": "string",
+              "description": "GitHub-reported bypass eligibility for the current viewer across the relevant rulesets.",
               "enum": [
                 "unknown",
                 "never",
@@ -570,7 +658,8 @@
               ]
             },
             "rulesetBypassUnreadable": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "True when a codeowner-requiring ruleset's detail read was masked-404 unreadable, so bypassDetected could not rule out an actual configured bypass. Diagnostic only: never flips status to clear by itself, but downgrades an otherwise-certain deadlock to possible_deadlock."
             },
             "prAuthorIsSoleEligibleCodeowner": {
               "type": "boolean",
@@ -584,10 +673,12 @@
         },
         "humanChangesRequestedCount": {
           "type": "integer",
+          "description": "Count of non-bot reviewers whose latest review state is CHANGES_REQUESTED.",
           "minimum": 0
         },
         "blockingChangesRequestedLogins": {
           "type": "array",
+          "description": "Logins of non-bot reviewers whose latest review state is CHANGES_REQUESTED.",
           "items": {
             "type": "string",
             "minLength": 1
@@ -597,6 +688,7 @@
     },
     "advisoryWait": {
       "type": "object",
+      "description": "Copilot advisory-review wait-state evaluation, deciding whether the E14/F2 gate must keep waiting, request a fresh review, or is satisfied.",
       "required": [
         "outcome",
         "f3Outcome",
@@ -620,6 +712,7 @@
       "properties": {
         "outcome": {
           "type": "string",
+          "description": "E14/F2 advisory-wait outcome: SATISFIED, WAIT, REQUEST_NEEDED, RECOVERY_NEEDED, or CAP_EXHAUSTED.",
           "enum": [
             "SATISFIED",
             "WAIT",
@@ -630,6 +723,7 @@
         },
         "f3Outcome": {
           "type": "string",
+          "description": "F3-specific advisory-wait outcome, which treats a settled (no-longer-pending) Copilot request as SATISFIED even when outcome above is not.",
           "enum": [
             "SATISFIED",
             "WAIT",
@@ -640,47 +734,59 @@
         },
         "lastCopilotCommit": {
           "type": "string",
+          "description": "Commit SHA of the latest Copilot review found, or empty when none exists.",
           "pattern": "^$|^[0-9a-f]{40}$"
         },
         "copilotPending": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether Copilot currently has an outstanding review request on the PR."
         },
         "copilotPendingCoversHead": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether the pending Copilot review request was made for the current PR head commit."
         },
         "sameHeadMarkerPresent": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether a trusted advisory-wait marker recorded for the current head SHA was found."
         },
         "earliestSameHeadAt": {
           "type": "string",
+          "description": "Timestamp of the earliest trusted same-head advisory-wait marker, or empty when none exists.",
           "pattern": "^$|^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
         },
         "sameHeadMarkerCount": {
           "type": "integer",
+          "description": "Count of trusted advisory-wait markers matching the current head SHA.",
           "minimum": 0
         },
         "requestMarkerCount": {
           "type": "integer",
+          "description": "Count of trusted advisory-wait request markers posted for this PR.",
           "minimum": 0
         },
         "requestCap": {
           "type": "integer",
+          "description": "Configured maximum number of advisory-wait review requests before the gate reports CAP_EXHAUSTED.",
           "minimum": 1
         },
         "pendingWindowMinutes": {
           "type": "number",
+          "description": "Configured minutes to wait, once a same-head marker is present, while Copilot's review is still pending before treating the wait as satisfied.",
           "exclusiveMinimum": 0
         },
         "settledWindowMinutes": {
           "type": "number",
+          "description": "Configured minutes to wait, once a same-head marker is present and Copilot is no longer pending, before treating the wait as satisfied.",
           "exclusiveMinimum": 0
         },
         "pollIntervalMinutes": {
           "type": "number",
+          "description": "Configured polling interval, in minutes, for re-checking the advisory-wait state.",
           "exclusiveMinimum": 0
         },
         "capExhaustedRoute": {
           "type": "string",
+          "description": "Configured routing once requestCap is reached: phase-specific handling, or an unconditional hold.",
           "enum": [
             "phase-specific",
             "hold"
@@ -688,6 +794,7 @@
         },
         "elapsedMinutes": {
           "type": "integer",
+          "description": "Minutes elapsed since the earliest same-head advisory-wait marker, compared against pendingWindowMinutes/settledWindowMinutes.",
           "minimum": 0
         },
         "copilotUnavailable": {
@@ -702,6 +809,7 @@
     },
     "ci": {
       "type": "object",
+      "description": "Required-check evaluation derived from live CI check runs plus branch protection/ruleset required-check configuration.",
       "required": [
         "status",
         "noRequiredChecksConfigured",
@@ -722,6 +830,7 @@
       "properties": {
         "status": {
           "type": "string",
+          "description": "Overall classification of the required checks: missing, success, pending, failed, or unknown.",
           "enum": [
             "missing",
             "success",
@@ -731,7 +840,8 @@
           ]
         },
         "noRequiredChecksConfigured": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether no required checks are configured for the base branch. Never true when protection/ruleset reads were unreadable or a required check is source-pinned."
         },
         "protectionReadsUnreadable": {
           "type": "boolean",
@@ -739,6 +849,7 @@
         },
         "presentRunConclusion": {
           "type": "string",
+          "description": "Conclusion across all present check runs, with waiver-covered runs counted as passing; used as the F2 fallback when no required checks are configured.",
           "enum": [
             "all-passing",
             "some-failing",
@@ -748,20 +859,25 @@
         },
         "requiredCheckCount": {
           "type": "integer",
+          "description": "Count of required check names resolved from branch protection/ruleset.",
           "minimum": 0
         },
         "generatedRequiredCheckCount": {
           "type": "integer",
+          "description": "Count of required checks that have at least one matching run reported for the current head.",
           "minimum": 0
         },
         "requiredChecksGenerated": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether every required check name has a matching run reported for the current head (no missing required checks)."
         },
         "requiredChecksPassing": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether at least one required check is configured and the overall status is success."
         },
         "requiredCheckNames": {
           "type": "array",
+          "description": "Names of every required check resolved from branch protection/ruleset.",
           "items": {
             "type": "string",
             "minLength": 1
@@ -769,6 +885,7 @@
         },
         "missingRequiredCheckNames": {
           "type": "array",
+          "description": "Required check names with no matching run reported for the current head.",
           "items": {
             "type": "string",
             "minLength": 1
@@ -791,27 +908,34 @@
             "additionalProperties": false,
             "properties": {
               "name": {
-                "type": "string"
+                "type": "string",
+                "description": "Discarded check's reported name."
               },
               "type": {
-                "type": "string"
+                "type": "string",
+                "description": "Discarded check's producer-identity type (e.g. check-run or status-context)."
               },
               "workflowName": {
-                "type": "string"
+                "type": "string",
+                "description": "Actions workflow name the discarded check ran under, when applicable."
               },
               "selectedState": {
                 "type": "string",
+                "description": "State of the same-name/type/workflow instance the dedup selected as latest instead of this discarded one.",
                 "minLength": 1
               },
               "selectedCompletedAt": {
-                "type": ["string", "null"]
+                "type": ["string", "null"],
+                "description": "Completion timestamp of the selected instance, or null when not yet completed."
               },
               "discardedState": {
                 "type": "string",
+                "description": "Non-passing state of this discarded sibling instance.",
                 "minLength": 1
               },
               "discardedCompletedAt": {
-                "type": ["string", "null"]
+                "type": ["string", "null"],
+                "description": "Completion timestamp of this discarded instance, or null when not yet completed."
               }
             }
           }
@@ -830,6 +954,7 @@
         },
         "checks": {
           "type": "array",
+          "description": "Every check run reported for the current head, normalized with required/waiver status.",
           "items": {
             "type": "object",
             "required": [
@@ -842,21 +967,26 @@
             "properties": {
               "name": {
                 "type": "string",
+                "description": "Check's reported name.",
                 "minLength": 1
               },
               "state": {
                 "type": "string",
+                "description": "Check's normalized state.",
                 "minLength": 1
               },
               "completedAt": {
                 "type": "string",
+                "description": "Check's completion timestamp, or empty when not yet completed.",
                 "pattern": "^$|^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
               },
               "required": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Whether this check name is one of the resolved required checks."
               },
               "coveredByWaiver": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Present and true only when a valid, policy-configured external-check waiver rewrote this non-passing check to pass-equivalent for gate purposes."
               }
             }
           }
@@ -865,6 +995,7 @@
     },
     "claim": {
       "type": "object",
+      "description": "Claim-ownership validation comparing this session's expected claim/agent identifiers to the claim issue's currently active claim.",
       "required": [
         "expectedClaimId",
         "expectedAgentId",
@@ -877,16 +1008,20 @@
       "additionalProperties": false,
       "properties": {
         "expectedClaimId": {
-          "type": "string"
+          "type": "string",
+          "description": "Claim id this session expects to still be active, as recorded at claim time."
         },
         "expectedAgentId": {
-          "type": "string"
+          "type": "string",
+          "description": "Agent id this session expects to still be active, as recorded at claim time."
         },
         "activeClaimPresent": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether any active claim was resolved from the claim issue's comment stream."
         },
         "activeClaim": {
           "type": "object",
+          "description": "Fields of the currently active claim, or empty strings when none is present.",
           "required": [
             "agentId",
             "claimId",
@@ -897,31 +1032,39 @@
           "additionalProperties": false,
           "properties": {
             "agentId": {
-              "type": "string"
+              "type": "string",
+              "description": "Active claim's recorded agent id."
             },
             "claimId": {
-              "type": "string"
+              "type": "string",
+              "description": "Active claim's opaque claim id."
             },
             "supersedes": {
-              "type": "string"
+              "type": "string",
+              "description": "Prior claim id this active claim superseded, or empty for a fresh claim."
             },
             "branch": {
-              "type": "string"
+              "type": "string",
+              "description": "Implementation branch recorded on the active claim."
             },
             "createdAt": {
               "type": "string",
+              "description": "GitHub creation timestamp of the active claim's latest valid claimed-by comment.",
               "pattern": "^$|^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
             }
           }
         },
         "matchesExpectedClaim": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether the active claim's agent id, claim id, and (when supplied) activation nonce all match the expected values."
         },
         "claimLost": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether ownership no longer matches the expected claim; the inverse of matchesExpectedClaim."
         },
         "reason": {
           "type": "string",
+          "description": "Specific reason the claim matched or did not: match, missing-active-claim, claim-id-mismatch, or agent-id-mismatch.",
           "enum": [
             "match",
             "missing-active-claim",
@@ -933,6 +1076,7 @@
     },
     "dispositionEvidence": {
       "type": "object",
+      "description": "E7 disposition-completeness evidence: whether every reviewer comment and unresolved thread has a recorded IDD-agent disposition, gating a return to E1 when evidence is missing.",
       "required": [
         "route",
         "reason",
@@ -948,6 +1092,7 @@
       "properties": {
         "route": {
           "type": "string",
+          "description": "Whether disposition evidence is complete (\"proceed\") or the gate must return to E1 (\"return-to-e1\").",
           "enum": [
             "proceed",
             "return-to-e1"
@@ -955,6 +1100,7 @@
         },
         "reason": {
           "type": "string",
+          "description": "Whether disposition evidence is complete, or evidence is missing.",
           "enum": [
             "complete",
             "missing-disposition-evidence"
@@ -962,24 +1108,30 @@
         },
         "blockingCount": {
           "type": "integer",
+          "description": "Total count of outstanding items (missing regular comments plus missing threads) blocking the disposition-evidence gate.",
           "minimum": 0
         },
         "missingRegularCommentCount": {
           "type": "integer",
+          "description": "Count of regular comments with no recognized IDD-agent disposition.",
           "minimum": 0
         },
         "missingThreadCount": {
           "type": "integer",
+          "description": "Count of unresolved or undispositioned review threads.",
           "minimum": 0
         },
         "soleCauseAckOnlyPostDisposition": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Advisory-only: true when at least one blocking item exists and every blocking item is a resolved thread blocking solely due to post-disposition advisory-bot ack-only activity. Never changes route by itself."
         },
         "soleCauseInPlaceEditOnly": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Advisory-only, a stricter subset of soleCauseAckOnlyPostDisposition: also true only when every qualifying ack-only reply is an in-place edit of pre-existing content rather than a new post-disposition comment. Never changes route by itself."
         },
         "missingRegularComments": {
           "type": "array",
+          "description": "Regular comments still missing a recognized IDD-agent disposition.",
           "items": {
             "type": "object",
             "required": [
@@ -992,28 +1144,34 @@
             "properties": {
               "id": {
                 "type": "string",
+                "description": "Comment identifier.",
                 "minLength": 1
               },
               "authorLogin": {
                 "type": "string",
+                "description": "Login of the comment's author.",
                 "minLength": 1
               },
               "createdAt": {
                 "type": "string",
+                "description": "Comment creation timestamp.",
                 "format": "date-time",
                 "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
               },
               "bodyPreview": {
-                "type": "string"
+                "type": "string",
+                "description": "Truncated preview of the comment body."
               },
               "hint": {
-                "type": "string"
+                "type": "string",
+                "description": "Diagnostic-only note, present only when applicable: this comment is a recognized advisory non-review notice with an IDD-agent reply that used the wrong disposition phrase, naming the exact phrase the notice-specific carry-forward requires."
               }
             }
           }
         },
         "missingThreads": {
           "type": "array",
+          "description": "Unresolved or undispositioned review threads.",
           "items": {
             "type": "object",
             "required": [
@@ -1027,13 +1185,16 @@
             "properties": {
               "id": {
                 "type": "string",
+                "description": "Review thread's GraphQL node id.",
                 "minLength": 1
               },
               "isResolved": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Whether the thread is marked resolved on GitHub."
               },
               "reason": {
                 "type": "string",
+                "description": "Why this thread is still outstanding: incomplete-thread-comments, missing-fresh-disposition, or unresolved-without-fresh-disposition.",
                 "enum": [
                   "incomplete-thread-comments",
                   "missing-fresh-disposition",
@@ -1041,10 +1202,12 @@
                 ]
               },
               "ackOnlyPostDisposition": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Advisory-only: true when this resolved thread blocks solely because of post-disposition advisory-bot ack-only activity newer than the review-currency snapshot boundary."
               },
               "inPlaceEditOnly": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Advisory-only, narrower than ackOnlyPostDisposition: true only when every qualifying reply is an in-place edit of content that already existed at or before the thread's disposition."
               }
             }
           }
@@ -1053,6 +1216,7 @@
     },
     "waiverEvidence": {
       "type": "object",
+      "description": "External-check waiver markers grouped by validity outcome, evaluated against the current PR head, active claim, trusted-actor policy, and the configured waivable-check surface.",
       "required": [
         "valid",
         "expired",
@@ -1066,6 +1230,7 @@
       "properties": {
         "valid": {
           "type": "array",
+          "description": "Waivers that passed every validity check and cover a policy-configured waivable check.",
           "items": {
             "type": "object",
             "required": [
@@ -1077,22 +1242,27 @@
             "additionalProperties": false,
             "properties": {
               "authorLogin": {
-                "type": "string"
+                "type": "string",
+                "description": "Login of the waiver's author, normalized to lowercase."
               },
               "checkSelector": {
-                "type": "string"
+                "type": "string",
+                "description": "Check-name selector the waiver targets."
               },
               "reason": {
-                "type": "string"
+                "type": "string",
+                "description": "Maintainer-authored justification recorded on the waiver."
               },
               "expiresAt": {
-                "type": "string"
+                "type": "string",
+                "description": "Waiver's recorded expiry timestamp."
               }
             }
           }
         },
         "expired": {
           "type": "array",
+          "description": "Waivers whose expiry has passed, or whose validity window exceeded the configured maximum.",
           "items": {
             "type": "object",
             "required": [
@@ -1103,19 +1273,23 @@
             "additionalProperties": false,
             "properties": {
               "authorLogin": {
-                "type": "string"
+                "type": "string",
+                "description": "Login of the waiver's author, normalized to lowercase."
               },
               "checkSelector": {
-                "type": "string"
+                "type": "string",
+                "description": "Check-name selector the waiver targets."
               },
               "expiresAt": {
-                "type": "string"
+                "type": "string",
+                "description": "Waiver's recorded expiry timestamp."
               }
             }
           }
         },
         "wrongHead": {
           "type": "array",
+          "description": "Waivers bound to a PR head commit other than the current head.",
           "items": {
             "type": "object",
             "required": [
@@ -1126,19 +1300,23 @@
             "additionalProperties": false,
             "properties": {
               "authorLogin": {
-                "type": "string"
+                "type": "string",
+                "description": "Login of the waiver's author, normalized to lowercase."
               },
               "checkSelector": {
-                "type": "string"
+                "type": "string",
+                "description": "Check-name selector the waiver targets."
               },
               "waiverHeadSha": {
-                "type": "string"
+                "type": "string",
+                "description": "PR head commit SHA recorded on the waiver, which does not match the current head."
               }
             }
           }
         },
         "wrongClaim": {
           "type": "array",
+          "description": "Waivers bound to a claim id other than the currently active claim.",
           "items": {
             "type": "object",
             "required": [
@@ -1149,19 +1327,23 @@
             "additionalProperties": false,
             "properties": {
               "authorLogin": {
-                "type": "string"
+                "type": "string",
+                "description": "Login of the waiver's author, normalized to lowercase."
               },
               "checkSelector": {
-                "type": "string"
+                "type": "string",
+                "description": "Check-name selector the waiver targets."
               },
               "waiverClaimId": {
-                "type": "string"
+                "type": "string",
+                "description": "Claim id recorded on the waiver, which does not match the active claim."
               }
             }
           }
         },
         "unauthorized": {
           "type": "array",
+          "description": "Waivers posted by an author who is not a trusted marker actor.",
           "items": {
             "type": "object",
             "required": [
@@ -1172,19 +1354,23 @@
             "additionalProperties": false,
             "properties": {
               "authorLogin": {
-                "type": "string"
+                "type": "string",
+                "description": "Login of the waiver's author, normalized to lowercase."
               },
               "checkSelector": {
-                "type": "string"
+                "type": "string",
+                "description": "Check-name selector the waiver targets."
               },
               "expiresAt": {
-                "type": "string"
+                "type": "string",
+                "description": "Waiver's recorded expiry timestamp."
               }
             }
           }
         },
         "malformed": {
           "type": "array",
+          "description": "Comments that matched the external-check-waiver marker prefix but could not be parsed.",
           "items": {
             "type": "object",
             "required": [
@@ -1194,16 +1380,19 @@
             "additionalProperties": false,
             "properties": {
               "authorLogin": {
-                "type": "string"
+                "type": "string",
+                "description": "Login of the comment's author, normalized to lowercase."
               },
               "bodyPreview": {
-                "type": "string"
+                "type": "string",
+                "description": "Truncated preview of the unparseable comment body."
               }
             }
           }
         },
         "notConfigured": {
           "type": "array",
+          "description": "Waivers that passed every validity check but name a check the policy never declared waivable; excluded from valid and never fold a check into requiredChecksPassing.",
           "items": {
             "type": "object",
             "required": [
@@ -1214,13 +1403,16 @@
             "additionalProperties": false,
             "properties": {
               "authorLogin": {
-                "type": "string"
+                "type": "string",
+                "description": "Login of the waiver's author, normalized to lowercase."
               },
               "checkSelector": {
-                "type": "string"
+                "type": "string",
+                "description": "Check-name selector the waiver targets."
               },
               "expiresAt": {
-                "type": "string"
+                "type": "string",
+                "description": "Waiver's recorded expiry timestamp."
               }
             }
           }
@@ -1240,6 +1432,7 @@
       "properties": {
         "mergeStateStatus": {
           "type": "string",
+          "description": "Live GitHub merge-state status for the PR head (e.g. CLEAN, BEHIND, BLOCKED), used to detect a stale head requiring an update before merge.",
           "enum": [
             "",
             "BEHIND",
@@ -1254,6 +1447,7 @@
         },
         "mergeable": {
           "type": "string",
+          "description": "Live GitHub mergeability value for the PR head.",
           "enum": [
             "",
             "CONFLICTING",
@@ -1262,7 +1456,8 @@
           ]
         },
         "requiresUpToDateHead": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether the base branch's ruleset or classic protection requires the PR head to be up to date with the base branch before merge."
         },
         "requiresUpToDateHeadSource": {
           "description": "Provenance of requiresUpToDateHead: a confirmed ruleset or classic-protection read, an unreadable read that fails closed to true, or a genuinely readable 'no rule found'.",
@@ -1278,12 +1473,14 @@
     },
     "trustedMarkerActors": {
       "type": "array",
+      "description": "Configured trusted marker actor logins used to validate operational markers (claim, watermark, waiver, and related markers) for this snapshot.",
       "items": {
         "type": "string"
       }
     },
     "trustedMarkerActorsSource": {
       "type": "string",
+      "description": "Provenance of trustedMarkerActors: an explicit flag, an environment variable, repository config, or none configured.",
       "enum": ["flag", "env", "config", "none"]
     },
     "ready": {
@@ -1299,10 +1496,12 @@
         "additionalProperties": false,
         "properties": {
           "gate": {
-            "type": "string"
+            "type": "string",
+            "description": "Identifier of the unmet pre-merge gate, e.g. ci, required-reviews, claim-ownership, or branch-currency."
           },
           "detail": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable explanation of why this gate is unmet."
           }
         }
       }


### PR DESCRIPTION
# Summary

Adds a non-empty `description` to every named property at every depth
in `schemas/pre-merge-readiness.schema.json`, including object
properties nested inside array item schemas (`reviewCurrency`,
`threads`, `unrepliedComments`, `reviewerStates`, `advisoryWait`, `ci`,
`claim`, `dispositionEvidence`, `waiverEvidence`, and the remaining
`branchCurrency`/`trustedMarkerActors` fields). 199 properties gained a
description; 12 already had one from earlier PRs and were left
unchanged.

Descriptions are grounded in `src/scripts/pre-merge-readiness.mts` and
the section-summarizer functions feeding
`buildPreMergeReadinessSummary` in `src/scripts/protocol-helpers.mts`
(`diffReviewSnapshot`, `summarizeReviewThreadsForGate`,
`summarizeRegularCommentsForGate`, `summarizeReviewerStates`,
`summarizeCodeownerSelfApproval`, `buildAdvisoryWaitSummary`,
`summarizeRequiredChecks`, `summarizeClaimValidation`,
`summarizeDispositionEvidenceForGate`, `summarizeExternalCheckWaivers`,
`summarizeBranchCurrency`, `computePreMergeReadinessBlockers`), plus
`idd-pre-merge.instructions.md` terminology (e.g. AMD = "Awaiting
Maintainer Decision", ack-only post-disposition evidence). This is
annotation-only: no property name, type, enum, pattern, `required`
list, `additionalProperties` rule, or emitted wire value changes.

Part of roadmap #1869 ("broaden per-property descriptions across
published schemas"); a disjoint sibling track to #1865 and #1866,
which describe the marker/compact-result and advisory/discovery-graph
schema families respectively.

## Linked issue

Closes #1867

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

The schema is kept as one file/PR because its nested sections form a
single pre-merge evidence contract emitted by one owning helper
(`pre-merge-readiness.mts`), per the issue's own scoping rationale.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `node --test tests/pre-merge-readiness.test.mts` (240 pass)
- [x] `node --test tests/schema-validation.test.mts
      tests/schema-type-reconciliation.test.mts
      tests/schema-output-roundtrip.test.mts` (264 pass)
- [x] `node scripts/validate-schemas.mjs`
- [x] `node --test tests/helper-runtime-manifest.test.mts` (28 pass,
      another consumer of this schema path)
- [x] fix-validate / pre-push-validate (biome, dprint, markdownlint,
      cspell, audit-docs, audit-code-span-wrap, build:check, idd-doctor)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none -- annotation-only schema change)
- [x] Context budget impact reviewed (schema file only; no instruction
      file touched)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added descriptive guidance throughout the pre-merge readiness schema.
  * Clarified protocol fields, review status, comment handling, reviewer state, CI checks, ownership, waivers, branch currency, trusted actors, and blocker details.
  * Existing validation rules and required fields remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->