### PR TITLE
fix(cli-args): reserve a declared flag's own alias before disambiguation

### DIFF
--- a/scripts/cli-args.mjs
+++ b/scripts/cli-args.mjs
@@ -110,6 +110,24 @@ const NODE_OPTION_KEY_PATTERN = /^--[A-Za-z0-9][A-Za-z0-9-]*$/;
  * `string`-type flag is rewritten onto that flag's long `=` form before
  * `util.parseArgs` ever sees it: `-p=5` becomes `--pr=5`, `-p=-3` becomes
  * `--pr=-3`. A short letter with no matching flag entry is left untouched.
+ *
+ * **Declared-alias reservation (#1961).** The two-token rewrite above is
+ * only safe when the following token is a genuinely arbitrary value (a
+ * negative number, an unrelated string starting with a dash, and so on).
+ * When that token instead exactly matches a short alias the spec itself
+ * declares -- for any flag, not only a string-typed one, e.g. a boolean
+ * help flag's own short letter -- rewriting it would silently swallow a
+ * real flag as another flag's literal value instead of ever reaching
+ * `util.parseArgs` as itself. A declared long option form never hits this
+ * problem in the first place: it already falls outside the two-token
+ * rewrite entirely, since a value starting with `--` is excluded from
+ * `isAmbiguousValue` above. So every declared short form is carved out of
+ * the rewrite, left exactly as typed; `util.parseArgs` then reports its
+ * own ambiguous-value error for it (re-shaped by {@link toRepoShapedError}
+ * into this module's usual missing-value idiom), the same clear failure
+ * this module already produces when a flag's value is missing outright,
+ * rather than resolving to a wrong literal value one flag can never
+ * actually mean for another.
  */
 // Matches a short option's `=value` form as ONE argv token, e.g. `-p=5`
 // or `-p=-3` -- captures the short letter and everything after `=`
@@ -126,6 +144,16 @@ function disambiguateSingleDashValues(argv, spec) {
     Object.entries(spec)
       .filter(([, flagSpec]) => flagSpec.type === 'string' && flagSpec.short)
       .map(([dashedKey, flagSpec]) => [`-${flagSpec.short}`, dashedKey]),
+  );
+  // #1961: every declared short alias, regardless of the owning flag's
+  // `type` -- unlike `shortToLong` above (string-typed flags only, since
+  // that map feeds the `-x=value` single-token rewrite, which only makes
+  // sense for a value-taking flag), a boolean flag's short alias (e.g. a
+  // help flag) is just as reservable as a string flag's.
+  const declaredShortForms = new Set(
+    Object.values(spec)
+      .filter((flagSpec) => flagSpec.short)
+      .map((flagSpec) => `-${flagSpec.short}`),
   );
   const rewritten = [];
   for (let index = 0; index < argv.length; index += 1) {
@@ -145,12 +173,16 @@ function disambiguateSingleDashValues(argv, spec) {
       }
     }
     // Two-token case: `--flag VALUE` / `-p VALUE` where VALUE starts with
-    // a single dash and could plausibly be another option.
+    // a single dash and could plausibly be another option. Excludes a
+    // VALUE that is itself a declared short alias (#1961 above) -- that
+    // token is reserved, never rewritten into another flag's literal
+    // value, regardless of which flag precedes it.
     const next = argv[index + 1];
     const isAmbiguousValue =
       typeof next === 'string' &&
       next.startsWith('-') &&
-      !next.startsWith('--');
+      !next.startsWith('--') &&
+      !declaredShortForms.has(next);
     if (stringFlags.has(token) && isAmbiguousValue) {
       rewritten.push(`${token}=${next}`);
       index += 1;

--- a/src/scripts/cli-args.mts
+++ b/src/scripts/cli-args.mts
@@ -160,6 +160,24 @@ const NODE_OPTION_KEY_PATTERN = /^--[A-Za-z0-9][A-Za-z0-9-]*$/;
  * `string`-type flag is rewritten onto that flag's long `=` form before
  * `util.parseArgs` ever sees it: `-p=5` becomes `--pr=5`, `-p=-3` becomes
  * `--pr=-3`. A short letter with no matching flag entry is left untouched.
+ *
+ * **Declared-alias reservation (#1961).** The two-token rewrite above is
+ * only safe when the following token is a genuinely arbitrary value (a
+ * negative number, an unrelated string starting with a dash, and so on).
+ * When that token instead exactly matches a short alias the spec itself
+ * declares -- for any flag, not only a string-typed one, e.g. a boolean
+ * help flag's own short letter -- rewriting it would silently swallow a
+ * real flag as another flag's literal value instead of ever reaching
+ * `util.parseArgs` as itself. A declared long option form never hits this
+ * problem in the first place: it already falls outside the two-token
+ * rewrite entirely, since a value starting with `--` is excluded from
+ * `isAmbiguousValue` above. So every declared short form is carved out of
+ * the rewrite, left exactly as typed; `util.parseArgs` then reports its
+ * own ambiguous-value error for it (re-shaped by {@link toRepoShapedError}
+ * into this module's usual missing-value idiom), the same clear failure
+ * this module already produces when a flag's value is missing outright,
+ * rather than resolving to a wrong literal value one flag can never
+ * actually mean for another.
  */
 // Matches a short option's `=value` form as ONE argv token, e.g. `-p=5`
 // or `-p=-3` -- captures the short letter and everything after `=`
@@ -181,6 +199,16 @@ function disambiguateSingleDashValues(
       .filter(([, flagSpec]) => flagSpec.type === 'string' && flagSpec.short)
       .map(([dashedKey, flagSpec]) => [`-${flagSpec.short}`, dashedKey]),
   );
+  // #1961: every declared short alias, regardless of the owning flag's
+  // `type` -- unlike `shortToLong` above (string-typed flags only, since
+  // that map feeds the `-x=value` single-token rewrite, which only makes
+  // sense for a value-taking flag), a boolean flag's short alias (e.g. a
+  // help flag) is just as reservable as a string flag's.
+  const declaredShortForms = new Set(
+    Object.values(spec)
+      .filter((flagSpec) => flagSpec.short)
+      .map((flagSpec) => `-${flagSpec.short}`),
+  );
   const rewritten: string[] = [];
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
@@ -201,12 +229,16 @@ function disambiguateSingleDashValues(
     }
 
     // Two-token case: `--flag VALUE` / `-p VALUE` where VALUE starts with
-    // a single dash and could plausibly be another option.
+    // a single dash and could plausibly be another option. Excludes a
+    // VALUE that is itself a declared short alias (#1961 above) -- that
+    // token is reserved, never rewritten into another flag's literal
+    // value, regardless of which flag precedes it.
     const next = argv[index + 1];
     const isAmbiguousValue =
       typeof next === 'string' &&
       next.startsWith('-') &&
-      !next.startsWith('--');
+      !next.startsWith('--') &&
+      !declaredShortForms.has(next);
     if (stringFlags.has(token) && isAmbiguousValue) {
       rewritten.push(`${token}=${next}`);
       index += 1;

--- a/tests/cli-args.test.mts
+++ b/tests/cli-args.test.mts
@@ -109,6 +109,74 @@ test('parseCliArgs: a short alias still rejects a flag-shaped value', () => {
   });
 });
 
+// --- Declared-alias reservation (#1961) --------------------------------------
+// A value token that itself exactly matches one of the spec's own declared
+// short option forms must never be silently swallowed as a preceding string
+// flag's literal value -- reserve it so the caller gets a clear parse error
+// instead. Long option forms already can't hit this: a value starting with
+// -- is excluded from the ambiguity rewrite entirely (see the "rejects a
+// flag-shaped value" test above), so this section covers the short-form gap
+// #1961 reported (found on rerun-advisory-convergence.mts's --check-name,
+// reproduced generically here via SAMPLE_SPEC's --help/-h).
+
+test('parseCliArgs: a declared short alias (the help flag) after a string flag is reserved, not swallowed as its value', () => {
+  assert.throws(() => parseCliArgs(['--owner', '-h'], SAMPLE_SPEC), {
+    message: 'missing value for argument: --owner',
+  });
+});
+
+test('parseCliArgs: the reservation also covers a declared short alias for another STRING flag, not just a boolean one', () => {
+  // The reservation is not help-specific: --pr's own short alias (-p) must
+  // be just as reserved as --help's when it appears as another flag's
+  // candidate value.
+  assert.throws(() => parseCliArgs(['--owner', '-p'], SAMPLE_SPEC), {
+    message: 'missing value for argument: --owner',
+  });
+});
+
+test('parseCliArgs: the short-alias-as-flag two-token path also reserves a declared alias for its value', () => {
+  // Mirrors the '-p', '-3' passthrough test above, but with a reserved
+  // alias in the value position instead of an ordinary negative number:
+  // the token-itself-is-a-short-alias branch must apply the same
+  // reservation as the long-flag-token branch tested just above.
+  assert.throws(() => parseCliArgs(['-p', '-h'], SAMPLE_SPEC), {
+    message: 'missing value for argument: -p',
+  });
+});
+
+test('parseCliArgs: an UNDECLARED single-dash token is still accepted as a literal value (reservation is scoped to real aliases only)', () => {
+  // No flag in SAMPLE_SPEC declares -x as a short form, so it must keep
+  // flowing through as an ordinary value -- same established contract as
+  // the -3 negative-number case, just spelled with a letter.
+  const { values } = parseCliArgs(['--owner', '-x'], SAMPLE_SPEC);
+  assert.equal(values.owner, '-x');
+});
+
+test('parseCliArgs: standalone -h still resolves to help once nothing precedes it to swallow it', () => {
+  // The reservation only changes the two-token ambiguous-value path above;
+  // it must not regress -h's ordinary standalone recognition.
+  const result = parseCliArgs(['-h'], SAMPLE_SPEC);
+  assert.equal(result.help, true);
+});
+
+test('parseCliArgs: the exact #1961 reproduction shape (a --title/--number/--help spec mirroring branch-name.mts)', () => {
+  // node bin/idd-branch-name.mjs --title -h --number 5 used to print
+  // issue/5-h (exit 0) instead of showing help or failing -- --title had
+  // no short alias of its own, but -h (declared for --help) was still
+  // silently swallowed as --title's literal value. This spec mirrors
+  // branch-name.mts's real flags to keep the regression traceable to the
+  // reported command.
+  const REPRO_SPEC = {
+    '--number': { type: 'string' },
+    '--title': { type: 'string' },
+    '--help': { type: 'boolean', short: 'h' },
+  } as const;
+  assert.throws(
+    () => parseCliArgs(['--title', '-h', '--number', '5'], REPRO_SPEC),
+    { message: 'missing value for argument: --title' },
+  );
+});
+
 test('parseCliArgs: repeated non-multiple flags -- last one wins (Node native behavior)', () => {
   const { values } = parseCliArgs(['--pr', '1', '--pr', '2'], SAMPLE_SPEC);
   assert.equal(values.pr, '2');

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -2157,19 +2157,24 @@ test('parseArgs fails fast when --owner is immediately followed by another long 
 });
 
 // parseCliArgs()'s own generic single-dash-value disambiguation (see
-// cli-args.mts's disambiguateSingleDashValues doc comment) now applies to
-// every declared string flag, not just --pr -- one of this migration's
-// intentional, disclosed behavior changes (#1955). `-h` after --owner no
-// longer looks like an ambiguous short option to node:util: it is
-// rewritten to `--owner=-h` up front, so --owner captures the literal
-// value "-h" (which passes the --owner identifier-character check) and
-// parsing instead fails on the --owner/--repo pairing rule below, since
-// --repo is still missing.
-test('parseArgs resolves --owner followed by the short help flag as a literal value, then fails the --owner/--repo pairing check', () => {
-  assert.throws(
-    () => parseArgs(['--owner', '-h']),
-    /provide both --owner and --repo, or neither/,
-  );
+// cli-args.mts's disambiguateSingleDashValues doc comment) applies to
+// every declared string flag, not just --pr -- disclosed as an
+// intentional #1955 migration behavior change at the time. That
+// disclosure named a real gap: `-h` after --owner used to look like an
+// ordinary ambiguous value to the rewrite, so it was captured as --owner's
+// literal value "-h" instead of ever being recognized as the declared
+// --help alias it actually is. #1961 closes that gap: a value token that
+// itself exactly matches one of the spec's own declared short option
+// forms (here, -h for --help) is now reserved and left un-rewritten, so
+// node:util's own strict-mode parser sees the genuinely ambiguous
+// `--owner -h` pair and reports its usual ambiguous-value error --
+// re-shaped by parseCliArgs() onto the same missing-value idiom every
+// other missing --owner value already gets, rather than resolving to a
+// value --owner can never actually mean.
+test('parseArgs fails fast when --owner is immediately followed by the short help flag, instead of silently swallowing it as a literal value (#1961)', () => {
+  assert.throws(() => parseArgs(['--owner', '-h']), {
+    message: 'missing value for argument: --owner',
+  });
 });
 
 test('parseArgs fails fast when --repo has a missing value', () => {


### PR DESCRIPTION
# Summary

`disambiguateSingleDashValues()` (`src/scripts/cli-args.mts`) rewrote
`--flag VALUE` into `--flag=VALUE` whenever `VALUE` started with a single
dash, even when `VALUE` exactly matched one of the CLI spec's own
declared short option form (e.g. `-h` for a `--help` boolean flag). That
silently swallowed a real flag as another flag's literal value instead
of ever letting it reach `util.parseArgs` as itself — found during
#1955's review on `rerun-advisory-convergence.mts`'s `--check-name` flag,
and confirmed systemic to every already-migrated `idd-*` helper sharing
this wrapper (reproduced here against `branch-name.mts`'s spec too, e.g.
`node bin/idd-branch-name.mjs --title -h --number 5` used to print
`issue/5-h` instead of showing help or erroring).

This PR reserves every value token that exactly matches a declared short
form, across all flag types (not just `string`), from the ambiguity
rewrite. A reserved token now falls through to `util.parseArgs`
unmodified, which reports its own ambiguous-value error, re-shaped by the
existing `toRepoShapedError()` helper into this repository's established
`missing value for argument: <flag>` idiom — the same clear failure mode
a genuinely missing value already gets. Declared long option forms
(`--flag`) already avoided this problem, since a value starting with
`--` was already excluded from the rewrite before this change.

## Linked issue

Closes #1961

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The one existing test (`tests/rerun-advisory-convergence.test.mts`) that
had documented the old swallowing behavior as an intentional, disclosed
#1955 migration trade-off is updated in this PR — #1961 supersedes that
disclosure with the fix, and the test/comment now reflect the corrected
contract instead of the superseded one.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (full suite: 3404/3404 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs changed)
- [x] `node scripts/idd-doctor.mjs` (if applicable)
- [x] manual repro: `node bin/idd-branch-name.mjs --title -h --number 5`
      now fails with `missing value for argument: --title` instead of
      silently printing `issue/5-h`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
