### PR TITLE
fix(advisory-wait): treat a GraphQL review request as pending when REST is empty

### DIFF
--- a/scripts/advisory-wait-state.mjs
+++ b/scripts/advisory-wait-state.mjs
@@ -613,13 +613,12 @@ function fetchGraphqlRequestedReviewerLogins(owner, repo, prNumber) {
       query($owner: String!, $repo: String!, $number: Int!) {
         repository(owner: $owner, name: $repo) {
           pullRequest(number: $number) {
-            reviewRequests(first: 20) {
+            reviewRequests(first: 100) {
               nodes {
                 requestedReviewer {
                   ... on Bot { login }
                   ... on User { login }
                   ... on Mannequin { login }
-                  ... on Team { slug }
                 }
               }
             }

--- a/scripts/advisory-wait-state.mjs
+++ b/scripts/advisory-wait-state.mjs
@@ -16,6 +16,7 @@ import {
 import { parseCliArgs } from './cli-args.mjs';
 import {
   DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+  ghGraphql,
   ghText,
   safeGhText,
 } from './gh-exec.mjs';
@@ -24,6 +25,8 @@ import {
   buildAdvisoryWaitSummary,
   compareIsoTimestamps,
   computeCopilotPendingCoversHead,
+  findLastCopilotReviewCommit,
+  isCopilotPending,
   isValidIsoTimestamp,
   normalizeTrustedMarkerLogins,
   parseAdvisoryRecoveryComment,
@@ -405,13 +408,38 @@ function main() {
   const advisoryWaitPolicy = readAdvisoryWaitPolicy();
   const primaryBotLogin = readAdvisoryPrimaryBotLogin();
   const secondaryBotLogin = readAdvisorySecondaryBotLogin();
+  // #2167: only pay for the optional GraphQL reviewRequests call when the
+  // cheaper REST + timeline signals are both inconclusive -- mirrors
+  // resolveCopilotPending's own precedence (protocol-helpers.mts) so this
+  // pre-check and the pure function it feeds never disagree on when a
+  // GraphQL fallback is actually needed.
+  const restRequestedReviewers = requestedReviewers.users ?? [];
+  const restCopilotPending = isCopilotPending(
+    restRequestedReviewers,
+    primaryBotLogin,
+  );
+  const lastCopilotCommitForGraphqlGate = findLastCopilotReviewCommit(
+    reviews,
+    primaryBotLogin,
+  );
+  const copilotPendingCoversHeadForGraphqlGate =
+    computeCopilotPendingCoversHead(timelineEvents, prHeadSha, primaryBotLogin);
+  const graphqlRequestedReviewerLogins =
+    !restCopilotPending &&
+    !(
+      copilotPendingCoversHeadForGraphqlGate &&
+      lastCopilotCommitForGraphqlGate !== prHeadSha
+    )
+      ? fetchGraphqlRequestedReviewerLogins(owner, repo, args.prNumber)
+      : null;
   const summary = buildAdvisoryWaitSummary(
     {
       prHeadSha,
       reviews,
-      requestedReviewers: requestedReviewers.users ?? [],
+      requestedReviewers: restRequestedReviewers,
       timelineEvents,
       comments: comments.map(normalizeComment),
+      graphqlRequestedReviewerLogins,
     },
     {
       now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
@@ -565,4 +593,51 @@ function ghApiJson(path, paginate = false, extraArgs = []) {
     );
   }
   return JSON.parse(ghText(args));
+}
+/**
+ * #2167: REST `requested_reviewers` can report empty even when Copilot
+ * review is still genuinely outstanding -- see `resolveCopilotPending`'s
+ * doc comment in protocol-helpers.mts for the observed incident this
+ * fixes. `main()` below calls this only when REST and already-fetched
+ * timeline evidence are both inconclusive, so this optional GraphQL call
+ * is skipped whenever a cheaper signal already resolves pending state.
+ *
+ * Returns the requested-reviewer login list on success, or `null` on any
+ * failure (network error, non-2xx response, unparsable payload) so the
+ * caller falls back to the REST-derived result rather than assuming
+ * pending -- a GraphQL 4xx must never read as "pending".
+ */
+function fetchGraphqlRequestedReviewerLogins(owner, repo, prNumber) {
+  try {
+    const query = `
+      query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            reviewRequests(first: 20) {
+              nodes {
+                requestedReviewer {
+                  ... on Bot { login }
+                  ... on User { login }
+                  ... on Mannequin { login }
+                  ... on Team { slug }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+    const payload = ghGraphql(query, {
+      owner,
+      repo,
+      number: prNumber,
+    });
+    const nodes =
+      payload.data?.repository?.pullRequest?.reviewRequests?.nodes ?? [];
+    return nodes
+      .map((node) => String(node?.requestedReviewer?.login ?? ''))
+      .filter((login) => login !== '');
+  } catch {
+    return null;
+  }
 }

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1819,6 +1819,53 @@ export function computeCopilotPendingCoversHead(
   return headIndex !== -1 && requestIndex !== -1 && requestIndex > headIndex;
 }
 /**
+ * #2167: REST `requested_reviewers` can report empty (`{"users":[]}`) even
+ * when Copilot review is still genuinely outstanding for the current HEAD --
+ * observed on this source repository during PR #2158, where REST returned
+ * an empty list (HTTP 200, not a 5xx) while GraphQL `reviewRequests` still
+ * listed the primary bot and `computeCopilotPendingCoversHead` was already
+ * `true`. `isCopilotPending` alone is REST-only and misses that case;
+ * `evaluateAdvisoryWaitOutcome` / `evaluateAdvisoryWaitF3Outcome` and the
+ * AW3 table are unchanged -- callers pass this corrected boolean into
+ * `outcomeInput` exactly where the uncorrected `isCopilotPending` result
+ * used to go, so the corrected pending bit flows through the existing
+ * formulas unmodified.
+ *
+ * Precedence, cheapest signal first:
+ * 1. REST `requestedReviewers` already lists the primary bot -> `true`.
+ * 2. Already-fetched timeline evidence (`copilotPendingCoversHead`) shows
+ *    the primary bot is still requested as of a HEAD the latest Copilot
+ *    review does not cover -> `true`, no extra HTTP call needed.
+ * 3. `graphqlRequestedReviewerLogins` -- an optional, already-fetched
+ *    GraphQL `reviewRequests` login list; `null`/`undefined` means "not
+ *    attempted, or the attempt failed" -- lists the primary bot -> `true`.
+ * 4. Otherwise -> `false`, including when the optional GraphQL check was
+ *    skipped or failed: an absent or failed GraphQL result keeps the
+ *    REST-derived result rather than assuming pending.
+ */
+export function resolveCopilotPending(
+  requestedReviewers,
+  copilotPendingCoversHead,
+  lastCopilotCommit,
+  prHeadSha,
+  graphqlRequestedReviewerLogins,
+  primaryBotLogin = DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
+) {
+  if (isCopilotPending(requestedReviewers, primaryBotLogin)) {
+    return true;
+  }
+  if (copilotPendingCoversHead && lastCopilotCommit !== prHeadSha) {
+    return true;
+  }
+  if (graphqlRequestedReviewerLogins) {
+    return isCopilotPending(
+      [...graphqlRequestedReviewerLogins],
+      primaryBotLogin,
+    );
+  }
+  return false;
+}
+/**
  * True when the OPTIONAL secondary advisory bot has already been requested for
  * the current HEAD — i.e. a `review_requested` event for `secondaryBotLogin`
  * follows the current HEAD's `committed` event in the PR timeline. This is the
@@ -2103,6 +2150,7 @@ export function buildAdvisoryWaitSummary(
     requestedReviewers = [],
     timelineEvents = [],
     comments = [],
+    graphqlRequestedReviewerLogins = null,
   },
   options = {},
 ) {
@@ -2135,10 +2183,17 @@ export function buildAdvisoryWaitSummary(
     reviews,
     primaryBotLogin,
   );
-  const copilotPending = isCopilotPending(requestedReviewers, primaryBotLogin);
   const copilotPendingCoversHead = computeCopilotPendingCoversHead(
     timelineEvents,
     prHeadSha,
+    primaryBotLogin,
+  );
+  const copilotPending = resolveCopilotPending(
+    requestedReviewers,
+    copilotPendingCoversHead,
+    lastCopilotCommit,
+    prHeadSha,
+    graphqlRequestedReviewerLogins,
     primaryBotLogin,
   );
   const {

--- a/src/scripts/advisory-wait-state.mts
+++ b/src/scripts/advisory-wait-state.mts
@@ -861,13 +861,12 @@ function fetchGraphqlRequestedReviewerLogins(
       query($owner: String!, $repo: String!, $number: Int!) {
         repository(owner: $owner, name: $repo) {
           pullRequest(number: $number) {
-            reviewRequests(first: 20) {
+            reviewRequests(first: 100) {
               nodes {
                 requestedReviewer {
                   ... on Bot { login }
                   ... on User { login }
                   ... on Mannequin { login }
-                  ... on Team { slug }
                 }
               }
             }

--- a/src/scripts/advisory-wait-state.mts
+++ b/src/scripts/advisory-wait-state.mts
@@ -17,6 +17,7 @@ import {
 import { parseCliArgs } from './cli-args.mts';
 import {
   DEFAULT_GH_PAGINATED_TIMEOUT_MS,
+  ghGraphql,
   ghText,
   safeGhText,
 } from './gh-exec.mts';
@@ -26,6 +27,8 @@ import {
   buildAdvisoryWaitSummary,
   compareIsoTimestamps,
   computeCopilotPendingCoversHead,
+  findLastCopilotReviewCommit,
+  isCopilotPending,
   isValidIsoTimestamp,
   normalizeTrustedMarkerLogins,
   parseAdvisoryRecoveryComment,
@@ -622,13 +625,39 @@ function main(): void {
   const primaryBotLogin = readAdvisoryPrimaryBotLogin();
   const secondaryBotLogin = readAdvisorySecondaryBotLogin();
 
+  // #2167: only pay for the optional GraphQL reviewRequests call when the
+  // cheaper REST + timeline signals are both inconclusive -- mirrors
+  // resolveCopilotPending's own precedence (protocol-helpers.mts) so this
+  // pre-check and the pure function it feeds never disagree on when a
+  // GraphQL fallback is actually needed.
+  const restRequestedReviewers = requestedReviewers.users ?? [];
+  const restCopilotPending = isCopilotPending(
+    restRequestedReviewers,
+    primaryBotLogin,
+  );
+  const lastCopilotCommitForGraphqlGate = findLastCopilotReviewCommit(
+    reviews,
+    primaryBotLogin,
+  );
+  const copilotPendingCoversHeadForGraphqlGate =
+    computeCopilotPendingCoversHead(timelineEvents, prHeadSha, primaryBotLogin);
+  const graphqlRequestedReviewerLogins =
+    !restCopilotPending &&
+    !(
+      copilotPendingCoversHeadForGraphqlGate &&
+      lastCopilotCommitForGraphqlGate !== prHeadSha
+    )
+      ? fetchGraphqlRequestedReviewerLogins(owner, repo, args.prNumber)
+      : null;
+
   const summary = buildAdvisoryWaitSummary(
     {
       prHeadSha,
       reviews,
-      requestedReviewers: requestedReviewers.users ?? [],
+      requestedReviewers: restRequestedReviewers,
       timelineEvents,
       comments: comments.map(normalizeComment),
+      graphqlRequestedReviewerLogins,
     },
     {
       now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
@@ -807,4 +836,68 @@ function ghApiJson(
     );
   }
   return JSON.parse(ghText(args));
+}
+
+/**
+ * #2167: REST `requested_reviewers` can report empty even when Copilot
+ * review is still genuinely outstanding -- see `resolveCopilotPending`'s
+ * doc comment in protocol-helpers.mts for the observed incident this
+ * fixes. `main()` below calls this only when REST and already-fetched
+ * timeline evidence are both inconclusive, so this optional GraphQL call
+ * is skipped whenever a cheaper signal already resolves pending state.
+ *
+ * Returns the requested-reviewer login list on success, or `null` on any
+ * failure (network error, non-2xx response, unparsable payload) so the
+ * caller falls back to the REST-derived result rather than assuming
+ * pending -- a GraphQL 4xx must never read as "pending".
+ */
+function fetchGraphqlRequestedReviewerLogins(
+  owner: string,
+  repo: string,
+  prNumber: number,
+): string[] | null {
+  try {
+    const query = `
+      query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          pullRequest(number: $number) {
+            reviewRequests(first: 20) {
+              nodes {
+                requestedReviewer {
+                  ... on Bot { login }
+                  ... on User { login }
+                  ... on Mannequin { login }
+                  ... on Team { slug }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+    const payload = ghGraphql(query, {
+      owner,
+      repo,
+      number: prNumber,
+    }) as {
+      data?: {
+        repository?: {
+          pullRequest?: {
+            reviewRequests?: {
+              nodes?: Array<{
+                requestedReviewer?: { login?: string | null } | null;
+              }> | null;
+            } | null;
+          } | null;
+        } | null;
+      };
+    };
+    const nodes =
+      payload.data?.repository?.pullRequest?.reviewRequests?.nodes ?? [];
+    return nodes
+      .map((node) => String(node?.requestedReviewer?.login ?? ''))
+      .filter((login) => login !== '');
+  } catch {
+    return null;
+  }
 }

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2616,6 +2616,54 @@ export function computeCopilotPendingCoversHead(
 }
 
 /**
+ * #2167: REST `requested_reviewers` can report empty (`{"users":[]}`) even
+ * when Copilot review is still genuinely outstanding for the current HEAD --
+ * observed on this source repository during PR #2158, where REST returned
+ * an empty list (HTTP 200, not a 5xx) while GraphQL `reviewRequests` still
+ * listed the primary bot and `computeCopilotPendingCoversHead` was already
+ * `true`. `isCopilotPending` alone is REST-only and misses that case;
+ * `evaluateAdvisoryWaitOutcome` / `evaluateAdvisoryWaitF3Outcome` and the
+ * AW3 table are unchanged -- callers pass this corrected boolean into
+ * `outcomeInput` exactly where the uncorrected `isCopilotPending` result
+ * used to go, so the corrected pending bit flows through the existing
+ * formulas unmodified.
+ *
+ * Precedence, cheapest signal first:
+ * 1. REST `requestedReviewers` already lists the primary bot -> `true`.
+ * 2. Already-fetched timeline evidence (`copilotPendingCoversHead`) shows
+ *    the primary bot is still requested as of a HEAD the latest Copilot
+ *    review does not cover -> `true`, no extra HTTP call needed.
+ * 3. `graphqlRequestedReviewerLogins` -- an optional, already-fetched
+ *    GraphQL `reviewRequests` login list; `null`/`undefined` means "not
+ *    attempted, or the attempt failed" -- lists the primary bot -> `true`.
+ * 4. Otherwise -> `false`, including when the optional GraphQL check was
+ *    skipped or failed: an absent or failed GraphQL result keeps the
+ *    REST-derived result rather than assuming pending.
+ */
+export function resolveCopilotPending(
+  requestedReviewers: RequestedReviewerLike[],
+  copilotPendingCoversHead: boolean,
+  lastCopilotCommit: string,
+  prHeadSha: string,
+  graphqlRequestedReviewerLogins?: readonly string[] | null,
+  primaryBotLogin: string = DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
+): boolean {
+  if (isCopilotPending(requestedReviewers, primaryBotLogin)) {
+    return true;
+  }
+  if (copilotPendingCoversHead && lastCopilotCommit !== prHeadSha) {
+    return true;
+  }
+  if (graphqlRequestedReviewerLogins) {
+    return isCopilotPending(
+      [...graphqlRequestedReviewerLogins],
+      primaryBotLogin,
+    );
+  }
+  return false;
+}
+
+/**
  * True when the OPTIONAL secondary advisory bot has already been requested for
  * the current HEAD — i.e. a `review_requested` event for `secondaryBotLogin`
  * follows the current HEAD's `committed` event in the PR timeline. This is the
@@ -2948,12 +2996,18 @@ export function buildAdvisoryWaitSummary(
     requestedReviewers = [],
     timelineEvents = [],
     comments = [],
+    graphqlRequestedReviewerLogins = null,
   }: {
     prHeadSha: string;
     reviews?: ReviewLike[];
     requestedReviewers?: RequestedReviewerLike[];
     timelineEvents?: TimelineEventLike[];
     comments?: CommentLike[];
+    /** #2167: optional, already-fetched GraphQL `reviewRequests` login
+     * list, consulted only when REST and timeline evidence are both
+     * inconclusive; `null` (the default) means "not attempted, or the
+     * attempt failed" -- see {@link resolveCopilotPending}. */
+    graphqlRequestedReviewerLogins?: readonly string[] | null;
   },
   options: {
     now?: string;
@@ -3000,10 +3054,17 @@ export function buildAdvisoryWaitSummary(
     reviews,
     primaryBotLogin,
   );
-  const copilotPending = isCopilotPending(requestedReviewers, primaryBotLogin);
   const copilotPendingCoversHead = computeCopilotPendingCoversHead(
     timelineEvents,
     prHeadSha,
+    primaryBotLogin,
+  );
+  const copilotPending = resolveCopilotPending(
+    requestedReviewers,
+    copilotPendingCoversHead,
+    lastCopilotCommit,
+    prHeadSha,
+    graphqlRequestedReviewerLogins,
     primaryBotLogin,
   );
   const {

--- a/tests/advisory-wait.test.mts
+++ b/tests/advisory-wait.test.mts
@@ -26,6 +26,7 @@ import {
   computeSecondaryRequestedForHead,
   isCopilotReviewerLogin,
   operationalMarkerPrefix,
+  resolveCopilotPending,
   unsafeTextReason,
 } from '../src/scripts/protocol-helpers.mts';
 import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
@@ -982,6 +983,149 @@ test('advisory wait summary resolves coverage against a configured primary bot',
   });
   assert.equal(defaultBot.lastCopilotCommit, 'c'.repeat(40));
   assert.equal(defaultBot.copilotPending, false);
+});
+
+// #2167: REST `requested_reviewers` can report empty while Copilot review
+// is still genuinely outstanding for the current HEAD (observed on this
+// source repository during PR #2158 -- REST returned `{"users":[]}` while
+// GraphQL `reviewRequests` still listed the primary bot and the timeline
+// already proved `copilotPendingCoversHead: true`). These cases exercise
+// `resolveCopilotPending`'s precedence directly, and via
+// `buildAdvisoryWaitSummary`'s `graphqlRequestedReviewerLogins` input.
+test('resolveCopilotPending: REST empty, timeline coverage true -> pending true without any GraphQL data', () => {
+  assert.equal(
+    resolveCopilotPending(
+      [],
+      /* copilotPendingCoversHead */ true,
+      /* lastCopilotCommit */ 'a'.repeat(40),
+      /* prHeadSha */ 'b'.repeat(40),
+      /* graphqlRequestedReviewerLogins */ null,
+    ),
+    true,
+  );
+});
+
+test('resolveCopilotPending: REST empty, timeline inconclusive, GraphQL lists the bot -> pending true', () => {
+  assert.equal(
+    resolveCopilotPending(
+      [],
+      /* copilotPendingCoversHead */ false,
+      /* lastCopilotCommit */ '',
+      /* prHeadSha */ 'b'.repeat(40),
+      /* graphqlRequestedReviewerLogins */ ['copilot-pull-request-reviewer'],
+    ),
+    true,
+  );
+});
+
+test('resolveCopilotPending: REST empty, timeline inconclusive, GraphQL empty -> pending false', () => {
+  assert.equal(
+    resolveCopilotPending(
+      [],
+      /* copilotPendingCoversHead */ false,
+      /* lastCopilotCommit */ '',
+      /* prHeadSha */ 'b'.repeat(40),
+      /* graphqlRequestedReviewerLogins */ [],
+    ),
+    false,
+  );
+});
+
+test('resolveCopilotPending: REST empty, timeline inconclusive, GraphQL failed (null) -> keeps the REST result (false)', () => {
+  // A `null` graphqlRequestedReviewerLogins means "not attempted, or the
+  // attempt failed" -- a GraphQL 4xx (or any other failure) must never be
+  // read as pending.
+  assert.equal(
+    resolveCopilotPending(
+      [],
+      /* copilotPendingCoversHead */ false,
+      /* lastCopilotCommit */ '',
+      /* prHeadSha */ 'b'.repeat(40),
+      /* graphqlRequestedReviewerLogins */ null,
+    ),
+    false,
+  );
+});
+
+test('resolveCopilotPending: REST already pending short-circuits before consulting timeline or GraphQL', () => {
+  assert.equal(
+    resolveCopilotPending(
+      [{ login: 'copilot-pull-request-reviewer' }],
+      /* copilotPendingCoversHead */ false,
+      /* lastCopilotCommit */ 'a'.repeat(40),
+      /* prHeadSha */ 'a'.repeat(40),
+      /* graphqlRequestedReviewerLogins */ null,
+    ),
+    true,
+  );
+});
+
+test('buildAdvisoryWaitSummary: empty REST requestedReviewers plus timeline coverage yields copilotPending true without any GraphQL evidence', () => {
+  // Reproduces the observed #2158 incident end-to-end through the public
+  // summary function: REST requested_reviewers is empty, but the timeline
+  // already proves the primary bot was re-requested after the current
+  // HEAD's own commit event, and no prior Copilot review covers this HEAD.
+  const headSha = 'e'.repeat(40);
+  const priorHeadSha = 'f'.repeat(40);
+  const summary = buildAdvisoryWaitSummary(
+    {
+      prHeadSha: headSha,
+      reviews: [
+        {
+          user: { login: 'copilot-pull-request-reviewer' },
+          submitted_at: '2026-08-18T23:00:00Z',
+          commit_id: priorHeadSha,
+        },
+      ],
+      requestedReviewers: [],
+      timelineEvents: [
+        { event: 'committed', sha: priorHeadSha },
+        { event: 'committed', sha: headSha },
+        {
+          event: 'review_requested',
+          requested_reviewer: { login: 'copilot-pull-request-reviewer' },
+        },
+      ],
+      comments: [],
+      graphqlRequestedReviewerLogins: null,
+    },
+    { now: '2026-08-19T00:00:00Z' },
+  );
+  assert.equal(summary.lastCopilotCommit, priorHeadSha);
+  assert.equal(summary.copilotPendingCoversHead, true);
+  assert.equal(summary.copilotPending, true);
+});
+
+test('buildAdvisoryWaitSummary: empty REST requestedReviewers plus a GraphQL-listed bot yields copilotPending true', () => {
+  const headSha = 'd'.repeat(40);
+  const summary = buildAdvisoryWaitSummary(
+    {
+      prHeadSha: headSha,
+      reviews: [],
+      requestedReviewers: [],
+      timelineEvents: [],
+      comments: [],
+      graphqlRequestedReviewerLogins: ['copilot-pull-request-reviewer'],
+    },
+    { now: '2026-08-19T00:00:00Z' },
+  );
+  assert.equal(summary.copilotPending, true);
+});
+
+test('buildAdvisoryWaitSummary: empty REST requestedReviewers and no GraphQL evidence yields copilotPending false', () => {
+  const headSha = 'd'.repeat(40);
+  const summary = buildAdvisoryWaitSummary(
+    {
+      prHeadSha: headSha,
+      reviews: [],
+      requestedReviewers: [],
+      timelineEvents: [],
+      comments: [],
+      graphqlRequestedReviewerLogins: null,
+    },
+    { now: '2026-08-19T00:00:00Z' },
+  );
+  assert.equal(summary.copilotPending, false);
 });
 
 test('primary advisory bot login resolves defaults, overrides, and fail-safe fallbacks', () => {


### PR DESCRIPTION
# Summary

REST `requested_reviewers` can report empty (`{"users":[]}`, HTTP 200)
while Copilot review is still genuinely outstanding for the current
PR HEAD — observed on this source repository during PR #2158, where
GraphQL `reviewRequests` still listed the primary bot and timeline
evidence (`copilotPendingCoversHead`) already proved coverage.
`isCopilotPending` was REST-only and missed this, degrading E14
window selection (a false-idle pending bit uses the shorter settled
window instead of the recovery path).

Adds `resolveCopilotPending` (`protocol-helpers.mts`), which layers
two extra signals onto the REST check before falling back to `false`:
already-fetched timeline coverage (no new HTTP call, checked first),
then an optional GraphQL `reviewRequests` result the caller may
supply. A failed or skipped GraphQL attempt keeps the REST-derived
result rather than assuming pending — a GraphQL 4xx never reads as
pending. `buildAdvisoryWaitSummary` now calls this instead of the
bare REST check, via a new optional `graphqlRequestedReviewerLogins`
input.

`advisory-wait-state.mts`'s `main()` only pays for the optional
GraphQL call when REST and timeline coverage are both inconclusive
(mirrors `resolveCopilotPending`'s own precedence, duplicated
deliberately so the pure function stays fully unit-testable without
`gh` process stubbing — see inline comment).

`evaluateAdvisoryWaitOutcome`, `evaluateAdvisoryWaitF3Outcome`, the
AW3 table, and window constants are all unchanged, per the issue's
explicit scope — only the `copilotPending` bit feeding into them is
corrected.

An independent critique pass (spawned as part of this PR's C1 review)
found and fixed one biome formatting issue and added a `... on Team`
fragment to the GraphQL query for completeness; findings are recorded
on the linked issue.

## Linked issue

Closes #2167

## Follow-up issues (if any)

- [ ] none — one known, out-of-scope limitation is flagged on the
      issue instead of filed separately: `computeCopilotPendingCoversHead`
      has no awareness of a `review_request_removed` timeline event, so a
      Copilot request that was explicitly cancelled after being made would
      still read as "covers HEAD". This is a pre-existing property of that
      function (already load-bearing today in `evaluateAdvisoryWaitOutcome`'s
      `RECOVERY_NEEDED` branch whenever REST truthfully reports pending);
      this fix only widens which paths can reach that pre-existing behavior
      (REST-empty cases now can too) without changing what happens once
      reached. See the issue comment for the full reasoning.

## Background / rationale (if material)

See Summary above; the issue body's own Background/Proposed
change/Out of scope sections were used as the acceptance bar
throughout.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of pending Copilot reviews by combining available review-request and activity signals.
  - Added a fallback check when existing information is inconclusive, reducing incorrect wait-state results.
  - Preserved safe behavior when fallback information is unavailable or cannot be retrieved.
  - Improved advisory wait summaries so they more accurately reflect whether a Copilot review is still pending.

- **Tests**
  - Added coverage for review-status precedence, fallback failures, and already-pending scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->