### PR TITLE
docs(discover): name the FNV-1a desync hash fallback

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -538,8 +538,11 @@ for how the remaining tie-breakers below apply after this rule.
 `discover.selectionDesync` is `session-offset` (default `off`) and the
 highest-score tie band has more than one eligible candidate, pick the
 band entry at index `selectDesyncedIndex(session-token, band-size)`
-instead of index 0 — a pure `hash(session-token) mod band-size` over
-the band ordered by ascending issue number.
+instead of index 0 — FNV-1a 32-bit over the token's UTF-16 code units
+(offset basis `0x811c9dc5`, prime `0x01000193`, wrap to 32 bits after
+every multiply, then unsigned right-shift and modulo `band-size`) over
+the band ordered by ascending issue number. Worked example: token
+`copilot-8122ca35`, band-size `3` → index `1`.
 
 `session-token` **must be per-session-unique**: the bare, session-shared
 `{agent-id}` from `idd-overview-core.instructions.md` alone is **not** a

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -541,8 +541,11 @@ for how the remaining tie-breakers below apply after this rule.
 `discover.selectionDesync` is `session-offset` (default `off`) and the
 highest-score tie band has more than one eligible candidate, pick the
 band entry at index `selectDesyncedIndex(session-token, band-size)`
-instead of index 0 — a pure `hash(session-token) mod band-size` over
-the band ordered by ascending issue number.
+instead of index 0 — FNV-1a 32-bit over the token's UTF-16 code units
+(offset basis `0x811c9dc5`, prime `0x01000193`, wrap to 32 bits after
+every multiply, then unsigned right-shift and modulo `band-size`) over
+the band ordered by ascending issue number. Worked example: token
+`copilot-8122ca35`, band-size `3` → index `1`.
 
 `session-token` **must be per-session-unique**: the bare, session-shared
 `{agent-id}` from `idd-overview-core.instructions.md` alone is **not** a

--- a/tests/policy-helpers.test.mts
+++ b/tests/policy-helpers.test.mts
@@ -317,6 +317,14 @@ test('selectDesyncedIndex spreads distinct session tokens across the band', () =
   );
 });
 
+// Locks the A4 Step 2 helper-unavailable worked example in both
+// idd-template/.github/instructions/idd-discover.instructions.md and
+// .github/instructions/idd-discover.instructions.md. A later hash
+// change must update that prose in both structure-pair copies.
+test('selectDesyncedIndex matches the discover-instruction worked example', () => {
+  assert.equal(selectDesyncedIndex('copilot-8122ca35', 3), 1);
+});
+
 // #1449: clone() swapped from JSON.parse(JSON.stringify(value)) to
 // structuredClone(value). Two-level coverage — a direct clone() assertion
 // showing structuredClone preserves an undefined-valued key would only


### PR DESCRIPTION
# Summary

Name the helper-unavailable A4 Step 2 desync formula as FNV-1a 32-bit
(offset, prime, wrap-after-multiply, unsigned modulo) and add a worked
example locked by a unit test, so a session without the CLI hashes the
same way as `selectDesyncedIndex`.

## Linked issue

Closes #2162

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`idd-discover.instructions.md` told helper-unavailable sessions to
treat `selectDesyncedIndex` as a generic `hash(session-token) mod
band-size`. An adopter session implemented that as truncated SHA-256
and picked a different band index than the FNV-1a CLI. This pair is
`structure` in `audit/sync-manifest.json`, so both the template and
the dogfood copy are edited by hand. Hash, CLI, and the `off` /
lowest-number fallback are unchanged.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

Also ran `node scripts/audit-code-span-wrap.mjs` and `pnpm run lint:minimum`.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

Both discover copies stay under `phaseLimitBytes` 33000 (template
32107, dogfood 31762).