### PR TITLE
fix(pre-merge-readiness): gate coveredByWaiver on a fresh rerun

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -717,9 +717,10 @@ The adopted helper boundaries are intentionally narrow:
   `terminalUnavailable`, `open`), so an agent never has to re-derive the
   remaining time-to-deadline by hand when a `ci` blocker cites a posted
   but not-yet-active waiver
-- (`#2034`) each `waiverEvidence.valid` entry now also carries the
-  waiver comment's own `createdAt` (`'none'` when unparseable, which
-  fails closed). A matched check only becomes `coveredByWaiver: true`
+- (preventive; no observed incident yet — `#2034`) each
+  `waiverEvidence.valid` entry now also carries the waiver comment's
+  own `createdAt` (`'none'` when unparseable, which fails closed). A
+  matched check only becomes `coveredByWaiver: true`
   once its own live run's `completedAt` is at or after the moment the
   waiver became genuinely active — the waiver's `createdAt` alone for
   a generic waivable check. For `idd-advisory-convergence`

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -721,18 +721,23 @@ The adopted helper boundaries are intentionally narrow:
   waiver comment's own `createdAt` (`'none'` when unparseable, which
   fails closed). A matched check only becomes `coveredByWaiver: true`
   once its own live run's `completedAt` is at or after the moment the
-  waiver became genuinely active — the waiver's `createdAt` for a
-  generic waivable check, or (for `idd-advisory-convergence`
-  specifically) the later of that and the `#2021` deadline/terminal
-  precondition-open moment. A check whose live run last completed
-  before that moment stays reported as blocked even though a `valid`
-  waiver marker exists, since it was never actually re-run since the
-  waiver took effect — mirroring `idd-advisory-wait.instructions.md`'s
-  Terminal-routing guidance to rerun the check after posting a waiver,
-  instead of leaving that as an unenforced manual step. When this is
-  what withholds coverage for `idd-advisory-convergence`, the `ci`
-  blocker's detail names the stale run's `completedAt` and the
-  waiver's own `createdAt`
+  waiver became genuinely active — the waiver's `createdAt` alone for
+  a generic waivable check. For `idd-advisory-convergence`
+  specifically, that moment is the later of the waiver's `createdAt`
+  and the `#2021` deadline precondition-open moment when the
+  precondition opened via the 24h deadline (a real, computable
+  timestamp); when it opened via proven terminal Copilot
+  unavailability instead, there is no equivalent timestamp to compare
+  against, so the cutoff there is the waiver's `createdAt` alone, same
+  as the generic case. A check whose live run last completed before
+  its applicable cutoff stays reported as blocked even though a
+  `valid` waiver marker exists, since it was never actually re-run
+  since the waiver took effect — mirroring
+  `idd-advisory-wait.instructions.md`'s Terminal-routing guidance to
+  rerun the check after posting a waiver, instead of leaving that as
+  an unenforced manual step. When this is what withholds coverage for
+  `idd-advisory-convergence`, the `ci` blocker's detail names the
+  stale run's `completedAt` and the waiver's own `createdAt`
 - it does not replace the pre-merge or merge decision tables; it only
   reduces command-copy variance when collecting canonical merge-gate
   evidence

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -717,6 +717,22 @@ The adopted helper boundaries are intentionally narrow:
   `terminalUnavailable`, `open`), so an agent never has to re-derive the
   remaining time-to-deadline by hand when a `ci` blocker cites a posted
   but not-yet-active waiver
+- (`#2034`) each `waiverEvidence.valid` entry now also carries the
+  waiver comment's own `createdAt` (`'none'` when unparseable, which
+  fails closed). A matched check only becomes `coveredByWaiver: true`
+  once its own live run's `completedAt` is at or after the moment the
+  waiver became genuinely active — the waiver's `createdAt` for a
+  generic waivable check, or (for `idd-advisory-convergence`
+  specifically) the later of that and the `#2021` deadline/terminal
+  precondition-open moment. A check whose live run last completed
+  before that moment stays reported as blocked even though a `valid`
+  waiver marker exists, since it was never actually re-run since the
+  waiver took effect — mirroring `idd-advisory-wait.instructions.md`'s
+  Terminal-routing guidance to rerun the check after posting a waiver,
+  instead of leaving that as an unenforced manual step. When this is
+  what withholds coverage for `idd-advisory-convergence`, the `ci`
+  blocker's detail names the stale run's `completedAt` and the
+  waiver's own `createdAt`
 - it does not replace the pre-merge or merge decision tables; it only
   reduces command-copy variance when collecting canonical merge-gate
   evidence

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -717,9 +717,10 @@ The adopted helper boundaries are intentionally narrow:
   `terminalUnavailable`, `open`), so an agent never has to re-derive the
   remaining time-to-deadline by hand when a `ci` blocker cites a posted
   but not-yet-active waiver
-- (`#2034`) each `waiverEvidence.valid` entry now also carries the
-  waiver comment's own `createdAt` (`'none'` when unparseable, which
-  fails closed). A matched check only becomes `coveredByWaiver: true`
+- (preventive; no observed incident yet — `#2034`) each
+  `waiverEvidence.valid` entry now also carries the waiver comment's
+  own `createdAt` (`'none'` when unparseable, which fails closed). A
+  matched check only becomes `coveredByWaiver: true`
   once its own live run's `completedAt` is at or after the moment the
   waiver became genuinely active — the waiver's `createdAt` alone for
   a generic waivable check. For `idd-advisory-convergence`

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -721,18 +721,23 @@ The adopted helper boundaries are intentionally narrow:
   waiver comment's own `createdAt` (`'none'` when unparseable, which
   fails closed). A matched check only becomes `coveredByWaiver: true`
   once its own live run's `completedAt` is at or after the moment the
-  waiver became genuinely active — the waiver's `createdAt` for a
-  generic waivable check, or (for `idd-advisory-convergence`
-  specifically) the later of that and the `#2021` deadline/terminal
-  precondition-open moment. A check whose live run last completed
-  before that moment stays reported as blocked even though a `valid`
-  waiver marker exists, since it was never actually re-run since the
-  waiver took effect — mirroring `idd-advisory-wait.instructions.md`'s
-  Terminal-routing guidance to rerun the check after posting a waiver,
-  instead of leaving that as an unenforced manual step. When this is
-  what withholds coverage for `idd-advisory-convergence`, the `ci`
-  blocker's detail names the stale run's `completedAt` and the
-  waiver's own `createdAt`
+  waiver became genuinely active — the waiver's `createdAt` alone for
+  a generic waivable check. For `idd-advisory-convergence`
+  specifically, that moment is the later of the waiver's `createdAt`
+  and the `#2021` deadline precondition-open moment when the
+  precondition opened via the 24h deadline (a real, computable
+  timestamp); when it opened via proven terminal Copilot
+  unavailability instead, there is no equivalent timestamp to compare
+  against, so the cutoff there is the waiver's `createdAt` alone, same
+  as the generic case. A check whose live run last completed before
+  its applicable cutoff stays reported as blocked even though a
+  `valid` waiver marker exists, since it was never actually re-run
+  since the waiver took effect — mirroring
+  `idd-advisory-wait.instructions.md`'s Terminal-routing guidance to
+  rerun the check after posting a waiver, instead of leaving that as
+  an unenforced manual step. When this is what withholds coverage for
+  `idd-advisory-convergence`, the `ci` blocker's detail names the
+  stale run's `completedAt` and the waiver's own `createdAt`
 - it does not replace the pre-merge or merge decision tables; it only
   reduces command-copy variance when collecting canonical merge-gate
   evidence

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -717,6 +717,22 @@ The adopted helper boundaries are intentionally narrow:
   `terminalUnavailable`, `open`), so an agent never has to re-derive the
   remaining time-to-deadline by hand when a `ci` blocker cites a posted
   but not-yet-active waiver
+- (`#2034`) each `waiverEvidence.valid` entry now also carries the
+  waiver comment's own `createdAt` (`'none'` when unparseable, which
+  fails closed). A matched check only becomes `coveredByWaiver: true`
+  once its own live run's `completedAt` is at or after the moment the
+  waiver became genuinely active — the waiver's `createdAt` for a
+  generic waivable check, or (for `idd-advisory-convergence`
+  specifically) the later of that and the `#2021` deadline/terminal
+  precondition-open moment. A check whose live run last completed
+  before that moment stays reported as blocked even though a `valid`
+  waiver marker exists, since it was never actually re-run since the
+  waiver took effect — mirroring `idd-advisory-wait.instructions.md`'s
+  Terminal-routing guidance to rerun the check after posting a waiver,
+  instead of leaving that as an unenforced manual step. When this is
+  what withholds coverage for `idd-advisory-convergence`, the `ci`
+  blocker's detail names the stale run's `completedAt` and the
+  waiver's own `createdAt`
 - it does not replace the pre-merge or merge decision tables; it only
   reduces command-copy variance when collecting canonical merge-gate
   evidence

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -1240,7 +1240,8 @@
               "authorLogin",
               "checkSelector",
               "reason",
-              "expiresAt"
+              "expiresAt",
+              "createdAt"
             ],
             "additionalProperties": false,
             "properties": {
@@ -1259,6 +1260,10 @@
               "expiresAt": {
                 "type": "string",
                 "description": "Waiver's recorded expiry timestamp."
+              },
+              "createdAt": {
+                "type": "string",
+                "description": "Waiver comment's own creation timestamp (#2034), or 'none' when unparseable; the moment a generic waivable check's waiver became genuinely active, used to gate coveredByWaiver on a fresh post-waiver check run."
               }
             }
           }

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -1263,7 +1263,8 @@
               },
               "createdAt": {
                 "type": "string",
-                "description": "Waiver comment's own creation timestamp (#2034), or 'none' when unparseable; the moment a generic waivable check's waiver became genuinely active, used to gate coveredByWaiver on a fresh post-waiver check run."
+                "description": "Waiver comment's own creation timestamp (#2034), or 'none' when unparseable; the moment a generic waivable check's waiver became genuinely active, used to gate coveredByWaiver on a fresh post-waiver check run.",
+                "pattern": "^(none|\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z)$"
               }
             }
           }

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -298,6 +298,7 @@ export function summarizeExternalCheckWaivers(
       checkSelector: parsed.checkSelector,
       reason: parsed.reason,
       expiresAt: parsed.expiresAt,
+      createdAt: parsed.createdAt,
     });
   }
   return {
@@ -3424,6 +3425,7 @@ export function summarizeRequiredChecks(
     protectionReadsUnreadable = false,
     trustSourcePinnedRequiredChecks = false,
     excludeFromWaiverCoverage = null,
+    waiverActiveSinceOverride = null,
   } = {},
 ) {
   const branchReviewRequirements = summarizeBranchReviewRequirements(
@@ -3436,15 +3438,47 @@ export function summarizeRequiredChecks(
   const normalizedChecks = checks.map((check) => {
     const name = String(check.name ?? '');
     const state = String(check.state ?? '').toUpperCase();
+    const completedAt = String(check.completedAt ?? '');
+    const completedAtMs = isValidIsoTimestamp(completedAt)
+      ? new Date(completedAt).getTime()
+      : null;
+    const matchingWaivers = validWaivers.filter((w) =>
+      matchCheckSelectorLocal(name, w.checkSelector),
+    );
+    const activeSinceOverride =
+      typeof waiverActiveSinceOverride === 'function'
+        ? waiverActiveSinceOverride(name)
+        : null;
+    const activeSinceOverrideMs = isValidIsoTimestamp(activeSinceOverride)
+      ? new Date(activeSinceOverride).getTime()
+      : null;
+    // #2034: a matched waiver only covers a check whose live run's
+    // `completedAt` is at or after the moment the waiver became genuinely
+    // active -- otherwise the check was never actually re-run since the
+    // waiver took effect, so reporting it covered here would diverge from
+    // what the real required check (and GitHub's branch protection) still
+    // shows. Fails closed on a missing/unparseable `completedAt` (never run,
+    // still pending) or waiver `createdAt` (`'none'`).
+    const hasFreshWaiverCoverage =
+      completedAtMs !== null &&
+      matchingWaivers.some((w) => {
+        const waiverCreatedAtMs = isValidIsoTimestamp(w.createdAt)
+          ? new Date(w.createdAt).getTime()
+          : null;
+        if (waiverCreatedAtMs === null) return false;
+        const activeSinceMs =
+          activeSinceOverrideMs !== null
+            ? Math.max(waiverCreatedAtMs, activeSinceOverrideMs)
+            : waiverCreatedAtMs;
+        return completedAtMs >= activeSinceMs;
+      });
     const coveredByWaiver =
       !CHECK_PASS_EQUIVALENT_STATES.has(state) &&
       !(
         typeof excludeFromWaiverCoverage === 'function' &&
         excludeFromWaiverCoverage(name)
       ) &&
-      validWaivers.some((w) =>
-        matchCheckSelectorLocal(name, w.checkSelector),
-      ) &&
+      hasFreshWaiverCoverage &&
       // The check must also sit on the policy's waivable surface. A
       // null/undefined list keeps the legacy behavior with no gate; an empty
       // configured list covers nothing.
@@ -3453,7 +3487,7 @@ export function summarizeRequiredChecks(
     return {
       name,
       state,
-      completedAt: String(check.completedAt ?? ''),
+      completedAt,
       coveredByWaiver,
       // Producer-identity discriminator (#1483); see `CheckLike` and
       // `selectLatestCheckPerName` for how it disambiguates a same-name
@@ -4621,10 +4655,14 @@ export function computePreMergeReadinessBlockers(report) {
     // an exact waiver and waiting out the deadline is sufficient" when the
     // real cause is that only a glob selector (e.g. `idd-*`) targets this
     // check -- that never converges no matter how long the deadline waits.
-    const advisoryConvergenceExactWaiverCount = waiverEvidenceValidList.filter(
-      (entry) =>
-        String(entry?.checkSelector ?? '') === advisoryConvergenceCheckSelector,
-    ).length;
+    const advisoryConvergenceExactWaiverEntries =
+      waiverEvidenceValidList.filter(
+        (entry) =>
+          String(entry?.checkSelector ?? '') ===
+          advisoryConvergenceCheckSelector,
+      );
+    const advisoryConvergenceExactWaiverCount =
+      advisoryConvergenceExactWaiverEntries.length;
     const advisoryConvergenceAnyWaiverCount = waiverEvidenceValidList.filter(
       (entry) =>
         matchCheckSelectorLocal(
@@ -4636,11 +4674,7 @@ export function computePreMergeReadinessBlockers(report) {
       advisoryConvergencePrecondition.open === true;
     if (
       advisoryConvergenceCheckNonPassing &&
-      advisoryConvergenceAnyWaiverCount > 0 &&
-      !(
-        advisoryConvergencePreconditionOpenForDetail &&
-        advisoryConvergenceExactWaiverCount > 0
-      )
+      advisoryConvergenceAnyWaiverCount > 0
     ) {
       const deadlineMinutes = Number(
         advisoryConvergencePrecondition.deadlineMinutes ?? 0,
@@ -4670,9 +4704,48 @@ export function computePreMergeReadinessBlockers(report) {
             'precondition',
         );
       }
-      detail +=
-        ` (a posted external-check waiver exists for current HEAD but is ` +
-        `not yet covering "${advisoryConvergenceCheckSelector}": ${reasons.join('; ')})`;
+      // #2034: precondition open AND an exact-match waiver exists, yet the
+      // check is still reported non-passing -- the only remaining cause is
+      // the rerun-freshness gate: the check's own live run last completed
+      // before the waiver became genuinely active. Name the stale run's
+      // `completedAt` and the waiver's own `createdAt` explicitly, mirroring
+      // the other two reasons, instead of leaving an agent to re-derive why
+      // an apparently-satisfied waiver still left the check blocked.
+      if (
+        advisoryConvergencePreconditionOpenForDetail &&
+        advisoryConvergenceExactWaiverCount > 0 &&
+        reasons.length === 0
+      ) {
+        const staleCheck = Array.isArray(ci.checks)
+          ? ci.checks.find(
+              (check) =>
+                check?.required === true &&
+                check?.coveredByWaiver !== true &&
+                !CHECK_PASS_EQUIVALENT_STATES.has(String(check?.state ?? '')) &&
+                matchCheckSelectorLocal(
+                  check?.name,
+                  advisoryConvergenceCheckSelector,
+                ),
+            )
+          : undefined;
+        const staleCompletedAt =
+          String(staleCheck?.completedAt ?? '') || 'none';
+        const waiverCreatedAts = advisoryConvergenceExactWaiverEntries
+          .map((entry) => String(entry?.createdAt ?? 'none'))
+          .join(', ');
+        reasons.push(
+          `its live run last completed at "${staleCompletedAt}", which is ` +
+            `not at or after the waiver's own createdAt (${waiverCreatedAts}) ` +
+            'or the deadline/terminal precondition-open moment, whichever is ' +
+            'later -- rerun the check so its live run reflects the waiver ' +
+            'before trusting this as covered',
+        );
+      }
+      if (reasons.length > 0) {
+        detail +=
+          ` (a posted external-check waiver exists for current HEAD but is ` +
+          `not yet covering "${advisoryConvergenceCheckSelector}": ${reasons.join('; ')})`;
+      }
     }
     blockers.push({ gate: 'ci', detail });
   }
@@ -4970,6 +5043,23 @@ export function buildPreMergeReadinessSummary(
     advisoryConvergenceElapsedMinutes >= advisoryConvergenceDeadlineMinutes;
   const advisoryConvergencePreconditionOpen =
     advisoryConvergenceDeadlinePassed || copilotUnavailable;
+  // #2034: the deadline-path precondition-open moment as an actual ISO
+  // timestamp, used to override the waiver-active cutoff `summarizeRequiredChecks`
+  // applies to `idd-advisory-convergence` specifically -- that check's waiver
+  // only becomes genuinely active once this precondition opens, which can be
+  // later than the waiver comment's own `createdAt`. Only computed for the
+  // deadline path (`advisoryConvergenceDeadlinePassed`); the terminal-
+  // unavailability path has no equivalent real timestamp to anchor on, so it
+  // intentionally falls back to the waiver's own `createdAt` (see
+  // `waiverActiveSinceOverride` below).
+  const advisoryConvergenceDeadlineOpensAt =
+    advisoryConvergenceDeadlinePassed &&
+    isValidIsoTimestamp(advisoryConvergenceHeadCommittedAt)
+      ? new Date(
+          new Date(advisoryConvergenceHeadCommittedAt).getTime() +
+            advisoryConvergenceDeadlineMinutes * 60000,
+        ).toISOString()
+      : '';
   const advisoryConvergenceWaiverPrecondition = {
     checkSelector: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
     deadlineMinutes: advisoryConvergenceDeadlineMinutes,
@@ -5016,6 +5106,14 @@ export function buildPreMergeReadinessSummary(
     excludeFromWaiverCoverage: (name) =>
       name === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
       !advisoryConvergenceGenuinelyCovered,
+    // #2034: only override the cutoff for `idd-advisory-convergence` itself,
+    // and only on the deadline path -- an unrelated check's waiver stays
+    // anchored on its own comment's `createdAt`.
+    waiverActiveSinceOverride: (name) =>
+      name === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
+      advisoryConvergenceDeadlineOpensAt
+        ? advisoryConvergenceDeadlineOpensAt
+        : null,
   });
   // #1570: reuse the SAME raw waiver evidence above (already validated for
   // selector/HEAD/claim/authority/expiry) to decide whether the caller-

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -4733,12 +4733,19 @@ export function computePreMergeReadinessBlockers(report) {
         const waiverCreatedAts = advisoryConvergenceExactWaiverEntries
           .map((entry) => String(entry?.createdAt ?? 'none'))
           .join(', ');
+        // The deadline path has a real, computable activation override (the
+        // deadline-open moment); the terminal-unavailability path does not,
+        // so the cutoff there is the waiver's own createdAt alone -- naming
+        // both unconditionally would misstate the terminal case.
+        const activeSinceDescription =
+          advisoryConvergencePrecondition.deadlinePassed === true
+            ? `not at or after the waiver's own createdAt (${waiverCreatedAts}) ` +
+              'or the #2021 deadline precondition-open moment, whichever is later'
+            : `not at or after the waiver's own createdAt (${waiverCreatedAts})`;
         reasons.push(
           `its live run last completed at "${staleCompletedAt}", which is ` +
-            `not at or after the waiver's own createdAt (${waiverCreatedAts}) ` +
-            'or the deadline/terminal precondition-open moment, whichever is ' +
-            'later -- rerun the check so its live run reflects the waiver ' +
-            'before trusting this as covered',
+            `${activeSinceDescription} -- rerun the check so its live run ` +
+            'reflects the waiver before trusting this as covered',
         );
       }
       if (reasons.length > 0) {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -318,6 +318,14 @@ export interface ExternalCheckWaiverEvidence {
     checkSelector: string;
     reason: string;
     expiresAt: string;
+    // #2034: the waiver comment's own `createdAt` -- the moment a generic
+    // waivable check's waiver became genuinely active. `summarizeRequiredChecks`
+    // compares a matched check's `completedAt` against this (or a per-check
+    // override, e.g. `idd-advisory-convergence`'s deadline-open moment) before
+    // reporting `coveredByWaiver: true`, so a stale pre-waiver run stays
+    // blocked. `'none'` when the comment's `createdAt` was unparseable --
+    // fails closed (never covers).
+    createdAt: string;
   }[];
   expired: { authorLogin: string; checkSelector: string; expiresAt: string }[];
   wrongHead: {
@@ -822,6 +830,7 @@ export function summarizeExternalCheckWaivers(
       checkSelector: parsed.checkSelector,
       reason: parsed.reason,
       expiresAt: parsed.expiresAt,
+      createdAt: parsed.createdAt,
     });
   }
 
@@ -4387,8 +4396,11 @@ export function summarizeRequiredChecks(
     protectionReadsUnreadable = false,
     trustSourcePinnedRequiredChecks = false,
     excludeFromWaiverCoverage = null,
+    waiverActiveSinceOverride = null,
   }: {
-    waivers?: { valid?: { checkSelector?: unknown }[] | null } | null;
+    waivers?: {
+      valid?: { checkSelector?: unknown; createdAt?: unknown }[] | null;
+    } | null;
     waivableSelectors?: { selector?: unknown; matchMode?: unknown }[] | null;
     // #1377: see `buildPreMergeReadinessSummary`'s option of the same name.
     protectionReadsUnreadable?: boolean;
@@ -4406,6 +4418,24 @@ export function summarizeRequiredChecks(
     // never excludes anything -- unchanged pre-#2021 behavior for every
     // caller that doesn't pass it.
     excludeFromWaiverCoverage?: ((checkName: string) => boolean) | null;
+    // #2034: per-CHECK-NAME override of the moment a matched waiver became
+    // genuinely active, superseding the waiver's own `createdAt` when later.
+    // A matched check only counts as `coveredByWaiver` once its live run's
+    // `completedAt` is at or after this moment -- otherwise the check was
+    // never actually re-run since the waiver took effect, and reporting it
+    // covered would diverge from what the real required check (and GitHub's
+    // branch protection) still shows. Returning `null` (the default, and
+    // every caller that omits this option) leaves the waiver's own
+    // `createdAt` as the sole cutoff -- unchanged pre-#2034 behavior for a
+    // generic waivable check. `buildPreMergeReadinessSummary` passes an
+    // override for `idd-advisory-convergence` specifically: that check's
+    // waiver only becomes genuinely active once the #2021 deadline/terminal
+    // precondition opens, and (deadline path only) the precondition-open
+    // moment is a real, computable timestamp later than the waiver's own
+    // `createdAt` could be. The terminal-unavailability path has no natural
+    // timestamp to invent, so it is left unoverridden and falls back to the
+    // waiver's own `createdAt`, same as the generic path.
+    waiverActiveSinceOverride?: ((checkName: string) => string | null) | null;
     // #1689: `ciGate.trustSourcePinnedRequiredChecks` opt-in (mirrors
     // `ciGate.trustEmptyProtectionReads`'s shape). Default `false` keeps the
     // pre-#1689 conservative behavior: a required check whose ruleset entry
@@ -4439,15 +4469,47 @@ export function summarizeRequiredChecks(
   const normalizedChecks = checks.map((check) => {
     const name = String(check.name ?? '');
     const state = String(check.state ?? '').toUpperCase();
+    const completedAt = String(check.completedAt ?? '');
+    const completedAtMs = isValidIsoTimestamp(completedAt)
+      ? new Date(completedAt).getTime()
+      : null;
+    const matchingWaivers = validWaivers.filter((w) =>
+      matchCheckSelectorLocal(name, w.checkSelector),
+    );
+    const activeSinceOverride =
+      typeof waiverActiveSinceOverride === 'function'
+        ? waiverActiveSinceOverride(name)
+        : null;
+    const activeSinceOverrideMs = isValidIsoTimestamp(activeSinceOverride)
+      ? new Date(activeSinceOverride).getTime()
+      : null;
+    // #2034: a matched waiver only covers a check whose live run's
+    // `completedAt` is at or after the moment the waiver became genuinely
+    // active -- otherwise the check was never actually re-run since the
+    // waiver took effect, so reporting it covered here would diverge from
+    // what the real required check (and GitHub's branch protection) still
+    // shows. Fails closed on a missing/unparseable `completedAt` (never run,
+    // still pending) or waiver `createdAt` (`'none'`).
+    const hasFreshWaiverCoverage =
+      completedAtMs !== null &&
+      matchingWaivers.some((w) => {
+        const waiverCreatedAtMs = isValidIsoTimestamp(w.createdAt)
+          ? new Date(w.createdAt).getTime()
+          : null;
+        if (waiverCreatedAtMs === null) return false;
+        const activeSinceMs =
+          activeSinceOverrideMs !== null
+            ? Math.max(waiverCreatedAtMs, activeSinceOverrideMs)
+            : waiverCreatedAtMs;
+        return completedAtMs >= activeSinceMs;
+      });
     const coveredByWaiver =
       !CHECK_PASS_EQUIVALENT_STATES.has(state) &&
       !(
         typeof excludeFromWaiverCoverage === 'function' &&
         excludeFromWaiverCoverage(name)
       ) &&
-      validWaivers.some((w) =>
-        matchCheckSelectorLocal(name, w.checkSelector),
-      ) &&
+      hasFreshWaiverCoverage &&
       // The check must also sit on the policy's waivable surface. A
       // null/undefined list keeps the legacy behavior with no gate; an empty
       // configured list covers nothing.
@@ -4456,7 +4518,7 @@ export function summarizeRequiredChecks(
     return {
       name,
       state,
-      completedAt: String(check.completedAt ?? ''),
+      completedAt,
       coveredByWaiver,
       // Producer-identity discriminator (#1483); see `CheckLike` and
       // `selectLatestCheckPerName` for how it disambiguates a same-name
@@ -5821,10 +5883,14 @@ export function computePreMergeReadinessBlockers(
     // an exact waiver and waiting out the deadline is sufficient" when the
     // real cause is that only a glob selector (e.g. `idd-*`) targets this
     // check -- that never converges no matter how long the deadline waits.
-    const advisoryConvergenceExactWaiverCount = waiverEvidenceValidList.filter(
-      (entry) =>
-        String(entry?.checkSelector ?? '') === advisoryConvergenceCheckSelector,
-    ).length;
+    const advisoryConvergenceExactWaiverEntries =
+      waiverEvidenceValidList.filter(
+        (entry) =>
+          String(entry?.checkSelector ?? '') ===
+          advisoryConvergenceCheckSelector,
+      );
+    const advisoryConvergenceExactWaiverCount =
+      advisoryConvergenceExactWaiverEntries.length;
     const advisoryConvergenceAnyWaiverCount = waiverEvidenceValidList.filter(
       (entry) =>
         matchCheckSelectorLocal(
@@ -5836,11 +5902,7 @@ export function computePreMergeReadinessBlockers(
       advisoryConvergencePrecondition.open === true;
     if (
       advisoryConvergenceCheckNonPassing &&
-      advisoryConvergenceAnyWaiverCount > 0 &&
-      !(
-        advisoryConvergencePreconditionOpenForDetail &&
-        advisoryConvergenceExactWaiverCount > 0
-      )
+      advisoryConvergenceAnyWaiverCount > 0
     ) {
       const deadlineMinutes = Number(
         advisoryConvergencePrecondition.deadlineMinutes ?? 0,
@@ -5872,9 +5934,48 @@ export function computePreMergeReadinessBlockers(
             'precondition',
         );
       }
-      detail +=
-        ` (a posted external-check waiver exists for current HEAD but is ` +
-        `not yet covering "${advisoryConvergenceCheckSelector}": ${reasons.join('; ')})`;
+      // #2034: precondition open AND an exact-match waiver exists, yet the
+      // check is still reported non-passing -- the only remaining cause is
+      // the rerun-freshness gate: the check's own live run last completed
+      // before the waiver became genuinely active. Name the stale run's
+      // `completedAt` and the waiver's own `createdAt` explicitly, mirroring
+      // the other two reasons, instead of leaving an agent to re-derive why
+      // an apparently-satisfied waiver still left the check blocked.
+      if (
+        advisoryConvergencePreconditionOpenForDetail &&
+        advisoryConvergenceExactWaiverCount > 0 &&
+        reasons.length === 0
+      ) {
+        const staleCheck = Array.isArray(ci.checks)
+          ? (ci.checks as Record<string, unknown>[]).find(
+              (check) =>
+                check?.required === true &&
+                check?.coveredByWaiver !== true &&
+                !CHECK_PASS_EQUIVALENT_STATES.has(String(check?.state ?? '')) &&
+                matchCheckSelectorLocal(
+                  check?.name,
+                  advisoryConvergenceCheckSelector,
+                ),
+            )
+          : undefined;
+        const staleCompletedAt =
+          String(staleCheck?.completedAt ?? '') || 'none';
+        const waiverCreatedAts = advisoryConvergenceExactWaiverEntries
+          .map((entry) => String(entry?.createdAt ?? 'none'))
+          .join(', ');
+        reasons.push(
+          `its live run last completed at "${staleCompletedAt}", which is ` +
+            `not at or after the waiver's own createdAt (${waiverCreatedAts}) ` +
+            'or the deadline/terminal precondition-open moment, whichever is ' +
+            'later -- rerun the check so its live run reflects the waiver ' +
+            'before trusting this as covered',
+        );
+      }
+      if (reasons.length > 0) {
+        detail +=
+          ` (a posted external-check waiver exists for current HEAD but is ` +
+          `not yet covering "${advisoryConvergenceCheckSelector}": ${reasons.join('; ')})`;
+      }
     }
     blockers.push({ gate: 'ci', detail });
   }
@@ -6336,6 +6437,23 @@ export function buildPreMergeReadinessSummary(
     advisoryConvergenceElapsedMinutes >= advisoryConvergenceDeadlineMinutes;
   const advisoryConvergencePreconditionOpen =
     advisoryConvergenceDeadlinePassed || copilotUnavailable;
+  // #2034: the deadline-path precondition-open moment as an actual ISO
+  // timestamp, used to override the waiver-active cutoff `summarizeRequiredChecks`
+  // applies to `idd-advisory-convergence` specifically -- that check's waiver
+  // only becomes genuinely active once this precondition opens, which can be
+  // later than the waiver comment's own `createdAt`. Only computed for the
+  // deadline path (`advisoryConvergenceDeadlinePassed`); the terminal-
+  // unavailability path has no equivalent real timestamp to anchor on, so it
+  // intentionally falls back to the waiver's own `createdAt` (see
+  // `waiverActiveSinceOverride` below).
+  const advisoryConvergenceDeadlineOpensAt =
+    advisoryConvergenceDeadlinePassed &&
+    isValidIsoTimestamp(advisoryConvergenceHeadCommittedAt)
+      ? new Date(
+          new Date(advisoryConvergenceHeadCommittedAt).getTime() +
+            advisoryConvergenceDeadlineMinutes * 60000,
+        ).toISOString()
+      : '';
   const advisoryConvergenceWaiverPrecondition = {
     checkSelector: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
     deadlineMinutes: advisoryConvergenceDeadlineMinutes,
@@ -6384,6 +6502,14 @@ export function buildPreMergeReadinessSummary(
     excludeFromWaiverCoverage: (name) =>
       name === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
       !advisoryConvergenceGenuinelyCovered,
+    // #2034: only override the cutoff for `idd-advisory-convergence` itself,
+    // and only on the deadline path -- an unrelated check's waiver stays
+    // anchored on its own comment's `createdAt`.
+    waiverActiveSinceOverride: (name) =>
+      name === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
+      advisoryConvergenceDeadlineOpensAt
+        ? advisoryConvergenceDeadlineOpensAt
+        : null,
   });
 
   // #1570: reuse the SAME raw waiver evidence above (already validated for

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4433,8 +4433,8 @@ export function summarizeRequiredChecks(
     // precondition opens, and (deadline path only) the precondition-open
     // moment is a real, computable timestamp later than the waiver's own
     // `createdAt` could be. The terminal-unavailability path has no natural
-    // timestamp to invent, so it is left unoverridden and falls back to the
-    // waiver's own `createdAt`, same as the generic path.
+    // timestamp to invent, so no override is applied and it falls back to
+    // the waiver's own `createdAt`, same as the generic path.
     waiverActiveSinceOverride?: ((checkName: string) => string | null) | null;
     // #1689: `ciGate.trustSourcePinnedRequiredChecks` opt-in (mirrors
     // `ciGate.trustEmptyProtectionReads`'s shape). Default `false` keeps the

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4426,15 +4426,16 @@ export function summarizeRequiredChecks(
     // covered would diverge from what the real required check (and GitHub's
     // branch protection) still shows. Returning `null` (the default, and
     // every caller that omits this option) leaves the waiver's own
-    // `createdAt` as the sole cutoff -- unchanged pre-#2034 behavior for a
-    // generic waivable check. `buildPreMergeReadinessSummary` passes an
-    // override for `idd-advisory-convergence` specifically: that check's
-    // waiver only becomes genuinely active once the #2021 deadline/terminal
-    // precondition opens, and (deadline path only) the precondition-open
-    // moment is a real, computable timestamp later than the waiver's own
-    // `createdAt` could be. The terminal-unavailability path has no natural
-    // timestamp to invent, so no override is applied and it falls back to
-    // the waiver's own `createdAt`, same as the generic path.
+    // `createdAt` as the sole cutoff -- this is the ONLY cutoff source for a
+    // generic waivable check; #2034 changes that check's behavior too (a
+    // valid waiver no longer covers it unconditionally). `buildPreMergeReadinessSummary`
+    // passes an override for `idd-advisory-convergence` specifically: that
+    // check's waiver only becomes genuinely active once the #2021 deadline
+    // precondition opens, and the deadline-open moment is a real, computable
+    // timestamp later than the waiver's own `createdAt` could be. The
+    // terminal-unavailability precondition path has no equivalent timestamp
+    // to invent, so no override is applied there either, and it falls back
+    // to the waiver's own `createdAt`, same as the generic path.
     waiverActiveSinceOverride?: ((checkName: string) => string | null) | null;
     // #1689: `ciGate.trustSourcePinnedRequiredChecks` opt-in (mirrors
     // `ciGate.trustEmptyProtectionReads`'s shape). Default `false` keeps the
@@ -5963,12 +5964,19 @@ export function computePreMergeReadinessBlockers(
         const waiverCreatedAts = advisoryConvergenceExactWaiverEntries
           .map((entry) => String(entry?.createdAt ?? 'none'))
           .join(', ');
+        // The deadline path has a real, computable activation override (the
+        // deadline-open moment); the terminal-unavailability path does not,
+        // so the cutoff there is the waiver's own createdAt alone -- naming
+        // both unconditionally would misstate the terminal case.
+        const activeSinceDescription =
+          advisoryConvergencePrecondition.deadlinePassed === true
+            ? `not at or after the waiver's own createdAt (${waiverCreatedAts}) ` +
+              'or the #2021 deadline precondition-open moment, whichever is later'
+            : `not at or after the waiver's own createdAt (${waiverCreatedAts})`;
         reasons.push(
           `its live run last completed at "${staleCompletedAt}", which is ` +
-            `not at or after the waiver's own createdAt (${waiverCreatedAts}) ` +
-            'or the deadline/terminal precondition-open moment, whichever is ' +
-            'later -- rerun the check so its live run reflects the waiver ' +
-            'before trusting this as covered',
+            `${activeSinceDescription} -- rerun the check so its live run ` +
+            'reflects the waiver before trusting this as covered',
         );
       }
       if (reasons.length > 0) {

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -4489,6 +4489,40 @@ test('summarizeRequiredChecks: waiver covers failing required check', () => {
         checkSelector: 'CodeRabbit',
         reason: 'rate-limit',
         expiresAt: '2099-01-01T00:00:00Z',
+        createdAt: '2026-05-16T00:00:00Z',
+      },
+    ],
+    expired: [],
+    wrongHead: [],
+    wrongClaim: [],
+    unauthorized: [],
+    malformed: [],
+  };
+  const result = summarizeRequiredChecks(
+    [
+      {
+        name: 'CodeRabbit',
+        state: 'PENDING',
+        completedAt: '2026-05-17T00:00:00Z',
+      },
+    ],
+    [],
+    { required_status_checks: { contexts: ['CodeRabbit'] } },
+    { waivers },
+  );
+  assert.equal(result.checks[0].coveredByWaiver, true);
+  assert.equal(result.status, 'success');
+});
+
+test('summarizeRequiredChecks: a check with no live run at all is never covered by waiver, even a valid one (#2034 fail-closed)', () => {
+  const waivers = {
+    valid: [
+      {
+        authorLogin: 'kurone-kito',
+        checkSelector: 'CodeRabbit',
+        reason: 'rate-limit',
+        expiresAt: '2099-01-01T00:00:00Z',
+        createdAt: '2026-05-16T00:00:00Z',
       },
     ],
     expired: [],
@@ -4503,8 +4537,8 @@ test('summarizeRequiredChecks: waiver covers failing required check', () => {
     { required_status_checks: { contexts: ['CodeRabbit'] } },
     { waivers },
   );
-  assert.equal(result.checks[0].coveredByWaiver, true);
-  assert.equal(result.status, 'success');
+  assert.equal(result.checks[0].coveredByWaiver, undefined);
+  assert.notEqual(result.status, 'success');
 });
 
 test('summarizeRequiredChecks: waiver does not affect already-passing check', () => {
@@ -4882,6 +4916,7 @@ test('summarizeRequiredChecks: waiver with glob selector covers matching failing
         checkSelector: 'Code*',
         reason: 'test',
         expiresAt: '2099-01-01T00:00:00Z',
+        createdAt: '2026-05-16T00:00:00Z',
       },
     ],
     expired: [],
@@ -5086,6 +5121,7 @@ test('summarizeRequiredChecks: a configured-waivable check still folds in', () =
         checkSelector: 'CodeRabbit',
         reason: 'rate-limit',
         expiresAt: '2099-01-01T00:00:00Z',
+        createdAt: '2026-05-16T00:00:00Z',
       },
     ],
     expired: [],
@@ -5096,7 +5132,13 @@ test('summarizeRequiredChecks: a configured-waivable check still folds in', () =
     notConfigured: [],
   };
   const result = summarizeRequiredChecks(
-    [{ name: 'CodeRabbit', state: 'FAILURE', completedAt: '' }],
+    [
+      {
+        name: 'CodeRabbit',
+        state: 'FAILURE',
+        completedAt: '2026-05-17T00:00:00Z',
+      },
+    ],
     [],
     { required_status_checks: { contexts: ['CodeRabbit'] } },
     {
@@ -5204,6 +5246,7 @@ test('summarizeRequiredChecks: a glob waiver folds in an exact-configured-waivab
         checkSelector: 'Code*',
         reason: 'rate-limit',
         expiresAt: '2099-01-01T00:00:00Z',
+        createdAt: '2026-05-16T00:00:00Z',
       },
     ],
     expired: [],
@@ -5214,7 +5257,13 @@ test('summarizeRequiredChecks: a glob waiver folds in an exact-configured-waivab
     notConfigured: [],
   };
   const result = summarizeRequiredChecks(
-    [{ name: 'CodeRabbit', state: 'FAILURE', completedAt: '' }],
+    [
+      {
+        name: 'CodeRabbit',
+        state: 'FAILURE',
+        completedAt: '2026-05-17T00:00:00Z',
+      },
+    ],
     [],
     { required_status_checks: { contexts: ['CodeRabbit'] } },
     {
@@ -6264,7 +6313,11 @@ function withAdvisoryConvergenceRequiredCheck(fixture: {
     {
       name: 'idd-advisory-convergence',
       state: 'FAILURE',
-      completedAt: '2026-05-11T23:59:00Z',
+      // #2034: after every waiver `createdAt` (`2026-05-12T00:00:00Z`) this
+      // helper's callers post, so the rerun-freshness gate does not withhold
+      // coverage in the "should be covered" cases below -- those tests cover
+      // #2021's precondition and #2046's mode gating specifically, not #2034.
+      completedAt: '2026-05-12T00:30:00Z',
     },
   ];
   return { ...fixture.input, branchRules, checks };
@@ -6522,12 +6575,17 @@ test('#2021: withholding coverage from idd-advisory-convergence does not remove 
     {
       name: 'idd-advisory-convergence',
       state: 'FAILURE',
-      completedAt: '2026-05-11T23:59:00Z',
+      // #2034: after the glob waiver's own `createdAt` (`2026-05-12T00:00:00Z`
+      // below) so the unrelated idd-security assertion below is not entangled
+      // with the rerun-freshness gate this issue adds -- idd-advisory-convergence
+      // itself still stays uncovered here regardless, via the precondition-closed
+      // exclusion this test targets.
+      completedAt: '2026-05-12T00:30:00Z',
     },
     {
       name: 'idd-security',
       state: 'FAILURE',
-      completedAt: '2026-05-11T23:59:00Z',
+      completedAt: '2026-05-12T00:30:00Z',
     },
   ];
   const waivableCheckSelectors = [{ selector: 'idd-*', matchMode: 'glob' }];
@@ -6810,6 +6868,148 @@ test('#2046: idd-advisory-convergence waiver posted with the deadline passed and
         ...(input.comments ?? []),
         {
           id: 'mode-enabled-waiver',
+          author: { login: 'kurone-kito' },
+          body: waiverBody,
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T00:00:00Z',
+        },
+      ],
+    },
+    {
+      ...fixture.options,
+      includeDispositionEvidence: true,
+      waivableCheckSelectors,
+      externalCheckWaiverMaxValidity: 'PT24H',
+      externalCheckWaiverMode: 'maintainer-authorized',
+      advisoryConvergenceHeadCommittedAt: '2026-05-10T23:00:00Z',
+    },
+  );
+
+  const check = ciCheckByName(covered, 'idd-advisory-convergence');
+  assert.equal(check?.coveredByWaiver, true);
+  assert.equal((covered.ci as Record<string, unknown>).status, 'success');
+  const coveredGates = (covered.blockers as { gate: string }[]).map(
+    (blocker) => blocker.gate,
+  );
+  assert.ok(!coveredGates.includes('ci'));
+});
+
+// #2034: a valid, precondition-satisfied, mode-enabled waiver still never
+// covers a check whose own live run last completed BEFORE the waiver became
+// genuinely active -- the check was never actually re-run since, so
+// reporting it covered would diverge from what the real required check (and
+// GitHub's branch protection) still shows.
+test('#2034: idd-advisory-convergence waiver posted, precondition open, but the check last completed before the waiver took effect stays blocked, evidence names the stale run', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const input = withAdvisoryConvergenceRequiredCheck(fixture);
+  const staleChecks = (input.checks ?? []).map((check) =>
+    check.name === 'idd-advisory-convergence'
+      ? { ...check, completedAt: '2026-05-11T23:30:00Z' }
+      : check,
+  );
+  const waivableCheckSelectors = [
+    { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+  ];
+  const waiverBody = renderExternalCheckWaiverComment({
+    agentId: fixture.options.expectedAgentId,
+    claimId: fixture.options.expectedClaimId,
+    headSha: fixture.input.prHeadSha,
+    checkSelector: 'idd-advisory-convergence',
+    reason: 'idd-advisory-convergence would not converge across 3 rounds',
+    expiresAt: '2026-05-13T00:00:00Z',
+    actor: 'kurone-kito',
+  });
+
+  const blocked = buildPreMergeReadinessSummary(
+    {
+      ...input,
+      checks: staleChecks,
+      comments: [
+        ...(input.comments ?? []),
+        {
+          id: 'stale-run-waiver',
+          author: { login: 'kurone-kito' },
+          body: waiverBody,
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T00:00:00Z',
+        },
+      ],
+    },
+    {
+      ...fixture.options,
+      includeDispositionEvidence: true,
+      waivableCheckSelectors,
+      externalCheckWaiverMaxValidity: 'PT24H',
+      externalCheckWaiverMode: 'maintainer-authorized',
+      // Deadline opens at 2026-05-11T23:00:00Z (24h after HEAD committed);
+      // the check's own live run last completed before both that moment
+      // AND the waiver's own createdAt (2026-05-12T00:00:00Z).
+      advisoryConvergenceHeadCommittedAt: '2026-05-10T23:00:00Z',
+    },
+  );
+
+  const precondition = (
+    blocked as {
+      advisoryConvergenceWaiverPrecondition: Record<string, unknown>;
+    }
+  ).advisoryConvergenceWaiverPrecondition;
+  assert.equal(precondition.open, true);
+
+  const waiverEvidence = blocked.waiverEvidence as {
+    valid: Record<string, unknown>[];
+  };
+  assert.equal(waiverEvidence.valid.length, 1);
+  assert.equal(
+    waiverEvidence.valid[0].checkSelector,
+    'idd-advisory-convergence',
+  );
+
+  const check = ciCheckByName(blocked, 'idd-advisory-convergence');
+  assert.equal(check?.coveredByWaiver, undefined);
+  assert.equal(blocked.ready, false);
+  assert.deepEqual(blocked.blockers, computePreMergeReadinessBlockers(blocked));
+  const ciBlocker = (
+    blocked.blockers as { gate: string; detail: string }[]
+  ).find((blocker) => blocker.gate === 'ci');
+  assert.ok(ciBlocker, 'expected a ci blocker');
+  assert.match(
+    ciBlocker?.detail ?? '',
+    /its live run last completed at "2026-05-11T23:30:00Z"/,
+  );
+});
+
+// #2034: the same waiver covers the check once its live run completes AFTER
+// the waiver became genuinely active -- confirming the freshness gate does
+// not regress the intended-working, actually-rerun case.
+test('#2034: the same idd-advisory-convergence waiver is covered once the check completes a fresh run after the waiver took effect', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const input = withAdvisoryConvergenceRequiredCheck(fixture);
+  const freshChecks = (input.checks ?? []).map((check) =>
+    check.name === 'idd-advisory-convergence'
+      ? { ...check, completedAt: '2026-05-12T00:15:00Z' }
+      : check,
+  );
+  const waivableCheckSelectors = [
+    { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+  ];
+  const waiverBody = renderExternalCheckWaiverComment({
+    agentId: fixture.options.expectedAgentId,
+    claimId: fixture.options.expectedClaimId,
+    headSha: fixture.input.prHeadSha,
+    checkSelector: 'idd-advisory-convergence',
+    reason: 'idd-advisory-convergence would not converge across 3 rounds',
+    expiresAt: '2026-05-13T00:00:00Z',
+    actor: 'kurone-kito',
+  });
+
+  const covered = buildPreMergeReadinessSummary(
+    {
+      ...input,
+      checks: freshChecks,
+      comments: [
+        ...(input.comments ?? []),
+        {
+          id: 'fresh-run-waiver',
           author: { login: 'kurone-kito' },
           body: waiverBody,
           createdAt: '2026-05-12T00:00:00Z',

--- a/tests/required-checks-summary.test.mts
+++ b/tests/required-checks-summary.test.mts
@@ -258,6 +258,7 @@ test('discardedNonPassingRequiredChecks still surfaces a waived CANCELLED siblin
         checkSelector: 'lint',
         reason: 'known-flaky-cancel',
         expiresAt: '2099-01-01T00:00:00Z',
+        createdAt: '2026-07-17T00:00:00Z',
       },
     ],
     expired: [],


### PR DESCRIPTION
Closes #2034

## Summary

- `coveredByWaiver` (`pre-merge-readiness.mjs`) treated a required
  check as covered the moment a valid `idd-external-check-waiver:`
  marker existed, based purely on the check's currently-reported live
  state — it never confirmed the check had actually been re-run since
  the waiver became genuinely active. A session trusting `ready: true`
  / `coveredByWaiver: true` immediately after posting a waiver could
  still see `gh pr merge` rejected by GitHub's branch protection, since
  the real check-run could still carry its pre-waiver `FAILURE`
  conclusion.
- `summarizeExternalCheckWaivers` now records each `valid` waiver
  entry's own comment `createdAt` (`'none'` when unparseable, which
  fails closed).
- `summarizeRequiredChecks` gains a `waiverActiveSinceOverride` option
  and only reports `coveredByWaiver: true` when a matched check's
  `completedAt` is at or after the moment its waiver became genuinely
  active — the waiver's own `createdAt` for a generic waivable check.
  Also fails closed when a check has no `completedAt` at all (never
  run).
- `buildPreMergeReadinessSummary` passes an override for
  `idd-advisory-convergence` specifically: its waiver becomes active
  no earlier than the #2021 deadline/terminal precondition-open
  moment, so the cutoff there is the later of the waiver's own
  `createdAt` and that moment. The terminal-unavailability path has no
  natural timestamp to anchor on, so it intentionally falls back to
  the waiver's own `createdAt`.
- When the freshness gate is what withholds `idd-advisory-convergence`
  coverage specifically, the `ci` blocker's detail now names the stale
  run's `completedAt` and the waiver's own `createdAt`, mirroring the
  existing precondition-not-open and no-exact-selector reasons.
- Updated `schemas/pre-merge-readiness.schema.json` for the new
  `valid[].createdAt` field, and `docs/idd-helper-scripts.md` (plus
  its `idd-template/` mirror, kept byte-identical) to document the new
  gate.
- Fixed several pre-existing tests whose waiver/check fixtures did not
  model a fresh post-waiver rerun, plus one added regression test for
  the no-`completedAt`-at-all fail-closed case.
- 2 new end-to-end tests per the issue's acceptance criteria: a valid,
  precondition-satisfied waiver posted after the check's live run last
  completed (still blocked, evidence names the stale run); the same
  waiver after a fresh run completes (covered).

## Test plan

- [x] `node --experimental-strip-types --test tests/pre-merge-readiness.test.mts` (257 pass)
- [x] `node --experimental-strip-types --test tests/required-checks-summary.test.mts`
- [x] `node --experimental-strip-types --test tests/schema-type-reconciliation.test.mts`
- [x] `node --experimental-strip-types --test tests/*.test.mts` (3576 pass)
- [x] `pnpm run lint:minimum`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Waivers now record their creation time and only apply to check runs completed after activation.
  * Advisory-convergence waivers now respect deadline and terminal preconditions.
* **Bug Fixes**
  * Stale or missing check runs remain blocked instead of being incorrectly covered by waivers.
  * Blocker details now show relevant run, waiver, and deadline timestamps.
* **Documentation**
  * Updated pre-merge readiness guidance to explain waiver timing and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->