### PR TITLE
docs(onboarding): add bootstrap execution mode to Step 1B list

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -431,7 +431,8 @@ merge policy, PR review profile, review-thread resolution policy,
 critique-loop profile, credential scope, claim-timing defaults, CI wait
 policy defaults, issue-author approval gate, maintainer approval actor
 policy, issue-authoring companion status, helper runtime profile, IDD
-label names, and the up-to-date-head ruleset check.
+label names, the up-to-date-head ruleset check, and bootstrap execution
+mode.
 
 Use
 [Onboarding Reference — Policy Decisions](docs/onboarding/policy-decisions.md)

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -286,6 +286,8 @@ require explicit operator confirmation:
     every merely-`BEHIND` PR and multiplies advisory-review rounds
     without review value; a before/after sample measured the sync-merge
     share fall from ~27% to ~3.7%, kurone-kito/idd-skill#1817)
+14. bootstrap execution mode (`direct-import` default, or
+    `issue-mediated`)
 
 Use
 [Onboarding Reference — Policy Decisions](docs/onboarding/policy-decisions.md)

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1524,8 +1524,8 @@ After completing the steps above, confirm each item:
       customizations are complete.
 - [ ] The selected CI wait policy values, merge policy, credential
       scope, claim timing values, issue-author approval gate decision,
-      maintainer approval actor policy, and helper runtime profile are
-      explicitly recorded.
+      maintainer approval actor policy, helper runtime profile, and
+      bootstrap execution mode are explicitly recorded.
 - [ ] If the operator opted into issue authoring, the companion skill
       files are present under the native destination recorded in the policy.
 - [ ] No `{{...}}` placeholders remain, the `Project commands` table is

--- a/idd-template/docs/onboarding/issue-mediated-bootstrap.md
+++ b/idd-template/docs/onboarding/issue-mediated-bootstrap.md
@@ -238,6 +238,8 @@ recording action rather than a pinned remote-fetch step:
 - Helper runtime profile: <value>
 - IDD label names: <value>
 - Up-to-date-head ruleset check: <value>
+- Bootstrap execution mode: issue-mediated (this issue's own execution
+  path)
 
 This is a single, atomically-reviewable change: the core import,
 placeholder substitution, and agent-entry-file updates land together,

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -305,6 +305,29 @@ infer), adopt the guard recipe in
 [Customizing IDD — Reserved-label guard recipe](../customization.md#reserved-label-guard-recipe)
 before relying on unattended discovery or hold semantics.
 
+### Bootstrap execution mode
+
+Confirm whether the initial IDD import itself runs through the
+distributed direct-import default or through the optional
+issue-mediated alternate:
+
+- `direct-import` (distributed default, "theirs-flow"): Steps 2, 4, 5,
+  and 6 import the template with a direct, unreviewed commit, then hand
+  off to the normal claim -> work -> PR -> CI -> merge loop for every
+  subsequent change.
+- `issue-mediated`: routes that same import through a reviewable
+  issue -> branch -> PR -> merge cycle instead, using the placeholder
+  values and Step 1B policy decisions already confirmed earlier in the
+  hearing. Choose this when the operator wants every repository
+  mutation — including the very first one — to have a reviewable
+  record, or simply prefers not to grant an agent a direct-commit path.
+
+If the operator does not state a preference, propose `direct-import`
+and only switch modes on explicit confirmation. See
+[Onboarding Reference — Issue-Mediated
+Bootstrap](issue-mediated-bootstrap.md) for the full procedure and
+prerequisites.
+
 ## Related default policies to confirm
 
 The onboarding entry point should also confirm whether the repository
@@ -464,6 +487,10 @@ This repository uses the following IDD policies:
 
 - **`issueAuthoring.maxClarificationRounds`**:
   `{3 | custom finite bound}`
+
+### Bootstrap Execution Mode
+
+**Mode**: `{direct-import | issue-mediated}`
 ```
 
 When the repository uses a non-default merge, review, or thread policy,

--- a/tests/non-node-fallback.test.mts
+++ b/tests/non-node-fallback.test.mts
@@ -219,7 +219,7 @@ test('onboarding keeps claim timing and CI wait policy in the explicit confirmat
   );
   assert.match(
     onboarding,
-    /critique-loop profile, credential scope, claim-timing defaults, CI wait\s+policy defaults, issue-author approval gate, maintainer approval actor\s+policy, issue-authoring companion status, helper runtime profile, IDD\s+label names, and the up-to-date-head ruleset check\./,
+    /critique-loop profile, credential scope, claim-timing defaults, CI wait\s+policy defaults, issue-author approval gate, maintainer approval actor\s+policy, issue-authoring companion status, helper runtime profile, IDD\s+label names, the up-to-date-head ruleset check, and bootstrap execution\s+mode\./,
     'ONBOARDING Step 2 re-check must stay aligned with the Step 1B confirmation list',
   );
   assert.match(


### PR DESCRIPTION
# Summary

Adds "bootstrap execution mode" as a 14th Step 1B policy decision in
`idd-template/ONBOARDING.md`, documents the `direct-import` /
`issue-mediated` choice in
`idd-template/docs/onboarding/policy-decisions.md` (linking to
`issue-mediated-bootstrap.md`, shipped by #1978), and adds a matching
Step 3 recording-template block.

## Linked issue

Closes #1980

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

#1978 introduced the issue-mediated bootstrap alternate but its choice
was not yet part of the enumerated Step 1B decision list or the Step 3
recording template that every other onboarding policy decision uses.
This closes that gap and unblocks `markdown-link-audit` (part of
`node scripts/audit-docs.mjs --check`), which was failing until the
link target from #1978 existed.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
