### PR TITLE
chore(release): cut v0.6.0 — changelog synthesis, iddVersion bump

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.5.0",
+  "iddVersion": "0.6.0",
   "markerPrefix": "idd-skill",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,9 @@ waivers, and schema-documentation completeness release.
   indentation inside block boundaries, multiple candidate enclosing
   HTML block types, a fence opener under wide list padding, code
   spans stopping inside an open HTML block, and opened-tag matching
-  when closing a raw-text block — the shared tokenizer
-  suitability-triage's code-region masking depends on.
-- Suitability-triage hardening: masks markdown code regions in Check
+  when closing a raw-text block. Suitability-triage's Check 3
+  code-region masking depends on this shared tokenizer.
+- Suitability-triage hardening: masks Markdown code regions in Check
   3, requires the PR to reference the candidate issue, and surfaces
   existing A4.5 rejection comments instead of missing them.
 - Schema documentation completeness: per-property descriptions added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,11 +37,13 @@ waivers, and schema-documentation completeness release.
 
 - Markdown-code fence/list/HTML-block-boundary tracking hardened
   across a series of edge cases — nested container boundaries, opaque
-  fence state, list-content indentation inside block boundaries,
-  multiple candidate enclosing HTML block types, a fence opener under
-  wide list padding, code spans stopping inside an open HTML block,
-  and opened-tag matching when closing a raw-text block — the shared
-  tokenizer suitability-triage's code-region masking depends on.
+  fence state, an inline code span's enclosing-block context across
+  raw-text HTML elements and spaced thematic breaks, list-content
+  indentation inside block boundaries, multiple candidate enclosing
+  HTML block types, a fence opener under wide list padding, code
+  spans stopping inside an open HTML block, and opened-tag matching
+  when closing a raw-text block — the shared tokenizer
+  suitability-triage's code-region masking depends on.
 - Suitability-triage hardening: masks markdown code regions in Check
   3, requires the PR to reference the candidate issue, and surfaces
   existing A4.5 rejection comments instead of missing them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,69 @@ discipline and has no tag.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-07
+
+Markdown-code tokenizer hardening, advisory-convergence claimless
+waivers, and schema-documentation completeness release.
+
+### Added
+
+- `idd-advisory-convergence.yml`'s CI runner made overridable via a
+  `CI_RUNNER_LABEL` repository variable, and the `post-merge-cleanup.yml`
+  workflow mirrored into `idd-template/`.
+- Claimless external-check-waiver support: a claim-id `none` sentinel
+  recognized by the protocol helpers plus an authoring-CLI
+  `--claimless` flag, and an opt-in advisory-convergence applicability
+  exemption for bot-authored PRs with no claim history.
+- `--from-pr` live head-SHA derivation added to the `post-idd-marker`
+  helper for advisory marker types.
+- The pre-merge gate now hints at the missing-disposition phrase and a
+  stale-watermark case when it blocks.
+
+### Changed
+
+- Markdown-code fence/list/HTML-block-boundary tracking hardened
+  across a series of edge cases — nested container boundaries, opaque
+  fence state, list-content indentation inside block boundaries,
+  multiple candidate enclosing HTML block types, a fence opener under
+  wide list padding, code spans stopping inside an open HTML block,
+  and opened-tag matching when closing a raw-text block — the shared
+  tokenizer suitability-triage's code-region masking depends on.
+- Suitability-triage hardening: masks markdown code regions in Check
+  3, requires the PR to reference the candidate issue, and surfaces
+  existing A4.5 rejection comments instead of missing them.
+- Schema documentation completeness: per-property descriptions added
+  across the compact-contract, pre-merge-readiness, and
+  advisory/discovery-evidence published schemas, with a new test
+  enforcing that invariant repo-wide; a missing
+  `activation-nonce-mismatch` enum value added to
+  `pre-merge-readiness`'s `claim.reason`.
+- Onboarding hardening: package-manager/ephemeral-npx CI and
+  `allowBuilds` guidance completed, a hook-manager/`shellEmulator`
+  coexistence warning added, runtime-native issue-authoring paths
+  honored, doc-lint config shipped with the imported template, and a
+  recommendation to disable the ruleset's up-to-date-head requirement
+  for adopters who hit it.
+- `idd-doctor` fixes: granted GitHub API read scopes and `GH_TOKEN` in
+  CI, matches the hyphenated `copilot-advisory` literal, and scopes
+  its cleanup-backlog scan to IDD branches only.
+- `protocol-helpers` fixes: gates the `reviewDecision` `APPROVED`
+  bypass on data instead of trusting the label alone, and recognizes a
+  third Codex usage-limit notice trailer wording.
+- Misc docs: literal `npx` invocation forms shown per manifest-key, a
+  recommendation to prefer Codex reviewer subagents, a warning against
+  advisory job-name overrides, and a corrected `ubuntu-slim` ownership
+  claim.
+
+### Fixed
+
+- `rerun-advisory-convergence` recovers a stuck rollup when a live
+  review already covers HEAD.
+- `advisory-convergence` detects suppressed Copilot review findings.
+- `supersession-detection` requires an actual closing keyword next to
+  a PR reference, not just a bare reference, before treating it as a
+  superseding PR.
+
 ## [0.5.0] - 2026-08-02
 
 Weak-model "lite" profile, 128k context-budget ceiling, and

