### PR TITLE
fix(onboarding): ship doc-lint config with the imported template

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -23,6 +23,7 @@ no-inline-html:
 # level-1 heading alongside the page's own `# H1`. The default pattern
 # (`^\s*title\s*[:=]`) matches both, firing
 # `MD025/single-title/single-h1 Multiple top-level headings` on every
-# conforming OKF page. See docs/okf-frontmatter.md.
+# conforming OKF page. See
+# docs/customization.md#docs-bundle-frontmatter-convention-okf.
 single-title:
   front_matter_title: ""

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -61,6 +61,9 @@
         "idd-template/.github/idd/*.json",
         "idd-template/.github/workflows/post-merge-cleanup.yml",
         "idd-template/.githooks/*",
+        "idd-template/.cspell.config.yml",
+        "idd-template/.markdownlint.yml",
+        "idd-template/.markdownlint-cli2.yaml",
         "idd-template/.github/instructions/idd-*.instructions.md",
         "idd-template/.github/instructions/lite/idd-*.instructions.md",
         "idd-template/docs/index.md",
@@ -80,6 +83,9 @@
         "idd-template/.githooks/_idd-worktree-guard.sh",
         "idd-template/.githooks/pre-commit",
         "idd-template/.githooks/pre-push",
+        "idd-template/.cspell.config.yml",
+        "idd-template/.markdownlint.yml",
+        "idd-template/.markdownlint-cli2.yaml",
         "idd-template/.github/instructions/idd-overview-core.instructions.md",
         "idd-template/.github/instructions/idd-overview-appendix.instructions.md",
         "idd-template/.github/instructions/idd-discover.instructions.md",
@@ -823,6 +829,20 @@
         "Roadmap-audit claims are coordination-only.",
         "heartbeat, release, or take over rather than holding the claim open."
       ]
