### PR TITLE
fix(ci): set GH_ENTERPRISE_TOKEN in the 3 remaining gh auth spots

### DIFF
--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -65,6 +65,11 @@ jobs:
         id: cleanup
         env:
           GH_TOKEN: ${{ github.token }}
+          # gh reads whichever of these two matches its resolved host
+          # (`gh help environment`), so setting both is inert on
+          # github.com and lets this same step authenticate on a
+          # self-hosted GHES host too.
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
           # workflow_dispatch's `pr_number` input is `type: number` in the
           # UI, but that constraint is not strictly enforced for direct API
           # dispatches, so route it through env: and reference it as a
@@ -120,6 +125,11 @@ jobs:
       - name: Post cleanup evidence comment
         env:
           GH_TOKEN: ${{ github.token }}
+          # gh reads whichever of these two matches its resolved host
+          # (`gh help environment`), so setting both is inert on
+          # github.com and lets this same step authenticate on a
+          # self-hosted GHES host too.
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.cleanup.outputs.pr_number }}
           STATUS: ${{ steps.cleanup.outputs.status }}
           APPLIED: ${{ steps.cleanup.outputs.applied }}

--- a/.github/workflows/strip-untrusted-labels.yml
+++ b/.github/workflows/strip-untrusted-labels.yml
@@ -82,6 +82,11 @@ jobs:
       - name: Remove reserved label applied by an advisory bot
         env:
           GH_TOKEN: ${{ github.token }}
+          # gh reads whichever of these two matches its resolved host
+          # (`gh help environment`), so setting both is inert on
+          # github.com and lets this same step authenticate on a
+          # self-hosted GHES host too.
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           LABEL_NAME: ${{ github.event.label.name }}

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -796,6 +796,11 @@ jobs:
       - name: Remove reserved label applied by an untrusted labeler
         env:
           GH_TOKEN: ${{ github.token }}
+          # gh reads whichever of these two matches its resolved host
+          # (`gh help environment`), so setting both is inert on
+          # github.com and lets this same step authenticate on a
+          # self-hosted GHES host too.
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           LABEL_NAME: ${{ github.event.label.name }}

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -796,6 +796,11 @@ jobs:
       - name: Remove reserved label applied by an untrusted labeler
         env:
           GH_TOKEN: ${{ github.token }}
+          # gh reads whichever of these two matches its resolved host
+          # (`gh help environment`), so setting both is inert on
+          # github.com and lets this same step authenticate on a
+          # self-hosted GHES host too.
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           LABEL_NAME: ${{ github.event.label.name }}


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

#1946/#1959 set `GH_ENTERPRISE_TOKEN` alongside `GH_TOKEN` in five CI
locations but deliberately left three more untouched to keep that PR's
scope narrow. This PR finishes that follow-through by adding
`GH_ENTERPRISE_TOKEN: ${{ github.token }}` next to the existing
`GH_TOKEN: ${{ github.token }}` in the same three deferred locations,
mirroring #1959's exact pattern and explanatory comment:

- `.github/workflows/post-merge-cleanup.yml` (this source repository's
  own copy, distinct from the already-fixed `idd-template/` copy) — both
  `gh`-calling steps.
- `.github/workflows/strip-untrusted-labels.yml` — its one `gh pr
  edit`/`gh issue edit` step.
- `idd-template/docs/customization.md`'s `strip-untrusted-labels.yml`
  recipe example. `docs/customization.md` is the generated mirror,
  regenerated via `node scripts/sync-docs.mjs --apply` from the edited
  `idd-template/` canonical copy — never hand-edited directly.

## Linked issue

Closes #1963

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

This is a token-only parity fix, matching #1946's own precedent. It
does **not** address `gh api`'s separate `GH_HOST`-based host
resolution for helpers that shell out through
`src/scripts/gh-exec.mts` — that is #1962's distinct design question,
called out in #1963's own body as a caveat. Setting
`GH_ENTERPRISE_TOKEN` here is necessary but not sufficient for full
GHES support until #1962 lands.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [ ] `pnpm test` (no test-relevant code changed; workflow YAML and docs only)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved workflow authentication for GitHub Enterprise Server environments while preserving GitHub.com compatibility.
  * Cleanup and label-management workflows now operate reliably across supported hosting environments.

* **Documentation**
  * Updated customization guidance to reflect GitHub Enterprise Server authentication support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->