### PR TITLE
feat(advisory-convergence): print next-action diagnostics on assert fail

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -129,7 +129,15 @@ In the idd-skill source repository, the following optional helpers were adopted:
 - `scripts/advisory-convergence.mjs` for the F2 advisory/disposition
   sub-gate (#1340): a deterministic `converged`/`ready` verdict with an
   exit-code contract via `--assert`, claim-independent so it also works
-  as a required-check-able CI verdict
+  as a required-check-able CI verdict. Stdout is always the JSON
+  verdict only. When `--assert` fails (`ready` is false), a compact
+  English next-action block is written to stderr _before_ that JSON so
+  a GitHub Actions log surfaces the recovery command first (`#2142`).
+  The block is derived from verdict fields, not from rewriting
+  `reasons[]`. Under `GITHUB_ACTIONS=true` a `::notice::` line is
+  added as extra surfacing; it is not a substitute for the stderr
+  block. `reasons[]` wording and the `--assert` exit-code contract
+  stay unchanged.
 - `scripts/rerun-advisory-convergence.mjs` (#1431) for a rerun-plan
   diagnosis of stuck `idd-advisory-convergence` check-run rollups,
   read-only by default: fetches every check-run instance for a PR's

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -129,7 +129,15 @@ In the idd-skill source repository, the following optional helpers were adopted:
 - `scripts/advisory-convergence.mjs` for the F2 advisory/disposition
   sub-gate (#1340): a deterministic `converged`/`ready` verdict with an
   exit-code contract via `--assert`, claim-independent so it also works
-  as a required-check-able CI verdict
+  as a required-check-able CI verdict. Stdout is always the JSON
+  verdict only. When `--assert` fails (`ready` is false), a compact
+  English next-action block is written to stderr _before_ that JSON so
+  a GitHub Actions log surfaces the recovery command first (`#2142`).
+  The block is derived from verdict fields, not from rewriting
+  `reasons[]`. Under `GITHUB_ACTIONS=true` a `::notice::` line is
+  added as extra surfacing; it is not a substitute for the stderr
+  block. `reasons[]` wording and the `--assert` exit-code contract
+  stay unchanged.
 - `scripts/rerun-advisory-convergence.mjs` (#1431) for a rerun-plan
   diagnosis of stuck `idd-advisory-convergence` check-run rollups,
   read-only by default: fetches every check-run instance for a PR's

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -2022,6 +2022,115 @@ function fetchThreadCommentPages(threadId, afterCursor) {
   }
   return nodes;
 }
+/**
+ * Compact next-action guidance for a non-ready `--assert` verdict (#2142).
+ * Derived from structured verdict fields, never from parsing `reasons[]`.
+ * Empty when `ready` is true. Script-authored English; not LLM prose.
+ */
+export function formatAssertNextActions(verdict) {
+  if (verdict.ready) {
+    return '';
+  }
+  const pr = verdict.prNumber;
+  const sha = verdict.prHeadSha;
+  const bot = verdict.primaryBotLogin || 'copilot';
+  const restLogin =
+    bot === 'copilot' ? 'copilot-pull-request-reviewer[bot]' : bot;
+  const lines = ['Next action (idd-advisory-convergence --assert failed):'];
+  if (verdict.applicability.status === 'indeterminate') {
+    lines.push(
+      `- Applicability is indeterminate (${verdict.applicability.reason}). Repair the claim linkage on issue comments (claimed-by branch vs PR head) or post a maintainer external-check waiver, then re-run: node scripts/advisory-convergence.mjs --pr ${pr} --assert`,
+    );
+  }
+  if (!verdict.review.found) {
+    lines.push(
+      `- ${bot} has not reviewed this PR. Request a review (E14) then post an advisory-wait marker:`,
+      `  gh api repos/<owner>/<repo>/pulls/${pr}/requested_reviewers -X POST -f "reviewers[]=${restLogin}"`,
+      `  node scripts/post-idd-marker.mjs --type advisory --target pr ${pr} --agent-id <id> --head-sha ${sha} --timestamp <ISO8601> --apply`,
+    );
+  } else if (!verdict.review.matchesHead) {
+    lines.push(
+      `- Latest ${bot} review covers ${verdict.review.commitId || '<unknown>'}, not HEAD ${sha}. Request a re-review of the current HEAD (E14 / AW3 REQUEST_NEEDED) and wait with: node scripts/advisory-wait-state.mjs --pr ${pr}`,
+    );
+  }
+  const itemCount = verdict.review.itemCount;
+  if (
+    verdict.review.matchesHead &&
+    typeof itemCount === 'number' &&
+    itemCount > 0
+  ) {
+    lines.push(
+      `- Latest ${bot} review on HEAD has ${itemCount} posted item(s). Disposition each thread (E6/E13): node scripts/resolve-review-thread.mjs --pr ${pr} --comment-id <id> --body "**Accepted** — …" --claim-issue <n> --claim-id <id> --apply`,
+    );
+  }
+  if (verdict.threads.blockingCount > 0) {
+    const ids =
+      verdict.threads.blockingIds.join(', ') || '(see threads.blockingIds)';
+    lines.push(
+      `- ${verdict.threads.blockingCount} Copilot thread(s) are unresolved and lack a valid disposition (${ids}). Reply with a stamped **Accepted**/**Rejected** and resolve via resolve-review-thread (E6/E13).`,
+    );
+  }
+  if (verdict.review.suppressedCount > 0) {
+    lines.push(
+      `- Latest ${bot} review reports ${verdict.review.suppressedCount} suppressed comment(s). After reading the review body, post a trusted review-ack if they are handled: node scripts/post-idd-marker.mjs --type review-ack --target pr ${pr} --agent-id <id> --head-sha ${sha} --timestamp <ISO8601> --apply`,
+    );
+  }
+  if (verdict.terminal.state === 'COPILOT_UNAVAILABLE') {
+    if (verdict.waiver.mode === 'maintainer-authorized') {
+      lines.push(
+        `- Copilot is terminally unavailable. Post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha} (idd-pre-merge F2 / external-check-waiver), then: node scripts/rerun-advisory-convergence.mjs --pr ${pr}`,
+      );
+    } else {
+      lines.push(
+        `- Copilot is terminally unavailable and waivers are not enabled (mode "${verdict.waiver.mode}"). Hold for a maintainer; do not auto-merge.`,
+      );
+    }
+  } else if (verdict.deadline.passed) {
+    if (verdict.waiver.mode === 'maintainer-authorized') {
+      lines.push(
+        `- Convergence deadline (${verdict.deadline.minutes}m) has passed. Post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha}, then rerun the required check.`,
+      );
+    } else {
+      lines.push(
+        `- Convergence deadline (${verdict.deadline.minutes}m) has passed and waivers are not enabled (mode "${verdict.waiver.mode}"). Hold for a maintainer.`,
+      );
+    }
+  }
+  if (verdict.sameHeadReroll.requestable) {
+    lines.push(
+      `- Same-HEAD reroll is still requestable. Diagnose and rerun one instance at a time: node scripts/rerun-advisory-convergence.mjs --pr ${pr}`,
+    );
+  }
+  if (lines.length === 1) {
+    lines.push(
+      `- Re-read the JSON verdict on stdout and follow idd-advisory-wait.instructions.md / idd-pre-merge.instructions.md F2. Then: node scripts/advisory-convergence.mjs --pr ${pr} --assert`,
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+/** Write next-action guidance (stderr, first) then the JSON verdict (stdout). */
+export function writeAdvisoryConvergenceCliOutput(
+  verdict,
+  streams = process,
+  env = process.env,
+) {
+  if (!verdict.ready) {
+    const next = formatAssertNextActions(verdict);
+    if (next) {
+      streams.stderr.write(next);
+      if (env.GITHUB_ACTIONS === 'true') {
+        const summary = next
+          .split('\n')
+          .find((line) => line.startsWith('- '))
+          ?.replace(/^- /, '');
+        if (summary) {
+          streams.stderr.write(`::notice::${summary}\n`);
+        }
+      }
+    }
+  }
+  streams.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+}
 // CLI: emit the verdict as JSON and set the exit code when invoked directly.
 // Guarded behind `import.meta.main` so importing this module (for unit
 // tests) never parses process.argv, prints usage, or makes a `gh` call.
@@ -2032,7 +2141,7 @@ if (import.meta.main) {
   if (help) {
     printHelp();
   } else if (verdict) {
-    process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+    writeAdvisoryConvergenceCliOutput(verdict);
   }
   process.exit(exitCode);
 }

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -2038,14 +2038,20 @@ export function formatAssertNextActions(verdict) {
     bot === 'copilot' ? 'copilot-pull-request-reviewer[bot]' : bot;
   const lines = ['Next action (idd-advisory-convergence --assert failed):'];
   if (verdict.applicability.status === 'indeterminate') {
+    const waiverReady =
+      (verdict.deadline.passed ||
+        verdict.terminal.state === 'COPILOT_UNAVAILABLE') &&
+      verdict.waiver.mode === 'maintainer-authorized';
     lines.push(
-      `- Applicability is indeterminate (${verdict.applicability.reason}). Repair the claim linkage on issue comments (claimed-by branch vs PR head) or post a maintainer external-check waiver, then re-run: node scripts/advisory-convergence.mjs --pr ${pr} --assert`,
+      waiverReady
+        ? `- Applicability is indeterminate (${verdict.applicability.reason}). Repair the claim linkage (claimed-by branch vs PR head) or post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha}, then: node scripts/advisory-convergence.mjs --pr ${pr} --assert`
+        : `- Applicability is indeterminate (${verdict.applicability.reason}). Repair the claim linkage (claimed-by branch vs PR head), then: node scripts/advisory-convergence.mjs --pr ${pr} --assert`,
     );
   }
   if (!verdict.review.found) {
     lines.push(
       `- ${bot} has not reviewed this PR. Request a review (E14) then post an advisory-wait marker:`,
-      `  gh api repos/<owner>/<repo>/pulls/${pr}/requested_reviewers -X POST -f "reviewers[]=${restLogin}"`,
+      `  gh pr edit ${pr} --add-reviewer ${bot === 'copilot' ? 'copilot' : restLogin}`,
       `  node scripts/post-idd-marker.mjs --type advisory --target pr ${pr} --agent-id <id> --head-sha ${sha} --timestamp <ISO8601> --apply`,
     );
   } else if (!verdict.review.matchesHead) {
@@ -2108,28 +2114,29 @@ export function formatAssertNextActions(verdict) {
   }
   return `${lines.join('\n')}\n`;
 }
-/** Write next-action guidance (stderr, first) then the JSON verdict (stdout). */
-export function writeAdvisoryConvergenceCliOutput(
-  verdict,
-  streams = process,
-  env = process.env,
-) {
-  if (!verdict.ready) {
+/** Write next-action guidance (stderr, first) then the JSON verdict (stdout).
+ * Guidance is emitted only when `emitGuidance` is true (the `--assert`
+ * failure path). Report-only runs keep stdout JSON and a silent stderr. */
+export function writeAdvisoryConvergenceCliOutput(verdict, options = {}) {
+  const stdout = options.stdout ?? process.stdout;
+  const stderr = options.stderr ?? process.stderr;
+  const env = options.env ?? process.env;
+  if (options.emitGuidance && !verdict.ready) {
     const next = formatAssertNextActions(verdict);
     if (next) {
-      streams.stderr.write(next);
+      stderr.write(next);
       if (env.GITHUB_ACTIONS === 'true') {
         const summary = next
           .split('\n')
           .find((line) => line.startsWith('- '))
           ?.replace(/^- /, '');
         if (summary) {
-          streams.stderr.write(`::notice::${summary}\n`);
+          stderr.write(`::notice::${summary}\n`);
         }
       }
     }
   }
-  streams.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
 }
 // CLI: emit the verdict as JSON and set the exit code when invoked directly.
 // Guarded behind `import.meta.main` so importing this module (for unit
@@ -2141,7 +2148,9 @@ if (import.meta.main) {
   if (help) {
     printHelp();
   } else if (verdict) {
-    writeAdvisoryConvergenceCliOutput(verdict);
+    writeAdvisoryConvergenceCliOutput(verdict, {
+      emitGuidance: exitCode !== 0,
+    });
   }
   process.exit(exitCode);
 }

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -2663,15 +2663,21 @@ export function formatAssertNextActions(
   ];
 
   if (verdict.applicability.status === 'indeterminate') {
+    const waiverReady =
+      (verdict.deadline.passed ||
+        verdict.terminal.state === 'COPILOT_UNAVAILABLE') &&
+      verdict.waiver.mode === 'maintainer-authorized';
     lines.push(
-      `- Applicability is indeterminate (${verdict.applicability.reason}). Repair the claim linkage on issue comments (claimed-by branch vs PR head) or post a maintainer external-check waiver, then re-run: node scripts/advisory-convergence.mjs --pr ${pr} --assert`,
+      waiverReady
+        ? `- Applicability is indeterminate (${verdict.applicability.reason}). Repair the claim linkage (claimed-by branch vs PR head) or post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha}, then: node scripts/advisory-convergence.mjs --pr ${pr} --assert`
+        : `- Applicability is indeterminate (${verdict.applicability.reason}). Repair the claim linkage (claimed-by branch vs PR head), then: node scripts/advisory-convergence.mjs --pr ${pr} --assert`,
     );
   }
 
   if (!verdict.review.found) {
     lines.push(
       `- ${bot} has not reviewed this PR. Request a review (E14) then post an advisory-wait marker:`,
-      `  gh api repos/<owner>/<repo>/pulls/${pr}/requested_reviewers -X POST -f "reviewers[]=${restLogin}"`,
+      `  gh pr edit ${pr} --add-reviewer ${bot === 'copilot' ? 'copilot' : restLogin}`,
       `  node scripts/post-idd-marker.mjs --type advisory --target pr ${pr} --agent-id <id> --head-sha ${sha} --timestamp <ISO8601> --apply`,
     );
   } else if (!verdict.review.matchesHead) {
@@ -2742,31 +2748,37 @@ export function formatAssertNextActions(
   return `${lines.join('\n')}\n`;
 }
 
-/** Write next-action guidance (stderr, first) then the JSON verdict (stdout). */
+/** Write next-action guidance (stderr, first) then the JSON verdict (stdout).
+ * Guidance is emitted only when `emitGuidance` is true (the `--assert`
+ * failure path). Report-only runs keep stdout JSON and a silent stderr. */
 export function writeAdvisoryConvergenceCliOutput(
   verdict: AdvisoryConvergenceVerdict,
-  streams: {
-    stdout: { write: (chunk: string) => void };
-    stderr: { write: (chunk: string) => void };
-  } = process,
-  env: NodeJS.ProcessEnv = process.env,
+  options: {
+    emitGuidance?: boolean;
+    stdout?: { write: (chunk: string) => void };
+    stderr?: { write: (chunk: string) => void };
+    env?: NodeJS.ProcessEnv;
+  } = {},
 ): void {
-  if (!verdict.ready) {
+  const stdout = options.stdout ?? process.stdout;
+  const stderr = options.stderr ?? process.stderr;
+  const env = options.env ?? process.env;
+  if (options.emitGuidance && !verdict.ready) {
     const next = formatAssertNextActions(verdict);
     if (next) {
-      streams.stderr.write(next);
+      stderr.write(next);
       if (env.GITHUB_ACTIONS === 'true') {
         const summary = next
           .split('\n')
           .find((line) => line.startsWith('- '))
           ?.replace(/^- /, '');
         if (summary) {
-          streams.stderr.write(`::notice::${summary}\n`);
+          stderr.write(`::notice::${summary}\n`);
         }
       }
     }
   }
-  streams.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
 }
 
 // CLI: emit the verdict as JSON and set the exit code when invoked directly.
@@ -2779,7 +2791,9 @@ if (import.meta.main) {
   if (help) {
     printHelp();
   } else if (verdict) {
-    writeAdvisoryConvergenceCliOutput(verdict);
+    writeAdvisoryConvergenceCliOutput(verdict, {
+      emitGuidance: exitCode !== 0,
+    });
   }
   process.exit(exitCode);
 }

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -2642,6 +2642,133 @@ function fetchThreadCommentPages(
   return nodes;
 }
 
+/**
+ * Compact next-action guidance for a non-ready `--assert` verdict (#2142).
+ * Derived from structured verdict fields, never from parsing `reasons[]`.
+ * Empty when `ready` is true. Script-authored English; not LLM prose.
+ */
+export function formatAssertNextActions(
+  verdict: AdvisoryConvergenceVerdict,
+): string {
+  if (verdict.ready) {
+    return '';
+  }
+  const pr = verdict.prNumber;
+  const sha = verdict.prHeadSha;
+  const bot = verdict.primaryBotLogin || 'copilot';
+  const restLogin =
+    bot === 'copilot' ? 'copilot-pull-request-reviewer[bot]' : bot;
+  const lines: string[] = [
+    'Next action (idd-advisory-convergence --assert failed):',
+  ];
+
+  if (verdict.applicability.status === 'indeterminate') {
+    lines.push(
+      `- Applicability is indeterminate (${verdict.applicability.reason}). Repair the claim linkage on issue comments (claimed-by branch vs PR head) or post a maintainer external-check waiver, then re-run: node scripts/advisory-convergence.mjs --pr ${pr} --assert`,
+    );
+  }
+
+  if (!verdict.review.found) {
+    lines.push(
+      `- ${bot} has not reviewed this PR. Request a review (E14) then post an advisory-wait marker:`,
+      `  gh api repos/<owner>/<repo>/pulls/${pr}/requested_reviewers -X POST -f "reviewers[]=${restLogin}"`,
+      `  node scripts/post-idd-marker.mjs --type advisory --target pr ${pr} --agent-id <id> --head-sha ${sha} --timestamp <ISO8601> --apply`,
+    );
+  } else if (!verdict.review.matchesHead) {
+    lines.push(
+      `- Latest ${bot} review covers ${verdict.review.commitId || '<unknown>'}, not HEAD ${sha}. Request a re-review of the current HEAD (E14 / AW3 REQUEST_NEEDED) and wait with: node scripts/advisory-wait-state.mjs --pr ${pr}`,
+    );
+  }
+
+  const itemCount = verdict.review.itemCount;
+  if (
+    verdict.review.matchesHead &&
+    typeof itemCount === 'number' &&
+    itemCount > 0
+  ) {
+    lines.push(
+      `- Latest ${bot} review on HEAD has ${itemCount} posted item(s). Disposition each thread (E6/E13): node scripts/resolve-review-thread.mjs --pr ${pr} --comment-id <id> --body "**Accepted** — …" --claim-issue <n> --claim-id <id> --apply`,
+    );
+  }
+
+  if (verdict.threads.blockingCount > 0) {
+    const ids =
+      verdict.threads.blockingIds.join(', ') || '(see threads.blockingIds)';
+    lines.push(
+      `- ${verdict.threads.blockingCount} Copilot thread(s) are unresolved and lack a valid disposition (${ids}). Reply with a stamped **Accepted**/**Rejected** and resolve via resolve-review-thread (E6/E13).`,
+    );
+  }
+
+  if (verdict.review.suppressedCount > 0) {
+    lines.push(
+      `- Latest ${bot} review reports ${verdict.review.suppressedCount} suppressed comment(s). After reading the review body, post a trusted review-ack if they are handled: node scripts/post-idd-marker.mjs --type review-ack --target pr ${pr} --agent-id <id> --head-sha ${sha} --timestamp <ISO8601> --apply`,
+    );
+  }
+
+  if (verdict.terminal.state === 'COPILOT_UNAVAILABLE') {
+    if (verdict.waiver.mode === 'maintainer-authorized') {
+      lines.push(
+        `- Copilot is terminally unavailable. Post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha} (idd-pre-merge F2 / external-check-waiver), then: node scripts/rerun-advisory-convergence.mjs --pr ${pr}`,
+      );
+    } else {
+      lines.push(
+        `- Copilot is terminally unavailable and waivers are not enabled (mode "${verdict.waiver.mode}"). Hold for a maintainer; do not auto-merge.`,
+      );
+    }
+  } else if (verdict.deadline.passed) {
+    if (verdict.waiver.mode === 'maintainer-authorized') {
+      lines.push(
+        `- Convergence deadline (${verdict.deadline.minutes}m) has passed. Post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha}, then rerun the required check.`,
+      );
+    } else {
+      lines.push(
+        `- Convergence deadline (${verdict.deadline.minutes}m) has passed and waivers are not enabled (mode "${verdict.waiver.mode}"). Hold for a maintainer.`,
+      );
+    }
+  }
+
+  if (verdict.sameHeadReroll.requestable) {
+    lines.push(
+      `- Same-HEAD reroll is still requestable. Diagnose and rerun one instance at a time: node scripts/rerun-advisory-convergence.mjs --pr ${pr}`,
+    );
+  }
+
+  if (lines.length === 1) {
+    lines.push(
+      `- Re-read the JSON verdict on stdout and follow idd-advisory-wait.instructions.md / idd-pre-merge.instructions.md F2. Then: node scripts/advisory-convergence.mjs --pr ${pr} --assert`,
+    );
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+/** Write next-action guidance (stderr, first) then the JSON verdict (stdout). */
+export function writeAdvisoryConvergenceCliOutput(
+  verdict: AdvisoryConvergenceVerdict,
+  streams: {
+    stdout: { write: (chunk: string) => void };
+    stderr: { write: (chunk: string) => void };
+  } = process,
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (!verdict.ready) {
+    const next = formatAssertNextActions(verdict);
+    if (next) {
+      streams.stderr.write(next);
+      if (env.GITHUB_ACTIONS === 'true') {
+        const summary = next
+          .split('\n')
+          .find((line) => line.startsWith('- '))
+          ?.replace(/^- /, '');
+        if (summary) {
+          streams.stderr.write(`::notice::${summary}\n`);
+        }
+      }
+    }
+  }
+  streams.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+}
+
 // CLI: emit the verdict as JSON and set the exit code when invoked directly.
 // Guarded behind `import.meta.main` so importing this module (for unit
 // tests) never parses process.argv, prints usage, or makes a `gh` call.
@@ -2652,7 +2779,7 @@ if (import.meta.main) {
   if (help) {
     printHelp();
   } else if (verdict) {
-    process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+    writeAdvisoryConvergenceCliOutput(verdict);
   }
   process.exit(exitCode);
 }

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -3892,6 +3892,7 @@ test('formatAssertNextActions covers no-review and off-HEAD (#2142)', () => {
   const none = computeAdvisoryConvergenceVerdict(baseInputs(), baseOptions());
   const noneText = formatAssertNextActions(none);
   assert.match(noneText, /has not reviewed this PR/);
+  assert.match(noneText, /gh pr edit \d+ --add-reviewer copilot/);
   assert.match(noneText, /post-idd-marker\.mjs --type advisory/);
   assert.doesNotMatch(
     noneText,
@@ -4030,6 +4031,7 @@ test('formatAssertNextActions covers indeterminate applicability (#2142)', () =>
   });
   assert.match(text, /indeterminate/);
   assert.match(text, /claimed-by/);
+  assert.doesNotMatch(text, /external-check waiver/);
 });
 
 test('writeAdvisoryConvergenceCliOutput writes guidance before JSON (#2142)', () => {
@@ -4040,22 +4042,20 @@ test('writeAdvisoryConvergenceCliOutput writes guidance before JSON (#2142)', ()
   assert.equal(verdict.ready, false);
   let stdout = '';
   let stderr = '';
-  writeAdvisoryConvergenceCliOutput(
-    verdict,
-    {
-      stdout: {
-        write: (chunk) => {
-          stdout += chunk;
-        },
-      },
-      stderr: {
-        write: (chunk) => {
-          stderr += chunk;
-        },
+  writeAdvisoryConvergenceCliOutput(verdict, {
+    emitGuidance: true,
+    stdout: {
+      write: (chunk) => {
+        stdout += chunk;
       },
     },
-    {},
-  );
+    stderr: {
+      write: (chunk) => {
+        stderr += chunk;
+      },
+    },
+    env: {},
+  });
   assert.match(stderr, /Next action/);
   assert.match(stderr, /has not reviewed this PR/);
   const parsed = JSON.parse(stdout) as { ready: boolean; reasons: string[] };
@@ -4064,17 +4064,28 @@ test('writeAdvisoryConvergenceCliOutput writes guidance before JSON (#2142)', ()
   assert.doesNotMatch(stdout, /Next action/);
 
   let actionsErr = '';
-  writeAdvisoryConvergenceCliOutput(
-    verdict,
-    {
-      stdout: { write: () => undefined },
-      stderr: {
-        write: (chunk) => {
-          actionsErr += chunk;
-        },
+  writeAdvisoryConvergenceCliOutput(verdict, {
+    emitGuidance: true,
+    stdout: { write: () => undefined },
+    stderr: {
+      write: (chunk) => {
+        actionsErr += chunk;
       },
     },
-    { GITHUB_ACTIONS: 'true' },
-  );
+    env: { GITHUB_ACTIONS: 'true' },
+  });
   assert.match(actionsErr, /::notice::/);
+
+  let reportErr = '';
+  writeAdvisoryConvergenceCliOutput(verdict, {
+    emitGuidance: false,
+    stdout: { write: () => undefined },
+    stderr: {
+      write: (chunk) => {
+        reportErr += chunk;
+      },
+    },
+    env: { GITHUB_ACTIONS: 'true' },
+  });
+  assert.equal(reportErr, '');
 });

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -9,6 +9,7 @@ import {
   classifyClaimCandidateAmbiguity,
   classifyCopilotAuthoredThreadIds,
   computeAdvisoryConvergenceVerdict,
+  formatAssertNextActions,
   hasTrustedClaimMarkerHistory,
   isSoleCopilotNotReviewedYetReason,
   parseArgs,
@@ -18,6 +19,7 @@ import {
   runAdvisoryConvergenceWithPoll,
   SAME_HEAD_REROLL_INELIGIBLE_REASON,
   viewerProbeGhOptions,
+  writeAdvisoryConvergenceCliOutput,
 } from '../src/scripts/advisory-convergence.mts';
 import {
   renderAdvisoryWaitRecoveryMarker,
@@ -3865,4 +3867,214 @@ test('viewerProbeGhOptions captures gh stderr only under GitHub Actions', () => 
   );
   // Only the literal string 'true' opts in (matches GitHub's own value).
   assert.deepEqual(viewerProbeGhOptions({ GITHUB_ACTIONS: '1' }).stdio, local);
+});
+
+test('formatAssertNextActions is empty when the verdict is ready (#2142)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        {
+          author: { login: COPILOT_LOGIN },
+          submittedAt: RECENT,
+          commitId: HEAD,
+          itemCount: 0,
+          body: '',
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(verdict.ready, true);
+  assert.equal(formatAssertNextActions(verdict), '');
+});
+
+test('formatAssertNextActions covers no-review and off-HEAD (#2142)', () => {
+  const none = computeAdvisoryConvergenceVerdict(baseInputs(), baseOptions());
+  const noneText = formatAssertNextActions(none);
+  assert.match(noneText, /has not reviewed this PR/);
+  assert.match(noneText, /post-idd-marker\.mjs --type advisory/);
+  assert.doesNotMatch(
+    noneText,
+    /copilot has not reviewed this pull request yet/,
+  );
+
+  const offHead = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        {
+          author: { login: COPILOT_LOGIN },
+          submittedAt: RECENT,
+          commitId: OTHER_SHA,
+          itemCount: 0,
+          body: '',
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  const offText = formatAssertNextActions(offHead);
+  assert.match(offText, /not HEAD/);
+  assert.match(offText, /advisory-wait-state\.mjs/);
+});
+
+test('formatAssertNextActions covers posted items, threads, and suppressed (#2142)', () => {
+  const posted = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        {
+          author: { login: COPILOT_LOGIN },
+          submittedAt: RECENT,
+          commitId: HEAD,
+          itemCount: 2,
+          body: '',
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.match(formatAssertNextActions(posted), /2 posted item/);
+  assert.match(formatAssertNextActions(posted), /resolve-review-thread/);
+
+  const threads = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        {
+          author: { login: COPILOT_LOGIN },
+          submittedAt: RECENT,
+          commitId: HEAD,
+          itemCount: 0,
+          body: '',
+        },
+      ],
+      threads: [
+        {
+          id: 'thread-copilot-1',
+          isResolved: false,
+          comments: {
+            nodes: [
+              {
+                author: { login: COPILOT_LOGIN },
+                body: 'please extract this',
+                createdAt: RECENT,
+              },
+            ],
+          },
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  const threadText = formatAssertNextActions(threads);
+  assert.match(threadText, /thread-copilot-1/);
+  assert.match(threadText, /resolve-review-thread/);
+
+  const suppressed = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        {
+          author: { login: COPILOT_LOGIN },
+          submittedAt: RECENT,
+          commitId: HEAD,
+          itemCount: 0,
+          body: '<details><summary>Suppressed comments (2)</summary></details>',
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.match(formatAssertNextActions(suppressed), /suppressed comment/);
+  assert.match(formatAssertNextActions(suppressed), /--type review-ack/);
+});
+
+test('formatAssertNextActions covers deadline, terminal, and reroll (#2142)', () => {
+  const deadline = computeAdvisoryConvergenceVerdict(
+    baseInputs(),
+    baseOptions({ headCommittedAt: OLD, waiverMode: 'maintainer-authorized' }),
+  );
+  assert.equal(deadline.deadline.passed, true);
+  assert.match(formatAssertNextActions(deadline), /deadline/);
+  assert.match(formatAssertNextActions(deadline), /external-check waiver/);
+
+  const terminal = computeAdvisoryConvergenceVerdict(
+    baseInputs(),
+    baseOptions(),
+  );
+  const terminalText = formatAssertNextActions({
+    ...terminal,
+    ready: false,
+    terminal: { ...terminal.terminal, state: 'COPILOT_UNAVAILABLE' },
+    waiver: { ...terminal.waiver, mode: 'disabled' },
+  });
+  assert.match(terminalText, /terminally unavailable/);
+  assert.match(terminalText, /Hold for a maintainer/);
+
+  const reroll = formatAssertNextActions({
+    ...terminal,
+    ready: false,
+    sameHeadReroll: { ...terminal.sameHeadReroll, requestable: true },
+  });
+  assert.match(reroll, /Same-HEAD reroll/);
+  assert.match(reroll, /rerun-advisory-convergence/);
+});
+
+test('formatAssertNextActions covers indeterminate applicability (#2142)', () => {
+  const base = computeAdvisoryConvergenceVerdict(baseInputs(), baseOptions());
+  const text = formatAssertNextActions({
+    ...base,
+    ready: false,
+    applicability: {
+      scope: 'idd-claimed',
+      status: 'indeterminate',
+      reason: 'idd-claimed-branch-mismatch',
+    },
+  });
+  assert.match(text, /indeterminate/);
+  assert.match(text, /claimed-by/);
+});
+
+test('writeAdvisoryConvergenceCliOutput writes guidance before JSON (#2142)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs(),
+    baseOptions(),
+  );
+  assert.equal(verdict.ready, false);
+  let stdout = '';
+  let stderr = '';
+  writeAdvisoryConvergenceCliOutput(
+    verdict,
+    {
+      stdout: {
+        write: (chunk) => {
+          stdout += chunk;
+        },
+      },
+      stderr: {
+        write: (chunk) => {
+          stderr += chunk;
+        },
+      },
+    },
+    {},
+  );
+  assert.match(stderr, /Next action/);
+  assert.match(stderr, /has not reviewed this PR/);
+  const parsed = JSON.parse(stdout) as { ready: boolean; reasons: string[] };
+  assert.equal(parsed.ready, false);
+  assert.ok(parsed.reasons.length > 0);
+  assert.doesNotMatch(stdout, /Next action/);
+
+  let actionsErr = '';
+  writeAdvisoryConvergenceCliOutput(
+    verdict,
+    {
+      stdout: { write: () => undefined },
+      stderr: {
+        write: (chunk) => {
+          actionsErr += chunk;
+        },
+      },
+    },
+    { GITHUB_ACTIONS: 'true' },
+  );
+  assert.match(actionsErr, /::notice::/);
 });


### PR DESCRIPTION
# Summary

When `idd-advisory-convergence --assert` is not ready, the helper now
prints a compact English next-action block on stderr before the JSON
verdict on stdout. `reasons[]` wording and the exit-code contract are
unchanged.

## Linked issue

Closes #2142

## Follow-up issues (if any)

- [ ] #2143 adds structured `nextActions` on the verdict JSON itself

## Background / rationale (if material)

The CI job log was a 200-line verdict plus `##[error]`. Operators
needed a mechanical next command (review-ack, waiver, E14, rerun)
without fattening `reasons[]`, which `#2015` matches exactly.

Sibling `#2137` is in another session on the same helper file. This
PR only adds the formatter and CLI write order.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed