### PR TITLE
docs(onboarding): state the POSIX shell and jq execution prerequisites

### DIFF
--- a/docs/idd-advisory-wait-shell-fallback.md
+++ b/docs/idd-advisory-wait-shell-fallback.md
@@ -17,9 +17,9 @@ These commands only apply when helper-first cannot be trusted — see
 the "Fail-closed fallback trigger" section in the instruction file.
 
 **Prerequisite**: a standalone `jq` binary on `PATH`. `gh api --jq` is
-built into `gh` and needs nothing extra, but the `jq -r`/`jq -s`-piped
-commands below need the real binary, which neither `gh` nor Git for
-Windows installs (see ONBOARDING.md's Step 0 execution-environment
+built into `gh` and needs nothing extra, but the commands below piping
+into `jq -r`/`jq -s` need the real binary, which neither `gh` nor Git
+for Windows installs (see ONBOARDING.md's Step 0 execution-environment
 prerequisites).
 
 The instruction file owns the contract (decision rules, ordering,

--- a/docs/idd-advisory-wait-shell-fallback.md
+++ b/docs/idd-advisory-wait-shell-fallback.md
@@ -16,6 +16,12 @@ marker-posting and cleanup mutations.
 These commands only apply when helper-first cannot be trusted — see
 the "Fail-closed fallback trigger" section in the instruction file.
 
+**Prerequisite**: a standalone `jq` binary on `PATH`. `gh api --jq` is
+built into `gh` and needs nothing extra, but the `jq -r`/`jq -s`-piped
+commands below need the real binary, which neither `gh` nor Git for
+Windows installs (see ONBOARDING.md's Step 0 execution-environment
+prerequisites).
+
 The instruction file owns the contract (decision rules, ordering,
 fail-closed handling, and what each step must produce); this document
 is the command reference. If the contract and these commands diverge,

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -239,10 +239,10 @@ a Node.js check tied to the helper-runtime-profile choice belongs at
 Step 1B's helper-runtime-profile item instead, not here.
 
 **Execution-environment prerequisites.** Separately from the `gh`
-check above, the distributed workflow's `` ```sh ``/`` ```bash `` blocks
-assume a POSIX shell and common coreutils (`grep`, `sed`, `mkdir`,
+check above, the distributed workflow's `sh`/`bash` fenced blocks
+assume a POSIX shell and common Unix utilities (`grep`, `sed`, `mkdir`,
 `dirname`, `tr`, `head`, `sort`, `curl`). On Windows, get one from Git
-for Windows (Git Bash, which bundles those coreutils) or WSL — native
+for Windows (Git Bash, which bundles those utilities) or WSL — native
 `cmd.exe`/PowerShell cannot run these blocks unmodified. The
 `instructions-only` profile's advisory-wait shell fallback additionally
 needs a standalone `jq` binary on `PATH` (see

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -238,6 +238,26 @@ pnpm for the default instructions-only profile (see
 a Node.js check tied to the helper-runtime-profile choice belongs at
 Step 1B's helper-runtime-profile item instead, not here.
 
+**Execution-environment prerequisites.** Separately from the `gh`
+check above, the distributed workflow's `` ```sh ``/`` ```bash `` blocks
+assume a POSIX shell and common coreutils (`grep`, `sed`, `mkdir`,
+`dirname`, `tr`, `head`, `sort`, `curl`). On Windows, get one from Git
+for Windows (Git Bash, which bundles those coreutils) or WSL — native
+`cmd.exe`/PowerShell cannot run these blocks unmodified. The
+`instructions-only` profile's advisory-wait shell fallback additionally
+needs a standalone `jq` binary on `PATH` (see
+[Advisory-Wait Shell Fallback](docs/idd-advisory-wait-shell-fallback.md));
+`gh api --jq` is built into `gh` and covers other call sites, but not
+this fallback's own `jq -r`/`jq -s`-piped ones, and neither `gh` nor Git
+for Windows installs a standalone `jq`.
+
+Native-Windows adopters should also set
+`git config --global core.longpaths true` (a one-time host-level
+setting, not a repository change): B1's sibling-worktree layout
+(`<repo>.<branch-with-slashes-dashed>` beside the primary worktree)
+combined with this repository's deep `.github/instructions/` paths can
+approach Windows' 260-character path limit.
+
 ---
 
 ## Dry-run — Readiness assessment

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -248,8 +248,8 @@ for Windows (Git Bash, which bundles those utilities) or WSL — native
 needs a standalone `jq` binary on `PATH` (see
 [Advisory-Wait Shell Fallback](docs/idd-advisory-wait-shell-fallback.md));
 `gh api --jq` is built into `gh` and covers other call sites, but not
-this fallback's own `jq -r`/`jq -s`-piped ones, and neither `gh` nor Git
-for Windows installs a standalone `jq`.
+this fallback's own commands piping into `jq -r`/`jq -s`, and neither
+`gh` nor Git for Windows installs a standalone `jq`.
 
 Native-Windows adopters should also set
 `git config --global core.longpaths true` (a one-time host-level

--- a/idd-template/docs/idd-advisory-wait-shell-fallback.md
+++ b/idd-template/docs/idd-advisory-wait-shell-fallback.md
@@ -17,9 +17,9 @@ These commands only apply when helper-first cannot be trusted — see
 the "Fail-closed fallback trigger" section in the instruction file.
 
 **Prerequisite**: a standalone `jq` binary on `PATH`. `gh api --jq` is
-built into `gh` and needs nothing extra, but the `jq -r`/`jq -s`-piped
-commands below need the real binary, which neither `gh` nor Git for
-Windows installs (see ONBOARDING.md's Step 0 execution-environment
+built into `gh` and needs nothing extra, but the commands below piping
+into `jq -r`/`jq -s` need the real binary, which neither `gh` nor Git
+for Windows installs (see ONBOARDING.md's Step 0 execution-environment
 prerequisites).
 
 The instruction file owns the contract (decision rules, ordering,

--- a/idd-template/docs/idd-advisory-wait-shell-fallback.md
+++ b/idd-template/docs/idd-advisory-wait-shell-fallback.md
@@ -16,6 +16,12 @@ marker-posting and cleanup mutations.
 These commands only apply when helper-first cannot be trusted — see
 the "Fail-closed fallback trigger" section in the instruction file.
 
+**Prerequisite**: a standalone `jq` binary on `PATH`. `gh api --jq` is
+built into `gh` and needs nothing extra, but the `jq -r`/`jq -s`-piped
+commands below need the real binary, which neither `gh` nor Git for
+Windows installs (see ONBOARDING.md's Step 0 execution-environment
+prerequisites).
+
 The instruction file owns the contract (decision rules, ordering,
 fail-closed handling, and what each step must produce); this document
 is the command reference. If the contract and these commands diverge,


### PR DESCRIPTION
## Summary

`idd-template/ONBOARDING.md`'s Step 0 prerequisite check covers `gh`
only. The distributed tree has 63 `sh`/`bash` fenced blocks assuming a
POSIX shell and coreutils, and the `instructions-only` profile's
advisory-wait shell fallback pipes into a standalone `jq` binary at
several call sites — neither is stated anywhere an adopter would look.
On native Windows (no POSIX shell, no `jq` by default), this surfaces
as a confusing per-command failure instead of a stated prerequisite.

- Added an "Execution-environment prerequisites" paragraph to Step 0,
  as its own block separate from the existing `gh` check (which,
  along with its host-scoping rationale and Node.js-exclusion
  sentence, is unchanged):
  - POSIX shell assumption, naming Git Bash (Git for Windows) and WSL
  - standalone `jq` requirement for the advisory-wait shell fallback,
    distinguished from the built-in `gh api --jq`
  - `git config --global core.longpaths true` for native-Windows
    adopters, since B1's sibling-worktree layout plus this repo's deep
    `.github/instructions/` paths can approach Windows' 260-character
    path limit
- `idd-advisory-wait-shell-fallback.md`: states the `jq` prerequisite
  at the point of use too.

Out of scope (per the issue): PowerShell porting, a shell/`jq` probe in
`idd-doctor`, removing the `jq` dependency, and the `.githooks/`
line-ending/fork-count issues.

Closes #2069

## Test plan

- [x] `node scripts/sync-docs.mjs --apply` — mirrors regenerated
      cleanly, no diff beyond the intended edit
- [x] `node scripts/audit-docs.mjs --check` — `documentation audit
      passed`
- [x] `node scripts/audit-code-span-wrap.mjs` — no mid-token wraps
- [x] `pnpm run lint:minimum` — 3608 tests pass; cspell, markdown link
      check (84 links), markdownlint, dprint, biome all clean
