### PR TITLE
fix(idd-merge): widen bundle-merge headroom after a second breach

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -339,7 +339,7 @@ hold.
 
 **`suppressedCount` unvalidated**: `#1511` is `itemCount`-only; reroll
 never zeroed it in `kurone-kito/lints-config` PRs `#243`/`#245`
-(2026-08-10/11). #2050 fixes it.
+(2026-08-10/11). PR #2054 fixes it.
 
 ## Terminal Copilot stall-recovery contract (state, policy, markers, clock)
 

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -339,7 +339,7 @@ hold.
 
 **`suppressedCount` unvalidated**: `#1511` is `itemCount`-only; reroll
 never zeroed it in `kurone-kito/lints-config` PRs `#243`/`#245`
-(2026-08-10/11). #2050: triaged review-ack fixes it.
+(2026-08-10/11). #2050 fixes it.
 
 ## Terminal Copilot stall-recovery contract (state, policy, markers, clock)
 

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -426,9 +426,9 @@ Before any mutating action in F3, apply the
      denies `-D`; see `docs/permissions.md`). If it fails with `error:
      the branch '<branch-name>' is not fully merged` despite the PR
      being merged — `fetch --prune` can drop the remote-tracking ref
-     before local `main` fast-forwards — run step 4's `fetch`/
-     `--ff-only` first, then retry.
-4. Update the local `main` branch.
+     before local `main` fast-forwards — run step 4 first, then retry.
+4. Update the local `main` branch (`git fetch origin main && git merge
+   --ff-only origin/main`).
 5. If GitHub auto-delete is disabled: delete the remote branch too.
    (Worktrunk may be used for steps 3–5.)
 

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -400,9 +400,8 @@ Before any mutating action in F3, apply the
    later step. Any removal (plain or `--force`) silently discards
    ignored files too, including inside an initialized submodule — so
    **before the first removal attempt**, review what's there. Scope
-   both inspection commands explicitly to `<path>` (an unqualified
-   command run from the primary worktree inspects the wrong
-   repository):
+   both inspection commands explicitly to `<path>` — an unqualified
+   command inspects the wrong repository:
 
    - `git -C <path> status --porcelain --ignored --untracked-files=all`
      (avoids a false-clean result under `status.showUntrackedFiles=no`)
@@ -421,14 +420,14 @@ Before any mutating action in F3, apply the
      trees containing submodules cannot be moved or removed` (a
      submodule was initialized inside that worktree), retry with `git
      worktree remove --force <path>`, which also overrides the
-     uncommitted/untracked block. Use `--force` only once the review
-     above found nothing worth preserving, not as a default.
+     uncommitted/untracked block. Use `--force` only after that review
+     finds nothing worth preserving.
    - `git branch -d <branch-name>` (the baseline permission profile
      denies `-D`; see `docs/permissions.md`). If it fails with `error:
      the branch '<branch-name>' is not fully merged` despite the PR
      being merged — `fetch --prune` can drop the remote-tracking ref
-     before local `main` fast-forwards — run step 4 first (`git fetch
-     origin main && git merge --ff-only origin/main`), then retry.
+     before local `main` fast-forwards — run step 4's `fetch`/
+     `--ff-only` first, then retry.
 4. Update the local `main` branch.
 5. If GitHub auto-delete is disabled: delete the remote branch too.
    (Worktrunk may be used for steps 3–5.)

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -334,7 +334,7 @@ hold.
 
 **`suppressedCount` unvalidated**: `#1511` is `itemCount`-only; reroll
 never zeroed it in `kurone-kito/lints-config` PRs `#243`/`#245`
-(2026-08-10/11). #2050: triaged review-ack fixes it.
+(2026-08-10/11). #2050 fixes it.
 
 ## Terminal Copilot stall-recovery contract (state, policy, markers, clock)
 

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -334,7 +334,7 @@ hold.
 
 **`suppressedCount` unvalidated**: `#1511` is `itemCount`-only; reroll
 never zeroed it in `kurone-kito/lints-config` PRs `#243`/`#245`
-(2026-08-10/11). #2050 fixes it.
+(2026-08-10/11). PR #2054 fixes it.
 
 ## Terminal Copilot stall-recovery contract (state, policy, markers, clock)
 

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -395,9 +395,8 @@ Before any mutating action in F3, apply the
    later step. Any removal (plain or `--force`) silently discards
    ignored files too, including inside an initialized submodule — so
    **before the first removal attempt**, review what's there. Scope
