### PR TITLE
feat(advisory-convergence): honor reviewPolicy in applicability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ discipline and has no tag.
 
 ### Changed
 
+- `advisory-convergence` honors `reviewPolicy`: `human-required` and
+  `no-advisory` make the check `not_applicable` (ready without Copilot
+  clauses) instead of judging every applicable PR as Copilot-advisory.
+  `copilot-advisory`, absent, or an invalid value keep today's
+  fail-closed behavior. Profile artifacts now list the config field
+  and the "do not register this check unless you want an advisory-bot
+  gate" note on the same patch surface as the phase-file edits.
 - The required `idd-advisory-convergence` job no longer runs on
   `pull_request_review_comment`. Ordinary human review chatter no
   longer creates or cancels that required check. IDD-originated

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -168,6 +168,14 @@ authority:
 - `external-bot` when a non-Copilot reviewer has a stable actor identity
   and a current-head completion signal.
 
+`advisory-convergence` reads `reviewPolicy` when deciding
+applicability. `human-required` and `no-advisory` make the check
+`not_applicable` (ready without Copilot clauses). `copilot-advisory`,
+`external-bot`, absent, or an invalid value keep today's
+primary-bot applicability. Do not register
+`idd-advisory-convergence` as a required status check unless the
+chosen policy actually wants an advisory-bot gate.
+
 When importing the template, keep the `profiles/` directory with the
 copied docs. For any non-default PR review profile, use the matching
 `profiles/<profile>/README.md` artifact as the reusable patch surface.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1933,9 +1933,12 @@ reflexively as any other CLI option.
   from `deadline`. When `terminal.state` is `COPILOT_UNAVAILABLE`, the
   SAME waiver escape hatch above also opens — independent of whether the
   ordinary deadline has passed — but `ready` still requires a valid
-  waiver in addition (`ready = converged || ((deadline.passed ||
-  terminal.state == "COPILOT_UNAVAILABLE") && waived)`); the terminal
-  state alone never sets `ready: true`. Observed incident:
+  waiver in addition (`ready = not_applicable || converged ||
+  ((deadline.passed || terminal.state == "COPILOT_UNAVAILABLE") &&
+  waived)`); the terminal state alone never sets `ready: true`. A
+  `not_applicable` applicability (including `reviewPolicy`
+  `human-required` / `no-advisory`) is an independent ready path and
+  does not change this waiver rule. Observed incident:
   kurone-kito/idd-skill#1562. See `idd-advisory-wait.instructions.md`'s
   Terminal routing section for the full hold/rerun sequence.
 - **Eligibility-relevant disposition-evidence counters (`#1719`)**: the

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1863,8 +1863,24 @@ reflexively as any other CLI option.
   [`advisory-convergence.schema.json`][advisory-convergence-schema]
 - Every invocation other than `--help`/`-h` prints the JSON verdict.
   Without `--assert` it always exits `0` (report-only). With `--assert` it
-  exits non-zero unless `ready` is `true` (`ready = converged || (deadline
-  passed && validly waived)`).
+  exits non-zero unless `ready` is `true` (`ready = not_applicable ||
+  converged || ((deadline passed || terminal-unavailable) && validly
+  waived)`).
+- **Review-policy applicability (`#2137`)**: this helper reads
+  `reviewPolicy` from `.github/idd/config.json`. Exact
+  `human-required` or `no-advisory` classifies the PR `not_applicable`
+  (reasons `review-policy-human-required` /
+  `review-policy-no-advisory`) so `--assert` exits 0 through the
+  existing `scopeNotApplicable` path, not by faking `converged`.
+  Copilot review/thread clauses do not apply; human approval and
+  conversation resolution stay on branch protection and the phase
+  files. `copilot-advisory`, absent, or an invalid value keep today's
+  fail-closed Copilot applicability. `external-bot` keeps the
+  configured `primaryBotLogin` path. A trusted human approve is never
+  a Copilot substitute under `copilot-advisory`. Do not invent a new
+  `convergenceScope` value for this. Do not register
+  `idd-advisory-convergence` as a required check unless the policy
+  actually wants an advisory-bot gate.
 - **Bounded "not reviewed yet" poll (`#2015`)**: the CLI entry point runs
   through `runAdvisoryConvergenceWithPoll`, not `runAdvisoryConvergence`
   directly. When (and only when) the verdict's sole blocking reason is

--- a/docs/idd-review-policy-profiles.md
+++ b/docs/idd-review-policy-profiles.md
@@ -196,6 +196,9 @@ the authoritative review gate.
   `.github/instructions/idd-review-triage.instructions.md`: keep human
   comments in the review universe and remove assumptions that Copilot
   advisory PATH B items must appear.
+- `.github/idd/config.json`: set `reviewPolicy` to `human-required`.
+  Do not register `idd-advisory-convergence` as a required check
+  unless this policy actually wants an advisory-bot gate.
 - Repository settings: configure CODEOWNERS, required reviews, or branch
   protection outside IDD.
 - Verification evidence: capture a dry-run or PR-state example showing
@@ -214,6 +217,9 @@ branch protection, and any human review rules configured outside IDD.
 - `.github/instructions/idd-advisory-wait.instructions.md`: mark the
   advisory wait helper unused by this profile, or remove local
   references to it from the customized phase flow.
+- `.github/idd/config.json`: set `reviewPolicy` to `no-advisory`.
+  Do not register `idd-advisory-convergence` as a required check
+  unless this policy actually wants an advisory-bot gate.
 - `docs/idd-advisory-wait-shell-fallback.md`: mark the doc unused by
   this profile, or remove local references to it, matching the
   `idd-advisory-wait.instructions.md` disposition above.

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -168,6 +168,14 @@ authority:
 - `external-bot` when a non-Copilot reviewer has a stable actor identity
   and a current-head completion signal.
 
+`advisory-convergence` reads `reviewPolicy` when deciding
+applicability. `human-required` and `no-advisory` make the check
+`not_applicable` (ready without Copilot clauses). `copilot-advisory`,
+`external-bot`, absent, or an invalid value keep today's
+primary-bot applicability. Do not register
+`idd-advisory-convergence` as a required status check unless the
+chosen policy actually wants an advisory-bot gate.
+
 When importing the template, keep the `profiles/` directory with the
 copied docs. For any non-default PR review profile, use the matching
 `profiles/<profile>/README.md` artifact as the reusable patch surface.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1933,9 +1933,12 @@ reflexively as any other CLI option.
   from `deadline`. When `terminal.state` is `COPILOT_UNAVAILABLE`, the
   SAME waiver escape hatch above also opens — independent of whether the
   ordinary deadline has passed — but `ready` still requires a valid
-  waiver in addition (`ready = converged || ((deadline.passed ||
-  terminal.state == "COPILOT_UNAVAILABLE") && waived)`); the terminal
-  state alone never sets `ready: true`. Observed incident:
+  waiver in addition (`ready = not_applicable || converged ||
+  ((deadline.passed || terminal.state == "COPILOT_UNAVAILABLE") &&
+  waived)`); the terminal state alone never sets `ready: true`. A
+  `not_applicable` applicability (including `reviewPolicy`
+  `human-required` / `no-advisory`) is an independent ready path and
+  does not change this waiver rule. Observed incident:
   kurone-kito/idd-skill#1562. See `idd-advisory-wait.instructions.md`'s
   Terminal routing section for the full hold/rerun sequence.
 - **Eligibility-relevant disposition-evidence counters (`#1719`)**: the

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1863,8 +1863,24 @@ reflexively as any other CLI option.
   [`advisory-convergence.schema.json`][advisory-convergence-schema]
 - Every invocation other than `--help`/`-h` prints the JSON verdict.
   Without `--assert` it always exits `0` (report-only). With `--assert` it
-  exits non-zero unless `ready` is `true` (`ready = converged || (deadline
-  passed && validly waived)`).
+  exits non-zero unless `ready` is `true` (`ready = not_applicable ||
+  converged || ((deadline passed || terminal-unavailable) && validly
+  waived)`).
+- **Review-policy applicability (`#2137`)**: this helper reads
+  `reviewPolicy` from `.github/idd/config.json`. Exact
+  `human-required` or `no-advisory` classifies the PR `not_applicable`
+  (reasons `review-policy-human-required` /
+  `review-policy-no-advisory`) so `--assert` exits 0 through the
+  existing `scopeNotApplicable` path, not by faking `converged`.
+  Copilot review/thread clauses do not apply; human approval and
+  conversation resolution stay on branch protection and the phase
+  files. `copilot-advisory`, absent, or an invalid value keep today's
+  fail-closed Copilot applicability. `external-bot` keeps the
+  configured `primaryBotLogin` path. A trusted human approve is never
+  a Copilot substitute under `copilot-advisory`. Do not invent a new
+  `convergenceScope` value for this. Do not register
+  `idd-advisory-convergence` as a required check unless the policy
+  actually wants an advisory-bot gate.
 - **Bounded "not reviewed yet" poll (`#2015`)**: the CLI entry point runs
   through `runAdvisoryConvergenceWithPoll`, not `runAdvisoryConvergence`
   directly. When (and only when) the verdict's sole blocking reason is

--- a/idd-template/docs/idd-review-policy-profiles.md
+++ b/idd-template/docs/idd-review-policy-profiles.md
@@ -196,6 +196,9 @@ the authoritative review gate.
   `.github/instructions/idd-review-triage.instructions.md`: keep human
   comments in the review universe and remove assumptions that Copilot
   advisory PATH B items must appear.
+- `.github/idd/config.json`: set `reviewPolicy` to `human-required`.
+  Do not register `idd-advisory-convergence` as a required check
+  unless this policy actually wants an advisory-bot gate.
 - Repository settings: configure CODEOWNERS, required reviews, or branch
   protection outside IDD.
 - Verification evidence: capture a dry-run or PR-state example showing
@@ -214,6 +217,9 @@ branch protection, and any human review rules configured outside IDD.
 - `.github/instructions/idd-advisory-wait.instructions.md`: mark the
   advisory wait helper unused by this profile, or remove local
   references to it from the customized phase flow.
+- `.github/idd/config.json`: set `reviewPolicy` to `no-advisory`.
+  Do not register `idd-advisory-convergence` as a required check
+  unless this policy actually wants an advisory-bot gate.
 - `docs/idd-advisory-wait-shell-fallback.md`: mark the doc unused by
   this profile, or remove local references to it, matching the
   `idd-advisory-wait.instructions.md` disposition above.

--- a/idd-template/profiles/human-required/README.md
+++ b/idd-template/profiles/human-required/README.md
@@ -6,12 +6,14 @@ below as one workflow change; documentation alone does not make this
 profile active.
 
 **Do not register `idd-advisory-convergence` as required under this
-profile.** Hosting that workflow is optional. Registering it as a
-required status check re-asserts Copilot convergence on every
-review-thread reply, edit, or delete, so ordinary human prose can fail
-the required check on the PR and cancel an in-flight run (observed
-2026-08-17 on PR #2130). Leave the check unregistered unless you later
-switch to a Copilot-advisory review policy.
+profile unless this policy actually wants an advisory-bot gate.**
+Hosting that workflow is optional. Set `reviewPolicy` to
+`human-required` in `.github/idd/config.json` so a later session does
+not re-host the check against a human-only policy. Registering the
+job as a required status check re-asserts Copilot convergence on
+hybrid or IDD-claimed PRs even after the phase files drop the Copilot
+wait. Leave the check unregistered unless you later switch to a
+Copilot-advisory or `external-bot` review policy.
 
 ## Adopter-Owned Values
 
@@ -26,16 +28,17 @@ Record these values before editing phase behavior:
 
 ## Patch Surface
 
-| File                                                       | Required local edit                                                                                                                                      |
-| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `.github/instructions/idd-review-fix.instructions.md`      | Remove the E14 Copilot re-review request and advisory wait. Replace it with a human-review handoff only if the repository wants that handoff documented. |
-| `.github/instructions/idd-advisory-wait.instructions.md`   | Mark the Copilot advisory wait helper unused by this profile, or remove local references to it from the customized phase flow.                           |
-| `.github/instructions/idd-pre-merge.instructions.md`       | Make required human approval, branch protection, unresolved conversations, CI, freshness, and claim evidence the F2 gate.                                |
-| `.github/instructions/idd-merge.instructions.md`           | Remove final Copilot advisory rechecks while keeping CI, claim, freshness, required review, and unresolved-thread checks.                                |
-| `.github/instructions/idd-review-snapshot.instructions.md` | Keep human comments in the review universe and remove assumptions that Copilot advisory PATH B items must appear.                                        |
-| `.github/instructions/idd-review-triage.instructions.md`   | Keep human review comments as decision-relevant feedback and remove Copilot-specific advisory requirements.                                              |
-| `docs/idd-review-policy-profiles.md`                       | Record the selected `human-required` profile and link to the local verification evidence.                                                                |
-| `docs/customization.md` or another local policy document   | Record the reviewer authority, branch protection rule, and review-thread resolution profile.                                                             |
+| File                                                       | Required local edit                                                                                                                                            |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.github/idd/config.json`                                  | Set `reviewPolicy` to `human-required`. Do not register `idd-advisory-convergence` as a required check unless this policy actually wants an advisory-bot gate. |
+| `.github/instructions/idd-review-fix.instructions.md`      | Remove the E14 Copilot re-review request and advisory wait. Replace it with a human-review handoff only if the repository wants that handoff documented.       |
+| `.github/instructions/idd-advisory-wait.instructions.md`   | Mark the Copilot advisory wait helper unused by this profile, or remove local references to it from the customized phase flow.                                 |
+| `.github/instructions/idd-pre-merge.instructions.md`       | Make required human approval, branch protection, unresolved conversations, CI, freshness, and claim evidence the F2 gate.                                      |
+| `.github/instructions/idd-merge.instructions.md`           | Remove final Copilot advisory rechecks while keeping CI, claim, freshness, required review, and unresolved-thread checks.                                      |
+| `.github/instructions/idd-review-snapshot.instructions.md` | Keep human comments in the review universe and remove assumptions that Copilot advisory PATH B items must appear.                                              |
+| `.github/instructions/idd-review-triage.instructions.md`   | Keep human review comments as decision-relevant feedback and remove Copilot-specific advisory requirements.                                                    |
+| `docs/idd-review-policy-profiles.md`                       | Record the selected `human-required` profile and link to the local verification evidence.                                                                      |
+| `docs/customization.md` or another local policy document   | Record the reviewer authority, branch protection rule, and review-thread resolution profile.                                                                   |
 
 ## Verification Evidence
 

--- a/idd-template/profiles/human-required/README.md
+++ b/idd-template/profiles/human-required/README.md
@@ -10,10 +10,11 @@ profile unless this policy actually wants an advisory-bot gate.**
 Hosting that workflow is optional. Set `reviewPolicy` to
 `human-required` in `.github/idd/config.json` so a later session does
 not re-host the check against a human-only policy. Registering the
-job as a required status check re-asserts Copilot convergence on
-hybrid or IDD-claimed PRs even after the phase files drop the Copilot
-wait. Leave the check unregistered unless you later switch to a
-Copilot-advisory or `external-bot` review policy.
+job as a required status check still adds an extra required CI
+gate and extra runs, even though the helper no longer demands
+Copilot under `human-required`. Leave the check unregistered unless
+you later switch to a Copilot-advisory or `external-bot` review
+policy, or you explicitly want that extra required check.
 
 ## Adopter-Owned Values
 

--- a/idd-template/profiles/no-advisory/README.md
+++ b/idd-template/profiles/no-advisory/README.md
@@ -7,12 +7,14 @@ workflow change so later agents do not wait for a reviewer that the
 repository no longer uses.
 
 **Do not register `idd-advisory-convergence` as required under this
-profile.** Hosting that workflow is optional. Registering it as a
-required status check re-asserts Copilot convergence on every
-review-thread reply, edit, or delete, so ordinary human prose can fail
-the required check on the PR and cancel an in-flight run (observed
-2026-08-17 on PR #2130). Leave the check unregistered unless you later
-switch to a Copilot-advisory review policy.
+profile unless this policy actually wants an advisory-bot gate.**
+Hosting that workflow is optional. Set `reviewPolicy` to
+`no-advisory` in `.github/idd/config.json` so a later session does
+not re-host the check against a no-advisory policy. Registering the
+job as a required status check re-asserts Copilot convergence on
+hybrid or IDD-claimed PRs even after the phase files drop the
+advisory wait. Leave the check unregistered unless you later switch
+to a Copilot-advisory or `external-bot` review policy.
 
 ## Adopter-Owned Values
 
@@ -27,17 +29,18 @@ Record these values before editing phase behavior:
 
 ## Patch Surface
 
-| File                                                       | Required local edit                                                                                                                        |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `.github/instructions/idd-review-fix.instructions.md`      | Remove the E14 advisory request and wait path.                                                                                             |
-| `.github/instructions/idd-advisory-wait.instructions.md`   | Mark the advisory wait helper unused by this profile, or remove local references to it from the customized phase flow.                     |
-| `docs/idd-advisory-wait-shell-fallback.md`                 | Mark the doc unused by this profile, or remove local references to it, matching the `idd-advisory-wait.instructions.md` disposition above. |
-| `.github/instructions/idd-pre-merge.instructions.md`       | Gate on CI, branch protection, unresolved conversations, freshness, and claim evidence without requiring an advisory reviewer.             |
-| `.github/instructions/idd-merge.instructions.md`           | Remove final advisory rechecks while keeping CI, claim, freshness, branch protection, and unresolved-thread checks.                        |
-| `.github/instructions/idd-review-snapshot.instructions.md` | Keep human comments in scope and remove advisory-only PATH B requirements.                                                                 |
-| `.github/instructions/idd-review-triage.instructions.md`   | Keep human review comments in the review universe and remove advisory-only disposition requirements.                                       |
-| `docs/idd-review-policy-profiles.md`                       | Record the selected `no-advisory` profile and link to the local verification evidence.                                                     |
-| `docs/customization.md` or another local policy document   | Record why no IDD-managed advisory reviewer is used and which outside gates still protect merges.                                          |
+| File                                                       | Required local edit                                                                                                                                         |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.github/idd/config.json`                                  | Set `reviewPolicy` to `no-advisory`. Do not register `idd-advisory-convergence` as a required check unless this policy actually wants an advisory-bot gate. |
+| `.github/instructions/idd-review-fix.instructions.md`      | Remove the E14 advisory request and wait path.                                                                                                              |
+| `.github/instructions/idd-advisory-wait.instructions.md`   | Mark the advisory wait helper unused by this profile, or remove local references to it from the customized phase flow.                                      |
+| `docs/idd-advisory-wait-shell-fallback.md`                 | Mark the doc unused by this profile, or remove local references to it, matching the `idd-advisory-wait.instructions.md` disposition above.                  |
+| `.github/instructions/idd-pre-merge.instructions.md`       | Gate on CI, branch protection, unresolved conversations, freshness, and claim evidence without requiring an advisory reviewer.                              |
+| `.github/instructions/idd-merge.instructions.md`           | Remove final advisory rechecks while keeping CI, claim, freshness, branch protection, and unresolved-thread checks.                                         |
+| `.github/instructions/idd-review-snapshot.instructions.md` | Keep human comments in scope and remove advisory-only PATH B requirements.                                                                                  |
+| `.github/instructions/idd-review-triage.instructions.md`   | Keep human review comments in the review universe and remove advisory-only disposition requirements.                                                        |
+| `docs/idd-review-policy-profiles.md`                       | Record the selected `no-advisory` profile and link to the local verification evidence.                                                                      |
+| `docs/customization.md` or another local policy document   | Record why no IDD-managed advisory reviewer is used and which outside gates still protect merges.                                                           |
 
 ## Verification Evidence
 

--- a/idd-template/profiles/no-advisory/README.md
+++ b/idd-template/profiles/no-advisory/README.md
@@ -11,10 +11,11 @@ profile unless this policy actually wants an advisory-bot gate.**
 Hosting that workflow is optional. Set `reviewPolicy` to
 `no-advisory` in `.github/idd/config.json` so a later session does
 not re-host the check against a no-advisory policy. Registering the
-job as a required status check re-asserts Copilot convergence on
-hybrid or IDD-claimed PRs even after the phase files drop the
-advisory wait. Leave the check unregistered unless you later switch
-to a Copilot-advisory or `external-bot` review policy.
+job as a required status check still adds an extra required CI
+gate and extra runs, even though the helper no longer demands
+Copilot under `no-advisory`. Leave the check unregistered unless
+you later switch to a Copilot-advisory or `external-bot` review
+policy, or you explicitly want that extra required check.
 
 ## Adopter-Owned Values
 

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -43,7 +43,7 @@
         "no-advisory",
         "external-bot"
       ],
-      "description": "Selects the PR review-authority profile enforced by the E/F-phase instructions. Required; the distributed default is the Copilot-advisory profile, where CI, branch protection, and claim checks still gate the merge."
+      "description": "Selects the PR review-authority profile enforced by the E/F-phase instructions. Required; the distributed default is the Copilot-advisory profile, where CI, branch protection, and claim checks still gate the merge. `advisory-convergence` also reads this field: `human-required` and `no-advisory` make the check `not_applicable` (ready without Copilot clauses); `copilot-advisory`, `external-bot`, absent, or an invalid value keep today's Copilot/`primaryBotLogin` applicability. Do not register `idd-advisory-convergence` as a required check unless this policy actually wants an advisory-bot gate."
     },
     "threadResolutionPolicy": {
       "type": "string",

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -1597,9 +1597,11 @@ function collectFromGitHub(args) {
   // `prFirstCommitAt` above: a transient GraphQL failure must never
   // widen what this gate accepts.
   const exemptBotAuthoredPrs = policy.advisoryWait.exemptBotAuthoredPrs;
-  // #2137: exact string only. Invalid / non-string / absent stay
-  // undefined so computeAdvisoryConvergenceVerdict keeps today's
-  // Copilot / primaryBotLogin applicability.
+  // #2137: forward any string (including invalid enum values).
+  // Non-string / absent stay undefined. computeAdvisoryConvergenceVerdict
+  // treats only exact human-required / no-advisory as skip, so an
+  // invalid string still keeps today's Copilot / primaryBotLogin
+  // applicability.
   const reviewPolicy =
     typeof rawConfig?.reviewPolicy === 'string'
       ? rawConfig.reviewPolicy

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -167,6 +167,23 @@ export const SAME_HEAD_REROLL_INELIGIBLE_REASON = {
   REVIEW_ITEM_COUNT_NOT_POSITIVE: 'review-item-count-not-positive',
   ALREADY_SATISFIED_VIA_REVIEW_ACK: 'already-satisfied-via-review-ack',
 };
+/** #2137: exact `reviewPolicy` values that skip Copilot / primary-bot
+ * clauses. Mapped to the `applicability.reason` token so tests and
+ * operators can tell which policy produced the short-circuit. */
+const REVIEW_POLICY_NOT_APPLICABLE_REASON = {
+  'human-required': 'review-policy-human-required',
+  'no-advisory': 'review-policy-no-advisory',
+};
+/** Return the `not_applicable` reason for a human-only / no-advisory
+ * `reviewPolicy`, or `null` when today's Copilot / `primaryBotLogin`
+ * applicability should run. Exact enum match only: absent, invalid,
+ * `copilot-advisory`, and `external-bot` all return `null`. */
+export function reviewPolicyNotApplicableReason(reviewPolicy) {
+  if (reviewPolicy === 'human-required' || reviewPolicy === 'no-advisory') {
+    return REVIEW_POLICY_NOT_APPLICABLE_REASON[reviewPolicy];
+  }
+  return null;
+}
 /**
  * Compute the deterministic advisory-convergence verdict from already-
  * fetched PR evidence. Pure (no I/O), so it is directly unit-testable with
@@ -244,8 +261,20 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
   // required-with-throw like the two claim-evidence booleans above.
   const exemptBotAuthoredPrs = options.exemptBotAuthoredPrs === true;
   const prAuthorIsBot = inputs.prAuthorIsBot === true;
-  const applicability =
-    convergenceScope === 'idd-claimed'
+  // #2137: honor reviewPolicy first. human-required / no-advisory must
+  // not demand Copilot even on an `idd-claimed` hybrid PR (that scope
+  // is the wrong substitute). Ready comes from the existing
+  // `scopeNotApplicable` path, never a fake `converged`.
+  const reviewPolicySkipReason = reviewPolicyNotApplicableReason(
+    options.reviewPolicy,
+  );
+  const applicability = reviewPolicySkipReason
+    ? {
+        scope: convergenceScope,
+        status: 'not_applicable',
+        reason: reviewPolicySkipReason,
+      }
+    : convergenceScope === 'idd-claimed'
       ? !claim.activeClaimPresent
         ? claimCandidateAmbiguous
           ? {
@@ -1568,6 +1597,13 @@ function collectFromGitHub(args) {
   // `prFirstCommitAt` above: a transient GraphQL failure must never
   // widen what this gate accepts.
   const exemptBotAuthoredPrs = policy.advisoryWait.exemptBotAuthoredPrs;
+  // #2137: exact string only. Invalid / non-string / absent stay
+  // undefined so computeAdvisoryConvergenceVerdict keeps today's
+  // Copilot / primaryBotLogin applicability.
+  const reviewPolicy =
+    typeof rawConfig?.reviewPolicy === 'string'
+      ? rawConfig.reviewPolicy
+      : undefined;
   let prAuthorIsBot = false;
   if (exemptBotAuthoredPrs && convergenceScope === 'all-prs') {
     try {
@@ -1596,6 +1632,7 @@ function collectFromGitHub(args) {
       advisoryBotLogins,
       convergenceScope,
       exemptBotAuthoredPrs,
+      reviewPolicy,
       prHeadRefName,
       prAuthorLogin,
       headCommittedAt,

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -506,6 +506,15 @@ export interface AdvisoryConvergenceOptions {
    * (flag unset, `idd-claimed` scope, non-Bot author, or claim history
    * present) leaves today's behavior completely unchanged. */
   exemptBotAuthoredPrs?: boolean;
+  /** #2137: `reviewPolicy` from `.github/idd/config.json`. Exact
+   * `human-required` / `no-advisory` make this gate `not_applicable`
+   * (ready through the existing `scopeNotApplicable` path, never a fake
+   * `converged`). `copilot-advisory`, `external-bot`, absent, or any
+   * other value keep today's Copilot / `primaryBotLogin` applicability
+   * (fail-closed: invalid does not widen). Not a new
+   * `convergenceScope` value; a trusted human approve is never a
+   * Copilot substitute under `copilot-advisory`. */
+  reviewPolicy?: string;
   prHeadRefName?: string | null;
   /** The PR author's login, excluded from "external feedback" the same way
    * `summarizeDispositionEvidenceForGate` excludes it elsewhere. */
@@ -579,6 +588,29 @@ export interface AdvisoryConvergenceOptions {
    * observes -- so this is only a behavior change for a repository that
    * has configured a non-default `claimTiming.staleAge`. */
   staleAgeMs?: number;
+}
+
+/** #2137: exact `reviewPolicy` values that skip Copilot / primary-bot
+ * clauses. Mapped to the `applicability.reason` token so tests and
+ * operators can tell which policy produced the short-circuit. */
+const REVIEW_POLICY_NOT_APPLICABLE_REASON = {
+  'human-required': 'review-policy-human-required',
+  'no-advisory': 'review-policy-no-advisory',
+} as const;
+
+/** Return the `not_applicable` reason for a human-only / no-advisory
+ * `reviewPolicy`, or `null` when today's Copilot / `primaryBotLogin`
+ * applicability should run. Exact enum match only: absent, invalid,
+ * `copilot-advisory`, and `external-bot` all return `null`. */
+export function reviewPolicyNotApplicableReason(
+  reviewPolicy: unknown,
+):
+  | (typeof REVIEW_POLICY_NOT_APPLICABLE_REASON)[keyof typeof REVIEW_POLICY_NOT_APPLICABLE_REASON]
+  | null {
+  if (reviewPolicy === 'human-required' || reviewPolicy === 'no-advisory') {
+    return REVIEW_POLICY_NOT_APPLICABLE_REASON[reviewPolicy];
+  }
+  return null;
 }
 
 /**
@@ -663,8 +695,20 @@ export function computeAdvisoryConvergenceVerdict(
   // required-with-throw like the two claim-evidence booleans above.
   const exemptBotAuthoredPrs = options.exemptBotAuthoredPrs === true;
   const prAuthorIsBot = inputs.prAuthorIsBot === true;
-  const applicability: AdvisoryConvergenceApplicability =
-    convergenceScope === 'idd-claimed'
+  // #2137: honor reviewPolicy first. human-required / no-advisory must
+  // not demand Copilot even on an `idd-claimed` hybrid PR (that scope
+  // is the wrong substitute). Ready comes from the existing
+  // `scopeNotApplicable` path, never a fake `converged`.
+  const reviewPolicySkipReason = reviewPolicyNotApplicableReason(
+    options.reviewPolicy,
+  );
+  const applicability: AdvisoryConvergenceApplicability = reviewPolicySkipReason
+    ? {
+        scope: convergenceScope,
+        status: 'not_applicable',
+        reason: reviewPolicySkipReason,
+      }
+    : convergenceScope === 'idd-claimed'
       ? !claim.activeClaimPresent
         ? claimCandidateAmbiguous
           ? {
@@ -2110,6 +2154,13 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
   // `prFirstCommitAt` above: a transient GraphQL failure must never
   // widen what this gate accepts.
   const exemptBotAuthoredPrs = policy.advisoryWait.exemptBotAuthoredPrs;
+  // #2137: exact string only. Invalid / non-string / absent stay
+  // undefined so computeAdvisoryConvergenceVerdict keeps today's
+  // Copilot / primaryBotLogin applicability.
+  const reviewPolicy =
+    typeof rawConfig?.reviewPolicy === 'string'
+      ? rawConfig.reviewPolicy
+      : undefined;
   let prAuthorIsBot = false;
   if (exemptBotAuthoredPrs && convergenceScope === 'all-prs') {
     try {
@@ -2139,6 +2190,7 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
       advisoryBotLogins,
       convergenceScope,
       exemptBotAuthoredPrs,
+      reviewPolicy,
       prHeadRefName,
       prAuthorLogin,
       headCommittedAt,

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -2154,9 +2154,11 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
   // `prFirstCommitAt` above: a transient GraphQL failure must never
   // widen what this gate accepts.
   const exemptBotAuthoredPrs = policy.advisoryWait.exemptBotAuthoredPrs;
-  // #2137: exact string only. Invalid / non-string / absent stay
-  // undefined so computeAdvisoryConvergenceVerdict keeps today's
-  // Copilot / primaryBotLogin applicability.
+  // #2137: forward any string (including invalid enum values).
+  // Non-string / absent stay undefined. computeAdvisoryConvergenceVerdict
+  // treats only exact human-required / no-advisory as skip, so an
+  // invalid string still keeps today's Copilot / primaryBotLogin
+  // applicability.
   const reviewPolicy =
     typeof rawConfig?.reviewPolicy === 'string'
       ? rawConfig.reviewPolicy

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -14,6 +14,7 @@ import {
   parseArgs,
   pickResolvingClaimEvents,
   resolveClaimEvidence,
+  reviewPolicyNotApplicableReason,
   runAdvisoryConvergence,
   runAdvisoryConvergenceWithPoll,
   SAME_HEAD_REROLL_INELIGIBLE_REASON,
@@ -514,6 +515,149 @@ test('exemptBotAuthoredPrs: flag unset (default false) -> unchanged applicable/a
     status: 'applicable',
     reason: 'all-prs',
   });
+});
+
+// --- reviewPolicy applicability (#2137) -------------------------------------
+
+test('reviewPolicyNotApplicableReason: exact human-required / no-advisory only', () => {
+  assert.equal(
+    reviewPolicyNotApplicableReason('human-required'),
+    'review-policy-human-required',
+  );
+  assert.equal(
+    reviewPolicyNotApplicableReason('no-advisory'),
+    'review-policy-no-advisory',
+  );
+  assert.equal(reviewPolicyNotApplicableReason('copilot-advisory'), null);
+  assert.equal(reviewPolicyNotApplicableReason('external-bot'), null);
+  assert.equal(reviewPolicyNotApplicableReason(undefined), null);
+  assert.equal(reviewPolicyNotApplicableReason(''), null);
+  assert.equal(reviewPolicyNotApplicableReason('HUMAN-REQUIRED'), null);
+  assert.equal(reviewPolicyNotApplicableReason('not-a-real-policy'), null);
+});
+
+test('reviewPolicy human-required: no Copilot review is not_applicable and ready, not fake-converged', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [], claimEvents: [] }),
+    baseOptions({ reviewPolicy: 'human-required' }),
+  );
+  assertValidVerdict(verdict);
+  assert.deepEqual(verdict.applicability, {
+    scope: 'all-prs',
+    status: 'not_applicable',
+    reason: 'review-policy-human-required',
+  });
+  assert.equal(verdict.pending, false);
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.ready, true);
+  assert.deepEqual(verdict.reasons, []);
+});
+
+test('reviewPolicy no-advisory: no Copilot review is not_applicable and ready, not fake-converged', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [], claimEvents: [] }),
+    baseOptions({ reviewPolicy: 'no-advisory' }),
+  );
+  assertValidVerdict(verdict);
+  assert.deepEqual(verdict.applicability, {
+    scope: 'all-prs',
+    status: 'not_applicable',
+    reason: 'review-policy-no-advisory',
+  });
+  assert.equal(verdict.pending, false);
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.ready, true);
+  assert.deepEqual(verdict.reasons, []);
+});
+
+test('reviewPolicy copilot-advisory: same fixture still fails until Copilot converges', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [], claimEvents: [] }),
+    baseOptions({ reviewPolicy: 'copilot-advisory' }),
+  );
+  assertValidVerdict(verdict);
+  assert.deepEqual(verdict.applicability, {
+    scope: 'all-prs',
+    status: 'applicable',
+    reason: 'all-prs',
+  });
+  assert.equal(verdict.pending, true);
+  assert.equal(verdict.ready, false);
+});
+
+test('reviewPolicy absent: same fixture still fails until Copilot converges', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [], claimEvents: [] }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.applicability.status, 'applicable');
+  assert.equal(verdict.pending, true);
+  assert.equal(verdict.ready, false);
+});
+
+test('reviewPolicy invalid: does not widen past copilot-advisory applicability', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [], claimEvents: [] }),
+    baseOptions({ reviewPolicy: 'not-a-real-policy' }),
+  );
+  assertValidVerdict(verdict);
+  assert.deepEqual(verdict.applicability, {
+    scope: 'all-prs',
+    status: 'applicable',
+    reason: 'all-prs',
+  });
+  assert.equal(verdict.pending, true);
+  assert.equal(verdict.ready, false);
+});
+
+test('reviewPolicy external-bot: keeps the configured primaryBotLogin path', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [], claimEvents: [] }),
+    baseOptions({ reviewPolicy: 'external-bot' }),
+  );
+  assertValidVerdict(verdict);
+  assert.deepEqual(verdict.applicability, {
+    scope: 'all-prs',
+    status: 'applicable',
+    reason: 'all-prs',
+  });
+  assert.equal(verdict.pending, true);
+  assert.equal(verdict.ready, false);
+});
+
+test('reviewPolicy human-required wins under idd-claimed with a matching claim (hybrid PR)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment()],
+    }),
+    baseOptions({
+      reviewPolicy: 'human-required',
+      convergenceScope: 'idd-claimed',
+      prHeadRefName: 'issue/1234-test',
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.deepEqual(verdict.applicability, {
+    scope: 'idd-claimed',
+    status: 'not_applicable',
+    reason: 'review-policy-human-required',
+  });
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.ready, true);
+  assert.deepEqual(verdict.reasons, []);
+});
+
+test('reviewPolicy human-required does not treat a dirty Copilot review as converged', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({ reviews: [copilotReview({ itemCount: 3 })] }),
+    baseOptions({ reviewPolicy: 'human-required' }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.applicability.status, 'not_applicable');
+  assert.equal(verdict.converged, false);
+  assert.equal(verdict.ready, true);
 });
 
 test('regression: a re-request without a new push supersedes an earlier dirty on-HEAD review', () => {
@@ -3397,6 +3541,14 @@ test('collectFromGitHub sources prAuthorIsBot/exemptBotAuthoredPrs into the retu
   );
   assert.match(source, /inputs:\s*\{[^}]*\bprAuthorIsBot,[^}]*\}/s);
   assert.match(source, /options:\s*\{[^}]*\bexemptBotAuthoredPrs,[^}]*\}/s);
+});
+
+test('collectFromGitHub sources reviewPolicy into the returned options (#2137: pins the call-site forwarding shape)', () => {
+  const source = readFileSync(
+    new URL('../src/scripts/advisory-convergence.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(source, /options:\s*\{[^}]*\breviewPolicy,[^}]*\}/s);
 });
 
 // --- parseArgs ---------------------------------------------------------------


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`advisory-convergence` now reads `reviewPolicy`. `human-required` and
`no-advisory` classify the PR `not_applicable`, so `--assert` exits 0
through the existing ready path instead of demanding Copilot. Today's
Copilot / `primaryBotLogin` path stays fail-closed for `copilot-advisory`,
absent, invalid, and `external-bot`. Profile artifacts list the config
field and the do-not-register note on the same patch surface as the
phase-file edits.

## Linked issue

Closes #2137

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Once `idd-advisory-convergence` is a required check, every applicable PR
was judged as Copilot-advisory even when the adopter chose
`human-required` or `no-advisory`. `idd-claimed` was the wrong
substitute: a hybrid PR that closes an IDD issue still demanded Copilot.
Ready comes from `not_applicable`, not a fake `converged`. A trusted
human approve is not treated as a Copilot substitute under
`copilot-advisory`.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed