### PR TITLE
feat(advisory-convergence): stop required reruns on human review chatter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -68,6 +68,7 @@ scripts/resume-claim-routing.mjs linguist-generated=true
 scripts/resume-route-selection.mjs linguist-generated=true
 scripts/review-activity-snapshot.mjs linguist-generated=true
 scripts/review-clause.mjs linguist-generated=true
+scripts/review-comment-origin.mjs linguist-generated=true
 scripts/review-disposition-verify.mjs linguist-generated=true
 scripts/select-desynced-index.mjs linguist-generated=true
 scripts/stalled-session-quiet-check.mjs linguist-generated=true

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -13,7 +13,9 @@
 #
 # Job id is deliberately NOT `idd-advisory-convergence`.
 concurrency:
-  cancel-in-progress: true
+  # Do not cancel: a later human LGTM must not abort an in-flight
+  # IDD-originated refresh before it reruns the required check (#2136).
+  cancel-in-progress: false
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
 name: IDD advisory-convergence comment refresh
 on:
@@ -37,6 +39,27 @@ jobs:
           ref: main
           fetch-depth: 1
           persist-credentials: false
+      - name: Assert Node.js floor
+        run: |
+          # Same engines.node floor as the required companion job so a
+          # stale runner cannot silently skip the IDD-originated rerun.
+          node -e '
+            const versionParts = process.versions.node.split(".");
+            const [major, minor, patch] = versionParts.map(Number);
+            const isPrerelease = versionParts.some((part) => part.includes("-"));
+            const ok =
+              !isPrerelease &&
+              ((major === 22 && (minor > 23 || (minor === 23 && patch >= 2))) ||
+                (major === 24 && minor >= 2) ||
+                major >= 26);
+            if (!ok) {
+              console.error(
+                "Node " + process.version + " does not satisfy this " +
+                "repository'"'"'s engines.node range (^22.23.2 || ^24.2.0 || >=26.0.0).",
+              );
+              process.exit(1);
+            }
+          '
       - name: Classify review comment
         id: origin
         env:

--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -1,0 +1,51 @@
+# Non-required companion to idd-advisory-convergence.yml (#2136).
+#
+# Human review-thread chatter must not create or cancel the required
+# `idd-advisory-convergence` check-run. This workflow has a different
+# name, job id, and concurrency group so it cannot overwrite that SHA
+# verdict or cancel an in-flight required run.
+#
+# When the comment is IDD-originated (reply-identity stamp, disposition
+# prefix, or an operational marker the required check already honors),
+# it reuses `rerun-advisory-convergence.mjs --apply` to refresh the
+# existing pull_request-family required run for the current HEAD SHA.
+# It never asserts `ready` itself.
+#
+# Job id is deliberately NOT `idd-advisory-convergence`.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+name: IDD advisory-convergence comment refresh
+on:
+  pull_request_review_comment:
+    types:
+      - created
+      - edited
+      - deleted
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  actions: write
+jobs:
+  refresh-if-idd-originated:
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Classify review comment
+        id: origin
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: node scripts/review-comment-origin.mjs
+      - name: Rerun required HEAD check
+        if: steps.origin.outputs.idd_originated == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/rerun-advisory-convergence.mjs --pr "$PR_NUMBER" --apply

--- a/.github/workflows/idd-advisory-convergence.yml
+++ b/.github/workflows/idd-advisory-convergence.yml
@@ -1,11 +1,12 @@
 concurrency:
   cancel-in-progress: true
-  # Grouped by PR number, not github.ref: pull_request_review and
-  # pull_request_review_comment are not pull_request-family events, so
-  # github.ref is not guaranteed to resolve the same way for them as it
-  # does for a pull_request-only workflow (see idd-doctor.yml / lint.yml).
-  # workflow_dispatch has no pull_request context either, so it falls
-  # back to its own inputs.
+  # Grouped by PR number, not github.ref: pull_request_review is not
+  # a pull_request-family event, so github.ref is not guaranteed to
+  # resolve the same way for it as it does for a pull_request-only
+  # workflow (see idd-doctor.yml / lint.yml). Review-thread comments
+  # live in a separate non-required workflow (#2136) and must not
+  # share this group. workflow_dispatch has no pull_request context
+  # either, so it falls back to its own inputs.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
 name: IDD advisory-convergence gate
 # Required-check gate (#1341): asserts that the primary advisory bot's
@@ -53,16 +54,15 @@ name: IDD advisory-convergence gate
 # session that would also need to get past review.
 #
 # CI topology: unlike lint.yml/idd-doctor.yml's pull_request-only
-# trigger, convergence can also change WITHOUT a new push -- when
-# Copilot submits its review (pull_request_review), or when a
-# disposition marker (or any other reply/edit/delete) is posted on a
-# review thread (pull_request_review_comment) -- so both are added
-# alongside pull_request. The latter matters because Clause 2 of the
-# verdict (every Copilot-authored thread resolved-or-dispositioned)
-# changes exactly when an E6 disposition reply is posted; without this
-# trigger the check would only refresh on the next push, review
-# submission, or manual workflow_dispatch run, leaving it stuck on a
-# stale failing verdict after triage already resolved every thread.
+# trigger, convergence can also change WITHOUT a new push when Copilot
+# submits its review (`pull_request_review`). That trigger stays here
+# on the required job. Review-thread *comments* do not: a casual
+# human reply used to start this same required job, overwrite or
+# cancel the SHA's verdict, and show up as "the reply got linted"
+# (#2136). IDD-originated comments (disposition / stamp / operational
+# marker) refresh the existing HEAD-associated required run from the
+# companion `idd-advisory-convergence-comment.yml` workflow instead,
+# via `rerun-advisory-convergence --apply`.
 #
 # Known gap vs. the issue's original three-trigger proposal:
 # `pull_request_review_thread` (thread resolved/unresolved) is a real
@@ -259,11 +259,6 @@ on:
   pull_request_review:
     types:
       - submitted
-  pull_request_review_comment:
-    types:
-      - created
-      - edited
-      - deleted
   workflow_dispatch:
     inputs:
       pr_number:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ discipline and has no tag.
 
 ### Changed
 
+- The required `idd-advisory-convergence` job no longer runs on
+  `pull_request_review_comment`. Ordinary human review chatter no
+  longer creates or cancels that required check. IDD-originated
+  comments refresh the existing HEAD run from a separate
+  non-required companion workflow.
 - `engines.node` bumped to `^22.23.2 || ^24.2.0 || >=26.0.0`: the
   22.x floor moves to the 2026-07-29 emergency security release
   (fixes 11 CVEs including CVE-2026-56846/CVE-2026-56848 HTTP/2

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -417,10 +417,11 @@ merges — a maintainer must separately register `idd-advisory-convergence`
 as a **required** status check in the repository's branch-protection
 Ruleset; this is a GitHub-settings action taken outside of IDD
 automation, not something an agent applies on its own. Once
-registered, every review-thread reply, edit, or delete re-asserts the
-same Copilot verdict — ordinary human prose can fail that required
-check on the PR and cancel an in-flight run (observed 2026-08-17 on
-PR #2130). This is `idd-advisory-convergence`, not `lint.yml`.
+registered, ordinary human review-thread replies do **not** re-assert
+that required check. IDD-originated comments refresh the existing
+HEAD-associated required run from the companion
+`idd-advisory-convergence-comment.yml` workflow. This is
+`idd-advisory-convergence`, not `lint.yml`.
 Repositories that want human-led or gradual IDD adoption should not
 register the check as required until they intend the Copilot-advisory
 loop. After that
@@ -438,14 +439,17 @@ once `ciGate.externalCheckWaivers.mode` is `maintainer-authorized`
 **and** `idd-advisory-convergence` is itself listed under
 `ciGate.externalChecks.waivable` — enabling waiver mode for some other
 external check never silently makes this one waivable too. **Posting a
-waiver comment does not by itself turn the check green**: a waiver is a
-regular PR comment, which is not one of the workflow's triggers
-(`pull_request` push, `pull_request_review` submission, or
-`pull_request_review_comment` created/edited/deleted on a review
-thread), so after posting a waiver a maintainer must also **re-run the
-existing** PR-linked check run **for the current HEAD SHA** — the
-Actions UI "Re-run jobs" button, or `gh run rerun <run-id>` — for the
-required check to actually reflect it. `workflow_dispatch` does
+waiver comment does not by itself turn the check green**: a waiver is
+a regular PR conversation comment, which is not one of the required
+workflow's triggers (`pull_request` push or `pull_request_review`
+submission), so after posting a waiver a maintainer must also
+**re-run the existing** PR-linked check run **for the current HEAD
+SHA** — the Actions UI "Re-run jobs" button, or
+`gh run rerun <run-id>` — for the required check to actually
+reflect it. An IDD-originated review-thread comment refreshes that
+same HEAD run via the companion
+`idd-advisory-convergence-comment.yml` workflow. `workflow_dispatch`
+does
 **not** reliably do this:
 a dispatched run has no `pull_request` context of its own, so GitHub
 associates it with the dispatch ref rather than the PR's HEAD SHA, and

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -18,7 +18,9 @@
 # workflow. `defaults.run.shell` pins every `run:` step to `bash`.
 name: IDD advisory-convergence comment refresh
 concurrency:
-  cancel-in-progress: true
+  # Do not cancel: a later human LGTM must not abort an in-flight
+  # IDD-originated refresh before it reruns the required check (#2136).
+  cancel-in-progress: false
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
 on:
   pull_request_review_comment:

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -1,0 +1,57 @@
+# Non-required companion to idd-advisory-convergence.yml (#2136).
+#
+# Human review-thread chatter must not create or cancel the required
+# `idd-advisory-convergence` check-run. This workflow has a different
+# name, job id, and concurrency group so it cannot overwrite that SHA
+# verdict or cancel an in-flight required run.
+#
+# When the comment is IDD-originated (reply-identity stamp, disposition
+# prefix, or an operational marker the required check already honors),
+# it reuses `rerun-advisory-convergence.mjs --apply` to refresh the
+# existing pull_request-family required run for the current HEAD SHA.
+# It never asserts `ready` itself.
+#
+# Job id is deliberately NOT `idd-advisory-convergence`.
+#
+# Runner: shipped default is `ubuntu-slim`. Override via the
+# `CI_RUNNER_LABEL` repository variable, matching the required
+# workflow. `defaults.run.shell` pins every `run:` step to `bash`.
+name: IDD advisory-convergence comment refresh
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+on:
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  actions: write
+defaults:
+  run:
+    shell: bash
+jobs:
+  refresh-if-idd-originated:
+    runs-on: ${{ vars.CI_RUNNER_LABEL || 'ubuntu-slim' }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+      - name: Classify review comment
+        id: origin
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: node scripts/review-comment-origin.mjs
+      - name: Rerun required HEAD check
+        if: steps.origin.outputs.idd_originated == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_ENTERPRISE_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/rerun-advisory-convergence.mjs --pr "$PR_NUMBER" --apply

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -31,19 +31,19 @@ name: IDD advisory-convergence gate
 # dogfooded copy at .github/workflows/idd-advisory-convergence.yml.
 concurrency:
   cancel-in-progress: true
-  # Grouped by PR number, not github.ref: pull_request_review and
-  # pull_request_review_comment are not pull_request-family events, so
-  # github.ref does not resolve the same way for them as it does for a
-  # pull_request-only workflow. workflow_dispatch has no pull_request
-  # context either, so it falls back to its own input.
+  # Grouped by PR number, not github.ref: pull_request_review is not a
+  # pull_request-family event, so github.ref does not resolve the same
+  # way for it as it does for a pull_request-only workflow.
+  # Review-thread comments live in the companion
+  # idd-advisory-convergence-comment.yml workflow and must not share
+  # this group. workflow_dispatch has no pull_request context either,
+  # so it falls back to its own input.
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
 on:
   pull_request:
     types: [opened, reopened, synchronize]
   pull_request_review:
     types: [submitted]
-  pull_request_review_comment:
-    types: [created, edited, deleted]
   workflow_dispatch:
     inputs:
       pr_number:

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1390,10 +1390,10 @@ fires.
 
 **Human-reply retrigger.** A casual human reply used to start the
 required `idd-advisory-convergence` job, fail or cancel the SHA
-verdict, and look like "the reply got linted" (observed 2026-08-17 on
-PR #2130). That path is now the companion comment workflow above,
-and only IDD-originated comments refresh the required run. This is
-`idd-advisory-convergence`, not `lint.yml`.
+verdict, and look like "the reply got linted." That path is now the
+companion comment workflow above, and only IDD-originated comments
+refresh the required run. This is `idd-advisory-convergence`, not
+`lint.yml`.
 Repositories that want human-led or gradual IDD adoption should
 leave the check unregistered until they intend the Copilot-advisory
 loop.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1321,11 +1321,15 @@ workflow turns "Copilot's review converged on the current PR HEAD" from
 an instruction the execution model must choose to honor into a
 status check GitHub itself can enforce. It is opt-in — the template
 already mirrors the workflow at
-[`idd-template/.github/workflows/idd-advisory-convergence.yml`](.github/workflows/idd-advisory-convergence.yml);
-copy that one file into your repository's `.github/workflows/` to
-enable it. It is not wired in automatically by importing the rest of
-`idd-template/`, since adding a new required-status-check-able workflow
-is a deliberate adopter decision, not a default.
+[`idd-template/.github/workflows/idd-advisory-convergence.yml`](.github/workflows/idd-advisory-convergence.yml)
+and its comment-refresh companion
+[`idd-template/.github/workflows/idd-advisory-convergence-comment.yml`](.github/workflows/idd-advisory-convergence-comment.yml);
+copy both files into your repository's `.github/workflows/` to
+enable it. Register only the required job id
+`idd-advisory-convergence` as a status check — the companion is
+non-required. They are not wired in automatically by importing the
+rest of `idd-template/`, since adding a new required-status-check-able
+workflow is a deliberate adopter decision, not a default.
 
 Adjust the command to your helper-runtime profile, and the
 `actions/checkout` version if needed — the mirrored file intentionally
@@ -1361,37 +1365,35 @@ drives every live GitHub API call the script makes (reviews, threads,
 comments), independent of what is checked out locally, so pinning the
 checkout to the trusted branch costs nothing functionally.
 
-Three automatic trigger types keep the verdict current: `pull_request`
-for the normal push case, plus two triggers for the ways convergence
-can change **without** a new push — `pull_request_review` for
-Copilot's review submission, and `pull_request_review_comment` for a
-reply posted, edited, or deleted on a review thread, including the
-disposition markers (`**Accepted**` / `**Rejected**`) triage posts,
-since those are exactly what flips a thread from blocking to
-dispositioned. A thread being resolved or
-unresolved via the "Resolve conversation" button
-(`pull_request_review_thread`) is a real GitHub webhook event, but it
-is **not** one of the events GitHub Actions supports as a workflow
-`on:` trigger — including it makes the whole workflow file fail
-GitHub's schema validation (confirmed both against GitHub's own
+Two automatic trigger types keep the required verdict current:
+`pull_request` for the normal push case, and `pull_request_review` for
+Copilot's review submission. Review-thread comments are **not** on
+that required job. IDD-originated comments (a disposition prefix, the
+reply-identity stamp, or an operational marker the check already
+honors) refresh the existing HEAD-associated required run from the
+companion `idd-advisory-convergence-comment.yml` workflow, which
+calls `rerun-advisory-convergence --apply` and never reports
+`ready` itself. Ordinary human prose (`LGTM`) does not create or
+cancel the required check.
+
+A thread being resolved or unresolved via the "Resolve conversation"
+button (`pull_request_review_thread`) is a real GitHub webhook event,
+but it is **not** one of the events GitHub Actions supports as a
+workflow `on:` trigger — including it makes the whole workflow file
+fail GitHub's schema validation (confirmed both against GitHub's own
 trigger-events reference and empirically). Residual gap: if a
 Copilot-authored thread is resolved or reopened with no accompanying
-comment, push, or fresh Copilot review, this check keeps reporting its
-last computed verdict until one of the three automatic triggers fires
-or a maintainer runs the workflow's fourth trigger,
-`workflow_dispatch`, manually — an explicit "Run workflow" affordance
-for that case, taking a `pr_number` input since a manually dispatched
-run has no PR context of its own.
+comment, push, or fresh Copilot review, this check keeps reporting
+its last computed verdict until a push, a Copilot review, an
+IDD-originated comment refresh, or a maintainer `workflow_dispatch`
+fires.
 
-**Human-reply retrigger.** Those same comment and review triggers fire
-for every review-thread reply, edit, or delete — including ordinary
-human prose, not just IDD disposition markers. If you register
-`idd-advisory-convergence` as a required status check, that reply
-re-asserts the fail-closed Copilot verdict. The PR's required check
-can fail (Checks tab / merge rollup), and, because the workflow
-shares a PR-number concurrency group with `cancel-in-progress: true`,
-can cancel an in-flight run for that PR (observed 2026-08-17 on
-PR #2130). This is `idd-advisory-convergence`, not `lint.yml`.
+**Human-reply retrigger.** A casual human reply used to start the
+required `idd-advisory-convergence` job, fail or cancel the SHA
+verdict, and look like "the reply got linted" (observed 2026-08-17 on
+PR #2130). That path is now the companion comment workflow above,
+and only IDD-originated comments refresh the required run. This is
+`idd-advisory-convergence`, not `lint.yml`.
 Repositories that want human-led or gradual IDD adoption should
 leave the check unregistered until they intend the Copilot-advisory
 loop.

--- a/idd-template/README.md
+++ b/idd-template/README.md
@@ -138,6 +138,7 @@ generated separately in `ONBOARDING.md`.
 .github/instructions/lite/idd-review-fix-lite.instructions.md
 .github/instructions/lite/idd-review-snapshot-lite.instructions.md
 .github/instructions/lite/idd-work-lite.instructions.md
+.github/workflows/idd-advisory-convergence-comment.yml
 .github/workflows/idd-advisory-convergence.yml
 .github/workflows/post-merge-cleanup.yml
 .markdownlint-cli2.yaml

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -417,10 +417,11 @@ merges — a maintainer must separately register `idd-advisory-convergence`
 as a **required** status check in the repository's branch-protection
 Ruleset; this is a GitHub-settings action taken outside of IDD
 automation, not something an agent applies on its own. Once
-registered, every review-thread reply, edit, or delete re-asserts the
-same Copilot verdict — ordinary human prose can fail that required
-check on the PR and cancel an in-flight run (observed 2026-08-17 on
-PR #2130). This is `idd-advisory-convergence`, not `lint.yml`.
+registered, ordinary human review-thread replies do **not** re-assert
+that required check. IDD-originated comments refresh the existing
+HEAD-associated required run from the companion
+`idd-advisory-convergence-comment.yml` workflow. This is
+`idd-advisory-convergence`, not `lint.yml`.
 Repositories that want human-led or gradual IDD adoption should not
 register the check as required until they intend the Copilot-advisory
 loop. After that
@@ -438,14 +439,17 @@ once `ciGate.externalCheckWaivers.mode` is `maintainer-authorized`
 **and** `idd-advisory-convergence` is itself listed under
 `ciGate.externalChecks.waivable` — enabling waiver mode for some other
 external check never silently makes this one waivable too. **Posting a
-waiver comment does not by itself turn the check green**: a waiver is a
-regular PR comment, which is not one of the workflow's triggers
-(`pull_request` push, `pull_request_review` submission, or
-`pull_request_review_comment` created/edited/deleted on a review
-thread), so after posting a waiver a maintainer must also **re-run the
-existing** PR-linked check run **for the current HEAD SHA** — the
-Actions UI "Re-run jobs" button, or `gh run rerun <run-id>` — for the
-required check to actually reflect it. `workflow_dispatch` does
+waiver comment does not by itself turn the check green**: a waiver is
+a regular PR conversation comment, which is not one of the required
+workflow's triggers (`pull_request` push or `pull_request_review`
+submission), so after posting a waiver a maintainer must also
+**re-run the existing** PR-linked check run **for the current HEAD
+SHA** — the Actions UI "Re-run jobs" button, or
+`gh run rerun <run-id>` — for the required check to actually
+reflect it. An IDD-originated review-thread comment refreshes that
+same HEAD run via the companion
+`idd-advisory-convergence-comment.yml` workflow. `workflow_dispatch`
+does
 **not** reliably do this:
 a dispatched run has no `pull_request` context of its own, so GitHub
 associates it with the dispatch ref rather than the PR's HEAD SHA, and

--- a/scripts/review-comment-origin.mjs
+++ b/scripts/review-comment-origin.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/review-comment-origin.mts
+//
+// The scripts/review-comment-origin.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Classify a review-thread comment as IDD-originated vs ordinary human
+// chatter (#2136). Used by the non-required comment-refresh workflow so
+// a casual LGTM does not rerun the required idd-advisory-convergence
+// check, while an E6/E13 disposition, reply-identity stamp, or other
+// operational marker still can.
+import { appendFileSync } from 'node:fs';
+import { parseCliArgs } from './cli-args.mjs';
+import { loadIddConfig } from './idd-config.mjs';
+import { isIddOriginatedReply } from './marker-helpers.mjs';
+import {
+  isDispositionComment,
+  isRejectionConfirmedDisposition,
+  operationalMarkerPrefix,
+} from './protocol-helpers.mjs';
+
+const REVIEW_COMMENT_ORIGIN_FLAG_SPEC = {
+  '--body': { type: 'string', default: '' },
+  '--marker-prefix': { type: 'string', default: '' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+/**
+ * True when `body` is an IDD-originated review-thread utterance.
+ *
+ * Order is independent: any one signal is sufficient. Human prose
+ * (`LGTM`, `thanks`) matches none of these.
+ */
+export function classifyReviewCommentOrigin(body, markerPrefix) {
+  const text = body ?? '';
+  const reasons = [];
+  if (isIddOriginatedReply(text, markerPrefix)) {
+    reasons.push('review-reply-stamp');
+  }
+  if (isDispositionComment({ body: text })) {
+    reasons.push('disposition-prefix');
+  }
+  if (isRejectionConfirmedDisposition({ body: text })) {
+    reasons.push('rejection-confirmed');
+  }
+  if (operationalMarkerPrefix(text)) {
+    reasons.push('operational-marker');
+  }
+  return { iddOriginated: reasons.length > 0, reasons };
+}
+export function isIddOriginatedReviewComment(body, markerPrefix) {
+  return classifyReviewCommentOrigin(body, markerPrefix).iddOriginated;
+}
+const USAGE = `Usage:
+  node scripts/review-comment-origin.mjs [--body <text>] [--marker-prefix <prefix>]
+
+Classify a review-thread comment as IDD-originated. Prints JSON
+{iddOriginated, reasons} to stdout. --body defaults to $COMMENT_BODY
+so a GitHub Actions env: pass does not have to put the comment on the
+argv. Exit 0 always on a successful classify (including "not
+originated"); a non-zero exit is a usage or parse error.
+`;
+function resolveMarkerPrefix(flagValue) {
+  const trimmed = flagValue.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+  const fromConfig = loadIddConfig()?.markerPrefix;
+  return typeof fromConfig === 'string' && fromConfig.trim()
+    ? fromConfig.trim()
+    : undefined;
+}
+if (import.meta.main) {
+  const args = parseCliArgs(
+    process.argv.slice(2),
+    REVIEW_COMMENT_ORIGIN_FLAG_SPEC,
+  );
+  if (args.help) {
+    process.stdout.write(USAGE);
+    process.exitCode = 0;
+  } else {
+    const flaggedBody =
+      typeof args.values.body === 'string' ? args.values.body : '';
+    const body =
+      flaggedBody.length > 0 ? flaggedBody : (process.env.COMMENT_BODY ?? '');
+    const verdict = classifyReviewCommentOrigin(
+      body,
+      resolveMarkerPrefix(
+        typeof args.values['marker-prefix'] === 'string'
+          ? args.values['marker-prefix']
+          : '',
+      ),
+    );
+    process.stdout.write(`${JSON.stringify(verdict)}\n`);
+    const githubOutput = process.env.GITHUB_OUTPUT;
+    if (githubOutput) {
+      appendFileSync(
+        githubOutput,
+        `idd_originated=${verdict.iddOriginated ? 'true' : 'false'}\n`,
+      );
+    }
+    process.exitCode = 0;
+  }
+}

--- a/src/scripts/review-comment-origin.mts
+++ b/src/scripts/review-comment-origin.mts
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/review-comment-origin.mts
+//
+// The scripts/review-comment-origin.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Classify a review-thread comment as IDD-originated vs ordinary human
+// chatter (#2136). Used by the non-required comment-refresh workflow so
+// a casual LGTM does not rerun the required idd-advisory-convergence
+// check, while an E6/E13 disposition, reply-identity stamp, or other
+// operational marker still can.
+
+import { appendFileSync } from 'node:fs';
+
+import { parseCliArgs } from './cli-args.mts';
+import { loadIddConfig } from './idd-config.mts';
+import { isIddOriginatedReply } from './marker-helpers.mts';
+import {
+  isDispositionComment,
+  isRejectionConfirmedDisposition,
+  operationalMarkerPrefix,
+} from './protocol-helpers.mts';
+
+const REVIEW_COMMENT_ORIGIN_FLAG_SPEC = {
+  '--body': { type: 'string', default: '' },
+  '--marker-prefix': { type: 'string', default: '' },
+  '--help': { type: 'boolean', short: 'h' },
+} as const;
+
+export interface ReviewCommentOriginVerdict {
+  iddOriginated: boolean;
+  reasons: string[];
+}
+
+/**
+ * True when `body` is an IDD-originated review-thread utterance.
+ *
+ * Order is independent: any one signal is sufficient. Human prose
+ * (`LGTM`, `thanks`) matches none of these.
+ */
+export function classifyReviewCommentOrigin(
+  body: string,
+  markerPrefix?: string,
+): ReviewCommentOriginVerdict {
+  const text = body ?? '';
+  const reasons: string[] = [];
+  if (isIddOriginatedReply(text, markerPrefix)) {
+    reasons.push('review-reply-stamp');
+  }
+  if (isDispositionComment({ body: text })) {
+    reasons.push('disposition-prefix');
+  }
+  if (isRejectionConfirmedDisposition({ body: text })) {
+    reasons.push('rejection-confirmed');
+  }
+  if (operationalMarkerPrefix(text)) {
+    reasons.push('operational-marker');
+  }
+  return { iddOriginated: reasons.length > 0, reasons };
+}
+
+export function isIddOriginatedReviewComment(
+  body: string,
+  markerPrefix?: string,
+): boolean {
+  return classifyReviewCommentOrigin(body, markerPrefix).iddOriginated;
+}
+
+const USAGE = `Usage:
+  node scripts/review-comment-origin.mjs [--body <text>] [--marker-prefix <prefix>]
+
+Classify a review-thread comment as IDD-originated. Prints JSON
+{iddOriginated, reasons} to stdout. --body defaults to $COMMENT_BODY
+so a GitHub Actions env: pass does not have to put the comment on the
+argv. Exit 0 always on a successful classify (including "not
+originated"); a non-zero exit is a usage or parse error.
+`;
+
+function resolveMarkerPrefix(flagValue: string): string | undefined {
+  const trimmed = flagValue.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+  const fromConfig = loadIddConfig()?.markerPrefix;
+  return typeof fromConfig === 'string' && fromConfig.trim()
+    ? fromConfig.trim()
+    : undefined;
+}
+
+if (import.meta.main) {
+  const args = parseCliArgs(
+    process.argv.slice(2),
+    REVIEW_COMMENT_ORIGIN_FLAG_SPEC,
+  );
+  if (args.help) {
+    process.stdout.write(USAGE);
+    process.exitCode = 0;
+  } else {
+    const flaggedBody =
+      typeof args.values.body === 'string' ? args.values.body : '';
+    const body =
+      flaggedBody.length > 0 ? flaggedBody : (process.env.COMMENT_BODY ?? '');
+    const verdict = classifyReviewCommentOrigin(
+      body,
+      resolveMarkerPrefix(
+        typeof args.values['marker-prefix'] === 'string'
+          ? args.values['marker-prefix']
+          : '',
+      ),
+    );
+    process.stdout.write(`${JSON.stringify(verdict)}\n`);
+    const githubOutput = process.env.GITHUB_OUTPUT;
+    if (githubOutput) {
+      appendFileSync(
+        githubOutput,
+        `idd_originated=${verdict.iddOriginated ? 'true' : 'false'}\n`,
+      );
+    }
+    process.exitCode = 0;
+  }
+}

--- a/tests/advisory-convergence-comment-workflow.test.mts
+++ b/tests/advisory-convergence-comment-workflow.test.mts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+function readWorkflow(rel: string): string {
+  return readFileSync(new URL(`../${rel}`, import.meta.url), 'utf8');
+}
+
+const REQUIRED_PATHS = [
+  '.github/workflows/idd-advisory-convergence.yml',
+  'idd-template/.github/workflows/idd-advisory-convergence.yml',
+] as const;
+
+const COMMENT_PATHS = [
+  '.github/workflows/idd-advisory-convergence-comment.yml',
+  'idd-template/.github/workflows/idd-advisory-convergence-comment.yml',
+] as const;
+
+test('required advisory-convergence workflows keep the required job id', () => {
+  for (const path of REQUIRED_PATHS) {
+    const text = readWorkflow(path);
+    assert.match(
+      text,
+      /^ {2}idd-advisory-convergence:$/m,
+      `${path} must keep job id idd-advisory-convergence`,
+    );
+  }
+});
+
+test('required advisory-convergence workflows no longer trigger on review comments', () => {
+  for (const path of REQUIRED_PATHS) {
+    const text = readWorkflow(path);
+    // The `on:` block must not list pull_request_review_comment as a trigger.
+    const onBlock = text.slice(
+      text.indexOf('\non:'),
+      text.indexOf('\npermissions:'),
+    );
+    assert.doesNotMatch(
+      onBlock,
+      /pull_request_review_comment/,
+      `${path} on: must not include pull_request_review_comment`,
+    );
+    assert.match(onBlock, /pull_request:/);
+    assert.match(onBlock, /pull_request_review:/);
+  }
+});
+
+test('comment-refresh workflows are non-required and use a different job id', () => {
+  for (const path of COMMENT_PATHS) {
+    const text = readWorkflow(path);
+    assert.doesNotMatch(
+      text,
+      /^ {2}idd-advisory-convergence:$/m,
+      `${path} must not reuse the required job id`,
+    );
+    assert.match(text, /^ {2}refresh-if-idd-originated:$/m);
+    assert.match(text, /pull_request_review_comment:/);
+    assert.match(text, /rerun-advisory-convergence/);
+    assert.match(text, /review-comment-origin/);
+  }
+});
+
+test('comment-refresh workflow files exist next to the required copies', () => {
+  for (const path of COMMENT_PATHS) {
+    assert.ok(readFileSync(`${REPO_ROOT}/${path}`, 'utf8').length > 0);
+  }
+});

--- a/tests/advisory-convergence-comment-workflow.test.mts
+++ b/tests/advisory-convergence-comment-workflow.test.mts
@@ -60,6 +60,11 @@ test('comment-refresh workflows are non-required and use a different job id', ()
     assert.match(text, /pull_request_review_comment:/);
     assert.match(text, /rerun-advisory-convergence/);
     assert.match(text, /review-comment-origin/);
+    assert.match(
+      text,
+      /cancel-in-progress:\s*false/,
+      `${path} must not cancel an in-flight IDD refresh`,
+    );
   }
 });
 

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -1775,6 +1775,10 @@ test("audit/sync-manifest.json's guarded repo state: this repository's own engin
         mode: 'full-range',
       },
       {
+        file: '.github/workflows/idd-advisory-convergence-comment.yml',
+        mode: 'full-range',
+      },
+      {
         file: '.github/workflows/pnpm-boundary-node22-floor.yml',
         mode: 'low-bound-contains',
       },

--- a/tests/help-text-flags.test.mts
+++ b/tests/help-text-flags.test.mts
@@ -191,6 +191,7 @@ const COVERED_HELPERS = [
   'resume-claim-routing',
   'resume-route-selection',
   'review-activity-snapshot',
+  'review-comment-origin',
   'review-disposition-verify',
   'select-desynced-index',
   'stalled-session-quiet-check',

--- a/tests/review-comment-origin.test.mts
+++ b/tests/review-comment-origin.test.mts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { renderReviewReplyStamp } from '../src/scripts/marker-helpers.mts';
+import {
+  classifyReviewCommentOrigin,
+  isIddOriginatedReviewComment,
+} from '../src/scripts/review-comment-origin.mts';
+
+test('ordinary human review chatter is not IDD-originated', () => {
+  for (const body of ['LGTM', 'thanks, fixed', 'Looks good to me.']) {
+    assert.equal(isIddOriginatedReviewComment(body), false, body);
+    assert.deepEqual(classifyReviewCommentOrigin(body).reasons, []);
+  }
+});
+
+test('a disposition prefix is IDD-originated', () => {
+  const accepted = '**Accepted** — fixed in abc123';
+  const rejected = '**Rejected** — out of scope';
+  assert.equal(isIddOriginatedReviewComment(accepted), true);
+  assert.ok(
+    classifyReviewCommentOrigin(accepted).reasons.includes(
+      'disposition-prefix',
+    ),
+  );
+  assert.equal(isIddOriginatedReviewComment(rejected), true);
+});
+
+test('a reply-identity stamp is IDD-originated even without a disposition prefix', () => {
+  const stamped = `thanks\n\n${renderReviewReplyStamp()}`;
+  assert.equal(isIddOriginatedReviewComment(stamped), true);
+  assert.ok(
+    classifyReviewCommentOrigin(stamped).reasons.includes('review-reply-stamp'),
+  );
+});
+
+test('an operational first-bytes marker is IDD-originated', () => {
+  const ack = `review-ack: grok-test ${'a'.repeat(40)} 2026-08-18T00:00:00Z`;
+  assert.equal(isIddOriginatedReviewComment(ack), true);
+  assert.ok(
+    classifyReviewCommentOrigin(ack).reasons.includes('operational-marker'),
+  );
+});
+
+test('rejection-confirmed is IDD-originated', () => {
+  const body = '**Rejection confirmed by maintainer** — agreed';
+  assert.equal(isIddOriginatedReviewComment(body), true);
+  assert.ok(
+    classifyReviewCommentOrigin(body).reasons.includes('rejection-confirmed'),
+  );
+});


### PR DESCRIPTION
# Summary

Take `pull_request_review_comment` off the required
`idd-advisory-convergence` job so a casual `LGTM` no longer creates or
cancels that required check. A separate non-required companion
workflow refreshes the existing HEAD-associated required run only when
the comment is IDD-originated (disposition prefix, reply-identity
stamp, or an operational marker). The required job id is unchanged.

## Linked issue

Closes #2136

## Follow-up issues (if any)

- [ ] #2137 honor reviewPolicy when deciding applicability
- [ ] #2140 document the shipped hybrid review-reply identity contract

## Background / rationale (if material)

Hybrid and human-led PRs treat review-thread chatter as conversation,
not as a required-check trigger. The old comment trigger re-asserted
the whole Copilot verdict and shared the PR-number concurrency group
(`cancel-in-progress: true`), which is the check people felt as "the
reply got linted."

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed

The companion workflow needs `actions: write` so it can rerun the
existing required check. It never asserts `ready` itself.

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

`pnpm test` passed (3681 tests). Pre-push-validate and
`sync-docs --check` passed.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic refresh handling for advisory checks when IDD-originated review comments are created, edited, or deleted.
  - Added recognition of IDD-originated comment markers and operational signals.

- **Changed**
  - Ordinary human review-thread replies no longer retrigger or alter the required advisory check.
  - Updated the template and onboarding guidance to reflect the revised workflow behavior.

- **Documentation**
  - Updated the changelog, customization guides, onboarding instructions, and template inventory.

- **Tests**
  - Added coverage for comment classification, workflow triggers, refresh behavior, and help output consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->