### PR TITLE
feat(context-tax): add sample and snapshot schemas

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,6 +30,7 @@ scripts/cli-args.mjs linguist-generated=true
 scripts/code-span-wrap.mjs linguist-generated=true
 scripts/collaborator-permission.mjs linguist-generated=true
 scripts/consistency-helpers.mjs linguist-generated=true
+scripts/context-tax-core.mjs linguist-generated=true
 scripts/discover-orphan-filter.mjs linguist-generated=true
 scripts/discover-readiness-check.mjs linguist-generated=true
 scripts/discover-roadmap-graph.mjs linguist-generated=true

--- a/fixtures/schemas/context-tax-event.invalid.json
+++ b/fixtures/schemas/context-tax-event.invalid.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "event": "enter",
+  "stageId": "work",
+  "at": "2026-08-25T15:10:00Z",
+  "vendor": "claude",
+  "branch": "issue/2288-feat-context-tax-define-sample-snapshot"
+}

--- a/fixtures/schemas/context-tax-event.valid.json
+++ b/fixtures/schemas/context-tax-event.valid.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": 1,
+  "event": "enter",
+  "stageId": "work",
+  "at": "2026-08-25T15:10:00Z",
+  "vendor": "claude",
+  "vendorSessionId": "sess_opaque_2",
+  "issueNumber": 2288,
+  "usage": null
+}

--- a/fixtures/schemas/context-tax-sample.invalid.json
+++ b/fixtures/schemas/context-tax-sample.invalid.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "kind": "issue-loop",
+  "vendor": "grok",
+  "model": "grok-4.6",
+  "attribution": "marker-join",
+  "outcome": "merged",
+  "usage": {
+    "inputUncached": 1,
+    "cacheRead": 0,
+    "cacheCreation": 0,
+    "output": 1,
+    "reasoning": 0
+  },
+  "compactionCount": 0,
+  "startedAt": "2026-08-25T15:00:00Z",
+  "endedAt": "2026-08-25T16:00:00Z",
+  "vendorSessionId": "sess_opaque_1",
+  "cwd": "/home/me/project"
+}

--- a/fixtures/schemas/context-tax-sample.valid.json
+++ b/fixtures/schemas/context-tax-sample.valid.json
@@ -1,0 +1,39 @@
+{
+  "schemaVersion": 1,
+  "kind": "issue-loop",
+  "vendor": "grok",
+  "model": "grok-4.6",
+  "attribution": "marker-join",
+  "outcome": "merged",
+  "usage": {
+    "inputUncached": 1200,
+    "cacheRead": 800,
+    "cacheCreation": 100,
+    "output": 400,
+    "reasoning": 50
+  },
+  "compactionCount": 0,
+  "startedAt": "2026-08-25T15:00:00Z",
+  "endedAt": "2026-08-25T16:00:00Z",
+  "vendorSessionId": "sess_opaque_1",
+  "issueNumber": 2288,
+  "stages": [
+    {
+      "id": "discover",
+      "usage": {
+        "inputUncached": 200,
+        "cacheRead": 0,
+        "cacheCreation": 0,
+        "output": 40,
+        "reasoning": 0
+      }
+    }
+  ],
+  "claimId": "0b186d45-421e-4c2d-910e-930f922e3148",
+  "prNumber": 1,
+  "effort": "M",
+  "toolCallCount": 12,
+  "turnCount": 4,
+  "includesSubagents": false,
+  "ambiguous": false
+}

--- a/fixtures/schemas/context-tax-snapshot.invalid.json
+++ b/fixtures/schemas/context-tax-snapshot.invalid.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-25T16:00:00Z",
+  "minPublishableSamples": 10,
+  "minPublishableVendors": 2,
+  "publishable": false,
+  "sampleCount": 0,
+  "vendors": [],
+  "readmePath": "README.md"
+}

--- a/fixtures/schemas/context-tax-snapshot.valid.json
+++ b/fixtures/schemas/context-tax-snapshot.valid.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-25T16:00:00Z",
+  "minPublishableSamples": 10,
+  "minPublishableVendors": 2,
+  "publishable": false,
+  "sampleCount": 0,
+  "vendors": []
+}

--- a/schemas/context-tax-event.schema.json
+++ b/schemas/context-tax-event.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kurone-kito.github.io/idd-skill/schemas/context-tax-event.schema.json",
+  "title": "Context-tax phase event",
+  "description": "One explicit phase enter/exit line a later helper writes. Not a harvested vendor log.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "event", "stageId", "at", "vendor"],
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "enum": [1],
+      "description": "Literal schema version. Always 1 for this contract."
+    },
+    "event": {
+      "type": "string",
+      "enum": ["enter", "exit"],
+      "description": "Whether this line marks entering or leaving the stage."
+    },
+    "stageId": {
+      "type": "string",
+      "enum": [
+        "discover",
+        "claim",
+        "work",
+        "submit-pr",
+        "review",
+        "merge",
+        "cleanup"
+      ],
+      "description": "IDD stage this event belongs to."
+    },
+    "at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC timestamp of the enter or exit."
+    },
+    "vendor": {
+      "type": "string",
+      "enum": ["grok", "claude", "codex"],
+      "description": "Agent vendor writing the event."
+    },
+    "vendorSessionId": {
+      "type": ["string", "null"],
+      "description": "Opaque vendor session id when known. Never a filesystem path."
+    },
+    "issueNumber": {
+      "type": ["integer", "null"],
+      "exclusiveMinimum": 0,
+      "description": "Issue number when the event is issue-scoped."
+    },
+    "usage": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": [
+        "inputUncached",
+        "cacheRead",
+        "cacheCreation",
+        "output",
+        "reasoning"
+      ],
+      "description": "Optional token usage snapshot at this event.",
+      "properties": {
+        "inputUncached": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Uncached input tokens."
+        },
+        "cacheRead": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Cache-read tokens."
+        },
+        "cacheCreation": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Cache-creation tokens."
+        },
+        "output": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Output tokens."
+        },
+        "reasoning": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Reasoning tokens."
+        }
+      }
+    }
+  }
+}

--- a/schemas/context-tax-event.schema.json
+++ b/schemas/context-tax-event.schema.json
@@ -62,27 +62,27 @@
       "description": "Optional token usage snapshot at this event.",
       "properties": {
         "inputUncached": {
-          "type": "number",
+          "type": "integer",
           "minimum": 0,
           "description": "Uncached input tokens."
         },
         "cacheRead": {
-          "type": "number",
+          "type": "integer",
           "minimum": 0,
           "description": "Cache-read tokens."
         },
         "cacheCreation": {
-          "type": "number",
+          "type": "integer",
           "minimum": 0,
           "description": "Cache-creation tokens."
         },
         "output": {
-          "type": "number",
+          "type": "integer",
           "minimum": 0,
           "description": "Output tokens."
         },
         "reasoning": {
-          "type": "number",
+          "type": "integer",
           "minimum": 0,
           "description": "Reasoning tokens."
         }

--- a/schemas/context-tax-sample.schema.json
+++ b/schemas/context-tax-sample.schema.json
@@ -62,27 +62,27 @@
       "description": "Token usage for the whole sample. All counts are >= 0.",
       "properties": {
         "inputUncached": {
-          "type": "number",
+          "type": "integer",
           "minimum": 0,
           "description": "Uncached input tokens."
         },
         "cacheRead": {
-          "type": "number",
+          "type": "integer",
           "minimum": 0,
           "description": "Cache-read tokens."
         },
         "cacheCreation": {
-          "type": "number",
+          "type": "integer",
           "minimum": 0,
           "description": "Cache-creation tokens."
         },
         "output": {
-          "type": "number",
+          "type": "integer",
           "minimum": 0,
           "description": "Output tokens."
         },
         "reasoning": {
-          "type": "number",
+          "type": "integer",
           "minimum": 0,
           "description": "Reasoning tokens. 0 when the vendor has no signal."
         }
@@ -147,27 +147,27 @@
             "description": "Token usage for this stage.",
             "properties": {
               "inputUncached": {
-                "type": "number",
+                "type": "integer",
                 "minimum": 0,
                 "description": "Uncached input tokens."
               },
               "cacheRead": {
-                "type": "number",
+                "type": "integer",
                 "minimum": 0,
                 "description": "Cache-read tokens."
               },
               "cacheCreation": {
-                "type": "number",
+                "type": "integer",
                 "minimum": 0,
                 "description": "Cache-creation tokens."
               },
               "output": {
-                "type": "number",
+                "type": "integer",
                 "minimum": 0,
                 "description": "Output tokens."
               },
               "reasoning": {
-                "type": "number",
+                "type": "integer",
                 "minimum": 0,
                 "description": "Reasoning tokens."
               }

--- a/schemas/context-tax-sample.schema.json
+++ b/schemas/context-tax-sample.schema.json
@@ -1,0 +1,212 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kurone-kito.github.io/idd-skill/schemas/context-tax-sample.schema.json",
+  "title": "Context-tax sample",
+  "description": "One harvested IDD loop or unscoped session record. README aggregates consume only issue-loop samples.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "kind",
+    "vendor",
+    "model",
+    "attribution",
+    "outcome",
+    "usage",
+    "compactionCount",
+    "startedAt",
+    "endedAt",
+    "vendorSessionId"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "enum": [1],
+      "description": "Literal schema version. Always 1 for this contract."
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["issue-loop", "session"],
+      "description": "issue-loop is per-issue and README-publishable; session is unscoped history."
+    },
+    "vendor": {
+      "type": "string",
+      "enum": ["grok", "claude", "codex"],
+      "description": "Harvested agent vendor."
+    },
+    "model": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Vendor model identifier. Never a filesystem path."
+    },
+    "attribution": {
+      "type": "string",
+      "enum": ["marker-join", "phase-event", "session-unscoped"],
+      "description": "How this sample was joined to an issue, or session-unscoped when it was not."
+    },
+    "outcome": {
+      "type": "string",
+      "enum": ["merged", "aborted", "unclaimed", "human-handoff", "unknown"],
+      "description": "Terminal outcome of the harvested loop or session."
+    },
+    "usage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "inputUncached",
+        "cacheRead",
+        "cacheCreation",
+        "output",
+        "reasoning"
+      ],
+      "description": "Token usage for the whole sample. All counts are >= 0.",
+      "properties": {
+        "inputUncached": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Uncached input tokens."
+        },
+        "cacheRead": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Cache-read tokens."
+        },
+        "cacheCreation": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Cache-creation tokens."
+        },
+        "output": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Output tokens."
+        },
+        "reasoning": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Reasoning tokens. 0 when the vendor has no signal."
+        }
+      }
+    },
+    "compactionCount": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Compaction events in this sample. 0 when the vendor has no signal."
+    },
+    "startedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC start of the harvested window."
+    },
+    "endedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC end of the harvested window."
+    },
+    "vendorSessionId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Opaque vendor session id. Never a filesystem path."
+    },
+    "issueNumber": {
+      "type": "integer",
+      "exclusiveMinimum": 0,
+      "description": "Required on issue-loop samples. Optional on session samples."
+    },
+    "stages": {
+      "type": "array",
+      "description": "Per-stage usage. Required on issue-loop samples. Optional on session samples.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "usage"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "enum": [
+              "discover",
+              "claim",
+              "work",
+              "submit-pr",
+              "review",
+              "merge",
+              "cleanup"
+            ],
+            "description": "IDD stage this usage belongs to."
+          },
+          "usage": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "inputUncached",
+              "cacheRead",
+              "cacheCreation",
+              "output",
+              "reasoning"
+            ],
+            "description": "Token usage for this stage.",
+            "properties": {
+              "inputUncached": {
+                "type": "number",
+                "minimum": 0,
+                "description": "Uncached input tokens."
+              },
+              "cacheRead": {
+                "type": "number",
+                "minimum": 0,
+                "description": "Cache-read tokens."
+              },
+              "cacheCreation": {
+                "type": "number",
+                "minimum": 0,
+                "description": "Cache-creation tokens."
+              },
+              "output": {
+                "type": "number",
+                "minimum": 0,
+                "description": "Output tokens."
+              },
+              "reasoning": {
+                "type": "number",
+                "minimum": 0,
+                "description": "Reasoning tokens."
+              }
+            }
+          }
+        }
+      }
+    },
+    "claimId": {
+      "type": ["string", "null"],
+      "description": "Opaque claim-id when known. Null when unknown."
+    },
+    "prNumber": {
+      "type": ["integer", "null"],
+      "exclusiveMinimum": 0,
+      "description": "Linked PR number when known."
+    },
+    "effort": {
+      "type": ["string", "null"],
+      "enum": ["S", "M", "L", null],
+      "description": "Authored effort hint when known."
+    },
+    "toolCallCount": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "description": "Tool-call count when the vendor reports one."
+    },
+    "turnCount": {
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "description": "Turn count when the vendor reports one."
+    },
+    "includesSubagents": {
+      "type": "boolean",
+      "description": "True when harvested usage includes subagent work."
+    },
+    "ambiguous": {
+      "type": "boolean",
+      "description": "True when overlapping sessions share this issue; reporters drop these from medians."
+    }
+  }
+}

--- a/schemas/context-tax-snapshot.schema.json
+++ b/schemas/context-tax-snapshot.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kurone-kito.github.io/idd-skill/schemas/context-tax-snapshot.schema.json",
+  "title": "Context-tax snapshot",
+  "description": "Committed aggregates a later reporter renders into docs/README. This issue only describes the shape.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "generatedAt",
+    "minPublishableSamples",
+    "minPublishableVendors",
+    "publishable",
+    "sampleCount",
+    "vendors"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "type": "integer",
+      "enum": [1],
+      "description": "Literal schema version. Always 1 for this contract."
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "UTC time this snapshot was produced."
+    },
+    "minPublishableSamples": {
+      "type": "integer",
+      "enum": [10],
+      "description": "Publish-gate constant: at least 10 issue-loop samples."
+    },
+    "minPublishableVendors": {
+      "type": "integer",
+      "enum": [2],
+      "description": "Publish-gate constant: at least 2 distinct vendors."
+    },
+    "publishable": {
+      "type": "boolean",
+      "description": "True when sampleCount and vendors satisfy the publish-gate constants."
+    },
+    "sampleCount": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of issue-loop samples in this snapshot."
+    },
+    "vendors": {
+      "type": "array",
+      "description": "Distinct vendors represented in this snapshot.",
+      "items": {
+        "type": "string",
+        "enum": ["grok", "claude", "codex"],
+        "description": "A harvested agent vendor."
+      }
+    }
+  }
+}

