### PR TITLE
fix(ci): set GH_ENTERPRISE_TOKEN alongside GH_TOKEN for GHES gh auth

### DIFF
--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -296,6 +296,11 @@ jobs:
       - name: Run advisory-convergence verdict (--assert)
         env:
           GH_TOKEN: ${{ github.token }}
+          # gh reads whichever of these two matches its resolved host
+          # (`gh help environment`), so setting both is inert on
+          # github.com and lets this same step authenticate on a
+          # self-hosted GHES host too.
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
           # workflow_dispatch's `pr_number` input is `type: number` in the
           # UI, but that constraint is not strictly enforced for direct API
           # dispatches, so route it through env: and reference it as a

--- a/.github/workflows/idd-doctor.yml
+++ b/.github/workflows/idd-doctor.yml
@@ -67,4 +67,9 @@ jobs:
       - name: Run idd-doctor repository-health check
         env:
           GH_TOKEN: ${{ github.token }}
+          # gh reads whichever of these two matches its resolved host
+          # (`gh help environment`), so setting both is inert on
+          # github.com and lets this same step authenticate on a
+          # self-hosted GHES host too.
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
         run: node scripts/idd-doctor.mjs

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -93,6 +93,11 @@ jobs:
           node-version: 24.x
       - env:
           GH_TOKEN: ${{ github.token }}
+          # gh reads whichever of these two matches its resolved host
+          # (`gh help environment`), so setting both is inert on
+          # github.com and lets this same step authenticate on a
+          # self-hosted GHES host too.
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
           # workflow_dispatch's `pr_number` input is `type: number` in the
           # UI, but that constraint is not strictly enforced for direct API
           # dispatches, so route it through env: and reference it as a

--- a/idd-template/.github/workflows/post-merge-cleanup.yml
+++ b/idd-template/.github/workflows/post-merge-cleanup.yml
@@ -177,6 +177,11 @@ jobs:
         if: steps.profile.outputs.profile != 'instructions-only'
         env:
           GH_TOKEN: ${{ github.token }}
+          # gh reads whichever of these two matches its resolved host
+          # (`gh help environment`), so setting both is inert on
+          # github.com and lets this same step authenticate on a
+          # self-hosted GHES host too.
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
           # workflow_dispatch's `pr_number` input is `type: number` in the
           # UI, but that constraint is not strictly enforced for direct API
           # dispatches, so route it through env: and reference it as a
@@ -268,6 +273,11 @@ jobs:
         if: steps.profile.outputs.profile != 'instructions-only'
         env:
           GH_TOKEN: ${{ github.token }}
+          # gh reads whichever of these two matches its resolved host
+          # (`gh help environment`), so setting both is inert on
+          # github.com and lets this same step authenticate on a
+          # self-hosted GHES host too.
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.cleanup.outputs.pr_number }}
           STATUS: ${{ steps.cleanup.outputs.status }}
           APPLIED: ${{ steps.cleanup.outputs.applied }}

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1086,6 +1086,19 @@ examples onto a GHES-hosted repository, keep both lines rather than
 deleting `GH_ENTERPRISE_TOKEN` as apparently redundant (preventive; no
 observed incident yet).
 
+**Setting the token alone is not sufficient on GHES.** The
+`idd-doctor`/`idd-advisory-convergence` helpers call `gh api` directly,
+and `gh api` resolves its target host from `GH_HOST`/`--hostname` (or
+the CLI's configured default), not from the checked-out repository's
+Git remote the way `gh pr view`/`gh issue edit` do — so on a
+GHES-hosted repository, an unset `GH_HOST` still sends these `gh api`
+calls to `api.github.com` using `GH_TOKEN`, and `GH_ENTERPRISE_TOKEN`
+is never read at all (observed 2026-08-11, a Codex advisory review on
+[kurone-kito/idd-skill#1959](https://github.com/kurone-kito/idd-skill/pull/1959)).
+Resolving the correct host for these calls needs its own design — see
+kurone-kito/idd-skill#1962 — so a GHES adopter should treat the two
+examples above as necessary but not yet sufficient until that lands.
+
 This gate checks repository **health**, not the disposable-worktree rule:
 CI cannot detect a primary-worktree B1 violation (it leaves no trace in
 pushed history and CI checks out a detached HEAD), so worktree

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -991,6 +991,7 @@ jobs:
       - run: node scripts/idd-doctor.mjs
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
 ```
 
 **`package-manager`** — the helper ships as an installed
@@ -1024,6 +1025,7 @@ jobs:
       - run: pnpm exec idd-doctor
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
 ```
 
 **`ephemeral-npx`** — no helper files or `devDependency` are vendored;
@@ -1054,6 +1056,7 @@ jobs:
       - run: npx --yes --package <reviewed-helper-spec> idd-doctor
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
 ```
 
 Both the extra `permissions:` scopes and `GH_TOKEN` are required:
@@ -1067,6 +1070,18 @@ silently skipped. The branch-protection probe stays unreadable
 regardless: it needs a repository-administration permission that
 GitHub Actions' `permissions:` model can't grant to `GITHUB_TOKEN`, so
 it keeps warning even with these scopes added.
+
+**Setting `GH_TOKEN` and `GH_ENTERPRISE_TOKEN` together.** `gh`'s
+environment-variable auth resolution is host-scoped (`gh help
+environment`): `GH_TOKEN`/`GITHUB_TOKEN` apply only when a command
+targets `github.com` or a `ghe.com` subdomain, while a self-hosted
+GitHub Enterprise Server (GHES) host reads
+`GH_ENTERPRISE_TOKEN`/`GITHUB_ENTERPRISE_TOKEN` instead. `gh` only
+reads the variable that matches its resolved host, so the three
+examples above set both — harmless on `github.com` and additive on
+GHES — instead of branching per host. If you copy one of these
+examples onto a GHES-hosted repository, keep both lines rather than
+deleting `GH_ENTERPRISE_TOKEN` as apparently redundant.
 
 This gate checks repository **health**, not the disposable-worktree rule:
 CI cannot detect a primary-worktree B1 violation (it leaves no trace in

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1059,11 +1059,13 @@ jobs:
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
 ```
 
-Both the extra `permissions:` scopes and `GH_TOKEN` are required:
-without `GH_TOKEN`, `gh` has no credential, so idd-doctor's
-GitHub-API-backed checks silently skip or emit one generic warning,
-yet the job still reports success — a green gate that checked less
-than it appears to (observed on this repository's own workflow,
+Both the extra `permissions:` scopes and a host-matching token are
+required: without the correct host-scoped token (`GH_TOKEN` on
+`github.com`/`ghe.com`; `GH_ENTERPRISE_TOKEN` on GHES — see below),
+`gh` has no credential, so idd-doctor's GitHub-API-backed checks
+silently skip or emit one generic warning, yet the job still reports
+success — a green gate that checked less than it appears to (observed
+on this repository's own workflow,
 kurone-kito/idd-skill#1828). With them, the post-merge cleanup backlog
 and autopilot-suitability checks actually run instead of being
 silently skipped. The branch-protection probe stays unreadable
@@ -1081,7 +1083,8 @@ reads the variable that matches its resolved host, so the three
 examples above set both — harmless on `github.com` and additive on
 GHES — instead of branching per host. If you copy one of these
 examples onto a GHES-hosted repository, keep both lines rather than
-deleting `GH_ENTERPRISE_TOKEN` as apparently redundant.
+deleting `GH_ENTERPRISE_TOKEN` as apparently redundant (preventive; no
+observed incident yet).
 
 This gate checks repository **health**, not the disposable-worktree rule:
 CI cannot detect a primary-worktree B1 violation (it leaves no trace in


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`gh`'s environment-variable auth resolution is host-scoped (`gh help
environment`): `GH_TOKEN`/`GITHUB_TOKEN` apply only when a command
targets `github.com` or a `ghe.com` subdomain, while a self-hosted
GitHub Enterprise Server (GHES) host reads
`GH_ENTERPRISE_TOKEN`/`GITHUB_ENTERPRISE_TOKEN` instead. Every workflow
in this repository and its distributed template that authenticates
`gh` inside a step previously set only `GH_TOKEN`, so `gh` stayed
unauthenticated on GHES despite the token being present.

This PR sets `GH_ENTERPRISE_TOKEN: ${{ github.token }}` alongside every
existing `GH_TOKEN: ${{ github.token }}` in the five locations named in
the issue:

- `.github/workflows/idd-doctor.yml`
- `.github/workflows/idd-advisory-convergence.yml`
- `idd-template/.github/workflows/idd-advisory-convergence.yml`
- `idd-template/.github/workflows/post-merge-cleanup.yml` (two steps)
- `idd-template/ONBOARDING.md`'s three `idd-doctor` CI-gate examples,
  plus a new paragraph explaining why both variables are set so a GHES
  adopter doesn't delete the extra line as apparently redundant

`gh` only reads the variable matching its resolved host, so adding the
second variable is inert on `github.com` and additive on GHES.

## Linked issue

Closes #1946

## Follow-up issues (if any)

- [x] kurone-kito/idd-skill#1963 — the three more locations sharing
      this unfixed pattern (`.github/workflows/post-merge-cleanup.yml`'s
      own source-repo copy, `.github/workflows/strip-untrusted-labels.yml`,
      and `idd-template/docs/customization.md`'s mirrored example),
      flagged as deliberately out of scope here by the issue's own
      refined plan comment
- [x] kurone-kito/idd-skill#1962 — a Codex advisory review on this PR
      found that `GH_ENTERPRISE_TOKEN` alone is not sufficient on GHES
      for any step that shells out through this repository's
      `gh api`-based helpers (`src/scripts/gh-exec.mts`), since `gh
      api` resolves its target host from `GH_HOST`/`--hostname`, not
      from the checked-out repository's Git remote. Documented as a
      caveat in `idd-template/ONBOARDING.md`; the actual host-resolution
      fix needs its own design and is tracked there instead of being
      absorbed untested into this PR

## Background / rationale (if material)

Flagged by a Codex advisory review on PR #1940 (#1926) as out of that
issue's scope: #1926 matched the ONBOARDING.md examples to
`idd-doctor.yml`'s own values exactly, and that reference workflow
(running on github.com) has no need for `GH_ENTERPRISE_TOKEN`, so
widening #1926 would have broken parity with the reference it had to
match. This is the same silent-degradation failure mode #1828 and
#1926 fixed for the missing-scopes/missing-token case, recurring here
for the missing-host-variable case.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no `idd-*.instructions.md`/
      `docs/idd-workflow.md`/`docs/customization.md` changes in this
      PR, so not applicable)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for automated repository checks and cleanup in GitHub Enterprise environments.
  - Workflow authentication now works consistently across both GitHub.com and GitHub Enterprise Server.

- **Documentation**
  - Updated onboarding guidance with authentication instructions for GitHub.com and GitHub Enterprise repositories.
  - Clarified which authentication settings should be retained for compatibility across hosting environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
