### PR TITLE
fix(audit-pr-cleanup): retry --apply internally until a re-scan reports zero new candidates

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -357,16 +357,25 @@ Before any mutating action in F3, apply the
      `applied`/`clean` within this one invocation. If the output also
      reports `retryBoundExhausted: true` (visible as
      `retryBoundExhausted=true` in table format), the retry bound was
-     reached while a rescan still found candidates: still follow the
-     `applied`/`clean` evidence-comment path above, not the
-     `failed`/`incomplete` cleanup-failure path below, but note the
-     `retryAttempts` count in the evidence comment as an informational,
-     non-blocking residual-lag signal rather than a defect.
+     reached while a rescan still found candidates. Route by the apply
+     `status` exactly as above, even then: if `status` is still
+     `applied`/`clean`, follow that evidence-comment path and note the
+     `retryAttempts` count as an informational, non-blocking
+     residual-lag signal rather than a defect; if `status` came back
+     `incomplete` (the fresh rescan found a genuine permission-blocked
+     remainder) or `failed`, follow the `failed`/`incomplete`
+     cleanup-failure path below instead — `retryBoundExhausted: true`
+     never overrides a non-success `status`.
 
-     If the apply `status` is `failed` or `incomplete`: post the
-     cleanup-failure comment format instead, including the
-     `viewer-cannot-minimize` count when non-zero. Explicit evidence,
-     not a merge gate — the merge already succeeded. Proceed to step 3.
+     If the apply `status` is `failed`, `incomplete`, or
+     `rescan-failed`: post the cleanup-failure comment format instead,
+     including the `viewer-cannot-minimize` count when non-zero.
+     `rescan-failed` means the confirming rescan itself errored after a
+     mutation (already-applied work is preserved in the report but
+     convergence was never confirmed) — note that distinction in the
+     comment and re-run `--apply` to confirm convergence. Explicit
+     evidence, not a merge gate — the merge already succeeded. Proceed
+     to step 3.
 
    - **`permission-blocked`**: skipped items exist with
      `viewerCanMinimize: false` and no apply-eligible candidates found.

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -350,6 +350,19 @@ Before any mutating action in F3, apply the
      `viewer-cannot-minimize` counts for `applied`, or a converged
      `clean` record) so this run's work is recorded. Proceed to step 3.
 
+     The helper internally retries a whole scan-and-minimize pass, bounded,
+     when a fresh rescan still reports candidates after applying (a
+     candidate that only became eligible after the previous pass, e.g.
+     GraphQL read-after-write lag) — the common case still converges to
+     `applied`/`clean` within this one invocation. If the output also
+     reports `retryBoundExhausted: true` (visible as
+     `retryBoundExhausted=true` in table format), the retry bound was
+     reached while a rescan still found candidates: still follow the
+     `applied`/`clean` evidence-comment path above, not the
+     `failed`/`incomplete` cleanup-failure path below, but note the
+     `retryAttempts` count in the evidence comment as an informational,
+     non-blocking residual-lag signal rather than a defect.
+
      If the apply `status` is `failed` or `incomplete`: post the
      cleanup-failure comment format instead, including the
      `viewer-cannot-minimize` count when non-zero. Explicit evidence,

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -103,6 +103,8 @@ jobs:
             FAILED=$(printf '%s' "$JSON" | jq -r '(.failed // []) | length')
             SKIPPED=$(printf '%s' "$JSON" | jq -r '(.skipped // []) | length')
             BLOCKED=$(printf '%s' "$JSON" | jq -r '[(.skipped // [])[] | select(.isMinimized==false and .viewerCanMinimize==false)] | length')
+            RETRY_ATTEMPTS=$(printf '%s' "$JSON" | jq -r '.retryAttempts // 0')
+            RETRY_BOUND_EXHAUSTED=$(printf '%s' "$JSON" | jq -r '.retryBoundExhausted // false')
             if [ "$HELPER_EXIT" -ne 0 ]; then
               echo "::warning::audit-pr-cleanup exited $HELPER_EXIT but emitted a valid JSON report; using helper status \"$STATUS\""
             fi
@@ -113,6 +115,8 @@ jobs:
             FAILED=0
             SKIPPED=0
             BLOCKED=0
+            RETRY_ATTEMPTS=0
+            RETRY_BOUND_EXHAUSTED=false
           fi
           {
             echo "pr_number=$PR_NUMBER"
@@ -121,6 +125,8 @@ jobs:
             echo "failed=$FAILED"
             echo "skipped=$SKIPPED"
             echo "blocked=$BLOCKED"
+            echo "retry_attempts=$RETRY_ATTEMPTS"
+            echo "retry_bound_exhausted=$RETRY_BOUND_EXHAUSTED"
           } >> "$GITHUB_OUTPUT"
       - name: Post cleanup evidence comment
         env:
@@ -136,6 +142,8 @@ jobs:
           FAILED: ${{ steps.cleanup.outputs.failed }}
           SKIPPED: ${{ steps.cleanup.outputs.skipped }}
           BLOCKED: ${{ steps.cleanup.outputs.blocked }}
+          RETRY_ATTEMPTS: ${{ steps.cleanup.outputs.retry_attempts }}
+          RETRY_BOUND_EXHAUSTED: ${{ steps.cleanup.outputs.retry_bound_exhausted }}
         run: |
           # Avoid duplicate evidence comments. Workflow-level concurrency
           # only serialises this workflow's own runs; an agent F4 (or a
@@ -178,8 +186,8 @@ jobs:
             echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment (id: ${EXISTING}); skipping workflow post."
             exit 0
           fi
-          BODY=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
-            "<!-- idd-cleanup-evidence: ${STATUS} applied:${APPLIED} failed:${FAILED} skipped:${SKIPPED} viewer-cannot-minimize:${BLOCKED} -->" \
+          BODY=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+            "<!-- idd-cleanup-evidence: ${STATUS} applied:${APPLIED} failed:${FAILED} skipped:${SKIPPED} viewer-cannot-minimize:${BLOCKED} retry-attempts:${RETRY_ATTEMPTS} retry-bound-exhausted:${RETRY_BOUND_EXHAUSTED} -->" \
             "**F4 Cleanup Evidence** (server-side fallback via \`post-merge-cleanup.yml\`)" \
             "| Field              | Value |" \
             "| ------------------ | ----- |" \
@@ -188,6 +196,7 @@ jobs:
             "| Failed             | ${FAILED} |" \
             "| Skipped            | ${SKIPPED} |" \
             "| Permission-blocked | ${BLOCKED} |" \
+            "| Retry attempts (bound-exhausted) | ${RETRY_ATTEMPTS} (${RETRY_BOUND_EXHAUSTED}) |" \
             "| Posted by          | post-merge-cleanup workflow |" \
           )
           printf '%s' "$BODY" | gh pr comment "$PR_NUMBER" --body-file -

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -402,15 +402,15 @@ which suffices for its single-shot post-merge run:
 
 **F4 Cleanup Evidence**
 
-| Field                            | Value                                  |
-| -------------------------------- | -------------------------------------- |
-| Status                           | applied / failed / incomplete          |
-| Applied                          | N                                      |
-| Failed                           | N                                      |
-| Skipped                          | N                                      |
-| Permission-blocked               | N                                      |
-| Retry attempts (bound-exhausted) | N (true / false)                       |
-| Notes                            | reason for any failed or skipped items |
+| Field                            | Value                                         |
+| -------------------------------- | --------------------------------------------- |
+| Status                           | applied / failed / incomplete / rescan-failed |
+| Applied                          | N                                             |
+| Failed                           | N                                             |
+| Skipped                          | N                                             |
+| Permission-blocked               | N                                             |
+| Retry attempts (bound-exhausted) | N (true / false)                              |
+| Notes                            | reason for any failed or skipped items        |
 ```
 
 `retry-attempts` / `retry-bound-exhausted` mirror
@@ -419,14 +419,20 @@ which suffices for its single-shot post-merge run:
 issue 2011): a `true` bound-exhausted value with an otherwise
 `applied`/`clean` status is informational, not a cleanup failure — a
 fresh rescan still found candidates after the bound, not that
-anything went wrong.
+anything went wrong. A `rescan-failed` status (below) always takes the
+cleanup-failure path regardless of `retry-bound-exhausted`, since the
+confirming rescan itself never completed.
 
 ### Cleanup-failure comment
 
-Post this comment when apply `status` is `failed` or `incomplete`. If
-`viewer-cannot-minimize > 0` is also non-zero, include the blocked count
-in the same comment rather than posting a separate permission-blocked
-comment:
+Post this comment when apply `status` is `failed`, `incomplete`, or
+`rescan-failed`. `rescan-failed` means the confirming rescan after a
+mutation errored (a transient GraphQL/`gh` failure) — already-applied
+work is preserved in the report, but convergence was never confirmed;
+note that distinction and suggest a re-run rather than describing it as
+a per-candidate failure. If `viewer-cannot-minimize > 0` is also
+non-zero, include the blocked count in the same comment rather than
+posting a separate permission-blocked comment:
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->
@@ -435,7 +441,7 @@ comment:
 
 Cleanup candidates were detected but not all could be applied.
 
-- Status: failed / incomplete
+- Status: failed / incomplete / rescan-failed
 - Failed: N candidates (reason: ...)
 - Unapplied: N candidates
 - Permission-blocked: N candidates (if any)

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -398,19 +398,28 @@ uses a simpler presence-only guard (it skips on any existing marker),
 which suffices for its single-shot post-merge run:
 
 ```markdown
-<!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->
+<!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} retry-attempts:{N} retry-bound-exhausted:{true|false} -->
 
 **F4 Cleanup Evidence**
 
-| Field              | Value                                  |
-| ------------------ | -------------------------------------- |
-| Status             | applied / failed / incomplete          |
-| Applied            | N                                      |
-| Failed             | N                                      |
-| Skipped            | N                                      |
-| Permission-blocked | N                                      |
-| Notes              | reason for any failed or skipped items |
+| Field                            | Value                                  |
+| -------------------------------- | -------------------------------------- |
+| Status                           | applied / failed / incomplete          |
+| Applied                          | N                                      |
+| Failed                           | N                                      |
+| Skipped                          | N                                      |
+| Permission-blocked               | N                                      |
+| Retry attempts (bound-exhausted) | N (true / false)                       |
+| Notes                            | reason for any failed or skipped items |
 ```
+
+`retry-attempts` / `retry-bound-exhausted` mirror
+`audit-pr-cleanup.mjs --apply`'s own `retryAttempts` /
+`retryBoundExhausted` JSON fields (its internal whole-pass retry, see
+issue 2011): a `true` bound-exhausted value with an otherwise
+`applied`/`clean` status is informational, not a cleanup failure — a
+fresh rescan still found candidates after the bound, not that
+anything went wrong.
 
 ### Cleanup-failure comment
 

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -402,15 +402,15 @@ which suffices for its single-shot post-merge run:
 
 **F4 Cleanup Evidence**
 
-| Field                            | Value                                         |
-| -------------------------------- | --------------------------------------------- |
-| Status                           | applied / failed / incomplete / rescan-failed |
-| Applied                          | N                                             |
-| Failed                           | N                                             |
-| Skipped                          | N                                             |
-| Permission-blocked               | N                                             |
-| Retry attempts (bound-exhausted) | N (true / false)                              |
-| Notes                            | reason for any failed or skipped items        |
+| Field                            | Value                                                 |
+| -------------------------------- | ----------------------------------------------------- |
+| Status                           | applied / clean / failed / incomplete / rescan-failed |
+| Applied                          | N                                                     |
+| Failed                           | N                                                     |
+| Skipped                          | N                                                     |
+| Permission-blocked               | N                                                     |
+| Retry attempts (bound-exhausted) | N (true / false)                                      |
+| Notes                            | reason for any failed or skipped items                |
 ```
 
 `retry-attempts` / `retry-bound-exhausted` mirror

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -376,9 +376,9 @@ corresponding path:
 | `permission-blocked` | Post a cleanup-permission-blocked comment, then proceed to F4 |
 |                      | step 3.                                                       |
 
-After apply, if `status` is `failed` or `incomplete`, post a
-cleanup-failure comment. A cleanup failure after a successful F3 merge
-does not re-block the merge; it is an explicit record only.
+After apply, if `status` is `failed`, `incomplete`, or `rescan-failed`,
+post a cleanup-failure comment. A cleanup failure after a successful F3
+merge does not re-block the merge; it is an explicit record only.
 
 ### Cleanup evidence comment
 

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -345,6 +345,19 @@ Before any mutating action in F3, apply the
      `viewer-cannot-minimize` counts for `applied`, or a converged
      `clean` record) so this run's work is recorded. Proceed to step 3.
 
+     The helper internally retries a whole scan-and-minimize pass, bounded,
+     when a fresh rescan still reports candidates after applying (a
+     candidate that only became eligible after the previous pass, e.g.
+     GraphQL read-after-write lag) — the common case still converges to
+     `applied`/`clean` within this one invocation. If the output also
+     reports `retryBoundExhausted: true` (visible as
+     `retryBoundExhausted=true` in table format), the retry bound was
+     reached while a rescan still found candidates: still follow the
+     `applied`/`clean` evidence-comment path above, not the
+     `failed`/`incomplete` cleanup-failure path below, but note the
+     `retryAttempts` count in the evidence comment as an informational,
+     non-blocking residual-lag signal rather than a defect.
+
      If the apply `status` is `failed` or `incomplete`: post the
      cleanup-failure comment format instead, including the
      `viewer-cannot-minimize` count when non-zero. Explicit evidence,

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -352,16 +352,25 @@ Before any mutating action in F3, apply the
      `applied`/`clean` within this one invocation. If the output also
      reports `retryBoundExhausted: true` (visible as
      `retryBoundExhausted=true` in table format), the retry bound was
-     reached while a rescan still found candidates: still follow the
-     `applied`/`clean` evidence-comment path above, not the
-     `failed`/`incomplete` cleanup-failure path below, but note the
-     `retryAttempts` count in the evidence comment as an informational,
-     non-blocking residual-lag signal rather than a defect.
+     reached while a rescan still found candidates. Route by the apply
+     `status` exactly as above, even then: if `status` is still
+     `applied`/`clean`, follow that evidence-comment path and note the
+     `retryAttempts` count as an informational, non-blocking
+     residual-lag signal rather than a defect; if `status` came back
+     `incomplete` (the fresh rescan found a genuine permission-blocked
+     remainder) or `failed`, follow the `failed`/`incomplete`
+     cleanup-failure path below instead — `retryBoundExhausted: true`
+     never overrides a non-success `status`.
 
-     If the apply `status` is `failed` or `incomplete`: post the
-     cleanup-failure comment format instead, including the
-     `viewer-cannot-minimize` count when non-zero. Explicit evidence,
-     not a merge gate — the merge already succeeded. Proceed to step 3.
+     If the apply `status` is `failed`, `incomplete`, or
+     `rescan-failed`: post the cleanup-failure comment format instead,
+     including the `viewer-cannot-minimize` count when non-zero.
+     `rescan-failed` means the confirming rescan itself errored after a
+     mutation (already-applied work is preserved in the report but
+     convergence was never confirmed) — note that distinction in the
+     comment and re-run `--apply` to confirm convergence. Explicit
+     evidence, not a merge gate — the merge already succeeded. Proceed
+     to step 3.
 
    - **`permission-blocked`**: skipped items exist with
      `viewerCanMinimize: false` and no apply-eligible candidates found.

--- a/idd-template/.github/workflows/post-merge-cleanup.yml
+++ b/idd-template/.github/workflows/post-merge-cleanup.yml
@@ -250,6 +250,8 @@ jobs:
             FAILED=$(printf '%s' "$JSON" | jq -r '(.failed // []) | length')
             SKIPPED=$(printf '%s' "$JSON" | jq -r '(.skipped // []) | length')
             BLOCKED=$(printf '%s' "$JSON" | jq -r '[(.skipped // [])[] | select(.isMinimized==false and .viewerCanMinimize==false)] | length')
+            RETRY_ATTEMPTS=$(printf '%s' "$JSON" | jq -r '.retryAttempts // 0')
+            RETRY_BOUND_EXHAUSTED=$(printf '%s' "$JSON" | jq -r '.retryBoundExhausted // false')
             if [ "$HELPER_EXIT" -ne 0 ]; then
               echo "::warning::audit-pr-cleanup exited $HELPER_EXIT but emitted a valid JSON report; using helper status \"$STATUS\""
             fi
@@ -260,6 +262,8 @@ jobs:
             FAILED=0
             SKIPPED=0
             BLOCKED=0
+            RETRY_ATTEMPTS=0
+            RETRY_BOUND_EXHAUSTED=false
           fi
           {
             echo "pr_number=$PR_NUMBER"
@@ -268,6 +272,8 @@ jobs:
             echo "failed=$FAILED"
             echo "skipped=$SKIPPED"
             echo "blocked=$BLOCKED"
+            echo "retry_attempts=$RETRY_ATTEMPTS"
+            echo "retry_bound_exhausted=$RETRY_BOUND_EXHAUSTED"
           } >> "$GITHUB_OUTPUT"
       - name: Post cleanup evidence comment
         if: steps.profile.outputs.profile != 'instructions-only'
@@ -284,6 +290,8 @@ jobs:
           FAILED: ${{ steps.cleanup.outputs.failed }}
           SKIPPED: ${{ steps.cleanup.outputs.skipped }}
           BLOCKED: ${{ steps.cleanup.outputs.blocked }}
+          RETRY_ATTEMPTS: ${{ steps.cleanup.outputs.retry_attempts }}
+          RETRY_BOUND_EXHAUSTED: ${{ steps.cleanup.outputs.retry_bound_exhausted }}
         run: |
           # Avoid duplicate evidence comments. Workflow-level concurrency
           # only serialises this workflow's own runs; an agent F4 (or a
@@ -335,8 +343,8 @@ jobs:
             echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment (id: ${EXISTING}); skipping workflow post."
             exit 0
           fi
-          BODY=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
-            "<!-- idd-cleanup-evidence: ${STATUS} applied:${APPLIED} failed:${FAILED} skipped:${SKIPPED} viewer-cannot-minimize:${BLOCKED} -->" \
+          BODY=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
+            "<!-- idd-cleanup-evidence: ${STATUS} applied:${APPLIED} failed:${FAILED} skipped:${SKIPPED} viewer-cannot-minimize:${BLOCKED} retry-attempts:${RETRY_ATTEMPTS} retry-bound-exhausted:${RETRY_BOUND_EXHAUSTED} -->" \
             "**F4 Cleanup Evidence** (server-side fallback via \`post-merge-cleanup.yml\`)" \
             "| Field              | Value |" \
             "| ------------------ | ----- |" \
@@ -345,6 +353,7 @@ jobs:
             "| Failed             | ${FAILED} |" \
             "| Skipped            | ${SKIPPED} |" \
             "| Permission-blocked | ${BLOCKED} |" \
+            "| Retry attempts (bound-exhausted) | ${RETRY_ATTEMPTS} (${RETRY_BOUND_EXHAUSTED}) |" \
             "| Posted by          | post-merge-cleanup workflow |" \
           )
           printf '%s' "$BODY" | gh pr comment "$PR_NUMBER" --body-file -

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -402,15 +402,15 @@ which suffices for its single-shot post-merge run:
 
 **F4 Cleanup Evidence**
 
-| Field                            | Value                                  |
-| -------------------------------- | -------------------------------------- |
-| Status                           | applied / failed / incomplete          |
-| Applied                          | N                                      |
-| Failed                           | N                                      |
-| Skipped                          | N                                      |
-| Permission-blocked               | N                                      |
-| Retry attempts (bound-exhausted) | N (true / false)                       |
-| Notes                            | reason for any failed or skipped items |
+| Field                            | Value                                         |
+| -------------------------------- | --------------------------------------------- |
+| Status                           | applied / failed / incomplete / rescan-failed |
+| Applied                          | N                                             |
+| Failed                           | N                                             |
+| Skipped                          | N                                             |
+| Permission-blocked               | N                                             |
+| Retry attempts (bound-exhausted) | N (true / false)                              |
+| Notes                            | reason for any failed or skipped items        |
 ```
 
 `retry-attempts` / `retry-bound-exhausted` mirror
@@ -419,14 +419,20 @@ which suffices for its single-shot post-merge run:
 issue 2011): a `true` bound-exhausted value with an otherwise
 `applied`/`clean` status is informational, not a cleanup failure — a
 fresh rescan still found candidates after the bound, not that
-anything went wrong.
+anything went wrong. A `rescan-failed` status (below) always takes the
+cleanup-failure path regardless of `retry-bound-exhausted`, since the
+confirming rescan itself never completed.
 
 ### Cleanup-failure comment
 
-Post this comment when apply `status` is `failed` or `incomplete`. If
-`viewer-cannot-minimize > 0` is also non-zero, include the blocked count
-in the same comment rather than posting a separate permission-blocked
-comment:
+Post this comment when apply `status` is `failed`, `incomplete`, or
+`rescan-failed`. `rescan-failed` means the confirming rescan after a
+mutation errored (a transient GraphQL/`gh` failure) — already-applied
+work is preserved in the report, but convergence was never confirmed;
+note that distinction and suggest a re-run rather than describing it as
+a per-candidate failure. If `viewer-cannot-minimize > 0` is also
+non-zero, include the blocked count in the same comment rather than
+posting a separate permission-blocked comment:
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->
@@ -435,7 +441,7 @@ comment:
 
 Cleanup candidates were detected but not all could be applied.
 
-- Status: failed / incomplete
+- Status: failed / incomplete / rescan-failed
 - Failed: N candidates (reason: ...)
 - Unapplied: N candidates
 - Permission-blocked: N candidates (if any)

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -398,19 +398,28 @@ uses a simpler presence-only guard (it skips on any existing marker),
 which suffices for its single-shot post-merge run:
 
 ```markdown
-<!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} -->
+<!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} retry-attempts:{N} retry-bound-exhausted:{true|false} -->
 
 **F4 Cleanup Evidence**
 
-| Field              | Value                                  |
-| ------------------ | -------------------------------------- |
-| Status             | applied / failed / incomplete          |
-| Applied            | N                                      |
-| Failed             | N                                      |
-| Skipped            | N                                      |
-| Permission-blocked | N                                      |
-| Notes              | reason for any failed or skipped items |
+| Field                            | Value                                  |
+| -------------------------------- | -------------------------------------- |
+| Status                           | applied / failed / incomplete          |
+| Applied                          | N                                      |
+| Failed                           | N                                      |
+| Skipped                          | N                                      |
+| Permission-blocked               | N                                      |
+| Retry attempts (bound-exhausted) | N (true / false)                       |
+| Notes                            | reason for any failed or skipped items |
 ```
+
+`retry-attempts` / `retry-bound-exhausted` mirror
+`audit-pr-cleanup.mjs --apply`'s own `retryAttempts` /
+`retryBoundExhausted` JSON fields (its internal whole-pass retry, see
+issue 2011): a `true` bound-exhausted value with an otherwise
+`applied`/`clean` status is informational, not a cleanup failure — a
+fresh rescan still found candidates after the bound, not that
+anything went wrong.
 
 ### Cleanup-failure comment
 

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -402,15 +402,15 @@ which suffices for its single-shot post-merge run:
 
 **F4 Cleanup Evidence**
 
-| Field                            | Value                                         |
-| -------------------------------- | --------------------------------------------- |
-| Status                           | applied / failed / incomplete / rescan-failed |
-| Applied                          | N                                             |
-| Failed                           | N                                             |
-| Skipped                          | N                                             |
-| Permission-blocked               | N                                             |
-| Retry attempts (bound-exhausted) | N (true / false)                              |
-| Notes                            | reason for any failed or skipped items        |
+| Field                            | Value                                                 |
+| -------------------------------- | ----------------------------------------------------- |
+| Status                           | applied / clean / failed / incomplete / rescan-failed |
+| Applied                          | N                                                     |
+| Failed                           | N                                                     |
+| Skipped                          | N                                                     |
+| Permission-blocked               | N                                                     |
+| Retry attempts (bound-exhausted) | N (true / false)                                      |
+| Notes                            | reason for any failed or skipped items                |
 ```
 
 `retry-attempts` / `retry-bound-exhausted` mirror

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -376,9 +376,9 @@ corresponding path:
 | `permission-blocked` | Post a cleanup-permission-blocked comment, then proceed to F4 |
 |                      | step 3.                                                       |
 
-After apply, if `status` is `failed` or `incomplete`, post a
-cleanup-failure comment. A cleanup failure after a successful F3 merge
-does not re-block the merge; it is an explicit record only.
+After apply, if `status` is `failed`, `incomplete`, or `rescan-failed`,
+post a cleanup-failure comment. A cleanup failure after a successful F3
+merge does not re-block the merge; it is an explicit record only.
 
 ### Cleanup evidence comment
 

--- a/scripts/audit-pr-cleanup-summary.mjs
+++ b/scripts/audit-pr-cleanup-summary.mjs
@@ -33,6 +33,16 @@ export function computeReportSummary(report) {
     return;
   }
   if (report.mode === 'apply') {
+    // A confirming rescan that itself failed means convergence was never
+    // verified, regardless of what the pre-rescan applied/failed counts
+    // say -- this must never be reported as `applied`/`clean` (#2011
+    // review finding: a fallback workflow trusts a parseable `status` even
+    // on a nonzero helper exit, so an unqualified success status here would
+    // publish false convergence evidence).
+    if (report.rescanError) {
+      report.status = 'rescan-failed';
+      return;
+    }
     if (report.failed.length > 0) {
       report.status = 'failed';
       return;

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -106,7 +106,77 @@ async function main() {
   const report = await buildReport(owner, repo, prNumber);
   if (args.apply) {
     report.mode = 'apply';
-    for (const candidate of report.candidates) {
+    const {
+      report: finalReport,
+      attempts,
+      boundExhausted,
+    } = await runApplyWithRetry(
+      report,
+      (pass) =>
+        applyCandidatePass(owner, repo, prNumber, pass, args, claimContext),
+      () => buildReport(owner, repo, prNumber),
+    );
+    finalReport.retryAttempts = attempts;
+    if (boundExhausted) {
+      finalReport.retryBoundExhausted = true;
+    }
+    computeReportSummary(finalReport);
+    if (finalReport.failed.length > 0) {
+      writeReport(finalReport, args.format);
+      process.exit(1);
+    }
+    computeReportSummary(finalReport);
+    writeReport(finalReport, args.format);
+    return;
+  }
+  computeReportSummary(report);
+  writeReport(report, args.format);
+}
+/**
+ * Runs one whole apply pass over `report.candidates`, mutating
+ * `report.applied` / `report.failed` in place (#2011, extracted verbatim
+ * from the previous single-pass `main()` body). Re-validates the active
+ * claim before each candidate, and again after `revalidateCandidate`'s
+ * fresh per-candidate re-fetch, matching the pre-existing behavior.
+ */
+async function applyCandidatePass(
+  owner,
+  repo,
+  prNumber,
+  report,
+  args,
+  claimContext,
+) {
+  for (const candidate of report.candidates) {
+    if (!args.skipClaimCheck) {
+      try {
+        assertActiveClaim(
+          owner,
+          repo,
+          args.claimIssue,
+          args.agentId,
+          args.claimId,
+          claimContext,
+        );
+      } catch (error) {
+        report.failed.push({
+          ...candidate,
+          error: error.message,
+        });
+        break;
+      }
+    }
+    try {
+      const freshCandidate = await revalidateCandidate(
+        owner,
+        repo,
+        prNumber,
+        candidate,
+        report,
+      );
+      if (!freshCandidate) {
+        continue;
+      }
       if (!args.skipClaimCheck) {
         try {
           assertActiveClaim(
@@ -119,65 +189,79 @@ async function main() {
           );
         } catch (error) {
           report.failed.push({
-            ...candidate,
+            ...freshCandidate,
             error: error.message,
           });
           break;
         }
       }
-      try {
-        const freshCandidate = await revalidateCandidate(
-          owner,
-          repo,
-          prNumber,
-          candidate,
-          report,
-        );
-        if (!freshCandidate) {
-          continue;
-        }
-        if (!args.skipClaimCheck) {
-          try {
-            assertActiveClaim(
-              owner,
-              repo,
-              args.claimIssue,
-              args.agentId,
-              args.claimId,
-              claimContext,
-            );
-          } catch (error) {
-            report.failed.push({
-              ...freshCandidate,
-              error: error.message,
-            });
-            break;
-          }
-        }
-        const minimized = minimizeComment(
-          freshCandidate.subjectId,
-          freshCandidate.classifier,
-        );
-        report.applied.push({
-          ...freshCandidate,
-          isMinimized: minimized.isMinimized,
-          minimizedReason: minimized.minimizedReason,
-        });
-      } catch (error) {
-        report.failed.push({
-          ...candidate,
-          error: error.message,
-        });
-      }
-    }
-    computeReportSummary(report);
-    if (report.failed.length > 0) {
-      writeReport(report, args.format);
-      process.exit(1);
+      const minimized = minimizeComment(
+        freshCandidate.subjectId,
+        freshCandidate.classifier,
+      );
+      report.applied.push({
+        ...freshCandidate,
+        isMinimized: minimized.isMinimized,
+        minimizedReason: minimized.minimizedReason,
+      });
+    } catch (error) {
+      report.failed.push({
+        ...candidate,
+        error: error.message,
+      });
     }
   }
-  computeReportSummary(report);
-  writeReport(report, args.format);
+}
+/** Default bound on whole-pass apply retries (#2011). */
+const DEFAULT_APPLY_RETRY_MAX_ATTEMPTS = 3;
+/**
+ * Retries a whole apply-and-rescan pass, bounded by `maxAttempts`, so a
+ * candidate that only becomes eligible after the previous pass finished
+ * (e.g. GraphQL read-after-write lag on `minimizeComment`, #2011) still
+ * converges within one `--apply` invocation instead of requiring a second,
+ * manual call.
+ *
+ * `applyPass` and `rescan` are injected rather than calling `buildReport`
+ * / `gh` directly, so this orchestration is unit-testable with fakes.
+ * `applyPass` must mutate its report argument's `applied` / `failed`
+ * arrays in place (matching {@link applyCandidatePass}); `rescan` must
+ * return a fresh dry-run-equivalent report reflecting current state.
+ *
+ * Stops immediately, without any further rescan, the first time a pass
+ * leaves `failed` non-empty (matches the pre-existing fail-fast
+ * behavior). Otherwise rescans after every pass: zero candidates means
+ * converged; a non-empty rescan below the attempt bound starts another
+ * pass, carrying the accumulated `applied` list onto the fresh report;
+ * a non-empty rescan at the attempt bound is reported as
+ * `boundExhausted` rather than retried further.
+ */
+export async function runApplyWithRetry(
+  initialReport,
+  applyPass,
+  rescan,
+  maxAttempts = DEFAULT_APPLY_RETRY_MAX_ATTEMPTS,
+) {
+  let report = initialReport;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    await applyPass(report);
+    if (report.failed.length > 0) {
+      return { report, attempts: attempt, boundExhausted: false };
+    }
+    const freshReport = await rescan();
+    if (freshReport.candidates.length === 0) {
+      return { report, attempts: attempt, boundExhausted: false };
+    }
+    if (attempt === maxAttempts) {
+      return { report, attempts: attempt, boundExhausted: true };
+    }
+    freshReport.mode = 'apply';
+    freshReport.applied = report.applied;
+    report = freshReport;
+  }
+  // Unreachable: maxAttempts <= 0 falls through the loop without ever
+  // attempting a pass. Guarded the same way the CLI's own arg parsing
+  // never produces a non-positive maxAttempts today.
+  return { report, attempts: 0, boundExhausted: true };
 }
 // Build an IDD-scoped disposition-author predicate from the resolved
 // trusted-marker actors (the accounts the IDD agent posts dispositions under).

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -247,15 +247,20 @@ export async function runApplyWithRetry(
     if (report.failed.length > 0) {
       return { report, attempts: attempt, boundExhausted: false };
     }
+    // Carry the accumulated `applied` list onto the fresh rescan so the
+    // returned report's `candidates` / `skipped` reflect confirmed
+    // post-apply state (e.g. cascade-minimized items now show up as
+    // already-minimized skips) rather than the stale pre-apply snapshot
+    // that fed this pass.
     const freshReport = await rescan();
-    if (freshReport.candidates.length === 0) {
-      return { report, attempts: attempt, boundExhausted: false };
-    }
-    if (attempt === maxAttempts) {
-      return { report, attempts: attempt, boundExhausted: true };
-    }
     freshReport.mode = 'apply';
     freshReport.applied = report.applied;
+    if (freshReport.candidates.length === 0) {
+      return { report: freshReport, attempts: attempt, boundExhausted: false };
+    }
+    if (attempt === maxAttempts) {
+      return { report: freshReport, attempts: attempt, boundExhausted: true };
+    }
     report = freshReport;
   }
   // Unreachable: maxAttempts <= 0 falls through the loop without ever

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -5,6 +5,7 @@
 // above by `pnpm run build`. Edit the .mts source, never the generated
 // .mjs. See docs/typescript-sources.md.
 import { readFileSync } from 'node:fs';
+import { setTimeout as sleep } from 'node:timers/promises';
 import { computeReportSummary } from './audit-pr-cleanup-summary.mjs';
 import { parseCliArgs } from './cli-args.mjs';
 import {
@@ -214,6 +215,17 @@ async function applyCandidatePass(
 }
 /** Default bound on whole-pass apply retries (#2011). */
 const DEFAULT_APPLY_RETRY_MAX_ATTEMPTS = 3;
+/** Base backoff (ms) before each rescan; linear-ish with jitter, matching
+ * {@link withBoundedRetry}'s formula in gh-exec.mts. */
+const DEFAULT_APPLY_RETRY_BACKOFF_MS = 200;
+/** Default backoff before a rescan: gives GraphQL read-after-write lag on
+ * the previous pass's minimizeComment calls a moment to settle (#2011). */
+async function defaultApplyRetryBackoff(attempt) {
+  await sleep(
+    DEFAULT_APPLY_RETRY_BACKOFF_MS * attempt +
+      Math.random() * DEFAULT_APPLY_RETRY_BACKOFF_MS,
+  );
+}
 /**
  * Retries a whole apply-and-rescan pass, bounded by `maxAttempts`, so a
  * candidate that only becomes eligible after the previous pass finished
@@ -221,11 +233,15 @@ const DEFAULT_APPLY_RETRY_MAX_ATTEMPTS = 3;
  * converges within one `--apply` invocation instead of requiring a second,
  * manual call.
  *
- * `applyPass` and `rescan` are injected rather than calling `buildReport`
- * / `gh` directly, so this orchestration is unit-testable with fakes.
- * `applyPass` must mutate its report argument's `applied` / `failed`
- * arrays in place (matching {@link applyCandidatePass}); `rescan` must
- * return a fresh dry-run-equivalent report reflecting current state.
+ * `applyPass`, `rescan`, and `backoff` are injected rather than calling
+ * `buildReport` / `gh` / real timers directly, so this orchestration is
+ * unit-testable with fakes. `applyPass` must mutate its report argument's
+ * `applied` / `failed` arrays in place (matching
+ * {@link applyCandidatePass}); `rescan` must return a fresh
+ * dry-run-equivalent report reflecting current state; `backoff` waits
+ * before each rescan (default: a short linear-ish delay with jitter, so
+ * GraphQL read-after-write lag on the pass's own mutations has a moment
+ * to settle before re-querying).
  *
  * Stops immediately, without any further rescan, the first time a pass
  * leaves `failed` non-empty (matches the pre-existing fail-fast
@@ -240,6 +256,7 @@ export async function runApplyWithRetry(
   applyPass,
   rescan,
   maxAttempts = DEFAULT_APPLY_RETRY_MAX_ATTEMPTS,
+  backoff = defaultApplyRetryBackoff,
 ) {
   let report = initialReport;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
@@ -247,6 +264,10 @@ export async function runApplyWithRetry(
     if (report.failed.length > 0) {
       return { report, attempts: attempt, boundExhausted: false };
     }
+    // A short backoff before rescanning gives GraphQL read-after-write lag
+    // on this pass's minimizeComment calls a moment to settle, instead of
+    // immediately re-querying the same stale state.
+    await backoff(attempt);
     // Carry the accumulated `applied` list onto the fresh rescan so the
     // returned report's `candidates` / `skipped` reflect confirmed
     // post-apply state (e.g. cascade-minimized items now show up as

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -1144,8 +1144,12 @@ function writeReport(report, format) {
   }
   // Print summary header
   if (report.summary) {
+    const retrySuffix =
+      report.retryAttempts === undefined
+        ? ''
+        : `, retryAttempts=${report.retryAttempts}, retryBoundExhausted=${Boolean(report.retryBoundExhausted)}`;
     console.log(
-      `summary: status=${report.status}, candidates=${report.summary.candidate}, applied=${report.summary.applied}, failed=${report.summary.failed}, skipped=${report.summary.skipped}`,
+      `summary: status=${report.status}, candidates=${report.summary.candidate}, applied=${report.summary.applied}, failed=${report.summary.failed}, skipped=${report.summary.skipped}${retrySuffix}`,
     );
     console.log('');
   }

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -261,8 +261,16 @@ export async function runApplyWithRetry(
   maxAttempts = DEFAULT_APPLY_RETRY_MAX_ATTEMPTS,
   backoff = defaultApplyRetryBackoff,
 ) {
+  // A non-finite `maxAttempts` (`Infinity`) would defeat the bounded-retry
+  // contract with an unbounded loop; a fractional value (e.g. `2.5`) would
+  // never satisfy `attempt === maxAttempts` below and fall through to the
+  // fallback return with an incorrect `attempts: 0` (same class of bug as
+  // `withBoundedRetry`'s `attempts` guard, gh-exec.mts, #1394).
+  const totalAttempts = Number.isFinite(maxAttempts)
+    ? Math.max(1, Math.trunc(maxAttempts))
+    : DEFAULT_APPLY_RETRY_MAX_ATTEMPTS;
   let report = initialReport;
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+  for (let attempt = 1; attempt <= totalAttempts; attempt += 1) {
     await applyPass(report);
     if (report.failed.length > 0) {
       return { report, attempts: attempt, boundExhausted: false };
@@ -309,14 +317,13 @@ export async function runApplyWithRetry(
     if (freshReport.candidates.length === 0) {
       return { report: freshReport, attempts: attempt, boundExhausted: false };
     }
-    if (attempt === maxAttempts) {
+    if (attempt === totalAttempts) {
       return { report: freshReport, attempts: attempt, boundExhausted: true };
     }
     report = freshReport;
   }
-  // Unreachable: maxAttempts <= 0 falls through the loop without ever
-  // attempting a pass. Guarded the same way the CLI's own arg parsing
-  // never produces a non-positive maxAttempts today.
+  // Unreachable: totalAttempts is normalized to >= 1 above, so the loop
+  // always runs at least one attempt and returns from inside it.
   return { report, attempts: 0, boundExhausted: true };
 }
 // Build an IDD-scoped disposition-author predicate from the resolved

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -50,6 +50,11 @@ const trustedMarkerAuthorCache = new Map();
 const collaboratorPermissionCache = new Map();
 let cachedConfiguredTrustedMarkerActorSources = null;
 let cachedCurrentViewerLogin = null;
+/** Default bound on whole-pass apply retries (#2011). */
+const DEFAULT_APPLY_RETRY_MAX_ATTEMPTS = 3;
+/** Base backoff (ms) before each rescan; linear-ish with jitter, matching
+ * {@link withBoundedRetry}'s formula in gh-exec.mts. */
+const DEFAULT_APPLY_RETRY_BACKOFF_MS = 200;
 if (import.meta.main) {
   await main();
 }
@@ -213,11 +218,6 @@ async function applyCandidatePass(
     }
   }
 }
-/** Default bound on whole-pass apply retries (#2011). */
-const DEFAULT_APPLY_RETRY_MAX_ATTEMPTS = 3;
-/** Base backoff (ms) before each rescan; linear-ish with jitter, matching
- * {@link withBoundedRetry}'s formula in gh-exec.mts. */
-const DEFAULT_APPLY_RETRY_BACKOFF_MS = 200;
 /** Default backoff before a rescan: gives GraphQL read-after-write lag on
  * the previous pass's minimizeComment calls a moment to settle (#2011). */
 async function defaultApplyRetryBackoff(attempt) {

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -120,14 +120,17 @@ async function main() {
       report,
       (pass) =>
         applyCandidatePass(owner, repo, prNumber, pass, args, claimContext),
-      () => buildReport(owner, repo, prNumber),
+      // throwOnError so a transient GraphQL/gh failure on this confirming
+      // rescan is catchable by runApplyWithRetry (which preserves the
+      // already-applied work) instead of exiting the process outright.
+      () => buildReport(owner, repo, prNumber, { throwOnError: true }),
     );
     finalReport.retryAttempts = attempts;
     if (boundExhausted) {
       finalReport.retryBoundExhausted = true;
     }
     computeReportSummary(finalReport);
-    if (finalReport.failed.length > 0) {
+    if (finalReport.failed.length > 0 || finalReport.rescanError) {
       writeReport(finalReport, args.format);
       process.exit(1);
     }
@@ -268,13 +271,40 @@ export async function runApplyWithRetry(
     // on this pass's minimizeComment calls a moment to settle, instead of
     // immediately re-querying the same stale state.
     await backoff(attempt);
+    let freshReport;
+    try {
+      freshReport = await rescan();
+    } catch (error) {
+      // Preserve the already-mutated report (including the accumulated
+      // `applied` list) instead of losing it to an uncaught rescan
+      // failure — `rescan` is expected to be called with a
+      // throw-on-error option so a transient GraphQL/gh hiccup lands
+      // here rather than exiting the process outright.
+      report.rescanError = error.message;
+      return { report, attempts: attempt, boundExhausted: false };
+    }
+    freshReport.mode = 'apply';
+    // Exclude subjects this run already applied from the fresh rescan's
+    // `candidates` / `skipped`: `buildReport` classifies a just-minimized
+    // comment as an already-minimized skip, so grafting `applied` onto an
+    // unfiltered rescan would place the same subject in both arrays
+    // (inflating skipped counts) and, left in `candidates`, would get
+    // re-mutated by the next pass (wasting the retry bound on rediscovering
+    // work already done instead of finding genuinely new candidates).
+    const appliedSubjectIds = new Set(
+      report.applied.map((row) => row.subjectId),
+    );
+    freshReport.candidates = freshReport.candidates.filter(
+      (row) => !appliedSubjectIds.has(row.subjectId),
+    );
+    freshReport.skipped = freshReport.skipped.filter(
+      (row) => !appliedSubjectIds.has(row.subjectId),
+    );
     // Carry the accumulated `applied` list onto the fresh rescan so the
     // returned report's `candidates` / `skipped` reflect confirmed
     // post-apply state (e.g. cascade-minimized items now show up as
     // already-minimized skips) rather than the stale pre-apply snapshot
     // that fed this pass.
-    const freshReport = await rescan();
-    freshReport.mode = 'apply';
     freshReport.applied = report.applied;
     if (freshReport.candidates.length === 0) {
       return { report: freshReport, attempts: attempt, boundExhausted: false };
@@ -1174,8 +1204,11 @@ function writeReport(report, format) {
       report.retryAttempts === undefined
         ? ''
         : `, retryAttempts=${report.retryAttempts}, retryBoundExhausted=${Boolean(report.retryBoundExhausted)}`;
+    const rescanErrorSuffix = report.rescanError
+      ? `, rescanError=${report.rescanError}`
+      : '';
     console.log(
-      `summary: status=${report.status}, candidates=${report.summary.candidate}, applied=${report.summary.applied}, failed=${report.summary.failed}, skipped=${report.summary.skipped}${retrySuffix}`,
+      `summary: status=${report.status}, candidates=${report.summary.candidate}, applied=${report.summary.applied}, failed=${report.summary.failed}, skipped=${report.summary.skipped}${retrySuffix}${rescanErrorSuffix}`,
     );
     console.log('');
   }

--- a/src/scripts/audit-pr-cleanup-summary.mts
+++ b/src/scripts/audit-pr-cleanup-summary.mts
@@ -18,6 +18,7 @@ export interface CleanupReport {
   mode?: string;
   summary?: Record<string, number> | null;
   status?: string | null;
+  rescanError?: string;
 }
 
 export function computeReportSummary(report: CleanupReport): void {
@@ -53,6 +54,16 @@ export function computeReportSummary(report: CleanupReport): void {
   }
 
   if (report.mode === 'apply') {
+    // A confirming rescan that itself failed means convergence was never
+    // verified, regardless of what the pre-rescan applied/failed counts
+    // say -- this must never be reported as `applied`/`clean` (#2011
+    // review finding: a fallback workflow trusts a parseable `status` even
+    // on a nonzero helper exit, so an unqualified success status here would
+    // publish false convergence evidence).
+    if (report.rescanError) {
+      report.status = 'rescan-failed';
+      return;
+    }
     if (report.failed.length > 0) {
       report.status = 'failed';
       return;

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -229,6 +229,13 @@ let cachedConfiguredTrustedMarkerActorSources: {
 } | null = null;
 let cachedCurrentViewerLogin: string | null = null;
 
+/** Default bound on whole-pass apply retries (#2011). */
+const DEFAULT_APPLY_RETRY_MAX_ATTEMPTS = 3;
+
+/** Base backoff (ms) before each rescan; linear-ish with jitter, matching
+ * {@link withBoundedRetry}'s formula in gh-exec.mts. */
+const DEFAULT_APPLY_RETRY_BACKOFF_MS = 200;
+
 if (import.meta.main) {
   await main();
 }
@@ -408,13 +415,6 @@ async function applyCandidatePass(
     }
   }
 }
-
-/** Default bound on whole-pass apply retries (#2011). */
-const DEFAULT_APPLY_RETRY_MAX_ATTEMPTS = 3;
-
-/** Base backoff (ms) before each rescan; linear-ish with jitter, matching
- * {@link withBoundedRetry}'s formula in gh-exec.mts. */
-const DEFAULT_APPLY_RETRY_BACKOFF_MS = 200;
 
 /** Default backoff before a rescan: gives GraphQL read-after-write lag on
  * the previous pass's minimizeComment calls a moment to settle (#2011). */

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -6,6 +6,7 @@
 // .mjs. See docs/typescript-sources.md.
 
 import { readFileSync } from 'node:fs';
+import { setTimeout as sleep } from 'node:timers/promises';
 import type { CleanupReport } from './audit-pr-cleanup-summary.mts';
 import { computeReportSummary } from './audit-pr-cleanup-summary.mts';
 import { parseCliArgs } from './cli-args.mts';
@@ -411,6 +412,19 @@ async function applyCandidatePass(
 /** Default bound on whole-pass apply retries (#2011). */
 const DEFAULT_APPLY_RETRY_MAX_ATTEMPTS = 3;
 
+/** Base backoff (ms) before each rescan; linear-ish with jitter, matching
+ * {@link withBoundedRetry}'s formula in gh-exec.mts. */
+const DEFAULT_APPLY_RETRY_BACKOFF_MS = 200;
+
+/** Default backoff before a rescan: gives GraphQL read-after-write lag on
+ * the previous pass's minimizeComment calls a moment to settle (#2011). */
+async function defaultApplyRetryBackoff(attempt: number): Promise<void> {
+  await sleep(
+    DEFAULT_APPLY_RETRY_BACKOFF_MS * attempt +
+      Math.random() * DEFAULT_APPLY_RETRY_BACKOFF_MS,
+  );
+}
+
 /** Outcome of {@link runApplyWithRetry}. */
 export interface ApplyRetryResult {
   report: CleanupAuditReport;
@@ -425,11 +439,15 @@ export interface ApplyRetryResult {
  * converges within one `--apply` invocation instead of requiring a second,
  * manual call.
  *
- * `applyPass` and `rescan` are injected rather than calling `buildReport`
- * / `gh` directly, so this orchestration is unit-testable with fakes.
- * `applyPass` must mutate its report argument's `applied` / `failed`
- * arrays in place (matching {@link applyCandidatePass}); `rescan` must
- * return a fresh dry-run-equivalent report reflecting current state.
+ * `applyPass`, `rescan`, and `backoff` are injected rather than calling
+ * `buildReport` / `gh` / real timers directly, so this orchestration is
+ * unit-testable with fakes. `applyPass` must mutate its report argument's
+ * `applied` / `failed` arrays in place (matching
+ * {@link applyCandidatePass}); `rescan` must return a fresh
+ * dry-run-equivalent report reflecting current state; `backoff` waits
+ * before each rescan (default: a short linear-ish delay with jitter, so
+ * GraphQL read-after-write lag on the pass's own mutations has a moment
+ * to settle before re-querying).
  *
  * Stops immediately, without any further rescan, the first time a pass
  * leaves `failed` non-empty (matches the pre-existing fail-fast
@@ -444,6 +462,7 @@ export async function runApplyWithRetry(
   applyPass: (report: CleanupAuditReport) => Promise<void>,
   rescan: () => Promise<CleanupAuditReport>,
   maxAttempts: number = DEFAULT_APPLY_RETRY_MAX_ATTEMPTS,
+  backoff: (attempt: number) => Promise<void> = defaultApplyRetryBackoff,
 ): Promise<ApplyRetryResult> {
   let report = initialReport;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
@@ -452,6 +471,10 @@ export async function runApplyWithRetry(
       return { report, attempts: attempt, boundExhausted: false };
     }
 
+    // A short backoff before rescanning gives GraphQL read-after-write lag
+    // on this pass's minimizeComment calls a moment to settle, instead of
+    // immediately re-querying the same stale state.
+    await backoff(attempt);
     // Carry the accumulated `applied` list onto the fresh rescan so the
     // returned report's `candidates` / `skipped` reflect confirmed
     // post-apply state (e.g. cascade-minimized items now show up as

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -174,6 +174,12 @@ export interface CleanupAuditReport extends CleanupReport {
    * `status`, computed by the shared, untouched `computeReportSummary`.
    */
   retryBoundExhausted?: boolean;
+  /**
+   * Set when a confirming rescan itself failed (#2011) — the report still
+   * carries every candidate this run genuinely applied before the
+   * failure, rather than losing that record to an uncaught exit.
+   */
+  rescanError?: string;
 }
 
 /** Active claim resolved from the trusted claim-marker stream. */
@@ -313,7 +319,10 @@ async function main(): Promise<void> {
       report,
       (pass) =>
         applyCandidatePass(owner, repo, prNumber, pass, args, claimContext),
-      () => buildReport(owner, repo, prNumber),
+      // throwOnError so a transient GraphQL/gh failure on this confirming
+      // rescan is catchable by runApplyWithRetry (which preserves the
+      // already-applied work) instead of exiting the process outright.
+      () => buildReport(owner, repo, prNumber, { throwOnError: true }),
     );
     finalReport.retryAttempts = attempts;
     if (boundExhausted) {
@@ -321,7 +330,7 @@ async function main(): Promise<void> {
     }
 
     computeReportSummary(finalReport);
-    if (finalReport.failed.length > 0) {
+    if (finalReport.failed.length > 0 || finalReport.rescanError) {
       writeReport(finalReport, args.format);
       process.exit(1);
     }
@@ -475,13 +484,41 @@ export async function runApplyWithRetry(
     // on this pass's minimizeComment calls a moment to settle, instead of
     // immediately re-querying the same stale state.
     await backoff(attempt);
+
+    let freshReport: CleanupAuditReport;
+    try {
+      freshReport = await rescan();
+    } catch (error) {
+      // Preserve the already-mutated report (including the accumulated
+      // `applied` list) instead of losing it to an uncaught rescan
+      // failure — `rescan` is expected to be called with a
+      // throw-on-error option so a transient GraphQL/gh hiccup lands
+      // here rather than exiting the process outright.
+      report.rescanError = (error as Error).message;
+      return { report, attempts: attempt, boundExhausted: false };
+    }
+    freshReport.mode = 'apply';
+    // Exclude subjects this run already applied from the fresh rescan's
+    // `candidates` / `skipped`: `buildReport` classifies a just-minimized
+    // comment as an already-minimized skip, so grafting `applied` onto an
+    // unfiltered rescan would place the same subject in both arrays
+    // (inflating skipped counts) and, left in `candidates`, would get
+    // re-mutated by the next pass (wasting the retry bound on rediscovering
+    // work already done instead of finding genuinely new candidates).
+    const appliedSubjectIds = new Set(
+      report.applied.map((row) => row.subjectId),
+    );
+    freshReport.candidates = freshReport.candidates.filter(
+      (row) => !appliedSubjectIds.has(row.subjectId),
+    );
+    freshReport.skipped = freshReport.skipped.filter(
+      (row) => !appliedSubjectIds.has(row.subjectId),
+    );
     // Carry the accumulated `applied` list onto the fresh rescan so the
     // returned report's `candidates` / `skipped` reflect confirmed
     // post-apply state (e.g. cascade-minimized items now show up as
     // already-minimized skips) rather than the stale pre-apply snapshot
     // that fed this pass.
-    const freshReport = await rescan();
-    freshReport.mode = 'apply';
     freshReport.applied = report.applied;
     if (freshReport.candidates.length === 0) {
       return { report: freshReport, attempts: attempt, boundExhausted: false };
@@ -1652,8 +1689,11 @@ function writeReport(report: CleanupAuditReport, format: string): void {
       report.retryAttempts === undefined
         ? ''
         : `, retryAttempts=${report.retryAttempts}, retryBoundExhausted=${Boolean(report.retryBoundExhausted)}`;
+    const rescanErrorSuffix = report.rescanError
+      ? `, rescanError=${report.rescanError}`
+      : '';
     console.log(
-      `summary: status=${report.status}, candidates=${report.summary.candidate}, applied=${report.summary.applied}, failed=${report.summary.failed}, skipped=${report.summary.skipped}${retrySuffix}`,
+      `summary: status=${report.status}, candidates=${report.summary.candidate}, applied=${report.summary.applied}, failed=${report.summary.failed}, skipped=${report.summary.skipped}${retrySuffix}${rescanErrorSuffix}`,
     );
     console.log('');
   }

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -473,8 +473,16 @@ export async function runApplyWithRetry(
   maxAttempts: number = DEFAULT_APPLY_RETRY_MAX_ATTEMPTS,
   backoff: (attempt: number) => Promise<void> = defaultApplyRetryBackoff,
 ): Promise<ApplyRetryResult> {
+  // A non-finite `maxAttempts` (`Infinity`) would defeat the bounded-retry
+  // contract with an unbounded loop; a fractional value (e.g. `2.5`) would
+  // never satisfy `attempt === maxAttempts` below and fall through to the
+  // fallback return with an incorrect `attempts: 0` (same class of bug as
+  // `withBoundedRetry`'s `attempts` guard, gh-exec.mts, #1394).
+  const totalAttempts = Number.isFinite(maxAttempts)
+    ? Math.max(1, Math.trunc(maxAttempts))
+    : DEFAULT_APPLY_RETRY_MAX_ATTEMPTS;
   let report = initialReport;
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+  for (let attempt = 1; attempt <= totalAttempts; attempt += 1) {
     await applyPass(report);
     if (report.failed.length > 0) {
       return { report, attempts: attempt, boundExhausted: false };
@@ -523,15 +531,14 @@ export async function runApplyWithRetry(
     if (freshReport.candidates.length === 0) {
       return { report: freshReport, attempts: attempt, boundExhausted: false };
     }
-    if (attempt === maxAttempts) {
+    if (attempt === totalAttempts) {
       return { report: freshReport, attempts: attempt, boundExhausted: true };
     }
 
     report = freshReport;
   }
-  // Unreachable: maxAttempts <= 0 falls through the loop without ever
-  // attempting a pass. Guarded the same way the CLI's own arg parsing
-  // never produces a non-positive maxAttempts today.
+  // Unreachable: totalAttempts is normalized to >= 1 above, so the loop
+  // always runs at least one attempt and returns from inside it.
   return { report, attempts: 0, boundExhausted: true };
 }
 

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -146,7 +146,7 @@ interface AssociatedThreadStats {
 }
 
 /** Full cleanup-audit report emitted by this helper. */
-interface CleanupAuditReport extends CleanupReport {
+export interface CleanupAuditReport extends CleanupReport {
   repository: string;
   pr: number;
   prUrl: string;
@@ -161,6 +161,18 @@ interface CleanupAuditReport extends CleanupReport {
   failed: ReportRow[];
   summary: Record<string, number> | null;
   status: string | null;
+  /**
+   * Number of internal whole-pass apply attempts `runApplyWithRetry` ran
+   * (#2011). Present only in apply mode.
+   */
+  retryAttempts?: number;
+  /**
+   * True when the internal retry bound was reached while a fresh rescan
+   * still reported candidates (#2011) — distinct from an ordinary
+   * `applied`/`clean` convergence, which leaves this unset. Does not alter
+   * `status`, computed by the shared, untouched `computeReportSummary`.
+   */
+  retryBoundExhausted?: boolean;
 }
 
 /** Active claim resolved from the trusted claim-marker stream. */
@@ -178,6 +190,16 @@ interface CleanupArgs {
   claimId?: string;
   agentId?: string;
   skipClaimCheck?: boolean;
+}
+
+/**
+ * Claim-check context threaded through apply-mode candidate processing
+ * (#2011's `applyCandidatePass`), matching {@link assertActiveClaim}'s
+ * `options` shape.
+ */
+interface ClaimContext {
+  expectedLinkedPrs?: string[];
+  prFirstCommitAt?: string | null;
 }
 
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
@@ -275,7 +297,81 @@ async function main(): Promise<void> {
 
   if (args.apply) {
     report.mode = 'apply';
-    for (const candidate of report.candidates) {
+    const {
+      report: finalReport,
+      attempts,
+      boundExhausted,
+    } = await runApplyWithRetry(
+      report,
+      (pass) =>
+        applyCandidatePass(owner, repo, prNumber, pass, args, claimContext),
+      () => buildReport(owner, repo, prNumber),
+    );
+    finalReport.retryAttempts = attempts;
+    if (boundExhausted) {
+      finalReport.retryBoundExhausted = true;
+    }
+
+    computeReportSummary(finalReport);
+    if (finalReport.failed.length > 0) {
+      writeReport(finalReport, args.format);
+      process.exit(1);
+    }
+
+    computeReportSummary(finalReport);
+    writeReport(finalReport, args.format);
+    return;
+  }
+
+  computeReportSummary(report);
+  writeReport(report, args.format);
+}
+
+/**
+ * Runs one whole apply pass over `report.candidates`, mutating
+ * `report.applied` / `report.failed` in place (#2011, extracted verbatim
+ * from the previous single-pass `main()` body). Re-validates the active
+ * claim before each candidate, and again after `revalidateCandidate`'s
+ * fresh per-candidate re-fetch, matching the pre-existing behavior.
+ */
+async function applyCandidatePass(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  report: CleanupAuditReport,
+  args: CleanupArgs,
+  claimContext: ClaimContext,
+): Promise<void> {
+  for (const candidate of report.candidates) {
+    if (!args.skipClaimCheck) {
+      try {
+        assertActiveClaim(
+          owner,
+          repo,
+          args.claimIssue,
+          args.agentId,
+          args.claimId,
+          claimContext,
+        );
+      } catch (error) {
+        report.failed.push({
+          ...candidate,
+          error: (error as Error).message,
+        });
+        break;
+      }
+    }
+    try {
+      const freshCandidate = await revalidateCandidate(
+        owner,
+        repo,
+        prNumber,
+        candidate,
+        report,
+      );
+      if (!freshCandidate) {
+        continue;
+      }
       if (!args.skipClaimCheck) {
         try {
           assertActiveClaim(
@@ -288,67 +384,90 @@ async function main(): Promise<void> {
           );
         } catch (error) {
           report.failed.push({
-            ...candidate,
+            ...freshCandidate,
             error: (error as Error).message,
           });
           break;
         }
       }
-      try {
-        const freshCandidate = await revalidateCandidate(
-          owner,
-          repo,
-          prNumber,
-          candidate,
-          report,
-        );
-        if (!freshCandidate) {
-          continue;
-        }
-        if (!args.skipClaimCheck) {
-          try {
-            assertActiveClaim(
-              owner,
-              repo,
-              args.claimIssue,
-              args.agentId,
-              args.claimId,
-              claimContext,
-            );
-          } catch (error) {
-            report.failed.push({
-              ...freshCandidate,
-              error: (error as Error).message,
-            });
-            break;
-          }
-        }
-        const minimized = minimizeComment(
-          freshCandidate.subjectId,
-          freshCandidate.classifier,
-        );
-        report.applied.push({
-          ...freshCandidate,
-          isMinimized: minimized.isMinimized,
-          minimizedReason: minimized.minimizedReason,
-        });
-      } catch (error) {
-        report.failed.push({
-          ...candidate,
-          error: (error as Error).message,
-        });
-      }
-    }
-
-    computeReportSummary(report);
-    if (report.failed.length > 0) {
-      writeReport(report, args.format);
-      process.exit(1);
+      const minimized = minimizeComment(
+        freshCandidate.subjectId,
+        freshCandidate.classifier,
+      );
+      report.applied.push({
+        ...freshCandidate,
+        isMinimized: minimized.isMinimized,
+        minimizedReason: minimized.minimizedReason,
+      });
+    } catch (error) {
+      report.failed.push({
+        ...candidate,
+        error: (error as Error).message,
+      });
     }
   }
+}
 
-  computeReportSummary(report);
-  writeReport(report, args.format);
+/** Default bound on whole-pass apply retries (#2011). */
+const DEFAULT_APPLY_RETRY_MAX_ATTEMPTS = 3;
+
+/** Outcome of {@link runApplyWithRetry}. */
+export interface ApplyRetryResult {
+  report: CleanupAuditReport;
+  attempts: number;
+  boundExhausted: boolean;
+}
+
+/**
+ * Retries a whole apply-and-rescan pass, bounded by `maxAttempts`, so a
+ * candidate that only becomes eligible after the previous pass finished
+ * (e.g. GraphQL read-after-write lag on `minimizeComment`, #2011) still
+ * converges within one `--apply` invocation instead of requiring a second,
+ * manual call.
+ *
+ * `applyPass` and `rescan` are injected rather than calling `buildReport`
+ * / `gh` directly, so this orchestration is unit-testable with fakes.
+ * `applyPass` must mutate its report argument's `applied` / `failed`
+ * arrays in place (matching {@link applyCandidatePass}); `rescan` must
+ * return a fresh dry-run-equivalent report reflecting current state.
+ *
+ * Stops immediately, without any further rescan, the first time a pass
+ * leaves `failed` non-empty (matches the pre-existing fail-fast
+ * behavior). Otherwise rescans after every pass: zero candidates means
+ * converged; a non-empty rescan below the attempt bound starts another
+ * pass, carrying the accumulated `applied` list onto the fresh report;
+ * a non-empty rescan at the attempt bound is reported as
+ * `boundExhausted` rather than retried further.
+ */
+export async function runApplyWithRetry(
+  initialReport: CleanupAuditReport,
+  applyPass: (report: CleanupAuditReport) => Promise<void>,
+  rescan: () => Promise<CleanupAuditReport>,
+  maxAttempts: number = DEFAULT_APPLY_RETRY_MAX_ATTEMPTS,
+): Promise<ApplyRetryResult> {
+  let report = initialReport;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    await applyPass(report);
+    if (report.failed.length > 0) {
+      return { report, attempts: attempt, boundExhausted: false };
+    }
+
+    const freshReport = await rescan();
+    if (freshReport.candidates.length === 0) {
+      return { report, attempts: attempt, boundExhausted: false };
+    }
+    if (attempt === maxAttempts) {
+      return { report, attempts: attempt, boundExhausted: true };
+    }
+
+    freshReport.mode = 'apply';
+    freshReport.applied = report.applied;
+    report = freshReport;
+  }
+  // Unreachable: maxAttempts <= 0 falls through the loop without ever
+  // attempting a pass. Guarded the same way the CLI's own arg parsing
+  // never produces a non-positive maxAttempts today.
+  return { report, attempts: 0, boundExhausted: true };
 }
 
 // Build an IDD-scoped disposition-author predicate from the resolved

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -452,16 +452,21 @@ export async function runApplyWithRetry(
       return { report, attempts: attempt, boundExhausted: false };
     }
 
+    // Carry the accumulated `applied` list onto the fresh rescan so the
+    // returned report's `candidates` / `skipped` reflect confirmed
+    // post-apply state (e.g. cascade-minimized items now show up as
+    // already-minimized skips) rather than the stale pre-apply snapshot
+    // that fed this pass.
     const freshReport = await rescan();
-    if (freshReport.candidates.length === 0) {
-      return { report, attempts: attempt, boundExhausted: false };
-    }
-    if (attempt === maxAttempts) {
-      return { report, attempts: attempt, boundExhausted: true };
-    }
-
     freshReport.mode = 'apply';
     freshReport.applied = report.applied;
+    if (freshReport.candidates.length === 0) {
+      return { report: freshReport, attempts: attempt, boundExhausted: false };
+    }
+    if (attempt === maxAttempts) {
+      return { report: freshReport, attempts: attempt, boundExhausted: true };
+    }
+
     report = freshReport;
   }
   // Unreachable: maxAttempts <= 0 falls through the loop without ever

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -1620,8 +1620,12 @@ function writeReport(report: CleanupAuditReport, format: string): void {
 
   // Print summary header
   if (report.summary) {
+    const retrySuffix =
+      report.retryAttempts === undefined
+        ? ''
+        : `, retryAttempts=${report.retryAttempts}, retryBoundExhausted=${Boolean(report.retryBoundExhausted)}`;
     console.log(
-      `summary: status=${report.status}, candidates=${report.summary.candidate}, applied=${report.summary.applied}, failed=${report.summary.failed}, skipped=${report.summary.skipped}`,
+      `summary: status=${report.status}, candidates=${report.summary.candidate}, applied=${report.summary.applied}, failed=${report.summary.failed}, skipped=${report.summary.skipped}${retrySuffix}`,
     );
     console.log('');
   }

--- a/tests/audit-pr-cleanup-summary.test.mts
+++ b/tests/audit-pr-cleanup-summary.test.mts
@@ -195,6 +195,27 @@ test('computeReportSummary converges to applied when remaining candidates were c
   assert.equal(report.summary?.['viewer-cannot-minimize'], 0);
 });
 
+test('computeReportSummary emits rescan-failed when a confirming rescan errored, even with no failed candidates', () => {
+  // #2011 review finding: a fallback workflow trusts a parseable `status`
+  // even on a nonzero helper exit, so an unqualified applied/clean status
+  // here would publish false convergence evidence for a rescan that never
+  // actually confirmed the candidates converged.
+  const report = createReport({
+    mode: 'apply',
+    candidates: [{ subjectId: 'candidate-1' }],
+    skipped: [],
+    applied: [{ subjectId: 'candidate-1' }],
+    failed: [],
+    rescanError: 'GraphQL: transient failure',
+  });
+
+  computeReportSummary(report);
+
+  assert.equal(report.status, 'rescan-failed');
+  assert.equal(report.summary?.applied, 1);
+  assert.equal(report.summary?.failed, 0);
+});
+
 test('computeReportSummary emits failed when apply has both applied and failed candidates', () => {
   const report = createReport({
     mode: 'apply',

--- a/tests/audit-pr-cleanup-summary.test.mts
+++ b/tests/audit-pr-cleanup-summary.test.mts
@@ -216,6 +216,26 @@ test('computeReportSummary emits rescan-failed when a confirming rescan errored,
   assert.equal(report.summary?.failed, 0);
 });
 
+test('computeReportSummary prioritizes rescan-failed over failed when both are present', () => {
+  // rescanError takes precedence even though this combination cannot arise
+  // from runApplyWithRetry today (it returns immediately once a pass leaves
+  // a failed candidate, before ever reaching the rescan): the confirming
+  // state is unknown either way, so it must not silently read as the
+  // narrower `failed` outcome.
+  const report = createReport({
+    mode: 'apply',
+    candidates: [{ subjectId: 'candidate-1' }],
+    skipped: [],
+    applied: [],
+    failed: [{ subjectId: 'candidate-1', error: 'boom' }],
+    rescanError: 'GraphQL: transient failure',
+  });
+
+  computeReportSummary(report);
+
+  assert.equal(report.status, 'rescan-failed');
+});
+
 test('computeReportSummary emits failed when apply has both applied and failed candidates', () => {
   const report = createReport({
     mode: 'apply',

--- a/tests/audit-pr-cleanup.test.mts
+++ b/tests/audit-pr-cleanup.test.mts
@@ -230,3 +230,64 @@ test('runApplyWithRetry backs off before each rescan, once per retried attempt',
   // tagged with its own attempt number.
   assert.deepEqual(backoffAttempts, [1, 2]);
 });
+
+test("runApplyWithRetry excludes already-applied subjects from the fresh rescan's candidates and skipped lists", async () => {
+  const { runApplyWithRetry } = await import(
+    '../src/scripts/audit-pr-cleanup.mts'
+  );
+  const initial = createAuditReport({
+    candidates: [createRow('c1'), createRow('c2')],
+  });
+
+  const result = await runApplyWithRetry(
+    initial,
+    async (report) => {
+      for (const candidate of report.candidates) {
+        report.applied.push({ ...candidate, isMinimized: true });
+      }
+    },
+    async () =>
+      createAuditReport({
+        mode: 'dry-run',
+        // c1 still shows as a stale candidate (its own lag hasn't resolved
+        // yet); c2 shows as an already-minimized skip (buildReport's fresh
+        // scan already reflects that mutation). Both were genuinely applied
+        // this run, so neither should survive filtering.
+        candidates: [createRow('c1')],
+        skipped: [{ ...createRow('c2'), isMinimized: true }],
+      }),
+    undefined,
+    noBackoff,
+  );
+
+  assert.equal(result.report.candidates.length, 0);
+  assert.equal(result.report.skipped.length, 0);
+  assert.deepEqual(
+    result.report.applied.map((row) => row.subjectId),
+    ['c1', 'c2'],
+  );
+  assert.equal(result.boundExhausted, false);
+});
+
+test('runApplyWithRetry preserves already-applied work when the confirming rescan fails', async () => {
+  const { runApplyWithRetry } = await import(
+    '../src/scripts/audit-pr-cleanup.mts'
+  );
+  const initial = createAuditReport({ candidates: [createRow('c1')] });
+
+  const result = await runApplyWithRetry(
+    initial,
+    async (report) => {
+      report.applied.push({ ...createRow('c1'), isMinimized: true });
+    },
+    async () => {
+      throw new Error('GraphQL: transient failure');
+    },
+    undefined,
+    noBackoff,
+  );
+
+  assert.equal(result.report.applied.length, 1);
+  assert.equal(result.report.rescanError, 'GraphQL: transient failure');
+  assert.equal(result.boundExhausted, false);
+});

--- a/tests/audit-pr-cleanup.test.mts
+++ b/tests/audit-pr-cleanup.test.mts
@@ -291,3 +291,72 @@ test('runApplyWithRetry preserves already-applied work when the confirming resca
   assert.equal(result.report.rescanError, 'GraphQL: transient failure');
   assert.equal(result.boundExhausted, false);
 });
+
+test('runApplyWithRetry falls back to the default attempt bound on a non-finite maxAttempts value (Copilot review, PR #2019)', async () => {
+  const { runApplyWithRetry } = await import(
+    '../src/scripts/audit-pr-cleanup.mts'
+  );
+  const initial = createAuditReport({ candidates: [createRow('c1')] });
+  let rescanCalls = 0;
+
+  const result = await runApplyWithRetry(
+    initial,
+    async (report) => {
+      for (const candidate of report.candidates) {
+        report.applied.push({ ...candidate, isMinimized: true });
+      }
+    },
+    async () => {
+      rescanCalls += 1;
+      // A churning comment stream: every rescan still finds one candidate.
+      // Without the Number.isFinite guard, `attempt <= Infinity` is always
+      // true, so the loop never terminates -- asserting a bounded rescan
+      // count (the default of 3, not an unbounded count) is the actual
+      // regression check.
+      return createAuditReport({
+        mode: 'dry-run',
+        candidates: [createRow(`c${rescanCalls + 1}`)],
+      });
+    },
+    Number.POSITIVE_INFINITY,
+    noBackoff,
+  );
+
+  assert.equal(rescanCalls, 3);
+  assert.equal(result.attempts, 3);
+  assert.equal(result.boundExhausted, true);
+});
+
+test('runApplyWithRetry truncates a fractional maxAttempts instead of misreporting attempts:0', async () => {
+  const { runApplyWithRetry } = await import(
+    '../src/scripts/audit-pr-cleanup.mts'
+  );
+  const initial = createAuditReport({ candidates: [createRow('c1')] });
+  let rescanCalls = 0;
+
+  const result = await runApplyWithRetry(
+    initial,
+    async (report) => {
+      for (const candidate of report.candidates) {
+        report.applied.push({ ...candidate, isMinimized: true });
+      }
+    },
+    async () => {
+      rescanCalls += 1;
+      return createAuditReport({
+        mode: 'dry-run',
+        candidates: [createRow(`c${rescanCalls + 1}`)],
+      });
+    },
+    2.5,
+    noBackoff,
+  );
+
+  // Math.trunc(2.5) === 2: without it, `attempt === maxAttempts` (an
+  // integer compared against 2.5) is never true and the loop falls through
+  // to the unreachable-path fallback, misreporting `attempts: 0` despite
+  // having run 2 real attempts.
+  assert.equal(rescanCalls, 2);
+  assert.equal(result.attempts, 2);
+  assert.equal(result.boundExhausted, true);
+});

--- a/tests/audit-pr-cleanup.test.mts
+++ b/tests/audit-pr-cleanup.test.mts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
+import type { CleanupAuditReport } from '../src/scripts/audit-pr-cleanup.mts';
+
 // Importing the CLI module directly is only possible now that its top-level
 // statements are guarded behind `import.meta.main` (#1210, migrated from
 // isCliExecution() by #1447); previously the import parsed process.argv,
@@ -16,4 +18,162 @@ test('importing audit-pr-cleanup.mts has no import-time side effect', async () =
   } finally {
     process.env.PATH = originalPath;
   }
+});
+
+function createAuditReport(
+  overrides: Partial<CleanupAuditReport> = {},
+): CleanupAuditReport {
+  return {
+    repository: 'kurone-kito/idd-skill',
+    pr: 1,
+    prUrl: 'https://github.com/kurone-kito/idd-skill/pull/1',
+    merged: true,
+    mode: 'apply',
+    trustedMarkerActors: [],
+    trustedMarkerActorsSources: [],
+    collaboratorTrustEnabled: false,
+    candidates: [],
+    skipped: [],
+    applied: [],
+    failed: [],
+    summary: null,
+    status: null,
+    ...overrides,
+  };
+}
+
+function createRow(subjectId: string) {
+  return {
+    subjectId,
+    url: '',
+    type: '',
+    classifier: '',
+    viewerCanMinimize: true,
+    isMinimized: false,
+    minimizedReason: null,
+  };
+}
+
+// #2011: buildReport() runs exactly once today, so a candidate that only
+// becomes eligible after that single pass (e.g. GraphQL read-after-write lag
+// on minimizeComment) survives to the final report instead of converging
+// within one --apply invocation. These cases exercise runApplyWithRetry's
+// orchestration with fake applyPass/rescan callbacks — no gh call, no
+// process.env.PATH trick needed, since the retry logic never touches gh
+// itself.
+test('runApplyWithRetry converges on the first pass when the rescan finds nothing new', async () => {
+  const { runApplyWithRetry } = await import(
+    '../src/scripts/audit-pr-cleanup.mts'
+  );
+  const initial = createAuditReport({ candidates: [createRow('c1')] });
+  let applyPassCalls = 0;
+  let rescanCalls = 0;
+
+  const result = await runApplyWithRetry(
+    initial,
+    async (report) => {
+      applyPassCalls += 1;
+      report.applied.push({ ...createRow('c1'), isMinimized: true });
+    },
+    async () => {
+      rescanCalls += 1;
+      return createAuditReport({ mode: 'dry-run', candidates: [] });
+    },
+  );
+
+  assert.equal(applyPassCalls, 1);
+  assert.equal(rescanCalls, 1);
+  assert.equal(result.attempts, 1);
+  assert.equal(result.boundExhausted, false);
+  assert.equal(result.report.applied.length, 1);
+});
+
+test('runApplyWithRetry re-applies a candidate that only becomes eligible after the first pass', async () => {
+  const { runApplyWithRetry } = await import(
+    '../src/scripts/audit-pr-cleanup.mts'
+  );
+  const initial = createAuditReport({ candidates: [createRow('c1')] });
+  let rescanCalls = 0;
+
+  const result = await runApplyWithRetry(
+    initial,
+    async (report) => {
+      for (const candidate of report.candidates) {
+        report.applied.push({ ...candidate, isMinimized: true });
+      }
+    },
+    async () => {
+      rescanCalls += 1;
+      // The first rescan (after attempt 1) discovers a comment that only
+      // became a candidate after the pass finished; the second rescan
+      // (after attempt 2 applies it) reports the run as converged.
+      return createAuditReport({
+        mode: 'dry-run',
+        candidates: rescanCalls === 1 ? [createRow('c2')] : [],
+      });
+    },
+  );
+
+  assert.equal(rescanCalls, 2);
+  assert.equal(result.attempts, 2);
+  assert.equal(result.boundExhausted, false);
+  assert.deepEqual(
+    result.report.applied.map((row) => row.subjectId),
+    ['c1', 'c2'],
+  );
+});
+
+test('runApplyWithRetry reports boundExhausted when candidates keep reappearing through the attempt bound', async () => {
+  const { runApplyWithRetry } = await import(
+    '../src/scripts/audit-pr-cleanup.mts'
+  );
+  const initial = createAuditReport({ candidates: [createRow('c1')] });
+  let rescanCalls = 0;
+
+  const result = await runApplyWithRetry(
+    initial,
+    async (report) => {
+      for (const candidate of report.candidates) {
+        report.applied.push({ ...candidate, isMinimized: true });
+      }
+    },
+    async () => {
+      rescanCalls += 1;
+      // A churning comment stream: every rescan still finds one candidate.
+      return createAuditReport({
+        mode: 'dry-run',
+        candidates: [createRow(`c${rescanCalls + 1}`)],
+      });
+    },
+    3,
+  );
+
+  assert.equal(rescanCalls, 3);
+  assert.equal(result.attempts, 3);
+  assert.equal(result.boundExhausted, true);
+  assert.equal(result.report.applied.length, 3);
+});
+
+test('runApplyWithRetry stops immediately, without rescanning, once a pass leaves a failed candidate', async () => {
+  const { runApplyWithRetry } = await import(
+    '../src/scripts/audit-pr-cleanup.mts'
+  );
+  const initial = createAuditReport({ candidates: [createRow('c1')] });
+  let rescanCalls = 0;
+
+  const result = await runApplyWithRetry(
+    initial,
+    async (report) => {
+      report.failed.push({ ...createRow('c1'), error: 'boom' });
+    },
+    async () => {
+      rescanCalls += 1;
+      return createAuditReport({ mode: 'dry-run', candidates: [] });
+    },
+  );
+
+  assert.equal(rescanCalls, 0);
+  assert.equal(result.attempts, 1);
+  assert.equal(result.boundExhausted, false);
+  assert.equal(result.report.failed.length, 1);
 });

--- a/tests/audit-pr-cleanup.test.mts
+++ b/tests/audit-pr-cleanup.test.mts
@@ -86,6 +86,9 @@ test('runApplyWithRetry converges on the first pass when the rescan finds nothin
   assert.equal(result.attempts, 1);
   assert.equal(result.boundExhausted, false);
   assert.equal(result.report.applied.length, 1);
+  // The returned report reflects the confirming rescan (0 remaining), not
+  // the stale pre-apply candidate snapshot that fed the pass.
+  assert.equal(result.report.candidates.length, 0);
 });
 
 test('runApplyWithRetry re-applies a candidate that only becomes eligible after the first pass', async () => {
@@ -121,6 +124,7 @@ test('runApplyWithRetry re-applies a candidate that only becomes eligible after 
     result.report.applied.map((row) => row.subjectId),
     ['c1', 'c2'],
   );
+  assert.equal(result.report.candidates.length, 0);
 });
 
 test('runApplyWithRetry reports boundExhausted when candidates keep reappearing through the attempt bound', async () => {
@@ -152,6 +156,13 @@ test('runApplyWithRetry reports boundExhausted when candidates keep reappearing 
   assert.equal(result.attempts, 3);
   assert.equal(result.boundExhausted, true);
   assert.equal(result.report.applied.length, 3);
+  // The final rescan's still-outstanding candidate is preserved so the
+  // caller can see what remained, not the pre-apply snapshot from the
+  // last attempt.
+  assert.deepEqual(
+    result.report.candidates.map((row) => row.subjectId),
+    ['c4'],
+  );
 });
 
 test('runApplyWithRetry stops immediately, without rescanning, once a pass leaves a failed candidate', async () => {

--- a/tests/audit-pr-cleanup.test.mts
+++ b/tests/audit-pr-cleanup.test.mts
@@ -42,6 +42,10 @@ function createAuditReport(
   };
 }
 
+// Skips runApplyWithRetry's default real-timer backoff so these tests stay
+// fast and deterministic; the backoff's own timing is not under test here.
+async function noBackoff(): Promise<void> {}
+
 function createRow(subjectId: string) {
   return {
     subjectId,
@@ -79,6 +83,8 @@ test('runApplyWithRetry converges on the first pass when the rescan finds nothin
       rescanCalls += 1;
       return createAuditReport({ mode: 'dry-run', candidates: [] });
     },
+    undefined,
+    noBackoff,
   );
 
   assert.equal(applyPassCalls, 1);
@@ -115,6 +121,8 @@ test('runApplyWithRetry re-applies a candidate that only becomes eligible after 
         candidates: rescanCalls === 1 ? [createRow('c2')] : [],
       });
     },
+    undefined,
+    noBackoff,
   );
 
   assert.equal(rescanCalls, 2);
@@ -150,6 +158,7 @@ test('runApplyWithRetry reports boundExhausted when candidates keep reappearing 
       });
     },
     3,
+    noBackoff,
   );
 
   assert.equal(rescanCalls, 3);
@@ -187,4 +196,37 @@ test('runApplyWithRetry stops immediately, without rescanning, once a pass leave
   assert.equal(result.attempts, 1);
   assert.equal(result.boundExhausted, false);
   assert.equal(result.report.failed.length, 1);
+});
+
+test('runApplyWithRetry backs off before each rescan, once per retried attempt', async () => {
+  const { runApplyWithRetry } = await import(
+    '../src/scripts/audit-pr-cleanup.mts'
+  );
+  const initial = createAuditReport({ candidates: [createRow('c1')] });
+  const backoffAttempts: number[] = [];
+  let rescanCalls = 0;
+
+  await runApplyWithRetry(
+    initial,
+    async (report) => {
+      for (const candidate of report.candidates) {
+        report.applied.push({ ...candidate, isMinimized: true });
+      }
+    },
+    async () => {
+      rescanCalls += 1;
+      return createAuditReport({
+        mode: 'dry-run',
+        candidates: rescanCalls === 1 ? [createRow('c2')] : [],
+      });
+    },
+    undefined,
+    async (attempt) => {
+      backoffAttempts.push(attempt);
+    },
+  );
+
+  // Backed off before the attempt-1 rescan and the attempt-2 rescan, each
+  // tagged with its own attempt number.
+  assert.deepEqual(backoffAttempts, [1, 2]);
 });


### PR DESCRIPTION
# Summary

`audit-pr-cleanup.mjs --apply` used to build its candidate report once
and apply once, so a comment that only became a minimize-eligible
candidate *after* that single pass (e.g. GraphQL read-after-write lag
on `minimizeComment`) survived to the final report instead of
converging within one invocation, forcing a second manual `--apply`
call.

This PR extracts the per-candidate apply logic into
`applyCandidatePass` and wraps it in a new `runApplyWithRetry`, which
re-scans after each pass (with a short backoff so eventual-consistency
lag has a moment to settle) and re-applies newly found candidates for
up to 3 whole passes. When the bound is reached with candidates still
remaining, the new `retryAttempts` / `retryBoundExhausted` fields
(visible in both `--format json` and `--format table`) distinguish that
case from an ordinary `applied` / `clean` result, without changing
`computeReportSummary`'s existing `status` semantics for the common
case.

`idd-merge.instructions.md`'s F4 apply-status decision tree now
documents the `retryBoundExhausted: true` case as an informational,
non-blocking signal that still follows the `applied`/`clean`
evidence-comment path — not the `failed`/`incomplete`
cleanup-failure path — matching #1039's originally intended, unmet
criterion.

## Linked issue

Closes #2011

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Reproduced independently across 6 of 6 F4 cleanup passes in one
adopter session (see #2011's own Background section for the source
repository and PR numbers); the underlying cause (GraphQL
read-after-write propagation lag vs. some other mid-run cascade) is
not confirmed from source, but the absence of any whole-run retry was
confirmed, and is what forced the second manual invocation regardless
of the exact cause.

`runApplyWithRetry`'s `applyPass` / `rescan` / `backoff` callbacks are
injected rather than calling `buildReport` / `gh` / real timers
directly, so the retry orchestration is unit-tested with fakes (no
`gh` call) rather than only covered by the existing import-purity
test.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Cleanup now retries apply-and-rescan passes up to a bounded limit.
  * Previously applied items are preserved and excluded from later rescans.
  * Cleanup reports now show retry attempts, retry-limit status, and rescan errors.
  * Exhausting retries after otherwise successful cleanup is reported as informational rather than a failure.
  * Rescan failures are clearly reported and require another cleanup run.

* **Documentation**
  * Updated cleanup evidence documentation and workflow comments to include retry details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->