### PR TITLE
docs(review-triage): route inconclusive PATH A claims to the AMD hold

### DIFF
--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -89,7 +89,13 @@ maintainer confirmation for an unprivileged PATH A actor: confirmed →
 `Accept` and act; **false on the live evidence** → disposition it
 `Rejected` and cite the contradicting evidence (the code as read, the
 real run conclusion, file contents, or artifact) — a verified-false
-claim is a reasoned rejection, not an action item.
+claim is a reasoned rejection, not an action item; **inconclusive**
+(neither confirmed nor contradicted, because the needed check has no
+route this environment can run, not merely low confidence) → for an
+actor-permission-capped PATH A item, route it through the
+CODEOWNER/required-reviewer AMD hold (E6) instead of `Rejected`.
+`Rejected` stays reserved for a claim the live evidence actually
+contradicts.
 
 **Resolved-thread duplicate pre-check (PATH B, before verification).**
 Before verification above, check whether a new PATH B item — a review
@@ -128,22 +134,12 @@ state of its own, but can still match a prior resolved thread's claim.
   at current HEAD, or the new occurrence carries genuinely new
   information the prior thread did not address.
 
-**Worked example.** A bot re-raises "this workflow step needs
-`contents: write`" two rounds after an identical claim on the same file
-was rejected with evidence (the step only uploads an artifact). Confirm
-the claim and evidence still hold at current HEAD, reply `**Rejected**
-— same claim as {prior thread URL}: verified false there; unchanged at
-current HEAD.`, then resolve the thread.
-
 **Reasoned-rejection convergence.** The iterate-to-zero loop may converge
 by reasoned rejection of peripheral or verified-false items — not every
 comment needs a code change. Record the reason in the disposition reply;
