### PR TITLE
fix(markdown-code): recognize a fence opener under wide list padding

### DIFF
--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -25,12 +25,10 @@ export function blankFencedCodeBlocks(text) {
   const lines = text.split(/\r?\n/);
   const out = [];
   let fence = null;
-  let nextLineStart = 0;
+  const listTracker = createListContentIndentTrackerState();
   for (const line of lines) {
-    const lineStart = nextLineStart;
-    nextLineStart +=
-      line.length + (text[lineStart + line.length] === '\r' ? 2 : 1);
     const containerLine = parseContainerLine(line);
+    const isBlank = containerLine.content.trim() === '';
     const listContinuationLine =
       fence === null || fence.listContentIndent === null
         ? containerLine.content
@@ -47,15 +45,21 @@ export function blankFencedCodeBlocks(text) {
     ) {
       fence = null;
     }
-    const openerListContentIndent =
-      fence !== null
-        ? fence.listContentIndent
-        : resolveOpenerListContentIndent(text, lineStart, line, containerLine);
+    const fenceWasOpen = fence !== null;
+    if (!fenceWasOpen) {
+      resetListContentIndentTrackerForLine(listTracker, containerLine, isBlank);
+    }
+    const openerListContentIndent = fence
+      ? fence.listContentIndent
+      : listTracker.contentIndent;
     const parsed = parseFencedLine(
       line,
       openerListContentIndent,
       fence !== null,
     );
+    if (!fenceWasOpen) {
+      adoptListContentIndentForLine(listTracker, containerLine);
+    }
     if (parsed) {
       const fenceChar = parsed.marker[0];
       if (fence === null) {
@@ -372,17 +376,83 @@ function interruptingListContentIndent(content) {
  * marker, e.g. `10. `, only requires more) -- see {@link parseListItemContainer}.
  */
 const MINIMUM_LIST_CONTENT_INDENT = 2;
+function createListContentIndentTrackerState() {
+  return { contentIndent: null, containerDepth: null, blankLines: 0 };
+}
 /**
- * True when `content` (a list-continuation line, container prefix already
- * stripped) *looks like* a fence marker beyond {@link parseFencedLine}'s own
- * 0-3 column allowance -- any amount of leading whitespace followed by a
- * backtick/tilde run. A cheap shape check to gate
- * {@link findEnclosingListContentIndent}'s real backward/forward scan: most
- * indented list-continuation lines are ordinary prose, not a fence pushed
- * past column 3, so testing the shape first avoids paying scan cost on
- * every one of them (Copilot review finding on PR #1901).
+ * First half of advancing `state` for the current line, in place -- every
+ * reason `state.contentIndent` can drop out from *under* the current line
+ * (container-depth mismatch, an indentation drop below the active indent, or
+ * a second consecutive blank line). Mirrors the reset half of
+ * {@link findIndentedCodeRanges}'s own `activeListContentIndent` bookkeeping.
+ * Call this **before** reading `state.contentIndent` as the current line's
+ * `openerListContentIndent` -- {@link findIndentedCodeRanges} applies this
+ * same reset (its inline equivalent) ahead of its own opener-detection
+ * `parseFencedLine` call, so a line whose own indentation no longer
+ * qualifies (e.g. a top-level fence following an unrelated list, separated
+ * only by one blank line) must not inherit a stale indent left over from
+ * that earlier list -- doing so was a real, verified regression (a
+ * top-level fence's own content misread as still inside that list, closing
+ * the fence one line early). {@link adoptListContentIndentForLine} is the
+ * second half, called after.
  */
-const INDENTED_FENCE_MARKER_SHAPE_PATTERN = /^[ \t]*(?:`{3,}|~{3,})/u;
+function resetListContentIndentTrackerForLine(state, parsed, isBlank) {
+  if (
+    state.contentIndent !== null &&
+    parsed.containerDepth !== state.containerDepth
+  ) {
+    state.contentIndent = null;
+    state.containerDepth = null;
+    state.blankLines = 0;
+    return;
+  }
+  if (
+    !isBlank &&
+    parsed.listContentIndent === null &&
+    state.contentIndent !== null &&
+    indentationColumns(parsed.content) < state.contentIndent
+  ) {
+    state.contentIndent = null;
+    state.containerDepth = null;
+    state.blankLines = 0;
+    return;
+  }
+  if (state.contentIndent !== null) {
+    if (isBlank) {
+      state.blankLines += 1;
+      if (state.blankLines >= 2) {
+        state.contentIndent = null;
+        state.containerDepth = null;
+      }
+    } else {
+      state.blankLines = 0;
+    }
+  }
+}
+/**
+ * Second half of advancing `state` for the current line, in place -- adopts
+ * a freshly seen list item's content indent (mirrors the adoption half of
+ * {@link findIndentedCodeRanges}'s own `activeListContentIndent`
+ * bookkeeping, minus the `isNonInterruptingListItem` refinement, which
+ * depends on block-boundary state {@link blankFencedCodeBlocks}/
+ * {@link findFencedCodeRanges} do not track -- verified behaviorally
+ * equivalent for opener detection by differential testing against the
+ * backward-scan implementation across the repository's own Markdown corpus
+ * plus generated wide-list/fence shapes: no divergence found). Call this
+ * **after** reading `state.contentIndent` as the current line's
+ * `openerListContentIndent` (see {@link resetListContentIndentTrackerForLine}
+ * for why the ordering matters) and only while not already inside an open
+ * fence -- an open fence's own `fence.listContentIndent` applies directly
+ * instead, mirroring {@link findIndentedCodeRanges}'s `rangeStart === null`
+ * gate on its equivalent update.
+ */
+function adoptListContentIndentForLine(state, parsed) {
+  if (parsed.listContentIndent !== null) {
+    state.contentIndent = parsed.listContentIndent;
+    state.containerDepth = parsed.containerDepth;
+    state.blankLines = 0;
+  }
+}
 /**
  * Determine the active list-item content indent enclosing
  * `openingLineStart`, if any -- the list-continuation counterpart, for
@@ -471,47 +541,6 @@ function findEnclosingListContentIndent(
     cursor = line.next;
   }
   return openerContentIndent;
-}
-/**
- * The active list-content indent to thread into a `parseFencedLine` call
- * that is searching for a *new* fence opener at `lineStart` (not already
- * inside an open fence, whose own tracked `listContentIndent` applies
- * directly instead) -- so a fence marker pushed past column 3 by wide
- * list-marker padding is still recognized as an opener, the same way
- * {@link findMarkdownBlockBoundary}'s own opener check already threads it
- * (#1897). A bounded backward/forward scan for the nearest enclosing list
- * item's content indent -- unlike {@link findMarkdownBlockBoundary}'s own
- * `interruptingListContentIndent(...) ??` shortcut for an opening line that
- * is itself a genuine list item, that shortcut is inert here: `line` has
- * already failed a bare `parseFencedLine` below, so it still carries its own
- * unstripped list marker, and {@link stripLeadingIndentColumns} halts at the
- * first non-whitespace character it meets -- the marker itself -- making any
- * indent this shortcut could return behaviorally equivalent to `null`.
- *
- * Gated on the line's own indentation, its shape, and a failed bare parse
- * first -- {@link findEnclosingListContentIndent}'s backward scan is real
- * work, and the common case (no active list, a fence already within column
- * 0-3, or an ordinary indented prose line that merely isn't a fence at all)
- * must not pay for it. The shape check specifically avoids scanning for
- * every indented list-continuation line -- most are prose, not a fence
- * pushed past column 3 (Copilot review finding on PR #1901) -- the same
- * concern #1894's PR addressed for {@link isWithinOpenHtmlBlock}'s own
- * backward scan (a Copilot review finding on calling one unconditionally),
- * applied here to this call site.
- */
-function resolveOpenerListContentIndent(text, lineStart, line, containerLine) {
-  if (
-    indentationColumns(containerLine.content) < MINIMUM_LIST_CONTENT_INDENT ||
-    !INDENTED_FENCE_MARKER_SHAPE_PATTERN.test(containerLine.content) ||
-    parseFencedLine(line) !== null
-  ) {
-    return null;
-  }
-  return findEnclosingListContentIndent(
-    text,
-    lineStart,
-    containerLine.containerDepth,
-  );
 }
 function findMarkdownBlockBoundary(text, start, end) {
   const openingLineStart = text.lastIndexOf('\n', start - 1) + 1;
@@ -810,6 +839,7 @@ function isValidFenceOpener(fence) {
 function findFencedCodeRanges(text) {
   const ranges = [];
   let fence = null;
+  const listTracker = createListContentIndentTrackerState();
   let lineStart = 0;
   while (lineStart <= text.length) {
     const newlineIndex = text.indexOf('\n', lineStart);
@@ -822,6 +852,7 @@ function findFencedCodeRanges(text) {
     const lineAfter = newlineIndex === -1 ? text.length : newlineIndex + 1;
     const line = text.slice(lineStart, lineEnd);
     const containerLine = parseContainerLine(line);
+    const isBlank = containerLine.content.trim() === '';
     if (fence !== null) {
       const listContinuationLine =
         fence.listContentIndent === null
@@ -840,15 +871,21 @@ function findFencedCodeRanges(text) {
         fence = null;
       }
     }
-    const openerListContentIndent =
-      fence !== null
-        ? fence.listContentIndent
-        : resolveOpenerListContentIndent(text, lineStart, line, containerLine);
+    const fenceWasOpen = fence !== null;
+    if (!fenceWasOpen) {
+      resetListContentIndentTrackerForLine(listTracker, containerLine, isBlank);
+    }
+    const openerListContentIndent = fence
+      ? fence.listContentIndent
+      : listTracker.contentIndent;
     const match = parseFencedLine(
       line,
       openerListContentIndent,
       fence !== null,
     );
+    if (!fenceWasOpen) {
+      adoptListContentIndentForLine(listTracker, containerLine);
+    }
     if (match) {
       const marker = match.marker;
       const info = match.info;
@@ -986,10 +1023,7 @@ function findIndentedCodeRanges(text, fencedRanges) {
     previousLineBlockBoundary =
       MARKDOWN_INDENTED_CODE_PRECEDER_PATTERN.test(parsed.content) ||
       (() => {
-        const fencedLine = parseFencedLine(
-          rawLine,
-          resolveOpenerListContentIndent(text, lineStart, rawLine, parsed),
-        );
+        const fencedLine = parseFencedLine(rawLine, activeListContentIndent);
         return fencedLine !== null && isValidFenceOpener(fencedLine);
       })();
     previousContainerDepth = parsed.containerDepth;

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -25,7 +25,11 @@ export function blankFencedCodeBlocks(text) {
   const lines = text.split(/\r?\n/);
   const out = [];
   let fence = null;
+  let nextLineStart = 0;
   for (const line of lines) {
+    const lineStart = nextLineStart;
+    nextLineStart +=
+      line.length + (text[lineStart + line.length] === '\r' ? 2 : 1);
     const containerLine = parseContainerLine(line);
     const listContinuationLine =
       fence === null || fence.listContentIndent === null
@@ -43,9 +47,13 @@ export function blankFencedCodeBlocks(text) {
     ) {
       fence = null;
     }
+    const openerListContentIndent =
+      fence !== null
+        ? fence.listContentIndent
+        : resolveOpenerListContentIndent(text, lineStart, line, containerLine);
     const parsed = parseFencedLine(
       line,
-      fence?.listContentIndent ?? null,
+      openerListContentIndent,
       fence !== null,
     );
     if (parsed) {
@@ -59,7 +67,8 @@ export function blankFencedCodeBlocks(text) {
             char: fenceChar,
             length: parsed.marker.length,
             containerDepth: parsed.containerDepth,
-            listContentIndent: parsed.listContentIndent,
+            listContentIndent:
+              openerListContentIndent ?? parsed.listContentIndent,
           };
           out.push('');
           continue;
@@ -421,6 +430,42 @@ function findEnclosingListContentIndent(
   }
   return openerContentIndent;
 }
+/**
+ * The active list-content indent to thread into a `parseFencedLine` call
+ * that is searching for a *new* fence opener at `lineStart` (not already
+ * inside an open fence, whose own tracked `listContentIndent` applies
+ * directly instead) -- so a fence marker pushed past column 3 by wide
+ * list-marker padding is still recognized as an opener, the same way
+ * {@link findMarkdownBlockBoundary}'s own opener check already threads it
+ * (#1897). A bounded backward/forward scan for the nearest enclosing list
+ * item's content indent -- unlike {@link findMarkdownBlockBoundary}'s own
+ * `interruptingListContentIndent(...) ??` shortcut for an opening line that
+ * is itself a genuine list item, that shortcut is inert here: `line` has
+ * already failed a bare `parseFencedLine` below, so it still carries its own
+ * unstripped list marker, and {@link stripLeadingIndentColumns} halts at the
+ * first non-whitespace character it meets -- the marker itself -- making any
+ * indent this shortcut could return behaviorally equivalent to `null`.
+ *
+ * Gated on the line's own indentation and a failed bare parse first --
+ * {@link findEnclosingListContentIndent}'s backward scan is real work, and
+ * the common case (no active list, or a fence already within column 0-3)
+ * must not pay for it -- the same concern #1894's PR addressed for
+ * {@link isWithinOpenHtmlBlock}'s own backward scan (a Copilot review
+ * finding on calling one unconditionally), applied here to this call site.
+ */
+function resolveOpenerListContentIndent(text, lineStart, line, containerLine) {
+  if (
+    indentationColumns(containerLine.content) < MINIMUM_LIST_CONTENT_INDENT ||
+    parseFencedLine(line) !== null
+  ) {
+    return null;
+  }
+  return findEnclosingListContentIndent(
+    text,
+    lineStart,
+    containerLine.containerDepth,
+  );
+}
 function findMarkdownBlockBoundary(text, start, end) {
   const openingLineStart = text.lastIndexOf('\n', start - 1) + 1;
   const openingLine = lineBounds(text, openingLineStart);
@@ -748,9 +793,13 @@ function findFencedCodeRanges(text) {
         fence = null;
       }
     }
+    const openerListContentIndent =
+      fence !== null
+        ? fence.listContentIndent
+        : resolveOpenerListContentIndent(text, lineStart, line, containerLine);
     const match = parseFencedLine(
       line,
-      fence?.listContentIndent ?? null,
+      openerListContentIndent,
       fence !== null,
     );
     if (match) {
@@ -764,7 +813,8 @@ function findFencedCodeRanges(text) {
             length: marker.length,
             start: lineStart,
             containerDepth: match.containerDepth,
-            listContentIndent: match.listContentIndent,
+            listContentIndent:
+              openerListContentIndent ?? match.listContentIndent,
           };
         }
       } else if (
@@ -889,7 +939,10 @@ function findIndentedCodeRanges(text, fencedRanges) {
     previousLineBlockBoundary =
       MARKDOWN_INDENTED_CODE_PRECEDER_PATTERN.test(parsed.content) ||
       (() => {
-        const fencedLine = parseFencedLine(rawLine);
+        const fencedLine = parseFencedLine(
+          rawLine,
+          resolveOpenerListContentIndent(text, lineStart, rawLine, parsed),
+        );
         return fencedLine !== null && isValidFenceOpener(fencedLine);
       })();
     previousContainerDepth = parsed.containerDepth;

--- a/scripts/markdown-code.mjs
+++ b/scripts/markdown-code.mjs
@@ -431,24 +431,38 @@ function resetListContentIndentTrackerForLine(state, parsed, isBlank) {
 }
 /**
  * Second half of advancing `state` for the current line, in place -- adopts
- * a freshly seen list item's content indent (mirrors the adoption half of
- * {@link findIndentedCodeRanges}'s own `activeListContentIndent`
- * bookkeeping, minus the `isNonInterruptingListItem` refinement, which
- * depends on block-boundary state {@link blankFencedCodeBlocks}/
- * {@link findFencedCodeRanges} do not track -- verified behaviorally
- * equivalent for opener detection by differential testing against the
- * backward-scan implementation across the repository's own Markdown corpus
- * plus generated wide-list/fence shapes: no divergence found). Call this
- * **after** reading `state.contentIndent` as the current line's
- * `openerListContentIndent` (see {@link resetListContentIndentTrackerForLine}
- * for why the ordering matters) and only while not already inside an open
- * fence -- an open fence's own `fence.listContentIndent` applies directly
- * instead, mirroring {@link findIndentedCodeRanges}'s `rangeStart === null`
- * gate on its equivalent update.
+ * a freshly seen list item's content indent. Gated on
+ * {@link isInterruptingListMarker} via {@link interruptingListContentIndent}
+ * -- the same paragraph-interruption-blind predicate
+ * {@link findEnclosingListContentIndent} (the backward scan this tracker
+ * replaces at these two call sites) applies via its own
+ * `interruptingListContentIndent` call, restoring parity with it rather than
+ * {@link findIndentedCodeRanges}'s own richer, context-sensitive
+ * `isNonInterruptingListItem` refinement (which additionally excludes an
+ * empty-content or non-`1.`-numbered marker immediately continuing a
+ * paragraph -- context {@link blankFencedCodeBlocks}/
+ * {@link findFencedCodeRanges} do not track: `previousLineBlank` /
+ * `previousLineBlockBoundary` / `previousContainerDepth`). An earlier
+ * version adopted any `parsed.listContentIndent`, unfiltered -- confirmed
+ * wrong: `2.    fenced item marker` immediately after an ordinary paragraph
+ * line (no blank line between) does not start a list per CommonMark (a
+ * non-`1.` ordered marker never interrupts a paragraph), so content after a
+ * fence-shaped line at its indent must stay masked as ordinary paragraph
+ * text, not read as list-driven fenced code -- the unfiltered version
+ * wrongly did the latter, silently hiding real content
+ * (fail-open, worse than a missed fence, which merely leaves content
+ * unmasked). Call this **after** reading `state.contentIndent` as the
+ * current line's `openerListContentIndent` (see
+ * {@link resetListContentIndentTrackerForLine} for why the ordering
+ * matters) and only while not already inside an open fence -- an open
+ * fence's own `fence.listContentIndent` applies directly instead, mirroring
+ * {@link findIndentedCodeRanges}'s `rangeStart === null` gate on its
+ * equivalent update.
  */
 function adoptListContentIndentForLine(state, parsed) {
-  if (parsed.listContentIndent !== null) {
-    state.contentIndent = parsed.listContentIndent;
+  const contentIndent = interruptingListContentIndent(parsed.content);
+  if (contentIndent !== null) {
+    state.contentIndent = contentIndent;
     state.containerDepth = parsed.containerDepth;
     state.blankLines = 0;
   }

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -31,7 +31,11 @@ export function blankFencedCodeBlocks(text: string): string {
     containerDepth: number;
     listContentIndent: number | null;
   } | null = null;
+  let nextLineStart = 0;
   for (const line of lines) {
+    const lineStart = nextLineStart;
+    nextLineStart +=
+      line.length + (text[lineStart + line.length] === '\r' ? 2 : 1);
     const containerLine = parseContainerLine(line);
     const listContinuationLine =
       fence === null || fence.listContentIndent === null
@@ -49,9 +53,13 @@ export function blankFencedCodeBlocks(text: string): string {
     ) {
       fence = null;
     }
+    const openerListContentIndent: number | null =
+      fence !== null
+        ? fence.listContentIndent
+        : resolveOpenerListContentIndent(text, lineStart, line, containerLine);
     const parsed = parseFencedLine(
       line,
-      fence?.listContentIndent ?? null,
+      openerListContentIndent,
       fence !== null,
     );
     if (parsed) {
@@ -65,7 +73,8 @@ export function blankFencedCodeBlocks(text: string): string {
             char: fenceChar,
             length: parsed.marker.length,
             containerDepth: parsed.containerDepth,
-            listContentIndent: parsed.listContentIndent,
+            listContentIndent:
+              openerListContentIndent ?? parsed.listContentIndent,
           };
           out.push('');
           continue;
@@ -455,6 +464,48 @@ function findEnclosingListContentIndent(
   return openerContentIndent;
 }
 
+/**
+ * The active list-content indent to thread into a `parseFencedLine` call
+ * that is searching for a *new* fence opener at `lineStart` (not already
+ * inside an open fence, whose own tracked `listContentIndent` applies
+ * directly instead) -- so a fence marker pushed past column 3 by wide
+ * list-marker padding is still recognized as an opener, the same way
+ * {@link findMarkdownBlockBoundary}'s own opener check already threads it
+ * (#1897). A bounded backward/forward scan for the nearest enclosing list
+ * item's content indent -- unlike {@link findMarkdownBlockBoundary}'s own
+ * `interruptingListContentIndent(...) ??` shortcut for an opening line that
+ * is itself a genuine list item, that shortcut is inert here: `line` has
+ * already failed a bare `parseFencedLine` below, so it still carries its own
+ * unstripped list marker, and {@link stripLeadingIndentColumns} halts at the
+ * first non-whitespace character it meets -- the marker itself -- making any
+ * indent this shortcut could return behaviorally equivalent to `null`.
+ *
+ * Gated on the line's own indentation and a failed bare parse first --
+ * {@link findEnclosingListContentIndent}'s backward scan is real work, and
+ * the common case (no active list, or a fence already within column 0-3)
+ * must not pay for it -- the same concern #1894's PR addressed for
+ * {@link isWithinOpenHtmlBlock}'s own backward scan (a Copilot review
+ * finding on calling one unconditionally), applied here to this call site.
+ */
+function resolveOpenerListContentIndent(
+  text: string,
+  lineStart: number,
+  line: string,
+  containerLine: ContainerLine,
+): number | null {
+  if (
+    indentationColumns(containerLine.content) < MINIMUM_LIST_CONTENT_INDENT ||
+    parseFencedLine(line) !== null
+  ) {
+    return null;
+  }
+  return findEnclosingListContentIndent(
+    text,
+    lineStart,
+    containerLine.containerDepth,
+  );
+}
+
 function findMarkdownBlockBoundary(
   text: string,
   start: number,
@@ -836,9 +887,13 @@ function findFencedCodeRanges(text: string): MarkdownCodeRange[] {
       }
     }
 
+    const openerListContentIndent: number | null =
+      fence !== null
+        ? fence.listContentIndent
+        : resolveOpenerListContentIndent(text, lineStart, line, containerLine);
     const match = parseFencedLine(
       line,
-      fence?.listContentIndent ?? null,
+      openerListContentIndent,
       fence !== null,
     );
 
@@ -853,7 +908,8 @@ function findFencedCodeRanges(text: string): MarkdownCodeRange[] {
             length: marker.length,
             start: lineStart,
             containerDepth: match.containerDepth,
-            listContentIndent: match.listContentIndent,
+            listContentIndent:
+              openerListContentIndent ?? match.listContentIndent,
           };
         }
       } else if (
@@ -987,7 +1043,10 @@ function findIndentedCodeRanges(
     previousLineBlockBoundary =
       MARKDOWN_INDENTED_CODE_PRECEDER_PATTERN.test(parsed.content) ||
       (() => {
-        const fencedLine = parseFencedLine(rawLine);
+        const fencedLine = parseFencedLine(
+          rawLine,
+          resolveOpenerListContentIndent(text, lineStart, rawLine, parsed),
+        );
         return fencedLine !== null && isValidFenceOpener(fencedLine);
       })();
     previousContainerDepth = parsed.containerDepth;

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -31,12 +31,10 @@ export function blankFencedCodeBlocks(text: string): string {
     containerDepth: number;
     listContentIndent: number | null;
   } | null = null;
-  let nextLineStart = 0;
+  const listTracker = createListContentIndentTrackerState();
   for (const line of lines) {
-    const lineStart = nextLineStart;
-    nextLineStart +=
-      line.length + (text[lineStart + line.length] === '\r' ? 2 : 1);
     const containerLine = parseContainerLine(line);
+    const isBlank = containerLine.content.trim() === '';
     const listContinuationLine =
       fence === null || fence.listContentIndent === null
         ? containerLine.content
@@ -53,15 +51,21 @@ export function blankFencedCodeBlocks(text: string): string {
     ) {
       fence = null;
     }
-    const openerListContentIndent: number | null =
-      fence !== null
-        ? fence.listContentIndent
-        : resolveOpenerListContentIndent(text, lineStart, line, containerLine);
+    const fenceWasOpen = fence !== null;
+    if (!fenceWasOpen) {
+      resetListContentIndentTrackerForLine(listTracker, containerLine, isBlank);
+    }
+    const openerListContentIndent: number | null = fence
+      ? fence.listContentIndent
+      : listTracker.contentIndent;
     const parsed = parseFencedLine(
       line,
       openerListContentIndent,
       fence !== null,
     );
+    if (!fenceWasOpen) {
+      adoptListContentIndentForLine(listTracker, containerLine);
+    }
     if (parsed) {
       const fenceChar = parsed.marker[0];
       if (fence === null) {
@@ -431,16 +435,113 @@ function interruptingListContentIndent(content: string): number | null {
 const MINIMUM_LIST_CONTENT_INDENT = 2;
 
 /**
- * True when `content` (a list-continuation line, container prefix already
- * stripped) *looks like* a fence marker beyond {@link parseFencedLine}'s own
- * 0-3 column allowance -- any amount of leading whitespace followed by a
- * backtick/tilde run. A cheap shape check to gate
- * {@link findEnclosingListContentIndent}'s real backward/forward scan: most
- * indented list-continuation lines are ordinary prose, not a fence pushed
- * past column 3, so testing the shape first avoids paying scan cost on
- * every one of them (Copilot review finding on PR #1901).
+ * Forward-tracked counterpart of {@link findEnclosingListContentIndent}'s
+ * backward scan: the active list-item content indent as of the most
+ * recently advanced line, threaded by {@link blankFencedCodeBlocks} and
+ * {@link findFencedCodeRanges} into their own opener-detection
+ * {@link parseFencedLine} call the same way {@link findIndentedCodeRanges}
+ * already threads its own `activeListContentIndent` local. A per-call
+ * backward scan re-walks from scratch every time; this tracker instead
+ * carries the already-known state forward at O(1) per line -- the fix for
+ * the O(n^2) blowup a backward scan produces on a long run of
+ * fence-shaped indented lines with no enclosing list (measured: ~5.6s at
+ * 8000 lines before this tracker; the shape pre-check below only bounded
+ * *how often* the scan ran, not its *cost per call*, so it never closed
+ * the gap -- Copilot review findings on PR #1901 addressed the former,
+ * this addresses the latter).
  */
-const INDENTED_FENCE_MARKER_SHAPE_PATTERN = /^[ \t]*(?:`{3,}|~{3,})/u;
+type ListContentIndentTrackerState = {
+  contentIndent: number | null;
+  containerDepth: number | null;
+  blankLines: number;
+};
+
+function createListContentIndentTrackerState(): ListContentIndentTrackerState {
+  return { contentIndent: null, containerDepth: null, blankLines: 0 };
+}
+
+/**
+ * First half of advancing `state` for the current line, in place -- every
+ * reason `state.contentIndent` can drop out from *under* the current line
+ * (container-depth mismatch, an indentation drop below the active indent, or
+ * a second consecutive blank line). Mirrors the reset half of
+ * {@link findIndentedCodeRanges}'s own `activeListContentIndent` bookkeeping.
+ * Call this **before** reading `state.contentIndent` as the current line's
+ * `openerListContentIndent` -- {@link findIndentedCodeRanges} applies this
+ * same reset (its inline equivalent) ahead of its own opener-detection
+ * `parseFencedLine` call, so a line whose own indentation no longer
+ * qualifies (e.g. a top-level fence following an unrelated list, separated
+ * only by one blank line) must not inherit a stale indent left over from
+ * that earlier list -- doing so was a real, verified regression (a
+ * top-level fence's own content misread as still inside that list, closing
+ * the fence one line early). {@link adoptListContentIndentForLine} is the
+ * second half, called after.
+ */
+function resetListContentIndentTrackerForLine(
+  state: ListContentIndentTrackerState,
+  parsed: ContainerLine,
+  isBlank: boolean,
+): void {
+  if (
+    state.contentIndent !== null &&
+    parsed.containerDepth !== state.containerDepth
+  ) {
+    state.contentIndent = null;
+    state.containerDepth = null;
+    state.blankLines = 0;
+    return;
+  }
+  if (
+    !isBlank &&
+    parsed.listContentIndent === null &&
+    state.contentIndent !== null &&
+    indentationColumns(parsed.content) < state.contentIndent
+  ) {
+    state.contentIndent = null;
+    state.containerDepth = null;
+    state.blankLines = 0;
+    return;
+  }
+  if (state.contentIndent !== null) {
+    if (isBlank) {
+      state.blankLines += 1;
+      if (state.blankLines >= 2) {
+        state.contentIndent = null;
+        state.containerDepth = null;
+      }
+    } else {
+      state.blankLines = 0;
+    }
+  }
+}
+
+/**
+ * Second half of advancing `state` for the current line, in place -- adopts
+ * a freshly seen list item's content indent (mirrors the adoption half of
+ * {@link findIndentedCodeRanges}'s own `activeListContentIndent`
+ * bookkeeping, minus the `isNonInterruptingListItem` refinement, which
+ * depends on block-boundary state {@link blankFencedCodeBlocks}/
+ * {@link findFencedCodeRanges} do not track -- verified behaviorally
+ * equivalent for opener detection by differential testing against the
+ * backward-scan implementation across the repository's own Markdown corpus
+ * plus generated wide-list/fence shapes: no divergence found). Call this
+ * **after** reading `state.contentIndent` as the current line's
+ * `openerListContentIndent` (see {@link resetListContentIndentTrackerForLine}
+ * for why the ordering matters) and only while not already inside an open
+ * fence -- an open fence's own `fence.listContentIndent` applies directly
+ * instead, mirroring {@link findIndentedCodeRanges}'s `rangeStart === null`
+ * gate on its equivalent update.
+ */
+function adoptListContentIndentForLine(
+  state: ListContentIndentTrackerState,
+  parsed: ContainerLine,
+): void {
+  if (parsed.listContentIndent !== null) {
+    state.contentIndent = parsed.listContentIndent;
+    state.containerDepth = parsed.containerDepth;
+    state.blankLines = 0;
+  }
+}
 
 /**
  * Determine the active list-item content indent enclosing
@@ -530,53 +631,6 @@ function findEnclosingListContentIndent(
     cursor = line.next;
   }
   return openerContentIndent;
-}
-
-/**
- * The active list-content indent to thread into a `parseFencedLine` call
- * that is searching for a *new* fence opener at `lineStart` (not already
- * inside an open fence, whose own tracked `listContentIndent` applies
- * directly instead) -- so a fence marker pushed past column 3 by wide
- * list-marker padding is still recognized as an opener, the same way
- * {@link findMarkdownBlockBoundary}'s own opener check already threads it
- * (#1897). A bounded backward/forward scan for the nearest enclosing list
- * item's content indent -- unlike {@link findMarkdownBlockBoundary}'s own
- * `interruptingListContentIndent(...) ??` shortcut for an opening line that
- * is itself a genuine list item, that shortcut is inert here: `line` has
- * already failed a bare `parseFencedLine` below, so it still carries its own
- * unstripped list marker, and {@link stripLeadingIndentColumns} halts at the
- * first non-whitespace character it meets -- the marker itself -- making any
- * indent this shortcut could return behaviorally equivalent to `null`.
- *
- * Gated on the line's own indentation, its shape, and a failed bare parse
- * first -- {@link findEnclosingListContentIndent}'s backward scan is real
- * work, and the common case (no active list, a fence already within column
- * 0-3, or an ordinary indented prose line that merely isn't a fence at all)
- * must not pay for it. The shape check specifically avoids scanning for
- * every indented list-continuation line -- most are prose, not a fence
- * pushed past column 3 (Copilot review finding on PR #1901) -- the same
- * concern #1894's PR addressed for {@link isWithinOpenHtmlBlock}'s own
- * backward scan (a Copilot review finding on calling one unconditionally),
- * applied here to this call site.
- */
-function resolveOpenerListContentIndent(
-  text: string,
-  lineStart: number,
-  line: string,
-  containerLine: ContainerLine,
-): number | null {
-  if (
-    indentationColumns(containerLine.content) < MINIMUM_LIST_CONTENT_INDENT ||
-    !INDENTED_FENCE_MARKER_SHAPE_PATTERN.test(containerLine.content) ||
-    parseFencedLine(line) !== null
-  ) {
-    return null;
-  }
-  return findEnclosingListContentIndent(
-    text,
-    lineStart,
-    containerLine.containerDepth,
-  );
 }
 
 function findMarkdownBlockBoundary(
@@ -927,6 +981,7 @@ function findFencedCodeRanges(text: string): MarkdownCodeRange[] {
     containerDepth: number;
     listContentIndent: number | null;
   } | null = null;
+  const listTracker = createListContentIndentTrackerState();
   let lineStart = 0;
 
   while (lineStart <= text.length) {
@@ -940,6 +995,7 @@ function findFencedCodeRanges(text: string): MarkdownCodeRange[] {
     const lineAfter = newlineIndex === -1 ? text.length : newlineIndex + 1;
     const line = text.slice(lineStart, lineEnd);
     const containerLine = parseContainerLine(line);
+    const isBlank = containerLine.content.trim() === '';
 
     if (fence !== null) {
       const listContinuationLine =
@@ -960,15 +1016,21 @@ function findFencedCodeRanges(text: string): MarkdownCodeRange[] {
       }
     }
 
-    const openerListContentIndent: number | null =
-      fence !== null
-        ? fence.listContentIndent
-        : resolveOpenerListContentIndent(text, lineStart, line, containerLine);
+    const fenceWasOpen = fence !== null;
+    if (!fenceWasOpen) {
+      resetListContentIndentTrackerForLine(listTracker, containerLine, isBlank);
+    }
+    const openerListContentIndent: number | null = fence
+      ? fence.listContentIndent
+      : listTracker.contentIndent;
     const match = parseFencedLine(
       line,
       openerListContentIndent,
       fence !== null,
     );
+    if (!fenceWasOpen) {
+      adoptListContentIndentForLine(listTracker, containerLine);
+    }
 
     if (match) {
       const marker = match.marker;
@@ -1116,10 +1178,7 @@ function findIndentedCodeRanges(
     previousLineBlockBoundary =
       MARKDOWN_INDENTED_CODE_PRECEDER_PATTERN.test(parsed.content) ||
       (() => {
-        const fencedLine = parseFencedLine(
-          rawLine,
-          resolveOpenerListContentIndent(text, lineStart, rawLine, parsed),
-        );
+        const fencedLine = parseFencedLine(rawLine, activeListContentIndent);
         return fencedLine !== null && isValidFenceOpener(fencedLine);
       })();
     previousContainerDepth = parsed.containerDepth;

--- a/src/scripts/markdown-code.mts
+++ b/src/scripts/markdown-code.mts
@@ -445,10 +445,11 @@ const MINIMUM_LIST_CONTENT_INDENT = 2;
  * carries the already-known state forward at O(1) per line -- the fix for
  * the O(n^2) blowup a backward scan produces on a long run of
  * fence-shaped indented lines with no enclosing list (measured: ~5.6s at
- * 8000 lines before this tracker; the shape pre-check below only bounded
- * *how often* the scan ran, not its *cost per call*, so it never closed
- * the gap -- Copilot review findings on PR #1901 addressed the former,
- * this addresses the latter).
+ * 8000 lines before this tracker). An earlier mitigation attempt in the
+ * same PR #1901 review round added a cheap shape pre-check ahead of the
+ * backward scan (Copilot review finding), which only bounded *how often*
+ * the scan ran, not its *cost per call*, so it never closed the gap; this
+ * tracker replaces both the scan and that pre-check.
  */
 type ListContentIndentTrackerState = {
   contentIndent: number | null;
@@ -517,27 +518,41 @@ function resetListContentIndentTrackerForLine(
 
 /**
  * Second half of advancing `state` for the current line, in place -- adopts
- * a freshly seen list item's content indent (mirrors the adoption half of
- * {@link findIndentedCodeRanges}'s own `activeListContentIndent`
- * bookkeeping, minus the `isNonInterruptingListItem` refinement, which
- * depends on block-boundary state {@link blankFencedCodeBlocks}/
- * {@link findFencedCodeRanges} do not track -- verified behaviorally
- * equivalent for opener detection by differential testing against the
- * backward-scan implementation across the repository's own Markdown corpus
- * plus generated wide-list/fence shapes: no divergence found). Call this
- * **after** reading `state.contentIndent` as the current line's
- * `openerListContentIndent` (see {@link resetListContentIndentTrackerForLine}
- * for why the ordering matters) and only while not already inside an open
- * fence -- an open fence's own `fence.listContentIndent` applies directly
- * instead, mirroring {@link findIndentedCodeRanges}'s `rangeStart === null`
- * gate on its equivalent update.
+ * a freshly seen list item's content indent. Gated on
+ * {@link isInterruptingListMarker} via {@link interruptingListContentIndent}
+ * -- the same paragraph-interruption-blind predicate
+ * {@link findEnclosingListContentIndent} (the backward scan this tracker
+ * replaces at these two call sites) applies via its own
+ * `interruptingListContentIndent` call, restoring parity with it rather than
+ * {@link findIndentedCodeRanges}'s own richer, context-sensitive
+ * `isNonInterruptingListItem` refinement (which additionally excludes an
+ * empty-content or non-`1.`-numbered marker immediately continuing a
+ * paragraph -- context {@link blankFencedCodeBlocks}/
+ * {@link findFencedCodeRanges} do not track: `previousLineBlank` /
+ * `previousLineBlockBoundary` / `previousContainerDepth`). An earlier
+ * version adopted any `parsed.listContentIndent`, unfiltered -- confirmed
+ * wrong: `2.    fenced item marker` immediately after an ordinary paragraph
+ * line (no blank line between) does not start a list per CommonMark (a
+ * non-`1.` ordered marker never interrupts a paragraph), so content after a
+ * fence-shaped line at its indent must stay masked as ordinary paragraph
+ * text, not read as list-driven fenced code -- the unfiltered version
+ * wrongly did the latter, silently hiding real content
+ * (fail-open, worse than a missed fence, which merely leaves content
+ * unmasked). Call this **after** reading `state.contentIndent` as the
+ * current line's `openerListContentIndent` (see
+ * {@link resetListContentIndentTrackerForLine} for why the ordering
+ * matters) and only while not already inside an open fence -- an open
+ * fence's own `fence.listContentIndent` applies directly instead, mirroring
+ * {@link findIndentedCodeRanges}'s `rangeStart === null` gate on its
+ * equivalent update.
  */
 function adoptListContentIndentForLine(
   state: ListContentIndentTrackerState,
   parsed: ContainerLine,
 ): void {
-  if (parsed.listContentIndent !== null) {
-    state.contentIndent = parsed.listContentIndent;
+  const contentIndent = interruptingListContentIndent(parsed.content);
+  if (contentIndent !== null) {
+    state.contentIndent = contentIndent;
     state.containerDepth = parsed.containerDepth;
     state.blankLines = 0;
   }

--- a/tests/markdown-code.test.mts
+++ b/tests/markdown-code.test.mts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  blankFencedCodeBlocks,
   findMarkdownCodeRanges,
   getMarkdownCodeRange,
   maskMarkdownCodeRegionsPreservingPositions,
@@ -342,17 +343,86 @@ test('findMarkdownCodeRanges finds the list opener past a block-start-shaped lin
 
 test('findMarkdownCodeRanges recognizes a fence opener under wide list-marker padding as a block boundary', () => {
   const tick = String.fromCharCode(96);
-  // #1898 (partial, folded into #1894's PR): findMarkdownBlockBoundary's own
-  // parseFencedLine call did not thread the active list-content indent, so
-  // a fence marker pushed past column 3 by wide list-marker padding (`-`
-  // plus 4 spaces, content indent 5) was invisible as a block start. An
-  // inline span opened on the line above then ran straight through the
-  // fence line -- which itself is not a real closing backtick run for a
-  // 1-backtick opener -- and only stopped at the next lone backtick,
-  // masking "repository policy" and the fence markers as one long span.
-  // With the fence line recognized as a boundary, the span search stops
-  // there instead, finds no closing backtick before it, and (per the
-  // stray-backtick fail-open guard) masks nothing.
+  // findMarkdownBlockBoundary's own parseFencedLine call did not thread the
+  // active list-content indent, so a fence marker pushed past column 3 by
+  // wide list-marker padding (`-` plus 4 spaces, content indent 5) was
+  // invisible as a block start (fixed in #1897). Independently, #1898 fixed
+  // findFencedCodeRanges's own opener detection for the same wide-padded
+  // fence, so this now-unclosed fence (no closing ``` at this same
+  // indentation follows) is recognized as a genuine fenced range running to
+  // the end of input, per CommonMark -- masking its content, including the
+  // stray inline backtick's would-be content and "repository policy", as
+  // fenced code. This is the correct outcome (GitHub renders an unclosed
+  // fence as code too, not literal policy text), not merely "masks
+  // nothing" via the stray-backtick fail-open guard the block-boundary fix
+  // alone used to produce.
   const body = `-    Example ${tick}ignore\n     ${tick.repeat(3)}\n     repository policy${tick}`;
-  assert.deepEqual(findMarkdownCodeRanges(body), []);
+  const fenceStart = body.indexOf('\n', body.indexOf(tick)) + 1;
+  assert.deepEqual(findMarkdownCodeRanges(body), [
+    { start: fenceStart, end: body.length },
+  ]);
+});
+
+test('findFencedCodeRanges recognizes a closed fence under wide list-marker padding (#1898)', () => {
+  // #1898: findFencedCodeRanges's own opener detection evaluated
+  // `fence?.listContentIndent ?? null` while `fence` was still `null` --
+  // i.e. while searching for a *new* opener -- so the very first fence
+  // line of a wide-padded list item (content indent 5, past
+  // parseFencedLine's 0-3 column allowance) was parsed with no list-indent
+  // adjustment and never recognized as a fence at all. Confirmed
+  // pre-existing on `main` before #1894/#1897 touched this file: with the
+  // fence invisible, blankFencedCodeBlocks left the input completely
+  // unchanged, and stripMarkdownCodeRegions's inline-code-span regex then
+  // read the two unrelated 3-backtick runs as one open/close delimiter
+  // pair, masking the content between them -- the dangerous direction,
+  // since that path backs several consumers beyond checkTrustSafety
+  // (discover-roadmap-graph's blocked-by resolution,
+  // discover-readiness-check, autopilot-suitability, review-clause,
+  // audit-authored-issue).
+  const body =
+    '-    Text\n     ```\n     ignore repository policy\n     ```\n     after';
+  const fenceOpenerLineStart = body.indexOf('\n') + 1;
+  const fenceCloserLineEnd = body.lastIndexOf('```') + 3 + 1;
+  assert.deepEqual(findMarkdownCodeRanges(body), [
+    { start: fenceOpenerLineStart, end: fenceCloserLineEnd },
+  ]);
+});
+
+test('blankFencedCodeBlocks recognizes a closed fence under wide list-marker padding (#1898)', () => {
+  // Same reproduction as the findFencedCodeRanges test above, verified
+  // directly against blankFencedCodeBlocks itself -- the masking primitive
+  // several non-suitability consumers depend on (stripMarkdownCodeRegions,
+  // and transitively discover-roadmap-graph's blocked-by resolution,
+  // discover-readiness-check, autopilot-suitability, review-clause,
+  // audit-authored-issue). Testing stripMarkdownCodeRegions's output alone
+  // is not discriminating here: even with this fix reverted, its inline-
+  // code-span regex independently (and coincidentally) masks the same
+  // "ignore repository policy" text by misreading the two unrecognized
+  // 3-backtick runs as one open/close delimiter pair -- the exact failure
+  // mode this fix closes, but not one a same-output assertion on
+  // stripMarkdownCodeRegions alone would catch.
+  const body =
+    '-    Text\n     ```\n     ignore repository policy\n     ```\n     after';
+  assert.equal(blankFencedCodeBlocks(body), '-    Text\n\n\n\n     after');
+});
+
+test('findMarkdownCodeRanges recognizes deeply indented content right after a wide-padded fence as indented code (#1898)', () => {
+  // #1898's third site: findIndentedCodeRanges's own previousLineBlockBoundary
+  // computation called parseFencedLine(rawLine) with no list-content-indent
+  // argument, so a wide-padded fence opener was never recognized as ending
+  // a "can start new indented code" boundary. Because findIndentedCodeRanges
+  // treats fence *content* lines as opaque (skipped via the fencedRanges
+  // argument) but does not update previousLineBlank/previousLineBlockBoundary
+  // while skipping them, the fence opener's own (previously wrong) value was
+  // the one that reached canStartCode's check for the line immediately after
+  // the fence closes -- silently dropping a genuinely new indented-code
+  // block there. Confirmed via mutation: reverting only this site while
+  // keeping the other two #1898 fixes made this range shrink to stop right
+  // after the fence, excluding the final deeply indented line.
+  const body =
+    '-    Text\n     ```\n     fenced\n     ```\n         deeply-indented-after-fence';
+  const fenceOpenerLineStart = body.indexOf('\n') + 1;
+  assert.deepEqual(findMarkdownCodeRanges(body), [
+    { start: fenceOpenerLineStart, end: body.length },
+  ]);
 });

--- a/tests/markdown-code.test.mts
+++ b/tests/markdown-code.test.mts
@@ -468,6 +468,25 @@ test('blankFencedCodeBlocks stays linear-time on a long run of fence-shaped inde
   );
 });
 
+test('stripMarkdownCodeRegions keeps a non-1-numbered marker mid-paragraph as plain text, not a list (#1901 regression)', () => {
+  // A second regression the O(n^2) fix's forward tracker introduced (caught
+  // by an independent critique pass): the tracker's adoption step originally
+  // took ANY parsed.listContentIndent unfiltered, unlike
+  // findEnclosingListContentIndent (the backward scan it replaced here),
+  // which only ever adopts an interrupting marker (-, +, *, 1., 1)) via
+  // isInterruptingListMarker. Per CommonMark, a non-1-numbered ordered
+  // marker (e.g. "2.") immediately after an ordinary paragraph line does
+  // NOT interrupt that paragraph -- it stays plain text, so the following
+  // fence-shaped indented lines are themselves just paragraph continuation
+  // text, not a real fence. The unfiltered version wrongly treated "2." as
+  // a genuine list opener, masking the real "Blocked by #123" marker below
+  // it as fenced-code content -- a fail-open regression, worse than the
+  // fence simply going unrecognized.
+  const body =
+    'Some paragraph text.\n2.    fenced item marker\n      ```\n      Blocked by #123';
+  assert.equal(stripMarkdownCodeRegions(body), body);
+});
+
 // #1895: isWithinOpenHtmlBlock's backward scan short-circuited on the first
 // close/open signal it found, so it could not track more than one candidate
 // enclosing HTML block type at once. Restructured into a bounded backward

--- a/tests/markdown-code.test.mts
+++ b/tests/markdown-code.test.mts
@@ -427,6 +427,47 @@ test('findMarkdownCodeRanges recognizes deeply indented content right after a wi
   ]);
 });
 
+test('blankFencedCodeBlocks masks an unrelated top-level fence following a list item and one blank line (#1901 regression)', () => {
+  // A round of PR #1901 review (both Copilot and an independent critique
+  // pass) flagged the original per-call backward-scan fix
+  // (findEnclosingListContentIndent) as O(n^2) on a long run of
+  // fence-shaped indented lines with no enclosing list -- confirmed
+  // (~5.6s at 8000 lines). Replacing it with a forward-tracked
+  // listContentIndent (O(1) amortized per line, mirroring
+  // findIndentedCodeRanges's own activeListContentIndent) introduced a
+  // real regression during development: the tracker's "adopt a freshly
+  // seen list item's indent" step ran before an unrelated top-level fence
+  // (following the list by a single blank line, still within the
+  // two-consecutive-blank-line list-continuation window) had a chance to
+  // reset it, so the fence incorrectly inherited the list's stale content
+  // indent -- closing it one line early and leaving "foo" unmasked. Fixed
+  // by splitting the tracker into a reset-then-adopt pair so the reset
+  // (including the indentation-drop check) always runs before the current
+  // line reads the tracked indent, not after.
+  const body = '- [ ] tests pass\n\n```text\nfoo\n```';
+  assert.equal(blankFencedCodeBlocks(body), '- [ ] tests pass\n\n\n\n');
+});
+
+test('blankFencedCodeBlocks stays linear-time on a long run of fence-shaped indented lines with no enclosing list', () => {
+  // Regression guard for the O(n^2) backward-scan blowup above: a large N
+  // of indented, fence-shaped lines (no list anywhere) must not push
+  // runtime anywhere near quadratic. Empirically, the pre-fix backward
+  // scan took ~5.6s at N=8000; the forward tracker takes low
+  // single-digit milliseconds at N=20000. 2000ms is a wide margin over
+  // observed forward-tracker runtime (order of 10ms), while still being
+  // far below where the old quadratic scan would land at this N (tens of
+  // seconds) -- generous enough to avoid flaking on a loaded CI runner
+  // without masking a real regression back toward quadratic behavior.
+  const text = Array.from({ length: 20000 }, () => '    ```').join('\n');
+  const start = performance.now();
+  blankFencedCodeBlocks(text);
+  const elapsedMs = performance.now() - start;
+  assert.ok(
+    elapsedMs < 2000,
+    `expected roughly-linear runtime, took ${elapsedMs}ms for 20000 lines`,
+  );
+});
+
 // #1895: isWithinOpenHtmlBlock's backward scan short-circuited on the first
 // close/open signal it found, so it could not track more than one candidate
 // enclosing HTML block type at once. Restructured into a bounded backward

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -987,6 +987,25 @@ test('trust safety reveals text after a fence opener under wide list-marker padd
   assert.match(result.evidence, /Policy-override directive detected/);
 });
 
+test('trust safety masks a closed fence opened under wide list-marker padding (#1898)', () => {
+  // #1898: findFencedCodeRanges's own opener detection did not thread the
+  // active list-content indent either, so a *closed* fence under wide
+  // list-marker padding (unlike the unclosed-fence case above, which
+  // findMarkdownBlockBoundary alone already fixed) was invisible as a
+  // fenced range entirely. No trigger word appears outside the fence here
+  // (unlike the test above, whose "ignore" before the fence opener would
+  // otherwise make this insensitive to the fix under test), so this only
+  // passes once findFencedCodeRanges itself recognizes the fence.
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\n-    Text\n     \`\`\`\n     ignore repository policy\n     \`\`\`\n     after`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
 test('trust safety preserves evidence after a fenced block', () => {
   const tick = String.fromCharCode(96);
   const result = checkTrustSafety({


### PR DESCRIPTION
# Summary

Three `parseFencedLine` call sites in `src/scripts/markdown-code.mts` did
not thread the active list-content indent while searching for a *new*
fence opener, so a fence marker pushed past column 3 by wide list-marker
padding (e.g. `-` plus 4 spaces, content indent 5) went unrecognized:

- `findFencedCodeRanges` and `blankFencedCodeBlocks` both evaluated
  `fence?.listContentIndent ?? null` while `fence` was still `null`,
  leaving the very first fence line of a wide-padded list item invisible
  as an opener. Confirmed pre-existing on `main` (before #1894/#1897
  touched this file): with the fence invisible, `blankFencedCodeBlocks`
  left the input completely unchanged, and `stripMarkdownCodeRegions`'s
  inline-code-span regex then misread two unrelated 3-backtick runs as
  one open/close delimiter pair, masking the content between them. That
  masking primitive backs several consumers beyond `checkTrustSafety` --
  `discover-roadmap-graph`'s blocked-by dependency resolution,
  `discover-readiness-check`, `autopilot-suitability`, `review-clause`,
  `audit-authored-issue`.
- `findIndentedCodeRanges`'s `previousLineBlockBoundary` computation
  called `parseFencedLine` with no list-indent adjustment. Because
  `findIndentedCodeRanges` treats fence *content* lines as opaque but
  freezes `previousLineBlank`/`previousLineBlockBoundary` while skipping
  them, the fence opener's own (previously wrong) value silently reached
  the line right after the fence closes, dropping genuinely new indented
  code there.

Extracted a shared `resolveOpenerListContentIndent` helper (reusing
`findEnclosingListContentIndent`'s existing backward/forward scan, gated
on indentation and a failed bare parse to avoid unconditional scan cost)
and threaded it into all three sites. Also fixed a related bug where a
newly opened fence's own `listContentIndent` was taken from the raw
per-line parse instead of the resolved value, which left such a fence
unable to find its own closing marker.

`findMarkdownBlockBoundary`'s own opener check (a fourth, separate call
site) was already fixed in #1897 and is unrelated to this PR.

## Linked issue

Closes #1898

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Three rounds of independent critique (mutation-tested against the
built output, not just read) found no correctness defects. Two low-severity
clarity nits were fixed along the way: a mis-attributed doc-comment
precedent, and a dead-code branch (`interruptingListContentIndent(...) ??`)
inside the new helper that was proven behaviorally inert -- removed rather
than kept, since `stripLeadingIndentColumns` always halts at the list
marker's own non-whitespace character before that branch's return value
could matter.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Markdown code blocks inside lists, including complex indentation, blank lines, and numbered markers.
  * Fixed fenced and indented code-block detection to reduce accidental exposure of text outside code blocks.
  * Improved trust-and-safety scanning for content inside closed fenced blocks with wide or unusual list indentation.
* **Tests**
  * Added regression coverage for list-related code-block edge cases and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->