### PR TITLE
fix(rerun-advisory): recover stuck rollups when live review covers HEAD

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -67,6 +67,7 @@ scripts/resolve-review-thread.mjs linguist-generated=true
 scripts/resume-claim-routing.mjs linguist-generated=true
 scripts/resume-route-selection.mjs linguist-generated=true
 scripts/review-activity-snapshot.mjs linguist-generated=true
+scripts/review-clause.mjs linguist-generated=true
 scripts/review-disposition-verify.mjs linguist-generated=true
 scripts/select-desynced-index.mjs linguist-generated=true
 scripts/stalled-session-quiet-check.mjs linguist-generated=true

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -134,7 +134,14 @@ In the idd-skill source repository, the following optional helpers were adopted:
   review does not cover the current HEAD is classified
   `awaiting-fresh-review` rather than `rerun-eligible` (#1775), so the
   diagnosis (and `--apply`) never burn the rerun-once budget on a
-  failure only a fresh review can clear. When the rollup is stuck on a
+  failure only a fresh review can clear. That historical job-log verdict
+  is an immutable snapshot from when the run executed, so it can go
+  stale once a fresh review actually lands afterward — a live check
+  (reusing `advisory-convergence.mjs`'s own latest-review evidence)
+  recovers the instance back to `rerun-eligible` once the current HEAD
+  is genuinely covered; live coverage that is unreadable or not yet
+  established leaves the hold exactly as before (#1806). When the
+  rollup is stuck on a
   bot-gated instance alongside an already-passing non-bot
   pull_request-family instance, it additionally offers a
   `recoveryRefreshPlan` — populated even alongside a non-empty rerun
@@ -1373,6 +1380,19 @@ to post it is the consuming track's job.
   classified `awaiting-fresh-review` rather than `rerun-eligible`
   (#1775), so neither the diagnosis nor `--apply` burns the rerun-once
   budget on a failure only a fresh review can clear
+- That job-log verdict is an immutable snapshot from when the run
+  executed, so it can go stale once a fresh review lands after the run
+  already failed. `rerun-advisory-convergence.mjs` also checks a LIVE
+  signal (reusing `advisory-convergence.mjs`'s own latest-review
+  evidence: whether the latest trusted primary-bot review's commit now
+  matches the PR's current HEAD) and, when that live check confirms
+  coverage, reclassifies the instance back to `rerun-eligible` instead
+  of leaving it stuck forever -- the diagnosis JSON's per-instance
+  `reason` field distinguishes this live-coverage recovery from an
+  ordinary rerun-eligible instance. Live coverage that cannot be
+  established (unreadable, or genuinely not yet covered) leaves the
+  historical hold exactly as before this recovery path existed --
+  fail-closed, never an invented rerun (#1806)
 - Also reports a `recoveryRefreshPlan` when the rollup is stuck on a
   bot-gated instance alongside an already-passing non-bot
   pull_request-family instance — populated even alongside a non-empty

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -134,7 +134,14 @@ In the idd-skill source repository, the following optional helpers were adopted:
   review does not cover the current HEAD is classified
   `awaiting-fresh-review` rather than `rerun-eligible` (#1775), so the
   diagnosis (and `--apply`) never burn the rerun-once budget on a
-  failure only a fresh review can clear. When the rollup is stuck on a
+  failure only a fresh review can clear. That historical job-log verdict
+  is an immutable snapshot from when the run executed, so it can go
+  stale once a fresh review actually lands afterward — a live check
+  (reusing `advisory-convergence.mjs`'s own latest-review evidence)
+  recovers the instance back to `rerun-eligible` once the current HEAD
+  is genuinely covered; live coverage that is unreadable or not yet
+  established leaves the hold exactly as before (#1806). When the
+  rollup is stuck on a
   bot-gated instance alongside an already-passing non-bot
   pull_request-family instance, it additionally offers a
   `recoveryRefreshPlan` — populated even alongside a non-empty rerun
@@ -1373,6 +1380,19 @@ to post it is the consuming track's job.
   classified `awaiting-fresh-review` rather than `rerun-eligible`
   (#1775), so neither the diagnosis nor `--apply` burns the rerun-once
   budget on a failure only a fresh review can clear
+- That job-log verdict is an immutable snapshot from when the run
+  executed, so it can go stale once a fresh review lands after the run
+  already failed. `rerun-advisory-convergence.mjs` also checks a LIVE
+  signal (reusing `advisory-convergence.mjs`'s own latest-review
+  evidence: whether the latest trusted primary-bot review's commit now
+  matches the PR's current HEAD) and, when that live check confirms
+  coverage, reclassifies the instance back to `rerun-eligible` instead
+  of leaving it stuck forever -- the diagnosis JSON's per-instance
+  `reason` field distinguishes this live-coverage recovery from an
+  ordinary rerun-eligible instance. Live coverage that cannot be
+  established (unreadable, or genuinely not yet covered) leaves the
+  historical hold exactly as before this recovery path existed --
+  fail-closed, never an invented rerun (#1806)
 - Also reports a `recoveryRefreshPlan` when the rollup is stuck on a
   bot-gated instance alongside an already-passing non-bot
   pull_request-family instance — populated even alongside a non-empty

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -14,10 +14,17 @@
 // with a hard exit code.
 //
 // Reuse map (no duplicated review-parsing logic):
-//   - `isCopilotReviewerLogin` / `readAdvisoryPrimaryBotLogin` /
-//     `resolveAdvisoryPrimaryBotLogin` -- Copilot identity resolution.
+//   - `readAdvisoryPrimaryBotLogin` / `resolveAdvisoryPrimaryBotLogin` --
+//     Copilot identity resolution.
 //   - `resolveAdvisoryBotLogins`, `resolveTrustedMarkerActors` -- the same
 //     trust/identity resolution every other helper uses.
+//   - `resolveLatestCopilotReviewClause`, `fetchReviewsAndHeadCommit`,
+//     `isVerifiedCopilotAuthor` (which itself reuses
+//     `isCopilotReviewerLogin`'s login-string check) -- the latest-review
+//     Clause 1 evidence, extracted to `review-clause.mts` (#1806) so
+//     `rerun-advisory-convergence.mts` can reuse the exact same evidence
+//     for its own live-coverage recovery signal, without importing this
+//     whole file.
 //   - `summarizeDispositionEvidenceForGate` -- reused UNFILTERED for
 //     per-thread disposition-marker validity; this file only adds a thin
 //     Copilot-authorship filter on top of its `missingThreads` output.
@@ -75,6 +82,7 @@ import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mjs';
 import {
   GH_TEXT_LOOP_OPTIONS,
   ghApiJson,
+  ghGraphql,
   ghText,
   safeGhText,
 } from './gh-exec.mjs';
@@ -87,7 +95,6 @@ import {
 } from './policy-helpers.mjs';
 import {
   DEFAULT_STALE_AGE_MS,
-  isCopilotReviewerLogin,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
   resolveAdvisoryBotLogins,
@@ -97,6 +104,11 @@ import {
   summarizeDispositionEvidenceForGate,
   summarizeExternalCheckWaivers,
 } from './protocol-helpers.mjs';
+import {
+  fetchReviewsAndHeadCommit,
+  isVerifiedCopilotAuthor,
+  resolveLatestCopilotReviewClause,
+} from './review-clause.mjs';
 /** The external-check-waiver selector this gate recognizes (documented in
  * docs/idd-helper-scripts.md and docs/policy-constants.md; #1341's required
  * check is expected to register under the same name). #1570: re-exported
@@ -661,86 +673,13 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     reasons,
   };
 }
-/**
- * #1686: defense-in-depth on top of `isCopilotReviewerLogin`'s login-string
- * check. GitHub's GraphQL API reports `__typename: "Bot"` consistently for
- * every App/bot account regardless of login spelling, and a real human
- * account can never report it -- so a *registrable* login lookalike (e.g. a
- * human account named `copilot-pull-request-reviewer`, distinct from the
- * real bot's own `[bot]`-suffixed login) still fails this check even though
- * it passes the login-string comparison. This file's own GraphQL queries
- * (`fetchReviewsAndHeadCommit` / `fetchReviewThreads` /
- * `fetchThreadCommentPages`) request `__typename` on every `author` field,
- * so every LIVE payload this gate evaluates carries it; a payload that
- * omits it (an older fixture, or a future caller not routed through this
- * file's own queries) is treated as "unknown" and does NOT fail the check
- * -- this stays a narrowing on top of the login match, never a new
- * blocking requirement for a caller this field predates. Deliberately kept
- * local to this file (mirroring `rerun-advisory-convergence.mts`'s own
- * "closes it locally without widening that shared function's behavior"
- * precedent) rather than folded into `isCopilotReviewerLogin` itself, which
- * many REST-payload callers across the codebase rely on and which has no
- * `__typename` to check.
- */
-function isVerifiedCopilotAuthor(author, primaryBotLogin) {
-  if (!isCopilotReviewerLogin(author?.login ?? '', primaryBotLogin)) {
-    return false;
-  }
-  const typename = author?.__typename;
-  return typename === undefined || typename === null || typename === 'Bot';
-}
-/** Evaluate Clause 1 against the single, absolute-latest Copilot review --
- * per the issue's literal wording ("the latest Copilot review's commit_id
- * equals current HEAD"), not "the latest review among those that happen to
- * target current HEAD". Those two differ when Copilot's most recent
- * activity targets a commit other than the current HEAD (e.g. an unusual
- * force-push/revert ordering, see PR #1343 review): only looking within
- * on-HEAD reviews could report `matchesHead: true` off a stale earlier
- * review while ignoring what Copilot's true latest signal actually says.
- * This simpler form still correctly handles a legitimate re-request
- * without a new push (this repo's own AW3 `REQUEST_NEEDED` flow, where a
- * later review supersedes an earlier dirty one on the *same* commit): the
- * absolute latest naturally IS that later, superseding review when both
- * target the current HEAD. "Latest" is fetch order, not `submittedAt`:
- * GitHub's GraphQL `reviews` connection returns reviews in submission
- * order, the same assumption this file's own `fetchThreadCommentPages` /
- * `fetchReviewThreads` already rely on (they append paginated results
- * without ever re-sorting). This deliberately does NOT sort by
- * `submittedAt` the way `findLastCopilotReviewCommit` does elsewhere in
- * this codebase (protocol-helpers.mts) -- that timestamp-sort approach is
- * exactly the footgun being avoided here: `submittedAt` can be missing or
- * invalid on a real payload (the field is nullable) and would otherwise
- * let an earlier, differently-ordered review win by comparator accident. */
-function resolveLatestCopilotReviewClause(reviews, prHeadSha, primaryBotLogin) {
-  const latest = reviews
-    .filter((review) => isVerifiedCopilotAuthor(review.author, primaryBotLogin))
-    .at(-1);
-  if (!latest) {
-    return {
-      found: false,
-      commitId: '',
-      matchesHead: false,
-      itemCount: null,
-      submittedAt: '',
-      satisfied: false,
-    };
-  }
-  const commitId = String(latest.commitId ?? '').toLowerCase();
-  const matchesHead = commitId === prHeadSha;
-  const itemCount = matchesHead
-    ? Number.isFinite(latest.itemCount)
-      ? Number(latest.itemCount)
-      : null
-    : null;
-  return {
-    found: true,
-    commitId,
-    matchesHead,
-    itemCount,
-    submittedAt: String(latest.submittedAt ?? ''),
-    satisfied: matchesHead && itemCount === 0,
-  };
-}
+// `isVerifiedCopilotAuthor` (#1686 defense-in-depth on top of
+// `isCopilotReviewerLogin`'s login-string check) and
+// `resolveLatestCopilotReviewClause` (Clause 1 evaluation against the
+// single, absolute-latest Copilot review) now live in `review-clause.mts`
+// and are imported above -- both used here unchanged, with
+// `isVerifiedCopilotAuthor` also reused directly by
+// `classifyCopilotAuthoredThreadIds` below.
 /** Thread IDs whose *originating* (first) comment is Copilot-authored.
  * `summarizeReviewThreadsForGate` classifies by latest-commenter identity
  * for a different purpose (backlog gating) and is not bot-scoped, so this
@@ -1436,72 +1375,12 @@ function resolveTrustedCollaboratorMarkerLogins(
     );
   });
 }
-function ghGraphql(query, variables) {
-  const args = ['api', 'graphql', '-f', `query=${query}`];
-  for (const [key, value] of Object.entries(variables)) {
-    if (value === null || value === undefined) continue;
-    if (typeof value === 'number') {
-      args.push('-F', `${key}=${value}`);
-      continue;
-    }
-    args.push('-f', `${key}=${value}`);
-  }
-  return JSON.parse(ghText(args).trim() || '{}');
-}
-function fetchReviewsAndHeadCommit(owner, repo, prNumber) {
-  const nodes = [];
-  let headCommittedAt = '';
-  let cursor = null;
-  // Paginate `reviews` the same way `fetchReviewThreads` paginates
-  // `reviewThreads` below: a PR with more than one page of reviews would
-  // otherwise silently evaluate Clause 1 against only the first 100,
-  // potentially missing a later, dirty, current-HEAD review (see PR #1343
-  // review). `commits(last: 1)` is fetched once, on the first page, since
-  // it never changes across pages.
-  while (true) {
-    const payload = ghGraphql(
-      `
-        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
-          repository(owner: $owner, name: $repo) {
-            pullRequest(number: $number) {
-              reviews(first: 100, after: $cursor) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  commit { oid }
-                  submittedAt
-                  author { login __typename }
-                  comments { totalCount }
-                }
-              }
-              commits(last: 1) {
-                nodes { commit { committedDate } }
-              }
-            }
-          }
-        }`,
-      { owner, repo, number: prNumber, cursor },
-    );
-    const pullRequest = payload?.data?.repository?.pullRequest;
-    nodes.push(...(pullRequest?.reviews?.nodes ?? []));
-    if (!headCommittedAt) {
-      headCommittedAt = String(
-        pullRequest?.commits?.nodes?.[0]?.commit?.committedDate ?? '',
-      );
-    }
-    if (!pullRequest?.reviews?.pageInfo?.hasNextPage) break;
-    if (!pullRequest.reviews.pageInfo.endCursor) {
-      throw new Error('review pagination payload is missing endCursor');
-    }
-    cursor = pullRequest.reviews.pageInfo.endCursor;
-  }
-  const reviews = nodes.map((node) => ({
-    author: node.author ?? null,
-    submittedAt: node.submittedAt ?? null,
-    commitId: node.commit?.oid ?? null,
-    itemCount: node.comments?.totalCount ?? null,
-  }));
-  return { reviews, headCommittedAt };
-}
+// `ghGraphql` now lives in `gh-exec.mts` (imported above) and
+// `fetchReviewsAndHeadCommit` (+ its local `RawReviewNode` shape) now
+// lives in `review-clause.mts` (imported above) -- both used here
+// unchanged. The other two `ghGraphql(...)` call sites in this file
+// (`fetchReviewThreads` and the claim-candidate fetch below) keep calling
+// the same function via the new import.
 function fetchReviewThreads(owner, repo, prNumber) {
   const nodes = [];
   let cursor = null;

--- a/scripts/gh-exec.mjs
+++ b/scripts/gh-exec.mjs
@@ -159,6 +159,27 @@ export function ghApiJson(path, options = {}) {
   // decide whether the output was empty.
   return JSON.parse(raw.trim() || '{}');
 }
+/**
+ * Run a `gh api graphql` query with variables, returning the parsed JSON
+ * response. Extracted from `advisory-convergence.mts` (#1806) so
+ * `review-clause.mts` (and any other future GraphQL caller) can reuse the
+ * same query-execution wrapper instead of a second copy, matching this
+ * file's existing role as the shared `gh`-execution module for `ghText` /
+ * `ghApiJson`. Uses `ghText`'s own default timeout (no explicit override
+ * here, unchanged from this function's pre-extraction behavior).
+ */
+export function ghGraphql(query, variables) {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    if (value === null || value === undefined) continue;
+    if (typeof value === 'number') {
+      args.push('-F', `${key}=${value}`);
+      continue;
+    }
+    args.push('-f', `${key}=${value}`);
+  }
+  return JSON.parse(ghText(args).trim() || '{}');
+}
 const DEFAULT_BOUNDED_RETRY_ATTEMPTS = 3;
 const DEFAULT_BOUNDED_RETRY_BASE_DELAY_MS = 200;
 /**

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -58,6 +58,22 @@
 //     `gh run rerun` invocations changes that outcome -- only a fresh
 //     review does -- so this is never placed in the plan and never
 //     spends the rerun-once budget (#1775, observed on PR #1772).
+//     #1806: this historical verdict is a snapshot of the workflow job
+//     log at the time THAT run executed, and the log is immutable -- so
+//     an instance that failed BEFORE a fresh review landed keeps
+//     reporting uncovered-HEAD forever, even once live coverage is
+//     satisfied (observed on PR #1854: the failed run's own log still
+//     said "does not cover current HEAD" after Copilot had already
+//     reviewed the real current HEAD with no new comments). When a LIVE
+//     check (reusing `advisory-convergence.mts`'s own Clause 1 evidence
+//     via `review-clause.mts`) confirms the current HEAD IS now covered,
+//     this classification recovers to `rerun-eligible` instead of
+//     staying stuck -- see `RerunPlanOptions.headCoverageSatisfied` and
+//     `classifyInstance`'s uncovered-HEAD step. Live coverage that is
+//     unreadable, not yet established, or simply not checked (no
+//     historical uncovered-HEAD reason to recover) leaves this hold
+//     exactly as it was before #1806 -- fail-closed, never an invented
+//     rerun.
 //   - `rerun-eligible`: non-pass, terminal, resolved -- goes into the
 //     ordered rerun plan (bot-triggered or not, unless gated per above).
 //
@@ -88,6 +104,17 @@
 //     bare top-level array, but the commit check-runs endpoint's shape is
 //     `{ total_count, check_runs: [...] }`, so this file's own
 //     `fetchCheckRunsForRef` passes `--jq '.check_runs[]'` instead.
+//   - `resolveLatestCopilotReviewClause`, `fetchReviewsAndHeadCommit`
+//     (review-clause.mts, #1806) -- the SAME latest-review Clause 1
+//     evidence `advisory-convergence.mts`'s own `converged` verdict is
+//     built on, reused here for the live-coverage recovery signal
+//     (`RerunPlanOptions.headCoverageSatisfied`) instead of a second,
+//     independent GraphQL path that could drift out of sync with the
+//     real gate's own notion of "covers current HEAD". Deliberately
+//     imported from the small `review-clause.mts` module rather than
+//     `advisory-convergence.mts` directly, keeping this read-only
+//     helper's dependency surface off that file's full claim/waiver/
+//     disposition machinery (see `review-clause.mts`'s own doc comment).
 //
 // This helper never mutates GitHub state: it only reads check-run/run data
 // and prints a diagnosis plus a plan of commands for a human (or a future
@@ -110,6 +137,19 @@ import {
   parsePaginatedGhNdjson,
   resolveAdvisoryBotLogins,
 } from './protocol-helpers.mjs';
+// #1806: reuses `advisory-convergence.mts`'s own latest-review Clause 1
+// evidence (whether the latest trusted primary-bot review's commit
+// matches the PR's current HEAD) to recover a check-run instance whose
+// OWN historical job-log verdict is stale, instead of a second ad-hoc
+// GraphQL path. Imported from `review-clause.mts` (not
+// `advisory-convergence.mts` directly) -- see that module's own doc
+// comment and this file's module-header "Reuse map" above for why this
+// helper's dependency surface deliberately stays off the full
+// `advisory-convergence.mts` claim/waiver/disposition machinery.
+import {
+  fetchReviewsAndHeadCommit,
+  resolveLatestCopilotReviewClause,
+} from './review-clause.mjs';
 import { loadJson, validateConfigSection } from './validate-schemas.mjs';
 /** The check name this helper diagnoses. Matches
  * `ADVISORY_CONVERGENCE_CHECK_SELECTOR` in advisory-convergence.mts;
@@ -199,7 +239,14 @@ export function computeRerunPlan(input, options) {
       .trim()
       .toLowerCase() || DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
   const advisoryBotLogins = normalizeLoginList(options.advisoryBotLogins ?? []);
-  const classifyOptions = { primaryBotLogin, advisoryBotLogins };
+  const classifyOptions = {
+    primaryBotLogin,
+    advisoryBotLogins,
+    // #1806: `undefined` normalizes to `null` here so `classifyInstance`'s
+    // uncovered-HEAD step can use a single `=== true` check to fail closed
+    // on every non-`true` value (`false`, `null`, and omitted alike).
+    headCoverageSatisfied: options.headCoverageSatisfied ?? null,
+  };
   const instances = (input.instances ?? []).map((instance) =>
     classifyInstance(instance, classifyOptions),
   );
@@ -571,14 +618,31 @@ function classifyInstance(instance, options) {
   // in the plan and never spend the rerun-once budget on it. Only fires
   // when `verdictReasons` was actually consulted and matched; a missing
   // / unparsed log leaves classification unchanged (no invented hold).
+  //
+  // #1806 live-coverage recovery: the job log above is an IMMUTABLE
+  // snapshot from when THAT run executed, so it can go stale once a
+  // fresh review actually lands after the run failed (observed on PR
+  // #1854). `options.headCoverageSatisfied` is a LIVE, per-PR signal
+  // (see `RerunPlanOptions.headCoverageSatisfied`) that lets this hold
+  // recover instead of staying stuck forever. Only `=== true` recovers;
+  // `false`, `null`, and `undefined` all keep the historical hold exactly
+  // as before #1806 -- fail-closed, so an unreadable or not-yet-covered
+  // live signal never invents a rerun.
   if (hasUncoveredHeadVerdictReason(instance.verdictReasons)) {
     const matched =
       instance.verdictReasons?.find(isUncoveredHeadVerdictReason) ??
       UNCOVERED_HEAD_REASON_MARKER;
+    if (options.headCoverageSatisfied !== true) {
+      return {
+        ...instance,
+        classification: 'awaiting-fresh-review',
+        reason: `advisory-convergence verdict reports "${matched}"; rerunning cannot clear this -- wait for a fresh review covering the current HEAD rather than spending the rerun-once budget (#1775)`,
+      };
+    }
     return {
       ...instance,
-      classification: 'awaiting-fresh-review',
-      reason: `advisory-convergence verdict reports "${matched}"; rerunning cannot clear this -- wait for a fresh review covering the current HEAD rather than spending the rerun-once budget (#1775)`,
+      classification: 'rerun-eligible',
+      reason: `advisory-convergence verdict historically reported "${matched}", but a live check now confirms the current HEAD is covered by a fresh review; the historical hold is stale -- safe to rerun (live-coverage recovery, #1806)`,
     };
   }
   // 8. Non-pass, terminal, resolved, pull_request-family -- safe to rerun.
@@ -1486,6 +1550,41 @@ export function sanitizeRemoteConfig(config) {
   }
   return sanitized;
 }
+/**
+ * Live counterpart to the uncovered-HEAD hold (#1806): re-derives whether
+ * the latest trusted primary-bot review's commit now matches the PR's
+ * current HEAD, reusing `review-clause.mts`'s own review-clause evidence
+ * (`fetchReviewsAndHeadCommit` + `resolveLatestCopilotReviewClause` -- the
+ * SAME evidence `advisory-convergence.mts`'s real `converged` verdict is
+ * built on) instead of a second ad-hoc GraphQL path. Only called from
+ * `collectFromGitHub` when at least one collected instance's own
+ * historical `verdictReasons` already reports an uncovered-HEAD reason --
+ * see that call site -- so a PR with no such instance never pays for this
+ * extra fetch.
+ *
+ * Fails closed to `null` ("evidence unreadable") on ANY error -- never
+ * `false` -- so a transient GraphQL/network failure can never be
+ * indistinguishable from "checked, not covered" if a future caller wants
+ * to tell the two apart; `classifyInstance`'s uncovered-HEAD step treats
+ * both `false` and `null` identically (hold), matching the existing
+ * `verdictReasons`-null pattern elsewhere in this file (a missing/failed
+ * fetch never invents a hold OR a rerun).
+ */
+function resolveLiveHeadCoverage(
+  owner,
+  repo,
+  prNumber,
+  prHeadSha,
+  primaryBotLogin,
+) {
+  try {
+    const { reviews } = fetchReviewsAndHeadCommit(owner, repo, prNumber);
+    return resolveLatestCopilotReviewClause(reviews, prHeadSha, primaryBotLogin)
+      .matchesHead;
+  } catch {
+    return null;
+  }
+}
 function collectFromGitHub(args) {
   // A true cross-repository invocation only when the caller explicitly
   // named both --owner and --repo (parseArgs already rejects naming only
@@ -1675,6 +1774,23 @@ function collectFromGitHub(args) {
   // own (possibly loosened) policy, or (for a cross-repo invocation) the
   // caller's own repo's policy.
   const { rerunPolicy } = normalizeCiWaitPolicy(rawConfig?.ciWait);
+  // #1806: only pay for the live-coverage fetch when at least one
+  // collected instance's own historical verdict already reports an
+  // uncovered-HEAD reason -- the ONLY situation `classifyInstance`'s
+  // uncovered-HEAD step consults `headCoverageSatisfied` at all. A PR
+  // with no such instance never triggers the extra GraphQL round trip.
+  const anyHistoricalUncoveredHead = [...verdictReasonsByRunId.values()].some(
+    (reasons) => hasUncoveredHeadVerdictReason(reasons),
+  );
+  const headCoverageSatisfied = anyHistoricalUncoveredHead
+    ? resolveLiveHeadCoverage(
+        owner,
+        repo,
+        Number(args.prNumber),
+        prHeadSha,
+        primaryBotLogin,
+      )
+    : null;
   return {
     input: {
       prNumber: Number(args.prNumber),
@@ -1689,6 +1805,7 @@ function collectFromGitHub(args) {
       primaryBotLogin,
       advisoryBotLogins,
       rerunPolicy,
+      headCoverageSatisfied,
     },
   };
 }

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -314,6 +314,22 @@ export function computeRerunPlan(input, options) {
   //    own rerun already IS the needed non-bot trigger). Vacuously `true`
   //    when there is nothing in `plan` to begin with, preserving the
   //    original bot-gated-only case unchanged.
+  //
+  // #1806 interaction (intentional): a live-coverage-recovered instance
+  // (classified `rerun-eligible` instead of `awaiting-fresh-review` --
+  // see `classifyInstance`'s uncovered-HEAD step) enters `eligibleInstances`
+  // like any other rerun-eligible instance. If ITS OWN `runAttempt` already
+  // exhausted the rerun-once budget, rule 1 above applies to it exactly the
+  // same way it already applies to any other budget-held eligible instance:
+  // `anyEligibleHeld` becomes `true` and `recoveryRefreshPlan` is withheld
+  // for the WHOLE rollup, even when a separate, still-genuinely-stuck
+  // `bot-gated-skip` sibling exists. This is not a #1806-specific carve-out
+  // -- #1806 only widens which instances CAN reach `eligibleInstances` in
+  // the first place; rule 1's own boundary (a human must look at a
+  // budget-exhausted eligible instance rather than have the tool silently
+  // route around it via a different instance's rerun) applies uniformly
+  // once an instance is there, regardless of how it got classified
+  // `rerun-eligible`. See the "budget-exhausted recovered instance" test.
   const anyEligibleHeld = eligibleInstances.some(
     (instance) =>
       eligibleDecisions.get(instance.checkRunId)?.action !== 'rerun',

--- a/scripts/review-clause.mjs
+++ b/scripts/review-clause.mjs
@@ -1,0 +1,153 @@
+// idd-generated-from: src/scripts/review-clause.mts
+//
+// The scripts/review-clause.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Shared "does the latest trusted primary-bot review cover the PR's
+// current HEAD" evidence (Clause 1 of `advisory-convergence.mts`'s
+// `converged` definition), extracted (#1806) so a second, independent
+// caller (`rerun-advisory-convergence.mts`) can reuse the SAME review
+// fetch and matching logic the real `idd-advisory-convergence` gate
+// already uses, instead of a second ad-hoc GraphQL path that could drift
+// out of sync with it. `advisory-convergence.mts` itself now imports these
+// from here too -- this file has no behavior of its own beyond what both
+// callers already relied on before the extraction.
+//
+// Kept deliberately small (only depends on `gh-exec.mts`'s shared
+// `ghGraphql` and `protocol-helpers.mts`'s shared `isCopilotReviewerLogin`)
+// so a read-only, low-dependency caller like `rerun-advisory-convergence.mts`
+// can import it without also pulling in `advisory-convergence.mts`'s full
+// claim/waiver/disposition machinery -- see that file's own module-header
+// "Reuse map" comment. Both dependencies are already reused directly by
+// `rerun-advisory-convergence.mts` itself today, so this adds no new
+// dependency surface to that caller.
+import { ghGraphql } from './gh-exec.mjs';
+import { isCopilotReviewerLogin } from './protocol-helpers.mjs';
+/**
+ * `true` when `author` is a verified Copilot (or the configured primary
+ * bot login)-authored review/comment -- reuses `isCopilotReviewerLogin`
+ * (protocol-helpers.mts) for the login match itself (the exact,
+ * lookalike-resistant comparison #1686 hardened), plus (when the payload
+ * carries it) a `__typename === 'Bot'` check so a same-named `User`
+ * account cannot masquerade as the trusted bot even if it somehow matched
+ * the login. A payload that omits `__typename` is treated as "unknown",
+ * never as a rejection, since not every GraphQL query in this codebase
+ * selects that field.
+ */
+export function isVerifiedCopilotAuthor(author, primaryBotLogin) {
+  if (!isCopilotReviewerLogin(author?.login ?? '', primaryBotLogin)) {
+    return false;
+  }
+  const typename = author?.__typename;
+  return typename === undefined || typename === null || typename === 'Bot';
+}
+/** Evaluate Clause 1 against the single, absolute-latest Copilot review --
+ * per the issue's literal wording ("the latest Copilot review's commit_id
+ * equals current HEAD"), not "the latest review among those that happen to
+ * target current HEAD". Those two differ when Copilot's most recent
+ * activity targets a commit other than the current HEAD (e.g. an unusual
+ * force-push/revert ordering, see PR #1343 review): only looking within
+ * on-HEAD reviews could report `matchesHead: true` off a stale earlier
+ * review while ignoring what Copilot's true latest signal actually says.
+ * This simpler form still correctly handles a legitimate re-request
+ * without a new push (this repo's own AW3 `REQUEST_NEEDED` flow, where a
+ * later review supersedes an earlier dirty one on the *same* commit): the
+ * absolute latest naturally IS that later, superseding review when both
+ * target the current HEAD. "Latest" is fetch order, not `submittedAt`:
+ * GitHub's GraphQL `reviews` connection returns reviews in submission
+ * order -- this deliberately does NOT sort by `submittedAt`, since that
+ * field is nullable and could otherwise let an earlier, differently-
+ * ordered review win by comparator accident. */
+export function resolveLatestCopilotReviewClause(
+  reviews,
+  prHeadSha,
+  primaryBotLogin,
+) {
+  const latest = reviews
+    .filter((review) => isVerifiedCopilotAuthor(review.author, primaryBotLogin))
+    .at(-1);
+  if (!latest) {
+    return {
+      found: false,
+      commitId: '',
+      matchesHead: false,
+      itemCount: null,
+      submittedAt: '',
+      satisfied: false,
+    };
+  }
+  const commitId = String(latest.commitId ?? '').toLowerCase();
+  const matchesHead = commitId === prHeadSha;
+  const itemCount = matchesHead
+    ? Number.isFinite(latest.itemCount)
+      ? Number(latest.itemCount)
+      : null
+    : null;
+  return {
+    found: true,
+    commitId,
+    matchesHead,
+    itemCount,
+    submittedAt: String(latest.submittedAt ?? ''),
+    satisfied: matchesHead && itemCount === 0,
+  };
+}
+/**
+ * Fetch every PR review (paginated) plus the current HEAD commit's
+ * `committedDate`, via the same GraphQL query `advisory-convergence.mts`'s
+ * own Clause 1 evidence collection has always used.
+ */
+export function fetchReviewsAndHeadCommit(owner, repo, prNumber) {
+  const nodes = [];
+  let headCommittedAt = '';
+  let cursor = null;
+  // Paginate `reviews`: a PR with more than one page of reviews would
+  // otherwise silently evaluate Clause 1 against only the first 100,
+  // potentially missing a later, dirty, current-HEAD review (see PR #1343
+  // review). `commits(last: 1)` is fetched once, on the first page, since
+  // it never changes across pages.
+  while (true) {
+    const payload = ghGraphql(
+      `
+        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $number) {
+              reviews(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  commit { oid }
+                  submittedAt
+                  author { login __typename }
+                  comments { totalCount }
+                }
+              }
+              commits(last: 1) {
+                nodes { commit { committedDate } }
+              }
+            }
+          }
+        }`,
+      { owner, repo, number: prNumber, cursor },
+    );
+    const pullRequest = payload?.data?.repository?.pullRequest;
+    nodes.push(...(pullRequest?.reviews?.nodes ?? []));
+    if (!headCommittedAt) {
+      headCommittedAt = String(
+        pullRequest?.commits?.nodes?.[0]?.commit?.committedDate ?? '',
+      );
+    }
+    if (!pullRequest?.reviews?.pageInfo?.hasNextPage) break;
+    if (!pullRequest.reviews.pageInfo.endCursor) {
+      throw new Error('review pagination payload is missing endCursor');
+    }
+    cursor = pullRequest.reviews.pageInfo.endCursor;
+  }
+  const reviews = nodes.map((node) => ({
+    author: node.author ?? null,
+    submittedAt: node.submittedAt ?? null,
+    commitId: node.commit?.oid ?? null,
+    itemCount: node.comments?.totalCount ?? null,
+  }));
+  return { reviews, headCommittedAt };
+}

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -14,10 +14,17 @@
 // with a hard exit code.
 //
 // Reuse map (no duplicated review-parsing logic):
-//   - `isCopilotReviewerLogin` / `readAdvisoryPrimaryBotLogin` /
-//     `resolveAdvisoryPrimaryBotLogin` -- Copilot identity resolution.
+//   - `readAdvisoryPrimaryBotLogin` / `resolveAdvisoryPrimaryBotLogin` --
+//     Copilot identity resolution.
 //   - `resolveAdvisoryBotLogins`, `resolveTrustedMarkerActors` -- the same
 //     trust/identity resolution every other helper uses.
+//   - `resolveLatestCopilotReviewClause`, `fetchReviewsAndHeadCommit`,
+//     `isVerifiedCopilotAuthor` (which itself reuses
+//     `isCopilotReviewerLogin`'s login-string check) -- the latest-review
+//     Clause 1 evidence, extracted to `review-clause.mts` (#1806) so
+//     `rerun-advisory-convergence.mts` can reuse the exact same evidence
+//     for its own live-coverage recovery signal, without importing this
+//     whole file.
 //   - `summarizeDispositionEvidenceForGate` -- reused UNFILTERED for
 //     per-thread disposition-marker validity; this file only adds a thin
 //     Copilot-authorship filter on top of its `missingThreads` output.
@@ -79,6 +86,7 @@ import {
   GH_TEXT_LOOP_OPTIONS,
   type GhTextOptions,
   ghApiJson,
+  ghGraphql,
   ghText,
   safeGhText,
 } from './gh-exec.mts';
@@ -92,7 +100,6 @@ import {
 import type { PrCommitPayload } from './protocol-helpers.mts';
 import {
   DEFAULT_STALE_AGE_MS,
-  isCopilotReviewerLogin,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
   resolveAdvisoryBotLogins,
@@ -102,6 +109,21 @@ import {
   summarizeDispositionEvidenceForGate,
   summarizeExternalCheckWaivers,
 } from './protocol-helpers.mts';
+// #1806: the latest-review Clause 1 evidence (types + pure evaluator + the
+// GraphQL fetch behind it) moved to `review-clause.mts` so
+// `rerun-advisory-convergence.mts` can reuse the SAME evidence this gate
+// uses, without importing this whole file's claim/waiver/disposition
+// machinery. Re-imported here verbatim -- no behavior change to this file.
+import type {
+  AdvisoryConvergenceReviewClause,
+  GhAuthorPayload,
+  ReviewPayload,
+} from './review-clause.mts';
+import {
+  fetchReviewsAndHeadCommit,
+  isVerifiedCopilotAuthor,
+  resolveLatestCopilotReviewClause,
+} from './review-clause.mts';
 
 /** The external-check-waiver selector this gate recognizes (documented in
  * docs/idd-helper-scripts.md and docs/policy-constants.md; #1341's required
@@ -142,17 +164,15 @@ export const SAME_HEAD_REROLL_INELIGIBLE_REASON = {
 export type SameHeadRerollIneligibleReasonToken =
   (typeof SAME_HEAD_REROLL_INELIGIBLE_REASON)[keyof typeof SAME_HEAD_REROLL_INELIGIBLE_REASON];
 
-/** Author reference embedded in GitHub REST/GraphQL payloads.
- * `__typename` (#1686) is GraphQL-only -- this file's own `reviews` /
- * `reviewThreads` / thread-comment-page queries request it explicitly (see
- * `fetchReviewsAndHeadCommit` / `fetchReviewThreads` /
- * `fetchThreadCommentPages`), so every LIVE payload this gate evaluates
- * carries it; a fixture/test payload that omits it is treated as
- * "unknown", never as a rejection -- see {@link isVerifiedCopilotAuthor}. */
-interface GhAuthorPayload {
-  login?: string | null;
-  __typename?: string | null;
-}
+// `GhAuthorPayload` (author reference embedded in GitHub REST/GraphQL
+// payloads) now lives in `review-clause.mts` and is imported above --
+// `__typename` (#1686) is GraphQL-only; this file's own `reviewThreads` /
+// thread-comment-page queries request it explicitly (see
+// `fetchReviewThreads` / `fetchThreadCommentPages`, and
+// `fetchReviewsAndHeadCommit` in `review-clause.mts`), so every LIVE
+// payload this gate evaluates carries it; a fixture/test payload that
+// omits it is treated as "unknown", never as a rejection -- see
+// {@link isVerifiedCopilotAuthor} (also in `review-clause.mts`).
 
 /** Issue/PR comment payload fields consumed by this helper. */
 interface IssueCommentPayload {
@@ -166,13 +186,9 @@ interface IssueCommentPayload {
   updated_at?: string | null;
 }
 
-/** PR review payload, normalized from the GraphQL `reviews` connection. */
-interface ReviewPayload {
-  author?: GhAuthorPayload | null;
-  submittedAt?: string | null;
-  commitId?: string | null;
-  itemCount?: number | null;
-}
+// `ReviewPayload` (PR review payload, normalized from the GraphQL
+// `reviews` connection) now lives in `review-clause.mts` and is imported
+// above.
 
 /** Review-thread reply node (GraphQL `reviewThreads` comment). */
 interface ThreadCommentPayload {
@@ -213,15 +229,11 @@ interface ClosingIssueRefPayload {
   number?: number | null;
 }
 
-/** Latest-review clause evidence (Clause 1 of the `converged` definition). */
-export interface AdvisoryConvergenceReviewClause {
-  found: boolean;
-  commitId: string;
-  matchesHead: boolean;
-  itemCount: number | null;
-  submittedAt: string;
-  satisfied: boolean;
-}
+// `AdvisoryConvergenceReviewClause` (latest-review clause evidence,
+// Clause 1 of the `converged` definition below) now lives in
+// `review-clause.mts`; re-exported here so this file's existing public
+// export surface stays unchanged for any consumer importing it from here.
+export type { AdvisoryConvergenceReviewClause } from './review-clause.mts';
 
 /** Thread clause evidence (Clause 2 of the `converged` definition). A
  * Copilot-authored thread satisfies this clause when it is resolved
@@ -1072,94 +1084,13 @@ export function computeAdvisoryConvergenceVerdict(
   };
 }
 
-/**
- * #1686: defense-in-depth on top of `isCopilotReviewerLogin`'s login-string
- * check. GitHub's GraphQL API reports `__typename: "Bot"` consistently for
- * every App/bot account regardless of login spelling, and a real human
- * account can never report it -- so a *registrable* login lookalike (e.g. a
- * human account named `copilot-pull-request-reviewer`, distinct from the
- * real bot's own `[bot]`-suffixed login) still fails this check even though
- * it passes the login-string comparison. This file's own GraphQL queries
- * (`fetchReviewsAndHeadCommit` / `fetchReviewThreads` /
- * `fetchThreadCommentPages`) request `__typename` on every `author` field,
- * so every LIVE payload this gate evaluates carries it; a payload that
- * omits it (an older fixture, or a future caller not routed through this
- * file's own queries) is treated as "unknown" and does NOT fail the check
- * -- this stays a narrowing on top of the login match, never a new
- * blocking requirement for a caller this field predates. Deliberately kept
- * local to this file (mirroring `rerun-advisory-convergence.mts`'s own
- * "closes it locally without widening that shared function's behavior"
- * precedent) rather than folded into `isCopilotReviewerLogin` itself, which
- * many REST-payload callers across the codebase rely on and which has no
- * `__typename` to check.
- */
-function isVerifiedCopilotAuthor(
-  author: GhAuthorPayload | null | undefined,
-  primaryBotLogin: string,
-): boolean {
-  if (!isCopilotReviewerLogin(author?.login ?? '', primaryBotLogin)) {
-    return false;
-  }
-  const typename = author?.__typename;
-  return typename === undefined || typename === null || typename === 'Bot';
-}
-
-/** Evaluate Clause 1 against the single, absolute-latest Copilot review --
- * per the issue's literal wording ("the latest Copilot review's commit_id
- * equals current HEAD"), not "the latest review among those that happen to
- * target current HEAD". Those two differ when Copilot's most recent
- * activity targets a commit other than the current HEAD (e.g. an unusual
- * force-push/revert ordering, see PR #1343 review): only looking within
- * on-HEAD reviews could report `matchesHead: true` off a stale earlier
- * review while ignoring what Copilot's true latest signal actually says.
- * This simpler form still correctly handles a legitimate re-request
- * without a new push (this repo's own AW3 `REQUEST_NEEDED` flow, where a
- * later review supersedes an earlier dirty one on the *same* commit): the
- * absolute latest naturally IS that later, superseding review when both
- * target the current HEAD. "Latest" is fetch order, not `submittedAt`:
- * GitHub's GraphQL `reviews` connection returns reviews in submission
- * order, the same assumption this file's own `fetchThreadCommentPages` /
- * `fetchReviewThreads` already rely on (they append paginated results
- * without ever re-sorting). This deliberately does NOT sort by
- * `submittedAt` the way `findLastCopilotReviewCommit` does elsewhere in
- * this codebase (protocol-helpers.mts) -- that timestamp-sort approach is
- * exactly the footgun being avoided here: `submittedAt` can be missing or
- * invalid on a real payload (the field is nullable) and would otherwise
- * let an earlier, differently-ordered review win by comparator accident. */
-function resolveLatestCopilotReviewClause(
-  reviews: ReviewPayload[],
-  prHeadSha: string,
-  primaryBotLogin: string,
-): AdvisoryConvergenceReviewClause {
-  const latest = reviews
-    .filter((review) => isVerifiedCopilotAuthor(review.author, primaryBotLogin))
-    .at(-1);
-  if (!latest) {
-    return {
-      found: false,
-      commitId: '',
-      matchesHead: false,
-      itemCount: null,
-      submittedAt: '',
-      satisfied: false,
-    };
-  }
-  const commitId = String(latest.commitId ?? '').toLowerCase();
-  const matchesHead = commitId === prHeadSha;
-  const itemCount = matchesHead
-    ? Number.isFinite(latest.itemCount)
-      ? Number(latest.itemCount)
-      : null
-    : null;
-  return {
-    found: true,
-    commitId,
-    matchesHead,
-    itemCount,
-    submittedAt: String(latest.submittedAt ?? ''),
-    satisfied: matchesHead && itemCount === 0,
-  };
-}
+// `isVerifiedCopilotAuthor` (#1686 defense-in-depth on top of
+// `isCopilotReviewerLogin`'s login-string check) and
+// `resolveLatestCopilotReviewClause` (Clause 1 evaluation against the
+// single, absolute-latest Copilot review) now live in `review-clause.mts`
+// and are imported above -- both used here unchanged, with
+// `isVerifiedCopilotAuthor` also reused directly by
+// `classifyCopilotAuthoredThreadIds` below.
 
 /** Thread IDs whose *originating* (first) comment is Copilot-authored.
  * `summarizeReviewThreadsForGate` classifies by latest-commenter identity
@@ -1952,105 +1883,12 @@ function resolveTrustedCollaboratorMarkerLogins(
   });
 }
 
-function ghGraphql(
-  query: string,
-  variables: Record<string, string | number | null | undefined>,
-): unknown {
-  const args = ['api', 'graphql', '-f', `query=${query}`];
-  for (const [key, value] of Object.entries(variables)) {
-    if (value === null || value === undefined) continue;
-    if (typeof value === 'number') {
-      args.push('-F', `${key}=${value}`);
-      continue;
-    }
-    args.push('-f', `${key}=${value}`);
-  }
-  return JSON.parse(ghText(args).trim() || '{}');
-}
-
-interface RawReviewNode {
-  commit?: { oid?: string | null } | null;
-  submittedAt?: string | null;
-  author?: GhAuthorPayload | null;
-  comments?: { totalCount?: number | null } | null;
-}
-
-function fetchReviewsAndHeadCommit(
-  owner: string,
-  repo: string,
-  prNumber: number,
-): { reviews: ReviewPayload[]; headCommittedAt: string } {
-  const nodes: RawReviewNode[] = [];
-  let headCommittedAt = '';
-  let cursor: string | null | undefined = null;
-
-  // Paginate `reviews` the same way `fetchReviewThreads` paginates
-  // `reviewThreads` below: a PR with more than one page of reviews would
-  // otherwise silently evaluate Clause 1 against only the first 100,
-  // potentially missing a later, dirty, current-HEAD review (see PR #1343
-  // review). `commits(last: 1)` is fetched once, on the first page, since
-  // it never changes across pages.
-  while (true) {
-    const payload = ghGraphql(
-      `
-        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
-          repository(owner: $owner, name: $repo) {
-            pullRequest(number: $number) {
-              reviews(first: 100, after: $cursor) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  commit { oid }
-                  submittedAt
-                  author { login __typename }
-                  comments { totalCount }
-                }
-              }
-              commits(last: 1) {
-                nodes { commit { committedDate } }
-              }
-            }
-          }
-        }`,
-      { owner, repo, number: prNumber, cursor },
-    ) as {
-      data?: {
-        repository?: {
-          pullRequest?: {
-            reviews?: {
-              pageInfo?: PageInfoPayload | null;
-              nodes?: RawReviewNode[] | null;
-            } | null;
-            commits?: {
-              nodes?: { commit?: { committedDate?: string | null } | null }[];
-            } | null;
-          } | null;
-        } | null;
-      } | null;
-    };
-
-    const pullRequest = payload?.data?.repository?.pullRequest;
-    nodes.push(...(pullRequest?.reviews?.nodes ?? []));
-    if (!headCommittedAt) {
-      headCommittedAt = String(
-        pullRequest?.commits?.nodes?.[0]?.commit?.committedDate ?? '',
-      );
-    }
-
-    if (!pullRequest?.reviews?.pageInfo?.hasNextPage) break;
-    if (!pullRequest.reviews.pageInfo.endCursor) {
-      throw new Error('review pagination payload is missing endCursor');
-    }
-    cursor = pullRequest.reviews.pageInfo.endCursor;
-  }
-
-  const reviews = nodes.map((node) => ({
-    author: node.author ?? null,
-    submittedAt: node.submittedAt ?? null,
-    commitId: node.commit?.oid ?? null,
-    itemCount: node.comments?.totalCount ?? null,
-  }));
-  return { reviews, headCommittedAt };
-}
+// `ghGraphql` now lives in `gh-exec.mts` (imported above) and
+// `fetchReviewsAndHeadCommit` (+ its local `RawReviewNode` shape) now
+// lives in `review-clause.mts` (imported above) -- both used here
+// unchanged. The other two `ghGraphql(...)` call sites in this file
+// (`fetchReviewThreads` and the claim-candidate fetch below) keep calling
+// the same function via the new import.
 
 function fetchReviewThreads(
   owner: string,

--- a/src/scripts/gh-exec.mts
+++ b/src/scripts/gh-exec.mts
@@ -258,6 +258,31 @@ export function ghApiJson(
   return JSON.parse(raw.trim() || '{}');
 }
 
+/**
+ * Run a `gh api graphql` query with variables, returning the parsed JSON
+ * response. Extracted from `advisory-convergence.mts` (#1806) so
+ * `review-clause.mts` (and any other future GraphQL caller) can reuse the
+ * same query-execution wrapper instead of a second copy, matching this
+ * file's existing role as the shared `gh`-execution module for `ghText` /
+ * `ghApiJson`. Uses `ghText`'s own default timeout (no explicit override
+ * here, unchanged from this function's pre-extraction behavior).
+ */
+export function ghGraphql(
+  query: string,
+  variables: Record<string, string | number | null | undefined>,
+): unknown {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    if (value === null || value === undefined) continue;
+    if (typeof value === 'number') {
+      args.push('-F', `${key}=${value}`);
+      continue;
+    }
+    args.push('-f', `${key}=${value}`);
+  }
+  return JSON.parse(ghText(args).trim() || '{}');
+}
+
 /** Options accepted by {@link withBoundedRetry}. */
 export interface BoundedRetryOptions {
   /** Total attempts including the first. Default 3. */

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -58,6 +58,22 @@
 //     `gh run rerun` invocations changes that outcome -- only a fresh
 //     review does -- so this is never placed in the plan and never
 //     spends the rerun-once budget (#1775, observed on PR #1772).
+//     #1806: this historical verdict is a snapshot of the workflow job
+//     log at the time THAT run executed, and the log is immutable -- so
+//     an instance that failed BEFORE a fresh review landed keeps
+//     reporting uncovered-HEAD forever, even once live coverage is
+//     satisfied (observed on PR #1854: the failed run's own log still
+//     said "does not cover current HEAD" after Copilot had already
+//     reviewed the real current HEAD with no new comments). When a LIVE
+//     check (reusing `advisory-convergence.mts`'s own Clause 1 evidence
+//     via `review-clause.mts`) confirms the current HEAD IS now covered,
+//     this classification recovers to `rerun-eligible` instead of
+//     staying stuck -- see `RerunPlanOptions.headCoverageSatisfied` and
+//     `classifyInstance`'s uncovered-HEAD step. Live coverage that is
+//     unreadable, not yet established, or simply not checked (no
+//     historical uncovered-HEAD reason to recover) leaves this hold
+//     exactly as it was before #1806 -- fail-closed, never an invented
+//     rerun.
 //   - `rerun-eligible`: non-pass, terminal, resolved -- goes into the
 //     ordered rerun plan (bot-triggered or not, unless gated per above).
 //
@@ -88,6 +104,17 @@
 //     bare top-level array, but the commit check-runs endpoint's shape is
 //     `{ total_count, check_runs: [...] }`, so this file's own
 //     `fetchCheckRunsForRef` passes `--jq '.check_runs[]'` instead.
+//   - `resolveLatestCopilotReviewClause`, `fetchReviewsAndHeadCommit`
+//     (review-clause.mts, #1806) -- the SAME latest-review Clause 1
+//     evidence `advisory-convergence.mts`'s own `converged` verdict is
+//     built on, reused here for the live-coverage recovery signal
+//     (`RerunPlanOptions.headCoverageSatisfied`) instead of a second,
+//     independent GraphQL path that could drift out of sync with the
+//     real gate's own notion of "covers current HEAD". Deliberately
+//     imported from the small `review-clause.mts` module rather than
+//     `advisory-convergence.mts` directly, keeping this read-only
+//     helper's dependency surface off that file's full claim/waiver/
+//     disposition machinery (see `review-clause.mts`'s own doc comment).
 //
 // This helper never mutates GitHub state: it only reads check-run/run data
 // and prints a diagnosis plus a plan of commands for a human (or a future
@@ -113,6 +140,19 @@ import {
   parsePaginatedGhNdjson,
   resolveAdvisoryBotLogins,
 } from './protocol-helpers.mts';
+// #1806: reuses `advisory-convergence.mts`'s own latest-review Clause 1
+// evidence (whether the latest trusted primary-bot review's commit
+// matches the PR's current HEAD) to recover a check-run instance whose
+// OWN historical job-log verdict is stale, instead of a second ad-hoc
+// GraphQL path. Imported from `review-clause.mts` (not
+// `advisory-convergence.mts` directly) -- see that module's own doc
+// comment and this file's module-header "Reuse map" above for why this
+// helper's dependency surface deliberately stays off the full
+// `advisory-convergence.mts` claim/waiver/disposition machinery.
+import {
+  fetchReviewsAndHeadCommit,
+  resolveLatestCopilotReviewClause,
+} from './review-clause.mts';
 import { loadJson, validateConfigSection } from './validate-schemas.mts';
 
 /** The check name this helper diagnoses. Matches
@@ -397,6 +437,22 @@ export interface RerunPlanOptions {
    * `plan` and `recoveryRefreshPlan` -- see
    * {@link RerunAdvisoryConvergencePlan.rerunPolicy}. */
   rerunPolicy?: string;
+  /**
+   * Live signal (#1806): whether the latest trusted primary-bot review's
+   * commit now matches the PR's current HEAD -- independent of any
+   * instance's own historical (job-log) verdict. `true` lets an instance
+   * whose historical `verdictReasons` report an uncovered-HEAD hold
+   * recover to `rerun-eligible` (see `classifyInstance`'s uncovered-HEAD
+   * step); `false`, `null`, or omitted all fail closed to the existing
+   * `awaiting-fresh-review` hold -- this never invents a rerun when live
+   * coverage could not be established or was never checked. Pure/DI: tests
+   * inject this directly with no network; production `collectFromGitHub`
+   * fills it (via `resolveLiveHeadCoverage`) only when at least one
+   * collected instance's own historical verdict already reports an
+   * uncovered-HEAD reason, reusing `review-clause.mts`'s
+   * `fetchReviewsAndHeadCommit` + `resolveLatestCopilotReviewClause`.
+   */
+  headCoverageSatisfied?: boolean | null;
 }
 
 /**
@@ -428,7 +484,14 @@ export function computeRerunPlan(
       .trim()
       .toLowerCase() || DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN;
   const advisoryBotLogins = normalizeLoginList(options.advisoryBotLogins ?? []);
-  const classifyOptions = { primaryBotLogin, advisoryBotLogins };
+  const classifyOptions = {
+    primaryBotLogin,
+    advisoryBotLogins,
+    // #1806: `undefined` normalizes to `null` here so `classifyInstance`'s
+    // uncovered-HEAD step can use a single `=== true` check to fail closed
+    // on every non-`true` value (`false`, `null`, and omitted alike).
+    headCoverageSatisfied: options.headCoverageSatisfied ?? null,
+  };
 
   const instances = (input.instances ?? []).map((instance) =>
     classifyInstance(instance, classifyOptions),
@@ -741,7 +804,12 @@ function normalizeLoginList(logins: unknown[]): string[] {
  */
 function classifyInstance(
   instance: RerunPlanRawInstance,
-  options: { primaryBotLogin: string; advisoryBotLogins: string[] },
+  options: {
+    primaryBotLogin: string;
+    advisoryBotLogins: string[];
+    /** See {@link RerunPlanOptions.headCoverageSatisfied}. */
+    headCoverageSatisfied?: boolean | null;
+  },
 ): RerunPlanClassifiedInstance {
   const status = String(instance.status ?? '')
     .trim()
@@ -840,14 +908,31 @@ function classifyInstance(
   // in the plan and never spend the rerun-once budget on it. Only fires
   // when `verdictReasons` was actually consulted and matched; a missing
   // / unparsed log leaves classification unchanged (no invented hold).
+  //
+  // #1806 live-coverage recovery: the job log above is an IMMUTABLE
+  // snapshot from when THAT run executed, so it can go stale once a
+  // fresh review actually lands after the run failed (observed on PR
+  // #1854). `options.headCoverageSatisfied` is a LIVE, per-PR signal
+  // (see `RerunPlanOptions.headCoverageSatisfied`) that lets this hold
+  // recover instead of staying stuck forever. Only `=== true` recovers;
+  // `false`, `null`, and `undefined` all keep the historical hold exactly
+  // as before #1806 -- fail-closed, so an unreadable or not-yet-covered
+  // live signal never invents a rerun.
   if (hasUncoveredHeadVerdictReason(instance.verdictReasons)) {
     const matched =
       instance.verdictReasons?.find(isUncoveredHeadVerdictReason) ??
       UNCOVERED_HEAD_REASON_MARKER;
+    if (options.headCoverageSatisfied !== true) {
+      return {
+        ...instance,
+        classification: 'awaiting-fresh-review',
+        reason: `advisory-convergence verdict reports "${matched}"; rerunning cannot clear this -- wait for a fresh review covering the current HEAD rather than spending the rerun-once budget (#1775)`,
+      };
+    }
     return {
       ...instance,
-      classification: 'awaiting-fresh-review',
-      reason: `advisory-convergence verdict reports "${matched}"; rerunning cannot clear this -- wait for a fresh review covering the current HEAD rather than spending the rerun-once budget (#1775)`,
+      classification: 'rerun-eligible',
+      reason: `advisory-convergence verdict historically reported "${matched}", but a live check now confirms the current HEAD is covered by a fresh review; the historical hold is stale -- safe to rerun (live-coverage recovery, #1806)`,
     };
   }
 
@@ -1960,6 +2045,42 @@ export function sanitizeRemoteConfig(
   return sanitized as IddConfig;
 }
 
+/**
+ * Live counterpart to the uncovered-HEAD hold (#1806): re-derives whether
+ * the latest trusted primary-bot review's commit now matches the PR's
+ * current HEAD, reusing `review-clause.mts`'s own review-clause evidence
+ * (`fetchReviewsAndHeadCommit` + `resolveLatestCopilotReviewClause` -- the
+ * SAME evidence `advisory-convergence.mts`'s real `converged` verdict is
+ * built on) instead of a second ad-hoc GraphQL path. Only called from
+ * `collectFromGitHub` when at least one collected instance's own
+ * historical `verdictReasons` already reports an uncovered-HEAD reason --
+ * see that call site -- so a PR with no such instance never pays for this
+ * extra fetch.
+ *
+ * Fails closed to `null` ("evidence unreadable") on ANY error -- never
+ * `false` -- so a transient GraphQL/network failure can never be
+ * indistinguishable from "checked, not covered" if a future caller wants
+ * to tell the two apart; `classifyInstance`'s uncovered-HEAD step treats
+ * both `false` and `null` identically (hold), matching the existing
+ * `verdictReasons`-null pattern elsewhere in this file (a missing/failed
+ * fetch never invents a hold OR a rerun).
+ */
+function resolveLiveHeadCoverage(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  prHeadSha: string,
+  primaryBotLogin: string,
+): boolean | null {
+  try {
+    const { reviews } = fetchReviewsAndHeadCommit(owner, repo, prNumber);
+    return resolveLatestCopilotReviewClause(reviews, prHeadSha, primaryBotLogin)
+      .matchesHead;
+  } catch {
+    return null;
+  }
+}
+
 function collectFromGitHub(args: RerunPlanArgs): {
   input: RerunPlanInput;
   options: RerunPlanOptions;
@@ -2172,6 +2293,24 @@ function collectFromGitHub(args: RerunPlanArgs): {
     (rawConfig as { ciWait?: unknown } | null)?.ciWait,
   );
 
+  // #1806: only pay for the live-coverage fetch when at least one
+  // collected instance's own historical verdict already reports an
+  // uncovered-HEAD reason -- the ONLY situation `classifyInstance`'s
+  // uncovered-HEAD step consults `headCoverageSatisfied` at all. A PR
+  // with no such instance never triggers the extra GraphQL round trip.
+  const anyHistoricalUncoveredHead = [...verdictReasonsByRunId.values()].some(
+    (reasons) => hasUncoveredHeadVerdictReason(reasons),
+  );
+  const headCoverageSatisfied = anyHistoricalUncoveredHead
+    ? resolveLiveHeadCoverage(
+        owner,
+        repo,
+        Number(args.prNumber),
+        prHeadSha,
+        primaryBotLogin,
+      )
+    : null;
+
   return {
     input: {
       prNumber: Number(args.prNumber),
@@ -2186,6 +2325,7 @@ function collectFromGitHub(args: RerunPlanArgs): {
       primaryBotLogin,
       advisoryBotLogins,
       rerunPolicy,
+      headCoverageSatisfied,
     },
   };
 }

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -566,6 +566,22 @@ export function computeRerunPlan(
   //    own rerun already IS the needed non-bot trigger). Vacuously `true`
   //    when there is nothing in `plan` to begin with, preserving the
   //    original bot-gated-only case unchanged.
+  //
+  // #1806 interaction (intentional): a live-coverage-recovered instance
+  // (classified `rerun-eligible` instead of `awaiting-fresh-review` --
+  // see `classifyInstance`'s uncovered-HEAD step) enters `eligibleInstances`
+  // like any other rerun-eligible instance. If ITS OWN `runAttempt` already
+  // exhausted the rerun-once budget, rule 1 above applies to it exactly the
+  // same way it already applies to any other budget-held eligible instance:
+  // `anyEligibleHeld` becomes `true` and `recoveryRefreshPlan` is withheld
+  // for the WHOLE rollup, even when a separate, still-genuinely-stuck
+  // `bot-gated-skip` sibling exists. This is not a #1806-specific carve-out
+  // -- #1806 only widens which instances CAN reach `eligibleInstances` in
+  // the first place; rule 1's own boundary (a human must look at a
+  // budget-exhausted eligible instance rather than have the tool silently
+  // route around it via a different instance's rerun) applies uniformly
+  // once an instance is there, regardless of how it got classified
+  // `rerun-eligible`. See the "budget-exhausted recovered instance" test.
   const anyEligibleHeld = eligibleInstances.some(
     (instance) =>
       eligibleDecisions.get(instance.checkRunId)?.action !== 'rerun',

--- a/src/scripts/review-clause.mts
+++ b/src/scripts/review-clause.mts
@@ -1,0 +1,228 @@
+// idd-generated-from: src/scripts/review-clause.mts
+//
+// The scripts/review-clause.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Shared "does the latest trusted primary-bot review cover the PR's
+// current HEAD" evidence (Clause 1 of `advisory-convergence.mts`'s
+// `converged` definition), extracted (#1806) so a second, independent
+// caller (`rerun-advisory-convergence.mts`) can reuse the SAME review
+// fetch and matching logic the real `idd-advisory-convergence` gate
+// already uses, instead of a second ad-hoc GraphQL path that could drift
+// out of sync with it. `advisory-convergence.mts` itself now imports these
+// from here too -- this file has no behavior of its own beyond what both
+// callers already relied on before the extraction.
+//
+// Kept deliberately small (only depends on `gh-exec.mts`'s shared
+// `ghGraphql` and `protocol-helpers.mts`'s shared `isCopilotReviewerLogin`)
+// so a read-only, low-dependency caller like `rerun-advisory-convergence.mts`
+// can import it without also pulling in `advisory-convergence.mts`'s full
+// claim/waiver/disposition machinery -- see that file's own module-header
+// "Reuse map" comment. Both dependencies are already reused directly by
+// `rerun-advisory-convergence.mts` itself today, so this adds no new
+// dependency surface to that caller.
+
+import { ghGraphql } from './gh-exec.mts';
+import { isCopilotReviewerLogin } from './protocol-helpers.mts';
+
+/** Minimal GitHub GraphQL author payload shape consumed here. `__typename`
+ * distinguishes a genuine `Bot` account from a same-named `User` masquerade
+ * when the caller has that discriminator available; a payload that omits
+ * it is treated as "unknown", never as a rejection. */
+export interface GhAuthorPayload {
+  login?: string | null;
+  __typename?: string | null;
+}
+
+/** PR review payload, normalized from the GraphQL `reviews` connection. */
+export interface ReviewPayload {
+  author?: GhAuthorPayload | null;
+  submittedAt?: string | null;
+  commitId?: string | null;
+  itemCount?: number | null;
+}
+
+/** Latest-review clause evidence (Clause 1 of `advisory-convergence.mts`'s
+ * `converged` definition). */
+export interface AdvisoryConvergenceReviewClause {
+  found: boolean;
+  commitId: string;
+  matchesHead: boolean;
+  itemCount: number | null;
+  submittedAt: string;
+  satisfied: boolean;
+}
+
+/** GraphQL pagination cursor block, local to this file's own `reviews`
+ * pagination -- a separate, unexported copy of the same tiny shape other
+ * `advisory-convergence.mts` pagination loops (that stayed in that file)
+ * also use, rather than a cross-module import for a 2-field type. */
+interface PageInfoPayload {
+  hasNextPage?: boolean | null;
+  endCursor?: string | null;
+}
+
+/** Raw GraphQL `reviews` connection node, before normalization into
+ * {@link ReviewPayload}. */
+interface RawReviewNode {
+  commit?: { oid?: string | null } | null;
+  submittedAt?: string | null;
+  author?: GhAuthorPayload | null;
+  comments?: { totalCount?: number | null } | null;
+}
+
+/**
+ * `true` when `author` is a verified Copilot (or the configured primary
+ * bot login)-authored review/comment -- reuses `isCopilotReviewerLogin`
+ * (protocol-helpers.mts) for the login match itself (the exact,
+ * lookalike-resistant comparison #1686 hardened), plus (when the payload
+ * carries it) a `__typename === 'Bot'` check so a same-named `User`
+ * account cannot masquerade as the trusted bot even if it somehow matched
+ * the login. A payload that omits `__typename` is treated as "unknown",
+ * never as a rejection, since not every GraphQL query in this codebase
+ * selects that field.
+ */
+export function isVerifiedCopilotAuthor(
+  author: GhAuthorPayload | null | undefined,
+  primaryBotLogin: string,
+): boolean {
+  if (!isCopilotReviewerLogin(author?.login ?? '', primaryBotLogin)) {
+    return false;
+  }
+  const typename = author?.__typename;
+  return typename === undefined || typename === null || typename === 'Bot';
+}
+
+/** Evaluate Clause 1 against the single, absolute-latest Copilot review --
+ * per the issue's literal wording ("the latest Copilot review's commit_id
+ * equals current HEAD"), not "the latest review among those that happen to
+ * target current HEAD". Those two differ when Copilot's most recent
+ * activity targets a commit other than the current HEAD (e.g. an unusual
+ * force-push/revert ordering, see PR #1343 review): only looking within
+ * on-HEAD reviews could report `matchesHead: true` off a stale earlier
+ * review while ignoring what Copilot's true latest signal actually says.
+ * This simpler form still correctly handles a legitimate re-request
+ * without a new push (this repo's own AW3 `REQUEST_NEEDED` flow, where a
+ * later review supersedes an earlier dirty one on the *same* commit): the
+ * absolute latest naturally IS that later, superseding review when both
+ * target the current HEAD. "Latest" is fetch order, not `submittedAt`:
+ * GitHub's GraphQL `reviews` connection returns reviews in submission
+ * order -- this deliberately does NOT sort by `submittedAt`, since that
+ * field is nullable and could otherwise let an earlier, differently-
+ * ordered review win by comparator accident. */
+export function resolveLatestCopilotReviewClause(
+  reviews: ReviewPayload[],
+  prHeadSha: string,
+  primaryBotLogin: string,
+): AdvisoryConvergenceReviewClause {
+  const latest = reviews
+    .filter((review) => isVerifiedCopilotAuthor(review.author, primaryBotLogin))
+    .at(-1);
+  if (!latest) {
+    return {
+      found: false,
+      commitId: '',
+      matchesHead: false,
+      itemCount: null,
+      submittedAt: '',
+      satisfied: false,
+    };
+  }
+  const commitId = String(latest.commitId ?? '').toLowerCase();
+  const matchesHead = commitId === prHeadSha;
+  const itemCount = matchesHead
+    ? Number.isFinite(latest.itemCount)
+      ? Number(latest.itemCount)
+      : null
+    : null;
+  return {
+    found: true,
+    commitId,
+    matchesHead,
+    itemCount,
+    submittedAt: String(latest.submittedAt ?? ''),
+    satisfied: matchesHead && itemCount === 0,
+  };
+}
+
+/**
+ * Fetch every PR review (paginated) plus the current HEAD commit's
+ * `committedDate`, via the same GraphQL query `advisory-convergence.mts`'s
+ * own Clause 1 evidence collection has always used.
+ */
+export function fetchReviewsAndHeadCommit(
+  owner: string,
+  repo: string,
+  prNumber: number,
+): { reviews: ReviewPayload[]; headCommittedAt: string } {
+  const nodes: RawReviewNode[] = [];
+  let headCommittedAt = '';
+  let cursor: string | null | undefined = null;
+
+  // Paginate `reviews`: a PR with more than one page of reviews would
+  // otherwise silently evaluate Clause 1 against only the first 100,
+  // potentially missing a later, dirty, current-HEAD review (see PR #1343
+  // review). `commits(last: 1)` is fetched once, on the first page, since
+  // it never changes across pages.
+  while (true) {
+    const payload = ghGraphql(
+      `
+        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $number) {
+              reviews(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  commit { oid }
+                  submittedAt
+                  author { login __typename }
+                  comments { totalCount }
+                }
+              }
+              commits(last: 1) {
+                nodes { commit { committedDate } }
+              }
+            }
+          }
+        }`,
+      { owner, repo, number: prNumber, cursor },
+    ) as {
+      data?: {
+        repository?: {
+          pullRequest?: {
+            reviews?: {
+              pageInfo?: PageInfoPayload | null;
+              nodes?: RawReviewNode[] | null;
+            } | null;
+            commits?: {
+              nodes?: { commit?: { committedDate?: string | null } | null }[];
+            } | null;
+          } | null;
+        } | null;
+      } | null;
+    };
+
+    const pullRequest = payload?.data?.repository?.pullRequest;
+    nodes.push(...(pullRequest?.reviews?.nodes ?? []));
+    if (!headCommittedAt) {
+      headCommittedAt = String(
+        pullRequest?.commits?.nodes?.[0]?.commit?.committedDate ?? '',
+      );
+    }
+
+    if (!pullRequest?.reviews?.pageInfo?.hasNextPage) break;
+    if (!pullRequest.reviews.pageInfo.endCursor) {
+      throw new Error('review pagination payload is missing endCursor');
+    }
+    cursor = pullRequest.reviews.pageInfo.endCursor;
+  }
+
+  const reviews = nodes.map((node) => ({
+    author: node.author ?? null,
+    submittedAt: node.submittedAt ?? null,
+    commitId: node.commit?.oid ?? null,
+    itemCount: node.comments?.totalCount ?? null,
+  }));
+  return { reviews, headCommittedAt };
+}

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -929,6 +929,54 @@ test('does not offer a recovery-refresh plan when a genuine rerun-eligible insta
   assert.equal(plan.recoveryRefreshCaveat, '');
 });
 
+// Regression (#1806 E2 critique pass): a live-coverage-recovered instance
+// (classified rerun-eligible instead of awaiting-fresh-review) is a genuine
+// rerun-eligible instance for rule 1's purposes too -- when ITS OWN
+// runAttempt already exhausted the rerun-once budget, it must suppress
+// recoveryRefreshPlan for the whole rollup exactly the same way any other
+// budget-held rerun-eligible instance already does (see the "genuine
+// rerun-eligible instance already exists" test above), even though the
+// instance came from the #1806 recovery path rather than an ordinary
+// terminal failure. This locks in that the widened classification path does
+// not accidentally create a second, looser rule.
+test('#1806: a budget-exhausted live-coverage-recovered instance still suppresses recovery-refresh (rule 1 applies uniformly)', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          checkRunId: 'gated',
+          runId: '7001',
+          conclusion: 'action_required',
+        }),
+        baseInstance({
+          checkRunId: 'passing',
+          runId: '7002',
+          conclusion: 'success',
+          startedAt: '2026-07-16T11:00:00Z',
+        }),
+        baseInstance({
+          checkRunId: 'recovered',
+          runId: '7003',
+          conclusion: 'failure',
+          runAttempt: 2, // already used its one rerun-once budget
+          verdictReasons: [UNCOVERED_HEAD_HISTORICAL_REASON],
+        }),
+      ],
+    }),
+    baseOptions({ headCoverageSatisfied: true }),
+  );
+  // The recovered instance itself is classified rerun-eligible...
+  const recovered = plan.instances.find((i) => i.checkRunId === 'recovered');
+  assert.equal(recovered?.classification, 'rerun-eligible');
+  // ...but its own budget-exhaustion withholds it from `plan`...
+  assert.equal(recovered?.rerunBudgetHeld, true);
+  assert.equal(plan.plan.length, 0);
+  // ...and, per rule 1, that held-but-eligible instance suppresses
+  // recoveryRefreshPlan for the whole rollup, same as the pre-#1806 case.
+  assert.deepEqual(plan.recoveryRefreshPlan, []);
+  assert.notEqual(plan.rerunPolicyHoldNotice, '');
+});
+
 // Regression (#1745 Codex review on this same PR, P2): a bot-triggered
 // rerun-eligible instance (e.g. a CANCELLED sibling, narrowed out of
 // bot-gated-skip by this same PR) does NOT itself supply the "fresh

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -531,6 +531,137 @@ test('#1775: applyRerunPlan never spends budget on an awaiting-fresh-review inst
   assert.equal(result.resolved, true);
 });
 
+// --- Classification: live-coverage recovery (#1806) ----------------------
+
+const UNCOVERED_HEAD_HISTORICAL_REASON =
+  'latest copilot review (commit dd0360511785c070a41da94f51de14aa2f2951f8) does not cover current HEAD a479827a75a92962222ce702a3467d1725135c1e';
+
+test('#1806: headCoverageSatisfied false keeps the historical uncovered-HEAD hold', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          conclusion: 'failure',
+          verdictReasons: [UNCOVERED_HEAD_HISTORICAL_REASON],
+        }),
+      ],
+    }),
+    baseOptions({ headCoverageSatisfied: false }),
+  );
+  assert.equal(plan.instances[0]?.classification, 'awaiting-fresh-review');
+  assert.equal(plan.counts.awaitingFreshReview, 1);
+  assert.equal(plan.counts.rerunEligible, 0);
+  assert.equal(plan.plan.length, 0);
+  assert.match(plan.instances[0]?.reason ?? '', /wait for a fresh review/);
+});
+
+test('#1806: headCoverageSatisfied omitted (undefined) fails closed to the historical hold', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          conclusion: 'failure',
+          verdictReasons: [UNCOVERED_HEAD_HISTORICAL_REASON],
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.instances[0]?.classification, 'awaiting-fresh-review');
+  assert.equal(plan.plan.length, 0);
+});
+
+test('#1806: headCoverageSatisfied explicit null fails closed to the historical hold', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          conclusion: 'failure',
+          verdictReasons: [UNCOVERED_HEAD_HISTORICAL_REASON],
+        }),
+      ],
+    }),
+    baseOptions({ headCoverageSatisfied: null }),
+  );
+  assert.equal(plan.instances[0]?.classification, 'awaiting-fresh-review');
+  assert.equal(plan.plan.length, 0);
+});
+
+test('#1806: headCoverageSatisfied true recovers the instance to rerun-eligible', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          conclusion: 'failure',
+          verdictReasons: [UNCOVERED_HEAD_HISTORICAL_REASON],
+        }),
+      ],
+    }),
+    baseOptions({ headCoverageSatisfied: true }),
+  );
+  assert.equal(plan.instances[0]?.classification, 'rerun-eligible');
+  assert.equal(plan.counts.rerunEligible, 1);
+  assert.equal(plan.counts.awaitingFreshReview, 0);
+  assert.equal(plan.plan.length, 1);
+  // The reason text must distinguish this recovery from an ordinary
+  // rerun-eligible instance (surfaces in the CLI's full JSON output).
+  assert.match(plan.instances[0]?.reason ?? '', /historically reported/);
+  assert.match(plan.instances[0]?.reason ?? '', /live check now confirms/);
+  assert.match(plan.instances[0]?.reason ?? '', /#1806/);
+});
+
+test('#1806: applyRerunPlan spends budget on a live-coverage-recovered instance', () => {
+  const initialPlan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          conclusion: 'failure',
+          verdictReasons: [UNCOVERED_HEAD_HISTORICAL_REASON],
+        }),
+      ],
+    }),
+    baseOptions({ headCoverageSatisfied: true }),
+  );
+  assert.equal(initialPlan.plan.length, 1);
+
+  let rerunCalled = false;
+  const resolvedPlan = computeRerunPlan(
+    baseInput({ instances: [baseInstance({ conclusion: 'success' })] }),
+    baseOptions(),
+  );
+  const result = applyRerunPlan(initialPlan, {
+    rerunAndWait: () => {
+      rerunCalled = true;
+    },
+    recomputePlan: () => resolvedPlan,
+  });
+
+  assert.equal(rerunCalled, true);
+  assert.equal(result.executed.length, 1);
+  assert.equal(result.resolved, true);
+});
+
+test('#1806: existing #1775 behavior is unchanged when headCoverageSatisfied is not involved (non-coverage reason)', () => {
+  // Guards against a regression where the new step-7 branch accidentally
+  // widens beyond the uncovered-HEAD marker itself.
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          conclusion: 'failure',
+          verdictReasons: [
+            '1 copilot-authored review thread(s) are neither resolved nor validly dispositioned',
+          ],
+        }),
+      ],
+    }),
+    baseOptions({ headCoverageSatisfied: true }),
+  );
+  assert.equal(plan.instances[0]?.classification, 'rerun-eligible');
+  assert.equal(plan.plan.length, 1);
+  assert.doesNotMatch(plan.instances[0]?.reason ?? '', /#1806/);
+});
+
 // --- extractAdvisoryVerdictReasonsFromLog / uncovered-HEAD helpers ------
 
 test('#1775: extractAdvisoryVerdictReasonsFromLog parses gh-run-view-shaped logs', () => {


### PR DESCRIPTION
## Summary

`idd-advisory-convergence` check-run instances can stay stuck forever
once their own historical job-log verdict reports "does not cover
current HEAD", even after a fresh Copilot review has since landed and
genuinely covers it -- the job log is an immutable snapshot from when
that run executed. Reproduced live during PR #1854's merge (see the
"Field evidence" comment on #1806): clearing the required-check rollup
needed a manual `gh run rerun` outside the tool.

- Extracted the latest-review Clause 1 evidence (types, the pure
  `resolveLatestCopilotReviewClause` evaluator, the
  `fetchReviewsAndHeadCommit` GraphQL fetch, and
  `isVerifiedCopilotAuthor`) from `advisory-convergence.mts` into a new
  small `src/scripts/review-clause.mts` module, and moved the shared
  `ghGraphql` wrapper into `gh-exec.mts`. Pure refactor, no behavior
  change -- `advisory-convergence.mts` re-imports every moved symbol
  verbatim and keeps re-exporting `AdvisoryConvergenceReviewClause`.
- Added a live counterpart to the #1775 uncovered-HEAD hold in
  `rerun-advisory-convergence.mts`: `collectFromGitHub` now checks, via
  the shared `review-clause.mts` evidence, whether the latest trusted
  primary-bot review's commit now matches the PR's current HEAD. When
  it does, `classifyInstance` recovers the instance from
  `awaiting-fresh-review` to `rerun-eligible` instead of holding it
  forever. When live coverage cannot be established or is not yet
  satisfied, the existing hold is unchanged (fail-closed) -- this never
  invents a rerun. The live fetch only runs when at least one collected
  instance's historical verdict already reports uncovered-HEAD, so an
  unaffected PR never pays for the extra GraphQL round trip.
- Documented the recovery path in `idd-template/docs/idd-helper-scripts.md`
  (synced to `docs/idd-helper-scripts.md`) next to the existing
  `awaiting-fresh-review` / #1775 prose.

Closes #1806

## Test plan

- [x] `pnpm exec tsc -p tsconfig.json --noEmit` -- clean
- [x] `pnpm run build` / `pnpm run build:check` -- generated `.mjs`
      matches source, no drift
- [x] `node --test tests/rerun-advisory-convergence.test.mts
      tests/advisory-convergence.test.mts` -- 244/244 pass, including new
      `#1806` cases (`headCoverageSatisfied: false/undefined/null` stays
      held; `true` recovers to `rerun-eligible` and `applyRerunPlan`
      spends budget on it; existing `#1775` cases pass unchanged)
- [x] `pnpm run test` (full suite) -- 3192/3192 pass
- [x] `node scripts/idd-doctor.mjs` -- passed (only pre-existing,
      unrelated warnings)
- [x] full `pre-push-validate` command set -- clean
