### PR TITLE
fix(workflows): pin shipped workflow run steps to bash

### DIFF
--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -19,7 +19,11 @@ name: IDD advisory-convergence gate
 # that mandates self-hosted runners even on github.com/GHEC hits the
 # same wall and can use the same variable. This mechanism works for
 # whatever the shipped fallback value is now or later, not
-# specifically `ubuntu-latest`.
+# specifically `ubuntu-latest`. Whatever label you point this at must
+# still be bash-capable: `defaults.run.shell` below pins every `run:`
+# step to `bash` regardless of runner OS, since GitHub Actions'
+# per-OS default shell (PowerShell Core on Windows) would otherwise
+# silently misinterpret this file's POSIX shell syntax.
 #
 # Adjust the pinned `actions/checkout` SHA (or use the floating `@v4`
 # tag as shipped here), the checkout `ref:` (see below), and the
@@ -53,6 +57,16 @@ permissions:
   contents: read
   issues: read
   pull-requests: read
+defaults:
+  run:
+    # Pins every run: step's shell regardless of runner OS -- GitHub
+    # Actions otherwise picks bash on Linux/macOS but PowerShell Core
+    # on Windows, which would silently misinterpret this file's POSIX
+    # shell syntax (e.g. "$PR_NUMBER" as an undefined PowerShell
+    # variable) instead of failing loudly. Available on every
+    # GitHub-hosted runner, including Windows via Git Bash, so this is
+    # a no-op on the runners this template ships for today.
+    shell: bash
 jobs:
   # The job id `idd-advisory-convergence` is the exact check-run context
   # consumed by the rerun helper, advisory-wait policy, required status

--- a/idd-template/.github/workflows/post-merge-cleanup.yml
+++ b/idd-template/.github/workflows/post-merge-cleanup.yml
@@ -80,6 +80,15 @@ permissions:
 concurrency:
   group: post-merge-cleanup-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
   cancel-in-progress: false
+defaults:
+  run:
+    # Pins every run: step's shell regardless of runner OS -- GitHub
+    # Actions otherwise picks bash on Linux/macOS but PowerShell Core
+    # on Windows, which would silently misinterpret this file's POSIX
+    # command substitution and shell variable expansion instead of
+    # failing loudly. Available on every GitHub-hosted runner,
+    # including Windows via Git Bash.
+    shell: bash
 jobs:
   cleanup:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true


### PR DESCRIPTION
Closes #2070

## Summary

- Neither `idd-advisory-convergence.yml` nor `post-merge-cleanup.yml`
  declared a shell, so GitHub Actions falls back to its per-OS
  default: `bash` on Linux/macOS, **PowerShell Core** on Windows.
  `idd-advisory-convergence.yml` invites the adopter to repoint its
  runner via the `CI_RUNNER_LABEL` repository variable with no note
  that the `run:` steps assume a POSIX shell — on a Windows runner,
  `"$PR_NUMBER"` is an undefined PowerShell variable rather than an
  environment reference, so the step would run as `--pr ""` (silently
  wrong) rather than failing cleanly. `post-merge-cleanup.yml`'s five
  `run: |` blocks use command substitution and shell variable
  expansion that would fail outright under PowerShell.
- Added `defaults: { run: { shell: bash } }` at the workflow level to
  both files — `shell: bash` is available on every GitHub-hosted
  runner, including Windows via Git Bash, so this is a no-op on the
  runners these templates actually run on today.
- Added a one-line note to `idd-advisory-convergence.yml`'s existing
  `CI_RUNNER_LABEL` documentation block naming the bash-capable-runner
  requirement.
- No step's command text, `env:`, `permissions:`, `concurrency:`,
  trigger set, or `runs-on` expression changed.

## Test plan

- [x] `actionlint idd-template/.github/workflows/idd-advisory-convergence.yml idd-template/.github/workflows/post-merge-cleanup.yml` (clean)
- [x] `node scripts/sync-docs.mjs --apply` produces no diff beyond the
      intended edit
- [x] `node scripts/audit-docs.mjs --check` passes
- [x] `node --experimental-strip-types --test tests/*.test.mts` (3576 pass)
- [x] `pnpm run lint:minimum`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow reliability by ensuring automation steps use consistent Bash shell behavior across supported runner operating systems.
  * Updated runner requirements to clarify that configured runners must support Bash.
  * Standardized shell execution for advisory convergence and post-merge cleanup workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->