### PR TITLE
docs(review-triage): keep bot trigger phrases out of PATH B reasons

### DIFF
--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -323,6 +323,14 @@ ack / error, as defined in E4):
   has, disposition that review instead and take a fresh E1 snapshot, so
   the rejection's later timestamp doesn't filter the completed review
   out of the next pass.
+- **Paraphrase, never reproduce, a bot's trigger or command string in
+  `{reason}`.** Advisory bots scan comment bodies for their own
+  command-trigger strings even inside Markdown code spans, so quoting
+  a bot's literal review-request mention verbatim — fenced or not —
+  can fire it as though a fresh review had been manually requested.
+  Describe the situation in your own words instead. Canonical
+  paraphrase for the low-star / manual-trigger skip-review case:
+  "requires a manually triggered review for low-star repositories".
 - **Carry the rejection forward across pushes.** Once a notice carries a
   `**Rejected** — {bot} did not review HEAD …` reply, that disposition
   persists across later HEAD changes and pushes while the same notice

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -318,6 +318,14 @@ ack / error, as defined in E4):
   has, disposition that review instead and take a fresh E1 snapshot, so
   the rejection's later timestamp doesn't filter the completed review
   out of the next pass.
+- **Paraphrase, never reproduce, a bot's trigger or command string in
+  `{reason}`.** Advisory bots scan comment bodies for their own
+  command-trigger strings even inside Markdown code spans, so quoting
+  a bot's literal review-request mention verbatim — fenced or not —
+  can fire it as though a fresh review had been manually requested.
+  Describe the situation in your own words instead. Canonical
+  paraphrase for the low-star / manual-trigger skip-review case:
+  "requires a manually triggered review for low-star repositories".
 - **Carry the rejection forward across pushes.** Once a notice carries a
   `**Rejected** — {bot} did not review HEAD …` reply, that disposition
   persists across later HEAD changes and pushes while the same notice


### PR DESCRIPTION
## Summary

- Adds a content-safety note to E6 PATH B's "Advisory non-review
  notice" subsection: the freeform `{reason}` field in the
  deterministic rejection template must paraphrase, never reproduce,
  a bot's literal trigger/command string, since advisory bots scan
  comment bodies for their own command-trigger strings even inside
  Markdown code spans.
- Gives one canonical paraphrase for the low-star / manual-trigger
  skip-review case.
- Edits the canonical `idd-template/` source and regenerates the
  repo-root mirror via `node scripts/sync-docs.mjs --apply`.

Closes #2164

## Background

Observed independently on three `kurone-kito/dotfiles` PRs in the
2026-08-15 run (gist `52ed338da39f8cfb80b4bf8cf7c2636d`, Finding 4):
workers quoted a bot's documented review-request mention as the
honest explanation of a skip-review / low-star gate, and the bot
replied within seconds as if a manual review had been requested. E6's
"never auto-request a fresh review to upgrade a notice" rule covers
API/actions, not this prose footgun.

## Test plan

- [x] `node scripts/sync-docs.mjs --apply` clean (no further diff)
- [x] `node scripts/audit-docs.mjs --check` passes
- [x] `node scripts/audit-code-span-wrap.mjs` passes
- [x] `pnpm run build:check` passes
- [x] `node scripts/idd-doctor.mjs` passes (pre-existing warnings only)
- [x] `npx cspell lint "**" --no-progress` passes
- [x] `npx markdownlint-cli2 "**/*.md"` passes
- [x] `npx dprint check "**/*.md"` passes
- [x] `npx biome check` passes
- [x] Manual read-through: the added text never types out any bot's
      actual trigger/command string


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for paraphrasing advisory bot commands and trigger strings.
  * Clarified wording for cases where reviews are skipped due to repository popularity or manual triggers.
  * Applied the guidance consistently across the relevant review-triage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->