### PR TITLE
docs(review-triage): name review-ack as the Clause 1 escape hatch

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -344,11 +344,10 @@ hold.
 never zeroed it in `kurone-kito/lints-config` PRs `#243`/`#245`
 (2026-08-10/11). PR #2054 fixes it.
 
-**Already-dispositioned escape hatch**: when the blocking suppressed
-finding(s) already have a trusted `**Accepted**` / `**Rejected**`
-disposition, a reroll is unnecessary — see
-`idd-review-triage.instructions.md`'s `review-ack:` paragraph (E6)
-instead.
+**Already-handled escape hatch**: when the blocking suppressed
+finding(s) have already been read and handled, a reroll is
+unnecessary — post a trusted `review-ack:` marker instead; see
+`idd-review-triage.instructions.md`'s `review-ack:` paragraph (E6).
 
 ## Terminal Copilot stall-recovery contract (state, policy, markers, clock)
 

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -344,6 +344,12 @@ hold.
 never zeroed it in `kurone-kito/lints-config` PRs `#243`/`#245`
 (2026-08-10/11). PR #2054 fixes it.
 
+**Already-dispositioned escape hatch**: when the blocking suppressed
+finding(s) already have a trusted `**Accepted**` / `**Rejected**`
+disposition, a reroll is unnecessary — see
+`idd-review-triage.instructions.md`'s `review-ack:` paragraph (E6)
+instead.
+
 ## Terminal Copilot stall-recovery contract (state, policy, markers, clock)
 
 `#1572` defines the state/policy/marker contract for a terminal

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -296,7 +296,10 @@ nonce was recorded for the active claim.
   scripts/advisory-convergence.mjs --pr {pr-number} --assert` (or the
   profile-selected `idd-advisory-convergence` command). Non-zero exit
   routes to E1/E4 (check **AW6** first when
-  `sameHeadReroll.eligible`); `ready: true` satisfies. On
+  `sameHeadReroll.eligible`; an `ack-suppressed` next-action means
+  Clause 1 is blocked solely on `suppressedCount` — see
+  `idd-review-triage.instructions.md`'s `review-ack:` paragraph (E6)
+  instead of rerolling); `ready: true` satisfies. On
   `instructions-only`, both halves use the [F2 `gh`/`jq` fallback](../../docs/idd-advisory-wait-shell-fallback.md#f2).
   Separately, require `dispositionEvidence.route` to be `proceed`
   (`dispositionEvidence.blockingCount == 0` — both

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -297,7 +297,7 @@ nonce was recorded for the active claim.
   profile-selected `idd-advisory-convergence` command). Non-zero exit
   routes to E1/E4 (check **AW6** first when
   `sameHeadReroll.eligible`; an `ack-suppressed` next-action means
-  Clause 1 is blocked solely on `suppressedCount` — see
+  Clause 1's `suppressedCount` term still needs coverage — see
   `idd-review-triage.instructions.md`'s `review-ack:` paragraph (E6)
   instead of rerolling); `ready: true` satisfies. On
   `instructions-only`, both halves use the [F2 `gh`/`jq` fallback](../../docs/idd-advisory-wait-shell-fallback.md#f2).

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -300,28 +300,31 @@ PATH B — Advisory items (completed review of the current HEAD):
 (thread / comment disposition) only. When the latest Copilot review on
 current HEAD also reports `suppressedCount > 0` (a finding folded into
 a `<details><summary>Suppressed comments (N)</summary>` block instead
-of a comment — see `docs/idd-helper-scripts.md`), Clause 1 stays unmet
-by disposition alone: it requires either `suppressedCount === 0` or a
-valid `review-ack:` marker
-(`suppressedCount === 0 || hasValidReviewAck`). Once a trusted actor
-has recorded `**Accepted**` / `**Rejected**` for every suppressed
-finding, post `review-ack:` for the current HEAD SHA (helper-first:
-`post-idd-marker --type review-ack --from-pr <pr-number> --agent-id
-<id> --timestamp <ISO8601> --apply`):
+of a comment, so it has no thread or comment ID of its own to reply
+to — see `docs/idd-helper-scripts.md`), Clause 1's `suppressedCount`
+term needs its own coverage
+(`suppressedCount === 0 || hasValidReviewAck`) regardless of any
+Clause 2 disposition elsewhere in the same review. After reading the
+review body and confirming the suppressed finding(s) are handled
+(fixed, or judged as needing no action), post `review-ack:` for the
+current HEAD SHA (helper-first: `post-idd-marker --type review-ack
+--from-pr <pr-number> --agent-id <id> --timestamp <ISO8601>
+--apply`):
 
 ```text
 review-ack: {agent-id} {PR_HEAD_SHA} {ISO8601-acknowledged-at}
 ```
 
-_Worked example_: after replying
-`**Rejected** — verified placeholders-only` to a suppressed finding,
-also post
+_Worked example_: a review posts one regular-comment finding plus a
+suppressed one; after replying `**Rejected** — verified
+placeholders-only` to the regular-comment finding, also post
 `review-ack: claude-code-1a2b3c4d 4b825dc642cb6eb9a060e54bf8d69288fbee4904 2026-08-19T00:10:00Z`
-— the rejection reply alone never sets `converged`; Clause 1 needs the
-marker too. Plain text, no HTML comment (matches `advisory-wait:`'s
+to cover the suppressed one — the regular-comment rejection alone
+never sets `converged`; the `suppressedCount` term needs the marker
+too. Plain text, no HTML comment (matches `advisory-reroll:`'s
 shape). This is not a license to skip **AW6** or the fix flow when a
-suppressed finding is Accepted and needs a code change — `review-ack:`
-covers already-dispositioned findings only.
+suppressed finding needs a code change — `review-ack:` asserts the
+finding was read and handled, not that it required no action.
 
 PATH B — Advisory non-review notice (rate-limit / quota / queued / bare
 ack / error, as defined in E4):

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -307,7 +307,7 @@ valid `review-ack:` marker
 has recorded `**Accepted**` / `**Rejected**` for every suppressed
 finding, post `review-ack:` for the current HEAD SHA (helper-first:
 `post-idd-marker --type review-ack --from-pr <pr-number> --agent-id
-<id> --apply`):
+<id> --timestamp <ISO8601> --apply`):
 
 ```text
 review-ack: {agent-id} {PR_HEAD_SHA} {ISO8601-acknowledged-at}

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -307,9 +307,13 @@ term needs its own coverage
 Clause 2 disposition elsewhere in the same review. After reading the
 review body and confirming the suppressed finding(s) are handled
 (fixed, or judged as needing no action), post `review-ack:` for the
-current HEAD SHA (helper-first: `post-idd-marker --type review-ack
---from-pr <pr-number> --agent-id <id> --timestamp <ISO8601>
---apply`):
+current HEAD SHA. `post-idd-marker.mjs` itself performs no author
+gating — anyone with `gh` credentials can post the comment — but
+`idd-advisory-convergence` only honors a marker whose GitHub author is
+a `trustedMarkerActors` login; an untrusted poster's marker is ignored,
+not rejected at post time (helper-first: `post-idd-marker --type
+review-ack --from-pr <pr-number> --agent-id <id> --timestamp
+<ISO8601> --apply`):
 
 ```text
 review-ack: {agent-id} {PR_HEAD_SHA} {ISO8601-acknowledged-at}

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -295,6 +295,34 @@ PATH B — Advisory items (completed review of the current HEAD):
 - Do not send PATH B items to review-fix. Their work is complete once
   the marker is posted and any thread resolution is done.
 
+**`review-ack:` marker — Clause 1 vs Clause 2.** Posting `**Accepted**`
+/ `**Rejected**` above satisfies advisory-convergence's Clause 2
+(thread / comment disposition) only. When the latest Copilot review on
+current HEAD also reports `suppressedCount > 0` (a finding folded into
+a `<details><summary>Suppressed comments (N)</summary>` block instead
+of a comment — see `docs/idd-helper-scripts.md`), Clause 1 stays unmet
+by disposition alone: it requires either `suppressedCount === 0` or a
+valid `review-ack:` marker
+(`suppressedCount === 0 || hasValidReviewAck`). Once a trusted actor
+has recorded `**Accepted**` / `**Rejected**` for every suppressed
+finding, post `review-ack:` for the current HEAD SHA (helper-first:
+`post-idd-marker --type review-ack --from-pr <pr-number> --agent-id
+<id> --apply`):
+
+```text
+review-ack: {agent-id} {PR_HEAD_SHA} {ISO8601-acknowledged-at}
+```
+
+_Worked example_: after replying
+`**Rejected** — verified placeholders-only` to a suppressed finding,
+also post
+`review-ack: claude-code-1a2b3c4d 4b825dc642cb6eb9a060e54bf8d69288fbee4904 2026-08-19T00:10:00Z`
+— the rejection reply alone never sets `converged`; Clause 1 needs the
+marker too. Plain text, no HTML comment (matches `advisory-wait:`'s
+shape). This is not a license to skip **AW6** or the fix flow when a
+suppressed finding is Accepted and needs a code change — `review-ack:`
+covers already-dispositioned findings only.
+
 PATH B — Advisory non-review notice (rate-limit / quota / queued / bare
 ack / error, as defined in E4):
 

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -339,6 +339,12 @@ hold.
 never zeroed it in `kurone-kito/lints-config` PRs `#243`/`#245`
 (2026-08-10/11). PR #2054 fixes it.
 
+**Already-dispositioned escape hatch**: when the blocking suppressed
+finding(s) already have a trusted `**Accepted**` / `**Rejected**`
+disposition, a reroll is unnecessary — see
+`idd-review-triage.instructions.md`'s `review-ack:` paragraph (E6)
+instead.
+
 ## Terminal Copilot stall-recovery contract (state, policy, markers, clock)
 
 `#1572` defines the state/policy/marker contract for a terminal

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -339,11 +339,10 @@ hold.
 never zeroed it in `kurone-kito/lints-config` PRs `#243`/`#245`
 (2026-08-10/11). PR #2054 fixes it.
 
-**Already-dispositioned escape hatch**: when the blocking suppressed
-finding(s) already have a trusted `**Accepted**` / `**Rejected**`
-disposition, a reroll is unnecessary — see
-`idd-review-triage.instructions.md`'s `review-ack:` paragraph (E6)
-instead.
+**Already-handled escape hatch**: when the blocking suppressed
+finding(s) have already been read and handled, a reroll is
+unnecessary — post a trusted `review-ack:` marker instead; see
+`idd-review-triage.instructions.md`'s `review-ack:` paragraph (E6).
 
 ## Terminal Copilot stall-recovery contract (state, policy, markers, clock)
 

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -291,7 +291,10 @@ nonce was recorded for the active claim.
   scripts/advisory-convergence.mjs --pr {pr-number} --assert` (or the
   profile-selected `idd-advisory-convergence` command). Non-zero exit
   routes to E1/E4 (check **AW6** first when
-  `sameHeadReroll.eligible`); `ready: true` satisfies. On
+  `sameHeadReroll.eligible`; an `ack-suppressed` next-action means
+  Clause 1 is blocked solely on `suppressedCount` — see
+  `idd-review-triage.instructions.md`'s `review-ack:` paragraph (E6)
+  instead of rerolling); `ready: true` satisfies. On
   `instructions-only`, both halves use the [F2 `gh`/`jq` fallback](../../docs/idd-advisory-wait-shell-fallback.md#f2).
   Separately, require `dispositionEvidence.route` to be `proceed`
   (`dispositionEvidence.blockingCount == 0` — both

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -292,7 +292,7 @@ nonce was recorded for the active claim.
   profile-selected `idd-advisory-convergence` command). Non-zero exit
   routes to E1/E4 (check **AW6** first when
   `sameHeadReroll.eligible`; an `ack-suppressed` next-action means
-  Clause 1 is blocked solely on `suppressedCount` — see
+  Clause 1's `suppressedCount` term still needs coverage — see
   `idd-review-triage.instructions.md`'s `review-ack:` paragraph (E6)
   instead of rerolling); `ready: true` satisfies. On
   `instructions-only`, both halves use the [F2 `gh`/`jq` fallback](../../docs/idd-advisory-wait-shell-fallback.md#f2).

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -295,28 +295,31 @@ PATH B — Advisory items (completed review of the current HEAD):
 (thread / comment disposition) only. When the latest Copilot review on
 current HEAD also reports `suppressedCount > 0` (a finding folded into
 a `<details><summary>Suppressed comments (N)</summary>` block instead
-of a comment — see `docs/idd-helper-scripts.md`), Clause 1 stays unmet
-by disposition alone: it requires either `suppressedCount === 0` or a
-valid `review-ack:` marker
-(`suppressedCount === 0 || hasValidReviewAck`). Once a trusted actor
-has recorded `**Accepted**` / `**Rejected**` for every suppressed
-finding, post `review-ack:` for the current HEAD SHA (helper-first:
-`post-idd-marker --type review-ack --from-pr <pr-number> --agent-id
-<id> --timestamp <ISO8601> --apply`):
+of a comment, so it has no thread or comment ID of its own to reply
+to — see `docs/idd-helper-scripts.md`), Clause 1's `suppressedCount`
+term needs its own coverage
+(`suppressedCount === 0 || hasValidReviewAck`) regardless of any
+Clause 2 disposition elsewhere in the same review. After reading the
+review body and confirming the suppressed finding(s) are handled
+(fixed, or judged as needing no action), post `review-ack:` for the
+current HEAD SHA (helper-first: `post-idd-marker --type review-ack
+--from-pr <pr-number> --agent-id <id> --timestamp <ISO8601>
+--apply`):
 
 ```text
 review-ack: {agent-id} {PR_HEAD_SHA} {ISO8601-acknowledged-at}
 ```
 
-_Worked example_: after replying
-`**Rejected** — verified placeholders-only` to a suppressed finding,
-also post
+_Worked example_: a review posts one regular-comment finding plus a
+suppressed one; after replying `**Rejected** — verified
+placeholders-only` to the regular-comment finding, also post
 `review-ack: claude-code-1a2b3c4d 4b825dc642cb6eb9a060e54bf8d69288fbee4904 2026-08-19T00:10:00Z`
-— the rejection reply alone never sets `converged`; Clause 1 needs the
-marker too. Plain text, no HTML comment (matches `advisory-wait:`'s
+to cover the suppressed one — the regular-comment rejection alone
+never sets `converged`; the `suppressedCount` term needs the marker
+too. Plain text, no HTML comment (matches `advisory-reroll:`'s
 shape). This is not a license to skip **AW6** or the fix flow when a
-suppressed finding is Accepted and needs a code change — `review-ack:`
-covers already-dispositioned findings only.
+suppressed finding needs a code change — `review-ack:` asserts the
+finding was read and handled, not that it required no action.
 
 PATH B — Advisory non-review notice (rate-limit / quota / queued / bare
 ack / error, as defined in E4):

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -302,9 +302,13 @@ term needs its own coverage
 Clause 2 disposition elsewhere in the same review. After reading the
 review body and confirming the suppressed finding(s) are handled
 (fixed, or judged as needing no action), post `review-ack:` for the
-current HEAD SHA (helper-first: `post-idd-marker --type review-ack
---from-pr <pr-number> --agent-id <id> --timestamp <ISO8601>
---apply`):
+current HEAD SHA. `post-idd-marker.mjs` itself performs no author
+gating — anyone with `gh` credentials can post the comment — but
+`idd-advisory-convergence` only honors a marker whose GitHub author is
+a `trustedMarkerActors` login; an untrusted poster's marker is ignored,
+not rejected at post time (helper-first: `post-idd-marker --type
+review-ack --from-pr <pr-number> --agent-id <id> --timestamp
+<ISO8601> --apply`):
 
 ```text
 review-ack: {agent-id} {PR_HEAD_SHA} {ISO8601-acknowledged-at}

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -302,7 +302,7 @@ valid `review-ack:` marker
 has recorded `**Accepted**` / `**Rejected**` for every suppressed
 finding, post `review-ack:` for the current HEAD SHA (helper-first:
 `post-idd-marker --type review-ack --from-pr <pr-number> --agent-id
-<id> --apply`):
+<id> --timestamp <ISO8601> --apply`):
 
 ```text
 review-ack: {agent-id} {PR_HEAD_SHA} {ISO8601-acknowledged-at}

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -290,6 +290,34 @@ PATH B — Advisory items (completed review of the current HEAD):
 - Do not send PATH B items to review-fix. Their work is complete once
   the marker is posted and any thread resolution is done.
 
+**`review-ack:` marker — Clause 1 vs Clause 2.** Posting `**Accepted**`
+/ `**Rejected**` above satisfies advisory-convergence's Clause 2
+(thread / comment disposition) only. When the latest Copilot review on
+current HEAD also reports `suppressedCount > 0` (a finding folded into
+a `<details><summary>Suppressed comments (N)</summary>` block instead
+of a comment — see `docs/idd-helper-scripts.md`), Clause 1 stays unmet
+by disposition alone: it requires either `suppressedCount === 0` or a
+valid `review-ack:` marker
+(`suppressedCount === 0 || hasValidReviewAck`). Once a trusted actor
+has recorded `**Accepted**` / `**Rejected**` for every suppressed
+finding, post `review-ack:` for the current HEAD SHA (helper-first:
+`post-idd-marker --type review-ack --from-pr <pr-number> --agent-id
+<id> --apply`):
+
+```text
+review-ack: {agent-id} {PR_HEAD_SHA} {ISO8601-acknowledged-at}
+```
+
+_Worked example_: after replying
+`**Rejected** — verified placeholders-only` to a suppressed finding,
+also post
+`review-ack: claude-code-1a2b3c4d 4b825dc642cb6eb9a060e54bf8d69288fbee4904 2026-08-19T00:10:00Z`
+— the rejection reply alone never sets `converged`; Clause 1 needs the
+marker too. Plain text, no HTML comment (matches `advisory-wait:`'s
+shape). This is not a license to skip **AW6** or the fix flow when a
+suppressed finding is Accepted and needs a code change — `review-ack:`
+covers already-dispositioned findings only.
+
 PATH B — Advisory non-review notice (rate-limit / quota / queued / bare
 ack / error, as defined in E4):
 


### PR DESCRIPTION
# Summary

E6 (PATH B) told workers to post `**Accepted**` / `**Rejected**`
dispositions for a Copilot advisory review, but never explained that
those markers only satisfy advisory-convergence's Clause 2
(thread/comment disposition). When a review's `suppressedCount > 0`
(a finding folded into a `Suppressed comments (N)` block instead of a
posted comment), Clause 1 additionally requires a `review-ack:`
marker — a mechanic the helper already ships (`#2050`/`#2056`) and
`docs/idd-helper-scripts.md` already documents, but no routed E-phase
instruction file names it. This adds a short `review-ack:` subsection
to E6, with a worked example, and one-hop pointers from F2's advisory
convergence check and AW6's same-HEAD reroll section.

While drafting the worked example I dry-ran the proposed
`post-idd-marker --type review-ack` command and found it errors
without `--timestamp` even under `--from-pr` (only `--head-sha` is
derived from the PR) — fixed in a follow-up commit, verified via a
second dry-run. An independent critique pass then found the E6 text
described "replying" to a suppressed finding as though it had a
comment/thread ID to reply to, which it does not (cross-checked
against `advisory-convergence.mts`'s own next-action text) — corrected
in a second follow-up commit. Copilot's own review of this PR then
flagged (as a suppressed finding, dogfooding the exact mechanic this
PR documents) that the `review-ack:` paragraph never stated the
trust-gating rule already documented elsewhere for this marker family
— added in a third follow-up commit.

## Linked issue

Closes #2165

## Follow-up issues (if any)

- [ ] none — the `bundle-review` context-ceiling bundle
      (`idd-overview-core` + `idd-overview-appendix` +
      `idd-review-snapshot` + `idd-review-triage` + `idd-review-fix` +
      `idd-advisory-wait` + `idd-ci`) is close to its budget after this
      change: `audit-docs.mjs`'s `context-ceiling-128k` notice reports
      96.46% utilization, and the bundle's own byte sum is ~123.0 KB
      against its 126000-byte `limitBytes` (~2.97 KB headroom). Not
      actionable from this PR — noted for a maintainer to consider a
      trim/split pass if the bundle keeps growing.

## Background / rationale (if material)

Sibling issue #2164 (also under the same `#2166` roadmap) edits an
adjacent E6 subsection in the same file concurrently. No overlap in
the edited text; flagging in case of a merge-order conflict.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
