### PR TITLE
docs(claim): warn orchestrator delegation against context inheritance

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -459,6 +459,18 @@ later forced-handoff collision the orchestrator never saw) means the
 worker is no longer the winning activation — treat that the same as any
 other lost claim.
 
+**State the worker role explicitly when the delegate inherits full
+context.** Some delegation mechanisms give the worker the
+orchestrator's own complete conversation context instead of a clean
+slate limited to the brief. There, the worker can carry over the
+orchestrator's own framing — mistaking itself for the session that
+launched several workers and is waiting on their replies — instead of
+recognizing the brief reassigns it to a single-issue worker role. The
+delegation brief must state explicitly that the delegate is the sole
+worker for the named issue, that no peer workers exist for it to
+coordinate with or wait on, and that it must perform the implementation
+work itself rather than re-delegate or wait for a reply (#2179).
+
 ### Hide displaced claim chain on takeover
 
 When the verified new claim was posted with `supersedes: <prior-id>`

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -454,6 +454,18 @@ later forced-handoff collision the orchestrator never saw) means the
 worker is no longer the winning activation — treat that the same as any
 other lost claim.
 
+**State the worker role explicitly when the delegate inherits full
+context.** Some delegation mechanisms give the worker the
+orchestrator's own complete conversation context instead of a clean
+slate limited to the brief. There, the worker can carry over the
+orchestrator's own framing — mistaking itself for the session that
+launched several workers and is waiting on their replies — instead of
+recognizing the brief reassigns it to a single-issue worker role. The
+delegation brief must state explicitly that the delegate is the sole
+worker for the named issue, that no peer workers exist for it to
+coordinate with or wait on, and that it must perform the implementation
+work itself rather than re-delegate or wait for a reply (#2179).
+
 ### Hide displaced claim chain on takeover
 
 When the verified new claim was posted with `supersedes: <prior-id>`


### PR DESCRIPTION
# Summary

Add a caution to `idd-claim.instructions.md`'s "Orchestrator delegation" section: when the delegation mechanism gives a subagent worker the orchestrator's own full conversation context instead of a clean slate limited to the brief, the worker can carry over the orchestrator's own "waiting on peer workers" framing instead of recognizing it was reassigned to a single-issue worker role. The delegation brief must now state explicitly that the delegate is the sole worker for the named issue, that no peers exist to coordinate with or wait on, and that it must perform the implementation work itself.

## Linked issue

Closes #2179

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Observed directly in this repository (2026-08-19): a session delegating three forced-handoff-recovered issues to three context-inheriting subagents saw two of three independently resume the orchestrator's own "waiting on workers" narrative instead of starting the assigned work, until an explicit follow-up message corrected each one. Given `bundle-discovery`'s tight context-budget headroom (95.13% -> 95.84% utilization after this change, against a 98% hard ceiling), the added paragraph is kept short and cites the issue number rather than the full incident narrative, per `docs/idd-design-rationale.md`'s "Cite the observed incident" exemption for new `.github/instructions/` passages in budget-constrained bundles.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (ran `pnpm run lint:minimum`)
- [x] `pnpm test` (3741 tests pass)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (ran `node scripts/sync-docs.mjs --apply`; mirror in sync)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
