### PR TITLE
feat(idd-advisory-convergence): poll briefly for Copilot's review before asserting not-ready

### DIFF
--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -97,25 +97,44 @@ name: IDD advisory-convergence gate
 # lands, independent of the separate `pull_request_review` trigger,
 # which only fires once the primary bot's own review actually lands
 # (typically 10-40s later) -- so a push that also needed a fresh review
-# used to get asserted, and fail, before that review existed, costing a
-# near-certain external rerun every time (the exact recovery documented
-# a few paragraphs below). `advisory-convergence.mjs`'s CLI entry point
-# now runs `runAdvisoryConvergenceWithPoll` instead of asserting
+# used to get asserted, and fail, before that review existed, costing an
+# external rerun most of the time (the exact recovery documented a few
+# paragraphs below). `advisory-convergence.mjs`'s CLI entry point now
+# runs `runAdvisoryConvergenceWithPoll` instead of asserting
 # immediately: when (and ONLY when) the verdict's sole blocking reason
 # is literally "{bot} has not reviewed this pull request yet" --
 # `isSoleCopilotNotReviewedYetReason` in the .mts source -- it polls a
-# short, bounded window (a few seconds apart, capped around a minute)
-# before its real assert-driven exit. Every OTHER not-ready reason
-# (a stale-HEAD review, unresolved threads, an indeterminate claim
-# scope, a deadline/terminal-unavailability reason, etc.) still fails
-# immediately on the first pass with no wait, exactly as before this
-# change. This does not weaken the check's required, fail-closed,
-# non-bypassable nature or change roadmap #1342's deterministic-
-# convergence policy in any way: if the review still has not landed by
-# the end of the window, or lands with outstanding items, the job fails
-# exactly as it always has -- this only absorbs a common, near-
-# universal race internally instead of costing an external rerun for it
-# every time.
+# short, bounded window (a few seconds apart, capped around a minute,
+# wall-clock bounded) before its real assert-driven exit. Every OTHER
+# not-ready reason (a stale-HEAD review, unresolved threads, an
+# indeterminate claim scope, a deadline/terminal-unavailability reason,
+# etc.) still fails immediately on the first pass with no wait, exactly
+# as before this change. This does not weaken the check's required,
+# fail-closed, non-bypassable nature or change roadmap #1342's
+# deterministic-convergence policy in any way: if the review still has
+# not landed by the end of the window, or lands with outstanding items,
+# the job fails exactly as it always has.
+#
+# Known residual (PR #2023 review): this job's own concurrency group
+# (below) is keyed by PR number ALONE across all three of its triggers,
+# with `cancel-in-progress: true`. If the primary bot's review actually
+# lands WHILE this poll is asleep, that submission starts a fresh
+# `pull_request_review`-triggered run in the SAME group, which cancels
+# THIS run before its next scheduled re-check ever observes the review
+# -- this run ends CANCELLED, and the fresh run becomes the one
+# responsible for reflecting convergence, subject to the exact same
+# stale-rollup risk `#1381` documents a few paragraphs below (whose
+# recovery, `rerun-advisory-convergence.mjs`, already handles a stale
+# CANCELLED sibling instance, not only a FAILURE one -- see "Rerun
+# mechanics" in `idd-ci.instructions.md`). Not a regression versus the
+# pre-#2015 baseline (before this change, the run always finished
+# FAILURE well before the review landed, so cancellation essentially
+# never happened, but the later review-triggered run's rollup update
+# was ALREADY subject to this same `#1381` risk) -- only a narrower win
+# than "no external rerun ever needed." See
+# `runAdvisoryConvergenceWithPoll`'s own doc comment
+# (`src/scripts/advisory-convergence.mts`) for the full analysis; no
+# safe mechanical fix was found within #2015's scope.
 #
 # Correction (kurone-kito/idd-skill#1381): in practice, workflow_dispatch
 # does NOT reliably flip the PR's required-check rollup for its own HEAD

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -80,17 +80,42 @@ name: IDD advisory-convergence gate
 # triggers fires or a maintainer runs workflow_dispatch.
 #
 # workflow_dispatch (manual re-run) exists for a second reason beyond
-# the thread-resolve gap above: `--assert` exits non-zero for ANY
-# not-ready verdict, including the ordinary "Copilot has not reviewed
-# this HEAD yet" pending case -- GitHub Actions has no distinct
-# non-failing "pending" check state, so the check simply shows red
-# until it converges (by design; see roadmap #1342's stated deadlock
-# policy). That also means posting a maintainer waiver comment does
-# NOT by itself turn a previously-failed check green, because a PR
-# comment is not one of this workflow's trigger events and a completed
-# run's conclusion never changes on its own -- a new run has to
-# execute. workflow_dispatch gives that a one-click affordance instead
-# of relying solely on the Actions UI's generic "re-run failed jobs".
+# the thread-resolve gap above: `--assert` still exits non-zero for ANY
+# not-ready verdict that survives the bounded poll described below --
+# GitHub Actions has no distinct non-failing "pending" check state, so
+# the check simply shows red until it converges (by design; see
+# roadmap #1342's stated deadlock policy). That also means posting a
+# maintainer waiver comment does NOT by itself turn a previously-failed
+# check green, because a PR comment is not one of this workflow's
+# trigger events and a completed run's conclusion never changes on its
+# own -- a new run has to execute. workflow_dispatch gives that a
+# one-click affordance instead of relying solely on the Actions UI's
+# generic "re-run failed jobs".
+#
+# Bounded poll for the "not reviewed yet" race (#2015): the
+# `pull_request` `synchronize` trigger above fires the instant a push
+# lands, independent of the separate `pull_request_review` trigger,
+# which only fires once the primary bot's own review actually lands
+# (typically 10-40s later) -- so a push that also needed a fresh review
+# used to get asserted, and fail, before that review existed, costing a
+# near-certain external rerun every time (the exact recovery documented
+# a few paragraphs below). `advisory-convergence.mjs`'s CLI entry point
+# now runs `runAdvisoryConvergenceWithPoll` instead of asserting
+# immediately: when (and ONLY when) the verdict's sole blocking reason
+# is literally "{bot} has not reviewed this pull request yet" --
+# `isSoleCopilotNotReviewedYetReason` in the .mts source -- it polls a
+# short, bounded window (a few seconds apart, capped around a minute)
+# before its real assert-driven exit. Every OTHER not-ready reason
+# (a stale-HEAD review, unresolved threads, an indeterminate claim
+# scope, a deadline/terminal-unavailability reason, etc.) still fails
+# immediately on the first pass with no wait, exactly as before this
+# change. This does not weaken the check's required, fail-closed,
+# non-bypassable nature or change roadmap #1342's deterministic-
+# convergence policy in any way: if the review still has not landed by
+# the end of the window, or lands with outstanding items, the job fails
+# exactly as it always has -- this only absorbs a common, near-
+# universal race internally instead of costing an external rerun for it
+# every time.
 #
 # Correction (kurone-kito/idd-skill#1381): in practice, workflow_dispatch
 # does NOT reliably flip the PR's required-check rollup for its own HEAD

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1759,6 +1759,21 @@ to post it is the consuming track's job.
   Without `--assert` it always exits `0` (report-only). With `--assert` it
   exits non-zero unless `ready` is `true` (`ready = converged || (deadline
   passed && validly waived)`).
+- **Bounded "not reviewed yet" poll (`#2015`)**: the CLI entry point runs
+  through `runAdvisoryConvergenceWithPoll`, not `runAdvisoryConvergence`
+  directly. When (and only when) the verdict's sole blocking reason is
+  literally "`{bot}` has not reviewed this pull request yet" — the primary
+  bot has never reviewed the PR at all yet, not merely an off-HEAD review —
+  it polls a short, bounded window (every
+  `DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS`, default 7.5s, up to
+  `DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS`, default 60s) before its real
+  `--assert`-driven exit, absorbing the common race where the hosting
+  workflow's `pull_request` `synchronize` trigger fires before the
+  separate `pull_request_review` trigger's review has landed. Every other
+  not-ready reason (an off-HEAD review, unresolved threads, an
+  indeterminate claim scope, a deadline/terminal reason, etc.) still fails
+  immediately with no wait, exactly as before this addition — the
+  exit-code contract and `ready` formula above are otherwise unchanged.
 - **Deadlock / deadline policy**: while the primary bot has not reviewed
   the current HEAD, `pending` is `true` and the gate is not ready. After
   `advisoryWait.convergenceDeadline` (default 24h; see

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1774,14 +1774,20 @@ to post it is the consuming track's job.
   indeterminate claim scope, a deadline/terminal reason, etc.) still fails
   immediately with no wait, exactly as before this addition — the
   exit-code contract and `ready` formula above are otherwise unchanged.
-  The poll's bound is wall-clock (a deadline, not a sleep-count), so a
-  slow `gh` collection pass cannot push the loop meaningfully past its
-  documented budget. Known residual (PR #2023 review): a review that
-  lands while this poll is asleep can still start a fresh
-  `pull_request_review`-triggered run in the hosting workflow's own
-  PR-scoped `cancel-in-progress` concurrency group, cancelling this run
-  before it observes the review — a narrower win than "never needs an
-  external rerun again"; see the full analysis in
+  The poll's bound is wall-clock (a deadline, not a sleep-count): each
+  sleep is capped to the remaining budget, and a re-check is never
+  launched once a sleep has already consumed all of it (PR #2023 review
+  round 2). Known residuals (PR #2023 review): (1) a re-check that starts
+  just _before_ the deadline (while genuine budget remains) can still run
+  long, bounded only by `gh-exec.mts`'s own per-call `gh` timeouts (up to
+  120s for a paginated call, `#1675`), not by `maxWaitMs` — closing that
+  gap would mean threading a remaining-budget deadline into every `gh`
+  call inside `collectFromGitHub`, out of scope for this narrow poll
+  wrapper; (2) a review that lands while this poll is asleep can still
+  start a fresh `pull_request_review`-triggered run in the hosting
+  workflow's own PR-scoped `cancel-in-progress` concurrency group,
+  cancelling this run before it observes the review — a narrower win than
+  "never needs an external rerun again"; see the full analysis in
   `runAdvisoryConvergenceWithPoll`'s doc comment
   (`src/scripts/advisory-convergence.mts`).
 - **Deadlock / deadline policy**: while the primary bot has not reviewed

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1774,6 +1774,16 @@ to post it is the consuming track's job.
   indeterminate claim scope, a deadline/terminal reason, etc.) still fails
   immediately with no wait, exactly as before this addition — the
   exit-code contract and `ready` formula above are otherwise unchanged.
+  The poll's bound is wall-clock (a deadline, not a sleep-count), so a
+  slow `gh` collection pass cannot push the loop meaningfully past its
+  documented budget. Known residual (PR #2023 review): a review that
+  lands while this poll is asleep can still start a fresh
+  `pull_request_review`-triggered run in the hosting workflow's own
+  PR-scoped `cancel-in-progress` concurrency group, cancelling this run
+  before it observes the review — a narrower win than "never needs an
+  external rerun again"; see the full analysis in
+  `runAdvisoryConvergenceWithPoll`'s doc comment
+  (`src/scripts/advisory-convergence.mts`).
 - **Deadlock / deadline policy**: while the primary bot has not reviewed
   the current HEAD, `pending` is `true` and the gate is not ready. After
   `advisoryWait.convergenceDeadline` (default 24h; see

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1759,6 +1759,21 @@ to post it is the consuming track's job.
   Without `--assert` it always exits `0` (report-only). With `--assert` it
   exits non-zero unless `ready` is `true` (`ready = converged || (deadline
   passed && validly waived)`).
+- **Bounded "not reviewed yet" poll (`#2015`)**: the CLI entry point runs
+  through `runAdvisoryConvergenceWithPoll`, not `runAdvisoryConvergence`
+  directly. When (and only when) the verdict's sole blocking reason is
+  literally "`{bot}` has not reviewed this pull request yet" — the primary
+  bot has never reviewed the PR at all yet, not merely an off-HEAD review —
+  it polls a short, bounded window (every
+  `DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS`, default 7.5s, up to
+  `DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS`, default 60s) before its real
+  `--assert`-driven exit, absorbing the common race where the hosting
+  workflow's `pull_request` `synchronize` trigger fires before the
+  separate `pull_request_review` trigger's review has landed. Every other
+  not-ready reason (an off-HEAD review, unresolved threads, an
+  indeterminate claim scope, a deadline/terminal reason, etc.) still fails
+  immediately with no wait, exactly as before this addition — the
+  exit-code contract and `ready` formula above are otherwise unchanged.
 - **Deadlock / deadline policy**: while the primary bot has not reviewed
   the current HEAD, `pending` is `true` and the gate is not ready. After
   `advisoryWait.convergenceDeadline` (default 24h; see

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1774,14 +1774,20 @@ to post it is the consuming track's job.
   indeterminate claim scope, a deadline/terminal reason, etc.) still fails
   immediately with no wait, exactly as before this addition — the
   exit-code contract and `ready` formula above are otherwise unchanged.
-  The poll's bound is wall-clock (a deadline, not a sleep-count), so a
-  slow `gh` collection pass cannot push the loop meaningfully past its
-  documented budget. Known residual (PR #2023 review): a review that
-  lands while this poll is asleep can still start a fresh
-  `pull_request_review`-triggered run in the hosting workflow's own
-  PR-scoped `cancel-in-progress` concurrency group, cancelling this run
-  before it observes the review — a narrower win than "never needs an
-  external rerun again"; see the full analysis in
+  The poll's bound is wall-clock (a deadline, not a sleep-count): each
+  sleep is capped to the remaining budget, and a re-check is never
+  launched once a sleep has already consumed all of it (PR #2023 review
+  round 2). Known residuals (PR #2023 review): (1) a re-check that starts
+  just _before_ the deadline (while genuine budget remains) can still run
+  long, bounded only by `gh-exec.mts`'s own per-call `gh` timeouts (up to
+  120s for a paginated call, `#1675`), not by `maxWaitMs` — closing that
+  gap would mean threading a remaining-budget deadline into every `gh`
+  call inside `collectFromGitHub`, out of scope for this narrow poll
+  wrapper; (2) a review that lands while this poll is asleep can still
+  start a fresh `pull_request_review`-triggered run in the hosting
+  workflow's own PR-scoped `cancel-in-progress` concurrency group,
+  cancelling this run before it observes the review — a narrower win than
+  "never needs an external rerun again"; see the full analysis in
   `runAdvisoryConvergenceWithPoll`'s doc comment
   (`src/scripts/advisory-convergence.mts`).
 - **Deadlock / deadline policy**: while the primary bot has not reviewed

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1774,6 +1774,16 @@ to post it is the consuming track's job.
   indeterminate claim scope, a deadline/terminal reason, etc.) still fails
   immediately with no wait, exactly as before this addition — the
   exit-code contract and `ready` formula above are otherwise unchanged.
+  The poll's bound is wall-clock (a deadline, not a sleep-count), so a
+  slow `gh` collection pass cannot push the loop meaningfully past its
+  documented budget. Known residual (PR #2023 review): a review that
+  lands while this poll is asleep can still start a fresh
+  `pull_request_review`-triggered run in the hosting workflow's own
+  PR-scoped `cancel-in-progress` concurrency group, cancelling this run
+  before it observes the review — a narrower win than "never needs an
+  external rerun again"; see the full analysis in
+  `runAdvisoryConvergenceWithPoll`'s doc comment
+  (`src/scripts/advisory-convergence.mts`).
 - **Deadlock / deadline policy**: while the primary bot has not reviewed
   the current HEAD, `pending` is `true` and the gate is not ready. After
   `advisoryWait.convergenceDeadline` (default 24h; see

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -1023,6 +1023,22 @@ function sleepSync(ms) {
  * past its documented bound and risk the hosting workflow's own
  * `timeout-minutes` before ever reaching its fail-closed exit.
  *
+ * A re-check is never launched once a sleep has already consumed the full
+ * remaining budget (PR #2023 review round 2, Codex P2 + Copilot) --
+ * `collectFromGitHub` has its own independent `gh` timeouts (up to
+ * `DEFAULT_GH_PAGINATED_TIMEOUT_MS` = 120s, #1675) that this poll's
+ * `maxWaitMs` cannot bound from the outside, so starting a fresh collection
+ * pass exactly AT the deadline could otherwise blow the wall-clock bound
+ * wide open. KNOWN RESIDUAL: a collection that starts just BEFORE the
+ * deadline (i.e. while genuine budget remains) can still run long, bounded
+ * only by `gh-exec.mts`'s own per-call timeouts, not by `maxWaitMs` --
+ * threading a remaining-budget deadline into every `gh` call inside
+ * `collectFromGitHub` would close that gap but is a multi-call-site change
+ * out of scope for this narrow poll wrapper. One consequence: a
+ * `pollIntervalMs` configured `>=` `maxWaitMs` yields zero re-checks (the
+ * first sleep alone exhausts the budget) -- an edge case only reachable via
+ * an explicit non-default override, never the production defaults below.
+ *
  * KNOWN RESIDUAL (PR #2023 review, Codex P1): the hosting workflow's
  * concurrency group is keyed by PR number ALONE across all three of its
  * triggers, with `cancel-in-progress: true` (see
@@ -1078,6 +1094,11 @@ export function runAdvisoryConvergenceWithPoll(
     const deadline = now() + maxWaitMs;
     while (now() < deadline) {
       sleep(Math.min(pollIntervalMs, deadline - now()));
+      // #2023 review round 2: don't launch a re-check once the sleep above
+      // has already consumed the entire remaining budget -- see this
+      // function's own doc comment for why (collection has its own
+      // unbounded-relative-to-maxWaitMs `gh` timeouts).
+      if (now() >= deadline) break;
       result = runAdvisoryConvergence(argv, deps);
       if (
         result.exitCode === 0 ||

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -67,9 +67,9 @@
 // lands, independent of the separate `pull_request_review` trigger, which
 // only fires once the primary bot's own review actually lands (typically
 // 10-40s later) -- so a push that also needs a fresh review used to get
-// asserted, and fail, before that review existed, costing a near-certain
-// external rerun every time. The CLI entry point at the bottom of this
-// file now runs through `runAdvisoryConvergenceWithPoll` instead of
+// asserted, and fail, before that review existed, costing an external
+// rerun most of the time. The CLI entry point at the bottom of this file
+// now runs through `runAdvisoryConvergenceWithPoll` instead of
 // `runAdvisoryConvergence` directly: when (and ONLY when) the verdict's
 // sole blocking reason is that the primary bot has not reviewed the PR AT
 // ALL yet (`isSoleCopilotNotReviewedYetReason` -- excludes a stale-HEAD
@@ -77,12 +77,19 @@
 // reason, all of which still fail immediately with no wait, exactly as
 // before), it polls a short, bounded window (every
 // `DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS`, up to
-// `DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS` total) before its real
+// `DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS` total, wall-clock bounded --
+// see `runAdvisoryConvergenceWithPoll`'s own doc comment) before its real
 // assert-driven exit. This changes nothing about `--assert`'s exit-code
 // contract, roadmap #1342's deterministic-convergence policy, or this
 // check's required/fail-closed/non-bypassable nature: if the review still
 // has not landed by the end of the window, or lands with outstanding
-// items, the job fails exactly as it always has.
+// items, the job fails exactly as it always has. See
+// `runAdvisoryConvergenceWithPoll`'s own doc comment for a known residual
+// (PR #2023 review): a review landing WHILE this poll is asleep can still
+// need the pre-existing external-rerun recovery, via a different
+// mechanism (this run gets cancelled by the hosting workflow's own
+// concurrency group, not a plain immediate-assert failure) -- the poll's
+// actual win is narrower than "never needs a rerun again."
 import {
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
   DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES,
@@ -964,6 +971,16 @@ export const DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS = 7_500;
  * {@link runAdvisoryConvergenceWithPoll} (#2015) -- the issue's suggested
  * ~60s ceiling. */
 export const DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS = 60_000;
+/** Falls back to `fallback` for a non-finite or non-positive value --
+ * mirrors `gh-exec.mts`'s `withBoundedRetry` guard on its own duration
+ * options, so a `NaN`/zero/negative caller-supplied interval or budget
+ * cannot silently defeat the bound (a zero interval against a real,
+ * non-faked clock would otherwise tight-loop until `maxWaitMs` elapses). */
+function positiveMsOrDefault(value, fallback) {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+}
 /** Synchronous bounded sleep via `Atomics.wait` on a throwaway
  * `SharedArrayBuffer` -- the same technique
  * `rerun-advisory-convergence.mts`'s own `sleepSync` uses, chosen there (and
@@ -996,6 +1013,46 @@ function sleepSync(ms) {
  * passed and the verdict was not ready (the only way
  * {@link runAdvisoryConvergence} returns non-zero), so this never needs to
  * re-parse `argv` itself to check `--assert`.
+ *
+ * The bound is wall-clock, not sleep-count: `maxWaitMs` is a deadline
+ * (`now() + maxWaitMs`), and each iteration's actual sleep is capped to the
+ * REMAINING budget, not the nominal `pollIntervalMs` (PR #2023 review,
+ * Codex P2) -- production `collectFromGitHub` performs several real,
+ * potentially slow `gh` calls per re-check, and counting only requested
+ * sleep time (ignoring that collection time) could let the loop run well
+ * past its documented bound and risk the hosting workflow's own
+ * `timeout-minutes` before ever reaching its fail-closed exit.
+ *
+ * KNOWN RESIDUAL (PR #2023 review, Codex P1): the hosting workflow's
+ * concurrency group is keyed by PR number ALONE across all three of its
+ * triggers, with `cancel-in-progress: true` (see
+ * `idd-advisory-convergence.yml`'s own header). If the primary bot's review
+ * actually lands WHILE this poll is still sleeping, that submission starts
+ * a fresh `pull_request_review`-triggered run in the SAME concurrency
+ * group, which cancels this run before its next scheduled re-check ever
+ * observes the review -- this run ends CANCELLED, not SUCCESS, and the
+ * fresh run becomes the one responsible for reflecting the converged
+ * state. No safe mechanical fix was found for this within #2015's scope:
+ * narrowing the concurrency group would defeat the deliberate cross-trigger
+ * debouncing the workflow's own "Concurrency-hardening investigation"
+ * comment already documents as load-bearing, and there is no way for a
+ * script to detect an imminent cancellation from inside the run it is
+ * about to lose. This is NOT a regression versus the pre-#2015 baseline,
+ * only a narrower win than "no external rerun ever needed": before #2015,
+ * this run always finished FAILURE well before the review landed (10-40s
+ * later), so cancellation essentially never happened, but the resulting
+ * rollup update from the later review-triggered run was ALREADY subject to
+ * the exact same documented stale-rollup risk this residual describes (see
+ * `#1381` in that same investigation comment) -- the pre-existing recovery
+ * (`rerun-advisory-convergence.mjs`, which explicitly reruns a stale
+ * CANCELLED-conclusion sibling instance, not only a FAILURE one) covers
+ * this run's cancelled outcome exactly as it already covered the
+ * pre-#2015 case. The poll's actual win is narrower than the eliminate-
+ * every-rerun framing above: it resolves without any rerun specifically
+ * when a scheduled re-check happens to observe the landed review before a
+ * competing trigger's cancellation reaches this run -- which still occurs
+ * whenever the review lands close to (but not exactly inside) an active
+ * sleep, or after this poll's window has already closed.
  */
 export function runAdvisoryConvergenceWithPoll(
   argv,
@@ -1008,15 +1065,19 @@ export function runAdvisoryConvergenceWithPoll(
     result.verdict &&
     isSoleCopilotNotReviewedYetReason(result.verdict)
   ) {
-    const pollIntervalMs =
-      pollOptions.pollIntervalMs ?? DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS;
-    const maxWaitMs =
-      pollOptions.maxWaitMs ?? DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS;
+    const pollIntervalMs = positiveMsOrDefault(
+      pollOptions.pollIntervalMs,
+      DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS,
+    );
+    const maxWaitMs = positiveMsOrDefault(
+      pollOptions.maxWaitMs,
+      DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS,
+    );
     const sleep = pollOptions.sleep ?? sleepSync;
-    let waitedMs = 0;
-    while (waitedMs < maxWaitMs) {
-      sleep(pollIntervalMs);
-      waitedMs += pollIntervalMs;
+    const now = pollOptions.now ?? Date.now;
+    const deadline = now() + maxWaitMs;
+    while (now() < deadline) {
+      sleep(Math.min(pollIntervalMs, deadline - now()));
       result = runAdvisoryConvergence(argv, deps);
       if (
         result.exitCode === 0 ||

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -61,6 +61,28 @@
 // never let the gate pass on anything other than the primary bot's own
 // real signal -- it only tells a caller when requesting a reroll is safe
 // and how much budget remains.
+//
+// #2015: bounded poll for the "not reviewed yet" race. The hosting
+// workflow's `pull_request` `synchronize` trigger fires the instant a push
+// lands, independent of the separate `pull_request_review` trigger, which
+// only fires once the primary bot's own review actually lands (typically
+// 10-40s later) -- so a push that also needs a fresh review used to get
+// asserted, and fail, before that review existed, costing a near-certain
+// external rerun every time. The CLI entry point at the bottom of this
+// file now runs through `runAdvisoryConvergenceWithPoll` instead of
+// `runAdvisoryConvergence` directly: when (and ONLY when) the verdict's
+// sole blocking reason is that the primary bot has not reviewed the PR AT
+// ALL yet (`isSoleCopilotNotReviewedYetReason` -- excludes a stale-HEAD
+// review, unresolved threads, an indeterminate claim scope, or any other
+// reason, all of which still fail immediately with no wait, exactly as
+// before), it polls a short, bounded window (every
+// `DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS`, up to
+// `DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS` total) before its real
+// assert-driven exit. This changes nothing about `--assert`'s exit-code
+// contract, roadmap #1342's deterministic-convergence policy, or this
+// check's required/fail-closed/non-bypassable nature: if the review still
+// has not landed by the end of the window, or lands with outstanding
+// items, the job fails exactly as it always has.
 import {
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
   DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES,
@@ -903,6 +925,110 @@ export function runAdvisoryConvergence(argv, deps = defaultDeps) {
   const exitCode = args.assert ? (verdict.ready ? 0 : 1) : 0;
   return { verdict, exitCode, help: false };
 }
+/**
+ * #2015: `true` only for the narrow "primary bot has not reviewed this
+ * pull request AT ALL yet" verdict shape -- the one case
+ * {@link runAdvisoryConvergenceWithPoll} is allowed to poll on. Deliberately
+ * NOT true for "the bot's latest review targets an older commit" (a
+ * *different* `reasons[]` string, produced once `review.found` is `true`
+ * but `matchesHead` is `false` -- see the `pending`/`reasons.push` pair in
+ * {@link computeAdvisoryConvergenceVerdict}): once the bot has reviewed the
+ * PR at least once, `review.found` stays `true` forever, so this predicate
+ * can only ever fire before the bot's very first review lands. That is
+ * exactly the issue #2015 acceptance criterion ("the only reason a first
+ * check would fail is '{bot} has not reviewed this pull request yet' --
+ * not on any other failure reason"), not an accidental scope gap: a later
+ * push invalidating an earlier review is a different race with a different
+ * reason string, and is intentionally left to fail immediately with no
+ * wait, same as every other not-ready reason.
+ *
+ * `reasons.length === 1` is defense-in-depth, not redundant with the
+ * `pending`/`review.found` pair: an unusually short configured deadline
+ * (or a terminal-Copilot-unavailability state) can append its own reason
+ * alongside the pending one, and this predicate must not poll then either
+ * -- polling cannot help a deadline/terminal reason converge.
+ */
+export function isSoleCopilotNotReviewedYetReason(verdict) {
+  return (
+    verdict.pending &&
+    !verdict.review.found &&
+    verdict.reasons.length === 1 &&
+    verdict.reasons[0] ===
+      `${verdict.primaryBotLogin} has not reviewed this pull request yet`
+  );
+}
+/** Poll interval for {@link runAdvisoryConvergenceWithPoll}'s bounded wait
+ * (#2015), within the issue's suggested 5-10s cadence. */
+export const DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS = 7_500;
+/** Total bounded wait budget, across all poll attempts, for
+ * {@link runAdvisoryConvergenceWithPoll} (#2015) -- the issue's suggested
+ * ~60s ceiling. */
+export const DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS = 60_000;
+/** Synchronous bounded sleep via `Atomics.wait` on a throwaway
+ * `SharedArrayBuffer` -- the same technique
+ * `rerun-advisory-convergence.mts`'s own `sleepSync` uses, chosen there (and
+ * reused here rather than switching this file to `async`/`await`) so this
+ * file can stay fully synchronous like every other helper in this module
+ * family; duplicated as this one-line function rather than imported from
+ * that sibling file, mirroring that file's own precedent of duplicating a
+ * few lines over adding cross-file coupling for a narrow, already-stable
+ * reuse. */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+/**
+ * #2015: wraps {@link runAdvisoryConvergence} with a short, bounded poll
+ * for the narrow case {@link isSoleCopilotNotReviewedYetReason} identifies
+ * -- absorbing the common race where the `pull_request` `synchronize`
+ * trigger fires (and this CLI runs) before the separate
+ * `pull_request_review` trigger's review has actually landed (typically
+ * 10-40s later). Every other not-ready reason still fails on the very
+ * first pass with no wait, exactly as {@link runAdvisoryConvergence} alone
+ * already does -- this wrapper adds no new pass path, only absorbs a
+ * latency this one specific reason is known to resolve on its own. Does
+ * NOT change `--assert`'s exit-code contract or roadmap #1342's
+ * deterministic, fail-closed convergence policy: if the bot's review still
+ * has not landed by the end of the window, or lands with outstanding
+ * items, the final result fails exactly as `runAdvisoryConvergence` alone
+ * would have failed immediately.
+ *
+ * `exitCode !== 0` from the first attempt already implies `--assert` was
+ * passed and the verdict was not ready (the only way
+ * {@link runAdvisoryConvergence} returns non-zero), so this never needs to
+ * re-parse `argv` itself to check `--assert`.
+ */
+export function runAdvisoryConvergenceWithPoll(
+  argv,
+  deps = defaultDeps,
+  pollOptions = {},
+) {
+  let result = runAdvisoryConvergence(argv, deps);
+  if (
+    result.exitCode !== 0 &&
+    result.verdict &&
+    isSoleCopilotNotReviewedYetReason(result.verdict)
+  ) {
+    const pollIntervalMs =
+      pollOptions.pollIntervalMs ?? DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS;
+    const maxWaitMs =
+      pollOptions.maxWaitMs ?? DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS;
+    const sleep = pollOptions.sleep ?? sleepSync;
+    let waitedMs = 0;
+    while (waitedMs < maxWaitMs) {
+      sleep(pollIntervalMs);
+      waitedMs += pollIntervalMs;
+      result = runAdvisoryConvergence(argv, deps);
+      if (
+        result.exitCode === 0 ||
+        !result.verdict ||
+        !isSoleCopilotNotReviewedYetReason(result.verdict)
+      ) {
+        break;
+      }
+    }
+  }
+  return result;
+}
 // --- Production I/O: fetch PR/review/thread/comment evidence via `gh` ----
 /**
  * `gh` options for the viewer-login probe (`gh api user`).
@@ -1580,7 +1706,7 @@ function fetchThreadCommentPages(threadId, afterCursor) {
 // Guarded behind `import.meta.main` so importing this module (for unit
 // tests) never parses process.argv, prints usage, or makes a `gh` call.
 if (import.meta.main) {
-  const { verdict, exitCode, help } = runAdvisoryConvergence(
+  const { verdict, exitCode, help } = runAdvisoryConvergenceWithPoll(
     process.argv.slice(2),
   );
   if (help) {

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -1528,6 +1528,22 @@ function sleepSync(ms: number): void {
  * past its documented bound and risk the hosting workflow's own
  * `timeout-minutes` before ever reaching its fail-closed exit.
  *
+ * A re-check is never launched once a sleep has already consumed the full
+ * remaining budget (PR #2023 review round 2, Codex P2 + Copilot) --
+ * `collectFromGitHub` has its own independent `gh` timeouts (up to
+ * `DEFAULT_GH_PAGINATED_TIMEOUT_MS` = 120s, #1675) that this poll's
+ * `maxWaitMs` cannot bound from the outside, so starting a fresh collection
+ * pass exactly AT the deadline could otherwise blow the wall-clock bound
+ * wide open. KNOWN RESIDUAL: a collection that starts just BEFORE the
+ * deadline (i.e. while genuine budget remains) can still run long, bounded
+ * only by `gh-exec.mts`'s own per-call timeouts, not by `maxWaitMs` --
+ * threading a remaining-budget deadline into every `gh` call inside
+ * `collectFromGitHub` would close that gap but is a multi-call-site change
+ * out of scope for this narrow poll wrapper. One consequence: a
+ * `pollIntervalMs` configured `>=` `maxWaitMs` yields zero re-checks (the
+ * first sleep alone exhausts the budget) -- an edge case only reachable via
+ * an explicit non-default override, never the production defaults below.
+ *
  * KNOWN RESIDUAL (PR #2023 review, Codex P1): the hosting workflow's
  * concurrency group is keyed by PR number ALONE across all three of its
  * triggers, with `cancel-in-progress: true` (see
@@ -1587,6 +1603,11 @@ export function runAdvisoryConvergenceWithPoll(
     const deadline = now() + maxWaitMs;
     while (now() < deadline) {
       sleep(Math.min(pollIntervalMs, deadline - now()));
+      // #2023 review round 2: don't launch a re-check once the sleep above
+      // has already consumed the entire remaining budget -- see this
+      // function's own doc comment for why (collection has its own
+      // unbounded-relative-to-maxWaitMs `gh` timeouts).
+      if (now() >= deadline) break;
       result = runAdvisoryConvergence(argv, deps);
       if (
         result.exitCode === 0 ||

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -67,9 +67,9 @@
 // lands, independent of the separate `pull_request_review` trigger, which
 // only fires once the primary bot's own review actually lands (typically
 // 10-40s later) -- so a push that also needs a fresh review used to get
-// asserted, and fail, before that review existed, costing a near-certain
-// external rerun every time. The CLI entry point at the bottom of this
-// file now runs through `runAdvisoryConvergenceWithPoll` instead of
+// asserted, and fail, before that review existed, costing an external
+// rerun most of the time. The CLI entry point at the bottom of this file
+// now runs through `runAdvisoryConvergenceWithPoll` instead of
 // `runAdvisoryConvergence` directly: when (and ONLY when) the verdict's
 // sole blocking reason is that the primary bot has not reviewed the PR AT
 // ALL yet (`isSoleCopilotNotReviewedYetReason` -- excludes a stale-HEAD
@@ -77,12 +77,19 @@
 // reason, all of which still fail immediately with no wait, exactly as
 // before), it polls a short, bounded window (every
 // `DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS`, up to
-// `DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS` total) before its real
+// `DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS` total, wall-clock bounded --
+// see `runAdvisoryConvergenceWithPoll`'s own doc comment) before its real
 // assert-driven exit. This changes nothing about `--assert`'s exit-code
 // contract, roadmap #1342's deterministic-convergence policy, or this
 // check's required/fail-closed/non-bypassable nature: if the review still
 // has not landed by the end of the window, or lands with outstanding
-// items, the job fails exactly as it always has.
+// items, the job fails exactly as it always has. See
+// `runAdvisoryConvergenceWithPoll`'s own doc comment for a known residual
+// (PR #2023 review): a review landing WHILE this poll is asleep can still
+// need the pre-existing external-rerun recovery, via a different
+// mechanism (this run gets cancelled by the hosting workflow's own
+// concurrency group, not a plain immediate-assert failure) -- the poll's
+// actual win is narrower than "never needs a rerun again."
 
 import {
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
@@ -1446,12 +1453,36 @@ export const DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS = 7_500;
 export const DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS = 60_000;
 
 /** Options accepted by {@link runAdvisoryConvergenceWithPoll}. All optional
- * -- `sleep` exists solely so tests can inject a deterministic, instant
- * fake instead of a real bounded wait. */
+ * -- `sleep` and `now` exist solely so tests can inject a deterministic,
+ * instant fake clock instead of a real bounded wait; production always uses
+ * the real `sleepSync`/`Date.now` pair. Both must be supplied together for a
+ * fake clock to behave correctly (`sleep`'s fake advances must be the ONLY
+ * thing `now` reads) -- a test that fakes one but not the other either
+ * hangs (real `now`, faked instant `sleep`: the deadline never approaches
+ * except via genuine wall-clock time) or spins (faked `now`, real `sleep`:
+ * unlikely, but keep the pair together regardless). */
 export interface AdvisoryConvergencePollOptions {
   pollIntervalMs?: number;
   maxWaitMs?: number;
   sleep?: (ms: number) => void;
+  /** Defaults to `Date.now` (not `performance.now`) -- matching the exact
+   * clock source `rerun-advisory-convergence.mts`'s own `waitForNewAttempt`
+   * deadline already uses for the identical bounded-poll shape. */
+  now?: () => number;
+}
+
+/** Falls back to `fallback` for a non-finite or non-positive value --
+ * mirrors `gh-exec.mts`'s `withBoundedRetry` guard on its own duration
+ * options, so a `NaN`/zero/negative caller-supplied interval or budget
+ * cannot silently defeat the bound (a zero interval against a real,
+ * non-faked clock would otherwise tight-loop until `maxWaitMs` elapses). */
+function positiveMsOrDefault(
+  value: number | undefined,
+  fallback: number,
+): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
 }
 
 /** Synchronous bounded sleep via `Atomics.wait` on a throwaway
@@ -1487,6 +1518,46 @@ function sleepSync(ms: number): void {
  * passed and the verdict was not ready (the only way
  * {@link runAdvisoryConvergence} returns non-zero), so this never needs to
  * re-parse `argv` itself to check `--assert`.
+ *
+ * The bound is wall-clock, not sleep-count: `maxWaitMs` is a deadline
+ * (`now() + maxWaitMs`), and each iteration's actual sleep is capped to the
+ * REMAINING budget, not the nominal `pollIntervalMs` (PR #2023 review,
+ * Codex P2) -- production `collectFromGitHub` performs several real,
+ * potentially slow `gh` calls per re-check, and counting only requested
+ * sleep time (ignoring that collection time) could let the loop run well
+ * past its documented bound and risk the hosting workflow's own
+ * `timeout-minutes` before ever reaching its fail-closed exit.
+ *
+ * KNOWN RESIDUAL (PR #2023 review, Codex P1): the hosting workflow's
+ * concurrency group is keyed by PR number ALONE across all three of its
+ * triggers, with `cancel-in-progress: true` (see
+ * `idd-advisory-convergence.yml`'s own header). If the primary bot's review
+ * actually lands WHILE this poll is still sleeping, that submission starts
+ * a fresh `pull_request_review`-triggered run in the SAME concurrency
+ * group, which cancels this run before its next scheduled re-check ever
+ * observes the review -- this run ends CANCELLED, not SUCCESS, and the
+ * fresh run becomes the one responsible for reflecting the converged
+ * state. No safe mechanical fix was found for this within #2015's scope:
+ * narrowing the concurrency group would defeat the deliberate cross-trigger
+ * debouncing the workflow's own "Concurrency-hardening investigation"
+ * comment already documents as load-bearing, and there is no way for a
+ * script to detect an imminent cancellation from inside the run it is
+ * about to lose. This is NOT a regression versus the pre-#2015 baseline,
+ * only a narrower win than "no external rerun ever needed": before #2015,
+ * this run always finished FAILURE well before the review landed (10-40s
+ * later), so cancellation essentially never happened, but the resulting
+ * rollup update from the later review-triggered run was ALREADY subject to
+ * the exact same documented stale-rollup risk this residual describes (see
+ * `#1381` in that same investigation comment) -- the pre-existing recovery
+ * (`rerun-advisory-convergence.mjs`, which explicitly reruns a stale
+ * CANCELLED-conclusion sibling instance, not only a FAILURE one) covers
+ * this run's cancelled outcome exactly as it already covered the
+ * pre-#2015 case. The poll's actual win is narrower than the eliminate-
+ * every-rerun framing above: it resolves without any rerun specifically
+ * when a scheduled re-check happens to observe the landed review before a
+ * competing trigger's cancellation reaches this run -- which still occurs
+ * whenever the review lands close to (but not exactly inside) an active
+ * sleep, or after this poll's window has already closed.
  */
 export function runAdvisoryConvergenceWithPoll(
   argv: string[],
@@ -1503,15 +1574,19 @@ export function runAdvisoryConvergenceWithPoll(
     result.verdict &&
     isSoleCopilotNotReviewedYetReason(result.verdict)
   ) {
-    const pollIntervalMs =
-      pollOptions.pollIntervalMs ?? DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS;
-    const maxWaitMs =
-      pollOptions.maxWaitMs ?? DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS;
+    const pollIntervalMs = positiveMsOrDefault(
+      pollOptions.pollIntervalMs,
+      DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS,
+    );
+    const maxWaitMs = positiveMsOrDefault(
+      pollOptions.maxWaitMs,
+      DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS,
+    );
     const sleep = pollOptions.sleep ?? sleepSync;
-    let waitedMs = 0;
-    while (waitedMs < maxWaitMs) {
-      sleep(pollIntervalMs);
-      waitedMs += pollIntervalMs;
+    const now = pollOptions.now ?? Date.now;
+    const deadline = now() + maxWaitMs;
+    while (now() < deadline) {
+      sleep(Math.min(pollIntervalMs, deadline - now()));
       result = runAdvisoryConvergence(argv, deps);
       if (
         result.exitCode === 0 ||

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -61,6 +61,28 @@
 // never let the gate pass on anything other than the primary bot's own
 // real signal -- it only tells a caller when requesting a reroll is safe
 // and how much budget remains.
+//
+// #2015: bounded poll for the "not reviewed yet" race. The hosting
+// workflow's `pull_request` `synchronize` trigger fires the instant a push
+// lands, independent of the separate `pull_request_review` trigger, which
+// only fires once the primary bot's own review actually lands (typically
+// 10-40s later) -- so a push that also needs a fresh review used to get
+// asserted, and fail, before that review existed, costing a near-certain
+// external rerun every time. The CLI entry point at the bottom of this
+// file now runs through `runAdvisoryConvergenceWithPoll` instead of
+// `runAdvisoryConvergence` directly: when (and ONLY when) the verdict's
+// sole blocking reason is that the primary bot has not reviewed the PR AT
+// ALL yet (`isSoleCopilotNotReviewedYetReason` -- excludes a stale-HEAD
+// review, unresolved threads, an indeterminate claim scope, or any other
+// reason, all of which still fail immediately with no wait, exactly as
+// before), it polls a short, bounded window (every
+// `DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS`, up to
+// `DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS` total) before its real
+// assert-driven exit. This changes nothing about `--assert`'s exit-code
+// contract, roadmap #1342's deterministic-convergence policy, or this
+// check's required/fail-closed/non-bypassable nature: if the review still
+// has not landed by the end of the window, or lands with outstanding
+// items, the job fails exactly as it always has.
 
 import {
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
@@ -1379,6 +1401,130 @@ export function runAdvisoryConvergence(
   return { verdict, exitCode, help: false };
 }
 
+/**
+ * #2015: `true` only for the narrow "primary bot has not reviewed this
+ * pull request AT ALL yet" verdict shape -- the one case
+ * {@link runAdvisoryConvergenceWithPoll} is allowed to poll on. Deliberately
+ * NOT true for "the bot's latest review targets an older commit" (a
+ * *different* `reasons[]` string, produced once `review.found` is `true`
+ * but `matchesHead` is `false` -- see the `pending`/`reasons.push` pair in
+ * {@link computeAdvisoryConvergenceVerdict}): once the bot has reviewed the
+ * PR at least once, `review.found` stays `true` forever, so this predicate
+ * can only ever fire before the bot's very first review lands. That is
+ * exactly the issue #2015 acceptance criterion ("the only reason a first
+ * check would fail is '{bot} has not reviewed this pull request yet' --
+ * not on any other failure reason"), not an accidental scope gap: a later
+ * push invalidating an earlier review is a different race with a different
+ * reason string, and is intentionally left to fail immediately with no
+ * wait, same as every other not-ready reason.
+ *
+ * `reasons.length === 1` is defense-in-depth, not redundant with the
+ * `pending`/`review.found` pair: an unusually short configured deadline
+ * (or a terminal-Copilot-unavailability state) can append its own reason
+ * alongside the pending one, and this predicate must not poll then either
+ * -- polling cannot help a deadline/terminal reason converge.
+ */
+export function isSoleCopilotNotReviewedYetReason(
+  verdict: AdvisoryConvergenceVerdict,
+): boolean {
+  return (
+    verdict.pending &&
+    !verdict.review.found &&
+    verdict.reasons.length === 1 &&
+    verdict.reasons[0] ===
+      `${verdict.primaryBotLogin} has not reviewed this pull request yet`
+  );
+}
+
+/** Poll interval for {@link runAdvisoryConvergenceWithPoll}'s bounded wait
+ * (#2015), within the issue's suggested 5-10s cadence. */
+export const DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS = 7_500;
+
+/** Total bounded wait budget, across all poll attempts, for
+ * {@link runAdvisoryConvergenceWithPoll} (#2015) -- the issue's suggested
+ * ~60s ceiling. */
+export const DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS = 60_000;
+
+/** Options accepted by {@link runAdvisoryConvergenceWithPoll}. All optional
+ * -- `sleep` exists solely so tests can inject a deterministic, instant
+ * fake instead of a real bounded wait. */
+export interface AdvisoryConvergencePollOptions {
+  pollIntervalMs?: number;
+  maxWaitMs?: number;
+  sleep?: (ms: number) => void;
+}
+
+/** Synchronous bounded sleep via `Atomics.wait` on a throwaway
+ * `SharedArrayBuffer` -- the same technique
+ * `rerun-advisory-convergence.mts`'s own `sleepSync` uses, chosen there (and
+ * reused here rather than switching this file to `async`/`await`) so this
+ * file can stay fully synchronous like every other helper in this module
+ * family; duplicated as this one-line function rather than imported from
+ * that sibling file, mirroring that file's own precedent of duplicating a
+ * few lines over adding cross-file coupling for a narrow, already-stable
+ * reuse. */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * #2015: wraps {@link runAdvisoryConvergence} with a short, bounded poll
+ * for the narrow case {@link isSoleCopilotNotReviewedYetReason} identifies
+ * -- absorbing the common race where the `pull_request` `synchronize`
+ * trigger fires (and this CLI runs) before the separate
+ * `pull_request_review` trigger's review has actually landed (typically
+ * 10-40s later). Every other not-ready reason still fails on the very
+ * first pass with no wait, exactly as {@link runAdvisoryConvergence} alone
+ * already does -- this wrapper adds no new pass path, only absorbs a
+ * latency this one specific reason is known to resolve on its own. Does
+ * NOT change `--assert`'s exit-code contract or roadmap #1342's
+ * deterministic, fail-closed convergence policy: if the bot's review still
+ * has not landed by the end of the window, or lands with outstanding
+ * items, the final result fails exactly as `runAdvisoryConvergence` alone
+ * would have failed immediately.
+ *
+ * `exitCode !== 0` from the first attempt already implies `--assert` was
+ * passed and the verdict was not ready (the only way
+ * {@link runAdvisoryConvergence} returns non-zero), so this never needs to
+ * re-parse `argv` itself to check `--assert`.
+ */
+export function runAdvisoryConvergenceWithPoll(
+  argv: string[],
+  deps: AdvisoryConvergenceDeps = defaultDeps,
+  pollOptions: AdvisoryConvergencePollOptions = {},
+): {
+  verdict: AdvisoryConvergenceVerdict | null;
+  exitCode: number;
+  help: boolean;
+} {
+  let result = runAdvisoryConvergence(argv, deps);
+  if (
+    result.exitCode !== 0 &&
+    result.verdict &&
+    isSoleCopilotNotReviewedYetReason(result.verdict)
+  ) {
+    const pollIntervalMs =
+      pollOptions.pollIntervalMs ?? DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS;
+    const maxWaitMs =
+      pollOptions.maxWaitMs ?? DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS;
+    const sleep = pollOptions.sleep ?? sleepSync;
+    let waitedMs = 0;
+    while (waitedMs < maxWaitMs) {
+      sleep(pollIntervalMs);
+      waitedMs += pollIntervalMs;
+      result = runAdvisoryConvergence(argv, deps);
+      if (
+        result.exitCode === 0 ||
+        !result.verdict ||
+        !isSoleCopilotNotReviewedYetReason(result.verdict)
+      ) {
+        break;
+      }
+    }
+  }
+  return result;
+}
+
 // --- Production I/O: fetch PR/review/thread/comment evidence via `gh` ----
 
 /**
@@ -2157,7 +2303,7 @@ function fetchThreadCommentPages(
 // Guarded behind `import.meta.main` so importing this module (for unit
 // tests) never parses process.argv, prints usage, or makes a `gh` call.
 if (import.meta.main) {
-  const { verdict, exitCode, help } = runAdvisoryConvergence(
+  const { verdict, exitCode, help } = runAdvisoryConvergenceWithPoll(
     process.argv.slice(2),
   );
   if (help) {

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -10,10 +10,12 @@ import {
   classifyCopilotAuthoredThreadIds,
   computeAdvisoryConvergenceVerdict,
   hasTrustedClaimMarkerHistory,
+  isSoleCopilotNotReviewedYetReason,
   parseArgs,
   pickResolvingClaimEvents,
   resolveClaimEvidence,
   runAdvisoryConvergence,
+  runAdvisoryConvergenceWithPoll,
   SAME_HEAD_REROLL_INELIGIBLE_REASON,
   viewerProbeGhOptions,
 } from '../src/scripts/advisory-convergence.mts';
@@ -2981,6 +2983,208 @@ test('runAdvisoryConvergence: missing --pr throws before any collection happens'
   };
   assert.throws(() => runAdvisoryConvergence([], deps));
   assert.equal(called, false);
+});
+
+// --- isSoleCopilotNotReviewedYetReason / runAdvisoryConvergenceWithPoll ----
+// (#2015: bounded poll for the "not reviewed yet" race only)
+
+test('isSoleCopilotNotReviewedYetReason: true when the bot has never reviewed and that is the only reason', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [] }),
+    baseOptions(),
+  );
+  assert.equal(verdict.pending, true);
+  assert.equal(verdict.review.found, false);
+  assert.deepEqual(verdict.reasons, [
+    'copilot has not reviewed this pull request yet',
+  ]);
+  assert.equal(isSoleCopilotNotReviewedYetReason(verdict), true);
+});
+
+test('isSoleCopilotNotReviewedYetReason: false when the verdict is already ready', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [copilotReview()] }),
+    baseOptions(),
+  );
+  assert.equal(verdict.ready, true);
+  assert.equal(isSoleCopilotNotReviewedYetReason(verdict), false);
+});
+
+test('isSoleCopilotNotReviewedYetReason: false when the bot reviewed an older commit (different reason string)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [copilotReview({ commitId: OTHER_SHA })] }),
+    baseOptions(),
+  );
+  assert.equal(verdict.pending, true);
+  assert.equal(verdict.review.found, true);
+  assert.equal(isSoleCopilotNotReviewedYetReason(verdict), false);
+});
+
+test('isSoleCopilotNotReviewedYetReason: false when an unrelated blocking reason accompanies the pending one', () => {
+  // Zero reviews (pending, review.found === false) BUT the deadline has
+  // already passed with no valid waiver, which appends its own reason
+  // alongside the pending one -- reasons.length > 1, so this must not poll.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [] }),
+    baseOptions({ headCommittedAt: OLD, waiverMode: 'disabled' }),
+  );
+  assert.equal(verdict.pending, true);
+  assert.equal(verdict.review.found, false);
+  assert.ok(verdict.reasons.length > 1);
+  assert.equal(isSoleCopilotNotReviewedYetReason(verdict), false);
+});
+
+function pollDepsFor(
+  inputsSequence: AdvisoryConvergenceInputs[],
+  options: AdvisoryConvergenceOptions,
+): { deps: AdvisoryConvergenceDeps; collectCalls: () => number } {
+  let index = 0;
+  let calls = 0;
+  const deps: AdvisoryConvergenceDeps = {
+    collect: () => {
+      calls += 1;
+      const inputs = inputsSequence[Math.min(index, inputsSequence.length - 1)];
+      if (index < inputsSequence.length - 1) index += 1;
+      return { inputs, options };
+    },
+  };
+  return { deps, collectCalls: () => calls };
+}
+
+function fakeSleep(): { sleep: (ms: number) => void; calls: () => number } {
+  let calls = 0;
+  return {
+    sleep: () => {
+      calls += 1;
+    },
+    calls: () => calls,
+  };
+}
+
+test('runAdvisoryConvergenceWithPoll: review landing within the window resolves without exhausting it', () => {
+  const { deps, collectCalls } = pollDepsFor(
+    [
+      baseInputs({ reviews: [] }),
+      baseInputs({ reviews: [] }),
+      baseInputs({ reviews: [copilotReview()] }),
+    ],
+    baseOptions(),
+  );
+  const { sleep, calls } = fakeSleep();
+  const { verdict, exitCode } = runAdvisoryConvergenceWithPoll(
+    ['--pr', '1234', '--assert'],
+    deps,
+    { maxWaitMs: 60_000, pollIntervalMs: 7_500, sleep },
+  );
+  assert.equal(verdict?.ready, true);
+  assert.equal(exitCode, 0);
+  // 3 collect() calls total (1 initial + 2 poll re-checks); the loop must
+  // stop as soon as the review lands, well short of the 8-attempt max-wait
+  // budget (60_000 / 7_500 ~= 8).
+  assert.equal(collectCalls(), 3);
+  assert.equal(calls(), 2);
+});
+
+test('runAdvisoryConvergenceWithPoll: review never landing still fails with the existing reason string after the window', () => {
+  const { deps, collectCalls } = pollDepsFor(
+    [baseInputs({ reviews: [] })],
+    baseOptions(),
+  );
+  const { sleep, calls } = fakeSleep();
+  const { verdict, exitCode } = runAdvisoryConvergenceWithPoll(
+    ['--pr', '1234', '--assert'],
+    deps,
+    { maxWaitMs: 20_000, pollIntervalMs: 7_500, sleep },
+  );
+  assert.equal(verdict?.ready, false);
+  assert.deepEqual(verdict?.reasons, [
+    'copilot has not reviewed this pull request yet',
+  ]);
+  assert.equal(exitCode, 1);
+  // ceil(20_000 / 7_500) = 3 poll attempts once maxWaitMs is exhausted,
+  // plus the initial attempt.
+  assert.equal(calls(), 3);
+  assert.equal(collectCalls(), 4);
+});
+
+test('runAdvisoryConvergenceWithPoll: does not poll for any other not-ready reason', () => {
+  const { deps, collectCalls } = pollDepsFor(
+    [
+      baseInputs({
+        reviews: [copilotReview({ commitId: OTHER_SHA })],
+      }),
+    ],
+    baseOptions(),
+  );
+  const { sleep, calls } = fakeSleep();
+  const { verdict, exitCode } = runAdvisoryConvergenceWithPoll(
+    ['--pr', '1234', '--assert'],
+    deps,
+    { sleep },
+  );
+  assert.equal(verdict?.ready, false);
+  assert.equal(exitCode, 1);
+  assert.equal(collectCalls(), 1);
+  assert.equal(calls(), 0);
+});
+
+test('runAdvisoryConvergenceWithPoll: without --assert never polls regardless of verdict', () => {
+  const { deps, collectCalls } = pollDepsFor(
+    [baseInputs({ reviews: [] })],
+    baseOptions(),
+  );
+  const { sleep, calls } = fakeSleep();
+  const { verdict, exitCode } = runAdvisoryConvergenceWithPoll(
+    ['--pr', '1234'],
+    deps,
+    { sleep },
+  );
+  assert.equal(verdict?.ready, false);
+  assert.equal(exitCode, 0);
+  assert.equal(collectCalls(), 1);
+  assert.equal(calls(), 0);
+});
+
+test('runAdvisoryConvergenceWithPoll: --help short-circuits before collecting or sleeping', () => {
+  let called = false;
+  const deps: AdvisoryConvergenceDeps = {
+    collect: () => {
+      called = true;
+      return { inputs: baseInputs(), options: baseOptions() };
+    },
+  };
+  const { sleep, calls } = fakeSleep();
+  const { help, exitCode } = runAdvisoryConvergenceWithPoll(['--help'], deps, {
+    sleep,
+  });
+  assert.equal(help, true);
+  assert.equal(exitCode, 0);
+  assert.equal(called, false);
+  assert.equal(calls(), 0);
+});
+
+test('runAdvisoryConvergenceWithPoll: a reason change mid-poll stops the loop immediately instead of exhausting the window', () => {
+  const { deps, collectCalls } = pollDepsFor(
+    [
+      baseInputs({ reviews: [] }),
+      baseInputs({ reviews: [copilotReview({ commitId: OTHER_SHA })] }),
+    ],
+    baseOptions(),
+  );
+  const { sleep, calls } = fakeSleep();
+  const { verdict, exitCode } = runAdvisoryConvergenceWithPoll(
+    ['--pr', '1234', '--assert'],
+    deps,
+    { maxWaitMs: 60_000, pollIntervalMs: 7_500, sleep },
+  );
+  assert.equal(verdict?.ready, false);
+  assert.equal(verdict?.review.found, true);
+  assert.equal(exitCode, 1);
+  // Stops after the single re-check that reveals the new (off-HEAD) review
+  // -- must not keep polling out the rest of the 60s window once the
+  // blocking reason is no longer the sole "not reviewed yet" case.
+  assert.equal(calls(), 1);
+  assert.equal(collectCalls(), 2);
 });
 
 test('viewerProbeGhOptions captures gh stderr only under GitHub Actions', () => {

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -3117,10 +3117,14 @@ test('runAdvisoryConvergenceWithPoll: review never landing still fails with the 
     'copilot has not reviewed this pull request yet',
   ]);
   assert.equal(exitCode, 1);
-  // ceil(20_000 / 7_500) = 3 poll attempts once maxWaitMs is exhausted,
-  // plus the initial attempt.
+  // 3 sleeps (7_500, 7_500, then capped to the remaining 5_000) but only 2
+  // in-loop re-checks (collectCalls() == 3 == 1 initial + 2): the 3rd sleep
+  // consumes the entire remaining budget, so the guard added in #2023
+  // review round 2 (Codex/Copilot: "avoid launching a recheck after the
+  // remaining budget is consumed") skips the re-check that would otherwise
+  // start exactly AT the deadline.
   assert.equal(calls(), 3);
-  assert.equal(collectCalls(), 4);
+  assert.equal(collectCalls(), 3);
   // The bound is wall-clock (a deadline), not a sum of nominal intervals:
   // the final sleep is capped to the REMAINING budget (20_000 - 15_000 =
   // 5_000), not the full 7_500 nominal interval -- PR #2023 review (Codex
@@ -3128,6 +3132,30 @@ test('runAdvisoryConvergenceWithPoll: review never landing still fails with the 
   // 20s bound on this exact input.
   assert.deepEqual(sleptMs(), [7_500, 7_500, 5_000]);
   assert.equal(now(), 20_000);
+});
+
+test('runAdvisoryConvergenceWithPoll: pollIntervalMs >= maxWaitMs yields zero re-checks, not an over-budget one', () => {
+  // Edge case flagged during #2023 review round 2's guard fix: a caller
+  // (never production, which always uses the < defaults below) configuring
+  // an interval at least as large as the whole budget means the first sleep
+  // alone exhausts it, so the guard must skip the re-check entirely rather
+  // than launch one over an already-consumed budget.
+  const { deps, collectCalls } = pollDepsFor(
+    [baseInputs({ reviews: [] })],
+    baseOptions(),
+  );
+  const { sleep, now, calls, sleptMs } = fakeClock();
+  const { verdict, exitCode } = runAdvisoryConvergenceWithPoll(
+    ['--pr', '1234', '--assert'],
+    deps,
+    { maxWaitMs: 10_000, pollIntervalMs: 30_000, sleep, now },
+  );
+  assert.equal(verdict?.ready, false);
+  assert.equal(exitCode, 1);
+  assert.equal(calls(), 1);
+  assert.deepEqual(sleptMs(), [10_000]);
+  // Only the initial (pre-loop) collect() call -- zero in-loop re-checks.
+  assert.equal(collectCalls(), 1);
 });
 
 test('runAdvisoryConvergenceWithPoll: slow collection time counts against the wall-clock budget, not just sleep time', () => {
@@ -3143,10 +3171,14 @@ test('runAdvisoryConvergenceWithPoll: slow collection time counts against the wa
   // too, and stop far sooner.
   const { sleep, now } = fakeClock();
   let collectCalls = 0;
+  const collectStartTimes: number[] = [];
+  const collectEndTimes: number[] = [];
   const deps: AdvisoryConvergenceDeps = {
     collect: () => {
       collectCalls += 1;
+      collectStartTimes.push(now());
       sleep(6_000);
+      collectEndTimes.push(now());
       return { inputs: baseInputs({ reviews: [] }), options: baseOptions() };
     },
   };
@@ -3165,6 +3197,21 @@ test('runAdvisoryConvergenceWithPoll: slow collection time counts against the wa
     collectCalls < 10,
     `expected far fewer than 10 collect() calls under the wall-clock fix, got ${collectCalls}`,
   );
+  // #2023 review round 2 (Codex/Copilot, on this exact test): asserting
+  // only the call count missed that the LAST re-check could still start at
+  // or after the deadline and run long uncounted. Assert elapsed virtual
+  // time directly: `runAdvisoryConvergenceWithPoll` reads `now()` for its
+  // deadline right after the initial (pre-loop) collect() call returns, so
+  // the deadline is `collectEndTimes[0] + maxWaitMs`; no IN-LOOP re-check
+  // (every collectStartTimes entry after the first) may start at or after
+  // it -- that is exactly the guard this fix adds.
+  const deadline = collectEndTimes[0] + 20_000;
+  for (const startedAt of collectStartTimes.slice(1)) {
+    assert.ok(
+      startedAt < deadline,
+      `expected re-check start ${startedAt} to be before deadline ${deadline}`,
+    );
+  }
 });
 
 test('runAdvisoryConvergenceWithPoll: does not poll for any other not-ready reason', () => {

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -3051,13 +3051,29 @@ function pollDepsFor(
   return { deps, collectCalls: () => calls };
 }
 
-function fakeSleep(): { sleep: (ms: number) => void; calls: () => number } {
-  let calls = 0;
+// A combined fake sleep + fake clock: `sleep` advances the SAME virtual
+// `now()` it is paired with, so `runAdvisoryConvergenceWithPoll`'s
+// wall-clock deadline (`now() + maxWaitMs`) advances deterministically and
+// instantly instead of requiring real elapsed time. Faking `sleep` alone
+// (leaving `now` as the real `Date.now`) would hang the test for up to the
+// real `maxWaitMs`, since a real clock barely advances between near-instant
+// fake-sleep iterations.
+function fakeClock(startAt = 0): {
+  sleep: (ms: number) => void;
+  now: () => number;
+  calls: () => number;
+  sleptMs: () => number[];
+} {
+  let time = startAt;
+  const sleptMs: number[] = [];
   return {
-    sleep: () => {
-      calls += 1;
+    sleep: (ms: number) => {
+      sleptMs.push(ms);
+      time += ms;
     },
-    calls: () => calls,
+    now: () => time,
+    calls: () => sleptMs.length,
+    sleptMs: () => [...sleptMs],
   };
 }
 
@@ -3070,11 +3086,11 @@ test('runAdvisoryConvergenceWithPoll: review landing within the window resolves 
     ],
     baseOptions(),
   );
-  const { sleep, calls } = fakeSleep();
+  const { sleep, now, calls } = fakeClock();
   const { verdict, exitCode } = runAdvisoryConvergenceWithPoll(
     ['--pr', '1234', '--assert'],
     deps,
-    { maxWaitMs: 60_000, pollIntervalMs: 7_500, sleep },
+    { maxWaitMs: 60_000, pollIntervalMs: 7_500, sleep, now },
   );
   assert.equal(verdict?.ready, true);
   assert.equal(exitCode, 0);
@@ -3090,11 +3106,11 @@ test('runAdvisoryConvergenceWithPoll: review never landing still fails with the 
     [baseInputs({ reviews: [] })],
     baseOptions(),
   );
-  const { sleep, calls } = fakeSleep();
+  const { sleep, now, calls, sleptMs } = fakeClock();
   const { verdict, exitCode } = runAdvisoryConvergenceWithPoll(
     ['--pr', '1234', '--assert'],
     deps,
-    { maxWaitMs: 20_000, pollIntervalMs: 7_500, sleep },
+    { maxWaitMs: 20_000, pollIntervalMs: 7_500, sleep, now },
   );
   assert.equal(verdict?.ready, false);
   assert.deepEqual(verdict?.reasons, [
@@ -3105,6 +3121,50 @@ test('runAdvisoryConvergenceWithPoll: review never landing still fails with the 
   // plus the initial attempt.
   assert.equal(calls(), 3);
   assert.equal(collectCalls(), 4);
+  // The bound is wall-clock (a deadline), not a sum of nominal intervals:
+  // the final sleep is capped to the REMAINING budget (20_000 - 15_000 =
+  // 5_000), not the full 7_500 nominal interval -- PR #2023 review (Codex
+  // P2). Without this cap the loop would run 500ms past its documented
+  // 20s bound on this exact input.
+  assert.deepEqual(sleptMs(), [7_500, 7_500, 5_000]);
+  assert.equal(now(), 20_000);
+});
+
+test('runAdvisoryConvergenceWithPoll: slow collection time counts against the wall-clock budget, not just sleep time', () => {
+  // Simulate a slow `gh` collection pass (production `collectFromGitHub`
+  // performs several real, potentially paginated API calls per re-check)
+  // by having `collect()` itself advance the shared fake clock by 6s --
+  // exactly the scenario Codex's P2 finding warned a sleep-only budget
+  // would miss. With a 1s nominal poll interval and a 20s bound, a
+  // sleep-only-counting implementation (the pre-fix behavior, which summed
+  // only the nominal interval per iteration) would run roughly 20
+  // iterations before noticing the budget was exhausted. The wall-clock
+  // deadline fix must notice the extra 6s consumed by each collect() call
+  // too, and stop far sooner.
+  const { sleep, now } = fakeClock();
+  let collectCalls = 0;
+  const deps: AdvisoryConvergenceDeps = {
+    collect: () => {
+      collectCalls += 1;
+      sleep(6_000);
+      return { inputs: baseInputs({ reviews: [] }), options: baseOptions() };
+    },
+  };
+  const { verdict, exitCode } = runAdvisoryConvergenceWithPoll(
+    ['--pr', '1234', '--assert'],
+    deps,
+    { maxWaitMs: 20_000, pollIntervalMs: 1_000, sleep, now },
+  );
+  assert.equal(verdict?.ready, false);
+  assert.equal(exitCode, 1);
+  // A sleep-only-counting loop would need ~20 poll iterations (21 total
+  // collect() calls) before its naive waitedMs sum reached 20_000. The
+  // wall-clock deadline fix stops in single digits once real elapsed time
+  // (sleep + collection) crosses the bound.
+  assert.ok(
+    collectCalls < 10,
+    `expected far fewer than 10 collect() calls under the wall-clock fix, got ${collectCalls}`,
+  );
 });
 
 test('runAdvisoryConvergenceWithPoll: does not poll for any other not-ready reason', () => {
@@ -3116,11 +3176,11 @@ test('runAdvisoryConvergenceWithPoll: does not poll for any other not-ready reas
     ],
     baseOptions(),
   );
-  const { sleep, calls } = fakeSleep();
+  const { sleep, now, calls } = fakeClock();
   const { verdict, exitCode } = runAdvisoryConvergenceWithPoll(
     ['--pr', '1234', '--assert'],
     deps,
-    { sleep },
+    { sleep, now },
   );
   assert.equal(verdict?.ready, false);
   assert.equal(exitCode, 1);
@@ -3133,11 +3193,11 @@ test('runAdvisoryConvergenceWithPoll: without --assert never polls regardless of
     [baseInputs({ reviews: [] })],
     baseOptions(),
   );
-  const { sleep, calls } = fakeSleep();
+  const { sleep, now, calls } = fakeClock();
   const { verdict, exitCode } = runAdvisoryConvergenceWithPoll(
     ['--pr', '1234'],
     deps,
-    { sleep },
+    { sleep, now },
   );
   assert.equal(verdict?.ready, false);
   assert.equal(exitCode, 0);
@@ -3153,9 +3213,10 @@ test('runAdvisoryConvergenceWithPoll: --help short-circuits before collecting or
       return { inputs: baseInputs(), options: baseOptions() };
     },
   };
-  const { sleep, calls } = fakeSleep();
+  const { sleep, now, calls } = fakeClock();
   const { help, exitCode } = runAdvisoryConvergenceWithPoll(['--help'], deps, {
     sleep,
+    now,
   });
   assert.equal(help, true);
   assert.equal(exitCode, 0);
@@ -3171,11 +3232,11 @@ test('runAdvisoryConvergenceWithPoll: a reason change mid-poll stops the loop im
     ],
     baseOptions(),
   );
-  const { sleep, calls } = fakeSleep();
+  const { sleep, now, calls } = fakeClock();
   const { verdict, exitCode } = runAdvisoryConvergenceWithPoll(
     ['--pr', '1234', '--assert'],
     deps,
-    { maxWaitMs: 60_000, pollIntervalMs: 7_500, sleep },
+    { maxWaitMs: 60_000, pollIntervalMs: 7_500, sleep, now },
   );
   assert.equal(verdict?.ready, false);
   assert.equal(verdict?.review.found, true);
@@ -3198,11 +3259,11 @@ test('runAdvisoryConvergenceWithPoll: review lands on HEAD mid-poll with outstan
     ],
     baseOptions(),
   );
-  const { sleep, calls } = fakeSleep();
+  const { sleep, now, calls } = fakeClock();
   const { verdict, exitCode } = runAdvisoryConvergenceWithPoll(
     ['--pr', '1234', '--assert'],
     deps,
-    { maxWaitMs: 60_000, pollIntervalMs: 7_500, sleep },
+    { maxWaitMs: 60_000, pollIntervalMs: 7_500, sleep, now },
   );
   assert.equal(verdict?.review.found, true);
   assert.equal(verdict?.review.matchesHead, true);

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -3187,6 +3187,39 @@ test('runAdvisoryConvergenceWithPoll: a reason change mid-poll stops the loop im
   assert.equal(collectCalls(), 2);
 });
 
+test('runAdvisoryConvergenceWithPoll: review lands on HEAD mid-poll with outstanding items still fails (no weakening)', () => {
+  // The issue's own acceptance criterion: "lands with outstanding items"
+  // must still fail exactly as today -- landing on HEAD is not itself
+  // enough to pass if the review carries actionable items.
+  const { deps, collectCalls } = pollDepsFor(
+    [
+      baseInputs({ reviews: [] }),
+      baseInputs({ reviews: [copilotReview({ itemCount: 1 })] }),
+    ],
+    baseOptions(),
+  );
+  const { sleep, calls } = fakeSleep();
+  const { verdict, exitCode } = runAdvisoryConvergenceWithPoll(
+    ['--pr', '1234', '--assert'],
+    deps,
+    { maxWaitMs: 60_000, pollIntervalMs: 7_500, sleep },
+  );
+  assert.equal(verdict?.review.found, true);
+  assert.equal(verdict?.review.matchesHead, true);
+  assert.equal(verdict?.review.satisfied, false);
+  assert.equal(verdict?.converged, false);
+  assert.equal(verdict?.ready, false);
+  assert.equal(exitCode, 1);
+  assert.ok(
+    verdict?.reasons.some((reason) => reason.includes('actionable item')),
+  );
+  // Stops after the single re-check that reveals the on-HEAD review with
+  // outstanding items -- not the sole "not reviewed yet" case anymore, so
+  // it must not keep polling out the rest of the window.
+  assert.equal(calls(), 1);
+  assert.equal(collectCalls(), 2);
+});
+
 test('viewerProbeGhOptions captures gh stderr only under GitHub Actions', () => {
   // Under Actions: capture stderr (pipe) so the expected `gh api user` 403 does
   // not leak into the run log; stdout is still piped so viewerLogin is read.


### PR DESCRIPTION
# Summary

The `idd-advisory-convergence` required check's CLI asserted immediately
after a single collect, so a push that also needed a fresh Copilot review
frequently failed with "Copilot has not reviewed this pull request yet"
before that review actually landed (the `pull_request` `synchronize`
trigger fires independently of, and usually before, the separate
`pull_request_review` trigger — typically 10-40s of latency). This added
a short, bounded poll inside the CLI, scoped narrowly to that one verdict
shape:

- `isSoleCopilotNotReviewedYetReason` identifies the narrow case: the
  primary bot has never reviewed the PR at all yet, and that is the
  verdict's only blocking reason.
- `runAdvisoryConvergenceWithPoll` wraps the existing (unchanged)
  `runAdvisoryConvergence`: on that one reason, it polls every ~7.5s up
  to a ~60s bound, re-collecting and re-computing the verdict each time,
  and stops as soon as the verdict becomes ready or the blocking reason
  changes to anything else. Every other not-ready reason (a stale-HEAD
  review, unresolved threads, an indeterminate claim scope, a deadline
  reason, etc.) still fails on the very first pass with no wait, exactly
  as before.
- Stays fully synchronous (`Atomics.wait`-based `sleepSync`, mirroring
  `rerun-advisory-convergence.mts`'s own precedent) rather than
  introducing `async`/`await` into a file that has never needed it.
- Updated the workflow's own header comment and
  `docs/idd-helper-scripts.md` (both the mirror and, in a follow-up
  commit, its canonical `idd-template/` source) to describe the new
  bounded-wait behavior instead of the old immediate-assert design.

This does not weaken the check's required, fail-closed, non-bypassable
nature or change roadmap #1342's deterministic-convergence policy in any
way — a review that never lands, or lands with outstanding items, still
fails exactly as it always has.

## Linked issue

Closes #2015

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Scope note: `review.found` flips permanently to `true` after the primary
bot's first review ever lands on a PR, so this poll can only fire before
that first review — a later `synchronize` push invalidating an earlier
review produces a *different* reason string ("does not cover current
HEAD"), which is deliberately **not** polled. This matches the issue's
literal acceptance criteria ("the only reason a first check would fail is
'{bot} has not reviewed this pull request yet' — not on any other failure
reason") exactly, not a scope gap — called out explicitly in the B2 plan
comment and the code/doc comments so a reviewer does not read it as an
oversight.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (`node --test tests/*.test.mts`, 3487 pass)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed, 4 pre-existing warnings
      unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none — advisory-convergence stays
      required, fail-closed, and non-bypassable; only latency absorption
      changed)
- [x] Context budget impact reviewed (no new instruction-file content)
