### PR TITLE
fix(supersession-detection): require closing keyword for pr refs

### DIFF
--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -86,17 +86,30 @@ export function findCandidateFileOverlap(files, candidateSet) {
   ].filter((file) => candidateSet.has(file));
 }
 /**
- * Word-bounded `#<issueNumber>` cross-reference test (#1878), matched
- * against a merged PR's `closingIssuesReferences` connection first, falling
- * back to a plain regex scan of `title`/`body`. `\b` after the digits
- * rejects a longer number sharing the same prefix (`#18620` does not match
- * `issueNumber: 1862`, since two digits share no word boundary), while still
- * matching every form the issue names: `#1862`, `Refs #1862`,
- * `Closes #1862`. Deliberately does not mask markdown code regions first
- * (unlike `checkDuplicateOrSuperseded`'s own free-text declaration scan) --
- * the issue pins a plain substring/regex check with no masking step, and a
- * `#<number>` cross-reference inside a code span or fence is not a realistic
- * false-positive vector for this specific pattern.
+ * Closing-keyword-adjacent `#<issueNumber>` cross-reference test (#1878;
+ * narrowed by #1888), matched against a merged PR's
+ * `closingIssuesReferences` connection first, falling back to a regex scan
+ * of `title`/`body`. That regex scan **requires** a recognized GitHub
+ * closing keyword (`close(s|d)?`, `fix(es|ed)?`, `resolve(s|d)?`,
+ * case-insensitive) immediately before the reference, separated only by
+ * whitespace -- the same grammar `idd-pr-submit.instructions.md`'s D3.5
+ * step already documents for closing-keyword detection
+ * (`\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#<N>\b`). A bare `#<n>`
+ * mention with no adjacent closing keyword no longer counts as a reference:
+ * PR #1886 (closes only #1878) bare-mentioned "#1862" once as a narrative
+ * reproduction-example citation ("observed live: issue #1862 vs. merged PR
+ * #1864...") rather than declaring it implements #1862, which the prior
+ * unconditional bare-mention fallback (#1878) wrongly treated as evidence
+ * PR #1886 itself superseded #1862. `\b` after the digits still rejects a
+ * longer number sharing the same prefix (`Closes #18620` does not match
+ * `issueNumber: 1862`), and the mandatory `\s+` between keyword and `#`
+ * means a keyword glued directly to the reference (`closes#1862`, no
+ * whitespace) does not match either. Deliberately does not mask markdown
+ * code regions first (unlike `checkDuplicateOrSuperseded`'s own free-text
+ * declaration scan) -- the issue pins a plain substring/regex check with no
+ * masking step, and a closing-keyword-adjacent cross-reference inside a
+ * code span or fence is not a realistic false-positive vector for this
+ * specific pattern.
  *
  * Defensive against a malformed `pr` shape the same way the rest of this
  * kernel is: a non-array `closingIssuesReferences` or non-string
@@ -128,19 +141,24 @@ export function prReferencesIssue(pr, issueNumber) {
   ) {
     return true;
   }
-  // Copilot review finding on PR #1886: a trailing `\b` alone only rejects
-  // a longer number sharing the digit prefix (`#18620` vs `1862`) -- it
-  // does NOT reject a word character immediately before `#` (`\b` requires
-  // one side `\w`, so `\b#` would require a `\w` before `#`, the opposite
-  // of what's needed here). `foo#1862` matched with only a trailing `\b`,
-  // which is not "word-bounded" as the issue's algorithm describes and
-  // could reintroduce a false positive from an incidental substring in a
-  // PR title/body. `(?<!\w)` requires the character immediately before `#`
-  // (if any) to NOT be a word character, rejecting `foo#1862` while still
-  // matching every legitimate form (start-of-string, whitespace, or
-  // punctuation before `#`: `#1862`, `Refs #1862`, `Closes #1862`,
-  // `(#1862)`).
-  const pattern = new RegExp(`(?<!\\w)#${issueNumber}\\b`);
+  // #1888: narrowed from a bare `#<n>` scan (#1878) to require a
+  // recognized GitHub closing keyword immediately before the reference --
+  // "this PR references that issue as background/example context" is no
+  // longer treated the same as "this PR implements that issue's own
+  // deliverable". `\b` before the keyword group rejects a keyword glued to
+  // a longer word (`Autoclose` does not match `close`), the mandatory
+  // `\s+` requires at least one whitespace character between the keyword
+  // and `#` (rejecting both a keyword glued directly to the reference,
+  // e.g. `closes#1862`, and the #1878 `foo#1862` word-glued-`#` case --
+  // whitespace is never a word character, so nothing word-glued can
+  // precede `#` here), and the trailing `\b` still rejects a longer number
+  // sharing the same digit prefix (`Closes #18620` does not match
+  // `issueNumber: 1862`). Case-insensitive so `Closes`, `closes`, `CLOSES`,
+  // etc. all match.
+  const pattern = new RegExp(
+    `\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+#${issueNumber}\\b`,
+    'i',
+  );
   const title = typeof pr.title === 'string' ? pr.title : '';
   const body = typeof pr.body === 'string' ? pr.body : '';
   return pattern.test(title) || pattern.test(body);

--- a/src/scripts/supersession-detection.mts
+++ b/src/scripts/supersession-detection.mts
@@ -169,17 +169,30 @@ export function findCandidateFileOverlap(
 }
 
 /**
- * Word-bounded `#<issueNumber>` cross-reference test (#1878), matched
- * against a merged PR's `closingIssuesReferences` connection first, falling
- * back to a plain regex scan of `title`/`body`. `\b` after the digits
- * rejects a longer number sharing the same prefix (`#18620` does not match
- * `issueNumber: 1862`, since two digits share no word boundary), while still
- * matching every form the issue names: `#1862`, `Refs #1862`,
- * `Closes #1862`. Deliberately does not mask markdown code regions first
- * (unlike `checkDuplicateOrSuperseded`'s own free-text declaration scan) --
- * the issue pins a plain substring/regex check with no masking step, and a
- * `#<number>` cross-reference inside a code span or fence is not a realistic
- * false-positive vector for this specific pattern.
+ * Closing-keyword-adjacent `#<issueNumber>` cross-reference test (#1878;
+ * narrowed by #1888), matched against a merged PR's
+ * `closingIssuesReferences` connection first, falling back to a regex scan
+ * of `title`/`body`. That regex scan **requires** a recognized GitHub
+ * closing keyword (`close(s|d)?`, `fix(es|ed)?`, `resolve(s|d)?`,
+ * case-insensitive) immediately before the reference, separated only by
+ * whitespace -- the same grammar `idd-pr-submit.instructions.md`'s D3.5
+ * step already documents for closing-keyword detection
+ * (`\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#<N>\b`). A bare `#<n>`
+ * mention with no adjacent closing keyword no longer counts as a reference:
+ * PR #1886 (closes only #1878) bare-mentioned "#1862" once as a narrative
+ * reproduction-example citation ("observed live: issue #1862 vs. merged PR
+ * #1864...") rather than declaring it implements #1862, which the prior
+ * unconditional bare-mention fallback (#1878) wrongly treated as evidence
+ * PR #1886 itself superseded #1862. `\b` after the digits still rejects a
+ * longer number sharing the same prefix (`Closes #18620` does not match
+ * `issueNumber: 1862`), and the mandatory `\s+` between keyword and `#`
+ * means a keyword glued directly to the reference (`closes#1862`, no
+ * whitespace) does not match either. Deliberately does not mask markdown
+ * code regions first (unlike `checkDuplicateOrSuperseded`'s own free-text
+ * declaration scan) -- the issue pins a plain substring/regex check with no
+ * masking step, and a closing-keyword-adjacent cross-reference inside a
+ * code span or fence is not a realistic false-positive vector for this
+ * specific pattern.
  *
  * Defensive against a malformed `pr` shape the same way the rest of this
  * kernel is: a non-array `closingIssuesReferences` or non-string
@@ -218,19 +231,24 @@ export function prReferencesIssue(
   ) {
     return true;
   }
-  // Copilot review finding on PR #1886: a trailing `\b` alone only rejects
-  // a longer number sharing the digit prefix (`#18620` vs `1862`) -- it
-  // does NOT reject a word character immediately before `#` (`\b` requires
-  // one side `\w`, so `\b#` would require a `\w` before `#`, the opposite
-  // of what's needed here). `foo#1862` matched with only a trailing `\b`,
-  // which is not "word-bounded" as the issue's algorithm describes and
-  // could reintroduce a false positive from an incidental substring in a
-  // PR title/body. `(?<!\w)` requires the character immediately before `#`
-  // (if any) to NOT be a word character, rejecting `foo#1862` while still
-  // matching every legitimate form (start-of-string, whitespace, or
-  // punctuation before `#`: `#1862`, `Refs #1862`, `Closes #1862`,
-  // `(#1862)`).
-  const pattern = new RegExp(`(?<!\\w)#${issueNumber}\\b`);
+  // #1888: narrowed from a bare `#<n>` scan (#1878) to require a
+  // recognized GitHub closing keyword immediately before the reference --
+  // "this PR references that issue as background/example context" is no
+  // longer treated the same as "this PR implements that issue's own
+  // deliverable". `\b` before the keyword group rejects a keyword glued to
+  // a longer word (`Autoclose` does not match `close`), the mandatory
+  // `\s+` requires at least one whitespace character between the keyword
+  // and `#` (rejecting both a keyword glued directly to the reference,
+  // e.g. `closes#1862`, and the #1878 `foo#1862` word-glued-`#` case --
+  // whitespace is never a word character, so nothing word-glued can
+  // precede `#` here), and the trailing `\b` still rejects a longer number
+  // sharing the same digit prefix (`Closes #18620` does not match
+  // `issueNumber: 1862`). Case-insensitive so `Closes`, `closes`, `CLOSES`,
+  // etc. all match.
+  const pattern = new RegExp(
+    `\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+#${issueNumber}\\b`,
+    'i',
+  );
   const title = typeof pr.title === 'string' ? pr.title : '';
   const body = typeof pr.body === 'string' ? pr.body : '';
   return pattern.test(title) || pattern.test(body);

--- a/tests/supersession-detection.test.mts
+++ b/tests/supersession-detection.test.mts
@@ -302,7 +302,14 @@ test('evaluateHighConfidenceDuplicate: true positive preserved via closingIssues
   assert.match(result?.evidence ?? '', /references issue #1862/);
 });
 
-test('evaluateHighConfidenceDuplicate: true positive preserved via a title/body #<number> cross-reference', () => {
+test('evaluateHighConfidenceDuplicate: true positive preserved via a title/body closing-keyword cross-reference (#1888)', () => {
+  // #1888 acceptance criterion 2: a closing-keyword mention (e.g.
+  // "Fixes #<B>") without closingIssuesReferences coverage still fails
+  // Check 4 as high-confidence. Prior to #1888 this test used a bare
+  // "Refs #1862" body, which the #1888 narrowing now correctly treats as
+  // NOT a reference (see the dedicated bare-mention test below) -- this
+  // slot is repurposed to a genuine closing-keyword form instead of just
+  // flipping the old assertion, so it still exercises a true positive.
   const result = evaluateHighConfidenceDuplicate(
     {
       closedByMergedPrNumbers: [],
@@ -315,7 +322,7 @@ test('evaluateHighConfidenceDuplicate: true positive preserved via a title/body 
           files: ['scripts/target.mjs'],
           closingIssuesReferences: [],
           title: 'fix: address feedback',
-          body: 'Refs #1862 for background.',
+          body: 'Fixes #1862 for the shared behavior.',
         },
       ],
     },
@@ -323,6 +330,37 @@ test('evaluateHighConfidenceDuplicate: true positive preserved via a title/body 
   );
   assert.equal(result?.pass, false);
   assert.match(result?.evidence ?? '', /#2001/);
+});
+
+test('evaluateHighConfidenceDuplicate: a bare "#<n>" citation with no closing keyword is not a hit (#1888; #1862 vs PR #1886 shape)', () => {
+  // #1888 acceptance criterion 1: reproduces the live false positive --
+  // merged PR #1886 closes only #1878, but its body bare-cites #1862 once
+  // as a narrative reproduction-example ("observed live: issue #1862 vs.
+  // merged PR #1864...") while also overlapping #1862's own declared
+  // candidate file. Before #1888, condition (b)'s unconditional bare-
+  // mention fallback treated that citation alone as evidence PR #1886
+  // superseded #1862; the narrowed regex requires an adjacent closing
+  // keyword, which this citation never had, so the verdict must now be
+  // `null` (falls through to the caller's weak heuristic), not a hit.
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      closedByMergedPrNumbers: [],
+      candidateFiles: ['tests/suitability-triage.test.mts'],
+      highContentionFiles: [],
+      mergedPrs: [
+        {
+          number: 1886,
+          mergedAt: '2026-08-05T00:00:00Z',
+          files: ['tests/suitability-triage.test.mts'],
+          closingIssuesReferences: [1878],
+          title: "fix(suitability-triage): Check 4's bare-mention condition",
+          body: 'observed live: issue #1862 vs. merged PR #1864 reproduced the Check 4 bug this PR fixes.',
+        },
+      ],
+    },
+    1862,
+  );
+  assert.equal(result, null);
 });
 
 test('evaluateHighConfidenceDuplicate: scan continues past a non-qualifying overlap to a later qualifying PR', () => {
@@ -404,13 +442,17 @@ test('prReferencesIssue: a { number } object entry with a different number still
   );
 });
 
-test('prReferencesIssue: matches a plain "#1862" in the title', () => {
+test('prReferencesIssue: a bare "#1862" in the title with no closing keyword does not match (#1888)', () => {
+  // #1888: prior to this fix, any bare "#<n>" mention matched
+  // unconditionally (#1878) -- "Refs #1862" cites the issue without
+  // declaring the PR implements it, and must no longer count as a
+  // reference.
   assert.equal(
     prReferencesIssue(
       { closingIssuesReferences: [], title: 'Refs #1862', body: '' },
       1862,
     ),
-    true,
+    false,
   );
 });
 
@@ -424,33 +466,86 @@ test('prReferencesIssue: matches "Closes #1862" in the body', () => {
   );
 });
 
-test('prReferencesIssue: word-boundary rejects a longer number sharing the same prefix', () => {
-  // "#18620" must not match candidate 1862 -- there is no word boundary
-  // between two digits.
+test('prReferencesIssue: matches every recognized closing keyword, case-insensitively and in past tense (#1888)', () => {
+  for (const body of [
+    'Closes #1862',
+    'closes #1862',
+    'CLOSES #1862',
+    'Close #1862',
+    'closed #1862',
+    'Fixes #1862',
+    'fix #1862',
+    'FIXED #1862',
+    'Resolves #1862',
+    'resolve #1862',
+    'RESOLVED #1862',
+  ]) {
+    assert.equal(
+      prReferencesIssue({ closingIssuesReferences: [], title: '', body }, 1862),
+      true,
+      `expected a match for body: ${body}`,
+    );
+  }
+});
+
+test('prReferencesIssue: word-boundary rejects a longer number sharing the same prefix (#1888: keyword-adjacent form)', () => {
+  // "Closes #18620" must not match candidate 1862 -- there is no word
+  // boundary between two digits. Uses a closing-keyword form (#1888)
+  // instead of the pre-#1888 bare "Refs #18620", since a bare mention no
+  // longer matches for an unrelated reason (absent keyword) and would no
+  // longer exercise this specific digit-boundary regression.
   assert.equal(
     prReferencesIssue(
-      { closingIssuesReferences: [], title: 'Refs #18620', body: '' },
+      { closingIssuesReferences: [], title: 'Closes #18620', body: '' },
       1862,
     ),
     false,
   );
 });
 
-test('prReferencesIssue: word-boundary rejects a "#" immediately preceded by a word character (Copilot review finding, PR #1886)', () => {
-  // "foo#1862" must not match -- a trailing \b alone doesn't reject a word
-  // character directly before "#"; a genuine cross-reference needs no word
-  // character immediately preceding it either.
+test('prReferencesIssue: a keyword glued directly to "#" with no whitespace does not match (#1888)', () => {
+  // "closes#1862" must not match -- the narrowed regex requires at least
+  // one whitespace character between the closing keyword and the "#"
+  // reference (matching GitHub's own closing-reference grammar), so a
+  // keyword-glued reference is rejected the same way the pre-#1888 fix
+  // rejected a word character glued directly before "#" (Copilot review
+  // finding, PR #1886).
   assert.equal(
     prReferencesIssue(
-      { closingIssuesReferences: [], title: 'foo#1862', body: '' },
+      { closingIssuesReferences: [], title: 'closes#1862', body: '' },
       1862,
     ),
     false,
   );
 });
 
-test('prReferencesIssue: still matches every legitimate cross-reference form after the leading-boundary fix', () => {
-  for (const body of ['#1862', 'Refs #1862', 'Closes #1862', '(#1862)']) {
+test('prReferencesIssue: bare/non-keyword cross-reference forms no longer match (#1888)', () => {
+  // Every form here matched unconditionally before #1888 (#1878's
+  // unconditional bare-mention fallback); none has a closing keyword
+  // immediately adjacent to the "#1862" reference, so none should match
+  // after the #1888 narrowing.
+  for (const body of [
+    '#1862',
+    'Refs #1862',
+    '(#1862)',
+    'See #1862',
+    'closing #1862',
+  ]) {
+    assert.equal(
+      prReferencesIssue({ closingIssuesReferences: [], title: '', body }, 1862),
+      false,
+      `expected no match for body: ${body}`,
+    );
+  }
+});
+
+test('prReferencesIssue: keyword-adjacent forms still match after the #1888 narrowing', () => {
+  for (const body of [
+    'Closes #1862',
+    'Fixes #1862',
+    'Resolves #1862',
+    '(Closes #1862)',
+  ]) {
     assert.equal(
       prReferencesIssue({ closingIssuesReferences: [], title: '', body }, 1862),
       true,


### PR DESCRIPTION
# Summary

`suitability-triage.mjs` Check 4's high-confidence tier (`prReferencesIssue`
in `src/scripts/supersession-detection.mts`) used to accept any bare
`#<candidate-number>` mention anywhere in a merged PR's title/body as
evidence the PR references — and therefore supersedes — that issue. This
conflated "cites the issue as background/example context" with "implements
the issue's own deliverable": merged PR #1886 (which closes only #1878)
bare-mentions "#1862" once as a narrative reproduction-example citation
("observed live: issue #1862 vs. merged PR #1864..."), and that citation
alone tripped a false high-confidence duplicate verdict on #1862 again.

This narrows the bare-mention regex to require a recognized GitHub closing
keyword (`close(s|d)?`, `fix(es|ed)?`, `resolve(s|d)?`, case-insensitive)
immediately adjacent to the `#<n>` reference (separated only by
whitespace), reusing the exact grammar already documented in
`idd-pr-submit.instructions.md`'s D3.5 step:
`\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#<N>\b`. Condition (a)
(`closingIssuesReferences`) is unchanged.

Two regression tests were added to `tests/supersession-detection.test.mts`:
one reproducing the exact #1862/PR #1886 shape (bare mention, no closing
keyword, with file overlap → no high-confidence hit), and one confirming a
closing-keyword mention without `closingIssuesReferences` coverage still
fails Check 4 as high-confidence. Existing tests that assumed the old
unconditional bare-mention behavior were repurposed to keyword-adjacent
forms so they still exercise their original boundary conditions (digit
prefix, keyword-glued-to-`#`) under the new regex.

## Linked issue

Closes #1888

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Second follow-up narrowing the same `prReferencesIssue` helper #1878/PR
#1886 introduced — that PR added the same-issue-reference requirement to
Check 4's file-overlap signal but accepted a bare mention as sufficient
"reference" evidence; this PR tightens that acceptance criterion without
touching Signal 1 (`closedByPullRequestsReferences`) or the file-overlap
logic itself.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs changed by this PR)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
