### PR TITLE
docs(issue-authoring): scope contract.md's canonical reference

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -2,7 +2,9 @@
 
 This file keeps the `issue-authoring` bundle usable when it is installed
 or copied outside this repository root. It mirrors the canonical
-contract in `docs/issue-authoring-skill.md`.
+contract in `docs/issue-authoring-skill.md`. That canonical document
+exists only inside this bundle's source repository — an installed copy
+of this bundle should not expect it to be present.
 
 ## Target marker prefix
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -2,7 +2,9 @@
 
 This file keeps the `issue-authoring` bundle usable when it is installed
 or copied outside this repository root. It mirrors the canonical
-contract in `docs/issue-authoring-skill.md`.
+contract in `docs/issue-authoring-skill.md`. That canonical document
+exists only inside this bundle's source repository — an installed copy
+of this bundle should not expect it to be present.
 
 ## Target marker prefix
 


### PR DESCRIPTION
# Summary

Adds a source-repository scoping note to `skills/issue-authoring/references/contract.md`'s opening reference to `docs/issue-authoring-skill.md`, matching the "inside the source repository" wording `SKILL.md` already uses for the equivalent cross-reference. The canonical `docs/issue-authoring-skill.md` file only exists inside this bundle's source repository, so an unscoped reference in an installed copy pointed at a document that does not exist there.

## Linked issue

Closes #2239

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

An adopter repository installed `contract.md` without any `docs/issue-authoring-skill.md` present, and their own reviewer (GitHub Copilot) independently flagged the unscoped reference twice on the same PR.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [ ] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
