### PR TITLE
fix(helpers): rename the ambiguous --token GH-auth flag to --gh-token

### DIFF
--- a/scripts/claim-approval-gate.mjs
+++ b/scripts/claim-approval-gate.mjs
@@ -35,6 +35,7 @@ const CLAIM_APPROVAL_GATE_FLAG_SPEC = {
   '--owner': { type: 'string' },
   '--repo': { type: 'string' },
   '--policy': { type: 'string' },
+  '--gh-token': { type: 'string' },
   '--token': { type: 'string' },
   '--generated-plan-updated-at': { type: 'string' },
   '--verbose': { type: 'boolean', default: false },
@@ -227,9 +228,9 @@ function runCli() {
   if (!Number.isInteger(args.issue) || (args.issue ?? 0) <= 0) {
     throw new Error('--issue is required and must be a positive integer');
   }
-  if (args.token) {
-    process.env.GH_TOKEN = args.token;
-    process.env.GITHUB_TOKEN = args.token;
+  if (args.ghToken) {
+    process.env.GH_TOKEN = args.ghToken;
+    process.env.GITHUB_TOKEN = args.ghToken;
   }
   const owner =
     args.owner ||
@@ -294,9 +295,66 @@ function runCli() {
   };
   process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
 }
+function warnDeprecatedFlag(deprecated, canonical) {
+  process.stderr.write(
+    `warning: ${deprecated} is deprecated; use ${canonical} instead.\n`,
+  );
+}
+/**
+ * Find `flag`'s last occurrence in `argv`, recognizing both the
+ * two-token form (`--flag value`) and the single-token `--flag=value`
+ * form `parseCliArgs` also accepts.
+ */
+function findLastFlagOccurrenceIndex(argv, flag) {
+  const equalsPrefix = `${flag}=`;
+  for (let index = argv.length - 1; index >= 0; index -= 1) {
+    if (argv[index] === flag || argv[index].startsWith(equalsPrefix)) {
+      return index;
+    }
+  }
+  return -1;
+}
+/**
+ * Resolve a canonical/deprecated flag pair: whichever flag's LAST
+ * occurrence comes later in argv wins when both spellings are given
+ * together (matches `pre-merge-readiness.mts`'s `--claim-id` /
+ * `--expected-claim-id` precedent). `-1` (never given) sorts before any
+ * real index, so an absent flag never wins against one that was
+ * actually passed.
+ */
+function resolveLastGivenAlias(
+  argv,
+  canonicalFlag,
+  canonicalValue,
+  deprecatedFlag,
+  deprecatedValue,
+) {
+  if (canonicalValue === undefined) {
+    return deprecatedValue;
+  }
+  if (deprecatedValue === undefined) {
+    return canonicalValue;
+  }
+  const lastCanonicalIndex = findLastFlagOccurrenceIndex(argv, canonicalFlag);
+  const lastDeprecatedIndex = findLastFlagOccurrenceIndex(argv, deprecatedFlag);
+  return lastDeprecatedIndex > lastCanonicalIndex
+    ? deprecatedValue
+    : canonicalValue;
+}
 function parseArgs(argv) {
   const { values, help } = parseCliArgs(argv, CLAIM_APPROVAL_GATE_FLAG_SPEC);
   const issueToken = values.issue;
+  const ghToken = resolveLastGivenAlias(
+    argv,
+    '--gh-token',
+    values['gh-token'],
+    '--token',
+    values.token,
+  );
+  const deprecatedTokenValue = values.token;
+  if (deprecatedTokenValue !== undefined) {
+    warnDeprecatedFlag('--token', '--gh-token');
+  }
   return {
     // Kept as lenient Number.parseInt (not the canonical-integer helper),
     // matching the pre-migration contract exactly: this file's own
@@ -308,7 +366,7 @@ function parseArgs(argv) {
     owner: values.owner ?? '',
     repo: values.repo ?? '',
     policy: values.policy ?? '',
-    token: values.token ?? '',
+    ghToken: ghToken ?? '',
     generatedPlanUpdatedAt: values['generated-plan-updated-at'] ?? '',
     verbose: values.verbose,
     help,
@@ -316,7 +374,8 @@ function parseArgs(argv) {
 }
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/claim-approval-gate.mjs --issue <number> [--token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--generated-plan-updated-at <ISO8601>] [--verbose]
+  node scripts/claim-approval-gate.mjs --issue <number> [--gh-token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--generated-plan-updated-at <ISO8601>] [--verbose]
+  Deprecated aliases (one release): --token -> --gh-token
 
 Output schema:
 {

--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -42,6 +42,7 @@ const RESUME_CLAIM_ROUTING_FLAG_SPEC = {
   '--issue': { type: 'string' },
   '--owner': { type: 'string' },
   '--repo': { type: 'string' },
+  '--gh-token': { type: 'string' },
   '--token': { type: 'string' },
   '--claim-id': { type: 'string' },
   '--nonce': { type: 'string' },
@@ -313,9 +314,9 @@ function runCli() {
   if (!Number.isInteger(args.issue) || (args.issue ?? 0) <= 0) {
     throw new Error('--issue is required and must be a positive integer');
   }
-  if (args.token) {
-    process.env.GH_TOKEN = args.token;
-    process.env.GITHUB_TOKEN = args.token;
+  if (args.ghToken) {
+    process.env.GH_TOKEN = args.ghToken;
+    process.env.GITHUB_TOKEN = args.ghToken;
   }
   const owner =
     args.owner ||
@@ -691,10 +692,67 @@ function compareEvents(left, right) {
   }
   return compareIso(left.createdAt, right.createdAt);
 }
+function warnDeprecatedFlag(deprecated, canonical) {
+  process.stderr.write(
+    `warning: ${deprecated} is deprecated; use ${canonical} instead.\n`,
+  );
+}
+/**
+ * Find `flag`'s last occurrence in `argv`, recognizing both the
+ * two-token form (`--flag value`) and the single-token `--flag=value`
+ * form `parseCliArgs` also accepts.
+ */
+function findLastFlagOccurrenceIndex(argv, flag) {
+  const equalsPrefix = `${flag}=`;
+  for (let index = argv.length - 1; index >= 0; index -= 1) {
+    if (argv[index] === flag || argv[index].startsWith(equalsPrefix)) {
+      return index;
+    }
+  }
+  return -1;
+}
+/**
+ * Resolve a canonical/deprecated flag pair: whichever flag's LAST
+ * occurrence comes later in argv wins when both spellings are given
+ * together (matches `pre-merge-readiness.mts`'s `--claim-id` /
+ * `--expected-claim-id` precedent). `-1` (never given) sorts before any
+ * real index, so an absent flag never wins against one that was
+ * actually passed.
+ */
+function resolveLastGivenAlias(
+  argv,
+  canonicalFlag,
+  canonicalValue,
+  deprecatedFlag,
+  deprecatedValue,
+) {
+  if (canonicalValue === undefined) {
+    return deprecatedValue;
+  }
+  if (deprecatedValue === undefined) {
+    return canonicalValue;
+  }
+  const lastCanonicalIndex = findLastFlagOccurrenceIndex(argv, canonicalFlag);
+  const lastDeprecatedIndex = findLastFlagOccurrenceIndex(argv, deprecatedFlag);
+  return lastDeprecatedIndex > lastCanonicalIndex
+    ? deprecatedValue
+    : canonicalValue;
+}
 function parseArgs(argv) {
   const { values, help } = parseCliArgs(argv, RESUME_CLAIM_ROUTING_FLAG_SPEC);
   const issueToken = values.issue;
   const staleAgeMsToken = values['stale-age-ms'];
+  const ghToken = resolveLastGivenAlias(
+    argv,
+    '--gh-token',
+    values['gh-token'],
+    '--token',
+    values.token,
+  );
+  const deprecatedTokenValue = values.token;
+  if (deprecatedTokenValue !== undefined) {
+    warnDeprecatedFlag('--token', '--gh-token');
+  }
   return {
     // Both --issue and --stale-age-ms are kept as lenient Number.parseInt
     // (not the canonical-integer helper), matching the pre-migration
@@ -708,7 +766,7 @@ function parseArgs(argv) {
     issue: issueToken === undefined ? null : Number.parseInt(issueToken, 10),
     owner: values.owner ?? '',
     repo: values.repo ?? '',
-    token: values.token ?? '',
+    ghToken: ghToken ?? '',
     claimId: values['claim-id'] ?? '',
     nonce: values.nonce ?? '',
     now: values.now ?? '',
@@ -722,7 +780,8 @@ function parseArgs(argv) {
 }
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/resume-claim-routing.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--token <token>] [--claim-id <token>] [--nonce <token>] [--now <ISO8601>] [--policy <path>] [--stale-age-ms <ms>] [--trusted-marker-logins "<a,b,...>"] [--fresh-claim-gate]
+  node scripts/resume-claim-routing.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--gh-token <token>] [--claim-id <token>] [--nonce <token>] [--now <ISO8601>] [--policy <path>] [--stale-age-ms <ms>] [--trusted-marker-logins "<a,b,...>"] [--fresh-claim-gate]
+  Deprecated aliases (one release): --token -> --gh-token
 
   --fresh-claim-gate  emit the write-side A5(c) claimability verdict for the
                       issue from current marker state, ignoring --claim-id (a

--- a/scripts/resume-route-selection.mjs
+++ b/scripts/resume-route-selection.mjs
@@ -55,6 +55,7 @@ const RESUME_ROUTE_SELECTION_FLAG_SPEC = {
   '--issue': { type: 'string' },
   '--owner': { type: 'string' },
   '--repo': { type: 'string' },
+  '--gh-token': { type: 'string' },
   '--token': { type: 'string' },
   '--table-dump': { type: 'boolean', default: false },
   '--help': { type: 'boolean', short: 'h' },
@@ -153,9 +154,9 @@ function runCli() {
   if (!Number.isInteger(args.issue) || (args.issue ?? 0) <= 0) {
     throw new Error('--issue is required and must be a positive integer');
   }
-  if (args.token) {
-    process.env.GH_TOKEN = args.token;
-    process.env.GITHUB_TOKEN = args.token;
+  if (args.ghToken) {
+    process.env.GH_TOKEN = args.ghToken;
+    process.env.GITHUB_TOKEN = args.ghToken;
   }
   const owner =
     args.owner ||
@@ -490,9 +491,66 @@ function fetchReviewThreads({ owner, repo, number }) {
   }
   return threads;
 }
+function warnDeprecatedFlag(deprecated, canonical) {
+  process.stderr.write(
+    `warning: ${deprecated} is deprecated; use ${canonical} instead.\n`,
+  );
+}
+/**
+ * Find `flag`'s last occurrence in `argv`, recognizing both the
+ * two-token form (`--flag value`) and the single-token `--flag=value`
+ * form `parseCliArgs` also accepts.
+ */
+function findLastFlagOccurrenceIndex(argv, flag) {
+  const equalsPrefix = `${flag}=`;
+  for (let index = argv.length - 1; index >= 0; index -= 1) {
+    if (argv[index] === flag || argv[index].startsWith(equalsPrefix)) {
+      return index;
+    }
+  }
+  return -1;
+}
+/**
+ * Resolve a canonical/deprecated flag pair: whichever flag's LAST
+ * occurrence comes later in argv wins when both spellings are given
+ * together (matches `pre-merge-readiness.mts`'s `--claim-id` /
+ * `--expected-claim-id` precedent). `-1` (never given) sorts before any
+ * real index, so an absent flag never wins against one that was
+ * actually passed.
+ */
+function resolveLastGivenAlias(
+  argv,
+  canonicalFlag,
+  canonicalValue,
+  deprecatedFlag,
+  deprecatedValue,
+) {
+  if (canonicalValue === undefined) {
+    return deprecatedValue;
+  }
+  if (deprecatedValue === undefined) {
+    return canonicalValue;
+  }
+  const lastCanonicalIndex = findLastFlagOccurrenceIndex(argv, canonicalFlag);
+  const lastDeprecatedIndex = findLastFlagOccurrenceIndex(argv, deprecatedFlag);
+  return lastDeprecatedIndex > lastCanonicalIndex
+    ? deprecatedValue
+    : canonicalValue;
+}
 function parseArgs(argv) {
   const { values, help } = parseCliArgs(argv, RESUME_ROUTE_SELECTION_FLAG_SPEC);
   const issueToken = values.issue;
+  const ghToken = resolveLastGivenAlias(
+    argv,
+    '--gh-token',
+    values['gh-token'],
+    '--token',
+    values.token,
+  );
+  const deprecatedTokenValue = values.token;
+  if (deprecatedTokenValue !== undefined) {
+    warnDeprecatedFlag('--token', '--gh-token');
+  }
   return {
     // Kept as lenient Number.parseInt (not the canonical-integer helper),
     // matching the pre-migration contract exactly -- see #1451's PR
@@ -500,14 +558,15 @@ function parseArgs(argv) {
     issue: issueToken === undefined ? null : Number.parseInt(issueToken, 10),
     owner: values.owner ?? '',
     repo: values.repo ?? '',
-    token: values.token ?? '',
+    ghToken: ghToken ?? '',
     tableDump: values['table-dump'],
     help,
   };
 }
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/resume-route-selection.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--token <token>] [--table-dump]
+  node scripts/resume-route-selection.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--gh-token <token>] [--table-dump]
+  Deprecated aliases (one release): --token -> --gh-token
 
 Output schema:
 {

--- a/scripts/stalled-session-quiet-check.mjs
+++ b/scripts/stalled-session-quiet-check.mjs
@@ -29,6 +29,7 @@ const STALLED_SESSION_QUIET_CHECK_FLAG_SPEC = {
   '--pr': { type: 'string' },
   '--owner': { type: 'string' },
   '--repo': { type: 'string' },
+  '--gh-token': { type: 'string' },
   '--token': { type: 'string' },
   '--now': { type: 'string' },
   '--quiet-window-ms': { type: 'string' },
@@ -143,9 +144,9 @@ function runCli() {
   if (args.pr === null || !Number.isInteger(args.pr) || args.pr <= 0) {
     throw new Error('--pr is required and must be a positive integer');
   }
-  if (args.token) {
-    process.env.GH_TOKEN = args.token;
-    process.env.GITHUB_TOKEN = args.token;
+  if (args.ghToken) {
+    process.env.GH_TOKEN = args.ghToken;
+    process.env.GITHUB_TOKEN = args.ghToken;
   }
   const owner =
     args.owner ||
@@ -309,6 +310,52 @@ function parseDurationToMs(value) {
   const seconds = Number.parseInt(match[4] ?? '0', 10);
   return (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000;
 }
+function warnDeprecatedFlag(deprecated, canonical) {
+  process.stderr.write(
+    `warning: ${deprecated} is deprecated; use ${canonical} instead.\n`,
+  );
+}
+/**
+ * Find `flag`'s last occurrence in `argv`, recognizing both the
+ * two-token form (`--flag value`) and the single-token `--flag=value`
+ * form `parseCliArgs` also accepts.
+ */
+function findLastFlagOccurrenceIndex(argv, flag) {
+  const equalsPrefix = `${flag}=`;
+  for (let index = argv.length - 1; index >= 0; index -= 1) {
+    if (argv[index] === flag || argv[index].startsWith(equalsPrefix)) {
+      return index;
+    }
+  }
+  return -1;
+}
+/**
+ * Resolve a canonical/deprecated flag pair: whichever flag's LAST
+ * occurrence comes later in argv wins when both spellings are given
+ * together (matches `pre-merge-readiness.mts`'s `--claim-id` /
+ * `--expected-claim-id` precedent). `-1` (never given) sorts before any
+ * real index, so an absent flag never wins against one that was
+ * actually passed.
+ */
+function resolveLastGivenAlias(
+  argv,
+  canonicalFlag,
+  canonicalValue,
+  deprecatedFlag,
+  deprecatedValue,
+) {
+  if (canonicalValue === undefined) {
+    return deprecatedValue;
+  }
+  if (deprecatedValue === undefined) {
+    return canonicalValue;
+  }
+  const lastCanonicalIndex = findLastFlagOccurrenceIndex(argv, canonicalFlag);
+  const lastDeprecatedIndex = findLastFlagOccurrenceIndex(argv, deprecatedFlag);
+  return lastDeprecatedIndex > lastCanonicalIndex
+    ? deprecatedValue
+    : canonicalValue;
+}
 function parseArgs(argv) {
   const { values, help } = parseCliArgs(
     argv,
@@ -316,6 +363,17 @@ function parseArgs(argv) {
   );
   const prToken = values.pr;
   const quietWindowMsToken = values['quiet-window-ms'];
+  const ghToken = resolveLastGivenAlias(
+    argv,
+    '--gh-token',
+    values['gh-token'],
+    '--token',
+    values.token,
+  );
+  const deprecatedTokenValue = values.token;
+  if (deprecatedTokenValue !== undefined) {
+    warnDeprecatedFlag('--token', '--gh-token');
+  }
   return {
     // Both --pr and --quiet-window-ms are kept as lenient Number.parseInt
     // (not the canonical-integer helper), matching the pre-migration
@@ -329,7 +387,7 @@ function parseArgs(argv) {
     pr: prToken === undefined ? null : Number.parseInt(prToken, 10),
     owner: values.owner ?? '',
     repo: values.repo ?? '',
-    token: values.token ?? '',
+    ghToken: ghToken ?? '',
     now: values.now ?? '',
     quietWindowMs:
       quietWindowMsToken === undefined
@@ -343,8 +401,9 @@ function parseArgs(argv) {
 function printHelp() {
   process.stdout.write(`Usage:
   node scripts/stalled-session-quiet-check.mjs --pr <number> [--owner <owner>] [--repo <repo>]
-    [--token <token>] [--now <ISO8601>] [--quiet-window-ms <ms>]
+    [--gh-token <token>] [--now <ISO8601>] [--quiet-window-ms <ms>]
     [--claim-created-at <ISO8601>] [--policy <path>]
+  Deprecated aliases (one release): --token -> --gh-token
 
 Evaluates the S2 quiet-window check for stalled-session detection.
 Outputs JSON with quiet_window_met and evidence fields.

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -65,7 +65,8 @@ const SUITABILITY_TRIAGE_FLAG_SPEC = {
   '--issue': { type: 'string' },
   '--body-file': { type: 'string' },
   '--stdin': { type: 'boolean', default: false },
-  '--token': { type: 'string', default: '' },
+  '--gh-token': { type: 'string' },
+  '--token': { type: 'string' },
   '--owner': { type: 'string', default: '' },
   '--repo': { type: 'string', default: '' },
   '--policy': { type: 'string', default: '' },
@@ -1133,9 +1134,9 @@ function runCli() {
   if (args.issue === null || !Number.isInteger(args.issue) || args.issue <= 0) {
     throw new Error('--issue is required and must be a positive integer');
   }
-  if (args.token) {
-    process.env.GH_TOKEN = args.token;
-    process.env.GITHUB_TOKEN = args.token;
+  if (args.ghToken) {
+    process.env.GH_TOKEN = args.ghToken;
+    process.env.GITHUB_TOKEN = args.ghToken;
   }
   const owner =
     args.owner ||
@@ -1482,13 +1483,70 @@ function runLocalCli(args) {
 function parseLenientIntegerOrNull(token) {
   return token === undefined ? null : Number.parseInt(token, 10);
 }
+function warnDeprecatedFlag(deprecated, canonical) {
+  process.stderr.write(
+    `warning: ${deprecated} is deprecated; use ${canonical} instead.\n`,
+  );
+}
+/**
+ * Find `flag`'s last occurrence in `argv`, recognizing both the
+ * two-token form (`--flag value`) and the single-token `--flag=value`
+ * form `parseCliArgs` also accepts.
+ */
+function findLastFlagOccurrenceIndex(argv, flag) {
+  const equalsPrefix = `${flag}=`;
+  for (let index = argv.length - 1; index >= 0; index -= 1) {
+    if (argv[index] === flag || argv[index].startsWith(equalsPrefix)) {
+      return index;
+    }
+  }
+  return -1;
+}
+/**
+ * Resolve a canonical/deprecated flag pair: whichever flag's LAST
+ * occurrence comes later in argv wins when both spellings are given
+ * together (matches `pre-merge-readiness.mts`'s `--claim-id` /
+ * `--expected-claim-id` precedent). `-1` (never given) sorts before any
+ * real index, so an absent flag never wins against one that was
+ * actually passed.
+ */
+function resolveLastGivenAlias(
+  argv,
+  canonicalFlag,
+  canonicalValue,
+  deprecatedFlag,
+  deprecatedValue,
+) {
+  if (canonicalValue === undefined) {
+    return deprecatedValue;
+  }
+  if (deprecatedValue === undefined) {
+    return canonicalValue;
+  }
+  const lastCanonicalIndex = findLastFlagOccurrenceIndex(argv, canonicalFlag);
+  const lastDeprecatedIndex = findLastFlagOccurrenceIndex(argv, deprecatedFlag);
+  return lastDeprecatedIndex > lastCanonicalIndex
+    ? deprecatedValue
+    : canonicalValue;
+}
 export function parseArgs(argv) {
   const { values, help } = parseCliArgs(argv, SUITABILITY_TRIAGE_FLAG_SPEC);
+  const ghToken = resolveLastGivenAlias(
+    argv,
+    '--gh-token',
+    values['gh-token'],
+    '--token',
+    values.token,
+  );
+  const deprecatedTokenValue = values.token;
+  if (deprecatedTokenValue !== undefined) {
+    warnDeprecatedFlag('--token', '--gh-token');
+  }
   return {
     issue: parseLenientIntegerOrNull(values.issue),
     bodyFile: values['body-file'],
     stdin: values.stdin,
-    token: values.token,
+    ghToken: ghToken ?? '',
     owner: values.owner,
     repo: values.repo,
     policy: values.policy,
@@ -1520,8 +1578,9 @@ function loadPolicy(policyPath) {
 }
 function printHelp() {
   process.stdout.write(`Usage:
-  node scripts/suitability-triage.mjs --issue <number> [--token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--manifest <path>] [--bundles <id1,id2>] [--verbose] [--help]
+  node scripts/suitability-triage.mjs --issue <number> [--gh-token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--manifest <path>] [--bundles <id1,id2>] [--verbose] [--help]
   node scripts/suitability-triage.mjs (--body-file <path> | --stdin) [--policy <path>] [--verbose] [--help]
+  Deprecated aliases (one release): --token -> --gh-token
 
 --issue, --body-file, and --stdin are mutually exclusive; exactly one is
 required. --body-file/--stdin (#2102) run a local, offline dry-run against

--- a/src/scripts/claim-approval-gate.mts
+++ b/src/scripts/claim-approval-gate.mts
@@ -106,6 +106,7 @@ const CLAIM_APPROVAL_GATE_FLAG_SPEC = {
   '--owner': { type: 'string' },
   '--repo': { type: 'string' },
   '--policy': { type: 'string' },
+  '--gh-token': { type: 'string' },
   '--token': { type: 'string' },
   '--generated-plan-updated-at': { type: 'string' },
   '--verbose': { type: 'boolean', default: false },
@@ -313,9 +314,9 @@ function runCli(): void {
   if (!Number.isInteger(args.issue) || (args.issue ?? 0) <= 0) {
     throw new Error('--issue is required and must be a positive integer');
   }
-  if (args.token) {
-    process.env.GH_TOKEN = args.token;
-    process.env.GITHUB_TOKEN = args.token;
+  if (args.ghToken) {
+    process.env.GH_TOKEN = args.ghToken;
+    process.env.GITHUB_TOKEN = args.ghToken;
   }
 
   const owner =
@@ -397,15 +398,78 @@ interface ParsedArgs {
   owner: string;
   repo: string;
   policy: string;
-  token: string;
+  ghToken: string;
   generatedPlanUpdatedAt: string;
   verbose: boolean;
   help: boolean;
 }
 
+function warnDeprecatedFlag(deprecated: string, canonical: string): void {
+  process.stderr.write(
+    `warning: ${deprecated} is deprecated; use ${canonical} instead.\n`,
+  );
+}
+
+/**
+ * Find `flag`'s last occurrence in `argv`, recognizing both the
+ * two-token form (`--flag value`) and the single-token `--flag=value`
+ * form `parseCliArgs` also accepts.
+ */
+function findLastFlagOccurrenceIndex(
+  argv: readonly string[],
+  flag: string,
+): number {
+  const equalsPrefix = `${flag}=`;
+  for (let index = argv.length - 1; index >= 0; index -= 1) {
+    if (argv[index] === flag || argv[index].startsWith(equalsPrefix)) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Resolve a canonical/deprecated flag pair: whichever flag's LAST
+ * occurrence comes later in argv wins when both spellings are given
+ * together (matches `pre-merge-readiness.mts`'s `--claim-id` /
+ * `--expected-claim-id` precedent). `-1` (never given) sorts before any
+ * real index, so an absent flag never wins against one that was
+ * actually passed.
+ */
+function resolveLastGivenAlias(
+  argv: readonly string[],
+  canonicalFlag: string,
+  canonicalValue: string | undefined,
+  deprecatedFlag: string,
+  deprecatedValue: string | undefined,
+): string | undefined {
+  if (canonicalValue === undefined) {
+    return deprecatedValue;
+  }
+  if (deprecatedValue === undefined) {
+    return canonicalValue;
+  }
+  const lastCanonicalIndex = findLastFlagOccurrenceIndex(argv, canonicalFlag);
+  const lastDeprecatedIndex = findLastFlagOccurrenceIndex(argv, deprecatedFlag);
+  return lastDeprecatedIndex > lastCanonicalIndex
+    ? deprecatedValue
+    : canonicalValue;
+}
+
 function parseArgs(argv: string[]): ParsedArgs {
   const { values, help } = parseCliArgs(argv, CLAIM_APPROVAL_GATE_FLAG_SPEC);
   const issueToken = values.issue as string | undefined;
+  const ghToken = resolveLastGivenAlias(
+    argv,
+    '--gh-token',
+    values['gh-token'] as string | undefined,
+    '--token',
+    values.token as string | undefined,
+  );
+  const deprecatedTokenValue = values.token as string | undefined;
+  if (deprecatedTokenValue !== undefined) {
+    warnDeprecatedFlag('--token', '--gh-token');
+  }
   return {
     // Kept as lenient Number.parseInt (not the canonical-integer helper),
     // matching the pre-migration contract exactly: this file's own
@@ -417,7 +481,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     owner: (values.owner as string | undefined) ?? '',
     repo: (values.repo as string | undefined) ?? '',
     policy: (values.policy as string | undefined) ?? '',
-    token: (values.token as string | undefined) ?? '',
+    ghToken: ghToken ?? '',
     generatedPlanUpdatedAt:
       (values['generated-plan-updated-at'] as string | undefined) ?? '',
     verbose: values.verbose as boolean,
@@ -427,7 +491,8 @@ function parseArgs(argv: string[]): ParsedArgs {
 
 function printHelp(): void {
   process.stdout.write(`Usage:
-  node scripts/claim-approval-gate.mjs --issue <number> [--token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--generated-plan-updated-at <ISO8601>] [--verbose]
+  node scripts/claim-approval-gate.mjs --issue <number> [--gh-token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--generated-plan-updated-at <ISO8601>] [--verbose]
+  Deprecated aliases (one release): --token -> --gh-token
 
 Output schema:
 {

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -125,7 +125,7 @@ interface ResumeClaimRoutingArgs {
   issue: number | null;
   owner: string;
   repo: string;
-  token: string;
+  ghToken: string;
   claimId: string;
   nonce: string;
   now: string;
@@ -155,6 +155,7 @@ const RESUME_CLAIM_ROUTING_FLAG_SPEC = {
   '--issue': { type: 'string' },
   '--owner': { type: 'string' },
   '--repo': { type: 'string' },
+  '--gh-token': { type: 'string' },
   '--token': { type: 'string' },
   '--claim-id': { type: 'string' },
   '--nonce': { type: 'string' },
@@ -460,9 +461,9 @@ function runCli(): void {
   if (!Number.isInteger(args.issue) || (args.issue ?? 0) <= 0) {
     throw new Error('--issue is required and must be a positive integer');
   }
-  if (args.token) {
-    process.env.GH_TOKEN = args.token;
-    process.env.GITHUB_TOKEN = args.token;
+  if (args.ghToken) {
+    process.env.GH_TOKEN = args.ghToken;
+    process.env.GITHUB_TOKEN = args.ghToken;
   }
 
   const owner =
@@ -922,10 +923,73 @@ function compareEvents(
   return compareIso(left.createdAt, right.createdAt);
 }
 
+function warnDeprecatedFlag(deprecated: string, canonical: string): void {
+  process.stderr.write(
+    `warning: ${deprecated} is deprecated; use ${canonical} instead.\n`,
+  );
+}
+
+/**
+ * Find `flag`'s last occurrence in `argv`, recognizing both the
+ * two-token form (`--flag value`) and the single-token `--flag=value`
+ * form `parseCliArgs` also accepts.
+ */
+function findLastFlagOccurrenceIndex(
+  argv: readonly string[],
+  flag: string,
+): number {
+  const equalsPrefix = `${flag}=`;
+  for (let index = argv.length - 1; index >= 0; index -= 1) {
+    if (argv[index] === flag || argv[index].startsWith(equalsPrefix)) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Resolve a canonical/deprecated flag pair: whichever flag's LAST
+ * occurrence comes later in argv wins when both spellings are given
+ * together (matches `pre-merge-readiness.mts`'s `--claim-id` /
+ * `--expected-claim-id` precedent). `-1` (never given) sorts before any
+ * real index, so an absent flag never wins against one that was
+ * actually passed.
+ */
+function resolveLastGivenAlias(
+  argv: readonly string[],
+  canonicalFlag: string,
+  canonicalValue: string | undefined,
+  deprecatedFlag: string,
+  deprecatedValue: string | undefined,
+): string | undefined {
+  if (canonicalValue === undefined) {
+    return deprecatedValue;
+  }
+  if (deprecatedValue === undefined) {
+    return canonicalValue;
+  }
+  const lastCanonicalIndex = findLastFlagOccurrenceIndex(argv, canonicalFlag);
+  const lastDeprecatedIndex = findLastFlagOccurrenceIndex(argv, deprecatedFlag);
+  return lastDeprecatedIndex > lastCanonicalIndex
+    ? deprecatedValue
+    : canonicalValue;
+}
+
 function parseArgs(argv: string[]): ResumeClaimRoutingArgs {
   const { values, help } = parseCliArgs(argv, RESUME_CLAIM_ROUTING_FLAG_SPEC);
   const issueToken = values.issue as string | undefined;
   const staleAgeMsToken = values['stale-age-ms'] as string | undefined;
+  const ghToken = resolveLastGivenAlias(
+    argv,
+    '--gh-token',
+    values['gh-token'] as string | undefined,
+    '--token',
+    values.token as string | undefined,
+  );
+  const deprecatedTokenValue = values.token as string | undefined;
+  if (deprecatedTokenValue !== undefined) {
+    warnDeprecatedFlag('--token', '--gh-token');
+  }
   return {
     // Both --issue and --stale-age-ms are kept as lenient Number.parseInt
     // (not the canonical-integer helper), matching the pre-migration
@@ -939,7 +1003,7 @@ function parseArgs(argv: string[]): ResumeClaimRoutingArgs {
     issue: issueToken === undefined ? null : Number.parseInt(issueToken, 10),
     owner: (values.owner as string | undefined) ?? '',
     repo: (values.repo as string | undefined) ?? '',
-    token: (values.token as string | undefined) ?? '',
+    ghToken: ghToken ?? '',
     claimId: (values['claim-id'] as string | undefined) ?? '',
     nonce: (values.nonce as string | undefined) ?? '',
     now: (values.now as string | undefined) ?? '',
@@ -955,7 +1019,8 @@ function parseArgs(argv: string[]): ResumeClaimRoutingArgs {
 
 function printHelp(): void {
   process.stdout.write(`Usage:
-  node scripts/resume-claim-routing.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--token <token>] [--claim-id <token>] [--nonce <token>] [--now <ISO8601>] [--policy <path>] [--stale-age-ms <ms>] [--trusted-marker-logins "<a,b,...>"] [--fresh-claim-gate]
+  node scripts/resume-claim-routing.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--gh-token <token>] [--claim-id <token>] [--nonce <token>] [--now <ISO8601>] [--policy <path>] [--stale-age-ms <ms>] [--trusted-marker-logins "<a,b,...>"] [--fresh-claim-gate]
+  Deprecated aliases (one release): --token -> --gh-token
 
   --fresh-claim-gate  emit the write-side A5(c) claimability verdict for the
                       issue from current marker state, ignoring --claim-id (a

--- a/src/scripts/resume-route-selection.mts
+++ b/src/scripts/resume-route-selection.mts
@@ -98,7 +98,7 @@ interface ResumeRouteSelectionArgs {
   issue: number | null;
   owner: string;
   repo: string;
-  token: string;
+  ghToken: string;
   tableDump: boolean;
   help: boolean;
 }
@@ -147,6 +147,7 @@ const RESUME_ROUTE_SELECTION_FLAG_SPEC = {
   '--issue': { type: 'string' },
   '--owner': { type: 'string' },
   '--repo': { type: 'string' },
+  '--gh-token': { type: 'string' },
   '--token': { type: 'string' },
   '--table-dump': { type: 'boolean', default: false },
   '--help': { type: 'boolean', short: 'h' },
@@ -255,9 +256,9 @@ function runCli(): void {
   if (!Number.isInteger(args.issue) || (args.issue ?? 0) <= 0) {
     throw new Error('--issue is required and must be a positive integer');
   }
-  if (args.token) {
-    process.env.GH_TOKEN = args.token;
-    process.env.GITHUB_TOKEN = args.token;
+  if (args.ghToken) {
+    process.env.GH_TOKEN = args.ghToken;
+    process.env.GITHUB_TOKEN = args.ghToken;
   }
 
   const owner =
@@ -671,9 +672,72 @@ function fetchReviewThreads({
   return threads;
 }
 
+function warnDeprecatedFlag(deprecated: string, canonical: string): void {
+  process.stderr.write(
+    `warning: ${deprecated} is deprecated; use ${canonical} instead.\n`,
+  );
+}
+
+/**
+ * Find `flag`'s last occurrence in `argv`, recognizing both the
+ * two-token form (`--flag value`) and the single-token `--flag=value`
+ * form `parseCliArgs` also accepts.
+ */
+function findLastFlagOccurrenceIndex(
+  argv: readonly string[],
+  flag: string,
+): number {
+  const equalsPrefix = `${flag}=`;
+  for (let index = argv.length - 1; index >= 0; index -= 1) {
+    if (argv[index] === flag || argv[index].startsWith(equalsPrefix)) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Resolve a canonical/deprecated flag pair: whichever flag's LAST
+ * occurrence comes later in argv wins when both spellings are given
+ * together (matches `pre-merge-readiness.mts`'s `--claim-id` /
+ * `--expected-claim-id` precedent). `-1` (never given) sorts before any
+ * real index, so an absent flag never wins against one that was
+ * actually passed.
+ */
+function resolveLastGivenAlias(
+  argv: readonly string[],
+  canonicalFlag: string,
+  canonicalValue: string | undefined,
+  deprecatedFlag: string,
+  deprecatedValue: string | undefined,
+): string | undefined {
+  if (canonicalValue === undefined) {
+    return deprecatedValue;
+  }
+  if (deprecatedValue === undefined) {
+    return canonicalValue;
+  }
+  const lastCanonicalIndex = findLastFlagOccurrenceIndex(argv, canonicalFlag);
+  const lastDeprecatedIndex = findLastFlagOccurrenceIndex(argv, deprecatedFlag);
+  return lastDeprecatedIndex > lastCanonicalIndex
+    ? deprecatedValue
+    : canonicalValue;
+}
+
 function parseArgs(argv: string[]): ResumeRouteSelectionArgs {
   const { values, help } = parseCliArgs(argv, RESUME_ROUTE_SELECTION_FLAG_SPEC);
   const issueToken = values.issue as string | undefined;
+  const ghToken = resolveLastGivenAlias(
+    argv,
+    '--gh-token',
+    values['gh-token'] as string | undefined,
+    '--token',
+    values.token as string | undefined,
+  );
+  const deprecatedTokenValue = values.token as string | undefined;
+  if (deprecatedTokenValue !== undefined) {
+    warnDeprecatedFlag('--token', '--gh-token');
+  }
   return {
     // Kept as lenient Number.parseInt (not the canonical-integer helper),
     // matching the pre-migration contract exactly -- see #1451's PR
@@ -681,7 +745,7 @@ function parseArgs(argv: string[]): ResumeRouteSelectionArgs {
     issue: issueToken === undefined ? null : Number.parseInt(issueToken, 10),
     owner: (values.owner as string | undefined) ?? '',
     repo: (values.repo as string | undefined) ?? '',
-    token: (values.token as string | undefined) ?? '',
+    ghToken: ghToken ?? '',
     tableDump: values['table-dump'] as boolean,
     help,
   };
@@ -689,7 +753,8 @@ function parseArgs(argv: string[]): ResumeRouteSelectionArgs {
 
 function printHelp(): void {
   process.stdout.write(`Usage:
-  node scripts/resume-route-selection.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--token <token>] [--table-dump]
+  node scripts/resume-route-selection.mjs --issue <number> [--owner <owner>] [--repo <repo>] [--gh-token <token>] [--table-dump]
+  Deprecated aliases (one release): --token -> --gh-token
 
 Output schema:
 {

--- a/src/scripts/stalled-session-quiet-check.mts
+++ b/src/scripts/stalled-session-quiet-check.mts
@@ -60,7 +60,7 @@ interface QuietArgs {
   pr: number | null;
   owner: string;
   repo: string;
-  token: string;
+  ghToken: string;
   now: string;
   quietWindowMs: number;
   claimCreatedAt: string;
@@ -82,6 +82,7 @@ const STALLED_SESSION_QUIET_CHECK_FLAG_SPEC = {
   '--pr': { type: 'string' },
   '--owner': { type: 'string' },
   '--repo': { type: 'string' },
+  '--gh-token': { type: 'string' },
   '--token': { type: 'string' },
   '--now': { type: 'string' },
   '--quiet-window-ms': { type: 'string' },
@@ -211,9 +212,9 @@ function runCli(): void {
   if (args.pr === null || !Number.isInteger(args.pr) || args.pr <= 0) {
     throw new Error('--pr is required and must be a positive integer');
   }
-  if (args.token) {
-    process.env.GH_TOKEN = args.token;
-    process.env.GITHUB_TOKEN = args.token;
+  if (args.ghToken) {
+    process.env.GH_TOKEN = args.ghToken;
+    process.env.GITHUB_TOKEN = args.ghToken;
   }
 
   const owner =
@@ -411,6 +412,58 @@ function parseDurationToMs(value: unknown): number | null {
   return (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1000;
 }
 
+function warnDeprecatedFlag(deprecated: string, canonical: string): void {
+  process.stderr.write(
+    `warning: ${deprecated} is deprecated; use ${canonical} instead.\n`,
+  );
+}
+
+/**
+ * Find `flag`'s last occurrence in `argv`, recognizing both the
+ * two-token form (`--flag value`) and the single-token `--flag=value`
+ * form `parseCliArgs` also accepts.
+ */
+function findLastFlagOccurrenceIndex(
+  argv: readonly string[],
+  flag: string,
+): number {
+  const equalsPrefix = `${flag}=`;
+  for (let index = argv.length - 1; index >= 0; index -= 1) {
+    if (argv[index] === flag || argv[index].startsWith(equalsPrefix)) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Resolve a canonical/deprecated flag pair: whichever flag's LAST
+ * occurrence comes later in argv wins when both spellings are given
+ * together (matches `pre-merge-readiness.mts`'s `--claim-id` /
+ * `--expected-claim-id` precedent). `-1` (never given) sorts before any
+ * real index, so an absent flag never wins against one that was
+ * actually passed.
+ */
+function resolveLastGivenAlias(
+  argv: readonly string[],
+  canonicalFlag: string,
+  canonicalValue: string | undefined,
+  deprecatedFlag: string,
+  deprecatedValue: string | undefined,
+): string | undefined {
+  if (canonicalValue === undefined) {
+    return deprecatedValue;
+  }
+  if (deprecatedValue === undefined) {
+    return canonicalValue;
+  }
+  const lastCanonicalIndex = findLastFlagOccurrenceIndex(argv, canonicalFlag);
+  const lastDeprecatedIndex = findLastFlagOccurrenceIndex(argv, deprecatedFlag);
+  return lastDeprecatedIndex > lastCanonicalIndex
+    ? deprecatedValue
+    : canonicalValue;
+}
+
 function parseArgs(argv: string[]): QuietArgs {
   const { values, help } = parseCliArgs(
     argv,
@@ -418,6 +471,17 @@ function parseArgs(argv: string[]): QuietArgs {
   );
   const prToken = values.pr as string | undefined;
   const quietWindowMsToken = values['quiet-window-ms'] as string | undefined;
+  const ghToken = resolveLastGivenAlias(
+    argv,
+    '--gh-token',
+    values['gh-token'] as string | undefined,
+    '--token',
+    values.token as string | undefined,
+  );
+  const deprecatedTokenValue = values.token as string | undefined;
+  if (deprecatedTokenValue !== undefined) {
+    warnDeprecatedFlag('--token', '--gh-token');
+  }
   return {
     // Both --pr and --quiet-window-ms are kept as lenient Number.parseInt
     // (not the canonical-integer helper), matching the pre-migration
@@ -431,7 +495,7 @@ function parseArgs(argv: string[]): QuietArgs {
     pr: prToken === undefined ? null : Number.parseInt(prToken, 10),
     owner: (values.owner as string | undefined) ?? '',
     repo: (values.repo as string | undefined) ?? '',
-    token: (values.token as string | undefined) ?? '',
+    ghToken: ghToken ?? '',
     now: (values.now as string | undefined) ?? '',
     quietWindowMs:
       quietWindowMsToken === undefined
@@ -446,8 +510,9 @@ function parseArgs(argv: string[]): QuietArgs {
 function printHelp(): void {
   process.stdout.write(`Usage:
   node scripts/stalled-session-quiet-check.mjs --pr <number> [--owner <owner>] [--repo <repo>]
-    [--token <token>] [--now <ISO8601>] [--quiet-window-ms <ms>]
+    [--gh-token <token>] [--now <ISO8601>] [--quiet-window-ms <ms>]
     [--claim-created-at <ISO8601>] [--policy <path>]
+  Deprecated aliases (one release): --token -> --gh-token
 
 Evaluates the S2 quiet-window check for stalled-session detection.
 Outputs JSON with quiet_window_met and evidence fields.

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -64,7 +64,7 @@ interface SuitabilityTriageArgs {
   bodyFile?: string;
   /** #2102: local/offline dry-run input, mutually exclusive with --issue. */
   stdin: boolean;
-  token: string;
+  ghToken: string;
   owner: string;
   repo: string;
   policy: string;
@@ -98,7 +98,8 @@ const SUITABILITY_TRIAGE_FLAG_SPEC = {
   '--issue': { type: 'string' },
   '--body-file': { type: 'string' },
   '--stdin': { type: 'boolean', default: false },
-  '--token': { type: 'string', default: '' },
+  '--gh-token': { type: 'string' },
+  '--token': { type: 'string' },
   '--owner': { type: 'string', default: '' },
   '--repo': { type: 'string', default: '' },
   '--policy': { type: 'string', default: '' },
@@ -1330,9 +1331,9 @@ function runCli(): void {
   if (args.issue === null || !Number.isInteger(args.issue) || args.issue <= 0) {
     throw new Error('--issue is required and must be a positive integer');
   }
-  if (args.token) {
-    process.env.GH_TOKEN = args.token;
-    process.env.GITHUB_TOKEN = args.token;
+  if (args.ghToken) {
+    process.env.GH_TOKEN = args.ghToken;
+    process.env.GITHUB_TOKEN = args.ghToken;
   }
 
   const owner =
@@ -1716,13 +1717,76 @@ function parseLenientIntegerOrNull(token: string | undefined): number | null {
   return token === undefined ? null : Number.parseInt(token, 10);
 }
 
+function warnDeprecatedFlag(deprecated: string, canonical: string): void {
+  process.stderr.write(
+    `warning: ${deprecated} is deprecated; use ${canonical} instead.\n`,
+  );
+}
+
+/**
+ * Find `flag`'s last occurrence in `argv`, recognizing both the
+ * two-token form (`--flag value`) and the single-token `--flag=value`
+ * form `parseCliArgs` also accepts.
+ */
+function findLastFlagOccurrenceIndex(
+  argv: readonly string[],
+  flag: string,
+): number {
+  const equalsPrefix = `${flag}=`;
+  for (let index = argv.length - 1; index >= 0; index -= 1) {
+    if (argv[index] === flag || argv[index].startsWith(equalsPrefix)) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Resolve a canonical/deprecated flag pair: whichever flag's LAST
+ * occurrence comes later in argv wins when both spellings are given
+ * together (matches `pre-merge-readiness.mts`'s `--claim-id` /
+ * `--expected-claim-id` precedent). `-1` (never given) sorts before any
+ * real index, so an absent flag never wins against one that was
+ * actually passed.
+ */
+function resolveLastGivenAlias(
+  argv: readonly string[],
+  canonicalFlag: string,
+  canonicalValue: string | undefined,
+  deprecatedFlag: string,
+  deprecatedValue: string | undefined,
+): string | undefined {
+  if (canonicalValue === undefined) {
+    return deprecatedValue;
+  }
+  if (deprecatedValue === undefined) {
+    return canonicalValue;
+  }
+  const lastCanonicalIndex = findLastFlagOccurrenceIndex(argv, canonicalFlag);
+  const lastDeprecatedIndex = findLastFlagOccurrenceIndex(argv, deprecatedFlag);
+  return lastDeprecatedIndex > lastCanonicalIndex
+    ? deprecatedValue
+    : canonicalValue;
+}
+
 export function parseArgs(argv: string[]): SuitabilityTriageArgs {
   const { values, help } = parseCliArgs(argv, SUITABILITY_TRIAGE_FLAG_SPEC);
+  const ghToken = resolveLastGivenAlias(
+    argv,
+    '--gh-token',
+    values['gh-token'] as string | undefined,
+    '--token',
+    values.token as string | undefined,
+  );
+  const deprecatedTokenValue = values.token as string | undefined;
+  if (deprecatedTokenValue !== undefined) {
+    warnDeprecatedFlag('--token', '--gh-token');
+  }
   return {
     issue: parseLenientIntegerOrNull(values.issue as string | undefined),
     bodyFile: values['body-file'] as string | undefined,
     stdin: values.stdin as boolean,
-    token: values.token as string,
+    ghToken: ghToken ?? '',
     owner: values.owner as string,
     repo: values.repo as string,
     policy: values.policy as string,
@@ -1756,8 +1820,9 @@ function loadPolicy(policyPath: string): unknown {
 
 function printHelp(): void {
   process.stdout.write(`Usage:
-  node scripts/suitability-triage.mjs --issue <number> [--token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--manifest <path>] [--bundles <id1,id2>] [--verbose] [--help]
+  node scripts/suitability-triage.mjs --issue <number> [--gh-token <token>] [--owner <owner>] [--repo <repo>] [--policy <path>] [--manifest <path>] [--bundles <id1,id2>] [--verbose] [--help]
   node scripts/suitability-triage.mjs (--body-file <path> | --stdin) [--policy <path>] [--verbose] [--help]
+  Deprecated aliases (one release): --token -> --gh-token
 
 --issue, --body-file, and --stdin are mutually exclusive; exactly one is
 required. --body-file/--stdin (#2102) run a local, offline dry-run against

--- a/tests/claim-approval-gate.test.mts
+++ b/tests/claim-approval-gate.test.mts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -689,4 +689,107 @@ process.exit(1);
       ),
     /failed to load policy from .*bad-policy\.json/,
   );
+});
+
+// #2195: --token substituted GH_TOKEN/GITHUB_TOKEN for gh auth, ambiguous
+// against select-desynced-index.mjs's unrelated same-named session-desync
+// token. --gh-token is now canonical; --token stays a deprecated alias for
+// one release. A fake `gh` on PATH dumps GH_TOKEN/GITHUB_TOKEN to a side
+// file before failing (any real network call is out of scope for this
+// flag-propagation test), so the CLI process always exits non-zero -- only
+// the dumped env values matter here.
+function ghTokenPropagationFixture() {
+  const tempRoot = mkdtempSync(
+    join(tmpdir(), 'idd-claim-approval-gate-token-'),
+  );
+  const ghPath = join(tempRoot, 'gh');
+  const dumpPath = join(tempRoot, 'env-dump.json');
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+require('fs').writeFileSync(process.env.ENV_DUMP_PATH, JSON.stringify({
+  ghToken: process.env.GH_TOKEN ?? null,
+  githubToken: process.env.GITHUB_TOKEN ?? null,
+}));
+process.exit(1);
+`,
+  );
+  chmodSync(ghPath, 0o755);
+  return { tempRoot, ghPath, dumpPath };
+}
+
+function runClaimApprovalGateCli(
+  extraArgs: string[],
+  fixture: ReturnType<typeof ghTokenPropagationFixture>,
+) {
+  assert.throws(() =>
+    execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/claim-approval-gate.mjs'),
+        '--issue',
+        '1',
+        ...extraArgs,
+      ],
+      {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fixture.tempRoot}:${process.env.PATH ?? ''}`,
+          ENV_DUMP_PATH: fixture.dumpPath,
+        },
+      },
+    ),
+  );
+  return JSON.parse(readFileSync(fixture.dumpPath, 'utf8')) as {
+    ghToken: string | null;
+    githubToken: string | null;
+  };
+}
+
+test('--gh-token sets GH_TOKEN/GITHUB_TOKEN for gh auth', () => {
+  const fixture = ghTokenPropagationFixture();
+  const dump = runClaimApprovalGateCli(
+    ['--gh-token', 'canonical-test-token'],
+    fixture,
+  );
+  assert.equal(dump.ghToken, 'canonical-test-token');
+  assert.equal(dump.githubToken, 'canonical-test-token');
+});
+
+test('--token still sets GH_TOKEN/GITHUB_TOKEN and warns as a deprecated alias', () => {
+  const fixture = ghTokenPropagationFixture();
+  let stderr = '';
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/claim-approval-gate.mjs'),
+        '--issue',
+        '1',
+        '--token',
+        'deprecated-test-token',
+      ],
+      {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fixture.tempRoot}:${process.env.PATH ?? ''}`,
+          ENV_DUMP_PATH: fixture.dumpPath,
+        },
+      },
+    );
+    assert.fail('expected the CLI to exit non-zero');
+  } catch (error) {
+    stderr = String((error as { stderr?: unknown }).stderr ?? '');
+  }
+  const dump = JSON.parse(readFileSync(fixture.dumpPath, 'utf8')) as {
+    ghToken: string | null;
+    githubToken: string | null;
+  };
+  assert.equal(dump.ghToken, 'deprecated-test-token');
+  assert.equal(dump.githubToken, 'deprecated-test-token');
+  assert.match(stderr, /--token is deprecated; use --gh-token instead\./);
 });

--- a/tests/flag-name-matrix.test.mts
+++ b/tests/flag-name-matrix.test.mts
@@ -107,6 +107,23 @@ const FLAG_CONCEPTS = [
       'review-activity-snapshot.mjs',
     ],
   },
+  {
+    concept: 'GitHub auth token',
+    canonical: '--gh-token',
+    deprecated: '--token',
+    helpers: [
+      'claim-approval-gate.mjs',
+      'resume-claim-routing.mjs',
+      'resume-route-selection.mjs',
+      'stalled-session-quiet-check.mjs',
+      'suitability-triage.mjs',
+    ],
+    // select-desynced-index.mjs's own '--token' flag is the unrelated A4
+    // Step 2 session-desync token (idd-discover.instructions.md), not a
+    // GH-auth-token substitution -- exclude it from the broad deprecated-
+    // alias scan below so it never false-positives against this pair (#2195).
+    deprecatedScanExclude: ['select-desynced-index.mjs'],
+  },
 ];
 
 // Known near-miss spellings a future helper might plausibly introduce.
@@ -119,7 +136,13 @@ const NEAR_MISS_VARIANTS = [
   { variant: '--bot-logins', canonical: '--advisory-bot-logins' },
 ];
 
-for (const { concept, canonical, deprecated, helpers } of FLAG_CONCEPTS) {
+for (const {
+  concept,
+  canonical,
+  deprecated,
+  helpers,
+  deprecatedScanExclude,
+} of FLAG_CONCEPTS) {
   test(`every ${concept} helper exposes the canonical ${canonical}`, () => {
     for (const helper of helpers) {
       const src = readScript(helper);
@@ -136,6 +159,9 @@ for (const { concept, canonical, deprecated, helpers } of FLAG_CONCEPTS) {
 
   test(`no helper accepts ${deprecated} without the canonical ${canonical}`, () => {
     for (const file of scriptFiles) {
+      if (deprecatedScanExclude?.includes(file)) {
+        continue;
+      }
       const src = readScript(file);
       if (includesQuotedFlag(src, deprecated)) {
         assert.ok(
@@ -148,6 +174,9 @@ for (const { concept, canonical, deprecated, helpers } of FLAG_CONCEPTS) {
 
   test(`${deprecated} alias emits a stderr deprecation warning`, () => {
     for (const file of scriptFiles) {
+      if (deprecatedScanExclude?.includes(file)) {
+        continue;
+      }
       const src = readScript(file);
       if (!includesQuotedFlag(src, deprecated)) {
         continue;

--- a/tests/resume-claim-routing.test.mts
+++ b/tests/resume-claim-routing.test.mts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import {
   buildForcedHandoffEnabledGate,
@@ -1217,4 +1221,109 @@ test('runCli sources currentLogin from resolveViewerLogin (#2148)', () => {
     'utf8',
   );
   assert.match(source, /resolveViewerLogin\(GH_TEXT_LOOP_TIMEOUT_OPTIONS\)/);
+});
+
+// #2195: --token substituted GH_TOKEN/GITHUB_TOKEN for gh auth, ambiguous
+// against select-desynced-index.mjs's unrelated same-named session-desync
+// token. --gh-token is now canonical; --token stays a deprecated alias for
+// one release. A fake `gh` on PATH dumps GH_TOKEN/GITHUB_TOKEN to a side
+// file before failing (any real network call is out of scope for this
+// flag-propagation test), so the CLI process always exits non-zero -- only
+// the dumped env values matter here.
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+function ghTokenPropagationFixture() {
+  const tempRoot = mkdtempSync(
+    join(tmpdir(), 'idd-resume-claim-routing-token-'),
+  );
+  const ghPath = join(tempRoot, 'gh');
+  const dumpPath = join(tempRoot, 'env-dump.json');
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+require('fs').writeFileSync(process.env.ENV_DUMP_PATH, JSON.stringify({
+  ghToken: process.env.GH_TOKEN ?? null,
+  githubToken: process.env.GITHUB_TOKEN ?? null,
+}));
+process.exit(1);
+`,
+  );
+  chmodSync(ghPath, 0o755);
+  return { tempRoot, ghPath, dumpPath };
+}
+
+function runResumeClaimRoutingCli(
+  extraArgs: string[],
+  fixture: ReturnType<typeof ghTokenPropagationFixture>,
+) {
+  assert.throws(() =>
+    execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/resume-claim-routing.mjs'),
+        '--issue',
+        '1',
+        ...extraArgs,
+      ],
+      {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fixture.tempRoot}:${process.env.PATH ?? ''}`,
+          ENV_DUMP_PATH: fixture.dumpPath,
+        },
+      },
+    ),
+  );
+  return JSON.parse(readFileSync(fixture.dumpPath, 'utf8')) as {
+    ghToken: string | null;
+    githubToken: string | null;
+  };
+}
+
+test('--gh-token sets GH_TOKEN/GITHUB_TOKEN for gh auth', () => {
+  const fixture = ghTokenPropagationFixture();
+  const dump = runResumeClaimRoutingCli(
+    ['--gh-token', 'canonical-test-token'],
+    fixture,
+  );
+  assert.equal(dump.ghToken, 'canonical-test-token');
+  assert.equal(dump.githubToken, 'canonical-test-token');
+});
+
+test('--token still sets GH_TOKEN/GITHUB_TOKEN and warns as a deprecated alias', () => {
+  const fixture = ghTokenPropagationFixture();
+  let stderr = '';
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/resume-claim-routing.mjs'),
+        '--issue',
+        '1',
+        '--token',
+        'deprecated-test-token',
+      ],
+      {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fixture.tempRoot}:${process.env.PATH ?? ''}`,
+          ENV_DUMP_PATH: fixture.dumpPath,
+        },
+      },
+    );
+    assert.fail('expected the CLI to exit non-zero');
+  } catch (error) {
+    stderr = String((error as { stderr?: unknown }).stderr ?? '');
+  }
+  const dump = JSON.parse(readFileSync(fixture.dumpPath, 'utf8')) as {
+    ghToken: string | null;
+    githubToken: string | null;
+  };
+  assert.equal(dump.ghToken, 'deprecated-test-token');
+  assert.equal(dump.githubToken, 'deprecated-test-token');
+  assert.match(stderr, /--token is deprecated; use --gh-token instead\./);
 });

--- a/tests/resume-route-selection.test.mts
+++ b/tests/resume-route-selection.test.mts
@@ -1,5 +1,10 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import {
   classifyBranchState,
@@ -318,4 +323,109 @@ test('recovers empty required-check set from gh pr checks failure', () => {
   );
   assert.equal(recovered.recovered, true);
   assert.deepEqual(recovered.value, []);
+});
+
+// #2195: --token substituted GH_TOKEN/GITHUB_TOKEN for gh auth, ambiguous
+// against select-desynced-index.mjs's unrelated same-named session-desync
+// token. --gh-token is now canonical; --token stays a deprecated alias for
+// one release. A fake `gh` on PATH dumps GH_TOKEN/GITHUB_TOKEN to a side
+// file before failing (any real network call is out of scope for this
+// flag-propagation test), so the CLI process always exits non-zero -- only
+// the dumped env values matter here.
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+function ghTokenPropagationFixture() {
+  const tempRoot = mkdtempSync(
+    join(tmpdir(), 'idd-resume-route-selection-token-'),
+  );
+  const ghPath = join(tempRoot, 'gh');
+  const dumpPath = join(tempRoot, 'env-dump.json');
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+require('fs').writeFileSync(process.env.ENV_DUMP_PATH, JSON.stringify({
+  ghToken: process.env.GH_TOKEN ?? null,
+  githubToken: process.env.GITHUB_TOKEN ?? null,
+}));
+process.exit(1);
+`,
+  );
+  chmodSync(ghPath, 0o755);
+  return { tempRoot, ghPath, dumpPath };
+}
+
+function runResumeRouteSelectionCli(
+  extraArgs: string[],
+  fixture: ReturnType<typeof ghTokenPropagationFixture>,
+) {
+  assert.throws(() =>
+    execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/resume-route-selection.mjs'),
+        '--issue',
+        '1',
+        ...extraArgs,
+      ],
+      {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fixture.tempRoot}:${process.env.PATH ?? ''}`,
+          ENV_DUMP_PATH: fixture.dumpPath,
+        },
+      },
+    ),
+  );
+  return JSON.parse(readFileSync(fixture.dumpPath, 'utf8')) as {
+    ghToken: string | null;
+    githubToken: string | null;
+  };
+}
+
+test('--gh-token sets GH_TOKEN/GITHUB_TOKEN for gh auth', () => {
+  const fixture = ghTokenPropagationFixture();
+  const dump = runResumeRouteSelectionCli(
+    ['--gh-token', 'canonical-test-token'],
+    fixture,
+  );
+  assert.equal(dump.ghToken, 'canonical-test-token');
+  assert.equal(dump.githubToken, 'canonical-test-token');
+});
+
+test('--token still sets GH_TOKEN/GITHUB_TOKEN and warns as a deprecated alias', () => {
+  const fixture = ghTokenPropagationFixture();
+  let stderr = '';
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/resume-route-selection.mjs'),
+        '--issue',
+        '1',
+        '--token',
+        'deprecated-test-token',
+      ],
+      {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fixture.tempRoot}:${process.env.PATH ?? ''}`,
+          ENV_DUMP_PATH: fixture.dumpPath,
+        },
+      },
+    );
+    assert.fail('expected the CLI to exit non-zero');
+  } catch (error) {
+    stderr = String((error as { stderr?: unknown }).stderr ?? '');
+  }
+  const dump = JSON.parse(readFileSync(fixture.dumpPath, 'utf8')) as {
+    ghToken: string | null;
+    githubToken: string | null;
+  };
+  assert.equal(dump.ghToken, 'deprecated-test-token');
+  assert.equal(dump.githubToken, 'deprecated-test-token');
+  assert.match(stderr, /--token is deprecated; use --gh-token instead\./);
 });

--- a/tests/stalled-session-quiet-check.test.mts
+++ b/tests/stalled-session-quiet-check.test.mts
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import { evaluateQuietWindow } from '../src/scripts/stalled-session-quiet-check.mts';
 
@@ -117,5 +122,112 @@ describe('stalled-session-quiet-check', () => {
       () => evaluateQuietWindow({ now: 'invalid-timestamp', activities: [] }),
       /input\.now must be a valid ISO8601 timestamp/u,
     );
+  });
+});
+
+// #2195: --token substituted GH_TOKEN/GITHUB_TOKEN for gh auth, ambiguous
+// against select-desynced-index.mjs's unrelated same-named session-desync
+// token. --gh-token is now canonical; --token stays a deprecated alias for
+// one release. A fake `gh` on PATH dumps GH_TOKEN/GITHUB_TOKEN to a side
+// file before failing (any real network call is out of scope for this
+// flag-propagation test), so the CLI process always exits non-zero -- only
+// the dumped env values matter here.
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+function ghTokenPropagationFixture() {
+  const tempRoot = mkdtempSync(
+    join(tmpdir(), 'idd-stalled-session-quiet-check-token-'),
+  );
+  const ghPath = join(tempRoot, 'gh');
+  const dumpPath = join(tempRoot, 'env-dump.json');
+  writeFileSync(
+    ghPath,
+    `#!/usr/bin/env node
+require('fs').writeFileSync(process.env.ENV_DUMP_PATH, JSON.stringify({
+  ghToken: process.env.GH_TOKEN ?? null,
+  githubToken: process.env.GITHUB_TOKEN ?? null,
+}));
+process.exit(1);
+`,
+  );
+  chmodSync(ghPath, 0o755);
+  return { tempRoot, ghPath, dumpPath };
+}
+
+function runStalledSessionQuietCheckCli(
+  extraArgs: string[],
+  fixture: ReturnType<typeof ghTokenPropagationFixture>,
+) {
+  assert.throws(() =>
+    execFileSync(
+      process.execPath,
+      [
+        join(REPO_ROOT, 'scripts/stalled-session-quiet-check.mjs'),
+        '--pr',
+        '1',
+        ...extraArgs,
+      ],
+      {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          PATH: `${fixture.tempRoot}:${process.env.PATH ?? ''}`,
+          ENV_DUMP_PATH: fixture.dumpPath,
+        },
+      },
+    ),
+  );
+  return JSON.parse(readFileSync(fixture.dumpPath, 'utf8')) as {
+    ghToken: string | null;
+    githubToken: string | null;
+  };
+}
+
+describe('stalled-session-quiet-check CLI --gh-token / --token', () => {
+  it('--gh-token sets GH_TOKEN/GITHUB_TOKEN for gh auth', () => {
+    const fixture = ghTokenPropagationFixture();
+    const dump = runStalledSessionQuietCheckCli(
+      ['--gh-token', 'canonical-test-token'],
+      fixture,
+    );
+    assert.equal(dump.ghToken, 'canonical-test-token');
+    assert.equal(dump.githubToken, 'canonical-test-token');
+  });
+
+  it('--token still sets GH_TOKEN/GITHUB_TOKEN and warns as a deprecated alias', () => {
+    const fixture = ghTokenPropagationFixture();
+    let stderr = '';
+    try {
+      execFileSync(
+        process.execPath,
+        [
+          join(REPO_ROOT, 'scripts/stalled-session-quiet-check.mjs'),
+          '--pr',
+          '1',
+          '--token',
+          'deprecated-test-token',
+        ],
+        {
+          cwd: REPO_ROOT,
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PATH: `${fixture.tempRoot}:${process.env.PATH ?? ''}`,
+            ENV_DUMP_PATH: fixture.dumpPath,
+          },
+        },
+      );
+      assert.fail('expected the CLI to exit non-zero');
+    } catch (error) {
+      stderr = String((error as { stderr?: unknown }).stderr ?? '');
+    }
+    const dump = JSON.parse(readFileSync(fixture.dumpPath, 'utf8')) as {
+      ghToken: string | null;
+      githubToken: string | null;
+    };
+    assert.equal(dump.ghToken, 'deprecated-test-token');
+    assert.equal(dump.githubToken, 'deprecated-test-token');
+    assert.match(stderr, /--token is deprecated; use --gh-token instead\./);
   });
 });

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -122,6 +122,60 @@ test('parseArgs: --help is recognized without requiring --issue', () => {
   assert.equal(args.help, true);
 });
 
+// --- #2195: --token was ambiguous against select-desynced-index.mjs's
+// unrelated same-named session-desync token; --gh-token is now canonical
+// and --token stays a deprecated alias for one release. -------------------
+
+test('parseArgs: --gh-token resolves to ghToken', () => {
+  const args = parseArgs(['--gh-token', 'canonical-test-token']);
+  assert.equal(args.ghToken, 'canonical-test-token');
+});
+
+test('parseArgs: --token still resolves to ghToken and warns as a deprecated alias', () => {
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  let stderr = '';
+  process.stderr.write = ((chunk: unknown) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  let args: ReturnType<typeof parseArgs>;
+  try {
+    args = parseArgs(['--token', 'deprecated-test-token']);
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+  assert.equal(args.ghToken, 'deprecated-test-token');
+  assert.match(stderr, /--token is deprecated; use --gh-token instead\./);
+});
+
+test('parseArgs: an absent --gh-token/--token resolves to an empty string, no warning', () => {
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  let stderr = '';
+  process.stderr.write = ((chunk: unknown) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+  let args: ReturnType<typeof parseArgs>;
+  try {
+    args = parseArgs(['--issue', '42']);
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+  assert.equal(args.ghToken, '');
+  assert.equal(stderr, '');
+});
+
+test('parseArgs: when both --gh-token and --token are given, the last one in argv wins', () => {
+  assert.equal(
+    parseArgs(['--gh-token', 'first', '--token', 'second']).ghToken,
+    'second',
+  );
+  assert.equal(
+    parseArgs(['--token', 'first', '--gh-token', 'second']).ghToken,
+    'second',
+  );
+});
+
 // --- #1499: --manifest / --bundles override surface -------------------------
 
 test('parseArgs: --manifest defaults to the shared DEFAULT_MANIFEST_PATH', () => {


### PR DESCRIPTION
# Summary

Five helper scripts (`claim-approval-gate.mts`, `resume-claim-routing.mts`,
`resume-route-selection.mts`, `stalled-session-quiet-check.mts`,
`suitability-triage.mts`) defined an undocumented `--token` flag that
substitutes the GitHub auth token (`GH_TOKEN`/`GITHUB_TOKEN`) for that
process's `gh` calls — ambiguous against `select-desynced-index.mts`'s
unrelated, documented `--token` (the A4 Step 2 session-desync token).

Rename the canonical flag to `--gh-token` in all five scripts; keep
`--token` as a deprecated alias for one release (warns on stderr,
"last flag given in argv wins" when both are passed), matching
`pre-merge-readiness.mts`'s existing `--expected-claim-id` precedent
exactly. `select-desynced-index.mts`'s own `--token` is untouched.

Added CLI/unit test coverage for both flags (none of the five test
files previously covered `--token` at all) and extended
`tests/flag-name-matrix.test.mts`'s data-driven concept table with the
new pair, excluding `select-desynced-index.mjs` from the broad
deprecated-alias scan so its unrelated `--token` literal doesn't
false-positive.

## Linked issue

Closes #2195

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

**Observed incident** (from the issue): during a 2026-08-19 IDD
session, after computing a session-desync token for A4 Step 2
candidate selection, running `suitability-triage.mjs --issue <n>
--token <the-same-session-token>` — reusing the flag name by
pattern-matching from `select-desynced-index.mjs`'s usage — silently
set `GH_TOKEN` to the non-credential session token for that one
subprocess, producing a misleading `HTTP 401: Bad credentials` that
looked like a real authentication outage.

`select-desynced-index.mts`'s `--token` (session-desync token) is
older, documented, and protocol-critical (`idd-discover.instructions.md`),
so it stays unchanged — renaming it would touch a `bundle-discovery`
context-ceiling instruction file with materially less headroom than
the plain `docs/`/`src/scripts/` surface this change touches instead.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
