### PR TITLE
fix(idd-doctor): honor GitHub Rulesets and trustEmptyProtectionReads

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -25,7 +25,11 @@ import {
   POLICY_DEFAULTS,
   parseProjectCommandRows,
 } from './policy-helpers.mjs';
-import { resolveTrustedMarkerActors } from './protocol-helpers.mjs';
+import { fetchGovernanceJson } from './pre-merge-readiness.mjs';
+import {
+  resolveTrustedMarkerActors,
+  summarizeBranchReviewRequirements,
+} from './protocol-helpers.mjs';
 import { loadJson, validate } from './validate-schemas.mjs';
 
 const WORKSHOP_ENTRY_POINTS = ['README.md', 'README.ja.md', 'docs/index.md'];
@@ -2773,12 +2777,24 @@ function checkGithubReadiness(root, requireGithub, report) {
     }
     return;
   }
-  const protection = runCommand(
-    'gh',
-    ['api', `repos/${owner}/${repo}/branches/${branch}/protection`],
-    root,
-  );
-  if (!protection.ok) {
+  const trustEmptyProtectionReads = readTrustEmptyProtectionReads(root);
+  const encodedBranch = encodeURIComponent(branch);
+  let branchRulesRead;
+  let branchProtectionRead;
+  try {
+    branchRulesRead = fetchGovernanceJson(
+      `repos/${owner}/${repo}/rules/branches/${encodedBranch}`,
+      true,
+      trustEmptyProtectionReads,
+      [],
+    );
+    branchProtectionRead = fetchGovernanceJson(
+      `repos/${owner}/${repo}/branches/${encodedBranch}/protection`,
+      false,
+      trustEmptyProtectionReads,
+      {},
+    );
+  } catch {
     const message = `branch protection not readable for ${owner}/${repo}:${branch}`;
     if (requireGithub) {
       report.errors.push(message);
@@ -2787,11 +2803,8 @@ function checkGithubReadiness(root, requireGithub, report) {
     }
     return;
   }
-  let protectionJson;
-  try {
-    protectionJson = JSON.parse(protection.stdout);
-  } catch {
-    const message = 'branch protection response is not valid JSON';
+  if (branchRulesRead.unreadable || branchProtectionRead.unreadable) {
+    const message = `branch protection not readable for ${owner}/${repo}:${branch}`;
     if (requireGithub) {
       report.errors.push(message);
     } else {
@@ -2799,24 +2812,87 @@ function checkGithubReadiness(root, requireGithub, report) {
     }
     return;
   }
-  const requiredChecks = protectionJson.required_status_checks?.contexts ?? [];
-  const strict = protectionJson.required_status_checks?.strict ?? false;
-  if (requiredChecks.length === 0) {
+  const findings = evaluateBranchProtectionFindings(
+    branchRulesRead.value,
+    branchProtectionRead.value,
+  );
+  if (findings.requiredCheckCount === 0) {
     report.warnings.push(
       `branch protection is enabled but no required status checks are configured on ${branch}`,
     );
   } else {
     report.passes.push(
-      `required status checks configured on ${branch} (${requiredChecks.length}, strict=${strict})`,
+      `required status checks configured on ${branch} (${findings.requiredCheckCount}, strict=${findings.requiredChecksStrict})`,
     );
   }
-  const reviewConfig = protectionJson.required_pull_request_reviews;
-  if (!reviewConfig) {
+  if (!findings.reviewPolicyConfigured) {
     report.warnings.push(
       `required pull request reviews are not configured on ${branch}`,
     );
   } else {
     report.passes.push('required pull request review policy is configured');
+  }
+}
+/**
+ * Combine a classic `branches/{branch}/protection` read with a GitHub
+ * Rulesets `rules/branches/{branch}` read into the findings
+ * `checkGithubReadiness` reports. Pure and network-free so the
+ * classic-only / Rulesets-only / both / neither matrix is directly
+ * testable without mocking `gh`.
+ *
+ * Required-check counting reuses the already-exported
+ * `summarizeBranchReviewRequirements()` (`protocol-helpers.mts`), which
+ * already normalizes the field-name differences between classic
+ * `contexts` and a Rulesets `required_status_checks` rule's `parameters`
+ * into one deduplicated name set -- this function adds no separate
+ * name-extraction logic of its own (idd-skill#2010).
+ *
+ * Review-policy presence deliberately stays a presence check, not a
+ * minimum-approval-count check, matching this file's pre-existing
+ * classic-only behavior: a repository that requires a pull request but
+ * configures zero mandatory approvals still counts as configured. The
+ * same presence test is simply widened to also recognize a Rulesets
+ * `pull_request`-type rule.
+ */
+export function evaluateBranchProtectionFindings(
+  branchRules,
+  branchProtection,
+) {
+  const requiredCheckCount = summarizeBranchReviewRequirements(
+    branchRules,
+    branchProtection,
+  ).requiredCheckNames.length;
+  const reviewPolicyConfigured =
+    Boolean(branchProtection.required_pull_request_reviews) ||
+    branchRules.some((rule) => rule?.type === 'pull_request');
+  return {
+    requiredCheckCount,
+    requiredChecksStrict: Boolean(
+      branchProtection.required_status_checks?.strict,
+    ),
+    reviewPolicyConfigured,
+  };
+}
+/**
+ * Root-relative `ciGate.trustEmptyProtectionReads` reader
+ * (idd-skill#2010; #1377 introduced the flag). Deliberately not
+ * `pre-merge-readiness.mts`'s own `readTrustEmptyProtectionReads`, which
+ * reads `.github/idd/config.json` relative to `process.cwd()` --
+ * `idd-doctor.mts` supports `--repo-root <path>`, and this file already
+ * reads the same config file root-relative elsewhere (see
+ * `readCleanupEvidenceTrustedLogins`). Fails closed to `false` on a
+ * missing or unparseable config, matching
+ * `normalizePolicyConfig(null).ciGate.trustEmptyProtectionReads`'s
+ * default.
+ */
+export function readTrustEmptyProtectionReads(root) {
+  try {
+    const config = JSON.parse(
+      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
+    );
+    return config?.ciGate?.trustEmptyProtectionReads === true;
+  } catch {
+    return false;
   }
 }
 function runCommand(command, argv, cwd) {

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -30,6 +30,7 @@ import {
   parsePaginatedGhNdjson,
   resolveTrustedMarkerActors,
   summarizeBranchReviewRequirements,
+  summarizeRequiredCheckMetadata,
 } from './protocol-helpers.mjs';
 import { loadJson, validate } from './validate-schemas.mjs';
 
@@ -2868,7 +2869,13 @@ function checkGithubReadiness(root, requireGithub, report) {
  * rule's own `strict_required_status_checks_policy` parameter, not just
  * classic protection's `strict` field -- a Rulesets-only repository with
  * that policy enabled previously always reported `strict=false`
- * (idd-skill#2010 review).
+ * (idd-skill#2010 review). GitHub's ruleset docs state that flag "will
+ * not take effect unless at least one status check is enabled", so it
+ * only counts here when that same rule's own check list is non-empty --
+ * the same non-empty-check guard `summarizeBranchCurrency()`
+ * (`protocol-helpers.mts`) already applies for the identical reason
+ * (`#1513`), reusing its `summarizeRequiredCheckMetadata()` extraction
+ * rather than a second name-counting implementation.
  */
 export function evaluateBranchProtectionFindings(
   branchRules,
@@ -2884,7 +2891,8 @@ export function evaluateBranchProtectionFindings(
   const rulesetStrict = branchRules.some(
     (rule) =>
       rule?.type === 'required_status_checks' &&
-      Boolean(rule.parameters?.strict_required_status_checks_policy),
+      rule.parameters?.strict_required_status_checks_policy === true &&
+      summarizeRequiredCheckMetadata(rule.parameters ?? {}).names.length > 0,
   );
   return {
     requiredCheckCount: requirements.requiredCheckNames.length,

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -27,6 +27,7 @@ import {
 } from './policy-helpers.mjs';
 import { fetchGovernanceJson } from './pre-merge-readiness.mjs';
 import {
+  parsePaginatedGhNdjson,
   resolveTrustedMarkerActors,
   summarizeBranchReviewRequirements,
 } from './protocol-helpers.mjs';
@@ -2787,12 +2788,14 @@ function checkGithubReadiness(root, requireGithub, report) {
       true,
       trustEmptyProtectionReads,
       [],
+      (path, paginate) => fetchGhApiJsonAt(root, path, paginate),
     );
     branchProtectionRead = fetchGovernanceJson(
       `repos/${owner}/${repo}/branches/${encodedBranch}/protection`,
       false,
       trustEmptyProtectionReads,
       {},
+      (path, paginate) => fetchGhApiJsonAt(root, path, paginate),
     );
   } catch {
     const message = `branch protection not readable for ${owner}/${repo}:${branch}`;
@@ -2816,9 +2819,16 @@ function checkGithubReadiness(root, requireGithub, report) {
     branchRulesRead.value,
     branchProtectionRead.value,
   );
-  if (findings.requiredCheckCount === 0) {
+  if (
+    findings.requiredCheckCount === 0 &&
+    !findings.requiredChecksSourcePinned
+  ) {
     report.warnings.push(
       `branch protection is enabled but no required status checks are configured on ${branch}`,
+    );
+  } else if (findings.requiredCheckCount === 0) {
+    report.passes.push(
+      `required status checks configured on ${branch} via a source-pinned requirement (e.g. a Rulesets "workflows" rule) with no enumerable check name`,
     );
   } else {
     report.passes.push(
@@ -2853,23 +2863,34 @@ function checkGithubReadiness(root, requireGithub, report) {
  * configures zero mandatory approvals still counts as configured. The
  * same presence test is simply widened to also recognize a Rulesets
  * `pull_request`-type rule.
+ *
+ * `requiredChecksStrict` also honors a Rulesets `required_status_checks`
+ * rule's own `strict_required_status_checks_policy` parameter, not just
+ * classic protection's `strict` field -- a Rulesets-only repository with
+ * that policy enabled previously always reported `strict=false`
+ * (idd-skill#2010 review).
  */
 export function evaluateBranchProtectionFindings(
   branchRules,
   branchProtection,
 ) {
-  const requiredCheckCount = summarizeBranchReviewRequirements(
+  const requirements = summarizeBranchReviewRequirements(
     branchRules,
     branchProtection,
-  ).requiredCheckNames.length;
+  );
   const reviewPolicyConfigured =
     Boolean(branchProtection.required_pull_request_reviews) ||
     branchRules.some((rule) => rule?.type === 'pull_request');
+  const rulesetStrict = branchRules.some(
+    (rule) =>
+      rule?.type === 'required_status_checks' &&
+      Boolean(rule.parameters?.strict_required_status_checks_policy),
+  );
   return {
-    requiredCheckCount,
-    requiredChecksStrict: Boolean(
-      branchProtection.required_status_checks?.strict,
-    ),
+    requiredCheckCount: requirements.requiredCheckNames.length,
+    requiredChecksSourcePinned: requirements.requiredCheckSourcePinned,
+    requiredChecksStrict:
+      Boolean(branchProtection.required_status_checks?.strict) || rulesetStrict,
     reviewPolicyConfigured,
   };
 }
@@ -2894,6 +2915,43 @@ export function readTrustEmptyProtectionReads(root) {
   } catch {
     return false;
   }
+}
+/**
+ * Root-scoped `gh api` fetch for {@link fetchGovernanceJson}'s injectable
+ * `fetchJson` parameter. That function's own default fetcher
+ * (`ghApiJson` in `pre-merge-readiness.mts`, via `runGh`/`ghText`) always
+ * runs `gh` from `process.cwd()` with no `cwd` override -- correct for
+ * that file's own CLI, which always operates on the repository it is
+ * invoked from, but `idd-doctor.mts` supports `--repo-root <path>`
+ * targeting a repository (potentially on a different GitHub host) other
+ * than the caller's own working directory, and `gh api` infers its
+ * target host from the current directory absent an explicit
+ * `--hostname`. Route through this file's own `runCommand()` instead,
+ * which already threads `root` as `cwd` for every other `gh` call in
+ * this function (idd-skill#2010 review), so `gh`'s host inference
+ * resolves against the target repository. Mirrors `ghApiJson`'s own
+ * `--paginate --jq '.[]'` NDJSON handling via the shared
+ * `parsePaginatedGhNdjson()`, and shapes a failure's thrown error the
+ * same way a real `execFileSync` failure would (`status`/`stderr`), so
+ * `fetchGovernanceJson()`'s `deriveGhHttpStatus()`-based 404 detection
+ * still works unchanged.
+ */
+function fetchGhApiJsonAt(root, path, paginate) {
+  const argv = paginate
+    ? ['api', path, '--paginate', '--jq', '.[]']
+    : ['api', path];
+  const result = runCommand('gh', argv, root);
+  if (!result.ok) {
+    throw Object.assign(new Error('gh api failed'), {
+      status: 1,
+      stderr: result.stderr ?? '',
+    });
+  }
+  const raw = result.stdout.trim();
+  if (!raw) {
+    return paginate ? [] : {};
+  }
+  return paginate ? parsePaginatedGhNdjson(raw) : JSON.parse(raw);
 }
 function runCommand(command, argv, cwd) {
   try {

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -2741,7 +2741,7 @@ function checkWorkshopExampleRepoBackLink(root, options, report) {
 function checkGithubReadiness(root, requireGithub, report) {
   const repoView = runCommand(
     'gh',
-    ['repo', 'view', '--json', 'owner,name,defaultBranchRef'],
+    ['repo', 'view', '--json', 'owner,name,defaultBranchRef,url'],
     root,
   );
   if (!repoView.ok) {
@@ -2769,6 +2769,7 @@ function checkGithubReadiness(root, requireGithub, report) {
   const owner = parsed.owner?.login;
   const repo = parsed.name;
   const branch = parsed.defaultBranchRef?.name;
+  const ghHostname = resolveTargetGhHostname(parsed.url);
   if (!owner || !repo || !branch) {
     const message =
       'github checks skipped: repository owner/name/default branch is incomplete';
@@ -2789,14 +2790,14 @@ function checkGithubReadiness(root, requireGithub, report) {
       true,
       trustEmptyProtectionReads,
       [],
-      (path, paginate) => fetchGhApiJsonAt(root, path, paginate),
+      (path, paginate) => fetchGhApiJsonAt(root, ghHostname, path, paginate),
     );
     branchProtectionRead = fetchGovernanceJson(
       `repos/${owner}/${repo}/branches/${encodedBranch}/protection`,
       false,
       trustEmptyProtectionReads,
       {},
-      (path, paginate) => fetchGhApiJsonAt(root, path, paginate),
+      (path, paginate) => fetchGhApiJsonAt(root, ghHostname, path, paginate),
     );
   } catch {
     const message = `branch protection not readable for ${owner}/${repo}:${branch}`;
@@ -2925,29 +2926,70 @@ export function readTrustEmptyProtectionReads(root) {
   }
 }
 /**
+ * Derive the `--hostname` value {@link fetchGhApiJsonAt} should pass to
+ * `gh api` from the target repository's own `gh repo view --json url`
+ * result (already fetched once by `checkGithubReadiness`, so this adds
+ * no extra `gh` call). `gh api` resolves its target host from `GH_HOST`
+ * / `--hostname` / the CLI's single authenticated host, defaulting to
+ * `github.com` -- unlike a higher-level subcommand such as `gh repo
+ * view`, it does **not** infer the host from the checked-out
+ * repository's Git remote at all, so routing the request through `cwd:
+ * root` (as every other `gh` call in this function already does) has no
+ * effect on which host `gh api` targets (`gh-exec.mts`'s
+ * `resolveGhApiHostname()` documents the identical `gh api` contract for
+ * its own GHES fix, `#1962`; idd-skill#2010 review, Codex round 2).
+ * `resolveGhApiHostname()` itself is env-based (`GH_HOST`/
+ * `GITHUB_SERVER_URL`) and deliberately does not derive a host from a
+ * git remote, by its own design -- the wrong signal here, since
+ * `idd-doctor --repo-root <path>` may target a repository on a
+ * different host than the calling environment's own default. Deriving
+ * from the target repository's own resolved `url` instead is the
+ * correct, `--repo-root`-specific signal. Returns `undefined` for the
+ * common `github.com` case (and any unparseable URL), so the emitted
+ * argv matches `resolveGhApiHostname()`'s own "no override on
+ * github.com" convention.
+ */
+export function resolveTargetGhHostname(url) {
+  if (!url) {
+    return undefined;
+  }
+  let host;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+  return host && host !== 'github.com' ? host : undefined;
+}
+/**
  * Root-scoped `gh api` fetch for {@link fetchGovernanceJson}'s injectable
  * `fetchJson` parameter. That function's own default fetcher
- * (`ghApiJson` in `pre-merge-readiness.mts`, via `runGh`/`ghText`) always
- * runs `gh` from `process.cwd()` with no `cwd` override -- correct for
- * that file's own CLI, which always operates on the repository it is
- * invoked from, but `idd-doctor.mts` supports `--repo-root <path>`
- * targeting a repository (potentially on a different GitHub host) other
- * than the caller's own working directory, and `gh api` infers its
- * target host from the current directory absent an explicit
- * `--hostname`. Route through this file's own `runCommand()` instead,
- * which already threads `root` as `cwd` for every other `gh` call in
- * this function (idd-skill#2010 review), so `gh`'s host inference
- * resolves against the target repository. Mirrors `ghApiJson`'s own
- * `--paginate --jq '.[]'` NDJSON handling via the shared
- * `parsePaginatedGhNdjson()`, and shapes a failure's thrown error the
- * same way a real `execFileSync` failure would (`status`/`stderr`), so
- * `fetchGovernanceJson()`'s `deriveGhHttpStatus()`-based 404 detection
- * still works unchanged.
+ * (`ghApiJson` in `pre-merge-readiness.mts`, via `runGh`/`ghText`) never
+ * passes `--hostname` at all, so it always targets `gh`'s own default
+ * host resolution -- correct for that file's own CLI, which always
+ * operates on the repository it is invoked from (typically the same
+ * host the calling environment already authenticates against), but
+ * wrong for `idd-doctor.mts`'s `--repo-root <path>`, which can target a
+ * different repository (and GitHub host) than the caller's own working
+ * directory or environment. Pass the `hostname` {@link
+ * resolveTargetGhHostname} resolved from the target repository's own
+ * `gh repo view` result, and route through this file's own
+ * `runCommand()` (already `cwd`-scoped to `root` for every other `gh`
+ * call in this function -- harmless for `gh api`'s own host resolution,
+ * but keeps this call consistent with its siblings). Mirrors
+ * `ghApiJson`'s own `--paginate --jq '.[]'` NDJSON handling via the
+ * shared `parsePaginatedGhNdjson()`, and shapes a failure's thrown error
+ * the same way a real `execFileSync` failure would (`status`/`stderr`),
+ * so `fetchGovernanceJson()`'s `deriveGhHttpStatus()`-based 404
+ * detection still works unchanged.
  */
-function fetchGhApiJsonAt(root, path, paginate) {
-  const argv = paginate
-    ? ['api', path, '--paginate', '--jq', '.[]']
-    : ['api', path];
+function fetchGhApiJsonAt(root, hostname, path, paginate) {
+  const argv = [
+    'api',
+    path,
+    ...(hostname ? ['--hostname', hostname] : []),
+    ...(paginate ? ['--paginate', '--jq', '.[]'] : []),
+  ];
   const result = runCommand('gh', argv, root);
   if (!result.ok) {
     throw Object.assign(new Error('gh api failed'), {

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -2808,7 +2808,7 @@ function checkGithubReadiness(root, requireGithub, report) {
     }
     return;
   }
-  if (branchRulesRead.unreadable || branchProtectionRead.unreadable) {
+  if (isBranchProtectionUnreadable(branchRulesRead, branchProtectionRead)) {
     const message = `branch protection not readable for ${owner}/${repo}:${branch}`;
     if (requireGithub) {
       report.errors.push(message);
@@ -2844,6 +2844,28 @@ function checkGithubReadiness(root, requireGithub, report) {
   } else {
     report.passes.push('required pull request review policy is configured');
   }
+}
+/**
+ * Whether `checkGithubReadiness` should report branch protection as
+ * unreadable, combining both governance reads' outcomes. Only `true` when
+ * **both** the Rulesets read (`rules/branches/{branch}`) and the classic
+ * read (`branches/{branch}/protection`) are unreadable -- matching
+ * idd-skill#2010's acceptance criteria ("When the Rulesets read succeeds,
+ * or the config key is `true`, drop the warning ... instead of returning
+ * early"). A repository on Rulesets-only protection legitimately 404s on
+ * the classic endpoint (GitHub's classic-protection endpoint never
+ * reflects Rulesets-only configuration); requiring only one read to
+ * succeed keeps that case from being misreported as unreadable even when
+ * `ciGate.trustEmptyProtectionReads` is unset (idd-skill#2010 review,
+ * Copilot round). Pure so the classic-only / Rulesets-only / both /
+ * neither matrix is directly testable without mocking `gh`, mirroring
+ * {@link evaluateBranchProtectionFindings}'s own rationale.
+ */
+export function isBranchProtectionUnreadable(
+  branchRulesRead,
+  branchProtectionRead,
+) {
+  return branchRulesRead.unreadable && branchProtectionRead.unreadable;
 }
 /**
  * Combine a classic `branches/{branch}/protection` read with a GitHub

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -5362,7 +5362,7 @@ function maxIsoTimestamp(values) {
   }
   return latest;
 }
-function summarizeRequiredCheckMetadata(parameters) {
+export function summarizeRequiredCheckMetadata(parameters) {
   const names = new Set();
   // #1689: the SPECIFIC subset of `names` whose rule entry is itself
   // source-pinned -- distinct from the aggregate `sourcePinned` flag below,

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -3196,7 +3196,7 @@ function checkGithubReadiness(
     return;
   }
 
-  if (branchRulesRead.unreadable || branchProtectionRead.unreadable) {
+  if (isBranchProtectionUnreadable(branchRulesRead, branchProtectionRead)) {
     const message = `branch protection not readable for ${owner}/${repo}:${branch}`;
     if (requireGithub) {
       report.errors.push(message);
@@ -3267,6 +3267,29 @@ type BranchProtectionReadPayload = NonNullable<
 interface GovernanceReadOutcome<T> {
   value: T;
   unreadable: boolean;
+}
+
+/**
+ * Whether `checkGithubReadiness` should report branch protection as
+ * unreadable, combining both governance reads' outcomes. Only `true` when
+ * **both** the Rulesets read (`rules/branches/{branch}`) and the classic
+ * read (`branches/{branch}/protection`) are unreadable -- matching
+ * idd-skill#2010's acceptance criteria ("When the Rulesets read succeeds,
+ * or the config key is `true`, drop the warning ... instead of returning
+ * early"). A repository on Rulesets-only protection legitimately 404s on
+ * the classic endpoint (GitHub's classic-protection endpoint never
+ * reflects Rulesets-only configuration); requiring only one read to
+ * succeed keeps that case from being misreported as unreadable even when
+ * `ciGate.trustEmptyProtectionReads` is unset (idd-skill#2010 review,
+ * Copilot round). Pure so the classic-only / Rulesets-only / both /
+ * neither matrix is directly testable without mocking `gh`, mirroring
+ * {@link evaluateBranchProtectionFindings}'s own rationale.
+ */
+export function isBranchProtectionUnreadable(
+  branchRulesRead: { unreadable: boolean },
+  branchProtectionRead: { unreadable: boolean },
+): boolean {
+  return branchRulesRead.unreadable && branchProtectionRead.unreadable;
 }
 
 /** Findings the branch-protection check reports for the doctor output. */

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -31,6 +31,7 @@ import {
   parsePaginatedGhNdjson,
   resolveTrustedMarkerActors,
   summarizeBranchReviewRequirements,
+  summarizeRequiredCheckMetadata,
 } from './protocol-helpers.mts';
 import { loadJson, validate } from './validate-schemas.mts';
 
@@ -3307,7 +3308,13 @@ export interface BranchProtectionFindings {
  * rule's own `strict_required_status_checks_policy` parameter, not just
  * classic protection's `strict` field -- a Rulesets-only repository with
  * that policy enabled previously always reported `strict=false`
- * (idd-skill#2010 review).
+ * (idd-skill#2010 review). GitHub's ruleset docs state that flag "will
+ * not take effect unless at least one status check is enabled", so it
+ * only counts here when that same rule's own check list is non-empty --
+ * the same non-empty-check guard `summarizeBranchCurrency()`
+ * (`protocol-helpers.mts`) already applies for the identical reason
+ * (`#1513`), reusing its `summarizeRequiredCheckMetadata()` extraction
+ * rather than a second name-counting implementation.
  */
 export function evaluateBranchProtectionFindings(
   branchRules: BranchRuleReadEntry[],
@@ -3323,7 +3330,8 @@ export function evaluateBranchProtectionFindings(
   const rulesetStrict = branchRules.some(
     (rule) =>
       rule?.type === 'required_status_checks' &&
-      Boolean(rule.parameters?.strict_required_status_checks_policy),
+      rule.parameters?.strict_required_status_checks_policy === true &&
+      summarizeRequiredCheckMetadata(rule.parameters ?? {}).names.length > 0,
   );
   return {
     requiredCheckCount: requirements.requiredCheckNames.length,

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -3120,7 +3120,7 @@ function checkGithubReadiness(
 ) {
   const repoView = runCommand(
     'gh',
-    ['repo', 'view', '--json', 'owner,name,defaultBranchRef'],
+    ['repo', 'view', '--json', 'owner,name,defaultBranchRef,url'],
     root,
   );
   if (!repoView.ok) {
@@ -3137,6 +3137,7 @@ function checkGithubReadiness(
     owner?: { login?: string };
     name?: string;
     defaultBranchRef?: { name?: string };
+    url?: string;
   };
   try {
     parsed = JSON.parse(repoView.stdout);
@@ -3154,6 +3155,7 @@ function checkGithubReadiness(
   const owner = parsed.owner?.login;
   const repo = parsed.name;
   const branch = parsed.defaultBranchRef?.name;
+  const ghHostname = resolveTargetGhHostname(parsed.url);
   if (!owner || !repo || !branch) {
     const message =
       'github checks skipped: repository owner/name/default branch is incomplete';
@@ -3175,14 +3177,14 @@ function checkGithubReadiness(
       true,
       trustEmptyProtectionReads,
       [],
-      (path, paginate) => fetchGhApiJsonAt(root, path, paginate),
+      (path, paginate) => fetchGhApiJsonAt(root, ghHostname, path, paginate),
     );
     branchProtectionRead = fetchGovernanceJson<BranchProtectionReadPayload>(
       `repos/${owner}/${repo}/branches/${encodedBranch}/protection`,
       false,
       trustEmptyProtectionReads,
       {},
-      (path, paginate) => fetchGhApiJsonAt(root, path, paginate),
+      (path, paginate) => fetchGhApiJsonAt(root, ghHostname, path, paginate),
     );
   } catch {
     const message = `branch protection not readable for ${owner}/${repo}:${branch}`;
@@ -3366,33 +3368,78 @@ export function readTrustEmptyProtectionReads(root: string): boolean {
 }
 
 /**
+ * Derive the `--hostname` value {@link fetchGhApiJsonAt} should pass to
+ * `gh api` from the target repository's own `gh repo view --json url`
+ * result (already fetched once by `checkGithubReadiness`, so this adds
+ * no extra `gh` call). `gh api` resolves its target host from `GH_HOST`
+ * / `--hostname` / the CLI's single authenticated host, defaulting to
+ * `github.com` -- unlike a higher-level subcommand such as `gh repo
+ * view`, it does **not** infer the host from the checked-out
+ * repository's Git remote at all, so routing the request through `cwd:
+ * root` (as every other `gh` call in this function already does) has no
+ * effect on which host `gh api` targets (`gh-exec.mts`'s
+ * `resolveGhApiHostname()` documents the identical `gh api` contract for
+ * its own GHES fix, `#1962`; idd-skill#2010 review, Codex round 2).
+ * `resolveGhApiHostname()` itself is env-based (`GH_HOST`/
+ * `GITHUB_SERVER_URL`) and deliberately does not derive a host from a
+ * git remote, by its own design -- the wrong signal here, since
+ * `idd-doctor --repo-root <path>` may target a repository on a
+ * different host than the calling environment's own default. Deriving
+ * from the target repository's own resolved `url` instead is the
+ * correct, `--repo-root`-specific signal. Returns `undefined` for the
+ * common `github.com` case (and any unparseable URL), so the emitted
+ * argv matches `resolveGhApiHostname()`'s own "no override on
+ * github.com" convention.
+ */
+export function resolveTargetGhHostname(
+  url: string | undefined,
+): string | undefined {
+  if (!url) {
+    return undefined;
+  }
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+  return host && host !== 'github.com' ? host : undefined;
+}
+
+/**
  * Root-scoped `gh api` fetch for {@link fetchGovernanceJson}'s injectable
  * `fetchJson` parameter. That function's own default fetcher
- * (`ghApiJson` in `pre-merge-readiness.mts`, via `runGh`/`ghText`) always
- * runs `gh` from `process.cwd()` with no `cwd` override -- correct for
- * that file's own CLI, which always operates on the repository it is
- * invoked from, but `idd-doctor.mts` supports `--repo-root <path>`
- * targeting a repository (potentially on a different GitHub host) other
- * than the caller's own working directory, and `gh api` infers its
- * target host from the current directory absent an explicit
- * `--hostname`. Route through this file's own `runCommand()` instead,
- * which already threads `root` as `cwd` for every other `gh` call in
- * this function (idd-skill#2010 review), so `gh`'s host inference
- * resolves against the target repository. Mirrors `ghApiJson`'s own
- * `--paginate --jq '.[]'` NDJSON handling via the shared
- * `parsePaginatedGhNdjson()`, and shapes a failure's thrown error the
- * same way a real `execFileSync` failure would (`status`/`stderr`), so
- * `fetchGovernanceJson()`'s `deriveGhHttpStatus()`-based 404 detection
- * still works unchanged.
+ * (`ghApiJson` in `pre-merge-readiness.mts`, via `runGh`/`ghText`) never
+ * passes `--hostname` at all, so it always targets `gh`'s own default
+ * host resolution -- correct for that file's own CLI, which always
+ * operates on the repository it is invoked from (typically the same
+ * host the calling environment already authenticates against), but
+ * wrong for `idd-doctor.mts`'s `--repo-root <path>`, which can target a
+ * different repository (and GitHub host) than the caller's own working
+ * directory or environment. Pass the `hostname` {@link
+ * resolveTargetGhHostname} resolved from the target repository's own
+ * `gh repo view` result, and route through this file's own
+ * `runCommand()` (already `cwd`-scoped to `root` for every other `gh`
+ * call in this function -- harmless for `gh api`'s own host resolution,
+ * but keeps this call consistent with its siblings). Mirrors
+ * `ghApiJson`'s own `--paginate --jq '.[]'` NDJSON handling via the
+ * shared `parsePaginatedGhNdjson()`, and shapes a failure's thrown error
+ * the same way a real `execFileSync` failure would (`status`/`stderr`),
+ * so `fetchGovernanceJson()`'s `deriveGhHttpStatus()`-based 404
+ * detection still works unchanged.
  */
 function fetchGhApiJsonAt(
   root: string,
+  hostname: string | undefined,
   path: string,
   paginate: boolean,
 ): unknown {
-  const argv = paginate
-    ? ['api', path, '--paginate', '--jq', '.[]']
-    : ['api', path];
+  const argv = [
+    'api',
+    path,
+    ...(hostname ? ['--hostname', hostname] : []),
+    ...(paginate ? ['--paginate', '--jq', '.[]'] : []),
+  ];
   const result = runCommand('gh', argv, root);
   if (!result.ok) {
     throw Object.assign(new Error('gh api failed'), {

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -3224,19 +3224,31 @@ function checkGithubReadiness(
   }
 }
 
-/** Fields consulted from one `rules/branches/{branch}` rule entry. */
-interface BranchRuleReadEntry {
-  type?: string | null;
-}
+/**
+ * One `rules/branches/{branch}` rule entry, as accepted by
+ * `summarizeBranchReviewRequirements()`'s branch-rules parameter
+ * (`protocol-helpers.mts`). Extracted via `Parameters<>` rather than
+ * duplicated: that helper's own `BranchRuleLike` type is not exported,
+ * and re-declaring a narrower local shape by hand previously drifted
+ * out of sync with what `summarizeBranchReviewRequirements()` actually
+ * reads from `rule.parameters` (idd-skill#2010 review).
+ */
+type BranchRuleReadEntry = NonNullable<
+  Parameters<typeof summarizeBranchReviewRequirements>[0]
+>[number];
 
-/** Fields consulted from a classic `branches/{branch}/protection` payload. */
-interface BranchProtectionReadPayload {
-  required_status_checks?: {
-    contexts?: string[] | null;
-    strict?: unknown;
-  } | null;
-  required_pull_request_reviews?: Record<string, unknown> | null;
-}
+/**
+ * A classic `branches/{branch}/protection` payload, as accepted by
+ * `summarizeBranchReviewRequirements()`'s branch-protection parameter.
+ * Extracted the same way as {@link BranchRuleReadEntry}. Both parameters
+ * are optional (default-valued) on `summarizeBranchReviewRequirements()`
+ * itself, which is why `Parameters<>` alone would include `| undefined`
+ * here; `NonNullable<>` strips that back out since every call site below
+ * always passes a concrete value.
+ */
+type BranchProtectionReadPayload = NonNullable<
+  Parameters<typeof summarizeBranchReviewRequirements>[1]
+>;
 
 /** Outcome of one `fetchGovernanceJson()` read (mirrors its own return shape). */
 interface GovernanceReadOutcome<T> {

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -26,7 +26,11 @@ import {
   POLICY_DEFAULTS,
   parseProjectCommandRows,
 } from './policy-helpers.mts';
-import { resolveTrustedMarkerActors } from './protocol-helpers.mts';
+import { fetchGovernanceJson } from './pre-merge-readiness.mts';
+import {
+  resolveTrustedMarkerActors,
+  summarizeBranchReviewRequirements,
+} from './protocol-helpers.mts';
 import { loadJson, validate } from './validate-schemas.mts';
 
 const WORKSHOP_ENTRY_POINTS = ['README.md', 'README.ja.md', 'docs/index.md'];
@@ -3159,12 +3163,24 @@ function checkGithubReadiness(
     return;
   }
 
-  const protection = runCommand(
-    'gh',
-    ['api', `repos/${owner}/${repo}/branches/${branch}/protection`],
-    root,
-  );
-  if (!protection.ok) {
+  const trustEmptyProtectionReads = readTrustEmptyProtectionReads(root);
+  const encodedBranch = encodeURIComponent(branch);
+  let branchRulesRead: GovernanceReadOutcome<BranchRuleReadEntry[]>;
+  let branchProtectionRead: GovernanceReadOutcome<BranchProtectionReadPayload>;
+  try {
+    branchRulesRead = fetchGovernanceJson<BranchRuleReadEntry[]>(
+      `repos/${owner}/${repo}/rules/branches/${encodedBranch}`,
+      true,
+      trustEmptyProtectionReads,
+      [],
+    );
+    branchProtectionRead = fetchGovernanceJson<BranchProtectionReadPayload>(
+      `repos/${owner}/${repo}/branches/${encodedBranch}/protection`,
+      false,
+      trustEmptyProtectionReads,
+      {},
+    );
+  } catch {
     const message = `branch protection not readable for ${owner}/${repo}:${branch}`;
     if (requireGithub) {
       report.errors.push(message);
@@ -3174,14 +3190,8 @@ function checkGithubReadiness(
     return;
   }
 
-  let protectionJson: {
-    required_status_checks?: { contexts?: string[]; strict?: boolean };
-    required_pull_request_reviews?: unknown;
-  };
-  try {
-    protectionJson = JSON.parse(protection.stdout);
-  } catch {
-    const message = 'branch protection response is not valid JSON';
+  if (branchRulesRead.unreadable || branchProtectionRead.unreadable) {
+    const message = `branch protection not readable for ${owner}/${repo}:${branch}`;
     if (requireGithub) {
       report.errors.push(message);
     } else {
@@ -3190,25 +3200,118 @@ function checkGithubReadiness(
     return;
   }
 
-  const requiredChecks = protectionJson.required_status_checks?.contexts ?? [];
-  const strict = protectionJson.required_status_checks?.strict ?? false;
-  if (requiredChecks.length === 0) {
+  const findings = evaluateBranchProtectionFindings(
+    branchRulesRead.value,
+    branchProtectionRead.value,
+  );
+
+  if (findings.requiredCheckCount === 0) {
     report.warnings.push(
       `branch protection is enabled but no required status checks are configured on ${branch}`,
     );
   } else {
     report.passes.push(
-      `required status checks configured on ${branch} (${requiredChecks.length}, strict=${strict})`,
+      `required status checks configured on ${branch} (${findings.requiredCheckCount}, strict=${findings.requiredChecksStrict})`,
     );
   }
 
-  const reviewConfig = protectionJson.required_pull_request_reviews;
-  if (!reviewConfig) {
+  if (!findings.reviewPolicyConfigured) {
     report.warnings.push(
       `required pull request reviews are not configured on ${branch}`,
     );
   } else {
     report.passes.push('required pull request review policy is configured');
+  }
+}
+
+/** Fields consulted from one `rules/branches/{branch}` rule entry. */
+interface BranchRuleReadEntry {
+  type?: string | null;
+}
+
+/** Fields consulted from a classic `branches/{branch}/protection` payload. */
+interface BranchProtectionReadPayload {
+  required_status_checks?: {
+    contexts?: string[] | null;
+    strict?: unknown;
+  } | null;
+  required_pull_request_reviews?: Record<string, unknown> | null;
+}
+
+/** Outcome of one `fetchGovernanceJson()` read (mirrors its own return shape). */
+interface GovernanceReadOutcome<T> {
+  value: T;
+  unreadable: boolean;
+}
+
+/** Findings the branch-protection check reports for the doctor output. */
+export interface BranchProtectionFindings {
+  requiredCheckCount: number;
+  requiredChecksStrict: boolean;
+  reviewPolicyConfigured: boolean;
+}
+
+/**
+ * Combine a classic `branches/{branch}/protection` read with a GitHub
+ * Rulesets `rules/branches/{branch}` read into the findings
+ * `checkGithubReadiness` reports. Pure and network-free so the
+ * classic-only / Rulesets-only / both / neither matrix is directly
+ * testable without mocking `gh`.
+ *
+ * Required-check counting reuses the already-exported
+ * `summarizeBranchReviewRequirements()` (`protocol-helpers.mts`), which
+ * already normalizes the field-name differences between classic
+ * `contexts` and a Rulesets `required_status_checks` rule's `parameters`
+ * into one deduplicated name set -- this function adds no separate
+ * name-extraction logic of its own (idd-skill#2010).
+ *
+ * Review-policy presence deliberately stays a presence check, not a
+ * minimum-approval-count check, matching this file's pre-existing
+ * classic-only behavior: a repository that requires a pull request but
+ * configures zero mandatory approvals still counts as configured. The
+ * same presence test is simply widened to also recognize a Rulesets
+ * `pull_request`-type rule.
+ */
+export function evaluateBranchProtectionFindings(
+  branchRules: BranchRuleReadEntry[],
+  branchProtection: BranchProtectionReadPayload,
+): BranchProtectionFindings {
+  const requiredCheckCount = summarizeBranchReviewRequirements(
+    branchRules,
+    branchProtection,
+  ).requiredCheckNames.length;
+  const reviewPolicyConfigured =
+    Boolean(branchProtection.required_pull_request_reviews) ||
+    branchRules.some((rule) => rule?.type === 'pull_request');
+  return {
+    requiredCheckCount,
+    requiredChecksStrict: Boolean(
+      branchProtection.required_status_checks?.strict,
+    ),
+    reviewPolicyConfigured,
+  };
+}
+
+/**
+ * Root-relative `ciGate.trustEmptyProtectionReads` reader
+ * (idd-skill#2010; #1377 introduced the flag). Deliberately not
+ * `pre-merge-readiness.mts`'s own `readTrustEmptyProtectionReads`, which
+ * reads `.github/idd/config.json` relative to `process.cwd()` --
+ * `idd-doctor.mts` supports `--repo-root <path>`, and this file already
+ * reads the same config file root-relative elsewhere (see
+ * `readCleanupEvidenceTrustedLogins`). Fails closed to `false` on a
+ * missing or unparseable config, matching
+ * `normalizePolicyConfig(null).ciGate.trustEmptyProtectionReads`'s
+ * default.
+ */
+export function readTrustEmptyProtectionReads(root: string): boolean {
+  try {
+    const config = JSON.parse(
+      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
+    ) as { ciGate?: { trustEmptyProtectionReads?: unknown } } | null;
+    return config?.ciGate?.trustEmptyProtectionReads === true;
+  } catch {
+    return false;
   }
 }
 

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -28,6 +28,7 @@ import {
 } from './policy-helpers.mts';
 import { fetchGovernanceJson } from './pre-merge-readiness.mts';
 import {
+  parsePaginatedGhNdjson,
   resolveTrustedMarkerActors,
   summarizeBranchReviewRequirements,
 } from './protocol-helpers.mts';
@@ -3173,12 +3174,14 @@ function checkGithubReadiness(
       true,
       trustEmptyProtectionReads,
       [],
+      (path, paginate) => fetchGhApiJsonAt(root, path, paginate),
     );
     branchProtectionRead = fetchGovernanceJson<BranchProtectionReadPayload>(
       `repos/${owner}/${repo}/branches/${encodedBranch}/protection`,
       false,
       trustEmptyProtectionReads,
       {},
+      (path, paginate) => fetchGhApiJsonAt(root, path, paginate),
     );
   } catch {
     const message = `branch protection not readable for ${owner}/${repo}:${branch}`;
@@ -3205,9 +3208,16 @@ function checkGithubReadiness(
     branchProtectionRead.value,
   );
 
-  if (findings.requiredCheckCount === 0) {
+  if (
+    findings.requiredCheckCount === 0 &&
+    !findings.requiredChecksSourcePinned
+  ) {
     report.warnings.push(
       `branch protection is enabled but no required status checks are configured on ${branch}`,
+    );
+  } else if (findings.requiredCheckCount === 0) {
+    report.passes.push(
+      `required status checks configured on ${branch} via a source-pinned requirement (e.g. a Rulesets "workflows" rule) with no enumerable check name`,
     );
   } else {
     report.passes.push(
@@ -3259,6 +3269,15 @@ interface GovernanceReadOutcome<T> {
 /** Findings the branch-protection check reports for the doctor output. */
 export interface BranchProtectionFindings {
   requiredCheckCount: number;
+  /**
+   * `true` when a Rulesets `workflows` rule (or any other
+   * source-pinned-but-unresolved requirement `summarizeBranchReviewRequirements()`
+   * detects) requires checks with no enumerable name -- distinct from
+   * `requiredCheckCount === 0` meaning "nothing configured" (idd-skill#2010
+   * review): a branch protected solely by a required-workflows Rulesets
+   * rule has real protection even though it contributes zero names.
+   */
+  requiredChecksSourcePinned: boolean;
   requiredChecksStrict: boolean;
   reviewPolicyConfigured: boolean;
 }
@@ -3283,23 +3302,34 @@ export interface BranchProtectionFindings {
  * configures zero mandatory approvals still counts as configured. The
  * same presence test is simply widened to also recognize a Rulesets
  * `pull_request`-type rule.
+ *
+ * `requiredChecksStrict` also honors a Rulesets `required_status_checks`
+ * rule's own `strict_required_status_checks_policy` parameter, not just
+ * classic protection's `strict` field -- a Rulesets-only repository with
+ * that policy enabled previously always reported `strict=false`
+ * (idd-skill#2010 review).
  */
 export function evaluateBranchProtectionFindings(
   branchRules: BranchRuleReadEntry[],
   branchProtection: BranchProtectionReadPayload,
 ): BranchProtectionFindings {
-  const requiredCheckCount = summarizeBranchReviewRequirements(
+  const requirements = summarizeBranchReviewRequirements(
     branchRules,
     branchProtection,
-  ).requiredCheckNames.length;
+  );
   const reviewPolicyConfigured =
     Boolean(branchProtection.required_pull_request_reviews) ||
     branchRules.some((rule) => rule?.type === 'pull_request');
+  const rulesetStrict = branchRules.some(
+    (rule) =>
+      rule?.type === 'required_status_checks' &&
+      Boolean(rule.parameters?.strict_required_status_checks_policy),
+  );
   return {
-    requiredCheckCount,
-    requiredChecksStrict: Boolean(
-      branchProtection.required_status_checks?.strict,
-    ),
+    requiredCheckCount: requirements.requiredCheckNames.length,
+    requiredChecksSourcePinned: requirements.requiredCheckSourcePinned,
+    requiredChecksStrict:
+      Boolean(branchProtection.required_status_checks?.strict) || rulesetStrict,
     reviewPolicyConfigured,
   };
 }
@@ -3325,6 +3355,48 @@ export function readTrustEmptyProtectionReads(root: string): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Root-scoped `gh api` fetch for {@link fetchGovernanceJson}'s injectable
+ * `fetchJson` parameter. That function's own default fetcher
+ * (`ghApiJson` in `pre-merge-readiness.mts`, via `runGh`/`ghText`) always
+ * runs `gh` from `process.cwd()` with no `cwd` override -- correct for
+ * that file's own CLI, which always operates on the repository it is
+ * invoked from, but `idd-doctor.mts` supports `--repo-root <path>`
+ * targeting a repository (potentially on a different GitHub host) other
+ * than the caller's own working directory, and `gh api` infers its
+ * target host from the current directory absent an explicit
+ * `--hostname`. Route through this file's own `runCommand()` instead,
+ * which already threads `root` as `cwd` for every other `gh` call in
+ * this function (idd-skill#2010 review), so `gh`'s host inference
+ * resolves against the target repository. Mirrors `ghApiJson`'s own
+ * `--paginate --jq '.[]'` NDJSON handling via the shared
+ * `parsePaginatedGhNdjson()`, and shapes a failure's thrown error the
+ * same way a real `execFileSync` failure would (`status`/`stderr`), so
+ * `fetchGovernanceJson()`'s `deriveGhHttpStatus()`-based 404 detection
+ * still works unchanged.
+ */
+function fetchGhApiJsonAt(
+  root: string,
+  path: string,
+  paginate: boolean,
+): unknown {
+  const argv = paginate
+    ? ['api', path, '--paginate', '--jq', '.[]']
+    : ['api', path];
+  const result = runCommand('gh', argv, root);
+  if (!result.ok) {
+    throw Object.assign(new Error('gh api failed'), {
+      status: 1,
+      stderr: result.stderr ?? '',
+    });
+  }
+  const raw = result.stdout.trim();
+  if (!raw) {
+    return paginate ? [] : {};
+  }
+  return paginate ? parsePaginatedGhNdjson(raw) : JSON.parse(raw);
 }
 
 function runCommand(

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -6770,7 +6770,7 @@ function maxIsoTimestamp(values: unknown[]): string | null {
   return latest;
 }
 
-function summarizeRequiredCheckMetadata(
+export function summarizeRequiredCheckMetadata(
   parameters: RequiredCheckParametersLike,
 ) {
   const names = new Set<string>();

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -3333,6 +3333,29 @@ test("evaluateBranchProtectionFindings honors a Rulesets required_status_checks 
   assert.equal(findings.requiredChecksStrict, true);
 });
 
+test('evaluateBranchProtectionFindings ignores a Rulesets strict policy whose own rule has an empty check list, even when another source supplies the counted checks (idd-skill#2010 review, Codex round 2)', () => {
+  // GitHub's ruleset docs: strict_required_status_checks_policy "will not
+  // take effect unless at least one status check is enabled" -- scoped to
+  // that SAME rule's own check list, not the combined count from other
+  // sources. Classic protection supplies the one counted check here, so
+  // requiredCheckCount is 1, but the Rulesets rule claiming strict=true
+  // has zero checks of its own and must not contribute strict=true.
+  const findings = evaluateBranchProtectionFindings(
+    [
+      {
+        type: 'required_status_checks',
+        parameters: {
+          required_status_checks: [],
+          strict_required_status_checks_policy: true,
+        },
+      },
+    ],
+    { required_status_checks: { contexts: ['lint'], strict: false } },
+  );
+  assert.equal(findings.requiredCheckCount, 1);
+  assert.equal(findings.requiredChecksStrict, false);
+});
+
 test('evaluateBranchProtectionFindings strict stays false when neither classic nor Rulesets configures an up-to-date-head policy', () => {
   const findings = evaluateBranchProtectionFindings(
     [

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -3243,6 +3243,7 @@ test('evaluateBranchProtectionFindings counts classic-only required checks and r
   });
   assert.deepEqual(findings, {
     requiredCheckCount: 2,
+    requiredChecksSourcePinned: false,
     requiredChecksStrict: true,
     reviewPolicyConfigured: true,
   });
@@ -3263,6 +3264,7 @@ test('evaluateBranchProtectionFindings counts Rulesets-only required checks and 
   );
   assert.deepEqual(findings, {
     requiredCheckCount: 2,
+    requiredChecksSourcePinned: false,
     requiredChecksStrict: false,
     reviewPolicyConfigured: true,
   });
@@ -3286,6 +3288,7 @@ test('evaluateBranchProtectionFindings unions distinct check names from both sou
   // test -- here neither source configures one, so it stays unconfigured.
   assert.deepEqual(findings, {
     requiredCheckCount: 2,
+    requiredChecksSourcePinned: false,
     requiredChecksStrict: false,
     reviewPolicyConfigured: false,
   });
@@ -3295,9 +3298,55 @@ test('evaluateBranchProtectionFindings reports neither source configured when bo
   const findings = evaluateBranchProtectionFindings([], {});
   assert.deepEqual(findings, {
     requiredCheckCount: 0,
+    requiredChecksSourcePinned: false,
     requiredChecksStrict: false,
     reviewPolicyConfigured: false,
   });
+});
+
+test('evaluateBranchProtectionFindings treats a Rulesets "workflows" rule as configured despite zero enumerable check names (idd-skill#2010 review)', () => {
+  // A branch protected solely by a Rulesets required-workflows rule has
+  // real protection: summarizeBranchReviewRequirements() correctly cannot
+  // contribute a check NAME for it (workflow-based requirements have no
+  // enumerable context), but that must not read as "nothing configured".
+  const findings = evaluateBranchProtectionFindings(
+    [{ type: 'workflows', parameters: {} }],
+    {},
+  );
+  assert.equal(findings.requiredCheckCount, 0);
+  assert.equal(findings.requiredChecksSourcePinned, true);
+});
+
+test("evaluateBranchProtectionFindings honors a Rulesets required_status_checks rule's own strict policy (idd-skill#2010 review)", () => {
+  const findings = evaluateBranchProtectionFindings(
+    [
+      {
+        type: 'required_status_checks',
+        parameters: {
+          required_status_checks: [{ context: 'lint' }],
+          strict_required_status_checks_policy: true,
+        },
+      },
+    ],
+    {},
+  );
+  assert.equal(findings.requiredChecksStrict, true);
+});
+
+test('evaluateBranchProtectionFindings strict stays false when neither classic nor Rulesets configures an up-to-date-head policy', () => {
+  const findings = evaluateBranchProtectionFindings(
+    [
+      {
+        type: 'required_status_checks',
+        parameters: {
+          required_status_checks: [{ context: 'lint' }],
+          strict_required_status_checks_policy: false,
+        },
+      },
+    ],
+    { required_status_checks: { contexts: [], strict: false } },
+  );
+  assert.equal(findings.requiredChecksStrict, false);
 });
 
 test('evaluateBranchProtectionFindings treats a zero-approval classic review requirement as configured (presence, not a minimum-count test)', () => {

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -56,6 +56,7 @@ import {
   readWorktreeGuardEnabled,
   resolveConfiguredHelperRuntimePackageSpec,
   resolveConfiguredHelperRuntimeProfile,
+  resolveTargetGhHostname,
   scanFileForPlaceholders,
   stripMarkdownNonText,
   worktreeGuardWiredAt,
@@ -3429,4 +3430,25 @@ test('readTrustEmptyProtectionReads is true only when ciGate.trustEmptyProtectio
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+// idd-skill#2010 review (Codex round 2): `gh api` never infers its target
+// host from the checked-out repository's Git remote (unlike a higher-level
+// subcommand such as `gh repo view`), so idd-doctor.mts's governance reads
+// must derive and pass an explicit `--hostname` for a GHES-hosted target
+// repository instead of relying on `cwd`.
+test('resolveTargetGhHostname returns undefined for github.com and an absent/unparseable URL', () => {
+  assert.equal(
+    resolveTargetGhHostname('https://github.com/kurone-kito/idd-skill'),
+    undefined,
+  );
+  assert.equal(resolveTargetGhHostname(undefined), undefined);
+  assert.equal(resolveTargetGhHostname('not a url'), undefined);
+});
+
+test('resolveTargetGhHostname resolves a GHES hostname, lowercased', () => {
+  assert.equal(
+    resolveTargetGhHostname('https://GHE.example.com/owner/repo'),
+    'ghe.example.com',
+  );
 });

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -31,6 +31,7 @@ import {
   decodeGithubReadmeBase64,
   emitCleanupBacklogProgress,
   evaluateAutopilotSuitabilityConsistency,
+  evaluateBranchProtectionFindings,
   evaluateDependencyVersionDrift,
   evaluateMarkerPrefixConsistency,
   extractMarkerPrefixes,
@@ -50,6 +51,7 @@ import {
   parseProjectCommandRows,
   parseThresholdsProseHours,
   readCleanupEvidenceTrustedLogins,
+  readTrustEmptyProtectionReads,
   readWorktreeGuardBranchPatterns,
   readWorktreeGuardEnabled,
   resolveConfiguredHelperRuntimePackageSpec,
@@ -3224,6 +3226,134 @@ test('checkDependencyVersionDrift skips silently when node_modules packages are 
     checkDependencyVersionDrift(dir, report);
     assert.equal(report.errors.length, 0);
     assert.equal(report.warnings.length, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// idd-skill#2010: evaluateBranchProtectionFindings combines a classic
+// `branches/{branch}/protection` read with a GitHub Rulesets
+// `rules/branches/{branch}` read. This matrix exercises every source
+// combination `checkGithubReadiness` can see in production, without
+// mocking `gh` -- the function is pure.
+test('evaluateBranchProtectionFindings counts classic-only required checks and review policy', () => {
+  const findings = evaluateBranchProtectionFindings([], {
+    required_status_checks: { contexts: ['lint', 'test'], strict: true },
+    required_pull_request_reviews: { required_approving_review_count: 1 },
+  });
+  assert.deepEqual(findings, {
+    requiredCheckCount: 2,
+    requiredChecksStrict: true,
+    reviewPolicyConfigured: true,
+  });
+});
+
+test('evaluateBranchProtectionFindings counts Rulesets-only required checks and review policy', () => {
+  const findings = evaluateBranchProtectionFindings(
+    [
+      {
+        type: 'required_status_checks',
+        parameters: {
+          required_status_checks: [{ context: 'lint' }, { context: 'test' }],
+        },
+      },
+      { type: 'pull_request', parameters: {} },
+    ],
+    {},
+  );
+  assert.deepEqual(findings, {
+    requiredCheckCount: 2,
+    requiredChecksStrict: false,
+    reviewPolicyConfigured: true,
+  });
+});
+
+test('evaluateBranchProtectionFindings unions distinct check names from both sources without double-counting an overlapping name', () => {
+  const findings = evaluateBranchProtectionFindings(
+    [
+      {
+        type: 'required_status_checks',
+        parameters: { required_status_checks: [{ context: 'lint' }] },
+      },
+    ],
+    {
+      required_status_checks: { contexts: ['lint', 'test'], strict: false },
+      required_pull_request_reviews: null,
+    },
+  );
+  // 'lint' is required by both sources and counts once; 'test' is classic-
+  // only. Review policy comes from the Rulesets rule below in a sibling
+  // test -- here neither source configures one, so it stays unconfigured.
+  assert.deepEqual(findings, {
+    requiredCheckCount: 2,
+    requiredChecksStrict: false,
+    reviewPolicyConfigured: false,
+  });
+});
+
+test('evaluateBranchProtectionFindings reports neither source configured when both reads are empty', () => {
+  const findings = evaluateBranchProtectionFindings([], {});
+  assert.deepEqual(findings, {
+    requiredCheckCount: 0,
+    requiredChecksStrict: false,
+    reviewPolicyConfigured: false,
+  });
+});
+
+test('evaluateBranchProtectionFindings treats a zero-approval classic review requirement as configured (presence, not a minimum-count test)', () => {
+  const findings = evaluateBranchProtectionFindings([], {
+    required_pull_request_reviews: { required_approving_review_count: 0 },
+  });
+  assert.equal(findings.reviewPolicyConfigured, true);
+});
+
+test('readTrustEmptyProtectionReads is false when .github/idd/config.json is absent, lacks ciGate, or is malformed (idd-skill#2010)', () => {
+  const dir = mkdtempSync(
+    join(tmpdir(), 'idd-doctor-trust-empty-protection-reads-'),
+  );
+  try {
+    // No config file at all.
+    assert.equal(readTrustEmptyProtectionReads(dir), false);
+
+    // Config present but no ciGate key.
+    mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(join(dir, '.github/idd/config.json'), JSON.stringify({}));
+    assert.equal(readTrustEmptyProtectionReads(dir), false);
+
+    // ciGate present but trustEmptyProtectionReads explicitly false.
+    writeFileSync(
+      join(dir, '.github/idd/config.json'),
+      JSON.stringify({ ciGate: { trustEmptyProtectionReads: false } }),
+    );
+    assert.equal(readTrustEmptyProtectionReads(dir), false);
+
+    // Malformed JSON must never widen trust beyond the safe default.
+    writeFileSync(join(dir, '.github/idd/config.json'), '{ not json');
+    assert.equal(readTrustEmptyProtectionReads(dir), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readTrustEmptyProtectionReads is true only when ciGate.trustEmptyProtectionReads is exactly true (idd-skill#2010)', () => {
+  const dir = mkdtempSync(
+    join(tmpdir(), 'idd-doctor-trust-empty-protection-reads-true-'),
+  );
+  try {
+    mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(
+      join(dir, '.github/idd/config.json'),
+      JSON.stringify({ ciGate: { trustEmptyProtectionReads: true } }),
+    );
+    assert.equal(readTrustEmptyProtectionReads(dir), true);
+
+    // A truthy-but-non-boolean value must not widen trust (mirrors
+    // pre-merge-readiness.mts's `=== true` comparison).
+    writeFileSync(
+      join(dir, '.github/idd/config.json'),
+      JSON.stringify({ ciGate: { trustEmptyProtectionReads: 'true' } }),
+    );
+    assert.equal(readTrustEmptyProtectionReads(dir), false);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -44,6 +44,7 @@ import {
   formatCleanupBacklogScanProgress,
   hookChainsToGithooksScript,
   hookWiresWorktreeGuard,
+  isBranchProtectionUnreadable,
   isGithubBackLinkHost,
   parseIsoDurationToHours,
   parseLockfileImporterVersion,
@@ -3378,6 +3379,40 @@ test('evaluateBranchProtectionFindings treats a zero-approval classic review req
     required_pull_request_reviews: { required_approving_review_count: 0 },
   });
   assert.equal(findings.reviewPolicyConfigured, true);
+});
+
+// idd-skill#2010 review (Copilot round): isBranchProtectionUnreadable must
+// warn only when BOTH governance reads are unreadable, not when either one
+// is -- a Rulesets-only repository legitimately 404s on the classic
+// `branches/{branch}/protection` endpoint even though its Rulesets read
+// (`rules/branches/{branch}`) succeeds, and that must not be reported as
+// unreadable even with `ciGate.trustEmptyProtectionReads` unset.
+test('isBranchProtectionUnreadable is false when only the Rulesets read succeeds (classic 404, Rulesets-only repository)', () => {
+  assert.equal(
+    isBranchProtectionUnreadable({ unreadable: false }, { unreadable: true }),
+    false,
+  );
+});
+
+test('isBranchProtectionUnreadable is false when only the classic read succeeds (Rulesets 404, classic-only repository)', () => {
+  assert.equal(
+    isBranchProtectionUnreadable({ unreadable: true }, { unreadable: false }),
+    false,
+  );
+});
+
+test('isBranchProtectionUnreadable is false when both reads succeed', () => {
+  assert.equal(
+    isBranchProtectionUnreadable({ unreadable: false }, { unreadable: false }),
+    false,
+  );
+});
+
+test('isBranchProtectionUnreadable is true only when both reads are unreadable', () => {
+  assert.equal(
+    isBranchProtectionUnreadable({ unreadable: true }, { unreadable: true }),
+    true,
+  );
 });
 
 test('readTrustEmptyProtectionReads is false when .github/idd/config.json is absent, lacks ciGate, or is malformed (idd-skill#2010)', () => {


### PR DESCRIPTION
## Summary

`idd-doctor.mts`'s branch-protection check only read the classic
`branches/{branch}/protection` endpoint, so a repository migrated to
GitHub Rulesets was silently treated as unprotected (or "not readable"
under `ciGate.trustEmptyProtectionReads`). Reproduced independently
across four adopter repositories after each migrated `main`'s branch
protection to Rulesets (idd-skill#2010).

- Adds a `rules/branches/{branch}` read alongside the existing classic
  read, both via the already-exported `fetchGovernanceJson()`
  (`pre-merge-readiness.mts`) instead of a new `gh`-invocation path.
- Honors `ciGate.trustEmptyProtectionReads` the same way
  `pre-merge-readiness.mts` already does, via a small root-relative
  reader (`idd-doctor.mts` supports `--repo-root`, so
  `pre-merge-readiness.mts`'s own `process.cwd()`-bound reader would
  read the wrong repository's config here).
- Required-check counting reuses the already-exported
  `summarizeBranchReviewRequirements()` (`protocol-helpers.mts`) to
  merge classic `contexts` with a Rulesets `required_status_checks`
  rule into one deduplicated name set.
- Review-policy detection keeps the existing presence-based check and
  widens it to a Rulesets `pull_request`-type rule.
- `fetchBranchRulesets()` is intentionally not called — see the
  plan comment on #2010 for why (its only consumer resolves ruleset
  bypass-actor detail for reviewer-eligibility analysis in
  `protocol-helpers.mts`, which this diagnostic does not need;
  `rules/branches/{branch}` alone already carries each active rule's
  `type`/`parameters` inline).

## Test plan

- [x] `node --test tests/idd-doctor.test.mts` — new
      `evaluateBranchProtectionFindings()` coverage for the
      classic-only / Rulesets-only / both / neither matrix, plus
      `readTrustEmptyProtectionReads()` fail-closed-default coverage.
- [x] `pnpm run typecheck`
- [x] `pnpm run build` (regenerates `scripts/idd-doctor.mjs`)
- [x] `pnpm run build:check`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `npx cspell lint "**" --no-progress`
- [x] `npx biome check && npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md"`

Closes #2010


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved GitHub readiness checks to evaluate both branch protection rules and repository rulesets.
  * Added detection for required checks, source-pinned workflows, review policies, and strict protection settings.
  * Added configurable handling for empty protection responses.

* **Bug Fixes**
  * Improved reliability when reading branch governance settings, including pagination, encoded branch names, and normalized API failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->