### PR TITLE
fix(cli-args): strip leading -- pnpm forwards via run-script alias

### DIFF
--- a/scripts/cli-args.mjs
+++ b/scripts/cli-args.mjs
@@ -239,10 +239,32 @@ export function parseCliArgs(argv, spec) {
     }
     nodeOptions[dashedKey.slice(2)] = flagSpec;
   }
+  // #1921: pnpm forwards a literal `--` through a `pnpm run <script> --
+  // <flags>` alias without stripping it first (unlike `npm run`, which
+  // consumes its own separator before the script ever sees argv). Node's
+  // `util.parseArgs` treats that leading `--` as the conventional
+  // end-of-options marker, so every flag after it gets rejected as an
+  // unexpected positional under `allowPositionals: false` -- strip
+  // exactly one leading `--` here so a pnpm-forwarded invocation parses
+  // the same as the equivalent bare form. Scope is deliberately one
+  // token at position 0 only; a `--` anywhere else in argv keeps its
+  // current behavior unchanged.
+  const args = argv[0] === '--' ? argv.slice(1) : argv;
+  // A second literal `--` immediately after the stripped one (i.e. argv
+  // started `--`, `--`, ...) must still be a hard error, not silently
+  // swallowed. Without this guard, stripping once would leave a lone
+  // trailing `--` for Node to consume as its own terminator with zero
+  // positionals -- a NEW silent-success hole `parseCliArgs(['--', '--'],
+  // spec)` does not have today (it currently throws `unknown argument:
+  // --`, since the second `--` becomes a rejected positional). The strip
+  // above never repeats -- this is a single explicit check, not a loop.
+  if (args[0] === '--') {
+    throw new Error('unknown argument: --');
+  }
   let parsed;
   try {
     parsed = nodeParseArgs({
-      args: disambiguateSingleDashValues(argv, spec),
+      args: disambiguateSingleDashValues(args, spec),
       options: nodeOptions,
       strict: true,
       allowPositionals: false,

--- a/src/scripts/cli-args.mts
+++ b/src/scripts/cli-args.mts
@@ -312,10 +312,33 @@ export function parseCliArgs(
     nodeOptions[dashedKey.slice(2)] = flagSpec;
   }
 
+  // #1921: pnpm forwards a literal `--` through a `pnpm run <script> --
+  // <flags>` alias without stripping it first (unlike `npm run`, which
+  // consumes its own separator before the script ever sees argv). Node's
+  // `util.parseArgs` treats that leading `--` as the conventional
+  // end-of-options marker, so every flag after it gets rejected as an
+  // unexpected positional under `allowPositionals: false` -- strip
+  // exactly one leading `--` here so a pnpm-forwarded invocation parses
+  // the same as the equivalent bare form. Scope is deliberately one
+  // token at position 0 only; a `--` anywhere else in argv keeps its
+  // current behavior unchanged.
+  const args = argv[0] === '--' ? argv.slice(1) : argv;
+  // A second literal `--` immediately after the stripped one (i.e. argv
+  // started `--`, `--`, ...) must still be a hard error, not silently
+  // swallowed. Without this guard, stripping once would leave a lone
+  // trailing `--` for Node to consume as its own terminator with zero
+  // positionals -- a NEW silent-success hole `parseCliArgs(['--', '--'],
+  // spec)` does not have today (it currently throws `unknown argument:
+  // --`, since the second `--` becomes a rejected positional). The strip
+  // above never repeats -- this is a single explicit check, not a loop.
+  if (args[0] === '--') {
+    throw new Error('unknown argument: --');
+  }
+
   let parsed: ReturnType<typeof nodeParseArgs>;
   try {
     parsed = nodeParseArgs({
-      args: disambiguateSingleDashValues(argv, spec),
+      args: disambiguateSingleDashValues(args, spec),
       options: nodeOptions,
       strict: true,
       allowPositionals: false,

--- a/tests/cli-args.test.mts
+++ b/tests/cli-args.test.mts
@@ -149,6 +149,54 @@ test('parseCliArgs: positionals is always empty (allowPositionals: false)', () =
   assert.deepEqual(positionals, []);
 });
 
+// --- Leading `--` stripping (#1921) -----------------------------------------
+// pnpm forwards a literal `--` through `pnpm run <script> -- <flags>`
+// without stripping it (unlike npm, which strips its own separator first),
+// so every migrated helper crashed with "unknown argument: --help" under
+// that invocation form. parseCliArgs must strip exactly one leading `--`
+// before Node ever sees argv.
+
+test('parseCliArgs: a single leading -- is stripped, parsing identically to the bare form', () => {
+  const withSeparator = parseCliArgs(['--', '--help'], SAMPLE_SPEC);
+  const bare = parseCliArgs(['--help'], SAMPLE_SPEC);
+  assert.deepEqual(withSeparator, bare);
+});
+
+test('parseCliArgs: a leading -- still resolves a following flag to its value', () => {
+  const { values } = parseCliArgs(['--', '--pr', '7'], SAMPLE_SPEC);
+  assert.equal(values.pr, '7');
+});
+
+test('parseCliArgs: a doubled leading -- -- still throws (the strip never repeats)', () => {
+  // Only ONE leading `--` is ever stripped -- the resulting post-strip
+  // argv[0] is checked once, not looped, so a second literal `--` at
+  // position 0 remains a hard error rather than being silently consumed
+  // as Node's own end-of-options terminator.
+  assert.throws(() => parseCliArgs(['--', '--', '--help'], SAMPLE_SPEC), {
+    message: 'unknown argument: --',
+  });
+});
+
+test('parseCliArgs: a bare doubled -- -- (no trailing flag) still throws, not silently accepted', () => {
+  // Without the explicit post-strip guard, stripping the first `--` would
+  // leave a lone trailing `--` for Node to consume as its own terminator
+  // with zero positionals -- silently succeeding instead of erroring, and
+  // contradicting the established "a second literal -- stays an error"
+  // contract (verified against this repository's current, unpatched
+  // behavior for this exact input, which already throws this way).
+  assert.throws(() => parseCliArgs(['--', '--'], SAMPLE_SPEC), {
+    message: 'unknown argument: --',
+  });
+});
+
+test('parseCliArgs: a -- appearing anywhere other than index 0 keeps its current behavior', () => {
+  // A trailing (non-leading) `--` is consumed by Node as the end-of-options
+  // terminator with no positionals following it, so it parses successfully
+  // -- this must stay unchanged by the leading-only strip above.
+  const { values } = parseCliArgs(['--pr', '7', '--'], SAMPLE_SPEC);
+  assert.equal(values.pr, '7');
+});
+
 // --- parseCanonicalIntegerOrThrow / parseCanonicalIntegerOrNull -------------
 // Both integer contracts named in #1446's acceptance criteria: throw (e.g.
 // ci-wait-policy.mts's --rerun-count) and resolve-to-null (e.g.


### PR DESCRIPTION
# Summary

pnpm forwards a literal `--` through a `pnpm run <script> -- <flags>`
alias without stripping it first (unlike `npm run`, which strips its
own separator before the script ever sees `argv`). Every helper
migrated onto `parseCliArgs` (`src/scripts/cli-args.mts`) crashed with
an unhandled `unknown argument: --help`-style exception under that
invocation form, because Node's `util.parseArgs` treats the forwarded
`--` as the conventional end-of-options marker and rejects everything
after it as an unexpected positional under `allowPositionals: false`.

`parseCliArgs` now strips exactly one leading `--` from `argv` before
handing it to `disambiguateSingleDashValues`/`nodeParseArgs`, mirroring
what `npm run` already does on the caller's behalf. Scope is
deliberately one token at position 0 only — a `--` anywhere else in
`argv` keeps its current behavior unchanged, and the strip itself never
repeats.

**One deviation from the issue's literal one-line proposed snippet**,
verified empirically and recorded on the issue before implementation
(see the plan comment): a bare `const args = argv[0] === '--' ?
argv.slice(1) : argv;` satisfies 3 of the issue's 4 acceptance rows, but
changes the doubled `-- -- --help` case's thrown error token from `--`
to `--help`, and opens a **new** silent-success hole for the bare
`['--', '--']` input that the unpatched repository does not have today
(it currently throws `unknown argument: --`). The implemented fix adds
one explicit post-strip guard — `if (args[0] === '--') { throw new
Error('unknown argument: --'); }` — closing that hole and matching
every acceptance row exactly, including the extra `['--', '--']` case,
without looping the strip or introducing new
end-of-options/positional-collection semantics.

## Linked issue

Closes #1921

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

While validating this change, `pnpm run build` was observed to flip the
executable bit on every `bin/*.mjs` file relative to the committed tree
(`100644` → `100755`) whenever `core.fileMode` is `true` locally —
traced instead to `npx` itself chmod'ing the resolved bin script on
invocation, not to the build step. This is pre-existing, environment-
driven, and unrelated to every file this PR touches (`scripts/cli-args.mjs`,
which the build step does regenerate, carries no mode change). No
`bin/*.mjs` file is part of this diff.

## IDD impact

- [ ] Instruction files changed
- [x] Helper scripts changed (`parseCliArgs`, the shared `util.parseArgs`
      wrapper every migrated `idd-*` CLI helper depends on)
- [ ] Template files changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (3342 passed)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed, 3 pre-existing warnings
      unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (none)
