### PR TITLE
fix(merge-execute): treat BLOCKED discarded check siblings as a gate

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1656,16 +1656,16 @@ reflexively as any other CLI option.
   `CANCELLED` bot-triggered instance sitting alongside the `SUCCESS`
   instance the dedup selected as "latest", the live PR #1741 divergence
   where `ci.status: "success"` disagreed with GitHub's own
-  `statusCheckRollup.state: "FAILURE"` for the same commit. Evidence only
-  (empty array, never omitted, when nothing was discarded) when GitHub's
-  live `mergeStateStatus` is not `BLOCKED`. A non-empty list is always a
-  prompt to double-check the live GitHub rollup rather than trusting a
-  bare `ci.status: "success"`. Combined with live
+  `statusCheckRollup.state: "FAILURE"` for the same commit. Always
+  emitted (empty array, never omitted, when nothing was discarded). A
+  non-empty list does not by itself gate F2/F3; it is a prompt to
+  double-check the live GitHub rollup rather than trusting a bare
+  `ci.status: "success"`. Combined with live
   `mergeStateStatus: "BLOCKED"` it is also a
-  `discarded-required-check-siblings` merge-gate blocker (#2127): recover
-  via `rerun-advisory-convergence`, do not merge or `--admin`. An empty
-  or absent list never fires that gate, so a CODEOWNER-only `BLOCKED`
-  path is unchanged.
+  `discarded-required-check-siblings` merge-gate blocker (#2127):
+  recover via `rerun-advisory-convergence`, do not merge or `--admin`.
+  An empty or absent list never fires that gate, so a CODEOWNER-only
+  `BLOCKED` path is unchanged.
 - `ci.sourcePinnedRequiredCheckNames` (#1689) lists the required check
   names whose green state was downgraded to `ci.status: "unknown"` because
   their ruleset/classic-protection entry is source-pinned

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1657,9 +1657,15 @@ reflexively as any other CLI option.
   instance the dedup selected as "latest", the live PR #1741 divergence
   where `ci.status: "success"` disagreed with GitHub's own
   `statusCheckRollup.state: "FAILURE"` for the same commit. Evidence only
-  (empty array, never omitted, when nothing was discarded) -- it does not
-  itself gate F2/F3; a non-empty list is a prompt to double-check the live
-  GitHub rollup directly rather than trusting a bare `ci.status: "success"`.
+  (empty array, never omitted, when nothing was discarded) when GitHub's
+  live `mergeStateStatus` is not `BLOCKED`. A non-empty list is always a
+  prompt to double-check the live GitHub rollup rather than trusting a
+  bare `ci.status: "success"`. Combined with live
+  `mergeStateStatus: "BLOCKED"` it is also a
+  `discarded-required-check-siblings` merge-gate blocker (#2127): recover
+  via `rerun-advisory-convergence`, do not merge or `--admin`. An empty
+  or absent list never fires that gate, so a CODEOWNER-only `BLOCKED`
+  path is unchanged.
 - `ci.sourcePinnedRequiredCheckNames` (#1689) lists the required check
   names whose green state was downgraded to `ci.status: "unknown"` because
   their ruleset/classic-protection entry is source-pinned
@@ -1765,6 +1771,9 @@ reflexively as any other CLI option.
   live `mergeStateStatus: "BEHIND"` paired with a confirmed-or-assumed
   `branchCurrency.requiresUpToDateHead: true` fails closed as a
   `branch-currency` blocker before `--apply` ever calls `gh pr merge`).
+  A live `mergeStateStatus: "BLOCKED"` paired with a non-empty
+  `ci.discardedNonPassingRequiredChecks` list is a
+  `discarded-required-check-siblings` blocker (#2127).
   Each failing gate is listed in `blockers[]`
   as `{ gate, detail }`.
 - Dry-run (default) is read-only: it prints `ready`, `blockers`, and

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1656,16 +1656,16 @@ reflexively as any other CLI option.
   `CANCELLED` bot-triggered instance sitting alongside the `SUCCESS`
   instance the dedup selected as "latest", the live PR #1741 divergence
   where `ci.status: "success"` disagreed with GitHub's own
-  `statusCheckRollup.state: "FAILURE"` for the same commit. Evidence only
-  (empty array, never omitted, when nothing was discarded) when GitHub's
-  live `mergeStateStatus` is not `BLOCKED`. A non-empty list is always a
-  prompt to double-check the live GitHub rollup rather than trusting a
-  bare `ci.status: "success"`. Combined with live
+  `statusCheckRollup.state: "FAILURE"` for the same commit. Always
+  emitted (empty array, never omitted, when nothing was discarded). A
+  non-empty list does not by itself gate F2/F3; it is a prompt to
+  double-check the live GitHub rollup rather than trusting a bare
+  `ci.status: "success"`. Combined with live
   `mergeStateStatus: "BLOCKED"` it is also a
-  `discarded-required-check-siblings` merge-gate blocker (#2127): recover
-  via `rerun-advisory-convergence`, do not merge or `--admin`. An empty
-  or absent list never fires that gate, so a CODEOWNER-only `BLOCKED`
-  path is unchanged.
+  `discarded-required-check-siblings` merge-gate blocker (#2127):
+  recover via `rerun-advisory-convergence`, do not merge or `--admin`.
+  An empty or absent list never fires that gate, so a CODEOWNER-only
+  `BLOCKED` path is unchanged.
 - `ci.sourcePinnedRequiredCheckNames` (#1689) lists the required check
   names whose green state was downgraded to `ci.status: "unknown"` because
   their ruleset/classic-protection entry is source-pinned

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1657,9 +1657,15 @@ reflexively as any other CLI option.
   instance the dedup selected as "latest", the live PR #1741 divergence
   where `ci.status: "success"` disagreed with GitHub's own
   `statusCheckRollup.state: "FAILURE"` for the same commit. Evidence only
-  (empty array, never omitted, when nothing was discarded) -- it does not
-  itself gate F2/F3; a non-empty list is a prompt to double-check the live
-  GitHub rollup directly rather than trusting a bare `ci.status: "success"`.
+  (empty array, never omitted, when nothing was discarded) when GitHub's
+  live `mergeStateStatus` is not `BLOCKED`. A non-empty list is always a
+  prompt to double-check the live GitHub rollup rather than trusting a
+  bare `ci.status: "success"`. Combined with live
+  `mergeStateStatus: "BLOCKED"` it is also a
+  `discarded-required-check-siblings` merge-gate blocker (#2127): recover
+  via `rerun-advisory-convergence`, do not merge or `--admin`. An empty
+  or absent list never fires that gate, so a CODEOWNER-only `BLOCKED`
+  path is unchanged.
 - `ci.sourcePinnedRequiredCheckNames` (#1689) lists the required check
   names whose green state was downgraded to `ci.status: "unknown"` because
   their ruleset/classic-protection entry is source-pinned
@@ -1765,6 +1771,9 @@ reflexively as any other CLI option.
   live `mergeStateStatus: "BEHIND"` paired with a confirmed-or-assumed
   `branchCurrency.requiresUpToDateHead: true` fails closed as a
   `branch-currency` blocker before `--apply` ever calls `gh pr merge`).
+  A live `mergeStateStatus: "BLOCKED"` paired with a non-empty
+  `ci.discardedNonPassingRequiredChecks` list is a
+  `discarded-required-check-siblings` blocker (#2127).
   Each failing gate is listed in `blockers[]`
   as `{ gate, detail }`.
 - Dry-run (default) is read-only: it prints `ready`, `blockers`, and

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -4534,7 +4534,9 @@ function isPreMergeReviewSatisfied(reviewerStates) {
  * evidence. Applies the written F2 ack-only overrides (#2125) so a
  * `fully_autonomous_merge` F3 session can complete when courtesy
  * advisory-bot acks are the sole remaining currency or disposition
- * blocker; any other cause still blocks.
+ * blocker; any other cause still blocks. A live `BLOCKED` merge state
+ * plus a non-empty discarded required-check sibling list is its own
+ * gate (#2127) and does not take the `--admin` path.
  */
 export function computePreMergeReadinessBlockers(report) {
   const blockers = [];
@@ -4855,6 +4857,22 @@ export function computePreMergeReadinessBlockers(report) {
     blockers.push({
       gate: 'branch-currency',
       detail: `mergeStateStatus is "BEHIND" and the base branch requires an up-to-date head before merge (requiresUpToDateHeadSource="${String(branchCurrency.requiresUpToDateHeadSource ?? 'unknown')}")`,
+    });
+  }
+  // #2127: discarded same-named required-check siblings stay evidence-only
+  // while GitHub is CLEAN/BEHIND (#1745). Combined with live BLOCKED they
+  // are the Rulesets all-instances split (helper latest-wins is green,
+  // GitHub still refuses merge). A non-array or missing list is treated
+  // as absent so a CODEOWNER-only BLOCKED path (#1663) stays silent here.
+  const discardedSiblings = ci.discardedNonPassingRequiredChecks;
+  if (
+    mergeStateStatus === 'BLOCKED' &&
+    Array.isArray(discardedSiblings) &&
+    discardedSiblings.length > 0
+  ) {
+    blockers.push({
+      gate: 'discarded-required-check-siblings',
+      detail: `mergeStateStatus is "BLOCKED" and ci.discardedNonPassingRequiredChecks has ${String(discardedSiblings.length)} discarded same-named required-check sibling(s); recover via rerun-advisory-convergence, do not merge or --admin`,
     });
   }
   return blockers;

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -5744,7 +5744,9 @@ function isPreMergeReviewSatisfied(
  * evidence. Applies the written F2 ack-only overrides (#2125) so a
  * `fully_autonomous_merge` F3 session can complete when courtesy
  * advisory-bot acks are the sole remaining currency or disposition
- * blocker; any other cause still blocks.
+ * blocker; any other cause still blocks. A live `BLOCKED` merge state
+ * plus a non-empty discarded required-check sibling list is its own
+ * gate (#2127) and does not take the `--admin` path.
  */
 export function computePreMergeReadinessBlockers(
   report: Record<string, unknown>,
@@ -6104,6 +6106,25 @@ export function computePreMergeReadinessBlockers(
       detail: `mergeStateStatus is "BEHIND" and the base branch requires an up-to-date head before merge (requiresUpToDateHeadSource="${String(
         branchCurrency.requiresUpToDateHeadSource ?? 'unknown',
       )}")`,
+    });
+  }
+
+  // #2127: discarded same-named required-check siblings stay evidence-only
+  // while GitHub is CLEAN/BEHIND (#1745). Combined with live BLOCKED they
+  // are the Rulesets all-instances split (helper latest-wins is green,
+  // GitHub still refuses merge). A non-array or missing list is treated
+  // as absent so a CODEOWNER-only BLOCKED path (#1663) stays silent here.
+  const discardedSiblings = ci.discardedNonPassingRequiredChecks;
+  if (
+    mergeStateStatus === 'BLOCKED' &&
+    Array.isArray(discardedSiblings) &&
+    discardedSiblings.length > 0
+  ) {
+    blockers.push({
+      gate: 'discarded-required-check-siblings',
+      detail: `mergeStateStatus is "BLOCKED" and ci.discardedNonPassingRequiredChecks has ${String(
+        discardedSiblings.length,
+      )} discarded same-named required-check sibling(s); recover via rerun-advisory-convergence, do not merge or --admin`,
     });
   }
 

--- a/tests/idd-merge-execute.test.mts
+++ b/tests/idd-merge-execute.test.mts
@@ -27,6 +27,7 @@ function readyReport(): Record<string, unknown> {
       requiredChecksPassing: true,
       noRequiredChecksConfigured: false,
       presentRunConclusion: 'all-passing',
+      discardedNonPassingRequiredChecks: [],
     },
     reviewerStates: {
       requiredApprovalsSatisfied: true,
@@ -317,6 +318,66 @@ test('garbled review-currency route still blocks even with an ack-only reason (#
     blockers.map((b) => b.gate),
     ['review-currency'],
   );
+});
+
+test('BLOCKED + discarded required-check siblings is a dedicated merge-gate (#2127)', () => {
+  const report = readyReport();
+  report.branchCurrency = {
+    ...(report.branchCurrency as Record<string, unknown>),
+    mergeStateStatus: 'BLOCKED',
+  };
+  report.ci = {
+    ...(report.ci as Record<string, unknown>),
+    discardedNonPassingRequiredChecks: [
+      { name: 'idd-advisory-convergence', discardedState: 'CANCELLED' },
+    ],
+  };
+  const blockers = evaluateMergeGates(report);
+  assert.deepEqual(
+    blockers.map((blocker) => blocker.gate),
+    ['discarded-required-check-siblings'],
+  );
+  assert.match(blockers[0]?.detail ?? '', /BLOCKED/);
+  const { deps, calls } = depsFor(report);
+  const { verdict, exitCode } = runMergeExecute(
+    [...BASE_ARGS, '--apply'],
+    deps,
+  );
+  assert.equal(verdict.ready, false);
+  assert.equal(verdict.merged, false);
+  assert.deepEqual(calls.merged, []);
+  assert.deepEqual(calls.adminMerged, []);
+  assert.equal(exitCode, 1);
+});
+
+test('CLEAN + discarded required-check siblings stays evidence-only (#2127)', () => {
+  const report = readyReport();
+  report.ci = {
+    ...(report.ci as Record<string, unknown>),
+    discardedNonPassingRequiredChecks: [
+      { name: 'idd-advisory-convergence', discardedState: 'CANCELLED' },
+    ],
+  };
+  assert.deepEqual(evaluateMergeGates(report), []);
+});
+
+test('BLOCKED with an empty or absent discarded-sibling list does not fire #2127', () => {
+  const empty = readyReport();
+  empty.branchCurrency = {
+    ...(empty.branchCurrency as Record<string, unknown>),
+    mergeStateStatus: 'BLOCKED',
+  };
+  assert.deepEqual(evaluateMergeGates(empty), []);
+
+  const absent = readyReport();
+  absent.branchCurrency = {
+    ...(absent.branchCurrency as Record<string, unknown>),
+    mergeStateStatus: 'BLOCKED',
+  };
+  const ci = { ...(absent.ci as Record<string, unknown>) };
+  delete ci.discardedNonPassingRequiredChecks;
+  absent.ci = ci;
+  assert.deepEqual(evaluateMergeGates(absent), []);
 });
 
 test('ack-only override stays fail-closed when mixed with a non-ack disposition gap (#2125)', () => {


### PR DESCRIPTION
## Summary

Closes #2127.

`computePreMergeReadinessBlockers` now emits `discarded-required-check-siblings` when live `mergeStateStatus` is `BLOCKED` **and** `ci.discardedNonPassingRequiredChecks` is a non-empty array. `idd-merge-execute --apply` therefore does not call `gh pr merge` or `--admin` on that split.

CLEAN + discarded siblings stays evidence-only (#1745). BLOCKED with an empty or absent list stays silent so the CODEOWNER-only path (#1663) is unchanged. Helper-scripts docs name the conjunction.

No F3 instruction edit: `bundle-merge` is already at 97.95% of its 98% ceiling.

## Test plan

- [x] `node --test tests/idd-merge-execute.test.mts` (52 pass, including the three #2127 cases)
- [x] `node --test tests/pre-merge-readiness.test.mts` (260 pass)
- [x] `pnpm run build`
- [x] `node scripts/audit-docs.mjs --check`
- [x] lint on the touched files

Signing: configured GPG hit pinentry ioctl (category P); commit used `git commit-ssh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a merge blocker when GitHub reports a blocked state with discarded, non-passing required-check siblings.
  * Prevented normal and administrator merges while this blocker is active.
  * Preserved existing behavior for clean states and when sibling evidence is empty or unavailable.
  * Allowed the F2 acknowledgment-only review-currency override.

* **Documentation**
  * Documented recovery by rerunning advisory convergence; merging or using administrator overrides is not permitted.

* **Tests**
  * Added coverage for blocked, clean, empty-list, and absent-list scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->