### PR TITLE
docs(pr-submit): extend closing-keyword rules to commit messages

### DIFF
--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -294,10 +294,12 @@ completion.
    closing-keyword scan also reads commit messages (subject and body),
    not only the PR body, so a stray keyword there can auto-close an
    issue outside the deliberate set even when the PR body is clean.
-   List the branch's own commits:
+   List the branch's own commits, using a visible delimiter rather
+   than a NUL byte so common terminals and search tools don't treat
+   the output as binary:
 
    ```sh
-   git log origin/main..HEAD --pretty=format:'%H%n%B%n%x00'
+   git log origin/main..HEAD --pretty=format:'%H%n%B%n===commit-boundary==='
    ```
 
    For each commit's full message, search using step 3's same keyword
@@ -315,16 +317,27 @@ completion.
    **On a stray match**: amend the offending commit (`git commit
    --amend` for the tip commit, or an interactive rebase for an
    earlier one) using the same safe reordering as the Mirror
-   false-positive example above, then force-push the correction
-   (`git push --force-with-lease`) — this step runs before D4, ahead
-   of any review, so rewriting history here is a sanctioned exception
-   to D2's normal-push rule, not the exceptional recovery route D2
-   itself describes. **Amend before merge** — this scan runs at merge
-   time, so the fix must land before the PR merges; a commit message
-   caught only after merge cannot be amended, and recovery requires
-   reopening the affected issue by hand. Repeat this step once after
-   the amendment. If it still finds a stray match, post a hold note on
-   the issue citing the PR URL and stop. Do not proceed to D4.
+   false-positive example above. On a signed-commit repo whose primary
+   signing is non-interactive-hostile, run the amend or rebase through
+   the same D1 fallback-signing wrapper noted above, including any
+   rebase continuation — the plain command can stall the same way D1
+   already documents. Then force-push the correction (`git push
+   --force-with-lease`) only when repository policy permits
+   force-pushing a published branch, mirroring D2's own force-push
+   restriction; if it does not, hold for operator intervention instead
+   of rewriting published history. **Amend before merge** — this scan
+   runs at merge time, so the fix must land before the PR merges; a
+   commit message caught only after merge cannot be amended, and
+   recovery requires reopening the affected issue by hand. Repeat this
+   step once after the amendment. If it still finds a stray match,
+   post a hold note on the issue citing the PR URL and stop. Do not
+   proceed to D4.
+
+   **Re-run before merge**: this scan only covers commits present at
+   D3.5 time. Later branch commits — accepted review fixes
+   (`idd-review-fix.instructions.md` E9-E12) or a `main` merge — are
+   not automatically covered; re-run this step against the final HEAD
+   before F3 merges.
 
 ## D4 — Wait for CI
 

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -315,13 +315,16 @@ completion.
    **On a stray match**: amend the offending commit (`git commit
    --amend` for the tip commit, or an interactive rebase for an
    earlier one) using the same safe reordering as the Mirror
-   false-positive example above, then re-push. **Amend before
-   merge** — this scan runs at merge time, so the fix must land before
-   the PR merges; a commit message caught only after merge cannot be
-   amended, and recovery requires reopening the affected issue by
-   hand. Repeat this step once after the amendment. If it still finds
-   a stray match, post a hold note on the issue citing the PR URL and
-   stop. Do not proceed to D4.
+   false-positive example above, then force-push the correction
+   (`git push --force-with-lease`) — this step runs before D4, ahead
+   of any review, so rewriting history here is a sanctioned exception
+   to D2's normal-push rule, not the exceptional recovery route D2
+   itself describes. **Amend before merge** — this scan runs at merge
+   time, so the fix must land before the PR merges; a commit message
+   caught only after merge cannot be amended, and recovery requires
+   reopening the affected issue by hand. Repeat this step once after
+   the amendment. If it still finds a stray match, post a hold note on
+   the issue citing the PR URL and stop. Do not proceed to D4.
 
 ## D4 — Wait for CI
 

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -152,7 +152,10 @@ constraint applies only to the actual PR body content that GitHub
 must parse.
 
 GitHub recognizes the following keyword forms: close, closes, closed,
