### PR TITLE
fix(suitability-triage): exclude hyphenated-token matches from Check 7

### DIFF
--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -144,11 +144,26 @@ const EXTERNAL_SYSTEM_ACCESS_PATTERN =
 const DUPLICATE_DECLARATION_PATTERN =
   /\b(duplicate of|superseded by)\s*(?:#\d+|https?:\/\/\S+?\/(?:issues|pull)\/\d+)\b/gi;
 const DUPLICATE_NEGATION_PATTERN = /\b(not|no|avoid)\b[\s\S]{0,30}$/i;
+// A bare `\b` treats a hyphen as a non-word character, so it also matches the
+// tail of this repository's own hyphenated outcome/label vocabulary (e.g.
+// `decision` inside `needs-decision`, `human` inside `blocked-by-human`).
+// `(?<![\w-])`/`(?![\w-])` reject a match immediately adjacent to a hyphen
+// (part of a larger hyphenated token) while still matching a freestanding
+// use of the same word (#2205).
 const SUBJECTIVE_SUBJECT_PATTERN =
-  /\b(maintainer|stakeholder|human|opinion|judgment|judgement|ux|feel)\b/i;
-const SUBJECTIVE_GATE_PATTERN = /\b(approval|sign-?off|decision|preference)\b/i;
+  /(?<![\w-])(maintainer|stakeholder|human|opinion|judgment|judgement|ux|feel)(?![\w-])/i;
+const SUBJECTIVE_GATE_PATTERN =
+  /(?<![\w-])(approval|sign-?off|decision|preference)(?![\w-])/i;
 const OUTCOME_SIGNAL_PATTERN =
   /\b(pass|fail|result|output|contains|include|present|required|objective|measurable|deterministic)\b/i;
+// Whole-body proximity variant of the subjective-approval check, built from
+// the same two pattern sources above (not hand-duplicated) so the
+// hyphen-boundary fix (#2205) applies to both the per-line and whole-body
+// test paths.
+const SUBJECTIVE_PROXIMITY_PATTERN = new RegExp(
+  `${SUBJECTIVE_GATE_PATTERN.source}[\\s\\S]{0,80}${SUBJECTIVE_SUBJECT_PATTERN.source}`,
+  'i',
+);
 // Check 3 precision: an unsafe execution directive tells the agent to act on
 // *supplied / untrusted* content, not any command verb that merely lands near
 // the ordinary determiner "this". Match the strong untrusted-origin signals, or
@@ -1065,10 +1080,7 @@ export function checkVerifiability(context) {
         (line) =>
           SUBJECTIVE_SUBJECT_PATTERN.test(line) &&
           SUBJECTIVE_GATE_PATTERN.test(line),
-      ) ||
-      /\b(approval|sign-?off|decision|preference)\b[\s\S]{0,80}\b(maintainer|stakeholder|human|opinion|judgment|judgement|ux|feel)\b/i.test(
-        body,
-      )
+      ) || SUBJECTIVE_PROXIMITY_PATTERN.test(body)
     );
   })();
   // A body that carries BOTH a resolved-decision marker (a

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -266,11 +266,26 @@ const EXTERNAL_SYSTEM_ACCESS_PATTERN =
 const DUPLICATE_DECLARATION_PATTERN =
   /\b(duplicate of|superseded by)\s*(?:#\d+|https?:\/\/\S+?\/(?:issues|pull)\/\d+)\b/gi;
 const DUPLICATE_NEGATION_PATTERN = /\b(not|no|avoid)\b[\s\S]{0,30}$/i;
+// A bare `\b` treats a hyphen as a non-word character, so it also matches the
+// tail of this repository's own hyphenated outcome/label vocabulary (e.g.
+// `decision` inside `needs-decision`, `human` inside `blocked-by-human`).
+// `(?<![\w-])`/`(?![\w-])` reject a match immediately adjacent to a hyphen
+// (part of a larger hyphenated token) while still matching a freestanding
+// use of the same word (#2205).
 const SUBJECTIVE_SUBJECT_PATTERN =
-  /\b(maintainer|stakeholder|human|opinion|judgment|judgement|ux|feel)\b/i;
-const SUBJECTIVE_GATE_PATTERN = /\b(approval|sign-?off|decision|preference)\b/i;
+  /(?<![\w-])(maintainer|stakeholder|human|opinion|judgment|judgement|ux|feel)(?![\w-])/i;
+const SUBJECTIVE_GATE_PATTERN =
+  /(?<![\w-])(approval|sign-?off|decision|preference)(?![\w-])/i;
 const OUTCOME_SIGNAL_PATTERN =
   /\b(pass|fail|result|output|contains|include|present|required|objective|measurable|deterministic)\b/i;
+// Whole-body proximity variant of the subjective-approval check, built from
+// the same two pattern sources above (not hand-duplicated) so the
+// hyphen-boundary fix (#2205) applies to both the per-line and whole-body
+// test paths.
+const SUBJECTIVE_PROXIMITY_PATTERN = new RegExp(
+  `${SUBJECTIVE_GATE_PATTERN.source}[\\s\\S]{0,80}${SUBJECTIVE_SUBJECT_PATTERN.source}`,
+  'i',
+);
 // Check 3 precision: an unsafe execution directive tells the agent to act on
 // *supplied / untrusted* content, not any command verb that merely lands near
 // the ordinary determiner "this". Match the strong untrusted-origin signals, or
@@ -1255,10 +1270,7 @@ export function checkVerifiability(context: Context): CheckOutcome {
         (line) =>
           SUBJECTIVE_SUBJECT_PATTERN.test(line) &&
           SUBJECTIVE_GATE_PATTERN.test(line),
-      ) ||
-      /\b(approval|sign-?off|decision|preference)\b[\s\S]{0,80}\b(maintainer|stakeholder|human|opinion|judgment|judgement|ux|feel)\b/i.test(
-        body,
-      )
+      ) || SUBJECTIVE_PROXIMITY_PATTERN.test(body)
     );
   })();
   // A body that carries BOTH a resolved-decision marker (a

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -1887,6 +1887,56 @@ test('verifiability fails when approval wording comes before subjective actor', 
   assert.equal(result.pass, false);
 });
 
+test('verifiability passes a hyphenated needs-decision tail match reproducing #2190 verbatim (#2205)', () => {
+  // Check 7 false-positive that now passes: `needs-decision` is a literal
+  // label-name reference, not free prose describing a pending decision. Both
+  // the per-line and whole-body proximity paths see this on one line.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\n#2181 (\`needs-decision\`) recorded this situation and the maintainer's chosen resolution here.`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('verifiability passes a hyphenated blocked-by-human tail match spanning lines (#2205)', () => {
+  // Exercises the whole-body proximity path specifically: the gate and
+  // subject words are on different lines, so only the cross-line [\s\S]{0,80}
+  // window sees them together. `human` is the tail of `blocked-by-human`.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThe sign-off command below only quotes the\nstatus:blocked-by-human label name for reference.`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('verifiability still fails a freestanding subjective decision on one line (#2205)', () => {
+  // True-positive that still fails: genuine freestanding prose, not a
+  // hyphenated label tail, so the per-line path still catches it.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThis needs the maintainer's decision before shipping.`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('verifiability still fails a freestanding subjective sign-off spanning lines (#2205)', () => {
+  // True-positive that still fails via the whole-body proximity path: both
+  // words are freestanding (no adjacent hyphen), just split across lines.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nFinal sign-off is required before merge, since the\nmaintainer must personally review the visual design.`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('repository fit fails when external system access is required', () => {
   const result = checkRepositoryFit({
     issue: {


### PR DESCRIPTION
## Summary

Check 7's subjective-approval patterns (`SUBJECTIVE_SUBJECT_PATTERN`,
`SUBJECTIVE_GATE_PATTERN`) used a bare `\b` word boundary, which treats
a hyphen as a non-word character. This let both patterns match the
*tail* of this repository's own hyphenated outcome/label vocabulary —
`decision` inside `needs-decision`, `human` inside `blocked-by-human`
— even when that text is a literal reference to the label/outcome
name, not free prose describing an actual pending human decision.
Confirmed misfiring at least four times across separate sessions
(reproduced live with `suitability-triage.mjs --stdin` each time).

Tightens both patterns with a `(?<![\w-])`/`(?![\w-])` lookaround that
rejects a match immediately adjacent to a hyphen, while a freestanding
use of the same word still matches unchanged. The whole-body proximity
regex inside `checkVerifiability` is now derived from the same two
pattern sources (`SUBJECTIVE_PROXIMITY_PATTERN`) instead of being a
hand-duplicated literal, so the fix applies to both the per-line and
whole-body test paths.

`RESOLVED_DECISION_PATTERN`/`hasResolvedDecision` and the
resolved-decision escape hatch (#1135) are unchanged — out of scope
for this issue.

## Test plan

- [x] `pnpm test` — 3784/3784 pass, including 4 new fixtures covering
      both the per-line and whole-body proximity paths: a
      false-positive-that-now-passes reproducing #2190's exact
      trigger substring verbatim, a false-positive-that-now-passes
      hyphenated tail spanning lines, and two
      true-positive-that-still-fails freestanding fixtures.
- [x] `pnpm run lint:minimum` (tsc, build:check, biome, dprint,
      markdownlint, cspell) passes clean.
- [x] `pnpm run build` regenerated `scripts/suitability-triage.mjs`,
      committed alongside the source.

Closes #2205