### PR TITLE
fix(external-check-waiver): fix empty-string --actor fallback-chain bug

### DIFF
--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -287,20 +287,24 @@ export function planExternalCheckWaiver(input, options = {}) {
  * programmatic override, else the CLI `--actor` flag, else the
  * authenticated `gh` viewer.
  *
- * Uses `||` rather than `??` for this specific chain: the CLI flag spec
- * gives `--actor` a parsed default of `''` (not `undefined`), so
- * `args.actor` is always a string and is `''` whenever the flag is
- * omitted. A `??` chain would treat that `''` as "provided" and never
- * fall through to `viewerLogin`, which is exactly the bug this scoped fix
- * addresses -- an empty string here must be treated the same as absent.
- * `options.actor` is genuinely optional (`string | undefined`) and an
- * empty override is equally meaningless, so the same `||` step covers it
- * too. No other fallback chain in this file changes.
+ * Trims each candidate _before_ testing it for truthiness and picks the
+ * first non-empty result, rather than a plain `a || b || c` chain -- a
+ * whitespace-only candidate (for example a programmatic `options.actor`
+ * override of `'   '`) is truthy as a raw string, so a post-trim `||`
+ * chain would select it and then collapse it to `''` without ever
+ * falling through to the next source. This also fixes the original bug
+ * this helper exists for: the CLI flag spec gives `--actor` a parsed
+ * default of `''` (not `undefined`), so `args.actor` is always a string
+ * and is `''` whenever the flag is omitted -- a `??` chain would treat
+ * that `''` as "provided" and never fall through to `viewerLogin`. No
+ * other fallback chain in this file changes.
  */
 export function resolveActorLogin(optionsActor, argsActor, viewerLogin) {
-  return String(optionsActor || argsActor || viewerLogin)
-    .trim()
-    .toLowerCase();
+  return (
+    [optionsActor, argsActor, viewerLogin]
+      .map((actor) => actor?.trim() ?? '')
+      .find(Boolean) ?? ''
+  ).toLowerCase();
 }
 export async function runExternalCheckWaiver(options = {}) {
   const args = options.args ?? parseArgs(process.argv.slice(2));

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -282,6 +282,26 @@ export function planExternalCheckWaiver(input, options = {}) {
     body,
   };
 }
+/**
+ * Resolves the effective actor login for authority evaluation: an explicit
+ * programmatic override, else the CLI `--actor` flag, else the
+ * authenticated `gh` viewer.
+ *
+ * Uses `||` rather than `??` for this specific chain: the CLI flag spec
+ * gives `--actor` a parsed default of `''` (not `undefined`), so
+ * `args.actor` is always a string and is `''` whenever the flag is
+ * omitted. A `??` chain would treat that `''` as "provided" and never
+ * fall through to `viewerLogin`, which is exactly the bug this scoped fix
+ * addresses -- an empty string here must be treated the same as absent.
+ * `options.actor` is genuinely optional (`string | undefined`) and an
+ * empty override is equally meaningless, so the same `||` step covers it
+ * too. No other fallback chain in this file changes.
+ */
+export function resolveActorLogin(optionsActor, argsActor, viewerLogin) {
+  return String(optionsActor || argsActor || viewerLogin)
+    .trim()
+    .toLowerCase();
+}
 export async function runExternalCheckWaiver(options = {}) {
   const args = options.args ?? parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -304,9 +324,7 @@ export async function runExternalCheckWaiver(options = {}) {
   const viewerLogin = String(safeGhText(['api', 'user', '--jq', '.login']))
     .trim()
     .toLowerCase();
-  const actor = String(options.actor ?? args.actor ?? viewerLogin)
-    .trim()
-    .toLowerCase();
+  const actor = resolveActorLogin(options.actor, args.actor, viewerLogin);
   if (!actor) {
     throw new Error(
       'could not determine current GitHub user; ensure gh is authenticated',

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -545,24 +545,28 @@ export function planExternalCheckWaiver(
  * programmatic override, else the CLI `--actor` flag, else the
  * authenticated `gh` viewer.
  *
- * Uses `||` rather than `??` for this specific chain: the CLI flag spec
- * gives `--actor` a parsed default of `''` (not `undefined`), so
- * `args.actor` is always a string and is `''` whenever the flag is
- * omitted. A `??` chain would treat that `''` as "provided" and never
- * fall through to `viewerLogin`, which is exactly the bug this scoped fix
- * addresses -- an empty string here must be treated the same as absent.
- * `options.actor` is genuinely optional (`string | undefined`) and an
- * empty override is equally meaningless, so the same `||` step covers it
- * too. No other fallback chain in this file changes.
+ * Trims each candidate _before_ testing it for truthiness and picks the
+ * first non-empty result, rather than a plain `a || b || c` chain -- a
+ * whitespace-only candidate (for example a programmatic `options.actor`
+ * override of `'   '`) is truthy as a raw string, so a post-trim `||`
+ * chain would select it and then collapse it to `''` without ever
+ * falling through to the next source. This also fixes the original bug
+ * this helper exists for: the CLI flag spec gives `--actor` a parsed
+ * default of `''` (not `undefined`), so `args.actor` is always a string
+ * and is `''` whenever the flag is omitted -- a `??` chain would treat
+ * that `''` as "provided" and never fall through to `viewerLogin`. No
+ * other fallback chain in this file changes.
  */
 export function resolveActorLogin(
   optionsActor: string | undefined,
   argsActor: string,
   viewerLogin: string,
 ): string {
-  return String(optionsActor || argsActor || viewerLogin)
-    .trim()
-    .toLowerCase();
+  return (
+    [optionsActor, argsActor, viewerLogin]
+      .map((actor) => actor?.trim() ?? '')
+      .find(Boolean) ?? ''
+  ).toLowerCase();
 }
 
 export async function runExternalCheckWaiver(

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -540,6 +540,31 @@ export function planExternalCheckWaiver(
   };
 }
 
+/**
+ * Resolves the effective actor login for authority evaluation: an explicit
+ * programmatic override, else the CLI `--actor` flag, else the
+ * authenticated `gh` viewer.
+ *
+ * Uses `||` rather than `??` for this specific chain: the CLI flag spec
+ * gives `--actor` a parsed default of `''` (not `undefined`), so
+ * `args.actor` is always a string and is `''` whenever the flag is
+ * omitted. A `??` chain would treat that `''` as "provided" and never
+ * fall through to `viewerLogin`, which is exactly the bug this scoped fix
+ * addresses -- an empty string here must be treated the same as absent.
+ * `options.actor` is genuinely optional (`string | undefined`) and an
+ * empty override is equally meaningless, so the same `||` step covers it
+ * too. No other fallback chain in this file changes.
+ */
+export function resolveActorLogin(
+  optionsActor: string | undefined,
+  argsActor: string,
+  viewerLogin: string,
+): string {
+  return String(optionsActor || argsActor || viewerLogin)
+    .trim()
+    .toLowerCase();
+}
+
 export async function runExternalCheckWaiver(
   options: RunExternalCheckWaiverOptions = {},
 ): Promise<{ exitCode: number; report?: ExternalCheckWaiverReport }> {
@@ -565,9 +590,7 @@ export async function runExternalCheckWaiver(
   const viewerLogin = String(safeGhText(['api', 'user', '--jq', '.login']))
     .trim()
     .toLowerCase();
-  const actor = String(options.actor ?? args.actor ?? viewerLogin)
-    .trim()
-    .toLowerCase();
+  const actor = resolveActorLogin(options.actor, args.actor, viewerLogin);
   if (!actor) {
     throw new Error(
       'could not determine current GitHub user; ensure gh is authenticated',

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -6,6 +6,7 @@ import {
   deriveGhApiStatusFromError,
   parseArgs,
   planExternalCheckWaiver,
+  resolveActorLogin,
 } from '../src/scripts/external-check-waiver.mts';
 import { normalizePolicyConfig } from '../src/scripts/policy-helpers.mts';
 import {
@@ -148,6 +149,66 @@ test('parseArgs: --claimless combined with --claim-id throws', () => {
         'claim-1',
       ]),
     /--claimless cannot be combined with --claim-id/,
+  );
+});
+
+// --- #2022: --actor empty-string fallback-chain bug ------------------------
+
+test('resolveActorLogin: no --actor flag falls through to the authenticated viewer', () => {
+  const args = parseArgs([
+    '--pr',
+    '5',
+    '--check',
+    'CodeRabbit',
+    '--reason',
+    'flaky',
+  ]);
+  assert.equal(args.actor, '');
+  assert.equal(
+    resolveActorLogin(undefined, args.actor, 'maintainer-user'),
+    'maintainer-user',
+  );
+});
+
+test('resolveActorLogin: --actor "" passed explicitly also falls through to the authenticated viewer', () => {
+  const args = parseArgs([
+    '--pr',
+    '5',
+    '--check',
+    'CodeRabbit',
+    '--reason',
+    'flaky',
+    '--actor',
+    '',
+  ]);
+  assert.equal(args.actor, '');
+  assert.equal(
+    resolveActorLogin(undefined, args.actor, 'maintainer-user'),
+    'maintainer-user',
+  );
+});
+
+test('resolveActorLogin: a non-empty --actor flag is preserved', () => {
+  const args = parseArgs([
+    '--pr',
+    '5',
+    '--check',
+    'CodeRabbit',
+    '--reason',
+    'flaky',
+    '--actor',
+    'someone-else',
+  ]);
+  assert.equal(
+    resolveActorLogin(undefined, args.actor, 'maintainer-user'),
+    'someone-else',
+  );
+});
+
+test('resolveActorLogin: a programmatic options.actor override wins over the CLI flag and viewer', () => {
+  assert.equal(
+    resolveActorLogin('override-actor', 'someone-else', 'maintainer-user'),
+    'override-actor',
   );
 });
 

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -212,6 +212,20 @@ test('resolveActorLogin: a programmatic options.actor override wins over the CLI
   );
 });
 
+test('resolveActorLogin: a whitespace-only options.actor override falls through instead of collapsing to empty', () => {
+  assert.equal(
+    resolveActorLogin('   ', 'someone-else', 'maintainer-user'),
+    'someone-else',
+  );
+});
+
+test('resolveActorLogin: a whitespace-only argsActor falls through to the viewer', () => {
+  assert.equal(
+    resolveActorLogin(undefined, '   ', 'maintainer-user'),
+    'maintainer-user',
+  );
+});
+
 type PlanInput = Parameters<typeof planExternalCheckWaiver>[0];
 // The base-input builder always supplies these fields, so the test
 // mutations below may dereference them without optional guards.


### PR DESCRIPTION
## Summary

`runExternalCheckWaiver`'s actor resolution used
`options.actor ?? args.actor ?? viewerLogin`. The `--actor` CLI flag's
parsed default is `''` (not `undefined`), so `args.actor` is always a
string and `??` treated an omitted `--actor` as "provided", never
falling through to the authenticated `gh` viewer — forcing callers to
pass `--actor` explicitly to work around it.

Extracts a small, directly-testable `resolveActorLogin()` helper and
switches `||` in for `??` on this one fallback chain only, so an empty
string is treated the same as absent. No other `??` usage in the file
changes.

## Changes

- `src/scripts/external-check-waiver.mts`: add `resolveActorLogin()`
  and use it for the actor-resolution fallback.
- `scripts/external-check-waiver.mjs`: regenerated via `pnpm run build`.
- `tests/external-check-waiver.test.mts`: new tests covering no
  `--actor` flag, an explicit `--actor ""`, a non-empty `--actor`, and
  a programmatic `options.actor` override.

Closes #2022

## Background

Refs #2016, PR #2018 — the session working that issue had to pass
`--actor` explicitly to work around this bug while posting a
maintainer-authorized `idd-advisory-convergence` waiver comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved actor selection for external check waivers.
  * Empty or omitted actor values now automatically fall back to the authenticated account.
  * Explicit programmatic and command-line actor values continue to be honored, with programmatic values taking precedence.

* **Tests**
  * Added coverage for fallback behavior, value precedence, and non-empty actor handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->