### PR TITLE
fix(idd-ci): derive --rerun-count mechanically from run_attempt

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -29,8 +29,9 @@ node scripts/ci-wait-policy.mjs
 Prefer `--run-id <run-id>` (from run_attempt; mirrors
 `rerun-advisory-convergence.mts`) to `--rerun-count <count>`. Resolve
 `<profile-selected-ci-wait-policy-command>` from
-`docs/idd-helper-scripts.md`. Do not hardcode `node
-scripts/ci-wait-policy.mjs` for profiles that don't vendor `scripts/`.
+`docs/idd-helper-scripts.md`. Do not hardcode
+`node scripts/ci-wait-policy.mjs` for profiles that don't vendor
+`scripts/`.
 
 ## Shared policy keys
 

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -26,12 +26,11 @@ node scripts/ci-wait-policy.mjs
 <profile-selected-ci-wait-policy-command>
 ```
 
-Append `--run-id <run-id>` (mirrors
-`rerun-advisory-convergence.mts`) or `--rerun-count <count>` for the
-rerun decision. Resolve `<profile-selected-ci-wait-policy-command>` from
-`docs/idd-helper-scripts.md`. Do not hardcode
-`node scripts/ci-wait-policy.mjs` for profiles that don't vendor
-`scripts/`.
+Prefer `--run-id <run-id>` (from run_attempt; mirrors
+`rerun-advisory-convergence.mts`) to `--rerun-count <count>`. Resolve
+`<profile-selected-ci-wait-policy-command>` from
+`docs/idd-helper-scripts.md`. Do not hardcode `node
+scripts/ci-wait-policy.mjs` for profiles that don't vendor `scripts/`.
 
 ## Shared policy keys
 

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -26,9 +26,9 @@ node scripts/ci-wait-policy.mjs
 <profile-selected-ci-wait-policy-command>
 ```
 
-Append `--rerun-count <count>` when the caller needs the deterministic
-rerun-budget decision. Resolve
-`<profile-selected-ci-wait-policy-command>` from
+Append `--run-id <run-id>` (mirrors
+`rerun-advisory-convergence.mts`) or `--rerun-count <count>` for the
+rerun decision. Resolve `<profile-selected-ci-wait-policy-command>` from
 `docs/idd-helper-scripts.md`. Do not hardcode
 `node scripts/ci-wait-policy.mjs` for profiles that don't vendor
 `scripts/`.

--- a/.github/instructions/lite/idd-ci-lite.instructions.md
+++ b/.github/instructions/lite/idd-ci-lite.instructions.md
@@ -42,8 +42,9 @@ CI-polling instructions instead of this file.
 ## Helper-first canonical path
 
 1. Resolve policy: `node scripts/ci-wait-policy.mjs` (append
-   `--rerun-count <count>` for the rerun-budget decision). Resolve the
-   package-manager / ephemeral-npx equivalent from
+   `--run-id <run-id>` — preferred, derives the rerun budget from
+   `run_attempt` — or `--rerun-count <count>` as a manual fallback).
+   Resolve the package-manager / ephemeral-npx equivalent from
    `docs/idd-helper-scripts.md`. This helper already resolves
    `ciWait.*` from `.github/idd/config.json` and emits the final
    `runningTimeout` / `generationTimeout` / `rerunPolicy` values

--- a/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -376,11 +376,11 @@ than the run it supersedes. Once both have completed, the later
    external target rather than an Actions run; or its entry has `type:
    "check-run"` but an empty `url` (the upstream `detailsUrl` was
    itself absent). Otherwise resolve the rerun
-   decision from the
-   run's own history: `gh run view <run-id-from-url> --json attempt` —
-   GitHub's `attempt` starts at `1` for a never-rerun run, so pass
-   `attempt - 1` as `<count>` to `node scripts/ci-wait-policy.mjs
-   --rerun-count <count>`, never this wait's own memory. If it allows
+   decision directly from the run's own live state:
+   `node scripts/ci-wait-policy.mjs --run-id <run-id-from-url>`
+   (`--owner`/`--repo` when targeting a different repository) — this
+   derives the budget mechanically from the run's own `run_attempt`
+   field, never this wait's own memory. If it allows
    a rerun, rerun that check once as a **whole-run rerun, not
    `--failed`** (`gh run rerun <run-id-from-url>`) — a stalled check
    has no failed jobs to selectively rerun, only a run that never

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -677,6 +677,15 @@ The adopted helper boundaries are intentionally narrow:
 - `ci-wait-policy.mjs` is read-only, resolves `ciWait.*` defaults from
   `.github/idd/config.json`, and can evaluate whether the current rerun
   count still permits an automatic rerun
+- `--run-id <run-id>` (with `--owner`/`--repo`, defaulting to the local
+  checkout's own repository) derives that rerun count mechanically from
+  the live run's `run_attempt` field via `gh api
+  repos/{owner}/{repo}/actions/runs/{run-id}`, the same pattern
+  `rerun-advisory-convergence.mjs` already uses for its own budget check
+  — preferred over passing `--rerun-count` by hand, since `run_attempt`
+  is live GitHub state and cross-session-safe by construction; `--rerun-count`
+  keeps working unchanged when `--run-id` is omitted, and serves as an
+  explicit fallback when the `--run-id` lookup fails
 - it does not poll CI, rerun workflows, or replace the CI decision
   table; it only reduces config-copy variance when callers need the
   shared CI wait defaults
@@ -1333,13 +1342,32 @@ to post it is the consuming track's job.
     idd-ci-wait-policy
   ```
 
-- Optional rerun-budget evaluation: append
-  `--rerun-count <count>` to the selected command
+- Optional rerun-budget evaluation, preferred mechanical form: append
+  `--run-id <run-id>` (with `--owner`/`--repo`, defaulting to the local
+  checkout's own repository when omitted) to derive `rerunCount =
+  run_attempt - 1` from the live Actions run (`gh api
+  repos/{owner}/{repo}/actions/runs/{run-id}`), the same `run_attempt`
+  pattern `rerun-advisory-convergence.mjs` already uses for its own
+  budget check
+- Optional rerun-budget evaluation, manual/offline form: append
+  `--rerun-count <count>` to the selected command instead — this keeps
+  working unchanged when `--run-id` is omitted, and serves as the
+  explicit fallback if `--run-id`'s live lookup fails (network/
+  permission error, or a missing/non-numeric `run_attempt` in the
+  fetched payload). `--run-id` takes precedence over `--rerun-count`
+  only when both are given and the live lookup succeeds; with no
+  `--rerun-count` fallback, a failed `--run-id` lookup exits non-zero
+  with a clear reason instead of silently resolving to a `0` rerun count
 - Stable fields consumed by instructions or helpers:
   `policy.runningTimeout`, `policy.runningTimeoutMs`,
   `policy.generationTimeout`, `policy.generationTimeoutMs`,
   `policy.rerunPolicy`, and optional `rerunDecision.action` /
-  `rerunDecision.reason`
+  `rerunDecision.reason`. When `--run-id` was given: `rerunCountSource`
+  (`"run-id"` or `"rerun-count"`, reporting which source ultimately
+  supplied `rerunDecision`'s `rerunCount`), `runAttempt` (the fetched
+  run's raw `run_attempt`, only present on a successful live lookup),
+  and `runIdLookupError` (only present when the live lookup failed but a
+  `--rerun-count` fallback was available)
 - it remains read-only; the command does not poll CI, rerun workflows,
   or post any GitHub comment
 

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -24,8 +24,9 @@ node scripts/ci-wait-policy.mjs
 Prefer `--run-id <run-id>` (from run_attempt; mirrors
 `rerun-advisory-convergence.mts`) to `--rerun-count <count>`. Resolve
 `<profile-selected-ci-wait-policy-command>` from
-`docs/idd-helper-scripts.md`. Do not hardcode `node
-scripts/ci-wait-policy.mjs` for profiles that don't vendor `scripts/`.
+`docs/idd-helper-scripts.md`. Do not hardcode
+`node scripts/ci-wait-policy.mjs` for profiles that don't vendor
+`scripts/`.
 
 ## Shared policy keys
 

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -21,9 +21,9 @@ node scripts/ci-wait-policy.mjs
 <profile-selected-ci-wait-policy-command>
 ```
 
-Append `--rerun-count <count>` when the caller needs the deterministic
-rerun-budget decision. Resolve
-`<profile-selected-ci-wait-policy-command>` from
+Append `--run-id <run-id>` (mirrors
+`rerun-advisory-convergence.mts`) or `--rerun-count <count>` for the
+rerun decision. Resolve `<profile-selected-ci-wait-policy-command>` from
 `docs/idd-helper-scripts.md`. Do not hardcode
 `node scripts/ci-wait-policy.mjs` for profiles that don't vendor
 `scripts/`.

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -21,12 +21,11 @@ node scripts/ci-wait-policy.mjs
 <profile-selected-ci-wait-policy-command>
 ```
 
-Append `--run-id <run-id>` (mirrors
-`rerun-advisory-convergence.mts`) or `--rerun-count <count>` for the
-rerun decision. Resolve `<profile-selected-ci-wait-policy-command>` from
-`docs/idd-helper-scripts.md`. Do not hardcode
-`node scripts/ci-wait-policy.mjs` for profiles that don't vendor
-`scripts/`.
+Prefer `--run-id <run-id>` (from run_attempt; mirrors
+`rerun-advisory-convergence.mts`) to `--rerun-count <count>`. Resolve
+`<profile-selected-ci-wait-policy-command>` from
+`docs/idd-helper-scripts.md`. Do not hardcode `node
+scripts/ci-wait-policy.mjs` for profiles that don't vendor `scripts/`.
 
 ## Shared policy keys
 

--- a/idd-template/.github/instructions/lite/idd-ci-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-ci-lite.instructions.md
@@ -37,8 +37,9 @@ CI-polling instructions instead of this file.
 ## Helper-first canonical path
 
 1. Resolve policy: `node scripts/ci-wait-policy.mjs` (append
-   `--rerun-count <count>` for the rerun-budget decision). Resolve the
-   package-manager / ephemeral-npx equivalent from
+   `--run-id <run-id>` — preferred, derives the rerun budget from
+   `run_attempt` — or `--rerun-count <count>` as a manual fallback).
+   Resolve the package-manager / ephemeral-npx equivalent from
    `docs/idd-helper-scripts.md`. This helper already resolves
    `ciWait.*` from `.github/idd/config.json` and emits the final
    `runningTimeout` / `generationTimeout` / `rerunPolicy` values

--- a/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -371,11 +371,11 @@ than the run it supersedes. Once both have completed, the later
    external target rather than an Actions run; or its entry has `type:
    "check-run"` but an empty `url` (the upstream `detailsUrl` was
    itself absent). Otherwise resolve the rerun
-   decision from the
-   run's own history: `gh run view <run-id-from-url> --json attempt` —
-   GitHub's `attempt` starts at `1` for a never-rerun run, so pass
-   `attempt - 1` as `<count>` to `node scripts/ci-wait-policy.mjs
-   --rerun-count <count>`, never this wait's own memory. If it allows
+   decision directly from the run's own live state:
+   `node scripts/ci-wait-policy.mjs --run-id <run-id-from-url>`
+   (`--owner`/`--repo` when targeting a different repository) — this
+   derives the budget mechanically from the run's own `run_attempt`
+   field, never this wait's own memory. If it allows
    a rerun, rerun that check once as a **whole-run rerun, not
    `--failed`** (`gh run rerun <run-id-from-url>`) — a stalled check
    has no failed jobs to selectively rerun, only a run that never

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -677,6 +677,15 @@ The adopted helper boundaries are intentionally narrow:
 - `ci-wait-policy.mjs` is read-only, resolves `ciWait.*` defaults from
   `.github/idd/config.json`, and can evaluate whether the current rerun
   count still permits an automatic rerun
+- `--run-id <run-id>` (with `--owner`/`--repo`, defaulting to the local
+  checkout's own repository) derives that rerun count mechanically from
+  the live run's `run_attempt` field via `gh api
+  repos/{owner}/{repo}/actions/runs/{run-id}`, the same pattern
+  `rerun-advisory-convergence.mjs` already uses for its own budget check
+  — preferred over passing `--rerun-count` by hand, since `run_attempt`
+  is live GitHub state and cross-session-safe by construction; `--rerun-count`
+  keeps working unchanged when `--run-id` is omitted, and serves as an
+  explicit fallback when the `--run-id` lookup fails
 - it does not poll CI, rerun workflows, or replace the CI decision
   table; it only reduces config-copy variance when callers need the
   shared CI wait defaults
@@ -1333,13 +1342,32 @@ to post it is the consuming track's job.
     idd-ci-wait-policy
   ```
 
-- Optional rerun-budget evaluation: append
-  `--rerun-count <count>` to the selected command
+- Optional rerun-budget evaluation, preferred mechanical form: append
+  `--run-id <run-id>` (with `--owner`/`--repo`, defaulting to the local
+  checkout's own repository when omitted) to derive `rerunCount =
+  run_attempt - 1` from the live Actions run (`gh api
+  repos/{owner}/{repo}/actions/runs/{run-id}`), the same `run_attempt`
+  pattern `rerun-advisory-convergence.mjs` already uses for its own
+  budget check
+- Optional rerun-budget evaluation, manual/offline form: append
+  `--rerun-count <count>` to the selected command instead — this keeps
+  working unchanged when `--run-id` is omitted, and serves as the
+  explicit fallback if `--run-id`'s live lookup fails (network/
+  permission error, or a missing/non-numeric `run_attempt` in the
+  fetched payload). `--run-id` takes precedence over `--rerun-count`
+  only when both are given and the live lookup succeeds; with no
+  `--rerun-count` fallback, a failed `--run-id` lookup exits non-zero
+  with a clear reason instead of silently resolving to a `0` rerun count
 - Stable fields consumed by instructions or helpers:
   `policy.runningTimeout`, `policy.runningTimeoutMs`,
   `policy.generationTimeout`, `policy.generationTimeoutMs`,
   `policy.rerunPolicy`, and optional `rerunDecision.action` /
-  `rerunDecision.reason`
+  `rerunDecision.reason`. When `--run-id` was given: `rerunCountSource`
+  (`"run-id"` or `"rerun-count"`, reporting which source ultimately
+  supplied `rerunDecision`'s `rerunCount`), `runAttempt` (the fetched
+  run's raw `run_attempt`, only present on a successful live lookup),
+  and `runIdLookupError` (only present when the live lookup failed but a
+  `--rerun-count` fallback was available)
 - it remains read-only; the command does not poll CI, rerun workflows,
   or post any GitHub comment
 

--- a/scripts/ci-wait-policy.mjs
+++ b/scripts/ci-wait-policy.mjs
@@ -7,6 +7,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { parseCanonicalIntegerOrThrow, parseCliArgs } from './cli-args.mjs';
+import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
 import { loadJson, validateConfigSection } from './validate-schemas.mjs';
 
 const DEFAULT_RUNNING_TIMEOUT = 'PT30M';
@@ -40,6 +41,9 @@ export const DEFAULT_CI_WAIT_POLICY = Object.freeze({
 const CI_WAIT_POLICY_FLAG_SPEC = {
   '--policy': { type: 'string', default: DEFAULT_POLICY_PATH },
   '--rerun-count': { type: 'string' },
+  '--run-id': { type: 'string' },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
   '--help': { type: 'boolean', short: 'h' },
 };
 if (import.meta.main) {
@@ -127,6 +131,57 @@ export function resolveCiRerunDecision({
     rerunCount: normalizedCount,
   };
 }
+/**
+ * Derive the CI-wait rerun count mechanically from a live Actions run's
+ * `run_attempt` field: `run_attempt` starts at `1` for the original run and
+ * increments by one on every rerun (`gh run rerun`, regardless of which
+ * session or actor issued it, including a human clicking "Re-run failed
+ * jobs" in the GitHub UI), so `run_attempt - 1` is exactly "how many times
+ * has this run already been rerun" -- the same quantity `--rerun-count`
+ * otherwise requires the caller to track manually, session-locally (#1996).
+ *
+ * Mirrors `rerun-advisory-convergence.mts`'s `resolveInstanceRerunDecision`,
+ * which treats a missing or non-numeric `run_attempt` as fail-closed
+ * (`'run-attempt-unknown'`) rather than silently deriving `rerunCount: 0`
+ * from a guess -- the same reasoning applies here: `resolveCiRerunDecision`
+ * would otherwise resolve an invented `0` to `action: 'rerun'`, which is
+ * never something this helper should decide from unreadable data. A
+ * `run_attempt: 0` is rejected by the `>= 1` bound below for the same
+ * reason -- letting it through would produce `rerunCount: -1`, which
+ * `resolveCiRerunDecision`'s own non-negative-integer normalization
+ * silently collapses back to `0`, reintroducing the exact silent-zero this
+ * function exists to prevent.
+ */
+export function deriveRerunCountFromRunAttempt(runAttempt) {
+  if (
+    typeof runAttempt === 'number' &&
+    Number.isInteger(runAttempt) &&
+    runAttempt >= 1
+  ) {
+    return runAttempt - 1;
+  }
+  throw new Error(
+    `cannot derive --rerun-count from run_attempt: expected a positive integer, got ${JSON.stringify(runAttempt)}`,
+  );
+}
+/**
+ * Fetch the live Actions run `runId` (`GET
+ * repos/{owner}/{repo}/actions/runs/{run_id}`) and derive its rerun count
+ * via {@link deriveRerunCountFromRunAttempt}. Reuses the same
+ * `ghText`/`GH_TEXT_LOOP_TIMEOUT_OPTIONS` timeout-guarded pattern
+ * `rerun-advisory-convergence.mts`'s `collectFromGitHub` already uses for
+ * the identical per-run `run_attempt` lookup, so a stalled or
+ * unexpectedly-interactive `gh` call here fails closed within a bounded
+ * timeout instead of hanging this policy resolver indefinitely.
+ */
+export function fetchRerunCountFromRunId(owner, repo, runId) {
+  const raw = ghText(
+    ['api', `repos/${owner}/${repo}/actions/runs/${runId}`],
+    GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  );
+  const payload = JSON.parse(raw);
+  return deriveRerunCountFromRunAttempt(payload.run_attempt);
+}
 function normalizeDuration(value, fallback) {
   if (parseDurationToMs(value) === null) {
     return fallback;
@@ -144,13 +199,53 @@ function runCli() {
     process.exit(0);
   }
   const policy = readCiWaitPolicy(args.policy);
-  const output = {
-    policy,
-  };
-  if (args.rerunCount !== null) {
+  const output = { policy };
+  let rerunCount = args.rerunCount;
+  if (args.runId !== null) {
+    const owner =
+      args.owner ||
+      ghText(
+        ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      );
+    const repo =
+      args.repo ||
+      ghText(
+        ['repo', 'view', '--json', 'name', '--jq', '.name'],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      );
+    try {
+      rerunCount = fetchRerunCountFromRunId(owner, repo, args.runId);
+      output.rerunCountSource = 'run-id';
+      output.runAttempt = rerunCount + 1;
+    } catch (error) {
+      // #1996: unifies two distinct failure modes -- the `gh api` call
+      // itself failing (network/permission/transient), and the call
+      // succeeding but returning a payload with a missing or non-numeric
+      // `run_attempt` (deriveRerunCountFromRunAttempt's own throw) -- into
+      // one "the live lookup did not yield a usable rerunCount" outcome,
+      // matching how rerun-advisory-convergence.mts's own collection step
+      // unifies both into the same `runAttempt: null` signal. `--run-id`
+      // takes precedence over `--rerun-count` only when the live lookup
+      // actually succeeds; on either failure mode, fall back to an
+      // explicitly-given `--rerun-count` (the issue's own "explicit
+      // override / offline path" language), or fail closed with a clear,
+      // non-zero exit -- never a silent `rerunCount: 0`.
+      if (args.rerunCount === null) {
+        throw new Error(
+          `--run-id ${args.runId} lookup failed and no --rerun-count fallback was given: ${error.message}`,
+          { cause: error },
+        );
+      }
+      output.rerunCountSource = 'rerun-count';
+      output.runIdLookupError = error.message;
+      rerunCount = args.rerunCount;
+    }
+  }
+  if (rerunCount !== null) {
     output.rerunDecision = resolveCiRerunDecision({
       rerunPolicy: policy.rerunPolicy,
-      rerunCount: args.rerunCount,
+      rerunCount,
     });
   }
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
@@ -158,6 +253,14 @@ function runCli() {
 function parseArgs(argv) {
   const { values, help } = parseCliArgs(argv, CI_WAIT_POLICY_FLAG_SPEC);
   const rerunCountToken = values['rerun-count'];
+  const runIdToken = values['run-id'];
+  const owner = values.owner.trim();
+  const repo = values.repo.trim();
+  if (Boolean(owner) !== Boolean(repo)) {
+    throw new Error(
+      '--owner and --repo must be given together (both or neither)',
+    );
+  }
   return {
     policy: values.policy,
     // `min: 0`: --rerun-count is a non-negative counter (0 is a valid
@@ -169,14 +272,35 @@ function parseArgs(argv) {
       rerunCountToken === undefined
         ? null
         : parseCanonicalIntegerOrThrow(rerunCountToken, '--rerun-count', 0),
+    // `min: 1`: a workflow run id is never `0` -- mirrors the positive-
+    // integer contract this file's `--rerun-count` sibling deliberately
+    // opts out of (see the `min: 0` note above).
+    runId:
+      runIdToken === undefined
+        ? null
+        : String(parseCanonicalIntegerOrThrow(runIdToken, '--run-id', 1)),
+    owner,
+    repo,
     help,
   };
 }
 function printHelp() {
   process.stdout.write(`Usage:
   node scripts/ci-wait-policy.mjs [--policy <path>] [--rerun-count <count>]
+    [--run-id <run-id> [--owner <owner> --repo <repo>]]
 
 Resolves the shared ciWait policy defaults from .github/idd/config.json.
 Optionally emits the deterministic rerun decision for a current rerun count.
+
+--run-id fetches the live Actions run via
+'gh api repos/{owner}/{repo}/actions/runs/{run-id}' and derives
+rerunCount = run_attempt - 1 mechanically, taking precedence over
+--rerun-count when the lookup succeeds. --owner/--repo default to the
+local checkout's own repository when omitted (gh repo view); pass both or
+neither. --rerun-count keeps working unchanged when --run-id is omitted,
+and serves as the explicit override/offline fallback when the --run-id
+lookup fails (network/permission error, or a missing/non-numeric
+run_attempt in the fetched payload) -- absent that fallback, the CLI exits
+non-zero rather than silently emitting rerunCount: 0.
 `);
 }

--- a/scripts/ci-wait-policy.mjs
+++ b/scripts/ci-wait-policy.mjs
@@ -15,6 +15,14 @@ const DEFAULT_GENERATION_TIMEOUT = 'PT10M';
 const DEFAULT_RERUN_POLICY = 'rerun-once';
 const DEFAULT_POLICY_PATH = '.github/idd/config.json';
 const RERUN_POLICIES = new Set(['rerun-once', 'hold']);
+/** A conservative GitHub owner/repo identifier character class --
+ * alphanumeric, hyphen, underscore, period. Mirrors
+ * `rerun-advisory-convergence.mts`'s own `GITHUB_IDENTIFIER_PATTERN` for
+ * the identical `--owner`/`--repo` flags: not GitHub's exact validation
+ * rule, just a defensive CLI-input guard against whitespace or a shell
+ * metacharacter reaching the `gh api repos/{owner}/{repo}/...` path this
+ * file's `--run-id` resolution builds from these values. */
+const GITHUB_IDENTIFIER_PATTERN = /^[A-Za-z0-9_.-]+$/;
 const ISO_DURATION_PATTERN =
   /^P(?=\d|T\d)(?:(\d+)D)?(?:T(?=\d)(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/;
 const POLICY_SCHEMA = loadJson('schemas/policy.schema.json');
@@ -202,35 +210,48 @@ function runCli() {
   const output = { policy };
   let rerunCount = args.rerunCount;
   if (args.runId !== null) {
-    const owner =
-      args.owner ||
-      ghText(
-        ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
-        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-      );
-    const repo =
-      args.repo ||
-      ghText(
-        ['repo', 'view', '--json', 'name', '--jq', '.name'],
-        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-      );
+    // #1996: owner/repo auto-detection (`gh repo view`) lives INSIDE this
+    // try block, not just the `fetchRerunCountFromRunId` call below -- a
+    // caller can give `--run-id` with neither `--owner` nor `--repo`, and
+    // a failure resolving either (same network/permission/transient class
+    // as the run lookup itself) is just as much "the live lookup did not
+    // yield a usable rerunCount" as a failure inside
+    // fetchRerunCountFromRunId. Excluding it from the try would let that
+    // one failure mode crash uncaught instead of falling back to an
+    // explicitly-given --rerun-count, silently breaking the documented
+    // fallback contract for exactly this path (caught by the C1 critique
+    // pass; regression-guarded by the "resolves owner/repo INSIDE the
+    // fallback" CLI test below).
     try {
+      const owner =
+        args.owner ||
+        ghText(
+          ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+          GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+        );
+      const repo =
+        args.repo ||
+        ghText(
+          ['repo', 'view', '--json', 'name', '--jq', '.name'],
+          GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+        );
       rerunCount = fetchRerunCountFromRunId(owner, repo, args.runId);
       output.rerunCountSource = 'run-id';
       output.runAttempt = rerunCount + 1;
     } catch (error) {
-      // #1996: unifies two distinct failure modes -- the `gh api` call
-      // itself failing (network/permission/transient), and the call
-      // succeeding but returning a payload with a missing or non-numeric
-      // `run_attempt` (deriveRerunCountFromRunAttempt's own throw) -- into
-      // one "the live lookup did not yield a usable rerunCount" outcome,
-      // matching how rerun-advisory-convergence.mts's own collection step
-      // unifies both into the same `runAttempt: null` signal. `--run-id`
-      // takes precedence over `--rerun-count` only when the live lookup
-      // actually succeeds; on either failure mode, fall back to an
-      // explicitly-given `--rerun-count` (the issue's own "explicit
-      // override / offline path" language), or fail closed with a clear,
-      // non-zero exit -- never a silent `rerunCount: 0`.
+      // #1996: unifies three distinct failure modes -- owner/repo
+      // auto-detection failing, the `gh api` run lookup itself failing
+      // (network/permission/transient), and the lookup succeeding but
+      // returning a payload with a missing or non-numeric `run_attempt`
+      // (deriveRerunCountFromRunAttempt's own throw) -- into one "the live
+      // lookup did not yield a usable rerunCount" outcome, matching how
+      // rerun-advisory-convergence.mts's own collection step unifies
+      // several failure sources into the same `runAttempt: null` signal.
+      // `--run-id` takes precedence over `--rerun-count` only when the
+      // live lookup actually succeeds; on any of these failure modes, fall
+      // back to an explicitly-given `--rerun-count` (the issue's own
+      // "explicit override / offline path" language), or fail closed with
+      // a clear, non-zero exit -- never a silent `rerunCount: 0`.
       if (args.rerunCount === null) {
         throw new Error(
           `--run-id ${args.runId} lookup failed and no --rerun-count fallback was given: ${error.message}`,
@@ -259,6 +280,16 @@ function parseArgs(argv) {
   if (Boolean(owner) !== Boolean(repo)) {
     throw new Error(
       '--owner and --repo must be given together (both or neither)',
+    );
+  }
+  if (owner && !GITHUB_IDENTIFIER_PATTERN.test(owner)) {
+    throw new Error(
+      '--owner must contain only letters, digits, hyphens, underscores, or periods',
+    );
+  }
+  if (repo && !GITHUB_IDENTIFIER_PATTERN.test(repo)) {
+    throw new Error(
+      '--repo must contain only letters, digits, hyphens, underscores, or periods',
     );
   }
   return {

--- a/scripts/ci-wait-policy.mjs
+++ b/scripts/ci-wait-policy.mjs
@@ -271,6 +271,21 @@ function runCli() {
   }
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
 }
+/**
+ * Validate `token` as a canonical positive-integer string (same format and
+ * `min: 1` bound `--rerun-count`'s sibling validation uses), but return the
+ * ORIGINAL string rather than `parseCanonicalIntegerOrThrow`'s numeric
+ * return value. A GitHub Actions run id is used only as an opaque path
+ * segment (`repos/{owner}/{repo}/actions/runs/{run-id}`) -- round-tripping
+ * it through a JavaScript `number` risks silent precision loss above
+ * `Number.MAX_SAFE_INTEGER` (Copilot review, PR #1998), which this
+ * function avoids by discarding the parsed number and keeping the
+ * caller-supplied digits verbatim once format/bound validation passes.
+ */
+function validateRunIdToken(token) {
+  parseCanonicalIntegerOrThrow(token, '--run-id', 1);
+  return token;
+}
 function parseArgs(argv) {
   const { values, help } = parseCliArgs(argv, CI_WAIT_POLICY_FLAG_SPEC);
   const rerunCountToken = values['rerun-count'];
@@ -305,11 +320,15 @@ function parseArgs(argv) {
         : parseCanonicalIntegerOrThrow(rerunCountToken, '--rerun-count', 0),
     // `min: 1`: a workflow run id is never `0` -- mirrors the positive-
     // integer contract this file's `--rerun-count` sibling deliberately
-    // opts out of (see the `min: 0` note above).
-    runId:
-      runIdToken === undefined
-        ? null
-        : String(parseCanonicalIntegerOrThrow(runIdToken, '--run-id', 1)),
+    // opts out of (see the `min: 0` note above). Deliberately keeps the
+    // ORIGINAL string token, not `String(parseCanonicalIntegerOrThrow(...))`
+    // -- a run id above `Number.MAX_SAFE_INTEGER` would silently round
+    // through that number round-trip (e.g. `9007199254740993` becomes
+    // `9007199254740992`), querying a different run than the caller
+    // requested (Copilot review, PR #1998). `parseCanonicalIntegerOrThrow`
+    // is still called for its format/bound validation and shaped-error
+    // throw -- its numeric return value is discarded on purpose.
+    runId: runIdToken === undefined ? null : validateRunIdToken(runIdToken),
     owner,
     repo,
     help,

--- a/src/scripts/ci-wait-policy.mts
+++ b/src/scripts/ci-wait-policy.mts
@@ -17,6 +17,14 @@ const DEFAULT_GENERATION_TIMEOUT = 'PT10M';
 const DEFAULT_RERUN_POLICY = 'rerun-once';
 const DEFAULT_POLICY_PATH = '.github/idd/config.json';
 const RERUN_POLICIES = new Set(['rerun-once', 'hold']);
+/** A conservative GitHub owner/repo identifier character class --
+ * alphanumeric, hyphen, underscore, period. Mirrors
+ * `rerun-advisory-convergence.mts`'s own `GITHUB_IDENTIFIER_PATTERN` for
+ * the identical `--owner`/`--repo` flags: not GitHub's exact validation
+ * rule, just a defensive CLI-input guard against whitespace or a shell
+ * metacharacter reaching the `gh api repos/{owner}/{repo}/...` path this
+ * file's `--run-id` resolution builds from these values. */
+const GITHUB_IDENTIFIER_PATTERN = /^[A-Za-z0-9_.-]+$/;
 const ISO_DURATION_PATTERN =
   /^P(?=\d|T\d)(?:(\d+)D)?(?:T(?=\d)(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/;
 const POLICY_SCHEMA = loadJson('schemas/policy.schema.json');
@@ -282,35 +290,48 @@ function runCli(): void {
   let rerunCount = args.rerunCount;
 
   if (args.runId !== null) {
-    const owner =
-      args.owner ||
-      ghText(
-        ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
-        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-      );
-    const repo =
-      args.repo ||
-      ghText(
-        ['repo', 'view', '--json', 'name', '--jq', '.name'],
-        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-      );
+    // #1996: owner/repo auto-detection (`gh repo view`) lives INSIDE this
+    // try block, not just the `fetchRerunCountFromRunId` call below -- a
+    // caller can give `--run-id` with neither `--owner` nor `--repo`, and
+    // a failure resolving either (same network/permission/transient class
+    // as the run lookup itself) is just as much "the live lookup did not
+    // yield a usable rerunCount" as a failure inside
+    // fetchRerunCountFromRunId. Excluding it from the try would let that
+    // one failure mode crash uncaught instead of falling back to an
+    // explicitly-given --rerun-count, silently breaking the documented
+    // fallback contract for exactly this path (caught by the C1 critique
+    // pass; regression-guarded by the "resolves owner/repo INSIDE the
+    // fallback" CLI test below).
     try {
+      const owner =
+        args.owner ||
+        ghText(
+          ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+          GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+        );
+      const repo =
+        args.repo ||
+        ghText(
+          ['repo', 'view', '--json', 'name', '--jq', '.name'],
+          GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+        );
       rerunCount = fetchRerunCountFromRunId(owner, repo, args.runId);
       output.rerunCountSource = 'run-id';
       output.runAttempt = rerunCount + 1;
     } catch (error) {
-      // #1996: unifies two distinct failure modes -- the `gh api` call
-      // itself failing (network/permission/transient), and the call
-      // succeeding but returning a payload with a missing or non-numeric
-      // `run_attempt` (deriveRerunCountFromRunAttempt's own throw) -- into
-      // one "the live lookup did not yield a usable rerunCount" outcome,
-      // matching how rerun-advisory-convergence.mts's own collection step
-      // unifies both into the same `runAttempt: null` signal. `--run-id`
-      // takes precedence over `--rerun-count` only when the live lookup
-      // actually succeeds; on either failure mode, fall back to an
-      // explicitly-given `--rerun-count` (the issue's own "explicit
-      // override / offline path" language), or fail closed with a clear,
-      // non-zero exit -- never a silent `rerunCount: 0`.
+      // #1996: unifies three distinct failure modes -- owner/repo
+      // auto-detection failing, the `gh api` run lookup itself failing
+      // (network/permission/transient), and the lookup succeeding but
+      // returning a payload with a missing or non-numeric `run_attempt`
+      // (deriveRerunCountFromRunAttempt's own throw) -- into one "the live
+      // lookup did not yield a usable rerunCount" outcome, matching how
+      // rerun-advisory-convergence.mts's own collection step unifies
+      // several failure sources into the same `runAttempt: null` signal.
+      // `--run-id` takes precedence over `--rerun-count` only when the
+      // live lookup actually succeeds; on any of these failure modes, fall
+      // back to an explicitly-given `--rerun-count` (the issue's own
+      // "explicit override / offline path" language), or fail closed with
+      // a clear, non-zero exit -- never a silent `rerunCount: 0`.
       if (args.rerunCount === null) {
         throw new Error(
           `--run-id ${args.runId} lookup failed and no --rerun-count fallback was given: ${(error as Error).message}`,
@@ -349,6 +370,16 @@ function parseArgs(argv: string[]): {
   if (Boolean(owner) !== Boolean(repo)) {
     throw new Error(
       '--owner and --repo must be given together (both or neither)',
+    );
+  }
+  if (owner && !GITHUB_IDENTIFIER_PATTERN.test(owner)) {
+    throw new Error(
+      '--owner must contain only letters, digits, hyphens, underscores, or periods',
+    );
+  }
+  if (repo && !GITHUB_IDENTIFIER_PATTERN.test(repo)) {
+    throw new Error(
+      '--repo must contain only letters, digits, hyphens, underscores, or periods',
     );
   }
   return {

--- a/src/scripts/ci-wait-policy.mts
+++ b/src/scripts/ci-wait-policy.mts
@@ -354,6 +354,22 @@ function runCli(): void {
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
 }
 
+/**
+ * Validate `token` as a canonical positive-integer string (same format and
+ * `min: 1` bound `--rerun-count`'s sibling validation uses), but return the
+ * ORIGINAL string rather than `parseCanonicalIntegerOrThrow`'s numeric
+ * return value. A GitHub Actions run id is used only as an opaque path
+ * segment (`repos/{owner}/{repo}/actions/runs/{run-id}`) -- round-tripping
+ * it through a JavaScript `number` risks silent precision loss above
+ * `Number.MAX_SAFE_INTEGER` (Copilot review, PR #1998), which this
+ * function avoids by discarding the parsed number and keeping the
+ * caller-supplied digits verbatim once format/bound validation passes.
+ */
+function validateRunIdToken(token: string): string {
+  parseCanonicalIntegerOrThrow(token, '--run-id', 1);
+  return token;
+}
+
 function parseArgs(argv: string[]): {
   policy: string;
   rerunCount: number | null;
@@ -395,11 +411,15 @@ function parseArgs(argv: string[]): {
         : parseCanonicalIntegerOrThrow(rerunCountToken, '--rerun-count', 0),
     // `min: 1`: a workflow run id is never `0` -- mirrors the positive-
     // integer contract this file's `--rerun-count` sibling deliberately
-    // opts out of (see the `min: 0` note above).
-    runId:
-      runIdToken === undefined
-        ? null
-        : String(parseCanonicalIntegerOrThrow(runIdToken, '--run-id', 1)),
+    // opts out of (see the `min: 0` note above). Deliberately keeps the
+    // ORIGINAL string token, not `String(parseCanonicalIntegerOrThrow(...))`
+    // -- a run id above `Number.MAX_SAFE_INTEGER` would silently round
+    // through that number round-trip (e.g. `9007199254740993` becomes
+    // `9007199254740992`), querying a different run than the caller
+    // requested (Copilot review, PR #1998). `parseCanonicalIntegerOrThrow`
+    // is still called for its format/bound validation and shaped-error
+    // throw -- its numeric return value is discarded on purpose.
+    runId: runIdToken === undefined ? null : validateRunIdToken(runIdToken),
     owner,
     repo,
     help,

--- a/src/scripts/ci-wait-policy.mts
+++ b/src/scripts/ci-wait-policy.mts
@@ -9,6 +9,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { parseCanonicalIntegerOrThrow, parseCliArgs } from './cli-args.mts';
+import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mts';
 import { loadJson, validateConfigSection } from './validate-schemas.mts';
 
 const DEFAULT_RUNNING_TIMEOUT = 'PT30M';
@@ -35,6 +36,11 @@ interface CiRerunDecision {
   rerunCount: number;
 }
 
+/** Actions run-payload fields this file reads for `--run-id` resolution. */
+interface RawWorkflowRunPayload {
+  run_attempt?: number | null;
+}
+
 export const DEFAULT_CI_WAIT_POLICY = Object.freeze({
   runningTimeout: DEFAULT_RUNNING_TIMEOUT,
   runningTimeoutMs: 30 * 60 * 1000,
@@ -59,6 +65,9 @@ export const DEFAULT_CI_WAIT_POLICY = Object.freeze({
 const CI_WAIT_POLICY_FLAG_SPEC = {
   '--policy': { type: 'string', default: DEFAULT_POLICY_PATH },
   '--rerun-count': { type: 'string' },
+  '--run-id': { type: 'string' },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
   '--help': { type: 'boolean', short: 'h' },
 } as const;
 
@@ -168,6 +177,63 @@ export function resolveCiRerunDecision({
   };
 }
 
+/**
+ * Derive the CI-wait rerun count mechanically from a live Actions run's
+ * `run_attempt` field: `run_attempt` starts at `1` for the original run and
+ * increments by one on every rerun (`gh run rerun`, regardless of which
+ * session or actor issued it, including a human clicking "Re-run failed
+ * jobs" in the GitHub UI), so `run_attempt - 1` is exactly "how many times
+ * has this run already been rerun" -- the same quantity `--rerun-count`
+ * otherwise requires the caller to track manually, session-locally (#1996).
+ *
+ * Mirrors `rerun-advisory-convergence.mts`'s `resolveInstanceRerunDecision`,
+ * which treats a missing or non-numeric `run_attempt` as fail-closed
+ * (`'run-attempt-unknown'`) rather than silently deriving `rerunCount: 0`
+ * from a guess -- the same reasoning applies here: `resolveCiRerunDecision`
+ * would otherwise resolve an invented `0` to `action: 'rerun'`, which is
+ * never something this helper should decide from unreadable data. A
+ * `run_attempt: 0` is rejected by the `>= 1` bound below for the same
+ * reason -- letting it through would produce `rerunCount: -1`, which
+ * `resolveCiRerunDecision`'s own non-negative-integer normalization
+ * silently collapses back to `0`, reintroducing the exact silent-zero this
+ * function exists to prevent.
+ */
+export function deriveRerunCountFromRunAttempt(runAttempt: unknown): number {
+  if (
+    typeof runAttempt === 'number' &&
+    Number.isInteger(runAttempt) &&
+    runAttempt >= 1
+  ) {
+    return runAttempt - 1;
+  }
+  throw new Error(
+    `cannot derive --rerun-count from run_attempt: expected a positive integer, got ${JSON.stringify(runAttempt)}`,
+  );
+}
+
+/**
+ * Fetch the live Actions run `runId` (`GET
+ * repos/{owner}/{repo}/actions/runs/{run_id}`) and derive its rerun count
+ * via {@link deriveRerunCountFromRunAttempt}. Reuses the same
+ * `ghText`/`GH_TEXT_LOOP_TIMEOUT_OPTIONS` timeout-guarded pattern
+ * `rerun-advisory-convergence.mts`'s `collectFromGitHub` already uses for
+ * the identical per-run `run_attempt` lookup, so a stalled or
+ * unexpectedly-interactive `gh` call here fails closed within a bounded
+ * timeout instead of hanging this policy resolver indefinitely.
+ */
+export function fetchRerunCountFromRunId(
+  owner: string,
+  repo: string,
+  runId: string,
+): number {
+  const raw = ghText(
+    ['api', `repos/${owner}/${repo}/actions/runs/${runId}`],
+    GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  );
+  const payload = JSON.parse(raw) as RawWorkflowRunPayload;
+  return deriveRerunCountFromRunAttempt(payload.run_attempt);
+}
+
 function normalizeDuration(value: unknown, fallback: string): string {
   if (parseDurationToMs(value) === null) {
     return fallback;
@@ -180,6 +246,29 @@ function normalizeRerunPolicy(value: unknown): string {
   return RERUN_POLICIES.has(text) ? text : DEFAULT_RERUN_POLICY;
 }
 
+// #1996: output shape when `--run-id` is not given must stay byte-for-byte
+// identical to the pre-#1996 `{policy, rerunDecision?}` shape -- the
+// existing `--rerun-count`-only CLI test asserts a `deepEqual` against
+// exactly that shape, and the issue's own acceptance criteria requires
+// `--rerun-count` to keep working "unchanged" when `--run-id` is absent.
+// The three `--run-id`-derived fields below are therefore only ever added
+// to `output` inside the `args.runId !== null` branch.
+interface CiWaitPolicyOutput {
+  policy: CiWaitPolicy;
+  rerunDecision?: CiRerunDecision;
+  /** Present only when `--run-id` was given: which source ultimately
+   * supplied `rerunDecision`'s `rerunCount` -- the live `run_attempt`
+   * lookup, or the `--rerun-count` fallback after that lookup failed. */
+  rerunCountSource?: 'run-id' | 'rerun-count';
+  /** Present only when `--run-id` was given and its live lookup succeeded:
+   * the fetched run's raw `run_attempt` value, for caller-side auditing. */
+  runAttempt?: number;
+  /** Present only when `--run-id` was given and its live lookup failed but
+   * a `--rerun-count` fallback was available -- the failure reason, so a
+   * caller silently falling back to the offline value can still see why. */
+  runIdLookupError?: string;
+}
+
 function runCli(): void {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -188,14 +277,56 @@ function runCli(): void {
   }
 
   const policy = readCiWaitPolicy(args.policy);
-  const output: { policy: CiWaitPolicy; rerunDecision?: CiRerunDecision } = {
-    policy,
-  };
+  const output: CiWaitPolicyOutput = { policy };
 
-  if (args.rerunCount !== null) {
+  let rerunCount = args.rerunCount;
+
+  if (args.runId !== null) {
+    const owner =
+      args.owner ||
+      ghText(
+        ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      );
+    const repo =
+      args.repo ||
+      ghText(
+        ['repo', 'view', '--json', 'name', '--jq', '.name'],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      );
+    try {
+      rerunCount = fetchRerunCountFromRunId(owner, repo, args.runId);
+      output.rerunCountSource = 'run-id';
+      output.runAttempt = rerunCount + 1;
+    } catch (error) {
+      // #1996: unifies two distinct failure modes -- the `gh api` call
+      // itself failing (network/permission/transient), and the call
+      // succeeding but returning a payload with a missing or non-numeric
+      // `run_attempt` (deriveRerunCountFromRunAttempt's own throw) -- into
+      // one "the live lookup did not yield a usable rerunCount" outcome,
+      // matching how rerun-advisory-convergence.mts's own collection step
+      // unifies both into the same `runAttempt: null` signal. `--run-id`
+      // takes precedence over `--rerun-count` only when the live lookup
+      // actually succeeds; on either failure mode, fall back to an
+      // explicitly-given `--rerun-count` (the issue's own "explicit
+      // override / offline path" language), or fail closed with a clear,
+      // non-zero exit -- never a silent `rerunCount: 0`.
+      if (args.rerunCount === null) {
+        throw new Error(
+          `--run-id ${args.runId} lookup failed and no --rerun-count fallback was given: ${(error as Error).message}`,
+          { cause: error },
+        );
+      }
+      output.rerunCountSource = 'rerun-count';
+      output.runIdLookupError = (error as Error).message;
+      rerunCount = args.rerunCount;
+    }
+  }
+
+  if (rerunCount !== null) {
     output.rerunDecision = resolveCiRerunDecision({
       rerunPolicy: policy.rerunPolicy,
-      rerunCount: args.rerunCount,
+      rerunCount,
     });
   }
 
@@ -205,10 +336,21 @@ function runCli(): void {
 function parseArgs(argv: string[]): {
   policy: string;
   rerunCount: number | null;
+  runId: string | null;
+  owner: string;
+  repo: string;
   help: boolean;
 } {
   const { values, help } = parseCliArgs(argv, CI_WAIT_POLICY_FLAG_SPEC);
   const rerunCountToken = values['rerun-count'] as string | undefined;
+  const runIdToken = values['run-id'] as string | undefined;
+  const owner = (values.owner as string).trim();
+  const repo = (values.repo as string).trim();
+  if (Boolean(owner) !== Boolean(repo)) {
+    throw new Error(
+      '--owner and --repo must be given together (both or neither)',
+    );
+  }
   return {
     policy: values.policy as string,
     // `min: 0`: --rerun-count is a non-negative counter (0 is a valid
@@ -220,6 +362,15 @@ function parseArgs(argv: string[]): {
       rerunCountToken === undefined
         ? null
         : parseCanonicalIntegerOrThrow(rerunCountToken, '--rerun-count', 0),
+    // `min: 1`: a workflow run id is never `0` -- mirrors the positive-
+    // integer contract this file's `--rerun-count` sibling deliberately
+    // opts out of (see the `min: 0` note above).
+    runId:
+      runIdToken === undefined
+        ? null
+        : String(parseCanonicalIntegerOrThrow(runIdToken, '--run-id', 1)),
+    owner,
+    repo,
     help,
   };
 }
@@ -227,8 +378,20 @@ function parseArgs(argv: string[]): {
 function printHelp(): void {
   process.stdout.write(`Usage:
   node scripts/ci-wait-policy.mjs [--policy <path>] [--rerun-count <count>]
+    [--run-id <run-id> [--owner <owner> --repo <repo>]]
 
 Resolves the shared ciWait policy defaults from .github/idd/config.json.
 Optionally emits the deterministic rerun decision for a current rerun count.
+
+--run-id fetches the live Actions run via
+'gh api repos/{owner}/{repo}/actions/runs/{run-id}' and derives
+rerunCount = run_attempt - 1 mechanically, taking precedence over
+--rerun-count when the lookup succeeds. --owner/--repo default to the
+local checkout's own repository when omitted (gh repo view); pass both or
+neither. --rerun-count keeps working unchanged when --run-id is omitted,
+and serves as the explicit override/offline fallback when the --run-id
+lookup fails (network/permission error, or a missing/non-numeric
+run_attempt in the fetched payload) -- absent that fallback, the CLI exits
+non-zero rather than silently emitting rerunCount: 0.
 `);
 }

--- a/tests/ci-wait-policy.test.mts
+++ b/tests/ci-wait-policy.test.mts
@@ -530,6 +530,54 @@ if (process.argv[2] === 'api') {
   }
 });
 
+// #1996 C1 critique regression: the owner/repo auto-detection (`gh repo
+// view`, used when --owner/--repo are omitted) must sit INSIDE the same
+// try/fallback as the run lookup itself -- a caller can give --run-id with
+// neither --owner nor --repo, and a failure resolving either must fall
+// back to an explicit --rerun-count exactly like a failed run-id lookup
+// does, not crash uncaught. This test omits --owner/--repo entirely so the
+// stub's `gh repo view` call is what fails.
+test('CLI --run-id falls back to --rerun-count when owner/repo auto-detection itself fails (not just the run lookup)', () => {
+  const restore = stubGh(`
+if (process.argv[2] === 'repo' && process.argv[3] === 'view') {
+  process.stderr.write('gh: authentication required');
+  process.exit(1);
+} else {
+  process.stderr.write('unexpected gh invocation: ' + process.argv.slice(2).join(' '));
+  process.exit(1);
+}
+`);
+  try {
+    const output = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          join(REPO_ROOT, 'scripts/ci-wait-policy.mjs'),
+          '--run-id',
+          '31631273987',
+          '--rerun-count',
+          '0',
+        ],
+        { encoding: 'utf8' },
+      ),
+    );
+    assert.equal(output.rerunCountSource, 'rerun-count');
+    assert.ok(
+      typeof output.runIdLookupError === 'string' &&
+        output.runIdLookupError.length > 0,
+      'expected runIdLookupError to report the owner/repo auto-detection failure',
+    );
+    assert.deepEqual(output.rerunDecision, {
+      action: 'rerun',
+      reason: 'rerun-budget-available',
+      rerunPolicy: 'rerun-once',
+      rerunCount: 0,
+    });
+  } finally {
+    restore();
+  }
+});
+
 test('CLI --owner without --repo (or vice versa) throws -- both-or-neither', () => {
   for (const args of [
     ['--run-id', '1', '--owner', 'kurone-kito'],
@@ -540,6 +588,27 @@ test('CLI --owner without --repo (or vice versa) throws -- both-or-neither', () 
       ...args,
     ]);
     assert.match(stderr, /--owner and --repo must be given together/);
+  }
+});
+
+// #1996 C1 critique: --owner/--repo validated against the same
+// conservative GitHub-identifier character class
+// rerun-advisory-convergence.mts already applies to the identical flags,
+// rejecting whitespace/shell-metacharacter values before they reach the
+// `gh api repos/{owner}/{repo}/...` path.
+test('CLI --owner/--repo reject values outside the GitHub identifier character class', () => {
+  for (const args of [
+    ['--run-id', '1', '--owner', 'invalid owner', '--repo', 'idd-skill'],
+    ['--run-id', '1', '--owner', 'kurone-kito', '--repo', 'idd;skill'],
+  ]) {
+    const { stderr } = runCliExpectFailure([
+      join(REPO_ROOT, 'scripts/ci-wait-policy.mjs'),
+      ...args,
+    ]);
+    assert.match(
+      stderr,
+      /must contain only letters, digits, hyphens, underscores, or periods/,
+    );
   }
 });
 

