### PR TITLE
docs(advisory-wait): note org-level review-quota outage as a cause

### DIFF
--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -94,6 +94,12 @@ distributed defaults in `docs/policy-constants.md`: `REQUEST_CAP`,
 (default) — E14 skips to E15, F2/F3 hold; `hold` — E14, F2, and F3 all
 hold on `CAP_EXHAUSTED`.
 
+**Diagnostic note**: when every documented recovery route below fails
+identically and repeatedly, an organization-level review-quota outage
+(unrelated to this PR) is a plausible cause worth checking — for
+example via the review provider's own status or admin surface — before
+continuing to retry the same recovery cycle.
+
 ### Caller mapping
 
 <!-- dprint-ignore-start -->

--- a/.github/instructions/idd-advisory-wait.instructions.md
+++ b/.github/instructions/idd-advisory-wait.instructions.md
@@ -95,9 +95,9 @@ distributed defaults in `docs/policy-constants.md`: `REQUEST_CAP`,
 hold on `CAP_EXHAUSTED`.
 
 **Diagnostic note**: when every documented recovery route below fails
-identically and repeatedly, an organization-level review-quota outage
-(unrelated to this PR) is a plausible cause worth checking — for
-example via the review provider's own status or admin surface — before
+identically and repeatedly, an organization-level Copilot review-quota
+outage (unrelated to this PR) is a plausible cause worth checking — for
+example via Copilot/GitHub status or an org admin surface — before
 continuing to retry the same recovery cycle.
 
 ### Caller mapping

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -89,6 +89,12 @@ distributed defaults in `docs/policy-constants.md`: `REQUEST_CAP`,
 (default) — E14 skips to E15, F2/F3 hold; `hold` — E14, F2, and F3 all
 hold on `CAP_EXHAUSTED`.
 
+**Diagnostic note**: when every documented recovery route below fails
+identically and repeatedly, an organization-level review-quota outage
+(unrelated to this PR) is a plausible cause worth checking — for
+example via the review provider's own status or admin surface — before
+continuing to retry the same recovery cycle.
+
 ### Caller mapping
 
 <!-- dprint-ignore-start -->

--- a/idd-template/.github/instructions/idd-advisory-wait.instructions.md
+++ b/idd-template/.github/instructions/idd-advisory-wait.instructions.md
@@ -90,9 +90,9 @@ distributed defaults in `docs/policy-constants.md`: `REQUEST_CAP`,
 hold on `CAP_EXHAUSTED`.
 
 **Diagnostic note**: when every documented recovery route below fails
-identically and repeatedly, an organization-level review-quota outage
-(unrelated to this PR) is a plausible cause worth checking — for
-example via the review provider's own status or admin surface — before
+identically and repeatedly, an organization-level Copilot review-quota
+outage (unrelated to this PR) is a plausible cause worth checking — for
+example via Copilot/GitHub status or an org admin surface — before
 continuing to retry the same recovery cycle.
 
 ### Caller mapping


### PR DESCRIPTION
# Summary

Add a short diagnostic note to `idd-advisory-wait.instructions.md` near
its `CAP_EXHAUSTED`/`CAP_EXHAUSTED_ROUTE` coverage, suggesting an
organization-level review-quota outage as a plausible cause when every
documented recovery route fails identically and repeatedly. The
template source (`idd-template/.github/instructions/idd-advisory-wait.instructions.md`)
and its regenerated repo-root mirror both carry the change, kept in
sync via `node scripts/sync-docs.mjs --apply`.

## Linked issue

Closes #2241

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

One adopter's required check stayed failed for roughly 28 hours while
every documented technical recovery route (re-requesting review, the
AW6 same-HEAD reroll, the AW3-S remove-re-request cycle, and a direct
API call) failed identically; the actual cause was an organization-level
review-quota outage unrelated to the PR, and the same recovery cycle
worked within minutes once the quota recovered.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed (bundle-review 122154/126000,
      bundle-merge 108144/114000 — within budget)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for repeated recovery failures.
  * Advises checking review-service status or administrative dashboards for organization-wide quota outages before retrying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->