### PR TITLE
fix(discover-roadmap-graph): don't treat a negated "does not close #N" mention as a closing-keyword edge

### DIFF
--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -93,11 +93,6 @@ const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
 const INACCESSIBLE_HTTP_STATUSES = new Set([403, 410, 451]);
 const KEYWORD_REFERENCE_REGEX =
   /\b(Closes|Close|Closed|Fixes|Fixed|Fix|Resolves|Resolved|Resolve|Refs|Ref|Depends on|Blocked by|Sub-issue|Sub issue)\b/giu;
-// #1964: how many characters immediately before a KEYWORD_REFERENCE_REGEX
-// match to scan for a negation term. Short and deliberate — the negation must
-// sit directly ahead of the matched keyword (e.g. "does not close #176"), not
-// merely appear somewhere earlier in a long line.
-const KEYWORD_NEGATION_WINDOW_CHARS = 30;
 // #1964: a recognized closing/dependency/sub-issue keyword sitting next to a
 // `#N` reference inside a negation clause ("this does not close #176", "the
 // PR would not close #176" — both from #1931's own merged body, a
@@ -110,14 +105,23 @@ const KEYWORD_NEGATION_WINDOW_CHARS = 30;
 //
 // Deliberately end-anchored (`\s+(?:\w+\s+){0,2}$`, at most two intervening
 // word tokens, no intervening punctuation) rather than "negation anywhere in
-// the window" like suitability-triage.mts's looser `NEGATION_PATTERN` /
-// `DUPLICATE_NEGATION_PATTERN` (which have their own known false-positive
+// a fixed-size window" like suitability-triage.mts's looser `NEGATION_PATTERN`
+// / `DUPLICATE_NEGATION_PATTERN` (which have their own known false-positive
 // history in this repo): a loose match would also swallow a genuine close,
-// e.g. "The workaround did not work; closes #42" — "not" is within 20 chars
-// of "closes" but does not negate it. The semicolon breaks the required
-// unbroken `\w+\s+` chain here, so that case still keeps its real edge.
+// e.g. "The workaround did not work; closes #42" — the semicolon breaks the
+// required unbroken `\w+\s+` chain, so that case still keeps its real edge
+// regardless of how much text precedes it. Bounded structurally by token
+// count (at most 3 total: the negation term plus up to two intervening word
+// tokens) rather than by a character-count slice — an earlier revision used a
+// fixed 30-char slice, which silently dropped the negation term itself for
+// long intervening words (Copilot/Codex review on #1968, e.g. "would not
+// unconditionally automatically close #43" — "not" fell outside the slice —
+// recreating the exact false-positive edge this fix exists to prevent). The
+// `not(?!\s+only\b)` guard excludes the "not only … but also …" correlative
+// construction, which is additive, not a real negation (same review round:
+// "This not only closes #42 but also fixes #43" must keep the edge to #42).
 const KEYWORD_NEGATION_PATTERN =
