### PR TITLE
fix(pre-merge-readiness): evaluate advisory-convergence waiver's deadline/terminal precondition

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -700,6 +700,17 @@ The adopted helper boundaries are intentionally narrow:
   `ciGate.externalChecks.waivable`; only a `valid` waiver for a
   configured-waivable check is reported with `coveredByWaiver: true` and
   treated as passing by the CI gate)
+- (`#2021`) a `valid` waiver for the `idd-advisory-convergence` selector
+  specifically only becomes `coveredByWaiver: true` once the SAME
+  deadline/terminal precondition `advisory-convergence.mjs`'s own gate
+  enforces has also opened — a 24h deadline anchored on the current HEAD
+  commit's own `committedDate`, or proven terminal Copilot
+  unavailability. The output's `advisoryConvergenceWaiverPrecondition`
+  field always reports this evaluation (`deadlineMinutes`,
+  `headCommittedAt`, `elapsedMinutes`, `deadlinePassed`,
+  `terminalUnavailable`, `open`), so an agent never has to re-derive the
+  remaining time-to-deadline by hand when a `ci` blocker cites a posted
+  but not-yet-active waiver
 - it does not replace the pre-merge or merge decision tables; it only
   reduces command-copy variance when collecting canonical merge-gate
   evidence

--- a/fixtures/pre-merge-readiness/ack-only-current.json
+++ b/fixtures/pre-merge-readiness/ack-only-current.json
@@ -341,6 +341,15 @@
       "malformed": [],
       "notConfigured": []
     },
+    "advisoryConvergenceWaiverPrecondition": {
+      "checkSelector": "idd-advisory-convergence",
+      "deadlineMinutes": 1440,
+      "headCommittedAt": "none",
+      "elapsedMinutes": null,
+      "deadlinePassed": false,
+      "terminalUnavailable": false,
+      "open": false
+    },
     "branchCurrency": {
       "mergeStateStatus": "",
       "mergeable": "",

--- a/fixtures/pre-merge-readiness/changes-requested.json
+++ b/fixtures/pre-merge-readiness/changes-requested.json
@@ -275,6 +275,15 @@
       "malformed": [],
       "notConfigured": []
     },
+    "advisoryConvergenceWaiverPrecondition": {
+      "checkSelector": "idd-advisory-convergence",
+      "deadlineMinutes": 1440,
+      "headCommittedAt": "none",
+      "elapsedMinutes": null,
+      "deadlinePassed": false,
+      "terminalUnavailable": false,
+      "open": false
+    },
     "branchCurrency": {
       "mergeStateStatus": "",
       "mergeable": "",

--- a/fixtures/pre-merge-readiness/ci-not-ready.json
+++ b/fixtures/pre-merge-readiness/ci-not-ready.json
@@ -279,6 +279,15 @@
       "malformed": [],
       "notConfigured": []
     },
+    "advisoryConvergenceWaiverPrecondition": {
+      "checkSelector": "idd-advisory-convergence",
+      "deadlineMinutes": 1440,
+      "headCommittedAt": "none",
+      "elapsedMinutes": null,
+      "deadlinePassed": false,
+      "terminalUnavailable": false,
+      "open": false
+    },
     "branchCurrency": {
       "mergeStateStatus": "",
       "mergeable": "",

--- a/fixtures/pre-merge-readiness/claim-lost.json
+++ b/fixtures/pre-merge-readiness/claim-lost.json
@@ -303,6 +303,15 @@
       "malformed": [],
       "notConfigured": []
     },
+    "advisoryConvergenceWaiverPrecondition": {
+      "checkSelector": "idd-advisory-convergence",
+      "deadlineMinutes": 1440,
+      "headCommittedAt": "none",
+      "elapsedMinutes": null,
+      "deadlinePassed": false,
+      "terminalUnavailable": false,
+      "open": false
+    },
     "branchCurrency": {
       "mergeStateStatus": "",
       "mergeable": "",

--- a/fixtures/pre-merge-readiness/clean.json
+++ b/fixtures/pre-merge-readiness/clean.json
@@ -303,6 +303,15 @@
       "malformed": [],
       "notConfigured": []
     },
+    "advisoryConvergenceWaiverPrecondition": {
+      "checkSelector": "idd-advisory-convergence",
+      "deadlineMinutes": 1440,
+      "headCommittedAt": "none",
+      "elapsedMinutes": null,
+      "deadlinePassed": false,
+      "terminalUnavailable": false,
+      "open": false
+    },
     "branchCurrency": {
       "mergeStateStatus": "",
       "mergeable": "",

--- a/fixtures/pre-merge-readiness/stale-watermark.json
+++ b/fixtures/pre-merge-readiness/stale-watermark.json
@@ -303,6 +303,15 @@
       "malformed": [],
       "notConfigured": []
     },
+    "advisoryConvergenceWaiverPrecondition": {
+      "checkSelector": "idd-advisory-convergence",
+      "deadlineMinutes": 1440,
+      "headCommittedAt": "none",
+      "elapsedMinutes": null,
+      "deadlinePassed": false,
+      "terminalUnavailable": false,
+      "open": false
+    },
     "branchCurrency": {
       "mergeStateStatus": "",
       "mergeable": "",

--- a/fixtures/pre-merge-readiness/unreplied-comment.json
+++ b/fixtures/pre-merge-readiness/unreplied-comment.json
@@ -289,6 +289,15 @@
       "malformed": [],
       "notConfigured": []
     },
+    "advisoryConvergenceWaiverPrecondition": {
+      "checkSelector": "idd-advisory-convergence",
+      "deadlineMinutes": 1440,
+      "headCommittedAt": "none",
+      "elapsedMinutes": null,
+      "deadlinePassed": false,
+      "terminalUnavailable": false,
+      "open": false
+    },
     "branchCurrency": {
       "mergeStateStatus": "",
       "mergeable": "",

--- a/fixtures/pre-merge-readiness/unresolved-thread.json
+++ b/fixtures/pre-merge-readiness/unresolved-thread.json
@@ -303,6 +303,15 @@
       "malformed": [],
       "notConfigured": []
     },
+    "advisoryConvergenceWaiverPrecondition": {
+      "checkSelector": "idd-advisory-convergence",
+      "deadlineMinutes": 1440,
+      "headCommittedAt": "none",
+      "elapsedMinutes": null,
+      "deadlinePassed": false,
+      "terminalUnavailable": false,
+      "open": false
+    },
     "branchCurrency": {
       "mergeStateStatus": "",
       "mergeable": "",

--- a/fixtures/schemas/pre-merge-readiness.valid.json
+++ b/fixtures/schemas/pre-merge-readiness.valid.json
@@ -182,6 +182,15 @@
     "malformed": [],
     "notConfigured": []
   },
+  "advisoryConvergenceWaiverPrecondition": {
+    "checkSelector": "idd-advisory-convergence",
+    "deadlineMinutes": 1440,
+    "headCommittedAt": "none",
+    "elapsedMinutes": null,
+    "deadlinePassed": false,
+    "terminalUnavailable": false,
+    "open": false
+  },
   "branchCurrency": {
     "mergeStateStatus": "CLEAN",
     "mergeable": "MERGEABLE",

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -700,6 +700,17 @@ The adopted helper boundaries are intentionally narrow:
   `ciGate.externalChecks.waivable`; only a `valid` waiver for a
   configured-waivable check is reported with `coveredByWaiver: true` and
   treated as passing by the CI gate)
+- (`#2021`) a `valid` waiver for the `idd-advisory-convergence` selector
+  specifically only becomes `coveredByWaiver: true` once the SAME
+  deadline/terminal precondition `advisory-convergence.mjs`'s own gate
+  enforces has also opened — a 24h deadline anchored on the current HEAD
+  commit's own `committedDate`, or proven terminal Copilot
+  unavailability. The output's `advisoryConvergenceWaiverPrecondition`
+  field always reports this evaluation (`deadlineMinutes`,
+  `headCommittedAt`, `elapsedMinutes`, `deadlinePassed`,
+  `terminalUnavailable`, `open`), so an agent never has to re-derive the
+  remaining time-to-deadline by hand when a `ci` blocker cites a posted
+  but not-yet-active waiver
 - it does not replace the pre-merge or merge decision tables; it only
   reduces command-copy variance when collecting canonical merge-gate
   evidence

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -17,6 +17,7 @@
     "ci",
     "claim",
     "waiverEvidence",
+    "advisoryConvergenceWaiverPrecondition",
     "branchCurrency",
     "ready",
     "blockers"
@@ -1417,6 +1418,51 @@
               }
             }
           }
+        }
+      }
+    },
+    "advisoryConvergenceWaiverPrecondition": {
+      "type": "object",
+      "description": "#2021: deadline/terminal precondition gating whether a posted idd-advisory-convergence waiver counts toward ci.coveredByWaiver -- mirrors advisory-convergence.mts's own deadline clock (a 24h deadline anchored on the current HEAD commit's own committedDate) and its terminal Copilot-unavailability escape hatch, so this evidence collector never reports a check as covered before that gate itself would call the waiver waived.",
+      "required": [
+        "checkSelector",
+        "deadlineMinutes",
+        "headCommittedAt",
+        "elapsedMinutes",
+        "deadlinePassed",
+        "terminalUnavailable",
+        "open"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "checkSelector": {
+          "type": "string",
+          "description": "The idd-advisory-convergence check selector this precondition gates."
+        },
+        "deadlineMinutes": {
+          "type": "number",
+          "description": "Configured advisory convergence deadline in minutes (advisoryWait.convergenceDeadline, default 1440 = 24h).",
+          "minimum": 0
+        },
+        "headCommittedAt": {
+          "type": "string",
+          "description": "ISO timestamp of the current HEAD commit itself, or the literal 'none' when unavailable."
+        },
+        "elapsedMinutes": {
+          "type": ["integer", "null"],
+          "description": "Whole minutes elapsed from headCommittedAt to now, or null when headCommittedAt is invalid or absent."
+        },
+        "deadlinePassed": {
+          "type": "boolean",
+          "description": "True when elapsedMinutes is known and has reached deadlineMinutes."
+        },
+        "terminalUnavailable": {
+          "type": "boolean",
+          "description": "The caller-supplied #1572 terminal Copilot-unavailability verdict (same value as advisoryWait.copilotUnavailable)."
+        },
+        "open": {
+          "type": "boolean",
+          "description": "True when deadlinePassed or terminalUnavailable -- the precondition that must hold before a posted idd-advisory-convergence waiver counts toward ci.coveredByWaiver."
         }
       }
     },

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -6,6 +6,7 @@
 // generated .mjs. See docs/typescript-sources.md.
 import { readFileSync } from 'node:fs';
 import {
+  readAdvisoryConvergenceDeadlineMinutes,
   readAdvisoryPrimaryBotLogin,
   readAdvisoryRecoveryCycleCap,
   readAdvisoryTerminalWindowMinutes,
@@ -46,6 +47,7 @@ import {
   resolveTrustedMarkerActors,
   selectCodeownersText,
 } from './protocol-helpers.mjs';
+import { fetchReviewsAndHeadCommit } from './review-clause.mjs';
 
 // GitHub's GraphQL `DateTime` scalar can't be null, so a `CheckRun` that
 // has not completed yet (and a `StatusContext`, which has no completedAt
@@ -406,6 +408,23 @@ export function collectPreMergeReadiness(argv) {
     },
   );
   const copilotUnavailable = copilotRecovery.state === 'COPILOT_UNAVAILABLE';
+  // #2021: fetch the current HEAD commit's own `committedDate` via the SAME
+  // GraphQL field `advisory-convergence.mts`'s own deadline clock reads
+  // (`fetchReviewsAndHeadCommit`, extracted to `review-clause.mts` precisely
+  // so a second, independent caller can reuse this exact evidence instead of
+  // a second ad-hoc GraphQL path that could drift out of sync with it -- see
+  // that module's header). Only `headCommittedAt` is used here; the
+  // paginated `reviews` return value is discarded since this caller already
+  // fetched reviews separately via REST above. Deliberately uncaught, same
+  // rationale as `copilotUnavailable` immediately above: a lookup failure
+  // must crash this evidence collector rather than silently resolve to an
+  // empty `headCommittedAt`, which would make `advisoryConvergenceDeadlinePassed`
+  // fail closed to `false` for the wrong reason (masking a genuinely-open
+  // deadline as unreadable evidence instead of surfacing the fetch failure).
+  const { headCommittedAt: advisoryConvergenceHeadCommittedAt } =
+    fetchReviewsAndHeadCommit(owner, repo, args.prNumber);
+  const advisoryConvergenceDeadlineMinutes =
+    readAdvisoryConvergenceDeadlineMinutes();
   const summary = buildPreMergeReadinessSummary(
     {
       prHeadSha,
@@ -456,6 +475,8 @@ export function collectPreMergeReadiness(argv) {
       capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
       primaryBotLogin,
       copilotUnavailable,
+      advisoryConvergenceHeadCommittedAt,
+      advisoryConvergenceDeadlineMinutes,
       waivableCheckSelectors,
       externalCheckWaiverMaxValidity,
       trustSourcePinnedRequiredChecks,

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3318,6 +3318,7 @@ export function summarizeRequiredChecks(
     waivableSelectors = null,
     protectionReadsUnreadable = false,
     trustSourcePinnedRequiredChecks = false,
+    excludeFromWaiverCoverage = null,
   } = {},
 ) {
   const branchReviewRequirements = summarizeBranchReviewRequirements(
@@ -3332,6 +3333,10 @@ export function summarizeRequiredChecks(
     const state = String(check.state ?? '').toUpperCase();
     const coveredByWaiver =
       !CHECK_PASS_EQUIVALENT_STATES.has(state) &&
+      !(
+        typeof excludeFromWaiverCoverage === 'function' &&
+        excludeFromWaiverCoverage(name)
+      ) &&
       validWaivers.some((w) =>
         matchCheckSelectorLocal(name, w.checkSelector),
       ) &&
@@ -4501,20 +4506,36 @@ export function computePreMergeReadinessBlockers(report) {
           ),
       );
     const waiverEvidenceForDetail = preMergeAsRecord(report.waiverEvidence);
-    const advisoryConvergenceValidWaiverCount = Array.isArray(
-      waiverEvidenceForDetail.valid,
-    )
-      ? waiverEvidenceForDetail.valid.filter((entry) =>
-          matchCheckSelectorLocal(
-            advisoryConvergenceCheckSelector,
-            entry?.checkSelector,
-          ),
-        ).length
-      : 0;
+    const waiverEvidenceValidList = Array.isArray(waiverEvidenceForDetail.valid)
+      ? waiverEvidenceForDetail.valid
+      : [];
+    // #2021 (Codex review on PR #2033): distinguish an EXACT-selector waiver
+    // (the only kind `advisory-convergence.mts`'s own gate ever counts, see
+    // `advisoryConvergenceExactWaiverValid` in `buildPreMergeReadinessSummary`)
+    // from a broader glob-only match, so this detail never implies "posting
+    // an exact waiver and waiting out the deadline is sufficient" when the
+    // real cause is that only a glob selector (e.g. `idd-*`) targets this
+    // check -- that never converges no matter how long the deadline waits.
+    const advisoryConvergenceExactWaiverCount = waiverEvidenceValidList.filter(
+      (entry) =>
+        String(entry?.checkSelector ?? '') === advisoryConvergenceCheckSelector,
+    ).length;
+    const advisoryConvergenceAnyWaiverCount = waiverEvidenceValidList.filter(
+      (entry) =>
+        matchCheckSelectorLocal(
+          advisoryConvergenceCheckSelector,
+          entry?.checkSelector,
+        ),
+    ).length;
+    const advisoryConvergencePreconditionOpenForDetail =
+      advisoryConvergencePrecondition.open === true;
     if (
       advisoryConvergenceCheckNonPassing &&
-      advisoryConvergenceValidWaiverCount > 0 &&
-      advisoryConvergencePrecondition.open !== true
+      advisoryConvergenceAnyWaiverCount > 0 &&
+      !(
+        advisoryConvergencePreconditionOpenForDetail &&
+        advisoryConvergenceExactWaiverCount > 0
+      )
     ) {
       const deadlineMinutes = Number(
         advisoryConvergencePrecondition.deadlineMinutes ?? 0,
@@ -4524,14 +4545,29 @@ export function computePreMergeReadinessBlockers(report) {
         typeof elapsedMinutes === 'number'
           ? Math.max(0, deadlineMinutes - elapsedMinutes)
           : null;
+      const reasons = [];
+      if (!advisoryConvergencePreconditionOpenForDetail) {
+        reasons.push(
+          'its deadline/terminal precondition has not opened -- ' +
+            `deadlineMinutes=${deadlineMinutes}, ` +
+            `elapsedMinutes=${elapsedMinutes ?? 'unknown'}, ` +
+            `remainingMinutes=${remainingMinutes ?? 'unknown'}, ` +
+            `terminalUnavailable=${Boolean(advisoryConvergencePrecondition.terminalUnavailable)}`,
+        );
+      }
+      if (advisoryConvergenceExactWaiverCount === 0) {
+        reasons.push(
+          'no posted waiver has a selector that EXACTLY equals ' +
+            `"${advisoryConvergenceCheckSelector}" (only a broader/glob ` +
+            "selector matches this check by name); advisory-convergence.mts's " +
+            'own gate never counts a glob match for its own selector, so ' +
+            'this check cannot converge via that waiver regardless of the ' +
+            'precondition',
+        );
+      }
       detail +=
-        ` (a posted external-check waiver for "${advisoryConvergenceCheckSelector}" ` +
-        'exists for current HEAD but is not yet active: its deadline/' +
-        'terminal precondition has not opened -- ' +
-        `deadlineMinutes=${deadlineMinutes}, ` +
-        `elapsedMinutes=${elapsedMinutes ?? 'unknown'}, ` +
-        `remainingMinutes=${remainingMinutes ?? 'unknown'}, ` +
-        `terminalUnavailable=${Boolean(advisoryConvergencePrecondition.terminalUnavailable)})`;
+        ` (a posted external-check waiver exists for current HEAD but is ` +
+        `not yet covering "${advisoryConvergenceCheckSelector}": ${reasons.join('; ')})`;
     }
     blockers.push({ gate: 'ci', detail });
   }
@@ -4837,36 +4873,43 @@ export function buildPreMergeReadinessSummary(
     terminalUnavailable: copilotUnavailable,
     open: advisoryConvergencePreconditionOpen,
   };
-  // The waiver evidence the CI gate actually consumes: identical to
-  // `waiverEvidence` except any `valid` entry that would cover the
-  // `idd-advisory-convergence` CHECK is excluded while the precondition
-  // above has not opened. Excluded by the SAME matching semantics
-  // `summarizeRequiredChecks`'s own `coveredByWaiver` computation uses below
-  // (`matchCheckSelectorLocal(name, w.checkSelector)`, glob-aware) rather
-  // than a strict `===` -- a hand-authored waiver whose selector is a glob
-  // (e.g. `idd-*`) still glob-matches the check name and must not slip
-  // through the precondition gate just because its literal selector string
-  // differs from the constant. Every entry that does NOT cover this check is
-  // unaffected -- this precondition is specific to the gate
-  // `advisory-convergence.mts` itself enforces for its own selector.
-  const ciWaiverEvidence = advisoryConvergencePreconditionOpen
-    ? waiverEvidence
-    : {
-        ...waiverEvidence,
-        valid: waiverEvidence.valid.filter(
-          (entry) =>
-            !matchCheckSelectorLocal(
-              DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
-              entry.checkSelector,
-            ),
-        ),
-      };
+  // #2021 (Codex review on PR #2033, two findings): `advisory-convergence.mts`'s
+  // own `waived` computation only counts a waiver whose `checkSelector` is an
+  // EXACT match to its selector constant (`entry.checkSelector ===
+  // waiverCheckSelector`, advisory-convergence.mts line ~1108) -- never a
+  // glob. A glob waiver such as `idd-*` (permitted when
+  // `waivableCheckSelectors` allows it) would still glob-match the
+  // `idd-advisory-convergence` CHECK NAME via `summarizeRequiredChecks`'s
+  // `matchCheckSelectorLocal`, so treating "precondition open" as sufficient
+  // to fall back to the raw, unfiltered `waiverEvidence` (as an earlier
+  // revision of this fix did) would report `coveredByWaiver: true` for a
+  // selector that gate would never itself accept -- reproducing this same
+  // issue's false-`ready` class for a different trigger. `genuinelyCovered`
+  // requires BOTH the precondition open AND an EXACT-match valid entry.
+  const advisoryConvergenceExactWaiverValid = waiverEvidence.valid.some(
+    (entry) =>
+      entry.checkSelector === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+  );
+  const advisoryConvergenceGenuinelyCovered =
+    advisoryConvergencePreconditionOpen && advisoryConvergenceExactWaiverValid;
   const ci = summarizeRequiredChecks(checks, branchRules, branchProtection, {
-    waivers: ciWaiverEvidence,
+    // Raw, UNFILTERED `waiverEvidence` -- deliberately not a caller-side
+    // pre-filtered copy. A pre-filter that removed a whole `valid` entry
+    // (e.g. every occurrence of a glob waiver covering
+    // `idd-advisory-convergence`) would also strip that SAME entry's
+    // coverage of any OTHER check it glob-matches (e.g. a configured
+    // `idd-security`), turning a convergence-specific restriction into an
+    // unintended block on unrelated checks (Codex review finding on PR
+    // #2033). `excludeFromWaiverCoverage` below applies the restriction
+    // surgically, per check name, instead.
+    waivers: waiverEvidence,
     waivableSelectors: waivableCheckSelectors,
     protectionReadsUnreadable,
     trustSourcePinnedRequiredChecks:
       options.trustSourcePinnedRequiredChecks === true,
+    excludeFromWaiverCoverage: (name) =>
+      name === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
+      !advisoryConvergenceGenuinelyCovered,
   });
   // #1570: reuse the SAME raw waiver evidence above (already validated for
   // selector/HEAD/claim/authority/expiry) to decide whether the caller-

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -6,6 +6,7 @@
 import { Buffer } from 'node:buffer';
 import {
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+  DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES,
   DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
   normalizeAdvisoryWaitRuntimeOptions,
 } from './advisory-wait-policy.mjs';
@@ -76,6 +77,18 @@ export function parsePaginatedGhNdjson(raw) {
       return Array.isArray(value) ? value : [value];
     });
 }
+/** Check-run states treated as pass-equivalent for the CI required-check
+ * gate: a check in one of these states is never eligible for waiver
+ * coverage (already passing, or intentionally not run) and never counts as
+ * a genuinely non-passing cause. Hoisted to module scope (#2021) so both
+ * {@link summarizeRequiredChecks} and {@link computePreMergeReadinessBlockers}
+ * share one definition instead of two independently-maintained copies. */
+const CHECK_PASS_EQUIVALENT_STATES = new Set([
+  'SUCCESS',
+  'SKIPPED',
+  'NEUTRAL',
+  'NOT_APPLICABLE',
+]);
 function matchCheckSelectorLocal(name, selector, matchMode) {
   const n = String(name ?? '').trim();
   const s = String(selector ?? '').trim();
@@ -3314,17 +3327,11 @@ export function summarizeRequiredChecks(
   const requiredCheckNames = branchReviewRequirements.requiredCheckNames;
   const requiredCheckNameSet = new Set(requiredCheckNames);
   const validWaivers = waivers?.valid ?? [];
-  const SUCCESS_STATES = new Set([
-    'SUCCESS',
-    'SKIPPED',
-    'NEUTRAL',
-    'NOT_APPLICABLE',
-  ]);
   const normalizedChecks = checks.map((check) => {
     const name = String(check.name ?? '');
     const state = String(check.state ?? '').toUpperCase();
     const coveredByWaiver =
-      !SUCCESS_STATES.has(state) &&
+      !CHECK_PASS_EQUIVALENT_STATES.has(state) &&
       validWaivers.some((w) =>
         matchCheckSelectorLocal(name, w.checkSelector),
       ) &&
@@ -4458,11 +4465,74 @@ export function computePreMergeReadinessBlockers(report) {
     // #1377: name the masked-403-as-404 cause explicitly when that is why the
     // gate is not all-passing, matching idd-ci.instructions.md's wording,
     // instead of the generic status/noRequiredChecksConfigured detail below.
-    const detail =
+    let detail =
       ci.protectionReadsUnreadable === true
         ? 'cannot determine required checks: protection/ruleset unreadable'
         : sourcePinnedDetail ||
           `CI is not all-passing (status="${String(ci.status ?? '')}", noRequiredChecksConfigured=${Boolean(ci.noRequiredChecksConfigured)}, presentRunConclusion="${String(ci.presentRunConclusion ?? '')}")`;
+    // #2021: when the `idd-advisory-convergence` check itself is present,
+    // required, and non-passing, and a posted otherwise-valid waiver exists
+    // for it but is not yet covering the check because its deadline/
+    // terminal precondition has not opened (see
+    // `advisoryConvergenceWaiverPrecondition` in
+    // `buildPreMergeReadinessSummary`), append that evidence -- including
+    // the remaining time-to-deadline -- so an agent reading this blocker
+    // does not have to independently re-derive it or mistake "waiver
+    // posted" for "check covered". Scoped to that specific check (not just
+    // "some ci blocker exists") so an unrelated failing check (e.g. lint)
+    // never gets this note appended.
+    const advisoryConvergencePrecondition = preMergeAsRecord(
+      report.advisoryConvergenceWaiverPrecondition,
+    );
+    const advisoryConvergenceCheckSelector = String(
+      advisoryConvergencePrecondition.checkSelector ?? '',
+    );
+    const advisoryConvergenceCheckNonPassing =
+      advisoryConvergenceCheckSelector &&
+      Array.isArray(ci.checks) &&
+      ci.checks.some(
+        (check) =>
+          check?.required === true &&
+          check?.coveredByWaiver !== true &&
+          !CHECK_PASS_EQUIVALENT_STATES.has(String(check?.state ?? '')) &&
+          matchCheckSelectorLocal(
+            check?.name,
+            advisoryConvergenceCheckSelector,
+          ),
+      );
+    const waiverEvidenceForDetail = preMergeAsRecord(report.waiverEvidence);
+    const advisoryConvergenceValidWaiverCount = Array.isArray(
+      waiverEvidenceForDetail.valid,
+    )
+      ? waiverEvidenceForDetail.valid.filter((entry) =>
+          matchCheckSelectorLocal(
+            advisoryConvergenceCheckSelector,
+            entry?.checkSelector,
+          ),
+        ).length
+      : 0;
+    if (
+      advisoryConvergenceCheckNonPassing &&
+      advisoryConvergenceValidWaiverCount > 0 &&
+      advisoryConvergencePrecondition.open !== true
+    ) {
+      const deadlineMinutes = Number(
+        advisoryConvergencePrecondition.deadlineMinutes ?? 0,
+      );
+      const elapsedMinutes = advisoryConvergencePrecondition.elapsedMinutes;
+      const remainingMinutes =
+        typeof elapsedMinutes === 'number'
+          ? Math.max(0, deadlineMinutes - elapsedMinutes)
+          : null;
+      detail +=
+        ` (a posted external-check waiver for "${advisoryConvergenceCheckSelector}" ` +
+        'exists for current HEAD but is not yet active: its deadline/' +
+        'terminal precondition has not opened -- ' +
+        `deadlineMinutes=${deadlineMinutes}, ` +
+        `elapsedMinutes=${elapsedMinutes ?? 'unknown'}, ` +
+        `remainingMinutes=${remainingMinutes ?? 'unknown'}, ` +
+        `terminalUnavailable=${Boolean(advisoryConvergencePrecondition.terminalUnavailable)})`;
+    }
     blockers.push({ gate: 'ci', detail });
   }
   const reviewerStates = preMergeAsRecord(report.reviewerStates);
@@ -4724,22 +4794,92 @@ export function buildPreMergeReadinessSummary(
     waivableSelectors: waivableCheckSelectors,
     maxValidity: options.externalCheckWaiverMaxValidity ?? '',
   });
+  // #1570: the caller-supplied terminal-unavailability verdict, reused below
+  // both for the dedicated `copilot-terminal-unavailable` blocker and (#2021)
+  // as one of the two preconditions that must open before an
+  // `idd-advisory-convergence` waiver counts toward `ci.coveredByWaiver`.
+  const copilotUnavailable = options.copilotUnavailable === true;
+  // #2021: `advisory-convergence.mts`'s own gate never treats a posted
+  // `idd-advisory-convergence` waiver as active until ONE of two independent
+  // preconditions is ALSO true -- a 24h deadline anchored on the current HEAD
+  // commit's own `committedDate`, or proven terminal Copilot unavailability
+  // (`copilotUnavailable` above). Reported truthfully in `waiverEvidence`
+  // itself either way (the marker is real and otherwise valid), but a check
+  // only becomes `coveredByWaiver` here once this SAME precondition has
+  // opened -- otherwise this helper reports `coveredByWaiver: true` before
+  // `advisory-convergence.mts` itself would ever call the waiver `waived`,
+  // sending an otherwise-correct session into a `gh pr merge` GitHub rejects
+  // outright (root cause: kurone-kito/idd-skill#2021).
+  const advisoryConvergenceDeadlineMinutes = Number.isFinite(
+    options.advisoryConvergenceDeadlineMinutes,
+  )
+    ? Number(options.advisoryConvergenceDeadlineMinutes)
+    : DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
+  const advisoryConvergenceHeadCommittedAt = String(
+    options.advisoryConvergenceHeadCommittedAt ?? '',
+  );
+  const advisoryConvergenceElapsedMinutes = isValidIsoTimestamp(
+    advisoryConvergenceHeadCommittedAt,
+  )
+    ? minutesBetweenIso(advisoryConvergenceHeadCommittedAt, now)
+    : null;
+  const advisoryConvergenceDeadlinePassed =
+    advisoryConvergenceElapsedMinutes !== null &&
+    advisoryConvergenceElapsedMinutes >= advisoryConvergenceDeadlineMinutes;
+  const advisoryConvergencePreconditionOpen =
+    advisoryConvergenceDeadlinePassed || copilotUnavailable;
+  const advisoryConvergenceWaiverPrecondition = {
+    checkSelector: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+    deadlineMinutes: advisoryConvergenceDeadlineMinutes,
+    headCommittedAt: advisoryConvergenceHeadCommittedAt || 'none',
+    elapsedMinutes: advisoryConvergenceElapsedMinutes,
+    deadlinePassed: advisoryConvergenceDeadlinePassed,
+    terminalUnavailable: copilotUnavailable,
+    open: advisoryConvergencePreconditionOpen,
+  };
+  // The waiver evidence the CI gate actually consumes: identical to
+  // `waiverEvidence` except any `valid` entry that would cover the
+  // `idd-advisory-convergence` CHECK is excluded while the precondition
+  // above has not opened. Excluded by the SAME matching semantics
+  // `summarizeRequiredChecks`'s own `coveredByWaiver` computation uses below
+  // (`matchCheckSelectorLocal(name, w.checkSelector)`, glob-aware) rather
+  // than a strict `===` -- a hand-authored waiver whose selector is a glob
+  // (e.g. `idd-*`) still glob-matches the check name and must not slip
+  // through the precondition gate just because its literal selector string
+  // differs from the constant. Every entry that does NOT cover this check is
+  // unaffected -- this precondition is specific to the gate
+  // `advisory-convergence.mts` itself enforces for its own selector.
+  const ciWaiverEvidence = advisoryConvergencePreconditionOpen
+    ? waiverEvidence
+    : {
+        ...waiverEvidence,
+        valid: waiverEvidence.valid.filter(
+          (entry) =>
+            !matchCheckSelectorLocal(
+              DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+              entry.checkSelector,
+            ),
+        ),
+      };
   const ci = summarizeRequiredChecks(checks, branchRules, branchProtection, {
-    waivers: waiverEvidence,
+    waivers: ciWaiverEvidence,
     waivableSelectors: waivableCheckSelectors,
     protectionReadsUnreadable,
     trustSourcePinnedRequiredChecks:
       options.trustSourcePinnedRequiredChecks === true,
   });
-  // #1570: reuse the SAME waiver evidence above (already validated for
+  // #1570: reuse the SAME raw waiver evidence above (already validated for
   // selector/HEAD/claim/authority/expiry) to decide whether the caller-
   // supplied terminal-unavailability verdict is also validly waived, filtered
   // to the `idd-advisory-convergence` selector -- the identical selector
   // advisory-convergence.mts's own terminal-waiver path consumes, so a single
   // maintainer-posted waiver marker satisfies whichever gate (the CI
   // required-check, or this direct F2/F3 evidence collector) is currently
-  // asking.
-  const copilotUnavailable = options.copilotUnavailable === true;
+  // asking. Deliberately reads the RAW `waiverEvidence`, not
+  // `ciWaiverEvidence`: this blocker is itself gated on
+  // `copilotUnavailable === true` (the terminal precondition already proven),
+  // so the deadline-vs-terminal precondition split above would be redundant
+  // here.
   const copilotUnavailableWaived =
     copilotUnavailable &&
     waiverEvidence.valid.some(
@@ -4821,6 +4961,12 @@ export function buildPreMergeReadinessSummary(
     ci,
     claim,
     waiverEvidence,
+    // #2021: the deadline/terminal precondition evaluated above, reported
+    // unconditionally as its own field (never folded into `waiverEvidence`,
+    // whose shape is the schema-locked `ExternalCheckWaiverEvidence`) so a
+    // blocker detail or a resuming agent can cite the remaining
+    // time-to-deadline without re-deriving it.
+    advisoryConvergenceWaiverPrecondition,
     branchCurrency,
   };
   if (dispositionEvidence) {

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -8,6 +8,7 @@
 import { readFileSync } from 'node:fs';
 
 import {
+  readAdvisoryConvergenceDeadlineMinutes,
   readAdvisoryPrimaryBotLogin,
   readAdvisoryRecoveryCycleCap,
   readAdvisoryTerminalWindowMinutes,
@@ -53,6 +54,7 @@ import {
   resolveTrustedMarkerActors,
   selectCodeownersText,
 } from './protocol-helpers.mts';
+import { fetchReviewsAndHeadCommit } from './review-clause.mts';
 
 /** Author reference embedded in GitHub REST/GraphQL payloads. */
 interface GhAuthorPayload {
@@ -627,6 +629,24 @@ export function collectPreMergeReadiness(
   );
   const copilotUnavailable = copilotRecovery.state === 'COPILOT_UNAVAILABLE';
 
+  // #2021: fetch the current HEAD commit's own `committedDate` via the SAME
+  // GraphQL field `advisory-convergence.mts`'s own deadline clock reads
+  // (`fetchReviewsAndHeadCommit`, extracted to `review-clause.mts` precisely
+  // so a second, independent caller can reuse this exact evidence instead of
+  // a second ad-hoc GraphQL path that could drift out of sync with it -- see
+  // that module's header). Only `headCommittedAt` is used here; the
+  // paginated `reviews` return value is discarded since this caller already
+  // fetched reviews separately via REST above. Deliberately uncaught, same
+  // rationale as `copilotUnavailable` immediately above: a lookup failure
+  // must crash this evidence collector rather than silently resolve to an
+  // empty `headCommittedAt`, which would make `advisoryConvergenceDeadlinePassed`
+  // fail closed to `false` for the wrong reason (masking a genuinely-open
+  // deadline as unreadable evidence instead of surfacing the fetch failure).
+  const { headCommittedAt: advisoryConvergenceHeadCommittedAt } =
+    fetchReviewsAndHeadCommit(owner, repo, args.prNumber);
+  const advisoryConvergenceDeadlineMinutes =
+    readAdvisoryConvergenceDeadlineMinutes();
+
   const summary = buildPreMergeReadinessSummary(
     {
       prHeadSha,
@@ -677,6 +697,8 @@ export function collectPreMergeReadiness(
       capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
       primaryBotLogin,
       copilotUnavailable,
+      advisoryConvergenceHeadCommittedAt,
+      advisoryConvergenceDeadlineMinutes,
       waivableCheckSelectors,
       externalCheckWaiverMaxValidity,
       trustSourcePinnedRequiredChecks,

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4257,11 +4257,26 @@ export function summarizeRequiredChecks(
     waivableSelectors = null,
     protectionReadsUnreadable = false,
     trustSourcePinnedRequiredChecks = false,
+    excludeFromWaiverCoverage = null,
   }: {
     waivers?: { valid?: { checkSelector?: unknown }[] | null } | null;
     waivableSelectors?: { selector?: unknown; matchMode?: unknown }[] | null;
     // #1377: see `buildPreMergeReadinessSummary`'s option of the same name.
     protectionReadsUnreadable?: boolean;
+    // #2021 (Codex review on PR #2033): surgical per-CHECK-NAME override that
+    // withholds `coveredByWaiver` for one specific check regardless of which
+    // `waivers.valid` entry would otherwise match it -- WITHOUT filtering
+    // that entry out of `waivers.valid` itself, so any OTHER check the same
+    // (e.g. glob) waiver entry also covers is completely unaffected. Exists
+    // because `buildPreMergeReadinessSummary`'s `idd-advisory-convergence`
+    // precondition gate (#2021) must withhold coverage for THAT one check
+    // when the precondition hasn't opened or only a glob (non-exact)
+    // selector matches it, but a caller-side pre-filter of `waivers.valid`
+    // would incorrectly also strip that same waiver's coverage of an
+    // unrelated check the glob also names. `null`/omitted (the default)
+    // never excludes anything -- unchanged pre-#2021 behavior for every
+    // caller that doesn't pass it.
+    excludeFromWaiverCoverage?: ((checkName: string) => boolean) | null;
     // #1689: `ciGate.trustSourcePinnedRequiredChecks` opt-in (mirrors
     // `ciGate.trustEmptyProtectionReads`'s shape). Default `false` keeps the
     // pre-#1689 conservative behavior: a required check whose ruleset entry
@@ -4297,6 +4312,10 @@ export function summarizeRequiredChecks(
     const state = String(check.state ?? '').toUpperCase();
     const coveredByWaiver =
       !CHECK_PASS_EQUIVALENT_STATES.has(state) &&
+      !(
+        typeof excludeFromWaiverCoverage === 'function' &&
+        excludeFromWaiverCoverage(name)
+      ) &&
       validWaivers.some((w) =>
         matchCheckSelectorLocal(name, w.checkSelector),
       ) &&
@@ -5663,21 +5682,36 @@ export function computePreMergeReadinessBlockers(
           ),
       );
     const waiverEvidenceForDetail = preMergeAsRecord(report.waiverEvidence);
-    const advisoryConvergenceValidWaiverCount = Array.isArray(
-      waiverEvidenceForDetail.valid,
-    )
-      ? (waiverEvidenceForDetail.valid as Record<string, unknown>[]).filter(
-          (entry) =>
-            matchCheckSelectorLocal(
-              advisoryConvergenceCheckSelector,
-              entry?.checkSelector,
-            ),
-        ).length
-      : 0;
+    const waiverEvidenceValidList = Array.isArray(waiverEvidenceForDetail.valid)
+      ? (waiverEvidenceForDetail.valid as Record<string, unknown>[])
+      : [];
+    // #2021 (Codex review on PR #2033): distinguish an EXACT-selector waiver
+    // (the only kind `advisory-convergence.mts`'s own gate ever counts, see
+    // `advisoryConvergenceExactWaiverValid` in `buildPreMergeReadinessSummary`)
+    // from a broader glob-only match, so this detail never implies "posting
+    // an exact waiver and waiting out the deadline is sufficient" when the
+    // real cause is that only a glob selector (e.g. `idd-*`) targets this
+    // check -- that never converges no matter how long the deadline waits.
+    const advisoryConvergenceExactWaiverCount = waiverEvidenceValidList.filter(
+      (entry) =>
+        String(entry?.checkSelector ?? '') === advisoryConvergenceCheckSelector,
+    ).length;
+    const advisoryConvergenceAnyWaiverCount = waiverEvidenceValidList.filter(
+      (entry) =>
+        matchCheckSelectorLocal(
+          advisoryConvergenceCheckSelector,
+          entry?.checkSelector,
+        ),
+    ).length;
+    const advisoryConvergencePreconditionOpenForDetail =
+      advisoryConvergencePrecondition.open === true;
     if (
       advisoryConvergenceCheckNonPassing &&
-      advisoryConvergenceValidWaiverCount > 0 &&
-      advisoryConvergencePrecondition.open !== true
+      advisoryConvergenceAnyWaiverCount > 0 &&
+      !(
+        advisoryConvergencePreconditionOpenForDetail &&
+        advisoryConvergenceExactWaiverCount > 0
+      )
     ) {
       const deadlineMinutes = Number(
         advisoryConvergencePrecondition.deadlineMinutes ?? 0,
@@ -5687,16 +5721,31 @@ export function computePreMergeReadinessBlockers(
         typeof elapsedMinutes === 'number'
           ? Math.max(0, deadlineMinutes - elapsedMinutes)
           : null;
+      const reasons: string[] = [];
+      if (!advisoryConvergencePreconditionOpenForDetail) {
+        reasons.push(
+          'its deadline/terminal precondition has not opened -- ' +
+            `deadlineMinutes=${deadlineMinutes}, ` +
+            `elapsedMinutes=${elapsedMinutes ?? 'unknown'}, ` +
+            `remainingMinutes=${remainingMinutes ?? 'unknown'}, ` +
+            `terminalUnavailable=${Boolean(
+              advisoryConvergencePrecondition.terminalUnavailable,
+            )}`,
+        );
+      }
+      if (advisoryConvergenceExactWaiverCount === 0) {
+        reasons.push(
+          'no posted waiver has a selector that EXACTLY equals ' +
+            `"${advisoryConvergenceCheckSelector}" (only a broader/glob ` +
+            "selector matches this check by name); advisory-convergence.mts's " +
+            'own gate never counts a glob match for its own selector, so ' +
+            'this check cannot converge via that waiver regardless of the ' +
+            'precondition',
+        );
+      }
       detail +=
-        ` (a posted external-check waiver for "${advisoryConvergenceCheckSelector}" ` +
-        'exists for current HEAD but is not yet active: its deadline/' +
-        'terminal precondition has not opened -- ' +
-        `deadlineMinutes=${deadlineMinutes}, ` +
-        `elapsedMinutes=${elapsedMinutes ?? 'unknown'}, ` +
-        `remainingMinutes=${remainingMinutes ?? 'unknown'}, ` +
-        `terminalUnavailable=${Boolean(
-          advisoryConvergencePrecondition.terminalUnavailable,
-        )})`;
+        ` (a posted external-check waiver exists for current HEAD but is ` +
+        `not yet covering "${advisoryConvergenceCheckSelector}": ${reasons.join('; ')})`;
     }
     blockers.push({ gate: 'ci', detail });
   }
@@ -6162,37 +6211,44 @@ export function buildPreMergeReadinessSummary(
     open: advisoryConvergencePreconditionOpen,
   };
 
-  // The waiver evidence the CI gate actually consumes: identical to
-  // `waiverEvidence` except any `valid` entry that would cover the
-  // `idd-advisory-convergence` CHECK is excluded while the precondition
-  // above has not opened. Excluded by the SAME matching semantics
-  // `summarizeRequiredChecks`'s own `coveredByWaiver` computation uses below
-  // (`matchCheckSelectorLocal(name, w.checkSelector)`, glob-aware) rather
-  // than a strict `===` -- a hand-authored waiver whose selector is a glob
-  // (e.g. `idd-*`) still glob-matches the check name and must not slip
-  // through the precondition gate just because its literal selector string
-  // differs from the constant. Every entry that does NOT cover this check is
-  // unaffected -- this precondition is specific to the gate
-  // `advisory-convergence.mts` itself enforces for its own selector.
-  const ciWaiverEvidence = advisoryConvergencePreconditionOpen
-    ? waiverEvidence
-    : {
-        ...waiverEvidence,
-        valid: waiverEvidence.valid.filter(
-          (entry) =>
-            !matchCheckSelectorLocal(
-              DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
-              entry.checkSelector,
-            ),
-        ),
-      };
+  // #2021 (Codex review on PR #2033, two findings): `advisory-convergence.mts`'s
+  // own `waived` computation only counts a waiver whose `checkSelector` is an
+  // EXACT match to its selector constant (`entry.checkSelector ===
+  // waiverCheckSelector`, advisory-convergence.mts line ~1108) -- never a
+  // glob. A glob waiver such as `idd-*` (permitted when
+  // `waivableCheckSelectors` allows it) would still glob-match the
+  // `idd-advisory-convergence` CHECK NAME via `summarizeRequiredChecks`'s
+  // `matchCheckSelectorLocal`, so treating "precondition open" as sufficient
+  // to fall back to the raw, unfiltered `waiverEvidence` (as an earlier
+  // revision of this fix did) would report `coveredByWaiver: true` for a
+  // selector that gate would never itself accept -- reproducing this same
+  // issue's false-`ready` class for a different trigger. `genuinelyCovered`
+  // requires BOTH the precondition open AND an EXACT-match valid entry.
+  const advisoryConvergenceExactWaiverValid = waiverEvidence.valid.some(
+    (entry) =>
+      entry.checkSelector === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+  );
+  const advisoryConvergenceGenuinelyCovered =
+    advisoryConvergencePreconditionOpen && advisoryConvergenceExactWaiverValid;
 
   const ci = summarizeRequiredChecks(checks, branchRules, branchProtection, {
-    waivers: ciWaiverEvidence,
+    // Raw, UNFILTERED `waiverEvidence` -- deliberately not a caller-side
+    // pre-filtered copy. A pre-filter that removed a whole `valid` entry
+    // (e.g. every occurrence of a glob waiver covering
+    // `idd-advisory-convergence`) would also strip that SAME entry's
+    // coverage of any OTHER check it glob-matches (e.g. a configured
+    // `idd-security`), turning a convergence-specific restriction into an
+    // unintended block on unrelated checks (Codex review finding on PR
+    // #2033). `excludeFromWaiverCoverage` below applies the restriction
+    // surgically, per check name, instead.
+    waivers: waiverEvidence,
     waivableSelectors: waivableCheckSelectors,
     protectionReadsUnreadable,
     trustSourcePinnedRequiredChecks:
       options.trustSourcePinnedRequiredChecks === true,
+    excludeFromWaiverCoverage: (name) =>
+      name === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
+      !advisoryConvergenceGenuinelyCovered,
   });
 
   // #1570: reuse the SAME raw waiver evidence above (already validated for

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -7,6 +7,7 @@
 import { Buffer } from 'node:buffer';
 import {
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+  DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES,
   DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
   normalizeAdvisoryWaitRuntimeOptions,
 } from './advisory-wait-policy.mts';
@@ -545,6 +546,19 @@ export function parsePaginatedGhNdjson(raw: unknown): unknown[] {
       return Array.isArray(value) ? value : [value];
     });
 }
+
+/** Check-run states treated as pass-equivalent for the CI required-check
+ * gate: a check in one of these states is never eligible for waiver
+ * coverage (already passing, or intentionally not run) and never counts as
+ * a genuinely non-passing cause. Hoisted to module scope (#2021) so both
+ * {@link summarizeRequiredChecks} and {@link computePreMergeReadinessBlockers}
+ * share one definition instead of two independently-maintained copies. */
+const CHECK_PASS_EQUIVALENT_STATES = new Set([
+  'SUCCESS',
+  'SKIPPED',
+  'NEUTRAL',
+  'NOT_APPLICABLE',
+]);
 
 function matchCheckSelectorLocal(
   name: unknown,
@@ -4277,18 +4291,12 @@ export function summarizeRequiredChecks(
   const requiredCheckNames = branchReviewRequirements.requiredCheckNames;
   const requiredCheckNameSet = new Set(requiredCheckNames);
   const validWaivers = waivers?.valid ?? [];
-  const SUCCESS_STATES = new Set([
-    'SUCCESS',
-    'SKIPPED',
-    'NEUTRAL',
-    'NOT_APPLICABLE',
-  ]);
 
   const normalizedChecks = checks.map((check) => {
     const name = String(check.name ?? '');
     const state = String(check.state ?? '').toUpperCase();
     const coveredByWaiver =
-      !SUCCESS_STATES.has(state) &&
+      !CHECK_PASS_EQUIVALENT_STATES.has(state) &&
       validWaivers.some((w) =>
         matchCheckSelectorLocal(name, w.checkSelector),
       ) &&
@@ -5614,7 +5622,7 @@ export function computePreMergeReadinessBlockers(
     // #1377: name the masked-403-as-404 cause explicitly when that is why the
     // gate is not all-passing, matching idd-ci.instructions.md's wording,
     // instead of the generic status/noRequiredChecksConfigured detail below.
-    const detail =
+    let detail =
       ci.protectionReadsUnreadable === true
         ? 'cannot determine required checks: protection/ruleset unreadable'
         : sourcePinnedDetail ||
@@ -5623,6 +5631,73 @@ export function computePreMergeReadinessBlockers(
           )}", noRequiredChecksConfigured=${Boolean(
             ci.noRequiredChecksConfigured,
           )}, presentRunConclusion="${String(ci.presentRunConclusion ?? '')}")`;
+
+    // #2021: when the `idd-advisory-convergence` check itself is present,
+    // required, and non-passing, and a posted otherwise-valid waiver exists
+    // for it but is not yet covering the check because its deadline/
+    // terminal precondition has not opened (see
+    // `advisoryConvergenceWaiverPrecondition` in
+    // `buildPreMergeReadinessSummary`), append that evidence -- including
+    // the remaining time-to-deadline -- so an agent reading this blocker
+    // does not have to independently re-derive it or mistake "waiver
+    // posted" for "check covered". Scoped to that specific check (not just
+    // "some ci blocker exists") so an unrelated failing check (e.g. lint)
+    // never gets this note appended.
+    const advisoryConvergencePrecondition = preMergeAsRecord(
+      report.advisoryConvergenceWaiverPrecondition,
+    );
+    const advisoryConvergenceCheckSelector = String(
+      advisoryConvergencePrecondition.checkSelector ?? '',
+    );
+    const advisoryConvergenceCheckNonPassing =
+      advisoryConvergenceCheckSelector &&
+      Array.isArray(ci.checks) &&
+      (ci.checks as Record<string, unknown>[]).some(
+        (check) =>
+          check?.required === true &&
+          check?.coveredByWaiver !== true &&
+          !CHECK_PASS_EQUIVALENT_STATES.has(String(check?.state ?? '')) &&
+          matchCheckSelectorLocal(
+            check?.name,
+            advisoryConvergenceCheckSelector,
+          ),
+      );
+    const waiverEvidenceForDetail = preMergeAsRecord(report.waiverEvidence);
+    const advisoryConvergenceValidWaiverCount = Array.isArray(
+      waiverEvidenceForDetail.valid,
+    )
+      ? (waiverEvidenceForDetail.valid as Record<string, unknown>[]).filter(
+          (entry) =>
+            matchCheckSelectorLocal(
+              advisoryConvergenceCheckSelector,
+              entry?.checkSelector,
+            ),
+        ).length
+      : 0;
+    if (
+      advisoryConvergenceCheckNonPassing &&
+      advisoryConvergenceValidWaiverCount > 0 &&
+      advisoryConvergencePrecondition.open !== true
+    ) {
+      const deadlineMinutes = Number(
+        advisoryConvergencePrecondition.deadlineMinutes ?? 0,
+      );
+      const elapsedMinutes = advisoryConvergencePrecondition.elapsedMinutes;
+      const remainingMinutes =
+        typeof elapsedMinutes === 'number'
+          ? Math.max(0, deadlineMinutes - elapsedMinutes)
+          : null;
+      detail +=
+        ` (a posted external-check waiver for "${advisoryConvergenceCheckSelector}" ` +
+        'exists for current HEAD but is not yet active: its deadline/' +
+        'terminal precondition has not opened -- ' +
+        `deadlineMinutes=${deadlineMinutes}, ` +
+        `elapsedMinutes=${elapsedMinutes ?? 'unknown'}, ` +
+        `remainingMinutes=${remainingMinutes ?? 'unknown'}, ` +
+        `terminalUnavailable=${Boolean(
+          advisoryConvergencePrecondition.terminalUnavailable,
+        )})`;
+    }
     blockers.push({ gate: 'ci', detail });
   }
 
@@ -5842,6 +5917,23 @@ export function buildPreMergeReadinessSummary(
     // unavailable` blocker below, so an unmigrated caller sees unchanged
     // behavior.
     copilotUnavailable?: boolean;
+    // #2021: the current HEAD commit's own `committedDate` (GraphQL),
+    // anchoring the SAME 24h deadline clock `advisory-convergence.mts`'s own
+    // gate uses before treating a posted `idd-advisory-convergence` waiver as
+    // active. Sourced by the CALLER (`pre-merge-readiness.mts`, via the
+    // identical GraphQL field `review-clause.mts`'s `fetchReviewsAndHeadCommit`
+    // reads), mirroring how `copilotUnavailable` above is caller-precomputed.
+    // Omitted/invalid (the default) resolves `elapsedMinutes` to `null` and
+    // `deadlinePassed` to `false` -- the safer default, never falsely
+    // treating a still-open deadline as passed.
+    advisoryConvergenceHeadCommittedAt?: string | null;
+    // Configured `advisoryWait.convergenceDeadline` in minutes (#2021),
+    // resolved by the caller, mirroring `externalCheckWaiverMaxValidity`
+    // below's "policy value resolved by the CLI layer" pattern. Omitted by
+    // unit callers (falls back to the same 24h
+    // `DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES` default
+    // `advisory-convergence.mts` itself uses).
+    advisoryConvergenceDeadlineMinutes?: number;
     // Configured `ciGate.externalCheckWaivers.maxValidity` (ISO-8601 duration),
     // threaded to the consume-side waiver window check. Omitted by unit callers
     // (window check off); `collectPreMergeReadiness` always sources the policy
@@ -6024,23 +6116,97 @@ export function buildPreMergeReadinessSummary(
     waivableSelectors: waivableCheckSelectors,
     maxValidity: options.externalCheckWaiverMaxValidity ?? '',
   });
+
+  // #1570: the caller-supplied terminal-unavailability verdict, reused below
+  // both for the dedicated `copilot-terminal-unavailable` blocker and (#2021)
+  // as one of the two preconditions that must open before an
+  // `idd-advisory-convergence` waiver counts toward `ci.coveredByWaiver`.
+  const copilotUnavailable = options.copilotUnavailable === true;
+
+  // #2021: `advisory-convergence.mts`'s own gate never treats a posted
+  // `idd-advisory-convergence` waiver as active until ONE of two independent
+  // preconditions is ALSO true -- a 24h deadline anchored on the current HEAD
+  // commit's own `committedDate`, or proven terminal Copilot unavailability
+  // (`copilotUnavailable` above). Reported truthfully in `waiverEvidence`
+  // itself either way (the marker is real and otherwise valid), but a check
+  // only becomes `coveredByWaiver` here once this SAME precondition has
+  // opened -- otherwise this helper reports `coveredByWaiver: true` before
+  // `advisory-convergence.mts` itself would ever call the waiver `waived`,
+  // sending an otherwise-correct session into a `gh pr merge` GitHub rejects
+  // outright (root cause: kurone-kito/idd-skill#2021).
+  const advisoryConvergenceDeadlineMinutes = Number.isFinite(
+    options.advisoryConvergenceDeadlineMinutes,
+  )
+    ? Number(options.advisoryConvergenceDeadlineMinutes)
+    : DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
+  const advisoryConvergenceHeadCommittedAt = String(
+    options.advisoryConvergenceHeadCommittedAt ?? '',
+  );
+  const advisoryConvergenceElapsedMinutes = isValidIsoTimestamp(
+    advisoryConvergenceHeadCommittedAt,
+  )
+    ? minutesBetweenIso(advisoryConvergenceHeadCommittedAt, now)
+    : null;
+  const advisoryConvergenceDeadlinePassed =
+    advisoryConvergenceElapsedMinutes !== null &&
+    advisoryConvergenceElapsedMinutes >= advisoryConvergenceDeadlineMinutes;
+  const advisoryConvergencePreconditionOpen =
+    advisoryConvergenceDeadlinePassed || copilotUnavailable;
+  const advisoryConvergenceWaiverPrecondition = {
+    checkSelector: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+    deadlineMinutes: advisoryConvergenceDeadlineMinutes,
+    headCommittedAt: advisoryConvergenceHeadCommittedAt || 'none',
+    elapsedMinutes: advisoryConvergenceElapsedMinutes,
+    deadlinePassed: advisoryConvergenceDeadlinePassed,
+    terminalUnavailable: copilotUnavailable,
+    open: advisoryConvergencePreconditionOpen,
+  };
+
+  // The waiver evidence the CI gate actually consumes: identical to
+  // `waiverEvidence` except any `valid` entry that would cover the
+  // `idd-advisory-convergence` CHECK is excluded while the precondition
+  // above has not opened. Excluded by the SAME matching semantics
+  // `summarizeRequiredChecks`'s own `coveredByWaiver` computation uses below
+  // (`matchCheckSelectorLocal(name, w.checkSelector)`, glob-aware) rather
+  // than a strict `===` -- a hand-authored waiver whose selector is a glob
+  // (e.g. `idd-*`) still glob-matches the check name and must not slip
+  // through the precondition gate just because its literal selector string
+  // differs from the constant. Every entry that does NOT cover this check is
+  // unaffected -- this precondition is specific to the gate
+  // `advisory-convergence.mts` itself enforces for its own selector.
+  const ciWaiverEvidence = advisoryConvergencePreconditionOpen
+    ? waiverEvidence
+    : {
+        ...waiverEvidence,
+        valid: waiverEvidence.valid.filter(
+          (entry) =>
+            !matchCheckSelectorLocal(
+              DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+              entry.checkSelector,
+            ),
+        ),
+      };
+
   const ci = summarizeRequiredChecks(checks, branchRules, branchProtection, {
-    waivers: waiverEvidence,
+    waivers: ciWaiverEvidence,
     waivableSelectors: waivableCheckSelectors,
     protectionReadsUnreadable,
     trustSourcePinnedRequiredChecks:
       options.trustSourcePinnedRequiredChecks === true,
   });
 
-  // #1570: reuse the SAME waiver evidence above (already validated for
+  // #1570: reuse the SAME raw waiver evidence above (already validated for
   // selector/HEAD/claim/authority/expiry) to decide whether the caller-
   // supplied terminal-unavailability verdict is also validly waived, filtered
   // to the `idd-advisory-convergence` selector -- the identical selector
   // advisory-convergence.mts's own terminal-waiver path consumes, so a single
   // maintainer-posted waiver marker satisfies whichever gate (the CI
   // required-check, or this direct F2/F3 evidence collector) is currently
-  // asking.
-  const copilotUnavailable = options.copilotUnavailable === true;
+  // asking. Deliberately reads the RAW `waiverEvidence`, not
+  // `ciWaiverEvidence`: this blocker is itself gated on
+  // `copilotUnavailable === true` (the terminal precondition already proven),
+  // so the deadline-vs-terminal precondition split above would be redundant
+  // here.
   const copilotUnavailableWaived =
     copilotUnavailable &&
     waiverEvidence.valid.some(
@@ -6127,6 +6293,12 @@ export function buildPreMergeReadinessSummary(
     ci,
     claim,
     waiverEvidence,
+    // #2021: the deadline/terminal precondition evaluated above, reported
+    // unconditionally as its own field (never folded into `waiverEvidence`,
+    // whose shape is the schema-locked `ExternalCheckWaiverEvidence`) so a
+    // blocker detail or a resuming agent can cite the remaining
+    // time-to-deadline without re-deriving it.
+    advisoryConvergenceWaiverPrecondition,
     branchCurrency,
   };
 

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -6292,7 +6292,11 @@ test('#2021: idd-advisory-convergence waiver posted but precondition window not 
   assert.ok(ciBlocker, 'expected a ci blocker');
   assert.match(
     ciBlocker?.detail ?? '',
-    /idd-advisory-convergence.*not yet active/,
+    /not yet covering "idd-advisory-convergence"/,
+  );
+  assert.match(
+    ciBlocker?.detail ?? '',
+    /deadline\/terminal precondition has not opened/,
   );
   assert.match(ciBlocker?.detail ?? '', /remainingMinutes=1380/);
 });
@@ -6362,6 +6366,169 @@ test('#2021: a glob-selector waiver (e.g. idd-*) is also withheld from coveredBy
   );
   assert.equal(blocked.ready, false);
   assert.deepEqual(blocked.blockers, computePreMergeReadinessBlockers(blocked));
+});
+
+// #2021 (Codex review finding 1 on PR #2033): a glob-selector waiver must
+// stay withheld from `coveredByWaiver` even AFTER the deadline/terminal
+// precondition opens -- `advisory-convergence.mts`'s own `waived`
+// computation only counts an EXACT selector match
+// (`entry.checkSelector === waiverCheckSelector`), never a glob, so a
+// glob-only waiver never converges that gate no matter how long the
+// deadline waits. Distinct from the sibling test above, which covers the
+// precondition-CLOSED case for the same glob selector.
+test('#2021: a glob-selector waiver (e.g. idd-*) still does not cover coveredByWaiver once the precondition opens (only an exact selector match does)', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const input = withAdvisoryConvergenceRequiredCheck(fixture);
+  const waivableCheckSelectors = [{ selector: 'idd-*', matchMode: 'glob' }];
+  const waiverBody = renderExternalCheckWaiverComment({
+    agentId: fixture.options.expectedAgentId,
+    claimId: fixture.options.expectedClaimId,
+    headSha: fixture.input.prHeadSha,
+    checkSelector: 'idd-*',
+    reason: 'blanket idd-* waiver posted by mistake',
+    expiresAt: '2026-05-13T00:00:00Z',
+    actor: 'kurone-kito',
+  });
+
+  const blocked = buildPreMergeReadinessSummary(
+    {
+      ...input,
+      comments: [
+        ...(input.comments ?? []),
+        {
+          id: 'glob-waiver-open',
+          author: { login: 'kurone-kito' },
+          body: waiverBody,
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T00:00:00Z',
+        },
+      ],
+    },
+    {
+      ...fixture.options,
+      includeDispositionEvidence: true,
+      waivableCheckSelectors,
+      externalCheckWaiverMaxValidity: 'PT24H',
+      // Precondition OPEN this time: deadline has passed.
+      advisoryConvergenceHeadCommittedAt: '2026-05-10T23:00:00Z',
+    },
+  );
+
+  const precondition = (
+    blocked as {
+      advisoryConvergenceWaiverPrecondition: Record<string, unknown>;
+    }
+  ).advisoryConvergenceWaiverPrecondition;
+  assert.equal(
+    precondition.open,
+    true,
+    'sanity check: the precondition is open',
+  );
+
+  const check = ciCheckByName(blocked, 'idd-advisory-convergence');
+  assert.equal(
+    check?.coveredByWaiver,
+    undefined,
+    'a glob-only waiver must never cover this check, even once the precondition opens',
+  );
+  assert.equal(blocked.ready, false);
+  assert.deepEqual(blocked.blockers, computePreMergeReadinessBlockers(blocked));
+  const ciBlocker = (
+    blocked.blockers as { gate: string; detail: string }[]
+  ).find((blocker) => blocker.gate === 'ci');
+  assert.match(
+    ciBlocker?.detail ?? '',
+    /no posted waiver has a selector that EXACTLY equals/,
+  );
+});
+
+// #2021 (Codex review finding 2 on PR #2033): withholding coveredByWaiver
+// for idd-advisory-convergence must not strip the SAME glob waiver's
+// coverage of a completely unrelated check it also names -- the exclusion
+// must be surgical, per check name, not a removal of the whole waiver
+// entry.
+test('#2021: withholding coverage from idd-advisory-convergence does not remove the same glob waiver from an unrelated check', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const branchRules = (
+    fixture.input.branchRules as Record<string, unknown>[]
+  ).map((rule) =>
+    rule.type === 'required_status_checks'
+      ? {
+          type: 'required_status_checks',
+          parameters: {
+            required_status_checks: [
+              { context: 'lint' },
+              { context: 'idd-advisory-convergence' },
+              { context: 'idd-security' },
+            ],
+          },
+        }
+      : rule,
+  );
+  const checks = [
+    ...(fixture.input.checks as Record<string, unknown>[]),
+    {
+      name: 'idd-advisory-convergence',
+      state: 'FAILURE',
+      completedAt: '2026-05-11T23:59:00Z',
+    },
+    {
+      name: 'idd-security',
+      state: 'FAILURE',
+      completedAt: '2026-05-11T23:59:00Z',
+    },
+  ];
+  const waivableCheckSelectors = [{ selector: 'idd-*', matchMode: 'glob' }];
+  const waiverBody = renderExternalCheckWaiverComment({
+    agentId: fixture.options.expectedAgentId,
+    claimId: fixture.options.expectedClaimId,
+    headSha: fixture.input.prHeadSha,
+    checkSelector: 'idd-*',
+    reason: 'blanket idd-* waiver covering multiple checks',
+    expiresAt: '2026-05-13T00:00:00Z',
+    actor: 'kurone-kito',
+  });
+
+  const summary = buildPreMergeReadinessSummary(
+    {
+      ...fixture.input,
+      branchRules,
+      checks,
+      comments: [
+        ...fixture.input.comments,
+        {
+          id: 'glob-waiver-multi',
+          author: { login: 'kurone-kito' },
+          body: waiverBody,
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T00:00:00Z',
+        },
+      ],
+    },
+    {
+      ...fixture.options,
+      includeDispositionEvidence: true,
+      waivableCheckSelectors,
+      externalCheckWaiverMaxValidity: 'PT24H',
+      // Precondition closed -- idd-advisory-convergence must stay
+      // uncovered, but idd-security must still be covered by the same
+      // glob waiver entry.
+      advisoryConvergenceHeadCommittedAt: '2026-05-11T23:00:00Z',
+    },
+  );
+
+  const convergenceCheck = ciCheckByName(summary, 'idd-advisory-convergence');
+  assert.equal(
+    convergenceCheck?.coveredByWaiver,
+    undefined,
+    'idd-advisory-convergence stays uncovered while its precondition is closed',
+  );
+  const securityCheck = ciCheckByName(summary, 'idd-security');
+  assert.equal(
+    securityCheck?.coveredByWaiver,
+    true,
+    'an unrelated check matched by the same glob waiver must remain covered',
+  );
 });
 
 test('#2021: idd-advisory-convergence waiver posted and the 24h deadline has passed is covered (unchanged coveredByWaiver behavior)', () => {

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -6164,6 +6164,332 @@ test('#1570: buildPreMergeReadinessSummary blocks on copilot-terminal-unavailabl
   );
 });
 
+// #2021: a posted, otherwise-valid `idd-advisory-convergence` waiver must
+// only make the REQUIRED CHECK itself `coveredByWaiver` once the SAME
+// deadline/terminal precondition `advisory-convergence.mts`'s own gate
+// enforces has also opened -- a 24h deadline anchored on the current HEAD
+// commit's own committedDate, or proven terminal Copilot unavailability.
+// Before this fix, `pre-merge-readiness.mjs` reported `coveredByWaiver: true`
+// (and therefore `ready: true`) the moment a valid waiver marker existed,
+// regardless of whether either precondition had opened -- sending a session
+// into a `gh pr merge` GitHub rejects outright (root cause of #2021).
+function ciCheckByName(
+  summary: unknown,
+  name: string,
+): Record<string, unknown> | undefined {
+  const checks = (summary as { ci: { checks: Record<string, unknown>[] } }).ci
+    .checks;
+  return checks.find((check) => check.name === name);
+}
+
+// Typed from `buildPreMergeReadinessSummary`'s own first-parameter shape
+// (not `Record<string, unknown>`, which carries no NAMED properties and
+// would make a later `{ ...input, comments: [...] }` spread silently drop
+// required fields like `prHeadSha` from the inferred type) so this helper
+// stays real-input-shape-checked without reaching for `any`.
+type PreMergeReadinessInput = Parameters<
+  typeof buildPreMergeReadinessSummary
+>[0];
+
+function withAdvisoryConvergenceRequiredCheck(fixture: {
+  input: PreMergeReadinessInput;
+}): PreMergeReadinessInput {
+  const branchRules = (fixture.input.branchRules ?? []).map((rule) =>
+    rule.type === 'required_status_checks'
+      ? {
+          type: 'required_status_checks',
+          parameters: {
+            required_status_checks: [
+              { context: 'lint' },
+              { context: 'idd-advisory-convergence' },
+            ],
+          },
+        }
+      : rule,
+  );
+  const checks = [
+    ...(fixture.input.checks ?? []),
+    {
+      name: 'idd-advisory-convergence',
+      state: 'FAILURE',
+      completedAt: '2026-05-11T23:59:00Z',
+    },
+  ];
+  return { ...fixture.input, branchRules, checks };
+}
+
+test('#2021: idd-advisory-convergence waiver posted but precondition window not yet open leaves the check blocked', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const input = withAdvisoryConvergenceRequiredCheck(fixture);
+  const waivableCheckSelectors = [
+    { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+  ];
+  const waiverBody = renderExternalCheckWaiverComment({
+    agentId: fixture.options.expectedAgentId,
+    claimId: fixture.options.expectedClaimId,
+    headSha: fixture.input.prHeadSha,
+    checkSelector: 'idd-advisory-convergence',
+    reason: 'idd-advisory-convergence would not converge across 3 rounds',
+    expiresAt: '2026-05-13T00:00:00Z',
+    actor: 'kurone-kito',
+  });
+
+  const blocked = buildPreMergeReadinessSummary(
+    {
+      ...input,
+      comments: [
+        ...(input.comments ?? []),
+        {
+          id: 'deadline-waiver',
+          author: { login: 'kurone-kito' },
+          body: waiverBody,
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T00:00:00Z',
+        },
+      ],
+    },
+    {
+      ...fixture.options,
+      includeDispositionEvidence: true,
+      waivableCheckSelectors,
+      externalCheckWaiverMaxValidity: 'PT24H',
+      // HEAD committed 1h before `now` (2026-05-12T00:00:00Z): only 60
+      // elapsed minutes against the 1440-minute (24h) default deadline, so
+      // the deadline has not passed. copilotUnavailable is omitted (false),
+      // so terminal unavailability is not proven either -- neither
+      // precondition is open.
+      advisoryConvergenceHeadCommittedAt: '2026-05-11T23:00:00Z',
+    },
+  );
+
+  const precondition = (
+    blocked as {
+      advisoryConvergenceWaiverPrecondition: Record<string, unknown>;
+    }
+  ).advisoryConvergenceWaiverPrecondition;
+  assert.equal(precondition.deadlineMinutes, 1440);
+  assert.equal(precondition.elapsedMinutes, 60);
+  assert.equal(precondition.deadlinePassed, false);
+  assert.equal(precondition.terminalUnavailable, false);
+  assert.equal(precondition.open, false);
+
+  // The raw waiver evidence still reports the marker as valid (it is a real,
+  // otherwise-valid waiver) -- only ci.coveredByWaiver is withheld.
+  const waiverEvidence = (blocked.waiverEvidence as { valid: unknown[] }).valid;
+  assert.equal(waiverEvidence.length, 1);
+
+  const check = ciCheckByName(blocked, 'idd-advisory-convergence');
+  assert.equal(check?.coveredByWaiver, undefined);
+  assert.equal(
+    (blocked.ci as Record<string, unknown>).requiredChecksPassing,
+    false,
+  );
+  assert.equal(blocked.ready, false);
+  assert.deepEqual(blocked.blockers, computePreMergeReadinessBlockers(blocked));
+  const ciBlocker = (
+    blocked.blockers as { gate: string; detail: string }[]
+  ).find((blocker) => blocker.gate === 'ci');
+  assert.ok(ciBlocker, 'expected a ci blocker');
+  assert.match(
+    ciBlocker?.detail ?? '',
+    /idd-advisory-convergence.*not yet active/,
+  );
+  assert.match(ciBlocker?.detail ?? '', /remainingMinutes=1380/);
+});
+
+// #2021: the precondition gate must also close a GLOB-selector waiver that
+// would otherwise cover the check by name (e.g. `idd-*`), not just a
+// literal `idd-advisory-convergence` selector -- `summarizeRequiredChecks`'s
+// own `coveredByWaiver` matches via `matchCheckSelectorLocal` (glob-aware),
+// so a strict `===` precondition filter would let a glob waiver slip
+// through uncontrolled while `advisory-convergence.mts`'s own exact-match
+// gate would never count it, reproducing the exact false-`ready` class
+// this issue exists to close.
+test('#2021: a glob-selector waiver (e.g. idd-*) is also withheld from coveredByWaiver while the precondition is closed', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const input = withAdvisoryConvergenceRequiredCheck(fixture);
+  const waivableCheckSelectors = [{ selector: 'idd-*', matchMode: 'glob' }];
+  const waiverBody = renderExternalCheckWaiverComment({
+    agentId: fixture.options.expectedAgentId,
+    claimId: fixture.options.expectedClaimId,
+    headSha: fixture.input.prHeadSha,
+    checkSelector: 'idd-*',
+    reason: 'blanket idd-* waiver posted by mistake',
+    expiresAt: '2026-05-13T00:00:00Z',
+    actor: 'kurone-kito',
+  });
+
+  const blocked = buildPreMergeReadinessSummary(
+    {
+      ...input,
+      comments: [
+        ...(input.comments ?? []),
+        {
+          id: 'glob-waiver',
+          author: { login: 'kurone-kito' },
+          body: waiverBody,
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T00:00:00Z',
+        },
+      ],
+    },
+    {
+      ...fixture.options,
+      includeDispositionEvidence: true,
+      waivableCheckSelectors,
+      externalCheckWaiverMaxValidity: 'PT24H',
+      // Precondition closed: deadline not passed, terminal not proven.
+      advisoryConvergenceHeadCommittedAt: '2026-05-11T23:00:00Z',
+    },
+  );
+
+  const precondition = (
+    blocked as {
+      advisoryConvergenceWaiverPrecondition: Record<string, unknown>;
+    }
+  ).advisoryConvergenceWaiverPrecondition;
+  assert.equal(precondition.open, false);
+
+  // The raw waiver evidence still reports the glob marker as valid.
+  const waiverEvidence = (blocked.waiverEvidence as { valid: unknown[] }).valid;
+  assert.equal(waiverEvidence.length, 1);
+
+  const check = ciCheckByName(blocked, 'idd-advisory-convergence');
+  assert.equal(
+    check?.coveredByWaiver,
+    undefined,
+    'a glob waiver must not cover the check while the precondition is closed',
+  );
+  assert.equal(blocked.ready, false);
+  assert.deepEqual(blocked.blockers, computePreMergeReadinessBlockers(blocked));
+});
+
+test('#2021: idd-advisory-convergence waiver posted and the 24h deadline has passed is covered (unchanged coveredByWaiver behavior)', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const input = withAdvisoryConvergenceRequiredCheck(fixture);
+  const waivableCheckSelectors = [
+    { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+  ];
+  const waiverBody = renderExternalCheckWaiverComment({
+    agentId: fixture.options.expectedAgentId,
+    claimId: fixture.options.expectedClaimId,
+    headSha: fixture.input.prHeadSha,
+    checkSelector: 'idd-advisory-convergence',
+    reason: 'idd-advisory-convergence would not converge across 3 rounds',
+    expiresAt: '2026-05-13T00:00:00Z',
+    actor: 'kurone-kito',
+  });
+
+  const waived = buildPreMergeReadinessSummary(
+    {
+      ...input,
+      comments: [
+        ...(input.comments ?? []),
+        {
+          id: 'deadline-waiver',
+          author: { login: 'kurone-kito' },
+          body: waiverBody,
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T00:00:00Z',
+        },
+      ],
+    },
+    {
+      ...fixture.options,
+      includeDispositionEvidence: true,
+      waivableCheckSelectors,
+      externalCheckWaiverMaxValidity: 'PT24H',
+      // HEAD committed 25h before `now`: 1500 elapsed minutes >= the
+      // 1440-minute default deadline -- the deadline HAS passed.
+      advisoryConvergenceHeadCommittedAt: '2026-05-10T23:00:00Z',
+    },
+  );
+
+  const precondition = (
+    waived as { advisoryConvergenceWaiverPrecondition: Record<string, unknown> }
+  ).advisoryConvergenceWaiverPrecondition;
+  assert.equal(precondition.elapsedMinutes, 1500);
+  assert.equal(precondition.deadlinePassed, true);
+  assert.equal(precondition.terminalUnavailable, false);
+  assert.equal(precondition.open, true);
+
+  const check = ciCheckByName(waived, 'idd-advisory-convergence');
+  assert.equal(check?.coveredByWaiver, true);
+  assert.equal((waived.ci as Record<string, unknown>).status, 'success');
+  assert.equal(
+    (waived.ci as Record<string, unknown>).requiredChecksPassing,
+    true,
+  );
+  const waivedGates = (waived.blockers as { gate: string }[]).map(
+    (blocker) => blocker.gate,
+  );
+  assert.ok(!waivedGates.includes('ci'));
+  assert.deepEqual(waived.blockers, computePreMergeReadinessBlockers(waived));
+});
+
+test('#2021: idd-advisory-convergence waiver posted and terminal Copilot unavailability is proven is covered even before the deadline passes', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const input = withAdvisoryConvergenceRequiredCheck(fixture);
+  const waivableCheckSelectors = [
+    { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+  ];
+  const waiverBody = renderExternalCheckWaiverComment({
+    agentId: fixture.options.expectedAgentId,
+    claimId: fixture.options.expectedClaimId,
+    headSha: fixture.input.prHeadSha,
+    checkSelector: 'idd-advisory-convergence',
+    reason:
+      'Copilot review API confirmed unavailable; recovery cycles exhausted',
+    expiresAt: '2026-05-13T00:00:00Z',
+    actor: 'kurone-kito',
+  });
+
+  const waived = buildPreMergeReadinessSummary(
+    {
+      ...input,
+      comments: [
+        ...(input.comments ?? []),
+        {
+          id: 'terminal-waiver',
+          author: { login: 'kurone-kito' },
+          body: waiverBody,
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T00:00:00Z',
+        },
+      ],
+    },
+    {
+      ...fixture.options,
+      includeDispositionEvidence: true,
+      waivableCheckSelectors,
+      externalCheckWaiverMaxValidity: 'PT24H',
+      // The deadline has NOT passed (same 1h-before-now HEAD as the
+      // still-blocked case above) -- only the terminal precondition is met.
+      advisoryConvergenceHeadCommittedAt: '2026-05-11T23:00:00Z',
+      copilotUnavailable: true,
+    },
+  );
+
+  const precondition = (
+    waived as { advisoryConvergenceWaiverPrecondition: Record<string, unknown> }
+  ).advisoryConvergenceWaiverPrecondition;
+  assert.equal(precondition.deadlinePassed, false);
+  assert.equal(precondition.terminalUnavailable, true);
+  assert.equal(precondition.open, true);
+
+  const check = ciCheckByName(waived, 'idd-advisory-convergence');
+  assert.equal(check?.coveredByWaiver, true);
+  assert.equal((waived.ci as Record<string, unknown>).status, 'success');
+  const waivedGates = (waived.blockers as { gate: string }[]).map(
+    (blocker) => blocker.gate,
+  );
+  assert.ok(!waivedGates.includes('ci'));
+  // The dedicated copilot-terminal-unavailable blocker is also cleared by
+  // the same waiver (#1570's pre-existing behavior, unaffected by #2021).
+  assert.ok(!waivedGates.includes('copilot-terminal-unavailable'));
+  assert.deepEqual(waived.blockers, computePreMergeReadinessBlockers(waived));
+});
+
 // #1377: a masked-403-as-404 on the branch-protection or ruleset reads must
 // block the ci gate with a specific, actionable detail instead of silently
 // falling through to noRequiredChecksConfigured, even in the exact "all

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -451,6 +451,7 @@ export const preMergeReadinessKeys = [
   'claim',
   'dispositionEvidence',
   'waiverEvidence',
+  'advisoryConvergenceWaiverPrecondition',
   'branchCurrency',
   'trustedMarkerActors',
   'trustedMarkerActorsSource',
@@ -1073,6 +1074,15 @@ const preMergeReadinessFixture = {
     unauthorized: [],
     malformed: [],
     notConfigured: [],
+  },
+  advisoryConvergenceWaiverPrecondition: {
+    checkSelector: 'idd-advisory-convergence',
+    deadlineMinutes: 1440,
+    headCommittedAt: 'none',
+    elapsedMinutes: null,
+    deadlinePassed: false,
+    terminalUnavailable: false,
+    open: false,
   },
   branchCurrency: {
     mergeStateStatus: 'CLEAN',


### PR DESCRIPTION
## Summary

`pre-merge-readiness.mjs` reported a posted `idd-advisory-convergence`
external-check waiver as `coveredByWaiver: true` (and therefore
`ready: true`) the moment a valid marker existed for the current HEAD,
without checking the same deadline/terminal precondition
`advisory-convergence.mts` itself requires before treating a waiver as
active — a 24h deadline anchored on the current HEAD commit's own
`committedDate`, or proven terminal Copilot unavailability. This
false-positive `ready: true` sent a prior session into a
`gh pr merge --apply` attempt that GitHub rejected outright, since the
underlying required check was never actually satisfied.

This PR fixes `pre-merge-readiness.mts` to fetch the HEAD commit's
`committedDate` (via the same GraphQL field `advisory-convergence.mts`
itself reads, `fetchReviewsAndHeadCommit` in `review-clause.mts`) and
evaluate the identical precondition before folding an
`idd-advisory-convergence` waiver into `ci.coveredByWaiver`. The
precondition also mirrors `advisory-convergence.mts`'s own glob-aware
selector matching (`matchCheckSelectorLocal`), so a hand-authored glob
waiver (e.g. `idd-*`) can't slip through the gate just because its
literal selector string differs from the check name.

The evaluation is reported unconditionally as a new
`advisoryConvergenceWaiverPrecondition` field on the readiness report
(`checkSelector`, `deadlineMinutes`, `headCommittedAt`,
`elapsedMinutes`, `deadlinePassed`, `terminalUnavailable`, `open`), and
a `ci` blocker now cites the waiver's presence plus the remaining
time-to-deadline instead of a generic "CI is not all-passing" message,
so an agent doesn't have to independently re-derive it.

## What changed

- `src/scripts/pre-merge-readiness.mts`: fetch `headCommittedAt` and
  the configured `advisoryWait.convergenceDeadline`, thread both into
  `buildPreMergeReadinessSummary`.
- `src/scripts/protocol-helpers.mts`: evaluate the deadline/terminal
  precondition, gate `ci.coveredByWaiver` on it for the
  `idd-advisory-convergence` selector specifically (glob-aware, every
  other waivable selector unaffected), add the new
  `advisoryConvergenceWaiverPrecondition` evidence field, and cite it
  in the `ci` blocker detail when applicable.
- `schemas/pre-merge-readiness.schema.json`: declare the new required
  field.
- `fixtures/pre-merge-readiness/*.json`,
  `fixtures/schemas/pre-merge-readiness.valid.json`,
  `tests/schema-type-reconciliation.test.mts`: updated for the new
  field (all 8 fixtures share the same default-unopened-precondition
  shape since none override the new options).
- `tests/pre-merge-readiness.test.mts`: 4 new tests covering the
  acceptance criteria — precondition not yet open (still blocked), a
  glob-selector waiver also withheld while closed, deadline passed
  (covered, unchanged `coveredByWaiver` behavior), and terminal
  Copilot unavailability proven (covered).
- `docs/idd-helper-scripts.md` (regenerated from
  `idd-template/docs/idd-helper-scripts.md` via `sync-docs.mjs
  --apply`): documents the new field and precondition.
- `scripts/pre-merge-readiness.mjs`, `scripts/protocol-helpers.mjs`:
  regenerated via `pnpm run build`.

## Test plan

- [x] `pnpm run build` regenerates the `.mjs` copies from the edited
  `.mts` sources
- [x] `pnpm run lint:minimum` passes (typecheck, build:check, biome,
  dprint, full test suite, cspell, markdownlint, audit-docs including
  the `typeSuppressionBudgets` gate)
- [x] New tests cover all three acceptance-criteria scenarios plus a
  glob-selector regression case
- [x] Existing `coveredByWaiver: true` behavior is unchanged once
  either precondition is met (asserted directly in the new tests)

Refs #2016, PR #2018.

Closes #2021
