### PR TITLE
fix(schema): add missing activation-nonce-mismatch to pre-merge-readiness claim.reason enum

### DIFF
--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -1069,7 +1069,8 @@
             "match",
             "missing-active-claim",
             "claim-id-mismatch",
-            "agent-id-mismatch"
+            "agent-id-mismatch",
+            "activation-nonce-mismatch"
           ]
         }
       }

--- a/tests/schema-validation.test.mts
+++ b/tests/schema-validation.test.mts
@@ -349,6 +349,25 @@ test('pre-merge-readiness valid fixture accepts fractional timestamp evidence', 
   assert.deepEqual(errors, []);
 });
 
+test('pre-merge-readiness valid fixture accepts activation-nonce-mismatch claim reason', () => {
+  const schema = loadJson('schemas/pre-merge-readiness.schema.json');
+  const fixture = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/pre-merge-readiness.valid.json')),
+  );
+  // Mirrors summarizeClaimValidation's fifth `reason` outcome (only
+  // reachable when both expectedClaimId and expectedNonce are supplied —
+  // see tests/pre-merge-readiness.test.mts's "mismatched nonce routes to
+  // the contested/stop path" for the functional coverage of the value
+  // itself). This test is schema-acceptance only: the enum previously
+  // listed just four values and rejected this one (#1873).
+  fixture.claim.reason = 'activation-nonce-mismatch';
+  fixture.claim.matchesExpectedClaim = false;
+  fixture.claim.claimLost = true;
+
+  const errors = validate(fixture, schema);
+  assert.deepEqual(errors, []);
+});
+
 test('pre-merge-readiness count fields require non-negative integers', () => {
   const schema = loadJson('schemas/pre-merge-readiness.schema.json');
   const fixture = JSON.parse(


### PR DESCRIPTION
# Summary

`claim.reason` in `schemas/pre-merge-readiness.schema.json` listed
only four of the five values `summarizeClaimValidation`
(`src/scripts/protocol-helpers.mts`) can actually emit. This adds the
missing `activation-nonce-mismatch` value to the enum and covers it
with a schema-acceptance test.

## Linked issue

Closes #1873

## Follow-up issues (if any)

- #1877 — discovered while dispositioning this PR's own advisory
  non-review notices: `isCodexUsageLimitNotice`
  (`src/scripts/protocol-helpers.mts`) doesn't recognize a third,
  newly-observed Codex rate-limit trailer wording, so
  `disposition-non-review-notices.mjs` silently skips it. Unrelated to
  this PR's schema change; dispositioned that one notice by hand per
  the written E6 fallback rule.

## Background / rationale (if material)

`summarizeClaimValidation`'s `else if (expectedClaimId &&
expectedNonce)` branch (around line 5381) sets `reason =
'activation-nonce-mismatch'` when the trusted active-claim's
activation-nonce winner does not match the caller's expected nonce.
`idd-pre-merge.instructions.md`'s F2 gate always passes `--nonce`, so
this branch is reachable in production, not merely theoretical — it
was flagged by CodeRabbit during review of PR #1871 (Refs #1867),
which added `description` fields to this schema but explicitly kept
its acceptance criteria annotation-only, so widening the enum was out
of scope there.

I also checked whether any other schema shares this enum path before
scoping the fix to this one file: `evaluateRoadmapClaim` in
`src/scripts/idd-roadmap-audit-execute.mts` wraps
`summarizeClaimValidation` too, but never passes `expectedNonce`, so
its call site can never reach the `activation-nonce-mismatch` branch
(guarded by `expectedClaimId && expectedNonce`); its own
`CLAIM_REASON_EXPLANATIONS` map correctly omits the value and falls
back to a total default for any unrecognized code. `idd-merge-execute
.schema.json` has no `claim.reason` enum at all. No other file needs a
matching widen.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)
- [x] `node --test tests/schema-validation.test.mts tests/schema-type-reconciliation.test.mts tests/schema-output-roundtrip.test.mts`
- [x] `node scripts/validate-schemas.mjs`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
