### PR TITLE
docs(onboarding): correct issue-authoring companion publish description

### DIFF
--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -176,8 +176,13 @@ skill ID to multiple runtime roots by default (preventive; no observed incident
 yet); a mixed-runtime target should
 use one native copy plus an explicit manual route unless the operator
 deliberately accepts identical duplicates. The companion helps draft
-IDD-ready issues and roadmaps. It does not authorize publishing issues or
-starting the main execution loop on its own.
+IDD-ready issues and roadmaps. It publishes each drafted `ready` body
+directly under the configured authoring label once the mechanical
+pre-publish gate and critique pass both pass — no separate publish
+approval step. Releasing that authoring hold is the single boundary that
+still needs an explicit request: publishing alone does not start the main
+execution loop, because Discover treats a labeled issue as not startable
+while the hold remains.
 
 ### Helper runtime profile
 

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -176,13 +176,17 @@ skill ID to multiple runtime roots by default (preventive; no observed incident
 yet); a mixed-runtime target should
 use one native copy plus an explicit manual route unless the operator
 deliberately accepts identical duplicates. The companion helps draft
-IDD-ready issues and roadmaps. It publishes each drafted `ready` body
-directly under the configured authoring label once the mechanical
-pre-publish gate and critique pass both pass — no separate publish
-approval step. Releasing that authoring hold is the single boundary that
-still needs an explicit request: publishing alone does not start the main
-execution loop, because Discover treats a labeled issue as not startable
-while the hold remains.
+IDD-ready issues and roadmaps. By default, it publishes each drafted
+`ready` body directly under the configured authoring label once it
+passes the mechanical pre-publish gate and the critique pass — no
+separate publish approval step — unless the current request explicitly
+asked for a preview instead. Releasing that authoring hold is the
+single boundary within the companion's own workflow that still needs an
+explicit request: publishing under the hold alone does not start the
+main execution loop, because Discover treats an issue carrying the
+authoring label as not startable while the hold remains. The
+issue-author approval gate described above still applies independently
+once the hold is released.
 
 ### Helper runtime profile
 


### PR DESCRIPTION
# Summary

Corrects the issue-authoring companion's publish description in the
onboarding policy-decisions page for v0.6.0. `SKILL.md` steps 7-8 now
publish a drafted `ready` body directly under the authoring hold once
it clears the mechanical gate and the critique pass, reserving the
single explicit-request boundary for releasing the hold. This
onboarding page still told operators the companion "does not authorize
publishing issues", the opposite of what it now does. Rewrites the
sentence to state the publish-under-hold behavior, reserve the
explicit-request language for releasing the hold, and note that a
published-but-held issue is skipped by Discover so publishing alone
does not start execution.

## Linked issue

Closes #1932

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Field-reported from `kurone-kito/builder-config` and confirmed against
this repository's own file content at the v0.6.0 pin (see #1932), so
this is upstream's own onboarding page lagging its own `SKILL.md`, not
an adopter-side edit. No behavior changes in `SKILL.md` or
`workflow-boundary.md` — documentation-only correction confined to the
single candidate file.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no source bundle sync involved; single doc-only edit)
- [x] `node scripts/idd-doctor.mjs` (if applicable)
- [x] `pnpm run lint:minimum` (the issue's own acceptance-criteria gate)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that drafted ready issues and roadmaps are published automatically after the pre-publish checks and critique pass.
  - Documented that releasing the authoring hold still requires an explicit request.
  - Clarified that held issues are excluded from Discover’s startable work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->