### PR TITLE
fix(idd-doctor): pin gh api hostname explicitly for github.com

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -2994,27 +2994,29 @@ export function readTrustEmptyProtectionReads(root) {
  * `--hostname` at all) leaves `GH_HOST` in force, so a GHES-configured
  * `GH_HOST` in the calling environment would otherwise leak into a
  * governance read for a genuinely `github.com`-hosted target
- * repository (idd-skill#2030). Preserves an explicit non-default port
- * via `URL.host` rather than `URL.hostname` for a GHES target,
- * mirroring `branch-conflict-state.mts`'s `parseGitFetchOrigin()`
- * (idd-skill#2030, PR #2026 review). Returns `undefined` only for an
+ * repository (idd-skill#2030). Deliberately keeps the bare hostname
+ * (`URL.hostname`, dropping any explicit port) for a GHES target, like
+ * `resolveGhApiHostname()` (`gh-exec.mts`) already does: `gh api
+ * --hostname` rejects any value containing a colon outright (confirmed
+ * against a real `gh` binary: `--hostname host:port` fails argv
+ * validation before a request is even attempted), so a ported GHES
+ * host cannot be routed through `--hostname` at all -- correctly
+ * routing one requires constructing an absolute API URL instead, which
+ * neither this resolver nor its `gh-exec.mts` sibling do yet (deferred
+ * to idd-skill#2052, PR #2051 review). Returns `undefined` only for an
  * unparseable or host-less `url`.
  */
 export function resolveTargetGhHostname(url) {
   if (!url) {
     return undefined;
   }
-  let parsed;
+  let hostname;
   try {
-    parsed = new URL(url);
+    hostname = new URL(url).hostname.toLowerCase();
   } catch {
     return undefined;
   }
-  const hostname = parsed.hostname.toLowerCase();
-  if (!hostname) {
-    return undefined;
-  }
-  return hostname === 'github.com' ? 'github.com' : parsed.host.toLowerCase();
+  return hostname ? hostname : undefined;
 }
 /**
  * Root-scoped `gh api` fetch for {@link fetchGovernanceJson}'s injectable

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -2985,22 +2985,36 @@ export function readTrustEmptyProtectionReads(root) {
  * `idd-doctor --repo-root <path>` may target a repository on a
  * different host than the calling environment's own default. Deriving
  * from the target repository's own resolved `url` instead is the
- * correct, `--repo-root`-specific signal. Returns `undefined` for the
- * common `github.com` case (and any unparseable URL), so the emitted
- * argv matches `resolveGhApiHostname()`'s own "no override on
- * github.com" convention.
+ * correct, `--repo-root`-specific signal. Returns the literal
+ * `'github.com'` for the common `github.com` case, as an explicit
+ * `--hostname` override -- unlike `resolveGhApiHostname()`'s own "no
+ * override on github.com" convention, an explicit override is required
+ * here: an explicit `--hostname` flag wins over `gh api`'s own
+ * environment-based `GH_HOST` fallback, but `undefined` (no
+ * `--hostname` at all) leaves `GH_HOST` in force, so a GHES-configured
+ * `GH_HOST` in the calling environment would otherwise leak into a
+ * governance read for a genuinely `github.com`-hosted target
+ * repository (idd-skill#2030). Preserves an explicit non-default port
+ * via `URL.host` rather than `URL.hostname` for a GHES target,
+ * mirroring `branch-conflict-state.mts`'s `parseGitFetchOrigin()`
+ * (idd-skill#2030, PR #2026 review). Returns `undefined` only for an
+ * unparseable or host-less `url`.
  */
 export function resolveTargetGhHostname(url) {
   if (!url) {
     return undefined;
   }
-  let host;
+  let parsed;
   try {
-    host = new URL(url).hostname.toLowerCase();
+    parsed = new URL(url);
   } catch {
     return undefined;
   }
-  return host && host !== 'github.com' ? host : undefined;
+  const hostname = parsed.hostname.toLowerCase();
+  if (!hostname) {
+    return undefined;
+  }
+  return hostname === 'github.com' ? 'github.com' : parsed.host.toLowerCase();
 }
 /**
  * Root-scoped `gh api` fetch for {@link fetchGovernanceJson}'s injectable

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -3443,10 +3443,20 @@ export function readTrustEmptyProtectionReads(root: string): boolean {
  * `idd-doctor --repo-root <path>` may target a repository on a
  * different host than the calling environment's own default. Deriving
  * from the target repository's own resolved `url` instead is the
- * correct, `--repo-root`-specific signal. Returns `undefined` for the
- * common `github.com` case (and any unparseable URL), so the emitted
- * argv matches `resolveGhApiHostname()`'s own "no override on
- * github.com" convention.
+ * correct, `--repo-root`-specific signal. Returns the literal
+ * `'github.com'` for the common `github.com` case, as an explicit
+ * `--hostname` override -- unlike `resolveGhApiHostname()`'s own "no
+ * override on github.com" convention, an explicit override is required
+ * here: an explicit `--hostname` flag wins over `gh api`'s own
+ * environment-based `GH_HOST` fallback, but `undefined` (no
+ * `--hostname` at all) leaves `GH_HOST` in force, so a GHES-configured
+ * `GH_HOST` in the calling environment would otherwise leak into a
+ * governance read for a genuinely `github.com`-hosted target
+ * repository (idd-skill#2030). Preserves an explicit non-default port
+ * via `URL.host` rather than `URL.hostname` for a GHES target,
+ * mirroring `branch-conflict-state.mts`'s `parseGitFetchOrigin()`
+ * (idd-skill#2030, PR #2026 review). Returns `undefined` only for an
+ * unparseable or host-less `url`.
  */
 export function resolveTargetGhHostname(
   url: string | undefined,
@@ -3454,13 +3464,17 @@ export function resolveTargetGhHostname(
   if (!url) {
     return undefined;
   }
-  let host: string;
+  let parsed: URL;
   try {
-    host = new URL(url).hostname.toLowerCase();
+    parsed = new URL(url);
   } catch {
     return undefined;
   }
-  return host && host !== 'github.com' ? host : undefined;
+  const hostname = parsed.hostname.toLowerCase();
+  if (!hostname) {
+    return undefined;
+  }
+  return hostname === 'github.com' ? 'github.com' : parsed.host.toLowerCase();
 }
 
 /**

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -3452,10 +3452,16 @@ export function readTrustEmptyProtectionReads(root: string): boolean {
  * `--hostname` at all) leaves `GH_HOST` in force, so a GHES-configured
  * `GH_HOST` in the calling environment would otherwise leak into a
  * governance read for a genuinely `github.com`-hosted target
- * repository (idd-skill#2030). Preserves an explicit non-default port
- * via `URL.host` rather than `URL.hostname` for a GHES target,
- * mirroring `branch-conflict-state.mts`'s `parseGitFetchOrigin()`
- * (idd-skill#2030, PR #2026 review). Returns `undefined` only for an
+ * repository (idd-skill#2030). Deliberately keeps the bare hostname
+ * (`URL.hostname`, dropping any explicit port) for a GHES target, like
+ * `resolveGhApiHostname()` (`gh-exec.mts`) already does: `gh api
+ * --hostname` rejects any value containing a colon outright (confirmed
+ * against a real `gh` binary: `--hostname host:port` fails argv
+ * validation before a request is even attempted), so a ported GHES
+ * host cannot be routed through `--hostname` at all -- correctly
+ * routing one requires constructing an absolute API URL instead, which
+ * neither this resolver nor its `gh-exec.mts` sibling do yet (deferred
+ * to idd-skill#2052, PR #2051 review). Returns `undefined` only for an
  * unparseable or host-less `url`.
  */
 export function resolveTargetGhHostname(
@@ -3464,17 +3470,13 @@ export function resolveTargetGhHostname(
   if (!url) {
     return undefined;
   }
-  let parsed: URL;
+  let hostname: string;
   try {
-    parsed = new URL(url);
+    hostname = new URL(url).hostname.toLowerCase();
   } catch {
     return undefined;
   }
-  const hostname = parsed.hostname.toLowerCase();
-  if (!hostname) {
-    return undefined;
-  }
-  return hostname === 'github.com' ? 'github.com' : parsed.host.toLowerCase();
+  return hostname ? hostname : undefined;
 }
 
 /**

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -3676,15 +3676,15 @@ test('resolveTargetGhHostname resolves a GHES hostname, lowercased', () => {
   );
 });
 
-// idd-skill#2030 (PR #2026 review, owner follow-up): a GHES remote on a
-// non-standard port must keep that port -- `URL.hostname` alone would
-// silently drop it and misdirect the governance read at the default
-// HTTPS port instead of the repository's actual server, mirroring the
-// same `.host`-over-`.hostname` fix `branch-conflict-state.mts`'s
-// `parseGitFetchOrigin()` already applies.
-test('resolveTargetGhHostname preserves an explicit non-default port for a GHES hostname', () => {
+// idd-skill#2030 (PR #2051 review, Copilot): `gh api --hostname` rejects
+// any value containing a colon outright (confirmed against a real `gh`
+// binary), so this resolver must never emit a ported hostname -- keeping
+// the bare host, same as `gh-exec.mts`'s `resolveGhApiHostname()` sibling,
+// is deliberate here, not an oversight. Genuine port support needs an
+// absolute-URL request path instead of `--hostname`; deferred to #2052.
+test('resolveTargetGhHostname drops an explicit non-default port for a GHES hostname (gh api --hostname cannot carry one)', () => {
   assert.equal(
     resolveTargetGhHostname('https://ghe.example.com:8443/owner/repo'),
-    'ghe.example.com:8443',
+    'ghe.example.com',
   );
 });

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -3660,10 +3660,10 @@ test('fetchGhApiJsonAt preserves a failed `gh api` call\'s stdout so fetchGovern
 // subcommand such as `gh repo view`), so idd-doctor.mts's governance reads
 // must derive and pass an explicit `--hostname` for a GHES-hosted target
 // repository instead of relying on `cwd`.
-test('resolveTargetGhHostname returns undefined for github.com and an absent/unparseable URL', () => {
+test('resolveTargetGhHostname returns the explicit "github.com" override for a github.com URL, and undefined for an absent/unparseable URL (idd-skill#2030)', () => {
   assert.equal(
     resolveTargetGhHostname('https://github.com/kurone-kito/idd-skill'),
-    undefined,
+    'github.com',
   );
   assert.equal(resolveTargetGhHostname(undefined), undefined);
   assert.equal(resolveTargetGhHostname('not a url'), undefined);
@@ -3673,5 +3673,18 @@ test('resolveTargetGhHostname resolves a GHES hostname, lowercased', () => {
   assert.equal(
     resolveTargetGhHostname('https://GHE.example.com/owner/repo'),
     'ghe.example.com',
+  );
+});
+
+// idd-skill#2030 (PR #2026 review, owner follow-up): a GHES remote on a
+// non-standard port must keep that port -- `URL.hostname` alone would
+// silently drop it and misdirect the governance read at the default
+// HTTPS port instead of the repository's actual server, mirroring the
+// same `.host`-over-`.hostname` fix `branch-conflict-state.mts`'s
+// `parseGitFetchOrigin()` already applies.
+test('resolveTargetGhHostname preserves an explicit non-default port for a GHES hostname', () => {
+  assert.equal(
+    resolveTargetGhHostname('https://ghe.example.com:8443/owner/repo'),
+    'ghe.example.com:8443',
   );
 });


### PR DESCRIPTION
# Summary

`idd-doctor.mts`'s `resolveTargetGhHostname()` returned `undefined` for
a `github.com` target repository, so no `--hostname` override was
passed to its governance `gh api` reads. `gh api` falls back to a
`GH_HOST`-configured environment variable when no explicit `--hostname`
is given, so a calling environment with `GH_HOST` set to a GHES
instance would misdirect these reads even though `--repo-root` targets
a genuinely `github.com`-hosted repository.

Changed `resolveTargetGhHostname()` to return the literal string
`'github.com'` as an explicit override in that case, so an explicit
`--hostname` flag (which wins over `GH_HOST`) is always passed.

Also attempted to fold in a related finding from the same issue's
follow-up comment: switching the resolver's GHES branch from
`URL.hostname` to `URL.host` to preserve an explicit non-default port.
Copilot's review of this PR caught that this is unusable as shipped:
`gh api --hostname` rejects any value containing a colon outright
(confirmed against a real `gh` binary), so a ported host would hard-fail
every governance read instead of merely misrouting the port. Reverted
that piece back to the bare hostname (matching `gh-exec.mts`'s existing
`resolveGhApiHostname()` sibling, which has the same unaddressed
limitation) and filed #2052 as a follow-up for genuine port support via
an absolute-URL request path.

## Linked issue

Closes #2030

## Follow-up issues (if any)

- [x] #2052 (support a ported GHES host in `gh api` governance reads --
  drafted under `status:authoring`, pending release)

## Background / rationale (if material)

Surfaced during PR #2026's review (Codex), as the third successive
finding on the same host-resolution concern in that PR -- deferred
here per this repository's review round-cap discipline. The port-
preservation attempt arrived as a follow-up owner comment on this issue
after #2028/#2030 were filed; Copilot's review of this PR (round 1)
found it unusable as implemented, so it was reverted and deferred to
#2052 instead of shipped broken.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
