### PR TITLE
feat(advisory-convergence): opt-in bot-authored-PR exemption

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -10,7 +10,7 @@ Shared advisory-wait protocol used by **E14**
 and **F3** (`idd-merge.instructions.md`). Policy constants (cap/windows)
 are named in
 [`docs/policy-constants.md`](../../docs/policy-constants.md); this file
-owns behavior (`exemptBotAuthoredPrs`, #1906, is separate).
+owns behavior; `exemptBotAuthoredPrs` (#1906) gates applicability.
 
 ## Scope — Copilot-only settle/wait window
 

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -10,7 +10,7 @@ Shared advisory-wait protocol used by **E14**
 and **F3** (`idd-merge.instructions.md`). Policy constants (cap/windows)
 are named in
 [`docs/policy-constants.md`](../../docs/policy-constants.md); this file
-owns behavior; `advisoryWait.exemptBotAuthoredPrs` gates applicability.
+owns behavior; `advisoryWait.exemptBotAuthoredPrs` is convergence-only.
 
 ## Scope — Copilot-only settle/wait window
 

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -10,7 +10,7 @@ Shared advisory-wait protocol used by **E14**
 and **F3** (`idd-merge.instructions.md`). Policy constants (cap/windows)
 are named in
 [`docs/policy-constants.md`](../../docs/policy-constants.md); this file
-owns behavior.
+owns behavior (`exemptBotAuthoredPrs`, #1906, is separate).
 
 ## Scope — Copilot-only settle/wait window
 

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -10,7 +10,7 @@ Shared advisory-wait protocol used by **E14**
 and **F3** (`idd-merge.instructions.md`). Policy constants (cap/windows)
 are named in
 [`docs/policy-constants.md`](../../docs/policy-constants.md); this file
-owns behavior; `exemptBotAuthoredPrs` (#1906) gates applicability.
+owns behavior; `advisoryWait.exemptBotAuthoredPrs` gates applicability.
 
 ## Scope — Copilot-only settle/wait window
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -273,6 +273,20 @@ for the exact per-case waiver availability). Invalid values are
 rejected by schema, and runtime normalization falls back to `all-prs`
 for untrusted config reads.
 
+Repositories may also customize `advisoryWait.exemptBotAuthoredPrs`
+(#1906) in `.github/idd/config.json`. This opt-in, off-by-default flag
+takes effect only under `advisoryWait.convergenceScope: "all-prs"` (it
+never changes any `idd-claimed` outcome). When `true`, a PR whose author
+resolves to a GitHub Bot-typed account AND has no claim-marker history at
+all resolves to `not_applicable` (reason `bot-authored-no-claim-history`)
+automatically, without a fresh per-PR maintainer waiver -- useful for a
+repository that receives frequent automated dependency-update PRs
+(Dependabot, Renovate, ImgBot, or similar) whose primary-bot review never
+lands. A Bot-typed author that DOES have claim-marker history, or any
+human-authored PR, is never exempted regardless of this flag. Invalid
+values are rejected by schema, and runtime normalization falls back to
+`false` for untrusted config reads.
+
 `advisoryWait.primaryBotLogin` selects the advisory bot whose review the
 advisory-wait gate tracks (default Copilot), and
 `advisoryWait.secondaryBotLogin` names an **optional, non-gating** secondary

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -282,7 +282,9 @@ all resolves to `not_applicable` (reason `bot-authored-no-claim-history`)
 automatically, without a fresh per-PR maintainer waiver -- useful for a
 repository that receives frequent automated dependency-update PRs
 (Dependabot, Renovate, ImgBot, or similar) whose primary-bot review never
-lands. A Bot-typed author that DOES have claim-marker history, or any
+lands (observed 2026-08-05, #1904 -- 1 of 18 sampled `dependabot[bot]`-
+authored pull requests in this repository's own history ever received a
+Copilot review). A Bot-typed author that DOES have claim-marker history, or any
 human-authored PR, is never exempted regardless of this flag. Invalid
 values are rejected by schema, and runtime normalization falls back to
 `false` for untrusted config reads.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -282,9 +282,10 @@ all resolves to `not_applicable` (reason `bot-authored-no-claim-history`)
 automatically, without a fresh per-PR maintainer waiver -- useful for a
 repository that receives frequent automated dependency-update PRs
 (Dependabot, Renovate, ImgBot, or similar) whose primary-bot review never
-lands (observed 2026-08-05, #1904 -- 1 of 18 sampled `dependabot[bot]`-
-authored pull requests in this repository's own history ever received a
-Copilot review). A Bot-typed author that DOES have claim-marker history, or any
+lands (observed 2026-08-05, #1904 -- 1 of 18 sampled pull requests
+authored by `dependabot[bot]` in this repository's own history ever
+received a Copilot review). A Bot-typed author that DOES have claim-marker
+history, or any
 human-authored PR, is never exempted regardless of this flag. Invalid
 values are rejected by schema, and runtime normalization falls back to
 `false` for untrusted config reads.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1772,10 +1772,10 @@ to post it is the consuming track's job.
   `idd-claimed-no-verified-linked-issue-claim` branch just above, so this
   flag changes nothing there). When `true`, a PR whose author resolves to
   a GitHub Bot-typed account (fetched via a small dedicated GraphQL
-  `__typename` query) AND has no claim-marker history at all is
-  classified `applicability: { status: "not_applicable", reason:
-  "bot-authored-no-claim-history" }`, letting a recurring automated
-  dependency-update PR (Dependabot, Renovate, ImgBot, or similar) pass
+  `__typename` query) AND has no claim-marker history at all resolves
+  to `not_applicable` (reason `bot-authored-no-claim-history`), letting
+  a recurring automated dependency-update PR (Dependabot, Renovate,
+  ImgBot, or similar) pass
   the gate without a fresh per-PR maintainer waiver. A Bot-typed author
   that DOES have claim-marker history, or any human-authored PR, is
   never exempted regardless of this flag. The `scope-not-applicable`

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1766,6 +1766,22 @@ to post it is the consuming track's job.
     genuinely waivable). See
     `computeAdvisoryConvergenceVerdict`'s `AdvisoryConvergenceApplicability`
     doc comment (advisory-convergence.mts) for the full contract.
+- `advisoryWait.exemptBotAuthoredPrs` (#1906): opt-in, off by default,
+  and effective only under `convergenceScope: "all-prs"` (`idd-claimed`
+  already resolves the same PR shape `not_applicable` via the
+  `idd-claimed-no-verified-linked-issue-claim` branch just above, so this
+  flag changes nothing there). When `true`, a PR whose author resolves to
+  a GitHub Bot-typed account (fetched via a small dedicated GraphQL
+  `__typename` query) AND has no claim-marker history at all is
+  classified `applicability: { status: "not_applicable", reason:
+  "bot-authored-no-claim-history" }`, letting a recurring automated
+  dependency-update PR (Dependabot, Renovate, ImgBot, or similar) pass
+  the gate without a fresh per-PR maintainer waiver. A Bot-typed author
+  that DOES have claim-marker history, or any human-authored PR, is
+  never exempted regardless of this flag. The `scope-not-applicable`
+  same-HEAD-reroll token below already covers this new `not_applicable`
+  cause too, since its underlying check reads `applicability.status`
+  generically, not `convergenceScope` specifically.
 
 #### Bounded same-HEAD advisory reroll (AW6, #1511)
 
@@ -1806,7 +1822,7 @@ structurally unable to disagree.
 <!-- dprint-ignore-start -->
 | Token                                    | Fires when...                                                                                                                                          |
 | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `scope-not-applicable`                    | `applicability.status` is `not_applicable` OR `indeterminate` (#1686) -- `advisoryWait.convergenceScope: "idd-claimed"` and this PR either has no verified linked claim/branch, or has a broken/ambiguous claim linkage. Offering a same-HEAD reroll is pointless in either case. |
+| `scope-not-applicable`                    | `applicability.status` is `not_applicable` OR `indeterminate` (#1686) -- either `advisoryWait.convergenceScope: "idd-claimed"` and this PR has no verified linked claim/branch or has a broken/ambiguous claim linkage, or (#1906) `advisoryWait.exemptBotAuthoredPrs: true` under `"all-prs"` scope exempted a Bot-authored PR with no claim history. Offering a same-HEAD reroll is pointless in any of these cases. |
 | `review-pending`                          | The primary bot has not yet reviewed current HEAD (`pending: true`). Always co-occurs with `review-item-count-unknown` below, since an off-HEAD review reports no usable item count. |
 | `unresolved-copilot-threads`              | `threads.satisfied` is `false` -- at least one Copilot-authored thread is neither resolved nor validly dispositioned.                                   |
 | `missing-regular-comment-disposition`     | `dispositionEvidence.missingRegularCommentCount` is non-zero -- an outstanding regular (non-thread) PR comment still lacks a fresh disposition marker.  |

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -181,11 +181,11 @@ The current policy schema and helper runtime now support
 `advisoryWait.pollInterval`, `advisoryWait.capExhaustedRoute`,
 `advisoryWait.primaryBotLogin`, `advisoryWait.secondaryBotLogin`,
 `advisoryWait.convergenceDeadline`, `advisoryWait.sameHeadRerollCap`,
-`advisoryWait.recoveryCycleCap`, `advisoryWait.terminalWindow`, and
-`advisoryWait.convergenceScope`. Omitted keys keep the distributed defaults
-below. The duration keys (`pendingWindow`, `settledWindow`, `pollInterval`,
-`convergenceDeadline`, `terminalWindow`) accept positive whole-minute
-ISO 8601 durations only.
+`advisoryWait.recoveryCycleCap`, `advisoryWait.terminalWindow`,
+`advisoryWait.convergenceScope`, and `advisoryWait.exemptBotAuthoredPrs`.
+Omitted keys keep the distributed defaults below. The duration keys
+(`pendingWindow`, `settledWindow`, `pollInterval`, `convergenceDeadline`,
+`terminalWindow`) accept positive whole-minute ISO 8601 durations only.
 `advisoryWait.recoveryCycleCap` / `advisoryWait.terminalWindow` (#1572)
 define the terminal Copilot stall-recovery **state contract**, accounted
 independently of `requestCap` and `sameHeadRerollCap`: see
@@ -219,6 +219,16 @@ it equal to the primary) keeps behavior identical to the primary-only path.
 Configure it to a **requestable reviewer** whose `--add-reviewer` request
 appears on the PR timeline (like the primary); a bot that reviews via app
 install without a requestable-reviewer event cannot be tracked once per HEAD.
+`advisoryWait.exemptBotAuthoredPrs` (#1906) is an opt-in, off-by-default
+flag effective only under `advisoryWait.convergenceScope: "all-prs"`. When
+`true`, a PR whose author resolves to a GitHub Bot-typed account AND has no
+claim-marker history at all becomes `not_applicable` (reason
+`bot-authored-no-claim-history`), so a repository with frequent automated
+dependency-update PRs does not need a fresh per-PR maintainer waiver for
+each one. It has no effect under `idd-claimed` scope, where that same PR
+shape already resolves `not_applicable` via the existing
+`idd-claimed-no-verified-linked-issue-claim` branch; see
+[Helper scripts](idd-helper-scripts.md) for the full contract.
 
 | Policy default                                   | Distributed value                                                                                                                                                                                                                                                                                                                                            | Owning surface                                                                                                                                                                                                       | Onboarding expectation                                                                                                                                          |
 | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -236,6 +246,7 @@ install without a requestable-reviewer event cannot be tracked once per HEAD.
 | Copilot stall-recovery cycle cap                 | 2 recovery cycles per PR HEAD (`advisoryWait.recoveryCycleCap`)                                                                                                                                                                                                                                                                                              | [Advisory wait](../.github/instructions/idd-advisory-wait.instructions.md)                                                                                                                                           | Keep unless the repository needs a different bounded terminal-recovery budget; kept separate from `requestCap` and `sameHeadRerollCap` by design.               |
 | Copilot terminal-unavailability window           | 12 h (`advisoryWait.terminalWindow`)                                                                                                                                                                                                                                                                                                                         | [Advisory wait](../.github/instructions/idd-advisory-wait.instructions.md)                                                                                                                                           | Keep unless the repository needs a different window before `COPILOT_UNAVAILABLE` waiver eligibility applies.                                                    |
 | Advisory-convergence enforcement scope           | `all-prs` (`advisoryWait.convergenceScope`)                                                                                                                                                                                                                                                                                                                  | [Pre-merge](../.github/instructions/idd-pre-merge.instructions.md), [Helper scripts](idd-helper-scripts.md), [Customizing IDD](customization.md#policy-constants)                                                    | Keep `all-prs` for existing behavior; switch to `idd-claimed` only when the repository wants convergence to apply solely to verified IDD-owned PRs.             |
+| Bot-authored-PR exemption                        | `false` (`advisoryWait.exemptBotAuthoredPrs`)                                                                                                                                                                                                                                                                                                                | [Helper scripts](idd-helper-scripts.md), [Customizing IDD](customization.md#policy-constants)                                                                                                                        | Keep `false` unless the repository wants recurring Bot-authored, claimless PRs under `all-prs` scope to skip the maintainer-waiver path automatically.          |
 | Advisory-convergence required-check registration | Not registered by default (hosting the `idd-advisory-convergence` workflow is itself an opt-in step — see [ONBOARDING](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#optional--host-idd-advisory-convergence-as-a-required-check-ci-workflow); once hosted, a required-status-check Ruleset entry is a separate manual step) | [Customizing IDD](customization.md#policy-constants), [Helper scripts](idd-helper-scripts.md)                                                                                                                        | Register `idd-advisory-convergence` as a required status check to make convergence non-bypassable; this is a maintainer GitHub-settings action, not agent work. |
 
 `idd-claimed` keeps genuinely claimless/manual dependency PRs out of the

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -5,7 +5,7 @@ Shared advisory-wait protocol used by **E14**
 and **F3** (`idd-merge.instructions.md`). Policy constants (cap/windows)
 are named in
 [`docs/policy-constants.md`](../../docs/policy-constants.md); this file
-owns behavior; `advisoryWait.exemptBotAuthoredPrs` gates applicability.
+owns behavior; `advisoryWait.exemptBotAuthoredPrs` is convergence-only.
 
 ## Scope — Copilot-only settle/wait window
 

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -5,7 +5,7 @@ Shared advisory-wait protocol used by **E14**
 and **F3** (`idd-merge.instructions.md`). Policy constants (cap/windows)
 are named in
 [`docs/policy-constants.md`](../../docs/policy-constants.md); this file
-owns behavior.
+owns behavior (`exemptBotAuthoredPrs`, #1906, is separate).
 
 ## Scope — Copilot-only settle/wait window
 

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -5,7 +5,7 @@ Shared advisory-wait protocol used by **E14**
 and **F3** (`idd-merge.instructions.md`). Policy constants (cap/windows)
 are named in
 [`docs/policy-constants.md`](../../docs/policy-constants.md); this file
-owns behavior; `exemptBotAuthoredPrs` (#1906) gates applicability.
+owns behavior; `advisoryWait.exemptBotAuthoredPrs` gates applicability.
 
 ## Scope — Copilot-only settle/wait window
 

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -5,7 +5,7 @@ Shared advisory-wait protocol used by **E14**
 and **F3** (`idd-merge.instructions.md`). Policy constants (cap/windows)
 are named in
 [`docs/policy-constants.md`](../../docs/policy-constants.md); this file
-owns behavior (`exemptBotAuthoredPrs`, #1906, is separate).
+owns behavior; `exemptBotAuthoredPrs` (#1906) gates applicability.
 
 ## Scope — Copilot-only settle/wait window
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -273,6 +273,20 @@ for the exact per-case waiver availability). Invalid values are
 rejected by schema, and runtime normalization falls back to `all-prs`
 for untrusted config reads.
 
+Repositories may also customize `advisoryWait.exemptBotAuthoredPrs`
+(#1906) in `.github/idd/config.json`. This opt-in, off-by-default flag
+takes effect only under `advisoryWait.convergenceScope: "all-prs"` (it
+never changes any `idd-claimed` outcome). When `true`, a PR whose author
+resolves to a GitHub Bot-typed account AND has no claim-marker history at
+all resolves to `not_applicable` (reason `bot-authored-no-claim-history`)
+automatically, without a fresh per-PR maintainer waiver -- useful for a
+repository that receives frequent automated dependency-update PRs
+(Dependabot, Renovate, ImgBot, or similar) whose primary-bot review never
+lands. A Bot-typed author that DOES have claim-marker history, or any
+human-authored PR, is never exempted regardless of this flag. Invalid
+values are rejected by schema, and runtime normalization falls back to
+`false` for untrusted config reads.
+
 `advisoryWait.primaryBotLogin` selects the advisory bot whose review the
 advisory-wait gate tracks (default Copilot), and
 `advisoryWait.secondaryBotLogin` names an **optional, non-gating** secondary

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -282,7 +282,9 @@ all resolves to `not_applicable` (reason `bot-authored-no-claim-history`)
 automatically, without a fresh per-PR maintainer waiver -- useful for a
 repository that receives frequent automated dependency-update PRs
 (Dependabot, Renovate, ImgBot, or similar) whose primary-bot review never
-lands. A Bot-typed author that DOES have claim-marker history, or any
+lands (observed 2026-08-05, #1904 -- 1 of 18 sampled `dependabot[bot]`-
+authored pull requests in this repository's own history ever received a
+Copilot review). A Bot-typed author that DOES have claim-marker history, or any
 human-authored PR, is never exempted regardless of this flag. Invalid
 values are rejected by schema, and runtime normalization falls back to
 `false` for untrusted config reads.

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -282,9 +282,10 @@ all resolves to `not_applicable` (reason `bot-authored-no-claim-history`)
 automatically, without a fresh per-PR maintainer waiver -- useful for a
 repository that receives frequent automated dependency-update PRs
 (Dependabot, Renovate, ImgBot, or similar) whose primary-bot review never
-lands (observed 2026-08-05, #1904 -- 1 of 18 sampled `dependabot[bot]`-
-authored pull requests in this repository's own history ever received a
-Copilot review). A Bot-typed author that DOES have claim-marker history, or any
+lands (observed 2026-08-05, #1904 -- 1 of 18 sampled pull requests
+authored by `dependabot[bot]` in this repository's own history ever
+received a Copilot review). A Bot-typed author that DOES have claim-marker
+history, or any
 human-authored PR, is never exempted regardless of this flag. Invalid
 values are rejected by schema, and runtime normalization falls back to
 `false` for untrusted config reads.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1772,10 +1772,10 @@ to post it is the consuming track's job.
   `idd-claimed-no-verified-linked-issue-claim` branch just above, so this
   flag changes nothing there). When `true`, a PR whose author resolves to
   a GitHub Bot-typed account (fetched via a small dedicated GraphQL
-  `__typename` query) AND has no claim-marker history at all is
-  classified `applicability: { status: "not_applicable", reason:
-  "bot-authored-no-claim-history" }`, letting a recurring automated
-  dependency-update PR (Dependabot, Renovate, ImgBot, or similar) pass
+  `__typename` query) AND has no claim-marker history at all resolves
+  to `not_applicable` (reason `bot-authored-no-claim-history`), letting
+  a recurring automated dependency-update PR (Dependabot, Renovate,
+  ImgBot, or similar) pass
   the gate without a fresh per-PR maintainer waiver. A Bot-typed author
   that DOES have claim-marker history, or any human-authored PR, is
   never exempted regardless of this flag. The `scope-not-applicable`

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1766,6 +1766,22 @@ to post it is the consuming track's job.
     genuinely waivable). See
     `computeAdvisoryConvergenceVerdict`'s `AdvisoryConvergenceApplicability`
     doc comment (advisory-convergence.mts) for the full contract.
+- `advisoryWait.exemptBotAuthoredPrs` (#1906): opt-in, off by default,
+  and effective only under `convergenceScope: "all-prs"` (`idd-claimed`
+  already resolves the same PR shape `not_applicable` via the
+  `idd-claimed-no-verified-linked-issue-claim` branch just above, so this
+  flag changes nothing there). When `true`, a PR whose author resolves to
+  a GitHub Bot-typed account (fetched via a small dedicated GraphQL
+  `__typename` query) AND has no claim-marker history at all is
+  classified `applicability: { status: "not_applicable", reason:
+  "bot-authored-no-claim-history" }`, letting a recurring automated
+  dependency-update PR (Dependabot, Renovate, ImgBot, or similar) pass
+  the gate without a fresh per-PR maintainer waiver. A Bot-typed author
+  that DOES have claim-marker history, or any human-authored PR, is
+  never exempted regardless of this flag. The `scope-not-applicable`
+  same-HEAD-reroll token below already covers this new `not_applicable`
+  cause too, since its underlying check reads `applicability.status`
+  generically, not `convergenceScope` specifically.
 
 #### Bounded same-HEAD advisory reroll (AW6, #1511)
 
@@ -1806,7 +1822,7 @@ structurally unable to disagree.
 <!-- dprint-ignore-start -->
 | Token                                    | Fires when...                                                                                                                                          |
 | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `scope-not-applicable`                    | `applicability.status` is `not_applicable` OR `indeterminate` (#1686) -- `advisoryWait.convergenceScope: "idd-claimed"` and this PR either has no verified linked claim/branch, or has a broken/ambiguous claim linkage. Offering a same-HEAD reroll is pointless in either case. |
+| `scope-not-applicable`                    | `applicability.status` is `not_applicable` OR `indeterminate` (#1686) -- either `advisoryWait.convergenceScope: "idd-claimed"` and this PR has no verified linked claim/branch or has a broken/ambiguous claim linkage, or (#1906) `advisoryWait.exemptBotAuthoredPrs: true` under `"all-prs"` scope exempted a Bot-authored PR with no claim history. Offering a same-HEAD reroll is pointless in any of these cases. |
 | `review-pending`                          | The primary bot has not yet reviewed current HEAD (`pending: true`). Always co-occurs with `review-item-count-unknown` below, since an off-HEAD review reports no usable item count. |
 | `unresolved-copilot-threads`              | `threads.satisfied` is `false` -- at least one Copilot-authored thread is neither resolved nor validly dispositioned.                                   |
 | `missing-regular-comment-disposition`     | `dispositionEvidence.missingRegularCommentCount` is non-zero -- an outstanding regular (non-thread) PR comment still lacks a fresh disposition marker.  |

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -181,11 +181,11 @@ The current policy schema and helper runtime now support
 `advisoryWait.pollInterval`, `advisoryWait.capExhaustedRoute`,
 `advisoryWait.primaryBotLogin`, `advisoryWait.secondaryBotLogin`,
 `advisoryWait.convergenceDeadline`, `advisoryWait.sameHeadRerollCap`,
-`advisoryWait.recoveryCycleCap`, `advisoryWait.terminalWindow`, and
-`advisoryWait.convergenceScope`. Omitted keys keep the distributed defaults
-below. The duration keys (`pendingWindow`, `settledWindow`, `pollInterval`,
-`convergenceDeadline`, `terminalWindow`) accept positive whole-minute
-ISO 8601 durations only.
+`advisoryWait.recoveryCycleCap`, `advisoryWait.terminalWindow`,
+`advisoryWait.convergenceScope`, and `advisoryWait.exemptBotAuthoredPrs`.
+Omitted keys keep the distributed defaults below. The duration keys
+(`pendingWindow`, `settledWindow`, `pollInterval`, `convergenceDeadline`,
+`terminalWindow`) accept positive whole-minute ISO 8601 durations only.
 `advisoryWait.recoveryCycleCap` / `advisoryWait.terminalWindow` (#1572)
 define the terminal Copilot stall-recovery **state contract**, accounted
 independently of `requestCap` and `sameHeadRerollCap`: see
@@ -219,6 +219,16 @@ it equal to the primary) keeps behavior identical to the primary-only path.
 Configure it to a **requestable reviewer** whose `--add-reviewer` request
 appears on the PR timeline (like the primary); a bot that reviews via app
 install without a requestable-reviewer event cannot be tracked once per HEAD.
+`advisoryWait.exemptBotAuthoredPrs` (#1906) is an opt-in, off-by-default
+flag effective only under `advisoryWait.convergenceScope: "all-prs"`. When
+`true`, a PR whose author resolves to a GitHub Bot-typed account AND has no
+claim-marker history at all becomes `not_applicable` (reason
+`bot-authored-no-claim-history`), so a repository with frequent automated
+dependency-update PRs does not need a fresh per-PR maintainer waiver for
+each one. It has no effect under `idd-claimed` scope, where that same PR
+shape already resolves `not_applicable` via the existing
+`idd-claimed-no-verified-linked-issue-claim` branch; see
+[Helper scripts](idd-helper-scripts.md) for the full contract.
 
 | Policy default                                   | Distributed value                                                                                                                                                                                                                                                                                                                                            | Owning surface                                                                                                                                                                                                       | Onboarding expectation                                                                                                                                          |
 | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -236,6 +246,7 @@ install without a requestable-reviewer event cannot be tracked once per HEAD.
 | Copilot stall-recovery cycle cap                 | 2 recovery cycles per PR HEAD (`advisoryWait.recoveryCycleCap`)                                                                                                                                                                                                                                                                                              | [Advisory wait](../.github/instructions/idd-advisory-wait.instructions.md)                                                                                                                                           | Keep unless the repository needs a different bounded terminal-recovery budget; kept separate from `requestCap` and `sameHeadRerollCap` by design.               |
 | Copilot terminal-unavailability window           | 12 h (`advisoryWait.terminalWindow`)                                                                                                                                                                                                                                                                                                                         | [Advisory wait](../.github/instructions/idd-advisory-wait.instructions.md)                                                                                                                                           | Keep unless the repository needs a different window before `COPILOT_UNAVAILABLE` waiver eligibility applies.                                                    |
 | Advisory-convergence enforcement scope           | `all-prs` (`advisoryWait.convergenceScope`)                                                                                                                                                                                                                                                                                                                  | [Pre-merge](../.github/instructions/idd-pre-merge.instructions.md), [Helper scripts](idd-helper-scripts.md), [Customizing IDD](customization.md#policy-constants)                                                    | Keep `all-prs` for existing behavior; switch to `idd-claimed` only when the repository wants convergence to apply solely to verified IDD-owned PRs.             |
+| Bot-authored-PR exemption                        | `false` (`advisoryWait.exemptBotAuthoredPrs`)                                                                                                                                                                                                                                                                                                                | [Helper scripts](idd-helper-scripts.md), [Customizing IDD](customization.md#policy-constants)                                                                                                                        | Keep `false` unless the repository wants recurring Bot-authored, claimless PRs under `all-prs` scope to skip the maintainer-waiver path automatically.          |
 | Advisory-convergence required-check registration | Not registered by default (hosting the `idd-advisory-convergence` workflow is itself an opt-in step — see [ONBOARDING](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#optional--host-idd-advisory-convergence-as-a-required-check-ci-workflow); once hosted, a required-status-check Ruleset entry is a separate manual step) | [Customizing IDD](customization.md#policy-constants), [Helper scripts](idd-helper-scripts.md)                                                                                                                        | Register `idd-advisory-convergence` as a required status check to make convergence non-bypassable; this is a maintainer GitHub-settings action, not agent work. |
 
 `idd-claimed` keeps genuinely claimless/manual dependency PRs out of the

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -290,6 +290,10 @@
           "enum": ["all-prs", "idd-claimed"],
           "description": "Controls whether advisory convergence applies to every PR or only verified IDD-owned PRs. Default: all-prs. Invalid values are rejected by schema."
         },
+        "exemptBotAuthoredPrs": {
+          "type": "boolean",
+          "description": "Opt-in, off by default. When true AND convergenceScope is all-prs, a PR whose author resolves to a GitHub Bot-typed account (via GraphQL __typename) AND has no claim-marker history at all is classified applicability: not_applicable (reason bot-authored-no-claim-history), letting the check pass without a per-PR maintainer waiver. Has no effect under convergenceScope: idd-claimed, where that same PR shape already resolves not_applicable via the existing idd-claimed-no-verified-linked-issue-claim branch. A Bot-typed author that DOES have claim-marker history, or any human-authored PR, is never exempted regardless of this flag. Default: false."
+        },
         "requestCap": {
           "type": "integer",
           "minimum": 1,

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -206,6 +206,12 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   }
   const claimMarkerHistoryPresent = inputs.claimMarkerHistoryPresent;
   const claimCandidateAmbiguous = inputs.claimCandidateAmbiguous;
+  // #1906: read as `=== true` on both sides -- see each field's own doc
+  // comment (`AdvisoryConvergenceInputs.prAuthorIsBot`,
+  // `AdvisoryConvergenceOptions.exemptBotAuthoredPrs`) for why neither is
+  // required-with-throw like the two claim-evidence booleans above.
+  const exemptBotAuthoredPrs = options.exemptBotAuthoredPrs === true;
+  const prAuthorIsBot = inputs.prAuthorIsBot === true;
   const applicability =
     convergenceScope === 'idd-claimed'
       ? !claim.activeClaimPresent
@@ -249,11 +255,21 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
                   status: 'applicable',
                   reason: 'idd-claimed-branch-matched',
                 }
-      : {
-          scope: convergenceScope,
-          status: 'applicable',
-          reason: 'all-prs',
-        };
+      : // #1906: opt-in bot-authored-PR exemption, `all-prs` scope only --
+        // `idd-claimed` already resolves this exact PR shape to
+        // `not_applicable` via its own `idd-claimed-no-verified-linked-
+        // issue-claim` branch above, untouched by this addition.
+        exemptBotAuthoredPrs && prAuthorIsBot && !claimMarkerHistoryPresent
+        ? {
+            scope: convergenceScope,
+            status: 'not_applicable',
+            reason: 'bot-authored-no-claim-history',
+          }
+        : {
+            scope: convergenceScope,
+            status: 'applicable',
+            reason: 'all-prs',
+          };
   // `scopeNotApplicable` keeps its pre-#1686 meaning EXACTLY -- `status ===
   // 'not_applicable'` only -- since it still gates the waiver-evidence
   // bookkeeping (`waived` below) and the unconditional `ready` pass for a
@@ -1089,6 +1105,23 @@ function collectFromGitHub(args) {
   }
   const staleAgeMs =
     parseIsoDurationToMs(policy.claimTiming.staleAge) ?? DEFAULT_STALE_AGE_MS;
+  // #1906: opt-in, off by default. Only fetch the PR's own author
+  // `__typename` when the policy flag is actually enabled -- a
+  // repository that never opts in pays for zero extra GraphQL round
+  // trips. Fails closed to `false` ("not a Bot-typed author", today's
+  // `applicable`/`all-prs` outcome) on any fetch error, matching
+  // `prFirstCommitAt` above: a transient GraphQL failure must never
+  // widen what this gate accepts.
+  const exemptBotAuthoredPrs = policy.advisoryWait.exemptBotAuthoredPrs;
+  let prAuthorIsBot = false;
+  if (exemptBotAuthoredPrs) {
+    try {
+      prAuthorIsBot =
+        fetchPrAuthor(owner, repo, Number(args.prNumber))?.__typename === 'Bot';
+    } catch {
+      prAuthorIsBot = false;
+    }
+  }
   return {
     inputs: {
       prNumber: Number(args.prNumber),
@@ -1099,6 +1132,7 @@ function collectFromGitHub(args) {
       claimEvents,
       claimMarkerHistoryPresent,
       claimCandidateAmbiguous,
+      prAuthorIsBot,
     },
     options: {
       now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
@@ -1109,6 +1143,7 @@ function collectFromGitHub(args) {
         policy?.advisoryWait?.convergenceScope === 'idd-claimed'
           ? 'idd-claimed'
           : 'all-prs',
+      exemptBotAuthoredPrs,
       prHeadRefName,
       prAuthorLogin,
       headCommittedAt,
@@ -1417,6 +1452,32 @@ function resolveTrustedCollaboratorMarkerLogins(
 // unchanged. The other two `ghGraphql(...)` call sites in this file
 // (`fetchReviewThreads` and the claim-candidate fetch below) keep calling
 // the same function via the new import.
+/** #1906: fetch the PR's own author `login`/`__typename` via a small
+ * dedicated GraphQL query -- the REST-shaped `gh pr view --json author`
+ * fetch in `collectFromGitHub` only returns `login`, no type
+ * discriminator. Deliberately its own minimal round trip rather than
+ * folded into `fetchReviewThreads` below or `fetchReviewsAndHeadCommit`
+ * (review-clause.mts): both of those are narrowly-scoped Copilot-review
+ * evidence collectors, the latter shared verbatim with
+ * `rerun-advisory-convergence.mts`, and widening either with an unrelated
+ * PR-author field would blur that scope for no shared benefit. Called by
+ * `collectFromGitHub` only when the opt-in `exemptBotAuthoredPrs` policy
+ * is enabled (see the call site), so a repository that never sets the
+ * flag never pays for this extra request. */
+function fetchPrAuthor(owner, repo, prNumber) {
+  const payload = ghGraphql(
+    `
+      query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            author { login __typename }
+          }
+        }
+      }`,
+    { owner, repo, number: prNumber },
+  );
+  return payload?.data?.repository?.pullRequest?.author ?? null;
+}
 function fetchReviewThreads(owner, repo, prNumber) {
   const nodes = [];
   let cursor = null;

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -1105,16 +1105,25 @@ function collectFromGitHub(args) {
   }
   const staleAgeMs =
     parseIsoDurationToMs(policy.claimTiming.staleAge) ?? DEFAULT_STALE_AGE_MS;
-  // #1906: opt-in, off by default. Only fetch the PR's own author
-  // `__typename` when the policy flag is actually enabled -- a
-  // repository that never opts in pays for zero extra GraphQL round
-  // trips. Fails closed to `false` ("not a Bot-typed author", today's
+  const convergenceScope =
+    policy?.advisoryWait?.convergenceScope === 'idd-claimed'
+      ? 'idd-claimed'
+      : 'all-prs';
+  // #1906: opt-in, off by default, and only ever consulted under
+  // `all-prs` scope (`idd-claimed` never reaches the new applicability
+  // branch -- see `computeAdvisoryConvergenceVerdict`). Fetch the PR's
+  // own author `__typename` only when BOTH the flag is enabled AND
+  // scope is `all-prs`, so a repository that enables the flag under
+  // `idd-claimed` (where it can never apply) still pays for zero extra
+  // GraphQL round trips, matching the "no behavior/cost change unless
+  // genuinely applicable" goal the plain opt-in-off case already gets.
+  // Fails closed to `false` ("not a Bot-typed author", today's
   // `applicable`/`all-prs` outcome) on any fetch error, matching
   // `prFirstCommitAt` above: a transient GraphQL failure must never
   // widen what this gate accepts.
   const exemptBotAuthoredPrs = policy.advisoryWait.exemptBotAuthoredPrs;
   let prAuthorIsBot = false;
-  if (exemptBotAuthoredPrs) {
+  if (exemptBotAuthoredPrs && convergenceScope === 'all-prs') {
     try {
       prAuthorIsBot =
         fetchPrAuthor(owner, repo, Number(args.prNumber))?.__typename === 'Bot';
@@ -1139,10 +1148,7 @@ function collectFromGitHub(args) {
       primaryBotLogin,
       trustedMarkerLogins,
       advisoryBotLogins,
-      convergenceScope:
-        policy?.advisoryWait?.convergenceScope === 'idd-claimed'
-          ? 'idd-claimed'
-          : 'all-prs',
+      convergenceScope,
       exemptBotAuthoredPrs,
       prHeadRefName,
       prAuthorLogin,

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -100,6 +100,9 @@ export const POLICY_DEFAULTS = Object.freeze({
     pollInterval: 'PT2M',
     capExhaustedRoute: 'phase-specific',
     convergenceScope: 'all-prs',
+    // #1906: opt-in, off by default -- no behavior change for a
+    // repository that does not explicitly set this to `true`.
+    exemptBotAuthoredPrs: false,
   }),
   ciWait: Object.freeze({
     runningTimeout: 'PT30M',
@@ -332,6 +335,11 @@ export function normalizePolicyConfig(config) {
         ADVISORY_CONVERGENCE_SCOPES,
         POLICY_DEFAULTS.advisoryWait.convergenceScope,
       ),
+      // #1906: same simple-boolean coercion style as
+      // `skipIssueAuthorApprovalGate` above -- only a literal `true`
+      // opts in, everything else (including a malformed value) keeps
+      // the conservative `false` default.
+      exemptBotAuthoredPrs: c?.advisoryWait?.exemptBotAuthoredPrs === true,
     },
     ciWait: {
       runningTimeout: parseDuration(

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -443,6 +443,18 @@ export interface AdvisoryConvergenceInputs {
    * `Error` instead of silently coercing to `false`
    * (kurone-kito/idd-skill#1821). */
   claimCandidateAmbiguous: boolean;
+  /** #1906: `true` when the PR's own author resolves to a GitHub
+   * Bot-typed account (`__typename === 'Bot'`), fetched via a small
+   * dedicated GraphQL query in `collectFromGitHub` (the REST-shaped `gh
+   * pr view --json author` fetch there carries only `login`, no type
+   * discriminator). Optional and read as `=== true` (unlike
+   * `claimMarkerHistoryPresent`/`claimCandidateAmbiguous` above,
+   * deliberately NOT required-with-throw): a missing, `undefined`, or
+   * non-boolean value already fails closed to `false` -- "not a
+   * Bot-typed author" -- which keeps today's `applicable`/`all-prs`
+   * outcome, the same safe direction this field's own consumer
+   * (`options.exemptBotAuthoredPrs`) already defaults to when unset. */
+  prAuthorIsBot?: boolean;
 }
 
 /** Pure options accepted by {@link computeAdvisoryConvergenceVerdict}. */
@@ -452,6 +464,16 @@ export interface AdvisoryConvergenceOptions {
   trustedMarkerLogins?: unknown[] | null;
   advisoryBotLogins?: unknown[] | null;
   convergenceScope?: 'all-prs' | 'idd-claimed';
+  /** #1906: `advisoryWait.exemptBotAuthoredPrs` -- opt-in, off by
+   * default. When `true`, `convergenceScope` is `'all-prs'`, the PR
+   * author is Bot-typed (`inputs.prAuthorIsBot`), and
+   * `claimMarkerHistoryPresent` is `false`, the applicability
+   * computation below classifies the PR `not_applicable` (reason
+   * `bot-authored-no-claim-history`) instead of the ordinary
+   * `applicable`/`all-prs`. Read as `=== true`; every other case
+   * (flag unset, `idd-claimed` scope, non-Bot author, or claim history
+   * present) leaves today's behavior completely unchanged. */
+  exemptBotAuthoredPrs?: boolean;
   prHeadRefName?: string | null;
   /** The PR author's login, excluded from "external feedback" the same way
    * `summarizeDispositionEvidenceForGate` excludes it elsewhere. */
@@ -602,6 +624,12 @@ export function computeAdvisoryConvergenceVerdict(
   }
   const claimMarkerHistoryPresent = inputs.claimMarkerHistoryPresent;
   const claimCandidateAmbiguous = inputs.claimCandidateAmbiguous;
+  // #1906: read as `=== true` on both sides -- see each field's own doc
+  // comment (`AdvisoryConvergenceInputs.prAuthorIsBot`,
+  // `AdvisoryConvergenceOptions.exemptBotAuthoredPrs`) for why neither is
+  // required-with-throw like the two claim-evidence booleans above.
+  const exemptBotAuthoredPrs = options.exemptBotAuthoredPrs === true;
+  const prAuthorIsBot = inputs.prAuthorIsBot === true;
   const applicability: AdvisoryConvergenceApplicability =
     convergenceScope === 'idd-claimed'
       ? !claim.activeClaimPresent
@@ -645,11 +673,21 @@ export function computeAdvisoryConvergenceVerdict(
                   status: 'applicable',
                   reason: 'idd-claimed-branch-matched',
                 }
-      : {
-          scope: convergenceScope,
-          status: 'applicable',
-          reason: 'all-prs',
-        };
+      : // #1906: opt-in bot-authored-PR exemption, `all-prs` scope only --
+        // `idd-claimed` already resolves this exact PR shape to
+        // `not_applicable` via its own `idd-claimed-no-verified-linked-
+        // issue-claim` branch above, untouched by this addition.
+        exemptBotAuthoredPrs && prAuthorIsBot && !claimMarkerHistoryPresent
+        ? {
+            scope: convergenceScope,
+            status: 'not_applicable',
+            reason: 'bot-authored-no-claim-history',
+          }
+        : {
+            scope: convergenceScope,
+            status: 'applicable',
+            reason: 'all-prs',
+          };
   // `scopeNotApplicable` keeps its pre-#1686 meaning EXACTLY -- `status ===
   // 'not_applicable'` only -- since it still gates the waiver-evidence
   // bookkeeping (`waived` below) and the unconditional `ready` pass for a
@@ -1565,6 +1603,24 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
   const staleAgeMs =
     parseIsoDurationToMs(policy.claimTiming.staleAge) ?? DEFAULT_STALE_AGE_MS;
 
+  // #1906: opt-in, off by default. Only fetch the PR's own author
+  // `__typename` when the policy flag is actually enabled -- a
+  // repository that never opts in pays for zero extra GraphQL round
+  // trips. Fails closed to `false` ("not a Bot-typed author", today's
+  // `applicable`/`all-prs` outcome) on any fetch error, matching
+  // `prFirstCommitAt` above: a transient GraphQL failure must never
+  // widen what this gate accepts.
+  const exemptBotAuthoredPrs = policy.advisoryWait.exemptBotAuthoredPrs;
+  let prAuthorIsBot = false;
+  if (exemptBotAuthoredPrs) {
+    try {
+      prAuthorIsBot =
+        fetchPrAuthor(owner, repo, Number(args.prNumber))?.__typename === 'Bot';
+    } catch {
+      prAuthorIsBot = false;
+    }
+  }
+
   return {
     inputs: {
       prNumber: Number(args.prNumber),
@@ -1575,6 +1631,7 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
       claimEvents,
       claimMarkerHistoryPresent,
       claimCandidateAmbiguous,
+      prAuthorIsBot,
     },
     options: {
       now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
@@ -1585,6 +1642,7 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
         policy?.advisoryWait?.convergenceScope === 'idd-claimed'
           ? 'idd-claimed'
           : 'all-prs',
+      exemptBotAuthoredPrs,
       prHeadRefName,
       prAuthorLogin,
       headCommittedAt,
@@ -1925,6 +1983,43 @@ function resolveTrustedCollaboratorMarkerLogins(
 // unchanged. The other two `ghGraphql(...)` call sites in this file
 // (`fetchReviewThreads` and the claim-candidate fetch below) keep calling
 // the same function via the new import.
+
+/** #1906: fetch the PR's own author `login`/`__typename` via a small
+ * dedicated GraphQL query -- the REST-shaped `gh pr view --json author`
+ * fetch in `collectFromGitHub` only returns `login`, no type
+ * discriminator. Deliberately its own minimal round trip rather than
+ * folded into `fetchReviewThreads` below or `fetchReviewsAndHeadCommit`
+ * (review-clause.mts): both of those are narrowly-scoped Copilot-review
+ * evidence collectors, the latter shared verbatim with
+ * `rerun-advisory-convergence.mts`, and widening either with an unrelated
+ * PR-author field would blur that scope for no shared benefit. Called by
+ * `collectFromGitHub` only when the opt-in `exemptBotAuthoredPrs` policy
+ * is enabled (see the call site), so a repository that never sets the
+ * flag never pays for this extra request. */
+function fetchPrAuthor(
+  owner: string,
+  repo: string,
+  prNumber: number,
+): GhAuthorPayload | null {
+  const payload = ghGraphql(
+    `
+      query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            author { login __typename }
+          }
+        }
+      }`,
+    { owner, repo, number: prNumber },
+  ) as {
+    data?: {
+      repository?: {
+        pullRequest?: { author?: GhAuthorPayload | null } | null;
+      } | null;
+    } | null;
+  };
+  return payload?.data?.repository?.pullRequest?.author ?? null;
+}
 
 function fetchReviewThreads(
   owner: string,

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -1603,16 +1603,26 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
   const staleAgeMs =
     parseIsoDurationToMs(policy.claimTiming.staleAge) ?? DEFAULT_STALE_AGE_MS;
 
-  // #1906: opt-in, off by default. Only fetch the PR's own author
-  // `__typename` when the policy flag is actually enabled -- a
-  // repository that never opts in pays for zero extra GraphQL round
-  // trips. Fails closed to `false` ("not a Bot-typed author", today's
+  const convergenceScope =
+    policy?.advisoryWait?.convergenceScope === 'idd-claimed'
+      ? 'idd-claimed'
+      : 'all-prs';
+
+  // #1906: opt-in, off by default, and only ever consulted under
+  // `all-prs` scope (`idd-claimed` never reaches the new applicability
+  // branch -- see `computeAdvisoryConvergenceVerdict`). Fetch the PR's
+  // own author `__typename` only when BOTH the flag is enabled AND
+  // scope is `all-prs`, so a repository that enables the flag under
+  // `idd-claimed` (where it can never apply) still pays for zero extra
+  // GraphQL round trips, matching the "no behavior/cost change unless
+  // genuinely applicable" goal the plain opt-in-off case already gets.
+  // Fails closed to `false` ("not a Bot-typed author", today's
   // `applicable`/`all-prs` outcome) on any fetch error, matching
   // `prFirstCommitAt` above: a transient GraphQL failure must never
   // widen what this gate accepts.
   const exemptBotAuthoredPrs = policy.advisoryWait.exemptBotAuthoredPrs;
   let prAuthorIsBot = false;
-  if (exemptBotAuthoredPrs) {
+  if (exemptBotAuthoredPrs && convergenceScope === 'all-prs') {
     try {
       prAuthorIsBot =
         fetchPrAuthor(owner, repo, Number(args.prNumber))?.__typename === 'Bot';
@@ -1638,10 +1648,7 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
       primaryBotLogin,
       trustedMarkerLogins,
       advisoryBotLogins,
-      convergenceScope:
-        policy?.advisoryWait?.convergenceScope === 'idd-claimed'
-          ? 'idd-claimed'
-          : 'all-prs',
+      convergenceScope,
       exemptBotAuthoredPrs,
       prHeadRefName,
       prAuthorLogin,

--- a/src/scripts/policy-helpers.mts
+++ b/src/scripts/policy-helpers.mts
@@ -42,6 +42,7 @@ interface RawConfig {
     pollInterval?: unknown;
     capExhaustedRoute?: unknown;
     convergenceScope?: unknown;
+    exemptBotAuthoredPrs?: unknown;
   };
   ciWait?: {
     runningTimeout?: unknown;
@@ -184,6 +185,9 @@ export const POLICY_DEFAULTS = Object.freeze({
     pollInterval: 'PT2M',
     capExhaustedRoute: 'phase-specific',
     convergenceScope: 'all-prs',
+    // #1906: opt-in, off by default -- no behavior change for a
+    // repository that does not explicitly set this to `true`.
+    exemptBotAuthoredPrs: false,
   }),
   ciWait: Object.freeze({
     runningTimeout: 'PT30M',
@@ -435,6 +439,11 @@ export function normalizePolicyConfig(config: unknown) {
         ADVISORY_CONVERGENCE_SCOPES,
         POLICY_DEFAULTS.advisoryWait.convergenceScope,
       ),
+      // #1906: same simple-boolean coercion style as
+      // `skipIssueAuthorApprovalGate` above -- only a literal `true`
+      // opts in, everything else (including a malformed value) keeps
+      // the conservative `false` default.
+      exemptBotAuthoredPrs: c?.advisoryWait?.exemptBotAuthoredPrs === true,
     },
     ciWait: {
       runningTimeout: parseDuration(

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -415,6 +415,105 @@ test('idd-claimed scope: a PR without a verified linked claim is not applicable'
   assert.deepEqual(verdict.reasons, []);
 });
 
+// --- exemptBotAuthoredPrs (#1906) -------------------------------------------
+
+test('exemptBotAuthoredPrs: all-prs scope, flag on, Bot-typed author, no claim history -> not_applicable', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview({ itemCount: 2 })],
+      claimEvents: [],
+      prAuthorIsBot: true,
+    }),
+    baseOptions({ exemptBotAuthoredPrs: true }),
+  );
+  assertValidVerdict(verdict);
+  assert.deepEqual(verdict.applicability, {
+    scope: 'all-prs',
+    status: 'not_applicable',
+    reason: 'bot-authored-no-claim-history',
+  });
+  assert.equal(verdict.pending, false);
+  assert.equal(verdict.ready, true);
+  assert.deepEqual(verdict.reasons, []);
+  // Bonus: the existing `scopeNotApplicable`-gated `ineligibleReasons`
+  // computation is scope-generic (reads `applicability.status`, not
+  // `convergenceScope`), so it already covers this new `all-prs` cause
+  // with no code change of its own -- confirm that holds.
+  assert.deepEqual(verdict.sameHeadReroll.ineligibleReasons, [
+    SAME_HEAD_REROLL_INELIGIBLE_REASON.SCOPE_NOT_APPLICABLE,
+  ]);
+});
+
+test('exemptBotAuthoredPrs: all-prs scope, flag on, Bot-typed author WITH claim history -> unchanged applicable/all-prs', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview()],
+      claimEvents: [],
+      claimMarkerHistoryPresent: true,
+      prAuthorIsBot: true,
+    }),
+    baseOptions({ exemptBotAuthoredPrs: true }),
+  );
+  assertValidVerdict(verdict);
+  assert.deepEqual(verdict.applicability, {
+    scope: 'all-prs',
+    status: 'applicable',
+    reason: 'all-prs',
+  });
+});
+
+test('exemptBotAuthoredPrs: all-prs scope, flag on, human-authored PR -> unchanged applicable/all-prs', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [copilotReview()], claimEvents: [] }),
+    baseOptions({ exemptBotAuthoredPrs: true }),
+  );
+  assertValidVerdict(verdict);
+  assert.deepEqual(verdict.applicability, {
+    scope: 'all-prs',
+    status: 'applicable',
+    reason: 'all-prs',
+  });
+});
+
+test('exemptBotAuthoredPrs: idd-claimed scope never changes output, even for a Bot author with no claim history (#1906 AC)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [], claimEvents: [], prAuthorIsBot: true }),
+    baseOptions({
+      convergenceScope: 'idd-claimed',
+      prHeadRefName: 'feature/no-claim',
+      exemptBotAuthoredPrs: true,
+    }),
+  );
+  assertValidVerdict(verdict);
+  // Same token as the pre-existing idd-claimed test above -- NOT the new
+  // `bot-authored-no-claim-history` reason. This is the one a careless
+  // implementation (hoisting the bot check above the scope ternary)
+  // would silently break.
+  assert.deepEqual(verdict.applicability, {
+    scope: 'idd-claimed',
+    status: 'not_applicable',
+    reason: 'idd-claimed-no-verified-linked-issue-claim',
+  });
+  assert.equal(verdict.ready, true);
+});
+
+test('exemptBotAuthoredPrs: flag unset (default false) -> unchanged applicable/all-prs even for a Bot author with no claim history', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview()],
+      claimEvents: [],
+      prAuthorIsBot: true,
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.deepEqual(verdict.applicability, {
+    scope: 'all-prs',
+    status: 'applicable',
+    reason: 'all-prs',
+  });
+});
+
 test('regression: a re-request without a new push supersedes an earlier dirty on-HEAD review', () => {
   // Same commit reviewed twice (a legitimate re-request per this repo's own
   // advisory-wait protocol, AW3 REQUEST_NEEDED, without a new push): the

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -2793,6 +2793,19 @@ test('collectFromGitHub sources claimEvents/claimCandidateAmbiguous/claimMarkerH
   );
 });
 
+test('collectFromGitHub sources prAuthorIsBot/exemptBotAuthoredPrs into the returned inputs/options (#1906: pins the call-site forwarding shape)', () => {
+  // Same "pin the call site" spirit as the #1810 test above: the computed
+  // `prAuthorIsBot` and `exemptBotAuthoredPrs` values are only useful if
+  // they actually reach the returned `inputs`/`options` objects a future
+  // refactor could otherwise silently drop, with no other test coverage.
+  const source = readFileSync(
+    new URL('../src/scripts/advisory-convergence.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(source, /inputs:\s*\{[^}]*\bprAuthorIsBot,[^}]*\}/s);
+  assert.match(source, /options:\s*\{[^}]*\bexemptBotAuthoredPrs,[^}]*\}/s);
+});
+
 // --- parseArgs ---------------------------------------------------------------
 
 test('parseArgs: parses --pr, --assert, and --claim-issue', () => {

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -774,6 +774,7 @@ test('policy normalization provides default-safe values and supports aliases', (
       settledWindow: 'PT10M',
       pollInterval: 'PT2M',
       capExhaustedRoute: 'phase-specific',
+      exemptBotAuthoredPrs: false,
     },
     ciWait: {
       runningTimeout: 'PT30M',
@@ -864,6 +865,7 @@ test('policy normalization provides default-safe values and supports aliases', (
         settledWindow: 'PT11M',
         pollInterval: 'PT3M',
         capExhaustedRoute: 'hold',
+        exemptBotAuthoredPrs: true,
       },
       ciWait: {
         runningTimeout: 'PT35M',
@@ -942,6 +944,7 @@ test('policy normalization provides default-safe values and supports aliases', (
         settledWindow: 'PT11M',
         pollInterval: 'PT3M',
         capExhaustedRoute: 'hold',
+        exemptBotAuthoredPrs: true,
       },
       ciWait: {
         runningTimeout: 'PT35M',
@@ -1042,6 +1045,7 @@ test('policy normalization provides default-safe values and supports aliases', (
       settledWindow: 'PT10M',
       pollInterval: 'PT2M',
       capExhaustedRoute: 'phase-specific',
+      exemptBotAuthoredPrs: false,
     },
   );
 

--- a/tests/policy-helpers.test.mts
+++ b/tests/policy-helpers.test.mts
@@ -51,6 +51,26 @@ test('advisoryWait.convergenceScope defaults to all-prs and accepts idd-claimed'
   );
 });
 
+test('advisoryWait.exemptBotAuthoredPrs defaults to false and only a literal true opts in (#1906)', () => {
+  assert.equal(POLICY_DEFAULTS.advisoryWait.exemptBotAuthoredPrs, false);
+  assert.equal(
+    normalizePolicyConfig({}).advisoryWait.exemptBotAuthoredPrs,
+    false,
+  );
+  assert.equal(
+    normalizePolicyConfig({
+      advisoryWait: { exemptBotAuthoredPrs: true },
+    }).advisoryWait.exemptBotAuthoredPrs,
+    true,
+  );
+  assert.equal(
+    normalizePolicyConfig({
+      advisoryWait: { exemptBotAuthoredPrs: 'true' },
+    }).advisoryWait.exemptBotAuthoredPrs,
+    false,
+  );
+});
+
 test('POLICY_DEFAULTS.labels exposes the three reserved label name defaults', () => {
   // Additive only (#1272): POLICY_DEFAULTS carries the literal defaults,
   // and normalizePolicyConfig normalizes this namespace too (for shape


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Adds an opt-in `advisoryWait.exemptBotAuthoredPrs` policy field
(default `false`) to `advisory-convergence.mjs`. When `true` and
`convergenceScope === 'all-prs'`, a PR whose author resolves to a
GitHub Bot-typed account (new GraphQL `__typename` plumbing) AND has
no claim marker history is classified `applicability: { status:
'not_applicable', reason: 'bot-authored-no-claim-history' }`, letting
the check pass without a per-PR maintainer waiver. `idd-claimed` scope
stays byte-identical -- it already resolves the same PR shape via its
existing `idd-claimed-no-verified-linked-issue-claim` branch, so this
change leaves every `idd-claimed` branch untouched.

- New standalone `fetchPrAuthor` GraphQL query in
  `advisory-convergence.mts`, called only when the flag is enabled
  (skips the extra round trip for the common unopted-in case) and
  wrapped fail-closed so a transient fetch error degrades to "not
  exempted" instead of crashing the check.
- `AdvisoryConvergenceInputs.prAuthorIsBot` and
  `AdvisoryConvergenceOptions.exemptBotAuthoredPrs` are both optional
  (read as `=== true`), unlike the existing required-with-throw
  `claimMarkerHistoryPresent`/`claimCandidateAmbiguous` fields --
  documented in each field's own doc comment why the asymmetry is
  intentional (a missing/invalid value here already fails closed to
  the safe "not exempted" outcome).
- `policy-helpers.mts` / `schemas/policy.schema.json` normalize and
  document the new field alongside `convergenceScope`.
- New tests cover every acceptance-criteria scenario below, plus a
  source-text "pin" test (mirroring the existing #1810 pattern) that
  guards `collectFromGitHub`'s `prAuthorIsBot`/`exemptBotAuthoredPrs`
  forwarding -- mutation-verified to fail when either field is dropped
  from the returned `inputs`/`options` objects.

## Linked issue

Closes #1906

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

This narrow, opt-in exemption is the automated complement to the
claimless `idd-external-check-waiver` marker work landed for
recurring bot-authored dependency-update PRs whose primary-bot review
never lands, so a repository does not need one manual maintainer
action per stuck PR/HEAD.

Two deliberate deviations from the issue text, disclosed here:

- **Doc-edit direction.** The issue says to update the instructions/
  docs files "(+ `idd-template/` mirrors)". Per
  `audit/sync-manifest.json`, that direction is backwards for this
  repo: `idd-template/docs/*.md` and
  `idd-template/.github/instructions/idd-advisory-wait.instructions.md`
  are the sync **source**; `docs/*.md` and
  `.github/instructions/idd-advisory-wait.instructions.md` are the
  generated **target**. This PR edits the `idd-template/` sources and
  regenerates the targets via `node scripts/sync-docs.mjs --apply`.
- **`idd-advisory-wait.instructions.md` cross-reference kept minimal.**
  `bundle-review`'s `context-ceiling-128k` budget
  (`node scripts/audit-docs.mjs --check`) had essentially no headroom
  left (97.95% before this change, 98% is a hard failure). A full
  explanatory paragraph tripped the gate; the field is instead
  documented in full in `docs/idd-helper-scripts.md` (applicability
  table), `docs/policy-constants.md` (defaults table + prose), and
  `docs/customization.md` -- all three are also named as candidate
  files in the issue -- and `idd-advisory-wait.instructions.md` gets
  only a single-clause pointer, since it documents no other policy
  field (not even the existing `convergenceScope`) by its own
  convention of deferring field-level docs elsewhere.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [x] Config schema changed
- [x] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional policy setting to exempt bot-authored pull requests without claim history from advisory waiting when processing all pull requests.
  - Exempted pull requests are marked as not applicable; claimed bot pull requests and human-authored pull requests remain subject to existing rules.
  - The setting is disabled by default and does not affect claimed-only processing.

- **Documentation**
  - Documented configuration, scope, defaults, validation, and diagnostic behavior.

- **Tests**
  - Added coverage for exemption, defaults, validation, and unchanged behavior in other scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->