### PR TITLE
fix(onboard): prefer existing config.json commands on re-import

### DIFF
--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -295,7 +295,10 @@ const WHOLE_PLACEHOLDER_TOKEN_PATTERN = /^\{\{[A-Z][A-Z0-9_]*\}\}$/;
  * Read the target tree's existing `.github/idd/config.json` `commands`
  * table, when present, parseable, and non-empty (#2222). A row still
  * holding an unsubstituted placeholder token — a freshly imported tree
- * before `--substitute` has run, e.g. `{{FIX_VALIDATE_COMMANDS}}` — is
+ * before `--substitute` has run, e.g. the raw doubled-brace
+ * FIX_VALIDATE_COMMANDS token (spelled without braces here per this
+ * module's own comment convention below, so this file's own generated
+ * `.mjs` copy never registers as leftover template residue) — is
  * treated as unset rather than as a real existing value. Returns `null`
  * for a missing file, unparseable JSON, or an absent/non-object/empty
  * `commands` table; every such case means first-time onboarding, so the
@@ -453,8 +456,10 @@ const RESTORABLE_COMMAND_KEYS = new Set([
  * copies `.github/idd/config.json` byte-for-byte from source — including
  * on a re-import over an already-onboarded target, where it clobbers a
  * deliberately customized `commands` table with the source template's raw
- * `{{PLACEHOLDER}}` tokens. Without this restore, `deriveValidateCommands`
- * above has nothing left to prefer by the time `--substitute` runs.
+ * doubled-brace placeholder tokens (spelled without braces in comments
+ * per this module's own convention below). Without this restore,
+ * `deriveValidateCommands` above has nothing left to prefer by the time
+ * `--substitute` runs.
  *
  * Call this **after** `applyImportPlan` has copied the target tree, passing
  * the `commands` snapshot `readExistingCommandsTable` captured from the

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -287,22 +287,30 @@ export function deriveInstallDepsCommand(targetDir) {
   }
   return null;
 }
-// Whole-string match only (no `g` flag): a config row is either exactly an
-// unsubstituted placeholder token or a real value, never a mix worth
-// partially matching.
-const WHOLE_PLACEHOLDER_TOKEN_PATTERN = /^\{\{[A-Z][A-Z0-9_]*\}\}$/;
+// The exact set of doubled-brace tokens this module's own onboarding
+// substitution ever writes/reads (ONBOARDING_PLACEHOLDERS above). An
+// adopter's own commands row can legitimately hold a `{{...}}`-shaped
+// literal value that has nothing to do with this onboarding flow (their
+// own downstream template syntax); only a row matching one of *our* seven
+// known tokens is unresolved onboarding residue worth treating as unset,
+// not any string that merely has the same doubled-brace shape (Copilot
+// review on PR #2254).
+const KNOWN_PLACEHOLDER_TOKENS = new Set(
+  ONBOARDING_PLACEHOLDERS.map((entry) => entry.token),
+);
 /**
  * Read the target tree's existing `.github/idd/config.json` `commands`
  * table, when present, parseable, and non-empty (#2222). A row still
- * holding an unsubstituted placeholder token — a freshly imported tree
- * before `--substitute` has run, e.g. the raw doubled-brace
- * FIX_VALIDATE_COMMANDS token (spelled without braces here per this
- * module's own comment convention below, so this file's own generated
- * `.mjs` copy never registers as leftover template residue) — is
- * treated as unset rather than as a real existing value. Returns `null`
- * for a missing file, unparseable JSON, or an absent/non-object/empty
- * `commands` table; every such case means first-time onboarding, so the
- * caller falls back to the package.json-derived heuristic unchanged.
+ * holding one of this module's own unsubstituted onboarding placeholder
+ * tokens — a freshly imported tree before `--substitute` has run, e.g.
+ * the raw doubled-brace FIX_VALIDATE_COMMANDS token (spelled without
+ * braces here per this module's own comment convention below, so this
+ * file's own generated `.mjs` copy never registers as leftover template
+ * residue) — is treated as unset rather than as a real existing value.
+ * Returns `null` for a missing file, unparseable JSON, or an
+ * absent/non-object/empty `commands` table; every such case means
+ * first-time onboarding, so the caller falls back to the
+ * package.json-derived heuristic unchanged.
  *
  * Exported so `runImportCli` can snapshot the pre-import table before
  * `--import` overwrites `.github/idd/config.json`, restoring it afterward
@@ -338,7 +346,7 @@ export function readExistingCommandsTable(targetDir) {
   const table = {};
   for (const [key, value] of Object.entries(commands)) {
     const trimmed = typeof value === 'string' ? value.trim() : '';
-    if (trimmed !== '' && !WHOLE_PLACEHOLDER_TOKEN_PATTERN.test(trimmed)) {
+    if (trimmed !== '' && !KNOWN_PLACEHOLDER_TOKENS.has(trimmed)) {
       table[key] = value;
     }
   }

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -317,6 +317,14 @@ const KNOWN_PLACEHOLDER_TOKENS = new Set(
  * via `restoreExistingCommandsTable` below.
  */
 export function readExistingCommandsTable(targetDir) {
+  // fileExists uses lstatSync (never follows symlinks), matching this
+  // module's existing convention (see the lstatSync note above) --
+  // readTextIfPresent's plain readFileSync would otherwise happily follow
+  // a symlinked config.json and let its target-boundary-external content
+  // leak into the substitution verdict and target files (#2254 review).
+  if (!fileExists(targetDir, '.github/idd/config.json')) {
+    return null;
+  }
   const configText = readTextIfPresent(targetDir, '.github/idd/config.json');
   if (configText === null) {
     return null;
@@ -493,6 +501,12 @@ export function restoreExistingCommandsTable(targetDir, existingCommands) {
     return;
   }
   const configRelativePath = '.github/idd/config.json';
+  // Same lstatSync-based symlink rejection as readExistingCommandsTable
+  // above -- a symlinked config.json here would otherwise let this
+  // function write through it to a target-boundary-external file.
+  if (!fileExists(targetDir, configRelativePath)) {
+    return;
+  }
   const text = readTextIfPresent(targetDir, configRelativePath);
   if (text === null) {
     return;

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -319,6 +319,14 @@ export function readExistingCommandsTable(targetDir) {
   } catch {
     return null;
   }
+  // A valid JSON document can still parse to a non-object root (`null`, a
+  // number, a bare string, an array) -- guard before reading `.commands`
+  // off it, since a `null` root would otherwise throw on property access
+  // rather than being treated as "no commands table" like every other
+  // malformed-config case above.
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null;
+  }
   const commands = parsed.commands;
   if (
     commands === null ||

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -320,9 +320,14 @@ export function readExistingCommandsTable(targetDir) {
   // fileExists uses lstatSync (never follows symlinks), matching this
   // module's existing convention (see the lstatSync note above) --
   // readTextIfPresent's plain readFileSync would otherwise happily follow
-  // a symlinked config.json and let its target-boundary-external content
-  // leak into the substitution verdict and target files (#2254 review).
-  if (!fileExists(targetDir, '.github/idd/config.json')) {
+  // a symlinked config.json (or a symlinked .github/.github/idd ancestor
+  // directory -- fileExists alone only lstats the leaf) and let its
+  // target-boundary-external content leak into the substitution verdict
+  // and target files (#2254 review).
+  if (
+    hasNonDirectoryAncestor(targetDir, '.github/idd/config.json') ||
+    !fileExists(targetDir, '.github/idd/config.json')
+  ) {
     return null;
   }
   const configText = readTextIfPresent(targetDir, '.github/idd/config.json');
@@ -501,10 +506,14 @@ export function restoreExistingCommandsTable(targetDir, existingCommands) {
     return;
   }
   const configRelativePath = '.github/idd/config.json';
-  // Same lstatSync-based symlink rejection as readExistingCommandsTable
-  // above -- a symlinked config.json here would otherwise let this
-  // function write through it to a target-boundary-external file.
-  if (!fileExists(targetDir, configRelativePath)) {
+  // Same ancestor-and-leaf symlink rejection as readExistingCommandsTable
+  // above -- a symlinked config.json, or a symlinked .github/.github/idd
+  // ancestor directory, would otherwise let this function write through
+  // it to a target-boundary-external file.
+  if (
+    hasNonDirectoryAncestor(targetDir, configRelativePath) ||
+    !fileExists(targetDir, configRelativePath)
+  ) {
     return;
   }
   const text = readTextIfPresent(targetDir, configRelativePath);

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -287,14 +287,82 @@ export function deriveInstallDepsCommand(targetDir) {
   }
   return null;
 }
+// Whole-string match only (no `g` flag): a config row is either exactly an
+// unsubstituted placeholder token or a real value, never a mix worth
+// partially matching.
+const WHOLE_PLACEHOLDER_TOKEN_PATTERN = /^\{\{[A-Z][A-Z0-9_]*\}\}$/;
+/**
+ * Read the target tree's existing `.github/idd/config.json` `commands`
+ * table, when present, parseable, and non-empty (#2222). A row still
+ * holding an unsubstituted placeholder token — a freshly imported tree
+ * before `--substitute` has run, e.g. `{{FIX_VALIDATE_COMMANDS}}` — is
+ * treated as unset rather than as a real existing value. Returns `null`
+ * for a missing file, unparseable JSON, or an absent/non-object/empty
+ * `commands` table; every such case means first-time onboarding, so the
+ * caller falls back to the package.json-derived heuristic unchanged.
+ *
+ * Exported so `runImportCli` can snapshot the pre-import table before
+ * `--import` overwrites `.github/idd/config.json`, restoring it afterward
+ * via `restoreExistingCommandsTable` below.
+ */
+export function readExistingCommandsTable(targetDir) {
+  const configText = readTextIfPresent(targetDir, '.github/idd/config.json');
+  if (configText === null) {
+    return null;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(configText);
+  } catch {
+    return null;
+  }
+  const commands = parsed.commands;
+  if (
+    commands === null ||
+    typeof commands !== 'object' ||
+    Array.isArray(commands)
+  ) {
+    return null;
+  }
+  const table = {};
+  for (const [key, value] of Object.entries(commands)) {
+    const trimmed = typeof value === 'string' ? value.trim() : '';
+    if (trimmed !== '' && !WHOLE_PLACEHOLDER_TOKEN_PATTERN.test(trimmed)) {
+      table[key] = value;
+    }
+  }
+  return Object.keys(table).length > 0 ? table : null;
+}
 /**
  * Derive the three validate-command rows from the target tree per the
  * reference patterns: Node trees read the existing `package.json` scripts;
  * `go.mod` / `Cargo.toml` trees use the fixed rows; a tree with no
  * recognized tooling at all takes the no-op `true` rows. Anything else
  * stays unresolved so the operator supplies flags.
+ *
+ * A re-import against a tree that already carries a populated `commands`
+ * table in `.github/idd/config.json` (#2222) prefers each existing row
+ * over this re-derivation instead of silently overwriting a deliberately
+ * customized command with a mechanically re-derived one; the caller's own
+ * `--*-commands` flag overrides still take priority over both (applied by
+ * `resolvePlaceholderValues`, not here). Only a row the existing table
+ * leaves unset falls through to the heuristic below, and a first-time
+ * onboarding (no existing table) leaves every row on the heuristic exactly
+ * as before.
  */
 export function deriveValidateCommands(targetDir) {
+  const heuristic = deriveValidateCommandsFromTooling(targetDir);
+  const existing = readExistingCommandsTable(targetDir);
+  if (existing === null) {
+    return heuristic;
+  }
+  return {
+    fixValidate: existing['fix-validate'] ?? heuristic.fixValidate,
+    prePushValidate: existing['pre-push-validate'] ?? heuristic.prePushValidate,
+    postFixValidate: existing['post-fix-validate'] ?? heuristic.postFixValidate,
+  };
+}
+function deriveValidateCommandsFromTooling(targetDir) {
   const packageJsonText = readTextIfPresent(targetDir, 'package.json');
   if (packageJsonText !== null) {
     let scripts = {};
@@ -364,6 +432,66 @@ export function deriveValidateCommands(targetDir) {
     };
   }
   return { fixValidate: null, prePushValidate: null, postFixValidate: null };
+}
+/** Escape a literal string for embedding in a `RegExp` source. */
+function escapeRegExpLiteral(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+// Scope matches deriveValidateCommands above exactly (#2222's three
+// validate-command rows). install-deps is deliberately excluded: the issue
+// scopes only fix-validate/pre-push-validate/post-fix-validate, and
+// INSTALL_DEPS_COMMAND already has its own independent re-derivation
+// (deriveInstallDepsCommand) that this restore step must not shadow.
+const RESTORABLE_COMMAND_KEYS = new Set([
+  'fix-validate',
+  'pre-push-validate',
+  'post-fix-validate',
+]);
+/**
+ * Restore a target's pre-import validate-command row values into its
+ * freshly-copied `.github/idd/config.json` (#2222). `--import` always
+ * copies `.github/idd/config.json` byte-for-byte from source — including
+ * on a re-import over an already-onboarded target, where it clobbers a
+ * deliberately customized `commands` table with the source template's raw
+ * `{{PLACEHOLDER}}` tokens. Without this restore, `deriveValidateCommands`
+ * above has nothing left to prefer by the time `--substitute` runs.
+ *
+ * Call this **after** `applyImportPlan` has copied the target tree, passing
+ * the `commands` snapshot `readExistingCommandsTable` captured from the
+ * **pre-import** target. Only restores the three rows in
+ * `RESTORABLE_COMMAND_KEYS`, and only a row that is still the raw
+ * placeholder token right after the copy — a source-provided literal value
+ * (no `{{...}}` template site for that key) is left untouched, since there
+ * is nothing to substitute later and overwriting it would silently discard
+ * an intentional source-side change instead. No-op when the snapshot is
+ * null/empty, the target has no `.github/idd/config.json`, or a given
+ * snapshot row has no matching placeholder-token site left to restore into.
+ */
+export function restoreExistingCommandsTable(targetDir, existingCommands) {
+  if (existingCommands === null || Object.keys(existingCommands).length === 0) {
+    return;
+  }
+  const configRelativePath = '.github/idd/config.json';
+  const text = readTextIfPresent(targetDir, configRelativePath);
+  if (text === null) {
+    return;
+  }
+  let updated = text;
+  for (const [key, value] of Object.entries(existingCommands)) {
+    if (!RESTORABLE_COMMAND_KEYS.has(key)) {
+      continue;
+    }
+    const rowPattern = new RegExp(
+      `("${escapeRegExpLiteral(key)}"\\s*:\\s*)"\\{\\{[A-Z][A-Z0-9_]*\\}\\}"`,
+    );
+    updated = updated.replace(
+      rowPattern,
+      (_match, prefix) => `${prefix}"${escapeJsonStringContent(value)}"`,
+    );
+  }
+  if (updated !== text) {
+    writeFileSync(join(targetDir, ...configRelativePath.split('/')), updated);
+  }
 }
 /** Default remote-URL reader: `git -C <target> config remote.origin.url`. */
 export function readGitRemoteUrl(targetDir) {
@@ -1205,6 +1333,11 @@ function runImportCli(args) {
   if (!statSync(targetDir).isDirectory()) {
     throw new Error(`--target is not a directory: ${args.target}`);
   }
+  // Snapshot before the copy: --import always overwrites
+  // .github/idd/config.json byte-for-byte from source (#2222), so a
+  // re-import's already-customized commands table must be captured now,
+  // before applyImportPlan below replaces it with the raw template.
+  const existingCommandsSnapshot = readExistingCommandsTable(targetDir);
   const plan = buildImportPlan(sourceDir, targetDir, {
     profile: args.profile,
     force: args.force,
@@ -1221,6 +1354,9 @@ function runImportCli(args) {
   const filesChanged = canWrite
     ? applyImportPlan(sourceDir, targetDir, plan)
     : 0;
+  if (canWrite && filesChanged > 0) {
+    restoreExistingCommandsTable(targetDir, existingCommandsSnapshot);
+  }
   const verdict = {
     protocolVersion: '1',
     mode: args.dryRun ? 'dry-run' : 'apply',

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -372,13 +372,21 @@ export function readExistingCommandsTable(
   if (configText === null) {
     return null;
   }
-  let parsed: { commands?: unknown };
+  let parsed: unknown;
   try {
-    parsed = JSON.parse(configText) as { commands?: unknown };
+    parsed = JSON.parse(configText);
   } catch {
     return null;
   }
-  const commands = parsed.commands;
+  // A valid JSON document can still parse to a non-object root (`null`, a
+  // number, a bare string, an array) -- guard before reading `.commands`
+  // off it, since a `null` root would otherwise throw on property access
+  // rather than being treated as "no commands table" like every other
+  // malformed-config case above.
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return null;
+  }
+  const commands = (parsed as { commands?: unknown }).commands;
   if (
     commands === null ||
     typeof commands !== 'object' ||

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -343,23 +343,31 @@ export interface ValidateCommandRows {
   postFixValidate: string | null;
 }
 
-// Whole-string match only (no `g` flag): a config row is either exactly an
-// unsubstituted placeholder token or a real value, never a mix worth
-// partially matching.
-const WHOLE_PLACEHOLDER_TOKEN_PATTERN = /^\{\{[A-Z][A-Z0-9_]*\}\}$/;
+// The exact set of doubled-brace tokens this module's own onboarding
+// substitution ever writes/reads (ONBOARDING_PLACEHOLDERS above). An
+// adopter's own commands row can legitimately hold a `{{...}}`-shaped
+// literal value that has nothing to do with this onboarding flow (their
+// own downstream template syntax); only a row matching one of *our* seven
+// known tokens is unresolved onboarding residue worth treating as unset,
+// not any string that merely has the same doubled-brace shape (Copilot
+// review on PR #2254).
+const KNOWN_PLACEHOLDER_TOKENS: ReadonlySet<string> = new Set(
+  ONBOARDING_PLACEHOLDERS.map((entry) => entry.token),
+);
 
 /**
  * Read the target tree's existing `.github/idd/config.json` `commands`
  * table, when present, parseable, and non-empty (#2222). A row still
- * holding an unsubstituted placeholder token — a freshly imported tree
- * before `--substitute` has run, e.g. the raw doubled-brace
- * FIX_VALIDATE_COMMANDS token (spelled without braces here per this
- * module's own comment convention below, so this file's own generated
- * `.mjs` copy never registers as leftover template residue) — is
- * treated as unset rather than as a real existing value. Returns `null`
- * for a missing file, unparseable JSON, or an absent/non-object/empty
- * `commands` table; every such case means first-time onboarding, so the
- * caller falls back to the package.json-derived heuristic unchanged.
+ * holding one of this module's own unsubstituted onboarding placeholder
+ * tokens — a freshly imported tree before `--substitute` has run, e.g.
+ * the raw doubled-brace FIX_VALIDATE_COMMANDS token (spelled without
+ * braces here per this module's own comment convention below, so this
+ * file's own generated `.mjs` copy never registers as leftover template
+ * residue) — is treated as unset rather than as a real existing value.
+ * Returns `null` for a missing file, unparseable JSON, or an
+ * absent/non-object/empty `commands` table; every such case means
+ * first-time onboarding, so the caller falls back to the
+ * package.json-derived heuristic unchanged.
  *
  * Exported so `runImportCli` can snapshot the pre-import table before
  * `--import` overwrites `.github/idd/config.json`, restoring it afterward
@@ -399,7 +407,7 @@ export function readExistingCommandsTable(
     commands as Record<string, unknown>,
   )) {
     const trimmed = typeof value === 'string' ? value.trim() : '';
-    if (trimmed !== '' && !WHOLE_PLACEHOLDER_TOKEN_PATTERN.test(trimmed)) {
+    if (trimmed !== '' && !KNOWN_PLACEHOLDER_TOKENS.has(trimmed)) {
       table[key] = value as string;
     }
   }

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -376,6 +376,14 @@ const KNOWN_PLACEHOLDER_TOKENS: ReadonlySet<string> = new Set(
 export function readExistingCommandsTable(
   targetDir: string,
 ): Record<string, string> | null {
+  // fileExists uses lstatSync (never follows symlinks), matching this
+  // module's existing convention (see the lstatSync note above) --
+  // readTextIfPresent's plain readFileSync would otherwise happily follow
+  // a symlinked config.json and let its target-boundary-external content
+  // leak into the substitution verdict and target files (#2254 review).
+  if (!fileExists(targetDir, '.github/idd/config.json')) {
+    return null;
+  }
   const configText = readTextIfPresent(targetDir, '.github/idd/config.json');
   if (configText === null) {
     return null;
@@ -566,6 +574,12 @@ export function restoreExistingCommandsTable(
     return;
   }
   const configRelativePath = '.github/idd/config.json';
+  // Same lstatSync-based symlink rejection as readExistingCommandsTable
+  // above -- a symlinked config.json here would otherwise let this
+  // function write through it to a target-boundary-external file.
+  if (!fileExists(targetDir, configRelativePath)) {
+    return;
+  }
   const text = readTextIfPresent(targetDir, configRelativePath);
   if (text === null) {
     return;

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -352,7 +352,10 @@ const WHOLE_PLACEHOLDER_TOKEN_PATTERN = /^\{\{[A-Z][A-Z0-9_]*\}\}$/;
  * Read the target tree's existing `.github/idd/config.json` `commands`
  * table, when present, parseable, and non-empty (#2222). A row still
  * holding an unsubstituted placeholder token — a freshly imported tree
- * before `--substitute` has run, e.g. `{{FIX_VALIDATE_COMMANDS}}` — is
+ * before `--substitute` has run, e.g. the raw doubled-brace
+ * FIX_VALIDATE_COMMANDS token (spelled without braces here per this
+ * module's own comment convention below, so this file's own generated
+ * `.mjs` copy never registers as leftover template residue) — is
  * treated as unset rather than as a real existing value. Returns `null`
  * for a missing file, unparseable JSON, or an absent/non-object/empty
  * `commands` table; every such case means first-time onboarding, so the
@@ -523,8 +526,10 @@ const RESTORABLE_COMMAND_KEYS: ReadonlySet<string> = new Set([
  * copies `.github/idd/config.json` byte-for-byte from source — including
  * on a re-import over an already-onboarded target, where it clobbers a
  * deliberately customized `commands` table with the source template's raw
- * `{{PLACEHOLDER}}` tokens. Without this restore, `deriveValidateCommands`
- * above has nothing left to prefer by the time `--substitute` runs.
+ * doubled-brace placeholder tokens (spelled without braces in comments
+ * per this module's own convention below). Without this restore,
+ * `deriveValidateCommands` above has nothing left to prefer by the time
+ * `--substitute` runs.
  *
  * Call this **after** `applyImportPlan` has copied the target tree, passing
  * the `commands` snapshot `readExistingCommandsTable` captured from the

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -343,14 +343,91 @@ export interface ValidateCommandRows {
   postFixValidate: string | null;
 }
 
+// Whole-string match only (no `g` flag): a config row is either exactly an
+// unsubstituted placeholder token or a real value, never a mix worth
+// partially matching.
+const WHOLE_PLACEHOLDER_TOKEN_PATTERN = /^\{\{[A-Z][A-Z0-9_]*\}\}$/;
+
+/**
+ * Read the target tree's existing `.github/idd/config.json` `commands`
+ * table, when present, parseable, and non-empty (#2222). A row still
+ * holding an unsubstituted placeholder token — a freshly imported tree
+ * before `--substitute` has run, e.g. `{{FIX_VALIDATE_COMMANDS}}` — is
+ * treated as unset rather than as a real existing value. Returns `null`
+ * for a missing file, unparseable JSON, or an absent/non-object/empty
+ * `commands` table; every such case means first-time onboarding, so the
+ * caller falls back to the package.json-derived heuristic unchanged.
+ *
+ * Exported so `runImportCli` can snapshot the pre-import table before
+ * `--import` overwrites `.github/idd/config.json`, restoring it afterward
+ * via `restoreExistingCommandsTable` below.
+ */
+export function readExistingCommandsTable(
+  targetDir: string,
+): Record<string, string> | null {
+  const configText = readTextIfPresent(targetDir, '.github/idd/config.json');
+  if (configText === null) {
+    return null;
+  }
+  let parsed: { commands?: unknown };
+  try {
+    parsed = JSON.parse(configText) as { commands?: unknown };
+  } catch {
+    return null;
+  }
+  const commands = parsed.commands;
+  if (
+    commands === null ||
+    typeof commands !== 'object' ||
+    Array.isArray(commands)
+  ) {
+    return null;
+  }
+  const table: Record<string, string> = {};
+  for (const [key, value] of Object.entries(
+    commands as Record<string, unknown>,
+  )) {
+    const trimmed = typeof value === 'string' ? value.trim() : '';
+    if (trimmed !== '' && !WHOLE_PLACEHOLDER_TOKEN_PATTERN.test(trimmed)) {
+      table[key] = value as string;
+    }
+  }
+  return Object.keys(table).length > 0 ? table : null;
+}
+
 /**
  * Derive the three validate-command rows from the target tree per the
  * reference patterns: Node trees read the existing `package.json` scripts;
  * `go.mod` / `Cargo.toml` trees use the fixed rows; a tree with no
  * recognized tooling at all takes the no-op `true` rows. Anything else
  * stays unresolved so the operator supplies flags.
+ *
+ * A re-import against a tree that already carries a populated `commands`
+ * table in `.github/idd/config.json` (#2222) prefers each existing row
+ * over this re-derivation instead of silently overwriting a deliberately
+ * customized command with a mechanically re-derived one; the caller's own
+ * `--*-commands` flag overrides still take priority over both (applied by
+ * `resolvePlaceholderValues`, not here). Only a row the existing table
+ * leaves unset falls through to the heuristic below, and a first-time
+ * onboarding (no existing table) leaves every row on the heuristic exactly
+ * as before.
  */
 export function deriveValidateCommands(targetDir: string): ValidateCommandRows {
+  const heuristic = deriveValidateCommandsFromTooling(targetDir);
+  const existing = readExistingCommandsTable(targetDir);
+  if (existing === null) {
+    return heuristic;
+  }
+  return {
+    fixValidate: existing['fix-validate'] ?? heuristic.fixValidate,
+    prePushValidate: existing['pre-push-validate'] ?? heuristic.prePushValidate,
+    postFixValidate: existing['post-fix-validate'] ?? heuristic.postFixValidate,
+  };
+}
+
+function deriveValidateCommandsFromTooling(
+  targetDir: string,
+): ValidateCommandRows {
   const packageJsonText = readTextIfPresent(targetDir, 'package.json');
   if (packageJsonText !== null) {
     let scripts: Record<string, unknown> = {};
@@ -422,6 +499,73 @@ export function deriveValidateCommands(targetDir: string): ValidateCommandRows {
     };
   }
   return { fixValidate: null, prePushValidate: null, postFixValidate: null };
+}
+
+/** Escape a literal string for embedding in a `RegExp` source. */
+function escapeRegExpLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+}
+
+// Scope matches deriveValidateCommands above exactly (#2222's three
+// validate-command rows). install-deps is deliberately excluded: the issue
+// scopes only fix-validate/pre-push-validate/post-fix-validate, and
+// INSTALL_DEPS_COMMAND already has its own independent re-derivation
+// (deriveInstallDepsCommand) that this restore step must not shadow.
+const RESTORABLE_COMMAND_KEYS: ReadonlySet<string> = new Set([
+  'fix-validate',
+  'pre-push-validate',
+  'post-fix-validate',
+]);
+
+/**
+ * Restore a target's pre-import validate-command row values into its
+ * freshly-copied `.github/idd/config.json` (#2222). `--import` always
+ * copies `.github/idd/config.json` byte-for-byte from source — including
+ * on a re-import over an already-onboarded target, where it clobbers a
+ * deliberately customized `commands` table with the source template's raw
+ * `{{PLACEHOLDER}}` tokens. Without this restore, `deriveValidateCommands`
+ * above has nothing left to prefer by the time `--substitute` runs.
+ *
+ * Call this **after** `applyImportPlan` has copied the target tree, passing
+ * the `commands` snapshot `readExistingCommandsTable` captured from the
+ * **pre-import** target. Only restores the three rows in
+ * `RESTORABLE_COMMAND_KEYS`, and only a row that is still the raw
+ * placeholder token right after the copy — a source-provided literal value
+ * (no `{{...}}` template site for that key) is left untouched, since there
+ * is nothing to substitute later and overwriting it would silently discard
+ * an intentional source-side change instead. No-op when the snapshot is
+ * null/empty, the target has no `.github/idd/config.json`, or a given
+ * snapshot row has no matching placeholder-token site left to restore into.
+ */
+export function restoreExistingCommandsTable(
+  targetDir: string,
+  existingCommands: Record<string, string> | null,
+): void {
+  if (existingCommands === null || Object.keys(existingCommands).length === 0) {
+    return;
+  }
+  const configRelativePath = '.github/idd/config.json';
+  const text = readTextIfPresent(targetDir, configRelativePath);
+  if (text === null) {
+    return;
+  }
+  let updated = text;
+  for (const [key, value] of Object.entries(existingCommands)) {
+    if (!RESTORABLE_COMMAND_KEYS.has(key)) {
+      continue;
+    }
+    const rowPattern = new RegExp(
+      `("${escapeRegExpLiteral(key)}"\\s*:\\s*)"\\{\\{[A-Z][A-Z0-9_]*\\}\\}"`,
+    );
+    updated = updated.replace(
+      rowPattern,
+      (_match, prefix: string) =>
+        `${prefix}"${escapeJsonStringContent(value)}"`,
+    );
+  }
+  if (updated !== text) {
+    writeFileSync(join(targetDir, ...configRelativePath.split('/')), updated);
+  }
 }
 
 /** How a placeholder value was established. */
@@ -1521,6 +1665,11 @@ function runImportCli(args: ParsedArgs): void {
   if (!statSync(targetDir).isDirectory()) {
     throw new Error(`--target is not a directory: ${args.target}`);
   }
+  // Snapshot before the copy: --import always overwrites
+  // .github/idd/config.json byte-for-byte from source (#2222), so a
+  // re-import's already-customized commands table must be captured now,
+  // before applyImportPlan below replaces it with the raw template.
+  const existingCommandsSnapshot = readExistingCommandsTable(targetDir);
   const plan = buildImportPlan(sourceDir, targetDir, {
     profile: args.profile,
     force: args.force,
@@ -1537,6 +1686,9 @@ function runImportCli(args: ParsedArgs): void {
   const filesChanged = canWrite
     ? applyImportPlan(sourceDir, targetDir, plan)
     : 0;
+  if (canWrite && filesChanged > 0) {
+    restoreExistingCommandsTable(targetDir, existingCommandsSnapshot);
+  }
   const verdict = {
     protocolVersion: '1',
     mode: args.dryRun ? 'dry-run' : 'apply',

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -379,9 +379,14 @@ export function readExistingCommandsTable(
   // fileExists uses lstatSync (never follows symlinks), matching this
   // module's existing convention (see the lstatSync note above) --
   // readTextIfPresent's plain readFileSync would otherwise happily follow
-  // a symlinked config.json and let its target-boundary-external content
-  // leak into the substitution verdict and target files (#2254 review).
-  if (!fileExists(targetDir, '.github/idd/config.json')) {
+  // a symlinked config.json (or a symlinked .github/.github/idd ancestor
+  // directory -- fileExists alone only lstats the leaf) and let its
+  // target-boundary-external content leak into the substitution verdict
+  // and target files (#2254 review).
+  if (
+    hasNonDirectoryAncestor(targetDir, '.github/idd/config.json') ||
+    !fileExists(targetDir, '.github/idd/config.json')
+  ) {
     return null;
   }
   const configText = readTextIfPresent(targetDir, '.github/idd/config.json');
@@ -574,10 +579,14 @@ export function restoreExistingCommandsTable(
     return;
   }
   const configRelativePath = '.github/idd/config.json';
-  // Same lstatSync-based symlink rejection as readExistingCommandsTable
-  // above -- a symlinked config.json here would otherwise let this
-  // function write through it to a target-boundary-external file.
-  if (!fileExists(targetDir, configRelativePath)) {
+  // Same ancestor-and-leaf symlink rejection as readExistingCommandsTable
+  // above -- a symlinked config.json, or a symlinked .github/.github/idd
+  // ancestor directory, would otherwise let this function write through
+  // it to a target-boundary-external file.
+  if (
+    hasNonDirectoryAncestor(targetDir, configRelativePath) ||
+    !fileExists(targetDir, configRelativePath)
+  ) {
     return;
   }
   const text = readTextIfPresent(targetDir, configRelativePath);

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -438,6 +438,24 @@ test('deriveValidateCommands ignores a missing, empty, or unparseable commands t
     prePushValidate: 'go vet ./... && go test ./...',
     postFixValidate: 'go fmt ./... && go vet ./... && go test ./...',
   });
+
+  // A valid JSON document can still parse to a non-object root (`null`, a
+  // bare number/string, or an array) -- must not throw on property access.
+  for (const nonObjectRoot of ['null', '42', '"just a string"', '[1, 2]']) {
+    const root = makeFixtureDir();
+    writeFileSync(join(root, 'go.mod'), 'module x\n');
+    mkdirSync(join(root, '.github', 'idd'), { recursive: true });
+    writeFileSync(join(root, '.github', 'idd', 'config.json'), nonObjectRoot);
+    assert.deepEqual(
+      deriveValidateCommands(root),
+      {
+        fixValidate: 'go fmt ./...',
+        prePushValidate: 'go vet ./... && go test ./...',
+        postFixValidate: 'go fmt ./... && go vet ./... && go test ./...',
+      },
+      `config.json root: ${nonObjectRoot}`,
+    );
+  }
 });
 
 test('a first-time onboarding (no existing commands table) still derives from package.json exactly as before', () => {

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -610,6 +610,33 @@ test('restoreExistingCommandsTable is a no-op for a null/empty snapshot or a mis
   assert.equal(existsSync(join(noConfigRoot, '.github', 'idd')), false);
 });
 
+test('readExistingCommandsTable and restoreExistingCommandsTable never follow a symlinked config.json out of the target (#2254 review)', () => {
+  const outsideRoot = makeFixtureDir();
+  const outsideConfigPath = join(outsideRoot, 'secret-config.json');
+  writeFileSync(
+    outsideConfigPath,
+    JSON.stringify({ commands: { 'fix-validate': 'leaked-secret-command' } }),
+  );
+
+  const targetRoot = makeFixtureDir();
+  mkdirSync(join(targetRoot, '.github', 'idd'), { recursive: true });
+  const symlinkPath = join(targetRoot, '.github', 'idd', 'config.json');
+  symlinkSync(outsideConfigPath, symlinkPath);
+
+  // A symlinked config.json is treated as absent, never followed to read
+  // content from outside the target tree.
+  assert.equal(readExistingCommandsTable(targetRoot), null);
+
+  // Nor written through: restoring must not touch the outside file, and
+  // must leave the symlink itself untouched too.
+  restoreExistingCommandsTable(targetRoot, { 'fix-validate': 'restored' });
+  assert.equal(
+    readFileSync(outsideConfigPath, 'utf8'),
+    JSON.stringify({ commands: { 'fix-validate': 'leaked-secret-command' } }),
+  );
+  assert.ok(lstatSync(symlinkPath).isSymbolicLink());
+});
+
 // ---------------------------------------------------------------------------
 // Resolution rules
 // ---------------------------------------------------------------------------

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -637,6 +637,30 @@ test('readExistingCommandsTable and restoreExistingCommandsTable never follow a 
   assert.ok(lstatSync(symlinkPath).isSymbolicLink());
 });
 
+test('readExistingCommandsTable and restoreExistingCommandsTable never follow a symlinked ancestor directory either (#2254 review)', () => {
+  const outsideRoot = makeFixtureDir();
+  writeFileSync(
+    join(outsideRoot, 'config.json'),
+    JSON.stringify({ commands: { 'fix-validate': 'leaked-secret-command' } }),
+  );
+
+  const targetRoot = makeFixtureDir();
+  mkdirSync(join(targetRoot, '.github'), { recursive: true });
+  // .github/idd itself is a symlink to an external directory -- a plain
+  // fileExists lstat on the leaf config.json alone would not catch this,
+  // since the leaf lstat follows the symlinked parent to resolve its path.
+  symlinkSync(outsideRoot, join(targetRoot, '.github', 'idd'));
+
+  assert.equal(readExistingCommandsTable(targetRoot), null);
+
+  restoreExistingCommandsTable(targetRoot, { 'fix-validate': 'restored' });
+  assert.equal(
+    readFileSync(join(outsideRoot, 'config.json'), 'utf8'),
+    JSON.stringify({ commands: { 'fix-validate': 'leaked-secret-command' } }),
+  );
+  assert.ok(lstatSync(join(targetRoot, '.github', 'idd')).isSymbolicLink());
+});
+
 // ---------------------------------------------------------------------------
 // Resolution rules
 // ---------------------------------------------------------------------------

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -42,9 +42,11 @@ import {
   MARKER_PREFIX_PATTERN,
   ONBOARDING_PLACEHOLDERS,
   parseRemoteRepoRef,
+  readExistingCommandsTable,
   resolveCoreTemplateFiles,
   resolveImportFiles,
   resolvePlaceholderValues,
+  restoreExistingCommandsTable,
   runVerify,
   SCAN_EXCLUDED_PATHS,
   scanPlaceholderTokens,
@@ -342,6 +344,232 @@ test('deriveValidateCommands uses fixed rows for go and the no-op for bare trees
     prePushValidate: null,
     postFixValidate: null,
   });
+});
+
+function writeExistingCommandsConfig(
+  root: string,
+  commands: Record<string, string>,
+): void {
+  mkdirSync(join(root, '.github', 'idd'), { recursive: true });
+  writeFileSync(
+    join(root, '.github', 'idd', 'config.json'),
+    JSON.stringify({ commands }),
+  );
+}
+
+test('deriveValidateCommands prefers an existing populated commands table on re-import (#2222)', () => {
+  const root = makeFixtureDir();
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ scripts: { 'lint:fix': 'x', lint: 'x', test: 'x' } }),
+  );
+  writeFileSync(join(root, 'pnpm-lock.yaml'), '');
+  writeExistingCommandsConfig(root, {
+    'fix-validate': 'npx biome check --write',
+    'pre-push-validate': 'npx biome check',
+    'post-fix-validate': 'npx biome check --write',
+  });
+  // The heuristic would derive pnpm lint:fix/lint/test rows; the existing
+  // deliberately customized table wins for every row it sets.
+  assert.deepEqual(deriveValidateCommands(root), {
+    fixValidate: 'npx biome check --write',
+    prePushValidate: 'npx biome check',
+    postFixValidate: 'npx biome check --write',
+  });
+});
+
+test('deriveValidateCommands falls back to the heuristic only for rows the existing table leaves unset', () => {
+  const root = makeFixtureDir();
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ scripts: { 'lint:fix': 'x', lint: 'x', test: 'x' } }),
+  );
+  writeFileSync(join(root, 'pnpm-lock.yaml'), '');
+  writeExistingCommandsConfig(root, {
+    'fix-validate': 'npx biome check --write',
+  });
+  assert.deepEqual(deriveValidateCommands(root), {
+    fixValidate: 'npx biome check --write',
+    prePushValidate: 'pnpm run lint && pnpm run test',
+    postFixValidate: 'pnpm run lint:fix && pnpm run lint && pnpm run test',
+  });
+});
+
+test('deriveValidateCommands treats an unsubstituted placeholder row as unset, not as an existing value', () => {
+  const root = makeFixtureDir();
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ scripts: { 'lint:fix': 'x', lint: 'x', test: 'x' } }),
+  );
+  writeFileSync(join(root, 'pnpm-lock.yaml'), '');
+  // A freshly imported tree before --substitute has run still carries the
+  // raw template tokens — those must not be read back as real commands.
+  writeExistingCommandsConfig(root, {
+    'fix-validate': '{{FIX_VALIDATE_COMMANDS}}',
+    'pre-push-validate': '{{PRE_PUSH_VALIDATE_COMMANDS}}',
+    'post-fix-validate': '{{POST_FIX_VALIDATE_COMMANDS}}',
+  });
+  assert.deepEqual(deriveValidateCommands(root), {
+    fixValidate: 'pnpm run lint:fix && pnpm run lint',
+    prePushValidate: 'pnpm run lint && pnpm run test',
+    postFixValidate: 'pnpm run lint:fix && pnpm run lint && pnpm run test',
+  });
+});
+
+test('deriveValidateCommands ignores a missing, empty, or unparseable commands table', () => {
+  const goRoot = makeFixtureDir();
+  writeFileSync(join(goRoot, 'go.mod'), 'module x\n');
+  writeExistingCommandsConfig(goRoot, {});
+  assert.deepEqual(deriveValidateCommands(goRoot), {
+    fixValidate: 'go fmt ./...',
+    prePushValidate: 'go vet ./... && go test ./...',
+    postFixValidate: 'go fmt ./... && go vet ./... && go test ./...',
+  });
+
+  const malformedRoot = makeFixtureDir();
+  writeFileSync(join(malformedRoot, 'go.mod'), 'module x\n');
+  mkdirSync(join(malformedRoot, '.github', 'idd'), { recursive: true });
+  writeFileSync(
+    join(malformedRoot, '.github', 'idd', 'config.json'),
+    '{ not valid json',
+  );
+  assert.deepEqual(deriveValidateCommands(malformedRoot), {
+    fixValidate: 'go fmt ./...',
+    prePushValidate: 'go vet ./... && go test ./...',
+    postFixValidate: 'go fmt ./... && go vet ./... && go test ./...',
+  });
+});
+
+test('a first-time onboarding (no existing commands table) still derives from package.json exactly as before', () => {
+  const root = makeFixtureDir();
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ scripts: { 'lint:fix': 'x', lint: 'x', test: 'x' } }),
+  );
+  writeFileSync(join(root, 'pnpm-lock.yaml'), '');
+  assert.deepEqual(deriveValidateCommands(root), {
+    fixValidate: 'pnpm run lint:fix && pnpm run lint',
+    prePushValidate: 'pnpm run lint && pnpm run test',
+    postFixValidate: 'pnpm run lint:fix && pnpm run lint && pnpm run test',
+  });
+});
+
+test('resolvePlaceholderValues re-import: existing config commands win, an explicit flag still overrides them', () => {
+  const root = makeFixtureDir();
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ scripts: { 'lint:fix': 'x', lint: 'x', test: 'x' } }),
+  );
+  writeFileSync(join(root, 'pnpm-lock.yaml'), '');
+  writeExistingCommandsConfig(root, {
+    'fix-validate': 'npx biome check --write',
+    'pre-push-validate': 'npx biome check',
+    'post-fix-validate': 'npx biome check --write',
+  });
+  const resolution = resolvePlaceholderValues(
+    root,
+    { PRE_PUSH_VALIDATE_COMMANDS: 'npm run ci' },
+    { readRemoteUrl: () => null },
+  );
+  assert.deepEqual(resolution.values.FIX_VALIDATE_COMMANDS, {
+    value: 'npx biome check --write',
+    source: 'derived',
+  });
+  assert.deepEqual(resolution.values.PRE_PUSH_VALIDATE_COMMANDS, {
+    value: 'npm run ci',
+    source: 'flag',
+  });
+  assert.deepEqual(resolution.values.POST_FIX_VALIDATE_COMMANDS, {
+    value: 'npx biome check --write',
+    source: 'derived',
+  });
+});
+
+test('readExistingCommandsTable is a generic commands-table reader (not scoped to the three validate rows)', () => {
+  const root = makeFixtureDir();
+  writeExistingCommandsConfig(root, {
+    'install-deps': 'npm install',
+    'fix-validate': 'npx biome check --write',
+  });
+  // deriveValidateCommands only reads the three keys it needs from this;
+  // the #2222 restore-scope boundary is enforced in
+  // restoreExistingCommandsTable below, not here.
+  assert.deepEqual(readExistingCommandsTable(root), {
+    'install-deps': 'npm install',
+    'fix-validate': 'npx biome check --write',
+  });
+});
+
+test('restoreExistingCommandsTable never restores install-deps, even when the snapshot includes it (#2222 scope)', () => {
+  const root = makeFixtureDir();
+  mkdirSync(join(root, '.github', 'idd'), { recursive: true });
+  writeFileSync(
+    join(root, '.github', 'idd', 'config.json'),
+    JSON.stringify({
+      commands: {
+        'install-deps': '{{INSTALL_DEPS_COMMAND}}',
+        'fix-validate': '{{FIX_VALIDATE_COMMANDS}}',
+      },
+    }),
+  );
+  restoreExistingCommandsTable(root, {
+    'install-deps': 'npm install',
+    'fix-validate': 'npx biome check --write',
+  });
+  const restored = JSON.parse(
+    readFileSync(join(root, '.github', 'idd', 'config.json'), 'utf8'),
+  ) as { commands: Record<string, string> };
+  assert.equal(restored.commands['fix-validate'], 'npx biome check --write');
+  // install-deps is out of #2222's scope: the placeholder token is left
+  // exactly as --import wrote it, for the normal --substitute flow to
+  // resolve independently via deriveInstallDepsCommand.
+  assert.equal(restored.commands['install-deps'], '{{INSTALL_DEPS_COMMAND}}');
+});
+
+test('restoreExistingCommandsTable only rewrites a row still holding the raw placeholder token', () => {
+  const root = makeFixtureDir();
+  mkdirSync(join(root, '.github', 'idd'), { recursive: true });
+  writeFileSync(
+    join(root, '.github', 'idd', 'config.json'),
+    JSON.stringify({
+      commands: {
+        // Source already provided a real value for this key (no
+        // placeholder site) — restoring must not clobber it.
+        'fix-validate': 'go fmt ./...',
+        'pre-push-validate': '{{PRE_PUSH_VALIDATE_COMMANDS}}',
+      },
+    }),
+  );
+  restoreExistingCommandsTable(root, {
+    'fix-validate': 'npx biome check --write',
+    'pre-push-validate': 'npx biome check',
+  });
+  const result = JSON.parse(
+    readFileSync(join(root, '.github', 'idd', 'config.json'), 'utf8'),
+  ) as { commands: Record<string, string> };
+  assert.equal(result.commands['fix-validate'], 'go fmt ./...');
+  assert.equal(result.commands['pre-push-validate'], 'npx biome check');
+});
+
+test('restoreExistingCommandsTable is a no-op for a null/empty snapshot or a missing config.json', () => {
+  const root = makeFixtureDir();
+  mkdirSync(join(root, '.github', 'idd'), { recursive: true });
+  const configPath = join(root, '.github', 'idd', 'config.json');
+  writeFileSync(
+    configPath,
+    JSON.stringify({
+      commands: { 'fix-validate': '{{FIX_VALIDATE_COMMANDS}}' },
+    }),
+  );
+  const before = readFileSync(configPath, 'utf8');
+  restoreExistingCommandsTable(root, null);
+  restoreExistingCommandsTable(root, {});
+  assert.equal(readFileSync(configPath, 'utf8'), before);
+
+  const noConfigRoot = makeFixtureDir();
+  // Must not throw when .github/idd/config.json does not exist at all.
+  restoreExistingCommandsTable(noConfigRoot, { 'fix-validate': 'x' });
+  assert.equal(existsSync(join(noConfigRoot, '.github', 'idd')), false);
 });
 
 // ---------------------------------------------------------------------------
@@ -1493,6 +1721,102 @@ test('bin/idd-onboard.mjs --import --force overwrites a differing existing targe
       join(REPO_ROOT, 'idd-template', '.github', 'idd', 'config.json'),
       'utf8',
     ),
+  );
+});
+
+test('bin/idd-onboard.mjs --import --force preserves a customized commands table across a real re-import (#2222)', () => {
+  // Reproduces the actual re-import workflow end to end: fresh import,
+  // substitute with customized validate commands, then re-import with
+  // --force (the only way a real re-import can proceed once any template
+  // file differs) must not silently discard those customized rows even
+  // though --import always copies .github/idd/config.json byte-for-byte
+  // from source.
+  const targetRoot = makeFixtureDir();
+  execFileSync(process.execPath, [
+    BIN_PATH,
+    '--import',
+    '--source',
+    REPO_ROOT,
+    '--target',
+    targetRoot,
+  ]);
+  execFileSync(process.execPath, [
+    BIN_PATH,
+    '--substitute',
+    '--target',
+    targetRoot,
+    '--repo-name',
+    'my-app',
+    '--marker-prefix',
+    'my-app',
+    '--trusted-marker-actor',
+    'trusted-user-a',
+    '--fix-validate-commands',
+    'npx biome check --write (customized)',
+    '--pre-push-validate-commands',
+    'npx biome check (customized)',
+    '--post-fix-validate-commands',
+    'npx biome check --write (customized)',
+    '--install-deps-command',
+    'npm install',
+  ]);
+
+  const { status, verdict } = runCliBin([
+    '--import',
+    '--force',
+    '--source',
+    REPO_ROOT,
+    '--target',
+    targetRoot,
+  ]);
+  assert.equal(status, 0);
+  assert.equal(verdict.written, true);
+
+  const config = JSON.parse(
+    readFileSync(join(targetRoot, '.github', 'idd', 'config.json'), 'utf8'),
+  ) as { commands: Record<string, string> };
+  // The three validate-command rows survive the re-import unchanged...
+  assert.equal(
+    config.commands['fix-validate'],
+    'npx biome check --write (customized)',
+  );
+  assert.equal(
+    config.commands['pre-push-validate'],
+    'npx biome check (customized)',
+  );
+  assert.equal(
+    config.commands['post-fix-validate'],
+    'npx biome check --write (customized)',
+  );
+  // ...while install-deps (out of #2222's scope) reverts to the raw
+  // template placeholder token exactly like every other re-imported file,
+  // ready for the next --substitute to re-resolve it normally.
+  assert.equal(config.commands['install-deps'], '{{INSTALL_DEPS_COMMAND}}');
+
+  // A follow-up --substitute converges cleanly: install-deps takes its new
+  // override, and the three preserved rows need no override at all.
+  const followUp = runCliBin([
+    '--substitute',
+    '--target',
+    targetRoot,
+    '--repo-name',
+    'my-app',
+    '--marker-prefix',
+    'my-app',
+    '--trusted-marker-actor',
+    'trusted-user-a',
+    '--install-deps-command',
+    'npm ci',
+  ]);
+  assert.equal(followUp.status, 0);
+  assert.deepEqual(followUp.verdict.residue, []);
+  const finalConfig = JSON.parse(
+    readFileSync(join(targetRoot, '.github', 'idd', 'config.json'), 'utf8'),
+  ) as { commands: Record<string, string> };
+  assert.equal(finalConfig.commands['install-deps'], 'npm ci');
+  assert.equal(
+    finalConfig.commands['fix-validate'],
+    'npx biome check --write (customized)',
   );
 });
 

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -416,6 +416,26 @@ test('deriveValidateCommands treats an unsubstituted placeholder row as unset, n
   });
 });
 
+test('deriveValidateCommands preserves a row that merely has the same doubled-brace shape as an onboarding token but is not one of ours (#2254 review)', () => {
+  const root = makeFixtureDir();
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ scripts: { 'lint:fix': 'x', lint: 'x', test: 'x' } }),
+  );
+  writeFileSync(join(root, 'pnpm-lock.yaml'), '');
+  // An adopter's own downstream template syntax, unrelated to this
+  // onboarding flow's seven known placeholder tokens -- must survive
+  // as a real existing value, not be discarded as unresolved residue.
+  writeExistingCommandsConfig(root, {
+    'fix-validate': '{{CI_COMMAND}}',
+  });
+  assert.deepEqual(deriveValidateCommands(root), {
+    fixValidate: '{{CI_COMMAND}}',
+    prePushValidate: 'pnpm run lint && pnpm run test',
+    postFixValidate: 'pnpm run lint:fix && pnpm run lint && pnpm run test',
+  });
+});
+
 test('deriveValidateCommands ignores a missing, empty, or unparseable commands table', () => {
   const goRoot = makeFixtureDir();
   writeFileSync(join(goRoot, 'go.mod'), 'module x\n');


### PR DESCRIPTION
## Summary

- `deriveValidateCommands` now prefers each of the three
  `fix-validate`/`pre-push-validate`/`post-fix-validate` rows from an
  existing `.github/idd/config.json` `commands` table over its own
  package.json-derived heuristic, falling back to the heuristic only
  for a row the existing table leaves unset or for first-time
  onboarding (no existing table). Explicit `--*-commands` CLI flags
  still win over both, unchanged.
- `runImportCli` now snapshots that table before `--import` copies
  `.github/idd/config.json`, then restores the three validate-command
  rows into the freshly-copied file afterward — scoped away from
  `install-deps`, which already has its own independent re-derivation
  (`deriveInstallDepsCommand`) and stays out of this issue's scope.

## Why the change grew past `deriveValidateCommands`

The issue's Proposed change named only `deriveValidateCommands`, but a
C-phase critique pass caught that `--import` always copies
`.github/idd/config.json` byte-for-byte from source — including on a
real re-import, which requires `--import --force` (any other template
file differing blocks the whole operation without it). That copy
clobbers a deliberately customized `commands` table with the source
template's raw placeholder tokens *before* `--substitute` ever runs,
so `deriveValidateCommands`'s own preference logic had nothing left to
prefer by the time it read the file. Fixing only `deriveValidateCommands`
passed all six of its own unit tests while still discarding a
customized command on the actual re-import workflow the issue
describes. The `runImportCli` snapshot/restore closes that gap; an
end-to-end regression test now exercises the real
`--import` → `--substitute` → `--import --force` → `--substitute`
sequence through the CLI binary, not just the two functions in
isolation.

## Test plan

- [x] `node --test tests/idd-onboard.test.mts` — 105/105 pass (11 new:
      unit coverage for `deriveValidateCommands`/
      `readExistingCommandsTable`/`restoreExistingCommandsTable`, plus
      one CLI-binary end-to-end regression reproducing the real
      re-import workflow)
- [x] `pnpm run build:check`
- [x] `node scripts/idd-doctor.mjs`
- [x] `node scripts/audit-docs.mjs --check`
- [x] Manually reproduced the critique's original 4-step failure
      scenario in a scratch target dir before and after the fix

Refs #2222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Re-imports now preserve customized validation commands already configured in the target repository.
  - Placeholder values are ignored, while explicit imported command values remain unchanged.
  - Dependency installation commands continue to reset to the provided template value.
  - Validation commands still receive sensible defaults when no existing configuration is available.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->