### PR TITLE
docs(issue-authoring): recognize hearing-confirmed marker prefix

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -18,11 +18,12 @@ an afterthought once a marker is already half-drafted.
   `idd-skill` in an installed bundle; use it only when the target
   repository actually configured that value.
 - If the prefix is not discoverable from the repository docs or user
-  context, stop and ask instead of emitting a guessed marker. A prefix
-  the operator already confirmed during an onboarding hearing (Steps
-  1A-1C of `idd-template/ONBOARDING.md`) counts as a resolved value
-  under "user context" — even before it is committed anywhere in the
-  target repository's tree — and does not require asking again.
+  context, stop and ask instead of emitting a guessed marker
+  (preventive; no observed incident yet). A prefix the operator already
+  confirmed during an onboarding hearing (Steps 1A-1C of
+  `idd-template/ONBOARDING.md`) counts as a resolved value under "user
+  context" — even before it is committed anywhere in the target
+  repository's tree — and does not require asking again.
 
 ## Trigger policy
 

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -18,7 +18,11 @@ an afterthought once a marker is already half-drafted.
   `idd-skill` in an installed bundle; use it only when the target
   repository actually configured that value.
 - If the prefix is not discoverable from the repository docs or user
-  context, stop and ask instead of emitting a guessed marker.
+  context, stop and ask instead of emitting a guessed marker. A prefix
+  the operator already confirmed during an onboarding hearing (Steps
+  1A-1C of `idd-template/ONBOARDING.md`) counts as a resolved value
+  under "user context" — even before it is committed anywhere in the
+  target repository's tree — and does not require asking again.
 
 ## Trigger policy
 

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -805,7 +805,11 @@ read safely.
 configured prefix, `idd-skill`, literally — this document describes
 this repository's own convention. Resolve the target repository's
 marker prefix before emitting any authoring marker in an installed
-bundle; never assume `idd-skill` outside this source repository. See
+bundle; never assume `idd-skill` outside this source repository. A
+prefix the operator already confirmed during an onboarding hearing
+(Steps 1A-1C of `idd-template/ONBOARDING.md`) counts as a resolved
+value under "user context" — even before it is committed anywhere in
+the target repository's tree — and does not require asking again. See
 the bundled `contract.md`'s
 [Target marker prefix](https://github.com/kurone-kito/idd-skill/blob/main/skills/issue-authoring/references/contract.md#target-marker-prefix)
 section for the adopter-facing, prefix-parameterized version of this

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -18,11 +18,12 @@ an afterthought once a marker is already half-drafted.
   `idd-skill` in an installed bundle; use it only when the target
   repository actually configured that value.
 - If the prefix is not discoverable from the repository docs or user
-  context, stop and ask instead of emitting a guessed marker. A prefix
-  the operator already confirmed during an onboarding hearing (Steps
-  1A-1C of `idd-template/ONBOARDING.md`) counts as a resolved value
-  under "user context" — even before it is committed anywhere in the
-  target repository's tree — and does not require asking again.
+  context, stop and ask instead of emitting a guessed marker
+  (preventive; no observed incident yet). A prefix the operator already
+  confirmed during an onboarding hearing (Steps 1A-1C of
+  `idd-template/ONBOARDING.md`) counts as a resolved value under "user
+  context" — even before it is committed anywhere in the target
+  repository's tree — and does not require asking again.
 
 ## Trigger policy
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -18,7 +18,11 @@ an afterthought once a marker is already half-drafted.
   `idd-skill` in an installed bundle; use it only when the target
   repository actually configured that value.
 - If the prefix is not discoverable from the repository docs or user
-  context, stop and ask instead of emitting a guessed marker.
+  context, stop and ask instead of emitting a guessed marker. A prefix
+  the operator already confirmed during an onboarding hearing (Steps
+  1A-1C of `idd-template/ONBOARDING.md`) counts as a resolved value
+  under "user context" — even before it is committed anywhere in the
+  target repository's tree — and does not require asking again.
 
 ## Trigger policy
 


### PR DESCRIPTION
# Summary

Clarifies the issue-authoring skill contract's "Target marker prefix"
rule so a marker prefix the operator already confirmed during an
onboarding hearing (Steps 1A-1C of `idd-template/ONBOARDING.md`) counts
as a resolved value under "user context," even before it is committed
anywhere in the target repository's tree. Without this, a strict
reading of the existing "stop and ask" rule could stall a
bootstrap-onboarding session by requiring it to ask again for a value
the operator already gave.

## Linked issue

Closes #1979

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Part of the same "issue-mediated bootstrap onboarding" effort as two
sibling issues in the same batch (a new onboarding doc, and a Step 1B
policy-decision list update). This issue is independently reviewable
and does not block or get blocked by either of them.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [ ] `pnpm test` (docs-only change; no test suite affected)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue-authoring guidance to recognize an operator-confirmed marker prefix during onboarding.
  * Agents no longer need to ask again when the prefix has been confirmed but not yet committed to the target repository.
  * Guidance continues to require resolving the repository prefix and asking when no prefix is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->