### PR TITLE
docs(idd-ci): document the manual budget-held rerun after a waiver

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1542,7 +1542,7 @@ to post it is the consuming track's job.
 ### Manual recovery: budget-held instance after a waiver rebind
 
 `rerun-advisory-convergence.mjs --apply` deliberately never touches a
-`bot-gated-skip`, `awaiting-fresh-review`, or rerun-budget-held
+`bot-gated-skip`, `awaiting-fresh-review`, or `rerun-budget-held`
 instance (see above) -- that withholding is correct and load-bearing
 on its own, and this section does not change it: the script keeps
 withholding these instances from its own plan, and gains no

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1568,10 +1568,10 @@ Confirm all three before running it:
    the marker format above) now covers that same HEAD and check
    selector, and is itself valid -- unexpired, correctly claim-bound,
    posted by a trusted actor.
-3. The held instance's recorded failure reason (its own
-   `rerunPolicyHoldNotice`, or the run's log) predates the waiver --
-   the waiver is the reason to reconsider this instance, not an
-   unrelated later development.
+3. The held instance's recorded failure reason (the rerun-plan
+   diagnosis's `rerunPolicyHoldNotice` for that instance, or the run's
+   own log) predates the waiver -- the waiver is the reason to
+   reconsider this instance, not an unrelated later development.
 
 Only once all three hold, issue `gh run rerun <run-id>` on that
 specific instance directly -- a one-time, visible, auditable exception

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1539,6 +1539,45 @@ to post it is the consuming track's job.
   searched, so a mismatch names its own cause instead of only its
   symptom
 
+### Manual recovery: budget-held instance after a waiver rebind
+
+`rerun-advisory-convergence.mjs --apply` deliberately never touches a
+`bot-gated-skip`, `awaiting-fresh-review`, or rerun-budget-held
+instance (see above) -- that withholding is correct and load-bearing
+on its own, and this section does not change it: the script keeps
+withholding these instances from its own plan, and gains no
+`--override-budget` flag or equivalent. A specific combination sits
+outside what the withholding alone can resolve: an
+`idd-advisory-convergence` instance already went `rerun-budget-held`
+from a genuinely-failed attempt, and only afterward does a maintainer
+post a valid `idd-external-check-waiver:` marker covering the current
+HEAD and check. The held instance's recorded failure predates the
+waiver and has nothing left to say about current mergeability, but the
+waiver alone does not make GitHub re-evaluate an already-completed
+check-run.
+
+This is a maintainer-authorized manual override, not a helper flag and
+not something a worker performs unprompted -- the same deliberate
+human-judgment-gate philosophy as
+`ciGate.externalCheckWaivers.mode: "maintainer-authorized"` itself.
+Confirm all three before running it:
+
+1. The held instance's own run targets the PR's current HEAD SHA, not
+   a stale, already-superseded push.
+2. A maintainer-authorized `idd-external-check-waiver:` marker (see
+   the marker format above) now covers that same HEAD and check
+   selector, and is itself valid -- unexpired, correctly claim-bound,
+   posted by a trusted actor.
+3. The held instance's recorded failure reason (its own
+   `rerunPolicyHoldNotice`, or the run's log) predates the waiver --
+   the waiver is the reason to reconsider this instance, not an
+   unrelated later development.
+
+Only once all three hold, issue `gh run rerun <run-id>` on that
+specific instance directly -- a one-time, visible, auditable exception
+to the budget withholding, not a config flag exercisable as
+reflexively as any other CLI option.
+
 ### Merge-gate evidence
 
 - When helper runtime is enabled, these commands are the preferred

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1542,7 +1542,7 @@ to post it is the consuming track's job.
 ### Manual recovery: budget-held instance after a waiver rebind
 
 `rerun-advisory-convergence.mjs --apply` deliberately never touches a
-`bot-gated-skip`, `awaiting-fresh-review`, or rerun-budget-held
+`bot-gated-skip`, `awaiting-fresh-review`, or `rerun-budget-held`
 instance (see above) -- that withholding is correct and load-bearing
 on its own, and this section does not change it: the script keeps
 withholding these instances from its own plan, and gains no

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1568,10 +1568,10 @@ Confirm all three before running it:
    the marker format above) now covers that same HEAD and check
    selector, and is itself valid -- unexpired, correctly claim-bound,
    posted by a trusted actor.
-3. The held instance's recorded failure reason (its own
-   `rerunPolicyHoldNotice`, or the run's log) predates the waiver --
-   the waiver is the reason to reconsider this instance, not an
-   unrelated later development.
+3. The held instance's recorded failure reason (the rerun-plan
+   diagnosis's `rerunPolicyHoldNotice` for that instance, or the run's
+   own log) predates the waiver -- the waiver is the reason to
+   reconsider this instance, not an unrelated later development.
 
 Only once all three hold, issue `gh run rerun <run-id>` on that
 specific instance directly -- a one-time, visible, auditable exception

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1539,6 +1539,45 @@ to post it is the consuming track's job.
   searched, so a mismatch names its own cause instead of only its
   symptom
 
+### Manual recovery: budget-held instance after a waiver rebind
+
+`rerun-advisory-convergence.mjs --apply` deliberately never touches a
+`bot-gated-skip`, `awaiting-fresh-review`, or rerun-budget-held
+instance (see above) -- that withholding is correct and load-bearing
+on its own, and this section does not change it: the script keeps
+withholding these instances from its own plan, and gains no
+`--override-budget` flag or equivalent. A specific combination sits
+outside what the withholding alone can resolve: an
+`idd-advisory-convergence` instance already went `rerun-budget-held`
+from a genuinely-failed attempt, and only afterward does a maintainer
+post a valid `idd-external-check-waiver:` marker covering the current
+HEAD and check. The held instance's recorded failure predates the
+waiver and has nothing left to say about current mergeability, but the
+waiver alone does not make GitHub re-evaluate an already-completed
+check-run.
+
+This is a maintainer-authorized manual override, not a helper flag and
+not something a worker performs unprompted -- the same deliberate
+human-judgment-gate philosophy as
+`ciGate.externalCheckWaivers.mode: "maintainer-authorized"` itself.
+Confirm all three before running it:
+
+1. The held instance's own run targets the PR's current HEAD SHA, not
+   a stale, already-superseded push.
+2. A maintainer-authorized `idd-external-check-waiver:` marker (see
+   the marker format above) now covers that same HEAD and check
+   selector, and is itself valid -- unexpired, correctly claim-bound,
+   posted by a trusted actor.
+3. The held instance's recorded failure reason (its own
+   `rerunPolicyHoldNotice`, or the run's log) predates the waiver --
+   the waiver is the reason to reconsider this instance, not an
+   unrelated later development.
+
+Only once all three hold, issue `gh run rerun <run-id>` on that
+specific instance directly -- a one-time, visible, auditable exception
+to the budget withholding, not a config flag exercisable as
+reflexively as any other CLI option.
+
 ### Merge-gate evidence
 
 - When helper runtime is enabled, these commands are the preferred


### PR DESCRIPTION
## Summary

`rerun-advisory-convergence.mjs --apply` deliberately never touches a
`bot-gated-skip`, `awaiting-fresh-review`, or rerun-budget-held
instance — correct and load-bearing on its own. One combination sits
outside what that withholding alone resolves: an
`idd-advisory-convergence` instance already went `rerun-budget-held`
from a genuinely-failed attempt, and only afterward does a maintainer
post a valid `idd-external-check-waiver:` marker covering the current
HEAD and check. The held instance's recorded failure predates the
waiver, but the waiver alone does not make GitHub re-evaluate an
already-completed check-run.

Adds a "Manual recovery: budget-held instance after a waiver rebind"
subsection to `docs/idd-helper-scripts.md`, immediately after "Rerun-plan
diagnosis (stuck advisory-convergence)":

- The 4-step confirm-then-rerun sequence: instance targets the current
  HEAD; a valid, correctly-bound `idd-external-check-waiver:` marker
  now covers that HEAD and check; the held instance's own recorded
  failure predates the waiver; then a direct `gh run rerun <run-id>`.
- The deliberate non-goal: `rerun-advisory-convergence.mjs` itself is
  unchanged, no `--override-budget` flag or equivalent — this
  documents an existing manual, auditable, one-time maintainer
  override, matching the same human-judgment-gate philosophy as
  `ciGate.externalCheckWaivers.mode: "maintainer-authorized"`.

Edited `idd-template/docs/idd-helper-scripts.md` (the canonical
source, per `audit/sync-manifest.json`'s `idd-helper-scripts-doc`
exact-mode pair) — the issue's own candidate-files list named the
generated `docs/` mirror, but the sync direction runs the other way.

Refs #2080 (a related but independent gap: a waiver's own claim
binding can go stale across a claim takeover *before* it is ever
consumed; this issue assumes a valid, correctly-bound waiver already
exists).

Closes #2103

## Test plan

- [x] `node scripts/sync-docs.mjs --apply` — mirror regenerated
      cleanly, no diff beyond the intended edit
- [x] `node scripts/audit-docs.mjs --check` — `documentation audit
      passed`; `docs/idd-helper-scripts.md` is not part of any
      `bundleBudgets` entry, so no byte-ceiling constraint applies
- [x] `node scripts/audit-code-span-wrap.mjs` — no mid-token wraps
- [x] `pnpm run lint:minimum` — 3611 tests pass; cspell, markdown link
      check, markdownlint, dprint, biome all clean
