### PR TITLE
feat(advisory-convergence): add structured nextActions to verdict

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -134,10 +134,14 @@ In the idd-skill source repository, the following optional helpers were adopted:
   English next-action block is written to stderr _before_ that JSON so
   a GitHub Actions log surfaces the recovery command first (`#2142`).
   The block is derived from verdict fields, not from rewriting
-  `reasons[]`. Under `GITHUB_ACTIONS=true` a `::notice::` line is
-  added as extra surfacing; it is not a substitute for the stderr
-  block. `reasons[]` wording and the `--assert` exit-code contract
-  stay unchanged.
+  `reasons[]`. The same catalog is also emitted on the verdict as
+  `nextActions` (`#2143`): each item is a stable `token`, a one-line
+  English `summary`, and the command or phase `pointer` the stderr
+  block already printed. A ready verdict has `nextActions: []`; `ready`
+  does not depend on the field. Under `GITHUB_ACTIONS=true` a
+  `::notice::` line is added as extra surfacing; it is not a substitute
+  for the stderr block. `reasons[]` wording and the `--assert`
+  exit-code contract stay unchanged.
 - `scripts/rerun-advisory-convergence.mjs` (#1431) for a rerun-plan
   diagnosis of stuck `idd-advisory-convergence` check-run rollups,
   read-only by default: fetches every check-run instance for a PR's
@@ -1874,6 +1878,14 @@ reflexively as any other CLI option.
   exits non-zero unless `ready` is `true` (`ready = not_applicable ||
   converged || ((deadline passed || terminal-unavailable) && validly
   waived)`).
+- **Structured `nextActions` (`#2143`)**: the verdict also reports a
+  `nextActions` array populated from the same catalog the `--assert`
+  failure stderr block uses (`collectAssertNextActions`). Each item
+  has `token` (stable enum), `summary` (one-line English), and
+  `pointer` (the command or phase pointer already printed on stderr;
+  multi-command pointers are newline-separated). Ready verdicts emit
+  `nextActions: []`. `ready` does not depend on this field, and
+  `reasons[]` stays diagnostic state -- do not overload it.
 - **Review-policy applicability (`#2137`)**: this helper reads
   `reviewPolicy` from `.github/idd/config.json`. Exact
   `human-required` or `no-advisory` classifies the PR `not_applicable`

--- a/fixtures/schemas/advisory-convergence.valid.json
+++ b/fixtures/schemas/advisory-convergence.valid.json
@@ -69,5 +69,6 @@
   "converged": true,
   "waived": false,
   "ready": true,
-  "reasons": []
+  "reasons": [],
+  "nextActions": []
 }

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -134,10 +134,14 @@ In the idd-skill source repository, the following optional helpers were adopted:
   English next-action block is written to stderr _before_ that JSON so
   a GitHub Actions log surfaces the recovery command first (`#2142`).
   The block is derived from verdict fields, not from rewriting
-  `reasons[]`. Under `GITHUB_ACTIONS=true` a `::notice::` line is
-  added as extra surfacing; it is not a substitute for the stderr
-  block. `reasons[]` wording and the `--assert` exit-code contract
-  stay unchanged.
+  `reasons[]`. The same catalog is also emitted on the verdict as
+  `nextActions` (`#2143`): each item is a stable `token`, a one-line
+  English `summary`, and the command or phase `pointer` the stderr
+  block already printed. A ready verdict has `nextActions: []`; `ready`
+  does not depend on the field. Under `GITHUB_ACTIONS=true` a
+  `::notice::` line is added as extra surfacing; it is not a substitute
+  for the stderr block. `reasons[]` wording and the `--assert`
+  exit-code contract stay unchanged.
 - `scripts/rerun-advisory-convergence.mjs` (#1431) for a rerun-plan
   diagnosis of stuck `idd-advisory-convergence` check-run rollups,
   read-only by default: fetches every check-run instance for a PR's
@@ -1874,6 +1878,14 @@ reflexively as any other CLI option.
   exits non-zero unless `ready` is `true` (`ready = not_applicable ||
   converged || ((deadline passed || terminal-unavailable) && validly
   waived)`).
+- **Structured `nextActions` (`#2143`)**: the verdict also reports a
+  `nextActions` array populated from the same catalog the `--assert`
+  failure stderr block uses (`collectAssertNextActions`). Each item
+  has `token` (stable enum), `summary` (one-line English), and
+  `pointer` (the command or phase pointer already printed on stderr;
+  multi-command pointers are newline-separated). Ready verdicts emit
+  `nextActions: []`. `ready` does not depend on this field, and
+  `reasons[]` stays diagnostic state -- do not overload it.
 - **Review-policy applicability (`#2137`)**: this helper reads
   `reviewPolicy` from `.github/idd/config.json`. Exact
   `human-required` or `no-advisory` classifies the PR `not_applicable`

--- a/schemas/advisory-convergence.schema.json
+++ b/schemas/advisory-convergence.schema.json
@@ -23,7 +23,8 @@
     "converged",
     "waived",
     "ready",
-    "reasons"
+    "reasons",
+    "nextActions"
   ],
   "additionalProperties": false,
   "properties": {
@@ -378,6 +379,45 @@
       "type": "array",
       "description": "Human-readable strings explaining every unmet condition, accumulated in evaluation order.",
       "items": { "type": "string" }
+    },
+    "nextActions": {
+      "type": "array",
+      "description": "Structured next-action catalog (#2143) shared with the stderr --assert failure block. Empty exactly when ready is true. Never feeds ready. Each item is a stable token, a one-line English summary, and the command or phase pointer the stderr block already printed.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["token", "summary", "pointer"],
+        "properties": {
+          "token": {
+            "type": "string",
+            "description": "Stable machine-readable token naming which catalog branch produced this item.",
+            "enum": [
+              "indeterminate-applicability",
+              "request-review",
+              "request-re-review",
+              "disposition-posted-items",
+              "disposition-threads",
+              "ack-suppressed",
+              "waiver-terminal",
+              "hold-terminal",
+              "waiver-deadline",
+              "hold-deadline",
+              "same-head-reroll",
+              "reread-verdict"
+            ]
+          },
+          "summary": {
+            "type": "string",
+            "description": "One-line English summary of the recovery step.",
+            "minLength": 1
+          },
+          "pointer": {
+            "type": "string",
+            "description": "Concrete command or phase pointer already printed on the stderr block for this branch. Multi-command pointers are newline-separated.",
+            "minLength": 1
+          }
+        }
+      }
     }
   }
 }

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -169,8 +169,9 @@ export const SAME_HEAD_REROLL_INELIGIBLE_REASON = {
 };
 /** #2143: stable tokens for `nextActions[].token` -- one per branch of
  * {@link collectAssertNextActions}, the same catalog the stderr track
- * (`formatAssertNextActions`) already prints. Exported so tests and the
- * schema enum share a single source of truth. */
+ * (`formatAssertNextActions`) already prints. Exported so tests can pin
+ * the set. The schema `enum` is hand-maintained beside this object and
+ * must stay in sync; the pin test compares both. */
 export const ADVISORY_CONVERGENCE_NEXT_ACTION_TOKEN = {
   INDETERMINATE_APPLICABILITY: 'indeterminate-applicability',
   REQUEST_REVIEW: 'request-review',

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -167,6 +167,24 @@ export const SAME_HEAD_REROLL_INELIGIBLE_REASON = {
   REVIEW_ITEM_COUNT_NOT_POSITIVE: 'review-item-count-not-positive',
   ALREADY_SATISFIED_VIA_REVIEW_ACK: 'already-satisfied-via-review-ack',
 };
+/** #2143: stable tokens for `nextActions[].token` -- one per branch of
+ * {@link collectAssertNextActions}, the same catalog the stderr track
+ * (`formatAssertNextActions`) already prints. Exported so tests and the
+ * schema enum share a single source of truth. */
+export const ADVISORY_CONVERGENCE_NEXT_ACTION_TOKEN = {
+  INDETERMINATE_APPLICABILITY: 'indeterminate-applicability',
+  REQUEST_REVIEW: 'request-review',
+  REQUEST_RE_REVIEW: 'request-re-review',
+  DISPOSITION_POSTED_ITEMS: 'disposition-posted-items',
+  DISPOSITION_THREADS: 'disposition-threads',
+  ACK_SUPPRESSED: 'ack-suppressed',
+  WAIVER_TERMINAL: 'waiver-terminal',
+  HOLD_TERMINAL: 'hold-terminal',
+  WAIVER_DEADLINE: 'waiver-deadline',
+  HOLD_DEADLINE: 'hold-deadline',
+  SAME_HEAD_REROLL: 'same-head-reroll',
+  REREAD_VERDICT: 'reread-verdict',
+};
 /** #2137: exact `reviewPolicy` values that skip Copilot / primary-bot
  * clauses. Mapped to the `applicability.reason` token so tests and
  * operators can tell which policy produced the short-circuit. */
@@ -886,6 +904,25 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     scopeNotApplicable ||
     converged ||
     ((deadlinePassed || terminalUnavailable) && waived);
+  const reviewReport = {
+    ...review,
+    satisfied: reviewSatisfied,
+  };
+  // #2143: same catalog as the stderr track. Computed AFTER `ready` so a
+  // ready verdict is always `[]`; `ready` itself never reads this field.
+  const nextActions = collectAssertNextActions({
+    ready,
+    prNumber: inputs.prNumber,
+    prHeadSha,
+    primaryBotLogin,
+    applicability,
+    review: reviewReport,
+    threads: threadClause,
+    deadline,
+    waiver,
+    sameHeadReroll,
+    terminal,
+  });
   return {
     protocolVersion: '1',
     decisionAuthority: 'instructions',
@@ -899,7 +936,7 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     // `resolveLatestCopilotReviewClause` itself returns -- every other field
     // (`matchesHead` / `itemCount` / `suppressedCount` / `submittedAt` /
     // `found` / `commitId`) is untouched.
-    review: { ...review, satisfied: reviewSatisfied },
+    review: reviewReport,
     threads: threadClause,
     pending,
     deadline,
@@ -911,6 +948,7 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     waived,
     ready,
     reasons,
+    nextActions,
   };
 }
 // `isVerifiedCopilotAuthor` (#1686 defense-in-depth on top of
@@ -2062,41 +2100,54 @@ function fetchThreadCommentPages(threadId, afterCursor) {
   return nodes;
 }
 /**
- * Compact next-action guidance for a non-ready `--assert` verdict (#2142).
+ * Structured next-action catalog for a non-ready verdict (#2143).
  * Derived from structured verdict fields, never from parsing `reasons[]`.
  * Empty when `ready` is true. Script-authored English; not LLM prose.
+ * Shared by the stdout JSON field and the stderr formatter so the two
+ * channels cannot disagree.
  */
-export function formatAssertNextActions(verdict) {
+export function collectAssertNextActions(verdict) {
   if (verdict.ready) {
-    return '';
+    return [];
   }
   const pr = verdict.prNumber;
   const sha = verdict.prHeadSha;
   const bot = verdict.primaryBotLogin || 'copilot';
   const restLogin =
     bot === 'copilot' ? 'copilot-pull-request-reviewer[bot]' : bot;
-  const lines = ['Next action (idd-advisory-convergence --assert failed):'];
+  const T = ADVISORY_CONVERGENCE_NEXT_ACTION_TOKEN;
+  const items = [];
   if (verdict.applicability.status === 'indeterminate') {
     const waiverReady =
       (verdict.deadline.passed ||
         verdict.terminal.state === 'COPILOT_UNAVAILABLE') &&
       verdict.waiver.mode === 'maintainer-authorized';
-    lines.push(
-      waiverReady
-        ? `- Applicability is indeterminate (${verdict.applicability.reason}). Repair the claim linkage (claimed-by branch vs PR head) or post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha}, then: node scripts/advisory-convergence.mjs --pr ${pr} --assert`
-        : `- Applicability is indeterminate (${verdict.applicability.reason}). Repair the claim linkage (claimed-by branch vs PR head), then: node scripts/advisory-convergence.mjs --pr ${pr} --assert`,
-    );
+    const pointer = `node scripts/advisory-convergence.mjs --pr ${pr} --assert`;
+    items.push({
+      token: T.INDETERMINATE_APPLICABILITY,
+      summary: waiverReady
+        ? `Applicability is indeterminate (${verdict.applicability.reason}). Repair the claim linkage (claimed-by branch vs PR head) or post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha}, then: ${pointer}`
+        : `Applicability is indeterminate (${verdict.applicability.reason}). Repair the claim linkage (claimed-by branch vs PR head), then: ${pointer}`,
+      pointer,
+    });
   }
   if (!verdict.review.found) {
-    lines.push(
-      `- ${bot} has not reviewed this PR. Request a review (E14) then post an advisory-wait marker:`,
-      `  gh pr edit ${pr} --add-reviewer ${bot === 'copilot' ? 'copilot' : restLogin}`,
-      `  node scripts/post-idd-marker.mjs --type advisory --target pr ${pr} --agent-id <id> --head-sha ${sha} --timestamp <ISO8601> --apply`,
-    );
+    const reviewer = bot === 'copilot' ? 'copilot' : restLogin;
+    items.push({
+      token: T.REQUEST_REVIEW,
+      summary: `${bot} has not reviewed this PR. Request a review (E14) then post an advisory-wait marker:`,
+      pointer: [
+        `gh pr edit ${pr} --add-reviewer ${reviewer}`,
+        `node scripts/post-idd-marker.mjs --type advisory --target pr ${pr} --agent-id <id> --head-sha ${sha} --timestamp <ISO8601> --apply`,
+      ].join('\n'),
+    });
   } else if (!verdict.review.matchesHead) {
-    lines.push(
-      `- Latest ${bot} review covers ${verdict.review.commitId || '<unknown>'}, not HEAD ${sha}. Request a re-review of the current HEAD (E14 / AW3 REQUEST_NEEDED) and wait with: node scripts/advisory-wait-state.mjs --pr ${pr}`,
-    );
+    const pointer = `node scripts/advisory-wait-state.mjs --pr ${pr}`;
+    items.push({
+      token: T.REQUEST_RE_REVIEW,
+      summary: `Latest ${bot} review covers ${verdict.review.commitId || '<unknown>'}, not HEAD ${sha}. Request a re-review of the current HEAD (E14 / AW3 REQUEST_NEEDED) and wait with: ${pointer}`,
+      pointer,
+    });
   }
   const itemCount = verdict.review.itemCount;
   if (
@@ -2104,52 +2155,101 @@ export function formatAssertNextActions(verdict) {
     typeof itemCount === 'number' &&
     itemCount > 0
   ) {
-    lines.push(
-      `- Latest ${bot} review on HEAD has ${itemCount} posted item(s). Disposition each thread (E6/E13): node scripts/resolve-review-thread.mjs --pr ${pr} --comment-id <id> --body "**Accepted** — …" --claim-issue <n> --claim-id <id> --apply`,
-    );
+    const pointer = `node scripts/resolve-review-thread.mjs --pr ${pr} --comment-id <id> --body "**Accepted** — …" --claim-issue <n> --claim-id <id> --apply`;
+    items.push({
+      token: T.DISPOSITION_POSTED_ITEMS,
+      summary: `Latest ${bot} review on HEAD has ${itemCount} posted item(s). Disposition each thread (E6/E13): ${pointer}`,
+      pointer,
+    });
   }
   if (verdict.threads.blockingCount > 0) {
     const ids =
       verdict.threads.blockingIds.join(', ') || '(see threads.blockingIds)';
-    lines.push(
-      `- ${verdict.threads.blockingCount} Copilot thread(s) are unresolved and lack a valid disposition (${ids}). Reply with a stamped **Accepted**/**Rejected** and resolve via resolve-review-thread (E6/E13).`,
-    );
+    const pointer = 'resolve-review-thread (E6/E13)';
+    items.push({
+      token: T.DISPOSITION_THREADS,
+      summary: `${verdict.threads.blockingCount} Copilot thread(s) are unresolved and lack a valid disposition (${ids}). Reply with a stamped **Accepted**/**Rejected** and resolve via ${pointer}.`,
+      pointer,
+    });
   }
   if (verdict.review.suppressedCount > 0) {
-    lines.push(
-      `- Latest ${bot} review reports ${verdict.review.suppressedCount} suppressed comment(s). After reading the review body, post a trusted review-ack if they are handled: node scripts/post-idd-marker.mjs --type review-ack --target pr ${pr} --agent-id <id> --head-sha ${sha} --timestamp <ISO8601> --apply`,
-    );
+    const pointer = `node scripts/post-idd-marker.mjs --type review-ack --target pr ${pr} --agent-id <id> --head-sha ${sha} --timestamp <ISO8601> --apply`;
+    items.push({
+      token: T.ACK_SUPPRESSED,
+      summary: `Latest ${bot} review reports ${verdict.review.suppressedCount} suppressed comment(s). After reading the review body, post a trusted review-ack if they are handled: ${pointer}`,
+      pointer,
+    });
   }
   if (verdict.terminal.state === 'COPILOT_UNAVAILABLE') {
     if (verdict.waiver.mode === 'maintainer-authorized') {
-      lines.push(
-        `- Copilot is terminally unavailable. Post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha} (idd-pre-merge F2 / external-check-waiver), then: node scripts/rerun-advisory-convergence.mjs --pr ${pr}`,
-      );
+      const pointer = `node scripts/rerun-advisory-convergence.mjs --pr ${pr}`;
+      items.push({
+        token: T.WAIVER_TERMINAL,
+        summary: `Copilot is terminally unavailable. Post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha} (idd-pre-merge F2 / external-check-waiver), then: ${pointer}`,
+        pointer,
+      });
     } else {
-      lines.push(
-        `- Copilot is terminally unavailable and waivers are not enabled (mode "${verdict.waiver.mode}"). Hold for a maintainer; do not auto-merge.`,
-      );
+      const pointer = 'Hold for a maintainer; do not auto-merge.';
+      items.push({
+        token: T.HOLD_TERMINAL,
+        summary: `Copilot is terminally unavailable and waivers are not enabled (mode "${verdict.waiver.mode}"). ${pointer}`,
+        pointer,
+      });
     }
   } else if (verdict.deadline.passed) {
     if (verdict.waiver.mode === 'maintainer-authorized') {
-      lines.push(
-        `- Convergence deadline (${verdict.deadline.minutes}m) has passed. Post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha}, then rerun the required check.`,
-      );
+      const pointer = `Post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha}, then rerun the required check.`;
+      items.push({
+        token: T.WAIVER_DEADLINE,
+        summary: `Convergence deadline (${verdict.deadline.minutes}m) has passed. ${pointer}`,
+        pointer,
+      });
     } else {
-      lines.push(
-        `- Convergence deadline (${verdict.deadline.minutes}m) has passed and waivers are not enabled (mode "${verdict.waiver.mode}"). Hold for a maintainer.`,
-      );
+      const pointer = 'Hold for a maintainer.';
+      items.push({
+        token: T.HOLD_DEADLINE,
+        summary: `Convergence deadline (${verdict.deadline.minutes}m) has passed and waivers are not enabled (mode "${verdict.waiver.mode}"). ${pointer}`,
+        pointer,
+      });
     }
   }
   if (verdict.sameHeadReroll.requestable) {
-    lines.push(
-      `- Same-HEAD reroll is still requestable. Diagnose and rerun one instance at a time: node scripts/rerun-advisory-convergence.mjs --pr ${pr}`,
-    );
+    const pointer = `node scripts/rerun-advisory-convergence.mjs --pr ${pr}`;
+    items.push({
+      token: T.SAME_HEAD_REROLL,
+      summary: `Same-HEAD reroll is still requestable. Diagnose and rerun one instance at a time: ${pointer}`,
+      pointer,
+    });
   }
-  if (lines.length === 1) {
-    lines.push(
-      `- Re-read the JSON verdict on stdout and follow idd-advisory-wait.instructions.md / idd-pre-merge.instructions.md F2. Then: node scripts/advisory-convergence.mjs --pr ${pr} --assert`,
-    );
+  if (items.length === 0) {
+    const pointer = `node scripts/advisory-convergence.mjs --pr ${pr} --assert`;
+    items.push({
+      token: T.REREAD_VERDICT,
+      summary: `Re-read the JSON verdict on stdout and follow idd-advisory-wait.instructions.md / idd-pre-merge.instructions.md F2. Then: ${pointer}`,
+      pointer,
+    });
+  }
+  return items;
+}
+/**
+ * Compact next-action guidance for a non-ready `--assert` verdict (#2142).
+ * Formats {@link collectAssertNextActions}; does not read
+ * `verdict.nextActions`, so a spread-mutated verdict stays consistent
+ * with its own fields. Empty when `ready` is true.
+ */
+export function formatAssertNextActions(verdict) {
+  const items = collectAssertNextActions(verdict);
+  if (items.length === 0) {
+    return '';
+  }
+  const lines = ['Next action (idd-advisory-convergence --assert failed):'];
+  for (const item of items) {
+    lines.push(`- ${item.summary}`);
+    if (item.pointer.includes('\n')) {
+      for (const extra of item.pointer.split('\n')) {
+        lines.push(`  ${extra}`);
+      }
+    }
   }
   return `${lines.join('\n')}\n`;
 }

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -195,6 +195,37 @@ export const SAME_HEAD_REROLL_INELIGIBLE_REASON = {
 export type SameHeadRerollIneligibleReasonToken =
   (typeof SAME_HEAD_REROLL_INELIGIBLE_REASON)[keyof typeof SAME_HEAD_REROLL_INELIGIBLE_REASON];
 
+/** #2143: stable tokens for `nextActions[].token` -- one per branch of
+ * {@link collectAssertNextActions}, the same catalog the stderr track
+ * (`formatAssertNextActions`) already prints. Exported so tests and the
+ * schema enum share a single source of truth. */
+export const ADVISORY_CONVERGENCE_NEXT_ACTION_TOKEN = {
+  INDETERMINATE_APPLICABILITY: 'indeterminate-applicability',
+  REQUEST_REVIEW: 'request-review',
+  REQUEST_RE_REVIEW: 'request-re-review',
+  DISPOSITION_POSTED_ITEMS: 'disposition-posted-items',
+  DISPOSITION_THREADS: 'disposition-threads',
+  ACK_SUPPRESSED: 'ack-suppressed',
+  WAIVER_TERMINAL: 'waiver-terminal',
+  HOLD_TERMINAL: 'hold-terminal',
+  WAIVER_DEADLINE: 'waiver-deadline',
+  HOLD_DEADLINE: 'hold-deadline',
+  SAME_HEAD_REROLL: 'same-head-reroll',
+  REREAD_VERDICT: 'reread-verdict',
+} as const;
+
+export type AdvisoryConvergenceNextActionToken =
+  (typeof ADVISORY_CONVERGENCE_NEXT_ACTION_TOKEN)[keyof typeof ADVISORY_CONVERGENCE_NEXT_ACTION_TOKEN];
+
+/** One mechanically usable next-action item (#2143). `pointer` is the
+ * concrete command or phase pointer the stderr block already printed
+ * for that branch; a multi-command pointer is newline-separated. */
+export interface AdvisoryConvergenceNextAction {
+  token: AdvisoryConvergenceNextActionToken;
+  summary: string;
+  pointer: string;
+}
+
 // `GhAuthorPayload` (author reference embedded in GitHub REST/GraphQL
 // payloads) now lives in `review-clause.mts` and is imported above --
 // `__typename` (#1686) is GraphQL-only; this file's own `reviewThreads` /
@@ -420,6 +451,9 @@ export interface AdvisoryConvergenceVerdict {
   waived: boolean;
   ready: boolean;
   reasons: string[];
+  /** #2143: structured next-action catalog shared with the stderr
+   * track. Empty exactly when `ready` is true. Never feeds `ready`. */
+  nextActions: AdvisoryConvergenceNextAction[];
 }
 
 /** Pure inputs to {@link computeAdvisoryConvergenceVerdict} (already fetched;
@@ -1335,6 +1369,26 @@ export function computeAdvisoryConvergenceVerdict(
     converged ||
     ((deadlinePassed || terminalUnavailable) && waived);
 
+  const reviewReport: AdvisoryConvergenceReviewClause = {
+    ...review,
+    satisfied: reviewSatisfied,
+  };
+  // #2143: same catalog as the stderr track. Computed AFTER `ready` so a
+  // ready verdict is always `[]`; `ready` itself never reads this field.
+  const nextActions = collectAssertNextActions({
+    ready,
+    prNumber: inputs.prNumber,
+    prHeadSha,
+    primaryBotLogin,
+    applicability,
+    review: reviewReport,
+    threads: threadClause,
+    deadline,
+    waiver,
+    sameHeadReroll,
+    terminal,
+  });
+
   return {
     protocolVersion: '1',
     decisionAuthority: 'instructions',
@@ -1348,7 +1402,7 @@ export function computeAdvisoryConvergenceVerdict(
     // `resolveLatestCopilotReviewClause` itself returns -- every other field
     // (`matchesHead` / `itemCount` / `suppressedCount` / `submittedAt` /
     // `found` / `commitId`) is untouched.
-    review: { ...review, satisfied: reviewSatisfied },
+    review: reviewReport,
     threads: threadClause,
     pending,
     deadline,
@@ -1360,6 +1414,7 @@ export function computeAdvisoryConvergenceVerdict(
     waived,
     ready,
     reasons,
+    nextActions,
   };
 }
 
@@ -2696,48 +2751,77 @@ function fetchThreadCommentPages(
   return nodes;
 }
 
+/** Fields the next-action catalog reads. Omits `nextActions` itself so
+ * {@link formatAssertNextActions} can recompute from a spread-mutated
+ * verdict without trusting a stale copy. */
+type NextActionVerdictSource = Pick<
+  AdvisoryConvergenceVerdict,
+  | 'ready'
+  | 'prNumber'
+  | 'prHeadSha'
+  | 'primaryBotLogin'
+  | 'applicability'
+  | 'review'
+  | 'threads'
+  | 'deadline'
+  | 'waiver'
+  | 'sameHeadReroll'
+  | 'terminal'
+>;
+
 /**
- * Compact next-action guidance for a non-ready `--assert` verdict (#2142).
+ * Structured next-action catalog for a non-ready verdict (#2143).
  * Derived from structured verdict fields, never from parsing `reasons[]`.
  * Empty when `ready` is true. Script-authored English; not LLM prose.
+ * Shared by the stdout JSON field and the stderr formatter so the two
+ * channels cannot disagree.
  */
-export function formatAssertNextActions(
-  verdict: AdvisoryConvergenceVerdict,
-): string {
+export function collectAssertNextActions(
+  verdict: NextActionVerdictSource,
+): AdvisoryConvergenceNextAction[] {
   if (verdict.ready) {
-    return '';
+    return [];
   }
   const pr = verdict.prNumber;
   const sha = verdict.prHeadSha;
   const bot = verdict.primaryBotLogin || 'copilot';
   const restLogin =
     bot === 'copilot' ? 'copilot-pull-request-reviewer[bot]' : bot;
-  const lines: string[] = [
-    'Next action (idd-advisory-convergence --assert failed):',
-  ];
+  const T = ADVISORY_CONVERGENCE_NEXT_ACTION_TOKEN;
+  const items: AdvisoryConvergenceNextAction[] = [];
 
   if (verdict.applicability.status === 'indeterminate') {
     const waiverReady =
       (verdict.deadline.passed ||
         verdict.terminal.state === 'COPILOT_UNAVAILABLE') &&
       verdict.waiver.mode === 'maintainer-authorized';
-    lines.push(
-      waiverReady
-        ? `- Applicability is indeterminate (${verdict.applicability.reason}). Repair the claim linkage (claimed-by branch vs PR head) or post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha}, then: node scripts/advisory-convergence.mjs --pr ${pr} --assert`
-        : `- Applicability is indeterminate (${verdict.applicability.reason}). Repair the claim linkage (claimed-by branch vs PR head), then: node scripts/advisory-convergence.mjs --pr ${pr} --assert`,
-    );
+    const pointer = `node scripts/advisory-convergence.mjs --pr ${pr} --assert`;
+    items.push({
+      token: T.INDETERMINATE_APPLICABILITY,
+      summary: waiverReady
+        ? `Applicability is indeterminate (${verdict.applicability.reason}). Repair the claim linkage (claimed-by branch vs PR head) or post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha}, then: ${pointer}`
+        : `Applicability is indeterminate (${verdict.applicability.reason}). Repair the claim linkage (claimed-by branch vs PR head), then: ${pointer}`,
+      pointer,
+    });
   }
 
   if (!verdict.review.found) {
-    lines.push(
-      `- ${bot} has not reviewed this PR. Request a review (E14) then post an advisory-wait marker:`,
-      `  gh pr edit ${pr} --add-reviewer ${bot === 'copilot' ? 'copilot' : restLogin}`,
-      `  node scripts/post-idd-marker.mjs --type advisory --target pr ${pr} --agent-id <id> --head-sha ${sha} --timestamp <ISO8601> --apply`,
-    );
+    const reviewer = bot === 'copilot' ? 'copilot' : restLogin;
+    items.push({
+      token: T.REQUEST_REVIEW,
+      summary: `${bot} has not reviewed this PR. Request a review (E14) then post an advisory-wait marker:`,
+      pointer: [
+        `gh pr edit ${pr} --add-reviewer ${reviewer}`,
+        `node scripts/post-idd-marker.mjs --type advisory --target pr ${pr} --agent-id <id> --head-sha ${sha} --timestamp <ISO8601> --apply`,
+      ].join('\n'),
+    });
   } else if (!verdict.review.matchesHead) {
-    lines.push(
-      `- Latest ${bot} review covers ${verdict.review.commitId || '<unknown>'}, not HEAD ${sha}. Request a re-review of the current HEAD (E14 / AW3 REQUEST_NEEDED) and wait with: node scripts/advisory-wait-state.mjs --pr ${pr}`,
-    );
+    const pointer = `node scripts/advisory-wait-state.mjs --pr ${pr}`;
+    items.push({
+      token: T.REQUEST_RE_REVIEW,
+      summary: `Latest ${bot} review covers ${verdict.review.commitId || '<unknown>'}, not HEAD ${sha}. Request a re-review of the current HEAD (E14 / AW3 REQUEST_NEEDED) and wait with: ${pointer}`,
+      pointer,
+    });
   }
 
   const itemCount = verdict.review.itemCount;
@@ -2746,59 +2830,113 @@ export function formatAssertNextActions(
     typeof itemCount === 'number' &&
     itemCount > 0
   ) {
-    lines.push(
-      `- Latest ${bot} review on HEAD has ${itemCount} posted item(s). Disposition each thread (E6/E13): node scripts/resolve-review-thread.mjs --pr ${pr} --comment-id <id> --body "**Accepted** — …" --claim-issue <n> --claim-id <id> --apply`,
-    );
+    const pointer = `node scripts/resolve-review-thread.mjs --pr ${pr} --comment-id <id> --body "**Accepted** — …" --claim-issue <n> --claim-id <id> --apply`;
+    items.push({
+      token: T.DISPOSITION_POSTED_ITEMS,
+      summary: `Latest ${bot} review on HEAD has ${itemCount} posted item(s). Disposition each thread (E6/E13): ${pointer}`,
+      pointer,
+    });
   }
 
   if (verdict.threads.blockingCount > 0) {
     const ids =
       verdict.threads.blockingIds.join(', ') || '(see threads.blockingIds)';
-    lines.push(
-      `- ${verdict.threads.blockingCount} Copilot thread(s) are unresolved and lack a valid disposition (${ids}). Reply with a stamped **Accepted**/**Rejected** and resolve via resolve-review-thread (E6/E13).`,
-    );
+    const pointer = 'resolve-review-thread (E6/E13)';
+    items.push({
+      token: T.DISPOSITION_THREADS,
+      summary: `${verdict.threads.blockingCount} Copilot thread(s) are unresolved and lack a valid disposition (${ids}). Reply with a stamped **Accepted**/**Rejected** and resolve via ${pointer}.`,
+      pointer,
+    });
   }
 
   if (verdict.review.suppressedCount > 0) {
-    lines.push(
-      `- Latest ${bot} review reports ${verdict.review.suppressedCount} suppressed comment(s). After reading the review body, post a trusted review-ack if they are handled: node scripts/post-idd-marker.mjs --type review-ack --target pr ${pr} --agent-id <id> --head-sha ${sha} --timestamp <ISO8601> --apply`,
-    );
+    const pointer = `node scripts/post-idd-marker.mjs --type review-ack --target pr ${pr} --agent-id <id> --head-sha ${sha} --timestamp <ISO8601> --apply`;
+    items.push({
+      token: T.ACK_SUPPRESSED,
+      summary: `Latest ${bot} review reports ${verdict.review.suppressedCount} suppressed comment(s). After reading the review body, post a trusted review-ack if they are handled: ${pointer}`,
+      pointer,
+    });
   }
 
   if (verdict.terminal.state === 'COPILOT_UNAVAILABLE') {
     if (verdict.waiver.mode === 'maintainer-authorized') {
-      lines.push(
-        `- Copilot is terminally unavailable. Post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha} (idd-pre-merge F2 / external-check-waiver), then: node scripts/rerun-advisory-convergence.mjs --pr ${pr}`,
-      );
+      const pointer = `node scripts/rerun-advisory-convergence.mjs --pr ${pr}`;
+      items.push({
+        token: T.WAIVER_TERMINAL,
+        summary: `Copilot is terminally unavailable. Post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha} (idd-pre-merge F2 / external-check-waiver), then: ${pointer}`,
+        pointer,
+      });
     } else {
-      lines.push(
-        `- Copilot is terminally unavailable and waivers are not enabled (mode "${verdict.waiver.mode}"). Hold for a maintainer; do not auto-merge.`,
-      );
+      const pointer = 'Hold for a maintainer; do not auto-merge.';
+      items.push({
+        token: T.HOLD_TERMINAL,
+        summary: `Copilot is terminally unavailable and waivers are not enabled (mode "${verdict.waiver.mode}"). ${pointer}`,
+        pointer,
+      });
     }
   } else if (verdict.deadline.passed) {
     if (verdict.waiver.mode === 'maintainer-authorized') {
-      lines.push(
-        `- Convergence deadline (${verdict.deadline.minutes}m) has passed. Post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha}, then rerun the required check.`,
-      );
+      const pointer = `Post a maintainer external-check waiver for selector "${verdict.waiver.checkSelector}" on HEAD ${sha}, then rerun the required check.`;
+      items.push({
+        token: T.WAIVER_DEADLINE,
+        summary: `Convergence deadline (${verdict.deadline.minutes}m) has passed. ${pointer}`,
+        pointer,
+      });
     } else {
-      lines.push(
-        `- Convergence deadline (${verdict.deadline.minutes}m) has passed and waivers are not enabled (mode "${verdict.waiver.mode}"). Hold for a maintainer.`,
-      );
+      const pointer = 'Hold for a maintainer.';
+      items.push({
+        token: T.HOLD_DEADLINE,
+        summary: `Convergence deadline (${verdict.deadline.minutes}m) has passed and waivers are not enabled (mode "${verdict.waiver.mode}"). ${pointer}`,
+        pointer,
+      });
     }
   }
 
   if (verdict.sameHeadReroll.requestable) {
-    lines.push(
-      `- Same-HEAD reroll is still requestable. Diagnose and rerun one instance at a time: node scripts/rerun-advisory-convergence.mjs --pr ${pr}`,
-    );
+    const pointer = `node scripts/rerun-advisory-convergence.mjs --pr ${pr}`;
+    items.push({
+      token: T.SAME_HEAD_REROLL,
+      summary: `Same-HEAD reroll is still requestable. Diagnose and rerun one instance at a time: ${pointer}`,
+      pointer,
+    });
   }
 
-  if (lines.length === 1) {
-    lines.push(
-      `- Re-read the JSON verdict on stdout and follow idd-advisory-wait.instructions.md / idd-pre-merge.instructions.md F2. Then: node scripts/advisory-convergence.mjs --pr ${pr} --assert`,
-    );
+  if (items.length === 0) {
+    const pointer = `node scripts/advisory-convergence.mjs --pr ${pr} --assert`;
+    items.push({
+      token: T.REREAD_VERDICT,
+      summary: `Re-read the JSON verdict on stdout and follow idd-advisory-wait.instructions.md / idd-pre-merge.instructions.md F2. Then: ${pointer}`,
+      pointer,
+    });
   }
 
+  return items;
+}
+
+/**
+ * Compact next-action guidance for a non-ready `--assert` verdict (#2142).
+ * Formats {@link collectAssertNextActions}; does not read
+ * `verdict.nextActions`, so a spread-mutated verdict stays consistent
+ * with its own fields. Empty when `ready` is true.
+ */
+export function formatAssertNextActions(
+  verdict: NextActionVerdictSource,
+): string {
+  const items = collectAssertNextActions(verdict);
+  if (items.length === 0) {
+    return '';
+  }
+  const lines: string[] = [
+    'Next action (idd-advisory-convergence --assert failed):',
+  ];
+  for (const item of items) {
+    lines.push(`- ${item.summary}`);
+    if (item.pointer.includes('\n')) {
+      for (const extra of item.pointer.split('\n')) {
+        lines.push(`  ${extra}`);
+      }
+    }
+  }
   return `${lines.join('\n')}\n`;
 }
 

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -197,8 +197,9 @@ export type SameHeadRerollIneligibleReasonToken =
 
 /** #2143: stable tokens for `nextActions[].token` -- one per branch of
  * {@link collectAssertNextActions}, the same catalog the stderr track
- * (`formatAssertNextActions`) already prints. Exported so tests and the
- * schema enum share a single source of truth. */
+ * (`formatAssertNextActions`) already prints. Exported so tests can pin
+ * the set. The schema `enum` is hand-maintained beside this object and
+ * must stay in sync; the pin test compares both. */
 export const ADVISORY_CONVERGENCE_NEXT_ACTION_TOKEN = {
   INDETERMINATE_APPLICABILITY: 'indeterminate-applicability',
   REQUEST_REVIEW: 'request-review',

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -4188,6 +4188,37 @@ test('formatAssertNextActions covers indeterminate applicability (#2142)', () =>
   assert.doesNotMatch(text, /external-check waiver/);
 });
 
+test('nextActions token catalog is pinned and matches the schema enum (#2143)', () => {
+  const tokens = Object.values(ADVISORY_CONVERGENCE_NEXT_ACTION_TOKEN).sort();
+  assert.deepEqual(
+    tokens,
+    [
+      'ack-suppressed',
+      'disposition-posted-items',
+      'disposition-threads',
+      'hold-deadline',
+      'hold-terminal',
+      'indeterminate-applicability',
+      'request-re-review',
+      'request-review',
+      'reread-verdict',
+      'same-head-reroll',
+      'waiver-deadline',
+      'waiver-terminal',
+    ].sort(),
+  );
+  const schemaTokens = (
+    SCHEMA as {
+      properties: {
+        nextActions: {
+          items: { properties: { token: { enum: string[] } } };
+        };
+      };
+    }
+  ).properties.nextActions.items.properties.token.enum;
+  assert.deepEqual([...schemaTokens].sort(), tokens);
+});
+
 test('computeAdvisoryConvergenceVerdict: ready nextActions is empty (#2143)', () => {
   const verdict = computeAdvisoryConvergenceVerdict(
     baseInputs({

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -3,11 +3,13 @@ import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 import {
+  ADVISORY_CONVERGENCE_NEXT_ACTION_TOKEN,
   type AdvisoryConvergenceDeps,
   type AdvisoryConvergenceInputs,
   type AdvisoryConvergenceOptions,
   classifyClaimCandidateAmbiguity,
   classifyCopilotAuthoredThreadIds,
+  collectAssertNextActions,
   computeAdvisoryConvergenceVerdict,
   formatAssertNextActions,
   hasTrustedClaimMarkerHistory,
@@ -4184,6 +4186,56 @@ test('formatAssertNextActions covers indeterminate applicability (#2142)', () =>
   assert.match(text, /indeterminate/);
   assert.match(text, /claimed-by/);
   assert.doesNotMatch(text, /external-check waiver/);
+});
+
+test('computeAdvisoryConvergenceVerdict: ready nextActions is empty (#2143)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [
+        {
+          author: { login: COPILOT_LOGIN },
+          submittedAt: RECENT,
+          commitId: HEAD,
+          itemCount: 0,
+          body: '',
+        },
+      ],
+    }),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.ready, true);
+  assert.deepEqual(verdict.nextActions, []);
+  assert.deepEqual(collectAssertNextActions(verdict), []);
+});
+
+test('computeAdvisoryConvergenceVerdict: not-ready nextActions match stderr (#2143)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs(),
+    baseOptions(),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.ready, false);
+  assert.ok(verdict.nextActions.length > 0);
+  const first = verdict.nextActions[0];
+  assert.equal(
+    first?.token,
+    ADVISORY_CONVERGENCE_NEXT_ACTION_TOKEN.REQUEST_REVIEW,
+  );
+  assert.ok(first);
+  const stderr = formatAssertNextActions(verdict);
+  assert.match(stderr, /has not reviewed this PR/);
+  for (const line of first.pointer.split('\n')) {
+    assert.ok(
+      stderr.includes(line),
+      `stderr must contain pointer line: ${line}`,
+    );
+  }
+  assert.deepEqual(collectAssertNextActions(verdict), verdict.nextActions);
+  assert.doesNotMatch(
+    JSON.stringify(verdict.reasons),
+    /request-review|nextActions/,
+  );
 });
 
 test('writeAdvisoryConvergenceCliOutput writes guidance before JSON (#2142)', () => {

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -264,6 +264,7 @@ export const advisoryConvergenceKeys = [
   'waived',
   'ready',
   'reasons',
+  'nextActions',
 ] as const satisfies readonly (keyof AdvisoryConvergenceVerdict)[];
 
 export const advisoryWaitStateKeys = [
@@ -619,6 +620,7 @@ const advisoryConvergenceFixture = {
   waived: false,
   ready: true,
   reasons: [],
+  nextActions: [],
 } satisfies AdvisoryConvergenceVerdict;
 
 const advisoryWaitStateFixture = {


### PR DESCRIPTION
# Summary

The advisory-convergence verdict now includes a `nextActions` array
populated from the same catalog the `--assert` stderr block uses, so
`jq` callers no longer have to rebuild the next step from `reasons[]`.

## Linked issue

Closes #2143

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

`#2142` made the Actions log readable. Agents and pipelines still
consume only stdout. `reasons[]` stays diagnostic state (`#2015`
matches one of those strings exactly), so this PR adds a dedicated
field instead of overloading it. `protocolVersion` stays `"1"`. Ready
verdicts emit `nextActions: []`.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed