### PR TITLE
docs(review): dedupe bundle-review's cross-file restatements to recover ceiling headroom

### DIFF
--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -81,11 +81,11 @@ signed-commit repo with non-interactive-hostile primary signing (GPG
 pinentry / hardware-touch), use the
 [signed-commit merge wrapper](../../docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure)
 for the whole operation instead of the plain command — see
-`idd-review-triage.instructions.md`'s sync-path step 2 for the
+`idd-review-triage.instructions.md`'s Sync path step 2 for the
 wrapper's `-m` subject requirement.
 
 **Active review gate**: same check as
-`idd-review-triage.instructions.md`'s sync path step 1.
+`idd-review-triage.instructions.md`'s Sync path step 1.
 
 ## E12 — Lint, test, push
 

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -153,10 +153,11 @@ unambiguous:
 - **Review threads**: after posting your reply, **immediately resolve
   the thread**, using the same resolve-review-thread mechanism as
   `idd-review-triage.instructions.md`'s E6 (profile-selected helper
-  command, reply-before-resolve, GraphQL fallback — see E6 for the
-  exact command and flags). Resolution means "agent acted", not
-  "reviewer agreed" — a disagreeing reviewer can reopen the thread,
-  re-surfacing it in the next E1 pass.
+  command, reply-before-resolve, GraphQL fallback — see
+  `idd-review-triage.instructions.md`'s E6 for the exact command and
+  flags). Resolution means "agent acted", not "reviewer agreed" — a
+  disagreeing reviewer can reopen the thread, re-surfacing it in the
+  next E1 pass.
 - **Regular comments**: reply only; do not resolve.
 - **Persistent non-review notices**: a non-review notice already
   dispositioned `**Rejected** — {bot} did not review HEAD …` in a prior

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -153,7 +153,8 @@ unambiguous:
 - **Review threads**: after posting your reply, **immediately resolve
   the thread**, using the same resolve-review-thread mechanism as
   `idd-review-triage.instructions.md`'s E6 (profile-selected helper
-  command, reply-before-resolve, GraphQL fallback — see
+  command, reply-before-resolve, manual REST + GraphQL
+  `resolveReviewThread` fallback — see
   `idd-review-triage.instructions.md`'s E6 for the exact command and
   flags). Resolution means "agent acted", not "reviewer agreed" — a
   disagreeing reviewer can reopen the thread, re-surfacing it in the

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -80,16 +80,12 @@ git merge origin/main`), resolve them, and complete the merge. On a
 signed-commit repo with non-interactive-hostile primary signing (GPG
 pinentry / hardware-touch), use the
 [signed-commit merge wrapper](../../docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure)
-for the whole operation instead of the plain command. That wrapper's
-merge invocation includes a conventional `-m` subject (for example
-`chore: merge origin/main into the claimed branch`) so a commitlint
-`commit-msg` hook does not reject the merge commit.
+for the whole operation instead of the plain command — see
+`idd-review-triage.instructions.md`'s sync-path step 2 for the
+wrapper's `-m` subject requirement.
 
 **Active review gate**: same check as
-`idd-review-triage.instructions.md`'s sync path step 1 — unresolved
-review threads, unreplied comments, or a reviewer's
-`CHANGES_REQUESTED` state require explicit operator confirmation before
-this merge, since the merge commit will appear in PR history.
+`idd-review-triage.instructions.md`'s sync path step 1.
 
 ## E12 — Lint, test, push
 
@@ -148,24 +144,19 @@ Start every reply with one of these prefixes so that disposition is
 unambiguous:
 
 - `**Accepted** — fixed in {commit-sha or comma-separated list}: {brief explanation}`
-  After that visible prefix, include the prefix-aware reply-identity
-  stamp
-  `<!-- {markerPrefix}-review-reply -->`
-  (use the repository `markerPrefix`, default `idd-skill`; helpers
-  inject it; a manual `gh api` JSON body must append it). The stamp is
-  utterance identity, not an E1 `review-watermark`, and it must not
-  replace the required `**Accepted**` first bytes.
+  After that visible prefix, include the reply-identity stamp exactly as
+  `idd-review-triage.instructions.md`'s E6 defines it
+  (`<!-- {markerPrefix}-review-reply -->`) — same stamp mechanics and
+  constraints, applied here to the `**Accepted**`-only prefix this
+  phase posts.
 
 - **Review threads**: after posting your reply, **immediately resolve
-  the thread**. When helper runtime is enabled, the profile-selected
-  resolve-review-thread command (`--pr <number> --comment-id <id>
-  --apply`, with `--body`/`--claim-issue`/`--claim-id`; see
-  `docs/idd-helper-scripts.md`) posts the reply and resolves in one
-  call, replying before resolving so a failed reply never leaves a
-  silently-resolved thread; the manual REST + GraphQL
-  `resolveReviewThread` sequence is the fallback. Resolution means
-  "agent acted", not "reviewer agreed" — a disagreeing reviewer can
-  reopen the thread, re-surfacing it in the next E1 pass.
+  the thread**, using the same resolve-review-thread mechanism as
+  `idd-review-triage.instructions.md`'s E6 (profile-selected helper
+  command, reply-before-resolve, GraphQL fallback — see E6 for the
+  exact command and flags). Resolution means "agent acted", not
+  "reviewer agreed" — a disagreeing reviewer can reopen the thread,
+  re-surfacing it in the next E1 pass.
 - **Regular comments**: reply only; do not resolve.
 - **Persistent non-review notices**: a non-review notice already
   dispositioned `**Rejected** — {bot} did not review HEAD …` in a prior

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -322,16 +322,14 @@ review-ack --from-pr <pr-number> --agent-id <id> --timestamp
 review-ack: {agent-id} {PR_HEAD_SHA} {ISO8601-acknowledged-at}
 ```
 
-_Worked example_: a review posts one regular-comment finding plus a
-suppressed one; after replying `**Rejected** — verified
-placeholders-only` to the regular-comment finding, also post
+_Worked example_: a review posts a regular-comment finding plus a
+suppressed one. Disposition the regular-comment finding normally
+(`**Rejected** — verified placeholders-only`), then also post
 `review-ack: claude-code-1a2b3c4d 4b825dc642cb6eb9a060e54bf8d69288fbee4904 2026-08-19T00:10:00Z`
-to cover the suppressed one — the regular-comment rejection alone
-never sets `converged`; the `suppressedCount` term needs the marker
-too. Plain text, no HTML comment (matches `advisory-reroll:`'s
-shape). This is not a license to skip **AW6** or the fix flow when a
-suppressed finding needs a code change — `review-ack:` asserts the
-finding was read and handled, not that it required no action.
+(plain text, no HTML comment) to cover the suppressed one — the
+regular-comment rejection alone never sets `converged`, and this is
+not a license to skip **AW6** or the fix flow when the suppressed
+finding needs a code change.
 
 PATH B — Advisory non-review notice (rate-limit / quota / queued / bare
 ack / error, as defined in E4):
@@ -577,10 +575,9 @@ the loop — bind the merge to current HEAD and proceed. An **ack-only**
 comment opens no new thread, carries no `CHANGES_REQUESTED`, and raises
 no new finding; anything else re-opens the loop normally.
 
-_Example_: after you disposition a CodeRabbit thread `**Rejected**`,
-CodeRabbit replies "Thanks for confirming" on it — no new thread or
-finding, so the `updatedAt` advance is ignored; continue to F-phase on
-the current HEAD.
+_Example_: CodeRabbit replies "Thanks for confirming" after your
+`**Rejected**` disposition — no new thread or finding, so continue to
+F-phase on the current HEAD despite the `updatedAt` advance.
 
 **Helper evidence**: when the advisory-bot identity is configured, the
 activity-snapshot / `pre-merge-readiness` evidence emits the structural

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -76,11 +76,11 @@ signed-commit repo with non-interactive-hostile primary signing (GPG
 pinentry / hardware-touch), use the
 [signed-commit merge wrapper](../../docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure)
 for the whole operation instead of the plain command — see
-`idd-review-triage.instructions.md`'s sync-path step 2 for the
+`idd-review-triage.instructions.md`'s Sync path step 2 for the
 wrapper's `-m` subject requirement.
 
 **Active review gate**: same check as
-`idd-review-triage.instructions.md`'s sync path step 1.
+`idd-review-triage.instructions.md`'s Sync path step 1.
 
 ## E12 — Lint, test, push
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -148,7 +148,8 @@ unambiguous:
 - **Review threads**: after posting your reply, **immediately resolve
   the thread**, using the same resolve-review-thread mechanism as
   `idd-review-triage.instructions.md`'s E6 (profile-selected helper
-  command, reply-before-resolve, GraphQL fallback — see
+  command, reply-before-resolve, manual REST + GraphQL
+  `resolveReviewThread` fallback — see
   `idd-review-triage.instructions.md`'s E6 for the exact command and
   flags). Resolution means "agent acted", not "reviewer agreed" — a
   disagreeing reviewer can reopen the thread, re-surfacing it in the

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -148,10 +148,11 @@ unambiguous:
 - **Review threads**: after posting your reply, **immediately resolve
   the thread**, using the same resolve-review-thread mechanism as
   `idd-review-triage.instructions.md`'s E6 (profile-selected helper
