### PR TITLE
feat(pre-merge-readiness): add --claimless for no-issue PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ discipline and has no tag.
 
 ### Added
 
+- `pre-merge-readiness --claimless` for PRs with no
+  `closingIssuesReferences`: skips claim fetch/revalidation and
+  reports the not-applicable / unclaimed ownership shape. Combining
+  the flag with `--claim-issue` or `--claim-id` is rejected, and a
+  PR that still closes an issue fails closed.
 - Present-tense hybrid review-reply identity contract on the
   operator docs: IDD replies carry the prefix-aware stamp (not an
   E1 `review-watermark`); unmarked human replies on human threads

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1659,7 +1659,14 @@ reflexively as any other CLI option.
   kurone-kito/idd-skill#1522, kurone-kito/idd-skill#1528 — omit when no
   nonce was recorded for the active claim, which stays backward
   compatible), and
-  `--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`
+  `--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`.
+  `--claimless` (#2017) is the no-issue alternative: it cannot combine
+  with `--claim-issue` or `--claim-id`, and it is honored only when the
+  PR's `closingIssuesReferences` is empty (otherwise fail closed and
+  pass `--claim-issue`). It skips claim fetch/revalidation and emits
+  the not-applicable / unclaimed ownership shape (claim-id `none`); CI,
+  review, advisory, thread, and branch-currency gates still run.
+  `idd-merge-execute` still requires `--claim-issue`.
 - Stable contract:
   [`pre-merge-readiness.schema.json`][pre-merge-readiness-schema]
 - Stable sections consumed by the instructions: `reviewCurrency`,

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1659,7 +1659,14 @@ reflexively as any other CLI option.
   kurone-kito/idd-skill#1522, kurone-kito/idd-skill#1528 — omit when no
   nonce was recorded for the active claim, which stays backward
   compatible), and
-  `--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`
+  `--trusted-marker-logins "<trusted-login-1>,<trusted-login-2>"`.
+  `--claimless` (#2017) is the no-issue alternative: it cannot combine
+  with `--claim-issue` or `--claim-id`, and it is honored only when the
+  PR's `closingIssuesReferences` is empty (otherwise fail closed and
+  pass `--claim-issue`). It skips claim fetch/revalidation and emits
+  the not-applicable / unclaimed ownership shape (claim-id `none`); CI,
+  review, advisory, thread, and branch-currency gates still run.
+  `idd-merge-execute` still requires `--claim-issue`.
 - Stable contract:
   [`pre-merge-readiness.schema.json`][pre-merge-readiness-schema]
 - Stable sections consumed by the instructions: `reviewCurrency`,

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -1071,7 +1071,8 @@
             "missing-active-claim",
             "claim-id-mismatch",
             "agent-id-mismatch",
-            "activation-nonce-mismatch"
+            "activation-nonce-mismatch",
+            "not-applicable"
           ]
         }
       }

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -153,6 +153,7 @@ const PRE_MERGE_READINESS_FLAG_SPEC = {
   '--expected-agent-id': { type: 'string' },
   '--nonce': { type: 'string' },
   '--now': { type: 'string' },
+  '--claimless': { type: 'boolean', default: false },
   '--help': { type: 'boolean', short: 'h' },
 };
 /**
@@ -174,7 +175,7 @@ export function collectPreMergeReadiness(argv) {
   if (!args.prNumber) {
     throw new Error('missing required --pr <number> argument');
   }
-  if (!args.claimIssueNumber) {
+  if (!args.claimless && !args.claimIssueNumber) {
     throw new Error('missing required --claim-issue <number> argument');
   }
   const owner =
@@ -222,7 +223,7 @@ export function collectPreMergeReadiness(argv) {
     // new network round-trip) so the branch-currency gate below can pair a
     // live `BEHIND` state with the up-to-date-head requirement resolved
     // from `branchRules`/`branchProtection`.
-    'headRefOid,baseRefName,url,author,reviewDecision,statusCheckRollup,mergeable,mergeStateStatus',
+    'headRefOid,baseRefName,url,author,reviewDecision,statusCheckRollup,mergeable,mergeStateStatus,closingIssuesReferences',
     '--jq',
     '.',
   ]);
@@ -233,6 +234,16 @@ export function collectPreMergeReadiness(argv) {
   const reviewDecision = String(pr.reviewDecision ?? '');
   const mergeable = String(pr.mergeable ?? '');
   const mergeStateStatus = String(pr.mergeStateStatus ?? '');
+  if (args.claimless) {
+    const closingRefs = Array.isArray(pr.closingIssuesReferences)
+      ? pr.closingIssuesReferences
+      : [];
+    if (closingRefs.length > 0) {
+      throw new Error(
+        '--claimless requires a PR with no closingIssuesReferences; pass --claim-issue instead',
+      );
+    }
+  }
   const encodedBaseRefName = encodeURIComponent(baseRefName);
   // #1483: sourced from the same `gh pr view` call above (the
   // `statusCheckRollup` field), not a separate `gh pr checks` call --
@@ -300,10 +311,12 @@ export function collectPreMergeReadiness(argv) {
     `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
     true,
   );
-  const claimComments = ghApiJson(
-    `repos/${owner}/${repo}/issues/${args.claimIssueNumber}/comments`,
-    true,
-  );
+  const claimComments = args.claimless
+    ? []
+    : ghApiJson(
+        `repos/${owner}/${repo}/issues/${args.claimIssueNumber}/comments`,
+        true,
+      );
   const threads = fetchReviewThreads(owner, repo, args.prNumber);
   const changedFiles = ghApiJson(
     `repos/${owner}/${repo}/pulls/${args.prNumber}/files`,
@@ -490,6 +503,7 @@ export function collectPreMergeReadiness(argv) {
       expectedClaimId: args.expectedClaimId,
       expectedAgentId: args.expectedAgentId,
       expectedNonce: args.nonce,
+      claimless: args.claimless,
       includeDispositionEvidence: true,
       requestCap: advisoryWaitPolicy.requestCap,
       pendingWindowMinutes: advisoryWaitPolicy.pendingWindowMinutes,
@@ -635,6 +649,13 @@ export function parseArgs(argv) {
   if (expectedAgentIdToken !== undefined) {
     warnDeprecatedFlag('--expected-agent-id', '--agent-id');
   }
+  const claimless = Boolean(values.claimless);
+  if (claimless && values['claim-issue'] !== undefined) {
+    throw new Error('--claimless cannot be combined with --claim-issue');
+  }
+  if (claimless && claimId) {
+    throw new Error('--claimless cannot be combined with --claim-id');
+  }
   return {
     prNumber: requirePositiveInteger(values.pr, '--pr'),
     claimIssueNumber: requirePositiveInteger(
@@ -651,11 +672,13 @@ export function parseArgs(argv) {
     nonce: values.nonce ?? '',
     now: values.now ?? '',
     help,
+    claimless: Boolean(values.claimless),
   };
 }
 function printHelp() {
   process.stdout.write(`Usage:
   node scripts/pre-merge-readiness.mjs --pr <number> --claim-issue <number> [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--idd-agent-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--claim-id <claim-id>] [--agent-id <agent-id>] [--nonce <token>] [--now <ISO8601>]
+  node scripts/pre-merge-readiness.mjs --pr <number> --claimless [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--idd-agent-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--now <ISO8601>]
   Deprecated aliases (one release): --expected-claim-id -> --claim-id, --expected-agent-id -> --agent-id
 
   --nonce <token>  this session's own recorded activation-nonce (#1522): when
@@ -665,6 +688,10 @@ function printHelp() {
                     catching a second, independent activation of the same
                     claim-id as a collision. Omit --nonce, or leave it empty,
                     to skip this comparison entirely (backward compatible).
+  --claimless      skip claim fetch/revalidation (#2017). Only for a PR
+                    whose closingIssuesReferences is empty; cannot combine
+                    with --claim-issue or --claim-id. Claim-ownership in
+                    the report is the not-applicable / unclaimed shape.
 `);
 }
 /**

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -5148,19 +5148,35 @@ export function buildPreMergeReadinessSummary(
       primaryBotLogin: options.primaryBotLogin,
     },
   );
-  const claim = summarizeClaimValidation(claimEvents, {
-    trustedMarkerLogins,
-    forcedHandoffEnabled: options.forcedHandoffEnabled === true,
-    expectedLinkedPrs: options.expectedLinkedPrs ?? [],
-    prFirstCommitAt: options.prFirstCommitAt ?? null,
-    authorizedForcedHandoffLogins: options.authorizedForcedHandoffLogins,
-    isAuthorizedForcedHandoff: options.isAuthorizedForcedHandoff,
-    isForcedHandoffEnabled: options.isForcedHandoffEnabled,
-    expectedClaimId: options.expectedClaimId,
-    expectedAgentId: options.expectedAgentId,
-    expectedNonce: options.expectedNonce,
-    staleAgeMs: options.staleAgeMs,
-  });
+  const claim = options.claimless
+    ? {
+        expectedClaimId: 'none',
+        expectedAgentId: '',
+        activeClaimPresent: false,
+        activeClaim: {
+          agentId: '',
+          claimId: 'none',
+          supersedes: '',
+          branch: '',
+          createdAt: '',
+        },
+        matchesExpectedClaim: true,
+        claimLost: false,
+        reason: 'not-applicable',
+      }
+    : summarizeClaimValidation(claimEvents, {
+        trustedMarkerLogins,
+        forcedHandoffEnabled: options.forcedHandoffEnabled === true,
+        expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+        prFirstCommitAt: options.prFirstCommitAt ?? null,
+        authorizedForcedHandoffLogins: options.authorizedForcedHandoffLogins,
+        isAuthorizedForcedHandoff: options.isAuthorizedForcedHandoff,
+        isForcedHandoffEnabled: options.isForcedHandoffEnabled,
+        expectedClaimId: options.expectedClaimId,
+        expectedAgentId: options.expectedAgentId,
+        expectedNonce: options.expectedNonce,
+        staleAgeMs: options.staleAgeMs,
+      });
   const waivableCheckSelectors = options.waivableCheckSelectors ?? null;
   const waiverEvidence = summarizeExternalCheckWaivers(comments, {
     prHeadSha,

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -320,6 +320,8 @@ interface PreMergeReadinessArgs {
   nonce: string;
   now: string;
   help: boolean;
+  /** #2017: skip claim fetch/revalidation on a PR with no closing issues. */
+  claimless: boolean;
 }
 
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
@@ -344,6 +346,7 @@ const PRE_MERGE_READINESS_FLAG_SPEC = {
   '--expected-agent-id': { type: 'string' },
   '--nonce': { type: 'string' },
   '--now': { type: 'string' },
+  '--claimless': { type: 'boolean', default: false },
   '--help': { type: 'boolean', short: 'h' },
 } as const;
 
@@ -379,7 +382,7 @@ export function collectPreMergeReadiness(
   if (!args.prNumber) {
     throw new Error('missing required --pr <number> argument');
   }
-  if (!args.claimIssueNumber) {
+  if (!args.claimless && !args.claimIssueNumber) {
     throw new Error('missing required --claim-issue <number> argument');
   }
 
@@ -429,7 +432,7 @@ export function collectPreMergeReadiness(
     // new network round-trip) so the branch-currency gate below can pair a
     // live `BEHIND` state with the up-to-date-head requirement resolved
     // from `branchRules`/`branchProtection`.
-    'headRefOid,baseRefName,url,author,reviewDecision,statusCheckRollup,mergeable,mergeStateStatus',
+    'headRefOid,baseRefName,url,author,reviewDecision,statusCheckRollup,mergeable,mergeStateStatus,closingIssuesReferences',
     '--jq',
     '.',
   ]) as {
@@ -441,6 +444,7 @@ export function collectPreMergeReadiness(
     statusCheckRollup?: StatusCheckRollupPayload[] | null;
     mergeable?: unknown;
     mergeStateStatus?: unknown;
+    closingIssuesReferences?: unknown;
   };
   const prHeadSha = String(pr.headRefOid ?? '');
   const baseRefName = String(pr.baseRefName ?? '');
@@ -449,6 +453,16 @@ export function collectPreMergeReadiness(
   const reviewDecision = String(pr.reviewDecision ?? '');
   const mergeable = String(pr.mergeable ?? '');
   const mergeStateStatus = String(pr.mergeStateStatus ?? '');
+  if (args.claimless) {
+    const closingRefs = Array.isArray(pr.closingIssuesReferences)
+      ? pr.closingIssuesReferences
+      : [];
+    if (closingRefs.length > 0) {
+      throw new Error(
+        '--claimless requires a PR with no closingIssuesReferences; pass --claim-issue instead',
+      );
+    }
+  }
   const encodedBaseRefName = encodeURIComponent(baseRefName);
 
   // #1483: sourced from the same `gh pr view` call above (the
@@ -517,10 +531,12 @@ export function collectPreMergeReadiness(
     `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
     true,
   ) as IssueCommentPayload[];
-  const claimComments = ghApiJson(
-    `repos/${owner}/${repo}/issues/${args.claimIssueNumber}/comments`,
-    true,
-  ) as IssueCommentPayload[];
+  const claimComments = args.claimless
+    ? []
+    : (ghApiJson(
+        `repos/${owner}/${repo}/issues/${args.claimIssueNumber}/comments`,
+        true,
+      ) as IssueCommentPayload[]);
   const threads = fetchReviewThreads(owner, repo, args.prNumber);
   const changedFiles = (
     ghApiJson(`repos/${owner}/${repo}/pulls/${args.prNumber}/files`, true) as {
@@ -712,6 +728,7 @@ export function collectPreMergeReadiness(
       expectedClaimId: args.expectedClaimId,
       expectedAgentId: args.expectedAgentId,
       expectedNonce: args.nonce,
+      claimless: args.claimless,
       includeDispositionEvidence: true,
       requestCap: advisoryWaitPolicy.requestCap,
       pendingWindowMinutes: advisoryWaitPolicy.pendingWindowMinutes,
@@ -876,6 +893,14 @@ export function parseArgs(argv: string[]): PreMergeReadinessArgs {
     warnDeprecatedFlag('--expected-agent-id', '--agent-id');
   }
 
+  const claimless = Boolean(values.claimless);
+  if (claimless && values['claim-issue'] !== undefined) {
+    throw new Error('--claimless cannot be combined with --claim-issue');
+  }
+  if (claimless && claimId) {
+    throw new Error('--claimless cannot be combined with --claim-id');
+  }
+
   return {
     prNumber: requirePositiveInteger(values.pr as string | undefined, '--pr'),
     claimIssueNumber: requirePositiveInteger(
@@ -894,12 +919,14 @@ export function parseArgs(argv: string[]): PreMergeReadinessArgs {
     nonce: (values.nonce as string | undefined) ?? '',
     now: (values.now as string | undefined) ?? '',
     help,
+    claimless: Boolean(values.claimless),
   };
 }
 
 function printHelp(): void {
   process.stdout.write(`Usage:
   node scripts/pre-merge-readiness.mjs --pr <number> --claim-issue <number> [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--idd-agent-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--claim-id <claim-id>] [--agent-id <agent-id>] [--nonce <token>] [--now <ISO8601>]
+  node scripts/pre-merge-readiness.mjs --pr <number> --claimless [--owner <owner>] [--repo <repo>] [--trusted-marker-logins <login1,login2>] [--idd-agent-logins <login1,login2>] [--advisory-bot-logins <login1,login2>] [--now <ISO8601>]
   Deprecated aliases (one release): --expected-claim-id -> --claim-id, --expected-agent-id -> --agent-id
 
   --nonce <token>  this session's own recorded activation-nonce (#1522): when
@@ -909,6 +936,10 @@ function printHelp(): void {
                     catching a second, independent activation of the same
                     claim-id as a collision. Omit --nonce, or leave it empty,
                     to skip this comparison entirely (backward compatible).
+  --claimless      skip claim fetch/revalidation (#2017). Only for a PR
+                    whose closingIssuesReferences is empty; cannot combine
+                    with --claim-issue or --claim-id. Claim-ownership in
+                    the report is the not-applicable / unclaimed shape.
 `);
 }
 

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -6343,6 +6343,9 @@ export function buildPreMergeReadinessSummary(
     // collision check below. Omitted by every caller that predates this
     // option (unchanged pre-#1528 behavior).
     expectedNonce?: unknown;
+    // #2017: skip claim-marker fetch/revalidation and emit the
+    // not-applicable / unclaimed ownership shape (claim-id `none`).
+    claimless?: boolean;
     viewerLogin?: string | null;
     viewerTeamSlugs?: unknown[];
     viewerAppSlug?: string | null;
@@ -6567,19 +6570,35 @@ export function buildPreMergeReadinessSummary(
       primaryBotLogin: options.primaryBotLogin,
     },
   );
-  const claim = summarizeClaimValidation(claimEvents, {
-    trustedMarkerLogins,
-    forcedHandoffEnabled: options.forcedHandoffEnabled === true,
-    expectedLinkedPrs: options.expectedLinkedPrs ?? [],
-    prFirstCommitAt: options.prFirstCommitAt ?? null,
-    authorizedForcedHandoffLogins: options.authorizedForcedHandoffLogins,
-    isAuthorizedForcedHandoff: options.isAuthorizedForcedHandoff,
-    isForcedHandoffEnabled: options.isForcedHandoffEnabled,
-    expectedClaimId: options.expectedClaimId,
-    expectedAgentId: options.expectedAgentId,
-    expectedNonce: options.expectedNonce,
-    staleAgeMs: options.staleAgeMs,
-  });
+  const claim = options.claimless
+    ? {
+        expectedClaimId: 'none',
+        expectedAgentId: '',
+        activeClaimPresent: false,
+        activeClaim: {
+          agentId: '',
+          claimId: 'none',
+          supersedes: '',
+          branch: '',
+          createdAt: '',
+        },
+        matchesExpectedClaim: true,
+        claimLost: false,
+        reason: 'not-applicable',
+      }
+    : summarizeClaimValidation(claimEvents, {
+        trustedMarkerLogins,
+        forcedHandoffEnabled: options.forcedHandoffEnabled === true,
+        expectedLinkedPrs: options.expectedLinkedPrs ?? [],
+        prFirstCommitAt: options.prFirstCommitAt ?? null,
+        authorizedForcedHandoffLogins: options.authorizedForcedHandoffLogins,
+        isAuthorizedForcedHandoff: options.isAuthorizedForcedHandoff,
+        isForcedHandoffEnabled: options.isForcedHandoffEnabled,
+        expectedClaimId: options.expectedClaimId,
+        expectedAgentId: options.expectedAgentId,
+        expectedNonce: options.expectedNonce,
+        staleAgeMs: options.staleAgeMs,
+      });
   const waivableCheckSelectors = options.waivableCheckSelectors ?? null;
   const waiverEvidence = summarizeExternalCheckWaivers(comments, {
     prHeadSha,

--- a/tests/pre-merge-readiness-collection-smoke.test.mts
+++ b/tests/pre-merge-readiness-collection-smoke.test.mts
@@ -183,13 +183,20 @@ const REVIEWS_AND_HEAD_COMMIT_COMMITTED_DATE = '2026-07-31T23:00:00Z';
  * `threadResolved` is the one field that differs between the clean and
  * blocked scenarios (see the two tests below).
  */
-function buildStubGhScript(threadResolved: boolean): string {
+function buildStubGhScript(
+  threadResolved: boolean,
+  options: {
+    closingIssuesReferences?: unknown[];
+    failOnClaimComments?: boolean;
+  } = {},
+): string {
   const prView = {
     headRefOid: 'a'.repeat(40),
     baseRefName: BASE_REF,
     url: `https://github.com/${REPO_REF}/pull/${PR_NUMBER}`,
     author: { login: 'author-user' },
     reviewDecision: 'APPROVED',
+    closingIssuesReferences: options.closingIssuesReferences ?? [],
     statusCheckRollup: [
       {
         __typename: 'CheckRun',
@@ -317,7 +324,9 @@ if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/pulls/${PR_NUMBER}/reviews`
 if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/pulls/${PR_NUMBER}/requested_reviewers`}') out('{"users":[]}');
 if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/issues/${PR_NUMBER}/timeline`}') out('');
 if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/issues/${PR_NUMBER}/comments`}') out(${JSON.stringify(ndjson(prComments))});
-if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/issues/${CLAIM_ISSUE}/comments`}') out(${JSON.stringify(ndjson(claimComments))});
+if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/issues/${CLAIM_ISSUE}/comments`}') {
+  ${options.failOnClaimComments ? "process.stderr.write('claim comments must not be fetched under --claimless\\\\n'); process.exit(1);" : `out(${JSON.stringify(ndjson(claimComments))});`}
+}
 if (a(0) === 'api' && a(1) === 'graphql' && args.join(' ').includes('reviewThreads')) out(${JSON.stringify(JSON.stringify(reviewThreadsPayload))});
 if (a(0) === 'api' && a(1) === 'graphql' && args.join(' ').includes('committedDate')) out(${JSON.stringify(JSON.stringify(reviewsAndHeadCommitPayload))});
 if (a(0) === 'api' && a(1) === '${`repos/${REPO_REF}/pulls/${PR_NUMBER}/files`}') out(${JSON.stringify(ndjson(changedFiles))});
@@ -437,6 +446,114 @@ test('pre-merge-readiness.mjs CLI: clean scenario collects and normalizes raw gh
     precondition.headCommittedAt,
     REVIEWS_AND_HEAD_COMMIT_COMMITTED_DATE,
   );
+});
+
+test('pre-merge-readiness.mjs CLI: --claimless on an empty-references PR skips claim fetch (#2017)', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-pre-merge-claimless-cli-'));
+  const cwdRoot = mkdtempSync(join(tmpdir(), 'idd-pre-merge-claimless-cwd-'));
+  try {
+    const ghPath = join(tempRoot, 'gh');
+    writeFileSync(
+      ghPath,
+      buildStubGhScript(true, { failOnClaimComments: true }),
+    );
+    chmodSync(ghPath, 0o755);
+    const output = execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/pre-merge-readiness.mjs'),
+        '--pr',
+        String(PR_NUMBER),
+        '--claimless',
+        '--owner',
+        OWNER,
+        '--repo',
+        REPO,
+        '--now',
+        '2026-08-01T00:00:00Z',
+      ],
+      {
+        cwd: cwdRoot,
+        encoding: 'utf8',
+        env: { ...process.env, PATH: `${tempRoot}:${process.env.PATH ?? ''}` },
+        timeout: 60_000,
+      },
+    );
+    const report = JSON.parse(output) as {
+      claim: {
+        reason: string;
+        claimLost: boolean;
+        expectedClaimId: string;
+        activeClaim: { claimId: string };
+      };
+      ci: unknown;
+      reviewCurrency: unknown;
+      advisoryWait: unknown;
+      threads: unknown;
+      branchCurrency: unknown;
+    };
+    assert.equal(report.claim.reason, 'not-applicable');
+    assert.equal(report.claim.claimLost, false);
+    assert.equal(report.claim.expectedClaimId, 'none');
+    assert.equal(report.claim.activeClaim.claimId, 'none');
+    assert.ok(report.ci);
+    assert.ok(report.reviewCurrency);
+    assert.ok(report.advisoryWait);
+    assert.ok(report.threads);
+    assert.ok(report.branchCurrency);
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+    rmSync(cwdRoot, { recursive: true, force: true });
+  }
+});
+
+test('pre-merge-readiness.mjs CLI: --claimless fails closed when closingIssuesReferences is non-empty (#2017)', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-pre-merge-claimless-fail-'));
+  const cwdRoot = mkdtempSync(
+    join(tmpdir(), 'idd-pre-merge-claimless-fail-cwd-'),
+  );
+  try {
+    const ghPath = join(tempRoot, 'gh');
+    writeFileSync(
+      ghPath,
+      buildStubGhScript(true, {
+        closingIssuesReferences: [{ number: 99 }],
+        failOnClaimComments: true,
+      }),
+    );
+    chmodSync(ghPath, 0o755);
+    assert.throws(
+      () =>
+        execFileSync(
+          process.execPath,
+          [
+            join(REPO_ROOT, 'scripts/pre-merge-readiness.mjs'),
+            '--pr',
+            String(PR_NUMBER),
+            '--claimless',
+            '--owner',
+            OWNER,
+            '--repo',
+            REPO,
+            '--now',
+            '2026-08-01T00:00:00Z',
+          ],
+          {
+            cwd: cwdRoot,
+            encoding: 'utf8',
+            env: {
+              ...process.env,
+              PATH: `${tempRoot}:${process.env.PATH ?? ''}`,
+            },
+            timeout: 60_000,
+          },
+        ),
+      /closingIssuesReferences/,
+    );
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+    rmSync(cwdRoot, { recursive: true, force: true });
+  }
 });
 
 test('pre-merge-readiness.mjs CLI: blocked scenario (one unresolved review thread) surfaces it end-to-end', () => {

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -6476,6 +6476,22 @@ test('parseArgs: valid --pr / --claim-issue parse to positive integers', () => {
   const args = parseArgs(['--pr', '1082', '--claim-issue', '1076']);
   assert.equal(args.prNumber, 1082);
   assert.equal(args.claimIssueNumber, 1076);
+  assert.equal(args.claimless, false);
+});
+
+test('parseArgs: --claimless is accepted alone and rejects claim flags (#2017)', () => {
+  const args = parseArgs(['--pr', '1082', '--claimless']);
+  assert.equal(args.prNumber, 1082);
+  assert.equal(args.claimIssueNumber, null);
+  assert.equal(args.claimless, true);
+  assert.throws(
+    () => parseArgs(['--pr', '1082', '--claimless', '--claim-issue', '1076']),
+    /--claimless cannot be combined with --claim-issue/,
+  );
+  assert.throws(
+    () => parseArgs(['--pr', '1082', '--claimless', '--claim-id', 'abc']),
+    /--claimless cannot be combined with --claim-id/,
+  );
 });
 
 test('parseArgs: --nonce (#1528) defaults to empty and round-trips when given', () => {
@@ -6515,6 +6531,31 @@ test('parseArgs: a non-positive / non-integer number throws a clear message', ()
   assert.throws(
     () => parseArgs(['--claim-issue', '0']),
     /invalid --claim-issue value/,
+  );
+});
+
+test('buildPreMergeReadinessSummary: claimless emits not-applicable ownership (#2017)', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const summary = buildPreMergeReadinessSummary(fixture.input, {
+    ...fixture.options,
+    claimless: true,
+  });
+  const claim = summary.claim as {
+    reason: string;
+    claimLost: boolean;
+    expectedClaimId: string;
+    activeClaimPresent: boolean;
+    activeClaim: { claimId: string };
+  };
+  assert.equal(claim.reason, 'not-applicable');
+  assert.equal(claim.claimLost, false);
+  assert.equal(claim.expectedClaimId, 'none');
+  assert.equal(claim.activeClaimPresent, false);
+  assert.equal(claim.activeClaim.claimId, 'none');
+  const blockers = summary.blockers as { gate: string }[];
+  assert.equal(
+    blockers.some((blocker) => blocker.gate === 'claim-ownership'),
+    false,
   );
 });
 


### PR DESCRIPTION
# Summary

`pre-merge-readiness` now accepts `--claimless` for PRs that close no
issue. That path skips claim fetch/revalidation and reports the
not-applicable / unclaimed ownership shape (`claim-id` `none`). CI,
review, advisory, thread, and branch-currency gates still run.
`idd-merge-execute` still requires `--claim-issue`.

## Linked issue

Closes #2017

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Maintainer hearing 2026-08-17 recorded the open choice: add
`--claimless`, gated like `external-check-waiver`, only when
`closingIssuesReferences` is empty. Combining the flag with
`--claim-issue` or `--claim-id` is rejected.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [x] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed