### PR TITLE
docs(onboarding): gate welcome-issue prompt on actual companion state

### DIFF
--- a/idd-template/docs/onboarding/issue-mediated-bootstrap.md
+++ b/idd-template/docs/onboarding/issue-mediated-bootstrap.md
@@ -396,13 +396,21 @@ this merge**, not reused from the pre-import dry-run's stored output:
 the repository's package manager, test commands, and missing
 prerequisites can differ once the bootstrap import lands, and a stale
 pre-import finding can prompt the operator to fix a gap the import
-already closed. Condition the prompt set on
-the recorded Step 1B companion decision: only include an issue-authoring
-prompt (e.g. "start issue authoring to implement {inferred gap}") when
-that decision was `installed`; for `not installed`, substitute a prompt
-that does not depend on the companion skill (e.g. "run the IDD loop" or
-a repository-evidence-derived task prompt), so every welcome issue's
-prompts are ones the operator can actually run.
+already closed. Condition the prompt set on whether the companion is
+**actually installed** at welcome-issue drafting time, not the recorded
+Step 1B **target** state alone — the two can diverge: the core
+bootstrap issue always records the companion status as `not installed`
+(see above), and even once the operator's real target state is
+`installed`, the companion files land only when the separate companion
+follow-up issue completes its own claim -> work -> PR -> merge cycle,
+on its own schedule, not guaranteed to finish before or alongside the
+welcome issue's drafting. Only include an issue-authoring prompt (e.g.
+"start issue authoring to implement {inferred gap}") once the companion
+is actually installed; until then — even with an `installed` target
+state — substitute a prompt that does not depend on the companion skill
+(e.g. "run the IDD loop" or a repository-evidence-derived task prompt),
+so every welcome issue's prompts are ones the operator can actually
+run.
 
 ## Execution: issue -> branch -> PR -> merge, not the full loop
 


### PR DESCRIPTION
# Summary

`idd-template/docs/onboarding/issue-mediated-bootstrap.md`'s
"Welcome/next-steps issue, in detail" subsection gated the welcome
issue's issue-authoring example prompt on the recorded Step 1B
companion decision — ambiguous between two distinct recorded values
the same doc establishes elsewhere: the core-bootstrap issue's
temporary placeholder (always `not installed`, regardless of the
operator's real choice) and the operator's real target state (read
later by a separate companion follow-up issue). Gating on the target
state alone would advertise `start issue authoring` immediately after
the core bootstrap merges, even before the companion follow-up issue
has completed its own claim -> work -> PR -> merge cycle and the
companion files actually exist.

Reworded the paragraph to gate on whether the companion is actually
installed at welcome-issue drafting time, distinguishing that
explicitly from the recorded target state and explaining why they can
diverge.

## Linked issue

Closes #2037

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Refs #2008 (the subsection this issue edits).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed