### PR TITLE
fix(post-merge-cleanup): status-aware duplicate-evidence guard

### DIFF
--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -145,19 +145,24 @@ jobs:
           RETRY_ATTEMPTS: ${{ steps.cleanup.outputs.retry_attempts }}
           RETRY_BOUND_EXHAUSTED: ${{ steps.cleanup.outputs.retry_bound_exhausted }}
         run: |
-          # Avoid duplicate evidence comments. Workflow-level concurrency
-          # only serialises this workflow's own runs; an agent F4 (or a
-          # maintainer rerunning workflow_dispatch on the same PR) can
-          # still have posted an evidence comment outside this run. Skip
-          # if a <!-- idd-cleanup-evidence: ... --> comment already on the
-          # PR was posted by a trusted author -- this workflow's own posts
-          # are authored by `github-actions[bot]` (the GITHUB_TOKEN actor),
-          # and an agent's local F4 post is authored by a configured
-          # `trustedMarkerActors` login. An untrusted commenter pre-posting
-          # this marker prefix must never suppress the genuine evidence
-          # post or be treated as a completed cleanup record (this is the
-          # same trust-scoping every other IDD operational marker already
-          # applies).
+          # Avoid duplicate evidence comments, but only on a genuinely
+          # converged outcome. Workflow-level concurrency only serialises
+          # this workflow's own runs; an agent F4 (or a maintainer
+          # rerunning workflow_dispatch on the same PR) can still have
+          # posted an evidence comment outside this run. Skip only when
+          # the latest trusted <!-- idd-cleanup-evidence: {status} ... -->
+          # comment already records `applied` or `clean` -- a trusted
+          # comment recording any other status (`failed`, `incomplete`,
+          # `rescan-failed`, `permission-blocked`) invites a retry, so a
+          # rerun must post fresh evidence for its own outcome instead of
+          # leaving stale non-success evidence as the PR's only record.
+          # "Trusted" scoping: this workflow's own posts are authored by
+          # `github-actions[bot]` (the GITHUB_TOKEN actor), and an agent's
+          # local F4 post is authored by a configured `trustedMarkerActors`
+          # login. An untrusted commenter pre-posting this marker prefix
+          # must never suppress the genuine evidence post or be treated as
+          # a completed cleanup record (this is the same trust-scoping
+          # every other IDD operational marker already applies).
           TRUSTED_LOGINS=$(
             {
               jq -r '(.trustedMarkerActors // [])[]' .github/idd/config.json 2>/dev/null
@@ -170,20 +175,27 @@ jobs:
           # empty and post a duplicate evidence comment on a transient
           # `gh api` failure (rate limit/network). A plain command
           # substitution assignment does trip `-e` on failure.
+          #
+          # The API returns issue comments in creation-ascending order, so
+          # iterating every match without an early `break` and keeping the
+          # last assignment leaves EXISTING/EXISTING_STATUS holding the
+          # *latest* trusted comment, not merely the first one found.
           COMMENTS_TSV=$(gh api --paginate \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login] | @tsv')
+            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login, (.body | split("\n")[0])] | @tsv')
           EXISTING=""
-          while IFS=$'\t' read -r candidate_id candidate_login; do
+          EXISTING_STATUS=""
+          while IFS=$'\t' read -r candidate_id candidate_login candidate_marker_line; do
             [ -z "$candidate_id" ] && continue
             lower_login=$(printf '%s' "$candidate_login" | tr '[:upper:]' '[:lower:]')
             if printf '%s\n' "$TRUSTED_LOGINS" | grep -Fxq "$lower_login"; then
               EXISTING="$candidate_id"
-              break
+              EXISTING_STATUS=$(printf '%s' "$candidate_marker_line" \
+                | sed -n 's/^<!-- idd-cleanup-evidence: \([^ ]*\) .*/\1/p')
             fi
           done <<< "$COMMENTS_TSV"
-          if [ -n "$EXISTING" ]; then
-            echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment (id: ${EXISTING}); skipping workflow post."
+          if [ -n "$EXISTING" ] && { [ "$EXISTING_STATUS" = "applied" ] || [ "$EXISTING_STATUS" = "clean" ]; }; then
+            echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment recording '${EXISTING_STATUS}' (id: ${EXISTING}); skipping workflow post."
             exit 0
           fi
           BODY=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -185,9 +185,9 @@ record the workflow itself posted. A trusted comment recording any
 other status (`failed`, `incomplete`, `permission-blocked`,
 `rescan-failed`) does not suppress either side, so a
 `workflow_dispatch` rerun after a `rescan-failed` post still posts
-fresh evidence. The workflow's PR-keyed `concurrency` group only
-serializes workflow runs against each other; it does not gate the
-agent's local F4.
+fresh evidence (preventive; no observed incident yet — #2043). The
+workflow's PR-keyed `concurrency` group only serializes workflow runs
+against each other; it does not gate the agent's local F4.
 
 ## GitHub mechanism
 
@@ -401,7 +401,7 @@ prior success record exists, or to correct an existing `failed` /
 `rescan-failed` record in particular invites a retry, so a later
 `workflow_dispatch` rerun (or agent F4 re-run) must post fresh evidence
 for its own outcome rather than leave stale non-success evidence as the
-PR's only record:
+PR's only record (preventive; no observed incident yet — #2043):
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} retry-attempts:{N} retry-bound-exhausted:{true|false} -->

--- a/docs/idd-comment-minimization.md
+++ b/docs/idd-comment-minimization.md
@@ -175,13 +175,17 @@ canonical, mandatory contract. The server-side workflow is a
 backstop, not a replacement: same helper, same candidate rules,
 same evidence comment shape, non-blocking on errors. Double-posting is
 prevented by the cleanup-evidence record itself, not by Actions
-concurrency: the workflow skips when a trusted-author
-`<!-- idd-cleanup-evidence:` comment already exists (posted by
-`github-actions[bot]` or a configured `trustedMarkerActors` login — an
-untrusted commenter's marker-prefixed comment never counts), and the
-agent F4 step skips its own post under the same trusted-author rule when
-a prior success record is already present — including the one the
-workflow posted. The workflow's PR-keyed `concurrency` group only
+concurrency: the workflow skips when the latest trusted-author
+`<!-- idd-cleanup-evidence:` comment already records a successful
+outcome (`applied` or `clean`; posted by `github-actions[bot]` or a
+configured `trustedMarkerActors` login — an untrusted commenter's
+marker-prefixed comment never counts), and the agent F4 step skips its
+own post under the same success-record rule — including a success
+record the workflow itself posted. A trusted comment recording any
+other status (`failed`, `incomplete`, `permission-blocked`,
+`rescan-failed`) does not suppress either side, so a
+`workflow_dispatch` rerun after a `rescan-failed` post still posts
+fresh evidence. The workflow's PR-keyed `concurrency` group only
 serializes workflow runs against each other; it does not gate the
 agent's local F4.
 
@@ -385,17 +389,19 @@ merge does not re-block the merge; it is an explicit record only.
 Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
 marker so a resuming agent — or a concurrent `post-merge-cleanup`
-workflow run — can detect that evidence was already posted. The
-**agent-side** rule keys on the prior **success** record: **skip the
-post when a `<!-- idd-cleanup-evidence:` comment recording a successful
-outcome (`applied` / `clean`) already exists on the PR**, so the agent
-never stacks a duplicate success record — even when this run's own apply
-returned `applied` for residual markers a concurrent `post-merge-cleanup`
-workflow run minimized first; still post when no prior success record
-exists, or to correct an existing `failed` / `incomplete` /
-`permission-blocked` record. The `post-merge-cleanup` workflow instead
-uses a simpler presence-only guard (it skips on any existing marker),
-which suffices for its single-shot post-merge run:
+workflow run — can detect that evidence was already posted. Both the
+**agent-side** F4 step and the `post-merge-cleanup` workflow key on the
+prior **success** record: **skip the post when the latest trusted
+`<!-- idd-cleanup-evidence:` comment records a successful outcome
+(`applied` / `clean`)**, so neither side stacks a duplicate success
+record — even when this run's own apply returned `applied` for residual
+markers the other side already minimized first; still post when no
+prior success record exists, or to correct an existing `failed` /
+`incomplete` / `permission-blocked` / `rescan-failed` record — a
+`rescan-failed` record in particular invites a retry, so a later
+`workflow_dispatch` rerun (or agent F4 re-run) must post fresh evidence
+for its own outcome rather than leave stale non-success evidence as the
+PR's only record:
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} retry-attempts:{N} retry-bound-exhausted:{true|false} -->

--- a/idd-template/.github/workflows/post-merge-cleanup.yml
+++ b/idd-template/.github/workflows/post-merge-cleanup.yml
@@ -302,19 +302,24 @@ jobs:
           RETRY_ATTEMPTS: ${{ steps.cleanup.outputs.retry_attempts }}
           RETRY_BOUND_EXHAUSTED: ${{ steps.cleanup.outputs.retry_bound_exhausted }}
         run: |
-          # Avoid duplicate evidence comments. Workflow-level concurrency
-          # only serialises this workflow's own runs; an agent F4 (or a
-          # maintainer rerunning workflow_dispatch on the same PR) can
-          # still have posted an evidence comment outside this run. Skip
-          # if a <!-- idd-cleanup-evidence: ... --> comment already on the
-          # PR was posted by a trusted author -- this workflow's own posts
-          # are authored by `github-actions[bot]` (the GITHUB_TOKEN actor),
-          # and an agent's local F4 post is authored by a configured
-          # `trustedMarkerActors` login. An untrusted commenter pre-posting
-          # this marker prefix must never suppress the genuine evidence
-          # post or be treated as a completed cleanup record (this is the
-          # same trust-scoping every other IDD operational marker already
-          # applies).
+          # Avoid duplicate evidence comments, but only on a genuinely
+          # converged outcome. Workflow-level concurrency only serialises
+          # this workflow's own runs; an agent F4 (or a maintainer
+          # rerunning workflow_dispatch on the same PR) can still have
+          # posted an evidence comment outside this run. Skip only when
+          # the latest trusted <!-- idd-cleanup-evidence: {status} ... -->
+          # comment already records `applied` or `clean` -- a trusted
+          # comment recording any other status (`failed`, `incomplete`,
+          # `rescan-failed`, `permission-blocked`) invites a retry, so a
+          # rerun must post fresh evidence for its own outcome instead of
+          # leaving stale non-success evidence as the PR's only record.
+          # "Trusted" scoping: this workflow's own posts are authored by
+          # `github-actions[bot]` (the GITHUB_TOKEN actor), and an agent's
+          # local F4 post is authored by a configured `trustedMarkerActors`
+          # login. An untrusted commenter pre-posting this marker prefix
+          # must never suppress the genuine evidence post or be treated as
+          # a completed cleanup record (this is the same trust-scoping
+          # every other IDD operational marker already applies).
           # This step runs under the default GitHub Actions bash flags
           # (-eo pipefail), so a plain `jq ... .github/idd/config.json`
           # would abort the whole step under `set -e` when the file is
@@ -336,20 +341,27 @@ jobs:
           # empty and post a duplicate evidence comment on a transient
           # `gh api` failure (rate limit/network). A plain command
           # substitution assignment does trip `-e` on failure.
+          #
+          # The API returns issue comments in creation-ascending order, so
+          # iterating every match without an early `break` and keeping the
+          # last assignment leaves EXISTING/EXISTING_STATUS holding the
+          # *latest* trusted comment, not merely the first one found.
           COMMENTS_TSV=$(gh api --paginate \
             "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
-            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login] | @tsv')
+            --jq '.[] | select(.body | startswith("<!-- idd-cleanup-evidence:")) | [.id, .user.login, (.body | split("\n")[0])] | @tsv')
           EXISTING=""
