### PR TITLE
fix(merged-pr-feedback-sweep): flag COMMENTED-state advisory reviews with outside-diff-range findings

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2479,7 +2479,16 @@ same as `AW4`/`AW5`.
     from the in-thread disposition check), and regular comments /
     `CHANGES_REQUESTED` review bodies from non-IDD-agent authors that have
     **no later IDD-agent disposition** (`**Accepted**` / `**Rejected**` /
-    `**Awaiting maintainer decision**`). Trusted IDD operational markers, IDD
+    `**Awaiting maintainer decision**`). A non-`CHANGES_REQUESTED` review from
+    a _configured_ advisory-bot author (the same narrower identity check as
+    the summary-walkthrough exclusion below, not the broader `isKnownReviewBot`)
+    is also surfaced when its body carries a CodeRabbit
+    `<summary>⚠️ Outside diff range comments (N)</summary>`-shaped block with
+    `N >= 1` (#2194) — GitHub embeds a finding directly in the review body
+    text, rather than as a normal inline review comment, when it targets a
+    line the diff-hunk view cannot host; `N == 0` or an absent block is an
+    ordinary walkthrough/summary review with nothing outside the diff and
+    stays unsurfaced. Trusted IDD operational markers, IDD
     disposition comments, any HTML comment beginning with `<!-- idd-` (for
     example cleanup-evidence, excluded regardless of author — including CI
     automation such as `github-actions[bot]`), and a genuine CodeRabbit

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2479,7 +2479,16 @@ same as `AW4`/`AW5`.
     from the in-thread disposition check), and regular comments /
     `CHANGES_REQUESTED` review bodies from non-IDD-agent authors that have
     **no later IDD-agent disposition** (`**Accepted**` / `**Rejected**` /
-    `**Awaiting maintainer decision**`). Trusted IDD operational markers, IDD
+    `**Awaiting maintainer decision**`). A non-`CHANGES_REQUESTED` review from
+    a _configured_ advisory-bot author (the same narrower identity check as
+    the summary-walkthrough exclusion below, not the broader `isKnownReviewBot`)
+    is also surfaced when its body carries a CodeRabbit
+    `<summary>⚠️ Outside diff range comments (N)</summary>`-shaped block with
+    `N >= 1` (#2194) — GitHub embeds a finding directly in the review body
+    text, rather than as a normal inline review comment, when it targets a
+    line the diff-hunk view cannot host; `N == 0` or an absent block is an
+    ordinary walkthrough/summary review with nothing outside the diff and
+    stays unsurfaced. Trusted IDD operational markers, IDD
     disposition comments, any HTML comment beginning with `<!-- idd-` (for
     example cleanup-evidence, excluded regardless of author — including CI
     automation such as `github-actions[bot]`), and a genuine CodeRabbit

--- a/scripts/merged-pr-feedback-sweep.mjs
+++ b/scripts/merged-pr-feedback-sweep.mjs
@@ -228,6 +228,24 @@ function threadHasIddAmd(thread, isIdd) {
         .startsWith('**Awaiting maintainer decision**'),
   );
 }
+// #2194: GitHub embeds a review finding directly in the review `body` field
+// (never as a separate review thread or regular comment) when the finding
+// targets a line the diff-hunk view cannot host -- CodeRabbit's stable
+// `<summary>⚠️ Outside diff range comments (N)</summary>` heading. A
+// non-`CHANGES_REQUESTED` review carrying such a block still holds a real
+// finding this sweep must not miss. `N === 0` (or an absent block) is an
+// ordinary walkthrough/summary review with nothing outside the diff, not a
+// finding.
+const OUTSIDE_DIFF_RANGE_COMMENTS_RE =
+  /<summary>\s*⚠️\s*Outside diff range comments\s*\((\d+)\)\s*<\/summary>/;
+function hasOutsideDiffRangeFindings(reviewBody) {
+  const match = OUTSIDE_DIFF_RANGE_COMMENTS_RE.exec(reviewBody);
+  if (!match) {
+    return false;
+  }
+  const count = Number.parseInt(match[1], 10);
+  return Number.isFinite(count) && count >= 1;
+}
 function collectUnaddressedComments(
   comments,
   reviews,
@@ -320,10 +338,21 @@ function collectUnaddressedComments(
     });
   }
   for (const review of reviews) {
-    if (review.state !== 'CHANGES_REQUESTED') {
+    const author = authorLogin(review);
+    // #2194: a non-`CHANGES_REQUESTED` review is still surfaced when it is
+    // from a *configured* advisory bot (matching the same narrower gate the
+    // comment loop above uses, not the broader `isAdvisoryBot`) and its body
+    // carries an outside-diff-range finding GitHub could not host as a
+    // normal inline comment.
+    if (
+      review.state !== 'CHANGES_REQUESTED' &&
+      !(
+        isConfiguredAdvisoryBotIdentity(author) &&
+        hasOutsideDiffRangeFindings(String(review.body ?? ''))
+      )
+    ) {
       continue;
     }
-    const author = authorLogin(review);
     // Same author rule as comments: exclude only explicit IDD agents; a
     // missing/unknown author is surfaced with `author: null`.
     if (isIdd(author)) {

--- a/src/scripts/merged-pr-feedback-sweep.mts
+++ b/src/scripts/merged-pr-feedback-sweep.mts
@@ -357,6 +357,26 @@ function threadHasIddAmd(
   );
 }
 
+// #2194: GitHub embeds a review finding directly in the review `body` field
+// (never as a separate review thread or regular comment) when the finding
+// targets a line the diff-hunk view cannot host -- CodeRabbit's stable
+// `<summary>⚠️ Outside diff range comments (N)</summary>` heading. A
+// non-`CHANGES_REQUESTED` review carrying such a block still holds a real
+// finding this sweep must not miss. `N === 0` (or an absent block) is an
+// ordinary walkthrough/summary review with nothing outside the diff, not a
+// finding.
+const OUTSIDE_DIFF_RANGE_COMMENTS_RE =
+  /<summary>\s*⚠️\s*Outside diff range comments\s*\((\d+)\)\s*<\/summary>/;
+
+function hasOutsideDiffRangeFindings(reviewBody: string): boolean {
+  const match = OUTSIDE_DIFF_RANGE_COMMENTS_RE.exec(reviewBody);
+  if (!match) {
+    return false;
+  }
+  const count = Number.parseInt(match[1], 10);
+  return Number.isFinite(count) && count >= 1;
+}
+
 function collectUnaddressedComments(
   comments: SweepCommentInput[],
   reviews: SweepReviewInput[],
@@ -452,10 +472,21 @@ function collectUnaddressedComments(
   }
 
   for (const review of reviews) {
-    if (review.state !== 'CHANGES_REQUESTED') {
+    const author = authorLogin(review);
+    // #2194: a non-`CHANGES_REQUESTED` review is still surfaced when it is
+    // from a *configured* advisory bot (matching the same narrower gate the
+    // comment loop above uses, not the broader `isAdvisoryBot`) and its body
+    // carries an outside-diff-range finding GitHub could not host as a
+    // normal inline comment.
+    if (
+      review.state !== 'CHANGES_REQUESTED' &&
+      !(
+        isConfiguredAdvisoryBotIdentity(author) &&
+        hasOutsideDiffRangeFindings(String(review.body ?? ''))
+      )
+    ) {
       continue;
     }
-    const author = authorLogin(review);
     // Same author rule as comments: exclude only explicit IDD agents; a
     // missing/unknown author is surfaced with `author: null`.
     if (isIdd(author)) {

--- a/tests/merged-pr-feedback-sweep.test.mts
+++ b/tests/merged-pr-feedback-sweep.test.mts
@@ -586,6 +586,90 @@ test('a COMMENTED (non-CHANGES_REQUESTED) review body is not feedback', () => {
   assert.equal(result.prs.length, 0);
 });
 
+// #2194: a COMMENTED-state review from a configured advisory bot can still
+// carry a real finding GitHub embeds directly in the review body -- an
+// "Outside diff range comments" block, for content the diff-hunk view
+// cannot host as a normal inline review comment.
+test('a COMMENTED review with an outside-diff-range block is surfaced', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 20,
+      reviews: [
+        {
+          body: '<details><summary>⚠️ Outside diff range comments (1)</summary>\n\nsome finding\n\n</details>',
+          state: 'COMMENTED',
+          submittedAt: '2026-08-19T00:00:00Z',
+          url: 'https://example/r20',
+          author: { login: 'coderabbitai[bot]' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 1);
+  assert.equal(result.prs[0].unaddressedComments.length, 1);
+  assert.equal(result.prs[0].unaddressedComments[0].kind, 'review');
+  assert.equal(
+    result.prs[0].unaddressedComments[0].author,
+    'coderabbitai[bot]',
+  );
+  assert.equal(result.prs[0].unaddressedComments[0].advisoryBot, true);
+});
+
+test('a COMMENTED review from a configured advisory bot without an outside-diff-range block is not feedback', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 21,
+      reviews: [
+        {
+          body: 'Reviewed the changes, no actionable comments posted.',
+          state: 'COMMENTED',
+          submittedAt: '2026-08-19T00:00:00Z',
+          author: { login: 'coderabbitai[bot]' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 0);
+});
+
+test('a COMMENTED review with an outside-diff-range block from a non-configured author is not feedback', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 22,
+      reviews: [
+        {
+          body: '<details><summary>⚠️ Outside diff range comments (1)</summary>\n\nsome finding\n\n</details>',
+          state: 'COMMENTED',
+          submittedAt: '2026-08-19T00:00:00Z',
+          author: { login: 'a-human' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 0);
+});
+
+test('a COMMENTED review with an outside-diff-range count of 0 is not feedback', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 23,
+      reviews: [
+        {
+          body: '<details><summary>⚠️ Outside diff range comments (0)</summary>\n\n</details>',
+          state: 'COMMENTED',
+          submittedAt: '2026-08-19T00:00:00Z',
+          author: { login: 'coderabbitai[bot]' },
+        },
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 0);
+});
+
 test('summary aggregates across PRs and skips clean PRs', () => {
   const prs: MergedPrInput[] = [
     {


### PR DESCRIPTION
# Summary

`merged-pr-feedback-sweep.mts`'s review-collection loop skipped every
review whose state was not `CHANGES_REQUESTED`, including a
COMMENTED-state advisory-bot review carrying a CodeRabbit "Outside
diff range comments" block — content GitHub embeds directly in the
review body when the diff-hunk view cannot host it as a normal inline
comment. Observed on PR #2185: a citation-format finding existed only
inside the review body, invisible to both the sweep and the live
E-phase triage flow (deliberately Copilot-only per #909/#1352).

Surface a non-`CHANGES_REQUESTED` review when its author passes the
existing `isConfiguredAdvisoryBotIdentity` check and its body carries
an outside-diff-range finding (`N >= 1`, via a new local
`hasOutsideDiffRangeFindings` detector). Existing `CHANGES_REQUESTED`
behavior is unchanged. This is a detection-only fix to a read-only,
manually-run sweep — no change to `idd-advisory-convergence`, the
E-phase live triage flow, or any merge-blocking gate.

## Linked issue

Closes #2194

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Refs #909 #1352 #931 — the advisory-convergence gate stays
deliberately Copilot-only (decided in #909, reaffirmed in #1352); this
issue does not change that. `merged-pr-feedback-sweep.mjs` is the
accepted recovery path for a non-Copilot bot's finding slipping past
merge, and this fixes a gap in that safety net specifically, not the
gate itself.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merged pull request feedback now includes configured advisory-bot reviews with nonzero CodeRabbit “Outside diff range comments.”
  * Reviews without findings, with zero findings, or from unconfigured authors remain excluded.
* **Tests**
  * Added coverage for eligible and ineligible review scenarios.
* **Documentation**
  * Updated guidance to describe the expanded feedback sweep behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->