### PR TITLE
chore(context-ceiling): preemptively exempt bundle-review

### DIFF
--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -394,7 +394,7 @@
     "maxBundleLimitBytes": 126000,
     "maxUtilizationPct": 98,
     "noticeUtilizationPct": 95,
-    "exemptBundles": []
+    "exemptBundles": ["bundle-review"]
   },
   "docBudgetGuard": {
     "id": "doc-budget-drift",


### PR DESCRIPTION
# Summary

Register `bundle-review` under `audit/sync-manifest.json`'s
`contextCeiling.exemptBundles` (currently `[]`). This registration is
**preemptive relative to the Exemption lifecycle section's documented
trigger** (`docs/policy-constants.md`): `bundle-review` has not yet
crossed `maxUtilizationPct` (98%) or `maxBundleLimitBytes` (126,000
bytes) as of this PR.

- At issue filing time: 97.02% utilization, ~1,233 bytes of headroom
  to the 98% hard-fail (122,247 / 126,000 bytes; recorded in #2181).
- Re-measured on this PR's branch: **96.46%** utilization, **121,540**
  bytes, ~1,940 bytes of headroom to the 98% hard-fail — improved by
  #2191 (merged earlier this session, cross-reference dedup), but
  `bundle-review` is still pinned at `maxBundleLimitBytes` with no
  ratchet headroom the way #2091's other six bundles had, and its
  growth pace (+4,684 bytes in ~4 days per #2181) can still close the
  remaining margin quickly.
- No further content-diet issue is filed alongside this PR. The
  in-flight follow-up work toward a real byte reduction is #2191
  (merged, cross-reference dedup) and #2193 (open, investigating
  whether a structural split of `bundle-review` is a genuine further
  reduction or a measurement artifact). The exemption is intended to
  be removed once that follow-up work durably clears the ceiling,
  matching the Exemption lifecycle section's return-to-empty
  convention — not left in place indefinitely.

`node scripts/audit-docs.mjs --check` still prints the
`bundle-review` utilization notice and a new "listed in exemptBundles
but currently violates neither ceiling check; consider removing the
exemption" notice — both expected and non-blocking; the check exits 0.

## Linked issue

Closes #2190

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Refs #2181 (context-ceiling capacity question, still open) and #2193
(open investigation into a structural fix). Neither is resolved by
this PR; this PR only adds the preemptive stopgap so a PR touching one
of `bundle-review`'s seven member files does not get hard-failed while
that follow-up work continues.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

(None of the above apply: `audit/sync-manifest.json` is a bundle-budget
data file consumed by `audit-docs.mjs`, not the policy schema, a
template, or a helper script itself.)

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