-   both inspection commands explicitly to `<path>` (an unqualified
-   command run from the primary worktree inspects the wrong
-   repository):
+   both inspection commands explicitly to `<path>` — an unqualified
+   command inspects the wrong repository:
 
    - `git -C <path> status --porcelain --ignored --untracked-files=all`
      (avoids a false-clean result under `status.showUntrackedFiles=no`)
@@ -416,14 +415,14 @@ Before any mutating action in F3, apply the
      trees containing submodules cannot be moved or removed` (a
      submodule was initialized inside that worktree), retry with `git
      worktree remove --force <path>`, which also overrides the
-     uncommitted/untracked block. Use `--force` only once the review
-     above found nothing worth preserving, not as a default.
+     uncommitted/untracked block. Use `--force` only after that review
+     finds nothing worth preserving.
    - `git branch -d <branch-name>` (the baseline permission profile
      denies `-D`; see `docs/permissions.md`). If it fails with `error:
      the branch '<branch-name>' is not fully merged` despite the PR
      being merged — `fetch --prune` can drop the remote-tracking ref
-     before local `main` fast-forwards — run step 4 first (`git fetch
-     origin main && git merge --ff-only origin/main`), then retry.
+     before local `main` fast-forwards — run step 4's `fetch`/
+     `--ff-only` first, then retry.
 4. Update the local `main` branch.
 5. If GitHub auto-delete is disabled: delete the remote branch too.
    (Worktrunk may be used for steps 3–5.)

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -421,9 +421,9 @@ Before any mutating action in F3, apply the
      denies `-D`; see `docs/permissions.md`). If it fails with `error:
      the branch '<branch-name>' is not fully merged` despite the PR
      being merged — `fetch --prune` can drop the remote-tracking ref
-     before local `main` fast-forwards — run step 4's `fetch`/
-     `--ff-only` first, then retry.
-4. Update the local `main` branch.
+     before local `main` fast-forwards — run step 4 first, then retry.
+4. Update the local `main` branch (`git fetch origin main && git merge
+   --ff-only origin/main`).
 5. If GitHub auto-delete is disabled: delete the remote branch too.
    (Worktrunk may be used for steps 3–5.)
 


### PR DESCRIPTION
## Summary

`main` re-breached `bundle-merge`'s 98% context-ceiling within an hour
of the first fix (#2096): #2054 (issue #2050) added a single 40-byte
citation to `idd-advisory-wait.instructions.md`, taking utilization to
98.01% (105847/108000). Same stale-base merge race as #2096's root
cause, just a much smaller trigger this time -- which is itself the
point: at #2096's post-fix headroom (~33 bytes), essentially any
`bundle-merge`-member-touching PR would re-breach it.

A minimal one-line trim would have restored only ~13 bytes of
headroom -- not durable against this repo's concurrent-session merge
rate. This PR widens the margin instead:

- `idd-advisory-wait.instructions.md`: shortened #2054's added
  citation, citation preserved.
- `idd-merge.instructions.md` (canonical `idd-template/` source):
  further compressed #2096's own added F4 step 3 prose -- no command,
  trigger condition, or remediation step dropped, wording only.
- Re-synced the generated `.github/instructions/` mirrors.

`bundle-merge`: 98.01% (105847/108000, failing) -> 97.90%
(~105736/108000, passing, ~104 bytes headroom).

**Scope note**: I deliberately stopped at ~104 bytes of headroom
rather than chasing a larger buffer, because the remaining
compressible-looking prose in this file (F3's snapshot-comparison gate
logic, F4's evidence-comment status routing) is precise operational
gate logic I don't have full authoring context on -- trimming it
without that context risks introducing ambiguity into merge-safety
rules, which is a different risk class than tightening prose I wrote
myself in #2096. Raising `limitBytes` or restructuring the bundle
stays the maintainer decision tracked in #2091; I'm posting the
recurrence data there.

Same no-issue emergency-maintenance pattern as #2096 (see that PR's
own rationale re: `pre-merge-readiness.mjs` lacking a claimless mode,
#2017).

Refs #2050, #2054, #2091, #2096

## Test plan

- [x] `node scripts/audit-docs.mjs --check` -> `documentation audit
      passed` (bundle-merge now 97.90%, under the 98% ceiling)
- [x] `node scripts/sync-docs.mjs --apply` -> mirrors regenerated
      cleanly, no `--force`
- [x] Diff reviewed line-by-line to confirm no command, trigger
      condition, or remediation step was dropped
- [ ] CI green on this PR's own branch
