### PR TITLE
docs(onboarding): add Grok Build as an AGENTS.md consumer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,9 @@ pnpm-lock.yaml.*
 # OpenAI Codex sandbox
 .codex/
 
+# Grok Build local state
+.grok/
+
 ### Workshop recording outputs ###
 docs/workshop/assets/recordings/*.gif
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,8 @@ already been copied, start from the local `ONBOARDING.md` file instead.
 
 The onboarding guide copies the portable instruction files, asks for
 project-specific command values, and updates agent entry files such as
-`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, or Copilot instructions.
+`AGENTS.md` (also Grok Build), `CLAUDE.md`, `GEMINI.md`, or Copilot
+instructions.
 
 ### Validate the import with IDD doctor (optional)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,8 +38,8 @@ already been copied, start from the local `ONBOARDING.md` file instead.
 
 The onboarding guide copies the portable instruction files, asks for
 project-specific command values, and updates agent entry files such as
-`AGENTS.md` (also Grok Build), `CLAUDE.md`, `GEMINI.md`, or Copilot
-instructions.
+`AGENTS.md` (Codex CLI, OpenCode, and Grok Build), `CLAUDE.md`,
+`GEMINI.md`, or Copilot instructions.
 
 ### Validate the import with IDD doctor (optional)
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -345,10 +345,11 @@ Keep approval labels and operational marker trust as separate controls:
 
 This section is **Claude Code-specific**: it documents the committed
 `.claude/settings.json` allow/deny baseline and its opt-in template
-counterpart. Every other harness this workflow supports (Copilot, Codex
-CLI, OpenCode, Antigravity CLI) has no equivalent file and simply
-ignores it -- this section is purely additive for those agents, not a
-cross-agent permission contract.
+counterpart. Copilot, Codex CLI, OpenCode, and Antigravity CLI have no
+equivalent file and ignore it. Grok Build is the exception: it merges
+that committed allow/deny baseline into its permission rules. This
+section is not a cross-agent permission contract for the harnesses that
+ignore the file.
 
 A fresh Claude Code session otherwise starts from an empty per-user
 `.claude/settings.local.json`, so every environment re-accumulates the

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -505,9 +505,9 @@ from `skills/issue-authoring/` in the idd-skill source repository. That path is
 the canonical source bundle, not the target repository's discovery path.
 When you install it in a target repository, choose one agent-specific native
 skill directory that the selected runtime reads, such as `.agents/skills/`
-for Codex CLI or OpenCode, `.claude/skills/` for Claude Code and Grok
-Build, or `.opencode/skills/` for OpenCode. Do not add a `.grok/skills/`
-install root. The examples below use the Codex destination
+for Codex CLI or OpenCode, `.claude/skills/` for Claude Code, OpenCode,
+and Grok Build, or `.opencode/skills/` for OpenCode. Do not add a
+`.grok/skills/` install root. The examples below use the Codex destination
 `.agents/skills/issue-authoring/`; change `SKILL_DEST` to the one selected
 destination before running any example. Do not install the same skill ID in
 multiple roots unless the operator explicitly accepts identical duplicates

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -505,8 +505,9 @@ from `skills/issue-authoring/` in the idd-skill source repository. That path is
 the canonical source bundle, not the target repository's discovery path.
 When you install it in a target repository, choose one agent-specific native
 skill directory that the selected runtime reads, such as `.agents/skills/`
-for Codex CLI or OpenCode, `.claude/skills/` for Claude Code, or
-`.opencode/skills/` for OpenCode. The examples below use the Codex destination
+for Codex CLI or OpenCode, `.claude/skills/` for Claude Code and Grok
+Build, or `.opencode/skills/` for OpenCode. Do not add a `.grok/skills/`
+install root. The examples below use the Codex destination
 `.agents/skills/issue-authoring/`; change `SKILL_DEST` to the one selected
 destination before running any example. Do not install the same skill ID in
 multiple roots unless the operator explicitly accepts identical duplicates
@@ -1577,9 +1578,9 @@ any copied file other than those three meta-docs.
 By default, leave the repository with root entry files for every
 manually-routed non-Copilot agent named in `docs/idd-workflow.md`:
 `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md`. `AGENTS.md` is the shared
-agents.md-standard entry for both Codex CLI and OpenCode — OpenCode
-auto-loads it natively, so no dedicated root file is needed for
-OpenCode.
+agents.md-standard entry for Codex CLI, OpenCode, and Grok Build —
+each auto-loads it natively, so no dedicated root file is needed for
+OpenCode or Grok Build. Operators must not create `GROK.md`.
 
 - If the file already exists, append or adapt an IDD section without
   replacing unrelated repository guidance.

--- a/idd-template/docs/getting-started.md
+++ b/idd-template/docs/getting-started.md
@@ -38,7 +38,8 @@ already been copied, start from the local `ONBOARDING.md` file instead.
 
 The onboarding guide copies the portable instruction files, asks for
 project-specific command values, and updates agent entry files such as
-`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, or Copilot instructions.
+`AGENTS.md` (also Grok Build), `CLAUDE.md`, `GEMINI.md`, or Copilot
+instructions.
 
 ### Validate the import with IDD doctor (optional)
 

--- a/idd-template/docs/getting-started.md
+++ b/idd-template/docs/getting-started.md
@@ -38,8 +38,8 @@ already been copied, start from the local `ONBOARDING.md` file instead.
 
 The onboarding guide copies the portable instruction files, asks for
 project-specific command values, and updates agent entry files such as
-`AGENTS.md` (also Grok Build), `CLAUDE.md`, `GEMINI.md`, or Copilot
-instructions.
+`AGENTS.md` (Codex CLI, OpenCode, and Grok Build), `CLAUDE.md`,
+`GEMINI.md`, or Copilot instructions.
 
 ### Validate the import with IDD doctor (optional)
 

--- a/idd-template/docs/onboarding/agent-entry-and-verification.md
+++ b/idd-template/docs/onboarding/agent-entry-and-verification.md
@@ -109,16 +109,20 @@ Before starting IDD work, open
 phase file manually when the current step changes.
 ```
 
-### AGENTS.md (for Codex CLI and OpenCode)
+### AGENTS.md (for Codex CLI, OpenCode, and Grok Build)
 
-`AGENTS.md` is the shared agents.md-standard entry file for both Codex
-CLI and OpenCode: each auto-loads `AGENTS.md` from the repository root
-natively, so this single file covers both runtimes and OpenCode needs
-no dedicated root file of its own.
+`AGENTS.md` is the shared agents.md-standard entry file for Codex CLI,
+OpenCode, and Grok Build: each auto-loads `AGENTS.md` from the
+repository root natively, so this single file covers those runtimes
+and neither OpenCode nor Grok Build needs a dedicated root file of its
+own. Do not create `GROK.md`. `idd-doctor` still checks only
+`AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` — do not add a `GROK.md`
+check.
 
 If `AGENTS.md` already exists, add the shared IDD workflow section and
-keep the wording explicit that Codex CLI and OpenCode agents should
-manually open `.github/instructions/idd-overview-core.instructions.md`
+keep the wording explicit that Codex CLI, OpenCode, and Grok Build
+agents should manually open
+`.github/instructions/idd-overview-core.instructions.md`
 and the routed phase file before starting IDD work.
 
 If `AGENTS.md` does not exist, create a minimal file such as below.
@@ -188,6 +192,19 @@ workflow stub above to every session; the steps below are an
   that login to `trustedMarkerActors` (and the advisory-bot lists if
   it also reviews) in `.github/idd/config.json` — a config-values edit
   only; `schemas/policy.schema.json` stays agent-agnostic.
+
+#### Grok Build: no extra root file
+
+Grok Build auto-loads `AGENTS.md` (and `CLAUDE.md` when present). Do
+not create `GROK.md`. It discovers the optional `issue-authoring`
+companion under `.claude/skills/` the same way OpenCode does — do not
+add a `.grok/skills/` install root.
+
+If a target repository runs Grok Build as an autonomous worker under
+its own GitHub identity (not just an interactive assistant), add that
+login to `trustedMarkerActors` (and the advisory-bot lists if it also
+reviews) in `.github/idd/config.json` — a config-values edit only;
+`schemas/policy.schema.json` stays agent-agnostic.
 
 ### Issue-authoring companion verification
 
@@ -339,7 +356,7 @@ checks, confirm the detailed items below.
       the operator explicitly opted out of creating it.
 - [ ] `AGENTS.md` exists and references `docs/idd-workflow.md`, unless
       the operator explicitly opted out of creating it; this single
-      file covers both Codex CLI and OpenCode.
+      file covers Codex CLI, OpenCode, and Grok Build.
 - [ ] `GEMINI.md` exists and references `docs/idd-workflow.md`, unless
       the operator explicitly opted out of creating it.
 - [ ] Among the entry files the operator did not opt out of creating,

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -345,10 +345,11 @@ Keep approval labels and operational marker trust as separate controls:
 
 This section is **Claude Code-specific**: it documents the committed
 `.claude/settings.json` allow/deny baseline and its opt-in template
-counterpart. Every other harness this workflow supports (Copilot, Codex
-CLI, OpenCode, Antigravity CLI) has no equivalent file and simply
-ignores it -- this section is purely additive for those agents, not a
-cross-agent permission contract.
+counterpart. Copilot, Codex CLI, OpenCode, and Antigravity CLI have no
+equivalent file and ignore it. Grok Build is the exception: it merges
+that committed allow/deny baseline into its permission rules. This
+section is not a cross-agent permission contract for the harnesses that
+ignore the file.
 
 A fresh Claude Code session otherwise starts from an empty per-user
 `.claude/settings.local.json`, so every environment re-accumulates the

--- a/tests/non-node-fallback.test.mts
+++ b/tests/non-node-fallback.test.mts
@@ -391,7 +391,7 @@ test('onboarding links extracted agent-entry and verification guidance', () => {
   );
   assert.match(
     reference,
-    /### AGENTS\.md \(for Codex CLI and OpenCode\)/,
+    /### AGENTS\.md \(for Codex CLI, OpenCode, and Grok Build\)/,
     'agent-entry reference must keep the AGENTS.md example outside ONBOARDING',
   );
   assert.match(


### PR DESCRIPTION
# Summary

Add Grok Build to onboarding as an `AGENTS.md` consumer. Forbid
`GROK.md`, ignore `.grok/` in the source repo, and record that Grok
Build merges the committed `.claude/settings.json` baseline.

## Linked issue

Closes #2115

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Blocked by #2113, now merged. This is the OpenCode-onboarding
equivalent (#1418). Doctor still checks only AGENTS.md, CLAUDE.md, and
GEMINI.md.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed