### PR TITLE
docs(onboarding): draft a welcome issue after bootstrap merges

### DIFF
--- a/idd-template/docs/onboarding/issue-mediated-bootstrap.md
+++ b/idd-template/docs/onboarding/issue-mediated-bootstrap.md
@@ -252,6 +252,14 @@ companion install follows as its own separate issue **only when the
 companion target state above is `installed`** — do not draft a
 companion-install follow-up for an operator who chose `not installed`.
 
+Once this issue merges, also draft a welcome/next-steps issue by
+default — unlike the optional add-ons above, this one is not left to
+the operator's discretion. Give it the same autopilot-suitability
+score `1` and confirmed blocked-by-human label this issue carries (it
+must stay off the Discover -> Claim -> Work loop too), and derive its
+2-3 example next-step prompts from a fresh post-merge
+repository-evidence read, not the pre-import dry-run report.
+
 **Record `not installed` here even when the operator wants the
 companion — and explicitly defer the matching Step 6 item, not just
 the recorded value.** `ONBOARDING.md`'s Step 6 checklist item
@@ -367,7 +375,8 @@ This is also the one add-on that must stay off the Discover -> Claim ->
 Work loop entirely, unlike its four sibling bullets above: its whole
 body is a reference to read, not something to build, so an autopilot
 agent selecting it would attempt to "implement" prose that describes
-nothing. Give it the same autopilot-suitability score `1` and the
+nothing (preventive; no observed incident yet). Give it the same
+autopilot-suitability score `1` and the
 operator-confirmed `labels.blockedByHumanLabelName` value the core
 bootstrap issue itself carries (Step 1B item 12) — never the
 distributed default label name unconditionally.
