### PR TITLE
fix(idd-merge): harden F4 worktree cleanup inspection

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -397,14 +397,12 @@ Before any mutating action in F3, apply the
    format, and fallback GraphQL commands.
 3. Run from the **primary worktree**, never from inside the worktree
    being removed. Any removal (plain or `--force`) silently discards
-   ignored files too, including inside a submodule. **Before the first
-   removal attempt**, re-validate this session's claim and worktree
-   lock (`idd-claim.instructions.md`); stop if either is no longer
-   ours. Scope every inspection to `<path>`.
+   ignored files too, including inside a submodule. Scope every
+   inspection to `<path>` (or `<path>/<sub>` for a `-` submodule
+   path — parent status hides leftovers there).
 
-   Use `--untracked-files=normal` (not `all`). Inspect any `-` path
-   from `submodule status` directly (parent status hides them). A
-   clean submodule worktree can still hide a stash or unpushed commit:
+   Use `--untracked-files=normal` (not `all`). A clean submodule
+   worktree can still hide a stash or unpushed commit:
 
    - `git -C <path> status --porcelain --ignored --untracked-files=normal`
    - `git -C <path> submodule status --recursive`
@@ -416,8 +414,11 @@ Before any mutating action in F3, apply the
    command can reproduce it. Preserve anything else first. Copy
    secrets (e.g. `.env`) out only — never commit or push them.
    Non-secret work may go to a **different** ref or be copied out —
-   not to `<branch-name>` itself, which this step deletes next. Then
-   delete the worktree, then the branch:
+   not to `<branch-name>` itself, which this step deletes next.
+   Immediately before each `worktree remove`, re-validate this
+   session's claim and worktree lock (`idd-claim.instructions.md`);
+   stop if either is no longer ours.
+   Then delete the worktree, then the branch:
 
    - `git worktree remove <path>`. If it fails with `fatal: working
      trees containing submodules cannot be moved or removed`, retry

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -396,37 +396,40 @@ Before any mutating action in F3, apply the
    format, cleanup-failure comment format, permission-blocked comment
    format, and fallback GraphQL commands.
 3. Run from the **primary worktree**, never from inside the worktree
-   being removed — deleting the running process's own cwd breaks every
-   later step. Any removal (plain or `--force`) silently discards
-   ignored files too, including inside an initialized submodule — so
-   **before the first removal attempt**, review what's there. Scope
-   both inspection commands explicitly to `<path>` — an unqualified
-   command inspects the wrong repository:
+   being removed. Any removal (plain or `--force`) silently discards
+   ignored files too, including inside a submodule. **Before the first
+   removal attempt**, re-validate this session's claim and worktree
+   lock; stop if either is no longer ours. Then review what's there.
+   Scope every inspection to `<path>`.
 
-   - `git -C <path> status --porcelain --ignored --untracked-files=all`
-     (avoids a false-clean result under `status.showUntrackedFiles=no`)
+   Use `--untracked-files=normal` (not `all`). Inspect any `-` path
+   from `submodule status` directly (parent status hides them). A
+   clean submodule worktree can still hide a stash or detached-HEAD
+   commit remotes do not have:
+
+   - `git -C <path> status --porcelain --ignored --untracked-files=normal`
+   - `git -C <path> submodule status --recursive`
    - `git -C <path> submodule foreach --recursive 'git status
-     --porcelain --ignored --untracked-files=all'` (keep the `Entering
-     '<submodule>'` banner — it attributes a clean/dirty result to the
-     right submodule)
+     --porcelain --ignored --untracked-files=normal; git stash list;
+     git log --all --not --remotes --oneline'`
 
-   Generated output (e.g. `node_modules/`) is disposable and not a
-   reason to stop. Anything else (local notes, an untracked `.env`,
-   unpushed WIP) must be preserved to a **different** ref or copied
-   out before continuing — not to `<branch-name>` itself, which this
-   step deletes next. Then delete the worktree, then the branch:
+   Generated output is disposable only if a configured project
+   command can reproduce it. Preserve anything else first. Copy
+   secrets (e.g. `.env`) out only — never commit or push them.
+   Non-secret work may go to a **different** ref or be copied out —
+   not to `<branch-name>` itself, which this step deletes next. Then
+   delete the worktree, then the branch:
 
    - `git worktree remove <path>`. If it fails with `fatal: working
-     trees containing submodules cannot be moved or removed` (a
-     submodule was initialized inside that worktree), retry with `git
-     worktree remove --force <path>`, which also overrides the
-     uncommitted/untracked block. Use `--force` only after that review
-     finds nothing worth preserving.
+     trees containing submodules cannot be moved or removed`, retry
+     with `git worktree remove --force <path>`. Use `--force` only
+     after that review finds nothing worth preserving.
    - `git branch -d <branch-name>` (the baseline permission profile
      denies `-D`; see `docs/permissions.md`). If it fails with `error:
      the branch '<branch-name>' is not fully merged` despite the PR
      being merged — `fetch --prune` can drop the remote-tracking ref
      before local `main` fast-forwards — run step 4 first, then retry.
+
 4. Update the local `main` branch (`git fetch origin main && git merge
    --ff-only origin/main`).
 5. If GitHub auto-delete is disabled: delete the remote branch too.

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -399,19 +399,18 @@ Before any mutating action in F3, apply the
    being removed. Any removal (plain or `--force`) silently discards
    ignored files too, including inside a submodule. **Before the first
    removal attempt**, re-validate this session's claim and worktree
-   lock; stop if either is no longer ours. Then review what's there.
-   Scope every inspection to `<path>`.
+   lock (`idd-claim.instructions.md`); stop if either is no longer
+   ours. Scope every inspection to `<path>`.
 
    Use `--untracked-files=normal` (not `all`). Inspect any `-` path
    from `submodule status` directly (parent status hides them). A
-   clean submodule worktree can still hide a stash or detached-HEAD
-   commit remotes do not have:
+   clean submodule worktree can still hide a stash or unpushed commit:
 
    - `git -C <path> status --porcelain --ignored --untracked-files=normal`
    - `git -C <path> submodule status --recursive`
    - `git -C <path> submodule foreach --recursive 'git status
      --porcelain --ignored --untracked-files=normal; git stash list;
-     git log --all --not --remotes --oneline'`
+     git rev-list --all --not --remotes --count'`
 
    Generated output is disposable only if a configured project
    command can reproduce it. Preserve anything else first. Copy

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -397,9 +397,9 @@ Before any mutating action in F3, apply the
    format, and fallback GraphQL commands.
 3. Run from the **primary worktree**, never from inside the worktree
    being removed. Any removal (plain or `--force`) silently discards
-   ignored files too, including inside a submodule. Scope every
-   inspection to `<path>` (or `<path>/<sub>` for a `-` submodule
-   path — parent status hides leftovers there).
+   ignored files too, including inside a submodule. Scope Git
+   commands to `<path>`. Inspect leftover files under a `-`
+   submodule path directly (not a repo).
 
    Use `--untracked-files=normal` (not `all`). A clean submodule
    worktree can still hide a stash or unpushed commit:

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -391,37 +391,40 @@ Before any mutating action in F3, apply the
    format, cleanup-failure comment format, permission-blocked comment
    format, and fallback GraphQL commands.
 3. Run from the **primary worktree**, never from inside the worktree
-   being removed — deleting the running process's own cwd breaks every
-   later step. Any removal (plain or `--force`) silently discards
-   ignored files too, including inside an initialized submodule — so
-   **before the first removal attempt**, review what's there. Scope
-   both inspection commands explicitly to `<path>` — an unqualified
-   command inspects the wrong repository:
+   being removed. Any removal (plain or `--force`) silently discards
+   ignored files too, including inside a submodule. **Before the first
+   removal attempt**, re-validate this session's claim and worktree
+   lock; stop if either is no longer ours. Then review what's there.
+   Scope every inspection to `<path>`.
 
-   - `git -C <path> status --porcelain --ignored --untracked-files=all`
-     (avoids a false-clean result under `status.showUntrackedFiles=no`)
+   Use `--untracked-files=normal` (not `all`). Inspect any `-` path
+   from `submodule status` directly (parent status hides them). A
+   clean submodule worktree can still hide a stash or detached-HEAD
+   commit remotes do not have:
+
+   - `git -C <path> status --porcelain --ignored --untracked-files=normal`
+   - `git -C <path> submodule status --recursive`
    - `git -C <path> submodule foreach --recursive 'git status
-     --porcelain --ignored --untracked-files=all'` (keep the `Entering
-     '<submodule>'` banner — it attributes a clean/dirty result to the
-     right submodule)
+     --porcelain --ignored --untracked-files=normal; git stash list;
+     git log --all --not --remotes --oneline'`
 
-   Generated output (e.g. `node_modules/`) is disposable and not a
-   reason to stop. Anything else (local notes, an untracked `.env`,
-   unpushed WIP) must be preserved to a **different** ref or copied
-   out before continuing — not to `<branch-name>` itself, which this
-   step deletes next. Then delete the worktree, then the branch:
+   Generated output is disposable only if a configured project
+   command can reproduce it. Preserve anything else first. Copy
+   secrets (e.g. `.env`) out only — never commit or push them.
+   Non-secret work may go to a **different** ref or be copied out —
+   not to `<branch-name>` itself, which this step deletes next. Then
+   delete the worktree, then the branch:
 
    - `git worktree remove <path>`. If it fails with `fatal: working
-     trees containing submodules cannot be moved or removed` (a
-     submodule was initialized inside that worktree), retry with `git
-     worktree remove --force <path>`, which also overrides the
-     uncommitted/untracked block. Use `--force` only after that review
-     finds nothing worth preserving.
+     trees containing submodules cannot be moved or removed`, retry
+     with `git worktree remove --force <path>`. Use `--force` only
+     after that review finds nothing worth preserving.
    - `git branch -d <branch-name>` (the baseline permission profile
      denies `-D`; see `docs/permissions.md`). If it fails with `error:
      the branch '<branch-name>' is not fully merged` despite the PR
      being merged — `fetch --prune` can drop the remote-tracking ref
      before local `main` fast-forwards — run step 4 first, then retry.
+
 4. Update the local `main` branch (`git fetch origin main && git merge
    --ff-only origin/main`).
 5. If GitHub auto-delete is disabled: delete the remote branch too.

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -392,9 +392,9 @@ Before any mutating action in F3, apply the
    format, and fallback GraphQL commands.
 3. Run from the **primary worktree**, never from inside the worktree
    being removed. Any removal (plain or `--force`) silently discards
-   ignored files too, including inside a submodule. Scope every
-   inspection to `<path>` (or `<path>/<sub>` for a `-` submodule
-   path — parent status hides leftovers there).
+   ignored files too, including inside a submodule. Scope Git
+   commands to `<path>`. Inspect leftover files under a `-`
+   submodule path directly (not a repo).
 
    Use `--untracked-files=normal` (not `all`). A clean submodule
    worktree can still hide a stash or unpushed commit:

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -394,19 +394,18 @@ Before any mutating action in F3, apply the
    being removed. Any removal (plain or `--force`) silently discards
    ignored files too, including inside a submodule. **Before the first
    removal attempt**, re-validate this session's claim and worktree
-   lock; stop if either is no longer ours. Then review what's there.
-   Scope every inspection to `<path>`.
+   lock (`idd-claim.instructions.md`); stop if either is no longer
+   ours. Scope every inspection to `<path>`.
 
    Use `--untracked-files=normal` (not `all`). Inspect any `-` path
    from `submodule status` directly (parent status hides them). A
-   clean submodule worktree can still hide a stash or detached-HEAD
-   commit remotes do not have:
+   clean submodule worktree can still hide a stash or unpushed commit:
 
    - `git -C <path> status --porcelain --ignored --untracked-files=normal`
    - `git -C <path> submodule status --recursive`
    - `git -C <path> submodule foreach --recursive 'git status
      --porcelain --ignored --untracked-files=normal; git stash list;
-     git log --all --not --remotes --oneline'`
+     git rev-list --all --not --remotes --count'`
 
    Generated output is disposable only if a configured project
    command can reproduce it. Preserve anything else first. Copy

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -392,14 +392,12 @@ Before any mutating action in F3, apply the
    format, and fallback GraphQL commands.
 3. Run from the **primary worktree**, never from inside the worktree
    being removed. Any removal (plain or `--force`) silently discards
