### PR TITLE
fix(roadmap-audit): don't block A1.5 on closed-descendant cycles

### DIFF
--- a/.github/instructions/idd-roadmap-audit.instructions.md
+++ b/.github/instructions/idd-roadmap-audit.instructions.md
@@ -87,7 +87,16 @@ outside the selected roadmap graph.
   inside the recursive roadmap graph, preserve that evidence and treat
   the affected path as unresolved until the graph can be interpreted
   safely. Do not guess at a closure order when the traversal graph is
-  ambiguous.
+  ambiguous. **Root-preserving exemption for cycles only** (duplicate
+  references are unaffected): define the cycle's **segment** as the
+  suffix of the recorded path starting at the first occurrence of the
+  back-edge target. When the segment excludes the roadmap under audit
+  AND every node in it is CLOSED, treat the cycle as informational
+  provenance instead of a blocker, regardless of relationship type —
+  such a loop has no closure order left to get wrong. A cycle whose
+  segment includes the audited roadmap, or holds any node that is open,
+  inaccessible, unresolved, or absent from the traversal's node set,
+  still blocks.
 - If all referenced child and descendant work is closed or otherwise
   complete, compare the roadmap success criteria against the closed
   child issues, linked merged PRs, task-list state, follow-up comments,

--- a/idd-template/.github/instructions/idd-roadmap-audit.instructions.md
+++ b/idd-template/.github/instructions/idd-roadmap-audit.instructions.md
@@ -82,7 +82,16 @@ outside the selected roadmap graph.
   inside the recursive roadmap graph, preserve that evidence and treat
   the affected path as unresolved until the graph can be interpreted
   safely. Do not guess at a closure order when the traversal graph is
-  ambiguous.
+  ambiguous. **Root-preserving exemption for cycles only** (duplicate
+  references are unaffected): define the cycle's **segment** as the
+  suffix of the recorded path starting at the first occurrence of the
+  back-edge target. When the segment excludes the roadmap under audit
+  AND every node in it is CLOSED, treat the cycle as informational
+  provenance instead of a blocker, regardless of relationship type —
+  such a loop has no closure order left to get wrong. A cycle whose
+  segment includes the audited roadmap, or holds any node that is open,
+  inaccessible, unresolved, or absent from the traversal's node set,
+  still blocks.
 - If all referenced child and descendant work is closed or otherwise
   complete, compare the roadmap success criteria against the closed
   child issues, linked merged PRs, task-list state, follow-up comments,

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -61,11 +61,15 @@ function roadmapAuditBranchPattern(roadmapNumber) {
  * roadmap descendant, every traversal cycle, a blocked roadmap root, and a
  * childless/malformed roadmap is collected as a blocker; `ready` is true only
  * when no blocker is collected. The rules mirror the written A1.5 completion
- * criteria exactly — this helper adds no stricter sub-condition. One shape is
- * interpreted as safe rather than ambiguous (#1278): a `reference` back-edge
- * from a non-roadmap execution leaf is the provenance breadcrumb the A1.5
- * follow-up rule itself requires, so it never blocks as a cycle (an open
- * leaf still blocks as `open-child`). Pure and
+ * criteria exactly — this helper adds no stricter sub-condition. Two cycle
+ * shapes are interpreted as safe rather than ambiguous: a `reference`
+ * back-edge from a non-roadmap execution leaf (#1278) is the provenance
+ * breadcrumb the A1.5 follow-up rule itself requires, so it never blocks as
+ * a cycle (an open leaf still blocks as `open-child`); and, regardless of
+ * relationship type, a cycle whose **segment** (the suffix of the recorded
+ * path starting at the first occurrence of the back-edge target) never
+ * touches the audited roadmap and is entirely CLOSED (#1919) — such a loop
+ * has no closure order left to get wrong. Pure and
  * network-free so it is unit-testable apart from live GitHub.
  */
 export function evaluateRoadmapAuditGates(report, options = {}) {
@@ -185,23 +189,34 @@ export function evaluateRoadmapAuditGates(report, options = {}) {
       detail: `reference #${diagnostic.source} → #${diagnostic.target} (${diagnostic.relationship}) is inaccessible: ${diagnostic.reason}`,
     });
   }
-  // Cycles / ambiguous graph: do not guess a closure order. A `reference`
-  // back-edge whose source is a non-roadmap execution leaf is exempt (#1278):
-  // a closed leaf's `Refs #<roadmap>` breadcrumb is the provenance the A1.5
-  // follow-up rule requires, and an open leaf is already blocked above as
-  // `open-child`, so the audit still fails closed while reporting the true
-  // cause. Roadmap-source cycles, unknown-source cycles, stronger
-  // relationships (task-list / dependency / closing-keyword / sub-issue),
-  // and execution sources in any other state keep blocking.
+  // Cycles / ambiguous graph: do not guess a closure order. Two exemptions
+  // keep a genuinely-resolved cycle from blocking; every other cycle keeps
+  // blocking (fail closed):
+  //
+  //  - (#1278) A `reference` back-edge whose source is a non-roadmap
+  //    execution leaf is exempt: a closed leaf's `Refs #<roadmap>`
+  //    breadcrumb is the provenance the A1.5 follow-up rule requires, and an
+  //    open leaf is already blocked above as `open-child`, so the audit
+  //    still fails closed while reporting the true cause. This exemption is
+  //    also applied earlier, at the traversal level (`discover-roadmap-graph`
+  //    never even records the CLOSED-source case as a cycle), so only the
+  //    OPEN-source dedup case actually reaches this branch in practice.
+  //  - (#1919) Any cycle, of any relationship type, whose **segment** (see
+  //    `isResolvedCycleSegment`) excludes the audited roadmap and is
+  //    entirely CLOSED: such a loop has no closure order left to get wrong,
+  //    so it is recorded as informational provenance instead of a blocker.
   const openExecutionLeaves = new Set(report.executionCandidates);
   for (const cycle of report.diagnostics.cycles) {
     const sourceNode = report.nodes.find(
       (entry) => entry.number === cycle.source,
     );
-    if (
+    const isProvenanceBreadcrumb =
       cycle.relationship === 'reference' &&
       sourceNode?.classification === 'execution' &&
-      (sourceNode.state === 'CLOSED' || openExecutionLeaves.has(cycle.source))
+      (sourceNode.state === 'CLOSED' || openExecutionLeaves.has(cycle.source));
+    if (
+      isProvenanceBreadcrumb ||
+      isResolvedCycleSegment(cycle, report, rootNumber)
     ) {
       continue;
     }
@@ -213,6 +228,40 @@ export function evaluateRoadmapAuditGates(report, options = {}) {
     });
   }
   return blockers;
+}
+/**
+ * The **cycle segment** (#1919): the suffix of a recorded cycle path
+ * starting at the first occurrence of the back-edge target. For the
+ * recorded path `1904 -> 1905 -> 1564 -> 1563 -> 1564` the segment is
+ * `1564 -> 1563 -> 1564` — the actual closed loop, excluding the acyclic
+ * prefix that merely reached it. `cycle.target` is always present in
+ * `cycle.path` (the traversal appends it as the path's last element), so the
+ * fallback to the full path never fires in practice; it exists only so this
+ * helper stays total for a malformed/hand-built diagnostic.
+ */
+function cycleSegment(cycle) {
+  const firstIndex = cycle.path.indexOf(cycle.target);
+  return firstIndex === -1 ? cycle.path : cycle.path.slice(firstIndex);
+}
+/**
+ * True when a cycle's segment (see {@link cycleSegment}) never touches the
+ * audited roadmap AND every node in it is CLOSED (#1919). A node absent from
+ * `report.nodes`, or carrying any state other than `CLOSED` (including
+ * `OPEN`), fails the all-CLOSED check — fail closed. Such a cycle has no
+ * closure order left to get wrong: every member issue is already closed and
+ * the loop never passes through the roadmap under audit, so it is
+ * informational provenance rather than a blocker.
+ */
+function isResolvedCycleSegment(cycle, report, rootNumber) {
+  const segment = cycleSegment(cycle);
+  if (segment.includes(rootNumber)) {
+    return false;
+  }
+  return segment.every(
+    (segmentNumber) =>
+      report.nodes.find((entry) => entry.number === segmentNumber)?.state ===
+      'CLOSED',
+  );
 }
 /** First (sorted) root→target provenance path, or `[]` when none is recorded. */
 function buildProvenanceLookup(report) {

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -24,6 +24,7 @@ import {
   enumerateRoadmapGraph,
   isClaimStaleByAge,
   parseClaimStaleAgeMs,
+  type RoadmapCycleDiagnostic,
   type RoadmapGraphReport,
 } from './discover-roadmap-graph.mts';
 import { GH_TEXT_LOOP_OPTIONS, ghText } from './gh-exec.mts';
@@ -149,11 +150,15 @@ interface RoadmapAuditExecuteArgs {
  * roadmap descendant, every traversal cycle, a blocked roadmap root, and a
  * childless/malformed roadmap is collected as a blocker; `ready` is true only
  * when no blocker is collected. The rules mirror the written A1.5 completion
- * criteria exactly — this helper adds no stricter sub-condition. One shape is
- * interpreted as safe rather than ambiguous (#1278): a `reference` back-edge
- * from a non-roadmap execution leaf is the provenance breadcrumb the A1.5
- * follow-up rule itself requires, so it never blocks as a cycle (an open
- * leaf still blocks as `open-child`). Pure and
+ * criteria exactly — this helper adds no stricter sub-condition. Two cycle
+ * shapes are interpreted as safe rather than ambiguous: a `reference`
+ * back-edge from a non-roadmap execution leaf (#1278) is the provenance
+ * breadcrumb the A1.5 follow-up rule itself requires, so it never blocks as
+ * a cycle (an open leaf still blocks as `open-child`); and, regardless of
+ * relationship type, a cycle whose **segment** (the suffix of the recorded
+ * path starting at the first occurrence of the back-edge target) never
+ * touches the audited roadmap and is entirely CLOSED (#1919) — such a loop
+ * has no closure order left to get wrong. Pure and
  * network-free so it is unit-testable apart from live GitHub.
  */
 export function evaluateRoadmapAuditGates(
@@ -288,23 +293,34 @@ export function evaluateRoadmapAuditGates(
     });
   }
 
-  // Cycles / ambiguous graph: do not guess a closure order. A `reference`
-  // back-edge whose source is a non-roadmap execution leaf is exempt (#1278):
-  // a closed leaf's `Refs #<roadmap>` breadcrumb is the provenance the A1.5
-  // follow-up rule requires, and an open leaf is already blocked above as
-  // `open-child`, so the audit still fails closed while reporting the true
-  // cause. Roadmap-source cycles, unknown-source cycles, stronger
-  // relationships (task-list / dependency / closing-keyword / sub-issue),
-  // and execution sources in any other state keep blocking.
+  // Cycles / ambiguous graph: do not guess a closure order. Two exemptions
+  // keep a genuinely-resolved cycle from blocking; every other cycle keeps
+  // blocking (fail closed):
+  //
+  //  - (#1278) A `reference` back-edge whose source is a non-roadmap
+  //    execution leaf is exempt: a closed leaf's `Refs #<roadmap>`
+  //    breadcrumb is the provenance the A1.5 follow-up rule requires, and an
+  //    open leaf is already blocked above as `open-child`, so the audit
+  //    still fails closed while reporting the true cause. This exemption is
+  //    also applied earlier, at the traversal level (`discover-roadmap-graph`
+  //    never even records the CLOSED-source case as a cycle), so only the
+  //    OPEN-source dedup case actually reaches this branch in practice.
+  //  - (#1919) Any cycle, of any relationship type, whose **segment** (see
+  //    `isResolvedCycleSegment`) excludes the audited roadmap and is
+  //    entirely CLOSED: such a loop has no closure order left to get wrong,
+  //    so it is recorded as informational provenance instead of a blocker.
   const openExecutionLeaves = new Set(report.executionCandidates);
   for (const cycle of report.diagnostics.cycles) {
     const sourceNode = report.nodes.find(
       (entry) => entry.number === cycle.source,
     );
-    if (
+    const isProvenanceBreadcrumb =
       cycle.relationship === 'reference' &&
       sourceNode?.classification === 'execution' &&
-      (sourceNode.state === 'CLOSED' || openExecutionLeaves.has(cycle.source))
+      (sourceNode.state === 'CLOSED' || openExecutionLeaves.has(cycle.source));
+    if (
+      isProvenanceBreadcrumb ||
+      isResolvedCycleSegment(cycle, report, rootNumber)
     ) {
       continue;
     }
@@ -317,6 +333,46 @@ export function evaluateRoadmapAuditGates(
   }
 
   return blockers;
+}
+
+/**
+ * The **cycle segment** (#1919): the suffix of a recorded cycle path
+ * starting at the first occurrence of the back-edge target. For the
+ * recorded path `1904 -> 1905 -> 1564 -> 1563 -> 1564` the segment is
+ * `1564 -> 1563 -> 1564` — the actual closed loop, excluding the acyclic
+ * prefix that merely reached it. `cycle.target` is always present in
+ * `cycle.path` (the traversal appends it as the path's last element), so the
+ * fallback to the full path never fires in practice; it exists only so this
+ * helper stays total for a malformed/hand-built diagnostic.
+ */
+function cycleSegment(cycle: RoadmapCycleDiagnostic): number[] {
+  const firstIndex = cycle.path.indexOf(cycle.target);
+  return firstIndex === -1 ? cycle.path : cycle.path.slice(firstIndex);
+}
+
+/**
+ * True when a cycle's segment (see {@link cycleSegment}) never touches the
+ * audited roadmap AND every node in it is CLOSED (#1919). A node absent from
+ * `report.nodes`, or carrying any state other than `CLOSED` (including
+ * `OPEN`), fails the all-CLOSED check — fail closed. Such a cycle has no
+ * closure order left to get wrong: every member issue is already closed and
+ * the loop never passes through the roadmap under audit, so it is
+ * informational provenance rather than a blocker.
+ */
+function isResolvedCycleSegment(
+  cycle: RoadmapCycleDiagnostic,
+  report: RoadmapGraphReport,
+  rootNumber: number,
+): boolean {
+  const segment = cycleSegment(cycle);
+  if (segment.includes(rootNumber)) {
+    return false;
+  }
+  return segment.every(
+    (segmentNumber) =>
+      report.nodes.find((entry) => entry.number === segmentNumber)?.state ===
+      'CLOSED',
+  );
 }
 
 /** First (sorted) root→target provenance path, or `[]` when none is recorded. */

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -707,6 +707,116 @@ test('an unknown-source reference cycle still blocks (fail closed) (#1278)', () 
   );
 });
 
+// ---------------------------------------------------------------------------
+// #1919 — root-preserving exemption for cycles among fully-closed descendants
+// ---------------------------------------------------------------------------
+
+test('a cycle whose segment excludes the audited roadmap and is entirely CLOSED is not a blocker: dry-run is ready (#1919)', async () => {
+  // Mirrors the reported #1904 shape: a `dependency` back-edge (not
+  // `reference`, so #1278's own exemption never applies) between two CLOSED
+  // descendants that never routes back through the audited roadmap.
+  const issues = new Map<number, unknown>([
+    [ROADMAP, rawRoadmapIssue(ROADMAP, '- [x] #1300')],
+    [
+      1300,
+      rawExecutionIssue(1300, 'Follow-up work.\n\nBlocked by #1301', 'closed'),
+    ],
+    [
+      1301,
+      rawExecutionIssue(1301, 'Follow-up work.\n\nBlocked by #1300', 'closed'),
+    ],
+  ]);
+  const graph = await enumerateRoadmapGraph(ROADMAP, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+  assert.deepEqual(
+    graph.diagnostics.cycles.map((cycle) => cycle.relationship),
+    ['dependency'],
+  );
+  const { deps, calls } = makeDeps(graph);
+  const { verdict, exitCode } = await runRoadmapAuditExecute(
+    ['--roadmap', String(ROADMAP)],
+    deps,
+  );
+
+  assert.equal(verdict.ready, true);
+  assert.deepEqual(verdict.blockers, []);
+  assert.equal(exitCode, 0);
+  assert.deepEqual(calls.closed, []);
+});
+
+test('a cycle blocks when its segment contains the audited roadmap, regardless of relationship type (#1919)', () => {
+  const report = readyReport();
+  report.nodes.push(
+    node({ number: 1560, state: 'CLOSED' }),
+    node({ number: 1561, state: 'CLOSED' }),
+  );
+  // `task-list` (not `reference`), and the roadmap sits mid-segment rather
+  // than at an endpoint -- the segment-inclusion check must scan the whole
+  // segment, not just its first/last element.
+  report.diagnostics.cycles = [
+    {
+      source: 1561,
+      target: 1560,
+      relationship: 'task-list',
+      path: [1560, ROADMAP, 1561, 1560],
+    },
+  ];
+  const blockers = evaluateRoadmapAuditGates(report);
+
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.kind),
+    ['cycle'],
+  );
+});
+
+test('a cycle blocks when any segment node is OPEN, even though it excludes the audited roadmap (#1919)', () => {
+  const report = readyReport();
+  report.nodes.push(
+    node({ number: 1563, state: 'OPEN' }),
+    node({ number: 1564, state: 'CLOSED' }),
+  );
+  report.diagnostics.cycles = [
+    {
+      source: 1563,
+      target: 1564,
+      relationship: 'dependency',
+      path: [ROADMAP, 1564, 1563, 1564],
+    },
+  ];
+  const blockers = evaluateRoadmapAuditGates(report);
+
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.kind),
+    ['cycle'],
+  );
+});
+
+test('a cycle blocks when a segment node is absent from the report, even though it excludes the audited roadmap (#1919)', () => {
+  const report = readyReport();
+  report.nodes.push(
+    node({ number: 1563, state: 'CLOSED' }),
+    node({ number: 1564, state: 'CLOSED' }),
+  );
+  // 9999 is deliberately absent from `report.nodes`: a mid-segment node that
+  // is neither the cycle's source nor its target still fails the all-CLOSED
+  // check (fail closed on an unresolvable state).
+  report.diagnostics.cycles = [
+    {
+      source: 1563,
+      target: 1564,
+      relationship: 'dependency',
+      path: [ROADMAP, 1564, 9999, 1563, 1564],
+    },
+  ];
+  const blockers = evaluateRoadmapAuditGates(report);
+
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.kind),
+    ['cycle'],
+  );
+});
+
 test('a childless roadmap (no edges) is reported, never closed', () => {
   const report = readyReport();
   report.nodes = [


### PR DESCRIPTION
# Summary

`evaluateRoadmapAuditGates()` (A1.5 roadmap-completion audit) fails a
roadmap on any recorded traversal cycle, even one that never passes
through the audited roadmap and whose every member issue is already
closed. Reproduced on the already-closed roadmap #1904, which reports
18 `cycle` blockers despite every descendant being CLOSED and both
tracks merged.

Adds a root-preserving exemption: define a cycle's **segment** as the
suffix of its recorded path starting at the first occurrence of the
back-edge target. A cycle now raises a blocker only when its segment
includes the audited roadmap, or holds any node that is not CLOSED
(open, inaccessible, unresolved, or absent from the graph). A cycle
whose segment excludes the roadmap and is entirely CLOSED has no
closure order left to get wrong, so it is recorded as informational
provenance instead of a blocker — regardless of relationship type.

This is additive to the existing #1278 `reference`-edge exemption
(kept unchanged for its OPEN-leaf dedup case): #1278 only covered
`reference`-relationship back-edges from a closed execution leaf;
this issue's fix covers any relationship type (task-list, dependency,
etc.) whenever the segment itself excludes the root and is fully
closed.

## Linked issue

Closes #1919

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`src/scripts/discover-roadmap-graph.mts`'s own traversal-level
exemption (the narrower #1278 rule) is unchanged, so
`tests/discover-roadmap-graph.test.mts` passes unmodified per the
issue's acceptance criteria. The new rule lives entirely in
`evaluateRoadmapAuditGates` (`src/scripts/idd-roadmap-audit-execute.mts`),
which consumes `report.diagnostics.cycles` after that traversal-level
filtering already ran.

`idd-roadmap-audit.instructions.md` (canonical `idd-template/` source
+ synced repository copy) now states the same narrowed condition,
scoped to cycles only — duplicate-reference handling is untouched and
stays fail-closed.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`lint:minimum`; `build:check`'s `bin/*.mjs` diff is
      the pre-existing, unrelated local mode-only artifact
      (100644→100755) present on a clean checkout of this environment
      — no `bin/` file has a content change in this PR)
- [x] `pnpm test` (3396/3396 passing, including 4 new cycle-segment
      tests and the full existing `#1278` / `discover-roadmap-graph`
      suites unchanged)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (`node scripts/sync-docs.mjs --apply`
      run; `.github/instructions/idd-roadmap-audit.instructions.md`
      regenerated from the canonical template copy)
- [x] `node scripts/idd-doctor.mjs` (passed: 3 pre-existing
      environment warnings unrelated to this change — missing
      non-default profile READMEs, local `core.hooksPath`, unreadable
      branch protection from this token)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — this only narrows an A1.5
      mechanical helper's cycle-blocker evaluation)
- [x] Context budget impact reviewed (`idd-roadmap-audit.instructions.md`
      is not a member of `bundle-review` / `bundle-merge`; ~628 byte
      delta per copy)
