### PR TITLE
chore(dx): pick up .gitattributes and VS Code defaults

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -82,6 +82,9 @@ idd-template/scripts/minimize-superseded-markers.mjs linguist-generated=true
 # Every bin/ shim is generated from src/bin/*.mts (whole directory).
 bin/**/*.mjs linguist-generated=true
 
+# Vendored lockfile
+pnpm-lock.yaml linguist-vendored
+
 # Binary files
 *.gif binary
 *.ico binary
@@ -94,4 +97,6 @@ bin/**/*.mjs linguist-generated=true
 .coderabbit.yaml export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+.gitmessage export-ignore
+.husky/** export-ignore
 .imgbotconfig export-ignore

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
+    "biomejs.biome",
     "davidanson.vscode-markdownlint",
     "editorconfig.editorconfig",
     "redhat.vscode-yaml",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,12 @@
 {
+  "editor.defaultFormatter": "biomejs.biome",
   "explorer.fileNesting.enabled": true,
   "explorer.fileNesting.expand": false,
   "explorer.fileNesting.patterns": {
     "*.md": "${capture}.*.md",
     ".gitattributes": ".gitignore, .gitmessage",
     ".markdownlint.*": ".markdownlint-cli2.*",
+    ".tool-versions": ".node-version, .nvmrc",
     "AGENTS.md": "CLAUDE.md, GEMINI.md",
     "package.json": "pnpm-lock.yaml, pnpm-workspace.yaml"
   },
@@ -12,6 +14,9 @@
     ".gitmessage": "git-commit",
     ".imgbotconfig": "json",
     "LICENSE": "plaintext"
+  },
+  "files.readonlyInclude": {
+    "**/node_modules/**/*": true
   },
   "files.watcherExclude": {
     "**/*.tgz": true,


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Pick up three small, low-risk `.gitattributes` and VS Code default gaps
found by comparing this repo against the sibling
`kurone-kito/pnpm-project-template`:

- `.gitattributes`: `export-ignore` `.gitmessage` and `.husky/**`, and
  mark `pnpm-lock.yaml` as `linguist-vendored` — as explicit narrow
  lines, not the template's consolidated `.git*` wildcard form, which
  would also glob-match `.github` and strip `.github/instructions/`
  (this project's shipped product) from `git archive` / "Download ZIP"
  output.
- `.vscode/settings.json`: set Biome as the default formatter, nest
  `.tool-versions` next to `.node-version`/`.nvmrc` in
  `explorer.fileNesting.patterns`, and mark `node_modules` read-only.
- `.vscode/extensions.json`: recommend the Biome VS Code extension,
  matching this repo's actual lint/format stack (`biome.json`).

## Linked issue

Closes #1976

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Deliberately excludes two other `pnpm-project-template` variants the
issue calls out as not applicable here: the `.git*` wildcard
export-ignore form (see above), and the template's
`"package.json": ".npmrc, pnpm-lock.yaml, pnpm-workspace.yaml"` /
`"tsconfig.json": "*.tsbuildinfo"` file-nesting entries (this repo has
no `.npmrc`, and `tsconfig.json` sets `"noEmit": true` with no
`incremental`/`tsBuildInfoFile` option, so no `.tsbuildinfo` is ever
produced at the root).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

Also ran `pnpm run lint:minimum` (the issue's own acceptance criterion)
and confirmed both `.vscode/settings.json` and `.vscode/extensions.json`
stay valid JSON, and `.gitattributes` does not use a `.git*` wildcard
form.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
