### PR TITLE
fix(ci): resolve the correct GHES host for gh api calls, not just token

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1097,13 +1097,16 @@ advisory review on
 [kurone-kito/idd-skill#1959](https://github.com/kurone-kito/idd-skill/pull/1959)).
 `src/scripts/gh-exec.mts`'s shared `ghApiJson`/`ghGraphql` wrappers now
 resolve the correct `--hostname` automatically
-([kurone-kito/idd-skill#1962](https://github.com/kurone-kito/idd-skill/issues/1962)):
-in GitHub Actions they derive it from the `GITHUB_SERVER_URL` default
-environment variable (no workflow `env:` change needed, and no
-behavior change at all on `github.com`, where it already equals the
-default host); outside Actions (a local `gh-doctor` run) they defer to
-an explicit `GH_HOST` or `gh`'s own single-authenticated-host default,
-same as `gh` itself. `idd-advisory-convergence` (both the CI-hosted
+([kurone-kito/idd-skill#1962](https://github.com/kurone-kito/idd-skill/issues/1962)),
+preferring an explicit `GH_HOST` when set (in which case no
+`--hostname` is added — `gh` already resolves it correctly on its
+own) and otherwise, in GitHub Actions, deriving the host from the
+`GITHUB_SERVER_URL` default environment variable (no workflow `env:`
+change needed, and no behavior change at all on `github.com`, where it
+already equals the default host). Outside Actions (a local
+`idd-doctor` run) with neither signal set, they defer to `gh`'s own
+single-authenticated-host default, same as `gh` itself.
+`idd-advisory-convergence` (both the CI-hosted
 required-check workflow and its underlying `advisory-convergence.mts`
 GitHub-API calls) goes through these shared wrappers, so it is covered
 end to end. `idd-doctor.mts`'s own few direct `gh api` call sites do

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1086,18 +1086,31 @@ examples onto a GHES-hosted repository, keep both lines rather than
 deleting `GH_ENTERPRISE_TOKEN` as apparently redundant (preventive; no
 observed incident yet).
 
-**Setting the token alone is not sufficient on GHES.** The
-`idd-doctor`/`idd-advisory-convergence` helpers call `gh api` directly,
-and `gh api` resolves its target host from `GH_HOST`/`--hostname` (or
-the CLI's configured default), not from the checked-out repository's
-Git remote the way `gh pr view`/`gh issue edit` do — so on a
-GHES-hosted repository, an unset `GH_HOST` still sends these `gh api`
-calls to `api.github.com` using `GH_TOKEN`, and `GH_ENTERPRISE_TOKEN`
-is never read at all (observed 2026-08-11, a Codex advisory review on
+**Setting the token alone is not sufficient by itself on GHES.** `gh
+api`/`gh api graphql` resolve their target host from `GH_HOST`/
+`--hostname` (or the CLI's configured default), not from the
+checked-out repository's Git remote the way `gh pr view`/`gh issue
+edit` do — so on a GHES-hosted repository, an unset `GH_HOST` would
+otherwise send these calls to `api.github.com` using `GH_TOKEN`, with
+`GH_ENTERPRISE_TOKEN` never read at all (observed 2026-08-11, a Codex
+advisory review on
 [kurone-kito/idd-skill#1959](https://github.com/kurone-kito/idd-skill/pull/1959)).
-Resolving the correct host for these calls needs its own design — see
-kurone-kito/idd-skill#1962 — so a GHES adopter should treat the two
-examples above as necessary but not yet sufficient until that lands.
+`src/scripts/gh-exec.mts`'s shared `ghApiJson`/`ghGraphql` wrappers now
+resolve the correct `--hostname` automatically
+([kurone-kito/idd-skill#1962](https://github.com/kurone-kito/idd-skill/issues/1962)):
+in GitHub Actions they derive it from the `GITHUB_SERVER_URL` default
+environment variable (no workflow `env:` change needed, and no
+behavior change at all on `github.com`, where it already equals the
+default host); outside Actions (a local `gh-doctor` run) they defer to
+an explicit `GH_HOST` or `gh`'s own single-authenticated-host default,
+same as `gh` itself. `idd-advisory-convergence` (both the CI-hosted
+required-check workflow and its underlying `advisory-convergence.mts`
+GitHub-API calls) goes through these shared wrappers, so it is covered
+end to end. `idd-doctor.mts`'s own few direct `gh api` call sites do
+not route through `gh-exec.mts` and are **not** covered by this fix —
+a GHES adopter relying on `idd-doctor`'s GitHub-API-backed checks
+(post-merge cleanup backlog, autopilot-suitability) should still treat
+host resolution there as an open gap.
 
 This gate checks repository **health**, not the disposable-worktree rule:
 CI cannot detect a primary-worktree B1 violation (it leaves no trace in

--- a/scripts/gh-exec.mjs
+++ b/scripts/gh-exec.mjs
@@ -119,6 +119,65 @@ export async function ghTextAsync(args, options = {}) {
   return stdout.trim();
 }
 /**
+ * Resolve the `--hostname` override {@link ghApiJson} / {@link ghGraphql}
+ * pass to `gh api` / `gh api graphql`, so a self-hosted GitHub Enterprise
+ * Server (GHES) repository's GitHub-API-backed calls target the correct
+ * host instead of silently defaulting to `api.github.com` (#1962).
+ *
+ * `gh api` resolves its target host from `GH_HOST` / `--hostname`, or the
+ * CLI's single configured/authenticated host, defaulting to `github.com`
+ * -- unlike higher-level subcommands (`gh pr view`, `gh issue edit`, ...),
+ * it does **not** infer the host from the checked-out repository's Git
+ * remote (`gh help environment`). On a GHES-hosted repository running in
+ * GitHub Actions, this means an unset `GH_HOST` still sends these calls to
+ * `api.github.com` using `GH_TOKEN`, and `GH_ENTERPRISE_TOKEN` (set
+ * alongside it by #1946) is never read at all, even though the workflow
+ * itself is genuinely running against the GHES host.
+ *
+ * Resolution order:
+ *
+ * 1. `GH_HOST`, when set -- `gh` already reads this itself (`gh help
+ *    environment`), so no `--hostname` override is needed here; returning
+ *    `undefined` avoids a second, potentially-redundant resolution path
+ *    for a case `gh` already handles, and leaves an operator's explicit
+ *    override unchanged.
+ * 2. `GITHUB_SERVER_URL` -- a GitHub Actions **default** environment
+ *    variable present in every job (no workflow `env:` entry required),
+ *    always a well-formed `scheme://host` URL supplied by the runner
+ *    itself (`https://github.com` or `https://<ghes-host>`), so this
+ *    strips the scheme instead of parsing untrusted input. When the
+ *    stripped host equals `github.com` (the overwhelming common case,
+ *    including every run of this repository's own CI), this returns
+ *    `undefined` so the emitted argv stays byte-identical to before this
+ *    change -- the "no behavior change on github.com" half of #1962's
+ *    acceptance criteria.
+ * 3. Otherwise (a non-Actions caller with no `GH_HOST` set, e.g. a local
+ *    `idd-doctor` run) -- `undefined`. `gh`'s own "single authenticated
+ *    host" default already resolves correctly for a developer
+ *    authenticated only to their GHES instance; a developer authenticated
+ *    to more than one host sets `GH_HOST` themselves (case 1), the same
+ *    convention `gh` itself documents. This deliberately adds no
+ *    git-remote-derived fallback here (contrast
+ *    `branch-conflict-state.mts`'s `resolveFetchOrigin`, which fetches
+ *    from a remote and has no other host signal available): that would
+ *    widen this change beyond `gh-exec.mts`'s two wrappers and risks
+ *    silently overriding a `gh` config that was already resolving
+ *    correctly. See `idd-template/ONBOARDING.md`'s GHES host-resolution
+ *    note for the fuller design record, including the still-open gap for
+ *    helpers (e.g. `idd-doctor.mts`) that call `gh api` directly instead
+ *    of through this module's shared wrappers.
+ */
+export function resolveGhApiHostname(env = process.env) {
+  if (env.GH_HOST?.trim()) return undefined;
+  const serverUrl = env.GITHUB_SERVER_URL?.trim();
+  if (!serverUrl) return undefined;
+  const host = serverUrl
+    .replace(/^[a-z][a-z0-9+.-]*:\/\//i, '')
+    .replace(/\/+$/, '')
+    .toLowerCase();
+  return host && host !== 'github.com' ? host : undefined;
+}
+/**
  * Run `gh api <path>` and parse its output as JSON, optionally paginating
  * (NDJSON-compatible) and/or tolerating specific failure statuses.
  *
@@ -126,10 +185,19 @@ export async function ghTextAsync(args, options = {}) {
  * replaces: `advisory-wait-state.mts`'s NDJSON-pagination handling and
  * `review-activity-snapshot.mts`'s `allowStatuses` tolerated-failure
  * fallback.
+ *
+ * Targets the correct GHES host via {@link resolveGhApiHostname} (#1962)
+ * instead of always defaulting to `github.com`.
  */
 export function ghApiJson(path, options = {}) {
   const { paginate = false, extraArgs = [], allowStatuses = [] } = options;
-  const args = ['api', path, ...extraArgs];
+  const hostname = resolveGhApiHostname();
+  const args = [
+    'api',
+    path,
+    ...(hostname ? ['--hostname', hostname] : []),
+    ...extraArgs,
+  ];
   if (paginate) {
     args.push('--paginate', '--jq', '.[]');
   }
@@ -167,9 +235,19 @@ export function ghApiJson(path, options = {}) {
  * file's existing role as the shared `gh`-execution module for `ghText` /
  * `ghApiJson`. Uses `ghText`'s own default timeout (no explicit override
  * here, unchanged from this function's pre-extraction behavior).
+ *
+ * Targets the correct GHES host via {@link resolveGhApiHostname} (#1962)
+ * instead of always defaulting to `github.com`.
  */
 export function ghGraphql(query, variables) {
-  const args = ['api', 'graphql', '-f', `query=${query}`];
+  const hostname = resolveGhApiHostname();
+  const args = [
+    'api',
+    'graphql',
+    ...(hostname ? ['--hostname', hostname] : []),
+    '-f',
+    `query=${query}`,
+  ];
   for (const [key, value] of Object.entries(variables)) {
     if (value === null || value === undefined) continue;
     if (typeof value === 'number') {

--- a/src/scripts/gh-exec.mts
+++ b/src/scripts/gh-exec.mts
@@ -214,6 +214,68 @@ export interface GhApiJsonOptions {
 }
 
 /**
+ * Resolve the `--hostname` override {@link ghApiJson} / {@link ghGraphql}
+ * pass to `gh api` / `gh api graphql`, so a self-hosted GitHub Enterprise
+ * Server (GHES) repository's GitHub-API-backed calls target the correct
+ * host instead of silently defaulting to `api.github.com` (#1962).
+ *
+ * `gh api` resolves its target host from `GH_HOST` / `--hostname`, or the
+ * CLI's single configured/authenticated host, defaulting to `github.com`
+ * -- unlike higher-level subcommands (`gh pr view`, `gh issue edit`, ...),
+ * it does **not** infer the host from the checked-out repository's Git
+ * remote (`gh help environment`). On a GHES-hosted repository running in
+ * GitHub Actions, this means an unset `GH_HOST` still sends these calls to
+ * `api.github.com` using `GH_TOKEN`, and `GH_ENTERPRISE_TOKEN` (set
+ * alongside it by #1946) is never read at all, even though the workflow
+ * itself is genuinely running against the GHES host.
+ *
+ * Resolution order:
+ *
+ * 1. `GH_HOST`, when set -- `gh` already reads this itself (`gh help
+ *    environment`), so no `--hostname` override is needed here; returning
+ *    `undefined` avoids a second, potentially-redundant resolution path
+ *    for a case `gh` already handles, and leaves an operator's explicit
+ *    override unchanged.
+ * 2. `GITHUB_SERVER_URL` -- a GitHub Actions **default** environment
+ *    variable present in every job (no workflow `env:` entry required),
+ *    always a well-formed `scheme://host` URL supplied by the runner
+ *    itself (`https://github.com` or `https://<ghes-host>`), so this
+ *    strips the scheme instead of parsing untrusted input. When the
+ *    stripped host equals `github.com` (the overwhelming common case,
+ *    including every run of this repository's own CI), this returns
+ *    `undefined` so the emitted argv stays byte-identical to before this
+ *    change -- the "no behavior change on github.com" half of #1962's
+ *    acceptance criteria.
+ * 3. Otherwise (a non-Actions caller with no `GH_HOST` set, e.g. a local
+ *    `idd-doctor` run) -- `undefined`. `gh`'s own "single authenticated
+ *    host" default already resolves correctly for a developer
+ *    authenticated only to their GHES instance; a developer authenticated
+ *    to more than one host sets `GH_HOST` themselves (case 1), the same
+ *    convention `gh` itself documents. This deliberately adds no
+ *    git-remote-derived fallback here (contrast
+ *    `branch-conflict-state.mts`'s `resolveFetchOrigin`, which fetches
+ *    from a remote and has no other host signal available): that would
+ *    widen this change beyond `gh-exec.mts`'s two wrappers and risks
+ *    silently overriding a `gh` config that was already resolving
+ *    correctly. See `idd-template/ONBOARDING.md`'s GHES host-resolution
+ *    note for the fuller design record, including the still-open gap for
+ *    helpers (e.g. `idd-doctor.mts`) that call `gh api` directly instead
+ *    of through this module's shared wrappers.
+ */
+export function resolveGhApiHostname(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  if (env.GH_HOST?.trim()) return undefined;
+  const serverUrl = env.GITHUB_SERVER_URL?.trim();
+  if (!serverUrl) return undefined;
+  const host = serverUrl
+    .replace(/^[a-z][a-z0-9+.-]*:\/\//i, '')
+    .replace(/\/+$/, '')
+    .toLowerCase();
+  return host && host !== 'github.com' ? host : undefined;
+}
+
+/**
  * Run `gh api <path>` and parse its output as JSON, optionally paginating
  * (NDJSON-compatible) and/or tolerating specific failure statuses.
  *
@@ -221,13 +283,22 @@ export interface GhApiJsonOptions {
  * replaces: `advisory-wait-state.mts`'s NDJSON-pagination handling and
  * `review-activity-snapshot.mts`'s `allowStatuses` tolerated-failure
  * fallback.
+ *
+ * Targets the correct GHES host via {@link resolveGhApiHostname} (#1962)
+ * instead of always defaulting to `github.com`.
  */
 export function ghApiJson(
   path: string,
   options: GhApiJsonOptions = {},
 ): unknown {
   const { paginate = false, extraArgs = [], allowStatuses = [] } = options;
-  const args = ['api', path, ...extraArgs];
+  const hostname = resolveGhApiHostname();
+  const args = [
+    'api',
+    path,
+    ...(hostname ? ['--hostname', hostname] : []),
+    ...extraArgs,
+  ];
   if (paginate) {
     args.push('--paginate', '--jq', '.[]');
   }
@@ -266,12 +337,22 @@ export function ghApiJson(
  * file's existing role as the shared `gh`-execution module for `ghText` /
  * `ghApiJson`. Uses `ghText`'s own default timeout (no explicit override
  * here, unchanged from this function's pre-extraction behavior).
+ *
+ * Targets the correct GHES host via {@link resolveGhApiHostname} (#1962)
+ * instead of always defaulting to `github.com`.
  */
 export function ghGraphql(
   query: string,
   variables: Record<string, string | number | null | undefined>,
 ): unknown {
-  const args = ['api', 'graphql', '-f', `query=${query}`];
+  const hostname = resolveGhApiHostname();
+  const args = [
+    'api',
+    'graphql',
+    ...(hostname ? ['--hostname', hostname] : []),
+    '-f',
+    `query=${query}`,
+  ];
   for (const [key, value] of Object.entries(variables)) {
     if (value === null || value === undefined) continue;
     if (typeof value === 'number') {

--- a/tests/gh-exec.test.mts
+++ b/tests/gh-exec.test.mts
@@ -10,11 +10,52 @@ import {
   GH_TEXT_LOOP_OPTIONS,
   GH_TEXT_LOOP_TIMEOUT_OPTIONS,
   ghApiJson,
+  ghGraphql,
   ghText,
   ghTextAsync,
+  resolveGhApiHostname,
   safeGhText,
   withBoundedRetry,
 } from '../src/scripts/gh-exec.mts';
+
+/**
+ * Save/restore `GH_HOST` and `GITHUB_SERVER_URL` around a test body (the
+ * `stubGh`/`process.env.PATH` pattern already used below) so a test that
+ * sets either variable can never leak into a later test -- both matter
+ * because CI itself defines `GITHUB_SERVER_URL=https://github.com` in the
+ * runner environment (#1962).
+ */
+function withGhHostEnv(
+  overrides: { GH_HOST?: string; GITHUB_SERVER_URL?: string },
+  run: () => void,
+): void {
+  const originalGhHost = process.env.GH_HOST;
+  const originalServerUrl = process.env.GITHUB_SERVER_URL;
+  if (overrides.GH_HOST === undefined) {
+    delete process.env.GH_HOST;
+  } else {
+    process.env.GH_HOST = overrides.GH_HOST;
+  }
+  if (overrides.GITHUB_SERVER_URL === undefined) {
+    delete process.env.GITHUB_SERVER_URL;
+  } else {
+    process.env.GITHUB_SERVER_URL = overrides.GITHUB_SERVER_URL;
+  }
+  try {
+    run();
+  } finally {
+    if (originalGhHost === undefined) {
+      delete process.env.GH_HOST;
+    } else {
+      process.env.GH_HOST = originalGhHost;
+    }
+    if (originalServerUrl === undefined) {
+      delete process.env.GITHUB_SERVER_URL;
+    } else {
+      process.env.GITHUB_SERVER_URL = originalServerUrl;
+    }
+  }
+}
 
 // Stub `gh` on PATH (the discover-roadmap-graph.test.mts / post-idd-marker.test.mts
 // pattern) so every scenario below exercises the real execFileSync + child-process
@@ -214,6 +255,119 @@ process.stdout.write('{}');
       'repos/o/r/issues/1',
       '--jq',
       '.title',
+    ]);
+  } finally {
+    restore();
+  }
+});
+
+test('resolveGhApiHostname returns undefined with no GH_HOST / GITHUB_SERVER_URL signal', () => {
+  withGhHostEnv({}, () => {
+    assert.equal(resolveGhApiHostname(), undefined);
+  });
+});
+
+test('resolveGhApiHostname returns undefined when GH_HOST is set, even alongside a GHES GITHUB_SERVER_URL (#1962)', () => {
+  withGhHostEnv(
+    {
+      GH_HOST: 'ghes.example.com',
+      GITHUB_SERVER_URL: 'https://other-ghes.example.com',
+    },
+    () => {
+      // gh already reads GH_HOST itself; a --hostname override here would
+      // be redundant at best and could disagree with an operator's
+      // explicit choice at worst.
+      assert.equal(resolveGhApiHostname(), undefined);
+    },
+  );
+});
+
+test('resolveGhApiHostname returns undefined for GITHUB_SERVER_URL=https://github.com (no behavior change on github.com, #1962)', () => {
+  withGhHostEnv({ GITHUB_SERVER_URL: 'https://github.com' }, () => {
+    assert.equal(resolveGhApiHostname(), undefined);
+  });
+});
+
+test('resolveGhApiHostname strips scheme and trailing slash for a GHES GITHUB_SERVER_URL (#1962)', () => {
+  withGhHostEnv({ GITHUB_SERVER_URL: 'https://ghes.example.com/' }, () => {
+    assert.equal(resolveGhApiHostname(), 'ghes.example.com');
+  });
+});
+
+test('resolveGhApiHostname lowercases a mixed-case GHES host and tolerates http scheme (#1962)', () => {
+  withGhHostEnv({ GITHUB_SERVER_URL: 'http://GHES.Example.com' }, () => {
+    assert.equal(resolveGhApiHostname(), 'ghes.example.com');
+  });
+});
+
+test('resolveGhApiHostname returns undefined for an empty GITHUB_SERVER_URL', () => {
+  withGhHostEnv({ GITHUB_SERVER_URL: '' }, () => {
+    assert.equal(resolveGhApiHostname(), undefined);
+  });
+});
+
+test('ghApiJson adds --hostname before extraArgs on a GHES GITHUB_SERVER_URL, and never on github.com (#1962)', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-gh-exec-test-'));
+  const argsFile = join(tempRoot, 'args.json');
+  const restore = stubGh(`
+const fs = require('node:fs');
+fs.writeFileSync(${JSON.stringify(argsFile)}, JSON.stringify(process.argv.slice(2)));
+process.stdout.write('{}');
+`);
+  try {
+    withGhHostEnv({ GITHUB_SERVER_URL: 'https://ghes.example.com' }, () => {
+      ghApiJson('repos/o/r/issues/1', { extraArgs: ['--jq', '.title'] });
+    });
+    assert.deepEqual(JSON.parse(readFileSync(argsFile, 'utf8')), [
+      'api',
+      'repos/o/r/issues/1',
+      '--hostname',
+      'ghes.example.com',
+      '--jq',
+      '.title',
+    ]);
+    withGhHostEnv({ GITHUB_SERVER_URL: 'https://github.com' }, () => {
+      ghApiJson('repos/o/r/issues/1', { extraArgs: ['--jq', '.title'] });
+    });
+    assert.deepEqual(JSON.parse(readFileSync(argsFile, 'utf8')), [
+      'api',
+      'repos/o/r/issues/1',
+      '--jq',
+      '.title',
+    ]);
+  } finally {
+    restore();
+  }
+});
+
+test('ghGraphql adds --hostname before -f query on a GHES GITHUB_SERVER_URL, and never on github.com (#1962)', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-gh-exec-test-'));
+  const argsFile = join(tempRoot, 'args.json');
+  const restore = stubGh(`
+const fs = require('node:fs');
+fs.writeFileSync(${JSON.stringify(argsFile)}, JSON.stringify(process.argv.slice(2)));
+process.stdout.write('{}');
+`);
+  try {
+    withGhHostEnv({ GITHUB_SERVER_URL: 'https://ghes.example.com' }, () => {
+      ghGraphql('query { viewer { login } }', {});
+    });
+    assert.deepEqual(JSON.parse(readFileSync(argsFile, 'utf8')), [
+      'api',
+      'graphql',
+      '--hostname',
+      'ghes.example.com',
+      '-f',
+      'query=query { viewer { login } }',
+    ]);
+    withGhHostEnv({ GITHUB_SERVER_URL: 'https://github.com' }, () => {
+      ghGraphql('query { viewer { login } }', {});
+    });
+    assert.deepEqual(JSON.parse(readFileSync(argsFile, 'utf8')), [
+      'api',
+      'graphql',
+      '-f',
+      'query=query { viewer { login } }',
     ]);
   } finally {
     restore();


### PR DESCRIPTION
## Summary

- `gh api` / `gh api graphql` resolve their target host from `GH_HOST`/`--hostname`, or the CLI's single configured/authenticated host, defaulting to `github.com` — they do **not** infer it from the checked-out repository's git remote the way `gh pr view`/`gh issue edit` do. On a GitHub Enterprise Server (GHES) repository, `src/scripts/gh-exec.mts`'s shared `ghApiJson()`/`ghGraphql()` wrappers therefore kept targeting `api.github.com` with `GH_TOKEN`, leaving `GH_ENTERPRISE_TOKEN` (set alongside it by #1946/#1959) unread.
- Add `resolveGhApiHostname()` and thread its result into both wrappers as an explicit `--hostname` flag, only when it resolves to something other than `github.com` — so argv on `github.com` (this repository's own CI) is byte-identical to before. In GitHub Actions the host is derived from the `GITHUB_SERVER_URL` default environment variable (no workflow `env:` change needed); outside Actions it defers to an explicit `GH_HOST` or `gh`'s own single-authenticated-host default, matching `gh`'s documented resolution order (`gh help environment`).
- Updated `idd-template/ONBOARDING.md`'s GHES caveat (added by #1959) to describe the shipped behavior instead of "needs its own design."

## Scope note (read before reviewing)

I audited every `src/scripts/*.mts` file that shells out `gh api`: only **3 files** (`advisory-convergence.mts` — the CI-hosted `idd-advisory-convergence` required check — `review-clause.mts`, and `live-status-digest.mts`) actually call the shared `ghApiJson`/`ghGraphql` from `gh-exec.mts` and are fixed by this change. Roughly 15 other helpers (including `idd-doctor.mts`, `claim-approval-gate.mts`, `pre-merge-readiness.mts`, `advisory-wait-state.mts`, and others) maintain their **own local** `gh api` wrapper functions that duplicate similar logic instead of importing the shared one, so their host resolution is **unchanged** by this PR. This is a pre-existing architectural pattern, not something #1962 introduces — consolidating every local wrapper onto the shared one would touch far more files than a "Limited scope" fix should, so I left it as a documented residual in `ONBOARDING.md` rather than silently expanding scope. `idd-doctor.mts` specifically uses its own `runCommand('gh', [...])` abstraction with a different signature/contract, so it isn't a drop-in swap either.

## Design notes

- **Why no `GH_HOST` env mutation**: only a per-invocation `--hostname` flag is added; the process environment is never touched. `GH_HOST`, when already set, is left alone (`gh` already resolves it correctly) — this also sidesteps the issue's own flagged risk of a malformed `GH_HOST` value breaking every `gh` call in this repository's own CI.
- **Why `GITHUB_SERVER_URL` and not a git-remote parse**: it's a GitHub Actions default environment variable, always a well-formed `scheme://host` URL supplied by the runner itself — no parsing of untrusted input, no extra API/network call, and it's automatically present without any workflow file changes.
- **Local/non-Actions callers** (e.g. a developer running `idd-doctor` against a GHES clone): unaffected by this PR either way — `gh`'s own `GH_HOST`/single-authenticated-host resolution already applies unchanged.

## Test plan

- [x] `pnpm run build` (regenerates `scripts/gh-exec.mjs`; `bin/*.mjs` mode-bit noise from `pnpm run build`'s biome step is pre-existing/environment-local — confirmed present on `origin/main` before this branch existed — and is not included in this PR's diff)
- [x] `node --test tests/*.test.mts` — 3406/3406 passing, no regressions
- [x] New unit tests for `resolveGhApiHostname` (GH_HOST precedence, github.com no-op, GHES scheme/case/trailing-slash handling) and argv-forwarding tests for `ghApiJson`/`ghGraphql` (`tests/gh-exec.test.mts`)
- [x] `pnpm run typecheck`
- [x] `npx biome check`, `npx dprint check "**/*.md"`, `npx markdownlint-cli2 "**/*.md"`
- [x] `node scripts/audit-docs.mjs --check`, `node scripts/audit-code-span-wrap.mjs`
- [x] `npx cspell lint "**" --no-progress` — 0 issues across 678 files
- [x] `node scripts/idd-doctor.mjs` — passed (only pre-existing, unrelated warnings)
- [x] `pnpm run lint:minimum` components all verified individually above

Closes #1962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRtbwNrzaPTHPHBtaePrdT
