### PR TITLE
docs(advisory-wait): add an AW3-S bound-marker direct-API fallback

### DIFF
--- a/docs/idd-advisory-wait-shell-fallback.md
+++ b/docs/idd-advisory-wait-shell-fallback.md
@@ -192,7 +192,7 @@ GH_TOKEN="${GH_TOKEN:-$(gh auth token)}"
 curl -X POST "https://api.github.com/repos/{owner}/{repo}/issues/{pr-number}/comments" \
   -H "Authorization: Bearer ${GH_TOKEN}" \
   -H "Content-Type: application/json" \
-  -d "{\"body\":\"advisory-wait-recovery: {agent-id} {PR_HEAD_SHA} {ISO8601-timestamp} claim:{claim-id} attempt:{n}\"}"
+  -d "{\"body\":\"advisory-wait-recovery: {agent-id} {PR_HEAD_SHA} {ISO8601-recovery-time} claim:{claim-id} attempt:{n}\"}"
 ```
 
 ## AW3-H

--- a/docs/idd-advisory-wait-shell-fallback.md
+++ b/docs/idd-advisory-wait-shell-fallback.md
@@ -186,6 +186,13 @@ node scripts/post-idd-marker.mjs --type advisory-recovery --target pr <pr-number
 <profile-selected-post-idd-marker-command> --type advisory-recovery \
   --target pr <pr-number> --agent-id <id> --claim-id <id> \
   --head-sha <PR_HEAD_SHA> --attempt <n> --timestamp <ISO8601> --apply
+# instructions-only profile, or any profile if the helper is unavailable —
+# manually, matching the grammar renderAdvisoryWaitRecoveryMarker emits:
+GH_TOKEN="${GH_TOKEN:-$(gh auth token)}"
+curl -X POST "https://api.github.com/repos/{owner}/{repo}/issues/{pr-number}/comments" \
+  -H "Authorization: Bearer ${GH_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{\"body\":\"advisory-wait-recovery: {agent-id} {PR_HEAD_SHA} {ISO8601-timestamp} claim:{claim-id} attempt:{n}\"}"
 ```
 
 ## AW3-H

--- a/idd-template/docs/idd-advisory-wait-shell-fallback.md
+++ b/idd-template/docs/idd-advisory-wait-shell-fallback.md
@@ -192,7 +192,7 @@ GH_TOKEN="${GH_TOKEN:-$(gh auth token)}"
 curl -X POST "https://api.github.com/repos/{owner}/{repo}/issues/{pr-number}/comments" \
   -H "Authorization: Bearer ${GH_TOKEN}" \
   -H "Content-Type: application/json" \
-  -d "{\"body\":\"advisory-wait-recovery: {agent-id} {PR_HEAD_SHA} {ISO8601-timestamp} claim:{claim-id} attempt:{n}\"}"
+  -d "{\"body\":\"advisory-wait-recovery: {agent-id} {PR_HEAD_SHA} {ISO8601-recovery-time} claim:{claim-id} attempt:{n}\"}"
 ```
 
 ## AW3-H

--- a/idd-template/docs/idd-advisory-wait-shell-fallback.md
+++ b/idd-template/docs/idd-advisory-wait-shell-fallback.md
@@ -186,6 +186,13 @@ node scripts/post-idd-marker.mjs --type advisory-recovery --target pr <pr-number
 <profile-selected-post-idd-marker-command> --type advisory-recovery \
   --target pr <pr-number> --agent-id <id> --claim-id <id> \
   --head-sha <PR_HEAD_SHA> --attempt <n> --timestamp <ISO8601> --apply
+# instructions-only profile, or any profile if the helper is unavailable —
+# manually, matching the grammar renderAdvisoryWaitRecoveryMarker emits:
+GH_TOKEN="${GH_TOKEN:-$(gh auth token)}"
+curl -X POST "https://api.github.com/repos/{owner}/{repo}/issues/{pr-number}/comments" \
+  -H "Authorization: Bearer ${GH_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{\"body\":\"advisory-wait-recovery: {agent-id} {PR_HEAD_SHA} {ISO8601-timestamp} claim:{claim-id} attempt:{n}\"}"
 ```
 
 ## AW3-H


### PR DESCRIPTION
## Summary

AW3-S's bound-marker step (step 5, "post exactly one bound marker")
had no `instructions-only` fallback, unlike its sibling AW3-R thirty
lines above in the same file. The step is mandatory — the terminal
contract counts recovery cycles by marker presence — so a session on
`instructions-only` could complete every verified step of a bounded
stale-request recovery cycle and then be unable to record it, making
the recovery invisible to `advisoryWait.recoveryCycleCap` and
re-attemptable past the cap.

- Added a `curl` fallback to AW3-S step 5 in
  `idd-template/docs/idd-advisory-wait-shell-fallback.md`, following
  AW3-R's exact "or manually:" pattern, posting the full
  `advisory-wait-recovery: {agent-id} {head-sha} {timestamp}
  claim:{id} attempt:{n}` grammar `renderAdvisoryWaitRecoveryMarker`
  emits (verified against `src/scripts/marker-helpers.mts:984`).
- No pointer clause added to `idd-advisory-wait.instructions.md`:
  its AW3-S section already links directly to this file's `#aw3-s`
  anchor (`../../docs/idd-advisory-wait-shell-fallback.md#aw3-s`), so
  a reader following that existing link sees the new fallback with no
  change needed there. This also avoids touching a
  `bundle-merge`/`bundle-review` context-ceiling member file, both of
  which currently have very little headroom (see #2091).

Closes #2064

## Test plan

- [x] `node scripts/sync-docs.mjs --apply` — mirror regenerated
      cleanly, no diff beyond the intended edit
- [x] `node scripts/audit-docs.mjs --check` — `documentation audit
      passed`; `bundle-merge`/`bundle-review` utilization unchanged
      (confirms no bundle-member file was touched)
- [x] `node scripts/audit-code-span-wrap.mjs` — no mid-token wraps
- [x] `pnpm run lint:minimum` — 3608 tests pass; cspell, markdown link
      check, markdownlint, dprint, biome all clean
