### PR TITLE
fix(resume-claim-routing): surface forced-handoff-recovery eligibility without --claim-id

### DIFF
--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -144,6 +144,12 @@ authoritative replacement:
   (`cold-recovery-activation-nonce-collision`: no local nonce and 2+
   trusted activation-nonce markers — #1529).
 
+A `non_inheritable`/`stop` verdict whose `evidence.forced_handoff` is
+non-null (#2178) means a valid successor pair already exists — retry
+with `--claim-id <evidence.forced_handoff.new_claim_id>` before
+concluding the claim is not inheritable; see
+`docs/idd-helper-scripts.md`'s Resume claim and route evidence section.
+
 If helper runtime is absent, helper output is invalid, or helper evidence
 disagrees with live GitHub state, use the written table below and treat
 it as authoritative.

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1340,6 +1340,17 @@ Interpretation rules:
   a mismatch routes `state`/`reason` to `disputed` /
   `activation-nonce-mismatch` instead of `already_owned`. Omit it (or leave
   the claim-id's nonce not posted) to skip the comparison unchanged.
+- `evidence.forced_handoff` (kurone-kito/idd-skill#2178): populated on
+  **any** call, including a bare `--issue` call with no `--claim-id`,
+  whenever a trusted, rule-7-valid `forced-handoff` marker's successor
+  pair (`{old_agent_id, old_claim_id, new_agent_id, new_claim_id,
+  forced_by, timestamp}`, `timestamp` the transferring comment's GitHub
+  `created_at`) matches the resolved active claim; `null` otherwise. A
+  bare `--issue` call whose `evidence.forced_handoff` is non-null but
+  whose `state`/`action` still reads `non_inheritable`/`stop` should
+  retry with `--claim-id <evidence.forced_handoff.new_claim_id>` to
+  check adoption eligibility — that second call is what can turn the
+  verdict into `already_owned`/`keep`.
 
 - Step 3 route command:
   `node scripts/resume-route-selection.mjs --issue <issue-number>`

--- a/idd-template/.github/instructions/idd-resume.instructions.md
+++ b/idd-template/.github/instructions/idd-resume.instructions.md
@@ -139,6 +139,12 @@ authoritative replacement:
   (`cold-recovery-activation-nonce-collision`: no local nonce and 2+
   trusted activation-nonce markers — #1529).
 
+A `non_inheritable`/`stop` verdict whose `evidence.forced_handoff` is
+non-null (#2178) means a valid successor pair already exists — retry
+with `--claim-id <evidence.forced_handoff.new_claim_id>` before
+concluding the claim is not inheritable; see
+`docs/idd-helper-scripts.md`'s Resume claim and route evidence section.
+
 If helper runtime is absent, helper output is invalid, or helper evidence
 disagrees with live GitHub state, use the written table below and treat
 it as authoritative.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1340,6 +1340,17 @@ Interpretation rules:
   a mismatch routes `state`/`reason` to `disputed` /
   `activation-nonce-mismatch` instead of `already_owned`. Omit it (or leave
   the claim-id's nonce not posted) to skip the comparison unchanged.
+- `evidence.forced_handoff` (kurone-kito/idd-skill#2178): populated on
+  **any** call, including a bare `--issue` call with no `--claim-id`,
+  whenever a trusted, rule-7-valid `forced-handoff` marker's successor
+  pair (`{old_agent_id, old_claim_id, new_agent_id, new_claim_id,
+  forced_by, timestamp}`, `timestamp` the transferring comment's GitHub
+  `created_at`) matches the resolved active claim; `null` otherwise. A
+  bare `--issue` call whose `evidence.forced_handoff` is non-null but
+  whose `state`/`action` still reads `non_inheritable`/`stop` should
+  retry with `--claim-id <evidence.forced_handoff.new_claim_id>` to
+  check adoption eligibility — that second call is what can turn the
+  verdict into `already_owned`/`keep`.
 
 - Step 3 route command:
   `node scripts/resume-route-selection.mjs --issue <issue-number>`

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -5620,9 +5620,14 @@ function isStrictlyBeforeIso(left, right) {
   }
   return leftTime < rightTime;
 }
-export function resolveActiveClaim(events, isTrustedAuthor = () => true) {
-  const options = normalizeClaimResolutionOptions(isTrustedAuthor);
-  const orderedEvents = events
+/**
+ * Chronological ordering `resolveActiveClaim` and
+ * `resolveActiveClaimWithForcedHandoffTrace` both reduce over: by GitHub
+ * `created_at` second, tie-broken by claim-id (same-second contenders),
+ * then by sub-second time, then by original array index.
+ */
+function sortClaimEvents(events) {
+  return events
     .map((event, index) => {
       const claim = parseClaimComment(event.body ?? '', event.createdAt ?? '');
       return {
@@ -5666,11 +5671,61 @@ export function resolveActiveClaim(events, isTrustedAuthor = () => true) {
       return left.index - right.index;
     })
     .map(({ event }) => event);
+}
+/**
+ * Same reduction as {@link resolveActiveClaim}, but also tracks which
+ * specific forced-handoff marker (if any) produced the final active
+ * claim's identity. `resolveActiveClaim`'s state machine has no memory of
+ * *why* the active claim changed, so a caller that needs forced-handoff
+ * provenance (`resume-claim-routing.mts`'s `evidence.forced_handoff`,
+ * kurone-kito/idd-skill#2178) cannot reconstruct it safely by
+ * independently re-scanning events for a `new*`-field match against the
+ * final active claim: a stale or never-applied forced-handoff marker
+ * whose `new*` fields merely coincide with the real active claim's
+ * identity (for example a duplicate/retried handoff attempt posted after
+ * a first one already succeeded) would misattribute the wrong `old*`
+ * fields as evidence. Replaying the identical single-pass reduction here
+ * -- the one place that already knows the true before/after state at each
+ * step -- is what answers "which marker actually caused this transition"
+ * correctly.
+ */
+export function resolveActiveClaimWithForcedHandoffTrace(
+  events,
+  isTrustedAuthor = () => true,
+) {
+  const options = normalizeClaimResolutionOptions(isTrustedAuthor);
+  const orderedEvents = sortClaimEvents(events);
   let active = null;
+  let appliedForcedHandoff = null;
   for (const event of orderedEvents) {
-    active = applyClaimEvent(active, event, options);
+    const previous = active;
+    const next = applyClaimEvent(previous, event, options);
+    const identityChanged =
+      (next?.claimId ?? null) !== (previous?.claimId ?? null) ||
+      (next?.agentId ?? null) !== (previous?.agentId ?? null);
+    if (identityChanged) {
+      const candidate = previous
+        ? parseForcedHandoffComment(event.body ?? '', event.createdAt ?? '')
+        : null;
+      appliedForcedHandoff =
+        candidate &&
+        next &&
+        previous &&
+        candidate.oldAgentId === previous.agentId &&
+        candidate.oldClaimId === previous.claimId &&
+        candidate.branch === previous.branch &&
+        candidate.newAgentId === next.agentId &&
+        candidate.newClaimId === next.claimId
+          ? candidate
+          : null;
+    }
+    active = next;
   }
-  return active;
+  return { activeClaim: active, appliedForcedHandoff };
+}
+export function resolveActiveClaim(events, isTrustedAuthor = () => true) {
+  return resolveActiveClaimWithForcedHandoffTrace(events, isTrustedAuthor)
+    .activeClaim;
 }
 export function applyClaimEvent(activeClaim, event, options = {}) {
   const normalizedOptions = normalizeClaimResolutionOptions(options);

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -263,7 +263,7 @@ function toForcedHandoffEvidence(applied) {
     new_agent_id: applied.newAgentId,
     new_claim_id: applied.newClaimId,
     forced_by: applied.forcedBy,
-    timestamp: applied.createdAt ?? '',
+    timestamp: applied.createdAt ?? null,
   };
 }
 /**

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -12,7 +12,10 @@ import {
   resolveViewerLogin,
 } from './gh-exec.mjs';
 import { loadPolicyConfig } from './idd-config.mjs';
-import { listActivationNonces } from './marker-helpers.mjs';
+import {
+  listActivationNonces,
+  parseForcedHandoffComment,
+} from './marker-helpers.mjs';
 import { normalizePolicyConfig } from './policy-helpers.mjs';
 import {
   buildForcedHandoffEnableGate,
@@ -115,6 +118,13 @@ export function evaluateResumeClaimRouting(input, options = {}) {
   const activationNonceWinner =
     activationNonces.length > 0 ? activationNonces[0] : null;
   const nonceChecked = normalizeToken(input.nonce);
+  const forcedHandoffApplied =
+    state.activeClaim && state.mode === 'new-format'
+      ? findAppliedForcedHandoff(events, state.activeClaim, {
+          isForcedHandoffEnabled,
+          isAuthorizedForcedHandoff,
+        })
+      : null;
   const warnings = [...state.warnings];
   let routeState = 'unclaimed';
   let action = 're_claim';
@@ -248,7 +258,73 @@ export function evaluateResumeClaimRouting(input, options = {}) {
       later_competing_claim: laterCompetingClaim,
       activation_nonce_winner: activationNonceWinner,
       activation_nonce_count: activationNonces.length,
+      forced_handoff: forcedHandoffApplied,
     },
+  };
+}
+/**
+ * Find the trusted, rule-7-valid `forced-handoff` marker (if any) whose
+ * transfer produced `activeClaim` — i.e. `newAgentId`/`newClaimId`/`branch`
+ * match `activeClaim` exactly, and the same enable/author-binding/authority
+ * checks `applyClaimEvent` requires to honor a handoff all pass
+ * independently here. A fresh `claimId` is effectively unique per
+ * activation, so at most one trusted marker can validly target it; on the
+ * rare chance more than one candidate passes, the earliest by GitHub
+ * `created_at` wins, mirroring the chronological reduction
+ * `resolveActiveClaim` itself performs.
+ */
+function findAppliedForcedHandoff(events, activeClaim, options) {
+  const candidates = events
+    .map((event) => ({
+      event,
+      forcedHandoff: parseForcedHandoffComment(
+        event.body ?? '',
+        event.createdAt ?? '',
+      ),
+    }))
+    .filter((entry) => entry.forcedHandoff !== null)
+    .filter(
+      ({ forcedHandoff }) =>
+        forcedHandoff.newAgentId === activeClaim.agentId &&
+        forcedHandoff.newClaimId === activeClaim.claimId &&
+        forcedHandoff.branch === activeClaim.branch,
+    )
+    .filter(({ event, forcedHandoff }) => {
+      if (!options.isForcedHandoffEnabled(forcedHandoff, event)) {
+        return false;
+      }
+      const authorLogin = String(event.author?.login ?? '')
+        .trim()
+        .toLowerCase();
+      const forcedByLower = String(forcedHandoff.forcedBy ?? '')
+        .trim()
+        .toLowerCase();
+      if (!authorLogin || authorLogin !== forcedByLower) {
+        return false;
+      }
+      return options.isAuthorizedForcedHandoff(
+        forcedHandoff.forcedBy,
+        forcedHandoff,
+        event,
+      );
+    })
+    .sort((left, right) =>
+      compareIso(
+        left.forcedHandoff.createdAt ?? left.event.createdAt,
+        right.forcedHandoff.createdAt ?? right.event.createdAt,
+      ),
+    );
+  if (candidates.length === 0) {
+    return null;
+  }
+  const winner = candidates[0].forcedHandoff;
+  return {
+    old_agent_id: winner.oldAgentId,
+    old_claim_id: winner.oldClaimId,
+    new_agent_id: winner.newAgentId,
+    new_claim_id: winner.newClaimId,
+    forced_by: winner.forcedBy,
+    timestamp: winner.createdAt ?? '',
   };
 }
 /**

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -12,10 +12,7 @@ import {
   resolveViewerLogin,
 } from './gh-exec.mjs';
 import { loadPolicyConfig } from './idd-config.mjs';
-import {
-  listActivationNonces,
-  parseForcedHandoffComment,
-} from './marker-helpers.mjs';
+import { listActivationNonces } from './marker-helpers.mjs';
 import { normalizePolicyConfig } from './policy-helpers.mjs';
 import {
   buildForcedHandoffEnableGate,
@@ -24,7 +21,7 @@ import {
   normalizeLinkedPrReference,
   parseClaimComment,
   parseReleaseComment,
-  resolveActiveClaim,
+  resolveActiveClaimWithForcedHandoffTrace,
 } from './protocol-helpers.mjs';
 
 const LEGACY_CLAIM_PATTERN =
@@ -118,13 +115,6 @@ export function evaluateResumeClaimRouting(input, options = {}) {
   const activationNonceWinner =
     activationNonces.length > 0 ? activationNonces[0] : null;
   const nonceChecked = normalizeToken(input.nonce);
-  const forcedHandoffApplied =
-    state.activeClaim && state.mode === 'new-format'
-      ? findAppliedForcedHandoff(events, state.activeClaim, {
-          isForcedHandoffEnabled,
-          isAuthorizedForcedHandoff,
-        })
-      : null;
   const warnings = [...state.warnings];
   let routeState = 'unclaimed';
   let action = 're_claim';
@@ -258,73 +248,22 @@ export function evaluateResumeClaimRouting(input, options = {}) {
       later_competing_claim: laterCompetingClaim,
       activation_nonce_winner: activationNonceWinner,
       activation_nonce_count: activationNonces.length,
-      forced_handoff: forcedHandoffApplied,
+      forced_handoff: toForcedHandoffEvidence(state.appliedForcedHandoff),
     },
   };
 }
-/**
- * Find the trusted, rule-7-valid `forced-handoff` marker (if any) whose
- * transfer produced `activeClaim` — i.e. `newAgentId`/`newClaimId`/`branch`
- * match `activeClaim` exactly, and the same enable/author-binding/authority
- * checks `applyClaimEvent` requires to honor a handoff all pass
- * independently here. A fresh `claimId` is effectively unique per
- * activation, so at most one trusted marker can validly target it; on the
- * rare chance more than one candidate passes, the earliest by GitHub
- * `created_at` wins, mirroring the chronological reduction
- * `resolveActiveClaim` itself performs.
- */
-function findAppliedForcedHandoff(events, activeClaim, options) {
-  const candidates = events
-    .map((event) => ({
-      event,
-      forcedHandoff: parseForcedHandoffComment(
-        event.body ?? '',
-        event.createdAt ?? '',
-      ),
-    }))
-    .filter((entry) => entry.forcedHandoff !== null)
-    .filter(
-      ({ forcedHandoff }) =>
-        forcedHandoff.newAgentId === activeClaim.agentId &&
-        forcedHandoff.newClaimId === activeClaim.claimId &&
-        forcedHandoff.branch === activeClaim.branch,
-    )
-    .filter(({ event, forcedHandoff }) => {
-      if (!options.isForcedHandoffEnabled(forcedHandoff, event)) {
-        return false;
-      }
-      const authorLogin = String(event.author?.login ?? '')
-        .trim()
-        .toLowerCase();
-      const forcedByLower = String(forcedHandoff.forcedBy ?? '')
-        .trim()
-        .toLowerCase();
-      if (!authorLogin || authorLogin !== forcedByLower) {
-        return false;
-      }
-      return options.isAuthorizedForcedHandoff(
-        forcedHandoff.forcedBy,
-        forcedHandoff,
-        event,
-      );
-    })
-    .sort((left, right) =>
-      compareIso(
-        left.forcedHandoff.createdAt ?? left.event.createdAt,
-        right.forcedHandoff.createdAt ?? right.event.createdAt,
-      ),
-    );
-  if (candidates.length === 0) {
+/** Render {@link ActiveClaimResolution.appliedForcedHandoff} for JSON output. */
+function toForcedHandoffEvidence(applied) {
+  if (!applied) {
     return null;
   }
-  const winner = candidates[0].forcedHandoff;
   return {
-    old_agent_id: winner.oldAgentId,
-    old_claim_id: winner.oldClaimId,
-    new_agent_id: winner.newAgentId,
-    new_claim_id: winner.newClaimId,
-    forced_by: winner.forcedBy,
-    timestamp: winner.createdAt ?? '',
+    old_agent_id: applied.oldAgentId,
+    old_claim_id: applied.oldClaimId,
+    new_agent_id: applied.newAgentId,
+    new_claim_id: applied.newClaimId,
+    forced_by: applied.forcedBy,
+    timestamp: applied.createdAt ?? '',
   };
 }
 /**
@@ -524,8 +463,8 @@ function resolveClaimState(events, nowIso, staleAgeMs, options = {}) {
       );
     }
   };
-  const activeClaim = hasNewFormatClaim
-    ? resolveActiveClaim(events, {
+  const claimTrace = hasNewFormatClaim
+    ? resolveActiveClaimWithForcedHandoffTrace(events, {
         isTrustedAuthor: () => true, // events were already filtered by caller
         isForcedHandoffEnabled,
         isAuthorizedForcedHandoff,
@@ -548,7 +487,8 @@ function resolveClaimState(events, nowIso, staleAgeMs, options = {}) {
   if (hasNewFormatClaim) {
     return {
       mode: 'new-format',
-      activeClaim,
+      activeClaim: claimTrace?.activeClaim ?? null,
+      appliedForcedHandoff: claimTrace?.appliedForcedHandoff ?? null,
       warnings,
       legacyClaim: null,
       legacyReleased: false,
@@ -559,6 +499,7 @@ function resolveClaimState(events, nowIso, staleAgeMs, options = {}) {
   return {
     mode: 'legacy-only',
     activeClaim: null,
+    appliedForcedHandoff: null,
     warnings,
     legacyClaim: legacy.claim,
     legacyReleased: legacy.released,

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -7093,13 +7093,14 @@ function isStrictlyBeforeIso(
   return leftTime < rightTime;
 }
 
-export function resolveActiveClaim(
-  events: CommentLike[],
-  isTrustedAuthor: ClaimResolutionOptions | ((login: string) => boolean) = () =>
-    true,
-): ParsedClaimMarker | null {
-  const options = normalizeClaimResolutionOptions(isTrustedAuthor);
-  const orderedEvents = events
+/**
+ * Chronological ordering `resolveActiveClaim` and
+ * `resolveActiveClaimWithForcedHandoffTrace` both reduce over: by GitHub
+ * `created_at` second, tie-broken by claim-id (same-second contenders),
+ * then by sub-second time, then by original array index.
+ */
+function sortClaimEvents(events: CommentLike[]): CommentLike[] {
+  return events
     .map((event, index) => {
       const claim = parseClaimComment(event.body ?? '', event.createdAt ?? '');
       return {
@@ -7146,12 +7147,82 @@ export function resolveActiveClaim(
       return left.index - right.index;
     })
     .map(({ event }) => event);
+}
+
+/** Result of {@link resolveActiveClaimWithForcedHandoffTrace}. */
+export interface ActiveClaimResolution {
+  activeClaim: ParsedClaimMarker | null;
+  /**
+   * The specific trusted, rule-7-valid `forced-handoff` marker whose
+   * application produced `activeClaim`'s current identity, or `null` when
+   * the latest claim-identity change was not a forced handoff (fresh
+   * claim, stale takeover) or no claim-identity change occurred at all
+   * (e.g. only heartbeats followed the last transition).
+   */
+  appliedForcedHandoff: ParsedForcedHandoffMarker | null;
+}
+
+/**
+ * Same reduction as {@link resolveActiveClaim}, but also tracks which
+ * specific forced-handoff marker (if any) produced the final active
+ * claim's identity. `resolveActiveClaim`'s state machine has no memory of
+ * *why* the active claim changed, so a caller that needs forced-handoff
+ * provenance (`resume-claim-routing.mts`'s `evidence.forced_handoff`,
+ * kurone-kito/idd-skill#2178) cannot reconstruct it safely by
+ * independently re-scanning events for a `new*`-field match against the
+ * final active claim: a stale or never-applied forced-handoff marker
+ * whose `new*` fields merely coincide with the real active claim's
+ * identity (for example a duplicate/retried handoff attempt posted after
+ * a first one already succeeded) would misattribute the wrong `old*`
+ * fields as evidence. Replaying the identical single-pass reduction here
+ * -- the one place that already knows the true before/after state at each
+ * step -- is what answers "which marker actually caused this transition"
+ * correctly.
+ */
+export function resolveActiveClaimWithForcedHandoffTrace(
+  events: CommentLike[],
+  isTrustedAuthor: ClaimResolutionOptions | ((login: string) => boolean) = () =>
+    true,
+): ActiveClaimResolution {
+  const options = normalizeClaimResolutionOptions(isTrustedAuthor);
+  const orderedEvents = sortClaimEvents(events);
 
   let active: ParsedClaimMarker | null = null;
+  let appliedForcedHandoff: ParsedForcedHandoffMarker | null = null;
   for (const event of orderedEvents) {
-    active = applyClaimEvent(active, event, options);
+    const previous = active;
+    const next = applyClaimEvent(previous, event, options);
+    const identityChanged =
+      (next?.claimId ?? null) !== (previous?.claimId ?? null) ||
+      (next?.agentId ?? null) !== (previous?.agentId ?? null);
+    if (identityChanged) {
+      const candidate = previous
+        ? parseForcedHandoffComment(event.body ?? '', event.createdAt ?? '')
+        : null;
+      appliedForcedHandoff =
+        candidate &&
+        next &&
+        previous &&
+        candidate.oldAgentId === previous.agentId &&
+        candidate.oldClaimId === previous.claimId &&
+        candidate.branch === previous.branch &&
+        candidate.newAgentId === next.agentId &&
+        candidate.newClaimId === next.claimId
+          ? candidate
+          : null;
+    }
+    active = next;
   }
-  return active;
+  return { activeClaim: active, appliedForcedHandoff };
+}
+
+export function resolveActiveClaim(
+  events: CommentLike[],
+  isTrustedAuthor: ClaimResolutionOptions | ((login: string) => boolean) = () =>
+    true,
+): ParsedClaimMarker | null {
+  return resolveActiveClaimWithForcedHandoffTrace(events, isTrustedAuthor)
+    .activeClaim;
 }
 
 export function applyClaimEvent(

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -14,10 +14,7 @@ import {
   resolveViewerLogin,
 } from './gh-exec.mts';
 import { loadPolicyConfig } from './idd-config.mts';
-import {
-  listActivationNonces,
-  parseForcedHandoffComment,
-} from './marker-helpers.mts';
+import { listActivationNonces } from './marker-helpers.mts';
 import { normalizePolicyConfig } from './policy-helpers.mts';
 import type {
   ParsedClaimMarker,
@@ -30,7 +27,7 @@ import {
   normalizeLinkedPrReference,
   parseClaimComment,
   parseReleaseComment,
-  resolveActiveClaim,
+  resolveActiveClaimWithForcedHandoffTrace,
 } from './protocol-helpers.mts';
 
 /** Author reference embedded in GitHub REST payloads. */
@@ -240,13 +237,6 @@ export function evaluateResumeClaimRouting(
   const activationNonceWinner =
     activationNonces.length > 0 ? activationNonces[0] : null;
   const nonceChecked = normalizeToken(input.nonce);
-  const forcedHandoffApplied =
-    state.activeClaim && state.mode === 'new-format'
-      ? findAppliedForcedHandoff(events, state.activeClaim, {
-          isForcedHandoffEnabled,
-          isAuthorizedForcedHandoff,
-        })
-      : null;
 
   const warnings = [...state.warnings];
   let routeState = 'unclaimed';
@@ -383,96 +373,25 @@ export function evaluateResumeClaimRouting(
       later_competing_claim: laterCompetingClaim,
       activation_nonce_winner: activationNonceWinner,
       activation_nonce_count: activationNonces.length,
-      forced_handoff: forcedHandoffApplied,
+      forced_handoff: toForcedHandoffEvidence(state.appliedForcedHandoff),
     },
   };
 }
 
-/**
- * Find the trusted, rule-7-valid `forced-handoff` marker (if any) whose
- * transfer produced `activeClaim` — i.e. `newAgentId`/`newClaimId`/`branch`
- * match `activeClaim` exactly, and the same enable/author-binding/authority
- * checks `applyClaimEvent` requires to honor a handoff all pass
- * independently here. A fresh `claimId` is effectively unique per
- * activation, so at most one trusted marker can validly target it; on the
- * rare chance more than one candidate passes, the earliest by GitHub
- * `created_at` wins, mirroring the chronological reduction
- * `resolveActiveClaim` itself performs.
- */
-function findAppliedForcedHandoff(
-  events: NormalizedClaimEvent[],
-  activeClaim: ParsedClaimMarker,
-  options: {
-    isForcedHandoffEnabled: (
-      forcedHandoff: ParsedForcedHandoffMarker,
-      event: CommentEventLike,
-    ) => boolean;
-    isAuthorizedForcedHandoff: (
-      forcedBy: string,
-      forcedHandoff: ParsedForcedHandoffMarker,
-      event: CommentEventLike,
-    ) => boolean;
-  },
+/** Render {@link ActiveClaimResolution.appliedForcedHandoff} for JSON output. */
+function toForcedHandoffEvidence(
+  applied: ParsedForcedHandoffMarker | null,
 ): AppliedForcedHandoffEvidence | null {
-  const candidates = events
-    .map((event) => ({
-      event,
-      forcedHandoff: parseForcedHandoffComment(
-        event.body ?? '',
-        event.createdAt ?? '',
-      ),
-    }))
-    .filter(
-      (
-        entry,
-      ): entry is {
-        event: NormalizedClaimEvent;
-        forcedHandoff: ParsedForcedHandoffMarker;
-      } => entry.forcedHandoff !== null,
-    )
-    .filter(
-      ({ forcedHandoff }) =>
-        forcedHandoff.newAgentId === activeClaim.agentId &&
-        forcedHandoff.newClaimId === activeClaim.claimId &&
-        forcedHandoff.branch === activeClaim.branch,
-    )
-    .filter(({ event, forcedHandoff }) => {
-      if (!options.isForcedHandoffEnabled(forcedHandoff, event)) {
-        return false;
-      }
-      const authorLogin = String(event.author?.login ?? '')
-        .trim()
-        .toLowerCase();
-      const forcedByLower = String(forcedHandoff.forcedBy ?? '')
-        .trim()
-        .toLowerCase();
-      if (!authorLogin || authorLogin !== forcedByLower) {
-        return false;
-      }
-      return options.isAuthorizedForcedHandoff(
-        forcedHandoff.forcedBy,
-        forcedHandoff,
-        event,
-      );
-    })
-    .sort((left, right) =>
-      compareIso(
-        left.forcedHandoff.createdAt ?? left.event.createdAt,
-        right.forcedHandoff.createdAt ?? right.event.createdAt,
-      ),
-    );
-
-  if (candidates.length === 0) {
+  if (!applied) {
     return null;
   }
-  const winner = candidates[0].forcedHandoff;
   return {
-    old_agent_id: winner.oldAgentId,
-    old_claim_id: winner.oldClaimId,
-    new_agent_id: winner.newAgentId,
-    new_claim_id: winner.newClaimId,
-    forced_by: winner.forcedBy,
-    timestamp: winner.createdAt ?? '',
+    old_agent_id: applied.oldAgentId,
+    old_claim_id: applied.oldClaimId,
+    new_agent_id: applied.newAgentId,
+    new_claim_id: applied.newClaimId,
+    forced_by: applied.forcedBy,
+    timestamp: applied.createdAt ?? '',
   };
 }
 
@@ -735,8 +654,8 @@ function resolveClaimState(
     }
   };
 
-  const activeClaim = hasNewFormatClaim
-    ? resolveActiveClaim(events, {
+  const claimTrace = hasNewFormatClaim
+    ? resolveActiveClaimWithForcedHandoffTrace(events, {
         isTrustedAuthor: () => true, // events were already filtered by caller
         isForcedHandoffEnabled,
         isAuthorizedForcedHandoff,
@@ -760,7 +679,8 @@ function resolveClaimState(
   if (hasNewFormatClaim) {
     return {
       mode: 'new-format',
-      activeClaim,
+      activeClaim: claimTrace?.activeClaim ?? null,
+      appliedForcedHandoff: claimTrace?.appliedForcedHandoff ?? null,
       warnings,
       legacyClaim: null,
       legacyReleased: false,
@@ -772,6 +692,7 @@ function resolveClaimState(
   return {
     mode: 'legacy-only',
     activeClaim: null,
+    appliedForcedHandoff: null,
     warnings,
     legacyClaim: legacy.claim,
     legacyReleased: legacy.released,

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -108,7 +108,8 @@ interface LegacyClaimMarker {
  * the active claim to the pair currently active. `timestamp` is the
  * transferring comment's GitHub `created_at` (the same authority every other
  * marker in this file uses), not the marker's own embedded `timestamp`
- * field.
+ * field; `null` when that comment metadata is unavailable, never an empty
+ * string.
  */
 interface AppliedForcedHandoffEvidence {
   old_agent_id: string;
@@ -116,7 +117,7 @@ interface AppliedForcedHandoffEvidence {
   new_agent_id: string;
   new_claim_id: string;
   forced_by: string;
-  timestamp: string;
+  timestamp: string | null;
 }
 
 /** Parsed CLI arguments. */
@@ -391,7 +392,7 @@ function toForcedHandoffEvidence(
     new_agent_id: applied.newAgentId,
     new_claim_id: applied.newClaimId,
     forced_by: applied.forcedBy,
-    timestamp: applied.createdAt ?? '',
+    timestamp: applied.createdAt ?? null,
   };
 }
 

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -14,7 +14,10 @@ import {
   resolveViewerLogin,
 } from './gh-exec.mts';
 import { loadPolicyConfig } from './idd-config.mts';
-import { listActivationNonces } from './marker-helpers.mts';
+import {
+  listActivationNonces,
+  parseForcedHandoffComment,
+} from './marker-helpers.mts';
 import { normalizePolicyConfig } from './policy-helpers.mts';
 import type {
   ParsedClaimMarker,
@@ -101,6 +104,22 @@ interface LegacyClaimMarker {
   agentId: string;
   createdAt: string;
   branch: string;
+}
+
+/**
+ * Evidence that a trusted, rule-7-valid `forced-handoff` marker transferred
+ * the active claim to the pair currently active. `timestamp` is the
+ * transferring comment's GitHub `created_at` (the same authority every other
+ * marker in this file uses), not the marker's own embedded `timestamp`
+ * field.
+ */
+interface AppliedForcedHandoffEvidence {
+  old_agent_id: string;
+  old_claim_id: string;
+  new_agent_id: string;
+  new_claim_id: string;
+  forced_by: string;
+  timestamp: string;
 }
 
 /** Parsed CLI arguments. */
@@ -221,6 +240,13 @@ export function evaluateResumeClaimRouting(
   const activationNonceWinner =
     activationNonces.length > 0 ? activationNonces[0] : null;
   const nonceChecked = normalizeToken(input.nonce);
+  const forcedHandoffApplied =
+    state.activeClaim && state.mode === 'new-format'
+      ? findAppliedForcedHandoff(events, state.activeClaim, {
+          isForcedHandoffEnabled,
+          isAuthorizedForcedHandoff,
+        })
+      : null;
 
   const warnings = [...state.warnings];
   let routeState = 'unclaimed';
@@ -357,7 +383,96 @@ export function evaluateResumeClaimRouting(
       later_competing_claim: laterCompetingClaim,
       activation_nonce_winner: activationNonceWinner,
       activation_nonce_count: activationNonces.length,
+      forced_handoff: forcedHandoffApplied,
     },
+  };
+}
+
+/**
+ * Find the trusted, rule-7-valid `forced-handoff` marker (if any) whose
+ * transfer produced `activeClaim` — i.e. `newAgentId`/`newClaimId`/`branch`
+ * match `activeClaim` exactly, and the same enable/author-binding/authority
+ * checks `applyClaimEvent` requires to honor a handoff all pass
+ * independently here. A fresh `claimId` is effectively unique per
+ * activation, so at most one trusted marker can validly target it; on the
+ * rare chance more than one candidate passes, the earliest by GitHub
+ * `created_at` wins, mirroring the chronological reduction
+ * `resolveActiveClaim` itself performs.
+ */
+function findAppliedForcedHandoff(
+  events: NormalizedClaimEvent[],
+  activeClaim: ParsedClaimMarker,
+  options: {
+    isForcedHandoffEnabled: (
+      forcedHandoff: ParsedForcedHandoffMarker,
+      event: CommentEventLike,
+    ) => boolean;
+    isAuthorizedForcedHandoff: (
+      forcedBy: string,
+      forcedHandoff: ParsedForcedHandoffMarker,
+      event: CommentEventLike,
+    ) => boolean;
+  },
+): AppliedForcedHandoffEvidence | null {
+  const candidates = events
+    .map((event) => ({
+      event,
+      forcedHandoff: parseForcedHandoffComment(
+        event.body ?? '',
+        event.createdAt ?? '',
+      ),
+    }))
+    .filter(
+      (
+        entry,
+      ): entry is {
+        event: NormalizedClaimEvent;
+        forcedHandoff: ParsedForcedHandoffMarker;
+      } => entry.forcedHandoff !== null,
+    )
+    .filter(
+      ({ forcedHandoff }) =>
+        forcedHandoff.newAgentId === activeClaim.agentId &&
+        forcedHandoff.newClaimId === activeClaim.claimId &&
+        forcedHandoff.branch === activeClaim.branch,
+    )
+    .filter(({ event, forcedHandoff }) => {
+      if (!options.isForcedHandoffEnabled(forcedHandoff, event)) {
+        return false;
+      }
+      const authorLogin = String(event.author?.login ?? '')
+        .trim()
+        .toLowerCase();
+      const forcedByLower = String(forcedHandoff.forcedBy ?? '')
+        .trim()
+        .toLowerCase();
+      if (!authorLogin || authorLogin !== forcedByLower) {
+        return false;
+      }
+      return options.isAuthorizedForcedHandoff(
+        forcedHandoff.forcedBy,
+        forcedHandoff,
+        event,
+      );
+    })
+    .sort((left, right) =>
+      compareIso(
+        left.forcedHandoff.createdAt ?? left.event.createdAt,
+        right.forcedHandoff.createdAt ?? right.event.createdAt,
+      ),
+    );
+
+  if (candidates.length === 0) {
+    return null;
+  }
+  const winner = candidates[0].forcedHandoff;
+  return {
+    old_agent_id: winner.oldAgentId,
+    old_claim_id: winner.oldClaimId,
+    new_agent_id: winner.newAgentId,
+    new_claim_id: winner.newClaimId,
+    forced_by: winner.forcedBy,
+    timestamp: winner.createdAt ?? '',
   };
 }
 

--- a/tests/resume-claim-routing.test.mts
+++ b/tests/resume-claim-routing.test.mts
@@ -528,7 +528,7 @@ test('evidence.forced_handoff is populated on a bare --issue call (no --claim-id
   });
 });
 
-test('evidence.forced_handoff is absent when no forced-handoff marker applies', () => {
+test('evidence.forced_handoff is null when no forced-handoff marker applies', () => {
   const result = evaluateResumeClaimRouting(
     {
       now: '2026-05-12T10:30:00Z',

--- a/tests/resume-claim-routing.test.mts
+++ b/tests/resume-claim-routing.test.mts
@@ -565,6 +565,63 @@ test('evidence.forced_handoff stays null when a forced-handoff marker exists but
   assert.equal(result.evidence.forced_handoff, null);
 });
 
+test('evidence.forced_handoff is not misattributed to a stale, never-applied duplicate handoff sharing the same new-claim target', () => {
+  // Regression for the review finding on #2178's first draft: a naive
+  // scan for "which forced-handoff marker's new* fields match the final
+  // active claim" can pick a marker that was never actually applied by
+  // the real reducer, when a later, correctly-applied marker happens to
+  // target the identical new-claim-id (e.g. a human retries a handoff
+  // after realizing their first attempt cited stale old* fields, reusing
+  // the same intended successor claim-id both times).
+  //
+  // Timeline: fresh claim (agent-A/claim-1) -> stale takeover to
+  // agent-D/claim-9 (>24h later) -> a stray forced-handoff still citing
+  // the ORIGINAL agent-A/claim-1 as old* (never applied: active was
+  // already agent-D/claim-9 by then) -> the real forced-handoff citing
+  // agent-D/claim-9 as old*, both targeting the same agent-B/claim-2.
+  const events = [
+    {
+      createdAt: '2026-06-01T10:00:00Z',
+      author: { login: 'maintainer' },
+      body: '<!-- claimed-by: agent-A claim-1 supersedes: none 2026-06-01T10:00:00Z branch: issue/50-task -->',
+    },
+    {
+      createdAt: '2026-06-02T11:00:00Z',
+      author: { login: 'maintainer' },
+      body: '<!-- claimed-by: agent-D claim-9 supersedes: claim-1 2026-06-02T11:00:00Z branch: issue/50-task -->',
+    },
+    {
+      createdAt: '2026-06-02T11:05:00Z',
+      author: { login: 'maintainer' },
+      body: '<!-- forced-handoff: {"oldAgentId":"agent-A","oldClaimId":"claim-1","newAgentId":"agent-B","newClaimId":"claim-2","branch":"issue/50-task","forcedBy":"maintainer","reason":"stray retry citing stale old-claim","timestamp":"2026-06-02T11:05:00Z","contextScope":"issue-only"} -->\n\n_maintainer: forced handoff — IDD automation marker. Do not edit._',
+    },
+    {
+      createdAt: '2026-06-02T11:10:00Z',
+      author: { login: 'maintainer' },
+      body: '<!-- forced-handoff: {"oldAgentId":"agent-D","oldClaimId":"claim-9","newAgentId":"agent-B","newClaimId":"claim-2","branch":"issue/50-task","forcedBy":"maintainer","reason":"actual handoff","timestamp":"2026-06-02T11:10:00Z","contextScope":"issue-only"} -->\n\n_maintainer: forced handoff — IDD automation marker. Do not edit._',
+    },
+  ];
+
+  const result = evaluateResumeClaimRouting(
+    { now: '2026-06-02T12:00:00Z', events },
+    {
+      isTrustedAuthor: trusted(['maintainer']),
+      isForcedHandoffEnabled: () => true,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === 'maintainer',
+    },
+  );
+
+  assert.equal(result.active_claim?.claim_id, 'claim-2');
+  assert.deepEqual(result.evidence.forced_handoff, {
+    old_agent_id: 'agent-D',
+    old_claim_id: 'claim-9',
+    new_agent_id: 'agent-B',
+    new_claim_id: 'claim-2',
+    forced_by: 'maintainer',
+    timestamp: '2026-06-02T11:10:00Z',
+  });
+});
+
 test('forced-handoff is ignored when forced-handoff mode is disabled', () => {
   const result = evaluateResumeClaimRouting(
     {

--- a/tests/resume-claim-routing.test.mts
+++ b/tests/resume-claim-routing.test.mts
@@ -498,6 +498,73 @@ test('authorized forced-handoff marker promotes successor claim before routing',
   assert.equal(result.active_claim?.claim_id, 'claim-new');
 });
 
+test('evidence.forced_handoff is populated on a bare --issue call (no --claim-id) against a valid forced-handoff successor (#2178)', () => {
+  const result = evaluateResumeClaimRouting(
+    {
+      // claimId omitted: exercises the exact "bare --issue call" gap named
+      // in #2178 -- the routing verdict stays non_inheritable/stop for
+      // backward compatibility, but the new evidence field must still
+      // populate so the caller can retry with --claim-id.
+      now: '2026-05-12T11:00:00Z',
+      events: FORCED_HANDOFF_EVENTS,
+    },
+    {
+      isTrustedAuthor: trusted(['maintainer']),
+      isForcedHandoffEnabled: () => true,
+      isAuthorizedForcedHandoff: (forcedBy) => forcedBy === 'maintainer',
+    },
+  );
+
+  assert.equal(result.state, 'non_inheritable');
+  assert.equal(result.action, 'stop');
+  assert.equal(result.reason, 'active-claim-non-stale');
+  assert.deepEqual(result.evidence.forced_handoff, {
+    old_agent_id: 'copilot',
+    old_claim_id: 'claim-old',
+    new_agent_id: 'copilot',
+    new_claim_id: 'claim-new',
+    forced_by: 'maintainer',
+    timestamp: '2026-05-12T10:01:00Z',
+  });
+});
+
+test('evidence.forced_handoff is absent when no forced-handoff marker applies', () => {
+  const result = evaluateResumeClaimRouting(
+    {
+      now: '2026-05-12T10:30:00Z',
+      events: [
+        {
+          createdAt: '2026-05-12T10:00:00Z',
+          author: { login: 'maintainer' },
+          body: '<!-- claimed-by: copilot claim-plain supersedes: none 2026-05-12T10:00:00Z branch: issue/12-task -->',
+        },
+      ],
+    },
+    { isTrustedAuthor: trusted(['maintainer']) },
+  );
+
+  assert.equal(result.evidence.forced_handoff, null);
+});
+
+test('evidence.forced_handoff stays null when a forced-handoff marker exists but is ignored (mode disabled)', () => {
+  const result = evaluateResumeClaimRouting(
+    {
+      now: '2026-05-12T11:00:00Z',
+      events: FORCED_HANDOFF_EVENTS,
+    },
+    {
+      isTrustedAuthor: trusted(['maintainer']),
+      // isForcedHandoffEnabled omitted -> defaults to () => false, so the
+      // marker never transfers ownership and must not be reported as
+      // applied evidence either.
+      isAuthorizedForcedHandoff: () => true,
+    },
+  );
+
+  assert.equal(result.active_claim?.claim_id, 'claim-old');
+  assert.equal(result.evidence.forced_handoff, null);
+});
+
 test('forced-handoff is ignored when forced-handoff mode is disabled', () => {
   const result = evaluateResumeClaimRouting(
     {


### PR DESCRIPTION
# Summary

Add a non-breaking `evidence.forced_handoff` field to `resume-claim-routing.mjs`'s output, populated whenever a trusted, rule-7-valid `forced-handoff` marker's successor pair matches the currently resolved active claim -- including on a bare `--issue` call with no `--claim-id`. Existing `state`/`action` enum values and meanings are unchanged.

## Linked issue

Closes #2178

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

A bare `--issue` call against a forced-handoff-recovered claim already resolves the successor pair internally (the `active_claim` field reflects it correctly), but nothing in the output signals *why* -- `warnings` only lists markers the resolver *rejected*, never the one it accepted. A session that treats the bare verdict (`non_inheritable`/`stop`) as sufficient evidence, or that reasonably declines to contest what looks like someone else's live claim, has no machine-readable pointer toward the documented retry-with-`--claim-id` path. This plausibly contributes to forced-handoff-recovered issues sitting unclaimed longer than necessary (observed on this repository's own issues #2161, #2159, #1663).

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed (docs/idd-helper-scripts.md and idd-resume.instructions.md are docs, not workflow-instruction template files in the IDD-impact sense; see checklist below)
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (ran `pnpm run lint:minimum`)
- [x] `pnpm test` (3744 tests pass, including 3 new tests for the field)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check` (ran `node scripts/sync-docs.mjs --apply`; mirrors in sync)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed (bundle-resume utilization: 95.09%, under the 98% hard ceiling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume routing when a valid forced handoff identifies a successor claim.
  * Resume now retries with the successor claim before stopping with a non-inheritable result.
  * Bare issue-based requests continue to require explicit successor claim verification.

* **New Features**
  * Added forced-handoff evidence to routing results, including previous and successor claim details, actor, and timestamp.
  * Legacy-only routing results clearly report when no forced-handoff evidence is available.

* **Documentation**
  * Updated resume-routing guidance to explain forced-handoff evidence and successor claim verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->