### PR TITLE
fix(resume): fail closed on cold-recovery nonce collisions

### DIFF
--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -140,7 +140,9 @@ authoritative replacement:
 - `state: stale` + `action: takeover` → stale-claim takeover route.
 - `state: non_inheritable` + `action: stop` → active non-stale claim
   stop route.
-- `state: disputed` + `action: stop` → contested-claim stop route.
+- `state: disputed` + `action: stop` → contested-claim stop route
+  (`cold-recovery-activation-nonce-collision`: no local nonce and 2+
+  trusted activation-nonce markers — #1529).
 
 If helper runtime is absent, helper output is invalid, or helper evidence
 disagrees with live GitHub state, use the written table below and treat

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -236,9 +236,10 @@ exercises. Beyond the AC's letter, `evaluateResumeClaimRouting`
 unit-tested, anticipating Resume Step 1 wiring — but the documented Resume
 Step 1 invocation (`idd-resume.instructions.md`) never threads either flag
 through, and a resumed process has no local memory of which nonce was its
-own to compare against in the first place. That cold-recovery design
-(kurone-kito/idd-skill#1529) is a natural fast-follow (the same shared
-parse/render primitives already support it) — not a silent design gap.
+own to compare against in the first place. Cold recovery
+(kurone-kito/idd-skill#1529) now fail-closes: a resume that holds no
+local nonce treats 2+ trusted activation-nonce markers for the active
+claim-id as `disputed`/`stop` rather than guessing an owner.
 The merge write-gate half landed separately: `summarizeClaimValidation`
 (`protocol-helpers.mts`) now shares the same `findActivationNonceWinner`
 primitive via `pre-merge-readiness.mjs`'s `--nonce` flag

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -135,7 +135,9 @@ authoritative replacement:
 - `state: stale` + `action: takeover` → stale-claim takeover route.
 - `state: non_inheritable` + `action: stop` → active non-stale claim
   stop route.
-- `state: disputed` + `action: stop` → contested-claim stop route.
+- `state: disputed` + `action: stop` → contested-claim stop route
+  (`cold-recovery-activation-nonce-collision`: no local nonce and 2+
+  trusted activation-nonce markers — #1529).
 
 If helper runtime is absent, helper output is invalid, or helper evidence
 disagrees with live GitHub state, use the written table below and treat

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -237,9 +237,10 @@ exercises. Beyond the AC's letter, `evaluateResumeClaimRouting`
 unit-tested, anticipating Resume Step 1 wiring — but the documented Resume
 Step 1 invocation (`idd-resume.instructions.md`) never threads either flag
 through, and a resumed process has no local memory of which nonce was its
-own to compare against in the first place. That cold-recovery design
-(kurone-kito/idd-skill#1529) is a natural fast-follow (the same shared
-parse/render primitives already support it) — not a silent design gap.
+own to compare against in the first place. Cold recovery
+(kurone-kito/idd-skill#1529) now fail-closes: a resume that holds no
+local nonce treats 2+ trusted activation-nonce markers for the active
+claim-id as `disputed`/`stop` rather than guessing an owner.
 The merge write-gate half landed separately: `summarizeClaimValidation`
 (`protocol-helpers.mts`) now shares the same `findActivationNonceWinner`
 primitive via `pre-merge-readiness.mjs`'s `--nonce` flag

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -250,6 +250,8 @@ export function parseActivationNonceComment(body, createdAt) {
  * matching `activation-nonce` marker exists -- callers must treat that as
  * "no comparison possible," not a mismatch (#1522 AC3).
  */
+/** Sorted activation-nonce values in `events` for `claimId`. Empty when
+ * none match. `events` must already be trust-filtered. */
 export function listActivationNonces(events, claimId) {
   return events
     .map((event) =>

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -250,14 +250,17 @@ export function parseActivationNonceComment(body, createdAt) {
  * matching `activation-nonce` marker exists -- callers must treat that as
  * "no comparison possible," not a mismatch (#1522 AC3).
  */
-export function findActivationNonceWinner(events, claimId) {
-  const nonces = events
+export function listActivationNonces(events, claimId) {
+  return events
     .map((event) =>
       parseActivationNonceComment(event.body ?? '', event.createdAt ?? ''),
     )
     .filter((marker) => Boolean(marker) && marker?.claimId === claimId)
     .map((marker) => marker.nonce)
     .sort();
+}
+export function findActivationNonceWinner(events, claimId) {
+  const nonces = listActivationNonces(events, claimId);
   return nonces.length > 0 ? nonces[0] : null;
 }
 export function parseReleaseComment(body) {

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -8,11 +8,11 @@ import { parseCliArgs } from './cli-args.mjs';
 import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mjs';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
 import { loadPolicyConfig } from './idd-config.mjs';
+import { listActivationNonces } from './marker-helpers.mjs';
 import { normalizePolicyConfig } from './policy-helpers.mjs';
 import {
   buildForcedHandoffEnableGate,
   DEFAULT_STALE_AGE_MS,
-  findActivationNonceWinner,
   isStaleByAge,
   normalizeLinkedPrReference,
   parseClaimComment,
@@ -105,9 +105,11 @@ export function evaluateResumeClaimRouting(input, options = {}) {
   const laterCompetingClaim = state.activeClaim
     ? findLaterCompetingClaim(events, state.activeClaim)
     : null;
-  const activationNonceWinner = state.activeClaim
-    ? findActivationNonceWinner(events, state.activeClaim.claimId)
-    : null;
+  const activationNonces = state.activeClaim
+    ? listActivationNonces(events, state.activeClaim.claimId)
+    : [];
+  const activationNonceWinner =
+    activationNonces.length > 0 ? activationNonces[0] : null;
   const nonceChecked = normalizeToken(input.nonce);
   const warnings = [...state.warnings];
   let routeState = 'unclaimed';
@@ -173,6 +175,13 @@ export function evaluateResumeClaimRouting(input, options = {}) {
       routeState = 'disputed';
       action = 'stop';
       reason = 'activation-nonce-mismatch';
+    } else if (!nonceChecked && activationNonces.length >= 2) {
+      // #1529: a cold resume has no local nonce. Two or more trusted
+      // activation-nonce markers for this claim-id cannot identify a unique
+      // owner (`agent-id` is shared across concurrent same-type sessions).
+      routeState = 'disputed';
+      action = 'stop';
+      reason = 'cold-recovery-activation-nonce-collision';
     } else {
       routeState = 'already_owned';
       action = 'keep';
@@ -234,6 +243,7 @@ export function evaluateResumeClaimRouting(input, options = {}) {
       same_second_contenders: sameSecondContenders,
       later_competing_claim: laterCompetingClaim,
       activation_nonce_winner: activationNonceWinner,
+      activation_nonce_count: activationNonces.length,
     },
   };
 }
@@ -708,9 +718,11 @@ function printHelp() {
                       earliest nonce among however many were posted). A
                       mismatch means a second, independent session activated
                       the identical claim-id -- routes to "disputed" the same
-                      as a later-competing-claim loss. Omit --nonce, or leave
-                      the claim-id's nonce not posted, to skip the comparison
-                      (unchanged pre-#1522 behavior).
+                      as a later-competing-claim loss. Omit --nonce when
+                      the claim-id has 0 or 1 trusted nonce to skip the
+                      comparison. Omit --nonce when 2+ trusted nonces exist
+                      and this session has no local nonce: route to
+                      disputed/stop (cold-recovery collision, #1529).
 
 Output (selected fields; the JSON also carries repository / issue / policy /
 warnings / evidence):

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -176,9 +176,9 @@ export function evaluateResumeClaimRouting(input, options = {}) {
       action = 'stop';
       reason = 'activation-nonce-mismatch';
     } else if (!nonceChecked && activationNonces.length >= 2) {
-      // #1529: a cold resume has no local nonce. Two or more trusted
-      // activation-nonce markers for this claim-id cannot identify a unique
-      // owner (`agent-id` is shared across concurrent same-type sessions).
+      // #1529: omitting --nonce is no longer a full opt-out once 2+
+      // trusted activation-nonce markers exist. A cold resume cannot tell
+      // which marker is its own (`agent-id` is shared), so fail closed.
       routeState = 'disputed';
       action = 'stop';
       reason = 'cold-recovery-activation-nonce-collision';

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -436,6 +436,8 @@ export interface NonceEventLike {
  * matching `activation-nonce` marker exists -- callers must treat that as
  * "no comparison possible," not a mismatch (#1522 AC3).
  */
+/** Sorted activation-nonce values in `events` for `claimId`. Empty when
+ * none match. `events` must already be trust-filtered. */
 export function listActivationNonces(
   events: NonceEventLike[],
   claimId: string,

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -436,11 +436,11 @@ export interface NonceEventLike {
  * matching `activation-nonce` marker exists -- callers must treat that as
  * "no comparison possible," not a mismatch (#1522 AC3).
  */
-export function findActivationNonceWinner(
+export function listActivationNonces(
   events: NonceEventLike[],
   claimId: string,
-): string | null {
-  const nonces = events
+): string[] {
+  return events
     .map((event) =>
       parseActivationNonceComment(event.body ?? '', event.createdAt ?? ''),
     )
@@ -450,6 +450,13 @@ export function findActivationNonceWinner(
     )
     .map((marker) => marker.nonce)
     .sort();
+}
+
+export function findActivationNonceWinner(
+  events: NonceEventLike[],
+  claimId: string,
+): string | null {
+  const nonces = listActivationNonces(events, claimId);
   return nonces.length > 0 ? nonces[0] : null;
 }
 

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -10,6 +10,7 @@ import type { CollaboratorPermissionCache } from './collaborator-permission.mts'
 import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mts';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mts';
 import { loadPolicyConfig } from './idd-config.mts';
+import { listActivationNonces } from './marker-helpers.mts';
 import { normalizePolicyConfig } from './policy-helpers.mts';
 import type {
   ParsedClaimMarker,
@@ -18,7 +19,6 @@ import type {
 import {
   buildForcedHandoffEnableGate,
   DEFAULT_STALE_AGE_MS,
-  findActivationNonceWinner,
   isStaleByAge,
   normalizeLinkedPrReference,
   parseClaimComment,
@@ -211,9 +211,11 @@ export function evaluateResumeClaimRouting(
   const laterCompetingClaim = state.activeClaim
     ? findLaterCompetingClaim(events, state.activeClaim)
     : null;
-  const activationNonceWinner = state.activeClaim
-    ? findActivationNonceWinner(events, state.activeClaim.claimId)
-    : null;
+  const activationNonces = state.activeClaim
+    ? listActivationNonces(events, state.activeClaim.claimId)
+    : [];
+  const activationNonceWinner =
+    activationNonces.length > 0 ? activationNonces[0] : null;
   const nonceChecked = normalizeToken(input.nonce);
 
   const warnings = [...state.warnings];
@@ -281,6 +283,13 @@ export function evaluateResumeClaimRouting(
       routeState = 'disputed';
       action = 'stop';
       reason = 'activation-nonce-mismatch';
+    } else if (!nonceChecked && activationNonces.length >= 2) {
+      // #1529: a cold resume has no local nonce. Two or more trusted
+      // activation-nonce markers for this claim-id cannot identify a unique
+      // owner (`agent-id` is shared across concurrent same-type sessions).
+      routeState = 'disputed';
+      action = 'stop';
+      reason = 'cold-recovery-activation-nonce-collision';
     } else {
       routeState = 'already_owned';
       action = 'keep';
@@ -343,6 +352,7 @@ export function evaluateResumeClaimRouting(
       same_second_contenders: sameSecondContenders,
       later_competing_claim: laterCompetingClaim,
       activation_nonce_winner: activationNonceWinner,
+      activation_nonce_count: activationNonces.length,
     },
   };
 }
@@ -921,9 +931,11 @@ function printHelp(): void {
                       earliest nonce among however many were posted). A
                       mismatch means a second, independent session activated
                       the identical claim-id -- routes to "disputed" the same
-                      as a later-competing-claim loss. Omit --nonce, or leave
-                      the claim-id's nonce not posted, to skip the comparison
-                      (unchanged pre-#1522 behavior).
+                      as a later-competing-claim loss. Omit --nonce when
+                      the claim-id has 0 or 1 trusted nonce to skip the
+                      comparison. Omit --nonce when 2+ trusted nonces exist
+                      and this session has no local nonce: route to
+                      disputed/stop (cold-recovery collision, #1529).
 
 Output (selected fields; the JSON also carries repository / issue / policy /
 warnings / evidence):

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -284,9 +284,9 @@ export function evaluateResumeClaimRouting(
       action = 'stop';
       reason = 'activation-nonce-mismatch';
     } else if (!nonceChecked && activationNonces.length >= 2) {
-      // #1529: a cold resume has no local nonce. Two or more trusted
-      // activation-nonce markers for this claim-id cannot identify a unique
-      // owner (`agent-id` is shared across concurrent same-type sessions).
+      // #1529: omitting --nonce is no longer a full opt-out once 2+
+      // trusted activation-nonce markers exist. A cold resume cannot tell
+      // which marker is its own (`agent-id` is shared), so fail closed.
       routeState = 'disputed';
       action = 'stop';
       reason = 'cold-recovery-activation-nonce-collision';

--- a/tests/resume-claim-routing.test.mts
+++ b/tests/resume-claim-routing.test.mts
@@ -146,7 +146,7 @@ test('activation-nonce: no posted nonce marker skips the comparison (AC3 backwar
   assert.equal(result.evidence.activation_nonce_winner, null);
 });
 
-test('activation-nonce: omitting --nonce opts out of the comparison entirely', () => {
+test('activation-nonce: omitting --nonce with 2+ trusted markers is a cold-recovery collision (#1529)', () => {
   const result = evaluateResumeClaimRouting(
     {
       claimId: 'claim-abc',
@@ -172,10 +172,36 @@ test('activation-nonce: omitting --nonce opts out of the comparison entirely', (
     { isTrustedAuthor: trusted(['maintainer']) },
   );
 
-  // A real collision exists in the event stream, but this caller never
-  // supplied its own recorded nonce -- pre-#1522 behavior is preserved.
+  assert.equal(result.state, 'disputed');
+  assert.equal(result.action, 'stop');
+  assert.equal(result.reason, 'cold-recovery-activation-nonce-collision');
+  assert.equal(result.evidence.activation_nonce_count, 2);
+});
+
+test('activation-nonce: omitting --nonce with a single marker still skips comparison', () => {
+  const result = evaluateResumeClaimRouting(
+    {
+      claimId: 'claim-abc',
+      now: '2026-05-12T10:00:00Z',
+      events: [
+        {
+          createdAt: '2026-05-12T09:00:00Z',
+          author: { login: 'maintainer' },
+          body: '<!-- claimed-by: copilot claim-abc supersedes: none 2026-05-12T09:00:00Z branch: issue/1-task -->',
+        },
+        {
+          createdAt: '2026-05-12T09:00:05Z',
+          author: { login: 'maintainer' },
+          body: '<!-- activation-nonce: copilot claim-abc nonce-aaa 2026-05-12T09:00:05Z -->',
+        },
+      ],
+    },
+    { isTrustedAuthor: trusted(['maintainer']) },
+  );
+
   assert.equal(result.state, 'already_owned');
   assert.equal(result.reason, 'claim-id-match');
+  assert.equal(result.evidence.activation_nonce_count, 1);
 });
 
 test('returns non_inheritable for non-stale active claim from another session', () => {


### PR DESCRIPTION
## Summary

Closes #1529.

Implements the 2026-08-17 option-2 decision: when Resume holds no local nonce and the active claim-id has 2+ trusted activation-nonce markers, `evaluateResumeClaimRouting` returns `disputed` / `stop` (`cold-recovery-activation-nonce-collision`). A single posted nonce still skips comparison. Resume Step 1 helper mapping names the reason. The open-item wording is removed from `idd-design-rationale.md`.

## Test plan

- [x] `node --test tests/resume-claim-routing.test.mts` (38 pass)
- [x] `pnpm run build`
- [x] `node scripts/audit-docs.mjs --check` (`bundle-resume` 97.88%)

Signing: `git commit-ssh`.