### PR TITLE
docs(customization): add full-history sweep for label-guard actor list

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -740,10 +740,11 @@ The recipe below adapts that workflow for adopters. Save it as
   the event's `sender` (not a GraphQL-rendered display name). This is
   independent of, and not necessarily identical to, any
   `advisoryBotLogins` configured for PR review — list only the
-  actor(s) that auto-label **issues**. ("Issues" here contrasts with
-  `advisoryBotLogins`' PR-review role — it does not exclude a bot the
-  sweep shows labeling only pull requests; the workflow's
-  `pull_request_target: labeled` trigger below uses this same list.)
+  actor(s) that auto-label **issues**. (This does not exclude a bot the
+  sweep shows labeling only pull requests: "issues" here contrasts with
+  `advisoryBotLogins`' PR-_review_ role, not the events this actor list
+  guards — the workflow's `pull_request_target: labeled` trigger below
+  reuses this same list.)
 
 This recipe guards the three policy-decision labels only. If this
 repository also configures `issueAuthoring.authoringLabelName`

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -721,9 +721,9 @@ The recipe below adapts that workflow for adopters. Save it as
   runs. Build the complete list with a full-history sweep, not a single
   observed event: read the paginated
   `GET /repos/{owner}/{repo}/issues/events` endpoint to completion,
-  keeping only entries where `event == "labeled"` and the acting
-  actor's `type` is `Bot`. That endpoint returns issue and pull request
-  events together, so this one sweep needs no separate PR-side pass.
+  keeping only entries where `event == "labeled"` and the actor's
+  `type` is `Bot`. That endpoint returns issue and pull request events
+  together, so this one sweep needs no separate PR-side pass.
   Filter the sweep's results down to the actor(s) recognized as an
   untrusted semantic auto-labeler — exclude any bot already trusted to
   apply these labels on purpose (for example, this repository's own IDD
@@ -740,7 +740,10 @@ The recipe below adapts that workflow for adopters. Save it as
   the event's `sender` (not a GraphQL-rendered display name). This is
   independent of, and not necessarily identical to, any
   `advisoryBotLogins` configured for PR review — list only the
-  actor(s) that auto-label **issues**.
+  actor(s) that auto-label **issues**. ("Issues" here contrasts with
+  `advisoryBotLogins`' PR-review role — it does not exclude a bot the
+  sweep shows labeling only pull requests; the workflow's
+  `pull_request_target: labeled` trigger below uses this same list.)
 
 This recipe guards the three policy-decision labels only. If this
 repository also configures `issueAuthoring.authoringLabelName`

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -724,15 +724,23 @@ The recipe below adapts that workflow for adopters. Save it as
   keeping only entries where `event == "labeled"` and the acting
   actor's `type` is `Bot`. That endpoint returns issue and pull request
   events together, so this one sweep needs no separate PR-side pass.
-  The sweep also buys something a single observed event cannot: it can
-  positively confirm a bot **never** labels, so a configured review bot
-  can be left out of this list on evidence instead of assumption.
-  Between sweeps, validate any single newly observed labeler the same
-  way — confirmed via the REST simple-user object's `login` and
-  `type: Bot` fields directly on the event's `sender` (not a
-  GraphQL-rendered display name). This is independent of, and not
-  necessarily identical to, any `advisoryBotLogins` configured for PR
-  review — list only the actor(s) that auto-label **issues**.
+  Filter the sweep's results down to the actor(s) recognized as an
+  untrusted semantic auto-labeler — exclude any bot already trusted to
+  apply these labels on purpose (for example, this repository's own IDD
+  or CI automation), or the guard will strip a label that automation
+  intentionally applied. The sweep also buys something a single
+  observed event cannot: it can confirm that, as of the sweep, a bot
+  has never labeled, so a configured review bot with no matching
+  history can be left out of this list on that evidence instead of
+  assumption. That absence is not permanent — re-run the sweep after
+  enabling new automation or after a long gap, since a bot with no
+  history yet can still start labeling later. Between sweeps, validate
+  any single newly observed labeler the same way — confirmed via the
+  REST simple-user object's `login` and `type: Bot` fields directly on
+  the event's `sender` (not a GraphQL-rendered display name). This is
+  independent of, and not necessarily identical to, any
+  `advisoryBotLogins` configured for PR review — list only the
+  actor(s) that auto-label **issues**.
 
 This recipe guards the three policy-decision labels only. If this
 repository also configures `issueAuthoring.authoringLabelName`

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -742,7 +742,7 @@ The recipe below adapts that workflow for adopters. Save it as
   `advisoryBotLogins` configured for PR review — list only the
   actor(s) that auto-label **issues**. (This does not exclude a bot the
   sweep shows labeling only pull requests: "issues" here contrasts with
-  `advisoryBotLogins`' PR-_review_ role, not the events this actor list
+  `advisoryBotLogins`' PR-review role, not the events this actor list
   guards — the workflow's `pull_request_target: labeled` trigger below
   reuses this same list.)
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -732,9 +732,11 @@ The recipe below adapts that workflow for adopters. Save it as
   observed event cannot: it can confirm that, as of the sweep, a bot
   has never labeled, so a configured review bot with no matching
   history can be left out of this list on that evidence instead of
-  assumption. That absence is not permanent — re-run the sweep after
-  enabling new automation or after a long gap, since a bot with no
-  history yet can still start labeling later. Between sweeps, validate
+  assumption (field-reported 2026-08-11, kurone-kito/idd-skill#1928).
+  That absence is not permanent — re-run the sweep after enabling new
+  automation or after a long gap, since a bot with no history yet can
+  still start labeling later (preventive; no observed incident yet).
+  Between sweeps, validate
   any single newly observed labeler the same way — confirmed via the
   REST simple-user object's `login` and `type: Bot` fields directly on
   the event's `sender` (not a GraphQL-rendered display name). This is

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -718,7 +718,17 @@ The recipe below adapts that workflow for adopters. Save it as
   labels must guard the names it actually uses.
 - `<labeler-bot-login-1>`, `<labeler-bot-login-2>`, ...: the login(s) of
   whichever semantic issue auto-labeler(s) this repository actually
-  runs, confirmed via the REST simple-user object's `login` and
+  runs. Build the complete list with a full-history sweep, not a single
+  observed event: read the paginated
+  `GET /repos/{owner}/{repo}/issues/events` endpoint to completion,
+  keeping only entries where `event == "labeled"` and the acting
+  actor's `type` is `Bot`. That endpoint returns issue and pull request
+  events together, so this one sweep needs no separate PR-side pass.
+  The sweep also buys something a single observed event cannot: it can
+  positively confirm a bot **never** labels, so a configured review bot
+  can be left out of this list on evidence instead of assumption.
+  Between sweeps, validate any single newly observed labeler the same
+  way — confirmed via the REST simple-user object's `login` and
   `type: Bot` fields directly on the event's `sender` (not a
   GraphQL-rendered display name). This is independent of, and not
   necessarily identical to, any `advisoryBotLogins` configured for PR

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -740,10 +740,11 @@ The recipe below adapts that workflow for adopters. Save it as
   the event's `sender` (not a GraphQL-rendered display name). This is
   independent of, and not necessarily identical to, any
   `advisoryBotLogins` configured for PR review — list only the
-  actor(s) that auto-label **issues**. ("Issues" here contrasts with
-  `advisoryBotLogins`' PR-review role — it does not exclude a bot the
-  sweep shows labeling only pull requests; the workflow's
-  `pull_request_target: labeled` trigger below uses this same list.)
+  actor(s) that auto-label **issues**. (This does not exclude a bot the
+  sweep shows labeling only pull requests: "issues" here contrasts with
+  `advisoryBotLogins`' PR-_review_ role, not the events this actor list
+  guards — the workflow's `pull_request_target: labeled` trigger below
+  reuses this same list.)
 
 This recipe guards the three policy-decision labels only. If this
 repository also configures `issueAuthoring.authoringLabelName`

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -721,9 +721,9 @@ The recipe below adapts that workflow for adopters. Save it as
   runs. Build the complete list with a full-history sweep, not a single
   observed event: read the paginated
   `GET /repos/{owner}/{repo}/issues/events` endpoint to completion,
-  keeping only entries where `event == "labeled"` and the acting
-  actor's `type` is `Bot`. That endpoint returns issue and pull request
-  events together, so this one sweep needs no separate PR-side pass.
+  keeping only entries where `event == "labeled"` and the actor's
+  `type` is `Bot`. That endpoint returns issue and pull request events
+  together, so this one sweep needs no separate PR-side pass.
   Filter the sweep's results down to the actor(s) recognized as an
   untrusted semantic auto-labeler — exclude any bot already trusted to
   apply these labels on purpose (for example, this repository's own IDD
@@ -740,7 +740,10 @@ The recipe below adapts that workflow for adopters. Save it as
   the event's `sender` (not a GraphQL-rendered display name). This is
   independent of, and not necessarily identical to, any
   `advisoryBotLogins` configured for PR review — list only the
-  actor(s) that auto-label **issues**.
+  actor(s) that auto-label **issues**. ("Issues" here contrasts with
+  `advisoryBotLogins`' PR-review role — it does not exclude a bot the
+  sweep shows labeling only pull requests; the workflow's
+  `pull_request_target: labeled` trigger below uses this same list.)
 
 This recipe guards the three policy-decision labels only. If this
 repository also configures `issueAuthoring.authoringLabelName`

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -724,15 +724,23 @@ The recipe below adapts that workflow for adopters. Save it as
   keeping only entries where `event == "labeled"` and the acting
   actor's `type` is `Bot`. That endpoint returns issue and pull request
   events together, so this one sweep needs no separate PR-side pass.
-  The sweep also buys something a single observed event cannot: it can
-  positively confirm a bot **never** labels, so a configured review bot
-  can be left out of this list on evidence instead of assumption.
-  Between sweeps, validate any single newly observed labeler the same
-  way — confirmed via the REST simple-user object's `login` and
-  `type: Bot` fields directly on the event's `sender` (not a
-  GraphQL-rendered display name). This is independent of, and not
-  necessarily identical to, any `advisoryBotLogins` configured for PR
-  review — list only the actor(s) that auto-label **issues**.
+  Filter the sweep's results down to the actor(s) recognized as an
+  untrusted semantic auto-labeler — exclude any bot already trusted to
+  apply these labels on purpose (for example, this repository's own IDD
+  or CI automation), or the guard will strip a label that automation
+  intentionally applied. The sweep also buys something a single
+  observed event cannot: it can confirm that, as of the sweep, a bot
+  has never labeled, so a configured review bot with no matching
+  history can be left out of this list on that evidence instead of
+  assumption. That absence is not permanent — re-run the sweep after
+  enabling new automation or after a long gap, since a bot with no
+  history yet can still start labeling later. Between sweeps, validate
+  any single newly observed labeler the same way — confirmed via the
+  REST simple-user object's `login` and `type: Bot` fields directly on
+  the event's `sender` (not a GraphQL-rendered display name). This is
+  independent of, and not necessarily identical to, any
+  `advisoryBotLogins` configured for PR review — list only the
+  actor(s) that auto-label **issues**.
 
 This recipe guards the three policy-decision labels only. If this
 repository also configures `issueAuthoring.authoringLabelName`

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -742,7 +742,7 @@ The recipe below adapts that workflow for adopters. Save it as
   `advisoryBotLogins` configured for PR review — list only the
   actor(s) that auto-label **issues**. (This does not exclude a bot the
   sweep shows labeling only pull requests: "issues" here contrasts with
-  `advisoryBotLogins`' PR-_review_ role, not the events this actor list
+  `advisoryBotLogins`' PR-review role, not the events this actor list
   guards — the workflow's `pull_request_target: labeled` trigger below
   reuses this same list.)
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -732,9 +732,11 @@ The recipe below adapts that workflow for adopters. Save it as
   observed event cannot: it can confirm that, as of the sweep, a bot
   has never labeled, so a configured review bot with no matching
   history can be left out of this list on that evidence instead of
-  assumption. That absence is not permanent — re-run the sweep after
-  enabling new automation or after a long gap, since a bot with no
-  history yet can still start labeling later. Between sweeps, validate
+  assumption (field-reported 2026-08-11, kurone-kito/idd-skill#1928).
+  That absence is not permanent — re-run the sweep after enabling new
+  automation or after a long gap, since a bot with no history yet can
+  still start labeling later (preventive; no observed incident yet).
+  Between sweeps, validate
   any single newly observed labeler the same way — confirmed via the
   REST simple-user object's `login` and `type: Bot` fields directly on
   the event's `sender` (not a GraphQL-rendered display name). This is

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -718,7 +718,17 @@ The recipe below adapts that workflow for adopters. Save it as
   labels must guard the names it actually uses.
 - `<labeler-bot-login-1>`, `<labeler-bot-login-2>`, ...: the login(s) of
   whichever semantic issue auto-labeler(s) this repository actually
-  runs, confirmed via the REST simple-user object's `login` and
+  runs. Build the complete list with a full-history sweep, not a single
+  observed event: read the paginated
+  `GET /repos/{owner}/{repo}/issues/events` endpoint to completion,
+  keeping only entries where `event == "labeled"` and the acting
+  actor's `type` is `Bot`. That endpoint returns issue and pull request
+  events together, so this one sweep needs no separate PR-side pass.
+  The sweep also buys something a single observed event cannot: it can
+  positively confirm a bot **never** labels, so a configured review bot
+  can be left out of this list on evidence instead of assumption.
+  Between sweeps, validate any single newly observed labeler the same
+  way — confirmed via the REST simple-user object's `login` and
   `type: Bot` fields directly on the event's `sender` (not a
   GraphQL-rendered display name). This is independent of, and not
   necessarily identical to, any `advisoryBotLogins` configured for PR


### PR DESCRIPTION
# Summary

The reserved-label guard recipe's actor-list bullet only described
confirming one observed labeling event (via the REST simple-user
`login` / `type: Bot` fields on the event's `sender`). That method
validates one event; it gives no way to establish the **complete**
actor list and no way to assert an absence. This adds the paginated
`GET /repos/{owner}/{repo}/issues/events` full-history sweep, filtered
to `labeled` events with a `Bot`-type actor, as the recommended way to
build the complete list. The sweep can positively confirm a bot never
labels (so a configured review bot can be left out of the guard on
evidence, not assumption) and covers issues and pull requests in one
endpoint. The existing per-event `type: Bot` confirmation is kept as
the way to validate a single newly observed actor between sweeps, and
the existing warning against copying this repository's own
`advisoryBotLogins` pair unconditionally is preserved verbatim.

## Linked issue

Closes #1928

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Field-reported from `kurone-kito/builder-config`, which ran the
full-history sweep and positively ruled out two already-configured
review bots that had never applied a label, something the per-event
method cannot produce.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