@@ -375,12 +384,17 @@ distributed default label name unconditionally.
 Draft its body as 2-3 example prompts the operator can literally copy
 and try next, phrased as concrete requests mirroring the operator's own
 examples ("start issue authoring to implement {inferred gap}", "run the
-IDD loop"). Derive `{inferred gap}` and the other prompt content from
-the same repository-evidence read the optional Dry-run readiness report
-already performs
+IDD loop"). Derive `{inferred gap}` and the other prompt content using
+the same repository-evidence-read method the optional Dry-run readiness
+report already performs
 ([Dry-run — Readiness assessment](../../ONBOARDING.md#dry-run--readiness-assessment))
 — detected package manager, missing prerequisites, and so on — rather
-than inventing a new inference mechanism. Condition the prompt set on
+than inventing a new inference mechanism. Run that read **fresh, after
+this merge**, not reused from the pre-import dry-run's stored output:
+the repository's package manager, test commands, and missing
+prerequisites can differ once the bootstrap import lands, and a stale
+pre-import finding can prompt the operator to fix a gap the import
+already closed. Condition the prompt set on
 the recorded Step 1B companion decision: only include an issue-authoring
 prompt (e.g. "start issue authoring to implement {inferred gap}") when
 that decision was `installed`; for `not installed`, substitute a prompt
@@ -413,6 +427,9 @@ explicitly not the full autonomous Discover -> Claim -> Work loop:
 Once this PR merges, the repository is IDD-operational and every
 subsequent change — including the optional add-ons above — runs through
 the normal claim -> work -> PR -> CI -> merge loop, with the one
-exception already noted above: the welcome/next-steps issue stays off
-that loop and is instead executed directly, the same way the core
-bootstrap issue itself is.
+exception already noted above: the welcome/next-steps issue is not
+executed as code at all. Unlike this bootstrap issue's own
+issue -> branch -> PR -> merge execution, the welcome issue has nothing
+to implement, so a human (or the same narrowly-scoped, pre-authorized
+agent) reads it and closes it directly once acknowledged — no branch,
+PR, or merge.

--- a/idd-template/docs/onboarding/issue-mediated-bootstrap.md
+++ b/idd-template/docs/onboarding/issue-mediated-bootstrap.md
@@ -345,12 +345,41 @@ them:
   Step 1B companion decision was `installed`; do not draft this
   follow-up for an operator who chose `not installed`, since there is
   nothing for it to do
+- a welcome/next-steps issue — unlike its sibling bullets above, which
+  are drafted only on request, draft this one **by default** whenever
+  the operator chose issue-mediated bootstrap (details below)
 
 None of these are required for the repository to become
 IDD-operational, and unlike the core import, each one can run through
 the real Discover -> Claim -> Work loop once the core bootstrap issue
 merges — the local IDD instructions and policy files that Discover needs
-already exist by then.
+already exist by then — with one exception: the welcome/next-steps issue
+must not run through that loop at all (see below).
+
+**Welcome/next-steps issue, in detail.** Draft it automatically whenever
+the operator chose issue-mediated bootstrap — do not wait for a separate
+request. The whole premise of choosing the guided path over theirs-flow
+is that the operator is less likely to already know IDD, so gating this
+one add-on on a separate ask would defeat the point.
+
+This is also the one add-on that must stay off the Discover -> Claim ->
+Work loop entirely, unlike its four sibling bullets above: its whole
+body is a reference to read, not something to build, so an autopilot
+agent selecting it would attempt to "implement" prose that describes
+nothing. Give it the same autopilot-suitability score `1` and the
+operator-confirmed `labels.blockedByHumanLabelName` value the core
+bootstrap issue itself carries (Step 1B item 12) — never the
+distributed default label name unconditionally.
+
+Draft its body as 2-3 example prompts the operator can literally copy
+and try next, phrased as concrete requests mirroring the operator's own
+examples ("start issue authoring to implement {inferred gap}", "run the
+IDD loop"). Derive `{inferred gap}` and the other prompt content from
+the same repository-evidence read the optional Dry-run readiness report
+already performs
+([Dry-run — Readiness assessment](../../ONBOARDING.md#dry-run--readiness-assessment))
+— detected package manager, missing prerequisites, and so on — rather
+than inventing a new inference mechanism.
 
 ## Execution: issue -> branch -> PR -> merge, not the full loop
 

--- a/idd-template/docs/onboarding/issue-mediated-bootstrap.md
+++ b/idd-template/docs/onboarding/issue-mediated-bootstrap.md
@@ -356,11 +356,12 @@ merges — the local IDD instructions and policy files that Discover needs
 already exist by then — with one exception: the welcome/next-steps issue
 must not run through that loop at all (see below).
 
-**Welcome/next-steps issue, in detail.** Draft it automatically whenever
-the operator chose issue-mediated bootstrap — do not wait for a separate
-request. The whole premise of choosing the guided path over theirs-flow
-is that the operator is less likely to already know IDD, so gating this
-one add-on on a separate ask would defeat the point.
+**Welcome/next-steps issue, in detail.** Once the core bootstrap issue
+merges, draft it automatically — do not wait for a separate request, the
+way its four sibling bullets do. The whole premise of choosing the
+guided path over theirs-flow is that the operator is less likely to
+already know IDD, so gating this one add-on on a separate ask would
+defeat the point.
 
 This is also the one add-on that must stay off the Discover -> Claim ->
 Work loop entirely, unlike its four sibling bullets above: its whole
@@ -379,7 +380,13 @@ the same repository-evidence read the optional Dry-run readiness report
 already performs
 ([Dry-run — Readiness assessment](../../ONBOARDING.md#dry-run--readiness-assessment))
 — detected package manager, missing prerequisites, and so on — rather
-than inventing a new inference mechanism.
+than inventing a new inference mechanism. Condition the prompt set on
+the recorded Step 1B companion decision: only include an issue-authoring
+prompt (e.g. "start issue authoring to implement {inferred gap}") when
+that decision was `installed`; for `not installed`, substitute a prompt
+that does not depend on the companion skill (e.g. "run the IDD loop" or
+a repository-evidence-derived task prompt), so every welcome issue's
+prompts are ones the operator can actually run.
 
 ## Execution: issue -> branch -> PR -> merge, not the full loop
 
@@ -405,4 +412,7 @@ explicitly not the full autonomous Discover -> Claim -> Work loop:
 
 Once this PR merges, the repository is IDD-operational and every
 subsequent change — including the optional add-ons above — runs through
-the normal claim -> work -> PR -> CI -> merge loop.
+the normal claim -> work -> PR -> CI -> merge loop, with the one
+exception already noted above: the welcome/next-steps issue stays off
+that loop and is instead executed directly, the same way the core
+bootstrap issue itself is.


### PR DESCRIPTION
<!--
At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md
-->

# Summary

Adds a default (not request-gated) welcome/next-steps follow-up to
`idd-template/docs/onboarding/issue-mediated-bootstrap.md`'s "Optional
add-ons stay separate follow-ups" list. Unlike its four sibling
add-ons, the welcome issue is drafted automatically whenever the
operator chose issue-mediated bootstrap, and it must stay off the
Discover -> Claim -> Work loop entirely (its body is a reference to
read, not something to build) -- so it carries autopilot-suitability
score 1 plus the operator-confirmed `labels.blockedByHumanLabelName`
value from Step 1B, not a hard-coded default. The doc also specifies
the welcome issue's own body content: 2-3 example prompts derived from
the existing Dry-run readiness report's repository-evidence read.

## Linked issue

Closes #2008

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The operator's own onboarding proposal asked for a completion-time
tutorial suggesting concrete next prompts. Clarified with the operator
(2026-08-13): scope this to issue-mediated bootstrap only, as a
follow-up drafted once the core bootstrap issue merges -- reusing the
same "Optional add-ons stay separate follow-ups" precedent list the
doc already establishes for worktree-guard activation, the
`idd-doctor` CI gate, and so on. Unlike those, a welcome issue has
nothing to build, so it needs the same non-claimable treatment
(score 1 + the blocked-by-human label) the core bootstrap issue itself
already carries, rather than the ordinary Discover-routable path its
four sibling add-ons use.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