-fix, fixes, fixed, resolve, resolves, resolved.
+fix, fixes, fixed, resolve, resolves, resolved. GitHub's merge-time
+detection reads these same forms in the branch's commit messages too,
+not only the PR body — see Mirror false-positive below for the
+structural-separation rule that covers both surfaces.
 
 #### Anti-patterns
 
@@ -170,28 +173,35 @@ merge and the issue↔PR linking surfaces (sidebar, timeline) will not
 populate.
 
 **Mirror false-positive — negation-blind detection**: the same literal
-matching runs in the other direction too. GitHub's detector matches a
-recognized keyword form immediately adjacent to a `#N` reference and
-has no concept of negation — wrapping the keyword in surrounding
-"not" / "deliberately" / "isn't" wording does not stop detection when
-the keyword itself still sits next to the `#N` it must not close. Keep
-every recognized keyword form (`close`, `closes`, `closed`, `fix`,
-`fixes`, `fixed`, `resolve`, `resolves`, `resolved`) structurally apart
-from any reference it must not close:
+matching runs in the other direction too, and it is not limited to the
+PR body — GitHub's merge-time scan reads the same recognized keyword
+forms in the branch's commit messages (subject and body) as well.
+GitHub's detector matches a recognized keyword form immediately
+adjacent to a `#N` reference and has no concept of negation —
+wrapping the keyword in surrounding "not" / "deliberately" / "isn't"
+wording does not stop detection when the keyword itself still sits
+next to the `#N` it must not close, whether that text lives in the PR
+body or in a commit message. Keep every recognized keyword form
+(`close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`,
+`resolves`, `resolved`) structurally apart from any reference it must
+not close, in both locations:
 
 - Risky — a keyword sits directly before the reference, even inside a
-  negation clause: "this PR does not close #42" (`close` is
-  immediately adjacent to `#42`; GitHub cannot see the "not").
+  negation clause, whether in the PR body or a commit message: "this
+  PR does not close #42" (`close` is immediately adjacent to `#42`;
+  GitHub cannot see the "not").
 - Safe — reorder so no recognized keyword is adjacent to the
   reference: "Refs #42 (deliberately not a closing keyword — see the
   discussion there for why this PR does not resolve it directly)".
   Here `resolve` is followed by "it", not a `#N` token, so nothing
-  adjacent to `#42` matches.
+  adjacent to `#42` matches. The same reordering works verbatim inside
+  a commit subject or body.
 
 Do not rely on careful phrasing alone as the only safeguard — the
-strengthened check in D3.5 below verifies `closingIssuesReferences`
-against the deliberate closing set exactly, catching a spurious extra
-close even if phrasing slips.
+strengthened checks in D3.5 below verify `closingIssuesReferences`
+against the deliberate closing set exactly and scan the branch's own
+commit messages, catching a spurious extra close even if phrasing
+slips.
 
 #### Multiple closing issues
 
@@ -279,6 +289,39 @@ completion.
    Repeat this step once after either fix. If it still fails, post a
    hold note on the issue citing the PR URL and stop. Do not proceed to
    D4.
+
+7. **Scan the branch's own commit messages**: GitHub's merge-time
+   closing-keyword scan also reads commit messages (subject and body),
+   not only the PR body, so a stray keyword there can auto-close an
+   issue outside the deliberate set even when the PR body is clean.
+   List the branch's own commits:
+
+   ```sh
+   git log origin/main..HEAD --pretty=format:'%H%n%B%n%x00'
+   ```
+
+   For each commit's full message, search using step 3's same keyword
+   alternation, generalized to any issue number instead of the fixed
+   `<N>`:
+
+   ```text
+   (?im)\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#(\d+)\b
+   ```
+
+   A match against the claimed issue's own number `<N>` is expected
+   (deliberate); only a captured number **outside** the deliberate
+   closing set from D3 is a stray commit-message close.
+
+   **On a stray match**: amend the offending commit (`git commit
+   --amend` for the tip commit, or an interactive rebase for an
+   earlier one) using the same safe reordering as the Mirror
+   false-positive example above, then re-push. **Amend before
+   merge** — this scan runs at merge time, so the fix must land before
+   the PR merges; a commit message caught only after merge cannot be
+   amended, and recovery requires reopening the affected issue by
+   hand. Repeat this step once after the amendment. If it still finds
+   a stray match, post a hold note on the issue citing the PR URL and
+   stop. Do not proceed to D4.
 
 ## D4 — Wait for CI
 

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -310,9 +310,10 @@ completion.
    (?im)\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#(\d+)\b
    ```
 
-   A match against the claimed issue's own number `<N>` is expected
-   (deliberate); only a captured number **outside** the deliberate
-   closing set from D3 is a stray commit-message close.
+   A match against any issue number in the deliberate closing set from
+   D3 is expected (deliberate — this covers both the single-issue `<N>`
+   case and "Multiple closing issues" above); only a captured number
+   **outside** that set is a stray commit-message close.
 
    **On a stray match**: amend the offending commit (`git commit
    --amend` for the tip commit, or an interactive rebase for an

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -318,7 +318,11 @@ completion.
    **On a stray match**: amend the offending commit (`git commit
    --amend` for the tip commit, or an interactive rebase for an
    earlier one) using the same safe reordering as the Mirror
-   false-positive example above. On a signed-commit repo whose primary
+   false-positive example above. If the branch already carries a merge
+   commit (for example, from an E-phase `main` sync), rebase with
+   `--rebase-merges` instead of a plain interactive rebase, so the
+   merge and its recorded conflict resolution aren't silently
+   linearized or dropped. On a signed-commit repo whose primary
    signing is non-interactive-hostile, run the amend or rebase through
    the same D1 fallback-signing wrapper noted above, including any
    rebase continuation — the plain command can stall the same way D1

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -313,7 +313,11 @@ completion.
    **On a stray match**: amend the offending commit (`git commit
    --amend` for the tip commit, or an interactive rebase for an
    earlier one) using the same safe reordering as the Mirror
-   false-positive example above. On a signed-commit repo whose primary
+   false-positive example above. If the branch already carries a merge
+   commit (for example, from an E-phase `main` sync), rebase with
+   `--rebase-merges` instead of a plain interactive rebase, so the
+   merge and its recorded conflict resolution aren't silently
+   linearized or dropped. On a signed-commit repo whose primary
    signing is non-interactive-hostile, run the amend or rebase through
    the same D1 fallback-signing wrapper noted above, including any
    rebase continuation — the plain command can stall the same way D1

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -147,7 +147,10 @@ constraint applies only to the actual PR body content that GitHub
 must parse.
 
 GitHub recognizes the following keyword forms: close, closes, closed,
-fix, fixes, fixed, resolve, resolves, resolved.
+fix, fixes, fixed, resolve, resolves, resolved. GitHub's merge-time
+detection reads these same forms in the branch's commit messages too,
+not only the PR body — see Mirror false-positive below for the
+structural-separation rule that covers both surfaces.
 
 #### Anti-patterns
 
@@ -165,28 +168,35 @@ merge and the issue↔PR linking surfaces (sidebar, timeline) will not
 populate.
 
 **Mirror false-positive — negation-blind detection**: the same literal
-matching runs in the other direction too. GitHub's detector matches a
-recognized keyword form immediately adjacent to a `#N` reference and
-has no concept of negation — wrapping the keyword in surrounding
-"not" / "deliberately" / "isn't" wording does not stop detection when
-the keyword itself still sits next to the `#N` it must not close. Keep
-every recognized keyword form (`close`, `closes`, `closed`, `fix`,
-`fixes`, `fixed`, `resolve`, `resolves`, `resolved`) structurally apart
-from any reference it must not close:
+matching runs in the other direction too, and it is not limited to the
+PR body — GitHub's merge-time scan reads the same recognized keyword
+forms in the branch's commit messages (subject and body) as well.
+GitHub's detector matches a recognized keyword form immediately
+adjacent to a `#N` reference and has no concept of negation —
+wrapping the keyword in surrounding "not" / "deliberately" / "isn't"
+wording does not stop detection when the keyword itself still sits
+next to the `#N` it must not close, whether that text lives in the PR
+body or in a commit message. Keep every recognized keyword form
+(`close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`,
+`resolves`, `resolved`) structurally apart from any reference it must
+not close, in both locations:
 
 - Risky — a keyword sits directly before the reference, even inside a
-  negation clause: "this PR does not close #42" (`close` is
-  immediately adjacent to `#42`; GitHub cannot see the "not").
+  negation clause, whether in the PR body or a commit message: "this
+  PR does not close #42" (`close` is immediately adjacent to `#42`;
+  GitHub cannot see the "not").
 - Safe — reorder so no recognized keyword is adjacent to the
   reference: "Refs #42 (deliberately not a closing keyword — see the
   discussion there for why this PR does not resolve it directly)".
   Here `resolve` is followed by "it", not a `#N` token, so nothing
-  adjacent to `#42` matches.
+  adjacent to `#42` matches. The same reordering works verbatim inside
+  a commit subject or body.
 
 Do not rely on careful phrasing alone as the only safeguard — the
-strengthened check in D3.5 below verifies `closingIssuesReferences`
-against the deliberate closing set exactly, catching a spurious extra
-close even if phrasing slips.
+strengthened checks in D3.5 below verify `closingIssuesReferences`
+against the deliberate closing set exactly and scan the branch's own
+commit messages, catching a spurious extra close even if phrasing
+slips.
 
 #### Multiple closing issues
 
@@ -274,6 +284,39 @@ completion.
    Repeat this step once after either fix. If it still fails, post a
    hold note on the issue citing the PR URL and stop. Do not proceed to
    D4.
+
+7. **Scan the branch's own commit messages**: GitHub's merge-time
+   closing-keyword scan also reads commit messages (subject and body),
+   not only the PR body, so a stray keyword there can auto-close an
+   issue outside the deliberate set even when the PR body is clean.
+   List the branch's own commits:
+
+   ```sh
+   git log origin/main..HEAD --pretty=format:'%H%n%B%n%x00'
+   ```
+
+   For each commit's full message, search using step 3's same keyword
+   alternation, generalized to any issue number instead of the fixed
+   `<N>`:
+
+   ```text
+   (?im)\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#(\d+)\b
+   ```
+
+   A match against the claimed issue's own number `<N>` is expected
+   (deliberate); only a captured number **outside** the deliberate
+   closing set from D3 is a stray commit-message close.
+
+   **On a stray match**: amend the offending commit (`git commit
+   --amend` for the tip commit, or an interactive rebase for an
+   earlier one) using the same safe reordering as the Mirror
+   false-positive example above, then re-push. **Amend before
+   merge** — this scan runs at merge time, so the fix must land before
+   the PR merges; a commit message caught only after merge cannot be
+   amended, and recovery requires reopening the affected issue by
+   hand. Repeat this step once after the amendment. If it still finds
+   a stray match, post a hold note on the issue citing the PR URL and
+   stop. Do not proceed to D4.
 
 ## D4 — Wait for CI
 

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -305,9 +305,10 @@ completion.
    (?im)\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#(\d+)\b
    ```
 
-   A match against the claimed issue's own number `<N>` is expected
-   (deliberate); only a captured number **outside** the deliberate
-   closing set from D3 is a stray commit-message close.
+   A match against any issue number in the deliberate closing set from
+   D3 is expected (deliberate — this covers both the single-issue `<N>`
+   case and "Multiple closing issues" above); only a captured number
+   **outside** that set is a stray commit-message close.
 
    **On a stray match**: amend the offending commit (`git commit
    --amend` for the tip commit, or an interactive rebase for an

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -310,13 +310,16 @@ completion.
    **On a stray match**: amend the offending commit (`git commit
    --amend` for the tip commit, or an interactive rebase for an
    earlier one) using the same safe reordering as the Mirror
-   false-positive example above, then re-push. **Amend before
-   merge** — this scan runs at merge time, so the fix must land before
-   the PR merges; a commit message caught only after merge cannot be
-   amended, and recovery requires reopening the affected issue by
-   hand. Repeat this step once after the amendment. If it still finds
-   a stray match, post a hold note on the issue citing the PR URL and
-   stop. Do not proceed to D4.
+   false-positive example above, then force-push the correction
+   (`git push --force-with-lease`) — this step runs before D4, ahead
+   of any review, so rewriting history here is a sanctioned exception
+   to D2's normal-push rule, not the exceptional recovery route D2
+   itself describes. **Amend before merge** — this scan runs at merge
+   time, so the fix must land before the PR merges; a commit message
+   caught only after merge cannot be amended, and recovery requires
+   reopening the affected issue by hand. Repeat this step once after
+   the amendment. If it still finds a stray match, post a hold note on
+   the issue citing the PR URL and stop. Do not proceed to D4.
 
 ## D4 — Wait for CI
 

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -289,10 +289,12 @@ completion.
    closing-keyword scan also reads commit messages (subject and body),
    not only the PR body, so a stray keyword there can auto-close an
    issue outside the deliberate set even when the PR body is clean.
-   List the branch's own commits:
+   List the branch's own commits, using a visible delimiter rather
+   than a NUL byte so common terminals and search tools don't treat
+   the output as binary:
 
    ```sh