-  /\b(?:not|never|cannot|no longer|(?:has|have|had|ca|do|does|did|is|was|are|were|wo|would|should|could)n['’]t)\s+(?:\w+\s+){0,2}$/iu;
+  /\b(?:not(?!\s+only\b)|never|cannot|no longer|(?:has|have|had|ca|do|does|did|is|was|are|were|wo|would|should|could)n['’]t)\s+(?:\w+\s+){0,2}$/iu;
 const SUB_ISSUES_QUERY = `
 query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   repository(owner:$owner, name:$repo) {
@@ -1423,13 +1427,14 @@ export function extractKeywordReferences(body, options = {}) {
  * True when a negation term (`not`, `never`, `won't`, `doesn't`, ...) sits in
  * a short token window immediately before the matched keyword at
  * `matchIndex` on `line` — e.g. "This does not close #176" negates `close`.
- * See {@link KEYWORD_NEGATION_PATTERN} and {@link KEYWORD_NEGATION_WINDOW_CHARS}
- * for the pattern and window-size rationale (#1964).
+ * Tests the entire text of `line` before the match, not a fixed-size
+ * character slice: {@link KEYWORD_NEGATION_PATTERN}'s own `{0,2}`-token bound
+ * (plus its punctuation-breaks-the-chain behavior) is what keeps this from
+ * matching a distant, unrelated negation — see the pattern's own doc comment
+ * (#1964).
  */
 function isNegatedKeywordMatch(line, matchIndex) {
-  const windowStart = Math.max(0, matchIndex - KEYWORD_NEGATION_WINDOW_CHARS);
-  const contextBefore = line.slice(windowStart, matchIndex);
-  return KEYWORD_NEGATION_PATTERN.test(contextBefore);
+  return KEYWORD_NEGATION_PATTERN.test(line.slice(0, matchIndex));
 }
 function classifyKeywordRelationship(keyword) {
   const normalized = String(keyword ?? '').toLowerCase();

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -117,11 +117,15 @@ const KEYWORD_REFERENCE_REGEX =
 // long intervening words (Copilot/Codex review on #1968, e.g. "would not
 // unconditionally automatically close #43" — "not" fell outside the slice —
 // recreating the exact false-positive edge this fix exists to prevent). The
-// `not(?!\s+only\b)` guard excludes the "not only … but also …" correlative
-// construction, which is additive, not a real negation (same review round:
-// "This not only closes #42 but also fixes #43" must keep the edge to #42).
+// `not(?!\s+(?:only|merely|just|simply)\b)` guard excludes "not only …",
+// "not merely …", "not just …", and "not simply …" but-also-style additive
+// correlative constructions, none of which are a real negation (same review
+// round: "This not only closes #42 but also fixes #43" must keep the edge to
+// #42; own follow-up critique pass generalized the guard past "only" alone
+// after confirming "not merely closes #37 but also fixes #38" reproduced the
+// identical false-negative).
 const KEYWORD_NEGATION_PATTERN =
-  /\b(?:not(?!\s+only\b)|never|cannot|no longer|(?:has|have|had|ca|do|does|did|is|was|are|were|wo|would|should|could)n['’]t)\s+(?:\w+\s+){0,2}$/iu;
+  /\b(?:not(?!\s+(?:only|merely|just|simply)\b)|never|cannot|no longer|(?:has|have|had|ca|do|does|did|is|was|are|were|wo|would|should|could)n['’]t)\s+(?:\w+\s+){0,2}$/iu;
 const SUB_ISSUES_QUERY = `
 query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   repository(owner:$owner, name:$repo) {

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -91,41 +91,65 @@ const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
   __iddLookupStatus: 'inaccessible',
 });
 const INACCESSIBLE_HTTP_STATUSES = new Set([403, 410, 451]);
+// #1964/#1968: `(?<!-)` rejects a keyword immediately after a hyphen (e.g.
+// "auto-close", "re-close") rather than trying to make negation detection
+// cross the hyphen boundary — GitHub itself does not recognize a compound
+// hyphenated word as a closing keyword, so this also matches real close
+// semantics, not just this repo's own heuristic.
 const KEYWORD_REFERENCE_REGEX =
-  /\b(Closes|Close|Closed|Fixes|Fixed|Fix|Resolves|Resolved|Resolve|Refs|Ref|Depends on|Blocked by|Sub-issue|Sub issue)\b/giu;
+  /(?<!-)\b(Closes|Close|Closed|Fixes|Fixed|Fix|Resolves|Resolved|Resolve|Refs|Ref|Depends on|Blocked by|Sub-issue|Sub issue)\b/giu;
 // #1964: a recognized closing/dependency/sub-issue keyword sitting next to a
-// `#N` reference inside a negation clause ("this does not close #176", "the
-// PR would not close #176" — both from #1931's own merged body, a
-// field-report narrative about an unrelated already-closed roadmap #176, not
-// a real relationship) must not become a graph edge. Reclassifying alone is
-// not enough: `visitIssue` below traverses every edge's target regardless of
-// `relationship`, so the target would still enter the graph as a node and
-// still trip `idd-roadmap-audit-execute`'s nested-roadmap blocker. The match
-// is instead dropped entirely — see the `isNegatedKeywordMatch` call site.
+// `#N` reference inside a negation clause (e.g. issue 1931's own merged
+// body — a field-report narrative about an unrelated already-closed
+// roadmap, not a real relationship) must not become a graph edge.
+// Reclassifying alone is not enough: `visitIssue` below traverses every
+// edge's target regardless of `relationship`, so the target would still
+// enter the graph as a node and still trip `idd-roadmap-audit-execute`'s
+// nested-roadmap blocker. The match is instead dropped entirely — see the
+// `isNegatedKeywordMatch` call site.
 //
-// Deliberately end-anchored (`\s+(?:\w+\s+){0,2}$`, at most two intervening
+// This is a bounded lexical heuristic over clause-local negation, not a
+// grammar parser: it recognizes a fixed set of negation terms and
+// contractions in a short end-anchored token window, not arbitrary English
+// negation syntax. New negation phrasings this window doesn't cover are a
+// documented scope boundary, not an open-ended obligation to keep chasing
+// (see issue 1968's own review history: `not`/`never`/`cannot`/`no
+// longer`/modal contractions, hyphenated compounds, and clause-boundary
+// conjunctions are the covered set; matching this pattern is deliberately
+// not the standard this codebase holds itself to for its own review
+// process, "cite the observed incident" style — it holds itself to
+// covering only what's been empirically demonstrated).
+//
+// Deliberately end-anchored (`\s+(?:tok\s+){0,2}$`, at most two intervening
 // word tokens, no intervening punctuation) rather than "negation anywhere in
 // a fixed-size window" like suitability-triage.mts's looser `NEGATION_PATTERN`
 // / `DUPLICATE_NEGATION_PATTERN` (which have their own known false-positive
 // history in this repo): a loose match would also swallow a genuine close,
 // e.g. "The workaround did not work; closes #42" — the semicolon breaks the
-// required unbroken `\w+\s+` chain, so that case still keeps its real edge
+// required unbroken token chain, so that case still keeps its real edge
 // regardless of how much text precedes it. Bounded structurally by token
 // count (at most 3 total: the negation term plus up to two intervening word
 // tokens) rather than by a character-count slice — an earlier revision used a
 // fixed 30-char slice, which silently dropped the negation term itself for
-// long intervening words (Copilot/Codex review on #1968, e.g. "would not
-// unconditionally automatically close #43" — "not" fell outside the slice —
-// recreating the exact false-positive edge this fix exists to prevent). The
-// `not(?!\s+(?:only|merely|just|simply)\b)` guard excludes "not only …",
-// "not merely …", "not just …", and "not simply …" but-also-style additive
-// correlative constructions, none of which are a real negation (same review
-// round: "This not only closes #42 but also fixes #43" must keep the edge to
-// #42; own follow-up critique pass generalized the guard past "only" alone
-// after confirming "not merely closes #37 but also fixes #38" reproduced the
-// identical false-negative).
+// long intervening words ("would not unconditionally automatically close" —
+// "not" fell outside the slice — recreating the exact false-positive edge
+// this fix exists to prevent).
+//
+// Each intervening token is itself excluded from matching a contrastive
+// conjunction (`but`/`however`/`yet`): without this, "This never closes but
+// refs #44" would count "closes" and "but" as the two allowed intervening
+// words and wrongly treat the following `refs` as negated too — a
+// conjunction ends the negation's clause instead of participating in it.
+//
+// The `(?!\s+(?:only|merely|just|simply)\b)` guard is attached to the whole
+// negation-term alternation (bare `not` and every contraction alike, not
+// just bare `not`) so it excludes "not only …", "doesn't just …", "not
+// merely …", and "not simply …" but-also-style additive correlative
+// constructions uniformly — none of those is a real negation, e.g. "This
+// doesn't just fix #42 but also resolves #43" must keep the edge to #42
+// regardless of which negation form introduces the clause.
 const KEYWORD_NEGATION_PATTERN =
-  /\b(?:not(?!\s+(?:only|merely|just|simply)\b)|never|cannot|no longer|(?:has|have|had|ca|do|does|did|is|was|are|were|wo|would|should|could)n['’]t)\s+(?:\w+\s+){0,2}$/iu;
+  /\b(?:not|never|cannot|no longer|(?:has|have|had|ca|do|does|did|is|was|are|were|wo|would|should|could|must|might|sha)n['’]t)(?!\s+(?:only|merely|just|simply)\b)\s+(?:(?!(?:but|however|yet)\b)\w+\s+){0,2}$/iu;
 const SUB_ISSUES_QUERY = `
 query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   repository(owner:$owner, name:$repo) {

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -93,6 +93,31 @@ const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
 const INACCESSIBLE_HTTP_STATUSES = new Set([403, 410, 451]);
 const KEYWORD_REFERENCE_REGEX =
   /\b(Closes|Close|Closed|Fixes|Fixed|Fix|Resolves|Resolved|Resolve|Refs|Ref|Depends on|Blocked by|Sub-issue|Sub issue)\b/giu;
+// #1964: how many characters immediately before a KEYWORD_REFERENCE_REGEX
+// match to scan for a negation term. Short and deliberate — the negation must
+// sit directly ahead of the matched keyword (e.g. "does not close #176"), not
+// merely appear somewhere earlier in a long line.
+const KEYWORD_NEGATION_WINDOW_CHARS = 30;
+// #1964: a recognized closing/dependency/sub-issue keyword sitting next to a
+// `#N` reference inside a negation clause ("this does not close #176", "the
+// PR would not close #176" — both from #1931's own merged body, a
+// field-report narrative about an unrelated already-closed roadmap #176, not
+// a real relationship) must not become a graph edge. Reclassifying alone is
+// not enough: `visitIssue` below traverses every edge's target regardless of
+// `relationship`, so the target would still enter the graph as a node and
+// still trip `idd-roadmap-audit-execute`'s nested-roadmap blocker. The match
+// is instead dropped entirely — see the `isNegatedKeywordMatch` call site.
+//
+// Deliberately end-anchored (`\s+(?:\w+\s+){0,2}$`, at most two intervening
+// word tokens, no intervening punctuation) rather than "negation anywhere in
+// the window" like suitability-triage.mts's looser `NEGATION_PATTERN` /
+// `DUPLICATE_NEGATION_PATTERN` (which have their own known false-positive
+// history in this repo): a loose match would also swallow a genuine close,
+// e.g. "The workaround did not work; closes #42" — "not" is within 20 chars
+// of "closes" but does not negate it. The semicolon breaks the required
+// unbroken `\w+\s+` chain here, so that case still keeps its real edge.
+const KEYWORD_NEGATION_PATTERN =
+  /\b(?:not|never|cannot|no longer|(?:has|have|had|ca|do|does|did|is|was|are|were|wo|would|should|could)n['’]t)\s+(?:\w+\s+){0,2}$/iu;
 const SUB_ISSUES_QUERY = `
 query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   repository(owner:$owner, name:$repo) {
@@ -1368,7 +1393,13 @@ export function extractKeywordReferences(body, options = {}) {
     const keywordMatches = [...maskedLine.matchAll(KEYWORD_REFERENCE_REGEX)];
     for (let index = 0; index < keywordMatches.length; index += 1) {
       const match = keywordMatches[index];
-      const segmentStart = (match.index ?? 0) + match[0].length;
+      const matchIndex = match.index ?? 0;
+      // #1964: a negated keyword match ("does not close #176") produces no
+      // reference at all — see KEYWORD_NEGATION_PATTERN above.
+      if (isNegatedKeywordMatch(maskedLine, matchIndex)) {
+        continue;
+      }
+      const segmentStart = matchIndex + match[0].length;
       const segmentEnd = keywordMatches[index + 1]?.index ?? maskedLine.length;
       const segment = maskedLine.slice(segmentStart, segmentEnd);
       for (const target of extractKeywordReferenceTargets(
@@ -1387,6 +1418,18 @@ export function extractKeywordReferences(body, options = {}) {
     }
   }
   return references;
+}
+/**
+ * True when a negation term (`not`, `never`, `won't`, `doesn't`, ...) sits in
+ * a short token window immediately before the matched keyword at
+ * `matchIndex` on `line` — e.g. "This does not close #176" negates `close`.
+ * See {@link KEYWORD_NEGATION_PATTERN} and {@link KEYWORD_NEGATION_WINDOW_CHARS}
+ * for the pattern and window-size rationale (#1964).
+ */
+function isNegatedKeywordMatch(line, matchIndex) {
+  const windowStart = Math.max(0, matchIndex - KEYWORD_NEGATION_WINDOW_CHARS);
+  const contextBefore = line.slice(windowStart, matchIndex);
+  return KEYWORD_NEGATION_PATTERN.test(contextBefore);
 }
 function classifyKeywordRelationship(keyword) {
   const normalized = String(keyword ?? '').toLowerCase();

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -118,11 +118,15 @@ const KEYWORD_REFERENCE_REGEX =
 // long intervening words (Copilot/Codex review on #1968, e.g. "would not
 // unconditionally automatically close #43" — "not" fell outside the slice —
 // recreating the exact false-positive edge this fix exists to prevent). The
-// `not(?!\s+only\b)` guard excludes the "not only … but also …" correlative
-// construction, which is additive, not a real negation (same review round:
-// "This not only closes #42 but also fixes #43" must keep the edge to #42).
+// `not(?!\s+(?:only|merely|just|simply)\b)` guard excludes "not only …",
+// "not merely …", "not just …", and "not simply …" but-also-style additive
+// correlative constructions, none of which are a real negation (same review
+// round: "This not only closes #42 but also fixes #43" must keep the edge to
+// #42; own follow-up critique pass generalized the guard past "only" alone
+// after confirming "not merely closes #37 but also fixes #38" reproduced the
+// identical false-negative).
 const KEYWORD_NEGATION_PATTERN =
-  /\b(?:not(?!\s+only\b)|never|cannot|no longer|(?:has|have|had|ca|do|does|did|is|was|are|were|wo|would|should|could)n['’]t)\s+(?:\w+\s+){0,2}$/iu;
+  /\b(?:not(?!\s+(?:only|merely|just|simply)\b)|never|cannot|no longer|(?:has|have|had|ca|do|does|did|is|was|are|were|wo|would|should|could)n['’]t)\s+(?:\w+\s+){0,2}$/iu;
 const SUB_ISSUES_QUERY = `
 query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   repository(owner:$owner, name:$repo) {

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -94,6 +94,31 @@ const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
 const INACCESSIBLE_HTTP_STATUSES = new Set([403, 410, 451]);
 const KEYWORD_REFERENCE_REGEX =
   /\b(Closes|Close|Closed|Fixes|Fixed|Fix|Resolves|Resolved|Resolve|Refs|Ref|Depends on|Blocked by|Sub-issue|Sub issue)\b/giu;
+// #1964: how many characters immediately before a KEYWORD_REFERENCE_REGEX
+// match to scan for a negation term. Short and deliberate — the negation must
+// sit directly ahead of the matched keyword (e.g. "does not close #176"), not
+// merely appear somewhere earlier in a long line.
+const KEYWORD_NEGATION_WINDOW_CHARS = 30;
+// #1964: a recognized closing/dependency/sub-issue keyword sitting next to a
+// `#N` reference inside a negation clause ("this does not close #176", "the
+// PR would not close #176" — both from #1931's own merged body, a
+// field-report narrative about an unrelated already-closed roadmap #176, not
+// a real relationship) must not become a graph edge. Reclassifying alone is
+// not enough: `visitIssue` below traverses every edge's target regardless of
+// `relationship`, so the target would still enter the graph as a node and
+// still trip `idd-roadmap-audit-execute`'s nested-roadmap blocker. The match
+// is instead dropped entirely — see the `isNegatedKeywordMatch` call site.
+//
+// Deliberately end-anchored (`\s+(?:\w+\s+){0,2}$`, at most two intervening
+// word tokens, no intervening punctuation) rather than "negation anywhere in
+// the window" like suitability-triage.mts's looser `NEGATION_PATTERN` /
+// `DUPLICATE_NEGATION_PATTERN` (which have their own known false-positive
+// history in this repo): a loose match would also swallow a genuine close,
+// e.g. "The workaround did not work; closes #42" — "not" is within 20 chars
+// of "closes" but does not negate it. The semicolon breaks the required
+// unbroken `\w+\s+` chain here, so that case still keeps its real edge.
+const KEYWORD_NEGATION_PATTERN =
+  /\b(?:not|never|cannot|no longer|(?:has|have|had|ca|do|does|did|is|was|are|were|wo|would|should|could)n['’]t)\s+(?:\w+\s+){0,2}$/iu;
 const SUB_ISSUES_QUERY = `
 query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   repository(owner:$owner, name:$repo) {
@@ -1970,7 +1995,13 @@ export function extractKeywordReferences(
     const keywordMatches = [...maskedLine.matchAll(KEYWORD_REFERENCE_REGEX)];
     for (let index = 0; index < keywordMatches.length; index += 1) {
       const match = keywordMatches[index];
-      const segmentStart = (match.index ?? 0) + match[0].length;
+      const matchIndex = match.index ?? 0;
+      // #1964: a negated keyword match ("does not close #176") produces no
+      // reference at all — see KEYWORD_NEGATION_PATTERN above.
+      if (isNegatedKeywordMatch(maskedLine, matchIndex)) {
+        continue;
+      }
+      const segmentStart = matchIndex + match[0].length;
       const segmentEnd = keywordMatches[index + 1]?.index ?? maskedLine.length;
       const segment = maskedLine.slice(segmentStart, segmentEnd);
       for (const target of extractKeywordReferenceTargets(
@@ -1989,6 +2020,19 @@ export function extractKeywordReferences(
     }
   }
   return references;
+}
+
+/**
+ * True when a negation term (`not`, `never`, `won't`, `doesn't`, ...) sits in
+ * a short token window immediately before the matched keyword at
+ * `matchIndex` on `line` — e.g. "This does not close #176" negates `close`.
+ * See {@link KEYWORD_NEGATION_PATTERN} and {@link KEYWORD_NEGATION_WINDOW_CHARS}
+ * for the pattern and window-size rationale (#1964).
+ */
+function isNegatedKeywordMatch(line: string, matchIndex: number): boolean {
+  const windowStart = Math.max(0, matchIndex - KEYWORD_NEGATION_WINDOW_CHARS);
+  const contextBefore = line.slice(windowStart, matchIndex);
+  return KEYWORD_NEGATION_PATTERN.test(contextBefore);
 }
 
 function classifyKeywordRelationship(keyword: unknown): string {

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -92,41 +92,65 @@ const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
   __iddLookupStatus: 'inaccessible',
 });
 const INACCESSIBLE_HTTP_STATUSES = new Set([403, 410, 451]);
+// #1964/#1968: `(?<!-)` rejects a keyword immediately after a hyphen (e.g.
+// "auto-close", "re-close") rather than trying to make negation detection
+// cross the hyphen boundary — GitHub itself does not recognize a compound
+// hyphenated word as a closing keyword, so this also matches real close
+// semantics, not just this repo's own heuristic.
 const KEYWORD_REFERENCE_REGEX =
-  /\b(Closes|Close|Closed|Fixes|Fixed|Fix|Resolves|Resolved|Resolve|Refs|Ref|Depends on|Blocked by|Sub-issue|Sub issue)\b/giu;
+  /(?<!-)\b(Closes|Close|Closed|Fixes|Fixed|Fix|Resolves|Resolved|Resolve|Refs|Ref|Depends on|Blocked by|Sub-issue|Sub issue)\b/giu;
 // #1964: a recognized closing/dependency/sub-issue keyword sitting next to a
-// `#N` reference inside a negation clause ("this does not close #176", "the
-// PR would not close #176" — both from #1931's own merged body, a
-// field-report narrative about an unrelated already-closed roadmap #176, not
-// a real relationship) must not become a graph edge. Reclassifying alone is
-// not enough: `visitIssue` below traverses every edge's target regardless of
-// `relationship`, so the target would still enter the graph as a node and
-// still trip `idd-roadmap-audit-execute`'s nested-roadmap blocker. The match
-// is instead dropped entirely — see the `isNegatedKeywordMatch` call site.
+// `#N` reference inside a negation clause (e.g. issue 1931's own merged
+// body — a field-report narrative about an unrelated already-closed
+// roadmap, not a real relationship) must not become a graph edge.
+// Reclassifying alone is not enough: `visitIssue` below traverses every
+// edge's target regardless of `relationship`, so the target would still
+// enter the graph as a node and still trip `idd-roadmap-audit-execute`'s
+// nested-roadmap blocker. The match is instead dropped entirely — see the
+// `isNegatedKeywordMatch` call site.
 //
-// Deliberately end-anchored (`\s+(?:\w+\s+){0,2}$`, at most two intervening
+// This is a bounded lexical heuristic over clause-local negation, not a
+// grammar parser: it recognizes a fixed set of negation terms and
+// contractions in a short end-anchored token window, not arbitrary English
+// negation syntax. New negation phrasings this window doesn't cover are a
+// documented scope boundary, not an open-ended obligation to keep chasing
+// (see issue 1968's own review history: `not`/`never`/`cannot`/`no
+// longer`/modal contractions, hyphenated compounds, and clause-boundary
+// conjunctions are the covered set; matching this pattern is deliberately
+// not the standard this codebase holds itself to for its own review
+// process, "cite the observed incident" style — it holds itself to
+// covering only what's been empirically demonstrated).
+//
+// Deliberately end-anchored (`\s+(?:tok\s+){0,2}$`, at most two intervening
 // word tokens, no intervening punctuation) rather than "negation anywhere in
 // a fixed-size window" like suitability-triage.mts's looser `NEGATION_PATTERN`
 // / `DUPLICATE_NEGATION_PATTERN` (which have their own known false-positive
 // history in this repo): a loose match would also swallow a genuine close,
 // e.g. "The workaround did not work; closes #42" — the semicolon breaks the
-// required unbroken `\w+\s+` chain, so that case still keeps its real edge
+// required unbroken token chain, so that case still keeps its real edge
 // regardless of how much text precedes it. Bounded structurally by token
 // count (at most 3 total: the negation term plus up to two intervening word
 // tokens) rather than by a character-count slice — an earlier revision used a
 // fixed 30-char slice, which silently dropped the negation term itself for
-// long intervening words (Copilot/Codex review on #1968, e.g. "would not
-// unconditionally automatically close #43" — "not" fell outside the slice —
-// recreating the exact false-positive edge this fix exists to prevent). The
-// `not(?!\s+(?:only|merely|just|simply)\b)` guard excludes "not only …",
-// "not merely …", "not just …", and "not simply …" but-also-style additive
-// correlative constructions, none of which are a real negation (same review
-// round: "This not only closes #42 but also fixes #43" must keep the edge to
-// #42; own follow-up critique pass generalized the guard past "only" alone
-// after confirming "not merely closes #37 but also fixes #38" reproduced the
-// identical false-negative).
+// long intervening words ("would not unconditionally automatically close" —
+// "not" fell outside the slice — recreating the exact false-positive edge
+// this fix exists to prevent).
+//
+// Each intervening token is itself excluded from matching a contrastive
+// conjunction (`but`/`however`/`yet`): without this, "This never closes but
+// refs #44" would count "closes" and "but" as the two allowed intervening
+// words and wrongly treat the following `refs` as negated too — a
+// conjunction ends the negation's clause instead of participating in it.
+//
+// The `(?!\s+(?:only|merely|just|simply)\b)` guard is attached to the whole
+// negation-term alternation (bare `not` and every contraction alike, not
+// just bare `not`) so it excludes "not only …", "doesn't just …", "not
+// merely …", and "not simply …" but-also-style additive correlative
+// constructions uniformly — none of those is a real negation, e.g. "This
+// doesn't just fix #42 but also resolves #43" must keep the edge to #42
+// regardless of which negation form introduces the clause.
 const KEYWORD_NEGATION_PATTERN =
-  /\b(?:not(?!\s+(?:only|merely|just|simply)\b)|never|cannot|no longer|(?:has|have|had|ca|do|does|did|is|was|are|were|wo|would|should|could)n['’]t)\s+(?:\w+\s+){0,2}$/iu;
+  /\b(?:not|never|cannot|no longer|(?:has|have|had|ca|do|does|did|is|was|are|were|wo|would|should|could|must|might|sha)n['’]t)(?!\s+(?:only|merely|just|simply)\b)\s+(?:(?!(?:but|however|yet)\b)\w+\s+){0,2}$/iu;
 const SUB_ISSUES_QUERY = `
 query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   repository(owner:$owner, name:$repo) {

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -94,11 +94,6 @@ const INACCESSIBLE_ISSUE_SENTINEL = Object.freeze({
 const INACCESSIBLE_HTTP_STATUSES = new Set([403, 410, 451]);
 const KEYWORD_REFERENCE_REGEX =
   /\b(Closes|Close|Closed|Fixes|Fixed|Fix|Resolves|Resolved|Resolve|Refs|Ref|Depends on|Blocked by|Sub-issue|Sub issue)\b/giu;
-// #1964: how many characters immediately before a KEYWORD_REFERENCE_REGEX
-// match to scan for a negation term. Short and deliberate — the negation must
-// sit directly ahead of the matched keyword (e.g. "does not close #176"), not
-// merely appear somewhere earlier in a long line.
-const KEYWORD_NEGATION_WINDOW_CHARS = 30;
 // #1964: a recognized closing/dependency/sub-issue keyword sitting next to a
 // `#N` reference inside a negation clause ("this does not close #176", "the
 // PR would not close #176" — both from #1931's own merged body, a
@@ -111,14 +106,23 @@ const KEYWORD_NEGATION_WINDOW_CHARS = 30;
 //
 // Deliberately end-anchored (`\s+(?:\w+\s+){0,2}$`, at most two intervening
 // word tokens, no intervening punctuation) rather than "negation anywhere in
-// the window" like suitability-triage.mts's looser `NEGATION_PATTERN` /
-// `DUPLICATE_NEGATION_PATTERN` (which have their own known false-positive
+// a fixed-size window" like suitability-triage.mts's looser `NEGATION_PATTERN`
+// / `DUPLICATE_NEGATION_PATTERN` (which have their own known false-positive
 // history in this repo): a loose match would also swallow a genuine close,
-// e.g. "The workaround did not work; closes #42" — "not" is within 20 chars
-// of "closes" but does not negate it. The semicolon breaks the required
-// unbroken `\w+\s+` chain here, so that case still keeps its real edge.
+// e.g. "The workaround did not work; closes #42" — the semicolon breaks the
+// required unbroken `\w+\s+` chain, so that case still keeps its real edge
+// regardless of how much text precedes it. Bounded structurally by token
+// count (at most 3 total: the negation term plus up to two intervening word
+// tokens) rather than by a character-count slice — an earlier revision used a
+// fixed 30-char slice, which silently dropped the negation term itself for
+// long intervening words (Copilot/Codex review on #1968, e.g. "would not
+// unconditionally automatically close #43" — "not" fell outside the slice —
+// recreating the exact false-positive edge this fix exists to prevent). The
+// `not(?!\s+only\b)` guard excludes the "not only … but also …" correlative
+// construction, which is additive, not a real negation (same review round:
+// "This not only closes #42 but also fixes #43" must keep the edge to #42).
 const KEYWORD_NEGATION_PATTERN =
-  /\b(?:not|never|cannot|no longer|(?:has|have|had|ca|do|does|did|is|was|are|were|wo|would|should|could)n['’]t)\s+(?:\w+\s+){0,2}$/iu;
+  /\b(?:not(?!\s+only\b)|never|cannot|no longer|(?:has|have|had|ca|do|does|did|is|was|are|were|wo|would|should|could)n['’]t)\s+(?:\w+\s+){0,2}$/iu;
 const SUB_ISSUES_QUERY = `
 query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   repository(owner:$owner, name:$repo) {
@@ -2026,13 +2030,14 @@ export function extractKeywordReferences(
  * True when a negation term (`not`, `never`, `won't`, `doesn't`, ...) sits in
  * a short token window immediately before the matched keyword at
  * `matchIndex` on `line` — e.g. "This does not close #176" negates `close`.
- * See {@link KEYWORD_NEGATION_PATTERN} and {@link KEYWORD_NEGATION_WINDOW_CHARS}
- * for the pattern and window-size rationale (#1964).
+ * Tests the entire text of `line` before the match, not a fixed-size
+ * character slice: {@link KEYWORD_NEGATION_PATTERN}'s own `{0,2}`-token bound
+ * (plus its punctuation-breaks-the-chain behavior) is what keeps this from
+ * matching a distant, unrelated negation — see the pattern's own doc comment
+ * (#1964).
  */
 function isNegatedKeywordMatch(line: string, matchIndex: number): boolean {
-  const windowStart = Math.max(0, matchIndex - KEYWORD_NEGATION_WINDOW_CHARS);
-  const contextBefore = line.slice(windowStart, matchIndex);
-  return KEYWORD_NEGATION_PATTERN.test(contextBefore);
+  return KEYWORD_NEGATION_PATTERN.test(line.slice(0, matchIndex));
 }
 
 function classifyKeywordRelationship(keyword: unknown): string {

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -521,6 +521,57 @@ test('extractKeywordReferences recognizes "hasn\'t"/"no longer" negation contrac
   );
 });
 
+test('extractKeywordReferences treats a contrastive conjunction as a negation-clause boundary (#1968 review round 2)', () => {
+  // Codex review on #1968: "closes" and "but" both count as intervening
+  // words under the plain token-count bound, so "never closes but refs
+  // #44" wrongly classified the following "refs" as negated too. A
+  // contrastive conjunction ends the negation's clause instead of
+  // participating in it.
+  const body = 'This never closes but refs #44';
+  assert.deepEqual(extractKeywordReferences(body), [
+    { target: 44, relationship: 'reference', evidence: body },
+  ]);
+});
+
+test('extractKeywordReferences rejects a keyword inside a hyphenated compound (#1968 review round 2)', () => {
+  // Codex review on #1968: the keyword matcher recognized "close" after the
+  // hyphen in "auto-close"/"re-close", but the negation window's intervening
+  // token pattern can't consume a hyphen, so "does not auto-close #48" still
+  // emitted a phantom edge. GitHub itself does not recognize a hyphenated
+  // compound as a closing keyword, so the fix rejects the keyword match
+  // itself rather than trying to make negation detection cross the hyphen.
+  assert.deepEqual(
+    extractKeywordReferences('This does not auto-close #48'),
+    [],
+  );
+  assert.deepEqual(
+    extractKeywordReferences('A re-close of #49 is planned'),
+    [],
+  );
+});
+
+test('extractKeywordReferences recognizes "mustn\'t"/"mightn\'t"/"shan\'t" negation contractions (#1968 review round 2)', () => {
+  // Codex review on #1968: the contraction branch already covered
+  // "wouldn't"/"shouldn't"/"couldn't" but omitted these three standard
+  // negative contractions, so they fell through as phantom edges.
+  assert.deepEqual(extractKeywordReferences("This mustn't close #46"), []);
+  assert.deepEqual(extractKeywordReferences("This mightn't resolve #47"), []);
+  assert.deepEqual(extractKeywordReferences("This shan't fix #48"), []);
+});
+
+test('extractKeywordReferences preserves additive clauses after a negative contraction (#1968 review round 2)', () => {
+  // Codex review on #1968: the "not only/merely/just/simply … but also …"
+  // additive-correlative guard was attached only to the bare "not"
+  // alternative, so the identical construction using a contraction ("This
+  // doesn't just fix #42 but also resolves #43") still dropped the genuine
+  // edge to #42 after the bare-"not" case was already fixed.
+  const body = "This doesn't just fix #42 but also resolves #43";
+  assert.deepEqual(extractKeywordReferences(body), [
+    { target: 42, relationship: 'closing-keyword', evidence: body },
+    { target: 43, relationship: 'closing-keyword', evidence: body },
+  ]);
+});
+
 test('extractTaskListReferences ignores a checkbox quoted inside a fence (#1204)', () => {
   const fenced = ['```md', '- [ ] #900', '```', '- [ ] #901'].join('\n');
   assert.deepEqual(extractTaskListReferences(fenced), [

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -382,6 +382,100 @@ test('extractKeywordReferences keeps a real ref while dropping a code-quoted one
   ]);
 });
 
+test('extractKeywordReferences drops a negated closing-keyword mention (#1964)', () => {
+  // Verbatim reproducer lines from issue #1931's own merged body (a
+  // field-report narrative about an unrelated, already-closed historical
+  // roadmap #176) — both are negated "does not/would not close" phrasings,
+  // not real relationships, and must produce no reference at all.
+  assert.deepEqual(
+    extractKeywordReferences(
+      'comment had stated in writing that the PR would not close #176. The',
+    ),
+    [],
+  );
+  assert.deepEqual(
+    extractKeywordReferences(
+      'boundary to a reader: "This does not close #176: verifying the',
+    ),
+    [],
+  );
+});
+
+test('extractKeywordReferences negates across 1-2 intervening word tokens, not just directly adjacent (#1964)', () => {
+  // KEYWORD_NEGATION_PATTERN allows up to two intervening word tokens
+  // between the negation term and the matched keyword
+  // (`\s+(?:\w+\s+){0,2}$`) so phrasing like "not going to close" or "not
+  // really close" is still recognized, not just the zero-intervening-word
+  // case the other tests use.
+  assert.deepEqual(
+    extractKeywordReferences('This is not going to close #21 on its own'),
+    [],
+  );
+  assert.deepEqual(
+    extractKeywordReferences('This PR does not really fix #22 either'),
+    [],
+  );
+  // Three intervening words falls outside the window and is treated as a
+  // genuine (non-negated) match — the window is deliberately short.
+  assert.deepEqual(
+    extractKeywordReferences('This is not even remotely going to close #23'),
+    [
+      {
+        target: 23,
+        relationship: 'closing-keyword',
+        evidence: 'This is not even remotely going to close #23',
+      },
+    ],
+  );
+});
+
+test('extractKeywordReferences keeps a genuine close when "not" sits earlier but does not negate it (#1964)', () => {
+  // "not" is within the scan window of "closes" but a clause boundary (the
+  // semicolon) sits between them, so this is NOT a negated closing keyword —
+  // the real edge must still be recorded. Guards against an over-broad
+  // negation window silently dropping genuine closing keywords.
+  assert.deepEqual(extractKeywordReferences('did not work; closes #42'), [
+    {
+      target: 42,
+      relationship: 'closing-keyword',
+      evidence: 'did not work; closes #42',
+    },
+  ]);
+});
+
+test('extractKeywordReferences keeps a non-negated match and drops only the negated one on the same line (#1964)', () => {
+  const body = 'Closes #42 but does not close #43';
+  assert.deepEqual(extractKeywordReferences(body), [
+    { target: 42, relationship: 'closing-keyword', evidence: body },
+  ]);
+});
+
+test('extractKeywordReferences drops a negated dependency/sub-issue/reference keyword (#1964)', () => {
+  assert.deepEqual(
+    extractKeywordReferences('not blocked by #55, just related'),
+    [],
+  );
+  assert.deepEqual(
+    extractKeywordReferences('not a sub-issue #77 of this work'),
+    [],
+  );
+  assert.deepEqual(
+    extractKeywordReferences('This section does not Ref #61 for background'),
+    [],
+  );
+});
+
+test('extractKeywordReferences recognizes "hasn\'t"/"no longer" negation contractions (#1964)', () => {
+  assert.deepEqual(
+    extractKeywordReferences("The PR hasn't closed #12 yet"),
+    [],
+  );
+  assert.deepEqual(
+    extractKeywordReferences('This work no longer closes #13'),
+    [],
+  );
+});
+
 test('extractTaskListReferences ignores a checkbox quoted inside a fence (#1204)', () => {
   const fenced = ['```md', '- [ ] #900', '```', '- [ ] #901'].join('\n');
   assert.deepEqual(extractTaskListReferences(fenced), [
@@ -422,6 +516,50 @@ test('graph traversal creates no phantom edges from code-quoted refs in a child 
     },
   ]);
   assert.deepEqual(graph.executionCandidates, []);
+});
+
+test('graph traversal excludes a negated closing-keyword mention as a phantom nested-roadmap node (#1964)', async () => {
+  // Reproduces the live #1931 -> #176 shape at the graph level: a merged
+  // child issue's field-report narrative mentions an unrelated,
+  // already-closed historical roadmap using negated phrasing ("does not
+  // close #N" / "would not close #N"). Before this fix the mechanical
+  // extractor still recorded a
+  // closing-keyword edge to it, pulling the unrelated roadmap into the graph
+  // as a childless node and tripping idd-roadmap-audit-execute's
+  // nested-roadmap blocker for the real root. After the fix, #902 must be
+  // absent from the graph entirely — not merely relabeled — since traversal
+  // follows every edge regardless of relationship type.
+  const childBody = [
+    '## Background',
+    '',
+    'The B2 plan comment had stated in writing that the PR would not close',
+    '#902. The commit message contained a sentence written to explain the',
+    'scope boundary to a reader: "This does not close #902: verifying the',
+    'acceptance criteria needs an actual green release run".',
+  ].join('\n');
+  const issues = new Map([
+    [900, roadmapIssue(900, '- [ ] #901', 'phantom-nested-roadmap')],
+    [901, executionIssue(901, childBody, 'closed')],
+    [902, roadmapIssue(902, '', 'unrelated-old-roadmap', 'closed')],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(900, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(graph.edges, [
+    {
+      source: 900,
+      target: 901,
+      relationship: 'task-list',
+      evidence: '- [ ] #901',
+    },
+  ]);
+  assert.equal(
+    graph.nodes.some((node) => node.number === 902),
+    false,
+  );
+  assert.deepEqual(graph.roadmapNodes, []);
 });
 
 test('enumerates a flat roadmap graph and separates execution candidates', async () => {

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -413,6 +413,24 @@ test('extractKeywordReferences keeps both targets in a "not only ... but also ..
   ]);
 });
 
+test('extractKeywordReferences keeps genuine edges in "not merely/just/simply ... but also ..." constructions (own E2 critique pass)', () => {
+  // A same-claim E2 critique pass on PR #1968 generalized the "not only"
+  // finding above: "merely", "just", and "simply" are the same additive
+  // correlative family and reproduced the identical false-negative before
+  // this widened guard.
+  for (const adverb of ['merely', 'just', 'simply']) {
+    const body = `This not ${adverb} closes #37 but also fixes #38`;
+    assert.deepEqual(
+      extractKeywordReferences(body),
+      [
+        { target: 37, relationship: 'closing-keyword', evidence: body },
+        { target: 38, relationship: 'closing-keyword', evidence: body },
+      ],
+      `adverb: ${adverb}`,
+    );
+  }
+});
+
 test('extractKeywordReferences still negates across long intervening words (#1968 review)', () => {
   // Copilot/Codex review on #1968: an earlier revision bounded the negation
   // scan to a fixed 30-character slice, which could truncate the negation
@@ -549,19 +567,23 @@ test('graph traversal excludes a negated closing-keyword mention as a phantom ne
   // Reproduces the live #1931 -> #176 shape at the graph level: a merged
   // child issue's field-report narrative mentions an unrelated,
   // already-closed historical roadmap using negated phrasing ("does not
-  // close #N" / "would not close #N"). Before this fix the mechanical
-  // extractor still recorded a
-  // closing-keyword edge to it, pulling the unrelated roadmap into the graph
-  // as a childless node and tripping idd-roadmap-audit-execute's
-  // nested-roadmap blocker for the real root. After the fix, #902 must be
-  // absent from the graph entirely — not merely relabeled — since traversal
-  // follows every edge regardless of relationship type.
+  // close #N" / "would not close #N"), each phrase kept on a single physical
+  // line (matching the real #1931 body — the negation window is per-line, so
+  // a phrase split across a line wrap would not even reach the negation
+  // check: the keyword and `#N` would already be on different lines and
+  // never pair up in the first place, negation aside). Before this fix the
+  // mechanical extractor still recorded a closing-keyword edge for both,
+  // pulling the unrelated roadmap into the graph as a childless node and
+  // tripping idd-roadmap-audit-execute's nested-roadmap blocker for the real
+  // root. After the fix, #902 must be absent from the graph entirely — not
+  // merely relabeled — since traversal follows every edge regardless of
+  // relationship type.
   const childBody = [
     '## Background',
     '',
-    'The B2 plan comment had stated in writing that the PR would not close',
-    '#902. The commit message contained a sentence written to explain the',
-    'scope boundary to a reader: "This does not close #902: verifying the',
+    'The B2 plan comment had stated in writing that the PR would not close #902.',
+    'The commit message contained a sentence written to explain the scope',
+    'boundary to a reader: "This does not close #902: verifying the',
     'acceptance criteria needs an actual green release run".',
   ].join('\n');
   const issues = new Map([

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -401,6 +401,33 @@ test('extractKeywordReferences drops a negated closing-keyword mention (#1964)',
   );
 });
 
+test('extractKeywordReferences keeps both targets in a "not only ... but also ..." construction (#1968 review)', () => {
+  // Copilot/Codex review on #1968: "not only" is an additive correlative
+  // construction, not a real negation. Before this guard, KEYWORD_NEGATION_PATTERN
+  // treated "not" in "not only closes #42" as negating #42, dropping a
+  // genuine edge — a regression this fix must not introduce.
+  const body = 'This not only closes #42 but also fixes #43';
+  assert.deepEqual(extractKeywordReferences(body), [
+    { target: 42, relationship: 'closing-keyword', evidence: body },
+    { target: 43, relationship: 'closing-keyword', evidence: body },
+  ]);
+});
+
+test('extractKeywordReferences still negates across long intervening words (#1968 review)', () => {
+  // Copilot/Codex review on #1968: an earlier revision bounded the negation
+  // scan to a fixed 30-character slice, which could truncate the negation
+  // term itself out of the scanned text when the (still only 2) intervening
+  // words were long — recreating the exact false-positive edge this fix
+  // exists to prevent. The scan must be bounded by token count, not a
+  // character-count slice.
+  assert.deepEqual(
+    extractKeywordReferences(
+      'This would not unconditionally automatically close #43',
+    ),
+    [],
+  );
+});
+
 test('extractKeywordReferences negates across 1-2 intervening word tokens, not just directly adjacent (#1964)', () => {
   // KEYWORD_NEGATION_PATTERN allows up to two intervening word tokens
   // between the negation term and the matched keyword


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`extractKeywordReferences()` in `src/scripts/discover-roadmap-graph.mts`
matched a recognized keyword (close, fix, resolve, depends on, sub-issue,
...) anywhere in an issue body line with no negation awareness. A narrative
field-report line phrased as a negation (e.g. "does not [keyword] #N" / "would
not [keyword] #N") was still recorded as a real relationship edge. This adds
a short, end-anchored negation-window check and skips a negated match
entirely instead of recording any edge for it.

## Linked issue

Closes #1964

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Root cause and reproduction confirmed against live GitHub state before
drafting the fix: issue #1931's own merged body contains two negated
mentions, inside a field-report narrative about an unrelated already-closed
historical roadmap, that the mechanical extractor still recorded as
`closing-keyword` edges. Since graph traversal (`visitIssue`) follows every
edge regardless of its `relationship`, and
`idd-roadmap-audit-execute`'s nested-roadmap blocker only checks node
classification (not how the node was reached), simply reclassifying the
match to `relationship: 'reference'` would **not** have cleared the audit
blocker — the unrelated roadmap would still enter the graph as a phantom
node with zero reachable execution leaves. Verified empirically before and
after the fix (see the issue comment thread for the before/after
`idd-roadmap-audit-execute --roadmap 1937` runs).

The negation pattern is deliberately end-anchored (allows up to two
intervening word tokens between the negation term and the keyword, no
intervening punctuation) rather than "negation anywhere in a wide window,"
so a genuine close elsewhere on the same line (e.g.
`"the workaround did not work; closes #42"`) still keeps its real edge.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (3405 tests pass)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs changed)
- [x] `node scripts/idd-doctor.mjs` (passed, pre-existing warnings unrelated
      to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved roadmap reference detection to ignore negated phrases such as “does not close” or “never fixes.”
  * Excluded keywords embedded immediately after hyphens, such as “auto-close.”
  * Preserved valid correlative wording such as “not only closes.”
  * Prevented negated references from creating incorrect roadmap links, nodes, or traversal targets.
* **Tests**
  * Added coverage for negation, contractions, clause boundaries, hyphenated terms, mixed references, and graph traversal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->