-   ignored files too, including inside a submodule. **Before the first
-   removal attempt**, re-validate this session's claim and worktree
-   lock (`idd-claim.instructions.md`); stop if either is no longer
-   ours. Scope every inspection to `<path>`.
+   ignored files too, including inside a submodule. Scope every
+   inspection to `<path>` (or `<path>/<sub>` for a `-` submodule
+   path — parent status hides leftovers there).
 
-   Use `--untracked-files=normal` (not `all`). Inspect any `-` path
-   from `submodule status` directly (parent status hides them). A
-   clean submodule worktree can still hide a stash or unpushed commit:
+   Use `--untracked-files=normal` (not `all`). A clean submodule
+   worktree can still hide a stash or unpushed commit:
 
    - `git -C <path> status --porcelain --ignored --untracked-files=normal`
    - `git -C <path> submodule status --recursive`
@@ -411,8 +409,11 @@ Before any mutating action in F3, apply the
    command can reproduce it. Preserve anything else first. Copy
    secrets (e.g. `.env`) out only — never commit or push them.
    Non-secret work may go to a **different** ref or be copied out —
-   not to `<branch-name>` itself, which this step deletes next. Then
-   delete the worktree, then the branch:
+   not to `<branch-name>` itself, which this step deletes next.
+   Immediately before each `worktree remove`, re-validate this
+   session's claim and worktree lock (`idd-claim.instructions.md`);
+   stop if either is no longer ours.
+   Then delete the worktree, then the branch:
 
    - `git worktree remove <path>`. If it fails with `fatal: working
      trees containing submodules cannot be moved or removed`, retry


### PR DESCRIPTION
Closes #2020.

## Summary

Harden F4 step 3 in `idd-template/.github/instructions/idd-merge.instructions.md`
(and the generated mirror) so worktree removal inspects the leftover
classes Codex found on PR #2018, without crossing `bundle-merge`'s 98%
context-ceiling cap.

## Independent verification (git 2.53.0)

Not taken from the bot's 2.43.0 comments alone:

1. **Deinitialized leftovers** — after `git submodule deinit -f`, files
   written back under the path do not appear in parent
   `status --porcelain` (gitlink still owns the path) and `foreach`
   skips them. `submodule status` shows a `-` prefix. Inspect that
   path directly.
2. **Unpushed submodule refs** — an initialized submodule with a clean
   worktree can still hold a stash and a detached-HEAD commit remotes
   do not have. `git log --branches --not --remotes` misses detached
   HEAD; `git log --all --not --remotes` plus `git stash list` catch
   both.
5. **`--untracked-files=all` explosion** — 50 ignored files under
   `node_modules/` produced 51 status lines with `all` and 2 with
   `normal` (`!! node_modules/`).

## Scoping decisions (findings 3 and 4)

3. **Disposable generated output** is reviewer-facing, not a mechanical
   "any ignored path is safe to delete" rule. Treat as disposable only
   what a configured project command (for example `install-deps`) can
   reproduce.
4. **Secret-bearing ignored files** (for example `.env`) must be copied
   out only. Never commit or push them to a preservation ref. Non-secret
   work may still go to a different ref or be copied out.

## Ceiling

`bundle-merge` was 12 bytes under the 98% cap. This rewrite is a net
+10 bytes after tightening the existing F4 sentences (including a
shorter `--force` retry line). `node scripts/audit-docs.mjs --check`
passes at 98.00% (notice threshold; not over the hard cap).

## Out of this pass (budget)

The "cwd deletion breaks later steps" rationale and the explicit
"`--force` overrides dirty/untracked" parenthetical were folded into
shorter sentences rather than split into a follow-up. Findings 1, 2,
5, and 6 stay in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated worktree cleanup guidance to revalidate ownership and locks before removal.
  * Expanded cleanup checks for untracked, ignored, stashed, committed, and submodule content.
  * Clarified preservation of non-reproducible local work and safe handling of secrets.
  * Limited forced removal to specific reviewed submodule-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->