### PR TITLE
docs(advisory-wait): note requested_reviewers can lag a re-review

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -37,14 +37,13 @@ and take the caller's `SATISFIED` action (E14 → E15, F2 → CI check, F3
 one). Enter the full protocol below **only** when
 `LAST_COPILOT_COMMIT != PR_HEAD_SHA`.
 
-Keep the wait itself cheap per the
-[wake-up discipline](idd-ci.instructions.md#wake-up-discipline): a
-single wake at the **expected** completion, or background only if the
-topology-safety condition holds; otherwise wait synchronously — no
-single `gh` command blocks on Copilot review state; run the protocol
-below (helper-first, AW1-AW5 fallback) as a foreground wait, never
-`run_in_background`, absent the confirmed condition. Batch all
-post-wait actions into one turn.
+Keep the wait cheap per the
+[wake-up discipline](idd-ci.instructions.md#wake-up-discipline): one
+wake at the expected completion, or background only if topology-safe;
+otherwise wait synchronously. No `gh` command blocks on Copilot
+review state — run the protocol (helper-first, AW1-AW5 fallback) in
+the foreground, never `run_in_background` without that condition.
+Batch post-wait actions into one turn.
 
 ## 1. Canonical path (helper-first)
 
@@ -148,6 +147,9 @@ AW3 inputs:
 - `LAST_COPILOT_COMMIT` — `commit_id` of the latest Copilot review
   (empty if none); equals `PR_HEAD_SHA` short-circuits to **SATISFIED**.
 - `COPILOT_PENDING` — `true` if Copilot is in `requested_reviewers`.
+  Observed once: `"false"` can lag a re-request or empty on submit —
+  not idle proof. `LAST_COPILOT_COMMIT == PR_HEAD_SHA` is SATISFIED.
+  A same-head `"false"` uses the shorter settled window.
 - `COPILOT_PENDING_COVERS_HEAD` — `true` if the latest Copilot
   `review_requested` event follows current HEAD's `committed` event.
 

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -39,7 +39,8 @@ one). Enter the full protocol below **only** when
 
 Keep the wait cheap per the
 [wake-up discipline](idd-ci.instructions.md#wake-up-discipline): one
-wake at the expected completion, or background only if topology-safe;
+wake at the expected completion, or background only if the
+topology-safety condition holds;
 otherwise wait synchronously. No `gh` command blocks on Copilot
 review state — run the protocol (helper-first, AW1-AW5 fallback) in
 the foreground, never `run_in_background` without that condition.
@@ -147,9 +148,9 @@ AW3 inputs:
 - `LAST_COPILOT_COMMIT` — `commit_id` of the latest Copilot review
   (empty if none); equals `PR_HEAD_SHA` short-circuits to **SATISFIED**.
 - `COPILOT_PENDING` — `true` if Copilot is in `requested_reviewers`.
-  Observed once: `"false"` can lag a re-request or empty on submit —
-  not idle proof. `LAST_COPILOT_COMMIT == PR_HEAD_SHA` is SATISFIED.
-  A same-head `"false"` uses the shorter settled window.
+  Observed once: `false` can lag a re-request or empty on submit —
+  not idle proof. `LAST_COPILOT_COMMIT == PR_HEAD_SHA` is
+  **SATISFIED**. A same-head `false` uses the shorter settled window.
 - `COPILOT_PENDING_COVERS_HEAD` — `true` if the latest Copilot
   `review_requested` event follows current HEAD's `committed` event.
 

--- a/docs/idd-advisory-wait-shell-fallback.md
+++ b/docs/idd-advisory-wait-shell-fallback.md
@@ -46,6 +46,9 @@ LAST_COPILOT_COMMIT=$(
 
 COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
   --jq '.users | any(.login == "Copilot" or .login == "copilot-pull-request-reviewer" or .login == "copilot-pull-request-reviewer[bot]")')
+# Observed once: this field can lag a successful re-request or empty
+# on submit, so false is not idle proof. LAST_COPILOT_COMMIT ==
+# PR_HEAD_SHA remains the SATISFIED signal.
 
 COPILOT_PENDING_COVERS_HEAD=$(
   gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/timeline" \

--- a/docs/idd-advisory-wait-shell-fallback.md
+++ b/docs/idd-advisory-wait-shell-fallback.md
@@ -46,9 +46,9 @@ LAST_COPILOT_COMMIT=$(
 
 COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
   --jq '.users | any(.login == "Copilot" or .login == "copilot-pull-request-reviewer" or .login == "copilot-pull-request-reviewer[bot]")')
-# Observed once: this field can lag a successful re-request or empty
-# on submit, so false is not idle proof. LAST_COPILOT_COMMIT ==
-# PR_HEAD_SHA remains the SATISFIED signal.
+# Observed once: requested_reviewers can lag a successful re-request
+# or empty on submit, so false is not idle proof.
+# LAST_COPILOT_COMMIT == PR_HEAD_SHA remains the SATISFIED signal.
 
 COPILOT_PENDING_COVERS_HEAD=$(
   gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/timeline" \

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -32,14 +32,13 @@ and take the caller's `SATISFIED` action (E14 → E15, F2 → CI check, F3
 one). Enter the full protocol below **only** when
 `LAST_COPILOT_COMMIT != PR_HEAD_SHA`.
 
-Keep the wait itself cheap per the
-[wake-up discipline](idd-ci.instructions.md#wake-up-discipline): a
-single wake at the **expected** completion, or background only if the
-topology-safety condition holds; otherwise wait synchronously — no
-single `gh` command blocks on Copilot review state; run the protocol
-below (helper-first, AW1-AW5 fallback) as a foreground wait, never
-`run_in_background`, absent the confirmed condition. Batch all
-post-wait actions into one turn.
+Keep the wait cheap per the
+[wake-up discipline](idd-ci.instructions.md#wake-up-discipline): one
+wake at the expected completion, or background only if topology-safe;
+otherwise wait synchronously. No `gh` command blocks on Copilot
+review state — run the protocol (helper-first, AW1-AW5 fallback) in
+the foreground, never `run_in_background` without that condition.
+Batch post-wait actions into one turn.
 
 ## 1. Canonical path (helper-first)
 
@@ -143,6 +142,9 @@ AW3 inputs:
 - `LAST_COPILOT_COMMIT` — `commit_id` of the latest Copilot review
   (empty if none); equals `PR_HEAD_SHA` short-circuits to **SATISFIED**.
 - `COPILOT_PENDING` — `true` if Copilot is in `requested_reviewers`.
+  Observed once: `"false"` can lag a re-request or empty on submit —
+  not idle proof. `LAST_COPILOT_COMMIT == PR_HEAD_SHA` is SATISFIED.
+  A same-head `"false"` uses the shorter settled window.
 - `COPILOT_PENDING_COVERS_HEAD` — `true` if the latest Copilot
   `review_requested` event follows current HEAD's `committed` event.
 

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -34,7 +34,8 @@ one). Enter the full protocol below **only** when
 
 Keep the wait cheap per the
 [wake-up discipline](idd-ci.instructions.md#wake-up-discipline): one
-wake at the expected completion, or background only if topology-safe;
+wake at the expected completion, or background only if the
+topology-safety condition holds;
 otherwise wait synchronously. No `gh` command blocks on Copilot
 review state — run the protocol (helper-first, AW1-AW5 fallback) in
 the foreground, never `run_in_background` without that condition.
@@ -142,9 +143,9 @@ AW3 inputs:
 - `LAST_COPILOT_COMMIT` — `commit_id` of the latest Copilot review
   (empty if none); equals `PR_HEAD_SHA` short-circuits to **SATISFIED**.
 - `COPILOT_PENDING` — `true` if Copilot is in `requested_reviewers`.
-  Observed once: `"false"` can lag a re-request or empty on submit —
-  not idle proof. `LAST_COPILOT_COMMIT == PR_HEAD_SHA` is SATISFIED.
-  A same-head `"false"` uses the shorter settled window.
+  Observed once: `false` can lag a re-request or empty on submit —
+  not idle proof. `LAST_COPILOT_COMMIT == PR_HEAD_SHA` is
+  **SATISFIED**. A same-head `false` uses the shorter settled window.
 - `COPILOT_PENDING_COVERS_HEAD` — `true` if the latest Copilot
   `review_requested` event follows current HEAD's `committed` event.
 

--- a/idd-template/docs/idd-advisory-wait-shell-fallback.md
+++ b/idd-template/docs/idd-advisory-wait-shell-fallback.md
@@ -46,6 +46,9 @@ LAST_COPILOT_COMMIT=$(
 
 COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
   --jq '.users | any(.login == "Copilot" or .login == "copilot-pull-request-reviewer" or .login == "copilot-pull-request-reviewer[bot]")')
+# Observed once: this field can lag a successful re-request or empty
+# on submit, so false is not idle proof. LAST_COPILOT_COMMIT ==
+# PR_HEAD_SHA remains the SATISFIED signal.
 
 COPILOT_PENDING_COVERS_HEAD=$(
   gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/timeline" \

--- a/idd-template/docs/idd-advisory-wait-shell-fallback.md
+++ b/idd-template/docs/idd-advisory-wait-shell-fallback.md
@@ -46,9 +46,9 @@ LAST_COPILOT_COMMIT=$(
 
 COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
   --jq '.users | any(.login == "Copilot" or .login == "copilot-pull-request-reviewer" or .login == "copilot-pull-request-reviewer[bot]")')
-# Observed once: this field can lag a successful re-request or empty
-# on submit, so false is not idle proof. LAST_COPILOT_COMMIT ==
-# PR_HEAD_SHA remains the SATISFIED signal.
+# Observed once: requested_reviewers can lag a successful re-request
+# or empty on submit, so false is not idle proof.
+# LAST_COPILOT_COMMIT == PR_HEAD_SHA remains the SATISFIED signal.
 
 COPILOT_PENDING_COVERS_HEAD=$(
   gh api "repos/${OWNER}/${REPO}/issues/{pr-number}/timeline" \


### PR DESCRIPTION
# Summary

Document that `requested_reviewers` can lag a successful Copilot
re-review request or empty as soon as the review lands. AW1 now
treats a false `COPILOT_PENDING` as not idle proof.
`LAST_COPILOT_COMMIT == PR_HEAD_SHA` remains the SATISFIED signal.
No AW3 table or window change.

## Linked issue

Closes #2066

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Field feedback cited in the issue saw a successful re-request that
never appeared in `reviewRequests`, then a timely Copilot review.
A prior A4.5 rejection was about context-ceiling headroom; #2110
freed enough budget to land a documented caveat only.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed