### PR TITLE
fix(advisory-convergence): detect suppressed Copilot review findings

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1811,7 +1811,7 @@ structurally unable to disagree.
 | `unresolved-copilot-threads`              | `threads.satisfied` is `false` -- at least one Copilot-authored thread is neither resolved nor validly dispositioned.                                   |
 | `missing-regular-comment-disposition`     | `dispositionEvidence.missingRegularCommentCount` is non-zero -- an outstanding regular (non-thread) PR comment still lacks a fresh disposition marker.  |
 | `review-item-count-unknown`               | The latest review's comment count is unavailable -- either the review is off-HEAD (co-firing with `review-pending` above, since `resolveLatestCopilotReviewClause` reports `itemCount: null` for any non-matching-HEAD review), or it is on current HEAD but the count itself is unavailable (a GraphQL nullable-field edge case). |
-| `review-item-count-not-positive`          | The latest review's `itemCount` is a known, non-positive value (i.e. exactly `0` -- already fully converged, nothing to reroll).                        |
+| `review-item-count-not-positive`          | The latest review's `itemCount` is a known `0` AND `suppressedCount` (#1880) is also `0` -- already fully converged, nothing (posted or suppressed) to reroll for.                        |
 <!-- dprint-ignore-end -->
 
 When `review-item-count-not-positive` is absent but `converged` is still
@@ -1822,6 +1822,20 @@ check the review body directly -- the shape of the reported adopter
 incident: a "Comments suppressed due to low confidence" item embedded in
 the review's own body text counts toward `itemCount` but never surfaces
 as a review thread, so no thread query can ever explain it.
+
+**`suppressedCount` (#1880).** A distinct, `itemCount === 0` shape of the
+same underlying problem: GitHub Copilot can fold a finding into a
+`<details><summary>Suppressed comments (N)</summary>` block in the
+review's top-level `body` instead of posting it as a comment at all, so
+`comments.totalCount` (`itemCount`) stays `0` while a real finding still
+exists. `resolveLatestCopilotReviewClause` (review-clause.mts) parses
+this heading into `review.suppressedCount`, and Clause 1's `satisfied`
+computation and `reviewItemCountPositiveTerm` above both treat
+`suppressedCount > 0` the same way they already treat `itemCount > 0` --
+blocking convergence with a dedicated top-level reason, and keeping the
+same-HEAD reroll recovery path available for it, since `suppressedCount`
+is read from the same static per-submission review snapshot `itemCount`
+is.
 
 **AW6 procedure** (`idd-advisory-wait.instructions.md`), invoked only
 from F2 on a non-zero `--assert` exit:

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1786,16 +1786,16 @@ evidence, purely additively: `converged` / `waived` / `ready` are
 computed with **no reference to it at all**, so it can never let the
 gate pass on anything but the primary bot's own real signal.
 
-| Field               | Meaning                                                                                                                                                                                                                                                                                                                               |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `eligible`          | `matchesHead: true`, `itemCount > 0`, every Copilot-authored thread resolved or validly dispositioned, AND no outstanding regular-comment disposition evidence (`dispositionEvidence.missingRegularCommentCount === 0`) -- the static count is the ONLY thing keeping `converged` false, with no other triage work still outstanding. |
-| `ineligibleReasons` | `#1719`: one stable, machine-readable token per failing term of the `eligible` conjunction above (empty exactly when `eligible` is `true`), so a caller can self-diagnose a stuck reroll without re-deriving the rule by hand. See below for the token list and the report-mode example.                                              |
-| `count`             | Trusted `advisory-reroll:` marker count matching the current HEAD (resets on a new push, since a new HEAD's markers start over).                                                                                                                                                                                                      |
-| `cap`               | Configured bounded budget, `advisoryWait.sameHeadRerollCap` (default 2, deliberately conservative but > 1: same-SHA re-review is not a guaranteed one-shot off-ramp).                                                                                                                                                                 |
-| `exhausted`         | `count >= cap`: stop rerolling, fall through to the existing deadline-plus-maintainer-waiver backstop (#1512) or hold.                                                                                                                                                                                                                |
-| `latestAt`          | GitHub `created_at` of the latest trusted same-HEAD reroll marker, or `''` -- **never** the marker's embedded, agent-supplied timestamp (same anchor rule AW2 already states for `advisory-wait:`).                                                                                                                                   |
-| `inFlight`          | `true` while a reroll marker exists, no primary-bot review has been submitted after it yet, **and** the configured `advisoryWait.pendingWindow` has not yet elapsed since it was posted. Recomputed fresh from GitHub state on every call (never in-session memory), so a crash mid-poll can never cause a duplicate reroll request.  |
-| `requestable`       | `eligible && !exhausted && !inFlight` -- the exact instant it is safe to request a fresh same-HEAD reroll.                                                                                                                                                                                                                            |
+| Field               | Meaning                                                                                                                                                                                                                                                                                                                                                                                       |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `eligible`          | `matchesHead: true`, `itemCount` known AND (`itemCount > 0` OR `suppressedCount > 0`, #1880), every Copilot-authored thread resolved or validly dispositioned, AND no outstanding regular-comment disposition evidence (`dispositionEvidence.missingRegularCommentCount === 0`) -- the static count is the ONLY thing keeping `converged` false, with no other triage work still outstanding. |
+| `ineligibleReasons` | `#1719`: one stable, machine-readable token per failing term of the `eligible` conjunction above (empty exactly when `eligible` is `true`), so a caller can self-diagnose a stuck reroll without re-deriving the rule by hand. See below for the token list and the report-mode example.                                                                                                      |
+| `count`             | Trusted `advisory-reroll:` marker count matching the current HEAD (resets on a new push, since a new HEAD's markers start over).                                                                                                                                                                                                                                                              |
+| `cap`               | Configured bounded budget, `advisoryWait.sameHeadRerollCap` (default 2, deliberately conservative but > 1: same-SHA re-review is not a guaranteed one-shot off-ramp).                                                                                                                                                                                                                         |
+| `exhausted`         | `count >= cap`: stop rerolling, fall through to the existing deadline-plus-maintainer-waiver backstop (#1512) or hold.                                                                                                                                                                                                                                                                        |
+| `latestAt`          | GitHub `created_at` of the latest trusted same-HEAD reroll marker, or `''` -- **never** the marker's embedded, agent-supplied timestamp (same anchor rule AW2 already states for `advisory-wait:`).                                                                                                                                                                                           |
+| `inFlight`          | `true` while a reroll marker exists, no primary-bot review has been submitted after it yet, **and** the configured `advisoryWait.pendingWindow` has not yet elapsed since it was posted. Recomputed fresh from GitHub state on every call (never in-session memory), so a crash mid-poll can never cause a duplicate reroll request.                                                          |
+| `requestable`       | `eligible && !exhausted && !inFlight` -- the exact instant it is safe to request a fresh same-HEAD reroll.                                                                                                                                                                                                                                                                                    |
 
 **`ineligibleReasons` tokens (`#1719`)**: one entry per failing term, in
 the same order the `eligible` conjunction is written in
@@ -1823,13 +1823,17 @@ incident: a "Comments suppressed due to low confidence" item embedded in
 the review's own body text counts toward `itemCount` but never surfaces
 as a review thread, so no thread query can ever explain it.
 
-**`suppressedCount` (#1880).** A distinct, `itemCount === 0` shape of the
-same underlying problem: GitHub Copilot can fold a finding into a
-`<details><summary>Suppressed comments (N)</summary>` block in the
-review's top-level `body` instead of posting it as a comment at all, so
-`comments.totalCount` (`itemCount`) stays `0` while a real finding still
-exists. `resolveLatestCopilotReviewClause` (review-clause.mts) parses
-this heading into `review.suppressedCount`, and Clause 1's `satisfied`
+**`suppressedCount` (kurone-kito/idd-skill#1880).** A distinct,
+`itemCount === 0` shape of the same underlying problem: GitHub Copilot
+can fold a finding into a `<details><summary>Suppressed comments
+(N)</summary>` block in the review's top-level `body` instead of
+posting it as a comment at all, so `comments.totalCount` (`itemCount`)
+stays `0` while a real finding still exists. Observed incident: PR
+kurone-kito/idd-skill#1875, merged 2026-08-05 (a Copilot review on that
+PR had `comments.totalCount: 0` with a body still containing an
+unaddressed `Suppressed comments (1)` finding).
+`resolveLatestCopilotReviewClause` (review-clause.mts) parses this
+heading into `review.suppressedCount`, and Clause 1's `satisfied`
 computation and `reviewItemCountPositiveTerm` above both treat
 `suppressedCount > 0` the same way they already treat `itemCount > 0` --
 blocking convergence with a dedicated top-level reason, and keeping the

--- a/fixtures/schemas/advisory-convergence.valid.json
+++ b/fixtures/schemas/advisory-convergence.valid.json
@@ -16,6 +16,7 @@
     "matchesHead": true,
     "itemCount": 0,
     "submittedAt": "2026-07-11T10:00:00Z",
+    "suppressedCount": 0,
     "satisfied": true
   },
   "threads": {

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1811,7 +1811,7 @@ structurally unable to disagree.
 | `unresolved-copilot-threads`              | `threads.satisfied` is `false` -- at least one Copilot-authored thread is neither resolved nor validly dispositioned.                                   |
 | `missing-regular-comment-disposition`     | `dispositionEvidence.missingRegularCommentCount` is non-zero -- an outstanding regular (non-thread) PR comment still lacks a fresh disposition marker.  |
 | `review-item-count-unknown`               | The latest review's comment count is unavailable -- either the review is off-HEAD (co-firing with `review-pending` above, since `resolveLatestCopilotReviewClause` reports `itemCount: null` for any non-matching-HEAD review), or it is on current HEAD but the count itself is unavailable (a GraphQL nullable-field edge case). |
-| `review-item-count-not-positive`          | The latest review's `itemCount` is a known, non-positive value (i.e. exactly `0` -- already fully converged, nothing to reroll).                        |
+| `review-item-count-not-positive`          | The latest review's `itemCount` is a known `0` AND `suppressedCount` (#1880) is also `0` -- already fully converged, nothing (posted or suppressed) to reroll for.                        |
 <!-- dprint-ignore-end -->
 
 When `review-item-count-not-positive` is absent but `converged` is still
@@ -1822,6 +1822,20 @@ check the review body directly -- the shape of the reported adopter
 incident: a "Comments suppressed due to low confidence" item embedded in
 the review's own body text counts toward `itemCount` but never surfaces
 as a review thread, so no thread query can ever explain it.
+
+**`suppressedCount` (#1880).** A distinct, `itemCount === 0` shape of the
+same underlying problem: GitHub Copilot can fold a finding into a
+`<details><summary>Suppressed comments (N)</summary>` block in the
+review's top-level `body` instead of posting it as a comment at all, so
+`comments.totalCount` (`itemCount`) stays `0` while a real finding still
+exists. `resolveLatestCopilotReviewClause` (review-clause.mts) parses
+this heading into `review.suppressedCount`, and Clause 1's `satisfied`
+computation and `reviewItemCountPositiveTerm` above both treat
+`suppressedCount > 0` the same way they already treat `itemCount > 0` --
+blocking convergence with a dedicated top-level reason, and keeping the
+same-HEAD reroll recovery path available for it, since `suppressedCount`
+is read from the same static per-submission review snapshot `itemCount`
+is.
 
 **AW6 procedure** (`idd-advisory-wait.instructions.md`), invoked only
 from F2 on a non-zero `--assert` exit:

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1786,16 +1786,16 @@ evidence, purely additively: `converged` / `waived` / `ready` are
 computed with **no reference to it at all**, so it can never let the
 gate pass on anything but the primary bot's own real signal.
 
-| Field               | Meaning                                                                                                                                                                                                                                                                                                                               |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `eligible`          | `matchesHead: true`, `itemCount > 0`, every Copilot-authored thread resolved or validly dispositioned, AND no outstanding regular-comment disposition evidence (`dispositionEvidence.missingRegularCommentCount === 0`) -- the static count is the ONLY thing keeping `converged` false, with no other triage work still outstanding. |
-| `ineligibleReasons` | `#1719`: one stable, machine-readable token per failing term of the `eligible` conjunction above (empty exactly when `eligible` is `true`), so a caller can self-diagnose a stuck reroll without re-deriving the rule by hand. See below for the token list and the report-mode example.                                              |
-| `count`             | Trusted `advisory-reroll:` marker count matching the current HEAD (resets on a new push, since a new HEAD's markers start over).                                                                                                                                                                                                      |
-| `cap`               | Configured bounded budget, `advisoryWait.sameHeadRerollCap` (default 2, deliberately conservative but > 1: same-SHA re-review is not a guaranteed one-shot off-ramp).                                                                                                                                                                 |
-| `exhausted`         | `count >= cap`: stop rerolling, fall through to the existing deadline-plus-maintainer-waiver backstop (#1512) or hold.                                                                                                                                                                                                                |
-| `latestAt`          | GitHub `created_at` of the latest trusted same-HEAD reroll marker, or `''` -- **never** the marker's embedded, agent-supplied timestamp (same anchor rule AW2 already states for `advisory-wait:`).                                                                                                                                   |
-| `inFlight`          | `true` while a reroll marker exists, no primary-bot review has been submitted after it yet, **and** the configured `advisoryWait.pendingWindow` has not yet elapsed since it was posted. Recomputed fresh from GitHub state on every call (never in-session memory), so a crash mid-poll can never cause a duplicate reroll request.  |
-| `requestable`       | `eligible && !exhausted && !inFlight` -- the exact instant it is safe to request a fresh same-HEAD reroll.                                                                                                                                                                                                                            |
+| Field               | Meaning                                                                                                                                                                                                                                                                                                                                                                                       |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `eligible`          | `matchesHead: true`, `itemCount` known AND (`itemCount > 0` OR `suppressedCount > 0`, #1880), every Copilot-authored thread resolved or validly dispositioned, AND no outstanding regular-comment disposition evidence (`dispositionEvidence.missingRegularCommentCount === 0`) -- the static count is the ONLY thing keeping `converged` false, with no other triage work still outstanding. |
+| `ineligibleReasons` | `#1719`: one stable, machine-readable token per failing term of the `eligible` conjunction above (empty exactly when `eligible` is `true`), so a caller can self-diagnose a stuck reroll without re-deriving the rule by hand. See below for the token list and the report-mode example.                                                                                                      |
+| `count`             | Trusted `advisory-reroll:` marker count matching the current HEAD (resets on a new push, since a new HEAD's markers start over).                                                                                                                                                                                                                                                              |
+| `cap`               | Configured bounded budget, `advisoryWait.sameHeadRerollCap` (default 2, deliberately conservative but > 1: same-SHA re-review is not a guaranteed one-shot off-ramp).                                                                                                                                                                                                                         |
+| `exhausted`         | `count >= cap`: stop rerolling, fall through to the existing deadline-plus-maintainer-waiver backstop (#1512) or hold.                                                                                                                                                                                                                                                                        |
+| `latestAt`          | GitHub `created_at` of the latest trusted same-HEAD reroll marker, or `''` -- **never** the marker's embedded, agent-supplied timestamp (same anchor rule AW2 already states for `advisory-wait:`).                                                                                                                                                                                           |
+| `inFlight`          | `true` while a reroll marker exists, no primary-bot review has been submitted after it yet, **and** the configured `advisoryWait.pendingWindow` has not yet elapsed since it was posted. Recomputed fresh from GitHub state on every call (never in-session memory), so a crash mid-poll can never cause a duplicate reroll request.                                                          |
+| `requestable`       | `eligible && !exhausted && !inFlight` -- the exact instant it is safe to request a fresh same-HEAD reroll.                                                                                                                                                                                                                                                                                    |
 
 **`ineligibleReasons` tokens (`#1719`)**: one entry per failing term, in
 the same order the `eligible` conjunction is written in
@@ -1823,13 +1823,17 @@ incident: a "Comments suppressed due to low confidence" item embedded in
 the review's own body text counts toward `itemCount` but never surfaces
 as a review thread, so no thread query can ever explain it.
 
-**`suppressedCount` (#1880).** A distinct, `itemCount === 0` shape of the
-same underlying problem: GitHub Copilot can fold a finding into a
-`<details><summary>Suppressed comments (N)</summary>` block in the
-review's top-level `body` instead of posting it as a comment at all, so
-`comments.totalCount` (`itemCount`) stays `0` while a real finding still
-exists. `resolveLatestCopilotReviewClause` (review-clause.mts) parses
-this heading into `review.suppressedCount`, and Clause 1's `satisfied`
+**`suppressedCount` (kurone-kito/idd-skill#1880).** A distinct,
+`itemCount === 0` shape of the same underlying problem: GitHub Copilot
+can fold a finding into a `<details><summary>Suppressed comments
+(N)</summary>` block in the review's top-level `body` instead of
+posting it as a comment at all, so `comments.totalCount` (`itemCount`)
+stays `0` while a real finding still exists. Observed incident: PR
+kurone-kito/idd-skill#1875, merged 2026-08-05 (a Copilot review on that
+PR had `comments.totalCount: 0` with a body still containing an
+unaddressed `Suppressed comments (1)` finding).
+`resolveLatestCopilotReviewClause` (review-clause.mts) parses this
+heading into `review.suppressedCount`, and Clause 1's `satisfied`
 computation and `reviewItemCountPositiveTerm` above both treat
 `suppressedCount > 0` the same way they already treat `itemCount > 0` --
 blocking convergence with a dedicated top-level reason, and keeping the

--- a/schemas/advisory-convergence.schema.json
+++ b/schemas/advisory-convergence.schema.json
@@ -84,7 +84,7 @@
     "review": {
       "type": "object",
       "description": "Clause 1 evidence: identity and HEAD-coverage of the primary bot's latest review, by fetch order.",
-      "required": ["found", "commitId", "matchesHead", "itemCount", "submittedAt", "satisfied"],
+      "required": ["found", "commitId", "matchesHead", "itemCount", "submittedAt", "suppressedCount", "satisfied"],
       "additionalProperties": false,
       "properties": {
         "found": {
@@ -107,9 +107,14 @@
           "type": "string",
           "description": "submittedAt timestamp of the latest primary-bot review, or empty when none was found."
         },
+        "suppressedCount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count parsed from a `Suppressed comments (N)` heading in the latest review's body (read only when matchesHead is true; 0 otherwise), 0 when no such section is present -- kurone-kito/idd-skill#1880. GitHub Copilot can fold a finding into this collapsed body section instead of posting it as a comment, which itemCount (comments.totalCount) never reflects."
+        },
         "satisfied": {
           "type": "boolean",
-          "description": "True when the latest review covers HEAD and reports zero actionable items -- Clause 1's pass condition."
+          "description": "True when the latest review covers HEAD, reports zero actionable items, AND has no suppressed-comments section -- Clause 1's pass condition."
         }
       }
     },

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -361,18 +361,41 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   // is already resolved and `itemCount` is still positive, no thread query
   // can explain it -- point directly at the review body instead of leaving
   // an agent to re-derive this by hand a second time.
+  //
+  // #1880: a related but distinct incident shape -- the primary bot's
+  // review on current HEAD carries `itemCount: 0` (zero POSTED comments)
+  // while its top-level body still embeds a `Suppressed comments (N)`
+  // block for a finding it chose not to post as a comment at all. The
+  // #1719 branch above only fires when `itemCount > 0`, so this case fell
+  // through to full convergence with an empty `reasons[]` until now (PR
+  // #1875 commit 9711d404). `review.satisfied` (review-clause.mts) is
+  // already gated on `suppressedCount === 0`, so `converged` is already
+  // correctly `false` here -- this branch only supplies the explanation.
   if (!scopeBlocksConvergenceEval && !pending && !review.satisfied) {
-    const itemCountReason =
-      review.itemCount === null
-        ? `latest ${primaryBotLogin} review on current HEAD carries an unknown number of actionable items (comment count unavailable)`
-        : `latest ${primaryBotLogin} review on current HEAD carries ${review.itemCount} actionable item(s)`;
-    reasons.push(
-      threadClause.satisfied &&
-        review.itemCount !== null &&
-        review.itemCount > 0
-        ? `${itemCountReason} -- no unresolved ${primaryBotLogin}-authored thread accounts for them; check the review body directly for an item suppressed due to low confidence, which counts toward itemCount but never appears in reviewThreads`
-        : itemCountReason,
-    );
+    if (review.itemCount === 0 && review.suppressedCount > 0) {
+      reasons.push(
+        `latest ${primaryBotLogin} review on current HEAD carries ${review.suppressedCount} suppressed comment(s) not reflected in itemCount (posted comment count is 0) -- check the review body directly, since a suppressed finding is never posted as a comment or review thread`,
+      );
+    } else {
+      const itemCountReason =
+        review.itemCount === null
+          ? `latest ${primaryBotLogin} review on current HEAD carries an unknown number of actionable items (comment count unavailable)`
+          : `latest ${primaryBotLogin} review on current HEAD carries ${review.itemCount} actionable item(s)`;
+      // A review can carry both posted comments (itemCount > 0) AND a
+      // suppressed-comments section at once; append a pointer to the
+      // latter rather than silently dropping it from the reported reason.
+      const suppressedSuffix =
+        review.suppressedCount > 0
+          ? ` (plus ${review.suppressedCount} suppressed comment(s) in the review body, not counted in itemCount)`
+          : '';
+      reasons.push(
+        threadClause.satisfied &&
+          review.itemCount !== null &&
+          review.itemCount > 0
+          ? `${itemCountReason}${suppressedSuffix} -- no unresolved ${primaryBotLogin}-authored thread accounts for them; check the review body directly for an item suppressed due to low confidence, which counts toward itemCount but never appears in reviewThreads`
+          : `${itemCountReason}${suppressedSuffix}`,
+      );
+    }
   }
   if (!scopeBlocksConvergenceEval && !threadClause.satisfied) {
     reasons.push(

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -446,6 +446,17 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   // `review-item-count-not-positive`), while `reviewItemCountKnownTerm &&
   // reviewItemCountPositiveTerm` together still reduce to exactly the
   // original `itemCount !== null && itemCount > 0` conjunct.
+  // #1880: `reviewItemCountPositiveTerm` ALSO counts `suppressedCount > 0`
+  // as "positive" -- `itemCount` and `suppressedCount` are both read from
+  // the SAME static review snapshot (never updated by later disposition
+  // activity, same as `itemCount`'s own doc comment on
+  // `AdvisoryConvergenceReviewClause`), so a suppressed-only block is the
+  // identical "nothing else can clear this except a fresh review" shape
+  // #1511's reroll exists for. The token's FAILURE condition stays exactly
+  // as precise as before: `REVIEW_ITEM_COUNT_NOT_POSITIVE` now fires only
+  // when itemCount is a known 0 AND suppressedCount is also 0 -- i.e.
+  // genuinely nothing (posted or suppressed) to reroll for, still an
+  // accurate reading of the existing token name/doc row.
   // #1686: `indeterminate` now also disqualifies a same-HEAD reroll --
   // offering to reroll Copilot is pointless while the underlying claim
   // linkage itself is broken/ambiguous, so this term (and its
@@ -458,7 +469,9 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     dispositionEvidence.missingRegularCommentCount === 0;
   const reviewItemCountKnownTerm = review.itemCount !== null;
   const reviewItemCountPositiveTerm =
-    review.itemCount === null || review.itemCount > 0;
+    review.itemCount === null ||
+    review.itemCount > 0 ||
+    review.suppressedCount > 0;
   const sameHeadRerollTerms = [
     {
       token: SAME_HEAD_REROLL_INELIGIBLE_REASON.SCOPE_NOT_APPLICABLE,

--- a/scripts/review-clause.mjs
+++ b/scripts/review-clause.mjs
@@ -24,6 +24,27 @@
 // dependency surface to that caller.
 import { ghGraphql } from './gh-exec.mjs';
 import { isCopilotReviewerLogin } from './protocol-helpers.mjs';
+
+/** Matches GitHub Copilot's `Suppressed comments (N)` `<summary>` heading,
+ * case-insensitively -- the only structured signal a suppressed finding
+ * leaves in the review body (#1880). */
+const SUPPRESSED_COMMENTS_HEADING_PATTERN = /suppressed comments \((\d+)\)/i;
+/**
+ * Parse the `Suppressed comments (N)` count GitHub Copilot embeds in a
+ * review's top-level body when it folds a low-confidence finding into a
+ * collapsed `<details>` block instead of posting it as a separate review
+ * comment (kurone-kito/idd-skill#1880). Returns `0` when the body carries
+ * no such section, including an absent/empty/unparseable body -- unlike
+ * `itemCount`, there is no distinct "unknown" state to preserve here: a
+ * missing section unambiguously means zero suppressed comments.
+ */
+export function parseSuppressedCommentCount(body) {
+  if (typeof body !== 'string' || body.length === 0) return 0;
+  const match = body.match(SUPPRESSED_COMMENTS_HEADING_PATTERN);
+  if (!match) return 0;
+  const count = Number(match[1]);
+  return Number.isFinite(count) ? count : 0;
+}
 /**
  * `true` when `author` is a verified Copilot (or the configured primary
  * bot login)-authored review/comment -- reuses `isCopilotReviewerLogin`
@@ -74,6 +95,7 @@ export function resolveLatestCopilotReviewClause(
       matchesHead: false,
       itemCount: null,
       submittedAt: '',
+      suppressedCount: 0,
       satisfied: false,
     };
   }
@@ -84,13 +106,21 @@ export function resolveLatestCopilotReviewClause(
       ? Number(latest.itemCount)
       : null
     : null;
+  // #1880: gated by `matchesHead`, mirroring `itemCount` above -- moot for
+  // `satisfied` itself (already gated by `matchesHead &&`), but keeps an
+  // off-HEAD review's report fields consistent with each other rather than
+  // parsing a body this clause is about to ignore anyway.
+  const suppressedCount = matchesHead
+    ? parseSuppressedCommentCount(latest.body)
+    : 0;
   return {
     found: true,
     commitId,
     matchesHead,
     itemCount,
     submittedAt: String(latest.submittedAt ?? ''),
-    satisfied: matchesHead && itemCount === 0,
+    suppressedCount,
+    satisfied: matchesHead && itemCount === 0 && suppressedCount === 0,
   };
 }
 /**
@@ -120,6 +150,7 @@ export function fetchReviewsAndHeadCommit(owner, repo, prNumber) {
                   submittedAt
                   author { login __typename }
                   comments { totalCount }
+                  body
                 }
               }
               commits(last: 1) {
@@ -148,6 +179,7 @@ export function fetchReviewsAndHeadCommit(owner, repo, prNumber) {
     submittedAt: node.submittedAt ?? null,
     commitId: node.commit?.oid ?? null,
     itemCount: node.comments?.totalCount ?? null,
+    body: node.body ?? null,
   }));
   return { reviews, headCommittedAt };
 }

--- a/scripts/review-clause.mjs
+++ b/scripts/review-clause.mjs
@@ -25,10 +25,20 @@
 import { ghGraphql } from './gh-exec.mjs';
 import { isCopilotReviewerLogin } from './protocol-helpers.mjs';
 
-/** Matches GitHub Copilot's `Suppressed comments (N)` `<summary>` heading,
- * case-insensitively -- the only structured signal a suppressed finding
- * leaves in the review body (#1880). */
-const SUPPRESSED_COMMENTS_HEADING_PATTERN = /suppressed comments \((\d+)\)/i;
+/** Matches GitHub Copilot's `<summary>Suppressed comments (N)</summary>`
+ * heading, case-insensitively -- the only structured signal a suppressed
+ * finding leaves in the review body (#1880). Anchored to the surrounding
+ * `<summary>`/`</summary>` tags, not a bare `Suppressed comments (N)`
+ * substring search: this file's own diff (this pattern, its doc comments,
+ * and the regression test fixture) now contains that literal phrase, and
+ * an advisory bot reviewing THIS pull request could quote it back in
+ * ordinary prose (e.g. discussing the test fixture) without wrapping it in
+ * the real HTML tags -- the same prose-quoted-example false-positive class
+ * a marker parser elsewhere in this codebase already hit once
+ * (kurone-kito/idd-skill#1614). Requiring the literal tag pair keeps a
+ * plain-text mention from matching. */
+const SUPPRESSED_COMMENTS_HEADING_PATTERN =
+  /<summary>\s*suppressed comments \((\d+)\)\s*<\/summary>/i;
 /**
  * Parse the `Suppressed comments (N)` count GitHub Copilot embeds in a
  * review's top-level body when it folds a low-confidence finding into a

--- a/scripts/review-clause.mjs
+++ b/scripts/review-clause.mjs
@@ -15,14 +15,17 @@
 // callers already relied on before the extraction.
 //
 // Kept deliberately small (only depends on `gh-exec.mts`'s shared
-// `ghGraphql` and `protocol-helpers.mts`'s shared `isCopilotReviewerLogin`)
-// so a read-only, low-dependency caller like `rerun-advisory-convergence.mts`
-// can import it without also pulling in `advisory-convergence.mts`'s full
-// claim/waiver/disposition machinery -- see that file's own module-header
-// "Reuse map" comment. Both dependencies are already reused directly by
-// `rerun-advisory-convergence.mts` itself today, so this adds no new
-// dependency surface to that caller.
+// `ghGraphql`, `protocol-helpers.mts`'s shared `isCopilotReviewerLogin`,
+// and -- as of #1880 -- `markdown-code.mts`'s shared
+// `stripMarkdownCodeRegions`) so a read-only, low-dependency caller like
+// `rerun-advisory-convergence.mts` can import it without also pulling in
+// `advisory-convergence.mts`'s full claim/waiver/disposition machinery --
+// see that file's own module-header "Reuse map" comment. The first two
+// dependencies are already reused directly by `rerun-advisory-convergence.mts`
+// itself today; `markdown-code.mts` has no imports of its own, so this adds
+// no heavy dependency surface to that caller either.
 import { ghGraphql } from './gh-exec.mjs';
+import { stripMarkdownCodeRegions } from './markdown-code.mjs';
 import { isCopilotReviewerLogin } from './protocol-helpers.mjs';
 
 /** Matches GitHub Copilot's `<summary>Suppressed comments (N)</summary>`
@@ -36,7 +39,9 @@ import { isCopilotReviewerLogin } from './protocol-helpers.mjs';
  * the real HTML tags -- the same prose-quoted-example false-positive class
  * a marker parser elsewhere in this codebase already hit once
  * (kurone-kito/idd-skill#1614). Requiring the literal tag pair keeps a
- * plain-text mention from matching. */
+ * plain-text mention from matching -- but is not sufficient alone: see
+ * {@link parseSuppressedCommentCount}'s own code-region stripping for the
+ * remaining case (the literal tags quoted INSIDE a code span/fence). */
 const SUPPRESSED_COMMENTS_HEADING_PATTERN =
   /<summary>\s*suppressed comments \((\d+)\)\s*<\/summary>/i;
 /**
@@ -47,10 +52,24 @@ const SUPPRESSED_COMMENTS_HEADING_PATTERN =
  * no such section, including an absent/empty/unparseable body -- unlike
  * `itemCount`, there is no distinct "unknown" state to preserve here: a
  * missing section unambiguously means zero suppressed comments.
+ *
+ * Strips fenced/inline Markdown code regions (`stripMarkdownCodeRegions`,
+ * markdown-code.mts) before matching, so a review body that quotes the
+ * literal `<summary>Suppressed comments (N)</summary>` tag pair inside
+ * backticks or a fenced code block (e.g. an advisory bot discussing this
+ * exact detection logic, as happened on this PR's own #1884 Copilot
+ * review) is not mistaken for a real suppressed-comments section -- the
+ * `<summary>`/`</summary>` anchoring above narrows the prose-quoting risk
+ * but does not by itself exclude a code-quoted example; stripping the code
+ * regions first closes that gap the same way #1614's marker-parser fix did.
+ * Real GitHub-rendered `<details>`/`<summary>` markup is raw HTML, never
+ * inside a code span/fence, so this never blanks the genuine heading.
  */
 export function parseSuppressedCommentCount(body) {
   if (typeof body !== 'string' || body.length === 0) return 0;
-  const match = body.match(SUPPRESSED_COMMENTS_HEADING_PATTERN);
+  const match = stripMarkdownCodeRegions(body).match(
+    SUPPRESSED_COMMENTS_HEADING_PATTERN,
+  );
   if (!match) return 0;
   const count = Number(match[1]);
   return Number.isFinite(count) ? count : 0;

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -760,18 +760,41 @@ export function computeAdvisoryConvergenceVerdict(
   // is already resolved and `itemCount` is still positive, no thread query
   // can explain it -- point directly at the review body instead of leaving
   // an agent to re-derive this by hand a second time.
+  //
+  // #1880: a related but distinct incident shape -- the primary bot's
+  // review on current HEAD carries `itemCount: 0` (zero POSTED comments)
+  // while its top-level body still embeds a `Suppressed comments (N)`
+  // block for a finding it chose not to post as a comment at all. The
+  // #1719 branch above only fires when `itemCount > 0`, so this case fell
+  // through to full convergence with an empty `reasons[]` until now (PR
+  // #1875 commit 9711d404). `review.satisfied` (review-clause.mts) is
+  // already gated on `suppressedCount === 0`, so `converged` is already
+  // correctly `false` here -- this branch only supplies the explanation.
   if (!scopeBlocksConvergenceEval && !pending && !review.satisfied) {
-    const itemCountReason =
-      review.itemCount === null
-        ? `latest ${primaryBotLogin} review on current HEAD carries an unknown number of actionable items (comment count unavailable)`
-        : `latest ${primaryBotLogin} review on current HEAD carries ${review.itemCount} actionable item(s)`;
-    reasons.push(
-      threadClause.satisfied &&
-        review.itemCount !== null &&
-        review.itemCount > 0
-        ? `${itemCountReason} -- no unresolved ${primaryBotLogin}-authored thread accounts for them; check the review body directly for an item suppressed due to low confidence, which counts toward itemCount but never appears in reviewThreads`
-        : itemCountReason,
-    );
+    if (review.itemCount === 0 && review.suppressedCount > 0) {
+      reasons.push(
+        `latest ${primaryBotLogin} review on current HEAD carries ${review.suppressedCount} suppressed comment(s) not reflected in itemCount (posted comment count is 0) -- check the review body directly, since a suppressed finding is never posted as a comment or review thread`,
+      );
+    } else {
+      const itemCountReason =
+        review.itemCount === null
+          ? `latest ${primaryBotLogin} review on current HEAD carries an unknown number of actionable items (comment count unavailable)`
+          : `latest ${primaryBotLogin} review on current HEAD carries ${review.itemCount} actionable item(s)`;
+      // A review can carry both posted comments (itemCount > 0) AND a
+      // suppressed-comments section at once; append a pointer to the
+      // latter rather than silently dropping it from the reported reason.
+      const suppressedSuffix =
+        review.suppressedCount > 0
+          ? ` (plus ${review.suppressedCount} suppressed comment(s) in the review body, not counted in itemCount)`
+          : '';
+      reasons.push(
+        threadClause.satisfied &&
+          review.itemCount !== null &&
+          review.itemCount > 0
+          ? `${itemCountReason}${suppressedSuffix} -- no unresolved ${primaryBotLogin}-authored thread accounts for them; check the review body directly for an item suppressed due to low confidence, which counts toward itemCount but never appears in reviewThreads`
+          : `${itemCountReason}${suppressedSuffix}`,
+      );
+    }
   }
   if (!scopeBlocksConvergenceEval && !threadClause.satisfied) {
     reasons.push(

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -848,6 +848,17 @@ export function computeAdvisoryConvergenceVerdict(
   // `review-item-count-not-positive`), while `reviewItemCountKnownTerm &&
   // reviewItemCountPositiveTerm` together still reduce to exactly the
   // original `itemCount !== null && itemCount > 0` conjunct.
+  // #1880: `reviewItemCountPositiveTerm` ALSO counts `suppressedCount > 0`
+  // as "positive" -- `itemCount` and `suppressedCount` are both read from
+  // the SAME static review snapshot (never updated by later disposition
+  // activity, same as `itemCount`'s own doc comment on
+  // `AdvisoryConvergenceReviewClause`), so a suppressed-only block is the
+  // identical "nothing else can clear this except a fresh review" shape
+  // #1511's reroll exists for. The token's FAILURE condition stays exactly
+  // as precise as before: `REVIEW_ITEM_COUNT_NOT_POSITIVE` now fires only
+  // when itemCount is a known 0 AND suppressedCount is also 0 -- i.e.
+  // genuinely nothing (posted or suppressed) to reroll for, still an
+  // accurate reading of the existing token name/doc row.
   // #1686: `indeterminate` now also disqualifies a same-HEAD reroll --
   // offering to reroll Copilot is pointless while the underlying claim
   // linkage itself is broken/ambiguous, so this term (and its
@@ -860,7 +871,9 @@ export function computeAdvisoryConvergenceVerdict(
     dispositionEvidence.missingRegularCommentCount === 0;
   const reviewItemCountKnownTerm = review.itemCount !== null;
   const reviewItemCountPositiveTerm =
-    review.itemCount === null || review.itemCount > 0;
+    review.itemCount === null ||
+    review.itemCount > 0 ||
+    review.suppressedCount > 0;
   const sameHeadRerollTerms: {
     token: SameHeadRerollIneligibleReasonToken;
     satisfied: boolean;

--- a/src/scripts/review-clause.mts
+++ b/src/scripts/review-clause.mts
@@ -15,15 +15,18 @@
 // callers already relied on before the extraction.
 //
 // Kept deliberately small (only depends on `gh-exec.mts`'s shared
-// `ghGraphql` and `protocol-helpers.mts`'s shared `isCopilotReviewerLogin`)
-// so a read-only, low-dependency caller like `rerun-advisory-convergence.mts`
-// can import it without also pulling in `advisory-convergence.mts`'s full
-// claim/waiver/disposition machinery -- see that file's own module-header
-// "Reuse map" comment. Both dependencies are already reused directly by
-// `rerun-advisory-convergence.mts` itself today, so this adds no new
-// dependency surface to that caller.
+// `ghGraphql`, `protocol-helpers.mts`'s shared `isCopilotReviewerLogin`,
+// and -- as of #1880 -- `markdown-code.mts`'s shared
+// `stripMarkdownCodeRegions`) so a read-only, low-dependency caller like
+// `rerun-advisory-convergence.mts` can import it without also pulling in
+// `advisory-convergence.mts`'s full claim/waiver/disposition machinery --
+// see that file's own module-header "Reuse map" comment. The first two
+// dependencies are already reused directly by `rerun-advisory-convergence.mts`
+// itself today; `markdown-code.mts` has no imports of its own, so this adds
+// no heavy dependency surface to that caller either.
 
 import { ghGraphql } from './gh-exec.mts';
+import { stripMarkdownCodeRegions } from './markdown-code.mts';
 import { isCopilotReviewerLogin } from './protocol-helpers.mts';
 
 /** Minimal GitHub GraphQL author payload shape consumed here. `__typename`
@@ -94,7 +97,9 @@ interface RawReviewNode {
  * the real HTML tags -- the same prose-quoted-example false-positive class
  * a marker parser elsewhere in this codebase already hit once
  * (kurone-kito/idd-skill#1614). Requiring the literal tag pair keeps a
- * plain-text mention from matching. */
+ * plain-text mention from matching -- but is not sufficient alone: see
+ * {@link parseSuppressedCommentCount}'s own code-region stripping for the
+ * remaining case (the literal tags quoted INSIDE a code span/fence). */
 const SUPPRESSED_COMMENTS_HEADING_PATTERN =
   /<summary>\s*suppressed comments \((\d+)\)\s*<\/summary>/i;
 
@@ -106,12 +111,26 @@ const SUPPRESSED_COMMENTS_HEADING_PATTERN =
  * no such section, including an absent/empty/unparseable body -- unlike
  * `itemCount`, there is no distinct "unknown" state to preserve here: a
  * missing section unambiguously means zero suppressed comments.
+ *
+ * Strips fenced/inline Markdown code regions (`stripMarkdownCodeRegions`,
+ * markdown-code.mts) before matching, so a review body that quotes the
+ * literal `<summary>Suppressed comments (N)</summary>` tag pair inside
+ * backticks or a fenced code block (e.g. an advisory bot discussing this
+ * exact detection logic, as happened on this PR's own #1884 Copilot
+ * review) is not mistaken for a real suppressed-comments section -- the
+ * `<summary>`/`</summary>` anchoring above narrows the prose-quoting risk
+ * but does not by itself exclude a code-quoted example; stripping the code
+ * regions first closes that gap the same way #1614's marker-parser fix did.
+ * Real GitHub-rendered `<details>`/`<summary>` markup is raw HTML, never
+ * inside a code span/fence, so this never blanks the genuine heading.
  */
 export function parseSuppressedCommentCount(
   body: string | null | undefined,
 ): number {
   if (typeof body !== 'string' || body.length === 0) return 0;
-  const match = body.match(SUPPRESSED_COMMENTS_HEADING_PATTERN);
+  const match = stripMarkdownCodeRegions(body).match(
+    SUPPRESSED_COMMENTS_HEADING_PATTERN,
+  );
   if (!match) return 0;
   const count = Number(match[1]);
   return Number.isFinite(count) ? count : 0;

--- a/src/scripts/review-clause.mts
+++ b/src/scripts/review-clause.mts
@@ -41,6 +41,12 @@ export interface ReviewPayload {
   submittedAt?: string | null;
   commitId?: string | null;
   itemCount?: number | null;
+  /** #1880: the review's top-level body text. GitHub Copilot can fold a
+   * finding into a `<details><summary>Suppressed comments (N)</summary>`
+   * block here instead of posting it as a separate review comment, in
+   * which case `itemCount` (from `comments.totalCount`) stays `0` even
+   * though a real finding exists -- see {@link parseSuppressedCommentCount}. */
+  body?: string | null;
 }
 
 /** Latest-review clause evidence (Clause 1 of `advisory-convergence.mts`'s
@@ -51,6 +57,10 @@ export interface AdvisoryConvergenceReviewClause {
   matchesHead: boolean;
   itemCount: number | null;
   submittedAt: string;
+  /** #1880: count parsed from a `Suppressed comments (N)` heading in the
+   * review body, `0` when no such section is present (or the review is
+   * off-HEAD). See {@link parseSuppressedCommentCount}. */
+  suppressedCount: number;
   satisfied: boolean;
 }
 
@@ -70,6 +80,31 @@ interface RawReviewNode {
   submittedAt?: string | null;
   author?: GhAuthorPayload | null;
   comments?: { totalCount?: number | null } | null;
+  body?: string | null;
+}
+
+/** Matches GitHub Copilot's `Suppressed comments (N)` `<summary>` heading,
+ * case-insensitively -- the only structured signal a suppressed finding
+ * leaves in the review body (#1880). */
+const SUPPRESSED_COMMENTS_HEADING_PATTERN = /suppressed comments \((\d+)\)/i;
+
+/**
+ * Parse the `Suppressed comments (N)` count GitHub Copilot embeds in a
+ * review's top-level body when it folds a low-confidence finding into a
+ * collapsed `<details>` block instead of posting it as a separate review
+ * comment (kurone-kito/idd-skill#1880). Returns `0` when the body carries
+ * no such section, including an absent/empty/unparseable body -- unlike
+ * `itemCount`, there is no distinct "unknown" state to preserve here: a
+ * missing section unambiguously means zero suppressed comments.
+ */
+export function parseSuppressedCommentCount(
+  body: string | null | undefined,
+): number {
+  if (typeof body !== 'string' || body.length === 0) return 0;
+  const match = body.match(SUPPRESSED_COMMENTS_HEADING_PATTERN);
+  if (!match) return 0;
+  const count = Number(match[1]);
+  return Number.isFinite(count) ? count : 0;
 }
 
 /**
@@ -126,6 +161,7 @@ export function resolveLatestCopilotReviewClause(
       matchesHead: false,
       itemCount: null,
       submittedAt: '',
+      suppressedCount: 0,
       satisfied: false,
     };
   }
@@ -136,13 +172,21 @@ export function resolveLatestCopilotReviewClause(
       ? Number(latest.itemCount)
       : null
     : null;
+  // #1880: gated by `matchesHead`, mirroring `itemCount` above -- moot for
+  // `satisfied` itself (already gated by `matchesHead &&`), but keeps an
+  // off-HEAD review's report fields consistent with each other rather than
+  // parsing a body this clause is about to ignore anyway.
+  const suppressedCount = matchesHead
+    ? parseSuppressedCommentCount(latest.body)
+    : 0;
   return {
     found: true,
     commitId,
     matchesHead,
     itemCount,
     submittedAt: String(latest.submittedAt ?? ''),
-    satisfied: matchesHead && itemCount === 0,
+    suppressedCount,
+    satisfied: matchesHead && itemCount === 0 && suppressedCount === 0,
   };
 }
 
@@ -178,6 +222,7 @@ export function fetchReviewsAndHeadCommit(
                   submittedAt
                   author { login __typename }
                   comments { totalCount }
+                  body
                 }
               }
               commits(last: 1) {
@@ -223,6 +268,7 @@ export function fetchReviewsAndHeadCommit(
     submittedAt: node.submittedAt ?? null,
     commitId: node.commit?.oid ?? null,
     itemCount: node.comments?.totalCount ?? null,
+    body: node.body ?? null,
   }));
   return { reviews, headCommittedAt };
 }

--- a/src/scripts/review-clause.mts
+++ b/src/scripts/review-clause.mts
@@ -83,10 +83,20 @@ interface RawReviewNode {
   body?: string | null;
 }
 
-/** Matches GitHub Copilot's `Suppressed comments (N)` `<summary>` heading,
- * case-insensitively -- the only structured signal a suppressed finding
- * leaves in the review body (#1880). */
-const SUPPRESSED_COMMENTS_HEADING_PATTERN = /suppressed comments \((\d+)\)/i;
+/** Matches GitHub Copilot's `<summary>Suppressed comments (N)</summary>`
+ * heading, case-insensitively -- the only structured signal a suppressed
+ * finding leaves in the review body (#1880). Anchored to the surrounding
+ * `<summary>`/`</summary>` tags, not a bare `Suppressed comments (N)`
+ * substring search: this file's own diff (this pattern, its doc comments,
+ * and the regression test fixture) now contains that literal phrase, and
+ * an advisory bot reviewing THIS pull request could quote it back in
+ * ordinary prose (e.g. discussing the test fixture) without wrapping it in
+ * the real HTML tags -- the same prose-quoted-example false-positive class
+ * a marker parser elsewhere in this codebase already hit once
+ * (kurone-kito/idd-skill#1614). Requiring the literal tag pair keeps a
+ * plain-text mention from matching. */
+const SUPPRESSED_COMMENTS_HEADING_PATTERN =
+  /<summary>\s*suppressed comments \((\d+)\)\s*<\/summary>/i;
 
 /**
  * Parse the `Suppressed comments (N)` count GitHub Copilot embeds in a

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -1864,6 +1864,52 @@ test('reasons: a PLAIN-TEXT mention of "Suppressed comments (N)" outside a <summ
   assert.equal(verdict.ready, true);
 });
 
+test('reasons: the literal <summary>...</summary> tag pair QUOTED INSIDE a code span does NOT false-block (PR #1884 Copilot review finding)', () => {
+  // A reviewer discussing this exact detection logic could quote the real
+  // HTML tags back in inline code or a fenced block rather than plain
+  // prose -- the <summary> anchoring alone does not exclude that case;
+  // parseSuppressedCommentCount must strip code regions first.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({
+          itemCount: 0,
+          body: 'consider guarding against a body that contains `<summary>Suppressed comments (1)</summary>` as a quoted example rather than a real heading.',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.suppressedCount, 0);
+  assert.equal(verdict.review.satisfied, true);
+  assert.equal(verdict.converged, true);
+  assert.equal(verdict.ready, true);
+});
+
+test('reasons: the literal <summary>...</summary> tag pair QUOTED INSIDE a fenced code block does NOT false-block', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({
+          itemCount: 0,
+          body: [
+            'Example of the shape to guard against:',
+            '```html',
+            '<summary>Suppressed comments (1)</summary>',
+            '```',
+          ].join('\n'),
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.suppressedCount, 0);
+  assert.equal(verdict.converged, true);
+  assert.equal(verdict.ready, true);
+});
+
 test('reasons: itemCount > 0 AND a suppressed section both mentioned, existing #1719 hint path unaffected', () => {
   const verdict = computeAdvisoryConvergenceVerdict(
     baseInputs({

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -1754,6 +1754,94 @@ test('reasons: itemCount > 0 with an unresolved blocking thread does NOT add the
   assert.match(verdict.reasons.join('\n'), /2 actionable item/);
 });
 
+// --- 9c. Suppressed-only Copilot review findings (#1880) --------------------
+
+const SUPPRESSED_COMMENTS_BODY = [
+  '<details>',
+  '<summary>Suppressed comments (1)</summary>',
+  '',
+  '**tests/idd-onboard.test.mts:2122**',
+  '* This test is described as exercising the documented `cspell lint',
+  '  "**" --no-progress` command path, but it adds an extra `--no-cache`',
+  "  flag that isn't present in the docs or in the repo's own",
+  '  `lint:minimum` script. ...',
+  '</details>',
+].join('\n');
+
+test('reasons: itemCount 0 with a suppressed-comments body section does NOT converge (PR #1875 commit 9711d404 shape)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({ itemCount: 0, body: SUPPRESSED_COMMENTS_BODY }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.pending, false);
+  assert.equal(verdict.review.itemCount, 0);
+  assert.equal(verdict.review.suppressedCount, 1);
+  assert.equal(verdict.review.satisfied, false);
+  assert.equal(verdict.threads.satisfied, true);
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.ready, false);
+  assert.notDeepEqual(verdict.reasons, []);
+  assert.match(verdict.reasons.join('\n'), /1 suppressed comment/);
+  assert.match(verdict.reasons.join('\n'), /check the review body directly/);
+});
+
+test('reasons: itemCount 0 with NO suppressed-comments section still converges normally (no false block)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({
+          itemCount: 0,
+          body: '<details>\n<summary>Some unrelated collapsed section</summary>\nnothing suppressed here\n</details>',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.suppressedCount, 0);
+  assert.equal(verdict.review.satisfied, true);
+  assert.equal(verdict.converged, true);
+  assert.equal(verdict.ready, true);
+  assert.deepEqual(verdict.reasons, []);
+});
+
+test('reasons: itemCount 0 with an empty/absent body still converges normally (no false block)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [copilotReview({ itemCount: 0 })] }), // no body key
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.suppressedCount, 0);
+  assert.equal(verdict.converged, true);
+  assert.equal(verdict.ready, true);
+});
+
+test('reasons: itemCount > 0 AND a suppressed section both mentioned, existing #1719 hint path unaffected', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({ itemCount: 2, body: SUPPRESSED_COMMENTS_BODY }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.itemCount, 2);
+  assert.equal(verdict.review.suppressedCount, 1);
+  assert.equal(verdict.converged, false);
+  assert.match(verdict.reasons.join('\n'), /2 actionable item/);
+  assert.match(
+    verdict.reasons.join('\n'),
+    /check the review body directly for an item suppressed due to low confidence/,
+  );
+  assert.match(verdict.reasons.join('\n'), /1 suppressed comment/);
+});
+
 test('dispositionEvidence: exposes missingRegularCommentCount feeding sameHeadReroll.eligible, plus its missingThreadCount sibling', () => {
   const verdict = computeAdvisoryConvergenceVerdict(
     baseInputs({

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -1193,6 +1193,25 @@ test('sameHeadReroll: eligible when matchesHead, itemCount > 0, and no blocking 
   assert.equal(verdict.sameHeadReroll.requestable, true);
 });
 
+test('sameHeadReroll: eligible when itemCount is 0 but suppressedCount > 0 (#1880 -- the same static-snapshot recovery shape as itemCount > 0)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({
+          itemCount: 0,
+          body: '<details>\n<summary>Suppressed comments (1)</summary>\nnote\n</details>',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.sameHeadReroll.eligible, true);
+  assert.equal(verdict.sameHeadReroll.requestable, true);
+  assert.deepEqual(verdict.sameHeadReroll.ineligibleReasons, []);
+});
+
 test('sameHeadReroll: NOT eligible when itemCount is already 0 (already converged, nothing to reroll)', () => {
   const verdict = computeAdvisoryConvergenceVerdict(
     baseInputs({ reviews: [copilotReview()] }), // itemCount: 0 default

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -1840,6 +1840,30 @@ test('reasons: itemCount 0 with an empty/absent body still converges normally (n
   assert.equal(verdict.ready, true);
 });
 
+test('reasons: a PLAIN-TEXT mention of "Suppressed comments (N)" outside a <summary> tag does NOT false-block (prose-quoted-example class, #1614)', () => {
+  // Simulates an advisory bot quoting the phrase back in ordinary review
+  // prose (e.g. discussing this very fix's test fixture) rather than a
+  // real GitHub-rendered suppressed-comments heading -- the parser must
+  // require the literal <summary>...</summary> wrapper, not a bare
+  // substring match, or reviewing THIS pull request could self-block it.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({
+          itemCount: 0,
+          body: 'nit: the test fixture hardcodes the string "Suppressed comments (1)" -- consider extracting it into a shared constant.',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.suppressedCount, 0);
+  assert.equal(verdict.review.satisfied, true);
+  assert.equal(verdict.converged, true);
+  assert.equal(verdict.ready, true);
+});
+
 test('reasons: itemCount > 0 AND a suppressed section both mentioned, existing #1719 hint path unaffected', () => {
   const verdict = computeAdvisoryConvergenceVerdict(
     baseInputs({

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -562,6 +562,7 @@ const advisoryConvergenceFixture = {
     matchesHead: true,
     itemCount: 0,
     submittedAt: '2026-07-11T10:00:00Z',
+    suppressedCount: 0,
     satisfied: true,
   },
   threads: {


### PR DESCRIPTION
# Summary

`computeAdvisoryConvergenceVerdict` (the F2/F3 merge-readiness gate)
previously derived its Clause 1 actionable-item count only from a
Copilot review's `comments.totalCount` (posted inline comments). When
Copilot instead folds a finding into a collapsed
`<details><summary>Suppressed comments (N)</summary>` block in the
review's top-level body without posting it as a comment,
`comments.totalCount` stays `0`, so the gate reported full convergence
(`converged: true, ready: true, reasons: []`) with a real, unaddressed
finding still sitting in the review body (observed live on PR #1875
commit `9711d404`).

This PR fetches the review `body` via GraphQL, parses the
`Suppressed comments (N)` heading (anchored to the literal
`<summary>...</summary>` wrapper GitHub renders it in, not a bare
substring search), and blocks Clause 1 whenever `N > 0` — the same way
an un-threaded `itemCount > 0` finding already blocks convergence. The
existing #1719 `itemCount > 0` hint path is unchanged.

Also extends the paired same-HEAD reroll recovery mechanism (#1511) to
recognize a suppressed-only block, and hardens the detection regex
against a self-referential prose-quoting false positive (mirrors a
previously-fixed bug class, #1614) — both found during this PR's own
C1 self-review loop; see the three commits for the full rationale of
each.

## Linked issue

Closes #1880

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

A suppressed-only finding currently has no disposition path of its
own — it cannot be cleared by resolving a thread or posting an
Accept/Reject marker, only by a same-HEAD reroll (now covered by this
PR, capped at 2 attempts) or a new commit. This is out of scope for
this fix (the issue's acceptance criteria only ask for detection), but
noted here in case it becomes worth a follow-up issue later.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

`schemas/advisory-convergence.schema.json` gained a new required
`review.suppressedCount` field (integer, minimum 0); every existing
consumer (three test files) was updated in the same commit set.

## Verification

- [x] `pnpm lint` (via `biome check`, `dprint check`, `markdownlint-cli2`)
- [x] `pnpm test` (`node --test tests/*.test.mts`, 3203/3203 pass)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`docs/idd-helper-scripts.md` and its
      `idd-template/` source are byte-identical, verified via
      `node scripts/sync-docs.mjs --apply`)
- [x] `node scripts/idd-doctor.mjs` (passes; only pre-existing,
      unrelated warnings)
- [x] `pnpm run build:check` and `pnpm run typecheck` also pass

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (this PR touches the merge-gate
      helper itself; see the "ironic but important" self-check note
      below)
- [x] Context budget impact reviewed (no instruction-file changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Copilot-suppressed findings are now included when determining advisory review convergence.
  - Reviews with suppressed findings correctly remain non-converged and ineligible for same-HEAD reroll recovery.
  - Convergence and reroll messages now provide clearer details for visible and suppressed findings.

- **Documentation**
  - Updated guidance to explain suppressed-comment handling and eligibility rules.

- **Tests**
  - Added coverage for suppressed-only reviews, mixed findings, and invalid or unrelated review content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->