--- a/scripts/context-tax-core.mjs
+++ b/scripts/context-tax-core.mjs
@@ -42,11 +42,13 @@ const DROPPED_KEYS = new Set([
  * Boundary-agnostic path detection: the POSIX/drive/dot-relative branch
  * requires only that the match not be glued to an alphanumeric run (no
  * delimiter whitelist -- ":", ",", ";", etc. all work without enumerating
- * each one); the UNC and `ghq/` branches have no boundary requirement at
- * all and match anywhere in the string.
+ * each one); the backslash-segment branch (single-leading-backslash
+ * Windows-root-relative paths and UNC paths alike -- both are just
+ * "backslash, segment, backslash, segment") and the `ghq/` branch have no
+ * boundary requirement at all and match anywhere in the string.
  */
 const PATH_LIKE =
-  /(?<![A-Za-z0-9])(?:\/[^\s"'`]+|[A-Za-z]:[\\/][^\s"'`]*|[.~]\/[^\s"'`]*)|\\\\[^\s\\]+\\[^\s\\]*|ghq\//i;
+  /(?<![A-Za-z0-9])(?:\/[^\s"'`]+|[A-Za-z]:[\\/][^\s"'`]*|[.~]\/[^\s"'`]*)|\\[^\s\\]+\\[^\s\\]*|ghq\//i;
 const SECRET_LIKE =
   /\b(?:ghp_|gho_|ghs_|ghu_|github_pat_|sk-|xox(?:b|a|p|r|s)-)[A-Za-z0-9_-]+/;
 /**

--- a/scripts/context-tax-core.mjs
+++ b/scripts/context-tax-core.mjs
@@ -75,8 +75,9 @@ function redactString(value) {
  * Drop or replace privacy-sensitive fields from an untrusted harvested
  * record. Absolute paths, secret-shaped strings, and known
  * prompt/assistant/tool-argument key names (including recognizable
- * compound variants) do not survive. This is a defense-in-depth net for
- * stray fields, not a substitute for an adapter choosing what to extract:
+ * compound variants) do not survive -- as values or as object keys. This
+ * is a defense-in-depth net for stray fields, not a substitute for an
+ * adapter choosing what to extract:
  * `ContextTaxSample`/`ContextTaxEvent` have no field for raw conversational
  * text, so a correctly built adapter never passes a role/message/tool-call
  * container through here in the first place.
@@ -95,7 +96,7 @@ export function redactContextTaxRecord(input) {
   }
   const out = {};
   for (const [key, value] of Object.entries(input)) {
-    if (isDroppedKey(key)) {
+    if (isDroppedKey(key) || redactString(key) === undefined) {
       continue;
     }
     const redacted = redactContextTaxRecord(value);

--- a/scripts/context-tax-core.mjs
+++ b/scripts/context-tax-core.mjs
@@ -37,8 +37,7 @@ const DROPPED_KEYS = new Set([
   'logpath',
   'home',
 ]);
-const PATH_LIKE =
-  /(?:^|[\s"'`=(])(?:\/(?:home|Users|tmp|var|opt|usr)\/|\w:\\|\\\\|[.~]\/|ghq\/|issue\/\d+-|\.issue-\d+-)/i;
+const PATH_LIKE = /(?:^|[\s"'`=(])(?:\/[^\s"'`]+|[A-Za-z]:\\|[.~]\/)|ghq\//i;
 const SECRET_LIKE =
   /\b(?:ghp_|gho_|ghs_|ghu_|github_pat_|sk-|xox(?:b|a|p|r|s)-)[A-Za-z0-9_-]+/;
 function isDroppedKey(key) {
@@ -81,17 +80,40 @@ export function redactContextTaxRecord(input) {
 }
 /**
  * Infer an issue number from a worktree or cwd *basename* only
- * (`issue/<n>-…` or `.issue-<n>-…`). A value that still contains a
- * path separator is treated as a path and ignored.
+ * (`issue-<n>-…` or `.issue-<n>-…`, including B1 `repo.issue-<n>-…`).
+ * A value that still contains a path separator is treated as a path
+ * and ignored.
  */
 export function inferIssueNumberFromBasename(basename) {
   if (basename.includes('/') || basename.includes('\\')) {
     return undefined;
   }
-  const match = basename.match(/issue[/.-](\d+)/);
+  const match = basename.match(/(?:^|\.)issue-(\d+)(?:-|$)/);
   if (!match) {
     return undefined;
   }
   const n = Number(match[1]);
   return Number.isInteger(n) && n > 0 ? n : undefined;
+}
+export function isIssueLoopSample(sample) {
+  return (
+    sample.kind === 'issue-loop' &&
+    typeof sample.issueNumber === 'number' &&
+    Array.isArray(sample.stages)
+  );
+}
+/**
+ * Enforce the issue-loop join contract the JSON Schema cannot express
+ * without oneOf. Session samples pass through.
+ */
+export function assertContextTaxSample(sample) {
+  if (sample.kind !== 'issue-loop') {
+    return;
+  }
+  if (typeof sample.issueNumber !== 'number' || sample.issueNumber <= 0) {
+    throw new Error('issue-loop sample requires a positive issueNumber');
+  }
+  if (!Array.isArray(sample.stages)) {
+    throw new Error('issue-loop sample requires stages');
+  }
 }

--- a/scripts/context-tax-core.mjs
+++ b/scripts/context-tax-core.mjs
@@ -25,6 +25,7 @@ const DROPPED_KEYS = new Set([
   'arguments',
   'toolarguments',
   'toolargs',
+  'toolinput',
   'filecontents',
   'filecontent',
   'cwd',
@@ -37,12 +38,28 @@ const DROPPED_KEYS = new Set([
   'logpath',
   'home',
 ]);
+/**
+ * Path detection is boundary-agnostic (no delimiter whitelist): a match
+ * simply must not be glued to an alphanumeric run, so it fires after any
+ * delimiter (":", ",", ";", ...) without enumerating them one by one.
+ */
 const PATH_LIKE =
-  /(?:^|[\s"'`=(:])(?:\/[^\s"'`]+|[A-Za-z]:[\\/][^\s"'`]*|[.~]\/[^\s"'`]*)|\\\\[^\s\\]+\\[^\s\\]*|ghq\//i;
+  /(?<![A-Za-z0-9])(?:\/[^\s"'`]+|[A-Za-z]:[\\/][^\s"'`]*|[.~]\/[^\s"'`]*)|\\\\[^\s\\]+\\[^\s\\]*|ghq\//i;
 const SECRET_LIKE =
   /\b(?:ghp_|gho_|ghs_|ghu_|github_pat_|sk-|xox(?:b|a|p|r|s)-)[A-Za-z0-9_-]+/;
+/**
+ * Match by substring, not exact key, so compound vendor field names
+ * (`systemPrompt`, `assistantMessage`, `toolInput`) are dropped without
+ * enumerating every variant of each sensitive keyword.
+ */
 function isDroppedKey(key) {
-  return DROPPED_KEYS.has(key.replace(/[_-]/g, '').toLowerCase());
+  const normalized = key.replace(/[_-]/g, '').toLowerCase();
+  for (const dropped of DROPPED_KEYS) {
+    if (normalized.includes(dropped)) {
+      return true;
+    }
+  }
+  return false;
 }
 function redactString(value) {
   if (PATH_LIKE.test(value) || SECRET_LIKE.test(value)) {

--- a/scripts/context-tax-core.mjs
+++ b/scripts/context-tax-core.mjs
@@ -155,12 +155,22 @@ export function assertContextTaxSample(sample) {
   }
 }
 /**
- * Enforce the distinct-vendors constraint the JSON Schema cannot express
- * (`uniqueItems` is outside `validate-schemas.mts`'s enforced keyword
- * subset).
+ * Enforce the constraints the JSON Schema cannot express: distinct
+ * `vendors` (`uniqueItems` is outside `validate-schemas.mts`'s enforced
+ * keyword subset), and that `publishable` agrees with the
+ * `sampleCount`/`vendors` gate the schema documents but cannot compare
+ * across fields on its own.
  */
 export function assertContextTaxSnapshot(snapshot) {
   if (new Set(snapshot.vendors).size !== snapshot.vendors.length) {
     throw new Error('snapshot vendors must be distinct');
+  }
+  const eligible =
+    snapshot.sampleCount >= snapshot.minPublishableSamples &&
+    snapshot.vendors.length >= snapshot.minPublishableVendors;
+  if (snapshot.publishable !== eligible) {
+    throw new Error(
+      'snapshot publishable must match the sampleCount/vendors gate',
+    );
   }
 }

--- a/scripts/context-tax-core.mjs
+++ b/scripts/context-tax-core.mjs
@@ -132,16 +132,19 @@ export function isIssueLoopSample(sample) {
 }
 /**
  * Enforce cross-field constraints the JSON Schema cannot express:
- * `endedAt` must not precede `startedAt` (any kind); the issue-loop join
- * contract without `oneOf` -- `issueNumber`/`stages` for `issue-loop`; and
- * that `attribution` agrees with `kind` (a `session-unscoped` sample was
- * never joined to an issue, so it cannot claim `issue-loop`, and vice
- * versa).
+ * `startedAt`/`endedAt` must both parse to a valid instant and `endedAt`
+ * must not precede `startedAt` (any kind); the issue-loop join contract
+ * without `oneOf` -- `issueNumber`/`stages` for `issue-loop`; and that
+ * `attribution` agrees with `kind` (a `session-unscoped` sample was never
+ * joined to an issue, so it cannot claim `issue-loop`, and vice versa).
  */
 export function assertContextTaxSample(sample) {
-  if (
-    new Date(sample.endedAt).getTime() < new Date(sample.startedAt).getTime()
-  ) {
+  const startedAtMs = new Date(sample.startedAt).getTime();
+  const endedAtMs = new Date(sample.endedAt).getTime();
+  if (!Number.isFinite(startedAtMs) || !Number.isFinite(endedAtMs)) {
+    throw new Error('sample startedAt/endedAt must be valid timestamps');
+  }
+  if (endedAtMs < startedAtMs) {
     throw new Error('sample endedAt must not precede startedAt');
   }
   if (sample.kind !== 'issue-loop') {

--- a/scripts/context-tax-core.mjs
+++ b/scripts/context-tax-core.mjs
@@ -122,10 +122,15 @@ export function isIssueLoopSample(sample) {
 }
 /**
  * Enforce the issue-loop join contract the JSON Schema cannot express
- * without oneOf. Session samples pass through.
+ * without oneOf: `issueNumber`/`stages` for `issue-loop`, and that
+ * `attribution` agrees with `kind` (a `session-unscoped` sample was never
+ * joined to an issue, so it cannot claim `issue-loop`, and vice versa).
  */
 export function assertContextTaxSample(sample) {
   if (sample.kind !== 'issue-loop') {
+    if (sample.attribution !== 'session-unscoped') {
+      throw new Error('session sample must use session-unscoped attribution');
+    }
     return;
   }
   if (!Number.isInteger(sample.issueNumber) || sample.issueNumber <= 0) {
@@ -133,5 +138,20 @@ export function assertContextTaxSample(sample) {
   }
   if (!Array.isArray(sample.stages)) {
     throw new Error('issue-loop sample requires stages');
+  }
+  if (sample.attribution === 'session-unscoped') {
+    throw new Error(
+      'issue-loop sample cannot use session-unscoped attribution',
+    );
+  }
+}
+/**
+ * Enforce the distinct-vendors constraint the JSON Schema cannot express
+ * (`uniqueItems` is outside `validate-schemas.mts`'s enforced keyword
+ * subset).
+ */
+export function assertContextTaxSnapshot(snapshot) {
+  if (new Set(snapshot.vendors).size !== snapshot.vendors.length) {
+    throw new Error('snapshot vendors must be distinct');
   }
 }

--- a/scripts/context-tax-core.mjs
+++ b/scripts/context-tax-core.mjs
@@ -130,12 +130,19 @@ export function isIssueLoopSample(sample) {
   );
 }
 /**
- * Enforce the issue-loop join contract the JSON Schema cannot express
- * without oneOf: `issueNumber`/`stages` for `issue-loop`, and that
- * `attribution` agrees with `kind` (a `session-unscoped` sample was never
- * joined to an issue, so it cannot claim `issue-loop`, and vice versa).
+ * Enforce cross-field constraints the JSON Schema cannot express:
+ * `endedAt` must not precede `startedAt` (any kind); the issue-loop join
+ * contract without `oneOf` -- `issueNumber`/`stages` for `issue-loop`; and
+ * that `attribution` agrees with `kind` (a `session-unscoped` sample was
+ * never joined to an issue, so it cannot claim `issue-loop`, and vice
+ * versa).
  */
 export function assertContextTaxSample(sample) {
+  if (
+    new Date(sample.endedAt).getTime() < new Date(sample.startedAt).getTime()
+  ) {
+    throw new Error('sample endedAt must not precede startedAt');
+  }
   if (sample.kind !== 'issue-loop') {
     if (sample.attribution !== 'session-unscoped') {
       throw new Error('session sample must use session-unscoped attribution');

--- a/scripts/context-tax-core.mjs
+++ b/scripts/context-tax-core.mjs
@@ -39,9 +39,11 @@ const DROPPED_KEYS = new Set([
   'home',
 ]);
 /**
- * Path detection is boundary-agnostic (no delimiter whitelist): a match
- * simply must not be glued to an alphanumeric run, so it fires after any
- * delimiter (":", ",", ";", ...) without enumerating them one by one.
+ * Boundary-agnostic path detection: the POSIX/drive/dot-relative branch
+ * requires only that the match not be glued to an alphanumeric run (no
+ * delimiter whitelist -- ":", ",", ";", etc. all work without enumerating
+ * each one); the UNC and `ghq/` branches have no boundary requirement at
+ * all and match anywhere in the string.
  */
 const PATH_LIKE =
   /(?<![A-Za-z0-9])(?:\/[^\s"'`]+|[A-Za-z]:[\\/][^\s"'`]*|[.~]\/[^\s"'`]*)|\\\\[^\s\\]+\\[^\s\\]*|ghq\//i;
@@ -69,8 +71,13 @@ function redactString(value) {
 }
 /**
  * Drop or replace privacy-sensitive fields from an untrusted harvested
- * record. Absolute paths, prompt/assistant/tool-argument text, file
- * contents, and secret-shaped strings do not survive.
+ * record. Absolute paths, secret-shaped strings, and known
+ * prompt/assistant/tool-argument key names (including recognizable
+ * compound variants) do not survive. This is a defense-in-depth net for
+ * stray fields, not a substitute for an adapter choosing what to extract:
+ * `ContextTaxSample`/`ContextTaxEvent` have no field for raw conversational
+ * text, so a correctly built adapter never passes a role/message/tool-call
+ * container through here in the first place.
  */
 export function redactContextTaxRecord(input) {
   if (typeof input === 'string') {

--- a/scripts/context-tax-core.mjs
+++ b/scripts/context-tax-core.mjs
@@ -37,7 +37,8 @@ const DROPPED_KEYS = new Set([
   'logpath',
   'home',
 ]);
-const PATH_LIKE = /(?:^|[\s"'`=(])(?:\/[^\s"'`]+|[A-Za-z]:\\|[.~]\/)|ghq\//i;
+const PATH_LIKE =
+  /(?:^|[\s"'`=(:])(?:\/[^\s"'`]+|[A-Za-z]:[\\/][^\s"'`]*|[.~]\/[^\s"'`]*)|\\\\[^\s\\]+\\[^\s\\]*|ghq\//i;
 const SECRET_LIKE =
   /\b(?:ghp_|gho_|ghs_|ghu_|github_pat_|sk-|xox(?:b|a|p|r|s)-)[A-Za-z0-9_-]+/;
 function isDroppedKey(key) {
@@ -110,7 +111,7 @@ export function assertContextTaxSample(sample) {
   if (sample.kind !== 'issue-loop') {
     return;
   }
-  if (typeof sample.issueNumber !== 'number' || sample.issueNumber <= 0) {
+  if (!Number.isInteger(sample.issueNumber) || sample.issueNumber <= 0) {
     throw new Error('issue-loop sample requires a positive issueNumber');
   }
   if (!Array.isArray(sample.stages)) {

--- a/scripts/context-tax-core.mjs
+++ b/scripts/context-tax-core.mjs
@@ -1,0 +1,97 @@
+// idd-generated-from: src/scripts/context-tax-core.mts
+//
+// The scripts/context-tax-core.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Shared context-tax measurement contracts (#2288). Source-repo only:
+// not HELPER_COMMANDS, not idd-template/. Later adapter/harvest issues
+// import this module. No CLI.
+/** IDD stages a harvested sample may break usage into. */
+export const CONTEXT_TAX_STAGE_IDS = [
+  'discover',
+  'claim',
+  'work',
+  'submit-pr',
+  'review',
+  'merge',
+  'cleanup',
+];
+const DROPPED_KEYS = new Set([
+  'prompt',
+  'assistant',
+  'messages',
+  'content',
+  'arguments',
+  'toolarguments',
+  'toolargs',
+  'filecontents',
+  'filecontent',
+  'cwd',
+  'path',
+  'filepath',
+  'pathname',
+  'branch',
+  'worktree',
+  'logfile',
+  'logpath',
+  'home',
+]);
+const PATH_LIKE =
+  /(?:^|[\s"'`=(])(?:\/(?:home|Users|tmp|var|opt|usr)\/|\w:\\|\\\\|[.~]\/|ghq\/|issue\/\d+-|\.issue-\d+-)/i;
+const SECRET_LIKE =
+  /\b(?:ghp_|gho_|ghs_|ghu_|github_pat_|sk-|xox(?:b|a|p|r|s)-)[A-Za-z0-9_-]+/;
+function isDroppedKey(key) {
+  return DROPPED_KEYS.has(key.replace(/[_-]/g, '').toLowerCase());
+}
+function redactString(value) {
+  if (PATH_LIKE.test(value) || SECRET_LIKE.test(value)) {
+    return undefined;
+  }
+  return value;
+}
+/**
+ * Drop or replace privacy-sensitive fields from an untrusted harvested
+ * record. Absolute paths, prompt/assistant/tool-argument text, file
+ * contents, and secret-shaped strings do not survive.
+ */
+export function redactContextTaxRecord(input) {
+  if (typeof input === 'string') {
+    return redactString(input);
+  }
+  if (input === null || typeof input !== 'object') {
+    return input;
+  }
+  if (Array.isArray(input)) {
+    return input
+      .map((item) => redactContextTaxRecord(item))
+      .filter((item) => item !== undefined);
+  }
+  const out = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (isDroppedKey(key)) {
+      continue;
+    }
+    const redacted = redactContextTaxRecord(value);
+    if (redacted !== undefined) {
+      out[key] = redacted;
+    }
+  }
+  return out;
+}
+/**
+ * Infer an issue number from a worktree or cwd *basename* only
+ * (`issue/<n>-…` or `.issue-<n>-…`). A value that still contains a
+ * path separator is treated as a path and ignored.
+ */
+export function inferIssueNumberFromBasename(basename) {
+  if (basename.includes('/') || basename.includes('\\')) {
+    return undefined;
+  }
+  const match = basename.match(/issue[/.-](\d+)/);
+  if (!match) {
+    return undefined;
+  }
+  const n = Number(match[1]);
+  return Number.isInteger(n) && n > 0 ? n : undefined;
+}

--- a/src/scripts/context-tax-core.mts
+++ b/src/scripts/context-tax-core.mts
@@ -163,11 +163,13 @@ const DROPPED_KEYS = new Set([
  * Boundary-agnostic path detection: the POSIX/drive/dot-relative branch
  * requires only that the match not be glued to an alphanumeric run (no
  * delimiter whitelist -- ":", ",", ";", etc. all work without enumerating
- * each one); the UNC and `ghq/` branches have no boundary requirement at
- * all and match anywhere in the string.
+ * each one); the backslash-segment branch (single-leading-backslash
+ * Windows-root-relative paths and UNC paths alike -- both are just
+ * "backslash, segment, backslash, segment") and the `ghq/` branch have no
+ * boundary requirement at all and match anywhere in the string.
  */
 const PATH_LIKE =
-  /(?<![A-Za-z0-9])(?:\/[^\s"'`]+|[A-Za-z]:[\\/][^\s"'`]*|[.~]\/[^\s"'`]*)|\\\\[^\s\\]+\\[^\s\\]*|ghq\//i;
+  /(?<![A-Za-z0-9])(?:\/[^\s"'`]+|[A-Za-z]:[\\/][^\s"'`]*|[.~]\/[^\s"'`]*)|\\[^\s\\]+\\[^\s\\]*|ghq\//i;
 
 const SECRET_LIKE =
   /\b(?:ghp_|gho_|ghs_|ghu_|github_pat_|sk-|xox(?:b|a|p|r|s)-)[A-Za-z0-9_-]+/;

--- a/src/scripts/context-tax-core.mts
+++ b/src/scripts/context-tax-core.mts
@@ -158,7 +158,8 @@ const DROPPED_KEYS = new Set([
   'home',
 ]);
 
-const PATH_LIKE = /(?:^|[\s"'`=(])(?:\/[^\s"'`]+|[A-Za-z]:\\|[.~]\/)|ghq\//i;
+const PATH_LIKE =
+  /(?:^|[\s"'`=(:])(?:\/[^\s"'`]+|[A-Za-z]:[\\/][^\s"'`]*|[.~]\/[^\s"'`]*)|\\\\[^\s\\]+\\[^\s\\]*|ghq\//i;
 
 const SECRET_LIKE =
   /\b(?:ghp_|gho_|ghs_|ghu_|github_pat_|sk-|xox(?:b|a|p|r|s)-)[A-Za-z0-9_-]+/;
@@ -242,7 +243,7 @@ export function assertContextTaxSample(sample: ContextTaxSample): void {
   if (sample.kind !== 'issue-loop') {
     return;
   }
-  if (typeof sample.issueNumber !== 'number' || sample.issueNumber <= 0) {
+  if (!Number.isInteger(sample.issueNumber) || sample.issueNumber <= 0) {
     throw new Error('issue-loop sample requires a positive issueNumber');
   }
   if (!Array.isArray(sample.stages)) {

--- a/src/scripts/context-tax-core.mts
+++ b/src/scripts/context-tax-core.mts
@@ -254,10 +254,15 @@ export function isIssueLoopSample(
 
 /**
  * Enforce the issue-loop join contract the JSON Schema cannot express
- * without oneOf. Session samples pass through.
+ * without oneOf: `issueNumber`/`stages` for `issue-loop`, and that
+ * `attribution` agrees with `kind` (a `session-unscoped` sample was never
+ * joined to an issue, so it cannot claim `issue-loop`, and vice versa).
  */
 export function assertContextTaxSample(sample: ContextTaxSample): void {
   if (sample.kind !== 'issue-loop') {
+    if (sample.attribution !== 'session-unscoped') {
+      throw new Error('session sample must use session-unscoped attribution');
+    }
     return;
   }
   if (!Number.isInteger(sample.issueNumber) || sample.issueNumber <= 0) {
@@ -265,5 +270,21 @@ export function assertContextTaxSample(sample: ContextTaxSample): void {
   }
   if (!Array.isArray(sample.stages)) {
     throw new Error('issue-loop sample requires stages');
+  }
+  if (sample.attribution === 'session-unscoped') {
+    throw new Error(
+      'issue-loop sample cannot use session-unscoped attribution',
+    );
+  }
+}
+
+/**
+ * Enforce the distinct-vendors constraint the JSON Schema cannot express
+ * (`uniqueItems` is outside `validate-schemas.mts`'s enforced keyword
+ * subset).
+ */
+export function assertContextTaxSnapshot(snapshot: ContextTaxSnapshot): void {
+  if (new Set(snapshot.vendors).size !== snapshot.vendors.length) {
+    throw new Error('snapshot vendors must be distinct');
   }
 }

--- a/src/scripts/context-tax-core.mts
+++ b/src/scripts/context-tax-core.mts
@@ -200,8 +200,9 @@ function redactString(value: string): string | undefined {
  * Drop or replace privacy-sensitive fields from an untrusted harvested
  * record. Absolute paths, secret-shaped strings, and known
  * prompt/assistant/tool-argument key names (including recognizable
- * compound variants) do not survive. This is a defense-in-depth net for
- * stray fields, not a substitute for an adapter choosing what to extract:
+ * compound variants) do not survive -- as values or as object keys. This
+ * is a defense-in-depth net for stray fields, not a substitute for an
+ * adapter choosing what to extract:
  * `ContextTaxSample`/`ContextTaxEvent` have no field for raw conversational
  * text, so a correctly built adapter never passes a role/message/tool-call
  * container through here in the first place.
@@ -220,7 +221,7 @@ export function redactContextTaxRecord(input: unknown): unknown {
   }
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
-    if (isDroppedKey(key)) {
+    if (isDroppedKey(key) || redactString(key) === undefined) {
       continue;
     }
     const redacted = redactContextTaxRecord(value);

--- a/src/scripts/context-tax-core.mts
+++ b/src/scripts/context-tax-core.mts
@@ -145,6 +145,7 @@ const DROPPED_KEYS = new Set([
   'arguments',
   'toolarguments',
   'toolargs',
+  'toolinput',
   'filecontents',
   'filecontent',
   'cwd',
@@ -158,14 +159,30 @@ const DROPPED_KEYS = new Set([
   'home',
 ]);
 
+/**
+ * Path detection is boundary-agnostic (no delimiter whitelist): a match
+ * simply must not be glued to an alphanumeric run, so it fires after any
+ * delimiter (":", ",", ";", ...) without enumerating them one by one.
+ */
 const PATH_LIKE =
-  /(?:^|[\s"'`=(:])(?:\/[^\s"'`]+|[A-Za-z]:[\\/][^\s"'`]*|[.~]\/[^\s"'`]*)|\\\\[^\s\\]+\\[^\s\\]*|ghq\//i;
+  /(?<![A-Za-z0-9])(?:\/[^\s"'`]+|[A-Za-z]:[\\/][^\s"'`]*|[.~]\/[^\s"'`]*)|\\\\[^\s\\]+\\[^\s\\]*|ghq\//i;
 
 const SECRET_LIKE =
   /\b(?:ghp_|gho_|ghs_|ghu_|github_pat_|sk-|xox(?:b|a|p|r|s)-)[A-Za-z0-9_-]+/;
 
+/**
+ * Match by substring, not exact key, so compound vendor field names
+ * (`systemPrompt`, `assistantMessage`, `toolInput`) are dropped without
+ * enumerating every variant of each sensitive keyword.
+ */
 function isDroppedKey(key: string): boolean {
-  return DROPPED_KEYS.has(key.replace(/[_-]/g, '').toLowerCase());
+  const normalized = key.replace(/[_-]/g, '').toLowerCase();
+  for (const dropped of DROPPED_KEYS) {
+    if (normalized.includes(dropped)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function redactString(value: string): string | undefined {

--- a/src/scripts/context-tax-core.mts
+++ b/src/scripts/context-tax-core.mts
@@ -288,12 +288,22 @@ export function assertContextTaxSample(sample: ContextTaxSample): void {
 }
 
 /**
- * Enforce the distinct-vendors constraint the JSON Schema cannot express
- * (`uniqueItems` is outside `validate-schemas.mts`'s enforced keyword
- * subset).
+ * Enforce the constraints the JSON Schema cannot express: distinct
+ * `vendors` (`uniqueItems` is outside `validate-schemas.mts`'s enforced
+ * keyword subset), and that `publishable` agrees with the
+ * `sampleCount`/`vendors` gate the schema documents but cannot compare
+ * across fields on its own.
  */
 export function assertContextTaxSnapshot(snapshot: ContextTaxSnapshot): void {
   if (new Set(snapshot.vendors).size !== snapshot.vendors.length) {
     throw new Error('snapshot vendors must be distinct');
+  }
+  const eligible =
+    snapshot.sampleCount >= snapshot.minPublishableSamples &&
+    snapshot.vendors.length >= snapshot.minPublishableVendors;
+  if (snapshot.publishable !== eligible) {
+    throw new Error(
+      'snapshot publishable must match the sampleCount/vendors gate',
+    );
   }
 }

--- a/src/scripts/context-tax-core.mts
+++ b/src/scripts/context-tax-core.mts
@@ -160,9 +160,11 @@ const DROPPED_KEYS = new Set([
 ]);
 
 /**
- * Path detection is boundary-agnostic (no delimiter whitelist): a match
- * simply must not be glued to an alphanumeric run, so it fires after any
- * delimiter (":", ",", ";", ...) without enumerating them one by one.
+ * Boundary-agnostic path detection: the POSIX/drive/dot-relative branch
+ * requires only that the match not be glued to an alphanumeric run (no
+ * delimiter whitelist -- ":", ",", ";", etc. all work without enumerating
+ * each one); the UNC and `ghq/` branches have no boundary requirement at
+ * all and match anywhere in the string.
  */
 const PATH_LIKE =
   /(?<![A-Za-z0-9])(?:\/[^\s"'`]+|[A-Za-z]:[\\/][^\s"'`]*|[.~]\/[^\s"'`]*)|\\\\[^\s\\]+\\[^\s\\]*|ghq\//i;
@@ -194,8 +196,13 @@ function redactString(value: string): string | undefined {
 
 /**
  * Drop or replace privacy-sensitive fields from an untrusted harvested
- * record. Absolute paths, prompt/assistant/tool-argument text, file
- * contents, and secret-shaped strings do not survive.
+ * record. Absolute paths, secret-shaped strings, and known
+ * prompt/assistant/tool-argument key names (including recognizable
+ * compound variants) do not survive. This is a defense-in-depth net for
+ * stray fields, not a substitute for an adapter choosing what to extract:
+ * `ContextTaxSample`/`ContextTaxEvent` have no field for raw conversational
+ * text, so a correctly built adapter never passes a role/message/tool-call
+ * container through here in the first place.
  */
 export function redactContextTaxRecord(input: unknown): unknown {
   if (typeof input === 'string') {

--- a/src/scripts/context-tax-core.mts
+++ b/src/scripts/context-tax-core.mts
@@ -1,0 +1,206 @@
+// idd-generated-from: src/scripts/context-tax-core.mts
+//
+// The scripts/context-tax-core.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Shared context-tax measurement contracts (#2288). Source-repo only:
+// not HELPER_COMMANDS, not idd-template/. Later adapter/harvest issues
+// import this module. No CLI.
+
+/** IDD stages a harvested sample may break usage into. */
+export const CONTEXT_TAX_STAGE_IDS = [
+  'discover',
+  'claim',
+  'work',
+  'submit-pr',
+  'review',
+  'merge',
+  'cleanup',
+] as const;
+
+export type ContextTaxStageId = (typeof CONTEXT_TAX_STAGE_IDS)[number];
+
+export type ContextTaxVendor = 'grok' | 'claude' | 'codex';
+
+export type ContextTaxKind = 'issue-loop' | 'session';
+
+export type ContextTaxAttribution =
+  | 'marker-join'
+  | 'phase-event'
+  | 'session-unscoped';
+
+export type ContextTaxOutcome =
+  | 'merged'
+  | 'aborted'
+  | 'unclaimed'
+  | 'human-handoff'
+  | 'unknown';
+
+export type ContextTaxEffort = 'S' | 'M' | 'L';
+
+/** Token usage. Every field is >= 0. */
+export interface ContextTaxUsage {
+  inputUncached: number;
+  cacheRead: number;
+  cacheCreation: number;
+  output: number;
+  reasoning: number;
+}
+
+export interface ContextTaxStageUsage {
+  id: ContextTaxStageId;
+  usage: ContextTaxUsage;
+}
+
+/** One harvested sample. Matches schemas/context-tax-sample.schema.json. */
+export interface ContextTaxSample {
+  schemaVersion: 1;
+  kind: ContextTaxKind;
+  vendor: ContextTaxVendor;
+  model: string;
+  attribution: ContextTaxAttribution;
+  outcome: ContextTaxOutcome;
+  usage: ContextTaxUsage;
+  compactionCount: number;
+  startedAt: string;
+  endedAt: string;
+  vendorSessionId: string;
+  issueNumber?: number;
+  stages?: readonly ContextTaxStageUsage[];
+  claimId?: string | null;
+  prNumber?: number | null;
+  effort?: ContextTaxEffort | null;
+  toolCallCount?: number | null;
+  turnCount?: number | null;
+  includesSubagents?: boolean;
+  ambiguous?: boolean;
+}
+
+/** One explicit phase enter/exit line. */
+export interface ContextTaxEvent {
+  schemaVersion: 1;
+  event: 'enter' | 'exit';
+  stageId: ContextTaxStageId;
+  at: string;
+  vendor: ContextTaxVendor;
+  vendorSessionId?: string | null;
+  issueNumber?: number | null;
+  usage?: ContextTaxUsage | null;
+}
+
+/** Committed aggregates a later reporter renders. */
+export interface ContextTaxSnapshot {
+  schemaVersion: 1;
+  generatedAt: string;
+  minPublishableSamples: 10;
+  minPublishableVendors: 2;
+  publishable: boolean;
+  sampleCount: number;
+  vendors: readonly ContextTaxVendor[];
+}
+
+/**
+ * Join hints an adapter may return. Only a numeric issue number is
+ * allowed -- never a path or branch string.
+ */
+export interface ContextTaxJoinHints {
+  issueNumber?: number;
+}
+
+export interface ContextTaxAdapterResult {
+  sample: ContextTaxSample;
+  joinHints?: ContextTaxJoinHints;
+}
+
+/** Vendor adapter. Later harvest issues implement this. */
+export interface ContextTaxVendorAdapter {
+  harvest(input: unknown): ContextTaxAdapterResult;
+}
+
+const DROPPED_KEYS = new Set([
+  'prompt',
+  'assistant',
+  'messages',
+  'content',
+  'arguments',
+  'toolarguments',
+  'toolargs',
+  'filecontents',
+  'filecontent',
+  'cwd',
+  'path',
+  'filepath',
+  'pathname',
+  'branch',
+  'worktree',
+  'logfile',
+  'logpath',
+  'home',
+]);
+
+const PATH_LIKE =
+  /(?:^|[\s"'`=(])(?:\/(?:home|Users|tmp|var|opt|usr)\/|\w:\\|\\\\|[.~]\/|ghq\/|issue\/\d+-|\.issue-\d+-)/i;
+
+const SECRET_LIKE =
+  /\b(?:ghp_|gho_|ghs_|ghu_|github_pat_|sk-|xox(?:b|a|p|r|s)-)[A-Za-z0-9_-]+/;
+
+function isDroppedKey(key: string): boolean {
+  return DROPPED_KEYS.has(key.replace(/[_-]/g, '').toLowerCase());
+}
+
+function redactString(value: string): string | undefined {
+  if (PATH_LIKE.test(value) || SECRET_LIKE.test(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * Drop or replace privacy-sensitive fields from an untrusted harvested
+ * record. Absolute paths, prompt/assistant/tool-argument text, file
+ * contents, and secret-shaped strings do not survive.
+ */
+export function redactContextTaxRecord(input: unknown): unknown {
+  if (typeof input === 'string') {
+    return redactString(input);
+  }
+  if (input === null || typeof input !== 'object') {
+    return input;
+  }
+  if (Array.isArray(input)) {
+    return input
+      .map((item) => redactContextTaxRecord(item))
+      .filter((item) => item !== undefined);
+  }
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
+    if (isDroppedKey(key)) {
+      continue;
+    }
+    const redacted = redactContextTaxRecord(value);
+    if (redacted !== undefined) {
+      out[key] = redacted;
+    }
+  }
+  return out;
+}
+
+/**
+ * Infer an issue number from a worktree or cwd *basename* only
+ * (`issue/<n>-…` or `.issue-<n>-…`). A value that still contains a
+ * path separator is treated as a path and ignored.
+ */
+export function inferIssueNumberFromBasename(
+  basename: string,
+): number | undefined {
+  if (basename.includes('/') || basename.includes('\\')) {
+    return undefined;
+  }
+  const match = basename.match(/issue[/.-](\d+)/);
+  if (!match) {
+    return undefined;
+  }
+  const n = Number(match[1]);
+  return Number.isInteger(n) && n > 0 ? n : undefined;
+}

--- a/src/scripts/context-tax-core.mts
+++ b/src/scripts/context-tax-core.mts
@@ -262,12 +262,19 @@ export function isIssueLoopSample(
 }
 
 /**
- * Enforce the issue-loop join contract the JSON Schema cannot express
- * without oneOf: `issueNumber`/`stages` for `issue-loop`, and that
- * `attribution` agrees with `kind` (a `session-unscoped` sample was never
- * joined to an issue, so it cannot claim `issue-loop`, and vice versa).
+ * Enforce cross-field constraints the JSON Schema cannot express:
+ * `endedAt` must not precede `startedAt` (any kind); the issue-loop join
+ * contract without `oneOf` -- `issueNumber`/`stages` for `issue-loop`; and
+ * that `attribution` agrees with `kind` (a `session-unscoped` sample was
+ * never joined to an issue, so it cannot claim `issue-loop`, and vice
+ * versa).
  */
 export function assertContextTaxSample(sample: ContextTaxSample): void {
+  if (
+    new Date(sample.endedAt).getTime() < new Date(sample.startedAt).getTime()
+  ) {
+    throw new Error('sample endedAt must not precede startedAt');
+  }
   if (sample.kind !== 'issue-loop') {
     if (sample.attribution !== 'session-unscoped') {
       throw new Error('session sample must use session-unscoped attribution');

--- a/src/scripts/context-tax-core.mts
+++ b/src/scripts/context-tax-core.mts
@@ -53,10 +53,8 @@ export interface ContextTaxStageUsage {
   usage: ContextTaxUsage;
 }
 
-/** One harvested sample. Matches schemas/context-tax-sample.schema.json. */
-export interface ContextTaxSample {
+interface ContextTaxSampleBase {
   schemaVersion: 1;
-  kind: ContextTaxKind;
   vendor: ContextTaxVendor;
   model: string;
   attribution: ContextTaxAttribution;
@@ -66,8 +64,6 @@ export interface ContextTaxSample {
   startedAt: string;
   endedAt: string;
   vendorSessionId: string;
-  issueNumber?: number;
-  stages?: readonly ContextTaxStageUsage[];
   claimId?: string | null;
   prNumber?: number | null;
   effort?: ContextTaxEffort | null;
@@ -76,6 +72,29 @@ export interface ContextTaxSample {
   includesSubagents?: boolean;
   ambiguous?: boolean;
 }
+
+/** Per-issue harvested sample. issueNumber and stages are required. */
+export interface ContextTaxIssueLoopSample extends ContextTaxSampleBase {
+  kind: 'issue-loop';
+  issueNumber: number;
+  stages: readonly ContextTaxStageUsage[];
+}
+
+/** Unscoped session sample. Join fields stay optional. */
+export interface ContextTaxSessionSample extends ContextTaxSampleBase {
+  kind: 'session';
+  issueNumber?: number;
+  stages?: readonly ContextTaxStageUsage[];
+}
+
+/**
+ * One harvested sample. Matches schemas/context-tax-sample.schema.json.
+ * JSON Schema cannot express the issue-loop conditional without oneOf;
+ * the TypeScript union and assertContextTaxSample enforce it.
+ */
+export type ContextTaxSample =
+  | ContextTaxIssueLoopSample
+  | ContextTaxSessionSample;
 
 /** One explicit phase enter/exit line. */
 export interface ContextTaxEvent {
@@ -139,8 +158,7 @@ const DROPPED_KEYS = new Set([
   'home',
 ]);
 
-const PATH_LIKE =
-  /(?:^|[\s"'`=(])(?:\/(?:home|Users|tmp|var|opt|usr)\/|\w:\\|\\\\|[.~]\/|ghq\/|issue\/\d+-|\.issue-\d+-)/i;
+const PATH_LIKE = /(?:^|[\s"'`=(])(?:\/[^\s"'`]+|[A-Za-z]:\\|[.~]\/)|ghq\//i;
 
 const SECRET_LIKE =
   /\b(?:ghp_|gho_|ghs_|ghu_|github_pat_|sk-|xox(?:b|a|p|r|s)-)[A-Za-z0-9_-]+/;
@@ -188,8 +206,9 @@ export function redactContextTaxRecord(input: unknown): unknown {
 
 /**
  * Infer an issue number from a worktree or cwd *basename* only
- * (`issue/<n>-…` or `.issue-<n>-…`). A value that still contains a
- * path separator is treated as a path and ignored.
+ * (`issue-<n>-…` or `.issue-<n>-…`, including B1 `repo.issue-<n>-…`).
+ * A value that still contains a path separator is treated as a path
+ * and ignored.
  */
 export function inferIssueNumberFromBasename(
   basename: string,
@@ -197,10 +216,36 @@ export function inferIssueNumberFromBasename(
   if (basename.includes('/') || basename.includes('\\')) {
     return undefined;
   }
-  const match = basename.match(/issue[/.-](\d+)/);
+  const match = basename.match(/(?:^|\.)issue-(\d+)(?:-|$)/);
   if (!match) {
     return undefined;
   }
   const n = Number(match[1]);
   return Number.isInteger(n) && n > 0 ? n : undefined;
+}
+
+export function isIssueLoopSample(
+  sample: ContextTaxSample,
+): sample is ContextTaxIssueLoopSample {
+  return (
+    sample.kind === 'issue-loop' &&
+    typeof sample.issueNumber === 'number' &&
+    Array.isArray(sample.stages)
+  );
+}
+
+/**
+ * Enforce the issue-loop join contract the JSON Schema cannot express
+ * without oneOf. Session samples pass through.
+ */
+export function assertContextTaxSample(sample: ContextTaxSample): void {
+  if (sample.kind !== 'issue-loop') {
+    return;
+  }
+  if (typeof sample.issueNumber !== 'number' || sample.issueNumber <= 0) {
+    throw new Error('issue-loop sample requires a positive issueNumber');
+  }
+  if (!Array.isArray(sample.stages)) {
+    throw new Error('issue-loop sample requires stages');
+  }
 }

--- a/src/scripts/context-tax-core.mts
+++ b/src/scripts/context-tax-core.mts
@@ -264,16 +264,19 @@ export function isIssueLoopSample(
 
 /**
  * Enforce cross-field constraints the JSON Schema cannot express:
- * `endedAt` must not precede `startedAt` (any kind); the issue-loop join
- * contract without `oneOf` -- `issueNumber`/`stages` for `issue-loop`; and
- * that `attribution` agrees with `kind` (a `session-unscoped` sample was
- * never joined to an issue, so it cannot claim `issue-loop`, and vice
- * versa).
+ * `startedAt`/`endedAt` must both parse to a valid instant and `endedAt`
+ * must not precede `startedAt` (any kind); the issue-loop join contract
+ * without `oneOf` -- `issueNumber`/`stages` for `issue-loop`; and that
+ * `attribution` agrees with `kind` (a `session-unscoped` sample was never
+ * joined to an issue, so it cannot claim `issue-loop`, and vice versa).
  */
 export function assertContextTaxSample(sample: ContextTaxSample): void {
-  if (
-    new Date(sample.endedAt).getTime() < new Date(sample.startedAt).getTime()
-  ) {
+  const startedAtMs = new Date(sample.startedAt).getTime();
+  const endedAtMs = new Date(sample.endedAt).getTime();
+  if (!Number.isFinite(startedAtMs) || !Number.isFinite(endedAtMs)) {
+    throw new Error('sample startedAt/endedAt must be valid timestamps');
+  }
+  if (endedAtMs < startedAtMs) {
     throw new Error('sample endedAt must not precede startedAt');
   }
   if (sample.kind !== 'issue-loop') {

--- a/tests/context-tax-core.test.mts
+++ b/tests/context-tax-core.test.mts
@@ -143,6 +143,18 @@ test('redaction drops compound prompt/assistant/tool-input field names', () => {
   assert.equal(clean.inputUncached, 5);
 });
 
+test('redaction drops single-leading-backslash Windows-root-relative paths', () => {
+  const dirty = {
+    rooted: String.raw`\Users\alice\private.ts`,
+    system: String.raw`\Windows\System32\config\SAM`,
+    keep: 'ok',
+  };
+  const clean = redactContextTaxRecord(dirty) as Record<string, unknown>;
+  assert.equal(clean.rooted, undefined);
+  assert.equal(clean.system, undefined);
+  assert.equal(clean.keep, 'ok');
+});
+
 test('assertContextTaxSample couples attribution to kind', () => {
   const issueLoop: ContextTaxSample = {
     schemaVersion: 1,

--- a/tests/context-tax-core.test.mts
+++ b/tests/context-tax-core.test.mts
@@ -217,6 +217,32 @@ test('assertContextTaxSnapshot rejects duplicate vendors', () => {
   );
 });
 
+test('assertContextTaxSnapshot requires publishable to match the sample/vendor gate', () => {
+  const eligible: ContextTaxSnapshot = {
+    schemaVersion: 1,
+    generatedAt: '2026-08-25T00:00:00Z',
+    minPublishableSamples: 10,
+    minPublishableVendors: 2,
+    publishable: true,
+    sampleCount: 10,
+    vendors: ['grok', 'claude'],
+  };
+  assert.doesNotThrow(() => assertContextTaxSnapshot(eligible));
+  assert.throws(
+    () =>
+      assertContextTaxSnapshot({
+        ...eligible,
+        publishable: true,
+        sampleCount: 3,
+      }),
+    /snapshot publishable must match the sampleCount\/vendors gate/,
+  );
+  assert.throws(
+    () => assertContextTaxSnapshot({ ...eligible, publishable: false }),
+    /snapshot publishable must match the sampleCount\/vendors gate/,
+  );
+});
+
 test('assertContextTaxSample rejects a non-integer issueNumber', () => {
   const base: ContextTaxSample = {
     schemaVersion: 1,

--- a/tests/context-tax-core.test.mts
+++ b/tests/context-tax-core.test.mts
@@ -115,6 +115,32 @@ test('redaction drops absolute paths preceded by a delimiter other than whitespa
   assert.equal(clean.keep, 'ok');
 });
 
+test('redaction drops absolute paths after any delimiter, not just a whitelisted set', () => {
+  const dirty = {
+    csvNote: 'note,/etc/shadow',
+    semicolonNote: 'a;/etc/shadow',
+    keep: 'ok',
+  };
+  const clean = redactContextTaxRecord(dirty) as Record<string, unknown>;
+  assert.equal(clean.csvNote, undefined);
+  assert.equal(clean.semicolonNote, undefined);
+  assert.equal(clean.keep, 'ok');
+});
+
+test('redaction drops compound prompt/assistant/tool-input field names', () => {
+  const dirty = {
+    systemPrompt: 'you are a helpful assistant',
+    assistantMessage: 'sure, here is the answer',
+    toolInput: '{"query": "secret"}',
+    inputUncached: 5,
+  };
+  const clean = redactContextTaxRecord(dirty) as Record<string, unknown>;
+  assert.equal(clean.systemPrompt, undefined);
+  assert.equal(clean.assistantMessage, undefined);
+  assert.equal(clean.toolInput, undefined);
+  assert.equal(clean.inputUncached, 5);
+});
+
 test('assertContextTaxSample rejects a non-integer issueNumber', () => {
   const base: ContextTaxSample = {
     schemaVersion: 1,

--- a/tests/context-tax-core.test.mts
+++ b/tests/context-tax-core.test.mts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  CONTEXT_TAX_STAGE_IDS,
+  type ContextTaxVendorAdapter,
+  inferIssueNumberFromBasename,
+  redactContextTaxRecord,
+} from '../src/scripts/context-tax-core.mts';
+import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
+
+test('stage id list is the seven IDD stages', () => {
+  assert.deepEqual(
+    [...CONTEXT_TAX_STAGE_IDS],
+    ['discover', 'claim', 'work', 'submit-pr', 'review', 'merge', 'cleanup'],
+  );
+});
+
+test('redaction drops a home path and a prompt string', () => {
+  const dirty = {
+    schemaVersion: 1,
+    vendor: 'grok',
+    cwd: '/home/kurone-kito/ghq/github.com/kurone-kito/idd-skill',
+    prompt: 'please merge this PR with these secrets',
+    model: 'grok-4.6',
+    usage: {
+      inputUncached: 1,
+      cacheRead: 0,
+      cacheCreation: 0,
+      output: 1,
+      reasoning: 0,
+    },
+  };
+  const clean = redactContextTaxRecord(dirty) as Record<string, unknown>;
+  const serialized = JSON.stringify(clean);
+  assert.equal(clean.cwd, undefined);
+  assert.equal(clean.prompt, undefined);
+  assert.equal(clean.vendor, 'grok');
+  assert.equal(clean.model, 'grok-4.6');
+  assert.doesNotMatch(serialized, /\/home\//);
+  assert.doesNotMatch(serialized, /please merge this PR/);
+});
+
+test('redaction strips path-like and secret-shaped strings in nested values', () => {
+  const dirty = {
+    vendorSessionId: 'sess_ok',
+    notes: 'cloned under /Users/me/ghq/github.com/acme/app',
+    token: 'ghp_abcdefghijklmnopqrstuvwx',
+    nested: { filePath: '/tmp/worktree/issue-12-foo', keep: 2 },
+  };
+  const clean = redactContextTaxRecord(dirty) as Record<string, unknown>;
+  const serialized = JSON.stringify(clean);
+  assert.equal(clean.vendorSessionId, 'sess_ok');
+  assert.equal(clean.notes, undefined);
+  assert.equal(clean.token, undefined);
+  assert.equal((clean.nested as Record<string, unknown>).filePath, undefined);
+  assert.equal((clean.nested as Record<string, unknown>).keep, 2);
+  assert.doesNotMatch(serialized, /ghq/);
+  assert.doesNotMatch(serialized, /ghp_/);
+});
+
+test('inferIssueNumberFromBasename accepts only a basename, never a path', () => {
+  assert.equal(
+    inferIssueNumberFromBasename(
+      'issue-2288-feat-context-tax-define-sample-snapshot',
+    ),
+    2288,
+  );
+  assert.equal(
+    inferIssueNumberFromBasename(
+      '.issue-2288-feat-context-tax-define-sample-snapshot',
+    ),
+    2288,
+  );
+  assert.equal(
+    inferIssueNumberFromBasename(
+      'idd-skill.issue-2288-feat-context-tax-define-sample-snapshot',
+    ),
+    2288,
+  );
+  assert.equal(
+    inferIssueNumberFromBasename(
+      '/home/me/ghq/github.com/acme/idd-skill.issue-2288-feat',
+    ),
+    undefined,
+  );
+});
+
+test('adapter interface is implementable without a CLI', () => {
+  const adapter: ContextTaxVendorAdapter = {
+    harvest() {
+      return {
+        sample: {
+          schemaVersion: 1,
+          kind: 'session',
+          vendor: 'codex',
+          model: 'gpt-test',
+          attribution: 'session-unscoped',
+          outcome: 'unknown',
+          usage: {
+            inputUncached: 0,
+            cacheRead: 0,
+            cacheCreation: 0,
+            output: 0,
+            reasoning: 0,
+          },
+          compactionCount: 0,
+          startedAt: '2026-08-25T00:00:00Z',
+          endedAt: '2026-08-25T00:01:00Z',
+          vendorSessionId: 'sess',
+        },
+        joinHints: { issueNumber: 2288 },
+      };
+    },
+  };
+  const result = adapter.harvest({});
+  assert.equal(result.sample.kind, 'session');
+  assert.equal(result.joinHints?.issueNumber, 2288);
+  assert.equal(Object.hasOwn(result.joinHints ?? {}, 'path'), false);
+});
+
+test('committed sample fixture validates against the sample schema', () => {
+  const errors = validate(
+    loadJson('fixtures/schemas/context-tax-sample.valid.json'),
+    loadJson('schemas/context-tax-sample.schema.json'),
+  );
+  assert.deepEqual(errors, []);
+});

--- a/tests/context-tax-core.test.mts
+++ b/tests/context-tax-core.test.mts
@@ -99,6 +99,53 @@ test('redaction drops unlisted POSIX absolute paths', () => {
   assert.equal(clean.keep, 'ok');
 });
 
+test('redaction drops absolute paths preceded by a delimiter other than whitespace/quote', () => {
+  const dirty = {
+    cwdNote: 'cwd:/workspace/acme/private.ts',
+    fileUrl: 'file:///etc/passwd',
+    uncPath: String.raw`\\server\share\private.txt`,
+    winNote: 'path:C:\\Users\\me',
+    keep: 'ok',
+  };
+  const clean = redactContextTaxRecord(dirty) as Record<string, unknown>;
+  assert.equal(clean.cwdNote, undefined);
+  assert.equal(clean.fileUrl, undefined);
+  assert.equal(clean.uncPath, undefined);
+  assert.equal(clean.winNote, undefined);
+  assert.equal(clean.keep, 'ok');
+});
+
+test('assertContextTaxSample rejects a non-integer issueNumber', () => {
+  const base: ContextTaxSample = {
+    schemaVersion: 1,
+    kind: 'issue-loop',
+    vendor: 'codex',
+    model: 'gpt-test',
+    attribution: 'marker-join',
+    outcome: 'unknown',
+    usage: {
+      inputUncached: 0,
+      cacheRead: 0,
+      cacheCreation: 0,
+      output: 0,
+      reasoning: 0,
+    },
+    compactionCount: 0,
+    startedAt: '2026-08-25T00:00:00Z',
+    endedAt: '2026-08-25T00:01:00Z',
+    vendorSessionId: 'sess',
+    issueNumber: 2288,
+    stages: [],
+  };
+  assert.doesNotThrow(() => assertContextTaxSample(base));
+  for (const issueNumber of [0.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+    assert.throws(
+      () => assertContextTaxSample({ ...base, issueNumber }),
+      /issue-loop sample requires a positive issueNumber/,
+    );
+  }
+});
+
 test('assertContextTaxSample requires join fields on issue-loop samples', () => {
   const session: ContextTaxSample = {
     schemaVersion: 1,

--- a/tests/context-tax-core.test.mts
+++ b/tests/context-tax-core.test.mts
@@ -242,6 +242,14 @@ test('assertContextTaxSample rejects endedAt preceding startedAt', () => {
       endedAt: '2026-08-25T00:01:00Z',
     }),
   );
+  assert.throws(
+    () => assertContextTaxSample({ ...session, startedAt: 'not-a-date' }),
+    /sample startedAt\/endedAt must be valid timestamps/,
+  );
+  assert.throws(
+    () => assertContextTaxSample({ ...session, endedAt: 'not-a-date' }),
+    /sample startedAt\/endedAt must be valid timestamps/,
+  );
 });
 
 test('assertContextTaxSnapshot rejects duplicate vendors', () => {

--- a/tests/context-tax-core.test.mts
+++ b/tests/context-tax-core.test.mts
@@ -200,6 +200,39 @@ test('assertContextTaxSample couples attribution to kind', () => {
   );
 });
 
+test('assertContextTaxSample rejects endedAt preceding startedAt', () => {
+  const session: ContextTaxSample = {
+    schemaVersion: 1,
+    kind: 'session',
+    vendor: 'codex',
+    model: 'gpt-test',
+    attribution: 'session-unscoped',
+    outcome: 'unknown',
+    usage: {
+      inputUncached: 0,
+      cacheRead: 0,
+      cacheCreation: 0,
+      output: 0,
+      reasoning: 0,
+    },
+    compactionCount: 0,
+    startedAt: '2026-08-25T00:01:00Z',
+    endedAt: '2026-08-25T00:00:00Z',
+    vendorSessionId: 'sess',
+  };
+  assert.throws(
+    () => assertContextTaxSample(session),
+    /sample endedAt must not precede startedAt/,
+  );
+  assert.doesNotThrow(() =>
+    assertContextTaxSample({
+      ...session,
+      startedAt: '2026-08-25T00:00:00Z',
+      endedAt: '2026-08-25T00:01:00Z',
+    }),
+  );
+});
+
 test('assertContextTaxSnapshot rejects duplicate vendors', () => {
   const snapshot: ContextTaxSnapshot = {
     schemaVersion: 1,

--- a/tests/context-tax-core.test.mts
+++ b/tests/context-tax-core.test.mts
@@ -3,8 +3,10 @@ import { test } from 'node:test';
 
 import {
   assertContextTaxSample,
+  assertContextTaxSnapshot,
   CONTEXT_TAX_STAGE_IDS,
   type ContextTaxSample,
+  type ContextTaxSnapshot,
   type ContextTaxVendorAdapter,
   inferIssueNumberFromBasename,
   redactContextTaxRecord,
@@ -139,6 +141,68 @@ test('redaction drops compound prompt/assistant/tool-input field names', () => {
   assert.equal(clean.assistantMessage, undefined);
   assert.equal(clean.toolInput, undefined);
   assert.equal(clean.inputUncached, 5);
+});
+
+test('assertContextTaxSample couples attribution to kind', () => {
+  const issueLoop: ContextTaxSample = {
+    schemaVersion: 1,
+    kind: 'issue-loop',
+    vendor: 'codex',
+    model: 'gpt-test',
+    attribution: 'marker-join',
+    outcome: 'unknown',
+    usage: {
+      inputUncached: 0,
+      cacheRead: 0,
+      cacheCreation: 0,
+      output: 0,
+      reasoning: 0,
+    },
+    compactionCount: 0,
+    startedAt: '2026-08-25T00:00:00Z',
+    endedAt: '2026-08-25T00:01:00Z',
+    vendorSessionId: 'sess',
+    issueNumber: 2288,
+    stages: [],
+  };
+  assert.doesNotThrow(() => assertContextTaxSample(issueLoop));
+  assert.throws(
+    () =>
+      assertContextTaxSample({
+        ...issueLoop,
+        attribution: 'session-unscoped',
+      }),
+    /issue-loop sample cannot use session-unscoped attribution/,
+  );
+  const session: ContextTaxSample = {
+    ...issueLoop,
+    kind: 'session',
+    issueNumber: undefined,
+    stages: undefined,
+    attribution: 'session-unscoped',
+  };
+  assert.doesNotThrow(() => assertContextTaxSample(session));
+  assert.throws(
+    () => assertContextTaxSample({ ...session, attribution: 'marker-join' }),
+    /session sample must use session-unscoped attribution/,
+  );
+});
+
+test('assertContextTaxSnapshot rejects duplicate vendors', () => {
+  const snapshot: ContextTaxSnapshot = {
+    schemaVersion: 1,
+    generatedAt: '2026-08-25T00:00:00Z',
+    minPublishableSamples: 10,
+    minPublishableVendors: 2,
+    publishable: false,
+    sampleCount: 3,
+    vendors: ['grok', 'claude'],
+  };
+  assert.doesNotThrow(() => assertContextTaxSnapshot(snapshot));
+  assert.throws(
+    () => assertContextTaxSnapshot({ ...snapshot, vendors: ['grok', 'grok'] }),
+    /snapshot vendors must be distinct/,
+  );
 });
 
 test('assertContextTaxSample rejects a non-integer issueNumber', () => {

--- a/tests/context-tax-core.test.mts
+++ b/tests/context-tax-core.test.mts
@@ -143,6 +143,17 @@ test('redaction drops compound prompt/assistant/tool-input field names', () => {
   assert.equal(clean.inputUncached, 5);
 });
 
+test('redaction drops path-like and secret-shaped object keys', () => {
+  const dirty = {
+    '/workspace/acme/private.ts': 3,
+    'C:\\Users\\alice\\secret.ts': 1,
+    keep: 'ok',
+  };
+  const clean = redactContextTaxRecord(dirty) as Record<string, unknown>;
+  assert.equal(Object.keys(clean).length, 1);
+  assert.equal(clean.keep, 'ok');
+});
+
 test('redaction drops single-leading-backslash Windows-root-relative paths', () => {
   const dirty = {
     rooted: String.raw`\Users\alice\private.ts`,

--- a/tests/context-tax-core.test.mts
+++ b/tests/context-tax-core.test.mts
@@ -2,7 +2,9 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  assertContextTaxSample,
   CONTEXT_TAX_STAGE_IDS,
+  type ContextTaxSample,
   type ContextTaxVendorAdapter,
   inferIssueNumberFromBasename,
   redactContextTaxRecord,
@@ -83,6 +85,48 @@ test('inferIssueNumberFromBasename accepts only a basename, never a path', () =>
       '/home/me/ghq/github.com/acme/idd-skill.issue-2288-feat',
     ),
     undefined,
+  );
+  assert.equal(
+    inferIssueNumberFromBasename('nonissue-123-unrelated'),
+    undefined,
+  );
+});
+
+test('redaction drops unlisted POSIX absolute paths', () => {
+  const dirty = { leaked: '/workspace/acme/private.ts', keep: 'ok' };
+  const clean = redactContextTaxRecord(dirty) as Record<string, unknown>;
+  assert.equal(clean.leaked, undefined);
+  assert.equal(clean.keep, 'ok');
+});
+
+test('assertContextTaxSample requires join fields on issue-loop samples', () => {
+  const session: ContextTaxSample = {
+    schemaVersion: 1,
+    kind: 'session',
+    vendor: 'codex',
+    model: 'gpt-test',
+    attribution: 'session-unscoped',
+    outcome: 'unknown',
+    usage: {
+      inputUncached: 0,
+      cacheRead: 0,
+      cacheCreation: 0,
+      output: 0,
+      reasoning: 0,
+    },
+    compactionCount: 0,
+    startedAt: '2026-08-25T00:00:00Z',
+    endedAt: '2026-08-25T00:01:00Z',
+    vendorSessionId: 'sess',
+  };
+  assert.doesNotThrow(() => assertContextTaxSample(session));
+  const incomplete = {
+    ...session,
+    kind: 'issue-loop',
+  } as ContextTaxSample;
+  assert.throws(
+    () => assertContextTaxSample(incomplete),
+    /issue-loop sample requires a positive issueNumber/,
   );
 });
 

--- a/tests/schema-output-roundtrip.test.mts
+++ b/tests/schema-output-roundtrip.test.mts
@@ -103,6 +103,30 @@ const SCHEMA_OUTPUT_COVERAGE: CoverageEntry[] = [
       'parseClaimComment (marker-helpers.mts, re-exported by protocol-helpers.mts)',
   },
   {
+    schema: 'context-tax-event.schema.json',
+    status: 'uncovered',
+    reason:
+      'context-tax-event.schema.json is a source-repo measurement contract, ' +
+      'not a helper stdout envelope -- fixture coverage lives in ' +
+      'discoverSchemaCases / scripts/validate-schemas.mjs.',
+  },
+  {
+    schema: 'context-tax-sample.schema.json',
+    status: 'uncovered',
+    reason:
+      'context-tax-sample.schema.json is a source-repo measurement contract, ' +
+      'not a helper stdout envelope -- fixture coverage lives in ' +
+      'discoverSchemaCases / scripts/validate-schemas.mjs.',
+  },
+  {
+    schema: 'context-tax-snapshot.schema.json',
+    status: 'uncovered',
+    reason:
+      'context-tax-snapshot.schema.json is a source-repo measurement ' +
+      'contract, not a helper stdout envelope -- fixture coverage lives in ' +
+      'discoverSchemaCases / scripts/validate-schemas.mjs.',
+  },
+  {
     schema: 'discover-roadmap-union.schema.json',
     status: 'covered',
     builder: 'enumerateAllRoadmapsGraph (discover-roadmap-graph.mts)',

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -6,6 +6,11 @@ import { fileURLToPath } from 'node:url';
 import type { AdvisoryConvergenceVerdict } from '../src/scripts/advisory-convergence.mts';
 import type { AdvisoryWaitStateReport } from '../src/scripts/advisory-wait-state.mts';
 import type { BranchConflictResult } from '../src/scripts/branch-conflict-state.mts';
+import type {
+  ContextTaxEvent,
+  ContextTaxSample,
+  ContextTaxSnapshot,
+} from '../src/scripts/context-tax-core.mts';
 import type { RoadmapGraphUnionReport } from '../src/scripts/discover-roadmap-graph.mts';
 import type { DispositionReport } from '../src/scripts/disposition-non-review-notices.mts';
 import type { IddMergeExecuteVerdict } from '../src/scripts/idd-merge-execute.mts';
@@ -403,6 +408,50 @@ export const onboardingHearingTranscriptKeys = [
   'answers',
 ] as const satisfies readonly (keyof OnboardingHearingTranscript)[];
 
+export const contextTaxSampleKeys = [
+  'schemaVersion',
+  'kind',
+  'vendor',
+  'model',
+  'attribution',
+  'outcome',
+  'usage',
+  'compactionCount',
+  'startedAt',
+  'endedAt',
+  'vendorSessionId',
+  'issueNumber',
+  'stages',
+  'claimId',
+  'prNumber',
+  'effort',
+  'toolCallCount',
+  'turnCount',
+  'includesSubagents',
+  'ambiguous',
+] as const satisfies readonly (keyof ContextTaxSample)[];
+
+export const contextTaxEventKeys = [
+  'schemaVersion',
+  'event',
+  'stageId',
+  'at',
+  'vendor',
+  'vendorSessionId',
+  'issueNumber',
+  'usage',
+] as const satisfies readonly (keyof ContextTaxEvent)[];
+
+export const contextTaxSnapshotKeys = [
+  'schemaVersion',
+  'generatedAt',
+  'minPublishableSamples',
+  'minPublishableVendors',
+  'publishable',
+  'sampleCount',
+  'vendors',
+] as const satisfies readonly (keyof ContextTaxSnapshot)[];
+
 export const policyConfigKeys = [
   '$schema',
   'iddVersion',
@@ -557,6 +606,18 @@ const exhaustivenessWitnesses: {
     StalledSessionQuietCheckReport,
     (typeof stalledSessionQuietCheckKeys)[number]
   >;
+  contextTaxSample: CoversAllKeysOf<
+    ContextTaxSample,
+    (typeof contextTaxSampleKeys)[number]
+  >;
+  contextTaxEvent: CoversAllKeysOf<
+    ContextTaxEvent,
+    (typeof contextTaxEventKeys)[number]
+  >;
+  contextTaxSnapshot: CoversAllKeysOf<
+    ContextTaxSnapshot,
+    (typeof contextTaxSnapshotKeys)[number]
+  >;
 } = {
   advisoryWaitState: true,
   branchConflictState: true,
@@ -571,6 +632,9 @@ const exhaustivenessWitnesses: {
   onboardingHearingTranscript: true,
   policyConfig: true,
   stalledSessionQuietCheck: true,
+  contextTaxSample: true,
+  contextTaxEvent: true,
+  contextTaxSnapshot: true,
 };
 
 // ---------------------------------------------------------------------------
@@ -880,6 +944,45 @@ const onboardingHearingTranscriptFixture = {
   confirmedAt: '2026-08-25T15:00:00Z',
   answers: [{ id: 'merge-policy', value: 'fully_autonomous_merge' }],
 } satisfies OnboardingHearingTranscript;
+
+const contextTaxSampleFixture = {
+  schemaVersion: 1,
+  kind: 'issue-loop',
+  vendor: 'grok',
+  model: 'grok-4.6',
+  attribution: 'marker-join',
+  outcome: 'merged',
+  usage: {
+    inputUncached: 1,
+    cacheRead: 0,
+    cacheCreation: 0,
+    output: 1,
+    reasoning: 0,
+  },
+  compactionCount: 0,
+  startedAt: '2026-08-25T15:00:00Z',
+  endedAt: '2026-08-25T16:00:00Z',
+  vendorSessionId: 'sess',
+  issueNumber: 2288,
+} satisfies ContextTaxSample;
+
+const contextTaxEventFixture = {
+  schemaVersion: 1,
+  event: 'enter',
+  stageId: 'work',
+  at: '2026-08-25T15:10:00Z',
+  vendor: 'claude',
+} satisfies ContextTaxEvent;
+
+const contextTaxSnapshotFixture = {
+  schemaVersion: 1,
+  generatedAt: '2026-08-25T16:00:00Z',
+  minPublishableSamples: 10,
+  minPublishableVendors: 2,
+  publishable: false,
+  sampleCount: 0,
+  vendors: [],
+} satisfies ContextTaxSnapshot;
 
 const policyConfigFixture = {
   iddVersion: '1.0.0',
@@ -1305,6 +1408,27 @@ const SCHEMA_TYPE_MAP: readonly SchemaTypeMapping[] = [
     owningModule: 'src/scripts/protocol-helpers.mts',
     keys: claimMarkerKeys,
     fixture: claimMarkerFixture,
+  },
+  {
+    schemaFile: 'context-tax-event.schema.json',
+    exportedType: 'ContextTaxEvent',
+    owningModule: 'src/scripts/context-tax-core.mts',
+    keys: contextTaxEventKeys,
+    fixture: contextTaxEventFixture,
+  },
+  {
+    schemaFile: 'context-tax-sample.schema.json',
+    exportedType: 'ContextTaxSample',
+    owningModule: 'src/scripts/context-tax-core.mts',
+    keys: contextTaxSampleKeys,
+    fixture: contextTaxSampleFixture,
+  },
+  {
+    schemaFile: 'context-tax-snapshot.schema.json',
+    exportedType: 'ContextTaxSnapshot',
+    owningModule: 'src/scripts/context-tax-core.mts',
+    keys: contextTaxSnapshotKeys,
+    fixture: contextTaxSnapshotFixture,
   },
   {
     schemaFile: 'discover-roadmap-union.schema.json',

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -964,6 +964,18 @@ const contextTaxSampleFixture = {
   endedAt: '2026-08-25T16:00:00Z',
   vendorSessionId: 'sess',
   issueNumber: 2288,
+  stages: [
+    {
+      id: 'work',
+      usage: {
+        inputUncached: 1,
+        cacheRead: 0,
+        cacheCreation: 0,
+        output: 1,
+        reasoning: 0,
+      },
+    },
+  ],
 } satisfies ContextTaxSample;
 
 const contextTaxEventFixture = {


### PR DESCRIPTION
## Summary

Add the context-tax measurement contract only: JSON Schemas for a harvested sample, an explicit phase event, and a committed snapshot, plus a shared TypeScript core with privacy redaction. This does not parse vendor logs, call GitHub, or edit the README.

## Changes

- `schemas/context-tax-sample.schema.json`, `context-tax-event.schema.json`, `context-tax-snapshot.schema.json`
- Matching valid/invalid fixtures inside the `validate-schemas.mts` keyword subset (no `$ref` / `oneOf` / `anyOf`)
- `src/scripts/context-tax-core.mts`: stage ids, usage type, adapter interface, join-hints (issue number only), redaction
- Unit tests that a home path and a prompt string do not survive redaction

`HELPER_COMMANDS` is unchanged. No `idd-template/` or instruction edits.

Closes #2288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context-tax event, sample, and snapshot data contracts with validation rules.
  * Added privacy-safe data handling, issue-loop detection, issue-number inference, and sample validation.
  * Added fixtures representing valid and invalid context-tax records.

* **Tests**
  * Added coverage for redaction, validation, schema compatibility, and representative context-tax data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->