### PR TITLE
docs(issue-authoring): say --force still reports overwrite

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -410,8 +410,11 @@ Ask these checks:
    import rather than an assumed carry-forward, and
    `idd-onboard.mjs --import` reports a `blockedOverwrites` finding
    instead of silently keeping a same-named local file as-is, unless
-   the import used `--force`, which silently overwrites the differing
-   file instead of recording it there (observed 2026-08-12/13 on an
+   the import used `--force`, which still writes the file and reports
+   it in the verdict JSON (`plan` as an `overwrite` entry,
+   `filesChanged`, and `written`) but omits it from
+   `blockedOverwrites` so the import is not blocked (observed
+   2026-08-12/13 on an
    adopter repository, `setup.ubuntu`, kurone-kito/idd-skill#2012).
 5. When drafting a resync issue's Background, run a mechanical
    placeholder diff against the **upstream `idd-skill` source

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -451,8 +451,11 @@ Ask these checks:
    import rather than an assumed carry-forward, and
    `idd-onboard.mjs --import` reports a `blockedOverwrites` finding
    instead of silently keeping a same-named local file as-is, unless
-   the import used `--force`, which silently overwrites the differing
-   file instead of recording it there (observed 2026-08-12/13 on an
+   the import used `--force`, which still writes the file and reports
+   it in the verdict JSON (`plan` as an `overwrite` entry,
+   `filesChanged`, and `written`) but omits it from
+   `blockedOverwrites` so the import is not blocked (observed
+   2026-08-12/13 on an
    adopter repository, `setup.ubuntu`, kurone-kito/idd-skill#2012).
 5. When drafting a resync issue's Background, run a mechanical
    placeholder diff against the **upstream `idd-skill` source

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -410,8 +410,11 @@ Ask these checks:
    import rather than an assumed carry-forward, and
    `idd-onboard.mjs --import` reports a `blockedOverwrites` finding
    instead of silently keeping a same-named local file as-is, unless
-   the import used `--force`, which silently overwrites the differing
-   file instead of recording it there (observed 2026-08-12/13 on an
+   the import used `--force`, which still writes the file and reports
+   it in the verdict JSON (`plan` as an `overwrite` entry,
+   `filesChanged`, and `written`) but omits it from
+   `blockedOverwrites` so the import is not blocked (observed
+   2026-08-12/13 on an
    adopter repository, `setup.ubuntu`, kurone-kito/idd-skill#2012).
 5. When drafting a resync issue's Background, run a mechanical
    placeholder diff against the **upstream `idd-skill` source


### PR DESCRIPTION
# Summary

Reword the issue-authoring contract so `--force` is not described as a
silent overwrite. It writes the file and reports it in the onboard
verdict JSON; only `blockedOverwrites` (and the blocking exit) is
suppressed.

## Linked issue

Closes #2058

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

PR #2055 already corrected a broader inaccuracy. Copilot then flagged
the remaining "silently overwrites" clause: `--force` still records the
file as a `plan` `overwrite` entry and in `filesChanged`/`written`.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (pre-push-validate subset)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (covered by audit-docs)
- [x] `node scripts/idd-doctor.mjs`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed