### PR TITLE
docs: register Grok Build on AGENTS.md and routing docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,8 +15,8 @@ VS Code Copilot Chat because they are the primary tools used for
 day-to-day work and benchmarking.
 
 `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` exist as lightweight
-compatibility entry points: `AGENTS.md` serves Codex CLI and OpenCode,
-`CLAUDE.md` serves Claude Code, and `GEMINI.md` serves
+compatibility entry points: `AGENTS.md` serves Codex CLI, OpenCode, and
+Grok Build, `CLAUDE.md` serves Claude Code, and `GEMINI.md` serves
 Antigravity CLI (formerly Gemini CLI). Keep this file as the canonical,
 fully detailed guide unless benchmark results justify a more neutral
 layout.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@ project.
 lives in
 [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
 This file contains tool-specific guidance for agents that read the
-agents.md standard — currently Codex CLI and OpenCode. When
-Copilot-specific workflow names appear, apply the intent using your
+agents.md standard — currently Codex CLI, OpenCode, and Grok Build.
+When Copilot-specific workflow names appear, apply the intent using your
 own interaction model rather than following product terms literally.
 
 ## Minimum requirements
@@ -122,7 +122,8 @@ For Codex CLI, read the canonical issue-authoring bundle explicitly from
 `skills/issue-authoring/`, or install one selected copy under
 `.agents/skills/issue-authoring/` when the target runtime supports native
 skill discovery there. The existing `.claude/skills/issue-authoring/` copy is
-the dogfood route for Claude Code and OpenCode compatibility; it is not the
+the dogfood route for Claude Code, OpenCode, and Grok Build
+compatibility; it is not the
 canonical source. Do not add checked-in `.agents/skills/` or
 `.opencode/skills/` mirrors by default (preventive; no observed incident yet),
 and do not assume the source path is automatically discovered by Codex.

--- a/README.ja.md
+++ b/README.ja.md
@@ -42,7 +42,8 @@ IDD は、これらの動きをひとつの監査可能な GitHub ネイティ�
 - **ブラックボックスではない移植可能なルール** — 導入先リポジトリで
   そのまま読める Markdown。閲覧も、フォークも、カスタマイズも自由です。
 - **エージェントを選べる自由** — GitHub Copilot、Claude Code、OpenAI
-  Codex CLI、OpenCode、Antigravity CLI (formerly Gemini CLI) で動作。
+  Codex CLI、OpenCode、Grok Build、Antigravity CLI (formerly Gemini
+  CLI) で動作。
   標準の Copilot 助言レビューは
   [review policy profiles](docs/idd-review-policy-profiles.md) で
   差し替えられます。
@@ -140,14 +141,14 @@ stop rules を仕組みとして設計する考え方(Anthropic のいう
 
 ## 次の一歩
 
-| 目的                                                | まず読む場所                                                                                                                                                               |
-| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 概念を先に理解したい                                | [`docs/concepts.md`](docs/concepts.md)                                                                                                                                     |
-| 自分のリポジトリに IDD を導入したい                 | [`idd-template/ONBOARDING.md`](idd-template/ONBOARDING.md)                                                                                                                 |
-| このリポジトリでエージェントを動かしたい            | [`AGENTS.md`](AGENTS.md) (Codex CLI と OpenCode)、[`CLAUDE.md`](CLAUDE.md)、[`GEMINI.md`](GEMINI.md)、[`.github/copilot-instructions.md`](.github/copilot-instructions.md) |
-| ループの前に AI 向け issue を整備したい             | [`skills/issue-authoring/SKILL.md`](skills/issue-authoring/SKILL.md)                                                                                                       |
-| review・merge・CI・discovery のポリシーを調整したい | [`docs/customization.md`](docs/customization.md)                                                                                                                           |
-| それ以外のすべて — 完全なリファレンスマニュアル     | [`docs/index.md`](docs/index.md)                                                                                                                                           |
+| 目的                                                | まず読む場所                                                                                                                                                                         |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 概念を先に理解したい                                | [`docs/concepts.md`](docs/concepts.md)                                                                                                                                               |
+| 自分のリポジトリに IDD を導入したい                 | [`idd-template/ONBOARDING.md`](idd-template/ONBOARDING.md)                                                                                                                           |
+| このリポジトリでエージェントを動かしたい            | [`AGENTS.md`](AGENTS.md) (Codex CLI、OpenCode、Grok Build)、[`CLAUDE.md`](CLAUDE.md)、[`GEMINI.md`](GEMINI.md)、[`.github/copilot-instructions.md`](.github/copilot-instructions.md) |
+| ループの前に AI 向け issue を整備したい             | [`skills/issue-authoring/SKILL.md`](skills/issue-authoring/SKILL.md)                                                                                                                 |
+| review・merge・CI・discovery のポリシーを調整したい | [`docs/customization.md`](docs/customization.md)                                                                                                                                     |
+| それ以外のすべて — 完全なリファレンスマニュアル     | [`docs/index.md`](docs/index.md)                                                                                                                                                     |
 
 主なパッケージは [`idd-template/`](idd-template/) です。移植用の
 `.github/instructions/` ファイル、導入・ワークフロードキュメント、

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ cleanup markers — so any agent can resume any work without guessing.
 - **Portable rules, not a black box** — plain Markdown you can
   inspect, fork, and customize in your own repository.
 - **Agent choice** — works across GitHub Copilot, Claude Code, OpenAI
-  Codex CLI, OpenCode, and Antigravity CLI (formerly Gemini CLI);
+  Codex CLI, OpenCode, Grok Build, and Antigravity CLI (formerly
+  Gemini CLI);
   [review policy profiles](docs/idd-review-policy-profiles.md) let you
   swap the default Copilot advisory gate.
 - **No service to operate** — no server, scheduler, or additional SaaS
@@ -138,14 +139,14 @@ companion repository at
 
 ## Where next
 
-| Goal                                              | Start here                                                                                                                                                                      |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Understand the concept first                      | [`docs/concepts.md`](docs/concepts.md)                                                                                                                                          |
-| Adopt IDD in my repository                        | [`idd-template/ONBOARDING.md`](idd-template/ONBOARDING.md)                                                                                                                      |
-| Run an agent on this repository                   | [`AGENTS.md`](AGENTS.md) (Codex CLI and OpenCode), [`CLAUDE.md`](CLAUDE.md), [`GEMINI.md`](GEMINI.md), and [`.github/copilot-instructions.md`](.github/copilot-instructions.md) |
-| Author AI-ready issues before the loop            | [`skills/issue-authoring/SKILL.md`](skills/issue-authoring/SKILL.md)                                                                                                            |
-| Customize review, merge, CI, and discovery policy | [`docs/customization.md`](docs/customization.md)                                                                                                                                |
-| Everything else — the full reference manual       | [`docs/index.md`](docs/index.md)                                                                                                                                                |
+| Goal                                              | Start here                                                                                                                                                                                   |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Understand the concept first                      | [`docs/concepts.md`](docs/concepts.md)                                                                                                                                                       |
+| Adopt IDD in my repository                        | [`idd-template/ONBOARDING.md`](idd-template/ONBOARDING.md)                                                                                                                                   |
+| Run an agent on this repository                   | [`AGENTS.md`](AGENTS.md) (Codex CLI, OpenCode, and Grok Build), [`CLAUDE.md`](CLAUDE.md), [`GEMINI.md`](GEMINI.md), and [`.github/copilot-instructions.md`](.github/copilot-instructions.md) |
+| Author AI-ready issues before the loop            | [`skills/issue-authoring/SKILL.md`](skills/issue-authoring/SKILL.md)                                                                                                                         |
+| Customize review, merge, CI, and discovery policy | [`docs/customization.md`](docs/customization.md)                                                                                                                                             |
+| Everything else — the full reference manual       | [`docs/index.md`](docs/index.md)                                                                                                                                                             |
 
 The primary package is [`idd-template/`](idd-template/): the portable
 `.github/instructions/` files, onboarding and workflow docs, and a

--- a/docs/ai-strategy.md
+++ b/docs/ai-strategy.md
@@ -16,10 +16,10 @@ in this project.
 - [.github/copilot-instructions.md](../.github/copilot-instructions.md)
   is the canonical, fully detailed AI guide. Keep it complete enough
   for GitHub Copilot CLI and VS Code Copilot Chat.
-- [AGENTS.md](../AGENTS.md) is a Codex CLI and OpenCode compatibility
-  entry point. It must stay self-contained for the rules those agents
-  need immediately, then point to the canonical Copilot guide for the
-  remaining detail.
+- [AGENTS.md](../AGENTS.md) is a Codex CLI, OpenCode, and Grok Build
+  compatibility entry point. It must stay self-contained for the rules
+  those agents need immediately, then point to the canonical Copilot
+  guide for the remaining detail.
 - [CLAUDE.md](../CLAUDE.md) is a Claude Code compatibility entry point
   with the same role.
 - [GEMINI.md](../GEMINI.md) is an Antigravity CLI (formerly Gemini CLI)

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -9,7 +9,8 @@ tags: [workflow, phase-routing]
 
 This document is the neutral entry point for the repository's
 Issue-Driven Development (IDD) workflow across GitHub Copilot, Codex
-CLI, OpenCode, Claude Code, and Antigravity CLI (formerly Gemini CLI).
+CLI, OpenCode, Grok Build, Claude Code, and Antigravity CLI (formerly
+Gemini CLI).
 
 Use it when you need to answer three questions quickly:
 
@@ -36,13 +37,19 @@ you are reading this guide first, start at step 1.
 | GitHub Copilot surfaces | `.github/copilot-instructions.md` | `.github/instructions/idd-overview-core.instructions.md` for execution surfaces; package-scoped `.instructions.md` files in VS Code Copilot when editing matching paths | The routed phase file when the current step changes                                                                                                                                                                                 |
 | Codex CLI               | `AGENTS.md`                       | None from `.github/instructions/`                                                                                                                                       | `.github/instructions/idd-overview-core.instructions.md` and the routed phase file                                                                                                                                                  |
 | OpenCode                | `AGENTS.md`                       | `AGENTS.md` itself — OpenCode's native rules mechanism auto-loads it; none from `.github/instructions/`                                                                 | `.github/instructions/idd-overview-core.instructions.md` and the routed phase file                                                                                                                                                  |
+| Grok Build              | `AGENTS.md`                       | `AGENTS.md` and `CLAUDE.md` when both exist (same contract; Grok Build loads every matching filename, unlike OpenCode's first-match); none from `.github/instructions/` | `.github/instructions/idd-overview-core.instructions.md` and the routed phase file; see [B1's harness-native worktree tool caveat](../.github/instructions/idd-work.instructions.md#worktree-creation)                              |
 | Claude Code             | `CLAUDE.md`                       | None from `.github/instructions/` by default                                                                                                                            | `.github/instructions/idd-overview-core.instructions.md` and the routed phase file; see [B1's harness-native worktree tool caveat](../.github/instructions/idd-work.instructions.md#worktree-creation) before using `EnterWorktree` |
 | Antigravity CLI         | `GEMINI.md`                       | None from `.github/instructions/`                                                                                                                                       | `.github/instructions/idd-overview-core.instructions.md` and the routed phase file                                                                                                                                                  |
 
-OpenCode also discovers the `issue-authoring` skill bundle in this
-repository through its `.claude/skills/` compatibility, since
-`.claude/skills/issue-authoring/` is a generated, byte-identical copy
-of the canonical bundle at `skills/issue-authoring/`.
+OpenCode and Grok Build also discover the `issue-authoring` skill
+bundle in this repository through `.claude/skills/` compatibility,
+since `.claude/skills/issue-authoring/` is a generated, byte-identical
+copy of the canonical bundle at `skills/issue-authoring/`.
+
+During IDD, do not call Grok Build's `enter_plan_mode` (it blocks
+non-plan-file edits). Do not let the bundled `review`, `pr-babysit`, or
+`execute-plan` skills replace IDD E/F phases or spawn extra worktrees.
+(Preventive; no observed incident yet.)
 
 During onboarding, create or update `CLAUDE.md`, `AGENTS.md`, and
 `GEMINI.md` so each non-Copilot agent listed above has a stable first
@@ -886,6 +893,7 @@ agent; only the mechanism differs.
 | Claude Code     | `Agent(subagent_type="general-purpose")` with the calling phase's critique checklist                                                                                                                                       |
 | Codex CLI       | Use one bounded read-only native subagent review when supported and suitable; parent waits for and collects the result. Fallback: structured self-critique when delegation is unavailable, disabled, unsuitable, or fails. |
 | OpenCode        | Launch a subagent via OpenCode's Task tool (e.g. the built-in `general` subagent, or a `subtask: true` command) — an independent mechanism                                                                                 |
+| Grok Build      | Independent `spawn_subagent` with the calling phase's critique checklist                                                                                                                                                   |
 | Antigravity CLI | Self-critique or use Antigravity's native multi-step task mechanism if available                                                                                                                                           |
 
 For Codex delegation, the parent collects the reviewer result before

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -64,15 +64,15 @@ current no-go recommendation.
 
 ## Comparison matrix
 
-| Criterion                         | idd-skill                                                         | GitHub Agentic Workflows        | Awesome-Copilot skills | Kiro / Factory.ai | OpenHands            |
-| --------------------------------- | ----------------------------------------------------------------- | ------------------------------- | ---------------------- | ----------------- | -------------------- |
-| Parallel agent coordination       | ✓ (claim/heartbeat)                                               | ✗                               | ✗                      | Varies            | ✗                    |
-| End-to-end phase coverage         | ✓ (full discovery-to-merge set)                                   | Partial                         | ✗                      | ✓ (proprietary)   | Partial              |
-| Zero infrastructure               | ✓ (Markdown files only)                                           | ✗ (GitHub servers)              | ✓                      | ✗ (SaaS account)  | ✗ (runtime required) |
-| Execution-agent neutral           | ✓ (Copilot, Claude, Codex, Antigravity CLI (formerly Gemini CLI)) | ✗ (GitHub Copilot only)         | ✓                      | ✗ (proprietary)   | ✗ (own runtime)      |
-| Fully auditable rules             | ✓ (plain Markdown)                                                | ✗                               | ✓                      | ✗                 | ✓ (open source)      |
-| GitHub-hosted CI integration      | ✓ (CI wait loop)                                                  | ✓                               | ✗                      | ✓                 | Varies               |
-| No separate orchestration service | ✓                                                                 | ✗ (GitHub-hosted agent service) | ✓                      | ✗                 | ✓                    |
+| Criterion                         | idd-skill                                                                               | GitHub Agentic Workflows        | Awesome-Copilot skills | Kiro / Factory.ai | OpenHands            |
+| --------------------------------- | --------------------------------------------------------------------------------------- | ------------------------------- | ---------------------- | ----------------- | -------------------- |
+| Parallel agent coordination       | ✓ (claim/heartbeat)                                                                     | ✗                               | ✗                      | Varies            | ✗                    |
+| End-to-end phase coverage         | ✓ (full discovery-to-merge set)                                                         | Partial                         | ✗                      | ✓ (proprietary)   | Partial              |
+| Zero infrastructure               | ✓ (Markdown files only)                                                                 | ✗ (GitHub servers)              | ✓                      | ✗ (SaaS account)  | ✗ (runtime required) |
+| Execution-agent neutral           | ✓ (Copilot, Claude, Codex, OpenCode, Antigravity CLI (formerly Gemini CLI), Grok Build) | ✗ (GitHub Copilot only)         | ✓                      | ✗ (proprietary)   | ✗ (own runtime)      |
+| Fully auditable rules             | ✓ (plain Markdown)                                                                      | ✗                               | ✓                      | ✗                 | ✓ (open source)      |
+| GitHub-hosted CI integration      | ✓ (CI wait loop)                                                                        | ✓                               | ✗                      | ✓                 | Varies               |
+| No separate orchestration service | ✓                                                                                       | ✗ (GitHub-hosted agent service) | ✓                      | ✗                 | ✓                    |
 
 The final row means idd-skill does not add its own IDD-specific SaaS
 account, orchestration account, scheduler, or server. Running the full

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -7,9 +7,9 @@ tags: [positioning, competitive-analysis]
 
 # IDD Skill — Competitive Landscape and Positioning
 
-Analysis date: 2026-05-07
+Analysis date: 2026-08-17
 
-> **Positioning snapshot — as of 2026-05-07.**
+> **Positioning snapshot — as of 2026-08-17.**
 > This comparison is a positioning snapshot, not a permanent claim.
 > Revalidate tool capabilities before using this document for external
 > marketing or publication.

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -9,7 +9,8 @@ tags: [workflow, phase-routing]
 
 This document is the neutral entry point for the repository's
 Issue-Driven Development (IDD) workflow across GitHub Copilot, Codex
-CLI, OpenCode, Claude Code, and Antigravity CLI (formerly Gemini CLI).
+CLI, OpenCode, Grok Build, Claude Code, and Antigravity CLI (formerly
+Gemini CLI).
 
 Use it when you need to answer three questions quickly:
 
@@ -36,12 +37,18 @@ you are reading this guide first, start at step 1.
 | GitHub Copilot surfaces | `.github/copilot-instructions.md` | `.github/instructions/idd-overview-core.instructions.md` for execution surfaces; package-scoped `.instructions.md` files in VS Code Copilot when editing matching paths | The routed phase file when the current step changes                                                                                                                                                                                 |
 | Codex CLI               | `AGENTS.md`                       | None from `.github/instructions/`                                                                                                                                       | `.github/instructions/idd-overview-core.instructions.md` and the routed phase file                                                                                                                                                  |
 | OpenCode                | `AGENTS.md`                       | `AGENTS.md` itself — OpenCode's native rules mechanism auto-loads it; none from `.github/instructions/`                                                                 | `.github/instructions/idd-overview-core.instructions.md` and the routed phase file                                                                                                                                                  |
+| Grok Build              | `AGENTS.md`                       | `AGENTS.md` and `CLAUDE.md` when both exist (same contract; Grok Build loads every matching filename, unlike OpenCode's first-match); none from `.github/instructions/` | `.github/instructions/idd-overview-core.instructions.md` and the routed phase file; see [B1's harness-native worktree tool caveat](../.github/instructions/idd-work.instructions.md#worktree-creation)                              |
 | Claude Code             | `CLAUDE.md`                       | None from `.github/instructions/` by default                                                                                                                            | `.github/instructions/idd-overview-core.instructions.md` and the routed phase file; see [B1's harness-native worktree tool caveat](../.github/instructions/idd-work.instructions.md#worktree-creation) before using `EnterWorktree` |
 | Antigravity CLI         | `GEMINI.md`                       | None from `.github/instructions/`                                                                                                                                       | `.github/instructions/idd-overview-core.instructions.md` and the routed phase file                                                                                                                                                  |
 
 When the `issue-authoring` companion bundle is installed under
-`.claude/skills/` in a target repository, OpenCode also discovers it
-there through its `.claude/skills/` compatibility.
+`.claude/skills/` in a target repository, OpenCode and Grok Build also
+discover it there through `.claude/skills/` compatibility.
+
+During IDD, do not call Grok Build's `enter_plan_mode` (it blocks
+non-plan-file edits). Do not let the bundled `review`, `pr-babysit`, or
+`execute-plan` skills replace IDD E/F phases or spawn extra worktrees.
+(Preventive; no observed incident yet.)
 
 During onboarding, create or update `CLAUDE.md`, `AGENTS.md`, and
 `GEMINI.md` so each non-Copilot agent listed above has a stable first
@@ -865,6 +872,7 @@ agent; only the mechanism differs.
 | Claude Code     | `Agent(subagent_type="general-purpose")` with the calling phase's critique checklist                                                                                                                                       |
 | Codex CLI       | Use one bounded read-only native subagent review when supported and suitable; parent waits for and collects the result. Fallback: structured self-critique when delegation is unavailable, disabled, unsuitable, or fails. |
 | OpenCode        | Launch a subagent via OpenCode's Task tool (e.g. the built-in `general` subagent, or a `subtask: true` command) — an independent mechanism                                                                                 |
+| Grok Build      | Independent `spawn_subagent` with the calling phase's critique checklist                                                                                                                                                   |
 | Antigravity CLI | Self-critique or use Antigravity's native multi-step task mechanism if available                                                                                                                                           |
 
 For Codex delegation, the parent collects the reviewer result before

--- a/tests/agent-entry-mirror-sync.test.mts
+++ b/tests/agent-entry-mirror-sync.test.mts
@@ -11,7 +11,7 @@ type EntryFile = (typeof FILES)[number];
 
 const REQUIRED_TOOL_NAMES: Record<EntryFile, readonly string[]> = {
   'CLAUDE.md': ['Claude'],
-  'AGENTS.md': ['Codex', 'OpenCode'],
+  'AGENTS.md': ['Codex', 'OpenCode', 'Grok'],
   'GEMINI.md': ['Gemini'],
 };
 


### PR DESCRIPTION
# Summary

Register Grok Build as an `AGENTS.md`-standard IDD runtime. Name it in
the AGENTS.md canonical-reference paragraph, routing tables, READMEs,
and strategy docs. Do not add a `GROK.md` root file.

## Linked issue

Closes #2113

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Grok Build auto-loads every matching project-rule filename (`AGENTS.md`
and `CLAUDE.md`) and does not auto-load `.github/instructions/`. This
child is the OpenCode-registration equivalent (#1414). CLAUDE.md and
GEMINI.md stay Grok-free. The workflow guide adds a preventive
`enter_plan_mode` / bundled-skill caveat (no observed incident yet).

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Grok Build to the list of supported execution agents across English and Japanese guides.
  - Documented Grok Build compatibility, workflow behavior, skill discovery, and worktree considerations.
  - Updated comparison and “Where next” guidance to reference Grok Build.

- **Tests**
  - Updated compatibility validation to recognize Grok Build in the supported agent references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->