### PR TITLE
fix(template): stop shipping a literal helperRuntime default

### DIFF
--- a/idd-template/.github/idd/config.json
+++ b/idd-template/.github/idd/config.json
@@ -19,9 +19,6 @@
     "pre-push-validate": "{{PRE_PUSH_VALIDATE_COMMANDS}}",
     "post-fix-validate": "{{POST_FIX_VALIDATE_COMMANDS}}"
   },
-  "helperRuntime": {
-    "profile": "package-manager"
-  },
   "issueScope": "roadmap-first",
   "orphanFirstPolicy": "none",
   "advisoryWait": {

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -462,6 +462,13 @@ error), so an agent can gate on the exit code without parsing prose.
     [--dry-run] [--repo-name <value> ...]
   ```
 
+  The `--substitute` shortcut resolves placeholders only; it does not
+  select or persist `helperRuntime.profile`. If Step 1B selected a
+  non-default helper runtime, apply the manual Step 4 configuration
+  instruction after running this command. The `--profile` option on
+  `--import` and `--verify` controls profile-conditional file selection and
+  completeness, not policy recording.
+
 - **Step 6 (verification checklist) → `--verify`**: a mechanical pass/fail
   check for a target tree after `--import` and `--substitute` have run,
   replacing a manual walkthrough of the checklist below with three check
@@ -532,6 +539,8 @@ The pristine `.github/idd/config.json` intentionally leaves
 `helperRuntime` absent. Do not add that key during the import when the
 confirmed profile is `instructions-only`; Step 4 records the key only for
 an explicitly selected helper profile.
+This rule is preventive; no observed incident yet. Issue `#2229` tracks the
+configuration inconsistency that prompted the correction.
 
 ### File list
 

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -528,6 +528,11 @@ Use
 for the detailed defaults, non-default consequences, and the policy
 recording template you will apply in Step 3.
 
+The pristine `.github/idd/config.json` intentionally leaves
+`helperRuntime` absent. Do not add that key during the import when the
+confirmed profile is `instructions-only`; Step 4 records the key only for
+an explicitly selected helper profile.
+
 ### File list
 
 This list includes `docs/index.md`, the entry point and topic map for
@@ -1717,6 +1722,23 @@ surviving tokens are expected and not reported as unresolved.
 
 After replacing, verify that no `{{...}}` placeholder strings remain in
 any copied file other than those three meta-docs.
+
+Apply the confirmed helper runtime profile after placeholder replacement:
+leave `helperRuntime` absent from `.github/idd/config.json` for the
+`instructions-only` default, which means no helper command is configured.
+Only when the operator explicitly selects another supported profile should
+you add the object below, replacing the example value with
+`package-manager`, `vendored-node`, or `ephemeral-npx` as appropriate:
+
+```json
+"helperRuntime": {
+  "profile": "package-manager"
+},
+```
+
+Keep this object aligned with the confirmed profile recorded in the local
+policy section; do not add it merely to record the `instructions-only`
+default.
 
 ---
 

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -1728,12 +1728,16 @@ leave `helperRuntime` absent from `.github/idd/config.json` for the
 `instructions-only` default, which means no helper command is configured.
 Only when the operator explicitly selects another supported profile should
 you add the object below, replacing the example value with
-`package-manager`, `vendored-node`, or `ephemeral-npx` as appropriate:
+`package-manager`, `vendored-node`, or `ephemeral-npx` as appropriate.
+Merge it into the top-level object in `.github/idd/config.json` and keep the
+surrounding member commas valid.
 
 ```json
-"helperRuntime": {
-  "profile": "package-manager"
-},
+{
+  "helperRuntime": {
+    "profile": "package-manager"
+  }
+}
 ```
 
 Keep this object aligned with the confirmed profile recorded in the local


### PR DESCRIPTION
## Summary

- remove the literal `helperRuntime.profile` from the pristine template config
- document that `instructions-only` keeps the key absent and non-default profiles add it during onboarding

## Validation

- `pnpm run lint:minimum`

Closes #2229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified onboarding guidance for configuring helper runtime profiles.
  * Documented the available runtime options for non-default profiles.
  * Specified that the default instructions-only profile preserves an absent helper runtime configuration.

* **Chores**
  * Removed the obsolete helper runtime configuration from the default template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->