### PR TITLE
feat(suitability-triage): add a local/offline dry-run mode

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -59,7 +59,17 @@ In the idd-skill source repository, the following optional helpers were adopted:
   including Check 4's high-confidence duplicate/superseded tier
   (closing-PR reference and same-candidate-files overlap, excluding
   high-contention files) (referenced in
-  [kurone-kito/idd-skill#1484](https://github.com/kurone-kito/idd-skill/issues/1484))
+  [kurone-kito/idd-skill#1484](https://github.com/kurone-kito/idd-skill/issues/1484)).
+  `--body-file <path>` / `--stdin`, mutually exclusive with `--issue`, run
+  a local/offline dry-run of six of the seven checks (every check except
+  `duplicate_or_superseded`, which needs a live search index) against a
+  drafted issue's text before it is ever published -- the same exported
+  check functions the live path uses, not a reimplementation. The output
+  carries `"mode": "local"` and no `outcome`/`passed`/`failedCheck` field
+  of any kind, so a local six-of-seven pass can never be mistaken for a
+  live `--issue <n>` verdict; `duplicate_or_superseded` always reports
+  `"not_evaluated"`, never omitted (referenced in
+  [kurone-kito/idd-skill#2102](https://github.com/kurone-kito/idd-skill/issues/2102))
 - `scripts/claim-approval-gate.mjs` for A5(a) issue-author approval
   verification; A5(d) open-PR conflict checks remain manual by design
   (referenced in

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -59,7 +59,17 @@ In the idd-skill source repository, the following optional helpers were adopted:
   including Check 4's high-confidence duplicate/superseded tier
   (closing-PR reference and same-candidate-files overlap, excluding
   high-contention files) (referenced in
-  [kurone-kito/idd-skill#1484](https://github.com/kurone-kito/idd-skill/issues/1484))
+  [kurone-kito/idd-skill#1484](https://github.com/kurone-kito/idd-skill/issues/1484)).
+  `--body-file <path>` / `--stdin`, mutually exclusive with `--issue`, run
+  a local/offline dry-run of six of the seven checks (every check except
+  `duplicate_or_superseded`, which needs a live search index) against a
+  drafted issue's text before it is ever published -- the same exported
+  check functions the live path uses, not a reimplementation. The output
+  carries `"mode": "local"` and no `outcome`/`passed`/`failedCheck` field
+  of any kind, so a local six-of-seven pass can never be mistaken for a
+  live `--issue <n>` verdict; `duplicate_or_superseded` always reports
+  `"not_evaluated"`, never omitted (referenced in
+  [kurone-kito/idd-skill#2102](https://github.com/kurone-kito/idd-skill/issues/2102))
 - `scripts/claim-approval-gate.mjs` for A5(a) issue-author approval
   verification; A5(d) open-PR conflict checks remain manual by design
   (referenced in

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -981,9 +981,13 @@ export function checkVerifiability(context) {
  * `runCli`'s own process-level side effects (env mutation, `gh` calls).
  */
 export function resolveInputMode(args) {
+  // Checks flag *presence* (`!== undefined`), not truthiness: `--body-file=`
+  // parses to `''` under Node's util.parseArgs, and a truthy check would
+  // silently fold that into "no mode selected" instead of the explicit,
+  // actionable empty-path error thrown below.
   const inputModeCount =
     (args.issue !== null ? 1 : 0) +
-    (args.bodyFile ? 1 : 0) +
+    (args.bodyFile !== undefined ? 1 : 0) +
     (args.stdin ? 1 : 0);
   if (inputModeCount === 0) {
     throw new Error('one of --issue, --body-file, or --stdin is required');
@@ -991,7 +995,10 @@ export function resolveInputMode(args) {
   if (inputModeCount > 1) {
     throw new Error('choose only one of --issue, --body-file, or --stdin');
   }
-  return args.bodyFile || args.stdin ? 'local' : 'issue';
+  if (args.bodyFile === '') {
+    throw new Error('--body-file requires a non-empty path');
+  }
+  return args.bodyFile !== undefined || args.stdin ? 'local' : 'issue';
 }
 function runCli() {
   const args = parseArgs(process.argv.slice(2));

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -1404,8 +1404,9 @@ a drafted issue's text before it is ever published: six of the seven
 checks (every check except duplicate_or_superseded, Check 4, which
 fundamentally needs a live search index) run against the same exported
 check functions the live --issue path uses. A leading "# Title" line in
-the supplied text is extracted as the title; everything else is the body.
-See "Local mode output schema" below -- it is a distinct, deliberately
+the supplied text is extracted as the title; everything else, minus any
+blank lines immediately after the title, is the body. See "Local mode
+output schema" below -- it is a distinct, deliberately
 incompatible shape from the live --issue output directly below it, so a
 local dry-run result can never be mistaken for a live verdict.
 

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -63,6 +63,8 @@ const MERGED_PR_SCAN_DEADLINE_MS = 2 * 60 * 1000;
 // trigger fires (see ci-wait-policy.mts's identical note).
 const SUITABILITY_TRIAGE_FLAG_SPEC = {
   '--issue': { type: 'string' },
+  '--body-file': { type: 'string' },
+  '--stdin': { type: 'boolean', default: false },
   '--token': { type: 'string', default: '' },
   '--owner': { type: 'string', default: '' },
   '--repo': { type: 'string', default: '' },
@@ -978,6 +980,23 @@ function runCli() {
     printHelp();
     process.exit(0);
   }
+  // #2102: --issue, --body-file, and --stdin select mutually exclusive
+  // input modes; exactly one is required. --body-file/--stdin never touch
+  // the network -- validated before any of the --issue-only setup below.
+  const inputModeCount =
+    (args.issue !== null ? 1 : 0) +
+    (args.bodyFile ? 1 : 0) +
+    (args.stdin ? 1 : 0);
+  if (inputModeCount === 0) {
+    throw new Error('one of --issue, --body-file, or --stdin is required');
+  }
+  if (inputModeCount > 1) {
+    throw new Error('choose only one of --issue, --body-file, or --stdin');
+  }
+  if (args.bodyFile || args.stdin) {
+    runLocalCli(args);
+    return;
+  }
   if (args.issue === null || !Number.isInteger(args.issue) || args.issue <= 0) {
     throw new Error('--issue is required and must be a positive integer');
   }
@@ -1209,6 +1228,103 @@ function runCli() {
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
 }
 /**
+ * #2102: local/offline dry-run core for `--body-file`/`--stdin`, mirroring
+ * `evaluateSuitability`'s split from `runCli`: this is the pure,
+ * exported-and-testable half; `runLocalCli` below is the thin I/O wrapper
+ * (read the file/stdin, call this, print JSON).
+ *
+ * Runs the same exported check functions `evaluateSuitability` calls for
+ * every check except `duplicate_or_superseded` (Check 4), which
+ * fundamentally needs a live `gh api search/issues` query and cannot run
+ * offline -- reported as its own explicit `"not_evaluated"` result value
+ * in every run, never silently omitted and never counted toward a
+ * pass/fail rollup. Unlike `evaluateSuitability`, this never short-circuits
+ * on the first failing check: a dry-run's whole purpose is surfacing every
+ * check's verdict in one pass, not the live path's checks-are-expensive
+ * early-exit (no check here does network I/O, so there is no cost to
+ * avoid).
+ *
+ * The return value has no `outcome` field at all, and no aggregate
+ * `passed` value: `mode: "local"` plus a per-check `checks[]` array is the
+ * entire contract, so a caller cannot mistake a six-of-seven local pass
+ * for a live `--issue <n>` verdict -- the same class of category error
+ * this repository's own prior finding flagged for
+ * `audit-authored-issue.mjs` (a structural-lint pass is not a
+ * `suitability-triage.mjs` semantic pass); this must not repeat one level
+ * down. Always returns every check's full evidence; `runLocalCli` applies
+ * the same verbose/non-verbose evidence filtering the live path uses.
+ */
+export function evaluateSuitabilityLocal(bodyText, options = {}) {
+  const { title, body } = splitLocalDraftTitleAndBody(bodyText);
+  const localIssue = {
+    number: 0,
+    title,
+    body,
+    state: 'draft',
+    labels: [],
+    url: '',
+    createdAt: new Date().toISOString(),
+  };
+  const context = {
+    issue: localIssue,
+    repository: null,
+    duplicateCandidates: [],
+    trustSafetyAmbiguous: false,
+    blockedByHumanLabelName: normalizeConfiguredLabelName(
+      options.blockedByHumanLabelName,
+      POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+    ),
+    needsDecisionLabelName: normalizeConfiguredLabelName(
+      options.needsDecisionLabelName,
+      POLICY_DEFAULTS.labels.needsDecisionLabelName,
+    ),
+  };
+  const checks = CHECKS.map((check) => {
+    if (check.id === 'duplicate_or_superseded') {
+      return {
+        id: check.id,
+        name: check.name,
+        result: 'not_evaluated',
+        evidence:
+          'Local dry-run mode has no live GitHub search index; this check cannot run offline.',
+      };
+    }
+    const outcome = check.evaluate(context);
+    return {
+      id: check.id,
+      name: check.name,
+      result: outcome.pass ? 'pass' : 'fail',
+      evidence: outcome.evidence,
+      ...(outcome.tier ? { tier: outcome.tier } : {}),
+    };
+  });
+  return { mode: 'local', issue: { title }, checks };
+}
+function runLocalCli(args) {
+  const bodyText = args.stdin
+    ? readFileSync(0, 'utf8')
+    : readFileSync(resolve(process.cwd(), args.bodyFile), 'utf8');
+  const policyConfig = loadPolicy(args.policy);
+  const labelsPolicy = normalizePolicyConfig(policyConfig).labels;
+  const result = evaluateSuitabilityLocal(bodyText, {
+    blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+    needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+  });
+  const output = {
+    mode: result.mode,
+    issue: result.issue,
+    checks: args.verbose
+      ? result.checks
+      : result.checks.map((check) => ({
+          id: check.id,
+          name: check.name,
+          result: check.result,
+          ...(check.tier ? { tier: check.tier } : {}),
+        })),
+  };
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+/**
  * Restores this file's pre-#1450 permissive `Number.parseInt` contract:
  * absent resolves to `null` (the original `issue: null` default, never
  * overwritten when `--issue` is absent); present feeds the raw token
@@ -1233,6 +1349,8 @@ export function parseArgs(argv) {
   const { values, help } = parseCliArgs(argv, SUITABILITY_TRIAGE_FLAG_SPEC);
   return {
     issue: parseLenientIntegerOrNull(values.issue),
+    bodyFile: values['body-file'],
+    stdin: values.stdin,
     token: values.token,
     owner: values.owner,
     repo: values.repo,
@@ -1266,6 +1384,18 @@ function loadPolicy(policyPath) {
 function printHelp() {
   process.stdout.write(`Usage:
   node scripts/suitability-triage.mjs --issue <number> [--token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--manifest <path>] [--bundles <id1,id2>] [--verbose] [--help]
+  node scripts/suitability-triage.mjs (--body-file <path> | --stdin) [--policy <path>] [--verbose] [--help]
+
+--issue, --body-file, and --stdin are mutually exclusive; exactly one is
+required. --body-file/--stdin (#2102) run a local, offline dry-run against
+a drafted issue's text before it is ever published: six of the seven
+checks (every check except duplicate_or_superseded, Check 4, which
+fundamentally needs a live search index) run against the same exported
+check functions the live --issue path uses. A leading "# Title" line in
+the supplied text is extracted as the title; everything else is the body.
+See "Local mode output schema" below -- it is a distinct, deliberately
+incompatible shape from the live --issue output directly below it, so a
+local dry-run result can never be mistaken for a live verdict.
 
 --manifest / --bundles override the Check 4 high-confidence tier's
 high-contention exclusion set (default: the same manifest path and bundle
@@ -1273,7 +1403,7 @@ IDs as discover-shared-file-overlap.mjs's own --manifest/--bundles), so a
 repository that customizes its A4 Step 2 contention bundles gets a matching
 Check-4 exclusion set instead of a stale hardcoded default.
 
-Output schema:
+Live (--issue) output schema:
 {
   "repository": {"owner": "...", "repo": "..."},
   "issue": {"number": 392, "title": "...", "state": "OPEN", "url": "..."},
@@ -1296,7 +1426,54 @@ Absent (not null) for the common never-triaged case, and never surfaced for
 a rejection-shaped comment from an untrusted actor. An optional sibling
 "existingRejectionCollectionWarnings" array is present only when fetching
 or scanning the comment thread itself failed.
+
+Local (--body-file/--stdin) output schema (#2102):
+{
+  "mode": "local",
+  "issue": {"title": "..."},
+  "checks": [
+    {"id":"repository_fit","name":"Repository Fit","result":"pass|fail","evidence":"..."},
+    {"id":"coherence","name":"Issue Coherence","result":"pass|fail","evidence":"..."},
+    {"id":"trust_safety","name":"Trust/Safety","result":"pass|fail","evidence":"..."},
+    {"id":"duplicate_or_superseded","name":"Duplicate or Superseded Work","result":"not_evaluated","evidence":"..."},
+    {"id":"actionability","name":"Actionability","result":"pass|fail","evidence":"..."},
+    {"id":"autonomy","name":"Autonomy","result":"pass|fail","evidence":"..."},
+    {"id":"verifiability","name":"Verifiability","result":"pass|fail","evidence":"..."}
+  ]
+}
+
+There is no "passed", "outcome", or "failedCheck" field in local mode, and
+no aggregate rollup of any kind: "duplicate_or_superseded" always reports
+"not_evaluated" and is never counted toward a pass/fail verdict, so a
+caller must inspect each checks[] entry individually rather than infer an
+overall suitability outcome from a local run.
 `);
+}
+/**
+ * #2102: split a locally-drafted `--body-file`/`--stdin` text blob into a
+ * title and a body, for the local dry-run mode. `audit-authored-issue.mts`
+ * has no equivalent split -- it validates body structure only, never a
+ * title -- so this convention is new here, not reused from that file.
+ *
+ * A leading `# Title` line (a single Markdown H1, the common convention
+ * for a drafted issue file that mirrors what GitHub's own title field will
+ * hold) is extracted as the title; any blank lines immediately following
+ * it are also consumed so the remaining body does not start with stray
+ * leading blank lines. Anything else -- no H1, or an H1 that is not the
+ * very first non-blank content -- leaves the title empty and the entire
+ * input becomes the body unchanged: `checkCoherence` and the other checks
+ * below already tolerate an empty title (see the live path's own
+ * `normalizeIssue`, which defaults a genuinely missing title to `''`), so
+ * under-splitting fails safe rather than guessing.
+ */
+export function splitLocalDraftTitleAndBody(text) {
+  const match = text.match(/^[ \t]*#[ \t]+(\S[^\n]*?)[ \t]*\r?\n/);
+  if (!match) {
+    return { title: '', body: text };
+  }
+  const title = match[1] ?? '';
+  const rest = text.slice(match[0].length).replace(/^(?:[ \t]*\r?\n)+/, '');
+  return { title, body: rest };
 }
 function normalizeIssue(issue) {
   const i = issue ?? {};

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -974,15 +974,13 @@ export function checkVerifiability(context) {
       'Issue includes objective verification language and substantive criteria.',
   };
 }
-function runCli() {
-  const args = parseArgs(process.argv.slice(2));
-  if (args.help) {
-    printHelp();
-    process.exit(0);
-  }
-  // #2102: --issue, --body-file, and --stdin select mutually exclusive
-  // input modes; exactly one is required. --body-file/--stdin never touch
-  // the network -- validated before any of the --issue-only setup below.
+/**
+ * #2102: `--issue`, `--body-file`, and `--stdin` select mutually exclusive
+ * input modes; exactly one is required. Exported (and thus independently
+ * testable) so both `throw` branches can be exercised without invoking
+ * `runCli`'s own process-level side effects (env mutation, `gh` calls).
+ */
+export function resolveInputMode(args) {
   const inputModeCount =
     (args.issue !== null ? 1 : 0) +
     (args.bodyFile ? 1 : 0) +
@@ -993,7 +991,17 @@ function runCli() {
   if (inputModeCount > 1) {
     throw new Error('choose only one of --issue, --body-file, or --stdin');
   }
-  if (args.bodyFile || args.stdin) {
+  return args.bodyFile || args.stdin ? 'local' : 'issue';
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  // #2102: --body-file/--stdin never touch the network -- resolved before
+  // any of the --issue-only setup below.
+  if (resolveInputMode(args) === 'local') {
     runLocalCli(args);
     return;
   }

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -1271,7 +1271,11 @@ export function evaluateSuitabilityLocal(bodyText, options = {}) {
     state: 'draft',
     labels: [],
     url: '',
-    createdAt: new Date().toISOString(),
+    // #2102 Copilot review: none of the six local checks read `createdAt`
+    // (only checkDuplicateOrSuperseded does, and that check never runs
+    // locally) -- a wall-clock timestamp here would make this "pure"
+    // evaluation nondeterministic for no benefit.
+    createdAt: '',
   };
   const context = {
     issue: localIssue,
@@ -1455,6 +1459,10 @@ no aggregate rollup of any kind: "duplicate_or_superseded" always reports
 "not_evaluated" and is never counted toward a pass/fail verdict, so a
 caller must inspect each checks[] entry individually rather than infer an
 overall suitability outcome from a local run.
+
+Like the live path, each entry's "evidence" is present only with
+--verbose; the schema above shows every field a checks[] entry can carry,
+not what a default (non-verbose) run actually returns.
 `);
 }
 /**

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -1465,17 +1465,23 @@ overall suitability outcome from a local run.
  *
  * A leading `# Title` line (a single Markdown H1, the common convention
  * for a drafted issue file that mirrors what GitHub's own title field will
- * hold) is extracted as the title; any blank lines immediately following
- * it are also consumed so the remaining body does not start with stray
- * leading blank lines. Anything else -- no H1, or an H1 that is not the
- * very first non-blank content -- leaves the title empty and the entire
- * input becomes the body unchanged: `checkCoherence` and the other checks
- * below already tolerate an empty title (see the live path's own
- * `normalizeIssue`, which defaults a genuinely missing title to `''`), so
- * under-splitting fails safe rather than guessing.
+ * hold) is extracted as the title -- any blank lines *before* it are
+ * skipped first, so it need not be the literal first line, only the first
+ * non-blank content, and it needs no trailing newline of its own (a draft
+ * whose entire content is `# Title` still extracts correctly). Any blank
+ * lines immediately following the H1 line are also consumed so the
+ * remaining body does not start with stray leading blank lines. Anything
+ * else -- no H1, or an H1 preceded by non-blank content -- leaves the
+ * title empty and the entire input becomes the body unchanged:
+ * `checkCoherence` and the other checks below already tolerate an empty
+ * title (see the live path's own `normalizeIssue`, which defaults a
+ * genuinely missing title to `''`), so under-splitting fails safe rather
+ * than guessing.
  */
 export function splitLocalDraftTitleAndBody(text) {
-  const match = text.match(/^[ \t]*#[ \t]+(\S[^\n]*?)[ \t]*\r?\n/);
+  const match = text.match(
+    /^(?:[ \t]*\r?\n)*[ \t]*#[ \t]+(\S[^\n]*?)[ \t]*(?:\r?\n|$)/,
+  );
   if (!match) {
     return { title: '', body: text };
   }

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1692,20 +1692,26 @@ overall suitability outcome from a local run.
  *
  * A leading `# Title` line (a single Markdown H1, the common convention
  * for a drafted issue file that mirrors what GitHub's own title field will
- * hold) is extracted as the title; any blank lines immediately following
- * it are also consumed so the remaining body does not start with stray
- * leading blank lines. Anything else -- no H1, or an H1 that is not the
- * very first non-blank content -- leaves the title empty and the entire
- * input becomes the body unchanged: `checkCoherence` and the other checks
- * below already tolerate an empty title (see the live path's own
- * `normalizeIssue`, which defaults a genuinely missing title to `''`), so
- * under-splitting fails safe rather than guessing.
+ * hold) is extracted as the title -- any blank lines *before* it are
+ * skipped first, so it need not be the literal first line, only the first
+ * non-blank content, and it needs no trailing newline of its own (a draft
+ * whose entire content is `# Title` still extracts correctly). Any blank
+ * lines immediately following the H1 line are also consumed so the
+ * remaining body does not start with stray leading blank lines. Anything
+ * else -- no H1, or an H1 preceded by non-blank content -- leaves the
+ * title empty and the entire input becomes the body unchanged:
+ * `checkCoherence` and the other checks below already tolerate an empty
+ * title (see the live path's own `normalizeIssue`, which defaults a
+ * genuinely missing title to `''`), so under-splitting fails safe rather
+ * than guessing.
  */
 export function splitLocalDraftTitleAndBody(text: string): {
   title: string;
   body: string;
 } {
-  const match = text.match(/^[ \t]*#[ \t]+(\S[^\n]*?)[ \t]*\r?\n/);
+  const match = text.match(
+    /^(?:[ \t]*\r?\n)*[ \t]*#[ \t]+(\S[^\n]*?)[ \t]*(?:\r?\n|$)/,
+  );
   if (!match) {
     return { title: '', body: text };
   }

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1630,8 +1630,9 @@ a drafted issue's text before it is ever published: six of the seven
 checks (every check except duplicate_or_superseded, Check 4, which
 fundamentally needs a live search index) run against the same exported
 check functions the live --issue path uses. A leading "# Title" line in
-the supplied text is extracted as the title; everything else is the body.
-See "Local mode output schema" below -- it is a distinct, deliberately
+the supplied text is extracted as the title; everything else, minus any
+blank lines immediately after the title, is the body. See "Local mode
+output schema" below -- it is a distinct, deliberately
 incompatible shape from the live --issue output directly below it, so a
 local dry-run result can never be mistaken for a live verdict.
 

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1156,16 +1156,15 @@ export function checkVerifiability(context: Context): CheckOutcome {
   };
 }
 
-function runCli(): void {
-  const args = parseArgs(process.argv.slice(2));
-  if (args.help) {
-    printHelp();
-    process.exit(0);
-  }
-
-  // #2102: --issue, --body-file, and --stdin select mutually exclusive
-  // input modes; exactly one is required. --body-file/--stdin never touch
-  // the network -- validated before any of the --issue-only setup below.
+/**
+ * #2102: `--issue`, `--body-file`, and `--stdin` select mutually exclusive
+ * input modes; exactly one is required. Exported (and thus independently
+ * testable) so both `throw` branches can be exercised without invoking
+ * `runCli`'s own process-level side effects (env mutation, `gh` calls).
+ */
+export function resolveInputMode(
+  args: Pick<SuitabilityTriageArgs, 'issue' | 'bodyFile' | 'stdin'>,
+): 'issue' | 'local' {
   const inputModeCount =
     (args.issue !== null ? 1 : 0) +
     (args.bodyFile ? 1 : 0) +
@@ -1176,7 +1175,19 @@ function runCli(): void {
   if (inputModeCount > 1) {
     throw new Error('choose only one of --issue, --body-file, or --stdin');
   }
-  if (args.bodyFile || args.stdin) {
+  return args.bodyFile || args.stdin ? 'local' : 'issue';
+}
+
+function runCli(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  // #2102: --body-file/--stdin never touch the network -- resolved before
+  // any of the --issue-only setup below.
+  if (resolveInputMode(args) === 'local') {
     runLocalCli(args);
     return;
   }

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -59,6 +59,10 @@ const MERGED_PR_SCAN_DEADLINE_MS = 2 * 60 * 1000;
 /** Parsed CLI arguments. */
 interface SuitabilityTriageArgs {
   issue: number | null;
+  /** #2102: local/offline dry-run input, mutually exclusive with --issue. */
+  bodyFile?: string;
+  /** #2102: local/offline dry-run input, mutually exclusive with --issue. */
+  stdin: boolean;
   token: string;
   owner: string;
   repo: string;
@@ -91,6 +95,8 @@ interface SuitabilityTriageArgs {
 // trigger fires (see ci-wait-policy.mts's identical note).
 const SUITABILITY_TRIAGE_FLAG_SPEC = {
   '--issue': { type: 'string' },
+  '--body-file': { type: 'string' },
+  '--stdin': { type: 'boolean', default: false },
   '--token': { type: 'string', default: '' },
   '--owner': { type: 'string', default: '' },
   '--repo': { type: 'string', default: '' },
@@ -1156,6 +1162,25 @@ function runCli(): void {
     printHelp();
     process.exit(0);
   }
+
+  // #2102: --issue, --body-file, and --stdin select mutually exclusive
+  // input modes; exactly one is required. --body-file/--stdin never touch
+  // the network -- validated before any of the --issue-only setup below.
+  const inputModeCount =
+    (args.issue !== null ? 1 : 0) +
+    (args.bodyFile ? 1 : 0) +
+    (args.stdin ? 1 : 0);
+  if (inputModeCount === 0) {
+    throw new Error('one of --issue, --body-file, or --stdin is required');
+  }
+  if (inputModeCount > 1) {
+    throw new Error('choose only one of --issue, --body-file, or --stdin');
+  }
+  if (args.bodyFile || args.stdin) {
+    runLocalCli(args);
+    return;
+  }
+
   if (args.issue === null || !Number.isInteger(args.issue) || args.issue <= 0) {
     throw new Error('--issue is required and must be a positive integer');
   }
@@ -1399,6 +1424,126 @@ function runCli(): void {
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
 }
 
+interface LocalSuitabilityResult {
+  mode: 'local';
+  issue: { title: string };
+  checks: CheckResult[];
+}
+
+interface LocalSuitabilityOptions {
+  blockedByHumanLabelName?: string;
+  needsDecisionLabelName?: string;
+}
+
+/**
+ * #2102: local/offline dry-run core for `--body-file`/`--stdin`, mirroring
+ * `evaluateSuitability`'s split from `runCli`: this is the pure,
+ * exported-and-testable half; `runLocalCli` below is the thin I/O wrapper
+ * (read the file/stdin, call this, print JSON).
+ *
+ * Runs the same exported check functions `evaluateSuitability` calls for
+ * every check except `duplicate_or_superseded` (Check 4), which
+ * fundamentally needs a live `gh api search/issues` query and cannot run
+ * offline -- reported as its own explicit `"not_evaluated"` result value
+ * in every run, never silently omitted and never counted toward a
+ * pass/fail rollup. Unlike `evaluateSuitability`, this never short-circuits
+ * on the first failing check: a dry-run's whole purpose is surfacing every
+ * check's verdict in one pass, not the live path's checks-are-expensive
+ * early-exit (no check here does network I/O, so there is no cost to
+ * avoid).
+ *
+ * The return value has no `outcome` field at all, and no aggregate
+ * `passed` value: `mode: "local"` plus a per-check `checks[]` array is the
+ * entire contract, so a caller cannot mistake a six-of-seven local pass
+ * for a live `--issue <n>` verdict -- the same class of category error
+ * this repository's own prior finding flagged for
+ * `audit-authored-issue.mjs` (a structural-lint pass is not a
+ * `suitability-triage.mjs` semantic pass); this must not repeat one level
+ * down. Always returns every check's full evidence; `runLocalCli` applies
+ * the same verbose/non-verbose evidence filtering the live path uses.
+ */
+export function evaluateSuitabilityLocal(
+  bodyText: string,
+  options: LocalSuitabilityOptions = {},
+): LocalSuitabilityResult {
+  const { title, body } = splitLocalDraftTitleAndBody(bodyText);
+
+  const localIssue: NormalizedIssue = {
+    number: 0,
+    title,
+    body,
+    state: 'draft',
+    labels: [],
+    url: '',
+    createdAt: new Date().toISOString(),
+  };
+
+  const context: Context = {
+    issue: localIssue,
+    repository: null,
+    duplicateCandidates: [],
+    trustSafetyAmbiguous: false,
+    blockedByHumanLabelName: normalizeConfiguredLabelName(
+      options.blockedByHumanLabelName,
+      POLICY_DEFAULTS.labels.blockedByHumanLabelName,
+    ),
+    needsDecisionLabelName: normalizeConfiguredLabelName(
+      options.needsDecisionLabelName,
+      POLICY_DEFAULTS.labels.needsDecisionLabelName,
+    ),
+  };
+
+  const checks: CheckResult[] = CHECKS.map((check) => {
+    if (check.id === 'duplicate_or_superseded') {
+      return {
+        id: check.id,
+        name: check.name,
+        result: 'not_evaluated',
+        evidence:
+          'Local dry-run mode has no live GitHub search index; this check cannot run offline.',
+      };
+    }
+    const outcome = check.evaluate(context);
+    return {
+      id: check.id,
+      name: check.name,
+      result: outcome.pass ? 'pass' : 'fail',
+      evidence: outcome.evidence,
+      ...(outcome.tier ? { tier: outcome.tier } : {}),
+    };
+  });
+
+  return { mode: 'local', issue: { title }, checks };
+}
+
+function runLocalCli(args: SuitabilityTriageArgs): void {
+  const bodyText = args.stdin
+    ? readFileSync(0, 'utf8')
+    : readFileSync(resolve(process.cwd(), args.bodyFile as string), 'utf8');
+
+  const policyConfig = loadPolicy(args.policy);
+  const labelsPolicy = normalizePolicyConfig(policyConfig).labels;
+  const result = evaluateSuitabilityLocal(bodyText, {
+    blockedByHumanLabelName: labelsPolicy.blockedByHumanLabelName,
+    needsDecisionLabelName: labelsPolicy.needsDecisionLabelName,
+  });
+
+  const output = {
+    mode: result.mode,
+    issue: result.issue,
+    checks: args.verbose
+      ? result.checks
+      : result.checks.map((check) => ({
+          id: check.id,
+          name: check.name,
+          result: check.result,
+          ...(check.tier ? { tier: check.tier } : {}),
+        })),
+  };
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+}
+
 /**
  * Restores this file's pre-#1450 permissive `Number.parseInt` contract:
  * absent resolves to `null` (the original `issue: null` default, never
@@ -1425,6 +1570,8 @@ export function parseArgs(argv: string[]): SuitabilityTriageArgs {
   const { values, help } = parseCliArgs(argv, SUITABILITY_TRIAGE_FLAG_SPEC);
   return {
     issue: parseLenientIntegerOrNull(values.issue as string | undefined),
+    bodyFile: values['body-file'] as string | undefined,
+    stdin: values.stdin as boolean,
     token: values.token as string,
     owner: values.owner as string,
     repo: values.repo as string,
@@ -1460,6 +1607,18 @@ function loadPolicy(policyPath: string): unknown {
 function printHelp(): void {
   process.stdout.write(`Usage:
   node scripts/suitability-triage.mjs --issue <number> [--token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--manifest <path>] [--bundles <id1,id2>] [--verbose] [--help]
+  node scripts/suitability-triage.mjs (--body-file <path> | --stdin) [--policy <path>] [--verbose] [--help]
+
+--issue, --body-file, and --stdin are mutually exclusive; exactly one is
+required. --body-file/--stdin (#2102) run a local, offline dry-run against
+a drafted issue's text before it is ever published: six of the seven
+checks (every check except duplicate_or_superseded, Check 4, which
+fundamentally needs a live search index) run against the same exported
+check functions the live --issue path uses. A leading "# Title" line in
+the supplied text is extracted as the title; everything else is the body.
+See "Local mode output schema" below -- it is a distinct, deliberately
+incompatible shape from the live --issue output directly below it, so a
+local dry-run result can never be mistaken for a live verdict.
 
 --manifest / --bundles override the Check 4 high-confidence tier's
 high-contention exclusion set (default: the same manifest path and bundle
@@ -1467,7 +1626,7 @@ IDs as discover-shared-file-overlap.mjs's own --manifest/--bundles), so a
 repository that customizes its A4 Step 2 contention bundles gets a matching
 Check-4 exclusion set instead of a stale hardcoded default.
 
-Output schema:
+Live (--issue) output schema:
 {
   "repository": {"owner": "...", "repo": "..."},
   "issue": {"number": 392, "title": "...", "state": "OPEN", "url": "..."},
@@ -1490,7 +1649,58 @@ Absent (not null) for the common never-triaged case, and never surfaced for
 a rejection-shaped comment from an untrusted actor. An optional sibling
 "existingRejectionCollectionWarnings" array is present only when fetching
 or scanning the comment thread itself failed.
+
+Local (--body-file/--stdin) output schema (#2102):
+{
+  "mode": "local",
+  "issue": {"title": "..."},
+  "checks": [
+    {"id":"repository_fit","name":"Repository Fit","result":"pass|fail","evidence":"..."},
+    {"id":"coherence","name":"Issue Coherence","result":"pass|fail","evidence":"..."},
+    {"id":"trust_safety","name":"Trust/Safety","result":"pass|fail","evidence":"..."},
+    {"id":"duplicate_or_superseded","name":"Duplicate or Superseded Work","result":"not_evaluated","evidence":"..."},
+    {"id":"actionability","name":"Actionability","result":"pass|fail","evidence":"..."},
+    {"id":"autonomy","name":"Autonomy","result":"pass|fail","evidence":"..."},
+    {"id":"verifiability","name":"Verifiability","result":"pass|fail","evidence":"..."}
+  ]
+}
+
+There is no "passed", "outcome", or "failedCheck" field in local mode, and
+no aggregate rollup of any kind: "duplicate_or_superseded" always reports
+"not_evaluated" and is never counted toward a pass/fail verdict, so a
+caller must inspect each checks[] entry individually rather than infer an
+overall suitability outcome from a local run.
 `);
+}
+
+/**
+ * #2102: split a locally-drafted `--body-file`/`--stdin` text blob into a
+ * title and a body, for the local dry-run mode. `audit-authored-issue.mts`
+ * has no equivalent split -- it validates body structure only, never a
+ * title -- so this convention is new here, not reused from that file.
+ *
+ * A leading `# Title` line (a single Markdown H1, the common convention
+ * for a drafted issue file that mirrors what GitHub's own title field will
+ * hold) is extracted as the title; any blank lines immediately following
+ * it are also consumed so the remaining body does not start with stray
+ * leading blank lines. Anything else -- no H1, or an H1 that is not the
+ * very first non-blank content -- leaves the title empty and the entire
+ * input becomes the body unchanged: `checkCoherence` and the other checks
+ * below already tolerate an empty title (see the live path's own
+ * `normalizeIssue`, which defaults a genuinely missing title to `''`), so
+ * under-splitting fails safe rather than guessing.
+ */
+export function splitLocalDraftTitleAndBody(text: string): {
+  title: string;
+  body: string;
+} {
+  const match = text.match(/^[ \t]*#[ \t]+(\S[^\n]*?)[ \t]*\r?\n/);
+  if (!match) {
+    return { title: '', body: text };
+  }
+  const title = match[1] ?? '';
+  const rest = text.slice(match[0].length).replace(/^(?:[ \t]*\r?\n)+/, '');
+  return { title, body: rest };
 }
 
 function normalizeIssue(issue: unknown): NormalizedIssue {

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1165,9 +1165,13 @@ export function checkVerifiability(context: Context): CheckOutcome {
 export function resolveInputMode(
   args: Pick<SuitabilityTriageArgs, 'issue' | 'bodyFile' | 'stdin'>,
 ): 'issue' | 'local' {
+  // Checks flag *presence* (`!== undefined`), not truthiness: `--body-file=`
+  // parses to `''` under Node's util.parseArgs, and a truthy check would
+  // silently fold that into "no mode selected" instead of the explicit,
+  // actionable empty-path error thrown below.
   const inputModeCount =
     (args.issue !== null ? 1 : 0) +
-    (args.bodyFile ? 1 : 0) +
+    (args.bodyFile !== undefined ? 1 : 0) +
     (args.stdin ? 1 : 0);
   if (inputModeCount === 0) {
     throw new Error('one of --issue, --body-file, or --stdin is required');
@@ -1175,7 +1179,10 @@ export function resolveInputMode(
   if (inputModeCount > 1) {
     throw new Error('choose only one of --issue, --body-file, or --stdin');
   }
-  return args.bodyFile || args.stdin ? 'local' : 'issue';
+  if (args.bodyFile === '') {
+    throw new Error('--body-file requires a non-empty path');
+  }
+  return args.bodyFile !== undefined || args.stdin ? 'local' : 'issue';
 }
 
 function runCli(): void {

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1486,7 +1486,11 @@ export function evaluateSuitabilityLocal(
     state: 'draft',
     labels: [],
     url: '',
-    createdAt: new Date().toISOString(),
+    // #2102 Copilot review: none of the six local checks read `createdAt`
+    // (only checkDuplicateOrSuperseded does, and that check never runs
+    // locally) -- a wall-clock timestamp here would make this "pure"
+    // evaluation nondeterministic for no benefit.
+    createdAt: '',
   };
 
   const context: Context = {
@@ -1681,6 +1685,10 @@ no aggregate rollup of any kind: "duplicate_or_superseded" always reports
 "not_evaluated" and is never counted toward a pass/fail verdict, so a
 caller must inspect each checks[] entry individually rather than infer an
 overall suitability outcome from a local run.
+
+Like the live path, each entry's "evidence" is present only with
+--verbose; the schema above shows every field a checks[] entry can carry,
+not what a default (non-verbose) run actually returns.
 `);
 }
 

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2764,6 +2764,20 @@ test('resolveInputMode throws when more than one input mode is selected', () => 
   );
 });
 
+test('resolveInputMode throws an actionable error for an empty --body-file value', () => {
+  assert.throws(
+    () => resolveInputMode({ issue: null, bodyFile: '', stdin: false }),
+    /--body-file requires a non-empty path/,
+  );
+});
+
+test('resolveInputMode still rejects multi-mode selection when --body-file is empty', () => {
+  assert.throws(
+    () => resolveInputMode({ issue: 42, bodyFile: '', stdin: false }),
+    /choose only one of --issue, --body-file, or --stdin/,
+  );
+});
+
 const LOCAL_GOOD_DRAFT = `# feat: add deterministic helper
 
 ## Purpose

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -18,9 +18,11 @@ import {
   checkTrustSafety,
   checkVerifiability,
   evaluateSuitability,
+  evaluateSuitabilityLocal,
   fetchMergedPrFileOverlapEvidence,
   loadHighContentionFiles,
   parseArgs,
+  splitLocalDraftTitleAndBody,
 } from '../src/scripts/suitability-triage.mts';
 
 // Stub `gh` on PATH with an invocation counter (the discover-roadmap-graph.
@@ -2662,4 +2664,124 @@ if (args[0] === 'pr' && args[1] === 'view') {
   } finally {
     restore();
   }
+});
+
+// #2102: local/offline dry-run mode (--body-file / --stdin).
+
+test('splitLocalDraftTitleAndBody extracts a leading H1 as the title', () => {
+  const { title, body } = splitLocalDraftTitleAndBody(
+    '# feat: add deterministic helper\n\n## Purpose\nAdd helper\n',
+  );
+  assert.equal(title, 'feat: add deterministic helper');
+  assert.equal(body, '## Purpose\nAdd helper\n');
+});
+
+test('splitLocalDraftTitleAndBody strips only the blank lines immediately after the title', () => {
+  const { title, body } = splitLocalDraftTitleAndBody(
+    '#   feat: with extra leading/trailing space   \n\n\n\nbody text\n',
+  );
+  assert.equal(title, 'feat: with extra leading/trailing space');
+  assert.equal(body, 'body text\n');
+});
+
+test('splitLocalDraftTitleAndBody leaves title empty and returns the whole input as body when there is no leading H1', () => {
+  const text = 'Just some body text, no H1 heading here.\n';
+  const { title, body } = splitLocalDraftTitleAndBody(text);
+  assert.equal(title, '');
+  assert.equal(body, text);
+});
+
+test('splitLocalDraftTitleAndBody does not extract an H1 that is not the first content', () => {
+  const text = 'Some intro line.\n# not a title\nmore body\n';
+  const { title, body } = splitLocalDraftTitleAndBody(text);
+  assert.equal(title, '');
+  assert.equal(body, text);
+});
+
+test('parseArgs recognizes --body-file and --stdin, defaulting both to absent/false', () => {
+  const bodyFileArgs = parseArgs(['--body-file', 'draft.md']);
+  assert.equal(bodyFileArgs.bodyFile, 'draft.md');
+  assert.equal(bodyFileArgs.stdin, false);
+
+  const stdinArgs = parseArgs(['--stdin']);
+  assert.equal(stdinArgs.stdin, true);
+  assert.equal(stdinArgs.bodyFile, undefined);
+
+  const issueArgs = parseArgs(['--issue', '42']);
+  assert.equal(issueArgs.bodyFile, undefined);
+  assert.equal(issueArgs.stdin, false);
+});
+
+const LOCAL_GOOD_DRAFT = `# feat: add deterministic helper
+
+## Purpose
+Add a deterministic helper function.
+
+## Scope
+Implement helper behavior in a single file.
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] lint passes
+`;
+
+test('evaluateSuitabilityLocal runs six checks and marks duplicate_or_superseded not_evaluated', () => {
+  const result = evaluateSuitabilityLocal(LOCAL_GOOD_DRAFT);
+  assert.equal(result.mode, 'local');
+  assert.equal(result.issue.title, 'feat: add deterministic helper');
+  assert.equal(result.checks.length, 7);
+
+  const byId = new Map(result.checks.map((check) => [check.id, check]));
+  assert.equal(byId.get('duplicate_or_superseded')?.result, 'not_evaluated');
+  for (const id of [
+    'repository_fit',
+    'coherence',
+    'trust_safety',
+    'actionability',
+    'autonomy',
+    'verifiability',
+  ]) {
+    assert.equal(byId.get(id)?.result, 'pass', `expected ${id} to pass`);
+  }
+});
+
+test('evaluateSuitabilityLocal never returns an outcome/passed/failedCheck field, live or otherwise', () => {
+  const result = evaluateSuitabilityLocal(LOCAL_GOOD_DRAFT);
+  // #2102 acceptance criteria: the local-mode result must be structurally
+  // distinguishable from evaluateSuitability's live-mode SuitabilityResult
+  // by a caller that only checks for a recognized `outcome` value -- assert
+  // the key is absent outright, not merely holding a non-enum value.
+  assert.equal('outcome' in result, false);
+  assert.equal('passed' in result, false);
+  assert.equal('failedCheck' in result, false);
+});
+
+test('evaluateSuitabilityLocal reports duplicate_or_superseded as not_evaluated even when every other check fails', () => {
+  // Empty draft: fails repository_fit-adjacent coherence/verifiability
+  // checks outright. duplicate_or_superseded must still read
+  // "not_evaluated", never "fail" and never silently absent -- there is
+  // no live search index to have failed against.
+  const result = evaluateSuitabilityLocal('');
+  const duplicateCheck = result.checks.find(
+    (check) => check.id === 'duplicate_or_superseded',
+  );
+  assert.ok(duplicateCheck);
+  assert.equal(duplicateCheck.result, 'not_evaluated');
+  assert.ok(
+    result.checks.some((check) => check.result === 'fail'),
+    'expected at least one of the six evaluated checks to fail on an empty draft',
+  );
+});
+
+test('evaluateSuitabilityLocal honors configured blocked/needs-decision label names (moot for labels, but exercised for parity)', () => {
+  // The synthetic local issue always has an empty labels array, so a
+  // configured blockedByHumanLabelName can never match -- this just
+  // confirms passing the option through does not throw or change the
+  // synthetic issue's own checkAutonomy outcome.
+  const result = evaluateSuitabilityLocal(LOCAL_GOOD_DRAFT, {
+    blockedByHumanLabelName: 'status:blocked-by-human',
+    needsDecisionLabelName: 'status:needs-decision',
+  });
+  const autonomyCheck = result.checks.find((check) => check.id === 'autonomy');
+  assert.equal(autonomyCheck?.result, 'pass');
 });

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2699,6 +2699,20 @@ test('splitLocalDraftTitleAndBody does not extract an H1 that is not the first c
   assert.equal(body, text);
 });
 
+test('splitLocalDraftTitleAndBody skips leading blank lines before the H1', () => {
+  const { title, body } = splitLocalDraftTitleAndBody(
+    '\n\n# feat: skip leading blanks\n\nbody text\n',
+  );
+  assert.equal(title, 'feat: skip leading blanks');
+  assert.equal(body, 'body text\n');
+});
+
+test('splitLocalDraftTitleAndBody extracts a title with no trailing newline', () => {
+  const { title, body } = splitLocalDraftTitleAndBody('# feat: only a title');
+  assert.equal(title, 'feat: only a title');
+  assert.equal(body, '');
+});
+
 test('parseArgs recognizes --body-file and --stdin, defaulting both to absent/false', () => {
   const bodyFileArgs = parseArgs(['--body-file', 'draft.md']);
   assert.equal(bodyFileArgs.bodyFile, 'draft.md');

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -22,6 +22,7 @@ import {
   fetchMergedPrFileOverlapEvidence,
   loadHighContentionFiles,
   parseArgs,
+  resolveInputMode,
   splitLocalDraftTitleAndBody,
 } from '../src/scripts/suitability-triage.mts';
 
@@ -2710,6 +2711,43 @@ test('parseArgs recognizes --body-file and --stdin, defaulting both to absent/fa
   const issueArgs = parseArgs(['--issue', '42']);
   assert.equal(issueArgs.bodyFile, undefined);
   assert.equal(issueArgs.stdin, false);
+});
+
+test('resolveInputMode returns "issue" for --issue alone and "local" for --body-file or --stdin alone', () => {
+  assert.equal(
+    resolveInputMode({ issue: 42, bodyFile: undefined, stdin: false }),
+    'issue',
+  );
+  assert.equal(
+    resolveInputMode({ issue: null, bodyFile: 'draft.md', stdin: false }),
+    'local',
+  );
+  assert.equal(
+    resolveInputMode({ issue: null, bodyFile: undefined, stdin: true }),
+    'local',
+  );
+});
+
+test('resolveInputMode throws when no input mode is selected', () => {
+  assert.throws(
+    () => resolveInputMode({ issue: null, bodyFile: undefined, stdin: false }),
+    /one of --issue, --body-file, or --stdin is required/,
+  );
+});
+
+test('resolveInputMode throws when more than one input mode is selected', () => {
+  assert.throws(
+    () => resolveInputMode({ issue: 42, bodyFile: undefined, stdin: true }),
+    /choose only one of --issue, --body-file, or --stdin/,
+  );
+  assert.throws(
+    () => resolveInputMode({ issue: 42, bodyFile: 'draft.md', stdin: false }),
+    /choose only one of --issue, --body-file, or --stdin/,
+  );
+  assert.throws(
+    () => resolveInputMode({ issue: null, bodyFile: 'draft.md', stdin: true }),
+    /choose only one of --issue, --body-file, or --stdin/,
+  );
 });
 
 const LOCAL_GOOD_DRAFT = `# feat: add deterministic helper


### PR DESCRIPTION
## Summary

`src/scripts/suitability-triage.mts` runs seven independent pure-function
checks over a shared `Context`. Six of the seven already behave
identically whether or not a live GitHub issue exists — only
`checkDuplicateOrSuperseded` needs network data — but the tool had no
entry point exercising them without one. `audit-authored-issue.mts`
already solves the equivalent problem for structural lint with
`--body-file`/`--stdin`; this session's own issue-authoring runs relied
on hand-rolled Node one-liners re-testing individual regexes against a
draft body five separate times instead of running the real checks.

- Add `--body-file <path>` / `--stdin`, mutually exclusive with
  `--issue` and with each other. A leading `# Title` line in the
  supplied text is extracted as the title — a new convention, since
  `audit-authored-issue.mts` validates body structure only and never
  splits a title. Anything else leaves the title empty and treats the
  whole input as body.
- New exported `evaluateSuitabilityLocal(bodyText, options)` (mirroring
  `evaluateSuitability`'s own split from `runCli`) runs the same
  exported check functions the live path uses for every check except
  `duplicate_or_superseded`, reported as its own explicit
  `"not_evaluated"` result — never omitted, never counted toward a
  pass/fail rollup. Unlike `evaluateSuitability`, it never
  short-circuits on a failing check, since a dry-run's whole point is
  surfacing every check's verdict in one pass and no check here does
  network I/O.
- Local-mode output carries `"mode": "local"` and no
  `outcome`/`passed`/`failedCheck` field of any kind, so a caller
  cannot mistake a six-of-seven local pass for a live `--issue <n>`
  verdict — the same class of category error this repository already
  flagged for `audit-authored-issue.mjs` (structural-lint green ≠
  `suitability-triage.mjs` semantic pass) one level up.
- Documented the new flags in `docs/idd-helper-scripts.md`.

Closes #2102

## Test plan

- [x] `node --test tests/suitability-triage.test.mts` — 188/188 pass,
      including 8 new tests: title/body splitting (4 cases), CLI flag
      parsing, six-checks-run-correctly, no live `outcome`/`passed`/
      `failedCheck` field present, `duplicate_or_superseded` stays
      `not_evaluated` even when every other check fails
- [x] `pnpm run lint:minimum` — 3620 tests pass; `build:check` confirms
      the committed `scripts/suitability-triage.mjs` matches a fresh
      build; cspell, markdown link check, markdownlint, dprint, biome
      all clean
- [x] `node scripts/audit-docs.mjs --check` — `documentation audit
      passed`
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] Manual CLI smoke test: `--body-file`, `--stdin`, `--verbose`,
      `--help`, and both mutual-exclusivity error paths (`--issue` +
      `--body-file` together; neither flag) all behave as documented


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added offline suitability checks using draft text from a file (`--body-file`) or standard input (`--stdin`).
  - Local checks run without network access and evaluate six applicable criteria.
  - Duplicate detection is clearly reported as `not_evaluated`.
  - Added validation to prevent combining local input options with issue-based input.
- **Documentation**
  - Updated helper documentation and command-line help with local evaluation guidance and output details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->