### PR TITLE
docs(issue-authoring): resync placeholder/lint-config scope

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -409,9 +409,10 @@ Ask these checks:
    customizations for these files need a by-hand merge into the new
    import rather than an assumed carry-forward, and
    `idd-onboard.mjs --import` reports a `blockedOverwrites` finding
-   instead of silently keeping a same-named local file as-is
-   (observed 2026-08-12/13 on an adopter repository, `setup.ubuntu`,
-   kurone-kito/idd-skill#2012).
+   instead of silently keeping a same-named local file as-is, unless
+   the import used `--force`, which silently overwrites the differing
+   file instead of recording it there (observed 2026-08-12/13 on an
+   adopter repository, `setup.ubuntu`, kurone-kito/idd-skill#2012).
 5. When drafting a resync issue's Background, run a mechanical
    placeholder diff against the **upstream `idd-skill` source
    repository's** `idd-template/` trees at the two relevant refs —

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -442,11 +442,16 @@ Ask these checks:
      `v<iddVersion>` tag matching what they actually imported either.
    - **Target ref.** The new release/ref the resync targets.
    - **Scope.** Intersect both trees with the Step 2 "File list" core
-     file set (`idd-template/ONBOARDING.md`'s generated file-list
-     block) plus whichever optional profile artifacts the adopter
-     selected, not the complete `idd-template/` tree — a file such as
+     file set as it reads **at the target ref**
+     (`idd-template/ONBOARDING.md`'s generated file-list block) plus
+     whichever optional profile artifacts the adopter selected, not
+     the complete `idd-template/` tree — a file such as
      `idd-template/ONBOARDING.md` itself is never copied into an
-     adopter, so reporting it as changed is noise.
+     adopter, so reporting it as changed is noise. Use the target
+     ref's manifest, not the baseline ref's: a file the target release
+     newly added to the core or a selected profile is exactly the kind
+     of change a resync issue must report, and the baseline ref's own
+     manifest predates it.
    - **Token filter.** Compare each ref's own placeholder table in
      effect at that ref (Onboarding Reference — Placeholder Values'
      "Final placeholder meanings" table, `docs/onboarding/placeholders.md`,

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -421,14 +421,28 @@ Ask these checks:
    - **Baseline ref.** Resolve the exact tag or commit SHA actually
      imported at the adopter's prior onboarding: identify it from the
      adopter's own git history (the import/resync commit's diff pins
-     the exact upstream content adopted), or, absent that evidence,
-     the nearest upstream commit whose `idd-template/` tree matches
-     the adopter's current files content-for-content. Do not
-     construct `v<iddVersion>` (`.github/idd/config.json`) as the
-     baseline without this check: `iddVersion` is only a coarse
-     signal and can be stale, an adopter still on `0.1.0` has no
-     matching tag at all (`CHANGELOG.md` records that `0.1.0`
-     predates the tag discipline), and an adopter who pinned a raw
+     the exact upstream content adopted). Absent that evidence, do not
+     content-match the adopter's files against a raw upstream
+     `idd-template/` tree directly — onboarding substitutes the seven
+     placeholders with concrete values
+     (`buildSubstitutionPlan`/`ONBOARDING_PLACEHOLDERS` in
+     `src/scripts/idd-onboard.mts`), so a normally onboarded adopter's
+     files never match any upstream commit's tree byte-for-byte — the
+     upstream tree still carries the literal `{{...}}` tokens.
+     Reverse-substitute the adopter's own recorded
+     values (`.github/idd/config.json`, the Step 3 recorded policy
+     decisions) back to `{{...}}` token form first, account for any
+     known intentional-divergence markers (see the divergence-signal
+     check above) as expected differences rather than mismatches, and
+     only then compare the normalized tree against candidate upstream
+     commits. Report the ambiguity in the resync issue itself, rather
+     than guessing, when more than one candidate ref remains
+     equivalent after normalization. Do not construct `v<iddVersion>`
+     (`.github/idd/config.json`) as the baseline without this check:
+     `iddVersion` is only a coarse signal and can be stale, an adopter
+     still on `0.1.0` has no matching tag at all (`CHANGELOG.md`
+     records that `0.1.0` predates the tag discipline), and an adopter
+     who pinned a raw
      commit SHA at import time instead of a tag may have no
      `v<iddVersion>` tag matching what they actually imported either.
    - **Target ref.** The new release/ref the resync targets.

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -453,17 +453,21 @@ Ask these checks:
      of change a resync issue must report, and the baseline ref's own
      manifest predates it.
    - **Token filter.** Compare each ref's own placeholder table in
-     effect at that ref (Onboarding Reference — Placeholder Values'
-     "Final placeholder meanings" table, `docs/onboarding/placeholders.md`,
-     as it read at the baseline ref and at the target ref
-     independently), not today's list applied to both — a placeholder
-     added or removed between the two refs is itself exactly the kind
-     of token-identity change this check exists to report, and reusing
-     one ref's list for the other's tree would hide that change. Never
-     match every `{{...}}`-shaped span unfiltered either way — an
-     unrestricted match also catches ordinary GitHub Actions
-     expressions such as `${{ github.token }}` in an imported workflow
-     file.
+     effect at that ref, not today's list applied to both — a
+     placeholder added or removed between the two refs is itself
+     exactly the kind of token-identity change this check exists to
+     report, and reusing one ref's list for the other's tree would
+     hide that change. At a ref from commit `e55ccd9c` (2026-05-12)
+     onward, that table is Onboarding Reference — Placeholder Values'
+     "Final placeholder meanings" table
+     (`docs/onboarding/placeholders.md`). An older ref has no such
+     file — the placeholders were documented directly inside
+     `idd-template/ONBOARDING.md`'s own "Step 1C — Collect placeholder
+     values" section instead; use that section's list as the
+     allowlist for a baseline ref that old. Never match every
+     `{{...}}`-shaped span unfiltered either way — an unrestricted
+     match also catches ordinary GitHub Actions expressions such as
+     `${{ github.token }}` in an imported workflow file.
    - **Excluded paths.** Skip `docs/onboarding/placeholders.md`,
      `docs/customization.md`, and `docs/onboarding/policy-decisions.md`
      — these deliberately keep `{{...}}` tokens literal to document

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -420,35 +420,23 @@ Ask these checks:
    imported.
    - **Baseline ref.** Resolve the exact tag or commit SHA actually
      imported at the adopter's prior onboarding: identify it from the
-     adopter's own git history (the import/resync commit's diff pins
-     the exact upstream content adopted). Absent that evidence, do not
-     content-match the adopter's files against a raw upstream
-     `idd-template/` tree directly — onboarding substitutes the seven
-     placeholders with concrete values
-     (`buildSubstitutionPlan`/`ONBOARDING_PLACEHOLDERS` in
-     `src/scripts/idd-onboard.mts`), so a normally onboarded adopter's
-     files never match any upstream commit's tree byte-for-byte — the
-     upstream tree still carries the literal `{{...}}` tokens.
-     Reverse-substitution is not a safe inverse here: a concrete
-     value (for example the literal `true` a command placeholder
-     takes when no relevant tool exists for that step, per Onboarding
-     Reference — Placeholder Values) can belong to more than one
-     placeholder, so a value found in the adopter's tree does not
-     identify a single token to restore, and a naive text replace can
-     also rewrite unrelated prose that happens to match the same
-     value. Transform each **candidate upstream tree forward**
-     instead, using the adopter's own recorded per-placeholder values
-     (`.github/idd/config.json`, the Step 3 recorded policy
-     decisions) through the same site-aware substitution the real
-     import applies (JSON sites receive an escaped value, every other
-     site takes it raw), then compare that transformed candidate
-     against the adopter's actual snapshot — this direction has no
-     ambiguity, since each placeholder's value is already known before
-     the transform runs. Account for any known intentional-divergence
-     markers (see the divergence-signal check above) as expected
-     differences rather than mismatches. Report the ambiguity in the
-     resync issue itself, rather than guessing, when more than one
-     candidate ref remains equivalent after this comparison. Do not
+     adopter's own git history — the import/resync commit's diff pins
+     the exact upstream content adopted. This is the only reliable
+     source: a normally onboarded adopter's files never match any raw
+     upstream `idd-template/` tree byte-for-byte (onboarding
+     substitutes the seven placeholders with concrete values), and
+     neither a reverse- nor a forward-substitution content-match
+     reconstructs the baseline reliably either — `.github/idd/config.json`
+     does not record every placeholder value (`REPO_NAME` among them),
+     Step 3 records the Step 1B policy decisions rather than a
+     placeholder-value map, and canonical onboarding explicitly
+     permits legitimate post-substitution edits (for example adding
+     extra trusted marker actors by hand after the first replacement),
+     so the adopter's current files can differ from the as-imported
+     snapshot for reasons that have nothing to do with which ref was
+     imported. When the adopter's git history carries no such evidence,
+     report the baseline as unresolved/ambiguous in the resync issue
+     itself instead of guessing one from content alone. Do not
      construct `v<iddVersion>`
      (`.github/idd/config.json`) as the baseline without this check:
      `iddVersion` is only a coarse signal and can be stale, an adopter

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -393,39 +393,70 @@ Ask these checks:
    Do not hard-code any single consumer's divergence-tracking mechanism.
 4. When an issue drafts a **template resync or reimport** (pulling a
    newer `idd-template/` revision into a repository that already
-   adopted IDD), consult `docs/customization.md`'s "Documentation lint
-   compatibility" section before treating `.markdownlint.yml` /
-   `.markdownlint-cli2.yaml` / `.cspell.config.yml` as unchanged — it is
-   part of the same imported bundle, so it resolves in an installed or
-   adopter context, unlike `idd-template/ONBOARDING.md`'s "Re-importing"
-   section, whose source-checkout-relative path does not exist once the
-   authoring skill runs outside this repository. Either section
-   documents the same named gap: an adopter's own rule customizations
-   for these files need a by-hand merge into the new import rather than
-   an assumed carry-forward, and `idd-onboard.mjs --import` reports a
-   `blockedOverwrites` finding instead of silently keeping a same-named
-   local file as-is. From a source checkout of `idd-skill` itself,
-   `idd-template/ONBOARDING.md`'s "Re-importing" section is the more
-   detailed maintainer-facing version of the same guidance.
+   adopted IDD), consult the **upstream target ref's** copy of
+   `docs/customization.md`'s "Documentation lint compatibility"
+   section (added 2026-08-05, commit `6ceaa6dd`) before treating
+   `.markdownlint.yml` / `.markdownlint-cli2.yaml` / `.cspell.config.yml`
+   as unchanged. `docs/customization.md` is itself part of the
+   imported core file set, so it resolves in an installed or adopter
+   context once present — but an adopter whose prior import predates
+   that commit has no such section in their own local copy yet, which
+   is exactly the named gap to document in the resync issue, not a
+   documentation-consultation failure. Either the target ref's
+   `docs/customization.md` section or, from a source checkout of
+   `idd-skill` itself, `idd-template/ONBOARDING.md`'s "Re-importing"
+   section, documents the same named gap: an adopter's own rule
+   customizations for these files need a by-hand merge into the new
+   import rather than an assumed carry-forward, and
+   `idd-onboard.mjs --import` reports a `blockedOverwrites` finding
+   instead of silently keeping a same-named local file as-is
+   (observed 2026-08-12/13 on an adopter repository, `setup.ubuntu`,
+   kurone-kito/idd-skill#2012).
 5. When drafting a resync issue's Background, run a mechanical
    placeholder diff against the **upstream `idd-skill` source
-   repository's** `idd-template/` trees at the two relevant refs — the
-   previously-adopted `v<iddVersion>` tag (`iddVersion` is recorded in
-   `.github/idd/config.json`) and the new target release/ref — never a
-   tree inside the target/adopter repository itself, which retains no
-   local `idd-template/` directory of its own once IDD is imported.
-   Compare the actual `{{...}}` token identities per changed file, not
-   only the aggregate occurrence count: a same-count one-for-one
-   placeholder swap changes what an adopter must substitute without
-   changing the count. Exclude reference-only meta-docs whose `{{...}}`
-   tokens are deliberately kept literal to document the placeholder
-   syntax itself — the `SCAN_EXCLUDED_PATHS` set in
-   `src/scripts/idd-onboard.mts` (e.g. `docs/onboarding/placeholders.md`)
-   — diffing those would misidentify literal documentation as an
-   outstanding substitution. Name any file whose placeholder tokens
-   changed, rather than asserting a file needs no placeholder
-   substitution as an unverified default (observed 2026-08-12/13 on an
-   adopter repository, #2012).
+   repository's** `idd-template/` trees at the two relevant refs —
+   never a tree inside the target/adopter repository itself, which
+   retains no local `idd-template/` directory of its own once IDD is
+   imported.
+   - **Baseline ref.** Resolve the exact tag or commit SHA actually
+     imported at the adopter's prior onboarding: identify it from the
+     adopter's own git history (the import/resync commit's diff pins
+     the exact upstream content adopted), or, absent that evidence,
+     the nearest upstream commit whose `idd-template/` tree matches
+     the adopter's current files content-for-content. Do not
+     construct `v<iddVersion>` (`.github/idd/config.json`) as the
+     baseline without this check: `iddVersion` is only a coarse
+     signal and can be stale, an adopter still on `0.1.0` has no
+     matching tag at all (`CHANGELOG.md` records that `0.1.0`
+     predates the tag discipline), and an adopter who pinned a raw
+     commit SHA at import time instead of a tag may have no
+     `v<iddVersion>` tag matching what they actually imported either.
+   - **Target ref.** The new release/ref the resync targets.
+   - **Scope.** Intersect both trees with the Step 2 "File list" core
+     file set (`idd-template/ONBOARDING.md`'s generated file-list
+     block) plus whichever optional profile artifacts the adopter
+     selected, not the complete `idd-template/` tree — a file such as
+     `idd-template/ONBOARDING.md` itself is never copied into an
+     adopter, so reporting it as changed is noise.
+   - **Token filter.** Compare only the seven placeholders documented
+     in Onboarding Reference — Placeholder Values' "Final placeholder
+     meanings" table (`docs/onboarding/placeholders.md`), not every
+     `{{...}}`-shaped span — an unrestricted match also catches
+     ordinary GitHub Actions expressions such as `${{ github.token }}`
+     in an imported workflow file.
+   - **Excluded paths.** Skip `docs/onboarding/placeholders.md`,
+     `docs/customization.md`, and `docs/onboarding/policy-decisions.md`
+     — these deliberately keep `{{...}}` tokens literal to document
+     the placeholder syntax itself, so diffing them misidentifies
+     literal documentation as an outstanding substitution.
+
+   Compare the actual token identities per changed file, not only the
+   aggregate occurrence count: a same-count one-for-one placeholder
+   swap changes what an adopter must substitute without changing the
+   count. Name any file whose placeholder tokens changed, rather than
+   asserting a file needs no placeholder substitution as an unverified
+   default (observed 2026-08-12/13 on an adopter repository,
+   `setup.ubuntu`, kurone-kito/idd-skill#2012).
 
 ## Dependency minimization
 

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -418,26 +418,21 @@ Ask these checks:
    never a tree inside the target/adopter repository itself, which
    retains no local `idd-template/` directory of its own once IDD is
    imported.
-   - **Baseline ref.** Resolve the exact tag or commit SHA actually
-     imported at the adopter's prior onboarding: identify it from the
-     adopter's own git history — the import/resync commit's diff pins
-     the exact upstream content adopted. This is the only reliable
-     source: a normally onboarded adopter's files never match any raw
-     upstream `idd-template/` tree byte-for-byte (onboarding
-     substitutes the seven placeholders with concrete values), and
-     neither a reverse- nor a forward-substitution content-match
-     reconstructs the baseline reliably either — `.github/idd/config.json`
-     does not record every placeholder value (`REPO_NAME` among them),
-     Step 3 records the Step 1B policy decisions rather than a
-     placeholder-value map, and canonical onboarding explicitly
-     permits legitimate post-substitution edits (for example adding
-     extra trusted marker actors by hand after the first replacement),
-     so the adopter's current files can differ from the as-imported
-     snapshot for reasons that have nothing to do with which ref was
-     imported. When the adopter's git history carries no such evidence,
-     report the baseline as unresolved/ambiguous in the resync issue
-     itself instead of guessing one from content alone. Do not
-     construct `v<iddVersion>`
+   - **Baseline ref.** Use the exact tag or commit SHA actually
+     imported at the adopter's prior onboarding when it is explicitly
+     recorded (for example in the original onboarding PR/commit
+     message) or when the operator can confirm it directly. Do not
+     infer it from the adopter's current file content: neither a diff
+     against the import commit nor a reverse- or forward-substitution
+     content-match against a candidate upstream tree reliably pins a
+     single ref — onboarding substitutes placeholder values and
+     permits legitimate post-substitution edits, an import commit's
+     diff itself only records the already-transformed adopter
+     snapshot, and more than one upstream commit can plausibly yield
+     the same imported subset. When no explicit record or operator
+     confirmation is available, report the baseline as
+     unresolved/ambiguous in the resync issue itself rather than
+     guessing one from content alone. Do not construct `v<iddVersion>`
      (`.github/idd/config.json`) as the baseline without this check:
      `iddVersion` is only a coarse signal and can be stale, an adopter
      still on `0.1.0` has no matching tag at all (`CHANGELOG.md`
@@ -452,12 +447,18 @@ Ask these checks:
      selected, not the complete `idd-template/` tree — a file such as
      `idd-template/ONBOARDING.md` itself is never copied into an
      adopter, so reporting it as changed is noise.
-   - **Token filter.** Compare only the seven placeholders documented
-     in Onboarding Reference — Placeholder Values' "Final placeholder
-     meanings" table (`docs/onboarding/placeholders.md`), not every
-     `{{...}}`-shaped span — an unrestricted match also catches
-     ordinary GitHub Actions expressions such as `${{ github.token }}`
-     in an imported workflow file.
+   - **Token filter.** Compare each ref's own placeholder table in
+     effect at that ref (Onboarding Reference — Placeholder Values'
+     "Final placeholder meanings" table, `docs/onboarding/placeholders.md`,
+     as it read at the baseline ref and at the target ref
+     independently), not today's list applied to both — a placeholder
+     added or removed between the two refs is itself exactly the kind
+     of token-identity change this check exists to report, and reusing
+     one ref's list for the other's tree would hide that change. Never
+     match every `{{...}}`-shaped span unfiltered either way — an
+     unrestricted match also catches ordinary GitHub Actions
+     expressions such as `${{ github.token }}` in an imported workflow
+     file.
    - **Excluded paths.** Skip `docs/onboarding/placeholders.md`,
      `docs/customization.md`, and `docs/onboarding/policy-decisions.md`
      — these deliberately keep `{{...}}` tokens literal to document

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -429,15 +429,27 @@ Ask these checks:
      `src/scripts/idd-onboard.mts`), so a normally onboarded adopter's
      files never match any upstream commit's tree byte-for-byte — the
      upstream tree still carries the literal `{{...}}` tokens.
-     Reverse-substitute the adopter's own recorded
-     values (`.github/idd/config.json`, the Step 3 recorded policy
-     decisions) back to `{{...}}` token form first, account for any
-     known intentional-divergence markers (see the divergence-signal
-     check above) as expected differences rather than mismatches, and
-     only then compare the normalized tree against candidate upstream
-     commits. Report the ambiguity in the resync issue itself, rather
-     than guessing, when more than one candidate ref remains
-     equivalent after normalization. Do not construct `v<iddVersion>`
+     Reverse-substitution is not a safe inverse here: a concrete
+     value (for example the literal `true` a command placeholder
+     takes when no relevant tool exists for that step, per Onboarding
+     Reference — Placeholder Values) can belong to more than one
+     placeholder, so a value found in the adopter's tree does not
+     identify a single token to restore, and a naive text replace can
+     also rewrite unrelated prose that happens to match the same
+     value. Transform each **candidate upstream tree forward**
+     instead, using the adopter's own recorded per-placeholder values
+     (`.github/idd/config.json`, the Step 3 recorded policy
+     decisions) through the same site-aware substitution the real
+     import applies (JSON sites receive an escaped value, every other
+     site takes it raw), then compare that transformed candidate
+     against the adopter's actual snapshot — this direction has no
+     ambiguity, since each placeholder's value is already known before
+     the transform runs. Account for any known intentional-divergence
+     markers (see the divergence-signal check above) as expected
+     differences rather than mismatches. Report the ambiguity in the
+     resync issue itself, rather than guessing, when more than one
+     candidate ref remains equivalent after this comparison. Do not
+     construct `v<iddVersion>`
      (`.github/idd/config.json`) as the baseline without this check:
      `iddVersion` is only a coarse signal and can be stale, an adopter
      still on `0.1.0` has no matching tag at all (`CHANGELOG.md`

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -459,26 +459,21 @@ Ask these checks:
    never a tree inside the target/adopter repository itself, which
    retains no local `idd-template/` directory of its own once IDD is
    imported.
-   - **Baseline ref.** Resolve the exact tag or commit SHA actually
-     imported at the adopter's prior onboarding: identify it from the
-     adopter's own git history — the import/resync commit's diff pins
-     the exact upstream content adopted. This is the only reliable
-     source: a normally onboarded adopter's files never match any raw
-     upstream `idd-template/` tree byte-for-byte (onboarding
-     substitutes the seven placeholders with concrete values), and
-     neither a reverse- nor a forward-substitution content-match
-     reconstructs the baseline reliably either — `.github/idd/config.json`
-     does not record every placeholder value (`REPO_NAME` among them),
-     Step 3 records the Step 1B policy decisions rather than a
-     placeholder-value map, and canonical onboarding explicitly
-     permits legitimate post-substitution edits (for example adding
-     extra trusted marker actors by hand after the first replacement),
-     so the adopter's current files can differ from the as-imported
-     snapshot for reasons that have nothing to do with which ref was
-     imported. When the adopter's git history carries no such evidence,
-     report the baseline as unresolved/ambiguous in the resync issue
-     itself instead of guessing one from content alone. Do not
-     construct `v<iddVersion>`
+   - **Baseline ref.** Use the exact tag or commit SHA actually
+     imported at the adopter's prior onboarding when it is explicitly
+     recorded (for example in the original onboarding PR/commit
+     message) or when the operator can confirm it directly. Do not
+     infer it from the adopter's current file content: neither a diff
+     against the import commit nor a reverse- or forward-substitution
+     content-match against a candidate upstream tree reliably pins a
+     single ref — onboarding substitutes placeholder values and
+     permits legitimate post-substitution edits, an import commit's
+     diff itself only records the already-transformed adopter
+     snapshot, and more than one upstream commit can plausibly yield
+     the same imported subset. When no explicit record or operator
+     confirmation is available, report the baseline as
+     unresolved/ambiguous in the resync issue itself rather than
+     guessing one from content alone. Do not construct `v<iddVersion>`
      (`.github/idd/config.json`) as the baseline without this check:
      `iddVersion` is only a coarse signal and can be stale, an adopter
      still on `0.1.0` has no matching tag at all (`CHANGELOG.md`
@@ -493,12 +488,18 @@ Ask these checks:
      selected, not the complete `idd-template/` tree — a file such as
      `idd-template/ONBOARDING.md` itself is never copied into an
      adopter, so reporting it as changed is noise.
-   - **Token filter.** Compare only the seven placeholders documented
-     in Onboarding Reference — Placeholder Values' "Final placeholder
-     meanings" table (`docs/onboarding/placeholders.md`), not every
-     `{{...}}`-shaped span — an unrestricted match also catches
-     ordinary GitHub Actions expressions such as `${{ github.token }}`
-     in an imported workflow file.
+   - **Token filter.** Compare each ref's own placeholder table in
+     effect at that ref (Onboarding Reference — Placeholder Values'
+     "Final placeholder meanings" table, `docs/onboarding/placeholders.md`,
+     as it read at the baseline ref and at the target ref
+     independently), not today's list applied to both — a placeholder
+     added or removed between the two refs is itself exactly the kind
+     of token-identity change this check exists to report, and reusing
+     one ref's list for the other's tree would hide that change. Never
+     match every `{{...}}`-shaped span unfiltered either way — an
+     unrestricted match also catches ordinary GitHub Actions
+     expressions such as `${{ github.token }}` in an imported workflow
+     file.
    - **Excluded paths.** Skip `docs/onboarding/placeholders.md`,
      `docs/customization.md`, and `docs/onboarding/policy-decisions.md`
      — these deliberately keep `{{...}}` tokens literal to document

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -461,35 +461,23 @@ Ask these checks:
    imported.
    - **Baseline ref.** Resolve the exact tag or commit SHA actually
      imported at the adopter's prior onboarding: identify it from the
-     adopter's own git history (the import/resync commit's diff pins
-     the exact upstream content adopted). Absent that evidence, do not
-     content-match the adopter's files against a raw upstream
-     `idd-template/` tree directly — onboarding substitutes the seven
-     placeholders with concrete values
-     (`buildSubstitutionPlan`/`ONBOARDING_PLACEHOLDERS` in
-     `src/scripts/idd-onboard.mts`), so a normally onboarded adopter's
-     files never match any upstream commit's tree byte-for-byte — the
-     upstream tree still carries the literal `{{...}}` tokens.
-     Reverse-substitution is not a safe inverse here: a concrete
-     value (for example the literal `true` a command placeholder
-     takes when no relevant tool exists for that step, per Onboarding
-     Reference — Placeholder Values) can belong to more than one
-     placeholder, so a value found in the adopter's tree does not
-     identify a single token to restore, and a naive text replace can
-     also rewrite unrelated prose that happens to match the same
-     value. Transform each **candidate upstream tree forward**
-     instead, using the adopter's own recorded per-placeholder values
-     (`.github/idd/config.json`, the Step 3 recorded policy
-     decisions) through the same site-aware substitution the real
-     import applies (JSON sites receive an escaped value, every other
-     site takes it raw), then compare that transformed candidate
-     against the adopter's actual snapshot — this direction has no
-     ambiguity, since each placeholder's value is already known before
-     the transform runs. Account for any known intentional-divergence
-     markers (see the divergence-signal check above) as expected
-     differences rather than mismatches. Report the ambiguity in the
-     resync issue itself, rather than guessing, when more than one
-     candidate ref remains equivalent after this comparison. Do not
+     adopter's own git history — the import/resync commit's diff pins
+     the exact upstream content adopted. This is the only reliable
+     source: a normally onboarded adopter's files never match any raw
+     upstream `idd-template/` tree byte-for-byte (onboarding
+     substitutes the seven placeholders with concrete values), and
+     neither a reverse- nor a forward-substitution content-match
+     reconstructs the baseline reliably either — `.github/idd/config.json`
+     does not record every placeholder value (`REPO_NAME` among them),
+     Step 3 records the Step 1B policy decisions rather than a
+     placeholder-value map, and canonical onboarding explicitly
+     permits legitimate post-substitution edits (for example adding
+     extra trusted marker actors by hand after the first replacement),
+     so the adopter's current files can differ from the as-imported
+     snapshot for reasons that have nothing to do with which ref was
+     imported. When the adopter's git history carries no such evidence,
+     report the baseline as unresolved/ambiguous in the resync issue
+     itself instead of guessing one from content alone. Do not
      construct `v<iddVersion>`
      (`.github/idd/config.json`) as the baseline without this check:
      `iddVersion` is only a coarse signal and can be stale, an adopter

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -462,14 +462,28 @@ Ask these checks:
    - **Baseline ref.** Resolve the exact tag or commit SHA actually
      imported at the adopter's prior onboarding: identify it from the
      adopter's own git history (the import/resync commit's diff pins
-     the exact upstream content adopted), or, absent that evidence,
-     the nearest upstream commit whose `idd-template/` tree matches
-     the adopter's current files content-for-content. Do not
-     construct `v<iddVersion>` (`.github/idd/config.json`) as the
-     baseline without this check: `iddVersion` is only a coarse
-     signal and can be stale, an adopter still on `0.1.0` has no
-     matching tag at all (`CHANGELOG.md` records that `0.1.0`
-     predates the tag discipline), and an adopter who pinned a raw
+     the exact upstream content adopted). Absent that evidence, do not
+     content-match the adopter's files against a raw upstream
+     `idd-template/` tree directly — onboarding substitutes the seven
+     placeholders with concrete values
+     (`buildSubstitutionPlan`/`ONBOARDING_PLACEHOLDERS` in
+     `src/scripts/idd-onboard.mts`), so a normally onboarded adopter's
+     files never match any upstream commit's tree byte-for-byte — the
+     upstream tree still carries the literal `{{...}}` tokens.
+     Reverse-substitute the adopter's own recorded
+     values (`.github/idd/config.json`, the Step 3 recorded policy
+     decisions) back to `{{...}}` token form first, account for any
+     known intentional-divergence markers (see the divergence-signal
+     check above) as expected differences rather than mismatches, and
+     only then compare the normalized tree against candidate upstream
+     commits. Report the ambiguity in the resync issue itself, rather
+     than guessing, when more than one candidate ref remains
+     equivalent after normalization. Do not construct `v<iddVersion>`
+     (`.github/idd/config.json`) as the baseline without this check:
+     `iddVersion` is only a coarse signal and can be stale, an adopter
+     still on `0.1.0` has no matching tag at all (`CHANGELOG.md`
+     records that `0.1.0` predates the tag discipline), and an adopter
+     who pinned a raw
      commit SHA at import time instead of a tag may have no
      `v<iddVersion>` tag matching what they actually imported either.
    - **Target ref.** The new release/ref the resync targets.

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -470,15 +470,27 @@ Ask these checks:
      `src/scripts/idd-onboard.mts`), so a normally onboarded adopter's
      files never match any upstream commit's tree byte-for-byte — the
      upstream tree still carries the literal `{{...}}` tokens.
-     Reverse-substitute the adopter's own recorded
-     values (`.github/idd/config.json`, the Step 3 recorded policy
-     decisions) back to `{{...}}` token form first, account for any
-     known intentional-divergence markers (see the divergence-signal
-     check above) as expected differences rather than mismatches, and
-     only then compare the normalized tree against candidate upstream
-     commits. Report the ambiguity in the resync issue itself, rather
-     than guessing, when more than one candidate ref remains
-     equivalent after normalization. Do not construct `v<iddVersion>`
+     Reverse-substitution is not a safe inverse here: a concrete
+     value (for example the literal `true` a command placeholder
+     takes when no relevant tool exists for that step, per Onboarding
+     Reference — Placeholder Values) can belong to more than one
+     placeholder, so a value found in the adopter's tree does not
+     identify a single token to restore, and a naive text replace can
+     also rewrite unrelated prose that happens to match the same
+     value. Transform each **candidate upstream tree forward**
+     instead, using the adopter's own recorded per-placeholder values
+     (`.github/idd/config.json`, the Step 3 recorded policy
+     decisions) through the same site-aware substitution the real
+     import applies (JSON sites receive an escaped value, every other
+     site takes it raw), then compare that transformed candidate
+     against the adopter's actual snapshot — this direction has no
+     ambiguity, since each placeholder's value is already known before
+     the transform runs. Account for any known intentional-divergence
+     markers (see the divergence-signal check above) as expected
+     differences rather than mismatches. Report the ambiguity in the
+     resync issue itself, rather than guessing, when more than one
+     candidate ref remains equivalent after this comparison. Do not
+     construct `v<iddVersion>`
      (`.github/idd/config.json`) as the baseline without this check:
      `iddVersion` is only a coarse signal and can be stale, an adopter
      still on `0.1.0` has no matching tag at all (`CHANGELOG.md`

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -494,17 +494,21 @@ Ask these checks:
      of change a resync issue must report, and the baseline ref's own
      manifest predates it.
    - **Token filter.** Compare each ref's own placeholder table in
-     effect at that ref (Onboarding Reference — Placeholder Values'
-     "Final placeholder meanings" table, `docs/onboarding/placeholders.md`,
-     as it read at the baseline ref and at the target ref
-     independently), not today's list applied to both — a placeholder
-     added or removed between the two refs is itself exactly the kind
-     of token-identity change this check exists to report, and reusing
-     one ref's list for the other's tree would hide that change. Never
-     match every `{{...}}`-shaped span unfiltered either way — an
-     unrestricted match also catches ordinary GitHub Actions
-     expressions such as `${{ github.token }}` in an imported workflow
-     file.
+     effect at that ref, not today's list applied to both — a
+     placeholder added or removed between the two refs is itself
+     exactly the kind of token-identity change this check exists to
+     report, and reusing one ref's list for the other's tree would
+     hide that change. At a ref from commit `e55ccd9c` (2026-05-12)
+     onward, that table is Onboarding Reference — Placeholder Values'
+     "Final placeholder meanings" table
+     (`docs/onboarding/placeholders.md`). An older ref has no such
+     file — the placeholders were documented directly inside
+     `idd-template/ONBOARDING.md`'s own "Step 1C — Collect placeholder
+     values" section instead; use that section's list as the
+     allowlist for a baseline ref that old. Never match every
+     `{{...}}`-shaped span unfiltered either way — an unrestricted
+     match also catches ordinary GitHub Actions expressions such as
+     `${{ github.token }}` in an imported workflow file.
    - **Excluded paths.** Skip `docs/onboarding/placeholders.md`,
      `docs/customization.md`, and `docs/onboarding/policy-decisions.md`
      — these deliberately keep `{{...}}` tokens literal to document

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -434,39 +434,70 @@ Ask these checks:
    Do not hard-code any single consumer's divergence-tracking mechanism.
 4. When an issue drafts a **template resync or reimport** (pulling a
    newer `idd-template/` revision into a repository that already
-   adopted IDD), consult `docs/customization.md`'s "Documentation lint
-   compatibility" section before treating `.markdownlint.yml` /
-   `.markdownlint-cli2.yaml` / `.cspell.config.yml` as unchanged — it is
-   part of the same imported bundle, so it resolves in an installed or
-   adopter context, unlike `idd-template/ONBOARDING.md`'s "Re-importing"
-   section, whose source-checkout-relative path does not exist once the
-   authoring skill runs outside this repository. Either section
-   documents the same named gap: an adopter's own rule customizations
-   for these files need a by-hand merge into the new import rather than
-   an assumed carry-forward, and `idd-onboard.mjs --import` reports a
-   `blockedOverwrites` finding instead of silently keeping a same-named
-   local file as-is. From a source checkout of `idd-skill` itself,
-   `idd-template/ONBOARDING.md`'s "Re-importing" section is the more
-   detailed maintainer-facing version of the same guidance.
+   adopted IDD), consult the **upstream target ref's** copy of
+   `docs/customization.md`'s "Documentation lint compatibility"
+   section (added 2026-08-05, commit `6ceaa6dd`) before treating
+   `.markdownlint.yml` / `.markdownlint-cli2.yaml` / `.cspell.config.yml`
+   as unchanged. `docs/customization.md` is itself part of the
+   imported core file set, so it resolves in an installed or adopter
+   context once present — but an adopter whose prior import predates
+   that commit has no such section in their own local copy yet, which
+   is exactly the named gap to document in the resync issue, not a
+   documentation-consultation failure. Either the target ref's
+   `docs/customization.md` section or, from a source checkout of
+   `idd-skill` itself, `idd-template/ONBOARDING.md`'s "Re-importing"
+   section, documents the same named gap: an adopter's own rule
+   customizations for these files need a by-hand merge into the new
+   import rather than an assumed carry-forward, and
+   `idd-onboard.mjs --import` reports a `blockedOverwrites` finding
+   instead of silently keeping a same-named local file as-is
+   (observed 2026-08-12/13 on an adopter repository, `setup.ubuntu`,
+   kurone-kito/idd-skill#2012).
 5. When drafting a resync issue's Background, run a mechanical
    placeholder diff against the **upstream `idd-skill` source
-   repository's** `idd-template/` trees at the two relevant refs — the
-   previously-adopted `v<iddVersion>` tag (`iddVersion` is recorded in
-   `.github/idd/config.json`) and the new target release/ref — never a
-   tree inside the target/adopter repository itself, which retains no
-   local `idd-template/` directory of its own once IDD is imported.
-   Compare the actual `{{...}}` token identities per changed file, not
-   only the aggregate occurrence count: a same-count one-for-one
-   placeholder swap changes what an adopter must substitute without
-   changing the count. Exclude reference-only meta-docs whose `{{...}}`
-   tokens are deliberately kept literal to document the placeholder
-   syntax itself — the `SCAN_EXCLUDED_PATHS` set in
-   `src/scripts/idd-onboard.mts` (e.g. `docs/onboarding/placeholders.md`)
-   — diffing those would misidentify literal documentation as an
-   outstanding substitution. Name any file whose placeholder tokens
-   changed, rather than asserting a file needs no placeholder
-   substitution as an unverified default (observed 2026-08-12/13 on an
-   adopter repository, #2012).
+   repository's** `idd-template/` trees at the two relevant refs —
+   never a tree inside the target/adopter repository itself, which
+   retains no local `idd-template/` directory of its own once IDD is
+   imported.
+   - **Baseline ref.** Resolve the exact tag or commit SHA actually
+     imported at the adopter's prior onboarding: identify it from the
+     adopter's own git history (the import/resync commit's diff pins
+     the exact upstream content adopted), or, absent that evidence,
+     the nearest upstream commit whose `idd-template/` tree matches
+     the adopter's current files content-for-content. Do not
+     construct `v<iddVersion>` (`.github/idd/config.json`) as the
+     baseline without this check: `iddVersion` is only a coarse
+     signal and can be stale, an adopter still on `0.1.0` has no
+     matching tag at all (`CHANGELOG.md` records that `0.1.0`
+     predates the tag discipline), and an adopter who pinned a raw
+     commit SHA at import time instead of a tag may have no
+     `v<iddVersion>` tag matching what they actually imported either.
+   - **Target ref.** The new release/ref the resync targets.
+   - **Scope.** Intersect both trees with the Step 2 "File list" core
+     file set (`idd-template/ONBOARDING.md`'s generated file-list
+     block) plus whichever optional profile artifacts the adopter
+     selected, not the complete `idd-template/` tree — a file such as
+     `idd-template/ONBOARDING.md` itself is never copied into an
+     adopter, so reporting it as changed is noise.
+   - **Token filter.** Compare only the seven placeholders documented
+     in Onboarding Reference — Placeholder Values' "Final placeholder
+     meanings" table (`docs/onboarding/placeholders.md`), not every
+     `{{...}}`-shaped span — an unrestricted match also catches
+     ordinary GitHub Actions expressions such as `${{ github.token }}`
+     in an imported workflow file.
+   - **Excluded paths.** Skip `docs/onboarding/placeholders.md`,
+     `docs/customization.md`, and `docs/onboarding/policy-decisions.md`
+     — these deliberately keep `{{...}}` tokens literal to document
+     the placeholder syntax itself, so diffing them misidentifies
+     literal documentation as an outstanding substitution.
+
+   Compare the actual token identities per changed file, not only the
+   aggregate occurrence count: a same-count one-for-one placeholder
+   swap changes what an adopter must substitute without changing the
+   count. Name any file whose placeholder tokens changed, rather than
+   asserting a file needs no placeholder substitution as an unverified
+   default (observed 2026-08-12/13 on an adopter repository,
+   `setup.ubuntu`, kurone-kito/idd-skill#2012).
 
 ## Alignment with A4.5 Suitability Gate
 

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -450,9 +450,10 @@ Ask these checks:
    customizations for these files need a by-hand merge into the new
    import rather than an assumed carry-forward, and
    `idd-onboard.mjs --import` reports a `blockedOverwrites` finding
-   instead of silently keeping a same-named local file as-is
-   (observed 2026-08-12/13 on an adopter repository, `setup.ubuntu`,
-   kurone-kito/idd-skill#2012).
+   instead of silently keeping a same-named local file as-is, unless
+   the import used `--force`, which silently overwrites the differing
+   file instead of recording it there (observed 2026-08-12/13 on an
+   adopter repository, `setup.ubuntu`, kurone-kito/idd-skill#2012).
 5. When drafting a resync issue's Background, run a mechanical
    placeholder diff against the **upstream `idd-skill` source
    repository's** `idd-template/` trees at the two relevant refs —

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -483,11 +483,16 @@ Ask these checks:
      `v<iddVersion>` tag matching what they actually imported either.
    - **Target ref.** The new release/ref the resync targets.
    - **Scope.** Intersect both trees with the Step 2 "File list" core
-     file set (`idd-template/ONBOARDING.md`'s generated file-list
-     block) plus whichever optional profile artifacts the adopter
-     selected, not the complete `idd-template/` tree — a file such as
+     file set as it reads **at the target ref**
+     (`idd-template/ONBOARDING.md`'s generated file-list block) plus
+     whichever optional profile artifacts the adopter selected, not
+     the complete `idd-template/` tree — a file such as
      `idd-template/ONBOARDING.md` itself is never copied into an
-     adopter, so reporting it as changed is noise.
+     adopter, so reporting it as changed is noise. Use the target
+     ref's manifest, not the baseline ref's: a file the target release
+     newly added to the core or a selected profile is exactly the kind
+     of change a resync issue must report, and the baseline ref's own
+     manifest predates it.
    - **Token filter.** Compare each ref's own placeholder table in
      effect at that ref (Onboarding Reference — Placeholder Values'
      "Final placeholder meanings" table, `docs/onboarding/placeholders.md`,

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -409,9 +409,10 @@ Ask these checks:
    customizations for these files need a by-hand merge into the new
    import rather than an assumed carry-forward, and
    `idd-onboard.mjs --import` reports a `blockedOverwrites` finding
-   instead of silently keeping a same-named local file as-is
-   (observed 2026-08-12/13 on an adopter repository, `setup.ubuntu`,
-   kurone-kito/idd-skill#2012).
+   instead of silently keeping a same-named local file as-is, unless
+   the import used `--force`, which silently overwrites the differing
+   file instead of recording it there (observed 2026-08-12/13 on an
+   adopter repository, `setup.ubuntu`, kurone-kito/idd-skill#2012).
 5. When drafting a resync issue's Background, run a mechanical
    placeholder diff against the **upstream `idd-skill` source
    repository's** `idd-template/` trees at the two relevant refs —

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -442,11 +442,16 @@ Ask these checks:
      `v<iddVersion>` tag matching what they actually imported either.
    - **Target ref.** The new release/ref the resync targets.
    - **Scope.** Intersect both trees with the Step 2 "File list" core
-     file set (`idd-template/ONBOARDING.md`'s generated file-list
-     block) plus whichever optional profile artifacts the adopter
-     selected, not the complete `idd-template/` tree — a file such as
+     file set as it reads **at the target ref**
+     (`idd-template/ONBOARDING.md`'s generated file-list block) plus
+     whichever optional profile artifacts the adopter selected, not
+     the complete `idd-template/` tree — a file such as
      `idd-template/ONBOARDING.md` itself is never copied into an
-     adopter, so reporting it as changed is noise.
+     adopter, so reporting it as changed is noise. Use the target
+     ref's manifest, not the baseline ref's: a file the target release
+     newly added to the core or a selected profile is exactly the kind
+     of change a resync issue must report, and the baseline ref's own
+     manifest predates it.
    - **Token filter.** Compare each ref's own placeholder table in
      effect at that ref (Onboarding Reference — Placeholder Values'
      "Final placeholder meanings" table, `docs/onboarding/placeholders.md`,

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -421,14 +421,28 @@ Ask these checks:
    - **Baseline ref.** Resolve the exact tag or commit SHA actually
      imported at the adopter's prior onboarding: identify it from the
      adopter's own git history (the import/resync commit's diff pins
-     the exact upstream content adopted), or, absent that evidence,
-     the nearest upstream commit whose `idd-template/` tree matches
-     the adopter's current files content-for-content. Do not
-     construct `v<iddVersion>` (`.github/idd/config.json`) as the
-     baseline without this check: `iddVersion` is only a coarse
-     signal and can be stale, an adopter still on `0.1.0` has no
-     matching tag at all (`CHANGELOG.md` records that `0.1.0`
-     predates the tag discipline), and an adopter who pinned a raw
+     the exact upstream content adopted). Absent that evidence, do not
+     content-match the adopter's files against a raw upstream
+     `idd-template/` tree directly — onboarding substitutes the seven
+     placeholders with concrete values
+     (`buildSubstitutionPlan`/`ONBOARDING_PLACEHOLDERS` in
+     `src/scripts/idd-onboard.mts`), so a normally onboarded adopter's
+     files never match any upstream commit's tree byte-for-byte — the
+     upstream tree still carries the literal `{{...}}` tokens.
+     Reverse-substitute the adopter's own recorded
+     values (`.github/idd/config.json`, the Step 3 recorded policy
+     decisions) back to `{{...}}` token form first, account for any
+     known intentional-divergence markers (see the divergence-signal
+     check above) as expected differences rather than mismatches, and
+     only then compare the normalized tree against candidate upstream
+     commits. Report the ambiguity in the resync issue itself, rather
+     than guessing, when more than one candidate ref remains
+     equivalent after normalization. Do not construct `v<iddVersion>`
+     (`.github/idd/config.json`) as the baseline without this check:
+     `iddVersion` is only a coarse signal and can be stale, an adopter
+     still on `0.1.0` has no matching tag at all (`CHANGELOG.md`
+     records that `0.1.0` predates the tag discipline), and an adopter
+     who pinned a raw
      commit SHA at import time instead of a tag may have no
      `v<iddVersion>` tag matching what they actually imported either.
    - **Target ref.** The new release/ref the resync targets.

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -453,17 +453,21 @@ Ask these checks:
      of change a resync issue must report, and the baseline ref's own
      manifest predates it.
    - **Token filter.** Compare each ref's own placeholder table in
-     effect at that ref (Onboarding Reference — Placeholder Values'
-     "Final placeholder meanings" table, `docs/onboarding/placeholders.md`,
-     as it read at the baseline ref and at the target ref
-     independently), not today's list applied to both — a placeholder
-     added or removed between the two refs is itself exactly the kind
-     of token-identity change this check exists to report, and reusing
-     one ref's list for the other's tree would hide that change. Never
-     match every `{{...}}`-shaped span unfiltered either way — an
-     unrestricted match also catches ordinary GitHub Actions
-     expressions such as `${{ github.token }}` in an imported workflow
-     file.
+     effect at that ref, not today's list applied to both — a
+     placeholder added or removed between the two refs is itself
+     exactly the kind of token-identity change this check exists to
+     report, and reusing one ref's list for the other's tree would
+     hide that change. At a ref from commit `e55ccd9c` (2026-05-12)
+     onward, that table is Onboarding Reference — Placeholder Values'
+     "Final placeholder meanings" table
+     (`docs/onboarding/placeholders.md`). An older ref has no such
+     file — the placeholders were documented directly inside
+     `idd-template/ONBOARDING.md`'s own "Step 1C — Collect placeholder
+     values" section instead; use that section's list as the
+     allowlist for a baseline ref that old. Never match every
+     `{{...}}`-shaped span unfiltered either way — an unrestricted
+     match also catches ordinary GitHub Actions expressions such as
+     `${{ github.token }}` in an imported workflow file.
    - **Excluded paths.** Skip `docs/onboarding/placeholders.md`,
      `docs/customization.md`, and `docs/onboarding/policy-decisions.md`
      — these deliberately keep `{{...}}` tokens literal to document

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -420,35 +420,23 @@ Ask these checks:
    imported.
    - **Baseline ref.** Resolve the exact tag or commit SHA actually
      imported at the adopter's prior onboarding: identify it from the
-     adopter's own git history (the import/resync commit's diff pins
-     the exact upstream content adopted). Absent that evidence, do not
-     content-match the adopter's files against a raw upstream
-     `idd-template/` tree directly — onboarding substitutes the seven
-     placeholders with concrete values
-     (`buildSubstitutionPlan`/`ONBOARDING_PLACEHOLDERS` in
-     `src/scripts/idd-onboard.mts`), so a normally onboarded adopter's
-     files never match any upstream commit's tree byte-for-byte — the
-     upstream tree still carries the literal `{{...}}` tokens.
-     Reverse-substitution is not a safe inverse here: a concrete
-     value (for example the literal `true` a command placeholder
-     takes when no relevant tool exists for that step, per Onboarding
-     Reference — Placeholder Values) can belong to more than one
-     placeholder, so a value found in the adopter's tree does not
-     identify a single token to restore, and a naive text replace can
-     also rewrite unrelated prose that happens to match the same
-     value. Transform each **candidate upstream tree forward**
-     instead, using the adopter's own recorded per-placeholder values
-     (`.github/idd/config.json`, the Step 3 recorded policy
-     decisions) through the same site-aware substitution the real
-     import applies (JSON sites receive an escaped value, every other
-     site takes it raw), then compare that transformed candidate
-     against the adopter's actual snapshot — this direction has no
-     ambiguity, since each placeholder's value is already known before
-     the transform runs. Account for any known intentional-divergence
-     markers (see the divergence-signal check above) as expected
-     differences rather than mismatches. Report the ambiguity in the
-     resync issue itself, rather than guessing, when more than one
-     candidate ref remains equivalent after this comparison. Do not
+     adopter's own git history — the import/resync commit's diff pins
+     the exact upstream content adopted. This is the only reliable
+     source: a normally onboarded adopter's files never match any raw
+     upstream `idd-template/` tree byte-for-byte (onboarding
+     substitutes the seven placeholders with concrete values), and
+     neither a reverse- nor a forward-substitution content-match
+     reconstructs the baseline reliably either — `.github/idd/config.json`
+     does not record every placeholder value (`REPO_NAME` among them),
+     Step 3 records the Step 1B policy decisions rather than a
+     placeholder-value map, and canonical onboarding explicitly
+     permits legitimate post-substitution edits (for example adding
+     extra trusted marker actors by hand after the first replacement),
+     so the adopter's current files can differ from the as-imported
+     snapshot for reasons that have nothing to do with which ref was
+     imported. When the adopter's git history carries no such evidence,
+     report the baseline as unresolved/ambiguous in the resync issue
+     itself instead of guessing one from content alone. Do not
      construct `v<iddVersion>`
      (`.github/idd/config.json`) as the baseline without this check:
      `iddVersion` is only a coarse signal and can be stale, an adopter

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -393,39 +393,70 @@ Ask these checks:
    Do not hard-code any single consumer's divergence-tracking mechanism.
 4. When an issue drafts a **template resync or reimport** (pulling a
    newer `idd-template/` revision into a repository that already
-   adopted IDD), consult `docs/customization.md`'s "Documentation lint
-   compatibility" section before treating `.markdownlint.yml` /
-   `.markdownlint-cli2.yaml` / `.cspell.config.yml` as unchanged — it is
-   part of the same imported bundle, so it resolves in an installed or
-   adopter context, unlike `idd-template/ONBOARDING.md`'s "Re-importing"
-   section, whose source-checkout-relative path does not exist once the
-   authoring skill runs outside this repository. Either section
-   documents the same named gap: an adopter's own rule customizations
-   for these files need a by-hand merge into the new import rather than
-   an assumed carry-forward, and `idd-onboard.mjs --import` reports a
-   `blockedOverwrites` finding instead of silently keeping a same-named
-   local file as-is. From a source checkout of `idd-skill` itself,
-   `idd-template/ONBOARDING.md`'s "Re-importing" section is the more
-   detailed maintainer-facing version of the same guidance.
+   adopted IDD), consult the **upstream target ref's** copy of
+   `docs/customization.md`'s "Documentation lint compatibility"
+   section (added 2026-08-05, commit `6ceaa6dd`) before treating
+   `.markdownlint.yml` / `.markdownlint-cli2.yaml` / `.cspell.config.yml`
+   as unchanged. `docs/customization.md` is itself part of the
+   imported core file set, so it resolves in an installed or adopter
+   context once present — but an adopter whose prior import predates
+   that commit has no such section in their own local copy yet, which
+   is exactly the named gap to document in the resync issue, not a
+   documentation-consultation failure. Either the target ref's
+   `docs/customization.md` section or, from a source checkout of
+   `idd-skill` itself, `idd-template/ONBOARDING.md`'s "Re-importing"
+   section, documents the same named gap: an adopter's own rule
+   customizations for these files need a by-hand merge into the new
+   import rather than an assumed carry-forward, and
+   `idd-onboard.mjs --import` reports a `blockedOverwrites` finding
+   instead of silently keeping a same-named local file as-is
+   (observed 2026-08-12/13 on an adopter repository, `setup.ubuntu`,
+   kurone-kito/idd-skill#2012).
 5. When drafting a resync issue's Background, run a mechanical
    placeholder diff against the **upstream `idd-skill` source
-   repository's** `idd-template/` trees at the two relevant refs — the
-   previously-adopted `v<iddVersion>` tag (`iddVersion` is recorded in
-   `.github/idd/config.json`) and the new target release/ref — never a
-   tree inside the target/adopter repository itself, which retains no
-   local `idd-template/` directory of its own once IDD is imported.
-   Compare the actual `{{...}}` token identities per changed file, not
-   only the aggregate occurrence count: a same-count one-for-one
-   placeholder swap changes what an adopter must substitute without
-   changing the count. Exclude reference-only meta-docs whose `{{...}}`
-   tokens are deliberately kept literal to document the placeholder
-   syntax itself — the `SCAN_EXCLUDED_PATHS` set in
-   `src/scripts/idd-onboard.mts` (e.g. `docs/onboarding/placeholders.md`)
-   — diffing those would misidentify literal documentation as an
-   outstanding substitution. Name any file whose placeholder tokens
-   changed, rather than asserting a file needs no placeholder
-   substitution as an unverified default (observed 2026-08-12/13 on an
-   adopter repository, #2012).
+   repository's** `idd-template/` trees at the two relevant refs —
+   never a tree inside the target/adopter repository itself, which
+   retains no local `idd-template/` directory of its own once IDD is
+   imported.
+   - **Baseline ref.** Resolve the exact tag or commit SHA actually
+     imported at the adopter's prior onboarding: identify it from the
+     adopter's own git history (the import/resync commit's diff pins
+     the exact upstream content adopted), or, absent that evidence,
+     the nearest upstream commit whose `idd-template/` tree matches
+     the adopter's current files content-for-content. Do not
+     construct `v<iddVersion>` (`.github/idd/config.json`) as the
+     baseline without this check: `iddVersion` is only a coarse
+     signal and can be stale, an adopter still on `0.1.0` has no
+     matching tag at all (`CHANGELOG.md` records that `0.1.0`
+     predates the tag discipline), and an adopter who pinned a raw
+     commit SHA at import time instead of a tag may have no
+     `v<iddVersion>` tag matching what they actually imported either.
+   - **Target ref.** The new release/ref the resync targets.
+   - **Scope.** Intersect both trees with the Step 2 "File list" core
+     file set (`idd-template/ONBOARDING.md`'s generated file-list
+     block) plus whichever optional profile artifacts the adopter
+     selected, not the complete `idd-template/` tree — a file such as
+     `idd-template/ONBOARDING.md` itself is never copied into an
+     adopter, so reporting it as changed is noise.
+   - **Token filter.** Compare only the seven placeholders documented
+     in Onboarding Reference — Placeholder Values' "Final placeholder
+     meanings" table (`docs/onboarding/placeholders.md`), not every
+     `{{...}}`-shaped span — an unrestricted match also catches
+     ordinary GitHub Actions expressions such as `${{ github.token }}`
+     in an imported workflow file.
+   - **Excluded paths.** Skip `docs/onboarding/placeholders.md`,
+     `docs/customization.md`, and `docs/onboarding/policy-decisions.md`
+     — these deliberately keep `{{...}}` tokens literal to document
+     the placeholder syntax itself, so diffing them misidentifies
+     literal documentation as an outstanding substitution.
+
+   Compare the actual token identities per changed file, not only the
+   aggregate occurrence count: a same-count one-for-one placeholder
+   swap changes what an adopter must substitute without changing the
+   count. Name any file whose placeholder tokens changed, rather than
+   asserting a file needs no placeholder substitution as an unverified
+   default (observed 2026-08-12/13 on an adopter repository,
+   `setup.ubuntu`, kurone-kito/idd-skill#2012).
 
 ## Dependency minimization
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -418,26 +418,21 @@ Ask these checks:
    never a tree inside the target/adopter repository itself, which
    retains no local `idd-template/` directory of its own once IDD is
    imported.
-   - **Baseline ref.** Resolve the exact tag or commit SHA actually
-     imported at the adopter's prior onboarding: identify it from the
-     adopter's own git history — the import/resync commit's diff pins
-     the exact upstream content adopted. This is the only reliable
-     source: a normally onboarded adopter's files never match any raw
-     upstream `idd-template/` tree byte-for-byte (onboarding
-     substitutes the seven placeholders with concrete values), and
-     neither a reverse- nor a forward-substitution content-match
-     reconstructs the baseline reliably either — `.github/idd/config.json`
-     does not record every placeholder value (`REPO_NAME` among them),
-     Step 3 records the Step 1B policy decisions rather than a
-     placeholder-value map, and canonical onboarding explicitly
-     permits legitimate post-substitution edits (for example adding
-     extra trusted marker actors by hand after the first replacement),
-     so the adopter's current files can differ from the as-imported
-     snapshot for reasons that have nothing to do with which ref was
-     imported. When the adopter's git history carries no such evidence,
-     report the baseline as unresolved/ambiguous in the resync issue
-     itself instead of guessing one from content alone. Do not
-     construct `v<iddVersion>`
+   - **Baseline ref.** Use the exact tag or commit SHA actually
+     imported at the adopter's prior onboarding when it is explicitly
+     recorded (for example in the original onboarding PR/commit
+     message) or when the operator can confirm it directly. Do not
+     infer it from the adopter's current file content: neither a diff
+     against the import commit nor a reverse- or forward-substitution
+     content-match against a candidate upstream tree reliably pins a
+     single ref — onboarding substitutes placeholder values and
+     permits legitimate post-substitution edits, an import commit's
+     diff itself only records the already-transformed adopter
+     snapshot, and more than one upstream commit can plausibly yield
+     the same imported subset. When no explicit record or operator
+     confirmation is available, report the baseline as
+     unresolved/ambiguous in the resync issue itself rather than
+     guessing one from content alone. Do not construct `v<iddVersion>`
      (`.github/idd/config.json`) as the baseline without this check:
      `iddVersion` is only a coarse signal and can be stale, an adopter
      still on `0.1.0` has no matching tag at all (`CHANGELOG.md`
@@ -452,12 +447,18 @@ Ask these checks:
      selected, not the complete `idd-template/` tree — a file such as
      `idd-template/ONBOARDING.md` itself is never copied into an
      adopter, so reporting it as changed is noise.
-   - **Token filter.** Compare only the seven placeholders documented
-     in Onboarding Reference — Placeholder Values' "Final placeholder
-     meanings" table (`docs/onboarding/placeholders.md`), not every
-     `{{...}}`-shaped span — an unrestricted match also catches
-     ordinary GitHub Actions expressions such as `${{ github.token }}`
-     in an imported workflow file.
+   - **Token filter.** Compare each ref's own placeholder table in
+     effect at that ref (Onboarding Reference — Placeholder Values'
+     "Final placeholder meanings" table, `docs/onboarding/placeholders.md`,
+     as it read at the baseline ref and at the target ref
+     independently), not today's list applied to both — a placeholder
+     added or removed between the two refs is itself exactly the kind
+     of token-identity change this check exists to report, and reusing
+     one ref's list for the other's tree would hide that change. Never
+     match every `{{...}}`-shaped span unfiltered either way — an
+     unrestricted match also catches ordinary GitHub Actions
+     expressions such as `${{ github.token }}` in an imported workflow
+     file.
    - **Excluded paths.** Skip `docs/onboarding/placeholders.md`,
      `docs/customization.md`, and `docs/onboarding/policy-decisions.md`
      — these deliberately keep `{{...}}` tokens literal to document

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -429,15 +429,27 @@ Ask these checks:
      `src/scripts/idd-onboard.mts`), so a normally onboarded adopter's
      files never match any upstream commit's tree byte-for-byte — the
      upstream tree still carries the literal `{{...}}` tokens.
-     Reverse-substitute the adopter's own recorded
-     values (`.github/idd/config.json`, the Step 3 recorded policy
-     decisions) back to `{{...}}` token form first, account for any
-     known intentional-divergence markers (see the divergence-signal
-     check above) as expected differences rather than mismatches, and
-     only then compare the normalized tree against candidate upstream
-     commits. Report the ambiguity in the resync issue itself, rather
-     than guessing, when more than one candidate ref remains
-     equivalent after normalization. Do not construct `v<iddVersion>`
+     Reverse-substitution is not a safe inverse here: a concrete
+     value (for example the literal `true` a command placeholder
+     takes when no relevant tool exists for that step, per Onboarding
+     Reference — Placeholder Values) can belong to more than one
+     placeholder, so a value found in the adopter's tree does not
+     identify a single token to restore, and a naive text replace can
+     also rewrite unrelated prose that happens to match the same
+     value. Transform each **candidate upstream tree forward**
+     instead, using the adopter's own recorded per-placeholder values
+     (`.github/idd/config.json`, the Step 3 recorded policy
+     decisions) through the same site-aware substitution the real
+     import applies (JSON sites receive an escaped value, every other
+     site takes it raw), then compare that transformed candidate
+     against the adopter's actual snapshot — this direction has no
+     ambiguity, since each placeholder's value is already known before
+     the transform runs. Account for any known intentional-divergence
+     markers (see the divergence-signal check above) as expected
+     differences rather than mismatches. Report the ambiguity in the
+     resync issue itself, rather than guessing, when more than one
+     candidate ref remains equivalent after this comparison. Do not
+     construct `v<iddVersion>`
      (`.github/idd/config.json`) as the baseline without this check:
      `iddVersion` is only a coarse signal and can be stale, an adopter
      still on `0.1.0` has no matching tag at all (`CHANGELOG.md`


### PR DESCRIPTION
# Summary

Reworked items 4-5 of `skills/issue-authoring/references/contract.md`'s
"Codebase-fidelity validation" checklist (and its manual mirror
`docs/issue-authoring-skill.md`) to close six verified gaps deferred
from PR #2027 (closing #2012):

1. Item 5's diff scope covered the complete upstream `idd-template/`
   tree instead of the Step 2 core/profile file set an adopter
   actually imports.
2. Item 5's unrestricted `{{...}}` token match also caught ordinary
   GitHub Actions expressions such as `${{ github.token }}`.
3. Item 5's exclusion-list guidance referenced a source-checkout-only
   TypeScript file path (`SCAN_EXCLUDED_PATHS` in
   `src/scripts/idd-onboard.mts`) -- now the three paths are enumerated
   directly, all of which are themselves part of the distributed core
   file set.
4. Item 4's cross-reference to `docs/customization.md`'s "Documentation
   lint compatibility" section did not account for an adopter whose
   prior import predates that section (added 2026-08-05, commit
   `6ceaa6dd`).
5. Item 5's diff baseline constructed an unreliable `v<iddVersion>`
   string instead of resolving the exact ref actually imported --
   broken both for an adopter on `0.1.0` (predates the tag discipline)
   and for one who pinned a raw commit SHA instead of a tag.
6. Item 4 carried no incident citation, unlike item 5's existing one.

## Linked issue

Closes #2031

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

All six gaps were verified against the codebase before recording --
grepped `buildSubstitutionPlan`/`ONBOARDING_PLACEHOLDERS`/
`SCAN_EXCLUDED_PATHS` in `src/scripts/idd-onboard.mts`, confirmed
commit `6ceaa6dd`'s date, confirmed `CHANGELOG.md`'s 0.1.0/tag-gap
note, and confirmed issue #2012's Background covers both the
placeholder-diff and lint-config-drift incidents this issue's item 4
citation now also carries.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable) -- not applicable, docs-only change to skill reference bundles

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated resynchronization guidance to require checking target-reference documentation-lint compatibility.
  - Added clearer instructions for verifying baseline and target references before comparison.
  - Defined manifest-based file scope, reference-specific placeholder rules, and excluded documentation paths.
  - Added requirements for reporting per-file placeholder changes, adopter-specific customizations, and blocked overwrites.
  - Clarified fallback behavior when baseline information is unresolved or ambiguous.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->