### PR TITLE
fix(cli): shape idd-rerun-advisory-convergence's native parseArgs errors too

### DIFF
--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -119,7 +119,6 @@
 // This helper never mutates GitHub state: it only reads check-run/run data
 // and prints a diagnosis plus a plan of commands for a human (or a future
 // --apply follow-up) to execute.
-import { parseArgs as nodeParseArgs } from 'node:util';
 import {
   DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
   resolveAdvisoryPrimaryBotLogin,
@@ -128,6 +127,7 @@ import {
   normalizeCiWaitPolicy,
   resolveCiRerunDecision,
 } from './ci-wait-policy.mjs';
+import { parseCanonicalIntegerOrNull, parseCliArgs } from './cli-args.mjs';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import { isValidIsoTimestamp } from './marker-helpers.mjs';
@@ -928,80 +928,51 @@ export function parseRunIdFromUrl(url) {
  * whitespace and shell metacharacters, not exactly replicating GitHub's
  * own registration rules. */
 const GITHUB_IDENTIFIER_PATTERN = /^[A-Za-z0-9_.-]+$/;
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --pr spec key
+// below. See cli-args.mts's module header for the full invariant. (This
+// comment deliberately avoids writing that key inside matching quote
+// marks, so it cannot itself satisfy the scan if the real key is ever
+// renamed -- see #1446's PR description for why that matters.)
+const RERUN_ADVISORY_CONVERGENCE_FLAG_SPEC = {
+  '--pr': { type: 'string' },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--now': { type: 'string', default: '' },
+  '--help': { type: 'boolean', short: 'h' },
+  '--apply': { type: 'boolean', default: false },
+  '--check-name': { type: 'string', default: '' },
+};
 /**
- * Rewrite a `--pr VALUE` pair into the single token `--pr=VALUE` whenever
- * `VALUE` starts with a single dash (not `--`) -- `node:util`'s own
- * `parseArgs` (`strict: true`) throws `ERR_PARSE_ARGS_INVALID_OPTION_VALUE`
- * ("... argument is ambiguous") for a bare `--pr -5`, since a
- * single-dash-prefixed value could plausibly be another short option
- * instead. Left uncaught, this crashed the CLI with a raw, uncaught Node
- * stack trace instead of this file's own documented `--pr` contract ("an
- * invalid --pr resolves to null (fails closed at the caller)") --
- * verified empirically (`--pr -5` threw before this fix; a negative PR
- * number is never valid, but the failure mode should be the same clean
- * `prNumber: null` every other malformed `--pr` value already gets, not
- * an uncaught crash) (self-discovered while evaluating #1446's shared
- * `cli-args.mts` wrapper, which solves this same class of gap generically
- * -- adopting it here is out of scope for #1431; this is the narrow,
- * `--pr`-only equivalent). Only `--pr` needs this: none of this file's
- * other flags (`--owner`, `--repo`, `--now`) can realistically take a
- * dash-prefixed value, and `--help`/`-h` is boolean (no value to
- * disambiguate).
- */
-function disambiguateSingleDashPrValue(argv) {
-  const rewritten = [];
-  for (let index = 0; index < argv.length; index += 1) {
-    const token = argv[index];
-    const next = argv[index + 1];
-    const isAmbiguousValue =
-      typeof next === 'string' &&
-      next.startsWith('-') &&
-      !next.startsWith('--');
-    if (token === '--pr' && isAmbiguousValue) {
-      rewritten.push(`--pr=${next}`);
-      index += 1;
-      continue;
-    }
-    rewritten.push(token);
-  }
-  return rewritten;
-}
-/**
- * Mechanical CLI-argument parsing is delegated to `node:util`'s own
- * stable (since Node 20; this repo's engines floor is `^22.22.2 || >=24`)
- * `parseArgs`, per a maintainer's review suggestion on PR #1434: it
- * already rejects a missing value, a value that looks like another
- * option (long `--foo` or short `-h` alike -- the hand-rolled
- * `requireFlagValue` this replaced only checked for `--`, so `--owner -h`
- * silently consumed `-h` as the owner instead of erroring), and an
- * unknown option, each with Node's own stable `ERR_PARSE_ARGS_*` error
- * codes. `allowPositionals: false` closes one more gap `strict: true`
- * alone does not: `strict` governs unknown *options*, not leftover
- * positional (non-option) tokens, so an invocation like
- * `--pr 1431 extra` would otherwise silently accept `extra` instead of
- * failing fast -- risky for a recovery/rerun helper where a typo should
- * error, not run against unintended, silently-ignored input (#1434
- * review, Copilot). This function's own job narrows to the
- * domain-specific validation `parseArgs` cannot express declaratively:
+ * Mechanical CLI-argument parsing is delegated to the shared
+ * `parseCliArgs()` wrapper (`cli-args.mts`, #1446) -- migrated here from a
+ * direct `node:util` `parseArgs` call, mirroring every other packaged
+ * `idd-*` helper (#1955). Before this migration, an unknown flag or a
+ * missing/ambiguous value threw Node's own raw `ERR_PARSE_ARGS_*` error
+ * text, which fell outside `bin/run-helper.mts`'s shaped-error
+ * interception (`extractShapedCliParseErrorMessage()`) entirely -- that
+ * mechanism only recognizes the exact message shapes `parseCliArgs`'s own
+ * `toRepoShapedError()` produces (#1922). Routing through `parseCliArgs`
+ * fixes the root cause once, rather than growing
+ * `extractShapedCliParseErrorMessage()`'s shape list with a fourth,
+ * helper-specific case. `parseCliArgs` also generically disambiguates a
+ * single-dash-prefixed value (e.g. `--pr -5`) for any declared
+ * `string`-type flag, so the narrow `--pr`-only
+ * `disambiguateSingleDashPrValue` helper this function used to call ahead
+ * of `node:util`'s own `parseArgs` is no longer needed and has been
+ * removed -- see cli-args.mts's `disambiguateSingleDashValues` doc
+ * comment for the generic version. This function's own job narrows to the
+ * domain-specific validation `parseCliArgs` cannot express declaratively:
  * the `--pr` value must be all digits (not just numeric-prefixed), and
  * `--owner`/`--repo` must be given together or not at all.
  */
 export function parseArgs(argv) {
-  const { values } = nodeParseArgs({
-    args: disambiguateSingleDashPrValue(argv),
-    options: {
-      pr: { type: 'string' },
-      owner: { type: 'string' },
-      repo: { type: 'string' },
-      now: { type: 'string' },
-      help: { type: 'boolean', short: 'h' },
-      apply: { type: 'boolean' },
-      'check-name': { type: 'string' },
-    },
-    strict: true,
-    allowPositionals: false,
-  });
-  if (values.help) {
+  const { values, help } = parseCliArgs(
+    argv,
+    RERUN_ADVISORY_CONVERGENCE_FLAG_SPEC,
+  );
+  if (help) {
     return {
       prNumber: null,
       owner: '',
@@ -1038,17 +1009,25 @@ export function parseArgs(argv) {
       '--repo must contain only letters, digits, hyphens, underscores, or periods',
     );
   }
-  // Number.parseInt parses only a leading numeric prefix ("1431abc" ->
-  // 1431), which would silently run this recovery helper -- and whatever
-  // `gh run rerun` plan it prints -- against the wrong PR on a typo.
-  // Require the entire value to be digits before parsing (#1434 review,
-  // Codex P2).
-  const rawPr = String(values.pr ?? '').trim();
-  const parsedPr = /^\d+$/.test(rawPr)
-    ? Number.parseInt(rawPr, 10)
-    : Number.NaN;
+  // parseCanonicalIntegerOrNull requires the ENTIRE (trimmed) value to be
+  // digits before parsing -- "1431abc" resolves to null rather than
+  // silently truncating to 1431, which would run this recovery helper --
+  // and whatever `gh run rerun` plan it prints -- against the wrong PR on
+  // a typo (#1434 review, Codex P2). Trimmed explicitly (unlike this
+  // wrapper's other `--pr` adopters) to keep this helper's pre-migration
+  // contract of tolerating incidental whitespace around an otherwise
+  // all-digit value.
+  //
+  // Disclosed behavior change (#1955 migration, C1 self-review): the
+  // pre-migration `/^\d+$/` grammar accepted a leading-zero value like
+  // "007" (parsing to 7 via Number.parseInt); parseCanonicalIntegerOrNull's
+  // stricter `/^(?:0|[1-9]\d*)$/` canonical-integer grammar rejects any
+  // leading zero (resolving "007" to null, same clean fail-closed outcome
+  // as any other malformed --pr value). GitHub never emits a
+  // zero-padded PR number, so this narrows an already-unrealistic input
+  // rather than a real one.
   return {
-    prNumber: Number.isInteger(parsedPr) && parsedPr >= 1 ? parsedPr : null,
+    prNumber: parseCanonicalIntegerOrNull(values.pr?.trim()),
     owner,
     repo,
     now: String(values.now ?? '').trim(),

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -120,8 +120,6 @@
 // and prints a diagnosis plus a plan of commands for a human (or a future
 // --apply follow-up) to execute.
 
-import { parseArgs as nodeParseArgs } from 'node:util';
-
 import {
   DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
   resolveAdvisoryPrimaryBotLogin,
@@ -130,6 +128,7 @@ import {
   normalizeCiWaitPolicy,
   resolveCiRerunDecision,
 } from './ci-wait-policy.mts';
+import { parseCanonicalIntegerOrNull, parseCliArgs } from './cli-args.mts';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mts';
 import { deriveGhHttpStatus } from './gh-http-status.mts';
 import type { IddConfig } from './idd-config.mts';
@@ -1273,82 +1272,53 @@ interface RerunPlanArgs {
  * own registration rules. */
 const GITHUB_IDENTIFIER_PATTERN = /^[A-Za-z0-9_.-]+$/;
 
-/**
- * Rewrite a `--pr VALUE` pair into the single token `--pr=VALUE` whenever
- * `VALUE` starts with a single dash (not `--`) -- `node:util`'s own
- * `parseArgs` (`strict: true`) throws `ERR_PARSE_ARGS_INVALID_OPTION_VALUE`
- * ("... argument is ambiguous") for a bare `--pr -5`, since a
- * single-dash-prefixed value could plausibly be another short option
- * instead. Left uncaught, this crashed the CLI with a raw, uncaught Node
- * stack trace instead of this file's own documented `--pr` contract ("an
- * invalid --pr resolves to null (fails closed at the caller)") --
- * verified empirically (`--pr -5` threw before this fix; a negative PR
- * number is never valid, but the failure mode should be the same clean
- * `prNumber: null` every other malformed `--pr` value already gets, not
- * an uncaught crash) (self-discovered while evaluating #1446's shared
- * `cli-args.mts` wrapper, which solves this same class of gap generically
- * -- adopting it here is out of scope for #1431; this is the narrow,
- * `--pr`-only equivalent). Only `--pr` needs this: none of this file's
- * other flags (`--owner`, `--repo`, `--now`) can realistically take a
- * dash-prefixed value, and `--help`/`-h` is boolean (no value to
- * disambiguate).
- */
-function disambiguateSingleDashPrValue(argv: readonly string[]): string[] {
-  const rewritten: string[] = [];
-  for (let index = 0; index < argv.length; index += 1) {
-    const token = argv[index];
-    const next = argv[index + 1];
-    const isAmbiguousValue =
-      typeof next === 'string' &&
-      next.startsWith('-') &&
-      !next.startsWith('--');
-    if (token === '--pr' && isAmbiguousValue) {
-      rewritten.push(`--pr=${next}`);
-      index += 1;
-      continue;
-    }
-    rewritten.push(token);
-  }
-  return rewritten;
-}
+// Flag-spec keys stay the dashed literal on purpose (never bare keys like
+// `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
+// .mjs source text for quoted flag literals such as the --pr spec key
+// below. See cli-args.mts's module header for the full invariant. (This
+// comment deliberately avoids writing that key inside matching quote
+// marks, so it cannot itself satisfy the scan if the real key is ever
+// renamed -- see #1446's PR description for why that matters.)
+const RERUN_ADVISORY_CONVERGENCE_FLAG_SPEC = {
+  '--pr': { type: 'string' },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--now': { type: 'string', default: '' },
+  '--help': { type: 'boolean', short: 'h' },
+  '--apply': { type: 'boolean', default: false },
+  '--check-name': { type: 'string', default: '' },
+} as const;
 
 /**
- * Mechanical CLI-argument parsing is delegated to `node:util`'s own
- * stable (since Node 20; this repo's engines floor is `^22.22.2 || >=24`)
- * `parseArgs`, per a maintainer's review suggestion on PR #1434: it
- * already rejects a missing value, a value that looks like another
- * option (long `--foo` or short `-h` alike -- the hand-rolled
- * `requireFlagValue` this replaced only checked for `--`, so `--owner -h`
- * silently consumed `-h` as the owner instead of erroring), and an
- * unknown option, each with Node's own stable `ERR_PARSE_ARGS_*` error
- * codes. `allowPositionals: false` closes one more gap `strict: true`
- * alone does not: `strict` governs unknown *options*, not leftover
- * positional (non-option) tokens, so an invocation like
- * `--pr 1431 extra` would otherwise silently accept `extra` instead of
- * failing fast -- risky for a recovery/rerun helper where a typo should
- * error, not run against unintended, silently-ignored input (#1434
- * review, Copilot). This function's own job narrows to the
- * domain-specific validation `parseArgs` cannot express declaratively:
+ * Mechanical CLI-argument parsing is delegated to the shared
+ * `parseCliArgs()` wrapper (`cli-args.mts`, #1446) -- migrated here from a
+ * direct `node:util` `parseArgs` call, mirroring every other packaged
+ * `idd-*` helper (#1955). Before this migration, an unknown flag or a
+ * missing/ambiguous value threw Node's own raw `ERR_PARSE_ARGS_*` error
+ * text, which fell outside `bin/run-helper.mts`'s shaped-error
+ * interception (`extractShapedCliParseErrorMessage()`) entirely -- that
+ * mechanism only recognizes the exact message shapes `parseCliArgs`'s own
+ * `toRepoShapedError()` produces (#1922). Routing through `parseCliArgs`
+ * fixes the root cause once, rather than growing
+ * `extractShapedCliParseErrorMessage()`'s shape list with a fourth,
+ * helper-specific case. `parseCliArgs` also generically disambiguates a
+ * single-dash-prefixed value (e.g. `--pr -5`) for any declared
+ * `string`-type flag, so the narrow `--pr`-only
+ * `disambiguateSingleDashPrValue` helper this function used to call ahead
+ * of `node:util`'s own `parseArgs` is no longer needed and has been
+ * removed -- see cli-args.mts's `disambiguateSingleDashValues` doc
+ * comment for the generic version. This function's own job narrows to the
+ * domain-specific validation `parseCliArgs` cannot express declaratively:
  * the `--pr` value must be all digits (not just numeric-prefixed), and
  * `--owner`/`--repo` must be given together or not at all.
  */
 export function parseArgs(argv: string[]): RerunPlanArgs {
-  const { values } = nodeParseArgs({
-    args: disambiguateSingleDashPrValue(argv),
-    options: {
-      pr: { type: 'string' },
-      owner: { type: 'string' },
-      repo: { type: 'string' },
-      now: { type: 'string' },
-      help: { type: 'boolean', short: 'h' },
-      apply: { type: 'boolean' },
-      'check-name': { type: 'string' },
-    },
-    strict: true,
-    allowPositionals: false,
-  });
+  const { values, help } = parseCliArgs(
+    argv,
+    RERUN_ADVISORY_CONVERGENCE_FLAG_SPEC,
+  );
 
-  if (values.help) {
+  if (help) {
     return {
       prNumber: null,
       owner: '',
@@ -1387,18 +1357,27 @@ export function parseArgs(argv: string[]): RerunPlanArgs {
     );
   }
 
-  // Number.parseInt parses only a leading numeric prefix ("1431abc" ->
-  // 1431), which would silently run this recovery helper -- and whatever
-  // `gh run rerun` plan it prints -- against the wrong PR on a typo.
-  // Require the entire value to be digits before parsing (#1434 review,
-  // Codex P2).
-  const rawPr = String(values.pr ?? '').trim();
-  const parsedPr = /^\d+$/.test(rawPr)
-    ? Number.parseInt(rawPr, 10)
-    : Number.NaN;
-
+  // parseCanonicalIntegerOrNull requires the ENTIRE (trimmed) value to be
+  // digits before parsing -- "1431abc" resolves to null rather than
+  // silently truncating to 1431, which would run this recovery helper --
+  // and whatever `gh run rerun` plan it prints -- against the wrong PR on
+  // a typo (#1434 review, Codex P2). Trimmed explicitly (unlike this
+  // wrapper's other `--pr` adopters) to keep this helper's pre-migration
+  // contract of tolerating incidental whitespace around an otherwise
+  // all-digit value.
+  //
+  // Disclosed behavior change (#1955 migration, C1 self-review): the
+  // pre-migration `/^\d+$/` grammar accepted a leading-zero value like
+  // "007" (parsing to 7 via Number.parseInt); parseCanonicalIntegerOrNull's
+  // stricter `/^(?:0|[1-9]\d*)$/` canonical-integer grammar rejects any
+  // leading zero (resolving "007" to null, same clean fail-closed outcome
+  // as any other malformed --pr value). GitHub never emits a
+  // zero-padded PR number, so this narrows an already-unrealistic input
+  // rather than a real one.
   return {
-    prNumber: Number.isInteger(parsedPr) && parsedPr >= 1 ? parsedPr : null,
+    prNumber: parseCanonicalIntegerOrNull(
+      (values.pr as string | undefined)?.trim(),
+    ),
     owner,
     repo,
     now: String(values.now ?? '').trim(),

--- a/tests/help-text-flags.test.mts
+++ b/tests/help-text-flags.test.mts
@@ -186,6 +186,7 @@ const COVERED_HELPERS = [
   'merged-pr-feedback-sweep',
   'phase-id-resolver',
   'pre-merge-readiness',
+  'rerun-advisory-convergence',
   'resolve-review-thread',
   'resume-claim-routing',
   'resume-route-selection',
@@ -235,11 +236,6 @@ const EXCLUDED_HELPERS: readonly { helper: string; reason: string }[] = [
   },
   {
     helper: 'idd-onboard',
-    reason:
-      'hand-rolled parseArgs() loop, no declarative FLAG_SPEC object to compare',
-  },
-  {
-    helper: 'rerun-advisory-convergence',
     reason:
       'hand-rolled parseArgs() loop, no declarative FLAG_SPEC object to compare',
   },

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -2004,6 +2004,19 @@ test('parseArgs still accepts a plain numeric --pr value', () => {
   assert.equal(parseArgs(['--pr', '1431']).prNumber, 1431);
 });
 
+// Disclosed behavior change (#1955 migration onto parseCliArgs(), C1
+// self-review): the pre-migration hand-rolled /^\d+$/ grammar accepted a
+// leading-zero value like "007" (Number.parseInt parsed it to 7).
+// parseCanonicalIntegerOrNull's stricter canonical-integer grammar
+// (/^(?:0|[1-9]\d*)$/) rejects any leading zero, resolving "007" to null
+// -- the same clean fail-closed outcome as any other malformed --pr
+// value, not a crash. GitHub never emits a zero-padded PR number, so
+// this narrows an already-unrealistic input rather than a real one; see
+// the function's own doc comment for the full disclosure.
+test('parseArgs resolves a leading-zero --pr value to null (behavior change from the pre-migration parser)', () => {
+  assert.equal(parseArgs(['--pr', '007']).prNumber, null);
+});
+
 // Regression (self-discovered while evaluating #1446's cli-args.mts,
 // user-directed fix): node:util's own parseArgs (strict: true) throws
 // ERR_PARSE_ARGS_INVALID_OPTION_VALUE for a bare `--pr -5` (a
@@ -2011,7 +2024,10 @@ test('parseArgs still accepts a plain numeric --pr value', () => {
 // verified to throw uncaught before this fix. A negative PR number is
 // never valid, but the failure mode must be the same clean
 // `prNumber: null` every other malformed --pr value already gets, not an
-// uncaught crash.
+// uncaught crash. Since #1955's migration onto parseCliArgs(), this
+// disambiguation is provided generically by cli-args.mts rather than by a
+// --pr-only local helper, but the observable outcome for this case is
+// unchanged.
 test('parseArgs resolves a dash-prefixed --pr value to null instead of throwing', () => {
   assert.equal(parseArgs(['--pr', '-5']).prNumber, null);
 });
@@ -2073,7 +2089,7 @@ test('parseArgs trims --check-name', () => {
 
 test('parseArgs fails fast when --check-name has a missing value', () => {
   assert.throws(() => parseArgs(['--pr', '1431', '--check-name']), {
-    code: 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE',
+    message: 'missing value for argument: --check-name',
   });
 });
 
@@ -2092,68 +2108,85 @@ test('resolveCheckName honors a custom checkName', () => {
   );
 });
 
-// parseArgs delegates mechanical parsing to node:util's own stable
-// `parseArgs` (a maintainer's review suggestion, adopted -- see the
-// function's doc comment). Its `strict: true` mode raises Node's own
-// stable `ERR_PARSE_ARGS_*` error codes for an unknown option or a
-// missing/ambiguous value; these tests assert on the stable `code`
-// rather than message text, which is Node's own to change.
+// parseArgs delegates mechanical parsing to the shared parseCliArgs()
+// wrapper (cli-args.mts, #1446), migrated here from a direct node:util
+// parseArgs() call so this helper's parse errors get the same
+// bin/run-helper.mts shaped-error interception every other packaged
+// idd-* CLI command already gets (#1955; see the function's doc
+// comment). node:util's own strict-mode ERR_PARSE_ARGS_* error is
+// re-shaped by parseCliArgs()'s toRepoShapedError() into this
+// repository's established `unknown argument: --x` / `missing value for
+// argument: --x` idiom -- these tests assert on that shaped message text
+// (cli-args.mts's own contract), not Node's `.code`, which the shaped
+// Error no longer carries.
 test('parseArgs rejects an unknown argument', () => {
   assert.throws(() => parseArgs(['--bogus']), {
-    code: 'ERR_PARSE_ARGS_UNKNOWN_OPTION',
+    message: 'unknown argument: --bogus',
   });
 });
 
 // Regression (#1434 review, Copilot): `strict: true` alone only governs
 // unknown *options*, not leftover positional (non-option) tokens, so
 // `--pr 1431 extra` would otherwise silently accept `extra` instead of
-// failing fast on a likely typo. `allowPositionals: false` closes this.
+// failing fast on a likely typo. `allowPositionals: false` closes this;
+// parseCliArgs() re-shapes both the unknown-option and
+// unexpected-positional codes onto the same `unknown argument: ` prefix.
 test('parseArgs rejects an unexpected positional argument', () => {
   assert.throws(() => parseArgs(['--pr', '1431', 'extra']), {
-    code: 'ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL',
+    message: 'unknown argument: extra',
   });
 });
 
 // Regression (#1434 review, Copilot + CodeRabbit): a value-taking flag
-// with no following token, or followed by another option -- long
-// (`--repo`) or short (`-h`) alike -- previously degraded into a
-// confusing "unknown argument" error (or, worse, silently accepted the
-// next flag as a value). node:util's parseArgs rejects all of these
-// forms natively.
+// with no following token, or followed by another long option, previously
+// degraded into a confusing "unknown argument" error (or, worse, silently
+// accepted the next flag as a value). node:util's parseArgs rejects both
+// forms natively; parseCliArgs() re-shapes the result onto this
+// repository's `missing value for argument: ` idiom.
 test('parseArgs fails fast when --owner is the last argument (missing value)', () => {
   assert.throws(() => parseArgs(['--pr', '1431', '--owner']), {
-    code: 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE',
+    message: 'missing value for argument: --owner',
   });
 });
 
 test('parseArgs fails fast when --owner is immediately followed by another long flag', () => {
   assert.throws(
     () => parseArgs(['--pr', '1431', '--owner', '--repo', 'idd-skill']),
-    { code: 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE' },
+    { message: 'missing value for argument: --owner' },
   );
 });
 
-test('parseArgs fails fast when --owner is immediately followed by the short help flag', () => {
-  assert.throws(() => parseArgs(['--owner', '-h']), {
-    code: 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE',
-  });
+// parseCliArgs()'s own generic single-dash-value disambiguation (see
+// cli-args.mts's disambiguateSingleDashValues doc comment) now applies to
+// every declared string flag, not just --pr -- one of this migration's
+// intentional, disclosed behavior changes (#1955). `-h` after --owner no
+// longer looks like an ambiguous short option to node:util: it is
+// rewritten to `--owner=-h` up front, so --owner captures the literal
+// value "-h" (which passes the --owner identifier-character check) and
+// parsing instead fails on the --owner/--repo pairing rule below, since
+// --repo is still missing.
+test('parseArgs resolves --owner followed by the short help flag as a literal value, then fails the --owner/--repo pairing check', () => {
+  assert.throws(
+    () => parseArgs(['--owner', '-h']),
+    /provide both --owner and --repo, or neither/,
+  );
 });
 
 test('parseArgs fails fast when --repo has a missing value', () => {
   assert.throws(() => parseArgs(['--repo']), {
-    code: 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE',
+    message: 'missing value for argument: --repo',
   });
 });
 
 test('parseArgs fails fast when --now has a missing value', () => {
   assert.throws(() => parseArgs(['--now']), {
-    code: 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE',
+    message: 'missing value for argument: --now',
   });
 });
 
 test('parseArgs fails fast when --pr has a missing value', () => {
   assert.throws(() => parseArgs(['--pr']), {
-    code: 'ERR_PARSE_ARGS_INVALID_OPTION_VALUE',
+    message: 'missing value for argument: --pr',
   });
 });
 


### PR DESCRIPTION
## Summary

Migrates `rerun-advisory-convergence.mts`'s `parseArgs()` off a direct
`node:util.parseArgs()` call onto this repository's shared
`parseCliArgs()`/`toRepoShapedError()` wrapper (`src/scripts/cli-args.mts`),
mirroring every other packaged `idd-*` helper. Before this change, an
unknown flag or a missing/ambiguous value threw Node's raw
`ERR_PARSE_ARGS_*` error text instead of the shaped
`unknown argument: --x` / `missing value for argument: --x` one-liner
`bin/run-helper.mts`'s shaped-error interception already gives every
other `idd-*` CLI command (per #1922's `extractShapedCliParseErrorMessage()`,
which only recognizes `parseCliArgs()`'s own message shapes).

Also removes the now-redundant `disambiguateSingleDashPrValue()` helper
— the shared wrapper's own generic `disambiguateSingleDashValues`
covers the same single-dash-value ambiguity (e.g. `--pr -5`) for any
declared string flag — while keeping this function's two
domain-specific validations: `--pr` must be all-digits, and
`--owner`/`--repo` must be given together or neither.

### Disclosed behavior changes

- `--owner` followed by `-h` now resolves `-h` as `--owner`'s literal
  value (passing the identifier check) instead of throwing an
  ambiguous-option error, then fails the `--owner`/`--repo` pairing
  rule since `--repo` is still absent.
- `--pr` with a leading zero (e.g. `"007"`) now resolves to `null`
  instead of parsing to `7`, since `parseCanonicalIntegerOrNull`'s
  canonical-integer grammar rejects leading zeros. GitHub never emits
  a zero-padded PR number, so this narrows an already-unrealistic
  input.

Both are covered by updated/new tests and documented inline where the
behavior is implemented.

## Verification

- `node bin/idd-rerun-advisory-convergence.mjs --bogus` now prints the
  clean shaped one-liner plus usage (exit code 1), not a raw stack
  trace — confirmed against the issue's own reproduction steps.
- `node bin/idd-rerun-advisory-convergence.mjs --pr` (missing value)
  behaves the same way.
- `tests/rerun-advisory-convergence.test.mts` (186 tests) and
  `tests/help-text-flags.test.mts` are green.
- Full suite: `pnpm test` — 3397/3397 passing.
- `pnpm run build:check`, `npx biome check`, `npx tsc --noEmit`, and an
  independent critique-pass subagent review all pass clean.

## Note: resumed claim

This PR resumes work an earlier worker in this same session had fully
implemented and locally verified before a host `/tmp` inode-exhaustion
outage forced it to stop before any GitHub mutation (no claim, branch,
or PR were ever posted). This session re-verified the diff was intact
post-outage, re-ran Discover/A4.5 fresh (see the plan comment on
#1955 for the independent Check-7 re-judgment), claimed with a fresh
claim-id, and regenerated the built `.mjs` output against current
`main` rather than reusing the prior worker's build output. A
follow-up C1 critique pass (subagent) found two disclosure gaps in
the original diff (both listed above) and fixed them before this PR
was opened.

Closes #1955
