### PR TITLE
feat(idd-doctor): warn when fully_autonomous_merge is unacknowledged

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -3,6 +3,7 @@
   "iddVersion": "0.7.0",
   "markerPrefix": "idd-skill",
   "mergePolicy": "fully_autonomous_merge",
+  "mergePolicyAck": "fully_autonomous_merge",
   "reviewPolicy": "copilot-advisory",
   "threadResolutionPolicy": "fast-agent-resolve",
   "claimTiming": {

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -35,6 +35,11 @@
       "enum": ["fully_autonomous_merge", "human_merge", "separate_merge_agent"],
       "description": "Selects which session is authorized to execute the F3 merge. Required when `config.json` exists; changing it is a workflow behavior change needing matching phase-file updates. An absent `config.json` is treated as the `human_merge` profile."
     },
+    "mergePolicyAck": {
+      "type": "string",
+      "enum": ["fully_autonomous_merge", "human_merge", "separate_merge_agent"],
+      "description": "Diagnostics-only confirmation that the operator has explicitly reconsidered the current `mergePolicy` value. Optional; never participates in F2.5/F3 merge-authority resolution and never changes what any `mergePolicy` value authorizes. `idd-doctor` warns when `mergePolicy` is `fully_autonomous_merge` and this field is absent or does not equal that same value; any other value here (including one that does not match the live `mergePolicy`) still validates against this schema."
+    },
     "reviewPolicy": {
       "type": "string",
       "enum": [

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -73,6 +73,7 @@ export function runDoctor({
   checkHelperRuntimeConfig(root, report);
   checkLiveConfigSchema(root, report);
   checkClaimTimingConsistency(root, report);
+  checkMergePolicyAcknowledgement(root, report);
   checkDependencyVersionDrift(root, report);
   checkAgentEntryFiles(root, report);
   checkTemplateVersionSignal(root, report);
@@ -1170,6 +1171,68 @@ export function checkClaimTimingConsistency(root, report) {
   const finding = classifyClaimTimingConsistency(claimTiming, overviewCoreText);
   if (finding) {
     report.warnings.push(finding.message);
+  }
+}
+/**
+ * `fully_autonomous_merge` grants an agent unattended F3 merge authority
+ * and is an explicit opt-in against the distributed `human_merge` default
+ * (idd-skill#2284). This reminds an operator who has `mergePolicy:
+ * "fully_autonomous_merge"` recorded -- including one who reached it via
+ * the old distributed default before it flipped -- that the profile is
+ * now an explicit choice, unless they have confirmed it with a matching
+ * `mergePolicyAck`. `mergePolicyAck` is diagnostics-only: it never
+ * participates in F2.5/F3 merge-authority resolution and this check never
+ * changes what any `mergePolicy` value authorizes.
+ *
+ * Returns null (no finding) for every `mergePolicy` value other than
+ * `fully_autonomous_merge`, for a missing/absent `mergePolicy` key, or
+ * when `mergePolicyAck` already equals `"fully_autonomous_merge"` --
+ * scoped to that exact value rather than a boolean, so flipping
+ * `mergePolicy` away and back drops a stale ack and the warning resumes
+ * until re-confirmed.
+ */
+export function classifyMergePolicyAcknowledgement(config) {
+  if (config?.mergePolicy !== 'fully_autonomous_merge') {
+    return null;
+  }
+  if (config.mergePolicyAck === 'fully_autonomous_merge') {
+    return null;
+  }
+  return {
+    level: 'warning',
+    message:
+      'mergePolicy is "fully_autonomous_merge", an explicit opt-in against ' +
+      'the distributed "human_merge" default -- confirm this choice by ' +
+      'setting mergePolicyAck: "fully_autonomous_merge" in ' +
+      '.github/idd/config.json to silence this reminder.',
+  };
+}
+/**
+ * Checks the first present live-config candidate (same
+ * {@link LIVE_CONFIG_CANDIDATE_FILES} order and first-present-wins rule as
+ * {@link resolveConfiguredHelperRuntime}) for the mergePolicy
+ * acknowledgement finding above. Never errors: an unreadable or malformed
+ * config is already surfaced by {@link checkLiveConfigSchema} /
+ * {@link checkHelperRuntimeConfig}, so this silently skips instead of
+ * double-reporting.
+ */
+export function checkMergePolicyAcknowledgement(root, report) {
+  for (const file of LIVE_CONFIG_CANDIDATE_FILES) {
+    const absolutePath = join(root, file);
+    if (!exists(absolutePath)) {
+      continue;
+    }
+    let config;
+    try {
+      config = JSON.parse(readFileSync(absolutePath, 'utf8'));
+    } catch {
+      return;
+    }
+    const finding = classifyMergePolicyAcknowledgement(config);
+    if (finding) {
+      report.warnings.push(finding.message);
+    }
+    return;
   }
 }
 // The two packages implicated in the #1164 incident: a stale node_modules

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1193,18 +1193,21 @@ export function checkClaimTimingConsistency(root, report) {
  *
  * Returns null (no finding) for every `mergePolicy` value other than
  * `fully_autonomous_merge`, for a missing/absent `mergePolicy` key, or
- * when `mergePolicyAck` already equals `"fully_autonomous_merge"` --
- * scoped to that exact value rather than a boolean, so flipping
- * `mergePolicy` to a *different* value and back to `fully_autonomous_merge`
- * makes the finding return null (since it only fires the moment
- * `mergePolicy` is `fully_autonomous_merge`) rather than resuming from
- * that different value. A round trip that lands back on the exact same
- * `fully_autonomous_merge` value with the acknowledgement never cleared in
- * between does not resume the warning -- this diagnostics-only field has
- * no timestamp or generation counter to detect that narrow case, a known,
- * accepted limitation of the deliberately value-scoped (not boolean, not
- * time-scoped) design (idd-skill#2301 review, rejected as a follow-up
- * beyond this issue's locked scope).
+ * when `mergePolicyAck` already equals `"fully_autonomous_merge"`.
+ *
+ * The ack is scoped to that exact value rather than a boolean: while
+ * `mergePolicy` is any value *other than* `fully_autonomous_merge`, this
+ * always returns null regardless of `mergePolicyAck` (the check only
+ * fires for that one value). But this is NOT a full time/generation-scoped
+ * reset -- a round trip that later lands back on the exact same
+ * `fully_autonomous_merge` value, with `mergePolicyAck` still
+ * (unrelatedly) equal to `"fully_autonomous_merge"` from an earlier
+ * confirmation that was never cleared in between, does **not** resume the
+ * warning: it silently returns null again. This diagnostics-only field
+ * has no timestamp or generation counter to detect that narrow case -- a
+ * known, accepted limitation of the deliberately value-scoped (not
+ * boolean, not time-scoped) design (idd-skill#2301 review, rejected as a
+ * follow-up beyond this issue's locked scope).
  */
 export function classifyMergePolicyAcknowledgement(
   config,

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1184,14 +1184,32 @@ export function checkClaimTimingConsistency(root, report) {
  * participates in F2.5/F3 merge-authority resolution and this check never
  * changes what any `mergePolicy` value authorizes.
  *
+ * `file` names the live-config candidate `config` was actually read from
+ * (`.github/idd/config.json` or the legacy `idd-policy.json`) so the
+ * remediation text points at the file the operator needs to edit, not
+ * always the canonical name (idd-skill#2301 review) -- setting
+ * `mergePolicyAck` in a *different* candidate than the one this doctor
+ * run selected would not silence the warning.
+ *
  * Returns null (no finding) for every `mergePolicy` value other than
  * `fully_autonomous_merge`, for a missing/absent `mergePolicy` key, or
  * when `mergePolicyAck` already equals `"fully_autonomous_merge"` --
  * scoped to that exact value rather than a boolean, so flipping
- * `mergePolicy` away and back drops a stale ack and the warning resumes
- * until re-confirmed.
+ * `mergePolicy` to a *different* value and back to `fully_autonomous_merge`
+ * makes the finding return null (since it only fires the moment
+ * `mergePolicy` is `fully_autonomous_merge`) rather than resuming from
+ * that different value. A round trip that lands back on the exact same
+ * `fully_autonomous_merge` value with the acknowledgement never cleared in
+ * between does not resume the warning -- this diagnostics-only field has
+ * no timestamp or generation counter to detect that narrow case, a known,
+ * accepted limitation of the deliberately value-scoped (not boolean, not
+ * time-scoped) design (idd-skill#2301 review, rejected as a follow-up
+ * beyond this issue's locked scope).
  */
-export function classifyMergePolicyAcknowledgement(config) {
+export function classifyMergePolicyAcknowledgement(
+  config,
+  file = '.github/idd/config.json',
+) {
   if (config?.mergePolicy !== 'fully_autonomous_merge') {
     return null;
   }
@@ -1203,8 +1221,8 @@ export function classifyMergePolicyAcknowledgement(config) {
     message:
       'mergePolicy is "fully_autonomous_merge", an explicit opt-in against ' +
       'the distributed "human_merge" default -- confirm this choice by ' +
-      'setting mergePolicyAck: "fully_autonomous_merge" in ' +
-      '.github/idd/config.json to silence this reminder.',
+      `setting mergePolicyAck: "fully_autonomous_merge" in ${file} to ` +
+      'silence this reminder.',
   };
 }
 /**
@@ -1228,7 +1246,7 @@ export function checkMergePolicyAcknowledgement(root, report) {
     } catch {
       return;
     }
-    const finding = classifyMergePolicyAcknowledgement(config);
+    const finding = classifyMergePolicyAcknowledgement(config, file);
     if (finding) {
       report.warnings.push(finding.message);
     }

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1200,9 +1200,9 @@ export function checkClaimTimingConsistency(root, report) {
  * always returns null regardless of `mergePolicyAck` (the check only
  * fires for that one value). But this is NOT a full time/generation-scoped
  * reset -- a round trip that later lands back on the exact same
- * `fully_autonomous_merge` value, with `mergePolicyAck` still
- * (unrelatedly) equal to `"fully_autonomous_merge"` from an earlier
- * confirmation that was never cleared in between, does **not** resume the
+ * `fully_autonomous_merge` value, with `mergePolicyAck` still equal to
+ * `"fully_autonomous_merge"` from an earlier, now-stale confirmation
+ * that was never cleared in between, does **not** resume the
  * warning: it silently returns null again. This diagnostics-only field
  * has no timestamp or generation counter to detect that narrow case -- a
  * known, accepted limitation of the deliberately value-scoped (not

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -891,10 +891,13 @@ export function resolveConfiguredHelperRuntimePackageSpec(root) {
  * separate copies that only ever read the canonical filename
  * (idd-skill#2028).
  *
- * Returns `{ config: null }` when no candidate file exists, or the first
- * present candidate is not valid JSON -- each caller keeps its own
- * fail-closed default for that case, matching every reader's behavior
- * before this extraction.
+ * Returns `{ config: null, file: null }` when no candidate file exists;
+ * `{ config: null, file }` when the first present candidate (`file`) is
+ * not valid JSON -- each caller keeps its own fail-closed default for
+ * either case, matching every reader's behavior before this extraction.
+ * `file` names which candidate was selected (idd-skill#2301 review) so a
+ * caller building a remediation message can point at the file actually
+ * read instead of assuming the canonical name.
  */
 function resolveLiveConfigDocument(root) {
   for (const file of LIVE_CONFIG_CANDIDATE_FILES) {
@@ -903,12 +906,12 @@ function resolveLiveConfigDocument(root) {
       continue;
     }
     try {
-      return { config: JSON.parse(readFileSync(absolutePath, 'utf8')) };
+      return { config: JSON.parse(readFileSync(absolutePath, 'utf8')), file };
     } catch {
-      return { config: null };
+      return { config: null, file };
     }
   }
-  return { config: null };
+  return { config: null, file: null };
 }
 /**
  * Resolve `autopilotSuitability.floor` and `labels.blockedByHumanLabelName`
@@ -1229,31 +1232,22 @@ export function classifyMergePolicyAcknowledgement(
   };
 }
 /**
- * Checks the first present live-config candidate (same
- * {@link LIVE_CONFIG_CANDIDATE_FILES} order and first-present-wins rule as
- * {@link resolveConfiguredHelperRuntime}) for the mergePolicy
- * acknowledgement finding above. Never errors: an unreadable or malformed
- * config is already surfaced by {@link checkLiveConfigSchema} /
+ * Checks the resolved live-config candidate ({@link resolveLiveConfigDocument},
+ * the same first-present-wins walk every other scalar policy reader in
+ * this file shares, idd-skill#2028) for the mergePolicy acknowledgement
+ * finding above. Never errors: an unreadable or malformed config is
+ * already surfaced by {@link checkLiveConfigSchema} /
  * {@link checkHelperRuntimeConfig}, so this silently skips instead of
  * double-reporting.
  */
 export function checkMergePolicyAcknowledgement(root, report) {
-  for (const file of LIVE_CONFIG_CANDIDATE_FILES) {
-    const absolutePath = join(root, file);
-    if (!exists(absolutePath)) {
-      continue;
-    }
-    let config;
-    try {
-      config = JSON.parse(readFileSync(absolutePath, 'utf8'));
-    } catch {
-      return;
-    }
-    const finding = classifyMergePolicyAcknowledgement(config, file);
-    if (finding) {
-      report.warnings.push(finding.message);
-    }
+  const { config, file } = resolveLiveConfigDocument(root);
+  if (config === null || file === null) {
     return;
+  }
+  const finding = classifyMergePolicyAcknowledgement(config, file);
+  if (finding) {
+    report.warnings.push(finding.message);
   }
 }
 // The two packages implicated in the #1164 incident: a stale node_modules

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1405,18 +1405,34 @@ export interface MergePolicyAckFinding {
  * participates in F2.5/F3 merge-authority resolution and this check never
  * changes what any `mergePolicy` value authorizes.
  *
+ * `file` names the live-config candidate `config` was actually read from
+ * (`.github/idd/config.json` or the legacy `idd-policy.json`) so the
+ * remediation text points at the file the operator needs to edit, not
+ * always the canonical name (idd-skill#2301 review) -- setting
+ * `mergePolicyAck` in a *different* candidate than the one this doctor
+ * run selected would not silence the warning.
+ *
  * Returns null (no finding) for every `mergePolicy` value other than
  * `fully_autonomous_merge`, for a missing/absent `mergePolicy` key, or
  * when `mergePolicyAck` already equals `"fully_autonomous_merge"` --
  * scoped to that exact value rather than a boolean, so flipping
- * `mergePolicy` away and back drops a stale ack and the warning resumes
- * until re-confirmed.
+ * `mergePolicy` to a *different* value and back to `fully_autonomous_merge`
+ * makes the finding return null (since it only fires the moment
+ * `mergePolicy` is `fully_autonomous_merge`) rather than resuming from
+ * that different value. A round trip that lands back on the exact same
+ * `fully_autonomous_merge` value with the acknowledgement never cleared in
+ * between does not resume the warning -- this diagnostics-only field has
+ * no timestamp or generation counter to detect that narrow case, a known,
+ * accepted limitation of the deliberately value-scoped (not boolean, not
+ * time-scoped) design (idd-skill#2301 review, rejected as a follow-up
+ * beyond this issue's locked scope).
  */
 export function classifyMergePolicyAcknowledgement(
   config:
     | { mergePolicy?: unknown; mergePolicyAck?: unknown }
     | null
     | undefined,
+  file: string = '.github/idd/config.json',
 ): MergePolicyAckFinding | null {
   if (config?.mergePolicy !== 'fully_autonomous_merge') {
     return null;
@@ -1429,8 +1445,8 @@ export function classifyMergePolicyAcknowledgement(
     message:
       'mergePolicy is "fully_autonomous_merge", an explicit opt-in against ' +
       'the distributed "human_merge" default -- confirm this choice by ' +
-      'setting mergePolicyAck: "fully_autonomous_merge" in ' +
-      '.github/idd/config.json to silence this reminder.',
+      `setting mergePolicyAck: "fully_autonomous_merge" in ${file} to ` +
+      'silence this reminder.',
   };
 }
 
@@ -1460,6 +1476,7 @@ export function checkMergePolicyAcknowledgement(
     }
     const finding = classifyMergePolicyAcknowledgement(
       config as { mergePolicy?: unknown; mergePolicyAck?: unknown } | null,
+      file,
     );
     if (finding) {
       report.warnings.push(finding.message);

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -146,6 +146,7 @@ export function runDoctor({
   checkHelperRuntimeConfig(root, report);
   checkLiveConfigSchema(root, report);
   checkClaimTimingConsistency(root, report);
+  checkMergePolicyAcknowledgement(root, report);
   checkDependencyVersionDrift(root, report);
   checkAgentEntryFiles(root, report);
   checkTemplateVersionSignal(root, report);
@@ -1384,6 +1385,86 @@ export function checkClaimTimingConsistency(
   const finding = classifyClaimTimingConsistency(claimTiming, overviewCoreText);
   if (finding) {
     report.warnings.push(finding.message);
+  }
+}
+
+/** One reportable finding from the mergePolicy acknowledgement check. */
+export interface MergePolicyAckFinding {
+  level: 'warning';
+  message: string;
+}
+
+/**
+ * `fully_autonomous_merge` grants an agent unattended F3 merge authority
+ * and is an explicit opt-in against the distributed `human_merge` default
+ * (idd-skill#2284). This reminds an operator who has `mergePolicy:
+ * "fully_autonomous_merge"` recorded -- including one who reached it via
+ * the old distributed default before it flipped -- that the profile is
+ * now an explicit choice, unless they have confirmed it with a matching
+ * `mergePolicyAck`. `mergePolicyAck` is diagnostics-only: it never
+ * participates in F2.5/F3 merge-authority resolution and this check never
+ * changes what any `mergePolicy` value authorizes.
+ *
+ * Returns null (no finding) for every `mergePolicy` value other than
+ * `fully_autonomous_merge`, for a missing/absent `mergePolicy` key, or
+ * when `mergePolicyAck` already equals `"fully_autonomous_merge"` --
+ * scoped to that exact value rather than a boolean, so flipping
+ * `mergePolicy` away and back drops a stale ack and the warning resumes
+ * until re-confirmed.
+ */
+export function classifyMergePolicyAcknowledgement(
+  config:
+    | { mergePolicy?: unknown; mergePolicyAck?: unknown }
+    | null
+    | undefined,
+): MergePolicyAckFinding | null {
+  if (config?.mergePolicy !== 'fully_autonomous_merge') {
+    return null;
+  }
+  if (config.mergePolicyAck === 'fully_autonomous_merge') {
+    return null;
+  }
+  return {
+    level: 'warning',
+    message:
+      'mergePolicy is "fully_autonomous_merge", an explicit opt-in against ' +
+      'the distributed "human_merge" default -- confirm this choice by ' +
+      'setting mergePolicyAck: "fully_autonomous_merge" in ' +
+      '.github/idd/config.json to silence this reminder.',
+  };
+}
+
+/**
+ * Checks the first present live-config candidate (same
+ * {@link LIVE_CONFIG_CANDIDATE_FILES} order and first-present-wins rule as
+ * {@link resolveConfiguredHelperRuntime}) for the mergePolicy
+ * acknowledgement finding above. Never errors: an unreadable or malformed
+ * config is already surfaced by {@link checkLiveConfigSchema} /
+ * {@link checkHelperRuntimeConfig}, so this silently skips instead of
+ * double-reporting.
+ */
+export function checkMergePolicyAcknowledgement(
+  root: string,
+  report: DoctorReport,
+) {
+  for (const file of LIVE_CONFIG_CANDIDATE_FILES) {
+    const absolutePath = join(root, file);
+    if (!exists(absolutePath)) {
+      continue;
+    }
+    let config: unknown;
+    try {
+      config = JSON.parse(readFileSync(absolutePath, 'utf8'));
+    } catch {
+      return;
+    }
+    const finding = classifyMergePolicyAcknowledgement(
+      config as { mergePolicy?: unknown; mergePolicyAck?: unknown } | null,
+    );
+    if (finding) {
+      report.warnings.push(finding.message);
+    }
+    return;
   }
 }
 

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1414,18 +1414,21 @@ export interface MergePolicyAckFinding {
  *
  * Returns null (no finding) for every `mergePolicy` value other than
  * `fully_autonomous_merge`, for a missing/absent `mergePolicy` key, or
- * when `mergePolicyAck` already equals `"fully_autonomous_merge"` --
- * scoped to that exact value rather than a boolean, so flipping
- * `mergePolicy` to a *different* value and back to `fully_autonomous_merge`
- * makes the finding return null (since it only fires the moment
- * `mergePolicy` is `fully_autonomous_merge`) rather than resuming from
- * that different value. A round trip that lands back on the exact same
- * `fully_autonomous_merge` value with the acknowledgement never cleared in
- * between does not resume the warning -- this diagnostics-only field has
- * no timestamp or generation counter to detect that narrow case, a known,
- * accepted limitation of the deliberately value-scoped (not boolean, not
- * time-scoped) design (idd-skill#2301 review, rejected as a follow-up
- * beyond this issue's locked scope).
+ * when `mergePolicyAck` already equals `"fully_autonomous_merge"`.
+ *
+ * The ack is scoped to that exact value rather than a boolean: while
+ * `mergePolicy` is any value *other than* `fully_autonomous_merge`, this
+ * always returns null regardless of `mergePolicyAck` (the check only
+ * fires for that one value). But this is NOT a full time/generation-scoped
+ * reset -- a round trip that later lands back on the exact same
+ * `fully_autonomous_merge` value, with `mergePolicyAck` still
+ * (unrelatedly) equal to `"fully_autonomous_merge"` from an earlier
+ * confirmation that was never cleared in between, does **not** resume the
+ * warning: it silently returns null again. This diagnostics-only field
+ * has no timestamp or generation counter to detect that narrow case -- a
+ * known, accepted limitation of the deliberately value-scoped (not
+ * boolean, not time-scoped) design (idd-skill#2301 review, rejected as a
+ * follow-up beyond this issue's locked scope).
  */
 export function classifyMergePolicyAcknowledgement(
   config:

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1421,9 +1421,9 @@ export interface MergePolicyAckFinding {
  * always returns null regardless of `mergePolicyAck` (the check only
  * fires for that one value). But this is NOT a full time/generation-scoped
  * reset -- a round trip that later lands back on the exact same
- * `fully_autonomous_merge` value, with `mergePolicyAck` still
- * (unrelatedly) equal to `"fully_autonomous_merge"` from an earlier
- * confirmation that was never cleared in between, does **not** resume the
+ * `fully_autonomous_merge` value, with `mergePolicyAck` still equal to
+ * `"fully_autonomous_merge"` from an earlier, now-stale confirmation
+ * that was never cleared in between, does **not** resume the
  * warning: it silently returns null again. This diagnostics-only field
  * has no timestamp or generation counter to detect that narrow case -- a
  * known, accepted limitation of the deliberately value-scoped (not

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1052,24 +1052,30 @@ export function resolveConfiguredHelperRuntimePackageSpec(
  * separate copies that only ever read the canonical filename
  * (idd-skill#2028).
  *
- * Returns `{ config: null }` when no candidate file exists, or the first
- * present candidate is not valid JSON -- each caller keeps its own
- * fail-closed default for that case, matching every reader's behavior
- * before this extraction.
+ * Returns `{ config: null, file: null }` when no candidate file exists;
+ * `{ config: null, file }` when the first present candidate (`file`) is
+ * not valid JSON -- each caller keeps its own fail-closed default for
+ * either case, matching every reader's behavior before this extraction.
+ * `file` names which candidate was selected (idd-skill#2301 review) so a
+ * caller building a remediation message can point at the file actually
+ * read instead of assuming the canonical name.
  */
-function resolveLiveConfigDocument(root: string): { config: unknown } {
+function resolveLiveConfigDocument(root: string): {
+  config: unknown;
+  file: string | null;
+} {
   for (const file of LIVE_CONFIG_CANDIDATE_FILES) {
     const absolutePath = join(root, file);
     if (!exists(absolutePath)) {
       continue;
     }
     try {
-      return { config: JSON.parse(readFileSync(absolutePath, 'utf8')) };
+      return { config: JSON.parse(readFileSync(absolutePath, 'utf8')), file };
     } catch {
-      return { config: null };
+      return { config: null, file };
     }
   }
-  return { config: null };
+  return { config: null, file: null };
 }
 
 /**
@@ -1454,11 +1460,11 @@ export function classifyMergePolicyAcknowledgement(
 }
 
 /**
- * Checks the first present live-config candidate (same
- * {@link LIVE_CONFIG_CANDIDATE_FILES} order and first-present-wins rule as
- * {@link resolveConfiguredHelperRuntime}) for the mergePolicy
- * acknowledgement finding above. Never errors: an unreadable or malformed
- * config is already surfaced by {@link checkLiveConfigSchema} /
+ * Checks the resolved live-config candidate ({@link resolveLiveConfigDocument},
+ * the same first-present-wins walk every other scalar policy reader in
+ * this file shares, idd-skill#2028) for the mergePolicy acknowledgement
+ * finding above. Never errors: an unreadable or malformed config is
+ * already surfaced by {@link checkLiveConfigSchema} /
  * {@link checkHelperRuntimeConfig}, so this silently skips instead of
  * double-reporting.
  */
@@ -1466,25 +1472,16 @@ export function checkMergePolicyAcknowledgement(
   root: string,
   report: DoctorReport,
 ) {
-  for (const file of LIVE_CONFIG_CANDIDATE_FILES) {
-    const absolutePath = join(root, file);
-    if (!exists(absolutePath)) {
-      continue;
-    }
-    let config: unknown;
-    try {
-      config = JSON.parse(readFileSync(absolutePath, 'utf8'));
-    } catch {
-      return;
-    }
-    const finding = classifyMergePolicyAcknowledgement(
-      config as { mergePolicy?: unknown; mergePolicyAck?: unknown } | null,
-      file,
-    );
-    if (finding) {
-      report.warnings.push(finding.message);
-    }
+  const { config, file } = resolveLiveConfigDocument(root);
+  if (config === null || file === null) {
     return;
+  }
+  const finding = classifyMergePolicyAcknowledgement(
+    config as { mergePolicy?: unknown; mergePolicyAck?: unknown } | null,
+    file,
+  );
+  if (finding) {
+    report.warnings.push(finding.message);
   }
 }
 

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -15,12 +15,14 @@ import {
   checkClaimTimingConsistency,
   checkDependencyVersionDrift,
   checkLiveConfigSchema,
+  checkMergePolicyAcknowledgement,
   checkPlaceholders,
   checkPolicySignals,
   checkProjectCommands,
   classifyBacklog,
   classifyClaimTimingConsistency,
   classifyLiveConfigSchemaFinding,
+  classifyMergePolicyAcknowledgement,
   classifyPrimaryHead,
   classifyReleaseTagDrift,
   classifyWorktreeGuardActivation,
@@ -3208,6 +3210,93 @@ test('checkClaimTimingConsistency pushes no warning when config and prose agree,
     rmSync(join(dir, '.github/idd/config.json'));
     const missingConfigReport = emptyReport(dir);
     checkClaimTimingConsistency(dir, missingConfigReport);
+    assert.equal(missingConfigReport.warnings.length, 0);
+    assert.equal(missingConfigReport.errors.length, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('classifyMergePolicyAcknowledgement warns when fully_autonomous_merge is unacknowledged', () => {
+  const finding = classifyMergePolicyAcknowledgement({
+    mergePolicy: 'fully_autonomous_merge',
+  });
+  assert.equal(finding?.level, 'warning');
+  assert.match(finding?.message ?? '', /fully_autonomous_merge/);
+  assert.match(finding?.message ?? '', /human_merge/);
+  assert.match(finding?.message ?? '', /mergePolicyAck/);
+});
+
+test('classifyMergePolicyAcknowledgement returns null when acknowledged', () => {
+  assert.equal(
+    classifyMergePolicyAcknowledgement({
+      mergePolicy: 'fully_autonomous_merge',
+      mergePolicyAck: 'fully_autonomous_merge',
+    }),
+    null,
+  );
+});
+
+test('classifyMergePolicyAcknowledgement warns when the ack value is stale (mismatched)', () => {
+  const finding = classifyMergePolicyAcknowledgement({
+    mergePolicy: 'fully_autonomous_merge',
+    mergePolicyAck: 'human_merge',
+  });
+  assert.equal(finding?.level, 'warning');
+});
+
+test('classifyMergePolicyAcknowledgement returns null for a different mergePolicy value, ack present or not', () => {
+  assert.equal(
+    classifyMergePolicyAcknowledgement({ mergePolicy: 'human_merge' }),
+    null,
+  );
+  assert.equal(
+    classifyMergePolicyAcknowledgement({
+      mergePolicy: 'separate_merge_agent',
+      mergePolicyAck: 'fully_autonomous_merge',
+    }),
+    null,
+  );
+});
+
+test('classifyMergePolicyAcknowledgement returns null for a missing/absent mergePolicy', () => {
+  assert.equal(classifyMergePolicyAcknowledgement(undefined), null);
+  assert.equal(classifyMergePolicyAcknowledgement(null), null);
+  assert.equal(classifyMergePolicyAcknowledgement({}), null);
+});
+
+test('checkMergePolicyAcknowledgement pushes a warning when unacknowledged, none when acknowledged or missing', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-merge-policy-ack-'));
+  try {
+    mkdirSync(join(dir, '.github/idd'), { recursive: true });
+    writeFileSync(
+      join(dir, '.github/idd/config.json'),
+      JSON.stringify({ mergePolicy: 'fully_autonomous_merge' }),
+    );
+
+    const unacknowledgedReport = emptyReport(dir);
+    checkMergePolicyAcknowledgement(dir, unacknowledgedReport);
+    assert.equal(unacknowledgedReport.errors.length, 0);
+    assert.equal(unacknowledgedReport.warnings.length, 1);
+    assert.match(unacknowledgedReport.warnings[0], /mergePolicyAck/);
+
+    writeFileSync(
+      join(dir, '.github/idd/config.json'),
+      JSON.stringify({
+        mergePolicy: 'fully_autonomous_merge',
+        mergePolicyAck: 'fully_autonomous_merge',
+      }),
+    );
+    const acknowledgedReport = emptyReport(dir);
+    checkMergePolicyAcknowledgement(dir, acknowledgedReport);
+    assert.equal(acknowledgedReport.warnings.length, 0);
+    assert.equal(acknowledgedReport.errors.length, 0);
+
+    // No config.json at all: this check is not the file-presence gate —
+    // it skips rather than erroring.
+    rmSync(join(dir, '.github/idd/config.json'));
+    const missingConfigReport = emptyReport(dir);
+    checkMergePolicyAcknowledgement(dir, missingConfigReport);
     assert.equal(missingConfigReport.warnings.length, 0);
     assert.equal(missingConfigReport.errors.length, 0);
   } finally {

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -3225,6 +3225,16 @@ test('classifyMergePolicyAcknowledgement warns when fully_autonomous_merge is un
   assert.match(finding?.message ?? '', /fully_autonomous_merge/);
   assert.match(finding?.message ?? '', /human_merge/);
   assert.match(finding?.message ?? '', /mergePolicyAck/);
+  assert.match(finding?.message ?? '', /\.github\/idd\/config\.json/);
+});
+
+test('classifyMergePolicyAcknowledgement names the legacy file when that is what was read (#2301 review)', () => {
+  const finding = classifyMergePolicyAcknowledgement(
+    { mergePolicy: 'fully_autonomous_merge' },
+    'idd-policy.json',
+  );
+  assert.match(finding?.message ?? '', /idd-policy\.json/);
+  assert.doesNotMatch(finding?.message ?? '', /\.github\/idd\/config\.json/);
 });
 
 test('classifyMergePolicyAcknowledgement returns null when acknowledged', () => {
@@ -3299,6 +3309,25 @@ test('checkMergePolicyAcknowledgement pushes a warning when unacknowledged, none
     checkMergePolicyAcknowledgement(dir, missingConfigReport);
     assert.equal(missingConfigReport.warnings.length, 0);
     assert.equal(missingConfigReport.errors.length, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('checkMergePolicyAcknowledgement names idd-policy.json when only the legacy candidate is present (#2301 review)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-merge-policy-ack-legacy-'));
+  try {
+    writeFileSync(
+      join(dir, 'idd-policy.json'),
+      JSON.stringify({ mergePolicy: 'fully_autonomous_merge' }),
+    );
+
+    const report = emptyReport(dir);
+    checkMergePolicyAcknowledgement(dir, report);
+    assert.equal(report.errors.length, 0);
+    assert.equal(report.warnings.length, 1);
+    assert.match(report.warnings[0], /idd-policy\.json/);
+    assert.doesNotMatch(report.warnings[0], /\.github\/idd\/config\.json/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -138,6 +138,10 @@ interface PolicyConfigFile {
     | 'fully_autonomous_merge'
     | 'human_merge'
     | 'separate_merge_agent';
+  mergePolicyAck?:
+    | 'fully_autonomous_merge'
+    | 'human_merge'
+    | 'separate_merge_agent';
   reviewPolicy:
     | 'copilot-advisory'
     | 'human-required'
@@ -408,6 +412,7 @@ export const policyConfigKeys = [
   'iddVersion',
   'markerPrefix',
   'mergePolicy',
+  'mergePolicyAck',
   'reviewPolicy',
   'threadResolutionPolicy',
   'authoringLanguage',


### PR DESCRIPTION
# Summary

Adds an optional `mergePolicyAck` field to the policy schema and a
diagnostics-only `idd-doctor` warning that fires when the live
`mergePolicy` is `fully_autonomous_merge` and `mergePolicyAck` is
absent or does not equal that same value. This reminds an operator
who has `fully_autonomous_merge` recorded — including one who
inherited it from the old distributed default before it flipped to
`human_merge` in #2284 — that the profile is now an explicit opt-in,
without failing CI or forcing a re-confirm. The warning message names
the live-config file that was actually read (`.github/idd/config.json`
or the legacy `idd-policy.json`), not always the canonical path.

The ack is value-scoped (not a boolean): once `mergePolicy` moves away
from `fully_autonomous_merge`, the warning stops firing (it only
applies to that value). A known, accepted limitation: if `mergePolicy`
later returns to `fully_autonomous_merge` while a stale ack for that
same value was never cleared, the warning does not resume — see
Follow-up issues.

`mergePolicyAck` is diagnostics-only: it never participates in
F2.5/F3 merge-authority resolution and never changes what any
`mergePolicy` value authorizes.

This repository's own `.github/idd/config.json` now records
`mergePolicyAck: "fully_autonomous_merge"`, exercising the clearing
path so its own `idd-doctor` run stays warning-free for this
finding.

## Linked issue

Closes #2285

## Follow-up issues (if any)

- [ ] A Codex review comment (rejected in this PR as out of scope)
      flagged that a `mergePolicy` round-trip back to the exact same
      `fully_autonomous_merge` value, with a stale ack never cleared
      in between, does not resume the warning. Fixing this would need
      a timestamp or generation counter on the ack, which is new
      design surface beyond this issue's locked scope. Worth a
      follow-up issue only if the maintainer wants tighter protection
      here.

## Background / rationale (if material)

Design was rescoped (see issue discussion) from an earlier
unconditional-nag draft after review found `idd-doctor` runs on
every push and every PR, which would have made the original design
an unclearable permanent warning for a deliberately, explicitly
chosen config value — inconsistent with every other existing
`idd-doctor` warning-level finding, which is a clearable defect.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional merge-policy acknowledgement settings for fully autonomous merging.
  - Added diagnostics that warn when autonomous merging lacks a matching acknowledgement.
  - Supports acknowledgements for all available merge-policy values.

- **Bug Fixes**
  - Improved configuration validation while safely handling missing or malformed configuration files.

- **Tests**
  - Added coverage for acknowledged, unacknowledged, stale, missing, and alternative merge-policy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