--- a/tests/ci-wait-policy.test.mts
+++ b/tests/ci-wait-policy.test.mts
@@ -629,6 +629,65 @@ if (process.argv[2] === 'repo' && process.argv[3] === 'view') {
   }
 });
 
+// #1996 E2 critique pass (independent subagent review, PR #1998): every
+// other --run-id success test above passes explicit --owner/--repo, and
+// the only auto-detection test exercises the FAILURE path (gh repo view
+// itself failing) -- nothing proved the composed
+// repos/{owner}/{repo}/actions/runs/{run-id} path is correct when
+// owner/repo come from auto-detection rather than flags. This test omits
+// --owner/--repo entirely, has the stub answer both `gh repo view` calls
+// (--json owner and --json name) plus the run lookup, and captures the
+// final `gh api` call's argv to prove the auto-detected values were
+// composed into the URL correctly.
+test('CLI --run-id auto-detects --owner/--repo via gh repo view and composes the correct API path', () => {
+  const tempRoot = mkdtempSync(
+    join(tmpdir(), 'idd-ci-wait-policy-autodetect-'),
+  );
+  const argsFile = join(tempRoot, 'args.json');
+  const restore = stubGh(`
+const fs = require('node:fs');
+if (process.argv[2] === 'repo' && process.argv[3] === 'view' && process.argv[5] === 'owner') {
+  process.stdout.write('kurone-kito');
+} else if (process.argv[2] === 'repo' && process.argv[3] === 'view' && process.argv[5] === 'name') {
+  process.stdout.write('idd-skill');
+} else if (process.argv[2] === 'api') {
+  fs.writeFileSync(${JSON.stringify(argsFile)}, JSON.stringify(process.argv.slice(2)));
+  process.stdout.write(JSON.stringify({ run_attempt: 1 }));
+} else {
+  process.stderr.write('unexpected gh invocation: ' + process.argv.slice(2).join(' '));
+  process.exit(1);
+}
+`);
+  try {
+    const output = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          join(REPO_ROOT, 'scripts/ci-wait-policy.mjs'),
+          '--run-id',
+          '31631273987',
+        ],
+        { encoding: 'utf8' },
+      ),
+    );
+    const capturedArgv = JSON.parse(readFileSync(argsFile, 'utf8')) as string[];
+    assert.deepEqual(capturedArgv, [
+      'api',
+      'repos/kurone-kito/idd-skill/actions/runs/31631273987',
+    ]);
+    assert.equal(output.rerunCountSource, 'run-id');
+    assert.equal(output.runAttempt, 1);
+    assert.deepEqual(output.rerunDecision, {
+      action: 'rerun',
+      reason: 'rerun-budget-available',
+      rerunPolicy: 'rerun-once',
+      rerunCount: 0,
+    });
+  } finally {
+    restore();
+  }
+});
+
 test('CLI --owner without --repo (or vice versa) throws -- both-or-neither', () => {
   for (const args of [
     ['--run-id', '1', '--owner', 'kurone-kito'],

--- a/tests/ci-wait-policy.test.mts
+++ b/tests/ci-wait-policy.test.mts
@@ -422,7 +422,16 @@ process.stdout.write(JSON.stringify({ run_attempt: 1 }));
   }
 });
 
-test('CLI --run-id derives rerunCount from a live run_attempt: 1 -> action rerun', () => {
+// #1996 C1 critique (Copilot review, PR #1998, suppressed comment): the
+// prior version of this test passed ONLY --run-id, so it could not
+// distinguish "--run-id wins on a successful lookup" from "--rerun-count
+// was simply never given" -- the two "falls back" tests below only prove
+// --rerun-count wins when the lookup FAILS, leaving the success-path
+// precedence rule unproven. Also passing a CONFLICTING --rerun-count 1
+// here (which would produce action: 'hold' if it won instead) makes the
+// action: 'rerun' / rerunCount: 0 assertions below actually prove
+// --run-id's live lookup took precedence.
+test('CLI --run-id derives rerunCount from a live run_attempt: 1 -> action rerun (wins over a conflicting --rerun-count on success)', () => {
   const restore = stubGh(`
 if (process.argv[2] === 'api') {
   process.stdout.write(JSON.stringify({ run_attempt: 1 }));
@@ -443,6 +452,8 @@ if (process.argv[2] === 'api') {
           'kurone-kito',
           '--repo',
           'idd-skill',
+          '--rerun-count',
+          '1',
         ],
         { encoding: 'utf8' },
       ),

--- a/tests/ci-wait-policy.test.mts
+++ b/tests/ci-wait-policy.test.mts
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { test } from 'node:test';
@@ -8,6 +14,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   DEFAULT_CI_WAIT_POLICY,
+  deriveRerunCountFromRunAttempt,
   normalizeCiWaitPolicy,
   parseDurationToMs,
   readCiWaitPolicy,
@@ -15,6 +22,23 @@ import {
 } from '../src/scripts/ci-wait-policy.mts';
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+// Stub `gh` on PATH -- the tests/gh-exec.test.mts pattern, reused here so
+// the --run-id CLI tests below exercise the real execFileSync + child-
+// process contract without network access. Returns a cleanup callback
+// that restores PATH; callers must invoke it (ideally in a `finally`)
+// even when the assertion throws.
+function stubGh(scriptBody: string): () => void {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-ci-wait-policy-gh-'));
+  const ghPath = join(tempRoot, 'gh');
+  writeFileSync(ghPath, `#!/usr/bin/env node\n${scriptBody}`);
+  chmodSync(ghPath, 0o755);
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${tempRoot}:${originalPath ?? ''}`;
+  return () => {
+    process.env.PATH = originalPath;
+  };
+}
 
 test('parseDurationToMs parses CI wait durations', () => {
   assert.equal(parseDurationToMs('PT30M'), 30 * 60 * 1000);
@@ -333,4 +357,205 @@ test('CLI --rerun-count 0 does not throw (0 is a valid non-negative value)', () 
     ),
   );
   assert.equal(output.rerunDecision.rerunCount, 0);
+});
+
+// #1996: deriveRerunCountFromRunAttempt is the pure core of the --run-id
+// derivation -- no `gh` call needed to exercise it directly.
+test('deriveRerunCountFromRunAttempt: run_attempt 1 (never rerun) derives rerunCount 0', () => {
+  assert.equal(deriveRerunCountFromRunAttempt(1), 0);
+});
+
+test('deriveRerunCountFromRunAttempt: run_attempt 2 (already rerun once) derives rerunCount 1', () => {
+  assert.equal(deriveRerunCountFromRunAttempt(2), 1);
+});
+
+test('deriveRerunCountFromRunAttempt: rejects a missing/non-numeric/zero run_attempt (fail closed, never a silent 0)', () => {
+  for (const runAttempt of [undefined, null, '2', 1.5, 0, -1, Number.NaN]) {
+    assert.throws(
+      () => deriveRerunCountFromRunAttempt(runAttempt),
+      /cannot derive --rerun-count from run_attempt/,
+      `expected run_attempt ${JSON.stringify(runAttempt)} to throw`,
+    );
+  }
+});
+
+// #1996: --run-id end-to-end CLI tests. Every case below passes explicit
+// --owner/--repo so the stubbed `gh` only ever needs to answer the single
+// `api repos/.../actions/runs/<id>` call, never `repo view` too.
+test('CLI --run-id derives rerunCount from a live run_attempt: 1 -> action rerun', () => {
+  const restore = stubGh(`
+if (process.argv[2] === 'api') {
+  process.stdout.write(JSON.stringify({ run_attempt: 1 }));
+} else {
+  process.stderr.write('unexpected gh invocation: ' + process.argv.slice(2).join(' '));
+  process.exit(1);
+}
+`);
+  try {
+    const output = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          join(REPO_ROOT, 'scripts/ci-wait-policy.mjs'),
+          '--run-id',
+          '31631273987',
+          '--owner',
+          'kurone-kito',
+          '--repo',
+          'idd-skill',
+        ],
+        { encoding: 'utf8' },
+      ),
+    );
+    assert.equal(output.rerunCountSource, 'run-id');
+    assert.equal(output.runAttempt, 1);
+    assert.deepEqual(output.rerunDecision, {
+      action: 'rerun',
+      reason: 'rerun-budget-available',
+      rerunPolicy: 'rerun-once',
+      rerunCount: 0,
+    });
+  } finally {
+    restore();
+  }
+});
+
+test('CLI --run-id derives rerunCount from a live run_attempt: 2 -> action hold (default rerun-once)', () => {
+  const restore = stubGh(`
+if (process.argv[2] === 'api') {
+  process.stdout.write(JSON.stringify({ run_attempt: 2 }));
+} else {
+  process.stderr.write('unexpected gh invocation: ' + process.argv.slice(2).join(' '));
+  process.exit(1);
+}
+`);
+  try {
+    const output = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          join(REPO_ROOT, 'scripts/ci-wait-policy.mjs'),
+          '--run-id',
+          '31631273987',
+          '--owner',
+          'kurone-kito',
+          '--repo',
+          'idd-skill',
+        ],
+        { encoding: 'utf8' },
+      ),
+    );
+    assert.equal(output.rerunCountSource, 'run-id');
+    assert.equal(output.runAttempt, 2);
+    assert.deepEqual(output.rerunDecision, {
+      action: 'hold',
+      reason: 'rerun-budget-exhausted',
+      rerunPolicy: 'rerun-once',
+      rerunCount: 1,
+    });
+  } finally {
+    restore();
+  }
+});
+
+test('CLI --run-id exits non-zero on a missing/non-numeric run_attempt with no --rerun-count fallback (graceful failure, never a silent rerunCount: 0)', () => {
+  const restore = stubGh(`
+if (process.argv[2] === 'api') {
+  process.stdout.write(JSON.stringify({ conclusion: 'success' }));
+} else {
+  process.stderr.write('unexpected gh invocation: ' + process.argv.slice(2).join(' '));
+  process.exit(1);
+}
+`);
+  try {
+    const { stderr } = runCliExpectFailure([
+      join(REPO_ROOT, 'scripts/ci-wait-policy.mjs'),
+      '--run-id',
+      '31631273987',
+      '--owner',
+      'kurone-kito',
+      '--repo',
+      'idd-skill',
+    ]);
+    assert.match(stderr, /--run-id 31631273987 lookup failed/);
+    assert.match(stderr, /cannot derive --rerun-count from run_attempt/);
+  } finally {
+    restore();
+  }
+});
+
+test('CLI --run-id falls back to an explicit --rerun-count when the live lookup itself fails (gh api error)', () => {
+  const restore = stubGh(`
+if (process.argv[2] === 'api') {
+  process.stderr.write('gh: Not Found (HTTP 404)');
+  process.exit(1);
+} else {
+  process.stderr.write('unexpected gh invocation: ' + process.argv.slice(2).join(' '));
+  process.exit(1);
+}
+`);
+  try {
+    const output = JSON.parse(
+      execFileSync(
+        process.execPath,
+        [
+          join(REPO_ROOT, 'scripts/ci-wait-policy.mjs'),
+          '--run-id',
+          '31631273987',
+          '--owner',
+          'kurone-kito',
+          '--repo',
+          'idd-skill',
+          '--rerun-count',
+          '1',
+        ],
+        { encoding: 'utf8' },
+      ),
+    );
+    assert.equal(output.rerunCountSource, 'rerun-count');
+    assert.ok(
+      typeof output.runIdLookupError === 'string' &&
+        output.runIdLookupError.length > 0,
+      'expected runIdLookupError to report why the live lookup failed',
+    );
+    assert.equal(output.runAttempt, undefined);
+    assert.deepEqual(output.rerunDecision, {
+      action: 'hold',
+      reason: 'rerun-budget-exhausted',
+      rerunPolicy: 'rerun-once',
+      rerunCount: 1,
+    });
+  } finally {
+    restore();
+  }
+});
+
+test('CLI --owner without --repo (or vice versa) throws -- both-or-neither', () => {
+  for (const args of [
+    ['--run-id', '1', '--owner', 'kurone-kito'],
+    ['--run-id', '1', '--repo', 'idd-skill'],
+  ]) {
+    const { stderr } = runCliExpectFailure([
+      join(REPO_ROOT, 'scripts/ci-wait-policy.mjs'),
+      ...args,
+    ]);
+    assert.match(stderr, /--owner and --repo must be given together/);
+  }
+});
+
+// #1996 output-shape backward compatibility (Fix #1 from the design
+// review): a --rerun-count-only invocation (no --run-id) must keep
+// producing the EXACT pre-#1996 {policy, rerunDecision} shape, with none
+// of the new --run-id-only fields present -- this is what lets the
+// existing 'readCiWaitPolicy reads nested ciWait config and CLI emits the
+// same resolution' test's deepEqual keep passing unmodified.
+test('CLI --rerun-count-only output omits every --run-id-only field (backward-compatible shape)', () => {
+  const output = JSON.parse(
+    execFileSync(
+      process.execPath,
+      [join(REPO_ROOT, 'scripts/ci-wait-policy.mjs'), '--rerun-count', '1'],
+      { encoding: 'utf8' },
+    ),
+  );
+  assert.deepEqual(Object.keys(output).sort(), ['policy', 'rerunDecision']);
 });

--- a/tests/ci-wait-policy.test.mts
+++ b/tests/ci-wait-policy.test.mts
@@ -4,6 +4,7 @@ import {
   chmodSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -382,6 +383,45 @@ test('deriveRerunCountFromRunAttempt: rejects a missing/non-numeric/zero run_att
 // #1996: --run-id end-to-end CLI tests. Every case below passes explicit
 // --owner/--repo so the stubbed `gh` only ever needs to answer the single
 // `api repos/.../actions/runs/<id>` call, never `repo view` too.
+
+// #1996 C1 critique (Copilot review, PR #1998): a run id above
+// Number.MAX_SAFE_INTEGER must reach the `gh api` call byte-for-byte, not
+// silently rounded by a Number round-trip (e.g. 9007199254740993 would
+// become 9007199254740992). Captures the exact argv the stub received to
+// prove the digits survive unmodified.
+test('CLI --run-id preserves a run id above Number.MAX_SAFE_INTEGER exactly (no precision loss)', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-ci-wait-policy-run-id-'));
+  const argsFile = join(tempRoot, 'args.json');
+  const unsafeRunId = '9007199254740993'; // MAX_SAFE_INTEGER (2^53-1) + 2
+  const restore = stubGh(`
+const fs = require('node:fs');
+fs.writeFileSync(${JSON.stringify(argsFile)}, JSON.stringify(process.argv.slice(2)));
+process.stdout.write(JSON.stringify({ run_attempt: 1 }));
+`);
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/ci-wait-policy.mjs'),
+        '--run-id',
+        unsafeRunId,
+        '--owner',
+        'kurone-kito',
+        '--repo',
+        'idd-skill',
+      ],
+      { encoding: 'utf8' },
+    );
+    const capturedArgv = JSON.parse(readFileSync(argsFile, 'utf8')) as string[];
+    assert.deepEqual(capturedArgv, [
+      'api',
+      `repos/kurone-kito/idd-skill/actions/runs/${unsafeRunId}`,
+    ]);
+  } finally {
+    restore();
+  }
+});
+
 test('CLI --run-id derives rerunCount from a live run_attempt: 1 -> action rerun', () => {
   const restore = stubGh(`
 if (process.argv[2] === 'api') {


### PR DESCRIPTION
# Summary

Extend `ci-wait-policy.mjs` with an optional `--run-id <id>` flag that
derives `rerunCount = run_attempt - 1` mechanically from a live `gh api
repos/{owner}/{repo}/actions/runs/{run-id}` lookup, mirroring the
`run_attempt` pattern `rerun-advisory-convergence.mts` already uses for
its own rerun-once budget check. `--rerun-count` keeps working unchanged
as an explicit override/offline fallback.

## Linked issue

Closes #1996

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`ci-wait-policy.mjs` previously required the calling agent to track its
own rerun count session-locally via `--rerun-count`. That breaks down
once a different session picks up D4/E15 CI-wait duty for the same PR
head (fresh Resume, forced-handoff successor, or a second worker
delegated the same duty) — the only signal available was trusting a
prior session's own hold-comment prose.

`run_attempt` is live, authoritative GitHub state: it starts at `1` and
increments by one on every rerun regardless of which session or actor
issued it (including a human clicking "Re-run failed jobs" in the GitHub
UI), so `rerunCount = run_attempt - 1` is deterministic and
cross-session-safe by construction.

Implementation notes:

- `deriveRerunCountFromRunAttempt` (pure) and
  `fetchRerunCountFromRunId` (I/O, `ghText` +
  `GH_TEXT_LOOP_TIMEOUT_OPTIONS`) mirror
  `rerun-advisory-convergence.mts`'s own `run_attempt` resolution and its
  fail-closed treatment of a missing/non-numeric value
  (`resolveInstanceRerunDecision`'s `'run-attempt-unknown'` handling) —
  never a silently-invented `rerunCount: 0`.
- `--run-id` takes precedence over `--rerun-count` only when the live
  lookup (owner/repo auto-detection included) succeeds; on any failure
  it falls back to an explicitly-given `--rerun-count`, or exits
  non-zero with a clear reason if no fallback was given. A same-response
  C1 critique pass (`Agent(subagent_type="general-purpose")`) caught two
  issues that are fixed in a follow-up commit on this branch: the
  owner/repo auto-detection calls originally sat outside the fallback's
  `try` block (would have crashed uncaught instead of falling back), and
  `--owner`/`--repo` accepted arbitrary strings instead of the same
  `GITHUB_IDENTIFIER_PATTERN` guard `rerun-advisory-convergence.mts`
  already applies to the identical flags.
- New output fields (`rerunCountSource`, `runAttempt`,
  `runIdLookupError`) only ever appear when `--run-id` was passed, so
  the pre-existing `--rerun-count`-only `{policy, rerunDecision}` JSON
  shape stays byte-for-byte unchanged (regression test included).
- `idd-ci.instructions.md`'s new guidance is intentionally terse: the
  review-path instruction bundle (`bundle-review`) sits at a hard 98%
  context-ceiling gate with near-zero headroom on `main` already
  (97.97% baseline). The full flag/field reference (precedence rule,
  fallback semantics, output fields) lives in
  `docs/idd-helper-scripts.md` instead, which is not bundle-constrained.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
