### PR TITLE
docs(issue-authoring): diff placeholders and lint config on resync

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -417,10 +417,15 @@ Ask these checks:
    Compare the actual `{{...}}` token identities per changed file, not
    only the aggregate occurrence count: a same-count one-for-one
    placeholder swap changes what an adopter must substitute without
-   changing the count. Name any file whose placeholder tokens changed,
-   rather than asserting a file needs no placeholder substitution as an
-   unverified default (observed 2026-08-12/13 on an adopter repository,
-   #2012).
+   changing the count. Exclude reference-only meta-docs whose `{{...}}`
+   tokens are deliberately kept literal to document the placeholder
+   syntax itself — the `SCAN_EXCLUDED_PATHS` set in
+   `src/scripts/idd-onboard.mts` (e.g. `docs/onboarding/placeholders.md`)
+   — diffing those would misidentify literal documentation as an
+   outstanding substitution. Name any file whose placeholder tokens
+   changed, rather than asserting a file needs no placeholder
+   substitution as an unverified default (observed 2026-08-12/13 on an
+   adopter repository, #2012).
 
 ## Dependency minimization
 

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -393,21 +393,34 @@ Ask these checks:
    Do not hard-code any single consumer's divergence-tracking mechanism.
 4. When an issue drafts a **template resync or reimport** (pulling a
    newer `idd-template/` revision into a repository that already
-   adopted IDD), consult `idd-template/ONBOARDING.md`'s "Re-importing"
-   section before treating any file as unchanged. Its named-gap
-   paragraph on `.markdownlint.yml` / `.markdownlint-cli2.yaml` /
-   `.cspell.config.yml` documents that an adopter's own rule
-   customizations for these files need a by-hand merge into the new
-   import rather than an assumed carry-forward, and that `--import`
-   reports a `blockedOverwrites` finding instead of silently keeping a
-   same-named local file as-is.
+   adopted IDD), consult `docs/customization.md`'s "Documentation lint
+   compatibility" section before treating `.markdownlint.yml` /
+   `.markdownlint-cli2.yaml` / `.cspell.config.yml` as unchanged — it is
+   part of the same imported bundle, so it resolves in an installed or
+   adopter context, unlike `idd-template/ONBOARDING.md`'s "Re-importing"
+   section, whose source-checkout-relative path does not exist once the
+   authoring skill runs outside this repository. Either section
+   documents the same named gap: an adopter's own rule customizations
+   for these files need a by-hand merge into the new import rather than
+   an assumed carry-forward, and `idd-onboard.mjs --import` reports a
+   `blockedOverwrites` finding instead of silently keeping a same-named
+   local file as-is. From a source checkout of `idd-skill` itself,
+   `idd-template/ONBOARDING.md`'s "Re-importing" section is the more
+   detailed maintainer-facing version of the same guidance.
 5. When drafting a resync issue's Background, run a mechanical
-   placeholder-occurrence diff between the previous import commit's and
-   the new target commit's `idd-template/` trees — a plain `{{...}}`
-   token grep over the changed files, compared across the two
-   revisions — and name any file whose placeholder-occurrence count
-   changed, rather than asserting a file needs no placeholder
-   substitution as an unverified default.
+   placeholder diff against the **upstream `idd-skill` source
+   repository's** `idd-template/` trees at the two relevant refs — the
+   previously-adopted `v<iddVersion>` tag (`iddVersion` is recorded in
+   `.github/idd/config.json`) and the new target release/ref — never a
+   tree inside the target/adopter repository itself, which retains no
+   local `idd-template/` directory of its own once IDD is imported.
+   Compare the actual `{{...}}` token identities per changed file, not
+   only the aggregate occurrence count: a same-count one-for-one
+   placeholder swap changes what an adopter must substitute without
+   changing the count. Name any file whose placeholder tokens changed,
+   rather than asserting a file needs no placeholder substitution as an
+   unverified default (observed 2026-08-12/13 on an adopter repository,
+   #2012).
 
 ## Dependency minimization
 

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -391,6 +391,23 @@ Ask these checks:
    taxonomy. An owner/CODEOWNERS marker or a referenced tracking issue may
    also serve, but the code-comment convention is the recommended default.
    Do not hard-code any single consumer's divergence-tracking mechanism.
+4. When an issue drafts a **template resync or reimport** (pulling a
+   newer `idd-template/` revision into a repository that already
+   adopted IDD), consult `idd-template/ONBOARDING.md`'s "Re-importing"
+   section before treating any file as unchanged. Its named-gap
+   paragraph on `.markdownlint.yml` / `.markdownlint-cli2.yaml` /
+   `.cspell.config.yml` documents that an adopter's own rule
+   customizations for these files need a by-hand merge into the new
+   import rather than an assumed carry-forward, and that `--import`
+   reports a `blockedOverwrites` finding instead of silently keeping a
+   same-named local file as-is.
+5. When drafting a resync issue's Background, run a mechanical
+   placeholder-occurrence diff between the previous import commit's and
+   the new target commit's `idd-template/` trees — a plain `{{...}}`
+   token grep over the changed files, compared across the two
+   revisions — and name any file whose placeholder-occurrence count
+   changed, rather than asserting a file needs no placeholder
+   substitution as an unverified default.
 
 ## Dependency minimization
 

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -432,6 +432,23 @@ Ask these checks:
    taxonomy. An owner/CODEOWNERS marker or a referenced tracking issue may
    also serve, but the code-comment convention is the recommended default.
    Do not hard-code any single consumer's divergence-tracking mechanism.
+4. When an issue drafts a **template resync or reimport** (pulling a
+   newer `idd-template/` revision into a repository that already
+   adopted IDD), consult `idd-template/ONBOARDING.md`'s "Re-importing"
+   section before treating any file as unchanged. Its named-gap
+   paragraph on `.markdownlint.yml` / `.markdownlint-cli2.yaml` /
+   `.cspell.config.yml` documents that an adopter's own rule
+   customizations for these files need a by-hand merge into the new
+   import rather than an assumed carry-forward, and that `--import`
+   reports a `blockedOverwrites` finding instead of silently keeping a
+   same-named local file as-is.
+5. When drafting a resync issue's Background, run a mechanical
+   placeholder-occurrence diff between the previous import commit's and
+   the new target commit's `idd-template/` trees — a plain `{{...}}`
+   token grep over the changed files, compared across the two
+   revisions — and name any file whose placeholder-occurrence count
+   changed, rather than asserting a file needs no placeholder
+   substitution as an unverified default.
 
 ## Alignment with A4.5 Suitability Gate
 

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -434,21 +434,34 @@ Ask these checks:
    Do not hard-code any single consumer's divergence-tracking mechanism.
 4. When an issue drafts a **template resync or reimport** (pulling a
    newer `idd-template/` revision into a repository that already
-   adopted IDD), consult `idd-template/ONBOARDING.md`'s "Re-importing"
-   section before treating any file as unchanged. Its named-gap
-   paragraph on `.markdownlint.yml` / `.markdownlint-cli2.yaml` /
-   `.cspell.config.yml` documents that an adopter's own rule
-   customizations for these files need a by-hand merge into the new
-   import rather than an assumed carry-forward, and that `--import`
-   reports a `blockedOverwrites` finding instead of silently keeping a
-   same-named local file as-is.
+   adopted IDD), consult `docs/customization.md`'s "Documentation lint
+   compatibility" section before treating `.markdownlint.yml` /
+   `.markdownlint-cli2.yaml` / `.cspell.config.yml` as unchanged — it is
+   part of the same imported bundle, so it resolves in an installed or
+   adopter context, unlike `idd-template/ONBOARDING.md`'s "Re-importing"
+   section, whose source-checkout-relative path does not exist once the
+   authoring skill runs outside this repository. Either section
+   documents the same named gap: an adopter's own rule customizations
+   for these files need a by-hand merge into the new import rather than
+   an assumed carry-forward, and `idd-onboard.mjs --import` reports a
+   `blockedOverwrites` finding instead of silently keeping a same-named
+   local file as-is. From a source checkout of `idd-skill` itself,
+   `idd-template/ONBOARDING.md`'s "Re-importing" section is the more
+   detailed maintainer-facing version of the same guidance.
 5. When drafting a resync issue's Background, run a mechanical
-   placeholder-occurrence diff between the previous import commit's and
-   the new target commit's `idd-template/` trees — a plain `{{...}}`
-   token grep over the changed files, compared across the two
-   revisions — and name any file whose placeholder-occurrence count
-   changed, rather than asserting a file needs no placeholder
-   substitution as an unverified default.
+   placeholder diff against the **upstream `idd-skill` source
+   repository's** `idd-template/` trees at the two relevant refs — the
+   previously-adopted `v<iddVersion>` tag (`iddVersion` is recorded in
+   `.github/idd/config.json`) and the new target release/ref — never a
+   tree inside the target/adopter repository itself, which retains no
+   local `idd-template/` directory of its own once IDD is imported.
+   Compare the actual `{{...}}` token identities per changed file, not
+   only the aggregate occurrence count: a same-count one-for-one
+   placeholder swap changes what an adopter must substitute without
+   changing the count. Name any file whose placeholder tokens changed,
+   rather than asserting a file needs no placeholder substitution as an
+   unverified default (observed 2026-08-12/13 on an adopter repository,
+   #2012).
 
 ## Alignment with A4.5 Suitability Gate
 

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -458,10 +458,15 @@ Ask these checks:
    Compare the actual `{{...}}` token identities per changed file, not
    only the aggregate occurrence count: a same-count one-for-one
    placeholder swap changes what an adopter must substitute without
-   changing the count. Name any file whose placeholder tokens changed,
-   rather than asserting a file needs no placeholder substitution as an
-   unverified default (observed 2026-08-12/13 on an adopter repository,
-   #2012).
+   changing the count. Exclude reference-only meta-docs whose `{{...}}`
+   tokens are deliberately kept literal to document the placeholder
+   syntax itself — the `SCAN_EXCLUDED_PATHS` set in
+   `src/scripts/idd-onboard.mts` (e.g. `docs/onboarding/placeholders.md`)
+   — diffing those would misidentify literal documentation as an
+   outstanding substitution. Name any file whose placeholder tokens
+   changed, rather than asserting a file needs no placeholder
+   substitution as an unverified default (observed 2026-08-12/13 on an
+   adopter repository, #2012).
 
 ## Alignment with A4.5 Suitability Gate
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -417,10 +417,15 @@ Ask these checks:
    Compare the actual `{{...}}` token identities per changed file, not
    only the aggregate occurrence count: a same-count one-for-one
    placeholder swap changes what an adopter must substitute without
-   changing the count. Name any file whose placeholder tokens changed,
-   rather than asserting a file needs no placeholder substitution as an
-   unverified default (observed 2026-08-12/13 on an adopter repository,
-   #2012).
+   changing the count. Exclude reference-only meta-docs whose `{{...}}`
+   tokens are deliberately kept literal to document the placeholder
+   syntax itself — the `SCAN_EXCLUDED_PATHS` set in
+   `src/scripts/idd-onboard.mts` (e.g. `docs/onboarding/placeholders.md`)
+   — diffing those would misidentify literal documentation as an
+   outstanding substitution. Name any file whose placeholder tokens
+   changed, rather than asserting a file needs no placeholder
+   substitution as an unverified default (observed 2026-08-12/13 on an
+   adopter repository, #2012).
 
 ## Dependency minimization
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -393,21 +393,34 @@ Ask these checks:
    Do not hard-code any single consumer's divergence-tracking mechanism.
 4. When an issue drafts a **template resync or reimport** (pulling a
    newer `idd-template/` revision into a repository that already
-   adopted IDD), consult `idd-template/ONBOARDING.md`'s "Re-importing"
-   section before treating any file as unchanged. Its named-gap
-   paragraph on `.markdownlint.yml` / `.markdownlint-cli2.yaml` /
-   `.cspell.config.yml` documents that an adopter's own rule
-   customizations for these files need a by-hand merge into the new
-   import rather than an assumed carry-forward, and that `--import`
-   reports a `blockedOverwrites` finding instead of silently keeping a
-   same-named local file as-is.
+   adopted IDD), consult `docs/customization.md`'s "Documentation lint
+   compatibility" section before treating `.markdownlint.yml` /
+   `.markdownlint-cli2.yaml` / `.cspell.config.yml` as unchanged — it is
+   part of the same imported bundle, so it resolves in an installed or
+   adopter context, unlike `idd-template/ONBOARDING.md`'s "Re-importing"
+   section, whose source-checkout-relative path does not exist once the
+   authoring skill runs outside this repository. Either section
+   documents the same named gap: an adopter's own rule customizations
+   for these files need a by-hand merge into the new import rather than
+   an assumed carry-forward, and `idd-onboard.mjs --import` reports a
+   `blockedOverwrites` finding instead of silently keeping a same-named
+   local file as-is. From a source checkout of `idd-skill` itself,
+   `idd-template/ONBOARDING.md`'s "Re-importing" section is the more
+   detailed maintainer-facing version of the same guidance.
 5. When drafting a resync issue's Background, run a mechanical
-   placeholder-occurrence diff between the previous import commit's and
-   the new target commit's `idd-template/` trees — a plain `{{...}}`
-   token grep over the changed files, compared across the two
-   revisions — and name any file whose placeholder-occurrence count
-   changed, rather than asserting a file needs no placeholder
-   substitution as an unverified default.
+   placeholder diff against the **upstream `idd-skill` source
+   repository's** `idd-template/` trees at the two relevant refs — the
+   previously-adopted `v<iddVersion>` tag (`iddVersion` is recorded in
+   `.github/idd/config.json`) and the new target release/ref — never a
+   tree inside the target/adopter repository itself, which retains no
+   local `idd-template/` directory of its own once IDD is imported.
+   Compare the actual `{{...}}` token identities per changed file, not
+   only the aggregate occurrence count: a same-count one-for-one
+   placeholder swap changes what an adopter must substitute without
+   changing the count. Name any file whose placeholder tokens changed,
+   rather than asserting a file needs no placeholder substitution as an
+   unverified default (observed 2026-08-12/13 on an adopter repository,
+   #2012).
 
 ## Dependency minimization
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -391,6 +391,23 @@ Ask these checks:
    taxonomy. An owner/CODEOWNERS marker or a referenced tracking issue may
    also serve, but the code-comment convention is the recommended default.
    Do not hard-code any single consumer's divergence-tracking mechanism.
+4. When an issue drafts a **template resync or reimport** (pulling a
+   newer `idd-template/` revision into a repository that already
+   adopted IDD), consult `idd-template/ONBOARDING.md`'s "Re-importing"
+   section before treating any file as unchanged. Its named-gap
+   paragraph on `.markdownlint.yml` / `.markdownlint-cli2.yaml` /
+   `.cspell.config.yml` documents that an adopter's own rule
+   customizations for these files need a by-hand merge into the new
+   import rather than an assumed carry-forward, and that `--import`
+   reports a `blockedOverwrites` finding instead of silently keeping a
+   same-named local file as-is.
+5. When drafting a resync issue's Background, run a mechanical
+   placeholder-occurrence diff between the previous import commit's and
+   the new target commit's `idd-template/` trees — a plain `{{...}}`
+   token grep over the changed files, compared across the two
+   revisions — and name any file whose placeholder-occurrence count
+   changed, rather than asserting a file needs no placeholder
+   substitution as an unverified default.
 
 ## Dependency minimization
 


### PR DESCRIPTION
# Summary

Adds two checks to the `## Codebase-fidelity validation` list in
`skills/issue-authoring/references/contract.md` (and its manually
mirrored copy `docs/issue-authoring-skill.md`) so a session drafting a
template resync/reimport issue is pointed at guidance that previously
existed but was only discovered empirically during execution:

- Item 4 cross-references `idd-template/ONBOARDING.md`'s "Re-importing"
  section by name for the `.markdownlint.yml` /
  `.markdownlint-cli2.yaml` / `.cspell.config.yml` named-gap case.
- Item 5 instructs a mechanical placeholder-occurrence diff (a plain
  `{{...}}` token grep) between the previous and new import commits'
  `idd-template/` trees, naming any file whose count changed, instead
  of asserting "no placeholder substitution needed" as an unverified
  default.

`node scripts/sync-docs.mjs --apply` regenerated
`.claude/skills/issue-authoring/references/contract.md` from the
canonical bundle to keep that mirror aligned, and
`node scripts/audit-docs.mjs --check` confirms no remaining drift.

## Linked issue

Closes #2012

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Both gaps surfaced while executing a resync issue against an adopter
repository, only during execution rather than while that issue was
drafted. Neither sub-gap had an existing issue tracking it. Full
background is recorded on #2012.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
