### PR TITLE
fix(idd-merge): trim F4 step 3 prose to clear bundle-merge ceiling

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -396,48 +396,39 @@ Before any mutating action in F3, apply the
    format, cleanup-failure comment format, permission-blocked comment
    format, and fallback GraphQL commands.
 3. Run from the **primary worktree**, never from inside the worktree
-   being removed — deleting the directory underlying the running
-   process's own cwd breaks every later step. Any removal (plain or
-   `--force`) silently discards ignored files too, including ones
-   inside an initialized submodule — so **before the first removal
-   attempt**, review what's there. Scope both inspection commands
-   explicitly to the target `<path>` (an unqualified command run from
-   the primary worktree inspects the wrong repository):
+   being removed — deleting the running process's own cwd breaks every
+   later step. Any removal (plain or `--force`) silently discards
+   ignored files too, including inside an initialized submodule — so
+   **before the first removal attempt**, review what's there. Scope
+   both inspection commands explicitly to `<path>` (an unqualified
+   command run from the primary worktree inspects the wrong
+   repository):
 
    - `git -C <path> status --porcelain --ignored --untracked-files=all`
-     (the explicit `--untracked-files` avoids a false-clean result under
-     a repository- or user-level `status.showUntrackedFiles=no`)
+     (avoids a false-clean result under `status.showUntrackedFiles=no`)
    - `git -C <path> submodule foreach --recursive 'git status
      --porcelain --ignored --untracked-files=all'` (keep the `Entering
-     '<submodule>'` banner — a banner-only line is a clean result, and
-     with more than one submodule the banner is what attributes a
-     finding to the right one)
+     '<submodule>'` banner — it attributes a clean/dirty result to the
+     right submodule)
 
-   Generated dependency/build output (e.g. `node_modules/` from
-   `install-deps`) is expected, disposable, and not a reason to stop.
-   Anything else uncommitted, untracked, or ignored (local notes, an
-   untracked `.env`, unpushed WIP) needs to be preserved to a
-   **different** ref, or copied out — never `<branch-name>` itself,
-   which step 3's own deletion below discards next — before
-   continuing. Then delete the worktree, then the branch:
+   Generated output (e.g. `node_modules/`) is disposable and not a
+   reason to stop. Anything else (local notes, an untracked `.env`,
+   unpushed WIP) must be preserved to a **different** ref or copied
+   out before continuing — not to `<branch-name>` itself, which this
+   step deletes next. Then delete the worktree, then the branch:
 
    - `git worktree remove <path>`. If it fails with `fatal: working
-     trees containing submodules cannot be moved or removed`, a
-     submodule-initializing step (e.g. `git submodule update --init
-     --recursive`) ran inside that worktree — retry with `git worktree
-     remove --force <path>`, which also overrides the uncommitted /
-     untracked / submodule block. Only reach for either form once the
-     review above found nothing worth preserving, not as an
-     unconditional default.
-   - `git branch -d <branch-name>` (this baseline's Claude Code
-     permission profile denies `git branch -D`; see
-     `docs/permissions.md`'s "What the baseline denies"). If it fails
-     with `error: the branch '<branch-name>' is not fully merged` even
-     though the PR was just merged via GitHub — a `fetch --prune` can
-     drop the branch's remote-tracking ref before local `main` is
-     fast-forwarded — run step 4 first (`git fetch origin main && git
-     merge --ff-only origin/main`), then retry `git branch -d
-     <branch-name>`.
+     trees containing submodules cannot be moved or removed` (a
+     submodule was initialized inside that worktree), retry with `git
+     worktree remove --force <path>`, which also overrides the
+     uncommitted/untracked block. Use `--force` only once the review
+     above found nothing worth preserving, not as a default.
+   - `git branch -d <branch-name>` (the baseline permission profile
+     denies `-D`; see `docs/permissions.md`). If it fails with `error:
+     the branch '<branch-name>' is not fully merged` despite the PR
+     being merged — `fetch --prune` can drop the remote-tracking ref
+     before local `main` fast-forwards — run step 4 first (`git fetch
+     origin main && git merge --ff-only origin/main`), then retry.
 4. Update the local `main` branch.
 5. If GitHub auto-delete is disabled: delete the remote branch too.
    (Worktrunk may be used for steps 3–5.)

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -391,48 +391,39 @@ Before any mutating action in F3, apply the
    format, cleanup-failure comment format, permission-blocked comment
    format, and fallback GraphQL commands.
 3. Run from the **primary worktree**, never from inside the worktree
-   being removed — deleting the directory underlying the running
-   process's own cwd breaks every later step. Any removal (plain or
-   `--force`) silently discards ignored files too, including ones
-   inside an initialized submodule — so **before the first removal
-   attempt**, review what's there. Scope both inspection commands
-   explicitly to the target `<path>` (an unqualified command run from
-   the primary worktree inspects the wrong repository):
+   being removed — deleting the running process's own cwd breaks every
+   later step. Any removal (plain or `--force`) silently discards
+   ignored files too, including inside an initialized submodule — so
+   **before the first removal attempt**, review what's there. Scope
+   both inspection commands explicitly to `<path>` (an unqualified
+   command run from the primary worktree inspects the wrong
+   repository):
 
    - `git -C <path> status --porcelain --ignored --untracked-files=all`
-     (the explicit `--untracked-files` avoids a false-clean result under
-     a repository- or user-level `status.showUntrackedFiles=no`)
+     (avoids a false-clean result under `status.showUntrackedFiles=no`)
    - `git -C <path> submodule foreach --recursive 'git status
      --porcelain --ignored --untracked-files=all'` (keep the `Entering
-     '<submodule>'` banner — a banner-only line is a clean result, and
-     with more than one submodule the banner is what attributes a
-     finding to the right one)
+     '<submodule>'` banner — it attributes a clean/dirty result to the
+     right submodule)
 
-   Generated dependency/build output (e.g. `node_modules/` from
-   `install-deps`) is expected, disposable, and not a reason to stop.
-   Anything else uncommitted, untracked, or ignored (local notes, an
-   untracked `.env`, unpushed WIP) needs to be preserved to a
-   **different** ref, or copied out — never `<branch-name>` itself,
-   which step 3's own deletion below discards next — before
-   continuing. Then delete the worktree, then the branch:
+   Generated output (e.g. `node_modules/`) is disposable and not a
+   reason to stop. Anything else (local notes, an untracked `.env`,
+   unpushed WIP) must be preserved to a **different** ref or copied
+   out before continuing — not to `<branch-name>` itself, which this
+   step deletes next. Then delete the worktree, then the branch:
 
    - `git worktree remove <path>`. If it fails with `fatal: working
-     trees containing submodules cannot be moved or removed`, a
-     submodule-initializing step (e.g. `git submodule update --init
-     --recursive`) ran inside that worktree — retry with `git worktree
-     remove --force <path>`, which also overrides the uncommitted /
-     untracked / submodule block. Only reach for either form once the
-     review above found nothing worth preserving, not as an
-     unconditional default.
-   - `git branch -d <branch-name>` (this baseline's Claude Code
-     permission profile denies `git branch -D`; see
-     `docs/permissions.md`'s "What the baseline denies"). If it fails
-     with `error: the branch '<branch-name>' is not fully merged` even
-     though the PR was just merged via GitHub — a `fetch --prune` can
-     drop the branch's remote-tracking ref before local `main` is
-     fast-forwarded — run step 4 first (`git fetch origin main && git
-     merge --ff-only origin/main`), then retry `git branch -d
-     <branch-name>`.
+     trees containing submodules cannot be moved or removed` (a
+     submodule was initialized inside that worktree), retry with `git
+     worktree remove --force <path>`, which also overrides the
+     uncommitted/untracked block. Use `--force` only once the review
+     above found nothing worth preserving, not as a default.
+   - `git branch -d <branch-name>` (the baseline permission profile
+     denies `-D`; see `docs/permissions.md`). If it fails with `error:
+     the branch '<branch-name>' is not fully merged` despite the PR
+     being merged — `fetch --prune` can drop the remote-tracking ref
+     before local `main` fast-forwards — run step 4 first (`git fetch
+     origin main && git merge --ff-only origin/main`), then retry.
 4. Update the local `main` branch.
 5. If GitHub auto-delete is disabled: delete the remote branch too.
    (Worktrunk may be used for steps 3–5.)


### PR DESCRIPTION
## Summary

`main` (HEAD `f1150bd1`, the merge of #2018) currently fails its own
documentation audit:

```
context-ceiling-128k: bundle-merge utilization 98.47% exceeds 98% (106346/108000 bytes)
```

This blocks `lint` / `pnpm-boundary` / `idd-advisory-convergence` on
**every** open PR, including ones that touch none of the affected
files (e.g. #2095). Root cause: #2018 added ~44 lines / ~2.5 KB of F4
worktree/submodule-removal guidance to
`.github/instructions/idd-merge.instructions.md`, a `bundle-merge`
member file. #2018's own PR-branch CI ran green — a stale-base merge
race (its last green `lint` run predates PR#2094 landing on `main`),
not a bypass.

This is an emergency, no-issue maintenance fix per the pattern #2017
records: a same-day, narrowly-scoped, cross-cutting fix blocking
multiple sibling PRs' F2 gates isn't worth a separate
Discover/Claim/author cycle first. `pre-merge-readiness.mts` requires
`--claim-issue` with no claimless mode (#2017), so this merges via the
manual F1–F5 checklist instead of the helper.

- Compressed the prose #2018 added in
  `idd-template/.github/instructions/idd-merge.instructions.md`
  (canonical source) — every command, the `--force` trigger condition,
  and the `branch -d` / `fetch --prune` remediation step are preserved
  verbatim; only wording is tightened.
- Re-synced the generated `.github/instructions/idd-merge.instructions.md`
  mirror via `node scripts/sync-docs.mjs --apply`.
- `bundle-merge` utilization: 106346/108000 (98.47%, failing) →
  ~105807/108000 (97.97%, passing).

Not raising `bundle-merge`'s `limitBytes` — that stays the maintainer
decision tracked in #2091, which this PR's headroom is still thin
against (see #2091 for the full per-bundle picture).

Refs #2016, #2018, #2091

## Test plan

- [x] `node scripts/audit-docs.mjs --check` → `documentation audit passed`
      (bundle-merge now 97.97%, under the 98% ceiling)
- [x] `node scripts/sync-docs.mjs --apply` → mirror regenerated cleanly,
      no `--force` needed
- [x] Diff reviewed line-by-line against the pre-#2018 and post-#2018
      versions to confirm no command, condition, or remediation step
      was dropped, only reworded
- [ ] CI (lint / pnpm-boundary / idd-advisory-convergence) green on
      this PR's own branch
