### PR TITLE
feat(onboard): add --hear propose/apply/TTY to idd-onboard

### DIFF
--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -1243,6 +1243,8 @@ function collectGhCliEvidence(host) {
 // Fenced-block utilities the distributed workflow instructions assume
 // (idd-template/docs/onboarding/hearing-catalog.json's execution-environment
 // item explanation) -- `sh`/`bash` themselves are checked separately below.
+// `jq` is the item's own separately-called-out requirement for the
+// instructions-only advisory-wait fallback (#2304 review).
 const HEAR_REQUIRED_UTILITIES = [
   'grep',
   'sed',
@@ -1252,22 +1254,29 @@ const HEAR_REQUIRED_UTILITIES = [
   'head',
   'sort',
   'curl',
+  'jq',
 ];
-function isUtilityAvailable(name) {
+function isUtilityAvailable(shell, name) {
   // `name` is always one of the fixed HEAR_REQUIRED_UTILITIES literals
   // above, never dash-prefixed or otherwise untrusted, so the `--`
   // end-of-options guard buys no real safety here -- and some /bin/sh
   // implementations treat `--` as the command_name argument to the
   // `command` builtin instead of an option terminator, which would
   // misreport every utility as missing (#2304 review).
-  return execSucceeds('sh', ['-c', `command -v ${name}`]);
+  return execSucceeds(shell, ['-c', `command -v ${name}`]);
 }
 function collectExecutionEnvironmentEvidence() {
-  const posixShell = execSucceeds('sh', ['-c', 'true']);
-  const missingUtilities = posixShell
-    ? HEAR_REQUIRED_UTILITIES.filter((name) => !isUtilityAvailable(name))
+  const shAvailable = execSucceeds('sh', ['-c', 'true']);
+  const bashAvailable = execSucceeds('bash', ['-c', 'true']);
+  // Probe utilities through whichever POSIX-ish shell is actually
+  // present -- the catalog item accepts either (#2304 review).
+  const probeShell = shAvailable ? 'sh' : bashAvailable ? 'bash' : null;
+  const missingUtilities = probeShell
+    ? HEAR_REQUIRED_UTILITIES.filter(
+        (name) => !isUtilityAvailable(probeShell, name),
+      )
     : [...HEAR_REQUIRED_UTILITIES];
-  return { posixShell, missingUtilities };
+  return { shAvailable, bashAvailable, missingUtilities };
 }
 function isValidHearAnswerValue(item, value) {
   if (value.length === 0) {

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -56,6 +56,9 @@ import {
   PROFILE_NAMES,
 } from './helper-runtime-manifest.mjs';
 import { findMissingWorktreeHardening } from './idd-doctor.mjs';
+import { loadOnboardingHearingCatalog } from './onboarding-hearing.mjs';
+import { makeReadlinePrompt } from './readline-prompt.mjs';
+import { loadJson, validate } from './validate-schemas.mjs';
 
 function placeholder(name, kind, flag) {
   return { name, token: `{{${name}}}`, kind, flag };
@@ -1158,17 +1161,334 @@ export function runVerify(sourceRoot, targetRoot, profile) {
     blocking,
   };
 }
-if (import.meta.main) {
+// --hear (#2281): the operator-facing hearing CLI. Wires the catalog
+// loader (#2279) and the existing placeholder-derivation hooks
+// (deriveMarkerPrefix, deriveInstallDepsCommand, deriveValidateCommands
+// via resolvePlaceholderValues, collectHelperRuntimeEvidence) into
+// three modes: --propose (read-only JSON), --apply --answers <file>
+// (validate a flat id->value map, print a confirmed transcript), and a
+// bare TTY wizard producing the same transcript shape. --hear never
+// persists config or rewrites ONBOARDING.md.
+/** Catalog item kinds the hearing transcript records an answer for. */
+function isAnswerableHearingItem(item) {
+  return item.kind !== 'check';
+}
+function buildHearCatalogItemViews(items, targetDir) {
+  const resolution = resolvePlaceholderValues(targetDir);
+  return items.map((item) => {
+    const documentedDefault =
+      item.options?.find((o) => o.isDefault)?.value ?? null;
+    const resolved = resolution.values[item.id];
+    const derived =
+      resolved != null && resolved.source === 'derived' ? resolved.value : null;
+    const view = {
+      id: item.id,
+      step: item.step,
+      kind: item.kind,
+      prompt: item.prompt,
+      explanation: item.explanation,
+      documentedDefault,
+      derived,
+    };
+    if (item.options) {
+      view.options = item.options;
+    }
+    return view;
+  });
+}
+function execSucceeds(command, execArgs) {
   try {
-    runCli();
-  } catch (error) {
+    execFileSync(command, execArgs, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+function safeExecOutput(command, execArgs) {
+  try {
+    return execFileSync(command, execArgs, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+/** Derive the `gh --hostname` value from the target's git remote (#2279's gh-cli / git-remote-host catalog items). */
+function deriveGitRemoteHost(targetDir) {
+  const remoteUrl = readGitRemoteUrl(targetDir);
+  if (remoteUrl === null) {
+    return null;
+  }
+  const scpMatch = remoteUrl.match(/^[\w.-]+@([\w.-]+):/);
+  if (scpMatch) {
+    return scpMatch[1] ?? null;
+  }
+  try {
+    return new URL(remoteUrl).host || null;
+  } catch {
+    return null;
+  }
+}
+function collectGhCliEvidence(host) {
+  const versionOutput = safeExecOutput('gh', ['--version']);
+  const available = versionOutput !== null;
+  const version = available ? (versionOutput.split('\n')[0] ?? null) : null;
+  const hostAuthenticated =
+    available && host !== null
+      ? execSucceeds('gh', ['auth', 'status', '--hostname', host])
+      : null;
+  return { available, version, hostAuthenticated };
+}
+// Fenced-block utilities the distributed workflow instructions assume
+// (idd-template/docs/onboarding/hearing-catalog.json's execution-environment
+// item explanation) -- `sh`/`bash` themselves are checked separately below.
+const HEAR_REQUIRED_UTILITIES = [
+  'grep',
+  'sed',
+  'mkdir',
+  'dirname',
+  'tr',
+  'head',
+  'sort',
+  'curl',
+];
+function isUtilityAvailable(name) {
+  return execSucceeds('sh', ['-c', `command -v -- ${name}`]);
+}
+function collectExecutionEnvironmentEvidence() {
+  const posixShell = execSucceeds('sh', ['-c', 'true']);
+  const missingUtilities = posixShell
+    ? HEAR_REQUIRED_UTILITIES.filter((name) => !isUtilityAvailable(name))
+    : [...HEAR_REQUIRED_UTILITIES];
+  return { posixShell, missingUtilities };
+}
+function isValidHearAnswerValue(item, value) {
+  if (value.length === 0) {
+    return false;
+  }
+  if (item.options && item.options.length > 0) {
+    return item.options.some((option) => option.value === value);
+  }
+  return true;
+}
+/**
+ * Validate a flat `{catalogItemId: value}` map against the answerable
+ * (non-`check`) catalog items: every answerable id must be present with
+ * a value valid for that item (enum membership when `options` is set,
+ * any non-empty string otherwise); any key outside the answerable id
+ * set is unknown and also fails closed.
+ */
+function validateHearAnswers(items, answersMap) {
+  const answerable = items.filter(isAnswerableHearingItem);
+  const answerableIds = new Set(answerable.map((item) => item.id));
+  const unresolved = new Set(
+    Object.keys(answersMap).filter((key) => !answerableIds.has(key)),
+  );
+  const answers = [];
+  for (const item of answerable) {
+    const raw = answersMap[item.id];
+    if (typeof raw !== 'string' || !isValidHearAnswerValue(item, raw)) {
+      unresolved.add(item.id);
+      continue;
+    }
+    answers.push({ id: item.id, value: raw });
+  }
+  return {
+    valid: unresolved.size === 0,
+    unresolved: [...unresolved].sort(),
+    answers,
+  };
+}
+/** Confirmed transcript document, matching schemas/onboarding-hearing-transcript.schema.json. */
+function buildHearTranscript(answers) {
+  return { version: '1.0.0', confirmedAt: new Date().toISOString(), answers };
+}
+function validateHearTranscriptShape(transcript) {
+  const schema = loadJson('schemas/onboarding-hearing-transcript.schema.json');
+  return validate(transcript, schema);
+}
+export const HEAR_NON_TTY_ERROR =
+  'operator interaction is required; run idd-onboard --hear in an interactive TTY, or use --hear --propose / --hear --apply';
+/**
+ * Bounds the TTY wizard's per-item retry loop: a non-interactive caller
+ * (a scripted PromptFn, or a closed/EOF stdin under a spoofed isTTY) that
+ * never supplies a valid answer must fail loudly instead of spinning
+ * forever.
+ */
+const HEAR_WIZARD_MAX_ATTEMPTS_PER_ITEM = 5;
+export async function runHearWizard(catalog, targetDir, options = {}) {
+  const {
+    isTTY = Boolean(process.stdin.isTTY && process.stdout.isTTY),
+    prompt: promptFn,
+  } = options;
+  if (!isTTY) {
+    throw new Error(HEAR_NON_TTY_ERROR);
+  }
+  const ask = promptFn ?? makeReadlinePrompt();
+  const views = buildHearCatalogItemViews(catalog.items, targetDir).filter(
+    (view) => view.kind !== 'check',
+  );
+  const byId = new Map(catalog.items.map((item) => [item.id, item]));
+  const answers = [];
+  for (const view of views) {
+    const item = byId.get(view.id);
+    if (!item) {
+      continue;
+    }
+    const effectiveDefault = view.derived ?? view.documentedDefault;
+    process.stdout.write(`\n${view.prompt}\n${view.explanation}\n`);
+    if (view.options && view.options.length > 0) {
+      process.stdout.write(
+        `Options: ${view.options.map((option) => option.value).join(', ')}\n`,
+      );
+    }
+    let value = null;
+    for (
+      let attempt = 0;
+      value === null && attempt < HEAR_WIZARD_MAX_ATTEMPTS_PER_ITEM;
+      attempt += 1
+    ) {
+      const suffix = effectiveDefault !== null ? ` [${effectiveDefault}]` : '';
+      const raw = (await ask(`${view.id}${suffix}: `)).trim();
+      const candidate =
+        raw === '' && effectiveDefault !== null ? effectiveDefault : raw;
+      if (isValidHearAnswerValue(item, candidate)) {
+        value = candidate;
+      } else {
+        process.stdout.write('Invalid answer; please try again.\n');
+      }
+    }
+    if (value === null) {
+      ask.close?.();
+      throw new Error(
+        `no valid answer for ${view.id} after ${HEAR_WIZARD_MAX_ATTEMPTS_PER_ITEM} attempts`,
+      );
+    }
+    answers.push({ id: view.id, value });
+  }
+  ask.close?.();
+  return answers;
+}
+function runHearProposeCli(catalog, targetDir) {
+  const items = buildHearCatalogItemViews(catalog.items, targetDir);
+  const gitRemoteHost = deriveGitRemoteHost(targetDir);
+  const verdict = {
+    protocolVersion: '1',
+    mode: 'propose',
+    target: targetDir,
+    catalogVersion: catalog.version,
+    items,
+    stepZeroEvidence: {
+      ghCli: collectGhCliEvidence(gitRemoteHost),
+      gitRemoteHost,
+      executionEnvironment: collectExecutionEnvironmentEvidence(),
+    },
+    helperRuntimeEvidence: collectHelperRuntimeEvidence(targetDir),
+  };
+  process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  process.exit(0);
+}
+function runHearApplyCli(catalog, answersPath) {
+  const raw = readFileSync(resolve(answersPath), 'utf8');
+  let answersMap;
+  try {
+    answersMap = JSON.parse(raw);
+  } catch {
+    throw new Error(`--answers file is not valid JSON: ${answersPath}`);
+  }
+  if (
+    typeof answersMap !== 'object' ||
+    answersMap === null ||
+    Array.isArray(answersMap)
+  ) {
+    throw new Error(
+      '--answers file must be a JSON object mapping catalog item id to value',
+    );
+  }
+  const result = validateHearAnswers(catalog.items, answersMap);
+  if (!result.valid) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          protocolVersion: '1',
+          mode: 'apply',
+          valid: false,
+          unresolved: result.unresolved,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    process.exit(1);
+  }
+  const transcript = buildHearTranscript(result.answers);
+  const schemaErrors = validateHearTranscriptShape(transcript);
+  if (schemaErrors.length > 0) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          protocolVersion: '1',
+          mode: 'apply',
+          valid: false,
+          unresolved: schemaErrors,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    process.exit(1);
+  }
+  process.stdout.write(
+    `${JSON.stringify({ protocolVersion: '1', mode: 'apply', valid: true, transcript }, null, 2)}\n`,
+  );
+  process.exit(0);
+}
+async function runHearCli(args) {
+  const targetDir = resolve(args.target);
+  if (!statSync(targetDir).isDirectory()) {
+    throw new Error(`--target is not a directory: ${args.target}`);
+  }
+  if (args.propose && args.applyHear) {
+    throw new Error(
+      '--hear --propose and --hear --apply are mutually exclusive',
+    );
+  }
+  const catalog = loadOnboardingHearingCatalog();
+  if (args.propose) {
+    runHearProposeCli(catalog, targetDir);
+    return;
+  }
+  if (args.applyHear) {
+    if (!args.answers) {
+      throw new Error('--hear --apply requires --answers <file>');
+    }
+    runHearApplyCli(catalog, args.answers);
+    return;
+  }
+  const answers = await runHearWizard(catalog, targetDir);
+  const transcript = buildHearTranscript(answers);
+  const schemaErrors = validateHearTranscriptShape(transcript);
+  if (schemaErrors.length > 0) {
+    throw new Error(
+      `generated transcript failed schema validation: ${schemaErrors.join('; ')}`,
+    );
+  }
+  process.stdout.write(`${JSON.stringify(transcript, null, 2)}\n`);
+  process.exit(0);
+}
+function main() {
+  runCli().catch((error) => {
     // Usage/config errors exit 2, keeping exit 1 unambiguous as the
     // residue signal (same split as audit-pr-cleanup's fail()).
     process.stderr.write(
       `idd-onboard: ${error instanceof Error ? error.message : String(error)}\n`,
     );
     process.exit(2);
-  }
+  });
+}
+if (import.meta.main) {
+  main();
 }
 // Excluded from the #1446 cli-args.mts wrapper: the placeholder-override
 // flags below (`flagToName`) are data-driven from `ONBOARDING_PLACEHOLDERS`
@@ -1180,6 +1500,10 @@ function parseArgs(argv) {
     substitute: false,
     importMode: false,
     verify: false,
+    hear: false,
+    propose: false,
+    applyHear: false,
+    answers: undefined,
     source: undefined,
     target: '.',
     dryRun: false,
@@ -1210,6 +1534,23 @@ function parseArgs(argv) {
     }
     if (token === '--verify') {
       parsed.verify = true;
+      continue;
+    }
+    if (token === '--hear') {
+      parsed.hear = true;
+      continue;
+    }
+    if (token === '--propose') {
+      parsed.propose = true;
+      continue;
+    }
+    if (token === '--apply') {
+      parsed.applyHear = true;
+      continue;
+    }
+    if (token === '--answers') {
+      parsed.answers = requireValue();
+      index += 1;
       continue;
     }
     if (token === '--source') {
@@ -1285,19 +1626,26 @@ function verifyForeignFlagsPresent(args) {
   }
   return present;
 }
-function runCli() {
+async function runCli() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
     printHelp();
     process.exit(0);
   }
-  const modeCount = [args.substitute, args.importMode, args.verify].filter(
-    Boolean,
-  ).length;
+  const modeCount = [
+    args.substitute,
+    args.importMode,
+    args.verify,
+    args.hear,
+  ].filter(Boolean).length;
   if (modeCount > 1) {
     throw new Error(
-      '--substitute, --import, and --verify are mutually exclusive',
+      '--substitute, --import, --verify, and --hear are mutually exclusive',
     );
+  }
+  if (args.hear) {
+    await runHearCli(args);
+    return;
   }
   if (args.importMode) {
     // parseArgs collects every known flag regardless of the active stage,
@@ -1324,7 +1672,7 @@ function runCli() {
   }
   if (!args.substitute) {
     throw new Error(
-      'pass --substitute, --import, or --verify to select a stage',
+      'pass --substitute, --import, --verify, or --hear to select a stage',
     );
   }
   const foreign = importOnlyFlagsPresent(args);
@@ -1458,6 +1806,9 @@ function printHelp() {
   process.stdout.write(`usage: node scripts/idd-onboard.mjs --substitute [options]
        node scripts/idd-onboard.mjs --import --source <dir> --target <dir> [options]
        node scripts/idd-onboard.mjs --verify --source <dir> --target <dir> [options]
+       node scripts/idd-onboard.mjs --hear --propose --target <dir>
+       node scripts/idd-onboard.mjs --hear --apply --answers <file> --target <dir>
+       node scripts/idd-onboard.mjs --hear --target <dir>   (interactive TTY wizard)
 
 Onboarding automation.
 
@@ -1529,5 +1880,39 @@ or placeholder residue); 2 usage or configuration error.
   --target <dir>                     target repository to verify (default: current directory)
   --profile <name>                   ${PROFILE_NAMES.join(' | ')}
   --help, -h                         show this help
+
+--hear (#2281): the operator-facing hearing CLI over the catalog and
+transcript schemas #2279 ships (idd-template/docs/onboarding/hearing-catalog.json).
+Derives candidates for the 21 answerable (non-check) catalog items by
+reusing --substitute's own derivation hooks
+(resolvePlaceholderValues / deriveMarkerPrefix / deriveInstallDepsCommand /
+deriveValidateCommands) and reports helper-runtime evidence
+(collectHelperRuntimeEvidence). Never edits idd-template/ONBOARDING.md,
+never writes .github/idd/config.json, never requires --source.
+
+  --hear --propose            read-only: print catalog items (with any
+                               derived candidate and documented default),
+                               Step 0 gh-cli / git-remote-host /
+                               execution-environment evidence, and
+                               helper-runtime evidence as JSON. Exit 0.
+  --hear --apply --answers <file>
+                               validate a JSON object mapping catalog
+                               item id -> confirmed value against the
+                               catalog and the transcript schema, then
+                               print the confirmed transcript. Exit 0
+                               valid; 1 a required id is missing, an id
+                               is unknown, or a value is not one of that
+                               item's options (nothing is written
+                               either way).
+  --hear (no --propose/--apply)
+                               interactive TTY wizard over the same 21
+                               items; shows each item's explanation,
+                               accepts empty input to confirm the shown
+                               default, and prints the same transcript
+                               shape as --apply. Exit 2 when stdin/stdout
+                               is not a TTY.
+  --target <dir>               target repository (default: current directory)
+  --answers <file>              path to the --apply answers JSON file
+  --help, -h                    show this help
 `);
 }

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -1254,7 +1254,13 @@ const HEAR_REQUIRED_UTILITIES = [
   'curl',
 ];
 function isUtilityAvailable(name) {
-  return execSucceeds('sh', ['-c', `command -v -- ${name}`]);
+  // `name` is always one of the fixed HEAR_REQUIRED_UTILITIES literals
+  // above, never dash-prefixed or otherwise untrusted, so the `--`
+  // end-of-options guard buys no real safety here -- and some /bin/sh
+  // implementations treat `--` as the command_name argument to the
+  // `command` builtin instead of an option terminator, which would
+  // misreport every utility as missing (#2304 review).
+  return execSucceeds('sh', ['-c', `command -v ${name}`]);
 }
 function collectExecutionEnvironmentEvidence() {
   const posixShell = execSucceeds('sh', ['-c', 'true']);

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -1449,9 +1449,11 @@ function runHearApplyCli(catalog, answersPath) {
     );
     process.exit(1);
   }
-  process.stdout.write(
-    `${JSON.stringify({ protocolVersion: '1', mode: 'apply', valid: true, transcript }, null, 2)}\n`,
-  );
+  // Print the transcript document itself (matching the interactive
+  // --hear wizard's own output), not a wrapper -- the printed JSON must
+  // validate against onboarding-hearing-transcript.schema.json directly
+  // (#2304 review).
+  process.stdout.write(`${JSON.stringify(transcript, null, 2)}\n`);
   process.exit(0);
 }
 async function runHearCli(args) {

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -1294,11 +1294,15 @@ function validateHearAnswers(items, answersMap) {
   const answers = [];
   for (const item of answerable) {
     const raw = answersMap[item.id];
-    if (typeof raw !== 'string' || !isValidHearAnswerValue(item, raw)) {
+    // Trim to match the TTY wizard's own input handling, so a
+    // whitespace-only answers-file value is treated the same as an
+    // empty one instead of silently passing option-less validation.
+    const value = typeof raw === 'string' ? raw.trim() : raw;
+    if (typeof value !== 'string' || !isValidHearAnswerValue(item, value)) {
       unresolved.add(item.id);
       continue;
     }
-    answers.push({ id: item.id, value: raw });
+    answers.push({ id: item.id, value });
   }
   return {
     valid: unresolved.size === 0,
@@ -1632,6 +1636,29 @@ function verifyForeignFlagsPresent(args) {
   }
   return present;
 }
+/** --hear-only flags the user explicitly passed (present regardless of mode). */
+function hearOnlyFlagsPresent(args) {
+  const present = [];
+  if (args.propose) {
+    present.push('--propose');
+  }
+  if (args.applyHear) {
+    present.push('--apply');
+  }
+  if (args.answers !== undefined) {
+    present.push('--answers');
+  }
+  return present;
+}
+/**
+ * Flags --hear does not accept: every import-only flag (`--source`,
+ * `--force`, `--profile` -- --hear never imports or overwrites) plus every
+ * substitute-only placeholder-override flag (--hear derives candidates
+ * read-only via the same hooks; it never accepts an explicit override).
+ */
+function hearForeignFlagsPresent(args) {
+  return [...importOnlyFlagsPresent(args), ...substituteOnlyFlagsPresent(args)];
+}
 async function runCli() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -1650,6 +1677,12 @@ async function runCli() {
     );
   }
   if (args.hear) {
+    const foreign = hearForeignFlagsPresent(args);
+    if (foreign.length > 0) {
+      throw new Error(
+        `--hear does not accept flag(s) it never uses: ${foreign.join(', ')}`,
+      );
+    }
     await runHearCli(args);
     return;
   }
@@ -1657,17 +1690,23 @@ async function runCli() {
     // parseArgs collects every known flag regardless of the active stage,
     // so a stage-foreign flag (e.g. a placeholder override alongside
     // --import) would otherwise be silently ignored instead of reported.
-    const foreign = substituteOnlyFlagsPresent(args);
+    const foreign = [
+      ...substituteOnlyFlagsPresent(args),
+      ...hearOnlyFlagsPresent(args),
+    ];
     if (foreign.length > 0) {
       throw new Error(
-        `--import does not accept substitute-only flag(s): ${foreign.join(', ')}`,
+        `--import does not accept substitute-only flag(s) or --hear-only flag(s): ${foreign.join(', ')}`,
       );
     }
     runImportCli(args);
     return;
   }
   if (args.verify) {
-    const foreign = verifyForeignFlagsPresent(args);
+    const foreign = [
+      ...verifyForeignFlagsPresent(args),
+      ...hearOnlyFlagsPresent(args),
+    ];
     if (foreign.length > 0) {
       throw new Error(
         `--verify does not accept flag(s) it never uses: ${foreign.join(', ')}`,
@@ -1681,10 +1720,13 @@ async function runCli() {
       'pass --substitute, --import, --verify, or --hear to select a stage',
     );
   }
-  const foreign = importOnlyFlagsPresent(args);
+  const foreign = [
+    ...importOnlyFlagsPresent(args),
+    ...hearOnlyFlagsPresent(args),
+  ];
   if (foreign.length > 0) {
     throw new Error(
-      `--substitute does not accept import-only flag(s): ${foreign.join(', ')}`,
+      `--substitute does not accept import-only flag(s) or --hear-only flag(s): ${foreign.join(', ')}`,
     );
   }
   const targetDir = resolve(args.target);

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -1592,6 +1592,8 @@ function collectGhCliEvidence(host: string | null): HearGhCliEvidence {
 // Fenced-block utilities the distributed workflow instructions assume
 // (idd-template/docs/onboarding/hearing-catalog.json's execution-environment
 // item explanation) -- `sh`/`bash` themselves are checked separately below.
+// `jq` is the item's own separately-called-out requirement for the
+// instructions-only advisory-wait fallback (#2304 review).
 const HEAR_REQUIRED_UTILITIES = [
   'grep',
   'sed',
@@ -1601,29 +1603,37 @@ const HEAR_REQUIRED_UTILITIES = [
   'head',
   'sort',
   'curl',
+  'jq',
 ] as const;
 
-function isUtilityAvailable(name: string): boolean {
+function isUtilityAvailable(shell: string, name: string): boolean {
   // `name` is always one of the fixed HEAR_REQUIRED_UTILITIES literals
   // above, never dash-prefixed or otherwise untrusted, so the `--`
   // end-of-options guard buys no real safety here -- and some /bin/sh
   // implementations treat `--` as the command_name argument to the
   // `command` builtin instead of an option terminator, which would
   // misreport every utility as missing (#2304 review).
-  return execSucceeds('sh', ['-c', `command -v ${name}`]);
+  return execSucceeds(shell, ['-c', `command -v ${name}`]);
 }
 
 interface HearExecutionEnvironmentEvidence {
-  posixShell: boolean;
+  shAvailable: boolean;
+  bashAvailable: boolean;
   missingUtilities: string[];
 }
 
 function collectExecutionEnvironmentEvidence(): HearExecutionEnvironmentEvidence {
-  const posixShell = execSucceeds('sh', ['-c', 'true']);
-  const missingUtilities = posixShell
-    ? HEAR_REQUIRED_UTILITIES.filter((name) => !isUtilityAvailable(name))
+  const shAvailable = execSucceeds('sh', ['-c', 'true']);
+  const bashAvailable = execSucceeds('bash', ['-c', 'true']);
+  // Probe utilities through whichever POSIX-ish shell is actually
+  // present -- the catalog item accepts either (#2304 review).
+  const probeShell = shAvailable ? 'sh' : bashAvailable ? 'bash' : null;
+  const missingUtilities = probeShell
+    ? HEAR_REQUIRED_UTILITIES.filter(
+        (name) => !isUtilityAvailable(probeShell, name),
+      )
     : [...HEAR_REQUIRED_UTILITIES];
-  return { posixShell, missingUtilities };
+  return { shAvailable, bashAvailable, missingUtilities };
 }
 
 function isValidHearAnswerValue(

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -1671,11 +1671,15 @@ function validateHearAnswers(
   const answers: HearAnswer[] = [];
   for (const item of answerable) {
     const raw = answersMap[item.id];
-    if (typeof raw !== 'string' || !isValidHearAnswerValue(item, raw)) {
+    // Trim to match the TTY wizard's own input handling, so a
+    // whitespace-only answers-file value is treated the same as an
+    // empty one instead of silently passing option-less validation.
+    const value = typeof raw === 'string' ? raw.trim() : raw;
+    if (typeof value !== 'string' || !isValidHearAnswerValue(item, value)) {
       unresolved.add(item.id);
       continue;
     }
-    answers.push({ id: item.id, value: raw });
+    answers.push({ id: item.id, value });
   }
   return {
     valid: unresolved.size === 0,
@@ -2064,6 +2068,31 @@ function verifyForeignFlagsPresent(args: ParsedArgs): string[] {
   return present;
 }
 
+/** --hear-only flags the user explicitly passed (present regardless of mode). */
+function hearOnlyFlagsPresent(args: ParsedArgs): string[] {
+  const present: string[] = [];
+  if (args.propose) {
+    present.push('--propose');
+  }
+  if (args.applyHear) {
+    present.push('--apply');
+  }
+  if (args.answers !== undefined) {
+    present.push('--answers');
+  }
+  return present;
+}
+
+/**
+ * Flags --hear does not accept: every import-only flag (`--source`,
+ * `--force`, `--profile` -- --hear never imports or overwrites) plus every
+ * substitute-only placeholder-override flag (--hear derives candidates
+ * read-only via the same hooks; it never accepts an explicit override).
+ */
+function hearForeignFlagsPresent(args: ParsedArgs): string[] {
+  return [...importOnlyFlagsPresent(args), ...substituteOnlyFlagsPresent(args)];
+}
+
 async function runCli(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
@@ -2082,6 +2111,12 @@ async function runCli(): Promise<void> {
     );
   }
   if (args.hear) {
+    const foreign = hearForeignFlagsPresent(args);
+    if (foreign.length > 0) {
+      throw new Error(
+        `--hear does not accept flag(s) it never uses: ${foreign.join(', ')}`,
+      );
+    }
     await runHearCli(args);
     return;
   }
@@ -2089,17 +2124,23 @@ async function runCli(): Promise<void> {
     // parseArgs collects every known flag regardless of the active stage,
     // so a stage-foreign flag (e.g. a placeholder override alongside
     // --import) would otherwise be silently ignored instead of reported.
-    const foreign = substituteOnlyFlagsPresent(args);
+    const foreign = [
+      ...substituteOnlyFlagsPresent(args),
+      ...hearOnlyFlagsPresent(args),
+    ];
     if (foreign.length > 0) {
       throw new Error(
-        `--import does not accept substitute-only flag(s): ${foreign.join(', ')}`,
+        `--import does not accept substitute-only flag(s) or --hear-only flag(s): ${foreign.join(', ')}`,
       );
     }
     runImportCli(args);
     return;
   }
   if (args.verify) {
-    const foreign = verifyForeignFlagsPresent(args);
+    const foreign = [
+      ...verifyForeignFlagsPresent(args),
+      ...hearOnlyFlagsPresent(args),
+    ];
     if (foreign.length > 0) {
       throw new Error(
         `--verify does not accept flag(s) it never uses: ${foreign.join(', ')}`,
@@ -2113,10 +2154,13 @@ async function runCli(): Promise<void> {
       'pass --substitute, --import, --verify, or --hear to select a stage',
     );
   }
-  const foreign = importOnlyFlagsPresent(args);
+  const foreign = [
+    ...importOnlyFlagsPresent(args),
+    ...hearOnlyFlagsPresent(args),
+  ];
   if (foreign.length > 0) {
     throw new Error(
-      `--substitute does not accept import-only flag(s): ${foreign.join(', ')}`,
+      `--substitute does not accept import-only flag(s) or --hear-only flag(s): ${foreign.join(', ')}`,
     );
   }
   const targetDir = resolve(args.target);

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -1604,7 +1604,13 @@ const HEAR_REQUIRED_UTILITIES = [
 ] as const;
 
 function isUtilityAvailable(name: string): boolean {
-  return execSucceeds('sh', ['-c', `command -v -- ${name}`]);
+  // `name` is always one of the fixed HEAR_REQUIRED_UTILITIES literals
+  // above, never dash-prefixed or otherwise untrusted, so the `--`
+  // end-of-options guard buys no real safety here -- and some /bin/sh
+  // implementations treat `--` as the command_name argument to the
+  // `command` builtin instead of an option terminator, which would
+  // misreport every utility as missing (#2304 review).
+  return execSucceeds('sh', ['-c', `command -v ${name}`]);
 }
 
 interface HearExecutionEnvironmentEvidence {

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -1856,9 +1856,11 @@ function runHearApplyCli(
     );
     process.exit(1);
   }
-  process.stdout.write(
-    `${JSON.stringify({ protocolVersion: '1', mode: 'apply', valid: true, transcript }, null, 2)}\n`,
-  );
+  // Print the transcript document itself (matching the interactive
+  // --hear wizard's own output), not a wrapper -- the printed JSON must
+  // validate against onboarding-hearing-transcript.schema.json directly
+  // (#2304 review).
+  process.stdout.write(`${JSON.stringify(transcript, null, 2)}\n`);
   process.exit(0);
 }
 

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -58,6 +58,14 @@ import {
   PROFILE_NAMES,
 } from './helper-runtime-manifest.mts';
 import { findMissingWorktreeHardening } from './idd-doctor.mts';
+import type {
+  HearingCatalogItem,
+  OnboardingHearingCatalog,
+} from './onboarding-hearing.mts';
+import { loadOnboardingHearingCatalog } from './onboarding-hearing.mts';
+import type { PromptFn } from './readline-prompt.mts';
+import { makeReadlinePrompt } from './readline-prompt.mts';
+import { loadJson, validate } from './validate-schemas.mts';
 
 /** Substitution role of a placeholder: only `command` rows may be `true`. */
 export type OnboardingPlaceholderKind = 'identity' | 'command';
@@ -1471,23 +1479,436 @@ export function runVerify(
   };
 }
 
-if (import.meta.main) {
+// --hear (#2281): the operator-facing hearing CLI. Wires the catalog
+// loader (#2279) and the existing placeholder-derivation hooks
+// (deriveMarkerPrefix, deriveInstallDepsCommand, deriveValidateCommands
+// via resolvePlaceholderValues, collectHelperRuntimeEvidence) into
+// three modes: --propose (read-only JSON), --apply --answers <file>
+// (validate a flat id->value map, print a confirmed transcript), and a
+// bare TTY wizard producing the same transcript shape. --hear never
+// persists config or rewrites ONBOARDING.md.
+
+/** Catalog item kinds the hearing transcript records an answer for. */
+function isAnswerableHearingItem(item: HearingCatalogItem): boolean {
+  return item.kind !== 'check';
+}
+
+/** One catalog item as rendered for --propose / the TTY wizard. */
+interface HearCatalogItemView {
+  id: string;
+  step: HearingCatalogItem['step'];
+  kind: HearingCatalogItem['kind'];
+  prompt: string;
+  explanation: string;
+  options?: HearingCatalogItem['options'];
+  /** The `isDefault` option's value, or null (no enum options). */
+  documentedDefault: string | null;
+  /** The matching resolvePlaceholderValues() candidate, only when its
+   *  source is 'derived' (never an operator-supplied override). */
+  derived: string | null;
+}
+
+function buildHearCatalogItemViews(
+  items: readonly HearingCatalogItem[],
+  targetDir: string,
+): HearCatalogItemView[] {
+  const resolution = resolvePlaceholderValues(targetDir);
+  return items.map((item) => {
+    const documentedDefault =
+      item.options?.find((o) => o.isDefault)?.value ?? null;
+    const resolved = resolution.values[item.id];
+    const derived =
+      resolved != null && resolved.source === 'derived' ? resolved.value : null;
+    const view: HearCatalogItemView = {
+      id: item.id,
+      step: item.step,
+      kind: item.kind,
+      prompt: item.prompt,
+      explanation: item.explanation,
+      documentedDefault,
+      derived,
+    };
+    if (item.options) {
+      view.options = item.options;
+    }
+    return view;
+  });
+}
+
+function execSucceeds(command: string, execArgs: string[]): boolean {
   try {
-    runCli();
-  } catch (error) {
+    execFileSync(command, execArgs, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function safeExecOutput(command: string, execArgs: string[]): string | null {
+  try {
+    return execFileSync(command, execArgs, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/** Derive the `gh --hostname` value from the target's git remote (#2279's gh-cli / git-remote-host catalog items). */
+function deriveGitRemoteHost(targetDir: string): string | null {
+  const remoteUrl = readGitRemoteUrl(targetDir);
+  if (remoteUrl === null) {
+    return null;
+  }
+  const scpMatch = remoteUrl.match(/^[\w.-]+@([\w.-]+):/);
+  if (scpMatch) {
+    return scpMatch[1] ?? null;
+  }
+  try {
+    return new URL(remoteUrl).host || null;
+  } catch {
+    return null;
+  }
+}
+
+interface HearGhCliEvidence {
+  available: boolean;
+  version: string | null;
+  hostAuthenticated: boolean | null;
+}
+
+function collectGhCliEvidence(host: string | null): HearGhCliEvidence {
+  const versionOutput = safeExecOutput('gh', ['--version']);
+  const available = versionOutput !== null;
+  const version = available ? (versionOutput.split('\n')[0] ?? null) : null;
+  const hostAuthenticated =
+    available && host !== null
+      ? execSucceeds('gh', ['auth', 'status', '--hostname', host])
+      : null;
+  return { available, version, hostAuthenticated };
+}
+
+// Fenced-block utilities the distributed workflow instructions assume
+// (idd-template/docs/onboarding/hearing-catalog.json's execution-environment
+// item explanation) -- `sh`/`bash` themselves are checked separately below.
+const HEAR_REQUIRED_UTILITIES = [
+  'grep',
+  'sed',
+  'mkdir',
+  'dirname',
+  'tr',
+  'head',
+  'sort',
+  'curl',
+] as const;
+
+function isUtilityAvailable(name: string): boolean {
+  return execSucceeds('sh', ['-c', `command -v -- ${name}`]);
+}
+
+interface HearExecutionEnvironmentEvidence {
+  posixShell: boolean;
+  missingUtilities: string[];
+}
+
+function collectExecutionEnvironmentEvidence(): HearExecutionEnvironmentEvidence {
+  const posixShell = execSucceeds('sh', ['-c', 'true']);
+  const missingUtilities = posixShell
+    ? HEAR_REQUIRED_UTILITIES.filter((name) => !isUtilityAvailable(name))
+    : [...HEAR_REQUIRED_UTILITIES];
+  return { posixShell, missingUtilities };
+}
+
+function isValidHearAnswerValue(
+  item: HearingCatalogItem,
+  value: string,
+): boolean {
+  if (value.length === 0) {
+    return false;
+  }
+  if (item.options && item.options.length > 0) {
+    return item.options.some((option) => option.value === value);
+  }
+  return true;
+}
+
+/** One confirmed `{id, value}` pair, matching the transcript schema's answers[] shape. */
+interface HearAnswer {
+  id: string;
+  value: string;
+}
+
+interface HearAnswerValidation {
+  valid: boolean;
+  /** Offending ids: missing, unknown, or an invalid/out-of-enum value. */
+  unresolved: string[];
+  answers: HearAnswer[];
+}
+
+/**
+ * Validate a flat `{catalogItemId: value}` map against the answerable
+ * (non-`check`) catalog items: every answerable id must be present with
+ * a value valid for that item (enum membership when `options` is set,
+ * any non-empty string otherwise); any key outside the answerable id
+ * set is unknown and also fails closed.
+ */
+function validateHearAnswers(
+  items: readonly HearingCatalogItem[],
+  answersMap: Record<string, unknown>,
+): HearAnswerValidation {
+  const answerable = items.filter(isAnswerableHearingItem);
+  const answerableIds = new Set(answerable.map((item) => item.id));
+  const unresolved = new Set<string>(
+    Object.keys(answersMap).filter((key) => !answerableIds.has(key)),
+  );
+  const answers: HearAnswer[] = [];
+  for (const item of answerable) {
+    const raw = answersMap[item.id];
+    if (typeof raw !== 'string' || !isValidHearAnswerValue(item, raw)) {
+      unresolved.add(item.id);
+      continue;
+    }
+    answers.push({ id: item.id, value: raw });
+  }
+  return {
+    valid: unresolved.size === 0,
+    unresolved: [...unresolved].sort(),
+    answers,
+  };
+}
+
+/** Confirmed transcript document, matching schemas/onboarding-hearing-transcript.schema.json. */
+function buildHearTranscript(answers: readonly HearAnswer[]): {
+  version: string;
+  confirmedAt: string;
+  answers: readonly HearAnswer[];
+} {
+  return { version: '1.0.0', confirmedAt: new Date().toISOString(), answers };
+}
+
+function validateHearTranscriptShape(transcript: unknown): string[] {
+  const schema = loadJson('schemas/onboarding-hearing-transcript.schema.json');
+  return validate(transcript, schema);
+}
+
+/** Options accepted by {@link runHearWizard}, injectable for tests (mirrors force-handoff.mts's RunHandoffOptions). */
+interface RunHearWizardOptions {
+  isTTY?: boolean;
+  prompt?: PromptFn;
+}
+
+export const HEAR_NON_TTY_ERROR =
+  'operator interaction is required; run idd-onboard --hear in an interactive TTY, or use --hear --propose / --hear --apply';
+
+/**
+ * Bounds the TTY wizard's per-item retry loop: a non-interactive caller
+ * (a scripted PromptFn, or a closed/EOF stdin under a spoofed isTTY) that
+ * never supplies a valid answer must fail loudly instead of spinning
+ * forever.
+ */
+const HEAR_WIZARD_MAX_ATTEMPTS_PER_ITEM = 5;
+
+export async function runHearWizard(
+  catalog: OnboardingHearingCatalog,
+  targetDir: string,
+  options: RunHearWizardOptions = {},
+): Promise<HearAnswer[]> {
+  const {
+    isTTY = Boolean(process.stdin.isTTY && process.stdout.isTTY),
+    prompt: promptFn,
+  } = options;
+  if (!isTTY) {
+    throw new Error(HEAR_NON_TTY_ERROR);
+  }
+  const ask = promptFn ?? makeReadlinePrompt();
+  const views = buildHearCatalogItemViews(catalog.items, targetDir).filter(
+    (view) => view.kind !== 'check',
+  );
+  const byId = new Map(catalog.items.map((item) => [item.id, item]));
+  const answers: HearAnswer[] = [];
+  for (const view of views) {
+    const item = byId.get(view.id);
+    if (!item) {
+      continue;
+    }
+    const effectiveDefault = view.derived ?? view.documentedDefault;
+    process.stdout.write(`\n${view.prompt}\n${view.explanation}\n`);
+    if (view.options && view.options.length > 0) {
+      process.stdout.write(
+        `Options: ${view.options.map((option) => option.value).join(', ')}\n`,
+      );
+    }
+    let value: string | null = null;
+    for (
+      let attempt = 0;
+      value === null && attempt < HEAR_WIZARD_MAX_ATTEMPTS_PER_ITEM;
+      attempt += 1
+    ) {
+      const suffix = effectiveDefault !== null ? ` [${effectiveDefault}]` : '';
+      const raw = (await ask(`${view.id}${suffix}: `)).trim();
+      const candidate =
+        raw === '' && effectiveDefault !== null ? effectiveDefault : raw;
+      if (isValidHearAnswerValue(item, candidate)) {
+        value = candidate;
+      } else {
+        process.stdout.write('Invalid answer; please try again.\n');
+      }
+    }
+    if (value === null) {
+      ask.close?.();
+      throw new Error(
+        `no valid answer for ${view.id} after ${HEAR_WIZARD_MAX_ATTEMPTS_PER_ITEM} attempts`,
+      );
+    }
+    answers.push({ id: view.id, value });
+  }
+  ask.close?.();
+  return answers;
+}
+
+function runHearProposeCli(
+  catalog: OnboardingHearingCatalog,
+  targetDir: string,
+): void {
+  const items = buildHearCatalogItemViews(catalog.items, targetDir);
+  const gitRemoteHost = deriveGitRemoteHost(targetDir);
+  const verdict = {
+    protocolVersion: '1',
+    mode: 'propose',
+    target: targetDir,
+    catalogVersion: catalog.version,
+    items,
+    stepZeroEvidence: {
+      ghCli: collectGhCliEvidence(gitRemoteHost),
+      gitRemoteHost,
+      executionEnvironment: collectExecutionEnvironmentEvidence(),
+    },
+    helperRuntimeEvidence: collectHelperRuntimeEvidence(targetDir),
+  };
+  process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
+  process.exit(0);
+}
+
+function runHearApplyCli(
+  catalog: OnboardingHearingCatalog,
+  answersPath: string,
+): void {
+  const raw = readFileSync(resolve(answersPath), 'utf8');
+  let answersMap: unknown;
+  try {
+    answersMap = JSON.parse(raw);
+  } catch {
+    throw new Error(`--answers file is not valid JSON: ${answersPath}`);
+  }
+  if (
+    typeof answersMap !== 'object' ||
+    answersMap === null ||
+    Array.isArray(answersMap)
+  ) {
+    throw new Error(
+      '--answers file must be a JSON object mapping catalog item id to value',
+    );
+  }
+  const result = validateHearAnswers(
+    catalog.items,
+    answersMap as Record<string, unknown>,
+  );
+  if (!result.valid) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          protocolVersion: '1',
+          mode: 'apply',
+          valid: false,
+          unresolved: result.unresolved,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    process.exit(1);
+  }
+  const transcript = buildHearTranscript(result.answers);
+  const schemaErrors = validateHearTranscriptShape(transcript);
+  if (schemaErrors.length > 0) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          protocolVersion: '1',
+          mode: 'apply',
+          valid: false,
+          unresolved: schemaErrors,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    process.exit(1);
+  }
+  process.stdout.write(
+    `${JSON.stringify({ protocolVersion: '1', mode: 'apply', valid: true, transcript }, null, 2)}\n`,
+  );
+  process.exit(0);
+}
+
+async function runHearCli(args: ParsedArgs): Promise<void> {
+  const targetDir = resolve(args.target);
+  if (!statSync(targetDir).isDirectory()) {
+    throw new Error(`--target is not a directory: ${args.target}`);
+  }
+  if (args.propose && args.applyHear) {
+    throw new Error(
+      '--hear --propose and --hear --apply are mutually exclusive',
+    );
+  }
+  const catalog = loadOnboardingHearingCatalog();
+  if (args.propose) {
+    runHearProposeCli(catalog, targetDir);
+    return;
+  }
+  if (args.applyHear) {
+    if (!args.answers) {
+      throw new Error('--hear --apply requires --answers <file>');
+    }
+    runHearApplyCli(catalog, args.answers);
+    return;
+  }
+  const answers = await runHearWizard(catalog, targetDir);
+  const transcript = buildHearTranscript(answers);
+  const schemaErrors = validateHearTranscriptShape(transcript);
+  if (schemaErrors.length > 0) {
+    throw new Error(
+      `generated transcript failed schema validation: ${schemaErrors.join('; ')}`,
+    );
+  }
+  process.stdout.write(`${JSON.stringify(transcript, null, 2)}\n`);
+  process.exit(0);
+}
+
+function main(): void {
+  runCli().catch((error: unknown) => {
     // Usage/config errors exit 2, keeping exit 1 unambiguous as the
     // residue signal (same split as audit-pr-cleanup's fail()).
     process.stderr.write(
       `idd-onboard: ${error instanceof Error ? error.message : String(error)}\n`,
     );
     process.exit(2);
-  }
+  });
+}
+
+if (import.meta.main) {
+  main();
 }
 
 interface ParsedArgs {
   substitute: boolean;
   importMode: boolean;
   verify: boolean;
+  hear: boolean;
+  propose: boolean;
+  applyHear: boolean;
+  answers: string | undefined;
   source: string | undefined;
   target: string;
   dryRun: boolean;
@@ -1507,6 +1928,10 @@ function parseArgs(argv: string[]): ParsedArgs {
     substitute: false,
     importMode: false,
     verify: false,
+    hear: false,
+    propose: false,
+    applyHear: false,
+    answers: undefined,
     source: undefined,
     target: '.',
     dryRun: false,
@@ -1537,6 +1962,23 @@ function parseArgs(argv: string[]): ParsedArgs {
     }
     if (token === '--verify') {
       parsed.verify = true;
+      continue;
+    }
+    if (token === '--hear') {
+      parsed.hear = true;
+      continue;
+    }
+    if (token === '--propose') {
+      parsed.propose = true;
+      continue;
+    }
+    if (token === '--apply') {
+      parsed.applyHear = true;
+      continue;
+    }
+    if (token === '--answers') {
+      parsed.answers = requireValue();
+      index += 1;
       continue;
     }
     if (token === '--source') {
@@ -1616,19 +2058,26 @@ function verifyForeignFlagsPresent(args: ParsedArgs): string[] {
   return present;
 }
 
-function runCli(): void {
+async function runCli(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
     printHelp();
     process.exit(0);
   }
-  const modeCount = [args.substitute, args.importMode, args.verify].filter(
-    Boolean,
-  ).length;
+  const modeCount = [
+    args.substitute,
+    args.importMode,
+    args.verify,
+    args.hear,
+  ].filter(Boolean).length;
   if (modeCount > 1) {
     throw new Error(
-      '--substitute, --import, and --verify are mutually exclusive',
+      '--substitute, --import, --verify, and --hear are mutually exclusive',
     );
+  }
+  if (args.hear) {
+    await runHearCli(args);
+    return;
   }
   if (args.importMode) {
     // parseArgs collects every known flag regardless of the active stage,
@@ -1655,7 +2104,7 @@ function runCli(): void {
   }
   if (!args.substitute) {
     throw new Error(
-      'pass --substitute, --import, or --verify to select a stage',
+      'pass --substitute, --import, --verify, or --hear to select a stage',
     );
   }
   const foreign = importOnlyFlagsPresent(args);
@@ -1792,6 +2241,9 @@ function printHelp(): void {
   process.stdout.write(`usage: node scripts/idd-onboard.mjs --substitute [options]
        node scripts/idd-onboard.mjs --import --source <dir> --target <dir> [options]
        node scripts/idd-onboard.mjs --verify --source <dir> --target <dir> [options]
+       node scripts/idd-onboard.mjs --hear --propose --target <dir>
+       node scripts/idd-onboard.mjs --hear --apply --answers <file> --target <dir>
+       node scripts/idd-onboard.mjs --hear --target <dir>   (interactive TTY wizard)
 
 Onboarding automation.
 
@@ -1863,5 +2315,39 @@ or placeholder residue); 2 usage or configuration error.
   --target <dir>                     target repository to verify (default: current directory)
   --profile <name>                   ${PROFILE_NAMES.join(' | ')}
   --help, -h                         show this help
+
+--hear (#2281): the operator-facing hearing CLI over the catalog and
+transcript schemas #2279 ships (idd-template/docs/onboarding/hearing-catalog.json).
+Derives candidates for the 21 answerable (non-check) catalog items by
+reusing --substitute's own derivation hooks
+(resolvePlaceholderValues / deriveMarkerPrefix / deriveInstallDepsCommand /
+deriveValidateCommands) and reports helper-runtime evidence
+(collectHelperRuntimeEvidence). Never edits idd-template/ONBOARDING.md,
+never writes .github/idd/config.json, never requires --source.
+
+  --hear --propose            read-only: print catalog items (with any
+                               derived candidate and documented default),
+                               Step 0 gh-cli / git-remote-host /
+                               execution-environment evidence, and
+                               helper-runtime evidence as JSON. Exit 0.
+  --hear --apply --answers <file>
+                               validate a JSON object mapping catalog
+                               item id -> confirmed value against the
+                               catalog and the transcript schema, then
+                               print the confirmed transcript. Exit 0
+                               valid; 1 a required id is missing, an id
+                               is unknown, or a value is not one of that
+                               item's options (nothing is written
+                               either way).
+  --hear (no --propose/--apply)
+                               interactive TTY wizard over the same 21
+                               items; shows each item's explanation,
+                               accepts empty input to confirm the shown
+                               default, and prints the same transcript
+                               shape as --apply. Exit 2 when stdin/stdout
+                               is not a TTY.
+  --target <dir>               target repository (default: current directory)
+  --answers <file>              path to the --apply answers JSON file
+  --help, -h                    show this help
 `);
 }

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -2708,16 +2708,34 @@ test('runHearWizard shows each explanation, confirms the shown default on empty 
     const id = question.split(/ \[|: /)[0] ?? '';
     return noDefaultAnswers[id] ?? `fixture-${id}`;
   };
-  const answers = await runHearWizard(catalog, root, {
-    isTTY: true,
-    prompt,
-  });
+  const stdoutChunks: string[] = [];
+  const originalStdoutWrite = process.stdout.write;
+  process.stdout.write = ((chunk: string) => {
+    stdoutChunks.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  let answers: Awaited<ReturnType<typeof runHearWizard>>;
+  try {
+    answers = await runHearWizard(catalog, root, { isTTY: true, prompt });
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+  }
   const answerableIds = catalog.items
     .filter((item) => item.kind !== 'check')
     .map((item) => item.id)
     .sort();
   assert.deepEqual(answers.map((answer) => answer.id).sort(), answerableIds);
   assert.equal(seenQuestions.length, answerableIds.length);
+  // Every answerable item's explanation (not just its terse prompt) was
+  // actually printed to stdout, not merely relied on inside the mock.
+  const mergePolicyItem = catalog.items.find(
+    (item) => item.id === 'merge-policy',
+  );
+  assert.ok(mergePolicyItem);
+  assert.ok(
+    stdoutChunks.some((chunk) => chunk.includes(mergePolicyItem.explanation)),
+    'expected the merge-policy explanation to be printed to stdout',
+  );
   // merge-policy has no derivation hook, so empty input confirms its
   // documented default.
   assert.equal(

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -2567,8 +2567,9 @@ test('bin/idd-onboard.mjs --hear --apply confirms a complete, valid answers map 
     answersPath,
   ]);
   assert.equal(status, 0);
-  assert.equal(verdict.valid, true);
-  const transcript = verdict.transcript as {
+  // The success output IS the transcript document -- no wrapper --
+  // matching the interactive --hear wizard's own output.
+  const transcript = verdict as unknown as {
     answers: { id: string; value: string }[];
   };
   const schema = loadJson('schemas/onboarding-hearing-transcript.schema.json');

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -2633,6 +2633,67 @@ test('bin/idd-onboard.mjs --hear --apply exits 1 when a value is outside the ite
   assert.ok((verdict.unresolved as string[]).includes('merge-policy'));
 });
 
+test('bin/idd-onboard.mjs --hear --apply trims a whitespace-only answer, same as the TTY wizard, so it fails validation rather than passing as a real value', () => {
+  const root = makeFixtureDir();
+  const answers = buildValidHearAnswers();
+  answers.TRUSTED_MARKER_ACTOR = '   ';
+  const answersPath = join(root, 'answers.json');
+  writeFileSync(answersPath, JSON.stringify(answers));
+  const { status, verdict } = runCliBin([
+    '--hear',
+    '--apply',
+    '--answers',
+    answersPath,
+  ]);
+  assert.equal(status, 1);
+  assert.ok((verdict.unresolved as string[]).includes('TRUSTED_MARKER_ACTOR'));
+});
+
+test("bin/idd-onboard.mjs --hear rejects import/substitute-only flags (--source, --force, --profile, a placeholder override), matching the other stages' own foreign-flag guards", () => {
+  const root = makeFixtureDir();
+  for (const foreignArgs of [
+    ['--source', root],
+    ['--force'],
+    ['--profile', 'package-manager'],
+    ['--repo-name', 'x'],
+  ]) {
+    try {
+      execFileSync(
+        process.execPath,
+        [BIN_PATH, '--hear', '--propose', '--target', root, ...foreignArgs],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+      assert.fail(`expected a non-zero exit for --hear + ${foreignArgs[0]}`);
+    } catch (error) {
+      const failed = error as { status?: number; stderr?: string };
+      assert.equal(failed.status, 2);
+      assert.match(String(failed.stderr), /does not accept/);
+    }
+  }
+});
+
+test('bin/idd-onboard.mjs rejects --hear-only flags (--propose, --apply, --answers) when --hear is not selected', () => {
+  const root = makeFixtureDir();
+  for (const [stage, extra] of [
+    ['--substitute', ['--propose']],
+    ['--import', ['--apply']],
+    ['--verify', ['--answers', 'answers.json']],
+  ] as const) {
+    try {
+      execFileSync(
+        process.execPath,
+        [BIN_PATH, stage, '--target', root, ...extra],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+      assert.fail(`expected a non-zero exit for ${stage} + ${extra[0]}`);
+    } catch (error) {
+      const failed = error as { status?: number; stderr?: string };
+      assert.equal(failed.status, 2);
+      assert.match(String(failed.stderr), /does not accept/);
+    }
+  }
+});
+
 test('bin/idd-onboard.mjs --hear exits 2 in a non-TTY context, without --propose or --apply', () => {
   const root = makeFixtureDir();
   try {

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -38,6 +38,7 @@ import {
   deriveMarkerPrefix,
   deriveValidateCommands,
   escapeJsonStringContent,
+  HEAR_NON_TTY_ERROR,
   listSkippedPlaceholderPaths,
   MARKER_PREFIX_PATTERN,
   ONBOARDING_PLACEHOLDERS,
@@ -47,10 +48,14 @@ import {
   resolveImportFiles,
   resolvePlaceholderValues,
   restoreExistingCommandsTable,
+  runHearWizard,
   runVerify,
   SCAN_EXCLUDED_PATHS,
   scanPlaceholderTokens,
 } from '../src/scripts/idd-onboard.mts';
+import { loadOnboardingHearingCatalog } from '../src/scripts/onboarding-hearing.mts';
+import type { PromptFn } from '../src/scripts/readline-prompt.mts';
+import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
 
 const REPO_ROOT = resolve(fileURLToPath(import.meta.url), '..', '..');
 const PLACEHOLDERS_DOC = join(
@@ -2473,6 +2478,265 @@ test('bin/idd-onboard.mjs --help documents --verify and lists --profile values s
   assert.match(help, /manifestCompleteness/);
   assert.match(help, /placeholderResidue/);
   assert.match(help, /staleImportSignal/);
+});
+
+// ---------------------------------------------------------------------------
+// --hear (#2281)
+// ---------------------------------------------------------------------------
+
+/** A target tree with the evidence deriveInstallDepsCommand / a git remote need. */
+function writeHearFixture(root: string): void {
+  execFileSync('git', ['init', '--initial-branch=main', root], {
+    stdio: 'ignore',
+  });
+  execFileSync(
+    'git',
+    [
+      '-C',
+      root,
+      'remote',
+      'add',
+      'origin',
+      'git@github.com:trusted-user-a/hear-fixture.git',
+    ],
+    { stdio: 'ignore' },
+  );
+  writeFileSync(
+    join(root, 'package.json'),
+    '{"packageManager":"pnpm@9.0.0"}\n',
+  );
+  writeFileSync(join(root, 'pnpm-lock.yaml'), '');
+}
+
+/** One valid, complete answers map: documented default per option-bearing item, a fixture value otherwise. */
+function buildValidHearAnswers(): Record<string, string> {
+  const catalog = loadOnboardingHearingCatalog();
+  const answers: Record<string, string> = {};
+  for (const item of catalog.items) {
+    if (item.kind === 'check') {
+      continue;
+    }
+    const documentedDefault = item.options?.find(
+      (option) => option.isDefault,
+    )?.value;
+    answers[item.id] = documentedDefault ?? `fixture-${item.id}`;
+  }
+  return answers;
+}
+
+test('bin/idd-onboard.mjs --hear --propose lists every catalog item id, derives PROJECT_MARKER_PREFIX and the install-deps candidate, and reports helper-runtime evidence', () => {
+  const root = makeFixtureDir();
+  writeHearFixture(root);
+  const { status, verdict } = runCliBin([
+    '--hear',
+    '--propose',
+    '--target',
+    root,
+  ]);
+  assert.equal(status, 0);
+  assert.equal(verdict.mode, 'propose');
+  const catalog = loadOnboardingHearingCatalog();
+  const items = verdict.items as {
+    id: string;
+    derived: string | null;
+  }[];
+  assert.deepEqual(
+    items.map((item) => item.id).sort(),
+    catalog.items.map((item) => item.id).sort(),
+  );
+  const byId = new Map(items.map((item) => [item.id, item]));
+  assert.equal(byId.get('PROJECT_MARKER_PREFIX')?.derived, 'hear-fixture');
+  assert.equal(byId.get('INSTALL_DEPS_COMMAND')?.derived, 'pnpm install');
+  assert.ok(verdict.helperRuntimeEvidence);
+  assert.equal(
+    (verdict.helperRuntimeEvidence as { detectedPackageManager: string })
+      .detectedPackageManager,
+    'pnpm',
+  );
+  assert.ok(verdict.stepZeroEvidence);
+});
+
+test('bin/idd-onboard.mjs --hear --apply confirms a complete, valid answers map into a schema-valid transcript', () => {
+  const root = makeFixtureDir();
+  const answersPath = join(root, 'answers.json');
+  writeFileSync(answersPath, JSON.stringify(buildValidHearAnswers()));
+  const { status, verdict } = runCliBin([
+    '--hear',
+    '--apply',
+    '--answers',
+    answersPath,
+  ]);
+  assert.equal(status, 0);
+  assert.equal(verdict.valid, true);
+  const transcript = verdict.transcript as {
+    answers: { id: string; value: string }[];
+  };
+  const schema = loadJson('schemas/onboarding-hearing-transcript.schema.json');
+  assert.deepEqual(validate(transcript, schema), []);
+  const catalog = loadOnboardingHearingCatalog();
+  const answerableIds = catalog.items
+    .filter((item) => item.kind !== 'check')
+    .map((item) => item.id)
+    .sort();
+  assert.deepEqual(
+    transcript.answers.map((answer) => answer.id).sort(),
+    answerableIds,
+  );
+});
+
+test('bin/idd-onboard.mjs --hear --apply exits 1 and names a missing answerable id, writing nothing', () => {
+  const root = makeFixtureDir();
+  const answers = buildValidHearAnswers();
+  delete answers['merge-policy'];
+  const answersPath = join(root, 'answers.json');
+  writeFileSync(answersPath, JSON.stringify(answers));
+  const { status, verdict } = runCliBin([
+    '--hear',
+    '--apply',
+    '--answers',
+    answersPath,
+  ]);
+  assert.equal(status, 1);
+  assert.equal(verdict.valid, false);
+  assert.ok((verdict.unresolved as string[]).includes('merge-policy'));
+});
+
+test('bin/idd-onboard.mjs --hear --apply exits 1 on an unknown answer key', () => {
+  const root = makeFixtureDir();
+  const answers = buildValidHearAnswers();
+  answers['not-a-real-catalog-id'] = 'x';
+  const answersPath = join(root, 'answers.json');
+  writeFileSync(answersPath, JSON.stringify(answers));
+  const { status, verdict } = runCliBin([
+    '--hear',
+    '--apply',
+    '--answers',
+    answersPath,
+  ]);
+  assert.equal(status, 1);
+  assert.ok((verdict.unresolved as string[]).includes('not-a-real-catalog-id'));
+});
+
+test('bin/idd-onboard.mjs --hear --apply exits 1 when a value is outside the item enum', () => {
+  const root = makeFixtureDir();
+  const answers = buildValidHearAnswers();
+  answers['merge-policy'] = 'not-a-real-option';
+  const answersPath = join(root, 'answers.json');
+  writeFileSync(answersPath, JSON.stringify(answers));
+  const { status, verdict } = runCliBin([
+    '--hear',
+    '--apply',
+    '--answers',
+    answersPath,
+  ]);
+  assert.equal(status, 1);
+  assert.ok((verdict.unresolved as string[]).includes('merge-policy'));
+});
+
+test('bin/idd-onboard.mjs --hear exits 2 in a non-TTY context, without --propose or --apply', () => {
+  const root = makeFixtureDir();
+  try {
+    execFileSync(process.execPath, [BIN_PATH, '--hear', '--target', root], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    assert.fail('expected a non-zero exit');
+  } catch (error) {
+    const failed = error as { status?: number; stderr?: string };
+    assert.equal(failed.status, 2);
+    assert.match(String(failed.stderr), /interactive TTY/);
+  }
+});
+
+test('bin/idd-onboard.mjs exits 2 when --hear is combined with --import, --substitute, or --verify', () => {
+  for (const other of ['--import', '--substitute', '--verify']) {
+    try {
+      execFileSync(
+        process.execPath,
+        [BIN_PATH, '--hear', '--propose', other, '--target', makeFixtureDir()],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+      );
+      assert.fail(`expected a non-zero exit for --hear + ${other}`);
+    } catch (error) {
+      const failed = error as { status?: number; stderr?: string };
+      assert.equal(failed.status, 2);
+      assert.match(String(failed.stderr), /mutually exclusive/);
+    }
+  }
+});
+
+test('bin/idd-onboard.mjs --help documents --hear, --propose, --apply, and --answers', () => {
+  const help = execFileSync(process.execPath, [BIN_PATH, '--help'], {
+    encoding: 'utf8',
+  });
+  assert.match(help, /--hear/);
+  assert.match(help, /--propose/);
+  assert.match(help, /--apply/);
+  assert.match(help, /--answers/);
+});
+
+test('runHearWizard rejects a non-TTY context with HEAR_NON_TTY_ERROR', async () => {
+  const root = makeFixtureDir();
+  const catalog = loadOnboardingHearingCatalog();
+  await assert.rejects(
+    runHearWizard(catalog, root, { isTTY: false }),
+    new RegExp(HEAR_NON_TTY_ERROR.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&')),
+  );
+});
+
+test('runHearWizard shows each explanation, confirms the shown default on empty input, and produces a schema-valid transcript', async () => {
+  const root = makeFixtureDir();
+  writeHearFixture(root);
+  const catalog = loadOnboardingHearingCatalog();
+  const noDefaultAnswers: Record<string, string> = {
+    TRUSTED_MARKER_ACTOR: 'trusted-user-a',
+    'credential-scope': 'repository-scoped-pat',
+  };
+  const seenQuestions: string[] = [];
+  const prompt: PromptFn = async (question: string) => {
+    seenQuestions.push(question);
+    // A shown "[default]" suffix confirms via empty input; an item with
+    // no default (no derivation and no documented default -- currently
+    // TRUSTED_MARKER_ACTOR and credential-scope, plus the three command
+    // placeholders when this fixture's package.json declares no
+    // lint/build/test scripts) needs an explicit fallback so this mock
+    // always terminates within runHearWizard's bounded retry.
+    const hasShownDefault = / \[/.test(question);
+    if (hasShownDefault) {
+      return '';
+    }
+    const id = question.split(/ \[|: /)[0] ?? '';
+    return noDefaultAnswers[id] ?? `fixture-${id}`;
+  };
+  const answers = await runHearWizard(catalog, root, {
+    isTTY: true,
+    prompt,
+  });
+  const answerableIds = catalog.items
+    .filter((item) => item.kind !== 'check')
+    .map((item) => item.id)
+    .sort();
+  assert.deepEqual(answers.map((answer) => answer.id).sort(), answerableIds);
+  assert.equal(seenQuestions.length, answerableIds.length);
+  // merge-policy has no derivation hook, so empty input confirms its
+  // documented default.
+  assert.equal(
+    answers.find((answer) => answer.id === 'merge-policy')?.value,
+    'human_merge',
+  );
+  // PROJECT_MARKER_PREFIX has no documented default but does derive from
+  // the fixture's git remote, so empty input confirms that instead.
+  assert.equal(
+    answers.find((answer) => answer.id === 'PROJECT_MARKER_PREFIX')?.value,
+    'hear-fixture',
+  );
+  const transcript = {
+    version: '1.0.0',
+    confirmedAt: new Date().toISOString(),
+    answers,
+  };
+  const schema = loadJson('schemas/onboarding-hearing-transcript.schema.json');
+  assert.deepEqual(validate(transcript, schema), []);
 });
 
 test('importing idd-onboard.mts has no import-time side effect', async () => {


### PR DESCRIPTION
# Summary

Adds an operator-facing hearing CLI (`--hear`) to `src/scripts/idd-onboard.mts`,
wiring the catalog and transcript schemas #2279 shipped into three modes:

- `--hear --propose --target <dir>` — read-only. Prints every catalog
  item (with a derived candidate for the placeholder items that carry a
  derivation hook, and the documented default for enum policy items),
  Step 0 `gh`-cli / git-remote-host / execution-environment evidence,
  and `collectHelperRuntimeEvidence` output, as JSON. Requires no
  `--source`, writes nothing.
- `--hear --apply --answers <file>` — validates a flat
  `{catalogItemId: value}` JSON map against the 21 answerable
  (non-`check`) catalog items (unknown keys, missing ids, and
  out-of-enum values all fail closed), then prints a confirmed
  transcript that validates against
  `schemas/onboarding-hearing-transcript.schema.json`.
- `--hear` (no `--propose`/`--apply`) — an interactive TTY wizard over
  the same 21 items, showing each item's `explanation` (not just the
  terse prompt), accepting empty input to confirm the shown default
  (derived value or documented default), and producing the same
  transcript shape. Non-TTY callers get a clear `exit 2` pointing at
  `--propose`/`--apply` instead.

Reuses the existing derivation hooks (`resolvePlaceholderValues`,
`deriveMarkerPrefix`, `deriveInstallDepsCommand`, `deriveValidateCommands`,
`collectHelperRuntimeEvidence`) rather than reimplementing placeholder
derivation. `idd-template/ONBOARDING.md` is unchanged; `--hear` never
persists `.github/idd/config.json`.

`--hear` combined with `--import`/`--substitute`/`--verify` is rejected
as mutually exclusive, matching the existing stage-selection pattern.
`--help` documents the three sub-modes.

## Linked issue

Closes #2281

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The TTY wizard bounds its per-item retry loop at 5 attempts before
failing loudly, rather than looping forever on an invalid answer — a
non-interactive caller (a scripted `PromptFn`, or a spoofed `isTTY`
with closed/EOF stdin) that never supplies a valid answer must fail
instead of hanging indefinitely.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (`pnpm run lint:minimum`)
- [x] `pnpm test` (`node --test tests/idd-onboard.test.mts`, 118 passed)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
