### PR TITLE
perf(worktree-guard): cut common-path forks and document Windows risk

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -39,5 +39,7 @@ words:
   - WHATWG
   - dedup
   - deprioritize
+  - dofork
   - ministral
   - nvmrc
+  - remediations

--- a/.githooks/_idd-worktree-guard.sh
+++ b/.githooks/_idd-worktree-guard.sh
@@ -14,7 +14,42 @@ idd_worktree_guard_check() {
   # $1: human-readable action word ("commit" or "push").
   action="$1"
 
-  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
+  # Single combined `git rev-parse` replaces three separate forked
+  # pipelines (--show-toplevel; `git worktree list --porcelain | sed |
+  # head` to find the primary worktree; --abbrev-ref HEAD), leaving
+  # exactly two external-process forks on the common "enabled, not on a
+  # guarded branch" path: this call and the `tr` below. A later change
+  # must not silently regress that count.
+  #
+  # This must not gate on exit status: an unborn HEAD makes the
+  # trailing --abbrev-ref HEAD resolution fail (git exits 128), but git
+  # still prints the three preceding values, plus the literal token
+  # "HEAD" it could not resolve, to stdout -- confirmed locally. That
+  # "HEAD" line is indistinguishable from an actual detached HEAD's
+  # --abbrev-ref output, so both already fall through the existing
+  # branch != HEAD check below without special-casing. Whenever the
+  # first value (toplevel) fails outright -- outside a work tree, or
+  # inside a bare .git directory -- git prints nothing at all, so the
+  # loop below leaves repo_root empty and the guard returns 0. The
+  # trailing `|| true` keeps that non-zero exit from tripping a caller
+  # that sources this file under `set -e`, matching the old code's own
+  # `|| return 0` short-circuit.
+  info=$(git rev-parse --show-toplevel --git-dir --git-common-dir --abbrev-ref HEAD 2>/dev/null) || true
+  repo_root='' git_dir='' git_common_dir='' branch=''
+  i=0
+  while IFS= read -r line; do
+    i=$((i + 1))
+    case $i in
+      1) repo_root=$line ;;
+      2) git_dir=$line ;;
+      3) git_common_dir=$line ;;
+      4) branch=$line ;;
+    esac
+  done <<_IDD_WTG_EOF_
+$info
+_IDD_WTG_EOF_
+  [ -n "$repo_root" ] || return 0
+
   config="$repo_root/.github/idd/config.json"
   [ -f "$config" ] || return 0
 
@@ -33,18 +68,19 @@ idd_worktree_guard_check() {
     *) return 0 ;;
   esac
 
-  # Only the primary worktree is guarded. The primary worktree is the
-  # first entry reported by `git worktree list`; sibling worktrees are
-  # exactly where implementation branches are supposed to live.
-  primary=$(git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p' | head -n 1)
-  [ -n "$primary" ] || return 0
-  [ "$primary" = "$repo_root" ] || return 0
+  # Only the primary worktree is guarded. In the primary worktree
+  # --git-dir and --git-common-dir refer to the same directory (both
+  # print ".git", or the same absolute path); in a linked worktree
+  # --git-dir points at ".../worktrees/<name>" while --git-common-dir
+  # still points at the shared repository -- confirmed locally. Sibling
+  # worktrees are exactly where implementation branches are supposed to
+  # live, so this is equivalent to the old primary-vs-repo_root check.
+  [ "$git_dir" = "$git_common_dir" ] || return 0
 
   # Only implementation branches are guarded. The globs come from
   # worktreeGuard.branchPatterns, defaulting to issue/* and
-  # roadmap-audit/* when the key is absent. (A detached HEAD reports
-  # "HEAD" and never matches.)
-  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+  # roadmap-audit/* when the key is absent. (A detached HEAD, or an
+  # unborn HEAD, reports "HEAD" here and never matches.)
   [ -n "$branch" ] && [ "$branch" != "HEAD" ] || return 0
 
   patterns='issue/* roadmap-audit/*'

--- a/.githooks/_idd-worktree-guard.sh
+++ b/.githooks/_idd-worktree-guard.sh
@@ -17,9 +17,11 @@ idd_worktree_guard_check() {
   # Single combined `git rev-parse` replaces three separate forked
   # pipelines (--show-toplevel; `git worktree list --porcelain | sed |
   # head` to find the primary worktree; --abbrev-ref HEAD), leaving
-  # exactly two external-process forks on the common "enabled, not on a
-  # guarded branch" path: this call and the `tr` below. A later change
-  # must not silently regress that count.
+  # exactly two external-process forks -- this call and the `tr` below
+  # -- on the common "enabled, not on a guarded branch" path with the
+  # default worktreeGuard.branchPatterns; a configured override adds
+  # two more `tr` forks in the patterns= block further down. A later
+  # change must not silently regress either count.
   #
   # This must not gate on exit status: an unborn HEAD makes the
   # trailing --abbrev-ref HEAD resolution fail (git exits 128), but git

--- a/idd-template/.githooks/_idd-worktree-guard.sh
+++ b/idd-template/.githooks/_idd-worktree-guard.sh
@@ -14,7 +14,42 @@ idd_worktree_guard_check() {
   # $1: human-readable action word ("commit" or "push").
   action="$1"
 
-  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
+  # Single combined `git rev-parse` replaces three separate forked
+  # pipelines (--show-toplevel; `git worktree list --porcelain | sed |
+  # head` to find the primary worktree; --abbrev-ref HEAD), leaving
+  # exactly two external-process forks on the common "enabled, not on a
+  # guarded branch" path: this call and the `tr` below. A later change
+  # must not silently regress that count.
+  #
+  # This must not gate on exit status: an unborn HEAD makes the
+  # trailing --abbrev-ref HEAD resolution fail (git exits 128), but git
+  # still prints the three preceding values, plus the literal token
+  # "HEAD" it could not resolve, to stdout -- confirmed locally. That
+  # "HEAD" line is indistinguishable from an actual detached HEAD's
+  # --abbrev-ref output, so both already fall through the existing
+  # branch != HEAD check below without special-casing. Whenever the
+  # first value (toplevel) fails outright -- outside a work tree, or
+  # inside a bare .git directory -- git prints nothing at all, so the
+  # loop below leaves repo_root empty and the guard returns 0. The
+  # trailing `|| true` keeps that non-zero exit from tripping a caller
+  # that sources this file under `set -e`, matching the old code's own
+  # `|| return 0` short-circuit.
+  info=$(git rev-parse --show-toplevel --git-dir --git-common-dir --abbrev-ref HEAD 2>/dev/null) || true
+  repo_root='' git_dir='' git_common_dir='' branch=''
+  i=0
+  while IFS= read -r line; do
+    i=$((i + 1))
+    case $i in
+      1) repo_root=$line ;;
+      2) git_dir=$line ;;
+      3) git_common_dir=$line ;;
+      4) branch=$line ;;
+    esac
+  done <<_IDD_WTG_EOF_
+$info
+_IDD_WTG_EOF_
+  [ -n "$repo_root" ] || return 0
+
   config="$repo_root/.github/idd/config.json"
   [ -f "$config" ] || return 0
 
@@ -33,18 +68,19 @@ idd_worktree_guard_check() {
     *) return 0 ;;
   esac
 
-  # Only the primary worktree is guarded. The primary worktree is the
-  # first entry reported by `git worktree list`; sibling worktrees are
-  # exactly where implementation branches are supposed to live.
-  primary=$(git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p' | head -n 1)
-  [ -n "$primary" ] || return 0
-  [ "$primary" = "$repo_root" ] || return 0
+  # Only the primary worktree is guarded. In the primary worktree
+  # --git-dir and --git-common-dir refer to the same directory (both
+  # print ".git", or the same absolute path); in a linked worktree
+  # --git-dir points at ".../worktrees/<name>" while --git-common-dir
+  # still points at the shared repository -- confirmed locally. Sibling
+  # worktrees are exactly where implementation branches are supposed to
+  # live, so this is equivalent to the old primary-vs-repo_root check.
+  [ "$git_dir" = "$git_common_dir" ] || return 0
 
   # Only implementation branches are guarded. The globs come from
   # worktreeGuard.branchPatterns, defaulting to issue/* and
-  # roadmap-audit/* when the key is absent. (A detached HEAD reports
-  # "HEAD" and never matches.)
-  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+  # roadmap-audit/* when the key is absent. (A detached HEAD, or an
+  # unborn HEAD, reports "HEAD" here and never matches.)
   [ -n "$branch" ] && [ "$branch" != "HEAD" ] || return 0
 
   patterns='issue/* roadmap-audit/*'

--- a/idd-template/.githooks/_idd-worktree-guard.sh
+++ b/idd-template/.githooks/_idd-worktree-guard.sh
@@ -17,9 +17,11 @@ idd_worktree_guard_check() {
   # Single combined `git rev-parse` replaces three separate forked
   # pipelines (--show-toplevel; `git worktree list --porcelain | sed |
   # head` to find the primary worktree; --abbrev-ref HEAD), leaving
-  # exactly two external-process forks on the common "enabled, not on a
-  # guarded branch" path: this call and the `tr` below. A later change
-  # must not silently regress that count.
+  # exactly two external-process forks -- this call and the `tr` below
+  # -- on the common "enabled, not on a guarded branch" path with the
+  # default worktreeGuard.branchPatterns; a configured override adds
+  # two more `tr` forks in the patterns= block further down. A later
+  # change must not silently regress either count.
   #
   # This must not gate on exit status: an unborn HEAD makes the
   # trailing --abbrev-ref HEAD resolution fail (git exits 128), but git

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -966,9 +966,11 @@ To enable it in the target repository:
    `.githooks/` directory, not the whole repository or Git-for-Windows
    install tree, if the product supports that granularity): exclude
    the affected path(s) from antivirus real-time scanning; remove any
-   duplicate or stale `cygwin1.dll` from `PATH`; and disable Mandatory
-   ASLR for the affected `sh.exe`/`bash.exe` via Windows Security's
-   Exploit Protection settings.
+   duplicate or stale MSYS/Cygwin runtime DLL (`msys-2.0.dll` for Git
+   for Windows itself, or `cygwin1.dll` if a separate Cygwin install is
+   also on `PATH`) from `PATH`; and disable Mandatory ASLR for the
+   affected `sh.exe`/`bash.exe` via Windows Security's Exploit
+   Protection settings.
 
 When `worktreeGuard.enabled` is absent or `false`, the hooks are a
 no-op. To bypass the guard for a single intentional commit or push,

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -950,18 +950,25 @@ To enable it in the target repository:
 4. Native-Windows adopters chaining fork-heavy tooling after the guard
    (a linter, `lint-staged`, and similar) are more exposed to a class
    of Cygwin/MSYS `fork()` fragility unrelated to this template
-   (observed in `kurone-kito/builder-config`, 2026-08-14 — a
-   native-Windows commit failed inside `.githooks/pre-commit` with
-   `dofork: child -1 - forked process ... died unexpectedly`; root
-   cause is generic Git-for-Windows/Cygwin `fork()` emulation
-   fragility, not a defect in this template or repository — see
+   (observed in `kurone-kito/builder-config`, 2026-08-14, cited in
+   kurone-kito/idd-skill#2068 — a native-Windows commit failed inside
+   `.githooks/pre-commit` with a Cygwin `dofork` failure ("died
+   unexpectedly"); root cause is generic Git-for-Windows/Cygwin
+   `fork()` emulation fragility, not a defect in this template or
+   repository — see
    [git-for-windows/git#1176](https://github.com/git-for-windows/git/issues/1176)).
    Standard host-level remediations, none of them actionable from
-   inside this repository: exclude the repository and the
-   Git-for-Windows install directory from antivirus real-time
-   scanning; remove any duplicate or stale `cygwin1.dll` from `PATH`;
-   and disable Mandatory ASLR for the affected `sh.exe`/`bash.exe` via
-   Windows Security's Exploit Protection settings.
+   inside this repository, and each a temporary, last-resort
+   mitigation requiring the operator's own administrator approval —
+   restore the affected protection immediately once the guard's
+   commit or push succeeds, and scope any antivirus exclusion as
+   narrowly as the antivirus product allows (ideally just the
+   `.githooks/` directory, not the whole repository or Git-for-Windows
+   install tree, if the product supports that granularity): exclude
+   the affected path(s) from antivirus real-time scanning; remove any
+   duplicate or stale `cygwin1.dll` from `PATH`; and disable Mandatory
+   ASLR for the affected `sh.exe`/`bash.exe` via Windows Security's
+   Exploit Protection settings.
 
 When `worktreeGuard.enabled` is absent or `false`, the hooks are a
 no-op. To bypass the guard for a single intentional commit or push,

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -947,6 +947,22 @@ To enable it in the target repository:
    without an extension, so they need this explicit `.githooks/*` path
    rule to be covered too.
 
+4. Native-Windows adopters chaining fork-heavy tooling after the guard
+   (a linter, `lint-staged`, and similar) are more exposed to a class
+   of Cygwin/MSYS `fork()` fragility unrelated to this template
+   (observed in `kurone-kito/builder-config`, 2026-08-14 — a
+   native-Windows commit failed inside `.githooks/pre-commit` with
+   `dofork: child -1 - forked process ... died unexpectedly`; root
+   cause is generic Git-for-Windows/Cygwin `fork()` emulation
+   fragility, not a defect in this template or repository — see
+   [git-for-windows/git#1176](https://github.com/git-for-windows/git/issues/1176)).
+   Standard host-level remediations, none of them actionable from
+   inside this repository: exclude the repository and the
+   Git-for-Windows install directory from antivirus real-time
+   scanning; remove any duplicate or stale `cygwin1.dll` from `PATH`;
+   and disable Mandatory ASLR for the affected `sh.exe`/`bash.exe` via
+   Windows Security's Exploit Protection settings.
+
 When `worktreeGuard.enabled` is absent or `false`, the hooks are a
 no-op. To bypass the guard for a single intentional commit or push,
 pass `--no-verify`. CI cannot detect this class of violation — a

--- a/tests/worktree-guard-hook.test.mts
+++ b/tests/worktree-guard-hook.test.mts
@@ -174,6 +174,49 @@ test('hook honors a custom worktreeGuard.branchPatterns override', () => {
   }
 });
 
+test('hook allows a detached HEAD in the primary worktree when enabled', () => {
+  const repo = setupRepo({ worktreeGuard: { enabled: true } });
+  try {
+    const head = gitOut(repo, ['rev-parse', 'HEAD']);
+    git(repo, ['checkout', '-q', '--detach', head]);
+    assert.equal(runHook(repo, 'pre-commit'), 0);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('hook allows an unborn HEAD in the primary worktree when enabled', () => {
+  // Deliberately does not use setupRepo: that helper always creates an
+  // initial commit, but this case is specifically about a repo with a
+  // config file present and no commits at all yet (idd-skill#2068).
+  const dir = mkdtempSync(join(tmpdir(), 'idd-hook-unborn-'));
+  try {
+    git(dir, ['init', '-b', 'issue/123-example']);
+    git(dir, ['config', 'user.email', 'test@example.com']);
+    git(dir, ['config', 'user.name', 'Test']);
+    mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(
+      join(dir, '.github/idd/config.json'),
+      JSON.stringify({ worktreeGuard: { enabled: true } }, null, 2),
+    );
+    cpSync(HOOKS_DIR, join(dir, '.githooks'), { recursive: true });
+    assert.equal(runHook(dir, 'pre-commit'), 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('hook is a no-op run from outside any work tree', () => {
+  const repo = setupRepo({ worktreeGuard: { enabled: true } });
+  const outside = mkdtempSync(join(tmpdir(), 'idd-hook-outside-'));
+  try {
+    assert.equal(runHook(repo, 'pre-commit', outside), 0);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  }
+});
+
 test('hook allows issue/* commits from a sibling worktree', () => {
   const repo = setupRepo({ worktreeGuard: { enabled: true } });
   const sibling = `${repo}-sibling`;


### PR DESCRIPTION
## Summary

`.githooks/_idd-worktree-guard.sh`'s "enabled, not on a guarded
branch" path — the overwhelming majority of real commits in a
worktree-guard repository — spawned six external processes
synchronously before any adopter-chained tooling (`lint-staged`,
linters). Native-Windows Cygwin/MSYS `fork()` emulation is fragile
under repeated forking (observed hang/failure in
`kurone-kito/builder-config`, 2026-08-14: `dofork: child -1 - forked
process ... died unexpectedly`).

**(1) Cut the common-path fork count** (6 → 2, verified empirically
with process-spawn-counting wrappers, not just code inspection):
- One combined `git rev-parse --show-toplevel --git-dir
  --git-common-dir --abbrev-ref HEAD` replaces two separate
  `rev-parse` calls plus the three-process `git worktree list
  --porcelain | sed | head` pipeline.
- Its output is split with a fork-free `while read` heredoc loop
  (shell builtins only) instead of piping through `sed`/`head` again.
- `--git-dir` vs. `--git-common-dir` string equality replaces `git
  worktree list` for primary-vs-linked-worktree detection — confirmed
  locally they're equal in the primary worktree and differ (points at
  `.../worktrees/<name>`) in a linked one.
- Every degrade-independently case the old three separate probes
  handled is preserved: unborn HEAD, detached HEAD, outside a work
  tree, inside a bare `.git` directory. The tricky one: an unborn
  HEAD's trailing `--abbrev-ref HEAD` resolution fails, but git still
  prints the three preceding values *and* the literal unresolved
  `"HEAD"` token to stdout — confirmed locally — which is
  indistinguishable from a real detached HEAD's output, so both
  already fall through the existing `branch != HEAD` check with zero
  special-casing.
- Added `|| true` on the combined call so a failing `git rev-parse`
  can't trip a caller that sources this file under `set -e` — a latent
  gap the *old* code had too (its own trailing `branch=$(...)` line
  had no such guard), caught while building the dash test harness.

**(2) Document the Windows exposure** in `ONBOARDING.md`'s
worktree-guard activation section (step 4, distinct from the CRLF
line-ending issue tracked separately in #2060): root cause and the
three host-level remediations (antivirus exclusion, stale
`cygwin1.dll` removal, disabling Mandatory ASLR for `sh.exe`/
`bash.exe`).

**Tests**: added 3 cases the existing suite didn't cover yet —
detached HEAD, unborn HEAD, outside any work tree — to
`tests/worktree-guard-hook.test.mts` (12/12 pass). Independently
verified full behavioral parity between old and new implementations
under `dash` across all 10 scenarios (guard disabled, no config,
primary+guarded blocks, primary+unguarded allows, linked worktree
allows, detached/unborn HEAD allows, outside-worktree allows, custom
`branchPatterns` override) with a throwaway comparison harness before
writing the final diff.

`.githooks/_idd-worktree-guard.sh` has no automated repo-root mirror
(confirmed: no `sync-docs.mjs` pair for it) — hand-mirrored from the
`idd-template/` canonical source, matching the existing convention
(both copies were byte-identical before this change).

Closes #2068

## Test plan

- [x] `tests/worktree-guard-hook.test.mts` — 12/12 pass (3 new:
      detached HEAD, unborn HEAD, outside a work tree)
- [x] `pnpm run lint:minimum` — 3611 tests pass; cspell (added
      `dofork`/`remediations`), markdown link check, markdownlint,
      dprint, biome all clean
- [x] `node scripts/audit-docs.mjs --check` — `documentation audit
      passed`
- [x] `node scripts/audit-code-span-wrap.mjs` — no mid-token wraps
- [x] `shellcheck --shell=sh idd-template/.githooks/_idd-worktree-guard.sh`
      — clean
- [x] Empirical fork count (process-spawn-counting wrappers around
      `git`/`tr`/`sed`/`head`): old = 6, new = 2, on the common path
- [x] Behavioral parity (`dash`, 10 scenarios): old and new
      implementations produce identical verdicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree hook handling for detached HEADs, unborn repositories, and non-worktree environments.
  * Improved primary worktree detection for more reliable branch protection.

* **Documentation**
  * Added Windows troubleshooting guidance for fork failures involving antivirus, Cygwin, and security settings.

* **Tests**
  * Added coverage for detached, unborn, and outside-worktree scenarios.

* **Chores**
  * Updated spell-checking support for additional terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->