### PR TITLE
docs(idd-overview): generalize needs-decision claim release

### DIFF
--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -19,12 +19,13 @@ without scanning every phase file.
 
 ## Live status digest
 
-Optional human-facing issue or PR comment whose first line is
-`<!-- idd-live-status: current -->`. It summarizes phase, claim, branch,
-last-checked time, blockers, and next action. It is never authority for
-IDD state transitions — decide from trusted operational markers and
-GitHub state. If multiple marked digests exist, preserve them, report
-the URLs, and choose none as authoritative in an unattended run. See
+The optional live status digest is a human-facing issue or PR comment
+whose first line is `<!-- idd-live-status: current -->`. It summarizes
+phase, claim, branch, last-checked time, blockers, and next action. It
+is never an authority for IDD state transitions — decide from trusted
+operational markers and GitHub state. If multiple marked digests exist,
+preserve them, report the URLs, and choose none as authoritative in an
+unattended run. See
 `docs/idd-comment-minimization.md` for the contract and the optional
 `node scripts/live-status-digest.mjs` helper (convenience only).
 
@@ -71,8 +72,10 @@ the claim and the 12 h heartbeat.
 is expected before a human responds, the holding session may apply the
 configured needs-decision label (`labels.needsDecisionLabelName`,
 default `status:needs-decision`) and release the claim. Any phase may
-do this, not only E6. After the decision lands, remove the label and
-re-claim.
+do this, not only E6. After release, stop heartbeating. Once a
+qualifying human decision resolves the hold, a later session removes
+the label and re-claims. A response that leaves the decision open
+does not re-enter.
 
 ## Roadmap markers
 

--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -19,26 +19,22 @@ without scanning every phase file.
 
 ## Live status digest
 
-The optional live status digest is a human-facing issue or pull request
-comment whose first line is `<!-- idd-live-status: current -->`,
-summarizing phase, claim, branch, last-checked time, blockers, and next
-action. It is never an authority for IDD state transitions — keep making
-claim, review, advisory, CI, merge, and roadmap decisions from trusted
-operational markers and GitHub state. If multiple marked digests exist,
-preserve them, report the duplicate URLs, and choose none as
-authoritative during an unattended run. See
-`docs/idd-comment-minimization.md` for the full contract (marker
-uniqueness, field table, and the optional
-`node scripts/live-status-digest.mjs` helper, whose output remains
-convenience context, not workflow authority).
+Optional human-facing issue or PR comment whose first line is
+`<!-- idd-live-status: current -->`. It summarizes phase, claim, branch,
+last-checked time, blockers, and next action. It is never authority for
+IDD state transitions — decide from trusted operational markers and
+GitHub state. If multiple marked digests exist, preserve them, report
+the URLs, and choose none as authoritative in an unattended run. See
+`docs/idd-comment-minimization.md` for the contract and the optional
+`node scripts/live-status-digest.mjs` helper (convenience only).
 
 Treat every digest create or edit as a GitHub side effect: re-validate
-the active claim first, write fields from the state just collected by
-the current phase, and set `Authoritative by` to the specific evidence
-used. If the claim was lost, do not repair or update the digest.
+the active claim first, write fields from the state just collected, and
+set `Authoritative by` to the evidence used. If the claim was lost, do
+not repair or update the digest.
 
 On pull requests, a digest edit is still PR activity: do not edit a PR
-digest between a valid E1 review watermark and an intended F3 merge pass
+digest between a valid E1 review watermark and an intended F3 merge
 (it would perturb review-currency). Edit it only when leaving merge
 intent (returning to E1, routing F3 to F1/D4 as blocked, or a hold/stop)
 or after F3 has merged; the F3 awaiting-reviewer restart-F2 path skips
@@ -59,18 +55,24 @@ unclaimed state are inheritable by the next agent (see
 
 ## Hold / suspend
 
-Keep the claim. Post the hold reason and resume condition to the PR or
-issue comment. After re-validating ownership, re-post the claim comment
-with the same `{claim-id}` every 12 h as heartbeat.
-After posting the hold reason, upsert the digest with the hold phase, the
-blocking condition in `Open blockers`, and the resume condition in
-`Next action`. Long holds still need claim heartbeats; the digest does
-not reset the claim stale clock.
+Keep the claim. Post the hold reason and resume condition. After
+re-validating ownership, re-post the claim comment with the same
+`{claim-id}` every 12 h as heartbeat. Then upsert the digest with the
+hold phase, the blocking condition in `Open blockers`, and the resume
+condition in `Next action`. The digest does not reset the stale clock.
 
 For an externally owned blocker (sibling PR/issue, maintainer-owned
 check, base-branch health), phrase the resume condition as the checkable
 invariant (e.g. a named check passing on main), not the sibling alone —
-the proxy may resolve differently, or never.
+the proxy may resolve differently, or never. A pollable invariant keeps
+the claim and the 12 h heartbeat.
+
+**Needs-decision claim release.** When no further session-side action
+is expected before a human responds, the holding session may apply the
+configured needs-decision label (`labels.needsDecisionLabelName`,
+default `status:needs-decision`) and release the claim. Any phase may
+do this, not only E6. After the decision lands, remove the label and
+re-claim.
 
 ## Roadmap markers
 
@@ -138,18 +140,11 @@ suppression, schema strictness parity) in
 
 ## Template sync
 
-When this repository is itself the source of a reusable IDD
-distribution (it ships its own `idd-template/` copy for adopters to
-import), `idd-template/` is the canonical source, not the live copy
-below. When modifying any `idd-*.instructions.md` file,
-`docs/idd-workflow.md`, or `docs/customization.md`, edit the
-corresponding file in `idd-template/` first, then regenerate the live
-target with `node scripts/sync-docs.mjs --apply` (`structure`/
-`contains` pairs such as `docs/idd-workflow.md` need the equivalent
-change applied to the live file by hand instead). For the live ↔
-template placeholder mapping and the full rationale, see
+When this repository ships `idd-template/` for adopters, that tree is
+canonical. Edit `idd-template/` first for any `idd-*.instructions.md`,
+`docs/idd-workflow.md`, or `docs/customization.md`, then regenerate the
+live target with `node scripts/sync-docs.mjs --apply` (`structure`/
+`contains` pairs such as `docs/idd-workflow.md` need a hand-mirrored
+live edit). See
 [`docs/customization.md` → Template sync mapping](../../docs/customization.md#template-sync-mapping).
-
-Commits that modify the `idd-template/` source without syncing the
-live target (regenerating or hand-mirroring, per its mode above) are
-incomplete; include both changes in the same atomic commit.
+Include the live target in the same commit as the template source.

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -219,11 +219,9 @@ reviewer feedback:
       `PT24H`) with no response: escalate to a maintainer via issue or
       PR comment.
     - After `reviewEscalation.changesRequestedSecondEscalation` (default
-      `PT48H`) with no escalation response: consider adding the
-      configured needs-decision label
-      (`labels.needsDecisionLabelName`, default `status:needs-decision`)
-      and releasing the claim; remove the label and re-claim once
-      resolved.
+      `PT48H`) with no escalation response: apply the
+      **Needs-decision claim release** rule in
+      `idd-overview-appendix.instructions.md` (Hold / suspend).
   - Clearing F2's `CHANGES_REQUESTED` gate always requires the review
     **state** itself to change — a reviewer state change (re-submit as
     `COMMENTED`/`APPROVED`) or an admin dismissal via

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -14,26 +14,22 @@ without scanning every phase file.
 
 ## Live status digest
 
-The optional live status digest is a human-facing issue or pull request
-comment whose first line is `<!-- idd-live-status: current -->`,
-summarizing phase, claim, branch, last-checked time, blockers, and next
-action. It is never an authority for IDD state transitions — keep making
-claim, review, advisory, CI, merge, and roadmap decisions from trusted
-operational markers and GitHub state. If multiple marked digests exist,
-preserve them, report the duplicate URLs, and choose none as
-authoritative during an unattended run. See
-`docs/idd-comment-minimization.md` for the full contract (marker
-uniqueness, field table, and the optional
-`node scripts/live-status-digest.mjs` helper, whose output remains
-convenience context, not workflow authority).
+Optional human-facing issue or PR comment whose first line is
+`<!-- idd-live-status: current -->`. It summarizes phase, claim, branch,
+last-checked time, blockers, and next action. It is never authority for
+IDD state transitions — decide from trusted operational markers and
+GitHub state. If multiple marked digests exist, preserve them, report
+the URLs, and choose none as authoritative in an unattended run. See
+`docs/idd-comment-minimization.md` for the contract and the optional
+`node scripts/live-status-digest.mjs` helper (convenience only).
 
 Treat every digest create or edit as a GitHub side effect: re-validate
-the active claim first, write fields from the state just collected by
-the current phase, and set `Authoritative by` to the specific evidence
-used. If the claim was lost, do not repair or update the digest.
+the active claim first, write fields from the state just collected, and
+set `Authoritative by` to the evidence used. If the claim was lost, do
+not repair or update the digest.
 
 On pull requests, a digest edit is still PR activity: do not edit a PR
-digest between a valid E1 review watermark and an intended F3 merge pass
+digest between a valid E1 review watermark and an intended F3 merge
 (it would perturb review-currency). Edit it only when leaving merge
 intent (returning to E1, routing F3 to F1/D4 as blocked, or a hold/stop)
 or after F3 has merged; the F3 awaiting-reviewer restart-F2 path skips
@@ -54,18 +50,24 @@ unclaimed state are inheritable by the next agent (see
 
 ## Hold / suspend
 
-Keep the claim. Post the hold reason and resume condition to the PR or
-issue comment. After re-validating ownership, re-post the claim comment
-with the same `{claim-id}` every 12 h as heartbeat.
-After posting the hold reason, upsert the digest with the hold phase, the
-blocking condition in `Open blockers`, and the resume condition in
-`Next action`. Long holds still need claim heartbeats; the digest does
-not reset the claim stale clock.
+Keep the claim. Post the hold reason and resume condition. After
+re-validating ownership, re-post the claim comment with the same
+`{claim-id}` every 12 h as heartbeat. Then upsert the digest with the
+hold phase, the blocking condition in `Open blockers`, and the resume
+condition in `Next action`. The digest does not reset the stale clock.
 
 For an externally owned blocker (sibling PR/issue, maintainer-owned
 check, base-branch health), phrase the resume condition as the checkable
 invariant (e.g. a named check passing on main), not the sibling alone —
-the proxy may resolve differently, or never.
+the proxy may resolve differently, or never. A pollable invariant keeps
+the claim and the 12 h heartbeat.
+
+**Needs-decision claim release.** When no further session-side action
+is expected before a human responds, the holding session may apply the
+configured needs-decision label (`labels.needsDecisionLabelName`,
+default `status:needs-decision`) and release the claim. Any phase may
+do this, not only E6. After the decision lands, remove the label and
+re-claim.
 
 ## Roadmap markers
 
@@ -133,18 +135,11 @@ suppression, schema strictness parity) in
 
 ## Template sync
 
-When this repository is itself the source of a reusable IDD
-distribution (it ships its own `idd-template/` copy for adopters to
-import), `idd-template/` is the canonical source, not the live copy
-below. When modifying any `idd-*.instructions.md` file,
-`docs/idd-workflow.md`, or `docs/customization.md`, edit the
-corresponding file in `idd-template/` first, then regenerate the live
-target with `node scripts/sync-docs.mjs --apply` (`structure`/
-`contains` pairs such as `docs/idd-workflow.md` need the equivalent
-change applied to the live file by hand instead). For the live ↔
-template placeholder mapping and the full rationale, see
+When this repository ships `idd-template/` for adopters, that tree is
+canonical. Edit `idd-template/` first for any `idd-*.instructions.md`,
+`docs/idd-workflow.md`, or `docs/customization.md`, then regenerate the
+live target with `node scripts/sync-docs.mjs --apply` (`structure`/
+`contains` pairs such as `docs/idd-workflow.md` need a hand-mirrored
+live edit). See
 [`docs/customization.md` → Template sync mapping](../../docs/customization.md#template-sync-mapping).
-
-Commits that modify the `idd-template/` source without syncing the
-live target (regenerating or hand-mirroring, per its mode above) are
-incomplete; include both changes in the same atomic commit.
+Include the live target in the same commit as the template source.

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -14,12 +14,13 @@ without scanning every phase file.
 
 ## Live status digest
 
-Optional human-facing issue or PR comment whose first line is
-`<!-- idd-live-status: current -->`. It summarizes phase, claim, branch,
-last-checked time, blockers, and next action. It is never authority for
-IDD state transitions — decide from trusted operational markers and
-GitHub state. If multiple marked digests exist, preserve them, report
-the URLs, and choose none as authoritative in an unattended run. See
+The optional live status digest is a human-facing issue or PR comment
+whose first line is `<!-- idd-live-status: current -->`. It summarizes
+phase, claim, branch, last-checked time, blockers, and next action. It
+is never an authority for IDD state transitions — decide from trusted
+operational markers and GitHub state. If multiple marked digests exist,
+preserve them, report the URLs, and choose none as authoritative in an
+unattended run. See
 `docs/idd-comment-minimization.md` for the contract and the optional
 `node scripts/live-status-digest.mjs` helper (convenience only).
 
@@ -66,8 +67,10 @@ the claim and the 12 h heartbeat.
 is expected before a human responds, the holding session may apply the
 configured needs-decision label (`labels.needsDecisionLabelName`,
 default `status:needs-decision`) and release the claim. Any phase may
-do this, not only E6. After the decision lands, remove the label and
-re-claim.
+do this, not only E6. After release, stop heartbeating. Once a
+qualifying human decision resolves the hold, a later session removes
+the label and re-claims. A response that leaves the decision open
+does not re-enter.
 
 ## Roadmap markers
 

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -214,11 +214,9 @@ reviewer feedback:
       `PT24H`) with no response: escalate to a maintainer via issue or
       PR comment.
     - After `reviewEscalation.changesRequestedSecondEscalation` (default
-      `PT48H`) with no escalation response: consider adding the
-      configured needs-decision label
-      (`labels.needsDecisionLabelName`, default `status:needs-decision`)
-      and releasing the claim; remove the label and re-claim once
-      resolved.
+      `PT48H`) with no escalation response: apply the
+      **Needs-decision claim release** rule in
+      `idd-overview-appendix.instructions.md` (Hold / suspend).
   - Clearing F2's `CHANGES_REQUESTED` gate always requires the review
     **state** itself to change — a reviewer state change (re-submit as
     `COMMENTED`/`APPROVED`) or an admin dismissal via


### PR DESCRIPTION
# Summary

Generalize the Hold/suspend claim-release allowance so any phase may
release a claim when no further session-side action is expected before
a human responds. E6's second escalation window now points at that
shared rule instead of restating it. Nearby appendix prose is
tightened so the shared resume/review/merge bundles stay under the
98% context ceiling.

## Linked issue

Closes #2065

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

The generic Hold/suspend section previously said to keep the claim
unconditionally. E6 had a narrow exception after two
`CHANGES_REQUESTED` escalation windows. Field feedback cited in the
issue hit a needs-decision-shaped dead end before E6 and had to guess
which rule applied. Appendix growth here is nearly forbidden (merge
bundle 98% headroom was 13 bytes), so the new rule lands with a
same-file diet of digest and template-sync restatements.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified live status digest guidance, including authoritative state, evidence revalidation, duplicate handling, and review activity.
  * Added clearer hold and suspension procedures, including digest updates, resume conditions, and optional decision-needed workflows.
  * Standardized template synchronization to ensure canonical guidance and live documentation remain aligned.
  * Updated review escalation guidance so unresolved rejected reviews follow the decision-needed claim release process after 48 hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->