### PR TITLE
docs(pr-submit): forbid ad-hoc gh issue create from execution phases

### DIFF
--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -138,6 +138,13 @@ when one exists:
   Include only context grounded in the issue discussion, commits, diff,
   or explicit operator instructions; omit rather than speculate.
 
+**Do not create follow-up issues directly.** An executing IDD session
+must never call `gh issue create` (or the REST issues API) itself.
+Recommended follow-ups stay in the PR body's own prose above. If a
+follow-up is important enough to file in-repo now, invoke the
+`issue-authoring` skill (its Stage 1 hold) instead of improvising a
+body. Do not add a parallel "worker-lite authoring" contract.
+
 ### PR body language
 
 The PR body's prose sections above (summary, background/rationale,

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -233,7 +233,10 @@ reviewer feedback:
   - If the reviewer responds and disagrees: move the item to Accepted
     and proceed through the fix flow.
   - If the reviewer responds (either way): restart from E1.
-- If you decide "Reject now but should do eventually": open a new issue.
+- If you decide "Reject now but should do eventually": open a new issue
+  following `idd-pr-submit.instructions.md` D3's follow-up-issue rule —
+  never call `gh issue create` (or the REST issues API) directly; use
+  the `issue-authoring` skill.
   The new issue's body must include a `Refs #NNN` line on its own
   line (not narrative prose) back to the originating issue — use
   `Refs` specifically and reference the issue, never the PR: a

--- a/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -238,6 +238,10 @@ loop instead of returning to this D1 rebase path.
 7. If CODEOWNERS or expected reviewers are not auto-assigned, request
    them explicitly: `gh pr edit {pr-number} --add-reviewer
    {reviewer-login}`.
+8. **Do not create follow-up issues directly** — never call `gh issue
+   create` (or the REST issues API) yourself. Recommended follow-ups
+   stay in the PR body prose above; if one is important enough to file
+   now, invoke the `issue-authoring` skill instead.
 
 ### D3.5 — Verify closing keyword detection
 

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -133,6 +133,13 @@ when one exists:
   Include only context grounded in the issue discussion, commits, diff,
   or explicit operator instructions; omit rather than speculate.
 
+**Do not create follow-up issues directly.** An executing IDD session
+must never call `gh issue create` (or the REST issues API) itself.
+Recommended follow-ups stay in the PR body's own prose above. If a
+follow-up is important enough to file in-repo now, invoke the
+`issue-authoring` skill (its Stage 1 hold) instead of improvising a
+body. Do not add a parallel "worker-lite authoring" contract.
+
 ### PR body language
 
 The PR body's prose sections above (summary, background/rationale,

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -228,7 +228,10 @@ reviewer feedback:
   - If the reviewer responds and disagrees: move the item to Accepted
     and proceed through the fix flow.
   - If the reviewer responds (either way): restart from E1.
-- If you decide "Reject now but should do eventually": open a new issue.
+- If you decide "Reject now but should do eventually": open a new issue
+  following `idd-pr-submit.instructions.md` D3's follow-up-issue rule —
+  never call `gh issue create` (or the REST issues API) directly; use
+  the `issue-authoring` skill.
   The new issue's body must include a `Refs #NNN` line on its own
   line (not narrative prose) back to the originating issue — use
   `Refs` specifically and reference the issue, never the PR: a

--- a/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -233,6 +233,10 @@ loop instead of returning to this D1 rebase path.
 7. If CODEOWNERS or expected reviewers are not auto-assigned, request
    them explicitly: `gh pr edit {pr-number} --add-reviewer
    {reviewer-login}`.
+8. **Do not create follow-up issues directly** — never call `gh issue
+   create` (or the REST issues API) yourself. Recommended follow-ups
+   stay in the PR body prose above; if one is important enough to file
+   now, invoke the `issue-authoring` skill instead.
 
 ### D3.5 — Verify closing keyword detection
 


### PR DESCRIPTION
## Summary

- Adds a rule to D3 in `idd-pr-submit.instructions.md`: an executing
  IDD session must never call `gh issue create` (or the REST issues
  API) itself. Names the two allowed follow-up-issue paths — PR
  recommended-follow-up prose, or the `issue-authoring` skill.
- Adds a one-hop pointer from E6's "open a new issue" bullet in
  `idd-review-triage.instructions.md` (the one other execution-phase
  spot that told a worker to file a follow-up without the caveat).
- Adds the same rule to the `idd-pr-submit-lite.instructions.md`
  sibling, which restates the follow-up-issues bullet independently.
- Regenerates the repo-root mirrors via `node scripts/sync-docs.mjs --apply`.

Closes #2163

## Background

Observed on `kurone-kito/dotfiles` 2026-08-15 (gist
`52ed338da39f8cfb80b4bf8cf7c2636d`, Finding 3): six worker-filed
follow-ups shipped with no autopilot-suitability footer, two
overlapped in scope, and one expressed a real ordering constraint as
"Coordinate with #266" instead of `Blocked by #266`. Discover treated
the unscored issues as floor-default and could not see the
dependency. The `issue-authoring` skill already owns reuse-first,
footers, dependency encoding, and the authoring hold; this closes the
informal `gh issue create` path that kept drifting around it.

## Test plan

- [x] `node scripts/sync-docs.mjs --apply` clean (no further diff)
- [x] `node scripts/audit-docs.mjs --check` passes
- [x] `node scripts/audit-code-span-wrap.mjs` passes
- [x] `pnpm run build:check` passes
- [x] `node scripts/idd-doctor.mjs` passes (pre-existing warnings only)
- [x] `npx cspell lint "**" --no-progress` passes
- [x] `npx markdownlint-cli2 "**/*.md"` passes
- [x] `npx dprint check "**/*.md"` passes
- [x] `npx biome check` passes
- [x] Confirmed `idd-roadmap-audit.instructions.md`'s A1.5 gap-fill
      already routes through `issue-authoring` — no change needed
      there
