### PR TITLE
docs(appendix): align commit-signing note with tiered SSH fallback

### DIFF
--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -91,7 +91,7 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 
 ## Commit signing
 
-When it fails, check `docs/idd-helper-scripts.md`'s Signed-Commit
+When it hangs, check `docs/idd-helper-scripts.md`'s Signed-Commit
 Merge Wrapper; never permanently rewrite config. `--no-gpg-sign` on
 `git commit`/`git merge` is the last resort.
 

--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -92,11 +92,11 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 ## Commit signing
 
 When it blocks, check `docs/idd-helper-scripts.md`'s Signed-Commit
-Merge Wrapper; never permanently rewrite config. `--no-gpg-sign` on
-`git commit`/`git merge` is the last resort.
+Merge Wrapper; never permanently rewrite signing config. `--no-gpg-sign`
+on `git commit`/`git merge` is the last resort.
 
 Record material progress, decisions, and hold reasons as issue or PR
-comments at the time they are made. This ensures that any agent resuming
+comments as they happen. This ensures that any agent resuming
 without session context can understand the current state and continue
 correctly. Do not rely on session memory alone for information that
 another agent may need.

--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -91,9 +91,9 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 
 ## Commit signing
 
-When pinentry blocks signing, check `docs/idd-helper-scripts.md`'s
-Signed-Commit Merge Wrapper; never permanently rewrite signing config.
-`--no-gpg-sign` is the last resort.
+When it fails, check `docs/idd-helper-scripts.md`'s Signed-Commit
+Merge Wrapper; never permanently rewrite config. `--no-gpg-sign` on
+`git commit`/`merge` is the last resort.
 
 Record material progress, decisions, and hold reasons as issue or PR
 comments at the time they are made. This ensures that any agent resuming

--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -93,7 +93,7 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 
 When it fails, check `docs/idd-helper-scripts.md`'s Signed-Commit
 Merge Wrapper; never permanently rewrite config. `--no-gpg-sign` on
-`git commit`/`merge` is the last resort.
+`git commit`/`git merge` is the last resort.
 
 Record material progress, decisions, and hold reasons as issue or PR
 comments at the time they are made. This ensures that any agent resuming

--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -92,7 +92,7 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 ## Commit signing
 
 Check `docs/idd-helper-scripts.md`'s Signed-Commit Merge Wrapper for a
-fallback, never permanently rewriting signing config; add
+fallback and never permanently rewrite signing config; add
 `--no-gpg-sign` only when none resolves.
 
 Record material progress, decisions, and hold reasons as issue or PR

--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -91,7 +91,7 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 
 ## Commit signing
 
-Check `docs/idd-helper-scripts.md`'s signed-commit merge wrapper for a
+Check `docs/idd-helper-scripts.md`'s Signed-Commit Merge Wrapper for a
 fallback, never permanently rewriting signing config; add
 `--no-gpg-sign` only when none resolves.
 

--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -91,7 +91,7 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 
 ## Commit signing
 
-When it hangs, check `docs/idd-helper-scripts.md`'s Signed-Commit
+When it blocks, check `docs/idd-helper-scripts.md`'s Signed-Commit
 Merge Wrapper; never permanently rewrite config. `--no-gpg-sign` on
 `git commit`/`git merge` is the last resort.
 

--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -91,9 +91,9 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 
 ## Commit signing
 
-Check `docs/idd-helper-scripts.md`'s Signed-Commit Merge Wrapper for a
-fallback and never permanently rewrite signing config; add
-`--no-gpg-sign` only when none resolves.
+When pinentry blocks signing, check `docs/idd-helper-scripts.md`'s
+Signed-Commit Merge Wrapper; never permanently rewrite signing config.
+`--no-gpg-sign` is the last resort.
 
 Record material progress, decisions, and hold reasons as issue or PR
 comments at the time they are made. This ensures that any agent resuming

--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -91,9 +91,9 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 
 ## Commit signing
 
-In non-interactive agent or CI environments where GPG pinentry cannot be
-presented, add `--no-gpg-sign` to all `git commit` and `git merge`
-commands to prevent blocking.
+Check `docs/idd-helper-scripts.md`'s signed-commit merge wrapper for a
+fallback, never permanently rewriting signing config; add
+`--no-gpg-sign` only when none resolves.
 
 Record material progress, decisions, and hold reasons as issue or PR
 comments at the time they are made. This ensures that any agent resuming

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -86,9 +86,9 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 
 ## Commit signing
 
-When pinentry blocks signing, check `docs/idd-helper-scripts.md`'s
-Signed-Commit Merge Wrapper; never permanently rewrite signing config.
-`--no-gpg-sign` is the last resort.
+When it fails, check `docs/idd-helper-scripts.md`'s Signed-Commit
+Merge Wrapper; never permanently rewrite config. `--no-gpg-sign` on
+`git commit`/`merge` is the last resort.
 
 Record material progress, decisions, and hold reasons as issue or PR
 comments at the time they are made. This ensures that any agent resuming

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -86,9 +86,9 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 
 ## Commit signing
 
-Check `docs/idd-helper-scripts.md`'s Signed-Commit Merge Wrapper for a
-fallback and never permanently rewrite signing config; add
-`--no-gpg-sign` only when none resolves.
+When pinentry blocks signing, check `docs/idd-helper-scripts.md`'s
+Signed-Commit Merge Wrapper; never permanently rewrite signing config.
+`--no-gpg-sign` is the last resort.
 
 Record material progress, decisions, and hold reasons as issue or PR
 comments at the time they are made. This ensures that any agent resuming

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -88,7 +88,7 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 
 When it fails, check `docs/idd-helper-scripts.md`'s Signed-Commit
 Merge Wrapper; never permanently rewrite config. `--no-gpg-sign` on
-`git commit`/`merge` is the last resort.
+`git commit`/`git merge` is the last resort.
 
 Record material progress, decisions, and hold reasons as issue or PR
 comments at the time they are made. This ensures that any agent resuming

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -86,7 +86,7 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 
 ## Commit signing
 
-Check `docs/idd-helper-scripts.md`'s signed-commit merge wrapper for a
+Check `docs/idd-helper-scripts.md`'s Signed-Commit Merge Wrapper for a
 fallback, never permanently rewriting signing config; add
 `--no-gpg-sign` only when none resolves.
 

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -86,7 +86,7 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 
 ## Commit signing
 
-When it hangs, check `docs/idd-helper-scripts.md`'s Signed-Commit
+When it blocks, check `docs/idd-helper-scripts.md`'s Signed-Commit
 Merge Wrapper; never permanently rewrite config. `--no-gpg-sign` on
 `git commit`/`git merge` is the last resort.
 

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -86,9 +86,9 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 
 ## Commit signing
 
-In non-interactive agent or CI environments where GPG pinentry cannot be
-presented, add `--no-gpg-sign` to all `git commit` and `git merge`
-commands to prevent blocking.
+Check `docs/idd-helper-scripts.md`'s signed-commit merge wrapper for a
+fallback, never permanently rewriting signing config; add
+`--no-gpg-sign` only when none resolves.
 
 Record material progress, decisions, and hold reasons as issue or PR
 comments at the time they are made. This ensures that any agent resuming

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -87,7 +87,7 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 ## Commit signing
 
 Check `docs/idd-helper-scripts.md`'s Signed-Commit Merge Wrapper for a
-fallback, never permanently rewriting signing config; add
+fallback and never permanently rewrite signing config; add
 `--no-gpg-sign` only when none resolves.
 
 Record material progress, decisions, and hold reasons as issue or PR

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -86,7 +86,7 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 
 ## Commit signing
 
-When it fails, check `docs/idd-helper-scripts.md`'s Signed-Commit
+When it hangs, check `docs/idd-helper-scripts.md`'s Signed-Commit
 Merge Wrapper; never permanently rewrite config. `--no-gpg-sign` on
 `git commit`/`git merge` is the last resort.
 

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -87,11 +87,11 @@ For A0-T, A0-O, A1, A1.5, A3, and A4.5 repo-query rules, see
 ## Commit signing
 
 When it blocks, check `docs/idd-helper-scripts.md`'s Signed-Commit
-Merge Wrapper; never permanently rewrite config. `--no-gpg-sign` on
-`git commit`/`git merge` is the last resort.
+Merge Wrapper; never permanently rewrite signing config. `--no-gpg-sign`
+on `git commit`/`git merge` is the last resort.
 
 Record material progress, decisions, and hold reasons as issue or PR
-comments at the time they are made. This ensures that any agent resuming
+comments as they happen. This ensures that any agent resuming
 without session context can understand the current state and continue
 correctly. Do not rely on session memory alone for information that
 another agent may need.


### PR DESCRIPTION
# Summary

`idd-overview-appendix.instructions.md`'s "Commit signing" section told
agents to add `--no-gpg-sign` unconditionally whenever GPG pinentry
can't be presented — a strictly weaker answer than the tiered path
`idd-pr-submit.instructions.md`, `idd-review-fix.instructions.md`,
`idd-review-triage.instructions.md`, and `docs/idd-helper-scripts.md`
already document: check for a configured non-interactive-safe fallback
(the signed-commit merge wrapper) first, and use `--no-gpg-sign` only
as the last resort. This aligns the appendix with that sibling
guidance by pointing at the canonical wrapper section in
`docs/idd-helper-scripts.md` instead of restating its ladder.

The replacement wording was kept deliberately terse: the `bundle-review`
context-ceiling budget (`instructionSizeBudgets` / `bundleBudgets` in
`audit/sync-manifest.json`) was already at 97.99% utilization on `main`
(only ~11 bytes of headroom before the 98% error threshold), so a
longer restatement of the full sibling ladder would have tripped
`context-ceiling-128k` in `node scripts/audit-docs.mjs --check`. The
regenerated section stays within budget (utilization unchanged at
97.99%).

## Linked issue

Closes #1929

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`idd-template/.github/instructions/idd-overview-appendix.instructions.md`
is the sync-docs `exact`-mode source; the generated
`.github/instructions/idd-overview-appendix.instructions.md` copy was
regenerated with `node scripts/sync-docs.mjs --apply --force` (force
was required only because the file had a since-superseded local draft
from an earlier iteration of this same change; the final content is
byte-identical to what a normal `--apply` would produce from the final
template source).

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (ran `pnpm run lint:minimum`)
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (ran `node scripts/sync-docs.mjs --apply`
  and confirmed no further drift)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
