### PR TITLE
feat(template): make idd-advisory-convergence's runner overridable

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -57,6 +57,7 @@ words:
   - minimizable
   - waivable
   - rollup
+  - GHEC
   - GHES
   - WHATWG
   - dedup

--- a/idd-template/.cspell.config.yml
+++ b/idd-template/.cspell.config.yml
@@ -57,6 +57,7 @@ words:
   - minimizable
   - waivable
   - rollup
+  - GHEC
   - GHES
   - WHATWG
   - dedup

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -8,13 +8,26 @@ name: IDD advisory-convergence gate
 # required-status-check-able workflow is a deliberate adopter decision,
 # not a default.
 #
-# Adjust `runs-on`, the pinned `actions/checkout` SHA (or use the
-# floating `@v4` tag as shipped here), the checkout `ref:` (see below),
-# and the `node scripts/...` command to your own runner labels and
-# helper-runtime profile. This file intentionally uses the portable
-# `ubuntu-latest` + `@v4` forms rather than a repository-specific
-# pinned SHA or custom runner label, unlike this source repository's
-# own dogfooded copy at .github/workflows/idd-advisory-convergence.yml.
+# Runner override: `runs-on` below reads the `CI_RUNNER_LABEL`
+# repository variable, falling back to `ubuntu-latest` when unset. Set
+# it from Settings > Secrets and variables > Actions > Variables >
+# CI_RUNNER_LABEL -- no workflow file edit needed. The primary
+# motivating case is GitHub Enterprise Server: GHES does not support
+# GitHub-hosted runners at all (self-hosted runners are mandatory
+# there), so `ubuntu-latest` fails outright on GHES regardless of
+# which label this template ships as the fallback. Any organization
+# that mandates self-hosted runners even on github.com/GHEC hits the
+# same wall and can use the same variable. This mechanism works for
+# whatever the shipped fallback value is now or later, not
+# specifically `ubuntu-latest`.
+#
+# Adjust the pinned `actions/checkout` SHA (or use the floating `@v4`
+# tag as shipped here), the checkout `ref:` (see below), and the
+# `node scripts/...` command to your own helper-runtime profile. This
+# file intentionally uses the portable `ubuntu-latest` fallback +
+# `@v4` forms rather than a repository-specific pinned SHA or a
+# hardcoded custom runner label, unlike this source repository's own
+# dogfooded copy at .github/workflows/idd-advisory-convergence.yml.
 concurrency:
   cancel-in-progress: true
   # Grouped by PR number, not github.ref: pull_request_review and
@@ -48,7 +61,8 @@ jobs:
   # preventive; no observed incident yet. If either edit is intentional,
   # update every consumer to the new literal context together.
   idd-advisory-convergence:
-    runs-on: ubuntu-latest
+    # See the header comment above for the CI_RUNNER_LABEL override.
+    runs-on: ${{ vars.CI_RUNNER_LABEL || 'ubuntu-latest' }}
     # Bounds pathological hangs; adjust to your own observed run duration
     # once you have history (see idd-doctor.yml/lint.yml in the source
     # repository for the pattern of sizing this from real run durations).

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -999,14 +999,21 @@ enable it. It is not wired in automatically by importing the rest of
 `idd-template/`, since adding a new required-status-check-able workflow
 is a deliberate adopter decision, not a default.
 
-Adjust the command to your helper-runtime profile, and `runs-on` / the
-`actions/checkout` version to your own runner labels — the mirrored
-file intentionally uses the portable `ubuntu-latest` + `@v4` forms.
-This source repository's own copy at
+Adjust the command to your helper-runtime profile, and the
+`actions/checkout` version if needed — the mirrored file intentionally
+uses the floating `@v4` form. Override the runner via the
+`CI_RUNNER_LABEL` repository variable (Settings > Secrets and
+variables > Actions > Variables) rather than hand-editing `runs-on`;
+it falls back to the portable `ubuntu-latest` when unset. Setting it
+is **required**, not optional, on GitHub Enterprise Server, which does
+not support GitHub-hosted runners at all — self-hosted runners are
+mandatory there, and the same variable also covers any organization
+that mandates self-hosted runners even on github.com/GHEC. This
+source repository's own copy at
 `.github/workflows/idd-advisory-convergence.yml` instead pins a
-specific `actions/checkout` SHA and a custom runner label, which is
-appropriate for its own hardened, dogfooded CI but not a requirement
-for adopters. This workflow is read-only: it never mutates GitHub
+specific `actions/checkout` SHA and hardcodes a custom runner label,
+which is appropriate for its own hardened, dogfooded CI but not a
+requirement for adopters. This workflow is read-only: it never mutates GitHub
 state, only queries the GitHub API for reviews, review threads, and
 waiver markers. `issues: read` is required in addition to
 `pull-requests: read` because the helper reads the PR's own


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`idd-template/.github/workflows/idd-advisory-convergence.yml`'s
`runs-on` was hardcoded to `ubuntu-latest`, which fails outright on
GitHub Enterprise Server (GHES does not support GitHub-hosted runners
at all -- self-hosted is mandatory there), and on any org that
mandates self-hosted runners even on github.com/GHEC. This PR makes
the runner overridable via a new `CI_RUNNER_LABEL` repository
variable, with the current literal (`ubuntu-latest`) staying the
fallback -- no workflow file edit needed to opt out.

- `runs-on: ubuntu-latest` -> `runs-on: ${{ vars.CI_RUNNER_LABEL ||
  'ubuntu-latest' }}`.
- Updated the workflow's header comment to name `CI_RUNNER_LABEL`,
  explain the GHES/self-hosted motivation, and point at
  `Settings > Secrets and variables > Actions > Variables >
  CI_RUNNER_LABEL` as the override path.
- Updated the matching `idd-template/ONBOARDING.md` guidance (a
  hand-written prose duplicate of the same recipe, not covered by the
  automated `sync-docs.mjs` manifest) so it doesn't go stale relative
  to the workflow's own comment.
- Added `GHEC` to the cspell word list (in the canonical
  `idd-template/.cspell.config.yml` source; `sync-docs.mjs --apply`
  confirms the generated root `.cspell.config.yml` mirror already
  agrees).

This source repository's own dogfooded
`.github/workflows/idd-advisory-convergence.yml` is deliberately
**unchanged** -- it already runs on a custom runner label
(`ubuntu-slim`) on a known github.com host, and is explicitly out of
scope per the issue.

This issue is deliberately independent of #1911 (still open,
`status:needs-decision`, about changing the *default* runner value):
this PR adds an override mechanism only and does not touch the
current `ubuntu-latest` default itself.

## Linked issue

Closes #1913

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`audit/sync-manifest.json`'s `root-cspell-config` pair makes
`idd-template/.cspell.config.yml` the canonical source and
`.cspell.config.yml` (repo root) the generated target. An earlier
commit on this branch added the new cspell word to the generated
target directly; a self-review critique pass caught the resulting
sync-mirror drift (`audit-docs.mjs --check` failure) before push, and
a follow-up commit corrected it at the canonical source.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
