### PR TITLE
feat(post-idd-marker): add --from-pr live head-sha derivation to advisory marker types

### DIFF
--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -478,8 +478,16 @@ function headShaFromPr(prNumber, owner, repo) {
     '--jq',
     '.headRefOid',
   ]);
-  if (!headSha) {
-    throw new Error(`PR ${prNumber} has no usable headRefOid`);
+  // Validate the shape here (not just non-empty): a non-SHA value (e.g. the
+  // literal text "null" if `gh` ever printed that instead of a real SHA)
+  // would otherwise pass this check and only fail later inside
+  // buildMarkerBody's renderer with a generic "invalid ... marker payload"
+  // message that does not name the actual cause. Fail closed here instead
+  // with a targeted error (Copilot review, #1889/#1891).
+  if (!/^[0-9a-f]{40}$/i.test(headSha)) {
+    throw new Error(
+      `PR ${prNumber} has no usable headRefOid (expected a 40-hex-character SHA, got: ${headSha || '(empty)'})`,
+    );
   }
   return headSha;
 }

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -43,6 +43,20 @@ export const MARKER_TYPES = [
   'copilot-unavailable',
 ];
 /**
+ * The marker `type`s that accept `--from-pr <n>`. `watermark` derives all
+ * four snapshot fields via the full {@link runReviewActivitySnapshot}
+ * composition; the three advisory types (`advisory` / `advisory-recovery` /
+ * `advisory-reroll`, added in #1889) derive only `--head-sha` via the
+ * lighter {@link headShaFromPr} single `gh pr view` call, since those
+ * renderers accept no other snapshot-shaped field.
+ */
+export const FROM_PR_MARKER_TYPES = [
+  'watermark',
+  'advisory',
+  'advisory-recovery',
+  'advisory-reroll',
+];
+/**
  * The kebab-case `--flag` field names each marker `type` requires, keyed
  * the same way {@link buildMarkerBody}'s own switch reads `fields` --
  * consulted by the `import.meta.main` CLI entry point below to report a
@@ -362,16 +376,21 @@ its claim-revalidation gate before --apply, as the manual POST path it replaces.
   --type <type>        one of: ${MARKER_TYPES.join(', ')}
   --target <issue|pr>  the comment target kind (both use the issues comments API)
   <number>             issue or PR number (positional; required unless --from-pr)
-  --from-pr <n>        watermark only: derive --head-sha / --max-activity-at /
+  --from-pr <n>        watermark: derive --head-sha / --max-activity-at /
                        --total-item-count / --ci-completed-at from the live
-                       review-activity-snapshot of PR <n> and post the watermark
-                       to PR <n>, so only --agent-id / --claim-id (and --apply)
-                       are still needed (always targets the PR; an explicit
-                       non-pr --target is rejected). Not network-free.
-  --expected-head-sha <sha>  --from-pr only: the E1 Step 1 stored {head-SHA}.
-                       Fails closed (posts nothing) if the fresh snapshot's live
-                       HEAD no longer matches it, i.e. the branch moved between
-                       E1 Step 1 and this Step 2 call.
+                       review-activity-snapshot of PR <n>. advisory /
+                       advisory-recovery / advisory-reroll (#1889): derive
+                       only --head-sha from PR <n>'s live current head commit
+                       (a single lightweight gh pr view call, not the full
+                       snapshot). Either way the marker posts to PR <n>, so
+                       --head-sha never needs hand-typing (always targets the
+                       PR; an explicit non-pr --target is rejected). Not
+                       network-free.
+  --expected-head-sha <sha>  --from-pr --type watermark only: the E1 Step 1
+                       stored {head-SHA}. Fails closed (posts nothing) if the
+                       fresh snapshot's live HEAD no longer matches it, i.e.
+                       the branch moved between E1 Step 1 and this Step 2
+                       call.
   --apply              POST the marker (default: dry-run prints it in a JSON envelope)
   --owner <owner>      repo owner (default: gh repo view)
   --repo <repo>        repo name (default: gh repo view)
@@ -385,8 +404,11 @@ Per-type field flags:
                      (or --agent-id --claim-id --from-pr <n> [--expected-head-sha <sha>])
   baseline           --agent-id --claim-id --sha
   advisory           --agent-id --head-sha --timestamp
+                     (or --agent-id --from-pr <n> --timestamp)
   advisory-recovery  --agent-id --head-sha --timestamp [--claim-id --attempt]
+                     (or --agent-id --from-pr <n> --timestamp [--claim-id --attempt])
   advisory-reroll    --agent-id --head-sha --timestamp
+                     (or --agent-id --from-pr <n> --timestamp)
   copilot-unavailable --agent-id --claim-id --head-sha --attempt --timestamp
 
 --claim-id / --attempt on advisory-recovery are OPTIONAL (#1572): passing
@@ -394,14 +416,17 @@ both binds the marker to the active claim and an attempt number for
 recovery-cycle accounting (advisory-wait-state.mjs); passing neither renders
 the legacy 3-field form the shipped AW3-R recovery flow already posts.
 Passing only ONE of the two throws (half-bound, ambiguous) -- always pass
-both together or neither.
+both together or neither. This pairing works unchanged together with
+--from-pr.
 copilot-unavailable is a brand-new terminal marker with no legacy form, so
 all five fields are required.
 
 --from-pr forwards optional --trusted-marker-logins / --advisory-bot-logins to
-the snapshot child so its counts match the manual review-activity-snapshot path.
---expected-head-sha pins --from-pr to the Step 1 stored HEAD and fails closed
-(no post) on drift instead of silently posting a newer HEAD than Step 1 saw.
+the snapshot child (--type watermark only) so its counts match the manual
+review-activity-snapshot path.
+--expected-head-sha pins a --type watermark --from-pr to the Step 1 stored
+HEAD and fails closed (no post) on drift instead of silently posting a newer
+HEAD than Step 1 saw.
 `;
 /**
  * POST the marker body as a JSON document (`{"body": …}`) read from stdin via
@@ -425,6 +450,38 @@ function postMarker(owner, repo, number, body) {
     { input: JSON.stringify({ body }) },
   );
   return JSON.parse(out);
+}
+/**
+ * Fetch PR `<n>`'s current head commit SHA via a single lightweight `gh pr
+ * view` call -- the `--from-pr` derivation path for the three advisory
+ * marker types (#1889: `advisory` / `advisory-recovery` / `advisory-reroll`),
+ * which need only `--head-sha`, unlike `watermark`'s `--from-pr`, which
+ * composes the full four-field snapshot via
+ * {@link runReviewActivitySnapshot}. This is deliberately network-lighter
+ * than that snapshot: no CI checks, review threads, or comment pagination,
+ * just the one `headRefOid` field.
+ *
+ * Throws (fail-closed) when `headRefOid` comes back empty or missing, so a
+ * malformed `gh pr view` response can never post a marker with a blank
+ * `head-sha` -- mirrors {@link watermarkFieldsFromSnapshot}'s guard on the
+ * watermark path.
+ */
+function headShaFromPr(prNumber, owner, repo) {
+  const headSha = ghText([
+    'pr',
+    'view',
+    String(prNumber),
+    '-R',
+    `${owner}/${repo}`,
+    '--json',
+    'headRefOid',
+    '--jq',
+    '.headRefOid',
+  ]);
+  if (!headSha) {
+    throw new Error(`PR ${prNumber} has no usable headRefOid`);
+  }
+  return headSha;
 }
 /**
  * Run the sibling read-only `review-activity-snapshot.mjs` for a PR and return
@@ -488,29 +545,53 @@ if (import.meta.main) {
     );
     process.exit(1);
   }
-  // --expected-head-sha only guards the --from-pr derivation below; in manual
-  // mode the caller already supplies --head-sha directly, so there is nothing
-  // to compare it against.
+  // --expected-head-sha only guards the --from-pr --type watermark
+  // derivation below; in manual mode the caller already supplies --head-sha
+  // directly, so there is nothing to compare it against. It has no meaning
+  // for the three advisory --from-pr types (#1889): they have no E1 Step
+  // 1/Step 2 pinning concept, so reject the combination the same way rather
+  // than silently ignoring it.
   if (args.expectedHeadSha && args.fromPr === null) {
     process.stderr.write(
       '--expected-head-sha is only valid together with --from-pr\n',
     );
     process.exit(1);
   }
-  // `--from-pr <n>` snapshot-derivation mode (watermark only): default the post
-  // target to PR <n>, reject the manual snapshot fields as ambiguous, then
-  // derive head-sha / max-activity-at / total-item-count / ci-completed-at from
-  // the live review-activity-snapshot before the shared render + dry-run/apply
-  // path below. owner/repo are resolved here because the snapshot child needs
-  // them and the dry-run branch returns before the apply-path resolution.
+  if (
+    args.expectedHeadSha &&
+    args.fromPr !== null &&
+    args.type !== 'watermark'
+  ) {
+    process.stderr.write(
+      '--expected-head-sha is only valid together with --from-pr --type watermark\n',
+    );
+    process.exit(1);
+  }
+  // `--from-pr <n>` derivation mode: default the post target to PR <n>,
+  // reject the manually-supplied derived field(s) as ambiguous, then derive
+  // those fields from a live PR <n> read before the shared render +
+  // dry-run/apply path below. owner/repo are resolved here because the
+  // derivation needs them and the dry-run branch returns before the
+  // apply-path resolution.
+  //
+  // `--type watermark` derives all four snapshot fields via the full
+  // review-activity-snapshot composition (unchanged since #1134). The three
+  // advisory types (#1889: `advisory` / `advisory-recovery` /
+  // `advisory-reroll`) derive only `--head-sha`, via the lighter
+  // single-`gh pr view`-call `headShaFromPr` -- those renderers accept no
+  // other snapshot-shaped field, so composing the full snapshot for them
+  // would be needless extra network work.
   if (args.fromPr !== null) {
-    if (args.type !== 'watermark') {
-      process.stderr.write('--from-pr is only valid for --type watermark\n');
+    if (!FROM_PR_MARKER_TYPES.includes(args.type)) {
+      process.stderr.write(
+        `--from-pr is only valid for --type ${FROM_PR_MARKER_TYPES.join(', ')}\n`,
+      );
       process.exit(1);
     }
-    // --from-pr always posts the watermark to PR <n>. `--target` is
+    const isWatermark = args.type === 'watermark';
+    // --from-pr always posts the marker to PR <n>. `--target` is
     // descriptive-only (issue/pr both POST to the same /issues/<n>/comments
-    // endpoint), but an `issue`-targeted snapshot watermark is incoherent, so
+    // endpoint), but an `issue`-targeted PR-derived marker is incoherent, so
     // fail closed on an explicit non-pr target rather than recording it.
     if (args.target && args.target !== 'pr') {
       process.stderr.write(
@@ -527,25 +608,22 @@ if (import.meta.main) {
       );
       process.exit(1);
     }
-    const derivedFlags = [
-      'head-sha',
-      'max-activity-at',
-      'total-item-count',
-      'ci-completed-at',
-    ];
+    const derivedFlags = isWatermark
+      ? ['head-sha', 'max-activity-at', 'total-item-count', 'ci-completed-at']
+      : ['head-sha'];
     const conflicting = derivedFlags.filter((flag) => flag in args.fields);
     if (conflicting.length > 0) {
       process.stderr.write(
-        `--from-pr derives ${derivedFlags.join(' / ')} from the live snapshot; do not also pass: ${conflicting
+        `--from-pr derives ${derivedFlags.join(' / ')} from the live ${isWatermark ? 'snapshot' : 'PR'}; do not also pass: ${conflicting
           .map((flag) => `--${flag}`)
           .join(', ')}\n`,
       );
       process.exit(1);
     }
     // Resolve owner/repo inside the try: in --from-pr mode they are read
-    // eagerly (the snapshot child needs them and the dry-run branch returns
-    // before the apply-path resolution), so a `gh repo view` failure here is
-    // part of "derive from PR" and should report cleanly, not throw a raw stack.
+    // eagerly (the derivation needs them and the dry-run branch returns
+    // before the apply-path resolution), so a `gh` failure here is part of
+    // "derive from PR" and should report cleanly, not throw a raw stack.
     try {
       args.owner =
         args.owner ||
@@ -553,18 +631,26 @@ if (import.meta.main) {
       args.repo =
         args.repo ||
         ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-      const snapshot = runReviewActivitySnapshot(
-        args.fromPr,
-        args.owner,
-        args.repo,
-        args.trustedMarkerLogins,
-        args.advisoryBotLogins,
-      );
-      Object.assign(args.fields, watermarkFieldsFromSnapshot(snapshot));
-      warnings = describeUnaddressedActivity(snapshot);
+      if (isWatermark) {
+        const snapshot = runReviewActivitySnapshot(
+          args.fromPr,
+          args.owner,
+          args.repo,
+          args.trustedMarkerLogins,
+          args.advisoryBotLogins,
+        );
+        Object.assign(args.fields, watermarkFieldsFromSnapshot(snapshot));
+        warnings = describeUnaddressedActivity(snapshot);
+      } else {
+        args.fields['head-sha'] = headShaFromPr(
+          args.fromPr,
+          args.owner,
+          args.repo,
+        );
+      }
     } catch (error) {
       process.stderr.write(
-        `failed to derive watermark fields from PR ${args.fromPr}: ${error.message}\n`,
+        `failed to derive ${isWatermark ? 'watermark fields' : 'head-sha'} from PR ${args.fromPr}: ${error.message}\n`,
       );
       process.exit(1);
     }
@@ -573,9 +659,12 @@ if (import.meta.main) {
     // HEAD through Step 3) and this Step 2 call: posting a watermark keyed to
     // a HEAD newer than the one E1 Step 1 actually snapshotted would silently
     // violate that single-stored-value invariant. Refuse to post; the caller
-    // reruns E1 from Step 1 against the moved branch instead.
+    // reruns E1 from Step 1 against the moved branch instead. Watermark-only:
+    // --expected-head-sha is rejected above for the advisory --from-pr types,
+    // so this never fires for them.
     const liveHeadSha = args.fields['head-sha'];
     if (
+      isWatermark &&
       args.expectedHeadSha &&
       liveHeadSha.toLowerCase() !== args.expectedHeadSha.toLowerCase()
     ) {

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -49,6 +49,23 @@ export const MARKER_TYPES = [
 export type MarkerType = (typeof MARKER_TYPES)[number];
 
 /**
+ * The marker `type`s that accept `--from-pr <n>`. `watermark` derives all
+ * four snapshot fields via the full {@link runReviewActivitySnapshot}
+ * composition; the three advisory types (`advisory` / `advisory-recovery` /
+ * `advisory-reroll`, added in #1889) derive only `--head-sha` via the
+ * lighter {@link headShaFromPr} single `gh pr view` call, since those
+ * renderers accept no other snapshot-shaped field.
+ */
+export const FROM_PR_MARKER_TYPES = [
+  'watermark',
+  'advisory',
+  'advisory-recovery',
+  'advisory-reroll',
+] as const;
+
+export type FromPrMarkerType = (typeof FROM_PR_MARKER_TYPES)[number];
+
+/**
  * The kebab-case `--flag` field names each marker `type` requires, keyed
  * the same way {@link buildMarkerBody}'s own switch reads `fields` --
  * consulted by the `import.meta.main` CLI entry point below to report a
@@ -320,13 +337,19 @@ interface CliArgs {
   type: string;
   target: string;
   number: number | null;
-  /** `--from-pr <n>`: derive the watermark snapshot fields from PR <n>. */
+  /**
+   * `--from-pr <n>`: derive `--head-sha` from PR <n>'s live current HEAD.
+   * For `--type watermark`, also derives the three other snapshot fields
+   * via the full `review-activity-snapshot` composition; for the three
+   * advisory types (#1889), only `--head-sha` is derived. See
+   * {@link FROM_PR_MARKER_TYPES}.
+   */
   fromPr: number | null;
   /**
-   * `--expected-head-sha <sha>`: `--from-pr` only. The E1 Step 1 stored
-   * `{head-SHA}`. When set, fail closed (no post) if the fresh
-   * `--from-pr` snapshot's live HEAD no longer matches it — the branch
-   * moved between E1 Step 1 and this Step 2 call.
+   * `--expected-head-sha <sha>`: `--from-pr --type watermark` only. The E1
+   * Step 1 stored `{head-SHA}`. When set, fail closed (no post) if the
+   * fresh `--from-pr` snapshot's live HEAD no longer matches it — the
+   * branch moved between E1 Step 1 and this Step 2 call.
    */
   expectedHeadSha: string;
   apply: boolean;
@@ -437,16 +460,21 @@ its claim-revalidation gate before --apply, as the manual POST path it replaces.
   --type <type>        one of: ${MARKER_TYPES.join(', ')}
   --target <issue|pr>  the comment target kind (both use the issues comments API)
   <number>             issue or PR number (positional; required unless --from-pr)
-  --from-pr <n>        watermark only: derive --head-sha / --max-activity-at /
+  --from-pr <n>        watermark: derive --head-sha / --max-activity-at /
                        --total-item-count / --ci-completed-at from the live
-                       review-activity-snapshot of PR <n> and post the watermark
-                       to PR <n>, so only --agent-id / --claim-id (and --apply)
-                       are still needed (always targets the PR; an explicit
-                       non-pr --target is rejected). Not network-free.
-  --expected-head-sha <sha>  --from-pr only: the E1 Step 1 stored {head-SHA}.
-                       Fails closed (posts nothing) if the fresh snapshot's live
-                       HEAD no longer matches it, i.e. the branch moved between
-                       E1 Step 1 and this Step 2 call.
+                       review-activity-snapshot of PR <n>. advisory /
+                       advisory-recovery / advisory-reroll (#1889): derive
+                       only --head-sha from PR <n>'s live current head commit
+                       (a single lightweight gh pr view call, not the full
+                       snapshot). Either way the marker posts to PR <n>, so
+                       --head-sha never needs hand-typing (always targets the
+                       PR; an explicit non-pr --target is rejected). Not
+                       network-free.
+  --expected-head-sha <sha>  --from-pr --type watermark only: the E1 Step 1
+                       stored {head-SHA}. Fails closed (posts nothing) if the
+                       fresh snapshot's live HEAD no longer matches it, i.e.
+                       the branch moved between E1 Step 1 and this Step 2
+                       call.
   --apply              POST the marker (default: dry-run prints it in a JSON envelope)
   --owner <owner>      repo owner (default: gh repo view)
   --repo <repo>        repo name (default: gh repo view)
@@ -460,8 +488,11 @@ Per-type field flags:
                      (or --agent-id --claim-id --from-pr <n> [--expected-head-sha <sha>])
   baseline           --agent-id --claim-id --sha
   advisory           --agent-id --head-sha --timestamp
+                     (or --agent-id --from-pr <n> --timestamp)
   advisory-recovery  --agent-id --head-sha --timestamp [--claim-id --attempt]
+                     (or --agent-id --from-pr <n> --timestamp [--claim-id --attempt])
   advisory-reroll    --agent-id --head-sha --timestamp
+                     (or --agent-id --from-pr <n> --timestamp)
   copilot-unavailable --agent-id --claim-id --head-sha --attempt --timestamp
 
 --claim-id / --attempt on advisory-recovery are OPTIONAL (#1572): passing
@@ -469,14 +500,17 @@ both binds the marker to the active claim and an attempt number for
 recovery-cycle accounting (advisory-wait-state.mjs); passing neither renders
 the legacy 3-field form the shipped AW3-R recovery flow already posts.
 Passing only ONE of the two throws (half-bound, ambiguous) -- always pass
-both together or neither.
+both together or neither. This pairing works unchanged together with
+--from-pr.
 copilot-unavailable is a brand-new terminal marker with no legacy form, so
 all five fields are required.
 
 --from-pr forwards optional --trusted-marker-logins / --advisory-bot-logins to
-the snapshot child so its counts match the manual review-activity-snapshot path.
---expected-head-sha pins --from-pr to the Step 1 stored HEAD and fails closed
-(no post) on drift instead of silently posting a newer HEAD than Step 1 saw.
+the snapshot child (--type watermark only) so its counts match the manual
+review-activity-snapshot path.
+--expected-head-sha pins a --type watermark --from-pr to the Step 1 stored
+HEAD and fails closed (no post) on drift instead of silently posting a newer
+HEAD than Step 1 saw.
 `;
 
 /**
@@ -506,6 +540,39 @@ function postMarker(
     { input: JSON.stringify({ body }) },
   );
   return JSON.parse(out) as { id: number; html_url: string };
+}
+
+/**
+ * Fetch PR `<n>`'s current head commit SHA via a single lightweight `gh pr
+ * view` call -- the `--from-pr` derivation path for the three advisory
+ * marker types (#1889: `advisory` / `advisory-recovery` / `advisory-reroll`),
+ * which need only `--head-sha`, unlike `watermark`'s `--from-pr`, which
+ * composes the full four-field snapshot via
+ * {@link runReviewActivitySnapshot}. This is deliberately network-lighter
+ * than that snapshot: no CI checks, review threads, or comment pagination,
+ * just the one `headRefOid` field.
+ *
+ * Throws (fail-closed) when `headRefOid` comes back empty or missing, so a
+ * malformed `gh pr view` response can never post a marker with a blank
+ * `head-sha` -- mirrors {@link watermarkFieldsFromSnapshot}'s guard on the
+ * watermark path.
+ */
+function headShaFromPr(prNumber: number, owner: string, repo: string): string {
+  const headSha = ghText([
+    'pr',
+    'view',
+    String(prNumber),
+    '-R',
+    `${owner}/${repo}`,
+    '--json',
+    'headRefOid',
+    '--jq',
+    '.headRefOid',
+  ]);
+  if (!headSha) {
+    throw new Error(`PR ${prNumber} has no usable headRefOid`);
+  }
+  return headSha;
 }
 
 /**
@@ -572,30 +639,54 @@ if (import.meta.main) {
     );
     process.exit(1);
   }
-  // --expected-head-sha only guards the --from-pr derivation below; in manual
-  // mode the caller already supplies --head-sha directly, so there is nothing
-  // to compare it against.
+  // --expected-head-sha only guards the --from-pr --type watermark
+  // derivation below; in manual mode the caller already supplies --head-sha
+  // directly, so there is nothing to compare it against. It has no meaning
+  // for the three advisory --from-pr types (#1889): they have no E1 Step
+  // 1/Step 2 pinning concept, so reject the combination the same way rather
+  // than silently ignoring it.
   if (args.expectedHeadSha && args.fromPr === null) {
     process.stderr.write(
       '--expected-head-sha is only valid together with --from-pr\n',
     );
     process.exit(1);
   }
+  if (
+    args.expectedHeadSha &&
+    args.fromPr !== null &&
+    args.type !== 'watermark'
+  ) {
+    process.stderr.write(
+      '--expected-head-sha is only valid together with --from-pr --type watermark\n',
+    );
+    process.exit(1);
+  }
 
-  // `--from-pr <n>` snapshot-derivation mode (watermark only): default the post
-  // target to PR <n>, reject the manual snapshot fields as ambiguous, then
-  // derive head-sha / max-activity-at / total-item-count / ci-completed-at from
-  // the live review-activity-snapshot before the shared render + dry-run/apply
-  // path below. owner/repo are resolved here because the snapshot child needs
-  // them and the dry-run branch returns before the apply-path resolution.
+  // `--from-pr <n>` derivation mode: default the post target to PR <n>,
+  // reject the manually-supplied derived field(s) as ambiguous, then derive
+  // those fields from a live PR <n> read before the shared render +
+  // dry-run/apply path below. owner/repo are resolved here because the
+  // derivation needs them and the dry-run branch returns before the
+  // apply-path resolution.
+  //
+  // `--type watermark` derives all four snapshot fields via the full
+  // review-activity-snapshot composition (unchanged since #1134). The three
+  // advisory types (#1889: `advisory` / `advisory-recovery` /
+  // `advisory-reroll`) derive only `--head-sha`, via the lighter
+  // single-`gh pr view`-call `headShaFromPr` -- those renderers accept no
+  // other snapshot-shaped field, so composing the full snapshot for them
+  // would be needless extra network work.
   if (args.fromPr !== null) {
-    if (args.type !== 'watermark') {
-      process.stderr.write('--from-pr is only valid for --type watermark\n');
+    if (!FROM_PR_MARKER_TYPES.includes(args.type as FromPrMarkerType)) {
+      process.stderr.write(
+        `--from-pr is only valid for --type ${FROM_PR_MARKER_TYPES.join(', ')}\n`,
+      );
       process.exit(1);
     }
-    // --from-pr always posts the watermark to PR <n>. `--target` is
+    const isWatermark = args.type === 'watermark';
+    // --from-pr always posts the marker to PR <n>. `--target` is
     // descriptive-only (issue/pr both POST to the same /issues/<n>/comments
-    // endpoint), but an `issue`-targeted snapshot watermark is incoherent, so
+    // endpoint), but an `issue`-targeted PR-derived marker is incoherent, so
     // fail closed on an explicit non-pr target rather than recording it.
     if (args.target && args.target !== 'pr') {
       process.stderr.write(
@@ -612,25 +703,22 @@ if (import.meta.main) {
       );
       process.exit(1);
     }
-    const derivedFlags = [
-      'head-sha',
-      'max-activity-at',
-      'total-item-count',
-      'ci-completed-at',
-    ];
+    const derivedFlags = isWatermark
+      ? ['head-sha', 'max-activity-at', 'total-item-count', 'ci-completed-at']
+      : ['head-sha'];
     const conflicting = derivedFlags.filter((flag) => flag in args.fields);
     if (conflicting.length > 0) {
       process.stderr.write(
-        `--from-pr derives ${derivedFlags.join(' / ')} from the live snapshot; do not also pass: ${conflicting
+        `--from-pr derives ${derivedFlags.join(' / ')} from the live ${isWatermark ? 'snapshot' : 'PR'}; do not also pass: ${conflicting
           .map((flag) => `--${flag}`)
           .join(', ')}\n`,
       );
       process.exit(1);
     }
     // Resolve owner/repo inside the try: in --from-pr mode they are read
-    // eagerly (the snapshot child needs them and the dry-run branch returns
-    // before the apply-path resolution), so a `gh repo view` failure here is
-    // part of "derive from PR" and should report cleanly, not throw a raw stack.
+    // eagerly (the derivation needs them and the dry-run branch returns
+    // before the apply-path resolution), so a `gh` failure here is part of
+    // "derive from PR" and should report cleanly, not throw a raw stack.
     try {
       args.owner =
         args.owner ||
@@ -638,18 +726,26 @@ if (import.meta.main) {
       args.repo =
         args.repo ||
         ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-      const snapshot = runReviewActivitySnapshot(
-        args.fromPr,
-        args.owner,
-        args.repo,
-        args.trustedMarkerLogins,
-        args.advisoryBotLogins,
-      );
-      Object.assign(args.fields, watermarkFieldsFromSnapshot(snapshot));
-      warnings = describeUnaddressedActivity(snapshot);
+      if (isWatermark) {
+        const snapshot = runReviewActivitySnapshot(
+          args.fromPr,
+          args.owner,
+          args.repo,
+          args.trustedMarkerLogins,
+          args.advisoryBotLogins,
+        );
+        Object.assign(args.fields, watermarkFieldsFromSnapshot(snapshot));
+        warnings = describeUnaddressedActivity(snapshot);
+      } else {
+        args.fields['head-sha'] = headShaFromPr(
+          args.fromPr,
+          args.owner,
+          args.repo,
+        );
+      }
     } catch (error) {
       process.stderr.write(
-        `failed to derive watermark fields from PR ${args.fromPr}: ${(error as Error).message}\n`,
+        `failed to derive ${isWatermark ? 'watermark fields' : 'head-sha'} from PR ${args.fromPr}: ${(error as Error).message}\n`,
       );
       process.exit(1);
     }
@@ -658,9 +754,12 @@ if (import.meta.main) {
     // HEAD through Step 3) and this Step 2 call: posting a watermark keyed to
     // a HEAD newer than the one E1 Step 1 actually snapshotted would silently
     // violate that single-stored-value invariant. Refuse to post; the caller
-    // reruns E1 from Step 1 against the moved branch instead.
+    // reruns E1 from Step 1 against the moved branch instead. Watermark-only:
+    // --expected-head-sha is rejected above for the advisory --from-pr types,
+    // so this never fires for them.
     const liveHeadSha = args.fields['head-sha'];
     if (
+      isWatermark &&
       args.expectedHeadSha &&
       liveHeadSha.toLowerCase() !== args.expectedHeadSha.toLowerCase()
     ) {

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -569,8 +569,16 @@ function headShaFromPr(prNumber: number, owner: string, repo: string): string {
     '--jq',
     '.headRefOid',
   ]);
-  if (!headSha) {
-    throw new Error(`PR ${prNumber} has no usable headRefOid`);
+  // Validate the shape here (not just non-empty): a non-SHA value (e.g. the
+  // literal text "null" if `gh` ever printed that instead of a real SHA)
+  // would otherwise pass this check and only fail later inside
+  // buildMarkerBody's renderer with a generic "invalid ... marker payload"
+  // message that does not name the actual cause. Fail closed here instead
+  // with a targeted error (Copilot review, #1889/#1891).
+  if (!/^[0-9a-f]{40}$/i.test(headSha)) {
+    throw new Error(
+      `PR ${prNumber} has no usable headRefOid (expected a 40-hex-character SHA, got: ${headSha || '(empty)'})`,
+    );
   }
   return headSha;
 }

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'node:url';
 import {
   buildMarkerBody,
   describeUnaddressedActivity,
+  FROM_PR_MARKER_TYPES,
   MARKER_TYPES,
   parseArgs,
   watermarkFieldsFromSnapshot,
@@ -1277,7 +1278,11 @@ test('--from-pr rejects manual snapshot fields as ambiguous (before any gh call)
   assert.match(stderr, /--from-pr derives .* do not also pass: --head-sha/);
 });
 
-test('--from-pr is rejected for a non-watermark type', () => {
+test('--from-pr is rejected for a type outside FROM_PR_MARKER_TYPES', () => {
+  // #1889: --from-pr now supports watermark AND the three advisory types
+  // (see the dedicated tests below), but a structurally unrelated type like
+  // `claim` -- which has no head-sha field at all -- still fails exactly as
+  // before.
   const stderr = runCliExpectingFailure([
     join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
     '--type',
@@ -1289,7 +1294,19 @@ test('--from-pr is rejected for a non-watermark type', () => {
     '--claim-id',
     'c',
   ]);
-  assert.match(stderr, /--from-pr is only valid for --type watermark/);
+  assert.match(
+    stderr,
+    /--from-pr is only valid for --type watermark, advisory, advisory-recovery, advisory-reroll/,
+  );
+});
+
+test('FROM_PR_MARKER_TYPES lists exactly the four --from-pr-supported types', () => {
+  assert.deepEqual(FROM_PR_MARKER_TYPES, [
+    'watermark',
+    'advisory',
+    'advisory-recovery',
+    'advisory-reroll',
+  ]);
 });
 
 test('--from-pr fails closed on an explicit non-pr --target', () => {
@@ -1309,6 +1326,264 @@ test('--from-pr fails closed on an explicit non-pr --target', () => {
     'c',
   ]);
   assert.match(stderr, /--from-pr always targets the PR/);
+});
+
+// --- #1889: --from-pr live head-sha derivation for the advisory types ------
+//
+// Unlike watermark's --from-pr (full review-activity-snapshot composition),
+// the three advisory types derive ONLY --head-sha via a single lightweight
+// `gh pr view --json headRefOid --jq .headRefOid` call -- no CI checks,
+// review threads, or comment pagination.
+
+/**
+ * Stub `gh` on PATH so `headShaFromPr`'s single `gh pr view ... --jq
+ * .headRefOid` call resolves offline to `headSha`, without needing the full
+ * review-activity-snapshot stub the watermark tests use above. Any other
+ * invocation is treated as unexpected (proving the advisory --from-pr path
+ * never spawns the heavier snapshot child).
+ */
+function writeHeadShaOnlyGhStub(tempRoot: string, headSha: string): void {
+  const ghPath = join(tempRoot, 'gh');
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const out = (s) => { fs.writeSync(1, s); process.exit(0); };
+if (args[0] === 'pr' && args[1] === 'view') out('${headSha}\\n');
+fs.writeSync(2, 'unexpected gh invocation: ' + args.join(' '));
+process.exit(1);
+`,
+  );
+  chmodSync(ghPath, 0o755);
+}
+
+function runFromPrCliDryRun(tempRoot: string, argv: string[]): unknown {
+  const output = execFileSync(
+    process.execPath,
+    [join(REPO_ROOT, 'scripts/post-idd-marker.mjs'), ...argv],
+    {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      env: { ...process.env, PATH: `${tempRoot}:${process.env.PATH ?? ''}` },
+    },
+  );
+  return JSON.parse(output);
+}
+
+test('--from-pr CLI derives only --head-sha for --type advisory (dry-run)', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-from-pr-advisory-'));
+  writeHeadShaOnlyGhStub(tempRoot, SHA);
+
+  const result = runFromPrCliDryRun(tempRoot, [
+    '--type',
+    'advisory',
+    '--from-pr',
+    '1200',
+    '--owner',
+    'o',
+    '--repo',
+    'r',
+    '--agent-id',
+    'claude-02f8159e',
+    '--timestamp',
+    TS,
+  ]);
+
+  assert.deepEqual(result, {
+    mode: 'dry-run',
+    type: 'advisory',
+    target: 'pr',
+    number: 1200,
+    body: buildMarkerBody('advisory', {
+      'agent-id': 'claude-02f8159e',
+      'head-sha': SHA,
+      timestamp: TS,
+    }),
+  });
+});
+
+test('--from-pr CLI derives only --head-sha for --type advisory-reroll (dry-run)', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-from-pr-reroll-'));
+  writeHeadShaOnlyGhStub(tempRoot, SHA);
+
+  const result = runFromPrCliDryRun(tempRoot, [
+    '--type',
+    'advisory-reroll',
+    '--from-pr',
+    '1200',
+    '--owner',
+    'o',
+    '--repo',
+    'r',
+    '--agent-id',
+    'claude-02f8159e',
+    '--timestamp',
+    TS,
+  ]);
+
+  assert.deepEqual(result, {
+    mode: 'dry-run',
+    type: 'advisory-reroll',
+    target: 'pr',
+    number: 1200,
+    body: buildMarkerBody('advisory-reroll', {
+      'agent-id': 'claude-02f8159e',
+      'head-sha': SHA,
+      timestamp: TS,
+    }),
+  });
+});
+
+test('--from-pr CLI derives only --head-sha for --type advisory-recovery, legacy 3-field form (dry-run)', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-from-pr-recovery-legacy-'));
+  writeHeadShaOnlyGhStub(tempRoot, SHA);
+
+  const result = runFromPrCliDryRun(tempRoot, [
+    '--type',
+    'advisory-recovery',
+    '--from-pr',
+    '1200',
+    '--owner',
+    'o',
+    '--repo',
+    'r',
+    '--agent-id',
+    'claude-02f8159e',
+    '--timestamp',
+    TS,
+  ]);
+
+  assert.deepEqual(result, {
+    mode: 'dry-run',
+    type: 'advisory-recovery',
+    target: 'pr',
+    number: 1200,
+    body: buildMarkerBody('advisory-recovery', {
+      'agent-id': 'claude-02f8159e',
+      'head-sha': SHA,
+      timestamp: TS,
+    }),
+  });
+});
+
+test('--from-pr CLI + --claim-id/--attempt still renders the claim-bound advisory-recovery form (dry-run)', () => {
+  // #1572's optional claim-bound pairing must keep working unchanged
+  // alongside #1889's --from-pr derivation.
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-from-pr-recovery-bound-'));
+  writeHeadShaOnlyGhStub(tempRoot, SHA);
+
+  const result = runFromPrCliDryRun(tempRoot, [
+    '--type',
+    'advisory-recovery',
+    '--from-pr',
+    '1200',
+    '--owner',
+    'o',
+    '--repo',
+    'r',
+    '--agent-id',
+    'claude-02f8159e',
+    '--timestamp',
+    TS,
+    '--claim-id',
+    'claude-8cb5b32f1100',
+    '--attempt',
+    '2',
+  ]);
+
+  assert.deepEqual(result, {
+    mode: 'dry-run',
+    type: 'advisory-recovery',
+    target: 'pr',
+    number: 1200,
+    body: buildMarkerBody('advisory-recovery', {
+      'agent-id': 'claude-02f8159e',
+      'head-sha': SHA,
+      timestamp: TS,
+      'claim-id': 'claude-8cb5b32f1100',
+      attempt: '2',
+    }),
+  });
+});
+
+test('--from-pr rejects manual --head-sha as ambiguous for an advisory type (before any gh call)', () => {
+  const stderr = runCliExpectingFailure([
+    join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+    '--type',
+    'advisory',
+    '--from-pr',
+    '1200',
+    '--head-sha',
+    SHA,
+    '--agent-id',
+    'a',
+    '--timestamp',
+    TS,
+  ]);
+  assert.match(
+    stderr,
+    /--from-pr derives head-sha from the live PR; do not also pass: --head-sha/,
+  );
+});
+
+test('--expected-head-sha is rejected together with --from-pr for a non-watermark type', () => {
+  // #1889: the E1 Step 1/Step 2 HEAD-pinning concept is watermark-specific;
+  // an advisory --from-pr has no Step 1 counterpart to pin against, so the
+  // combination fails closed rather than silently ignoring the flag.
+  const stderr = runCliExpectingFailure([
+    join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+    '--type',
+    'advisory',
+    '--from-pr',
+    '1200',
+    '--expected-head-sha',
+    SHA,
+    '--agent-id',
+    'a',
+    '--timestamp',
+    TS,
+  ]);
+  assert.match(
+    stderr,
+    /--expected-head-sha is only valid together with --from-pr --type watermark/,
+  );
+});
+
+test('--from-pr fails closed on an explicit non-pr --target for an advisory type', () => {
+  const stderr = runCliExpectingFailure([
+    join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+    '--type',
+    'advisory',
+    '--target',
+    'issue',
+    '--from-pr',
+    '1200',
+    '--agent-id',
+    'a',
+    '--timestamp',
+    TS,
+  ]);
+  assert.match(stderr, /--from-pr always targets the PR/);
+});
+
+test('--from-pr rejects a positional number that disagrees for an advisory type', () => {
+  const stderr = runCliExpectingFailure([
+    join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+    '--type',
+    'advisory',
+    '1201',
+    '--from-pr',
+    '1200',
+    '--agent-id',
+    'a',
+    '--timestamp',
+    TS,
+  ]);
+  assert.match(
+    stderr,
+    /in --from-pr mode the positional number must be omitted or equal --from-pr/,
+  );
 });
 
 // --- CLI-layer required-flag validation (#1722) -----------------------------

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -1350,7 +1350,18 @@ function writeHeadShaOnlyGhStub(tempRoot: string, headSha: string): void {
 const fs = require('node:fs');
 const args = process.argv.slice(2);
 const out = (s) => { fs.writeSync(1, s); process.exit(0); };
-if (args[0] === 'pr' && args[1] === 'view') out('${headSha}\\n');
+// Tightened to the exact lightweight call shape headShaFromPr() issues
+// (--json headRefOid --jq .headRefOid), not any \`gh pr view\` invocation --
+// proves the advisory --from-pr path never accidentally requests the
+// richer field set the watermark path uses (Copilot review, #1889/#1891).
+if (
+  args[0] === 'pr' &&
+  args[1] === 'view' &&
+  args.includes('headRefOid') &&
+  args.includes('.headRefOid')
+) {
+  out('${headSha}\\n');
+}
 fs.writeSync(2, 'unexpected gh invocation: ' + args.join(' '));
 process.exit(1);
 `,
@@ -1370,6 +1381,53 @@ function runFromPrCliDryRun(tempRoot: string, argv: string[]): unknown {
   );
   return JSON.parse(output);
 }
+
+test('--from-pr fails closed with a targeted error when gh pr view returns a non-SHA value', () => {
+  // Copilot review (#1889/#1891): headShaFromPr() must not just check for
+  // non-empty -- a non-SHA value (e.g. the literal text "null") should fail
+  // closed here with a specific message, not fall through to
+  // buildMarkerBody's generic "invalid advisory-wait marker payload".
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-from-pr-bad-sha-'));
+  writeHeadShaOnlyGhStub(tempRoot, 'null');
+
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
+        '--type',
+        'advisory',
+        '--from-pr',
+        '1200',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--agent-id',
+        'a',
+        '--timestamp',
+        TS,
+      ],
+      {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${tempRoot}:${process.env.PATH ?? ''}`,
+        },
+      },
+    );
+  } catch (error) {
+    const failure = error as { status?: number; stderr?: string };
+    assert.equal(failure.status, 1);
+    assert.match(
+      failure.stderr ?? '',
+      /failed to derive head-sha from PR 1200: PR 1200 has no usable headRefOid \(expected a 40-hex-character SHA, got: null\)/,
+    );
+    return;
+  }
+  throw new Error('expected the CLI to exit non-zero');
+});
 
 test('--from-pr CLI derives only --head-sha for --type advisory (dry-run)', () => {
   const tempRoot = mkdtempSync(join(tmpdir(), 'idd-from-pr-advisory-'));


### PR DESCRIPTION
## Summary

Extends `post-idd-marker.mjs`'s `--from-pr <n>` option to the three
advisory marker types (`advisory`, `advisory-recovery`,
`advisory-reroll`), alongside the existing `watermark` support. These
three types now derive `--head-sha` from a live, lightweight
`gh pr view --json headRefOid --jq .headRefOid` call instead of
requiring the caller to hand-type a 40-hex-character SHA — closing the
gap that let a fabricated-suffix SHA sit on PR #1870 as a live
trusted-actor marker for several minutes (2026-08-05 incident, see the
issue body).

- `--head-sha` derivation is lightweight for the advisory types: no
  full `review-activity-snapshot` composition, since those renderers
  accept no other snapshot-shaped field.
- `--from-pr` continues to imply `--target pr` and reuses the existing
  positional/`--from-pr` number consistency check across all four
  supported types instead of duplicating it.
- Passing both `--from-pr` and `--head-sha` together still fails
  closed for every supported type (existing watermark behavior,
  extended to advisory types).
- `--expected-head-sha` (the E1 Step 1 HEAD-pinning guard) stays
  watermark-only; combining it with a non-watermark `--from-pr` now
  fails closed instead of silently doing nothing, since the advisory
  types have no Step 1/Step 2 pinning concept.
- `advisory-recovery`'s existing optional `--claim-id`/`--attempt`
  pairing keeps working unchanged alongside `--from-pr`.
- Manual `--head-sha` keeps working unchanged for all four types when
  `--from-pr` is omitted.
- CLI `--help` text updated to document the new `--from-pr` alternative
  for each advisory type, mirroring the existing watermark line.

## Test plan

- [x] `node --test tests/post-idd-marker.test.mts` — 72/72 pass (9 new
      tests covering `--from-pr` for `advisory` / `advisory-recovery`
      (legacy and claim-bound forms) / `advisory-reroll`, the
      `--head-sha` conflict rejection, the `--expected-head-sha`
      non-watermark rejection, and the still-unsupported-type
      rejection).
- [x] `pnpm run build:check` — generated `scripts/post-idd-marker.mjs`
      matches the `.mts` source, committed alongside it.
- [x] `pre-push-validate` (biome, dprint, markdownlint, cspell,
      audit-docs, audit-code-span-wrap, build:check, idd-doctor) — all
      pass.

Closes #1889

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QDT6bdwFXu3EmgFUmLPiyC