+    },
+    {
+      "id": "root-cspell-config",
+      "_comment": "Same direction as every other pair here (idd-template/ is the canonical source; edit it first, then `sync-docs.mjs --apply` regenerates the target) -- idd-skill#1860's twist is only that the generated target is this repo's own root config, which also governs this repo's own CI, not a docs/ mirror. The #1765 uncommitted-local-edit guard protects a maintainer who fixes the root file directly without touching the template first.",
+      "source": "idd-template/.cspell.config.yml",
+      "target": ".cspell.config.yml",
+      "mode": "exact"
+    },
+    {
+      "id": "root-markdownlint-config",
+      "_comment": "Same direction/rationale as root-cspell-config immediately above.",
+      "source": "idd-template/.markdownlint.yml",
+      "target": ".markdownlint.yml",
+      "mode": "exact"
     }
   ],
   "forbiddenPatterns": [

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -547,9 +547,10 @@ and no relevant script exists; else use `true`. For other tools, use
 ### Documentation lint compatibility
 
 The **fix-validate**/**pre-push-validate**/**post-fix-validate** example
-commands above run `markdownlint-cli2` and `cspell` against every
-Markdown file, including the imported `.github/instructions/**` and
-`docs/**` bundle. A target repository with no pre-existing documentation
+commands above run `markdownlint-cli2` (`**/*.md`, Markdown files only)
+and `cspell` (`**`, every file the working tree contains) against the
+imported `.github/instructions/**` and `docs/**` bundle among everything
+else. A target repository with no pre-existing documentation
 lint configuration can otherwise pass onboarding `--verify` and still
 fail those commands on the imported files alone. To close that gap, the
 imported file set (see the Step 2 file list in `idd-template/ONBOARDING.md`)

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -544,6 +544,33 @@ prefer project scripts; use `npx <tool>` only when `npx` is available
 and no relevant script exists; else use `true`. For other tools, use
 `true` when absent.
 
+### Documentation lint compatibility
+
+The **fix-validate**/**pre-push-validate**/**post-fix-validate** example
+commands above run `markdownlint-cli2` and `cspell` against every
+Markdown file, including the imported `.github/instructions/**` and
+`docs/**` bundle. A target repository with no pre-existing documentation
+lint configuration can otherwise pass onboarding `--verify` and still
+fail those commands on the imported files alone. To close that gap, the
+imported file set (see the Step 2 file list in `idd-template/ONBOARDING.md`)
+includes `.markdownlint.yml`, `.markdownlint-cli2.yaml`, and
+`.cspell.config.yml` at the repository root, carrying the rule
+overrides and word list this project's own documentation already needs
+to pass those same commands. Because `markdownlint-cli2`/`cspell`
+auto-discover root config, these files govern the target repository's
+entire Markdown surface once imported, not just the imported IDD
+documentation — expected given the `**`/`**/*.md` scope in the commands
+above, but worth knowing before the repository's own pre-existing
+documentation starts being spell-checked and style-linted too.
+
+This is non-destructive by construction: `idd-onboard.mjs --import`
+already refuses to overwrite an existing target file whose content
+differs unless `--force`, so a repository that already has its own
+`.markdownlint.yml`, `.markdownlint-cli2.yaml`, or `.cspell.config.yml`
+gets that overwrite reported under `blockedOverwrites` instead of a
+silent replacement or a silent gap — merge the template's rule overrides
+or word list into the existing file by hand.
+
 ### Template sync mapping
 
 When this repository is itself the source of a reusable IDD

--- a/idd-template/.cspell.config.yml
+++ b/idd-template/.cspell.config.yml
@@ -1,0 +1,65 @@
+allowCompoundWords: true
+cache:
+  cacheFormat: universal
+  cacheLocation: node_modules/.cache/cspell/.cspell.cache
+  cacheStrategy: metadata
+  useCache: true
+dictionaries:
+  - cpp
+  - en_US
+  - en-gb
+  - fullstack
+  - git
+  - markdown
+  - misc
+  - shellscript
+  - softwareTerms
+enableGlobDot: true
+features:
+  weighted-suggestions: true
+globRoot: ${cwd}
+ignorePaths:
+  - .*ignore
+  - .git
+  - .github/CODE_OF_CONDUCT.*
+  - .vscode/extensions.json
+  - pnpm-lock.yaml
+language: en,ja
+useGitignore: true
+version: '0.2'
+words:
+  - desync
+  - desynced
+  - idd
+  - isort
+  - kito
+  - Kiro
+  - kuron
+  - kurone
+  - kuroné
+  - ONNX
+  - pylint
+  - pytest
+  - pyproject
+  - qwen
+  - TOCTOU
+  - tsfile
+  - undispositioned
+  - unioned
+  - unmigrated
+  - unmirrored
+  - unpushed
+  - unreplied
+  - unrouted
+  - unscored
+  - unwaived
+  - Esync
+  - minimizable
+  - waivable
+  - rollup
+  - GHES
+  - WHATWG
+  - dedup
+  - deprioritize
+  - ministral
+  - nvmrc

--- a/idd-template/.markdownlint-cli2.yaml
+++ b/idd-template/.markdownlint-cli2.yaml
@@ -1,0 +1,3 @@
+ignores:
+  - .github/CODE_OF_CONDUCT*
+  - node_modules/**/*.md

--- a/idd-template/.markdownlint.yml
+++ b/idd-template/.markdownlint.yml
@@ -23,6 +23,7 @@ no-inline-html:
 # level-1 heading alongside the page's own `# H1`. The default pattern
 # (`^\s*title\s*[:=]`) matches both, firing
 # `MD025/single-title/single-h1 Multiple top-level headings` on every
-# conforming OKF page. See docs/okf-frontmatter.md.
+# conforming OKF page. See
+# docs/customization.md#docs-bundle-frontmatter-convention-okf.
 single-title:
   front_matter_title: ""

--- a/idd-template/.markdownlint.yml
+++ b/idd-template/.markdownlint.yml
@@ -1,0 +1,28 @@
+default: true
+# Allow non-aligned table columns. Tables with long cell content are
+# impractical to keep aligned without breaking readability.
+table-column-style: false
+# Allow limit breakthroughs in the code block and table row lengths. The
+# default is unconditional prohibition. It is exceptionally allowed in
+# these elements due to folding difficulties.
+line-length:
+  code_blocks: false
+  headings: false
+  tables: false
+# Allows the use of duplicate headings. The default is unconditional
+# prohibition. Due to the `siblings_only` flag not working, it is necessary
+# to enable duplicate headings in the entire document.
+no-duplicate-heading: false
+# Allows embedding of the specified HTML tag. The default is unconditional
+# prohibition. Allow for some valuable features, such as folding.
+no-inline-html:
+  allowed_elements:
+    - details
+    - summary
+# Stop MD025 from treating an OKF frontmatter `title:` field as a second
+# level-1 heading alongside the page's own `# H1`. The default pattern
+# (`^\s*title\s*[:=]`) matches both, firing
+# `MD025/single-title/single-h1 Multiple top-level headings` on every
+# conforming OKF page. See docs/okf-frontmatter.md.
+single-title:
+  front_matter_title: ""

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -94,6 +94,16 @@ file drop:
 (npx-resolved profiles do not vend the core this way, so this note applies only
 when you copy helper files.)
 
+**Named gap: `.markdownlint.yml` / `.markdownlint-cli2.yaml` /
+`.cspell.config.yml`.** A repository onboarded before these 3 files were
+added to the template's core file set gets an intentional, non-silent
+behavior change on the next re-import: `--verify`'s `manifestCompleteness`
+now reports them missing (blocking) until you re-run Step 2 for them, and
+`--import` reports a `blockedOverwrites` finding instead of silently
+skipping them if you already created same-named files of your own by
+then — merge the template's rule overrides / word list into your existing
+file by hand in that case, following Step 2's file-list note above.
+
 When you then audit whether re-imported roadmap work is actually done, judge
 **completion by auditing the implementation against the acceptance criteria**,
 not by a child issue's closed state — a skeleton or scaffold PR can merge and
@@ -421,6 +431,9 @@ for the frontmatter convention its generated table follows.
 .githooks/_idd-worktree-guard.sh
 .githooks/pre-commit
 .githooks/pre-push
+.cspell.config.yml
+.markdownlint.yml
+.markdownlint-cli2.yaml
 .github/instructions/idd-overview-core.instructions.md
 .github/instructions/idd-overview-appendix.instructions.md
 .github/instructions/idd-discover.instructions.md
@@ -478,6 +491,34 @@ profiles/external-bot/README.md
 
 <!-- /audit:generated -->
 
+This file list includes `.markdownlint.yml`, `.markdownlint-cli2.yaml`, and
+`.cspell.config.yml`. They exist because a target repository with no
+pre-existing documentation-lint configuration can otherwise import a
+clean, verified tree and still fail its own ordinary
+`markdownlint-cli2`/`cspell` jobs on the imported files: an early adopter
+onboarding validation found real findings across a small set of repeated
+rule patterns (line length, table-column style, single-title, and
+duplicate-heading for `markdownlint`; unrecognized IDD/tooling
+vocabulary and upstream `kurone-kito/idd-skill` cross-references for
+`cspell`) against the imported files with no lint config present at all.
+These 3 files close that gap out of the box; `.cspell.config.yml`'s
+`enableGlobDot: true` in particular is required for `cspell lint "**"` to
+scan `.github/instructions/**` at all — without it, that command
+silently skips those files rather than reporting them clean. If the
+target repository already has its own `.markdownlint.yml`,
+`.markdownlint-cli2.yaml`, or `.cspell.config.yml` with different
+content, `--import` refuses to overwrite it (reported under
+`blockedOverwrites`, same as any other differing file) — merge the
+relevant rule overrides or word list from the template's copy into the
+existing file by hand rather than forcing an overwrite or skipping the
+import for that file. This also means a **re-import** into an
+already-onboarded repository that predates these 3 files is a named,
+intentional gap under
+[Re-importing](#re-importing-import-named-gaps-not-a-blind-resync)
+below, not a regression: `--verify` now expects them, and `--import`
+blocks instead of silently skipping them if a same-named file already
+exists with different content.
+
 Optional companion files:
 
 <!-- audit:generated id=issue-authoring-companion-files -->
@@ -516,6 +557,9 @@ for FILE in \
   ".githooks/_idd-worktree-guard.sh" \
   ".githooks/pre-commit" \
   ".githooks/pre-push" \
+  ".cspell.config.yml" \
+  ".markdownlint.yml" \
+  ".markdownlint-cli2.yaml" \
   ".github/instructions/idd-overview-core.instructions.md" \
   ".github/instructions/idd-overview-appendix.instructions.md" \
   ".github/instructions/idd-discover.instructions.md" \
@@ -622,6 +666,9 @@ for FILE in \
   ".githooks/_idd-worktree-guard.sh" \
   ".githooks/pre-commit" \
   ".githooks/pre-push" \
+  ".cspell.config.yml" \
+  ".markdownlint.yml" \
+  ".markdownlint-cli2.yaml" \
   ".github/instructions/idd-overview-core.instructions.md" \
   ".github/instructions/idd-overview-appendix.instructions.md" \
   ".github/instructions/idd-discover.instructions.md" \
@@ -1170,6 +1217,14 @@ After completing the steps above, confirm each item:
 
 - [ ] Every core execution file, supporting doc, and profile artifact
       listed in Step 2 is present in the imported repository.
+- [ ] `.markdownlint.yml`, `.markdownlint-cli2.yaml`, and
+      `.cspell.config.yml` are present, or — if `--import` reported a
+      `blockedOverwrites` finding for any of them because the target
+      already had its own differing file — the template's rule
+      overrides / word list were merged into the existing file by hand
+      rather than skipped, so the documented `markdownlint-cli2`/`cspell`
+      commands in the `Project commands` table still pass against the
+      imported documentation.
 - [ ] The selected PR review profile is recorded, and any non-default
       profile artifact and phase-file edits are complete.
 - [ ] The selected review-thread resolution policy and critique-loop

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -95,7 +95,7 @@ file drop:
 when you copy helper files.)
 
 **Named gap: `.markdownlint.yml` / `.markdownlint-cli2.yaml` /
-`.cspell.config.yml`.** A repository onboarded before these 3 files were
+`.cspell.config.yml`.** A repository onboarded before these files were
 added to the template's core file set gets an intentional, non-silent
 behavior change on the next re-import: `--verify`'s `manifestCompleteness`
 now reports them missing (blocking) until you re-run Step 2 for them, and
@@ -103,7 +103,7 @@ now reports them missing (blocking) until you re-run Step 2 for them, and
 skipping them if you already created same-named files of your own by
 then — merge the template's rule overrides / word list into your existing
 file by hand in that case, following the Step 2 file-list note on these
-3 files.
+files.
 
 When you then audit whether re-imported roadmap work is actually done, judge
 **completion by auditing the implementation against the acceptance criteria**,
@@ -502,7 +502,7 @@ rule patterns (line length, table-column style, single-title, and
 duplicate-heading for `markdownlint`; unrecognized IDD/tooling
 vocabulary and upstream `kurone-kito/idd-skill` cross-references for
 `cspell`) against the imported files with no lint config present at all.
-These 3 files close that gap out of the box; `.cspell.config.yml`'s
+These files close that gap out of the box; `.cspell.config.yml`'s
 `enableGlobDot: true` in particular is required for `cspell lint "**"` to
 scan `.github/instructions/**` at all — without it, that command
 silently skips those files rather than reporting them clean. If the
@@ -513,7 +513,7 @@ content, `--import` refuses to overwrite it (reported under
 relevant rule overrides or word list from the template's copy into the
 existing file by hand rather than forcing an overwrite or skipping the
 import for that file. This also means a **re-import** into an
-already-onboarded repository that predates these 3 files is a named,
+already-onboarded repository that predates these files is a named,
 intentional gap under
 [Re-importing](#re-importing-import-named-gaps-not-a-blind-resync)
 below, not a regression: `--verify` now expects them, and `--import`

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -102,7 +102,8 @@ now reports them missing (blocking) until you re-run Step 2 for them, and
 `--import` reports a `blockedOverwrites` finding instead of silently
 skipping them if you already created same-named files of your own by
 then — merge the template's rule overrides / word list into your existing
-file by hand in that case, following Step 2's file-list note above.
+file by hand in that case, following the Step 2 file-list note on these
+3 files.
 
 When you then audit whether re-imported roadmap work is actually done, judge
 **completion by auditing the implementation against the acceptance criteria**,

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -104,6 +104,7 @@ generated separately in `ONBOARDING.md`.
 
 ```text
 .claude/settings.json
+.cspell.config.yml
 .githooks/_idd-worktree-guard.sh
 .githooks/pre-commit
 .githooks/pre-push
@@ -139,6 +140,8 @@ generated separately in `ONBOARDING.md`.
 .github/instructions/lite/idd-work-lite.instructions.md
 .github/workflows/idd-advisory-convergence.yml
 .github/workflows/post-merge-cleanup.yml
+.markdownlint-cli2.yaml
+.markdownlint.yml
 docs/concepts.md
 docs/customization.md
 docs/getting-started.md

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -547,9 +547,10 @@ and no relevant script exists; else use `true`. For other tools, use
 ### Documentation lint compatibility
 
 The **fix-validate**/**pre-push-validate**/**post-fix-validate** example
-commands above run `markdownlint-cli2` and `cspell` against every
-Markdown file, including the imported `.github/instructions/**` and
-`docs/**` bundle. A target repository with no pre-existing documentation
+commands above run `markdownlint-cli2` (`**/*.md`, Markdown files only)
+and `cspell` (`**`, every file the working tree contains) against the
+imported `.github/instructions/**` and `docs/**` bundle among everything
+else. A target repository with no pre-existing documentation
 lint configuration can otherwise pass onboarding `--verify` and still
 fail those commands on the imported files alone. To close that gap, the
 imported file set (see the Step 2 file list in `idd-template/ONBOARDING.md`)

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -544,6 +544,33 @@ prefer project scripts; use `npx <tool>` only when `npx` is available
 and no relevant script exists; else use `true`. For other tools, use
 `true` when absent.
 
+### Documentation lint compatibility
+
+The **fix-validate**/**pre-push-validate**/**post-fix-validate** example
+commands above run `markdownlint-cli2` and `cspell` against every
+Markdown file, including the imported `.github/instructions/**` and
+`docs/**` bundle. A target repository with no pre-existing documentation
+lint configuration can otherwise pass onboarding `--verify` and still
+fail those commands on the imported files alone. To close that gap, the
+imported file set (see the Step 2 file list in `idd-template/ONBOARDING.md`)
+includes `.markdownlint.yml`, `.markdownlint-cli2.yaml`, and
+`.cspell.config.yml` at the repository root, carrying the rule
+overrides and word list this project's own documentation already needs
+to pass those same commands. Because `markdownlint-cli2`/`cspell`
+auto-discover root config, these files govern the target repository's
+entire Markdown surface once imported, not just the imported IDD
+documentation — expected given the `**`/`**/*.md` scope in the commands
+above, but worth knowing before the repository's own pre-existing
+documentation starts being spell-checked and style-linted too.
+
+This is non-destructive by construction: `idd-onboard.mjs --import`
+already refuses to overwrite an existing target file whose content
+differs unless `--force`, so a repository that already has its own
+`.markdownlint.yml`, `.markdownlint-cli2.yaml`, or `.cspell.config.yml`
+gets that overwrite reported under `blockedOverwrites` instead of a
+silent replacement or a silent gap — merge the template's rule overrides
+or word list into the existing file by hand.
+
 ### Template sync mapping
 
 When this repository is itself the source of a reusable IDD

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -2063,23 +2063,6 @@ const CSPELL_BIN = join(REPO_ROOT, 'node_modules', '.bin', 'cspell');
 const LINT_BINARIES_INSTALLED =
   existsSync(MARKDOWNLINT_BIN) && existsSync(CSPELL_BIN);
 
-/** Count every `*.md` file under `root`, recursively. */
-function countMarkdownFiles(root: string): number {
-  let count = 0;
-  const walk = (dir: string): void => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const absolute = join(dir, entry.name);
-      if (entry.isDirectory()) {
-        walk(absolute);
-      } else if (entry.isFile() && entry.name.endsWith('.md')) {
-        count += 1;
-      }
-    }
-  };
-  walk(root);
-  return count;
-}
-
 test('a real import + substitute produces a doc tree that passes the documented markdownlint/cspell commands with full file coverage (idd-skill#1860)', (t) => {
   if (!LINT_BINARIES_INSTALLED) {
     // Expected on the bare-node lane (lint.yml), which runs this suite with
@@ -2149,6 +2132,15 @@ test('a real import + substitute produces a doc tree that passes the documented 
   // scanning .github/instructions/** -- assert real coverage instead of
   // trusting the exit code alone. cspell prints its summary line to
   // stderr, not stdout.
+  //
+  // Compare against the import plan's own entry count, not a Markdown-only
+  // file count (idd-skill#1875 review): `cspell lint "**"` scans every
+  // file type, not just `*.md`, so a Markdown-only count could still pass
+  // this assertion even with .github/instructions/**'s Markdown files
+  // silently never scanned, as long as enough non-Markdown files padded the
+  // total. The import plan's entry count has no such gap -- it is exactly
+  // the file count cspell should see if it examined everything --import
+  // wrote.
   const cspellOutput = `${cspellResult.stdout}${cspellResult.stderr}`;
   const filesCheckedMatch = /Files checked:\s*(\d+)/u.exec(cspellOutput);
   assert.ok(
@@ -2156,9 +2148,9 @@ test('a real import + substitute produces a doc tree that passes the documented 
     `could not find a "Files checked" count in cspell output:\n${cspellOutput}`,
   );
   const filesChecked = Number(filesCheckedMatch[1]);
-  const markdownFileCount = countMarkdownFiles(targetRoot);
+  const importedFileCount = (imported.verdict.plan as unknown[]).length;
   assert.ok(
-    filesChecked >= markdownFileCount,
-    `cspell only checked ${filesChecked} files, fewer than the ${markdownFileCount} imported Markdown files -- enableGlobDot may have regressed`,
+    filesChecked >= importedFileCount,
+    `cspell only checked ${filesChecked} files, fewer than the ${importedFileCount} files --import wrote -- enableGlobDot may have regressed`,
   );
 });

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -2035,13 +2035,22 @@ test('the ONBOARDING.md CLI-assisted onboarding section anchors its --import fil
 // Documentation-lint compatibility (idd-skill#1860)
 //
 // A Tier A adopter-repository validation imported this template into a
-// minimal repo with no pre-existing lint config and found 690 markdownlint
-// findings and (once cspell's default dot-directory skip is accounted for)
-// 505 cspell findings against the imported files alone. These tests exercise
-// the real import -> substitute -> documented-lint-command path end to end
-// against this repo's own installed markdownlint-cli2/cspell binaries, so a
-// future documentation change that reintroduces incompatible vocabulary or
-// formatting fails here instead of on an adopter's first CI run.
+// minimal repo with no pre-existing lint config and found real markdownlint
+// findings (line length, table-column style, single-title, duplicate-heading)
+// and cspell findings (unrecognized IDD/tooling vocabulary and upstream
+// kurone-kito/idd-skill cross-references) against the imported files alone.
+// The end-to-end test below exercises the real
+// import -> substitute -> documented-lint-command path against this repo's
+// own installed markdownlint-cli2/cspell binaries, so a future documentation
+// change that reintroduces incompatible vocabulary or formatting fails here
+// instead of on an adopter's first CI run.
+//
+// This repo's `lint.yml` CI job deliberately dogfoods a toolless bare-node
+// adopter path -- it runs `node --test tests/*.test.mts` with NO
+// package-manager install, so node_modules/.bin/* is absent there by
+// design (dprint/cspell/markdownlint-cli2 run separately, once, in
+// pnpm-boundary.yml). The end-to-end test below self-skips when the
+// binaries it needs are not installed, instead of failing that lane.
 // ---------------------------------------------------------------------------
 
 const MARKDOWNLINT_BIN = join(
@@ -2051,6 +2060,8 @@ const MARKDOWNLINT_BIN = join(
   'markdownlint-cli2',
 );
 const CSPELL_BIN = join(REPO_ROOT, 'node_modules', '.bin', 'cspell');
+const LINT_BINARIES_INSTALLED =
+  existsSync(MARKDOWNLINT_BIN) && existsSync(CSPELL_BIN);
 
 /** Count every `*.md` file under `root`, recursively. */
 function countMarkdownFiles(root: string): number {
@@ -2069,7 +2080,13 @@ function countMarkdownFiles(root: string): number {
   return count;
 }
 
-test('a real import + substitute produces a doc tree that passes the documented markdownlint/cspell commands with full file coverage (idd-skill#1860)', () => {
+test('a real import + substitute produces a doc tree that passes the documented markdownlint/cspell commands with full file coverage (idd-skill#1860)', (t) => {
+  if (!LINT_BINARIES_INSTALLED) {
+    // Expected on the bare-node lane (lint.yml), which runs this suite with
+    // no package-manager install by design -- see the block comment above.
+    t.skip('markdownlint-cli2/cspell are not installed in this environment');
+    return;
+  }
   const targetRoot = makeFixtureDir();
 
   const imported = runCliBin([

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -2148,7 +2148,12 @@ test('a real import + substitute produces a doc tree that passes the documented 
     `could not find a "Files checked" count in cspell output:\n${cspellOutput}`,
   );
   const filesChecked = Number(filesCheckedMatch[1]);
-  const importedFileCount = (imported.verdict.plan as unknown[]).length;
+  const { plan } = imported.verdict;
+  assert.ok(
+    Array.isArray(plan),
+    `expected imported.verdict.plan to be an array, got: ${JSON.stringify(plan)}`,
+  );
+  const importedFileCount = plan.length;
   assert.ok(
     filesChecked >= importedFileCount,
     `cspell only checked ${filesChecked} files, fewer than the ${importedFileCount} files --import wrote -- enableGlobDot may have regressed`,

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import {
   chmodSync,
   cpSync,
@@ -1303,6 +1303,47 @@ test('bin/idd-onboard.mjs --import blocks on a differing existing target file wi
   assertTreeUnchanged(targetRoot, before);
 });
 
+test('bin/idd-onboard.mjs --import blocks on a pre-existing, differing doc-lint config instead of silently replacing it (idd-skill#1860)', () => {
+  const targetRoot = makeFixtureDir();
+  // Simulate a target repository that already has its own documentation
+  // lint configuration, differing from the template's copy.
+  writeFileSync(
+    join(targetRoot, '.cspell.config.yml'),
+    'words:\n  - preexisting\n',
+  );
+  writeFileSync(join(targetRoot, '.markdownlint.yml'), 'default: false\n');
+  writeFileSync(
+    join(targetRoot, '.markdownlint-cli2.yaml'),
+    'ignores:\n  - vendor/**\n',
+  );
+  const before = snapshotTree(targetRoot);
+
+  const { status, verdict } = runCliBin([
+    '--import',
+    '--source',
+    REPO_ROOT,
+    '--target',
+    targetRoot,
+  ]);
+  assert.equal(status, 1);
+  assert.equal(verdict.written, false);
+  const blocked = verdict.blockedOverwrites as string[];
+  for (const target of [
+    '.cspell.config.yml',
+    '.markdownlint.yml',
+    '.markdownlint-cli2.yaml',
+  ]) {
+    assert.ok(
+      blocked.includes(target),
+      `expected ${target} to be reported as a blocked overwrite instead of silently replaced`,
+    );
+  }
+  // The whole apply is fail-closed on any blocking finding (idd-onboard.mts
+  // writes nothing when blockedOverwrites is non-empty), so the adopter's
+  // pre-existing config is untouched, not just the 3 doc-lint files.
+  assertTreeUnchanged(targetRoot, before);
+});
+
 test('bin/idd-onboard.mjs --import --force overwrites a differing existing target file', () => {
   const targetRoot = makeFixtureDir();
   mkdirSync(join(targetRoot, '.github', 'idd'), { recursive: true });
@@ -1987,5 +2028,120 @@ test('the ONBOARDING.md CLI-assisted onboarding section anchors its --import fil
     markerCount,
     1,
     'the idd-template-core-files generated block must appear exactly once in ONBOARDING.md',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Documentation-lint compatibility (idd-skill#1860)
+//
+// A Tier A adopter-repository validation imported this template into a
+// minimal repo with no pre-existing lint config and found 690 markdownlint
+// findings and (once cspell's default dot-directory skip is accounted for)
+// 505 cspell findings against the imported files alone. These tests exercise
+// the real import -> substitute -> documented-lint-command path end to end
+// against this repo's own installed markdownlint-cli2/cspell binaries, so a
+// future documentation change that reintroduces incompatible vocabulary or
+// formatting fails here instead of on an adopter's first CI run.
+// ---------------------------------------------------------------------------
+
+const MARKDOWNLINT_BIN = join(
+  REPO_ROOT,
+  'node_modules',
+  '.bin',
+  'markdownlint-cli2',
+);
+const CSPELL_BIN = join(REPO_ROOT, 'node_modules', '.bin', 'cspell');
+
+/** Count every `*.md` file under `root`, recursively. */
+function countMarkdownFiles(root: string): number {
+  let count = 0;
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const absolute = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute);
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        count += 1;
+      }
+    }
+  };
+  walk(root);
+  return count;
+}
+
+test('a real import + substitute produces a doc tree that passes the documented markdownlint/cspell commands with full file coverage (idd-skill#1860)', () => {
+  const targetRoot = makeFixtureDir();
+
+  const imported = runCliBin([
+    '--import',
+    '--source',
+    REPO_ROOT,
+    '--target',
+    targetRoot,
+  ]);
+  assert.equal(imported.status, 0, JSON.stringify(imported.verdict));
+  assert.equal(imported.verdict.written, true);
+
+  // The 3 doc-lint compatibility files must actually be part of what a
+  // plain --import copies, not something this test seeds by hand.
+  for (const compatibilityFile of [
+    '.cspell.config.yml',
+    '.markdownlint.yml',
+    '.markdownlint-cli2.yaml',
+  ]) {
+    assert.ok(
+      existsSync(join(targetRoot, compatibilityFile)),
+      `expected --import to copy ${compatibilityFile}`,
+    );
+  }
+
+  const substituted = runCliBin([
+    '--substitute',
+    '--target',
+    targetRoot,
+    ...CLI_OVERRIDE_FLAGS,
+  ]);
+  assert.equal(substituted.status, 0, JSON.stringify(substituted.verdict));
+  assert.equal(substituted.verdict.written, true);
+  assert.deepEqual(substituted.verdict.residue, []);
+
+  const markdownlintResult = spawnSync(MARKDOWNLINT_BIN, ['**/*.md'], {
+    cwd: targetRoot,
+    encoding: 'utf8',
+  });
+  assert.equal(
+    markdownlintResult.status,
+    0,
+    `markdownlint-cli2 findings against the imported docs:\n${markdownlintResult.stdout}${markdownlintResult.stderr}`,
+  );
+
+  const cspellResult = spawnSync(
+    CSPELL_BIN,
+    ['lint', '**', '--no-progress', '--no-cache'],
+    { cwd: targetRoot, encoding: 'utf8' },
+  );
+  assert.equal(
+    cspellResult.status,
+    0,
+    `cspell findings against the imported docs:\n${cspellResult.stdout}${cspellResult.stderr}`,
+  );
+
+  // Scope assertion, not just exit-0: cspell skips dot-directories by
+  // default, so a config regression that silently drops
+  // `enableGlobDot: true` would still exit 0 while quietly no longer
+  // scanning .github/instructions/** -- assert real coverage instead of
+  // trusting the exit code alone. cspell prints its summary line to
+  // stderr, not stdout.
+  const cspellOutput = `${cspellResult.stdout}${cspellResult.stderr}`;
+  const filesCheckedMatch = /Files checked:\s*(\d+)/u.exec(cspellOutput);
+  assert.ok(
+    filesCheckedMatch,
+    `could not find a "Files checked" count in cspell output:\n${cspellOutput}`,
+  );
+  const filesChecked = Number(filesCheckedMatch[1]);
+  const markdownFileCount = countMarkdownFiles(targetRoot);
+  assert.ok(
+    filesChecked >= markdownFileCount,
+    `cspell only checked ${filesChecked} files, fewer than the ${markdownFileCount} imported Markdown files -- enableGlobDot may have regressed`,
   );
 });

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -2115,11 +2115,10 @@ test('a real import + substitute produces a doc tree that passes the documented 
     `markdownlint-cli2 findings against the imported docs:\n${markdownlintResult.stdout}${markdownlintResult.stderr}`,
   );
 
-  const cspellResult = spawnSync(
-    CSPELL_BIN,
-    ['lint', '**', '--no-progress', '--no-cache'],
-    { cwd: targetRoot, encoding: 'utf8' },
-  );
+  const cspellResult = spawnSync(CSPELL_BIN, ['lint', '**', '--no-progress'], {
+    cwd: targetRoot,
+    encoding: 'utf8',
+  });
   assert.equal(
     cspellResult.status,
     0,


### PR DESCRIPTION
## Summary

A Tier A adopter-repository validation imported IDD into a minimal repo,
substituted placeholders, and ran `--verify` — it passed, but the first
adopter CI run found 119 cspell findings across 23 repeated words and 60
markdownlint findings across three repeated rule patterns against the
imported documentation alone. `--verify` checks manifest completeness and
placeholder residue; it never runs the documentation-lint commands
`docs/customization.md` itself documents (`markdownlint-cli2`, `cspell`).

Reproducing the failure class from a clean fixture (see the plan comment
on the issue for the full numbers): with **zero** adopter lint config,
markdownlint reports 690 findings across 4 repeated rule patterns
(`MD013/line-length`, `MD060/table-column-style`, `MD025/single-title`,
`MD024/no-duplicate-heading`), and cspell — once its default
dot-directory skip is accounted for (it silently only scanned 24 of 58
imported files without it, undercounting the true gap) — reports 505
unknown-word findings across 67 unique words. Copying this repo's own
`.markdownlint.yml` and `.cspell.config.yml` into the same fixture drives
both to 0/0, with **no fixture-specific hand edits** — this repo's own CI
already depends on exactly this config to pass its own lint jobs against
this same documentation.

## Changes

- **`audit/sync-manifest.json`**: adds `idd-template/.cspell.config.yml`,
  `idd-template/.markdownlint.yml`, and `idd-template/.markdownlint-cli2.yaml`
  to the `idd-template-core-files` generated block (`sourceGlobs` +
  `paths`), so all 3 files flow through the existing manifest-driven
  `--import`/`--verify` machinery for every profile — no `idd-onboard.mts`
  code change needed. Adds 2 new `syncPairs` entries
  (`root-cspell-config`, `root-markdownlint-config`), following the same
  source-is-`idd-template/` direction every other pair in this repo
  already uses; the twist here is only that the generated *target* is
  this repo's own root config (which also governs this repo's own CI),
  not a `docs/` mirror. The existing `#1765` uncommitted-local-edit guard
  already protects a maintainer who fixes the root file directly without
  touching the template first, so this direction carries no drift-loss
  risk.
- **`idd-template/.cspell.config.yml`** / **`idd-template/.markdownlint.yml`**
  (new, byte-identical seeds of the current root files): kept as exact
  mirrors deliberately, including the 3 repo-specific settings in
  `.cspell.config.yml` (`cacheLocation: node_modules/.cache/cspell`, the
  `pnpm-lock.yaml` ignore, the `.vscode/extensions.json` ignore) — they're
  harmless no-ops for an adopter without matching paths, and keeping the
  file byte-identical is what makes the `exact` syncPair self-sustaining:
  every future word this repo's maintainers add to pass their own
  `pre-push-validate` lands in the template automatically on the next
  `sync-docs.mjs --apply`.
- **`idd-template/.markdownlint-cli2.yaml`** (new, hand-authored, *not* a
  syncPair): a deliberately reduced copy carrying only
  `.github/CODE_OF_CONDUCT*` and `node_modules/**/*.md`, dropping this
  repo's own fixture-path ignores. Unlike the other two files, this one
  isn't proven necessary by the reproduction fixture (which has no
  `node_modules` underneath it) — it ships as defense-in-depth against a
  real adopter's `node_modules` markdown noise exploding
  `markdownlint-cli2 "**/*.md"`'s scope, not because the repro needed it.
- **Non-destructive by construction**: no new code path. `--import`
  already refuses to overwrite an existing target file whose content
  differs unless `--force` (`blockedOverwrites`, exit 1); `--verify`'s
  `manifestCompleteness` already reports a missing target as blocking. An
  adopter who already has their own `.markdownlint.yml`/
  `.cspell.config.yml` gets that exact actionable finding instead of a
  silent overwrite or silent gap.
- **`idd-template/ONBOARDING.md`** (canonical source): the generated Step
  2 file list / `gh api` / `curl` loops pick up the 3 new paths
  automatically via `sync-docs.mjs --apply`. Hand-authored additions: a
  paragraph after the file list explaining why these 3 files exist (by
  rule/word class — line length, table-column style, single-title,
  duplicate-heading for markdownlint; unrecognized IDD/tooling vocabulary
  and upstream `kurone-kito/idd-skill` cross-references for cspell —
  rather than hard-coded finding counts that would go stale as the
  distributed docs change) and why `enableGlobDot: true` matters
  specifically (`cspell lint "**"` silently skips
  `.github/instructions/**` without it); a new Step 6 checklist item
  covering the blocked-overwrite remediation path; and a "Named gap"
  paragraph under the existing "Re-importing" section flagging the
  **intended, non-silent behavior change for already-onboarded repos**
  (below).
- **`idd-template/docs/customization.md`** (canonical source; `docs/customization.md`
  is its generated live mirror, regenerated via `sync-docs.mjs --apply`
  per this repo's own sync convention — not hand-edited): a new
  "Documentation lint compatibility" subsection right after the "Project
  commands reference" table, since that's exactly where the documented
  `markdownlint-cli2`/`cspell lint` commands live, plus one line noting
  these files govern the adopter's **entire** Markdown surface once
  imported (root-level `markdownlint-cli2`/`cspell` config, not scoped to
  the imported docs alone) — expected given the documented `**`/`**/*.md`
  commands, but worth flagging explicitly.
- **`idd-template/README.md`**: its sourceGlobs-only Files inventory
  picked up the 3 new files automatically via `sync-docs.mjs --apply` —
  no manual edit.
- **`tests/idd-onboard.test.mts`**: 2 new tests (85 → 87).
  - Imports this real repo's template into a fresh tmp fixture via the
    committed `bin/idd-onboard.mjs` CLI, substitutes placeholders, then
    spawns this repo's own installed `markdownlint-cli2`/`cspell`
    binaries against the fixture and asserts both exit 0 — exercising the
    real import → substitute → documented-lint-command path end to end.
    Also asserts cspell's reported "Files checked" count is at least the
    imported Markdown file count (a scope assertion, not just exit-0) —
    a future regression that silently drops `enableGlobDot: true` would
    otherwise still exit 0 while quietly no longer scanning
    `.github/instructions/**`, exactly the gap the reproduction found in
    the naive documented command. Self-skips when
    `node_modules/.bin/markdownlint-cli2`/`cspell` are absent, since
    `lint.yml` deliberately runs this suite on a toolless bare-node path
    with no package-manager install (see its own header comment); it
    executes for real in `pnpm-boundary.yml`'s `pnpm run lint:minimum`,
    which installs dependencies first — that job's `Run protocol tests`
    log line for this test must read `ok`, not `# SKIP`, for this PR's
    coverage claim to hold.
  - A second test confirming the 3 new files still participate in the
    existing blocked-overwrite protection at the CLI level (`--import`
    exits 1, `written: false`, `blockedOverwrites` lists all 3 paths, and
    the target tree is byte-unchanged) when a target already has
    differing content at those paths.

## Behavior change for already-onboarded repositories

This is intended and non-silent, not a regression: a repository onboarded
before these 3 files existed in the core file set will get a **blocking**
`manifestCompleteness` finding from `--verify` until it re-imports them,
and `--import` will report `blockedOverwrites` instead of silently
skipping them if that repository already created same-named files of its
own by then. Documented as a named gap under
`idd-template/ONBOARDING.md`'s "Re-importing" section.

## Explicitly not changed

`src/scripts/idd-onboard.mts` (named as a candidate file in the issue)
needs no code change: `--import`'s manifest-driven copy and `--verify`'s
`manifestCompleteness` already treat every `idd-template-core-files`
entry generically, so 3 new manifest paths are enough.

## Verification

- `node scripts/sync-docs.mjs --check` / `--apply` — clean.
- `node scripts/audit-docs.mjs --check` — passes (only pre-existing,
  unrelated notices).
- `node --test tests/*.test.mts` — 3188/3188 pass.
- `pnpm run typecheck`, `biome check`, `dprint check`, `markdownlint-cli2`,
  `cspell lint`, `build:check` — all clean.
- Whole-repo markdownlint/cspell file-checked counts compared before and
  after adding the new nested `idd-template/.markdownlint.yml` /
  `.markdownlint-cli2.yaml` files, to rule out markdownlint-cli2's
  directory-cascading config resolution silently narrowing this repo's
  own lint scope over `idd-template/**`: markdownlint stayed at exactly
  160 files linted / 0 issues both before and after; cspell went from
  672 to 675 files checked (exactly +3, the 3 new files themselves) with
  0 issues both before and after — additive, not scope-narrowing.
- Re-ran the reproduction end to end against the real worktree after the
  change: `--import` (61 files, was 58) → `--substitute` (0 residue) →
  `markdownlint-cli2 "**/*.md"` (0 issues) → `cspell lint "**" --no-progress`
  (0 issues, 61 files checked, full coverage).
- Grepped `README.md`, `README.ja.md`, `idd-template/ONBOARDING.md`,
  `idd-template/README.md`, `docs/**` for a hardcoded core-file count —
  none found, so the 58→61 file-count change needed no mirrored-count fix.

Closes #1860



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for documentation linting and spell-check compatibility.
  - Clarified onboarding requirements, verification steps, and handling of existing configuration conflicts.
  - Updated template inventories and setup instructions to include linting support.

- **New Features**
  - Added standard Markdown and spell-check configurations to generated templates.
  - Improved compatibility for English and Japanese documentation, including project-specific terminology.

- **Tests**
  - Added end-to-end coverage confirming lint configurations are imported safely and documentation passes validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->