### PR TITLE
docs(idd-ci): note Rulesets may require every check-run non-failing

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -194,16 +194,15 @@ check name.
 If GH CLI cannot resolve a run ID, use Actions REST endpoints directly
 for the same run before posting a hold.
 
-**`idd-advisory-convergence` specifically** (when hosted as a required
-check): `workflow_dispatch` does **not** reliably refresh the PR's
-required-check rollup for current HEAD — a manually dispatched run has
-no `pull_request` context to associate with the PR's HEAD SHA (full
-investigation: this repo's dogfooded
+**`idd-advisory-convergence`** (as a required check): `workflow_dispatch`
+does **not** reliably refresh the PR's required-check rollup for current
+HEAD — a manually dispatched run has no `pull_request` context to
+associate with the PR's HEAD SHA (full investigation: this repo's
+dogfooded
 [`.github/workflows/idd-advisory-convergence.yml`](https://github.com/kurone-kito/idd-skill/blob/main/.github/workflows/idd-advisory-convergence.yml)
 header comment — not present in the portable stub this template
-ships). For a stuck or stale rollup entry, apply the rerun mechanic
-above (`gh run rerun <run-id>` on the _existing_ PR-linked run)
-instead of `workflow_dispatch`.
+ships). For a stuck or stale rollup entry, rerun the _existing_
+PR-linked run (`gh run rerun <run-id>`) instead of `workflow_dispatch`.
 
 A second cause: GitHub gates a bot-triggered run (e.g. Copilot's
 `pull_request_review`/`pull_request_review_comment` event) to
@@ -219,23 +218,26 @@ subscription).
 
 **If rerunning the passing non-bot instance alone does not clear the
 rollup (`#1745`)**: a HEAD can carry several `idd-advisory-convergence`
-check-run instances at once (the check fires on `pull_request` plus
+check-run instances (the check fires on `pull_request` plus
 `pull_request_review`/`pull_request_review_comment`, and
 `cancel-in-progress` cancels most of them), and GitHub's own required-check
 rollup can stay pinned to a bot-triggered instance whose **conclusion** is
-`CANCELLED` — distinct from the `action_required` case above. Unlike
-`action_required`, a `CANCELLED`-conclusion bot-triggered instance is
-**not** gated: rerunning it completes normally and does not re-enter
-`action_required` (confirmed by direct experiment, `#1745`). If the
+`CANCELLED`. Unlike `action_required`, a `CANCELLED`-conclusion
+bot-triggered instance is **not** gated: rerunning it completes
+normally and does not re-enter `action_required` (confirmed by direct
+experiment, `#1745`). If the
 non-bot rerun above does not clear the block, rerun every
 `CANCELLED`-conclusion bot-triggered sibling instance for the same HEAD
-next (`gh run rerun <run-id>` on each, one at a time, per the sequential
-rule in the helper-first plan below) — only an `action_required`-conclusion
-instance stays withheld from rerun.
+next (`gh run rerun <run-id>` on each, per the plan below) — only an
+`action_required`-conclusion instance stays withheld from rerun.
+
+Note: this is a known Rulesets platform behavior, not an `idd-skill`
+dedup bug — GitHub can require every same-named instance non-failing,
+not just the dedup-selected latest.
 
 **Helper-first**: prints this diagnosis and ordered rerun plan, read-only
-by default; pass `--apply` to also execute it — the preferred one-shot
-recovery path when a helper runtime is available. `--apply` reruns each
+by default; pass `--apply` to also execute it — the preferred recovery
+path when available. `--apply` reruns each
 rerun-eligible instance in order (recovery-refresh first when one
 applies), waits for each to reach a terminal state before starting the
 next, and stops early as soon as the rollup resolves — never a
@@ -253,8 +255,8 @@ Resolve `<profile-selected-rerun-advisory-convergence-command>` from
 `docs/idd-helper-scripts.md`; do not hardcode `node scripts/...` for
 non-vendored profiles. On `instructions-only` (no helper runtime), fall
 back to the manual sequence: run the diagnostic, then `gh run rerun
-<run-id>` on each plan entry one at a time, waiting for each to finish
-before the next.
+<run-id>` on each plan entry, waiting for each to finish before the
+next.
 
 **Terminal-waiver recheck (`#1570`)**: once a maintainer waives a proven
 `COPILOT_UNAVAILABLE` state

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -189,16 +189,15 @@ check name.
 If GH CLI cannot resolve a run ID, use Actions REST endpoints directly
 for the same run before posting a hold.
 
-**`idd-advisory-convergence` specifically** (when hosted as a required
-check): `workflow_dispatch` does **not** reliably refresh the PR's
-required-check rollup for current HEAD — a manually dispatched run has
-no `pull_request` context to associate with the PR's HEAD SHA (full
-investigation: this repo's dogfooded
+**`idd-advisory-convergence`** (as a required check): `workflow_dispatch`
+does **not** reliably refresh the PR's required-check rollup for current
+HEAD — a manually dispatched run has no `pull_request` context to
+associate with the PR's HEAD SHA (full investigation: this repo's
+dogfooded
 [`.github/workflows/idd-advisory-convergence.yml`](https://github.com/kurone-kito/idd-skill/blob/main/.github/workflows/idd-advisory-convergence.yml)
 header comment — not present in the portable stub this template
-ships). For a stuck or stale rollup entry, apply the rerun mechanic
-above (`gh run rerun <run-id>` on the _existing_ PR-linked run)
-instead of `workflow_dispatch`.
+ships). For a stuck or stale rollup entry, rerun the _existing_
+PR-linked run (`gh run rerun <run-id>`) instead of `workflow_dispatch`.
 
 A second cause: GitHub gates a bot-triggered run (e.g. Copilot's
 `pull_request_review`/`pull_request_review_comment` event) to
@@ -214,23 +213,26 @@ subscription).
 
 **If rerunning the passing non-bot instance alone does not clear the
 rollup (`#1745`)**: a HEAD can carry several `idd-advisory-convergence`
-check-run instances at once (the check fires on `pull_request` plus
+check-run instances (the check fires on `pull_request` plus
 `pull_request_review`/`pull_request_review_comment`, and
 `cancel-in-progress` cancels most of them), and GitHub's own required-check
 rollup can stay pinned to a bot-triggered instance whose **conclusion** is
-`CANCELLED` — distinct from the `action_required` case above. Unlike
-`action_required`, a `CANCELLED`-conclusion bot-triggered instance is
-**not** gated: rerunning it completes normally and does not re-enter
-`action_required` (confirmed by direct experiment, `#1745`). If the
+`CANCELLED`. Unlike `action_required`, a `CANCELLED`-conclusion
+bot-triggered instance is **not** gated: rerunning it completes
+normally and does not re-enter `action_required` (confirmed by direct
+experiment, `#1745`). If the
 non-bot rerun above does not clear the block, rerun every
 `CANCELLED`-conclusion bot-triggered sibling instance for the same HEAD
-next (`gh run rerun <run-id>` on each, one at a time, per the sequential
-rule in the helper-first plan below) — only an `action_required`-conclusion
-instance stays withheld from rerun.
+next (`gh run rerun <run-id>` on each, per the plan below) — only an
+`action_required`-conclusion instance stays withheld from rerun.
+
+Note: this is a known Rulesets platform behavior, not an `idd-skill`
+dedup bug — GitHub can require every same-named instance non-failing,
+not just the dedup-selected latest.
 
 **Helper-first**: prints this diagnosis and ordered rerun plan, read-only
-by default; pass `--apply` to also execute it — the preferred one-shot
-recovery path when a helper runtime is available. `--apply` reruns each
+by default; pass `--apply` to also execute it — the preferred recovery
+path when available. `--apply` reruns each
 rerun-eligible instance in order (recovery-refresh first when one
 applies), waits for each to reach a terminal state before starting the
 next, and stops early as soon as the rollup resolves — never a
@@ -248,8 +250,8 @@ Resolve `<profile-selected-rerun-advisory-convergence-command>` from
 `docs/idd-helper-scripts.md`; do not hardcode `node scripts/...` for
 non-vendored profiles. On `instructions-only` (no helper runtime), fall
 back to the manual sequence: run the diagnostic, then `gh run rerun
-<run-id>` on each plan entry one at a time, waiting for each to finish
-before the next.
+<run-id>` on each plan entry, waiting for each to finish before the
+next.
 
 **Terminal-waiver recheck (`#1570`)**: once a maintainer waives a proven
 `COPILOT_UNAVAILABLE` state


### PR DESCRIPTION
# Summary

Adds a short, clearly-labeled note to `idd-ci.instructions.md`'s
existing `#1745` `gh run rerun` recovery section explaining that on a
Rulesets-protected repository, GitHub's own required-status-check
evaluation may require every same-named `idd-advisory-convergence`
check-run instance at a head SHA to resolve non-failing — not just the
latest instance this repo's own dedup (`selectLatestCheckPerName` in
`protocol-helpers.mts`) already selects correctly. This is a known
GitHub-platform behavior, not an `idd-skill` bug, distinct from the
already-fixed dedup logic.

Documentation-only: no change to `src/scripts/protocol-helpers.mts`'s
dedup/selection logic. The generated `.github/instructions/idd-ci.instructions.md`
copy was regenerated from the canonical `idd-template/` source via
`node scripts/sync-docs.mjs --apply`.

The bundle-review context-ceiling budget that includes `idd-ci.instructions.md`
was extremely tight before this change (97.99% of its 120000-byte cap,
9 bytes of headroom before the 98% hard error), so the new note is
paired with a few small, meaning-preserving compressions of adjacent
existing sentences in the same section, netting a small overall
decrease (bundle-review dropped to 97.97% after this change).

## Linked issue

Closes #2013

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`idd-ci.instructions.md:220-234` (pre-change line numbers) already
documented the manual `gh run rerun` recovery procedure for a
stale/cancelled sibling check-run instance, per `#1745`. What was
missing was an explanation of *why* the recovery is sometimes still
needed even after this repo's own dedup logic already agrees with the
correct verdict — see #2013 for the two reproductions
(`kurone-kito/lints-config` PR #278, `kurone-kito/dotfiles` PR #246)
that motivated this clarification.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
