### PR TITLE
feat(protocol-helpers): support a claimless idd-external-check-waiver marker

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -391,7 +391,7 @@ still needs a valid waiver), and F2/F3's `advisoryWait.copilotUnavailable`/
 > recovery cycle is exhausted and the terminal window elapsed with no
 > current-HEAD review. A maintainer must post an
 > `idd-external-check-waiver:` marker for selector
-> `idd-advisory-convergence`, this HEAD, and the active claim before
+> `idd-advisory-convergence`, this HEAD, and claim (or `none`) before
 > this PR can proceed.
 
 **Waived**: rerun the existing `idd-advisory-convergence` run (never

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -377,8 +377,8 @@ alone never proves `COPILOT_UNAVAILABLE` (see **State**).
 ### Terminal routing (`#1570`)
 
 One `idd-external-check-waiver:` marker (selector
-`idd-advisory-convergence`, current HEAD, active claim) satisfies both
-consumers: the CI check's `terminal` field (its waiver hatch also opens
+`idd-advisory-convergence`, current HEAD, claim or `none`) satisfies
+both consumers: the CI check's `terminal` field (its waiver hatch also opens
 on `COPILOT_UNAVAILABLE` independent of `deadline.passed` — `ready`
 still needs a valid waiver), and F2/F3's `advisoryWait.copilotUnavailable`/
 `copilotUnavailableWaived` (`f3Outcome` unchanged; unwaived adds

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -377,8 +377,8 @@ alone never proves `COPILOT_UNAVAILABLE` (see **State**).
 ### Terminal routing (`#1570`)
 
 One `idd-external-check-waiver:` marker (selector
-`idd-advisory-convergence`, current HEAD, claim or `none`) satisfies
-both consumers: the CI check's `terminal` field (its waiver hatch also opens
+`idd-advisory-convergence`, current HEAD, active claim/`none`) satisfies
+both consumers: the CI check's `terminal` field (its waiver hatch opens
 on `COPILOT_UNAVAILABLE` independent of `deadline.passed` — `ready`
 still needs a valid waiver), and F2/F3's `advisoryWait.copilotUnavailable`/
 `copilotUnavailableWaived` (`f3Outcome` unchanged; unwaived adds
@@ -391,8 +391,8 @@ still needs a valid waiver), and F2/F3's `advisoryWait.copilotUnavailable`/
 > recovery cycle is exhausted and the terminal window elapsed with no
 > current-HEAD review. A maintainer must post an
 > `idd-external-check-waiver:` marker for selector
-> `idd-advisory-convergence`, this HEAD, and claim (or `none`) before
-> this PR can proceed.
+> `idd-advisory-convergence`, this HEAD, and active claim/`none` before
+> merging.
 
 **Waived**: rerun the existing `idd-advisory-convergence` run (never
 `workflow_dispatch` — see Rerun mechanics below); both fields recompute

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -860,25 +860,29 @@ default `instructions-only` profile keep using the written shell /
 - Contract:
   - dry-run is the default; the helper prints the canonical comment body
     plus claim/check/authority evidence before any mutation
-  - `--apply` posts the PR comment only after verifying the linked
-    issue's active claim, the current PR HEAD SHA, the live check state,
-    waivable-selector coverage, and maintainer/admin authority
+  - in normal mode, `--apply` posts the PR comment only after verifying
+    the linked issue's active claim, the current PR HEAD SHA, the live
+    check state, waivable-selector coverage, and maintainer/admin
+    authority
   - non-interactive apply is refused unless `--yes` is provided after a
     prior dry-run review; interactive TTY runs may confirm with `y/N`
   - the helper fails closed when authority cannot distinguish owner,
     Maintain, or Admin from plain Write access, when the requested check
     is not configured in `ciGate.externalChecks.waivable`, or when the
     expiry exceeds `ciGate.externalCheckWaivers.maxValidity`
