### PR TITLE
fix(helper-runtime): expose review comment origin

### DIFF
--- a/bin/idd-review-comment-origin.mjs
+++ b/bin/idd-review-comment-origin.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-review-comment-origin.mts
+//
+// The bin/idd-review-comment-origin.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/review-comment-origin.mjs');

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "idd-resume-claim-routing": "./bin/idd-resume-claim-routing.mjs",
     "idd-resume-route-selection": "./bin/idd-resume-route-selection.mjs",
     "idd-review-activity-snapshot": "./bin/idd-review-activity-snapshot.mjs",
+    "idd-review-comment-origin": "./bin/idd-review-comment-origin.mjs",
     "idd-review-disposition-verify": "./bin/idd-review-disposition-verify.mjs",
     "idd-roadmap-audit-execute": "./bin/idd-roadmap-audit-execute.mjs",
     "idd-select-desynced-index": "./bin/idd-select-desynced-index.mjs",

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -412,6 +412,15 @@ const HELPER_COMMANDS = [
     description: 'Collect read-only review activity and CI snapshot evidence.',
   },
   {
+    id: 'review-comment-origin',
+    scriptName: 'idd:review-comment-origin',
+    binName: 'idd-review-comment-origin',
+    entryPath: 'scripts/review-comment-origin.mjs',
+    vendoredCommand: 'node scripts/review-comment-origin.mjs',
+    description:
+      'Classify review-thread comments as IDD-originated or ordinary human chatter.',
+  },
+  {
     id: 'review-disposition-verify',
     scriptName: 'idd:review-disposition-verify',
     binName: 'idd-review-disposition-verify',

--- a/src/bin/idd-review-comment-origin.mts
+++ b/src/bin/idd-review-comment-origin.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-review-comment-origin.mts
+//
+// The bin/idd-review-comment-origin.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the generated
+// .mjs. See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/review-comment-origin.mjs');

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -496,6 +496,15 @@ const HELPER_COMMANDS: HelperCommand[] = [
     description: 'Collect read-only review activity and CI snapshot evidence.',
   },
   {
+    id: 'review-comment-origin',
+    scriptName: 'idd:review-comment-origin',
+    binName: 'idd-review-comment-origin',
+    entryPath: 'scripts/review-comment-origin.mjs',
+    vendoredCommand: 'node scripts/review-comment-origin.mjs',
+    description:
+      'Classify review-thread comments as IDD-originated or ordinary human chatter.',
+  },
+  {
     id: 'review-disposition-verify',
     scriptName: 'idd:review-disposition-verify',
     binName: 'idd-review-disposition-verify',


### PR DESCRIPTION
# Summary

- Add the `idd-review-comment-origin` package bin and helper manifest entry.
- Generate the package-manager wrapper from its TypeScript source.

## Linked issue

Closes #2214

## Verification

- `pnpm run lint:minimum`
- `node bin/idd-review-comment-origin.mjs --body "**Accepted** fixed"`
