### PR TITLE
fix(rerun-advisory-convergence): let --check-name override the search

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1399,15 +1399,19 @@ to post it is the consuming track's job.
 ### Rerun-plan diagnosis (stuck advisory-convergence)
 
 - Source repo / vendored-node command:
-  `node scripts/rerun-advisory-convergence.mjs --pr <pr-number> [--apply]`
+
+  ```sh
+  node scripts/rerun-advisory-convergence.mjs --pr <pr-number> [--check-name <name>] [--apply]
+  ```
+
 - Package-manager / ephemeral-npx command: use the
   profile-selected `idd:rerun-advisory-convergence` command from the
-  helper runtime manifest wiring above, with `[--apply]` appended the
-  same way; the literal invocation is:
+  helper runtime manifest wiring above, with `[--check-name <name>]`
+  and `[--apply]` appended the same way; the literal invocation is:
 
   ```sh
   npx --yes --package <helper-package-spec> \
-    idd-rerun-advisory-convergence --pr <pr-number> [--apply]
+    idd-rerun-advisory-convergence --pr <pr-number> [--check-name <name>] [--apply]
   ```
 
 - Rerun-plan diagnosis (#1431) for a stuck `idd-advisory-convergence`
@@ -1456,6 +1460,17 @@ to post it is the consuming track's job.
   the next, and stops early once the recomputed plan is fully resolved --
   a `bot-gated-skip`, `awaiting-fresh-review`, or rerun-budget-held
   instance is never rerun
+- `--check-name <name>` (#1935) overrides the check-run name searched for
+  and reported, defaulting to `idd-advisory-convergence` when omitted
+  (byte-identical output to before this flag existed). Use it when the
+  job that produces the check has a `name:` display-name key on top of
+  an unchanged job id -- GitHub Actions then names the check-run after
+  that display name instead of the job id, so the default search
+  silently finds nothing; see the job-definition comment in
+  `.github/workflows/idd-advisory-convergence.yml` for the full warning.
+  The not-found message names whichever check-run name was actually
+  searched, so a mismatch names its own cause instead of only its
+  symptom
 
 ### Merge-gate evidence
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1399,15 +1399,19 @@ to post it is the consuming track's job.
 ### Rerun-plan diagnosis (stuck advisory-convergence)
 
 - Source repo / vendored-node command:
-  `node scripts/rerun-advisory-convergence.mjs --pr <pr-number> [--apply]`
+
+  ```sh
+  node scripts/rerun-advisory-convergence.mjs --pr <pr-number> [--check-name <name>] [--apply]
+  ```
+
 - Package-manager / ephemeral-npx command: use the
   profile-selected `idd:rerun-advisory-convergence` command from the
-  helper runtime manifest wiring above, with `[--apply]` appended the
-  same way; the literal invocation is:
+  helper runtime manifest wiring above, with `[--check-name <name>]`
+  and `[--apply]` appended the same way; the literal invocation is:
 
   ```sh
   npx --yes --package <helper-package-spec> \
-    idd-rerun-advisory-convergence --pr <pr-number> [--apply]
+    idd-rerun-advisory-convergence --pr <pr-number> [--check-name <name>] [--apply]
   ```
 
 - Rerun-plan diagnosis (#1431) for a stuck `idd-advisory-convergence`
@@ -1456,6 +1460,17 @@ to post it is the consuming track's job.
   the next, and stops early once the recomputed plan is fully resolved --
   a `bot-gated-skip`, `awaiting-fresh-review`, or rerun-budget-held
   instance is never rerun
+- `--check-name <name>` (#1935) overrides the check-run name searched for
+  and reported, defaulting to `idd-advisory-convergence` when omitted
+  (byte-identical output to before this flag existed). Use it when the
+  job that produces the check has a `name:` display-name key on top of
+  an unchanged job id -- GitHub Actions then names the check-run after
+  that display name instead of the job id, so the default search
+  silently finds nothing; see the job-definition comment in
+  `.github/workflows/idd-advisory-convergence.yml` for the full warning.
+  The not-found message names whichever check-run name was actually
+  searched, so a mismatch names its own cause instead of only its
+  symptom
 
 ### Merge-gate evidence
 

--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -996,6 +996,7 @@ export function parseArgs(argv) {
       now: { type: 'string' },
       help: { type: 'boolean', short: 'h' },
       apply: { type: 'boolean' },
+      'check-name': { type: 'string' },
     },
     strict: true,
     allowPositionals: false,
@@ -1008,6 +1009,7 @@ export function parseArgs(argv) {
       now: '',
       help: true,
       apply: false,
+      checkName: '',
     };
   }
   const owner = String(values.owner ?? '').trim();
@@ -1052,7 +1054,21 @@ export function parseArgs(argv) {
     now: String(values.now ?? '').trim(),
     help: false,
     apply: Boolean(values.apply),
+    checkName: String(values['check-name'] ?? '').trim(),
   };
+}
+/**
+ * Resolve the check-run name {@link collectFromGitHub} searches for and
+ * reports, honoring `--check-name` when given and falling back to {@link
+ * RERUN_PLAN_CHECK_NAME} otherwise (an empty/whitespace-only value is
+ * treated the same as omitted, matching every other trimmed CLI string in
+ * this file). Extracted as its own pure, directly unit-testable function so
+ * the "omitting the flag keeps output byte-identical to before this flag
+ * existed" contract has direct test coverage instead of being reachable
+ * only through `collectFromGitHub`'s real `gh` I/O (#1935).
+ */
+export function resolveCheckName(args) {
+  return args.checkName.trim() || RERUN_PLAN_CHECK_NAME;
 }
 /**
  * Describe outstanding `pending` / `bot-gated-skip` / `unresolved` /
@@ -1186,7 +1202,7 @@ export function buildRerunPlanTextSections(plan) {
 }
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/rerun-advisory-convergence.mjs --pr <number> [--owner <owner> --repo <repo>] [--now <ISO8601>] [--apply] [--help]
+  node scripts/rerun-advisory-convergence.mjs --pr <number> [--owner <owner> --repo <repo>] [--now <ISO8601>] [--check-name <name>] [--apply] [--help]
 
 By default (without --apply): read-only. Fetches every
 "${RERUN_PLAN_CHECK_NAME}" check-run instance for the PR's current HEAD SHA
@@ -1218,6 +1234,16 @@ the target state resolved is printed to stderr.
 --owner and --repo must be given together (to inspect a PR outside the
 current checkout) or omitted together (to auto-detect the current
 checkout's own repository) -- providing only one is rejected.
+
+--check-name overrides the check-run name searched for and reported
+(default: "${RERUN_PLAN_CHECK_NAME}"). Use this when the job that
+produces the check has a "name:" display-name key on top of an
+unchanged job id -- GitHub Actions then names the check-run after that
+display name instead of the job id, so the default search silently
+finds nothing (field-reported, #1935; see the job-definition comment in
+.github/workflows/idd-advisory-convergence.yml for the full warning).
+Omitting this flag keeps output byte-identical to before this flag
+existed.
 
 Honors the inspected repository's configured ciWait.rerunPolicy: when
 it is "hold", both the rerun plan and the recovery-refresh plan stay
@@ -1649,12 +1675,8 @@ function collectFromGitHub(args) {
     ],
     GH_TEXT_LOOP_TIMEOUT_OPTIONS,
   ).toLowerCase();
-  const rawCheckRuns = fetchCheckRunsForRef(
-    owner,
-    repo,
-    prHeadSha,
-    RERUN_PLAN_CHECK_NAME,
-  );
+  const checkName = resolveCheckName(args);
+  const rawCheckRuns = fetchCheckRunsForRef(owner, repo, prHeadSha, checkName);
   // Resolve each unique run id exactly once (a direct by-ID GET, never a
   // list scan -- see fetchCheckRunsForRef's doc comment for why lists are
   // avoided here).
@@ -1811,7 +1833,7 @@ function collectFromGitHub(args) {
     input: {
       prNumber: Number(args.prNumber),
       prHeadSha,
-      checkName: RERUN_PLAN_CHECK_NAME,
+      checkName,
       owner,
       repo,
       instances,

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -1249,6 +1249,15 @@ interface RerunPlanArgs {
    * via `gh run rerun` instead of only diagnosing them. See
    * {@link applyRerunPlan}. */
   apply: boolean;
+  /** Raw `--check-name` value, trimmed but NOT yet defaulted -- an empty
+   * string means the flag was omitted. Resolve via {@link
+   * resolveCheckName} before use. Exists so an adopter whose job
+   * definition carries a `name:` display-name override (changing the
+   * actual check-run name away from the job id -- see the job-definition
+   * comment in .github/workflows/idd-advisory-convergence.yml) can point
+   * this helper at the real name instead of it silently finding nothing
+   * (#1935). */
+  checkName: string;
 }
 
 /** A conservative GitHub owner/repo identifier character class --
@@ -1330,6 +1339,7 @@ export function parseArgs(argv: string[]): RerunPlanArgs {
       now: { type: 'string' },
       help: { type: 'boolean', short: 'h' },
       apply: { type: 'boolean' },
+      'check-name': { type: 'string' },
     },
     strict: true,
     allowPositionals: false,
@@ -1343,6 +1353,7 @@ export function parseArgs(argv: string[]): RerunPlanArgs {
       now: '',
       help: true,
       apply: false,
+      checkName: '',
     };
   }
 
@@ -1390,7 +1401,24 @@ export function parseArgs(argv: string[]): RerunPlanArgs {
     now: String(values.now ?? '').trim(),
     help: false,
     apply: Boolean(values.apply),
+    checkName: String(values['check-name'] ?? '').trim(),
   };
+}
+
+/**
+ * Resolve the check-run name {@link collectFromGitHub} searches for and
+ * reports, honoring `--check-name` when given and falling back to {@link
+ * RERUN_PLAN_CHECK_NAME} otherwise (an empty/whitespace-only value is
+ * treated the same as omitted, matching every other trimmed CLI string in
+ * this file). Extracted as its own pure, directly unit-testable function so
+ * the "omitting the flag keeps output byte-identical to before this flag
+ * existed" contract has direct test coverage instead of being reachable
+ * only through `collectFromGitHub`'s real `gh` I/O (#1935).
+ */
+export function resolveCheckName(
+  args: Pick<RerunPlanArgs, 'checkName'>,
+): string {
+  return args.checkName.trim() || RERUN_PLAN_CHECK_NAME;
 }
 
 /**
@@ -1537,7 +1565,7 @@ export function buildRerunPlanTextSections(
 
 function printHelp(): void {
   process.stdout.write(`Usage:
-  node scripts/rerun-advisory-convergence.mjs --pr <number> [--owner <owner> --repo <repo>] [--now <ISO8601>] [--apply] [--help]
+  node scripts/rerun-advisory-convergence.mjs --pr <number> [--owner <owner> --repo <repo>] [--now <ISO8601>] [--check-name <name>] [--apply] [--help]
 
 By default (without --apply): read-only. Fetches every
 "${RERUN_PLAN_CHECK_NAME}" check-run instance for the PR's current HEAD SHA
@@ -1569,6 +1597,16 @@ the target state resolved is printed to stderr.
 --owner and --repo must be given together (to inspect a PR outside the
 current checkout) or omitted together (to auto-detect the current
 checkout's own repository) -- providing only one is rejected.
+
+--check-name overrides the check-run name searched for and reported
+(default: "${RERUN_PLAN_CHECK_NAME}"). Use this when the job that
+produces the check has a "name:" display-name key on top of an
+unchanged job id -- GitHub Actions then names the check-run after that
+display name instead of the job id, so the default search silently
+finds nothing (field-reported, #1935; see the job-definition comment in
+.github/workflows/idd-advisory-convergence.yml for the full warning).
+Omitting this flag keeps output byte-identical to before this flag
+existed.
 
 Honors the inspected repository's configured ciWait.rerunPolicy: when
 it is "hold", both the rerun plan and the recovery-refresh plan stay
@@ -2150,12 +2188,8 @@ function collectFromGitHub(args: RerunPlanArgs): {
     GH_TEXT_LOOP_TIMEOUT_OPTIONS,
   ).toLowerCase();
 
-  const rawCheckRuns = fetchCheckRunsForRef(
-    owner,
-    repo,
-    prHeadSha,
-    RERUN_PLAN_CHECK_NAME,
-  );
+  const checkName = resolveCheckName(args);
+  const rawCheckRuns = fetchCheckRunsForRef(owner, repo, prHeadSha, checkName);
 
   // Resolve each unique run id exactly once (a direct by-ID GET, never a
   // list scan -- see fetchCheckRunsForRef's doc comment for why lists are
@@ -2331,7 +2365,7 @@ function collectFromGitHub(args: RerunPlanArgs): {
     input: {
       prNumber: Number(args.prNumber),
       prHeadSha,
-      checkName: RERUN_PLAN_CHECK_NAME,
+      checkName,
       owner,
       repo,
       instances,

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -1250,8 +1250,11 @@ interface RerunPlanArgs {
    * {@link applyRerunPlan}. */
   apply: boolean;
   /** Raw `--check-name` value, trimmed but NOT yet defaulted -- an empty
-   * string means the flag was omitted. Resolve via {@link
-   * resolveCheckName} before use. Exists so an adopter whose job
+   * string means the flag was either omitted or given a
+   * whitespace-only value (indistinguishable after trimming, and
+   * treated identically by {@link resolveCheckName}: both fall back to
+   * {@link RERUN_PLAN_CHECK_NAME}). Resolve via {@link resolveCheckName}
+   * before use. Exists so an adopter whose job
    * definition carries a `name:` display-name override (changing the
    * actual check-run name away from the job id -- see the job-definition
    * comment in .github/workflows/idd-advisory-convergence.yml) can point

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -21,6 +21,7 @@ import {
   type RerunPlanInput,
   type RerunPlanOptions,
   type RerunPlanRawInstance,
+  resolveCheckName,
   resolveCheckRunUrl,
   runRerunAdvisoryConvergence,
   sanitizeRemoteConfig,
@@ -1409,6 +1410,23 @@ test('describeNoActionState reports no instances found when the batch is empty',
   );
 });
 
+// #1935: the not-found message must name the ACTUAL check-run name that
+// was searched, not the hardcoded default -- so a `--check-name` override
+// (an adopter's job carries a `name:` display-name key) names its own
+// cause instead of only its symptom.
+test('describeNoActionState names the custom check-run name that was searched, not the default', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      checkName: 'The idd-advisory-convergence check',
+      instances: [],
+    }),
+    baseOptions(),
+  );
+  const message = describeNoActionState(plan);
+  assert.match(message, /"The idd-advisory-convergence check"/);
+  assert.doesNotMatch(message, new RegExp(`"${RERUN_PLAN_CHECK_NAME}"`));
+});
+
 test('describeNoActionState surfaces pending, bot-gated, and unresolved counts instead of claiming nothing to do', () => {
   const plan = computeRerunPlan(
     baseInput({
@@ -1960,6 +1978,7 @@ test('parseArgs parses --pr, --owner, --repo, --now', () => {
     now: NOW,
     help: false,
     apply: false,
+    checkName: '',
   });
 });
 
@@ -2029,6 +2048,48 @@ test('parseArgs recognizes --help', () => {
 test('parseArgs recognizes --apply, defaulting to false when omitted', () => {
   assert.equal(parseArgs(['--pr', '1431']).apply, false);
   assert.equal(parseArgs(['--pr', '1431', '--apply']).apply, true);
+});
+
+// --- --check-name (#1935: escape hatch for a job `name:` override) ------
+
+test('parseArgs defaults checkName to the empty string when --check-name is omitted', () => {
+  assert.equal(parseArgs(['--pr', '1431']).checkName, '');
+});
+
+test('parseArgs parses --check-name', () => {
+  const args = parseArgs([
+    '--pr',
+    '1431',
+    '--check-name',
+    'The idd-advisory-convergence check',
+  ]);
+  assert.equal(args.checkName, 'The idd-advisory-convergence check');
+});
+
+test('parseArgs trims --check-name', () => {
+  const args = parseArgs(['--pr', '1431', '--check-name', '  custom-name  ']);
+  assert.equal(args.checkName, 'custom-name');
+});
+
+test('parseArgs fails fast when --check-name has a missing value', () => {
+  assert.throws(() => parseArgs(['--pr', '1431', '--check-name']), {
+    code: 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE',
+  });
+});
+
+test('resolveCheckName falls back to RERUN_PLAN_CHECK_NAME when checkName is empty (flag omitted) -- keeps output byte-identical to before this flag existed', () => {
+  assert.equal(resolveCheckName({ checkName: '' }), RERUN_PLAN_CHECK_NAME);
+});
+
+test('resolveCheckName falls back to RERUN_PLAN_CHECK_NAME when checkName is whitespace-only', () => {
+  assert.equal(resolveCheckName({ checkName: '   ' }), RERUN_PLAN_CHECK_NAME);
+});
+
+test('resolveCheckName honors a custom checkName', () => {
+  assert.equal(
+    resolveCheckName({ checkName: 'The idd-advisory-convergence check' }),
+    'The idd-advisory-convergence check',
+  );
 });
 
 // parseArgs delegates mechanical parsing to node:util's own stable
@@ -2223,6 +2284,37 @@ test('runRerunAdvisoryConvergence returns the parsed args alongside the plan', (
   });
   assert.equal(result.args.prNumber, 1431);
   assert.equal(result.args.apply, true);
+});
+
+test('runRerunAdvisoryConvergence threads --check-name through to deps.collect', () => {
+  let receivedCheckName: string | null = null;
+  const result = runRerunAdvisoryConvergence(
+    ['--pr', '1431', '--check-name', 'The idd-advisory-convergence check'],
+    {
+      collect: (args) => {
+        receivedCheckName = args.checkName;
+        return {
+          input: baseInput({
+            checkName: args.checkName || RERUN_PLAN_CHECK_NAME,
+          }),
+          options: baseOptions(),
+        };
+      },
+    },
+  );
+  assert.equal(receivedCheckName, 'The idd-advisory-convergence check');
+  assert.equal(result.plan?.checkName, 'The idd-advisory-convergence check');
+});
+
+test('runRerunAdvisoryConvergence leaves checkName empty (default) when --check-name is omitted', () => {
+  let receivedCheckName: string | null = null;
+  runRerunAdvisoryConvergence(['--pr', '1431'], {
+    collect: (args) => {
+      receivedCheckName = args.checkName;
+      return { input: baseInput(), options: baseOptions() };
+    },
+  });
+  assert.equal(receivedCheckName, '');
 });
 
 // --- applyRerunPlan -------------------------------------------------------


### PR DESCRIPTION
# Summary

- Add a `--check-name <name>` CLI flag to
  `idd-rerun-advisory-convergence`, threaded to the existing internal
  `checkName` input and defaulting to `idd-advisory-convergence`
  (`RERUN_PLAN_CHECK_NAME`) so omitting the flag keeps output
  byte-identical to today.
- Extract `resolveCheckName` as a small, directly unit-testable pure
  function that resolves `--check-name` (trimmed) against the default.
- The not-found diagnostic already names `plan.checkName`, so it now
  correctly reports whichever check-run name was actually searched
  once the flag is used, instead of only the hardcoded default.
- Document the new flag in `idd-template/docs/idd-helper-scripts.md`
  (canonical source), synced to `docs/idd-helper-scripts.md` via
  `node scripts/sync-docs.mjs --apply`.

## Linked issue

Closes #1935

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

GitHub Actions names a check-run after the job's `name:` field when one
is present, falling back to the job id only when it is absent. An
adopter who keeps the upstream job id but adds a display-name override
to match a local CI naming convention silently breaks
`idd-rerun-advisory-convergence`'s hardcoded search for the literal
`idd-advisory-convergence` check-run name (field-reported from
`kurone-kito/builder-config`). There was previously no way to point the
helper at the real name short of editing the workflow.

The dogfood and template workflow job-definition comments already warn
against a `name:` override (#1855, merged before this issue was filed)
— that half of the original issue is already closed on `main`. This PR
closes the remaining "no escape hatch" half: the CLI flag itself.

Resolving the expected name from the workflow definition at call time
was explicitly out of scope per the issue (would add a
workflow-parsing dependency); the flag plus the corrected not-found
message covers the observed failure without it.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`pnpm run lint:minimum`)
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (ran `sync-docs.mjs --apply` and
      committed the synced `docs/idd-helper-scripts.md`)
- [x] `node scripts/idd-doctor.mjs` (pre-existing warnings only, none
      related to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