-"a bot raised it" alone never forces a change.
-
-**Worked example.** A bot flags a "credential leak" on a config-only file
-that in fact holds only public placeholders. Reply `**Rejected** —
-verified: the flagged file contains only public placeholders; no
-credential is present.`
+"a bot raised it" alone never forces a change (e.g., a "credential
+leak" flag on a placeholders-only config file: `**Rejected** —
+verified: only public placeholders present`).
 
 ## E6 — Post disposition replies
 
@@ -157,13 +153,16 @@ PATH A — Accepted items:
 
 PATH A — Rejected reviewer feedback:
 
-For each Rejected PATH A item whose source is reviewer feedback:
+For each Rejected or inconclusive (E5) PATH A item whose source is
+reviewer feedback:
 
 - Reply using the format: `**Rejected** — {reason}`
-- **Exception**: if the source is a CODEOWNER or required reviewer, do
-  not reject unilaterally. Reply using the format:
-  `**Awaiting maintainer decision** — {your reasoning}` and wait for the
-  maintainer's response.
+- **Exception**: if the source is a CODEOWNER or required reviewer, or
+  the item is E5's inconclusive outcome, do not reject unilaterally.
+  Reply using the format:
+  `**Awaiting maintainer decision** — {your reasoning}` (name the
+  unavailable check when inconclusive) and wait for the maintainer's
+  response.
 - After posting your reply, **immediately resolve the thread** — except
   for `**Awaiting maintainer decision**`. When helper runtime is enabled,
   the profile-selected resolve-review-thread command (`--pr <number>
@@ -181,8 +180,7 @@ For each Rejected PATH A item whose source is reviewer feedback:
   (CODEOWNER/required-reviewer feedback with no thread) cannot use that
   gate structurally — instead post the hold comment stating you will
   **not** merge until the decision appears, and stop. Either way, wait
-  for the response in a future E1 pass: agreement closes the AMD (reply
-  to confirm, remove the hold); an override moves it to Accepted.
+  for the response in a future E1 pass (see the transitions below).
 - **When an `Awaiting maintainer decision` thread re-appears in ReviewItems_snapshot**:
   scan the activity universe for a **qualifying response** — a reply on
   this thread, or a separate comment/review that clearly references
@@ -199,13 +197,12 @@ For each Rejected PATH A item whose source is reviewer feedback:
   in a future E1 pass.
 - **When the maintainer eventually responds** (their response surfaces
   in a future E1 pass as an unresolved thread or new reply):
-  - If the maintainer **agrees with your rejection**: reply summarizing
+  - If the maintainer **agrees no action is needed**: reply summarizing
     the agreed decision (e.g.,
     `**Rejection confirmed by maintainer** — {summary}`) and resolve the
     thread.
-  - If the maintainer **disagrees**: move the item from Rejected to
-    Accepted and proceed through the fix flow. Resolve the thread after
-    fixing.
+  - If the maintainer **disagrees**: move the item to Accepted and
+    proceed through the fix flow. Resolve the thread after fixing.
   - If the maintainer's response arrived in a separate PR comment or
     review rather than in the original thread: mirror the decision onto
     the original thread and resolve the thread. Also **reply to the
@@ -359,13 +356,14 @@ review state.
 Before leaving triage, verify every ReviewItems_snapshot item has the
 evidence required by its path:
 
-- Every PATH A item has a recorded classification and an Accept or
-  Reject decision. Every Accepted item cites its "Verify before accept"
-  evidence, or the maintainer confirmation reply when actor-permission
-  capped.
-- Every Rejected PATH A item whose source is reviewer feedback has the
-  required rejection or `**Awaiting maintainer decision**` reply posted,
-  and any non-AMD thread resolution is complete.
+- Every PATH A item has a recorded classification and an Accept,
+  Reject, or inconclusive (E5) decision. Every Accepted item cites its
+  "Verify before accept" evidence, or the maintainer confirmation reply
+  when actor-permission capped.
+- Every Rejected or inconclusive PATH A item whose source is reviewer
+  feedback has the required rejection or
+  `**Awaiting maintainer decision**` reply posted, and any non-AMD
+  thread resolution is complete.
 - Every PATH B item has a posted `**Accepted**` or `**Rejected**`
   marker. Review threads are resolved immediately after the marker.
 - Only Accepted PATH A items remain candidates for

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -358,9 +358,9 @@ Before leaving triage, verify every ReviewItems_snapshot item has the
 evidence required by its path:
 
 - Every PATH A item has a recorded classification and an Accept,
-  Reject, or AMD (E5 inconclusive) decision. Every Accepted item cites
-  its "Verify before accept" evidence, or the maintainer confirmation
-  reply when actor-permission capped.
+  Reject, or AMD decision (including E5 inconclusive). Every Accepted
+  item cites its "Verify before accept" evidence, or the maintainer
+  confirmation reply when actor-permission capped.
 - Every Rejected or inconclusive PATH A item whose source is reviewer
   feedback has the required rejection or
   `**Awaiting maintainer decision**` reply posted, and any non-AMD

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -358,9 +358,9 @@ Before leaving triage, verify every ReviewItems_snapshot item has the
 evidence required by its path:
 
 - Every PATH A item has a recorded classification and an Accept,
-  Reject, or inconclusive (E5) decision. Every Accepted item cites its
-  "Verify before accept" evidence, or the maintainer confirmation reply
-  when actor-permission capped.
+  Reject, or AMD (E5 inconclusive) decision. Every Accepted item cites
+  its "Verify before accept" evidence, or the maintainer confirmation
+  reply when actor-permission capped.
 - Every Rejected or inconclusive PATH A item whose source is reviewer
   feedback has the required rejection or
   `**Awaiting maintainer decision**` reply posted, and any non-AMD

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -95,7 +95,7 @@ routes); **inconclusive** (neither confirmed nor contradicted — the
 needed check has no route here, not merely low confidence) → for an
 actor-permission-capped, reviewer-feedback PATH A item, route it
 through the CODEOWNER/required-reviewer AMD hold (E6) instead of
-`Rejected`, encoded `awaiting_maintainer` like that path (a
+`Rejected`, encoded `awaiting_maintainer`, E6's marker (a
 critique-pass finding stays under the unchanged cap above).
 
 **Resolved-thread duplicate pre-check (PATH B, before verification).**

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -89,13 +89,14 @@ maintainer confirmation for an unprivileged PATH A actor: confirmed →
 `Accept` and act; **false on the live evidence** → disposition it
 `Rejected` and cite the contradicting evidence (the code as read, the
 real run conclusion, file contents, or artifact) — a verified-false
-claim is a reasoned rejection, not an action item; **inconclusive**
-(neither confirmed nor contradicted, because the needed check has no
-route this environment can run, not merely low confidence) → for an
-actor-permission-capped PATH A item, route it through the
-CODEOWNER/required-reviewer AMD hold (E6) instead of `Rejected`.
-`Rejected` stays reserved for a claim the live evidence actually
-contradicts.
+claim is a reasoned rejection, not an action item (scoped to this
+verification only — not E4/E5's Low-severity/no-action `Rejected`
+routes); **inconclusive** (neither confirmed nor contradicted — the
+needed check has no route here, not merely low confidence) → for an
+actor-permission-capped, reviewer-feedback PATH A item, route it
+through the CODEOWNER/required-reviewer AMD hold (E6) instead of
+`Rejected` (a critique-pass finding stays under the unchanged cap
+above).
 
 **Resolved-thread duplicate pre-check (PATH B, before verification).**
 Before verification above, check whether a new PATH B item — a review
@@ -107,9 +108,7 @@ state of its own, but can still match a prior resolved thread's claim.
 
 - Match the new item against the index by file area and substantive
   claim, requiring the identical claim rather than merely a related
-  topic in the same file. (For example, a prior "raw SQL concatenation"
-  rejection on `db/query.mts` does not match a new "missing index"
-  comment on the same file: same file area, different claim.)
+  topic in the same file (same file, different claim, is not a match).
 - On a match, open the linked prior thread — the index disposition alone
   is not proof. Re-confirm the new item raises that **same underlying
   claim**, not just a related one, then confirm the prior thread
@@ -358,9 +357,9 @@ Before leaving triage, verify every ReviewItems_snapshot item has the
 evidence required by its path:
 
 - Every PATH A item has a recorded classification and an Accept,
-  Reject, or inconclusive (E5) decision. Every Accepted item cites its
-  "Verify before accept" evidence, or the maintainer confirmation reply
-  when actor-permission capped.
+  Reject, or inconclusive (E5, encoded `awaiting_maintainer`) decision.
+  Every Accepted item cites its "Verify before accept" evidence, or the
+  maintainer confirmation reply when actor-permission capped.
 - Every Rejected or inconclusive PATH A item whose source is reviewer
   feedback has the required rejection or
   `**Awaiting maintainer decision**` reply posted, and any non-AMD

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -95,8 +95,8 @@ routes); **inconclusive** (neither confirmed nor contradicted — the
 needed check has no route here, not merely low confidence) → for an
 actor-permission-capped, reviewer-feedback PATH A item, route it
 through the CODEOWNER/required-reviewer AMD hold (E6) instead of
-`Rejected` (a critique-pass finding stays under the unchanged cap
-above).
+`Rejected`, encoded `awaiting_maintainer` like that path (a
+critique-pass finding stays under the unchanged cap above).
 
 **Resolved-thread duplicate pre-check (PATH B, before verification).**
 Before verification above, check whether a new PATH B item — a review
@@ -108,7 +108,8 @@ state of its own, but can still match a prior resolved thread's claim.
 
 - Match the new item against the index by file area and substantive
   claim, requiring the identical claim rather than merely a related
-  topic in the same file (same file, different claim, is not a match).
+  topic in the same file (same file but a different claim is not a
+  match).
 - On a match, open the linked prior thread — the index disposition alone
   is not proof. Re-confirm the new item raises that **same underlying
   claim**, not just a related one, then confirm the prior thread
