### PR TITLE
fix(protocol-helpers): keep waiver valid after one-hop claim takeover

### DIFF
--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -210,6 +210,7 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     staleAgeMs: options.staleAgeMs,
   });
   const activeClaimId = claim.activeClaim?.claimId ?? '';
+  const activeClaimSupersedes = claim.activeClaim?.supersedes ?? '';
   // `idd-claimed` narrows this gate to verified IDD-owned PRs; the default
   // `all-prs` behavior keeps the gate applicable everywhere else.
   const convergenceScope =
@@ -805,6 +806,7 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     const waiverEvidence = summarizeExternalCheckWaivers(comments, {
       prHeadSha,
       activeClaimId,
+      activeClaimSupersedes,
       trustedMarkerLogins,
       now,
       // The REAL configured `ciGate.externalChecks.waivable` list (not a

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -148,6 +148,7 @@ export function summarizeExternalCheckWaivers(
   {
     prHeadSha = '',
     activeClaimId = '',
+    activeClaimSupersedes = '',
     trustedMarkerLogins = [],
     now = '',
     waivableSelectors = null,
@@ -218,9 +219,24 @@ export function summarizeExternalCheckWaivers(
     // the sentinel can never route around a genuine claim mismatch. Every
     // other combination is unchanged: a non-`none` claimId on an unclaimed PR
     // still falls into `wrongClaim` -- the exact regression #1077 fixed.
+    //
+    // #2080: one-hop takeover exception. A waiver bound to claim A remains
+    // valid after an in-policy takeover installs claim B whose
+    // `supersedes` field is A -- the waiver authorizes the PR, not the
+    // current session. The predecessor value is accepted only when it is
+    // non-empty and is NOT a case-insensitive `none` sentinel: a freshly
+    // claimed PR carries `supersedes: 'none'`, and treating that as a
+    // bindable predecessor would make every claimless waiver validate on
+    // every fresh claim (reopening #1077/#1905). A two-hop-old claim id
+    // (neither B nor B.supersedes) stays rejected; walking a full lineage
+    // is out of scope.
     const claimIdIsNoneSentinel = parsed.claimId.toLowerCase() === 'none';
+    const predecessorClaimId = String(activeClaimSupersedes ?? '').trim();
+    const predecessorIsBindable =
+      predecessorClaimId !== '' && predecessorClaimId.toLowerCase() !== 'none';
     const claimBindingSatisfied = activeClaimLower
-      ? parsed.claimId === activeClaimLower
+      ? parsed.claimId === activeClaimLower ||
+        (predecessorIsBindable && parsed.claimId === predecessorClaimId)
       : claimIdIsNoneSentinel;
     if (!claimBindingSatisfied) {
       wrongClaim.push({
@@ -2477,6 +2493,11 @@ export function resolveLatestReviewWatermark(comments, options = {}) {
     if (!parsed) {
       continue;
     }
+    // Exact claim-id match is intentional (#2080): a watermark records
+    // what THIS claim-holder verified. A takeover starts a new restore
+    // scope (`idd-review-snapshot.instructions.md`); do not treat the
+    // predecessor `supersedes` id as a match the way
+    // `summarizeExternalCheckWaivers` does for maintainer waivers.
     if (expectedClaimId && parsed.claimId !== expectedClaimId) {
       continue;
     }
@@ -5010,6 +5031,7 @@ export function buildPreMergeReadinessSummary(
   const waiverEvidence = summarizeExternalCheckWaivers(comments, {
     prHeadSha,
     activeClaimId: claim.activeClaim?.claimId ?? options.activeClaimId ?? '',
+    activeClaimSupersedes: claim.activeClaim?.supersedes ?? '',
     trustedMarkerLogins,
     now,
     waivableSelectors: waivableCheckSelectors,

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -628,6 +628,7 @@ export function computeAdvisoryConvergenceVerdict(
     staleAgeMs: options.staleAgeMs,
   });
   const activeClaimId = claim.activeClaim?.claimId ?? '';
+  const activeClaimSupersedes = claim.activeClaim?.supersedes ?? '';
 
   // `idd-claimed` narrows this gate to verified IDD-owned PRs; the default
   // `all-prs` behavior keeps the gate applicable everywhere else.
@@ -1237,6 +1238,7 @@ export function computeAdvisoryConvergenceVerdict(
     const waiverEvidence = summarizeExternalCheckWaivers(comments, {
       prHeadSha,
       activeClaimId,
+      activeClaimSupersedes,
       trustedMarkerLogins,
       now,
       // The REAL configured `ciGate.externalChecks.waivable` list (not a

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -649,6 +649,7 @@ export function summarizeExternalCheckWaivers(
   {
     prHeadSha = '',
     activeClaimId = '',
+    activeClaimSupersedes = '',
     trustedMarkerLogins = [],
     now = '',
     waivableSelectors = null,
@@ -657,6 +658,10 @@ export function summarizeExternalCheckWaivers(
   }: {
     prHeadSha?: string;
     activeClaimId?: unknown;
+    /** Immediate predecessor claim id (`ParsedClaimMarker.supersedes`).
+     * Used only for the one-hop takeover exception below; `none`/empty
+     * never bind. */
+    activeClaimSupersedes?: unknown;
     trustedMarkerLogins?: unknown[];
     now?: string;
     waivableSelectors?: { selector?: unknown; matchMode?: unknown }[] | null;
@@ -745,9 +750,24 @@ export function summarizeExternalCheckWaivers(
     // the sentinel can never route around a genuine claim mismatch. Every
     // other combination is unchanged: a non-`none` claimId on an unclaimed PR
     // still falls into `wrongClaim` -- the exact regression #1077 fixed.
+    //
+    // #2080: one-hop takeover exception. A waiver bound to claim A remains
+    // valid after an in-policy takeover installs claim B whose
+    // `supersedes` field is A -- the waiver authorizes the PR, not the
+    // current session. The predecessor value is accepted only when it is
+    // non-empty and is NOT a case-insensitive `none` sentinel: a freshly
+    // claimed PR carries `supersedes: 'none'`, and treating that as a
+    // bindable predecessor would make every claimless waiver validate on
+    // every fresh claim (reopening #1077/#1905). A two-hop-old claim id
+    // (neither B nor B.supersedes) stays rejected; walking a full lineage
+    // is out of scope.
     const claimIdIsNoneSentinel = parsed.claimId.toLowerCase() === 'none';
+    const predecessorClaimId = String(activeClaimSupersedes ?? '').trim();
+    const predecessorIsBindable =
+      predecessorClaimId !== '' && predecessorClaimId.toLowerCase() !== 'none';
     const claimBindingSatisfied = activeClaimLower
-      ? parsed.claimId === activeClaimLower
+      ? parsed.claimId === activeClaimLower ||
+        (predecessorIsBindable && parsed.claimId === predecessorClaimId)
       : claimIdIsNoneSentinel;
     if (!claimBindingSatisfied) {
       wrongClaim.push({
@@ -3376,6 +3396,11 @@ export function resolveLatestReviewWatermark(
     if (!parsed) {
       continue;
     }
+    // Exact claim-id match is intentional (#2080): a watermark records
+    // what THIS claim-holder verified. A takeover starts a new restore
+    // scope (`idd-review-snapshot.instructions.md`); do not treat the
+    // predecessor `supersedes` id as a match the way
+    // `summarizeExternalCheckWaivers` does for maintainer waivers.
     if (expectedClaimId && parsed.claimId !== expectedClaimId) {
       continue;
     }
@@ -6403,6 +6428,7 @@ export function buildPreMergeReadinessSummary(
   const waiverEvidence = summarizeExternalCheckWaivers(comments, {
     prHeadSha,
     activeClaimId: claim.activeClaim?.claimId ?? options.activeClaimId ?? '',
+    activeClaimSupersedes: claim.activeClaim?.supersedes ?? '',
     trustedMarkerLogins,
     now,
     waivableSelectors: waivableCheckSelectors,

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -1304,6 +1304,62 @@ test('staleAgeMs: a configured shorter stale window allows a takeover the hardco
   assert.equal(underConfiguredWindow.waiver.activeClaimId, SUCCESSOR_CLAIM_ID);
 });
 
+test('waiver: a marker bound to the superseded claim still waives after an in-policy takeover (#2080)', () => {
+  const TAKEOVER_AT = '2026-06-01T02:00:00Z';
+  const takeoverClaim = {
+    author: { login: TRUSTED },
+    body: `<!-- claimed-by: ${SUCCESSOR_AGENT_ID} ${SUCCESSOR_CLAIM_ID} supersedes: ${CLAIM_ID} ${TAKEOVER_AT} branch: issue/1234-test -->\n\n_${SUCCESSOR_AGENT_ID}: issue claim — IDD automation marker. Do not edit._`,
+    createdAt: TAKEOVER_AT,
+  };
+  const predecessorWaiver = waiverComment({ claimId: CLAIM_ID });
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment(), takeoverClaim],
+      comments: [predecessorWaiver],
+    }),
+    baseOptions({
+      headCommittedAt: OLD,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      staleAgeMs: 60 * 60 * 1000,
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.waiver.activeClaimId, SUCCESSOR_CLAIM_ID);
+  assert.equal(verdict.waiver.validCount, 1);
+  assert.equal(verdict.waived, true);
+  assert.equal(verdict.ready, true);
+});
+
+test('waiver: a two-hop-old claim id does not waive after takeover (#2080)', () => {
+  const TAKEOVER_AT = '2026-06-01T02:00:00Z';
+  const takeoverClaim = {
+    author: { login: TRUSTED },
+    body: `<!-- claimed-by: ${SUCCESSOR_AGENT_ID} ${SUCCESSOR_CLAIM_ID} supersedes: ${CLAIM_ID} ${TAKEOVER_AT} branch: issue/1234-test -->\n\n_${SUCCESSOR_AGENT_ID}: issue claim — IDD automation marker. Do not edit._`,
+    createdAt: TAKEOVER_AT,
+  };
+  const staleWaiver = waiverComment({ claimId: 'claim-grandparent' });
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment(), takeoverClaim],
+      comments: [staleWaiver],
+    }),
+    baseOptions({
+      headCommittedAt: OLD,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      staleAgeMs: 60 * 60 * 1000,
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.waiver.activeClaimId, SUCCESSOR_CLAIM_ID);
+  assert.equal(verdict.waiver.validCount, 0);
+  assert.equal(verdict.waived, false);
+  assert.equal(verdict.ready, false);
+});
+
 // --- 9. sameHeadReroll (#1511) -----------------------------------------------
 // --- Bounded same-HEAD advisory reroll evidence: `itemCount` (Clause 1) is
 // --- a STATIC submission-time snapshot, so rejecting/resolving every item

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -4770,6 +4770,66 @@ test('summarizeExternalCheckWaivers: claim-id "none" on a claimed PR is rejected
   assert.equal(result.wrongClaim.length, 1);
 });
 
+test('summarizeExternalCheckWaivers: a none-sentinel waiver still fails on a claimed PR whose supersedes is also none (#2080)', () => {
+  // Fresh claim: activeClaim.supersedes is the literal 'none' sentinel.
+  // Treating that as a bindable predecessor would make every claimless
+  // waiver validate on every freshly claimed PR.
+  const head = 'f'.repeat(40);
+  const body = makeWaiverComment({ headSha: head, claimId: 'none' });
+  const comment = {
+    body,
+    author: { login: 'kurone-kito' },
+    createdAt: '2026-05-17T00:00:00Z',
+  };
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: head,
+    activeClaimId: 'claim-123',
+    activeClaimSupersedes: 'none',
+    trustedMarkerLogins: ['kurone-kito'],
+    now: '2026-05-17T00:00:00Z',
+  });
+  assert.equal(result.valid.length, 0);
+  assert.equal(result.wrongClaim.length, 1);
+});
+
+test('summarizeExternalCheckWaivers: a waiver bound to the immediate supersedes predecessor stays valid after takeover (#2080)', () => {
+  const head = 'a'.repeat(40);
+  const body = makeWaiverComment({ headSha: head, claimId: 'claim-A' });
+  const comment = {
+    body,
+    author: { login: 'kurone-kito' },
+    createdAt: '2026-05-17T00:00:00Z',
+  };
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: head,
+    activeClaimId: 'claim-B',
+    activeClaimSupersedes: 'claim-A',
+    trustedMarkerLogins: ['kurone-kito'],
+    now: '2026-05-17T00:00:00Z',
+  });
+  assert.equal(result.valid.length, 1);
+  assert.equal(result.wrongClaim.length, 0);
+});
+
+test('summarizeExternalCheckWaivers: a two-hop-old claim id stays in wrongClaim (#2080)', () => {
+  const head = 'a'.repeat(40);
+  const body = makeWaiverComment({ headSha: head, claimId: 'claim-A' });
+  const comment = {
+    body,
+    author: { login: 'kurone-kito' },
+    createdAt: '2026-05-17T00:00:00Z',
+  };
+  const result = summarizeExternalCheckWaivers([comment], {
+    prHeadSha: head,
+    activeClaimId: 'claim-C',
+    activeClaimSupersedes: 'claim-B',
+    trustedMarkerLogins: ['kurone-kito'],
+    now: '2026-05-17T00:00:00Z',
+  });
+  assert.equal(result.valid.length, 0);
+  assert.equal(result.wrongClaim.length, 1);
+});
+
 test('summarizeExternalCheckWaivers: an empty head SHA fails closed to wrongHead', () => {
   const head = 'a'.repeat(40);
   const body = makeWaiverComment({ headSha: head, claimId: 'claim-123' });


### PR DESCRIPTION
# Summary

Keep a maintainer `idd-external-check-waiver` valid after an in-policy
claim takeover when the new claim's `supersedes` field is the waiver's
bound claim id. The `none` sentinel is never treated as a predecessor,
so a freshly claimed PR cannot validate a claimless waiver.

## Linked issue

Closes #2080

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Reproduced on PR #2036: a valid waiver bound to claim A was classified
`wrongClaim` after a stale-claim takeover installed claim B. The waiver
authorizes the PR's mergeability, not the current session. Watermarks
stay exact-match on purpose -- a takeover starts a new restore scope.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed