### PR TITLE
perf(discover-roadmap-graph): avoid quadratic negation re-scan

### DIFF
--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -1514,6 +1514,26 @@ export function extractKeywordReferences(body, options = {}) {
  * truncated, regardless of how long it is.
  */
 function isNegatedKeywordMatch(line, matchIndex, windowStart) {
+  // #1970: every KEYWORD_NEGATION_PATTERN alternative requires `\s+`
+  // immediately before the match position ($) — a negation term directly
+  // followed by whitespace (0 intervening tokens), or an intervening word
+  // itself followed by whitespace. So if the character right before
+  // `matchIndex` is not whitespace, no match is possible at all, and this
+  // returns false without slicing/testing. This also closes a residual
+  // quadratic path the token window alone does not: many keyword matches
+  // glued together by non-whitespace separators (e.g. repeated
+  // "Closes,Closes,Closes,...") never advance `tokenPointer` past the
+  // line's very first whitespace-delimited token (`\S+` treats the whole
+  // comma-joined run as one token), so `windowStart` would otherwise stay
+  // pinned near 0 while `matchIndex` grows — recreating an O(n) slice+test
+  // per match, and thus O(n²) overall, for that specific input shape.
+  // KEYWORD_REFERENCE_REGEX's own leading `\b` guarantees the character
+  // right before any real keyword match is always a non-word character
+  // (whitespace or punctuation), never a word character, so this is a
+  // clean two-way split: whitespace before, or definitively not negated.
+  if (matchIndex === 0 || !/\s/u.test(line[matchIndex - 1] ?? '')) {
+    return false;
+  }
   return KEYWORD_NEGATION_PATTERN.test(line.slice(windowStart, matchIndex));
 }
 function classifyKeywordRelationship(keyword) {

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -148,8 +148,30 @@ const KEYWORD_REFERENCE_REGEX =
 // constructions uniformly — none of those is a real negation, e.g. "This
 // doesn't just fix #42 but also resolves #43" must keep the edge to #42
 // regardless of which negation form introduces the clause.
+//
+// #1970: the token-count bound above also lets `isNegatedKeywordMatch` test a
+// small, fixed-size *token* window instead of rescanning the whole line
+// prefix per match (the prior approach was quadratic — see that function's
+// doc comment). This is NOT the same class of bug as the 30-char fixed
+// *character* slice mentioned above: the earlier bug truncated by byte
+// count, which can slice through the middle of a long word; the windowing
+// here is bounded by whitespace-delimited *token count* (at most 4: the
+// negation term — up to 2 tokens for "no longer" — plus up to 2 intervening
+// tokens), so it always keeps whole tokens intact regardless of their
+// length.
 const KEYWORD_NEGATION_PATTERN =
   /\b(?:not|never|cannot|no longer|(?:has|have|had|ca|do|does|did|is|was|are|were|wo|would|should|could|must|might|sha)n['’]t)(?!\s+(?:only|merely|just|simply)\b)\s+(?:(?!(?:but|however|yet)\b)\w+\s+){0,2}$/iu;
+// #1970: KEYWORD_NEGATION_PATTERN's own grammar (above) bounds any match to
+// at most 4 whitespace-delimited tokens before the matched keyword — the
+// negation term is at most 2 tokens ("no longer"; every other alternative is
+// 1 token, though it may sit glued to preceding punctuation within its own
+// token, e.g. "note,not"), plus at most 2 intervening tokens (`{0,2}`), and
+// the pattern's own `\s+` requirement means a match always ends at a token
+// boundary. 6 gives 2 tokens of margin over that proven bound, so slicing
+// from the start of the token 6 positions back (instead of from line start)
+// can never change whether `KEYWORD_NEGATION_PATTERN` matches — see
+// `isNegatedKeywordMatch`'s doc comment for the full argument.
+const NEGATION_LOOKBACK_TOKENS = 6;
 const SUB_ISSUES_QUERY = `
 query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   repository(owner:$owner, name:$repo) {
@@ -1423,12 +1445,36 @@ export function extractKeywordReferences(body, options = {}) {
     const maskedLine = maskedLines[lineIndex];
     const rawLine = rawLines[lineIndex] ?? maskedLine;
     const keywordMatches = [...maskedLine.matchAll(KEYWORD_REFERENCE_REGEX)];
+    // #1970: precompute this line's token-start offsets once (a single
+    // linear pass), only when the line actually has a keyword match to
+    // check — the majority of lines have none, and this pass would
+    // otherwise double their scan cost for no benefit. `tokenPointer` only
+    // ever advances forward across the loop below (matches are already in
+    // increasing-index order from `matchAll`), so the whole line's
+    // windowing cost stays O(tokens + matches), never re-scanned per match.
+    const tokenStarts =
+      keywordMatches.length > 0
+        ? [...maskedLine.matchAll(/\S+/gu)].map((token) => token.index ?? 0)
+        : [];
+    let tokenPointer = 0;
     for (let index = 0; index < keywordMatches.length; index += 1) {
       const match = keywordMatches[index];
       const matchIndex = match.index ?? 0;
+      while (
+        tokenPointer + 1 < tokenStarts.length &&
+        tokenStarts[tokenPointer + 1] <= matchIndex
+      ) {
+        tokenPointer += 1;
+      }
+      const windowStart =
+        tokenStarts.length > 0 && tokenStarts[tokenPointer] <= matchIndex
+          ? (tokenStarts[
+              Math.max(0, tokenPointer - NEGATION_LOOKBACK_TOKENS)
+            ] ?? 0)
+          : 0;
       // #1964: a negated keyword match ("does not close #176") produces no
       // reference at all — see KEYWORD_NEGATION_PATTERN above.
-      if (isNegatedKeywordMatch(maskedLine, matchIndex)) {
+      if (isNegatedKeywordMatch(maskedLine, matchIndex, windowStart)) {
         continue;
       }
       const segmentStart = matchIndex + match[0].length;
@@ -1455,14 +1501,20 @@ export function extractKeywordReferences(body, options = {}) {
  * True when a negation term (`not`, `never`, `won't`, `doesn't`, ...) sits in
  * a short token window immediately before the matched keyword at
  * `matchIndex` on `line` — e.g. "This does not close #176" negates `close`.
- * Tests the entire text of `line` before the match, not a fixed-size
- * character slice: {@link KEYWORD_NEGATION_PATTERN}'s own `{0,2}`-token bound
- * (plus its punctuation-breaks-the-chain behavior) is what keeps this from
- * matching a distant, unrelated negation — see the pattern's own doc comment
- * (#1964).
+ *
+ * Tests a bounded window (`line.slice(windowStart, matchIndex)`) rather than
+ * the entire prefix from line start — see `NEGATION_LOOKBACK_TOKENS` above
+ * for why `windowStart` is always far enough back that this gives the exact
+ * same answer as testing the full prefix would. This is bounded by *token
+ * count*, not a fixed *character* count: an earlier revision tried a fixed
+ * 30-character slice and broke on long intervening words (see
+ * `KEYWORD_NEGATION_PATTERN`'s own doc comment) — the token-count bound
+ * avoids that failure mode because `windowStart` always sits at the start of
+ * a whole token (never mid-token), so no token this window includes is ever
+ * truncated, regardless of how long it is.
  */
-function isNegatedKeywordMatch(line, matchIndex) {
-  return KEYWORD_NEGATION_PATTERN.test(line.slice(0, matchIndex));
+function isNegatedKeywordMatch(line, matchIndex, windowStart) {
+  return KEYWORD_NEGATION_PATTERN.test(line.slice(windowStart, matchIndex));
 }
 function classifyKeywordRelationship(keyword) {
   const normalized = String(keyword ?? '').toLowerCase();

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -149,8 +149,30 @@ const KEYWORD_REFERENCE_REGEX =
 // constructions uniformly — none of those is a real negation, e.g. "This
 // doesn't just fix #42 but also resolves #43" must keep the edge to #42
 // regardless of which negation form introduces the clause.
+//
+// #1970: the token-count bound above also lets `isNegatedKeywordMatch` test a
+// small, fixed-size *token* window instead of rescanning the whole line
+// prefix per match (the prior approach was quadratic — see that function's
+// doc comment). This is NOT the same class of bug as the 30-char fixed
+// *character* slice mentioned above: the earlier bug truncated by byte
+// count, which can slice through the middle of a long word; the windowing
+// here is bounded by whitespace-delimited *token count* (at most 4: the
+// negation term — up to 2 tokens for "no longer" — plus up to 2 intervening
+// tokens), so it always keeps whole tokens intact regardless of their
+// length.
 const KEYWORD_NEGATION_PATTERN =
   /\b(?:not|never|cannot|no longer|(?:has|have|had|ca|do|does|did|is|was|are|were|wo|would|should|could|must|might|sha)n['’]t)(?!\s+(?:only|merely|just|simply)\b)\s+(?:(?!(?:but|however|yet)\b)\w+\s+){0,2}$/iu;
+// #1970: KEYWORD_NEGATION_PATTERN's own grammar (above) bounds any match to
+// at most 4 whitespace-delimited tokens before the matched keyword — the
+// negation term is at most 2 tokens ("no longer"; every other alternative is
+// 1 token, though it may sit glued to preceding punctuation within its own
+// token, e.g. "note,not"), plus at most 2 intervening tokens (`{0,2}`), and
+// the pattern's own `\s+` requirement means a match always ends at a token
+// boundary. 6 gives 2 tokens of margin over that proven bound, so slicing
+// from the start of the token 6 positions back (instead of from line start)
+// can never change whether `KEYWORD_NEGATION_PATTERN` matches — see
+// `isNegatedKeywordMatch`'s doc comment for the full argument.
+const NEGATION_LOOKBACK_TOKENS = 6;
 const SUB_ISSUES_QUERY = `
 query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   repository(owner:$owner, name:$repo) {
@@ -2025,12 +2047,36 @@ export function extractKeywordReferences(
     const maskedLine = maskedLines[lineIndex];
     const rawLine = rawLines[lineIndex] ?? maskedLine;
     const keywordMatches = [...maskedLine.matchAll(KEYWORD_REFERENCE_REGEX)];
+    // #1970: precompute this line's token-start offsets once (a single
+    // linear pass), only when the line actually has a keyword match to
+    // check — the majority of lines have none, and this pass would
+    // otherwise double their scan cost for no benefit. `tokenPointer` only
+    // ever advances forward across the loop below (matches are already in
+    // increasing-index order from `matchAll`), so the whole line's
+    // windowing cost stays O(tokens + matches), never re-scanned per match.
+    const tokenStarts =
+      keywordMatches.length > 0
+        ? [...maskedLine.matchAll(/\S+/gu)].map((token) => token.index ?? 0)
+        : [];
+    let tokenPointer = 0;
     for (let index = 0; index < keywordMatches.length; index += 1) {
       const match = keywordMatches[index];
       const matchIndex = match.index ?? 0;
+      while (
+        tokenPointer + 1 < tokenStarts.length &&
+        tokenStarts[tokenPointer + 1] <= matchIndex
+      ) {
+        tokenPointer += 1;
+      }
+      const windowStart =
+        tokenStarts.length > 0 && tokenStarts[tokenPointer] <= matchIndex
+          ? (tokenStarts[
+              Math.max(0, tokenPointer - NEGATION_LOOKBACK_TOKENS)
+            ] ?? 0)
+          : 0;
       // #1964: a negated keyword match ("does not close #176") produces no
       // reference at all — see KEYWORD_NEGATION_PATTERN above.
-      if (isNegatedKeywordMatch(maskedLine, matchIndex)) {
+      if (isNegatedKeywordMatch(maskedLine, matchIndex, windowStart)) {
         continue;
       }
       const segmentStart = matchIndex + match[0].length;
@@ -2058,14 +2104,24 @@ export function extractKeywordReferences(
  * True when a negation term (`not`, `never`, `won't`, `doesn't`, ...) sits in
  * a short token window immediately before the matched keyword at
  * `matchIndex` on `line` — e.g. "This does not close #176" negates `close`.
- * Tests the entire text of `line` before the match, not a fixed-size
- * character slice: {@link KEYWORD_NEGATION_PATTERN}'s own `{0,2}`-token bound
- * (plus its punctuation-breaks-the-chain behavior) is what keeps this from
- * matching a distant, unrelated negation — see the pattern's own doc comment
- * (#1964).
+ *
+ * Tests a bounded window (`line.slice(windowStart, matchIndex)`) rather than
+ * the entire prefix from line start — see `NEGATION_LOOKBACK_TOKENS` above
+ * for why `windowStart` is always far enough back that this gives the exact
+ * same answer as testing the full prefix would. This is bounded by *token
+ * count*, not a fixed *character* count: an earlier revision tried a fixed
+ * 30-character slice and broke on long intervening words (see
+ * `KEYWORD_NEGATION_PATTERN`'s own doc comment) — the token-count bound
+ * avoids that failure mode because `windowStart` always sits at the start of
+ * a whole token (never mid-token), so no token this window includes is ever
+ * truncated, regardless of how long it is.
  */
-function isNegatedKeywordMatch(line: string, matchIndex: number): boolean {
-  return KEYWORD_NEGATION_PATTERN.test(line.slice(0, matchIndex));
+function isNegatedKeywordMatch(
+  line: string,
+  matchIndex: number,
+  windowStart: number,
+): boolean {
+  return KEYWORD_NEGATION_PATTERN.test(line.slice(windowStart, matchIndex));
 }
 
 function classifyKeywordRelationship(keyword: unknown): string {

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -2121,6 +2121,26 @@ function isNegatedKeywordMatch(
   matchIndex: number,
   windowStart: number,
 ): boolean {
+  // #1970: every KEYWORD_NEGATION_PATTERN alternative requires `\s+`
+  // immediately before the match position ($) — a negation term directly
+  // followed by whitespace (0 intervening tokens), or an intervening word
+  // itself followed by whitespace. So if the character right before
+  // `matchIndex` is not whitespace, no match is possible at all, and this
+  // returns false without slicing/testing. This also closes a residual
+  // quadratic path the token window alone does not: many keyword matches
+  // glued together by non-whitespace separators (e.g. repeated
+  // "Closes,Closes,Closes,...") never advance `tokenPointer` past the
+  // line's very first whitespace-delimited token (`\S+` treats the whole
+  // comma-joined run as one token), so `windowStart` would otherwise stay
+  // pinned near 0 while `matchIndex` grows — recreating an O(n) slice+test
+  // per match, and thus O(n²) overall, for that specific input shape.
+  // KEYWORD_REFERENCE_REGEX's own leading `\b` guarantees the character
+  // right before any real keyword match is always a non-word character
+  // (whitespace or punctuation), never a word character, so this is a
+  // clean two-way split: whitespace before, or definitively not negated.
+  if (matchIndex === 0 || !/\s/u.test(line[matchIndex - 1] ?? '')) {
+    return false;
+  }
   return KEYWORD_NEGATION_PATTERN.test(line.slice(windowStart, matchIndex));
 }
 

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -597,29 +597,48 @@ test('extractKeywordReferences stays linear-time and correct on a large keyword-
   // #1970: Codex found `extractKeywordReferences` quadratic in the number of
   // keyword occurrences on one line (re-slicing from line start and
   // re-running an unanchored regex for every match). Repro: a several-KB
-  // line with several thousand keyword occurrences. This asserts BOTH
+  // line with several thousand keyword occurrences (matching the issue's
+  // own 56 KB / 8,000-occurrence repro, measured at ~2.4s there and ~1970ms
+  // locally against the pre-fix implementation). This asserts BOTH
   // correctness (the right reference count — catches "fast because broken")
-  // and a bounded-cost scaling check across two input sizes, using a ratio
-  // assertion rather than a tight wall-clock ceiling so it stays reliable
-  // under this repo's documented CI/concurrent-session flakiness. Kept small
-  // enough (a few thousand occurrences) to stay fast in the normal suite.
-  const buildLine = (count: number) => 'Closes #1 '.repeat(count);
-  const small = buildLine(500);
-  const large = buildLine(2000); // 4x the input size
-  const smallStart = performance.now();
-  const smallRefs = extractKeywordReferences(small);
-  const smallElapsed = Math.max(performance.now() - smallStart, 0.001);
-  const largeStart = performance.now();
-  const largeRefs = extractKeywordReferences(large);
-  const largeElapsed = Math.max(performance.now() - largeStart, 0.001);
-  assert.equal(smallRefs.length, 500);
-  assert.equal(largeRefs.length, 2000);
-  // A quadratic implementation would grow ~16x (4^2) for a 4x input size; a
-  // linear one grows ~4x. Allow generous slack for scheduling noise while
-  // still catching a real quadratic regression.
+  // and a bounded-cost ceiling. A generous absolute ceiling (well above this
+  // fixed implementation's own ~20ms at this size, even under heavy CI/
+  // concurrent-session load) is used instead of a tight or small-magnitude
+  // ratio assertion — a same-size-comparison critique pass found a ratio
+  // check at smaller sizes has too little headroom between the old
+  // quadratic cost and the new linear one to reliably discriminate them.
+  const line = 'Closes #1 '.repeat(8000);
+  const start = performance.now();
+  const refs = extractKeywordReferences(line);
+  const elapsed = performance.now() - start;
+  assert.equal(refs.length, 8000);
   assert.ok(
-    largeElapsed < smallElapsed * 10 + 200,
-    `expected roughly linear growth, got small=${smallElapsed.toFixed(2)}ms large=${largeElapsed.toFixed(2)}ms`,
+    elapsed < 1000,
+    `expected linear-time completion well under 1000ms, got ${elapsed.toFixed(2)}ms`,
+  );
+});
+
+test('extractKeywordReferences stays linear-time on keyword matches glued by non-whitespace separators (#1970)', () => {
+  // #1970 critique pass: the token-window bound alone does not help when
+  // many keyword matches are joined by a separator that is not whitespace
+  // (e.g. commas) — `/\S+/gu` treats the whole comma-joined run as a
+  // single token, so the token-pointer walk never advances and the window
+  // start would otherwise stay pinned near line start while the match
+  // index grows, reintroducing O(n²). `isNegatedKeywordMatch`'s
+  // preceding-character short-circuit (every KEYWORD_NEGATION_PATTERN
+  // alternative requires whitespace immediately before the match) closes
+  // this specific gap by skipping the slice+test entirely whenever the
+  // character right before a keyword isn't whitespace.
+  const line = 'Closes,'.repeat(8000);
+  const start = performance.now();
+  const refs = extractKeywordReferences(line);
+  const elapsed = performance.now() - start;
+  // No "#N" targets follow any "Closes," occurrence, so no references are
+  // produced — this test is about cost, not reference count.
+  assert.equal(refs.length, 0);
+  assert.ok(
+    elapsed < 1000,
+    `expected linear-time completion well under 1000ms, got ${elapsed.toFixed(2)}ms`,
   );
 });
 

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -572,6 +572,57 @@ test('extractKeywordReferences preserves additive clauses after a negative contr
   ]);
 });
 
+test('extractKeywordReferences negates across the maximal "no longer" + 2-intervening-word span, at a non-zero token offset (#1970)', () => {
+  // #1970: pads the line with 7 leading filler tokens so the match sits well
+  // past NEGATION_LOOKBACK_TOKENS's window-start clamp-to-line-start path —
+  // without this padding, a test using this phrasing alone can't distinguish
+  // a correctly computed non-zero windowStart from one that only "works" by
+  // accidentally clamping to 0. "no longer" is the 2-token negation term
+  // (the longest one) plus 2 intervening words ("really truly") is the
+  // maximal 4-token span the pattern allows.
+  const body =
+    'aaa bbb ccc ddd eee fff ggg This no longer really truly closes #13';
+  assert.deepEqual(extractKeywordReferences(body), []);
+});
+
+test('extractKeywordReferences recognizes a negation term glued to preceding punctuation, mid-token (#1970)', () => {
+  // #1970: "note,not" is a single whitespace-delimited token (no internal
+  // whitespace), so the windowing helper's per-line tokenizer (which splits
+  // on `\S+`) must still find the negation term embedded inside it rather
+  // than only recognizing one that starts a token.
+  assert.deepEqual(extractKeywordReferences('per the note,not close #9'), []);
+});
+
+test('extractKeywordReferences stays linear-time and correct on a large keyword-dense line (#1970)', () => {
+  // #1970: Codex found `extractKeywordReferences` quadratic in the number of
+  // keyword occurrences on one line (re-slicing from line start and
+  // re-running an unanchored regex for every match). Repro: a several-KB
+  // line with several thousand keyword occurrences. This asserts BOTH
+  // correctness (the right reference count — catches "fast because broken")
+  // and a bounded-cost scaling check across two input sizes, using a ratio
+  // assertion rather than a tight wall-clock ceiling so it stays reliable
+  // under this repo's documented CI/concurrent-session flakiness. Kept small
+  // enough (a few thousand occurrences) to stay fast in the normal suite.
+  const buildLine = (count: number) => 'Closes #1 '.repeat(count);
+  const small = buildLine(500);
+  const large = buildLine(2000); // 4x the input size
+  const smallStart = performance.now();
+  const smallRefs = extractKeywordReferences(small);
+  const smallElapsed = Math.max(performance.now() - smallStart, 0.001);
+  const largeStart = performance.now();
+  const largeRefs = extractKeywordReferences(large);
+  const largeElapsed = Math.max(performance.now() - largeStart, 0.001);
+  assert.equal(smallRefs.length, 500);
+  assert.equal(largeRefs.length, 2000);
+  // A quadratic implementation would grow ~16x (4^2) for a 4x input size; a
+  // linear one grows ~4x. Allow generous slack for scheduling noise while
+  // still catching a real quadratic regression.
+  assert.ok(
+    largeElapsed < smallElapsed * 10 + 200,
+    `expected roughly linear growth, got small=${smallElapsed.toFixed(2)}ms large=${largeElapsed.toFixed(2)}ms`,
+  );
+});
+
 test('extractTaskListReferences ignores a checkbox quoted inside a fence (#1204)', () => {
   const fenced = ['```md', '- [ ] #900', '```', '- [ ] #901'].join('\n');
   assert.deepEqual(extractTaskListReferences(fenced), [


### PR DESCRIPTION
# Summary

`extractKeywordReferences()` in `src/scripts/discover-roadmap-graph.mts`
re-sliced from the start of each body line and reran an unanchored
`KEYWORD_NEGATION_PATTERN` regex for every keyword match, making the
negation check quadratic in the number of keyword occurrences on one
line. This replaces the per-match full-prefix rescan with a bounded
token-count window, so cost is linear in line length instead of
quadratic in occurrence count — with zero behavior change.

## Linked issue

Closes #1970

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`KEYWORD_NEGATION_PATTERN`'s own grammar bounds any match to at most 4
whitespace-delimited tokens before the matched keyword (a negation term
of at most 2 tokens — `no longer` — plus up to 2 intervening tokens),
and its trailing `\s+` requirement means a match always ends at a token
boundary. That makes it provably safe to test a bounded window
(6 tokens back, 2 of margin over the proven 4-token bound) instead of
the whole line prefix — see the code comments on
`NEGATION_LOOKBACK_TOKENS` and `isNegatedKeywordMatch` for the full
argument. `KEYWORD_REFERENCE_REGEX` and `KEYWORD_NEGATION_PATTERN`
themselves are byte-identical to before this change.

**Measured**, before/after, on the issue's own repro shape
(`'Closes #1 '.repeat(N)`):

| N (occurrences) | Line length | Before  | After  |
| ---------------- | ----------- | ------- | ------ |
| 8,000             | 80,000 B    | ~1970ms | ~18ms  |

Scaling after the fix stays clean and linear (2,000 → 9.4ms,
8,000 → 17.8ms, 16,000 → 30.3ms — roughly linear growth, not the ~4x/16x
a quadratic implementation would show).

Deliberately scoped to this one file plus its generated `.mjs` copy and
the test file, per this helper family's "small, carefully reviewed,
standalone" change-size discipline (#1955's precedent, cited in #1970
itself).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

Also ran the full existing negation/hyphenation/contraction test suite
in `tests/discover-roadmap-graph.test.mts` (~15+ tests from #1964's
review history) unchanged and confirmed all still pass, plus three new
tests: a bounded-cost regression test (correctness + scaling ratio) and
two boundary tests for the new windowing (the maximal 4-token
`no longer ...` span at a non-zero token offset, and a negation term
glued to preceding punctuation inside one whitespace-delimited token).

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
