### PR TITLE
docs(onboarding): require operator ack before welcome close

### DIFF
--- a/idd-template/docs/onboarding/issue-mediated-bootstrap.md
+++ b/idd-template/docs/onboarding/issue-mediated-bootstrap.md
@@ -441,5 +441,8 @@ exception already noted above: the welcome/next-steps issue is not
 executed as code at all. Unlike this bootstrap issue's own
 issue -> branch -> PR -> merge execution, the welcome issue has nothing
 to implement, so a human (or the same narrowly-scoped, pre-authorized
-agent) reads it and closes it directly once acknowledged — no branch,
-PR, or merge.
+agent) may read it, but neither actor may close it until the operator
+has left a recorded acknowledgment — a comment or reaction on the
+issue. The agent's own judgment that the content has been
+"acknowledged" is not enough. Close it directly after that operator
+signal — no branch, PR, or merge.


### PR DESCRIPTION
# Summary

Require a recorded operator acknowledgment (comment or reaction) before
the welcome/next-steps issue can be closed. The pre-authorized agent may
read the issue but must not close it on its own judgment.

## Linked issue

Closes #2047

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

The welcome issue exists so the operator sees IDD next steps. Closing it
as soon as an agent reads it defeats that purpose.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `node scripts/audit-docs.mjs --check`
- [x] `node scripts/idd-doctor.mjs`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed