### PR TITLE
fix(helpers): fall back when REST viewer-login or permission reads 503

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ discipline and has no tag.
 
 ### Changed
 
+- A5 collectors fall back when REST `GET /user` or collaborators
+  permission reads return 5xx: `resume-claim-routing` tries GraphQL
+  `viewer { login }` once, and `claim-approval-gate` treats a live
+  issue `author_association` of `OWNER` or `MEMBER` as sufficient
+  self-authorization without a successful permission read.
 - `advisory-convergence` honors `reviewPolicy`: `human-required` and
   `no-advisory` make the check `not_applicable` (ready without Copilot
   clauses) instead of judging every applicable PR as Copilot-advisory.

--- a/scripts/claim-approval-gate.mjs
+++ b/scripts/claim-approval-gate.mjs
@@ -91,11 +91,17 @@ export function evaluateClaimApprovalGate(input, options = {}) {
   const authorPermission = issueAuthor
     ? normalizePermissionResult(resolvePermission(issueAuthor))
     : { known: false, permission: '', error: 'issue author missing' };
-  const authorSelfAuthorized = isAuthorizedByPolicy(
-    authorPermission.permission,
+  const associationSelfAuthorized = authorAssociationSelfAuthorizes(
+    issue.authorAssociation,
     policyState.maintainerApprovalActorPolicy,
   );
-  if (!authorPermission.known) {
+  const authorSelfAuthorized =
+    isAuthorizedByPolicy(
+      authorPermission.permission,
+      policyState.maintainerApprovalActorPolicy,
+    ) ||
+    (!authorPermission.known && associationSelfAuthorized);
+  if (!authorPermission.known && !associationSelfAuthorized) {
     ambiguity.push('issue-author-permission-unavailable');
     permissionAmbiguity = true;
   }
@@ -104,7 +110,9 @@ export function evaluateClaimApprovalGate(input, options = {}) {
     name: 'Issue author self-authorized',
     result: authorSelfAuthorized ? 'pass' : 'fail',
     evidence: authorSelfAuthorized
-      ? `Issue author ${issueAuthor} satisfies policy ${policyState.maintainerApprovalActorPolicy}.`
+      ? authorPermission.known
+        ? `Issue author ${issueAuthor} satisfies policy ${policyState.maintainerApprovalActorPolicy}.`
+        : `Issue author ${issueAuthor} author_association ${issue.authorAssociation} satisfies policy ${policyState.maintainerApprovalActorPolicy} without a collaborators-permission read (#2148).`
       : `Issue author ${issueAuthor || '(missing)'} does not satisfy policy ${policyState.maintainerApprovalActorPolicy}.`,
   });
   const latestSubstantiveEditAt = resolveLatestSubstantiveEditAt(
@@ -327,6 +335,9 @@ function normalizeIssue(issue) {
   const i = issue;
   return {
     authorLogin: String(i?.user?.login ?? '')
+      .trim()
+      .toLowerCase(),
+    authorAssociation: String(i?.author_association ?? '')
       .trim()
       .toLowerCase(),
     labels: normalizeLabels(i?.labels),
@@ -581,6 +592,23 @@ function deriveReason(state) {
     return 'ready-comment-fresh';
   }
   return 'gate-disabled';
+}
+/** #2148: live issue `author_association` is enough for self-authorization
+ * when the collaborators-permission endpoint is unavailable. OWNER is
+ * always sufficient; MEMBER is accepted under the default
+ * owners-and-maintainers-only policy (the observed payload for an org
+ * owner when REST /permission 503s). */
+function authorAssociationSelfAuthorizes(association, policy) {
+  if (association === 'owner') {
+    return true;
+  }
+  if (association === 'member') {
+    return (
+      policy === 'owners-and-maintainers-only' ||
+      policy === 'all-write-permission-actors'
+    );
+  }
+  return false;
 }
 function isAuthorizedByPolicy(permission, policy) {
   if (policy === 'all-write-permission-actors') {

--- a/scripts/gh-exec.mjs
+++ b/scripts/gh-exec.mjs
@@ -260,8 +260,9 @@ export function ghGraphql(query, variables) {
   return JSON.parse(ghText(args).trim() || '{}');
 }
 /** #2148: REST `GET /user` failures that may still have a live GraphQL
- * `viewer { login }` — 5xx, timeout, empty body, or an unclassified
- * transport error. 4xx stays fail-closed on REST (no GraphQL fallback). */
+ * `viewer { login }` — 5xx, timeout, or a killed child. Unclassified
+ * errors and 4xx stay fail-closed on REST (no GraphQL fallback), so an
+ * unparsable 4xx cannot leak through `deriveGhHttpStatus() === null`. */
 export function viewerLoginFailureIsGraphqlEligible(error) {
   const code = String(error?.code ?? '');
   if (code === 'ETIMEDOUT' || code === 'ABORT_ERR') {
@@ -272,7 +273,7 @@ export function viewerLoginFailureIsGraphqlEligible(error) {
   }
   const status = deriveGhHttpStatus(error);
   if (status == null) {
-    return true;
+    return false;
   }
   return status >= 500 && status <= 599;
 }

--- a/scripts/gh-exec.mjs
+++ b/scripts/gh-exec.mjs
@@ -17,6 +17,7 @@
 import { execFile, execFileSync } from 'node:child_process';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { promisify } from 'node:util';
+import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import { parsePaginatedGhNdjson } from './protocol-helpers.mjs';
 /**
  * Default `execFileSync`/`execFile` timeout (ms) applied when a caller
@@ -257,6 +258,70 @@ export function ghGraphql(query, variables) {
     args.push('-f', `${key}=${value}`);
   }
   return JSON.parse(ghText(args).trim() || '{}');
+}
+/** #2148: REST `GET /user` failures that may still have a live GraphQL
+ * `viewer { login }` — 5xx, timeout, empty body, or an unclassified
+ * transport error. 4xx stays fail-closed on REST (no GraphQL fallback). */
+export function viewerLoginFailureIsGraphqlEligible(error) {
+  const code = String(error?.code ?? '');
+  if (code === 'ETIMEDOUT' || code === 'ABORT_ERR') {
+    return true;
+  }
+  if (error?.killed === true) {
+    return true;
+  }
+  const status = deriveGhHttpStatus(error);
+  if (status == null) {
+    return true;
+  }
+  return status >= 500 && status <= 599;
+}
+function defaultRestViewerLogin(options = {}) {
+  return ghText(['api', 'user', '--jq', '.login'], options);
+}
+function defaultGraphqlViewerLogin() {
+  const payload = ghGraphql('query { viewer { login } }', {});
+  const root = payload;
+  return String(root.data?.viewer?.login ?? root.viewer?.login ?? '').trim();
+}
+/** Resolve the current GitHub actor login for A5 collectors (#2148).
+ *
+ * REST `GET /user` first. On 5xx, timeout, or empty body, try GraphQL
+ * `viewer { login }` once. 4xx does not fall back. If both fail, the
+ * original REST error is rethrown (today's fail-closed abort). */
+export function resolveViewerLogin(options = {}, deps = {}) {
+  const rest = deps.rest ?? (() => defaultRestViewerLogin(options));
+  const graphql = deps.graphql ?? defaultGraphqlViewerLogin;
+  try {
+    const login = rest().trim();
+    if (login) {
+      return login;
+    }
+  } catch (error) {
+    if (!viewerLoginFailureIsGraphqlEligible(error)) {
+      throw error;
+    }
+    try {
+      const fallback = graphql().trim();
+      if (fallback) {
+        return fallback;
+      }
+    } catch {
+      // Keep the REST error as the fail-closed abort.
+    }
+    throw error;
+  }
+  try {
+    const fallback = graphql().trim();
+    if (fallback) {
+      return fallback;
+    }
+  } catch {
+    // Empty REST body plus GraphQL failure is still unavailable.
+  }
+  throw new Error(
+    'viewer login unavailable from REST /user and GraphQL viewer',
+  );
 }
 const DEFAULT_BOUNDED_RETRY_ATTEMPTS = 3;
 const DEFAULT_BOUNDED_RETRY_BASE_DELAY_MS = 200;

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -6,7 +6,11 @@
 // generated .mjs. See docs/typescript-sources.md.
 import { parseCliArgs } from './cli-args.mjs';
 import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mjs';
-import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
+import {
+  GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  ghText,
+  resolveViewerLogin,
+} from './gh-exec.mjs';
 import { loadPolicyConfig } from './idd-config.mjs';
 import { listActivationNonces } from './marker-helpers.mjs';
 import { normalizePolicyConfig } from './policy-helpers.mjs';
@@ -316,10 +320,7 @@ function runCli() {
   const trustedLogins = resolveTrustedLogins({
     fromArgs: args.trustedMarkerLogins,
     fromPolicy: policy.trustedMarkerActors,
-    currentLogin: ghText(
-      ['api', 'user', '--jq', '.login'],
-      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-    ),
+    currentLogin: resolveViewerLogin(GH_TEXT_LOOP_TIMEOUT_OPTIONS),
   });
   const trustedSet = new Set(trustedLogins.map((login) => login.toLowerCase()));
   const comments = fetchIssueComments(repository, args.issue);

--- a/src/scripts/claim-approval-gate.mts
+++ b/src/scripts/claim-approval-gate.mts
@@ -32,6 +32,7 @@ type ResolvePermission = (login: string) => unknown;
 
 interface NormalizedIssue {
   authorLogin: string;
+  authorAssociation: string;
   labels: string[];
   createdAt: string | null;
   updatedAt: string | null;
@@ -169,11 +170,17 @@ export function evaluateClaimApprovalGate(
   const authorPermission = issueAuthor
     ? normalizePermissionResult(resolvePermission(issueAuthor))
     : { known: false, permission: '', error: 'issue author missing' };
-  const authorSelfAuthorized = isAuthorizedByPolicy(
-    authorPermission.permission,
+  const associationSelfAuthorized = authorAssociationSelfAuthorizes(
+    issue.authorAssociation,
     policyState.maintainerApprovalActorPolicy,
   );
-  if (!authorPermission.known) {
+  const authorSelfAuthorized =
+    isAuthorizedByPolicy(
+      authorPermission.permission,
+      policyState.maintainerApprovalActorPolicy,
+    ) ||
+    (!authorPermission.known && associationSelfAuthorized);
+  if (!authorPermission.known && !associationSelfAuthorized) {
     ambiguity.push('issue-author-permission-unavailable');
     permissionAmbiguity = true;
   }
@@ -182,7 +189,9 @@ export function evaluateClaimApprovalGate(
     name: 'Issue author self-authorized',
     result: authorSelfAuthorized ? 'pass' : 'fail',
     evidence: authorSelfAuthorized
-      ? `Issue author ${issueAuthor} satisfies policy ${policyState.maintainerApprovalActorPolicy}.`
+      ? authorPermission.known
+        ? `Issue author ${issueAuthor} satisfies policy ${policyState.maintainerApprovalActorPolicy}.`
+        : `Issue author ${issueAuthor} author_association ${issue.authorAssociation} satisfies policy ${policyState.maintainerApprovalActorPolicy} without a collaborators-permission read (#2148).`
       : `Issue author ${issueAuthor || '(missing)'} does not satisfy policy ${policyState.maintainerApprovalActorPolicy}.`,
   });
 
@@ -329,6 +338,7 @@ function runCli(): void {
     html_url?: unknown;
     url?: unknown;
     user?: { login?: unknown };
+    author_association?: unknown;
   };
   const comments = ghApiJson(
     `repos/${repoRef}/issues/${args.issue}/comments`,
@@ -437,6 +447,7 @@ function normalizeIssue(issue: unknown): NormalizedIssue {
   const i = issue as
     | {
         user?: { login?: unknown };
+        author_association?: unknown;
         labels?: unknown;
         created_at?: unknown;
         updated_at?: unknown;
@@ -445,6 +456,9 @@ function normalizeIssue(issue: unknown): NormalizedIssue {
     | undefined;
   return {
     authorLogin: String(i?.user?.login ?? '')
+      .trim()
+      .toLowerCase(),
+    authorAssociation: String(i?.author_association ?? '')
       .trim()
       .toLowerCase(),
     labels: normalizeLabels(i?.labels),
@@ -773,6 +787,27 @@ function deriveReason(state: {
     return 'ready-comment-fresh';
   }
   return 'gate-disabled';
+}
+
+/** #2148: live issue `author_association` is enough for self-authorization
+ * when the collaborators-permission endpoint is unavailable. OWNER is
+ * always sufficient; MEMBER is accepted under the default
+ * owners-and-maintainers-only policy (the observed payload for an org
+ * owner when REST /permission 503s). */
+function authorAssociationSelfAuthorizes(
+  association: string,
+  policy: string,
+): boolean {
+  if (association === 'owner') {
+    return true;
+  }
+  if (association === 'member') {
+    return (
+      policy === 'owners-and-maintainers-only' ||
+      policy === 'all-write-permission-actors'
+    );
+  }
+  return false;
 }
 
 function isAuthorizedByPolicy(permission: string, policy: string): boolean {

--- a/src/scripts/gh-exec.mts
+++ b/src/scripts/gh-exec.mts
@@ -366,8 +366,9 @@ export function ghGraphql(
 }
 
 /** #2148: REST `GET /user` failures that may still have a live GraphQL
- * `viewer { login }` — 5xx, timeout, empty body, or an unclassified
- * transport error. 4xx stays fail-closed on REST (no GraphQL fallback). */
+ * `viewer { login }` — 5xx, timeout, or a killed child. Unclassified
+ * errors and 4xx stay fail-closed on REST (no GraphQL fallback), so an
+ * unparsable 4xx cannot leak through `deriveGhHttpStatus() === null`. */
 export function viewerLoginFailureIsGraphqlEligible(error: unknown): boolean {
   const code = String((error as { code?: unknown } | null)?.code ?? '');
   if (code === 'ETIMEDOUT' || code === 'ABORT_ERR') {
@@ -378,7 +379,7 @@ export function viewerLoginFailureIsGraphqlEligible(error: unknown): boolean {
   }
   const status = deriveGhHttpStatus(error);
   if (status == null) {
-    return true;
+    return false;
   }
   return status >= 500 && status <= 599;
 }

--- a/src/scripts/gh-exec.mts
+++ b/src/scripts/gh-exec.mts
@@ -20,6 +20,7 @@ import { execFile, execFileSync } from 'node:child_process';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { promisify } from 'node:util';
 
+import { deriveGhHttpStatus } from './gh-http-status.mts';
 import { parsePaginatedGhNdjson } from './protocol-helpers.mts';
 
 /**
@@ -362,6 +363,83 @@ export function ghGraphql(
     args.push('-f', `${key}=${value}`);
   }
   return JSON.parse(ghText(args).trim() || '{}');
+}
+
+/** #2148: REST `GET /user` failures that may still have a live GraphQL
+ * `viewer { login }` — 5xx, timeout, empty body, or an unclassified
+ * transport error. 4xx stays fail-closed on REST (no GraphQL fallback). */
+export function viewerLoginFailureIsGraphqlEligible(error: unknown): boolean {
+  const code = String((error as { code?: unknown } | null)?.code ?? '');
+  if (code === 'ETIMEDOUT' || code === 'ABORT_ERR') {
+    return true;
+  }
+  if ((error as { killed?: unknown } | null)?.killed === true) {
+    return true;
+  }
+  const status = deriveGhHttpStatus(error);
+  if (status == null) {
+    return true;
+  }
+  return status >= 500 && status <= 599;
+}
+
+function defaultRestViewerLogin(options: GhTextOptions = {}): string {
+  return ghText(['api', 'user', '--jq', '.login'], options);
+}
+
+function defaultGraphqlViewerLogin(): string {
+  const payload = ghGraphql('query { viewer { login } }', {});
+  const root = payload as {
+    data?: { viewer?: { login?: unknown } };
+    viewer?: { login?: unknown };
+  };
+  return String(root.data?.viewer?.login ?? root.viewer?.login ?? '').trim();
+}
+
+/** Resolve the current GitHub actor login for A5 collectors (#2148).
+ *
+ * REST `GET /user` first. On 5xx, timeout, or empty body, try GraphQL
+ * `viewer { login }` once. 4xx does not fall back. If both fail, the
+ * original REST error is rethrown (today's fail-closed abort). */
+export function resolveViewerLogin(
+  options: GhTextOptions = {},
+  deps: {
+    rest?: () => string;
+    graphql?: () => string;
+  } = {},
+): string {
+  const rest = deps.rest ?? (() => defaultRestViewerLogin(options));
+  const graphql = deps.graphql ?? defaultGraphqlViewerLogin;
+  try {
+    const login = rest().trim();
+    if (login) {
+      return login;
+    }
+  } catch (error) {
+    if (!viewerLoginFailureIsGraphqlEligible(error)) {
+      throw error;
+    }
+    try {
+      const fallback = graphql().trim();
+      if (fallback) {
+        return fallback;
+      }
+    } catch {
+      // Keep the REST error as the fail-closed abort.
+    }
+    throw error;
+  }
+  try {
+    const fallback = graphql().trim();
+    if (fallback) {
+      return fallback;
+    }
+  } catch {
+    // Empty REST body plus GraphQL failure is still unavailable.
+  }
+  throw new Error(
+    'viewer login unavailable from REST /user and GraphQL viewer',
+  );
 }
 
 /** Options accepted by {@link withBoundedRetry}. */

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -8,7 +8,11 @@
 import { parseCliArgs } from './cli-args.mts';
 import type { CollaboratorPermissionCache } from './collaborator-permission.mts';
 import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mts';
-import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mts';
+import {
+  GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  ghText,
+  resolveViewerLogin,
+} from './gh-exec.mts';
 import { loadPolicyConfig } from './idd-config.mts';
 import { listActivationNonces } from './marker-helpers.mts';
 import { normalizePolicyConfig } from './policy-helpers.mts';
@@ -444,10 +448,7 @@ function runCli(): void {
   const trustedLogins = resolveTrustedLogins({
     fromArgs: args.trustedMarkerLogins,
     fromPolicy: policy.trustedMarkerActors,
-    currentLogin: ghText(
-      ['api', 'user', '--jq', '.login'],
-      GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-    ),
+    currentLogin: resolveViewerLogin(GH_TEXT_LOOP_TIMEOUT_OPTIONS),
   });
   const trustedSet = new Set(trustedLogins.map((login) => login.toLowerCase()));
   const comments = fetchIssueComments(repository, args.issue);

--- a/tests/claim-approval-gate.test.mts
+++ b/tests/claim-approval-gate.test.mts
@@ -93,6 +93,86 @@ test('write collaborator is not self-authorized under default policy', () => {
   assert.equal(result.approved, false);
 });
 
+test('OWNER author_association self-authorizes when permission read is unknown (#2148)', () => {
+  const result = evaluateClaimApprovalGate(
+    {
+      issue: { ...BASE_ISSUE, author_association: 'OWNER' },
+      policy: { maintainerApprovalActorPolicy: 'owners-and-maintainers-only' },
+      timeline: BASE_TIMELINE,
+    },
+    {
+      resolvePermission: permissionResolver({
+        author: {
+          known: false,
+          permission: '',
+          error: 'permission lookup failed: 503',
+        },
+      }),
+    },
+  );
+  assert.equal(result.approved, true);
+  assert.equal(result.reason, 'author-self-authorized');
+  assert.equal(findCheck(result, 'ambiguity_guard')?.result, 'pass');
+});
+
+test('MEMBER author_association self-authorizes under default policy when permission read is unknown (#2148)', () => {
+  const result = evaluateClaimApprovalGate(
+    {
+      issue: { ...BASE_ISSUE, author_association: 'MEMBER' },
+      policy: { maintainerApprovalActorPolicy: 'owners-and-maintainers-only' },
+      timeline: BASE_TIMELINE,
+    },
+    {
+      resolvePermission: permissionResolver({
+        author: {
+          known: false,
+          permission: '',
+          error: 'permission lookup failed: 503',
+        },
+      }),
+    },
+  );
+  assert.equal(result.approved, true);
+  assert.equal(result.reason, 'author-self-authorized');
+});
+
+test('CONTRIBUTOR author_association does not self-authorize when permission read is unknown', () => {
+  const result = evaluateClaimApprovalGate(
+    {
+      issue: { ...BASE_ISSUE, author_association: 'CONTRIBUTOR' },
+      policy: { maintainerApprovalActorPolicy: 'owners-and-maintainers-only' },
+      timeline: BASE_TIMELINE,
+    },
+    {
+      resolvePermission: permissionResolver({
+        author: {
+          known: false,
+          permission: '',
+          error: 'permission lookup failed: 503',
+        },
+      }),
+    },
+  );
+  assert.equal(result.approved, false);
+  assert.equal(result.reason, 'approval-ambiguous');
+});
+
+test('known write permission is not overridden by OWNER association', () => {
+  const result = evaluateClaimApprovalGate(
+    {
+      issue: { ...BASE_ISSUE, author_association: 'OWNER' },
+      policy: { maintainerApprovalActorPolicy: 'owners-and-maintainers-only' },
+      timeline: BASE_TIMELINE,
+    },
+    {
+      resolvePermission: permissionResolver({
+        author: { known: true, permission: 'write' },
+      }),
+    },
+  );
+  assert.equal(result.approved, false);
+});
+
 test('write collaborator is self-authorized under all-write policy', () => {
   const result = evaluateClaimApprovalGate(
     {

--- a/tests/gh-exec.test.mts
+++ b/tests/gh-exec.test.mts
@@ -14,7 +14,9 @@ import {
   ghText,
   ghTextAsync,
   resolveGhApiHostname,
+  resolveViewerLogin,
   safeGhText,
+  viewerLoginFailureIsGraphqlEligible,
   withBoundedRetry,
 } from '../src/scripts/gh-exec.mts';
 
@@ -702,4 +704,118 @@ test('withBoundedRetry falls back to the default backoff on a non-finite baseDel
   // the call still completes and resolves normally under the fallback.
   assert.equal(result, 'ok');
   assert.equal(calls, 2);
+});
+
+test('resolveViewerLogin uses REST /user when it returns a login', () => {
+  let graphqlCalls = 0;
+  const login = resolveViewerLogin(
+    {},
+    {
+      rest: () => ' kurone-kito ',
+      graphql: () => {
+        graphqlCalls += 1;
+        return 'graphql-user';
+      },
+    },
+  );
+  assert.equal(login, 'kurone-kito');
+  assert.equal(graphqlCalls, 0);
+});
+
+test('resolveViewerLogin falls back to GraphQL viewer after REST 503', () => {
+  const restError = Object.assign(new Error('HTTP 503'), {
+    stderr: 'gh: Service Unavailable (HTTP 503)',
+  });
+  const login = resolveViewerLogin(
+    {},
+    {
+      rest: () => {
+        throw restError;
+      },
+      graphql: () => 'graphql-user',
+    },
+  );
+  assert.equal(login, 'graphql-user');
+});
+
+test('resolveViewerLogin falls back to GraphQL when REST returns an empty body', () => {
+  const login = resolveViewerLogin(
+    {},
+    {
+      rest: () => '',
+      graphql: () => 'graphql-user',
+    },
+  );
+  assert.equal(login, 'graphql-user');
+});
+
+test('resolveViewerLogin does not fall back on REST 403', () => {
+  const restError = Object.assign(new Error('HTTP 403'), {
+    stderr: 'gh: Resource not accessible by integration (HTTP 403)',
+  });
+  assert.equal(viewerLoginFailureIsGraphqlEligible(restError), false);
+  assert.throws(
+    () =>
+      resolveViewerLogin(
+        {},
+        {
+          rest: () => {
+            throw restError;
+          },
+          graphql: () => 'graphql-user',
+        },
+      ),
+    restError,
+  );
+});
+
+test('resolveViewerLogin rethrows the REST error when GraphQL also fails after 503', () => {
+  const restError = Object.assign(new Error('HTTP 503'), {
+    stderr: 'gh: Service Unavailable (HTTP 503)',
+  });
+  assert.throws(
+    () =>
+      resolveViewerLogin(
+        {},
+        {
+          rest: () => {
+            throw restError;
+          },
+          graphql: () => {
+            throw new Error('graphql down');
+          },
+        },
+      ),
+    restError,
+  );
+});
+
+test('viewerLoginFailureIsGraphqlEligible treats timeout as eligible', () => {
+  assert.equal(
+    viewerLoginFailureIsGraphqlEligible(
+      Object.assign(new Error('timeout'), { code: 'ETIMEDOUT' }),
+    ),
+    true,
+  );
+});
+
+test('resolveViewerLogin live seam: REST 503 then GraphQL viewer login', () => {
+  const restore = stubGh(`
+const args = process.argv.slice(2);
+if (args[0] === 'api' && args[1] === 'user') {
+  process.stderr.write('gh: Service Unavailable (HTTP 503)\\n');
+  process.exit(1);
+}
+if (args[0] === 'api' && args[1] === 'graphql') {
+  process.stdout.write(JSON.stringify({ data: { viewer: { login: 'graphql-user' } } }) + '\\n');
+  process.exit(0);
+}
+process.stderr.write('unexpected: ' + args.join(' ') + '\\n');
+process.exit(1);
+`);
+  try {
+    assert.equal(resolveViewerLogin(), 'graphql-user');
+  } finally {
+    restore();
+  }
 });

--- a/tests/gh-exec.test.mts
+++ b/tests/gh-exec.test.mts
@@ -799,6 +799,30 @@ test('viewerLoginFailureIsGraphqlEligible treats timeout as eligible', () => {
   );
 });
 
+test('viewerLoginFailureIsGraphqlEligible treats unclassified errors as fail-closed', () => {
+  assert.equal(
+    viewerLoginFailureIsGraphqlEligible(new Error('something went wrong')),
+    false,
+  );
+});
+
+test('resolveViewerLogin does not fall back on an unclassified REST error', () => {
+  const restError = new Error('gh: mysterious failure');
+  assert.throws(
+    () =>
+      resolveViewerLogin(
+        {},
+        {
+          rest: () => {
+            throw restError;
+          },
+          graphql: () => 'graphql-user',
+        },
+      ),
+    restError,
+  );
+});
+
 test('resolveViewerLogin live seam: REST 503 then GraphQL viewer login', () => {
   const restore = stubGh(`
 const args = process.argv.slice(2);

--- a/tests/resume-claim-routing.test.mts
+++ b/tests/resume-claim-routing.test.mts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 import {
@@ -1084,4 +1085,12 @@ test('evaluateFreshClaimGate: released competing claim is claimable, not already
   assert.equal(gate.verdict, 'claimable');
   assert.equal(gate.reason, 'no-active-claim');
   assert.equal(gate.winningClaimId, null);
+});
+
+test('runCli sources currentLogin from resolveViewerLogin (#2148)', () => {
+  const source = readFileSync(
+    new URL('../src/scripts/resume-claim-routing.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(source, /resolveViewerLogin\(GH_TEXT_LOOP_TIMEOUT_OPTIONS\)/);
 });


### PR DESCRIPTION
# Summary

A5 collectors no longer abort when REST `GET /user` or the
collaborators-permission endpoint returns 5xx, as long as GraphQL
`viewer { login }` or the issue `author_association` still names the
actor. 4xx stays fail-closed on REST.

## Linked issue

Closes #2148

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Observed on this repository: REST `/user` and
`/collaborators/{login}/permission` returned 503 while GraphQL
`viewer { login }` and the issue payload `author_association: OWNER`
still succeeded. `resume-claim-routing` threw in `runCli`, and
`claim-approval-gate` reported `approval-ambiguous` even though the
written claim path could proceed. This is not the CI `gh api user` 403
log-noise case (`#1425`) and not GHES hostname routing (`#1962` /
`#2052`).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed