### PR TITLE
fix(idd-doctor): scope cleanup backlog warning to IDD branch patterns

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1791,10 +1791,10 @@ function checkPostMergeCleanupBacklog(root, options, report) {
   // routine non-IDD merge (Dependabot dependency bumps, for example) never
   // created a branch the F4 cleanup-evidence contract applies to, so it
   // must not count toward the backlog total or the `Examples: ...` list.
-  const iddMergedPrs = filterIddBranchMergedPrs(
-    mergedPrs,
-    readWorktreeGuardBranchPatterns(root),
-  );
+  // Hoisted into a named variable (idd-skill#1936) so the warning text
+  // below can name the patterns actually in effect, not just apply them.
+  const branchPatterns = readWorktreeGuardBranchPatterns(root);
+  const iddMergedPrs = filterIddBranchMergedPrs(mergedPrs, branchPatterns);
   if (iddMergedPrs.length === 0) {
     return;
   }
@@ -1873,8 +1873,13 @@ function checkPostMergeCleanupBacklog(root, options, report) {
   const examplesText = verdict.examples.map((n) => `#${n}`).join(', ');
   const { profile, packageSpec } = resolveConfiguredHelperRuntime(root);
   const remediation = formatCleanupBacklogRemediation(profile, packageSpec);
+  // State the scoping explicitly (idd-skill#1936) so an operator reading a
+  // low count does not misread it as "no merged PRs in the window" --
+  // non-IDD merges (Dependabot bumps, etc.) are already excluded above and
+  // never reach this count.
+  const patternsText = branchPatterns.join(', ');
   report.warnings.push(
-    `post-merge cleanup backlog: ${verdict.count} merged PRs in the last ${windowDays} days lack F4 cleanup evidence (warn threshold: ${warnThreshold}). Examples: ${examplesText}. ${remediation}`,
+    `post-merge cleanup backlog: ${verdict.count} merged PRs in the last ${windowDays} days lack F4 cleanup evidence (warn threshold: ${warnThreshold}; scoped to IDD branch patterns: ${patternsText}). Examples: ${examplesText}. ${remediation}`,
   );
 }
 // Default drift thresholds (idd-skill#1269): warn when the checked-out HEAD

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -2102,10 +2102,10 @@ function checkPostMergeCleanupBacklog(
   // routine non-IDD merge (Dependabot dependency bumps, for example) never
   // created a branch the F4 cleanup-evidence contract applies to, so it
   // must not count toward the backlog total or the `Examples: ...` list.
-  const iddMergedPrs = filterIddBranchMergedPrs(
-    mergedPrs,
-    readWorktreeGuardBranchPatterns(root),
-  );
+  // Hoisted into a named variable (idd-skill#1936) so the warning text
+  // below can name the patterns actually in effect, not just apply them.
+  const branchPatterns = readWorktreeGuardBranchPatterns(root);
+  const iddMergedPrs = filterIddBranchMergedPrs(mergedPrs, branchPatterns);
   if (iddMergedPrs.length === 0) {
     return;
   }
@@ -2189,8 +2189,13 @@ function checkPostMergeCleanupBacklog(
   const examplesText = verdict.examples.map((n) => `#${n}`).join(', ');
   const { profile, packageSpec } = resolveConfiguredHelperRuntime(root);
   const remediation = formatCleanupBacklogRemediation(profile, packageSpec);
+  // State the scoping explicitly (idd-skill#1936) so an operator reading a
+  // low count does not misread it as "no merged PRs in the window" --
+  // non-IDD merges (Dependabot bumps, etc.) are already excluded above and
+  // never reach this count.
+  const patternsText = branchPatterns.join(', ');
   report.warnings.push(
-    `post-merge cleanup backlog: ${verdict.count} merged PRs in the last ${windowDays} days lack F4 cleanup evidence (warn threshold: ${warnThreshold}). Examples: ${examplesText}. ${remediation}`,
+    `post-merge cleanup backlog: ${verdict.count} merged PRs in the last ${windowDays} days lack F4 cleanup evidence (warn threshold: ${warnThreshold}; scoped to IDD branch patterns: ${patternsText}). Examples: ${examplesText}. ${remediation}`,
   );
 }
 

--- a/tests/idd-doctor-cleanup-backlog-cli-smoke.test.mts
+++ b/tests/idd-doctor-cleanup-backlog-cli-smoke.test.mts
@@ -268,5 +268,38 @@ test('checkPostMergeCleanupBacklog CLI: excludes a merged PR whose head ref is n
     );
     assert.match(backlogWarning ?? '', /#801/);
     assert.doesNotMatch(backlogWarning ?? '', /#802/);
+    // idd-skill#1936: the warning must state the count is scoped to IDD
+    // branch patterns (and name the patterns in effect), so an operator
+    // reading a low count does not misread it as "no merged PRs in the
+    // window" -- it is unaware of the non-IDD traffic filtered out above.
+    assert.match(backlogWarning ?? '', /scoped to IDD branch patterns/);
+    assert.match(backlogWarning ?? '', /issue\/\*/);
+    assert.match(backlogWarning ?? '', /roadmap-audit\/\*/);
+  });
+});
+
+// idd-skill#1936: when every merged PR in the window is on a non-IDD branch,
+// the scan must produce no backlog warning at all -- not just an empty
+// examples list -- guarding the early return right after
+// `filterIddBranchMergedPrs` in `checkPostMergeCleanupBacklog`.
+test('checkPostMergeCleanupBacklog CLI: produces no backlog warning when every merged PR is on a non-IDD branch (idd-skill#1936)', () => {
+  withTempCwd((cwd) => {
+    const report = runIddDoctorReport(
+      cwd,
+      buildCleanupBacklogStubGh({
+        owner: 'o',
+        repo: 'r',
+        mergedPrNumbers: [901, 902],
+        evidenceByPr: new Map(),
+        headRefNameByPr: new Map([
+          [901, 'dependabot/npm_and_yarn/lodash-4.17.21'],
+          [902, 'renovate/eslint-9.x'],
+        ]),
+      }),
+    );
+    assert.ok(
+      !report.warnings.some((w) => w.includes(BACKLOG_WARNING_SUBSTRING)),
+      `expected no cleanup-backlog warning when every PR is non-IDD, got: ${JSON.stringify(report.warnings)}`,
+    );
   });
 });

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -495,6 +495,17 @@ test('filterIddBranchMergedPrs honors a custom pattern list instead of the defau
   ]);
 });
 
+// idd-skill#1936: when every merged PR's head ref fails every configured
+// pattern (all non-IDD traffic in the window), the filter must return an
+// empty array rather than falling back to the unfiltered input.
+test('filterIddBranchMergedPrs returns an empty array when every entry is non-matching', () => {
+  const prs = [
+    { number: 401, headRefName: 'dependabot/npm_and_yarn/lodash-4.17.21' },
+    { number: 402, headRefName: 'renovate/eslint-9.x' },
+  ];
+  assert.deepEqual(filterIddBranchMergedPrs(prs), []);
+});
+
 test('classifyWorktreeHeadFinding returns null when HEAD is not a violation', () => {
   assert.equal(
     classifyWorktreeHeadFinding(


### PR DESCRIPTION
# Summary

`checkPostMergeCleanupBacklog`'s scan itself has been scoped to IDD
branch patterns since `kurone-kito/idd-skill#1829`
(`kurone-kito/idd-skill#1846`), but the emitted warning text never said
so — an operator reading a low count could still misread it as "no
merged PRs in the window" rather than "no IDD-worked merged PRs lack
cleanup evidence." This states the scoping explicitly and names the
configured `worktreeGuard.branchPatterns` in the message.

**Scope note for reviewers**: most of this issue's stated background
(no head-ref filtering at all) predates `#1846`, which shipped the
actual filtering 9 days before this issue was opened. Verified against
current `main` before starting — `src/scripts/idd-doctor.mts:2101-2111`
already calls `filterIddBranchMergedPrs` /
`readWorktreeGuardBranchPatterns`, with matching/non-matching/
custom-pattern coverage already in `tests/idd-doctor.test.mts` and a
mixed-branch CLI smoke test already in
`tests/idd-doctor-cleanup-backlog-cli-smoke.test.mts`. This PR delivers
only the two acceptance criteria left unmet: the warning-text scoping
statement, and the missing all-filtered-out test coverage. Full
reasoning posted to the issue before implementation:
<https://github.com/kurone-kito/idd-skill/issues/1936#issuecomment-5253113749>.

Changes:

- `src/scripts/idd-doctor.mts` (+ regenerated `scripts/idd-doctor.mjs`):
  hoist `readWorktreeGuardBranchPatterns(root)` into a named
  `branchPatterns` variable, then extend the backlog warning to state
  `scoped to IDD branch patterns: {patterns}` — no change to the fetch,
  evidence loop, `--require-github` behavior, or `gh` invocation count.
- `tests/idd-doctor.test.mts`: add a pure `filterIddBranchMergedPrs`
  case where every entry's head ref fails every configured pattern
  (all-filtered-out → `[]`).
- `tests/idd-doctor-cleanup-backlog-cli-smoke.test.mts`: add a CLI-level
  case asserting the early return (`iddMergedPrs.length === 0`) posts no
  backlog warning at all, and extend the existing mixed-branch case with
  assertions on the new scoping wording.

## Linked issue

Closes #1936

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Field-reported from `kurone-kito/setup.ubuntu`, where the backlog
warning fired repeatedly with a count mixing IDD and non-IDD merges —
by the time this issue was filed, the mixing itself was already fixed
by #1846, leaving only the messaging gap this PR closes.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
