### PR TITLE
feat(consistency): support N-clause engines.node in the mirror guard

### DIFF
--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -980,7 +980,7 @@ export function collectEnginesRangeMirrorViolations(
         const missing = clauses?.filter((clause) => !text.includes(clause));
         if (missing && missing.length > 0) {
           violations.push(
-            `engines-range-mirrors: ${mirror.file} does not mention all engines.node bounds ${missing.map((clause) => `"${clause}"`).join(', ')}`,
+            `engines-range-mirrors: ${mirror.file} does not mention all engines.node clause versions ${missing.map((clause) => `"${clause}"`).join(', ')}`,
           );
         }
         break;

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -908,16 +908,30 @@ export function collectDuplicateSyncPairTargets(syncPairs) {
   return violations;
 }
 /**
- * Parses `^<low>.<x>.<y> || >=<high>.<x>.<y>` -- the only shape this
- * repository's `engines.node` has ever used -- into its two version
- * bounds. Returns null when the range doesn't match that exact shape
- * (fail closed rather than guess at a different range grammar).
+ * Parses `^<v1>.<x>.<y> (|| ^<vN>.<x>.<y>)* || >=<high>.<x>.<y>` -- one or
+ * more `^` clauses, in written order, followed by exactly one trailing `>=`
+ * clause -- into an ordered list of version strings (the `>=` clause last).
+ * Returns null when the range doesn't match that exact shape: zero `^`
+ * clauses, a `>=` clause anywhere but last, or content after the trailing
+ * `>=` clause (fail closed rather than guess at a different range grammar).
+ * `#1706`'s original two-clause repository state (`^22.22.2 || >=24.2.0`)
+ * still parses to a 2-element list under this grammar (#2077).
  */
-function parseTwoClauseEnginesRange(engines) {
-  const match = /^\^(\d+\.\d+\.\d+)\s*\|\|\s*>=(\d+\.\d+\.\d+)$/.exec(
-    engines.trim(),
-  );
-  return match ? { low: match[1], high: match[2] } : null;
+function parseEnginesRangeClauses(engines) {
+  const parts = engines.trim().split(/\s*\|\|\s*/);
+  // Fewer than 2 parts means zero `^` clauses (either just a bare `>=`
+  // clause, or an unsplittable string) -- always invalid.
+  if (parts.length < 2) return null;
+  const highMatch = /^>=(\d+\.\d+\.\d+)$/.exec(parts[parts.length - 1]);
+  if (!highMatch) return null;
+  const clauses = [];
+  for (let index = 0; index < parts.length - 1; index += 1) {
+    const caretMatch = /^\^(\d+\.\d+\.\d+)$/.exec(parts[index]);
+    if (!caretMatch) return null;
+    clauses.push(caretMatch[1]);
+  }
+  clauses.push(highMatch[1]);
+  return clauses;
 }
 export function collectEnginesRangeMirrorViolations(
   enginesNode,
@@ -930,13 +944,17 @@ export function collectEnginesRangeMirrorViolations(
       'engines-range-mirrors: package.json engines.node is missing or not a string',
     ];
   }
-  const bounds = parseTwoClauseEnginesRange(engines);
+  const clauses = parseEnginesRangeClauses(engines);
   const violations = [];
-  if (!bounds) {
+  if (!clauses) {
     violations.push(
-      `engines-range-mirrors: engines.node "${engines}" does not match the expected "^<low> || >=<high>" shape; cannot verify mirrors`,
+      `engines-range-mirrors: engines.node "${engines}" does not match the expected "^<v1> (|| ^<vN>)* || >=<high>" shape; cannot verify mirrors`,
     );
   }
+  // The first clause is always the low bound: an ordered `^` clause list's
+  // first entry, followed by exactly one trailing `>=` clause -- unchanged
+  // meaning from the two-clause case's `low`.
+  const low = clauses?.[0];
   for (const mirror of mirrors) {
     let text;
     try {
@@ -955,27 +973,26 @@ export function collectEnginesRangeMirrorViolations(
           );
         }
         break;
-      case 'components':
-        if (
-          bounds &&
-          (!text.includes(bounds.low) || !text.includes(bounds.high))
-        ) {
+      case 'components': {
+        const missing = clauses?.filter((clause) => !text.includes(clause));
+        if (missing && missing.length > 0) {
           violations.push(
-            `engines-range-mirrors: ${mirror.file} does not mention both engines.node bounds "${bounds.low}" and "${bounds.high}"`,
+            `engines-range-mirrors: ${mirror.file} does not mention all engines.node bounds ${missing.map((clause) => `"${clause}"`).join(', ')}`,
           );
         }
         break;
+      }
       case 'low-bound-line':
-        if (bounds && text.trim() !== bounds.low) {
+        if (low !== undefined && text.trim() !== low) {
           violations.push(
-            `engines-range-mirrors: ${mirror.file} pins "${text.trim()}", expected the engines.node low bound "${bounds.low}"`,
+            `engines-range-mirrors: ${mirror.file} pins "${text.trim()}", expected the engines.node low bound "${low}"`,
           );
         }
         break;
       case 'low-bound-contains':
-        if (bounds && !text.includes(bounds.low)) {
+        if (low !== undefined && !text.includes(low)) {
           violations.push(
-            `engines-range-mirrors: ${mirror.file} does not mention the engines.node low bound "${bounds.low}"`,
+            `engines-range-mirrors: ${mirror.file} does not mention the engines.node low bound "${low}"`,
           );
         }
         break;

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -919,8 +919,11 @@ export function collectDuplicateSyncPairTargets(syncPairs) {
  */
 function parseEnginesRangeClauses(engines) {
   const parts = engines.trim().split(/\s*\|\|\s*/);
-  // Fewer than 2 parts means zero `^` clauses (either just a bare `>=`
-  // clause, or a string with no `||` separator at all) -- always invalid.
+  // Fewer than 2 parts means no `||`-separated trailing `>=` clause exists
+  // to anchor as the last part -- a bare `>=` clause with zero `^` clauses,
+  // a bare `^` clause with no `>=` clause at all, or any other single-part
+  // string. All are invalid: the grammar requires both a `^` clause and a
+  // trailing `>=` clause.
   if (parts.length < 2) return null;
   const highMatch = /^>=(\d+\.\d+\.\d+)$/.exec(parts[parts.length - 1]);
   if (!highMatch) return null;

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -920,7 +920,7 @@ export function collectDuplicateSyncPairTargets(syncPairs) {
 function parseEnginesRangeClauses(engines) {
   const parts = engines.trim().split(/\s*\|\|\s*/);
   // Fewer than 2 parts means zero `^` clauses (either just a bare `>=`
-  // clause, or an unsplittable string) -- always invalid.
+  // clause, or a string with no `||` separator at all) -- always invalid.
   if (parts.length < 2) return null;
   const highMatch = /^>=(\d+\.\d+\.\d+)$/.exec(parts[parts.length - 1]);
   if (!highMatch) return null;

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -1115,7 +1115,7 @@ export interface EnginesRangeMirrorSpec {
 function parseEnginesRangeClauses(engines: string): string[] | null {
   const parts = engines.trim().split(/\s*\|\|\s*/);
   // Fewer than 2 parts means zero `^` clauses (either just a bare `>=`
-  // clause, or an unsplittable string) -- always invalid.
+  // clause, or a string with no `||` separator at all) -- always invalid.
   if (parts.length < 2) return null;
 
   const highMatch = /^>=(\d+\.\d+\.\d+)$/.exec(parts[parts.length - 1]);

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -1114,8 +1114,11 @@ export interface EnginesRangeMirrorSpec {
  */
 function parseEnginesRangeClauses(engines: string): string[] | null {
   const parts = engines.trim().split(/\s*\|\|\s*/);
-  // Fewer than 2 parts means zero `^` clauses (either just a bare `>=`
-  // clause, or a string with no `||` separator at all) -- always invalid.
+  // Fewer than 2 parts means no `||`-separated trailing `>=` clause exists
+  // to anchor as the last part -- a bare `>=` clause with zero `^` clauses,
+  // a bare `^` clause with no `>=` clause at all, or any other single-part
+  // string. All are invalid: the grammar requires both a `^` clause and a
+  // trailing `>=` clause.
   if (parts.length < 2) return null;
 
   const highMatch = /^>=(\d+\.\d+\.\d+)$/.exec(parts[parts.length - 1]);

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -1179,7 +1179,7 @@ export function collectEnginesRangeMirrorViolations(
         const missing = clauses?.filter((clause) => !text.includes(clause));
         if (missing && missing.length > 0) {
           violations.push(
-            `engines-range-mirrors: ${mirror.file} does not mention all engines.node bounds ${missing.map((clause) => `"${clause}"`).join(', ')}`,
+            `engines-range-mirrors: ${mirror.file} does not mention all engines.node clause versions ${missing.map((clause) => `"${clause}"`).join(', ')}`,
           );
         }
         break;

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -1103,18 +1103,32 @@ export interface EnginesRangeMirrorSpec {
 }
 
 /**
- * Parses `^<low>.<x>.<y> || >=<high>.<x>.<y>` -- the only shape this
- * repository's `engines.node` has ever used -- into its two version
- * bounds. Returns null when the range doesn't match that exact shape
- * (fail closed rather than guess at a different range grammar).
+ * Parses `^<v1>.<x>.<y> (|| ^<vN>.<x>.<y>)* || >=<high>.<x>.<y>` -- one or
+ * more `^` clauses, in written order, followed by exactly one trailing `>=`
+ * clause -- into an ordered list of version strings (the `>=` clause last).
+ * Returns null when the range doesn't match that exact shape: zero `^`
+ * clauses, a `>=` clause anywhere but last, or content after the trailing
+ * `>=` clause (fail closed rather than guess at a different range grammar).
+ * `#1706`'s original two-clause repository state (`^22.22.2 || >=24.2.0`)
+ * still parses to a 2-element list under this grammar (#2077).
  */
-function parseTwoClauseEnginesRange(
-  engines: string,
-): { low: string; high: string } | null {
-  const match = /^\^(\d+\.\d+\.\d+)\s*\|\|\s*>=(\d+\.\d+\.\d+)$/.exec(
-    engines.trim(),
-  );
-  return match ? { low: match[1], high: match[2] } : null;
+function parseEnginesRangeClauses(engines: string): string[] | null {
+  const parts = engines.trim().split(/\s*\|\|\s*/);
+  // Fewer than 2 parts means zero `^` clauses (either just a bare `>=`
+  // clause, or an unsplittable string) -- always invalid.
+  if (parts.length < 2) return null;
+
+  const highMatch = /^>=(\d+\.\d+\.\d+)$/.exec(parts[parts.length - 1]);
+  if (!highMatch) return null;
+
+  const clauses: string[] = [];
+  for (let index = 0; index < parts.length - 1; index += 1) {
+    const caretMatch = /^\^(\d+\.\d+\.\d+)$/.exec(parts[index]);
+    if (!caretMatch) return null;
+    clauses.push(caretMatch[1]);
+  }
+  clauses.push(highMatch[1]);
+  return clauses;
 }
 
 export function collectEnginesRangeMirrorViolations(
@@ -1128,13 +1142,17 @@ export function collectEnginesRangeMirrorViolations(
       'engines-range-mirrors: package.json engines.node is missing or not a string',
     ];
   }
-  const bounds = parseTwoClauseEnginesRange(engines);
+  const clauses = parseEnginesRangeClauses(engines);
   const violations: string[] = [];
-  if (!bounds) {
+  if (!clauses) {
     violations.push(
-      `engines-range-mirrors: engines.node "${engines}" does not match the expected "^<low> || >=<high>" shape; cannot verify mirrors`,
+      `engines-range-mirrors: engines.node "${engines}" does not match the expected "^<v1> (|| ^<vN>)* || >=<high>" shape; cannot verify mirrors`,
     );
   }
+  // The first clause is always the low bound: an ordered `^` clause list's
+  // first entry, followed by exactly one trailing `>=` clause -- unchanged
+  // meaning from the two-clause case's `low`.
+  const low = clauses?.[0];
 
   for (const mirror of mirrors) {
     let text: string;
@@ -1154,27 +1172,26 @@ export function collectEnginesRangeMirrorViolations(
           );
         }
         break;
-      case 'components':
-        if (
-          bounds &&
-          (!text.includes(bounds.low) || !text.includes(bounds.high))
-        ) {
+      case 'components': {
+        const missing = clauses?.filter((clause) => !text.includes(clause));
+        if (missing && missing.length > 0) {
           violations.push(
-            `engines-range-mirrors: ${mirror.file} does not mention both engines.node bounds "${bounds.low}" and "${bounds.high}"`,
+            `engines-range-mirrors: ${mirror.file} does not mention all engines.node bounds ${missing.map((clause) => `"${clause}"`).join(', ')}`,
           );
         }
         break;
+      }
       case 'low-bound-line':
-        if (bounds && text.trim() !== bounds.low) {
+        if (low !== undefined && text.trim() !== low) {
           violations.push(
-            `engines-range-mirrors: ${mirror.file} pins "${text.trim()}", expected the engines.node low bound "${bounds.low}"`,
+            `engines-range-mirrors: ${mirror.file} pins "${text.trim()}", expected the engines.node low bound "${low}"`,
           );
         }
         break;
       case 'low-bound-contains':
-        if (bounds && !text.includes(bounds.low)) {
+        if (low !== undefined && !text.includes(low)) {
           violations.push(
-            `engines-range-mirrors: ${mirror.file} does not mention the engines.node low bound "${bounds.low}"`,
+            `engines-range-mirrors: ${mirror.file} does not mention the engines.node low bound "${low}"`,
           );
         }
         break;

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -1649,7 +1649,7 @@ test('collectEnginesRangeMirrorViolations: catches a stale full-range mention', 
   ]);
 });
 
-test('collectEnginesRangeMirrorViolations: components mode requires both bounds', () => {
+test('collectEnginesRangeMirrorViolations: components mode requires every clause, naming only what is missing', () => {
   const violations = collectEnginesRangeMirrorViolations(
     ENGINES_NODE,
     [{ file: 'prose.md', mode: 'components' }],
@@ -1657,7 +1657,7 @@ test('collectEnginesRangeMirrorViolations: components mode requires both bounds'
     () => 'Node.js 22.22.2 or newer',
   );
   assert.deepEqual(violations, [
-    `engines-range-mirrors: prose.md does not mention both engines.node bounds "22.22.2" and "24.2.0"`,
+    `engines-range-mirrors: prose.md does not mention all engines.node bounds "24.2.0"`,
   ]);
 });
 
@@ -1679,7 +1679,59 @@ test('collectEnginesRangeMirrorViolations: fails closed on a missing or non-stri
 test('collectEnginesRangeMirrorViolations: fails closed on an unrecognized range shape', () => {
   const violations = collectEnginesRangeMirrorViolations('>=18', [], () => '');
   assert.deepEqual(violations, [
-    'engines-range-mirrors: engines.node ">=18" does not match the expected "^<low> || >=<high>" shape; cannot verify mirrors',
+    'engines-range-mirrors: engines.node ">=18" does not match the expected "^<v1> (|| ^<vN>)* || >=<high>" shape; cannot verify mirrors',
+  ]);
+});
+
+test('collectEnginesRangeMirrorViolations: parses a three-clause range and requires all three components', () => {
+  const threeClause = '^22.23.2 || ^24.2.0 || >=26.0.0';
+  const passing = collectEnginesRangeMirrorViolations(
+    threeClause,
+    [{ file: 'prose.md', mode: 'components' }],
+    () => 'Requires 22.23.2, 24.2.0, or 26.0.0 or newer',
+  );
+  assert.deepEqual(passing, []);
+
+  const missingMiddle = collectEnginesRangeMirrorViolations(
+    threeClause,
+    [{ file: 'prose.md', mode: 'components' }],
+    () => 'Requires 22.23.2 or 26.0.0 or newer',
+  );
+  assert.deepEqual(missingMiddle, [
+    'engines-range-mirrors: prose.md does not mention all engines.node bounds "24.2.0"',
+  ]);
+
+  // low-bound modes still resolve to the first (leftmost) clause with more
+  // than two clauses present.
+  const lowBoundViolations = collectEnginesRangeMirrorViolations(
+    threeClause,
+    [{ file: '.nvmrc', mode: 'low-bound-line' }],
+    () => '22.20.0\n',
+  );
+  assert.deepEqual(lowBoundViolations, [
+    'engines-range-mirrors: .nvmrc pins "22.20.0", expected the engines.node low bound "22.23.2"',
+  ]);
+});
+
+test('collectEnginesRangeMirrorViolations: fails closed when a >= clause is not last', () => {
+  const violations = collectEnginesRangeMirrorViolations(
+    '^22.23.2 || >=24.2.0 || ^26.0.0',
+    [],
+    () => '',
+  );
+  assert.deepEqual(violations, [
+    'engines-range-mirrors: engines.node "^22.23.2 || >=24.2.0 || ^26.0.0" does not match the expected "^<v1> (|| ^<vN>)* || >=<high>" shape; cannot verify mirrors',
+  ]);
+});
+
+test('collectEnginesRangeMirrorViolations: fails closed on content after the trailing >= clause', () => {
+  const violations = collectEnginesRangeMirrorViolations(
+    '^22.23.2 || >=24.2.0 || extra',
+    [],
+    () => '',
+  );
+  assert.deepEqual(violations, [
+    'engines-range-mirrors: engines.node "^22.23.2 || >=24.2.0 || extra" does not match the expected "^<v1> (|| ^<vN>)* || >=<high>" shape; cannot verify mirrors',
   ]);
 });
 

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -1735,6 +1735,17 @@ test('collectEnginesRangeMirrorViolations: fails closed on content after the tra
   ]);
 });
 
+test('collectEnginesRangeMirrorViolations: fails closed on a bare ^ clause with no trailing >= clause', () => {
+  const violations = collectEnginesRangeMirrorViolations(
+    '^22.22.2',
+    [],
+    () => '',
+  );
+  assert.deepEqual(violations, [
+    'engines-range-mirrors: engines.node "^22.22.2" does not match the expected "^<v1> (|| ^<vN>)* || >=<high>" shape; cannot verify mirrors',
+  ]);
+});
+
 test('collectEnginesRangeMirrorViolations: reports an unreadable mirror file instead of throwing', () => {
   const violations = collectEnginesRangeMirrorViolations(
     ENGINES_NODE,

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -1657,7 +1657,7 @@ test('collectEnginesRangeMirrorViolations: components mode requires every clause
     () => 'Node.js 22.22.2 or newer',
   );
   assert.deepEqual(violations, [
-    `engines-range-mirrors: prose.md does not mention all engines.node bounds "24.2.0"`,
+    `engines-range-mirrors: prose.md does not mention all engines.node clause versions "24.2.0"`,
   ]);
 });
 
@@ -1698,7 +1698,7 @@ test('collectEnginesRangeMirrorViolations: parses a three-clause range and requi
     () => 'Requires 22.23.2 or 26.0.0 or newer',
   );
   assert.deepEqual(missingMiddle, [
-    'engines-range-mirrors: prose.md does not mention all engines.node bounds "24.2.0"',
+    'engines-range-mirrors: prose.md does not mention all engines.node clause versions "24.2.0"',
   ]);
 
   // low-bound modes still resolve to the first (leftmost) clause with more


### PR DESCRIPTION
Closes #2077

## Summary

- `parseTwoClauseEnginesRange` hardcoded `engines.node` to exactly two
  clauses (`^<low> || >=<high>`), so a required upcoming three-clause
  range (adding a middle `^24.2.0` clause ahead of a `>=26.0.0` tail,
  to exclude an already end-of-life Node line without also excluding
  the still-supported line above it) would return `null` and make
  every `collectEnginesRangeMirrorViolations` mode skip its
  bound-based comparisons — the ~13-file mirror guard #1706 built
  specifically to catch a missed `engines.node` mirror would go blind
  for the exact change it exists to protect.
- Replaced with `parseEnginesRangeClauses`: one-or-more `^x.y.z`
  clauses, in written order, followed by exactly one trailing
  `>=x.y.z` clause, returned as an ordered version-string list (the
  `>=` clause last) rather than a fixed `{ low, high }` pair. Rejects
  zero `^` clauses, a `>=` clause anywhere but last, or content after
  the trailing `>=` clause — fails closed the same way the old parser
  did for any other shape.
- `collectEnginesRangeMirrorViolations`'s four modes generalize
  accordingly: `low-bound-line`/`low-bound-contains` still resolve to
  the first clause (unchanged pin semantics); `full-range` is
  untouched (a literal substring match, never depended on parsed
  bounds); `components` now requires every clause's version present
  in the mirror text and names only the actually-missing ones in its
  violation message (previously always named both bounds regardless
  of which was missing).
- Mechanism-only: `package.json`'s live `engines.node` value stays
  `^22.22.2 || >=24.2.0` throughout, and the guarded repo-state test
  still passes with zero mirror-file edits.

## Test plan

- [x] Guarded repo-state test ("this repository's own `engines.node`
      mirrors are currently in sync") passes unchanged
- [x] New test: a three-clause range parses and `components` mode
      requires all three versions
- [x] New tests: a `>=` clause not last, and content after the
      trailing `>=` clause, both fail closed
- [x] `pnpm run build:check` (generated `.mjs` stays in sync)
- [x] `node --experimental-strip-types --test tests/*.test.mts` (3579 pass)
- [x] `pnpm run lint:minimum`
