### PR TITLE
docs(onboarding): fix two links to the undistributed ONBOARDING.md

### DIFF
--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -391,7 +391,7 @@ through GitHub's classic branch-protection API uses the explicit
   (observed 2026-08-11 onboarding a companion repository;
   [kurone-kito/idd-skill#1925](https://github.com/kurone-kito/idd-skill/issues/1925)).
   See [ONBOARDING.md's required-status-check registration
-  step](../../ONBOARDING.md#optional--host-idd-advisory-convergence-as-a-required-check-ci-workflow)
+  step](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#optional--host-idd-advisory-convergence-as-a-required-check-ci-workflow)
   for the working `PATCH` snippet, including the merge caveat (`PATCH`
   replaces the whole `checks` list) and the producer-pinning trade-off
   of `app_id: -1`.

--- a/idd-template/docs/onboarding/template-distribution.md
+++ b/idd-template/docs/onboarding/template-distribution.md
@@ -131,7 +131,7 @@ the other files `collectVendoredFiles` manages under the source
 repository's own `scripts/` have an `idd-template/` mirror. Getting the
 **complete** `vendored-node` bundle requires running this from the clone
 (see
-[CLI-assisted onboarding](../../ONBOARDING.md#cli-assisted-onboarding)):
+[CLI-assisted onboarding](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#cli-assisted-onboarding)):
 
 ```sh
 node scripts/idd-onboard.mjs --import --source <path-to-a-cloned-idd-skill-tree> \


### PR DESCRIPTION
Closes #2062

## Summary

- `idd-template/docs/onboarding/template-distribution.md:134` and
  `idd-template/docs/onboarding/policy-decisions.md:394` both linked
  to `../../ONBOARDING.md`, which resolves correctly only inside this
  repository — `idd-template/ONBOARDING.md` is deliberately excluded
  from the generated distributed file list, so after distribution the
  same relative path 404s for every adopter in every profile.
- Repointed both links to absolute upstream URLs
  (`https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#...`),
  matching the precedent `docs/customization.md` already uses for the
  identical situation — including the exact same anchor
  `policy-decisions.md`'s link needed, already proven reachable there.

## Note for a follow-up

While verifying `grep -rn '\.\./\.\./ONBOARDING\.md' idd-template/`
returned clean after this fix, I found one more occurrence of the
identical pattern the issue's own "Out of scope" section explicitly
deferred (a repository-wide audit): `idd-template/docs/onboarding/issue-mediated-bootstrap.md:390`.
Left unfixed here to stay within this issue's stated scope; will
report separately.

## Test plan

- [x] `grep -rn '\.\./\.\./ONBOARDING\.md' idd-template/` returns no
      matches for either fixed file
- [x] `node scripts/markdown-link-audit.mjs` exits 0
- [x] `node scripts/sync-docs.mjs --apply` produces no diff beyond the
      intended edit
- [x] `node scripts/audit-docs.mjs --check` passes
- [x] `node --experimental-strip-types --test tests/*.test.mts` (3576 pass)
- [x] `pnpm run lint:minimum`
