### PR TITLE
docs(work): name Grok Build harness worktree primitives in B1

### DIFF
--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -101,8 +101,13 @@ tool-chosen default of either. `EnterWorktree`'s create action always
 places the worktree under a harness-owned directory (observed as
 `.claude/worktrees/agent-<hash>`), never the sibling path above, so it
 can never satisfy the directory half of this rule — never use it to
-create the B1 worktree. When a harness-native tool cannot pin both, use
-the documented `git worktree add` path below (or WorkTrunk) instead.
+create the B1 worktree. Grok Build's `grok --worktree`, subagent
+`isolation: worktree`, and `x.ai/git/worktree/*` likewise place
+worktrees in a harness-owned location and cannot pin the sibling path
+or the `issue/<number>-<slug>` branch — never use them to create the
+B1 worktree (same failure class as #1930). When a harness-native tool
+cannot pin both, use the documented `git worktree add` path below (or
+WorkTrunk) instead.
 
 **Step 1 — Check for orphaned path**: if the target path already exists
 but is not listed in `git worktree list`, stop and report for manual

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -96,8 +96,13 @@ tool-chosen default of either. `EnterWorktree`'s create action always
 places the worktree under a harness-owned directory (observed as
 `.claude/worktrees/agent-<hash>`), never the sibling path above, so it
 can never satisfy the directory half of this rule — never use it to
-create the B1 worktree. When a harness-native tool cannot pin both, use
-the documented `git worktree add` path below (or WorkTrunk) instead.
+create the B1 worktree. Grok Build's `grok --worktree`, subagent
+`isolation: worktree`, and `x.ai/git/worktree/*` likewise place
+worktrees in a harness-owned location and cannot pin the sibling path
+or the `issue/<number>-<slug>` branch — never use them to create the
+B1 worktree (same failure class as #1930). When a harness-native tool
+cannot pin both, use the documented `git worktree add` path below (or
+WorkTrunk) instead.
 
 **Step 1 — Check for orphaned path**: if the target path already exists
 but is not listed in `git worktree list`, stop and report for manual


### PR DESCRIPTION
# Summary

Name Grok Build's harness-native worktree primitives in B1's existing
pin-or-do-not-use rule, next to Claude Code's `EnterWorktree`. The
sibling-path convention, WorkTrunk path, and `git worktree add` path
are unchanged. Lite work instructions are unchanged.

## Linked issue

Closes #2114

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Grok Build's `grok --worktree`, subagent `isolation: worktree`, and
`x.ai/git/worktree/*` place worktrees in a harness-owned location, the
same failure class as `EnterWorktree` (#1930). Operators will not find
the existing generic rule by searching the work file for Grok.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (pre-push-validate subset: biome, dprint, markdownlint, cspell, audit-docs, code-span-wrap, build:check, doctor)
- [x] `pnpm test` (`node --test tests/consistency.test.mts` — 87 pass)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (covered by audit-docs)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed (idd-work 18768/33000; bundle-work 42108/45000)