### PR TITLE
fix(protocol-helpers): treat CodeRabbit skip-review as non-review

### DIFF
--- a/scripts/disposition-non-review-notices.mjs
+++ b/scripts/disposition-non-review-notices.mjs
@@ -72,6 +72,9 @@ export function noticeReason(body) {
   if (/Codex usage limits/i.test(text)) {
     return 'Codex usage limits for code reviews reached';
   }
+  if (/skip review by coderabbit\.ai/i.test(text)) {
+    return 'review skipped (billing failure or below the manual-trigger star-count gate)';
+  }
   return 'advisory non-review notice';
 }
 /**

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -468,6 +468,15 @@ export function isCodeRabbitLogin(login) {
 // byte-for-byte the same marker and cannot drift.
 export const CODERABBIT_SUMMARY_MARKER =
   '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->';
+// #2161: CodeRabbit nests this inner marker inside a comment that also
+// starts with `CODERABBIT_SUMMARY_MARKER` when no review content exists
+// (billing failure, or a repository below the star-count manual-trigger
+// gate) -- the outer wrapper is byte-for-byte identical to a genuine
+// summary walkthrough, so this inner marker is the only signal
+// distinguishing the two. Single-sourced here so `isAdvisoryNonReviewNotice`
+// and `isReviewSummaryComment` agree on the same marker and cannot drift.
+export const CODERABBIT_SKIP_REVIEW_MARKER =
+  '<!-- This is an auto-generated comment: skip review by coderabbit.ai -->';
 export function classifyRegularBotComment(
   comment,
   comments,
@@ -1012,6 +1021,11 @@ const ADVISORY_NON_REVIEW_NOTICE_PATTERNS = [
   // the `summarize by coderabbit.ai` review marker) and its warning heading.
   /<!--\s*This is an auto-generated comment:\s*rate limited by coderabbit\.ai\s*-->/i,
   /^[>\s]*#{1,6}\s*Review limit reached\b/im,
+  // #2161: CodeRabbit skip-review notice, nested inside the same outer
+  // `summarize by coderabbit.ai` wrapper as a genuine walkthrough (see
+  // CODERABBIT_SKIP_REVIEW_MARKER above) -- carries no review content even
+  // though the outer wrapper alone cannot tell it apart from a real summary.
+  new RegExp(escapeRegExp(CODERABBIT_SKIP_REVIEW_MARKER), 'i'),
 ];
 // Codex usage / quota exhaustion for code reviews. Token-anchored on all
 // three of "Codex usage limit(s)", a reach/exceed/hit-family verb, and "for
@@ -1188,10 +1202,16 @@ export const NON_REVIEW_NOTICE_DISPOSITION_HINT =
 // True when a regular comment is a CodeRabbit summary walkthrough. Detection is
 // start-anchored on the exact single-sourced marker (after trimming leading
 // whitespace) so a comment that merely quotes the marker in prose is not matched.
+// #2161: a comment that also nests CODERABBIT_SKIP_REVIEW_MARKER carries no
+// review content despite starting with the summary marker, so it is excluded
+// here too -- never a summary walkthrough, always a non-review notice (see
+// isAdvisoryNonReviewNotice / ADVISORY_NON_REVIEW_NOTICE_PATTERNS).
 export function isReviewSummaryComment(body) {
-  return String(body ?? '')
-    .trimStart()
-    .startsWith(CODERABBIT_SUMMARY_MARKER);
+  const text = String(body ?? '').trimStart();
+  return (
+    text.startsWith(CODERABBIT_SUMMARY_MARKER) &&
+    !text.includes(CODERABBIT_SKIP_REVIEW_MARKER)
+  );
 }
 // A trusted IDD disposition of a CodeRabbit summary walkthrough: the canonical
 // `**Accepted** — {bot} summary walkthrough …` reply the helper posts. Requires

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -477,12 +477,12 @@ export const CODERABBIT_SUMMARY_MARKER =
 // and `isReviewSummaryComment` agree on the same marker and cannot drift.
 export const CODERABBIT_SKIP_REVIEW_MARKER =
   '<!-- This is an auto-generated comment: skip review by coderabbit.ai -->';
-// Case-insensitive: CodeRabbit's own outer-marker matching elsewhere in this
-// file (see the rate-limit / summarize markers above) tolerates whitespace
-// and casing drift, so this must too -- a case-sensitive `includes()` check
-// here previously let `isReviewSummaryComment` and `isAdvisoryNonReviewNotice`
-// disagree on a casing-only marker variation (kurone-kito/idd-skill#2161
-// review). Single-sourced so both predicates share the exact same test.
+// Case-insensitive, matching CodeRabbit's own outer-marker patterns
+// elsewhere in this file (see the rate-limit marker above) -- a
+// case-sensitive `includes()` check here previously let
+// `isReviewSummaryComment` and `isAdvisoryNonReviewNotice` disagree on a
+// casing-only marker variation (kurone-kito/idd-skill#2161 review).
+// Single-sourced so both predicates share the exact same test.
 const CODERABBIT_SKIP_REVIEW_MARKER_RE = new RegExp(
   escapeRegExp(CODERABBIT_SKIP_REVIEW_MARKER),
   'i',

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -477,6 +477,16 @@ export const CODERABBIT_SUMMARY_MARKER =
 // and `isReviewSummaryComment` agree on the same marker and cannot drift.
 export const CODERABBIT_SKIP_REVIEW_MARKER =
   '<!-- This is an auto-generated comment: skip review by coderabbit.ai -->';
+// Case-insensitive: CodeRabbit's own outer-marker matching elsewhere in this
+// file (see the rate-limit / summarize markers above) tolerates whitespace
+// and casing drift, so this must too -- a case-sensitive `includes()` check
+// here previously let `isReviewSummaryComment` and `isAdvisoryNonReviewNotice`
+// disagree on a casing-only marker variation (kurone-kito/idd-skill#2161
+// review). Single-sourced so both predicates share the exact same test.
+const CODERABBIT_SKIP_REVIEW_MARKER_RE = new RegExp(
+  escapeRegExp(CODERABBIT_SKIP_REVIEW_MARKER),
+  'i',
+);
 export function classifyRegularBotComment(
   comment,
   comments,
@@ -1025,7 +1035,7 @@ const ADVISORY_NON_REVIEW_NOTICE_PATTERNS = [
   // `summarize by coderabbit.ai` wrapper as a genuine walkthrough (see
   // CODERABBIT_SKIP_REVIEW_MARKER above) -- carries no review content even
   // though the outer wrapper alone cannot tell it apart from a real summary.
-  new RegExp(escapeRegExp(CODERABBIT_SKIP_REVIEW_MARKER), 'i'),
+  CODERABBIT_SKIP_REVIEW_MARKER_RE,
 ];
 // Codex usage / quota exhaustion for code reviews. Token-anchored on all
 // three of "Codex usage limit(s)", a reach/exceed/hit-family verb, and "for
@@ -1210,7 +1220,7 @@ export function isReviewSummaryComment(body) {
   const text = String(body ?? '').trimStart();
   return (
     text.startsWith(CODERABBIT_SUMMARY_MARKER) &&
-    !text.includes(CODERABBIT_SKIP_REVIEW_MARKER)
+    !CODERABBIT_SKIP_REVIEW_MARKER_RE.test(text)
   );
 }
 // A trusted IDD disposition of a CodeRabbit summary walkthrough: the canonical

--- a/src/scripts/disposition-non-review-notices.mts
+++ b/src/scripts/disposition-non-review-notices.mts
@@ -127,6 +127,9 @@ export function noticeReason(body: unknown): string {
   if (/Codex usage limits/i.test(text)) {
     return 'Codex usage limits for code reviews reached';
   }
+  if (/skip review by coderabbit\.ai/i.test(text)) {
+    return 'review skipped (billing failure or below the manual-trigger star-count gate)';
+  }
   return 'advisory non-review notice';
 }
 

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1070,6 +1070,17 @@ export const CODERABBIT_SUMMARY_MARKER =
 export const CODERABBIT_SKIP_REVIEW_MARKER =
   '<!-- This is an auto-generated comment: skip review by coderabbit.ai -->';
 
+// Case-insensitive: CodeRabbit's own outer-marker matching elsewhere in this
+// file (see the rate-limit / summarize markers above) tolerates whitespace
+// and casing drift, so this must too -- a case-sensitive `includes()` check
+// here previously let `isReviewSummaryComment` and `isAdvisoryNonReviewNotice`
+// disagree on a casing-only marker variation (kurone-kito/idd-skill#2161
+// review). Single-sourced so both predicates share the exact same test.
+const CODERABBIT_SKIP_REVIEW_MARKER_RE = new RegExp(
+  escapeRegExp(CODERABBIT_SKIP_REVIEW_MARKER),
+  'i',
+);
+
 export function classifyRegularBotComment(
   comment: CommentLike,
   comments: CommentLike[],
@@ -1734,7 +1745,7 @@ const ADVISORY_NON_REVIEW_NOTICE_PATTERNS: RegExp[] = [
   // `summarize by coderabbit.ai` wrapper as a genuine walkthrough (see
   // CODERABBIT_SKIP_REVIEW_MARKER above) -- carries no review content even
   // though the outer wrapper alone cannot tell it apart from a real summary.
-  new RegExp(escapeRegExp(CODERABBIT_SKIP_REVIEW_MARKER), 'i'),
+  CODERABBIT_SKIP_REVIEW_MARKER_RE,
 ];
 
 // Codex usage / quota exhaustion for code reviews. Token-anchored on all
@@ -1929,7 +1940,7 @@ export function isReviewSummaryComment(body: unknown): boolean {
   const text = String(body ?? '').trimStart();
   return (
     text.startsWith(CODERABBIT_SUMMARY_MARKER) &&
-    !text.includes(CODERABBIT_SKIP_REVIEW_MARKER)
+    !CODERABBIT_SKIP_REVIEW_MARKER_RE.test(text)
   );
 }
 

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1070,12 +1070,12 @@ export const CODERABBIT_SUMMARY_MARKER =
 export const CODERABBIT_SKIP_REVIEW_MARKER =
   '<!-- This is an auto-generated comment: skip review by coderabbit.ai -->';
 
-// Case-insensitive: CodeRabbit's own outer-marker matching elsewhere in this
-// file (see the rate-limit / summarize markers above) tolerates whitespace
-// and casing drift, so this must too -- a case-sensitive `includes()` check
-// here previously let `isReviewSummaryComment` and `isAdvisoryNonReviewNotice`
-// disagree on a casing-only marker variation (kurone-kito/idd-skill#2161
-// review). Single-sourced so both predicates share the exact same test.
+// Case-insensitive, matching CodeRabbit's own outer-marker patterns
+// elsewhere in this file (see the rate-limit marker above) -- a
+// case-sensitive `includes()` check here previously let
+// `isReviewSummaryComment` and `isAdvisoryNonReviewNotice` disagree on a
+// casing-only marker variation (kurone-kito/idd-skill#2161 review).
+// Single-sourced so both predicates share the exact same test.
 const CODERABBIT_SKIP_REVIEW_MARKER_RE = new RegExp(
   escapeRegExp(CODERABBIT_SKIP_REVIEW_MARKER),
   'i',

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1060,6 +1060,16 @@ export function isCodeRabbitLogin(login: string): boolean {
 export const CODERABBIT_SUMMARY_MARKER =
   '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->';
 
+// #2161: CodeRabbit nests this inner marker inside a comment that also
+// starts with `CODERABBIT_SUMMARY_MARKER` when no review content exists
+// (billing failure, or a repository below the star-count manual-trigger
+// gate) -- the outer wrapper is byte-for-byte identical to a genuine
+// summary walkthrough, so this inner marker is the only signal
+// distinguishing the two. Single-sourced here so `isAdvisoryNonReviewNotice`
+// and `isReviewSummaryComment` agree on the same marker and cannot drift.
+export const CODERABBIT_SKIP_REVIEW_MARKER =
+  '<!-- This is an auto-generated comment: skip review by coderabbit.ai -->';
+
 export function classifyRegularBotComment(
   comment: CommentLike,
   comments: CommentLike[],
@@ -1720,6 +1730,11 @@ const ADVISORY_NON_REVIEW_NOTICE_PATTERNS: RegExp[] = [
   // the `summarize by coderabbit.ai` review marker) and its warning heading.
   /<!--\s*This is an auto-generated comment:\s*rate limited by coderabbit\.ai\s*-->/i,
   /^[>\s]*#{1,6}\s*Review limit reached\b/im,
+  // #2161: CodeRabbit skip-review notice, nested inside the same outer
+  // `summarize by coderabbit.ai` wrapper as a genuine walkthrough (see
+  // CODERABBIT_SKIP_REVIEW_MARKER above) -- carries no review content even
+  // though the outer wrapper alone cannot tell it apart from a real summary.
+  new RegExp(escapeRegExp(CODERABBIT_SKIP_REVIEW_MARKER), 'i'),
 ];
 
 // Codex usage / quota exhaustion for code reviews. Token-anchored on all
@@ -1906,10 +1921,16 @@ export const NON_REVIEW_NOTICE_DISPOSITION_HINT =
 // True when a regular comment is a CodeRabbit summary walkthrough. Detection is
 // start-anchored on the exact single-sourced marker (after trimming leading
 // whitespace) so a comment that merely quotes the marker in prose is not matched.
+// #2161: a comment that also nests CODERABBIT_SKIP_REVIEW_MARKER carries no
+// review content despite starting with the summary marker, so it is excluded
+// here too -- never a summary walkthrough, always a non-review notice (see
+// isAdvisoryNonReviewNotice / ADVISORY_NON_REVIEW_NOTICE_PATTERNS).
 export function isReviewSummaryComment(body: unknown): boolean {
-  return String(body ?? '')
-    .trimStart()
-    .startsWith(CODERABBIT_SUMMARY_MARKER);
+  const text = String(body ?? '').trimStart();
+  return (
+    text.startsWith(CODERABBIT_SUMMARY_MARKER) &&
+    !text.includes(CODERABBIT_SKIP_REVIEW_MARKER)
+  );
 }
 
 // A trusted IDD disposition of a CodeRabbit summary walkthrough: the canonical

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -645,6 +645,15 @@ test('#2161: isReviewSummaryComment is false and isAdvisoryNonReviewNotice is tr
   assert.equal(isAdvisoryNonReviewNotice(CODERABBIT_SKIP_REVIEW), true);
 });
 
+test('#2161: isReviewSummaryComment and isAdvisoryNonReviewNotice agree on a casing-only skip-review marker variation', () => {
+  const upperCased = CODERABBIT_SKIP_REVIEW.replace(
+    'skip review by coderabbit.ai',
+    'Skip Review By CodeRabbit.ai',
+  );
+  assert.equal(isReviewSummaryComment(upperCased), false);
+  assert.equal(isAdvisoryNonReviewNotice(upperCased), true);
+});
+
 test('#2161: a genuine walkthrough (no inner skip-review marker) is still a summary walkthrough, not a notice', () => {
   assert.equal(isReviewSummaryComment(CODERABBIT_SUMMARY), true);
   assert.equal(isAdvisoryNonReviewNotice(CODERABBIT_SUMMARY), false);

--- a/tests/disposition-non-review-notices.test.mts
+++ b/tests/disposition-non-review-notices.test.mts
@@ -15,7 +15,9 @@ import {
 import { hasReviewReplyStamp } from '../src/scripts/marker-helpers.mts';
 import {
   dispositionNamesAdvisoryBot,
+  isAdvisoryNonReviewNotice,
   isDispositionComment,
+  isReviewSummaryComment,
   summarizeDispositionEvidenceForGate,
 } from '../src/scripts/protocol-helpers.mts';
 import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
@@ -37,6 +39,14 @@ const CODERABBIT_NOTICE =
   '<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n> ## Review limit reached';
 const CODERABBIT_SUMMARY =
   '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n## Walkthrough\nSome walkthrough text.';
+// #2161: CodeRabbit wraps a content-free skip-review notice (billing failure,
+// or a repo below the star-count manual-trigger gate) in the SAME outer
+// summarize-by-coderabbit.ai marker as a genuine walkthrough, distinguished
+// only by this nested inner marker.
+const CODERABBIT_SKIP_REVIEW =
+  '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n' +
+  '<!-- This is an auto-generated comment: skip review by coderabbit.ai -->\n' +
+  '> [!WARNING]\n> ## Review skipped\nReview was skipped due to path filters.';
 // A full 40-char head SHA for the cases that validate against the schema, which
 // now constrains `headSha` to `^[0-9a-f]{40}$`.
 const HEAD_SHA = '0123456789abcdef0123456789abcdef01234567';
@@ -302,6 +312,10 @@ test('noticeReason derives the category-specific reason', () => {
     'Codex usage limits for code reviews reached',
   );
   assert.equal(noticeReason('something else'), 'advisory non-review notice');
+  assert.equal(
+    noticeReason(CODERABBIT_SKIP_REVIEW),
+    'review skipped (billing failure or below the manual-trigger star-count gate)',
+  );
 });
 
 test('buildDispositionPlan plans one disposition per undispositioned notice', () => {
@@ -623,6 +637,33 @@ test('buildDispositionPlan plans an **Accepted** for an undispositioned CodeRabb
     /coderabbitai\[bot\] summary walkthrough at HEAD abc1234/,
   );
   assert.doesNotMatch(entry.body, /\bCodeRabbit\b/);
+  assert.equal(plan.skipped.length, 0);
+});
+
+test('#2161: isReviewSummaryComment is false and isAdvisoryNonReviewNotice is true for a CodeRabbit skip-review notice nested in the summary marker', () => {
+  assert.equal(isReviewSummaryComment(CODERABBIT_SKIP_REVIEW), false);
+  assert.equal(isAdvisoryNonReviewNotice(CODERABBIT_SKIP_REVIEW), true);
+});
+
+test('#2161: a genuine walkthrough (no inner skip-review marker) is still a summary walkthrough, not a notice', () => {
+  assert.equal(isReviewSummaryComment(CODERABBIT_SUMMARY), true);
+  assert.equal(isAdvisoryNonReviewNotice(CODERABBIT_SUMMARY), false);
+});
+
+test('#2161: buildDispositionPlan proposes **Rejected**, never **Accepted**, for a CodeRabbit skip-review notice', () => {
+  const plan = buildDispositionPlan(
+    {
+      headSha: 'abc1234',
+      comments: [notice(1, CODERABBIT, CODERABBIT_SKIP_REVIEW)],
+    },
+    { trustedMarkerLogins: ['kurone-kito'] },
+  );
+  assert.equal(plan.planned.length, 1);
+  const entry = plan.planned[0];
+  assert.equal(entry.botLogin, CODERABBIT);
+  assert.ok(entry.body.startsWith('**Rejected**'));
+  assert.doesNotMatch(entry.body, /\*\*Accepted\*\*/);
+  assert.match(entry.body, /did not review HEAD abc1234/);
   assert.equal(plan.skipped.length, 0);
 });
 


### PR DESCRIPTION
# Summary

CodeRabbit wraps both a genuine summary walkthrough and a content-free
"skip review" notice (billing failure, or a repository below the
star-count manual-trigger gate) in the same outer
`summarize by coderabbit.ai` marker; a skip-review notice also nests
an inner `skip review by coderabbit.ai` marker. `isReviewSummaryComment`
only checked the outer marker, so `disposition-non-review-notices`
proposed `**Accepted**` for a comment with no review content.

- `isReviewSummaryComment` now also excludes a body carrying the nested
  skip-review marker.
- `ADVISORY_NON_REVIEW_NOTICE_PATTERNS` now matches the skip-review
  marker, so `isAdvisoryNonReviewNotice` classifies it correctly.
- `noticeReason` gives the skip-review case its own reason string
  instead of falling into the generic `advisory non-review notice`.
- Added unit tests covering both the skip-review and genuine-walkthrough
  shapes (classifier-level and `buildDispositionPlan`-level).
- `pnpm run build` regenerated `scripts/protocol-helpers.mjs` and
  `scripts/disposition-non-review-notices.mjs`.

## Linked issue

Closes #2161

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Observed on `kurone-kito/kit.black` PRs during the 2026-08-15 run-4
batch (gist `52ed338da39f8cfb80b4bf8cf7c2636d`, Finding 1); still
present on `main` prior to this change.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
