### PR TITLE
fix(idd-doctor): preserve failed gh api stdout for status fallback

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -3020,11 +3020,12 @@ export function resolveTargetGhHostname(url) {
  * but keeps this call consistent with its siblings). Mirrors
  * `ghApiJson`'s own `--paginate --jq '.[]'` NDJSON handling via the
  * shared `parsePaginatedGhNdjson()`, and shapes a failure's thrown error
- * the same way a real `execFileSync` failure would (`status`/`stderr`),
- * so `fetchGovernanceJson()`'s `deriveGhHttpStatus()`-based 404
- * detection still works unchanged.
+ * the same way a real `execFileSync` failure would (`status`/`stderr`/
+ * `stdout`), so `fetchGovernanceJson()`'s `deriveGhHttpStatus()`-based
+ * 404 detection still works, including its stdout-carried JSON-body
+ * fallback. Exported for direct test coverage of that failure shape.
  */
-function fetchGhApiJsonAt(root, hostname, path, paginate) {
+export function fetchGhApiJsonAt(root, hostname, path, paginate) {
   const argv = [
     'api',
     path,
@@ -3036,6 +3037,7 @@ function fetchGhApiJsonAt(root, hostname, path, paginate) {
     throw Object.assign(new Error('gh api failed'), {
       status: 1,
       stderr: result.stderr ?? '',
+      stdout: result.stdout ?? '',
     });
   }
   const raw = result.stdout.trim();
@@ -3058,6 +3060,7 @@ function runCommand(command, argv, cwd) {
       ok: false,
       code: candidate.status,
       stderr: candidate.stderr?.toString?.() ?? '',
+      stdout: candidate.stdout?.toString?.() ?? '',
     };
   }
 }

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -102,7 +102,7 @@ interface SuitabilityIssueInput {
 
 type CommandResult =
   | { ok: true; stdout: string }
-  | { ok: false; code: number | undefined; stderr: string };
+  | { ok: false; code: number | undefined; stderr: string; stdout: string };
 
 interface DoctorCliArgs {
   root: string;
@@ -3481,11 +3481,12 @@ export function resolveTargetGhHostname(
  * but keeps this call consistent with its siblings). Mirrors
  * `ghApiJson`'s own `--paginate --jq '.[]'` NDJSON handling via the
  * shared `parsePaginatedGhNdjson()`, and shapes a failure's thrown error
- * the same way a real `execFileSync` failure would (`status`/`stderr`),
- * so `fetchGovernanceJson()`'s `deriveGhHttpStatus()`-based 404
- * detection still works unchanged.
+ * the same way a real `execFileSync` failure would (`status`/`stderr`/
+ * `stdout`), so `fetchGovernanceJson()`'s `deriveGhHttpStatus()`-based
+ * 404 detection still works, including its stdout-carried JSON-body
+ * fallback. Exported for direct test coverage of that failure shape.
  */
-function fetchGhApiJsonAt(
+export function fetchGhApiJsonAt(
   root: string,
   hostname: string | undefined,
   path: string,
@@ -3502,6 +3503,7 @@ function fetchGhApiJsonAt(
     throw Object.assign(new Error('gh api failed'), {
       status: 1,
       stderr: result.stderr ?? '',
+      stdout: result.stdout ?? '',
     });
   }
   const raw = result.stdout.trim();
@@ -3527,11 +3529,13 @@ function runCommand(
     const candidate = error as {
       status?: number;
       stderr?: { toString?: () => string };
+      stdout?: { toString?: () => string };
     };
     return {
       ok: false,
       code: candidate.status,
       stderr: candidate.stderr?.toString?.() ?? '',
+      stdout: candidate.stdout?.toString?.() ?? '',
     };
   }
 }

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -35,6 +35,7 @@ import {
   evaluateDependencyVersionDrift,
   evaluateMarkerPrefixConsistency,
   extractMarkerPrefixes,
+  fetchGhApiJsonAt,
   filterIddBranchMergedPrs,
   findMissingWorkshopReferences,
   findMissingWorktreeHardening,
@@ -63,6 +64,7 @@ import {
   stripMarkdownNonText,
   worktreeGuardWiredAt,
 } from '../src/scripts/idd-doctor.mts';
+import { fetchGovernanceJson } from '../src/scripts/pre-merge-readiness.mts';
 import { loadJson } from '../src/scripts/validate-schemas.mts';
 
 const ap = (n: number | string) =>
@@ -3604,6 +3606,51 @@ test('readTrustEmptyProtectionReads also reads the legacy idd-policy.json path w
     );
     assert.equal(readTrustEmptyProtectionReads(dir), true);
   } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('fetchGhApiJsonAt preserves a failed `gh api` call\'s stdout so fetchGovernanceJson honors ciGate.trustEmptyProtectionReads from a JSON error body\'s "status" field (idd-skill#2044)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-doctor-fetch-gh-api-stdout-'));
+  const binDir = join(dir, 'bin');
+  const originalPath = process.env.PATH;
+  try {
+    mkdirSync(binDir, { recursive: true });
+    // Fake `gh` that fails a `gh api` call with a JSON error body on stdout
+    // only -- no stderr `(HTTP nnn)` suffix -- the failure shape
+    // deriveGhHttpStatus() falls back to a JSON body's "status" field for.
+    writeFileSync(
+      join(binDir, 'gh'),
+      '#!/bin/sh\necho \'{"message":"Not Found","status":"404"}\'\nexit 1\n',
+    );
+    chmodSync(join(binDir, 'gh'), 0o755);
+    process.env.PATH = `${binDir}:${originalPath ?? ''}`;
+
+    const fetchJson = (path: string, paginate: boolean) =>
+      fetchGhApiJsonAt(dir, undefined, path, paginate);
+
+    assert.deepEqual(
+      fetchGovernanceJson(
+        'repos/owner/repo/branches/main/protection',
+        false,
+        true,
+        {},
+        fetchJson,
+      ),
+      { value: {}, unreadable: false },
+    );
+    assert.deepEqual(
+      fetchGovernanceJson(
+        'repos/owner/repo/branches/main/protection',
+        false,
+        false,
+        {},
+        fetchJson,
+      ),
+      { value: {}, unreadable: true },
+    );
+  } finally {
+    process.env.PATH = originalPath;
     rmSync(dir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
# Summary

`idd-doctor.mts`'s `runCommand()` discarded a failed child process's
`stdout`, so `fetchGhApiJsonAt()`'s synthetic thrown error could never
carry a JSON error body `gh` wrote to stdout instead of stderr. The
shared `deriveGhHttpStatus()` documents a fallback to that body's
`"status"` field when no `(HTTP NNN)` suffix appears on stderr, but
that fallback was unreachable from this call site: `fetchGovernanceJson()`
always rethrew instead of honoring `ciGate.trustEmptyProtectionReads`
for a `gh api` failure whose HTTP status appears only in a stdout-carried
JSON body.

Added `stdout` to `CommandResult`'s failure variant and threaded it
through `runCommand()` and `fetchGhApiJsonAt()`'s synthetic error,
matching `ghApiJson()`'s own behavior for the same failure shape (it
never needs this workaround because it re-throws Node's original
`execFileSync` error unmodified, which already carries `.stdout`).

## Linked issue

Closes #2044

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Raised as a suppressed Copilot review comment on PR #2026 (#2010's
implementation), deliberately deferred here per this repository's
review round-cap discipline rather than expanding that PR's
already-multi-round diff to touch shared `CommandResult` plumbing.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
