### PR TITLE
fix(suitability-triage): require PR to reference candidate issue

### DIFF
--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -25,9 +25,10 @@ import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
 import {
   buildClosedByMergedPrArgs,
   buildMergedPrListArgs,
-  buildPrFilesArgs,
+  buildPrDetailArgs,
   evaluateHighConfidenceDuplicate,
   findCandidateFileOverlap,
+  prReferencesIssue,
   resolveCandidateFileSet,
 } from './supersession-detection.mjs';
 
@@ -491,6 +492,7 @@ export function checkTrustSafety(context) {
 export function checkDuplicateOrSuperseded(context) {
   const highConfidence = evaluateHighConfidenceDuplicate(
     context.highConfidenceDuplicate,
+    context.issue.number,
   );
   if (highConfidence) {
     return highConfidence;
@@ -890,6 +892,7 @@ function runCli() {
           issue.createdAt,
           candidateFiles,
           highContentionFiles,
+          issue.number,
         );
         mergedPrs = scanResult.mergedPrs;
         if (scanResult.truncatedByDeadline) {
@@ -1096,6 +1099,15 @@ function normalizeHighConfidenceMergedPrs(value) {
         number: Number(e.number),
         mergedAt: String(e.mergedAt ?? ''),
         files: normalizeStringArray(e.files),
+        // #1878: same-issue-reference evidence, normalized the same
+        // fail-safe way as every other field on this options boundary --
+        // a malformed shape degrades to "no reference" rather than crashing
+        // or manufacturing a match.
+        closingIssuesReferences: normalizePositiveIntArray(
+          e.closingIssuesReferences,
+        ),
+        title: String(e.title ?? ''),
+        body: String(e.body ?? ''),
       };
     })
     .filter((entry) => Number.isInteger(entry.number) && entry.number > 0);
@@ -1173,7 +1185,7 @@ function fetchDuplicateCandidates(repoRef, issue) {
 }
 // --- #1484: high-confidence Check 4 tier CLI glue ---------------------------
 // The pure argv-builders (`buildClosedByMergedPrArgs`, `buildMergedPrListArgs`,
-// `buildPrFilesArgs`) and the evaluation kernel (`evaluateHighConfidenceDuplicate`)
+// `buildPrDetailArgs`) and the evaluation kernel (`evaluateHighConfidenceDuplicate`)
 // moved to `supersession-detection.mts` (#1499); this file keeps only the
 // `gh`-executing orchestration below (fetch, try/catch, deadline budget,
 // `collectionWarnings`), which the issue does not name as part of the
@@ -1254,12 +1266,22 @@ function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
  * `candidateFiles` / `highContentionFiles` (#1815) let the scan stop early:
  * `evaluateHighConfidenceDuplicate` only needs the FIRST merged PR (in scan
  * order) whose changed files overlap the exclusion-adjusted candidate set
- * to return a high-confidence fail -- every PR after it would otherwise be
- * fetched and then ignored. `resolveCandidateFileSet` /
- * `findCandidateFileOverlap` (`supersession-detection.mts`) are the exact
- * same helpers `evaluateHighConfidenceDuplicate` itself now uses, so the
- * PR this loop stops on is provably the same PR the downstream evaluation
- * would stop on -- no evidence-content change, only fewer PRs fetched.
+ * AND references `candidateIssueNumber` itself (#1878; see
+ * `prReferencesIssue` in `supersession-detection.mts`) to return a
+ * high-confidence fail -- every PR after it would otherwise be fetched and
+ * then ignored. `resolveCandidateFileSet` / `findCandidateFileOverlap` /
+ * `prReferencesIssue` (`supersession-detection.mts`) are the exact same
+ * helpers `evaluateHighConfidenceDuplicate` itself now uses, so the PR
+ * this loop stops on is provably the same PR the downstream evaluation
+ * would stop on -- no evidence-content change, only fewer PRs fetched. A
+ * merged PR whose files overlap but that never references the candidate
+ * (the #1862-vs-#1863/PR#1864 false positive #1878 fixes) no longer stops
+ * the scan -- every merged PR in the window is now fetched in that case,
+ * which is the fail-safe direction (worst case, a `truncatedByDeadline`
+ * scan degrades Check 4 to exact-title-only, never a false high-confidence
+ * hit) but does mean `MERGED_PR_SCAN_DEADLINE_MS` is reached far more
+ * often for a candidate whose files are shared across an entire roadmap of
+ * siblings, none of which reference it individually.
  * Exported (not just called) so `fetchMergedPrFileOverlapEvidence` can be
  * unit-tested directly against a stubbed `gh` on `PATH`, the way this
  * repo's other `gh`-calling functions are exercised (see
@@ -1270,6 +1292,7 @@ export function fetchMergedPrFileOverlapEvidence(
   sinceIso,
   candidateFiles,
   highContentionFiles,
+  candidateIssueNumber,
 ) {
   const list = ghJsonArray(buildMergedPrListArgs(repoRef, sinceIso));
   const mergedPrs = [];
@@ -1289,19 +1312,42 @@ export function fetchMergedPrFileOverlapEvidence(
     if (!Number.isInteger(number) || number <= 0) {
       continue;
     }
-    const files = runGh(buildPrFilesArgs(repoRef, number))
-      .split('\n')
-      .map((line) => line.trim())
+    const detail = ghJson(buildPrDetailArgs(repoRef, number));
+    const files = (Array.isArray(detail.files) ? detail.files : [])
+      .map((file) => String(file?.path ?? ''))
       .filter(Boolean);
-    mergedPrs.push({ number, mergedAt: String(pr.mergedAt ?? ''), files });
-    if (findCandidateFileOverlap(files, candidateSet).length > 0) {
-      // Qualifying overlap found (#1815): stop -- see the doc comment
-      // above. Deliberately a plain `break`, NOT `truncatedByDeadline =
-      // true`: this is a complete, successful scan that found its answer
-      // early, not a scan cut short before finishing. Setting the flag
-      // here would wrongly push a `collectionWarnings` entry in `runCli`,
-      // which degrades Check 4 to exact-title-only -- silently turning a
-      // genuine high-confidence hit into a false pass.
+    const closingIssuesReferences = (
+      Array.isArray(detail.closingIssuesReferences)
+        ? detail.closingIssuesReferences
+        : []
+    )
+      .map((ref) => Number(ref?.number))
+      .filter((n) => Number.isInteger(n) && n > 0);
+    const title = String(detail.title ?? '');
+    const body = String(detail.body ?? '');
+    mergedPrs.push({
+      number,
+      mergedAt: String(pr.mergedAt ?? ''),
+      files,
+      closingIssuesReferences,
+      title,
+      body,
+    });
+    if (
+      findCandidateFileOverlap(files, candidateSet).length > 0 &&
+      prReferencesIssue(
+        { closingIssuesReferences, title, body },
+        candidateIssueNumber,
+      )
+    ) {
+      // Qualifying overlap + same-issue reference found (#1815, #1878):
+      // stop -- see the doc comment above. Deliberately a plain `break`,
+      // NOT `truncatedByDeadline = true`: this is a complete, successful
+      // scan that found its answer early, not a scan cut short before
+      // finishing. Setting the flag here would wrongly push a
+      // `collectionWarnings` entry in `runCli`, which degrades Check 4 to
+      // exact-title-only -- silently turning a genuine high-confidence hit
+      // into a false pass.
       break;
     }
   }

--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -128,7 +128,19 @@ export function prReferencesIssue(pr, issueNumber) {
   ) {
     return true;
   }
-  const pattern = new RegExp(`#${issueNumber}\\b`);
+  // Copilot review finding on PR #1886: a trailing `\b` alone only rejects
+  // a longer number sharing the digit prefix (`#18620` vs `1862`) -- it
+  // does NOT reject a word character immediately before `#` (`\b` requires
+  // one side `\w`, so `\b#` would require a `\w` before `#`, the opposite
+  // of what's needed here). `foo#1862` matched with only a trailing `\b`,
+  // which is not "word-bounded" as the issue's algorithm describes and
+  // could reintroduce a false positive from an incidental substring in a
+  // PR title/body. `(?<!\w)` requires the character immediately before `#`
+  // (if any) to NOT be a word character, rejecting `foo#1862` while still
+  // matching every legitimate form (start-of-string, whitespace, or
+  // punctuation before `#`: `#1862`, `Refs #1862`, `Closes #1862`,
+  // `(#1862)`).
+  const pattern = new RegExp(`(?<!\\w)#${issueNumber}\\b`);
   const title = typeof pr.title === 'string' ? pr.title : '';
   const body = typeof pr.body === 'string' ? pr.body : '';
   return pattern.test(title) || pattern.test(body);

--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -86,20 +86,63 @@ export function findCandidateFileOverlap(files, candidateSet) {
   ].filter((file) => candidateSet.has(file));
 }
 /**
+ * Word-bounded `#<issueNumber>` cross-reference test (#1878), matched
+ * against a merged PR's `closingIssuesReferences` connection first, falling
+ * back to a plain regex scan of `title`/`body`. `\b` after the digits
+ * rejects a longer number sharing the same prefix (`#18620` does not match
+ * `issueNumber: 1862`, since two digits share no word boundary), while still
+ * matching every form the issue names: `#1862`, `Refs #1862`,
+ * `Closes #1862`. Deliberately does not mask markdown code regions first
+ * (unlike `checkDuplicateOrSuperseded`'s own free-text declaration scan) --
+ * the issue pins a plain substring/regex check with no masking step, and a
+ * `#<number>` cross-reference inside a code span or fence is not a realistic
+ * false-positive vector for this specific pattern.
+ *
+ * Defensive against a malformed `pr` shape the same way the rest of this
+ * kernel is: a non-array `closingIssuesReferences` or non-string
+ * `title`/`body` degrades to "no reference" rather than throwing, and an
+ * invalid `issueNumber` (non-positive-integer) always returns `false`.
+ */
+export function prReferencesIssue(pr, issueNumber) {
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+    return false;
+  }
+  const closing = Array.isArray(pr.closingIssuesReferences)
+    ? pr.closingIssuesReferences
+    : [];
+  if (closing.some((entry) => Number(entry) === issueNumber)) {
+    return true;
+  }
+  const pattern = new RegExp(`#${issueNumber}\\b`);
+  const title = typeof pr.title === 'string' ? pr.title : '';
+  const body = typeof pr.body === 'string' ? pr.body : '';
+  return pattern.test(title) || pattern.test(body);
+}
+/**
  * High-confidence Check 4 tier (#1484): evaluate the mechanical B2.0-style
  * signals -- a merged closing-PR reference on the candidate issue itself, or
  * a merged PR that already changed one of the issue's own declared
- * `## Candidate files` (excluding high-contention/shared files, which many
- * unrelated issues touch and so are not on their own high-confidence
- * evidence that THIS issue was superseded). Returns `null` -- never a
- * synthesized verdict of its own -- whenever no strong signal fires, so the
- * caller falls through to its own existing weak title/declaration heuristic
- * unchanged. This is the fail-safe contract the issue requires: never fail
- * TOWARD a false high-confidence flag. `input` may be `undefined` (evidence
- * not collected by the caller) or a partially malformed shape; both degrade
- * to "no verdict" rather than a crash or a false hit.
+ * `## Candidate files` **and** references the candidate issue itself
+ * (#1878; see `prReferencesIssue` above) -- excluding high-contention/shared
+ * files, which many unrelated issues touch and so are not on their own
+ * high-confidence evidence that THIS issue was superseded. Returns `null`
+ * -- never a synthesized verdict of its own -- whenever no strong signal
+ * fires, so the caller falls through to its own existing weak
+ * title/declaration heuristic unchanged. This is the fail-safe contract the
+ * issue requires: never fail TOWARD a false high-confidence flag. `input`
+ * may be `undefined` (evidence not collected by the caller) or a partially
+ * malformed shape; both degrade to "no verdict" rather than a crash or a
+ * false hit.
+ *
+ * `candidateIssueNumber` is required (#1878, not optional/defaulted):
+ * Signal 2 below cannot decide "references the candidate" without knowing
+ * which issue is the candidate, and a silently-defaulted value (e.g. `0` or
+ * `NaN`) would either always or never match depending on the default
+ * chosen -- neither is a safe implicit behavior for a check whose whole
+ * contract is "never fail toward a false positive". A missing caller-side
+ * argument is a compile-time error instead.
  */
-export function evaluateHighConfidenceDuplicate(input) {
+export function evaluateHighConfidenceDuplicate(input, candidateIssueNumber) {
   if (!input) {
     return null;
   }
@@ -109,6 +152,11 @@ export function evaluateHighConfidenceDuplicate(input) {
       : []
   ).filter((n) => Number.isInteger(n) && n > 0);
   if (closedByMergedPrNumbers.length > 0) {
+    // #1878: already an inherent same-issue reference -- this signal comes
+    // from the CANDIDATE issue's own `closedByPullRequestsReferences`
+    // connection (`fetchClosedByMergedPrNumbers` in `suitability-triage.mts`),
+    // so a hit here already means a merged PR closes THIS issue. No
+    // additional `prReferencesIssue` check applies to this signal.
     return {
       pass: false,
       evidence: `High-confidence duplicate: issue is already referenced by merged closing PR(s) #${closedByMergedPrNumbers.join(', #')} (closedByPullRequestsReferences).`,
@@ -131,14 +179,25 @@ export function evaluateHighConfidenceDuplicate(input) {
     }
     const files = Array.isArray(pr.files) ? pr.files : [];
     const overlap = findCandidateFileOverlap(files, candidateSet);
-    if (overlap.length > 0) {
-      const mergedAt = String(pr.mergedAt ?? '');
-      return {
-        pass: false,
-        evidence: `High-confidence duplicate: merged PR #${number}${mergedAt ? ` (merged ${mergedAt})` : ''} already changed candidate file(s): ${overlap.sort().join(', ')}.`,
-        tier: 'high-confidence',
-      };
+    if (overlap.length === 0) {
+      continue;
     }
+    if (!prReferencesIssue(pr, candidateIssueNumber)) {
+      // #1878: file overlap alone is no longer sufficient -- a merged
+      // sibling-roadmap PR can legitimately touch the same shared file
+      // without ever mentioning THIS candidate issue (the #1862-vs-#1863/
+      // PR#1864 false positive this issue fixes). Fall through to the
+      // NEXT merged PR in scan order instead of returning here, so a
+      // later PR in the same window that both overlaps and references the
+      // candidate is still detected.
+      continue;
+    }
+    const mergedAt = String(pr.mergedAt ?? '');
+    return {
+      pass: false,
+      evidence: `High-confidence duplicate: merged PR #${number}${mergedAt ? ` (merged ${mergedAt})` : ''} already changed candidate file(s): ${overlap.sort().join(', ')} and references issue #${candidateIssueNumber}.`,
+      tier: 'high-confidence',
+    };
   }
   return null;
 }
@@ -197,8 +256,15 @@ export function buildMergedPrListArgs(repoRef, sinceIso) {
     String(MERGED_PR_SCAN_LIMIT),
   ];
 }
-/** Argv for one merged PR's changed-file list. */
-export function buildPrFilesArgs(repoRef, prNumber) {
+/**
+ * Argv for one merged PR's changed-file list plus the same-issue-reference
+ * evidence #1878 adds (`title`, `body`, `closingIssuesReferences`) --
+ * requested on this single existing `gh pr view` call rather than a second
+ * one, matching the issue's own "no new API calls needed" framing. Returns
+ * the full JSON object (no `--jq` projection) since the caller now needs
+ * more than one field; `.files[].path` extraction moves to the caller.
+ */
+export function buildPrDetailArgs(repoRef, prNumber) {
   return [
     'pr',
     'view',
@@ -206,8 +272,6 @@ export function buildPrFilesArgs(repoRef, prNumber) {
     '--repo',
     repoRef,
     '--json',
-    'files',
-    '--jq',
-    '.files[].path',
+    'files,title,body,closingIssuesReferences',
   ];
 }

--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -110,7 +110,22 @@ export function prReferencesIssue(pr, issueNumber) {
   const closing = Array.isArray(pr.closingIssuesReferences)
     ? pr.closingIssuesReferences
     : [];
-  if (closing.some((entry) => Number(entry) === issueNumber)) {
+  // Copilot review finding on PR #1886: accept both a raw number entry
+  // (the shape suitability-triage.mts's own caller already normalizes to
+  // before calling this function) and a raw `{ number }` object entry (the
+  // shape `gh pr view --json closingIssuesReferences` itself actually
+  // returns, confirmed empirically) -- `Number({ number: 1862 })` alone
+  // evaluates to `NaN` and would silently degrade a true match to "no
+  // reference" if a future caller ever passed the unnormalized `gh`
+  // payload straight through.
+  if (
+    closing.some((entry) => {
+      if (entry !== null && typeof entry === 'object') {
+        return Number(entry.number) === issueNumber;
+      }
+      return Number(entry) === issueNumber;
+    })
+  ) {
     return true;
   }
   const pattern = new RegExp(`#${issueNumber}\\b`);

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -27,12 +27,13 @@ import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
 import {
   buildClosedByMergedPrArgs,
   buildMergedPrListArgs,
-  buildPrFilesArgs,
+  buildPrDetailArgs,
   type CheckOutcome,
   evaluateHighConfidenceDuplicate,
   findCandidateFileOverlap,
   type HighConfidenceDuplicateInput,
   type HighConfidenceMergedPr,
+  prReferencesIssue,
   resolveCandidateFileSet,
 } from './supersession-detection.mts';
 
@@ -632,6 +633,7 @@ export function checkTrustSafety(context: Context): CheckOutcome {
 export function checkDuplicateOrSuperseded(context: Context): CheckOutcome {
   const highConfidence = evaluateHighConfidenceDuplicate(
     context.highConfidenceDuplicate,
+    context.issue.number,
   );
   if (highConfidence) {
     return highConfidence;
@@ -1065,6 +1067,7 @@ function runCli(): void {
           issue.createdAt,
           candidateFiles,
           highContentionFiles,
+          issue.number,
         );
         mergedPrs = scanResult.mergedPrs;
         if (scanResult.truncatedByDeadline) {
@@ -1302,11 +1305,23 @@ function normalizeHighConfidenceMergedPrs(
         number?: unknown;
         mergedAt?: unknown;
         files?: unknown;
+        closingIssuesReferences?: unknown;
+        title?: unknown;
+        body?: unknown;
       };
       return {
         number: Number(e.number),
         mergedAt: String(e.mergedAt ?? ''),
         files: normalizeStringArray(e.files),
+        // #1878: same-issue-reference evidence, normalized the same
+        // fail-safe way as every other field on this options boundary --
+        // a malformed shape degrades to "no reference" rather than crashing
+        // or manufacturing a match.
+        closingIssuesReferences: normalizePositiveIntArray(
+          e.closingIssuesReferences,
+        ),
+        title: String(e.title ?? ''),
+        body: String(e.body ?? ''),
       };
     })
     .filter((entry) => Number.isInteger(entry.number) && entry.number > 0);
@@ -1410,7 +1425,7 @@ function fetchDuplicateCandidates(
 
 // --- #1484: high-confidence Check 4 tier CLI glue ---------------------------
 // The pure argv-builders (`buildClosedByMergedPrArgs`, `buildMergedPrListArgs`,
-// `buildPrFilesArgs`) and the evaluation kernel (`evaluateHighConfidenceDuplicate`)
+// `buildPrDetailArgs`) and the evaluation kernel (`evaluateHighConfidenceDuplicate`)
 // moved to `supersession-detection.mts` (#1499); this file keeps only the
 // `gh`-executing orchestration below (fetch, try/catch, deadline budget,
 // `collectionWarnings`), which the issue does not name as part of the
@@ -1519,12 +1534,22 @@ interface MergedPrFileOverlapScanResult {
  * `candidateFiles` / `highContentionFiles` (#1815) let the scan stop early:
  * `evaluateHighConfidenceDuplicate` only needs the FIRST merged PR (in scan
  * order) whose changed files overlap the exclusion-adjusted candidate set
- * to return a high-confidence fail -- every PR after it would otherwise be
- * fetched and then ignored. `resolveCandidateFileSet` /
- * `findCandidateFileOverlap` (`supersession-detection.mts`) are the exact
- * same helpers `evaluateHighConfidenceDuplicate` itself now uses, so the
- * PR this loop stops on is provably the same PR the downstream evaluation
- * would stop on -- no evidence-content change, only fewer PRs fetched.
+ * AND references `candidateIssueNumber` itself (#1878; see
+ * `prReferencesIssue` in `supersession-detection.mts`) to return a
+ * high-confidence fail -- every PR after it would otherwise be fetched and
+ * then ignored. `resolveCandidateFileSet` / `findCandidateFileOverlap` /
+ * `prReferencesIssue` (`supersession-detection.mts`) are the exact same
+ * helpers `evaluateHighConfidenceDuplicate` itself now uses, so the PR
+ * this loop stops on is provably the same PR the downstream evaluation
+ * would stop on -- no evidence-content change, only fewer PRs fetched. A
+ * merged PR whose files overlap but that never references the candidate
+ * (the #1862-vs-#1863/PR#1864 false positive #1878 fixes) no longer stops
+ * the scan -- every merged PR in the window is now fetched in that case,
+ * which is the fail-safe direction (worst case, a `truncatedByDeadline`
+ * scan degrades Check 4 to exact-title-only, never a false high-confidence
+ * hit) but does mean `MERGED_PR_SCAN_DEADLINE_MS` is reached far more
+ * often for a candidate whose files are shared across an entire roadmap of
+ * siblings, none of which reference it individually.
  * Exported (not just called) so `fetchMergedPrFileOverlapEvidence` can be
  * unit-tested directly against a stubbed `gh` on `PATH`, the way this
  * repo's other `gh`-calling functions are exercised (see
@@ -1535,6 +1560,7 @@ export function fetchMergedPrFileOverlapEvidence(
   sinceIso: string,
   candidateFiles: string[],
   highContentionFiles: string[],
+  candidateIssueNumber: number,
 ): MergedPrFileOverlapScanResult {
   const list = ghJsonArray(buildMergedPrListArgs(repoRef, sinceIso));
   const mergedPrs: HighConfidenceMergedPr[] = [];
@@ -1554,19 +1580,47 @@ export function fetchMergedPrFileOverlapEvidence(
     if (!Number.isInteger(number) || number <= 0) {
       continue;
     }
-    const files = runGh(buildPrFilesArgs(repoRef, number))
-      .split('\n')
-      .map((line) => line.trim())
+    const detail = ghJson(buildPrDetailArgs(repoRef, number)) as {
+      files?: { path?: unknown }[];
+      title?: unknown;
+      body?: unknown;
+      closingIssuesReferences?: { number?: unknown }[];
+    };
+    const files = (Array.isArray(detail.files) ? detail.files : [])
+      .map((file) => String(file?.path ?? ''))
       .filter(Boolean);
-    mergedPrs.push({ number, mergedAt: String(pr.mergedAt ?? ''), files });
-    if (findCandidateFileOverlap(files, candidateSet).length > 0) {
-      // Qualifying overlap found (#1815): stop -- see the doc comment
-      // above. Deliberately a plain `break`, NOT `truncatedByDeadline =
-      // true`: this is a complete, successful scan that found its answer
-      // early, not a scan cut short before finishing. Setting the flag
-      // here would wrongly push a `collectionWarnings` entry in `runCli`,
-      // which degrades Check 4 to exact-title-only -- silently turning a
-      // genuine high-confidence hit into a false pass.
+    const closingIssuesReferences = (
+      Array.isArray(detail.closingIssuesReferences)
+        ? detail.closingIssuesReferences
+        : []
+    )
+      .map((ref) => Number(ref?.number))
+      .filter((n) => Number.isInteger(n) && n > 0);
+    const title = String(detail.title ?? '');
+    const body = String(detail.body ?? '');
+    mergedPrs.push({
+      number,
+      mergedAt: String(pr.mergedAt ?? ''),
+      files,
+      closingIssuesReferences,
+      title,
+      body,
+    });
+    if (
+      findCandidateFileOverlap(files, candidateSet).length > 0 &&
+      prReferencesIssue(
+        { closingIssuesReferences, title, body },
+        candidateIssueNumber,
+      )
+    ) {
+      // Qualifying overlap + same-issue reference found (#1815, #1878):
+      // stop -- see the doc comment above. Deliberately a plain `break`,
+      // NOT `truncatedByDeadline = true`: this is a complete, successful
+      // scan that found its answer early, not a scan cut short before
+      // finishing. Setting the flag here would wrongly push a
+      // `collectionWarnings` entry in `runCli`, which degrades Check 4 to
+      // exact-title-only -- silently turning a genuine high-confidence hit
+      // into a false pass.
       break;
     }
   }

--- a/src/scripts/supersession-detection.mts
+++ b/src/scripts/supersession-detection.mts
@@ -50,11 +50,36 @@ const CLOSED_BY_MERGED_PR_QUERY = `query($owner:String!,$repo:String!,$number:In
   }
 }`;
 
-/** One merged PR's changed-file evidence for the high-confidence tier (#1484). */
+/**
+ * One merged PR's changed-file evidence for the high-confidence tier
+ * (#1484), plus the same-issue-reference evidence #1878 adds:
+ * `closingIssuesReferences`/`title`/`body` let
+ * {@link evaluateHighConfidenceDuplicate} confirm the PR references the
+ * candidate issue itself, not merely a file it happens to share. All three
+ * are required (not optional) so a caller that starts populating
+ * `mergedPrs` must supply them -- an omitted field defaults to "no
+ * reference", the fail-safe direction, but `tsc` still forces every
+ * construction site to make that a deliberate choice instead of a silent
+ * `undefined`.
+ */
 export interface HighConfidenceMergedPr {
   number: number;
   mergedAt: string;
   files: string[];
+  /** Issue numbers this merged PR's `closingIssuesReferences` connection
+   * includes (#1878). Distinct from Signal 1's own
+   * `closedByMergedPrNumbers` (below): that signal is gated on the
+   * candidate issue's own `state` being `CLOSED` (see
+   * `fetchClosedByMergedPrNumbers` in `suitability-triage.mts`), so a
+   * reopened candidate whose sibling PR merged with `Closes #candidate`
+   * is caught here, in Signal 2, and not by Signal 1. */
+  closingIssuesReferences: number[];
+  /** PR title (#1878): scanned for a `#<candidate-number>` cross-reference
+   * when `closingIssuesReferences` doesn't already include the candidate. */
+  title: string;
+  /** PR body (#1878): scanned for a `#<candidate-number>` cross-reference
+   * when `closingIssuesReferences` doesn't already include the candidate. */
+  body: string;
 }
 
 /**
@@ -144,21 +169,73 @@ export function findCandidateFileOverlap(
 }
 
 /**
+ * Word-bounded `#<issueNumber>` cross-reference test (#1878), matched
+ * against a merged PR's `closingIssuesReferences` connection first, falling
+ * back to a plain regex scan of `title`/`body`. `\b` after the digits
+ * rejects a longer number sharing the same prefix (`#18620` does not match
+ * `issueNumber: 1862`, since two digits share no word boundary), while still
+ * matching every form the issue names: `#1862`, `Refs #1862`,
+ * `Closes #1862`. Deliberately does not mask markdown code regions first
+ * (unlike `checkDuplicateOrSuperseded`'s own free-text declaration scan) --
+ * the issue pins a plain substring/regex check with no masking step, and a
+ * `#<number>` cross-reference inside a code span or fence is not a realistic
+ * false-positive vector for this specific pattern.
+ *
+ * Defensive against a malformed `pr` shape the same way the rest of this
+ * kernel is: a non-array `closingIssuesReferences` or non-string
+ * `title`/`body` degrades to "no reference" rather than throwing, and an
+ * invalid `issueNumber` (non-positive-integer) always returns `false`.
+ */
+export function prReferencesIssue(
+  pr: {
+    closingIssuesReferences?: unknown;
+    title?: unknown;
+    body?: unknown;
+  },
+  issueNumber: number,
+): boolean {
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+    return false;
+  }
+  const closing = Array.isArray(pr.closingIssuesReferences)
+    ? pr.closingIssuesReferences
+    : [];
+  if (closing.some((entry) => Number(entry) === issueNumber)) {
+    return true;
+  }
+  const pattern = new RegExp(`#${issueNumber}\\b`);
+  const title = typeof pr.title === 'string' ? pr.title : '';
+  const body = typeof pr.body === 'string' ? pr.body : '';
+  return pattern.test(title) || pattern.test(body);
+}
+
+/**
  * High-confidence Check 4 tier (#1484): evaluate the mechanical B2.0-style
  * signals -- a merged closing-PR reference on the candidate issue itself, or
  * a merged PR that already changed one of the issue's own declared
- * `## Candidate files` (excluding high-contention/shared files, which many
- * unrelated issues touch and so are not on their own high-confidence
- * evidence that THIS issue was superseded). Returns `null` -- never a
- * synthesized verdict of its own -- whenever no strong signal fires, so the
- * caller falls through to its own existing weak title/declaration heuristic
- * unchanged. This is the fail-safe contract the issue requires: never fail
- * TOWARD a false high-confidence flag. `input` may be `undefined` (evidence
- * not collected by the caller) or a partially malformed shape; both degrade
- * to "no verdict" rather than a crash or a false hit.
+ * `## Candidate files` **and** references the candidate issue itself
+ * (#1878; see `prReferencesIssue` above) -- excluding high-contention/shared
+ * files, which many unrelated issues touch and so are not on their own
+ * high-confidence evidence that THIS issue was superseded. Returns `null`
+ * -- never a synthesized verdict of its own -- whenever no strong signal
+ * fires, so the caller falls through to its own existing weak
+ * title/declaration heuristic unchanged. This is the fail-safe contract the
+ * issue requires: never fail TOWARD a false high-confidence flag. `input`
+ * may be `undefined` (evidence not collected by the caller) or a partially
+ * malformed shape; both degrade to "no verdict" rather than a crash or a
+ * false hit.
+ *
+ * `candidateIssueNumber` is required (#1878, not optional/defaulted):
+ * Signal 2 below cannot decide "references the candidate" without knowing
+ * which issue is the candidate, and a silently-defaulted value (e.g. `0` or
+ * `NaN`) would either always or never match depending on the default
+ * chosen -- neither is a safe implicit behavior for a check whose whole
+ * contract is "never fail toward a false positive". A missing caller-side
+ * argument is a compile-time error instead.
  */
 export function evaluateHighConfidenceDuplicate(
   input: HighConfidenceDuplicateInput | undefined,
+  candidateIssueNumber: number,
 ): CheckOutcome | null {
   if (!input) {
     return null;
@@ -170,6 +247,11 @@ export function evaluateHighConfidenceDuplicate(
       : []
   ).filter((n) => Number.isInteger(n) && n > 0);
   if (closedByMergedPrNumbers.length > 0) {
+    // #1878: already an inherent same-issue reference -- this signal comes
+    // from the CANDIDATE issue's own `closedByPullRequestsReferences`
+    // connection (`fetchClosedByMergedPrNumbers` in `suitability-triage.mts`),
+    // so a hit here already means a merged PR closes THIS issue. No
+    // additional `prReferencesIssue` check applies to this signal.
     return {
       pass: false,
       evidence: `High-confidence duplicate: issue is already referenced by merged closing PR(s) #${closedByMergedPrNumbers.join(', #')} (closedByPullRequestsReferences).`,
@@ -193,6 +275,9 @@ export function evaluateHighConfidenceDuplicate(
       number?: unknown;
       mergedAt?: unknown;
       files?: unknown;
+      closingIssuesReferences?: unknown;
+      title?: unknown;
+      body?: unknown;
     };
     const number = Number(pr.number);
     if (!Number.isInteger(number) || number <= 0) {
@@ -200,14 +285,25 @@ export function evaluateHighConfidenceDuplicate(
     }
     const files = Array.isArray(pr.files) ? pr.files : [];
     const overlap = findCandidateFileOverlap(files, candidateSet);
-    if (overlap.length > 0) {
-      const mergedAt = String(pr.mergedAt ?? '');
-      return {
-        pass: false,
-        evidence: `High-confidence duplicate: merged PR #${number}${mergedAt ? ` (merged ${mergedAt})` : ''} already changed candidate file(s): ${overlap.sort().join(', ')}.`,
-        tier: 'high-confidence',
-      };
+    if (overlap.length === 0) {
+      continue;
     }
+    if (!prReferencesIssue(pr, candidateIssueNumber)) {
+      // #1878: file overlap alone is no longer sufficient -- a merged
+      // sibling-roadmap PR can legitimately touch the same shared file
+      // without ever mentioning THIS candidate issue (the #1862-vs-#1863/
+      // PR#1864 false positive this issue fixes). Fall through to the
+      // NEXT merged PR in scan order instead of returning here, so a
+      // later PR in the same window that both overlaps and references the
+      // candidate is still detected.
+      continue;
+    }
+    const mergedAt = String(pr.mergedAt ?? '');
+    return {
+      pass: false,
+      evidence: `High-confidence duplicate: merged PR #${number}${mergedAt ? ` (merged ${mergedAt})` : ''} already changed candidate file(s): ${overlap.sort().join(', ')} and references issue #${candidateIssueNumber}.`,
+      tier: 'high-confidence',
+    };
   }
 
   return null;
@@ -278,8 +374,15 @@ export function buildMergedPrListArgs(
   ];
 }
 
-/** Argv for one merged PR's changed-file list. */
-export function buildPrFilesArgs(repoRef: string, prNumber: number): string[] {
+/**
+ * Argv for one merged PR's changed-file list plus the same-issue-reference
+ * evidence #1878 adds (`title`, `body`, `closingIssuesReferences`) --
+ * requested on this single existing `gh pr view` call rather than a second
+ * one, matching the issue's own "no new API calls needed" framing. Returns
+ * the full JSON object (no `--jq` projection) since the caller now needs
+ * more than one field; `.files[].path` extraction moves to the caller.
+ */
+export function buildPrDetailArgs(repoRef: string, prNumber: number): string[] {
   return [
     'pr',
     'view',
@@ -287,8 +390,6 @@ export function buildPrFilesArgs(repoRef: string, prNumber: number): string[] {
     '--repo',
     repoRef,
     '--json',
-    'files',
-    '--jq',
-    '.files[].path',
+    'files,title,body,closingIssuesReferences',
   ];
 }

--- a/src/scripts/supersession-detection.mts
+++ b/src/scripts/supersession-detection.mts
@@ -218,7 +218,19 @@ export function prReferencesIssue(
   ) {
     return true;
   }
-  const pattern = new RegExp(`#${issueNumber}\\b`);
+  // Copilot review finding on PR #1886: a trailing `\b` alone only rejects
+  // a longer number sharing the digit prefix (`#18620` vs `1862`) -- it
+  // does NOT reject a word character immediately before `#` (`\b` requires
+  // one side `\w`, so `\b#` would require a `\w` before `#`, the opposite
+  // of what's needed here). `foo#1862` matched with only a trailing `\b`,
+  // which is not "word-bounded" as the issue's algorithm describes and
+  // could reintroduce a false positive from an incidental substring in a
+  // PR title/body. `(?<!\w)` requires the character immediately before `#`
+  // (if any) to NOT be a word character, rejecting `foo#1862` while still
+  // matching every legitimate form (start-of-string, whitespace, or
+  // punctuation before `#`: `#1862`, `Refs #1862`, `Closes #1862`,
+  // `(#1862)`).
+  const pattern = new RegExp(`(?<!\\w)#${issueNumber}\\b`);
   const title = typeof pr.title === 'string' ? pr.title : '';
   const body = typeof pr.body === 'string' ? pr.body : '';
   return pattern.test(title) || pattern.test(body);

--- a/src/scripts/supersession-detection.mts
+++ b/src/scripts/supersession-detection.mts
@@ -200,7 +200,22 @@ export function prReferencesIssue(
   const closing = Array.isArray(pr.closingIssuesReferences)
     ? pr.closingIssuesReferences
     : [];
-  if (closing.some((entry) => Number(entry) === issueNumber)) {
+  // Copilot review finding on PR #1886: accept both a raw number entry
+  // (the shape suitability-triage.mts's own caller already normalizes to
+  // before calling this function) and a raw `{ number }` object entry (the
+  // shape `gh pr view --json closingIssuesReferences` itself actually
+  // returns, confirmed empirically) -- `Number({ number: 1862 })` alone
+  // evaluates to `NaN` and would silently degrade a true match to "no
+  // reference" if a future caller ever passed the unnormalized `gh`
+  // payload straight through.
+  if (
+    closing.some((entry) => {
+      if (entry !== null && typeof entry === 'object') {
+        return Number((entry as { number?: unknown }).number) === issueNumber;
+      }
+      return Number(entry) === issueNumber;
+    })
+  ) {
     return true;
   }
   const pattern = new RegExp(`#${issueNumber}\\b`);

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -1352,6 +1352,109 @@ test('checkDuplicateOrSuperseded: a real high-confidence hit still fires even wh
   assert.match(result.evidence, /#99/);
 });
 
+// --- #1878: same-issue-reference requirement, at the checkDuplicateOrSuperseded /
+// evaluateSuitability integration level (candidateIssueNumber is threaded
+// through automatically via context.issue.number / BASE_ISSUE.number).
+// The kernel-level equivalents live in tests/supersession-detection.test.mts
+// per this issue's own acceptance criteria; these pin the real call-site
+// wiring (issue.number reaching evaluateHighConfidenceDuplicate) end to end.
+
+test('checkDuplicateOrSuperseded: file overlap with no reference to the candidate falls through to the weak heuristic (#1862 vs #1863/PR#1864)', () => {
+  const result = checkDuplicateOrSuperseded({
+    issue: BASE_ISSUE,
+    duplicateCandidates: [] as Context['duplicateCandidates'],
+    highConfidenceDuplicate: {
+      closedByMergedPrNumbers: [],
+      candidateFiles: ['src/scripts/markdown-code.mts'],
+      highContentionFiles: [],
+      mergedPrs: [
+        {
+          number: 1864,
+          mergedAt: '2026-08-04T00:00:00Z',
+          files: ['src/scripts/markdown-code.mts'],
+          // Closes a DIFFERENT sibling issue, never BASE_ISSUE.number (1).
+          closingIssuesReferences: [9999],
+          title: 'fix(markdown-code): preserve opaque fence state',
+          body: 'Closes #9999',
+        },
+      ],
+    },
+  } as unknown as Context);
+  // Falls through to the weak heuristic (empty duplicateCandidates, no
+  // free-text declaration) -- must pass, not report a duplicate.
+  assert.equal(result.pass, true);
+});
+
+test('evaluateSuitability: file overlap with no reference to the candidate no longer maps to the duplicate outcome (#1878)', () => {
+  const result = evaluateSuitability(BASE_ISSUE, {
+    highConfidenceDuplicate: {
+      closedByMergedPrNumbers: [],
+      candidateFiles: ['src/scripts/markdown-code.mts'],
+      highContentionFiles: [],
+      mergedPrs: [
+        {
+          number: 1864,
+          mergedAt: '2026-08-04T00:00:00Z',
+          files: ['src/scripts/markdown-code.mts'],
+          closingIssuesReferences: [9999],
+          title: 'fix(markdown-code): preserve opaque fence state',
+          body: 'Closes #9999',
+        },
+      ],
+    },
+  });
+  assert.equal(result.outcome, 'ready');
+  assert.equal(result.failedCheck, null);
+});
+
+test('checkDuplicateOrSuperseded: a same-candidate-files hit referencing the candidate issue still fails (true positive preserved)', () => {
+  const result = checkDuplicateOrSuperseded({
+    issue: BASE_ISSUE,
+    duplicateCandidates: [] as Context['duplicateCandidates'],
+    highConfidenceDuplicate: {
+      closedByMergedPrNumbers: [],
+      candidateFiles: ['src/scripts/markdown-code.mts'],
+      highContentionFiles: [],
+      mergedPrs: [
+        {
+          number: 1865,
+          mergedAt: '2026-08-04T00:00:00Z',
+          files: ['src/scripts/markdown-code.mts'],
+          // References BASE_ISSUE.number (1) directly.
+          closingIssuesReferences: [1],
+          title: 'fix: address issue',
+          body: '',
+        },
+      ],
+    },
+  } as unknown as Context);
+  assert.equal(result.pass, false);
+  assert.match(result.evidence, /High-confidence duplicate/);
+  assert.match(result.evidence, /#1865/);
+});
+
+test('evaluateSuitability: a same-candidate-files hit referencing the candidate issue still maps to the duplicate outcome (true positive preserved)', () => {
+  const result = evaluateSuitability(BASE_ISSUE, {
+    highConfidenceDuplicate: {
+      closedByMergedPrNumbers: [],
+      candidateFiles: ['src/scripts/markdown-code.mts'],
+      highContentionFiles: [],
+      mergedPrs: [
+        {
+          number: 1865,
+          mergedAt: '2026-08-04T00:00:00Z',
+          files: ['src/scripts/markdown-code.mts'],
+          closingIssuesReferences: [1],
+          title: 'fix: address issue',
+          body: '',
+        },
+      ],
+    },
+  });
+  assert.equal(result.outcome, 'duplicate');
+  assert.equal(result.failedCheck, 'duplicate_or_superseded');
+});
+
 test('checkDuplicateOrSuperseded: omitting highConfidenceDuplicate leaves the weak heuristic unchanged', () => {
   // No new field at all (as every pre-#1484 caller would omit it) must
   // behave byte-for-byte as before: BASE_ISSUE's own title is not present in
@@ -1761,7 +1864,15 @@ test('checkRepositoryFit / checkCoherence / checkTrustSafety: verdict is unaffec
 // has the qualifying overlap and no `gh pr view` call is made for PRs
 // after it").
 
-test('fetchMergedPrFileOverlapEvidence stops scanning once a qualifying overlap is found (#1815)', () => {
+// #1878: fetchMergedPrFileOverlapEvidence's per-PR stub now returns the
+// structured `gh pr view --json files,title,body,closingIssuesReferences`
+// shape (files as {path} objects, closingIssuesReferences as {number}
+// objects) instead of a plain-text file list, since the same-issue-
+// reference check needs title/body/closingIssuesReferences alongside
+// files. The candidate issue number (1862, reused across these fixtures)
+// is passed as fetchMergedPrFileOverlapEvidence's new fifth argument.
+
+test('fetchMergedPrFileOverlapEvidence stops scanning once a qualifying overlap is found (#1815, #1878)', () => {
   const { restore, readCount } = stubGhWithCounter(`
 if (args[0] === 'pr' && args[1] === 'list') {
   process.stdout.write(JSON.stringify([
@@ -1774,11 +1885,11 @@ if (args[0] === 'pr' && args[1] === 'list') {
 if (args[0] === 'pr' && args[1] === 'view') {
   const number = args[2];
   if (number === '101') {
-    process.stdout.write('unrelated/file.mjs\\n');
+    process.stdout.write(JSON.stringify({ files: [{ path: 'unrelated/file.mjs' }], title: '', body: '', closingIssuesReferences: [] }));
   } else if (number === '102') {
-    process.stdout.write('scripts/target.mjs\\n');
+    process.stdout.write(JSON.stringify({ files: [{ path: 'scripts/target.mjs' }], title: '', body: '', closingIssuesReferences: [{ number: 1862 }] }));
   } else {
-    process.stdout.write('should/not/be-scanned.mjs\\n');
+    process.stdout.write(JSON.stringify({ files: [{ path: 'should/not/be-scanned.mjs' }], title: '', body: '', closingIssuesReferences: [] }));
   }
   process.exit(0);
 }
@@ -1789,17 +1900,64 @@ if (args[0] === 'pr' && args[1] === 'view') {
       '2026-06-01T00:00:00Z',
       ['scripts/target.mjs'],
       [],
+      1862,
     );
     // #102 is the first (and only) PR whose files overlap the candidate
-    // set; #103 must never be fetched.
+    // set AND references the candidate issue (#1878); #103 must never be
+    // fetched.
     assert.deepEqual(
       result.mergedPrs.map((pr) => pr.number),
       [101, 102],
     );
     assert.equal(result.truncatedByDeadline, false);
-    // 1 `pr list` call + 2 `pr view` calls (#101, #102) -- #103's file list
-    // is never fetched once #102's qualifying overlap is found.
+    // 1 `pr list` call + 2 `pr view` calls (#101, #102) -- #103's detail
+    // is never fetched once #102's qualifying overlap+reference is found.
     assert.equal(readCount(), 3);
+  } finally {
+    restore();
+  }
+});
+
+test('fetchMergedPrFileOverlapEvidence: an overlap with no reference to the candidate does not stop the scan (#1878)', () => {
+  // #102 overlaps the candidate file set but never references candidate
+  // issue 1862 -- the scan must continue to #103, which does reference it.
+  const { restore, readCount } = stubGhWithCounter(`
+if (args[0] === 'pr' && args[1] === 'list') {
+  process.stdout.write(JSON.stringify([
+    { number: 101, mergedAt: '2026-07-01T00:00:00Z' },
+    { number: 102, mergedAt: '2026-07-02T00:00:00Z' },
+    { number: 103, mergedAt: '2026-07-03T00:00:00Z' },
+  ]));
+  process.exit(0);
+}
+if (args[0] === 'pr' && args[1] === 'view') {
+  const number = args[2];
+  if (number === '101') {
+    process.stdout.write(JSON.stringify({ files: [{ path: 'unrelated/file.mjs' }], title: '', body: '', closingIssuesReferences: [] }));
+  } else if (number === '102') {
+    process.stdout.write(JSON.stringify({ files: [{ path: 'scripts/target.mjs' }], title: 'unrelated sibling PR', body: '', closingIssuesReferences: [9999] }));
+  } else {
+    process.stdout.write(JSON.stringify({ files: [{ path: 'scripts/target.mjs' }], title: '', body: 'Closes #1862', closingIssuesReferences: [] }));
+  }
+  process.exit(0);
+}
+`);
+  try {
+    const result = fetchMergedPrFileOverlapEvidence(
+      'o/r',
+      '2026-06-01T00:00:00Z',
+      ['scripts/target.mjs'],
+      [],
+      1862,
+    );
+    assert.deepEqual(
+      result.mergedPrs.map((pr) => pr.number),
+      [101, 102, 103],
+    );
+    assert.equal(result.truncatedByDeadline, false);
+    // All three PRs are fetched: #102's overlap alone never stops the
+    // scan, since it doesn't reference the candidate.
+    assert.equal(readCount(), 4);
   } finally {
     restore();
   }
@@ -1815,7 +1973,7 @@ if (args[0] === 'pr' && args[1] === 'list') {
   process.exit(0);
 }
 if (args[0] === 'pr' && args[1] === 'view') {
-  process.stdout.write('unrelated/file.mjs\\n');
+  process.stdout.write(JSON.stringify({ files: [{ path: 'unrelated/file.mjs' }], title: '', body: '', closingIssuesReferences: [] }));
   process.exit(0);
 }
 `);
@@ -1825,6 +1983,7 @@ if (args[0] === 'pr' && args[1] === 'view') {
       '2026-06-01T00:00:00Z',
       ['scripts/target.mjs'],
       [],
+      1862,
     );
     assert.deepEqual(
       result.mergedPrs.map((pr) => pr.number),
@@ -1846,7 +2005,7 @@ if (args[0] === 'pr' && args[1] === 'list') {
   process.exit(0);
 }
 if (args[0] === 'pr' && args[1] === 'view') {
-  process.stdout.write('anything.mjs\\n');
+  process.stdout.write(JSON.stringify({ files: [{ path: 'anything.mjs' }], title: '', body: '', closingIssuesReferences: [] }));
   process.exit(0);
 }
 `);
@@ -1856,6 +2015,7 @@ if (args[0] === 'pr' && args[1] === 'view') {
       '2026-06-01T00:00:00Z',
       [],
       [],
+      1862,
     );
     assert.deepEqual(
       result.mergedPrs.map((pr) => pr.number),

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -1935,7 +1935,7 @@ if (args[0] === 'pr' && args[1] === 'view') {
   if (number === '101') {
     process.stdout.write(JSON.stringify({ files: [{ path: 'unrelated/file.mjs' }], title: '', body: '', closingIssuesReferences: [] }));
   } else if (number === '102') {
-    process.stdout.write(JSON.stringify({ files: [{ path: 'scripts/target.mjs' }], title: 'unrelated sibling PR', body: '', closingIssuesReferences: [9999] }));
+    process.stdout.write(JSON.stringify({ files: [{ path: 'scripts/target.mjs' }], title: 'unrelated sibling PR', body: '', closingIssuesReferences: [{ number: 9999 }] }));
   } else {
     process.stdout.write(JSON.stringify({ files: [{ path: 'scripts/target.mjs' }], title: '', body: 'Closes #1862', closingIssuesReferences: [] }));
   }

--- a/tests/supersession-detection.test.mts
+++ b/tests/supersession-detection.test.mts
@@ -369,6 +369,38 @@ test('prReferencesIssue: matches via closingIssuesReferences', () => {
   );
 });
 
+test('prReferencesIssue: matches via a raw { number } object entry (Copilot review finding, PR #1886)', () => {
+  // gh pr view --json closingIssuesReferences actually returns an array of
+  // { number, ... } objects, not raw numbers -- confirmed empirically. A
+  // caller that ever passes that unnormalized shape straight through must
+  // still match, not silently degrade to "no reference".
+  assert.equal(
+    prReferencesIssue(
+      {
+        closingIssuesReferences: [{ number: 1862 }],
+        title: '',
+        body: '',
+      },
+      1862,
+    ),
+    true,
+  );
+});
+
+test('prReferencesIssue: a { number } object entry with a different number still does not match', () => {
+  assert.equal(
+    prReferencesIssue(
+      {
+        closingIssuesReferences: [{ number: 9999 }],
+        title: '',
+        body: '',
+      },
+      1862,
+    ),
+    false,
+  );
+});
+
 test('prReferencesIssue: matches a plain "#1862" in the title', () => {
   assert.equal(
     prReferencesIssue(

--- a/tests/supersession-detection.test.mts
+++ b/tests/supersession-detection.test.mts
@@ -4,9 +4,10 @@ import { test } from 'node:test';
 import {
   buildClosedByMergedPrArgs,
   buildMergedPrListArgs,
-  buildPrFilesArgs,
+  buildPrDetailArgs,
   evaluateHighConfidenceDuplicate,
   findCandidateFileOverlap,
+  prReferencesIssue,
   resolveCandidateFileSet,
 } from '../src/scripts/supersession-detection.mts';
 
@@ -22,54 +23,71 @@ import {
 // --- #1484: high-confidence Check 4 tier ------------------------------------
 
 test('evaluateHighConfidenceDuplicate: undefined input is absent, not a hit', () => {
-  assert.equal(evaluateHighConfidenceDuplicate(undefined), null);
+  assert.equal(evaluateHighConfidenceDuplicate(undefined, 1234), null);
 });
 
 test('evaluateHighConfidenceDuplicate: empty arrays fall through (fail-safe)', () => {
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: [],
-    candidateFiles: [],
-    highContentionFiles: [],
-    mergedPrs: [],
-  });
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      closedByMergedPrNumbers: [],
+      candidateFiles: [],
+      highContentionFiles: [],
+      mergedPrs: [],
+    },
+    1234,
+  );
   assert.equal(result, null);
 });
 
 test('evaluateHighConfidenceDuplicate: malformed (non-array) fields never crash and never hit', () => {
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: 'not-an-array',
-    candidateFiles: null,
-    highContentionFiles: undefined,
-    mergedPrs: 42,
-  } as unknown as Parameters<typeof evaluateHighConfidenceDuplicate>[0]);
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      closedByMergedPrNumbers: 'not-an-array',
+      candidateFiles: null,
+      highContentionFiles: undefined,
+      mergedPrs: 42,
+    } as unknown as Parameters<typeof evaluateHighConfidenceDuplicate>[0],
+    1234,
+  );
   assert.equal(result, null);
 });
 
 test('evaluateHighConfidenceDuplicate: closing-PR-reference hit cites the PR number', () => {
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: [123],
-    candidateFiles: [],
-    highContentionFiles: [],
-    mergedPrs: [],
-  });
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      closedByMergedPrNumbers: [123],
+      candidateFiles: [],
+      highContentionFiles: [],
+      mergedPrs: [],
+    },
+    1234,
+  );
   assert.equal(result?.pass, false);
   assert.match(result?.evidence ?? '', /#123/);
   assert.match(result?.evidence ?? '', /closedByPullRequestsReferences/);
 });
 
 test('evaluateHighConfidenceDuplicate: same-candidate-files hit cites the PR number and file', () => {
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: [],
-    candidateFiles: ['scripts/foo.mjs'],
-    highContentionFiles: [],
-    mergedPrs: [
-      {
-        number: 456,
-        mergedAt: '2026-07-10T00:00:00Z',
-        files: ['scripts/foo.mjs', 'docs/unrelated.md'],
-      },
-    ],
-  });
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      closedByMergedPrNumbers: [],
+      candidateFiles: ['scripts/foo.mjs'],
+      highContentionFiles: [],
+      mergedPrs: [
+        {
+          number: 456,
+          mergedAt: '2026-07-10T00:00:00Z',
+          files: ['scripts/foo.mjs', 'docs/unrelated.md'],
+          // #1878: the merged PR must also reference the candidate issue
+          // itself for this to remain a true positive under the new rule.
+          closingIssuesReferences: [900],
+          title: '',
+          body: '',
+        },
+      ],
+    },
+    900,
+  );
   assert.equal(result?.pass, false);
   assert.match(result?.evidence ?? '', /#456/);
   assert.match(result?.evidence ?? '', /scripts\/foo\.mjs/);
@@ -82,20 +100,26 @@ test('evaluateHighConfidenceDuplicate: reuses normalizeContentionPath so mirrore
   // changed-file path (generated mirror). Proves real reuse of
   // discover-shared-file-overlap's normalization, not a re-implementation
   // that only matches identical strings.
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: [],
-    candidateFiles: [
-      'idd-template/.github/instructions/idd-work.instructions.md',
-    ],
-    highContentionFiles: [],
-    mergedPrs: [
-      {
-        number: 789,
-        mergedAt: '2026-07-11T00:00:00Z',
-        files: ['.github/instructions/idd-work.instructions.md'],
-      },
-    ],
-  });
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      closedByMergedPrNumbers: [],
+      candidateFiles: [
+        'idd-template/.github/instructions/idd-work.instructions.md',
+      ],
+      highContentionFiles: [],
+      mergedPrs: [
+        {
+          number: 789,
+          mergedAt: '2026-07-11T00:00:00Z',
+          files: ['.github/instructions/idd-work.instructions.md'],
+          closingIssuesReferences: [700],
+          title: '',
+          body: '',
+        },
+      ],
+    },
+    700,
+  );
   assert.equal(result?.pass, false);
   assert.match(result?.evidence ?? '', /#789/);
 });
@@ -104,18 +128,24 @@ test('evaluateHighConfidenceDuplicate: a high-contention-only overlap is not hig
   // The only shared file is in the high-contention exclusion set, so this
   // must fall through (null), not fire -- a coincidental hit on a
   // broadly-shared file is not evidence THIS issue was superseded.
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: [],
-    candidateFiles: ['audit/sync-manifest.json'],
-    highContentionFiles: ['audit/sync-manifest.json'],
-    mergedPrs: [
-      {
-        number: 999,
-        mergedAt: '2026-07-12T00:00:00Z',
-        files: ['audit/sync-manifest.json'],
-      },
-    ],
-  });
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      closedByMergedPrNumbers: [],
+      candidateFiles: ['audit/sync-manifest.json'],
+      highContentionFiles: ['audit/sync-manifest.json'],
+      mergedPrs: [
+        {
+          number: 999,
+          mergedAt: '2026-07-12T00:00:00Z',
+          files: ['audit/sync-manifest.json'],
+          closingIssuesReferences: [],
+          title: '',
+          body: '',
+        },
+      ],
+    },
+    999,
+  );
   assert.equal(result, null);
 });
 
@@ -123,30 +153,48 @@ test('evaluateHighConfidenceDuplicate: a genuine file still hits when a co-liste
   // Regression guard for the exclusion filter being too aggressive: a
   // candidate list with one high-contention file and one genuine file must
   // still fire on the genuine file's overlap.
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: [],
-    candidateFiles: ['audit/sync-manifest.json', 'scripts/genuine.mjs'],
-    highContentionFiles: ['audit/sync-manifest.json'],
-    mergedPrs: [
-      {
-        number: 1000,
-        mergedAt: '2026-07-13T00:00:00Z',
-        files: ['audit/sync-manifest.json', 'scripts/genuine.mjs'],
-      },
-    ],
-  });
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      closedByMergedPrNumbers: [],
+      candidateFiles: ['audit/sync-manifest.json', 'scripts/genuine.mjs'],
+      highContentionFiles: ['audit/sync-manifest.json'],
+      mergedPrs: [
+        {
+          number: 1000,
+          mergedAt: '2026-07-13T00:00:00Z',
+          files: ['audit/sync-manifest.json', 'scripts/genuine.mjs'],
+          closingIssuesReferences: [500],
+          title: '',
+          body: '',
+        },
+      ],
+    },
+    500,
+  );
   assert.equal(result?.pass, false);
   assert.match(result?.evidence ?? '', /scripts\/genuine\.mjs/);
   assert.doesNotMatch(result?.evidence ?? '', /sync-manifest\.json/);
 });
 
 test('evaluateHighConfidenceDuplicate: closing-PR-reference is checked before the file-overlap scan', () => {
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: [111],
-    candidateFiles: ['scripts/foo.mjs'],
-    highContentionFiles: [],
-    mergedPrs: [{ number: 222, mergedAt: '', files: ['unrelated.mjs'] }],
-  });
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      closedByMergedPrNumbers: [111],
+      candidateFiles: ['scripts/foo.mjs'],
+      highContentionFiles: [],
+      mergedPrs: [
+        {
+          number: 222,
+          mergedAt: '',
+          files: ['unrelated.mjs'],
+          closingIssuesReferences: [],
+          title: '',
+          body: '',
+        },
+      ],
+    },
+    111,
+  );
   assert.match(result?.evidence ?? '', /#111/);
   assert.doesNotMatch(result?.evidence ?? '', /#222/);
 });
@@ -154,29 +202,241 @@ test('evaluateHighConfidenceDuplicate: closing-PR-reference is checked before th
 // --- #1499: typed tier field -------------------------------------------------
 
 test('evaluateHighConfidenceDuplicate: a closing-PR-reference hit carries tier "high-confidence"', () => {
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: [42],
-    candidateFiles: [],
-    highContentionFiles: [],
-    mergedPrs: [],
-  });
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      closedByMergedPrNumbers: [42],
+      candidateFiles: [],
+      highContentionFiles: [],
+      mergedPrs: [],
+    },
+    42,
+  );
   assert.equal(result?.tier, 'high-confidence');
 });
 
 test('evaluateHighConfidenceDuplicate: a same-candidate-files hit carries tier "high-confidence"', () => {
-  const result = evaluateHighConfidenceDuplicate({
-    closedByMergedPrNumbers: [],
-    candidateFiles: ['scripts/foo.mjs'],
-    highContentionFiles: [],
-    mergedPrs: [
-      {
-        number: 456,
-        mergedAt: '2026-07-10T00:00:00Z',
-        files: ['scripts/foo.mjs'],
-      },
-    ],
-  });
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      closedByMergedPrNumbers: [],
+      candidateFiles: ['scripts/foo.mjs'],
+      highContentionFiles: [],
+      mergedPrs: [
+        {
+          number: 456,
+          mergedAt: '2026-07-10T00:00:00Z',
+          files: ['scripts/foo.mjs'],
+          closingIssuesReferences: [800],
+          title: '',
+          body: '',
+        },
+      ],
+    },
+    800,
+  );
   assert.equal(result?.tier, 'high-confidence');
+});
+
+// --- #1878: same-issue-reference requirement --------------------------------
+// File overlap alone is no longer sufficient for the high-confidence tier;
+// the merged PR must also reference the candidate issue itself, via
+// closingIssuesReferences or a word-bounded '#<candidate-number>'
+// cross-reference in its title/body.
+
+test('evaluateHighConfidenceDuplicate: file overlap with no reference to the candidate falls through (#1862 vs #1863/PR#1864)', () => {
+  // Synthesizes the real false positive this issue fixes: sibling issue
+  // #1863 lists the same '## Candidate files' as candidate issue #1862;
+  // PR #1864 merges closing #1863 and touches those files, but its
+  // title/body never mentions #1862 and its closingIssuesReferences closes
+  // #1863, not #1862.
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      closedByMergedPrNumbers: [],
+      candidateFiles: [
+        'src/scripts/markdown-code.mts',
+        'tests/suitability-triage.test.mts',
+      ],
+      highContentionFiles: [],
+      mergedPrs: [
+        {
+          number: 1864,
+          mergedAt: '2026-08-04T00:00:00Z',
+          files: [
+            'src/scripts/markdown-code.mts',
+            'tests/suitability-triage.test.mts',
+          ],
+          closingIssuesReferences: [1863],
+          title: 'fix(markdown-code): preserve opaque fence state',
+          body: 'Closes #1863',
+        },
+      ],
+    },
+    1862,
+  );
+  assert.equal(result, null);
+});
+
+test('evaluateHighConfidenceDuplicate: true positive preserved via closingIssuesReferences', () => {
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      closedByMergedPrNumbers: [],
+      candidateFiles: ['scripts/target.mjs'],
+      highContentionFiles: [],
+      mergedPrs: [
+        {
+          number: 2000,
+          mergedAt: '2026-08-01T00:00:00Z',
+          files: ['scripts/target.mjs'],
+          closingIssuesReferences: [1862],
+          title: 'unrelated title',
+          body: 'unrelated body',
+        },
+      ],
+    },
+    1862,
+  );
+  assert.equal(result?.pass, false);
+  assert.match(result?.evidence ?? '', /#2000/);
+  assert.match(result?.evidence ?? '', /references issue #1862/);
+});
+
+test('evaluateHighConfidenceDuplicate: true positive preserved via a title/body #<number> cross-reference', () => {
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      closedByMergedPrNumbers: [],
+      candidateFiles: ['scripts/target.mjs'],
+      highContentionFiles: [],
+      mergedPrs: [
+        {
+          number: 2001,
+          mergedAt: '2026-08-01T00:00:00Z',
+          files: ['scripts/target.mjs'],
+          closingIssuesReferences: [],
+          title: 'fix: address feedback',
+          body: 'Refs #1862 for background.',
+        },
+      ],
+    },
+    1862,
+  );
+  assert.equal(result?.pass, false);
+  assert.match(result?.evidence ?? '', /#2001/);
+});
+
+test('evaluateHighConfidenceDuplicate: scan continues past a non-qualifying overlap to a later qualifying PR', () => {
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      closedByMergedPrNumbers: [],
+      candidateFiles: ['scripts/shared.mjs'],
+      highContentionFiles: [],
+      mergedPrs: [
+        {
+          // Overlaps but never references the candidate -- must be
+          // skipped, not returned.
+          number: 3000,
+          mergedAt: '2026-08-01T00:00:00Z',
+          files: ['scripts/shared.mjs'],
+          closingIssuesReferences: [9999],
+          title: 'unrelated sibling',
+          body: '',
+        },
+        {
+          // Overlaps AND references the candidate -- this is the hit.
+          number: 3001,
+          mergedAt: '2026-08-02T00:00:00Z',
+          files: ['scripts/shared.mjs'],
+          closingIssuesReferences: [1862],
+          title: '',
+          body: '',
+        },
+      ],
+    },
+    1862,
+  );
+  assert.equal(result?.pass, false);
+  assert.match(result?.evidence ?? '', /#3001/);
+  assert.doesNotMatch(result?.evidence ?? '', /#3000/);
+});
+
+// --- #1878: prReferencesIssue -----------------------------------------------
+
+test('prReferencesIssue: matches via closingIssuesReferences', () => {
+  assert.equal(
+    prReferencesIssue(
+      { closingIssuesReferences: [1862], title: '', body: '' },
+      1862,
+    ),
+    true,
+  );
+});
+
+test('prReferencesIssue: matches a plain "#1862" in the title', () => {
+  assert.equal(
+    prReferencesIssue(
+      { closingIssuesReferences: [], title: 'Refs #1862', body: '' },
+      1862,
+    ),
+    true,
+  );
+});
+
+test('prReferencesIssue: matches "Closes #1862" in the body', () => {
+  assert.equal(
+    prReferencesIssue(
+      { closingIssuesReferences: [], title: '', body: 'Closes #1862' },
+      1862,
+    ),
+    true,
+  );
+});
+
+test('prReferencesIssue: word-boundary rejects a longer number sharing the same prefix', () => {
+  // "#18620" must not match candidate 1862 -- there is no word boundary
+  // between two digits.
+  assert.equal(
+    prReferencesIssue(
+      { closingIssuesReferences: [], title: 'Refs #18620', body: '' },
+      1862,
+    ),
+    false,
+  );
+});
+
+test('prReferencesIssue: no match when neither signal references the issue', () => {
+  assert.equal(
+    prReferencesIssue(
+      {
+        closingIssuesReferences: [1863],
+        title: 'unrelated',
+        body: 'unrelated',
+      },
+      1862,
+    ),
+    false,
+  );
+});
+
+test('prReferencesIssue: malformed fields degrade to no reference, never crash', () => {
+  assert.equal(
+    prReferencesIssue(
+      {
+        closingIssuesReferences: 'not-an-array',
+        title: null,
+        body: undefined,
+      } as unknown as Parameters<typeof prReferencesIssue>[0],
+      1862,
+    ),
+    false,
+  );
+});
+
+test('prReferencesIssue: an invalid issueNumber always returns false', () => {
+  assert.equal(
+    prReferencesIssue(
+      { closingIssuesReferences: [1862], title: '', body: '' },
+      0,
+    ),
+    false,
+  );
 });
 
 // --- #1815: extracted resolveCandidateFileSet / findCandidateFileOverlap ---
@@ -305,6 +565,17 @@ test('buildMergedPrListArgs is read-only', () => {
   );
 });
 
-test('buildPrFilesArgs is read-only', () => {
-  assertReadOnlyArgv(buildPrFilesArgs('kurone-kito/idd-skill', 1492));
+test('buildPrDetailArgs is read-only', () => {
+  assertReadOnlyArgv(buildPrDetailArgs('kurone-kito/idd-skill', 1492));
+});
+
+test('buildPrDetailArgs requests title, body, and closingIssuesReferences on the same call (#1878, no new API calls)', () => {
+  const args = buildPrDetailArgs('kurone-kito/idd-skill', 1492);
+  const jsonIndex = args.indexOf('--json');
+  assert.notEqual(jsonIndex, -1);
+  const fields = (args[jsonIndex + 1] ?? '').split(',');
+  assert.equal(fields.includes('files'), true);
+  assert.equal(fields.includes('title'), true);
+  assert.equal(fields.includes('body'), true);
+  assert.equal(fields.includes('closingIssuesReferences'), true);
 });

--- a/tests/supersession-detection.test.mts
+++ b/tests/supersession-detection.test.mts
@@ -433,6 +433,29 @@ test('prReferencesIssue: word-boundary rejects a longer number sharing the same 
   );
 });
 
+test('prReferencesIssue: word-boundary rejects a "#" immediately preceded by a word character (Copilot review finding, PR #1886)', () => {
+  // "foo#1862" must not match -- a trailing \b alone doesn't reject a word
+  // character directly before "#"; a genuine cross-reference needs no word
+  // character immediately preceding it either.
+  assert.equal(
+    prReferencesIssue(
+      { closingIssuesReferences: [], title: 'foo#1862', body: '' },
+      1862,
+    ),
+    false,
+  );
+});
+
+test('prReferencesIssue: still matches every legitimate cross-reference form after the leading-boundary fix', () => {
+  for (const body of ['#1862', 'Refs #1862', 'Closes #1862', '(#1862)']) {
+    assert.equal(
+      prReferencesIssue({ closingIssuesReferences: [], title: '', body }, 1862),
+      true,
+      `expected a match for body: ${body}`,
+    );
+  }
+});
+
 test('prReferencesIssue: no match when neither signal references the issue', () => {
   assert.equal(
     prReferencesIssue(


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`suitability-triage.mjs` Check 4's high-confidence duplicate tier
flagged a candidate issue as a mechanical duplicate whenever any merged
PR since the issue's `createdAt` touched a file listed in its own
`## Candidate files` section. Sibling issues in the same roadmap
legitimately share candidate files (a shared parser module, a shared
regression test file), so merging one sibling's PR falsely flagged
every other sibling as superseded, even when their own acceptance
criteria were unaddressed on `main` (observed live: issue #1862 vs.
merged PR #1864 for sibling #1863).

File overlap alone is no longer sufficient for the high-confidence
tier. A merged PR must now also reference the candidate issue itself,
via `closingIssuesReferences` or a word-bounded `#<candidate-number>`
cross-reference in its title/body (new `prReferencesIssue` helper in
`supersession-detection.mts`). The per-PR `gh pr view` call requests
`title`, `body`, and `closingIssuesReferences` alongside `files` on the
same existing call (renamed `buildPrFilesArgs` -> `buildPrDetailArgs`)
-- no new API calls. A PR that overlaps but doesn't reference the
candidate no longer stops the scan, so a later PR in the same window
that both overlaps and references the candidate is still detected.

Signal 1 (`closedByMergedPrNumbers`, gated on the candidate issue's own
`state` being `CLOSED`) is unaffected by this change -- it is already an
inherent same-issue reference (the candidate issue's own
`closedByPullRequestsReferences`), and is distinct from Signal 2's new
check: a *reopened* candidate whose sibling PR merged with
`Closes #candidate` is caught by Signal 1 and not by Signal 2.

**Two disclosures, per this issue's own instructions:**

1. The issue's "Proposed change" describes the reference fields as
   "already fetched by the existing GraphQL query." That's not quite
   accurate as stated -- the prior `buildPrFilesArgs` fetched only
   `--json files` per PR. This PR does not deviate from the pinned
   *algorithm* (same-issue reference via `closingIssuesReferences` or a
   `#<number>` cross-reference, no new API calls), only from that
   factual aside: `title`/`body`/`closingIssuesReferences` are added to
   the same existing per-PR `gh pr view` call, keeping the call count
   identical.
2. Behavior change worth flagging for review: previously the scan
   stopped at the first merged PR whose files overlapped the candidate
   set. Under the new rule, in exactly the sibling-roadmap case this
   issue is about, that PR no longer qualifies alone, so the scan now
   continues through every merged PR in the window (up to 50, mirroring
   `MERGED_PR_SCAN_LIMIT`) looking for one that also references the
   candidate. That makes `MERGED_PR_SCAN_DEADLINE_MS` (2 minutes) far
   more reachable for a candidate whose files are shared across an
   entire roadmap of siblings, none of which reference it individually.
   This is the fail-safe direction already documented on
   `fetchMergedPrFileOverlapEvidence` (a `truncatedByDeadline` scan
   degrades Check 4 to exact-title-only, never a false high-confidence
   hit), so the algorithm itself is unchanged -- flagging it here since
   it's an observable behavior/cost shift, not just an internal detail.

## Linked issue

Closes #1878

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

See Summary above; the issue's own "Proposed change" section documents
the full rationale and the pinned algorithm this PR implements exactly.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (biome check, dprint check, markdownlint-cli2 all
      pass)
- [x] `pnpm test` (`node --test tests/*.test.mts`: 3222/3222 pass)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (not applicable -- no docs/ changes)
- [x] `node scripts/idd-doctor.mjs` (passed, 3 pre-existing warnings
      unrelated to this change)
- [x] `node --test tests/supersession-detection.test.mts
      tests/suitability-triage.test.mts` (173/173 pass, per the
      issue's acceptance criteria)
- [x] `pnpm run build:check` (regenerated
      `scripts/supersession-detection.mjs` /
      `scripts/suitability-triage.mjs` committed alongside the `.mts`
      sources)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