--- a/idd-template/.github/idd/config.json
+++ b/idd-template/.github/idd/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://kurone-kito.github.io/idd-skill/schemas/policy.schema.json",
-  "iddVersion": "0.5.0",
+  "iddVersion": "0.6.0",
   "markerPrefix": "{{PROJECT_MARKER_PREFIX}}",
   "mergePolicy": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kurone-kito/idd-skill",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "description": "Issue-Driven Development workflow assets",
   "license": "MIT",


### PR DESCRIPTION
# Summary

Cuts **v0.6.0** per the maintainer's direct instruction to pause
repository development temporarily, recorded on #1916, following the
`v0.5.0` playbook (`idd-skill#1710`, PR#1839), itself following the
`v0.4.0` playbook (`idd-skill#1260`, PR#1291).

- **Version bump**: `iddVersion` → `0.6.0` in `.github/idd/config.json`
  and `idd-template/.github/idd/config.json`, plus `package.json`
  `version` (the consistency test pins these in lockstep). A repo-wide
  grep for the project's own `0.5.0` version literal confirms no live
  reference remains — the historical `[0.5.0]` CHANGELOG heading
  excepted. This intentionally does not touch unrelated `0.5.0`
  matches in `pnpm-lock.yaml` (third-party dependency versions), which
  are not this project's release version and are out of this PR's
  scope.
- **CHANGELOG**: a `## [0.6.0] - 2026-08-07` section synthesizing the
  39 distinct pull requests merged since the `v0.5.0` tag
  (`v0.5.0..main` first-parent ancestry) as user-facing highlights
  under Added/Changed/Fixed at the `[0.5.0]` entry's editorial
  granularity — thematic clusters (markdown-code tokenizer hardening,
  suitability-triage hardening, schema documentation completeness,
  onboarding hardening, idd-doctor fixes, protocol-helpers fixes,
  claimless external-check-waiver support, advisory-convergence
  bot-authored-PR exemption, and misc docs), not a raw PR list. No
  `### Removed` section — nothing was deleted from the distributed
  surface this window, unlike `[0.5.0]`'s `agents/openai.yaml`
  removal. Accuracy was adversarially cross-checked against the full
  39-PR merged title list twice (two independent critique passes;
  the first found and fixed one genuine coverage gap — PR#1893's
  enclosing-block-context theme was initially missing from the
  markdown-code cluster paragraph — see commit history on this
  branch).

## Linked issue

Closes #1916

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

**Post-merge step (maintainer-authorized, tracked separately as
#1917):** after this PR merges, companion issue #1917 covers creating
the annotated tag on the merge commit and pushing it:

    git tag -a v0.6.0 -m "IDD workflow template v0.6.0" <merge-commit-sha>
    git push origin v0.6.0

This PR does not create or push any git tag — that is #1917's scope.
This release is tag + CHANGELOG only — no GitHub Release object
(confirmed via `gh release list`: none of the four prior tags,
`v0.2.0`-`v0.5.0`, has one).

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (no gate behavior changed; tag push
      is the documented, maintainer-authorized post-merge step tracked
      as #1917)
- [x] Context budget impact reviewed (docs+metadata-only change;
      CHANGELOG is not a budgeted bundle surface)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow and template enhancements, including configurable CI runners, advisory markers, and claimless waivers.
  * Improved tokenizer hardening, suitability triage, onboarding guidance, and pre-merge recommendations.
  * Expanded schema documentation and protocol helper guidance.
* **Bug Fixes**
  * Improved advisory reruns, Copilot finding visibility, and supersession detection.
* **Documentation**
  * Added comprehensive release documentation and updates to `idd-doctor` guidance.
* **Chores**
  * Updated the release to version 0.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->