### PR TITLE
docs(overview): record a non-default commit-signing outcome

### DIFF
--- a/.github/instructions/idd-overview-appendix.instructions.md
+++ b/.github/instructions/idd-overview-appendix.instructions.md
@@ -101,10 +101,11 @@ Merge Wrapper; never permanently rewrite signing config. `--no-gpg-sign`
 on `git commit`/`git merge` is the last resort.
 
 Record material progress, decisions, and hold reasons as issue or PR
-comments as they happen. This ensures that any agent resuming
-without session context can understand the current state and continue
-correctly. Do not rely on session memory alone for information that
-another agent may need.
+comments as they happen. That includes a non-default signing outcome
+(including a `--no-gpg-sign` fallback). This ensures that any agent
+resuming without session context can understand the current state and
+continue correctly. Do not rely on session memory alone for
+information that another agent may need.
 
 Operational restore markers (`review-watermark` and `review-baseline`)
 must include the current `{claim-id}` and must never be restored across

--- a/idd-template/.github/instructions/idd-overview-appendix.instructions.md
+++ b/idd-template/.github/instructions/idd-overview-appendix.instructions.md
@@ -96,10 +96,11 @@ Merge Wrapper; never permanently rewrite signing config. `--no-gpg-sign`
 on `git commit`/`git merge` is the last resort.
 
 Record material progress, decisions, and hold reasons as issue or PR
-comments as they happen. This ensures that any agent resuming
-without session context can understand the current state and continue
-correctly. Do not rely on session memory alone for information that
-another agent may need.
+comments as they happen. That includes a non-default signing outcome
+(including a `--no-gpg-sign` fallback). This ensures that any agent
+resuming without session context can understand the current state and
+continue correctly. Do not rely on session memory alone for
+information that another agent may need.
 
 Operational restore markers (`review-watermark` and `review-baseline`)
 must include the current `{claim-id}` and must never be restored across


### PR DESCRIPTION
## Summary

Closes #2101.

Adds one clause to the existing Commit signing recording rule: a
non-default signing outcome, including `--no-gpg-sign`, must be
recorded like other material progress. No new heading and no
GPG-vs-SSH order.

## Test plan

- [x] `node scripts/sync-docs.mjs --apply`
- [x] `node scripts/audit-docs.mjs --check` (no new ceiling failures)

Signing: `git commit-ssh`.