### PR TITLE
feat(markers): stamp IDD review replies with a hidden identity marker

### DIFF
--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -145,6 +145,13 @@ Start every reply with one of these prefixes so that disposition is
 unambiguous:
 
 - `**Accepted** — fixed in {commit-sha or comma-separated list}: {brief explanation}`
+  After that visible prefix, include the prefix-aware reply-identity
+  stamp
+  `<!-- {markerPrefix}-review-reply -->`
+  (use the repository `markerPrefix`, default `idd-skill`; helpers
+  inject it; a manual `gh api` JSON body must append it). The stamp is
+  utterance identity, not an E1 `review-watermark`, and it must not
+  replace the required `**Accepted**` first bytes.
 
 - **Review threads**: after posting your reply, **immediately resolve
   the thread**. When helper runtime is enabled, the profile-selected

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -263,6 +263,13 @@ separate PATH A signal, not part of this pairing):
   marker fails this on its own — the fence delimiters, not the marker,
   are the first bytes), or the gate counts zero dispositions for that
   comment.
+- After the visible prefix, include the prefix-aware reply-identity
+  stamp
+  `<!-- {markerPrefix}-review-reply -->`
+  (use the repository `markerPrefix`, default `idd-skill`; helpers
+  inject it; a manual `gh api` JSON body must append it). The stamp is
+  utterance identity, not an E1 `review-watermark`, and it must not
+  replace the required `**Accepted**` / `**Rejected**` first bytes.
 - Post **one disposition reply per advisory item** — never combine
   several markers into one comment; the 1:1 pairing clears only one item
   per comment, leaving the rest flagged `missing-disposition-evidence`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ discipline and has no tag.
 
 ## [Unreleased]
 
+### Added
+
+- Prefix-aware review-reply identity stamp
+  (`<!-- {markerPrefix}-review-reply -->`) for IDD-originated E6/E13
+  replies, with helper injection and a shared recognizer. The stamp
+  rides after the visible disposition prefix and is not an E1
+  `review-watermark` or F4 operational marker.
+
 ### Changed
 
 - `engines.node` bumped to `^22.23.2 || ^24.2.0 || >=26.0.0`: the

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -140,6 +140,13 @@ Start every reply with one of these prefixes so that disposition is
 unambiguous:
 
 - `**Accepted** — fixed in {commit-sha or comma-separated list}: {brief explanation}`
+  After that visible prefix, include the prefix-aware reply-identity
+  stamp
+  `<!-- {markerPrefix}-review-reply -->`
+  (use the repository `markerPrefix`, default `idd-skill`; helpers
+  inject it; a manual `gh api` JSON body must append it). The stamp is
+  utterance identity, not an E1 `review-watermark`, and it must not
+  replace the required `**Accepted**` first bytes.
 
 - **Review threads**: after posting your reply, **immediately resolve
   the thread**. When helper runtime is enabled, the profile-selected

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -258,6 +258,13 @@ separate PATH A signal, not part of this pairing):
   marker fails this on its own — the fence delimiters, not the marker,
   are the first bytes), or the gate counts zero dispositions for that
   comment.
+- After the visible prefix, include the prefix-aware reply-identity
+  stamp
+  `<!-- {markerPrefix}-review-reply -->`
+  (use the repository `markerPrefix`, default `idd-skill`; helpers
+  inject it; a manual `gh api` JSON body must append it). The stamp is
+  utterance identity, not an E1 `review-watermark`, and it must not
+  replace the required `**Accepted**` / `**Rejected**` first bytes.
 - Post **one disposition reply per advisory item** — never combine
   several markers into one comment; the 1:1 pairing clears only one item
   per comment, leaving the rest flagged `missing-disposition-evidence`.

--- a/schemas/resolve-review-thread.schema.json
+++ b/schemas/resolve-review-thread.schema.json
@@ -30,6 +30,10 @@
       "type": "boolean",
       "description": "Whether the owning review thread was already resolved at inspection time, in either dry-run or apply mode."
     },
+    "body": {
+      "type": "string",
+      "description": "Reply body that will be posted (dry-run) or was posted (apply), including the injected reply-identity stamp. Omitted when --body is empty."
+    },
     "status": {
       "type": "string",
       "enum": ["applied", "failed"],

--- a/scripts/disposition-non-review-notices.mjs
+++ b/scripts/disposition-non-review-notices.mjs
@@ -38,6 +38,7 @@ import {
 } from './collaborator-permission.mjs';
 import { DEFAULT_GH_PAGINATED_TIMEOUT_MS, ghText } from './gh-exec.mjs';
 import { loadIddConfig } from './idd-config.mjs';
+import { appendReviewReplyStamp } from './marker-helpers.mjs';
 import {
   advisoryBotIdentityToken,
   compareIsoTimestamps,
@@ -52,6 +53,11 @@ import {
   resolveActiveClaimForWriteGate,
   resolveAdvisoryBotLogins,
 } from './protocol-helpers.mjs';
+
+function resolveConfiguredMarkerPrefix() {
+  const raw = loadIddConfig()?.markerPrefix;
+  return typeof raw === 'string' ? raw : '';
+}
 /**
  * Derive the short `({reason})` clause for a non-review notice from its body.
  * Tightly tied to the categories `isAdvisoryNonReviewNotice` recognizes; falls
@@ -81,8 +87,17 @@ export function noticeReason(body) {
  * break gate recognition; it also never becomes a machine-readable pairing
  * key for `summarizeDispositionEvidenceForGate`'s count-based carry-forward.
  */
-export function buildDispositionBody(botLogin, headSha, reason, noticeId) {
-  return `**Rejected** — ${botLogin} did not review HEAD ${headSha} (${reason}); this is not a completed review (source: #issuecomment-${noticeId})`;
+export function buildDispositionBody(
+  botLogin,
+  headSha,
+  reason,
+  noticeId,
+  markerPrefix,
+) {
+  return appendReviewReplyStamp(
+    `**Rejected** — ${botLogin} did not review HEAD ${headSha} (${reason}); this is not a completed review (source: #issuecomment-${noticeId})`,
+    markerPrefix,
+  );
 }
 /**
  * Build the canonical `**Accepted**` disposition body for a CodeRabbit summary
@@ -95,8 +110,11 @@ export function buildDispositionBody(botLogin, headSha, reason, noticeId) {
  * re-disposition. The `summary walkthrough` phrase is what `isReviewSummaryDisposition`
  * keys on, so keep the two in lockstep.
  */
-export function buildSummaryDispositionBody(botLogin, headSha) {
-  return `**Accepted** — ${botLogin} summary walkthrough at HEAD ${headSha}; actionable comments, if any, are dispositioned as their own review threads`;
+export function buildSummaryDispositionBody(botLogin, headSha, markerPrefix) {
+  return appendReviewReplyStamp(
+    `**Accepted** — ${botLogin} summary walkthrough at HEAD ${headSha}; actionable comments, if any, are dispositioned as their own review threads`,
+    markerPrefix,
+  );
 }
 /**
  * Plan the dispositions for a PR's regular comments. Pure: takes the fetched
@@ -220,7 +238,13 @@ export function buildDispositionPlan(input, options = {}) {
       noticeId: comment.id,
       botLogin: comment.login,
       reason,
-      body: buildDispositionBody(comment.login, headSha, reason, comment.id),
+      body: buildDispositionBody(
+        comment.login,
+        headSha,
+        reason,
+        comment.id,
+        options.markerPrefix,
+      ),
     });
   }
   // CodeRabbit summary walkthrough auto-disposition (#1122). Separate from the
@@ -312,7 +336,11 @@ export function buildDispositionPlan(input, options = {}) {
       noticeId: comment.id,
       botLogin: comment.login,
       reason: 'summary walkthrough',
-      body: buildSummaryDispositionBody(comment.login, headSha),
+      body: buildSummaryDispositionBody(
+        comment.login,
+        headSha,
+        options.markerPrefix,
+      ),
     });
   }
   return { headSha, planned, skipped };
@@ -379,9 +407,6 @@ export function parseArgs(argv) {
     apply: values.apply,
     help,
   };
-}
-function ghJson(args) {
-  return JSON.parse(ghText(args));
 }
 /**
  * Fetch a paginated list endpoint as an array. `gh api --paginate` concatenates
@@ -464,18 +489,23 @@ function claimStillActive(
   return active?.claimId === claimId;
 }
 function postDisposition(owner, repo, pr, body) {
-  // A disposition body is plain text starting with `**Rejected**` (notice) or
-  // `**Accepted**` (summary walkthrough) — not an HTML-comment-first marker — so
-  // the `-f body=` field path posts it reliably; gh sends `{"body": <value>}` to
-  // the comments API.
-  return ghJson([
-    'api',
-    '--method',
-    'POST',
-    `repos/${owner}/${repo}/issues/${pr}/comments`,
-    '-f',
-    `body=${body}`,
-  ]);
+  // JSON `--input -` is required: the reply-identity stamp is an HTML
+  // comment after the visible disposition, so `-f body=` can drop or
+  // truncate the multiline body the same way it drops HTML-comment-first
+  // markers.
+  return JSON.parse(
+    ghText(
+      [
+        'api',
+        '--method',
+        'POST',
+        `repos/${owner}/${repo}/issues/${pr}/comments`,
+        '--input',
+        '-',
+      ],
+      { input: JSON.stringify({ body }) },
+    ),
+  );
 }
 /** Ids of all comments on the PR authored by `viewerLogin`. */
 function viewerCommentIds(owner, repo, pr, viewerLogin) {
@@ -670,9 +700,10 @@ if (import.meta.main) {
       // updatedAt-aware activity.
       updatedAt: comment.updated_at ?? '',
     }));
+    const markerPrefix = resolveConfiguredMarkerPrefix();
     return buildDispositionPlan(
       { headSha, comments },
-      { advisoryBotLogins, trustedMarkerLogins },
+      { advisoryBotLogins, trustedMarkerLogins, markerPrefix },
     );
   };
   if (!args.apply) {

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -240,17 +240,21 @@ export function hasReviewReplyStamp(
   markerPrefix = DEFAULT_REVIEW_REPLY_MARKER_PREFIX,
 ) {
   const prefix = normalizeReviewReplyMarkerPrefix(markerPrefix);
-  const match = createMarkerRegex(prefix, REVIEW_REPLY_STAMP_SUFFIX).exec(
-    body ?? '',
-  );
-  if (!match) {
-    return false;
-  }
+  const coarse = createMarkerRegex(prefix, REVIEW_REPLY_STAMP_SUFFIX);
   const exact = new RegExp(
     `^<!--\\s*${escapeRegex(prefix)}-${REVIEW_REPLY_STAMP_SUFFIX}\\s*-->$`,
     'i',
   );
-  return exact.test(match[0]);
+  // createMarkerRegex is non-global and will stop at the first suffix
+  // lookalike. Scan every match so an earlier `review-reply-extra` does
+  // not hide a later valid stamp (and so append stays idempotent).
+  const global = new RegExp(coarse.source, 'gi');
+  for (const match of (body ?? '').matchAll(global)) {
+    if (exact.test(match[0])) {
+      return true;
+    }
+  }
+  return false;
 }
 /**
  * Classify a comment as IDD-originated from the reply-identity stamp alone.

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -20,6 +20,8 @@
 // resolution machinery there (normalizeTrustedMarkerLogins and friends), and
 // moving them here would force exactly that forbidden back-import. Only the
 // single-marker parse/render primitives move in this wave.
+import { createMarkerRegex } from './marker-regex.mjs';
+
 const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
 const OPTIONAL_IDD_VISIBLE_NOTE_PATTERN = String.raw`(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)`;
 const OPERATIONAL_MARKER_ENTRIES = [
@@ -197,6 +199,79 @@ export const IDD_AGENT_DERIVED_MARKERS = new Set([
   'review-ack:',
   'copilot-unavailable:',
 ]);
+// ---------------------------------------------------------------------------
+// Review-reply identity stamp (#2135)
+//
+// Utterance identity on a visible E6/E13 reply body — not an E1 activity
+// snapshot. Deliberately absent from OPERATIONAL_MARKERS and
+// IDD_AGENT_DERIVED_MARKERS so F4 minimization never hides a stamped
+// disposition as OUTDATED and deriveIddAgentLogins never treats the stamp
+// as a first-bytes operational marker. The token rides AFTER the visible
+// **Accepted** / **Rejected** prefix; first bytes stay the disposition.
+// ---------------------------------------------------------------------------
+/** Distributed default `markerPrefix` when config is absent. */
+const DEFAULT_REVIEW_REPLY_MARKER_PREFIX = 'idd-skill';
+/**
+ * Suffix passed to {@link createMarkerRegex} for the reply-identity stamp.
+ * Must not be `watermark` or `review-watermark` — those are the E1 snapshot.
+ */
+export const REVIEW_REPLY_STAMP_SUFFIX = 'review-reply';
+function normalizeReviewReplyMarkerPrefix(markerPrefix) {
+  const trimmed = typeof markerPrefix === 'string' ? markerPrefix.trim() : '';
+  return trimmed.length > 0 ? trimmed : DEFAULT_REVIEW_REPLY_MARKER_PREFIX;
+}
+/** Render `<!-- {prefix}-review-reply -->` for the configured marker prefix. */
+export function renderReviewReplyStamp(
+  markerPrefix = DEFAULT_REVIEW_REPLY_MARKER_PREFIX,
+) {
+  return `<!-- ${normalizeReviewReplyMarkerPrefix(markerPrefix)}-${REVIEW_REPLY_STAMP_SUFFIX} -->`;
+}
+/**
+ * True when `body` carries a prefix-aware `review-reply` stamp anywhere
+ * (typically after the visible disposition). Mid-body match is required:
+ * the stamp is not first-bytes. An E1 `review-watermark` comment does not
+ * match because the suffix is a different token.
+ */
+export function hasReviewReplyStamp(
+  body,
+  markerPrefix = DEFAULT_REVIEW_REPLY_MARKER_PREFIX,
+) {
+  return createMarkerRegex(
+    normalizeReviewReplyMarkerPrefix(markerPrefix),
+    REVIEW_REPLY_STAMP_SUFFIX,
+  ).test(body ?? '');
+}
+/**
+ * Classify a comment as IDD-originated from the reply-identity stamp alone.
+ * Ordinary human prose (`LGTM`, `thanks, fixed`) is not originated. A
+ * well-formed stamp is sufficient; this does not inspect author login and
+ * does not satisfy Copilot Clause 2 by itself (that still needs a valid
+ * disposition body).
+ */
+export function isIddOriginatedReply(
+  body,
+  markerPrefix = DEFAULT_REVIEW_REPLY_MARKER_PREFIX,
+) {
+  return hasReviewReplyStamp(body, markerPrefix);
+}
+/**
+ * Append the reply-identity stamp after a visible reply body. Empty input
+ * is left unchanged. Already-stamped input is not double-stamped. The
+ * visible first bytes are preserved so `isDispositionComment` still matches.
+ */
+export function appendReviewReplyStamp(
+  body,
+  markerPrefix = DEFAULT_REVIEW_REPLY_MARKER_PREFIX,
+) {
+  const text = body ?? '';
+  if (text.trim() === '') {
+    return text;
+  }
+  if (hasReviewReplyStamp(text, markerPrefix)) {
+    return text;
+  }
+  return `${text.replace(/\s+$/, '')}\n\n${renderReviewReplyStamp(markerPrefix)}`;
+}
 const FORCED_HANDOFF_CONTEXT_SCOPES = new Set(['issue-only', 'issue-plus-pr']);
 const FORCED_HANDOFF_LINKED_PR_PATTERN = /^(?:[1-9]\d*|https?:\/\/[^\s<>"]+)$/;
 export function parseClaimComment(body, createdAt) {

--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -20,7 +20,7 @@
 // resolution machinery there (normalizeTrustedMarkerLogins and friends), and
 // moving them here would force exactly that forbidden back-import. Only the
 // single-marker parse/render primitives move in this wave.
-import { createMarkerRegex } from './marker-regex.mjs';
+import { createMarkerRegex, escapeRegex } from './marker-regex.mjs';
 
 const ISO8601_UTC_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z/;
 const OPTIONAL_IDD_VISIBLE_NOTE_PATTERN = String.raw`(?:\s*|\s*\n\s*_[^\n]*\bIDD\b[^\n]*_\s*)`;
@@ -229,17 +229,28 @@ export function renderReviewReplyStamp(
 /**
  * True when `body` carries a prefix-aware `review-reply` stamp anywhere
  * (typically after the visible disposition). Mid-body match is required:
- * the stamp is not first-bytes. An E1 `review-watermark` comment does not
- * match because the suffix is a different token.
+ * the stamp is not first-bytes. The stamp has no payload, so after the
+ * shared `createMarkerRegex` hit we require the matched comment to be
+ * exactly `<!-- {prefix}-review-reply -->` (optional whitespace). That
+ * rejects suffix extensions such as `review-reply-extra` that `\b`
+ * would otherwise accept before a hyphen.
  */
 export function hasReviewReplyStamp(
   body,
   markerPrefix = DEFAULT_REVIEW_REPLY_MARKER_PREFIX,
 ) {
-  return createMarkerRegex(
-    normalizeReviewReplyMarkerPrefix(markerPrefix),
-    REVIEW_REPLY_STAMP_SUFFIX,
-  ).test(body ?? '');
+  const prefix = normalizeReviewReplyMarkerPrefix(markerPrefix);
+  const match = createMarkerRegex(prefix, REVIEW_REPLY_STAMP_SUFFIX).exec(
+    body ?? '',
+  );
+  if (!match) {
+    return false;
+  }
+  const exact = new RegExp(
+    `^<!--\\s*${escapeRegex(prefix)}-${REVIEW_REPLY_STAMP_SUFFIX}\\s*-->$`,
+    'i',
+  );
+  return exact.test(match[0]);
 }
 /**
  * Classify a comment as IDD-originated from the reply-identity stamp alone.

--- a/scripts/resolve-review-thread.mjs
+++ b/scripts/resolve-review-thread.mjs
@@ -466,9 +466,13 @@ if (import.meta.main) {
   const pr = args.pr;
   const commentId = args.commentId;
   const markerPrefixRaw = loadIddConfig()?.markerPrefix;
-  const stampedBody = args.body.trim()
+  // `--body` is optional in dry-run. `parseCliArgs` defaults it to '', but
+  // coerce anyway so a missing value cannot throw on `.trim()` before the
+  // report is written.
+  const rawBody = typeof args.body === 'string' ? args.body : '';
+  const stampedBody = rawBody.trim()
     ? appendReviewReplyStamp(
-        args.body,
+        rawBody,
         typeof markerPrefixRaw === 'string' ? markerPrefixRaw : undefined,
       )
     : '';

--- a/scripts/resolve-review-thread.mjs
+++ b/scripts/resolve-review-thread.mjs
@@ -21,6 +21,8 @@ import {
   readForcedHandoffMode,
 } from './collaborator-permission.mjs';
 import { DEFAULT_GH_PAGINATED_TIMEOUT_MS, ghText } from './gh-exec.mjs';
+import { loadIddConfig } from './idd-config.mjs';
+import { appendReviewReplyStamp } from './marker-helpers.mjs';
 import {
   isDispositionComment,
   isRejectionConfirmedDisposition,
@@ -182,7 +184,8 @@ thread in one invocation (E13). Dry-run by default; --apply mutates.
   --comment-id <id>              review comment REST id whose thread to resolve (required)
   --body <text>                  reply body (required with --apply; with --apply, must start
                                  with **Accepted**, **Rejected**, or
-                                 **Rejection confirmed by maintainer** —)
+                                 **Rejection confirmed by maintainer** —; the helper
+                                 appends the reply-identity stamp)
   --owner <owner>                repo owner (default: gh repo view)
   --repo <repo>                  repo name (default: gh repo view)
   --claim-issue <number>         issue carrying the active claim (required with --apply)
@@ -193,9 +196,6 @@ thread in one invocation (E13). Dry-run by default; --apply mutates.
   --apply                        post the reply and resolve the thread (default: dry-run)
   -h, --help                     show this help
 `;
-function ghJson(args) {
-  return JSON.parse(ghText(args));
-}
 /**
  * Fetch a paginated list endpoint as an array. `gh api --paginate` concatenates
  * one JSON array per page; `--jq '.[]'` flattens each page to one JSON value per
@@ -340,14 +340,22 @@ function fetchThreadCommentIds(threadId, afterCursor) {
 }
 /** Post a reply to the review thread that owns `commentId` (REST). */
 function postReply(owner, repo, pr, commentId, body) {
-  return ghJson([
-    'api',
-    '--method',
-    'POST',
-    `repos/${owner}/${repo}/pulls/${pr}/comments/${commentId}/replies`,
-    '-f',
-    `body=${body}`,
-  ]);
+  // JSON `--input -` is required: the reply-identity stamp is an HTML
+  // comment after the visible disposition, so `-f body=` can drop or
+  // truncate the multiline body.
+  return JSON.parse(
+    ghText(
+      [
+        'api',
+        '--method',
+        'POST',
+        `repos/${owner}/${repo}/pulls/${pr}/comments/${commentId}/replies`,
+        '--input',
+        '-',
+      ],
+      { input: JSON.stringify({ body }) },
+    ),
+  );
 }
 /** Resolve a review thread by its GraphQL node id, confirming the result. */
 function resolveThread(threadId) {
@@ -457,6 +465,13 @@ if (import.meta.main) {
   }
   const pr = args.pr;
   const commentId = args.commentId;
+  const markerPrefixRaw = loadIddConfig()?.markerPrefix;
+  const stampedBody = args.body.trim()
+    ? appendReviewReplyStamp(
+        args.body,
+        typeof markerPrefixRaw === 'string' ? markerPrefixRaw : undefined,
+      )
+    : '';
   const owner =
     args.owner ||
     ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
@@ -472,6 +487,7 @@ if (import.meta.main) {
     commentId,
     ...(match ? { threadId: match.threadId } : {}),
     alreadyResolved: match?.isResolved ?? false,
+    ...(stampedBody ? { body: stampedBody } : {}),
   };
   if (!match) {
     report.error = `no review thread found for comment ${commentId} on PR #${pr}`;
@@ -566,7 +582,7 @@ if (import.meta.main) {
         }
       },
       postReply: () => {
-        const posted = postReply(owner, repo, pr, rootCommentId, args.body);
+        const posted = postReply(owner, repo, pr, rootCommentId, stampedBody);
         postedReplyId = posted.id;
         return posted;
       },

--- a/src/scripts/disposition-non-review-notices.mts
+++ b/src/scripts/disposition-non-review-notices.mts
@@ -40,6 +40,7 @@ import {
 } from './collaborator-permission.mts';
 import { DEFAULT_GH_PAGINATED_TIMEOUT_MS, ghText } from './gh-exec.mts';
 import { loadIddConfig } from './idd-config.mts';
+import { appendReviewReplyStamp } from './marker-helpers.mts';
 import {
   advisoryBotIdentityToken,
   compareIsoTimestamps,
@@ -95,6 +96,11 @@ export interface FailedDisposition {
   error: string;
 }
 
+function resolveConfiguredMarkerPrefix(): string {
+  const raw = loadIddConfig()?.markerPrefix;
+  return typeof raw === 'string' ? raw : '';
+}
+
 /** The CLI output envelope for both `dry-run` and `--apply` modes. */
 export interface DispositionReport {
   mode: 'dry-run' | 'apply';
@@ -142,8 +148,12 @@ export function buildDispositionBody(
   headSha: string,
   reason: string,
   noticeId: number,
+  markerPrefix?: string,
 ): string {
-  return `**Rejected** — ${botLogin} did not review HEAD ${headSha} (${reason}); this is not a completed review (source: #issuecomment-${noticeId})`;
+  return appendReviewReplyStamp(
+    `**Rejected** — ${botLogin} did not review HEAD ${headSha} (${reason}); this is not a completed review (source: #issuecomment-${noticeId})`,
+    markerPrefix,
+  );
 }
 
 /**
@@ -160,8 +170,12 @@ export function buildDispositionBody(
 export function buildSummaryDispositionBody(
   botLogin: string,
   headSha: string,
+  markerPrefix?: string,
 ): string {
-  return `**Accepted** — ${botLogin} summary walkthrough at HEAD ${headSha}; actionable comments, if any, are dispositioned as their own review threads`;
+  return appendReviewReplyStamp(
+    `**Accepted** — ${botLogin} summary walkthrough at HEAD ${headSha}; actionable comments, if any, are dispositioned as their own review threads`,
+    markerPrefix,
+  );
 }
 
 /**
@@ -188,6 +202,7 @@ export function buildDispositionPlan(
   options: {
     advisoryBotLogins?: unknown[] | null;
     trustedMarkerLogins?: unknown[] | null;
+    markerPrefix?: string;
   } = {},
 ): DispositionPlan {
   // Key all advisory-bot comparisons by the suffix-insensitive identity token
@@ -295,7 +310,13 @@ export function buildDispositionPlan(
       noticeId: comment.id,
       botLogin: comment.login,
       reason,
-      body: buildDispositionBody(comment.login, headSha, reason, comment.id),
+      body: buildDispositionBody(
+        comment.login,
+        headSha,
+        reason,
+        comment.id,
+        options.markerPrefix,
+      ),
     });
   }
 
@@ -389,7 +410,11 @@ export function buildDispositionPlan(
       noticeId: comment.id,
       botLogin: comment.login,
       reason: 'summary walkthrough',
-      body: buildSummaryDispositionBody(comment.login, headSha),
+      body: buildSummaryDispositionBody(
+        comment.login,
+        headSha,
+        options.markerPrefix,
+      ),
     });
   }
 
@@ -479,10 +504,6 @@ export function parseArgs(argv: string[]): CliArgs {
     apply: values.apply as boolean,
     help,
   };
-}
-
-function ghJson(args: string[]): unknown {
-  return JSON.parse(ghText(args));
 }
 
 /**
@@ -580,18 +601,23 @@ function postDisposition(
   pr: number,
   body: string,
 ): { id: number } {
-  // A disposition body is plain text starting with `**Rejected**` (notice) or
-  // `**Accepted**` (summary walkthrough) — not an HTML-comment-first marker — so
-  // the `-f body=` field path posts it reliably; gh sends `{"body": <value>}` to
-  // the comments API.
-  return ghJson([
-    'api',
-    '--method',
-    'POST',
-    `repos/${owner}/${repo}/issues/${pr}/comments`,
-    '-f',
-    `body=${body}`,
-  ]) as { id: number };
+  // JSON `--input -` is required: the reply-identity stamp is an HTML
+  // comment after the visible disposition, so `-f body=` can drop or
+  // truncate the multiline body the same way it drops HTML-comment-first
+  // markers.
+  return JSON.parse(
+    ghText(
+      [
+        'api',
+        '--method',
+        'POST',
+        `repos/${owner}/${repo}/issues/${pr}/comments`,
+        '--input',
+        '-',
+      ],
+      { input: JSON.stringify({ body }) },
+    ),
+  ) as { id: number };
 }
 
 /** Ids of all comments on the PR authored by `viewerLogin`. */
@@ -844,9 +870,10 @@ if (import.meta.main) {
       // updatedAt-aware activity.
       updatedAt: comment.updated_at ?? '',
     }));
+    const markerPrefix = resolveConfiguredMarkerPrefix();
     return buildDispositionPlan(
       { headSha, comments },
-      { advisoryBotLogins, trustedMarkerLogins },
+      { advisoryBotLogins, trustedMarkerLogins, markerPrefix },
     );
   };
 

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -416,17 +416,21 @@ export function hasReviewReplyStamp(
   markerPrefix: string = DEFAULT_REVIEW_REPLY_MARKER_PREFIX,
 ): boolean {
   const prefix = normalizeReviewReplyMarkerPrefix(markerPrefix);
-  const match = createMarkerRegex(prefix, REVIEW_REPLY_STAMP_SUFFIX).exec(
-    body ?? '',
-  );
-  if (!match) {
-    return false;
-  }
+  const coarse = createMarkerRegex(prefix, REVIEW_REPLY_STAMP_SUFFIX);
   const exact = new RegExp(
     `^<!--\\s*${escapeRegex(prefix)}-${REVIEW_REPLY_STAMP_SUFFIX}\\s*-->$`,
     'i',
   );
-  return exact.test(match[0]);
+  // createMarkerRegex is non-global and will stop at the first suffix
+  // lookalike. Scan every match so an earlier `review-reply-extra` does
+  // not hide a later valid stamp (and so append stays idempotent).
+  const global = new RegExp(coarse.source, 'gi');
+  for (const match of (body ?? '').matchAll(global)) {
+    if (exact.test(match[0])) {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -21,7 +21,7 @@
 // moving them here would force exactly that forbidden back-import. Only the
 // single-marker parse/render primitives move in this wave.
 
-import { createMarkerRegex } from './marker-regex.mts';
+import { createMarkerRegex, escapeRegex } from './marker-regex.mts';
 
 /** Operational marker matcher entry. */
 export interface OperationalMarker {
@@ -405,17 +405,28 @@ export function renderReviewReplyStamp(
 /**
  * True when `body` carries a prefix-aware `review-reply` stamp anywhere
  * (typically after the visible disposition). Mid-body match is required:
- * the stamp is not first-bytes. An E1 `review-watermark` comment does not
- * match because the suffix is a different token.
+ * the stamp is not first-bytes. The stamp has no payload, so after the
+ * shared `createMarkerRegex` hit we require the matched comment to be
+ * exactly `<!-- {prefix}-review-reply -->` (optional whitespace). That
+ * rejects suffix extensions such as `review-reply-extra` that `\b`
+ * would otherwise accept before a hyphen.
  */
 export function hasReviewReplyStamp(
   body: string,
   markerPrefix: string = DEFAULT_REVIEW_REPLY_MARKER_PREFIX,
 ): boolean {
-  return createMarkerRegex(
-    normalizeReviewReplyMarkerPrefix(markerPrefix),
-    REVIEW_REPLY_STAMP_SUFFIX,
-  ).test(body ?? '');
+  const prefix = normalizeReviewReplyMarkerPrefix(markerPrefix);
+  const match = createMarkerRegex(prefix, REVIEW_REPLY_STAMP_SUFFIX).exec(
+    body ?? '',
+  );
+  if (!match) {
+    return false;
+  }
+  const exact = new RegExp(
+    `^<!--\\s*${escapeRegex(prefix)}-${REVIEW_REPLY_STAMP_SUFFIX}\\s*-->$`,
+    'i',
+  );
+  return exact.test(match[0]);
 }
 
 /**

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -21,6 +21,8 @@
 // moving them here would force exactly that forbidden back-import. Only the
 // single-marker parse/render primitives move in this wave.
 
+import { createMarkerRegex } from './marker-regex.mts';
+
 /** Operational marker matcher entry. */
 export interface OperationalMarker {
   label: string;
@@ -367,6 +369,87 @@ export const IDD_AGENT_DERIVED_MARKERS: ReadonlySet<string> = new Set([
   'review-ack:',
   'copilot-unavailable:',
 ]);
+
+// ---------------------------------------------------------------------------
+// Review-reply identity stamp (#2135)
+//
+// Utterance identity on a visible E6/E13 reply body — not an E1 activity
+// snapshot. Deliberately absent from OPERATIONAL_MARKERS and
+// IDD_AGENT_DERIVED_MARKERS so F4 minimization never hides a stamped
+// disposition as OUTDATED and deriveIddAgentLogins never treats the stamp
+// as a first-bytes operational marker. The token rides AFTER the visible
+// **Accepted** / **Rejected** prefix; first bytes stay the disposition.
+// ---------------------------------------------------------------------------
+
+/** Distributed default `markerPrefix` when config is absent. */
+const DEFAULT_REVIEW_REPLY_MARKER_PREFIX = 'idd-skill';
+
+/**
+ * Suffix passed to {@link createMarkerRegex} for the reply-identity stamp.
+ * Must not be `watermark` or `review-watermark` — those are the E1 snapshot.
+ */
+export const REVIEW_REPLY_STAMP_SUFFIX = 'review-reply';
+
+function normalizeReviewReplyMarkerPrefix(markerPrefix: unknown): string {
+  const trimmed = typeof markerPrefix === 'string' ? markerPrefix.trim() : '';
+  return trimmed.length > 0 ? trimmed : DEFAULT_REVIEW_REPLY_MARKER_PREFIX;
+}
+
+/** Render `<!-- {prefix}-review-reply -->` for the configured marker prefix. */
+export function renderReviewReplyStamp(
+  markerPrefix: string = DEFAULT_REVIEW_REPLY_MARKER_PREFIX,
+): string {
+  return `<!-- ${normalizeReviewReplyMarkerPrefix(markerPrefix)}-${REVIEW_REPLY_STAMP_SUFFIX} -->`;
+}
+
+/**
+ * True when `body` carries a prefix-aware `review-reply` stamp anywhere
+ * (typically after the visible disposition). Mid-body match is required:
+ * the stamp is not first-bytes. An E1 `review-watermark` comment does not
+ * match because the suffix is a different token.
+ */
+export function hasReviewReplyStamp(
+  body: string,
+  markerPrefix: string = DEFAULT_REVIEW_REPLY_MARKER_PREFIX,
+): boolean {
+  return createMarkerRegex(
+    normalizeReviewReplyMarkerPrefix(markerPrefix),
+    REVIEW_REPLY_STAMP_SUFFIX,
+  ).test(body ?? '');
+}
+
+/**
+ * Classify a comment as IDD-originated from the reply-identity stamp alone.
+ * Ordinary human prose (`LGTM`, `thanks, fixed`) is not originated. A
+ * well-formed stamp is sufficient; this does not inspect author login and
+ * does not satisfy Copilot Clause 2 by itself (that still needs a valid
+ * disposition body).
+ */
+export function isIddOriginatedReply(
+  body: string,
+  markerPrefix: string = DEFAULT_REVIEW_REPLY_MARKER_PREFIX,
+): boolean {
+  return hasReviewReplyStamp(body, markerPrefix);
+}
+
+/**
+ * Append the reply-identity stamp after a visible reply body. Empty input
+ * is left unchanged. Already-stamped input is not double-stamped. The
+ * visible first bytes are preserved so `isDispositionComment` still matches.
+ */
+export function appendReviewReplyStamp(
+  body: string,
+  markerPrefix: string = DEFAULT_REVIEW_REPLY_MARKER_PREFIX,
+): string {
+  const text = body ?? '';
+  if (text.trim() === '') {
+    return text;
+  }
+  if (hasReviewReplyStamp(text, markerPrefix)) {
+    return text;
+  }
+  return `${text.replace(/\s+$/, '')}\n\n${renderReviewReplyStamp(markerPrefix)}`;
+}
 
 const FORCED_HANDOFF_CONTEXT_SCOPES = new Set(['issue-only', 'issue-plus-pr']);
 const FORCED_HANDOFF_LINKED_PR_PATTERN = /^(?:[1-9]\d*|https?:\/\/[^\s<>"]+)$/;

--- a/src/scripts/resolve-review-thread.mts
+++ b/src/scripts/resolve-review-thread.mts
@@ -23,6 +23,8 @@ import {
   readForcedHandoffMode,
 } from './collaborator-permission.mts';
 import { DEFAULT_GH_PAGINATED_TIMEOUT_MS, ghText } from './gh-exec.mts';
+import { loadIddConfig } from './idd-config.mts';
+import { appendReviewReplyStamp } from './marker-helpers.mts';
 import {
   isDispositionComment,
   isRejectionConfirmedDisposition,
@@ -64,6 +66,12 @@ export interface ResolveReviewThreadReport {
   /** Omitted when no review thread owns the comment. */
   threadId?: string;
   alreadyResolved: boolean;
+  /**
+   * Reply body that will be posted (dry-run) or was posted (apply),
+   * including the injected reply-identity stamp. Omitted when `--body`
+   * is empty.
+   */
+  body?: string;
   status?: 'applied' | 'failed';
   replyId?: number;
   error?: string;
@@ -261,7 +269,8 @@ thread in one invocation (E13). Dry-run by default; --apply mutates.
   --comment-id <id>              review comment REST id whose thread to resolve (required)
   --body <text>                  reply body (required with --apply; with --apply, must start
                                  with **Accepted**, **Rejected**, or
-                                 **Rejection confirmed by maintainer** —)
+                                 **Rejection confirmed by maintainer** —; the helper
+                                 appends the reply-identity stamp)
   --owner <owner>                repo owner (default: gh repo view)
   --repo <repo>                  repo name (default: gh repo view)
   --claim-issue <number>         issue carrying the active claim (required with --apply)
@@ -272,10 +281,6 @@ thread in one invocation (E13). Dry-run by default; --apply mutates.
   --apply                        post the reply and resolve the thread (default: dry-run)
   -h, --help                     show this help
 `;
-
-function ghJson(args: string[]): unknown {
-  return JSON.parse(ghText(args));
-}
 
 /**
  * Fetch a paginated list endpoint as an array. `gh api --paginate` concatenates
@@ -462,14 +467,22 @@ function postReply(
   commentId: number,
   body: string,
 ): { id: number } {
-  return ghJson([
-    'api',
-    '--method',
-    'POST',
-    `repos/${owner}/${repo}/pulls/${pr}/comments/${commentId}/replies`,
-    '-f',
-    `body=${body}`,
-  ]) as { id: number };
+  // JSON `--input -` is required: the reply-identity stamp is an HTML
+  // comment after the visible disposition, so `-f body=` can drop or
+  // truncate the multiline body.
+  return JSON.parse(
+    ghText(
+      [
+        'api',
+        '--method',
+        'POST',
+        `repos/${owner}/${repo}/pulls/${pr}/comments/${commentId}/replies`,
+        '--input',
+        '-',
+      ],
+      { input: JSON.stringify({ body }) },
+    ),
+  ) as { id: number };
 }
 
 /** Resolve a review thread by its GraphQL node id, confirming the result. */
@@ -590,6 +603,13 @@ if (import.meta.main) {
   }
   const pr = args.pr as number;
   const commentId = args.commentId as number;
+  const markerPrefixRaw = loadIddConfig()?.markerPrefix;
+  const stampedBody = args.body.trim()
+    ? appendReviewReplyStamp(
+        args.body,
+        typeof markerPrefixRaw === 'string' ? markerPrefixRaw : undefined,
+      )
+    : '';
   const owner =
     args.owner ||
     ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
@@ -607,6 +627,7 @@ if (import.meta.main) {
     commentId,
     ...(match ? { threadId: match.threadId } : {}),
     alreadyResolved: match?.isResolved ?? false,
+    ...(stampedBody ? { body: stampedBody } : {}),
   };
 
   if (!match) {
@@ -708,7 +729,7 @@ if (import.meta.main) {
         }
       },
       postReply: () => {
-        const posted = postReply(owner, repo, pr, rootCommentId, args.body);
+        const posted = postReply(owner, repo, pr, rootCommentId, stampedBody);
         postedReplyId = posted.id;
         return posted;
       },

--- a/src/scripts/resolve-review-thread.mts
+++ b/src/scripts/resolve-review-thread.mts
@@ -604,9 +604,13 @@ if (import.meta.main) {
   const pr = args.pr as number;
   const commentId = args.commentId as number;
   const markerPrefixRaw = loadIddConfig()?.markerPrefix;
-  const stampedBody = args.body.trim()
+  // `--body` is optional in dry-run. `parseCliArgs` defaults it to '', but
+  // coerce anyway so a missing value cannot throw on `.trim()` before the
+  // report is written.
+  const rawBody = typeof args.body === 'string' ? args.body : '';
+  const stampedBody = rawBody.trim()
     ? appendReviewReplyStamp(
-        args.body,
+        rawBody,
         typeof markerPrefixRaw === 'string' ? markerPrefixRaw : undefined,
       )
     : '';

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -12,6 +12,7 @@ import {
   noticeReason,
   parseArgs,
 } from '../src/scripts/disposition-non-review-notices.mts';
+import { hasReviewReplyStamp } from '../src/scripts/marker-helpers.mts';
 import {
   dispositionNamesAdvisoryBot,
   isDispositionComment,
@@ -113,8 +114,9 @@ test('buildDispositionBody is marker-first and names the bot login + head sha', 
   // disambiguator naming the source notice's own comment id.
   assert.match(
     body,
-    /\(review limit reached\); this is not a completed review \(source: #issuecomment-501\)$/,
+    /\(review limit reached\); this is not a completed review \(source: #issuecomment-501\)/,
   );
+  assert.ok(hasReviewReplyStamp(body));
 });
 
 test('buildDispositionPlan produces distinguishable bodies for two same-bot, same-HEAD, same-reason notices', () => {
@@ -137,8 +139,10 @@ test('buildDispositionPlan produces distinguishable bodies for two same-bot, sam
   assert.equal(plan.planned.length, 2);
   const [first, second] = plan.planned;
   assert.notEqual(first?.body, second?.body);
-  assert.match(first?.body ?? '', /\(source: #issuecomment-101\)$/);
-  assert.match(second?.body ?? '', /\(source: #issuecomment-102\)$/);
+  assert.match(first?.body ?? '', /\(source: #issuecomment-101\)/);
+  assert.match(second?.body ?? '', /\(source: #issuecomment-102\)/);
+  assert.ok(hasReviewReplyStamp(first?.body ?? ''));
+  assert.ok(hasReviewReplyStamp(second?.body ?? ''));
 });
 
 test('isDispositionComment and dispositionNamesAdvisoryBot recognize the extended body', () => {
@@ -183,7 +187,8 @@ test('dispositionNamesAdvisoryBot does not falsely match the #1482 source-notice
     'review limit reached',
     999,
   );
-  assert.match(body, /\(source: #issuecomment-999\)$/);
+  assert.match(body, /\(source: #issuecomment-999\)/);
+  assert.ok(hasReviewReplyStamp(body));
   assert.equal(dispositionNamesAdvisoryBot(body, 'issuecomment[bot]'), false);
 });
 
@@ -269,7 +274,8 @@ test('gate agreement: the extended **Rejected** body still clears a notice from 
     { trustedMarkerLogins: ['kurone-kito'] },
   );
   assert.equal(plan.planned.length, 1);
-  assert.match(plan.planned[0]?.body ?? '', /\(source: #issuecomment-201\)$/);
+  assert.match(plan.planned[0]?.body ?? '', /\(source: #issuecomment-201\)/);
+  assert.ok(hasReviewReplyStamp(plan.planned[0]?.body ?? ''));
   const disposition = {
     id: 202,
     author: { login: 'kurone-kito' },
@@ -597,6 +603,7 @@ test('buildSummaryDispositionBody is marker-first, names the login + head sha, a
   // RESOLVED path permanently clear the summary instead of per-HEAD
   // re-disposition, so the body must use the login form only.
   assert.doesNotMatch(body, /\bCodeRabbit\b/);
+  assert.ok(hasReviewReplyStamp(body));
 });
 
 test('buildDispositionPlan plans an **Accepted** for an undispositioned CodeRabbit summary', () => {

--- a/tests/marker-helpers-facade.test.mts
+++ b/tests/marker-helpers-facade.test.mts
@@ -39,6 +39,10 @@ const SAMPLE_NAMES = [
   'IDD_AGENT_DERIVED_MARKERS',
   'isValidIsoTimestamp',
   'OPERATIONAL_MARKERS',
+  'REVIEW_REPLY_STAMP_SUFFIX',
+  'hasReviewReplyStamp',
+  'appendReviewReplyStamp',
+  'isIddOriginatedReply',
 ] as const;
 
 test('protocol-helpers re-exports every sampled marker-helpers name by identity', () => {

--- a/tests/resolve-review-thread.test.mts
+++ b/tests/resolve-review-thread.test.mts
@@ -20,6 +20,12 @@ const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
 const resultSchema = loadJson('schemas/resolve-review-thread.schema.json');
 
+test('parseArgs defaults a missing --body to an empty string for dry-run', () => {
+  const args = parseArgs(['--pr', '42', '--comment-id', '1001']);
+  assert.equal(args.body, '');
+  assert.equal(args.body.trim(), '');
+});
+
 test('parseArgs reads the call shape and defaults to dry-run', () => {
   const args = parseArgs([
     '--pr',

--- a/tests/resolve-review-thread.test.mts
+++ b/tests/resolve-review-thread.test.mts
@@ -412,6 +412,7 @@ test('the dry-run and apply output envelopes validate against the schema', () =>
     alreadyResolved: false,
     status: 'applied',
     replyId: 4242,
+    body: '**Accepted** — fixed in abc\n\n<!-- idd-skill-review-reply -->',
   };
   assert.equal(validate(apply, resultSchema).length, 0, 'apply output');
 });

--- a/tests/review-reply-stamp.test.mts
+++ b/tests/review-reply-stamp.test.mts
@@ -66,6 +66,16 @@ test('hasReviewReplyStamp rejects hyphen-extended suffixes that createMarkerRege
   assert.equal(hasReviewReplyStamp('<!-- idd-skill-review-reply   -->'), true);
 });
 
+test('hasReviewReplyStamp still finds a valid stamp after an earlier lookalike', () => {
+  const body = [
+    '<!-- idd-skill-review-reply-extra -->',
+    '**Accepted** — later stamp',
+    '<!-- idd-skill-review-reply -->',
+  ].join('\n');
+  assert.equal(hasReviewReplyStamp(body), true);
+  assert.equal(appendReviewReplyStamp(body), body);
+});
+
 test('hasReviewReplyStamp honors an adopter markerPrefix and does not cross prefixes', () => {
   const adopter = '<!-- org-project-review-reply -->';
   assert.equal(hasReviewReplyStamp(adopter, 'org-project'), true);

--- a/tests/review-reply-stamp.test.mts
+++ b/tests/review-reply-stamp.test.mts
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { buildDispositionBody } from '../src/scripts/disposition-non-review-notices.mts';
+import {
+  appendReviewReplyStamp,
+  hasReviewReplyStamp,
+  isIddOriginatedReply,
+  OPERATIONAL_MARKERS,
+  operationalMarkerPrefix,
+  REVIEW_REPLY_STAMP_SUFFIX,
+  renderReviewReplyStamp,
+  renderReviewWatermarkMarker,
+} from '../src/scripts/marker-helpers.mts';
+import { isDispositionComment } from '../src/scripts/protocol-helpers.mts';
+
+const STAMP = '<!-- idd-skill-review-reply -->';
+
+test('REVIEW_REPLY_STAMP_SUFFIX is review-reply, not a watermark token', () => {
+  assert.equal(REVIEW_REPLY_STAMP_SUFFIX, 'review-reply');
+  assert.notEqual(REVIEW_REPLY_STAMP_SUFFIX, 'watermark');
+  assert.notEqual(REVIEW_REPLY_STAMP_SUFFIX, 'review-watermark');
+});
+
+test('renderReviewReplyStamp uses the configured prefix and default', () => {
+  assert.equal(renderReviewReplyStamp(), STAMP);
+  assert.equal(
+    renderReviewReplyStamp('org.project'),
+    '<!-- org.project-review-reply -->',
+  );
+});
+
+test('isIddOriginatedReply is true only when the prefix-aware stamp is present', () => {
+  const stamped = `**Accepted** — fixed in abc123\n\n${STAMP}`;
+  assert.equal(isIddOriginatedReply(stamped), true);
+  assert.equal(hasReviewReplyStamp(stamped), true);
+  assert.equal(isIddOriginatedReply('LGTM'), false);
+  assert.equal(isIddOriginatedReply('thanks, fixed'), false);
+  assert.equal(isIddOriginatedReply('**Accepted** — fixed in abc123'), false);
+});
+
+test('hasReviewReplyStamp does not treat an E1 review-watermark as a reply stamp', () => {
+  const watermark = renderReviewWatermarkMarker({
+    agentId: 'grok-test',
+    claimId: 'claim-1',
+    headSha: 'a'.repeat(40),
+    maxActivityAt: '2026-08-18T00:00:00Z',
+    totalItemCount: 1,
+    ciCompletedAt: '2026-08-18T00:00:00Z',
+  });
+  assert.match(watermark, /review-watermark/);
+  assert.equal(hasReviewReplyStamp(watermark), false);
+  assert.equal(isIddOriginatedReply(watermark), false);
+});
+
+test('hasReviewReplyStamp honors an adopter markerPrefix and does not cross prefixes', () => {
+  const adopter = '<!-- org.project-review-reply -->';
+  assert.equal(hasReviewReplyStamp(adopter, 'org.project'), true);
+  assert.equal(hasReviewReplyStamp(adopter, 'idd-skill'), false);
+  assert.equal(hasReviewReplyStamp(STAMP, 'org.project'), false);
+});
+
+test('appendReviewReplyStamp is idempotent and preserves first-byte disposition', () => {
+  const visible = '**Accepted** — fixed in abc123';
+  const once = appendReviewReplyStamp(visible);
+  const twice = appendReviewReplyStamp(once);
+  assert.equal(once, twice);
+  assert.ok(once.startsWith('**Accepted**'));
+  assert.ok(once.includes(STAMP));
+  assert.equal(appendReviewReplyStamp(''), '');
+  assert.equal(appendReviewReplyStamp('   '), '   ');
+});
+
+test('OPERATIONAL_MARKERS and F4 prefix detection ignore a stamped disposition', () => {
+  const stamped = appendReviewReplyStamp('**Rejected** — out of scope');
+  assert.equal(
+    OPERATIONAL_MARKERS.some((marker) =>
+      marker.label.toLowerCase().includes('review-reply'),
+    ),
+    false,
+  );
+  assert.equal(operationalMarkerPrefix(stamped), null);
+  assert.equal(operationalMarkerPrefix(STAMP), null);
+});
+
+test('a trusted-author Accepted body with no stamp is still an IDD disposition', () => {
+  const legacy = '**Accepted** — fixed in abc123: added the stamp later';
+  assert.equal(isDispositionComment({ body: legacy }), true);
+  assert.equal(isIddOriginatedReply(legacy), false);
+});
+
+test('buildDispositionBody injects the stamp after the visible rejection', () => {
+  const body = buildDispositionBody(
+    'coderabbitai[bot]',
+    'abc1234',
+    'review limit reached',
+    501,
+  );
+  assert.ok(body.startsWith('**Rejected**'));
+  assert.ok(hasReviewReplyStamp(body));
+  assert.equal(isDispositionComment({ body }), true);
+});

--- a/tests/review-reply-stamp.test.mts
+++ b/tests/review-reply-stamp.test.mts
@@ -25,8 +25,8 @@ test('REVIEW_REPLY_STAMP_SUFFIX is review-reply, not a watermark token', () => {
 test('renderReviewReplyStamp uses the configured prefix and default', () => {
   assert.equal(renderReviewReplyStamp(), STAMP);
   assert.equal(
-    renderReviewReplyStamp('org.project'),
-    '<!-- org.project-review-reply -->',
+    renderReviewReplyStamp('org-project'),
+    '<!-- org-project-review-reply -->',
   );
 });
 
@@ -67,10 +67,10 @@ test('hasReviewReplyStamp rejects hyphen-extended suffixes that createMarkerRege
 });
 
 test('hasReviewReplyStamp honors an adopter markerPrefix and does not cross prefixes', () => {
-  const adopter = '<!-- org.project-review-reply -->';
-  assert.equal(hasReviewReplyStamp(adopter, 'org.project'), true);
+  const adopter = '<!-- org-project-review-reply -->';
+  assert.equal(hasReviewReplyStamp(adopter, 'org-project'), true);
   assert.equal(hasReviewReplyStamp(adopter, 'idd-skill'), false);
-  assert.equal(hasReviewReplyStamp(STAMP, 'org.project'), false);
+  assert.equal(hasReviewReplyStamp(STAMP, 'org-project'), false);
 });
 
 test('appendReviewReplyStamp is idempotent and preserves first-byte disposition', () => {

--- a/tests/review-reply-stamp.test.mts
+++ b/tests/review-reply-stamp.test.mts
@@ -53,6 +53,19 @@ test('hasReviewReplyStamp does not treat an E1 review-watermark as a reply stamp
   assert.equal(isIddOriginatedReply(watermark), false);
 });
 
+test('hasReviewReplyStamp rejects hyphen-extended suffixes that createMarkerRegex would accept', () => {
+  assert.equal(
+    hasReviewReplyStamp('<!-- idd-skill-review-reply-extra -->'),
+    false,
+  );
+  assert.equal(
+    hasReviewReplyStamp('<!-- idd-skill-review-reply-watermark -->'),
+    false,
+  );
+  assert.equal(hasReviewReplyStamp('<!-- idd-skill-review-reply -->'), true);
+  assert.equal(hasReviewReplyStamp('<!-- idd-skill-review-reply   -->'), true);
+});
+
 test('hasReviewReplyStamp honors an adopter markerPrefix and does not cross prefixes', () => {
   const adopter = '<!-- org.project-review-reply -->';
   assert.equal(hasReviewReplyStamp(adopter, 'org.project'), true);

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -1169,6 +1169,7 @@ const resolveReviewThreadKeys = [
   'commentId',
   'threadId',
   'alreadyResolved',
+  'body',
   'status',
   'replyId',
   'error',
@@ -1180,6 +1181,7 @@ const resolveReviewThreadFixture = {
   commentId: 1001,
   threadId: 'thread-node-id',
   alreadyResolved: false,
+  body: '**Accepted** — fixed in abc\n\n<!-- idd-skill-review-reply -->',
   status: 'applied',
   replyId: 4242,
 } satisfies ResolveReviewThreadReport;


### PR DESCRIPTION
# Summary

Add a prefix-aware reply-identity stamp so later hybrid-review tracks can
classify an utterance as IDD-originated without treating author login as
identity. E6/E13 helpers inject
`<!-- {markerPrefix}-review-reply -->`
after the visible `**Accepted**` / `**Rejected**` prefix. The stamp is
not an E1 `review-watermark` and is not added to `OPERATIONAL_MARKERS` or
F4 minimization. F2 / advisory-convergence verdict math is unchanged.

## Linked issue

Closes #2135

## Follow-up issues (if any)

- [ ] #2139 consume the recognizer for unmarked human presence-only
- [ ] #2140 document the shipped hybrid review-reply identity contract

## Background / rationale (if material)

A maintainer listed in `trustedMarkerActors` is both the human who types
`LGTM` and the account that posts IDD dispositions. Author login cannot
tell those utterances apart. This PR ships the stamp and recognizer;
sibling tracks consume them.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

The schema change is additive: `resolve-review-thread` dry-run/apply
reports may now include the stamped `body`.

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

`pnpm lint` was run via `pnpm run lint:minimum` after `pnpm test`.
`docs:sync:check` passed as `node scripts/sync-docs.mjs --check`.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic identity stamps to review replies and disposition notices.
  * Stamps honor the configured marker prefix and preserve required visible response markers.
  * Dry-run and apply reports now include stamped reply bodies.
* **Bug Fixes**
  * Improved handling of multiline and HTML-formatted reply content.
* **Documentation**
  * Updated review instructions and changelog with the new reply-stamp behavior.
* **Tests**
  * Added coverage for stamp rendering, detection, compatibility, and idempotent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->