### PR TITLE
chore(config): shorten idd-skill's own advisory-convergence deadline

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -31,7 +31,8 @@
   "issueScope": "roadmap-first",
   "orphanFirstPolicy": "none",
   "advisoryWait": {
-    "convergenceScope": "idd-claimed"
+    "convergenceScope": "idd-claimed",
+    "convergenceDeadline": "PT9H"
   },
   "discover": {
     "selectionDesync": "session-offset"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,13 @@ own interaction model rather than following product terms literally.
   loop cannot converge on its own (Refs #1465). See
   [`.github/copilot-instructions.md`](.github/copilot-instructions.md#local-external-check-waiver-policy)
   for the full rationale.
+- **Advisory-convergence deadline**: This source repository also
+  records `advisoryWait.convergenceDeadline: "PT9H"` as a local IDD
+  dogfooding policy (applies only to `kurone-kito/idd-skill`),
+  shortening the maintainer-authorized-waiver deadline from the
+  distributed `idd-template/` default (`PT24H`) to fit this
+  repository's more autonomous, higher-concurrency dogfooding setup
+  (Refs #1465, #2076).
 
 ## For IDD work
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,13 @@ terms literally.
   loop cannot converge on its own (Refs #1465). See
   [`.github/copilot-instructions.md`](.github/copilot-instructions.md#local-external-check-waiver-policy)
   for the full rationale.
+- **Advisory-convergence deadline**: This source repository also
+  records `advisoryWait.convergenceDeadline: "PT9H"` as a local IDD
+  dogfooding policy (applies only to `kurone-kito/idd-skill`),
+  shortening the maintainer-authorized-waiver deadline from the
+  distributed `idd-template/` default (`PT24H`) to fit this
+  repository's more autonomous, higher-concurrency dogfooding setup
+  (Refs #1465, #2076).
 
 ## For IDD work
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -91,6 +91,13 @@ own interaction model rather than following product terms literally.
   loop cannot converge on its own (Refs #1465). See
   [`.github/copilot-instructions.md`](.github/copilot-instructions.md#local-external-check-waiver-policy)
   for the full rationale.
+- **Advisory-convergence deadline**: This source repository also
+  records `advisoryWait.convergenceDeadline: "PT9H"` as a local IDD
+  dogfooding policy (applies only to `kurone-kito/idd-skill`),
+  shortening the maintainer-authorized-waiver deadline from the
+  distributed `idd-template/` default (`PT24H`) to fit this
+  repository's more autonomous, higher-concurrency dogfooding setup
+  (Refs #1465, #2076).
 
 ## For IDD work
 


### PR DESCRIPTION
Closes #2076

## Summary

- `advisoryWait.convergenceDeadline` is already a fully implemented,
  schema-validated config key (`advisory-wait-policy.mts`'s
  `resolveAdvisoryConvergenceDeadlineMinutes`, `PT24H` default) — this
  repository's own `.github/idd/config.json` never set it, so it ran
  on the implicit adopter default despite already running a more
  autonomous, higher-concurrency dogfooding setup than the template
  default and already relying on the maintainer-authorized waiver as
  its accepted human off-ramp (Refs #1465).
- Set `advisoryWait.convergenceDeadline` to `PT9H` in this
  repository's own `.github/idd/config.json` only — `idd-template/`'s
  distributed default stays `PT24H`.
- Recorded it as a fourth `kurone-kito/idd-skill`-only dogfooding
  policy bullet in `CLAUDE.md`/`AGENTS.md`/`GEMINI.md`'s shared "Key
  workflow rules" section (all three, since
  `tests/agent-entry-mirror-sync.test.mts` requires that section to
  stay textually identical across the three agent-entry files — the
  issue's own "Candidate files" list only named `CLAUDE.md`, but the
  actual repo convention requires all three), matching the wording
  pattern of the three existing dogfooding-policy bullets there.

## Test plan

- [x] `node scripts/idd-doctor.mjs` reports
      `.github/idd/config.json validates against policy.schema.json`
- [x] `readAdvisoryConvergenceDeadlineMinutes()` resolves to `540`
      (9h) for this repository
- [x] `node --experimental-strip-types --test tests/*.test.mts` (3576 pass)
- [x] `pnpm run lint:minimum`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Updated the advisory convergence deadline from 24 hours to 9 hours.
  - Advisory decisions will now reach their deadline sooner, helping workflows progress more quickly when convergence is not achieved.

- **Documentation**
  - Added consistent local policy guidance describing the updated advisory deadline across supported development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->