### PR TITLE
docs(claim): record OWNER/MEMBER as the 503 self-auth fallback

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -52,6 +52,8 @@ gate-enable, actor-policy, approval-signal, and fail-closed rules as
 
 A bare organization `MEMBER` association never counts as approval;
 neither do issue body text, a generated plan, or operator attention.
+See A3.5's self-authorization fallback (#2148) for the one exception,
+which applies only when the permission read itself is unavailable.
 
 - If approval is missing for a roadmap/default discovery run, return to
   Discover using the same selection mode that produced this target so

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -404,7 +404,7 @@ neither is issue body text, a generated plan, nor operator attention.
 (#2148).** The bare-`MEMBER` rule above governs an approval-comment
 actor or the `idd:ready` label actor, both of which require a
 successful permission read. For the issue-author self-authorization
-signal specifically, when the collaborators-permission API is
+signal specifically, when the collaborator permission API is
 unavailable (503, empty, or otherwise unreadable), the issue's own
 live `author_association` substitutes instead of failing closed:
 `OWNER` always self-authorizes; `MEMBER` self-authorizes under both

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -400,6 +400,18 @@ collaborator permission API.
 A bare organization `MEMBER` association, by itself, is not approval;
 neither is issue body text, a generated plan, nor operator attention.
 
+**Self-authorization fallback when the permission read is unavailable
+(#2148).** The bare-`MEMBER` rule above governs an approval-comment
+actor or the `idd:ready` label actor, both of which require a
+successful permission read. For the issue-author self-authorization
+signal specifically, when the collaborators-permission API is
+unavailable (503, empty, or otherwise unreadable), the issue's own
+live `author_association` substitutes instead of failing closed:
+`OWNER` always self-authorizes; `MEMBER` self-authorizes under both
+`owners-and-maintainers-only` and `all-write-permission-actors`. This
+matches `claim-approval-gate.mjs`'s shipped behavior and does not
+widen either other signal.
+
 **Approval signals** (any one satisfies, when the gate is enabled):
 
 - the issue author is self-authorized under the current

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -47,6 +47,8 @@ gate-enable, actor-policy, approval-signal, and fail-closed rules as
 
 A bare organization `MEMBER` association never counts as approval;
 neither do issue body text, a generated plan, or operator attention.
+See A3.5's self-authorization fallback (#2148) for the one exception,
+which applies only when the permission read itself is unavailable.
 
 - If approval is missing for a roadmap/default discovery run, return to
   Discover using the same selection mode that produced this target so

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -402,6 +402,18 @@ collaborator permission API.
 A bare organization `MEMBER` association, by itself, is not approval;
 neither is issue body text, a generated plan, nor operator attention.
 
+**Self-authorization fallback when the permission read is unavailable
+(#2148).** The bare-`MEMBER` rule above governs an approval-comment
+actor or the `idd:ready` label actor, both of which require a
+successful permission read. For the issue-author self-authorization
+signal specifically, when the collaborators-permission API is
+unavailable (503, empty, or otherwise unreadable), the issue's own
+live `author_association` substitutes instead of failing closed:
+`OWNER` always self-authorizes; `MEMBER` self-authorizes under both
+`owners-and-maintainers-only` and `all-write-permission-actors`. This
+matches `claim-approval-gate.mjs`'s shipped behavior and does not
+widen either other signal.
+
 **Approval signals** (any one satisfies, when the gate is enabled):
 
 - the issue author is self-authorized under the current

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -406,7 +406,7 @@ neither is issue body text, a generated plan, nor operator attention.
 (#2148).** The bare-`MEMBER` rule above governs an approval-comment
 actor or the `idd:ready` label actor, both of which require a
 successful permission read. For the issue-author self-authorization
-signal specifically, when the collaborators-permission API is
+signal specifically, when the collaborator permission API is
 unavailable (503, empty, or otherwise unreadable), the issue's own
 live `author_association` substitutes instead of failing closed:
 `OWNER` always self-authorizes; `MEMBER` self-authorizes under both


### PR DESCRIPTION
## Summary

- Names the `#2148` shipped `claim-approval-gate.mjs`
  self-authorization fallback in A3.5 (`idd-discover.instructions.md`):
  when the collaborators-permission read is unavailable (503, empty,
  or otherwise unreadable), the live issue `author_association`
  substitutes — `OWNER` always self-authorizes, `MEMBER`
  self-authorizes under both `owners-and-maintainers-only` and
  `all-write-permission-actors` — scoped to the issue-author
  self-authorization signal only.
- Points A5(a) (`idd-claim.instructions.md`) at A3.5's fallback
  instead of restating a conflicting bare-`MEMBER` rule.
- Regenerates the exact-mode mirror
  (`.github/instructions/idd-claim.instructions.md`) and hand-syncs
  the structure-mode `idd-discover.instructions.md` mirror (that pair
  is `mode: "structure"` in `audit/sync-manifest.json`, not
  auto-copied by `sync-docs.mjs`).

Closes #2168

No helper or test behavior change — docs-only alignment with already-shipped code.

## Test plan

- [x] `node scripts/sync-docs.mjs --apply` clean (no further diff)
- [x] `node scripts/audit-docs.mjs --check` passes
- [x] `node scripts/audit-code-span-wrap.mjs` passes
- [x] `pnpm run build:check` passes
- [x] `node scripts/idd-doctor.mjs` passes (pre-existing warnings only)
- [x] `npx cspell lint "**" --no-progress` passes
- [x] `npx markdownlint-cli2 "**/*.md"` passes
- [x] `npx dprint check "**/*.md"` passes
- [x] `npx biome check` passes
- [x] Verified the described fallback against
      `scripts/claim-approval-gate.mjs`'s
      `authorAssociationSelfAuthorizes` and its call site, not just
      the issue's own paraphrase
