### PR TITLE
feat(critique-loop): add layered user-global delegate resolver

### DIFF
--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -520,7 +520,7 @@
           "description": "Number of consecutive E10 review-fix critique passes without meaningful progress before the auto-loop stops and posts a hold for a maintainer decision. Optional; defaults to `3`."
         },
         "delegate": {
-          "type": "object",
+          "type": ["object", "null"],
           "additionalProperties": false,
           "required": ["command"],
           "properties": {
@@ -536,7 +536,7 @@
               "description": "`fallback` (default): run `command`; fall through to the per-agent mechanism when it is absent, exits non-zero, times out, or its output cannot be read as a findings list. `combined`: run both every pass and union their reported issues."
             }
           },
-          "description": "Repository-configurable C1 critique delegate. Optional; absent keeps today's per-agent-only behavior with zero change."
+          "description": "Repository-configurable C1 critique delegate. Optional; absent keeps today's per-agent-only behavior. An explicit JSON `null` is the local disable sentinel: it prevents inheriting a user-global delegate without installing a local command. `required` and `properties` apply only when the value is an object."
         }
       },
       "description": "Container for the C-phase and E10 critique-loop convergence guardrails. Optional; omitting any nested key keeps that key's own distributed default."

--- a/scripts/idd-config.mjs
+++ b/scripts/idd-config.mjs
@@ -126,18 +126,14 @@ function describeJsonValueKind(value) {
 }
 /**
  * True for a config-root that cannot be resolved against the process cwd.
- * Accepts POSIX `/…` (not `//…`) and Windows drive-letter or UNC roots.
+ * On Windows: drive-letter (`C:\…` / `C:/…`) or UNC (`\\server\…`) only.
+ * On POSIX: `/…` only (not `//…`, not a Windows drive or UNC string).
  * Rejects relative paths and Windows current-drive roots such as `\config`,
  * which `path.isAbsolute` treats as absolute on win32.
  */
 function isQualifiedConfigRoot(value) {
-  if (/^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')) {
-    return true;
-  }
-  // POSIX `/…` is only a cwd-independent root off Windows. On win32,
-  // `/config` and Git Bash `/c/Users/…` become a current-drive path.
   if (process.platform === 'win32') {
-    return false;
+    return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\');
   }
   return value.startsWith('/') && !value.startsWith('//');
 }
