### PR TITLE
fix(idd-work): make retroactive disclosure a repair path

### DIFF
--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -274,12 +274,15 @@ plan comment and verified claim.
 
 ## B3 — Implement
 
-**Plan-comment checkpoint**: before writing any implementation code,
-confirm the B2 plan comment already exists on the issue. If it does
-not, stop and return to B2. If code was already written before this
-checkpoint is noticed, disclose the ordering deviation on the issue,
-post the plan retroactively with an explicit note about the
-reordering, and run the C1 critique pass against the completed diff.
+**Plan-comment checkpoint**: before implementation begins, the B2 plan
+comment must already exist on the issue; posting it before implementation
+is the only normal path. If it does not, stop and return to B2. The
+following is a repair path only for an ordering violation that has
+already occurred, not an alternative route: disclose the deviation on
+the issue, name the skipped checkpoint step (for example, the B2
+plan-comment checkpoint), post the plan retroactively with an explicit
+note about the reordering, and run the C1 critique pass against the
+completed diff.
 
 Implement the plan, running **fix-validate** before each atomic commit
 (one logical change per commit).

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -279,7 +279,7 @@ comment must already exist on the issue; posting it before implementation
 is the only normal path. If it does not, stop and return to B2. The
 following is a repair path only for an ordering violation that has
 already occurred, not an alternative route: disclose the deviation on
-the issue, name the skipped checkpoint step (for example, the B2
+the issue, name the skipped checkpoint step (for example, the B3
 plan-comment checkpoint), post the plan retroactively with an explicit
 note about the reordering, and run the C1 critique pass against the
 completed diff.

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -269,12 +269,15 @@ plan comment and verified claim.
 
 ## B3 — Implement
 
-**Plan-comment checkpoint**: before writing any implementation code,
-confirm the B2 plan comment already exists on the issue. If it does
-not, stop and return to B2. If code was already written before this
-checkpoint is noticed, disclose the ordering deviation on the issue,
-post the plan retroactively with an explicit note about the
-reordering, and run the C1 critique pass against the completed diff.
+**Plan-comment checkpoint**: before implementation begins, the B2 plan
+comment must already exist on the issue; posting it before implementation
+is the only normal path. If it does not, stop and return to B2. The
+following is a repair path only for an ordering violation that has
+already occurred, not an alternative route: disclose the deviation on
+the issue, name the skipped checkpoint step (for example, the B2
+plan-comment checkpoint), post the plan retroactively with an explicit
+note about the reordering, and run the C1 critique pass against the
+completed diff.
 
 Implement the plan, running **fix-validate** before each atomic commit
 (one logical change per commit).

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -274,7 +274,7 @@ comment must already exist on the issue; posting it before implementation
 is the only normal path. If it does not, stop and return to B2. The
 following is a repair path only for an ordering violation that has
 already occurred, not an alternative route: disclose the deviation on
-the issue, name the skipped checkpoint step (for example, the B2
+the issue, name the skipped checkpoint step (for example, the B3
 plan-comment checkpoint), post the plan retroactively with an explicit
 note about the reordering, and run the C1 critique pass against the
 completed diff.


### PR DESCRIPTION
## Summary

- make the B2 plan-comment checkpoint the only normal pre-implementation path
- define retroactive disclosure as recovery for an ordering violation and require naming the skipped checkpoint
- synchronize the canonical template instruction and generated repository copy

## Validation

- configured fix-validate
- configured pre-push validation
- `pnpm run lint:minimum` (3798 tests)

Closes #2230