### PR TITLE
docs(review-fix): give the signed merge wrapper a conventional -m

### DIFF
--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -80,7 +80,10 @@ git merge origin/main`), resolve them, and complete the merge. On a
 signed-commit repo with non-interactive-hostile primary signing (GPG
 pinentry / hardware-touch), use the
 [signed-commit merge wrapper](../../docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure)
-for the whole operation instead of the plain command.
+for the whole operation instead of the plain command. That wrapper's
+merge invocation includes a conventional `-m` subject (for example
+`chore: merge origin/main into the claimed branch`) so a commitlint
+`commit-msg` hook does not reject the merge commit.
 
 **Active review gate**: same check as
 `idd-review-triage.instructions.md`'s sync path step 1 — unresolved

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -461,7 +461,10 @@ Route based on `branchState` from the helper (or `mergeable` /
 2. Merge `main` into the feature branch:
    `git fetch origin main && git merge origin/main`. Use the
    [signed-commit merge wrapper](../../docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure)
-   when primary signing is non-interactive-hostile.
+   when primary signing is non-interactive-hostile. That wrapper's
+   merge invocation includes a conventional `-m` subject (for example
+   `chore: merge origin/main into the claimed branch`) so a commitlint
+   `commit-msg` hook does not reject the merge commit.
 3. If conflicts arise, resolve them and complete the merge with that
    same procedure — mirrors the D1 rebase note.
 4. Run **post-fix-validate**.

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -137,7 +137,9 @@ other GitHub side effect, confirm all of the following:
    hostile (GPG pinentry or hardware-touch) but that provides a
    fallback signing wrapper for arbitrary git subcommands (pass
    `-c gpg.format=ssh -c user.signingkey=<abs-path> -c
-   commit.gpgsign=true` to `git` before the subcommand — `git -c …
+   commit.gpgsign=true` to `git` before the subcommand, plus
+   `-m "chore: merge origin/main into the claimed branch"` on the
+   first `merge` so a commitlint hook accepts the subject — `git -c …
    merge`, not `git merge -c …`; a commit-only alias like
    `git commit-ssh` will not run `merge`), run this merge through that
    wrapper, not the plain command.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2536,10 +2536,17 @@ arbitrary git subcommands, run the **merge** step — including a
 plain command (`git fetch` creates no commit and needs no signing):
 
 ```sh
-git -c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true merge origin/main
+git -c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true merge -m "chore: merge origin/main into the claimed branch" origin/main
 # resolve conflicts if any, then:
 git -c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true merge --continue
 ```
+
+Include the conventional `-m` subject so a `commit-msg` hook that runs
+commitlint accepts the merge commit (a subject without a `type:` prefix
+fails the hook and leaves `MERGE_HEAD` in place). Repositories without
+that hook can keep the same subject; it does not change unsigned
+`git merge` elsewhere. `merge --continue` reuses `MERGE_MSG` and needs
+no second `-m`.
 
 Pass the `-c` flags to `git` itself, before the subcommand (`git -c …
 merge`, not `git merge -c …`); a commit-only alias such as `git

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -75,7 +75,10 @@ git merge origin/main`), resolve them, and complete the merge. On a
 signed-commit repo with non-interactive-hostile primary signing (GPG
 pinentry / hardware-touch), use the
 [signed-commit merge wrapper](../../docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure)
-for the whole operation instead of the plain command.
+for the whole operation instead of the plain command. That wrapper's
+merge invocation includes a conventional `-m` subject (for example
+`chore: merge origin/main into the claimed branch`) so a commitlint
+`commit-msg` hook does not reject the merge commit.
 
 **Active review gate**: same check as
 `idd-review-triage.instructions.md`'s sync path step 1 — unresolved

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -456,7 +456,10 @@ Route based on `branchState` from the helper (or `mergeable` /
 2. Merge `main` into the feature branch:
    `git fetch origin main && git merge origin/main`. Use the
    [signed-commit merge wrapper](../../docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure)
-   when primary signing is non-interactive-hostile.
+   when primary signing is non-interactive-hostile. That wrapper's
+   merge invocation includes a conventional `-m` subject (for example
+   `chore: merge origin/main into the claimed branch`) so a commitlint
+   `commit-msg` hook does not reject the merge commit.
 3. If conflicts arise, resolve them and complete the merge with that
    same procedure — mirrors the D1 rebase note.
 4. Run **post-fix-validate**.

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -132,7 +132,9 @@ other GitHub side effect, confirm all of the following:
    hostile (GPG pinentry or hardware-touch) but that provides a
    fallback signing wrapper for arbitrary git subcommands (pass
    `-c gpg.format=ssh -c user.signingkey=<abs-path> -c
-   commit.gpgsign=true` to `git` before the subcommand — `git -c …
+   commit.gpgsign=true` to `git` before the subcommand, plus
+   `-m "chore: merge origin/main into the claimed branch"` on the
+   first `merge` so a commitlint hook accepts the subject — `git -c …
    merge`, not `git merge -c …`; a commit-only alias like
    `git commit-ssh` will not run `merge`), run this merge through that
    wrapper, not the plain command.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2536,10 +2536,17 @@ arbitrary git subcommands, run the **merge** step — including a
 plain command (`git fetch` creates no commit and needs no signing):
 
 ```sh
-git -c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true merge origin/main
+git -c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true merge -m "chore: merge origin/main into the claimed branch" origin/main
 # resolve conflicts if any, then:
 git -c gpg.format=ssh -c user.signingkey=<abs-path> -c commit.gpgsign=true merge --continue
 ```
+
+Include the conventional `-m` subject so a `commit-msg` hook that runs
+commitlint accepts the merge commit (a subject without a `type:` prefix
+fails the hook and leaves `MERGE_HEAD` in place). Repositories without
+that hook can keep the same subject; it does not change unsigned
+`git merge` elsewhere. `merge --continue` reuses `MERGE_MSG` and needs
+no second `-m`.
 
 Pass the `-c` flags to `git` itself, before the subcommand (`git -c …
 merge`, not `git merge -c …`); a commit-only alias such as `git


### PR DESCRIPTION
# Summary

The signed-commit merge wrapper now includes a Conventional Commits
`-m` subject so a commitlint `commit-msg` hook does not reject the
merge commit and leave `MERGE_HEAD` in place.

## Linked issue

Closes #2149

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Observed on this repository during issue #2091 E11: a merge subject
without a `type:` prefix failed commitlint. Unsigned `git merge`
elsewhere is unchanged.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated merge guidance with an explicit conventional commit subject for signed merges.
  * Clarified fallback merge instructions to help prevent commit-message validation failures.
  * Applied the guidance consistently across standard and lightweight templates.
  * Confirmed that continuing an in-progress merge remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->