### PR TITLE
fix(protocol-helpers): align reviewCurrency's and dispositionEvidence's ack-only classifiers

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -2156,9 +2156,17 @@ export function buildActivitySnapshotSummary(
   );
   // An advisory bot can never anchor "dispositions exist": its own
   // **Accepted**/**Rejected**-shaped replies must not start the
-  // post-disposition window that classifies its later acks.
-  for (const login of advisoryBotLogins) {
-    dispositionAuthorLogins.delete(login);
+  // post-disposition window that classifies its later acks. Excludes via
+  // `isConfiguredAdvisoryBotLogin`, not a plain `Set.has`/`.delete`, so a
+  // `[bot]`-suffix mismatch between `dispositionAuthorLogins` and
+  // `advisoryBotLogins` (e.g. one storing GitHub's suffixed `dual-bot[bot]`
+  // author-login form, the other the supported suffixless `dual-bot` form,
+  // #2014) still excludes the shared login -- the same normalized identity
+  // every other advisory-bot recognition in this file already uses.
+  for (const login of [...dispositionAuthorLogins]) {
+    if (isConfiguredAdvisoryBotLogin(login, advisoryBotLogins)) {
+      dispositionAuthorLogins.delete(login);
+    }
   }
   const isAdvisoryBot = (login) =>
     isConfiguredAdvisoryBotLogin(login, advisoryBotLogins);
@@ -2180,6 +2188,19 @@ export function buildActivitySnapshotSummary(
   // classify the same post-disposition advisory-bot reply the same way.
   const isDispositionMarkerComment = (comment) =>
     isDispositionComment(comment) || isRejectionConfirmedDisposition(comment);
+  // Thread-scoped variant: recognizes the terminal rejection-confirmed
+  // marker only while its own thread is still resolved, mirroring
+  // `hasFreshDisposition`'s identical `threadResolved` gate above -- once a
+  // thread is reopened, the marker's "nothing more to do here" claim is
+  // stale for that thread. Needed specifically for the cross-thread global
+  // scan below (`dispositionCreatedAts`'s `threads.flatMap`), which pools
+  // every thread's replies into one PR-wide anchor: without this gate, a
+  // stale rejection-confirmed reply on a since-reopened thread could still
+  // anchor the window that misclassifies an unrelated, brand-new
+  // advisory-bot comment elsewhere on the PR as ack-only.
+  const isDispositionMarkerCommentForThread = (comment, threadResolved) =>
+    isDispositionComment(comment) ||
+    (threadResolved && isRejectionConfirmedDisposition(comment));
   const filteredComments = comments.filter((comment) => {
     if (!trustedMarkerLogins.has((comment.author?.login ?? '').toLowerCase())) {
       return true;
@@ -2205,7 +2226,10 @@ export function buildActivitySnapshotSummary(
         .filter(
           (comment) =>
             isDispositionAuthor(comment.author?.login) &&
-            isDispositionMarkerComment(comment),
+            isDispositionMarkerCommentForThread(
+              comment,
+              Boolean(thread.isResolved),
+            ),
         )
         .map((comment) => comment.createdAt),
     ),
@@ -2241,7 +2265,10 @@ export function buildActivitySnapshotSummary(
           .filter(
             (comment) =>
               isDispositionAuthor(comment.author?.login) &&
-              isDispositionMarkerComment(comment),
+              isDispositionMarkerCommentForThread(
+                comment,
+                Boolean(thread.isResolved),
+              ),
           )
           .map((comment) => comment.createdAt)
           .filter(isValidIsoTimestamp),
@@ -2625,8 +2652,16 @@ export function summarizeDispositionEvidenceForGate(
   // the "Pre-merge gate invariants" comment above `summarizeDispositionEvidenceForGate`:
   // each of those reacts differently (fail-open vs. fail-closed) to a global
   // change, so this subtraction must stay local to the ack-only diagnostic.
+  // Excludes via `isConfiguredAdvisoryBotLogin`, not a plain `Set.has`, so a
+  // `[bot]`-suffix mismatch between the two configured login sets (e.g.
+  // `iddAgentLogins` storing GitHub's `dual-bot[bot]` author-login form
+  // while `advisoryBotLogins` stores the supported suffixless `dual-bot`
+  // form) still excludes the shared login -- the same normalized identity
+  // every other advisory-bot recognition in this file already uses.
   const ackAnchorAuthorLogins = new Set(
-    [...iddAgentLogins].filter((login) => !advisoryBotLogins.has(login)),
+    [...iddAgentLogins].filter(
+      (login) => !isConfiguredAdvisoryBotLogin(login, advisoryBotLogins),
+    ),
   );
   const normalizedComments = comments
     .map((comment, inputIndex) => ({

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -2168,6 +2168,18 @@ export function buildActivitySnapshotSummary(
         .trim()
         .toLowerCase(),
     );
+  // #2014: `isDispositionComment` alone (the `**Accepted**`/`**Rejected**`
+  // prefixes) misses the terminal `**Rejection confirmed by maintainer**`
+  // marker (`isRejectionConfirmedDisposition`) that E6
+  // (idd-review-triage.instructions.md) posts instead of a fresh
+  // `**Rejected**` re-post once a maintainer agrees an
+  // `**Awaiting maintainer decision**` item needs no action -- a disposition
+  // is a disposition regardless of which of the two terminal shapes it took.
+  // `summarizeDispositionEvidenceForGate`'s `classifyThreadAckOnlyPostDisposition`
+  // already recognizes both; recognize both here too so the two producers
+  // classify the same post-disposition advisory-bot reply the same way.
+  const isDispositionMarkerComment = (comment) =>
+    isDispositionComment(comment) || isRejectionConfirmedDisposition(comment);
   const filteredComments = comments.filter((comment) => {
     if (!trustedMarkerLogins.has((comment.author?.login ?? '').toLowerCase())) {
       return true;
@@ -2185,7 +2197,7 @@ export function buildActivitySnapshotSummary(
       .filter(
         (comment) =>
           isDispositionAuthor(comment.author?.login) &&
-          isDispositionComment(comment),
+          isDispositionMarkerComment(comment),
       )
       .map((comment) => comment.createdAt),
     ...threads.flatMap((thread) =>
@@ -2193,7 +2205,7 @@ export function buildActivitySnapshotSummary(
         .filter(
           (comment) =>
             isDispositionAuthor(comment.author?.login) &&
-            isDispositionComment(comment),
+            isDispositionMarkerComment(comment),
         )
         .map((comment) => comment.createdAt),
     ),
@@ -2206,7 +2218,7 @@ export function buildActivitySnapshotSummary(
     if (!isAdvisoryBot(comment.author?.login)) {
       return false;
     }
-    if (isDispositionComment(comment)) {
+    if (isDispositionMarkerComment(comment)) {
       return false;
     }
     const activityAt = comment.updatedAt ?? comment.createdAt;
@@ -2229,7 +2241,7 @@ export function buildActivitySnapshotSummary(
           .filter(
             (comment) =>
               isDispositionAuthor(comment.author?.login) &&
-              isDispositionComment(comment),
+              isDispositionMarkerComment(comment),
           )
           .map((comment) => comment.createdAt)
           .filter(isValidIsoTimestamp),
@@ -2249,7 +2261,7 @@ export function buildActivitySnapshotSummary(
       if (!isAdvisoryBot(comment.author?.login)) {
         return false;
       }
-      if (isDispositionComment(comment)) {
+      if (isDispositionMarkerComment(comment)) {
         return false;
       }
       const activityAt = effectiveThreadCommentActivityAt(comment);
@@ -2601,6 +2613,21 @@ export function summarizeDispositionEvidenceForGate(
   const prAuthorLogin = String(options.prAuthorLogin ?? '')
     .trim()
     .toLowerCase();
+  // #2014: An advisory bot can never anchor "dispositions exist", mirroring
+  // `buildActivitySnapshotSummary`'s identical `dispositionAuthorLogins`
+  // subtraction above (this file, "An advisory bot can never anchor..."
+  // comment) -- its own `**Accepted**`/`**Rejected**`-shaped reply must not
+  // open the post-disposition window that classifies a later advisory-bot
+  // reply as ack-only. Scoped to ONLY `classifyThreadAckOnlyPostDisposition`'s
+  // own anchor below -- the raw `iddAgentLogins` set is used unchanged
+  // everywhere else in this function (`hasFreshDisposition`,
+  // `outstandingComments`, the generic `dispositionComments` 1:1 pool), per
+  // the "Pre-merge gate invariants" comment above `summarizeDispositionEvidenceForGate`:
+  // each of those reacts differently (fail-open vs. fail-closed) to a global
+  // change, so this subtraction must stay local to the ack-only diagnostic.
+  const ackAnchorAuthorLogins = new Set(
+    [...iddAgentLogins].filter((login) => !advisoryBotLogins.has(login)),
+  );
   const normalizedComments = comments
     .map((comment, inputIndex) => ({
       id: String(comment.id ?? ''),
@@ -2901,7 +2928,7 @@ export function summarizeDispositionEvidenceForGate(
       nodes
         .filter(
           (comment) =>
-            iddAgentLogins.has(
+            ackAnchorAuthorLogins.has(
               String(comment.author?.login ?? '')
                 .trim()
                 .toLowerCase(),

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -2184,10 +2184,13 @@ export function buildActivitySnapshotSummary(
   // `**Awaiting maintainer decision**` item needs no action -- a disposition
   // is a disposition regardless of which of the two terminal shapes it took.
   // `summarizeDispositionEvidenceForGate`'s `classifyThreadAckOnlyPostDisposition`
-  // already recognizes both; recognize both here too so the two producers
-  // classify the same post-disposition advisory-bot reply the same way.
-  const isDispositionMarkerComment = (comment) =>
-    isDispositionComment(comment) || isRejectionConfirmedDisposition(comment);
+  // already recognizes both, but ONLY as a reply on a resolved review thread
+  // (the marker's own contract, `isRejectionConfirmedDisposition`'s doc
+  // comment above). `filteredComments` below are plain top-level PR
+  // comments with no thread/resolved concept at all, so they must keep
+  // using plain `isDispositionComment` -- recognizing the terminal marker
+  // there would accept it as a disposition anchor with no resolved-thread
+  // context to validate it against (Copilot review, #2014 PR #2029).
   // Thread-scoped variant: recognizes the terminal rejection-confirmed
   // marker only while its own thread is still resolved, mirroring
   // `hasFreshDisposition`'s identical `threadResolved` gate above -- once a
@@ -2197,7 +2200,12 @@ export function buildActivitySnapshotSummary(
   // every thread's replies into one PR-wide anchor: without this gate, a
   // stale rejection-confirmed reply on a since-reopened thread could still
   // anchor the window that misclassifies an unrelated, brand-new
-  // advisory-bot comment elsewhere on the PR as ack-only.
+  // advisory-bot comment elsewhere on the PR as ack-only. This is the ONLY
+  // place the combined (`isDispositionComment` OR
+  // `isRejectionConfirmedDisposition`) recognition applies outside a
+  // thread whose `isResolved` is already independently confirmed true.
+  const isDispositionMarkerComment = (comment) =>
+    isDispositionComment(comment) || isRejectionConfirmedDisposition(comment);
   const isDispositionMarkerCommentForThread = (comment, threadResolved) =>
     isDispositionComment(comment) ||
     (threadResolved && isRejectionConfirmedDisposition(comment));
@@ -2218,7 +2226,7 @@ export function buildActivitySnapshotSummary(
       .filter(
         (comment) =>
           isDispositionAuthor(comment.author?.login) &&
-          isDispositionMarkerComment(comment),
+          isDispositionComment(comment),
       )
       .map((comment) => comment.createdAt),
     ...threads.flatMap((thread) =>
@@ -2242,7 +2250,7 @@ export function buildActivitySnapshotSummary(
     if (!isAdvisoryBot(comment.author?.login)) {
       return false;
     }
-    if (isDispositionMarkerComment(comment)) {
+    if (isDispositionComment(comment)) {
       return false;
     }
     const activityAt = comment.updatedAt ?? comment.createdAt;

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -3010,6 +3010,18 @@ export function buildActivitySnapshotSummary(
         .trim()
         .toLowerCase(),
     );
+  // #2014: `isDispositionComment` alone (the `**Accepted**`/`**Rejected**`
+  // prefixes) misses the terminal `**Rejection confirmed by maintainer**`
+  // marker (`isRejectionConfirmedDisposition`) that E6
+  // (idd-review-triage.instructions.md) posts instead of a fresh
+  // `**Rejected**` re-post once a maintainer agrees an
+  // `**Awaiting maintainer decision**` item needs no action -- a disposition
+  // is a disposition regardless of which of the two terminal shapes it took.
+  // `summarizeDispositionEvidenceForGate`'s `classifyThreadAckOnlyPostDisposition`
+  // already recognizes both; recognize both here too so the two producers
+  // classify the same post-disposition advisory-bot reply the same way.
+  const isDispositionMarkerComment = (comment: { body?: string | null }) =>
+    isDispositionComment(comment) || isRejectionConfirmedDisposition(comment);
 
   const filteredComments = comments.filter((comment) => {
     if (!trustedMarkerLogins.has((comment.author?.login ?? '').toLowerCase())) {
@@ -3029,7 +3041,7 @@ export function buildActivitySnapshotSummary(
       .filter(
         (comment) =>
           isDispositionAuthor(comment.author?.login) &&
-          isDispositionComment(comment),
+          isDispositionMarkerComment(comment),
       )
       .map((comment) => comment.createdAt),
     ...threads.flatMap((thread) =>
@@ -3037,7 +3049,7 @@ export function buildActivitySnapshotSummary(
         .filter(
           (comment) =>
             isDispositionAuthor(comment.author?.login) &&
-            isDispositionComment(comment),
+            isDispositionMarkerComment(comment),
         )
         .map((comment) => comment.createdAt),
     ),
@@ -3051,7 +3063,7 @@ export function buildActivitySnapshotSummary(
     if (!isAdvisoryBot(comment.author?.login)) {
       return false;
     }
-    if (isDispositionComment(comment)) {
+    if (isDispositionMarkerComment(comment)) {
       return false;
     }
     const activityAt = comment.updatedAt ?? comment.createdAt;
@@ -3075,7 +3087,7 @@ export function buildActivitySnapshotSummary(
           .filter(
             (comment) =>
               isDispositionAuthor(comment.author?.login) &&
-              isDispositionComment(comment),
+              isDispositionMarkerComment(comment),
           )
           .map((comment) => comment.createdAt)
           .filter(isValidIsoTimestamp),
@@ -3095,7 +3107,7 @@ export function buildActivitySnapshotSummary(
       if (!isAdvisoryBot(comment.author?.login)) {
         return false;
       }
-      if (isDispositionComment(comment)) {
+      if (isDispositionMarkerComment(comment)) {
         return false;
       }
       const activityAt = effectiveThreadCommentActivityAt(comment);
@@ -3493,6 +3505,21 @@ export function summarizeDispositionEvidenceForGate(
   const prAuthorLogin = String(options.prAuthorLogin ?? '')
     .trim()
     .toLowerCase();
+  // #2014: An advisory bot can never anchor "dispositions exist", mirroring
+  // `buildActivitySnapshotSummary`'s identical `dispositionAuthorLogins`
+  // subtraction above (this file, "An advisory bot can never anchor..."
+  // comment) -- its own `**Accepted**`/`**Rejected**`-shaped reply must not
+  // open the post-disposition window that classifies a later advisory-bot
+  // reply as ack-only. Scoped to ONLY `classifyThreadAckOnlyPostDisposition`'s
+  // own anchor below -- the raw `iddAgentLogins` set is used unchanged
+  // everywhere else in this function (`hasFreshDisposition`,
+  // `outstandingComments`, the generic `dispositionComments` 1:1 pool), per
+  // the "Pre-merge gate invariants" comment above `summarizeDispositionEvidenceForGate`:
+  // each of those reacts differently (fail-open vs. fail-closed) to a global
+  // change, so this subtraction must stay local to the ack-only diagnostic.
+  const ackAnchorAuthorLogins = new Set(
+    [...iddAgentLogins].filter((login) => !advisoryBotLogins.has(login)),
+  );
 
   const normalizedComments = comments
     .map((comment, inputIndex) => ({
@@ -3805,7 +3832,7 @@ export function summarizeDispositionEvidenceForGate(
       nodes
         .filter(
           (comment) =>
-            iddAgentLogins.has(
+            ackAnchorAuthorLogins.has(
               String(comment.author?.login ?? '')
                 .trim()
                 .toLowerCase(),

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -3026,10 +3026,13 @@ export function buildActivitySnapshotSummary(
   // `**Awaiting maintainer decision**` item needs no action -- a disposition
   // is a disposition regardless of which of the two terminal shapes it took.
   // `summarizeDispositionEvidenceForGate`'s `classifyThreadAckOnlyPostDisposition`
-  // already recognizes both; recognize both here too so the two producers
-  // classify the same post-disposition advisory-bot reply the same way.
-  const isDispositionMarkerComment = (comment: { body?: string | null }) =>
-    isDispositionComment(comment) || isRejectionConfirmedDisposition(comment);
+  // already recognizes both, but ONLY as a reply on a resolved review thread
+  // (the marker's own contract, `isRejectionConfirmedDisposition`'s doc
+  // comment above). `filteredComments` below are plain top-level PR
+  // comments with no thread/resolved concept at all, so they must keep
+  // using plain `isDispositionComment` -- recognizing the terminal marker
+  // there would accept it as a disposition anchor with no resolved-thread
+  // context to validate it against (Copilot review, #2014 PR #2029).
   // Thread-scoped variant: recognizes the terminal rejection-confirmed
   // marker only while its own thread is still resolved, mirroring
   // `hasFreshDisposition`'s identical `threadResolved` gate above -- once a
@@ -3039,7 +3042,12 @@ export function buildActivitySnapshotSummary(
   // every thread's replies into one PR-wide anchor: without this gate, a
   // stale rejection-confirmed reply on a since-reopened thread could still
   // anchor the window that misclassifies an unrelated, brand-new
-  // advisory-bot comment elsewhere on the PR as ack-only.
+  // advisory-bot comment elsewhere on the PR as ack-only. This is the ONLY
+  // place the combined (`isDispositionComment` OR
+  // `isRejectionConfirmedDisposition`) recognition applies outside a
+  // thread whose `isResolved` is already independently confirmed true.
+  const isDispositionMarkerComment = (comment: { body?: string | null }) =>
+    isDispositionComment(comment) || isRejectionConfirmedDisposition(comment);
   const isDispositionMarkerCommentForThread = (
     comment: { body?: string | null },
     threadResolved: boolean,
@@ -3065,7 +3073,7 @@ export function buildActivitySnapshotSummary(
       .filter(
         (comment) =>
           isDispositionAuthor(comment.author?.login) &&
-          isDispositionMarkerComment(comment),
+          isDispositionComment(comment),
       )
       .map((comment) => comment.createdAt),
     ...threads.flatMap((thread) =>
@@ -3090,7 +3098,7 @@ export function buildActivitySnapshotSummary(
     if (!isAdvisoryBot(comment.author?.login)) {
       return false;
     }
-    if (isDispositionMarkerComment(comment)) {
+    if (isDispositionComment(comment)) {
       return false;
     }
     const activityAt = comment.updatedAt ?? comment.createdAt;

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2998,9 +2998,17 @@ export function buildActivitySnapshotSummary(
   );
   // An advisory bot can never anchor "dispositions exist": its own
   // **Accepted**/**Rejected**-shaped replies must not start the
-  // post-disposition window that classifies its later acks.
-  for (const login of advisoryBotLogins) {
-    dispositionAuthorLogins.delete(login);
+  // post-disposition window that classifies its later acks. Excludes via
+  // `isConfiguredAdvisoryBotLogin`, not a plain `Set.has`/`.delete`, so a
+  // `[bot]`-suffix mismatch between `dispositionAuthorLogins` and
+  // `advisoryBotLogins` (e.g. one storing GitHub's suffixed `dual-bot[bot]`
+  // author-login form, the other the supported suffixless `dual-bot` form,
+  // #2014) still excludes the shared login -- the same normalized identity
+  // every other advisory-bot recognition in this file already uses.
+  for (const login of [...dispositionAuthorLogins]) {
+    if (isConfiguredAdvisoryBotLogin(login, advisoryBotLogins)) {
+      dispositionAuthorLogins.delete(login);
+    }
   }
   const isAdvisoryBot = (login: unknown) =>
     isConfiguredAdvisoryBotLogin(login, advisoryBotLogins);
@@ -3022,6 +3030,22 @@ export function buildActivitySnapshotSummary(
   // classify the same post-disposition advisory-bot reply the same way.
   const isDispositionMarkerComment = (comment: { body?: string | null }) =>
     isDispositionComment(comment) || isRejectionConfirmedDisposition(comment);
+  // Thread-scoped variant: recognizes the terminal rejection-confirmed
+  // marker only while its own thread is still resolved, mirroring
+  // `hasFreshDisposition`'s identical `threadResolved` gate above -- once a
+  // thread is reopened, the marker's "nothing more to do here" claim is
+  // stale for that thread. Needed specifically for the cross-thread global
+  // scan below (`dispositionCreatedAts`'s `threads.flatMap`), which pools
+  // every thread's replies into one PR-wide anchor: without this gate, a
+  // stale rejection-confirmed reply on a since-reopened thread could still
+  // anchor the window that misclassifies an unrelated, brand-new
+  // advisory-bot comment elsewhere on the PR as ack-only.
+  const isDispositionMarkerCommentForThread = (
+    comment: { body?: string | null },
+    threadResolved: boolean,
+  ) =>
+    isDispositionComment(comment) ||
+    (threadResolved && isRejectionConfirmedDisposition(comment));
 
   const filteredComments = comments.filter((comment) => {
     if (!trustedMarkerLogins.has((comment.author?.login ?? '').toLowerCase())) {
@@ -3049,7 +3073,10 @@ export function buildActivitySnapshotSummary(
         .filter(
           (comment) =>
             isDispositionAuthor(comment.author?.login) &&
-            isDispositionMarkerComment(comment),
+            isDispositionMarkerCommentForThread(
+              comment,
+              Boolean(thread.isResolved),
+            ),
         )
         .map((comment) => comment.createdAt),
     ),
@@ -3087,7 +3114,10 @@ export function buildActivitySnapshotSummary(
           .filter(
             (comment) =>
               isDispositionAuthor(comment.author?.login) &&
-              isDispositionMarkerComment(comment),
+              isDispositionMarkerCommentForThread(
+                comment,
+                Boolean(thread.isResolved),
+              ),
           )
           .map((comment) => comment.createdAt)
           .filter(isValidIsoTimestamp),
@@ -3517,8 +3547,16 @@ export function summarizeDispositionEvidenceForGate(
   // the "Pre-merge gate invariants" comment above `summarizeDispositionEvidenceForGate`:
   // each of those reacts differently (fail-open vs. fail-closed) to a global
   // change, so this subtraction must stay local to the ack-only diagnostic.
+  // Excludes via `isConfiguredAdvisoryBotLogin`, not a plain `Set.has`, so a
+  // `[bot]`-suffix mismatch between the two configured login sets (e.g.
+  // `iddAgentLogins` storing GitHub's `dual-bot[bot]` author-login form
+  // while `advisoryBotLogins` stores the supported suffixless `dual-bot`
+  // form) still excludes the shared login -- the same normalized identity
+  // every other advisory-bot recognition in this file already uses.
   const ackAnchorAuthorLogins = new Set(
-    [...iddAgentLogins].filter((login) => !advisoryBotLogins.has(login)),
+    [...iddAgentLogins].filter(
+      (login) => !isConfiguredAdvisoryBotLogin(login, advisoryBotLogins),
+    ),
   );
 
   const normalizedComments = comments

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -286,7 +286,7 @@ test('the marker-recognition fix only anchors a rejection-confirmed reply on a s
   // disposition from a reopened thread into an unrelated new advisory-bot
   // comment's classification.
   const reopenedThread = {
-    id: 'thread-reopened-rcbm',
+    id: 'thread-reopened-rejection-confirmed',
     isResolved: false,
     updatedAt: '',
     comments: {

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -1,0 +1,187 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  buildActivitySnapshotSummary,
+  summarizeDispositionEvidenceForGate,
+} from '../src/scripts/protocol-helpers.mts';
+
+// #2014: `buildActivitySnapshotSummary` (the `reviewCurrency` producer) and
+// `summarizeDispositionEvidenceForGate` (the `dispositionEvidence` producer)
+// both classify a post-disposition advisory-bot reply as "ack-only", but used
+// to compute that classification with structurally different logic that could
+// disagree on the identical PR state. This file exercises both producers
+// side-by-side against the same thread fixture and asserts they agree.
+//
+// Two of the four reported asymmetries are fixed here (see the PR body for
+// the other two, left as intentional scope differences):
+//   1. Anchor-set asymmetry -- an advisory bot must never anchor "a
+//      disposition exists" in either producer (`buildActivitySnapshotSummary`
+//      already subtracted `advisoryBotLogins` from its disposition-author
+//      set; `summarizeDispositionEvidenceForGate`'s ack-only anchor did not).
+//   2. Marker-recognition asymmetry -- the terminal
+//      `**Rejection confirmed by maintainer**` disposition
+//      (`isRejectionConfirmedDisposition`) must be recognized by both
+//      producers' ack-only anchors, not just `summarizeDispositionEvidenceForGate`'s.
+
+test('reviewCurrency and dispositionEvidence agree a shared advisory/IDD-agent login cannot anchor a disposition (#2014)', () => {
+  // `dual-bot` is configured as BOTH a trusted IDD-agent/marker login AND an
+  // advisory-bot login (a plausible overlap, e.g. a shared automation
+  // account) -- its own `**Accepted**` reply must not anchor "a disposition
+  // exists" for the ack-only classifier in either producer, so a genuine
+  // advisory bot's later courtesy reply still counts as real new activity
+  // that keeps the thread blocking.
+  const thread = {
+    id: 'thread-dual-bot-anchor',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'TC-1',
+          author: { login: 'reviewer-a' },
+          body: 'please double check this',
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T00:00:00Z',
+        },
+        {
+          id: 'TC-2',
+          author: { login: 'dual-bot' },
+          body: '**Accepted** — looks fine.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'TC-3',
+          author: { login: 'coderabbitai[bot]' },
+          body: 'Thanks for confirming.',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const dispositionSummary = summarizeDispositionEvidenceForGate(
+    { comments: [], threads: [thread] },
+    {
+      iddAgentLogins: ['dual-bot'],
+      advisoryBotLogins: ['dual-bot', 'coderabbitai[bot]'],
+      snapshotBoundaryAt: '2026-05-12T01:00:00Z',
+    },
+  );
+  const activitySummary = buildActivitySnapshotSummary(
+    { comments: [], reviews: [], threads: [thread], checks: [] },
+    {
+      trustedMarkerLogins: ['dual-bot'],
+      advisoryBotLogins: ['dual-bot', 'coderabbitai[bot]'],
+      advisoryBotLoginsSource: 'config',
+      dispositionAuthorLogins: ['dual-bot'],
+    },
+  );
+
+  // dispositionEvidence: the thread still blocks -- `dual-bot`'s own reply
+  // cannot count as a disposition anchor once it is also an advisory bot.
+  assert.equal(dispositionSummary.route, 'return-to-e1');
+  assert.equal(dispositionSummary.blockingCount, 1);
+  assert.equal(
+    dispositionSummary.missingThreads[0].reason,
+    'missing-fresh-disposition',
+  );
+  assert.equal(
+    dispositionSummary.missingThreads[0].ackOnlyPostDisposition,
+    false,
+  );
+  assert.equal(dispositionSummary.soleCauseAckOnlyPostDisposition, false);
+
+  // reviewCurrency: agrees -- CodeRabbit's reply is genuine new activity,
+  // not an ack-only courtesy reply, since there is no valid anchor either.
+  assert.deepEqual(activitySummary.ackOnly.items, []);
+  assert.equal(
+    activitySummary.effective.maxActivityUpdatedAt,
+    '2026-05-12T02:00:00Z',
+  );
+});
+
+test('reviewCurrency and dispositionEvidence agree a rejection-confirmed-by-maintainer reply anchors post-disposition acks (#2014)', () => {
+  // The AMD -> maintainer-agrees flow posts `**Rejection confirmed by
+  // maintainer**` instead of a fresh `**Rejected**` re-post
+  // (idd-review-triage.instructions.md E6). Both producers must recognize it
+  // as a real disposition anchor, or the advisory bot's later courtesy reply
+  // is misclassified as new blocking activity by whichever producer misses
+  // the marker.
+  const thread = {
+    id: 'thread-rejection-confirmed',
+    isResolved: true,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'RC-1',
+          author: { login: 'reviewer-a' },
+          body: 'please reconsider this',
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T00:00:00Z',
+        },
+        {
+          id: 'RC-2',
+          author: { login: 'idd-bot' },
+          body: '**Rejection confirmed by maintainer** — agreed, no action needed.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'RC-3',
+          author: { login: 'coderabbitai[bot]' },
+          body: 'Thanks for confirming.',
+          createdAt: '2026-05-12T02:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+        },
+      ],
+    },
+  };
+
+  const dispositionSummary = summarizeDispositionEvidenceForGate(
+    { comments: [], threads: [thread] },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+      snapshotBoundaryAt: '2026-05-12T01:00:00Z',
+    },
+  );
+  const activitySummary = buildActivitySnapshotSummary(
+    { comments: [], reviews: [], threads: [thread], checks: [] },
+    {
+      trustedMarkerLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+      advisoryBotLoginsSource: 'config',
+      dispositionAuthorLogins: ['idd-bot'],
+    },
+  );
+
+  // dispositionEvidence already recognized the marker before this fix.
+  assert.equal(dispositionSummary.route, 'return-to-e1');
+  assert.equal(dispositionSummary.blockingCount, 1);
+  assert.equal(
+    dispositionSummary.missingThreads[0].reason,
+    'missing-fresh-disposition',
+  );
+  assert.equal(
+    dispositionSummary.missingThreads[0].ackOnlyPostDisposition,
+    true,
+  );
+  assert.equal(dispositionSummary.soleCauseAckOnlyPostDisposition, true);
+
+  // reviewCurrency now agrees: CodeRabbit's reply is ack-only, so it is
+  // excluded from the effective (blocking) activity timestamp.
+  assert.deepEqual(
+    activitySummary.ackOnly.items.map((item) => [item.kind, item.id]),
+    [['thread-reply', 'RC-3']],
+  );
+  assert.equal(activitySummary.maxActivityUpdatedAt, '2026-05-12T02:00:00Z');
+  assert.equal(
+    activitySummary.effective.maxActivityUpdatedAt,
+    '2026-05-12T00:30:00Z',
+  );
+});

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -185,3 +185,163 @@ test('reviewCurrency and dispositionEvidence agree a rejection-confirmed-by-main
     '2026-05-12T00:30:00Z',
   );
 });
+
+// Codex review findings on this PR (#2014), both verified against source
+// before accepting.
+
+test('the anchor-set fix honors the [bot]-suffix cross-product (Codex P1, #2014)', () => {
+  // `iddAgentLogins` carries GitHub's suffixed `dual-bot[bot]` author-login
+  // form while `advisoryBotLogins` is configured with the supported
+  // suffixless `dual-bot` form (or vice versa) -- a plain `Set.has` lookup
+  // would miss the match and let the advisory bot anchor a disposition
+  // anyway. The exclusion must use the same suffix-normalized identity
+  // (`isConfiguredAdvisoryBotLogin`) both producers already use elsewhere.
+  const make = (iddAgentLogin: string, advisoryBotLogin: string) => {
+    const thread = {
+      id: 'thread-dual-bot-suffix',
+      isResolved: true,
+      updatedAt: '',
+      comments: {
+        pageInfo: { hasNextPage: false },
+        nodes: [
+          {
+            id: 'TC-1',
+            author: { login: 'reviewer-a' },
+            body: 'please double check this',
+            createdAt: '2026-05-12T00:00:00Z',
+            updatedAt: '2026-05-12T00:00:00Z',
+          },
+          {
+            id: 'TC-2',
+            // GitHub always reports a bot's actual login with the [bot]
+            // suffix; the configured `iddAgentLogins`/`advisoryBotLogins`
+            // values below may or may not match this literally.
+            author: { login: 'dual-bot[bot]' },
+            body: '**Accepted** — looks fine.',
+            createdAt: '2026-05-12T00:30:00Z',
+            updatedAt: '2026-05-12T00:30:00Z',
+          },
+          {
+            id: 'TC-3',
+            author: { login: 'coderabbitai[bot]' },
+            body: 'Thanks for confirming.',
+            createdAt: '2026-05-12T02:00:00Z',
+            updatedAt: '2026-05-12T02:00:00Z',
+          },
+        ],
+      },
+    };
+
+    const dispositionSummary = summarizeDispositionEvidenceForGate(
+      { comments: [], threads: [thread] },
+      {
+        iddAgentLogins: [iddAgentLogin],
+        advisoryBotLogins: [advisoryBotLogin, 'coderabbitai[bot]'],
+        snapshotBoundaryAt: '2026-05-12T01:00:00Z',
+      },
+    );
+    const activitySummary = buildActivitySnapshotSummary(
+      { comments: [], reviews: [], threads: [thread], checks: [] },
+      {
+        trustedMarkerLogins: [iddAgentLogin],
+        advisoryBotLogins: [advisoryBotLogin, 'coderabbitai[bot]'],
+        advisoryBotLoginsSource: 'config',
+        dispositionAuthorLogins: [iddAgentLogin],
+      },
+    );
+    return { dispositionSummary, activitySummary };
+  };
+
+  // `iddAgentLogin` stays pinned to the actual GitHub-reported author form
+  // (`dual-bot[bot]`) across both cases -- only `advisoryBotLogin`'s
+  // suffix form varies, isolating the exclusion fix under test from the
+  // unrelated (and already-suffix-consistent) disposition-author
+  // recognition.
+  for (const [iddAgentLogin, advisoryBotLogin] of [
+    ['dual-bot[bot]', 'dual-bot'],
+    ['dual-bot[bot]', 'dual-bot[bot]'],
+  ] as const) {
+    const { dispositionSummary, activitySummary } = make(
+      iddAgentLogin,
+      advisoryBotLogin,
+    );
+    assert.equal(
+      dispositionSummary.missingThreads[0].ackOnlyPostDisposition,
+      false,
+      `advisory-bot config ${advisoryBotLogin} should exclude author dual-bot[bot] from anchoring`,
+    );
+    assert.deepEqual(
+      activitySummary.ackOnly.items,
+      [],
+      `advisory-bot config ${advisoryBotLogin} should exclude author dual-bot[bot] from anchoring`,
+    );
+  }
+});
+
+test('the marker-recognition fix only anchors a rejection-confirmed reply on a still-resolved thread (Codex P2, #2014)', () => {
+  // A thread carrying `**Rejection confirmed by maintainer**` that is later
+  // reopened must stop anchoring the global post-disposition window --
+  // `hasFreshDisposition` already stops recognizing the marker once a
+  // thread is reopened; the global ack-only anchor must not leak a stale
+  // disposition from a reopened thread into an unrelated new advisory-bot
+  // comment's classification.
+  const reopenedThread = {
+    id: 'thread-reopened-rcbm',
+    isResolved: false,
+    updatedAt: '',
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: [
+        {
+          id: 'RO-1',
+          author: { login: 'reviewer-a' },
+          body: 'please reconsider this',
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T00:00:00Z',
+        },
+        {
+          id: 'RO-2',
+          author: { login: 'idd-bot' },
+          body: '**Rejection confirmed by maintainer** — agreed, no action needed.',
+          createdAt: '2026-05-12T00:30:00Z',
+          updatedAt: '2026-05-12T00:30:00Z',
+        },
+        {
+          id: 'RO-3',
+          author: { login: 'reviewer-a' },
+          body: 'Actually, reopening -- I disagree now.',
+          createdAt: '2026-05-12T01:00:00Z',
+          updatedAt: '2026-05-12T01:00:00Z',
+        },
+      ],
+    },
+  };
+  const newFinding = {
+    id: 'C-NEW',
+    author: { login: 'coderabbitai[bot]' },
+    body: 'New finding: consider tightening this check.',
+    createdAt: '2026-05-12T02:00:00Z',
+    updatedAt: '2026-05-12T02:00:00Z',
+  };
+
+  const activitySummary = buildActivitySnapshotSummary(
+    {
+      comments: [newFinding],
+      reviews: [],
+      threads: [reopenedThread],
+      checks: [],
+    },
+    {
+      trustedMarkerLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+      advisoryBotLoginsSource: 'config',
+      dispositionAuthorLogins: ['idd-bot'],
+    },
+  );
+
+  // The stale rejection-confirmed reply on the now-reopened thread must not
+  // anchor a post-disposition window at all, so CodeRabbit's brand-new
+  // finding is genuine new activity, not a misclassified courtesy ack.
+  assert.equal(activitySummary.ackOnly.dispositionsPresent, false);
+  assert.deepEqual(activitySummary.ackOnly.items, []);
+});

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -345,3 +345,55 @@ test('the marker-recognition fix only anchors a rejection-confirmed reply on a s
   assert.equal(activitySummary.ackOnly.dispositionsPresent, false);
   assert.deepEqual(activitySummary.ackOnly.items, []);
 });
+
+test('a top-level rejection-confirmed comment does not anchor the ack-only window (Copilot, #2014 PR #2029)', () => {
+  // `**Rejection confirmed by maintainer**` is only a valid disposition when
+  // it is a reply on a resolved review thread (`isRejectionConfirmedDisposition`'s
+  // doc comment). A plain top-level PR comment has no thread/resolved
+  // concept to validate the marker against, so it must NOT open the
+  // post-disposition ack-only window -- matching
+  // `summarizeDispositionEvidenceForGate`'s regular-comment pool
+  // (`dispositionComments`), which has only ever recognized
+  // `isDispositionComment` (`**Accepted**`/`**Rejected**`) for non-thread
+  // comments. Recognizing the marker here too would let a misplaced/quoted
+  // marker on an ordinary issue comment open the PR-wide ack window and
+  // suppress a genuinely new advisory-bot finding below.
+  const misplacedMarker = {
+    id: 'TL-1',
+    author: { login: 'idd-bot' },
+    body: '**Rejection confirmed by maintainer** — agreed, no action needed.',
+    createdAt: '2026-05-12T00:00:00Z',
+    updatedAt: '2026-05-12T00:00:00Z',
+  };
+  const newFinding = {
+    id: 'TL-2',
+    author: { login: 'coderabbitai[bot]' },
+    body: 'New finding: consider tightening this check.',
+    createdAt: '2026-05-12T01:00:00Z',
+    updatedAt: '2026-05-12T01:00:00Z',
+  };
+
+  const activitySummary = buildActivitySnapshotSummary(
+    {
+      comments: [misplacedMarker, newFinding],
+      reviews: [],
+      threads: [],
+      checks: [],
+    },
+    {
+      trustedMarkerLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+      advisoryBotLoginsSource: 'config',
+      dispositionAuthorLogins: ['idd-bot'],
+    },
+  );
+
+  // No valid disposition anchor exists at the top level, so CodeRabbit's
+  // new finding is genuine new activity, not a misclassified courtesy ack.
+  assert.equal(activitySummary.ackOnly.dispositionsPresent, false);
+  assert.deepEqual(activitySummary.ackOnly.items, []);
+  assert.equal(
+    activitySummary.effective.maxActivityUpdatedAt,
+    '2026-05-12T01:00:00Z',
+  );
+});


### PR DESCRIPTION
## Summary

`buildActivitySnapshotSummary` (the `reviewCurrency` producer) and
`summarizeDispositionEvidenceForGate` (the `dispositionEvidence` producer)
both classify a post-disposition advisory-bot reply as "ack-only", but
computed that classification with structurally different anchor logic, so
the same PR state could produce disagreeing verdicts. This aligns two of
the four reported asymmetries and documents why the other two are
legitimate scope differences.

## What changed

1. **Anchor-set asymmetry (aligned).** `classifyThreadAckOnlyPostDisposition`
   now excludes any login that is also configured as an advisory bot from
   anchoring "a disposition exists" — mirroring
   `buildActivitySnapshotSummary`'s existing `dispositionAuthorLogins`
   subtraction. The exclusion is a local `ackAnchorAuthorLogins` set used
   only inside this one anchor computation; every other
   `iddAgentLogins`-keyed check in the function (`hasFreshDisposition`, the
   outstanding-comments pool, the generic disposition-comment pool) is left
   untouched, since the file's own invariants note that each reacts
   differently to a global recognition change.
2. **Marker-recognition asymmetry (aligned).** `buildActivitySnapshotSummary`
   now recognizes the terminal `**Rejection confirmed by maintainer**`
   marker alongside `**Accepted**`/`**Rejected**` everywhere it decides
   whether a comment counts as a disposition for ack-only purposes — the
   per-thread anchors and their self-exclusion check — mirroring
   recognition `summarizeDispositionEvidenceForGate` already had for
   thread replies. This intentionally goes beyond the two self-exclusion
   call sites the issue cited: leaving the per-thread anchor computation
   unchanged would keep it null whenever the sole disposition on a thread
   is a rejection-confirmed reply, so the self-exclusion recognition alone
   can never make the two producers agree — confirmed empirically (see
   Testing below).

   Copilot review flagged that an earlier revision of this fix also
   applied the marker to the *global*, non-thread anchor
   (`filteredComments`, i.e. plain top-level PR comments) and its
   self-exclusion check — but the marker's own contract requires a reply
   on a resolved review thread, which a top-level comment can never be.
   That would have reintroduced the exact cross-producer gap this PR
   exists to close: `summarizeDispositionEvidenceForGate`'s regular-comment
   pool has only ever recognized `**Accepted**`/`**Rejected**` for
   non-thread comments. Both global-scope call sites were reverted to
   plain `isDispositionComment`; only the per-thread anchors (already
   gated on `thread.isResolved`) recognize the terminal marker.

   A second, lower-confidence Copilot finding (self-suppressed, not
   posted) argued the newly recognized terminal marker should anchor by
   effective (`updatedAt`-preferring) activity rather than `createdAt`
   when the marker is edited after posting, to match
   `classifyThreadAckOnlyPostDisposition`'s existing choice for the same
   marker. That is left for follow-up issue #2045 rather than a third
   full review-fix round here — see that issue for the full incident
   trail.
3. **Snapshot-boundary asymmetry (left as-is, intentional).**
   `reviewCurrency` has no internal boundary concept; its caller
   (`diffReviewSnapshot`) already applies an equivalent comparison one layer
   up, against the whole computed effective-activity timestamp.
   `dispositionEvidence` needs the boundary internally because it answers a
   narrower per-thread question — whether that thread was settled before the
   current review window even opened — with no equivalent at
   `reviewCurrency`'s coarser grain. Threading a boundary into
   `reviewCurrency` would duplicate logic its caller already applies, with
   no change in observable output.
4. **Fail-closed guard asymmetry (left as-is, intentional, already
   documented in source).** `buildActivitySnapshotSummary`'s per-thread
   branch stays conservative whenever `thread.updatedAt` parses as valid,
   because its broader set of callers may pass raw GraphQL threads where
   per-reply attribution can't be trusted (a normalizer must blank the field
   to opt in). `dispositionEvidence` has a narrower call shape and instead
   requires a `snapshotBoundaryAt` value and a resolved thread — a
   different, equally conservative floor suited to its own contract.

## Testing

New `tests/protocol-helpers.test.mts` (the repo has since split
protocol-helpers coverage into several topic-scoped files —
`protocol-helpers-advisory-bot-login.test.mts`,
`protocol-helpers-gh-pagination.test.mts`, plus function-specific tests
inside `review-snapshot.test.mts` / `pre-merge-readiness.test.mts` — but the
issue names this exact path in its acceptance criteria, so it was created
literally rather than picking a different location; happy to relocate on
review feedback) — two cases, each calling both producers on the identical
thread fixture:

- a login configured as both a trusted IDD-agent and an advisory bot posts
  the thread's only disposition-shaped reply
- an IDD agent posts `**Rejection confirmed by maintainer**` as the
  thread's only disposition

Both were confirmed to fail in the predicted disagreement direction against
the pre-fix source, then pass after the fix. A third case (added in
response to Copilot review) confirms a top-level, non-thread comment
carrying the marker does not open the ack-only window. Full suite
(`pnpm run test`, 3481 tests), `pnpm run typecheck`, and `pnpm run build`
(no diff) pass.

Closes #2014

