### PR TITLE
docs(issue-authoring): clean up stale Blocked-by notes on resolution

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -423,12 +423,20 @@ availability, or ordering constraint.
   track reports startable the moment its build foundation closes, and
   claiming it then means either failing its acceptance criteria or doing
   the siblings' unmerged work
-- once a `Blocked by #NNN` / `Depends on #NNN` reference resolves (the
-  referenced issue closes), revisit the blocked issue's own body and
-  remove the now-stale dependency line and any explanatory prose
-  describing the wait, rather than leaving it in place as inert
-  history. This is more than tidiness: stale wait-explaining prose can
-  trip `checkVerifiability`'s subjective-approval heuristic in
+- once a `Blocked by #NNN` / `Depends on #NNN` reference resolves —
+  the referenced issue closes **with its required outcome verified as
+  delivered**, not merely closed as not-planned, superseded without an
+  equivalent implementation, or later reopened — revisit the blocked
+  issue's own body and remove the now-stale dependency line and any
+  explanatory prose describing the wait, rather than leaving it in
+  place as inert history. Retain or restore the dependency edge
+  instead when the underlying constraint is not actually met: removing
+  it prematurely would let `discover-readiness-check` treat the
+  blocked issue as claimable despite the prerequisite still being
+  unresolved. (Observed 2026-08-13 on issue #1994's `Blocked by #1985`
+  note, after #1985 closed; reported in #2002.) This cleanup is more
+  than tidiness: stale wait-explaining prose can trip
+  `checkVerifiability`'s subjective-approval heuristic in
   `suitability-triage.mts`, which matches either a single line
   combining a subjective-subject word (`maintainer`, `stakeholder`,
   `human`, `opinion`, `judgment`/`judgement`, `ux`, or `feel` — not

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -427,10 +427,13 @@ availability, or ordering constraint.
   the referenced issue closes **with its required outcome verified as
   delivered**, not merely closed as not-planned, superseded without an
   equivalent implementation, or later reopened — revisit the blocked
-  issue's own body and remove the now-stale dependency line and any
-  explanatory prose describing the wait, rather than leaving it in
-  place as inert history, but keep any prose identifying the delivered
-  artifact or interface this issue's own scope depends on. When the
+  issue's own body and remove that reference and its explanatory wait
+  prose, rather than leaving it in place as inert history, but keep
+  any prose identifying the delivered artifact or interface this
+  issue's own scope depends on. A line naming several references
+  (`Blocked by #10, #11`) keeps the still-open ones — remove only the
+  resolved reference, and remove the whole line only once every
+  reference on it has resolved. When the
   underlying constraint is not actually met, reopen the prerequisite
   issue or repoint the dependency line at an open replacement issue
   instead of leaving a stale edge in place:

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -429,14 +429,18 @@ availability, or ordering constraint.
   equivalent implementation, or later reopened — revisit the blocked
   issue's own body and remove the now-stale dependency line and any
   explanatory prose describing the wait, rather than leaving it in
-  place as inert history. Retain or restore the dependency edge
-  instead when the underlying constraint is not actually met: removing
-  it prematurely would let `discover-readiness-check` treat the
-  blocked issue as claimable despite the prerequisite still being
-  unresolved. (Observed 2026-08-13 on issue #1994's `Blocked by #1985`
-  note, after #1985 closed; reported in #2002.) This cleanup is more
-  than tidiness: stale wait-explaining prose can trip
-  `checkVerifiability`'s subjective-approval heuristic in
+  place as inert history, but keep any prose identifying the delivered
+  artifact or interface this issue's own scope depends on. When the
+  underlying constraint is not actually met, reopen the prerequisite
+  issue or repoint the dependency line at an open replacement issue
+  instead of leaving a stale edge in place:
+  `discover-readiness-check` blocks only on an `OPEN` referenced
+  issue, regardless of why it closed, so retaining the edge alone does
+  not keep the dependent issue blocked. (Observed 2026-08-13 on issue
+  #1994's `Blocked by #1985` note, after #1985 closed; reported in
+  #2002.) This cleanup is more than tidiness: stale wait-explaining
+  prose can trip `checkVerifiability`'s subjective-approval heuristic
+  in
   `suitability-triage.mts`, which matches either a single line
   combining a subjective-subject word (`maintainer`, `stakeholder`,
   `human`, `opinion`, `judgment`/`judgement`, `ux`, or `feel` — not

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -447,9 +447,10 @@ availability, or ordering constraint.
   `suitability-triage.mts`, which matches either a single line
   combining a subjective-subject word (`maintainer`, `stakeholder`,
   `human`, `opinion`, `judgment`/`judgement`, `ux`, or `feel` — not
-  only authority nouns) with a gate word (`approval`, `sign-off`,
-  `decision`, or `preference`), or a gate word followed within 80
-  characters — including across lines — by a subjective-subject word.
+  only authority nouns) with a gate word (`approval`, `sign-off`/
+  `signoff`, `decision`, or `preference`), or a gate word followed
+  within 80 characters — including across lines — by a
+  subjective-subject word.
   This still fires even though the structural dependency filter
   already correctly treats the closed reference as unblocking
 

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -429,10 +429,14 @@ availability, or ordering constraint.
   describing the wait, rather than leaving it in place as inert
   history. This is more than tidiness: stale wait-explaining prose can
   trip `checkVerifiability`'s subjective-approval heuristic in
-  `suitability-triage.mts` (a line combining an authority-type noun
-  with an approval/sign-off/decision-type noun), even though the
-  structural dependency filter already correctly treats the closed
-  reference as unblocking
+  `suitability-triage.mts`, which matches either a single line
+  combining a subjective-subject word (`maintainer`, `stakeholder`,
+  `human`, `opinion`, `judgment`/`judgement`, `ux`, or `feel` — not
+  only authority nouns) with a gate word (`approval`, `sign-off`,
+  `decision`, or `preference`), or a gate word followed within 80
+  characters — including across lines — by a subjective-subject word.
+  This still fires even though the structural dependency filter
+  already correctly treats the closed reference as unblocking
 
 When an issue keeps a dependency edge, justify each dependency edge in
 the surrounding issue body and confirm that the split still preserves

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -423,6 +423,16 @@ availability, or ordering constraint.
   track reports startable the moment its build foundation closes, and
   claiming it then means either failing its acceptance criteria or doing
   the siblings' unmerged work
+- once a `Blocked by #NNN` / `Depends on #NNN` reference resolves (the
+  referenced issue closes), revisit the blocked issue's own body and
+  remove the now-stale dependency line and any explanatory prose
+  describing the wait, rather than leaving it in place as inert
+  history. This is more than tidiness: stale wait-explaining prose can
+  trip `checkVerifiability`'s subjective-approval heuristic in
+  `suitability-triage.mts` (a line combining an authority-type noun
+  with an approval/sign-off/decision-type noun), even though the
+  structural dependency filter already correctly treats the closed
+  reference as unblocking
 
 When an issue keeps a dependency edge, justify each dependency edge in
 the surrounding issue body and confirm that the split still preserves

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -815,9 +815,10 @@ availability, or ordering constraint.
   `suitability-triage.mts`, which matches either a single line
   combining a subjective-subject word (`maintainer`, `stakeholder`,
   `human`, `opinion`, `judgment`/`judgement`, `ux`, or `feel` — not
-  only authority nouns) with a gate word (`approval`, `sign-off`,
-  `decision`, or `preference`), or a gate word followed within 80
-  characters — including across lines — by a subjective-subject word.
+  only authority nouns) with a gate word (`approval`, `sign-off`/
+  `signoff`, `decision`, or `preference`), or a gate word followed
+  within 80 characters — including across lines — by a
+  subjective-subject word.
   This still fires even though the structural dependency filter
   already correctly treats the closed reference as unblocking
 

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -791,6 +791,16 @@ availability, or ordering constraint.
   track reports startable the moment its build foundation closes, and
   claiming it then means either failing its acceptance criteria or doing
   the siblings' unmerged work
+- once a `Blocked by #NNN` / `Depends on #NNN` reference resolves (the
+  referenced issue closes), revisit the blocked issue's own body and
+  remove the now-stale dependency line and any explanatory prose
+  describing the wait, rather than leaving it in place as inert
+  history. This is more than tidiness: stale wait-explaining prose can
+  trip `checkVerifiability`'s subjective-approval heuristic in
+  `suitability-triage.mts` (a line combining an authority-type noun
+  with an approval/sign-off/decision-type noun), even though the
+  structural dependency filter already correctly treats the closed
+  reference as unblocking
 
 When an issue keeps a dependency edge, justify each dependency edge in
 the surrounding issue body and confirm that the split still preserves

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -791,12 +791,20 @@ availability, or ordering constraint.
   track reports startable the moment its build foundation closes, and
   claiming it then means either failing its acceptance criteria or doing
   the siblings' unmerged work
-- once a `Blocked by #NNN` / `Depends on #NNN` reference resolves (the
-  referenced issue closes), revisit the blocked issue's own body and
-  remove the now-stale dependency line and any explanatory prose
-  describing the wait, rather than leaving it in place as inert
-  history. This is more than tidiness: stale wait-explaining prose can
-  trip `checkVerifiability`'s subjective-approval heuristic in
+- once a `Blocked by #NNN` / `Depends on #NNN` reference resolves —
+  the referenced issue closes **with its required outcome verified as
+  delivered**, not merely closed as not-planned, superseded without an
+  equivalent implementation, or later reopened — revisit the blocked
+  issue's own body and remove the now-stale dependency line and any
+  explanatory prose describing the wait, rather than leaving it in
+  place as inert history. Retain or restore the dependency edge
+  instead when the underlying constraint is not actually met: removing
+  it prematurely would let `discover-readiness-check` treat the
+  blocked issue as claimable despite the prerequisite still being
+  unresolved. (Observed 2026-08-13 on issue #1994's `Blocked by #1985`
+  note, after #1985 closed; reported in #2002.) This cleanup is more
+  than tidiness: stale wait-explaining prose can trip
+  `checkVerifiability`'s subjective-approval heuristic in
   `suitability-triage.mts`, which matches either a single line
   combining a subjective-subject word (`maintainer`, `stakeholder`,
   `human`, `opinion`, `judgment`/`judgement`, `ux`, or `feel` — not

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -795,10 +795,13 @@ availability, or ordering constraint.
   the referenced issue closes **with its required outcome verified as
   delivered**, not merely closed as not-planned, superseded without an
   equivalent implementation, or later reopened — revisit the blocked
-  issue's own body and remove the now-stale dependency line and any
-  explanatory prose describing the wait, rather than leaving it in
-  place as inert history, but keep any prose identifying the delivered
-  artifact or interface this issue's own scope depends on. When the
+  issue's own body and remove that reference and its explanatory wait
+  prose, rather than leaving it in place as inert history, but keep
+  any prose identifying the delivered artifact or interface this
+  issue's own scope depends on. A line naming several references
+  (`Blocked by #10, #11`) keeps the still-open ones — remove only the
+  resolved reference, and remove the whole line only once every
+  reference on it has resolved. When the
   underlying constraint is not actually met, reopen the prerequisite
   issue or repoint the dependency line at an open replacement issue
   instead of leaving a stale edge in place:

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -797,14 +797,18 @@ availability, or ordering constraint.
   equivalent implementation, or later reopened — revisit the blocked
   issue's own body and remove the now-stale dependency line and any
   explanatory prose describing the wait, rather than leaving it in
-  place as inert history. Retain or restore the dependency edge
-  instead when the underlying constraint is not actually met: removing
-  it prematurely would let `discover-readiness-check` treat the
-  blocked issue as claimable despite the prerequisite still being
-  unresolved. (Observed 2026-08-13 on issue #1994's `Blocked by #1985`
-  note, after #1985 closed; reported in #2002.) This cleanup is more
-  than tidiness: stale wait-explaining prose can trip
-  `checkVerifiability`'s subjective-approval heuristic in
+  place as inert history, but keep any prose identifying the delivered
+  artifact or interface this issue's own scope depends on. When the
+  underlying constraint is not actually met, reopen the prerequisite
+  issue or repoint the dependency line at an open replacement issue
+  instead of leaving a stale edge in place:
+  `discover-readiness-check` blocks only on an `OPEN` referenced
+  issue, regardless of why it closed, so retaining the edge alone does
+  not keep the dependent issue blocked. (Observed 2026-08-13 on issue
+  #1994's `Blocked by #1985` note, after #1985 closed; reported in
+  #2002.) This cleanup is more than tidiness: stale wait-explaining
+  prose can trip `checkVerifiability`'s subjective-approval heuristic
+  in
   `suitability-triage.mts`, which matches either a single line
   combining a subjective-subject word (`maintainer`, `stakeholder`,
   `human`, `opinion`, `judgment`/`judgement`, `ux`, or `feel` — not

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -797,10 +797,14 @@ availability, or ordering constraint.
   describing the wait, rather than leaving it in place as inert
   history. This is more than tidiness: stale wait-explaining prose can
   trip `checkVerifiability`'s subjective-approval heuristic in
-  `suitability-triage.mts` (a line combining an authority-type noun
-  with an approval/sign-off/decision-type noun), even though the
-  structural dependency filter already correctly treats the closed
-  reference as unblocking
+  `suitability-triage.mts`, which matches either a single line
+  combining a subjective-subject word (`maintainer`, `stakeholder`,
+  `human`, `opinion`, `judgment`/`judgement`, `ux`, or `feel` — not
+  only authority nouns) with a gate word (`approval`, `sign-off`,
+  `decision`, or `preference`), or a gate word followed within 80
+  characters — including across lines — by a subjective-subject word.
+  This still fires even though the structural dependency filter
+  already correctly treats the closed reference as unblocking
 
 When an issue keeps a dependency edge, justify each dependency edge in
 the surrounding issue body and confirm that the split still preserves

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -423,12 +423,20 @@ availability, or ordering constraint.
   track reports startable the moment its build foundation closes, and
   claiming it then means either failing its acceptance criteria or doing
   the siblings' unmerged work
-- once a `Blocked by #NNN` / `Depends on #NNN` reference resolves (the
-  referenced issue closes), revisit the blocked issue's own body and
-  remove the now-stale dependency line and any explanatory prose
-  describing the wait, rather than leaving it in place as inert
-  history. This is more than tidiness: stale wait-explaining prose can
-  trip `checkVerifiability`'s subjective-approval heuristic in
+- once a `Blocked by #NNN` / `Depends on #NNN` reference resolves —
+  the referenced issue closes **with its required outcome verified as
+  delivered**, not merely closed as not-planned, superseded without an
+  equivalent implementation, or later reopened — revisit the blocked
+  issue's own body and remove the now-stale dependency line and any
+  explanatory prose describing the wait, rather than leaving it in
+  place as inert history. Retain or restore the dependency edge
+  instead when the underlying constraint is not actually met: removing
+  it prematurely would let `discover-readiness-check` treat the
+  blocked issue as claimable despite the prerequisite still being
+  unresolved. (Observed 2026-08-13 on issue #1994's `Blocked by #1985`
+  note, after #1985 closed; reported in #2002.) This cleanup is more
+  than tidiness: stale wait-explaining prose can trip
+  `checkVerifiability`'s subjective-approval heuristic in
   `suitability-triage.mts`, which matches either a single line
   combining a subjective-subject word (`maintainer`, `stakeholder`,
   `human`, `opinion`, `judgment`/`judgement`, `ux`, or `feel` — not

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -427,10 +427,13 @@ availability, or ordering constraint.
   the referenced issue closes **with its required outcome verified as
   delivered**, not merely closed as not-planned, superseded without an
   equivalent implementation, or later reopened — revisit the blocked
-  issue's own body and remove the now-stale dependency line and any
-  explanatory prose describing the wait, rather than leaving it in
-  place as inert history, but keep any prose identifying the delivered
-  artifact or interface this issue's own scope depends on. When the
+  issue's own body and remove that reference and its explanatory wait
+  prose, rather than leaving it in place as inert history, but keep
+  any prose identifying the delivered artifact or interface this
+  issue's own scope depends on. A line naming several references
+  (`Blocked by #10, #11`) keeps the still-open ones — remove only the
+  resolved reference, and remove the whole line only once every
+  reference on it has resolved. When the
   underlying constraint is not actually met, reopen the prerequisite
   issue or repoint the dependency line at an open replacement issue
   instead of leaving a stale edge in place:

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -429,14 +429,18 @@ availability, or ordering constraint.
   equivalent implementation, or later reopened — revisit the blocked
   issue's own body and remove the now-stale dependency line and any
   explanatory prose describing the wait, rather than leaving it in
-  place as inert history. Retain or restore the dependency edge
-  instead when the underlying constraint is not actually met: removing
-  it prematurely would let `discover-readiness-check` treat the
-  blocked issue as claimable despite the prerequisite still being
-  unresolved. (Observed 2026-08-13 on issue #1994's `Blocked by #1985`
-  note, after #1985 closed; reported in #2002.) This cleanup is more
-  than tidiness: stale wait-explaining prose can trip
-  `checkVerifiability`'s subjective-approval heuristic in
+  place as inert history, but keep any prose identifying the delivered
+  artifact or interface this issue's own scope depends on. When the
+  underlying constraint is not actually met, reopen the prerequisite
+  issue or repoint the dependency line at an open replacement issue
+  instead of leaving a stale edge in place:
+  `discover-readiness-check` blocks only on an `OPEN` referenced
+  issue, regardless of why it closed, so retaining the edge alone does
+  not keep the dependent issue blocked. (Observed 2026-08-13 on issue
+  #1994's `Blocked by #1985` note, after #1985 closed; reported in
+  #2002.) This cleanup is more than tidiness: stale wait-explaining
+  prose can trip `checkVerifiability`'s subjective-approval heuristic
+  in
   `suitability-triage.mts`, which matches either a single line
   combining a subjective-subject word (`maintainer`, `stakeholder`,
   `human`, `opinion`, `judgment`/`judgement`, `ux`, or `feel` — not

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -447,9 +447,10 @@ availability, or ordering constraint.
   `suitability-triage.mts`, which matches either a single line
   combining a subjective-subject word (`maintainer`, `stakeholder`,
   `human`, `opinion`, `judgment`/`judgement`, `ux`, or `feel` — not
-  only authority nouns) with a gate word (`approval`, `sign-off`,
-  `decision`, or `preference`), or a gate word followed within 80
-  characters — including across lines — by a subjective-subject word.
+  only authority nouns) with a gate word (`approval`, `sign-off`/
+  `signoff`, `decision`, or `preference`), or a gate word followed
+  within 80 characters — including across lines — by a
+  subjective-subject word.
   This still fires even though the structural dependency filter
   already correctly treats the closed reference as unblocking
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -429,10 +429,14 @@ availability, or ordering constraint.
   describing the wait, rather than leaving it in place as inert
   history. This is more than tidiness: stale wait-explaining prose can
   trip `checkVerifiability`'s subjective-approval heuristic in
-  `suitability-triage.mts` (a line combining an authority-type noun
-  with an approval/sign-off/decision-type noun), even though the
-  structural dependency filter already correctly treats the closed
-  reference as unblocking
+  `suitability-triage.mts`, which matches either a single line
+  combining a subjective-subject word (`maintainer`, `stakeholder`,
+  `human`, `opinion`, `judgment`/`judgement`, `ux`, or `feel` — not
+  only authority nouns) with a gate word (`approval`, `sign-off`,
+  `decision`, or `preference`), or a gate word followed within 80
+  characters — including across lines — by a subjective-subject word.
+  This still fires even though the structural dependency filter
+  already correctly treats the closed reference as unblocking
 
 When an issue keeps a dependency edge, justify each dependency edge in
 the surrounding issue body and confirm that the split still preserves

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -423,6 +423,16 @@ availability, or ordering constraint.
   track reports startable the moment its build foundation closes, and
   claiming it then means either failing its acceptance criteria or doing
   the siblings' unmerged work
+- once a `Blocked by #NNN` / `Depends on #NNN` reference resolves (the
+  referenced issue closes), revisit the blocked issue's own body and
+  remove the now-stale dependency line and any explanatory prose
+  describing the wait, rather than leaving it in place as inert
+  history. This is more than tidiness: stale wait-explaining prose can
+  trip `checkVerifiability`'s subjective-approval heuristic in
+  `suitability-triage.mts` (a line combining an authority-type noun
+  with an approval/sign-off/decision-type noun), even though the
+  structural dependency filter already correctly treats the closed
+  reference as unblocking
 
 When an issue keeps a dependency edge, justify each dependency edge in
 the surrounding issue body and confirm that the split still preserves


### PR DESCRIPTION
## Summary

Re-triaging #1994 after its `Blocked by #1985` dependency merged,
`suitability-triage.mjs` failed Check 7 (Verifiability) on the issue's
own now-stale dependency-explaining prose, not on its actual acceptance
criteria — even though the structural `Blocked by` filter already
correctly treated the closed reference as unblocking. This adds
guidance so future authoring sessions strip that stale prose once the
referenced issue closes.

- `skills/issue-authoring/references/contract.md` (canonical source):
  new bullet in the "Dependency minimization" section — once a
  `Blocked by #NNN` / `Depends on #NNN` reference resolves, revisit the
  blocked issue's body and remove the now-stale dependency line and its
  explanatory prose. Names the concrete mechanism
  (`checkVerifiability`'s subjective-approval heuristic in
  `suitability-triage.mts`, verified by reading its
  `SUBJECTIVE_SUBJECT_PATTERN`/`SUBJECTIVE_GATE_PATTERN` co-occurrence
  check) so this reads as more than a tidiness suggestion.
- `docs/issue-authoring-skill.md`: identical bullet, per `CLAUDE.md`'s
  requirement to keep this maintenance doc manually aligned with the
  skill bundle.
- `.claude/skills/issue-authoring/references/contract.md`: regenerated
  via `node scripts/sync-docs.mjs --apply` from the canonical source
  above (generated mirror, not hand-edited).

No change to `src/scripts/suitability-triage.mts` — the fix is
removing stale content at authoring time, not loosening the checker.

Closes #2002


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified guidance for removing resolved dependency references from blocked issue descriptions.
  - Added instructions to remove outdated wait-related explanatory text once dependencies are resolved.
  - Documented that stale dependency wording may affect issue validation and verifiability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->