### PR TITLE
docs(claim): cross-reference wake-up discipline for delegation

### DIFF
--- a/.github/instructions/idd-claim.instructions.md
+++ b/.github/instructions/idd-claim.instructions.md
@@ -471,6 +471,18 @@ worker for the named issue, that no peer workers exist for it to
 coordinate with or wait on, and that it must perform the implementation
 work itself rather than re-delegate or wait for a reply (#2179).
 
+**Restate the CI/advisory-wait topology-safety condition.** The
+delegation brief must also carry — verbatim or by direct reference —
+the CI/advisory-wait topology-safety condition from [idd-ci.instructions.md's
+Wake-up discipline](idd-ci.instructions.md#wake-up-discipline), the same
+requirement already stated for this delegation pattern in
+[docs/idd-workflow.md's Orchestrator fan-out
+variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant). Without
+it, a worker can end its turn on a Monitor-style or backgrounded wait
+assuming an unconfirmed notification resumes it — under a
+supervisor/worker topology, only the supervisor is notified, so the
+worker's own turn stalls indefinitely (#2210).
+
 ### Hide displaced claim chain on takeover
 
 When the verified new claim was posted with `supersedes: <prior-id>`

--- a/idd-template/.github/instructions/idd-claim.instructions.md
+++ b/idd-template/.github/instructions/idd-claim.instructions.md
@@ -466,6 +466,18 @@ worker for the named issue, that no peer workers exist for it to
 coordinate with or wait on, and that it must perform the implementation
 work itself rather than re-delegate or wait for a reply (#2179).
 
+**Restate the CI/advisory-wait topology-safety condition.** The
+delegation brief must also carry — verbatim or by direct reference —
+the CI/advisory-wait topology-safety condition from [idd-ci.instructions.md's
+Wake-up discipline](idd-ci.instructions.md#wake-up-discipline), the same
+requirement already stated for this delegation pattern in
+[docs/idd-workflow.md's Orchestrator fan-out
+variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant). Without
+it, a worker can end its turn on a Monitor-style or backgrounded wait
+assuming an unconfirmed notification resumes it — under a
+supervisor/worker topology, only the supervisor is notified, so the
+worker's own turn stalls indefinitely (#2210).
+
 ### Hide displaced claim chain on takeover
 
 When the verified new claim was posted with `supersedes: <prior-id>`


### PR DESCRIPTION
## Summary

Adds a bullet to `idd-claim.instructions.md`'s "Orchestrator
delegation" section requiring a delegation brief to also carry the
CI/advisory-wait topology-safety condition from `idd-ci.instructions.md`'s
Wake-up discipline, cross-referencing the same requirement already
stated in `docs/idd-workflow.md`'s Orchestrator fan-out variant. The
section previously covered claim-token/nonce carrying and (#2179) the
worker-role-statement bullet, but was silent on this — a delegation
brief that omits it can leave a context-inheriting worker ending its
turn on an unconfirmed background/async wait with nothing to resume
it, since only the supervisor is notified under that topology.

Closes #2210

## Changes

- `idd-template/.github/instructions/idd-claim.instructions.md`
  (source): new bullet in Orchestrator delegation.
- `.github/instructions/idd-claim.instructions.md` (mirror,
  `exact`-mode sync pair): regenerated via `node scripts/sync-docs.mjs
  --apply`.

## Verification

- `node scripts/audit-docs.mjs --check` passes (bundle-discovery
  headroom retained).
- `node scripts/audit-code-span-wrap.mjs` passes.
- `pnpm run lint:minimum` passes (typecheck, build:check, biome,
  dprint, full test suite, workshop integrity, cspell, markdownlint).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated delegation guidance to account for CI and advisory-wait behavior in supervisor/worker workflows.
  * Clarified that backgrounded or Monitor-style waits must not depend on unconfirmed notifications, as notifications may be delivered only to supervisors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->