### PR TITLE
fix(worktree-guard): detect CRLF-broken hooks, document LF rule

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -909,6 +909,23 @@ To enable it in the target repository:
    chmod +x .githooks/pre-commit .githooks/pre-push
    ```
 
+3. On a native-Windows checkout, add an explicit LF rule for the three
+   shipped hook files to the target repository's own `.gitattributes`
+   (the template does not ship one — see "Out of scope" in idd-skill#2060):
+
+   ```gitattributes
+   .githooks/* text eol=lf
+   ```
+
+   Git for Windows' installer defaults to `core.autocrlf=true`
+   ("Checkout Windows-style, commit Unix-style line endings"). With no
+   `.gitattributes` override, that setting checks these files out as
+   CRLF; the trailing `\r` then breaks the `.`/`source` line that loads
+   `_idd-worktree-guard.sh`, hard-blocking every commit and push. A
+   `*.sh` rule alone is not enough — `pre-commit` and `pre-push` ship
+   without an extension, so they need this explicit `.githooks/*` path
+   rule to be covered too.
+
 When `worktreeGuard.enabled` is absent or `false`, the hooks are a
 no-op. To bypass the guard for a single intentional commit or push,
 pass `--no-verify`. CI cannot detect this class of violation — a

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -911,7 +911,8 @@ To enable it in the target repository:
 
 3. On a native-Windows checkout, add an explicit LF rule for the three
    shipped hook files to the target repository's own `.gitattributes`
-   (the template does not ship one — see "Out of scope" in idd-skill#2060):
+   (the template does not ship one — see "Out of scope" in
+   kurone-kito/idd-skill#2060):
 
    ```gitattributes
    .githooks/* text eol=lf

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1609,9 +1609,12 @@ export function classifyWorktreeGuardActivation({
         `worktreeGuard.enabled is true but ${names} contain${plural} CRLF ` +
         `line endings; the trailing \\r breaks the "." sourcing path (e.g. ` +
         `". …: cannot open …/_idd-worktree-guard.sh: No such file") even ` +
-        `though the wiring check still matches the text -- this HARD-BLOCKS ` +
-        `every commit and push here, not merely disables enforcement. ` +
-        `Likely cause: Git for Windows' default core.autocrlf=true with no ` +
+        `though the wiring check still matches the text. A CRLF-broken ` +
+        `hook HARD-BLOCKS any commit or push that invokes it -- via ` +
+        `core.hooksPath = .githooks directly, or a documented chain from ` +
+        `elsewhere -- not merely disables enforcement, so this must be ` +
+        `fixed before (or as part of) wiring core.hooksPath. Likely ` +
+        `cause: Git for Windows' default core.autocrlf=true with no ` +
         `adopter-side .gitattributes override. Add an explicit LF rule ` +
         `covering all three shipped .githooks/ files (for example ` +
         `".githooks/* text eol=lf"); see ONBOARDING.md's worktree-guard ` +

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1607,12 +1607,13 @@ export function classifyWorktreeGuardActivation({
       level: 'warning',
       message:
         `worktreeGuard.enabled is true but ${names} contain${plural} CRLF ` +
-        `line endings; the trailing \\r breaks the "." sourcing path even ` +
-        `though the wiring check still matches the text, so B1 ` +
-        `primary-worktree commits will NOT be blocked here. Likely cause: ` +
-        `Git for Windows' default core.autocrlf=true with no adopter-side ` +
-        `.gitattributes override. Add an explicit LF rule covering all ` +
-        `three shipped .githooks/ files (for example ` +
+        `line endings; the trailing \\r breaks the "." sourcing path (e.g. ` +
+        `". …: cannot open …/_idd-worktree-guard.sh: No such file") even ` +
+        `though the wiring check still matches the text -- this HARD-BLOCKS ` +
+        `every commit and push here, not merely disables enforcement. ` +
+        `Likely cause: Git for Windows' default core.autocrlf=true with no ` +
+        `adopter-side .gitattributes override. Add an explicit LF rule ` +
+        `covering all three shipped .githooks/ files (for example ` +
         `".githooks/* text eol=lf"); see ONBOARDING.md's worktree-guard ` +
         `activation section`,
     };

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1482,6 +1482,22 @@ export function hookWiresWorktreeGuard(content) {
   );
 }
 /**
+ * True when hook file content contains a Windows-style CRLF line ending. A
+ * working tree checked out under Git for Windows' default
+ * `core.autocrlf=true`, with no adopter-side `.gitattributes` override,
+ * converts these shipped POSIX shell hook files to CRLF -- the trailing `\r`
+ * then becomes part of the sourced path (e.g.
+ * `. "$(dirname "$0")/_idd-worktree-guard.sh"\r`), which every POSIX shell
+ * rejects as "No such file", hard-blocking every commit/push even though
+ * `hookWiresWorktreeGuard`'s own regex still matches the text -- the `\r`
+ * sits after, not inside, the matched filename (idd-skill#2060). Pure (no
+ * I/O) so it can be unit-tested directly. A non-string (absent/unreadable
+ * hook) is treated as CRLF-free.
+ */
+export function hookHasCrlfLineEndings(content) {
+  return typeof content === 'string' && content.includes('\r\n');
+}
+/**
  * True when a git hook file body chains execution to the corresponding
  * shipped `.githooks/<hookName>` script via one of the two documented
  * exec/invocation forms from ONBOARDING.md's "Coexisting with an existing
@@ -1569,6 +1585,7 @@ export function classifyWorktreeGuardActivation({
   headDetached,
   hooksPath,
   guardWired,
+  crlfHookNames,
 }) {
   // Only runs when the guard is opted in.
   if (!guardEnabled) {
@@ -1579,6 +1596,26 @@ export function classifyWorktreeGuardActivation({
   // `classifyPrimaryHead('HEAD')` reports no violation.
   if (headDetached) {
     return null;
+  }
+  // Checked ahead of `guardWired`, and regardless of its value: a
+  // CRLF-converted sourcing line still satisfies `hookWiresWorktreeGuard`'s
+  // regex, so `guardWired` alone cannot be trusted to catch this case.
+  if (crlfHookNames.length > 0) {
+    const names = crlfHookNames.join(', ');
+    const plural = crlfHookNames.length === 1 ? 's' : '';
+    return {
+      level: 'warning',
+      message:
+        `worktreeGuard.enabled is true but ${names} contain${plural} CRLF ` +
+        `line endings; the trailing \\r breaks the "." sourcing path even ` +
+        `though the wiring check still matches the text, so B1 ` +
+        `primary-worktree commits will NOT be blocked here. Likely cause: ` +
+        `Git for Windows' default core.autocrlf=true with no adopter-side ` +
+        `.gitattributes override. Add an explicit LF rule covering all ` +
+        `three shipped .githooks/ files (for example ` +
+        `".githooks/* text eol=lf"); see ONBOARDING.md's worktree-guard ` +
+        `activation section`,
+    };
   }
   // Correctly wired → nothing to report.
   if (guardWired) {
@@ -1681,6 +1718,41 @@ export function worktreeGuardWiredAt(root, hooksPath) {
   };
   return wired('pre-commit') && wired('pre-push');
 }
+// The three shipped hook files a native-Windows checkout under
+// `core.autocrlf=true` can silently convert to CRLF, hard-blocking the guard
+// (idd-skill#2060). Always read from `.githooks/` regardless of the resolved
+// `core.hooksPath`: that is where the shipped files themselves live, and
+// where an adopter's own `.gitattributes` LF rule must apply, whether or not
+// `core.hooksPath` points directly at them or chains through another
+// directory (e.g. Husky's `.husky/_`).
+const WORKTREE_GUARD_HOOK_FILE_NAMES = [
+  '_idd-worktree-guard.sh',
+  'pre-commit',
+  'pre-push',
+];
+/**
+ * Read the three shipped `.githooks/` files and report which ones (if any)
+ * contain CRLF line endings, in `WORKTREE_GUARD_HOOK_FILE_NAMES` order. A
+ * missing or unreadable file is treated as CRLF-free (nothing to report;
+ * `worktreeGuardWiredAt`'s own executable/presence checks already cover a
+ * genuinely missing hook).
+ */
+export function detectWorktreeGuardCrlfHookNames(root) {
+  const githooksDirectory = join(root, '.githooks');
+  const found = [];
+  for (const name of WORKTREE_GUARD_HOOK_FILE_NAMES) {
+    let content;
+    try {
+      content = readFileSync(join(githooksDirectory, name), 'utf8');
+    } catch {
+      content = null;
+    }
+    if (hookHasCrlfLineEndings(content)) {
+      found.push(name);
+    }
+  }
+  return found;
+}
 /**
  * Warn when `worktreeGuard.enabled` is true but the commit/push guard is not
  * actually wired in this environment (`core.hooksPath` unset or pointing at a
@@ -1725,6 +1797,7 @@ function checkWorktreeGuardActive(root, report) {
     headDetached: false,
     hooksPath: hooksPath.length > 0 ? hooksPath : null,
     guardWired,
+    crlfHookNames: detectWorktreeGuardCrlfHookNames(root),
   });
   if (finding) {
     report.warnings.push(finding.message);

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1904,9 +1904,12 @@ export function classifyWorktreeGuardActivation({
         `worktreeGuard.enabled is true but ${names} contain${plural} CRLF ` +
         `line endings; the trailing \\r breaks the "." sourcing path (e.g. ` +
         `". …: cannot open …/_idd-worktree-guard.sh: No such file") even ` +
-        `though the wiring check still matches the text -- this HARD-BLOCKS ` +
-        `every commit and push here, not merely disables enforcement. ` +
-        `Likely cause: Git for Windows' default core.autocrlf=true with no ` +
+        `though the wiring check still matches the text. A CRLF-broken ` +
+        `hook HARD-BLOCKS any commit or push that invokes it -- via ` +
+        `core.hooksPath = .githooks directly, or a documented chain from ` +
+        `elsewhere -- not merely disables enforcement, so this must be ` +
+        `fixed before (or as part of) wiring core.hooksPath. Likely ` +
+        `cause: Git for Windows' default core.autocrlf=true with no ` +
         `adopter-side .gitattributes override. Add an explicit LF rule ` +
         `covering all three shipped .githooks/ files (for example ` +
         `".githooks/* text eol=lf"); see ONBOARDING.md's worktree-guard ` +

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1743,6 +1743,16 @@ export interface WorktreeGuardActivationInput {
   hooksPath: string | null;
   /** The resolved hooks path actually wires the B1 guard. */
   guardWired: boolean;
+  /**
+   * Names of the shipped `.githooks/` files found to contain CRLF line
+   * endings (any of `_idd-worktree-guard.sh`, `pre-commit`, `pre-push`),
+   * in file order; empty when none do. Checked independently of
+   * `guardWired`, since `hookWiresWorktreeGuard`'s regex still matches a
+   * CRLF-converted sourcing line (idd-skill#2060) -- a non-empty list
+   * always produces a warning even when `guardWired` is (incorrectly)
+   * `true`.
+   */
+  crlfHookNames: string[];
 }
 
 /**
@@ -1759,6 +1769,23 @@ export function hookWiresWorktreeGuard(content: unknown): boolean {
     typeof content === 'string' &&
     /^[ \t]*(?:\.|source)[ \t]+[^\n]*_idd-worktree-guard\.sh/m.test(content)
   );
+}
+
+/**
+ * True when hook file content contains a Windows-style CRLF line ending. A
+ * working tree checked out under Git for Windows' default
+ * `core.autocrlf=true`, with no adopter-side `.gitattributes` override,
+ * converts these shipped POSIX shell hook files to CRLF -- the trailing `\r`
+ * then becomes part of the sourced path (e.g.
+ * `. "$(dirname "$0")/_idd-worktree-guard.sh"\r`), which every POSIX shell
+ * rejects as "No such file", hard-blocking every commit/push even though
+ * `hookWiresWorktreeGuard`'s own regex still matches the text -- the `\r`
+ * sits after, not inside, the matched filename (idd-skill#2060). Pure (no
+ * I/O) so it can be unit-tested directly. A non-string (absent/unreadable
+ * hook) is treated as CRLF-free.
+ */
+export function hookHasCrlfLineEndings(content: unknown): boolean {
+  return typeof content === 'string' && content.includes('\r\n');
 }
 
 /**
@@ -1853,6 +1880,7 @@ export function classifyWorktreeGuardActivation({
   headDetached,
   hooksPath,
   guardWired,
+  crlfHookNames,
 }: WorktreeGuardActivationInput): WorktreeHeadFinding | null {
   // Only runs when the guard is opted in.
   if (!guardEnabled) {
@@ -1863,6 +1891,26 @@ export function classifyWorktreeGuardActivation({
   // `classifyPrimaryHead('HEAD')` reports no violation.
   if (headDetached) {
     return null;
+  }
+  // Checked ahead of `guardWired`, and regardless of its value: a
+  // CRLF-converted sourcing line still satisfies `hookWiresWorktreeGuard`'s
+  // regex, so `guardWired` alone cannot be trusted to catch this case.
+  if (crlfHookNames.length > 0) {
+    const names = crlfHookNames.join(', ');
+    const plural = crlfHookNames.length === 1 ? 's' : '';
+    return {
+      level: 'warning',
+      message:
+        `worktreeGuard.enabled is true but ${names} contain${plural} CRLF ` +
+        `line endings; the trailing \\r breaks the "." sourcing path even ` +
+        `though the wiring check still matches the text, so B1 ` +
+        `primary-worktree commits will NOT be blocked here. Likely cause: ` +
+        `Git for Windows' default core.autocrlf=true with no adopter-side ` +
+        `.gitattributes override. Add an explicit LF rule covering all ` +
+        `three shipped .githooks/ files (for example ` +
+        `".githooks/* text eol=lf"); see ONBOARDING.md's worktree-guard ` +
+        `activation section`,
+    };
   }
   // Correctly wired → nothing to report.
   if (guardWired) {
@@ -1967,6 +2015,43 @@ export function worktreeGuardWiredAt(root: string, hooksPath: string): boolean {
   return wired('pre-commit') && wired('pre-push');
 }
 
+// The three shipped hook files a native-Windows checkout under
+// `core.autocrlf=true` can silently convert to CRLF, hard-blocking the guard
+// (idd-skill#2060). Always read from `.githooks/` regardless of the resolved
+// `core.hooksPath`: that is where the shipped files themselves live, and
+// where an adopter's own `.gitattributes` LF rule must apply, whether or not
+// `core.hooksPath` points directly at them or chains through another
+// directory (e.g. Husky's `.husky/_`).
+const WORKTREE_GUARD_HOOK_FILE_NAMES = [
+  '_idd-worktree-guard.sh',
+  'pre-commit',
+  'pre-push',
+];
+
+/**
+ * Read the three shipped `.githooks/` files and report which ones (if any)
+ * contain CRLF line endings, in `WORKTREE_GUARD_HOOK_FILE_NAMES` order. A
+ * missing or unreadable file is treated as CRLF-free (nothing to report;
+ * `worktreeGuardWiredAt`'s own executable/presence checks already cover a
+ * genuinely missing hook).
+ */
+export function detectWorktreeGuardCrlfHookNames(root: string): string[] {
+  const githooksDirectory = join(root, '.githooks');
+  const found: string[] = [];
+  for (const name of WORKTREE_GUARD_HOOK_FILE_NAMES) {
+    let content: string | null;
+    try {
+      content = readFileSync(join(githooksDirectory, name), 'utf8');
+    } catch {
+      content = null;
+    }
+    if (hookHasCrlfLineEndings(content)) {
+      found.push(name);
+    }
+  }
+  return found;
+}
+
 /**
  * Warn when `worktreeGuard.enabled` is true but the commit/push guard is not
  * actually wired in this environment (`core.hooksPath` unset or pointing at a
@@ -2011,6 +2096,7 @@ function checkWorktreeGuardActive(root: string, report: DoctorReport) {
     headDetached: false,
     hooksPath: hooksPath.length > 0 ? hooksPath : null,
     guardWired,
+    crlfHookNames: detectWorktreeGuardCrlfHookNames(root),
   });
   if (finding) {
     report.warnings.push(finding.message);

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1902,12 +1902,13 @@ export function classifyWorktreeGuardActivation({
       level: 'warning',
       message:
         `worktreeGuard.enabled is true but ${names} contain${plural} CRLF ` +
-        `line endings; the trailing \\r breaks the "." sourcing path even ` +
-        `though the wiring check still matches the text, so B1 ` +
-        `primary-worktree commits will NOT be blocked here. Likely cause: ` +
-        `Git for Windows' default core.autocrlf=true with no adopter-side ` +
-        `.gitattributes override. Add an explicit LF rule covering all ` +
-        `three shipped .githooks/ files (for example ` +
+        `line endings; the trailing \\r breaks the "." sourcing path (e.g. ` +
+        `". …: cannot open …/_idd-worktree-guard.sh: No such file") even ` +
+        `though the wiring check still matches the text -- this HARD-BLOCKS ` +
+        `every commit and push here, not merely disables enforcement. ` +
+        `Likely cause: Git for Windows' default core.autocrlf=true with no ` +
+        `adopter-side .gitattributes override. Add an explicit LF rule ` +
+        `covering all three shipped .githooks/ files (for example ` +
         `".githooks/* text eol=lf"); see ONBOARDING.md's worktree-guard ` +
         `activation section`,
     };

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -29,6 +29,7 @@ import {
   containsWorkshopReference,
   DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS,
   decodeGithubReadmeBase64,
+  detectWorktreeGuardCrlfHookNames,
   emitCleanupBacklogProgress,
   evaluateAutopilotSuitabilityConsistency,
   evaluateBranchProtectionFindings,
@@ -44,6 +45,7 @@ import {
   formatCleanupBacklogScanPreamble,
   formatCleanupBacklogScanProgress,
   hookChainsToGithooksScript,
+  hookHasCrlfLineEndings,
   hookWiresWorktreeGuard,
   isBranchProtectionUnreadable,
   isGithubBackLinkHost,
@@ -670,6 +672,32 @@ test('hookWiresWorktreeGuard treats a non-string (absent hook) as unwired', () =
   assert.equal(hookWiresWorktreeGuard(undefined), false);
 });
 
+test('hookWiresWorktreeGuard still matches a CRLF-converted sourcing line (regression evidence for #2060)', () => {
+  // The trailing \r sits after the matched filename, not inside it, so the
+  // regex alone cannot distinguish this from a healthy LF hook -- this is
+  // exactly why `hookHasCrlfLineEndings` exists as an independent check.
+  assert.equal(
+    hookWiresWorktreeGuard(
+      '#!/bin/sh\r\n. "$(dirname "$0")/_idd-worktree-guard.sh"\r\n',
+    ),
+    true,
+  );
+});
+
+test('hookHasCrlfLineEndings detects a CRLF line ending', () => {
+  assert.equal(hookHasCrlfLineEndings('#!/bin/sh\r\necho hi\r\n'), true);
+});
+
+test('hookHasCrlfLineEndings rejects LF-only content', () => {
+  assert.equal(hookHasCrlfLineEndings('#!/bin/sh\necho hi\n'), false);
+  assert.equal(hookHasCrlfLineEndings(''), false);
+});
+
+test('hookHasCrlfLineEndings treats a non-string (absent hook) as CRLF-free', () => {
+  assert.equal(hookHasCrlfLineEndings(null), false);
+  assert.equal(hookHasCrlfLineEndings(undefined), false);
+});
+
 test('hookChainsToGithooksScript detects the exec chain form', () => {
   assert.equal(
     hookChainsToGithooksScript(
@@ -857,6 +885,7 @@ test('classifyWorktreeGuardActivation returns null when the guard is disabled', 
       headDetached: false,
       hooksPath: null,
       guardWired: false,
+      crlfHookNames: [],
     }),
     null,
   );
@@ -869,6 +898,7 @@ test('classifyWorktreeGuardActivation stays silent on a detached HEAD (CI-safe)'
       headDetached: true,
       hooksPath: null,
       guardWired: false,
+      crlfHookNames: [],
     }),
     null,
   );
@@ -881,6 +911,7 @@ test('classifyWorktreeGuardActivation returns null when the guard is wired', () 
       headDetached: false,
       hooksPath: '.githooks',
       guardWired: true,
+      crlfHookNames: [],
     }),
     null,
   );
@@ -892,6 +923,7 @@ test('classifyWorktreeGuardActivation warns (never errors) when enabled-but-iner
     headDetached: false,
     hooksPath: '.husky/_',
     guardWired: false,
+    crlfHookNames: [],
   });
   assert.equal(finding?.level, 'warning');
   assert.match(finding?.message ?? '', /worktreeGuard\.enabled is true/);
@@ -915,9 +947,52 @@ test('classifyWorktreeGuardActivation shows (unset) when core.hooksPath is absen
     headDetached: false,
     hooksPath: null,
     guardWired: false,
+    crlfHookNames: [],
   });
   assert.equal(finding?.level, 'warning');
   assert.match(finding?.message ?? '', /core\.hooksPath = \(unset\)/);
+});
+
+test('classifyWorktreeGuardActivation warns on CRLF hooks even when guardWired is (incorrectly) true', () => {
+  const finding = classifyWorktreeGuardActivation({
+    guardEnabled: true,
+    headDetached: false,
+    hooksPath: '.githooks',
+    guardWired: true,
+    crlfHookNames: ['pre-commit'],
+  });
+  assert.equal(finding?.level, 'warning');
+  assert.match(finding?.message ?? '', /pre-commit contains CRLF/);
+  assert.match(finding?.message ?? '', /core\.autocrlf=true/);
+  assert.match(finding?.message ?? '', /\.gitattributes/);
+  assert.match(finding?.message ?? '', /text eol=lf/);
+});
+
+test('classifyWorktreeGuardActivation lists every CRLF-affected hook with plural wording', () => {
+  const finding = classifyWorktreeGuardActivation({
+    guardEnabled: true,
+    headDetached: false,
+    hooksPath: '.githooks',
+    guardWired: false,
+    crlfHookNames: ['pre-commit', 'pre-push'],
+  });
+  assert.match(
+    finding?.message ?? '',
+    /pre-commit, pre-push contain CRLF line endings/,
+  );
+});
+
+test('classifyWorktreeGuardActivation stays silent on a detached HEAD even with CRLF hooks (CI-safe)', () => {
+  assert.equal(
+    classifyWorktreeGuardActivation({
+      guardEnabled: true,
+      headDetached: true,
+      hooksPath: null,
+      guardWired: false,
+      crlfHookNames: ['pre-commit'],
+    }),
+    null,
+  );
 });
 
 test('readWorktreeGuardEnabled reads worktreeGuard.enabled from config', () => {
@@ -961,6 +1036,66 @@ function writeFixtureFile(root: string, relativePath: string, content: string) {
   // afterward.
   chmodSync(full, 0o755);
 }
+
+test('detectWorktreeGuardCrlfHookNames: finds CRLF-converted shipped hooks (regression for #2060)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-guard-crlf-'));
+  try {
+    writeFixtureFile(
+      dir,
+      '.githooks/_idd-worktree-guard.sh',
+      '#!/bin/sh\r\necho guard\r\n',
+    );
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-commit',
+      `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
+    );
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-push',
+      `#!/bin/sh\r\n${GUARD_SOURCE_LINE}`,
+    );
+    assert.deepEqual(detectWorktreeGuardCrlfHookNames(dir), [
+      '_idd-worktree-guard.sh',
+      'pre-push',
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('detectWorktreeGuardCrlfHookNames: LF-only hooks report no CRLF names (unchanged case)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-guard-crlf-none-'));
+  try {
+    writeFixtureFile(
+      dir,
+      '.githooks/_idd-worktree-guard.sh',
+      '#!/bin/sh\necho guard\n',
+    );
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-commit',
+      `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
+    );
+    writeFixtureFile(
+      dir,
+      '.githooks/pre-push',
+      `#!/bin/sh\n${GUARD_SOURCE_LINE}`,
+    );
+    assert.deepEqual(detectWorktreeGuardCrlfHookNames(dir), []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('detectWorktreeGuardCrlfHookNames: missing .githooks directory reports no CRLF names', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-guard-crlf-missing-'));
+  try {
+    assert.deepEqual(detectWorktreeGuardCrlfHookNames(dir), []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 test('worktreeGuardWiredAt: direct .githooks hooksPath wires both hooks (regression)', () => {
   const dir = mkdtempSync(join(tmpdir(), 'idd-guard-wired-'));


### PR DESCRIPTION
## Summary

- Add `hookHasCrlfLineEndings` and `detectWorktreeGuardCrlfHookNames`
  to `idd-doctor.mts`, checked independently of (and ahead of) the
  existing presence-based `guardWired` verdict in
  `classifyWorktreeGuardActivation`, so a CRLF-converted
  `.githooks/pre-commit`, `pre-push`, or `_idd-worktree-guard.sh`
  always produces a distinct, actionable warning — `hookWiresWorktreeGuard`'s
  regex still matches CRLF content (the `\r` sits after, not inside,
  the matched filename), so `guardWired` alone cannot be trusted.
- The existing LF verdict and its message text are unchanged — this
  only adds a new failing state.
- Document an explicit `.githooks/* text eol=lf` `.gitattributes` rule
  in `idd-template/ONBOARDING.md`'s worktree-guard activation section,
  naming both the extensionless-filename reason a bare `*.sh` rule is
  insufficient and Git for Windows' `core.autocrlf=true` default as
  the trigger.

Closes #2060

## Test plan

- [x] `pnpm run lint:minimum` (3590 tests, typecheck, build:check,
      biome, dprint, cspell, markdownlint) — all pass
- [x] New unit tests for `hookHasCrlfLineEndings` (LF/CRLF/absent
      cases) and a regression test proving `hookWiresWorktreeGuard`
      still matches CRLF content
- [x] New unit tests for `classifyWorktreeGuardActivation` covering:
      CRLF warning fires even when `guardWired` is (incorrectly)
      `true`; plural wording for multiple affected hooks; CI-safe
      silence on a detached HEAD even with CRLF hooks present
- [x] New fixture-based tests for `detectWorktreeGuardCrlfHookNames`
      (mixed CRLF/LF hooks, all-LF unchanged case, missing
      `.githooks/` directory)
