### PR TITLE
fix(advisory-convergence): add REST fallback for reviewer request

### DIFF
--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -2139,6 +2139,8 @@ export function collectAssertNextActions(verdict) {
       summary: `${bot} has not reviewed this PR. Request a review (E14) then post an advisory-wait marker:`,
       pointer: [
         `gh pr edit ${pr} --add-reviewer ${reviewer}`,
+        `# on GraphQL login-resolution failure ("Could not resolve user with login '${reviewer}'"):`,
+        `gh api repos/{owner}/{repo}/pulls/${pr}/requested_reviewers -X POST -f "reviewers[]=${restLogin}"`,
         `node scripts/post-idd-marker.mjs --type advisory --target pr ${pr} --agent-id <id> --head-sha ${sha} --timestamp <ISO8601> --apply`,
       ].join('\n'),
     });

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -2813,6 +2813,8 @@ export function collectAssertNextActions(
       summary: `${bot} has not reviewed this PR. Request a review (E14) then post an advisory-wait marker:`,
       pointer: [
         `gh pr edit ${pr} --add-reviewer ${reviewer}`,
+        `# on GraphQL login-resolution failure ("Could not resolve user with login '${reviewer}'"):`,
+        `gh api repos/{owner}/{repo}/pulls/${pr}/requested_reviewers -X POST -f "reviewers[]=${restLogin}"`,
         `node scripts/post-idd-marker.mjs --type advisory --target pr ${pr} --agent-id <id> --head-sha ${sha} --timestamp <ISO8601> --apply`,
       ].join('\n'),
     });

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -4047,6 +4047,13 @@ test('formatAssertNextActions covers no-review and off-HEAD (#2142)', () => {
   const noneText = formatAssertNextActions(none);
   assert.match(noneText, /has not reviewed this PR/);
   assert.match(noneText, /gh pr edit \d+ --add-reviewer copilot/);
+  // #2159: the gh add-reviewer form alone is not sufficient for the
+  // default bot login (GraphQL fails to resolve it) — the REST
+  // requested_reviewers fallback from E14 must also be present.
+  assert.match(
+    noneText,
+    /gh api repos\/\{owner\}\/\{repo\}\/pulls\/\d+\/requested_reviewers -X POST -f "reviewers\[\]=copilot-pull-request-reviewer\[bot\]"/,
+  );
   assert.match(noneText, /post-idd-marker\.mjs --type advisory/);
   assert.doesNotMatch(
     noneText,


### PR DESCRIPTION
# Summary

The `request-review` next-action pointer emitted by `collectAssertNextActions` told a session to run `gh pr edit <pr> --add-reviewer copilot`, which GitHub's GraphQL mutation fails to resolve for the default bot login (`Could not resolve user with login 'copilot' (requestReviewsByLogin)`, observed on PR #2156). E14 (`idd-review-fix.instructions.md`) already documents the correct two-step sequence: try `gh pr edit --add-reviewer`, and on that GraphQL failure, fall back to REST `pulls/{pr}/requested_reviewers` with the bot's real account login (`copilot-pull-request-reviewer[bot]` for the default). This PR adds the same REST fallback line to the `REQUEST_REVIEW` catalog pointer so a session following the catalog has a copy-pasteable recovery instead of a dead end.

`reasons[]`, `protocolVersion`, and `ready` are unchanged; only the `REQUEST_REVIEW` pointer/stderr text gained one extra line. GHES / non-default host API-URL construction stays out of scope (default Copilot login path only), per the issue.

## Linked issue

Closes #2159

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Same root cause already recorded on #1296 for the non-catalog path; #2142/#2143 introduced this structured next-action catalog and its existing formatter tests are unchanged by this fix (the new REST line is appended, not substituted).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs changed)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
