### PR TITLE
docs(suitability): add escape-hatch worked example to Check 7 edge cases

### DIFF
--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -247,5 +247,17 @@ and treat as a PASS so work is not blocked by agent capability limits.
 classify as `invalid` and stop rather than treating it as a PASS.
 Failing open on a safety check is a concrete security risk.
 
+**Escape-hatch acceptance criteria**: an either/or acceptance-criteria
+bullet where one branch is a substantive change and the other reads as
+"or document the gap/tradeoff" is not a Check 7 (Verifiability) PASS by
+default just because the second branch sounds safer. Worked example:
+"Add retry logic to the flaky network call, or document why retries are
+unsafe here" leaves an unresolved subjective call — whether a piece of
+documentation adequately discloses a known gap has no automated check
+unless the acceptance criteria state exactly what the documentation must
+say. Evaluate the documentation branch on its own merits, not as an
+automatic pass; if it only restates the bullet without disclosing the
+tradeoff, classify as `needs-decision` rather than PASS.
+
 After A4.5 passes, proceed to `idd-claim.instructions.md`; for rejected
 candidates follow the Failure Outcomes section above.

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -242,5 +242,17 @@ and treat as a PASS so work is not blocked by agent capability limits.
 classify as `invalid` and stop rather than treating it as a PASS.
 Failing open on a safety check is a concrete security risk.
 
+**Escape-hatch acceptance criteria**: an either/or acceptance-criteria
+bullet where one branch is a substantive change and the other reads as
+"or document the gap/tradeoff" is not a Check 7 (Verifiability) PASS by
+default just because the second branch sounds safer. Worked example:
+"Add retry logic to the flaky network call, or document why retries are
+unsafe here" leaves an unresolved subjective call — whether a piece of
+documentation adequately discloses a known gap has no automated check
+unless the acceptance criteria state exactly what the documentation must
+say. Evaluate the documentation branch on its own merits, not as an
+automatic pass; if it only restates the bullet without disclosing the
+tradeoff, classify as `needs-decision` rather than PASS.
+
 After A4.5 passes, proceed to `idd-claim.instructions.md`; for rejected
 candidates follow the Failure Outcomes section above.


### PR DESCRIPTION
# Summary

Adds a worked example naming the "escape-hatch acceptance criteria"
pattern to the Edge Cases list in the canonical
`idd-template/.github/instructions/idd-suitability.instructions.md`
(Check 7 / Verifiability context), then regenerates the repo-root
mirror via `sync-docs`.

## Linked issue

Closes #1984

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Field feedback from a downstream adopter repository
(`kurone-kito/lints-config`) showed that an either/or
acceptance-criteria bullet — where one branch is a substantive change
and the other reads as "or document the gap/tradeoff" — can be
misjudged as mechanically verifiable on a first read, even though
whether the documentation branch adequately discloses a known gap has
no automated check. The `idd-suitability-triage` helper correctly
flagged this via Check 7, but the written instructions did not name
the pattern, so a session running the seven checks without the helper
as a second opinion (a Copilot subagent, or an `instructions-only`
profile) could reach the wrong verdict. This change adds a concrete
worked example to the Edge Cases list so the written checks alone are
sufficient.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
