### PR TITLE
fix(review-triage): validate the disposition marker prefix before posting

### DIFF
--- a/scripts/resolve-review-thread.mjs
+++ b/scripts/resolve-review-thread.mjs
@@ -21,7 +21,11 @@ import {
   readForcedHandoffMode,
 } from './collaborator-permission.mjs';
 import { DEFAULT_GH_PAGINATED_TIMEOUT_MS, ghText } from './gh-exec.mjs';
-import { resolveActiveClaimForWriteGate } from './protocol-helpers.mjs';
+import {
+  isDispositionComment,
+  isRejectionConfirmedDisposition,
+  resolveActiveClaimForWriteGate,
+} from './protocol-helpers.mjs';
 /**
  * Find the review thread that owns the review comment whose REST database id is
  * `commentId`. The GraphQL `PullRequestReviewComment.databaseId` equals the REST
@@ -71,6 +75,41 @@ export function applyResolveReviewThread(deps) {
   deps.assertClaim();
   deps.resolveThread();
   return { replyId: reply.id };
+}
+/** The three marker forms `--apply` accepts, for use in error messages. */
+export const ACCEPTED_DISPOSITION_MARKERS =
+  '**Accepted**, **Rejected**, or **Rejection confirmed by maintainer** —';
+/**
+ * True when `body` starts with one of the marker prefixes
+ * `hasFreshDisposition` (`protocol-helpers.mts`) recognizes as a
+ * disposition, independent of thread-resolution state. Reuses
+ * `isDispositionComment` / `isRejectionConfirmedDisposition` directly so
+ * this posting-time check and the later merge-gate check can never drift
+ * out of sync (idd-skill#2005). Has no network dependency, so the CLI can
+ * call it before resolving `owner`/`repo` or looking up the thread — a
+ * malformed `--body` then fails closed without posting anything.
+ */
+export function hasKnownDispositionMarkerPrefix(body) {
+  const comment = { body };
+  return (
+    isDispositionComment(comment) || isRejectionConfirmedDisposition(comment)
+  );
+}
+/**
+ * The `**Rejection confirmed by maintainer**` form is valid only when the
+ * target thread is already resolved, matching
+ * `isRejectionConfirmedDisposition`'s own resolved-thread scoping inside
+ * `hasFreshDisposition`; `**Accepted**` / `**Rejected**` carry no such
+ * restriction. Only meaningful once `hasKnownDispositionMarkerPrefix` has
+ * already passed for the same `body` and the target thread's resolution
+ * state is known (i.e., after the thread lookup).
+ */
+export function isDispositionBodyValidForThread(body, threadIsResolved) {
+  const comment = { body };
+  if (isDispositionComment(comment)) {
+    return true;
+  }
+  return isRejectionConfirmedDisposition(comment) && threadIsResolved;
 }
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
@@ -141,7 +180,9 @@ thread in one invocation (E13). Dry-run by default; --apply mutates.
 
   --pr <number>                  PR number (required)
   --comment-id <id>              review comment REST id whose thread to resolve (required)
-  --body <text>                  reply body (required with --apply)
+  --body <text>                  reply body (required with --apply; with --apply, must start
+                                 with **Accepted**, **Rejected**, or (resolved threads only)
+                                 **Rejection confirmed by maintainer** —)
   --owner <owner>                repo owner (default: gh repo view)
   --repo <repo>                  repo name (default: gh repo view)
   --claim-issue <number>         issue carrying the active claim (required with --apply)
@@ -402,6 +443,17 @@ if (import.meta.main) {
     );
     process.exit(1);
   }
+  // Fail closed before any network call: --apply must never post a --body
+  // the F2/F3 disposition-evidence gate (hasFreshDisposition) won't
+  // recognize as a disposition (idd-skill#2005). The resolved-thread-only
+  // scoping for the "Rejection confirmed by maintainer" form is checked
+  // separately below, once the target thread's resolution state is known.
+  if (args.apply && !hasKnownDispositionMarkerPrefix(args.body)) {
+    process.stderr.write(
+      `--apply requires --body to start with one of the accepted disposition markers: ${ACCEPTED_DISPOSITION_MARKERS}\n`,
+    );
+    process.exit(1);
+  }
   const pr = args.pr;
   const commentId = args.commentId;
   const owner =
