### PR TITLE
docs: document the shipped hybrid review-reply identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ discipline and has no tag.
 
 ### Added
 
+- Present-tense hybrid review-reply identity contract on the
+  operator docs: IDD replies carry the prefix-aware stamp (not an
+  E1 `review-watermark`); unmarked human replies on human threads
+  are presence-only; Copilot threads still need an IDD disposition;
+  the required `idd-advisory-convergence` job is not created by
+  unmarked human review chatter; `reviewPolicy` is honored.
 - Prefix-aware review-reply identity stamp
   (`<!-- {markerPrefix}-review-reply -->`) for IDD-originated E6/E13
   replies, with helper injection and a shared recognizer. The stamp

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -179,8 +179,9 @@ chosen policy actually wants an advisory-bot gate.
 The shipped hybrid review-reply identity is documented in
 [Hybrid review-reply identity](idd-review-policy-profiles.md#hybrid-review-reply-identity-shipped):
 IDD replies carry `<!-- {markerPrefix}-review-reply -->` after the
-visible disposition prefix (not an E1 `review-watermark`); unmarked
-human replies on human threads are presence-only; Copilot threads
+visible disposition body (not an E1 `review-watermark`); unmarked
+human replies on human threads are presence-only and do not let the
+owning session post bare prose on its own items; Copilot threads
 still need an IDD disposition; the required job is not created by
 unmarked human review chatter.
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -176,6 +176,14 @@ primary-bot applicability. Do not register
 `idd-advisory-convergence` as a required status check unless the
 chosen policy actually wants an advisory-bot gate.
 
+The shipped hybrid review-reply identity is documented in
+[Hybrid review-reply identity](idd-review-policy-profiles.md#hybrid-review-reply-identity-shipped):
+IDD replies carry `<!-- {markerPrefix}-review-reply -->` after the
+visible disposition prefix (not an E1 `review-watermark`); unmarked
+human replies on human threads are presence-only; Copilot threads
+still need an IDD disposition; the required job is not created by
+unmarked human review chatter.
+
 When importing the template, keep the `profiles/` directory with the
 copied docs. For any non-default PR review profile, use the matching
 `profiles/<profile>/README.md` artifact as the reusable patch surface.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -872,6 +872,13 @@ The adopted helper boundaries are intentionally narrow:
   thread) and resolves the thread (GraphQL `resolveReviewThread`). Reply
   first, resolve second, so a failed reply never resolves the thread without a
   disposition.
+- **`--apply` appends the reply-identity stamp**
+  `<!-- {markerPrefix}-review-reply -->` after the visible
+  `**Accepted**` / `**Rejected**` body (same injection as
+  `disposition-non-review-notices --apply`). A manual `gh api` JSON
+  body must append that stamp itself. The stamp is utterance
+  identity; it is not an E1 `review-watermark`. See
+  [Hybrid review-reply identity](idd-review-policy-profiles.md#hybrid-review-reply-identity-shipped).
 - **Dry-run** reports the resolved `threadId` and current `alreadyResolved`
   state without posting; a comment with no owning thread omits `threadId`
   and includes an `error` note.

--- a/docs/idd-review-policy-profiles.md
+++ b/docs/idd-review-policy-profiles.md
@@ -261,6 +261,57 @@ signal.
   reviewed the current head and that stale, missing, or unavailable bot
   state blocks or holds according to the recorded policy.
 
+## Hybrid review-reply identity (shipped)
+
+These rules are the landed contract after the hybrid review-reply
+roadmap siblings (`#2135`, `#2136`, `#2137`, `#2139`). They are
+present-tense operator and phase behavior, not a current-state hazard
+warning.
+
+- **IDD-originated reply identity.** An IDD disposition or E13 reply
+  starts with the visible `**Accepted**` / `**Rejected**` (or
+  `**Awaiting maintainer decision**`) prefix. After that prefix it
+  carries the prefix-aware HTML-comment stamp
+  `<!-- {markerPrefix}-review-reply -->` (default `idd-skill`).
+  Helpers such as `resolve-review-thread --apply` and
+  `disposition-non-review-notices --apply` inject the stamp. A
+  manual `gh api` JSON body must append it. The stamp is utterance
+  identity. It is **not** the E1 `review-watermark` snapshot marker
+  (`<!-- review-watermark: … -->`), which records activity-universe
+  counts and never substitutes for a disposition.
+- **Unmarked human replies.** On a **human-authored** review thread,
+  an unmarked human reply (no stamp, no `**Accepted**` prefix) is
+  presence-only: a reply exists, so the thread is not
+  `unresolved-without-fresh-disposition` solely for lacking
+  `**Accepted**`. That rule does not license the owning session to
+  post bare prose on its own items.
+- **Advisory-bot threads still need an IDD disposition.** A Copilot
+  or configured-advisory-bot thread still requires a stamped or
+  legacy trusted IDD disposition, or resolution for
+  `advisory-convergence` Clause 2. An unmarked human `ok` does not
+  clear those threads.
+- **Required-check trigger.** The required
+  `idd-advisory-convergence` job is **not** created by an unmarked
+  human `pull_request_review_comment`. IDD-originated comments
+  (disposition prefix, reply-identity stamp, or an operational
+  marker the check already honors) refresh the existing HEAD run
+  from the companion `idd-advisory-convergence-comment.yml`
+  workflow. Ordinary human prose does not create or cancel the
+  required check.
+- **`reviewPolicy`.** `human-required` and `no-advisory` make
+  `advisory-convergence` `not_applicable` (ready without Copilot
+  clauses). `copilot-advisory`, `external-bot`, absent, or an
+  invalid value keep today's primary-bot applicability. Do not
+  register the check as required unless the chosen policy actually
+  wants an advisory-bot gate.
+
+Phase files that tell an agent to post a disposition name the stamp
+on both the helper path and the manual `gh api` path:
+`idd-review-triage.instructions.md` (E6) and
+`idd-review-fix.instructions.md` (E13). F2 evaluation of unmarked
+human vs Copilot threads lives in
+`idd-pre-merge.instructions.md`.
+
 ## Review Thread Resolution Profiles
 
 Review-thread resolution is a separate policy from who reviews the PR.

--- a/docs/idd-review-policy-profiles.md
+++ b/docs/idd-review-policy-profiles.md
@@ -270,8 +270,8 @@ warning.
 
 - **IDD-originated reply identity.** An IDD disposition or E13 reply
   starts with the visible `**Accepted**` / `**Rejected**` (or
-  `**Awaiting maintainer decision**`) prefix. After that prefix it
-  carries the prefix-aware HTML-comment stamp
+  `**Awaiting maintainer decision**`) prefix. After the visible
+  disposition body it carries the prefix-aware HTML-comment stamp
   `<!-- {markerPrefix}-review-reply -->` (default `idd-skill`).
   Helpers such as `resolve-review-thread --apply` and
   `disposition-non-review-notices --apply` inject the stamp. A

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1396,9 +1396,10 @@ refresh the required run. This is `idd-advisory-convergence`, not
 `lint.yml`.
 The shipped hybrid contract is present-tense: IDD replies carry
 `<!-- {markerPrefix}-review-reply -->` after the visible
-disposition prefix (this is **not** the E1 `review-watermark`);
-unmarked human replies on human threads are presence-only; Copilot
-threads still need an IDD disposition;
+disposition body (this is **not** the E1 `review-watermark`);
+unmarked human replies on human threads are presence-only and do
+not let the owning session post bare prose on its own items;
+Copilot threads still need an IDD disposition;
 `reviewPolicy: human-required` / `no-advisory` makes Copilot clauses
 `not_applicable`. See
 [Hybrid review-reply identity](docs/idd-review-policy-profiles.md#hybrid-review-reply-identity-shipped).

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1394,6 +1394,14 @@ verdict, and look like "the reply got linted." That path is now the
 companion comment workflow above, and only IDD-originated comments
 refresh the required run. This is `idd-advisory-convergence`, not
 `lint.yml`.
+The shipped hybrid contract is present-tense: IDD replies carry
+`<!-- {markerPrefix}-review-reply -->` after the visible
+disposition prefix (this is **not** the E1 `review-watermark`);
+unmarked human replies on human threads are presence-only; Copilot
+threads still need an IDD disposition; `reviewPolicy:
+human-required` / `no-advisory` makes Copilot clauses
+`not_applicable`. See
+[Hybrid review-reply identity](docs/idd-review-policy-profiles.md#hybrid-review-reply-identity-shipped).
 Repositories that want human-led or gradual IDD adoption should
 leave the check unregistered until they intend the Copilot-advisory
 loop.

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1398,8 +1398,8 @@ The shipped hybrid contract is present-tense: IDD replies carry
 `<!-- {markerPrefix}-review-reply -->` after the visible
 disposition prefix (this is **not** the E1 `review-watermark`);
 unmarked human replies on human threads are presence-only; Copilot
-threads still need an IDD disposition; `reviewPolicy:
-human-required` / `no-advisory` makes Copilot clauses
+threads still need an IDD disposition;
+`reviewPolicy: human-required` / `no-advisory` makes Copilot clauses
 `not_applicable`. See
 [Hybrid review-reply identity](docs/idd-review-policy-profiles.md#hybrid-review-reply-identity-shipped).
 Repositories that want human-led or gradual IDD adoption should

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -179,8 +179,9 @@ chosen policy actually wants an advisory-bot gate.
 The shipped hybrid review-reply identity is documented in
 [Hybrid review-reply identity](idd-review-policy-profiles.md#hybrid-review-reply-identity-shipped):
 IDD replies carry `<!-- {markerPrefix}-review-reply -->` after the
-visible disposition prefix (not an E1 `review-watermark`); unmarked
-human replies on human threads are presence-only; Copilot threads
+visible disposition body (not an E1 `review-watermark`); unmarked
+human replies on human threads are presence-only and do not let the
+owning session post bare prose on its own items; Copilot threads
 still need an IDD disposition; the required job is not created by
 unmarked human review chatter.
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -176,6 +176,14 @@ primary-bot applicability. Do not register
 `idd-advisory-convergence` as a required status check unless the
 chosen policy actually wants an advisory-bot gate.
 
+The shipped hybrid review-reply identity is documented in
+[Hybrid review-reply identity](idd-review-policy-profiles.md#hybrid-review-reply-identity-shipped):
+IDD replies carry `<!-- {markerPrefix}-review-reply -->` after the
+visible disposition prefix (not an E1 `review-watermark`); unmarked
+human replies on human threads are presence-only; Copilot threads
+still need an IDD disposition; the required job is not created by
+unmarked human review chatter.
+
 When importing the template, keep the `profiles/` directory with the
 copied docs. For any non-default PR review profile, use the matching
 `profiles/<profile>/README.md` artifact as the reusable patch surface.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -872,6 +872,13 @@ The adopted helper boundaries are intentionally narrow:
   thread) and resolves the thread (GraphQL `resolveReviewThread`). Reply
   first, resolve second, so a failed reply never resolves the thread without a
   disposition.
+- **`--apply` appends the reply-identity stamp**
+  `<!-- {markerPrefix}-review-reply -->` after the visible
+  `**Accepted**` / `**Rejected**` body (same injection as
+  `disposition-non-review-notices --apply`). A manual `gh api` JSON
+  body must append that stamp itself. The stamp is utterance
+  identity; it is not an E1 `review-watermark`. See
+  [Hybrid review-reply identity](idd-review-policy-profiles.md#hybrid-review-reply-identity-shipped).
 - **Dry-run** reports the resolved `threadId` and current `alreadyResolved`
   state without posting; a comment with no owning thread omits `threadId`
   and includes an `error` note.

--- a/idd-template/docs/idd-review-policy-profiles.md
+++ b/idd-template/docs/idd-review-policy-profiles.md
@@ -261,6 +261,57 @@ signal.
   reviewed the current head and that stale, missing, or unavailable bot
   state blocks or holds according to the recorded policy.
 
+## Hybrid review-reply identity (shipped)
+
+These rules are the landed contract after the hybrid review-reply
+roadmap siblings (`#2135`, `#2136`, `#2137`, `#2139`). They are
+present-tense operator and phase behavior, not a current-state hazard
+warning.
+
+- **IDD-originated reply identity.** An IDD disposition or E13 reply
+  starts with the visible `**Accepted**` / `**Rejected**` (or
+  `**Awaiting maintainer decision**`) prefix. After that prefix it
+  carries the prefix-aware HTML-comment stamp
+  `<!-- {markerPrefix}-review-reply -->` (default `idd-skill`).
+  Helpers such as `resolve-review-thread --apply` and
+  `disposition-non-review-notices --apply` inject the stamp. A
+  manual `gh api` JSON body must append it. The stamp is utterance
+  identity. It is **not** the E1 `review-watermark` snapshot marker
+  (`<!-- review-watermark: … -->`), which records activity-universe
+  counts and never substitutes for a disposition.
+- **Unmarked human replies.** On a **human-authored** review thread,
+  an unmarked human reply (no stamp, no `**Accepted**` prefix) is
+  presence-only: a reply exists, so the thread is not
+  `unresolved-without-fresh-disposition` solely for lacking
+  `**Accepted**`. That rule does not license the owning session to
+  post bare prose on its own items.
+- **Advisory-bot threads still need an IDD disposition.** A Copilot
+  or configured-advisory-bot thread still requires a stamped or
+  legacy trusted IDD disposition, or resolution for
+  `advisory-convergence` Clause 2. An unmarked human `ok` does not
+  clear those threads.
+- **Required-check trigger.** The required
+  `idd-advisory-convergence` job is **not** created by an unmarked
+  human `pull_request_review_comment`. IDD-originated comments
+  (disposition prefix, reply-identity stamp, or an operational
+  marker the check already honors) refresh the existing HEAD run
+  from the companion `idd-advisory-convergence-comment.yml`
+  workflow. Ordinary human prose does not create or cancel the
+  required check.
+- **`reviewPolicy`.** `human-required` and `no-advisory` make
+  `advisory-convergence` `not_applicable` (ready without Copilot
+  clauses). `copilot-advisory`, `external-bot`, absent, or an
+  invalid value keep today's primary-bot applicability. Do not
+  register the check as required unless the chosen policy actually
+  wants an advisory-bot gate.
+
+Phase files that tell an agent to post a disposition name the stamp
+on both the helper path and the manual `gh api` path:
+`idd-review-triage.instructions.md` (E6) and
+`idd-review-fix.instructions.md` (E13). F2 evaluation of unmarked
+human vs Copilot threads lives in
+`idd-pre-merge.instructions.md`.
+
 ## Review Thread Resolution Profiles
 
 Review-thread resolution is a separate policy from who reviews the PR.

--- a/idd-template/docs/idd-review-policy-profiles.md
+++ b/idd-template/docs/idd-review-policy-profiles.md
@@ -270,8 +270,8 @@ warning.
 
 - **IDD-originated reply identity.** An IDD disposition or E13 reply
   starts with the visible `**Accepted**` / `**Rejected**` (or
-  `**Awaiting maintainer decision**`) prefix. After that prefix it
-  carries the prefix-aware HTML-comment stamp
+  `**Awaiting maintainer decision**`) prefix. After the visible
+  disposition body it carries the prefix-aware HTML-comment stamp
   `<!-- {markerPrefix}-review-reply -->` (default `idd-skill`).
   Helpers such as `resolve-review-thread --apply` and
   `disposition-non-review-notices --apply` inject the stamp. A


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Operator docs now describe the landed hybrid review-reply contract in
the present tense: IDD replies carry the prefix-aware stamp (not an
E1 `review-watermark`), unmarked human replies on human threads are
presence-only, Copilot threads still need an IDD disposition, the
required `idd-advisory-convergence` job is not created by unmarked
human review chatter, and `reviewPolicy` is honored.

## Linked issue

Closes #2140

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Siblings #2135, #2136, #2137, and #2139 already shipped the
implementation. This issue waits on those merges so the docs can name
the landed behavior instead of a current-state hazard.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (docs-only; `audit-docs` and `lint:precommit` ran)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the hybrid review-reply identity contract and required IDD markers.
  * Clarified how human replies, Copilot replies, and advisory-bot threads are evaluated.
  * Documented `reviewPolicy` behavior across supported profiles.
  * Updated review-thread resolution guidance, including marker requirements for automated and manual replies.
* **Changelog**
  * Added an Unreleased entry summarizing the new review-reply handling rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->