@@ -137,8 +138,8 @@ state of its own, but can still match a prior resolved thread's claim.
 by reasoned rejection of peripheral or verified-false items — not every
 comment needs a code change. Record the reason in the disposition reply;
 "a bot raised it" alone never forces a change (e.g., a "credential
-leak" flag on a placeholders-only config file: `**Rejected** —
-verified: only public placeholders present`).
+leak" flag on a placeholders-only config file:
+`**Rejected** — verified placeholders-only`).
 
 ## E6 — Post disposition replies
 
@@ -150,7 +151,7 @@ PATH A — Accepted items:
   reviewer feedback is replied to after the fix work in
   `idd-review-fix.instructions.md`.
 
-PATH A — Rejected reviewer feedback:
+PATH A — Rejected/inconclusive reviewer feedback:
 
 For each Rejected or inconclusive (E5) PATH A item whose source is
 reviewer feedback:
@@ -357,9 +358,9 @@ Before leaving triage, verify every ReviewItems_snapshot item has the
 evidence required by its path:
 
 - Every PATH A item has a recorded classification and an Accept,
-  Reject, or inconclusive (E5, encoded `awaiting_maintainer`) decision.
-  Every Accepted item cites its "Verify before accept" evidence, or the
-  maintainer confirmation reply when actor-permission capped.
+  Reject, or inconclusive (E5) decision. Every Accepted item cites its
+  "Verify before accept" evidence, or the maintainer confirmation reply
+  when actor-permission capped.
 - Every Rejected or inconclusive PATH A item whose source is reviewer
   feedback has the required rejection or
   `**Awaiting maintainer decision**` reply posted, and any non-AMD

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -250,7 +250,7 @@ Use these prefixes so that disposition is always unambiguous:
 - PATH B acceptance marker (only for a _completed_ review of the current
   HEAD): `**Accepted** — {what the advisory comment confirmed}`
 - Ordinary rejection: `**Rejected** — {reason}`
-- CODEOWNER / required reviewer exception:
+- CODEOWNER / required reviewer, or inconclusive (E5), exception:
   `**Awaiting maintainer decision** — {reasoning}`
 
 Two requirements make the F2/F3 disposition-evidence gate recognize an

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -95,8 +95,8 @@ routes); **inconclusive** (neither confirmed nor contradicted — the
 needed check has no route here, not merely low confidence) → for an
 actor-permission-capped, reviewer-feedback PATH A item, route it
 through the CODEOWNER/required-reviewer AMD hold (E6) instead of
-`Rejected`, encoded `awaiting_maintainer`, E6's marker (a
-critique-pass finding stays under the unchanged cap above).
+`Rejected`, using E6's marker (a critique-pass finding stays under
+the unchanged cap above).
 
 **Resolved-thread duplicate pre-check (PATH B, before verification).**
 Before verification above, check whether a new PATH B item — a review

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -156,7 +156,8 @@ PATH A — Rejected reviewer feedback:
 For each Rejected or inconclusive (E5) PATH A item whose source is
 reviewer feedback:
 
-- Reply using the format: `**Rejected** — {reason}`
+- Reply using the format: `**Rejected** — {reason}` — unless the
+  Exception below applies.
 - **Exception**: if the source is a CODEOWNER or required reviewer, or
   the item is E5's inconclusive outcome, do not reject unilaterally.
   Reply using the format:

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -90,7 +90,7 @@ routes); **inconclusive** (neither confirmed nor contradicted — the
 needed check has no route here, not merely low confidence) → for an
 actor-permission-capped, reviewer-feedback PATH A item, route it
 through the CODEOWNER/required-reviewer AMD hold (E6) instead of
-`Rejected`, encoded `awaiting_maintainer` like that path (a
+`Rejected`, encoded `awaiting_maintainer`, E6's marker (a
 critique-pass finding stays under the unchanged cap above).
 
 **Resolved-thread duplicate pre-check (PATH B, before verification).**

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -245,7 +245,7 @@ Use these prefixes so that disposition is always unambiguous:
 - PATH B acceptance marker (only for a _completed_ review of the current
   HEAD): `**Accepted** — {what the advisory comment confirmed}`
 - Ordinary rejection: `**Rejected** — {reason}`
-- CODEOWNER / required reviewer exception:
+- CODEOWNER / required reviewer, or inconclusive (E5), exception:
   `**Awaiting maintainer decision** — {reasoning}`
 
 Two requirements make the F2/F3 disposition-evidence gate recognize an

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -84,7 +84,13 @@ maintainer confirmation for an unprivileged PATH A actor: confirmed →
 `Accept` and act; **false on the live evidence** → disposition it
 `Rejected` and cite the contradicting evidence (the code as read, the
 real run conclusion, file contents, or artifact) — a verified-false
-claim is a reasoned rejection, not an action item.
+claim is a reasoned rejection, not an action item; **inconclusive**
+(neither confirmed nor contradicted, because the needed check has no
+route this environment can run, not merely low confidence) → for an
+actor-permission-capped PATH A item, route it through the
+CODEOWNER/required-reviewer AMD hold (E6) instead of `Rejected`.
+`Rejected` stays reserved for a claim the live evidence actually
+contradicts.
 
 **Resolved-thread duplicate pre-check (PATH B, before verification).**
 Before verification above, check whether a new PATH B item — a review
@@ -123,22 +129,12 @@ state of its own, but can still match a prior resolved thread's claim.
   at current HEAD, or the new occurrence carries genuinely new
   information the prior thread did not address.
 
-**Worked example.** A bot re-raises "this workflow step needs
-`contents: write`" two rounds after an identical claim on the same file
-was rejected with evidence (the step only uploads an artifact). Confirm
-the claim and evidence still hold at current HEAD, reply `**Rejected**
-— same claim as {prior thread URL}: verified false there; unchanged at
-current HEAD.`, then resolve the thread.
-
 **Reasoned-rejection convergence.** The iterate-to-zero loop may converge
 by reasoned rejection of peripheral or verified-false items — not every
 comment needs a code change. Record the reason in the disposition reply;
-"a bot raised it" alone never forces a change.
-
-**Worked example.** A bot flags a "credential leak" on a config-only file
-that in fact holds only public placeholders. Reply `**Rejected** —
-verified: the flagged file contains only public placeholders; no
-credential is present.`
+"a bot raised it" alone never forces a change (e.g., a "credential
+leak" flag on a placeholders-only config file: `**Rejected** —
+verified: only public placeholders present`).
 
 ## E6 — Post disposition replies
 
@@ -152,13 +148,16 @@ PATH A — Accepted items:
 
 PATH A — Rejected reviewer feedback:
 
-For each Rejected PATH A item whose source is reviewer feedback:
+For each Rejected or inconclusive (E5) PATH A item whose source is
+reviewer feedback:
 
 - Reply using the format: `**Rejected** — {reason}`
-- **Exception**: if the source is a CODEOWNER or required reviewer, do
-  not reject unilaterally. Reply using the format:
-  `**Awaiting maintainer decision** — {your reasoning}` and wait for the
-  maintainer's response.
+- **Exception**: if the source is a CODEOWNER or required reviewer, or
+  the item is E5's inconclusive outcome, do not reject unilaterally.
+  Reply using the format:
+  `**Awaiting maintainer decision** — {your reasoning}` (name the
+  unavailable check when inconclusive) and wait for the maintainer's
+  response.
 - After posting your reply, **immediately resolve the thread** — except
   for `**Awaiting maintainer decision**`. When helper runtime is enabled,
   the profile-selected resolve-review-thread command (`--pr <number>
@@ -176,8 +175,7 @@ For each Rejected PATH A item whose source is reviewer feedback:
   (CODEOWNER/required-reviewer feedback with no thread) cannot use that
   gate structurally — instead post the hold comment stating you will
   **not** merge until the decision appears, and stop. Either way, wait
-  for the response in a future E1 pass: agreement closes the AMD (reply
-  to confirm, remove the hold); an override moves it to Accepted.
+  for the response in a future E1 pass (see the transitions below).
 - **When an `Awaiting maintainer decision` thread re-appears in ReviewItems_snapshot**:
   scan the activity universe for a **qualifying response** — a reply on
   this thread, or a separate comment/review that clearly references
@@ -194,13 +192,12 @@ For each Rejected PATH A item whose source is reviewer feedback:
   in a future E1 pass.
 - **When the maintainer eventually responds** (their response surfaces
   in a future E1 pass as an unresolved thread or new reply):
-  - If the maintainer **agrees with your rejection**: reply summarizing
+  - If the maintainer **agrees no action is needed**: reply summarizing
     the agreed decision (e.g.,
     `**Rejection confirmed by maintainer** — {summary}`) and resolve the
     thread.
-  - If the maintainer **disagrees**: move the item from Rejected to
-    Accepted and proceed through the fix flow. Resolve the thread after
-    fixing.
+  - If the maintainer **disagrees**: move the item to Accepted and
+    proceed through the fix flow. Resolve the thread after fixing.
   - If the maintainer's response arrived in a separate PR comment or
     review rather than in the original thread: mirror the decision onto
     the original thread and resolve the thread. Also **reply to the
@@ -354,13 +351,14 @@ review state.
 Before leaving triage, verify every ReviewItems_snapshot item has the
 evidence required by its path:
 
-- Every PATH A item has a recorded classification and an Accept or
-  Reject decision. Every Accepted item cites its "Verify before accept"
-  evidence, or the maintainer confirmation reply when actor-permission
-  capped.
-- Every Rejected PATH A item whose source is reviewer feedback has the
-  required rejection or `**Awaiting maintainer decision**` reply posted,
-  and any non-AMD thread resolution is complete.
+- Every PATH A item has a recorded classification and an Accept,
+  Reject, or inconclusive (E5) decision. Every Accepted item cites its
+  "Verify before accept" evidence, or the maintainer confirmation reply
+  when actor-permission capped.
+- Every Rejected or inconclusive PATH A item whose source is reviewer
+  feedback has the required rejection or
+  `**Awaiting maintainer decision**` reply posted, and any non-AMD
+  thread resolution is complete.
 - Every PATH B item has a posted `**Accepted**` or `**Rejected**`
   marker. Review threads are resolved immediately after the marker.
 - Only Accepted PATH A items remain candidates for

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -353,9 +353,9 @@ Before leaving triage, verify every ReviewItems_snapshot item has the
 evidence required by its path:
 
 - Every PATH A item has a recorded classification and an Accept,
-  Reject, or AMD (E5 inconclusive) decision. Every Accepted item cites
-  its "Verify before accept" evidence, or the maintainer confirmation
-  reply when actor-permission capped.
+  Reject, or AMD decision (including E5 inconclusive). Every Accepted
+  item cites its "Verify before accept" evidence, or the maintainer
+  confirmation reply when actor-permission capped.
 - Every Rejected or inconclusive PATH A item whose source is reviewer
   feedback has the required rejection or
   `**Awaiting maintainer decision**` reply posted, and any non-AMD

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -353,9 +353,9 @@ Before leaving triage, verify every ReviewItems_snapshot item has the
 evidence required by its path:
 
 - Every PATH A item has a recorded classification and an Accept,
-  Reject, or inconclusive (E5) decision. Every Accepted item cites its
-  "Verify before accept" evidence, or the maintainer confirmation reply
-  when actor-permission capped.
+  Reject, or AMD (E5 inconclusive) decision. Every Accepted item cites
+  its "Verify before accept" evidence, or the maintainer confirmation
+  reply when actor-permission capped.
 - Every Rejected or inconclusive PATH A item whose source is reviewer
   feedback has the required rejection or
   `**Awaiting maintainer decision**` reply posted, and any non-AMD

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -90,8 +90,8 @@ routes); **inconclusive** (neither confirmed nor contradicted — the
 needed check has no route here, not merely low confidence) → for an
 actor-permission-capped, reviewer-feedback PATH A item, route it
 through the CODEOWNER/required-reviewer AMD hold (E6) instead of