@@ -432,6 +484,17 @@ if (import.meta.main) {
   if (!args.apply) {
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     process.exit(0);
+  }
+  // The "Rejection confirmed by maintainer" form is only valid on an
+  // already-resolved thread (mirrors isRejectionConfirmedDisposition's own
+  // scoping) — the prefix alone (checked above) cannot know this, since it
+  // requires the thread lookup that just completed. Fail closed before
+  // mutating.
+  if (!isDispositionBodyValidForThread(args.body, match.isResolved)) {
+    report.status = 'failed';
+    report.error = `--body uses the "**Rejection confirmed by maintainer**" marker, which is only valid once review thread ${match.threadId} is already resolved (currently unresolved)`;
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exit(1);
   }
   // The reply targets the thread's top-level review comment, so a thread with
   // no exposed comment id cannot be replied to — fail closed before mutating.

--- a/scripts/resolve-review-thread.mjs
+++ b/scripts/resolve-review-thread.mjs
@@ -82,34 +82,34 @@ export const ACCEPTED_DISPOSITION_MARKERS =
 /**
  * True when `body` starts with one of the marker prefixes
  * `hasFreshDisposition` (`protocol-helpers.mts`) recognizes as a
- * disposition, independent of thread-resolution state. Reuses
- * `isDispositionComment` / `isRejectionConfirmedDisposition` directly so
- * this posting-time check and the later merge-gate check can never drift
- * out of sync (idd-skill#2005). Has no network dependency, so the CLI can
- * call it before resolving `owner`/`repo` or looking up the thread — a
- * malformed `--body` then fails closed without posting anything.
+ * disposition. Reuses `isDispositionComment` /
+ * `isRejectionConfirmedDisposition` directly so this posting-time check
+ * and the later merge-gate check can never drift out of sync
+ * (idd-skill#2005). Has no network dependency, so the CLI can call it
+ * before resolving `owner`/`repo` or looking up the thread — a malformed
+ * `--body` then fails closed without posting anything.
+ *
+ * Deliberately does NOT gate the `**Rejection confirmed by maintainer**`
+ * form on the target thread's *pre*-mutation resolution state.
+ * `isRejectionConfirmedDisposition`'s resolved-thread scoping inside
+ * `hasFreshDisposition` is evaluated later, by a downstream gate, against
+ * the thread's state *at that later evaluation time* — and
+ * `applyResolveReviewThread` below unconditionally resolves whatever
+ * thread it replies to, so a successful `--apply` call always leaves the
+ * thread resolved by the time any downstream gate looks at it, regardless
+ * of whether it was already resolved beforehand. The primary documented
+ * use of this exact marker (`idd-review-triage.instructions.md`'s AMD
+ * "maintainer agrees" transition) posts it on a thread that is still
+ * *unresolved* at call time by design, precisely because this call is
+ * what resolves it — an earlier revision of this check required
+ * pre-mutation resolution and would have rejected that call outright
+ * (caught by a Codex review on this PR).
  */
 export function hasKnownDispositionMarkerPrefix(body) {
   const comment = { body };
   return (
     isDispositionComment(comment) || isRejectionConfirmedDisposition(comment)
   );
-}
-/**
- * The `**Rejection confirmed by maintainer**` form is valid only when the
- * target thread is already resolved, matching
- * `isRejectionConfirmedDisposition`'s own resolved-thread scoping inside
- * `hasFreshDisposition`; `**Accepted**` / `**Rejected**` carry no such
- * restriction. Only meaningful once `hasKnownDispositionMarkerPrefix` has
- * already passed for the same `body` and the target thread's resolution
- * state is known (i.e., after the thread lookup).
- */
-export function isDispositionBodyValidForThread(body, threadIsResolved) {
-  const comment = { body };
-  if (isDispositionComment(comment)) {
-    return true;
-  }
-  return isRejectionConfirmedDisposition(comment) && threadIsResolved;
 }
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
@@ -181,7 +181,7 @@ thread in one invocation (E13). Dry-run by default; --apply mutates.
   --pr <number>                  PR number (required)
   --comment-id <id>              review comment REST id whose thread to resolve (required)
   --body <text>                  reply body (required with --apply; with --apply, must start
-                                 with **Accepted**, **Rejected**, or (resolved threads only)
+                                 with **Accepted**, **Rejected**, or
                                  **Rejection confirmed by maintainer** —)
   --owner <owner>                repo owner (default: gh repo view)
   --repo <repo>                  repo name (default: gh repo view)
@@ -445,9 +445,10 @@ if (import.meta.main) {
   }
   // Fail closed before any network call: --apply must never post a --body
   // the F2/F3 disposition-evidence gate (hasFreshDisposition) won't
-  // recognize as a disposition (idd-skill#2005). The resolved-thread-only
-  // scoping for the "Rejection confirmed by maintainer" form is checked
-  // separately below, once the target thread's resolution state is known.
+  // recognize as a disposition (idd-skill#2005). See
+  // hasKnownDispositionMarkerPrefix's own doc comment for why this does
+  // not separately gate the "Rejection confirmed by maintainer" form on
+  // the thread's pre-mutation resolution state.
   if (args.apply && !hasKnownDispositionMarkerPrefix(args.body)) {
     process.stderr.write(
       `--apply requires --body to start with one of the accepted disposition markers: ${ACCEPTED_DISPOSITION_MARKERS}\n`,
@@ -484,17 +485,6 @@ if (import.meta.main) {
   if (!args.apply) {
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     process.exit(0);
-  }
-  // The "Rejection confirmed by maintainer" form is only valid on an
-  // already-resolved thread (mirrors isRejectionConfirmedDisposition's own
-  // scoping) — the prefix alone (checked above) cannot know this, since it
-  // requires the thread lookup that just completed. Fail closed before
-  // mutating.
-  if (!isDispositionBodyValidForThread(args.body, match.isResolved)) {
-    report.status = 'failed';
-    report.error = `--body uses the "**Rejection confirmed by maintainer**" marker, which is only valid once review thread ${match.threadId} is already resolved (currently unresolved)`;
-    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
-    process.exit(1);
   }
   // The reply targets the thread's top-level review comment, so a thread with
   // no exposed comment id cannot be replied to — fail closed before mutating.

--- a/src/scripts/resolve-review-thread.mts
+++ b/src/scripts/resolve-review-thread.mts
@@ -24,6 +24,8 @@ import {
 } from './collaborator-permission.mts';
 import { DEFAULT_GH_PAGINATED_TIMEOUT_MS, ghText } from './gh-exec.mts';
 import {
+  isDispositionComment,
+  isRejectionConfirmedDisposition,
   type ParsedClaimMarker,
   resolveActiveClaimForWriteGate,
 } from './protocol-helpers.mts';
@@ -126,6 +128,47 @@ export function applyResolveReviewThread(deps: {
   return { replyId: reply.id };
 }
 
+/** The three marker forms `--apply` accepts, for use in error messages. */
+export const ACCEPTED_DISPOSITION_MARKERS =
+  '**Accepted**, **Rejected**, or **Rejection confirmed by maintainer** —';
+
+/**
+ * True when `body` starts with one of the marker prefixes
+ * `hasFreshDisposition` (`protocol-helpers.mts`) recognizes as a
+ * disposition, independent of thread-resolution state. Reuses
+ * `isDispositionComment` / `isRejectionConfirmedDisposition` directly so
+ * this posting-time check and the later merge-gate check can never drift
+ * out of sync (idd-skill#2005). Has no network dependency, so the CLI can
+ * call it before resolving `owner`/`repo` or looking up the thread — a
+ * malformed `--body` then fails closed without posting anything.
+ */
+export function hasKnownDispositionMarkerPrefix(body: string): boolean {
+  const comment = { body };
+  return (
+    isDispositionComment(comment) || isRejectionConfirmedDisposition(comment)
+  );
+}
+
+/**
+ * The `**Rejection confirmed by maintainer**` form is valid only when the
+ * target thread is already resolved, matching
+ * `isRejectionConfirmedDisposition`'s own resolved-thread scoping inside
+ * `hasFreshDisposition`; `**Accepted**` / `**Rejected**` carry no such
+ * restriction. Only meaningful once `hasKnownDispositionMarkerPrefix` has
+ * already passed for the same `body` and the target thread's resolution
+ * state is known (i.e., after the thread lookup).
+ */
+export function isDispositionBodyValidForThread(
+  body: string,
+  threadIsResolved: boolean,
+): boolean {
+  const comment = { body };
+  if (isDispositionComment(comment)) {
+    return true;
+  }
+  return isRejectionConfirmedDisposition(comment) && threadIsResolved;
+}
+
 // ---------------------------------------------------------------------------
 // CLI
 // ---------------------------------------------------------------------------
@@ -220,7 +263,9 @@ thread in one invocation (E13). Dry-run by default; --apply mutates.
 
   --pr <number>                  PR number (required)
   --comment-id <id>              review comment REST id whose thread to resolve (required)
-  --body <text>                  reply body (required with --apply)
+  --body <text>                  reply body (required with --apply; with --apply, must start
+                                 with **Accepted**, **Rejected**, or (resolved threads only)
+                                 **Rejection confirmed by maintainer** —)
   --owner <owner>                repo owner (default: gh repo view)
   --repo <repo>                  repo name (default: gh repo view)
   --claim-issue <number>         issue carrying the active claim (required with --apply)
@@ -535,6 +580,17 @@ if (import.meta.main) {
     );
     process.exit(1);
   }
+  // Fail closed before any network call: --apply must never post a --body
+  // the F2/F3 disposition-evidence gate (hasFreshDisposition) won't
+  // recognize as a disposition (idd-skill#2005). The resolved-thread-only
+  // scoping for the "Rejection confirmed by maintainer" form is checked
+  // separately below, once the target thread's resolution state is known.
+  if (args.apply && !hasKnownDispositionMarkerPrefix(args.body)) {
+    process.stderr.write(
+      `--apply requires --body to start with one of the accepted disposition markers: ${ACCEPTED_DISPOSITION_MARKERS}\n`,
+    );
+    process.exit(1);
+  }
   const pr = args.pr as number;
   const commentId = args.commentId as number;
   const owner =
@@ -569,6 +625,18 @@ if (import.meta.main) {
   if (!args.apply) {
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     process.exit(0);
+  }
+
+  // The "Rejection confirmed by maintainer" form is only valid on an
+  // already-resolved thread (mirrors isRejectionConfirmedDisposition's own
+  // scoping) — the prefix alone (checked above) cannot know this, since it
+  // requires the thread lookup that just completed. Fail closed before
+  // mutating.
+  if (!isDispositionBodyValidForThread(args.body, match.isResolved)) {
+    report.status = 'failed';
+    report.error = `--body uses the "**Rejection confirmed by maintainer**" marker, which is only valid once review thread ${match.threadId} is already resolved (currently unresolved)`;
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    process.exit(1);
   }
 
   // The reply targets the thread's top-level review comment, so a thread with

--- a/src/scripts/resolve-review-thread.mts
+++ b/src/scripts/resolve-review-thread.mts
@@ -135,38 +135,34 @@ export const ACCEPTED_DISPOSITION_MARKERS =
 /**
  * True when `body` starts with one of the marker prefixes
  * `hasFreshDisposition` (`protocol-helpers.mts`) recognizes as a
- * disposition, independent of thread-resolution state. Reuses
- * `isDispositionComment` / `isRejectionConfirmedDisposition` directly so
- * this posting-time check and the later merge-gate check can never drift
- * out of sync (idd-skill#2005). Has no network dependency, so the CLI can
- * call it before resolving `owner`/`repo` or looking up the thread — a
- * malformed `--body` then fails closed without posting anything.
+ * disposition. Reuses `isDispositionComment` /
+ * `isRejectionConfirmedDisposition` directly so this posting-time check
+ * and the later merge-gate check can never drift out of sync
+ * (idd-skill#2005). Has no network dependency, so the CLI can call it
+ * before resolving `owner`/`repo` or looking up the thread — a malformed
+ * `--body` then fails closed without posting anything.
+ *
+ * Deliberately does NOT gate the `**Rejection confirmed by maintainer**`
+ * form on the target thread's *pre*-mutation resolution state.
+ * `isRejectionConfirmedDisposition`'s resolved-thread scoping inside
+ * `hasFreshDisposition` is evaluated later, by a downstream gate, against
+ * the thread's state *at that later evaluation time* — and
+ * `applyResolveReviewThread` below unconditionally resolves whatever
+ * thread it replies to, so a successful `--apply` call always leaves the
+ * thread resolved by the time any downstream gate looks at it, regardless
+ * of whether it was already resolved beforehand. The primary documented
+ * use of this exact marker (`idd-review-triage.instructions.md`'s AMD
+ * "maintainer agrees" transition) posts it on a thread that is still
+ * *unresolved* at call time by design, precisely because this call is
+ * what resolves it — an earlier revision of this check required
+ * pre-mutation resolution and would have rejected that call outright
+ * (caught by a Codex review on this PR).
  */
 export function hasKnownDispositionMarkerPrefix(body: string): boolean {
   const comment = { body };
   return (
     isDispositionComment(comment) || isRejectionConfirmedDisposition(comment)
   );
-}
-
-/**
- * The `**Rejection confirmed by maintainer**` form is valid only when the
- * target thread is already resolved, matching
- * `isRejectionConfirmedDisposition`'s own resolved-thread scoping inside
- * `hasFreshDisposition`; `**Accepted**` / `**Rejected**` carry no such
- * restriction. Only meaningful once `hasKnownDispositionMarkerPrefix` has
- * already passed for the same `body` and the target thread's resolution
- * state is known (i.e., after the thread lookup).
- */
-export function isDispositionBodyValidForThread(
-  body: string,
-  threadIsResolved: boolean,
-): boolean {
-  const comment = { body };
-  if (isDispositionComment(comment)) {
-    return true;
-  }
-  return isRejectionConfirmedDisposition(comment) && threadIsResolved;
 }
 
 // ---------------------------------------------------------------------------
@@ -264,7 +260,7 @@ thread in one invocation (E13). Dry-run by default; --apply mutates.
   --pr <number>                  PR number (required)
   --comment-id <id>              review comment REST id whose thread to resolve (required)
   --body <text>                  reply body (required with --apply; with --apply, must start
-                                 with **Accepted**, **Rejected**, or (resolved threads only)
+                                 with **Accepted**, **Rejected**, or
                                  **Rejection confirmed by maintainer** —)
   --owner <owner>                repo owner (default: gh repo view)
   --repo <repo>                  repo name (default: gh repo view)
@@ -582,9 +578,10 @@ if (import.meta.main) {
   }
   // Fail closed before any network call: --apply must never post a --body
   // the F2/F3 disposition-evidence gate (hasFreshDisposition) won't
-  // recognize as a disposition (idd-skill#2005). The resolved-thread-only
-  // scoping for the "Rejection confirmed by maintainer" form is checked
-  // separately below, once the target thread's resolution state is known.
+  // recognize as a disposition (idd-skill#2005). See
+  // hasKnownDispositionMarkerPrefix's own doc comment for why this does
+  // not separately gate the "Rejection confirmed by maintainer" form on
+  // the thread's pre-mutation resolution state.
   if (args.apply && !hasKnownDispositionMarkerPrefix(args.body)) {
     process.stderr.write(
       `--apply requires --body to start with one of the accepted disposition markers: ${ACCEPTED_DISPOSITION_MARKERS}\n`,
@@ -625,18 +622,6 @@ if (import.meta.main) {
   if (!args.apply) {
     process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
     process.exit(0);
-  }
-
-  // The "Rejection confirmed by maintainer" form is only valid on an
-  // already-resolved thread (mirrors isRejectionConfirmedDisposition's own
-  // scoping) — the prefix alone (checked above) cannot know this, since it
-  // requires the thread lookup that just completed. Fail closed before
-  // mutating.
-  if (!isDispositionBodyValidForThread(args.body, match.isResolved)) {
-    report.status = 'failed';
-    report.error = `--body uses the "**Rejection confirmed by maintainer**" marker, which is only valid once review thread ${match.threadId} is already resolved (currently unresolved)`;
-    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
-    process.exit(1);
   }
 
   // The reply targets the thread's top-level review comment, so a thread with

--- a/tests/resolve-review-thread.test.mts
+++ b/tests/resolve-review-thread.test.mts
@@ -6,7 +6,6 @@ import {
   assertNoGraphqlErrors,
   findThreadForComment,
   hasKnownDispositionMarkerPrefix,
-  isDispositionBodyValidForThread,
   parseArgs,
   type ResolveReviewThreadReport,
   type ReviewThreadNode,
@@ -325,33 +324,18 @@ test('hasKnownDispositionMarkerPrefix rejects a non-conforming body before any n
   );
 });
 
-test('isDispositionBodyValidForThread scopes the "Rejection confirmed by maintainer" form to already-resolved threads', () => {
+test('hasKnownDispositionMarkerPrefix accepts "Rejection confirmed by maintainer" regardless of thread resolution state', () => {
+  // Regression coverage for a Codex review finding on this PR: an earlier
+  // revision of this check required the target thread to already be
+  // resolved before accepting this marker. That broke the documented AMD
+  // "maintainer agrees" transition (idd-review-triage.instructions.md),
+  // which posts exactly this marker on a thread that is still
+  // *unresolved* at call time -- resolve-review-thread.mjs's own --apply
+  // path is what resolves it, in the same call. This predicate has no
+  // thread-state input at all, so it can never re-introduce that bug.
   const body =
     '**Rejection confirmed by maintainer** — agreed, no action needed';
-  assert.equal(isDispositionBodyValidForThread(body, true), true);
-  assert.equal(
-    isDispositionBodyValidForThread(body, false),
-    false,
-    'must be rejected on a currently-unresolved thread',
-  );
-});
-
-test('isDispositionBodyValidForThread accepts **Accepted**/**Rejected** regardless of thread resolution state', () => {
-  assert.equal(
-    isDispositionBodyValidForThread('**Accepted** — fixed in abc1234', false),
-    true,
-  );
-  assert.equal(
-    isDispositionBodyValidForThread('**Accepted** — fixed in abc1234', true),
-    true,
-  );
-  assert.equal(
-    isDispositionBodyValidForThread(
-      '**Rejected** — verified placeholders-only',
-      false,
-    ),
-    true,
-  );
+  assert.equal(hasKnownDispositionMarkerPrefix(body), true);
 });
 
 test('the dry-run and apply output envelopes validate against the schema', () => {

--- a/tests/resolve-review-thread.test.mts
+++ b/tests/resolve-review-thread.test.mts
@@ -5,6 +5,8 @@ import {
   applyResolveReviewThread,
   assertNoGraphqlErrors,
   findThreadForComment,
+  hasKnownDispositionMarkerPrefix,
+  isDispositionBodyValidForThread,
   parseArgs,
   type ResolveReviewThreadReport,
   type ReviewThreadNode,
@@ -290,6 +292,66 @@ test('applyResolveReviewThread does not resolve the thread when the reply fails'
     /reply failed/,
   );
   assert.deepEqual(calls, ['claim']);
+});
+
+// --- #2005: validate the disposition marker prefix before posting ----------
+
+test('hasKnownDispositionMarkerPrefix accepts each of the three forms hasFreshDisposition recognizes', () => {
+  assert.equal(
+    hasKnownDispositionMarkerPrefix('**Accepted** — fixed in abc1234: ...'),
+    true,
+  );
+  assert.equal(
+    hasKnownDispositionMarkerPrefix(
+      '**Rejected** — verified placeholders-only',
+    ),
+    true,
+  );
+  assert.equal(
+    hasKnownDispositionMarkerPrefix(
+      '**Rejection confirmed by maintainer** — agreed, no action needed',
+    ),
+    true,
+  );
+});
+
+test('hasKnownDispositionMarkerPrefix rejects a non-conforming body before any network call', () => {
+  // This predicate has no network dependency at all -- the CLI calls it
+  // before resolving owner/repo or looking up the review thread, so a body
+  // like this is rejected before any gh/GraphQL call is made.
+  assert.equal(
+    hasKnownDispositionMarkerPrefix('**Fixed** — cleaned up the stray import'),
+    false,
+  );
+});
+
+test('isDispositionBodyValidForThread scopes the "Rejection confirmed by maintainer" form to already-resolved threads', () => {
+  const body =
+    '**Rejection confirmed by maintainer** — agreed, no action needed';
+  assert.equal(isDispositionBodyValidForThread(body, true), true);
+  assert.equal(
+    isDispositionBodyValidForThread(body, false),
+    false,
+    'must be rejected on a currently-unresolved thread',
+  );
+});
+
+test('isDispositionBodyValidForThread accepts **Accepted**/**Rejected** regardless of thread resolution state', () => {
+  assert.equal(
+    isDispositionBodyValidForThread('**Accepted** — fixed in abc1234', false),
+    true,
+  );
+  assert.equal(
+    isDispositionBodyValidForThread('**Accepted** — fixed in abc1234', true),
+    true,
+  );
+  assert.equal(
+    isDispositionBodyValidForThread(
+      '**Rejected** — verified placeholders-only',
+      false,
+    ),
+    true,
+  );
 });
 
 test('the dry-run and apply output envelopes validate against the schema', () => {

--- a/tests/resolve-review-thread.test.mts
+++ b/tests/resolve-review-thread.test.mts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import {
   applyResolveReviewThread,
@@ -12,6 +15,8 @@ import {
 } from '../src/scripts/resolve-review-thread.mts';
 import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
 import { buildReviewThreadNode } from './test-utils.mts';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
 const resultSchema = loadJson('schemas/resolve-review-thread.schema.json');
 
@@ -322,6 +327,48 @@ test('hasKnownDispositionMarkerPrefix rejects a non-conforming body before any n
     hasKnownDispositionMarkerPrefix('**Fixed** — cleaned up the stray import'),
     false,
   );
+});
+
+// The predicate test above proves `hasKnownDispositionMarkerPrefix` itself
+// rejects a non-conforming body, but not that the compiled CLI actually
+// calls it before any `gh` invocation -- a regression that moved or dropped
+// the `--apply` guard in `main()` would still leave that pure-function test
+// green. Run the real compiled entry point (docs/typescript-sources.md's
+// "never hand-edit scripts/*.mjs" source of truth) with `gh` scrubbed from
+// `PATH` (the tests/post-idd-marker.test.mts `runCliExpectingFailure`
+// pattern): if the guard fired, the process exits 1 with the documented
+// stderr message before ever shelling out; if it didn't, `gh` would be
+// invoked and fail with an unrelated ENOENT-style spawn error instead.
+test('--apply rejects a non-conforming --body before any gh call (compiled CLI)', () => {
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/resolve-review-thread.mjs'),
+        '--pr',
+        '42',
+        '--comment-id',
+        '1001',
+        '--claim-issue',
+        '2005',
+        '--claim-id',
+        'test-claim-id',
+        '--apply',
+        '--body',
+        '**Fixed** — cleaned up the stray import',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8', env: { ...process.env, PATH: '' } },
+    );
+  } catch (error) {
+    const failure = error as { status?: number; stderr?: string };
+    assert.equal(failure.status, 1);
+    assert.match(
+      failure.stderr ?? '',
+      /--apply requires --body to start with one of the accepted disposition markers/,
+    );
+    return;
+  }
+  throw new Error('expected the CLI to exit non-zero');
 });
 
 test('hasKnownDispositionMarkerPrefix accepts "Rejection confirmed by maintainer" regardless of thread resolution state', () => {


### PR DESCRIPTION
## Summary

`resolve-review-thread.mjs --apply` previously posted whatever `--body`
text was passed and resolved the thread, with no check that the body
matches a disposition marker the merge gate later requires
(`hasFreshDisposition` in `src/scripts/protocol-helpers.mts` only
recognizes `**Accepted**`, `**Rejected**`, or — on an already-resolved
thread — `**Rejection confirmed by maintainer** —`). Reproduced on PR
#2004 (issue #2002): two replies starting `**Fixed** — ...` succeeded
and resolved their threads, but `pre-merge-readiness.mjs`'s
`dispositionEvidence` gate later reported both as
`missing-fresh-disposition`, surfacing the mistake only after the
threads were already closed.

This change adds a fail-closed check to `--apply`:

- Before any network call, reject `--apply` when `--body` does not
  start with `**Accepted**`, `**Rejected**`, or
  `**Rejection confirmed by maintainer** —`. This check has no
  thread-state input: it deliberately does not require the target
  thread to already be resolved before accepting the
  `**Rejection confirmed by maintainer**` form. An earlier revision of
  this check did require pre-mutation resolution and was reverted
  (caught by a Codex review on this PR), because it would have
  rejected the documented AMD "maintainer agrees" transition
  (`idd-review-triage.instructions.md`), which posts exactly this
  marker on a thread that is still unresolved at call time —
  `--apply`'s own reply-then-resolve sequence is what resolves it, in
  the same call. `hasFreshDisposition`'s resolved-thread scoping for
  this marker (quoted above) is evaluated later by the downstream
  merge gate, against the thread's state at that later check — and a
  successful `--apply` call always leaves the thread resolved by then,
  regardless of whether it was already resolved beforehand.
- Reuses the exported `isDispositionComment` /
  `isRejectionConfirmedDisposition` predicates from
  `protocol-helpers.mts` directly, so the posting-time check and the
  later gate check can never drift out of sync.
- Dry-run mode is unaffected — it still prints the preview regardless
  of marker form, since dry-run never posts.

`pnpm run build` regenerates `scripts/resolve-review-thread.mjs` from
the edited `.mts` source (never hand-edited).

## Test plan

- New unit tests in `tests/resolve-review-thread.test.mts` cover: each
  of the three accepted forms succeeding via the pure predicate; a
  non-conforming body (e.g. `**Fixed** — ...`) rejected via the pure,
  network-free predicate and, separately, via the compiled CLI itself
  with `gh` removed from `PATH` (proving the guard is actually wired
  into `--apply`'s exit path, not just present as an unused function);
  the `**Rejection confirmed by maintainer**` form accepted regardless
  of the thread's resolution state (regression coverage for the
  reverted pre-mutation gate described above).
- `pnpm run lint:minimum` passes (typecheck, build:check, full test
  suite, docs/cspell/markdown audits).
- Manual smoke test: `node scripts/resolve-review-thread.mjs --apply
  --body '**Fixed** — ...' ...` exits 1 immediately with no `gh`
  network call.

Closes #2005
