### PR TITLE
docs(schema): describe advisory and discovery evidence properties

### DIFF
--- a/schemas/advisory-convergence.schema.json
+++ b/schemas/advisory-convergence.schema.json
@@ -357,7 +357,7 @@
     },
     "waived": {
       "type": "boolean",
-      "description": "True when the scope is not not_applicable (applicable or indeterminate) and at least one valid external-check waiver covers this gate; deliberately still reachable when applicability.status is indeterminate."
+      "description": "True when applicability.status is applicable or indeterminate (never not_applicable) and at least one valid external-check waiver covers this gate; deliberately still reachable when indeterminate."
     },
     "ready": {
       "type": "boolean",

--- a/schemas/advisory-convergence.schema.json
+++ b/schemas/advisory-convergence.schema.json
@@ -234,7 +234,7 @@
       "properties": {
         "eligible": {
           "type": "boolean",
-          "description": "True when the review is not pending, threads are satisfied, no disposition is missing, and the review's item count is known and positive -- the only case a stale item count alone still blocks converged."
+          "description": "True when the scope is applicable, the review is not pending, threads are satisfied, no regular-comment disposition is missing (missingThreadCount is not a term here), and the review's item count is known and positive -- the only case a stale item count alone still blocks converged."
         },
         "ineligibleReasons": {
           "type": "array",
@@ -357,7 +357,7 @@
     },
     "waived": {
       "type": "boolean",
-      "description": "True when the scope applies and at least one valid external-check waiver covers this gate."
+      "description": "True when the scope is not not_applicable (applicable or indeterminate) and at least one valid external-check waiver covers this gate; deliberately still reachable when applicability.status is indeterminate."
     },
     "ready": {
       "type": "boolean",

--- a/schemas/advisory-convergence.schema.json
+++ b/schemas/advisory-convergence.schema.json
@@ -29,63 +29,93 @@
   "properties": {
     "protocolVersion": {
       "type": "string",
+      "description": "Fixed contract-version tag for this verdict shape; not the tool's own version.",
       "enum": ["1"]
     },
     "decisionAuthority": {
       "type": "string",
+      "description": "Fixed marker that this verdict is read-only evidence advisory to the written instructions, not a self-authorizing merge decision.",
       "enum": ["instructions"]
     },
     "prNumber": {
       "type": "integer",
+      "description": "The pull request this verdict was computed for.",
       "minimum": 1
     },
     "prHeadSha": {
       "type": "string",
+      "description": "The PR HEAD commit SHA this verdict is anchored to.",
       "pattern": "^[0-9a-f]{40}$"
     },
     "now": {
       "type": "string",
+      "description": "ISO-8601 capture instant of this run; anchors the deadline, terminal, and sameHeadReroll clock calculations below.",
       "format": "date-time",
       "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
     },
     "primaryBotLogin": {
       "type": "string",
+      "description": "Resolved primary advisory-bot login every review and thread clause below is scoped to.",
       "minLength": 1
     },
     "applicability": {
       "type": "object",
+      "description": "Scope-gate evidence for whether this convergence gate applies to the PR under the configured advisoryWait.convergenceScope.",
       "required": ["scope", "status", "reason"],
       "additionalProperties": false,
       "properties": {
         "scope": {
           "type": "string",
+          "description": "Configured scope mode in effect: all-prs (gate applies everywhere) or idd-claimed (gate narrows to verified IDD-owned PRs).",
           "enum": ["all-prs", "idd-claimed"]
         },
         "status": {
           "type": "string",
+          "description": "applicable, not_applicable, or indeterminate; indeterminate means claim evidence exists but cannot be cleanly resolved to this PR, so ordinary convergence cannot pass -- only the deadline/waiver escape hatch can.",
           "enum": ["applicable", "not_applicable", "indeterminate"]
         },
         "reason": {
           "type": "string",
+          "description": "Machine-readable token naming which scope-resolution branch produced status.",
           "minLength": 1
         }
       }
     },
     "review": {
       "type": "object",
+      "description": "Clause 1 evidence: identity and HEAD-coverage of the primary bot's latest review, by fetch order.",
       "required": ["found", "commitId", "matchesHead", "itemCount", "submittedAt", "satisfied"],
       "additionalProperties": false,
       "properties": {
-        "found": { "type": "boolean" },
-        "commitId": { "type": "string" },
-        "matchesHead": { "type": "boolean" },
-        "itemCount": { "type": ["integer", "null"] },
-        "submittedAt": { "type": "string" },
-        "satisfied": { "type": "boolean" }
+        "found": {
+          "type": "boolean",
+          "description": "True when at least one verified primary-bot review exists at all."
+        },
+        "commitId": {
+          "type": "string",
+          "description": "commit_id of the latest primary-bot review, or empty when none was found."
+        },
+        "matchesHead": {
+          "type": "boolean",
+          "description": "True when commitId equals the PR's current HEAD."
+        },
+        "itemCount": {
+          "type": ["integer", "null"],
+          "description": "Actionable-item count from the latest review, read only when matchesHead is true; a static snapshot taken at submission time that later disposition activity never updates."
+        },
+        "submittedAt": {
+          "type": "string",
+          "description": "submittedAt timestamp of the latest primary-bot review, or empty when none was found."
+        },
+        "satisfied": {
+          "type": "boolean",
+          "description": "True when the latest review covers HEAD and reports zero actionable items -- Clause 1's pass condition."
+        }
       }
     },
     "threads": {
       "type": "object",
+      "description": "Clause 2 evidence: resolution and disposition status of every current primary-bot-authored review thread.",
       "required": [
         "copilotThreadCount",
         "blockingIds",
@@ -94,38 +124,79 @@
       ],
       "additionalProperties": false,
       "properties": {
-        "copilotThreadCount": { "type": "integer", "minimum": 0 },
+        "copilotThreadCount": {
+          "type": "integer",
+          "description": "Count of review threads whose originating comment is authored by the primary bot.",
+          "minimum": 0
+        },
         "blockingIds": {
           "type": "array",
+          "description": "IDs of primary-bot-authored threads that are both unresolved and missing a fresh disposition marker.",
           "items": { "type": "string" }
         },
-        "blockingCount": { "type": "integer", "minimum": 0 },
-        "satisfied": { "type": "boolean" }
+        "blockingCount": {
+          "type": "integer",
+          "description": "blockingIds.length.",
+          "minimum": 0
+        },
+        "satisfied": {
+          "type": "boolean",
+          "description": "True when blockingCount is zero -- Clause 2's pass condition."
+        }
       }
     },
     "pending": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "True while the primary bot has not yet produced a review covering the current HEAD; forced false when applicability.status is not_applicable or indeterminate."
     },
     "deadline": {
       "type": "object",
+      "description": "Deadline-clock evidence anchored on the current HEAD commit's own commit timestamp, gating when the waiver escape hatch opens.",
       "required": ["minutes", "headCommittedAt", "elapsedMinutes", "passed"],
       "additionalProperties": false,
       "properties": {
-        "minutes": { "type": "number", "minimum": 0 },
-        "headCommittedAt": { "type": "string" },
-        "elapsedMinutes": { "type": ["number", "null"] },
-        "passed": { "type": "boolean" }
+        "minutes": {
+          "type": "number",
+          "description": "Configured advisory convergence deadline in minutes (advisoryWait.convergenceDeadline, default 1440 = 24h).",
+          "minimum": 0
+        },
+        "headCommittedAt": {
+          "type": "string",
+          "description": "ISO timestamp of the current HEAD commit itself."
+        },
+        "elapsedMinutes": {
+          "type": ["number", "null"],
+          "description": "Whole minutes elapsed from headCommittedAt to now, or null when headCommittedAt is invalid or absent."
+        },
+        "passed": {
+          "type": "boolean",
+          "description": "True when elapsedMinutes is known and has reached minutes."
+        }
       }
     },
     "waiver": {
       "type": "object",
+      "description": "Escape-hatch evidence for a maintainer-authorized external-check waiver, evaluated only once deadline.passed or terminal.state is COPILOT_UNAVAILABLE.",
       "required": ["mode", "checkSelector", "activeClaimId", "validCount"],
       "additionalProperties": false,
       "properties": {
-        "mode": { "type": "string" },
-        "checkSelector": { "type": "string" },
-        "activeClaimId": { "type": "string" },
-        "validCount": { "type": "integer", "minimum": 0 }
+        "mode": {
+          "type": "string",
+          "description": "Configured external-check waiver mode (ciGate.externalCheckWaivers.mode)."
+        },
+        "checkSelector": {
+          "type": "string",
+          "description": "The external-check selector a waiver marker must name to cover this gate."
+        },
+        "activeClaimId": {
+          "type": "string",
+          "description": "Active claim id resolved for the PR's linked issue, or empty when none is bound."
+        },
+        "validCount": {
+          "type": "integer",
+          "description": "Count of valid external-check-waiver markers matching checkSelector.",
+          "minimum": 0
+        }
       }
     },
     "dispositionEvidence": {
@@ -134,12 +205,21 @@
       "required": ["missingRegularCommentCount", "missingThreadCount"],
       "additionalProperties": false,
       "properties": {
-        "missingRegularCommentCount": { "type": "integer", "minimum": 0 },
-        "missingThreadCount": { "type": "integer", "minimum": 0 }
+        "missingRegularCommentCount": {
+          "type": "integer",
+          "description": "Outstanding non-thread regular PR comments still lacking a fresh disposition marker; the exact counter sameHeadReroll.eligible's missing-regular-comment-disposition term reads.",
+          "minimum": 0
+        },
+        "missingThreadCount": {
+          "type": "integer",
+          "description": "Review threads of any authorship still lacking a fresh disposition marker; adjacent diagnostic evidence, not itself a sameHeadReroll term.",
+          "minimum": 0
+        }
       }
     },
     "sameHeadReroll": {
       "type": "object",
+      "description": "Bounded same-HEAD advisory-reroll evidence (#1511); purely additive and never referenced by converged, waived, or ready.",
       "required": [
         "eligible",
         "ineligibleReasons",
@@ -152,7 +232,10 @@
       ],
       "additionalProperties": false,
       "properties": {
-        "eligible": { "type": "boolean" },
+        "eligible": {
+          "type": "boolean",
+          "description": "True when the review is not pending, threads are satisfied, no disposition is missing, and the review's item count is known and positive -- the only case a stale item count alone still blocks converged."
+        },
         "ineligibleReasons": {
           "type": "array",
           "description": "#1719: one stable, machine-readable token per failing term of the eligible conjunction (in conjunction order); empty exactly when eligible is true.",
@@ -168,12 +251,32 @@
             ]
           }
         },
-        "count": { "type": "integer", "minimum": 0 },
-        "cap": { "type": "integer", "minimum": 1 },
-        "exhausted": { "type": "boolean" },
-        "latestAt": { "type": "string" },
-        "inFlight": { "type": "boolean" },
-        "requestable": { "type": "boolean" }
+        "count": {
+          "type": "integer",
+          "description": "Count of trusted advisory-reroll markers whose embedded HEAD SHA matches the current HEAD.",
+          "minimum": 0
+        },
+        "cap": {
+          "type": "integer",
+          "description": "Configured cap on same-HEAD reroll requests (advisoryWait.sameHeadRerollCap, default 2).",
+          "minimum": 1
+        },
+        "exhausted": {
+          "type": "boolean",
+          "description": "True when count has reached cap."
+        },
+        "latestAt": {
+          "type": "string",
+          "description": "GitHub created_at of the latest trusted reroll marker, or empty when none exists."
+        },
+        "inFlight": {
+          "type": "boolean",
+          "description": "True while a reroll marker exists, no fresh primary-bot review has landed since it, and the pending window has not yet elapsed since it was posted."
+        },
+        "requestable": {
+          "type": "boolean",
+          "description": "True when eligible and neither exhausted nor inFlight -- the moment it is safe to request a fresh same-HEAD reroll."
+        }
       }
     },
     "terminal": {
@@ -194,36 +297,75 @@
       ],
       "additionalProperties": false,
       "properties": {
-        "cap": { "type": "integer", "minimum": 1 },
-        "completedCycleCount": { "type": "integer", "minimum": 0 },
-        "remainingBudget": { "type": "integer", "minimum": 0 },
-        "capExhausted": { "type": "boolean" },
-        "terminalWindowMinutes": { "type": "number", "exclusiveMinimum": 0 },
+        "cap": {
+          "type": "integer",
+          "description": "Configured per-PR-HEAD recovery-cycle cap (advisoryWait.recoveryCycleCap, default 2).",
+          "minimum": 1
+        },
+        "completedCycleCount": {
+          "type": "integer",
+          "description": "Count of trusted, claim-bound, current-HEAD-bound advisory-recovery markers.",
+          "minimum": 0
+        },
+        "remainingBudget": {
+          "type": "integer",
+          "description": "max(cap - completedCycleCount, 0).",
+          "minimum": 0
+        },
+        "capExhausted": {
+          "type": "boolean",
+          "description": "True when completedCycleCount has reached cap."
+        },
+        "terminalWindowMinutes": {
+          "type": "number",
+          "description": "Configured terminal-unavailability window in minutes (advisoryWait.terminalWindow, default 720 = 12h).",
+          "exclusiveMinimum": 0
+        },
         "clockAnchor": {
           "type": "string",
+          "description": "GitHub created_at of the earliest qualifying trusted recovery marker, or empty when none exists.",
           "pattern": "^$|^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
         },
-        "elapsedMinutes": { "type": "number", "minimum": 0 },
-        "windowElapsed": { "type": "boolean" },
-        "activeClaimProvided": { "type": "boolean" },
+        "elapsedMinutes": {
+          "type": "number",
+          "description": "Minutes between clockAnchor and now; zero when there is no anchor.",
+          "minimum": 0
+        },
+        "windowElapsed": {
+          "type": "boolean",
+          "description": "True when clockAnchor is set and elapsedMinutes has reached terminalWindowMinutes."
+        },
+        "activeClaimProvided": {
+          "type": "boolean",
+          "description": "True only when both a claim id and an agent id were resolved to bind the recovery markers to the active claim."
+        },
         "state": {
           "type": "string",
+          "description": "COPILOT_UNAVAILABLE only when the recovery-cycle cap is exhausted, the terminal window has elapsed, and no current-HEAD primary-bot review exists; NOT_TERMINAL otherwise.",
           "enum": ["NOT_TERMINAL", "COPILOT_UNAVAILABLE"]
         },
-        "reason": { "type": "string", "minLength": 1 }
+        "reason": {
+          "type": "string",
+          "description": "Machine-readable reason token for the current terminal state.",
+          "minLength": 1
+        }
       }
     },
     "converged": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "True when the scope applies, the review is not pending, and both review and threads are satisfied -- the primary bot's own pass/fail signal, independent of sameHeadReroll."
     },
     "waived": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "True when the scope applies and at least one valid external-check waiver covers this gate."
     },
     "ready": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "Overall pass gate: true when the scope does not apply, or converged is true, or the deadline has passed (or terminal is COPILOT_UNAVAILABLE) and the gate is waived."
     },
     "reasons": {
       "type": "array",
+      "description": "Human-readable strings explaining every unmet condition, accumulated in evaluation order.",
       "items": { "type": "string" }
     }
   }