-          while IFS=$'\t' read -r candidate_id candidate_login; do
+          EXISTING_STATUS=""
+          while IFS=$'\t' read -r candidate_id candidate_login candidate_marker_line; do
             [ -z "$candidate_id" ] && continue
             lower_login=$(printf '%s' "$candidate_login" | tr '[:upper:]' '[:lower:]')
             if printf '%s\n' "$TRUSTED_LOGINS" | grep -Fxq "$lower_login"; then
               EXISTING="$candidate_id"
-              break
+              EXISTING_STATUS=$(printf '%s' "$candidate_marker_line" \
+                | sed -n 's/^<!-- idd-cleanup-evidence: \([^ ]*\) .*/\1/p')
             fi
           done <<< "$COMMENTS_TSV"
-          if [ -n "$EXISTING" ]; then
-            echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment (id: ${EXISTING}); skipping workflow post."
+          if [ -n "$EXISTING" ] && { [ "$EXISTING_STATUS" = "applied" ] || [ "$EXISTING_STATUS" = "clean" ]; }; then
+            echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment recording '${EXISTING_STATUS}' (id: ${EXISTING}); skipping workflow post."
             exit 0
           fi
           BODY=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -185,9 +185,9 @@ record the workflow itself posted. A trusted comment recording any
 other status (`failed`, `incomplete`, `permission-blocked`,
 `rescan-failed`) does not suppress either side, so a
 `workflow_dispatch` rerun after a `rescan-failed` post still posts
-fresh evidence. The workflow's PR-keyed `concurrency` group only
-serializes workflow runs against each other; it does not gate the
-agent's local F4.
+fresh evidence (preventive; no observed incident yet — #2043). The
+workflow's PR-keyed `concurrency` group only serializes workflow runs
+against each other; it does not gate the agent's local F4.
 
 ## GitHub mechanism
 
@@ -401,7 +401,7 @@ prior success record exists, or to correct an existing `failed` /
 `rescan-failed` record in particular invites a retry, so a later
 `workflow_dispatch` rerun (or agent F4 re-run) must post fresh evidence
 for its own outcome rather than leave stale non-success evidence as the
-PR's only record:
+PR's only record (preventive; no observed incident yet — #2043):
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} retry-attempts:{N} retry-bound-exhausted:{true|false} -->

--- a/idd-template/docs/idd-comment-minimization.md
+++ b/idd-template/docs/idd-comment-minimization.md
@@ -175,13 +175,17 @@ canonical, mandatory contract. The server-side workflow is a
 backstop, not a replacement: same helper, same candidate rules,
 same evidence comment shape, non-blocking on errors. Double-posting is
 prevented by the cleanup-evidence record itself, not by Actions
-concurrency: the workflow skips when a trusted-author
-`<!-- idd-cleanup-evidence:` comment already exists (posted by
-`github-actions[bot]` or a configured `trustedMarkerActors` login — an
-untrusted commenter's marker-prefixed comment never counts), and the
-agent F4 step skips its own post under the same trusted-author rule when
-a prior success record is already present — including the one the
-workflow posted. The workflow's PR-keyed `concurrency` group only
+concurrency: the workflow skips when the latest trusted-author
+`<!-- idd-cleanup-evidence:` comment already records a successful
+outcome (`applied` or `clean`; posted by `github-actions[bot]` or a
+configured `trustedMarkerActors` login — an untrusted commenter's
+marker-prefixed comment never counts), and the agent F4 step skips its
+own post under the same success-record rule — including a success
+record the workflow itself posted. A trusted comment recording any
+other status (`failed`, `incomplete`, `permission-blocked`,
+`rescan-failed`) does not suppress either side, so a
+`workflow_dispatch` rerun after a `rescan-failed` post still posts
+fresh evidence. The workflow's PR-keyed `concurrency` group only
 serializes workflow runs against each other; it does not gate the
 agent's local F4.
 
@@ -385,17 +389,19 @@ merge does not re-block the merge; it is an explicit record only.
 Post this comment to the PR after a successful or partial apply. The
 HTML comment token on the first line acts as a stable machine-readable
 marker so a resuming agent — or a concurrent `post-merge-cleanup`
-workflow run — can detect that evidence was already posted. The
-**agent-side** rule keys on the prior **success** record: **skip the
-post when a `<!-- idd-cleanup-evidence:` comment recording a successful
-outcome (`applied` / `clean`) already exists on the PR**, so the agent
-never stacks a duplicate success record — even when this run's own apply
-returned `applied` for residual markers a concurrent `post-merge-cleanup`
-workflow run minimized first; still post when no prior success record
-exists, or to correct an existing `failed` / `incomplete` /
-`permission-blocked` record. The `post-merge-cleanup` workflow instead
-uses a simpler presence-only guard (it skips on any existing marker),
-which suffices for its single-shot post-merge run:
+workflow run — can detect that evidence was already posted. Both the
+**agent-side** F4 step and the `post-merge-cleanup` workflow key on the
+prior **success** record: **skip the post when the latest trusted
+`<!-- idd-cleanup-evidence:` comment records a successful outcome
+(`applied` / `clean`)**, so neither side stacks a duplicate success
+record — even when this run's own apply returned `applied` for residual
+markers the other side already minimized first; still post when no
+prior success record exists, or to correct an existing `failed` /
+`incomplete` / `permission-blocked` / `rescan-failed` record — a
+`rescan-failed` record in particular invites a retry, so a later
+`workflow_dispatch` rerun (or agent F4 re-run) must post fresh evidence
+for its own outcome rather than leave stale non-success evidence as the
+PR's only record:
 
 ```markdown
 <!-- idd-cleanup-evidence: {status} applied:{N} failed:{N} skipped:{N} viewer-cannot-minimize:{N} retry-attempts:{N} retry-bound-exhausted:{true|false} -->


### PR DESCRIPTION
## Summary

- Replace the `post-merge-cleanup.yml` duplicate-evidence guard's
  presence-only check with a status-aware check: skip posting only
  when the latest trusted `idd-cleanup-evidence` comment already
  records `applied` or `clean`; post fresh evidence for any other
  status (`failed`, `incomplete`, `rescan-failed`,
  `permission-blocked`), matching the agent-side F4 rule already
  documented in `idd-merge.instructions.md`.
- Applied to both workflow copies (`.github/workflows/` and the
  `idd-template/` mirror).
- Updated `idd-template/docs/idd-comment-minimization.md` (canonical
  source) to describe the now-aligned agent/workflow skip behavior,
  and resynced `docs/idd-comment-minimization.md`.

Refs #2043

## Test plan

- [x] `pnpm run lint:minimum` (3580 tests, cspell, markdownlint) —
      all pass
- [x] `node scripts/audit-docs.mjs --check` — passes (only
      pre-existing context-ceiling notices)
- [x] `node scripts/audit-code-span-wrap.mjs` — passes
- [x] `/home/linuxbrew/.linuxbrew/bin/actionlint` on both workflow
      copies — clean
- [x] Manual bash simulation of the guard against 9 scenarios
      (no-prior-comment, single trusted rescan-failed/clean/applied,
      latest-wins in both directions, untrusted-author cases,
      permission-blocked) — all match the intended skip/post outcome


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cleanup evidence now suppresses duplicate updates only after a trusted successful outcome (`applied` or `clean`).
  * Failed, incomplete, permission-blocked, and rescan-failed outcomes now allow retries and fresh status updates.
  * Duplicate detection correctly evaluates the latest trusted evidence record.

* **Documentation**
  * Updated cleanup deduplication guidance to reflect the revised evidence-handling rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->