### PR TITLE
fix(suitability-triage): surface existing A4.5 rejection comments

### DIFF
--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -22,12 +22,14 @@ import {
   maskMarkdownCodeRegionsPreservingPositions,
 } from './markdown-code.mjs';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
+import { resolveTrustedMarkerActors } from './protocol-helpers.mjs';
 import {
   buildClosedByMergedPrArgs,
   buildMergedPrListArgs,
   buildPrDetailArgs,
   evaluateHighConfidenceDuplicate,
   findCandidateFileOverlap,
+  findTrustedSuitabilityRejection,
   prReferencesIssue,
   resolveCandidateFileSet,
 } from './supersession-detection.mjs';
@@ -791,7 +793,37 @@ function runCli() {
   const repoRef = `${owner}/${repo}`;
   const issue = fetchIssue(repoRef, args.issue);
   const duplicateCandidates = fetchDuplicateCandidates(repoRef, issue);
-  const labelsPolicy = normalizePolicyConfig(loadPolicy(args.policy)).labels;
+  const policyConfig = loadPolicy(args.policy);
+  const labelsPolicy = normalizePolicyConfig(policyConfig).labels;
+  // #1887: surface an existing, trusted `A4.5 suitability gate rejection`
+  // comment (if any) as a distinct output field, independent of the seven
+  // checks below and of the shouldCollectEvidence gate further down (that
+  // gate exists only to skip Check 4's own network-cost evidence when
+  // Checks 1-3 already fail) -- a prior trusted rejection matters
+  // regardless of which check a fresh run would fail today (the #1878
+  // scenario this issue documents: Check 7 fails fresh, but a human
+  // already ruled on it). Wrapped in its own try/catch: this is
+  // detect-only evidence, not a gate, so a transient `gh` failure here
+  // must degrade to `existingRejection: null` plus a warning, never crash
+  // the whole seven-check evaluation the way a genuine
+  // fetchIssue/fetchDuplicateCandidates failure still does.
+  const { actors: trustedMarkerActors } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    config: policyConfig,
+  });
+  const existingRejectionCollectionWarnings = [];
+  let existingRejection = null;
+  try {
+    const issueComments = fetchIssueComments(repoRef, args.issue);
+    existingRejection = findTrustedSuitabilityRejection(
+      issueComments,
+      trustedMarkerActors,
+    );
+  } catch (error) {
+    existingRejectionCollectionWarnings.push(
+      `existingRejection scan: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
   // #1815: repository_fit, coherence, and trust_safety are cheap, local,
   // no-I/O checks that run before duplicate_or_superseded (Check 4) in
   // evaluateSuitability's own CHECKS order, which short-circuits the whole
@@ -940,6 +972,10 @@ function runCli() {
     passed: result.passed,
     outcome: result.outcome,
     failedCheck: result.failedCheck,
+    ...(existingRejection ? { existingRejection } : {}),
+    ...(existingRejectionCollectionWarnings.length > 0
+      ? { existingRejectionCollectionWarnings }
+      : {}),
     ...(collectionWarnings.length > 0
       ? { highConfidenceDuplicateCollectionWarnings: collectionWarnings }
       : {}),
@@ -1029,6 +1065,7 @@ Output schema:
   "passed": true,
   "outcome": "ready|unclear|needs-decision|blocked-by-human|duplicate|out-of-scope|invalid",
   "failedCheck": "repository_fit|...|null",
+  "existingRejection": {"author":"...","createdAt":"...","url":"...","outcome":"...|null","check":"...|null"},
   "checks": [{"id":"repository_fit","name":"Repository Fit","result":"pass|fail","evidence":"..."}]
 }
 
@@ -1036,6 +1073,14 @@ Each checks[] entry may also carry "tier":"high-confidence|weak" -- present
 only on a duplicate_or_superseded fail (absent on every pass and on every
 other check), distinguishing a high-confidence mechanical hit from the weak
 title/declaration heuristic.
+
+"existingRejection" (#1887) is present only when a trusted marker actor
+already posted a correctly-formatted "A4.5 suitability gate rejection"
+comment on this issue -- the most recent one, when more than one exists.
+Absent (not null) for the common never-triaged case, and never surfaced for
+a rejection-shaped comment from an untrusted actor. An optional sibling
+"existingRejectionCollectionWarnings" array is present only when fetching
+or scanning the comment thread itself failed.
 `);
 }
 function normalizeIssue(issue) {
@@ -1182,6 +1227,31 @@ function fetchDuplicateCandidates(repoRef, issue) {
     `search/issues?q=${encodeURIComponent(query)}&per_page=50`,
   ]);
   return normalizeDuplicateCandidates(payload.items ?? []);
+}
+/**
+ * Paginated fetch of `<owner>/<repo>` issue `<issueNumber>`'s full comment
+ * thread (#1887), mirroring `resume-claim-routing.mts`'s own
+ * `fetchIssueComments` -- REST issue comments, 100 per page, until a
+ * short page signals the end. Feeds `findTrustedSuitabilityRejection`
+ * (`supersession-detection.mts`). Throws on a `gh` failure like every other
+ * `ghJson`-based fetch in this file; the caller wraps this call in its own
+ * try/catch so a failure here degrades `existingRejection` to `null` plus a
+ * warning instead of crashing the whole seven-check evaluation.
+ */
+function fetchIssueComments(repoRef, issueNumber) {
+  const comments = [];
+  const pageSize = 100;
+  for (let page = 1; ; page += 1) {
+    const pageItems = ghJson([
+      'api',
+      `repos/${repoRef}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
+    ]);
+    comments.push(...pageItems);
+    if (pageItems.length < pageSize) {
+      break;
+    }
+  }
+  return comments;
 }
 // --- #1484: high-confidence Check 4 tier CLI glue ---------------------------
 // The pure argv-builders (`buildClosedByMergedPrArgs`, `buildMergedPrListArgs`,

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -813,16 +813,24 @@ function runCli() {
   });
   const existingRejectionCollectionWarnings = [];
   let existingRejection = null;
-  try {
-    const issueComments = fetchIssueComments(repoRef, args.issue);
-    existingRejection = findTrustedSuitabilityRejection(
-      issueComments,
-      trustedMarkerActors,
-    );
-  } catch (error) {
-    existingRejectionCollectionWarnings.push(
-      `existingRejection scan: ${error instanceof Error ? error.message : String(error)}`,
-    );
+  // Copilot review finding on PR #1890: findTrustedSuitabilityRejection can
+  // never return a match with zero trusted actors (it returns null before
+  // even looking at `comments`), so fetching the full, possibly-paginated
+  // comment thread in that case is guaranteed wasted `gh api` traffic with
+  // no observable benefit. Skip the fetch entirely rather than only
+  // skipping the (already-cheap) scan.
+  if (trustedMarkerActors.length > 0) {
+    try {
+      const issueComments = fetchIssueComments(repoRef, args.issue);
+      existingRejection = findTrustedSuitabilityRejection(
+        issueComments,
+        trustedMarkerActors,
+      );
+    } catch (error) {
+      existingRejectionCollectionWarnings.push(
+        `existingRejection scan: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
   // #1815: repository_fit, coherence, and trust_safety are cheap, local,
   // no-I/O checks that run before duplicate_or_superseded (Check 4) in

--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -145,6 +145,97 @@ export function prReferencesIssue(pr, issueNumber) {
   const body = typeof pr.body === 'string' ? pr.body : '';
   return pattern.test(title) || pattern.test(body);
 }
+/** Literal prefix a trusted-actor "A4.5 suitability gate rejection" comment
+ * must start with (after trimming leading whitespace) to be recognized as
+ * an authoritative prior verdict by {@link findTrustedSuitabilityRejection}
+ * (#1887). Exported so `suitability-triage.mts` and its tests reference the
+ * exact same literal the A4.5 posting convention itself uses
+ * (`idd-suitability.instructions.md`'s Mutation Policy section) instead of
+ * risking two copies drifting apart. */
+export const SUITABILITY_REJECTION_PREFIX = 'A4.5 suitability gate rejection';
+// Not anchored to line start/end: real rejection comments interleave the
+// `outcome: <token>` declaration with trailing prose on the same line (e.g.
+// "outcome: duplicate (mechanical, narrow false positive -- see above)"),
+// so a `^...$` anchor would silently miss it. The trailing `\b` still
+// prevents a longer word sharing the same prefix (e.g. "duplicated") from
+// matching. Restricted to the six canonical A4.5 outcome values
+// (`idd-suitability.instructions.md`'s Failure Outcomes table) so this
+// never invents a token the protocol doesn't recognize.
+const SUITABILITY_REJECTION_OUTCOME_PATTERN =
+  /outcome:\s*(unclear|needs-decision|blocked-by-human|duplicate|out-of-scope|invalid)\b/i;
+const SUITABILITY_REJECTION_CHECK_PATTERN = /Check\s+\d+\s*\([^)]+\)/i;
+/**
+ * Scan `comments` for the most recent trusted-actor `A4.5 suitability gate
+ * rejection` comment (#1887): the acceptance-criteria-required detect-only
+ * evidence that a prior trusted run already recorded a specific outcome for
+ * this exact issue. A comment only qualifies when BOTH hold: its body,
+ * after trimming leading whitespace, starts with the literal
+ * {@link SUITABILITY_REJECTION_PREFIX} (the same "literal first bytes, not
+ * merely quoted or embedded mid-prose" anti-spoofing boundary
+ * `idd-claim.instructions.md` already applies to claim markers -- an
+ * untrusted actor pasting the phrase mid-sentence never qualifies either
+ * way, but this keeps the boundary consistent with the rest of the
+ * protocol); AND its author (case-insensitively) is one of
+ * `trustedMarkerLogins`. `trustedMarkerLogins` is expected pre-normalized
+ * (lowercased) by the caller via `resolveTrustedMarkerActors` in
+ * `protocol-helpers.mts` -- this function still lowercases defensively but
+ * does not import that module itself, keeping this file's own
+ * dependency-light, I/O-free kernel contract intact for a future
+ * non-suitability-triage consumer.
+ *
+ * Returns `null` -- never a synthesized verdict -- when no trusted match
+ * exists, whether because there is no such comment at all or because every
+ * rejection-shaped comment found was posted by an untrusted actor: both
+ * degrade to "nothing on record" the same way, matching this issue's
+ * fail-safe contract (an untrusted rejection-shaped comment is never
+ * treated as authoritative).
+ */
+export function findTrustedSuitabilityRejection(comments, trustedMarkerLogins) {
+  const trusted = new Set(
+    (trustedMarkerLogins ?? [])
+      .map((login) =>
+        String(login ?? '')
+          .trim()
+          .toLowerCase(),
+      )
+      .filter(Boolean),
+  );
+  if (trusted.size === 0 || !Array.isArray(comments)) {
+    return null;
+  }
+  let latest = null;
+  let latestTimestamp = Number.NEGATIVE_INFINITY;
+  for (const raw of comments) {
+    const comment = raw ?? {};
+    const body = typeof comment.body === 'string' ? comment.body : '';
+    if (!body.trimStart().startsWith(SUITABILITY_REJECTION_PREFIX)) {
+      continue;
+    }
+    const author = String(comment.user?.login ?? '')
+      .trim()
+      .toLowerCase();
+    if (!author || !trusted.has(author)) {
+      continue;
+    }
+    const createdAt =
+      typeof comment.created_at === 'string' ? comment.created_at : '';
+    const timestamp = Date.parse(createdAt);
+    if (!Number.isFinite(timestamp) || timestamp <= latestTimestamp) {
+      continue;
+    }
+    latestTimestamp = timestamp;
+    const outcomeMatch = SUITABILITY_REJECTION_OUTCOME_PATTERN.exec(body);
+    const checkMatch = SUITABILITY_REJECTION_CHECK_PATTERN.exec(body);
+    latest = {
+      author,
+      createdAt,
+      url: typeof comment.html_url === 'string' ? comment.html_url : '',
+      outcome: outcomeMatch ? (outcomeMatch[1] ?? null) : null,
+      check: checkMatch ? checkMatch[0] : null,
+    };
+  }
+  return latest;
+}
 /**
  * High-confidence Check 4 tier (#1484): evaluate the mechanical B2.0-style
  * signals -- a merged closing-PR reference on the candidate issue itself, or

--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -230,7 +230,13 @@ export function findTrustedSuitabilityRejection(comments, trustedMarkerLogins) {
       author,
       createdAt,
       url: typeof comment.html_url === 'string' ? comment.html_url : '',
-      outcome: outcomeMatch ? (outcomeMatch[1] ?? null) : null,
+      // Copilot review finding on PR #1890 (suppressed comment): the
+      // pattern above is case-insensitive (`/i`), but a captured group
+      // returns the verbatim matched text -- an actor writing e.g.
+      // "outcome: DUPLICATE" would otherwise surface an uncanonicalized
+      // "DUPLICATE" instead of the documented lowercase token, making a
+      // downstream string comparison brittle. Normalize before returning.
+      outcome: outcomeMatch ? (outcomeMatch[1]?.toLowerCase() ?? null) : null,
       check: checkMatch ? checkMatch[0] : null,
     };
   }

--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -233,7 +233,7 @@ export function findTrustedSuitabilityRejection(comments, trustedMarkerLogins) {
       // Copilot review finding on PR #1890 (suppressed comment): the
       // pattern above is case-insensitive (`/i`), but a captured group
       // returns the verbatim matched text -- an actor writing e.g.
-      // "outcome: DUPLICATE" would otherwise surface an uncanonicalized
+      // "outcome: DUPLICATE" would otherwise surface a non-canonical
       // "DUPLICATE" instead of the documented lowercase token, making a
       // downstream string comparison brittle. Normalize before returning.
       outcome: outcomeMatch ? (outcomeMatch[1]?.toLowerCase() ?? null) : null,

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -987,16 +987,24 @@ function runCli(): void {
   });
   const existingRejectionCollectionWarnings: string[] = [];
   let existingRejection: SuitabilityRejectionRecord | null = null;
-  try {
-    const issueComments = fetchIssueComments(repoRef, args.issue);
-    existingRejection = findTrustedSuitabilityRejection(
-      issueComments,
-      trustedMarkerActors,
-    );
-  } catch (error) {
-    existingRejectionCollectionWarnings.push(
-      `existingRejection scan: ${error instanceof Error ? error.message : String(error)}`,
-    );
+  // Copilot review finding on PR #1890: findTrustedSuitabilityRejection can
+  // never return a match with zero trusted actors (it returns null before
+  // even looking at `comments`), so fetching the full, possibly-paginated
+  // comment thread in that case is guaranteed wasted `gh api` traffic with
+  // no observable benefit. Skip the fetch entirely rather than only
+  // skipping the (already-cheap) scan.
+  if (trustedMarkerActors.length > 0) {
+    try {
+      const issueComments = fetchIssueComments(repoRef, args.issue);
+      existingRejection = findTrustedSuitabilityRejection(
+        issueComments,
+        trustedMarkerActors,
+      );
+    } catch (error) {
+      existingRejectionCollectionWarnings.push(
+        `existingRejection scan: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   // #1815: repository_fit, coherence, and trust_safety are cheap, local,

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -24,6 +24,7 @@ import {
   maskMarkdownCodeRegionsPreservingPositions,
 } from './markdown-code.mts';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
+import { resolveTrustedMarkerActors } from './protocol-helpers.mts';
 import {
   buildClosedByMergedPrArgs,
   buildMergedPrListArgs,
@@ -31,10 +32,13 @@ import {
   type CheckOutcome,
   evaluateHighConfidenceDuplicate,
   findCandidateFileOverlap,
+  findTrustedSuitabilityRejection,
   type HighConfidenceDuplicateInput,
   type HighConfidenceMergedPr,
   prReferencesIssue,
   resolveCandidateFileSet,
+  type SuitabilityRejectionComment,
+  type SuitabilityRejectionRecord,
 } from './supersession-detection.mts';
 
 /**
@@ -962,7 +966,38 @@ function runCli(): void {
 
   const issue = fetchIssue(repoRef, args.issue);
   const duplicateCandidates = fetchDuplicateCandidates(repoRef, issue);
-  const labelsPolicy = normalizePolicyConfig(loadPolicy(args.policy)).labels;
+  const policyConfig = loadPolicy(args.policy);
+  const labelsPolicy = normalizePolicyConfig(policyConfig).labels;
+
+  // #1887: surface an existing, trusted `A4.5 suitability gate rejection`
+  // comment (if any) as a distinct output field, independent of the seven
+  // checks below and of the shouldCollectEvidence gate further down (that
+  // gate exists only to skip Check 4's own network-cost evidence when
+  // Checks 1-3 already fail) -- a prior trusted rejection matters
+  // regardless of which check a fresh run would fail today (the #1878
+  // scenario this issue documents: Check 7 fails fresh, but a human
+  // already ruled on it). Wrapped in its own try/catch: this is
+  // detect-only evidence, not a gate, so a transient `gh` failure here
+  // must degrade to `existingRejection: null` plus a warning, never crash
+  // the whole seven-check evaluation the way a genuine
+  // fetchIssue/fetchDuplicateCandidates failure still does.
+  const { actors: trustedMarkerActors } = resolveTrustedMarkerActors({
+    envValue: process.env.IDD_TRUSTED_MARKER_ACTORS ?? '',
+    config: policyConfig as { trustedMarkerActors?: unknown } | null,
+  });
+  const existingRejectionCollectionWarnings: string[] = [];
+  let existingRejection: SuitabilityRejectionRecord | null = null;
+  try {
+    const issueComments = fetchIssueComments(repoRef, args.issue);
+    existingRejection = findTrustedSuitabilityRejection(
+      issueComments,
+      trustedMarkerActors,
+    );
+  } catch (error) {
+    existingRejectionCollectionWarnings.push(
+      `existingRejection scan: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 
   // #1815: repository_fit, coherence, and trust_safety are cheap, local,
   // no-I/O checks that run before duplicate_or_superseded (Check 4) in
@@ -1119,6 +1154,10 @@ function runCli(): void {
     passed: result.passed,
     outcome: result.outcome,
     failedCheck: result.failedCheck,
+    ...(existingRejection ? { existingRejection } : {}),
+    ...(existingRejectionCollectionWarnings.length > 0
+      ? { existingRejectionCollectionWarnings }
+      : {}),
     ...(collectionWarnings.length > 0
       ? { highConfidenceDuplicateCollectionWarnings: collectionWarnings }
       : {}),
@@ -1213,6 +1252,7 @@ Output schema:
   "passed": true,
   "outcome": "ready|unclear|needs-decision|blocked-by-human|duplicate|out-of-scope|invalid",
   "failedCheck": "repository_fit|...|null",
+  "existingRejection": {"author":"...","createdAt":"...","url":"...","outcome":"...|null","check":"...|null"},
   "checks": [{"id":"repository_fit","name":"Repository Fit","result":"pass|fail","evidence":"..."}]
 }
 
@@ -1220,6 +1260,14 @@ Each checks[] entry may also carry "tier":"high-confidence|weak" -- present
 only on a duplicate_or_superseded fail (absent on every pass and on every
 other check), distinguishing a high-confidence mechanical hit from the weak
 title/declaration heuristic.
+
+"existingRejection" (#1887) is present only when a trusted marker actor
+already posted a correctly-formatted "A4.5 suitability gate rejection"
+comment on this issue -- the most recent one, when more than one exists.
+Absent (not null) for the common never-triaged case, and never surfaced for
+a rejection-shaped comment from an untrusted actor. An optional sibling
+"existingRejectionCollectionWarnings" array is present only when fetching
+or scanning the comment thread itself failed.
 `);
 }
 
@@ -1421,6 +1469,35 @@ function fetchDuplicateCandidates(
     `search/issues?q=${encodeURIComponent(query)}&per_page=50`,
   ]) as { items?: unknown };
   return normalizeDuplicateCandidates(payload.items ?? []);
+}
+
+/**
+ * Paginated fetch of `<owner>/<repo>` issue `<issueNumber>`'s full comment
+ * thread (#1887), mirroring `resume-claim-routing.mts`'s own
+ * `fetchIssueComments` -- REST issue comments, 100 per page, until a
+ * short page signals the end. Feeds `findTrustedSuitabilityRejection`
+ * (`supersession-detection.mts`). Throws on a `gh` failure like every other
+ * `ghJson`-based fetch in this file; the caller wraps this call in its own
+ * try/catch so a failure here degrades `existingRejection` to `null` plus a
+ * warning instead of crashing the whole seven-check evaluation.
+ */
+function fetchIssueComments(
+  repoRef: string,
+  issueNumber: number,
+): SuitabilityRejectionComment[] {
+  const comments: SuitabilityRejectionComment[] = [];
+  const pageSize = 100;
+  for (let page = 1; ; page += 1) {
+    const pageItems = ghJson([
+      'api',
+      `repos/${repoRef}/issues/${issueNumber}/comments?per_page=${pageSize}&page=${page}`,
+    ]) as SuitabilityRejectionComment[];
+    comments.push(...pageItems);
+    if (pageItems.length < pageSize) {
+      break;
+    }
+  }
+  return comments;
 }
 
 // --- #1484: high-confidence Check 4 tier CLI glue ---------------------------

--- a/src/scripts/supersession-detection.mts
+++ b/src/scripts/supersession-detection.mts
@@ -236,6 +236,140 @@ export function prReferencesIssue(
   return pattern.test(title) || pattern.test(body);
 }
 
+/** Literal prefix a trusted-actor "A4.5 suitability gate rejection" comment
+ * must start with (after trimming leading whitespace) to be recognized as
+ * an authoritative prior verdict by {@link findTrustedSuitabilityRejection}
+ * (#1887). Exported so `suitability-triage.mts` and its tests reference the
+ * exact same literal the A4.5 posting convention itself uses
+ * (`idd-suitability.instructions.md`'s Mutation Policy section) instead of
+ * risking two copies drifting apart. */
+export const SUITABILITY_REJECTION_PREFIX = 'A4.5 suitability gate rejection';
+
+// Not anchored to line start/end: real rejection comments interleave the
+// `outcome: <token>` declaration with trailing prose on the same line (e.g.
+// "outcome: duplicate (mechanical, narrow false positive -- see above)"),
+// so a `^...$` anchor would silently miss it. The trailing `\b` still
+// prevents a longer word sharing the same prefix (e.g. "duplicated") from
+// matching. Restricted to the six canonical A4.5 outcome values
+// (`idd-suitability.instructions.md`'s Failure Outcomes table) so this
+// never invents a token the protocol doesn't recognize.
+const SUITABILITY_REJECTION_OUTCOME_PATTERN =
+  /outcome:\s*(unclear|needs-decision|blocked-by-human|duplicate|out-of-scope|invalid)\b/i;
+const SUITABILITY_REJECTION_CHECK_PATTERN = /Check\s+\d+\s*\([^)]+\)/i;
+
+/**
+ * One GitHub REST issue-comment entry, as consumed by
+ * {@link findTrustedSuitabilityRejection}. Loosely typed (every field
+ * `unknown`-safe) to match `gh api .../issues/<n>/comments`'s real payload
+ * shape without committing to its full schema -- mirrors
+ * `resume-claim-routing.mts`'s own `IssueCommentPayload`.
+ */
+export interface SuitabilityRejectionComment {
+  body?: unknown;
+  created_at?: unknown;
+  user?: { login?: unknown } | null;
+  html_url?: unknown;
+}
+
+/**
+ * An existing, trusted `A4.5 suitability gate rejection` comment already on
+ * record for an issue (#1887): the prior verdict a `suitability-triage.mjs`
+ * caller should see alongside its own freshly re-derived seven-check
+ * result, instead of never noticing it happened.
+ */
+export interface SuitabilityRejectionRecord {
+  /** Comment author login, lowercased. */
+  author: string;
+  /** Comment's GitHub `created_at` timestamp, verbatim. */
+  createdAt: string;
+  /** Comment permalink (`html_url`), when available. */
+  url: string;
+  /** Best-effort outcome token parsed from an `outcome: <token>`
+   * occurrence; `null` when the comment does not declare one in that
+   * recognized form. */
+  outcome: string | null;
+  /** Best-effort `Check N (<Name>)` excerpt parsed from the comment body's
+   * own headline convention; `null` when absent. */
+  check: string | null;
+}
+
+/**
+ * Scan `comments` for the most recent trusted-actor `A4.5 suitability gate
+ * rejection` comment (#1887): the acceptance-criteria-required detect-only
+ * evidence that a prior trusted run already recorded a specific outcome for
+ * this exact issue. A comment only qualifies when BOTH hold: its body,
+ * after trimming leading whitespace, starts with the literal
+ * {@link SUITABILITY_REJECTION_PREFIX} (the same "literal first bytes, not
+ * merely quoted or embedded mid-prose" anti-spoofing boundary
+ * `idd-claim.instructions.md` already applies to claim markers -- an
+ * untrusted actor pasting the phrase mid-sentence never qualifies either
+ * way, but this keeps the boundary consistent with the rest of the
+ * protocol); AND its author (case-insensitively) is one of
+ * `trustedMarkerLogins`. `trustedMarkerLogins` is expected pre-normalized
+ * (lowercased) by the caller via `resolveTrustedMarkerActors` in
+ * `protocol-helpers.mts` -- this function still lowercases defensively but
+ * does not import that module itself, keeping this file's own
+ * dependency-light, I/O-free kernel contract intact for a future
+ * non-suitability-triage consumer.
+ *
+ * Returns `null` -- never a synthesized verdict -- when no trusted match
+ * exists, whether because there is no such comment at all or because every
+ * rejection-shaped comment found was posted by an untrusted actor: both
+ * degrade to "nothing on record" the same way, matching this issue's
+ * fail-safe contract (an untrusted rejection-shaped comment is never
+ * treated as authoritative).
+ */
+export function findTrustedSuitabilityRejection(
+  comments: SuitabilityRejectionComment[] | null | undefined,
+  trustedMarkerLogins: string[] | null | undefined,
+): SuitabilityRejectionRecord | null {
+  const trusted = new Set(
+    (trustedMarkerLogins ?? [])
+      .map((login) =>
+        String(login ?? '')
+          .trim()
+          .toLowerCase(),
+      )
+      .filter(Boolean),
+  );
+  if (trusted.size === 0 || !Array.isArray(comments)) {
+    return null;
+  }
+
+  let latest: SuitabilityRejectionRecord | null = null;
+  let latestTimestamp = Number.NEGATIVE_INFINITY;
+  for (const raw of comments) {
+    const comment = (raw ?? {}) as SuitabilityRejectionComment;
+    const body = typeof comment.body === 'string' ? comment.body : '';
+    if (!body.trimStart().startsWith(SUITABILITY_REJECTION_PREFIX)) {
+      continue;
+    }
+    const author = String(comment.user?.login ?? '')
+      .trim()
+      .toLowerCase();
+    if (!author || !trusted.has(author)) {
+      continue;
+    }
+    const createdAt =
+      typeof comment.created_at === 'string' ? comment.created_at : '';
+    const timestamp = Date.parse(createdAt);
+    if (!Number.isFinite(timestamp) || timestamp <= latestTimestamp) {
+      continue;
+    }
+    latestTimestamp = timestamp;
+    const outcomeMatch = SUITABILITY_REJECTION_OUTCOME_PATTERN.exec(body);
+    const checkMatch = SUITABILITY_REJECTION_CHECK_PATTERN.exec(body);
+    latest = {
+      author,
+      createdAt,
+      url: typeof comment.html_url === 'string' ? comment.html_url : '',
+      outcome: outcomeMatch ? (outcomeMatch[1] ?? null) : null,
+      check: checkMatch ? checkMatch[0] : null,
+    };
+  }
+  return latest;
+}
+
 /**
  * High-confidence Check 4 tier (#1484): evaluate the mechanical B2.0-style
  * signals -- a merged closing-PR reference on the candidate issue itself, or

--- a/src/scripts/supersession-detection.mts
+++ b/src/scripts/supersession-detection.mts
@@ -363,7 +363,13 @@ export function findTrustedSuitabilityRejection(
       author,
       createdAt,
       url: typeof comment.html_url === 'string' ? comment.html_url : '',
-      outcome: outcomeMatch ? (outcomeMatch[1] ?? null) : null,
+      // Copilot review finding on PR #1890 (suppressed comment): the
+      // pattern above is case-insensitive (`/i`), but a captured group
+      // returns the verbatim matched text -- an actor writing e.g.
+      // "outcome: DUPLICATE" would otherwise surface an uncanonicalized
+      // "DUPLICATE" instead of the documented lowercase token, making a
+      // downstream string comparison brittle. Normalize before returning.
+      outcome: outcomeMatch ? (outcomeMatch[1]?.toLowerCase() ?? null) : null,
       check: checkMatch ? checkMatch[0] : null,
     };
   }

--- a/src/scripts/supersession-detection.mts
+++ b/src/scripts/supersession-detection.mts
@@ -366,7 +366,7 @@ export function findTrustedSuitabilityRejection(
       // Copilot review finding on PR #1890 (suppressed comment): the
       // pattern above is case-insensitive (`/i`), but a captured group
       // returns the verbatim matched text -- an actor writing e.g.
-      // "outcome: DUPLICATE" would otherwise surface an uncanonicalized
+      // "outcome: DUPLICATE" would otherwise surface a non-canonical
       // "DUPLICATE" instead of the documented lowercase token, making a
       // downstream string comparison brittle. Normalize before returning.
       outcome: outcomeMatch ? (outcomeMatch[1]?.toLowerCase() ?? null) : null,

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -1781,6 +1781,67 @@ test('runCli: shouldCollectEvidence is derived from repository_fit, coherence, a
   );
 });
 
+// --- #1887: existingRejection wiring ----------------------------------------
+// runCli itself isn't unit-tested for the same reason as the pins above
+// (real gh I/O); findTrustedSuitabilityRejection is proven correct in
+// isolation in tests/supersession-detection.test.mts. The remaining risk is
+// the wiring: that the call actually happens unconditionally (not nested
+// inside the shouldCollectEvidence gate, which exists only to skip Check 4's
+// own network-cost evidence -- a prior trusted rejection must still surface
+// even when Checks 1-3 would already fail fresh, per #1878), that a fetch
+// failure degrades gracefully instead of crashing the whole evaluation, and
+// that the output only adds the field when non-null.
+
+test('runCli: fetches issue comments and calls findTrustedSuitabilityRejection unconditionally, not gated behind shouldCollectEvidence (#1887)', () => {
+  const source = readFileSync(
+    new URL('../src/scripts/suitability-triage.mts', import.meta.url),
+    'utf8',
+  );
+  const shouldCollectIndex = source.indexOf('const shouldCollectEvidence =');
+  const existingRejectionCallIndex = source.indexOf(
+    'findTrustedSuitabilityRejection(',
+  );
+  assert.notEqual(existingRejectionCallIndex, -1);
+  assert.notEqual(shouldCollectIndex, -1);
+  // The existingRejection call site must appear BEFORE shouldCollectEvidence
+  // is even computed, proving it cannot be nested inside that gate's `if`
+  // block further down.
+  assert.equal(existingRejectionCallIndex < shouldCollectIndex, true);
+});
+
+test('runCli: the issue-comments fetch for existingRejection is wrapped in try/catch (degrade, not crash)', () => {
+  const source = readFileSync(
+    new URL('../src/scripts/suitability-triage.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /try \{\s*\n\s*const issueComments = fetchIssueComments\([\s\S]*?\} catch \(error\) \{\s*\n\s*existingRejectionCollectionWarnings\.push\(/,
+  );
+});
+
+test('runCli: existingRejection is spread into output only when non-null (no regression for the never-triaged case)', () => {
+  const source = readFileSync(
+    new URL('../src/scripts/suitability-triage.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /\.\.\.\(existingRejection \? \{ existingRejection \} : \{\}\)/,
+  );
+});
+
+test('fetchIssueComments argv requests the issue comments endpoint with pagination', () => {
+  const source = readFileSync(
+    new URL('../src/scripts/suitability-triage.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /`repos\/\$\{repoRef\}\/issues\/\$\{issueNumber\}\/comments\?per_page=\$\{pageSize\}&page=\$\{page\}`/,
+  );
+});
+
 // C1 self-review finding (#1815): the structural pins above prove
 // `shouldCollectEvidence` is wired to these three checks, but not that the
 // minimal `preEvidenceContext` runCli builds (issue + repository only,

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -1842,6 +1842,23 @@ test('fetchIssueComments argv requests the issue comments endpoint with paginati
   );
 });
 
+test('runCli: the issue-comments fetch is skipped entirely with zero trusted marker actors (PR #1890 review finding)', () => {
+  // findTrustedSuitabilityRejection can never return a match with an empty
+  // trusted-actor list (it returns null before inspecting `comments` at
+  // all), so fetching the full, possibly-paginated comment thread in that
+  // case is guaranteed wasted `gh api` traffic with no benefit. The fetch
+  // must be gated behind `trustedMarkerActors.length > 0`, not just the
+  // (already-cheap) scan.
+  const source = readFileSync(
+    new URL('../src/scripts/suitability-triage.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /if \(trustedMarkerActors\.length > 0\) \{\s*\n\s*try \{\s*\n\s*const issueComments = fetchIssueComments\(/,
+  );
+});
+
 // C1 self-review finding (#1815): the structural pins above prove
 // `shouldCollectEvidence` is wired to these three checks, but not that the
 // minimal `preEvidenceContext` runCli builds (issue + repository only,

--- a/tests/supersession-detection.test.mts
+++ b/tests/supersession-detection.test.mts
@@ -7,8 +7,11 @@ import {
   buildPrDetailArgs,
   evaluateHighConfidenceDuplicate,
   findCandidateFileOverlap,
+  findTrustedSuitabilityRejection,
   prReferencesIssue,
   resolveCandidateFileSet,
+  SUITABILITY_REJECTION_PREFIX,
+  type SuitabilityRejectionComment,
 } from '../src/scripts/supersession-detection.mts';
 
 // --- #1499: relocated from tests/suitability-triage.test.mts ---------------
@@ -633,4 +636,185 @@ test('buildPrDetailArgs requests title, body, and closingIssuesReferences on the
   assert.equal(fields.includes('title'), true);
   assert.equal(fields.includes('body'), true);
   assert.equal(fields.includes('closingIssuesReferences'), true);
+});
+
+// --- #1887: findTrustedSuitabilityRejection ---------------------------------
+// suitability-triage.mjs and its Check 4 helper never read the target
+// issue's own comment thread, so a fresh run cannot tell "never triaged"
+// apart from "already triaged and rejected by a trusted actor". These tests
+// cover the three acceptance-criteria scenarios directly against the pure
+// scanner (no `gh` stubbing needed, mirroring evaluateHighConfidenceDuplicate
+// above): a trusted prior rejection is detected and surfaced; the same
+// rejection-shaped comment from an untrusted actor is ignored; no matching
+// comment returns null (the never-triaged case).
+
+function makeRejectionComment(
+  overrides: Partial<SuitabilityRejectionComment> = {},
+): SuitabilityRejectionComment {
+  return {
+    body: `${SUITABILITY_REJECTION_PREFIX} — Check 7 (Verifiability): reason.\n\noutcome: needs-decision`,
+    created_at: '2026-08-05T03:55:11Z',
+    user: { login: 'kurone-kito' },
+    html_url:
+      'https://github.com/kurone-kito/idd-skill/issues/1878#issuecomment-1',
+    ...overrides,
+  };
+}
+
+test('findTrustedSuitabilityRejection: SUITABILITY_REJECTION_PREFIX matches the A4.5 posting convention literal', () => {
+  assert.equal(SUITABILITY_REJECTION_PREFIX, 'A4.5 suitability gate rejection');
+});
+
+test('findTrustedSuitabilityRejection: a trusted-actor rejection is detected and surfaced', () => {
+  const result = findTrustedSuitabilityRejection(
+    [makeRejectionComment()],
+    ['kurone-kito'],
+  );
+  assert.notEqual(result, null);
+  assert.equal(result?.author, 'kurone-kito');
+  assert.equal(result?.createdAt, '2026-08-05T03:55:11Z');
+  assert.equal(
+    result?.url,
+    'https://github.com/kurone-kito/idd-skill/issues/1878#issuecomment-1',
+  );
+  assert.equal(result?.outcome, 'needs-decision');
+  assert.equal(result?.check, 'Check 7 (Verifiability)');
+});
+
+test('findTrustedSuitabilityRejection: the same rejection-shaped comment from an untrusted actor is not surfaced', () => {
+  const result = findTrustedSuitabilityRejection(
+    [makeRejectionComment({ user: { login: 'random-untrusted-user' } })],
+    ['kurone-kito'],
+  );
+  assert.equal(result, null);
+});
+
+test('findTrustedSuitabilityRejection: no matching comment returns null (never-triaged case)', () => {
+  const result = findTrustedSuitabilityRejection(
+    [
+      {
+        body: 'Just an ordinary comment, unrelated to A4.5.',
+        created_at: '2026-08-05T03:55:11Z',
+        user: { login: 'kurone-kito' },
+        html_url: 'https://example.com/1',
+      },
+    ],
+    ['kurone-kito'],
+  );
+  assert.equal(result, null);
+});
+
+test('findTrustedSuitabilityRejection: an empty comment list returns null', () => {
+  assert.equal(findTrustedSuitabilityRejection([], ['kurone-kito']), null);
+});
+
+test('findTrustedSuitabilityRejection: a mid-prose mention (not the literal first bytes) is never treated as live', () => {
+  // Mirrors the claim-marker anti-spoofing boundary in
+  // idd-claim.instructions.md: a marker merely quoted or embedded mid-prose
+  // is never treated as live.
+  const result = findTrustedSuitabilityRejection(
+    [
+      makeRejectionComment({
+        body: `Earlier discussion referenced an "${SUITABILITY_REJECTION_PREFIX}" pattern without actually posting one.`,
+      }),
+    ],
+    ['kurone-kito'],
+  );
+  assert.equal(result, null);
+});
+
+test('findTrustedSuitabilityRejection: leading whitespace before the literal prefix still matches', () => {
+  const result = findTrustedSuitabilityRejection(
+    [
+      makeRejectionComment({
+        body: `  \n${SUITABILITY_REJECTION_PREFIX} — Check 1 (Repository Fit): reason.`,
+      }),
+    ],
+    ['kurone-kito'],
+  );
+  assert.notEqual(result, null);
+});
+
+test('findTrustedSuitabilityRejection: among several trusted rejections, the most recent one wins', () => {
+  const older = makeRejectionComment({
+    created_at: '2026-08-04T22:45:02Z',
+    body: `${SUITABILITY_REJECTION_PREFIX} — high-confidence file overlap with merged PR #1864 prevents an implementation claim.`,
+  });
+  const newer = makeRejectionComment({
+    created_at: '2026-08-05T06:28:40Z',
+    body: `${SUITABILITY_REJECTION_PREFIX} — Check 4 (Duplicate or Superseded Work), high-confidence tier.\n\noutcome: duplicate (mechanical, narrow false positive — see above)`,
+  });
+  // Order in the input array intentionally does not match chronological
+  // order, to prove the function compares timestamps rather than trusting
+  // array order.
+  const result = findTrustedSuitabilityRejection(
+    [newer, older],
+    ['kurone-kito'],
+  );
+  assert.equal(result?.createdAt, '2026-08-05T06:28:40Z');
+  // Regression guard: a real #1862 comment ends "outcome: duplicate
+  // (mechanical, narrow false positive — see above)" -- trailing prose
+  // after the canonical token on the same line. A `^...$`-anchored regex
+  // would silently miss this; the token must still parse to "duplicate".
+  assert.equal(result?.outcome, 'duplicate');
+  assert.equal(result?.check, 'Check 4 (Duplicate or Superseded Work)');
+});
+
+test('findTrustedSuitabilityRejection: a trusted rejection with no outcome/check line still surfaces author/createdAt/url', () => {
+  // Mirrors a real #1862 comment that predates the "outcome:" convention
+  // entirely -- must degrade to null fields, not throw or drop the record.
+  const result = findTrustedSuitabilityRejection(
+    [
+      makeRejectionComment({
+        body: `${SUITABILITY_REJECTION_PREFIX} — high-confidence file overlap with merged PR #1864 prevents an implementation claim.`,
+      }),
+    ],
+    ['kurone-kito'],
+  );
+  assert.notEqual(result, null);
+  assert.equal(result?.author, 'kurone-kito');
+  assert.equal(result?.outcome, null);
+  assert.equal(result?.check, null);
+});
+
+test('findTrustedSuitabilityRejection: author comparison is case-insensitive', () => {
+  const result = findTrustedSuitabilityRejection(
+    [makeRejectionComment({ user: { login: 'Kurone-Kito' } })],
+    ['kurone-kito'],
+  );
+  assert.notEqual(result, null);
+  assert.equal(result?.author, 'kurone-kito');
+});
+
+test('findTrustedSuitabilityRejection: an empty trusted-actor list never surfaces a match, even an exact one', () => {
+  const result = findTrustedSuitabilityRejection([makeRejectionComment()], []);
+  assert.equal(result, null);
+});
+
+test('findTrustedSuitabilityRejection: malformed (non-array) comments input degrades to null rather than throwing', () => {
+  const result = findTrustedSuitabilityRejection(
+    'not-an-array' as unknown as SuitabilityRejectionComment[],
+    ['kurone-kito'],
+  );
+  assert.equal(result, null);
+});
+
+test('findTrustedSuitabilityRejection: a malformed individual comment entry is skipped, not thrown', () => {
+  const result = findTrustedSuitabilityRejection(
+    [null as unknown as SuitabilityRejectionComment, makeRejectionComment()],
+    ['kurone-kito'],
+  );
+  assert.notEqual(result, null);
+  assert.equal(result?.author, 'kurone-kito');
+});
+
+test('findTrustedSuitabilityRejection: an unparseable created_at is skipped rather than winning the "most recent" comparison', () => {
+  const result = findTrustedSuitabilityRejection(
+    [
+      makeRejectionComment({ created_at: 'not-a-date' }),
+      makeRejectionComment({ created_at: '2026-08-05T03:55:11Z' }),
+    ],
+    ['kurone-kito'],
+  );
+  assert.equal(result?.createdAt, '2026-08-05T03:55:11Z');
 });

--- a/tests/supersession-detection.test.mts
+++ b/tests/supersession-detection.test.mts
@@ -786,6 +786,22 @@ test('findTrustedSuitabilityRejection: author comparison is case-insensitive', (
   assert.equal(result?.author, 'kurone-kito');
 });
 
+test('findTrustedSuitabilityRejection: a differently-cased outcome token is normalized to lowercase (Copilot review finding, PR #1890)', () => {
+  // The outcome pattern matches case-insensitively (`/i`), but a captured
+  // group returns the verbatim matched text by default -- an actor
+  // writing "outcome: DUPLICATE" must still surface the documented
+  // lowercase canonical token, not an uncanonicalized "DUPLICATE".
+  const result = findTrustedSuitabilityRejection(
+    [
+      makeRejectionComment({
+        body: `${SUITABILITY_REJECTION_PREFIX} — Check 4 (Duplicate or Superseded Work): reason.\n\noutcome: DUPLICATE`,
+      }),
+    ],
+    ['kurone-kito'],
+  );
+  assert.equal(result?.outcome, 'duplicate');
+});
+
 test('findTrustedSuitabilityRejection: an empty trusted-actor list never surfaces a match, even an exact one', () => {
   const result = findTrustedSuitabilityRejection([makeRejectionComment()], []);
   assert.equal(result, null);

--- a/tests/supersession-detection.test.mts
+++ b/tests/supersession-detection.test.mts
@@ -790,7 +790,7 @@ test('findTrustedSuitabilityRejection: a differently-cased outcome token is norm
   // The outcome pattern matches case-insensitively (`/i`), but a captured
   // group returns the verbatim matched text by default -- an actor
   // writing "outcome: DUPLICATE" must still surface the documented
-  // lowercase canonical token, not an uncanonicalized "DUPLICATE".
+  // lowercase canonical token, not a non-canonical "DUPLICATE".
   const result = findTrustedSuitabilityRejection(
     [
       makeRejectionComment({


### PR DESCRIPTION
# Summary

`suitability-triage.mjs` (Check 1-7 orchestrator) and its Check 4 helper
(`evaluateHighConfidenceDuplicate` in `supersession-detection.mts`) never
read the target issue's own comment thread, so a fresh run could not
distinguish "never triaged" from "already triaged and rejected by a
trusted actor" -- a caller reading only the fresh output had no way to
notice a prior trusted verdict already on record for the exact same
issue.

Adds `findTrustedSuitabilityRejection()` to `supersession-detection.mts`:
scans issue comments for the most recent one whose body starts with the
literal `A4.5 suitability gate rejection` AND whose author is a trusted
marker actor, best-effort parsing the outcome/check it names. An
untrusted actor's rejection-shaped comment is never surfaced as
authoritative. `suitability-triage.mts`'s `runCli` now fetches the
issue's comments (degrading gracefully on failure via a new
`existingRejectionCollectionWarnings` field, since this is detect-only
evidence, not a gate) and adds an `existingRejection` field to its JSON
output only when a trusted match exists, so a never-triaged issue's
output stays byte-identical to before.

## Linked issue

Closes #1887

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Two real occurrences during a single 2026-08-05 IDD loop session
illustrated this gap (see the issue body for the full account): on
#1878, a fresh `suitability-triage.mjs` run reported `needs-decision`
without any reference to a trusted rejection comment already posted on
that same issue roughly eight minutes after it was created; the
downstream claim step only caught the conflict by separately grepping
comments before claiming. This PR closes the gap at the source, in the
helper itself.

`findTrustedSuitabilityRejection` intentionally stays dependency-light
and does not import `protocol-helpers.mts`'s trusted-actor resolver
directly -- it accepts an already-normalized login list, matching
`supersession-detection.mts`'s existing "pure and I/O-free kernel"
design so a future non-suitability-triage consumer (e.g. a B2.0
mechanization) can reuse it without pulling in unrelated machinery.
`suitability-triage.mts` resolves the trusted-actor list via the
canonical `resolveTrustedMarkerActors` helper before calling it.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`npx biome check`, `npx dprint check`, `npx markdownlint-cli2`)
- [x] `pnpm test` (`node --test tests/*.test.mts`, 3244/3244 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `pnpm run build:check`
- [x] `node scripts/idd-doctor.mjs` (pre-existing warnings only, unrelated to this change)
- [x] `node --test tests/suitability-triage.test.mts tests/supersession-detection.test.mts` (195/195 passing)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none -- detect-only evidence, no gate/mutation behavior changed)
- [x] Context budget impact reviewed (no instruction-file changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detection of trusted suitability-gate rejection comments across complete issue threads.
  - CLI output now reports the latest matching rejection, including author, timestamp, outcome, checks, and link.
  - Added paginated comment retrieval for issues with large discussion threads.
  - Evaluation continues with a warning if comment collection fails.
  - Help output documents the new optional rejection fields.

- **Bug Fixes**
  - Improved handling of malformed, incomplete, outdated, or untrusted rejection comments.

- **Tests**
  - Added coverage for trusted-author filtering, comment parsing, pagination, failures, and output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->