### PR TITLE
docs(idd-merge): document worktree remove --force for submodules

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -373,15 +373,29 @@ Before any mutating action in F3, apply the
    See `docs/idd-comment-minimization.md` for the evidence comment
    format, cleanup-failure comment format, permission-blocked comment
    format, and fallback GraphQL commands.
-3. Delete the local worktree and local branch: `git worktree remove
-   <path>`. If that fails with `fatal: working trees containing
-   submodules cannot be moved or removed`, a submodule-initializing step
-   (e.g. `git submodule update --init --recursive`) ran inside that
-   worktree at some point — retry with `git worktree remove --force
-   <path>`. `--force` also discards any uncommitted or untracked
-   changes, so confirm first that `git status --porcelain` in the
-   worktree is empty; only use it once the worktree is already known
-   clean, not as an unconditional default.
+3. Run from the **primary worktree**, never from inside the worktree
+   being removed — deleting the directory underlying the running
+   process's own cwd breaks every later step. Delete the worktree, then
+   the branch:
+
+   - `git worktree remove <path>`. If it fails with `fatal: working
+     trees containing submodules cannot be moved or removed`, a
+     submodule-initializing step (e.g. `git submodule update --init
+     --recursive`) ran inside that worktree — retry with `git worktree
+     remove --force <path>`, which also overrides the uncommitted /
+     untracked / submodule block. Any removal, forced or not, silently
+     discards ignored files too — including ones inside an initialized
+     submodule, which a worktree-root `git status --porcelain --ignored`
+     never surfaces. Before relying on `--force`, confirm both the
+     worktree root (`git status --porcelain --ignored`) and every
+     submodule (`git submodule foreach --recursive 'git status
+     --porcelain --ignored'`) report nothing — only once the worktree is
+     confirmed clean this way, not as an unconditional default.
+   - `git branch -D <branch-name>`. Use `-D`, not `-d`: F3 already
+     confirmed the merge via GitHub itself, so `-d`'s local ancestry
+     re-check is redundant and can false-negative (`not fully merged`)
+     before step 4 below fast-forwards local `main`, or once a `fetch
+     --prune` has already dropped the branch's remote-tracking ref.
 4. Update the local `main` branch.
 5. If GitHub auto-delete is disabled: delete the remote branch too.
    (Worktrunk may be used for steps 3–5.)

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -376,28 +376,35 @@ Before any mutating action in F3, apply the
 3. Run from the **primary worktree**, never from inside the worktree
    being removed — deleting the directory underlying the running
    process's own cwd breaks every later step. Any removal (plain or
-   `--force`) silently discards ignored files, including ones inside an
-   initialized submodule — so **before the first removal attempt**,
-   scope both cleanliness checks explicitly to the target `<path>` (an
-   unqualified command run from the primary worktree checks the wrong
-   repository) and confirm both report nothing:
+   `--force`) silently discards ignored files too, including ones
+   inside an initialized submodule — so **before the first removal
+   attempt**, review what's there. Scope both inspection commands
+   explicitly to the target `<path>` (an unqualified command run from
+   the primary worktree inspects the wrong repository):
 
-   - `git -C <path> status --porcelain --ignored`
+   - `git -C <path> status --porcelain --ignored --untracked-files=all`
+     (the explicit `--untracked-files` avoids a false-clean result under
+     a repository- or user-level `status.showUntrackedFiles=no`)
    - `git -C <path> submodule foreach --quiet --recursive 'git status
-     --porcelain --ignored'` (`--quiet` suppresses the `Entering
-     '<submodule>'` banner, otherwise a clean result still isn't empty
-     output)
+     --porcelain --ignored --untracked-files=all'` (`--quiet` suppresses
+     the `Entering '<submodule>'` banner, which otherwise makes even a
+     clean result non-empty)
 
-   Only once both are confirmed empty, delete the worktree, then the
-   branch:
+   Generated dependency/build output (e.g. `node_modules/` from
+   `install-deps`) is expected, disposable, and not a reason to stop.
+   Anything else uncommitted, untracked, or ignored (local notes, an
+   untracked `.env`, unpushed WIP) needs to be preserved — commit, push,
+   or copy it out — before continuing. Then
+   delete the worktree, then the branch:
 
    - `git worktree remove <path>`. If it fails with `fatal: working
      trees containing submodules cannot be moved or removed`, a
      submodule-initializing step (e.g. `git submodule update --init
      --recursive`) ran inside that worktree — retry with `git worktree
      remove --force <path>`, which also overrides the uncommitted /
-     untracked / submodule block. Never use `--force` as an
-     unconditional default — only after the cleanliness checks above.
+     untracked / submodule block. Only reach for either form once the
+     review above found nothing worth preserving, not as an
+     unconditional default.
    - `git branch -d <branch-name>` (this baseline's Claude Code
      permission profile denies `git branch -D`; see
      `docs/permissions.md`'s "What the baseline denies"). If it fails

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -385,10 +385,11 @@ Before any mutating action in F3, apply the
    - `git -C <path> status --porcelain --ignored --untracked-files=all`
      (the explicit `--untracked-files` avoids a false-clean result under
      a repository- or user-level `status.showUntrackedFiles=no`)
-   - `git -C <path> submodule foreach --quiet --recursive 'git status
-     --porcelain --ignored --untracked-files=all'` (`--quiet` suppresses
-     the `Entering '<submodule>'` banner, which otherwise makes even a
-     clean result non-empty)
+   - `git -C <path> submodule foreach --recursive 'git status
+     --porcelain --ignored --untracked-files=all'` (keep the `Entering
+     '<submodule>'` banner — a banner-only line is a clean result, and
+     with more than one submodule the banner is what attributes a
+     finding to the right one)
 
    Generated dependency/build output (e.g. `node_modules/` from
    `install-deps`) is expected, disposable, and not a reason to stop.

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -393,9 +393,10 @@ Before any mutating action in F3, apply the
    Generated dependency/build output (e.g. `node_modules/` from
    `install-deps`) is expected, disposable, and not a reason to stop.
    Anything else uncommitted, untracked, or ignored (local notes, an
-   untracked `.env`, unpushed WIP) needs to be preserved — commit, push,
-   or copy it out — before continuing. Then
-   delete the worktree, then the branch:
+   untracked `.env`, unpushed WIP) needs to be preserved to a
+   **different** ref, or copied out — never `<branch-name>` itself,
+   which step 3's own deletion below discards next — before
+   continuing. Then delete the worktree, then the branch:
 
    - `git worktree remove <path>`. If it fails with `fatal: working
      trees containing submodules cannot be moved or removed`, a

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -410,7 +410,7 @@ Before any mutating action in F3, apply the
    - `git branch -d <branch-name>` (this baseline's Claude Code
      permission profile denies `git branch -D`; see
      `docs/permissions.md`'s "What the baseline denies"). If it fails
-     with `error: the branch '<branch>' is not fully merged` even
+     with `error: the branch '<branch-name>' is not fully merged` even
      though the PR was just merged via GitHub — a `fetch --prune` can
      drop the branch's remote-tracking ref before local `main` is
      fast-forwarded — run step 4 first (`git fetch origin main && git

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -398,11 +398,15 @@ Before any mutating action in F3, apply the
      remove --force <path>`, which also overrides the uncommitted /
      untracked / submodule block. Never use `--force` as an
      unconditional default — only after the cleanliness checks above.
-   - `git branch -D <branch-name>`. Use `-D`, not `-d`: F3 already
-     confirmed the merge via GitHub itself, so `-d`'s local ancestry
-     re-check is redundant and can false-negative (`not fully merged`)
-     before step 4 below fast-forwards local `main`, or once a `fetch
-     --prune` has already dropped the branch's remote-tracking ref.
+   - `git branch -d <branch-name>` (this baseline's Claude Code
+     permission profile denies `git branch -D`; see
+     `docs/permissions.md`'s "What the baseline denies"). If it fails
+     with `error: the branch '<branch>' is not fully merged` even
+     though the PR was just merged via GitHub — a `fetch --prune` can
+     drop the branch's remote-tracking ref before local `main` is
+     fast-forwarded — run step 4 first (`git fetch origin main && git
+     merge --ff-only origin/main`), then retry `git branch -d
+     <branch-name>`.
 4. Update the local `main` branch.
 5. If GitHub auto-delete is disabled: delete the remote branch too.
    (Worktrunk may be used for steps 3–5.)

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -375,22 +375,29 @@ Before any mutating action in F3, apply the
    format, and fallback GraphQL commands.
 3. Run from the **primary worktree**, never from inside the worktree
    being removed — deleting the directory underlying the running
-   process's own cwd breaks every later step. Delete the worktree, then
-   the branch:
+   process's own cwd breaks every later step. Any removal (plain or
+   `--force`) silently discards ignored files, including ones inside an
+   initialized submodule — so **before the first removal attempt**,
+   scope both cleanliness checks explicitly to the target `<path>` (an
+   unqualified command run from the primary worktree checks the wrong
+   repository) and confirm both report nothing:
+
+   - `git -C <path> status --porcelain --ignored`
+   - `git -C <path> submodule foreach --quiet --recursive 'git status
+     --porcelain --ignored'` (`--quiet` suppresses the `Entering
+     '<submodule>'` banner, otherwise a clean result still isn't empty
+     output)
+
+   Only once both are confirmed empty, delete the worktree, then the
+   branch:
 
    - `git worktree remove <path>`. If it fails with `fatal: working
      trees containing submodules cannot be moved or removed`, a
      submodule-initializing step (e.g. `git submodule update --init
      --recursive`) ran inside that worktree — retry with `git worktree
      remove --force <path>`, which also overrides the uncommitted /
-     untracked / submodule block. Any removal, forced or not, silently
-     discards ignored files too — including ones inside an initialized
-     submodule, which a worktree-root `git status --porcelain --ignored`
-     never surfaces. Before relying on `--force`, confirm both the
-     worktree root (`git status --porcelain --ignored`) and every
-     submodule (`git submodule foreach --recursive 'git status
-     --porcelain --ignored'`) report nothing — only once the worktree is
-     confirmed clean this way, not as an unconditional default.
+     untracked / submodule block. Never use `--force` as an
+     unconditional default — only after the cleanliness checks above.
    - `git branch -D <branch-name>`. Use `-D`, not `-d`: F3 already
      confirmed the merge via GitHub itself, so `-d`'s local ancestry
      re-check is redundant and can false-negative (`not fully merged`)

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -373,7 +373,15 @@ Before any mutating action in F3, apply the
    See `docs/idd-comment-minimization.md` for the evidence comment
    format, cleanup-failure comment format, permission-blocked comment
    format, and fallback GraphQL commands.
-3. Delete the local worktree and local branch.
+3. Delete the local worktree and local branch: `git worktree remove
+   <path>`. If that fails with `fatal: working trees containing
+   submodules cannot be moved or removed`, a submodule-initializing step
+   (e.g. `git submodule update --init --recursive`) ran inside that
+   worktree at some point — retry with `git worktree remove --force
+   <path>`. `--force` also discards any uncommitted or untracked
+   changes, so confirm first that `git status --porcelain` in the
+   worktree is empty; only use it once the worktree is already known
+   clean, not as an unconditional default.
 4. Update the local `main` branch.
 5. If GitHub auto-delete is disabled: delete the remote branch too.
    (Worktrunk may be used for steps 3–5.)

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -393,11 +393,15 @@ Before any mutating action in F3, apply the
      remove --force <path>`, which also overrides the uncommitted /
      untracked / submodule block. Never use `--force` as an
      unconditional default — only after the cleanliness checks above.
-   - `git branch -D <branch-name>`. Use `-D`, not `-d`: F3 already
-     confirmed the merge via GitHub itself, so `-d`'s local ancestry
-     re-check is redundant and can false-negative (`not fully merged`)
-     before step 4 below fast-forwards local `main`, or once a `fetch
-     --prune` has already dropped the branch's remote-tracking ref.
+   - `git branch -d <branch-name>` (this baseline's Claude Code
+     permission profile denies `git branch -D`; see
+     `docs/permissions.md`'s "What the baseline denies"). If it fails
+     with `error: the branch '<branch>' is not fully merged` even
+     though the PR was just merged via GitHub — a `fetch --prune` can
+     drop the branch's remote-tracking ref before local `main` is
+     fast-forwarded — run step 4 first (`git fetch origin main && git
+     merge --ff-only origin/main`), then retry `git branch -d
+     <branch-name>`.
 4. Update the local `main` branch.
 5. If GitHub auto-delete is disabled: delete the remote branch too.
    (Worktrunk may be used for steps 3–5.)

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -368,7 +368,15 @@ Before any mutating action in F3, apply the
    See `docs/idd-comment-minimization.md` for the evidence comment
    format, cleanup-failure comment format, permission-blocked comment
    format, and fallback GraphQL commands.
-3. Delete the local worktree and local branch.
+3. Delete the local worktree and local branch: `git worktree remove
+   <path>`. If that fails with `fatal: working trees containing
+   submodules cannot be moved or removed`, a submodule-initializing step
+   (e.g. `git submodule update --init --recursive`) ran inside that
+   worktree at some point — retry with `git worktree remove --force
+   <path>`. `--force` also discards any uncommitted or untracked
+   changes, so confirm first that `git status --porcelain` in the
+   worktree is empty; only use it once the worktree is already known
+   clean, not as an unconditional default.
 4. Update the local `main` branch.
 5. If GitHub auto-delete is disabled: delete the remote branch too.
    (Worktrunk may be used for steps 3–5.)

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -380,10 +380,11 @@ Before any mutating action in F3, apply the
    - `git -C <path> status --porcelain --ignored --untracked-files=all`
      (the explicit `--untracked-files` avoids a false-clean result under
      a repository- or user-level `status.showUntrackedFiles=no`)
-   - `git -C <path> submodule foreach --quiet --recursive 'git status
-     --porcelain --ignored --untracked-files=all'` (`--quiet` suppresses
-     the `Entering '<submodule>'` banner, which otherwise makes even a
-     clean result non-empty)
+   - `git -C <path> submodule foreach --recursive 'git status
+     --porcelain --ignored --untracked-files=all'` (keep the `Entering
+     '<submodule>'` banner — a banner-only line is a clean result, and
+     with more than one submodule the banner is what attributes a
+     finding to the right one)
 
    Generated dependency/build output (e.g. `node_modules/` from
    `install-deps`) is expected, disposable, and not a reason to stop.

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -405,7 +405,7 @@ Before any mutating action in F3, apply the
    - `git branch -d <branch-name>` (this baseline's Claude Code
      permission profile denies `git branch -D`; see
      `docs/permissions.md`'s "What the baseline denies"). If it fails
-     with `error: the branch '<branch>' is not fully merged` even
+     with `error: the branch '<branch-name>' is not fully merged` even
      though the PR was just merged via GitHub — a `fetch --prune` can
      drop the branch's remote-tracking ref before local `main` is
      fast-forwarded — run step 4 first (`git fetch origin main && git

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -371,28 +371,35 @@ Before any mutating action in F3, apply the
 3. Run from the **primary worktree**, never from inside the worktree
    being removed — deleting the directory underlying the running
    process's own cwd breaks every later step. Any removal (plain or
-   `--force`) silently discards ignored files, including ones inside an
-   initialized submodule — so **before the first removal attempt**,
-   scope both cleanliness checks explicitly to the target `<path>` (an
-   unqualified command run from the primary worktree checks the wrong
-   repository) and confirm both report nothing:
+   `--force`) silently discards ignored files too, including ones
+   inside an initialized submodule — so **before the first removal
+   attempt**, review what's there. Scope both inspection commands
+   explicitly to the target `<path>` (an unqualified command run from
+   the primary worktree inspects the wrong repository):
 
-   - `git -C <path> status --porcelain --ignored`
+   - `git -C <path> status --porcelain --ignored --untracked-files=all`
+     (the explicit `--untracked-files` avoids a false-clean result under
+     a repository- or user-level `status.showUntrackedFiles=no`)
    - `git -C <path> submodule foreach --quiet --recursive 'git status
-     --porcelain --ignored'` (`--quiet` suppresses the `Entering
-     '<submodule>'` banner, otherwise a clean result still isn't empty
-     output)
+     --porcelain --ignored --untracked-files=all'` (`--quiet` suppresses
+     the `Entering '<submodule>'` banner, which otherwise makes even a
+     clean result non-empty)
 
-   Only once both are confirmed empty, delete the worktree, then the
-   branch:
+   Generated dependency/build output (e.g. `node_modules/` from
+   `install-deps`) is expected, disposable, and not a reason to stop.
+   Anything else uncommitted, untracked, or ignored (local notes, an
+   untracked `.env`, unpushed WIP) needs to be preserved — commit, push,
+   or copy it out — before continuing. Then
+   delete the worktree, then the branch:
 
    - `git worktree remove <path>`. If it fails with `fatal: working
      trees containing submodules cannot be moved or removed`, a
      submodule-initializing step (e.g. `git submodule update --init
      --recursive`) ran inside that worktree — retry with `git worktree
      remove --force <path>`, which also overrides the uncommitted /
-     untracked / submodule block. Never use `--force` as an
-     unconditional default — only after the cleanliness checks above.
+     untracked / submodule block. Only reach for either form once the
+     review above found nothing worth preserving, not as an
+     unconditional default.
    - `git branch -d <branch-name>` (this baseline's Claude Code
      permission profile denies `git branch -D`; see
      `docs/permissions.md`'s "What the baseline denies"). If it fails

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -368,15 +368,29 @@ Before any mutating action in F3, apply the
    See `docs/idd-comment-minimization.md` for the evidence comment
    format, cleanup-failure comment format, permission-blocked comment
    format, and fallback GraphQL commands.
-3. Delete the local worktree and local branch: `git worktree remove
-   <path>`. If that fails with `fatal: working trees containing
-   submodules cannot be moved or removed`, a submodule-initializing step
-   (e.g. `git submodule update --init --recursive`) ran inside that
-   worktree at some point — retry with `git worktree remove --force
-   <path>`. `--force` also discards any uncommitted or untracked
-   changes, so confirm first that `git status --porcelain` in the
-   worktree is empty; only use it once the worktree is already known
-   clean, not as an unconditional default.
+3. Run from the **primary worktree**, never from inside the worktree
+   being removed — deleting the directory underlying the running
+   process's own cwd breaks every later step. Delete the worktree, then
+   the branch:
+
+   - `git worktree remove <path>`. If it fails with `fatal: working
+     trees containing submodules cannot be moved or removed`, a
+     submodule-initializing step (e.g. `git submodule update --init
+     --recursive`) ran inside that worktree — retry with `git worktree
+     remove --force <path>`, which also overrides the uncommitted /
+     untracked / submodule block. Any removal, forced or not, silently
+     discards ignored files too — including ones inside an initialized
+     submodule, which a worktree-root `git status --porcelain --ignored`
+     never surfaces. Before relying on `--force`, confirm both the
+     worktree root (`git status --porcelain --ignored`) and every
+     submodule (`git submodule foreach --recursive 'git status
+     --porcelain --ignored'`) report nothing — only once the worktree is
+     confirmed clean this way, not as an unconditional default.
+   - `git branch -D <branch-name>`. Use `-D`, not `-d`: F3 already
+     confirmed the merge via GitHub itself, so `-d`'s local ancestry
+     re-check is redundant and can false-negative (`not fully merged`)
+     before step 4 below fast-forwards local `main`, or once a `fetch
+     --prune` has already dropped the branch's remote-tracking ref.
 4. Update the local `main` branch.
 5. If GitHub auto-delete is disabled: delete the remote branch too.
    (Worktrunk may be used for steps 3–5.)

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -388,9 +388,10 @@ Before any mutating action in F3, apply the
    Generated dependency/build output (e.g. `node_modules/` from
    `install-deps`) is expected, disposable, and not a reason to stop.
    Anything else uncommitted, untracked, or ignored (local notes, an
-   untracked `.env`, unpushed WIP) needs to be preserved — commit, push,
-   or copy it out — before continuing. Then
-   delete the worktree, then the branch:
+   untracked `.env`, unpushed WIP) needs to be preserved to a
+   **different** ref, or copied out — never `<branch-name>` itself,
+   which step 3's own deletion below discards next — before
+   continuing. Then delete the worktree, then the branch:
 
    - `git worktree remove <path>`. If it fails with `fatal: working
      trees containing submodules cannot be moved or removed`, a

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -370,22 +370,29 @@ Before any mutating action in F3, apply the
    format, and fallback GraphQL commands.
 3. Run from the **primary worktree**, never from inside the worktree
    being removed — deleting the directory underlying the running
-   process's own cwd breaks every later step. Delete the worktree, then
-   the branch:
+   process's own cwd breaks every later step. Any removal (plain or
+   `--force`) silently discards ignored files, including ones inside an
+   initialized submodule — so **before the first removal attempt**,
+   scope both cleanliness checks explicitly to the target `<path>` (an
+   unqualified command run from the primary worktree checks the wrong
+   repository) and confirm both report nothing:
+
+   - `git -C <path> status --porcelain --ignored`
+   - `git -C <path> submodule foreach --quiet --recursive 'git status
+     --porcelain --ignored'` (`--quiet` suppresses the `Entering
+     '<submodule>'` banner, otherwise a clean result still isn't empty
+     output)
+
+   Only once both are confirmed empty, delete the worktree, then the
+   branch:
 
    - `git worktree remove <path>`. If it fails with `fatal: working
      trees containing submodules cannot be moved or removed`, a
      submodule-initializing step (e.g. `git submodule update --init
      --recursive`) ran inside that worktree — retry with `git worktree
      remove --force <path>`, which also overrides the uncommitted /
-     untracked / submodule block. Any removal, forced or not, silently
-     discards ignored files too — including ones inside an initialized
-     submodule, which a worktree-root `git status --porcelain --ignored`
-     never surfaces. Before relying on `--force`, confirm both the
-     worktree root (`git status --porcelain --ignored`) and every
-     submodule (`git submodule foreach --recursive 'git status
-     --porcelain --ignored'`) report nothing — only once the worktree is
-     confirmed clean this way, not as an unconditional default.
+     untracked / submodule block. Never use `--force` as an
+     unconditional default — only after the cleanliness checks above.
    - `git branch -D <branch-name>`. Use `-D`, not `-d`: F3 already
      confirmed the merge via GitHub itself, so `-d`'s local ancestry
      re-check is redundant and can false-negative (`not fully merged`)


### PR DESCRIPTION
## Summary

- Document the submodule-triggered `git worktree remove` failure, its
  cause, and the `--force` fix at F4's cleanup step (step 3), with an
  explicit caveat that `--force` also discards uncommitted/untracked
  changes and is only safe once the worktree is confirmed clean.
- Documentation addition only — no change to F4's cleanup sequencing.

## Note on file location

The issue's Candidate files and Background text cite
`.github/instructions/idd-work.instructions.md`, but that file only
covers B1-C6 (worktree creation through self-review) and has no F4
section. The exact sentence the issue quotes — "Delete the local
worktree and local branch." — exists in exactly one place:
`idd-template/.github/instructions/idd-merge.instructions.md`'s
`## F4 — Cleanup` step 3 (mirrored into
`.github/instructions/idd-merge.instructions.md` by `sync-docs`).
Treating the issue's file reference as a transcription error and
implementing the substance of the request there instead — the
deliverable's content is unambiguous even though the filename cited was
wrong. Verified via `grep -rn "Delete the local worktree" idd-template/
.github/instructions`, which matches only in `idd-merge.instructions.md`
(template and generated copy), and via the phase-routing table in
`idd-overview-core.instructions.md`, which maps F3-F5 to
`idd-merge.instructions.md`. Flagged on the issue in the B2 plan comment
before implementing.

## Verification

- `node scripts/sync-docs.mjs --apply` — synced 1 file, no diff beyond
  the intended edit.
- `node scripts/audit-docs.mjs --check` — passed.
- `node scripts/audit-code-span-wrap.mjs` — no mid-token wraps.
- `pnpm run lint:minimum` — passed (3476 tests, 0 failures).
- `node scripts/idd-doctor.mjs` — passed (pre-existing warnings only,
  unrelated to this change).

Closes #2016


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree cleanup reliability during merge operations.
  * Added safeguards to confirm worktrees are clean before forced removal.
  * Limited forced cleanup retries to cases involving submodule-related removal failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->