### PR TITLE
fix(cli): print the shaped CLI error instead of a raw stack trace on an unknown flag

### DIFF
--- a/bin/idd-review-disposition-verify.mjs
+++ b/bin/idd-review-disposition-verify.mjs
@@ -7,21 +7,6 @@
 /**
  * Bin wrapper for review-disposition-verify helper
  */
-import { spawn } from 'node:child_process';
-import { resolve } from 'node:path';
+import { runHelper } from './run-helper.mjs';
 
-const currentDir = import.meta.dirname;
-const scriptPath = resolve(
-  currentDir,
-  '../scripts/review-disposition-verify.mjs',
-);
-const child = spawn('node', [scriptPath, ...process.argv.slice(2)], {
-  stdio: 'inherit',
-});
-child.on('exit', (code) => {
-  process.exit(code ?? 0);
-});
-child.on('error', (error) => {
-  console.error('Failed to spawn review-disposition-verify:', error);
-  process.exit(1);
-});
+runHelper('../scripts/review-disposition-verify.mjs');

--- a/bin/run-helper.mjs
+++ b/bin/run-helper.mjs
@@ -4,89 +4,134 @@
 // The bin/run-helper.mjs copy is generated from the .mts source named
 // above by `pnpm run build`. Edit the .mts source, never the generated
 // .mjs. See docs/typescript-sources.md.
-import { spawnSync } from 'node:child_process';
-import {
-  closeSync,
-  mkdtempSync,
-  openSync,
-  readFileSync,
-  rmSync,
-} from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
 import { extractShapedCliParseErrorMessage } from '../scripts/cli-args.mjs';
 
 // Bounds the best-effort `--help` re-invocation used to fetch a usage line
 // below -- this must never hang the primary error-reporting path.
 const HELP_REINVOKE_TIMEOUT_MS = 5_000;
+// How long, after the child's *first* stderr chunk arrives, run-helper keeps
+// buffering (instead of forwarding live) to give a shaped parse error --
+// always an instant, synchronous crash right after startup -- a chance to
+// finish before it decides. Anchored to the first chunk rather than to
+// spawn time deliberately: anchoring to spawn would make the window race
+// against Node boot + this helper's own module-graph load (a heavier helper
+// pulling in gh-exec etc. can itself take a while on a loaded CI runner),
+// which could let a raw trace slip through live on a slow machine. Anchored
+// to first-chunk, the only question the timer answers is "did more output
+// keep arriving after that", which is independent of startup latency.
+const GRACE_WINDOW_MS = 200;
 export function runHelper(relativeScriptPath) {
   const binDirectory = import.meta.dirname;
   const scriptPath = resolve(binDirectory, relativeScriptPath);
-  // Capture the child's stderr via a real file, not spawnSync's own piped
-  // buffer -- required to inspect it for a shaped parse error (#1922)
-  // before deciding what to forward. A PIPE, specifically, turns out to be
-  // unsafe for this: when a Node child dies from an uncaught exception, its
-  // internal fatal-exception write to a *piped* stderr can be silently
-  // truncated (confirmed empirically -- a multi-MB thrown message caps
-  // around ~146 KiB over a pipe, every time, regardless of spawnSync's own
-  // maxBuffer), because that crash path does not wait for the pipe's
-  // buffer to drain before the process hard-exits. Writing to a real file
-  // has no such ceiling (verified with the same repro): a file write isn't
-  // subject to the OS pipe-buffer-fill race the crash path loses. This
-  // capture-via-file step is *why* stdin/stdout stay 'inherit' below (no
-  // behavior change there) while only stderr routes through this
-  // temporary file.
-  // The whole capture lifecycle (open, spawn, read) runs inside this try so
-  // captureDir is always removed on the way out -- including if openSync or
-  // spawnSync itself throws synchronously, not just the ordinary success
-  // path (E10 follow-up on this fix: the first version only guarded the
-  // read-back step, leaking captureDir on either earlier failure).
-  const captureDir = mkdtempSync(join(tmpdir(), 'idd-run-helper-stderr-'));
-  try {
-    const capturePath = join(captureDir, 'stderr.log');
-    const captureFd = openSync(capturePath, 'w');
-    let result;
-    try {
-      result = spawnSync(
-        process.execPath,
-        [scriptPath, ...process.argv.slice(2)],
-        {
-          stdio: ['inherit', 'inherit', captureFd],
-        },
-      );
-    } finally {
-      closeSync(captureFd);
+  // Stream the child's stderr through a pipe -- not a temp file -- and
+  // decide what to do with it in real time. An earlier version of this fix
+  // captured stderr via a real file specifically to avoid a pipe's crash-
+  // write truncation (see below), but that traded away two things every
+  // packaged CLI command needs: (1) live/incremental stderr for long-
+  // running helpers (idd-doctor's `emitCleanupBacklogProgress` writes each
+  // line to stderr specifically so a slow serial scan is distinguishable
+  // from a hang -- a temp-file capture buffers all of it until exit,
+  // silently breaking that UX), and (2) never requiring writable temp
+  // storage just to run a CLI command that itself does no filesystem I/O
+  // (a temp-file capture made *every* invocation, including `--help`,
+  // hard-depend on `os.tmpdir()` being writable). Buffering only for a
+  // short bounded window after the first chunk, then committing to live
+  // pass-through, restores both properties while still catching the
+  // scenario this fix targets: a shaped parse error is a synchronous throw
+  // within milliseconds of startup, always well inside the window.
+  //
+  // Trade-off, disclosed rather than silently dropped: a pipe is still
+  // subject to Node's own crash-write behavior on an uncaught exception --
+  // when a child dies with stderr connected to a pipe, its internal
+  // fatal-exception write can be silently capped (empirically, around
+  // ~146 KiB), regardless of how fast the parent drains it, because that
+  // crash path does not wait for the pipe to drain before hard-exiting.
+  // This is not a new regression, though: under the pre-#1922 plain
+  // 'inherit' stdio, any operator piping this process's own stderr
+  // onward (`... 2>&1 | tee log`, common in CI) already inherited that
+  // same ceiling one layer up. No helper in this repository throws an
+  // error anywhere near that size; a temp file would remove the ceiling
+  // but reintroduces both regressions above to do it, which is the worse
+  // trade for realistic use.
+  const child = spawn(
+    process.execPath,
+    [scriptPath, ...process.argv.slice(2)],
+    { stdio: ['inherit', 'inherit', 'pipe'] },
+  );
+  let buffered = [];
+  let streaming = false;
+  let graceTimer = null;
+  const commitToStreaming = () => {
+    if (streaming) {
+      return;
     }
-    if (result.error) {
-      throw result.error;
+    streaming = true;
+    if (graceTimer !== null) {
+      clearTimeout(graceTimer);
+      graceTimer = null;
     }
-    const capturedStderr = readFileSync(capturePath, 'utf8');
-    const exitCode = result.status ?? 1;
+    for (const chunk of buffered) {
+      process.stderr.write(chunk);
+    }
+    buffered = [];
+  };
+  child.stderr?.on('data', (chunk) => {
+    if (streaming) {
+      process.stderr.write(chunk);
+      return;
+    }
+    buffered.push(chunk);
+    if (graceTimer === null) {
+      graceTimer = setTimeout(commitToStreaming, GRACE_WINDOW_MS);
+      // Doesn't itself keep the process alive -- only the child's own open
+      // stdio handles should do that, so a fast successful exit inside the
+      // window isn't held open an extra 200ms waiting on this timer.
+      graceTimer.unref();
+    }
+  });
+  child.on('error', (error) => {
+    if (graceTimer !== null) {
+      clearTimeout(graceTimer);
+      graceTimer = null;
+    }
+    throw error;
+  });
+  // 'close' (not 'exit') is the right event to decide on: it fires only
+  // after every stdio stream has fully drained, guaranteeing every stderr
+  // 'data' event above has already run. Deciding on 'exit' instead would
+  // race the tail of the child's crash output -- possibly the "Error: "
+  // line itself -- out of the buffer.
+  child.on('close', (code) => {
+    if (graceTimer !== null) {
+      clearTimeout(graceTimer);
+      graceTimer = null;
+    }
+    const exitCode = code ?? 1;
+    if (streaming) {
+      // Already committed to live pass-through -- every chunk reached the
+      // real stderr as it arrived, so there is nothing buffered left to
+      // decide on. This includes an intentional boundary: a shaped-
+      // looking error thrown *after* the window has elapsed streams live,
+      // raw trace and all, exactly like any other output at that point.
+      process.exitCode = exitCode;
+      return;
+    }
+    const capturedStderr = Buffer.concat(buffered).toString('utf8');
     // Only a non-zero exit is even eligible for shaped-error interception --
     // a successful run's stderr (e.g. idd-doctor's streamed progress) is
     // never inspected, so it always falls through to the unconditional
     // forward below unchanged.
     const shapedMessage =
-      result.status !== 0
-        ? extractShapedCliParseErrorMessage(capturedStderr)
-        : null;
+      exitCode !== 0 ? extractShapedCliParseErrorMessage(capturedStderr) : null;
     if (shapedMessage === null) {
       // No recognized shaped parse error -- a successful run, or an
       // unrelated failure: forward the captured stderr through
       // byte-for-byte, preserving a genuine bug's full stack trace.
-      if (capturedStderr) {
-        process.stderr.write(capturedStderr);
+      for (const chunk of buffered) {
+        process.stderr.write(chunk);
       }
-      // Setting exitCode and letting the module finish naturally (instead
-      // of calling process.exit() here) is deliberate: a write to a piped
-      // stderr is asynchronous (a write to a real file, as used for the
-      // capture above, is actually synchronous on both POSIX and Windows --
-      // it's specifically the pipe this process's own stdout/stderr may
-      // itself be redirected through, one layer up, that's at risk), and
-      // process.exit() does not wait for a pending async write to flush.
-      // Node only exits once the event loop drains, which happens after
-      // the write completes, so this is the correct pattern rather than an
-      // explicit exit call right after a write.
       process.exitCode = exitCode;
       return;
     }
@@ -95,14 +140,8 @@ export function runHelper(relativeScriptPath) {
     if (usage !== null) {
       process.stderr.write(`${usage}\n`);
     }
-    // Same flush reasoning as above -- the shaped message and usage line
-    // are always short, but exiting right after a write that hasn't
-    // flushed yet is the wrong pattern to establish even where it
-    // doesn't yet bite.
     process.exitCode = exitCode;
-  } finally {
-    rmSync(captureDir, { recursive: true, force: true });
-  }
+  });
 }
 /**
  * Best-effort re-invocation of the failing script's own `--help` output, to
@@ -117,7 +156,7 @@ export function runHelper(relativeScriptPath) {
  * line rather than risking the primary error-reporting path above. Ordinary
  * piped stdout capture is fine here (unlike stderr above) -- a `--help`
  * exit is always a clean `process.exit(0)`, never the uncaught-exception
- * crash path that motivates the temp-file capture.
+ * crash path the buffering above exists to detect.
  */
 function fetchUsageLine(scriptPath) {
   const helpResult = spawnSync(process.execPath, [scriptPath, '--help'], {

--- a/bin/run-helper.mjs
+++ b/bin/run-helper.mjs
@@ -5,66 +5,104 @@
 // above by `pnpm run build`. Edit the .mts source, never the generated
 // .mjs. See docs/typescript-sources.md.
 import { spawnSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import {
+  closeSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { extractShapedCliParseErrorMessage } from '../scripts/cli-args.mjs';
 
-// spawnSync's own default stderr maxBuffer is 1 MiB -- too small for a
-// helper that streams verbose diagnostic progress to stderr by design
-// (idd-doctor's post-merge cleanup-backlog sweep, for one -- see
-// docs/idd-helper-scripts.md). Piping stderr (instead of inheriting it,
-// below) is required to inspect it for a shaped parse error (#1922) before
-// deciding what to forward, so this buffer budget keeps that inspection
-// from truncating or killing a legitimately chatty run. Not unlimited --
-// spawnSync has no true streaming mode -- but generous enough that no
-// helper in this repository is expected to approach it.
-const STDERR_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 // Bounds the best-effort `--help` re-invocation used to fetch a usage line
 // below -- this must never hang the primary error-reporting path.
 const HELP_REINVOKE_TIMEOUT_MS = 5_000;
 export function runHelper(relativeScriptPath) {
   const binDirectory = import.meta.dirname;
   const scriptPath = resolve(binDirectory, relativeScriptPath);
-  const result = spawnSync(
-    process.execPath,
-    [scriptPath, ...process.argv.slice(2)],
-    {
-      // stdin/stdout stay live-inherited -- no behavior change for normal
-      // output. Only stderr is captured (piped) so it can be inspected for
-      // a shaped parse error before deciding what to forward; the known,
-      // accepted trade-off is that stderr is no longer streamed live to
-      // the terminal in real time, only flushed once the child exits.
-      stdio: ['inherit', 'inherit', 'pipe'],
-      encoding: 'utf8',
-      maxBuffer: STDERR_MAX_BUFFER_BYTES,
-    },
-  );
-  if (result.error) {
-    throw result.error;
-  }
-  const exitCode = result.status ?? 1;
-  // Only a non-zero exit is even eligible for shaped-error interception --
-  // a successful run's stderr (e.g. idd-doctor's streamed progress) is
-  // never inspected, so it always falls through to the unconditional
-  // forward below unchanged.
-  const shapedMessage =
-    result.status !== 0
-      ? extractShapedCliParseErrorMessage(result.stderr ?? '')
-      : null;
-  if (shapedMessage === null) {
-    // No recognized shaped parse error -- a successful run, or an
-    // unrelated failure: forward the captured stderr through
-    // byte-for-byte, preserving a genuine bug's full stack trace.
-    if (result.stderr) {
-      process.stderr.write(result.stderr);
+  // Capture the child's stderr via a real file, not spawnSync's own piped
+  // buffer -- required to inspect it for a shaped parse error (#1922)
+  // before deciding what to forward. A PIPE, specifically, turns out to be
+  // unsafe for this: when a Node child dies from an uncaught exception, its
+  // internal fatal-exception write to a *piped* stderr can be silently
+  // truncated (confirmed empirically -- a multi-MB thrown message caps
+  // around ~146 KiB over a pipe, every time, regardless of spawnSync's own
+  // maxBuffer), because that crash path does not wait for the pipe's
+  // buffer to drain before the process hard-exits. Writing to a real file
+  // has no such ceiling (verified with the same repro): a file write isn't
+  // subject to the OS pipe-buffer-fill race the crash path loses. This
+  // capture-via-file step is *why* stdin/stdout stay 'inherit' below (no
+  // behavior change there) while only stderr routes through this
+  // temporary file.
+  // The whole capture lifecycle (open, spawn, read) runs inside this try so
+  // captureDir is always removed on the way out -- including if openSync or
+  // spawnSync itself throws synchronously, not just the ordinary success
+  // path (E10 follow-up on this fix: the first version only guarded the
+  // read-back step, leaking captureDir on either earlier failure).
+  const captureDir = mkdtempSync(join(tmpdir(), 'idd-run-helper-stderr-'));
+  try {
+    const capturePath = join(captureDir, 'stderr.log');
+    const captureFd = openSync(capturePath, 'w');
+    let result;
+    try {
+      result = spawnSync(
+        process.execPath,
+        [scriptPath, ...process.argv.slice(2)],
+        {
+          stdio: ['inherit', 'inherit', captureFd],
+        },
+      );
+    } finally {
+      closeSync(captureFd);
     }
-    process.exit(exitCode);
+    if (result.error) {
+      throw result.error;
+    }
+    const capturedStderr = readFileSync(capturePath, 'utf8');
+    const exitCode = result.status ?? 1;
+    // Only a non-zero exit is even eligible for shaped-error interception --
+    // a successful run's stderr (e.g. idd-doctor's streamed progress) is
+    // never inspected, so it always falls through to the unconditional
+    // forward below unchanged.
+    const shapedMessage =
+      result.status !== 0
+        ? extractShapedCliParseErrorMessage(capturedStderr)
+        : null;
+    if (shapedMessage === null) {
+      // No recognized shaped parse error -- a successful run, or an
+      // unrelated failure: forward the captured stderr through
+      // byte-for-byte, preserving a genuine bug's full stack trace.
+      if (capturedStderr) {
+        process.stderr.write(capturedStderr);
+      }
+      // Setting exitCode and letting the module finish naturally (instead
+      // of calling process.exit() here) is deliberate: a write to a piped
+      // stderr is asynchronous (a write to a real file, as used for the
+      // capture above, is actually synchronous on both POSIX and Windows --
+      // it's specifically the pipe this process's own stdout/stderr may
+      // itself be redirected through, one layer up, that's at risk), and
+      // process.exit() does not wait for a pending async write to flush.
+      // Node only exits once the event loop drains, which happens after
+      // the write completes, so this is the correct pattern rather than an
+      // explicit exit call right after a write.
+      process.exitCode = exitCode;
+      return;
+    }
+    process.stderr.write(`${shapedMessage}\n`);
+    const usage = fetchUsageLine(scriptPath);
+    if (usage !== null) {
+      process.stderr.write(`${usage}\n`);
+    }
+    // Same flush reasoning as above -- the shaped message and usage line
+    // are always short, but exiting right after a write that hasn't
+    // flushed yet is the wrong pattern to establish even where it
+    // doesn't yet bite.
+    process.exitCode = exitCode;
+  } finally {
+    rmSync(captureDir, { recursive: true, force: true });
   }
-  process.stderr.write(`${shapedMessage}\n`);
-  const usage = fetchUsageLine(scriptPath);
-  if (usage !== null) {
-    process.stderr.write(`${usage}\n`);
-  }
-  process.exit(exitCode);
 }
 /**
  * Best-effort re-invocation of the failing script's own `--help` output, to
@@ -76,7 +114,10 @@ export function runHelper(relativeScriptPath) {
  * throws "unknown argument: --help", which surfaces here as a non-zero
  * exit and is treated the same as "no usage available". Always optional:
  * any spawn error, non-zero exit, or timeout degrades silently to no usage
- * line rather than risking the primary error-reporting path above.
+ * line rather than risking the primary error-reporting path above. Ordinary
+ * piped stdout capture is fine here (unlike stderr above) -- a `--help`
+ * exit is always a clean `process.exit(0)`, never the uncaught-exception
+ * crash path that motivates the temp-file capture.
  */
 function fetchUsageLine(scriptPath) {
   const helpResult = spawnSync(process.execPath, [scriptPath, '--help'], {

--- a/bin/run-helper.mjs
+++ b/bin/run-helper.mjs
@@ -6,6 +6,21 @@
 // .mjs. See docs/typescript-sources.md.
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
+import { extractShapedCliParseErrorMessage } from '../scripts/cli-args.mjs';
+
+// spawnSync's own default stderr maxBuffer is 1 MiB -- too small for a
+// helper that streams verbose diagnostic progress to stderr by design
+// (idd-doctor's post-merge cleanup-backlog sweep, for one -- see
+// docs/idd-helper-scripts.md). Piping stderr (instead of inheriting it,
+// below) is required to inspect it for a shaped parse error (#1922) before
+// deciding what to forward, so this buffer budget keeps that inspection
+// from truncating or killing a legitimately chatty run. Not unlimited --
+// spawnSync has no true streaming mode -- but generous enough that no
+// helper in this repository is expected to approach it.
+const STDERR_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+// Bounds the best-effort `--help` re-invocation used to fetch a usage line
+// below -- this must never hang the primary error-reporting path.
+const HELP_REINVOKE_TIMEOUT_MS = 5_000;
 export function runHelper(relativeScriptPath) {
   const binDirectory = import.meta.dirname;
   const scriptPath = resolve(binDirectory, relativeScriptPath);
@@ -13,11 +28,64 @@ export function runHelper(relativeScriptPath) {
     process.execPath,
     [scriptPath, ...process.argv.slice(2)],
     {
-      stdio: 'inherit',
+      // stdin/stdout stay live-inherited -- no behavior change for normal
+      // output. Only stderr is captured (piped) so it can be inspected for
+      // a shaped parse error before deciding what to forward; the known,
+      // accepted trade-off is that stderr is no longer streamed live to
+      // the terminal in real time, only flushed once the child exits.
+      stdio: ['inherit', 'inherit', 'pipe'],
+      encoding: 'utf8',
+      maxBuffer: STDERR_MAX_BUFFER_BYTES,
     },
   );
   if (result.error) {
     throw result.error;
   }
-  process.exit(result.status ?? 1);
+  const exitCode = result.status ?? 1;
+  // Only a non-zero exit is even eligible for shaped-error interception --
+  // a successful run's stderr (e.g. idd-doctor's streamed progress) is
+  // never inspected, so it always falls through to the unconditional
+  // forward below unchanged.
+  const shapedMessage =
+    result.status !== 0
+      ? extractShapedCliParseErrorMessage(result.stderr ?? '')
+      : null;
+  if (shapedMessage === null) {
+    // No recognized shaped parse error -- a successful run, or an
+    // unrelated failure: forward the captured stderr through
+    // byte-for-byte, preserving a genuine bug's full stack trace.
+    if (result.stderr) {
+      process.stderr.write(result.stderr);
+    }
+    process.exit(exitCode);
+  }
+  process.stderr.write(`${shapedMessage}\n`);
+  const usage = fetchUsageLine(scriptPath);
+  if (usage !== null) {
+    process.stderr.write(`${usage}\n`);
+  }
+  process.exit(exitCode);
+}
+/**
+ * Best-effort re-invocation of the failing script's own `--help` output, to
+ * append "the calling script's own usage line" (#1922's acceptance
+ * criteria) after a shaped parse-error message. Every `--help` path among
+ * this repository's `parseCliArgs`-based helpers exits 0 before any
+ * network or `gh` call (see tests/help-text-flags.test.mts), but `--help`
+ * is not guaranteed to be declared at all -- an undeclared `--help` itself
+ * throws "unknown argument: --help", which surfaces here as a non-zero
+ * exit and is treated the same as "no usage available". Always optional:
+ * any spawn error, non-zero exit, or timeout degrades silently to no usage
+ * line rather than risking the primary error-reporting path above.
+ */
+function fetchUsageLine(scriptPath) {
+  const helpResult = spawnSync(process.execPath, [scriptPath, '--help'], {
+    encoding: 'utf8',
+    timeout: HELP_REINVOKE_TIMEOUT_MS,
+  });
+  if (helpResult.error || helpResult.status !== 0) {
+    return null;
+  }
+  const usage = helpResult.stdout?.trim();
+  return usage ? usage : null;
 }

--- a/scripts/cli-args.mjs
+++ b/scripts/cli-args.mjs
@@ -268,7 +268,17 @@ export function extractShapedCliParseErrorMessage(stderrText) {
   // from its own "Error: " line up to (but not including) whichever comes
   // first: a stack-frame line, the next "Error: " line, or the end of the
   // text.
-  const lines = stderrText.split('\n');
+  //
+  // Split on `/\r?\n/`, not a plain `'\n'` (Copilot review finding): on
+  // CRLF stderr (e.g. Windows), a plain `'\n'` split leaves a trailing
+  // `\r` on every line, which does more than cosmetically taint the
+  // captured message with a stray `\r` -- ERROR_LINE_PATTERN's un-anchored
+  // (non-multiline) `$` cannot match before that leftover `\r` at all, so
+  // the "Error: " line fails to match this pattern altogether and the
+  // whole shaped error goes undetected, silently falling back to the raw
+  // stack trace on the one platform (Windows) this repository explicitly
+  // supports.
+  const lines = stderrText.split(/\r?\n/);
   for (let index = 0; index < lines.length; index += 1) {
     const match = ERROR_LINE_PATTERN.exec(lines[index]);
     if (match === null) {

--- a/scripts/cli-args.mjs
+++ b/scripts/cli-args.mjs
@@ -50,6 +50,21 @@
 // #1450/#1451 first needs them.
 import { parseArgs as nodeParseArgs } from 'node:util';
 
+// #1922: the three message-shape prefixes toRepoShapedError() below
+// produces. Named here (rather than inlined at each call site) so
+// extractShapedCliParseErrorMessage() can recognize the exact same shapes
+// from raw text -- across the bin/run-helper.mts subprocess boundary,
+// where only the child's captured stderr text is visible, never the
+// original Error object -- without either copy silently drifting out of
+// sync with the other.
+const UNKNOWN_ARGUMENT_PREFIX = 'unknown argument: ';
+const MISSING_VALUE_FOR_ARGUMENT_PREFIX = 'missing value for argument: ';
+const UNEXPECTED_VALUE_FOR_ARGUMENT_PREFIX = 'unexpected value for argument: ';
+const REPO_SHAPED_CLI_PARSE_ERROR_PREFIXES = [
+  UNKNOWN_ARGUMENT_PREFIX,
+  MISSING_VALUE_FOR_ARGUMENT_PREFIX,
+  UNEXPECTED_VALUE_FOR_ARGUMENT_PREFIX,
+];
 const NODE_OPTION_KEY_PATTERN = /^--[A-Za-z0-9][A-Za-z0-9-]*$/;
 /**
  * Node's native `util.parseArgs` (`strict: true`) throws
@@ -211,16 +226,41 @@ function toRepoShapedError(error) {
   switch (err.code) {
     case 'ERR_PARSE_ARGS_UNKNOWN_OPTION':
     case 'ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL':
-      return new Error(`unknown argument: ${token}`);
+      return new Error(`${UNKNOWN_ARGUMENT_PREFIX}${token}`);
     case 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE':
       return new Error(
         err.message.includes('does not take an argument')
-          ? `unexpected value for argument: ${token}`
-          : `missing value for argument: ${token}`,
+          ? `${UNEXPECTED_VALUE_FOR_ARGUMENT_PREFIX}${token}`
+          : `${MISSING_VALUE_FOR_ARGUMENT_PREFIX}${token}`,
       );
     default:
       return err;
   }
+}
+/**
+ * Recognize Node's default uncaught-exception stderr text for a shaped CLI
+ * parse error (#1922) and extract just the one-line message, discarding
+ * the source-line preview, stack frames, and trailing `Node.js vX.Y.Z`
+ * footer Node prints around it. Scans **every** `Error: ` -prefixed line in
+ * the text -- not just the first -- and returns the first whose message
+ * starts with one of the three shapes {@link toRepoShapedError} produces,
+ * so a script that logs its own unrelated `Error: ...` diagnostic before a
+ * later real crash can't mask the shaped line. Returns `null` when no line
+ * matches, the safe default: a caller should forward the original text
+ * unchanged in that case, exactly as it would for any other error class.
+ */
+export function extractShapedCliParseErrorMessage(stderrText) {
+  for (const match of stderrText.matchAll(/^Error: (.+)$/gm)) {
+    const message = match[1];
+    if (
+      REPO_SHAPED_CLI_PARSE_ERROR_PREFIXES.some((prefix) =>
+        message.startsWith(prefix),
+      )
+    ) {
+      return message;
+    }
+  }
+  return null;
 }
 /**
  * Parse `argv` against a declarative flag spec, using `util.parseArgs`
@@ -259,7 +299,7 @@ export function parseCliArgs(argv, spec) {
   // --`, since the second `--` becomes a rejected positional). The strip
   // above never repeats -- this is a single explicit check, not a loop.
   if (args[0] === '--') {
-    throw new Error('unknown argument: --');
+    throw new Error(`${UNKNOWN_ARGUMENT_PREFIX}--`);
   }
   let parsed;
   try {

--- a/scripts/cli-args.mjs
+++ b/scripts/cli-args.mjs
@@ -249,9 +249,42 @@ function toRepoShapedError(error) {
  * matches, the safe default: a caller should forward the original text
  * unchanged in that case, exactly as it would for any other error class.
  */
+// Node's own stack-frame rendering, always "    at ..." (4+ spaces). Used
+// to find where a captured message ends -- see extractShapedCliParseErrorMessage's
+// line-scan below.
+const STACK_FRAME_LINE_PATTERN = /^\s+at /;
+// A line starting a new "Error: " block. Reused both to *find* candidate
+// blocks and to know where the *previous* block's message ends (a second
+// "Error: " line immediately terminates the one before it, same as a
+// stack frame would).
+const ERROR_LINE_PATTERN = /^Error: (.*)$/;
 export function extractShapedCliParseErrorMessage(stderrText) {
-  for (const match of stderrText.matchAll(/^Error: (.+)$/gm)) {
-    const message = match[1];
+  // Line-based, not a single regex: a shaped message can itself contain an
+  // embedded newline (e.g. a stray positional argument whose literal value
+  // spans multiple lines -- the underlying parseCliArgs() error already
+  // preserves that verbatim; this scan must too, rather than truncating at
+  // the first line via a `.`-based pattern, which silently drops
+  // everything after the first embedded newline). A message block runs
+  // from its own "Error: " line up to (but not including) whichever comes
+  // first: a stack-frame line, the next "Error: " line, or the end of the
+  // text.
+  const lines = stderrText.split('\n');
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = ERROR_LINE_PATTERN.exec(lines[index]);
+    if (match === null) {
+      continue;
+    }
+    const messageLines = [match[1]];
+    let cursor = index + 1;
+    while (
+      cursor < lines.length &&
+      !STACK_FRAME_LINE_PATTERN.test(lines[cursor]) &&
+      !ERROR_LINE_PATTERN.test(lines[cursor])
+    ) {
+      messageLines.push(lines[cursor]);
+      cursor += 1;
+    }
+    const message = messageLines.join('\n');
     if (
       REPO_SHAPED_CLI_PARSE_ERROR_PREFIXES.some((prefix) =>
         message.startsWith(prefix),

--- a/scripts/cli-args.mjs
+++ b/scripts/cli-args.mjs
@@ -258,6 +258,20 @@ const STACK_FRAME_LINE_PATTERN = /^\s+at /;
 // "Error: " line immediately terminates the one before it, same as a
 // stack frame would).
 const ERROR_LINE_PATTERN = /^Error: (.*)$/;
+// `NODE_OPTIONS=--stack-trace-limit=0` (a supported Node runtime option, not
+// an adversarial input) changes Node's uncaught-exception rendering to a
+// single bracketed `[Error: message]` line with no stack frames at all
+// (chatgpt-codex-connector review finding) -- verified empirically:
+// `NODE_OPTIONS='--stack-trace-limit=0' node bin/idd-branch-name.mjs
+// --bogus` prints `[Error: unknown argument: --bogus]` with none of the
+// usual "Error: "-prefixed / "    at " structure this module otherwise
+// relies on. Handled as its own single-line case, not folded into the
+// line-scan loop above: a message that itself happens to span multiple
+// lines under this zero-stack bracketed form has no unambiguous
+// terminator to scan for (no stack frame ever follows to mark the end),
+// so that narrower intersection is a disclosed, accepted gap rather than
+// something this pattern attempts to solve.
+const BRACKETED_ZERO_STACK_ERROR_LINE_PATTERN = /^\[Error: (.*)\]$/;
 export function extractShapedCliParseErrorMessage(stderrText) {
   // Line-based, not a single regex: a shaped message can itself contain an
   // embedded newline (e.g. a stray positional argument whose literal value
@@ -280,6 +294,12 @@ export function extractShapedCliParseErrorMessage(stderrText) {
   // supports.
   const lines = stderrText.split(/\r?\n/);
   for (let index = 0; index < lines.length; index += 1) {
+    const bracketed = BRACKETED_ZERO_STACK_ERROR_LINE_PATTERN.exec(
+      lines[index],
+    );
+    if (bracketed !== null && isShapedMessage(bracketed[1])) {
+      return bracketed[1];
+    }
     const match = ERROR_LINE_PATTERN.exec(lines[index]);
     if (match === null) {
       continue;
@@ -295,15 +315,16 @@ export function extractShapedCliParseErrorMessage(stderrText) {
       cursor += 1;
     }
     const message = messageLines.join('\n');
-    if (
-      REPO_SHAPED_CLI_PARSE_ERROR_PREFIXES.some((prefix) =>
-        message.startsWith(prefix),
-      )
-    ) {
+    if (isShapedMessage(message)) {
       return message;
     }
   }
   return null;
+}
+function isShapedMessage(message) {
+  return REPO_SHAPED_CLI_PARSE_ERROR_PREFIXES.some((prefix) =>
+    message.startsWith(prefix),
+  );
 }
 /**
  * Parse `argv` against a declarative flag spec, using `util.parseArgs`

--- a/src/bin/idd-review-disposition-verify.mts
+++ b/src/bin/idd-review-disposition-verify.mts
@@ -9,24 +9,6 @@
  * Bin wrapper for review-disposition-verify helper
  */
 
-import { spawn } from 'node:child_process';
-import { resolve } from 'node:path';
+import { runHelper } from './run-helper.mts';
 
-const currentDir = import.meta.dirname;
-const scriptPath = resolve(
-  currentDir,
-  '../scripts/review-disposition-verify.mjs',
-);
-
-const child = spawn('node', [scriptPath, ...process.argv.slice(2)], {
-  stdio: 'inherit',
-});
-
-child.on('exit', (code) => {
-  process.exit(code ?? 0);
-});
-
-child.on('error', (error) => {
-  console.error('Failed to spawn review-disposition-verify:', error);
-  process.exit(1);
-});
+runHelper('../scripts/review-disposition-verify.mjs');

--- a/src/bin/run-helper.mts
+++ b/src/bin/run-helper.mts
@@ -6,20 +6,18 @@
 // .mjs. See docs/typescript-sources.md.
 
 import { spawnSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import {
+  closeSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 
 import { extractShapedCliParseErrorMessage } from '../scripts/cli-args.mts';
 
-// spawnSync's own default stderr maxBuffer is 1 MiB -- too small for a
-// helper that streams verbose diagnostic progress to stderr by design
-// (idd-doctor's post-merge cleanup-backlog sweep, for one -- see
-// docs/idd-helper-scripts.md). Piping stderr (instead of inheriting it,
-// below) is required to inspect it for a shaped parse error (#1922) before
-// deciding what to forward, so this buffer budget keeps that inspection
-// from truncating or killing a legitimately chatty run. Not unlimited --
-// spawnSync has no true streaming mode -- but generous enough that no
-// helper in this repository is expected to approach it.
-const STDERR_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 // Bounds the best-effort `--help` re-invocation used to fetch a usage line
 // below -- this must never hang the primary error-reporting path.
 const HELP_REINVOKE_TIMEOUT_MS = 5_000;
@@ -27,51 +25,92 @@ const HELP_REINVOKE_TIMEOUT_MS = 5_000;
 export function runHelper(relativeScriptPath: string): void {
   const binDirectory = import.meta.dirname;
   const scriptPath = resolve(binDirectory, relativeScriptPath);
-  const result = spawnSync(
-    process.execPath,
-    [scriptPath, ...process.argv.slice(2)],
-    {
-      // stdin/stdout stay live-inherited -- no behavior change for normal
-      // output. Only stderr is captured (piped) so it can be inspected for
-      // a shaped parse error before deciding what to forward; the known,
-      // accepted trade-off is that stderr is no longer streamed live to
-      // the terminal in real time, only flushed once the child exits.
-      stdio: ['inherit', 'inherit', 'pipe'],
-      encoding: 'utf8',
-      maxBuffer: STDERR_MAX_BUFFER_BYTES,
-    },
-  );
 
-  if (result.error) {
-    throw result.error;
-  }
-
-  const exitCode = result.status ?? 1;
-  // Only a non-zero exit is even eligible for shaped-error interception --
-  // a successful run's stderr (e.g. idd-doctor's streamed progress) is
-  // never inspected, so it always falls through to the unconditional
-  // forward below unchanged.
-  const shapedMessage =
-    result.status !== 0
-      ? extractShapedCliParseErrorMessage(result.stderr ?? '')
-      : null;
-
-  if (shapedMessage === null) {
-    // No recognized shaped parse error -- a successful run, or an
-    // unrelated failure: forward the captured stderr through
-    // byte-for-byte, preserving a genuine bug's full stack trace.
-    if (result.stderr) {
-      process.stderr.write(result.stderr);
+  // Capture the child's stderr via a real file, not spawnSync's own piped
+  // buffer -- required to inspect it for a shaped parse error (#1922)
+  // before deciding what to forward. A PIPE, specifically, turns out to be
+  // unsafe for this: when a Node child dies from an uncaught exception, its
+  // internal fatal-exception write to a *piped* stderr can be silently
+  // truncated (confirmed empirically -- a multi-MB thrown message caps
+  // around ~146 KiB over a pipe, every time, regardless of spawnSync's own
+  // maxBuffer), because that crash path does not wait for the pipe's
+  // buffer to drain before the process hard-exits. Writing to a real file
+  // has no such ceiling (verified with the same repro): a file write isn't
+  // subject to the OS pipe-buffer-fill race the crash path loses. This
+  // capture-via-file step is *why* stdin/stdout stay 'inherit' below (no
+  // behavior change there) while only stderr routes through this
+  // temporary file.
+  // The whole capture lifecycle (open, spawn, read) runs inside this try so
+  // captureDir is always removed on the way out -- including if openSync or
+  // spawnSync itself throws synchronously, not just the ordinary success
+  // path (E10 follow-up on this fix: the first version only guarded the
+  // read-back step, leaking captureDir on either earlier failure).
+  const captureDir = mkdtempSync(join(tmpdir(), 'idd-run-helper-stderr-'));
+  try {
+    const capturePath = join(captureDir, 'stderr.log');
+    const captureFd = openSync(capturePath, 'w');
+    let result: ReturnType<typeof spawnSync>;
+    try {
+      result = spawnSync(
+        process.execPath,
+        [scriptPath, ...process.argv.slice(2)],
+        {
+          stdio: ['inherit', 'inherit', captureFd],
+        },
+      );
+    } finally {
+      closeSync(captureFd);
     }
-    process.exit(exitCode);
-  }
 
-  process.stderr.write(`${shapedMessage}\n`);
-  const usage = fetchUsageLine(scriptPath);
-  if (usage !== null) {
-    process.stderr.write(`${usage}\n`);
+    if (result.error) {
+      throw result.error;
+    }
+
+    const capturedStderr = readFileSync(capturePath, 'utf8');
+    const exitCode = result.status ?? 1;
+    // Only a non-zero exit is even eligible for shaped-error interception --
+    // a successful run's stderr (e.g. idd-doctor's streamed progress) is
+    // never inspected, so it always falls through to the unconditional
+    // forward below unchanged.
+    const shapedMessage =
+      result.status !== 0
+        ? extractShapedCliParseErrorMessage(capturedStderr)
+        : null;
+
+    if (shapedMessage === null) {
+      // No recognized shaped parse error -- a successful run, or an
+      // unrelated failure: forward the captured stderr through
+      // byte-for-byte, preserving a genuine bug's full stack trace.
+      if (capturedStderr) {
+        process.stderr.write(capturedStderr);
+      }
+      // Setting exitCode and letting the module finish naturally (instead
+      // of calling process.exit() here) is deliberate: a write to a piped
+      // stderr is asynchronous (a write to a real file, as used for the
+      // capture above, is actually synchronous on both POSIX and Windows --
+      // it's specifically the pipe this process's own stdout/stderr may
+      // itself be redirected through, one layer up, that's at risk), and
+      // process.exit() does not wait for a pending async write to flush.
+      // Node only exits once the event loop drains, which happens after
+      // the write completes, so this is the correct pattern rather than an
+      // explicit exit call right after a write.
+      process.exitCode = exitCode;
+      return;
+    }
+
+    process.stderr.write(`${shapedMessage}\n`);
+    const usage = fetchUsageLine(scriptPath);
+    if (usage !== null) {
+      process.stderr.write(`${usage}\n`);
+    }
+    // Same flush reasoning as above -- the shaped message and usage line
+    // are always short, but exiting right after a write that hasn't
+    // flushed yet is the wrong pattern to establish even where it
+    // doesn't yet bite.
+    process.exitCode = exitCode;
+  } finally {
+    rmSync(captureDir, { recursive: true, force: true });
   }
-  process.exit(exitCode);
 }
 
 /**
@@ -84,7 +123,10 @@ export function runHelper(relativeScriptPath: string): void {
  * throws "unknown argument: --help", which surfaces here as a non-zero
  * exit and is treated the same as "no usage available". Always optional:
  * any spawn error, non-zero exit, or timeout degrades silently to no usage
- * line rather than risking the primary error-reporting path above.
+ * line rather than risking the primary error-reporting path above. Ordinary
+ * piped stdout capture is fine here (unlike stderr above) -- a `--help`
+ * exit is always a clean `process.exit(0)`, never the uncaught-exception
+ * crash path that motivates the temp-file capture.
  */
 function fetchUsageLine(scriptPath: string): string | null {
   const helpResult = spawnSync(process.execPath, [scriptPath, '--help'], {

--- a/src/bin/run-helper.mts
+++ b/src/bin/run-helper.mts
@@ -5,16 +5,8 @@
 // above by `pnpm run build`. Edit the .mts source, never the generated
 // .mjs. See docs/typescript-sources.md.
 
-import { spawnSync } from 'node:child_process';
-import {
-  closeSync,
-  mkdtempSync,
-  openSync,
-  readFileSync,
-  rmSync,
-} from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
 
 import { extractShapedCliParseErrorMessage } from '../scripts/cli-args.mts';
 
@@ -22,78 +14,138 @@ import { extractShapedCliParseErrorMessage } from '../scripts/cli-args.mts';
 // below -- this must never hang the primary error-reporting path.
 const HELP_REINVOKE_TIMEOUT_MS = 5_000;
 
+// How long, after the child's *first* stderr chunk arrives, run-helper keeps
+// buffering (instead of forwarding live) to give a shaped parse error --
+// always an instant, synchronous crash right after startup -- a chance to
+// finish before it decides. Anchored to the first chunk rather than to
+// spawn time deliberately: anchoring to spawn would make the window race
+// against Node boot + this helper's own module-graph load (a heavier helper
+// pulling in gh-exec etc. can itself take a while on a loaded CI runner),
+// which could let a raw trace slip through live on a slow machine. Anchored
+// to first-chunk, the only question the timer answers is "did more output
+// keep arriving after that", which is independent of startup latency.
+const GRACE_WINDOW_MS = 200;
+
 export function runHelper(relativeScriptPath: string): void {
   const binDirectory = import.meta.dirname;
   const scriptPath = resolve(binDirectory, relativeScriptPath);
 
-  // Capture the child's stderr via a real file, not spawnSync's own piped
-  // buffer -- required to inspect it for a shaped parse error (#1922)
-  // before deciding what to forward. A PIPE, specifically, turns out to be
-  // unsafe for this: when a Node child dies from an uncaught exception, its
-  // internal fatal-exception write to a *piped* stderr can be silently
-  // truncated (confirmed empirically -- a multi-MB thrown message caps
-  // around ~146 KiB over a pipe, every time, regardless of spawnSync's own
-  // maxBuffer), because that crash path does not wait for the pipe's
-  // buffer to drain before the process hard-exits. Writing to a real file
-  // has no such ceiling (verified with the same repro): a file write isn't
-  // subject to the OS pipe-buffer-fill race the crash path loses. This
-  // capture-via-file step is *why* stdin/stdout stay 'inherit' below (no
-  // behavior change there) while only stderr routes through this
-  // temporary file.
-  // The whole capture lifecycle (open, spawn, read) runs inside this try so
-  // captureDir is always removed on the way out -- including if openSync or
-  // spawnSync itself throws synchronously, not just the ordinary success
-  // path (E10 follow-up on this fix: the first version only guarded the
-  // read-back step, leaking captureDir on either earlier failure).
-  const captureDir = mkdtempSync(join(tmpdir(), 'idd-run-helper-stderr-'));
-  try {
-    const capturePath = join(captureDir, 'stderr.log');
-    const captureFd = openSync(capturePath, 'w');
-    let result: ReturnType<typeof spawnSync>;
-    try {
-      result = spawnSync(
-        process.execPath,
-        [scriptPath, ...process.argv.slice(2)],
-        {
-          stdio: ['inherit', 'inherit', captureFd],
-        },
-      );
-    } finally {
-      closeSync(captureFd);
+  // Stream the child's stderr through a pipe -- not a temp file -- and
+  // decide what to do with it in real time. An earlier version of this fix
+  // captured stderr via a real file specifically to avoid a pipe's crash-
+  // write truncation (see below), but that traded away two things every
+  // packaged CLI command needs: (1) live/incremental stderr for long-
+  // running helpers (idd-doctor's `emitCleanupBacklogProgress` writes each
+  // line to stderr specifically so a slow serial scan is distinguishable
+  // from a hang -- a temp-file capture buffers all of it until exit,
+  // silently breaking that UX), and (2) never requiring writable temp
+  // storage just to run a CLI command that itself does no filesystem I/O
+  // (a temp-file capture made *every* invocation, including `--help`,
+  // hard-depend on `os.tmpdir()` being writable). Buffering only for a
+  // short bounded window after the first chunk, then committing to live
+  // pass-through, restores both properties while still catching the
+  // scenario this fix targets: a shaped parse error is a synchronous throw
+  // within milliseconds of startup, always well inside the window.
+  //
+  // Trade-off, disclosed rather than silently dropped: a pipe is still
+  // subject to Node's own crash-write behavior on an uncaught exception --
+  // when a child dies with stderr connected to a pipe, its internal
+  // fatal-exception write can be silently capped (empirically, around
+  // ~146 KiB), regardless of how fast the parent drains it, because that
+  // crash path does not wait for the pipe to drain before hard-exiting.
+  // This is not a new regression, though: under the pre-#1922 plain
+  // 'inherit' stdio, any operator piping this process's own stderr
+  // onward (`... 2>&1 | tee log`, common in CI) already inherited that
+  // same ceiling one layer up. No helper in this repository throws an
+  // error anywhere near that size; a temp file would remove the ceiling
+  // but reintroduces both regressions above to do it, which is the worse
+  // trade for realistic use.
+  const child = spawn(
+    process.execPath,
+    [scriptPath, ...process.argv.slice(2)],
+    { stdio: ['inherit', 'inherit', 'pipe'] },
+  );
+
+  let buffered: Buffer[] = [];
+  let streaming = false;
+  let graceTimer: NodeJS.Timeout | null = null;
+
+  const commitToStreaming = () => {
+    if (streaming) {
+      return;
+    }
+    streaming = true;
+    if (graceTimer !== null) {
+      clearTimeout(graceTimer);
+      graceTimer = null;
+    }
+    for (const chunk of buffered) {
+      process.stderr.write(chunk);
+    }
+    buffered = [];
+  };
+
+  child.stderr?.on('data', (chunk: Buffer) => {
+    if (streaming) {
+      process.stderr.write(chunk);
+      return;
+    }
+    buffered.push(chunk);
+    if (graceTimer === null) {
+      graceTimer = setTimeout(commitToStreaming, GRACE_WINDOW_MS);
+      // Doesn't itself keep the process alive -- only the child's own open
+      // stdio handles should do that, so a fast successful exit inside the
+      // window isn't held open an extra 200ms waiting on this timer.
+      graceTimer.unref();
+    }
+  });
+
+  child.on('error', (error) => {
+    if (graceTimer !== null) {
+      clearTimeout(graceTimer);
+      graceTimer = null;
+    }
+    throw error;
+  });
+
+  // 'close' (not 'exit') is the right event to decide on: it fires only
+  // after every stdio stream has fully drained, guaranteeing every stderr
+  // 'data' event above has already run. Deciding on 'exit' instead would
+  // race the tail of the child's crash output -- possibly the "Error: "
+  // line itself -- out of the buffer.
+  child.on('close', (code) => {
+    if (graceTimer !== null) {
+      clearTimeout(graceTimer);
+      graceTimer = null;
     }
 
-    if (result.error) {
-      throw result.error;
+    const exitCode = code ?? 1;
+
+    if (streaming) {
+      // Already committed to live pass-through -- every chunk reached the
+      // real stderr as it arrived, so there is nothing buffered left to
+      // decide on. This includes an intentional boundary: a shaped-
+      // looking error thrown *after* the window has elapsed streams live,
+      // raw trace and all, exactly like any other output at that point.
+      process.exitCode = exitCode;
+      return;
     }
 
-    const capturedStderr = readFileSync(capturePath, 'utf8');
-    const exitCode = result.status ?? 1;
+    const capturedStderr = Buffer.concat(buffered).toString('utf8');
     // Only a non-zero exit is even eligible for shaped-error interception --
     // a successful run's stderr (e.g. idd-doctor's streamed progress) is
     // never inspected, so it always falls through to the unconditional
     // forward below unchanged.
     const shapedMessage =
-      result.status !== 0
-        ? extractShapedCliParseErrorMessage(capturedStderr)
-        : null;
+      exitCode !== 0 ? extractShapedCliParseErrorMessage(capturedStderr) : null;
 
     if (shapedMessage === null) {
       // No recognized shaped parse error -- a successful run, or an
       // unrelated failure: forward the captured stderr through
       // byte-for-byte, preserving a genuine bug's full stack trace.
-      if (capturedStderr) {
-        process.stderr.write(capturedStderr);
+      for (const chunk of buffered) {
+        process.stderr.write(chunk);
       }
-      // Setting exitCode and letting the module finish naturally (instead
-      // of calling process.exit() here) is deliberate: a write to a piped
-      // stderr is asynchronous (a write to a real file, as used for the
-      // capture above, is actually synchronous on both POSIX and Windows --
-      // it's specifically the pipe this process's own stdout/stderr may
-      // itself be redirected through, one layer up, that's at risk), and
-      // process.exit() does not wait for a pending async write to flush.
-      // Node only exits once the event loop drains, which happens after
-      // the write completes, so this is the correct pattern rather than an
-      // explicit exit call right after a write.
       process.exitCode = exitCode;
       return;
     }
@@ -103,14 +155,8 @@ export function runHelper(relativeScriptPath: string): void {
     if (usage !== null) {
       process.stderr.write(`${usage}\n`);
     }
-    // Same flush reasoning as above -- the shaped message and usage line
-    // are always short, but exiting right after a write that hasn't
-    // flushed yet is the wrong pattern to establish even where it
-    // doesn't yet bite.
     process.exitCode = exitCode;
-  } finally {
-    rmSync(captureDir, { recursive: true, force: true });
-  }
+  });
 }
 
 /**
@@ -126,7 +172,7 @@ export function runHelper(relativeScriptPath: string): void {
  * line rather than risking the primary error-reporting path above. Ordinary
  * piped stdout capture is fine here (unlike stderr above) -- a `--help`
  * exit is always a clean `process.exit(0)`, never the uncaught-exception
- * crash path that motivates the temp-file capture.
+ * crash path the buffering above exists to detect.
  */
 function fetchUsageLine(scriptPath: string): string | null {
   const helpResult = spawnSync(process.execPath, [scriptPath, '--help'], {

--- a/src/bin/run-helper.mts
+++ b/src/bin/run-helper.mts
@@ -8,6 +8,22 @@
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 
+import { extractShapedCliParseErrorMessage } from '../scripts/cli-args.mts';
+
+// spawnSync's own default stderr maxBuffer is 1 MiB -- too small for a
+// helper that streams verbose diagnostic progress to stderr by design
+// (idd-doctor's post-merge cleanup-backlog sweep, for one -- see
+// docs/idd-helper-scripts.md). Piping stderr (instead of inheriting it,
+// below) is required to inspect it for a shaped parse error (#1922) before
+// deciding what to forward, so this buffer budget keeps that inspection
+// from truncating or killing a legitimately chatty run. Not unlimited --
+// spawnSync has no true streaming mode -- but generous enough that no
+// helper in this repository is expected to approach it.
+const STDERR_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+// Bounds the best-effort `--help` re-invocation used to fetch a usage line
+// below -- this must never hang the primary error-reporting path.
+const HELP_REINVOKE_TIMEOUT_MS = 5_000;
+
 export function runHelper(relativeScriptPath: string): void {
   const binDirectory = import.meta.dirname;
   const scriptPath = resolve(binDirectory, relativeScriptPath);
@@ -15,7 +31,14 @@ export function runHelper(relativeScriptPath: string): void {
     process.execPath,
     [scriptPath, ...process.argv.slice(2)],
     {
-      stdio: 'inherit',
+      // stdin/stdout stay live-inherited -- no behavior change for normal
+      // output. Only stderr is captured (piped) so it can be inspected for
+      // a shaped parse error before deciding what to forward; the known,
+      // accepted trade-off is that stderr is no longer streamed live to
+      // the terminal in real time, only flushed once the child exits.
+      stdio: ['inherit', 'inherit', 'pipe'],
+      encoding: 'utf8',
+      maxBuffer: STDERR_MAX_BUFFER_BYTES,
     },
   );
 
@@ -23,5 +46,54 @@ export function runHelper(relativeScriptPath: string): void {
     throw result.error;
   }
 
-  process.exit(result.status ?? 1);
+  const exitCode = result.status ?? 1;
+  // Only a non-zero exit is even eligible for shaped-error interception --
+  // a successful run's stderr (e.g. idd-doctor's streamed progress) is
+  // never inspected, so it always falls through to the unconditional
+  // forward below unchanged.
+  const shapedMessage =
+    result.status !== 0
+      ? extractShapedCliParseErrorMessage(result.stderr ?? '')
+      : null;
+
+  if (shapedMessage === null) {
+    // No recognized shaped parse error -- a successful run, or an
+    // unrelated failure: forward the captured stderr through
+    // byte-for-byte, preserving a genuine bug's full stack trace.
+    if (result.stderr) {
+      process.stderr.write(result.stderr);
+    }
+    process.exit(exitCode);
+  }
+
+  process.stderr.write(`${shapedMessage}\n`);
+  const usage = fetchUsageLine(scriptPath);
+  if (usage !== null) {
+    process.stderr.write(`${usage}\n`);
+  }
+  process.exit(exitCode);
+}
+
+/**
+ * Best-effort re-invocation of the failing script's own `--help` output, to
+ * append "the calling script's own usage line" (#1922's acceptance
+ * criteria) after a shaped parse-error message. Every `--help` path among
+ * this repository's `parseCliArgs`-based helpers exits 0 before any
+ * network or `gh` call (see tests/help-text-flags.test.mts), but `--help`
+ * is not guaranteed to be declared at all -- an undeclared `--help` itself
+ * throws "unknown argument: --help", which surfaces here as a non-zero
+ * exit and is treated the same as "no usage available". Always optional:
+ * any spawn error, non-zero exit, or timeout degrades silently to no usage
+ * line rather than risking the primary error-reporting path above.
+ */
+function fetchUsageLine(scriptPath: string): string | null {
+  const helpResult = spawnSync(process.execPath, [scriptPath, '--help'], {
+    encoding: 'utf8',
+    timeout: HELP_REINVOKE_TIMEOUT_MS,
+  });
+  if (helpResult.error || helpResult.status !== 0) {
+    return null;
+  }
+  const usage = helpResult.stdout?.trim();
+  return usage ? usage : null;
 }

--- a/src/scripts/cli-args.mts
+++ b/src/scripts/cli-args.mts
@@ -333,7 +333,17 @@ export function extractShapedCliParseErrorMessage(
   // from its own "Error: " line up to (but not including) whichever comes
   // first: a stack-frame line, the next "Error: " line, or the end of the
   // text.
-  const lines = stderrText.split('\n');
+  //
+  // Split on `/\r?\n/`, not a plain `'\n'` (Copilot review finding): on
+  // CRLF stderr (e.g. Windows), a plain `'\n'` split leaves a trailing
+  // `\r` on every line, which does more than cosmetically taint the
+  // captured message with a stray `\r` -- ERROR_LINE_PATTERN's un-anchored
+  // (non-multiline) `$` cannot match before that leftover `\r` at all, so
+  // the "Error: " line fails to match this pattern altogether and the
+  // whole shaped error goes undetected, silently falling back to the raw
+  // stack trace on the one platform (Windows) this repository explicitly
+  // supports.
+  const lines = stderrText.split(/\r?\n/);
   for (let index = 0; index < lines.length; index += 1) {
     const match = ERROR_LINE_PATTERN.exec(lines[index]);
     if (match === null) {

--- a/src/scripts/cli-args.mts
+++ b/src/scripts/cli-args.mts
@@ -51,6 +51,22 @@
 
 import { parseArgs as nodeParseArgs } from 'node:util';
 
+// #1922: the three message-shape prefixes toRepoShapedError() below
+// produces. Named here (rather than inlined at each call site) so
+// extractShapedCliParseErrorMessage() can recognize the exact same shapes
+// from raw text -- across the bin/run-helper.mts subprocess boundary,
+// where only the child's captured stderr text is visible, never the
+// original Error object -- without either copy silently drifting out of
+// sync with the other.
+const UNKNOWN_ARGUMENT_PREFIX = 'unknown argument: ';
+const MISSING_VALUE_FOR_ARGUMENT_PREFIX = 'missing value for argument: ';
+const UNEXPECTED_VALUE_FOR_ARGUMENT_PREFIX = 'unexpected value for argument: ';
+const REPO_SHAPED_CLI_PARSE_ERROR_PREFIXES = [
+  UNKNOWN_ARGUMENT_PREFIX,
+  MISSING_VALUE_FOR_ARGUMENT_PREFIX,
+  UNEXPECTED_VALUE_FOR_ARGUMENT_PREFIX,
+] as const;
+
 /** Flag value type accepted by `util.parseArgs`. */
 export type CliFlagType = 'string' | 'boolean';
 
@@ -271,16 +287,44 @@ function toRepoShapedError(error: unknown): Error {
   switch (err.code) {
     case 'ERR_PARSE_ARGS_UNKNOWN_OPTION':
     case 'ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL':
-      return new Error(`unknown argument: ${token}`);
+      return new Error(`${UNKNOWN_ARGUMENT_PREFIX}${token}`);
     case 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE':
       return new Error(
         err.message.includes('does not take an argument')
-          ? `unexpected value for argument: ${token}`
-          : `missing value for argument: ${token}`,
+          ? `${UNEXPECTED_VALUE_FOR_ARGUMENT_PREFIX}${token}`
+          : `${MISSING_VALUE_FOR_ARGUMENT_PREFIX}${token}`,
       );
     default:
       return err;
   }
+}
+
+/**
+ * Recognize Node's default uncaught-exception stderr text for a shaped CLI
+ * parse error (#1922) and extract just the one-line message, discarding
+ * the source-line preview, stack frames, and trailing `Node.js vX.Y.Z`
+ * footer Node prints around it. Scans **every** `Error: ` -prefixed line in
+ * the text -- not just the first -- and returns the first whose message
+ * starts with one of the three shapes {@link toRepoShapedError} produces,
+ * so a script that logs its own unrelated `Error: ...` diagnostic before a
+ * later real crash can't mask the shaped line. Returns `null` when no line
+ * matches, the safe default: a caller should forward the original text
+ * unchanged in that case, exactly as it would for any other error class.
+ */
+export function extractShapedCliParseErrorMessage(
+  stderrText: string,
+): string | null {
+  for (const match of stderrText.matchAll(/^Error: (.+)$/gm)) {
+    const message = match[1];
+    if (
+      REPO_SHAPED_CLI_PARSE_ERROR_PREFIXES.some((prefix) =>
+        message.startsWith(prefix),
+      )
+    ) {
+      return message;
+    }
+  }
+  return null;
 }
 
 /**
@@ -332,7 +376,7 @@ export function parseCliArgs(
   // --`, since the second `--` becomes a rejected positional). The strip
   // above never repeats -- this is a single explicit check, not a loop.
   if (args[0] === '--') {
-    throw new Error('unknown argument: --');
+    throw new Error(`${UNKNOWN_ARGUMENT_PREFIX}--`);
   }
 
   let parsed: ReturnType<typeof nodeParseArgs>;

--- a/src/scripts/cli-args.mts
+++ b/src/scripts/cli-args.mts
@@ -311,11 +311,45 @@ function toRepoShapedError(error: unknown): Error {
  * matches, the safe default: a caller should forward the original text
  * unchanged in that case, exactly as it would for any other error class.
  */
+// Node's own stack-frame rendering, always "    at ..." (4+ spaces). Used
+// to find where a captured message ends -- see extractShapedCliParseErrorMessage's
+// line-scan below.
+const STACK_FRAME_LINE_PATTERN = /^\s+at /;
+// A line starting a new "Error: " block. Reused both to *find* candidate
+// blocks and to know where the *previous* block's message ends (a second
+// "Error: " line immediately terminates the one before it, same as a
+// stack frame would).
+const ERROR_LINE_PATTERN = /^Error: (.*)$/;
+
 export function extractShapedCliParseErrorMessage(
   stderrText: string,
 ): string | null {
-  for (const match of stderrText.matchAll(/^Error: (.+)$/gm)) {
-    const message = match[1];
+  // Line-based, not a single regex: a shaped message can itself contain an
+  // embedded newline (e.g. a stray positional argument whose literal value
+  // spans multiple lines -- the underlying parseCliArgs() error already
+  // preserves that verbatim; this scan must too, rather than truncating at
+  // the first line via a `.`-based pattern, which silently drops
+  // everything after the first embedded newline). A message block runs
+  // from its own "Error: " line up to (but not including) whichever comes
+  // first: a stack-frame line, the next "Error: " line, or the end of the
+  // text.
+  const lines = stderrText.split('\n');
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = ERROR_LINE_PATTERN.exec(lines[index]);
+    if (match === null) {
+      continue;
+    }
+    const messageLines = [match[1]];
+    let cursor = index + 1;
+    while (
+      cursor < lines.length &&
+      !STACK_FRAME_LINE_PATTERN.test(lines[cursor]) &&
+      !ERROR_LINE_PATTERN.test(lines[cursor])
+    ) {
+      messageLines.push(lines[cursor]);
+      cursor += 1;
+    }
+    const message = messageLines.join('\n');
     if (
       REPO_SHAPED_CLI_PARSE_ERROR_PREFIXES.some((prefix) =>
         message.startsWith(prefix),

--- a/src/scripts/cli-args.mts
+++ b/src/scripts/cli-args.mts
@@ -320,6 +320,20 @@ const STACK_FRAME_LINE_PATTERN = /^\s+at /;
 // "Error: " line immediately terminates the one before it, same as a
 // stack frame would).
 const ERROR_LINE_PATTERN = /^Error: (.*)$/;
+// `NODE_OPTIONS=--stack-trace-limit=0` (a supported Node runtime option, not
+// an adversarial input) changes Node's uncaught-exception rendering to a
+// single bracketed `[Error: message]` line with no stack frames at all
+// (chatgpt-codex-connector review finding) -- verified empirically:
+// `NODE_OPTIONS='--stack-trace-limit=0' node bin/idd-branch-name.mjs
+// --bogus` prints `[Error: unknown argument: --bogus]` with none of the
+// usual "Error: "-prefixed / "    at " structure this module otherwise
+// relies on. Handled as its own single-line case, not folded into the
+// line-scan loop above: a message that itself happens to span multiple
+// lines under this zero-stack bracketed form has no unambiguous
+// terminator to scan for (no stack frame ever follows to mark the end),
+// so that narrower intersection is a disclosed, accepted gap rather than
+// something this pattern attempts to solve.
+const BRACKETED_ZERO_STACK_ERROR_LINE_PATTERN = /^\[Error: (.*)\]$/;
 
 export function extractShapedCliParseErrorMessage(
   stderrText: string,
@@ -345,6 +359,13 @@ export function extractShapedCliParseErrorMessage(
   // supports.
   const lines = stderrText.split(/\r?\n/);
   for (let index = 0; index < lines.length; index += 1) {
+    const bracketed = BRACKETED_ZERO_STACK_ERROR_LINE_PATTERN.exec(
+      lines[index],
+    );
+    if (bracketed !== null && isShapedMessage(bracketed[1])) {
+      return bracketed[1];
+    }
+
     const match = ERROR_LINE_PATTERN.exec(lines[index]);
     if (match === null) {
       continue;
@@ -360,15 +381,17 @@ export function extractShapedCliParseErrorMessage(
       cursor += 1;
     }
     const message = messageLines.join('\n');
-    if (
-      REPO_SHAPED_CLI_PARSE_ERROR_PREFIXES.some((prefix) =>
-        message.startsWith(prefix),
-      )
-    ) {
+    if (isShapedMessage(message)) {
       return message;
     }
   }
   return null;
+}
+
+function isShapedMessage(message: string): boolean {
+  return REPO_SHAPED_CLI_PARSE_ERROR_PREFIXES.some((prefix) =>
+    message.startsWith(prefix),
+  );
 }
 
 /**

--- a/tests/cli-args.test.mts
+++ b/tests/cli-args.test.mts
@@ -440,3 +440,46 @@ test('extractShapedCliParseErrorMessage: recognizes and cleans a CRLF-terminated
     'unknown argument: --x',
   );
 });
+
+test('extractShapedCliParseErrorMessage: recognizes the bracketed zero-stack form (NODE_OPTIONS=--stack-trace-limit=0, chatgpt-codex-connector review finding)', () => {
+  // Verified empirically: `NODE_OPTIONS='--stack-trace-limit=0' node
+  // bin/idd-branch-name.mjs --bogus` prints `[Error: unknown argument:
+  // --bogus]` -- a single bracketed line with no "Error: " prefix line
+  // and no stack frames at all, which the ordinary line-scan above never
+  // matches.
+  const stderrText = '[Error: unknown argument: --bogus]\n\nNode.js v22.22.2\n';
+  assert.equal(
+    extractShapedCliParseErrorMessage(stderrText),
+    'unknown argument: --bogus',
+  );
+});
+
+test('extractShapedCliParseErrorMessage: the bracketed zero-stack form still rejects an unrelated message', () => {
+  const stderrText =
+    '[Error: --number is required and must be a positive integer]\n\nNode.js v22.22.2\n';
+  assert.equal(extractShapedCliParseErrorMessage(stderrText), null);
+});
+
+test('extractShapedCliParseErrorMessage: documented boundary -- a positional argument whose value itself contains a line that looks like a stack frame truncates at that line (chatgpt-codex-connector review finding, rejected: adversarial input, not a defect)', () => {
+  // Single-channel stderr-text inference cannot fully distinguish a
+  // message-embedded line that happens to look like "    at bar" (or
+  // another "Error: " line) from a real stack frame boundary -- this is
+  // architecturally inherent to scanning already-rendered text across the
+  // subprocess boundary, not an oversight. The exit code and the shaped
+  // classification (first line, prefix) both stay correct; only the
+  // cosmetic tail of an adversarially-crafted token is affected. Verified
+  // directly: `node bin/idd-branch-name.mjs $'foo\n    at bar'` prints
+  // "unknown argument: foo" (correct prefix, correct exit code),
+  // truncating before "    at bar" rather than including it.
+  const stderrText = [
+    'Error: unknown argument: foo',
+    '    at bar',
+    '    at toRepoShapedError (file:///repo/scripts/cli-args.mjs:229:14)',
+    '',
+    'Node.js v22.22.2',
+  ].join('\n');
+  assert.equal(
+    extractShapedCliParseErrorMessage(stderrText),
+    'unknown argument: foo',
+  );
+});

--- a/tests/cli-args.test.mts
+++ b/tests/cli-args.test.mts
@@ -420,3 +420,23 @@ test('extractShapedCliParseErrorMessage: an embedded blank line inside the messa
     'unknown argument: foo\n\nbar',
   );
 });
+
+test('extractShapedCliParseErrorMessage: recognizes and cleans a CRLF-terminated shaped line (Copilot review finding on the line-based rewrite)', () => {
+  // A plain `split('\n')` (rather than `split(/\r?\n/)`) leaves a
+  // trailing "\r" on every line under CRLF stderr (e.g. Windows). That is
+  // not merely cosmetic: the un-anchored (non-multiline) `$` in
+  // ERROR_LINE_PATTERN cannot match before a leftover "\r", so the
+  // "Error: " line fails to match the pattern at all and the whole
+  // shaped error goes undetected -- verified as a real miss (returned
+  // null), not just a message with a stray "\r" appended.
+  const stderrText = [
+    'Error: unknown argument: --x\r',
+    '    at toRepoShapedError (file:///repo/scripts/cli-args.mjs:229:14)\r',
+    '\r',
+    'Node.js v22.22.2\r',
+  ].join('\n');
+  assert.equal(
+    extractShapedCliParseErrorMessage(stderrText),
+    'unknown argument: --x',
+  );
+});

--- a/tests/cli-args.test.mts
+++ b/tests/cli-args.test.mts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  extractShapedCliParseErrorMessage,
   parseCanonicalIntegerOrNull,
   parseCanonicalIntegerOrThrow,
   parseCliArgs,
@@ -278,4 +279,108 @@ test('requireFlag: throws "--flag is required" on a non-string value (e.g. a boo
   assert.throws(() => requireFlag(null, '--head-sha'), {
     message: '--head-sha is required',
   });
+});
+
+// --- extractShapedCliParseErrorMessage (#1922) -------------------------------
+// bin/run-helper.mts intercepts a shaped parse error across the child-process
+// boundary by recognizing it in captured stderr text -- it never sees the
+// original Error object, only Node's default uncaught-exception rendering
+// (a source-line preview, then `Error: {message}`, then stack frames, then a
+// trailing `Node.js vX.Y.Z` line). These fixtures mirror that exact shape.
+
+const REAL_UNCAUGHT_STDERR_UNKNOWN_ARGUMENT = `file:///repo/scripts/cli-args.mjs:214
+      return new Error(\`unknown argument: \${token}\`);
+             ^
+
+Error: unknown argument: --bogus-flag
+    at toRepoShapedError (file:///repo/scripts/cli-args.mjs:214:14)
+    at parseCliArgs (file:///repo/scripts/cli-args.mjs:273:11)
+    at parseArgs (file:///repo/scripts/branch-name.mjs:119:28)
+    at runCli (file:///repo/scripts/branch-name.mjs:105:16)
+    at file:///repo/scripts/branch-name.mjs:52:3
+    at ModuleJob.run (node:internal/modules/esm/module_job:343:25)
+
+Node.js v22.22.2
+`;
+
+test('extractShapedCliParseErrorMessage: extracts "unknown argument: " from real Node uncaught-exception stderr text', () => {
+  assert.equal(
+    extractShapedCliParseErrorMessage(REAL_UNCAUGHT_STDERR_UNKNOWN_ARGUMENT),
+    'unknown argument: --bogus-flag',
+  );
+});
+
+test('extractShapedCliParseErrorMessage: extracts "missing value for argument: "', () => {
+  const stderrText = [
+    'Error: missing value for argument: --pr',
+    '    at toRepoShapedError (file:///repo/scripts/cli-args.mjs:214:14)',
+    '',
+    'Node.js v22.22.2',
+  ].join('\n');
+  assert.equal(
+    extractShapedCliParseErrorMessage(stderrText),
+    'missing value for argument: --pr',
+  );
+});
+
+test('extractShapedCliParseErrorMessage: extracts "unexpected value for argument: "', () => {
+  const stderrText = [
+    'Error: unexpected value for argument: --assert',
+    '    at toRepoShapedError (file:///repo/scripts/cli-args.mjs:214:14)',
+    '',
+    'Node.js v22.22.2',
+  ].join('\n');
+  assert.equal(
+    extractShapedCliParseErrorMessage(stderrText),
+    'unexpected value for argument: --assert',
+  );
+});
+
+test('extractShapedCliParseErrorMessage: returns null for an unrelated error class (stack trace must stay intact)', () => {
+  const stderrText = [
+    'Error: --number is required and must be a positive integer',
+    '    at runCli (file:///repo/scripts/branch-name.mjs:111:11)',
+    '',
+    'Node.js v22.22.2',
+  ].join('\n');
+  assert.equal(extractShapedCliParseErrorMessage(stderrText), null);
+});
+
+test('extractShapedCliParseErrorMessage: returns null for text with no "Error: " line at all', () => {
+  assert.equal(extractShapedCliParseErrorMessage(''), null);
+  assert.equal(
+    extractShapedCliParseErrorMessage('some warning to stderr\n'),
+    null,
+  );
+});
+
+test('extractShapedCliParseErrorMessage: a 4th, unrecognized shaped-looking prefix (e.g. "invalid value for argument: ") is NOT matched', () => {
+  // parseCanonicalIntegerOrThrow's "invalid value for argument: " shape is
+  // deliberately out of scope for this issue (#1922 scopes to the three
+  // toRepoShapedError() forms only) -- confirms the extractor doesn't
+  // over-match a shape it was never told to recognize.
+  const stderrText = [
+    'Error: invalid value for argument: --pr',
+    '    at parseCanonicalIntegerOrThrow (file:///repo/scripts/cli-args.mjs:1:1)',
+    '',
+    'Node.js v22.22.2',
+  ].join('\n');
+  assert.equal(extractShapedCliParseErrorMessage(stderrText), null);
+});
+
+test('extractShapedCliParseErrorMessage: scans every "Error: " line, not just the first, and returns the first shaped match', () => {
+  // A script that logs its own non-fatal "Error: ..." diagnostic to stderr
+  // before a later shaped crash must not have that earlier line mask the
+  // real one.
+  const stderrText = [
+    'Error: config not found, using defaults',
+    'Error: unknown argument: --typo',
+    '    at toRepoShapedError (file:///repo/scripts/cli-args.mjs:214:14)',
+    '',
+    'Node.js v22.22.2',
+  ].join('\n');
+  assert.equal(
+    extractShapedCliParseErrorMessage(stderrText),
+    'unknown argument: --typo',
+  );
 });

--- a/tests/cli-args.test.mts
+++ b/tests/cli-args.test.mts
@@ -384,3 +384,39 @@ test('extractShapedCliParseErrorMessage: scans every "Error: " line, not just th
     'unknown argument: --typo',
   );
 });
+
+test('extractShapedCliParseErrorMessage: preserves an embedded newline in the offending token instead of truncating at the first line (chatgpt-codex-connector review finding)', () => {
+  // A stray positional argument whose own value contains a literal
+  // newline (e.g. `node bin/idd-branch-name.mjs $'foo\nbar'`) makes
+  // toRepoShapedError() throw `Error: unknown argument: foo\nbar` -- a
+  // real Error whose .message already preserves the full verbatim token.
+  // Node's default uncaught-exception rendering then prints that message
+  // across two lines with no blank line or stack-frame marker between
+  // them before the stack trace begins, exactly like this fixture.
+  const stderrText = [
+    'Error: unknown argument: foo',
+    'bar',
+    '    at toRepoShapedError (file:///repo/scripts/cli-args.mjs:229:14)',
+    '',
+    'Node.js v22.22.2',
+  ].join('\n');
+  assert.equal(
+    extractShapedCliParseErrorMessage(stderrText),
+    'unknown argument: foo\nbar',
+  );
+});
+
+test('extractShapedCliParseErrorMessage: an embedded blank line inside the message is preserved too, not mistaken for the trailing Node.js-version blank line', () => {
+  const stderrText = [
+    'Error: unknown argument: foo',
+    '',
+    'bar',
+    '    at toRepoShapedError (file:///repo/scripts/cli-args.mjs:229:14)',
+    '',
+    'Node.js v22.22.2',
+  ].join('\n');
+  assert.equal(
+    extractShapedCliParseErrorMessage(stderrText),
+    'unknown argument: foo\n\nbar',
+  );
+});

--- a/tests/run-helper.test.mts
+++ b/tests/run-helper.test.mts
@@ -259,8 +259,15 @@ test("runHelper(): a long-running helper's stderr streams live, not buffered unt
     });
     let firstLineAt: number | null = null;
     const start = Date.now();
+    // Accumulate into a persistent buffer and search that, rather than
+    // testing each chunk in isolation (Copilot review finding): stream
+    // chunk boundaries are arbitrary, so "first" is not guaranteed to
+    // land wholly within a single 'data' event even though the fixture
+    // writes it in one process.stderr.write() call.
+    let seenSoFar = '';
     child.stderr.on('data', (chunk: Buffer) => {
-      if (firstLineAt === null && chunk.toString('utf8').includes('first')) {
+      seenSoFar += chunk.toString('utf8');
+      if (firstLineAt === null && seenSoFar.includes('first')) {
         firstLineAt = Date.now() - start;
       }
     });

--- a/tests/run-helper.test.mts
+++ b/tests/run-helper.test.mts
@@ -14,9 +14,9 @@ import { fileURLToPath } from 'node:url';
 // trace. Every other error class must keep its stack trace untouched.
 //
 // Two coverage strategies:
-// - A real fleet member (bin/idd-branch-name.mjs): exercises the actual
-//   compiled artifacts end to end, mirroring
-//   tests/cli-entry-smoke.test.mts's shelling-out convention.
+// - Real fleet members (bin/idd-branch-name.mjs, bin/idd-review-disposition-
+//   verify.mjs): exercise the actual compiled artifacts end to end,
+//   mirroring tests/cli-entry-smoke.test.mts's shelling-out convention.
 // - Synthetic fixture scripts spawned through a temp wrapper that imports
 //   the real runHelper() (resolve()'s absolute-path short-circuit lets an
 //   absolute fixture path stand in for the normally-relative
@@ -28,6 +28,11 @@ import { fileURLToPath } from 'node:url';
 const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
 const RUN_HELPER_MJS = join(REPO_ROOT, 'bin', 'run-helper.mjs');
 const BRANCH_NAME_BIN = join(REPO_ROOT, 'bin', 'idd-branch-name.mjs');
+const REVIEW_DISPOSITION_VERIFY_BIN = join(
+  REPO_ROOT,
+  'bin',
+  'idd-review-disposition-verify.mjs',
+);
 
 interface SpawnCapture {
   stdout: string;
@@ -133,6 +138,18 @@ test('bin/idd-branch-name.mjs: a normal successful run is unaffected (stdout int
   ]);
   assert.equal(result.status, 0);
   assert.equal(result.stdout, 'issue/42-add-oauth-login-flow\n');
+});
+
+// #1922: the only bin/*.mjs that previously bypassed runHelper() entirely
+// (its own hand-rolled spawn/exit/error handling) -- migrated onto
+// runHelper() so the shaped-error fix applies uniformly to every packaged
+// idd-* CLI command, not just the 33 that already used it.
+test('bin/idd-review-disposition-verify.mjs: now goes through runHelper() too -- an unknown flag is shaped, not a raw stack trace', () => {
+  const result = spawnCapture(REVIEW_DISPOSITION_VERIFY_BIN, ['--bogus-flag']);
+  assert.notEqual(result.status, 0);
+  const firstLine = result.stderr.split('\n')[0];
+  assert.equal(firstLine, 'unknown argument: --bogus-flag');
+  assert.doesNotMatch(result.stderr, /\n\s+at /);
 });
 
 // --- Synthetic fixtures: cases the real fleet can't easily exercise --------

--- a/tests/run-helper.test.mts
+++ b/tests/run-helper.test.mts
@@ -106,6 +106,16 @@ test('bin/idd-branch-name.mjs: an unknown flag prints only the shaped one-line m
   assert.doesNotMatch(result.stderr, /ReferenceError/);
 });
 
+test('bin/idd-branch-name.mjs: a stray positional whose value contains an embedded newline is preserved in full, not truncated at the first line (chatgpt-codex-connector review finding)', () => {
+  const result = spawnCapture(BRANCH_NAME_BIN, ['foo\nbar']);
+  assert.notEqual(result.status, 0);
+  assert.equal(result.stderr.split('\n')[0], 'unknown argument: foo');
+  // The full token, including the embedded newline, is on the stream --
+  // this is what the earlier `.`-based (non-dotAll) line regex silently
+  // dropped.
+  assert.match(result.stderr, /^unknown argument: foo\nbar\nUsage:\n/);
+});
+
 test('bin/idd-branch-name.mjs: a missing value for a declared flag prints only the shaped message', () => {
   const result = spawnCapture(BRANCH_NAME_BIN, ['--number']);
   assert.notEqual(result.status, 0);
@@ -254,21 +264,39 @@ test("runHelper(): a long-running helper's stderr streams live, not buffered unt
         firstLineAt = Date.now() - start;
       }
     });
+    let closeAt: number | null = null;
     await new Promise<void>((resolvePromise, reject) => {
-      child.on('close', () => resolvePromise());
+      child.on('close', () => {
+        closeAt = Date.now() - start;
+        resolvePromise();
+      });
       child.on('error', reject);
     });
 
     // assert.ok (unlike assert.notEqual) is a recognized TypeScript
-    // assertion signature, narrowing firstLineAt to `number` for the bound
-    // check below.
+    // assertion signature, narrowing both timestamps to `number` for the
+    // gap check below.
     assert.ok(firstLineAt !== null, 'expected the first line to arrive');
-    // Generous bound (well under the ~1000ms gap to the second line) --
-    // this only needs to prove the first line didn't wait for the child
-    // to exit, not pin an exact latency.
+    assert.ok(closeAt !== null, 'expected the child to close');
+    // Measure the GAP between the first line arriving and the child
+    // closing, not an absolute wall-clock bound from spawn -- an absolute
+    // bound also counts two nested Node process boots (this test's own
+    // wrapper, then runHelper's spawned fixture) before the fixture's
+    // first line is even written, which a loaded CI runner can push past
+    // any reasonable fixed threshold on its own, independent of whether
+    // streaming actually works (chatgpt-codex-connector review finding on
+    // an earlier revision of this test: observed 532-582ms real CI
+    // latency against a naive 500ms bound, flaking a test proving a
+    // behavior that was in fact working). The gap check is immune to that
+    // startup latency: if streaming were broken (buffered until exit),
+    // the first line and the close would arrive together and the gap
+    // would be near zero regardless of how long startup took; a large gap
+    // is only possible if the first line really did arrive while the
+    // child was still running its ~1000ms sleep.
+    const gapMs = closeAt - firstLineAt;
     assert.ok(
-      firstLineAt < 500,
-      `expected the first line to arrive well before exit, got ${firstLineAt}ms`,
+      gapMs > 700,
+      `expected a gap of well over 700ms between the first line and child close (the fixture sleeps ~1000ms in between), got ${gapMs}ms`,
     );
   } finally {
     rmSync(tempRoot, { recursive: true, force: true });

--- a/tests/run-helper.test.mts
+++ b/tests/run-helper.test.mts
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+// ---------------------------------------------------------------------------
+// #1922 — bin/run-helper.mts intercepts a shaped CLI parse error across the
+// child-process spawn boundary and prints only the clean one-line message
+// (plus, best-effort, the failing script's own --help usage text) instead of
+// letting Node's default uncaught-exception handler dump a full raw stack
+// trace. Every other error class must keep its stack trace untouched.
+//
+// Two coverage strategies:
+// - A real fleet member (bin/idd-branch-name.mjs): exercises the actual
+//   compiled artifacts end to end, mirroring
+//   tests/cli-entry-smoke.test.mts's shelling-out convention.
+// - Synthetic fixture scripts spawned through a temp wrapper that imports
+//   the real runHelper() (resolve()'s absolute-path short-circuit lets an
+//   absolute fixture path stand in for the normally-relative
+//   relativeScriptPath argument) — used for cases the real fleet can't
+//   easily exercise, such as confirming a *successful* run's stderr output
+//   (e.g. idd-doctor's streamed progress) is never dropped.
+// ---------------------------------------------------------------------------
+
+const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
+const RUN_HELPER_MJS = join(REPO_ROOT, 'bin', 'run-helper.mjs');
+const BRANCH_NAME_BIN = join(REPO_ROOT, 'bin', 'idd-branch-name.mjs');
+
+interface SpawnCapture {
+  stdout: string;
+  stderr: string;
+  status: number | null;
+}
+
+/**
+ * Spawn `binPath` with `args`, capturing stdout/stderr/exit status either
+ * way. Uses `spawnSync` (not `execFileSync`) specifically because
+ * `execFileSync` only returns stdout on a zero exit and discards stderr
+ * entirely in that case -- this suite needs stderr on the success path too
+ * (e.g. confirming idd-doctor-style streamed progress isn't dropped).
+ */
+function spawnCapture(
+  binPath: string,
+  args: readonly string[] = [],
+): SpawnCapture {
+  const result = spawnSync(process.execPath, [binPath, ...args], {
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  return {
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    status: result.status,
+  };
+}
+
+/**
+ * Write `fixtureBody` as a throwaway script and a wrapper that invokes the
+ * real `runHelper()` against it (via an absolute path, which `resolve()`
+ * returns unchanged regardless of the `relativeScriptPath` name), then spawn
+ * the wrapper and capture the result -- exercises the real interception
+ * logic without needing a permanent bin/*.mjs entry for a synthetic case.
+ */
+function spawnFixture(
+  fixtureBody: string,
+  args: readonly string[] = [],
+): SpawnCapture {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-run-helper-fixture-'));
+  const fixturePath = join(tempRoot, 'fixture.mjs');
+  writeFileSync(fixturePath, fixtureBody);
+  const wrapperPath = join(tempRoot, 'wrapper.mjs');
+  writeFileSync(
+    wrapperPath,
+    `import { runHelper } from ${JSON.stringify(RUN_HELPER_MJS)};\nrunHelper(${JSON.stringify(fixturePath)});\n`,
+  );
+  return spawnCapture(wrapperPath, args);
+}
+
+// --- Real fleet member: bin/idd-branch-name.mjs ------------------------------
+
+test('bin/idd-branch-name.mjs: an unknown flag prints only the shaped one-line message, no stack frames, and exits non-zero', () => {
+  const result = spawnCapture(BRANCH_NAME_BIN, ['--bogus-flag', 'foo']);
+  assert.notEqual(result.status, 0);
+  const firstLine = result.stderr.split('\n')[0];
+  assert.equal(firstLine, 'unknown argument: --bogus-flag');
+  assert.doesNotMatch(result.stderr, /\n\s+at /);
+  assert.doesNotMatch(result.stderr, /ReferenceError/);
+});
+
+test('bin/idd-branch-name.mjs: a missing value for a declared flag prints only the shaped message', () => {
+  const result = spawnCapture(BRANCH_NAME_BIN, ['--number']);
+  assert.notEqual(result.status, 0);
+  const firstLine = result.stderr.split('\n')[0];
+  assert.equal(firstLine, 'missing value for argument: --number');
+  assert.doesNotMatch(result.stderr, /\n\s+at /);
+});
+
+test("bin/idd-branch-name.mjs: the shaped message is followed by the script's own usage line", () => {
+  const result = spawnCapture(BRANCH_NAME_BIN, ['--bogus-flag']);
+  assert.match(result.stderr, /^unknown argument: --bogus-flag\nUsage:\n/);
+});
+
+test('bin/idd-branch-name.mjs: an unrelated error (missing required --number) keeps its stack trace intact', () => {
+  const result = spawnCapture(BRANCH_NAME_BIN, ['--title', 'foo']);
+  assert.notEqual(result.status, 0);
+  // Node's own uncaught-exception rendering prints a source-line preview
+  // before the "Error: " line itself, so this is a plain substring/`m`-flag
+  // check, not an anchor on the very first byte of the stream (unlike the
+  // shaped-error cases above, where run-helper.mts's own output IS exactly
+  // that first line).
+  assert.match(result.stderr, /^Error: --number is required/m);
+  assert.match(result.stderr, /\n\s+at /);
+});
+
+test('bin/idd-branch-name.mjs: --help is unchanged -- still exits 0 and prints usage', () => {
+  const result = spawnCapture(BRANCH_NAME_BIN, ['--help']);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /^Usage:\n {2}node scripts\/branch-name\.mjs/);
+});
+
+test('bin/idd-branch-name.mjs: a normal successful run is unaffected (stdout intact, exit 0)', () => {
+  const result = spawnCapture(BRANCH_NAME_BIN, [
+    '--number',
+    '42',
+    '--title',
+    'Add the OAuth login flow',
+  ]);
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, 'issue/42-add-oauth-login-flow\n');
+});
+
+// --- Synthetic fixtures: cases the real fleet can't easily exercise --------
+
+test("runHelper(): a successful run's stderr output is forwarded unchanged, not dropped", () => {
+  // Mirrors idd-doctor's intentional streamed-progress-to-stderr pattern
+  // (docs/idd-helper-scripts.md) -- confirms piping stderr for inspection
+  // never silently swallows it on the success path.
+  const result = spawnFixture(
+    "process.stdout.write('known-stdout-line\\n');\nprocess.stderr.write('known-stderr-line\\n');\nprocess.exit(0);\n",
+  );
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, 'known-stdout-line\n');
+  assert.equal(result.stderr, 'known-stderr-line\n');
+});
+
+test('runHelper(): an unrelated thrown error (not one of the three shaped forms) forwards its full stack trace verbatim', () => {
+  const result = spawnFixture(
+    "throw new Error('totally unrelated failure');\n",
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /^Error: totally unrelated failure/m);
+  assert.match(result.stderr, /\n\s+at /);
+});
+
+test('runHelper(): a script with no --help support degrades to no usage line, still shaped', () => {
+  const result = spawnFixture(
+    "throw new Error('unknown argument: --bogus');\n",
+    ['--bogus'],
+  );
+  assert.notEqual(result.status, 0);
+  // No --help handling in this fixture -- --help itself would throw
+  // "unknown argument: --help", so fetchUsageLine() must see a non-zero
+  // exit and silently omit the usage line rather than propagating that
+  // secondary failure.
+  assert.equal(result.stderr, 'unknown argument: --bogus\n');
+});

--- a/tests/run-helper.test.mts
+++ b/tests/run-helper.test.mts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 // ---------------------------------------------------------------------------
 // #1922 — bin/run-helper.mts intercepts a shaped CLI parse error across the
@@ -27,6 +27,10 @@ import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
 const RUN_HELPER_MJS = join(REPO_ROOT, 'bin', 'run-helper.mjs');
+// A raw filesystem path is not a valid ESM import specifier on Windows
+// (backslashes) -- generated fixture wrappers below import via this
+// `file:` URL form instead (Copilot review finding), never the bare path.
+const RUN_HELPER_MJS_URL = pathToFileURL(RUN_HELPER_MJS).href;
 const BRANCH_NAME_BIN = join(REPO_ROOT, 'bin', 'idd-branch-name.mjs');
 const REVIEW_DISPOSITION_VERIFY_BIN = join(
   REPO_ROOT,
@@ -87,7 +91,7 @@ function spawnFixture(
     const wrapperPath = join(tempRoot, 'wrapper.mjs');
     writeFileSync(
       wrapperPath,
-      `import { runHelper } from ${JSON.stringify(RUN_HELPER_MJS)};\nrunHelper(${JSON.stringify(fixturePath)});\n`,
+      `import { runHelper } from ${JSON.stringify(RUN_HELPER_MJS_URL)};\nrunHelper(${JSON.stringify(fixturePath)});\n`,
     );
     return spawnCapture(wrapperPath, args);
   } finally {
@@ -251,7 +255,7 @@ test("runHelper(): a long-running helper's stderr streams live, not buffered unt
     const wrapperPath = join(tempRoot, 'wrapper.mjs');
     writeFileSync(
       wrapperPath,
-      `import { runHelper } from ${JSON.stringify(RUN_HELPER_MJS)};\nrunHelper(${JSON.stringify(fixturePath)});\n`,
+      `import { runHelper } from ${JSON.stringify(RUN_HELPER_MJS_URL)};\nrunHelper(${JSON.stringify(fixturePath)});\n`,
     );
 
     const child = spawn(process.execPath, [wrapperPath], {

--- a/tests/run-helper.test.mts
+++ b/tests/run-helper.test.mts
@@ -175,6 +175,27 @@ test('runHelper(): an unrelated thrown error (not one of the three shaped forms)
   assert.match(result.stderr, /\n\s+at /);
 });
 
+test("runHelper(): a large unrelated error message is NOT truncated (regression test -- Node's own uncaught-exception write to a piped stderr silently caps around ~146 KiB; capturing via a temp file instead of a pipe avoids it)", () => {
+  // 300 KiB comfortably clears the ~146 KiB ceiling this test guards
+  // against while staying under this test harness's own spawnSync
+  // maxBuffer (Node's 1 MiB default) for the *outer* capture.
+  const payloadSize = 300 * 1024;
+  const result = spawnFixture(
+    `throw new Error('payload: ' + 'z'.repeat(${payloadSize}));\n`,
+  );
+  assert.notEqual(result.status, 0);
+  // Measure the longest contiguous run of "z" rather than asserting exact
+  // byte length -- Node's own uncaught-exception rendering echoes the
+  // throwing source line as a preview, which itself contains one isolated
+  // "z" (inside the literal `'z'.repeat(...)` call); matching a long run
+  // isolates the actual repeated payload from that single stray character.
+  const longestRun = (result.stderr.match(/z+/g) ?? []).reduce(
+    (max, run) => Math.max(max, run.length),
+    0,
+  );
+  assert.equal(longestRun, payloadSize);
+});
+
 test('runHelper(): a script with no --help support degrades to no usage line, still shaped', () => {
   const result = spawnFixture(
     "throw new Error('unknown argument: --bogus');\n",

--- a/tests/run-helper.test.mts
+++ b/tests/run-helper.test.mts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { spawn, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -71,20 +71,28 @@ function spawnCapture(
  * returns unchanged regardless of the `relativeScriptPath` name), then spawn
  * the wrapper and capture the result -- exercises the real interception
  * logic without needing a permanent bin/*.mjs entry for a synthetic case.
+ * Always removes its scratch directory on the way out, success or failure
+ * (Copilot review finding on an earlier revision of this suite: the
+ * directory was never cleaned up, leaking one per test run under the OS
+ * temp folder).
  */
 function spawnFixture(
   fixtureBody: string,
   args: readonly string[] = [],
 ): SpawnCapture {
   const tempRoot = mkdtempSync(join(tmpdir(), 'idd-run-helper-fixture-'));
-  const fixturePath = join(tempRoot, 'fixture.mjs');
-  writeFileSync(fixturePath, fixtureBody);
-  const wrapperPath = join(tempRoot, 'wrapper.mjs');
-  writeFileSync(
-    wrapperPath,
-    `import { runHelper } from ${JSON.stringify(RUN_HELPER_MJS)};\nrunHelper(${JSON.stringify(fixturePath)});\n`,
-  );
-  return spawnCapture(wrapperPath, args);
+  try {
+    const fixturePath = join(tempRoot, 'fixture.mjs');
+    writeFileSync(fixturePath, fixtureBody);
+    const wrapperPath = join(tempRoot, 'wrapper.mjs');
+    writeFileSync(
+      wrapperPath,
+      `import { runHelper } from ${JSON.stringify(RUN_HELPER_MJS)};\nrunHelper(${JSON.stringify(fixturePath)});\n`,
+    );
+    return spawnCapture(wrapperPath, args);
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
 }
 
 // --- Real fleet member: bin/idd-branch-name.mjs ------------------------------
@@ -175,11 +183,17 @@ test('runHelper(): an unrelated thrown error (not one of the three shaped forms)
   assert.match(result.stderr, /\n\s+at /);
 });
 
-test("runHelper(): a large unrelated error message is NOT truncated (regression test -- Node's own uncaught-exception write to a piped stderr silently caps around ~146 KiB; capturing via a temp file instead of a pipe avoids it)", () => {
-  // 300 KiB comfortably clears the ~146 KiB ceiling this test guards
-  // against while staying under this test harness's own spawnSync
-  // maxBuffer (Node's 1 MiB default) for the *outer* capture.
-  const payloadSize = 300 * 1024;
+test('runHelper(): a moderately large unrelated error message is not truncated within the documented ceiling', () => {
+  // 48 KiB stays safely clear of the ~146 KiB ceiling Node's own
+  // uncaught-exception write to a piped stderr is empirically capped at
+  // (see the design comment in src/bin/run-helper.mts) -- realistic for
+  // any diagnostic this repository's helpers actually produce. The far
+  // larger, multi-hundred-KiB case this suite previously asserted against
+  // is a disclosed, accepted limitation of the pipe-based redesign (traded
+  // for live streaming and no tmpdir dependency, both of which are
+  // required by real current behavior -- see the two run-helper.test.mts
+  // tests below), not something this suite still guards.
+  const payloadSize = 48 * 1024;
   const result = spawnFixture(
     `throw new Error('payload: ' + 'z'.repeat(${payloadSize}));\n`,
   );
@@ -194,6 +208,86 @@ test("runHelper(): a large unrelated error message is NOT truncated (regression 
     0,
   );
   assert.equal(longestRun, payloadSize);
+});
+
+test('runHelper(): does not require a writable temp directory for an ordinary invocation (regression test for a pipe-only redesign -- a prior temp-file-based capture made every invocation, including this one, hard-depend on os.tmpdir())', () => {
+  const result = spawnSync(
+    process.execPath,
+    [BRANCH_NAME_BIN, '--number', '42', '--title', 'foo'],
+    {
+      encoding: 'utf8',
+      timeout: 30_000,
+      env: { ...process.env, TMPDIR: '/definitely/missing/idd-temp' },
+    },
+  );
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, 'issue/42-foo\n');
+});
+
+test("runHelper(): a long-running helper's stderr streams live, not buffered until exit (regression test for idd-doctor's emitCleanupBacklogProgress UX)", async () => {
+  // Two lines a full second apart, well past the 200ms grace window --
+  // if streaming is broken (buffered until the child exits), both lines
+  // arrive in the same burst at the very end; if it works, the first line
+  // arrives promptly and the second only after the sleep.
+  const fixtureBody = [
+    "process.stderr.write('first\\n');",
+    'await new Promise((r) => setTimeout(r, 1000));',
+    "process.stderr.write('second\\n');",
+  ].join('\n');
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-run-helper-fixture-'));
+  try {
+    const fixturePath = join(tempRoot, 'fixture.mjs');
+    writeFileSync(fixturePath, fixtureBody);
+    const wrapperPath = join(tempRoot, 'wrapper.mjs');
+    writeFileSync(
+      wrapperPath,
+      `import { runHelper } from ${JSON.stringify(RUN_HELPER_MJS)};\nrunHelper(${JSON.stringify(fixturePath)});\n`,
+    );
+
+    const child = spawn(process.execPath, [wrapperPath], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+    let firstLineAt: number | null = null;
+    const start = Date.now();
+    child.stderr.on('data', (chunk: Buffer) => {
+      if (firstLineAt === null && chunk.toString('utf8').includes('first')) {
+        firstLineAt = Date.now() - start;
+      }
+    });
+    await new Promise<void>((resolvePromise, reject) => {
+      child.on('close', () => resolvePromise());
+      child.on('error', reject);
+    });
+
+    // assert.ok (unlike assert.notEqual) is a recognized TypeScript
+    // assertion signature, narrowing firstLineAt to `number` for the bound
+    // check below.
+    assert.ok(firstLineAt !== null, 'expected the first line to arrive');
+    // Generous bound (well under the ~1000ms gap to the second line) --
+    // this only needs to prove the first line didn't wait for the child
+    // to exit, not pin an exact latency.
+    assert.ok(
+      firstLineAt < 500,
+      `expected the first line to arrive well before exit, got ${firstLineAt}ms`,
+    );
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('runHelper(): a shaped-looking error thrown after the grace window has elapsed streams live with its raw trace, not intercepted (documented design boundary, not an oversight)', () => {
+  const fixtureBody = [
+    "process.stderr.write('warming up\\n');",
+    'await new Promise((r) => setTimeout(r, 500));',
+    "throw new Error('unknown argument: --late');",
+  ].join('\n');
+  const result = spawnFixture(fixtureBody);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /^warming up$/m);
+  // The raw trace streamed live -- it is NOT collapsed to the shaped
+  // one-liner the way an immediate (within-window) throw would be.
+  assert.match(result.stderr, /^Error: unknown argument: --late/m);
+  assert.match(result.stderr, /\n\s+at /);
 });
 
 test('runHelper(): a script with no --help support degrades to no usage line, still shaped', () => {


### PR DESCRIPTION
# Summary

`parseCliArgs` (`src/scripts/cli-args.mts`) already reshapes Node's
native `util.parseArgs` errors into this repository's clean one-line
idiom (`unknown argument: --x`, `missing value for argument: --x`,
`unexpected value for argument: --x`) via `toRepoShapedError`, but
nothing ever caught the throw. Every `idd-*` CLI helper crashed with a
full raw Node stack trace on an unrecognized flag instead of printing
that clean message.

Since `parseCliArgs`'s synchronous throw contract is load-bearing for
its own unit tests, and every `bin/idd-*.mjs` entry point already
funnels through `run-helper.mts`'s `spawnSync` wrapper, this
intercepts the shaped error there instead of touching each of the
~34 individual helper scripts:

- `cli-args.mts` gains `extractShapedCliParseErrorMessage()`, which
  recognizes the three shaped message forms from raw captured stderr
  text (the only thing visible across the child-process boundary).
  `toRepoShapedError` and the extractor now share the same prefix
  constants so a future 4th shape can't silently drift out of sync.
- `run-helper.mts` pipes (instead of blindly inheriting) the child's
  stderr, and only on a non-zero exit checks it for a shaped match:
  a match prints just the one-line message plus, best-effort, the
  failing script's own `--help` usage text; anything else (success,
  or an unrelated failure) is forwarded through byte-for-byte
  unchanged, so a genuine bug keeps its full stack trace.
- A second commit migrates `idd-review-disposition-verify`'s bin
  wrapper — the only one that predated the `run-helper.mts`
  consolidation and hand-rolled its own `spawn`/`exit`/`error`
  handling, bypassing the fix entirely — onto the shared `runHelper()`,
  so every packaged `idd-*` command whose own parser goes through
  `parseCliArgs` gets the clean message (one disclosed exception below:
  `idd-rerun-advisory-convergence` calls `util.parseArgs` directly, not
  through `parseCliArgs`, so it's outside this mechanism's reach — see
  #1955). Found during this PR's own B2 critique pass by reproducing
  the bug directly against it.
- Later commits (post-initial-review) replaced an intermediate
  temp-file-based stderr capture with a pipe-based one that streams
  live by default and only buffers for a short window after the
  first chunk, after review verified the temp-file approach broke
  `idd-doctor`'s live progress streaming and made every CLI command
  hard-depend on a writable `os.tmpdir()`. Also fixed: an embedded
  newline in a shaped message no longer truncates the token; CRLF
  stderr (Windows) is now recognized; `NODE_OPTIONS=--stack-trace-limit=0`'s
  bracketed zero-stack form is now recognized. See disclosed
  boundaries below for what's intentionally still out of scope.

## Linked issue

Closes #1922

## Follow-up issues (if any)

- [x] #1955 — `idd-rerun-advisory-convergence` calls `util.parseArgs`
      directly, bypassing `parseCliArgs`/this fix entirely; a
      recovery-critical helper, so deliberately not migrated inside
      this PR

## Background / rationale (if material)

Field-reported from `kurone-kito/builder-config`: `--format json`
worked on a sibling helper moments earlier, then threw a raw stack
trace on this one — a flag guess is the normal way to probe a CLI.

Design rationale (why `run-helper.mts`, not each of the ~34 entry
scripts) is recorded on the issue's plan comments, including a
critique-pass revision that added the `idd-review-disposition-verify`
migration and clarified the stderr-forwarding behavior on a
successful run.

`parseCanonicalIntegerOrThrow`'s `invalid value for argument: ` is a
4th, distinct shape not covered here — matches the issue's own
explicit 3-form scope, disclosed as a residual gap in the plan
comments rather than silently left out.

**Other disclosed, accepted boundaries** (found and verified during
review, deliberately not chased further — see code comments in
`cli-args.mts` / `run-helper.mts` for detail):

- A pipe-captured child's own crash-write on an uncaught exception has
  an empirically-confirmed ceiling around ~146 KiB, regardless of how
  fast the parent drains it — no current helper throws anywhere near
  that size, and any operator already piping this process's own
  stderr onward (`2>&1 | tee`, common in CI) inherited the same
  ceiling under the pre-#1922 plain `'inherit'` stdio.
- A positional argument whose own value contains a line that happens
  to look like a stack frame (e.g. embeds a literal `"    at ..."`
  line) truncates the shaped message's cosmetic tail at that line —
  inherent to inferring message boundaries from already-rendered
  stderr text across the subprocess boundary; the exit code and the
  message's shaped classification both stay correct.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (3372/3372 passing, including new/changed
      assertions across `tests/cli-args.test.mts` and the new
      `tests/run-helper.test.mts`, grown across review rounds to
      cover the streaming/tmpdir/CRLF/zero-stack/multiline findings
      above)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs touched by this change)
- [x] `node scripts/idd-doctor.mjs` (if applicable) — passes with 3
      pre-existing, unrelated environment warnings

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — CLI error-reporting only)
- [x] Context budget impact reviewed (none — no instruction files
      touched)

