### PR TITLE
fix(ci): give workflow_dispatch its own concurrency group

### DIFF
--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -36,9 +36,10 @@ concurrency:
   # way for it as it does for a pull_request-only workflow.
   # Review-thread comments live in the companion
   # idd-advisory-convergence-comment.yml workflow and must not share
-  # this group. workflow_dispatch has no pull_request context either,
-  # so it falls back to its own input.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
+  # this group. Keep pull_request and pull_request_review in their
+  # existing group, but isolate workflow_dispatch so a manual re-check
+  # cannot cancel an in-flight PR-linked run.
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', inputs.pr_number) || github.event.pull_request.number }}
 on:
   pull_request:
     types: [opened, reopened, synchronize]

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -39,7 +39,7 @@ concurrency:
   # this group. Keep pull_request and pull_request_review in their
   # existing group, but isolate workflow_dispatch so a manual re-check
   # cannot cancel an in-flight PR-linked run.
-  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', inputs.pr_number) || github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', inputs.pr_number) || github.event.pull_request.number || inputs.pr_number }}
 on:
   pull_request:
     types: [opened, reopened, synchronize]


### PR DESCRIPTION
## Summary

- keep `pull_request` and `pull_request_review` in their existing PR-number concurrency group
- isolate `workflow_dispatch` with a `dispatch-<PR>` group so manual re-checks cannot cancel PR-linked runs

## Validation

- `actionlint idd-template/.github/workflows/idd-advisory-convergence.yml`
- `pnpm run lint:minimum`

Closes #2228