### PR TITLE
fix(pre-merge-readiness): use advisory-convergence's own review evidence

### DIFF
--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -36,7 +36,6 @@ import {
   buildPreMergeReadinessSummary,
   DEFAULT_STALE_AGE_MS,
   deriveIddAgentLogins,
-  findLastCopilotReviewCommit,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
   parsePaginatedGhNdjson,
@@ -47,7 +46,10 @@ import {
   resolveTrustedMarkerActors,
   selectCodeownersText,
 } from './protocol-helpers.mjs';
-import { fetchReviewsAndHeadCommit } from './review-clause.mjs';
+import {
+  fetchReviewsAndHeadCommit,
+  resolveLatestCopilotReviewClause,
+} from './review-clause.mjs';
 
 // GitHub's GraphQL `DateTime` scalar can't be null, so a `CheckRun` that
 // has not completed yet (and a `StatusContext`, which has no completedAt
@@ -375,6 +377,24 @@ export function collectPreMergeReadiness(argv) {
   const now = args.now || new Date().toISOString().replace('.000Z', 'Z');
   const normalizedComments = comments.map(normalizeComment);
   const normalizedReviews = reviews.map(normalizeReview);
+  // #2021: fetch the current HEAD commit's own `committedDate`, plus every
+  // PR review, via the SAME GraphQL query `advisory-convergence.mts`'s own
+  // deadline clock and Clause-1 review evidence both read
+  // (`fetchReviewsAndHeadCommit`, extracted to `review-clause.mts` precisely
+  // so a second, independent caller can reuse this exact evidence instead of
+  // a second ad-hoc GraphQL path that could drift out of sync with it -- see
+  // that module's header). Deliberately uncaught, same rationale as
+  // `copilotUnavailable` below: a lookup failure must crash this evidence
+  // collector rather than silently resolve to an empty `headCommittedAt`,
+  // which would make `advisoryConvergenceDeadlinePassed` fail closed to
+  // `false` for the wrong reason (masking a genuinely-open deadline as
+  // unreadable evidence instead of surfacing the fetch failure).
+  const {
+    reviews: advisoryConvergenceReviews,
+    headCommittedAt: advisoryConvergenceHeadCommittedAt,
+  } = fetchReviewsAndHeadCommit(owner, repo, args.prNumber);
+  const advisoryConvergenceDeadlineMinutes =
+    readAdvisoryConvergenceDeadlineMinutes();
   // #1570: precompute the `#1572` terminal Copilot-unavailability verdict
   // here (the CLI/orchestration layer) rather than inside
   // `buildPreMergeReadinessSummary` (protocol-helpers.mts), which cannot
@@ -393,10 +413,29 @@ export function collectPreMergeReadiness(argv) {
   // collectors only"): a crash here is evidence collection failing
   // loudly, and callers already know to fall back to the portable
   // gh/jq/API procedure rather than trust a helper that could not run.
-  const lastCopilotCommit = findLastCopilotReviewCommit(
-    normalizedReviews,
+  //
+  // #2042: `lastCopilotCommit` now resolves via
+  // `resolveLatestCopilotReviewClause` against the SAME GraphQL review
+  // evidence (`advisoryConvergenceReviews`, absolute-latest by fetch order)
+  // `advisory-convergence.mts`'s own required check uses for its identical
+  // `review.commitId` input (advisory-convergence.mts ~line 1087) -- not
+  // the separate REST/`submittedAt`-sorted `findLastCopilotReviewCommit`
+  // path this caller used before. That prior REST path is a second,
+  // independently-timed fetch that can disagree with the GraphQL evidence
+  // under a force-push/revert reordering (advisory-convergence.mts's own
+  // comment on this exact gap, ~line 1070); `copilotUnavailable` computed
+  // here is the sole evidence source for BOTH the `idd-advisory-convergence`
+  // waiver precondition below AND the dedicated `copilot-terminal-unavailable`
+  // blocker (`buildPreMergeReadinessSummary`'s `options.copilotUnavailable`,
+  // reported back as `advisoryWait.copilotUnavailable` -- there is no
+  // separate source to preserve for that second consumer; both already
+  // shared this single value before this fix, so unifying the evidence
+  // source here fixes both at once).
+  const lastCopilotCommit = resolveLatestCopilotReviewClause(
+    advisoryConvergenceReviews,
+    prHeadSha,
     primaryBotLogin,
-  );
+  ).commitId;
   const copilotRecovery = buildCopilotRecoverySummary(
     { comments: normalizedComments, prHeadSha, lastCopilotCommit },
     {
@@ -409,23 +448,6 @@ export function collectPreMergeReadiness(argv) {
     },
   );
   const copilotUnavailable = copilotRecovery.state === 'COPILOT_UNAVAILABLE';
-  // #2021: fetch the current HEAD commit's own `committedDate` via the SAME
-  // GraphQL field `advisory-convergence.mts`'s own deadline clock reads
-  // (`fetchReviewsAndHeadCommit`, extracted to `review-clause.mts` precisely
-  // so a second, independent caller can reuse this exact evidence instead of
-  // a second ad-hoc GraphQL path that could drift out of sync with it -- see
-  // that module's header). Only `headCommittedAt` is used here; the
-  // paginated `reviews` return value is discarded since this caller already
-  // fetched reviews separately via REST above. Deliberately uncaught, same
-  // rationale as `copilotUnavailable` immediately above: a lookup failure
-  // must crash this evidence collector rather than silently resolve to an
-  // empty `headCommittedAt`, which would make `advisoryConvergenceDeadlinePassed`
-  // fail closed to `false` for the wrong reason (masking a genuinely-open
-  // deadline as unreadable evidence instead of surfacing the fetch failure).
-  const { headCommittedAt: advisoryConvergenceHeadCommittedAt } =
-    fetchReviewsAndHeadCommit(owner, repo, args.prNumber);
-  const advisoryConvergenceDeadlineMinutes =
-    readAdvisoryConvergenceDeadlineMinutes();
   const summary = buildPreMergeReadinessSummary(
     {
       prHeadSha,

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -43,7 +43,6 @@ import {
   buildPreMergeReadinessSummary,
   DEFAULT_STALE_AGE_MS,
   deriveIddAgentLogins,
-  findLastCopilotReviewCommit,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
   parsePaginatedGhNdjson,
@@ -54,7 +53,10 @@ import {
   resolveTrustedMarkerActors,
   selectCodeownersText,
 } from './protocol-helpers.mts';
-import { fetchReviewsAndHeadCommit } from './review-clause.mts';
+import {
+  fetchReviewsAndHeadCommit,
+  resolveLatestCopilotReviewClause,
+} from './review-clause.mts';
 
 /** Author reference embedded in GitHub REST/GraphQL payloads. */
 interface GhAuthorPayload {
@@ -595,6 +597,25 @@ export function collectPreMergeReadiness(
   const normalizedComments = comments.map(normalizeComment);
   const normalizedReviews = reviews.map(normalizeReview);
 
+  // #2021: fetch the current HEAD commit's own `committedDate`, plus every
+  // PR review, via the SAME GraphQL query `advisory-convergence.mts`'s own
+  // deadline clock and Clause-1 review evidence both read
+  // (`fetchReviewsAndHeadCommit`, extracted to `review-clause.mts` precisely
+  // so a second, independent caller can reuse this exact evidence instead of
+  // a second ad-hoc GraphQL path that could drift out of sync with it -- see
+  // that module's header). Deliberately uncaught, same rationale as
+  // `copilotUnavailable` below: a lookup failure must crash this evidence
+  // collector rather than silently resolve to an empty `headCommittedAt`,
+  // which would make `advisoryConvergenceDeadlinePassed` fail closed to
+  // `false` for the wrong reason (masking a genuinely-open deadline as
+  // unreadable evidence instead of surfacing the fetch failure).
+  const {
+    reviews: advisoryConvergenceReviews,
+    headCommittedAt: advisoryConvergenceHeadCommittedAt,
+  } = fetchReviewsAndHeadCommit(owner, repo, args.prNumber);
+  const advisoryConvergenceDeadlineMinutes =
+    readAdvisoryConvergenceDeadlineMinutes();
+
   // #1570: precompute the `#1572` terminal Copilot-unavailability verdict
   // here (the CLI/orchestration layer) rather than inside
   // `buildPreMergeReadinessSummary` (protocol-helpers.mts), which cannot
@@ -613,10 +634,29 @@ export function collectPreMergeReadiness(
   // collectors only"): a crash here is evidence collection failing
   // loudly, and callers already know to fall back to the portable
   // gh/jq/API procedure rather than trust a helper that could not run.
-  const lastCopilotCommit = findLastCopilotReviewCommit(
-    normalizedReviews,
+  //
+  // #2042: `lastCopilotCommit` now resolves via
+  // `resolveLatestCopilotReviewClause` against the SAME GraphQL review
+  // evidence (`advisoryConvergenceReviews`, absolute-latest by fetch order)
+  // `advisory-convergence.mts`'s own required check uses for its identical
+  // `review.commitId` input (advisory-convergence.mts ~line 1087) -- not
+  // the separate REST/`submittedAt`-sorted `findLastCopilotReviewCommit`
+  // path this caller used before. That prior REST path is a second,
+  // independently-timed fetch that can disagree with the GraphQL evidence
+  // under a force-push/revert reordering (advisory-convergence.mts's own
+  // comment on this exact gap, ~line 1070); `copilotUnavailable` computed
+  // here is the sole evidence source for BOTH the `idd-advisory-convergence`
+  // waiver precondition below AND the dedicated `copilot-terminal-unavailable`
+  // blocker (`buildPreMergeReadinessSummary`'s `options.copilotUnavailable`,
+  // reported back as `advisoryWait.copilotUnavailable` -- there is no
+  // separate source to preserve for that second consumer; both already
+  // shared this single value before this fix, so unifying the evidence
+  // source here fixes both at once).
+  const lastCopilotCommit = resolveLatestCopilotReviewClause(
+    advisoryConvergenceReviews,
+    prHeadSha,
     primaryBotLogin,
-  );
+  ).commitId;
   const copilotRecovery = buildCopilotRecoverySummary(
     { comments: normalizedComments, prHeadSha, lastCopilotCommit },
     {
@@ -629,24 +669,6 @@ export function collectPreMergeReadiness(
     },
   );
   const copilotUnavailable = copilotRecovery.state === 'COPILOT_UNAVAILABLE';
-
-  // #2021: fetch the current HEAD commit's own `committedDate` via the SAME
-  // GraphQL field `advisory-convergence.mts`'s own deadline clock reads
-  // (`fetchReviewsAndHeadCommit`, extracted to `review-clause.mts` precisely
-  // so a second, independent caller can reuse this exact evidence instead of
-  // a second ad-hoc GraphQL path that could drift out of sync with it -- see
-  // that module's header). Only `headCommittedAt` is used here; the
-  // paginated `reviews` return value is discarded since this caller already
-  // fetched reviews separately via REST above. Deliberately uncaught, same
-  // rationale as `copilotUnavailable` immediately above: a lookup failure
-  // must crash this evidence collector rather than silently resolve to an
-  // empty `headCommittedAt`, which would make `advisoryConvergenceDeadlinePassed`
-  // fail closed to `false` for the wrong reason (masking a genuinely-open
-  // deadline as unreadable evidence instead of surfacing the fetch failure).
-  const { headCommittedAt: advisoryConvergenceHeadCommittedAt } =
-    fetchReviewsAndHeadCommit(owner, repo, args.prNumber);
-  const advisoryConvergenceDeadlineMinutes =
-    readAdvisoryConvergenceDeadlineMinutes();
 
   const summary = buildPreMergeReadinessSummary(
     {

--- a/tests/pre-merge-readiness-collection-smoke.test.mts
+++ b/tests/pre-merge-readiness-collection-smoke.test.mts
@@ -165,6 +165,16 @@ function ndjson(items: unknown[]): string {
   return items.map((item) => JSON.stringify(item)).join('\n');
 }
 
+// #2042: `fetchReviewsAndHeadCommit`'s fixture `committedDate`, hoisted to
+// module scope so the stub script (which embeds it) and the end-to-end
+// assertion below (which checks the parsed value round-tripped correctly)
+// share one source of truth instead of two independently-typed literals.
+// 1h before this suite's fixed `--now` (2026-08-01T00:00:00Z), well inside
+// the 24h default deadline, so `advisoryConvergenceDeadlinePassed` stays
+// `false` and this fixture does not perturb either scenario's existing
+// `ready`/blockers assertions.
+const REVIEWS_AND_HEAD_COMMIT_COMMITTED_DATE = '2026-07-31T23:00:00Z';
+
 /**
  * Build a stub `gh` Node script answering every call
  * `collectPreMergeReadiness` makes for the fixed OWNER/REPO/PR_NUMBER/
@@ -246,6 +256,39 @@ function buildStubGhScript(threadResolved: boolean): string {
       },
     },
   };
+  // #2042: `fetchReviewsAndHeadCommit` (review-clause.mts) issues its OWN
+  // `gh api graphql` call, distinct from the review-threads query above --
+  // matches on the `reviewThreads(` field name unique to that query (see
+  // the stub script below).
+  const reviewsAndHeadCommitPayload = {
+    data: {
+      repository: {
+        pullRequest: {
+          reviews: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              {
+                commit: { oid: prView.headRefOid },
+                submittedAt: '2026-07-31T12:00:00Z',
+                author: { login: 'reviewer-user', __typename: 'User' },
+                comments: { totalCount: 0 },
+                body: '',
+              },
+            ],
+          },
+          commits: {
+            nodes: [
+              {
+                commit: {
+                  committedDate: REVIEWS_AND_HEAD_COMMIT_COMMITTED_DATE,
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  };
 
   // Each branch below matches one distinct call `collectPreMergeReadiness`
   // makes. An unmatched call falls through to the final handler, which
@@ -271,7 +314,8 @@ if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/pulls/${PR_NUMBER}/requeste
 if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/issues/${PR_NUMBER}/timeline`}') out('');
 if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/issues/${PR_NUMBER}/comments`}') out(${JSON.stringify(ndjson(prComments))});
 if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/issues/${CLAIM_ISSUE}/comments`}') out(${JSON.stringify(ndjson(claimComments))});
-if (a(0) === 'api' && a(1) === 'graphql') out(${JSON.stringify(JSON.stringify(reviewThreadsPayload))});
+if (a(0) === 'api' && a(1) === 'graphql' && args.join(' ').includes('reviewThreads(')) out(${JSON.stringify(JSON.stringify(reviewThreadsPayload))});
+if (a(0) === 'api' && a(1) === 'graphql') out(${JSON.stringify(JSON.stringify(reviewsAndHeadCommitPayload))});
 if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/pulls/${PR_NUMBER}/files`}') out(${JSON.stringify(ndjson(changedFiles))});
 if (a(0) === 'api' && String(a(1)).startsWith('${`repos/${REPO_REF}/contents/`}')) notFound();
 process.stderr.write('unexpected gh invocation: ' + args.join(' ') + '\\n');
@@ -375,6 +419,20 @@ test('pre-merge-readiness.mjs CLI: clean scenario collects and normalizes raw gh
   };
   assert.equal(dispositionEvidence.missingThreads[0]?.id, 'RT_1');
   assert.equal(dispositionEvidence.missingThreads[0]?.isResolved, true);
+
+  // #2042: `fetchReviewsAndHeadCommit`'s own `gh api graphql` call must
+  // receive `reviewsAndHeadCommitPayload`, not `reviewThreadsPayload` --
+  // asserting the parsed `headCommittedAt` end-to-end catches a stub (or
+  // production query) drift that would otherwise silently leave this call
+  // site fed the wrong payload shape (it would parse to `''`/"none"
+  // without failing this test, the exact gap #2042 closes).
+  const precondition = report.advisoryConvergenceWaiverPrecondition as {
+    headCommittedAt: string;
+  };
+  assert.equal(
+    precondition.headCommittedAt,
+    REVIEWS_AND_HEAD_COMMIT_COMMITTED_DATE,
+  );
 });
 
 test('pre-merge-readiness.mjs CLI: blocked scenario (one unresolved review thread) surfaces it end-to-end', () => {

--- a/tests/pre-merge-readiness-collection-smoke.test.mts
+++ b/tests/pre-merge-readiness-collection-smoke.test.mts
@@ -257,9 +257,13 @@ function buildStubGhScript(threadResolved: boolean): string {
     },
   };
   // #2042: `fetchReviewsAndHeadCommit` (review-clause.mts) issues its OWN
-  // `gh api graphql` call, distinct from the review-threads query above --
-  // matches on the `reviewThreads(` field name unique to that query (see
-  // the stub script below).
+  // `gh api graphql` call, distinct from the review-threads query above.
+  // The stub script below matches each query on a field name unique to it
+  // (`reviewThreads` here, `committedDate` for this payload) rather than
+  // "the other query didn't match" -- so a third, genuinely unexpected
+  // GraphQL call falls through to the script's final `unexpected gh
+  // invocation` failure instead of silently receiving whichever fixture
+  // happened to be the catch-all.
   const reviewsAndHeadCommitPayload = {
     data: {
       repository: {
@@ -314,8 +318,8 @@ if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/pulls/${PR_NUMBER}/requeste
 if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/issues/${PR_NUMBER}/timeline`}') out('');
 if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/issues/${PR_NUMBER}/comments`}') out(${JSON.stringify(ndjson(prComments))});
 if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/issues/${CLAIM_ISSUE}/comments`}') out(${JSON.stringify(ndjson(claimComments))});
-if (a(0) === 'api' && a(1) === 'graphql' && args.join(' ').includes('reviewThreads(')) out(${JSON.stringify(JSON.stringify(reviewThreadsPayload))});
-if (a(0) === 'api' && a(1) === 'graphql') out(${JSON.stringify(JSON.stringify(reviewsAndHeadCommitPayload))});
+if (a(0) === 'api' && a(1) === 'graphql' && args.join(' ').includes('reviewThreads')) out(${JSON.stringify(JSON.stringify(reviewThreadsPayload))});
+if (a(0) === 'api' && a(1) === 'graphql' && args.join(' ').includes('committedDate')) out(${JSON.stringify(JSON.stringify(reviewsAndHeadCommitPayload))});
 if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/pulls/${PR_NUMBER}/files`}') out(${JSON.stringify(ndjson(changedFiles))});
 if (a(0) === 'api' && String(a(1)).startsWith('${`repos/${REPO_REF}/contents/`}')) notFound();
 process.stderr.write('unexpected gh invocation: ' + args.join(' ') + '\\n');


### PR DESCRIPTION
Closes #2042

## Summary

- The `idd-advisory-convergence` waiver precondition's `copilotUnavailable`
  input was computed in `pre-merge-readiness.mts` from REST reviews
  sorted by `submittedAt` (`findLastCopilotReviewCommit`), while
  `advisory-convergence.mts`'s own required check computes its terminal
  verdict from the GraphQL absolute-latest review returned by
  `fetchReviewsAndHeadCommit` — a disagreement risk that module's own
  code comment already documents (force-push/revert reordering). In the
  permissive direction, `pre-merge-readiness.mjs` could report
  `advisoryConvergenceGenuinelyCovered: true` prematurely, echoing
  #2021's false-`ready` problem in a narrower form for the
  terminal-unavailability path.
- `pre-merge-readiness.mts`'s existing `fetchReviewsAndHeadCommit` call
  now also keeps its `reviews` return value (previously discarded) and
  resolves `lastCopilotCommit` via `resolveLatestCopilotReviewClause`
  against it — the exact same evidence and resolver
  `advisory-convergence.mts`'s own `review.commitId` uses.
  `copilotUnavailable` is the single value both the waiver precondition
  and the dedicated `copilot-terminal-unavailable` blocker already
  read, so this one evidence-source swap fixes both consumers at once
  — there was no independent source to preserve for the blocker.
- Extended `tests/pre-merge-readiness-collection-smoke.test.mts`'s `gh
  api graphql` stub to distinguish the review-threads query from the
  `fetchReviewsAndHeadCommit` query (previously a single unconditional
  handler served the review-threads fixture to both, so this call
  site's wiring was silently unverified), and added an end-to-end
  assertion on `advisoryConvergenceWaiverPrecondition.headCommittedAt`.

## Test plan

- [x] `node --experimental-strip-types --test tests/pre-merge-readiness.test.mts` (263 pass)
- [x] `node --experimental-strip-types --test tests/pre-merge-readiness-collection-smoke.test.mts` (6 pass)
- [x] `node --experimental-strip-types --test tests/*.test.mts` (3576 pass)
- [x] `pnpm run lint:minimum`
