### PR TITLE
docs(customization): correct the ubuntu-slim ownership claim

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -759,9 +759,13 @@ jobs:
     # optionally also covering issueAuthoring.authoringLabelName.
     if: |-
       contains(fromJSON('["<labeler-bot-login-1>", "<labeler-bot-login-2>"]'), github.event.sender.login) && (github.event.label.name == '<roadmap-label-name>' || github.event.label.name == '<blocked-by-human-label-name>' || github.event.label.name == '<needs-decision-label-name>')
-    # ubuntu-latest here (a portable GitHub-hosted label) rather than
-    # this source repository's own ubuntu-slim runner label -- adjust
-    # to your own fleet's standard small runner.
+    # ubuntu-latest here for maximum portability across time and
+    # adopters. ubuntu-slim -- GitHub's own leaner hosted Ubuntu image,
+    # not a runner private to this source repository -- is a valid
+    # alternative for this recipe's single `gh` CLI call. Verify this
+    # job's actual tool needs against the target image's published
+    # toolchain before switching:
+    # https://github.com/actions/runner-images
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -1572,7 +1576,15 @@ integration branch split applies:
 **Right-size the runner to the job**: lightweight automation (label
 hygiene, stale sweeps, advisory gates) on the smallest runner class,
 standard or larger runners reserved for genuinely heavyweight build or
-test jobs.
+test jobs. `ubuntu-slim` is a concrete example: GitHub's own leaner,
+lower-cost hosted Ubuntu image (see
+[`actions/runner-images`](https://github.com/actions/runner-images) for
+its published toolchain and the full catalog). Verify a job's actual
+tool needs against that catalog before switching -- a leaner image
+ships less preinstalled software than `ubuntu-latest`. Current
+per-minute rates are billed per GitHub's own
+[Actions billing usage docs](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions);
+this guide does not hard-code a price since rates change.
 
 These are repository-local optimizations; they do not change the IDD merge gate
 or the cross-agent workflow.

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -759,9 +759,13 @@ jobs:
     # optionally also covering issueAuthoring.authoringLabelName.
     if: |-
       contains(fromJSON('["<labeler-bot-login-1>", "<labeler-bot-login-2>"]'), github.event.sender.login) && (github.event.label.name == '<roadmap-label-name>' || github.event.label.name == '<blocked-by-human-label-name>' || github.event.label.name == '<needs-decision-label-name>')
-    # ubuntu-latest here (a portable GitHub-hosted label) rather than
-    # this source repository's own ubuntu-slim runner label -- adjust
-    # to your own fleet's standard small runner.
+    # ubuntu-latest here for maximum portability across time and
+    # adopters. ubuntu-slim -- GitHub's own leaner hosted Ubuntu image,
+    # not a runner private to this source repository -- is a valid
+    # alternative for this recipe's single `gh` CLI call. Verify this
+    # job's actual tool needs against the target image's published
+    # toolchain before switching:
+    # https://github.com/actions/runner-images
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -1572,7 +1576,15 @@ integration branch split applies:
 **Right-size the runner to the job**: lightweight automation (label
 hygiene, stale sweeps, advisory gates) on the smallest runner class,
 standard or larger runners reserved for genuinely heavyweight build or
-test jobs.
+test jobs. `ubuntu-slim` is a concrete example: GitHub's own leaner,
+lower-cost hosted Ubuntu image (see
+[`actions/runner-images`](https://github.com/actions/runner-images) for
+its published toolchain and the full catalog). Verify a job's actual
+tool needs against that catalog before switching -- a leaner image
+ships less preinstalled software than `ubuntu-latest`. Current
+per-minute rates are billed per GitHub's own
+[Actions billing usage docs](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions);
+this guide does not hard-code a price since rates change.
 
 These are repository-local optimizations; they do not change the IDD merge gate
 or the cross-agent workflow.


### PR DESCRIPTION
# Summary

`idd-template/docs/customization.md`'s "Reserved-label guard recipe" YAML
comment framed `ubuntu-slim` as "this source repository's own" runner
label. That premise is false: `ubuntu-slim` is one of GitHub's own
officially cataloged hosted runner images
([`actions/runner-images`](https://github.com/actions/runner-images)),
requestable by any GitHub account with no self-hosted setup, as GitHub's
own [`github/gh-aw`](https://github.com/github/gh-aw) already
demonstrates.

This PR:

- Replaces the false private-ownership framing in the Reserved-label
  guard recipe's YAML comment with an accurate one: `ubuntu-latest` is
  kept for portability, `ubuntu-slim` is a valid publicly-available
  alternative, and switching requires verifying the job's actual tool
  needs against the target image's published toolchain first (linking
  `actions/runner-images`).
- Names `ubuntu-slim` as a concrete example in the "CI cost discipline"
  appendix's "Right-size the runner to the job" bullet, linking
  `actions/runner-images` for the toolchain catalog and GitHub's Actions
  billing usage docs for current rates (no hard-coded price), with the
  same verify-first caveat.
- Regenerates `docs/customization.md` via `node scripts/sync-docs.mjs
  --apply` to match the canonical `idd-template` source.
- Leaves the "Reusable pnpm boundary guard workflow" input table's
  `runner` default row (`ubuntu-slim`) unchanged -- already accurate,
  out of scope.

Documentation-only change. No workflow files are touched and no runner
behavior changes.

## Linked issue

Closes #1910

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Issue #1911 (separate, still open) asks whether this repository's own
shipped `idd-advisory-convergence.yml` workflow should actually switch
to `ubuntu-slim`. This PR deliberately does not touch that workflow or
make that call -- it only corrects a documentation ownership claim and
adds a named example to an appendix, per #1910's own "out of scope"
item 3.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [ ] `pnpm test` (no test-relevant code changed; documentation only)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance on choosing portable hosted runners, including `ubuntu-latest` and `ubuntu-slim`.
  * Added recommendations to verify available tools against published runner images.
  * Expanded CI cost guidance with information about leaner runner options and links to runner and billing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->