### PR TITLE
fix(idd-doctor): recognize a chained hook-manager setup as wired

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -874,16 +874,22 @@ exec "$(git rev-parse --show-toplevel)/.githooks/pre-commit" "$@"
 The same two forms apply to `.husky/pre-push`, substituting
 `pre-push` for `pre-commit` throughout.
 
-`idd-doctor`'s enabled-but-inert check reads the hook files at the
-resolved `core.hooksPath` directly; it does not follow a hook
-manager's own dispatch into a committed chain line, so a correctly
-chained setup can still report enabled-but-inert even though the guard
-is genuinely reachable through the chain
-([#1951](https://github.com/kurone-kito/idd-skill/issues/1951)). Treat
-that specific combination — **both** hooks already chained,
-`idd-doctor` still warning — as a known detector gap, not proof the
-chain needs to be undone; a warning while only one hook is chained
-remains actionable as intended.
+`idd-doctor`'s enabled-but-inert check follows a bounded one-level
+dispatch: when the hook file at the resolved `core.hooksPath` does not
+itself source the guard, it also checks the corresponding hook file in
+`core.hooksPath`'s **parent** directory — the shape Husky v9's own
+`.husky/_` split takes — for one of the two documented chain forms
+above, and confirms the referenced `.githooks/<hook>` script itself
+genuinely sources the guard
+([#1951](https://github.com/kurone-kito/idd-skill/issues/1951)). A
+setup that follows the recipe above for **both** hooks now reads as
+wired, not enabled-but-inert. The check still does not trace an
+arbitrary hook manager's own dispatch machinery beyond that one
+documented level, so a manager using a different indirection shape can
+still warn even when the guard is genuinely reachable through it; a
+warning while only one hook is chained, or while the chain targets a
+missing or incorrect `.githooks/*` script, remains actionable as
+intended either way.
 
 Fully replacing an existing hook manager instead of chaining it removes
 that tool from the repository outright, so treat it as an alternative
@@ -950,17 +956,21 @@ actually took effect with `idd-doctor`, which surfaces an
 **enabled-but-inert** finding when `worktreeGuard.enabled` is `true`
 but `core.hooksPath` is not pointed at `.githooks`, the signal that the
 setup step silently did not run. For the chaining path, `idd-doctor`'s
-confirmation is unreliable for the detector gap noted above, but
-chain-line presence alone isn't a safe substitute either: a fresh
-ephemeral clone checks out the committed chain lines immediately, even
-when the setup lifecycle never ran and `core.hooksPath` is still
-unset — the exact failure this confirmation step exists to catch.
-Verify both instead: that the committed chain lines are present in the
-manager's hook files, and that `git config --get core.hooksPath`
-resolves to the manager's own hooks directory (not empty), confirming
-its lifecycle actually ran and wired that value rather than just that
-the files exist. This is activation guidance only; the adopter default
-stays opt-in **off**.
+confirmation now covers the documented recipe the same way it covers
+the direct/fully-replacing path above — a correctly chained setup
+reads as wired once the manager's lifecycle has actually run.
+Chain-line presence alone still isn't a safe substitute for running
+`idd-doctor`, though: a fresh ephemeral clone checks out the committed
+chain lines immediately, even when the setup lifecycle never ran and
+`core.hooksPath` is still unset, which `idd-doctor` still correctly
+reports as enabled-but-inert (`core.hooksPath = (unset)`). If a custom
+dispatch shape falls outside the documented one-level recipe (above),
+fall back to verifying both explicitly: that the committed chain lines
+are present in the manager's hook files, and that
+`git config --get core.hooksPath` resolves to the manager's own hooks
+directory (not empty), confirming its lifecycle actually ran and wired
+that value rather than just that the files exist. This is activation
+guidance only; the adopter default stays opt-in **off**.
 
 ### Optional — run idd-doctor as a CI health gate
 

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -897,6 +897,18 @@ only one hook is chained, or while the chain targets a missing or
 incorrect `.githooks/*` script, remains actionable as intended either
 way.
 
+Recognizing the two chain forms above is itself a bounded lexical
+heuristic, not a shell parser: it matches the documented forms as an
+ordinary standalone physical line and deliberately does not evaluate
+quoting edge cases, variable expansion, here-docs, `eval`, subshell
+wrapping, or other adversarial or unusual shell constructions that
+could reach one of the two forms at runtime while lexically evading
+this check, or vice versa (preventive; no observed incident yet). This
+is a warning-level misconfiguration diagnostic, not a security
+boundary — an operator who wants to fool it can simply not enable the
+guard — so hardening against constructions beyond the documented
+recipe stays out of scope absent an observed incident.
+
 Fully replacing an existing hook manager instead of chaining it removes
 that tool from the repository outright, so treat it as an alternative
 worth knowing about, not the default recommendation. Under pnpm's

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -954,8 +954,11 @@ For the direct or fully-replacing path, because the agent re-runs this
 every task, the guard stays active for the whole session — confirm it
 actually took effect with `idd-doctor`, which surfaces an
 **enabled-but-inert** finding when `worktreeGuard.enabled` is `true`
-but `core.hooksPath` is not pointed at `.githooks`, the signal that the
-setup step silently did not run. For the chaining path, `idd-doctor`'s
+but `core.hooksPath` is not pointed at `.githooks` and no recognized
+chain is present, the signal that the setup step silently did not run
+(the chaining path below intentionally keeps `core.hooksPath` pointed
+at the manager's own directory instead, so that condition alone does
+not fire there). For the chaining path, `idd-doctor`'s
 confirmation now covers the documented recipe the same way it covers
 the direct/fully-replacing path above — a correctly chained setup
 reads as wired once the manager's lifecycle has actually run.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -885,9 +885,10 @@ review; [#1951](https://github.com/kurone-kito/idd-skill/issues/1951)).
 A setup that follows the recipe above for **both** hooks now reads as
 wired, not enabled-but-inert. The check still does not trace an
 arbitrary hook manager's own dispatch machinery beyond that one
-documented level: it confirms a hook file exists at `core.hooksPath`
-but does not verify that file's own content genuinely hands off to the
-parent sibling it trusts, so a present-but-inert or corrupted
+documented level: it confirms a hook file exists **and is executable**
+at `core.hooksPath` — since git itself silently skips a non-executable
+one — but does not verify that file's own content genuinely hands off
+to the parent sibling it trusts, so a present-but-inert or corrupted
 dispatcher stub can still read as wired even though git never reaches
 the parent chain (preventive; no observed incident yet). Conversely, a
 manager using a different indirection shape entirely can still warn

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -880,16 +880,21 @@ itself source the guard, it also checks the corresponding hook file in
 `core.hooksPath`'s **parent** directory — the shape Husky v9's own
 `.husky/_` split takes — for one of the two documented chain forms
 above, and confirms the referenced `.githooks/<hook>` script itself
-genuinely sources the guard
-([#1951](https://github.com/kurone-kito/idd-skill/issues/1951)). A
-setup that follows the recipe above for **both** hooks now reads as
+genuinely sources the guard (observed 2026-08-11 during PR #1948's
+review; [#1951](https://github.com/kurone-kito/idd-skill/issues/1951)).
+A setup that follows the recipe above for **both** hooks now reads as
 wired, not enabled-but-inert. The check still does not trace an
 arbitrary hook manager's own dispatch machinery beyond that one
-documented level, so a manager using a different indirection shape can
-still warn even when the guard is genuinely reachable through it; a
-warning while only one hook is chained, or while the chain targets a
-missing or incorrect `.githooks/*` script, remains actionable as
-intended either way.
+documented level: it confirms a hook file exists at `core.hooksPath`
+but does not verify that file's own content genuinely hands off to the
+parent sibling it trusts, so a present-but-inert or corrupted
+dispatcher stub can still read as wired even though git never reaches
+the parent chain (preventive; no observed incident yet). Conversely, a
+manager using a different indirection shape entirely can still warn
+even when the guard is genuinely reachable through it; a warning while
+only one hook is chained, or while the chain targets a missing or
+incorrect `.githooks/*` script, remains actionable as intended either
+way.
 
 Fully replacing an existing hook manager instead of chaining it removes
 that tool from the repository outright, so treat it as an alternative
@@ -966,10 +971,11 @@ Chain-line presence alone still isn't a safe substitute for running
 `idd-doctor`, though: a fresh ephemeral clone checks out the committed
 chain lines immediately, even when the setup lifecycle never ran and
 `core.hooksPath` is still unset, which `idd-doctor` still correctly
-reports as enabled-but-inert (`core.hooksPath = (unset)`). If a custom
-dispatch shape falls outside the documented one-level recipe (above),
-fall back to verifying both explicitly: that the committed chain lines
-are present in the manager's hook files, and that
+reports as enabled-but-inert (`core.hooksPath = (unset)`; preventive,
+no observed incident yet). If a custom dispatch shape falls outside
+the documented one-level recipe (above; also preventive, no observed
+incident yet), fall back to verifying both explicitly: that the
+committed chain lines are present in the manager's hook files, and that
 `git config --get core.hooksPath` resolves to the manager's own hooks
 directory (not empty), confirming its lifecycle actually ran and wired
 that value rather than just that the files exist. This is activation

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1441,6 +1441,32 @@ export function hookWiresWorktreeGuard(content) {
   );
 }
 /**
+ * True when a git hook file body chains execution to the corresponding
+ * shipped `.githooks/<hookName>` script via one of the two documented
+ * exec/invocation forms from ONBOARDING.md's "Coexisting with an existing
+ * hook manager" recipe:
+ *
+ * ```sh
+ * exec "$(git rev-parse --show-toplevel)/.githooks/<hookName>" "$@"
+ * "$(git rev-parse --show-toplevel)/.githooks/<hookName>" "$@" || exit $?
+ * ```
+ *
+ * Line-anchored and comment-immune the same way `hookWiresWorktreeGuard`
+ * is: a `#`-prefixed line (e.g. a leftover "was:" comment) never matches.
+ * Pure (no I/O) so it can be unit-tested directly. A non-string
+ * (absent/unreadable hook) is treated as not chaining.
+ */
+export function hookChainsToGithooksScript(content, hookName) {
+  if (typeof content !== 'string') {
+    return false;
+  }
+  const escaped = escapeRegex(hookName);
+  return new RegExp(
+    `^[ \\t]*(?:exec[ \\t]+)?"?[^"#\\n]*\\.githooks/${escaped}"?[ \\t]+"\\$@"`,
+    'm',
+  ).test(content);
+}
+/**
  * Decide whether the worktree guard is enabled-but-inert in the current
  * environment and, if so, produce a warning finding. Pure (no I/O) so it can
  * be unit-tested directly.
@@ -1480,27 +1506,55 @@ export function classifyWorktreeGuardActivation({
       `worktreeGuard.enabled is true but the commit/push guard is not active ` +
       `in this environment (core.hooksPath = ${shown}); B1 primary-worktree ` +
       `commits will NOT be blocked here. Wire it with: ` +
-      `git config core.hooksPath .githooks`,
+      `git config core.hooksPath .githooks — or, if an existing hook manager ` +
+      `already owns core.hooksPath here, chain each hook to the corresponding ` +
+      `.githooks/* script instead of repointing directly; see ONBOARDING.md's ` +
+      `"Coexisting with an existing hook manager" section`,
   };
 }
 /**
  * Read the `pre-commit` and `pre-push` hooks at the resolved `core.hooksPath`
- * and report whether both wire the B1 guard. A relative hooks path resolves
- * against the repository root; an absolute one is used as-is.
+ * and report whether both wire the B1 guard, directly or through a
+ * documented one-level chain. A relative hooks path resolves against the
+ * repository root; an absolute one is used as-is.
+ *
+ * A hook counts as wired when either:
+ *  - the file at `hooksPath` itself sources `_idd-worktree-guard.sh`
+ *    directly (the base, non-chained activation path), or
+ *  - the file at `hooksPath`, or the sibling file its manager hands off to
+ *    in `hooksPath`'s **parent** directory (the shape Husky v9's
+ *    `core.hooksPath = .husky/_` plus the committed `.husky/<hook>` file
+ *    takes — see ONBOARDING.md's "Coexisting with an existing hook
+ *    manager"), chains to the corresponding `.githooks/<hook>` script via a
+ *    documented exec/invocation line, **and** that `.githooks/<hook>` script
+ *    itself genuinely sources the guard (defense-in-depth against a chain
+ *    line pointing at a missing or tampered target).
+ *
+ * This stays bounded to the documented recipe's two concrete file
+ * locations — it does not trace an arbitrary hook manager's own dispatch
+ * machinery.
  */
-function worktreeGuardWiredAt(root, hooksPath) {
+export function worktreeGuardWiredAt(root, hooksPath) {
   const directory = isAbsolute(hooksPath) ? hooksPath : join(root, hooksPath);
-  const read = (name) => {
+  const parentDirectory = join(directory, '..');
+  const githooksDirectory = join(root, '.githooks');
+  const read = (dir, name) => {
     try {
-      return readFileSync(join(directory, name), 'utf8');
+      return readFileSync(join(dir, name), 'utf8');
     } catch {
       return null;
     }
   };
-  return (
-    hookWiresWorktreeGuard(read('pre-commit')) &&
-    hookWiresWorktreeGuard(read('pre-push'))
-  );
+  const wired = (name) => {
+    if (hookWiresWorktreeGuard(read(directory, name))) {
+      return true;
+    }
+    const chains =
+      hookChainsToGithooksScript(read(directory, name), name) ||
+      hookChainsToGithooksScript(read(parentDirectory, name), name);
+    return chains && hookWiresWorktreeGuard(read(githooksDirectory, name));
+  };
+  return wired('pre-commit') && wired('pre-push');
 }
 /**
  * Warn when `worktreeGuard.enabled` is true but the commit/push guard is not

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -6,7 +6,7 @@
 // .mjs. See docs/typescript-sources.md.
 import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { isAbsolute, join, relative, resolve } from 'node:path';
+import { basename, isAbsolute, join, relative, resolve } from 'node:path';
 import {
   normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitabilityMarker,
@@ -1540,13 +1540,21 @@ export function classifyWorktreeGuardActivation({
  *  - sources `_idd-worktree-guard.sh` directly (the base, non-chained
  *    activation path), or
  *  - itself chains to the corresponding `.githooks/<hook>` script via a
- *    documented exec/invocation line, or hands off to the sibling file in
- *    `hooksPath`'s **parent** directory that does (the shape Husky v9's
+ *    documented exec/invocation line, or — **only when `hooksPath`'s last
+ *    path segment is literally `_`**, the exact shape Husky v9's
  *    `core.hooksPath = .husky/_` plus the committed `.husky/<hook>` file
- *    takes — see ONBOARDING.md's "Coexisting with an existing hook
- *    manager"), with that `.githooks/<hook>` script itself confirmed to
- *    genuinely source the guard (defense-in-depth against a chain line
- *    pointing at a missing or tampered target).
+ *    takes (see ONBOARDING.md's "Coexisting with an existing hook
+ *    manager") — hands off to the sibling file in `hooksPath`'s **parent**
+ *    directory that does, with that `.githooks/<hook>` script itself
+ *    confirmed to genuinely source the guard (defense-in-depth against a
+ *    chain line pointing at a missing or tampered target).
+ *
+ * The parent-directory fallback is scoped to that one literal directory
+ * name deliberately: without it, a hook manager placing dispatchers at an
+ * arbitrary directory (e.g. `.other-hooks/dispatch`) could read as wired from
+ * an unrelated file that merely happens to sit in its parent directory and
+ * happens to contain a chain-shaped line, even though nothing connects the
+ * two files (Copilot review, PR #1969).
  *
  * The file at `hooksPath` must actually exist before either chain form is
  * trusted: when a hook manager's install is deleted or incomplete, git has
@@ -1561,6 +1569,7 @@ export function classifyWorktreeGuardActivation({
 export function worktreeGuardWiredAt(root, hooksPath) {
   const directory = isAbsolute(hooksPath) ? hooksPath : join(root, hooksPath);
   const parentDirectory = join(directory, '..');
+  const isHuskyUnderscoreSplit = basename(directory) === '_';
   const githooksDirectory = join(root, '.githooks');
   const read = (dir, name) => {
     try {
@@ -1581,7 +1590,8 @@ export function worktreeGuardWiredAt(root, hooksPath) {
     }
     const chains =
       hookChainsToGithooksScript(atHooksPath, name) ||
-      hookChainsToGithooksScript(read(parentDirectory, name), name);
+      (isHuskyUnderscoreSplit &&
+        hookChainsToGithooksScript(read(parentDirectory, name), name));
     return chains && hookWiresWorktreeGuard(read(githooksDirectory, name));
   };
   return wired('pre-commit') && wired('pre-push');

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1490,8 +1490,20 @@ export function hookWiresWorktreeGuard(content) {
  * joins such a pair into one logical command, so e.g. a `printf '%s' \`
  * line immediately followed by the exec form on the next physical line
  * never actually invokes it; it only passes those words as arguments to
- * the earlier command. Pure (no I/O) so it can be unit-tested directly. A
- * non-string (absent/unreadable hook) is treated as not chaining.
+ * the earlier command.
+ *
+ * Scope boundary: this is a bounded lexical heuristic for the two
+ * documented forms appearing as an ordinary standalone physical line, not
+ * a shell parser. It does not evaluate quoting edge cases, variable
+ * expansion, here-docs, `eval`, subshell wrapping, or any other
+ * adversarial or unusual shell construction that could still reach one of
+ * the two forms at runtime while lexically evading this check (or vice
+ * versa). This is a warning-level misconfiguration diagnostic, not a
+ * security boundary — an operator who wants to fool it can simply not
+ * enable the guard — so further hardening against constructions beyond
+ * the documented recipe is out of scope absent an observed incident.
+ * Pure (no I/O) so it can be unit-tested directly. A non-string
+ * (absent/unreadable hook) is treated as not chaining.
  */
 export function hookChainsToGithooksScript(content, hookName) {
   if (typeof content !== 'string') {

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1484,9 +1484,14 @@ export function hookWiresWorktreeGuard(content) {
  * adjacent `#` right after the closing quote (e.g. `"$@"#| cat`) is not a
  * comment delimiter to the shell at all — it stays part of the same word —
  * so accepting it here would let disguised trailing content back in through
- * the very escape hatch meant only for a genuine, separated comment. Pure
- * (no I/O) so it can be unit-tested directly. A non-string
- * (absent/unreadable hook) is treated as not chaining.
+ * the very escape hatch meant only for a genuine, separated comment. A
+ * candidate line must also not be a backslash-continuation of the
+ * preceding physical line (a line ending in `\` before it) — the shell
+ * joins such a pair into one logical command, so e.g. a `printf '%s' \`
+ * line immediately followed by the exec form on the next physical line
+ * never actually invokes it; it only passes those words as arguments to
+ * the earlier command. Pure (no I/O) so it can be unit-tested directly. A
+ * non-string (absent/unreadable hook) is treated as not chaining.
  */
 export function hookChainsToGithooksScript(content, hookName) {
   if (typeof content !== 'string') {
@@ -1497,9 +1502,11 @@ export function hookChainsToGithooksScript(content, hookName) {
   const lineEnd = '(?:[ \\t]*$|[ \\t]+#.*$)';
   const execForm = `exec[ \\t]+${quotedPath}[ \\t]+"\\$@"${lineEnd}`;
   const nonExecForm = `${quotedPath}[ \\t]+"\\$@"[ \\t]*\\|\\|[ \\t]*exit[ \\t]+\\$\\?${lineEnd}`;
-  return new RegExp(`^[ \\t]*(?:${execForm}|${nonExecForm})`, 'm').test(
-    content,
-  );
+  const notContinuedLine = '(?<!\\\\\\n)';
+  return new RegExp(
+    `${notContinuedLine}^[ \\t]*(?:${execForm}|${nonExecForm})`,
+    'm',
+  ).test(content);
 }
 /**
  * Decide whether the worktree guard is enabled-but-inert in the current

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -5,8 +5,15 @@
 // above by `pnpm run build`. Edit the .mts source, never the generated
 // .mjs. See docs/typescript-sources.md.
 import { execFileSync } from 'node:child_process';
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { basename, isAbsolute, join, relative, resolve } from 'node:path';
+import {
+  accessSync,
+  existsSync,
+  constants as fsConstants,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from 'node:fs';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 import {
   normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitabilityMarker,
@@ -1468,8 +1475,13 @@ export function hookWiresWorktreeGuard(content) {
  * `exec`, a guard failure that isn't explicitly propagated can be silently
  * swallowed by whatever the hook manager's own dispatcher runs next, so an
  * invocation lacking that suffix is not accepted as reliable chaining
- * evidence. Pure (no I/O) so it can be unit-tested directly. A non-string
- * (absent/unreadable hook) is treated as not chaining.
+ * evidence. Both forms must also end the line (only trailing whitespace and
+ * an optional `#` comment may follow) — a trailing shell operator such as
+ * `| cat` or a backgrounding `&` can decouple the line's own exit status
+ * from the guard's, so a line carrying either form of the two documented
+ * commands plus anything else is not accepted either. Pure (no I/O) so it
+ * can be unit-tested directly. A non-string (absent/unreadable hook) is
+ * treated as not chaining.
  */
 export function hookChainsToGithooksScript(content, hookName) {
   if (typeof content !== 'string') {
@@ -1477,8 +1489,9 @@ export function hookChainsToGithooksScript(content, hookName) {
   }
   const escaped = escapeRegex(hookName);
   const quotedPath = `"\\$\\(git rev-parse --show-toplevel\\)/\\.githooks/${escaped}"`;
-  const execForm = `exec[ \\t]+${quotedPath}[ \\t]+"\\$@"`;
-  const nonExecForm = `${quotedPath}[ \\t]+"\\$@"[ \\t]*\\|\\|[ \\t]*exit[ \\t]+\\$\\?`;
+  const lineEnd = '[ \\t]*(?:#.*)?$';
+  const execForm = `exec[ \\t]+${quotedPath}[ \\t]+"\\$@"${lineEnd}`;
+  const nonExecForm = `${quotedPath}[ \\t]+"\\$@"[ \\t]*\\|\\|[ \\t]*exit[ \\t]+\\$\\?${lineEnd}`;
   return new RegExp(`^[ \\t]*(?:${execForm}|${nonExecForm})`, 'm').test(
     content,
   );
@@ -1535,32 +1548,32 @@ export function classifyWorktreeGuardActivation({
  * documented one-level chain. A relative hooks path resolves against the
  * repository root; an absolute one is used as-is.
  *
- * A hook counts as wired when the file **actually present at
- * `hooksPath`** — the one git itself would invoke — either:
+ * A hook counts as wired when the file **actually present and executable
+ * at `hooksPath`** — the one git itself would invoke, and only when git
+ * would actually invoke it: git silently skips a hook file that exists but
+ * lacks the executable bit — either:
  *  - sources `_idd-worktree-guard.sh` directly (the base, non-chained
  *    activation path), or
  *  - itself chains to the corresponding `.githooks/<hook>` script via a
- *    documented exec/invocation line, or — **only when `hooksPath`'s last
- *    path segment is literally `_`**, the exact shape Husky v9's
+ *    documented exec/invocation line, or — **only when `hooksPath` resolves
+ *    to exactly `.husky/_`**, the precise shape Husky v9's own
  *    `core.hooksPath = .husky/_` plus the committed `.husky/<hook>` file
  *    takes (see ONBOARDING.md's "Coexisting with an existing hook
  *    manager") — hands off to the sibling file in `hooksPath`'s **parent**
  *    directory that does, with that `.githooks/<hook>` script itself
- *    confirmed to genuinely source the guard (defense-in-depth against a
- *    chain line pointing at a missing or tampered target).
+ *    confirmed to both genuinely source the guard and be executable
+ *    (defense-in-depth against a chain line pointing at a missing,
+ *    non-executable, or tampered target).
  *
- * The parent-directory fallback is scoped to that one literal directory
- * name deliberately: without it, a hook manager placing dispatchers at an
- * arbitrary directory (e.g. `.other-hooks/dispatch`) could read as wired from
- * an unrelated file that merely happens to sit in its parent directory and
- * happens to contain a chain-shaped line, even though nothing connects the
- * two files (Copilot review, PR #1969).
- *
- * The file at `hooksPath` must actually exist before either chain form is
- * trusted: when a hook manager's install is deleted or incomplete, git has
- * no active hook to invoke there at all, so a committed chain line living
- * only in the parent directory is not reachable and must not read as
- * wired just because it is present on disk.
+ * The parent-directory fallback checks the **full path** relative to the
+ * repository root, not merely `hooksPath`'s last path segment: matching on
+ * a bare trailing `_` would also fire for an unrelated directory that
+ * happens to end in `_` (e.g. `.other-hooks/_`), and matching on an
+ * arbitrary directory at all — without the executable-bit check above —
+ * would let an unrelated file that merely happens to sit in some other
+ * hooksPath's parent directory, and happens to contain a chain-shaped
+ * line, supply chain evidence for two files with no real dispatch
+ * relationship (Copilot + Codex review, PR #1969).
  *
  * This stays bounded to the documented recipe's two concrete file
  * locations — it does not trace an arbitrary hook manager's own dispatch
@@ -1569,7 +1582,8 @@ export function classifyWorktreeGuardActivation({
 export function worktreeGuardWiredAt(root, hooksPath) {
   const directory = isAbsolute(hooksPath) ? hooksPath : join(root, hooksPath);
   const parentDirectory = join(directory, '..');
-  const isHuskyUnderscoreSplit = basename(directory) === '_';
+  const isHuskyUnderscoreSplit =
+    relative(root, directory).split('\\').join('/') === '.husky/_';
   const githooksDirectory = join(root, '.githooks');
   const read = (dir, name) => {
     try {
@@ -1578,21 +1592,33 @@ export function worktreeGuardWiredAt(root, hooksPath) {
       return null;
     }
   };
+  const isExecutable = (dir, name) => {
+    try {
+      accessSync(join(dir, name), fsConstants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  };
   const wired = (name) => {
     const atHooksPath = read(directory, name);
+    // git silently skips a hook file that exists but isn't executable, so
+    // neither wiring form below is reachable without this bit set.
+    if (atHooksPath === null || !isExecutable(directory, name)) {
+      return false;
+    }
     if (hookWiresWorktreeGuard(atHooksPath)) {
       return true;
-    }
-    // No active hook file at core.hooksPath at all: git has nothing to
-    // invoke here, so a committed chain line elsewhere is unreachable.
-    if (atHooksPath === null) {
-      return false;
     }
     const chains =
       hookChainsToGithooksScript(atHooksPath, name) ||
       (isHuskyUnderscoreSplit &&
         hookChainsToGithooksScript(read(parentDirectory, name), name));
-    return chains && hookWiresWorktreeGuard(read(githooksDirectory, name));
+    return (
+      chains &&
+      hookWiresWorktreeGuard(read(githooksDirectory, name)) &&
+      isExecutable(githooksDirectory, name)
+    );
   };
   return wired('pre-commit') && wired('pre-push');
 }

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1536,10 +1536,11 @@ export function classifyWorktreeGuardActivation({
       `worktreeGuard.enabled is true but the commit/push guard is not active ` +
       `in this environment (core.hooksPath = ${shown}); B1 primary-worktree ` +
       `commits will NOT be blocked here. Wire it with: ` +
-      `git config core.hooksPath .githooks — or, if an existing hook manager ` +
-      `already owns core.hooksPath here, chain each hook to the corresponding ` +
-      `.githooks/* script instead of repointing directly; see ONBOARDING.md's ` +
-      `"Coexisting with an existing hook manager" section`,
+      `git config core.hooksPath .githooks && chmod +x ` +
+      `.githooks/pre-commit .githooks/pre-push — or, if an existing hook ` +
+      `manager already owns core.hooksPath here, chain each hook to the ` +
+      `corresponding .githooks/* script instead of repointing directly; see ` +
+      `ONBOARDING.md's "Coexisting with an existing hook manager" section`,
   };
 }
 /**

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1453,8 +1453,12 @@ export function hookWiresWorktreeGuard(content) {
  *
  * Line-anchored and comment-immune the same way `hookWiresWorktreeGuard`
  * is: a `#`-prefixed line (e.g. a leftover "was:" comment) never matches.
- * Pure (no I/O) so it can be unit-tested directly. A non-string
- * (absent/unreadable hook) is treated as not chaining.
+ * The quoted path must begin the executed command token (immediately after
+ * an optional `exec`, with nothing else in between) — an unrelated leading
+ * command such as `echo "$(...)/.githooks/pre-commit" "$@"` never matches,
+ * since that would only *mention* the path rather than invoke it. Pure (no
+ * I/O) so it can be unit-tested directly. A non-string (absent/unreadable
+ * hook) is treated as not chaining.
  */
 export function hookChainsToGithooksScript(content, hookName) {
   if (typeof content !== 'string') {
@@ -1462,7 +1466,7 @@ export function hookChainsToGithooksScript(content, hookName) {
   }
   const escaped = escapeRegex(hookName);
   return new RegExp(
-    `^[ \\t]*(?:exec[ \\t]+)?"?[^"#\\n]*\\.githooks/${escaped}"?[ \\t]+"\\$@"`,
+    `^[ \\t]*(?:exec[ \\t]+)?"[^"#\\n]*\\.githooks/${escaped}"[ \\t]+"\\$@"`,
     'm',
   ).test(content);
 }
@@ -1518,17 +1522,24 @@ export function classifyWorktreeGuardActivation({
  * documented one-level chain. A relative hooks path resolves against the
  * repository root; an absolute one is used as-is.
  *
- * A hook counts as wired when either:
- *  - the file at `hooksPath` itself sources `_idd-worktree-guard.sh`
- *    directly (the base, non-chained activation path), or
- *  - the file at `hooksPath`, or the sibling file its manager hands off to
- *    in `hooksPath`'s **parent** directory (the shape Husky v9's
+ * A hook counts as wired when the file **actually present at
+ * `hooksPath`** — the one git itself would invoke — either:
+ *  - sources `_idd-worktree-guard.sh` directly (the base, non-chained
+ *    activation path), or
+ *  - itself chains to the corresponding `.githooks/<hook>` script via a
+ *    documented exec/invocation line, or hands off to the sibling file in
+ *    `hooksPath`'s **parent** directory that does (the shape Husky v9's
  *    `core.hooksPath = .husky/_` plus the committed `.husky/<hook>` file
  *    takes — see ONBOARDING.md's "Coexisting with an existing hook
- *    manager"), chains to the corresponding `.githooks/<hook>` script via a
- *    documented exec/invocation line, **and** that `.githooks/<hook>` script
- *    itself genuinely sources the guard (defense-in-depth against a chain
- *    line pointing at a missing or tampered target).
+ *    manager"), with that `.githooks/<hook>` script itself confirmed to
+ *    genuinely source the guard (defense-in-depth against a chain line
+ *    pointing at a missing or tampered target).
+ *
+ * The file at `hooksPath` must actually exist before either chain form is
+ * trusted: when a hook manager's install is deleted or incomplete, git has
+ * no active hook to invoke there at all, so a committed chain line living
+ * only in the parent directory is not reachable and must not read as
+ * wired just because it is present on disk.
  *
  * This stays bounded to the documented recipe's two concrete file
  * locations — it does not trace an arbitrary hook manager's own dispatch
@@ -1546,11 +1557,17 @@ export function worktreeGuardWiredAt(root, hooksPath) {
     }
   };
   const wired = (name) => {
-    if (hookWiresWorktreeGuard(read(directory, name))) {
+    const atHooksPath = read(directory, name);
+    if (hookWiresWorktreeGuard(atHooksPath)) {
       return true;
     }
+    // No active hook file at core.hooksPath at all: git has nothing to
+    // invoke here, so a committed chain line elsewhere is unreachable.
+    if (atHooksPath === null) {
+      return false;
+    }
     const chains =
-      hookChainsToGithooksScript(read(directory, name), name) ||
+      hookChainsToGithooksScript(atHooksPath, name) ||
       hookChainsToGithooksScript(read(parentDirectory, name), name);
     return chains && hookWiresWorktreeGuard(read(githooksDirectory, name));
   };

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1456,19 +1456,32 @@ export function hookWiresWorktreeGuard(content) {
  * The quoted path must begin the executed command token (immediately after
  * an optional `exec`, with nothing else in between) — an unrelated leading
  * command such as `echo "$(...)/.githooks/pre-commit" "$@"` never matches,
- * since that would only *mention* the path rather than invoke it. Pure (no
- * I/O) so it can be unit-tested directly. A non-string (absent/unreadable
- * hook) is treated as not chaining.
+ * since that would only *mention* the path rather than invoke it. The path
+ * must also use the documented `$(git rev-parse --show-toplevel)/` prefix
+ * exactly, not merely end in `.githooks/<hookName>` — an unrelated target
+ * such as `"$HOME/.githooks/<hookName>"` never matches, since that string
+ * has no relationship to this repository's own shipped script regardless
+ * of what happens to live at the fixed `.githooks/<hookName>` path this
+ * function's caller separately verifies. The non-`exec` form additionally
+ * requires the documented `|| exit $?` failure-propagation suffix
+ * immediately afterward (only whitespace may separate them) — without
+ * `exec`, a guard failure that isn't explicitly propagated can be silently
+ * swallowed by whatever the hook manager's own dispatcher runs next, so an
+ * invocation lacking that suffix is not accepted as reliable chaining
+ * evidence. Pure (no I/O) so it can be unit-tested directly. A non-string
+ * (absent/unreadable hook) is treated as not chaining.
  */
 export function hookChainsToGithooksScript(content, hookName) {
   if (typeof content !== 'string') {
     return false;
   }
   const escaped = escapeRegex(hookName);
-  return new RegExp(
-    `^[ \\t]*(?:exec[ \\t]+)?"[^"#\\n]*\\.githooks/${escaped}"[ \\t]+"\\$@"`,
-    'm',
-  ).test(content);
+  const quotedPath = `"\\$\\(git rev-parse --show-toplevel\\)/\\.githooks/${escaped}"`;
+  const execForm = `exec[ \\t]+${quotedPath}[ \\t]+"\\$@"`;
+  const nonExecForm = `${quotedPath}[ \\t]+"\\$@"[ \\t]*\\|\\|[ \\t]*exit[ \\t]+\\$\\?`;
+  return new RegExp(`^[ \\t]*(?:${execForm}|${nonExecForm})`, 'm').test(
+    content,
+  );
 }
 /**
  * Decide whether the worktree guard is enabled-but-inert in the current

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1479,9 +1479,14 @@ export function hookWiresWorktreeGuard(content) {
  * an optional `#` comment may follow) — a trailing shell operator such as
  * `| cat` or a backgrounding `&` can decouple the line's own exit status
  * from the guard's, so a line carrying either form of the two documented
- * commands plus anything else is not accepted either. Pure (no I/O) so it
- * can be unit-tested directly. A non-string (absent/unreadable hook) is
- * treated as not chaining.
+ * commands plus anything else is not accepted either. The trailing comment
+ * itself must be preceded by whitespace, matching real shell tokenizing: an
+ * adjacent `#` right after the closing quote (e.g. `"$@"#| cat`) is not a
+ * comment delimiter to the shell at all — it stays part of the same word —
+ * so accepting it here would let disguised trailing content back in through
+ * the very escape hatch meant only for a genuine, separated comment. Pure
+ * (no I/O) so it can be unit-tested directly. A non-string
+ * (absent/unreadable hook) is treated as not chaining.
  */
 export function hookChainsToGithooksScript(content, hookName) {
   if (typeof content !== 'string') {
@@ -1489,7 +1494,7 @@ export function hookChainsToGithooksScript(content, hookName) {
   }
   const escaped = escapeRegex(hookName);
   const quotedPath = `"\\$\\(git rev-parse --show-toplevel\\)/\\.githooks/${escaped}"`;
-  const lineEnd = '[ \\t]*(?:#.*)?$';
+  const lineEnd = '(?:[ \\t]*$|[ \\t]+#.*$)';
   const execForm = `exec[ \\t]+${quotedPath}[ \\t]+"\\$@"${lineEnd}`;
   const nonExecForm = `${quotedPath}[ \\t]+"\\$@"[ \\t]*\\|\\|[ \\t]*exit[ \\t]+\\$\\?${lineEnd}`;
   return new RegExp(`^[ \\t]*(?:${execForm}|${nonExecForm})`, 'm').test(

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1711,6 +1711,36 @@ export function hookWiresWorktreeGuard(content: unknown): boolean {
 }
 
 /**
+ * True when a git hook file body chains execution to the corresponding
+ * shipped `.githooks/<hookName>` script via one of the two documented
+ * exec/invocation forms from ONBOARDING.md's "Coexisting with an existing
+ * hook manager" recipe:
+ *
+ * ```sh
+ * exec "$(git rev-parse --show-toplevel)/.githooks/<hookName>" "$@"
+ * "$(git rev-parse --show-toplevel)/.githooks/<hookName>" "$@" || exit $?
+ * ```
+ *
+ * Line-anchored and comment-immune the same way `hookWiresWorktreeGuard`
+ * is: a `#`-prefixed line (e.g. a leftover "was:" comment) never matches.
+ * Pure (no I/O) so it can be unit-tested directly. A non-string
+ * (absent/unreadable hook) is treated as not chaining.
+ */
+export function hookChainsToGithooksScript(
+  content: unknown,
+  hookName: string,
+): boolean {
+  if (typeof content !== 'string') {
+    return false;
+  }
+  const escaped = escapeRegex(hookName);
+  return new RegExp(
+    `^[ \\t]*(?:exec[ \\t]+)?"?[^"#\\n]*\\.githooks/${escaped}"?[ \\t]+"\\$@"`,
+    'm',
+  ).test(content);
+}
+
+/**
  * Decide whether the worktree guard is enabled-but-inert in the current
  * environment and, if so, produce a warning finding. Pure (no I/O) so it can
  * be unit-tested directly.
@@ -1750,28 +1780,56 @@ export function classifyWorktreeGuardActivation({
       `worktreeGuard.enabled is true but the commit/push guard is not active ` +
       `in this environment (core.hooksPath = ${shown}); B1 primary-worktree ` +
       `commits will NOT be blocked here. Wire it with: ` +
-      `git config core.hooksPath .githooks`,
+      `git config core.hooksPath .githooks — or, if an existing hook manager ` +
+      `already owns core.hooksPath here, chain each hook to the corresponding ` +
+      `.githooks/* script instead of repointing directly; see ONBOARDING.md's ` +
+      `"Coexisting with an existing hook manager" section`,
   };
 }
 
 /**
  * Read the `pre-commit` and `pre-push` hooks at the resolved `core.hooksPath`
- * and report whether both wire the B1 guard. A relative hooks path resolves
- * against the repository root; an absolute one is used as-is.
+ * and report whether both wire the B1 guard, directly or through a
+ * documented one-level chain. A relative hooks path resolves against the
+ * repository root; an absolute one is used as-is.
+ *
+ * A hook counts as wired when either:
+ *  - the file at `hooksPath` itself sources `_idd-worktree-guard.sh`
+ *    directly (the base, non-chained activation path), or
+ *  - the file at `hooksPath`, or the sibling file its manager hands off to
+ *    in `hooksPath`'s **parent** directory (the shape Husky v9's
+ *    `core.hooksPath = .husky/_` plus the committed `.husky/<hook>` file
+ *    takes — see ONBOARDING.md's "Coexisting with an existing hook
+ *    manager"), chains to the corresponding `.githooks/<hook>` script via a
+ *    documented exec/invocation line, **and** that `.githooks/<hook>` script
+ *    itself genuinely sources the guard (defense-in-depth against a chain
+ *    line pointing at a missing or tampered target).
+ *
+ * This stays bounded to the documented recipe's two concrete file
+ * locations — it does not trace an arbitrary hook manager's own dispatch
+ * machinery.
  */
-function worktreeGuardWiredAt(root: string, hooksPath: string): boolean {
+export function worktreeGuardWiredAt(root: string, hooksPath: string): boolean {
   const directory = isAbsolute(hooksPath) ? hooksPath : join(root, hooksPath);
-  const read = (name: string): string | null => {
+  const parentDirectory = join(directory, '..');
+  const githooksDirectory = join(root, '.githooks');
+  const read = (dir: string, name: string): string | null => {
     try {
-      return readFileSync(join(directory, name), 'utf8');
+      return readFileSync(join(dir, name), 'utf8');
     } catch {
       return null;
     }
   };
-  return (
-    hookWiresWorktreeGuard(read('pre-commit')) &&
-    hookWiresWorktreeGuard(read('pre-push'))
-  );
+  const wired = (name: string): boolean => {
+    if (hookWiresWorktreeGuard(read(directory, name))) {
+      return true;
+    }
+    const chains =
+      hookChainsToGithooksScript(read(directory, name), name) ||
+      hookChainsToGithooksScript(read(parentDirectory, name), name);
+    return chains && hookWiresWorktreeGuard(read(githooksDirectory, name));
+  };
+  return wired('pre-commit') && wired('pre-push');
 }
 
 /**

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1810,10 +1810,11 @@ export function classifyWorktreeGuardActivation({
       `worktreeGuard.enabled is true but the commit/push guard is not active ` +
       `in this environment (core.hooksPath = ${shown}); B1 primary-worktree ` +
       `commits will NOT be blocked here. Wire it with: ` +
-      `git config core.hooksPath .githooks — or, if an existing hook manager ` +
-      `already owns core.hooksPath here, chain each hook to the corresponding ` +
-      `.githooks/* script instead of repointing directly; see ONBOARDING.md's ` +
-      `"Coexisting with an existing hook manager" section`,
+      `git config core.hooksPath .githooks && chmod +x ` +
+      `.githooks/pre-commit .githooks/pre-push — or, if an existing hook ` +
+      `manager already owns core.hooksPath here, chain each hook to the ` +
+      `corresponding .githooks/* script instead of repointing directly; see ` +
+      `ONBOARDING.md's "Coexisting with an existing hook manager" section`,
   };
 }
 

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1749,9 +1749,14 @@ export function hookWiresWorktreeGuard(content: unknown): boolean {
  * an optional `#` comment may follow) — a trailing shell operator such as
  * `| cat` or a backgrounding `&` can decouple the line's own exit status
  * from the guard's, so a line carrying either form of the two documented
- * commands plus anything else is not accepted either. Pure (no I/O) so it
- * can be unit-tested directly. A non-string (absent/unreadable hook) is
- * treated as not chaining.
+ * commands plus anything else is not accepted either. The trailing comment
+ * itself must be preceded by whitespace, matching real shell tokenizing: an
+ * adjacent `#` right after the closing quote (e.g. `"$@"#| cat`) is not a
+ * comment delimiter to the shell at all — it stays part of the same word —
+ * so accepting it here would let disguised trailing content back in through
+ * the very escape hatch meant only for a genuine, separated comment. Pure
+ * (no I/O) so it can be unit-tested directly. A non-string
+ * (absent/unreadable hook) is treated as not chaining.
  */
 export function hookChainsToGithooksScript(
   content: unknown,
@@ -1762,7 +1767,7 @@ export function hookChainsToGithooksScript(
   }
   const escaped = escapeRegex(hookName);
   const quotedPath = `"\\$\\(git rev-parse --show-toplevel\\)/\\.githooks/${escaped}"`;
-  const lineEnd = '[ \\t]*(?:#.*)?$';
+  const lineEnd = '(?:[ \\t]*$|[ \\t]+#.*$)';
   const execForm = `exec[ \\t]+${quotedPath}[ \\t]+"\\$@"${lineEnd}`;
   const nonExecForm = `${quotedPath}[ \\t]+"\\$@"[ \\t]*\\|\\|[ \\t]*exit[ \\t]+\\$\\?${lineEnd}`;
   return new RegExp(`^[ \\t]*(?:${execForm}|${nonExecForm})`, 'm').test(

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1754,9 +1754,14 @@ export function hookWiresWorktreeGuard(content: unknown): boolean {
  * adjacent `#` right after the closing quote (e.g. `"$@"#| cat`) is not a
  * comment delimiter to the shell at all — it stays part of the same word —
  * so accepting it here would let disguised trailing content back in through
- * the very escape hatch meant only for a genuine, separated comment. Pure
- * (no I/O) so it can be unit-tested directly. A non-string
- * (absent/unreadable hook) is treated as not chaining.
+ * the very escape hatch meant only for a genuine, separated comment. A
+ * candidate line must also not be a backslash-continuation of the
+ * preceding physical line (a line ending in `\` before it) — the shell
+ * joins such a pair into one logical command, so e.g. a `printf '%s' \`
+ * line immediately followed by the exec form on the next physical line
+ * never actually invokes it; it only passes those words as arguments to
+ * the earlier command. Pure (no I/O) so it can be unit-tested directly. A
+ * non-string (absent/unreadable hook) is treated as not chaining.
  */
 export function hookChainsToGithooksScript(
   content: unknown,
@@ -1770,9 +1775,11 @@ export function hookChainsToGithooksScript(
   const lineEnd = '(?:[ \\t]*$|[ \\t]+#.*$)';
   const execForm = `exec[ \\t]+${quotedPath}[ \\t]+"\\$@"${lineEnd}`;
   const nonExecForm = `${quotedPath}[ \\t]+"\\$@"[ \\t]*\\|\\|[ \\t]*exit[ \\t]+\\$\\?${lineEnd}`;
-  return new RegExp(`^[ \\t]*(?:${execForm}|${nonExecForm})`, 'm').test(
-    content,
-  );
+  const notContinuedLine = '(?<!\\\\\\n)';
+  return new RegExp(
+    `${notContinuedLine}^[ \\t]*(?:${execForm}|${nonExecForm})`,
+    'm',
+  ).test(content);
 }
 
 /**

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1723,8 +1723,12 @@ export function hookWiresWorktreeGuard(content: unknown): boolean {
  *
  * Line-anchored and comment-immune the same way `hookWiresWorktreeGuard`
  * is: a `#`-prefixed line (e.g. a leftover "was:" comment) never matches.
- * Pure (no I/O) so it can be unit-tested directly. A non-string
- * (absent/unreadable hook) is treated as not chaining.
+ * The quoted path must begin the executed command token (immediately after
+ * an optional `exec`, with nothing else in between) — an unrelated leading
+ * command such as `echo "$(...)/.githooks/pre-commit" "$@"` never matches,
+ * since that would only *mention* the path rather than invoke it. Pure (no
+ * I/O) so it can be unit-tested directly. A non-string (absent/unreadable
+ * hook) is treated as not chaining.
  */
 export function hookChainsToGithooksScript(
   content: unknown,
@@ -1735,7 +1739,7 @@ export function hookChainsToGithooksScript(
   }
   const escaped = escapeRegex(hookName);
   return new RegExp(
-    `^[ \\t]*(?:exec[ \\t]+)?"?[^"#\\n]*\\.githooks/${escaped}"?[ \\t]+"\\$@"`,
+    `^[ \\t]*(?:exec[ \\t]+)?"[^"#\\n]*\\.githooks/${escaped}"[ \\t]+"\\$@"`,
     'm',
   ).test(content);
 }
@@ -1793,17 +1797,24 @@ export function classifyWorktreeGuardActivation({
  * documented one-level chain. A relative hooks path resolves against the
  * repository root; an absolute one is used as-is.
  *
- * A hook counts as wired when either:
- *  - the file at `hooksPath` itself sources `_idd-worktree-guard.sh`
- *    directly (the base, non-chained activation path), or
- *  - the file at `hooksPath`, or the sibling file its manager hands off to
- *    in `hooksPath`'s **parent** directory (the shape Husky v9's
+ * A hook counts as wired when the file **actually present at
+ * `hooksPath`** — the one git itself would invoke — either:
+ *  - sources `_idd-worktree-guard.sh` directly (the base, non-chained
+ *    activation path), or
+ *  - itself chains to the corresponding `.githooks/<hook>` script via a
+ *    documented exec/invocation line, or hands off to the sibling file in
+ *    `hooksPath`'s **parent** directory that does (the shape Husky v9's
  *    `core.hooksPath = .husky/_` plus the committed `.husky/<hook>` file
  *    takes — see ONBOARDING.md's "Coexisting with an existing hook
- *    manager"), chains to the corresponding `.githooks/<hook>` script via a
- *    documented exec/invocation line, **and** that `.githooks/<hook>` script
- *    itself genuinely sources the guard (defense-in-depth against a chain
- *    line pointing at a missing or tampered target).
+ *    manager"), with that `.githooks/<hook>` script itself confirmed to
+ *    genuinely source the guard (defense-in-depth against a chain line
+ *    pointing at a missing or tampered target).
+ *
+ * The file at `hooksPath` must actually exist before either chain form is
+ * trusted: when a hook manager's install is deleted or incomplete, git has
+ * no active hook to invoke there at all, so a committed chain line living
+ * only in the parent directory is not reachable and must not read as
+ * wired just because it is present on disk.
  *
  * This stays bounded to the documented recipe's two concrete file
  * locations — it does not trace an arbitrary hook manager's own dispatch
@@ -1821,11 +1832,17 @@ export function worktreeGuardWiredAt(root: string, hooksPath: string): boolean {
     }
   };
   const wired = (name: string): boolean => {
-    if (hookWiresWorktreeGuard(read(directory, name))) {
+    const atHooksPath = read(directory, name);
+    if (hookWiresWorktreeGuard(atHooksPath)) {
       return true;
     }
+    // No active hook file at core.hooksPath at all: git has nothing to
+    // invoke here, so a committed chain line elsewhere is unreachable.
+    if (atHooksPath === null) {
+      return false;
+    }
     const chains =
-      hookChainsToGithooksScript(read(directory, name), name) ||
+      hookChainsToGithooksScript(atHooksPath, name) ||
       hookChainsToGithooksScript(read(parentDirectory, name), name);
     return chains && hookWiresWorktreeGuard(read(githooksDirectory, name));
   };

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1726,9 +1726,20 @@ export function hookWiresWorktreeGuard(content: unknown): boolean {
  * The quoted path must begin the executed command token (immediately after
  * an optional `exec`, with nothing else in between) — an unrelated leading
  * command such as `echo "$(...)/.githooks/pre-commit" "$@"` never matches,
- * since that would only *mention* the path rather than invoke it. Pure (no
- * I/O) so it can be unit-tested directly. A non-string (absent/unreadable
- * hook) is treated as not chaining.
+ * since that would only *mention* the path rather than invoke it. The path
+ * must also use the documented `$(git rev-parse --show-toplevel)/` prefix
+ * exactly, not merely end in `.githooks/<hookName>` — an unrelated target
+ * such as `"$HOME/.githooks/<hookName>"` never matches, since that string
+ * has no relationship to this repository's own shipped script regardless
+ * of what happens to live at the fixed `.githooks/<hookName>` path this
+ * function's caller separately verifies. The non-`exec` form additionally
+ * requires the documented `|| exit $?` failure-propagation suffix
+ * immediately afterward (only whitespace may separate them) — without
+ * `exec`, a guard failure that isn't explicitly propagated can be silently
+ * swallowed by whatever the hook manager's own dispatcher runs next, so an
+ * invocation lacking that suffix is not accepted as reliable chaining
+ * evidence. Pure (no I/O) so it can be unit-tested directly. A non-string
+ * (absent/unreadable hook) is treated as not chaining.
  */
 export function hookChainsToGithooksScript(
   content: unknown,
@@ -1738,10 +1749,12 @@ export function hookChainsToGithooksScript(
     return false;
   }
   const escaped = escapeRegex(hookName);
-  return new RegExp(
-    `^[ \\t]*(?:exec[ \\t]+)?"[^"#\\n]*\\.githooks/${escaped}"[ \\t]+"\\$@"`,
-    'm',
-  ).test(content);
+  const quotedPath = `"\\$\\(git rev-parse --show-toplevel\\)/\\.githooks/${escaped}"`;
+  const execForm = `exec[ \\t]+${quotedPath}[ \\t]+"\\$@"`;
+  const nonExecForm = `${quotedPath}[ \\t]+"\\$@"[ \\t]*\\|\\|[ \\t]*exit[ \\t]+\\$\\?`;
+  return new RegExp(`^[ \\t]*(?:${execForm}|${nonExecForm})`, 'm').test(
+    content,
+  );
 }
 
 /**

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1760,8 +1760,20 @@ export function hookWiresWorktreeGuard(content: unknown): boolean {
  * joins such a pair into one logical command, so e.g. a `printf '%s' \`
  * line immediately followed by the exec form on the next physical line
  * never actually invokes it; it only passes those words as arguments to
- * the earlier command. Pure (no I/O) so it can be unit-tested directly. A
- * non-string (absent/unreadable hook) is treated as not chaining.
+ * the earlier command.
+ *
+ * Scope boundary: this is a bounded lexical heuristic for the two
+ * documented forms appearing as an ordinary standalone physical line, not
+ * a shell parser. It does not evaluate quoting edge cases, variable
+ * expansion, here-docs, `eval`, subshell wrapping, or any other
+ * adversarial or unusual shell construction that could still reach one of
+ * the two forms at runtime while lexically evading this check (or vice
+ * versa). This is a warning-level misconfiguration diagnostic, not a
+ * security boundary — an operator who wants to fool it can simply not
+ * enable the guard — so further hardening against constructions beyond
+ * the documented recipe is out of scope absent an observed incident.
+ * Pure (no I/O) so it can be unit-tested directly. A non-string
+ * (absent/unreadable hook) is treated as not chaining.
  */
 export function hookChainsToGithooksScript(
   content: unknown,

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -7,7 +7,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { isAbsolute, join, relative, resolve } from 'node:path';
+import { basename, isAbsolute, join, relative, resolve } from 'node:path';
 import {
   normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitabilityMarker,
@@ -1815,13 +1815,21 @@ export function classifyWorktreeGuardActivation({
  *  - sources `_idd-worktree-guard.sh` directly (the base, non-chained
  *    activation path), or
  *  - itself chains to the corresponding `.githooks/<hook>` script via a
- *    documented exec/invocation line, or hands off to the sibling file in
- *    `hooksPath`'s **parent** directory that does (the shape Husky v9's
+ *    documented exec/invocation line, or — **only when `hooksPath`'s last
+ *    path segment is literally `_`**, the exact shape Husky v9's
  *    `core.hooksPath = .husky/_` plus the committed `.husky/<hook>` file
- *    takes — see ONBOARDING.md's "Coexisting with an existing hook
- *    manager"), with that `.githooks/<hook>` script itself confirmed to
- *    genuinely source the guard (defense-in-depth against a chain line
- *    pointing at a missing or tampered target).
+ *    takes (see ONBOARDING.md's "Coexisting with an existing hook
+ *    manager") — hands off to the sibling file in `hooksPath`'s **parent**
+ *    directory that does, with that `.githooks/<hook>` script itself
+ *    confirmed to genuinely source the guard (defense-in-depth against a
+ *    chain line pointing at a missing or tampered target).
+ *
+ * The parent-directory fallback is scoped to that one literal directory
+ * name deliberately: without it, a hook manager placing dispatchers at an
+ * arbitrary directory (e.g. `.other-hooks/dispatch`) could read as wired from
+ * an unrelated file that merely happens to sit in its parent directory and
+ * happens to contain a chain-shaped line, even though nothing connects the
+ * two files (Copilot review, PR #1969).
  *
  * The file at `hooksPath` must actually exist before either chain form is
  * trusted: when a hook manager's install is deleted or incomplete, git has
@@ -1836,6 +1844,7 @@ export function classifyWorktreeGuardActivation({
 export function worktreeGuardWiredAt(root: string, hooksPath: string): boolean {
   const directory = isAbsolute(hooksPath) ? hooksPath : join(root, hooksPath);
   const parentDirectory = join(directory, '..');
+  const isHuskyUnderscoreSplit = basename(directory) === '_';
   const githooksDirectory = join(root, '.githooks');
   const read = (dir: string, name: string): string | null => {
     try {
@@ -1856,7 +1865,8 @@ export function worktreeGuardWiredAt(root: string, hooksPath: string): boolean {
     }
     const chains =
       hookChainsToGithooksScript(atHooksPath, name) ||
-      hookChainsToGithooksScript(read(parentDirectory, name), name);
+      (isHuskyUnderscoreSplit &&
+        hookChainsToGithooksScript(read(parentDirectory, name), name));
     return chains && hookWiresWorktreeGuard(read(githooksDirectory, name));
   };
   return wired('pre-commit') && wired('pre-push');

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -6,8 +6,15 @@
 // .mjs. See docs/typescript-sources.md.
 
 import { execFileSync } from 'node:child_process';
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { basename, isAbsolute, join, relative, resolve } from 'node:path';
+import {
+  accessSync,
+  existsSync,
+  constants as fsConstants,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from 'node:fs';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 import {
   normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitabilityMarker,
@@ -1738,8 +1745,13 @@ export function hookWiresWorktreeGuard(content: unknown): boolean {
  * `exec`, a guard failure that isn't explicitly propagated can be silently
  * swallowed by whatever the hook manager's own dispatcher runs next, so an
  * invocation lacking that suffix is not accepted as reliable chaining
- * evidence. Pure (no I/O) so it can be unit-tested directly. A non-string
- * (absent/unreadable hook) is treated as not chaining.
+ * evidence. Both forms must also end the line (only trailing whitespace and
+ * an optional `#` comment may follow) — a trailing shell operator such as
+ * `| cat` or a backgrounding `&` can decouple the line's own exit status
+ * from the guard's, so a line carrying either form of the two documented
+ * commands plus anything else is not accepted either. Pure (no I/O) so it
+ * can be unit-tested directly. A non-string (absent/unreadable hook) is
+ * treated as not chaining.
  */
 export function hookChainsToGithooksScript(
   content: unknown,
@@ -1750,8 +1762,9 @@ export function hookChainsToGithooksScript(
   }
   const escaped = escapeRegex(hookName);
   const quotedPath = `"\\$\\(git rev-parse --show-toplevel\\)/\\.githooks/${escaped}"`;
-  const execForm = `exec[ \\t]+${quotedPath}[ \\t]+"\\$@"`;
-  const nonExecForm = `${quotedPath}[ \\t]+"\\$@"[ \\t]*\\|\\|[ \\t]*exit[ \\t]+\\$\\?`;
+  const lineEnd = '[ \\t]*(?:#.*)?$';
+  const execForm = `exec[ \\t]+${quotedPath}[ \\t]+"\\$@"${lineEnd}`;
+  const nonExecForm = `${quotedPath}[ \\t]+"\\$@"[ \\t]*\\|\\|[ \\t]*exit[ \\t]+\\$\\?${lineEnd}`;
   return new RegExp(`^[ \\t]*(?:${execForm}|${nonExecForm})`, 'm').test(
     content,
   );
@@ -1810,32 +1823,32 @@ export function classifyWorktreeGuardActivation({
  * documented one-level chain. A relative hooks path resolves against the
  * repository root; an absolute one is used as-is.
  *
- * A hook counts as wired when the file **actually present at
- * `hooksPath`** — the one git itself would invoke — either:
+ * A hook counts as wired when the file **actually present and executable
+ * at `hooksPath`** — the one git itself would invoke, and only when git
+ * would actually invoke it: git silently skips a hook file that exists but
+ * lacks the executable bit — either:
  *  - sources `_idd-worktree-guard.sh` directly (the base, non-chained
  *    activation path), or
  *  - itself chains to the corresponding `.githooks/<hook>` script via a
- *    documented exec/invocation line, or — **only when `hooksPath`'s last
- *    path segment is literally `_`**, the exact shape Husky v9's
+ *    documented exec/invocation line, or — **only when `hooksPath` resolves
+ *    to exactly `.husky/_`**, the precise shape Husky v9's own
  *    `core.hooksPath = .husky/_` plus the committed `.husky/<hook>` file
  *    takes (see ONBOARDING.md's "Coexisting with an existing hook
  *    manager") — hands off to the sibling file in `hooksPath`'s **parent**
  *    directory that does, with that `.githooks/<hook>` script itself
- *    confirmed to genuinely source the guard (defense-in-depth against a
- *    chain line pointing at a missing or tampered target).
+ *    confirmed to both genuinely source the guard and be executable
+ *    (defense-in-depth against a chain line pointing at a missing,
+ *    non-executable, or tampered target).
  *
- * The parent-directory fallback is scoped to that one literal directory
- * name deliberately: without it, a hook manager placing dispatchers at an
- * arbitrary directory (e.g. `.other-hooks/dispatch`) could read as wired from
- * an unrelated file that merely happens to sit in its parent directory and
- * happens to contain a chain-shaped line, even though nothing connects the
- * two files (Copilot review, PR #1969).
- *
- * The file at `hooksPath` must actually exist before either chain form is
- * trusted: when a hook manager's install is deleted or incomplete, git has
- * no active hook to invoke there at all, so a committed chain line living
- * only in the parent directory is not reachable and must not read as
- * wired just because it is present on disk.
+ * The parent-directory fallback checks the **full path** relative to the
+ * repository root, not merely `hooksPath`'s last path segment: matching on
+ * a bare trailing `_` would also fire for an unrelated directory that
+ * happens to end in `_` (e.g. `.other-hooks/_`), and matching on an
+ * arbitrary directory at all — without the executable-bit check above —
+ * would let an unrelated file that merely happens to sit in some other
+ * hooksPath's parent directory, and happens to contain a chain-shaped
+ * line, supply chain evidence for two files with no real dispatch
+ * relationship (Copilot + Codex review, PR #1969).
  *
  * This stays bounded to the documented recipe's two concrete file
  * locations — it does not trace an arbitrary hook manager's own dispatch
@@ -1844,7 +1857,8 @@ export function classifyWorktreeGuardActivation({
 export function worktreeGuardWiredAt(root: string, hooksPath: string): boolean {
   const directory = isAbsolute(hooksPath) ? hooksPath : join(root, hooksPath);
   const parentDirectory = join(directory, '..');
-  const isHuskyUnderscoreSplit = basename(directory) === '_';
+  const isHuskyUnderscoreSplit =
+    relative(root, directory).split('\\').join('/') === '.husky/_';
   const githooksDirectory = join(root, '.githooks');
   const read = (dir: string, name: string): string | null => {
     try {
@@ -1853,21 +1867,33 @@ export function worktreeGuardWiredAt(root: string, hooksPath: string): boolean {
       return null;
     }
   };
+  const isExecutable = (dir: string, name: string): boolean => {
+    try {
+      accessSync(join(dir, name), fsConstants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  };
   const wired = (name: string): boolean => {
     const atHooksPath = read(directory, name);
+    // git silently skips a hook file that exists but isn't executable, so
+    // neither wiring form below is reachable without this bit set.
+    if (atHooksPath === null || !isExecutable(directory, name)) {
+      return false;
+    }
     if (hookWiresWorktreeGuard(atHooksPath)) {
       return true;
-    }
-    // No active hook file at core.hooksPath at all: git has nothing to
-    // invoke here, so a committed chain line elsewhere is unreachable.
-    if (atHooksPath === null) {
-      return false;
     }
     const chains =
       hookChainsToGithooksScript(atHooksPath, name) ||
       (isHuskyUnderscoreSplit &&
         hookChainsToGithooksScript(read(parentDirectory, name), name));
-    return chains && hookWiresWorktreeGuard(read(githooksDirectory, name));
+    return (
+      chains &&
+      hookWiresWorktreeGuard(read(githooksDirectory, name)) &&
+      isExecutable(githooksDirectory, name)
+    );
   };
   return wired('pre-commit') && wired('pre-push');
 }

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -753,6 +753,30 @@ test('hookChainsToGithooksScript rejects a "#" with no preceding whitespace (fal
   );
 });
 
+// Review feedback (PR #1969, chatgpt-codex-connector): the shell joins a
+// line ending in a backslash with the next physical line into one logical
+// command, so a chain-shaped line immediately following a backslash
+// continuation is not actually executed as its own command.
+test('hookChainsToGithooksScript rejects a chain line continued from the preceding backslash-terminated line (false-positive regression)', () => {
+  assert.equal(
+    hookChainsToGithooksScript(
+      'printf %s \\\nexec "$(git rev-parse --show-toplevel)/.githooks/pre-commit" "$@"\n',
+      'pre-commit',
+    ),
+    false,
+  );
+});
+
+test('hookChainsToGithooksScript still accepts a chain line following an ordinary (non-continued) line', () => {
+  assert.equal(
+    hookChainsToGithooksScript(
+      'echo hi\nexec "$(git rev-parse --show-toplevel)/.githooks/pre-commit" "$@"\n',
+      'pre-commit',
+    ),
+    true,
+  );
+});
+
 test('classifyWorktreeGuardActivation returns null when the guard is disabled', () => {
   assert.equal(
     classifyWorktreeGuardActivation({

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -35,6 +35,7 @@ import {
   formatCleanupBacklogRemediation,
   formatCleanupBacklogScanPreamble,
   formatCleanupBacklogScanProgress,
+  hookChainsToGithooksScript,
   hookWiresWorktreeGuard,
   isGithubBackLinkHost,
   parseIsoDurationToHours,
@@ -49,6 +50,7 @@ import {
   resolveConfiguredHelperRuntimeProfile,
   scanFileForPlaceholders,
   stripMarkdownNonText,
+  worktreeGuardWiredAt,
 } from '../src/scripts/idd-doctor.mts';
 import { loadJson } from '../src/scripts/validate-schemas.mts';
 
@@ -589,6 +591,51 @@ test('hookWiresWorktreeGuard treats a non-string (absent hook) as unwired', () =
   assert.equal(hookWiresWorktreeGuard(undefined), false);
 });
 
+test('hookChainsToGithooksScript detects the exec chain form', () => {
+  assert.equal(
+    hookChainsToGithooksScript(
+      '#!/bin/sh\nexec "$(git rev-parse --show-toplevel)/.githooks/pre-commit" "$@"\n',
+      'pre-commit',
+    ),
+    true,
+  );
+});
+
+test('hookChainsToGithooksScript detects the non-exec insertion form', () => {
+  assert.equal(
+    hookChainsToGithooksScript(
+      '#!/bin/sh\n"$(git rev-parse --show-toplevel)/.githooks/pre-push" "$@" || exit $?\nexec ./husky-real-hook\n',
+      'pre-push',
+    ),
+    true,
+  );
+});
+
+test('hookChainsToGithooksScript requires the matching hook name', () => {
+  assert.equal(
+    hookChainsToGithooksScript(
+      'exec "$(git rev-parse --show-toplevel)/.githooks/pre-commit" "$@"\n',
+      'pre-push',
+    ),
+    false,
+  );
+});
+
+test('hookChainsToGithooksScript ignores a commented-out chain line', () => {
+  assert.equal(
+    hookChainsToGithooksScript(
+      '#!/bin/sh\n# exec "$(git rev-parse --show-toplevel)/.githooks/pre-commit" "$@"\n',
+      'pre-commit',
+    ),
+    false,
+  );
+});
+
+test('hookChainsToGithooksScript treats a non-string (absent hook) as not chaining', () => {
+  assert.equal(hookChainsToGithooksScript(null, 'pre-commit'), false);
+  assert.equal(hookChainsToGithooksScript(undefined, 'pre-push'), false);
+});
+
 test('classifyWorktreeGuardActivation returns null when the guard is disabled', () => {
   assert.equal(
     classifyWorktreeGuardActivation({
@@ -636,6 +683,16 @@ test('classifyWorktreeGuardActivation warns (never errors) when enabled-but-iner
   assert.match(finding?.message ?? '', /worktreeGuard\.enabled is true/);
   assert.match(finding?.message ?? '', /core\.hooksPath = \.husky\/_/);
   assert.match(finding?.message ?? '', /git config core\.hooksPath \.githooks/);
+  // The remediation also points a chaining operator at the coexistence
+  // recipe instead of only telling them to repoint core.hooksPath directly.
+  assert.match(
+    finding?.message ?? '',
+    /existing hook manager already owns core\.hooksPath/,
+  );
+  assert.match(
+    finding?.message ?? '',
+    /Coexisting with an existing hook manager/,
+  );
 });
 
 test('classifyWorktreeGuardActivation shows (unset) when core.hooksPath is absent', () => {
@@ -662,6 +719,99 @@ test('readWorktreeGuardEnabled reads worktreeGuard.enabled from config', () => {
     assert.equal(readWorktreeGuardEnabled(dir), false);
     writeConfig({ markerPrefix: 'idd-skill' });
     assert.equal(readWorktreeGuardEnabled(dir), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const GUARD_SOURCE_LINE = '. "$(dirname "$0")/_idd-worktree-guard.sh"\n';
+const chainLine = (hookName: string) =>
+  `exec "$(git rev-parse --show-toplevel)/.githooks/${hookName}" "$@"\n`;
+
+function writeFixtureFile(root: string, relativePath: string, content: string) {
+  const full = join(root, relativePath);
+  mkdirSync(join(full, '..'), { recursive: true });
+  writeFileSync(full, content);
+}
+
+test('worktreeGuardWiredAt: direct .githooks hooksPath wires both hooks (regression)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-guard-wired-'));
+  try {
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-commit',
+      `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
+    );
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-push',
+      `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
+    );
+    assert.equal(worktreeGuardWiredAt(dir, '.githooks'), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('worktreeGuardWiredAt: Husky-shape chain (core.hooksPath=.husky/_, committed .husky/<hook>) reads as wired', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-guard-chain-'));
+  try {
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-commit',
+      `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
+    );
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-push',
+      `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
+    );
+    // Husky's generated dispatcher at core.hooksPath (.husky/_) does not
+    // itself chain; the committed, adopter-edited file lives one directory
+    // up, per ONBOARDING.md's chaining recipe.
+    writeFixtureFile(dir, '.husky/pre-commit', chainLine('pre-commit'));
+    writeFixtureFile(dir, '.husky/pre-push', chainLine('pre-push'));
+    assert.equal(worktreeGuardWiredAt(dir, '.husky/_'), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('worktreeGuardWiredAt: only one hook chained still reads as unwired', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-guard-chain-partial-'));
+  try {
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-commit',
+      `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
+    );
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-push',
+      `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
+    );
+    writeFixtureFile(dir, '.husky/pre-commit', chainLine('pre-commit'));
+    // pre-push was never chained -- still enabled-but-inert overall.
+    writeFixtureFile(
+      dir,
+      '.husky/pre-push',
+      '#!/bin/sh\necho husky pre-push\n',
+    );
+    assert.equal(worktreeGuardWiredAt(dir, '.husky/_'), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('worktreeGuardWiredAt: a chain line pointing at a missing/unwired .githooks target reads as unwired', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-guard-chain-broken-target-'));
+  try {
+    // .githooks/pre-commit does not exist at all -- a chain referencing it
+    // must not read as wired just because a chain line is present.
+    writeFixtureFile(dir, '.githooks/pre-push', 'echo not the guard\n');
+    writeFixtureFile(dir, '.husky/pre-commit', chainLine('pre-commit'));
+    writeFixtureFile(dir, '.husky/pre-push', chainLine('pre-push'));
+    assert.equal(worktreeGuardWiredAt(dir, '.husky/_'), false);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -738,6 +738,21 @@ test('hookChainsToGithooksScript still accepts a trailing comment after either d
   );
 });
 
+// Review feedback (PR #1969, chatgpt-codex-connector): a `#` with no
+// preceding whitespace is not a comment delimiter to a real shell -- it
+// stays part of the same word as the closing quote -- so accepting it
+// blindly let disguised trailing content (e.g. a pipe) back in through the
+// comment escape hatch the prior end-anchor fix added.
+test('hookChainsToGithooksScript rejects a "#" with no preceding whitespace (false-positive regression)', () => {
+  assert.equal(
+    hookChainsToGithooksScript(
+      'exec "$(git rev-parse --show-toplevel)/.githooks/pre-commit" "$@"# | cat\n',
+      'pre-commit',
+    ),
+    false,
+  );
+});
+
 test('classifyWorktreeGuardActivation returns null when the guard is disabled', () => {
   assert.equal(
     classifyWorktreeGuardActivation({

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -636,6 +636,40 @@ test('hookChainsToGithooksScript treats a non-string (absent hook) as not chaini
   assert.equal(hookChainsToGithooksScript(undefined, 'pre-push'), false);
 });
 
+// Review feedback (PR #1969, Copilot + chatgpt-codex-connector): the
+// unanchored `[^"#\n]*` prefix used to let ANY leading command that merely
+// *mentions* the .githooks path -- quoted or not -- read as a genuine
+// chain, even though nothing actually invokes the guard.
+test('hookChainsToGithooksScript rejects an unrelated leading command with an unquoted path (false-positive regression)', () => {
+  assert.equal(
+    hookChainsToGithooksScript(
+      'echo $(git rev-parse --show-toplevel)/.githooks/pre-commit "$@"\n',
+      'pre-commit',
+    ),
+    false,
+  );
+});
+
+test('hookChainsToGithooksScript rejects an unrelated leading command with a quoted path (false-positive regression)', () => {
+  assert.equal(
+    hookChainsToGithooksScript(
+      'echo "$(git rev-parse --show-toplevel)/.githooks/pre-commit" "$@"\n',
+      'pre-commit',
+    ),
+    false,
+  );
+});
+
+test('hookChainsToGithooksScript rejects a bare mention with no exec/invocation at all (false-positive regression)', () => {
+  assert.equal(
+    hookChainsToGithooksScript(
+      '#!/bin/sh\necho "chains to .githooks/pre-commit" "$@"\n',
+      'pre-commit',
+    ),
+    false,
+  );
+});
+
 test('classifyWorktreeGuardActivation returns null when the guard is disabled', () => {
   assert.equal(
     classifyWorktreeGuardActivation({
@@ -727,6 +761,14 @@ test('readWorktreeGuardEnabled reads worktreeGuard.enabled from config', () => {
 const GUARD_SOURCE_LINE = '. "$(dirname "$0")/_idd-worktree-guard.sh"\n';
 const chainLine = (hookName: string) =>
   `exec "$(git rev-parse --show-toplevel)/.githooks/${hookName}" "$@"\n`;
+// Husky v9's own generated core.hooksPath (.husky/_) dispatcher: present on
+// disk (git has something to invoke), but it neither sources the guard nor
+// chains anywhere itself -- the committed, adopter-edited chain line lives
+// one directory up, per ONBOARDING.md's recipe. Fixtures below must create
+// this stub at hooksPath itself, mirroring a real Husky install, or the
+// P1 "no active hook file" guard short-circuits every wired() check to
+// false regardless of what the test actually intends to isolate.
+const HUSKY_DISPATCHER_STUB = '#!/usr/bin/env sh\n. "$(dirname -- "$0")/h"\n';
 
 function writeFixtureFile(root: string, relativePath: string, content: string) {
   const full = join(root, relativePath);
@@ -768,7 +810,10 @@ test('worktreeGuardWiredAt: Husky-shape chain (core.hooksPath=.husky/_, committe
     );
     // Husky's generated dispatcher at core.hooksPath (.husky/_) does not
     // itself chain; the committed, adopter-edited file lives one directory
-    // up, per ONBOARDING.md's chaining recipe.
+    // up, per ONBOARDING.md's chaining recipe. It must still exist on disk
+    // for git to have anything to invoke at all.
+    writeFixtureFile(dir, '.husky/_/pre-commit', HUSKY_DISPATCHER_STUB);
+    writeFixtureFile(dir, '.husky/_/pre-push', HUSKY_DISPATCHER_STUB);
     writeFixtureFile(dir, '.husky/pre-commit', chainLine('pre-commit'));
     writeFixtureFile(dir, '.husky/pre-push', chainLine('pre-push'));
     assert.equal(worktreeGuardWiredAt(dir, '.husky/_'), true);
@@ -790,6 +835,8 @@ test('worktreeGuardWiredAt: only one hook chained still reads as unwired', () =>
       '.githooks/pre-push',
       `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
     );
+    writeFixtureFile(dir, '.husky/_/pre-commit', HUSKY_DISPATCHER_STUB);
+    writeFixtureFile(dir, '.husky/_/pre-push', HUSKY_DISPATCHER_STUB);
     writeFixtureFile(dir, '.husky/pre-commit', chainLine('pre-commit'));
     // pre-push was never chained -- still enabled-but-inert overall.
     writeFixtureFile(
@@ -809,8 +856,38 @@ test('worktreeGuardWiredAt: a chain line pointing at a missing/unwired .githooks
     // .githooks/pre-commit does not exist at all -- a chain referencing it
     // must not read as wired just because a chain line is present.
     writeFixtureFile(dir, '.githooks/pre-push', 'echo not the guard\n');
+    writeFixtureFile(dir, '.husky/_/pre-commit', HUSKY_DISPATCHER_STUB);
+    writeFixtureFile(dir, '.husky/_/pre-push', HUSKY_DISPATCHER_STUB);
     writeFixtureFile(dir, '.husky/pre-commit', chainLine('pre-commit'));
     writeFixtureFile(dir, '.husky/pre-push', chainLine('pre-push'));
+    assert.equal(worktreeGuardWiredAt(dir, '.husky/_'), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// Review feedback (PR #1969, chatgpt-codex-connector P1): when core.hooksPath
+// resolves to the manager's own dispatch directory but its generated hook
+// files are absent -- a deleted/incomplete install -- git has nothing to
+// invoke there at all, so the committed parent-directory chain lines are
+// unreachable and must not read as wired.
+test('worktreeGuardWiredAt: no active hook file at core.hooksPath reads as unwired despite committed chain lines', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-guard-chain-no-active-hook-'));
+  try {
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-commit',
+      `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
+    );
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-push',
+      `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
+    );
+    writeFixtureFile(dir, '.husky/pre-commit', chainLine('pre-commit'));
+    writeFixtureFile(dir, '.husky/pre-push', chainLine('pre-push'));
+    // .husky/_/pre-commit and .husky/_/pre-push (the files git would
+    // actually invoke) are deliberately never created.
     assert.equal(worktreeGuardWiredAt(dir, '.husky/_'), false);
   } finally {
     rmSync(dir, { recursive: true, force: true });

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -922,6 +922,47 @@ test('worktreeGuardWiredAt: no active hook file at core.hooksPath reads as unwir
   }
 });
 
+// Review feedback (PR #1969, Copilot suppressed comment): the
+// parent-directory fallback must be scoped to the documented Husky v9
+// `.husky/_` shape specifically -- otherwise an unrelated coincidental
+// file sitting in some other hooksPath's parent directory (no real
+// dispatch relationship to the active hook at all) could still read as
+// wired evidence.
+test('worktreeGuardWiredAt: parent-directory chain is ignored when hooksPath is not the Husky "_" shape', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-guard-chain-non-underscore-'));
+  try {
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-commit',
+      `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
+    );
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-push',
+      `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
+    );
+    // The file git actually invokes at core.hooksPath: present, but a
+    // no-op that never dispatches anywhere.
+    writeFixtureFile(
+      dir,
+      '.other-hooks/dispatch/pre-commit',
+      '#!/bin/sh\nexit 0\n',
+    );
+    writeFixtureFile(
+      dir,
+      '.other-hooks/dispatch/pre-push',
+      '#!/bin/sh\nexit 0\n',
+    );
+    // A coincidental, unrelated file in the parent directory that happens
+    // to contain a chain-shaped line -- not a real Husky "_"-split sibling.
+    writeFixtureFile(dir, '.other-hooks/pre-commit', chainLine('pre-commit'));
+    writeFixtureFile(dir, '.other-hooks/pre-push', chainLine('pre-push'));
+    assert.equal(worktreeGuardWiredAt(dir, '.other-hooks/dispatch'), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('readWorktreeGuardEnabled returns false when config is missing or invalid', () => {
   const dir = mkdtempSync(join(tmpdir(), 'idd-guard-'));
   try {

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -670,6 +670,34 @@ test('hookChainsToGithooksScript rejects a bare mention with no exec/invocation 
   );
 });
 
+// Review feedback (PR #1969, CodeRabbit): the matcher required only that
+// the quoted path *end* in `.githooks/<hookName>`, so an unrelated target
+// like `$HOME/.githooks/<hookName>` matched too, even though it has no
+// relationship to this repository's own shipped `.githooks/<hookName>`.
+test('hookChainsToGithooksScript rejects a foreign path that only happens to end in .githooks/<hookName> (false-positive regression)', () => {
+  assert.equal(
+    hookChainsToGithooksScript(
+      'exec "$HOME/.githooks/pre-commit" "$@"\n',
+      'pre-commit',
+    ),
+    false,
+  );
+});
+
+// Review feedback (PR #1969, chatgpt-codex-connector): the non-exec form
+// was accepted even without its documented `|| exit $?` failure-propagation
+// suffix, so a guard failure could be silently swallowed by whatever the
+// hook manager's own dispatcher ran next.
+test('hookChainsToGithooksScript rejects a non-exec invocation missing the failure-propagation suffix (false-positive regression)', () => {
+  assert.equal(
+    hookChainsToGithooksScript(
+      '"$(git rev-parse --show-toplevel)/.githooks/pre-commit" "$@"\necho continuing anyway\n',
+      'pre-commit',
+    ),
+    false,
+  );
+});
+
 test('classifyWorktreeGuardActivation returns null when the guard is disabled', () => {
   assert.equal(
     classifyWorktreeGuardActivation({

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -1,5 +1,11 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -698,6 +704,40 @@ test('hookChainsToGithooksScript rejects a non-exec invocation missing the failu
   );
 });
 
+// Review feedback (PR #1969, chatgpt-codex-connector): neither documented
+// form was end-anchored, so a trailing shell operator (piping, or
+// backgrounding) that decouples the line's own exit status from the
+// guard's could still match.
+test('hookChainsToGithooksScript rejects an exec form piped to another command (false-positive regression)', () => {
+  assert.equal(
+    hookChainsToGithooksScript(
+      'exec "$(git rev-parse --show-toplevel)/.githooks/pre-commit" "$@" | cat\n',
+      'pre-commit',
+    ),
+    false,
+  );
+});
+
+test('hookChainsToGithooksScript rejects a non-exec form backgrounded with &  (false-positive regression)', () => {
+  assert.equal(
+    hookChainsToGithooksScript(
+      '"$(git rev-parse --show-toplevel)/.githooks/pre-commit" "$@" || exit $? &\n',
+      'pre-commit',
+    ),
+    false,
+  );
+});
+
+test('hookChainsToGithooksScript still accepts a trailing comment after either documented form', () => {
+  assert.equal(
+    hookChainsToGithooksScript(
+      'exec "$(git rev-parse --show-toplevel)/.githooks/pre-commit" "$@"  # invoke the guard\n',
+      'pre-commit',
+    ),
+    true,
+  );
+});
+
 test('classifyWorktreeGuardActivation returns null when the guard is disabled', () => {
   assert.equal(
     classifyWorktreeGuardActivation({
@@ -802,6 +842,12 @@ function writeFixtureFile(root: string, relativePath: string, content: string) {
   const full = join(root, relativePath);
   mkdirSync(join(full, '..'), { recursive: true });
   writeFileSync(full, content);
+  // git skips a hook file lacking the executable bit; writeFileSync's
+  // default mode does not set it, so every fixture hook file must be made
+  // executable explicitly to be a faithful "active hook" stand-in. Callers
+  // that specifically need a non-executable fixture chmod it back off
+  // afterward.
+  chmodSync(full, 0o755);
 }
 
 test('worktreeGuardWiredAt: direct .githooks hooksPath wires both hooks (regression)', () => {
@@ -958,6 +1004,63 @@ test('worktreeGuardWiredAt: parent-directory chain is ignored when hooksPath is 
     writeFixtureFile(dir, '.other-hooks/pre-commit', chainLine('pre-commit'));
     writeFixtureFile(dir, '.other-hooks/pre-push', chainLine('pre-push'));
     assert.equal(worktreeGuardWiredAt(dir, '.other-hooks/dispatch'), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// Review feedback (PR #1969, chatgpt-codex-connector): the Husky
+// parent-directory fallback must key on the exact `.husky/_` path relative
+// to the repository root, not merely a trailing `_` path segment -- an
+// unrelated directory that happens to also end in `_` (e.g. `.other-hooks/_`)
+// has no real Husky dispatch relationship to its own parent directory.
+test('worktreeGuardWiredAt: a directory merely ending in "_" is not treated as the Husky shape', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-guard-chain-fake-underscore-'));
+  try {
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-commit',
+      `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
+    );
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-push',
+      `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
+    );
+    writeFixtureFile(dir, '.other-hooks/_/pre-commit', '#!/bin/sh\nexit 0\n');
+    writeFixtureFile(dir, '.other-hooks/_/pre-push', '#!/bin/sh\nexit 0\n');
+    writeFixtureFile(dir, '.other-hooks/pre-commit', chainLine('pre-commit'));
+    writeFixtureFile(dir, '.other-hooks/pre-push', chainLine('pre-push'));
+    assert.equal(worktreeGuardWiredAt(dir, '.other-hooks/_'), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// Review feedback (PR #1969, chatgpt-codex-connector P1): git silently
+// skips a hook file that exists but lacks the executable bit, so an
+// existence-only check is not sufficient evidence that git would invoke it.
+test('worktreeGuardWiredAt: a present but non-executable active hook file reads as unwired', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-guard-chain-non-executable-'));
+  try {
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-commit',
+      `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
+    );
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-push',
+      `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
+    );
+    writeFixtureFile(dir, '.husky/_/pre-commit', HUSKY_DISPATCHER_STUB);
+    // Readable, but not executable -- e.g. an incomplete install or a
+    // checkout that lost its mode bit.
+    chmodSync(join(dir, '.husky/_/pre-commit'), 0o644);
+    writeFixtureFile(dir, '.husky/_/pre-push', HUSKY_DISPATCHER_STUB);
+    writeFixtureFile(dir, '.husky/pre-commit', chainLine('pre-commit'));
+    writeFixtureFile(dir, '.husky/pre-push', chainLine('pre-push'));
+    assert.equal(worktreeGuardWiredAt(dir, '.husky/_'), false);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

`idd-doctor`'s enabled-but-inert detector for the B1 worktree guard
only read the hook file at the resolved `core.hooksPath` directly. PR
#1948's documented hook-manager coexistence recipe chains an existing
manager's hook to `exec` the corresponding `.githooks/*` script
instead of fully replacing the manager (Husky v9: `core.hooksPath =
.husky/_`, with the committed chain line living in the sibling
`.husky/<hook>` file one directory up). A correctly chained repository
therefore still reported enabled-but-inert, and the warning's own
remediation told the operator to repoint `core.hooksPath` at
`.githooks` directly — undoing the chain the docs had just
recommended.

This teaches `worktreeGuardWiredAt` a bounded, documented one-level
dispatch check (new `hookChainsToGithooksScript` helper): when a hook
file doesn't source the guard directly, it also checks the file itself
and its parent directory's sibling (the Husky `_`-split shape) for one
of the two documented chain forms, and confirms the referenced
`.githooks/<hook>` script itself genuinely sources the guard before
treating the chain as evidence of wiring. This stays scoped to the
*documented* recipe rather than tracing an arbitrary hook manager's
dispatch machinery, so it doesn't reintroduce the fragility the
issue's alternative fix explicitly wanted to avoid.

Also extends the enabled-but-inert warning's remediation text to point
a chaining operator at the coexistence recipe instead of only the
direct-repoint command, and rewords `ONBOARDING.md`'s two passages
that described this as a "known detector gap" now that it's closed.

## Test plan

- [x] New unit tests for `hookChainsToGithooksScript` (both documented
  chain forms, wrong hook name, commented-out line, non-string input)
- [x] New fixture-based unit tests for `worktreeGuardWiredAt` (direct
  `.githooks` hooksPath regression, Husky-shape fully-chained → wired,
  only-one-hook-chained → unwired, chain pointing at a
  missing/unwired `.githooks` target → unwired)
- [x] Updated existing `classifyWorktreeGuardActivation` test for the
  extended remediation text
- [x] `pnpm run test` (full suite, 3421 tests) passes
- [x] `npx tsc -p tsconfig.json` (typecheck) passes
- [x] `pre-push-validate` (biome, dprint, markdownlint, cspell,
  audit-docs, audit-code-span-wrap, build:check, idd-doctor) passes
  clean

Closes #1951


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `idd-doctor` now recognizes supported hook-manager chains that delegate to matching `.githooks` scripts.
  - Validates active hooks and delegated scripts, including required executable permissions and worktree-guard wiring.
  - Provides clearer activation and remediation guidance for direct and chained configurations.

- **Documentation**
  - Updated onboarding guidance with supported chaining patterns and ephemeral-environment behavior.

- **Bug Fixes**
  - Reduces false positives from comments, unrelated paths, unsafe shell syntax, missing hooks, and incomplete chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->