### PR TITLE
docs(authoring): document the bare #NNN MD018 line-start trap

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -307,16 +307,16 @@ feat: add auth system and refactor database layer and update docs
 - **Bare issue/PR reference wrapping**: a bare `#NNN` citation must
   never land as the first token of a paragraph, list item, or wrapped
   continuation line in prose Markdown. `dprint fmt`'s automatic
-  line-wrap can relocate a bare `#NNN` there, and CommonMark's
-  ATX-heading rule — enforced here by markdownlint's MD018 — then
-  reads the relocated text as a malformed heading instead of a
-  citation. Whenever a reference could plausibly open a sentence,
-  bullet, or wrapped line, phrase it as "issue `#NNN`" (or any
-  equivalent that keeps a word before the `#`) instead of leaving it
-  bare. No dedicated script is needed to detect this — the existing
-  `markdownlint-cli2` MD018 rule already catches every instance
-  mechanically; this bullet only documents the cause so the
-  format → lint → diagnose → reword round-trip is avoided up front.
+  line-wrap can relocate a bare `#NNN` there, and markdownlint's MD018
+  rule (`no-missing-space-atx`) then flags the relocated text as a
+  malformed heading, even though CommonMark itself still renders a
+  `#NNN` with no following space as plain text, not a real heading.
+  MD018 only fires when the line has zero leading indentation, so it
+  misses the same drift inside an indented list-item continuation
+  line — do not treat the linter as a complete safety net. Whenever a
+  reference could plausibly open a sentence, bullet, or wrapped line,
+  phrase it as "issue `#NNN`" (or any equivalent that keeps a word
+  before the `#`) instead of leaving it bare.
 
 ## Guardrails
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -304,6 +304,19 @@ feat: add auth system and refactor database layer and update docs
   part of the real value, delete it instead of just relocating the
   break. Enforced by `node scripts/audit-code-span-wrap.mjs`
   (repository-local; not part of the distributed `idd-template/`).
+- **Bare issue/PR reference wrapping**: a bare `#NNN` citation must
+  never land as the first token of a paragraph, list item, or wrapped
+  continuation line in prose Markdown. `dprint fmt`'s automatic
+  line-wrap can relocate a bare `#NNN` there, and CommonMark's
+  ATX-heading rule — enforced here by markdownlint's MD018 — then
+  reads the relocated text as a malformed heading instead of a
+  citation. Whenever a reference could plausibly open a sentence,
+  bullet, or wrapped line, phrase it as "issue `#NNN`" (or any
+  equivalent that keeps a word before the `#`) instead of leaving it
+  bare. No dedicated script is needed to detect this — the existing
+  `markdownlint-cli2` MD018 rule already catches every instance
+  mechanically; this bullet only documents the cause so the
+  format → lint → diagnose → reword round-trip is avoided up front.
 
 ## Guardrails
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,12 +57,13 @@ own interaction model rather than following product terms literally.
 - **Bare issue/PR reference wrapping**: a bare `#NNN` reference must
   never be the first token of a paragraph, list item, or wrapped
   continuation line in prose Markdown — `dprint fmt`'s automatic
-  line-wrap can relocate it there, and CommonMark/markdownlint's MD018
-  rule then reads it as a malformed ATX heading. Prefer "issue `#NNN`"
-  (or another phrasing that keeps a word before the `#`) whenever the
-  reference could plausibly open a sentence, bullet, or wrapped line.
-  No dedicated script is needed — `markdownlint-cli2`'s existing MD018
-  rule already catches every instance mechanically.
+  line-wrap can relocate it there, and markdownlint's MD018 rule
+  (`no-missing-space-atx`) then flags it as a malformed ATX heading.
+  MD018 only fires at zero leading indentation, so it misses the same
+  drift inside an indented list-item continuation line — do not rely
+  on the linter alone. Prefer "issue `#NNN`" (or another phrasing that
+  keeps a word before the `#`) whenever the reference could plausibly
+  open a sentence, bullet, or wrapped line.
 
 ## Key workflow rules
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,15 @@ own interaction model rather than following product terms literally.
   the real value, delete it instead of just relocating the break.
   Enforced by `node scripts/audit-code-span-wrap.mjs`
   (repository-local; not distributed to `idd-template/`).
+- **Bare issue/PR reference wrapping**: a bare `#NNN` reference must
+  never be the first token of a paragraph, list item, or wrapped
+  continuation line in prose Markdown — `dprint fmt`'s automatic
+  line-wrap can relocate it there, and CommonMark/markdownlint's MD018
+  rule then reads it as a malformed ATX heading. Prefer "issue `#NNN`"
+  (or another phrasing that keeps a word before the `#`) whenever the
+  reference could plausibly open a sentence, bullet, or wrapped line.
+  No dedicated script is needed — `markdownlint-cli2`'s existing MD018
+  rule already catches every instance mechanically.
 
 ## Key workflow rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,15 @@ terms literally.
   the real value, delete it instead of just relocating the break.
   Enforced by `node scripts/audit-code-span-wrap.mjs`
   (repository-local; not distributed to `idd-template/`).
+- **Bare issue/PR reference wrapping**: a bare `#NNN` reference must
+  never be the first token of a paragraph, list item, or wrapped
+  continuation line in prose Markdown — `dprint fmt`'s automatic
+  line-wrap can relocate it there, and CommonMark/markdownlint's MD018
+  rule then reads it as a malformed ATX heading. Prefer "issue `#NNN`"
+  (or another phrasing that keeps a word before the `#`) whenever the
+  reference could plausibly open a sentence, bullet, or wrapped line.
+  No dedicated script is needed — `markdownlint-cli2`'s existing MD018
+  rule already catches every instance mechanically.
 
 ## Key workflow rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,12 +57,13 @@ terms literally.
 - **Bare issue/PR reference wrapping**: a bare `#NNN` reference must
   never be the first token of a paragraph, list item, or wrapped
   continuation line in prose Markdown — `dprint fmt`'s automatic
-  line-wrap can relocate it there, and CommonMark/markdownlint's MD018
-  rule then reads it as a malformed ATX heading. Prefer "issue `#NNN`"
-  (or another phrasing that keeps a word before the `#`) whenever the
-  reference could plausibly open a sentence, bullet, or wrapped line.
-  No dedicated script is needed — `markdownlint-cli2`'s existing MD018
-  rule already catches every instance mechanically.
+  line-wrap can relocate it there, and markdownlint's MD018 rule
+  (`no-missing-space-atx`) then flags it as a malformed ATX heading.
+  MD018 only fires at zero leading indentation, so it misses the same
+  drift inside an indented list-item continuation line — do not rely
+  on the linter alone. Prefer "issue `#NNN`" (or another phrasing that
+  keeps a word before the `#`) whenever the reference could plausibly
+  open a sentence, bullet, or wrapped line.
 
 ## Key workflow rules
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -57,12 +57,13 @@ own interaction model rather than following product terms literally.
 - **Bare issue/PR reference wrapping**: a bare `#NNN` reference must
   never be the first token of a paragraph, list item, or wrapped
   continuation line in prose Markdown — `dprint fmt`'s automatic
-  line-wrap can relocate it there, and CommonMark/markdownlint's MD018
-  rule then reads it as a malformed ATX heading. Prefer "issue `#NNN`"
-  (or another phrasing that keeps a word before the `#`) whenever the
-  reference could plausibly open a sentence, bullet, or wrapped line.
-  No dedicated script is needed — `markdownlint-cli2`'s existing MD018
-  rule already catches every instance mechanically.
+  line-wrap can relocate it there, and markdownlint's MD018 rule
+  (`no-missing-space-atx`) then flags it as a malformed ATX heading.
+  MD018 only fires at zero leading indentation, so it misses the same
+  drift inside an indented list-item continuation line — do not rely
+  on the linter alone. Prefer "issue `#NNN`" (or another phrasing that
+  keeps a word before the `#`) whenever the reference could plausibly
+  open a sentence, bullet, or wrapped line.
 
 ## Key workflow rules
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -54,6 +54,15 @@ own interaction model rather than following product terms literally.
   the real value, delete it instead of just relocating the break.
   Enforced by `node scripts/audit-code-span-wrap.mjs`
   (repository-local; not distributed to `idd-template/`).
+- **Bare issue/PR reference wrapping**: a bare `#NNN` reference must
+  never be the first token of a paragraph, list item, or wrapped
+  continuation line in prose Markdown — `dprint fmt`'s automatic
+  line-wrap can relocate it there, and CommonMark/markdownlint's MD018
+  rule then reads it as a malformed ATX heading. Prefer "issue `#NNN`"
+  (or another phrasing that keeps a word before the `#`) whenever the
+  reference could plausibly open a sentence, bullet, or wrapped line.
+  No dedicated script is needed — `markdownlint-cli2`'s existing MD018
+  rule already catches every instance mechanically.
 
 ## Key workflow rules
 


### PR DESCRIPTION
# Summary

Adds a "Bare issue/PR reference wrapping" bullet next to the existing
"Inline code span wrapping" bullet in `CLAUDE.md`, `AGENTS.md`,
`GEMINI.md` (byte-identical across all three), and a substantively
equivalent bullet in `.github/copilot-instructions.md` in that file's
own established prose style. Documentation-only; no script,
`audit/sync-manifest.json`, or `.github/instructions/*.md` changes.

## Linked issue

Closes #2206

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`dprint fmt`'s prose rewrap can place a bare `#NNN` issue/PR reference
at the very start of a line, which markdownlint's MD018 rule
(`no-missing-space-atx`) then reads as a malformed ATX heading — even
though no heading was intended. This mirrors the existing "Inline code
span wrapping" trap already documented in these same files for a
different CommonMark rewrap hazard. `markdownlint-cli2` already
detects every instance mechanically; this change only documents the
cause and the fix pattern (prefer "issue `#NNN`" over a bare `#NNN`)
so the format → lint → diagnose → reword round-trip is avoided up
front.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Markdown authoring guidance to prevent bare issue or pull request references from appearing at the start of paragraphs, list items, or wrapped lines.
  - Clarified that existing Markdown linting validates this formatting requirement.
  - Applied the guidance consistently across project documentation and contributor instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->