-`Rejected`, encoded `awaiting_maintainer`, E6's marker (a
-critique-pass finding stays under the unchanged cap above).
+`Rejected`, using E6's marker (a critique-pass finding stays under
+the unchanged cap above).
 
 **Resolved-thread duplicate pre-check (PATH B, before verification).**
 Before verification above, check whether a new PATH B item — a review

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -90,8 +90,8 @@ routes); **inconclusive** (neither confirmed nor contradicted — the
 needed check has no route here, not merely low confidence) → for an
 actor-permission-capped, reviewer-feedback PATH A item, route it
 through the CODEOWNER/required-reviewer AMD hold (E6) instead of
-`Rejected` (a critique-pass finding stays under the unchanged cap
-above).
+`Rejected`, encoded `awaiting_maintainer` like that path (a
+critique-pass finding stays under the unchanged cap above).
 
 **Resolved-thread duplicate pre-check (PATH B, before verification).**
 Before verification above, check whether a new PATH B item — a review
@@ -103,7 +103,8 @@ state of its own, but can still match a prior resolved thread's claim.
 
 - Match the new item against the index by file area and substantive
   claim, requiring the identical claim rather than merely a related
-  topic in the same file (same file, different claim, is not a match).
+  topic in the same file (same file but a different claim is not a
+  match).
 - On a match, open the linked prior thread — the index disposition alone
   is not proof. Re-confirm the new item raises that **same underlying
   claim**, not just a related one, then confirm the prior thread