-   git log origin/main..HEAD --pretty=format:'%H%n%B%n%x00'
+   git log origin/main..HEAD --pretty=format:'%H%n%B%n===commit-boundary==='
    ```
 
    For each commit's full message, search using step 3's same keyword
@@ -310,16 +312,27 @@ completion.
    **On a stray match**: amend the offending commit (`git commit
    --amend` for the tip commit, or an interactive rebase for an
    earlier one) using the same safe reordering as the Mirror
-   false-positive example above, then force-push the correction
-   (`git push --force-with-lease`) — this step runs before D4, ahead
-   of any review, so rewriting history here is a sanctioned exception
-   to D2's normal-push rule, not the exceptional recovery route D2
-   itself describes. **Amend before merge** — this scan runs at merge
-   time, so the fix must land before the PR merges; a commit message
-   caught only after merge cannot be amended, and recovery requires
-   reopening the affected issue by hand. Repeat this step once after
-   the amendment. If it still finds a stray match, post a hold note on
-   the issue citing the PR URL and stop. Do not proceed to D4.
+   false-positive example above. On a signed-commit repo whose primary
+   signing is non-interactive-hostile, run the amend or rebase through
+   the same D1 fallback-signing wrapper noted above, including any
+   rebase continuation — the plain command can stall the same way D1
+   already documents. Then force-push the correction (`git push
+   --force-with-lease`) only when repository policy permits
+   force-pushing a published branch, mirroring D2's own force-push
+   restriction; if it does not, hold for operator intervention instead
+   of rewriting published history. **Amend before merge** — this scan
+   runs at merge time, so the fix must land before the PR merges; a
+   commit message caught only after merge cannot be amended, and
+   recovery requires reopening the affected issue by hand. Repeat this
+   step once after the amendment. If it still finds a stray match,
+   post a hold note on the issue citing the PR URL and stop. Do not
+   proceed to D4.
+
+   **Re-run before merge**: this scan only covers commits present at
+   D3.5 time. Later branch commits — accepted review fixes
+   (`idd-review-fix.instructions.md` E9-E12) or a `main` merge — are
+   not automatically covered; re-run this step against the final HEAD
+   before F3 merges.
 
 ## D4 — Wait for CI
 


### PR DESCRIPTION
# Summary

Extends D3's negation-blind closing-keyword rule and D3.5's
verification checklist from `idd-pr-submit.instructions.md` so both
cover the branch's commit messages, not only the PR body. GitHub's
merge-time closing-keyword scan reads commit messages too, so a
sentence explaining why an issue stays open ("this PR does not close
#N") can still auto-close it there, the same way it can in the PR
body.

## Linked issue

Closes #1931

## Follow-up issues (if any)

- [ ] none — noting one out-of-scope observation instead: the lite
      profile's independent, abbreviated `idd-pr-submit-lite
      .instructions.md` still stops its own closing-keyword check at
      `closingIssuesReferences` and was not extended here, since it is
      not one of this issue's candidate files. A future issue could
      port the same commit-message scan there if the lite profile
      wants parity.

## Background / rationale (if material)

Field-reported from a sibling repository's own PR: the PR body there
correctly used a non-closing reference form and never a closing
keyword, and the plan comment had stated in writing that the PR would
not resolve the referenced issue. The commit message contained a
sentence written to explain the scope boundary to a reader — and that
sentence placed a recognized keyword directly next to the issue
number it was explaining should stay open. GitHub auto-closed the
referenced issue within two seconds of the merge; it was caught and
reopened manually about a minute later.

This generalizes: the `Refs #N` convention exists precisely so a
session can say "this PR addresses #N but does not resolve it" — and
an agent carefully explaining why something stays open is exactly the
one most likely to write a negated closing phrase into a commit body,
where GitHub's detector still can't see the negation.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
