### PR TITLE
feat(protocol-helpers): treat unmarked human replies as presence-only

### DIFF
--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -302,13 +302,21 @@ nonce was recorded for the active claim.
   (`dispositionEvidence.blockingCount == 0` — both
   `missingRegularComments` (any outstanding non-thread regular PR
   comment from a non-agent author, including the PR author, lacking a
-  fresh disposition marker) and `missingThreads` (any review thread,
-  resolved or unresolved, still lacking one) are empty). The
-  `advisory-convergence.mjs --assert` check above only enforces the
-  _unresolved_ Copilot-authored subset of `missingThreads` (resolution
-  alone satisfies its own Clause 2 without a fresh disposition); it
-  never covers a non-Copilot thread or any `missingRegularComments`
-  entry, so this check stays necessary even when that one passes. Treat
+  later IDD-agent reply — a fresh disposition marker for advisory-bot
+  comments, or any later IDD-agent body for a human comment) and
+  `missingThreads` (any review thread still lacking a clearing reply)
+  are empty). Evaluation splits by origin: a **human-authored** thread
+  whose latest item is unmarked human prose is presence-only and is
+  not `unresolved-without-fresh-disposition` solely for lacking
+  `**Accepted**`; a **Copilot / configured-advisory-bot** thread still
+  needs a stamped or legacy trusted IDD disposition (or resolution for
+  Clause 2). An unmarked human `ok` must not clear those advisory
+  threads. The `advisory-convergence.mjs --assert` check above only
+  enforces the _unresolved_ Copilot-authored subset of `missingThreads`
+  (resolution alone satisfies its own Clause 2 without a fresh
+  disposition); it never covers a non-Copilot thread or any
+  `missingRegularComments` entry, so this check stays necessary even
+  when that one passes. Treat
   a missing or malformed `dispositionEvidence` object, or a non-list
   `missingRegularComments`/`missingThreads`, as unmet, never vacuously
   satisfied. A `route: return-to-e1` result routes to E1/E4 with that

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -270,6 +270,14 @@ separate PATH A signal, not part of this pairing):
   inject it; a manual `gh api` JSON body must append it). The stamp is
   utterance identity, not an E1 `review-watermark`, and it must not
   replace the required `**Accepted**` / `**Rejected**` first bytes.
+  F2 treats an unmarked human reply on a **human-authored** thread as
+  presence-only; it does **not** treat that as a completed IDD
+  disposition. Copilot / configured-advisory-bot threads still require
+  a stamped or legacy trusted IDD disposition (or resolution). E7
+  still fails a recorded PATH A agent reply that lacks this marker
+  contract — presence-only is an evaluation rule for other people's
+  replies, not a license to post bare prose on the session's own
+  items.
 - Post **one disposition reply per advisory item** — never combine
   several markers into one comment; the 1:1 pairing clears only one item
   per comment, leaving the rest flagged `missing-disposition-evidence`.

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -297,13 +297,21 @@ nonce was recorded for the active claim.
   (`dispositionEvidence.blockingCount == 0` — both
   `missingRegularComments` (any outstanding non-thread regular PR
   comment from a non-agent author, including the PR author, lacking a
-  fresh disposition marker) and `missingThreads` (any review thread,
-  resolved or unresolved, still lacking one) are empty). The
-  `advisory-convergence.mjs --assert` check above only enforces the
-  _unresolved_ Copilot-authored subset of `missingThreads` (resolution
-  alone satisfies its own Clause 2 without a fresh disposition); it
-  never covers a non-Copilot thread or any `missingRegularComments`
-  entry, so this check stays necessary even when that one passes. Treat
+  later IDD-agent reply — a fresh disposition marker for advisory-bot
+  comments, or any later IDD-agent body for a human comment) and
+  `missingThreads` (any review thread still lacking a clearing reply)
+  are empty). Evaluation splits by origin: a **human-authored** thread
+  whose latest item is unmarked human prose is presence-only and is
+  not `unresolved-without-fresh-disposition` solely for lacking
+  `**Accepted**`; a **Copilot / configured-advisory-bot** thread still
+  needs a stamped or legacy trusted IDD disposition (or resolution for
+  Clause 2). An unmarked human `ok` must not clear those advisory
+  threads. The `advisory-convergence.mjs --assert` check above only
+  enforces the _unresolved_ Copilot-authored subset of `missingThreads`
+  (resolution alone satisfies its own Clause 2 without a fresh
+  disposition); it never covers a non-Copilot thread or any
+  `missingRegularComments` entry, so this check stays necessary even
+  when that one passes. Treat
   a missing or malformed `dispositionEvidence` object, or a non-list
   `missingRegularComments`/`missingThreads`, as unmet, never vacuously
   satisfied. A `route: return-to-e1` result routes to E1/E4 with that

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -265,6 +265,14 @@ separate PATH A signal, not part of this pairing):
   inject it; a manual `gh api` JSON body must append it). The stamp is
   utterance identity, not an E1 `review-watermark`, and it must not
   replace the required `**Accepted**` / `**Rejected**` first bytes.
+  F2 treats an unmarked human reply on a **human-authored** thread as
+  presence-only; it does **not** treat that as a completed IDD
+  disposition. Copilot / configured-advisory-bot threads still require
+  a stamped or legacy trusted IDD disposition (or resolution). E7
+  still fails a recorded PATH A agent reply that lacks this marker
+  contract — presence-only is an evaluation rule for other people's
+  replies, not a license to post bare prose on the session's own
+  items.
 - Post **one disposition reply per advisory item** — never combine
   several markers into one comment; the 1:1 pairing clears only one item
   per comment, leaving the rest flagged `missing-disposition-evidence`.

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -28,6 +28,7 @@ export * from './marker-helpers.mjs';
 import {
   findActivationNonceWinner,
   IDD_AGENT_DERIVED_MARKERS,
+  isIddOriginatedReply,
   isValidIsoTimestamp,
   operationalMarkerPrefix,
   operationalMarkerPrefixByStart,
@@ -899,10 +900,18 @@ export function hasFreshDisposition(thread, options = {}) {
   // Callers that require IDD-only dispositions (e.g., audit-pr-cleanup) should pass:
   //   { isDispositionAuthor: (login) => iddAgentLogins.has(login) }
   // This design trades stricter default behavior for backward compatibility with utility functions.
+  // `isIddOriginatedBody` (#2139) additionally accepts a stamped disposition
+  // regardless of author login: the #2135 review-reply stamp is utterance
+  // identity, so a stamped `**Accepted**` still clears an advisory thread
+  // even when the same trusted account also posts unmarked human prose.
   const dispositionAuthorPredicate =
     typeof options.isDispositionAuthor === 'function'
       ? options.isDispositionAuthor
       : (login) => !isKnownReviewBot(login);
+  const originatedBodyPredicate =
+    typeof options.isIddOriginatedBody === 'function'
+      ? options.isIddOriginatedBody
+      : null;
   const comments = thread.comments?.nodes ?? [];
   // A resolved thread may be terminally dispositioned with the documented
   // `**Rejection confirmed by maintainer**` marker instead of a fresh
@@ -912,24 +921,26 @@ export function hasFreshDisposition(thread, options = {}) {
   const isDisposition = (comment) =>
     isDispositionComment(comment) ||
     (threadResolved && isRejectionConfirmedDisposition(comment));
+  const isIddDisposition = (comment) => {
+    if (!isDisposition(comment)) {
+      return false;
+    }
+    const authorLogin = String(comment.author?.login ?? '')
+      .trim()
+      .toLowerCase();
+    if (dispositionAuthorPredicate(authorLogin)) {
+      return true;
+    }
+    return Boolean(originatedBodyPredicate?.(String(comment.body ?? '')));
+  };
   const latestFeedbackAt = maxIsoTimestamp(
     comments
-      .filter((comment) => {
-        const authorLogin = String(comment.author?.login ?? '')
-          .trim()
-          .toLowerCase();
-        return !(
-          isDisposition(comment) && dispositionAuthorPredicate(authorLogin)
-        );
-      })
+      .filter((comment) => !isIddDisposition(comment))
       .map((comment) => effectiveThreadCommentActivityAt(comment))
       .filter(isValidIsoTimestamp),
   );
   return comments.some((comment) => {
-    const authorLogin = String(comment.author?.login ?? '')
-      .trim()
-      .toLowerCase();
-    if (!(isDisposition(comment) && dispositionAuthorPredicate(authorLogin))) {
+    if (!isIddDisposition(comment)) {
       return false;
     }
     const dispositionActivityAt = effectiveThreadCommentActivityAt(comment);
@@ -2696,6 +2707,34 @@ export function summarizeRegularCommentsForGate(comments, options = {}) {
 // Working rule: verify every advisory finding on this code with a byte-exact
 // repro before accepting it. #1182 / PR #1184 cycled through five advisory
 // rounds, each surfacing a distinct fail mode of exactly these gates.
+function isAdvisoryAuthoredThread(thread, advisoryBotLogins) {
+  const originating = (thread.comments?.nodes ?? [])[0];
+  return (
+    isCopilotReviewerLogin(originating?.author?.login) ||
+    isGateAdvisoryBotLogin(originating?.author?.login, advisoryBotLogins)
+  );
+}
+function isIddOriginatedThreadReply(comment, options) {
+  const body = String(comment.body ?? '');
+  if (isIddOriginatedReply(body, options.markerPrefix)) {
+    return true;
+  }
+  const authorLogin = String(comment.author?.login ?? '')
+    .trim()
+    .toLowerCase();
+  if (
+    !authorLogin ||
+    !(
+      options.iddAgentLogins.has(authorLogin) ||
+      options.trustedMarkerLogins.has(authorLogin)
+    )
+  ) {
+    return false;
+  }
+  return (
+    isDispositionComment({ body }) || isRejectionConfirmedDisposition({ body })
+  );
+}
 export function summarizeDispositionEvidenceForGate(
   { comments = [], threads = [] },
   options = {},
@@ -2718,6 +2757,7 @@ export function summarizeDispositionEvidenceForGate(
   const prAuthorLogin = String(options.prAuthorLogin ?? '')
     .trim()
     .toLowerCase();
+  const markerPrefix = options.markerPrefix;
   // #2014: An advisory bot can never anchor "dispositions exist", mirroring
   // `buildActivitySnapshotSummary`'s identical `dispositionAuthorLogins`
   // subtraction above (this file, "An advisory bot can never anchor..."
@@ -2935,14 +2975,28 @@ export function summarizeDispositionEvidenceForGate(
   // Walk the outstanding comments oldest-first and greedily consume the
   // earliest disposition marker strictly newer than each (markers that are not
   // newer than the current comment cannot address it or any later comment).
-  const dispositionTimes = dispositionComments
+  // 1:1 pairing of later IDD-agent replies. Advisory-bot outstanding
+  // comments still require a real disposition prefix. Human outstanding
+  // comments also accept an unmarked later IDD-agent reply (presence-only,
+  // #2139) so "thanks, fixed" clears the human item without hollowing out
+  // Copilot / CodeRabbit pairing.
+  const agentReplyComments = normalizedComments
     .filter(
-      (comment) => !consumedNoticeDispositionIndexes.has(comment.sortedIndex),
+      (comment) =>
+        iddAgentLogins.has(comment.authorLogin) &&
+        !consumedNoticeDispositionIndexes.has(comment.sortedIndex) &&
+        isValidIsoTimestamp(comment.activityAt) &&
+        !isOperationalOrDigestCommentForGate(
+          comment.body,
+          comment.authorLogin,
+          trustedMarkerLogins,
+        ),
     )
-    .map((comment) => comment.activityAt)
-    .filter(isValidIsoTimestamp)
-    .sort((left, right) => Date.parse(left) - Date.parse(right));
-  let markerCursor = 0;
+    .sort((left, right) => {
+      const byTime = compareIsoTimestamps(left.activityAt, right.activityAt);
+      return byTime !== 0 ? byTime : left.sortedIndex - right.sortedIndex;
+    });
+  const usedReplyIndexes = new Set();
   const missing = [];
   for (const comment of outstandingComments) {
     if (
@@ -2951,17 +3005,27 @@ export function summarizeDispositionEvidenceForGate(
     ) {
       continue;
     }
-    while (
-      markerCursor < dispositionTimes.length &&
-      compareIsoTimestamps(
-        dispositionTimes[markerCursor],
-        comment.activityAt,
-      ) <= 0
-    ) {
-      markerCursor += 1;
-    }
-    if (markerCursor < dispositionTimes.length) {
-      markerCursor += 1;
+    const requiresDispositionPrefix = isGateAdvisoryBotLogin(
+      comment.authorLogin,
+      advisoryBotLogins,
+    );
+    const reply = agentReplyComments.find((candidate) => {
+      if (usedReplyIndexes.has(candidate.sortedIndex)) {
+        return false;
+      }
+      if (compareIsoTimestamps(candidate.activityAt, comment.activityAt) <= 0) {
+        return false;
+      }
+      if (
+        requiresDispositionPrefix &&
+        !isDispositionComment({ body: candidate.body })
+      ) {
+        return false;
+      }
+      return true;
+    });
+    if (reply) {
+      usedReplyIndexes.add(reply.sortedIndex);
     } else {
       missing.push(comment);
     }
@@ -3142,10 +3206,37 @@ export function summarizeDispositionEvidenceForGate(
               String(login ?? '')
                 .trim()
                 .toLowerCase(),
+            ) ||
+            trustedMarkerLogins.has(
+              String(login ?? '')
+                .trim()
+                .toLowerCase(),
             ),
+          isIddOriginatedBody: (body) =>
+            isIddOriginatedReply(body, markerPrefix),
         })
       ) {
         return null;
+      }
+      // #2139: unmarked later replies on a *human-authored* thread are
+      // presence-only. Advisory-authored threads (Copilot / configured
+      // advisory bots) keep marker-first so an unmarked `ok` cannot
+      // satisfy Clause 2. An IDD-originated later reply that failed the
+      // freshness check above still falls through.
+      if (!isAdvisoryAuthoredThread(thread, advisoryBotLogins)) {
+        const laterReplies = commentsInThread.slice(1);
+        const hasUnmarkedHumanPresence =
+          laterReplies.length > 0 &&
+          !laterReplies.some((comment) =>
+            isIddOriginatedThreadReply(comment, {
+              iddAgentLogins,
+              trustedMarkerLogins,
+              markerPrefix,
+            }),
+          );
+        if (hasUnmarkedHumanPresence) {
+          return null;
+        }
       }
       // E1 only snapshots UNRESOLVED non-awaiting threads, and E7 only requires
       // dispositions for snapshot items. A thread that is already resolved and

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -25,6 +25,7 @@ export { DEFAULT_ADVISORY_BOT_LOGINS } from './advisory-wait-policy.mjs';
 // rule (it must never import back from this file).
 export * from './marker-helpers.mjs';
 
+import { loadIddConfig } from './idd-config.mjs';
 import {
   findActivationNonceWinner,
   IDD_AGENT_DERIVED_MARKERS,
@@ -2757,7 +2758,13 @@ export function summarizeDispositionEvidenceForGate(
   const prAuthorLogin = String(options.prAuthorLogin ?? '')
     .trim()
     .toLowerCase();
-  const markerPrefix = options.markerPrefix;
+  const explicitMarkerPrefix =
+    typeof options.markerPrefix === 'string' ? options.markerPrefix.trim() : '';
+  const configuredMarkerPrefix = String(
+    loadIddConfig()?.markerPrefix ?? '',
+  ).trim();
+  const markerPrefix =
+    explicitMarkerPrefix || configuredMarkerPrefix || undefined;
   // #2014: An advisory bot can never anchor "dispositions exist", mirroring
   // `buildActivitySnapshotSummary`'s identical `dispositionAuthorLogins`
   // subtraction above (this file, "An advisory bot can never anchor..."
@@ -3219,10 +3226,11 @@ export function summarizeDispositionEvidenceForGate(
         return null;
       }
       // #2139: unmarked later replies on a *human-authored* thread are
-      // presence-only. Advisory-authored threads (Copilot / configured
-      // advisory bots) keep marker-first so an unmarked `ok` cannot
-      // satisfy Clause 2. An IDD-originated later reply that failed the
-      // freshness check above still falls through.
+      // presence-only only when no IDD-originated reply exists in the
+      // thread. After a stamped or legacy trusted disposition, later
+      // human feedback still re-opens freshness (#978). Advisory-authored
+      // threads keep marker-first so an unmarked `ok` cannot satisfy
+      // Clause 2.
       if (!isAdvisoryAuthoredThread(thread, advisoryBotLogins)) {
         const laterReplies = commentsInThread.slice(1);
         const hasUnmarkedHumanPresence =

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -35,6 +35,7 @@ import type {
 import {
   findActivationNonceWinner,
   IDD_AGENT_DERIVED_MARKERS,
+  isIddOriginatedReply,
   isValidIsoTimestamp,
   operationalMarkerPrefix,
   operationalMarkerPrefixByStart,
@@ -1582,7 +1583,10 @@ function inferReviewerReopenedAt(thread: ThreadLike): string {
 
 export function hasFreshDisposition(
   thread: ThreadLike,
-  options: { isDispositionAuthor?: (login: string) => boolean } = {},
+  options: {
+    isDispositionAuthor?: (login: string) => boolean;
+    isIddOriginatedBody?: (body: string) => boolean;
+  } = {},
 ): boolean {
   // IMPORTANT: The default disposition-author predicate rejects known bots but accepts any human.
   // For F2/F3 merge-gate contexts (E7 disposition evidence), callers MUST pass
@@ -1590,10 +1594,18 @@ export function hasFreshDisposition(
   // Callers that require IDD-only dispositions (e.g., audit-pr-cleanup) should pass:
   //   { isDispositionAuthor: (login) => iddAgentLogins.has(login) }
   // This design trades stricter default behavior for backward compatibility with utility functions.
+  // `isIddOriginatedBody` (#2139) additionally accepts a stamped disposition
+  // regardless of author login: the #2135 review-reply stamp is utterance
+  // identity, so a stamped `**Accepted**` still clears an advisory thread
+  // even when the same trusted account also posts unmarked human prose.
   const dispositionAuthorPredicate =
     typeof options.isDispositionAuthor === 'function'
       ? options.isDispositionAuthor
       : (login: string) => !isKnownReviewBot(login);
+  const originatedBodyPredicate =
+    typeof options.isIddOriginatedBody === 'function'
+      ? options.isIddOriginatedBody
+      : null;
   const comments = thread.comments?.nodes ?? [];
   // A resolved thread may be terminally dispositioned with the documented
   // `**Rejection confirmed by maintainer**` marker instead of a fresh
@@ -1603,25 +1615,30 @@ export function hasFreshDisposition(
   const isDisposition = (comment: { body?: string | null }): boolean =>
     isDispositionComment(comment) ||
     (threadResolved && isRejectionConfirmedDisposition(comment));
+  const isIddDisposition = (comment: {
+    author?: AuthorRef | null;
+    body?: string | null;
+  }): boolean => {
+    if (!isDisposition(comment)) {
+      return false;
+    }
+    const authorLogin = String(comment.author?.login ?? '')
+      .trim()
+      .toLowerCase();
+    if (dispositionAuthorPredicate(authorLogin)) {
+      return true;
+    }
+    return Boolean(originatedBodyPredicate?.(String(comment.body ?? '')));
+  };
   const latestFeedbackAt = maxIsoTimestamp(
     comments
-      .filter((comment) => {
-        const authorLogin = String(comment.author?.login ?? '')
-          .trim()
-          .toLowerCase();
-        return !(
-          isDisposition(comment) && dispositionAuthorPredicate(authorLogin)
-        );
-      })
+      .filter((comment) => !isIddDisposition(comment))
       .map((comment) => effectiveThreadCommentActivityAt(comment))
       .filter(isValidIsoTimestamp),
   );
 
   return comments.some((comment) => {
-    const authorLogin = String(comment.author?.login ?? '')
-      .trim()
-      .toLowerCase();
-    if (!(isDisposition(comment) && dispositionAuthorPredicate(authorLogin))) {
+    if (!isIddDisposition(comment)) {
       return false;
     }
     const dispositionActivityAt = effectiveThreadCommentActivityAt(comment);
@@ -3616,6 +3633,46 @@ export function summarizeRegularCommentsForGate(
 // Working rule: verify every advisory finding on this code with a byte-exact
 // repro before accepting it. #1182 / PR #1184 cycled through five advisory
 // rounds, each surfacing a distinct fail mode of exactly these gates.
+function isAdvisoryAuthoredThread(
+  thread: ThreadLike,
+  advisoryBotLogins: Set<string>,
+): boolean {
+  const originating = (thread.comments?.nodes ?? [])[0];
+  return (
+    isCopilotReviewerLogin(originating?.author?.login) ||
+    isGateAdvisoryBotLogin(originating?.author?.login, advisoryBotLogins)
+  );
+}
+
+function isIddOriginatedThreadReply(
+  comment: { author?: AuthorRef | null; body?: string | null },
+  options: {
+    iddAgentLogins: Set<string>;
+    trustedMarkerLogins: Set<string>;
+    markerPrefix?: string;
+  },
+): boolean {
+  const body = String(comment.body ?? '');
+  if (isIddOriginatedReply(body, options.markerPrefix)) {
+    return true;
+  }
+  const authorLogin = String(comment.author?.login ?? '')
+    .trim()
+    .toLowerCase();
+  if (
+    !authorLogin ||
+    !(
+      options.iddAgentLogins.has(authorLogin) ||
+      options.trustedMarkerLogins.has(authorLogin)
+    )
+  ) {
+    return false;
+  }
+  return (
+    isDispositionComment({ body }) || isRejectionConfirmedDisposition({ body })
+  );
+}
+
 export function summarizeDispositionEvidenceForGate(
   {
     comments = [],
@@ -3627,6 +3684,7 @@ export function summarizeDispositionEvidenceForGate(
     trustedMarkerLogins?: unknown[] | null;
     prAuthorLogin?: string | null;
     snapshotBoundaryAt?: string | null;
+    markerPrefix?: string;
   } = {},
 ): DispositionEvidenceSummary {
   const iddAgentLogins = new Set(
@@ -3647,6 +3705,7 @@ export function summarizeDispositionEvidenceForGate(
   const prAuthorLogin = String(options.prAuthorLogin ?? '')
     .trim()
     .toLowerCase();
+  const markerPrefix = options.markerPrefix;
   // #2014: An advisory bot can never anchor "dispositions exist", mirroring
   // `buildActivitySnapshotSummary`'s identical `dispositionAuthorLogins`
   // subtraction above (this file, "An advisory bot can never anchor..."
@@ -3871,15 +3930,29 @@ export function summarizeDispositionEvidenceForGate(
   // Walk the outstanding comments oldest-first and greedily consume the
   // earliest disposition marker strictly newer than each (markers that are not
   // newer than the current comment cannot address it or any later comment).
-  const dispositionTimes = dispositionComments
+  // 1:1 pairing of later IDD-agent replies. Advisory-bot outstanding
+  // comments still require a real disposition prefix. Human outstanding
+  // comments also accept an unmarked later IDD-agent reply (presence-only,
+  // #2139) so "thanks, fixed" clears the human item without hollowing out
+  // Copilot / CodeRabbit pairing.
+  const agentReplyComments = normalizedComments
     .filter(
-      (comment) => !consumedNoticeDispositionIndexes.has(comment.sortedIndex),
+      (comment) =>
+        iddAgentLogins.has(comment.authorLogin) &&
+        !consumedNoticeDispositionIndexes.has(comment.sortedIndex) &&
+        isValidIsoTimestamp(comment.activityAt) &&
+        !isOperationalOrDigestCommentForGate(
+          comment.body,
+          comment.authorLogin,
+          trustedMarkerLogins,
+        ),
     )
-    .map((comment) => comment.activityAt)
-    .filter(isValidIsoTimestamp)
-    .sort((left, right) => Date.parse(left) - Date.parse(right));
+    .sort((left, right) => {
+      const byTime = compareIsoTimestamps(left.activityAt, right.activityAt);
+      return byTime !== 0 ? byTime : left.sortedIndex - right.sortedIndex;
+    });
 
-  let markerCursor = 0;
+  const usedReplyIndexes = new Set<number>();
   const missing: typeof outstandingComments = [];
   for (const comment of outstandingComments) {
     if (
@@ -3888,17 +3961,27 @@ export function summarizeDispositionEvidenceForGate(
     ) {
       continue;
     }
-    while (
-      markerCursor < dispositionTimes.length &&
-      compareIsoTimestamps(
-        dispositionTimes[markerCursor],
-        comment.activityAt,
-      ) <= 0
-    ) {
-      markerCursor += 1;
-    }
-    if (markerCursor < dispositionTimes.length) {
-      markerCursor += 1;
+    const requiresDispositionPrefix = isGateAdvisoryBotLogin(
+      comment.authorLogin,
+      advisoryBotLogins,
+    );
+    const reply = agentReplyComments.find((candidate) => {
+      if (usedReplyIndexes.has(candidate.sortedIndex)) {
+        return false;
+      }
+      if (compareIsoTimestamps(candidate.activityAt, comment.activityAt) <= 0) {
+        return false;
+      }
+      if (
+        requiresDispositionPrefix &&
+        !isDispositionComment({ body: candidate.body })
+      ) {
+        return false;
+      }
+      return true;
+    });
+    if (reply) {
+      usedReplyIndexes.add(reply.sortedIndex);
     } else {
       missing.push(comment);
     }
@@ -4084,10 +4167,37 @@ export function summarizeDispositionEvidenceForGate(
               String(login ?? '')
                 .trim()
                 .toLowerCase(),
+            ) ||
+            trustedMarkerLogins.has(
+              String(login ?? '')
+                .trim()
+                .toLowerCase(),
             ),
+          isIddOriginatedBody: (body) =>
+            isIddOriginatedReply(body, markerPrefix),
         })
       ) {
         return null;
+      }
+      // #2139: unmarked later replies on a *human-authored* thread are
+      // presence-only. Advisory-authored threads (Copilot / configured
+      // advisory bots) keep marker-first so an unmarked `ok` cannot
+      // satisfy Clause 2. An IDD-originated later reply that failed the
+      // freshness check above still falls through.
+      if (!isAdvisoryAuthoredThread(thread, advisoryBotLogins)) {
+        const laterReplies = commentsInThread.slice(1);
+        const hasUnmarkedHumanPresence =
+          laterReplies.length > 0 &&
+          !laterReplies.some((comment) =>
+            isIddOriginatedThreadReply(comment, {
+              iddAgentLogins,
+              trustedMarkerLogins,
+              markerPrefix,
+            }),
+          );
+        if (hasUnmarkedHumanPresence) {
+          return null;
+        }
       }
       // E1 only snapshots UNRESOLVED non-awaiting threads, and E7 only requires
       // dispositions for snapshot items. A thread that is already resolved and

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -27,6 +27,7 @@ export { DEFAULT_ADVISORY_BOT_LOGINS } from './advisory-wait-policy.mts';
 // rule (it must never import back from this file).
 export * from './marker-helpers.mts';
 
+import { loadIddConfig } from './idd-config.mts';
 import type {
   ParsedClaimMarker,
   ParsedForcedHandoffMarker,
@@ -3705,7 +3706,13 @@ export function summarizeDispositionEvidenceForGate(
   const prAuthorLogin = String(options.prAuthorLogin ?? '')
     .trim()
     .toLowerCase();
-  const markerPrefix = options.markerPrefix;
+  const explicitMarkerPrefix =
+    typeof options.markerPrefix === 'string' ? options.markerPrefix.trim() : '';
+  const configuredMarkerPrefix = String(
+    loadIddConfig()?.markerPrefix ?? '',
+  ).trim();
+  const markerPrefix =
+    explicitMarkerPrefix || configuredMarkerPrefix || undefined;
   // #2014: An advisory bot can never anchor "dispositions exist", mirroring
   // `buildActivitySnapshotSummary`'s identical `dispositionAuthorLogins`
   // subtraction above (this file, "An advisory bot can never anchor..."
@@ -4180,10 +4187,11 @@ export function summarizeDispositionEvidenceForGate(
         return null;
       }
       // #2139: unmarked later replies on a *human-authored* thread are
-      // presence-only. Advisory-authored threads (Copilot / configured
-      // advisory bots) keep marker-first so an unmarked `ok` cannot
-      // satisfy Clause 2. An IDD-originated later reply that failed the
-      // freshness check above still falls through.
+      // presence-only only when no IDD-originated reply exists in the
+      // thread. After a stamped or legacy trusted disposition, later
+      // human feedback still re-opens freshness (#978). Advisory-authored
+      // threads keep marker-first so an unmarked `ok` cannot satisfy
+      // Clause 2.
       if (!isAdvisoryAuthoredThread(thread, advisoryBotLogins)) {
         const laterReplies = commentsInThread.slice(1);
         const hasUnmarkedHumanPresence =

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { renderExternalCheckWaiverComment } from '../src/scripts/marker-helpers.mts';
+import {
+  renderExternalCheckWaiverComment,
+  renderReviewReplyStamp,
+} from '../src/scripts/marker-helpers.mts';
 import {
   fetchBranchRulesets,
   fetchGovernanceJson,
@@ -2281,7 +2284,7 @@ test('regular comment gate keeps forced-handoff markers visible without explicit
   );
 });
 
-test('disposition evidence blocks when a regular comment has no disposition marker reply', () => {
+test('disposition evidence accepts an unmarked IDD-agent reply to a regular human comment (#2139)', () => {
   const summary = summarizeDispositionEvidenceForGate(
     {
       comments: [
@@ -2303,10 +2306,39 @@ test('disposition evidence blocks when a regular comment has no disposition mark
     { iddAgentLogins: ['idd-bot'] },
   );
 
-  assert.equal(summary.route, 'return-to-e1');
-  assert.equal(summary.blockingCount, 1);
-  assert.equal(summary.missingRegularCommentCount, 1);
+  assert.equal(summary.route, 'proceed');
+  assert.equal(summary.blockingCount, 0);
+  assert.equal(summary.missingRegularCommentCount, 0);
   assert.equal(summary.missingThreadCount, 0);
+});
+
+test('disposition evidence still requires a disposition for an advisory-bot regular comment with unmarked prose (#2139)', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          body: '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n\nWalkthrough.',
+          author: { login: 'coderabbitai[bot]' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T00:00:01Z',
+          body: 'Thanks, updating now.',
+          author: { login: 'idd-bot' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['coderabbitai[bot]'],
+    },
+  );
+
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.missingRegularCommentCount, 1);
 });
 
 test('disposition evidence treats PATH A and PATH B as complete when both have markers', () => {
@@ -2503,7 +2535,7 @@ test('disposition evidence blocks unresolved threads without fresh disposition m
   );
 });
 
-test('disposition evidence rejects reviewer-authored Accepted marker in threads', () => {
+test('disposition evidence treats a reviewer-authored Accepted marker on a human thread as presence-only (#2139)', () => {
   const summary = summarizeDispositionEvidenceForGate(
     {
       comments: [],
@@ -2532,9 +2564,216 @@ test('disposition evidence rejects reviewer-authored Accepted marker in threads'
     { iddAgentLogins: ['idd-bot'] },
   );
 
+  assert.equal(summary.route, 'proceed');
+  assert.equal(summary.missingThreadCount, 0);
+});
+
+test('disposition evidence treats unmarked human prose on a human-authored thread as presence-only (#2139)', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-human-lgtm',
+          isResolved: false,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T00:00:00Z',
+                body: 'please fix the naming',
+              },
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T00:00:02Z',
+                body: 'LGTM, the rename looks good',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    { iddAgentLogins: ['idd-bot'], trustedMarkerLogins: ['maintainer'] },
+  );
+
+  assert.equal(summary.route, 'proceed');
+  assert.equal(summary.missingThreadCount, 0);
+});
+
+test('disposition evidence still flags a human-authored thread with no reply (#2139)', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-human-open',
+          isResolved: false,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T00:00:00Z',
+                body: 'please fix the naming',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    { iddAgentLogins: ['idd-bot'] },
+  );
+
   assert.equal(summary.route, 'return-to-e1');
   assert.equal(summary.missingThreadCount, 1);
-  assert.equal(summary.missingThreads[0].reason, 'missing-fresh-disposition');
+  assert.equal(
+    summary.missingThreads[0].reason,
+    'unresolved-without-fresh-disposition',
+  );
+});
+
+test('disposition evidence still flags a Copilot thread whose only reply is unmarked human prose (#2139)', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-copilot-ok',
+          isResolved: false,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'copilot' },
+                createdAt: '2026-05-12T00:00:00Z',
+                body: 'consider extracting this helper',
+              },
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T00:00:02Z',
+                body: 'ok',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    { iddAgentLogins: ['idd-bot'] },
+  );
+
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.missingThreadCount, 1);
+  assert.equal(
+    summary.missingThreads[0].reason,
+    'unresolved-without-fresh-disposition',
+  );
+});
+
+test('disposition evidence clears a Copilot thread with a stamped Accepted reply (#2139)', () => {
+  const stamp = renderReviewReplyStamp();
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-copilot-stamped',
+          isResolved: false,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'copilot' },
+                createdAt: '2026-05-12T00:00:00Z',
+                body: 'consider extracting this helper',
+              },
+              {
+                author: { login: 'idd-bot' },
+                createdAt: '2026-05-12T00:00:02Z',
+                body: `**Accepted** — extracted in abc123\n\n${stamp}`,
+              },
+            ],
+          },
+        },
+      ],
+    },
+    { iddAgentLogins: ['idd-bot'] },
+  );
+
+  assert.equal(summary.route, 'proceed');
+  assert.equal(summary.missingThreadCount, 0);
+});
+
+test('disposition evidence clears a Copilot thread with a legacy trusted Accepted reply (#2139)', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-copilot-legacy',
+          isResolved: false,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'copilot' },
+                createdAt: '2026-05-12T00:00:00Z',
+                body: 'consider extracting this helper',
+              },
+              {
+                author: { login: 'maintainer' },
+                createdAt: '2026-05-12T00:00:02Z',
+                body: '**Accepted** — extracted in abc123',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      trustedMarkerLogins: ['maintainer'],
+    },
+  );
+
+  assert.equal(summary.route, 'proceed');
+  assert.equal(summary.missingThreadCount, 0);
+});
+
+test('disposition evidence classifies a trusted maintainer LGTM as a human reply (#2139)', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-maintainer-lgtm',
+          isResolved: false,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T00:00:00Z',
+                body: 'please fix the naming',
+              },
+              {
+                author: { login: 'maintainer' },
+                createdAt: '2026-05-12T00:00:02Z',
+                body: 'LGTM',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      trustedMarkerLogins: ['maintainer'],
+    },
+  );
+
+  assert.equal(summary.route, 'proceed');
+  assert.equal(summary.missingThreadCount, 0);
 });
 
 test('disposition evidence accepts a resolved Rejection-confirmed-by-maintainer marker', () => {

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -2740,6 +2740,82 @@ test('disposition evidence clears a Copilot thread with a legacy trusted Accepte
   assert.equal(summary.missingThreadCount, 0);
 });
 
+test('disposition evidence keeps freshness after an IDD reply even if later human prose arrives (#2139)', () => {
+  const stamp = renderReviewReplyStamp();
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-stale-then-human',
+          isResolved: false,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T00:00:00Z',
+                body: 'please fix the naming',
+              },
+              {
+                author: { login: 'idd-bot' },
+                createdAt: '2026-05-12T00:00:02Z',
+                body: `**Accepted** — renamed in abc\n\n${stamp}`,
+              },
+              {
+                author: { login: 'reviewer-a' },
+                createdAt: '2026-05-12T00:00:04Z',
+                body: 'please reopen — still a problem',
+              },
+            ],
+          },
+        },
+      ],
+    },
+    { iddAgentLogins: ['idd-bot'] },
+  );
+
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(
+    summary.missingThreads[0].reason,
+    'unresolved-without-fresh-disposition',
+  );
+});
+
+test('disposition evidence recognizes a stamped Accepted under a custom markerPrefix (#2139)', () => {
+  const stamp = renderReviewReplyStamp('org-project');
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [],
+      threads: [
+        {
+          id: 'thread-custom-prefix',
+          isResolved: false,
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'copilot' },
+                createdAt: '2026-05-12T00:00:00Z',
+                body: 'consider extracting this helper',
+              },
+              {
+                author: { login: 'someone-else' },
+                createdAt: '2026-05-12T00:00:02Z',
+                body: `**Accepted** — extracted in abc123\n\n${stamp}`,
+              },
+            ],
+          },
+        },
+      ],
+    },
+    { iddAgentLogins: ['idd-bot'], markerPrefix: 'org-project' },
+  );
+
+  assert.equal(summary.route, 'proceed');
+  assert.equal(summary.missingThreadCount, 0);
+});
+
 test('disposition evidence classifies a trusted maintainer LGTM as a human reply (#2139)', () => {
   const summary = summarizeDispositionEvidenceForGate(
     {

--- a/tests/review-disposition-verify.test.mts
+++ b/tests/review-disposition-verify.test.mts
@@ -166,6 +166,19 @@ test('checkPathAItem: Rejected — no reply → fail', () => {
   assert.equal(result.checks.markerPresent, false);
 });
 
+test('checkPathAItem: Rejected — unmarked human prose is not a disposition (#2139)', () => {
+  const result = checkPathAItem({
+    id: 'a5-unmarked',
+    path: 'A',
+    type: 'review_thread',
+    decision: 'rejected',
+    markerReply: 'LGTM thanks, fixed',
+    threadResolved: true,
+  });
+  assert.equal(result.passed, false);
+  assert.equal(result.checks.markerPresent, false);
+});
+
 test('checkPathAItem: Rejected — regular_comment, null threadResolved → pass', () => {
   const result = checkPathAItem({
     id: 'a6',


### PR DESCRIPTION
# Summary

F2 disposition evidence no longer format-lints unmarked human review
replies. A later unmarked reply on a human-authored thread (or a later
IDD-agent body on a regular human PR comment) is presence-only. Copilot
and configured advisory-bot threads still require a stamped or legacy
trusted `**Accepted**` / `**Rejected**`, so an unmarked `ok` cannot
satisfy Clause 2.

## Linked issue

Closes #2139

## Follow-up issues (if any)

- [ ] #2140 documents the hybrid review-reply identity contract after
      the remaining sibling tracks land

## Background / rationale (if material)

The same `trustedMarkerActors` maintainer writes both IDD dispositions
and ordinary `LGTM` replies. Author login cannot tell those utterances
apart; #2135 already stamped IDD-originated replies. This track uses
that stamp (plus legacy trusted prefixes) so F2/E7 keep the marker
contract on the session's own replies without treating human chatter as
a failed disposition.

`src/scripts/advisory-convergence.mts` is intentionally untouched:
Clause 2 stays correct because Copilot threads remain in
`missingThreads` when the only reply is unmarked prose.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed