### PR TITLE
fix(protocol-helpers): recognize third Codex usage-limit notice trailer wording

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1013,14 +1013,30 @@ const CODEX_USAGE_LIMIT_TOKEN_PATTERN =
 // uses, so a comment that merely reuses those individual words near
 // SENTENCE_1's exact bot phrasing cannot piggyback a false accept (a gap
 // found and closed during this PR's own review-fix rounds).
+//
+// #1877: a THIRD, structurally distinct wording observed live on PR #1876
+// replaces the admin/credits sentence entirely with a dashboard pointer
+// ("You can see your limits in the [Codex usage dashboard](url).") — it is
+// an alternative closing sentence, not a continuation appended after
+// SENTENCE_1/SENTENCE_2, so it is a separate alternation branch
+// (SENTENCE_3) rather than a third optional suffix on the admin/credits
+// shape. SENTENCE_3 anchors the distinctive multi-word phrase "you can see
+// your limits" plus "Codex usage dashboard", with the same bounded,
+// gap-tolerant, non-exact-phrase approach as SENTENCE_1/SENTENCE_2. The
+// trailing markdown-link close `](url)` is matched structurally (bracket,
+// parens, non-`)` URL body) rather than an arbitrary-content character
+// budget, and is optional so a future plain-text rendering (no markdown
+// link) still matches.
 const CODEX_NOTICE_TRAILER_LEAD_IN =
   '[.!,;:\\s]{0,3}(?:\\bPlease\\b[.!,;:\\s]{0,3})?';
 const CODEX_NOTICE_TRAILER_SENTENCE_1 =
   '\\bcheck with the admins\\b[\\s\\S]{0,60}?\\bincrease the limits\\b[\\s\\S]{0,60}?\\badding credits\\b';
 const CODEX_NOTICE_TRAILER_SENTENCE_2 =
   '\\bcredits must be used\\b[\\s\\S]{0,40}?\\benable\\b[\\s\\S]{0,40}?\\brepository\\b[\\s\\S]{0,40}?\\b(?:code )?reviews?\\b';
+const CODEX_NOTICE_TRAILER_SENTENCE_3 =
+  '\\byou can see your limits\\b[\\s\\S]{0,60}?\\bCodex usage dashboard\\b(?:\\]\\([^)]*\\))?';
 const CODEX_NOTICE_TRAILER_CONTINUATION_PATTERN = new RegExp(
-  `^${CODEX_NOTICE_TRAILER_LEAD_IN}${CODEX_NOTICE_TRAILER_SENTENCE_1}(?:[.!,;:\\s]{0,5}${CODEX_NOTICE_TRAILER_SENTENCE_2})?[.!,;:\\s]*$`,
+  `^${CODEX_NOTICE_TRAILER_LEAD_IN}(?:${CODEX_NOTICE_TRAILER_SENTENCE_1}(?:[.!,;:\\s]{0,5}${CODEX_NOTICE_TRAILER_SENTENCE_2})?|${CODEX_NOTICE_TRAILER_SENTENCE_3})[.!,;:\\s]*$`,
   'i',
 );
 const CODEX_NOTICE_MAX_LENGTH = 220;

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1683,14 +1683,30 @@ const CODEX_USAGE_LIMIT_TOKEN_PATTERN =
 // uses, so a comment that merely reuses those individual words near
 // SENTENCE_1's exact bot phrasing cannot piggyback a false accept (a gap
 // found and closed during this PR's own review-fix rounds).
+//
+// #1877: a THIRD, structurally distinct wording observed live on PR #1876
+// replaces the admin/credits sentence entirely with a dashboard pointer
+// ("You can see your limits in the [Codex usage dashboard](url).") — it is
+// an alternative closing sentence, not a continuation appended after
+// SENTENCE_1/SENTENCE_2, so it is a separate alternation branch
+// (SENTENCE_3) rather than a third optional suffix on the admin/credits
+// shape. SENTENCE_3 anchors the distinctive multi-word phrase "you can see
+// your limits" plus "Codex usage dashboard", with the same bounded,
+// gap-tolerant, non-exact-phrase approach as SENTENCE_1/SENTENCE_2. The
+// trailing markdown-link close `](url)` is matched structurally (bracket,
+// parens, non-`)` URL body) rather than an arbitrary-content character
+// budget, and is optional so a future plain-text rendering (no markdown
+// link) still matches.
 const CODEX_NOTICE_TRAILER_LEAD_IN =
   '[.!,;:\\s]{0,3}(?:\\bPlease\\b[.!,;:\\s]{0,3})?';
 const CODEX_NOTICE_TRAILER_SENTENCE_1 =
   '\\bcheck with the admins\\b[\\s\\S]{0,60}?\\bincrease the limits\\b[\\s\\S]{0,60}?\\badding credits\\b';
 const CODEX_NOTICE_TRAILER_SENTENCE_2 =
   '\\bcredits must be used\\b[\\s\\S]{0,40}?\\benable\\b[\\s\\S]{0,40}?\\brepository\\b[\\s\\S]{0,40}?\\b(?:code )?reviews?\\b';
+const CODEX_NOTICE_TRAILER_SENTENCE_3 =
+  '\\byou can see your limits\\b[\\s\\S]{0,60}?\\bCodex usage dashboard\\b(?:\\]\\([^)]*\\))?';
 const CODEX_NOTICE_TRAILER_CONTINUATION_PATTERN = new RegExp(
-  `^${CODEX_NOTICE_TRAILER_LEAD_IN}${CODEX_NOTICE_TRAILER_SENTENCE_1}(?:[.!,;:\\s]{0,5}${CODEX_NOTICE_TRAILER_SENTENCE_2})?[.!,;:\\s]*$`,
+  `^${CODEX_NOTICE_TRAILER_LEAD_IN}(?:${CODEX_NOTICE_TRAILER_SENTENCE_1}(?:[.!,;:\\s]{0,5}${CODEX_NOTICE_TRAILER_SENTENCE_2})?|${CODEX_NOTICE_TRAILER_SENTENCE_3})[.!,;:\\s]*$`,
   'i',
 );
 const CODEX_NOTICE_MAX_LENGTH = 220;

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -337,6 +337,33 @@ test('buildDispositionPlan plans a rejection for the current Codex usage-limit w
   assert.match(plan.planned[0]?.body ?? '', /did not review HEAD abc1234/);
 });
 
+test('buildDispositionPlan plans a rejection for the #1877 dashboard-pointer wording', () => {
+  // #1877 regression: a third live Codex wording (observed on PR #1876,
+  // 2026-08-05) points at the Codex usage dashboard instead of the
+  // admin/credits sentence — must still be recognized as a non-review
+  // notice and dispositioned. Literal text captured from
+  // https://github.com/kurone-kito/idd-skill/pull/1876#issuecomment-5187108915.
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [
+        notice(
+          1,
+          CODEX,
+          'You have reached your Codex usage limits for code reviews. ' +
+            'You can see your limits in the [Codex usage dashboard]' +
+            '(https://chatgpt.com/codex/cloud/settings/usage).',
+        ),
+      ],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.equal(plan.planned.length, 1);
+  assert.equal(plan.planned[0]?.botLogin, CODEX);
+  assert.ok(plan.planned[0]?.body.startsWith('**Rejected**'));
+  assert.match(plan.planned[0]?.body ?? '', /did not review HEAD abc1234/);
+});
+
 test('buildDispositionPlan does not disposition the #1326 false-positive review comment', () => {
   // #1326: a genuine Codex review comment that combines "Codex", a
   // reach/exceed/hit verb, and "for code reviews" in ordinary prose (the

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -3715,6 +3715,54 @@ test('isAdvisoryNonReviewNotice matches only machine-generated non-review notice
     ),
     true,
   );
+  // #1877: a third live trailer wording (observed on PR #1876,
+  // 2026-08-05) points at the Codex usage dashboard instead of the
+  // admin/credits sentence — must still classify as a non-review notice.
+  // Literal text captured from
+  // https://github.com/kurone-kito/idd-skill/pull/1876#issuecomment-5187108915.
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'You have reached your Codex usage limits for code reviews. You ' +
+        'can see your limits in the [Codex usage dashboard]' +
+        '(https://chatgpt.com/codex/cloud/settings/usage).',
+    ),
+    true,
+  );
+  // #1877: the same dashboard-pointer wording without markdown link syntax
+  // (a plausible plain-text rendering) must also match — the markdown
+  // link close is optional, not required.
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'You have reached your Codex usage limits for code reviews. You ' +
+        'can see your limits in the Codex usage dashboard.',
+    ),
+    true,
+  );
+  // #1877: the dashboard-pointer trailer followed by further unrelated
+  // prose must still not match — SENTENCE_3 anchors the entire remainder,
+  // the same whole-remainder anchoring SENTENCE_1/SENTENCE_2 already
+  // enforce.
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'You have reached your Codex usage limits for code reviews. You ' +
+        'can see your limits in the [Codex usage dashboard]' +
+        '(https://chatgpt.com/codex/cloud/settings/usage). By the way I ' +
+        'also noticed a bug in the retry logic.',
+    ),
+    false,
+  );
+  // #1877: a narrative lead-in before "you can see your limits" must not
+  // match either — mirrors the existing SENTENCE_1 narrative-lead-in
+  // guard; the lead-in before the trailer's core tokens must stay
+  // punctuation/whitespace plus the one known "Please" word, never
+  // arbitrary narrative content.
+  assert.equal(
+    isAdvisoryNonReviewNotice(
+      'You have reached your Codex usage limits for code reviews. We ' +
+        'think you can see your limits in the Codex usage dashboard.',
+    ),
+    false,
+  );
   assert.equal(isAdvisoryNonReviewNotice(''), false);
   assert.equal(isAdvisoryNonReviewNotice(null), false);
 });


### PR DESCRIPTION
# Summary

`isCodexUsageLimitNotice` (`src/scripts/protocol-helpers.mts`) only
recognized two known trailer wordings after a matched "Codex usage
limits ... for code reviews" span. A third live wording observed on PR
#1876 (2026-08-05) — a dashboard pointer instead of the admin/credits
sentence — was not recognized, so `disposition-non-review-notices.mjs`
silently skipped the notice instead of planning a disposition for it.

This adds `CODEX_NOTICE_TRAILER_SENTENCE_3` as a genuine alternative
closing sentence (not a continuation appended after
SENTENCE_1/SENTENCE_2), anchored on the distinctive multi-word phrase
"you can see your limits" plus "Codex usage dashboard", following the
same token-anchored, gap-tolerant, non-exact-phrase, case-insensitive
approach the existing two trailer sentences use. The trailing
markdown-link close (`](url)`) is matched structurally so a plain-text
rendering without the link also matches.

## Linked issue

Closes #1877

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Discovered while dispositioning PR #1876's own advisory non-review
notices by hand (using the written E6 fallback rule in
`idd-review-triage.instructions.md`, since the helper missed it). See
<https://github.com/kurone-kito/idd-skill/pull/1876#issuecomment-5187108915>
for the exact live body that exposed the gap.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

`src/scripts/protocol-helpers.mts` is the `.mts` source of truth;
`scripts/protocol-helpers.mjs` is the generated artifact rebuilt via
`pnpm run build` and committed alongside it.

## Verification

- [x] `pnpm lint` (`npx biome check`)
- [x] `pnpm test` (`node --test tests/pre-merge-readiness.test.mts
      tests/disposition-non-review-notices.test.mts` — 291/291 pass,
      including new regression cases using the literal PR #1876 text)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs changed)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
