### PR TITLE
fix(suitability-triage): bound Check 3 unsafe-directive verb scan

### DIFF
--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -455,13 +455,32 @@ function findPolicyOverrideMatch(text, maskedText, getCodeRangeAt) {
   }
   return null;
 }
-function isUnsafeDirectiveSentenceEnd(char) {
-  return char === '.' || char === '?' || char === '!';
+function isUnsafeDirectiveSentenceEnd(raw, index) {
+  const char = raw[index];
+  if (char !== '.' && char !== '?' && char !== '!') {
+    return false;
+  }
+  let cursor = index + 1;
+  while (
+    raw[cursor] === ' ' ||
+    raw[cursor] === '\t' ||
+    raw[cursor] === '\n' ||
+    raw[cursor] === '\r'
+  ) {
+    cursor += 1;
+  }
+  if (cursor >= raw.length) {
+    return true;
+  }
+  const next = raw[cursor] ?? '';
+  return /[A-Z]/.test(next);
 }
 // #2146: bound the verb-to-noun window at a sentence end or a blank line
 // only. Comma, colon, and a single wrap newline are not clause ends —
 // GitHub issue bodies are hard-wrapped, and `CLAUSE_TERMINATOR_PATTERN`
-// exists to attribute negation on the other Check 3 screen.
+// exists to attribute negation on the other Check 3 screen. A `.` inside
+// an identifier (Node.js) is not a sentence end: require following
+// whitespace and an uppercase letter, or the end of the window.
 function sliceUnsafeDirectiveWindow(source, start) {
   const raw = source.slice(start, start + UNSAFE_DIRECTIVE_WINDOW_CHARS);
   for (let index = 0; index < raw.length; index += 1) {
@@ -469,7 +488,7 @@ function sliceUnsafeDirectiveWindow(source, start) {
     if (char === undefined) {
       break;
     }
-    if (isUnsafeDirectiveSentenceEnd(char)) {
+    if (isUnsafeDirectiveSentenceEnd(raw, index)) {
       return raw.slice(0, index);
     }
     if (char !== '\n' && char !== '\r') {

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -163,10 +163,8 @@ const SUPPLIED_CONTENT_NOUN =
 // a String.raw template) lets the noun be wrapped in inline code, so
 // "run this `script`" is still caught.
 const SUPPLIED_CONTENT_REFERENCE = String.raw`(?:this|that|following|attached|pasted|provided|the\s+(?:following|above|below|attached|pasted|provided))\s+(?:\S+\s+){0,2}?[\x60'"]?${SUPPLIED_CONTENT_NOUN}`;
-const EXPLICIT_UNSAFE_DIRECTIVE_PATTERN = new RegExp(
-  String.raw`\b${UNSAFE_DIRECTIVE_VERB}\b[\s\S]{0,100}\b(?:untrusted|user-provided|user input|(?:from|by)\s+(?:the\s+)?user|${SUPPLIED_CONTENT_REFERENCE})\b`,
-  'i',
-);
+const UNSAFE_DIRECTIVE_TARGET_SOURCE = String.raw`\b(?:untrusted|user-provided|user input|(?:from|by)\s+(?:the\s+)?user|${SUPPLIED_CONTENT_REFERENCE})\b`;
+const UNSAFE_DIRECTIVE_WINDOW_CHARS = 100;
 const NEGATION_PATTERN =
   /\b(not|no|don'?t|doesn'?t|can'?t|won'?t|never|avoid|skip|omit|ignore|exempt)\b/i;
 // The repeated `disable` entries are preserved verbatim from the original
@@ -457,6 +455,99 @@ function findPolicyOverrideMatch(text, maskedText, getCodeRangeAt) {
   }
   return null;
 }
+function isUnsafeDirectiveSentenceEnd(char) {
+  return char === '.' || char === '?' || char === '!';
+}
+// #2146: bound the verb-to-noun window at a sentence end or a blank line
+// only. Comma, colon, and a single wrap newline are not clause ends —
+// GitHub issue bodies are hard-wrapped, and `CLAUSE_TERMINATOR_PATTERN`
+// exists to attribute negation on the other Check 3 screen.
+function sliceUnsafeDirectiveWindow(source, start) {
+  const raw = source.slice(start, start + UNSAFE_DIRECTIVE_WINDOW_CHARS);
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw[index];
+    if (char === undefined) {
+      break;
+    }
+    if (isUnsafeDirectiveSentenceEnd(char)) {
+      return raw.slice(0, index);
+    }
+    if (char !== '\n' && char !== '\r') {
+      continue;
+    }
+    let cursor = index + 1;
+    if (char === '\r' && raw[cursor] === '\n') {
+      cursor += 1;
+    }
+    while (raw[cursor] === ' ' || raw[cursor] === '\t') {
+      cursor += 1;
+    }
+    if (raw[cursor] === '\n' || raw[cursor] === '\r') {
+      return raw.slice(0, index);
+    }
+  }
+  return raw;
+}
+function isVerbWhollyInBodyCode(
+  verbStart,
+  verbLength,
+  bodyOffset,
+  body,
+  bodyCodeRanges,
+) {
+  if (verbStart < bodyOffset) {
+    return false;
+  }
+  const bodyStart = verbStart - bodyOffset;
+  const range = getMarkdownCodeRange(body, bodyStart, bodyCodeRanges);
+  return range !== null && bodyStart + verbLength <= range.end;
+}
+// #2146: new skip rules on this screen only. Do not copy
+// findPolicyOverrideMatch — its raw fallback still fires when the whole
+// match is not inside one code range, which is exactly the #1911
+// false-positive (code-wrapped verb + later visible noun).
+function findUnsafeExecutionDirectiveMatch(
+  corpus,
+  bodyOffset,
+  body,
+  bodyCodeRanges,
+) {
+  const verbPattern = new RegExp(
+    String.raw`\b${UNSAFE_DIRECTIVE_VERB}\b`,
+    'gi',
+  );
+  const targetPattern = new RegExp(UNSAFE_DIRECTIVE_TARGET_SOURCE, 'i');
+  let verbMatch = verbPattern.exec(corpus);
+  while (verbMatch) {
+    const verbStart = verbMatch.index;
+    const verbText = verbMatch[0] ?? '';
+    if (
+      !isVerbWhollyInBodyCode(
+        verbStart,
+        verbText.length,
+        bodyOffset,
+        body,
+        bodyCodeRanges,
+      )
+    ) {
+      const window = sliceUnsafeDirectiveWindow(
+        corpus,
+        verbStart + verbText.length,
+      );
+      const targetMatch = targetPattern.exec(window);
+      if (targetMatch) {
+        const targetStart = targetMatch.index ?? 0;
+        const targetText = targetMatch[0] ?? '';
+        return corpus.slice(
+          verbStart,
+          verbStart + verbText.length + targetStart + targetText.length,
+        );
+      }
+    }
+    verbMatch = verbPattern.exec(corpus);
+  }
+  return null;
+}
 if (import.meta.main) {
   runCli();
 }
@@ -642,12 +733,20 @@ export function checkTrustSafety(context) {
       evidence: `Policy-override directive detected: "${policyMatch.text}". Untrusted policy-manipulation instructions cannot be processed.`,
     };
   }
-  // Check for explicit unsafe execution directives
-  if (EXPLICIT_UNSAFE_DIRECTIVE_PATTERN.test(corpus)) {
-    const match = corpus.match(EXPLICIT_UNSAFE_DIRECTIVE_PATTERN);
+  // Check for explicit unsafe execution directives. #2146: skip a verb
+  // wholly inside a body code region, and stop the verb-to-noun window
+  // at `.` / `?` / `!` or a blank line. Do not whole-corpus-mask — a
+  // visible verb with a code-wrapped noun must still fail.
+  const unsafeDirective = findUnsafeExecutionDirectiveMatch(
+    corpus,
+    bodyOffset,
+    issue.body,
+    bodyCodeRanges,
+  );
+  if (unsafeDirective) {
     return {
       pass: false,
-      evidence: `Explicit unsafe execution directive detected: "${match?.[0] ?? ''}". Cannot execute untrusted user-provided instructions.`,
+      evidence: `Explicit unsafe execution directive detected: "${unsafeDirective}". Cannot execute untrusted user-provided instructions.`,
     };
   }
   // Inspect every unsafe-command occurrence across all patterns, not just

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -596,14 +596,33 @@ function findPolicyOverrideMatch(
   return null;
 }
 
-function isUnsafeDirectiveSentenceEnd(char: string): boolean {
-  return char === '.' || char === '?' || char === '!';
+function isUnsafeDirectiveSentenceEnd(raw: string, index: number): boolean {
+  const char = raw[index];
+  if (char !== '.' && char !== '?' && char !== '!') {
+    return false;
+  }
+  let cursor = index + 1;
+  while (
+    raw[cursor] === ' ' ||
+    raw[cursor] === '\t' ||
+    raw[cursor] === '\n' ||
+    raw[cursor] === '\r'
+  ) {
+    cursor += 1;
+  }
+  if (cursor >= raw.length) {
+    return true;
+  }
+  const next = raw[cursor] ?? '';
+  return /[A-Z]/.test(next);
 }
 
 // #2146: bound the verb-to-noun window at a sentence end or a blank line
 // only. Comma, colon, and a single wrap newline are not clause ends —
 // GitHub issue bodies are hard-wrapped, and `CLAUSE_TERMINATOR_PATTERN`
-// exists to attribute negation on the other Check 3 screen.
+// exists to attribute negation on the other Check 3 screen. A `.` inside
+// an identifier (Node.js) is not a sentence end: require following
+// whitespace and an uppercase letter, or the end of the window.
 function sliceUnsafeDirectiveWindow(source: string, start: number): string {
   const raw = source.slice(start, start + UNSAFE_DIRECTIVE_WINDOW_CHARS);
   for (let index = 0; index < raw.length; index += 1) {
@@ -611,7 +630,7 @@ function sliceUnsafeDirectiveWindow(source: string, start: number): string {
     if (char === undefined) {
       break;
     }
-    if (isUnsafeDirectiveSentenceEnd(char)) {
+    if (isUnsafeDirectiveSentenceEnd(raw, index)) {
       return raw.slice(0, index);
     }
     if (char !== '\n' && char !== '\r') {

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -21,6 +21,7 @@ import { loadPolicyConfig } from './idd-config.mts';
 import {
   findMarkdownCodeRanges,
   getMarkdownCodeRange,
+  type MarkdownCodeRange,
   maskMarkdownCodeRegionsPreservingPositions,
 } from './markdown-code.mts';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
@@ -284,10 +285,8 @@ const SUPPLIED_CONTENT_NOUN =
 // a String.raw template) lets the noun be wrapped in inline code, so
 // "run this `script`" is still caught.
 const SUPPLIED_CONTENT_REFERENCE = String.raw`(?:this|that|following|attached|pasted|provided|the\s+(?:following|above|below|attached|pasted|provided))\s+(?:\S+\s+){0,2}?[\x60'"]?${SUPPLIED_CONTENT_NOUN}`;
-const EXPLICIT_UNSAFE_DIRECTIVE_PATTERN = new RegExp(
-  String.raw`\b${UNSAFE_DIRECTIVE_VERB}\b[\s\S]{0,100}\b(?:untrusted|user-provided|user input|(?:from|by)\s+(?:the\s+)?user|${SUPPLIED_CONTENT_REFERENCE})\b`,
-  'i',
-);
+const UNSAFE_DIRECTIVE_TARGET_SOURCE = String.raw`\b(?:untrusted|user-provided|user input|(?:from|by)\s+(?:the\s+)?user|${SUPPLIED_CONTENT_REFERENCE})\b`;
+const UNSAFE_DIRECTIVE_WINDOW_CHARS = 100;
 const NEGATION_PATTERN =
   /\b(not|no|don'?t|doesn'?t|can'?t|won'?t|never|avoid|skip|omit|ignore|exempt)\b/i;
 // The repeated `disable` entries are preserved verbatim from the original
@@ -597,6 +596,103 @@ function findPolicyOverrideMatch(
   return null;
 }
 
+function isUnsafeDirectiveSentenceEnd(char: string): boolean {
+  return char === '.' || char === '?' || char === '!';
+}
+
+// #2146: bound the verb-to-noun window at a sentence end or a blank line
+// only. Comma, colon, and a single wrap newline are not clause ends —
+// GitHub issue bodies are hard-wrapped, and `CLAUSE_TERMINATOR_PATTERN`
+// exists to attribute negation on the other Check 3 screen.
+function sliceUnsafeDirectiveWindow(source: string, start: number): string {
+  const raw = source.slice(start, start + UNSAFE_DIRECTIVE_WINDOW_CHARS);
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw[index];
+    if (char === undefined) {
+      break;
+    }
+    if (isUnsafeDirectiveSentenceEnd(char)) {
+      return raw.slice(0, index);
+    }
+    if (char !== '\n' && char !== '\r') {
+      continue;
+    }
+    let cursor = index + 1;
+    if (char === '\r' && raw[cursor] === '\n') {
+      cursor += 1;
+    }
+    while (raw[cursor] === ' ' || raw[cursor] === '\t') {
+      cursor += 1;
+    }
+    if (raw[cursor] === '\n' || raw[cursor] === '\r') {
+      return raw.slice(0, index);
+    }
+  }
+  return raw;
+}
+
+function isVerbWhollyInBodyCode(
+  verbStart: number,
+  verbLength: number,
+  bodyOffset: number,
+  body: string,
+  bodyCodeRanges: MarkdownCodeRange[],
+): boolean {
+  if (verbStart < bodyOffset) {
+    return false;
+  }
+  const bodyStart = verbStart - bodyOffset;
+  const range = getMarkdownCodeRange(body, bodyStart, bodyCodeRanges);
+  return range !== null && bodyStart + verbLength <= range.end;
+}
+
+// #2146: new skip rules on this screen only. Do not copy
+// findPolicyOverrideMatch — its raw fallback still fires when the whole
+// match is not inside one code range, which is exactly the #1911
+// false-positive (code-wrapped verb + later visible noun).
+function findUnsafeExecutionDirectiveMatch(
+  corpus: string,
+  bodyOffset: number,
+  body: string,
+  bodyCodeRanges: MarkdownCodeRange[],
+): string | null {
+  const verbPattern = new RegExp(
+    String.raw`\b${UNSAFE_DIRECTIVE_VERB}\b`,
+    'gi',
+  );
+  const targetPattern = new RegExp(UNSAFE_DIRECTIVE_TARGET_SOURCE, 'i');
+  let verbMatch: RegExpExecArray | null = verbPattern.exec(corpus);
+  while (verbMatch) {
+    const verbStart = verbMatch.index;
+    const verbText = verbMatch[0] ?? '';
+    if (
+      !isVerbWhollyInBodyCode(
+        verbStart,
+        verbText.length,
+        bodyOffset,
+        body,
+        bodyCodeRanges,
+      )
+    ) {
+      const window = sliceUnsafeDirectiveWindow(
+        corpus,
+        verbStart + verbText.length,
+      );
+      const targetMatch = targetPattern.exec(window);
+      if (targetMatch) {
+        const targetStart = targetMatch.index ?? 0;
+        const targetText = targetMatch[0] ?? '';
+        return corpus.slice(
+          verbStart,
+          verbStart + verbText.length + targetStart + targetText.length,
+        );
+      }
+    }
+    verbMatch = verbPattern.exec(corpus);
+  }
+  return null;
+}
+
 if (import.meta.main) {
   runCli();
 }
@@ -798,12 +894,20 @@ export function checkTrustSafety(context: Context): CheckOutcome {
     };
   }
 
-  // Check for explicit unsafe execution directives
-  if (EXPLICIT_UNSAFE_DIRECTIVE_PATTERN.test(corpus)) {
-    const match = corpus.match(EXPLICIT_UNSAFE_DIRECTIVE_PATTERN);
+  // Check for explicit unsafe execution directives. #2146: skip a verb
+  // wholly inside a body code region, and stop the verb-to-noun window
+  // at `.` / `?` / `!` or a blank line. Do not whole-corpus-mask — a
+  // visible verb with a code-wrapped noun must still fail.
+  const unsafeDirective = findUnsafeExecutionDirectiveMatch(
+    corpus,
+    bodyOffset,
+    issue.body,
+    bodyCodeRanges,
+  );
+  if (unsafeDirective) {
     return {
       pass: false,
-      evidence: `Explicit unsafe execution directive detected: "${match?.[0] ?? ''}". Cannot execute untrusted user-provided instructions.`,
+      evidence: `Explicit unsafe execution directive detected: "${unsafeDirective}". Cannot execute untrusted user-provided instructions.`,
     };
   }
 

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -1601,6 +1601,64 @@ test('trust safety still flags an inline-code-wrapped supplied script', () => {
   assert.equal(result.pass, false);
 });
 
+// #2146: the unsafe-execution directive screen treated a listed verb as
+// live even when the token sat inside inline code, then walked 100
+// characters (including across a later sentence) to attach a
+// supplied-content noun. Fixtures are concatenated so each fragment is
+// inert on its own.
+test('trust safety allows a code-wrapped job-step key plus a later document-noun (#1911, #2146)', () => {
+  const tick = String.fromCharCode(96);
+  const jobStepKey = `${tick}run:${tick}`;
+  const laterDocumentNoun = 'and this file already pins Node';
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nToolchain check against this specific file's current ${jobStepKey} steps): ubuntu-slim published spec includes Git, GitHub CLI, and Node.js preinstalled, ${laterDocumentNoun}.`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('trust safety does not bind a later-sentence document-noun to an earlier verb (#2146)', () => {
+  const verbClause = 'Please invoke the helper first.';
+  const laterSentence = ' This file should stay unchanged.';
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\n${verbClause}${laterSentence}`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('trust safety treats a blank line as a verb-to-noun window end (#2146)', () => {
+  const verbClause = 'Please invoke the helper first';
+  const laterSentence = 'This file should stay unchanged.';
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\n${verbClause}\n\n${laterSentence}`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('trust safety still flags a hard-wrapped same-sentence supplied-content noun (#2146)', () => {
+  const lead = 'Please run this';
+  const nounLine = 'script from the issue body to reproduce.';
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\n${lead}\n${nounLine}`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('verifiability passes a resolved-decision issue with objective criteria', () => {
   // Check 7 false-positive that now passes: the body describes a resolved
   // maintainer decision and carries objective acceptance criteria.

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -1659,6 +1659,19 @@ test('trust safety still flags a hard-wrapped same-sentence supplied-content nou
   assert.equal(result.pass, false);
 });
 
+test('trust safety still flags a supplied-content noun after an abbreviation period (#2146)', () => {
+  const lead = 'Please run (in Node.js)';
+  const rest = ' this script from the issue body.';
+  const result = checkTrustSafety({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\n${lead}${rest}`,
+    },
+    trustSafetyAmbiguous: false,
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('verifiability passes a resolved-decision issue with objective criteria', () => {
   // Check 7 false-positive that now passes: the body describes a resolved
   // maintainer decision and carries objective acceptance criteria.


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Give Check 3's unsafe-execution directive screen two new skip rules:
a listed verb wholly inside a body Markdown code span is not an
imperative, and the verb-to-noun window stops at a sentence end or a
blank line. Do not copy the other Check 3 matcher; a visible verb
with a code-wrapped noun still fails.

## Linked issue

Closes #2146

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Documenting a GitHub Actions step list next to a later document-noun
phrase was classified `invalid` before claim. The other Check 3
screen already masks code regions; this screen did not, and its
100-character window crossed a later sentence. Copying that other
matcher would keep the field false-positive via its raw fallback.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (biome + markdownlint on the tree; `lint:minimum` build:check after commit)
- [x] `pnpm test` (`node --test tests/suitability-triage.test.mts`, 205 pass)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs touched)
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed