### PR TITLE
fix(onboard): keep placeholder meta-docs literal on --substitute

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1183,8 +1183,16 @@ Use
 for the detailed placeholder meanings, no-op substitution rules, and
 marker-prefix guidance.
 
+**Three meta-docs stay literal on purpose**:
+`docs/onboarding/placeholders.md`, `docs/customization.md`, and
+`docs/onboarding/policy-decisions.md` document the seven placeholders
+with worked `{{...}}` examples rather than consuming them, so
+`--substitute` skips all three by path and never rewrites them (#1924).
+`--verify`'s placeholder-residue check applies the same skip, so their
+surviving tokens are expected and not reported as unresolved.
+
 After replacing, verify that no `{{...}}` placeholder strings remain in
-any copied file.
+any copied file other than those three meta-docs.
 
 ---
 

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -41,6 +41,7 @@ import { execFileSync } from 'node:child_process';
 import {
   chmodSync,
   copyFileSync,
+  existsSync,
   lstatSync,
   mkdirSync,
   readdirSync,
@@ -465,15 +466,31 @@ export function resolvePlaceholderValues(
 const PLACEHOLDER_TOKEN_PATTERN = /\{\{[A-Z][A-Z0-9_]*\}\}/g;
 /** Directories never scanned for placeholder tokens. */
 const SCAN_EXCLUDED_DIRS = new Set(['.git', 'node_modules']);
+/**
+ * Paths (relative to the substitution target root, `/`-separated) that
+ * document the seven onboarding placeholders rather than consume them —
+ * they intentionally keep every worked-example token literal, so a blind
+ * global rewrite corrupts their headings and orphans prose that refers
+ * back to the token by name (#1924). Both `scanPlaceholderTokens` and
+ * `applySubstitutionPlan` skip these paths, so they neither contribute
+ * matches to a substitution plan nor get rewritten even if a plan is
+ * ever built from a hand-rolled scan. Extend this set in one place if a
+ * later meta-doc needs the same carve-out.
+ */
+export const SCAN_EXCLUDED_PATHS = new Set([
+  'docs/onboarding/placeholders.md',
+  'docs/customization.md',
+  'docs/onboarding/policy-decisions.md',
+]);
 function isProbablyBinary(content) {
   return content.includes(0);
 }
 /**
  * Walk the target tree (excluding `.git` and `node_modules`, skipping
- * binary files) and collect every placeholder-shaped `{{...}}` token per
- * file, in ascending path order. Symlinks are deliberately not followed:
- * imported template files are regular files, and following links could
- * escape the target tree.
+ * binary files and `SCAN_EXCLUDED_PATHS`) and collect every
+ * placeholder-shaped `{{...}}` token per file, in ascending path order.
+ * Symlinks are deliberately not followed: imported template files are
+ * regular files, and following links could escape the target tree.
  */
 export function scanPlaceholderTokens(targetDir) {
   const results = [];
@@ -498,6 +515,10 @@ export function scanPlaceholderTokens(targetDir) {
       if (!entry.isFile()) {
         continue;
       }
+      const relativePath = relative(targetDir, absolute).split('\\').join('/');
+      if (SCAN_EXCLUDED_PATHS.has(relativePath)) {
+        continue;
+      }
       const raw = readFileSync(absolute);
       if (isProbablyBinary(raw)) {
         continue;
@@ -510,7 +531,7 @@ export function scanPlaceholderTokens(targetDir) {
       }
       if (tokens.size > 0) {
         results.push({
-          file: relative(targetDir, absolute).split('\\').join('/'),
+          file: relativePath,
           tokens,
         });
       }
@@ -518,6 +539,17 @@ export function scanPlaceholderTokens(targetDir) {
   };
   walk(targetDir);
   return results;
+}
+/**
+ * The subset of `SCAN_EXCLUDED_PATHS` that exists under `targetDir`,
+ * sorted. `--substitute` reports this list as `skippedPaths` in its
+ * printed verdict so an operator can see the meta-doc carve-out applied
+ * rather than inferring it from an absent plan entry.
+ */
+export function listSkippedPlaceholderPaths(targetDir) {
+  return [...SCAN_EXCLUDED_PATHS]
+    .filter((path) => existsSync(resolve(targetDir, path)))
+    .sort();
 }
 /**
  * Combine the token scan with the resolved values into the substitution
@@ -567,11 +599,16 @@ export function buildSubstitutionPlan(scans, resolution) {
  * Apply the plan: rewrite each planned file in a single replacement pass
  * over the placeholder-token pattern, so a token injected by one
  * substitution value is never re-substituted by a later one. Returns the
- * count of files written.
+ * count of files written. `SCAN_EXCLUDED_PATHS` entries are skipped here
+ * too, defense-in-depth alongside `scanPlaceholderTokens`'s own skip, in
+ * case a caller ever builds a plan from a hand-rolled scan.
  */
 export function applySubstitutionPlan(targetDir, plan) {
   const byFile = new Map();
   for (const entry of plan.entries) {
+    if (SCAN_EXCLUDED_PATHS.has(entry.file)) {
+      continue;
+    }
     const tokens = byFile.get(entry.file) ?? new Map();
     tokens.set(entry.from, entry.to);
     byFile.set(entry.file, tokens);
@@ -1146,6 +1183,7 @@ function runCli() {
     plan: plan.entries,
     residue: plan.residue,
     unknownTokens: plan.unknownTokens,
+    skippedPaths: listSkippedPlaceholderPaths(targetDir),
     filesChanged,
     written: canWrite && filesChanged > 0,
   };
@@ -1248,9 +1286,13 @@ target tree that already contains the imported template files
 (auto-derived from repository evidence where
 idd-template/docs/onboarding/placeholders.md defines a derivation;
 explicit flags override; --trusted-marker-actor is always explicit) and
-rewrites the files. Prints a JSON verdict with the per-file,
-per-placeholder plan, blocking residue (unresolved onboarding
-placeholders), and informational unknown {{...}} tokens.
+rewrites the files. Skips the placeholder-reference meta-docs
+(docs/onboarding/placeholders.md, docs/customization.md,
+docs/onboarding/policy-decisions.md), which document the tokens rather
+than consume them and stay literal on purpose. Prints a JSON verdict
+with the per-file, per-placeholder plan, blocking residue (unresolved
+onboarding placeholders), informational unknown {{...}} tokens, and the
+skipped meta-doc paths present in the target.
 
 Exit codes: 0 converged; 1 residue would remain (apply writes nothing
 in that case); 2 usage or configuration error.

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -42,6 +42,7 @@ import { execFileSync } from 'node:child_process';
 import {
   chmodSync,
   copyFileSync,
+  existsSync,
   lstatSync,
   mkdirSync,
   readdirSync,
@@ -555,6 +556,23 @@ const PLACEHOLDER_TOKEN_PATTERN = /\{\{[A-Z][A-Z0-9_]*\}\}/g;
 /** Directories never scanned for placeholder tokens. */
 const SCAN_EXCLUDED_DIRS = new Set(['.git', 'node_modules']);
 
+/**
+ * Paths (relative to the substitution target root, `/`-separated) that
+ * document the seven onboarding placeholders rather than consume them —
+ * they intentionally keep every worked-example token literal, so a blind
+ * global rewrite corrupts their headings and orphans prose that refers
+ * back to the token by name (#1924). Both `scanPlaceholderTokens` and
+ * `applySubstitutionPlan` skip these paths, so they neither contribute
+ * matches to a substitution plan nor get rewritten even if a plan is
+ * ever built from a hand-rolled scan. Extend this set in one place if a
+ * later meta-doc needs the same carve-out.
+ */
+export const SCAN_EXCLUDED_PATHS = new Set([
+  'docs/onboarding/placeholders.md',
+  'docs/customization.md',
+  'docs/onboarding/policy-decisions.md',
+]);
+
 /** Token occurrences found in one scanned file. */
 export interface PlaceholderFileScan {
   /** Path relative to the scan root, `/`-separated. */
@@ -569,10 +587,10 @@ function isProbablyBinary(content: Buffer): boolean {
 
 /**
  * Walk the target tree (excluding `.git` and `node_modules`, skipping
- * binary files) and collect every placeholder-shaped `{{...}}` token per
- * file, in ascending path order. Symlinks are deliberately not followed:
- * imported template files are regular files, and following links could
- * escape the target tree.
+ * binary files and `SCAN_EXCLUDED_PATHS`) and collect every
+ * placeholder-shaped `{{...}}` token per file, in ascending path order.
+ * Symlinks are deliberately not followed: imported template files are
+ * regular files, and following links could escape the target tree.
  */
 export function scanPlaceholderTokens(
   targetDir: string,
@@ -602,6 +620,10 @@ export function scanPlaceholderTokens(
       if (!entry.isFile()) {
         continue;
       }
+      const relativePath = relative(targetDir, absolute).split('\\').join('/');
+      if (SCAN_EXCLUDED_PATHS.has(relativePath)) {
+        continue;
+      }
       const raw = readFileSync(absolute);
       if (isProbablyBinary(raw)) {
         continue;
@@ -614,7 +636,7 @@ export function scanPlaceholderTokens(
       }
       if (tokens.size > 0) {
         results.push({
-          file: relative(targetDir, absolute).split('\\').join('/'),
+          file: relativePath,
           tokens,
         });
       }
@@ -622,6 +644,18 @@ export function scanPlaceholderTokens(
   };
   walk(targetDir);
   return results;
+}
+
+/**
+ * The subset of `SCAN_EXCLUDED_PATHS` that exists under `targetDir`,
+ * sorted. `--substitute` reports this list as `skippedPaths` in its
+ * printed verdict so an operator can see the meta-doc carve-out applied
+ * rather than inferring it from an absent plan entry.
+ */
+export function listSkippedPlaceholderPaths(targetDir: string): string[] {
+  return [...SCAN_EXCLUDED_PATHS]
+    .filter((path) => existsSync(resolve(targetDir, path)))
+    .sort();
 }
 
 /** One planned rewrite: every occurrence of a token in one file. */
@@ -714,7 +748,9 @@ export function buildSubstitutionPlan(
  * Apply the plan: rewrite each planned file in a single replacement pass
  * over the placeholder-token pattern, so a token injected by one
  * substitution value is never re-substituted by a later one. Returns the
- * count of files written.
+ * count of files written. `SCAN_EXCLUDED_PATHS` entries are skipped here
+ * too, defense-in-depth alongside `scanPlaceholderTokens`'s own skip, in
+ * case a caller ever builds a plan from a hand-rolled scan.
  */
 export function applySubstitutionPlan(
   targetDir: string,
@@ -722,6 +758,9 @@ export function applySubstitutionPlan(
 ): number {
   const byFile = new Map<string, Map<string, string>>();
   for (const entry of plan.entries) {
+    if (SCAN_EXCLUDED_PATHS.has(entry.file)) {
+      continue;
+    }
     const tokens = byFile.get(entry.file) ?? new Map<string, string>();
     tokens.set(entry.from, entry.to);
     byFile.set(entry.file, tokens);
@@ -1459,6 +1498,7 @@ function runCli(): void {
     plan: plan.entries,
     residue: plan.residue,
     unknownTokens: plan.unknownTokens,
+    skippedPaths: listSkippedPlaceholderPaths(targetDir),
     filesChanged,
     written: canWrite && filesChanged > 0,
   };
@@ -1564,9 +1604,13 @@ target tree that already contains the imported template files
 (auto-derived from repository evidence where
 idd-template/docs/onboarding/placeholders.md defines a derivation;
 explicit flags override; --trusted-marker-actor is always explicit) and
-rewrites the files. Prints a JSON verdict with the per-file,
-per-placeholder plan, blocking residue (unresolved onboarding
-placeholders), and informational unknown {{...}} tokens.
+rewrites the files. Skips the placeholder-reference meta-docs
+(docs/onboarding/placeholders.md, docs/customization.md,
+docs/onboarding/policy-decisions.md), which document the tokens rather
+than consume them and stay literal on purpose. Prints a JSON verdict
+with the per-file, per-placeholder plan, blocking residue (unresolved
+onboarding placeholders), informational unknown {{...}} tokens, and the
+skipped meta-doc paths present in the target.
 
 Exit codes: 0 converged; 1 residue would remain (apply writes nothing
 in that case); 2 usage or configuration error.

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -38,6 +38,7 @@ import {
   deriveMarkerPrefix,
   deriveValidateCommands,
   escapeJsonStringContent,
+  listSkippedPlaceholderPaths,
   MARKER_PREFIX_PATTERN,
   ONBOARDING_PLACEHOLDERS,
   parseRemoteRepoRef,
@@ -45,6 +46,7 @@ import {
   resolveImportFiles,
   resolvePlaceholderValues,
   runVerify,
+  SCAN_EXCLUDED_PATHS,
   scanPlaceholderTokens,
 } from '../src/scripts/idd-onboard.mts';
 
@@ -627,6 +629,104 @@ test('binary files and excluded directories are not scanned', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #1924 — meta-docs that document the placeholders stay literal
+// ---------------------------------------------------------------------------
+
+/** Write a token-bearing copy of each `SCAN_EXCLUDED_PATHS` doc into `root`. */
+function writeExcludedMetaDocs(root: string): void {
+  for (const relativePath of SCAN_EXCLUDED_PATHS) {
+    const absolute = join(root, ...relativePath.split('/'));
+    mkdirSync(dirname(absolute), { recursive: true });
+    writeFileSync(
+      absolute,
+      `# Reference\n\n\`{{REPO_NAME}}\` names the repository.\n`,
+    );
+  }
+}
+
+test('scanPlaceholderTokens skips SCAN_EXCLUDED_PATHS meta-docs entirely', () => {
+  const root = makeFixtureDir();
+  writeExcludedMetaDocs(root);
+  writeFileSync(join(root, 'README.md'), '# {{REPO_NAME}}\n');
+  const scans = scanPlaceholderTokens(root);
+  assert.deepEqual(scans.map((scan) => scan.file).sort(), ['README.md']);
+});
+
+test('--substitute leaves the meta-docs byte-identical, including on a second re-sync run', () => {
+  const root = makeFixtureDir();
+  writeTemplateFixture(root);
+  writeExcludedMetaDocs(root);
+  const before = new Map(
+    [...SCAN_EXCLUDED_PATHS].map((relativePath) => [
+      relativePath,
+      readFileSync(join(root, ...relativePath.split('/'))),
+    ]),
+  );
+  const resolution = resolvePlaceholderValues(root, ALL_OVERRIDES, {
+    readRemoteUrl: () => null,
+  });
+  for (let run = 0; run < 2; run += 1) {
+    const plan = buildSubstitutionPlan(scanPlaceholderTokens(root), resolution);
+    // The meta-docs never contribute a plan entry.
+    assert.ok(
+      plan.entries.every((entry) => !SCAN_EXCLUDED_PATHS.has(entry.file)),
+    );
+    applySubstitutionPlan(root, plan);
+  }
+  for (const [relativePath, original] of before) {
+    const after = readFileSync(join(root, ...relativePath.split('/')));
+    assert.ok(original.equals(after), `byte mismatch: ${relativePath}`);
+  }
+  // Every non-excluded site still converges normally in the same run.
+  assert.equal(
+    readFileSync(join(root, 'README.md'), 'utf8'),
+    '# my-app\n\nWorktree example: ../my-app.issue-1-fix\n',
+  );
+});
+
+test('applySubstitutionPlan refuses to rewrite a SCAN_EXCLUDED_PATHS entry even from a hand-built plan', () => {
+  const root = makeFixtureDir();
+  writeExcludedMetaDocs(root);
+  const [excludedPath] = SCAN_EXCLUDED_PATHS;
+  const before = readFileSync(join(root, ...excludedPath.split('/')));
+  const filesChanged = applySubstitutionPlan(root, {
+    entries: [
+      {
+        file: excludedPath,
+        placeholder: 'REPO_NAME',
+        occurrences: 1,
+        from: '{{REPO_NAME}}',
+        to: 'my-app',
+      },
+    ],
+    residue: [],
+    unknownTokens: [],
+  });
+  assert.equal(filesChanged, 0);
+  assert.ok(
+    before.equals(readFileSync(join(root, ...excludedPath.split('/')))),
+  );
+});
+
+test('checkPlaceholderResidue does not report the meta-docs as unresolved residue', () => {
+  const root = makeFixtureDir();
+  writeExcludedMetaDocs(root);
+  const result = checkPlaceholderResidue(root);
+  assert.deepEqual(result.residue, []);
+  assert.deepEqual(result.unknownTokens, []);
+});
+
+test('listSkippedPlaceholderPaths reports only the meta-docs present in the target, sorted', () => {
+  const root = makeFixtureDir();
+  const [firstPath] = [...SCAN_EXCLUDED_PATHS].sort();
+  mkdirSync(dirname(join(root, ...firstPath.split('/'))), {
+    recursive: true,
+  });
+  writeFileSync(join(root, ...firstPath.split('/')), '# ref\n');
+  assert.deepEqual(listSkippedPlaceholderPaths(root), [firstPath]);
+});
+
+// ---------------------------------------------------------------------------
 // Wave 2: --import (manifest-driven fetch/copy)
 // ---------------------------------------------------------------------------
 
@@ -1177,6 +1277,32 @@ test('bin/idd-onboard.mjs --substitute --dry-run prints the plan and writes noth
   assertTreeUnchanged(root, before);
 });
 
+test('bin/idd-onboard.mjs --substitute summary lists the skipped meta-doc paths', () => {
+  const root = makeFixtureDir();
+  writeTemplateFixture(root);
+  writeExcludedMetaDocs(root);
+  const before = new Map(
+    [...SCAN_EXCLUDED_PATHS].map((relativePath) => [
+      relativePath,
+      readFileSync(join(root, ...relativePath.split('/'))),
+    ]),
+  );
+  const { status, verdict } = runCliBin([
+    '--substitute',
+    '--target',
+    root,
+    ...CLI_OVERRIDE_FLAGS,
+  ]);
+  assert.equal(status, 0);
+  assert.deepEqual(verdict.skippedPaths, [...SCAN_EXCLUDED_PATHS].sort());
+  for (const [relativePath, original] of before) {
+    assert.ok(
+      original.equals(readFileSync(join(root, ...relativePath.split('/')))),
+      `byte mismatch: ${relativePath}`,
+    );
+  }
+});
+
 test('bin/idd-onboard.mjs without --dry-run applies exactly the planned edits', () => {
   const dryRoot = makeFixtureDir();
   writeTemplateFixture(dryRoot);
@@ -1636,6 +1762,31 @@ test('checkPlaceholderResidue classifies a leftover onboarding placeholder as bl
 test('checkPlaceholderResidue reports nothing for a fully substituted target', () => {
   const targetRoot = makeFixtureDir();
   importAndSubstitute(targetRoot);
+  const result = checkPlaceholderResidue(targetRoot);
+  assert.deepEqual(result.residue, []);
+});
+
+test('#1924 regression: importing the real template keeps the meta-docs literal', () => {
+  // The three real idd-template/docs meta-docs carry live {{TOKEN}}
+  // worked examples today (the field-reported corruption source), so this
+  // exercises the actual distributed files rather than a synthetic
+  // fixture.
+  const targetRoot = makeFixtureDir();
+  importAndSubstitute(targetRoot);
+  for (const relativePath of SCAN_EXCLUDED_PATHS) {
+    const sourceBytes = readFileSync(
+      join(REPO_ROOT, 'idd-template', ...relativePath.split('/')),
+    );
+    const targetBytes = readFileSync(
+      join(targetRoot, ...relativePath.split('/')),
+    );
+    assert.ok(
+      sourceBytes.equals(targetBytes),
+      `byte mismatch after import+substitute: ${relativePath}`,
+    );
+  }
+  // --verify's residue check must not read their surviving tokens as
+  // unresolved placeholders.
   const result = checkPlaceholderResidue(targetRoot);
   assert.deepEqual(result.residue, []);
 });


### PR DESCRIPTION
# Summary

`idd-onboard --substitute` blindly rewrites every `{{TOKEN}}`-shaped
match in the target tree, with only a directory-based exclusion (`.git`,
`node_modules`). Three imported docs exist to *document* the seven
onboarding placeholders with worked examples rather than *consume* them
(`docs/onboarding/placeholders.md`, `docs/customization.md`,
`docs/onboarding/policy-decisions.md`); a global rewrite corrupts their
headings and orphans prose that refers back to a token by name, as
field-reported from `kurone-kito/lints-config`. This repo's own
`idd-template/docs` copies still carry live `{{TOKEN}}` examples today
(28 occurrences across the three files), so the corruption is real and
reproducible on the next onboarding run — not already fixed elsewhere.

Adds a path-based `SCAN_EXCLUDED_PATHS` set alongside the existing
directory exclusion. `scanPlaceholderTokens` skips these paths so they
never contribute a plan entry (and `--verify`'s placeholder-residue
check inherits the fix for free, since it reuses the same scanner);
`applySubstitutionPlan` skips them too, defense in depth. `--substitute`
now reports which of the excluded paths exist under `--target` as
`skippedPaths` in its printed verdict, and `ONBOARDING.md` Step 4 states
the carve-out.

## Linked issue

Closes #1924

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The exclusion lives once, in `scanPlaceholderTokens`, so the scan, the
substitution plan, and `--verify`'s residue check all inherit it from
the same data flow. `applySubstitutionPlan` also checks the set
independently, matching the issue's explicit design so a future caller
building a plan from a hand-rolled scan can't accidentally rewrite one
of these paths.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
