### PR TITLE
docs(onboarding): decouple welcome-issue auto-draft from IDD-familiarity

### DIFF
--- a/idd-template/docs/onboarding/issue-mediated-bootstrap.md
+++ b/idd-template/docs/onboarding/issue-mediated-bootstrap.md
@@ -370,7 +370,8 @@ way its four sibling bullets do. Unlike those four, which only matter to
 an operator who specifically wants them, a welcome/next-steps issue is a
 low-cost default worth surfacing regardless of _why_ the operator chose
 issue-mediated bootstrap over theirs-flow — gating it on a separate ask
-would just delay something worth having either way.
+would delay something worth having either way (preventive; no observed
+incident yet).
 
 This is also the one add-on that must stay off the Discover -> Claim ->
 Work loop entirely, unlike its four sibling bullets above: its whole

--- a/idd-template/docs/onboarding/issue-mediated-bootstrap.md
+++ b/idd-template/docs/onboarding/issue-mediated-bootstrap.md
@@ -366,10 +366,11 @@ must not run through that loop at all (see below).
 
 **Welcome/next-steps issue, in detail.** Once the core bootstrap issue
 merges, draft it automatically — do not wait for a separate request, the
-way its four sibling bullets do. The whole premise of choosing the
-guided path over theirs-flow is that the operator is less likely to
-already know IDD, so gating this one add-on on a separate ask would
-defeat the point.
+way its four sibling bullets do. Unlike those four, which only matter to
+an operator who specifically wants them, a welcome/next-steps issue is a
+low-cost default worth surfacing regardless of _why_ the operator chose
+issue-mediated bootstrap over theirs-flow — gating it on a separate ask
+would just delay something worth having either way.
 
 This is also the one add-on that must stay off the Discover -> Claim ->
 Work loop entirely, unlike its four sibling bullets above: its whole


### PR DESCRIPTION
## Summary

`idd-template/docs/onboarding/issue-mediated-bootstrap.md`'s
"Welcome/next-steps issue, in detail" subsection justified auto-drafting
that issue (unlike its four sibling add-on bullets, which wait for a
separate request) with: "The whole premise of choosing the guided path
over theirs-flow is that the operator is less likely to already know
IDD."

That conflicts with the page's own "When to choose this mode" section,
which gives two different reasons an operator picks issue-mediated
bootstrap: wanting an audited/change-control trail, or preferring not
to grant a direct-commit path — neither about IDD familiarity.

- Reworded the rationale to justify auto-drafting as a low-cost
  default worth surfacing regardless of *why* the operator chose the
  mode, instead of asserting a reason the page doesn't support
  elsewhere.
- The auto-draft behavior itself, and the loop-exclusion rule for this
  add-on, are unchanged — wording-only.

Closes #2074

## Test plan

- [x] `node scripts/sync-docs.mjs --apply` — no diff beyond the
      intended edit (this file has no repo-root mirror)
- [x] `node scripts/audit-docs.mjs --check` — `documentation audit
      passed`
- [x] `node scripts/audit-code-span-wrap.mjs` — no mid-token wraps
- [x] `pnpm run lint:minimum` — 3608 tests pass, cspell/markdownlint/
      dprint/biome all clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the welcome and next-steps issue is a standard, low-cost follow-up for every issue-mediated bootstrap.
  * Updated onboarding guidance to avoid assumptions about operators’ familiarity with the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->