--- a/schemas/advisory-wait-state.schema.json
+++ b/schemas/advisory-wait-state.schema.json
@@ -126,7 +126,7 @@
     },
     "sameHeadMarkerCount": {
       "type": "number",
-      "description": "Count of trusted comments whose body matches the current HEAD's advisory-wait marker shape."
+      "description": "Count of trusted comments whose body matches the current HEAD's advisory-wait or advisory-wait-recovery marker shape."
     },
     "requestMarkerCount": {
       "type": "number",

--- a/schemas/advisory-wait-state.schema.json
+++ b/schemas/advisory-wait-state.schema.json
@@ -30,21 +30,26 @@
   "properties": {
     "protocolVersion": {
       "type": "string",
+      "description": "Fixed contract-version tag for this snapshot shape.",
       "pattern": "^1$"
     },
     "prHeadSha": {
       "type": "string",
+      "description": "The PR HEAD commit SHA this snapshot is anchored to.",
       "pattern": "^[0-9a-f]{40}$"
     },
     "lastCopilotCommit": {
       "type": "string",
+      "description": "commit_id of the primary bot's most recently submitted review, by submittedAt order, or empty when no such review exists.",
       "pattern": "^$|^[0-9a-f]{40}$"
     },
     "copilotPending": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "True when the primary bot currently appears in the PR's requested reviewers."
     },
     "copilotPendingCoversHead": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "True when a review-requested event for the primary bot is proven to have occurred after the current HEAD's commit event, i.e. the pending request targets current HEAD."
     },
     "outcome": {
       "type": "string",
@@ -78,46 +83,58 @@
     },
     "now": {
       "type": "string",
+      "description": "ISO-8601 capture instant of this run.",
       "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
     },
     "requestCap": {
       "type": "integer",
+      "description": "Configured maximum trusted request markers before the outcome routes to CAP_EXHAUSTED instead of REQUEST_NEEDED (advisoryWait.requestCap, default 30).",
       "minimum": 1
     },
     "pendingWindowMinutes": {
       "type": "number",
+      "description": "Configured minutes a same-HEAD marker may wait while copilotPending before the outcome self-declares SATISFIED rather than WAIT (advisoryWait.pendingWindow, default 30).",
       "exclusiveMinimum": 0
     },
     "settledWindowMinutes": {
       "type": "number",
+      "description": "Configured minutes a same-HEAD marker must age once Copilot is no longer pending before the outcome declares SATISFIED (advisoryWait.settledWindow, default 10).",
       "exclusiveMinimum": 0
     },
     "pollIntervalMinutes": {
       "type": "number",
+      "description": "Configured recommended re-poll cadence, in minutes, while the outcome stays WAIT (advisoryWait.pollInterval, default 2).",
       "exclusiveMinimum": 0
     },
     "capExhaustedRoute": {
       "type": "string",
+      "description": "Configured routing on CAP_EXHAUSTED: phase-specific (default -- E14 skips to E15, F2/F3 hold) or hold (all three phases hold).",
       "enum": ["phase-specific", "hold"]
     },
     "elapsedMinutes": {
-      "type": "number"
+      "type": "number",
+      "description": "Minutes from the earliest trusted same-HEAD marker to now, or zero when no such marker exists."
     },
     "sameHeadMarkerPresent": {
-      "type": "boolean"
+      "type": "boolean",
+      "description": "True when a trusted same-HEAD advisory-wait or advisory-wait-recovery marker already anchors the current HEAD."
     },
     "earliestSameHeadAt": {
       "type": "string",
+      "description": "GitHub created_at of the earliest trusted same-HEAD marker, or empty when none exists; the clock anchor for elapsedMinutes.",
       "pattern": "^$|^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
     },
     "sameHeadMarkerCount": {
-      "type": "number"
+      "type": "number",
+      "description": "Count of trusted comments whose body matches the current HEAD's advisory-wait marker shape."
     },
     "requestMarkerCount": {
-      "type": "number"
+      "type": "number",
+      "description": "Count of trusted comments requesting the primary bot for any HEAD, compared against requestCap."
     },
     "trustedMarkerSummary": {
       "type": "object",
+      "description": "Trust-provenance breakdown behind the marker counts above.",
       "required": [
         "viewerLogin",
         "configuredTrustedActors",
@@ -130,46 +147,56 @@
       ],
       "properties": {
         "viewerLogin": {
-          "type": "string"
+          "type": "string",
+          "description": "The authenticated actor's own login, lower-cased; auto-trusted so its own markers always count."
         },
         "configuredTrustedActors": {
           "type": "array",
+          "description": "Resolved trusted-actor list from flag, environment, or config precedence.",
           "items": {
             "type": "string"
           }
         },
         "collaboratorTrustEnabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "True when Write/Maintain/Admin collaborators are opted in as trusted marker authors."
         },
         "trustedMarkerLogins": {
           "type": "array",
+          "description": "Final normalized set of logins used to classify markers as trusted: viewer plus configured actors plus, when enabled, collaborator-derived logins.",
           "items": {
             "type": "string"
           }
         },
         "trustedSameHeadMarkerCount": {
-          "type": "number"
+          "type": "number",
+          "description": "Same-HEAD markers authored by a trusted login."
         },
         "untrustedSameHeadMarkerCount": {
-          "type": "number"
+          "type": "number",
+          "description": "Same-HEAD-shaped markers authored by an untrusted login; evidence they exist but do not count toward the gate."
         },
         "trustedRequestMarkerCount": {
-          "type": "number"
+          "type": "number",
+          "description": "Request markers authored by a trusted login, for any HEAD."
         },
         "untrustedRequestMarkerCount": {
-          "type": "number"
+          "type": "number",
+          "description": "Request-shaped markers authored by an untrusted login."
         }
       },
       "additionalProperties": false
     },
     "trustedMarkerActors": {
       "type": "array",
+      "description": "Resolved trusted-actor list re-emitted at the root, independent of the auto-trusted viewer and collaborator additions.",
       "items": {
         "type": "string"
       }
     },
     "trustedMarkerActorsSource": {
       "type": "string",
+      "description": "Provenance of trustedMarkerActors: flag, env, config, or none, in that precedence order.",
       "enum": ["flag", "env", "config", "none"]
     },
     "copilotRecovery": {

--- a/schemas/discover-roadmap-union.schema.json
+++ b/schemas/discover-roadmap-union.schema.json
@@ -55,7 +55,7 @@
     },
     "leaves": {
       "type": "array",
-      "description": "De-duplicated union of open execution leaves across every enumerated root, ranked by autopilot suitability descending and tie-broken by issue number ascending.",
+      "description": "De-duplicated union of open execution leaves across every enumerated root, ordered by compareUnionLeaves: autopilot suitability descending (scored before unscored at the same effective score), then effort ascending (S before M before L), then issue number ascending.",
       "items": {
         "type": "object",
         "required": [
@@ -144,7 +144,7 @@
             "properties": {
               "present": {
                 "type": "boolean",
-                "description": "True when a trusted, non-expired claim marker exists for this leaf."
+                "description": "True when a trusted claim marker exists for this leaf, whether or not it is stale -- see stale below for takeover eligibility."
               },
               "stale": {
                 "type": "boolean",

--- a/schemas/discover-roadmap-union.schema.json
+++ b/schemas/discover-roadmap-union.schema.json
@@ -15,12 +15,14 @@
   "properties": {
     "mode": {
       "type": "string",
+      "description": "Fixed literal distinguishing this cross-roadmap union report from the single-root roadmap graph shape.",
       "enum": [
         "all-roadmaps"
       ]
     },
     "roots": {
       "type": "array",
+      "description": "Every open roadmap root the union enumeration started from: an issue found by the configured roadmap label, an embedded roadmap-id marker, or a configured legacy root.",
       "items": {
         "type": "object",
         "required": [
@@ -33,22 +35,27 @@
         "properties": {
           "number": {
             "type": "integer",
+            "description": "Issue number of this roadmap root.",
             "minimum": 1
           },
           "title": {
-            "type": "string"
+            "type": "string",
+            "description": "Title of this roadmap root."
           },
           "state": {
-            "type": "string"
+            "type": "string",
+            "description": "Open/closed state of this roadmap root."
           },
           "roadmapMarkerId": {
-            "type": "string"
+            "type": "string",
+            "description": "This root's own embedded roadmap-id marker value, or empty when the root was found only by label."
           }
         }
       }
     },
     "leaves": {
       "type": "array",
+      "description": "De-duplicated union of open execution leaves across every enumerated root, ranked by autopilot suitability descending and tie-broken by issue number ascending.",
       "items": {
         "type": "object",
         "required": [
@@ -66,28 +73,34 @@
         "properties": {
           "number": {
             "type": "integer",
+            "description": "Issue number of this execution leaf.",
             "minimum": 1
           },
           "title": {
-            "type": "string"
+            "type": "string",
+            "description": "Title of this execution leaf."
           },
           "state": {
-            "type": "string"
+            "type": "string",
+            "description": "Open/closed state of this execution leaf."
           },
           "labels": {
             "type": "array",
+            "description": "Labels currently applied to this execution leaf.",
             "items": {
               "type": "string"
             }
           },
           "classification": {
             "type": "string",
+            "description": "Always execution; only nodes in a root's execution-candidate set become union leaves.",
             "enum": [
               "execution"
             ]
           },
           "roadmapMarkerId": {
-            "type": "string"
+            "type": "string",
+            "description": "This leaf's own embedded roadmap-id marker, normally empty since that marker denotes a roadmap node rather than an execution leaf."
           },
           "autopilotSuitability": {
             "description": "Authored autopilot-suitability score (1-5) or null when unscored. The `enum` enumerates every coherent value, so the full null | 1..5 contract (including the upper bound and rejection of non-numeric values) is enforced here, matching parseAutopilotSuitability at runtime.",
@@ -111,6 +124,7 @@
           },
           "sourceRoots": {
             "type": "array",
+            "description": "Every open roadmap root number this leaf is reachable from, sorted ascending; a leaf shared by sibling roots carries every source root here but is listed once in leaves.",
             "items": {
               "type": "integer",
               "minimum": 1
@@ -129,10 +143,12 @@
             "additionalProperties": false,
             "properties": {
               "present": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "True when a trusted, non-expired claim marker exists for this leaf."
               },
               "stale": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "True when the present claim's evidence is older than the configured claim stale-age threshold."
               },
               "claimId": {
                 "description": "Active claim id (string) when present:true, or null when present:false. The in-repo validator cannot express the `string | null` union, so no `type` is declared here; the runtime contract is string | null."
@@ -159,6 +175,7 @@
     },
     "diagnostics": {
       "type": "object",
+      "description": "De-duplicated problem-reference buckets accumulated across every per-root enumeration; a reference shared by sibling roots is reported once.",
       "required": [
         "duplicateReferences",
         "cycles",
@@ -169,6 +186,7 @@
       "properties": {
         "duplicateReferences": {
           "type": "array",
+          "description": "Same-shaped reference edges seen more than once from the same source issue.",
           "items": {
             "type": "object",
             "required": [
@@ -182,20 +200,25 @@
             "properties": {
               "source": {
                 "type": "integer",
+                "description": "Issue number of the referencing issue.",
                 "minimum": 1
               },
               "target": {
                 "type": "integer",
+                "description": "Issue number of the referenced issue.",
                 "minimum": 1
               },
               "relationship": {
-                "type": "string"
+                "type": "string",
+                "description": "Reference kind, e.g. task-list, sub-issue, dependency, or reference."
               },
               "evidence": {
-                "type": "string"
+                "type": "string",
+                "description": "Raw source-body line the reference was extracted from."
               },
               "firstSeenFrom": {
                 "type": "integer",
+                "description": "Source issue number of the first occurrence of this same reference, for tracing which mention is the duplicate.",
                 "minimum": 1
               }
             }
@@ -203,6 +226,7 @@
         },
         "cycles": {
           "type": "array",
+          "description": "Traversal back-edges where a reference's target is already an ancestor in the current enumeration path.",
           "items": {
             "type": "object",
             "required": [
@@ -215,17 +239,21 @@
             "properties": {
               "source": {
                 "type": "integer",
+                "description": "Issue number of the referencing issue that closed the cycle.",
                 "minimum": 1
               },
               "target": {
                 "type": "integer",
+                "description": "Issue number of the ancestor issue the cycle closes back to.",
                 "minimum": 1
               },
               "relationship": {
-                "type": "string"
+                "type": "string",
+                "description": "Reference kind of the edge that closed the cycle."
               },
               "path": {
                 "type": "array",
+                "description": "Full traversal path from the enumeration root through to the repeated target.",
                 "items": {
                   "type": "integer",
                   "minimum": 1
@@ -236,6 +264,7 @@
         },
         "inaccessibleReferences": {
           "type": "array",
+          "description": "References whose target issue lookup failed as forbidden, gone, or otherwise inaccessible.",
           "items": {
             "type": "object",
             "required": [
@@ -249,26 +278,32 @@
             "properties": {
               "source": {
                 "type": "integer",
+                "description": "Issue number of the referencing issue.",
                 "minimum": 1
               },
               "target": {
                 "type": "integer",
+                "description": "Issue number of the inaccessible referenced issue.",
                 "minimum": 1
               },
               "relationship": {
-                "type": "string"
+                "type": "string",
+                "description": "Reference kind of this edge."
               },
               "evidence": {
-                "type": "string"
+                "type": "string",
+                "description": "Raw source-body line the reference was extracted from."
               },
               "reason": {
-                "type": "string"
+                "type": "string",
+                "description": "Machine-readable failure token for why this reference could not be read."
               }
             }
           }
         },
         "unresolvedReferences": {
           "type": "array",
+          "description": "References whose target could not be resolved to an existing issue at all.",
           "items": {
             "type": "object",
             "required": [
@@ -282,20 +317,25 @@
             "properties": {
               "source": {
                 "type": "integer",
+                "description": "Issue number of the referencing issue.",
                 "minimum": 1
               },
               "target": {
                 "type": "integer",
+                "description": "Issue number of the unresolved referenced issue.",
                 "minimum": 1
               },
               "relationship": {
-                "type": "string"
+                "type": "string",
+                "description": "Reference kind of this edge."
               },
               "evidence": {
-                "type": "string"
+                "type": "string",
+                "description": "Raw source-body line the reference was extracted from."
               },
               "reason": {
-                "type": "string"
+                "type": "string",
+                "description": "Machine-readable failure token for why this reference could not be resolved."
               }
             }
           }
@@ -304,6 +344,7 @@
     },
     "summary": {
       "type": "object",
+      "description": "Aggregate counts over the union roots, leaves, and diagnostics above.",
       "required": [
         "rootCount",
         "leafCount",
@@ -318,18 +359,22 @@
       "properties": {
         "rootCount": {
           "type": "integer",
+          "description": "roots.length.",
           "minimum": 0
         },
         "leafCount": {
           "type": "integer",
+          "description": "leaves.length.",
           "minimum": 0
         },
         "scoredLeafCount": {
           "type": "integer",
+          "description": "Count of leaves carrying a coherent autopilot-suitability score.",
           "minimum": 0
         },
         "sharedLeafCount": {
           "type": "integer",
+          "description": "Count of leaves reachable from more than one source root.",
           "minimum": 0
         },
         "startableCount": {
@@ -344,18 +389,22 @@
         },
         "duplicateReferenceCount": {
           "type": "integer",
+          "description": "Count of de-duplicated entries in diagnostics.duplicateReferences.",
           "minimum": 0
         },
         "cycleCount": {
           "type": "integer",
+          "description": "Count of de-duplicated entries in diagnostics.cycles.",
           "minimum": 0
         },
         "inaccessibleReferenceCount": {
           "type": "integer",
+          "description": "Count of de-duplicated entries in diagnostics.inaccessibleReferences.",
           "minimum": 0
         },
         "unresolvedReferenceCount": {
           "type": "integer",
+          "description": "Count of de-duplicated entries in diagnostics.unresolvedReferences.",
           "minimum": 0
         }
       }

--- a/schemas/discover-roadmap-union.schema.json
+++ b/schemas/discover-roadmap-union.schema.json
@@ -48,7 +48,7 @@
           },
           "roadmapMarkerId": {
             "type": "string",
-            "description": "This root's own embedded roadmap-id marker value, or empty when the root was found only by label."
+            "description": "This root's own embedded roadmap-id marker value, or empty when the root issue carries no such marker (e.g. found by label or as a configured legacy root)."
           }
         }
       }


### PR DESCRIPTION
# Summary

Add non-empty `description` fields to every named property (including
nested object properties inside array item schemas) in the advisory
convergence, advisory wait, and discovery roadmap union schemas, so
downstream tools and operators can understand evidence and diagnostic
fields without reading the helper implementation.

## Linked issue

Closes #1866

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Part of roadmap #1869 (three independently reviewable per-schema-family
tracks, followed by a coverage-enforcement guard in #1868). This track
covers the advisory-convergence and discovery-graph evidence contracts;
sibling tracks #1865 and #1867 cover the marker/compact and pre-merge
readiness contracts respectively.

Descriptions are grounded in the owning builder functions:
`computeAdvisoryConvergenceVerdict` (`src/scripts/advisory-convergence.mts`),
`buildAdvisoryWaitSummary` (`src/scripts/protocol-helpers.mts`), and
`enumerateAllRoadmapsGraph` (`src/scripts/discover-roadmap-graph.mts`),
cross-checked against `docs/idd-helper-scripts.md` and
`.github/instructions/idd-advisory-wait.instructions.md`. Annotation-only:
no property name, type, enum, pattern, required list, `additionalProperties`
rule, or emitted wire value changes — verified by diffing each schema with
`description` fields stripped against the pre-change file (structurally
identical in all three cases).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (`node --test tests/advisory-convergence.test.mts tests/advisory-wait.test.mts tests/advisory-wait-recovery.test.mts` and `node --test tests/schema-validation.test.mts tests/schema-type-reconciliation.test.mts tests/schema-output-roundtrip.test.mts`)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (not applicable — no docs/ mirror changed)
- [x] `node scripts/idd-doctor.mjs` (if applicable)
- [x] `node scripts/validate-schemas.mjs`
- [x] `pnpm run build:check`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
