### PR TITLE
fix(onboarding): give idd-doctor CI examples read scopes + GH_TOKEN

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -903,6 +903,8 @@ on:
   pull_request:
 permissions:
   contents: read
+  issues: read
+  pull-requests: read
 jobs:
   idd-doctor:
     runs-on: ubuntu-latest
@@ -912,6 +914,8 @@ jobs:
           ref: ${{ github.sha }} # detached HEAD keeps the worktree check inert
           persist-credentials: false
       - run: node scripts/idd-doctor.mjs
+        env:
+          GH_TOKEN: ${{ github.token }}
 ```
 
 **`package-manager`** — the helper ships as an installed
@@ -926,6 +930,8 @@ on:
   pull_request:
 permissions:
   contents: read
+  issues: read
+  pull-requests: read
 jobs:
   idd-doctor:
     runs-on: ubuntu-latest
@@ -941,6 +947,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec idd-doctor
+        env:
+          GH_TOKEN: ${{ github.token }}
 ```
 
 **`ephemeral-npx`** — no helper files or `devDependency` are vendored;
@@ -955,6 +963,8 @@ on:
   pull_request:
 permissions:
   contents: read
+  issues: read
+  pull-requests: read
 jobs:
   idd-doctor:
     runs-on: ubuntu-latest
@@ -967,7 +977,15 @@ jobs:
         with:
           node-version: 24.x
       - run: npx --yes --package <reviewed-helper-spec> idd-doctor
+        env:
+          GH_TOKEN: ${{ github.token }}
 ```
+
+Both the extra `permissions:` scopes and `GH_TOKEN` are required: without
+them, idd-doctor's GitHub-API-backed checks (post-merge cleanup backlog,
+branch protection, autopilot-suitability) silently degrade to a single
+warning line and the job still reports success — a green gate that
+checked less than it appears to.
 
 This gate checks repository **health**, not the disposable-worktree rule:
 CI cannot detect a primary-worktree B1 violation (it leaves no trace in

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -982,10 +982,14 @@ jobs:
 ```
 
 Both the extra `permissions:` scopes and `GH_TOKEN` are required: without
-them, idd-doctor's GitHub-API-backed checks (post-merge cleanup backlog,
-branch protection, autopilot-suitability) silently degrade to a single
-warning line and the job still reports success — a green gate that
-checked less than it appears to.
+them, idd-doctor's GitHub-API-backed checks (post-merge cleanup backlog
+and autopilot-suitability) silently degrade to a single warning line and
+the job still reports success — a green gate that checked less than it
+appears to. The branch-protection probe stays unreadable either way:
+its endpoint needs `Administration: read`, which isn't an available
+`GITHUB_TOKEN` permissions scope, so `branch protection not readable` is
+an expected, permanent warning under `GITHUB_TOKEN` rather than
+something these scopes fix.
 
 This gate checks repository **health**, not the disposable-worktree rule:
 CI cannot detect a primary-worktree B1 violation (it leaves no trace in

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -981,15 +981,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 ```
 
-Both the extra `permissions:` scopes and `GH_TOKEN` are required: without
-them, idd-doctor's GitHub-API-backed checks (post-merge cleanup backlog
-and autopilot-suitability) silently degrade to a single warning line and
-the job still reports success — a green gate that checked less than it
-appears to. The branch-protection probe stays unreadable either way:
-its endpoint needs `Administration: read`, which isn't an available
-`GITHUB_TOKEN` permissions scope, so `branch protection not readable` is
-an expected, permanent warning under `GITHUB_TOKEN` rather than
-something these scopes fix.
+Both the extra `permissions:` scopes and `GH_TOKEN` are required:
+without `GH_TOKEN`, `gh` has no credential, so idd-doctor's
+GitHub-API-backed checks silently skip or emit one generic warning,
+yet the job still reports success — a green gate that checked less
+than it appears to. With them, the post-merge cleanup backlog and
+autopilot-suitability checks actually run instead of being silently
+skipped. The branch-protection probe stays unreadable regardless: it
+needs a repository-administration permission that GitHub Actions'
+`permissions:` model can't grant to `GITHUB_TOKEN`, so it keeps
+warning even with these scopes added.
 
 This gate checks repository **health**, not the disposable-worktree rule:
 CI cannot detect a primary-worktree B1 violation (it leaves no trace in

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -985,12 +985,13 @@ Both the extra `permissions:` scopes and `GH_TOKEN` are required:
 without `GH_TOKEN`, `gh` has no credential, so idd-doctor's
 GitHub-API-backed checks silently skip or emit one generic warning,
 yet the job still reports success — a green gate that checked less
-than it appears to. With them, the post-merge cleanup backlog and
-autopilot-suitability checks actually run instead of being silently
-skipped. The branch-protection probe stays unreadable regardless: it
-needs a repository-administration permission that GitHub Actions'
-`permissions:` model can't grant to `GITHUB_TOKEN`, so it keeps
-warning even with these scopes added.
+than it appears to (observed on this repository's own workflow,
+kurone-kito/idd-skill#1828). With them, the post-merge cleanup backlog
+and autopilot-suitability checks actually run instead of being
+silently skipped. The branch-protection probe stays unreadable
+regardless: it needs a repository-administration permission that
+GitHub Actions' `permissions:` model can't grant to `GITHUB_TOKEN`, so
+it keeps warning even with these scopes added.
 
 This gate checks repository **health**, not the disposable-worktree rule:
 CI cannot detect a primary-worktree B1 violation (it leaves no trace in


### PR DESCRIPTION
# Summary

Bring the three profile-specific `idd-doctor` CI health-gate examples in
`idd-template/ONBOARDING.md` in line with this repository's own
already-fixed `.github/workflows/idd-doctor.yml` (commit `29133a94`), so
an adopter who copies an example verbatim doesn't get a gate whose
GitHub-API-backed checks silently never run.

## Linked issue

Closes #1926

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`idd-doctor`'s GitHub-API-backed checks (post-merge cleanup backlog,
branch protection, autopilot-suitability) call `gh`. With no credential
in the environment they degrade to a single warning line and the run
still reports success — graceful degradation that is correct by design.
This repository's own dogfood workflow was fixed for that already
(`issues: read` + `pull-requests: read` permissions, plus
`env: GH_TOKEN: ${{ github.token }}`), but the adopter-facing
`ONBOARDING.md` examples were not updated with it. `ONBOARDING.md` is a
single-copy file under `idd-template/` with no repository-root mirror,
so no sync pair is involved.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (not applicable — `ONBOARDING.md` has no sync pair)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