@@ -151,9 +147,12 @@ export const USER_GLOBAL_CONFIG_DIRNAME = 'idd-skill';
 export const USER_GLOBAL_CONFIG_FILENAME = 'config.json';
 /**
  * Resolve the user-global IDD config path: `$XDG_CONFIG_HOME/idd-skill/config.json`
- * when `XDG_CONFIG_HOME` is a non-empty string, otherwise
- * `$HOME/.config/idd-skill/config.json`. Returns `undefined` when neither
- * base directory is available. Never calls `os.homedir()`.
+ * when `XDG_CONFIG_HOME` is a non-empty **qualified** root, otherwise
+ * `$HOME/.config/idd-skill/config.json` when `$HOME` is a qualified root.
+ * A qualified root is platform-specific (POSIX `/…`; Windows drive letter
+ * or UNC) — a non-empty but relative or cross-platform-unsafe value is
+ * ignored rather than joined against the process cwd. Returns `undefined`
+ * when neither base directory is usable. Never calls `os.homedir()`.
  */
 export function resolveUserGlobalConfigPath(options) {
   const env = options?.env ?? process.env;

--- a/scripts/idd-config.mjs
+++ b/scripts/idd-config.mjs
@@ -31,8 +31,11 @@
 // wider-review change #1721 does not attempt. A later session may pick that
 // residual up knowingly.
 import { readFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
-import { resolveEffectiveCritiqueLoopDelegate } from './policy-helpers.mjs';
+import { isAbsolute, join, resolve } from 'node:path';
+import {
+  inspectCritiqueLoopDelegateLayer,
+  resolveEffectiveCritiqueLoopDelegate,
+} from './policy-helpers.mjs';
 /**
  * Read and parse `.github/idd/config.json` from the current working
  * directory, returning `null` when the file is missing, unreadable, or
@@ -139,7 +142,7 @@ export function resolveUserGlobalConfigPath(options) {
   const env = options?.env ?? process.env;
   const xdg =
     typeof env.XDG_CONFIG_HOME === 'string' ? env.XDG_CONFIG_HOME.trim() : '';
-  if (xdg.length > 0) {
+  if (xdg.length > 0 && isAbsolute(xdg)) {
     return join(xdg, USER_GLOBAL_CONFIG_DIRNAME, USER_GLOBAL_CONFIG_FILENAME);
   }
   const homeCandidate =
@@ -149,7 +152,7 @@ export function resolveUserGlobalConfigPath(options) {
         ? env.HOME
         : '';
   const home = homeCandidate.trim();
-  if (home.length === 0) {
+  if (home.length === 0 || !isAbsolute(home)) {
     return undefined;
   }
   return join(
@@ -197,6 +200,10 @@ export function resolveEffectiveCritiqueLoopDelegateFromEnv(options) {
     options && Object.hasOwn(options, 'localConfig')
       ? options.localConfig
       : loadPolicyConfig(options?.localPolicyPath).config;
+  const local = inspectCritiqueLoopDelegateLayer(localConfig);
+  if (local.status !== 'absent') {
+    return resolveEffectiveCritiqueLoopDelegate({ localConfig });
+  }
   const global = loadUserGlobalPolicyDocument({
     env: options?.env,
     path: options?.globalConfigPath,

--- a/scripts/idd-config.mjs
+++ b/scripts/idd-config.mjs
@@ -31,7 +31,7 @@
 // wider-review change #1721 does not attempt. A later session may pick that
 // residual up knowingly.
 import { readFileSync } from 'node:fs';
-import { isAbsolute, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import {
   inspectCritiqueLoopDelegateLayer,
   resolveEffectiveCritiqueLoopDelegate,
@@ -124,6 +124,18 @@ function describeJsonValueKind(value) {
   }
   return `a ${typeof value}`;
 }
+/**
+ * True for a config-root that cannot be resolved against the process cwd.
+ * Accepts POSIX `/…` (not `//…`) and Windows drive-letter or UNC roots.
+ * Rejects relative paths and Windows current-drive roots such as `\config`,
+ * which `path.isAbsolute` treats as absolute on win32.
+ */
+function isQualifiedConfigRoot(value) {
+  if (/^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')) {
+    return true;
+  }
+  return value.startsWith('/') && !value.startsWith('//');
+}
 /** True when `error` is a Node.js filesystem error with `code: 'ENOENT'`. */
 function isEnoentError(error) {
   return typeof error === 'object' && error !== null && error.code === 'ENOENT';
@@ -142,7 +154,7 @@ export function resolveUserGlobalConfigPath(options) {
   const env = options?.env ?? process.env;
   const xdg =
     typeof env.XDG_CONFIG_HOME === 'string' ? env.XDG_CONFIG_HOME.trim() : '';
-  if (xdg.length > 0 && isAbsolute(xdg)) {
+  if (xdg.length > 0 && isQualifiedConfigRoot(xdg)) {
     return join(xdg, USER_GLOBAL_CONFIG_DIRNAME, USER_GLOBAL_CONFIG_FILENAME);
   }
   const homeCandidate =
@@ -152,7 +164,7 @@ export function resolveUserGlobalConfigPath(options) {
         ? env.HOME
         : '';
   const home = homeCandidate.trim();
-  if (home.length === 0 || !isAbsolute(home)) {
+  if (home.length === 0 || !isQualifiedConfigRoot(home)) {
     return undefined;
   }
   return join(

--- a/scripts/idd-config.mjs
+++ b/scripts/idd-config.mjs
@@ -31,7 +31,8 @@
 // wider-review change #1721 does not attempt. A later session may pick that
 // residual up knowingly.
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { join, resolve } from 'node:path';
+import { resolveEffectiveCritiqueLoopDelegate } from './policy-helpers.mjs';
 /**
  * Read and parse `.github/idd/config.json` from the current working
  * directory, returning `null` when the file is missing, unreadable, or
@@ -123,4 +124,86 @@ function describeJsonValueKind(value) {
 /** True when `error` is a Node.js filesystem error with `code: 'ENOENT'`. */
 function isEnoentError(error) {
   return typeof error === 'object' && error !== null && error.code === 'ENOENT';
+}
+/** Directory name under XDG/`$HOME/.config` for the operator-global IDD file. */
+export const USER_GLOBAL_CONFIG_DIRNAME = 'idd-skill';
+/** Basename of the operator-global IDD policy file. */
+export const USER_GLOBAL_CONFIG_FILENAME = 'config.json';
+/**
+ * Resolve the user-global IDD config path: `$XDG_CONFIG_HOME/idd-skill/config.json`
+ * when `XDG_CONFIG_HOME` is a non-empty string, otherwise
+ * `$HOME/.config/idd-skill/config.json`. Returns `undefined` when neither
+ * base directory is available. Never calls `os.homedir()`.
+ */
+export function resolveUserGlobalConfigPath(options) {
+  const env = options?.env ?? process.env;
+  const xdg =
+    typeof env.XDG_CONFIG_HOME === 'string' ? env.XDG_CONFIG_HOME.trim() : '';
+  if (xdg.length > 0) {
+    return join(xdg, USER_GLOBAL_CONFIG_DIRNAME, USER_GLOBAL_CONFIG_FILENAME);
+  }
+  const homeCandidate =
+    typeof options?.homedir === 'string' && options.homedir.length > 0
+      ? options.homedir
+      : typeof env.HOME === 'string'
+        ? env.HOME
+        : '';
+  const home = homeCandidate.trim();
+  if (home.length === 0) {
+    return undefined;
+  }
+  return join(
+    home,
+    '.config',
+    USER_GLOBAL_CONFIG_DIRNAME,
+    USER_GLOBAL_CONFIG_FILENAME,
+  );
+}
+/**
+ * Read the operator-global policy file for C1 delegate inheritance.
+ *
+ * Missing, unreadable, non-JSON, and non-object documents are `absent`
+ * (non-fatal). Callers must not merge any key other than
+ * `critiqueLoop.delegate` into repository policy — pass the document to
+ * {@link resolveEffectiveCritiqueLoopDelegate}, which reads only that
+ * fragment. Opt-in to local C1 execution; CI and merge helpers must not
+ * call this.
+ */
+export function loadUserGlobalPolicyDocument(options) {
+  const path =
+    typeof options?.path === 'string' && options.path.length > 0
+      ? options.path
+      : resolveUserGlobalConfigPath(options);
+  if (path === undefined) {
+    return { status: 'absent' };
+  }
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8'));
+    if (!isPlainObject(parsed)) {
+      return { status: 'absent', path };
+    }
+    return { status: 'present', path, config: parsed };
+  } catch {
+    return { status: 'absent', path };
+  }
+}
+/**
+ * Opt-in C1 entry: resolve the effective critique delegate from the
+ * repository-local document plus an optional user-global file. Does not
+ * run as a side effect of {@link loadIddConfig} or {@link loadPolicyConfig}.
+ */
+export function resolveEffectiveCritiqueLoopDelegateFromEnv(options) {
+  const localConfig =
+    options && Object.hasOwn(options, 'localConfig')
+      ? options.localConfig
+      : loadPolicyConfig(options?.localPolicyPath).config;
+  const global = loadUserGlobalPolicyDocument({
+    env: options?.env,
+    path: options?.globalConfigPath,
+    homedir: options?.homedir,
+  });
+  return resolveEffectiveCritiqueLoopDelegate({
+    localConfig,
+    globalConfig: global.status === 'present' ? global.config : undefined,
+  });
 }

--- a/scripts/idd-config.mjs
+++ b/scripts/idd-config.mjs
@@ -134,6 +134,11 @@ function isQualifiedConfigRoot(value) {
   if (/^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')) {
     return true;
   }
+  // POSIX `/…` is only a cwd-independent root off Windows. On win32,
+  // `/config` and Git Bash `/c/Users/…` become a current-drive path.
+  if (process.platform === 'win32') {
+    return false;
+  }
   return value.startsWith('/') && !value.startsWith('//');
 }
 /** True when `error` is a Node.js filesystem error with `code: 'ENOENT'`. */

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -792,13 +792,21 @@ export function inspectCritiqueLoopDelegateLayer(config) {
   if (typeof config !== 'object' || config === null || Array.isArray(config)) {
     return { status: 'absent' };
   }
+  if (!Object.hasOwn(config, 'critiqueLoop')) {
+    return { status: 'absent' };
+  }
   const critiqueLoop = config.critiqueLoop;
   if (
     typeof critiqueLoop !== 'object' ||
     critiqueLoop === null ||
-    Array.isArray(critiqueLoop) ||
-    !Object.hasOwn(critiqueLoop, 'delegate')
+    Array.isArray(critiqueLoop)
   ) {
+    // A present non-object `critiqueLoop` is a local configuration error:
+    // fail closed rather than treating it as "no delegate" and inheriting
+    // a user-global object.
+    return { status: 'malformed', reason: INVALID_LOCAL_DELEGATE_REASON };
+  }
+  if (!Object.hasOwn(critiqueLoop, 'delegate')) {
     return { status: 'absent' };
   }
   const value = critiqueLoop.delegate;

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -781,6 +781,77 @@ function parseCritiqueLoopDelegate(value) {
       : 'fallback',
   };
 }
+const INVALID_LOCAL_DELEGATE_REASON = 'invalid-repository-local-delegate';
+/**
+ * Inspect `critiqueLoop.delegate` on a raw policy document without applying
+ * `normalizePolicyConfig`'s fail-safe-to-undefined collapse. Distinguishes
+ * absence, the explicit JSON `null` disable sentinel, a configured object,
+ * and a present-but-malformed value.
+ */
+export function inspectCritiqueLoopDelegateLayer(config) {
+  if (typeof config !== 'object' || config === null || Array.isArray(config)) {
+    return { status: 'absent' };
+  }
+  const critiqueLoop = config.critiqueLoop;
+  if (
+    typeof critiqueLoop !== 'object' ||
+    critiqueLoop === null ||
+    Array.isArray(critiqueLoop) ||
+    !Object.hasOwn(critiqueLoop, 'delegate')
+  ) {
+    return { status: 'absent' };
+  }
+  const value = critiqueLoop.delegate;
+  if (value === null) {
+    return { status: 'disabled' };
+  }
+  const parsed = parseCritiqueLoopDelegate(value);
+  if (parsed) {
+    return { status: 'configured', delegate: parsed };
+  }
+  return { status: 'malformed', reason: INVALID_LOCAL_DELEGATE_REASON };
+}
+/**
+ * Resolve the effective C1 delegate from a repository-local document and an
+ * optional user-global document. Pure: callers supply already-loaded JSON
+ * (or `undefined` for an absent global file). Never reads the filesystem.
+ *
+ * Order: local object, local `null` disable, global object, then none.
+ * A malformed local delegate is fail-closed and does not inherit global.
+ * A malformed or disabled global fragment is treated as absent.
+ */
+export function resolveEffectiveCritiqueLoopDelegate(input) {
+  const local = inspectCritiqueLoopDelegateLayer(input.localConfig);
+  if (local.status === 'configured' && local.delegate) {
+    return {
+      status: 'local',
+      source: 'repository-local',
+      delegate: local.delegate,
+    };
+  }
+  if (local.status === 'disabled') {
+    return { status: 'disabled', source: 'repository-local' };
+  }
+  if (local.status === 'malformed') {
+    return {
+      status: 'local-malformed',
+      source: 'repository-local',
+      reason: local.reason ?? INVALID_LOCAL_DELEGATE_REASON,
+    };
+  }
+  if (input.globalConfig === undefined || input.globalConfig === null) {
+    return { status: 'none', source: 'none' };
+  }
+  const global = inspectCritiqueLoopDelegateLayer(input.globalConfig);
+  if (global.status === 'configured' && global.delegate) {
+    return {
+      status: 'global',
+      source: 'user-global',
+      delegate: global.delegate,
+    };
+  }
+  return { status: 'none', source: 'none' };
+}
 function hasConfiguredCollaboratorMarkerTrust(config) {
   const c = config;
   return (

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -813,6 +813,18 @@ export function inspectCritiqueLoopDelegateLayer(config) {
   if (value === null) {
     return { status: 'disabled' };
   }
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    const candidate = value;
+    if (Object.hasOwn(candidate, 'mode')) {
+      const mode = candidate.mode;
+      if (typeof mode !== 'string' || !CRITIQUE_LOOP_DELEGATE_MODES.has(mode)) {
+        return {
+          status: 'malformed',
+          reason: INVALID_LOCAL_DELEGATE_REASON,
+        };
+      }
+    }
+  }
   const parsed = parseCritiqueLoopDelegate(value);
   if (parsed) {
     return { status: 'configured', delegate: parsed };

--- a/src/scripts/idd-config.mts
+++ b/src/scripts/idd-config.mts
@@ -32,7 +32,12 @@
 // residual up knowingly.
 
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { join, resolve } from 'node:path';
+
+import {
+  type EffectiveCritiqueLoopDelegate,
+  resolveEffectiveCritiqueLoopDelegate,
+} from './policy-helpers.mts';
 
 /**
  * Weakly-typed, partial view of `.github/idd/config.json`. Every field is
@@ -160,4 +165,131 @@ function isEnoentError(error: unknown): boolean {
     error !== null &&
     (error as { code?: unknown }).code === 'ENOENT'
   );
+}
+
+/** Directory name under XDG/`$HOME/.config` for the operator-global IDD file. */
+export const USER_GLOBAL_CONFIG_DIRNAME = 'idd-skill';
+
+/** Basename of the operator-global IDD policy file. */
+export const USER_GLOBAL_CONFIG_FILENAME = 'config.json';
+
+export interface UserGlobalConfigPathOptions {
+  /**
+   * Environment used to resolve `XDG_CONFIG_HOME` then `HOME`. When
+   * provided, `process.env` is not consulted — tests inject a sandbox
+   * env so the real operator configuration is never read.
+   */
+  env?: NodeJS.ProcessEnv;
+  /** Explicit `$HOME` override, consulted after `XDG_CONFIG_HOME`. */
+  homedir?: string;
+}
+
+export interface UserGlobalPolicyDocumentLoad {
+  status: 'absent' | 'present';
+  path?: string;
+  config?: unknown;
+}
+
+export interface ResolveEffectiveCritiqueLoopDelegateFromEnvOptions {
+  /** Raw repository-local policy object. When omitted, load from disk. */
+  localConfig?: unknown;
+  /** Path forwarded to {@link loadPolicyConfig} when `localConfig` is omitted. */
+  localPolicyPath?: string;
+  env?: NodeJS.ProcessEnv;
+  /** Injected user-global file path; skips XDG/`HOME` resolution. */
+  globalConfigPath?: string;
+  homedir?: string;
+}
+
+/**
+ * Resolve the user-global IDD config path: `$XDG_CONFIG_HOME/idd-skill/config.json`
+ * when `XDG_CONFIG_HOME` is a non-empty string, otherwise
+ * `$HOME/.config/idd-skill/config.json`. Returns `undefined` when neither
+ * base directory is available. Never calls `os.homedir()`.
+ */
+export function resolveUserGlobalConfigPath(
+  options?: UserGlobalConfigPathOptions,
+): string | undefined {
+  const env = options?.env ?? process.env;
+  const xdg =
+    typeof env.XDG_CONFIG_HOME === 'string' ? env.XDG_CONFIG_HOME.trim() : '';
+  if (xdg.length > 0) {
+    return join(xdg, USER_GLOBAL_CONFIG_DIRNAME, USER_GLOBAL_CONFIG_FILENAME);
+  }
+
+  const homeCandidate =
+    typeof options?.homedir === 'string' && options.homedir.length > 0
+      ? options.homedir
+      : typeof env.HOME === 'string'
+        ? env.HOME
+        : '';
+  const home = homeCandidate.trim();
+  if (home.length === 0) {
+    return undefined;
+  }
+  return join(
+    home,
+    '.config',
+    USER_GLOBAL_CONFIG_DIRNAME,
+    USER_GLOBAL_CONFIG_FILENAME,
+  );
+}
+
+/**
+ * Read the operator-global policy file for C1 delegate inheritance.
+ *
+ * Missing, unreadable, non-JSON, and non-object documents are `absent`
+ * (non-fatal). Callers must not merge any key other than
+ * `critiqueLoop.delegate` into repository policy — pass the document to
+ * {@link resolveEffectiveCritiqueLoopDelegate}, which reads only that
+ * fragment. Opt-in to local C1 execution; CI and merge helpers must not
+ * call this.
+ */
+export function loadUserGlobalPolicyDocument(options?: {
+  env?: NodeJS.ProcessEnv;
+  path?: string;
+  homedir?: string;
+}): UserGlobalPolicyDocumentLoad {
+  const path =
+    typeof options?.path === 'string' && options.path.length > 0
+      ? options.path
+      : resolveUserGlobalConfigPath(options);
+  if (path === undefined) {
+    return { status: 'absent' };
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
+    if (!isPlainObject(parsed)) {
+      return { status: 'absent', path };
+    }
+    return { status: 'present', path, config: parsed };
+  } catch {
+    return { status: 'absent', path };
+  }
+}
+
+/**
+ * Opt-in C1 entry: resolve the effective critique delegate from the
+ * repository-local document plus an optional user-global file. Does not
+ * run as a side effect of {@link loadIddConfig} or {@link loadPolicyConfig}.
+ */
+export function resolveEffectiveCritiqueLoopDelegateFromEnv(
+  options?: ResolveEffectiveCritiqueLoopDelegateFromEnvOptions,
+): EffectiveCritiqueLoopDelegate {
+  const localConfig =
+    options && Object.hasOwn(options, 'localConfig')
+      ? options.localConfig
+      : loadPolicyConfig(options?.localPolicyPath).config;
+
+  const global = loadUserGlobalPolicyDocument({
+    env: options?.env,
+    path: options?.globalConfigPath,
+    homedir: options?.homedir,
+  });
+
+  return resolveEffectiveCritiqueLoopDelegate({
+    localConfig,
+    globalConfig: global.status === 'present' ? global.config : undefined,
+  });
 }

--- a/src/scripts/idd-config.mts
+++ b/src/scripts/idd-config.mts
@@ -32,10 +32,11 @@
 // residual up knowingly.
 
 import { readFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { isAbsolute, join, resolve } from 'node:path';
 
 import {
   type EffectiveCritiqueLoopDelegate,
+  inspectCritiqueLoopDelegateLayer,
   resolveEffectiveCritiqueLoopDelegate,
 } from './policy-helpers.mts';
 
@@ -213,7 +214,7 @@ export function resolveUserGlobalConfigPath(
   const env = options?.env ?? process.env;
   const xdg =
     typeof env.XDG_CONFIG_HOME === 'string' ? env.XDG_CONFIG_HOME.trim() : '';
-  if (xdg.length > 0) {
+  if (xdg.length > 0 && isAbsolute(xdg)) {
     return join(xdg, USER_GLOBAL_CONFIG_DIRNAME, USER_GLOBAL_CONFIG_FILENAME);
   }
 
@@ -224,7 +225,7 @@ export function resolveUserGlobalConfigPath(
         ? env.HOME
         : '';
   const home = homeCandidate.trim();
-  if (home.length === 0) {
+  if (home.length === 0 || !isAbsolute(home)) {
     return undefined;
   }
   return join(
@@ -281,6 +282,11 @@ export function resolveEffectiveCritiqueLoopDelegateFromEnv(
     options && Object.hasOwn(options, 'localConfig')
       ? options.localConfig
       : loadPolicyConfig(options?.localPolicyPath).config;
+
+  const local = inspectCritiqueLoopDelegateLayer(localConfig);
+  if (local.status !== 'absent') {
+    return resolveEffectiveCritiqueLoopDelegate({ localConfig });
+  }
 
   const global = loadUserGlobalPolicyDocument({
     env: options?.env,

--- a/src/scripts/idd-config.mts
+++ b/src/scripts/idd-config.mts
@@ -161,18 +161,14 @@ function describeJsonValueKind(value: unknown): string {
 
 /**
  * True for a config-root that cannot be resolved against the process cwd.
- * Accepts POSIX `/…` (not `//…`) and Windows drive-letter or UNC roots.
+ * On Windows: drive-letter (`C:\…` / `C:/…`) or UNC (`\\server\…`) only.
+ * On POSIX: `/…` only (not `//…`, not a Windows drive or UNC string).
  * Rejects relative paths and Windows current-drive roots such as `\config`,
  * which `path.isAbsolute` treats as absolute on win32.
  */
 function isQualifiedConfigRoot(value: string): boolean {
-  if (/^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')) {
-    return true;
-  }
-  // POSIX `/…` is only a cwd-independent root off Windows. On win32,
-  // `/config` and Git Bash `/c/Users/…` become a current-drive path.
   if (process.platform === 'win32') {
-    return false;
+    return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\');
   }
   return value.startsWith('/') && !value.startsWith('//');
 }
@@ -222,9 +218,12 @@ export interface ResolveEffectiveCritiqueLoopDelegateFromEnvOptions {
 
 /**
  * Resolve the user-global IDD config path: `$XDG_CONFIG_HOME/idd-skill/config.json`
- * when `XDG_CONFIG_HOME` is a non-empty string, otherwise
- * `$HOME/.config/idd-skill/config.json`. Returns `undefined` when neither
- * base directory is available. Never calls `os.homedir()`.
+ * when `XDG_CONFIG_HOME` is a non-empty **qualified** root, otherwise
+ * `$HOME/.config/idd-skill/config.json` when `$HOME` is a qualified root.
+ * A qualified root is platform-specific (POSIX `/…`; Windows drive letter
+ * or UNC) — a non-empty but relative or cross-platform-unsafe value is
+ * ignored rather than joined against the process cwd. Returns `undefined`
+ * when neither base directory is usable. Never calls `os.homedir()`.
  */
 export function resolveUserGlobalConfigPath(
   options?: UserGlobalConfigPathOptions,

--- a/src/scripts/idd-config.mts
+++ b/src/scripts/idd-config.mts
@@ -32,7 +32,7 @@
 // residual up knowingly.
 
 import { readFileSync } from 'node:fs';
-import { isAbsolute, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 
 import {
   type EffectiveCritiqueLoopDelegate,
@@ -159,6 +159,19 @@ function describeJsonValueKind(value: unknown): string {
   return `a ${typeof value}`;
 }
 
+/**
+ * True for a config-root that cannot be resolved against the process cwd.
+ * Accepts POSIX `/…` (not `//…`) and Windows drive-letter or UNC roots.
+ * Rejects relative paths and Windows current-drive roots such as `\config`,
+ * which `path.isAbsolute` treats as absolute on win32.
+ */
+function isQualifiedConfigRoot(value: string): boolean {
+  if (/^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')) {
+    return true;
+  }
+  return value.startsWith('/') && !value.startsWith('//');
+}
+
 /** True when `error` is a Node.js filesystem error with `code: 'ENOENT'`. */
 function isEnoentError(error: unknown): boolean {
   return (
@@ -214,7 +227,7 @@ export function resolveUserGlobalConfigPath(
   const env = options?.env ?? process.env;
   const xdg =
     typeof env.XDG_CONFIG_HOME === 'string' ? env.XDG_CONFIG_HOME.trim() : '';
-  if (xdg.length > 0 && isAbsolute(xdg)) {
+  if (xdg.length > 0 && isQualifiedConfigRoot(xdg)) {
     return join(xdg, USER_GLOBAL_CONFIG_DIRNAME, USER_GLOBAL_CONFIG_FILENAME);
   }
 
@@ -225,7 +238,7 @@ export function resolveUserGlobalConfigPath(
         ? env.HOME
         : '';
   const home = homeCandidate.trim();
-  if (home.length === 0 || !isAbsolute(home)) {
+  if (home.length === 0 || !isQualifiedConfigRoot(home)) {
     return undefined;
   }
   return join(

--- a/src/scripts/idd-config.mts
+++ b/src/scripts/idd-config.mts
@@ -169,6 +169,11 @@ function isQualifiedConfigRoot(value: string): boolean {
   if (/^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\')) {
     return true;
   }
+  // POSIX `/…` is only a cwd-independent root off Windows. On win32,
+  // `/config` and Git Bash `/c/Users/…` become a current-drive path.
+  if (process.platform === 'win32') {
+    return false;
+  }
   return value.startsWith('/') && !value.startsWith('//');
 }
 

--- a/src/scripts/policy-helpers.mts
+++ b/src/scripts/policy-helpers.mts
@@ -16,7 +16,7 @@ interface RawForcedHandoff {
   authorityPolicy?: unknown;
 }
 
-interface CritiqueLoopDelegate {
+export interface CritiqueLoopDelegate {
   command: string;
   mode: 'fallback' | 'combined';
 }
@@ -25,6 +25,43 @@ interface CritiqueLoopPolicy {
   cPhaseLowSeveritySkipAfter: number;
   e10NoProgressHoldAfter: number;
   delegate?: CritiqueLoopDelegate;
+}
+
+/** How one policy document presents `critiqueLoop.delegate`. */
+export type CritiqueLoopDelegateLayerStatus =
+  | 'absent'
+  | 'disabled'
+  | 'configured'
+  | 'malformed';
+
+export interface CritiqueLoopDelegateLayer {
+  status: CritiqueLoopDelegateLayerStatus;
+  delegate?: CritiqueLoopDelegate;
+  reason?: string;
+}
+
+/**
+ * Outcome of layered C1 delegate resolution. `local-malformed` is
+ * fail-closed: a bad repository-local `delegate` must not inherit a
+ * user-global object.
+ */
+export type EffectiveCritiqueLoopDelegateStatus =
+  | 'local'
+  | 'disabled'
+  | 'global'
+  | 'none'
+  | 'local-malformed';
+
+export type CritiqueLoopDelegateSource =
+  | 'repository-local'
+  | 'user-global'
+  | 'none';
+
+export interface EffectiveCritiqueLoopDelegate {
+  status: EffectiveCritiqueLoopDelegateStatus;
+  source: CritiqueLoopDelegateSource;
+  delegate?: CritiqueLoopDelegate;
+  reason?: string;
 }
 
 // Structural view of the untrusted config object parsed from an
@@ -948,6 +985,92 @@ function parseCritiqueLoopDelegate(
           | 'combined')
       : 'fallback',
   };
+}
+
+const INVALID_LOCAL_DELEGATE_REASON = 'invalid-repository-local-delegate';
+
+/**
+ * Inspect `critiqueLoop.delegate` on a raw policy document without applying
+ * `normalizePolicyConfig`'s fail-safe-to-undefined collapse. Distinguishes
+ * absence, the explicit JSON `null` disable sentinel, a configured object,
+ * and a present-but-malformed value.
+ */
+export function inspectCritiqueLoopDelegateLayer(
+  config: unknown,
+): CritiqueLoopDelegateLayer {
+  if (typeof config !== 'object' || config === null || Array.isArray(config)) {
+    return { status: 'absent' };
+  }
+
+  const critiqueLoop = (config as RawConfig).critiqueLoop;
+  if (
+    typeof critiqueLoop !== 'object' ||
+    critiqueLoop === null ||
+    Array.isArray(critiqueLoop) ||
+    !Object.hasOwn(critiqueLoop, 'delegate')
+  ) {
+    return { status: 'absent' };
+  }
+
+  const value = (critiqueLoop as { delegate: unknown }).delegate;
+  if (value === null) {
+    return { status: 'disabled' };
+  }
+
+  const parsed = parseCritiqueLoopDelegate(value);
+  if (parsed) {
+    return { status: 'configured', delegate: parsed };
+  }
+
+  return { status: 'malformed', reason: INVALID_LOCAL_DELEGATE_REASON };
+}
+
+/**
+ * Resolve the effective C1 delegate from a repository-local document and an
+ * optional user-global document. Pure: callers supply already-loaded JSON
+ * (or `undefined` for an absent global file). Never reads the filesystem.
+ *
+ * Order: local object, local `null` disable, global object, then none.
+ * A malformed local delegate is fail-closed and does not inherit global.
+ * A malformed or disabled global fragment is treated as absent.
+ */
+export function resolveEffectiveCritiqueLoopDelegate(input: {
+  localConfig: unknown;
+  globalConfig?: unknown;
+}): EffectiveCritiqueLoopDelegate {
+  const local = inspectCritiqueLoopDelegateLayer(input.localConfig);
+  if (local.status === 'configured' && local.delegate) {
+    return {
+      status: 'local',
+      source: 'repository-local',
+      delegate: local.delegate,
+    };
+  }
+  if (local.status === 'disabled') {
+    return { status: 'disabled', source: 'repository-local' };
+  }
+  if (local.status === 'malformed') {
+    return {
+      status: 'local-malformed',
+      source: 'repository-local',
+      reason: local.reason ?? INVALID_LOCAL_DELEGATE_REASON,
+    };
+  }
+
+  if (input.globalConfig === undefined || input.globalConfig === null) {
+    return { status: 'none', source: 'none' };
+  }
+
+  const global = inspectCritiqueLoopDelegateLayer(input.globalConfig);
+  if (global.status === 'configured' && global.delegate) {
+    return {
+      status: 'global',
+      source: 'user-global',
+      delegate: global.delegate,
+    };
+  }
+
+  return { status: 'none', source: 'none' };
 }
 
 function hasConfiguredCollaboratorMarkerTrust(config: unknown): boolean {

--- a/src/scripts/policy-helpers.mts
+++ b/src/scripts/policy-helpers.mts
@@ -1027,6 +1027,19 @@ export function inspectCritiqueLoopDelegateLayer(
     return { status: 'disabled' };
   }
 
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    const candidate = value as { mode?: unknown };
+    if (Object.hasOwn(candidate, 'mode')) {
+      const mode = candidate.mode;
+      if (typeof mode !== 'string' || !CRITIQUE_LOOP_DELEGATE_MODES.has(mode)) {
+        return {
+          status: 'malformed',
+          reason: INVALID_LOCAL_DELEGATE_REASON,
+        };
+      }
+    }
+  }
+
   const parsed = parseCritiqueLoopDelegate(value);
   if (parsed) {
     return { status: 'configured', delegate: parsed };

--- a/src/scripts/policy-helpers.mts
+++ b/src/scripts/policy-helpers.mts
@@ -1002,13 +1002,23 @@ export function inspectCritiqueLoopDelegateLayer(
     return { status: 'absent' };
   }
 
+  if (!Object.hasOwn(config, 'critiqueLoop')) {
+    return { status: 'absent' };
+  }
+
   const critiqueLoop = (config as RawConfig).critiqueLoop;
   if (
     typeof critiqueLoop !== 'object' ||
     critiqueLoop === null ||
-    Array.isArray(critiqueLoop) ||
-    !Object.hasOwn(critiqueLoop, 'delegate')
+    Array.isArray(critiqueLoop)
   ) {
+    // A present non-object `critiqueLoop` is a local configuration error:
+    // fail closed rather than treating it as "no delegate" and inheriting
+    // a user-global object.
+    return { status: 'malformed', reason: INVALID_LOCAL_DELEGATE_REASON };
+  }
+
+  if (!Object.hasOwn(critiqueLoop, 'delegate')) {
     return { status: 'absent' };
   }
 

--- a/tests/idd-config.test.mts
+++ b/tests/idd-config.test.mts
@@ -268,6 +268,21 @@ test('resolveUserGlobalConfigPath ignores a relative XDG_CONFIG_HOME and require
   );
 });
 
+test('resolveUserGlobalConfigPath rejects a Windows current-drive root such as \\config (#2257)', () => {
+  assert.equal(
+    resolveUserGlobalConfigPath({
+      env: { XDG_CONFIG_HOME: '\\config', HOME: '/home/operator' },
+    }),
+    join('/home/operator', '.config', 'idd-skill', 'config.json'),
+  );
+  assert.equal(
+    resolveUserGlobalConfigPath({
+      env: { HOME: '\\config' },
+    }),
+    undefined,
+  );
+});
+
 test('loadUserGlobalPolicyDocument treats a missing file as absent (#2257)', () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-user-global-missing-'));
   const result = loadUserGlobalPolicyDocument({

--- a/tests/idd-config.test.mts
+++ b/tests/idd-config.test.mts
@@ -283,6 +283,24 @@ test('resolveUserGlobalConfigPath rejects a Windows current-drive root such as \
   );
 });
 
+test('resolveUserGlobalConfigPath documents that POSIX slash roots are Unix-only (#2257)', () => {
+  if (process.platform === 'win32') {
+    assert.equal(
+      resolveUserGlobalConfigPath({
+        env: { XDG_CONFIG_HOME: '/config', HOME: 'C:\\Users\\operator' },
+      }),
+      join('C:\\Users\\operator', '.config', 'idd-skill', 'config.json'),
+    );
+    return;
+  }
+  assert.equal(
+    resolveUserGlobalConfigPath({
+      env: { XDG_CONFIG_HOME: '/xdg-config' },
+    }),
+    join('/xdg-config', 'idd-skill', 'config.json'),
+  );
+});
+
 test('loadUserGlobalPolicyDocument treats a missing file as absent (#2257)', () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-user-global-missing-'));
   const result = loadUserGlobalPolicyDocument({
@@ -301,7 +319,7 @@ test('loadUserGlobalPolicyDocument treats malformed JSON as absent (#2257)', () 
   assert.equal(result.path, path);
 });
 
-test('loadUserGlobalPolicyDocument ignores keys other than critiqueLoop.delegate (#2257)', () => {
+test('resolveEffectiveCritiqueLoopDelegateFromEnv ignores global keys other than critiqueLoop.delegate (#2257)', () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-user-global-extra-'));
   const path = join(sandbox, 'config.json');
   writeFileSync(

--- a/tests/idd-config.test.mts
+++ b/tests/idd-config.test.mts
@@ -253,6 +253,21 @@ test('resolveUserGlobalConfigPath does not consult process.env when env is injec
   assert.equal(resolveUserGlobalConfigPath({ env: {} }), undefined);
 });
 
+test('resolveUserGlobalConfigPath ignores a relative XDG_CONFIG_HOME and requires an absolute HOME (#2257)', () => {
+  assert.equal(
+    resolveUserGlobalConfigPath({
+      env: { XDG_CONFIG_HOME: 'config', HOME: '/home/operator' },
+    }),
+    join('/home/operator', '.config', 'idd-skill', 'config.json'),
+  );
+  assert.equal(
+    resolveUserGlobalConfigPath({
+      env: { HOME: 'relative-home' },
+    }),
+    undefined,
+  );
+});
+
 test('loadUserGlobalPolicyDocument treats a missing file as absent (#2257)', () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-user-global-missing-'));
   const result = loadUserGlobalPolicyDocument({
@@ -292,6 +307,27 @@ test('loadUserGlobalPolicyDocument ignores keys other than critiqueLoop.delegate
     status: 'global',
     source: 'user-global',
     delegate: { command: 'global-review', mode: 'fallback' },
+  });
+});
+
+test('resolveEffectiveCritiqueLoopDelegateFromEnv skips the global file when local policy already decides (#2257)', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-user-global-skipped-'));
+  const path = join(sandbox, 'config.json');
+  writeFileSync(
+    path,
+    JSON.stringify({
+      critiqueLoop: { delegate: { command: 'must-not-load' } },
+    }),
+  );
+  const resolved = resolveEffectiveCritiqueLoopDelegateFromEnv({
+    localConfig: { critiqueLoop: { delegate: { command: 'local-review' } } },
+    globalConfigPath: path,
+    env: {},
+  });
+  assert.deepEqual(resolved, {
+    status: 'local',
+    source: 'repository-local',
+    delegate: { command: 'local-review', mode: 'fallback' },
   });
 });
 

--- a/tests/idd-config.test.mts
+++ b/tests/idd-config.test.mts
@@ -5,7 +5,13 @@ import { join, resolve } from 'node:path';
 import { platform } from 'node:process';
 import { test } from 'node:test';
 
-import { loadIddConfig, loadPolicyConfig } from '../src/scripts/idd-config.mts';
+import {
+  loadIddConfig,
+  loadPolicyConfig,
+  loadUserGlobalPolicyDocument,
+  resolveEffectiveCritiqueLoopDelegateFromEnv,
+  resolveUserGlobalConfigPath,
+} from '../src/scripts/idd-config.mts';
 
 // Every scenario runs inside its own freshly `mkdtempSync`-created sandbox
 // (never the real repo cwd), mirroring the sandboxing already used by
@@ -219,5 +225,93 @@ test('loadPolicyConfig default path: throws (not silently absent) on a permissio
     } finally {
       chmodSync(configPath, 0o644);
     }
+  });
+});
+
+test('resolveUserGlobalConfigPath prefers XDG_CONFIG_HOME over HOME (#2257)', () => {
+  assert.equal(
+    resolveUserGlobalConfigPath({
+      env: {
+        XDG_CONFIG_HOME: '/xdg-config',
+        HOME: '/home/operator',
+      },
+    }),
+    join('/xdg-config', 'idd-skill', 'config.json'),
+  );
+});
+
+test('resolveUserGlobalConfigPath falls back to HOME/.config when XDG_CONFIG_HOME is empty (#2257)', () => {
+  assert.equal(
+    resolveUserGlobalConfigPath({
+      env: { XDG_CONFIG_HOME: '  ', HOME: '/home/operator' },
+    }),
+    join('/home/operator', '.config', 'idd-skill', 'config.json'),
+  );
+});
+
+test('resolveUserGlobalConfigPath does not consult process.env when env is injected (#2257)', () => {
+  assert.equal(resolveUserGlobalConfigPath({ env: {} }), undefined);
+});
+
+test('loadUserGlobalPolicyDocument treats a missing file as absent (#2257)', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-user-global-missing-'));
+  const result = loadUserGlobalPolicyDocument({
+    path: join(sandbox, 'missing.json'),
+  });
+  assert.equal(result.status, 'absent');
+  assert.equal(result.config, undefined);
+});
+
+test('loadUserGlobalPolicyDocument treats malformed JSON as absent (#2257)', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-user-global-badjson-'));
+  const path = join(sandbox, 'config.json');
+  writeFileSync(path, '{ not json');
+  const result = loadUserGlobalPolicyDocument({ path });
+  assert.equal(result.status, 'absent');
+  assert.equal(result.path, path);
+});
+
+test('loadUserGlobalPolicyDocument ignores keys other than critiqueLoop.delegate (#2257)', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-user-global-extra-'));
+  const path = join(sandbox, 'config.json');
+  writeFileSync(
+    path,
+    JSON.stringify({
+      mergePolicy: 'must-not-apply',
+      critiqueLoop: { delegate: { command: 'global-review' } },
+    }),
+  );
+  const result = loadUserGlobalPolicyDocument({ path });
+  assert.equal(result.status, 'present');
+  const resolved = resolveEffectiveCritiqueLoopDelegateFromEnv({
+    localConfig: {},
+    globalConfigPath: path,
+    env: {},
+  });
+  assert.deepEqual(resolved, {
+    status: 'global',
+    source: 'user-global',
+    delegate: { command: 'global-review', mode: 'fallback' },
+  });
+});
+
+test('resolveEffectiveCritiqueLoopDelegateFromEnv does not read HOME when path is injected (#2257)', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-user-global-injected-'));
+  const path = join(sandbox, 'config.json');
+  writeFileSync(
+    path,
+    JSON.stringify({
+      critiqueLoop: { delegate: { command: 'injected-review' } },
+    }),
+  );
+  const resolved = resolveEffectiveCritiqueLoopDelegateFromEnv({
+    localConfig: {},
+    globalConfigPath: path,
+    env: { HOME: '/this-must-not-be-read', XDG_CONFIG_HOME: '/neither' },
+  });
+  assert.deepEqual(resolved, {
+    status: 'global',
+    source: 'user-global',
+    delegate: { command: 'injected-review', mode: 'fallback' },
   });
 });

--- a/tests/idd-config.test.mts
+++ b/tests/idd-config.test.mts
@@ -283,6 +283,17 @@ test('resolveUserGlobalConfigPath rejects a Windows current-drive root such as \
   );
 });
 
+test('resolveUserGlobalConfigPath ignores a Windows drive root on POSIX (#2257)', {
+  skip: process.platform === 'win32',
+}, () => {
+  assert.equal(
+    resolveUserGlobalConfigPath({
+      env: { XDG_CONFIG_HOME: 'C:\\Users\\op', HOME: '/home/operator' },
+    }),
+    join('/home/operator', '.config', 'idd-skill', 'config.json'),
+  );
+});
+
 test('resolveUserGlobalConfigPath documents that POSIX slash roots are Unix-only (#2257)', () => {
   if (process.platform === 'win32') {
     assert.equal(

--- a/tests/policy-helpers.test.mts
+++ b/tests/policy-helpers.test.mts
@@ -484,6 +484,20 @@ test('resolveEffectiveCritiqueLoopDelegate fails closed on a malformed local del
   });
 });
 
+test('resolveEffectiveCritiqueLoopDelegate fails closed on a non-object local critiqueLoop (#2257)', () => {
+  const result = resolveEffectiveCritiqueLoopDelegate({
+    localConfig: { critiqueLoop: 'not-an-object' },
+    globalConfig: {
+      critiqueLoop: { delegate: { command: 'global-review' } },
+    },
+  });
+  assert.deepEqual(result, {
+    status: 'local-malformed',
+    source: 'repository-local',
+    reason: 'invalid-repository-local-delegate',
+  });
+});
+
 test('resolveEffectiveCritiqueLoopDelegate treats a malformed global fragment as absent (#2257)', () => {
   const result = resolveEffectiveCritiqueLoopDelegate({
     localConfig: {},

--- a/tests/policy-helpers.test.mts
+++ b/tests/policy-helpers.test.mts
@@ -4,9 +4,11 @@ import { test } from 'node:test';
 import {
   clone,
   getReviewEscalationChangesRequestedPolicy,
+  inspectCritiqueLoopDelegateLayer,
   normalizePolicyConfig,
   POLICY_DEFAULTS,
   parseIsoDurationToMs,
+  resolveEffectiveCritiqueLoopDelegate,
   selectDesyncedIndex,
 } from '../src/scripts/policy-helpers.mts';
 
@@ -378,6 +380,125 @@ test('critiqueLoop.delegate is absent (not an own key) when unconfigured, matchi
     false,
   );
   assert.equal(Object.hasOwn(POLICY_DEFAULTS.critiqueLoop, 'delegate'), false);
+});
+
+test('inspectCritiqueLoopDelegateLayer distinguishes absent, disabled, configured, and malformed (#2257)', () => {
+  assert.deepEqual(inspectCritiqueLoopDelegateLayer({}), { status: 'absent' });
+  assert.deepEqual(
+    inspectCritiqueLoopDelegateLayer({ critiqueLoop: { delegate: null } }),
+    { status: 'disabled' },
+  );
+  assert.deepEqual(
+    inspectCritiqueLoopDelegateLayer({
+      critiqueLoop: { delegate: { command: 'coderabbit review --plain' } },
+    }),
+    {
+      status: 'configured',
+      delegate: { command: 'coderabbit review --plain', mode: 'fallback' },
+    },
+  );
+  assert.deepEqual(
+    inspectCritiqueLoopDelegateLayer({
+      critiqueLoop: { delegate: { command: 'coderabbit review', bogus: 1 } },
+    }),
+    {
+      status: 'malformed',
+      reason: 'invalid-repository-local-delegate',
+    },
+  );
+});
+
+test('normalizePolicyConfig still fail-safes a local null delegate to absent (#2257)', () => {
+  // CI/merge helpers keep the pre-#2257 collapse; only the opt-in layered
+  // resolver treats JSON null as the disable sentinel.
+  assert.equal(
+    Object.hasOwn(
+      normalizePolicyConfig({ critiqueLoop: { delegate: null } }).critiqueLoop,
+      'delegate',
+    ),
+    false,
+  );
+});
+
+test('resolveEffectiveCritiqueLoopDelegate prefers a local object over a global object (#2257)', () => {
+  const result = resolveEffectiveCritiqueLoopDelegate({
+    localConfig: {
+      critiqueLoop: { delegate: { command: 'local-review' } },
+    },
+    globalConfig: {
+      critiqueLoop: {
+        delegate: { command: 'global-review', mode: 'combined' },
+      },
+    },
+  });
+  assert.deepEqual(result, {
+    status: 'local',
+    source: 'repository-local',
+    delegate: { command: 'local-review', mode: 'fallback' },
+  });
+});
+
+test('resolveEffectiveCritiqueLoopDelegate honors local JSON null over a valid global object (#2257)', () => {
+  const result = resolveEffectiveCritiqueLoopDelegate({
+    localConfig: { critiqueLoop: { delegate: null } },
+    globalConfig: {
+      critiqueLoop: { delegate: { command: 'global-review' } },
+    },
+  });
+  assert.deepEqual(result, {
+    status: 'disabled',
+    source: 'repository-local',
+  });
+});
+
+test('resolveEffectiveCritiqueLoopDelegate inherits a global object when local is absent (#2257)', () => {
+  const result = resolveEffectiveCritiqueLoopDelegate({
+    localConfig: {},
+    globalConfig: {
+      mergePolicy: 'must-not-leak',
+      critiqueLoop: {
+        delegate: { command: 'global-review', mode: 'combined' },
+      },
+    },
+  });
+  assert.deepEqual(result, {
+    status: 'global',
+    source: 'user-global',
+    delegate: { command: 'global-review', mode: 'combined' },
+  });
+});
+
+test('resolveEffectiveCritiqueLoopDelegate fails closed on a malformed local delegate (#2257)', () => {
+  const result = resolveEffectiveCritiqueLoopDelegate({
+    localConfig: {
+      critiqueLoop: { delegate: { command: 'local-review', bogus: 1 } },
+    },
+    globalConfig: {
+      critiqueLoop: { delegate: { command: 'global-review' } },
+    },
+  });
+  assert.deepEqual(result, {
+    status: 'local-malformed',
+    source: 'repository-local',
+    reason: 'invalid-repository-local-delegate',
+  });
+});
+
+test('resolveEffectiveCritiqueLoopDelegate treats a malformed global fragment as absent (#2257)', () => {
+  const result = resolveEffectiveCritiqueLoopDelegate({
+    localConfig: {},
+    globalConfig: {
+      critiqueLoop: { delegate: { command: 'global-review', bogus: 1 } },
+    },
+  });
+  assert.deepEqual(result, { status: 'none', source: 'none' });
+});
+
+test('resolveEffectiveCritiqueLoopDelegate returns none when both layers are absent (#2257)', () => {
+  assert.deepEqual(resolveEffectiveCritiqueLoopDelegate({ localConfig: {} }), {
+    status: 'none',
+    source: 'none',
+  });
 });
 
 test('selectDesyncedIndex returns 0 for empty, singleton, or invalid bands', () => {

--- a/tests/policy-helpers.test.mts
+++ b/tests/policy-helpers.test.mts
@@ -498,6 +498,54 @@ test('resolveEffectiveCritiqueLoopDelegate fails closed on a non-object local cr
   });
 });
 
+test('inspectCritiqueLoopDelegateLayer treats an explicit invalid mode as malformed (#2257)', () => {
+  assert.deepEqual(
+    inspectCritiqueLoopDelegateLayer({
+      critiqueLoop: {
+        delegate: { command: 'review', mode: 'always' },
+      },
+    }),
+    {
+      status: 'malformed',
+      reason: 'invalid-repository-local-delegate',
+    },
+  );
+  assert.deepEqual(
+    inspectCritiqueLoopDelegateLayer({
+      critiqueLoop: {
+        delegate: { command: 'review', mode: 1 },
+      },
+    }),
+    {
+      status: 'malformed',
+      reason: 'invalid-repository-local-delegate',
+    },
+  );
+});
+
+test('resolveEffectiveCritiqueLoopDelegate does not inherit a global invalid mode (#2257)', () => {
+  const result = resolveEffectiveCritiqueLoopDelegate({
+    localConfig: {},
+    globalConfig: {
+      critiqueLoop: {
+        delegate: { command: 'global-review', mode: 'always' },
+      },
+    },
+  });
+  assert.deepEqual(result, { status: 'none', source: 'none' });
+});
+
+test('normalizePolicyConfig still fail-safes an invalid explicit mode to fallback (#2199)', () => {
+  assert.deepEqual(
+    normalizePolicyConfig({
+      critiqueLoop: {
+        delegate: { command: 'review', mode: 'always' },
+      },
+    }).critiqueLoop.delegate,
+    { command: 'review', mode: 'fallback' },
+  );
+});
+
 test('resolveEffectiveCritiqueLoopDelegate treats a malformed global fragment as absent (#2257)', () => {
   const result = resolveEffectiveCritiqueLoopDelegate({
     localConfig: {},

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -214,6 +214,10 @@ interface PolicyConfigFile {
   critiqueLoop?: {
     cPhaseLowSeveritySkipAfter?: number;
     e10NoProgressHoldAfter?: number;
+    delegate?: {
+      command: string;
+      mode?: 'fallback' | 'combined';
+    } | null;
   };
   reviewEscalation?: {
     changesRequestedFirstEscalation?: string;

--- a/tests/schema-validation.test.mts
+++ b/tests/schema-validation.test.mts
@@ -810,6 +810,16 @@ test('policy schema treats missing critiqueLoop.delegate as the fail-safe defaul
   assert.deepEqual(errors, []);
 });
 
+test('policy schema accepts critiqueLoop.delegate JSON null as the local disable sentinel (#2257)', () => {
+  const schema = loadJson('schemas/policy.schema.json');
+  const instance = JSON.parse(
+    JSON.stringify(loadJson('fixtures/schemas/policy.valid.json')),
+  );
+  instance.critiqueLoop = { delegate: null };
+  const errors = validate(instance, schema);
+  assert.deepEqual(errors, []);
+});
+
 test('policy schema rejects a whitespace-only branchPatterns entry', () => {
   const schema = loadJson('schemas/policy.schema.json');
   const instance = JSON.parse(


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Add an opt-in layered C1 critique-delegate resolver. A repository-local
object wins, an explicit local `null` disables inheritance, and a
user-global object is used only when local policy is absent. CI and
merge helpers keep the existing repository-local fail-safe and never
read `$HOME`.

## Linked issue

Closes #2257

## Follow-up issues (if any)

- [ ] issue `#2258` — regression coverage (already filed; blocked by this PR's issue)
- [ ] issue `#2259` — canonical and generated documentation (already filed; blocked by this PR's issue)

## Background / rationale (if material)

`normalizePolicyConfig()` stays repository-local so GitHub-hosted CI
cannot pick up an operator's home-directory reviewer. The new resolver
is a separate C1-local entry that reads
`$XDG_CONFIG_HOME/idd-skill/config.json`, then
`$HOME/.config/idd-skill/config.json`, and only the
`critiqueLoop.delegate` fragment.

A present-but-malformed local delegate (including a non-object
`critiqueLoop` container) is fail-closed and does not inherit the
global object. A missing or malformed global file is treated as absent.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional user-global policy support through standard XDG or home configuration locations.
  * Added effective critique-loop delegate resolution with local settings taking precedence over global settings.
  * Added explicit `null` configuration to disable the local delegate.
* **Bug Fixes**
  * Invalid or malformed configuration is safely ignored or fails closed without unexpectedly inheriting settings.
* **Tests**
  * Added coverage for configuration discovery, precedence, disabling, validation, and malformed policy handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->