-  - `--claimless` (#1905) renders a claimless waiver -- literal claim-id
-    `none` -- instead of resolving a linked issue's active claim; use it
-    for a PR with no IDD claim at all (an automated dependency-update PR
-    such as Dependabot, Renovate, or ImgBot). Cannot combine with
-    `--issue` or `--claim-id`. The helper still blocks with a clear
-    reason if the PR turns out to have a resolvable active claim after
-    all -- a `none` waiver only ever satisfies the consumer-side gate
-    (`summarizeExternalCheckWaivers` in `protocol-helpers.mts`) when no
-    claim resolves there, so posting one against a claimed PR would just
-    be rejected `wrongClaim`.
+  - `--claimless` (#1905) mode renders a claimless waiver -- literal
+    claim-id `none` -- instead of resolving a linked issue's active
+    claim; use it for a PR with no IDD claim at all (an automated
+    dependency-update PR such as Dependabot, Renovate, or ImgBot).
+    Cannot combine with `--issue` or `--claim-id`. In this mode,
+    `--apply` verifies that no active claim resolves for the PR instead
+    of resolving one, while still applying the same HEAD, live-check,
+    selector, expiry, and authority checks as normal mode -- the helper
+    blocks with a clear reason if the PR turns out to have a resolvable
+    active claim after all, since a `none` waiver only ever satisfies
+    the consumer-side gate (`summarizeExternalCheckWaivers` in
+    `protocol-helpers.mts`) when no claim resolves there, so posting one
+    against a claimed PR would just be rejected `wrongClaim`.
 
 ### External-check waiver contract
 
@@ -938,7 +942,10 @@ Interpretation rules:
       --apply --yes
     ```
 
-  - claimless PR (dry-run), e.g. a stuck Dependabot PR with no IDD claim:
+  - claimless PR (dry-run), e.g. a Dependabot PR with no IDD claim whose
+    primary-bot review never lands (observed 2026-08-05, #1904 -- 1 of
+    18 sampled `dependabot[bot]`-authored pull requests in this
+    repository's own history ever received a Copilot review):
 
     ```sh
     idd-external-check-waiver --pr 123 \

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -869,6 +869,16 @@ default `instructions-only` profile keep using the written shell /
     Maintain, or Admin from plain Write access, when the requested check
     is not configured in `ciGate.externalChecks.waivable`, or when the
     expiry exceeds `ciGate.externalCheckWaivers.maxValidity`
+  - `--claimless` (#1905) renders a claimless waiver -- literal claim-id
+    `none` -- instead of resolving a linked issue's active claim; use it
+    for a PR with no IDD claim at all (an automated dependency-update PR
+    such as Dependabot, Renovate, or ImgBot). Cannot combine with
+    `--issue` or `--claim-id`. The helper still blocks with a clear
+    reason if the PR turns out to have a resolvable active claim after
+    all -- a `none` waiver only ever satisfies the consumer-side gate
+    (`summarizeExternalCheckWaivers` in `protocol-helpers.mts`) when no
+    claim resolves there, so posting one against a claimed PR would just
+    be rejected `wrongClaim`.
 
 ### External-check waiver contract
 
@@ -877,7 +887,7 @@ facade and F-phase consumer land. The contract is intentionally
 auditable and fail-closed.
 
 ```md
-<!-- idd-external-check-waiver: {agent-id} {claim-id} {head-sha} check:{check-selector} reason:{reason-token} expires:{iso8601} -->
+<!-- idd-external-check-waiver: {agent-id} {claim-id|none} {head-sha} check:{check-selector} reason:{reason-token} expires:{iso8601} -->
 
 _{actor}: external check waiver for IDD F phase._
 ```
@@ -894,6 +904,14 @@ Interpretation rules:
 - Missing or unparseable body fields, unknown selectors, expired
   comments, wrong HEAD, wrong claim, or untrusted authors must fail
   closed.
+- `claim-id` accepts the case-insensitive literal sentinel `none`
+  (#1905) alongside an arbitrary claim id, declaring a deliberately
+  claimless waiver. It satisfies the claim-binding check only when the
+  gate independently confirms no claim resolves for the PR (an empty
+  active claim id) -- on a PR with a resolvable active claim, `none` is
+  never accepted and still fails closed to the same wrong-claim
+  rejection as any other mismatched claim id; this never weakens the
+  #1077 fail-closed-on-empty-claim guarantee for a non-`none` claim id.
 - A valid waiver can apply only to checks listed in
   `ciGate.externalChecks.waivable` and only when
   `ciGate.externalCheckWaivers.mode` enables maintainer authorization.
@@ -918,6 +936,16 @@ Interpretation rules:
       --reason "rate limit" \
       --expires-in PT2H \
       --apply --yes
+    ```
+
+  - claimless PR (dry-run), e.g. a stuck Dependabot PR with no IDD claim:
+
+    ```sh
+    idd-external-check-waiver --pr 123 \
+      --claimless \
+      --check "idd-advisory-convergence" \
+      --reason "Dependabot PR, Copilot review never lands" \
+      --expires-in PT2H
     ```
 
   - inspect the rendered body first; do not hand-write or copy raw

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -386,7 +386,7 @@ still needs a valid waiver), and F2/F3's `advisoryWait.copilotUnavailable`/
 > recovery cycle is exhausted and the terminal window elapsed with no
 > current-HEAD review. A maintainer must post an
 > `idd-external-check-waiver:` marker for selector
-> `idd-advisory-convergence`, this HEAD, and the active claim before
+> `idd-advisory-convergence`, this HEAD, and claim (or `none`) before
 > this PR can proceed.
 
 **Waived**: rerun the existing `idd-advisory-convergence` run (never

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -372,8 +372,8 @@ alone never proves `COPILOT_UNAVAILABLE` (see **State**).
 ### Terminal routing (`#1570`)
 
 One `idd-external-check-waiver:` marker (selector
-`idd-advisory-convergence`, current HEAD, active claim) satisfies both
-consumers: the CI check's `terminal` field (its waiver hatch also opens
+`idd-advisory-convergence`, current HEAD, claim or `none`) satisfies
+both consumers: the CI check's `terminal` field (its waiver hatch also opens
 on `COPILOT_UNAVAILABLE` independent of `deadline.passed` — `ready`
 still needs a valid waiver), and F2/F3's `advisoryWait.copilotUnavailable`/
 `copilotUnavailableWaived` (`f3Outcome` unchanged; unwaived adds

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -372,8 +372,8 @@ alone never proves `COPILOT_UNAVAILABLE` (see **State**).
 ### Terminal routing (`#1570`)
 
 One `idd-external-check-waiver:` marker (selector
-`idd-advisory-convergence`, current HEAD, claim or `none`) satisfies
-both consumers: the CI check's `terminal` field (its waiver hatch also opens
+`idd-advisory-convergence`, current HEAD, active claim/`none`) satisfies
+both consumers: the CI check's `terminal` field (its waiver hatch opens
 on `COPILOT_UNAVAILABLE` independent of `deadline.passed` — `ready`
 still needs a valid waiver), and F2/F3's `advisoryWait.copilotUnavailable`/
 `copilotUnavailableWaived` (`f3Outcome` unchanged; unwaived adds
@@ -386,8 +386,8 @@ still needs a valid waiver), and F2/F3's `advisoryWait.copilotUnavailable`/
 > recovery cycle is exhausted and the terminal window elapsed with no
 > current-HEAD review. A maintainer must post an
 > `idd-external-check-waiver:` marker for selector
-> `idd-advisory-convergence`, this HEAD, and claim (or `none`) before
-> this PR can proceed.
+> `idd-advisory-convergence`, this HEAD, and active claim/`none` before
+> merging.
 
 **Waived**: rerun the existing `idd-advisory-convergence` run (never
 `workflow_dispatch` — see Rerun mechanics below); both fields recompute

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -860,25 +860,29 @@ default `instructions-only` profile keep using the written shell /
 - Contract:
   - dry-run is the default; the helper prints the canonical comment body
     plus claim/check/authority evidence before any mutation
-  - `--apply` posts the PR comment only after verifying the linked
-    issue's active claim, the current PR HEAD SHA, the live check state,
-    waivable-selector coverage, and maintainer/admin authority
+  - in normal mode, `--apply` posts the PR comment only after verifying
+    the linked issue's active claim, the current PR HEAD SHA, the live
+    check state, waivable-selector coverage, and maintainer/admin
+    authority
   - non-interactive apply is refused unless `--yes` is provided after a
     prior dry-run review; interactive TTY runs may confirm with `y/N`
   - the helper fails closed when authority cannot distinguish owner,
     Maintain, or Admin from plain Write access, when the requested check
     is not configured in `ciGate.externalChecks.waivable`, or when the
     expiry exceeds `ciGate.externalCheckWaivers.maxValidity`
-  - `--claimless` (#1905) renders a claimless waiver -- literal claim-id
-    `none` -- instead of resolving a linked issue's active claim; use it
-    for a PR with no IDD claim at all (an automated dependency-update PR
-    such as Dependabot, Renovate, or ImgBot). Cannot combine with
-    `--issue` or `--claim-id`. The helper still blocks with a clear
-    reason if the PR turns out to have a resolvable active claim after
-    all -- a `none` waiver only ever satisfies the consumer-side gate
-    (`summarizeExternalCheckWaivers` in `protocol-helpers.mts`) when no
-    claim resolves there, so posting one against a claimed PR would just
-    be rejected `wrongClaim`.
+  - `--claimless` (#1905) mode renders a claimless waiver -- literal
+    claim-id `none` -- instead of resolving a linked issue's active
+    claim; use it for a PR with no IDD claim at all (an automated
+    dependency-update PR such as Dependabot, Renovate, or ImgBot).
+    Cannot combine with `--issue` or `--claim-id`. In this mode,
+    `--apply` verifies that no active claim resolves for the PR instead
+    of resolving one, while still applying the same HEAD, live-check,
+    selector, expiry, and authority checks as normal mode -- the helper
+    blocks with a clear reason if the PR turns out to have a resolvable
+    active claim after all, since a `none` waiver only ever satisfies
+    the consumer-side gate (`summarizeExternalCheckWaivers` in
+    `protocol-helpers.mts`) when no claim resolves there, so posting one
+    against a claimed PR would just be rejected `wrongClaim`.
 
 ### External-check waiver contract
 
@@ -938,7 +942,10 @@ Interpretation rules:
       --apply --yes
     ```
 
-  - claimless PR (dry-run), e.g. a stuck Dependabot PR with no IDD claim:
+  - claimless PR (dry-run), e.g. a Dependabot PR with no IDD claim whose
+    primary-bot review never lands (observed 2026-08-05, #1904 -- 1 of
+    18 sampled `dependabot[bot]`-authored pull requests in this
+    repository's own history ever received a Copilot review):
 
     ```sh
     idd-external-check-waiver --pr 123 \

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -869,6 +869,16 @@ default `instructions-only` profile keep using the written shell /
     Maintain, or Admin from plain Write access, when the requested check
     is not configured in `ciGate.externalChecks.waivable`, or when the
     expiry exceeds `ciGate.externalCheckWaivers.maxValidity`
+  - `--claimless` (#1905) renders a claimless waiver -- literal claim-id
+    `none` -- instead of resolving a linked issue's active claim; use it
+    for a PR with no IDD claim at all (an automated dependency-update PR
+    such as Dependabot, Renovate, or ImgBot). Cannot combine with
+    `--issue` or `--claim-id`. The helper still blocks with a clear
+    reason if the PR turns out to have a resolvable active claim after
+    all -- a `none` waiver only ever satisfies the consumer-side gate
+    (`summarizeExternalCheckWaivers` in `protocol-helpers.mts`) when no
+    claim resolves there, so posting one against a claimed PR would just
+    be rejected `wrongClaim`.
 
 ### External-check waiver contract
 
@@ -877,7 +887,7 @@ facade and F-phase consumer land. The contract is intentionally
 auditable and fail-closed.
 
 ```md
-<!-- idd-external-check-waiver: {agent-id} {claim-id} {head-sha} check:{check-selector} reason:{reason-token} expires:{iso8601} -->
+<!-- idd-external-check-waiver: {agent-id} {claim-id|none} {head-sha} check:{check-selector} reason:{reason-token} expires:{iso8601} -->
 
 _{actor}: external check waiver for IDD F phase._
 ```
@@ -894,6 +904,14 @@ Interpretation rules:
 - Missing or unparseable body fields, unknown selectors, expired
   comments, wrong HEAD, wrong claim, or untrusted authors must fail
   closed.
+- `claim-id` accepts the case-insensitive literal sentinel `none`
+  (#1905) alongside an arbitrary claim id, declaring a deliberately
+  claimless waiver. It satisfies the claim-binding check only when the
+  gate independently confirms no claim resolves for the PR (an empty
+  active claim id) -- on a PR with a resolvable active claim, `none` is
+  never accepted and still fails closed to the same wrong-claim
+  rejection as any other mismatched claim id; this never weakens the
+  #1077 fail-closed-on-empty-claim guarantee for a non-`none` claim id.
 - A valid waiver can apply only to checks listed in
   `ciGate.externalChecks.waivable` and only when
   `ciGate.externalCheckWaivers.mode` enables maintainer authorization.
@@ -918,6 +936,16 @@ Interpretation rules:
       --reason "rate limit" \
       --expires-in PT2H \
       --apply --yes
+    ```
+
+  - claimless PR (dry-run), e.g. a stuck Dependabot PR with no IDD claim:
+
+    ```sh
+    idd-external-check-waiver --pr 123 \
+      --claimless \
+      --check "idd-advisory-convergence" \
+      --reason "Dependabot PR, Copilot review never lands" \
+      --expires-in PT2H
     ```
 
   - inspect the rendered body first; do not hand-write or copy raw

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -151,6 +151,14 @@ export function planExternalCheckWaiver(input, options = {}) {
         'PR has a resolvable active IDD claim on a linked issue; a claimless (none) waiver only applies when no claim resolves -- use --issue/--claim-id instead',
       );
     }
+    // The normal path's agentId comes from the resolved claim, independent
+    // of `actor`; --claimless has no claim to fall back on, so an empty
+    // actor must surface here as a blocking reason like every other invalid
+    // input in this function, rather than reaching
+    // renderExternalCheckWaiverComment's own throw-on-empty-agentId guard.
+    if (!actor) {
+      blockingReasons.push('actor is empty');
+    }
   } else if (!linkedIssue.ok) {
     blockingReasons.push(linkedIssue.reason);
   }
@@ -203,7 +211,9 @@ export function planExternalCheckWaiver(input, options = {}) {
   // design); the normal path binds to the linked issue's active claim, same
   // as before this change.
   const claimBinding = claimless
-    ? { agentId: actor, claimId: 'none' }
+    ? actor
+      ? { agentId: actor, claimId: 'none' }
+      : null
     : linkedIssue.ok
       ? {
           agentId: linkedIssue.issue.activeClaim.agentId,

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -121,11 +121,20 @@ export function planExternalCheckWaiver(input, options = {}) {
     expiresKnown && Number.isFinite(maxValidity)
       ? expiresDate.getTime() - now.getTime() <= (maxValidity ?? 0)
       : false;
+  // #1905: still resolved even under --claimless -- not to gate on it (a
+  // claimless waiver never requires a linked-issue claim), but so a
+  // resolvable active claim can be surfaced as a blocking diagnostic below:
+  // a `none`-claim-id waiver only ever satisfies
+  // `summarizeExternalCheckWaivers` on a PR with NO active claim, so
+  // rendering one against a claimed PR would just be rejected `wrongClaim`
+  // at the merge gate -- better to block it here with a clear reason than
+  // let the operator post a waiver that can never take effect.
   const linkedIssue = selectLinkedIssueCandidate(issueCandidates, {
     issueNumber: input?.issueNumber,
     expectedClaimId: input?.expectedClaimId,
     headRefName: String(pr.headRefName ?? '').trim(),
   });
+  const claimless = Boolean(input?.claimless);
   const blockingReasons = [];
   if (String(pr.state ?? 'OPEN').toUpperCase() !== 'OPEN') {
     blockingReasons.push(`PR #${pr.number ?? '?'} is not open`);
@@ -136,7 +145,13 @@ export function planExternalCheckWaiver(input, options = {}) {
   ) {
     blockingReasons.push('external-check waiver mode is disabled');
   }
-  if (!linkedIssue.ok) {
+  if (claimless) {
+    if (linkedIssue.ok) {
+      blockingReasons.push(
+        'PR has a resolvable active IDD claim on a linked issue; a claimless (none) waiver only applies when no claim resolves -- use --issue/--claim-id instead',
+      );
+    }
+  } else if (!linkedIssue.ok) {
     blockingReasons.push(linkedIssue.reason);
   }
   if (!requestedSelector) {
@@ -182,16 +197,29 @@ export function planExternalCheckWaiver(input, options = {}) {
       'one or more matched checks are not configured as waivable external checks',
     );
   }
+  // #1905: --claimless binds the marker to the sentinel claim-id `none` and
+  // the acting maintainer's own identity as agentId (there is no
+  // issue-claim agentId to reuse when the PR carries no active claim by
+  // design); the normal path binds to the linked issue's active claim, same
+  // as before this change.
+  const claimBinding = claimless
+    ? { agentId: actor, claimId: 'none' }
+    : linkedIssue.ok
+      ? {
+          agentId: linkedIssue.issue.activeClaim.agentId,
+          claimId: linkedIssue.issue.activeClaim.claimId,
+        }
+      : null;
   const body =
+    claimBinding &&
     requestedSelector &&
     reason &&
     expiresKnown &&
-    linkedIssue.ok &&
     String(pr.headRefOid ?? '').match(/^[0-9a-f]{40}$/i)
       ? renderExternalCheckWaiverComment({
           actor,
-          agentId: linkedIssue.issue.activeClaim.agentId,
-          claimId: linkedIssue.issue.activeClaim.claimId,
+          agentId: claimBinding.agentId,
+          claimId: claimBinding.claimId,
           headSha: String(pr.headRefOid ?? '').toLowerCase(),
           checkSelector: requestedSelector,
           reason,
@@ -318,6 +346,7 @@ export async function runExternalCheckWaiver(options = {}) {
         now: options.now instanceof Date ? options.now : new Date(),
       }),
       repoOwner: owner,
+      claimless: args.claimless,
     },
     { now: options.now, repoOwner: owner },
   );
@@ -827,6 +856,7 @@ const EXTERNAL_CHECK_WAIVER_FLAG_SPEC = {
   '--apply': { type: 'boolean', default: false },
   '--yes': { type: 'boolean', default: false },
   '--format': { type: 'string', default: 'json' },
+  '--claimless': { type: 'boolean', default: false },
   '--help': { type: 'boolean', short: 'h' },
 };
 export function parseArgs(argv) {
@@ -857,6 +887,7 @@ export function parseArgs(argv) {
     apply: values.apply,
     yes: values.yes,
     format,
+    claimless: values.claimless,
     help,
   };
   if (!parsed.help) {
@@ -868,6 +899,17 @@ export function parseArgs(argv) {
     }
     if (!parsed.reason) {
       throw new Error('missing required --reason <text> argument');
+    }
+    // #1905: --claimless renders claim-id `none` directly -- it never
+    // resolves a linked issue's active claim, so combining it with --issue
+    // or --claim-id is contradictory and almost certainly an operator
+    // mistake (one flag says "there is no claim", the other says "resolve
+    // this specific one").
+    if (parsed.claimless && parsed.issueNumber) {
+      throw new Error('--claimless cannot be combined with --issue');
+    }
+    if (parsed.claimless && parsed.claimId) {
+      throw new Error('--claimless cannot be combined with --claim-id');
     }
   }
   return parsed;
@@ -899,6 +941,10 @@ function printUsage() {
 Options:
   --issue <number>                  linked issue to use for active claim resolution
   --claim-id <id>                   require the resolved active claim to match this claim id
+  --claimless                       render a claimless waiver (claim-id "none") instead of
+                                     resolving a linked issue's active claim; for a PR with
+                                     no IDD claim at all (e.g. Dependabot). Cannot combine
+                                     with --issue or --claim-id.
   --actor <login>                   override the GitHub actor used for authority evaluation
   --repo <owner/name>               repository override
   --apply                           post the canonical waiver comment after validation

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -706,6 +706,13 @@ export function renderAdvisoryRerollMarker(payload) {
   }
   return `advisory-reroll: ${agentId} ${headSha} ${timestamp}`;
 }
+// #1905: the grammar's positional claim-id field
+// (`{agent-id} {claim-id|none} {head-sha} ...`) already accepts an
+// arbitrary non-whitespace token, so the case-insensitive literal `none`
+// sentinel parses through the SAME `(\S+)` capture as any other claim id --
+// no regex change needed here. `parsed.claimId` carries the token verbatim
+// (case preserved); see `ParsedExternalCheckWaiver.claimId`'s doc comment
+// for how the consumer resolves the sentinel.
 export function parseExternalCheckWaiverComment(body, createdAt) {
   const match = body
     .trimEnd()

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -190,8 +190,20 @@ export function summarizeExternalCheckWaivers(
     }
     // Fail closed on an empty active claim: when no claim resolves at the gate
     // (`activeClaimLower === ''`), a waiver cannot be bound to an owner and is
-    // rejected rather than passing unbound.
-    if (!activeClaimLower || parsed.claimId !== activeClaimLower) {
+    // rejected rather than passing unbound. #1905's one narrow exception: the
+    // case-insensitive literal sentinel `none` in the marker's claimId field
+    // explicitly declares "this is a claimless waiver" -- it satisfies the
+    // claim-binding check ONLY when the gate independently confirms no claim
+    // resolves (`!activeClaimLower`). A non-empty `activeClaimLower` always
+    // requires an exact `claimId` match; `none` is never accepted there, so
+    // the sentinel can never route around a genuine claim mismatch. Every
+    // other combination is unchanged: a non-`none` claimId on an unclaimed PR
+    // still falls into `wrongClaim` -- the exact regression #1077 fixed.
+    const claimIdIsNoneSentinel = parsed.claimId.toLowerCase() === 'none';
+    const claimBindingSatisfied = activeClaimLower
+      ? parsed.claimId === activeClaimLower
+      : claimIdIsNoneSentinel;
+    if (!claimBindingSatisfied) {
       wrongClaim.push({
         authorLogin,
         checkSelector: parsed.checkSelector,

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -406,6 +406,14 @@ export function planExternalCheckWaiver(
         'PR has a resolvable active IDD claim on a linked issue; a claimless (none) waiver only applies when no claim resolves -- use --issue/--claim-id instead',
       );
     }
+    // The normal path's agentId comes from the resolved claim, independent
+    // of `actor`; --claimless has no claim to fall back on, so an empty
+    // actor must surface here as a blocking reason like every other invalid
+    // input in this function, rather than reaching
+    // renderExternalCheckWaiverComment's own throw-on-empty-agentId guard.
+    if (!actor) {
+      blockingReasons.push('actor is empty');
+    }
   } else if (!linkedIssue.ok) {
     blockingReasons.push(linkedIssue.reason);
   }
@@ -459,7 +467,9 @@ export function planExternalCheckWaiver(
   // design); the normal path binds to the linked issue's active claim, same
   // as before this change.
   const claimBinding = claimless
-    ? { agentId: actor, claimId: 'none' }
+    ? actor
+      ? { agentId: actor, claimId: 'none' }
+      : null
     : linkedIssue.ok
       ? {
           agentId: linkedIssue.issue.activeClaim.agentId,

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -160,6 +160,16 @@ interface ExternalCheckWaiverPlanInput {
   reason?: string;
   expiresAt?: string;
   repoOwner?: string;
+  /**
+   * #1905: render a claimless waiver -- claim-id `none` -- instead of
+   * resolving the claim-id from a linked issue's active IDD claim. Skips
+   * the linked-issue-claim requirement entirely; blocks instead when a
+   * resolvable active claim IS found, since a claimless waiver only ever
+   * satisfies `summarizeExternalCheckWaivers` on a PR with no active
+   * claim, so posting one against a claimed PR would just be rejected as
+   * `wrongClaim` at the merge gate.
+   */
+  claimless?: boolean;
 }
 
 /** Structured waiver plan report. */
@@ -219,6 +229,7 @@ interface ExternalCheckWaiverArgs {
   apply: boolean;
   yes: boolean;
   format: string;
+  claimless: boolean;
   help: boolean;
 }
 
@@ -364,11 +375,20 @@ export function planExternalCheckWaiver(
     expiresKnown && Number.isFinite(maxValidity)
       ? expiresDate.getTime() - now.getTime() <= (maxValidity ?? 0)
       : false;
+  // #1905: still resolved even under --claimless -- not to gate on it (a
+  // claimless waiver never requires a linked-issue claim), but so a
+  // resolvable active claim can be surfaced as a blocking diagnostic below:
+  // a `none`-claim-id waiver only ever satisfies
+  // `summarizeExternalCheckWaivers` on a PR with NO active claim, so
+  // rendering one against a claimed PR would just be rejected `wrongClaim`
+  // at the merge gate -- better to block it here with a clear reason than
+  // let the operator post a waiver that can never take effect.
   const linkedIssue = selectLinkedIssueCandidate(issueCandidates, {
     issueNumber: input?.issueNumber,
     expectedClaimId: input?.expectedClaimId,
     headRefName: String(pr.headRefName ?? '').trim(),
   });
+  const claimless = Boolean(input?.claimless);
 
   const blockingReasons: string[] = [];
   if (String(pr.state ?? 'OPEN').toUpperCase() !== 'OPEN') {
@@ -380,7 +400,13 @@ export function planExternalCheckWaiver(
   ) {
     blockingReasons.push('external-check waiver mode is disabled');
   }
-  if (!linkedIssue.ok) {
+  if (claimless) {
+    if (linkedIssue.ok) {
+      blockingReasons.push(
+        'PR has a resolvable active IDD claim on a linked issue; a claimless (none) waiver only applies when no claim resolves -- use --issue/--claim-id instead',
+      );
+    }
+  } else if (!linkedIssue.ok) {
     blockingReasons.push(linkedIssue.reason);
   }
   if (!requestedSelector) {
@@ -427,16 +453,29 @@ export function planExternalCheckWaiver(
     );
   }
 
+  // #1905: --claimless binds the marker to the sentinel claim-id `none` and
+  // the acting maintainer's own identity as agentId (there is no
+  // issue-claim agentId to reuse when the PR carries no active claim by
+  // design); the normal path binds to the linked issue's active claim, same
+  // as before this change.
+  const claimBinding = claimless
+    ? { agentId: actor, claimId: 'none' }
+    : linkedIssue.ok
+      ? {
+          agentId: linkedIssue.issue.activeClaim.agentId,
+          claimId: linkedIssue.issue.activeClaim.claimId,
+        }
+      : null;
   const body =
+    claimBinding &&
     requestedSelector &&
     reason &&
     expiresKnown &&
-    linkedIssue.ok &&
     String(pr.headRefOid ?? '').match(/^[0-9a-f]{40}$/i)
       ? renderExternalCheckWaiverComment({
           actor,
-          agentId: linkedIssue.issue.activeClaim.agentId,
-          claimId: linkedIssue.issue.activeClaim.claimId,
+          agentId: claimBinding.agentId,
+          claimId: claimBinding.claimId,
           headSha: String(pr.headRefOid ?? '').toLowerCase(),
           checkSelector: requestedSelector,
           reason,
@@ -570,6 +609,7 @@ export async function runExternalCheckWaiver(
         now: options.now instanceof Date ? options.now : new Date(),
       }),
       repoOwner: owner,
+      claimless: args.claimless,
     },
     { now: options.now, repoOwner: owner },
   );
@@ -1171,6 +1211,7 @@ const EXTERNAL_CHECK_WAIVER_FLAG_SPEC = {
   '--apply': { type: 'boolean', default: false },
   '--yes': { type: 'boolean', default: false },
   '--format': { type: 'string', default: 'json' },
+  '--claimless': { type: 'boolean', default: false },
   '--help': { type: 'boolean', short: 'h' },
 } as const;
 
@@ -1206,6 +1247,7 @@ export function parseArgs(argv: string[]): ExternalCheckWaiverArgs {
     apply: values.apply as boolean,
     yes: values.yes as boolean,
     format,
+    claimless: values.claimless as boolean,
     help,
   };
 
@@ -1218,6 +1260,17 @@ export function parseArgs(argv: string[]): ExternalCheckWaiverArgs {
     }
     if (!parsed.reason) {
       throw new Error('missing required --reason <text> argument');
+    }
+    // #1905: --claimless renders claim-id `none` directly -- it never
+    // resolves a linked issue's active claim, so combining it with --issue
+    // or --claim-id is contradictory and almost certainly an operator
+    // mistake (one flag says "there is no claim", the other says "resolve
+    // this specific one").
+    if (parsed.claimless && parsed.issueNumber) {
+      throw new Error('--claimless cannot be combined with --issue');
+    }
+    if (parsed.claimless && parsed.claimId) {
+      throw new Error('--claimless cannot be combined with --claim-id');
     }
   }
 
@@ -1254,6 +1307,10 @@ function printUsage(): void {
 Options:
   --issue <number>                  linked issue to use for active claim resolution
   --claim-id <id>                   require the resolved active claim to match this claim id
+  --claimless                       render a claimless waiver (claim-id "none") instead of
+                                     resolving a linked issue's active claim; for a PR with
+                                     no IDD claim at all (e.g. Dependabot). Cannot combine
+                                     with --issue or --claim-id.
   --actor <login>                   override the GitHub actor used for authority evaluation
   --repo <owner/name>               repository override
   --apply                           post the canonical waiver comment after validation

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -120,6 +120,15 @@ export interface ParsedForcedHandoffMarker {
 /** Parsed `<!-- idd-external-check-waiver: ... -->` marker. */
 export interface ParsedExternalCheckWaiver {
   agentId: string;
+  /**
+   * The marker's positional claim-id field, verbatim (case preserved). May
+   * be an arbitrary claim id, or the case-insensitive literal sentinel
+   * `none` (#1905) declaring a deliberately claimless waiver -- the
+   * consumer (`summarizeExternalCheckWaivers` in `protocol-helpers.mts`)
+   * decides whether the sentinel applies by comparing
+   * `claimId.toLowerCase() === 'none'` against its own resolved active
+   * claim; this parser does not special-case the token.
+   */
   claimId: string;
   headSha: string;
   checkSelector: string;
@@ -1004,6 +1013,13 @@ export function renderAdvisoryRerollMarker(payload: {
   return `advisory-reroll: ${agentId} ${headSha} ${timestamp}`;
 }
 
+// #1905: the grammar's positional claim-id field
+// (`{agent-id} {claim-id|none} {head-sha} ...`) already accepts an
+// arbitrary non-whitespace token, so the case-insensitive literal `none`
+// sentinel parses through the SAME `(\S+)` capture as any other claim id --
+// no regex change needed here. `parsed.claimId` carries the token verbatim
+// (case preserved); see `ParsedExternalCheckWaiver.claimId`'s doc comment
+// for how the consumer resolves the sentinel.
 export function parseExternalCheckWaiverComment(
   body: string,
   createdAt: string,

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -688,8 +688,20 @@ export function summarizeExternalCheckWaivers(
 
     // Fail closed on an empty active claim: when no claim resolves at the gate
     // (`activeClaimLower === ''`), a waiver cannot be bound to an owner and is
-    // rejected rather than passing unbound.
-    if (!activeClaimLower || parsed.claimId !== activeClaimLower) {
+    // rejected rather than passing unbound. #1905's one narrow exception: the
+    // case-insensitive literal sentinel `none` in the marker's claimId field
+    // explicitly declares "this is a claimless waiver" -- it satisfies the
+    // claim-binding check ONLY when the gate independently confirms no claim
+    // resolves (`!activeClaimLower`). A non-empty `activeClaimLower` always
+    // requires an exact `claimId` match; `none` is never accepted there, so
+    // the sentinel can never route around a genuine claim mismatch. Every
+    // other combination is unchanged: a non-`none` claimId on an unclaimed PR
+    // still falls into `wrongClaim` -- the exact regression #1077 fixed.
+    const claimIdIsNoneSentinel = parsed.claimId.toLowerCase() === 'none';
+    const claimBindingSatisfied = activeClaimLower
+      ? parsed.claimId === activeClaimLower
+      : claimIdIsNoneSentinel;
+    if (!claimBindingSatisfied) {
       wrongClaim.push({
         authorLogin,
         checkSelector: parsed.checkSelector,

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -787,6 +787,76 @@ test("#1512: this repository's own .github/idd/config.json wires the maintainer-
   assert.equal(verdict.ready, true);
 });
 
+// --- #1905: claimless waiver (claim-id "none") escape hatch ----------------
+
+test('claimless waiver: a maintainer-posted none-claim-id waiver flips a stale-pending claimless PR ready', () => {
+  // A genuinely claimless PR (Dependabot, Renovate, ImgBot, or similar):
+  // no claim events at all, so `activeClaimId` resolves to '' inside the
+  // gate -- exactly the shape `advisoryWait.convergenceScope: "all-prs"`
+  // (the documented default) leaves stuck with no way to waive, before
+  // #1905's `none` sentinel.
+  const waiverBody = renderExternalCheckWaiverComment({
+    agentId: TRUSTED,
+    claimId: 'none',
+    headSha: HEAD,
+    checkSelector: 'idd-advisory-convergence',
+    reason: 'Dependabot PR has no IDD claim; Copilot review never lands',
+    expiresAt: '2026-07-12T00:00:00Z',
+    actor: TRUSTED,
+  });
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [], // still pending -- the primary bot never reviewed
+      claimEvents: [], // no IDD claim at all
+      comments: [
+        { author: { login: TRUSTED }, body: waiverBody, createdAt: RECENT },
+      ],
+    }),
+    baseOptions({
+      headCommittedAt: OLD,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.pending, true);
+  assert.equal(verdict.deadline.passed, true);
+  assert.equal(verdict.waiver.activeClaimId, '');
+  assert.equal(verdict.waiver.validCount, 1);
+  assert.equal(verdict.waived, true);
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.ready, true);
+});
+
+test('claimless waiver: a non-none claim id posted on a claimless PR does not waive (still fails closed)', () => {
+  const waiverBody = renderExternalCheckWaiverComment({
+    agentId: TRUSTED,
+    claimId: CLAIM_ID, // not the "none" sentinel, and no claim resolves to match it
+    headSha: HEAD,
+    checkSelector: 'idd-advisory-convergence',
+    reason: 'attempted waiver on a claimless PR with the wrong claim id',
+    expiresAt: '2026-07-12T00:00:00Z',
+    actor: TRUSTED,
+  });
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [],
+      comments: [
+        { author: { login: TRUSTED }, body: waiverBody, createdAt: RECENT },
+      ],
+    }),
+    baseOptions({
+      headCommittedAt: OLD,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+    }),
+  );
+  assert.equal(verdict.waiver.validCount, 0);
+  assert.equal(verdict.waived, false);
+  assert.equal(verdict.ready, false);
+});
+
 // --- 7. deadline-passed-no-waiver -----------------------------------------
 
 test('deadline-passed-no-waiver: no waiver comment leaves a stale-pending PR blocked', () => {

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -88,6 +88,69 @@ test('parseArgs: rejects an unknown flag', () => {
   assert.throws(() => parseArgs(['--bogus']));
 });
 
+// --- #1905: claimless waiver authoring flag ---------------------------------
+
+test('parseArgs: parses --claimless', () => {
+  const args = parseArgs([
+    '--pr',
+    '5',
+    '--check',
+    'CodeRabbit',
+    '--reason',
+    'flaky',
+    '--claimless',
+  ]);
+  assert.equal(args.claimless, true);
+});
+
+test('parseArgs: --claimless defaults to false', () => {
+  const args = parseArgs([
+    '--pr',
+    '5',
+    '--check',
+    'CodeRabbit',
+    '--reason',
+    'flaky',
+  ]);
+  assert.equal(args.claimless, false);
+});
+
+test('parseArgs: --claimless combined with --issue throws', () => {
+  assert.throws(
+    () =>
+      parseArgs([
+        '--pr',
+        '5',
+        '--check',
+        'x',
+        '--reason',
+        'y',
+        '--claimless',
+        '--issue',
+        '3',
+      ]),
+    /--claimless cannot be combined with --issue/,
+  );
+});
+
+test('parseArgs: --claimless combined with --claim-id throws', () => {
+  assert.throws(
+    () =>
+      parseArgs([
+        '--pr',
+        '5',
+        '--check',
+        'x',
+        '--reason',
+        'y',
+        '--claimless',
+        '--claim-id',
+        'claim-1',
+      ]),
+    /--claimless cannot be combined with --claim-id/,
+  );
+});
+
 type PlanInput = Parameters<typeof planExternalCheckWaiver>[0];
 // The base-input builder always supplies these fields, so the test
 // mutations below may dereference them without optional guards.
@@ -206,6 +269,44 @@ test('planExternalCheckWaiver fails closed when no active linked claim is availa
 
   assert.equal(report.canApply, false);
   assert.match(report.blockingReasons.join('\n'), /active linked issue claim/);
+});
+
+// --- #1905: claimless waiver authoring path ---------------------------------
+
+test('planExternalCheckWaiver: claimless renders a none-claim-id waiver without any linked issue claim', () => {
+  const input = buildBaseInput();
+  input.claimless = true;
+  // A genuinely claimless PR (e.g. Dependabot) has no linked issue at all.
+  input.issueCandidates = [];
+
+  const report = planExternalCheckWaiver(input, {
+    now: new Date('2026-05-17T06:00:00Z'),
+    repoOwner: 'kurone-kito',
+  });
+
+  assert.equal(report.canApply, true);
+  assert.equal(report.blockingReasons.length, 0);
+  assert.equal(report.linkedIssue, null);
+  assert.match(report.body, /idd-external-check-waiver: kurone-kito none /);
+});
+
+test('planExternalCheckWaiver: claimless is blocked when the PR has a resolvable active claim', () => {
+  const input = buildBaseInput();
+  input.claimless = true;
+  // buildBaseInput() already wires a linked issue with an active claim --
+  // a claimless (none) waiver would just be rejected wrongClaim at the
+  // merge gate for a PR shaped like this, so it must be blocked up front.
+
+  const report = planExternalCheckWaiver(input, {
+    now: new Date('2026-05-17T06:00:00Z'),
+    repoOwner: 'kurone-kito',
+  });
+
+  assert.equal(report.canApply, false);
+  assert.match(
+    report.blockingReasons.join('\n'),
+    /resolvable active IDD claim/,
+  );
 });
 
 test('planExternalCheckWaiver fails closed for unauthorized write-only actors', () => {

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -309,6 +309,22 @@ test('planExternalCheckWaiver: claimless is blocked when the PR has a resolvable
   );
 });
 
+test('planExternalCheckWaiver: claimless with an empty actor blocks with a reason instead of throwing', () => {
+  const input = buildBaseInput();
+  input.claimless = true;
+  input.issueCandidates = [];
+  input.actor = '';
+
+  const report = planExternalCheckWaiver(input, {
+    now: new Date('2026-05-17T06:00:00Z'),
+    repoOwner: 'kurone-kito',
+  });
+
+  assert.equal(report.canApply, false);
+  assert.match(report.blockingReasons.join('\n'), /actor is empty/);
+  assert.equal(report.body, '');
+});
+
 test('planExternalCheckWaiver fails closed for unauthorized write-only actors', () => {
   const input = buildBaseInput();
   input.actor = 'write-collaborator';

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -4653,6 +4653,88 @@ test('summarizeExternalCheckWaivers: an empty active claim fails closed to wrong
   assert.equal(result.wrongClaim.length, 1);
 });
 
+// --- #1905: claimless waiver (claim-id "none") sentinel ---------------------
+
+test('summarizeExternalCheckWaivers: claim-id "none" on an unclaimed PR is valid (claimless-accept)', () => {
+  const head = 'f'.repeat(40);
+  const body = makeWaiverComment({ headSha: head, claimId: 'none' });
+  const comment = {
+    body,
+    author: { login: 'kurone-kito' },
+    createdAt: '2026-05-17T00:00:00Z',
+  };
+  // No active claim resolves at the gate -- the literal `none` sentinel
+  // explicitly declares this a claimless waiver, satisfying the
+  // claim-binding check only because the gate independently confirms no
+  // claim exists.
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: head,
+    activeClaimId: '',
+    trustedMarkerLogins: ['kurone-kito'],
+    now: '2026-05-17T00:00:00Z',
+  });
+  assert.equal(result.valid.length, 1);
+  assert.equal(result.wrongClaim.length, 0);
+});
+
+test('summarizeExternalCheckWaivers: "NONE"/"None" (any case) on an unclaimed PR is valid', () => {
+  const head = 'f'.repeat(40);
+  for (const sentinel of ['NONE', 'None', 'nOnE']) {
+    const body = makeWaiverComment({ headSha: head, claimId: sentinel });
+    const comment = {
+      body,
+      author: { login: 'kurone-kito' },
+      createdAt: '2026-05-17T00:00:00Z',
+    };
+    const result = summarizeExternalCheckWaivers([comment], {
+      prHeadSha: head,
+      activeClaimId: '',
+      trustedMarkerLogins: ['kurone-kito'],
+      now: '2026-05-17T00:00:00Z',
+    });
+    assert.equal(result.valid.length, 1, `sentinel ${sentinel} must validate`);
+  }
+});
+
+test('summarizeExternalCheckWaivers: a non-none, non-matching claim id on an unclaimed PR still fails to wrongClaim (regression #1077, claimless-reject-wrong-sentinel)', () => {
+  const head = 'f'.repeat(40);
+  const body = makeWaiverComment({ headSha: head, claimId: 'claim-123' });
+  const comment = {
+    body,
+    author: { login: 'kurone-kito' },
+    createdAt: '2026-05-17T00:00:00Z',
+  };
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: head,
+    activeClaimId: '',
+    trustedMarkerLogins: ['kurone-kito'],
+    now: '2026-05-17T00:00:00Z',
+  });
+  assert.equal(result.valid.length, 0, 'unbound waiver must not be valid');
+  assert.equal(result.wrongClaim.length, 1);
+});
+
+test('summarizeExternalCheckWaivers: claim-id "none" on a claimed PR is rejected to wrongClaim (claimed-PR-rejects-none)', () => {
+  const head = 'f'.repeat(40);
+  const body = makeWaiverComment({ headSha: head, claimId: 'none' });
+  const comment = {
+    body,
+    author: { login: 'kurone-kito' },
+    createdAt: '2026-05-17T00:00:00Z',
+  };
+  // A real claim resolves at the gate -- the `none` sentinel only applies
+  // when the gate independently confirms no claim exists, so it must never
+  // route around a genuine claim mismatch.
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: head,
+    activeClaimId: 'claim-123',
+    trustedMarkerLogins: ['kurone-kito'],
+    now: '2026-05-17T00:00:00Z',
+  });
+  assert.equal(result.valid.length, 0, 'none must not bind to a real claim');
+  assert.equal(result.wrongClaim.length, 1);
+});
+
 test('summarizeExternalCheckWaivers: an empty head SHA fails closed to wrongHead', () => {
   const head = 'a'.repeat(40);
   const body = makeWaiverComment({ headSha: head, claimId: 'claim-123' });


### PR DESCRIPTION
# Summary

`summarizeExternalCheckWaivers` fails closed whenever no IDD claim
resolves at the gate (`activeClaimId === ''`), which is correct
hardening from #1077 -- but it also means a PR that never had an IDD
claim at all (most concretely an automated dependency-update PR from
Dependabot, Renovate, or ImgBot) can never be waived through the
`idd-advisory-convergence` deadline/terminal-unavailable escape hatch,
even by a trusted maintainer, once the check gets stuck.

This PR adds exactly one narrowly-scoped acceptance branch: a marker
whose positional `claimId` field is the case-insensitive literal
sentinel `none` now satisfies the claim-binding check, but **only**
when the gate independently confirms no claim resolves. Every other
combination keeps existing `wrongClaim` behavior verbatim:

- a non-`none` claim id on an unclaimed PR still fails closed
  (the exact regression #1077 fixed);
- the literal `none` on a PR that DOES have a resolvable active claim
  is also rejected `wrongClaim` -- the sentinel never routes around a
  genuine claim mismatch.

Also adds a `--claimless` flag to the `external-check-waiver`
authoring helper so a maintainer can render a claimless waiver marker
without hand-typing the HTML comment, and documents the marker grammar
and Terminal routing hold-message change (kept intentionally terse in
`idd-advisory-wait.instructions.md` to stay under the
`context-ceiling-128k` `bundle-review` byte budget, which was already
at its 98% ceiling before this change).

## Linked issue

Closes #1905

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Roadmap #1563 introduced `advisoryWait.convergenceScope` and its child
issue #1564 explicitly deferred "claimless maintainer waivers" as a
separate future change -- no follow-up was ever filed until #1905.
Refs #1563, #1564, #1567, #1077, #1686.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (3337/3337 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for claimless external-check waivers using the `none` claim identifier.
  - Added a `--claimless` option for creating waivers without a linked claim.
  - Claimless waivers require an actor and are rejected when an active claim exists.
- **Documentation**
  - Updated waiver guidance, marker rules, command usage, and dry-run examples.
- **Bug Fixes**
  - Improved validation to prevent mismatched claims and incorrectly applied claimless waivers.
- **Tests**
  - Added coverage for claimless waivers, validation conflicts, and fail-closed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->