### PR TITLE
docs(onboarding): relay per-choice explanations in plain language

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -222,6 +222,17 @@ before starting Step 1A.
 
 ---
 
+> **Relay explanations, not just labels.** For each item you present
+> across Steps 1A, 1B, and 1C, pull its matching explanation from the
+> companion reference doc and relay it to the operator in plain
+> language before asking for confirmation or a choice — do not only
+> quote the terse item text. Draw from
+> [Onboarding Reference — Placeholder Values](docs/onboarding/placeholders.md)
+> for Steps 1A and 1C, and
+> [Onboarding Reference — Policy Decisions](docs/onboarding/policy-decisions.md)
+> for Step 1B. Also define, in plain language on first use, any term
+> already covered in [Core IDD Concepts](docs/concepts.md).
+
 ## Step 1A — Auto-derive candidate values
 
 Inspect the target repository and propose candidate values for all seven placeholders:


### PR DESCRIPTION
# Summary

`idd-template/ONBOARDING.md`'s Steps 1A/1B/1C present hearing items as
terse labels plus a pointer to a companion reference doc
(`docs/onboarding/placeholders.md`, `docs/onboarding/policy-decisions.md`),
by design (idd-skill#192). Nothing instructed the executing agent to
actually surface the companion doc's explanation to the operator during
the hearing, so an agent could read a terse item as-is and leave the
operator to guess or separately ask what the companion doc already
answers.

This PR adds one shared blockquote note, placed immediately before the
Step 1A heading so it precedes Steps 1A, 1B, and 1C together, directing
the agent to relay each item's companion-doc explanation in plain
language before asking the operator to confirm or choose, instead of
only quoting the terse item text. The note names
`docs/onboarding/placeholders.md` for Steps 1A/1C,
`docs/onboarding/policy-decisions.md` for Step 1B, and points to
`docs/concepts.md` for jargon defined there. No prose explaining
individual policy options was added inline into ONBOARDING.md itself —
that content stays in the companion docs, preserving the existing
terse-entry-point / detailed-companion split.

## Linked issue

Closes #2006

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Sibling issue #2007 also targets `idd-template/ONBOARDING.md` and is
deliberately out of scope here to avoid file contention within this
run; this PR stays strictly within #2006's own declared acceptance
criteria.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
