### PR TITLE
docs(onboarding): explain workflow CODEOWNERS boundary

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1394,7 +1394,7 @@ emit the same required-check name. A credentials holder with
 CODEOWNERS covers workflow-file changes only. Either explicitly trust every
 credential that can publish checks, or use a producer-pinned required check
 with a specific integration `app_id` after verifying that IDD can read and
-enforce that topology. A Rulesets `workflows` rule is not a drop-in
+enforce that topology. A ruleset `workflows` rule is not a drop-in
 source-bound alternative here: IDD cannot correlate its unnamed result to a
 check run and will keep CI unresolved, so plan for a human merge or hold
 until the runtime supports it. Then enable **Require review from Code

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1354,21 +1354,29 @@ GitHub gates under the Issues permission category even when the issue
 number is a pull request.
 
 **Protect the workflow definition with CODEOWNERS.** A
-`pull_request`-triggered workflow resolves its own definition from the
-PR head before any job step can perform the trusted `main` checkout.
-That checkout protects the helper and configuration that the job runs,
-but it cannot protect a workflow definition that was changed before the
-checkout began. Add a CODEOWNERS entry for the workflow itself, for
-example:
+`pull_request`-triggered workflow runs its definition from the pull
+request's synthetic merge commit/ref before any job step can perform the
+trusted `main` checkout. That checkout protects the helper and
+configuration that the job runs, but it cannot protect a workflow
+definition changed in the pull request. This is preventive guidance; no
+observed incident is being claimed here. Add CODEOWNERS entries for the
+workflow and, when using `.github/CODEOWNERS`, for the ownership file
+itself, for example:
 
 ```text
-/.github/workflows/idd-advisory-convergence.yml @your-maintainer-team
+/.github/workflows/idd-advisory-convergence.yml @maintainer-user
+/.github/CODEOWNERS @maintainer-user
 ```
 
-Replace `@your-maintainer-team` with the maintainer or team responsible
-for the repository. The dry-run readiness report's `CODEOWNERS present`
-item above is the quick check that this prerequisite exists; it does not
-replace verifying that the entry covers this workflow path.
+Replace `@maintainer-user` with a maintainer who has write access. For a
+team, use the full `@organization/team-name` form. Then enable **Require
+review from Code Owners** on the protected default branch, or the
+equivalent repository-ruleset requirement; without that setting,
+CODEOWNERS only requests or routes a review and does not make approval a
+merge gate. The [dry-run — Readiness assessment](#dry-run--readiness-assessment)
+report's `CODEOWNERS present` item checks only that a CODEOWNERS file
+exists; it does not verify this workflow-path entry or the required-review
+setting.
 
 **Trusted-code checkout.** The checkout step pins `ref: main` (adjust
 if your default branch differs) rather than the PR's own head, for

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1373,9 +1373,10 @@ location that is active. For example, with `.github/CODEOWNERS`:
 
 Replace `@maintainer-user` with an eligible non-author maintainer who has
 write access. For a team, use the full `@organization/team-name` form;
-the team must be visible and have explicit write access. The PR author
-cannot approve their own pull request, so choose a separate eligible
-owner or document the intended reviewer or ruleset-bypass topology. If
+the team must be visible and have explicit write access. An approval from
+the PR author does not count toward required review or Code Owner gates,
+so choose a separate eligible owner or document the intended reviewer or
+ruleset-bypass topology. If
 the required check is registered with `app_id: -1` (any producer), an
 exact single-file rule does not bind the check to that workflow: protect
 `/.github/workflows/` (or `/.github/`) as well, or use a source-bound

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1430,6 +1430,11 @@ the entries. The current PR run cannot be weakened by PR copies of
 these paths because it checks out `main`, but later runs would trust
 them after merge (preventive; no observed incident yet).
 
+Also review repository or organization variables that select the runner,
+such as `CI_RUNNER_LABEL`, together with self-hosted runner administration
+and runner integrity. Require an equivalent protected trust boundary for
+any self-hosted runner label (preventive; no observed incident yet).
+
 Protect `/.github/workflows/` (or `/.github/`) regardless of whether
 the required check uses `app_id: -1` or a producer-pinned Actions
 integration, unless that integration is dedicated exclusively to this

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1376,8 +1376,9 @@ write access. For a team, use the full `@organization/team-name` form;
 the team must be visible and have explicit write access. An approval from
 the PR author does not count toward required review or Code Owner gates,
 so choose a separate eligible owner or document the intended reviewer or
-ruleset-bypass topology. If
-the required check is registered with `app_id: -1` (any producer), an
+ruleset-bypass topology.
+
+If the required check is registered with `app_id: -1` (any producer), an
 exact single-file rule does not bind the check to that workflow: protect
 `/.github/workflows/` (or `/.github/`) as well, or use a source-bound
 required-workflow/ruleset rule, so another workflow cannot emit the same

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1386,6 +1386,15 @@ paths; CODEOWNERS uses the last matching rule. If the active file is
 supported location that could replace it (`/.github/CODEOWNERS`, and for
 `/docs/CODEOWNERS`, `/CODEOWNERS` as well).
 
+For every candidate location that an adopter may activate, put its
+self-ownership entry in that candidate file before introducing it:
+`/.github/CODEOWNERS @maintainer-user` in `.github/CODEOWNERS`,
+`/CODEOWNERS @maintainer-user` in the repository-root file, and
+`/docs/CODEOWNERS @maintainer-user` in the docs file, where each file is
+used. A higher-priority file becomes active as soon as it exists, so
+perform this preparation in the trusted preliminary change as well.
+Keep each self-ownership entry after overlapping rules in its own file.
+
 Establish the active CODEOWNERS file and the **Require review from Code
 Owners** setting in a trusted preliminary change before introducing this
 workflow or registering its required check. If bootstrapping both in one
@@ -1416,7 +1425,8 @@ directly; CODEOWNERS covers workflow-file changes only. Either
 explicitly trust every credential that can publish checks, or use a
 producer-pinned required check with a specific integration `app_id`
 after verifying that IDD can read and enforce that topology. A ruleset
-`workflows` rule is not a drop-in source-bound alternative here: IDD
+`workflows` rule is not a drop-in source-bound alternative here
+(preventive; no observed incident yet): IDD
 cannot correlate its unnamed result to a check run and will keep CI
 unresolved, so plan for a human merge or hold until the runtime supports
 it. Then enable **Require review from Code Owners** on the protected

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1378,16 +1378,32 @@ the PR author does not count toward required review or Code Owner gates,
 so choose a separate eligible owner or document the intended reviewer or
 ruleset-bypass topology.
 
-If the required check is registered with `app_id: -1` (any producer), an
-exact single-file rule does not bind the check to that workflow: protect
-`/.github/workflows/` (or `/.github/`) as well, or use a source-bound
-required-workflow/ruleset rule, so another workflow cannot emit the same
-required-check name. Then enable **Require review from Code Owners** on
-the protected default branch, or the equivalent repository-ruleset
-requirement, and enable **Dismiss stale pull request approvals when new
-commits are pushed** (or its equivalent) so approval applies to the
-workflow revision that will merge. Without those settings, CODEOWNERS
-only requests or routes a review and does not make approval a merge gate.
+Place these protection entries after broader or overlapping patterns. When
+extending the file, move them after any new rule that also matches these
+paths; CODEOWNERS uses the last matching rule. If the active file is
+`/CODEOWNERS` or
+`/docs/CODEOWNERS`, also add ownership entries for every higher-priority
+supported location that could replace it (`/.github/CODEOWNERS`, and for
+`/docs/CODEOWNERS`, `/CODEOWNERS` as well).
+
+If the required check is registered with `app_id: -1` (any producer), a
+single-file rule does not bind the check to that workflow. Protect
+`/.github/workflows/` (or `/.github/`) as well, so another workflow cannot
+emit the same required-check name. A credentials holder with
+`statuses: write` or `checks: write` can still publish that name directly;
+CODEOWNERS covers workflow-file changes only. Either explicitly trust every
+credential that can publish checks, or use a producer-pinned required check
+with a specific integration `app_id` after verifying that IDD can read and
+enforce that topology. A Rulesets `workflows` rule is not a drop-in
+source-bound alternative here: IDD cannot correlate its unnamed result to a
+check run and will keep CI unresolved, so plan for a human merge or hold
+until the runtime supports it. Then enable **Require review from Code
+Owners** on the protected default branch, or the equivalent
+repository-ruleset requirement, and enable **Dismiss stale pull request
+approvals when new commits are pushed** (or its equivalent) so approval
+applies to the workflow revision that will merge. Without those settings,
+CODEOWNERS only requests or routes a review and does not make approval a
+merge gate.
 The [dry-run — Readiness assessment](#dry-run--readiness-assessment)
 report's `CODEOWNERS present` item checks only that a CODEOWNERS file
 exists; it does not verify workflow-path coverage, producer binding, or
@@ -1519,11 +1535,12 @@ silently drops them, weakening the merge gate to only the newly added
 check.
 
 `app_id: -1` also trades away GitHub's producer-identity enforcement
-for the check it names (preventive; no observed incident yet). Use it
-only when the adopter separately protects all workflow paths that could
-produce that literal check name, or uses a source-bound ruleset; it is
-not a blanket recommendation for every required check. Keep a specific
-`app_id` pin
+for the check it names (preventive; no observed incident yet). It also
+allows any credential with `statuses: write` or `checks: write` to publish
+that literal name. Use it only when the adopter explicitly accepts that
+trust scope and separately protects all workflow paths that could produce
+the name; it is not a blanket recommendation for every required check.
+Keep a specific `app_id` pin
 on any check where verifying the producer matters, and opt in to
 `ciGate.trustSourcePinnedRequiredChecks: true` (see the row in
 [Customizing IDD](docs/customization.md)) instead, once the operator

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1399,14 +1399,18 @@ supported location that could replace it (`/.github/CODEOWNERS`, and for
 `/docs/CODEOWNERS`, `/CODEOWNERS` as well) (preventive; no observed
 incident yet).
 
-For every candidate location that an adopter may activate, put its
-self-ownership entry in that candidate file before introducing it:
+For every candidate location that an adopter may activate, copy the
+complete workflow, broad-workflow, trusted-input, and active-CODEOWNERS
+protection set into that candidate file before introducing it. Put its
+self-ownership entry in that same complete set:
 `/.github/CODEOWNERS @maintainer-user` in `.github/CODEOWNERS`,
 `/CODEOWNERS @maintainer-user` in the repository-root file, and
 `/docs/CODEOWNERS @maintainer-user` in the docs file, where each file is
-used. A higher-priority file becomes active as soon as it exists, so
-perform this preparation in the trusted preliminary change as well.
-Keep each self-ownership entry after overlapping rules in its own file
+used. A higher-priority file becomes active as soon as it exists, so a
+candidate containing only its self-entry would replace the lower-priority
+file and drop the workflow or trusted-input protections. Perform this
+complete preparation in the trusted preliminary change as well, and keep
+each self-ownership entry after overlapping rules in its own file
 (preventive; no observed incident yet).
 
 Establish the active CODEOWNERS file and the **Require review from Code

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1386,24 +1386,45 @@ paths; CODEOWNERS uses the last matching rule. If the active file is
 supported location that could replace it (`/.github/CODEOWNERS`, and for
 `/docs/CODEOWNERS`, `/CODEOWNERS` as well).
 
-If the required check is registered with `app_id: -1` (any producer), a
-single-file rule does not bind the check to that workflow. Protect
-`/.github/workflows/` (or `/.github/`) as well, so another workflow cannot
-emit the same required-check name. A credentials holder with
-`statuses: write` or `checks: write` can still publish that name directly;
-CODEOWNERS covers workflow-file changes only. Either explicitly trust every
-credential that can publish checks, or use a producer-pinned required check
-with a specific integration `app_id` after verifying that IDD can read and
-enforce that topology. A ruleset `workflows` rule is not a drop-in
-source-bound alternative here: IDD cannot correlate its unnamed result to a
-check run and will keep CI unresolved, so plan for a human merge or hold
-until the runtime supports it. Then enable **Require review from Code
-Owners** on the protected default branch, or the equivalent
-repository-ruleset requirement, and enable **Dismiss stale pull request
-approvals when new commits are pushed** (or its equivalent) so approval
-applies to the workflow revision that will merge. Without those settings,
-CODEOWNERS only requests or routes a review and does not make approval a
-merge gate.
+Establish the active CODEOWNERS file and the **Require review from Code
+Owners** setting in a trusted preliminary change before introducing this
+workflow or registering its required check. If bootstrapping both in one
+PR is unavoidable, require equivalent explicit maintainer validation;
+GitHub evaluates CODEOWNERS from the base branch when it requests
+reviews, so a new CODEOWNERS file in the same PR cannot protect that
+bootstrap change.
+
+Also protect every trusted input that the workflow checks out from
+`main`, not only the workflow file — for example `/.github/idd/`,
+`/scripts/advisory-convergence.mjs`, and its transitive runtime inputs
+(or an immutable protected artifact). The exact set depends on the
+adopter's imports; inspect the workflow and helper before finalizing
+the entries. The current PR run cannot be weakened by PR copies of
+these paths because it checks out `main`, but later runs would trust
+them after merge.
+
+Protect `/.github/workflows/` (or `/.github/`) regardless of whether
+the required check uses `app_id: -1` or a producer-pinned Actions
+integration, unless that integration is dedicated exclusively to this
+check. An `app_id` identifies an integration, not an individual
+workflow, so broad workflow ownership remains necessary to prevent
+another workflow from emitting the same required-check name under the
+accepted integration. For `app_id: -1` (any producer), a single-file
+rule does not bind the check to that workflow. A credential holder with
+`statuses: write` or `checks: write` can still publish that name
+directly; CODEOWNERS covers workflow-file changes only. Either
+explicitly trust every credential that can publish checks, or use a
+producer-pinned required check with a specific integration `app_id`
+after verifying that IDD can read and enforce that topology. A ruleset
+`workflows` rule is not a drop-in source-bound alternative here: IDD
+cannot correlate its unnamed result to a check run and will keep CI
+unresolved, so plan for a human merge or hold until the runtime supports
+it. Then enable **Require review from Code Owners** on the protected
+default branch, or the equivalent repository-ruleset requirement, and
+enable **Dismiss stale pull request approvals when new commits are
+pushed** (or its equivalent) so approval applies to the workflow
+revision that will merge. Without those settings, CODEOWNERS only
+requests or routes a review and does not make approval a merge gate.
 The [dry-run — Readiness assessment](#dry-run--readiness-assessment)
 report's `CODEOWNERS present` item checks only that a CODEOWNERS file
 exists; it does not verify workflow-path coverage, producer binding, or
@@ -1540,6 +1561,9 @@ allows any credential with `statuses: write` or `checks: write` to publish
 that literal name. Use it only when the adopter explicitly accepts that
 trust scope and separately protects all workflow paths that could produce
 the name; it is not a blanket recommendation for every required check.
+A producer pin does not identify an individual workflow; keep broad
+workflow ownership unless the integration is dedicated exclusively to
+this check.
 Keep a specific `app_id` pin
 on any check where verifying the producer matters, and opt in to
 `ciGate.trustSourcePinnedRequiredChecks: true` (see the row in

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1373,10 +1373,22 @@ location that is active. For example, with `.github/CODEOWNERS`:
 
 Replace `@maintainer-user` with an eligible non-author maintainer who has
 write access. For a team, use the full `@organization/team-name` form;
-the team must be visible and have explicit write access. An approval from
-the PR author does not count toward required review or Code Owner gates,
-so choose a separate eligible owner or document the intended reviewer or
-ruleset-bypass topology.
+the team must be visible and have explicit write access. The autonomous
+pre-merge helper currently resolves direct user owners, not team
+membership, so a team-only owner can leave Code Owner approval ambiguous;
+use a direct user owner for autonomous merging or plan for a human merge
+until team-membership resolution is supported (preventive; no observed
+incident yet). An approval from the PR author does not count toward
+required review or Code Owner gates, so choose a separate eligible owner
+or document the intended reviewer or ruleset-bypass topology.
+
+CODEOWNERS can nominate owners for other changed paths as well; an
+approval from one of those owners can satisfy a repository-wide Code Owner
+review without proving that the owner resolved for the protected workflow
+or input paths approved. Keep every owner reachable through those changed
+paths within the same trust boundary, or require a gate that verifies
+approval from the owner resolved for the protected paths (preventive; no
+observed incident yet).
 
 Place these protection entries after broader or overlapping patterns. When
 extending the file, move them after any new rule that also matches these
@@ -1384,7 +1396,8 @@ paths; CODEOWNERS uses the last matching rule. If the active file is
 `/CODEOWNERS` or
 `/docs/CODEOWNERS`, also add ownership entries for every higher-priority
 supported location that could replace it (`/.github/CODEOWNERS`, and for
-`/docs/CODEOWNERS`, `/CODEOWNERS` as well).
+`/docs/CODEOWNERS`, `/CODEOWNERS` as well) (preventive; no observed
+incident yet).
 
 For every candidate location that an adopter may activate, put its
 self-ownership entry in that candidate file before introducing it:
@@ -1393,7 +1406,8 @@ self-ownership entry in that candidate file before introducing it:
 `/docs/CODEOWNERS @maintainer-user` in the docs file, where each file is
 used. A higher-priority file becomes active as soon as it exists, so
 perform this preparation in the trusted preliminary change as well.
-Keep each self-ownership entry after overlapping rules in its own file.
+Keep each self-ownership entry after overlapping rules in its own file
+(preventive; no observed incident yet).
 
 Establish the active CODEOWNERS file and the **Require review from Code
 Owners** setting in a trusted preliminary change before introducing this
@@ -1401,7 +1415,7 @@ workflow or registering its required check. If bootstrapping both in one
 PR is unavoidable, require equivalent explicit maintainer validation;
 GitHub evaluates CODEOWNERS from the base branch when it requests
 reviews, so a new CODEOWNERS file in the same PR cannot protect that
-bootstrap change.
+bootstrap change (preventive; no observed incident yet).
 
 Also protect every trusted input that the workflow checks out from
 `main`, not only the workflow file — for example `/.github/idd/`,
@@ -1410,7 +1424,7 @@ Also protect every trusted input that the workflow checks out from
 adopter's imports; inspect the workflow and helper before finalizing
 the entries. The current PR run cannot be weakened by PR copies of
 these paths because it checks out `main`, but later runs would trust
-them after merge.
+them after merge (preventive; no observed incident yet).
 
 Protect `/.github/workflows/` (or `/.github/`) regardless of whether
 the required check uses `app_id: -1` or a producer-pinned Actions
@@ -1418,10 +1432,12 @@ integration, unless that integration is dedicated exclusively to this
 check. An `app_id` identifies an integration, not an individual
 workflow, so broad workflow ownership remains necessary to prevent
 another workflow from emitting the same required-check name under the
-accepted integration. For `app_id: -1` (any producer), a single-file
+accepted integration (preventive; no observed incident yet). For
+`app_id: -1` (any producer), a single-file
 rule does not bind the check to that workflow. A credential holder with
 `statuses: write` or `checks: write` can still publish that name
-directly; CODEOWNERS covers workflow-file changes only. Either
+directly; CODEOWNERS covers workflow-file changes only (preventive; no
+observed incident yet). Either
 explicitly trust every credential that can publish checks, or use a
 producer-pinned required check with a specific integration `app_id`
 after verifying that IDD can read and enforce that topology. A ruleset

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1435,11 +1435,11 @@ such as `CI_RUNNER_LABEL`, together with self-hosted runner administration
 and runner integrity. Require an equivalent protected trust boundary for
 any self-hosted runner label (preventive; no observed incident yet).
 
-Pin every action used by this merge gate to a verified full commit SHA.
-The shipped workflow's `@v4` references are portable examples only; replace
-them before enabling the required check. If mutable action references remain,
-explicitly accept and record the action publishers and tag-movement trust
-scope instead of treating CODEOWNERS as sufficient protection
+Before enabling the required check, either pin every action used by this
+merge gate to a verified full commit SHA, or explicitly accept and record the
+action publishers and tag-movement trust scope for any mutable references.
+The shipped workflow's `@v4` references are portable examples only; do not
+treat CODEOWNERS as sufficient protection for mutable action references
 (preventive; no observed incident yet).
 
 Protect `/.github/workflows/` (or `/.github/`) regardless of whether

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1458,7 +1458,7 @@ requests or routes a review and does not make approval a merge gate.
 The [dry-run — Readiness assessment](#dry-run--readiness-assessment)
 report's `CODEOWNERS present` item checks only that a CODEOWNERS file
 exists; it does not verify workflow-path coverage, producer binding, or
-these required-review settings.
+these required-review settings (preventive; no observed incident yet).
 
 **Trusted-code checkout.** The checkout step pins `ref: main` (adjust
 if your default branch differs) rather than the PR's own head, for

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1437,9 +1437,9 @@ accepted integration (preventive; no observed incident yet). For
 rule does not bind the check to that workflow. A credential holder with
 `statuses: write` or `checks: write` can still publish that name
 directly; CODEOWNERS covers workflow-file changes only (preventive; no
-observed incident yet). Either
-explicitly trust every credential that can publish checks, or use a
-producer-pinned required check with a specific integration `app_id`
+observed incident yet). Either explicitly trust every credential that
+can publish checks, or use a producer-pinned required check with a
+specific integration `app_id`
 after verifying that IDD can read and enforce that topology. A ruleset
 `workflows` rule is not a drop-in source-bound alternative here
 (preventive; no observed incident yet): IDD

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1435,6 +1435,13 @@ such as `CI_RUNNER_LABEL`, together with self-hosted runner administration
 and runner integrity. Require an equivalent protected trust boundary for
 any self-hosted runner label (preventive; no observed incident yet).
 
+Pin every action used by this merge gate to a verified full commit SHA.
+The shipped workflow's `@v4` references are portable examples only; replace
+them before enabling the required check. If mutable action references remain,
+explicitly accept and record the action publishers and tag-movement trust
+scope instead of treating CODEOWNERS as sufficient protection
+(preventive; no observed incident yet).
+
 Protect `/.github/workflows/` (or `/.github/`) regardless of whether
 the required check uses `app_id: -1` or a producer-pinned Actions
 integration, unless that integration is dedicated exclusively to this

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1353,6 +1353,23 @@ conversation comments via the issue-comments REST endpoint, which
 GitHub gates under the Issues permission category even when the issue
 number is a pull request.
 
+**Protect the workflow definition with CODEOWNERS.** A
+`pull_request`-triggered workflow resolves its own definition from the
+PR head before any job step can perform the trusted `main` checkout.
+That checkout protects the helper and configuration that the job runs,
+but it cannot protect a workflow definition that was changed before the
+checkout began. Add a CODEOWNERS entry for the workflow itself, for
+example:
+
+```text
+/.github/workflows/idd-advisory-convergence.yml @your-maintainer-team
+```
+
+Replace `@your-maintainer-team` with the maintainer or team responsible
+for the repository. The dry-run readiness report's `CODEOWNERS present`
+item above is the quick check that this prerequisite exists; it does not
+replace verifying that the entry covers this workflow path.
+
 **Trusted-code checkout.** The checkout step pins `ref: main` (adjust
 if your default branch differs) rather than the PR's own head, for
 every trigger type including `workflow_dispatch`. The enforcement

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1359,24 +1359,37 @@ request's synthetic merge commit/ref before any job step can perform the
 trusted `main` checkout. That checkout protects the helper and
 configuration that the job runs, but it cannot protect a workflow
 definition changed in the pull request. This is preventive guidance; no
-observed incident is being claimed here. Add CODEOWNERS entries for the
-workflow and, when using `.github/CODEOWNERS`, for the ownership file
-itself, for example:
+observed incident is being claimed here.
+
+Add CODEOWNERS coverage for the workflow and for the active CODEOWNERS
+file itself. GitHub searches for `CODEOWNERS` in `.github/`, the
+repository root, then `docs/`, so add the self-ownership entry at the
+location that is active. For example, with `.github/CODEOWNERS`:
 
 ```text
 /.github/workflows/idd-advisory-convergence.yml @maintainer-user
 /.github/CODEOWNERS @maintainer-user
 ```
 
-Replace `@maintainer-user` with a maintainer who has write access. For a
-team, use the full `@organization/team-name` form. Then enable **Require
-review from Code Owners** on the protected default branch, or the
-equivalent repository-ruleset requirement; without that setting,
-CODEOWNERS only requests or routes a review and does not make approval a
-merge gate. The [dry-run — Readiness assessment](#dry-run--readiness-assessment)
+Replace `@maintainer-user` with an eligible non-author maintainer who has
+write access. For a team, use the full `@organization/team-name` form;
+the team must be visible and have explicit write access. The PR author
+cannot approve their own pull request, so choose a separate eligible
+owner or document the intended reviewer or ruleset-bypass topology. If
+the required check is registered with `app_id: -1` (any producer), an
+exact single-file rule does not bind the check to that workflow: protect
+`/.github/workflows/` (or `/.github/`) as well, or use a source-bound
+required-workflow/ruleset rule, so another workflow cannot emit the same
+required-check name. Then enable **Require review from Code Owners** on
+the protected default branch, or the equivalent repository-ruleset
+requirement, and enable **Dismiss stale pull request approvals when new
+commits are pushed** (or its equivalent) so approval applies to the
+workflow revision that will merge. Without those settings, CODEOWNERS
+only requests or routes a review and does not make approval a merge gate.
+The [dry-run — Readiness assessment](#dry-run--readiness-assessment)
 report's `CODEOWNERS present` item checks only that a CODEOWNERS file
-exists; it does not verify this workflow-path entry or the required-review
-setting.
+exists; it does not verify workflow-path coverage, producer binding, or
+these required-review settings.
 
 **Trusted-code checkout.** The checkout step pins `ref: main` (adjust
 if your default branch differs) rather than the PR's own head, for
@@ -1504,11 +1517,11 @@ silently drops them, weakening the merge gate to only the newly added
 check.
 
 `app_id: -1` also trades away GitHub's producer-identity enforcement
-for the check it names (preventive; no observed incident yet) — a
-reasonable trade for `idd-advisory-convergence`, since only the
-adopter's own hosted workflow ever produces a check with that exact
-name, but not a blanket recommendation for every required check. Keep
-a specific `app_id` pin
+for the check it names (preventive; no observed incident yet). Use it
+only when the adopter separately protects all workflow paths that could
+produce that literal check name, or uses a source-bound ruleset; it is
+not a blanket recommendation for every required check. Keep a specific
+`app_id` pin
 on any check where verifying the producer matters, and opt in to
 `ciGate.trustSourcePinnedRequiredChecks: true` (see the row in
 [Customizing IDD](docs/customization.md)) instead, once the operator

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -381,10 +381,13 @@ through GitHub's classic branch-protection API uses the explicit
   individual workflow, so another workflow or any credential with
   `statuses: write` or `checks: write` can publish a check with that exact
   name (preventive; no observed incident yet). Protect all workflow paths
-  and trusted helper/configuration inputs with CODEOWNERS and require the
-  corresponding Code Owner review. This is not a blanket choice for every
-  required check: keep a specific `app_id` pin on any check where
-  verifying the producer matters. GitHub's classic API silently
+  and trusted helper/configuration inputs with CODEOWNERS. For autonomous
+  merging, keep every owner reachable through changed workflow or input
+  paths within the same trust boundary, or use a dedicated gate that
+  verifies approval from the protected-path owner; otherwise plan for a
+  human merge or hold. This is not a blanket choice for every required
+  check: keep a specific `app_id` pin on any check where verifying the
+  producer matters. GitHub's classic API silently
   rewrites a `contexts` `PUT` into `app_id`-pinned `checks` entries,
   and a pinned entry is exactly what the fail-closed "Source-pinned
   required-check trust" default
@@ -454,6 +457,12 @@ This repository uses the following IDD policies:
   `{yes | no / not applicable}`
 - **Producer-identity choice**: `{app_id: -1 (any producer) |
   intentionally pinned}`
+- **If `app_id: -1` is selected, explicit trust-scope acceptance and
+  check-publishing credential review recorded**: `{yes | no / not
+  applicable}`
+- **Workflow/trusted-input protection and protected-owner boundary
+  recorded**: `{same trust boundary | dedicated gate | human merge/hold |
+  not applicable}`
 - **If intentionally pinned, `ciGate.trustSourcePinnedRequiredChecks`
   opt-in recorded**: `{yes | no / not applicable}`
 

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -475,6 +475,8 @@ This repository uses the following IDD policies:
   not applicable}`
 - **Runner-selection and self-hosted runner integrity protection
   recorded**: `{yes | no | not applicable}`
+- **Merge-gate action dependency trust recorded**: `{full commit-SHA pins |
+  mutable publisher/tag scope accepted | not applicable}`
 - **`Require review from Code Owners` enabled**: `{yes | no | unknown}`
 - **Dismiss stale pull request approvals when new commits are pushed**:
   `{yes | no | unknown}`

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -383,7 +383,10 @@ through GitHub's classic branch-protection API uses the explicit
   name (preventive; no observed incident yet). Protect the active CODEOWNERS
   file and any higher-priority candidate locations, as well as all workflow
   paths and trusted helper/configuration inputs, with CODEOWNERS. For
-  autonomous merging, keep every owner reachable through changed workflow or
+  runner-selection variables and self-hosted runner administration and
+  integrity, require an equivalent protected trust boundary as well
+  (preventive; no observed incident yet). For autonomous merging, keep
+  every owner reachable through changed workflow or
   input paths within the same trust boundary, or use a dedicated gate that
   verifies approval from the protected-path owner; otherwise plan for a
   human merge or hold (preventive; no observed incident yet). Also enable

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -380,9 +380,10 @@ through GitHub's classic branch-protection API uses the explicit
   adopter explicitly accepts that trust scope: the value identifies no
   individual workflow, so another workflow or any credential with
   `statuses: write` or `checks: write` can publish a check with that exact
-  name (preventive; no observed incident yet). Protect the active CODEOWNERS
-  file and any higher-priority candidate locations, as well as all workflow
-  paths and trusted helper/configuration inputs, with CODEOWNERS. For
+  name (preventive; no observed incident yet). Regardless of whether the
+  check uses `app_id: -1` or a specific producer pin, protect the active
+  CODEOWNERS file and any higher-priority candidate locations, as well as all
+  workflow paths and trusted helper/configuration inputs, with CODEOWNERS. For
   runner-selection variables and self-hosted runner administration and
   integrity, require an equivalent protected trust boundary as well
   (preventive; no observed incident yet). For autonomous merging, keep

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -380,18 +380,20 @@ through GitHub's classic branch-protection API uses the explicit
   adopter explicitly accepts that trust scope: the value identifies no
   individual workflow, so another workflow or any credential with
   `statuses: write` or `checks: write` can publish a check with that exact
-  name (preventive; no observed incident yet). Protect all workflow paths
-  and trusted helper/configuration inputs with CODEOWNERS. For autonomous
-  merging, keep every owner reachable through changed workflow or input
-  paths within the same trust boundary, or use a dedicated gate that
+  name (preventive; no observed incident yet). Protect the active CODEOWNERS
+  file and any higher-priority candidate locations, as well as all workflow
+  paths and trusted helper/configuration inputs, with CODEOWNERS. For
+  autonomous merging, keep every owner reachable through changed workflow or
+  input paths within the same trust boundary, or use a dedicated gate that
   verifies approval from the protected-path owner; otherwise plan for a
   human merge or hold (preventive; no observed incident yet). Also enable
   **Require review from Code Owners** on the protected default branch, or
   the equivalent repository-ruleset requirement, and enable **Dismiss
   stale pull request approvals when new commits are pushed** (or its
   equivalent). Without those settings, CODEOWNERS only routes or requests
-  a review and does not make approval a merge gate. This is not a blanket
-  choice for every required check: keep a specific `app_id` pin on any
+  a review and does not make approval a merge gate (preventive; no observed
+  incident yet). This is not a blanket choice for every required check: keep
+  a specific `app_id` pin on any
   check where verifying the producer matters. GitHub's classic API silently
   rewrites a `contexts` `PUT` into `app_id`-pinned `checks` entries,
   and a pinned entry is exactly what the fail-closed "Source-pinned

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -375,10 +375,14 @@ It should also confirm that any required status check registered
 through GitHub's classic branch-protection API uses the explicit
 `checks` array rather than a plain string-array `contexts` field:
 
-- Recommended: register required checks with an explicit `checks`
-  array. Use `app_id: -1` (any producer) for `idd-advisory-convergence`
-  specifically — only the adopter's own hosted workflow ever produces a
-  check with that exact name — but not as a blanket choice for every
+- Register required checks with an explicit `checks` array. Use
+  `app_id: -1` (any producer) for `idd-advisory-convergence` only when the
+  adopter explicitly accepts that trust scope: the value identifies no
+  individual workflow, so another workflow or any credential with
+  `statuses: write` or `checks: write` can publish a check with that exact
+  name (preventive; no observed incident yet). Protect all workflow paths
+  and trusted helper/configuration inputs with CODEOWNERS and require the
+  corresponding Code Owner review. This is not a blanket choice for every
   required check: keep a specific `app_id` pin on any check where
   verifying the producer matters. GitHub's classic API silently
   rewrites a `contexts` `PUT` into `app_id`-pinned `checks` entries,

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -468,6 +468,9 @@ This repository uses the following IDD policies:
 - **Workflow/trusted-input protection and protected-owner boundary
   recorded**: `{same trust boundary | dedicated gate | human merge/hold |
   not applicable}`
+- **`Require review from Code Owners` enabled**: `{yes | no | unknown}`
+- **Dismiss stale pull request approvals when new commits are pushed**:
+  `{yes | no | unknown}`
 - **If intentionally pinned, `ciGate.trustSourcePinnedRequiredChecks`
   opt-in recorded**: `{yes | no / not applicable}`
 

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -385,9 +385,14 @@ through GitHub's classic branch-protection API uses the explicit
   merging, keep every owner reachable through changed workflow or input
   paths within the same trust boundary, or use a dedicated gate that
   verifies approval from the protected-path owner; otherwise plan for a
-  human merge or hold. This is not a blanket choice for every required
-  check: keep a specific `app_id` pin on any check where verifying the
-  producer matters. GitHub's classic API silently
+  human merge or hold (preventive; no observed incident yet). Also enable
+  **Require review from Code Owners** on the protected default branch, or
+  the equivalent repository-ruleset requirement, and enable **Dismiss
+  stale pull request approvals when new commits are pushed** (or its
+  equivalent). Without those settings, CODEOWNERS only routes or requests
+  a review and does not make approval a merge gate. This is not a blanket
+  choice for every required check: keep a specific `app_id` pin on any
+  check where verifying the producer matters. GitHub's classic API silently
   rewrites a `contexts` `PUT` into `app_id`-pinned `checks` entries,
   and a pinned entry is exactly what the fail-closed "Source-pinned
   required-check trust" default

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -473,6 +473,8 @@ This repository uses the following IDD policies:
 - **Workflow/trusted-input protection and protected-owner boundary
   recorded**: `{same trust boundary | dedicated gate | human merge/hold |
   not applicable}`
+- **Runner-selection and self-hosted runner integrity protection
+  recorded**: `{yes | no | not applicable}`
 - **`Require review from Code Owners` enabled**: `{yes | no | unknown}`
 - **Dismiss stale pull request approvals when new commits are pushed**:
   `{yes | no | unknown}`


### PR DESCRIPTION
# Summary

- Explain the trust boundary around a `pull_request`-triggered advisory-convergence workflow definition.
- Instruct adopters to protect `/.github/workflows/idd-advisory-convergence.yml` with CODEOWNERS and connect that prerequisite to the dry-run readiness report.

## Linked issue

Closes #2240

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The workflow checks out trusted `main` content for its helper and configuration, but the workflow definition itself must be protected before that checkout runs. This adds the missing onboarding explanation while preserving the existing required-check guidance.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [ ] `pnpm lint`
- [ ] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

Configured `fix-validate` and `pre-push-validate` also passed, including Biome, dprint, markdownlint, cspell, code-span-wrap, build:check, and the IDD doctor.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded onboarding guidance for protecting workflows, CODEOWNERS configuration, runner selection, and self-hosted runners.
  * Clarified reviewer eligibility, rule precedence, trusted inputs, required-review settings, stale-approval dismissal, and producer trust.
  * Documented readiness-detection limitations and workflow/input protection requirements.
  * Explained that `app_id: -1` permits any status-writing credential to publish the required check.
  * Updated policy templates to capture runner protection, dependency pinning, Code Owners review, and stale-approval settings.
  * Included an example CODEOWNERS configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->