### PR TITLE
chore(context-ceiling): raise bundle-discovery's limitBytes ahead of its own notice threshold

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -277,7 +277,7 @@
         ".github/instructions/idd-overview-core.instructions.md",
         ".github/instructions/idd-suitability.instructions.md"
       ],
-      "limitBytes": 104000
+      "limitBytes": 109700
     },
     {
       "id": "bundle-resume",


### PR DESCRIPTION
# Summary

Raise `audit/sync-manifest.json`'s `bundle-discovery` `bundleBudgets`
entry `limitBytes` from `104000` to `109700` bytes. `bundle-discovery`
(idd-overview-core + idd-overview-appendix + idd-discover +
idd-suitability + idd-claim) had grown to 95.90% utilization
(99,734 / 104,000 bytes), past the 95% notice threshold in
`node scripts/audit-docs.mjs --check`, with no corresponding content
reduction planned. No other `bundleBudgets` entry, `contextCeiling`
field, or instruction content changes.

## Linked issue

Closes #2192

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

**Ratchet callout** (`docs/policy-constants.md`'s "Bundle-budget
growth" section requires this for any `limitBytes` raise):

- Re-measured current size at implementation time: **99,734 bytes**
  (95.90% of the prior 104,000-byte limit) — re-measured rather than
  reusing the issue's older 95.13%/98,934-byte figures, since the
  corpus keeps growing.
- New limit: **109,700 bytes** — roughly 9.99% headroom over the
  re-measured total, rounded to a clean multiple of 100, well under
  the 126,000-byte `contextCeiling.maxBundleLimitBytes` absolute
  ceiling.
- Justification: `bundle-discovery` still has normal ratchet headroom
  available (unlike `bundle-review`, pinned at the absolute ceiling
  and tracked separately under #2181); this is an independent,
  low-stakes companion fix per #2181's framing.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

(None of the above apply: `audit/sync-manifest.json` is a bundle-budget
data file consumed by `audit-docs.mjs`, not the policy schema, a
template, or a helper script itself.)

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
