### PR TITLE
fix(idd-doctor): extend legacy idd-policy.json fallback to scalar readers

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -193,18 +193,8 @@ function checkAutopilotSuitabilityConsistency(root, options, report) {
   if (!Array.isArray(issues) || issues.length === 0) {
     return;
   }
-  let floor;
-  let blockedByHumanLabelName;
-  try {
-    const config = JSON.parse(
-      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
-    );
-    floor = config?.autopilotSuitability?.floor;
-    blockedByHumanLabelName = config?.labels?.blockedByHumanLabelName;
-  } catch {
-    floor = undefined;
-    blockedByHumanLabelName = undefined;
-  }
+  const { floor, blockedByHumanLabelName } =
+    resolveAutopilotSuitabilityPolicy(root);
   const { warnings } = evaluateAutopilotSuitabilityConsistency(issues, {
     floor,
     markerPrefix: options.markerPrefix,
@@ -863,6 +853,56 @@ export function resolveConfiguredHelperRuntimePackageSpec(root) {
   return resolveConfiguredHelperRuntime(root).packageSpec;
 }
 /**
+ * Resolve the repository's live IDD config document, preferring the
+ * canonical `.github/idd/config.json` and falling back to the legacy
+ * `idd-policy.json` only when the canonical file is entirely absent --
+ * the same first-present-candidate-wins-outright walk over
+ * `LIVE_CONFIG_CANDIDATE_FILES` as `resolveConfiguredHelperRuntime` above,
+ * never a per-key merge of the two files. Shared by every scalar policy
+ * reader below (`readWorktreeGuardEnabled`, `readWorktreeGuardBranchPatterns`,
+ * `readCleanupEvidenceTrustedLogins`, `readTrustEmptyProtectionReads`, and
+ * `checkAutopilotSuitabilityConsistency`'s floor/label read) so the
+ * two-file resolution invariant lives in exactly one place instead of five
+ * separate copies that only ever read the canonical filename
+ * (idd-skill#2028).
+ *
+ * Returns `{ config: null }` when no candidate file exists, or the first
+ * present candidate is not valid JSON -- each caller keeps its own
+ * fail-closed default for that case, matching every reader's behavior
+ * before this extraction.
+ */
+function resolveLiveConfigDocument(root) {
+  for (const file of LIVE_CONFIG_CANDIDATE_FILES) {
+    const absolutePath = join(root, file);
+    if (!exists(absolutePath)) {
+      continue;
+    }
+    try {
+      return { config: JSON.parse(readFileSync(absolutePath, 'utf8')) };
+    } catch {
+      return { config: null };
+    }
+  }
+  return { config: null };
+}
+/**
+ * Resolve `autopilotSuitability.floor` and `labels.blockedByHumanLabelName`
+ * from the live IDD config (canonical-first, legacy-`idd-policy.json`
+ * fallback via {@link resolveLiveConfigDocument}), for
+ * `checkAutopilotSuitabilityConsistency`'s cross-field check. Extracted as
+ * its own exported reader -- matching `readWorktreeGuardEnabled` and its
+ * siblings -- so this one config read is independently unit-testable
+ * without mocking `gh issue list` (idd-skill#2028).
+ */
+export function resolveAutopilotSuitabilityPolicy(root) {
+  const { config } = resolveLiveConfigDocument(root);
+  const typedConfig = config;
+  return {
+    floor: typedConfig?.autopilotSuitability?.floor,
+    blockedByHumanLabelName: typedConfig?.labels?.blockedByHumanLabelName,
+  };
+}
+/**
  * Decide whether a parsed live-config document is a schema finding, given
  * the canonical policy schema and the file it was read from (for the
  * message). Pure (no I/O) so it can be unit-tested directly. Returns `null`
@@ -1268,14 +1308,8 @@ function checkTemplateVersionSignal(root, report) {
   );
 }
 export function readWorktreeGuardEnabled(root) {
-  try {
-    const config = JSON.parse(
-      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
-    );
-    return config?.worktreeGuard?.enabled === true;
-  } catch {
-    return false;
-  }
+  const { config } = resolveLiveConfigDocument(root);
+  return config?.worktreeGuard?.enabled === true;
 }
 /**
  * Read `worktreeGuard.branchPatterns` from the repo config, falling back
@@ -1284,26 +1318,20 @@ export function readWorktreeGuardEnabled(root) {
  * the hook agree on which branches the guard covers.
  */
 export function readWorktreeGuardBranchPatterns(root) {
-  try {
-    const config = JSON.parse(
-      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
-    );
-    const patterns = config?.worktreeGuard?.branchPatterns;
-    if (
-      Array.isArray(patterns) &&
-      patterns.length > 0 &&
-      patterns.every((p) => typeof p === 'string' && p.trim().length > 0)
-    ) {
-      // Return trimmed patterns: a configured entry with surrounding
-      // whitespace (e.g. `"issue/* "`) otherwise passes validation but
-      // never matches a real branch, silently covering nothing. The
-      // validation above stays fail-closed — any empty/whitespace-only or
-      // non-string entry invalidates the whole list and falls back to the
-      // defaults — so every surviving entry is non-empty after trim.
-      return patterns.map((pattern) => pattern.trim());
-    }
-  } catch {
-    // fall through to defaults
+  const { config } = resolveLiveConfigDocument(root);
+  const patterns = config?.worktreeGuard?.branchPatterns;
+  if (
+    Array.isArray(patterns) &&
+    patterns.length > 0 &&
+    patterns.every((p) => typeof p === 'string' && p.trim().length > 0)
+  ) {
+    // Return trimmed patterns: a configured entry with surrounding
+    // whitespace (e.g. `"issue/* "`) otherwise passes validation but
+    // never matches a real branch, silently covering nothing. The
+    // validation above stays fail-closed — any empty/whitespace-only or
+    // non-string entry invalidates the whole list and falls back to the
+    // defaults — so every surviving entry is non-empty after trim.
+    return patterns.map((pattern) => pattern.trim());
   }
   return DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS;
 }
@@ -1814,15 +1842,8 @@ export function formatCleanupBacklogRemediation(profile, packageSpec = '') {
  * trust).
  */
 export function readCleanupEvidenceTrustedLogins(root) {
-  let trustedMarkerActors;
-  try {
-    const config = JSON.parse(
-      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
-    );
-    trustedMarkerActors = config?.trustedMarkerActors;
-  } catch {
-    trustedMarkerActors = undefined;
-  }
+  const { config } = resolveLiveConfigDocument(root);
+  const trustedMarkerActors = config?.trustedMarkerActors;
   const { actors } = resolveTrustedMarkerActors({
     config: { trustedMarkerActors },
   });
@@ -2938,14 +2959,8 @@ export function evaluateBranchProtectionFindings(
  * default.
  */
 export function readTrustEmptyProtectionReads(root) {
-  try {
-    const config = JSON.parse(
-      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
-    );
-    return config?.ciGate?.trustEmptyProtectionReads === true;
-  } catch {
-    return false;
-  }
+  const { config } = resolveLiveConfigDocument(root);
+  return config?.ciGate?.trustEmptyProtectionReads === true;
 }
 /**
  * Derive the `--hostname` value {@link fetchGhApiJsonAt} should pass to

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1832,14 +1832,16 @@ export function formatCleanupBacklogRemediation(profile, packageSpec = '') {
 }
 /**
  * Trusted authors for `<!-- idd-cleanup-evidence: ... -->` comments: the
- * repository's configured `trustedMarkerActors` (`.github/idd/config.json`)
- * plus `github-actions[bot]`, the identity `post-merge-cleanup.yml` posts
- * under via `GITHUB_TOKEN`. Any commenter outside this set can pre-post the
- * marker prefix on a public repo, so an untrusted-author match must never
- * count as genuine cleanup evidence -- the same trust-scoping every other
- * IDD operational marker already applies. Fails closed to
- * `github-actions[bot]` alone (config unreadable/malformed never widens
- * trust).
+ * repository's configured `trustedMarkerActors` (from the live IDD config,
+ * canonical `.github/idd/config.json` first, falling back to the legacy
+ * `idd-policy.json` when the canonical file is absent -- see
+ * {@link resolveLiveConfigDocument}) plus `github-actions[bot]`, the
+ * identity `post-merge-cleanup.yml` posts under via `GITHUB_TOKEN`. Any
+ * commenter outside this set can pre-post the marker prefix on a public
+ * repo, so an untrusted-author match must never count as genuine cleanup
+ * evidence -- the same trust-scoping every other IDD operational marker
+ * already applies. Fails closed to `github-actions[bot]` alone (config
+ * unreadable/malformed never widens trust).
  */
 export function readCleanupEvidenceTrustedLogins(root) {
   const { config } = resolveLiveConfigDocument(root);
@@ -2950,12 +2952,14 @@ export function evaluateBranchProtectionFindings(
  * Root-relative `ciGate.trustEmptyProtectionReads` reader
  * (idd-skill#2010; #1377 introduced the flag). Deliberately not
  * `pre-merge-readiness.mts`'s own `readTrustEmptyProtectionReads`, which
- * reads `.github/idd/config.json` relative to `process.cwd()` --
- * `idd-doctor.mts` supports `--repo-root <path>`, and this file already
- * reads the same config file root-relative elsewhere (see
- * `readCleanupEvidenceTrustedLogins`). Fails closed to `false` on a
- * missing or unparseable config, matching
- * `normalizePolicyConfig(null).ciGate.trustEmptyProtectionReads`'s
+ * reads only `.github/idd/config.json` relative to `process.cwd()` and has
+ * no legacy fallback -- `idd-doctor.mts` supports `--repo-root <path>` and
+ * resolves the live config root-relative, canonical `.github/idd/config.json`
+ * first, falling back to the legacy `idd-policy.json` when the canonical
+ * file is absent (see {@link resolveLiveConfigDocument}, idd-skill#2028),
+ * the same two-file resolution every other scalar reader in this file
+ * shares. Fails closed to `false` on a missing or unparseable config,
+ * matching `normalizePolicyConfig(null).ciGate.trustEmptyProtectionReads`'s
  * default.
  */
 export function readTrustEmptyProtectionReads(root) {

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -286,21 +286,8 @@ function checkAutopilotSuitabilityConsistency(
     return;
   }
 
-  let floor: unknown;
-  let blockedByHumanLabelName: unknown;
-  try {
-    const config = JSON.parse(
-      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
-    ) as {
-      autopilotSuitability?: { floor?: unknown };
-      labels?: { blockedByHumanLabelName?: unknown };
-    } | null;
-    floor = config?.autopilotSuitability?.floor;
-    blockedByHumanLabelName = config?.labels?.blockedByHumanLabelName;
-  } catch {
-    floor = undefined;
-    blockedByHumanLabelName = undefined;
-  }
+  const { floor, blockedByHumanLabelName } =
+    resolveAutopilotSuitabilityPolicy(root);
 
   const { warnings } = evaluateAutopilotSuitabilityConsistency(issues, {
     floor,
@@ -1023,6 +1010,64 @@ export function resolveConfiguredHelperRuntimePackageSpec(
 }
 
 /**
+ * Resolve the repository's live IDD config document, preferring the
+ * canonical `.github/idd/config.json` and falling back to the legacy
+ * `idd-policy.json` only when the canonical file is entirely absent --
+ * the same first-present-candidate-wins-outright walk over
+ * `LIVE_CONFIG_CANDIDATE_FILES` as `resolveConfiguredHelperRuntime` above,
+ * never a per-key merge of the two files. Shared by every scalar policy
+ * reader below (`readWorktreeGuardEnabled`, `readWorktreeGuardBranchPatterns`,
+ * `readCleanupEvidenceTrustedLogins`, `readTrustEmptyProtectionReads`, and
+ * `checkAutopilotSuitabilityConsistency`'s floor/label read) so the
+ * two-file resolution invariant lives in exactly one place instead of five
+ * separate copies that only ever read the canonical filename
+ * (idd-skill#2028).
+ *
+ * Returns `{ config: null }` when no candidate file exists, or the first
+ * present candidate is not valid JSON -- each caller keeps its own
+ * fail-closed default for that case, matching every reader's behavior
+ * before this extraction.
+ */
+function resolveLiveConfigDocument(root: string): { config: unknown } {
+  for (const file of LIVE_CONFIG_CANDIDATE_FILES) {
+    const absolutePath = join(root, file);
+    if (!exists(absolutePath)) {
+      continue;
+    }
+    try {
+      return { config: JSON.parse(readFileSync(absolutePath, 'utf8')) };
+    } catch {
+      return { config: null };
+    }
+  }
+  return { config: null };
+}
+
+/**
+ * Resolve `autopilotSuitability.floor` and `labels.blockedByHumanLabelName`
+ * from the live IDD config (canonical-first, legacy-`idd-policy.json`
+ * fallback via {@link resolveLiveConfigDocument}), for
+ * `checkAutopilotSuitabilityConsistency`'s cross-field check. Extracted as
+ * its own exported reader -- matching `readWorktreeGuardEnabled` and its
+ * siblings -- so this one config read is independently unit-testable
+ * without mocking `gh issue list` (idd-skill#2028).
+ */
+export function resolveAutopilotSuitabilityPolicy(root: string): {
+  floor: unknown;
+  blockedByHumanLabelName: unknown;
+} {
+  const { config } = resolveLiveConfigDocument(root);
+  const typedConfig = config as {
+    autopilotSuitability?: { floor?: unknown };
+    labels?: { blockedByHumanLabelName?: unknown };
+  } | null;
+  return {
+    floor: typedConfig?.autopilotSuitability?.floor,
+    blockedByHumanLabelName: typedConfig?.labels?.blockedByHumanLabelName,
+  };
+}
+
+/**
  * Decide whether a parsed live-config document is a schema finding, given
  * the canonical policy schema and the file it was read from (for the
  * message). Pure (no I/O) so it can be unit-tested directly. Returns `null`
@@ -1504,14 +1549,11 @@ function checkTemplateVersionSignal(root: string, report: DoctorReport) {
 }
 
 export function readWorktreeGuardEnabled(root: string): boolean {
-  try {
-    const config = JSON.parse(
-      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
-    ) as { worktreeGuard?: { enabled?: unknown } } | null;
-    return config?.worktreeGuard?.enabled === true;
-  } catch {
-    return false;
-  }
+  const { config } = resolveLiveConfigDocument(root);
+  return (
+    (config as { worktreeGuard?: { enabled?: unknown } } | null)?.worktreeGuard
+      ?.enabled === true
+  );
 }
 
 /**
@@ -1521,26 +1563,22 @@ export function readWorktreeGuardEnabled(root: string): boolean {
  * the hook agree on which branches the guard covers.
  */
 export function readWorktreeGuardBranchPatterns(root: string): string[] {
-  try {
-    const config = JSON.parse(
-      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
-    ) as { worktreeGuard?: { branchPatterns?: unknown } } | null;
-    const patterns = config?.worktreeGuard?.branchPatterns;
-    if (
-      Array.isArray(patterns) &&
-      patterns.length > 0 &&
-      patterns.every((p) => typeof p === 'string' && p.trim().length > 0)
-    ) {
-      // Return trimmed patterns: a configured entry with surrounding
-      // whitespace (e.g. `"issue/* "`) otherwise passes validation but
-      // never matches a real branch, silently covering nothing. The
-      // validation above stays fail-closed — any empty/whitespace-only or
-      // non-string entry invalidates the whole list and falls back to the
-      // defaults — so every surviving entry is non-empty after trim.
-      return (patterns as string[]).map((pattern) => pattern.trim());
-    }
-  } catch {
-    // fall through to defaults
+  const { config } = resolveLiveConfigDocument(root);
+  const patterns = (
+    config as { worktreeGuard?: { branchPatterns?: unknown } } | null
+  )?.worktreeGuard?.branchPatterns;
+  if (
+    Array.isArray(patterns) &&
+    patterns.length > 0 &&
+    patterns.every((p) => typeof p === 'string' && p.trim().length > 0)
+  ) {
+    // Return trimmed patterns: a configured entry with surrounding
+    // whitespace (e.g. `"issue/* "`) otherwise passes validation but
+    // never matches a real branch, silently covering nothing. The
+    // validation above stays fail-closed — any empty/whitespace-only or
+    // non-string entry invalidates the whole list and falls back to the
+    // defaults — so every surviving entry is non-empty after trim.
+    return (patterns as string[]).map((pattern) => pattern.trim());
   }
   return DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS;
 }
@@ -2114,15 +2152,10 @@ export function formatCleanupBacklogRemediation(
  * trust).
  */
 export function readCleanupEvidenceTrustedLogins(root: string): Set<string> {
-  let trustedMarkerActors: unknown;
-  try {
-    const config = JSON.parse(
-      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
-    ) as { trustedMarkerActors?: unknown } | null;
-    trustedMarkerActors = config?.trustedMarkerActors;
-  } catch {
-    trustedMarkerActors = undefined;
-  }
+  const { config } = resolveLiveConfigDocument(root);
+  const trustedMarkerActors = (
+    config as { trustedMarkerActors?: unknown } | null
+  )?.trustedMarkerActors;
   const { actors } = resolveTrustedMarkerActors({
     config: { trustedMarkerActors },
   });
@@ -3380,14 +3413,11 @@ export function evaluateBranchProtectionFindings(
  * default.
  */
 export function readTrustEmptyProtectionReads(root: string): boolean {
-  try {
-    const config = JSON.parse(
-      readFileSync(join(root, '.github/idd/config.json'), 'utf8'),
-    ) as { ciGate?: { trustEmptyProtectionReads?: unknown } } | null;
-    return config?.ciGate?.trustEmptyProtectionReads === true;
-  } catch {
-    return false;
-  }
+  const { config } = resolveLiveConfigDocument(root);
+  return (
+    (config as { ciGate?: { trustEmptyProtectionReads?: unknown } } | null)
+      ?.ciGate?.trustEmptyProtectionReads === true
+  );
 }
 
 /**

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -2142,14 +2142,16 @@ export function formatCleanupBacklogRemediation(
 
 /**
  * Trusted authors for `<!-- idd-cleanup-evidence: ... -->` comments: the
- * repository's configured `trustedMarkerActors` (`.github/idd/config.json`)
- * plus `github-actions[bot]`, the identity `post-merge-cleanup.yml` posts
- * under via `GITHUB_TOKEN`. Any commenter outside this set can pre-post the
- * marker prefix on a public repo, so an untrusted-author match must never
- * count as genuine cleanup evidence -- the same trust-scoping every other
- * IDD operational marker already applies. Fails closed to
- * `github-actions[bot]` alone (config unreadable/malformed never widens
- * trust).
+ * repository's configured `trustedMarkerActors` (from the live IDD config,
+ * canonical `.github/idd/config.json` first, falling back to the legacy
+ * `idd-policy.json` when the canonical file is absent -- see
+ * {@link resolveLiveConfigDocument}) plus `github-actions[bot]`, the
+ * identity `post-merge-cleanup.yml` posts under via `GITHUB_TOKEN`. Any
+ * commenter outside this set can pre-post the marker prefix on a public
+ * repo, so an untrusted-author match must never count as genuine cleanup
+ * evidence -- the same trust-scoping every other IDD operational marker
+ * already applies. Fails closed to `github-actions[bot]` alone (config
+ * unreadable/malformed never widens trust).
  */
 export function readCleanupEvidenceTrustedLogins(root: string): Set<string> {
   const { config } = resolveLiveConfigDocument(root);
@@ -3404,12 +3406,14 @@ export function evaluateBranchProtectionFindings(
  * Root-relative `ciGate.trustEmptyProtectionReads` reader
  * (idd-skill#2010; #1377 introduced the flag). Deliberately not
  * `pre-merge-readiness.mts`'s own `readTrustEmptyProtectionReads`, which
- * reads `.github/idd/config.json` relative to `process.cwd()` --
- * `idd-doctor.mts` supports `--repo-root <path>`, and this file already
- * reads the same config file root-relative elsewhere (see
- * `readCleanupEvidenceTrustedLogins`). Fails closed to `false` on a
- * missing or unparseable config, matching
- * `normalizePolicyConfig(null).ciGate.trustEmptyProtectionReads`'s
+ * reads only `.github/idd/config.json` relative to `process.cwd()` and has
+ * no legacy fallback -- `idd-doctor.mts` supports `--repo-root <path>` and
+ * resolves the live config root-relative, canonical `.github/idd/config.json`
+ * first, falling back to the legacy `idd-policy.json` when the canonical
+ * file is absent (see {@link resolveLiveConfigDocument}, idd-skill#2028),
+ * the same two-file resolution every other scalar reader in this file
+ * shares. Fails closed to `false` on a missing or unparseable config,
+ * matching `normalizePolicyConfig(null).ciGate.trustEmptyProtectionReads`'s
  * default.
  */
 export function readTrustEmptyProtectionReads(root: string): boolean {

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -55,6 +55,7 @@ import {
   readTrustEmptyProtectionReads,
   readWorktreeGuardBranchPatterns,
   readWorktreeGuardEnabled,
+  resolveAutopilotSuitabilityPolicy,
   resolveConfiguredHelperRuntimePackageSpec,
   resolveConfiguredHelperRuntimeProfile,
   resolveTargetGhHostname,
@@ -248,6 +249,72 @@ test('autopilot-suitability consistency: floor 1 treats score-1 + blocked-by-hum
     warnings.find((w) => /issue #23/.test(w)) ?? '',
     /issue #23 is scored 2 \(>= floor 1\) but carries status:blocked-by-human/,
   );
+});
+
+test('resolveAutopilotSuitabilityPolicy reads floor and blockedByHumanLabelName from the canonical config (idd-skill#2028)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-doctor-suitability-policy-'));
+  try {
+    mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(
+      join(dir, '.github/idd/config.json'),
+      JSON.stringify({
+        autopilotSuitability: { floor: 3 },
+        labels: { blockedByHumanLabelName: 'status:human-only' },
+      }),
+    );
+    assert.deepEqual(resolveAutopilotSuitabilityPolicy(dir), {
+      floor: 3,
+      blockedByHumanLabelName: 'status:human-only',
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveAutopilotSuitabilityPolicy also reads the legacy idd-policy.json path when the canonical file is absent (idd-skill#2028)', () => {
+  const dir = mkdtempSync(
+    join(tmpdir(), 'idd-doctor-suitability-policy-legacy-'),
+  );
+  try {
+    writeFileSync(
+      join(dir, 'idd-policy.json'),
+      JSON.stringify({ autopilotSuitability: { floor: 2 } }),
+    );
+    assert.deepEqual(resolveAutopilotSuitabilityPolicy(dir), {
+      floor: 2,
+      blockedByHumanLabelName: undefined,
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveAutopilotSuitabilityPolicy returns undefined fields when config is missing or malformed, never falling through a present canonical config (idd-skill#2028)', () => {
+  const dir = mkdtempSync(
+    join(tmpdir(), 'idd-doctor-suitability-policy-absent-'),
+  );
+  try {
+    // No config file at all.
+    assert.deepEqual(resolveAutopilotSuitabilityPolicy(dir), {
+      floor: undefined,
+      blockedByHumanLabelName: undefined,
+    });
+
+    // Malformed canonical JSON must fail closed, not fall through to a
+    // legacy file even if one is also present.
+    mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(join(dir, '.github/idd/config.json'), '{ not json');
+    writeFileSync(
+      join(dir, 'idd-policy.json'),
+      JSON.stringify({ autopilotSuitability: { floor: 4 } }),
+    );
+    assert.deepEqual(resolveAutopilotSuitabilityPolicy(dir), {
+      floor: undefined,
+      blockedByHumanLabelName: undefined,
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('findPlaceholders returns template tokens', () => {
@@ -1121,6 +1188,34 @@ test('readWorktreeGuardEnabled returns false when config is missing or invalid',
   }
 });
 
+test('readWorktreeGuardEnabled also reads the legacy idd-policy.json path when the canonical file is absent (idd-skill#2028)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-guard-legacy-'));
+  try {
+    writeFileSync(
+      join(dir, 'idd-policy.json'),
+      JSON.stringify({ worktreeGuard: { enabled: true } }),
+    );
+    assert.equal(readWorktreeGuardEnabled(dir), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readWorktreeGuardEnabled never falls through a present canonical config to a legacy one (idd-skill#2028)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-guard-no-fallthrough-'));
+  try {
+    mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(join(dir, '.github/idd/config.json'), JSON.stringify({}));
+    writeFileSync(
+      join(dir, 'idd-policy.json'),
+      JSON.stringify({ worktreeGuard: { enabled: true } }),
+    );
+    assert.equal(readWorktreeGuardEnabled(dir), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('readWorktreeGuardBranchPatterns trims configured patterns and falls back when invalid', () => {
   const dir = mkdtempSync(join(tmpdir(), 'idd-guard-'));
   try {
@@ -1362,6 +1457,19 @@ test('readWorktreeGuardBranchPatterns defaults when config is missing', () => {
       readWorktreeGuardBranchPatterns(dir),
       DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS,
     );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readWorktreeGuardBranchPatterns also reads the legacy idd-policy.json path when the canonical file is absent (idd-skill#2028)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-bp-legacy-'));
+  try {
+    writeFileSync(
+      join(dir, 'idd-policy.json'),
+      JSON.stringify({ worktreeGuard: { branchPatterns: ['feature/*'] } }),
+    );
+    assert.deepEqual(readWorktreeGuardBranchPatterns(dir), ['feature/*']);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -1777,6 +1885,24 @@ test('readCleanupEvidenceTrustedLogins fails closed to github-actions[bot] alone
     assert.deepEqual(
       readCleanupEvidenceTrustedLogins(dir),
       new Set(['github-actions[bot]']),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readCleanupEvidenceTrustedLogins also reads the legacy idd-policy.json path when the canonical file is absent (idd-skill#2028)', () => {
+  const dir = mkdtempSync(
+    join(tmpdir(), 'idd-doctor-cleanup-evidence-trust-legacy-'),
+  );
+  try {
+    writeFileSync(
+      join(dir, 'idd-policy.json'),
+      JSON.stringify({ trustedMarkerActors: ['kurone-kito'] }),
+    );
+    assert.deepEqual(
+      readCleanupEvidenceTrustedLogins(dir),
+      new Set(['kurone-kito', 'github-actions[bot]']),
     );
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -3462,6 +3588,21 @@ test('readTrustEmptyProtectionReads is true only when ciGate.trustEmptyProtectio
       JSON.stringify({ ciGate: { trustEmptyProtectionReads: 'true' } }),
     );
     assert.equal(readTrustEmptyProtectionReads(dir), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readTrustEmptyProtectionReads also reads the legacy idd-policy.json path when the canonical file is absent (idd-skill#2028)', () => {
+  const dir = mkdtempSync(
+    join(tmpdir(), 'idd-doctor-trust-empty-protection-reads-legacy-'),
+  );
+  try {
+    writeFileSync(
+      join(dir, 'idd-policy.json'),
+      JSON.stringify({ ciGate: { trustEmptyProtectionReads: true } }),
+    );
+    assert.equal(readTrustEmptyProtectionReads(dir), true);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
# Summary

`idd-doctor.mts`'s scalar policy readers (`readWorktreeGuardEnabled`,
`readWorktreeGuardBranchPatterns`, `readCleanupEvidenceTrustedLogins`,
`readTrustEmptyProtectionReads`, and
`checkAutopilotSuitabilityConsistency`'s floor/label read) only ever
looked at the canonical `.github/idd/config.json`, unlike
`checkHelperRuntimeConfig`'s existing two-file support. An adopter
still on the legacy `idd-policy.json` filename alone silently got
every one of these readers' fail-closed default instead of their
actual configured value.

Extracted a shared `resolveLiveConfigDocument(root)` helper (mirroring
`resolveConfiguredHelperRuntime`'s own first-present-candidate-wins-
outright walk over `LIVE_CONFIG_CANDIDATE_FILES`) and routed all five
readers through it, so the canonical file still wins outright over the
legacy one with no per-key merge -- matching the existing
`resolveConfiguredHelperRuntimeProfile` no-fallthrough precedent
(idd-skill#1718 review).

Also extracted `checkAutopilotSuitabilityConsistency`'s inline config
read into its own exported `resolveAutopilotSuitabilityPolicy` reader,
matching the sibling readers' shape so it is independently
unit-testable without mocking `gh issue list`.

## Linked issue

Closes #2028

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Surfaced during PR #2026's review (Codex), scoped to
`readTrustEmptyProtectionReads()` alone; tracing the same pattern
across `idd-doctor.mts` showed it is a pre-existing, repo-wide gap
across the whole scalar-reader class, not specific to that one
function.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
