### PR TITLE
fix(helper-runtime-manifest): disclose the running-build command scope

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -235,9 +235,11 @@ future inventory reviews do not need to re-infer their role from code.
   for all four profiles (`package-manager`, `vendored-node`,
   `ephemeral-npx`, and `instructions-only`). Its output always carries a
   `runningBuild: { version, commandListScope: "running-build" }` field
-  disclosing that the reported command list describes only the currently
-  running helper build, independent of any `--package-spec` target
-  (referenced in
+  disclosing that `commandCatalog` describes only the currently running
+  helper build, independent of any `--package-spec` target -- a per-profile
+  `profiles.<profile>.commands` entry still embeds the supplied
+  `--package-spec` in its composed install/invocation strings, but
+  `commandCatalog` itself never changes (referenced in
   [kurone-kito/idd-skill#1923](https://github.com/kurone-kito/idd-skill/issues/1923)).
 - `scripts/phase-id-resolver.mjs` (`idd-phase-id-resolver`) — phase ID
   normalization utility; resolves canonical phase IDs from aliases and

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -232,11 +232,12 @@ future inventory reviews do not need to re-infer their role from code.
   `--cleanup-backlog-window-days 1` to keep it fast, mirroring CI.
 - `scripts/helper-runtime-manifest.mjs` (`idd-helper-bundle-manifest`) —
   import helper and manifest inspector; emits machine-readable helper wiring
-  for `package-manager`, `vendored-node`, and `ephemeral-npx` profiles. Its
-  output always carries a `runningBuild: { version, commandListScope:
-  "running-build" }` field disclosing that the reported command list
-  describes only the currently running helper build, independent of any
-  `--package-spec` target (referenced in
+  for all four profiles (`package-manager`, `vendored-node`,
+  `ephemeral-npx`, and `instructions-only`). Its output always carries a
+  `runningBuild: { version, commandListScope: "running-build" }` field
+  disclosing that the reported command list describes only the currently
+  running helper build, independent of any `--package-spec` target
+  (referenced in
   [kurone-kito/idd-skill#1923](https://github.com/kurone-kito/idd-skill/issues/1923)).
 - `scripts/phase-id-resolver.mjs` (`idd-phase-id-resolver`) — phase ID
   normalization utility; resolves canonical phase IDs from aliases and

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -232,7 +232,12 @@ future inventory reviews do not need to re-infer their role from code.
   `--cleanup-backlog-window-days 1` to keep it fast, mirroring CI.
 - `scripts/helper-runtime-manifest.mjs` (`idd-helper-bundle-manifest`) —
   import helper and manifest inspector; emits machine-readable helper wiring
-  for `package-manager`, `vendored-node`, and `ephemeral-npx` profiles.
+  for `package-manager`, `vendored-node`, and `ephemeral-npx` profiles. Its
+  output always carries a `runningBuild: { version, commandListScope:
+  "running-build" }` field disclosing that the reported command list
+  describes only the currently running helper build, independent of any
+  `--package-spec` target (referenced in
+  [kurone-kito/idd-skill#1923](https://github.com/kurone-kito/idd-skill/issues/1923)).
 - `scripts/phase-id-resolver.mjs` (`idd-phase-id-resolver`) — phase ID
   normalization utility; resolves canonical phase IDs from aliases and
   validates token format.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -235,9 +235,11 @@ future inventory reviews do not need to re-infer their role from code.
   for all four profiles (`package-manager`, `vendored-node`,
   `ephemeral-npx`, and `instructions-only`). Its output always carries a
   `runningBuild: { version, commandListScope: "running-build" }` field
-  disclosing that the reported command list describes only the currently
-  running helper build, independent of any `--package-spec` target
-  (referenced in
+  disclosing that `commandCatalog` describes only the currently running
+  helper build, independent of any `--package-spec` target -- a per-profile
+  `profiles.<profile>.commands` entry still embeds the supplied
+  `--package-spec` in its composed install/invocation strings, but
+  `commandCatalog` itself never changes (referenced in
   [kurone-kito/idd-skill#1923](https://github.com/kurone-kito/idd-skill/issues/1923)).
 - `scripts/phase-id-resolver.mjs` (`idd-phase-id-resolver`) — phase ID
   normalization utility; resolves canonical phase IDs from aliases and

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -232,11 +232,12 @@ future inventory reviews do not need to re-infer their role from code.
   `--cleanup-backlog-window-days 1` to keep it fast, mirroring CI.
 - `scripts/helper-runtime-manifest.mjs` (`idd-helper-bundle-manifest`) —
   import helper and manifest inspector; emits machine-readable helper wiring
-  for `package-manager`, `vendored-node`, and `ephemeral-npx` profiles. Its
-  output always carries a `runningBuild: { version, commandListScope:
-  "running-build" }` field disclosing that the reported command list
-  describes only the currently running helper build, independent of any
-  `--package-spec` target (referenced in
+  for all four profiles (`package-manager`, `vendored-node`,
+  `ephemeral-npx`, and `instructions-only`). Its output always carries a
+  `runningBuild: { version, commandListScope: "running-build" }` field
+  disclosing that the reported command list describes only the currently
+  running helper build, independent of any `--package-spec` target
+  (referenced in
   [kurone-kito/idd-skill#1923](https://github.com/kurone-kito/idd-skill/issues/1923)).
 - `scripts/phase-id-resolver.mjs` (`idd-phase-id-resolver`) — phase ID
   normalization utility; resolves canonical phase IDs from aliases and

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -232,7 +232,12 @@ future inventory reviews do not need to re-infer their role from code.
   `--cleanup-backlog-window-days 1` to keep it fast, mirroring CI.
 - `scripts/helper-runtime-manifest.mjs` (`idd-helper-bundle-manifest`) —
   import helper and manifest inspector; emits machine-readable helper wiring
-  for `package-manager`, `vendored-node`, and `ephemeral-npx` profiles.
+  for `package-manager`, `vendored-node`, and `ephemeral-npx` profiles. Its
+  output always carries a `runningBuild: { version, commandListScope:
+  "running-build" }` field disclosing that the reported command list
+  describes only the currently running helper build, independent of any
+  `--package-spec` target (referenced in
+  [kurone-kito/idd-skill#1923](https://github.com/kurone-kito/idd-skill/issues/1923)).
 - `scripts/phase-id-resolver.mjs` (`idd-phase-id-resolver`) — phase ID
   normalization utility; resolves canonical phase IDs from aliases and
   validates token format.

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -963,11 +963,12 @@ Options:
   --from-profile <package-manager|vendored-node|ephemeral-npx|instructions-only>
   --package-manager <npm|pnpm|yarn>
   --package-spec <npm-spec-or-tarball-url>
-                        Affects only composed install/invocation strings
-                        (ephemeral-npx, package-manager); the reported
-                        command list always reflects this running build,
-                        never the package-spec target (see "runningBuild"
-                        in the JSON output).
+                        Affects package-spec-derived output only (composed
+                        install/invocation strings, the managed dependency
+                        pin, the echoed packageSpec value); never changes
+                        the reported command list, which always reflects
+                        this running build (see "runningBuild" in the JSON
+                        output).
   --target-root <path>
   --help
 `);

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -772,11 +772,20 @@ export function resolveSourcePackageMetadata(packageRoot = PACKAGE_ROOT) {
       name: PACKAGE_NAME,
       repository: normalizeRepository(packageJson.repository),
       nodeEngines: String(packageJson.engines?.node ?? NODE_ENGINES),
-      version: String(packageJson.version ?? PACKAGE_VERSION_FALLBACK),
+      version: normalizePackageVersion(packageJson.version),
     };
   } catch {
     return fallback;
   }
+}
+// A non-string version (e.g. an object, if package.json were malformed)
+// must fall back rather than stringify to a misleading value like
+// "[object Object]" -- the exact silently-wrong-output class idd-skill#1923
+// exists to fix (idd-skill#1947 review finding).
+function normalizePackageVersion(version) {
+  return typeof version === 'string' && version
+    ? version
+    : PACKAGE_VERSION_FALLBACK;
 }
 function normalizeRepository(repository) {
   if (typeof repository === 'string' && repository) {

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -60,6 +60,13 @@ const LIVE_CONFIG_CANDIDATE_FILES = [
   'idd-policy.json',
 ];
 const NODE_ENGINES = '^22.22.2 || >=24.2.0';
+// Deliberately not a hardcoded release number: a literal version string
+// would silently go stale at the next release with no drift guard (unlike
+// NODE_ENGINES, which audit-docs.mjs's ENGINES_RANGE_MIRRORS keeps honest)
+// -- exactly the misleading-output class idd-skill#1923 exists to fix. Only
+// reached for a foreign/missing package.json root; the source repo,
+// package-manager, and ephemeral-npx paths always read the real version.
+const PACKAGE_VERSION_FALLBACK = 'unknown';
 const SCRIPT_FILE_EXTENSIONS = ['.mjs', '.js', '.json'];
 // Runtime data files a helper reads at execution time (not via `import`),
 // so the import-graph walk cannot discover them. A consumer that vendors
@@ -589,6 +596,10 @@ export function buildHelperRuntimeManifest({
   const selectedProfiles = normalizedProfile
     ? { [normalizedProfile]: profileCatalog[normalizedProfile] }
     : profileCatalog;
+  const runningBuild = {
+    version: packageMetadata.version,
+    commandListScope: 'running-build',
+  };
   return {
     version: 1,
     sourceRepository: packageMetadata.repository,
@@ -597,6 +608,11 @@ export function buildHelperRuntimeManifest({
     packageSpecPinHint: PACKAGE_SPEC_PIN_HINT,
     nodeEngines: packageMetadata.nodeEngines,
     packageManager: normalizedPackageManager,
+    // commandCatalog above always reflects this running build's own
+    // HELPER_COMMANDS, never the --package-spec target -- runningBuild
+    // discloses that scope machine-readably, plus this build's own
+    // version, independent of --profile (idd-skill#1923).
+    runningBuild,
     recommendation,
     availableProfiles: [...PROFILE_NAMES],
     commandCatalog,
@@ -741,6 +757,7 @@ export function resolveSourcePackageMetadata(packageRoot = PACKAGE_ROOT) {
     name: PACKAGE_NAME,
     repository: SOURCE_REPOSITORY,
     nodeEngines: NODE_ENGINES,
+    version: PACKAGE_VERSION_FALLBACK,
   };
   const packageJsonPath = resolve(packageRoot, 'package.json');
   if (!existsSync(packageJsonPath)) {
@@ -755,6 +772,7 @@ export function resolveSourcePackageMetadata(packageRoot = PACKAGE_ROOT) {
       name: PACKAGE_NAME,
       repository: normalizeRepository(packageJson.repository),
       nodeEngines: String(packageJson.engines?.node ?? NODE_ENGINES),
+      version: String(packageJson.version ?? PACKAGE_VERSION_FALLBACK),
     };
   } catch {
     return fallback;
@@ -945,6 +963,11 @@ Options:
   --from-profile <package-manager|vendored-node|ephemeral-npx|instructions-only>
   --package-manager <npm|pnpm|yarn>
   --package-spec <npm-spec-or-tarball-url>
+                        Affects only composed install/invocation strings
+                        (ephemeral-npx, package-manager); the reported
+                        command list always reflects this running build,
+                        never the package-spec target (see "runningBuild"
+                        in the JSON output).
   --target-root <path>
   --help
 `);

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -972,11 +972,12 @@ Options:
   --from-profile <package-manager|vendored-node|ephemeral-npx|instructions-only>
   --package-manager <npm|pnpm|yarn>
   --package-spec <npm-spec-or-tarball-url>
-                        Affects package-spec-derived output only (composed
-                        install/invocation strings, the managed dependency
-                        pin, the echoed packageSpec value); never changes
-                        the reported command list, which always reflects
-                        this running build (see "runningBuild" in the JSON
+                        Affects package-spec-derived output only (each
+                        profile's composed install/invocation strings, the
+                        managed dependency pin, the echoed packageSpec
+                        value); never changes commandCatalog, which always
+                        reflects this running build regardless of profile
+                        or package-spec (see "runningBuild" in the JSON
                         output).
   --target-root <path>
   --help

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -916,11 +916,21 @@ export function resolveSourcePackageMetadata(
       name: PACKAGE_NAME,
       repository: normalizeRepository(packageJson.repository),
       nodeEngines: String(packageJson.engines?.node ?? NODE_ENGINES),
-      version: String(packageJson.version ?? PACKAGE_VERSION_FALLBACK),
+      version: normalizePackageVersion(packageJson.version),
     };
   } catch {
     return fallback;
   }
+}
+
+// A non-string version (e.g. an object, if package.json were malformed)
+// must fall back rather than stringify to a misleading value like
+// "[object Object]" -- the exact silently-wrong-output class idd-skill#1923
+// exists to fix (idd-skill#1947 review finding).
+function normalizePackageVersion(version: unknown): string {
+  return typeof version === 'string' && version
+    ? version
+    : PACKAGE_VERSION_FALLBACK;
 }
 
 function normalizeRepository(repository: unknown): string {

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -53,6 +53,18 @@ interface PackageMetadata {
   name: string;
   repository: string;
   nodeEngines: string;
+  version: string;
+}
+
+// Discloses that HELPER_COMMANDS / commandCatalog below describe only the
+// currently executing helper build, never the --package-spec target
+// (idd-skill#1923). A string enum (not a boolean) so it stays extensible if
+// the issue's explicitly-deferred larger alternative -- fetching the
+// --package-spec target's own bin field -- ever ships as its own follow-up
+// with a second scope value.
+interface RunningBuildDisclosure {
+  version: string;
+  commandListScope: 'running-build';
 }
 
 interface LockfileMatch {
@@ -131,6 +143,13 @@ const LIVE_CONFIG_CANDIDATE_FILES = [
   'idd-policy.json',
 ];
 const NODE_ENGINES = '^22.22.2 || >=24.2.0';
+// Deliberately not a hardcoded release number: a literal version string
+// would silently go stale at the next release with no drift guard (unlike
+// NODE_ENGINES, which audit-docs.mjs's ENGINES_RANGE_MIRRORS keeps honest)
+// -- exactly the misleading-output class idd-skill#1923 exists to fix. Only
+// reached for a foreign/missing package.json root; the source repo,
+// package-manager, and ephemeral-npx paths always read the real version.
+const PACKAGE_VERSION_FALLBACK = 'unknown';
 const SCRIPT_FILE_EXTENSIONS = ['.mjs', '.js', '.json'];
 // Runtime data files a helper reads at execution time (not via `import`),
 // so the import-graph walk cannot discover them. A consumer that vendors
@@ -681,6 +700,11 @@ export function buildHelperRuntimeManifest({
     ? { [normalizedProfile]: profileCatalog[normalizedProfile] }
     : profileCatalog;
 
+  const runningBuild: RunningBuildDisclosure = {
+    version: packageMetadata.version,
+    commandListScope: 'running-build',
+  };
+
   return {
     version: 1,
     sourceRepository: packageMetadata.repository,
@@ -689,6 +713,11 @@ export function buildHelperRuntimeManifest({
     packageSpecPinHint: PACKAGE_SPEC_PIN_HINT,
     nodeEngines: packageMetadata.nodeEngines,
     packageManager: normalizedPackageManager,
+    // commandCatalog above always reflects this running build's own
+    // HELPER_COMMANDS, never the --package-spec target -- runningBuild
+    // discloses that scope machine-readably, plus this build's own
+    // version, independent of --profile (idd-skill#1923).
+    runningBuild,
     recommendation,
     availableProfiles: [...PROFILE_NAMES],
     commandCatalog,
@@ -866,6 +895,7 @@ export function resolveSourcePackageMetadata(
     name: PACKAGE_NAME,
     repository: SOURCE_REPOSITORY,
     nodeEngines: NODE_ENGINES,
+    version: PACKAGE_VERSION_FALLBACK,
   };
   const packageJsonPath = resolve(packageRoot, 'package.json');
   if (!existsSync(packageJsonPath)) {
@@ -877,6 +907,7 @@ export function resolveSourcePackageMetadata(
       name?: unknown;
       repository?: unknown;
       engines?: { node?: unknown };
+      version?: unknown;
     };
     if (packageJson.name !== PACKAGE_NAME) {
       return fallback;
@@ -885,6 +916,7 @@ export function resolveSourcePackageMetadata(
       name: PACKAGE_NAME,
       repository: normalizeRepository(packageJson.repository),
       nodeEngines: String(packageJson.engines?.node ?? NODE_ENGINES),
+      version: String(packageJson.version ?? PACKAGE_VERSION_FALLBACK),
     };
   } catch {
     return fallback;
@@ -1102,6 +1134,11 @@ Options:
   --from-profile <package-manager|vendored-node|ephemeral-npx|instructions-only>
   --package-manager <npm|pnpm|yarn>
   --package-spec <npm-spec-or-tarball-url>
+                        Affects only composed install/invocation strings
+                        (ephemeral-npx, package-manager); the reported
+                        command list always reflects this running build,
+                        never the package-spec target (see "runningBuild"
+                        in the JSON output).
   --target-root <path>
   --help
 `);

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -1144,11 +1144,12 @@ Options:
   --from-profile <package-manager|vendored-node|ephemeral-npx|instructions-only>
   --package-manager <npm|pnpm|yarn>
   --package-spec <npm-spec-or-tarball-url>
-                        Affects package-spec-derived output only (composed
-                        install/invocation strings, the managed dependency
-                        pin, the echoed packageSpec value); never changes
-                        the reported command list, which always reflects
-                        this running build (see "runningBuild" in the JSON
+                        Affects package-spec-derived output only (each
+                        profile's composed install/invocation strings, the
+                        managed dependency pin, the echoed packageSpec
+                        value); never changes commandCatalog, which always
+                        reflects this running build regardless of profile
+                        or package-spec (see "runningBuild" in the JSON
                         output).
   --target-root <path>
   --help

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -1134,11 +1134,12 @@ Options:
   --from-profile <package-manager|vendored-node|ephemeral-npx|instructions-only>
   --package-manager <npm|pnpm|yarn>
   --package-spec <npm-spec-or-tarball-url>
-                        Affects only composed install/invocation strings
-                        (ephemeral-npx, package-manager); the reported
-                        command list always reflects this running build,
-                        never the package-spec target (see "runningBuild"
-                        in the JSON output).
+                        Affects package-spec-derived output only (composed
+                        install/invocation strings, the managed dependency
+                        pin, the echoed packageSpec value); never changes
+                        the reported command list, which always reflects
+                        this running build (see "runningBuild" in the JSON
+                        output).
   --target-root <path>
   --help
 `);

--- a/tests/helper-runtime-manifest.test.mts
+++ b/tests/helper-runtime-manifest.test.mts
@@ -327,6 +327,7 @@ test('source package metadata falls back when vendored into another repository',
     name: '@kurone-kito/idd-skill',
     repository: 'github:kurone-kito/idd-skill',
     nodeEngines: '^22.22.2 || >=24.2.0',
+    version: 'unknown',
   });
 
   const missingRoot = mkdtempSync(
@@ -336,6 +337,7 @@ test('source package metadata falls back when vendored into another repository',
     name: '@kurone-kito/idd-skill',
     repository: 'github:kurone-kito/idd-skill',
     nodeEngines: '^22.22.2 || >=24.2.0',
+    version: 'unknown',
   });
 });
 
@@ -354,6 +356,7 @@ test('source package metadata accepts repository objects with url', () => {
       engines: {
         node: '^22.22.2 || >=24.2.0',
       },
+      version: '9.9.9-test',
     }),
   );
 
@@ -361,7 +364,64 @@ test('source package metadata accepts repository objects with url', () => {
     name: '@kurone-kito/idd-skill',
     repository: 'https://github.com/kurone-kito/idd-skill.git',
     nodeEngines: '^22.22.2 || >=24.2.0',
+    version: '9.9.9-test',
   });
+});
+
+// idd-skill#1923: the manifest previously let HELPER_COMMANDS's fixed
+// command list be misread as describing whatever --package-spec target
+// was passed, when it always described only this executing build. The
+// running-build version is read dynamically from this repo's own
+// package.json (never a hardcoded literal) so a release-version bump
+// can't break this suite.
+const REPO_PACKAGE_VERSION = JSON.parse(
+  readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'),
+).version;
+
+test('runningBuild discloses the running build version and command-list scope for every profile', () => {
+  for (const profile of [
+    'package-manager',
+    'vendored-node',
+    'ephemeral-npx',
+    'instructions-only',
+  ]) {
+    const manifest = buildHelperRuntimeManifest({
+      profile,
+      packageManager: profile === 'package-manager' ? 'pnpm' : '',
+      targetRoot: REPO_ROOT,
+    });
+    assert.deepEqual(
+      manifest.runningBuild,
+      { version: REPO_PACKAGE_VERSION, commandListScope: 'running-build' },
+      `profile ${profile}`,
+    );
+  }
+});
+
+test('a supplied --package-spec never changes the reported command list', () => {
+  const withDefaultSpec = buildHelperRuntimeManifest({
+    profile: 'ephemeral-npx',
+    targetRoot: REPO_ROOT,
+  });
+  const withCustomSpec = buildHelperRuntimeManifest({
+    profile: 'ephemeral-npx',
+    packageSpec: 'https://example.test/custom-tarball.tgz',
+    targetRoot: REPO_ROOT,
+  });
+
+  // The command catalog and running-build disclosure are identical --
+  // only composed install/invocation strings (which embed packageSpec)
+  // differ between the two manifests.
+  assert.deepEqual(
+    withDefaultSpec.commandCatalog,
+    withCustomSpec.commandCatalog,
+  );
+  assert.deepEqual(withDefaultSpec.runningBuild, withCustomSpec.runningBuild);
+  assert.notEqual(withDefaultSpec.packageSpec, withCustomSpec.packageSpec);
+  assert.notDeepEqual(
+    withDefaultSpec.profiles['ephemeral-npx'].commands,
+    withCustomSpec.profiles['ephemeral-npx'].commands,
+  );
 });
 
 test('empty targetRoot falls back to the current working directory', () => {

--- a/tests/helper-runtime-manifest.test.mts
+++ b/tests/helper-runtime-manifest.test.mts
@@ -368,6 +368,40 @@ test('source package metadata accepts repository objects with url', () => {
   });
 });
 
+// idd-skill#1947 review finding: a non-string version (malformed
+// package.json) must fall back to the sentinel rather than stringify to a
+// misleading value like "[object Object]".
+test('source package metadata falls back on a non-string version field', () => {
+  const nonStringVersionRoot = mkdtempSync(
+    join(tmpdir(), 'idd-helper-runtime-non-string-version-'),
+  );
+  writeFileSync(
+    join(nonStringVersionRoot, 'package.json'),
+    JSON.stringify({
+      name: '@kurone-kito/idd-skill',
+      version: { not: 'a string' },
+    }),
+  );
+  assert.deepEqual(resolveSourcePackageMetadata(nonStringVersionRoot), {
+    name: '@kurone-kito/idd-skill',
+    repository: 'github:kurone-kito/idd-skill',
+    nodeEngines: '^22.22.2 || >=24.2.0',
+    version: 'unknown',
+  });
+
+  const emptyStringVersionRoot = mkdtempSync(
+    join(tmpdir(), 'idd-helper-runtime-empty-version-'),
+  );
+  writeFileSync(
+    join(emptyStringVersionRoot, 'package.json'),
+    JSON.stringify({ name: '@kurone-kito/idd-skill', version: '' }),
+  );
+  assert.equal(
+    resolveSourcePackageMetadata(emptyStringVersionRoot).version,
+    'unknown',
+  );
+});
+
 // idd-skill#1923: the manifest previously let HELPER_COMMANDS's fixed
 // command list be misread as describing whatever --package-spec target
 // was passed, when it always described only this executing build. The


### PR DESCRIPTION
# Summary

`idd-helper-bundle-manifest`'s reported command list always came from the
currently installed build's own `HELPER_COMMANDS`, never from a
`--package-spec` target, but the manifest never disclosed that scope. An
operator bumping `helperRuntime.packageSpec` from a v0.4.0-era build to a
v0.6.0 tarball would see a manifest that reads as authoritative for the
v0.6.0 target while it was actually still describing the older running
build — silently under-reporting the target's real command set with no
warning or partial-result marker (field-reported from
`kurone-kito/lints-config`, cited in the issue).

Add an additive `runningBuild: { version, commandListScope: "running-build"
}` field to the manifest output — present for every profile — and document
the same scope in `--help`, so the disclosure is visible before a run, not
only after. `--package-spec`'s existing role (composing install/invocation
strings) is unchanged.

## Linked issue

Closes #1923

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`commandListScope` is a string enum rather than a boolean so it stays
extensible if the issue's explicitly out-of-scope larger alternative
(fetching the `--package-spec` target's own `bin` field) ever ships as its
own follow-up with a second scope value. The running-build `version` is
read from `package.json` with an honest `"unknown"` fallback rather than a
hardcoded release literal — a pinned version string would itself go
silently stale at the next release, which is the exact failure mode this
issue exists to fix.

B2.0 supersession re-check confirmed the full acceptance-criteria gap is
genuinely unimplemented on `main` (unlike a sibling issue on the same
roadmap that turned out mostly pre-shipped by an earlier PR) — this PR
implements the complete scope from the issue body, no reduction.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime manifests now report the currently running helper build version.
  * Added a `running-build` scope to clarify which commands belong to the active build.
  * Package metadata now includes a version, with `unknown` used when unavailable or invalid.
  * Clarified that `--package-spec` changes package-specific output but not the reported command catalog.

* **Documentation**
  * Updated helper manifest documentation and command-line help to explain build and package-scope behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->