### PR TITLE
fix(pre-merge-readiness): gate coveredByWaiver on waivers.mode

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -695,9 +695,15 @@ The adopted helper boundaries are intentionally narrow:
   unreplied comments, reviewer states, advisory state, CI, claim
   validation, and `waiverEvidence` (parsed external-check waiver comments
   classified as `valid`, `expired`, `wrongHead`, `wrongClaim`,
-  `unauthorized`, `malformed`, or `notConfigured` — the last for a valid
-  waiver naming a check the policy never declared waivable in
-  `ciGate.externalChecks.waivable`; only a `valid` waiver for a
+  `unauthorized`, `malformed`, `notConfigured`, or `modeDisabled` —
+  `notConfigured` for a valid waiver naming a check the policy never
+  declared waivable in `ciGate.externalChecks.waivable`, `modeDisabled`
+  (`#2046`) for an otherwise-valid, configured-waivable waiver while
+  `ciGate.externalCheckWaivers.mode` is not `maintainer-authorized`
+  (schema default: `disabled`) — mirroring `advisory-convergence.mjs`'s
+  own mode guard, so a `waivable` list left over from a prior
+  `maintainer-authorized` configuration can never make this gate report
+  a check covered on its own; only a `valid` waiver for a
   configured-waivable check is reported with `coveredByWaiver: true` and
   treated as passing by the CI gate)
 - (`#2021`) a `valid` waiver for the `idd-advisory-convergence` selector

--- a/fixtures/pre-merge-readiness/ack-only-current.json
+++ b/fixtures/pre-merge-readiness/ack-only-current.json
@@ -339,7 +339,8 @@
       "wrongClaim": [],
       "unauthorized": [],
       "malformed": [],