-  command, reply-before-resolve, GraphQL fallback — see E6 for the
-  exact command and flags). Resolution means "agent acted", not
-  "reviewer agreed" — a disagreeing reviewer can reopen the thread,
-  re-surfacing it in the next E1 pass.
+  command, reply-before-resolve, GraphQL fallback — see
+  `idd-review-triage.instructions.md`'s E6 for the exact command and
+  flags). Resolution means "agent acted", not "reviewer agreed" — a
+  disagreeing reviewer can reopen the thread, re-surfacing it in the
+  next E1 pass.
 - **Regular comments**: reply only; do not resolve.
 - **Persistent non-review notices**: a non-review notice already
   dispositioned `**Rejected** — {bot} did not review HEAD …` in a prior

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -75,16 +75,12 @@ git merge origin/main`), resolve them, and complete the merge. On a
 signed-commit repo with non-interactive-hostile primary signing (GPG
 pinentry / hardware-touch), use the
 [signed-commit merge wrapper](../../docs/idd-helper-scripts.md#signed-commit-merge-wrapper-shared-git-procedure)
-for the whole operation instead of the plain command. That wrapper's
-merge invocation includes a conventional `-m` subject (for example
-`chore: merge origin/main into the claimed branch`) so a commitlint
-`commit-msg` hook does not reject the merge commit.
+for the whole operation instead of the plain command — see
+`idd-review-triage.instructions.md`'s sync-path step 2 for the
+wrapper's `-m` subject requirement.
 
 **Active review gate**: same check as
-`idd-review-triage.instructions.md`'s sync path step 1 — unresolved
-review threads, unreplied comments, or a reviewer's
-`CHANGES_REQUESTED` state require explicit operator confirmation before
-this merge, since the merge commit will appear in PR history.
+`idd-review-triage.instructions.md`'s sync path step 1.
 
 ## E12 — Lint, test, push
 
@@ -143,24 +139,19 @@ Start every reply with one of these prefixes so that disposition is
 unambiguous:
 
 - `**Accepted** — fixed in {commit-sha or comma-separated list}: {brief explanation}`
-  After that visible prefix, include the prefix-aware reply-identity
-  stamp
-  `<!-- {markerPrefix}-review-reply -->`
-  (use the repository `markerPrefix`, default `idd-skill`; helpers
-  inject it; a manual `gh api` JSON body must append it). The stamp is
-  utterance identity, not an E1 `review-watermark`, and it must not
-  replace the required `**Accepted**` first bytes.
+  After that visible prefix, include the reply-identity stamp exactly as
+  `idd-review-triage.instructions.md`'s E6 defines it
+  (`<!-- {markerPrefix}-review-reply -->`) — same stamp mechanics and
+  constraints, applied here to the `**Accepted**`-only prefix this
+  phase posts.
 
 - **Review threads**: after posting your reply, **immediately resolve
-  the thread**. When helper runtime is enabled, the profile-selected
-  resolve-review-thread command (`--pr <number> --comment-id <id>
-  --apply`, with `--body`/`--claim-issue`/`--claim-id`; see
-  `docs/idd-helper-scripts.md`) posts the reply and resolves in one
-  call, replying before resolving so a failed reply never leaves a
-  silently-resolved thread; the manual REST + GraphQL
-  `resolveReviewThread` sequence is the fallback. Resolution means
-  "agent acted", not "reviewer agreed" — a disagreeing reviewer can
-  reopen the thread, re-surfacing it in the next E1 pass.
+  the thread**, using the same resolve-review-thread mechanism as
+  `idd-review-triage.instructions.md`'s E6 (profile-selected helper
+  command, reply-before-resolve, GraphQL fallback — see E6 for the
+  exact command and flags). Resolution means "agent acted", not
+  "reviewer agreed" — a disagreeing reviewer can reopen the thread,
+  re-surfacing it in the next E1 pass.
 - **Regular comments**: reply only; do not resolve.
 - **Persistent non-review notices**: a non-review notice already
   dispositioned `**Rejected** — {bot} did not review HEAD …` in a prior

--- a/idd-template/.github/instructions/idd-review-triage.instructions.md
+++ b/idd-template/.github/instructions/idd-review-triage.instructions.md
@@ -317,16 +317,14 @@ review-ack --from-pr <pr-number> --agent-id <id> --timestamp
 review-ack: {agent-id} {PR_HEAD_SHA} {ISO8601-acknowledged-at}
 ```
 
