### PR TITLE
docs(merge): record BLOCKED exclusion and code_quality inspectability

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -218,9 +218,19 @@ Before any mutating action in F3, apply the
        time passes between the plain merge's failure and the retry, and
        `--admin` bypasses the entire ruleset), with a fresh GitHub merge
        state of `mergeable: "MERGEABLE"` and `mergeStateStatus` settled
-       to `"CLEAN"` or `"BEHIND"` also required. `idd-merge-execute.mjs
-       --apply` applies this automatically and records the outcome in
-       the verdict's `adminFallbackUsed` field.
+       to `"CLEAN"` or `"BEHIND"` also required.
+       `isSafeSoloCodeownerAdminMergeState` still refuses
+       `mergeStateStatus: "BLOCKED"`. On kurone-kito/idd-skill's
+       current `main` ruleset (`require_code_owner_review: false`), the
+       `status: "clear"` trigger never matches, observed `BLOCKED`
+       states have not been a confirmed CODEOWNER deadlock, and the
+       remaining escalation on **this topology** is a human `--admin`
+       (or `hold-and-report`). Distributed `auto-admin-retry` is
+       unchanged when `status: "clear"` and
+       `prAuthorIsSoleEligibleCodeowner: true` hold. See
+       `docs/permissions.md` (kurone-kito/idd-skill#1663).
+       `idd-merge-execute.mjs --apply` applies this automatically and
+       records the outcome in the verdict's `adminFallbackUsed` field.
 
        ```sh
        gh pr merge {pr-number} --merge --match-head-commit "${PR_HEAD_SHA_F3}" --admin

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -222,7 +222,7 @@ Before any mutating action in F3, apply the
        `isSafeSoloCodeownerAdminMergeState` still refuses
        `mergeStateStatus: "BLOCKED"`. On kurone-kito/idd-skill's
        current `main` ruleset (`require_code_owner_review: false`), the
-       `status: "clear"` trigger never matches, observed `BLOCKED`
+       `status: "clear"` trigger never matches, observed `"BLOCKED"`
        states have not been a confirmed CODEOWNER deadlock, and the
        remaining escalation on **this topology** is a human `--admin`
        (or `hold-and-report`). Distributed `auto-admin-retry` is

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -226,8 +226,9 @@ Before any mutating action in F3, apply the
        states have not been a confirmed CODEOWNER deadlock, and the
        remaining escalation on **this topology** is a human `--admin`
        (or `hold-and-report`). Distributed `auto-admin-retry` is
-       unchanged when `status: "clear"` and
-       `prAuthorIsSoleEligibleCodeowner: true` hold. See
+       unchanged when `status: "clear"` with a bypass-available
+       `reason`, `prAuthorIsSoleEligibleCodeowner: true`, and
+       `codeownerEligibilityUnreadable: false` hold. See
        `docs/permissions.md` (kurone-kito/idd-skill#1663).
        `idd-merge-execute.mjs --apply` applies this automatically and
        records the outcome in the verdict's `adminFallbackUsed` field.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1848,14 +1848,15 @@ reflexively as any other CLI option.
   `mergeable: "MERGEABLE"` and `mergeStateStatus: "CLEAN"` or
   `"BEHIND"`; blocked, unknown, or unreadable state aborts the fallback
   rather than allowing a generic policy error to trigger `--admin`.
-  `BLOCKED` stays excluded because field evidence
-  (kurone-kito/idd-skill#1663) showed it is often cancelled or stale
-  required-check instances, a missing review-watermark, or incomplete
-  F2 — not a confirmed CODEOWNER deadlock. A live `BLOCKED` paired with
-  discarded required-check siblings is the separate
-  `discarded-required-check-siblings` gate (#2127), not a reason to
-  admit `BLOCKED` into the `--admin` retry. See `docs/permissions.md`
-  for the `code_quality` ruleset-rule read path and its F3 limitation.
+  `"BLOCKED"` stays excluded because field evidence
+  (kurone-kito/idd-skill#1663, 2026-08-06 and 2026-08-17) showed it is
+  often cancelled or stale required-check instances, a missing
+  review-watermark, or incomplete F2 — not a confirmed CODEOWNER
+  deadlock. A live `"BLOCKED"` paired with discarded required-check
+  siblings is the separate `discarded-required-check-siblings` gate
+  (kurone-kito/idd-skill#2127), not a reason to admit `"BLOCKED"` into
+  the `--admin` retry. See `docs/permissions.md` for the `code_quality`
+  ruleset-rule read path and its F3 limitation.
   The verdict's `adminFallbackUsed` field records whether the fallback
   fired (`true`) whenever it was attempted, regardless of whether the
   `--admin` retry itself ultimately succeeded. Any merge failure that

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1847,9 +1847,17 @@ reflexively as any other CLI option.
   retry it also requires live GitHub merge state
   `mergeable: "MERGEABLE"` and `mergeStateStatus: "CLEAN"` or
   `"BEHIND"`; blocked, unknown, or unreadable state aborts the fallback
-  rather than allowing a generic policy error to trigger `--admin`. The verdict's
-  `adminFallbackUsed` field records whether the fallback fired
-  (`true`) whenever it was attempted, regardless of whether the
+  rather than allowing a generic policy error to trigger `--admin`.
+  `BLOCKED` stays excluded because field evidence
+  (kurone-kito/idd-skill#1663) showed it is often cancelled or stale
+  required-check instances, a missing review-watermark, or incomplete
+  F2 — not a confirmed CODEOWNER deadlock. A live `BLOCKED` paired with
+  discarded required-check siblings is the separate
+  `discarded-required-check-siblings` gate (#2127), not a reason to
+  admit `BLOCKED` into the `--admin` retry. See `docs/permissions.md`
+  for the `code_quality` ruleset-rule read path and its F3 limitation.
+  The verdict's `adminFallbackUsed` field records whether the fallback
+  fired (`true`) whenever it was attempted, regardless of whether the
   `--admin` retry itself ultimately succeeded. Any merge failure that
   does not match this exact shape — a different error, an ineligible
   topology, or the opt-in `hold-and-report` policy — falls through

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -117,8 +117,8 @@ merges:
 
 The `--admin` retry's settled-state helper
 (`isSafeSoloCodeownerAdminMergeState`) still refuses
-`mergeStateStatus: BLOCKED`. That is the distributed contract, not a
-kurone-kito/idd-skill-only quirk: field evidence showed `BLOCKED` from
+`mergeStateStatus: "BLOCKED"`. That is the distributed contract, not a
+kurone-kito/idd-skill-only quirk: field evidence showed `"BLOCKED"` from
 cancelled or stale required-check instances, a missing
 review-watermark, or incomplete F2, and widening the retry would merge
 past a still-red required check.
@@ -130,18 +130,24 @@ actor):
 
 - `codeownerSelfApproval.status` reads `not_applicable`, so the retry
   trigger (`status: "clear"`) never matches.
-- Observed `BLOCKED` on #1660, #1741, #1914, and #2123 was
-  cancelled/stale required checks, a missing review-watermark, or
-  incomplete F2 — not a confirmed CODEOWNER deadlock.
-- #1867 is topology evidence, not another stale-check incident: F2 was
-  `ready: true`, the retry correctly stayed off because of
-  `not_applicable`, and a human `--admin` completed the merge.
+- Observed `"BLOCKED"` on kurone-kito/idd-skill#1660 (2026-07-23),
+  kurone-kito/idd-skill#1741 (2026-08-01),
+  kurone-kito/idd-skill#1914 (2026-08-06), and
+  kurone-kito/idd-skill#2123 (2026-08-17) was cancelled/stale required
+  checks, a missing review-watermark, or incomplete F2 — not a
+  confirmed CODEOWNER deadlock.
+- kurone-kito/idd-skill#1867 (2026-08-05) is topology evidence, not
+  another stale-check incident: F2 was `ready: true`, the retry
+  correctly stayed off because of `not_applicable`, and a human
+  `--admin` completed the merge.
 - When a plain `gh pr merge` still fails with "the base branch policy
   prohibits the merge" after F2 is clean **on this topology**, escalate
   with a human `--admin` (or `hold-and-report`). Distributed
   `auto-admin-retry` is unchanged for repositories where
-  `status: "clear"` and `prAuthorIsSoleEligibleCodeowner: true` hold.
-- `BLOCKED` plus discarded required-check siblings is a separate
+  `status: "clear"` with a bypass-available `reason`,
+  `prAuthorIsSoleEligibleCodeowner: true`, and
+  `codeownerEligibilityUnreadable: false` hold.
+- `"BLOCKED"` plus discarded required-check siblings is a separate
   CI-recovery gate (kurone-kito/idd-skill#2127), not a reason to widen
   the `--admin` retry.
 
@@ -153,23 +159,27 @@ CODEOWNERS mismatch as substitutes for a satisfiable GitHub merge gate.
 ## Reading the `code_quality` ruleset rule
 
 This source repository's `main` ruleset includes a `code_quality` rule
-(`severity: errors`). As of 2026-08-19, a per-SHA pass/fail **after a
+(`severity: errors`). As of 2026-08-18, a per-SHA pass/fail **after a
 push to a matching ref** is readable via ruleset rule-suites. A live
 PR-head verdict for F3 is not: the `main` ruleset matches
 `~DEFAULT_BRANCH`, and observed suites were `refs/heads/main` only.
-Automated F3 inspection therefore stays out of scope. A `BLOCKED`
+Automated F3 inspection therefore stays out of scope. A `"BLOCKED"`
 merge state is not evidence of a `code_quality` finding.
 
-Surfaces tried on kurone-kito/idd-skill (2026-08-19):
+Surfaces tried on kurone-kito/idd-skill (2026-08-18):
 
 - REST rule-suites — a post-push evaluation. List
-  `GET /repos/{owner}/{repo}/rulesets/rule-suites`, then
+  `GET /repos/{owner}/{repo}/rulesets/rule-suites` with `ref` set to
+  the matching ref (here `refs/heads/main`), a `time_period` that
+  covers the SHA (`day` is the default 24 h window; use `week` or
+  `month` for older pushes), and pagination (`per_page` up to 100;
+  follow `page` / Link headers — the default page is 30), then
   `GET /repos/{owner}/{repo}/rulesets/rule-suites/{id}`. List
   entries include `after_sha`; the detail's `rule_evaluations[]`
   includes `{ "rule_type": "code_quality", "result": "pass" }` (or
   `fail`). Filter the list for `after_sha` equal to the head when a
-  suite exists. This is not a pre-merge PR-head gate on this
-  topology.
+  suite exists. A 404 can mean the token cannot list rule suites.
+  This is not a pre-merge PR-head gate on this topology.
 - REST `GET /repos/{owner}/{repo}/code-quality/findings` — HTTP 404
   here (product API documented; not enabled on this repository). The
   documented sample payload has no commit SHA.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -115,8 +115,72 @@ merges:
   human review is the intended gate. Treat this as a repository policy
   change, not a per-run workaround.
 
+The `--admin` retry's settled-state helper
+(`isSafeSoloCodeownerAdminMergeState`) still refuses
+`mergeStateStatus: BLOCKED`. That is the distributed contract, not a
+kurone-kito/idd-skill-only quirk: field evidence showed `BLOCKED` from
+cancelled or stale required-check instances, a missing
+review-watermark, or incomplete F2, and widening the retry would merge
+past a still-red required check.
+
+On kurone-kito/idd-skill's current `main` ruleset
+(`require_code_owner_review: false`,
+`required_approving_review_count: 0`, one `pull_request` bypass
+actor):
+
+- `codeownerSelfApproval.status` reads `not_applicable`, so the retry
+  trigger (`status: "clear"`) never matches.
+- Observed `BLOCKED` on #1660, #1741, #1914, and #2123 was
+  cancelled/stale required checks, a missing review-watermark, or
+  incomplete F2 — not a confirmed CODEOWNER deadlock.
+- #1867 is topology evidence, not another stale-check incident: F2 was
+  `ready: true`, the retry correctly stayed off because of
+  `not_applicable`, and a human `--admin` completed the merge.
+- When a plain `gh pr merge` still fails with "the base branch policy
+  prohibits the merge" after F2 is clean **on this topology**, escalate
+  with a human `--admin` (or `hold-and-report`). Distributed
+  `auto-admin-retry` is unchanged for repositories where
+  `status: "clear"` and `prAuthorIsSoleEligibleCodeowner: true` hold.
+- `BLOCKED` plus discarded required-check siblings is a separate
+  CI-recovery gate (kurone-kito/idd-skill#2127), not a reason to widen
+  the `--admin` retry.
+
+See `idd-merge.instructions.md` F3 and kurone-kito/idd-skill#1663.
+
 Do not use issue-author approval, trusted operational markers, or
 CODEOWNERS mismatch as substitutes for a satisfiable GitHub merge gate.
+
+## Reading the `code_quality` ruleset rule
+
+This source repository's `main` ruleset includes a `code_quality` rule
+(`severity: errors`). As of 2026-08-19, a per-SHA pass/fail **after a
+push to a matching ref** is readable via ruleset rule-suites. A live
+PR-head verdict for F3 is not: the `main` ruleset matches
+`~DEFAULT_BRANCH`, and observed suites were `refs/heads/main` only.
+Automated F3 inspection therefore stays out of scope. A `BLOCKED`
+merge state is not evidence of a `code_quality` finding.
+
+Surfaces tried on kurone-kito/idd-skill (2026-08-19):
+
+- REST rule-suites — a post-push evaluation. List
+  `GET /repos/{owner}/{repo}/rulesets/rule-suites`, then
+  `GET /repos/{owner}/{repo}/rulesets/rule-suites/{id}`. List
+  entries include `after_sha`; the detail's `rule_evaluations[]`
+  includes `{ "rule_type": "code_quality", "result": "pass" }` (or
+  `fail`). Filter the list for `after_sha` equal to the head when a
+  suite exists. This is not a pre-merge PR-head gate on this
+  topology.
+- REST `GET /repos/{owner}/{repo}/code-quality/findings` — HTTP 404
+  here (product API documented; not enabled on this repository). The
+  documented sample payload has no commit SHA.
+- REST check-runs and commit statuses — no check-run name, app, or
+  context for the ruleset rule (CodeQL is a different product).
+- REST `GET /repos/{owner}/{repo}/rules/branches/{branch}` and
+  `GET /repos/{owner}/{repo}/rulesets/{id}` — rule definition only
+  (`type: code_quality`), not a commit verdict.
+- GraphQL `RepositoryRuleType` — no `CODE_QUALITY` enum value.
+- GraphQL pull-request `mergeable` / `mergeStateStatus` — overall
+  mergeability, not a `code_quality`-specific verdict.
 
 ## External-Check Waiver Authority
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -172,8 +172,8 @@ Surfaces tried on kurone-kito/idd-skill (2026-08-18):
   `GET /repos/{owner}/{repo}/rulesets/rule-suites` with `ref` set to
   the matching ref (here `refs/heads/main`), a `time_period` that
   covers the SHA (`day` is the default 24 h window; use `week` or
-  `month` for older pushes), and pagination (`per_page` up to 100;
-  follow `page` / Link headers — the default page is 30), then
+  `month` for older pushes), and pagination (`per_page` up to 100,
+  default 30; follow `page` / Link headers), then
   `GET /repos/{owner}/{repo}/rulesets/rule-suites/{id}`. List
   entries include `after_sha`; the detail's `rule_evaluations[]`
   includes `{ "rule_type": "code_quality", "result": "pass" }` (or

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -221,8 +221,9 @@ Before any mutating action in F3, apply the
        states have not been a confirmed CODEOWNER deadlock, and the
        remaining escalation on **this topology** is a human `--admin`
        (or `hold-and-report`). Distributed `auto-admin-retry` is
-       unchanged when `status: "clear"` and
-       `prAuthorIsSoleEligibleCodeowner: true` hold. See
+       unchanged when `status: "clear"` with a bypass-available
+       `reason`, `prAuthorIsSoleEligibleCodeowner: true`, and
+       `codeownerEligibilityUnreadable: false` hold. See
        `docs/permissions.md` (kurone-kito/idd-skill#1663).
        `idd-merge-execute.mjs --apply` applies this automatically and
        records the outcome in the verdict's `adminFallbackUsed` field.

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -217,7 +217,7 @@ Before any mutating action in F3, apply the
        `isSafeSoloCodeownerAdminMergeState` still refuses
        `mergeStateStatus: "BLOCKED"`. On kurone-kito/idd-skill's
        current `main` ruleset (`require_code_owner_review: false`), the
-       `status: "clear"` trigger never matches, observed `BLOCKED`
+       `status: "clear"` trigger never matches, observed `"BLOCKED"`
        states have not been a confirmed CODEOWNER deadlock, and the
        remaining escalation on **this topology** is a human `--admin`
        (or `hold-and-report`). Distributed `auto-admin-retry` is

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -213,9 +213,19 @@ Before any mutating action in F3, apply the
        time passes between the plain merge's failure and the retry, and
        `--admin` bypasses the entire ruleset), with a fresh GitHub merge
        state of `mergeable: "MERGEABLE"` and `mergeStateStatus` settled
-       to `"CLEAN"` or `"BEHIND"` also required. `idd-merge-execute.mjs
-       --apply` applies this automatically and records the outcome in
-       the verdict's `adminFallbackUsed` field.
+       to `"CLEAN"` or `"BEHIND"` also required.
+       `isSafeSoloCodeownerAdminMergeState` still refuses
+       `mergeStateStatus: "BLOCKED"`. On kurone-kito/idd-skill's
+       current `main` ruleset (`require_code_owner_review: false`), the
+       `status: "clear"` trigger never matches, observed `BLOCKED`
+       states have not been a confirmed CODEOWNER deadlock, and the
+       remaining escalation on **this topology** is a human `--admin`
+       (or `hold-and-report`). Distributed `auto-admin-retry` is
+       unchanged when `status: "clear"` and
+       `prAuthorIsSoleEligibleCodeowner: true` hold. See
+       `docs/permissions.md` (kurone-kito/idd-skill#1663).
+       `idd-merge-execute.mjs --apply` applies this automatically and
+       records the outcome in the verdict's `adminFallbackUsed` field.
 
        ```sh
        gh pr merge {pr-number} --merge --match-head-commit "${PR_HEAD_SHA_F3}" --admin

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1848,14 +1848,15 @@ reflexively as any other CLI option.
   `mergeable: "MERGEABLE"` and `mergeStateStatus: "CLEAN"` or
   `"BEHIND"`; blocked, unknown, or unreadable state aborts the fallback
   rather than allowing a generic policy error to trigger `--admin`.
-  `BLOCKED` stays excluded because field evidence
-  (kurone-kito/idd-skill#1663) showed it is often cancelled or stale
-  required-check instances, a missing review-watermark, or incomplete
-  F2 — not a confirmed CODEOWNER deadlock. A live `BLOCKED` paired with
-  discarded required-check siblings is the separate
-  `discarded-required-check-siblings` gate (#2127), not a reason to
-  admit `BLOCKED` into the `--admin` retry. See `docs/permissions.md`
-  for the `code_quality` ruleset-rule read path and its F3 limitation.
+  `"BLOCKED"` stays excluded because field evidence
+  (kurone-kito/idd-skill#1663, 2026-08-06 and 2026-08-17) showed it is
+  often cancelled or stale required-check instances, a missing
+  review-watermark, or incomplete F2 — not a confirmed CODEOWNER
+  deadlock. A live `"BLOCKED"` paired with discarded required-check
+  siblings is the separate `discarded-required-check-siblings` gate
+  (kurone-kito/idd-skill#2127), not a reason to admit `"BLOCKED"` into
+  the `--admin` retry. See `docs/permissions.md` for the `code_quality`
+  ruleset-rule read path and its F3 limitation.
   The verdict's `adminFallbackUsed` field records whether the fallback
   fired (`true`) whenever it was attempted, regardless of whether the
   `--admin` retry itself ultimately succeeded. Any merge failure that

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1847,9 +1847,17 @@ reflexively as any other CLI option.
   retry it also requires live GitHub merge state
   `mergeable: "MERGEABLE"` and `mergeStateStatus: "CLEAN"` or
   `"BEHIND"`; blocked, unknown, or unreadable state aborts the fallback
-  rather than allowing a generic policy error to trigger `--admin`. The verdict's
-  `adminFallbackUsed` field records whether the fallback fired
-  (`true`) whenever it was attempted, regardless of whether the
+  rather than allowing a generic policy error to trigger `--admin`.
+  `BLOCKED` stays excluded because field evidence
+  (kurone-kito/idd-skill#1663) showed it is often cancelled or stale
+  required-check instances, a missing review-watermark, or incomplete
+  F2 — not a confirmed CODEOWNER deadlock. A live `BLOCKED` paired with
+  discarded required-check siblings is the separate
+  `discarded-required-check-siblings` gate (#2127), not a reason to
+  admit `BLOCKED` into the `--admin` retry. See `docs/permissions.md`
+  for the `code_quality` ruleset-rule read path and its F3 limitation.
+  The verdict's `adminFallbackUsed` field records whether the fallback
+  fired (`true`) whenever it was attempted, regardless of whether the
   `--admin` retry itself ultimately succeeded. Any merge failure that
   does not match this exact shape — a different error, an ineligible
   topology, or the opt-in `hold-and-report` policy — falls through

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -117,8 +117,8 @@ merges:
 
 The `--admin` retry's settled-state helper
 (`isSafeSoloCodeownerAdminMergeState`) still refuses
-`mergeStateStatus: BLOCKED`. That is the distributed contract, not a
-kurone-kito/idd-skill-only quirk: field evidence showed `BLOCKED` from
+`mergeStateStatus: "BLOCKED"`. That is the distributed contract, not a
+kurone-kito/idd-skill-only quirk: field evidence showed `"BLOCKED"` from
 cancelled or stale required-check instances, a missing
 review-watermark, or incomplete F2, and widening the retry would merge
 past a still-red required check.
@@ -130,18 +130,24 @@ actor):
 
 - `codeownerSelfApproval.status` reads `not_applicable`, so the retry
   trigger (`status: "clear"`) never matches.
-- Observed `BLOCKED` on #1660, #1741, #1914, and #2123 was
-  cancelled/stale required checks, a missing review-watermark, or
-  incomplete F2 — not a confirmed CODEOWNER deadlock.
-- #1867 is topology evidence, not another stale-check incident: F2 was
-  `ready: true`, the retry correctly stayed off because of
-  `not_applicable`, and a human `--admin` completed the merge.
+- Observed `"BLOCKED"` on kurone-kito/idd-skill#1660 (2026-07-23),
+  kurone-kito/idd-skill#1741 (2026-08-01),
+  kurone-kito/idd-skill#1914 (2026-08-06), and
+  kurone-kito/idd-skill#2123 (2026-08-17) was cancelled/stale required
+  checks, a missing review-watermark, or incomplete F2 — not a
+  confirmed CODEOWNER deadlock.
+- kurone-kito/idd-skill#1867 (2026-08-05) is topology evidence, not
+  another stale-check incident: F2 was `ready: true`, the retry
+  correctly stayed off because of `not_applicable`, and a human
+  `--admin` completed the merge.
 - When a plain `gh pr merge` still fails with "the base branch policy
   prohibits the merge" after F2 is clean **on this topology**, escalate
   with a human `--admin` (or `hold-and-report`). Distributed
   `auto-admin-retry` is unchanged for repositories where
-  `status: "clear"` and `prAuthorIsSoleEligibleCodeowner: true` hold.
-- `BLOCKED` plus discarded required-check siblings is a separate
+  `status: "clear"` with a bypass-available `reason`,
+  `prAuthorIsSoleEligibleCodeowner: true`, and
+  `codeownerEligibilityUnreadable: false` hold.
+- `"BLOCKED"` plus discarded required-check siblings is a separate
   CI-recovery gate (kurone-kito/idd-skill#2127), not a reason to widen
   the `--admin` retry.
 
@@ -153,23 +159,27 @@ CODEOWNERS mismatch as substitutes for a satisfiable GitHub merge gate.
 ## Reading the `code_quality` ruleset rule
 
 This source repository's `main` ruleset includes a `code_quality` rule
-(`severity: errors`). As of 2026-08-19, a per-SHA pass/fail **after a
+(`severity: errors`). As of 2026-08-18, a per-SHA pass/fail **after a
 push to a matching ref** is readable via ruleset rule-suites. A live
 PR-head verdict for F3 is not: the `main` ruleset matches
 `~DEFAULT_BRANCH`, and observed suites were `refs/heads/main` only.
-Automated F3 inspection therefore stays out of scope. A `BLOCKED`
+Automated F3 inspection therefore stays out of scope. A `"BLOCKED"`
 merge state is not evidence of a `code_quality` finding.
 
-Surfaces tried on kurone-kito/idd-skill (2026-08-19):
+Surfaces tried on kurone-kito/idd-skill (2026-08-18):
 
 - REST rule-suites — a post-push evaluation. List
-  `GET /repos/{owner}/{repo}/rulesets/rule-suites`, then
+  `GET /repos/{owner}/{repo}/rulesets/rule-suites` with `ref` set to
+  the matching ref (here `refs/heads/main`), a `time_period` that
+  covers the SHA (`day` is the default 24 h window; use `week` or
+  `month` for older pushes), and pagination (`per_page` up to 100;
+  follow `page` / Link headers — the default page is 30), then
   `GET /repos/{owner}/{repo}/rulesets/rule-suites/{id}`. List
   entries include `after_sha`; the detail's `rule_evaluations[]`
   includes `{ "rule_type": "code_quality", "result": "pass" }` (or
   `fail`). Filter the list for `after_sha` equal to the head when a
-  suite exists. This is not a pre-merge PR-head gate on this
-  topology.
+  suite exists. A 404 can mean the token cannot list rule suites.
+  This is not a pre-merge PR-head gate on this topology.
 - REST `GET /repos/{owner}/{repo}/code-quality/findings` — HTTP 404
   here (product API documented; not enabled on this repository). The
   documented sample payload has no commit SHA.

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -115,8 +115,72 @@ merges:
   human review is the intended gate. Treat this as a repository policy
   change, not a per-run workaround.
 
+The `--admin` retry's settled-state helper
+(`isSafeSoloCodeownerAdminMergeState`) still refuses
+`mergeStateStatus: BLOCKED`. That is the distributed contract, not a
+kurone-kito/idd-skill-only quirk: field evidence showed `BLOCKED` from
+cancelled or stale required-check instances, a missing
+review-watermark, or incomplete F2, and widening the retry would merge
+past a still-red required check.
+
+On kurone-kito/idd-skill's current `main` ruleset
+(`require_code_owner_review: false`,
+`required_approving_review_count: 0`, one `pull_request` bypass
+actor):
+
+- `codeownerSelfApproval.status` reads `not_applicable`, so the retry
+  trigger (`status: "clear"`) never matches.
+- Observed `BLOCKED` on #1660, #1741, #1914, and #2123 was
+  cancelled/stale required checks, a missing review-watermark, or
+  incomplete F2 — not a confirmed CODEOWNER deadlock.
+- #1867 is topology evidence, not another stale-check incident: F2 was
+  `ready: true`, the retry correctly stayed off because of
+  `not_applicable`, and a human `--admin` completed the merge.
+- When a plain `gh pr merge` still fails with "the base branch policy
+  prohibits the merge" after F2 is clean **on this topology**, escalate
+  with a human `--admin` (or `hold-and-report`). Distributed
+  `auto-admin-retry` is unchanged for repositories where
+  `status: "clear"` and `prAuthorIsSoleEligibleCodeowner: true` hold.
+- `BLOCKED` plus discarded required-check siblings is a separate
+  CI-recovery gate (kurone-kito/idd-skill#2127), not a reason to widen
+  the `--admin` retry.
+
+See `idd-merge.instructions.md` F3 and kurone-kito/idd-skill#1663.
+
 Do not use issue-author approval, trusted operational markers, or
 CODEOWNERS mismatch as substitutes for a satisfiable GitHub merge gate.
+
+## Reading the `code_quality` ruleset rule
+
+This source repository's `main` ruleset includes a `code_quality` rule
+(`severity: errors`). As of 2026-08-19, a per-SHA pass/fail **after a
+push to a matching ref** is readable via ruleset rule-suites. A live
+PR-head verdict for F3 is not: the `main` ruleset matches
+`~DEFAULT_BRANCH`, and observed suites were `refs/heads/main` only.
+Automated F3 inspection therefore stays out of scope. A `BLOCKED`
+merge state is not evidence of a `code_quality` finding.
+
+Surfaces tried on kurone-kito/idd-skill (2026-08-19):
+
+- REST rule-suites — a post-push evaluation. List
+  `GET /repos/{owner}/{repo}/rulesets/rule-suites`, then
+  `GET /repos/{owner}/{repo}/rulesets/rule-suites/{id}`. List
+  entries include `after_sha`; the detail's `rule_evaluations[]`
+  includes `{ "rule_type": "code_quality", "result": "pass" }` (or
+  `fail`). Filter the list for `after_sha` equal to the head when a
+  suite exists. This is not a pre-merge PR-head gate on this
+  topology.
+- REST `GET /repos/{owner}/{repo}/code-quality/findings` — HTTP 404
+  here (product API documented; not enabled on this repository). The
+  documented sample payload has no commit SHA.
+- REST check-runs and commit statuses — no check-run name, app, or
+  context for the ruleset rule (CodeQL is a different product).
+- REST `GET /repos/{owner}/{repo}/rules/branches/{branch}` and
+  `GET /repos/{owner}/{repo}/rulesets/{id}` — rule definition only
+  (`type: code_quality`), not a commit verdict.
+- GraphQL `RepositoryRuleType` — no `CODE_QUALITY` enum value.
+- GraphQL pull-request `mergeable` / `mergeStateStatus` — overall
+  mergeability, not a `code_quality`-specific verdict.
 
 ## External-Check Waiver Authority
 

--- a/idd-template/docs/permissions.md
+++ b/idd-template/docs/permissions.md
@@ -172,8 +172,8 @@ Surfaces tried on kurone-kito/idd-skill (2026-08-18):
   `GET /repos/{owner}/{repo}/rulesets/rule-suites` with `ref` set to
   the matching ref (here `refs/heads/main`), a `time_period` that
   covers the SHA (`day` is the default 24 h window; use `week` or
-  `month` for older pushes), and pagination (`per_page` up to 100;
-  follow `page` / Link headers — the default page is 30), then
+  `month` for older pushes), and pagination (`per_page` up to 100,
+  default 30; follow `page` / Link headers), then
   `GET /repos/{owner}/{repo}/rulesets/rule-suites/{id}`. List
   entries include `after_sha`; the detail's `rule_evaluations[]`
   includes `{ "rule_type": "code_quality", "result": "pass" }` (or


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Record that the solo-CODEOWNER `--admin` retry still refuses
`mergeStateStatus: BLOCKED`, document this repository's topology
(`require_code_owner_review: false`, so the retry trigger never
matches), and document how to read the `code_quality` ruleset rule
after a push (ruleset rule-suites). Helper behavior is unchanged.

## Linked issue

Closes #1663

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Field notes on #1663 showed `BLOCKED` from cancelled/stale required
checks, a missing review-watermark, or incomplete F2 — not a confirmed
CODEOWNER deadlock. #1867 is topology evidence (retry correctly stayed
off because `codeownerSelfApproval` is `not_applicable`) and was
merged with a human `--admin`. Widening the retry to `BLOCKED` would
have merged past a still-red required check on #2123.

`GET /repos/{owner}/{repo}/rulesets/rule-suites/{id}` exposes
`rule_evaluations[].rule_type == "code_quality"` for a push
`after_sha`. Observed suites on this repository are `refs/heads/main`
only, so that path is not a live PR-head F3 gate. Automated F3
inspection of `code_quality` stays out of scope.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that administrative merge retries are allowed only for eligible solo-code-owner changes with confirmed mergeable, clean, or behind states.
  * Documented that blocked, unknown, or unreadable merge states stop the retry and require escalation.
  * Explained how blocked required checks and CI recovery are handled separately.
  * Added guidance on ruleset evaluation limitations and repository-specific merge-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->