### PR TITLE
feat(onboarding): add a Step 0 gh CLI prerequisite check

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -205,20 +205,24 @@ Run:
 ```sh
 gh --version
 git remote get-url origin
-gh auth status
+gh auth status --hostname <derived-host>
 ```
 
-Bare `gh auth status` reports on every host `gh` already knows about,
-not the repository being onboarded -- it exits successfully as long as
-some known host is authenticated, even if the target repository's own
-host was never configured at all (confirmed: `gh auth status
---hostname <unconfigured-host>` fails with "You are not logged into
-any accounts on \<host\>", while the bare form silently omits an
-unknown host instead of reporting it missing). Derive the target
-host from `git remote get-url origin`'s URL (a `github.com` URL needs
-no override; any other host is a GHES target) and scope the check to
-it: `gh auth status --hostname <derived-host>` (omit `--hostname` for
-github.com, matching `gh`'s own no-override convention there).
+Bare `gh auth status` (no `--hostname`) reports on every host `gh`
+already knows about, not the repository being onboarded: it exits
+successfully only when **every** known host is authenticated, so an
+unrelated stale credential for some other project's host can fail this
+check even though the target repository's own host is fine (confirmed
+against a real `gh` binary) -- and, if the target host itself was
+never configured at all, the bare form silently omits it instead of
+reporting it missing. Both failure directions require scoping to the
+target host specifically, always -- unlike `gh api`'s own `--hostname`
+convention, `gh auth status` has no case where omitting it is correct,
+not even for `github.com` (confirmed: `gh auth status --hostname
+github.com` behaves identically to a clean bare invocation, so there
+is no cost to always passing it). Derive `<derived-host>` from `git
+remote get-url origin`'s URL (parse the host portion; a
+`github.com` URL yields `github.com` itself).
 
 - On success, continue to Step 1A without further comment.
 - On failure (not installed, or not authenticated to the target

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -204,13 +204,27 @@ Run:
 
 ```sh
 gh --version
+git remote get-url origin
 gh auth status
 ```
 
+Bare `gh auth status` reports on every host `gh` already knows about,
+not the repository being onboarded -- it exits successfully as long as
+some known host is authenticated, even if the target repository's own
+host was never configured at all (confirmed: `gh auth status
+--hostname <unconfigured-host>` fails with "You are not logged into
+any accounts on \<host\>", while the bare form silently omits an
+unknown host instead of reporting it missing). Derive the target
+host from `git remote get-url origin`'s URL (a `github.com` URL needs
+no override; any other host is a GHES target) and scope the check to
+it: `gh auth status --hostname <derived-host>` (omit `--hostname` for
+github.com, matching `gh`'s own no-override convention there).
+
 - On success, continue to Step 1A without further comment.
-- On failure (not installed, or not authenticated), report the exact
-  remediation to the operator -- the CLI install command, or
-  `gh auth login` -- and ask whether to proceed anyway before
+- On failure (not installed, or not authenticated to the target
+  repository's own host), report the exact remediation to the operator
+  -- the CLI install command, or `gh auth login --hostname
+  <derived-host>` -- and ask whether to proceed anyway before
   continuing. This is a one-time setup conversation the operator stays
   in control of, not a silent skip and not an unconditional hard stop.
 
@@ -251,9 +265,10 @@ Return the report in this format:
 - Files that would be modified:
 ```
 
-`Missing prerequisites:` reports the same `gh --version`/`gh auth
-status` check as Step 0 above, plus any other missing tooling this
-dry-run pass observes -- both surfaces agree on the `gh` check itself.
+`Missing prerequisites:` reports the same host-scoped `gh --version`/
+`gh auth status --hostname <derived-host>` check as Step 0 above, plus
+any other missing tooling this dry-run pass observes -- both surfaces
+agree on the `gh` check itself.
 
 This dry-run is for evaluators who want a quick import readiness summary
 before starting Step 1A.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -178,13 +178,47 @@ reasoning depth, not for routine IDD loop execution.
 ## Your task
 
 1. Read this document before changing files.
-2. Auto-derive candidate placeholder values from repository evidence.
-3. Confirm policy decisions with the operator.
-4. Fetch or copy the template files.
-5. Replace placeholders with the confirmed values.
-6. Record the selected policies where future IDD sessions will read them.
-7. Update the repository's agent entry files.
-8. Verify the imported result with the checklist at the bottom.
+2. Confirm the `gh` CLI is installed and authenticated.
+3. Auto-derive candidate placeholder values from repository evidence.
+4. Confirm policy decisions with the operator.
+5. Fetch or copy the template files.
+6. Replace placeholders with the confirmed values.
+7. Record the selected policies where future IDD sessions will read them.
+8. Update the repository's agent entry files.
+9. Verify the imported result with the checklist at the bottom.
+
+---
+
+## Step 0 — Prerequisite check
+
+Before Step 1A, confirm the `gh` CLI is installed and authenticated.
+IDD depends on `gh` throughout its own lifetime -- claim markers, PR
+submission, review-thread disposition, merge execution, and every
+later IDD phase -- independent of whatever tech stack the target
+repository itself uses. This is the operator's own local `gh` session
+used interactively during onboarding, distinct from the CI-side
+`GH_TOKEN`/`GH_ENTERPRISE_TOKEN` wiring a hosted `idd-doctor` workflow
+needs (see [Optional — run idd-doctor as a CI health gate](#optional--run-idd-doctor-as-a-ci-health-gate)).
+
+Run:
+
+```sh
+gh --version
+gh auth status
+```
+
+- On success, continue to Step 1A without further comment.
+- On failure (not installed, or not authenticated), report the exact
+  remediation to the operator -- the CLI install command, or
+  `gh auth login` -- and ask whether to proceed anyway before
+  continuing. This is a one-time setup conversation the operator stays
+  in control of, not a silent skip and not an unconditional hard stop.
+
+This check is scoped to `gh` only. IDD does not require Node.js or
+pnpm for the default instructions-only profile (see
+[Tooling boundary](docs/onboarding/placeholders.md#tooling-boundary));
+a Node.js check tied to the helper-runtime-profile choice belongs at
+Step 1B's helper-runtime-profile item instead, not here.
 
 ---
 
@@ -216,6 +250,10 @@ Return the report in this format:
 - Files that would be created:
 - Files that would be modified:
 ```
+
+`Missing prerequisites:` reports the same `gh --version`/`gh auth
+status` check as Step 0 above, plus any other missing tooling this
+dry-run pass observes -- both surfaces agree on the `gh` check itself.
 
 This dry-run is for evaluators who want a quick import readiness summary
 before starting Step 1A.


### PR DESCRIPTION
# Summary

No step in the onboarding flow verified `gh` was installed and
authenticated before proceeding, even though IDD depends on `gh`
throughout its own lifetime -- claim markers, PR submission,
review-thread disposition, merge execution -- independent of whatever
tech stack the target repository itself uses.

Added a mandatory "Step 0 -- Prerequisite check" to
`idd-template/ONBOARDING.md`, sequenced before Step 1A in both the
"Your task" step list and the section flow, that runs `gh --version`/
`gh auth status`, explains why `gh` is required, and on failure
reports remediation and asks the operator to confirm before proceeding.
Folded the same check into the existing optional Dry-run readiness
report's "Missing prerequisites:" field so both surfaces agree.
Scoped to `gh` only -- no Node.js/pnpm check, since IDD does not
require them for the default instructions-only profile.

## Linked issue

Closes #2007

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`src/scripts/idd-onboard.mts` (the onboarding CLI) contains no
`gh`/auth-related code path at all -- the check was absent, not merely
under-documented (observed 2026-08-13, source review during an
onboarding-flow audit).

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable) -- not applicable, docs-only change to a template file

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
