### PR TITLE
docs(onboarding): warn that review replies retrigger Copilot checks

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -417,7 +417,13 @@ merges — a maintainer must separately register `idd-advisory-convergence`
 as a **required** status check in the repository's branch-protection
 Ruleset; this is a GitHub-settings action taken outside of IDD
 automation, not something an agent applies on its own. Once
-registered, the check follows the same deadline/waiver escape path as
+registered, every review-thread reply, edit, or delete re-asserts the
+same Copilot verdict — ordinary human prose can fail that required
+check and cancel an in-flight run for that PR. This is
+`idd-advisory-convergence`, not `lint.yml`. Repositories that want
+human-led or gradual IDD adoption should not register the check as
+required until they intend the Copilot-advisory loop. After that
+registration, the check follows the same deadline/waiver escape path as
 any other external check: while the primary advisory bot has not yet
 reviewed the current PR HEAD, `--assert` exits non-zero and the check
 **shows as failing** (GitHub Actions has no separate non-failing

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -419,10 +419,11 @@ Ruleset; this is a GitHub-settings action taken outside of IDD
 automation, not something an agent applies on its own. Once
 registered, every review-thread reply, edit, or delete re-asserts the
 same Copilot verdict — ordinary human prose can fail that required
-check and cancel an in-flight run for that PR. This is
-`idd-advisory-convergence`, not `lint.yml`. Repositories that want
-human-led or gradual IDD adoption should not register the check as
-required until they intend the Copilot-advisory loop. After that
+check on the PR and cancel an in-flight run (observed 2026-08-17 on
+PR #2130). This is `idd-advisory-convergence`, not `lint.yml`.
+Repositories that want human-led or gradual IDD adoption should not
+register the check as required until they intend the Copilot-advisory
+loop. After that
 registration, the check follows the same deadline/waiver escape path as
 any other external check: while the primary advisory bot has not yet
 reviewed the current PR HEAD, `--assert` exits non-zero and the check

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1387,13 +1387,14 @@ run has no PR context of its own.
 for every review-thread reply, edit, or delete — including ordinary
 human prose, not just IDD disposition markers. If you register
 `idd-advisory-convergence` as a required status check, that reply
-re-asserts the fail-closed Copilot verdict. The required check can
-show red on the comment and, because the workflow shares a PR-number
-concurrency group with `cancel-in-progress: true`, can cancel an
-in-flight run for that PR. This is `idd-advisory-convergence`, not
-`lint.yml`. Repositories that want human-led or gradual IDD adoption
-should leave the check unregistered until they intend the
-Copilot-advisory loop.
+re-asserts the fail-closed Copilot verdict. The PR's required check
+can fail (Checks tab / merge rollup), and, because the workflow
+shares a PR-number concurrency group with `cancel-in-progress: true`,
+can cancel an in-flight run for that PR (observed 2026-08-17 on
+PR #2130). This is `idd-advisory-convergence`, not `lint.yml`.
+Repositories that want human-led or gradual IDD adoption should
+leave the check unregistered until they intend the Copilot-advisory
+loop.
 
 **Register it as a required status check.** Hosting the workflow alone
 does not block merge — a maintainer must separately register

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1383,6 +1383,18 @@ or a maintainer runs the workflow's fourth trigger,
 for that case, taking a `pr_number` input since a manually dispatched
 run has no PR context of its own.
 
+**Human-reply retrigger.** Those same comment and review triggers fire
+for every review-thread reply, edit, or delete — including ordinary
+human prose, not just IDD disposition markers. If you register
+`idd-advisory-convergence` as a required status check, that reply
+re-asserts the fail-closed Copilot verdict. The required check can
+show red on the comment and, because the workflow shares a PR-number
+concurrency group with `cancel-in-progress: true`, can cancel an
+in-flight run for that PR. This is `idd-advisory-convergence`, not
+`lint.yml`. Repositories that want human-led or gradual IDD adoption
+should leave the check unregistered until they intend the
+Copilot-advisory loop.
+
 **Register it as a required status check.** Hosting the workflow alone
 does not block merge — a maintainer must separately register
 `idd-advisory-convergence` (the job id, which is also the

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -417,7 +417,13 @@ merges — a maintainer must separately register `idd-advisory-convergence`
 as a **required** status check in the repository's branch-protection
 Ruleset; this is a GitHub-settings action taken outside of IDD
 automation, not something an agent applies on its own. Once
-registered, the check follows the same deadline/waiver escape path as
+registered, every review-thread reply, edit, or delete re-asserts the
+same Copilot verdict — ordinary human prose can fail that required
+check and cancel an in-flight run for that PR. This is
+`idd-advisory-convergence`, not `lint.yml`. Repositories that want
+human-led or gradual IDD adoption should not register the check as
+required until they intend the Copilot-advisory loop. After that
+registration, the check follows the same deadline/waiver escape path as
 any other external check: while the primary advisory bot has not yet
 reviewed the current PR HEAD, `--assert` exits non-zero and the check
 **shows as failing** (GitHub Actions has no separate non-failing

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -419,10 +419,11 @@ Ruleset; this is a GitHub-settings action taken outside of IDD
 automation, not something an agent applies on its own. Once
 registered, every review-thread reply, edit, or delete re-asserts the
 same Copilot verdict — ordinary human prose can fail that required
-check and cancel an in-flight run for that PR. This is
-`idd-advisory-convergence`, not `lint.yml`. Repositories that want
-human-led or gradual IDD adoption should not register the check as
-required until they intend the Copilot-advisory loop. After that
+check on the PR and cancel an in-flight run (observed 2026-08-17 on
+PR #2130). This is `idd-advisory-convergence`, not `lint.yml`.
+Repositories that want human-led or gradual IDD adoption should not
+register the check as required until they intend the Copilot-advisory
+loop. After that
 registration, the check follows the same deadline/waiver escape path as
 any other external check: while the primary advisory bot has not yet
 reviewed the current PR HEAD, `--assert` exits non-zero and the check

--- a/idd-template/profiles/human-required/README.md
+++ b/idd-template/profiles/human-required/README.md
@@ -9,9 +9,9 @@ profile active.
 profile.** Hosting that workflow is optional. Registering it as a
 required status check re-asserts Copilot convergence on every
 review-thread reply, edit, or delete, so ordinary human prose can fail
-the required check and cancel an in-flight run. Leave the check
-unregistered unless you later switch to a Copilot-advisory review
-policy.
+the required check on the PR and cancel an in-flight run (observed
+2026-08-17 on PR #2130). Leave the check unregistered unless you later
+switch to a Copilot-advisory review policy.
 
 ## Adopter-Owned Values
 

--- a/idd-template/profiles/human-required/README.md
+++ b/idd-template/profiles/human-required/README.md
@@ -5,6 +5,14 @@ the authoritative review gate for every PR. Apply the complete surface
 below as one workflow change; documentation alone does not make this
 profile active.
 
+**Do not register `idd-advisory-convergence` as required under this
+profile.** Hosting that workflow is optional. Registering it as a
+required status check re-asserts Copilot convergence on every
+review-thread reply, edit, or delete, so ordinary human prose can fail
+the required check and cancel an in-flight run. Leave the check
+unregistered unless you later switch to a Copilot-advisory review
+policy.
+
 ## Adopter-Owned Values
 
 Record these values before editing phase behavior:

--- a/idd-template/profiles/no-advisory/README.md
+++ b/idd-template/profiles/no-advisory/README.md
@@ -6,6 +6,14 @@ rules configured outside IDD. Apply the complete surface below as one
 workflow change so later agents do not wait for a reviewer that the
 repository no longer uses.
 
+**Do not register `idd-advisory-convergence` as required under this
+profile.** Hosting that workflow is optional. Registering it as a
+required status check re-asserts Copilot convergence on every
+review-thread reply, edit, or delete, so ordinary human prose can fail
+the required check and cancel an in-flight run. Leave the check
+unregistered unless you later switch to a Copilot-advisory review
+policy.
+
 ## Adopter-Owned Values
 
 Record these values before editing phase behavior:

--- a/idd-template/profiles/no-advisory/README.md
+++ b/idd-template/profiles/no-advisory/README.md
@@ -10,9 +10,9 @@ repository no longer uses.
 profile.** Hosting that workflow is optional. Registering it as a
 required status check re-asserts Copilot convergence on every
 review-thread reply, edit, or delete, so ordinary human prose can fail
-the required check and cancel an in-flight run. Leave the check
-unregistered unless you later switch to a Copilot-advisory review
-policy.
+the required check on the PR and cancel an in-flight run (observed
+2026-08-17 on PR #2130). Leave the check unregistered unless you later
+switch to a Copilot-advisory review policy.
 
 ## Adopter-Owned Values
 


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Warn adopters that registering `idd-advisory-convergence` as a required
check re-asserts Copilot on every review-thread reply, edit, or delete.
Ordinary human prose can fail that required check and cancel an
in-flight run. This is the current-state operator warning from #2138.

## Linked issue

Closes #2138

## Follow-up issues (if any)

- [ ] none (sibling tracks stay on roadmap #2141)

## Background / rationale (if material)

The workflow already lists `pull_request_review_comment` so an E6
disposition can clear Clause 2 without a push. Adopters who then make
the job required are not told that a human `LGTM` starts the same
fail-closed Copilot assert. `human-required` and `no-advisory` profile
artifacts never mentioned the workflow.

Present tense only. Does not document reply stamps, presence-only
classification, or a `reviewPolicy` short-circuit.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how advisory convergence responds to review-thread replies, edits, and deletions.
  * Explained that ordinary human comments may cause the check to fail or cancel an in-progress run.
  * Distinguished advisory convergence from lint checks and provided guidance for gradual adoption.
  * Added policy warnings against requiring the check for human-required or no-advisory profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->