### PR TITLE
feat(advisory-convergence): add disposition-aware review-ack marker

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -339,7 +339,7 @@ hold.
 
 **`suppressedCount` unvalidated**: `#1511` is `itemCount`-only; reroll
 never zeroed it in `kurone-kito/lints-config` PRs `#243`/`#245`
-(2026-08-10/11).
+(2026-08-10/11). #2050: `review-ack` marker fixes it.
 
 ## Terminal Copilot stall-recovery contract (state, policy, markers, clock)
 

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -339,7 +339,7 @@ hold.
 
 **`suppressedCount` unvalidated**: `#1511` is `itemCount`-only; reroll
 never zeroed it in `kurone-kito/lints-config` PRs `#243`/`#245`
-(2026-08-10/11). #2050: `review-ack` marker fixes it.
+(2026-08-10/11). #2050: triaged review-ack fixes it.
 
 ## Terminal Copilot stall-recovery contract (state, policy, markers, clock)
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2001,21 +2001,35 @@ failure.
 
 **Disposition-aware resolution (kurone-kito/idd-skill#2050).** A
 same-HEAD reroll (above) is not the only escape hatch for `suppressedCount`
-today: `resolveLatestCopilotReviewClause`'s `satisfied` computation is now
-disposition-aware, not purely mechanical. `converged`'s Clause 1 becomes
-`matchesHead && (itemCount === 0 || threads.satisfied) && (suppressedCount
-=== 0 || hasValidReviewAck)`, computed as a thin override in
-`advisory-convergence.mts` (not inside `resolveLatestCopilotReviewClause`
-itself, since both halves need evidence -- `threads.satisfied`, PR comments,
-`trustedMarkerLogins` -- that pure function does not receive).
-`hasValidReviewAck` is `true` when a trusted `review-ack:` marker's OWN
-`created_at` postdates the latest Copilot review's `submittedAt` (never the
-marker's embedded timestamp), so any later review automatically invalidates
-a pre-existing ack. The `itemCount` half additionally requires
-`threads.copilotThreadCount > 0`: `threads.satisfied` alone is vacuously
-`true` when zero Copilot-authored threads exist at all, which would
-otherwise let a positive `itemCount` with no recorded thread evidence
-converge -- exactly the `#1719` incident shape above.
+today. `resolveLatestCopilotReviewClause` (review-clause.mts) itself stays
+purely mechanical -- `computeAdvisoryConvergenceVerdict`
+(advisory-convergence.mts) now computes a disposition-aware OVERRIDE of its
+`satisfied` field as a thin caller-side wrapper (not inside
+`resolveLatestCopilotReviewClause`, since the override needs evidence --
+review-scoped thread data, PR comments, `trustedMarkerLogins` -- that pure
+function does not receive), reported on the verdict's own `review.satisfied`
+in place of the raw mechanical value:
+
+```text
+matchesHead
+  && (itemCount === 0 || (a thread THIS review opened exists AND all are
+      resolved/dispositioned))
+  && (suppressedCount === 0 || hasValidReviewAck)
+```
+
+The `itemCount` half is bound to the LATEST review specifically
+(`classifyThreadIdsForReview`, matching each thread's originating comment's
+`pullRequestReview.id` against the review's own GraphQL node id, now also
+exposed as `review.reviewId`) -- NOT `threads.satisfied` (Clause 2's
+PR-WIDE, review-agnostic set) directly: an older, already-dispositioned
+thread from a DIFFERENT review must never stand in for the CURRENT
+review's own coverage, and `threads.satisfied` is additionally vacuous when
+zero Copilot-authored threads exist at all -- both variants of the same
+`#1719` incident shape above (a positive `itemCount` with no real thread
+evidence). `hasValidReviewAck` is `true` when a trusted `review-ack:`
+marker's OWN `created_at` postdates the latest Copilot review's
+`submittedAt` (never the marker's embedded timestamp), so any later review
+automatically invalidates a pre-existing ack.
 
 The `review-ack:` marker matches `advisory-reroll:`'s field shape and
 posting path exactly (see

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2015,8 +2015,8 @@ in place of the raw mechanical value:
 
 ```text
 matchesHead
-  && (itemCount === 0 || (itemCount is known AND >= 1 thread(s) THIS review
-      opened cover it AND all of them are resolved/dispositioned))
+  && (itemCount === 0 || (itemCount is known AND >= itemCount thread(s)
+      THIS review opened cover it AND all of them are resolved/dispositioned))
   && (suppressedCount === 0 || hasValidReviewAck)
 ```
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1947,18 +1947,21 @@ structurally unable to disagree.
 | `review-item-count-not-positive`          | The latest review's `itemCount` is a known `0` AND `suppressedCount` (#1880) is also `0` -- already fully converged, nothing (posted or suppressed) to reroll for.                        |
 <!-- dprint-ignore-end -->
 
-**Updated by kurone-kito/idd-skill#2050**: when `threads.copilotThreadCount`
-is zero (no Copilot-authored thread exists at all) and `review.itemCount >
-0`, the top-level `reasons` array's item-count entry is extended with a
+**Updated by kurone-kito/idd-skill#2050** (revised after PR #2054 review --
+scoped to the LATEST review, not the PR-wide `copilotThreadCount`): when
+zero threads THIS review opened exist at all and `review.itemCount > 0`,
+the top-level `reasons` array's item-count entry is extended with a
 pointer to check the review body directly -- the shape of the reported
 adopter incident: a "Comments suppressed due to low confidence" item
 embedded in the review's own body text counts toward `itemCount` but never
 surfaces as a review thread, so no thread query can ever explain it. When
-`copilotThreadCount > 0` instead (real Copilot-authored threads exist),
-`threads.satisfied: true` now lets `converged` proceed directly (Clause 1's
-`itemCount` half is satisfied via Clause 2's own thread-disposition
-evidence, `#2050`) -- the review-body pointer no longer applies to that
-case, since real thread evidence already accounts for the count.
+this review's own threads exist, are all resolved/dispositioned, AND their
+count covers `itemCount` instead, Clause 1's `itemCount` half is satisfied
+directly via that review-scoped thread-disposition evidence -- the
+review-body pointer no longer applies to that case. An older review's
+already-resolved thread, or a count of review-scoped threads smaller than
+`itemCount`, both still block (see the two dedicated regression tests
+added for each shape).
 
 **`suppressedCount` (kurone-kito/idd-skill#1880).** A distinct,
 `itemCount === 0` shape of the same underlying problem: GitHub Copilot
@@ -2048,8 +2051,11 @@ Plain text, no HTML comment. Post via `post-idd-marker.mjs --type
 review-ack --target pr <pr-number> --agent-id <id> --head-sha
 <PR_HEAD_SHA> --timestamp <ISO8601> --apply` (or `--from-pr <pr-number>`
 to derive `--head-sha` live) once the review's findings are fixed or
-dispositioned. Postable only by a `trustedMarkerActors` login -- an
-untrusted poster's marker is ignored. `idd-advisory-convergence` re-checks
+dispositioned. `post-idd-marker.mjs` itself performs no author gating (any
+caller with `gh` credentials can POST); only a marker authored by a
+`trustedMarkerActors` login is honored when `idd-advisory-convergence`
+later reads it back -- an untrusted poster's marker is ignored, not
+rejected at post time. `idd-advisory-convergence` re-checks
 live GitHub state, so re-run it (`gh run rerun <run-id>`) after posting --
 the marker itself does not retrigger the check.
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2012,8 +2012,8 @@ in place of the raw mechanical value:
 
 ```text
 matchesHead
-  && (itemCount === 0 || (a thread THIS review opened exists AND all are
-      resolved/dispositioned))
+  && (itemCount === 0 || (itemCount is known AND >= 1 thread(s) THIS review
+      opened cover it AND all of them are resolved/dispositioned))
   && (suppressedCount === 0 || hasValidReviewAck)
 ```
 
@@ -2026,10 +2026,14 @@ thread from a DIFFERENT review must never stand in for the CURRENT
 review's own coverage, and `threads.satisfied` is additionally vacuous when
 zero Copilot-authored threads exist at all -- both variants of the same
 `#1719` incident shape above (a positive `itemCount` with no real thread
-evidence). `hasValidReviewAck` is `true` when a trusted `review-ack:`
-marker's OWN `created_at` postdates the latest Copilot review's
-`submittedAt` (never the marker's embedded timestamp), so any later review
-automatically invalidates a pre-existing ack.
+evidence). `itemCount: null` (unknown count) also fails closed here rather
+than treating "at least one resolved thread exists" as sufficient, and the
+number of covering threads must be at least `itemCount` -- one dispositioned
+thread does not cover a review that posted two items (Copilot + CodeRabbit
+review, PR #2054). `hasValidReviewAck` is `true` when a trusted
+`review-ack:` marker's OWN `created_at` postdates the latest Copilot
+review's `submittedAt` (never the marker's embedded timestamp), so any
+later review automatically invalidates a pre-existing ack.
 
 The `review-ack:` marker matches `advisory-reroll:`'s field shape and
 posting path exactly (see

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1947,14 +1947,18 @@ structurally unable to disagree.
 | `review-item-count-not-positive`          | The latest review's `itemCount` is a known `0` AND `suppressedCount` (#1880) is also `0` -- already fully converged, nothing (posted or suppressed) to reroll for.                        |
 <!-- dprint-ignore-end -->
 
-When `review-item-count-not-positive` is absent but `converged` is still
-`false` with `threads.satisfied: true` (every visible Copilot-authored
-thread already resolved) and `review.itemCount > 0`, the top-level
-`reasons` array's item-count entry is itself extended with a pointer to
-check the review body directly -- the shape of the reported adopter
-incident: a "Comments suppressed due to low confidence" item embedded in
-the review's own body text counts toward `itemCount` but never surfaces
-as a review thread, so no thread query can ever explain it.
+**Updated by kurone-kito/idd-skill#2050**: when `threads.copilotThreadCount`
+is zero (no Copilot-authored thread exists at all) and `review.itemCount >
+0`, the top-level `reasons` array's item-count entry is extended with a
+pointer to check the review body directly -- the shape of the reported
+adopter incident: a "Comments suppressed due to low confidence" item
+embedded in the review's own body text counts toward `itemCount` but never
+surfaces as a review thread, so no thread query can ever explain it. When
+`copilotThreadCount > 0` instead (real Copilot-authored threads exist),
+`threads.satisfied: true` now lets `converged` proceed directly (Clause 1's
+`itemCount` half is satisfied via Clause 2's own thread-disposition
+evidence, `#2050`) -- the review-body pointer no longer applies to that
+case, since real thread evidence already accounts for the count.
 
 **`suppressedCount` (kurone-kito/idd-skill#1880).** A distinct,
 `itemCount === 0` shape of the same underlying problem: GitHub Copilot
@@ -1994,6 +1998,42 @@ anticipated outcome routed to the deadline/waiver backstop **or hold**
 step 5, including for adopters who keep the distributed
 `ciGate.externalCheckWaivers.mode: disabled` default), not a diagnosis
 failure.
+
+**Disposition-aware resolution (kurone-kito/idd-skill#2050).** A
+same-HEAD reroll (above) is not the only escape hatch for `suppressedCount`
+today: `resolveLatestCopilotReviewClause`'s `satisfied` computation is now
+disposition-aware, not purely mechanical. `converged`'s Clause 1 becomes
+`matchesHead && (itemCount === 0 || threads.satisfied) && (suppressedCount
+=== 0 || hasValidReviewAck)`, computed as a thin override in
+`advisory-convergence.mts` (not inside `resolveLatestCopilotReviewClause`
+itself, since both halves need evidence -- `threads.satisfied`, PR comments,
+`trustedMarkerLogins` -- that pure function does not receive).
+`hasValidReviewAck` is `true` when a trusted `review-ack:` marker's OWN
+`created_at` postdates the latest Copilot review's `submittedAt` (never the
+marker's embedded timestamp), so any later review automatically invalidates
+a pre-existing ack. The `itemCount` half additionally requires
+`threads.copilotThreadCount > 0`: `threads.satisfied` alone is vacuously
+`true` when zero Copilot-authored threads exist at all, which would
+otherwise let a positive `itemCount` with no recorded thread evidence
+converge -- exactly the `#1719` incident shape above.
+
+The `review-ack:` marker matches `advisory-reroll:`'s field shape and
+posting path exactly (see
+[`idd-advisory-wait.instructions.md`](../.github/instructions/idd-advisory-wait.instructions.md)'s
+`suppressedCount`-unvalidated note in its AW6 section):
+
+```text
+review-ack: {agent-id} {PR_HEAD_SHA} {ISO8601-acknowledged-at}
+```
+
+Plain text, no HTML comment. Post via `post-idd-marker.mjs --type
+review-ack --target pr <pr-number> --agent-id <id> --head-sha
+<PR_HEAD_SHA> --timestamp <ISO8601> --apply` (or `--from-pr <pr-number>`
+to derive `--head-sha` live) once the review's findings are fixed or
+dispositioned. Postable only by a `trustedMarkerActors` login -- an
+untrusted poster's marker is ignored. `idd-advisory-convergence` re-checks
+live GitHub state, so re-run it (`gh run rerun <run-id>`) after posting --
+the marker itself does not retrigger the check.
 
 **AW6 procedure** (`idd-advisory-wait.instructions.md`), invoked only
 from F2 on a non-zero `--assert` exit:

--- a/fixtures/schemas/advisory-convergence.valid.json
+++ b/fixtures/schemas/advisory-convergence.valid.json
@@ -12,6 +12,7 @@
   },
   "review": {
     "found": true,
+    "reviewId": "PRR_kwDOexample",
     "commitId": "0123456789abcdef0123456789abcdef01234567",
     "matchesHead": true,
     "itemCount": 0,

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -334,7 +334,7 @@ hold.
 
 **`suppressedCount` unvalidated**: `#1511` is `itemCount`-only; reroll
 never zeroed it in `kurone-kito/lints-config` PRs `#243`/`#245`
-(2026-08-10/11). #2050: `review-ack` marker fixes it.
+(2026-08-10/11). #2050: triaged review-ack fixes it.
 
 ## Terminal Copilot stall-recovery contract (state, policy, markers, clock)
 

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -334,7 +334,7 @@ hold.
 
 **`suppressedCount` unvalidated**: `#1511` is `itemCount`-only; reroll
 never zeroed it in `kurone-kito/lints-config` PRs `#243`/`#245`
-(2026-08-10/11).
+(2026-08-10/11). #2050: `review-ack` marker fixes it.
 
 ## Terminal Copilot stall-recovery contract (state, policy, markers, clock)
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2001,21 +2001,35 @@ failure.
 
 **Disposition-aware resolution (kurone-kito/idd-skill#2050).** A
 same-HEAD reroll (above) is not the only escape hatch for `suppressedCount`
-today: `resolveLatestCopilotReviewClause`'s `satisfied` computation is now
-disposition-aware, not purely mechanical. `converged`'s Clause 1 becomes
-`matchesHead && (itemCount === 0 || threads.satisfied) && (suppressedCount
-=== 0 || hasValidReviewAck)`, computed as a thin override in
-`advisory-convergence.mts` (not inside `resolveLatestCopilotReviewClause`
-itself, since both halves need evidence -- `threads.satisfied`, PR comments,
-`trustedMarkerLogins` -- that pure function does not receive).
-`hasValidReviewAck` is `true` when a trusted `review-ack:` marker's OWN
-`created_at` postdates the latest Copilot review's `submittedAt` (never the
-marker's embedded timestamp), so any later review automatically invalidates
-a pre-existing ack. The `itemCount` half additionally requires
-`threads.copilotThreadCount > 0`: `threads.satisfied` alone is vacuously
-`true` when zero Copilot-authored threads exist at all, which would
-otherwise let a positive `itemCount` with no recorded thread evidence
-converge -- exactly the `#1719` incident shape above.
+today. `resolveLatestCopilotReviewClause` (review-clause.mts) itself stays
+purely mechanical -- `computeAdvisoryConvergenceVerdict`
+(advisory-convergence.mts) now computes a disposition-aware OVERRIDE of its
+`satisfied` field as a thin caller-side wrapper (not inside
+`resolveLatestCopilotReviewClause`, since the override needs evidence --
+review-scoped thread data, PR comments, `trustedMarkerLogins` -- that pure
+function does not receive), reported on the verdict's own `review.satisfied`
+in place of the raw mechanical value:
+
+```text
+matchesHead
+  && (itemCount === 0 || (a thread THIS review opened exists AND all are
+      resolved/dispositioned))
+  && (suppressedCount === 0 || hasValidReviewAck)
+```
+
+The `itemCount` half is bound to the LATEST review specifically
+(`classifyThreadIdsForReview`, matching each thread's originating comment's
+`pullRequestReview.id` against the review's own GraphQL node id, now also
+exposed as `review.reviewId`) -- NOT `threads.satisfied` (Clause 2's
+PR-WIDE, review-agnostic set) directly: an older, already-dispositioned
+thread from a DIFFERENT review must never stand in for the CURRENT
+review's own coverage, and `threads.satisfied` is additionally vacuous when
+zero Copilot-authored threads exist at all -- both variants of the same
+`#1719` incident shape above (a positive `itemCount` with no real thread
+evidence). `hasValidReviewAck` is `true` when a trusted `review-ack:`
+marker's OWN `created_at` postdates the latest Copilot review's
+`submittedAt` (never the marker's embedded timestamp), so any later review
+automatically invalidates a pre-existing ack.
 
 The `review-ack:` marker matches `advisory-reroll:`'s field shape and
 posting path exactly (see

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2015,8 +2015,8 @@ in place of the raw mechanical value:
 
 ```text
 matchesHead
-  && (itemCount === 0 || (itemCount is known AND >= 1 thread(s) THIS review
-      opened cover it AND all of them are resolved/dispositioned))
+  && (itemCount === 0 || (itemCount is known AND >= itemCount thread(s)
+      THIS review opened cover it AND all of them are resolved/dispositioned))
   && (suppressedCount === 0 || hasValidReviewAck)
 ```
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1947,18 +1947,21 @@ structurally unable to disagree.
 | `review-item-count-not-positive`          | The latest review's `itemCount` is a known `0` AND `suppressedCount` (#1880) is also `0` -- already fully converged, nothing (posted or suppressed) to reroll for.                        |
 <!-- dprint-ignore-end -->
 
-**Updated by kurone-kito/idd-skill#2050**: when `threads.copilotThreadCount`
-is zero (no Copilot-authored thread exists at all) and `review.itemCount >
-0`, the top-level `reasons` array's item-count entry is extended with a
+**Updated by kurone-kito/idd-skill#2050** (revised after PR #2054 review --
+scoped to the LATEST review, not the PR-wide `copilotThreadCount`): when
+zero threads THIS review opened exist at all and `review.itemCount > 0`,
+the top-level `reasons` array's item-count entry is extended with a
 pointer to check the review body directly -- the shape of the reported
 adopter incident: a "Comments suppressed due to low confidence" item
 embedded in the review's own body text counts toward `itemCount` but never
 surfaces as a review thread, so no thread query can ever explain it. When
-`copilotThreadCount > 0` instead (real Copilot-authored threads exist),
-`threads.satisfied: true` now lets `converged` proceed directly (Clause 1's
-`itemCount` half is satisfied via Clause 2's own thread-disposition
-evidence, `#2050`) -- the review-body pointer no longer applies to that
-case, since real thread evidence already accounts for the count.
+this review's own threads exist, are all resolved/dispositioned, AND their
+count covers `itemCount` instead, Clause 1's `itemCount` half is satisfied
+directly via that review-scoped thread-disposition evidence -- the
+review-body pointer no longer applies to that case. An older review's
+already-resolved thread, or a count of review-scoped threads smaller than
+`itemCount`, both still block (see the two dedicated regression tests
+added for each shape).
 
 **`suppressedCount` (kurone-kito/idd-skill#1880).** A distinct,
 `itemCount === 0` shape of the same underlying problem: GitHub Copilot
@@ -2048,8 +2051,11 @@ Plain text, no HTML comment. Post via `post-idd-marker.mjs --type
 review-ack --target pr <pr-number> --agent-id <id> --head-sha
 <PR_HEAD_SHA> --timestamp <ISO8601> --apply` (or `--from-pr <pr-number>`
 to derive `--head-sha` live) once the review's findings are fixed or
-dispositioned. Postable only by a `trustedMarkerActors` login -- an
-untrusted poster's marker is ignored. `idd-advisory-convergence` re-checks
+dispositioned. `post-idd-marker.mjs` itself performs no author gating (any
+caller with `gh` credentials can POST); only a marker authored by a
+`trustedMarkerActors` login is honored when `idd-advisory-convergence`
+later reads it back -- an untrusted poster's marker is ignored, not
+rejected at post time. `idd-advisory-convergence` re-checks
 live GitHub state, so re-run it (`gh run rerun <run-id>`) after posting --
 the marker itself does not retrigger the check.
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2012,8 +2012,8 @@ in place of the raw mechanical value:
 
 ```text
 matchesHead
-  && (itemCount === 0 || (a thread THIS review opened exists AND all are
-      resolved/dispositioned))
+  && (itemCount === 0 || (itemCount is known AND >= 1 thread(s) THIS review
+      opened cover it AND all of them are resolved/dispositioned))
   && (suppressedCount === 0 || hasValidReviewAck)
 ```
 
@@ -2026,10 +2026,14 @@ thread from a DIFFERENT review must never stand in for the CURRENT
 review's own coverage, and `threads.satisfied` is additionally vacuous when
 zero Copilot-authored threads exist at all -- both variants of the same
 `#1719` incident shape above (a positive `itemCount` with no real thread
-evidence). `hasValidReviewAck` is `true` when a trusted `review-ack:`
-marker's OWN `created_at` postdates the latest Copilot review's
-`submittedAt` (never the marker's embedded timestamp), so any later review
-automatically invalidates a pre-existing ack.
+evidence). `itemCount: null` (unknown count) also fails closed here rather
+than treating "at least one resolved thread exists" as sufficient, and the
+number of covering threads must be at least `itemCount` -- one dispositioned
+thread does not cover a review that posted two items (Copilot + CodeRabbit
+review, PR #2054). `hasValidReviewAck` is `true` when a trusted
+`review-ack:` marker's OWN `created_at` postdates the latest Copilot
+review's `submittedAt` (never the marker's embedded timestamp), so any
+later review automatically invalidates a pre-existing ack.
 
 The `review-ack:` marker matches `advisory-reroll:`'s field shape and
 posting path exactly (see

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1947,14 +1947,18 @@ structurally unable to disagree.
 | `review-item-count-not-positive`          | The latest review's `itemCount` is a known `0` AND `suppressedCount` (#1880) is also `0` -- already fully converged, nothing (posted or suppressed) to reroll for.                        |
 <!-- dprint-ignore-end -->
 
-When `review-item-count-not-positive` is absent but `converged` is still
-`false` with `threads.satisfied: true` (every visible Copilot-authored
-thread already resolved) and `review.itemCount > 0`, the top-level
-`reasons` array's item-count entry is itself extended with a pointer to
-check the review body directly -- the shape of the reported adopter
-incident: a "Comments suppressed due to low confidence" item embedded in
-the review's own body text counts toward `itemCount` but never surfaces
-as a review thread, so no thread query can ever explain it.
+**Updated by kurone-kito/idd-skill#2050**: when `threads.copilotThreadCount`
+is zero (no Copilot-authored thread exists at all) and `review.itemCount >
+0`, the top-level `reasons` array's item-count entry is extended with a
+pointer to check the review body directly -- the shape of the reported
+adopter incident: a "Comments suppressed due to low confidence" item
+embedded in the review's own body text counts toward `itemCount` but never
+surfaces as a review thread, so no thread query can ever explain it. When
+`copilotThreadCount > 0` instead (real Copilot-authored threads exist),
+`threads.satisfied: true` now lets `converged` proceed directly (Clause 1's
+`itemCount` half is satisfied via Clause 2's own thread-disposition
+evidence, `#2050`) -- the review-body pointer no longer applies to that
+case, since real thread evidence already accounts for the count.
 
 **`suppressedCount` (kurone-kito/idd-skill#1880).** A distinct,
 `itemCount === 0` shape of the same underlying problem: GitHub Copilot
@@ -1994,6 +1998,42 @@ anticipated outcome routed to the deadline/waiver backstop **or hold**
 step 5, including for adopters who keep the distributed
 `ciGate.externalCheckWaivers.mode: disabled` default), not a diagnosis
 failure.
+
+**Disposition-aware resolution (kurone-kito/idd-skill#2050).** A
+same-HEAD reroll (above) is not the only escape hatch for `suppressedCount`
+today: `resolveLatestCopilotReviewClause`'s `satisfied` computation is now
+disposition-aware, not purely mechanical. `converged`'s Clause 1 becomes
+`matchesHead && (itemCount === 0 || threads.satisfied) && (suppressedCount
+=== 0 || hasValidReviewAck)`, computed as a thin override in
+`advisory-convergence.mts` (not inside `resolveLatestCopilotReviewClause`
+itself, since both halves need evidence -- `threads.satisfied`, PR comments,
+`trustedMarkerLogins` -- that pure function does not receive).
+`hasValidReviewAck` is `true` when a trusted `review-ack:` marker's OWN
+`created_at` postdates the latest Copilot review's `submittedAt` (never the
+marker's embedded timestamp), so any later review automatically invalidates
+a pre-existing ack. The `itemCount` half additionally requires
+`threads.copilotThreadCount > 0`: `threads.satisfied` alone is vacuously
+`true` when zero Copilot-authored threads exist at all, which would
+otherwise let a positive `itemCount` with no recorded thread evidence
+converge -- exactly the `#1719` incident shape above.
+
+The `review-ack:` marker matches `advisory-reroll:`'s field shape and
+posting path exactly (see
+[`idd-advisory-wait.instructions.md`](../.github/instructions/idd-advisory-wait.instructions.md)'s
+`suppressedCount`-unvalidated note in its AW6 section):
+
+```text
+review-ack: {agent-id} {PR_HEAD_SHA} {ISO8601-acknowledged-at}
+```
+
+Plain text, no HTML comment. Post via `post-idd-marker.mjs --type
+review-ack --target pr <pr-number> --agent-id <id> --head-sha
+<PR_HEAD_SHA> --timestamp <ISO8601> --apply` (or `--from-pr <pr-number>`
+to derive `--head-sha` live) once the review's findings are fixed or
+dispositioned. Postable only by a `trustedMarkerActors` login -- an
+untrusted poster's marker is ignored. `idd-advisory-convergence` re-checks
+live GitHub state, so re-run it (`gh run rerun <run-id>`) after posting --
+the marker itself does not retrigger the check.
 
 **AW6 procedure** (`idd-advisory-wait.instructions.md`), invoked only
 from F2 on a non-zero `--assert` exit:

--- a/schemas/advisory-convergence.schema.json
+++ b/schemas/advisory-convergence.schema.json
@@ -84,12 +84,16 @@
     "review": {
       "type": "object",
       "description": "Clause 1 evidence: identity and HEAD-coverage of the primary bot's latest review, by fetch order.",
-      "required": ["found", "commitId", "matchesHead", "itemCount", "submittedAt", "suppressedCount", "satisfied"],
+      "required": ["found", "reviewId", "commitId", "matchesHead", "itemCount", "submittedAt", "suppressedCount", "satisfied"],
       "additionalProperties": false,
       "properties": {
         "found": {
           "type": "boolean",
           "description": "True when at least one verified primary-bot review exists at all."
+        },
+        "reviewId": {
+          "type": "string",
+          "description": "GraphQL node id of the latest primary-bot review, read only when matchesHead is true; empty otherwise. kurone-kito/idd-skill#2050: used to bind Clause 1's itemCount-half thread evidence to THIS specific review (via each thread's originating comment's pullRequestReview.id), not any primary-bot-authored thread anywhere in the PR's history."
         },
         "commitId": {
           "type": "string",
@@ -114,7 +118,7 @@
         },
         "satisfied": {
           "type": "boolean",
-          "description": "True when the latest review covers HEAD, reports zero actionable items, AND has no suppressed-comments section -- Clause 1's pass condition."
+          "description": "kurone-kito/idd-skill#2050: disposition-aware, not purely mechanical -- reflects a caller-side override computed in advisory-convergence.mts, not resolveLatestCopilotReviewClause's own raw evaluation. True when the latest review covers HEAD (matchesHead) AND (itemCount is 0 OR every thread THIS review opened is resolved/dispositioned, requiring at least one such thread to exist) AND (suppressedCount is 0 OR a trusted review-ack marker posted after this review covers it) -- Clause 1's pass condition."
         }
       }
     },

--- a/schemas/advisory-convergence.schema.json
+++ b/schemas/advisory-convergence.schema.json
@@ -118,7 +118,7 @@
         },
         "satisfied": {
           "type": "boolean",
-          "description": "kurone-kito/idd-skill#2050: disposition-aware, not purely mechanical -- reflects a caller-side override computed in advisory-convergence.mts, not resolveLatestCopilotReviewClause's own raw evaluation. True when the latest review covers HEAD (matchesHead) AND (itemCount is 0 OR every thread THIS review opened is resolved/dispositioned, requiring at least one such thread to exist) AND (suppressedCount is 0 OR a trusted review-ack marker posted after this review covers it) -- Clause 1's pass condition."
+          "description": "kurone-kito/idd-skill#2050 (revised after PR #2054 review): disposition-aware, not purely mechanical -- reflects a caller-side override computed in advisory-convergence.mts, not resolveLatestCopilotReviewClause's own raw evaluation. True when the latest review covers HEAD (matchesHead) AND (itemCount is a KNOWN 0, OR itemCount is known-nonzero AND the number of threads THIS review opened is at least itemCount AND every one of them is resolved/dispositioned) AND (suppressedCount is 0 OR a trusted review-ack marker posted after this review covers it) -- Clause 1's pass condition. An unknown itemCount (null) always fails this condition."
         }
       }
     },

--- a/schemas/post-idd-marker.schema.json
+++ b/schemas/post-idd-marker.schema.json
@@ -22,6 +22,7 @@
         "advisory",
         "advisory-recovery",
         "advisory-reroll",
+        "review-ack",
         "copilot-unavailable"
       ],
       "description": "Operational marker type rendered for the comment."

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -412,20 +412,31 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     trustedMarkerLogins,
     review.submittedAt,
   );
-  // `itemCountClauseSatisfied`: `itemCount === 0`, OR Clause 2's OWN
-  // thread-disposition evidence already covers every item Copilot posted
-  // (`threadClause.satisfied`) PROVIDED at least one Copilot-authored thread
-  // actually exists (`copilotThreadCount > 0`). That second conjunct matters:
-  // `threadClause.satisfied` is vacuously `true` when ZERO Copilot-authored
-  // threads exist at all (`blockingCount === 0` trivially), which would
-  // otherwise let a review with a positive `itemCount` and NO recorded
-  // thread evidence converge with nothing actually read or dispositioned --
-  // exactly the #1719 incident shape documented below (a "Comments
-  // suppressed due to low confidence" item counted in `itemCount` but
-  // invisible to any `reviewThreads` query).
+  // `itemCountClauseSatisfied`: `itemCount === 0`, OR every thread THIS
+  // SPECIFIC review opened is resolved or validly dispositioned. Bound to
+  // `review.reviewId` (Copilot review, this PR: `classifyThreadIdsForReview`)
+  // rather than reusing `threadClause` (Clause 2's PR-WIDE, review-agnostic
+  // set) directly: `threadClause.satisfied` can be vacuously true from an
+  // OLDER, already-dispositioned review's threads while the LATEST review's
+  // own items have no thread representation at all -- a resolved-but-stale
+  // thread must never stand in for the CURRENT review's own coverage. This
+  // also naturally handles the #1719 incident shape (a "Comments suppressed
+  // due to low confidence" item counted in `itemCount` but invisible to any
+  // `reviewThreads` query): `latestReviewThreadIds` stays empty and
+  // `itemCountClauseSatisfied` stays `false`.
+  const latestReviewThreadIds = classifyThreadIdsForReview(
+    threads,
+    primaryBotLogin,
+    review.reviewId,
+  );
+  const latestReviewBlocking = dispositionEvidence.missingThreads.filter(
+    (thread) =>
+      latestReviewThreadIds.has(String(thread.id ?? '')) &&
+      thread.isResolved === false,
+  );
   const itemCountClauseSatisfied =
     review.itemCount === 0 ||
-    (threadClause.satisfied && threadClause.copilotThreadCount > 0);
+    (latestReviewThreadIds.size > 0 && latestReviewBlocking.length === 0);
   // `suppressedClauseSatisfied`: `suppressedCount === 0`, OR a valid
   // `review-ack` covers it.
   const suppressedClauseSatisfied =
@@ -487,15 +498,16 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
         review.suppressedCount > 0
           ? ` (plus ${review.suppressedCount} suppressed comment(s) in the review body, not counted in itemCount)`
           : '';
-      // #2050: only the zero-Copilot-thread shape still needs the "check
-      // the review body directly" pointer -- when real Copilot-authored
-      // threads exist and are all resolved/dispositioned,
+      // #2050: only the "this review opened zero threads" shape still needs
+      // the "check the review body directly" pointer -- when THIS review's
+      // own threads exist and are all resolved/dispositioned,
       // `itemCountClauseSatisfied` is already `true` and this `else` branch
       // is unreachable for that case; when they exist but are NOT all
       // resolved/dispositioned, the separate `threadClause.satisfied` reason
-      // below already names those threads directly.
+      // below already names those (PR-wide) blocking threads directly,
+      // which include this review's own unresolved ones.
       const noThreadEvidenceForItems =
-        threadClause.copilotThreadCount === 0 &&
+        latestReviewThreadIds.size === 0 &&
         review.itemCount !== null &&
         review.itemCount > 0;
       reasons.push(
@@ -857,6 +869,40 @@ export function classifyCopilotAuthoredThreadIds(threads, primaryBotLogin) {
       // `missingThreads[].id` fallback exactly (protocol-helpers.mts) so a
       // thread with an empty/missing GraphQL id still round-trips through
       // the `.has()` lookup in the caller instead of silently diverging.
+      ids.add(String(thread.id ?? '') || `thread-${index + 1}`);
+    }
+  });
+  return ids;
+}
+/**
+ * #2050: Copilot-authored thread IDs whose *originating* comment belongs to
+ * a SPECIFIC review (matched by GraphQL review node id), unlike
+ * {@link classifyCopilotAuthoredThreadIds}'s review-agnostic set (every
+ * Copilot-authored thread anywhere in the PR's history -- which Clause 2
+ * genuinely needs). Clause 1's `itemCount`-half needs narrower, review-bound
+ * evidence: `threadClause.satisfied` alone can be vacuously true from an
+ * OLDER, already-dispositioned review's threads while the LATEST review's
+ * own items have no thread representation at all -- a resolved-but-stale
+ * thread must never stand in for the CURRENT review's own coverage (Copilot
+ * review, this PR). Each thread's originating comment's `pullRequestReview`
+ * is already fetched by `fetchReviewThreads` below; matching on its `id`
+ * against a Copilot review's own `id` (review-clause.mts's `reviewId`) also
+ * proves Copilot authorship by construction (every comment in one GitHub
+ * review shares that review's single author), but `isVerifiedCopilotAuthor`
+ * is still checked directly for defense-in-depth, matching this file's
+ * existing convention. `reviewId === ''` (not found / off-HEAD) always
+ * returns an empty set, fail-closed.
+ */
+export function classifyThreadIdsForReview(threads, primaryBotLogin, reviewId) {
+  const ids = new Set();
+  if (!reviewId) return ids;
+  threads.forEach((thread, index) => {
+    const originating = (thread.comments?.nodes ?? [])[0];
+    if (
+      originating &&
+      isVerifiedCopilotAuthor(originating.author, primaryBotLogin) &&
+      String(originating.pullRequestReview?.id ?? '') === reviewId
+    ) {
       ids.add(String(thread.id ?? '') || `thread-${index + 1}`);
     }
   });

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -434,9 +434,25 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
       latestReviewThreadIds.has(String(thread.id ?? '')) &&
       thread.isResolved === false,
   );
+  // #2054 review (Copilot + CodeRabbit, independently): the thread-evidence
+  // disjunct alone neither required a KNOWN itemCount, nor that the
+  // NUMBER of this-review-originated threads actually covers every posted
+  // item -- `itemCount: null` (unknown count), or `itemCount: 2` with only
+  // ONE such thread, would otherwise satisfy this on "at least one resolved
+  // thread exists," leaving other posted items unaccounted for.
+  // `latestReviewThreadIds.size >= review.itemCount` requires as many
+  // review-scoped threads as claimed items (each of the review's own
+  // comments originates at most one thread, so this count can never
+  // legitimately exceed `itemCount`, making `>=` and exact equality
+  // equivalent in practice; `>=` is the more defensive form).
+  // `review.itemCount !== null` fails closed on the unknown-count case,
+  // matching this file's other missing-evidence guards (e.g.
+  // `reviewItemCountKnownTerm` in the sameHeadReroll terms below).
   const itemCountClauseSatisfied =
     review.itemCount === 0 ||
-    (latestReviewThreadIds.size > 0 && latestReviewBlocking.length === 0);
+    (review.itemCount !== null &&
+      latestReviewThreadIds.size >= review.itemCount &&
+      latestReviewBlocking.length === 0);
   // `suppressedClauseSatisfied`: `suppressedCount === 0`, OR a valid
   // `review-ack` covers it.
   const suppressedClauseSatisfied =

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -123,6 +123,7 @@ import {
   resolveCollaboratorMarkerTrust,
 } from './policy-helpers.mjs';
 import {
+  compareIsoTimestamps,
   DEFAULT_STALE_AGE_MS,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
@@ -388,12 +389,55 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     blockingCount: copilotBlocking.length,
     satisfied: copilotBlocking.length === 0,
   };
+  // --- #2050: disposition-aware Clause 1 override -------------------------
+  // The raw `review.satisfied` (review-clause.mts) is a purely mechanical
+  // `matchesHead && itemCount === 0 && suppressedCount === 0` check, with no
+  // awareness of whether a trusted actor already read and dispositioned
+  // those findings -- computed here as a thin caller-side override instead
+  // of inside `resolveLatestCopilotReviewClause` itself, since both halves
+  // below need evidence (`threadClause`, `comments`, `trustedMarkerLogins`)
+  // that pure, low-dependency function does not receive (and its OTHER
+  // caller, `rerun-advisory-convergence.mts`, only ever reads `.matchesHead`,
+  // never `.satisfied`, so this override cannot affect it).
+  //
+  // `hasValidReviewAck` (#2050): true when a trusted `review-ack:` marker's
+  // OWN GitHub `created_at` (never an embedded, agent-supplied timestamp --
+  // the same trust boundary `hasFreshDisposition`, protocol-helpers.mts, and
+  // `summarizeSameHeadRerollMarkers` above already apply) postdates the
+  // latest primary-bot review's `submittedAt`. A single whole-review
+  // acknowledgement, not a per-finding identifier scheme -- see the issue's
+  // "Decision" section for why.
+  const hasValidReviewAck = resolveHasValidReviewAck(
+    comments,
+    trustedMarkerLogins,
+    review.submittedAt,
+  );
+  // `itemCountClauseSatisfied`: `itemCount === 0`, OR Clause 2's OWN
+  // thread-disposition evidence already covers every item Copilot posted
+  // (`threadClause.satisfied`) PROVIDED at least one Copilot-authored thread
+  // actually exists (`copilotThreadCount > 0`). That second conjunct matters:
+  // `threadClause.satisfied` is vacuously `true` when ZERO Copilot-authored
+  // threads exist at all (`blockingCount === 0` trivially), which would
+  // otherwise let a review with a positive `itemCount` and NO recorded
+  // thread evidence converge with nothing actually read or dispositioned --
+  // exactly the #1719 incident shape documented below (a "Comments
+  // suppressed due to low confidence" item counted in `itemCount` but
+  // invisible to any `reviewThreads` query).
+  const itemCountClauseSatisfied =
+    review.itemCount === 0 ||
+    (threadClause.satisfied && threadClause.copilotThreadCount > 0);
+  // `suppressedClauseSatisfied`: `suppressedCount === 0`, OR a valid
+  // `review-ack` covers it.
+  const suppressedClauseSatisfied =
+    review.suppressedCount === 0 || hasValidReviewAck;
+  const reviewSatisfied =
+    review.matchesHead && itemCountClauseSatisfied && suppressedClauseSatisfied;
   // Clause 1's "review is not clean" reason is pushed here, after Clause 2's
-  // `threadClause` is available -- deliberately deferred from the `pending`
-  // check above (whose own `if` already exhausts the pending case, so
-  // `reasons` order is unaffected: pending and not-satisfied are mutually
-  // exclusive, and this still precedes Clause 2's own thread-blocking
-  // reason below).
+  // `threadClause` and the disposition-aware overrides above are available
+  // -- deliberately deferred from the `pending` check above (whose own `if`
+  // already exhausts the pending case, so `reasons` order is unaffected:
+  // pending and not-satisfied are mutually exclusive, and this still
+  // precedes Clause 2's own thread-blocking reason below).
   //
   // #1719: reported adopter incident -- the primary bot's review on current
   // HEAD carried `itemCount: 1` while every visible GraphQL review thread
@@ -402,10 +446,10 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   // top-level BODY TEXT rather than posted as a review thread -- it
   // contributes to `itemCount` but is invisible to any `reviewThreads`
   // query, so it can never be resolved the normal way, and nothing in this
-  // gate's output pointed there. When every visible Copilot-authored thread
-  // is already resolved and `itemCount` is still positive, no thread query
-  // can explain it -- point directly at the review body instead of leaving
-  // an agent to re-derive this by hand a second time.
+  // gate's output pointed there. When zero Copilot-authored threads exist at
+  // all, no thread query can explain a positive `itemCount` -- point
+  // directly at the review body instead of leaving an agent to re-derive
+  // this by hand a second time.
   //
   // #1880: a related but distinct incident shape -- the primary bot's
   // review on current HEAD carries `itemCount: 0` (zero POSTED comments)
@@ -413,13 +457,23 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   // block for a finding it chose not to post as a comment at all. The
   // #1719 branch above only fires when `itemCount > 0`, so this case fell
   // through to full convergence with an empty `reasons[]` until now (PR
-  // #1875 commit 9711d404). `review.satisfied` (review-clause.mts) is
-  // already gated on `suppressedCount === 0`, so `converged` is already
-  // correctly `false` here -- this branch only supplies the explanation.
-  if (!scopeBlocksConvergenceEval && !pending && !review.satisfied) {
+  // #1875 commit 9711d404). `reviewSatisfied` is already gated on
+  // `suppressedClauseSatisfied`, so `converged` is already correctly
+  // `false` here -- this branch only supplies the explanation.
+  //
+  // #2050: `ackSuffix` names the recovery marker (not a profile-specific
+  // command path -- adopters on a non-vendored profile run a different
+  // `post-idd-marker` invocation) whenever a nonzero `suppressedCount` is
+  // still unresolved for lack of a valid `review-ack` -- computed once,
+  // shared by both branches below.
+  const ackSuffix =
+    review.suppressedCount > 0 && !hasValidReviewAck
+      ? '; post a trusted review-ack marker after this review to cover the suppressed comment(s)'
+      : '';
+  if (!scopeBlocksConvergenceEval && !pending && !reviewSatisfied) {
     if (review.itemCount === 0 && review.suppressedCount > 0) {
       reasons.push(
-        `latest ${primaryBotLogin} review on current HEAD carries ${review.suppressedCount} suppressed comment(s) not reflected in itemCount (posted comment count is 0) -- check the review body directly, since a suppressed finding is never posted as a comment or review thread`,
+        `latest ${primaryBotLogin} review on current HEAD carries ${review.suppressedCount} suppressed comment(s) not reflected in itemCount (posted comment count is 0) -- check the review body directly, since a suppressed finding is never posted as a comment or review thread${ackSuffix}`,
       );
     } else {
       const itemCountReason =
@@ -433,12 +487,21 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
         review.suppressedCount > 0
           ? ` (plus ${review.suppressedCount} suppressed comment(s) in the review body, not counted in itemCount)`
           : '';
+      // #2050: only the zero-Copilot-thread shape still needs the "check
+      // the review body directly" pointer -- when real Copilot-authored
+      // threads exist and are all resolved/dispositioned,
+      // `itemCountClauseSatisfied` is already `true` and this `else` branch
+      // is unreachable for that case; when they exist but are NOT all
+      // resolved/dispositioned, the separate `threadClause.satisfied` reason
+      // below already names those threads directly.
+      const noThreadEvidenceForItems =
+        threadClause.copilotThreadCount === 0 &&
+        review.itemCount !== null &&
+        review.itemCount > 0;
       reasons.push(
-        threadClause.satisfied &&
-          review.itemCount !== null &&
-          review.itemCount > 0
-          ? `${itemCountReason}${suppressedSuffix} -- no unresolved ${primaryBotLogin}-authored thread accounts for them; check the review body directly for an item suppressed due to low confidence, which counts toward itemCount but never appears in reviewThreads`
-          : `${itemCountReason}${suppressedSuffix}`,
+        noThreadEvidenceForItems
+          ? `${itemCountReason}${suppressedSuffix}${ackSuffix} -- no ${primaryBotLogin}-authored review-thread evidence accounts for them; check the review body directly for an item suppressed due to low confidence, which counts toward itemCount but never appears in reviewThreads`
+          : `${itemCountReason}${suppressedSuffix}${ackSuffix}`,
       );
     }
   }
@@ -458,7 +521,7 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   const converged =
     !scopeBlocksConvergenceEval &&
     !pending &&
-    review.satisfied &&
+    reviewSatisfied &&
     threadClause.satisfied;
   // --- Same-HEAD advisory reroll evidence (#1511) ------------------------
   // Purely additive: `converged` above is already final and is never
@@ -740,7 +803,12 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     now,
     primaryBotLogin,
     applicability,
-    review,
+    // #2050: `satisfied` reported here is the disposition-aware override
+    // (`reviewSatisfied`), not the raw mechanical value
+    // `resolveLatestCopilotReviewClause` itself returns -- every other field
+    // (`matchesHead` / `itemCount` / `suppressedCount` / `submittedAt` /
+    // `found` / `commitId`) is untouched.
+    review: { ...review, satisfied: reviewSatisfied },
     threads: threadClause,
     pending,
     deadline,
@@ -851,6 +919,67 @@ function summarizeSameHeadRerollMarkers(
     }
   }
   return { count, latestAt };
+}
+// #2050: requires the FULL canonical `review-ack:` marker shape -- a valid
+// trailing ISO-8601 timestamp, end-anchored -- matching the `review-ack:`
+// entry in `OPERATIONAL_MARKERS` (marker-helpers.mts) exactly, same
+// reasoning as `summarizeSameHeadRerollMarkers`'s own pattern above: a
+// malformed or truncated comment must never count as a valid ack. Unlike
+// that pattern, this one is a fixed module-level constant rather than built
+// per call: `resolveHasValidReviewAck` does not filter on the marker's own
+// embedded HEAD SHA (see its doc comment for why), so there is no per-call
+// value to embed.
+const REVIEW_ACK_MARKER_PATTERN =
+  /^review-ack:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/;
+/**
+ * #2050: disposition-aware Clause 1 escape hatch -- true when a trusted
+ * `review-ack:` marker exists on the PR whose OWN GitHub-assigned
+ * `created_at` (never an embedded, agent-supplied timestamp -- the same
+ * "clock anchor is marker created_at, not embedded text" trust boundary
+ * `hasFreshDisposition` (protocol-helpers.mts) and
+ * `summarizeSameHeadRerollMarkers` above both already apply) is strictly
+ * after the latest primary-bot review's own `submittedAt`.
+ *
+ * Deliberately NOT scoped to the marker's own embedded HEAD SHA (unlike
+ * `summarizeSameHeadRerollMarkers`'s same-HEAD filter): the calling clause
+ * is already gated on `matchesHead`, and requiring the ack's `createdAt` to
+ * be strictly after `submittedAt` alone already makes any LATER review --
+ * on the same HEAD or not, e.g. an AW6 same-HEAD reroll -- automatically
+ * invalidate a pre-existing ack, with no extra bookkeeping. See the issue's
+ * "Proposed change" section for the full rationale.
+ *
+ * Fails closed (returns `false`) when `reviewSubmittedAt` is missing or
+ * invalid, since there is then no anchor to compare an ack against.
+ */
+function resolveHasValidReviewAck(
+  comments,
+  trustedMarkerLogins,
+  reviewSubmittedAt,
+) {
+  if (!isValidIsoTimestamp(reviewSubmittedAt)) {
+    return false;
+  }
+  const trusted = new Set(trustedMarkerLogins);
+  return comments.some((comment) => {
+    const body = String(comment.body ?? '').trimEnd();
+    if (!REVIEW_ACK_MARKER_PATTERN.test(body)) {
+      return false;
+    }
+    const login = String(comment.author?.login ?? comment.user?.login ?? '')
+      .trim()
+      .toLowerCase();
+    if (!trusted.has(login)) {
+      return false;
+    }
+    // GitHub server `createdAt`/`created_at` ONLY -- never the marker's own
+    // embedded (agent-supplied) timestamp field, same anchor rule AW2
+    // already states for `advisory-wait:`.
+    const createdAt = String(comment.createdAt ?? comment.created_at ?? '');
+    return (
+      isValidIsoTimestamp(createdAt) &&
+      compareIsoTimestamps(createdAt, reviewSubmittedAt) > 0
+    );
+  });
 }
 /** Whole minutes elapsed from `start` to `end`, clamped to 0 and floored --
  * matching `minutesBetweenIso` (protocol-helpers.mts) exactly, so a clock-

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -991,8 +991,15 @@ function summarizeSameHeadRerollMarkers(
 // per call: `resolveHasValidReviewAck` does not filter on the marker's own
 // embedded HEAD SHA (see its doc comment for why), so there is no per-call
 // value to embed.
+// #2054 review: captures the embedded timestamp field (group 1) so
+// `resolveHasValidReviewAck` can additionally validate it with
+// `isValidIsoTimestamp` -- the bare digit-shape match below alone accepts a
+// syntactically-digit-shaped but semantically invalid calendar date/time
+// (e.g. `2026-99-99T99:99:99Z`), which OPERATIONAL_MARKERS' shared shape
+// (and `summarizeSameHeadRerollMarkers`'s identical pattern above) also
+// does not reject on its own.
 const REVIEW_ACK_MARKER_PATTERN =
-  /^review-ack:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/;
+  /^review-ack:\s+\S+\s+[0-9a-f]{40}\s+(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)\s*$/;
 /**
  * #2050: disposition-aware Clause 1 escape hatch -- true when a trusted
  * `review-ack:` marker exists on the PR whose OWN GitHub-assigned
@@ -1024,7 +1031,13 @@ function resolveHasValidReviewAck(
   const trusted = new Set(trustedMarkerLogins);
   return comments.some((comment) => {
     const body = String(comment.body ?? '').trimEnd();
-    if (!REVIEW_ACK_MARKER_PATTERN.test(body)) {
+    const match = body.match(REVIEW_ACK_MARKER_PATTERN);
+    // #2054 review: the embedded timestamp is otherwise never trusted for
+    // the createdAt-vs-submittedAt comparison below, but a marker whose OWN
+    // digit-shaped field is not a real calendar date/time is malformed --
+    // reject it here the same way `detectMalformedOperationalMarker`
+    // (marker-helpers.mts) rejects other structurally-invalid markers.
+    if (!match || !isValidIsoTimestamp(match[1])) {
       return false;
     }
     const login = String(comment.author?.login ?? comment.user?.login ?? '')

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -121,6 +121,27 @@ const OPERATIONAL_MARKER_ENTRIES = [
     startPattern: /^advisory-reroll:/,
   },
   {
+    // #2050: disposition-aware Clause 1 escape hatch. A trusted actor posts
+    // this after reading a specific primary-bot review's findings
+    // (including any body-embedded `Suppressed comments (N)` section, #1880)
+    // -- a whole-review acknowledgement rather than a per-finding identifier
+    // scheme (see the issue's "Decision" section for why). PLAIN-TEXT, same
+    // family shape as advisory-reroll: above (no visible note), for the same
+    // reason: the ack comment itself must never pollute review-currency/
+    // watermark computations. Same field shape as advisory-reroll:
+    // (`{agentId} {headSha} {timestamp}`) -- see post-idd-marker.mts's
+    // `--type review-ack`. This entry only recognizes/parses the marker's
+    // shape; validity (a trusted author whose OWN `created_at` postdates the
+    // latest primary-bot review's `submittedAt`) is evaluated by
+    // `advisory-convergence.mts`'s `resolveHasValidReviewAck`, not here.
+    label: 'review-ack:',
+    pattern:
+      /^review-ack:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
+    // Case-sensitive on purpose (#1720), same reasoning as the
+    // advisory-wait: entry above.
+    startPattern: /^review-ack:/,
+  },
+  {
     // #1572: brand-new terminal marker type, no legacy form to preserve, so
     // the `claim:{claimId} attempt:{n}` binding suffix is unconditionally
     // required (unlike advisory-wait-recovery: above). PLAIN-TEXT, same
@@ -173,6 +194,7 @@ export const IDD_AGENT_DERIVED_MARKERS = new Set([
   'advisory-wait-recovery:',
   '<!-- advisory-wait:',
   'advisory-reroll:',
+  'review-ack:',
   'copilot-unavailable:',
 ]);
 const FORCED_HANDOFF_CONTEXT_SCOPES = new Set(['issue-only', 'issue-plus-pr']);
@@ -705,6 +727,27 @@ export function renderAdvisoryRerollMarker(payload) {
     throw new Error('invalid advisory-reroll marker payload');
   }
   return `advisory-reroll: ${agentId} ${headSha} ${timestamp}`;
+}
+// #2050: review-ack is ALSO a PLAIN-TEXT marker (no visible note), same
+// family shape as advisory-wait: / advisory-reroll: above -- a trusted actor
+// posts it after reading a specific primary-bot review's findings (including
+// any body-embedded suppressed-comments section), so Clause 1
+// (advisory-convergence.mts) can treat that review's `suppressedCount` as
+// covered without a per-finding identifier scheme. It carries the PR HEAD
+// SHA (not a claim id), matching the advisory-wait/advisory-reroll shape
+// exactly, though -- unlike advisory-reroll's same-HEAD filter -- Clause 1's
+// own validity check does not filter on it: see
+// `resolveHasValidReviewAck`'s doc comment (advisory-convergence.mts) for
+// why the marker's own `created_at` compared against the review's
+// `submittedAt` is sufficient on its own.
+export function renderReviewAckMarker(payload) {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
+    throw new Error('invalid review-ack marker payload');
+  }
+  return `review-ack: ${agentId} ${headSha} ${timestamp}`;
 }
 // #1905: the grammar's positional claim-id field
 // (`{agent-id} {claim-id|none} {head-sha} ...`) already accepts an

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -27,6 +27,7 @@ import {
   renderAdvisoryWaitRecoveryMarker,
   renderClaimedByMarker,
   renderCopilotUnavailableMarker,
+  renderReviewAckMarker,
   renderReviewBaselineMarker,
   renderReviewWatermarkMarker,
   renderUnclaimedByMarker,
@@ -40,21 +41,23 @@ export const MARKER_TYPES = [
   'advisory',
   'advisory-recovery',
   'advisory-reroll',
+  'review-ack',
   'copilot-unavailable',
 ];
 /**
  * The marker `type`s that accept `--from-pr <n>`. `watermark` derives all
  * four snapshot fields via the full {@link runReviewActivitySnapshot}
- * composition; the three advisory types (`advisory` / `advisory-recovery` /
- * `advisory-reroll`, added in #1889) derive only `--head-sha` via the
- * lighter {@link headShaFromPr} single `gh pr view` call, since those
- * renderers accept no other snapshot-shaped field.
+ * composition; the advisory-family types (`advisory` / `advisory-recovery` /
+ * `advisory-reroll`, added in #1889; `review-ack`, added in #2050) derive
+ * only `--head-sha` via the lighter {@link headShaFromPr} single `gh pr
+ * view` call, since those renderers accept no other snapshot-shaped field.
  */
 export const FROM_PR_MARKER_TYPES = [
   'watermark',
   'advisory',
   'advisory-recovery',
   'advisory-reroll',
+  'review-ack',
 ];
 /**
  * The kebab-case `--flag` field names each marker `type` requires, keyed
@@ -85,6 +88,7 @@ const REQUIRED_FIELDS_BY_TYPE = {
   advisory: ['agent-id', 'head-sha', 'timestamp'],
   'advisory-recovery': ['agent-id', 'head-sha', 'timestamp'],
   'advisory-reroll': ['agent-id', 'head-sha', 'timestamp'],
+  'review-ack': ['agent-id', 'head-sha', 'timestamp'],
   'copilot-unavailable': [
     'agent-id',
     'claim-id',
@@ -162,6 +166,12 @@ export function buildMarkerBody(type, fields) {
       });
     case 'advisory-reroll':
       return renderAdvisoryRerollMarker({
+        agentId: fields['agent-id'],
+        headSha: fields['head-sha'],
+        timestamp: fields.timestamp,
+      });
+    case 'review-ack':
+      return renderReviewAckMarker({
         agentId: fields['agent-id'],
         headSha: fields['head-sha'],
         timestamp: fields.timestamp,
@@ -378,11 +388,12 @@ its claim-revalidation gate before --apply, as the manual POST path it replaces.
   <number>             issue or PR number (positional; required unless --from-pr)
   --from-pr <n>        watermark: derive --head-sha / --max-activity-at /
                        --total-item-count / --ci-completed-at from the live
-                       review-activity-snapshot of PR <n>. advisory /
-                       advisory-recovery / advisory-reroll (#1889): derive
-                       only --head-sha from PR <n>'s live current head commit
-                       (a single lightweight gh pr view call, not the full
-                       snapshot). Either way the marker posts to PR <n>, so
+                       review-activity-snapshot of PR <n>. The advisory-family
+                       types (advisory / advisory-recovery / advisory-reroll,
+                       #1889; review-ack, #2050): derive only --head-sha from
+                       PR <n>'s live current head commit (a single
+                       lightweight gh pr view call, not the full snapshot).
+                       Either way the marker posts to PR <n>, so
                        --head-sha never needs hand-typing (always targets the
                        PR; an explicit non-pr --target is rejected). Not
                        network-free.
@@ -408,6 +419,8 @@ Per-type field flags:
   advisory-recovery  --agent-id --head-sha --timestamp [--claim-id --attempt]
                      (or --agent-id --from-pr <n> --timestamp [--claim-id --attempt])
   advisory-reroll    --agent-id --head-sha --timestamp
+                     (or --agent-id --from-pr <n> --timestamp)
+  review-ack         --agent-id --head-sha --timestamp
                      (or --agent-id --from-pr <n> --timestamp)
   copilot-unavailable --agent-id --claim-id --head-sha --attempt --timestamp
 
@@ -453,10 +466,10 @@ function postMarker(owner, repo, number, body) {
 }
 /**
  * Fetch PR `<n>`'s current head commit SHA via a single lightweight `gh pr
- * view` call -- the `--from-pr` derivation path for the three advisory
- * marker types (#1889: `advisory` / `advisory-recovery` / `advisory-reroll`),
- * which need only `--head-sha`, unlike `watermark`'s `--from-pr`, which
- * composes the full four-field snapshot via
+ * view` call -- the `--from-pr` derivation path for the advisory-family
+ * marker types (#1889: `advisory` / `advisory-recovery` / `advisory-reroll`;
+ * #2050: `review-ack`), which need only `--head-sha`, unlike `watermark`'s
+ * `--from-pr`, which composes the full four-field snapshot via
  * {@link runReviewActivitySnapshot}. This is deliberately network-lighter
  * than that snapshot: no CI checks, review threads, or comment pagination,
  * just the one `headRefOid` field.
@@ -556,9 +569,9 @@ if (import.meta.main) {
   // --expected-head-sha only guards the --from-pr --type watermark
   // derivation below; in manual mode the caller already supplies --head-sha
   // directly, so there is nothing to compare it against. It has no meaning
-  // for the three advisory --from-pr types (#1889): they have no E1 Step
-  // 1/Step 2 pinning concept, so reject the combination the same way rather
-  // than silently ignoring it.
+  // for the advisory-family --from-pr types (#1889 / #2050): they have no
+  // E1 Step 1/Step 2 pinning concept, so reject the combination the same way
+  // rather than silently ignoring it.
   if (args.expectedHeadSha && args.fromPr === null) {
     process.stderr.write(
       '--expected-head-sha is only valid together with --from-pr\n',
@@ -583,12 +596,12 @@ if (import.meta.main) {
   // apply-path resolution.
   //
   // `--type watermark` derives all four snapshot fields via the full
-  // review-activity-snapshot composition (unchanged since #1134). The three
-  // advisory types (#1889: `advisory` / `advisory-recovery` /
-  // `advisory-reroll`) derive only `--head-sha`, via the lighter
-  // single-`gh pr view`-call `headShaFromPr` -- those renderers accept no
-  // other snapshot-shaped field, so composing the full snapshot for them
-  // would be needless extra network work.
+  // review-activity-snapshot composition (unchanged since #1134). The
+  // advisory-family types (#1889: `advisory` / `advisory-recovery` /
+  // `advisory-reroll`; #2050: `review-ack`) derive only `--head-sha`, via
+  // the lighter single-`gh pr view`-call `headShaFromPr` -- those renderers
+  // accept no other snapshot-shaped field, so composing the full snapshot
+  // for them would be needless extra network work.
   if (args.fromPr !== null) {
     if (!FROM_PR_MARKER_TYPES.includes(args.type)) {
       process.stderr.write(

--- a/scripts/review-clause.mjs
+++ b/scripts/review-clause.mjs
@@ -120,6 +120,7 @@ export function resolveLatestCopilotReviewClause(
   if (!latest) {
     return {
       found: false,
+      reviewId: '',
       commitId: '',
       matchesHead: false,
       itemCount: null,
@@ -144,6 +145,10 @@ export function resolveLatestCopilotReviewClause(
     : 0;
   return {
     found: true,
+    // #2050: also gated by `matchesHead` -- an off-HEAD review's own id is
+    // never meaningful evidence for the caller's thread-scoping, mirroring
+    // `itemCount`/`suppressedCount` above.
+    reviewId: matchesHead ? String(latest.id ?? '') : '',
     commitId,
     matchesHead,
     itemCount,
@@ -175,6 +180,7 @@ export function fetchReviewsAndHeadCommit(owner, repo, prNumber) {
               reviews(first: 100, after: $cursor) {
                 pageInfo { hasNextPage endCursor }
                 nodes {
+                  id
                   commit { oid }
                   submittedAt
                   author { login __typename }
@@ -204,6 +210,7 @@ export function fetchReviewsAndHeadCommit(owner, repo, prNumber) {
     cursor = pullRequest.reviews.pageInfo.endCursor;
   }
   const reviews = nodes.map((node) => ({
+    id: node.id ?? null,
     author: node.author ?? null,
     submittedAt: node.submittedAt ?? null,
     commitId: node.commit?.oid ?? null,

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -128,6 +128,7 @@ import {
 } from './policy-helpers.mts';
 import type { PrCommitPayload } from './protocol-helpers.mts';
 import {
+  compareIsoTimestamps,
   DEFAULT_STALE_AGE_MS,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
@@ -809,12 +810,56 @@ export function computeAdvisoryConvergenceVerdict(
     satisfied: copilotBlocking.length === 0,
   };
 
+  // --- #2050: disposition-aware Clause 1 override -------------------------
+  // The raw `review.satisfied` (review-clause.mts) is a purely mechanical
+  // `matchesHead && itemCount === 0 && suppressedCount === 0` check, with no
+  // awareness of whether a trusted actor already read and dispositioned
+  // those findings -- computed here as a thin caller-side override instead
+  // of inside `resolveLatestCopilotReviewClause` itself, since both halves
+  // below need evidence (`threadClause`, `comments`, `trustedMarkerLogins`)
+  // that pure, low-dependency function does not receive (and its OTHER
+  // caller, `rerun-advisory-convergence.mts`, only ever reads `.matchesHead`,
+  // never `.satisfied`, so this override cannot affect it).
+  //
+  // `hasValidReviewAck` (#2050): true when a trusted `review-ack:` marker's
+  // OWN GitHub `created_at` (never an embedded, agent-supplied timestamp --
+  // the same trust boundary `hasFreshDisposition`, protocol-helpers.mts, and
+  // `summarizeSameHeadRerollMarkers` above already apply) postdates the
+  // latest primary-bot review's `submittedAt`. A single whole-review
+  // acknowledgement, not a per-finding identifier scheme -- see the issue's
+  // "Decision" section for why.
+  const hasValidReviewAck = resolveHasValidReviewAck(
+    comments,
+    trustedMarkerLogins,
+    review.submittedAt,
+  );
+  // `itemCountClauseSatisfied`: `itemCount === 0`, OR Clause 2's OWN
+  // thread-disposition evidence already covers every item Copilot posted
+  // (`threadClause.satisfied`) PROVIDED at least one Copilot-authored thread
+  // actually exists (`copilotThreadCount > 0`). That second conjunct matters:
+  // `threadClause.satisfied` is vacuously `true` when ZERO Copilot-authored
+  // threads exist at all (`blockingCount === 0` trivially), which would
+  // otherwise let a review with a positive `itemCount` and NO recorded
+  // thread evidence converge with nothing actually read or dispositioned --
+  // exactly the #1719 incident shape documented below (a "Comments
+  // suppressed due to low confidence" item counted in `itemCount` but
+  // invisible to any `reviewThreads` query).
+  const itemCountClauseSatisfied =
+    review.itemCount === 0 ||
+    (threadClause.satisfied && threadClause.copilotThreadCount > 0);
+  // `suppressedClauseSatisfied`: `suppressedCount === 0`, OR a valid
+  // `review-ack` covers it.
+  const suppressedClauseSatisfied =
+    review.suppressedCount === 0 || hasValidReviewAck;
+  const reviewSatisfied =
+    review.matchesHead && itemCountClauseSatisfied && suppressedClauseSatisfied;
+
   // Clause 1's "review is not clean" reason is pushed here, after Clause 2's
-  // `threadClause` is available -- deliberately deferred from the `pending`
-  // check above (whose own `if` already exhausts the pending case, so
-  // `reasons` order is unaffected: pending and not-satisfied are mutually
-  // exclusive, and this still precedes Clause 2's own thread-blocking
-  // reason below).
+  // `threadClause` and the disposition-aware overrides above are available
+  // -- deliberately deferred from the `pending` check above (whose own `if`
+  // already exhausts the pending case, so `reasons` order is unaffected:
+  // pending and not-satisfied are mutually exclusive, and this still
+  // precedes Clause 2's own thread-blocking reason below).
   //
   // #1719: reported adopter incident -- the primary bot's review on current
   // HEAD carried `itemCount: 1` while every visible GraphQL review thread
@@ -823,10 +868,10 @@ export function computeAdvisoryConvergenceVerdict(
   // top-level BODY TEXT rather than posted as a review thread -- it
   // contributes to `itemCount` but is invisible to any `reviewThreads`
   // query, so it can never be resolved the normal way, and nothing in this
-  // gate's output pointed there. When every visible Copilot-authored thread
-  // is already resolved and `itemCount` is still positive, no thread query
-  // can explain it -- point directly at the review body instead of leaving
-  // an agent to re-derive this by hand a second time.
+  // gate's output pointed there. When zero Copilot-authored threads exist at
+  // all, no thread query can explain a positive `itemCount` -- point
+  // directly at the review body instead of leaving an agent to re-derive
+  // this by hand a second time.
   //
   // #1880: a related but distinct incident shape -- the primary bot's
   // review on current HEAD carries `itemCount: 0` (zero POSTED comments)
@@ -834,13 +879,23 @@ export function computeAdvisoryConvergenceVerdict(
   // block for a finding it chose not to post as a comment at all. The
   // #1719 branch above only fires when `itemCount > 0`, so this case fell
   // through to full convergence with an empty `reasons[]` until now (PR
-  // #1875 commit 9711d404). `review.satisfied` (review-clause.mts) is
-  // already gated on `suppressedCount === 0`, so `converged` is already
-  // correctly `false` here -- this branch only supplies the explanation.
-  if (!scopeBlocksConvergenceEval && !pending && !review.satisfied) {
+  // #1875 commit 9711d404). `reviewSatisfied` is already gated on
+  // `suppressedClauseSatisfied`, so `converged` is already correctly
+  // `false` here -- this branch only supplies the explanation.
+  //
+  // #2050: `ackSuffix` names the recovery marker (not a profile-specific
+  // command path -- adopters on a non-vendored profile run a different
+  // `post-idd-marker` invocation) whenever a nonzero `suppressedCount` is
+  // still unresolved for lack of a valid `review-ack` -- computed once,
+  // shared by both branches below.
+  const ackSuffix =
+    review.suppressedCount > 0 && !hasValidReviewAck
+      ? '; post a trusted review-ack marker after this review to cover the suppressed comment(s)'
+      : '';
+  if (!scopeBlocksConvergenceEval && !pending && !reviewSatisfied) {
     if (review.itemCount === 0 && review.suppressedCount > 0) {
       reasons.push(
-        `latest ${primaryBotLogin} review on current HEAD carries ${review.suppressedCount} suppressed comment(s) not reflected in itemCount (posted comment count is 0) -- check the review body directly, since a suppressed finding is never posted as a comment or review thread`,
+        `latest ${primaryBotLogin} review on current HEAD carries ${review.suppressedCount} suppressed comment(s) not reflected in itemCount (posted comment count is 0) -- check the review body directly, since a suppressed finding is never posted as a comment or review thread${ackSuffix}`,
       );
     } else {
       const itemCountReason =
@@ -854,12 +909,21 @@ export function computeAdvisoryConvergenceVerdict(
         review.suppressedCount > 0
           ? ` (plus ${review.suppressedCount} suppressed comment(s) in the review body, not counted in itemCount)`
           : '';
+      // #2050: only the zero-Copilot-thread shape still needs the "check
+      // the review body directly" pointer -- when real Copilot-authored
+      // threads exist and are all resolved/dispositioned,
+      // `itemCountClauseSatisfied` is already `true` and this `else` branch
+      // is unreachable for that case; when they exist but are NOT all
+      // resolved/dispositioned, the separate `threadClause.satisfied` reason
+      // below already names those threads directly.
+      const noThreadEvidenceForItems =
+        threadClause.copilotThreadCount === 0 &&
+        review.itemCount !== null &&
+        review.itemCount > 0;
       reasons.push(
-        threadClause.satisfied &&
-          review.itemCount !== null &&
-          review.itemCount > 0
-          ? `${itemCountReason}${suppressedSuffix} -- no unresolved ${primaryBotLogin}-authored thread accounts for them; check the review body directly for an item suppressed due to low confidence, which counts toward itemCount but never appears in reviewThreads`
-          : `${itemCountReason}${suppressedSuffix}`,
+        noThreadEvidenceForItems
+          ? `${itemCountReason}${suppressedSuffix}${ackSuffix} -- no ${primaryBotLogin}-authored review-thread evidence accounts for them; check the review body directly for an item suppressed due to low confidence, which counts toward itemCount but never appears in reviewThreads`
+          : `${itemCountReason}${suppressedSuffix}${ackSuffix}`,
       );
     }
   }
@@ -881,7 +945,7 @@ export function computeAdvisoryConvergenceVerdict(
   const converged =
     !scopeBlocksConvergenceEval &&
     !pending &&
-    review.satisfied &&
+    reviewSatisfied &&
     threadClause.satisfied;
 
   // --- Same-HEAD advisory reroll evidence (#1511) ------------------------
@@ -1172,7 +1236,12 @@ export function computeAdvisoryConvergenceVerdict(
     now,
     primaryBotLogin,
     applicability,
-    review,
+    // #2050: `satisfied` reported here is the disposition-aware override
+    // (`reviewSatisfied`), not the raw mechanical value
+    // `resolveLatestCopilotReviewClause` itself returns -- every other field
+    // (`matchesHead` / `itemCount` / `suppressedCount` / `submittedAt` /
+    // `found` / `commitId`) is untouched.
+    review: { ...review, satisfied: reviewSatisfied },
     threads: threadClause,
     pending,
     deadline,
@@ -1289,6 +1358,69 @@ function summarizeSameHeadRerollMarkers(
     }
   }
   return { count, latestAt };
+}
+
+// #2050: requires the FULL canonical `review-ack:` marker shape -- a valid
+// trailing ISO-8601 timestamp, end-anchored -- matching the `review-ack:`
+// entry in `OPERATIONAL_MARKERS` (marker-helpers.mts) exactly, same
+// reasoning as `summarizeSameHeadRerollMarkers`'s own pattern above: a
+// malformed or truncated comment must never count as a valid ack. Unlike
+// that pattern, this one is a fixed module-level constant rather than built
+// per call: `resolveHasValidReviewAck` does not filter on the marker's own
+// embedded HEAD SHA (see its doc comment for why), so there is no per-call
+// value to embed.
+const REVIEW_ACK_MARKER_PATTERN =
+  /^review-ack:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/;
+
+/**
+ * #2050: disposition-aware Clause 1 escape hatch -- true when a trusted
+ * `review-ack:` marker exists on the PR whose OWN GitHub-assigned
+ * `created_at` (never an embedded, agent-supplied timestamp -- the same
+ * "clock anchor is marker created_at, not embedded text" trust boundary
+ * `hasFreshDisposition` (protocol-helpers.mts) and
+ * `summarizeSameHeadRerollMarkers` above both already apply) is strictly
+ * after the latest primary-bot review's own `submittedAt`.
+ *
+ * Deliberately NOT scoped to the marker's own embedded HEAD SHA (unlike
+ * `summarizeSameHeadRerollMarkers`'s same-HEAD filter): the calling clause
+ * is already gated on `matchesHead`, and requiring the ack's `createdAt` to
+ * be strictly after `submittedAt` alone already makes any LATER review --
+ * on the same HEAD or not, e.g. an AW6 same-HEAD reroll -- automatically
+ * invalidate a pre-existing ack, with no extra bookkeeping. See the issue's
+ * "Proposed change" section for the full rationale.
+ *
+ * Fails closed (returns `false`) when `reviewSubmittedAt` is missing or
+ * invalid, since there is then no anchor to compare an ack against.
+ */
+function resolveHasValidReviewAck(
+  comments: IssueCommentPayload[],
+  trustedMarkerLogins: string[],
+  reviewSubmittedAt: string,
+): boolean {
+  if (!isValidIsoTimestamp(reviewSubmittedAt)) {
+    return false;
+  }
+  const trusted = new Set(trustedMarkerLogins);
+  return comments.some((comment) => {
+    const body = String(comment.body ?? '').trimEnd();
+    if (!REVIEW_ACK_MARKER_PATTERN.test(body)) {
+      return false;
+    }
+    const login = String(comment.author?.login ?? comment.user?.login ?? '')
+      .trim()
+      .toLowerCase();
+    if (!trusted.has(login)) {
+      return false;
+    }
+    // GitHub server `createdAt`/`created_at` ONLY -- never the marker's own
+    // embedded (agent-supplied) timestamp field, same anchor rule AW2
+    // already states for `advisory-wait:`.
+    const createdAt = String(comment.createdAt ?? comment.created_at ?? '');
+    return (
+      isValidIsoTimestamp(createdAt) &&
+      compareIsoTimestamps(createdAt, reviewSubmittedAt) > 0
+    );
+  });
 }
 
 /** Whole minutes elapsed from `start` to `end`, clamped to 0 and floored --

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -1436,8 +1436,15 @@ function summarizeSameHeadRerollMarkers(
 // per call: `resolveHasValidReviewAck` does not filter on the marker's own
 // embedded HEAD SHA (see its doc comment for why), so there is no per-call
 // value to embed.
+// #2054 review: captures the embedded timestamp field (group 1) so
+// `resolveHasValidReviewAck` can additionally validate it with
+// `isValidIsoTimestamp` -- the bare digit-shape match below alone accepts a
+// syntactically-digit-shaped but semantically invalid calendar date/time
+// (e.g. `2026-99-99T99:99:99Z`), which OPERATIONAL_MARKERS' shared shape
+// (and `summarizeSameHeadRerollMarkers`'s identical pattern above) also
+// does not reject on its own.
 const REVIEW_ACK_MARKER_PATTERN =
-  /^review-ack:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/;
+  /^review-ack:\s+\S+\s+[0-9a-f]{40}\s+(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)\s*$/;
 
 /**
  * #2050: disposition-aware Clause 1 escape hatch -- true when a trusted
@@ -1470,7 +1477,13 @@ function resolveHasValidReviewAck(
   const trusted = new Set(trustedMarkerLogins);
   return comments.some((comment) => {
     const body = String(comment.body ?? '').trimEnd();
-    if (!REVIEW_ACK_MARKER_PATTERN.test(body)) {
+    const match = body.match(REVIEW_ACK_MARKER_PATTERN);
+    // #2054 review: the embedded timestamp is otherwise never trusted for
+    // the createdAt-vs-submittedAt comparison below, but a marker whose OWN
+    // digit-shaped field is not a real calendar date/time is malformed --
+    // reject it here the same way `detectMalformedOperationalMarker`
+    // (marker-helpers.mts) rejects other structurally-invalid markers.
+    if (!match || !isValidIsoTimestamp(match[1])) {
       return false;
     }
     const login = String(comment.author?.login ?? comment.user?.login ?? '')

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -833,20 +833,31 @@ export function computeAdvisoryConvergenceVerdict(
     trustedMarkerLogins,
     review.submittedAt,
   );
-  // `itemCountClauseSatisfied`: `itemCount === 0`, OR Clause 2's OWN
-  // thread-disposition evidence already covers every item Copilot posted
-  // (`threadClause.satisfied`) PROVIDED at least one Copilot-authored thread
-  // actually exists (`copilotThreadCount > 0`). That second conjunct matters:
-  // `threadClause.satisfied` is vacuously `true` when ZERO Copilot-authored
-  // threads exist at all (`blockingCount === 0` trivially), which would
-  // otherwise let a review with a positive `itemCount` and NO recorded
-  // thread evidence converge with nothing actually read or dispositioned --
-  // exactly the #1719 incident shape documented below (a "Comments
-  // suppressed due to low confidence" item counted in `itemCount` but
-  // invisible to any `reviewThreads` query).
+  // `itemCountClauseSatisfied`: `itemCount === 0`, OR every thread THIS
+  // SPECIFIC review opened is resolved or validly dispositioned. Bound to
+  // `review.reviewId` (Copilot review, this PR: `classifyThreadIdsForReview`)
+  // rather than reusing `threadClause` (Clause 2's PR-WIDE, review-agnostic
+  // set) directly: `threadClause.satisfied` can be vacuously true from an
+  // OLDER, already-dispositioned review's threads while the LATEST review's
+  // own items have no thread representation at all -- a resolved-but-stale
+  // thread must never stand in for the CURRENT review's own coverage. This
+  // also naturally handles the #1719 incident shape (a "Comments suppressed
+  // due to low confidence" item counted in `itemCount` but invisible to any
+  // `reviewThreads` query): `latestReviewThreadIds` stays empty and
+  // `itemCountClauseSatisfied` stays `false`.
+  const latestReviewThreadIds = classifyThreadIdsForReview(
+    threads,
+    primaryBotLogin,
+    review.reviewId,
+  );
+  const latestReviewBlocking = dispositionEvidence.missingThreads.filter(
+    (thread) =>
+      latestReviewThreadIds.has(String(thread.id ?? '')) &&
+      thread.isResolved === false,
+  );
   const itemCountClauseSatisfied =
     review.itemCount === 0 ||
-    (threadClause.satisfied && threadClause.copilotThreadCount > 0);
+    (latestReviewThreadIds.size > 0 && latestReviewBlocking.length === 0);
   // `suppressedClauseSatisfied`: `suppressedCount === 0`, OR a valid
   // `review-ack` covers it.
   const suppressedClauseSatisfied =
@@ -909,15 +920,16 @@ export function computeAdvisoryConvergenceVerdict(
         review.suppressedCount > 0
           ? ` (plus ${review.suppressedCount} suppressed comment(s) in the review body, not counted in itemCount)`
           : '';
-      // #2050: only the zero-Copilot-thread shape still needs the "check
-      // the review body directly" pointer -- when real Copilot-authored
-      // threads exist and are all resolved/dispositioned,
+      // #2050: only the "this review opened zero threads" shape still needs
+      // the "check the review body directly" pointer -- when THIS review's
+      // own threads exist and are all resolved/dispositioned,
       // `itemCountClauseSatisfied` is already `true` and this `else` branch
       // is unreachable for that case; when they exist but are NOT all
       // resolved/dispositioned, the separate `threadClause.satisfied` reason
-      // below already names those threads directly.
+      // below already names those (PR-wide) blocking threads directly,
+      // which include this review's own unresolved ones.
       const noThreadEvidenceForItems =
-        threadClause.copilotThreadCount === 0 &&
+        latestReviewThreadIds.size === 0 &&
         review.itemCount !== null &&
         review.itemCount > 0;
       reasons.push(
@@ -1295,6 +1307,45 @@ export function classifyCopilotAuthoredThreadIds(
       // `missingThreads[].id` fallback exactly (protocol-helpers.mts) so a
       // thread with an empty/missing GraphQL id still round-trips through
       // the `.has()` lookup in the caller instead of silently diverging.
+      ids.add(String(thread.id ?? '') || `thread-${index + 1}`);
+    }
+  });
+  return ids;
+}
+
+/**
+ * #2050: Copilot-authored thread IDs whose *originating* comment belongs to
+ * a SPECIFIC review (matched by GraphQL review node id), unlike
+ * {@link classifyCopilotAuthoredThreadIds}'s review-agnostic set (every
+ * Copilot-authored thread anywhere in the PR's history -- which Clause 2
+ * genuinely needs). Clause 1's `itemCount`-half needs narrower, review-bound
+ * evidence: `threadClause.satisfied` alone can be vacuously true from an
+ * OLDER, already-dispositioned review's threads while the LATEST review's
+ * own items have no thread representation at all -- a resolved-but-stale
+ * thread must never stand in for the CURRENT review's own coverage (Copilot
+ * review, this PR). Each thread's originating comment's `pullRequestReview`
+ * is already fetched by `fetchReviewThreads` below; matching on its `id`
+ * against a Copilot review's own `id` (review-clause.mts's `reviewId`) also
+ * proves Copilot authorship by construction (every comment in one GitHub
+ * review shares that review's single author), but `isVerifiedCopilotAuthor`
+ * is still checked directly for defense-in-depth, matching this file's
+ * existing convention. `reviewId === ''` (not found / off-HEAD) always
+ * returns an empty set, fail-closed.
+ */
+export function classifyThreadIdsForReview(
+  threads: ReviewThreadPayload[],
+  primaryBotLogin: string,
+  reviewId: string,
+): Set<string> {
+  const ids = new Set<string>();
+  if (!reviewId) return ids;
+  threads.forEach((thread, index) => {
+    const originating = (thread.comments?.nodes ?? [])[0];
+    if (
+      originating &&
+      isVerifiedCopilotAuthor(originating.author, primaryBotLogin) &&
+      String(originating.pullRequestReview?.id ?? '') === reviewId
+    ) {
       ids.add(String(thread.id ?? '') || `thread-${index + 1}`);
     }
   });

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -855,9 +855,25 @@ export function computeAdvisoryConvergenceVerdict(
       latestReviewThreadIds.has(String(thread.id ?? '')) &&
       thread.isResolved === false,
   );
+  // #2054 review (Copilot + CodeRabbit, independently): the thread-evidence
+  // disjunct alone neither required a KNOWN itemCount, nor that the
+  // NUMBER of this-review-originated threads actually covers every posted
+  // item -- `itemCount: null` (unknown count), or `itemCount: 2` with only
+  // ONE such thread, would otherwise satisfy this on "at least one resolved
+  // thread exists," leaving other posted items unaccounted for.
+  // `latestReviewThreadIds.size >= review.itemCount` requires as many
+  // review-scoped threads as claimed items (each of the review's own
+  // comments originates at most one thread, so this count can never
+  // legitimately exceed `itemCount`, making `>=` and exact equality
+  // equivalent in practice; `>=` is the more defensive form).
+  // `review.itemCount !== null` fails closed on the unknown-count case,
+  // matching this file's other missing-evidence guards (e.g.
+  // `reviewItemCountKnownTerm` in the sameHeadReroll terms below).
   const itemCountClauseSatisfied =
     review.itemCount === 0 ||
-    (latestReviewThreadIds.size > 0 && latestReviewBlocking.length === 0);
+    (review.itemCount !== null &&
+      latestReviewThreadIds.size >= review.itemCount &&
+      latestReviewBlocking.length === 0);
   // `suppressedClauseSatisfied`: `suppressedCount === 0`, OR a valid
   // `review-ack` covers it.
   const suppressedClauseSatisfied =

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -289,6 +289,27 @@ const OPERATIONAL_MARKER_ENTRIES: OperationalMarker[] = [
     startPattern: /^advisory-reroll:/,
   },
   {
+    // #2050: disposition-aware Clause 1 escape hatch. A trusted actor posts
+    // this after reading a specific primary-bot review's findings
+    // (including any body-embedded `Suppressed comments (N)` section, #1880)
+    // -- a whole-review acknowledgement rather than a per-finding identifier
+    // scheme (see the issue's "Decision" section for why). PLAIN-TEXT, same
+    // family shape as advisory-reroll: above (no visible note), for the same
+    // reason: the ack comment itself must never pollute review-currency/
+    // watermark computations. Same field shape as advisory-reroll:
+    // (`{agentId} {headSha} {timestamp}`) -- see post-idd-marker.mts's
+    // `--type review-ack`. This entry only recognizes/parses the marker's
+    // shape; validity (a trusted author whose OWN `created_at` postdates the
+    // latest primary-bot review's `submittedAt`) is evaluated by
+    // `advisory-convergence.mts`'s `resolveHasValidReviewAck`, not here.
+    label: 'review-ack:',
+    pattern:
+      /^review-ack:\s+\S+\s+[0-9a-f]{40}\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*$/,
+    // Case-sensitive on purpose (#1720), same reasoning as the
+    // advisory-wait: entry above.
+    startPattern: /^review-ack:/,
+  },
+  {
     // #1572: brand-new terminal marker type, no legacy form to preserve, so
     // the `claim:{claimId} attempt:{n}` binding suffix is unconditionally
     // required (unlike advisory-wait-recovery: above). PLAIN-TEXT, same
@@ -343,6 +364,7 @@ export const IDD_AGENT_DERIVED_MARKERS: ReadonlySet<string> = new Set([
   'advisory-wait-recovery:',
   '<!-- advisory-wait:',
   'advisory-reroll:',
+  'review-ack:',
   'copilot-unavailable:',
 ]);
 
@@ -1011,6 +1033,32 @@ export function renderAdvisoryRerollMarker(payload: {
     throw new Error('invalid advisory-reroll marker payload');
   }
   return `advisory-reroll: ${agentId} ${headSha} ${timestamp}`;
+}
+
+// #2050: review-ack is ALSO a PLAIN-TEXT marker (no visible note), same
+// family shape as advisory-wait: / advisory-reroll: above -- a trusted actor
+// posts it after reading a specific primary-bot review's findings (including
+// any body-embedded suppressed-comments section), so Clause 1
+// (advisory-convergence.mts) can treat that review's `suppressedCount` as
+// covered without a per-finding identifier scheme. It carries the PR HEAD
+// SHA (not a claim id), matching the advisory-wait/advisory-reroll shape
+// exactly, though -- unlike advisory-reroll's same-HEAD filter -- Clause 1's
+// own validity check does not filter on it: see
+// `resolveHasValidReviewAck`'s doc comment (advisory-convergence.mts) for
+// why the marker's own `created_at` compared against the review's
+// `submittedAt` is sufficient on its own.
+export function renderReviewAckMarker(payload: {
+  agentId?: unknown;
+  headSha?: unknown;
+  timestamp?: unknown;
+}): string {
+  const agentId = normalizeNonWhitespaceToken(payload?.agentId);
+  const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
+  const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
+  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
+    throw new Error('invalid review-ack marker payload');
+  }
+  return `review-ack: ${agentId} ${headSha} ${timestamp}`;
 }
 
 // #1905: the grammar's positional claim-id field

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -29,6 +29,7 @@ import {
   renderAdvisoryWaitRecoveryMarker,
   renderClaimedByMarker,
   renderCopilotUnavailableMarker,
+  renderReviewAckMarker,
   renderReviewBaselineMarker,
   renderReviewWatermarkMarker,
   renderUnclaimedByMarker,
@@ -43,6 +44,7 @@ export const MARKER_TYPES = [
   'advisory',
   'advisory-recovery',
   'advisory-reroll',
+  'review-ack',
   'copilot-unavailable',
 ] as const;
 
@@ -51,16 +53,17 @@ export type MarkerType = (typeof MARKER_TYPES)[number];
 /**
  * The marker `type`s that accept `--from-pr <n>`. `watermark` derives all
  * four snapshot fields via the full {@link runReviewActivitySnapshot}
- * composition; the three advisory types (`advisory` / `advisory-recovery` /
- * `advisory-reroll`, added in #1889) derive only `--head-sha` via the
- * lighter {@link headShaFromPr} single `gh pr view` call, since those
- * renderers accept no other snapshot-shaped field.
+ * composition; the advisory-family types (`advisory` / `advisory-recovery` /
+ * `advisory-reroll`, added in #1889; `review-ack`, added in #2050) derive
+ * only `--head-sha` via the lighter {@link headShaFromPr} single `gh pr
+ * view` call, since those renderers accept no other snapshot-shaped field.
  */
 export const FROM_PR_MARKER_TYPES = [
   'watermark',
   'advisory',
   'advisory-recovery',
   'advisory-reroll',
+  'review-ack',
 ] as const;
 
 export type FromPrMarkerType = (typeof FROM_PR_MARKER_TYPES)[number];
@@ -94,6 +97,7 @@ const REQUIRED_FIELDS_BY_TYPE: Record<MarkerType, readonly string[]> = {
   advisory: ['agent-id', 'head-sha', 'timestamp'],
   'advisory-recovery': ['agent-id', 'head-sha', 'timestamp'],
   'advisory-reroll': ['agent-id', 'head-sha', 'timestamp'],
+  'review-ack': ['agent-id', 'head-sha', 'timestamp'],
   'copilot-unavailable': [
     'agent-id',
     'claim-id',
@@ -202,6 +206,12 @@ export function buildMarkerBody(type: string, fields: MarkerFields): string {
       });
     case 'advisory-reroll':
       return renderAdvisoryRerollMarker({
+        agentId: fields['agent-id'],
+        headSha: fields['head-sha'],
+        timestamp: fields.timestamp,
+      });
+    case 'review-ack':
+      return renderReviewAckMarker({
         agentId: fields['agent-id'],
         headSha: fields['head-sha'],
         timestamp: fields.timestamp,
@@ -340,8 +350,8 @@ interface CliArgs {
   /**
    * `--from-pr <n>`: derive `--head-sha` from PR <n>'s live current HEAD.
    * For `--type watermark`, also derives the three other snapshot fields
-   * via the full `review-activity-snapshot` composition; for the three
-   * advisory types (#1889), only `--head-sha` is derived. See
+   * via the full `review-activity-snapshot` composition; for the
+   * advisory-family types (#1889 / #2050), only `--head-sha` is derived. See
    * {@link FROM_PR_MARKER_TYPES}.
    */
   fromPr: number | null;
@@ -462,11 +472,12 @@ its claim-revalidation gate before --apply, as the manual POST path it replaces.
   <number>             issue or PR number (positional; required unless --from-pr)
   --from-pr <n>        watermark: derive --head-sha / --max-activity-at /
                        --total-item-count / --ci-completed-at from the live
-                       review-activity-snapshot of PR <n>. advisory /
-                       advisory-recovery / advisory-reroll (#1889): derive
-                       only --head-sha from PR <n>'s live current head commit
-                       (a single lightweight gh pr view call, not the full
-                       snapshot). Either way the marker posts to PR <n>, so
+                       review-activity-snapshot of PR <n>. The advisory-family
+                       types (advisory / advisory-recovery / advisory-reroll,
+                       #1889; review-ack, #2050): derive only --head-sha from
+                       PR <n>'s live current head commit (a single
+                       lightweight gh pr view call, not the full snapshot).
+                       Either way the marker posts to PR <n>, so
                        --head-sha never needs hand-typing (always targets the
                        PR; an explicit non-pr --target is rejected). Not
                        network-free.
@@ -492,6 +503,8 @@ Per-type field flags:
   advisory-recovery  --agent-id --head-sha --timestamp [--claim-id --attempt]
                      (or --agent-id --from-pr <n> --timestamp [--claim-id --attempt])
   advisory-reroll    --agent-id --head-sha --timestamp
+                     (or --agent-id --from-pr <n> --timestamp)
+  review-ack         --agent-id --head-sha --timestamp
                      (or --agent-id --from-pr <n> --timestamp)
   copilot-unavailable --agent-id --claim-id --head-sha --attempt --timestamp
 
@@ -544,10 +557,10 @@ function postMarker(
 
 /**
  * Fetch PR `<n>`'s current head commit SHA via a single lightweight `gh pr
- * view` call -- the `--from-pr` derivation path for the three advisory
- * marker types (#1889: `advisory` / `advisory-recovery` / `advisory-reroll`),
- * which need only `--head-sha`, unlike `watermark`'s `--from-pr`, which
- * composes the full four-field snapshot via
+ * view` call -- the `--from-pr` derivation path for the advisory-family
+ * marker types (#1889: `advisory` / `advisory-recovery` / `advisory-reroll`;
+ * #2050: `review-ack`), which need only `--head-sha`, unlike `watermark`'s
+ * `--from-pr`, which composes the full four-field snapshot via
  * {@link runReviewActivitySnapshot}. This is deliberately network-lighter
  * than that snapshot: no CI checks, review threads, or comment pagination,
  * just the one `headRefOid` field.
@@ -650,9 +663,9 @@ if (import.meta.main) {
   // --expected-head-sha only guards the --from-pr --type watermark
   // derivation below; in manual mode the caller already supplies --head-sha
   // directly, so there is nothing to compare it against. It has no meaning
-  // for the three advisory --from-pr types (#1889): they have no E1 Step
-  // 1/Step 2 pinning concept, so reject the combination the same way rather
-  // than silently ignoring it.
+  // for the advisory-family --from-pr types (#1889 / #2050): they have no
+  // E1 Step 1/Step 2 pinning concept, so reject the combination the same way
+  // rather than silently ignoring it.
   if (args.expectedHeadSha && args.fromPr === null) {
     process.stderr.write(
       '--expected-head-sha is only valid together with --from-pr\n',
@@ -678,12 +691,12 @@ if (import.meta.main) {
   // apply-path resolution.
   //
   // `--type watermark` derives all four snapshot fields via the full
-  // review-activity-snapshot composition (unchanged since #1134). The three
-  // advisory types (#1889: `advisory` / `advisory-recovery` /
-  // `advisory-reroll`) derive only `--head-sha`, via the lighter
-  // single-`gh pr view`-call `headShaFromPr` -- those renderers accept no
-  // other snapshot-shaped field, so composing the full snapshot for them
-  // would be needless extra network work.
+  // review-activity-snapshot composition (unchanged since #1134). The
+  // advisory-family types (#1889: `advisory` / `advisory-recovery` /
+  // `advisory-reroll`; #2050: `review-ack`) derive only `--head-sha`, via
+  // the lighter single-`gh pr view`-call `headShaFromPr` -- those renderers
+  // accept no other snapshot-shaped field, so composing the full snapshot
+  // for them would be needless extra network work.
   if (args.fromPr !== null) {
     if (!FROM_PR_MARKER_TYPES.includes(args.type as FromPrMarkerType)) {
       process.stderr.write(

--- a/src/scripts/review-clause.mts
+++ b/src/scripts/review-clause.mts
@@ -40,6 +40,12 @@ export interface GhAuthorPayload {
 
 /** PR review payload, normalized from the GraphQL `reviews` connection. */
 export interface ReviewPayload {
+  /** #2050: the review's own GraphQL node id -- lets a caller bind evidence
+   * (e.g. a review thread's `pullRequestReview.id`) to THIS specific review,
+   * as opposed to any Copilot-authored thread anywhere in the PR's history.
+   * `''`/absent for a fixture that omits it (treated as "unknown", never a
+   * rejection, matching this file's other optional-field conventions). */
+  id?: string | null;
   author?: GhAuthorPayload | null;
   submittedAt?: string | null;
   commitId?: string | null;
@@ -56,6 +62,13 @@ export interface ReviewPayload {
  * `converged` definition). */
 export interface AdvisoryConvergenceReviewClause {
   found: boolean;
+  /** #2050: the matched review's own GraphQL node id (`''` when `!found` or
+   * off-HEAD) -- lets `advisory-convergence.mts` scope thread evidence to
+   * THIS specific review via each thread's originating comment's
+   * `pullRequestReview.id`, rather than any Copilot-authored thread
+   * anywhere in the PR's history (`classifyCopilotAuthoredThreadIds`'s
+   * broader, review-agnostic Clause 2 set). */
+  reviewId: string;
   commitId: string;
   matchesHead: boolean;
   itemCount: number | null;
@@ -79,6 +92,7 @@ interface PageInfoPayload {
 /** Raw GraphQL `reviews` connection node, before normalization into
  * {@link ReviewPayload}. */
 interface RawReviewNode {
+  id?: string | null;
   commit?: { oid?: string | null } | null;
   submittedAt?: string | null;
   author?: GhAuthorPayload | null;
@@ -186,6 +200,7 @@ export function resolveLatestCopilotReviewClause(
   if (!latest) {
     return {
       found: false,
+      reviewId: '',
       commitId: '',
       matchesHead: false,
       itemCount: null,
@@ -210,6 +225,10 @@ export function resolveLatestCopilotReviewClause(
     : 0;
   return {
     found: true,
+    // #2050: also gated by `matchesHead` -- an off-HEAD review's own id is
+    // never meaningful evidence for the caller's thread-scoping, mirroring
+    // `itemCount`/`suppressedCount` above.
+    reviewId: matchesHead ? String(latest.id ?? '') : '',
     commitId,
     matchesHead,
     itemCount,
@@ -247,6 +266,7 @@ export function fetchReviewsAndHeadCommit(
               reviews(first: 100, after: $cursor) {
                 pageInfo { hasNextPage endCursor }
                 nodes {
+                  id
                   commit { oid }
                   submittedAt
                   author { login __typename }
@@ -293,6 +313,7 @@ export function fetchReviewsAndHeadCommit(
   }
 
   const reviews = nodes.map((node) => ({
+    id: node.id ?? null,
     author: node.author ?? null,
     submittedAt: node.submittedAt ?? null,
     commitId: node.commit?.oid ?? null,

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -1915,7 +1915,7 @@ test('reasons: itemCount > 0 with every visible Copilot thread resolved points a
 test('reasons: itemCount > 0 with an unresolved blocking thread does NOT add the review-body pointer (a real thread already explains it)', () => {
   const verdict = computeAdvisoryConvergenceVerdict(
     baseInputs({
-      reviews: [copilotReview({ itemCount: 2 })],
+      reviews: [copilotReview({ id: 'REVIEW_BLOCK', itemCount: 2 })],
       threads: [
         {
           id: 'PRT_REAL_BLOCK',
@@ -1927,6 +1927,11 @@ test('reasons: itemCount > 0 with an unresolved blocking thread does NOT add the
                 body: 'nit: consider extracting this into a helper',
                 createdAt: OLD,
                 updatedAt: OLD,
+                // #2050: binds this thread to the review under test so
+                // classifyThreadIdsForReview recognizes it as real,
+                // review-scoped evidence (not the zero-thread-evidence
+                // shape this test is deliberately distinguishing from).
+                pullRequestReview: { id: 'REVIEW_BLOCK' },
               },
             ],
           },
@@ -2161,7 +2166,7 @@ function reviewAckComment(
 test('review-ack: nonzero itemCount with Clause 2 satisfied (via existing thread disposition) converges (#2039 shape)', () => {
   const verdict = computeAdvisoryConvergenceVerdict(
     baseInputs({
-      reviews: [copilotReview({ itemCount: 1 })],
+      reviews: [copilotReview({ id: 'REVIEW_LATEST', itemCount: 1 })],
       threads: [
         {
           id: 'PRT_ACK_1',
@@ -2173,6 +2178,11 @@ test('review-ack: nonzero itemCount with Clause 2 satisfied (via existing thread
                 body: 'nit: consider extracting this into a helper',
                 createdAt: OLD,
                 updatedAt: OLD,
+                // #2050: binds this thread to the LATEST review specifically
+                // (classifyThreadIdsForReview) -- a resolved/dispositioned
+                // thread from an OLDER, different review must not stand in
+                // for the current review's own coverage.
+                pullRequestReview: { id: 'REVIEW_LATEST' },
               },
               {
                 author: { login: TRUSTED },
@@ -2198,7 +2208,7 @@ test('review-ack: nonzero itemCount with Clause 2 satisfied (via existing thread
 test('review-ack: nonzero itemCount with Clause 2 NOT satisfied does not converge, even given a valid review-ack (#2050 acceptance criterion)', () => {
   const verdict = computeAdvisoryConvergenceVerdict(
     baseInputs({
-      reviews: [copilotReview({ itemCount: 1 })],
+      reviews: [copilotReview({ id: 'REVIEW_LATEST', itemCount: 1 })],
       threads: [
         {
           id: 'PRT_ACK_2',
@@ -2210,6 +2220,7 @@ test('review-ack: nonzero itemCount with Clause 2 NOT satisfied does not converg
                 body: 'nit: consider extracting this into a helper',
                 createdAt: OLD,
                 updatedAt: OLD,
+                pullRequestReview: { id: 'REVIEW_LATEST' },
               },
             ],
           },
@@ -2225,6 +2236,56 @@ test('review-ack: nonzero itemCount with Clause 2 NOT satisfied does not converg
   assert.equal(verdict.review.satisfied, false);
   assert.equal(verdict.converged, false);
   assert.equal(verdict.ready, false);
+});
+
+test("review-ack: an OLDER, already-resolved thread from a DIFFERENT review does not cover the LATEST review's own itemCount (PR #2054 review)", () => {
+  // A resolved Copilot thread exists PR-wide (threadClause.satisfied would
+  // be true, and copilotThreadCount > 0), but it belongs to an EARLIER
+  // review, not the current one -- the latest review's own itemCount: 1
+  // has NO thread representation at all. Reusing the PR-wide threadClause
+  // alone (without binding to review.reviewId) would incorrectly converge
+  // here; classifyThreadIdsForReview must keep it blocked.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({
+          id: 'REVIEW_OLD',
+          itemCount: 0,
+          submittedAt: OLD,
+        }),
+        copilotReview({ id: 'REVIEW_LATEST', itemCount: 1 }), // submittedAt: RECENT
+      ],
+      threads: [
+        {
+          id: 'PRT_OLD_RESOLVED',
+          isResolved: true,
+          comments: {
+            nodes: [
+              {
+                author: { login: COPILOT_LOGIN },
+                body: 'an older, already-resolved finding',
+                createdAt: OLD,
+                updatedAt: OLD,
+                pullRequestReview: { id: 'REVIEW_OLD' },
+              },
+            ],
+          },
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.itemCount, 1);
+  assert.equal(verdict.threads.copilotThreadCount, 1);
+  assert.equal(verdict.threads.satisfied, true);
+  assert.equal(verdict.review.satisfied, false);
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.ready, false);
+  assert.match(
+    verdict.reasons.join('\n'),
+    /no copilot-authored review-thread evidence accounts for them/,
+  );
 });
 
 test('review-ack: nonzero suppressedCount with a valid post-review ack converges', () => {

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -2471,6 +2471,65 @@ test('review-ack: a malformed marker (bad timestamp, or trailing prose) is not c
   );
   assertValidVerdict(trailingProse);
   assert.equal(trailingProse.review.satisfied, false);
+
+  // #2054 review: a digit-shaped but semantically invalid embedded
+  // calendar date/time (month 99, day 99, hour/minute/second 99) matches
+  // the bare digit-count regex but must still be rejected -- proves
+  // `isValidIsoTimestamp` is applied to the captured embedded field, not
+  // only the digit-shape match.
+  const invalidCalendarDate = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({ itemCount: 0, body: SUPPRESSED_COMMENTS_BODY }),
+      ],
+      comments: [
+        {
+          author: { login: TRUSTED },
+          body: `review-ack: ${AGENT_ID} ${HEAD} 2026-99-99T99:99:99Z`,
+          createdAt: ACK_AFTER_REVIEW,
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(invalidCalendarDate);
+  assert.equal(invalidCalendarDate.review.satisfied, false);
+});
+
+test('review-ack: validity is governed by the GitHub createdAt, never the embedded timestamp (asymmetric trust-boundary cases, PR #2054 review)', () => {
+  // Post-review createdAt with an OLD/bogus embedded timestamp still
+  // counts -- the embedded field is untrusted operator input, never
+  // consulted for validity.
+  const oldEmbeddedStillCounts = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({ itemCount: 0, body: SUPPRESSED_COMMENTS_BODY }),
+      ],
+      comments: [reviewAckComment(ACK_AFTER_REVIEW, { embeddedAt: OLD })],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(oldEmbeddedStillCounts);
+  assert.equal(oldEmbeddedStillCounts.review.satisfied, true);
+
+  // Pre-review createdAt with a FUTURE embedded timestamp must NOT count --
+  // an operator cannot fake freshness by writing a future date into the
+  // marker body; only the GitHub-assigned createdAt is authoritative.
+  const futureEmbeddedDoesNotCount = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({ itemCount: 0, body: SUPPRESSED_COMMENTS_BODY }),
+      ],
+      comments: [
+        reviewAckComment(ACK_BEFORE_REVIEW, {
+          embeddedAt: '2099-01-01T00:00:00Z',
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(futureEmbeddedDoesNotCount);
+  assert.equal(futureEmbeddedDoesNotCount.review.satisfied, false);
 });
 
 // --- 10. terminal Copilot unavailability (#1570/#1572) ----------------------

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -2288,6 +2288,75 @@ test("review-ack: an OLDER, already-resolved thread from a DIFFERENT review does
   );
 });
 
+test('review-ack: an unknown itemCount (null) does not converge even with a resolved review-scoped thread (PR #2054 review)', () => {
+  // Copilot + CodeRabbit (independently, #2054 review): the thread-evidence
+  // disjunct must fail closed on itemCount: null, not treat "at least one
+  // resolved thread exists" as sufficient when the count itself is unknown.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview({ id: 'REVIEW_LATEST', itemCount: null })],
+      threads: [
+        {
+          id: 'PRT_UNKNOWN_COUNT',
+          isResolved: true,
+          comments: {
+            nodes: [
+              {
+                author: { login: COPILOT_LOGIN },
+                body: 'a finding under an unknown item count',
+                createdAt: RECENT,
+                updatedAt: RECENT,
+                pullRequestReview: { id: 'REVIEW_LATEST' },
+              },
+            ],
+          },
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.itemCount, null);
+  assert.equal(verdict.review.satisfied, false);
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.ready, false);
+});
+
+test('review-ack: itemCount 2 with only ONE review-scoped resolved thread does not converge (partial coverage, PR #2054 review)', () => {
+  // Copilot + CodeRabbit (independently, #2054 review): the thread-evidence
+  // disjunct must require as many review-scoped threads as claimed items,
+  // not merely "at least one" -- otherwise one posted item stays
+  // unaccounted for.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview({ id: 'REVIEW_LATEST', itemCount: 2 })],
+      threads: [
+        {
+          id: 'PRT_PARTIAL_1',
+          isResolved: true,
+          comments: {
+            nodes: [
+              {
+                author: { login: COPILOT_LOGIN },
+                body: 'the only dispositioned finding',
+                createdAt: RECENT,
+                updatedAt: RECENT,
+                pullRequestReview: { id: 'REVIEW_LATEST' },
+              },
+            ],
+          },
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.itemCount, 2);
+  assert.equal(verdict.review.satisfied, false);
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.ready, false);
+});
+
 test('review-ack: nonzero suppressedCount with a valid post-review ack converges', () => {
   const verdict = computeAdvisoryConvergenceVerdict(
     baseInputs({

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -2131,6 +2131,218 @@ test('dispositionEvidence: missingRegularCommentCount is zero when nothing is ou
   assert.equal(verdict.dispositionEvidence.missingRegularCommentCount, 0);
 });
 
+// --- 9d. review-ack disposition-aware Clause 1 (#2050) ----------------------
+//
+// `copilotReview()`'s default `submittedAt` is `RECENT`
+// (2026-07-11T10:00:00Z) -- `ACK_AFTER_REVIEW` / `ACK_BEFORE_REVIEW` are
+// chosen relative to it.
+
+const ACK_AFTER_REVIEW = '2026-07-11T10:30:00Z'; // after RECENT
+const ACK_BEFORE_REVIEW = OLD; // well before RECENT
+
+/** `review-ack:` marker comment, matching `rerollMarkerComment`'s shape
+ * above -- `createdAt` is the GitHub server timestamp the code must use;
+ * `embeddedAt` (defaults to the same value) is the marker body's own
+ * agent-supplied timestamp, deliberately irrelevant to validity (#2050
+ * anchors on the comment's own `createdAt`, never the embedded text). */
+function reviewAckComment(
+  createdAt: string,
+  overrides: { login?: string; headSha?: string; embeddedAt?: string } = {},
+) {
+  const headSha = overrides.headSha ?? HEAD;
+  const embeddedAt = overrides.embeddedAt ?? createdAt;
+  return {
+    author: { login: overrides.login ?? TRUSTED },
+    body: `review-ack: ${AGENT_ID} ${headSha} ${embeddedAt}`,
+    createdAt,
+  };
+}
+
+test('review-ack: nonzero itemCount with Clause 2 satisfied (via existing thread disposition) converges (#2039 shape)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview({ itemCount: 1 })],
+      threads: [
+        {
+          id: 'PRT_ACK_1',
+          isResolved: false,
+          comments: {
+            nodes: [
+              {
+                author: { login: COPILOT_LOGIN },
+                body: 'nit: consider extracting this into a helper',
+                createdAt: OLD,
+                updatedAt: OLD,
+              },
+              {
+                author: { login: TRUSTED },
+                body: '**Rejected** — not applicable to this change.',
+                createdAt: RECENT,
+                updatedAt: RECENT,
+              },
+            ],
+          },
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.itemCount, 1);
+  assert.equal(verdict.threads.satisfied, true);
+  assert.equal(verdict.review.satisfied, true);
+  assert.equal(verdict.converged, true);
+  assert.equal(verdict.ready, true);
+});
+
+test('review-ack: nonzero itemCount with Clause 2 NOT satisfied does not converge, even given a valid review-ack (#2050 acceptance criterion)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [copilotReview({ itemCount: 1 })],
+      threads: [
+        {
+          id: 'PRT_ACK_2',
+          isResolved: false,
+          comments: {
+            nodes: [
+              {
+                author: { login: COPILOT_LOGIN },
+                body: 'nit: consider extracting this into a helper',
+                createdAt: OLD,
+                updatedAt: OLD,
+              },
+            ],
+          },
+        },
+      ],
+      comments: [reviewAckComment(ACK_AFTER_REVIEW)],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.itemCount, 1);
+  assert.equal(verdict.threads.satisfied, false);
+  assert.equal(verdict.review.satisfied, false);
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.ready, false);
+});
+
+test('review-ack: nonzero suppressedCount with a valid post-review ack converges', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({ itemCount: 0, body: SUPPRESSED_COMMENTS_BODY }),
+      ],
+      comments: [reviewAckComment(ACK_AFTER_REVIEW)],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.suppressedCount, 1);
+  assert.equal(verdict.review.satisfied, true);
+  assert.equal(verdict.converged, true);
+  assert.equal(verdict.ready, true);
+  assert.deepEqual(verdict.reasons, []);
+});
+
+test('review-ack: an ack predating the latest review does NOT cover a nonzero suppressedCount', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({ itemCount: 0, body: SUPPRESSED_COMMENTS_BODY }),
+      ],
+      comments: [reviewAckComment(ACK_BEFORE_REVIEW)],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.suppressedCount, 1);
+  assert.equal(verdict.review.satisfied, false);
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.ready, false);
+  assert.match(verdict.reasons.join('\n'), /post a trusted review-ack marker/);
+});
+
+test('review-ack: an ack from an untrusted login does not count', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({ itemCount: 0, body: SUPPRESSED_COMMENTS_BODY }),
+      ],
+      comments: [
+        reviewAckComment(ACK_AFTER_REVIEW, { login: 'random-contributor' }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.satisfied, false);
+  assert.equal(verdict.converged, false);
+});
+
+test('review-ack: a fresh review submitted after a valid ack invalidates it automatically, no separate invalidation step', () => {
+  // The same PR HEAD carries TWO Copilot reviews (an AW6 same-HEAD reroll is
+  // a live example) -- the ack posted after the FIRST review must not cover
+  // the SECOND, later one.
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({
+          itemCount: 0,
+          body: SUPPRESSED_COMMENTS_BODY,
+          submittedAt: OLD,
+        }),
+        copilotReview({ itemCount: 0, body: SUPPRESSED_COMMENTS_BODY }), // submittedAt: RECENT
+      ],
+      // Posted after the FIRST review (OLD) but before the SECOND (RECENT).
+      comments: [reviewAckComment('2026-06-15T00:00:00Z')],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.review.submittedAt, RECENT);
+  assert.equal(verdict.review.satisfied, false);
+  assert.equal(verdict.converged, false);
+});
+
+test('review-ack: a malformed marker (bad timestamp, or trailing prose) is not counted, matching the canonical OPERATIONAL_MARKERS shape', () => {
+  const badTimestamp = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({ itemCount: 0, body: SUPPRESSED_COMMENTS_BODY }),
+      ],
+      comments: [
+        {
+          author: { login: TRUSTED },
+          body: `review-ack: ${AGENT_ID} ${HEAD} not-a-timestamp`,
+          createdAt: ACK_AFTER_REVIEW,
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(badTimestamp);
+  assert.equal(badTimestamp.review.satisfied, false);
+
+  const trailingProse = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        copilotReview({ itemCount: 0, body: SUPPRESSED_COMMENTS_BODY }),
+      ],
+      comments: [
+        {
+          author: { login: TRUSTED },
+          body: `review-ack: ${AGENT_ID} ${HEAD} ${ACK_AFTER_REVIEW} please see above`,
+          createdAt: ACK_AFTER_REVIEW,
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(trailingProse);
+  assert.equal(trailingProse.review.satisfied, false);
+});
+
 // --- 10. terminal Copilot unavailability (#1570/#1572) ----------------------
 // --- The `#1572` terminal-recovery contract (buildCopilotRecoverySummary,
 // --- advisory-wait-state.mts) is reused here unmodified: exhausting its

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -139,6 +139,17 @@ test('buildMarkerBody renders advisory markers as plain text with no visible not
   assert.equal(reroll, `advisory-reroll: claude-417b737f ${SHA} ${TS}`);
   assert.doesNotMatch(reroll, /<!--/);
   assert.doesNotMatch(reroll, /\n/);
+
+  // #2050: disposition-aware Clause 1 escape hatch marker -- same plain-text
+  // shape as advisory-reroll above.
+  const reviewAck = buildMarkerBody('review-ack', {
+    'agent-id': 'claude-417b737f',
+    'head-sha': SHA,
+    timestamp: TS,
+  });
+  assert.equal(reviewAck, `review-ack: claude-417b737f ${SHA} ${TS}`);
+  assert.doesNotMatch(reviewAck, /<!--/);
+  assert.doesNotMatch(reviewAck, /\n/);
 });
 
 test('buildMarkerBody normalizes an upper-case head SHA for advisory markers', () => {
@@ -550,7 +561,7 @@ test('buildMarkerBody throws on an invalid field set (renderer validation)', () 
   );
 });
 
-test('MARKER_TYPES lists exactly the nine supported types', () => {
+test('MARKER_TYPES lists exactly the ten supported types', () => {
   assert.deepEqual(
     [...MARKER_TYPES],
     [
@@ -562,6 +573,7 @@ test('MARKER_TYPES lists exactly the nine supported types', () => {
       'advisory',
       'advisory-recovery',
       'advisory-reroll',
+      'review-ack',
       'copilot-unavailable',
     ],
   );
@@ -621,6 +633,17 @@ test('an advisory-reroll envelope validates against the schema (PR #1517 review)
     target: 'pr',
     number: 1047,
     body: `advisory-reroll: a ${SHA} ${TS}`,
+  };
+  assert.deepEqual(validate(envelope, schema), []);
+});
+
+test('a review-ack envelope validates against the schema (#2050)', () => {
+  const envelope = {
+    mode: 'dry-run',
+    type: 'review-ack',
+    target: 'pr',
+    number: 1047,
+    body: `review-ack: a ${SHA} ${TS}`,
   };
   assert.deepEqual(validate(envelope, schema), []);
 });
@@ -1279,10 +1302,10 @@ test('--from-pr rejects manual snapshot fields as ambiguous (before any gh call)
 });
 
 test('--from-pr is rejected for a type outside FROM_PR_MARKER_TYPES', () => {
-  // #1889: --from-pr now supports watermark AND the three advisory types
-  // (see the dedicated tests below), but a structurally unrelated type like
-  // `claim` -- which has no head-sha field at all -- still fails exactly as
-  // before.
+  // #1889 / #2050: --from-pr now supports watermark AND the advisory-family
+  // types (see the dedicated tests below), but a structurally unrelated type
+  // like `claim` -- which has no head-sha field at all -- still fails
+  // exactly as before.
   const stderr = runCliExpectingFailure([
     join(REPO_ROOT, 'scripts/post-idd-marker.mjs'),
     '--type',
@@ -1296,16 +1319,17 @@ test('--from-pr is rejected for a type outside FROM_PR_MARKER_TYPES', () => {
   ]);
   assert.match(
     stderr,
-    /--from-pr is only valid for --type watermark, advisory, advisory-recovery, advisory-reroll/,
+    /--from-pr is only valid for --type watermark, advisory, advisory-recovery, advisory-reroll, review-ack/,
   );
 });
 
-test('FROM_PR_MARKER_TYPES lists exactly the four --from-pr-supported types', () => {
+test('FROM_PR_MARKER_TYPES lists exactly the five --from-pr-supported types', () => {
   assert.deepEqual(FROM_PR_MARKER_TYPES, [
     'watermark',
     'advisory',
     'advisory-recovery',
     'advisory-reroll',
+    'review-ack',
   ]);
 });
 
@@ -1328,10 +1352,11 @@ test('--from-pr fails closed on an explicit non-pr --target', () => {
   assert.match(stderr, /--from-pr always targets the PR/);
 });
 
-// --- #1889: --from-pr live head-sha derivation for the advisory types ------
+// --- #1889 / #2050: --from-pr live head-sha derivation for the advisory- --
+// --- family types ----------------------------------------------------------
 //
 // Unlike watermark's --from-pr (full review-activity-snapshot composition),
-// the three advisory types derive ONLY --head-sha via a single lightweight
+// the advisory-family types derive ONLY --head-sha via a single lightweight
 // `gh pr view --json headRefOid --jq .headRefOid` call -- no CI checks,
 // review threads, or comment pagination.
 
@@ -1486,6 +1511,38 @@ test('--from-pr CLI derives only --head-sha for --type advisory-reroll (dry-run)
     target: 'pr',
     number: 1200,
     body: buildMarkerBody('advisory-reroll', {
+      'agent-id': 'claude-02f8159e',
+      'head-sha': SHA,
+      timestamp: TS,
+    }),
+  });
+});
+
+test('--from-pr CLI derives only --head-sha for --type review-ack (dry-run, #2050)', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-from-pr-review-ack-'));
+  writeHeadShaOnlyGhStub(tempRoot, SHA);
+
+  const result = runFromPrCliDryRun(tempRoot, [
+    '--type',
+    'review-ack',
+    '--from-pr',
+    '1200',
+    '--owner',
+    'o',
+    '--repo',
+    'r',
+    '--agent-id',
+    'claude-02f8159e',
+    '--timestamp',
+    TS,
+  ]);
+
+  assert.deepEqual(result, {
+    mode: 'dry-run',
+    type: 'review-ack',
+    target: 'pr',
+    number: 1200,
+    body: buildMarkerBody('review-ack', {
       'agent-id': 'claude-02f8159e',
       'head-sha': SHA,
       timestamp: TS,
@@ -1683,6 +1740,7 @@ const FULL_FIELDS_BY_TYPE: Record<string, Record<string, string>> = {
   advisory: { 'agent-id': 'a', 'head-sha': SHA, timestamp: TS },
   'advisory-recovery': { 'agent-id': 'a', 'head-sha': SHA, timestamp: TS },
   'advisory-reroll': { 'agent-id': 'a', 'head-sha': SHA, timestamp: TS },
+  'review-ack': { 'agent-id': 'a', 'head-sha': SHA, timestamp: TS },
   'copilot-unavailable': {
     'agent-id': 'a',
     'claim-id': 'c',

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -560,6 +560,7 @@ const advisoryConvergenceFixture = {
   },
   review: {
     found: true,
+    reviewId: 'PRR_kwDOexample',
     commitId: '0123456789abcdef0123456789abcdef01234567',
     matchesHead: true,
     itemCount: 0,


### PR DESCRIPTION
Closes #2050

## Summary

- Adds a `review-ack` `post-idd-marker.mjs` type (same field shape/posting path as `advisory-reroll`), postable by any actor but only trusted when the poster is in `trustedMarkerActors`.
- Makes `idd-advisory-convergence`'s Clause 1 `satisfied` disposition-aware, as a thin caller-side override in `advisory-convergence.mts` (kept out of `review-clause.mts` since both halves need evidence -- `threads.satisfied`, PR comments, `trustedMarkerLogins` -- that pure, low-dependency function does not receive, and its other caller `rerun-advisory-convergence.mts` only ever reads `.matchesHead`, never `.satisfied`):

  ```text
  matchesHead
    && (itemCount === 0 || (itemCount is known AND the number of threads
        THIS review opened is >= itemCount AND all of them are
        resolved/dispositioned))
    && (suppressedCount === 0 || hasValidReviewAck)
  ```

- `hasValidReviewAck`: a trusted `review-ack:` marker whose own GitHub-assigned `created_at` (never the embedded timestamp) postdates the latest Copilot review's `submittedAt` -- so a later review (same HEAD or not, e.g. an AW6 reroll) automatically invalidates a stale ack.
- Documents the new marker in `idd-advisory-wait.instructions.md` (AW6's `suppressedCount`-unvalidated note) and `idd-helper-scripts.md`.

Refs #1880, #1934, #2039.

## Deviations from the issue text (please review)

1. **Review-scoped, count-covering thread evidence, not the issue's literal `threadClause.satisfied`.** The issue's formula reuses Clause 2's `threadClause.satisfied` as-is, but that flag is PR-wide (any Copilot-authored thread anywhere on the PR) and is vacuously `true` with zero threads at all (`blockingCount === 0` trivially). Neither is sufficient: a review with `itemCount: 2` needs *this specific review's own* threads, and needs at least `itemCount` of them, all resolved/dispositioned -- otherwise an older, already-resolved thread from a *different* review (or simply zero thread evidence) would incorrectly satisfy a newer review's nonzero count. `classifyThreadIdsForReview` (new, `advisory-convergence.mts`) binds thread evidence to `review.reviewId` via each thread's originating comment's `pullRequestReview.id`; the gate requires `latestReviewThreadIds.size >= review.itemCount` with none of that review's own threads left unresolved. This is a narrowing deviation only: it can never make the gate converge *more* than the literal formula would, only less. Regression tests: `itemCount: 2` with only one review-scoped resolved thread does not converge (partial coverage); an older resolved thread from a different review does not cover a newer review's own count; an unknown (`null`) `itemCount` never converges.
2. **Doc placement, forced by a byte budget.** `bundle-review`'s `context-ceiling-128k` policy check (`schemas/policy.schema.json`) left only **~37 bytes** of headroom in `idd-advisory-wait.instructions.md` at baseline (`117563/117600` cap, i.e. the bundle was already at 97.97% before this PR touched it). The instructions-file addition is a one-line pointer; the full marker grammar and posting procedure live in `idd-helper-scripts.md` instead, which isn't in that bundle. This bundle is right at its ceiling independent of this PR -- worth a follow-up issue on its own, out of scope here.
3. **`hasFreshDisposition` reused as a *pattern*, not called.** The issue says "reuse `hasFreshDisposition`'s existing trust-boundary pattern... rather than re-deriving an equivalent comparison from scratch." `hasFreshDisposition` (`protocol-helpers.mts`) is thread-internal (compares a disposition comment's activity time against the *same thread's* other comments) and structurally inapplicable to an ack-vs-review comparison across two different comment streams. `resolveHasValidReviewAck` (`advisory-convergence.mts`) reuses the same trust boundary -- GitHub server `created_at`/`compareIsoTimestamps`, never an embedded timestamp -- mirroring `summarizeSameHeadRerollMarkers`'s identical local precedent in the same file, not `hasFreshDisposition` by direct call.

## Scope

Untouched, per the issue's explicit scope note (issue #2021 / PR #2033 territory, still open): `protocol-helpers.mts`'s `summarizeDispositionEvidenceForGate`, `pre-merge-readiness.mts`, `external-check-waiver.mts`, `review-clause.mts` (its exports are reused, not modified; it gained a `reviewId` passthrough field to support the review-scoping deviation above).

## Known follow-up (deferred, not fixed here -- #2056)

Four findings on this PR are real but narrow, and are deferred to #2056 rather than fixed in this already-large diff (round-cap discipline -- this PR is well past its second round of genuinely new substantive findings, spanning the original review round 4 plus two subsequent AW6 same-HEAD reroll attempts that both re-confirmed findings 1-2 and turned up findings 3-4):

1. `resolveHasValidReviewAck` validates a `review-ack` marker's `createdAt`-vs-`submittedAt` ordering but ignores the marker's own embedded HEAD SHA, which admits a narrow delayed-`--from-pr`-POST race (ack targets HEAD A, a newer HEAD B and its review land before the POST lands, the ack's real `createdAt` then incorrectly covers B). Trusted-actors-only, no adversarial vector, feature inert until a marker is posted.
2. `sameHeadReroll.eligible`/`.requestable` don't account for `reviewSatisfied` already being `true` via a valid ack, so they can report `true` for an already-converged review. Diagnostics-only -- the existing with/without-reroll-marker invariant test guarantees this never affects `converged`/`waived`/`ready`.
3. The nonzero `itemCountClauseSatisfied` branch trusts `latestReviewThreadIds.size >= review.itemCount` without requiring `itemCount` to be a non-negative integer first; not reachable via the real GraphQL `comments.totalCount` data path today (always non-negative), but nothing enforces that at the boundary. Defense-in-depth, not an active exploit.
4. The partial-coverage blocking-reason branch (`noThreadEvidenceForItems`) only fires at `latestReviewThreadIds.size === 0`, not `< itemCount`, so a partial-coverage case's reason text doesn't name which item lacks thread evidence. Diagnostics-text only -- `itemCountClauseSatisfied` itself already gates correctly.

Threads for findings 1 and 3 are dispositioned **Accepted** (deferred to #2056) and resolved on this PR. Findings 2 and 4 have no thread (fully suppressed in the review body both times); their disposition record is this note plus #2056.

## Merge-gate status: blocked pending a maintainer-authorized waiver window (not fixable by further iteration)

`idd-advisory-convergence` checks out `ref: main` by design (tamper-resistance), so this PR's own `review-ack` fix cannot self-cover its own `suppressedCount` until it merges -- a chicken-and-egg the issue's own "Decision" section anticipated with the unmodified 24h/maintainer-waiver fallback. Two AW6 same-HEAD reroll attempts (cap 2, both used) each reproduced real, already-triaged findings rather than a clean review, confirming the underlying gaps are genuinely unfixed pending #2056 rather than review noise -- a third attempt would not converge either.

A maintainer-authorized `idd-external-check-waiver` marker is posted on this PR (selector `idd-advisory-convergence`, HEAD `386aa9ef`, expires `2026-08-15T10:44:24.153Z`) -- [comment](https://github.com/kurone-kito/idd-skill/pull/2054#issuecomment-5292406401). Verified independently against `summarizeExternalCheckWaivers` (`protocol-helpers.mts`) with the PR's live comment data: the marker parses `valid` with zero rejections across every bucket (`expired`/`wrongHead`/`wrongClaim`/`unauthorized`/`malformed`/`notConfigured`).

**However**, reading `advisory-convergence.mts`'s own gate (main's copy) directly: the waiver-evidence check is only ever *evaluated* once `deadlinePassed || terminalUnavailable` is already true --

```ts
if (!converged && (deadlinePassed || terminalUnavailable) && waiverMode === 'maintainer-authorized') {
  const waiverEvidence = summarizeExternalCheckWaivers(comments, { /* ... */ });
  validWaiverCount = waiverEvidence.valid.filter(...).length;
}
```

-- so `waiver.validCount` reads `0` in every verdict pulled *before* that precondition opens, exactly the #2021 trap (`pre-merge-readiness.mjs`'s `coveredByWaiver` lies the same way, for the same reason). This PR's `deadline.headCommittedAt` is `2026-08-14T10:35:45Z` (HEAD `386aa9ef`'s commit time) with a 1440-minute (24h) window, so `deadlinePassed` becomes `true` at **`2026-08-15T10:35:45Z`**. The posted waiver expires at **`2026-08-15T10:44:24Z`** -- only a **~9-minute overlap** where both conditions hold simultaneously.

**Successor instructions**: do not trust `pre-merge-readiness.mjs`'s `coveredByWaiver` before `2026-08-15T10:35:45Z`. After that time (ideally right away, given the narrow window), re-post a fresh `idd-external-check-waiver` marker (`node scripts/external-check-waiver.mjs --pr 2054 --check idd-advisory-convergence --issue 2050 --claim-id <active-claim-id> --reason "..." --expires-in PT24H --apply`) to get a comfortable fresh 24h window instead of racing the original ~9-minute overlap, then `gh run rerun` the `idd-advisory-convergence` run for HEAD `386aa9ef` to get an honest re-evaluation. If the active claim on #2050 has changed, resolve the current `claim-id` from issue #2050's latest `claimed-by:` marker first.

## Test plan

- [x] `node --test tests/*.test.mts` -- 3555/3555 pass, including the `review-ack` regression tests (the 4 acceptance-criteria shapes -- nonzero `itemCount` w/ Clause 2 satisfied converges, nonzero `itemCount` w/ Clause 2 unsatisfied does not converge even with a valid ack, nonzero `suppressedCount` w/ valid ack converges, ack predating the review does not converge -- plus untrusted-login, cross-review-invalidation, review-scoping, partial-coverage, unknown-itemCount, and malformed/asymmetric-trust-boundary marker coverage).
- [x] `pnpm run build:check`, `npx biome check`, `npx dprint check "**/*.md"`, `npx markdownlint-cli2 "**/*.md"`, `npx cspell lint "**"`, `node scripts/audit-code-span-wrap.mjs`, `node scripts/audit-docs.mjs --check`, `node scripts/idd-doctor.mjs` -- all pass.
- [x] Manual dry-run smoke test: `node scripts/post-idd-marker.mjs --type review-ack --target pr <n> --agent-id <id> --head-sha <sha> --timestamp <ts>` renders the expected `review-ack: {agent-id} {head-sha} {timestamp}` body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for trusted `review-ack` markers to acknowledge suppressed review findings.
  - Advisory convergence now evaluates findings against the latest review and its specific threads.
  - Review acknowledgments must match the current commit, follow the latest review, and meet validation requirements.
  - Added review identifiers to advisory convergence results.

- **Documentation**
  - Updated advisory guidance for zero-thread reviews, review dispositions, acknowledgments, and reroll handling.

- **Tests**
  - Expanded coverage for valid and invalid acknowledgments, review scope, timestamps, and marker validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


