### PR TITLE
fix(doctor): scope the placeholder scanner to IDD-managed files

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -401,8 +401,9 @@ function checkRequiredFiles(_files, report) {
  * legitimately use `{{...}}` as its own runtime template syntax (i18n,
  * mustache-style templates, etc.) with nothing to do with IDD onboarding
  * (idd-skill#2079). An allowlist, not a denylist: only these path classes
- * are ever scanned, matching `checkRequiredFiles`'s file classes plus the
- * vendored `scripts/`/`schemas/`/`fixtures/schemas/` bundle.
+ * are ever scanned -- `docs/*.md`, `profiles/`, `.claude/skills/`,
+ * `.github/idd/`, and the vendored `scripts/`/`schemas/`/
+ * `fixtures/schemas/` bundle.
  *
  * `.github/instructions/` is included only in adopter mode
  * (`distributionSource` false): in the source repository itself those

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -394,23 +394,45 @@ function checkRequiredFiles(_files, report) {
     report.passes.push('profile artifacts are present');
   }
 }
-function checkPlaceholders(root, files, report) {
+/**
+ * True when `file` (a repo-relative, forward-slash path) is IDD-managed
+ * content `checkPlaceholders` should scan for unresolved `{{...}}` import
+ * placeholders -- not an adopter's own application source, which can
+ * legitimately use `{{...}}` as its own runtime template syntax (i18n,
+ * mustache-style templates, etc.) with nothing to do with IDD onboarding
+ * (idd-skill#2079). An allowlist, not a denylist: only these path classes
+ * are ever scanned, matching `checkRequiredFiles`'s file classes plus the
+ * vendored `scripts/`/`schemas/`/`fixtures/schemas/` bundle.
+ *
+ * `.github/instructions/` is included only in adopter mode
+ * (`distributionSource` false): in the source repository itself those
+ * files document the placeholder syntax with example tokens that are
+ * never meant to be "resolved", so scanning them there would self-trigger
+ * a false positive on every dogfooded run. Pure (no I/O) so it can be
+ * unit-tested directly.
+ */
+export function isIddManagedPlaceholderScanPath(file, distributionSource) {
+  if (file.startsWith('docs/') && file.endsWith('.md')) {
+    return true;
+  }
+  if (
+    file.startsWith('profiles/') ||
+    file.startsWith('.claude/skills/') ||
+    file.startsWith('scripts/') ||
+    file.startsWith('schemas/') ||
+    file.startsWith('fixtures/schemas/')
+  ) {
+    return true;
+  }
+  return !distributionSource && file.startsWith('.github/instructions/');
+}
+export function checkPlaceholders(root, files, report) {
   const distributionSource =
     exists(join(root, 'idd-template/ONBOARDING.md')) &&
     exists(join(root, 'audit/sync-manifest.json'));
-  const excludedPrefixes = [
-    'idd-template/',
-    'fixtures/',
-    'tests/fixtures/',
-    'tests/',
-    '.git/',
-  ];
-  if (distributionSource) {
-    excludedPrefixes.push('.github/instructions/', 'audit/');
-  }
   const hits = [];
   for (const file of files) {
-    if (excludedPrefixes.some((prefix) => file.startsWith(prefix))) {
+    if (!isIddManagedPlaceholderScanPath(file, distributionSource)) {
       continue;
     }
     const absolutePath = join(root, file);

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -420,7 +420,8 @@ export function isIddManagedPlaceholderScanPath(file, distributionSource) {
     file.startsWith('.claude/skills/') ||
     file.startsWith('scripts/') ||
     file.startsWith('schemas/') ||
-    file.startsWith('fixtures/schemas/')
+    file.startsWith('fixtures/schemas/') ||
+    file.startsWith('.github/idd/')
   ) {
     return true;
   }

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -530,7 +530,8 @@ export function isIddManagedPlaceholderScanPath(
     file.startsWith('.claude/skills/') ||
     file.startsWith('scripts/') ||
     file.startsWith('schemas/') ||
-    file.startsWith('fixtures/schemas/')
+    file.startsWith('fixtures/schemas/') ||
+    file.startsWith('.github/idd/')
   ) {
     return true;
   }

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -501,7 +501,43 @@ function checkRequiredFiles(_files: string[], report: DoctorReport) {
   }
 }
 
-function checkPlaceholders(
+/**
+ * True when `file` (a repo-relative, forward-slash path) is IDD-managed
+ * content `checkPlaceholders` should scan for unresolved `{{...}}` import
+ * placeholders -- not an adopter's own application source, which can
+ * legitimately use `{{...}}` as its own runtime template syntax (i18n,
+ * mustache-style templates, etc.) with nothing to do with IDD onboarding
+ * (idd-skill#2079). An allowlist, not a denylist: only these path classes
+ * are ever scanned, matching `checkRequiredFiles`'s file classes plus the
+ * vendored `scripts/`/`schemas/`/`fixtures/schemas/` bundle.
+ *
+ * `.github/instructions/` is included only in adopter mode
+ * (`distributionSource` false): in the source repository itself those
+ * files document the placeholder syntax with example tokens that are
+ * never meant to be "resolved", so scanning them there would self-trigger
+ * a false positive on every dogfooded run. Pure (no I/O) so it can be
+ * unit-tested directly.
+ */
+export function isIddManagedPlaceholderScanPath(
+  file: string,
+  distributionSource: boolean,
+): boolean {
+  if (file.startsWith('docs/') && file.endsWith('.md')) {
+    return true;
+  }
+  if (
+    file.startsWith('profiles/') ||
+    file.startsWith('.claude/skills/') ||
+    file.startsWith('scripts/') ||
+    file.startsWith('schemas/') ||
+    file.startsWith('fixtures/schemas/')
+  ) {
+    return true;
+  }
+  return !distributionSource && file.startsWith('.github/instructions/');
+}
+
+export function checkPlaceholders(
   root: string,
   files: string[],
   report: DoctorReport,
@@ -509,20 +545,10 @@ function checkPlaceholders(
   const distributionSource =
     exists(join(root, 'idd-template/ONBOARDING.md')) &&
     exists(join(root, 'audit/sync-manifest.json'));
-  const excludedPrefixes = [
-    'idd-template/',
-    'fixtures/',
-    'tests/fixtures/',
-    'tests/',
-    '.git/',
-  ];
-  if (distributionSource) {
-    excludedPrefixes.push('.github/instructions/', 'audit/');
-  }
   const hits: string[] = [];
 
   for (const file of files) {
-    if (excludedPrefixes.some((prefix) => file.startsWith(prefix))) {
+    if (!isIddManagedPlaceholderScanPath(file, distributionSource)) {
       continue;
     }
     const absolutePath = join(root, file);

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -508,8 +508,9 @@ function checkRequiredFiles(_files: string[], report: DoctorReport) {
  * legitimately use `{{...}}` as its own runtime template syntax (i18n,
  * mustache-style templates, etc.) with nothing to do with IDD onboarding
  * (idd-skill#2079). An allowlist, not a denylist: only these path classes
- * are ever scanned, matching `checkRequiredFiles`'s file classes plus the
- * vendored `scripts/`/`schemas/`/`fixtures/schemas/` bundle.
+ * are ever scanned -- `docs/*.md`, `profiles/`, `.claude/skills/`,
+ * `.github/idd/`, and the vendored `scripts/`/`schemas/`/
+ * `fixtures/schemas/` bundle.
  *
  * `.github/instructions/` is included only in adopter mode
  * (`distributionSource` false): in the source repository itself those

--- a/tests/fixtures/idd-doctor-placeholders/adopter-i18n-example.ts
+++ b/tests/fixtures/idd-doctor-placeholders/adopter-i18n-example.ts
@@ -1,0 +1,8 @@
+// idd-skill#2079 regression fixture: a non-IDD-managed adopter
+// application file using {{ token }} as its own runtime template
+// syntax (i18n, mustache-style templates, etc.). This must never be
+// flagged by idd-doctor's `checkPlaceholders` -- it has nothing to do
+// with IDD onboarding import placeholders.
+export default {
+  greeting: 'Hello, {{ year }}!',
+};

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -523,6 +523,17 @@ test('isIddManagedPlaceholderScanPath accepts every IDD-managed path class (idd-
       ),
       true,
     );
+    // idd-skill#2079 review follow-up: .github/idd/config.json is
+    // IDD-managed (validated by checkLiveConfigSchema) and templated
+    // in idd-template/.github/idd/config.json with
+    // {{PROJECT_MARKER_PREFIX}} -- the allowlist must not drop it.
+    assert.equal(
+      isIddManagedPlaceholderScanPath(
+        '.github/idd/config.json',
+        distributionSource,
+      ),
+      true,
+    );
   }
 });
 

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -3,6 +3,7 @@ import {
   chmodSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -15,6 +16,7 @@ import {
   checkClaimTimingConsistency,
   checkDependencyVersionDrift,
   checkLiveConfigSchema,
+  checkPlaceholders,
   checkPolicySignals,
   checkProjectCommands,
   classifyBacklog,
@@ -49,6 +51,7 @@ import {
   hookWiresWorktreeGuard,
   isBranchProtectionUnreadable,
   isGithubBackLinkHost,
+  isIddManagedPlaceholderScanPath,
   parseIsoDurationToHours,
   parseLockfileImporterVersion,
   parsePrimaryWorktreePath,
@@ -467,6 +470,141 @@ test('scanFileForPlaceholders scans non-docs files raw so code-span leftovers ar
     ),
     ['{{PROJECT_MARKER_PREFIX}}'],
   );
+});
+
+test('isIddManagedPlaceholderScanPath accepts every IDD-managed path class (idd-skill#2079)', () => {
+  for (const distributionSource of [true, false]) {
+    assert.equal(
+      isIddManagedPlaceholderScanPath(
+        'docs/getting-started.md',
+        distributionSource,
+      ),
+      true,
+    );
+    assert.equal(
+      isIddManagedPlaceholderScanPath(
+        'docs/onboarding/placeholders.md',
+        distributionSource,
+      ),
+      true,
+    );
+    assert.equal(
+      isIddManagedPlaceholderScanPath(
+        'profiles/human-required/README.md',
+        distributionSource,
+      ),
+      true,
+    );
+    assert.equal(
+      isIddManagedPlaceholderScanPath(
+        '.claude/skills/issue-authoring/SKILL.md',
+        distributionSource,
+      ),
+      true,
+    );
+    assert.equal(
+      isIddManagedPlaceholderScanPath(
+        'scripts/idd-doctor.mjs',
+        distributionSource,
+      ),
+      true,
+    );
+    assert.equal(
+      isIddManagedPlaceholderScanPath(
+        'schemas/idd-doctor.schema.json',
+        distributionSource,
+      ),
+      true,
+    );
+    assert.equal(
+      isIddManagedPlaceholderScanPath(
+        'fixtures/schemas/idd-doctor.schema.json',
+        distributionSource,
+      ),
+      true,
+    );
+  }
+});
+
+test('isIddManagedPlaceholderScanPath rejects an adopter application source file (idd-skill#2079 regression)', () => {
+  // The reported kit.black#128 case: an adopter's own i18n dictionary
+  // using {{ year }} as its own runtime template syntax.
+  assert.equal(
+    isIddManagedPlaceholderScanPath('packages/web/src/i18n/en.ts', true),
+    false,
+  );
+  assert.equal(
+    isIddManagedPlaceholderScanPath('packages/web/src/i18n/en.ts', false),
+    false,
+  );
+  assert.equal(isIddManagedPlaceholderScanPath('README.md', true), false);
+  assert.equal(isIddManagedPlaceholderScanPath('package.json', false), false);
+  // A docs/ file with a non-.md extension is out of scope too -- the
+  // issue's proposed scope is docs/*.md specifically.
+  assert.equal(
+    isIddManagedPlaceholderScanPath('docs/some-data.json', true),
+    false,
+  );
+});
+
+test('isIddManagedPlaceholderScanPath scans .github/instructions/ only in adopter mode', () => {
+  // distributionSource=true (the idd-skill source repo itself): these
+  // files document the placeholder syntax with example tokens that are
+  // never meant to be "resolved" -- scanning them would self-trigger.
+  assert.equal(
+    isIddManagedPlaceholderScanPath(
+      '.github/instructions/idd-discover.instructions.md',
+      true,
+    ),
+    false,
+  );
+  // distributionSource=false (an adopter's own copy after import): a
+  // leftover unresolved placeholder here is a genuine import bug.
+  assert.equal(
+    isIddManagedPlaceholderScanPath(
+      '.github/instructions/idd-discover.instructions.md',
+      false,
+    ),
+    true,
+  );
+});
+
+test('checkPlaceholders no longer flags a non-IDD-managed adopter file (idd-skill#2079 regression)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-doctor-placeholders-'));
+  try {
+    const fixtureContent = readFileSync(
+      'tests/fixtures/idd-doctor-placeholders/adopter-i18n-example.ts',
+      'utf8',
+    );
+    writeFixtureFile(dir, 'packages/web/src/i18n/en.ts', fixtureContent);
+    const report = { root: dir, errors: [], warnings: [], passes: [] };
+    checkPlaceholders(dir, ['packages/web/src/i18n/en.ts'], report);
+    assert.deepEqual(report.errors, []);
+    assert.match(
+      report.passes[0] ?? '',
+      /no unresolved \{\{\.\.\.\}\} placeholders/,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('checkPlaceholders still flags an unresolved placeholder in an IDD-managed file', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-doctor-placeholders-hit-'));
+  try {
+    writeFixtureFile(
+      dir,
+      'docs/getting-started.md',
+      'Welcome to {{PROJECT_MARKER_PREFIX}}!\n',
+    );
+    const report = { root: dir, errors: [], warnings: [], passes: [] };
+    checkPlaceholders(dir, ['docs/getting-started.md'], report);
+    assert.equal(report.errors.length, 1);
+    assert.match(report.errors[0], /docs\/getting-started\.md/);
+    assert.match(report.errors[0], /\{\{PROJECT_MARKER_PREFIX\}\}/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('parsePrimaryWorktreePath returns the first worktree entry', () => {

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -3,7 +3,6 @@ import {
   chmodSync,
   mkdirSync,
   mkdtempSync,
-  readFileSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -71,6 +70,7 @@ import {
 } from '../src/scripts/idd-doctor.mts';
 import { fetchGovernanceJson } from '../src/scripts/pre-merge-readiness.mts';
 import { loadJson } from '../src/scripts/validate-schemas.mts';
+import { readText } from './test-utils.mts';
 
 const ap = (n: number | string) =>
   `<!-- idd-skill-autopilot-suitability: ${n} -->`;
@@ -572,9 +572,8 @@ test('isIddManagedPlaceholderScanPath scans .github/instructions/ only in adopte
 test('checkPlaceholders no longer flags a non-IDD-managed adopter file (idd-skill#2079 regression)', () => {
   const dir = mkdtempSync(join(tmpdir(), 'idd-doctor-placeholders-'));
   try {
-    const fixtureContent = readFileSync(
+    const fixtureContent = readText(
       'tests/fixtures/idd-doctor-placeholders/adopter-i18n-example.ts',
-      'utf8',
     );
     writeFixtureFile(dir, 'packages/web/src/i18n/en.ts', fixtureContent);
     const report = { root: dir, errors: [], warnings: [], passes: [] };


### PR DESCRIPTION
## Summary

- `checkPlaceholders` (`idd-doctor.mjs`) scanned every git-tracked
  text-like file in an adopter repository, filtered only by a small
  denylist (`idd-template/`, `fixtures/`, `tests/`, `.git/`) — an
  adopter's own `{{...}}`-shaped runtime template syntax (i18n,
  mustache templates, etc.) tripped a false-positive "unresolved
  placeholder" error, despite having nothing to do with IDD
  onboarding. Observed in kurone-kito/kit.black#128.
- Replaced the denylist with an allowlist:
  `isIddManagedPlaceholderScanPath` scopes scanning to
  `checkRequiredFiles`'s own IDD-managed file classes (`docs/*.md`,
  `profiles/`, `.claude/skills/`, the vendored
  `scripts/`/`schemas/`/`fixtures/schemas/` bundle), plus
  `.github/instructions/` only in adopter mode — preserving the
  existing asymmetry where the source repository itself must not scan
  its own instruction files (they document the placeholder syntax
  with example tokens never meant to be "resolved").
- Verified end-to-end against this repository's own current file
  tree: `checkPlaceholders` still reports a clean pass, zero false
  positives, under the new allowlist.

Closes #2079

## Test plan

- [x] `pnpm run lint:minimum` (3595 tests, typecheck, build:check,
      biome, dprint, cspell, markdownlint) — all pass
- [x] New unit tests for `isIddManagedPlaceholderScanPath` covering
      every IDD-managed path class, the reported adopter-i18n false
      positive, and the `.github/instructions/` adopter-vs-source
      asymmetry
- [x] New `checkPlaceholders` integration tests: a non-IDD-managed
      adopter file (regression fixture at
      `tests/fixtures/idd-doctor-placeholders/adopter-i18n-example.ts`,
      matching kit.black#128's exact `{{ year }}` case) no longer
      flags, while a genuine unresolved placeholder in an IDD-managed
      file (`docs/getting-started.md`) still does
- [x] Manually ran `checkPlaceholders` against this repository's own
      real `git ls-files` tree to confirm no regression (still a
      clean pass)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved unresolved-placeholder detection by limiting scans to managed documentation, profiles, skills, scripts, schemas, and fixtures.
- Preserved application templates that use placeholder syntax for runtime or localization purposes.
- Added adopter-mode handling for GitHub instruction files.

## Tests
- Added coverage for managed and excluded paths.
- Added regression checks confirming valid adopter files are ignored while unresolved placeholders in managed content are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->