### PR TITLE
docs(overview-core): route operator-present pause resumption

### DIFF
--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -38,8 +38,8 @@ post via direct HTTP `POST` with a JSON body; see
 `docs/idd-helper-scripts.md` for the full `gh api` pitfalls. When
 helper runtime is enabled, the `post-idd-marker` helper (`--type claim
 --target issue <number> --apply` plus the claim fields) posts this
-marker through that JSON path (dry-run, posting nothing, without
-`--apply`); the direct `POST` stays the canonical fallback.
+marker through that JSON path (dry-run without `--apply`); the direct
+`POST` stays the canonical fallback.
 
 Every new HTML-comment operational marker must include a short visible
 note after the token: `review-watermark`/`review-baseline` use the
@@ -57,11 +57,9 @@ but never create new hidden-only claim comments.
   and is the portable ownership token used with trusted actor and
   session-record checks. Generate a fresh value on every fresh claim or
   stale takeover. Reuse the same `{claim-id}` only for heartbeats of
-  that already-verified claim. A matching `{agent-id}` is never
-  ownership proof by itself, because separate live sessions can share
-  the same agent ID. Reading an existing `{claim-id}` from issue comments
-  during discovery or resume does not by itself prove ownership; the
-  current session must have already recorded that token before the
+  that already-verified claim. Reading an existing `{claim-id}` from
+  issue comments does not by itself prove ownership; the current
+  session must have already recorded that token before the
   revalidation step.
 - `{prior-claim-id}` is `none` for a fresh claim on an unclaimed issue.
   For a stale-claim takeover, set it to the currently active claim's
@@ -228,6 +226,8 @@ Out of scope and explicitly **not** blocked:
 - F4 post-merge cleanup (F4 itself removes the sibling worktree;
   subsequent local `main` updates run from the primary worktree by
   design).
+- [Operator-present release](idd-resume.instructions.md#operator-present-release)
+  steps 1-2 (pre-claim; no claim held yet).
 
 The claim and cwd checks are read-only and pre-mutation; the lock
 acquisition is the final local guard. When in scope, all of these checks
@@ -302,7 +302,7 @@ file that matches your current situation.
 | --- | --- |
 | Starting fresh (no active claim) | `idd-discover.instructions.md`, then `idd-claim.instructions.md` |
 | Starting fresh with one explicit issue target | `idd-discover.instructions.md` A0-T, then `idd-claim.instructions.md` |
-| Resuming after crash / rate-limit / handoff | `idd-resume.instructions.md` |
+| Resuming after crash / rate-limit / handoff / operator-present deliberate pause | `idd-resume.instructions.md` |
 | Claimed, branch exists, no PR yet | `idd-work.instructions.md` |
 | PR open, CI running, no reviews yet | `idd-pr-submit.instructions.md` |
 | PR open, CI running, reviews exist | `idd-review-snapshot.instructions.md` (E1–E3) |

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -39,7 +39,7 @@ post via direct HTTP `POST` with a JSON body; see
 helper runtime is enabled, the `post-idd-marker` helper (`--type claim
 --target issue <number> --apply` plus the claim fields) posts this
 marker through that JSON path (dry-run without `--apply`); the direct
-`POST` stays the canonical fallback.
+`POST` is the fallback.
 
 Every new HTML-comment operational marker must include a short visible
 note after the token: `review-watermark`/`review-baseline` use the
@@ -59,7 +59,7 @@ but never create new hidden-only claim comments.
   stale takeover. Reuse the same `{claim-id}` only for heartbeats of
   that already-verified claim. Reading an existing `{claim-id}` from
   issue comments does not by itself prove ownership; the current
-  session must have already recorded that token before the
+  session must have recorded that token before the
   revalidation step.
 - `{prior-claim-id}` is `none` for a fresh claim on an unclaimed issue.
   For a stale-claim takeover, set it to the currently active claim's
@@ -78,8 +78,7 @@ _{agent-id}: issue claim released — IDD automation marker. Do not edit._
 When helper runtime is enabled, post this with `post-idd-marker --type
 unclaim --target issue <number> --apply` (plus agent-id / claim-id /
 timestamp; see `docs/idd-helper-scripts.md`); without `--apply` it is
-dry-run. The direct HTTP `POST` above is the fallback when helper
-runtime is unavailable.
+dry-run. The direct HTTP `POST` above is the fallback.
 
 ## Trusted marker actors
 
@@ -227,7 +226,8 @@ Out of scope and explicitly **not** blocked:
   subsequent local `main` updates run from the primary worktree by
   design).
 - [Operator-present release](idd-resume.instructions.md#operator-present-release)
-  steps 1-2 (pre-claim; no claim held yet).
+  steps 1-2 (pre-claim for the resuming session; the issue's own
+  active claim is untouched until step 2).
 
 The claim and cwd checks are read-only and pre-mutation; the lock
 acquisition is the final local guard. When in scope, all of these checks

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -33,8 +33,8 @@ post via direct HTTP `POST` with a JSON body; see
 `docs/idd-helper-scripts.md` for the full `gh api` pitfalls. When
 helper runtime is enabled, the `post-idd-marker` helper (`--type claim
 --target issue <number> --apply` plus the claim fields) posts this
-marker through that JSON path (dry-run, posting nothing, without
-`--apply`); the direct `POST` stays the canonical fallback.
+marker through that JSON path (dry-run without `--apply`); the direct
+`POST` stays the canonical fallback.
 
 Every new HTML-comment operational marker must include a short visible
 note after the token: `review-watermark`/`review-baseline` use the
@@ -52,11 +52,9 @@ but never create new hidden-only claim comments.
   and is the portable ownership token used with trusted actor and
   session-record checks. Generate a fresh value on every fresh claim or
   stale takeover. Reuse the same `{claim-id}` only for heartbeats of
-  that already-verified claim. A matching `{agent-id}` is never
-  ownership proof by itself, because separate live sessions can share
-  the same agent ID. Reading an existing `{claim-id}` from issue comments
-  during discovery or resume does not by itself prove ownership; the
-  current session must have already recorded that token before the
+  that already-verified claim. Reading an existing `{claim-id}` from
+  issue comments does not by itself prove ownership; the current
+  session must have already recorded that token before the
   revalidation step.
 - `{prior-claim-id}` is `none` for a fresh claim on an unclaimed issue.
   For a stale-claim takeover, set it to the currently active claim's
@@ -223,6 +221,8 @@ Out of scope and explicitly **not** blocked:
 - F4 post-merge cleanup (F4 itself removes the sibling worktree;
   subsequent local `main` updates run from the primary worktree by
   design).
+- [Operator-present release](idd-resume.instructions.md#operator-present-release)
+  steps 1-2 (pre-claim; no claim held yet).
 
 The claim and cwd checks are read-only and pre-mutation; the lock
 acquisition is the final local guard. When in scope, all of these checks
@@ -297,7 +297,7 @@ file that matches your current situation.
 | --- | --- |
 | Starting fresh (no active claim) | `idd-discover.instructions.md`, then `idd-claim.instructions.md` |
 | Starting fresh with one explicit issue target | `idd-discover.instructions.md` A0-T, then `idd-claim.instructions.md` |
-| Resuming after crash / rate-limit / handoff | `idd-resume.instructions.md` |
+| Resuming after crash / rate-limit / handoff / operator-present deliberate pause | `idd-resume.instructions.md` |
 | Claimed, branch exists, no PR yet | `idd-work.instructions.md` |
 | PR open, CI running, no reviews yet | `idd-pr-submit.instructions.md` |
 | PR open, CI running, reviews exist | `idd-review-snapshot.instructions.md` (E1–E3) |

--- a/idd-template/.github/instructions/idd-overview-core.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-core.instructions.md
@@ -34,7 +34,7 @@ post via direct HTTP `POST` with a JSON body; see
 helper runtime is enabled, the `post-idd-marker` helper (`--type claim
 --target issue <number> --apply` plus the claim fields) posts this
 marker through that JSON path (dry-run without `--apply`); the direct
-`POST` stays the canonical fallback.
+`POST` is the fallback.
 
 Every new HTML-comment operational marker must include a short visible
 note after the token: `review-watermark`/`review-baseline` use the
@@ -54,7 +54,7 @@ but never create new hidden-only claim comments.
   stale takeover. Reuse the same `{claim-id}` only for heartbeats of
   that already-verified claim. Reading an existing `{claim-id}` from
   issue comments does not by itself prove ownership; the current
-  session must have already recorded that token before the
+  session must have recorded that token before the
   revalidation step.
 - `{prior-claim-id}` is `none` for a fresh claim on an unclaimed issue.
   For a stale-claim takeover, set it to the currently active claim's
@@ -73,8 +73,7 @@ _{agent-id}: issue claim released — IDD automation marker. Do not edit._
 When helper runtime is enabled, post this with `post-idd-marker --type
 unclaim --target issue <number> --apply` (plus agent-id / claim-id /
 timestamp; see `docs/idd-helper-scripts.md`); without `--apply` it is
-dry-run. The direct HTTP `POST` above is the fallback when helper
-runtime is unavailable.
+dry-run. The direct HTTP `POST` above is the fallback.
 
 ## Trusted marker actors
 
@@ -222,7 +221,8 @@ Out of scope and explicitly **not** blocked:
   subsequent local `main` updates run from the primary worktree by
   design).
 - [Operator-present release](idd-resume.instructions.md#operator-present-release)
-  steps 1-2 (pre-claim; no claim held yet).
+  steps 1-2 (pre-claim for the resuming session; the issue's own
+  active claim is untouched until step 2).
 
 The claim and cwd checks are read-only and pre-mutation; the lock
 acquisition is the final local guard. When in scope, all of these checks


### PR DESCRIPTION
# Summary

Names operator-present deliberate-pause resumption in
`idd-overview-core.instructions.md`'s Phase routing table so a fresh
session lands on `idd-resume.instructions.md`'s Operator-present
release path (added by #1985/PR #1993) instead of misreading the
issue as unclaimed and routing through Discover/Claim. Adds a
matching exception bullet to the claim revalidation gate's "Out of
scope and explicitly not blocked" list, naming that path's pre-claim
steps 1-2 and cross-referencing the Resume file's own subsection
rather than restating its content.

`idd-overview-core.instructions.md` already sat at 97.97%-97.99%
utilization against `bundle-resume` and `bundle-review`'s 98% hard
byte cap (`context-ceiling-128k` in `audit/sync-manifest.json`), and
the two required additions alone pushed both over. Per the issue's
own escape hatch, an equal amount of genuinely redundant wording was
trimmed from elsewhere in the same file rather than raising a bundle
limit — see the Background / rationale section below for exactly
what was cut and why each cut is non-redundant-elsewhere-safe.

## Linked issue

Closes #1994

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Byte-budget arithmetic (measured on `main` before this change, both
bundles include `idd-overview-core.instructions.md`):

- `bundle-resume` (limit 43,300 B): 97.97% utilized, ~15 B headroom
  to the hard cap.
- `bundle-review` (limit 120,000 B): 97.99% utilized, ~10 B headroom.

The two required additions alone (~170 B) failed
`node scripts/audit-docs.mjs --check` with both bundles over 98%.
Trimmed the following genuinely redundant wording from elsewhere in
`idd-overview-core.instructions.md` to restore headroom (each verified
against the rest of the file, not merely assumed):

- Removed "A matching `{agent-id}` is never ownership proof by
  itself, because separate live sessions can share the same agent
  ID." from the `{claim-id}` bullet in Claim format — the same
  invariant is already stated twice elsewhere in this file: "agent-id
  alone never proves ownership" (the `{agent-id}` bullet immediately
  above) and "a correct HTML token, `agent-id`, or `claim-id` is
  never sufficient on its own" (Trusted marker actors). The "shared
  across concurrent sessions" premise is independently stated at
  `{agent-id}`'s own definition.
- Shortened "(dry-run, posting nothing, without `--apply`)" to
  "(dry-run without `--apply`)" in the same section's helper note.
- Removed "during discovery or resume" from the claim-id-reading
  caveat — a broadening (the caveat already applies universally), not
  a narrowing.

Post-trim: `bundle-resume` 97.95% (22 B headroom), `bundle-review`
97.99% (17 B headroom); `node scripts/audit-docs.mjs --check` passes.
An independent B2 critique subagent (per this repo's
`docs/idd-workflow.md` Critique pass invocation) re-verified the
`idd-resume.instructions.md#operator-present-release` anchor
resolves, that the new bullet's "steps 1-2" scoping exactly matches
the Resume file's own step numbering (steps 3+ are read-only or
covered by separate bootstrap logic, not this carve-out), and that no
other file or test in the repo depends on the exact removed wording
(grepped). It flagged only three Low-severity, non-blocking
observations (list-scope framing, a dropped explicit "because"
causal link whose premise and conclusion both survive elsewhere, and
the discovery/resume broadening being an intentional widening rather
than a regression) — none required a further code change.

No other content in `idd-overview-core.instructions.md` changes.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
