### PR TITLE
docs(discover): codify A2 traversal termination and provenance rules

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -283,6 +283,19 @@ authorizes an alternate scope for the current run:
   unresolvable with the reason, skip that branch, and continue
   traversal. Not an enumeration failure.
 
+**Termination.** Do not re-expand a target already on the current
+traversal path; record the back-edge as a cycle with its path and
+continue with the next reference.
+
+**Single visit.** A node is identified by issue number; a node
+reached again through another path is the same node — collect it
+once, never enter it into the candidate set twice.
+
+**Provenance.** Keep and report every distinct path that reaches a
+node, not only the first — the same rule the cross-roadmap union
+below already applies to a leaf reachable from several roadmap
+roots.
+
 **Helper read timing.** The `discover-roadmap-graph` helper (see
 [IDD helper script evaluation](../../docs/idd-helper-scripts.md)) is
 long-running on large graphs, emitting the whole graph in one final
@@ -290,9 +303,9 @@ stdout write. Redirect stdout to a file and wait for process exit before
 parsing — a zero-byte or mid-run read is **"still running," not** an A2
 enumeration failure.
 
-Report every A2 execution candidate with its provenance path (e.g.
-`#222 → #228 → #257`), any open roadmap nodes, and unresolvable
-references before passing to A3.
+Report every A2 execution candidate with its provenance paths (e.g.
+`#222 → #228 → #257`), any open roadmap nodes, cycles, duplicate
+references, and unresolvable references before passing to A3.
 
 **Autopilot cross-roadmap union (optional, additive).** When A1 elected
 the cross-roadmap mode, enumerate from **each** open roadmap root and

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -285,6 +285,19 @@ authorizes an alternate scope for the current run:
   unresolvable with the reason, skip that branch, and continue
   traversal. Not an enumeration failure.
 
+**Termination.** Do not re-expand a target already on the current
+traversal path; record the back-edge as a cycle with its path and
+continue with the next reference.
+
+**Single visit.** A node is identified by issue number; a node
+reached again through another path is the same node — collect it
+once, never enter it into the candidate set twice.
+
+**Provenance.** Keep and report every distinct path that reaches a
+node, not only the first — the same rule the cross-roadmap union
+below already applies to a leaf reachable from several roadmap
+roots.
+
 **Helper read timing.** The `discover-roadmap-graph` helper (see
 [IDD helper script evaluation](../../docs/idd-helper-scripts.md)) is
 long-running on large graphs, emitting the whole graph in one final
@@ -292,9 +305,9 @@ stdout write. Redirect stdout to a file and wait for process exit before
 parsing — a zero-byte or mid-run read is **"still running," not** an A2
 enumeration failure.
 
-Report every A2 execution candidate with its provenance path (e.g.
-`#222 → #228 → #257`), any open roadmap nodes, and unresolvable
-references before passing to A3.
+Report every A2 execution candidate with its provenance paths (e.g.
+`#222 → #228 → #257`), any open roadmap nodes, cycles, duplicate
+references, and unresolvable references before passing to A3.
 
 **Autopilot cross-roadmap union (optional, additive).** When A1 elected
 the cross-roadmap mode, enumerate from **each** open roadmap root and


### PR DESCRIPTION
## Summary

Discover A2 told the agent to "recursively collect all issues it
references" but never said when to stop re-expanding a reference,
whether an issue reached twice is one candidate or two, or what to
record when the graph folds back on itself. The `discover-roadmap-graph`
helper already implements all three behaviors; this PR writes them down
as instructions so a run without helper support has something equivalent
to follow.

Adds three rules to the A2 section of both `idd-discover.instructions.md`
copies:

- **Termination** — do not re-expand a target already on the current
  traversal path; record the back-edge as a cycle with its path.
- **Single visit** — a node is identified by issue number; collect it
  once even when reached via multiple paths.
- **Provenance** — keep and report every distinct path that reaches a
  node (plural), matching the rule the cross-roadmap union already
  applies to a leaf reachable from several roots.

Also updates the existing A2 report sentence in place (report contract,
the fourth rule) to list cycles and duplicate references alongside
execution candidates, open roadmap nodes, and unresolvable references,
and to refer to provenance paths in the plural.

No runtime behavior changes — pure documentation, matching what the
helper already does.

Closes #1920

## Verification

- `pnpm run typecheck`, `biome check`, `dprint check "**/*.md"`,
  `markdownlint-cli2 "**/*.md"`, `cspell lint "**"` — all clean.
- `node --test tests/*.test.mts` — 3392/3392 passing, including the
  `instruction-size-budgets` cases in `tests/consistency.test.mts`.
- `node scripts/audit-docs.mjs --check` — passed (only pre-existing
  context-ceiling notices, unaffected by this change).
- `node scripts/audit-code-span-wrap.mjs` — no mid-token wraps.
- `node scripts/idd-doctor.mjs` — passed with only pre-existing,
  environment-specific warnings.
- Byte budget: `.github/instructions/idd-discover.instructions.md` is
  31,549 bytes and the `idd-template` copy is 31,894 bytes, both under
  the 33,000-byte `phaseLimitBytes` cap.
- No file under `src/`, `scripts/`, or `bin/` changes.

**Known pre-existing, unrelated environment artifact**: this worktree
(like the primary worktree, present before this session started) shows
a file-mode-only diff on ~32 `bin/*.mjs` files (100644 → 100755, zero
content change) that trips `pnpm run build:check`'s
`git diff HEAD --exit-code -- scripts bin .gitattributes` step. This PR
does not touch `scripts/` or `bin/`, and the diff is confirmed mode-only
with no content lines. Not staged or committed here.

## Test plan

- [x] `pnpm run typecheck`
- [x] `biome check`
- [x] `dprint check "**/*.md"`
- [x] `markdownlint-cli2 "**/*.md"`
- [x] `cspell lint "**" --no-progress`
- [x] `node --test tests/*.test.mts`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `node scripts/idd-doctor.mjs`
