### PR TITLE
fix(merge-execute): honor F2 ack-only override at F3

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -70,10 +70,10 @@ Before any mutating action in F3, apply the
    execute `gh pr merge` in this pass.
 
    If the carried F2 evidence includes helper-side
-   `dispositionEvidence`, require `dispositionEvidence.route ==
-   "proceed"` and `dispositionEvidence.blockingCount == 0` before merge.
-   If either check fails, stop and return to E1/E4 with the reported
-   missing thread/comment disposition items. Use only the carried
+   `dispositionEvidence`, require `route == "proceed"` and
+   `blockingCount == 0` before merge, except the F2 override when
+   `soleCauseAckOnlyPostDisposition` is true. Any other missing item
+   still returns to E1/E4. Use only the carried
    `pre-merge-readiness` `dispositionEvidence` shape here; E7 verifier
    fields (`passed`, `items[]`) are not merge-gate substitutes.
 

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -164,6 +164,7 @@ unambiguous:
   same summary (see the E6 non-review-notice rule). Only a notice the
   bot replaces with an actual completed review needs a fresh
   disposition.
+- **Advisory courtesy acks**: do not re-disposition a courtesy bot ack.
 
 After E13 replies and resolutions are complete, upsert the PR live
 status digest before E14 if the next route is still review-fix or CI

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -65,10 +65,10 @@ Before any mutating action in F3, apply the
    execute `gh pr merge` in this pass.
 
    If the carried F2 evidence includes helper-side
-   `dispositionEvidence`, require `dispositionEvidence.route ==
-   "proceed"` and `dispositionEvidence.blockingCount == 0` before merge.
-   If either check fails, stop and return to E1/E4 with the reported
-   missing thread/comment disposition items. Use only the carried
+   `dispositionEvidence`, require `route == "proceed"` and
+   `blockingCount == 0` before merge, except the F2 override when
+   `soleCauseAckOnlyPostDisposition` is true. Any other missing item
+   still returns to E1/E4. Use only the carried
    `pre-merge-readiness` `dispositionEvidence` shape here; E7 verifier
    fields (`passed`, `items[]`) are not merge-gate substitutes.
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -159,6 +159,7 @@ unambiguous:
   same summary (see the E6 non-review-notice rule). Only a notice the
   bot replaces with an actual completed review needs a fresh
   disposition.
+- **Advisory courtesy acks**: do not re-disposition a courtesy bot ack.
 
 After E13 replies and resolutions are complete, upsert the PR live
 status digest before E14 if the next route is still review-fix or CI

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -4530,12 +4530,11 @@ function isPreMergeReviewSatisfied(reviewerStates) {
  * ordered blocker list. This is the single source of the merge-gate AND:
  * `buildPreMergeReadinessSummary` embeds `{ ready, blockers }` computed from it,
  * and `idd-merge-execute.evaluateMergeGates` delegates to it, so no caller
- * re-implements the conjunction. The rollup is **strict** — it reads
- * `dispositionEvidence.route === 'proceed'` directly and does NOT apply the
- * `soleCauseAckOnlyPostDisposition` override (a separate flag the F2 checklist
- * layers on top), so the fully-autonomous F3 executor keeps its fail-closed
- * behavior. A gate whose evidence is missing or garbled fails closed (recorded
- * as a blocker) rather than passing vacuously.
+ * re-implements the conjunction. Fail-closed on missing or garbled
+ * evidence. Applies the written F2 ack-only overrides (#2125) so a
+ * `fully_autonomous_merge` F3 session can complete when courtesy
+ * advisory-bot acks are the sole remaining currency or disposition
+ * blocker; any other cause still blocks.
  */
 export function computePreMergeReadinessBlockers(report) {
   const blockers = [];
@@ -4551,10 +4550,16 @@ export function computePreMergeReadinessBlockers(report) {
   }
   const reviewCurrency = preMergeAsRecord(report.reviewCurrency);
   const comparisonRoute = String(reviewCurrency.comparisonRoute ?? '');
-  if (comparisonRoute !== 'proceed') {
+  const comparisonReason = String(reviewCurrency.comparisonReason ?? '');
+  // #2125: F2's ack-only-post-disposition carve-out is now applied here
+  // too, so F3 merge-execute does not livelock on CodeRabbit courtesy acks.
+  if (
+    comparisonRoute !== 'proceed' &&
+    comparisonReason !== 'ack-only-post-disposition'
+  ) {
     blockers.push({
       gate: 'review-currency',
-      detail: `comparisonRoute is "${comparisonRoute}" (expected "proceed"): ${String(reviewCurrency.comparisonReason ?? 'unknown')}`,
+      detail: `comparisonRoute is "${comparisonRoute}" (expected "proceed"): ${comparisonReason || 'unknown'}`,
     });
   }
   const threads = preMergeAsRecord(report.threads);
@@ -4808,13 +4813,19 @@ export function computePreMergeReadinessBlockers(report) {
   }
   const dispositionEvidence = preMergeAsRecord(report.dispositionEvidence);
   // The written F2/F3 gate requires BOTH `route === 'proceed'` AND
-  // `blockingCount === 0`. Fail closed on a non-zero or non-numeric
-  // blockingCount so a missing/garbled count is treated as a blocker.
+  // `blockingCount === 0`, except the documented F2 override when
+  // `soleCauseAckOnlyPostDisposition` is exactly true (#2125). Fail
+  // closed on a non-zero or non-numeric blockingCount otherwise.
   const dispositionRoute = String(dispositionEvidence.route ?? '');
   const dispositionBlockingCount = Number(
     dispositionEvidence.blockingCount ?? -1,
   );
-  if (dispositionRoute !== 'proceed' || dispositionBlockingCount !== 0) {
+  const soleCauseAckOnlyPostDisposition =
+    dispositionEvidence.soleCauseAckOnlyPostDisposition === true;
+  if (
+    !soleCauseAckOnlyPostDisposition &&
+    (dispositionRoute !== 'proceed' || dispositionBlockingCount !== 0)
+  ) {
     blockers.push({
       gate: 'disposition-evidence',
       detail: `dispositionEvidence.route is "${dispositionRoute || 'missing'}" (expected "proceed"), blockingCount=${dispositionBlockingCount} (expected 0)`,
@@ -5250,8 +5261,8 @@ export function buildPreMergeReadinessSummary(
   }
   // Top-level rollup so a consumer reads one `ready` boolean + `blockers[]`
   // instead of hand-ANDing ~8 nested gates (a dropped clause would fail open).
-  // Strict by construction (see `computePreMergeReadinessBlockers`): the F2
-  // checklist applies the ack-only override on top of this, not inside it.
+  // Includes the F2 ack-only overrides (#2125) so a fully-autonomous F3
+  // session does not livelock on courtesy advisory-bot acks.
   const blockers = computePreMergeReadinessBlockers(summary);
   summary.ready = blockers.length === 0;
   summary.blockers = blockers;

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -4555,7 +4555,10 @@ export function computePreMergeReadinessBlockers(report) {
   // too, so F3 merge-execute does not livelock on CodeRabbit courtesy acks.
   if (
     comparisonRoute !== 'proceed' &&
-    comparisonReason !== 'ack-only-post-disposition'
+    !(
+      comparisonRoute === 'return-to-e1' &&
+      comparisonReason === 'ack-only-post-disposition'
+    )
   ) {
     blockers.push({
       gate: 'review-currency',
@@ -4821,7 +4824,10 @@ export function computePreMergeReadinessBlockers(report) {
     dispositionEvidence.blockingCount ?? -1,
   );
   const soleCauseAckOnlyPostDisposition =
-    dispositionEvidence.soleCauseAckOnlyPostDisposition === true;
+    dispositionEvidence.soleCauseAckOnlyPostDisposition === true &&
+    dispositionRoute === 'return-to-e1' &&
+    Number.isInteger(dispositionBlockingCount) &&
+    dispositionBlockingCount > 0;
   if (
     !soleCauseAckOnlyPostDisposition &&
     (dispositionRoute !== 'proceed' || dispositionBlockingCount !== 0)

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -5769,7 +5769,10 @@ export function computePreMergeReadinessBlockers(
   // too, so F3 merge-execute does not livelock on CodeRabbit courtesy acks.
   if (
     comparisonRoute !== 'proceed' &&
-    comparisonReason !== 'ack-only-post-disposition'
+    !(
+      comparisonRoute === 'return-to-e1' &&
+      comparisonReason === 'ack-only-post-disposition'
+    )
   ) {
     blockers.push({
       gate: 'review-currency',
@@ -6065,7 +6068,10 @@ export function computePreMergeReadinessBlockers(
     dispositionEvidence.blockingCount ?? -1,
   );
   const soleCauseAckOnlyPostDisposition =
-    dispositionEvidence.soleCauseAckOnlyPostDisposition === true;
+    dispositionEvidence.soleCauseAckOnlyPostDisposition === true &&
+    dispositionRoute === 'return-to-e1' &&
+    Number.isInteger(dispositionBlockingCount) &&
+    dispositionBlockingCount > 0;
   if (
     !soleCauseAckOnlyPostDisposition &&
     (dispositionRoute !== 'proceed' || dispositionBlockingCount !== 0)

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -5740,12 +5740,11 @@ function isPreMergeReviewSatisfied(
  * ordered blocker list. This is the single source of the merge-gate AND:
  * `buildPreMergeReadinessSummary` embeds `{ ready, blockers }` computed from it,
  * and `idd-merge-execute.evaluateMergeGates` delegates to it, so no caller
- * re-implements the conjunction. The rollup is **strict** — it reads
- * `dispositionEvidence.route === 'proceed'` directly and does NOT apply the
- * `soleCauseAckOnlyPostDisposition` override (a separate flag the F2 checklist
- * layers on top), so the fully-autonomous F3 executor keeps its fail-closed
- * behavior. A gate whose evidence is missing or garbled fails closed (recorded
- * as a blocker) rather than passing vacuously.
+ * re-implements the conjunction. Fail-closed on missing or garbled
+ * evidence. Applies the written F2 ack-only overrides (#2125) so a
+ * `fully_autonomous_merge` F3 session can complete when courtesy
+ * advisory-bot acks are the sole remaining currency or disposition
+ * blocker; any other cause still blocks.
  */
 export function computePreMergeReadinessBlockers(
   report: Record<string, unknown>,
@@ -5765,12 +5764,18 @@ export function computePreMergeReadinessBlockers(
 
   const reviewCurrency = preMergeAsRecord(report.reviewCurrency);
   const comparisonRoute = String(reviewCurrency.comparisonRoute ?? '');
-  if (comparisonRoute !== 'proceed') {
+  const comparisonReason = String(reviewCurrency.comparisonReason ?? '');
+  // #2125: F2's ack-only-post-disposition carve-out is now applied here
+  // too, so F3 merge-execute does not livelock on CodeRabbit courtesy acks.
+  if (
+    comparisonRoute !== 'proceed' &&
+    comparisonReason !== 'ack-only-post-disposition'
+  ) {
     blockers.push({
       gate: 'review-currency',
-      detail: `comparisonRoute is "${comparisonRoute}" (expected "proceed"): ${String(
-        reviewCurrency.comparisonReason ?? 'unknown',
-      )}`,
+      detail: `comparisonRoute is "${comparisonRoute}" (expected "proceed"): ${
+        comparisonReason || 'unknown'
+      }`,
     });
   }
 
@@ -6052,13 +6057,19 @@ export function computePreMergeReadinessBlockers(
 
   const dispositionEvidence = preMergeAsRecord(report.dispositionEvidence);
   // The written F2/F3 gate requires BOTH `route === 'proceed'` AND
-  // `blockingCount === 0`. Fail closed on a non-zero or non-numeric
-  // blockingCount so a missing/garbled count is treated as a blocker.
+  // `blockingCount === 0`, except the documented F2 override when
+  // `soleCauseAckOnlyPostDisposition` is exactly true (#2125). Fail
+  // closed on a non-zero or non-numeric blockingCount otherwise.
   const dispositionRoute = String(dispositionEvidence.route ?? '');
   const dispositionBlockingCount = Number(
     dispositionEvidence.blockingCount ?? -1,
   );
-  if (dispositionRoute !== 'proceed' || dispositionBlockingCount !== 0) {
+  const soleCauseAckOnlyPostDisposition =
+    dispositionEvidence.soleCauseAckOnlyPostDisposition === true;
+  if (
+    !soleCauseAckOnlyPostDisposition &&
+    (dispositionRoute !== 'proceed' || dispositionBlockingCount !== 0)
+  ) {
     blockers.push({
       gate: 'disposition-evidence',
       detail: `dispositionEvidence.route is "${
@@ -6659,8 +6670,8 @@ export function buildPreMergeReadinessSummary(
 
   // Top-level rollup so a consumer reads one `ready` boolean + `blockers[]`
   // instead of hand-ANDing ~8 nested gates (a dropped clause would fail open).
-  // Strict by construction (see `computePreMergeReadinessBlockers`): the F2
-  // checklist applies the ack-only override on top of this, not inside it.
+  // Includes the F2 ack-only overrides (#2125) so a fully-autonomous F3
+  // session does not livelock on courtesy advisory-bot acks.
   const blockers = computePreMergeReadinessBlockers(summary);
   summary.ready = blockers.length === 0;
   summary.blockers = blockers;

--- a/tests/idd-merge-execute.test.mts
+++ b/tests/idd-merge-execute.test.mts
@@ -269,6 +269,47 @@ test('disposition-evidence blocks when route is proceed but blockingCount is non
   assert.equal(exitCode, 1);
 });
 
+test('soleCauseAckOnlyPostDisposition does not add a disposition-evidence blocker (#2125)', () => {
+  const report = readyReport();
+  report.dispositionEvidence = {
+    route: 'return-to-e1',
+    blockingCount: 2,
+    soleCauseAckOnlyPostDisposition: true,
+  };
+  assert.deepEqual(evaluateMergeGates(report), []);
+  const { deps } = depsFor(report);
+  const { verdict, exitCode } = runMergeExecute(BASE_ARGS, deps);
+  assert.equal(verdict.ready, true);
+  assert.equal(exitCode, 0);
+});
+
+test('ack-only-post-disposition review-currency does not add a review-currency blocker (#2125)', () => {
+  const report = readyReport();
+  report.reviewCurrency = {
+    comparisonRoute: 'return-to-e1',
+    comparisonReason: 'ack-only-post-disposition',
+  };
+  assert.deepEqual(evaluateMergeGates(report), []);
+});
+
+test('ack-only override stays fail-closed when mixed with a non-ack disposition gap (#2125)', () => {
+  const report = readyReport();
+  report.reviewCurrency = {
+    comparisonRoute: 'return-to-e1',
+    comparisonReason: 'ack-only-post-disposition',
+  };
+  report.dispositionEvidence = {
+    route: 'return-to-e1',
+    blockingCount: 1,
+    soleCauseAckOnlyPostDisposition: false,
+  };
+  const blockers = evaluateMergeGates(report);
+  assert.deepEqual(
+    blockers.map((b) => b.gate),
+    ['disposition-evidence'],
+  );
+});
+
 test('CI all-passing accepts the no-required-checks fallback', () => {
   const report = readyReport();
   report.ci = {

--- a/tests/idd-merge-execute.test.mts
+++ b/tests/idd-merge-execute.test.mts
@@ -292,6 +292,33 @@ test('ack-only-post-disposition review-currency does not add a review-currency b
   assert.deepEqual(evaluateMergeGates(report), []);
 });
 
+test('soleCauseAckOnly flag does not override garbled disposition route or count (#2125)', () => {
+  const report = readyReport();
+  report.dispositionEvidence = {
+    route: '',
+    blockingCount: 'nope',
+    soleCauseAckOnlyPostDisposition: true,
+  };
+  const blockers = evaluateMergeGates(report);
+  assert.deepEqual(
+    blockers.map((b) => b.gate),
+    ['disposition-evidence'],
+  );
+});
+
+test('garbled review-currency route still blocks even with an ack-only reason (#2125)', () => {
+  const report = readyReport();
+  report.reviewCurrency = {
+    comparisonRoute: '',
+    comparisonReason: 'ack-only-post-disposition',
+  };
+  const blockers = evaluateMergeGates(report);
+  assert.deepEqual(
+    blockers.map((b) => b.gate),
+    ['review-currency'],
+  );
+});
+
 test('ack-only override stays fail-closed when mixed with a non-ack disposition gap (#2125)', () => {
   const report = readyReport();
   report.reviewCurrency = {


### PR DESCRIPTION
Closes #2125.

## Summary

`computePreMergeReadinessBlockers` now applies the documented F2
ack-only overrides so a `fully_autonomous_merge` F3 session can merge
when CodeRabbit courtesy acks are the only remaining currency or
disposition blocker. Other missing comments or non-ack threads still
fail closed.

F3's checklist matches that override. E13 forbids re-disposition of
courtesy acks.

## Test plan

- `node --test tests/idd-merge-execute.test.mts`
- `node scripts/audit-docs.mjs --check`

Refs #2020, PR #2123. Extends #978.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fully autonomous merges can proceed when advisory courtesy acknowledgements are the sole remaining blockers.
  * Merge readiness continues to block when other review or disposition conditions remain unresolved.
* **Bug Fixes**
  * Improved handling of disposition evidence and acknowledgement-only exceptions.
  * Missing or invalid evidence continues routing to the appropriate remediation steps.
* **Tests**
  * Added coverage for acknowledgement-only and mixed-blocker scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->