-_Worked example_: a review posts one regular-comment finding plus a
-suppressed one; after replying `**Rejected** — verified
-placeholders-only` to the regular-comment finding, also post
+_Worked example_: a review posts a regular-comment finding plus a
+suppressed one. Disposition the regular-comment finding normally
+(`**Rejected** — verified placeholders-only`), then also post
 `review-ack: claude-code-1a2b3c4d 4b825dc642cb6eb9a060e54bf8d69288fbee4904 2026-08-19T00:10:00Z`
-to cover the suppressed one — the regular-comment rejection alone
-never sets `converged`; the `suppressedCount` term needs the marker
-too. Plain text, no HTML comment (matches `advisory-reroll:`'s
-shape). This is not a license to skip **AW6** or the fix flow when a
-suppressed finding needs a code change — `review-ack:` asserts the
-finding was read and handled, not that it required no action.
+(plain text, no HTML comment) to cover the suppressed one — the
+regular-comment rejection alone never sets `converged`, and this is
+not a license to skip **AW6** or the fix flow when the suppressed
+finding needs a code change.
 
 PATH B — Advisory non-review notice (rate-limit / quota / queued / bare
 ack / error, as defined in E4):
@@ -572,10 +570,9 @@ the loop — bind the merge to current HEAD and proceed. An **ack-only**
 comment opens no new thread, carries no `CHANGES_REQUESTED`, and raises
 no new finding; anything else re-opens the loop normally.
 
-_Example_: after you disposition a CodeRabbit thread `**Rejected**`,
-CodeRabbit replies "Thanks for confirming" on it — no new thread or
-finding, so the `updatedAt` advance is ignored; continue to F-phase on
-the current HEAD.
+_Example_: CodeRabbit replies "Thanks for confirming" after your
+`**Rejected**` disposition — no new thread or finding, so continue to
+F-phase on the current HEAD despite the `updatedAt` advance.
 
 **Helper evidence**: when the advisory-bot identity is configured, the
 activity-snapshot / `pre-merge-readiness` evidence emits the structural


### PR DESCRIPTION
# Summary

`idd-review-fix.instructions.md` (E11, E13) restated four passages that
`idd-review-triage.instructions.md` (E6, sync-path step 2) already
explains in full. Convert each of the four to a cross-reference,
preserving every normative rule, ordering constraint, and cited
rationale at the one remaining full explanation:

1. Resolve-review-thread mechanism (E13 → cross-ref to E6).
2. Signed-commit merge wrapper's `-m` subject requirement (E11 →
   cross-ref to sync-path step 2).
3. "Active review gate" rule (E11 → drop the restatement it already
   opened with a cross-reference sentence for).
4. Reply-identity stamp explanation (E13 → cross-ref to E6, keeping
   E13's own `**Accepted**`-only-prefix detail).

Also shortened two illustrative example blocks in
`idd-review-triage.instructions.md` (the `review-ack:` worked example
and the courtesy-ack example), preserving what each distinction
illustrates — the issue's optional stretch items.

All edits land in the `idd-template/.github/instructions/` sync-pair
sources (`sync-docs.mjs --apply` regenerated the repo-root
`.github/instructions/` mirrors); no `.github/instructions/*` content
outside `bundle-review`'s member files was touched.

## Linked issue

Closes #2191

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

**Byte totals** (banner-stripped, `bundle-review`'s 7 member files):

- Before: 122,247 bytes (97.02% of the 126,000-byte `limitBytes`)
- After: 121,464 bytes (96.40%) — a 783-byte reduction

Still above the 95% notice threshold, as the issue itself flags: at
`bundle-review`'s recorded growth rate, this diet alone buys roughly a
day of extra headroom, not a durable fix — one recurring lever
alongside the `exemptBundles` stopgap (#2190), not a substitute for
either.

`contextCeiling.exemptBundles` does not currently contain
`bundle-review` (#2190 is not yet implemented on `main`), so the
acceptance criteria's conditional exemption-removal step does not
apply — nothing to remove.

**A4.5 Check 3 note**: the mechanical `suitability-triage.mjs` helper
flagged this issue `invalid` on its Trust/Safety check, matching on a
sentence that quotes this repo's own generated-file banner (explaining
the sync-pair convention) as an "unsafe execution directive". Verified
empirically via `--stdin` (paraphrasing only that quoted sentence
flips the check to pass, isolating it as the sole trigger) and applied
`idd-suitability.instructions.md`'s own written Check 3 criterion
directly, per its "written checks remain authoritative when helper
output disagrees" rule — full reasoning recorded on the issue.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Consolidated review-fix guidance by linking to shared definitions for merge requirements, review gates, reply identity, and thread resolution.
  * Clarified review-triage examples for suppressed findings, plain-text acknowledgments, courtesy replies, and progression to later review phases.
  * Applied the same instruction updates to the main and template documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->