@@ -132,8 +133,8 @@ state of its own, but can still match a prior resolved thread's claim.
 by reasoned rejection of peripheral or verified-false items — not every
 comment needs a code change. Record the reason in the disposition reply;
 "a bot raised it" alone never forces a change (e.g., a "credential
-leak" flag on a placeholders-only config file: `**Rejected** —
-verified: only public placeholders present`).
+leak" flag on a placeholders-only config file:
+`**Rejected** — verified placeholders-only`).
 
 ## E6 — Post disposition replies
 
@@ -145,7 +146,7 @@ PATH A — Accepted items:
   reviewer feedback is replied to after the fix work in
   `idd-review-fix.instructions.md`.
 
-PATH A — Rejected reviewer feedback:
+PATH A — Rejected/inconclusive reviewer feedback:
 
 For each Rejected or inconclusive (E5) PATH A item whose source is
 reviewer feedback:
@@ -352,9 +353,9 @@ Before leaving triage, verify every ReviewItems_snapshot item has the
 evidence required by its path:
 
 - Every PATH A item has a recorded classification and an Accept,
-  Reject, or inconclusive (E5, encoded `awaiting_maintainer`) decision.
-  Every Accepted item cites its "Verify before accept" evidence, or the
-  maintainer confirmation reply when actor-permission capped.
+  Reject, or inconclusive (E5) decision. Every Accepted item cites its
+  "Verify before accept" evidence, or the maintainer confirmation reply
+  when actor-permission capped.
 - Every Rejected or inconclusive PATH A item whose source is reviewer
   feedback has the required rejection or
   `**Awaiting maintainer decision**` reply posted, and any non-AMD

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -84,13 +84,14 @@ maintainer confirmation for an unprivileged PATH A actor: confirmed →
 `Accept` and act; **false on the live evidence** → disposition it
 `Rejected` and cite the contradicting evidence (the code as read, the
 real run conclusion, file contents, or artifact) — a verified-false
-claim is a reasoned rejection, not an action item; **inconclusive**
-(neither confirmed nor contradicted, because the needed check has no
-route this environment can run, not merely low confidence) → for an
-actor-permission-capped PATH A item, route it through the
-CODEOWNER/required-reviewer AMD hold (E6) instead of `Rejected`.
-`Rejected` stays reserved for a claim the live evidence actually
-contradicts.
+claim is a reasoned rejection, not an action item (scoped to this
+verification only — not E4/E5's Low-severity/no-action `Rejected`
+routes); **inconclusive** (neither confirmed nor contradicted — the
+needed check has no route here, not merely low confidence) → for an
+actor-permission-capped, reviewer-feedback PATH A item, route it
+through the CODEOWNER/required-reviewer AMD hold (E6) instead of
+`Rejected` (a critique-pass finding stays under the unchanged cap
+above).
 
 **Resolved-thread duplicate pre-check (PATH B, before verification).**
 Before verification above, check whether a new PATH B item — a review
@@ -102,9 +103,7 @@ state of its own, but can still match a prior resolved thread's claim.
 
 - Match the new item against the index by file area and substantive
   claim, requiring the identical claim rather than merely a related
-  topic in the same file. (For example, a prior "raw SQL concatenation"
-  rejection on `db/query.mts` does not match a new "missing index"
-  comment on the same file: same file area, different claim.)
+  topic in the same file (same file, different claim, is not a match).
 - On a match, open the linked prior thread — the index disposition alone
   is not proof. Re-confirm the new item raises that **same underlying
   claim**, not just a related one, then confirm the prior thread
@@ -353,9 +352,9 @@ Before leaving triage, verify every ReviewItems_snapshot item has the
 evidence required by its path:
 
 - Every PATH A item has a recorded classification and an Accept,
-  Reject, or inconclusive (E5) decision. Every Accepted item cites its
-  "Verify before accept" evidence, or the maintainer confirmation reply
-  when actor-permission capped.
+  Reject, or inconclusive (E5, encoded `awaiting_maintainer`) decision.
+  Every Accepted item cites its "Verify before accept" evidence, or the
+  maintainer confirmation reply when actor-permission capped.
 - Every Rejected or inconclusive PATH A item whose source is reviewer
   feedback has the required rejection or
   `**Awaiting maintainer decision**` reply posted, and any non-AMD

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -151,7 +151,8 @@ PATH A — Rejected reviewer feedback:
 For each Rejected or inconclusive (E5) PATH A item whose source is
 reviewer feedback:
 
-- Reply using the format: `**Rejected** — {reason}`
+- Reply using the format: `**Rejected** — {reason}` — unless the
+  Exception below applies.
 - **Exception**: if the source is a CODEOWNER or required reviewer, or
   the item is E5's inconclusive outcome, do not reject unilaterally.
   Reply using the format:


### PR DESCRIPTION
# Summary

`idd-review-triage.instructions.md`'s E5 "Verify before accept"
paragraph named only two outcomes for an actor-permission-capped PATH A
claim: confirmed (reaches `Accept`) and false on the live evidence
(reaches `Rejected`). A claim the current environment genuinely cannot
check either way -- one depending on credentials, artifacts, or
production-only behavior with no available route -- had nowhere to go
but `Rejected`, even though the same file defines `Rejected` as a
reasoned rejection backed by contradicting evidence, which by
construction does not exist for an inconclusive claim. E6's immediate
resolve would then silently drop a possibly valid, high-severity report.

This adds a third, `inconclusive` branch to "Verify before accept" for
that specific case, routing it to the existing CODEOWNER /
required-reviewer AMD hold instead of `Rejected` -- the same mechanism
#1690 already ships, reused rather than replaced. The actor-permission
cap's own text is untouched. E6's "Rejected reviewer feedback" scoping
line and its Exception trigger now also fire on this new outcome, and
the hold reply is required to name the specific unavailable check. The
immediate-resolution exception, the re-appearance path, and F2's
pre-merge AMD-thread classification are all keyed off the reply marker
text or thread state, not actor class, so they needed no changes; two
"maintainer eventually responds" bullets and E7's verification
checklist got a small wording tweak so they no longer assume every AMD
item started out labeled `Rejected`.

Also trims two worked examples in the same section to keep the
`bundle-review` context-ceiling budget (#1664/#1665) under its 98%
threshold after the addition -- the bundle had essentially zero
headroom left before this change.

## Linked issue

Closes #1933

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Field-reported from `kurone-kito/builder-config` and confirmed
byte-identical against this repository's own file at the v0.6.0 pin
(see #1933), so this is a gap in the shipped protocol rather than an
adopter-side edit. Extends #1690's shipped design rather than
reversing it: #1690's own body already describes the capped path as "a
reasoned reply (for example a Rejected disposition citing the failed
verification)" without separating a verification that failed to reach
a conclusion from one that reached a negative conclusion.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified review triage guidance for verified-false and inconclusive claims.
  * Added procedures for handling reasoned rejections, reviewer feedback, and maintainer decisions.
  * Strengthened requirements for matching resolved-thread duplicates and recording disposition outcomes.
  * Expanded verification requirements for AMD decisions and replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->