### PR TITLE
chore(lint): adopt shared @kurone-kito/markdownlint-config

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,24 +1,7 @@
-default: true
+extends: '@kurone-kito/markdownlint-config'
 # Allow non-aligned table columns. Tables with long cell content are
 # impractical to keep aligned without breaking readability.
 table-column-style: false
-# Allow limit breakthroughs in the code block and table row lengths. The
-# default is unconditional prohibition. It is exceptionally allowed in
-# these elements due to folding difficulties.
-line-length:
-  code_blocks: false
-  headings: false
-  tables: false
-# Allows the use of duplicate headings. The default is unconditional
-# prohibition. Due to the `siblings_only` flag not working, it is necessary
-# to enable duplicate headings in the entire document.
-no-duplicate-heading: false
-# Allows embedding of the specified HTML tag. The default is unconditional
-# prohibition. Allow for some valuable features, such as folding.
-no-inline-html:
-  allowed_elements:
-    - details
-    - summary
 # Stop MD025 from treating an OKF frontmatter `title:` field as a second
 # level-1 heading alongside the page's own `# H1`. The default pattern
 # (`^\s*title\s*[:=]`) matches both, firing

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -830,13 +830,6 @@
         "Roadmap-audit claims are coordination-only.",
         "heartbeat, release, or take over rather than holding the claim open."
       ]
-    },
-    {
-      "id": "root-markdownlint-config",
-      "_comment": "idd-template/ is the canonical source; edit it first, then `sync-docs.mjs --apply` regenerates the target -- idd-skill#1860's twist is only that the generated target is this repo's own root config, which also governs this repo's own CI, not a docs/ mirror. The #1765 uncommitted-local-edit guard protects a maintainer who fixes the root file directly without touching the template first. Unlike `.cspell.config.yml` (idd-skill#1974: root adopted an import-based `@kurone-kito/cspell-config` base, which would break ONBOARDING.md's self-contained-template guarantee if mirrored into idd-template/, so that pair was removed and the root file now diverges from its template independently), this pair still holds because both sides stay hand-declared with no import dependency.",
-      "source": "idd-template/.markdownlint.yml",
-      "target": ".markdownlint.yml",
-      "mode": "exact"
     }
   ],
   "forbiddenPatterns": [

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@commitlint/config-conventional": "^21.0.0",
     "@kurone-kito/biome-config": "0.22.0",
     "@kurone-kito/cspell-config": "0.22.0",
+    "@kurone-kito/markdownlint-config": "0.22.0",
     "@types/node": "26.1.2",
     "cspell": "^10.0.0",
     "dprint": "0.55.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       '@kurone-kito/cspell-config':
         specifier: 0.22.0
         version: 0.22.0(cspell@10.0.1)
+      '@kurone-kito/markdownlint-config':
+        specifier: 0.22.0
+        version: 0.22.0
       '@types/node':
         specifier: 26.1.2
         version: 26.1.2
@@ -556,6 +559,10 @@ packages:
     peerDependenciesMeta:
       cspell:
         optional: true
+
+  '@kurone-kito/markdownlint-config@0.22.0':
+    resolution: {integrity: sha512-eldayG/vr7tXDfbQczUwRr6YsR6Zlm/PS85ix7BL3MQjUTi6dP79zY/bq4usZ+bWPBIHswTBRSwpUOTax8gKiA==}
+    engines: {node: ^20.11 || ^22 || >=24}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1789,6 +1796,8 @@ snapshots:
   '@kurone-kito/cspell-config@0.22.0(cspell@10.0.1)':
     optionalDependencies:
       cspell: 10.0.1
+
+  '@kurone-kito/markdownlint-config@0.22.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Adopt `@kurone-kito/markdownlint-config@0.22.0` as the root markdownlint
base, keep the two local overrides, and drop the exact sync pair so
`idd-template/.markdownlint.yml` stays self-contained for onboarding.

## Linked issue

Closes #1977

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

#1977 originally proposed editing only the root config. Mid-implementation
it hit the `root-markdownlint-config` exact sync pair: mirroring
`extends: '@kurone-kito/markdownlint-config'` into the shipped template
would add an undisclosed personal-package prerequisite for every adopter.

The sibling #1974 / PR #2003 already settled that architecture call for
cspell: root imports the personal package; the template stays
self-contained; the exact sync pair is removed. The recorded option-2
decision on #1977 applies the same shape here.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

Lint parity: `markdownlint-cli2` reports 0 findings on 161 files before
and after. `idd-template/.markdownlint.yml` is unchanged.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed