### PR TITLE
fix(markdown-code): track enclosing blocks for continued code spans

### DIFF
--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -303,12 +303,18 @@ function findMarkdownBlockBoundary(text, start, end) {
     openingListItem?.content ?? openingParsed.content;
   const openingFence = parseFencedLine(openingRawLine);
   const openingContainerDepth = openingParsed.containerDepth;
+  // isWithinOpenHtmlBlock only ever changes the outcome below through
+  // isLazyQuoteContinuation, which already requires openingContainerDepth >
+  // 0 -- so skip the backward scan entirely outside a blockquote, where the
+  // result can never matter anyway (the common case, for ordinary
+  // unquoted bodies).
   const openingIsParagraph =
     !isMarkdownBlockStart(openingParagraphContent) &&
     !MARKDOWN_HTML_BLOCK_START_PATTERN.test(openingParagraphContent) &&
     !MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(openingParagraphContent) &&
     (openingFence === null || !isValidFenceOpener(openingFence)) &&
-    !isWithinOpenHtmlBlock(text, openingLineStart, openingContainerDepth);
+    (openingContainerDepth === 0 ||
+      !isWithinOpenHtmlBlock(text, openingLineStart, openingContainerDepth));
   let lineStart = openingLine.next;
   while (lineStart < end) {
     const line = lineBounds(text, lineStart);

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -121,6 +121,31 @@ const MARKDOWN_HTML_BLOCK_START_PATTERN =
   /^ {0,3}(?:<!--|<\?|<![A-Z]|<!\[CDATA\[|<\/?(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|h[1-6]|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|ol|p|pre|script|section|style|summary|table|tbody|td|textarea|tfoot|th|thead|title|tr|track|ul)(?:[ \t]|\/?>|$))/iu;
 const MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN =
   /^ {0,3}<\/?[A-Za-z][A-Za-z0-9-]*(?:[ \t]+[^<>]*?)?[ \t]*\/?>/u;
+// CommonMark §4.1: a thematic break is 3+ matching -, _, or * characters,
+// each optionally followed by spaces/tabs -- interior spacing is allowed
+// (e.g. `_ _ _`), unlike the tightly-packed run already covered above.
+const MARKDOWN_THEMATIC_BREAK_PATTERN =
+  /^ {0,3}([-_*])(?:[ \t]*\1){2,}[ \t]*$/u;
+// CommonMark type-1 raw-text HTML elements (script/pre/style/textarea) only
+// end at a line containing their matching closing tag -- unlike the other
+// HTML block types, a blank line does not close them.
+const HTML_RAW_TEXT_TAG_CLOSE_PATTERN = /<\/(?:script|pre|style|textarea)\b/iu;
+/**
+ * True when `content` (a line with any blockquote/list container prefix
+ * already stripped) starts a new Markdown block -- either the fixed-form
+ * patterns above, or a thematic break whose repeated marker characters are
+ * separated by spaces or tabs.
+ */
+function isMarkdownBlockStart(content) {
+  return (
+    MARKDOWN_BLOCK_CONTENT_PATTERN.test(content) ||
+    MARKDOWN_THEMATIC_BREAK_PATTERN.test(content)
+  );
+}
+/** True when `content` opens with an HTML closing-tag slash (`</tag>`). */
+function isHtmlClosingSyntax(content) {
+  return /^ {0,3}<\//u.test(content);
+}
 function lineBounds(text, lineStart) {
   const newlineIndex = text.indexOf('\n', lineStart);
   const end =
@@ -134,6 +159,63 @@ function lineBounds(text, lineStart) {
     next: newlineIndex === -1 ? text.length : newlineIndex + 1,
   };
 }
+/**
+ * Find the start offset of the line immediately before `lineStart`, or
+ * `null` when `lineStart` is already the first line of `text`.
+ */
+function findPreviousLineStart(text, lineStart) {
+  if (lineStart <= 0) {
+    return null;
+  }
+  const terminatorIndex = lineStart - 1;
+  if (terminatorIndex === 0) {
+    return 0;
+  }
+  const priorNewline = text.lastIndexOf('\n', terminatorIndex - 1);
+  return priorNewline === -1 ? 0 : priorNewline + 1;
+}
+/**
+ * True when the line at `openingLineStart` is still inside a raw or custom
+ * HTML block opened on an earlier line at the same container depth (for
+ * example, an unclosed `<script>` directly above a quoted paragraph) -- so it
+ * must not be mistaken for an ordinary paragraph line. Scans backward
+ * through consecutive, non-blank, same-depth lines: a blank line or a
+ * container-depth change ends the search (not enclosed); a raw-text tag's
+ * matching closing line (`</script>` etc.) ends it too, since that block
+ * type only closes on a matching end tag. A closing tag for any other
+ * element (e.g. `</div>`) proves nothing on its own -- CommonMark's other
+ * HTML block types close only at a blank line -- so it is skipped rather
+ * than treated as a boundary or a find.
+ */
+function isWithinOpenHtmlBlock(text, openingLineStart, containerDepth) {
+  let lineStart = findPreviousLineStart(text, openingLineStart);
+  while (lineStart !== null) {
+    const line = lineBounds(text, lineStart);
+    const parsed = parseContainerLine(text.slice(lineStart, line.end));
+    if (
+      parsed.containerDepth !== containerDepth ||
+      parsed.content.trim() === ''
+    ) {
+      return false;
+    }
+    if (HTML_RAW_TEXT_TAG_CLOSE_PATTERN.test(parsed.content)) {
+      return false;
+    }
+    if (!isHtmlClosingSyntax(parsed.content)) {
+      if (
+        MARKDOWN_HTML_BLOCK_START_PATTERN.test(parsed.content) ||
+        MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(parsed.content)
+      ) {
+        return true;
+      }
+      if (isMarkdownBlockStart(parsed.content)) {
+        return false;
+      }
+    }
+    lineStart = findPreviousLineStart(text, lineStart);
+  }
+  return false;
+}
 function findMarkdownBlockBoundary(text, start, end) {
   const openingLineStart = text.lastIndexOf('\n', start - 1) + 1;
   const openingLine = lineBounds(text, openingLineStart);
@@ -143,28 +225,32 @@ function findMarkdownBlockBoundary(text, start, end) {
   const openingParagraphContent =
     openingListItem?.content ?? openingParsed.content;
   const openingFence = parseFencedLine(openingRawLine);
+  const openingContainerDepth = openingParsed.containerDepth;
   const openingIsParagraph =
-    !MARKDOWN_BLOCK_CONTENT_PATTERN.test(openingParagraphContent) &&
+    !isMarkdownBlockStart(openingParagraphContent) &&
     !MARKDOWN_HTML_BLOCK_START_PATTERN.test(openingParagraphContent) &&
     !MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(openingParagraphContent) &&
-    (openingFence === null || !isValidFenceOpener(openingFence));
-  const openingContainerDepth = openingParsed.containerDepth;
+    (openingFence === null || !isValidFenceOpener(openingFence)) &&
+    !isWithinOpenHtmlBlock(text, openingLineStart, openingContainerDepth);
   let lineStart = openingLine.next;
   while (lineStart < end) {
     const line = lineBounds(text, lineStart);
     const parsed = parseContainerLine(text.slice(lineStart, line.end));
     const fencedLine = parseFencedLine(text.slice(lineStart, line.end));
     const isBlockStart =
-      MARKDOWN_BLOCK_CONTENT_PATTERN.test(parsed.content) ||
+      isMarkdownBlockStart(parsed.content) ||
       MARKDOWN_HTML_BLOCK_START_PATTERN.test(parsed.content) ||
       MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(parsed.content) ||
       (fencedLine !== null && isValidFenceOpener(fencedLine));
     if (parsed.containerDepth !== openingContainerDepth) {
-      // A quote marker may continue an inline span only when it belongs to
-      // the same container. A quote that starts or ends here is a block break.
+      // A quote marker may continue an inline span while it stays a proper
+      // prefix of the opening container -- CommonMark laziness permits
+      // omitting any number of trailing `>` markers, not only all of them.
+      // A quote that goes deeper, or a line that starts a new block, is a
+      // real break.
       const isLazyQuoteContinuation =
         openingContainerDepth > 0 &&
-        parsed.containerDepth === 0 &&
+        parsed.containerDepth < openingContainerDepth &&
         openingIsParagraph &&
         !isBlockStart;
       if (

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -200,6 +200,14 @@ function findPreviousLineStart(text, lineStart) {
  *
  * A closing tag for a non-raw-text element (e.g. `</div>`) proves nothing on
  * its own and is skipped rather than treated as a boundary or a find.
+ *
+ * A scanned line's own list-item marker (e.g. `- <script>`) is stripped
+ * before testing it against the HTML patterns, the same way the opening
+ * line's own marker already is. This only ever affects a caller reachable
+ * through a container-depth change elsewhere (see `findMarkdownBlockBoundary`
+ * below) -- a bare, blockquote-free list item never reaches this function,
+ * since `findMarkdownBlockBoundary` does not itself track list-content
+ * indentation continuation (a separate, pre-existing gap, out of scope here).
  */
 function isWithinOpenHtmlBlock(text, openingLineStart, containerDepth) {
   let crossedBlankLine = false;
@@ -215,17 +223,21 @@ function isWithinOpenHtmlBlock(text, openingLineStart, containerDepth) {
       lineStart = findPreviousLineStart(text, lineStart);
       continue;
     }
-    if (HTML_RAW_TEXT_TAG_CLOSE_PATTERN.test(parsed.content)) {
+    // A list marker (e.g. `- <script>`) is not part of the HTML tag itself;
+    // test the content after it, the same way the opening-line check does.
+    const htmlContent =
+      parseListItemMatch(parsed.content)?.content ?? parsed.content;
+    if (HTML_RAW_TEXT_TAG_CLOSE_PATTERN.test(htmlContent)) {
       return false;
     }
-    if (HTML_RAW_TEXT_TAG_OPEN_PATTERN.test(parsed.content)) {
+    if (HTML_RAW_TEXT_TAG_OPEN_PATTERN.test(htmlContent)) {
       return true;
     }
     if (
       !crossedBlankLine &&
-      !isHtmlClosingSyntax(parsed.content) &&
-      (MARKDOWN_HTML_BLOCK_START_PATTERN.test(parsed.content) ||
-        MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(parsed.content))
+      !isHtmlClosingSyntax(htmlContent) &&
+      (MARKDOWN_HTML_BLOCK_START_PATTERN.test(htmlContent) ||
+        MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(htmlContent))
     ) {
       return true;
     }

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -213,19 +213,26 @@ function findPreviousLineStart(text, lineStart) {
  * through consecutive, same-depth lines; a container-depth change ends the
  * search unconditionally (not enclosed).
  *
- * The two HTML block families close differently, so neither a blank line nor
- * a line that otherwise looks like a new block (heading, list, thematic
- * break) ends either one by itself -- CommonMark keeps their content
- * completely literal until their own close condition:
+ * CommonMark's HTML block families close differently, so a line that
+ * otherwise looks like a new block (heading, list, thematic break) never
+ * ends any of them by itself -- their content stays completely literal
+ * until their own close condition. This scan's handling of the blank-line
+ * question, by family:
  *
  * - Raw-text elements (`<script>`/`<pre>`/`<style>`/`<textarea>`) close only
  *   on a line containing their matching end tag; a blank line does not
  *   affect them, so the scan keeps looking for one past any number of blank
  *   lines.
- * - Every other HTML block type closes only at a blank line. Once the scan
- *   has crossed one, an opener found further back no longer reaches the
- *   opening line and is ignored -- only a still-reachable raw-text opener
- *   can still apply.
+ * - The special forms (comment/processing-instruction/declaration/CDATA)
+ *   likewise close only on their own token per CommonMark, not on a blank
+ *   line -- this scan currently only recognizes a same-line self-close
+ *   (`isSelfClosedSpecialHtmlBlock`) for them; short of that, it falls back
+ *   to the blank-line-terminated handling below, which is imprecise for a
+ *   multi-line special block containing a blank line (tracked in #1895).
+ * - Every generic HTML block type (`<div>` and the like) genuinely does
+ *   close at a blank line. Once the scan has crossed one, an opener found
+ *   further back no longer reaches the opening line and is ignored -- only
+ *   a still-reachable raw-text opener can still apply.
  *
  * A closing tag for a non-raw-text element (e.g. `</div>`) proves nothing on
  * its own and is skipped rather than treated as a boundary or a find.

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -137,10 +137,11 @@ const HTML_RAW_TEXT_TAG_OPEN_PATTERN =
  * stripped -- a caller-held list-item marker, if present, may still be in
  * place) starts a new Markdown block -- either the fixed-form patterns
  * above, or a thematic break whose repeated marker characters are separated
- * by spaces or tabs. The heading/list/thematic-break patterns this checks
- * are all anchored at the very start of `content`, so a leading list marker
- * (which none of them match) safely makes this return `false` rather than a
- * false positive.
+ * by spaces or tabs. `MARKDOWN_BLOCK_CONTENT_PATTERN`'s own list-item
+ * alternative already matches a leading `-`/`+`/`*`/`1.`/`1)` marker
+ * directly, correctly treating it as a block start on its own -- a list
+ * item is a genuine new block per CommonMark -- so no separate stripping is
+ * needed here regardless of whether the caller already stripped one.
  */
 function isMarkdownBlockStart(content) {
   return (

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -232,6 +232,17 @@ function findPreviousLineStart(text, lineStart) {
  * below) -- a bare, blockquote-free list item never reaches this function,
  * since `findMarkdownBlockBoundary` does not itself track list-content
  * indentation continuation (a separate, pre-existing gap, out of scope here).
+ *
+ * **Known limitation.** This scan short-circuits on the first close/open
+ * signal it finds, so it does not track more than one candidate enclosing
+ * block type at once. A line whose literal content merely *resembles* a
+ * raw-text closing tag (e.g. `</script>` appearing as plain text inside a
+ * still-open, unclosed multi-line HTML comment) is read as a genuine
+ * raw-text closer, ending the scan before it can reach the comment's real
+ * opener further back -- a bounded backward scan cannot fully disambiguate
+ * this without the kind of forward, single-pass block-state tracking the
+ * rest of this module does not otherwise need. Tracked as a follow-up
+ * rather than folded into this pass.
  */
 function isWithinOpenHtmlBlock(text, openingLineStart, containerDepth) {
   let crossedBlankLine = false;

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -133,10 +133,14 @@ const HTML_RAW_TEXT_TAG_CLOSE_PATTERN = /<\/(?:script|pre|style|textarea)\b/iu;
 const HTML_RAW_TEXT_TAG_OPEN_PATTERN =
   /^ {0,3}<(?:script|pre|style|textarea)\b/iu;
 /**
- * True when `content` (a line with any blockquote/list container prefix
- * already stripped) starts a new Markdown block -- either the fixed-form
- * patterns above, or a thematic break whose repeated marker characters are
- * separated by spaces or tabs.
+ * True when `content` (a line with any blockquote container prefix already
+ * stripped -- a caller-held list-item marker, if present, may still be in
+ * place) starts a new Markdown block -- either the fixed-form patterns
+ * above, or a thematic break whose repeated marker characters are separated
+ * by spaces or tabs. The heading/list/thematic-break patterns this checks
+ * are all anchored at the very start of `content`, so a leading list marker
+ * (which none of them match) safely makes this return `false` rather than a
+ * false positive.
  */
 function isMarkdownBlockStart(content) {
   return (

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -130,6 +130,8 @@ const MARKDOWN_THEMATIC_BREAK_PATTERN =
 // end at a line containing their matching closing tag -- unlike the other
 // HTML block types, a blank line does not close them.
 const HTML_RAW_TEXT_TAG_CLOSE_PATTERN = /<\/(?:script|pre|style|textarea)\b/iu;
+const HTML_RAW_TEXT_TAG_OPEN_PATTERN =
+  /^ {0,3}<(?:script|pre|style|textarea)\b/iu;
 /**
  * True when `content` (a line with any blockquote/list container prefix
  * already stripped) starts a new Markdown block -- either the fixed-form
@@ -179,38 +181,53 @@ function findPreviousLineStart(text, lineStart) {
  * HTML block opened on an earlier line at the same container depth (for
  * example, an unclosed `<script>` directly above a quoted paragraph) -- so it
  * must not be mistaken for an ordinary paragraph line. Scans backward
- * through consecutive, non-blank, same-depth lines: a blank line or a
- * container-depth change ends the search (not enclosed); a raw-text tag's
- * matching closing line (`</script>` etc.) ends it too, since that block
- * type only closes on a matching end tag. A closing tag for any other
- * element (e.g. `</div>`) proves nothing on its own -- CommonMark's other
- * HTML block types close only at a blank line -- so it is skipped rather
- * than treated as a boundary or a find.
+ * through consecutive, same-depth lines; a container-depth change ends the
+ * search unconditionally (not enclosed).
+ *
+ * The two HTML block families close differently, so neither a blank line nor
+ * a line that otherwise looks like a new block (heading, list, thematic
+ * break) ends either one by itself -- CommonMark keeps their content
+ * completely literal until their own close condition:
+ *
+ * - Raw-text elements (`<script>`/`<pre>`/`<style>`/`<textarea>`) close only
+ *   on a line containing their matching end tag; a blank line does not
+ *   affect them, so the scan keeps looking for one past any number of blank
+ *   lines.
+ * - Every other HTML block type closes only at a blank line. Once the scan
+ *   has crossed one, an opener found further back no longer reaches the
+ *   opening line and is ignored -- only a still-reachable raw-text opener
+ *   can still apply.
+ *
+ * A closing tag for a non-raw-text element (e.g. `</div>`) proves nothing on
+ * its own and is skipped rather than treated as a boundary or a find.
  */
 function isWithinOpenHtmlBlock(text, openingLineStart, containerDepth) {
+  let crossedBlankLine = false;
   let lineStart = findPreviousLineStart(text, openingLineStart);
   while (lineStart !== null) {
     const line = lineBounds(text, lineStart);
     const parsed = parseContainerLine(text.slice(lineStart, line.end));
-    if (
-      parsed.containerDepth !== containerDepth ||
-      parsed.content.trim() === ''
-    ) {
+    if (parsed.containerDepth !== containerDepth) {
       return false;
+    }
+    if (parsed.content.trim() === '') {
+      crossedBlankLine = true;
+      lineStart = findPreviousLineStart(text, lineStart);
+      continue;
     }
     if (HTML_RAW_TEXT_TAG_CLOSE_PATTERN.test(parsed.content)) {
       return false;
     }
-    if (!isHtmlClosingSyntax(parsed.content)) {
-      if (
-        MARKDOWN_HTML_BLOCK_START_PATTERN.test(parsed.content) ||
-        MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(parsed.content)
-      ) {
-        return true;
-      }
-      if (isMarkdownBlockStart(parsed.content)) {
-        return false;
-      }
+    if (HTML_RAW_TEXT_TAG_OPEN_PATTERN.test(parsed.content)) {
+      return true;
+    }
+    if (
+      !crossedBlankLine &&
+      !isHtmlClosingSyntax(parsed.content) &&
+      (MARKDOWN_HTML_BLOCK_START_PATTERN.test(parsed.content) ||
+        MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(parsed.content))
+    ) {
+      return true;
     }
     lineStart = findPreviousLineStart(text, lineStart);
   }

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -148,6 +148,30 @@ function isMarkdownBlockStart(content) {
 function isHtmlClosingSyntax(content) {
   return /^ {0,3}<\//u.test(content);
 }
+/**
+ * True when `content` opens one of CommonMark's four special HTML block
+ * forms (comment, processing instruction, declaration, CDATA) and also
+ * carries that form's own closing token later on the same line -- e.g.
+ * `<!-- comment -->`. Unlike a raw-text or generic HTML block, these forms
+ * can be fully self-contained on one line; when they are, that line proves
+ * nothing about enclosing a later line and must not be read as leaving an
+ * open block behind it.
+ */
+function isSelfClosedSpecialHtmlBlock(content) {
+  if (/^ {0,3}<!--/u.test(content)) {
+    return content.includes('-->');
+  }
+  if (/^ {0,3}<\?/u.test(content)) {
+    return content.includes('?>');
+  }
+  if (/^ {0,3}<!\[CDATA\[/iu.test(content)) {
+    return content.includes(']]>');
+  }
+  if (/^ {0,3}<![A-Z]/iu.test(content)) {
+    return content.includes('>');
+  }
+  return false;
+}
 function lineBounds(text, lineStart) {
   const newlineIndex = text.indexOf('\n', lineStart);
   const end =
@@ -236,6 +260,7 @@ function isWithinOpenHtmlBlock(text, openingLineStart, containerDepth) {
     if (
       !crossedBlankLine &&
       !isHtmlClosingSyntax(htmlContent) &&
+      !isSelfClosedSpecialHtmlBlock(htmlContent) &&
       (MARKDOWN_HTML_BLOCK_START_PATTERN.test(htmlContent) ||
         MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(htmlContent))
     ) {

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -147,10 +147,14 @@ const HTML_RAW_TEXT_TAG_OPEN_PATTERN =
   /^ {0,3}<(?:script|pre|style|textarea)\b/iu;
 
 /**
- * True when `content` (a line with any blockquote/list container prefix
- * already stripped) starts a new Markdown block -- either the fixed-form
- * patterns above, or a thematic break whose repeated marker characters are
- * separated by spaces or tabs.
+ * True when `content` (a line with any blockquote container prefix already
+ * stripped -- a caller-held list-item marker, if present, may still be in
+ * place) starts a new Markdown block -- either the fixed-form patterns
+ * above, or a thematic break whose repeated marker characters are separated
+ * by spaces or tabs. The heading/list/thematic-break patterns this checks
+ * are all anchored at the very start of `content`, so a leading list marker
+ * (which none of them match) safely makes this return `false` rather than a
+ * false positive.
  */
 function isMarkdownBlockStart(content: string): boolean {
   return (

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -164,6 +164,31 @@ function isHtmlClosingSyntax(content: string): boolean {
   return /^ {0,3}<\//u.test(content);
 }
 
+/**
+ * True when `content` opens one of CommonMark's four special HTML block
+ * forms (comment, processing instruction, declaration, CDATA) and also
+ * carries that form's own closing token later on the same line -- e.g.
+ * `<!-- comment -->`. Unlike a raw-text or generic HTML block, these forms
+ * can be fully self-contained on one line; when they are, that line proves
+ * nothing about enclosing a later line and must not be read as leaving an
+ * open block behind it.
+ */
+function isSelfClosedSpecialHtmlBlock(content: string): boolean {
+  if (/^ {0,3}<!--/u.test(content)) {
+    return content.includes('-->');
+  }
+  if (/^ {0,3}<\?/u.test(content)) {
+    return content.includes('?>');
+  }
+  if (/^ {0,3}<!\[CDATA\[/iu.test(content)) {
+    return content.includes(']]>');
+  }
+  if (/^ {0,3}<![A-Z]/iu.test(content)) {
+    return content.includes('>');
+  }
+  return false;
+}
+
 function lineBounds(
   text: string,
   lineStart: number,
@@ -264,6 +289,7 @@ function isWithinOpenHtmlBlock(
     if (
       !crossedBlankLine &&
       !isHtmlClosingSyntax(htmlContent) &&
+      !isSelfClosedSpecialHtmlBlock(htmlContent) &&
       (MARKDOWN_HTML_BLOCK_START_PATTERN.test(htmlContent) ||
         MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(htmlContent))
     ) {

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -238,19 +238,26 @@ function findPreviousLineStart(text: string, lineStart: number): number | null {
  * through consecutive, same-depth lines; a container-depth change ends the
  * search unconditionally (not enclosed).
  *
- * The two HTML block families close differently, so neither a blank line nor
- * a line that otherwise looks like a new block (heading, list, thematic
- * break) ends either one by itself -- CommonMark keeps their content
- * completely literal until their own close condition:
+ * CommonMark's HTML block families close differently, so a line that
+ * otherwise looks like a new block (heading, list, thematic break) never
+ * ends any of them by itself -- their content stays completely literal
+ * until their own close condition. This scan's handling of the blank-line
+ * question, by family:
  *
  * - Raw-text elements (`<script>`/`<pre>`/`<style>`/`<textarea>`) close only
  *   on a line containing their matching end tag; a blank line does not
  *   affect them, so the scan keeps looking for one past any number of blank
  *   lines.
- * - Every other HTML block type closes only at a blank line. Once the scan
- *   has crossed one, an opener found further back no longer reaches the
- *   opening line and is ignored -- only a still-reachable raw-text opener
- *   can still apply.
+ * - The special forms (comment/processing-instruction/declaration/CDATA)
+ *   likewise close only on their own token per CommonMark, not on a blank
+ *   line -- this scan currently only recognizes a same-line self-close
+ *   (`isSelfClosedSpecialHtmlBlock`) for them; short of that, it falls back
+ *   to the blank-line-terminated handling below, which is imprecise for a
+ *   multi-line special block containing a blank line (tracked in #1895).
+ * - Every generic HTML block type (`<div>` and the like) genuinely does
+ *   close at a blank line. Once the scan has crossed one, an opener found
+ *   further back no longer reaches the opening line and is ignored -- only
+ *   a still-reachable raw-text opener can still apply.
  *
  * A closing tag for a non-raw-text element (e.g. `</div>`) proves nothing on
  * its own and is skipped rather than treated as a boundary or a find.

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -257,6 +257,17 @@ function findPreviousLineStart(text: string, lineStart: number): number | null {
  * below) -- a bare, blockquote-free list item never reaches this function,
  * since `findMarkdownBlockBoundary` does not itself track list-content
  * indentation continuation (a separate, pre-existing gap, out of scope here).
+ *
+ * **Known limitation.** This scan short-circuits on the first close/open
+ * signal it finds, so it does not track more than one candidate enclosing
+ * block type at once. A line whose literal content merely *resembles* a
+ * raw-text closing tag (e.g. `</script>` appearing as plain text inside a
+ * still-open, unclosed multi-line HTML comment) is read as a genuine
+ * raw-text closer, ending the scan before it can reach the comment's real
+ * opener further back -- a bounded backward scan cannot fully disambiguate
+ * this without the kind of forward, single-pass block-state tracking the
+ * rest of this module does not otherwise need. Tracked as a follow-up
+ * rather than folded into this pass.
  */
 function isWithinOpenHtmlBlock(
   text: string,

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -224,6 +224,14 @@ function findPreviousLineStart(text: string, lineStart: number): number | null {
  *
  * A closing tag for a non-raw-text element (e.g. `</div>`) proves nothing on
  * its own and is skipped rather than treated as a boundary or a find.
+ *
+ * A scanned line's own list-item marker (e.g. `- <script>`) is stripped
+ * before testing it against the HTML patterns, the same way the opening
+ * line's own marker already is. This only ever affects a caller reachable
+ * through a container-depth change elsewhere (see `findMarkdownBlockBoundary`
+ * below) -- a bare, blockquote-free list item never reaches this function,
+ * since `findMarkdownBlockBoundary` does not itself track list-content
+ * indentation continuation (a separate, pre-existing gap, out of scope here).
  */
 function isWithinOpenHtmlBlock(
   text: string,
@@ -243,17 +251,21 @@ function isWithinOpenHtmlBlock(
       lineStart = findPreviousLineStart(text, lineStart);
       continue;
     }
-    if (HTML_RAW_TEXT_TAG_CLOSE_PATTERN.test(parsed.content)) {
+    // A list marker (e.g. `- <script>`) is not part of the HTML tag itself;
+    // test the content after it, the same way the opening-line check does.
+    const htmlContent =
+      parseListItemMatch(parsed.content)?.content ?? parsed.content;
+    if (HTML_RAW_TEXT_TAG_CLOSE_PATTERN.test(htmlContent)) {
       return false;
     }
-    if (HTML_RAW_TEXT_TAG_OPEN_PATTERN.test(parsed.content)) {
+    if (HTML_RAW_TEXT_TAG_OPEN_PATTERN.test(htmlContent)) {
       return true;
     }
     if (
       !crossedBlankLine &&
-      !isHtmlClosingSyntax(parsed.content) &&
-      (MARKDOWN_HTML_BLOCK_START_PATTERN.test(parsed.content) ||
-        MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(parsed.content))
+      !isHtmlClosingSyntax(htmlContent) &&
+      (MARKDOWN_HTML_BLOCK_START_PATTERN.test(htmlContent) ||
+        MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(htmlContent))
     ) {
       return true;
     }

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -143,6 +143,8 @@ const MARKDOWN_THEMATIC_BREAK_PATTERN =
 // end at a line containing their matching closing tag -- unlike the other
 // HTML block types, a blank line does not close them.
 const HTML_RAW_TEXT_TAG_CLOSE_PATTERN = /<\/(?:script|pre|style|textarea)\b/iu;
+const HTML_RAW_TEXT_TAG_OPEN_PATTERN =
+  /^ {0,3}<(?:script|pre|style|textarea)\b/iu;
 
 /**
  * True when `content` (a line with any blockquote/list container prefix
@@ -203,42 +205,57 @@ function findPreviousLineStart(text: string, lineStart: number): number | null {
  * HTML block opened on an earlier line at the same container depth (for
  * example, an unclosed `<script>` directly above a quoted paragraph) -- so it
  * must not be mistaken for an ordinary paragraph line. Scans backward
- * through consecutive, non-blank, same-depth lines: a blank line or a
- * container-depth change ends the search (not enclosed); a raw-text tag's
- * matching closing line (`</script>` etc.) ends it too, since that block
- * type only closes on a matching end tag. A closing tag for any other
- * element (e.g. `</div>`) proves nothing on its own -- CommonMark's other
- * HTML block types close only at a blank line -- so it is skipped rather
- * than treated as a boundary or a find.
+ * through consecutive, same-depth lines; a container-depth change ends the
+ * search unconditionally (not enclosed).
+ *
+ * The two HTML block families close differently, so neither a blank line nor
+ * a line that otherwise looks like a new block (heading, list, thematic
+ * break) ends either one by itself -- CommonMark keeps their content
+ * completely literal until their own close condition:
+ *
+ * - Raw-text elements (`<script>`/`<pre>`/`<style>`/`<textarea>`) close only
+ *   on a line containing their matching end tag; a blank line does not
+ *   affect them, so the scan keeps looking for one past any number of blank
+ *   lines.
+ * - Every other HTML block type closes only at a blank line. Once the scan
+ *   has crossed one, an opener found further back no longer reaches the
+ *   opening line and is ignored -- only a still-reachable raw-text opener
+ *   can still apply.
+ *
+ * A closing tag for a non-raw-text element (e.g. `</div>`) proves nothing on
+ * its own and is skipped rather than treated as a boundary or a find.
  */
 function isWithinOpenHtmlBlock(
   text: string,
   openingLineStart: number,
   containerDepth: number,
 ): boolean {
+  let crossedBlankLine = false;
   let lineStart = findPreviousLineStart(text, openingLineStart);
   while (lineStart !== null) {
     const line = lineBounds(text, lineStart);
     const parsed = parseContainerLine(text.slice(lineStart, line.end));
-    if (
-      parsed.containerDepth !== containerDepth ||
-      parsed.content.trim() === ''
-    ) {
+    if (parsed.containerDepth !== containerDepth) {
       return false;
+    }
+    if (parsed.content.trim() === '') {
+      crossedBlankLine = true;
+      lineStart = findPreviousLineStart(text, lineStart);
+      continue;
     }
     if (HTML_RAW_TEXT_TAG_CLOSE_PATTERN.test(parsed.content)) {
       return false;
     }
-    if (!isHtmlClosingSyntax(parsed.content)) {
-      if (
-        MARKDOWN_HTML_BLOCK_START_PATTERN.test(parsed.content) ||
-        MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(parsed.content)
-      ) {
-        return true;
-      }
-      if (isMarkdownBlockStart(parsed.content)) {
-        return false;
-      }
+    if (HTML_RAW_TEXT_TAG_OPEN_PATTERN.test(parsed.content)) {
+      return true;
+    }
+    if (
+      !crossedBlankLine &&
+      !isHtmlClosingSyntax(parsed.content) &&
+      (MARKDOWN_HTML_BLOCK_START_PATTERN.test(parsed.content) ||
+        MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(parsed.content))
+    ) {
+      return true;
     }
     lineStart = findPreviousLineStart(text, lineStart);
   }

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -134,6 +134,33 @@ const MARKDOWN_HTML_BLOCK_START_PATTERN =
   /^ {0,3}(?:<!--|<\?|<![A-Z]|<!\[CDATA\[|<\/?(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|h[1-6]|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|ol|p|pre|script|section|style|summary|table|tbody|td|textarea|tfoot|th|thead|title|tr|track|ul)(?:[ \t]|\/?>|$))/iu;
 const MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN =
   /^ {0,3}<\/?[A-Za-z][A-Za-z0-9-]*(?:[ \t]+[^<>]*?)?[ \t]*\/?>/u;
+// CommonMark §4.1: a thematic break is 3+ matching -, _, or * characters,
+// each optionally followed by spaces/tabs -- interior spacing is allowed
+// (e.g. `_ _ _`), unlike the tightly-packed run already covered above.
+const MARKDOWN_THEMATIC_BREAK_PATTERN =
+  /^ {0,3}([-_*])(?:[ \t]*\1){2,}[ \t]*$/u;
+// CommonMark type-1 raw-text HTML elements (script/pre/style/textarea) only
+// end at a line containing their matching closing tag -- unlike the other
+// HTML block types, a blank line does not close them.
+const HTML_RAW_TEXT_TAG_CLOSE_PATTERN = /<\/(?:script|pre|style|textarea)\b/iu;
+
+/**
+ * True when `content` (a line with any blockquote/list container prefix
+ * already stripped) starts a new Markdown block -- either the fixed-form
+ * patterns above, or a thematic break whose repeated marker characters are
+ * separated by spaces or tabs.
+ */
+function isMarkdownBlockStart(content: string): boolean {
+  return (
+    MARKDOWN_BLOCK_CONTENT_PATTERN.test(content) ||
+    MARKDOWN_THEMATIC_BREAK_PATTERN.test(content)
+  );
+}
+
+/** True when `content` opens with an HTML closing-tag slash (`</tag>`). */
+function isHtmlClosingSyntax(content: string): boolean {
+  return /^ {0,3}<\//u.test(content);
+}
 
 function lineBounds(
   text: string,
@@ -155,6 +182,69 @@ function lineBounds(
   };
 }
 
+/**
+ * Find the start offset of the line immediately before `lineStart`, or
+ * `null` when `lineStart` is already the first line of `text`.
+ */
+function findPreviousLineStart(text: string, lineStart: number): number | null {
+  if (lineStart <= 0) {
+    return null;
+  }
+  const terminatorIndex = lineStart - 1;
+  if (terminatorIndex === 0) {
+    return 0;
+  }
+  const priorNewline = text.lastIndexOf('\n', terminatorIndex - 1);
+  return priorNewline === -1 ? 0 : priorNewline + 1;
+}
+
+/**
+ * True when the line at `openingLineStart` is still inside a raw or custom
+ * HTML block opened on an earlier line at the same container depth (for
+ * example, an unclosed `<script>` directly above a quoted paragraph) -- so it
+ * must not be mistaken for an ordinary paragraph line. Scans backward
+ * through consecutive, non-blank, same-depth lines: a blank line or a
+ * container-depth change ends the search (not enclosed); a raw-text tag's
+ * matching closing line (`</script>` etc.) ends it too, since that block
+ * type only closes on a matching end tag. A closing tag for any other
+ * element (e.g. `</div>`) proves nothing on its own -- CommonMark's other
+ * HTML block types close only at a blank line -- so it is skipped rather
+ * than treated as a boundary or a find.
+ */
+function isWithinOpenHtmlBlock(
+  text: string,
+  openingLineStart: number,
+  containerDepth: number,
+): boolean {
+  let lineStart = findPreviousLineStart(text, openingLineStart);
+  while (lineStart !== null) {
+    const line = lineBounds(text, lineStart);
+    const parsed = parseContainerLine(text.slice(lineStart, line.end));
+    if (
+      parsed.containerDepth !== containerDepth ||
+      parsed.content.trim() === ''
+    ) {
+      return false;
+    }
+    if (HTML_RAW_TEXT_TAG_CLOSE_PATTERN.test(parsed.content)) {
+      return false;
+    }
+    if (!isHtmlClosingSyntax(parsed.content)) {
+      if (
+        MARKDOWN_HTML_BLOCK_START_PATTERN.test(parsed.content) ||
+        MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(parsed.content)
+      ) {
+        return true;
+      }
+      if (isMarkdownBlockStart(parsed.content)) {
+        return false;
+      }
+    }
+    lineStart = findPreviousLineStart(text, lineStart);
+  }
+  return false;
+}
+
 function findMarkdownBlockBoundary(
   text: string,
   start: number,
@@ -168,12 +258,13 @@ function findMarkdownBlockBoundary(
   const openingParagraphContent =
     openingListItem?.content ?? openingParsed.content;
   const openingFence = parseFencedLine(openingRawLine);
+  const openingContainerDepth = openingParsed.containerDepth;
   const openingIsParagraph =
-    !MARKDOWN_BLOCK_CONTENT_PATTERN.test(openingParagraphContent) &&
+    !isMarkdownBlockStart(openingParagraphContent) &&
     !MARKDOWN_HTML_BLOCK_START_PATTERN.test(openingParagraphContent) &&
     !MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(openingParagraphContent) &&
-    (openingFence === null || !isValidFenceOpener(openingFence));
-  const openingContainerDepth = openingParsed.containerDepth;
+    (openingFence === null || !isValidFenceOpener(openingFence)) &&
+    !isWithinOpenHtmlBlock(text, openingLineStart, openingContainerDepth);
   let lineStart = openingLine.next;
 
   while (lineStart < end) {
@@ -181,16 +272,19 @@ function findMarkdownBlockBoundary(
     const parsed = parseContainerLine(text.slice(lineStart, line.end));
     const fencedLine = parseFencedLine(text.slice(lineStart, line.end));
     const isBlockStart =
-      MARKDOWN_BLOCK_CONTENT_PATTERN.test(parsed.content) ||
+      isMarkdownBlockStart(parsed.content) ||
       MARKDOWN_HTML_BLOCK_START_PATTERN.test(parsed.content) ||
       MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(parsed.content) ||
       (fencedLine !== null && isValidFenceOpener(fencedLine));
     if (parsed.containerDepth !== openingContainerDepth) {
-      // A quote marker may continue an inline span only when it belongs to
-      // the same container. A quote that starts or ends here is a block break.
+      // A quote marker may continue an inline span while it stays a proper
+      // prefix of the opening container -- CommonMark laziness permits
+      // omitting any number of trailing `>` markers, not only all of them.
+      // A quote that goes deeper, or a line that starts a new block, is a
+      // real break.
       const isLazyQuoteContinuation =
         openingContainerDepth > 0 &&
-        parsed.containerDepth === 0 &&
+        parsed.containerDepth < openingContainerDepth &&
         openingIsParagraph &&
         !isBlockStart;
       if (

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -337,12 +337,18 @@ function findMarkdownBlockBoundary(
     openingListItem?.content ?? openingParsed.content;
   const openingFence = parseFencedLine(openingRawLine);
   const openingContainerDepth = openingParsed.containerDepth;
+  // isWithinOpenHtmlBlock only ever changes the outcome below through
+  // isLazyQuoteContinuation, which already requires openingContainerDepth >
+  // 0 -- so skip the backward scan entirely outside a blockquote, where the
+  // result can never matter anyway (the common case, for ordinary
+  // unquoted bodies).
   const openingIsParagraph =
     !isMarkdownBlockStart(openingParagraphContent) &&
     !MARKDOWN_HTML_BLOCK_START_PATTERN.test(openingParagraphContent) &&
     !MARKDOWN_CUSTOM_HTML_BLOCK_START_PATTERN.test(openingParagraphContent) &&
     (openingFence === null || !isValidFenceOpener(openingFence)) &&
-    !isWithinOpenHtmlBlock(text, openingLineStart, openingContainerDepth);
+    (openingContainerDepth === 0 ||
+      !isWithinOpenHtmlBlock(text, openingLineStart, openingContainerDepth));
   let lineStart = openingLine.next;
 
   while (lineStart < end) {

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -151,10 +151,11 @@ const HTML_RAW_TEXT_TAG_OPEN_PATTERN =
  * stripped -- a caller-held list-item marker, if present, may still be in
  * place) starts a new Markdown block -- either the fixed-form patterns
  * above, or a thematic break whose repeated marker characters are separated
- * by spaces or tabs. The heading/list/thematic-break patterns this checks
- * are all anchored at the very start of `content`, so a leading list marker
- * (which none of them match) safely makes this return `false` rather than a
- * false positive.
+ * by spaces or tabs. `MARKDOWN_BLOCK_CONTENT_PATTERN`'s own list-item
+ * alternative already matches a leading `-`/`+`/`*`/`1.`/`1)` marker
+ * directly, correctly treating it as a block start on its own -- a list
+ * item is a genuine new block per CommonMark -- so no separate stripping is
+ * needed here regardless of whether the caller already stripped one.
  */
 function isMarkdownBlockStart(content: string): boolean {
   return (

--- a/tests/markdown-code.test.mts
+++ b/tests/markdown-code.test.mts
@@ -222,3 +222,13 @@ test('findMarkdownCodeRanges still ends a generic HTML block at a blank line', (
     { start: body.indexOf(tick), end: body.lastIndexOf(tick) + 1 },
   ]);
 });
+
+test('findMarkdownCodeRanges does not mask a span opened after a list-item raw HTML opener inside a quote', () => {
+  const tick = String.fromCharCode(96);
+  // PR #1893 review finding: a list marker (`- <script>`) is not part of the
+  // HTML tag itself; stripping it before the HTML-pattern test is required
+  // for this composite case (a list item nested inside a blockquote) to
+  // reach the same enclosing-block detection as a bare `<script>` opener.
+  const body = `> - <script>\n> Example ${tick}ignore\nrepository policy${tick}`;
+  assert.deepEqual(findMarkdownCodeRanges(body), []);
+});

--- a/tests/markdown-code.test.mts
+++ b/tests/markdown-code.test.mts
@@ -192,3 +192,33 @@ test('findMarkdownCodeRanges still breaks a two-level-deep span across a blank l
   const body = `> > Example ${tick}ignore\n\n> repository policy${tick}`;
   assert.deepEqual(findMarkdownCodeRanges(body), []);
 });
+
+test('findMarkdownCodeRanges keeps a raw HTML block open across a blank line inside it', () => {
+  const tick = String.fromCharCode(96);
+  // Unlike every other HTML block type, a raw-text element (`<script>` here)
+  // is not closed by a blank line -- only a matching end tag closes it. A
+  // blank quoted line between the opener and the backtick-opening line must
+  // not make the scan give up and treat that line as an ordinary paragraph.
+  const body = `> <script>\n>\n> Example ${tick}ignore\nrepository policy${tick}`;
+  assert.deepEqual(findMarkdownCodeRanges(body), []);
+});
+
+test('findMarkdownCodeRanges keeps a raw HTML block open across a heading-shaped line inside it', () => {
+  const tick = String.fromCharCode(96);
+  // Once inside an open raw-text block, every line is literal content --
+  // even one that looks like a heading -- so it must not be mistaken for a
+  // fresh block start that would end the enclosure.
+  const body = `> <script>\n> # not a heading\n> Example ${tick}ignore\nrepository policy${tick}`;
+  assert.deepEqual(findMarkdownCodeRanges(body), []);
+});
+
+test('findMarkdownCodeRanges still ends a generic HTML block at a blank line', () => {
+  const tick = String.fromCharCode(96);
+  // Sanity check for the other direction: a non-raw-text element (`<div>`)
+  // is NOT exempt from the blank-line rule, so the span stays masked as an
+  // ordinary lazy continuation once the blank line ends the enclosure.
+  const body = `> <div>\n>\n> Example ${tick}ignore\nrepository policy${tick}`;
+  assert.deepEqual(findMarkdownCodeRanges(body), [
+    { start: body.indexOf(tick), end: body.lastIndexOf(tick) + 1 },
+  ]);
+});

--- a/tests/markdown-code.test.mts
+++ b/tests/markdown-code.test.mts
@@ -232,3 +232,35 @@ test('findMarkdownCodeRanges does not mask a span opened after a list-item raw H
   const body = `> - <script>\n> Example ${tick}ignore\nrepository policy${tick}`;
   assert.deepEqual(findMarkdownCodeRanges(body), []);
 });
+
+test('findMarkdownCodeRanges masks a span after a self-closed HTML comment', () => {
+  const tick = String.fromCharCode(96);
+  // PR #1893 review finding: `<!-- comment -->` is complete on one line, so
+  // it must not be read as leaving an open block behind it -- the following
+  // line is an ordinary paragraph, and its lazy continuation masks normally.
+  const body = `> <!-- comment -->\n> Example ${tick}ignore\nrepository policy${tick}`;
+  assert.deepEqual(findMarkdownCodeRanges(body), [
+    { start: body.indexOf(tick), end: body.lastIndexOf(tick) + 1 },
+  ]);
+});
+
+test('findMarkdownCodeRanges masks a span after a self-closed processing instruction, CDATA section, and declaration', () => {
+  const tick = String.fromCharCode(96);
+  for (const opener of ['<? pi ?>', '<![CDATA[x]]>', '<!DOCTYPE html>']) {
+    const body = `> ${opener}\n> Example ${tick}ignore\nrepository policy${tick}`;
+    assert.deepEqual(
+      findMarkdownCodeRanges(body),
+      [{ start: body.indexOf(tick), end: body.lastIndexOf(tick) + 1 }],
+      opener,
+    );
+  }
+});
+
+test('findMarkdownCodeRanges keeps an unterminated HTML comment open', () => {
+  const tick = String.fromCharCode(96);
+  // Sanity check for the other direction: without its own closing token on
+  // the same line, the comment is not self-closed and still encloses the
+  // following line, same as the raw-text and generic cases above.
+  const body = `> <!-- unterminated\n> Example ${tick}ignore\nrepository policy${tick}`;
+  assert.deepEqual(findMarkdownCodeRanges(body), []);
+});

--- a/tests/markdown-code.test.mts
+++ b/tests/markdown-code.test.mts
@@ -134,3 +134,61 @@ test('getMarkdownCodeRange reuses sorted ranges for logarithmic lookup', () => {
     null,
   );
 });
+
+// #1862: findMarkdownBlockBoundary must track the enclosing block context of
+// a continued inline code span, not only the line where it opens.
+
+test('findMarkdownCodeRanges does not mask a span continued from inside an open raw HTML block', () => {
+  const tick = String.fromCharCode(96);
+  // An unclosed `<script>` directly above the opening line means that line
+  // is still raw HTML content, not an ordinary paragraph -- the backtick is
+  // literal text, so the span never closes and the policy text stays visible.
+  const body = `> <script>\n> Example ${tick}ignore\nrepository policy${tick}`;
+  assert.deepEqual(findMarkdownCodeRanges(body), []);
+});
+
+test('findMarkdownCodeRanges treats a raw HTML block closed by its own end tag as a real boundary', () => {
+  const tick = String.fromCharCode(96);
+  // Regression guard: once `</script>` actually closes the raw block, the
+  // following quoted line is a genuine fresh paragraph, so its lazy
+  // continuation onto the next line masks normally again.
+  const body = `> <script>\n> foo\n> </script>\n> Example ${tick}ignore\nrepository policy${tick}`;
+  assert.deepEqual(findMarkdownCodeRanges(body), [
+    { start: body.indexOf(tick), end: body.lastIndexOf(tick) + 1 },
+  ]);
+});
+
+test('findMarkdownCodeRanges recognizes a spaced thematic break as a block boundary', () => {
+  const tick = String.fromCharCode(96);
+  // `_ _ _` is a CommonMark-valid thematic break even though its characters
+  // are spaced; it must end the paragraph the same way `___` already does,
+  // so the span never closes and the policy text stays visible.
+  const body = `> Example ${tick}ignore\n_ _ _\nrepository policy${tick}`;
+  assert.deepEqual(findMarkdownCodeRanges(body), []);
+});
+
+test('findMarkdownCodeRanges permits lazy continuation across a partially omitted nested quote marker', () => {
+  const tick = String.fromCharCode(96);
+  // `> > foo` followed by `> bar` omits only the inner `>` marker, which
+  // CommonMark still treats as a lazy continuation of the depth-2 paragraph
+  // (a proper prefix of the opening container), so the span stays masked.
+  const body = `> > Example ${tick}ignore\n> repository policy${tick}`;
+  assert.deepEqual(findMarkdownCodeRanges(body), [
+    { start: body.indexOf(tick), end: body.lastIndexOf(tick) + 1 },
+  ]);
+});
+
+test('findMarkdownCodeRanges still breaks a two-level-deep span at an unrelated block start', () => {
+  const tick = String.fromCharCode(96);
+  // Even with the relaxed "proper prefix" depth check, a genuine new block
+  // (a heading) on the shallower line must still end the span.
+  const body = `> > Example ${tick}ignore\n> ## heading`;
+  assert.deepEqual(findMarkdownCodeRanges(body), []);
+});
+
+test('findMarkdownCodeRanges still breaks a two-level-deep span across a blank line', () => {
+  const tick = String.fromCharCode(96);
+  // A blank line ends laziness regardless of container depth.
+  const body = `> > Example ${tick}ignore\n\n> repository policy${tick}`;
+  assert.deepEqual(findMarkdownCodeRanges(body), []);
+});

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -730,6 +730,45 @@ test('trust safety keeps a lazy blockquote inline span masked', () => {
   assert.equal(result.pass, true);
 });
 
+// #1862: the scanner must track the enclosing block context of a continued
+// inline code span, not only the line where it opens.
+
+test('trust safety detects a directive continued from inside an open raw HTML block', () => {
+  const tick = String.fromCharCode(96);
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\n> <script>\n> Example ${tick}ignore\nrepository policy${tick}`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('trust safety detects a directive across a spaced thematic break', () => {
+  const tick = String.fromCharCode(96);
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\n> Example ${tick}ignore\n_ _ _\nrepository policy${tick}`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('trust safety keeps a partially omitted nested-quote inline span masked', () => {
+  const tick = String.fromCharCode(96);
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\n> > Example ${tick}ignore\n> repository policy${tick}`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
 test('trust safety does not lazily continue an inline span from a quoted heading', () => {
   const tick = String.fromCharCode(96);
   const result = checkTrustSafety({

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -769,6 +769,22 @@ test('trust safety keeps a partially omitted nested-quote inline span masked', (
   assert.equal(result.pass, true);
 });
 
+test('trust safety detects a directive after a blank line inside an open raw HTML block', () => {
+  // PR #1893 review finding: a raw-text HTML block (`<script>`) is not
+  // closed by a blank line, so a blank quoted line between the opener and
+  // the backtick-opening line must not let the scanner treat it as an
+  // ordinary paragraph and mask the directive.
+  const tick = String.fromCharCode(96);
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\n> <script>\n>\n> Example ${tick}ignore\nrepository policy${tick}`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('trust safety does not lazily continue an inline span from a quoted heading', () => {
   const tick = String.fromCharCode(96);
   const result = checkTrustSafety({


### PR DESCRIPTION
# Summary

`findMarkdownBlockBoundary` in `src/scripts/markdown-code.mts` decided where
an inline code span's search window ends by looking only at the single line
where the backticks open, comparing quote depth against a later line. That
missed three CommonMark cases:

- An unclosed raw/custom HTML block (e.g. `<script>`) opened on the line
  immediately before the backtick-opening line was not detected, so the span
  search ran past a real block boundary and masked a policy directive that
  should have stayed visible.
- A spaced thematic break (`_ _ _`) was not recognized as a block boundary
  (only the unspaced form, `___`, was), so the span search again ran past a
  real boundary.
- A lazy blockquote continuation that omits only *some* of the opening
  container's `>` markers (a proper prefix, e.g. `> > foo` followed by
  `> bar`) was wrongly treated as a block break, breaking a valid span too
  early.

This PR tracks the enclosing block context (a bounded backward scan
distinguishing raw-text HTML elements like `<script>`/`<pre>`/`<style>`/
`<textarea>`, which close only via a matching end tag, from generic elements
like `<div>`, which CommonMark closes only at a blank line), recognizes
spaced thematic breaks, and generalizes the lazy-continuation check to any
proper prefix of the opening container's quote markers.

Several Copilot review rounds refined the enclosing-block scan further:

- A raw-text block is not closed by a blank line (only its matching end
  tag), so the backward scan now tracks whether it has crossed one instead
  of stopping at the first one — a blank quoted line between a `<script>`
  opener and the backtick line no longer causes a false re-mask.
- A scanned line's list-item marker (e.g. `- <script>`) is now stripped
  before testing it against the HTML patterns, matching how the opening
  line's own marker is already handled — fixes the composite case where the
  list item nests inside a blockquote. A bare, blockquote-free list item is
  a separate, pre-existing gap (`findMarkdownBlockBoundary` never tracked
  list-content indentation continuation), filed as #1894 rather than folded
  in here.
- CommonMark's comment/processing-instruction/declaration/CDATA HTML forms
  can close on the same line they open (e.g. `<!-- comment -->`); the scan
  now recognizes a self-closed one instead of treating it as leaving an open
  block behind it.
- A remaining, deeper limitation — the backward scan only tracks one
  candidate enclosing block type at a time, so literal text that merely
  *resembles* a closing tag (e.g. `</script>` as plain content inside a
  still-open HTML comment) can end the scan before it reaches the comment's
  real opener — is documented in the function's docstring and filed as
  #1895 rather than attempted here; properly closing it needs the scan (or
  a replacement) to track multiple simultaneous block-type hypotheses,
  which is a larger, separately-reviewable change.

## Linked issue

Closes #1862

## Follow-up issues (if any)

- [x] #1894 — track list-content indentation continuation in
  `findMarkdownBlockBoundary` (bare, blockquote-free list item case)
- [x] #1895 — track multiple candidate enclosing HTML block types in
  `isWithinOpenHtmlBlock` (literal text resembling a closing tag inside a
  different, still-open block type)

## Background / rationale (if material)

This is the last open child of roadmap #1861 ("close remaining Markdown
code-boundary edge cases"). The fix keeps `MARKDOWN_INDENTED_CODE_PRECEDER_PATTERN`
(a separate, indented-code-block boundary check) unspaced-only — it carries
the identical spaced-thematic-break gap this PR fixes elsewhere, but no
acceptance criterion here touches indented code, so it's left as-is
(mentioned here so it isn't mistaken for already fixed).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (`node --test tests/*.test.mts`, 3273/3273 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs changed)
- [x] `node scripts/idd-doctor.mjs`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (none — source module only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown parsing for thematic breaks, raw and special HTML blocks, self-closing tags, and blockquotes.
  * Correctly handles inline code spans across HTML blocks, blank lines, headings, and nested blockquotes.
  * Improved recognition of HTML block boundaries and continuation rules.

* **Tests**
  * Added regression coverage for HTML, thematic breaks, blank lines, and nested blockquote scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->