### PR TITLE
docs(issue-authoring): generalize the narrative-dependency encoding rule

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -502,22 +502,32 @@ availability, or ordering constraint.
   reviewed and verified independently
 - do not split one natural, cohesive change into artificial sibling
   issues only to widen parallel execution
-- when authoring a **docs or operator-help child that documents
-  behavior implemented by sibling issues**, encode `Blocked by #NNN` for
-  those implementation issues (or otherwise sequence the docs child to run
+- whenever an issue's own narrative states that its work cannot safely
+  start until another named issue resolves, encode `Blocked by #NNN`
+  for that issue (or otherwise sequence it to run after the dependency
+  resolves) rather than leaving the constraint as prose-only
+  sequencing. Discover and A4.5 honor the hard `Blocked by` edge, not
+  a narrative "runs after #NNN" note: A4.5 Actionability inspects the
+  body, not completability, so a narrative-only dependency reports the
+  issue startable the moment its other filters pass, and claiming it
+  then means either violating the asserted constraint or doing the
+  referenced issue's unresolved work first. This rule is general, not
+  limited to a fixed list of cases; the two recurring patterns below
+  are illustrative, not exhaustive
+- **example — docs or operator-help child that documents behavior
+  implemented by sibling issues**: encode `Blocked by #NNN` for those
+  implementation issues (or otherwise sequence the docs child to run
   after they merge) so the documentation is written against **shipped**
   behavior. Describing designed-but-unshipped behavior in the present
   tense is a recurring advisory-review-thrash pattern; "describe shipped
   behavior" is a true ordering constraint, so this edge is consistent
   with the encode-only-a-real-constraint rule above
-- when authoring a **finalize or verify track whose acceptance criteria
-  assert state produced by sibling implementation tracks**, encode
+- **example — finalize or verify track whose acceptance criteria
+  assert state produced by sibling implementation tracks**: encode
   `Blocked by #NNN` on **each** such sibling rather than stating the
-  ordering only in prose. Discover and A4.5 honor the hard `Blocked by`
-  edge, not a prose "runs after the siblings" note: A4.5 Actionability
-  inspects the body, not completability, so a prose-sequenced finalize
-  track reports startable the moment its build foundation closes, and
-  claiming it then means either failing its acceptance criteria or doing
+  ordering only in prose. A prose-sequenced finalize track reports
+  startable the moment its build foundation closes, and claiming it
+  then means either failing its acceptance criteria or doing
   the siblings' unmerged work
 - once a `Blocked by #NNN` / `Depends on #NNN` reference resolves —
   the referenced issue closes **with its required outcome verified as

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -504,8 +504,7 @@ availability, or ordering constraint.
   issues only to widen parallel execution
 - whenever an issue's own narrative states that its work cannot safely
   start until another named issue resolves, encode `Blocked by #NNN`
-  for that issue (or otherwise sequence it to run after the dependency
-  resolves) rather than leaving the constraint as prose-only
+  for that issue rather than leaving the constraint as prose-only
   sequencing. Discover and A4.5 honor the hard `Blocked by` edge, not
   a narrative "runs after #NNN" note: A4.5 Actionability inspects the
   body, not completability, so a narrative-only dependency reports the

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1177,22 +1177,32 @@ availability, or ordering constraint.
   reviewed and verified independently
 - do not split one natural, cohesive change into artificial sibling
   issues only to widen parallel execution
-- when authoring a **docs or operator-help child that documents
-  behavior implemented by sibling issues**, encode `Blocked by #NNN` for
-  those implementation issues (or otherwise sequence the docs child to run
+- whenever an issue's own narrative states that its work cannot safely
+  start until another named issue resolves, encode `Blocked by #NNN`
+  for that issue (or otherwise sequence it to run after the dependency
+  resolves) rather than leaving the constraint as prose-only
+  sequencing. Discover and A4.5 honor the hard `Blocked by` edge, not
+  a narrative "runs after #NNN" note: A4.5 Actionability inspects the
+  body, not completability, so a narrative-only dependency reports the
+  issue startable the moment its other filters pass, and claiming it
+  then means either violating the asserted constraint or doing the
+  referenced issue's unresolved work first. This rule is general, not
+  limited to a fixed list of cases; the two recurring patterns below
+  are illustrative, not exhaustive
+- **example — docs or operator-help child that documents behavior
+  implemented by sibling issues**: encode `Blocked by #NNN` for those
+  implementation issues (or otherwise sequence the docs child to run
   after they merge) so the documentation is written against **shipped**
   behavior. Describing designed-but-unshipped behavior in the present
   tense is a recurring advisory-review-thrash pattern; "describe shipped
   behavior" is a true ordering constraint, so this edge is consistent
   with the encode-only-a-real-constraint rule above
-- when authoring a **finalize or verify track whose acceptance criteria
-  assert state produced by sibling implementation tracks**, encode
+- **example — finalize or verify track whose acceptance criteria
+  assert state produced by sibling implementation tracks**: encode
   `Blocked by #NNN` on **each** such sibling rather than stating the
-  ordering only in prose. Discover and A4.5 honor the hard `Blocked by`
-  edge, not a prose "runs after the siblings" note: A4.5 Actionability
-  inspects the body, not completability, so a prose-sequenced finalize
-  track reports startable the moment its build foundation closes, and
-  claiming it then means either failing its acceptance criteria or doing
+  ordering only in prose. A prose-sequenced finalize track reports
+  startable the moment its build foundation closes, and claiming it
+  then means either failing its acceptance criteria or doing
   the siblings' unmerged work
 - once a `Blocked by #NNN` / `Depends on #NNN` reference resolves —
   the referenced issue closes **with its required outcome verified as

--- a/docs/issue-authoring-skill.md
+++ b/docs/issue-authoring-skill.md
@@ -1179,8 +1179,7 @@ availability, or ordering constraint.
   issues only to widen parallel execution
 - whenever an issue's own narrative states that its work cannot safely
   start until another named issue resolves, encode `Blocked by #NNN`
-  for that issue (or otherwise sequence it to run after the dependency
-  resolves) rather than leaving the constraint as prose-only
+  for that issue rather than leaving the constraint as prose-only
   sequencing. Discover and A4.5 honor the hard `Blocked by` edge, not
   a narrative "runs after #NNN" note: A4.5 Actionability inspects the
   body, not completability, so a narrative-only dependency reports the

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -502,22 +502,32 @@ availability, or ordering constraint.
   reviewed and verified independently
 - do not split one natural, cohesive change into artificial sibling
   issues only to widen parallel execution
-- when authoring a **docs or operator-help child that documents
-  behavior implemented by sibling issues**, encode `Blocked by #NNN` for
-  those implementation issues (or otherwise sequence the docs child to run
+- whenever an issue's own narrative states that its work cannot safely
+  start until another named issue resolves, encode `Blocked by #NNN`
+  for that issue (or otherwise sequence it to run after the dependency
+  resolves) rather than leaving the constraint as prose-only
+  sequencing. Discover and A4.5 honor the hard `Blocked by` edge, not
+  a narrative "runs after #NNN" note: A4.5 Actionability inspects the
+  body, not completability, so a narrative-only dependency reports the
+  issue startable the moment its other filters pass, and claiming it
+  then means either violating the asserted constraint or doing the
+  referenced issue's unresolved work first. This rule is general, not
+  limited to a fixed list of cases; the two recurring patterns below
+  are illustrative, not exhaustive
+- **example — docs or operator-help child that documents behavior
+  implemented by sibling issues**: encode `Blocked by #NNN` for those
+  implementation issues (or otherwise sequence the docs child to run
   after they merge) so the documentation is written against **shipped**
   behavior. Describing designed-but-unshipped behavior in the present
   tense is a recurring advisory-review-thrash pattern; "describe shipped
   behavior" is a true ordering constraint, so this edge is consistent
   with the encode-only-a-real-constraint rule above
-- when authoring a **finalize or verify track whose acceptance criteria
-  assert state produced by sibling implementation tracks**, encode
+- **example — finalize or verify track whose acceptance criteria
+  assert state produced by sibling implementation tracks**: encode
   `Blocked by #NNN` on **each** such sibling rather than stating the
-  ordering only in prose. Discover and A4.5 honor the hard `Blocked by`
-  edge, not a prose "runs after the siblings" note: A4.5 Actionability
-  inspects the body, not completability, so a prose-sequenced finalize
-  track reports startable the moment its build foundation closes, and
-  claiming it then means either failing its acceptance criteria or doing
+  ordering only in prose. A prose-sequenced finalize track reports
+  startable the moment its build foundation closes, and claiming it
+  then means either failing its acceptance criteria or doing
   the siblings' unmerged work
 - once a `Blocked by #NNN` / `Depends on #NNN` reference resolves —
   the referenced issue closes **with its required outcome verified as

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -504,8 +504,7 @@ availability, or ordering constraint.
   issues only to widen parallel execution
 - whenever an issue's own narrative states that its work cannot safely
   start until another named issue resolves, encode `Blocked by #NNN`
-  for that issue (or otherwise sequence it to run after the dependency
-  resolves) rather than leaving the constraint as prose-only
+  for that issue rather than leaving the constraint as prose-only
   sequencing. Discover and A4.5 honor the hard `Blocked by` edge, not
   a narrative "runs after #NNN" note: A4.5 Actionability inspects the
   body, not completability, so a narrative-only dependency reports the


### PR DESCRIPTION
# Summary

Generalize the issue-authoring contract's dependency-minimization
rule: any narrative start-blocking dependency now requires `Blocked
by #NNN` encoding, not only the two previously-named cases (docs
child documenting sibling behavior; finalize/verify track asserting
sibling-produced state). Both named cases are kept as illustrative
examples under the general rule, with their existing substantive
guidance preserved. Also updates `docs/issue-authoring-skill.md`,
which carries the same section as a manually-synced (structure/contains,
not auto-generated) duplicate of the canonical
`skills/issue-authoring/references/contract.md` text — found while
implementing, and fixed to avoid leaving the two copies inconsistent.

## Linked issue

Closes #2238

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`node scripts/sync-docs.mjs --apply` treats the
`skills/issue-authoring/references/contract.md` ↔
`docs/issue-authoring-skill.md` relationship as a structural
"contains" check (specific required-text markers only), not a
byte-for-byte mirror, so the generalized rule text did not propagate
automatically — both files needed the same manual edit.

## IDD impact

- [x] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [ ] `pnpm test` (docs-only change, no test suite coverage applicable)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified dependency-minimization guidance across issue-authoring documentation.
  - Narrative prerequisites must now be represented with an explicit blocking dependency or equivalent sequencing.
  - Updated examples to reflect the broader rule while retaining implementation and verification sequencing requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->