### PR TITLE
chore(lint): adopt @kurone-kito/cspell-config as the cspell base

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -1,42 +1,19 @@
-allowCompoundWords: true
+import:
+  - '@kurone-kito/cspell-config'
 cache:
   cacheFormat: universal
   cacheLocation: node_modules/.cache/cspell/.cspell.cache
   cacheStrategy: metadata
   useCache: true
-dictionaries:
-  - cpp
-  - en_US
-  - en-gb
-  - fullstack
-  - git
-  - markdown
-  - misc
-  - shellscript
-  - softwareTerms
-enableGlobDot: true
-features:
-  weighted-suggestions: true
-globRoot: ${cwd}
-ignorePaths:
-  - .*ignore
-  - .git
-  - .github/CODE_OF_CONDUCT.*
-  - .vscode/extensions.json
-  - pnpm-lock.yaml
 language: en,ja
-useGitignore: true
 version: '0.2'
 words:
   - desync
   - desynced
   - idd
   - isort
-  - kito
   - Kiro
-  - kuron
   - kurone
-  - kuroné
   - ONNX
   - pylint
   - pytest

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -832,15 +832,8 @@
       ]
     },
     {
-      "id": "root-cspell-config",
-      "_comment": "Same direction as every other pair here (idd-template/ is the canonical source; edit it first, then `sync-docs.mjs --apply` regenerates the target) -- idd-skill#1860's twist is only that the generated target is this repo's own root config, which also governs this repo's own CI, not a docs/ mirror. The #1765 uncommitted-local-edit guard protects a maintainer who fixes the root file directly without touching the template first.",
-      "source": "idd-template/.cspell.config.yml",
-      "target": ".cspell.config.yml",
-      "mode": "exact"
-    },
-    {
       "id": "root-markdownlint-config",
-      "_comment": "Same direction/rationale as root-cspell-config immediately above.",
+      "_comment": "idd-template/ is the canonical source; edit it first, then `sync-docs.mjs --apply` regenerates the target -- idd-skill#1860's twist is only that the generated target is this repo's own root config, which also governs this repo's own CI, not a docs/ mirror. The #1765 uncommitted-local-edit guard protects a maintainer who fixes the root file directly without touching the template first. Unlike `.cspell.config.yml` (idd-skill#1974: root adopted an import-based `@kurone-kito/cspell-config` base, which would break ONBOARDING.md's self-contained-template guarantee if mirrored into idd-template/, so that pair was removed and the root file now diverges from its template independently), this pair still holds because both sides stay hand-declared with no import dependency.",
       "source": "idd-template/.markdownlint.yml",
       "target": ".markdownlint.yml",
       "mode": "exact"

--- a/idd-template/.cspell.config.yml
+++ b/idd-template/.cspell.config.yml
@@ -1,19 +1,42 @@
-import:
-  - '@kurone-kito/cspell-config'
+allowCompoundWords: true
 cache:
   cacheFormat: universal
   cacheLocation: node_modules/.cache/cspell/.cspell.cache
   cacheStrategy: metadata
   useCache: true
+dictionaries:
+  - cpp
+  - en_US
+  - en-gb
+  - fullstack
+  - git
+  - markdown
+  - misc
+  - shellscript
+  - softwareTerms
+enableGlobDot: true
+features:
+  weighted-suggestions: true
+globRoot: ${cwd}
+ignorePaths:
+  - .*ignore
+  - .git
+  - .github/CODE_OF_CONDUCT.*
+  - .vscode/extensions.json
+  - pnpm-lock.yaml
 language: en,ja
+useGitignore: true
 version: '0.2'
 words:
   - desync
   - desynced
   - idd
   - isort
+  - kito
   - Kiro
+  - kuron
   - kurone
+  - kuroné
   - ONNX
   - pylint
   - pytest

--- a/idd-template/.cspell.config.yml
+++ b/idd-template/.cspell.config.yml
@@ -1,42 +1,19 @@
-allowCompoundWords: true
+import:
+  - '@kurone-kito/cspell-config'
 cache:
   cacheFormat: universal
   cacheLocation: node_modules/.cache/cspell/.cspell.cache
   cacheStrategy: metadata
   useCache: true
-dictionaries:
-  - cpp
-  - en_US
-  - en-gb
-  - fullstack
-  - git
-  - markdown
-  - misc
-  - shellscript
-  - softwareTerms
-enableGlobDot: true
-features:
-  weighted-suggestions: true
-globRoot: ${cwd}
-ignorePaths:
-  - .*ignore
-  - .git
-  - .github/CODE_OF_CONDUCT.*
-  - .vscode/extensions.json
-  - pnpm-lock.yaml
 language: en,ja
-useGitignore: true
 version: '0.2'
 words:
   - desync
   - desynced
   - idd
   - isort
-  - kito
   - Kiro
-  - kuron
   - kurone
-  - kuroné
   - ONNX
   - pylint
   - pytest

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.0.0",
     "@kurone-kito/biome-config": "0.22.0",
+    "@kurone-kito/cspell-config": "0.22.0",
     "@types/node": "26.1.2",
     "cspell": "^10.0.0",
     "dprint": "0.55.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       '@kurone-kito/biome-config':
         specifier: 0.22.0
         version: 0.22.0(@biomejs/biome@2.5.6)
+      '@kurone-kito/cspell-config':
+        specifier: 0.22.0
+        version: 0.22.0(cspell@10.0.1)
       '@types/node':
         specifier: 26.1.2
         version: 26.1.2
@@ -543,6 +546,15 @@ packages:
       '@biomejs/biome': '>=2.3.x'
     peerDependenciesMeta:
       '@biomejs/biome':
+        optional: true
+
+  '@kurone-kito/cspell-config@0.22.0':
+    resolution: {integrity: sha512-tA1Q/uw2aEd1oabQ5/mjCmHt/4BYcgFdt9nXbjaXRxiwj5MOhneR4MpuDx82qHVym7fkPovmiYR722anX9xzEQ==}
+    engines: {node: ^20.11 || ^22 || >=24}
+    peerDependencies:
+      cspell: '*'
+    peerDependenciesMeta:
+      cspell:
         optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -1773,6 +1785,10 @@ snapshots:
   '@kurone-kito/biome-config@0.22.0(@biomejs/biome@2.5.6)':
     optionalDependencies:
       '@biomejs/biome': 2.5.6
+
+  '@kurone-kito/cspell-config@0.22.0(cspell@10.0.1)':
+    optionalDependencies:
+      cspell: 10.0.1
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
## Summary

Adopt the shared `@kurone-kito/cspell-config` package as this repo's
own cspell base, replacing the hand-declared `dictionaries`/`words`/
`ignorePaths` in root `.cspell.config.yml` with an `import`, mirroring
the existing `@kurone-kito/biome-config` pattern (`biome.json`'s
`extends`, which is likewise root-only and never shipped in
`idd-template/`).

- `package.json`: add `@kurone-kito/cspell-config` as an exact-pinned
  (`0.22.0`) devDependency.
- Root `.cspell.config.yml`: rewrite to `import: ['@kurone-kito/cspell-config']`,
  keeping the local `cache:` block, an explicit `language: en,ja`
  override (the imported config sets `en,eo,ja`; scalar fields don't
  merge), and `version: '0.2'`.
- Dropped the local `dictionaries:` list entirely — empirically verified
  the imported `shell` dictionary covers what the local `shellscript`
  entry provided (`cspell lint` stays clean with it removed, re-verified
  with `--no-cache` to rule out a stale metadata-cache false-clean).
- Dropped `kito`/`kuron`/`kuroné` from the local `words:` list as
  lint-proven redundant against the imported package's own `words` list
  (not by inspection). Kept `kurone` (no accent) since it is **not** in
  the imported package's `words` list, so removing it would not be a
  proven-redundant deletion.
- `idd-template/.cspell.config.yml` is **unchanged** — see below.

## `idd-template/.cspell.config.yml` stays self-contained (not import-based)

An earlier revision of this PR mirrored the import-based config into
`idd-template/.cspell.config.yml` too, via `audit/sync-manifest.json`'s
`root-cspell-config` exact-mode sync pair (`idd-template/` was the
declared canonical source, regenerating this repo's own root config as
the target). Copilot, the Codex connector, and CodeRabbit each
independently flagged that this would break `ONBOARDING.md`'s
documented guarantee that the template's shipped lint configs work out
of the box for adopters — `idd-template/` has no `package.json` of its
own and no onboarding step installs `@kurone-kito/cspell-config`, so an
adopter who imports the template without separately depending on that
package would get a hard cspell config-resolution error.

Per maintainer decision, this PR keeps `idd-template/.cspell.config.yml`
hand-declared (unchanged) and removed the `root-cspell-config` sync pair
from `audit/sync-manifest.json` so the root config (this repo's own CI,
now import-based) and the template copy (shipped to adopters,
self-contained) diverge independently — the same shape
`@kurone-kito/biome-config` already has.

## Diff exceeds the issue's `## Candidate files`

The issue's `## Candidate files` lists only `package.json` and
`.cspell.config.yml`. This PR also touches:

- `pnpm-lock.yaml` — the routine lockfile update from the new
  `devDependencies` entry.
- `audit/sync-manifest.json` — removes the `root-cspell-config` pair and
  updates the neighboring `root-markdownlint-config` entry's `_comment`
  (it referenced the removed pair by name), per the self-containment
  fix above.

Closes #1974