-      "notConfigured": []
+      "notConfigured": [],
+      "modeDisabled": []
     },
     "advisoryConvergenceWaiverPrecondition": {
       "checkSelector": "idd-advisory-convergence",

--- a/fixtures/pre-merge-readiness/changes-requested.json
+++ b/fixtures/pre-merge-readiness/changes-requested.json
@@ -273,7 +273,8 @@
       "wrongClaim": [],
       "unauthorized": [],
       "malformed": [],
-      "notConfigured": []
+      "notConfigured": [],
+      "modeDisabled": []
     },
     "advisoryConvergenceWaiverPrecondition": {
       "checkSelector": "idd-advisory-convergence",

--- a/fixtures/pre-merge-readiness/ci-not-ready.json
+++ b/fixtures/pre-merge-readiness/ci-not-ready.json
@@ -277,7 +277,8 @@
       "wrongClaim": [],
       "unauthorized": [],
       "malformed": [],
-      "notConfigured": []
+      "notConfigured": [],
+      "modeDisabled": []
     },
     "advisoryConvergenceWaiverPrecondition": {
       "checkSelector": "idd-advisory-convergence",

--- a/fixtures/pre-merge-readiness/claim-lost.json
+++ b/fixtures/pre-merge-readiness/claim-lost.json
@@ -301,7 +301,8 @@
       "wrongClaim": [],
       "unauthorized": [],
       "malformed": [],
-      "notConfigured": []
+      "notConfigured": [],
+      "modeDisabled": []
     },
     "advisoryConvergenceWaiverPrecondition": {
       "checkSelector": "idd-advisory-convergence",

--- a/fixtures/pre-merge-readiness/clean.json
+++ b/fixtures/pre-merge-readiness/clean.json
@@ -301,7 +301,8 @@
       "wrongClaim": [],
       "unauthorized": [],
       "malformed": [],
-      "notConfigured": []
+      "notConfigured": [],
+      "modeDisabled": []
     },
     "advisoryConvergenceWaiverPrecondition": {
       "checkSelector": "idd-advisory-convergence",

--- a/fixtures/pre-merge-readiness/stale-watermark.json
+++ b/fixtures/pre-merge-readiness/stale-watermark.json
@@ -301,7 +301,8 @@
       "wrongClaim": [],
       "unauthorized": [],
       "malformed": [],
-      "notConfigured": []
+      "notConfigured": [],
+      "modeDisabled": []
     },
     "advisoryConvergenceWaiverPrecondition": {
       "checkSelector": "idd-advisory-convergence",

--- a/fixtures/pre-merge-readiness/unreplied-comment.json
+++ b/fixtures/pre-merge-readiness/unreplied-comment.json
@@ -287,7 +287,8 @@
       "wrongClaim": [],
       "unauthorized": [],
       "malformed": [],
-      "notConfigured": []
+      "notConfigured": [],
+      "modeDisabled": []
     },
     "advisoryConvergenceWaiverPrecondition": {
       "checkSelector": "idd-advisory-convergence",

--- a/fixtures/pre-merge-readiness/unresolved-thread.json
+++ b/fixtures/pre-merge-readiness/unresolved-thread.json
@@ -301,7 +301,8 @@
       "wrongClaim": [],
       "unauthorized": [],
       "malformed": [],
-      "notConfigured": []
+      "notConfigured": [],
+      "modeDisabled": []
     },
     "advisoryConvergenceWaiverPrecondition": {
       "checkSelector": "idd-advisory-convergence",

--- a/fixtures/schemas/pre-merge-readiness.valid.json
+++ b/fixtures/schemas/pre-merge-readiness.valid.json
@@ -180,7 +180,8 @@
     "wrongClaim": [],
     "unauthorized": [],
     "malformed": [],
-    "notConfigured": []
+    "notConfigured": [],
+    "modeDisabled": []
   },
   "advisoryConvergenceWaiverPrecondition": {
     "checkSelector": "idd-advisory-convergence",

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -695,9 +695,15 @@ The adopted helper boundaries are intentionally narrow:
   unreplied comments, reviewer states, advisory state, CI, claim
   validation, and `waiverEvidence` (parsed external-check waiver comments
   classified as `valid`, `expired`, `wrongHead`, `wrongClaim`,
-  `unauthorized`, `malformed`, or `notConfigured` — the last for a valid
-  waiver naming a check the policy never declared waivable in
-  `ciGate.externalChecks.waivable`; only a `valid` waiver for a
+  `unauthorized`, `malformed`, `notConfigured`, or `modeDisabled` —
+  `notConfigured` for a valid waiver naming a check the policy never
+  declared waivable in `ciGate.externalChecks.waivable`, `modeDisabled`
+  (`#2046`) for an otherwise-valid, configured-waivable waiver while
+  `ciGate.externalCheckWaivers.mode` is not `maintainer-authorized`
+  (schema default: `disabled`) — mirroring `advisory-convergence.mjs`'s
+  own mode guard, so a `waivable` list left over from a prior
+  `maintainer-authorized` configuration can never make this gate report
+  a check covered on its own; only a `valid` waiver for a
   configured-waivable check is reported with `coveredByWaiver: true` and
   treated as passing by the CI gate)
 - (`#2021`) a `valid` waiver for the `idd-advisory-convergence` selector

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -1226,7 +1226,8 @@
         "wrongClaim",
         "unauthorized",
         "malformed",
-        "notConfigured"
+        "notConfigured",
+        "modeDisabled"
       ],
       "additionalProperties": false,
       "properties": {
@@ -1395,6 +1396,33 @@
         "notConfigured": {
           "type": "array",
           "description": "Waivers that passed every validity check but name a check the policy never declared waivable; excluded from valid and never fold a check into requiredChecksPassing.",
+          "items": {
+            "type": "object",
+            "required": [
+              "authorLogin",
+              "checkSelector",
+              "expiresAt"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "authorLogin": {
+                "type": "string",
+                "description": "Login of the waiver's author, normalized to lowercase."
+              },
+              "checkSelector": {
+                "type": "string",
+                "description": "Check-name selector the waiver targets."
+              },
+              "expiresAt": {
+                "type": "string",
+                "description": "Waiver's recorded expiry timestamp."
+              }
+            }
+          }
+        },
+        "modeDisabled": {
+          "type": "array",
+          "description": "#2046: waivers that passed every validity and waivable-selector check but the policy's ciGate.externalCheckWaivers.mode is not maintainer-authorized; excluded from valid and never fold a check into requiredChecksPassing, mirroring advisory-convergence.mts's own mode guard.",
           "items": {
             "type": "object",
             "required": [

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -1177,9 +1177,10 @@ function readExternalCheckWaiverMaxValidity() {
 // Configured external-check waiver mode (`ciGate.externalCheckWaivers.mode`,
 // #2046). `mode` gates the WHOLE waiver mechanism independent of the
 // `waivable` selector list -- an absent or unreadable config falls back to
-// `normalizePolicyConfig`'s own schema default (`disabled`), matching
-// `advisory-convergence.mts`'s own guard rather than leaving an
-// otherwise-valid waiver uncovered by this check alone.
+// `normalizePolicyConfig`'s own schema default (`disabled`), the fail-closed
+// choice: an unreadable config can never make this check wrongly report an
+// otherwise-valid waiver as covered when the real required check would not
+// honor it, mirroring `advisory-convergence.mts`'s own fail-closed guard.
 function readExternalCheckWaiverMode() {
   try {
     return normalizePolicyConfig(

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -369,6 +369,7 @@ export function collectPreMergeReadiness(argv) {
   const forcedHandoffPermissionCache = new Map();
   const waivableCheckSelectors = readWaivableCheckSelectors();
   const externalCheckWaiverMaxValidity = readExternalCheckWaiverMaxValidity();
+  const externalCheckWaiverMode = readExternalCheckWaiverMode();
   const trustSourcePinnedRequiredChecks = readTrustSourcePinnedRequiredChecks();
   const staleAgeMs = readClaimStaleAgeMs();
   const now = args.now || new Date().toISOString().replace('.000Z', 'Z');
@@ -479,6 +480,7 @@ export function collectPreMergeReadiness(argv) {
       advisoryConvergenceDeadlineMinutes,
       waivableCheckSelectors,
       externalCheckWaiverMaxValidity,
+      externalCheckWaiverMode,
       trustSourcePinnedRequiredChecks,
       staleAgeMs,
       forcedHandoffEnabled,
@@ -1170,6 +1172,21 @@ function readExternalCheckWaiverMaxValidity() {
     ).ciGate.externalCheckWaivers.maxValidity;
   } catch {
     return 'PT24H';
+  }
+}
+// Configured external-check waiver mode (`ciGate.externalCheckWaivers.mode`,
+// #2046). `mode` gates the WHOLE waiver mechanism independent of the
+// `waivable` selector list -- an absent or unreadable config falls back to
+// `normalizePolicyConfig`'s own schema default (`disabled`), matching
+// `advisory-convergence.mts`'s own guard rather than leaving an
+// otherwise-valid waiver uncovered by this check alone.
+function readExternalCheckWaiverMode() {
+  try {
+    return normalizePolicyConfig(
+      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
+    ).ciGate.externalCheckWaivers.mode;
+  } catch {
+    return 'disabled';
   }
 }
 // Configured claim-staleness window (`claimTiming.staleAge`, #1310), parsed

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -152,6 +152,7 @@ export function summarizeExternalCheckWaivers(
     now = '',
     waivableSelectors = null,
     maxValidity = '',
+    mode = '',
   } = {},
 ) {
   const trustedSet = new Set(normalizeTrustedMarkerLogins(trustedMarkerLogins));
@@ -166,6 +167,11 @@ export function summarizeExternalCheckWaivers(
   const unauthorized = [];
   const malformed = [];
   const notConfigured = [];
+  const modeDisabled = [];
+  // An empty `mode` leaves this gate off (legacy/unit-caller default); a
+  // non-empty value must equal `maintainer-authorized` exactly, mirroring
+  // `advisory-convergence.mts`'s own guard.
+  const modeGateOpen = mode === '' || mode === 'maintainer-authorized';
   for (const comment of comments ?? []) {
     const body = String(comment?.body ?? '');
     // Prefilter on a marker-start, case-insensitive match aligned with
@@ -272,6 +278,21 @@ export function summarizeExternalCheckWaivers(
       });
       continue;
     }
+    // #2046: `mode` gates the whole waiver mechanism, independent of the
+    // `waivable` selector list -- an otherwise-valid, correctly-configured
+    // waiver must never count while the policy's
+    // `ciGate.externalCheckWaivers.mode` is not `maintainer-authorized`
+    // (schema default: `disabled`), matching `advisory-convergence.mts`'s
+    // own required check, which never even evaluates waiver evidence
+    // outside that mode.
+    if (!modeGateOpen) {
+      modeDisabled.push({
+        authorLogin,
+        checkSelector: parsed.checkSelector,
+        expiresAt: parsed.expiresAt,
+      });
+      continue;
+    }
     valid.push({
       authorLogin,
       checkSelector: parsed.checkSelector,
@@ -287,6 +308,7 @@ export function summarizeExternalCheckWaivers(
     unauthorized,
     malformed,
     notConfigured,
+    modeDisabled,
   };
 }
 export function findLiveStatusDigestComments(comments) {
@@ -4912,6 +4934,7 @@ export function buildPreMergeReadinessSummary(
     now,
     waivableSelectors: waivableCheckSelectors,
     maxValidity: options.externalCheckWaiverMaxValidity ?? '',
+    mode: options.externalCheckWaiverMode ?? '',
   });
   // #1570: the caller-supplied terminal-unavailability verdict, reused below
   // both for the dedicated `copilot-terminal-unavailable` blocker and (#2021)

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -1522,9 +1522,10 @@ function readExternalCheckWaiverMaxValidity(): string {
 // Configured external-check waiver mode (`ciGate.externalCheckWaivers.mode`,
 // #2046). `mode` gates the WHOLE waiver mechanism independent of the
 // `waivable` selector list -- an absent or unreadable config falls back to
-// `normalizePolicyConfig`'s own schema default (`disabled`), matching
-// `advisory-convergence.mts`'s own guard rather than leaving an
-// otherwise-valid waiver uncovered by this check alone.
+// `normalizePolicyConfig`'s own schema default (`disabled`), the fail-closed
+// choice: an unreadable config can never make this check wrongly report an
+// otherwise-valid waiver as covered when the real required check would not
+// honor it, mirroring `advisory-convergence.mts`'s own fail-closed guard.
 function readExternalCheckWaiverMode(): string {
   try {
     return normalizePolicyConfig(

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -588,6 +588,7 @@ export function collectPreMergeReadiness(
   const forcedHandoffPermissionCache: CollaboratorPermissionCache = new Map();
   const waivableCheckSelectors = readWaivableCheckSelectors();
   const externalCheckWaiverMaxValidity = readExternalCheckWaiverMaxValidity();
+  const externalCheckWaiverMode = readExternalCheckWaiverMode();
   const trustSourcePinnedRequiredChecks = readTrustSourcePinnedRequiredChecks();
   const staleAgeMs = readClaimStaleAgeMs();
   const now = args.now || new Date().toISOString().replace('.000Z', 'Z');
@@ -701,6 +702,7 @@ export function collectPreMergeReadiness(
       advisoryConvergenceDeadlineMinutes,
       waivableCheckSelectors,
       externalCheckWaiverMaxValidity,
+      externalCheckWaiverMode,
       trustSourcePinnedRequiredChecks,
       staleAgeMs,
       forcedHandoffEnabled,
@@ -1514,6 +1516,22 @@ function readExternalCheckWaiverMaxValidity(): string {
     ).ciGate.externalCheckWaivers.maxValidity;
   } catch {
     return 'PT24H';
+  }
+}
+
+// Configured external-check waiver mode (`ciGate.externalCheckWaivers.mode`,
+// #2046). `mode` gates the WHOLE waiver mechanism independent of the
+// `waivable` selector list -- an absent or unreadable config falls back to
+// `normalizePolicyConfig`'s own schema default (`disabled`), matching
+// `advisory-convergence.mts`'s own guard rather than leaving an
+// otherwise-valid waiver uncovered by this check alone.
+function readExternalCheckWaiverMode(): string {
+  try {
+    return normalizePolicyConfig(
+      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
+    ).ciGate.externalCheckWaivers.mode;
+  } catch {
+    return 'disabled';
   }
 }
 

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -346,6 +346,18 @@ export interface ExternalCheckWaiverEvidence {
     checkSelector: string;
     expiresAt: string;
   }[];
+  /**
+   * Waivers that passed every validity and waivable-selector check but the
+   * policy's `ciGate.externalCheckWaivers.mode` is not `maintainer-authorized`
+   * (#2046); they are excluded from `valid` and never fold a check into
+   * `requiredChecksPassing`, mirroring `advisory-convergence.mts`'s own
+   * mode guard.
+   */
+  modeDisabled: {
+    authorLogin: string;
+    checkSelector: string;
+    expiresAt: string;
+  }[];
 }
 
 /** Classification outcome for a single review thread at the gate. */
@@ -633,6 +645,7 @@ export function summarizeExternalCheckWaivers(
     now = '',
     waivableSelectors = null,
     maxValidity = '',
+    mode = '',
   }: {
     prHeadSha?: string;
     activeClaimId?: unknown;
@@ -644,6 +657,14 @@ export function summarizeExternalCheckWaivers(
     // direct callers that omit it keep the legacy behavior; the F2/F3 gate
     // always threads the policy value (default `PT24H`).
     maxValidity?: string;
+    // Configured `ciGate.externalCheckWaivers.mode` (#2046). An empty value
+    // (direct callers that omit it) leaves the mode gate off, matching the
+    // pre-#2046 legacy behavior; the F2/F3 gate always threads the policy
+    // value so an otherwise-valid waiver never counts while the schema
+    // default (`disabled`) is in effect, mirroring
+    // `advisory-convergence.mts`'s own `waiverMode === 'maintainer-authorized'`
+    // guard.
+    mode?: string;
   } = {},
 ): ExternalCheckWaiverEvidence {
   const trustedSet = new Set(normalizeTrustedMarkerLogins(trustedMarkerLogins));
@@ -659,6 +680,11 @@ export function summarizeExternalCheckWaivers(
   const unauthorized: ExternalCheckWaiverEvidence['unauthorized'] = [];
   const malformed: ExternalCheckWaiverEvidence['malformed'] = [];
   const notConfigured: ExternalCheckWaiverEvidence['notConfigured'] = [];
+  const modeDisabled: ExternalCheckWaiverEvidence['modeDisabled'] = [];
+  // An empty `mode` leaves this gate off (legacy/unit-caller default); a
+  // non-empty value must equal `maintainer-authorized` exactly, mirroring
+  // `advisory-convergence.mts`'s own guard.
+  const modeGateOpen = mode === '' || mode === 'maintainer-authorized';
 
   for (const comment of comments ?? []) {
     const body = String(comment?.body ?? '');
@@ -775,6 +801,22 @@ export function summarizeExternalCheckWaivers(
       continue;
     }
 
+    // #2046: `mode` gates the whole waiver mechanism, independent of the
+    // `waivable` selector list -- an otherwise-valid, correctly-configured
+    // waiver must never count while the policy's
+    // `ciGate.externalCheckWaivers.mode` is not `maintainer-authorized`
+    // (schema default: `disabled`), matching `advisory-convergence.mts`'s
+    // own required check, which never even evaluates waiver evidence
+    // outside that mode.
+    if (!modeGateOpen) {
+      modeDisabled.push({
+        authorLogin,
+        checkSelector: parsed.checkSelector,
+        expiresAt: parsed.expiresAt,
+      });
+      continue;
+    }
+
     valid.push({
       authorLogin,
       checkSelector: parsed.checkSelector,
@@ -791,6 +833,7 @@ export function summarizeExternalCheckWaivers(
     unauthorized,
     malformed,
     notConfigured,
+    modeDisabled,
   };
 }
 
@@ -6074,6 +6117,11 @@ export function buildPreMergeReadinessSummary(
     // (window check off); `collectPreMergeReadiness` always sources the policy
     // value (default `PT24H`).
     externalCheckWaiverMaxValidity?: string;
+    // Configured `ciGate.externalCheckWaivers.mode` (#2046), threaded to the
+    // consume-side mode gate. Omitted by unit callers (gate off, unchanged
+    // pre-#2046 behavior); `collectPreMergeReadiness` always sources the
+    // policy value (default `disabled`).
+    externalCheckWaiverMode?: string;
     // Configured `claimTiming.staleAge` (#1310), parsed to milliseconds and
     // threaded to the write-gate claim resolver below so the F2/F3 merge gate
     // honors it instead of the hardcoded 24h `isStaleAt` default. Omitted by
@@ -6250,6 +6298,7 @@ export function buildPreMergeReadinessSummary(
     now,
     waivableSelectors: waivableCheckSelectors,
     maxValidity: options.externalCheckWaiverMaxValidity ?? '',
+    mode: options.externalCheckWaiverMode ?? '',
   });
 
   // #1570: the caller-supplied terminal-unavailability verdict, reused below

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -4321,6 +4321,7 @@ test('summarizeExternalCheckWaivers: empty comments returns all-empty evidence',
     unauthorized: [],
     malformed: [],
     notConfigured: [],
+    modeDisabled: [],
   });
 });
 
@@ -4869,6 +4870,7 @@ test('summarizeExternalCheckWaivers: non-waiver comments are skipped without err
     unauthorized: [],
     malformed: [],
     notConfigured: [],
+    modeDisabled: [],
   });
 });
 
@@ -4933,6 +4935,56 @@ test('summarizeExternalCheckWaivers: validity-passing waiver for a non-waivable 
   assert.equal(result.notConfigured.length, 1);
   assert.equal(result.notConfigured[0].checkSelector, 'CodeRabbit');
   assert.equal(result.notConfigured[0].authorLogin, 'kurone-kito');
+});
+
+test('summarizeExternalCheckWaivers: an otherwise-valid, configured-waivable waiver goes to modeDisabled when mode is not maintainer-authorized (#2046)', () => {
+  const head = 'e'.repeat(40);
+  const body = makeWaiverComment({ claimId: 'claim-123', headSha: head });
+  const result = summarizeExternalCheckWaivers(
+    [
+      {
+        body,
+        author: { login: 'kurone-kito' },
+        createdAt: '2026-05-17T00:00:00Z',
+      },
+    ],
+    {
+      prHeadSha: head,
+      activeClaimId: 'claim-123',
+      trustedMarkerLogins: ['kurone-kito'],
+      now: '2026-05-17T00:00:00Z',
+      waivableSelectors: [{ selector: 'CodeRabbit', matchMode: 'exact' }],
+      mode: 'disabled',
+    },
+  );
+  assert.equal(result.valid.length, 0);
+  assert.equal(result.notConfigured.length, 0);
+  assert.equal(result.modeDisabled.length, 1);
+  assert.equal(result.modeDisabled[0].checkSelector, 'CodeRabbit');
+  assert.equal(result.modeDisabled[0].authorLogin, 'kurone-kito');
+});
+
+test('summarizeExternalCheckWaivers: an empty mode leaves the mode gate off (legacy behavior for unmigrated callers)', () => {
+  const head = 'e'.repeat(40);
+  const body = makeWaiverComment({ claimId: 'claim-123', headSha: head });
+  const result = summarizeExternalCheckWaivers(
+    [
+      {
+        body,
+        author: { login: 'kurone-kito' },
+        createdAt: '2026-05-17T00:00:00Z',
+      },
+    ],
+    {
+      prHeadSha: head,
+      activeClaimId: 'claim-123',
+      trustedMarkerLogins: ['kurone-kito'],
+      now: '2026-05-17T00:00:00Z',
+      waivableSelectors: [{ selector: 'CodeRabbit', matchMode: 'exact' }],
+    },
+  );
+  assert.equal(result.valid.length, 1);
+  assert.equal(result.modeDisabled.length, 0);
 });
 
 test('summarizeExternalCheckWaivers: waiver naming a configured-waivable check stays valid', () => {
@@ -6655,6 +6707,133 @@ test('#2021: idd-advisory-convergence waiver posted and terminal Copilot unavail
   // the same waiver (#1570's pre-existing behavior, unaffected by #2021).
   assert.ok(!waivedGates.includes('copilot-terminal-unavailable'));
   assert.deepEqual(waived.blockers, computePreMergeReadinessBlockers(waived));
+});
+
+// #2046: a waiver that is otherwise valid, precondition-open, and
+// configured-waivable must still never cover a check while
+// ciGate.externalCheckWaivers.mode is not maintainer-authorized (schema
+// default: disabled) -- mirroring advisory-convergence.mts's own mode
+// guard. Before this fix, pre-merge-readiness.mjs never read `mode` at
+// all, so a `waivable` list left over from a prior maintainer-authorized
+// configuration (or copy-pasted from another repository's config without
+// also copying `mode`) would report coveredByWaiver: true /
+// advisoryConvergenceGenuinelyCovered: true for such a waiver, while
+// advisory-convergence.mts's own required check would never honor it.
+test('#2046: idd-advisory-convergence waiver posted with the deadline passed but mode not maintainer-authorized leaves the check blocked', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const input = withAdvisoryConvergenceRequiredCheck(fixture);
+  const waivableCheckSelectors = [
+    { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+  ];
+  const waiverBody = renderExternalCheckWaiverComment({
+    agentId: fixture.options.expectedAgentId,
+    claimId: fixture.options.expectedClaimId,
+    headSha: fixture.input.prHeadSha,
+    checkSelector: 'idd-advisory-convergence',
+    reason: 'idd-advisory-convergence would not converge across 3 rounds',
+    expiresAt: '2026-05-13T00:00:00Z',
+    actor: 'kurone-kito',
+  });
+
+  const blocked = buildPreMergeReadinessSummary(
+    {
+      ...input,
+      comments: [
+        ...(input.comments ?? []),
+        {
+          id: 'mode-disabled-waiver',
+          author: { login: 'kurone-kito' },
+          body: waiverBody,
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T00:00:00Z',
+        },
+      ],
+    },
+    {
+      ...fixture.options,
+      includeDispositionEvidence: true,
+      waivableCheckSelectors,
+      externalCheckWaiverMaxValidity: 'PT24H',
+      externalCheckWaiverMode: 'disabled',
+      // HEAD committed 25h before `now`: the 24h deadline has already
+      // passed, so the precondition is open -- isolating that mode
+      // gating, not the precondition, is what withholds coverage here.
+      advisoryConvergenceHeadCommittedAt: '2026-05-10T23:00:00Z',
+    },
+  );
+
+  const precondition = (
+    blocked as {
+      advisoryConvergenceWaiverPrecondition: Record<string, unknown>;
+    }
+  ).advisoryConvergenceWaiverPrecondition;
+  assert.equal(precondition.deadlinePassed, true);
+  assert.equal(precondition.open, true);
+
+  // The raw waiver evidence reports the marker as modeDisabled, not valid.
+  const waiverEvidence = blocked.waiverEvidence as {
+    valid: unknown[];
+    modeDisabled: unknown[];
+  };
+  assert.equal(waiverEvidence.valid.length, 0);
+  assert.equal(waiverEvidence.modeDisabled.length, 1);
+
+  const check = ciCheckByName(blocked, 'idd-advisory-convergence');
+  assert.equal(check?.coveredByWaiver, undefined);
+  assert.equal(blocked.ready, false);
+  assert.deepEqual(blocked.blockers, computePreMergeReadinessBlockers(blocked));
+});
+
+// #2046: the same precondition-open waiver, with mode correctly set to
+// maintainer-authorized, still covers the check -- confirming the mode
+// gate does not regress the intended-working configuration.
+test('#2046: idd-advisory-convergence waiver posted with the deadline passed and mode maintainer-authorized still covers the check', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const input = withAdvisoryConvergenceRequiredCheck(fixture);
+  const waivableCheckSelectors = [
+    { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+  ];
+  const waiverBody = renderExternalCheckWaiverComment({
+    agentId: fixture.options.expectedAgentId,
+    claimId: fixture.options.expectedClaimId,
+    headSha: fixture.input.prHeadSha,
+    checkSelector: 'idd-advisory-convergence',
+    reason: 'idd-advisory-convergence would not converge across 3 rounds',
+    expiresAt: '2026-05-13T00:00:00Z',
+    actor: 'kurone-kito',
+  });
+
+  const covered = buildPreMergeReadinessSummary(
+    {
+      ...input,
+      comments: [
+        ...(input.comments ?? []),
+        {
+          id: 'mode-enabled-waiver',
+          author: { login: 'kurone-kito' },
+          body: waiverBody,
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T00:00:00Z',
+        },
+      ],
+    },
+    {
+      ...fixture.options,
+      includeDispositionEvidence: true,
+      waivableCheckSelectors,
+      externalCheckWaiverMaxValidity: 'PT24H',
+      externalCheckWaiverMode: 'maintainer-authorized',
+      advisoryConvergenceHeadCommittedAt: '2026-05-10T23:00:00Z',
+    },
+  );
+
+  const check = ciCheckByName(covered, 'idd-advisory-convergence');
+  assert.equal(check?.coveredByWaiver, true);
+  assert.equal((covered.ci as Record<string, unknown>).status, 'success');
+  const coveredGates = (covered.blockers as { gate: string }[]).map(
+    (blocker) => blocker.gate,
+  );
+  assert.ok(!coveredGates.includes('ci'));
 });
 
 // #1377: a masked-403-as-404 on the branch-protection or ruleset reads must

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -1074,6 +1074,7 @@ const preMergeReadinessFixture = {
     unauthorized: [],
     malformed: [],
     notConfigured: [],
+    modeDisabled: [],
   },
   advisoryConvergenceWaiverPrecondition: {
     checkSelector: 'idd-advisory-convergence',


### PR DESCRIPTION
Closes #2046

## Summary

- `summarizeExternalCheckWaivers` (`protocol-helpers.mts`) now accepts a
  `mode` option and routes an otherwise-valid, configured-waivable
  waiver to a new `modeDisabled` bucket instead of `valid` whenever the
  policy's `ciGate.externalCheckWaivers.mode` is not
  `maintainer-authorized` (schema default: `disabled`) — mirroring
  `advisory-convergence.mts`'s own required check, which never even
  evaluates waiver evidence outside that mode.
- `pre-merge-readiness.mts` gains a `readExternalCheckWaiverMode()`
  helper (mirroring `readExternalCheckWaiverMaxValidity()`) and threads
  the resolved value through, so both the general `coveredByWaiver`
  field and #2021's `advisoryConvergenceGenuinelyCovered` field are
  covered by the same fix.
- Updated `schemas/pre-merge-readiness.schema.json`, the 8 affected
  fixtures, and `tests/schema-type-reconciliation.test.mts`'s sample
  object for the new `modeDisabled` bucket.
- Documented the new bucket in `docs/idd-helper-scripts.md` and its
  `idd-template/` mirror (kept byte-identical).
- 4 new tests: two unit-level (`summarizeExternalCheckWaivers` with
  `mode: 'disabled'` vs. an omitted `mode`), two end-to-end
  (`buildPreMergeReadinessSummary` with `mode: 'disabled'` leaving an
  otherwise-covered, precondition-open `idd-advisory-convergence`
  waiver blocked, and `mode: 'maintainer-authorized'` covering it as
  before).

## Test plan

- [x] `node --experimental-strip-types --test tests/pre-merge-readiness.test.mts` (254 pass)
- [x] `node --experimental-strip-types --test tests/schema-type-reconciliation.test.mts` (69 pass)
- [x] `node --experimental-strip-types --test tests/*.test.mts` (3573 pass)
- [x] `pnpm run lint:minimum`
