### PR TITLE
docs(onboarding): fix a third link to the undistributed ONBOARDING.md

### DIFF
--- a/idd-template/docs/onboarding/issue-mediated-bootstrap.md
+++ b/idd-template/docs/onboarding/issue-mediated-bootstrap.md
@@ -389,7 +389,7 @@ examples ("start issue authoring to implement {inferred gap}", "run the
 IDD loop"). Derive `{inferred gap}` and the other prompt content using
 the same repository-evidence-read method the optional Dry-run readiness
 report already performs
-([Dry-run — Readiness assessment](../../ONBOARDING.md#dry-run--readiness-assessment))
+([Dry-run — Readiness assessment](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#dry-run--readiness-assessment))
 — detected package manager, missing prerequisites, and so on — rather
 than inventing a new inference mechanism. Run that read **fresh, after
 this merge**, not reused from the pre-import dry-run's stored output:


### PR DESCRIPTION
# Summary

`idd-template/docs/onboarding/issue-mediated-bootstrap.md` linked to
`../../ONBOARDING.md`, which resolves correctly only inside this
repository (the relative path lands on `idd-template/ONBOARDING.md`
here). `idd-template/ONBOARDING.md` is deliberately excluded from the
distributed file list, so after distribution the same relative path
404s for every adopter — the same defect class #2062 already fixed for
two other occurrences, and explicitly declared a repository-wide audit
out of scope for.

Repointed the link to an absolute upstream URL, matching the precedent
`docs/customization.md` and #2062's fix both already use for this
exact situation.

## Linked issue

Closes #2088

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Found while verifying #2062's fix — the same `grep` pattern still
matched this file, which #2062 left unfixed by design (scoped to only
the two occurrences it found).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed