### PR TITLE
feat(audit-pr-cleanup): support processing several PRs in one invocation

### DIFF
--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -103,8 +103,18 @@ async function main() {
   // cachedConfiguredTrustedMarkerActorSources, cachedCurrentViewerLogin) are
   // process-lifetime state, so a --prs batch already shares that
   // per-invocation setup cost across every PR in the loop below.
+  //
+  // Table-format batches print a header before each PR's block: the table
+  // renderer's summary/candidate rows never include the `pr`/`repository`
+  // fields (unlike JSON, where each report object already self-identifies
+  // via its own `pr` field), so consecutive same-shaped blocks would
+  // otherwise be indistinguishable (Copilot review, PR #2305).
+  const printBatchHeader = args.format === 'table' && prNumbers.length > 1;
   let anyFailed = false;
   for (const prNumber of prNumbers) {
+    if (printBatchHeader) {
+      console.log(`=== PR #${prNumber} ===`);
+    }
     if (await processOnePr(owner, repo, prNumber, args)) {
       anyFailed = true;
     }

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -70,12 +70,6 @@ async function main() {
     printUsage();
     process.exit(0);
   }
-  if (!args.pr && !args.prs) {
-    fail('missing required --pr <number> or --prs <n1,n2,...>');
-  }
-  if (args.pr && args.prs) {
-    fail('choose only one of --pr or --prs');
-  }
   if (args.apply && args.dryRun) {
     fail('choose only one of --dry-run or --apply');
   }
@@ -120,12 +114,22 @@ async function main() {
   }
 }
 /**
- * Resolves `--pr`/`--prs` (exactly one is required by the caller before this
- * runs) into an ordered, de-duplicated list of PR numbers. `--prs` splits on
- * `,`, trims whitespace, drops empty tokens, and validates each remaining
- * token with the same {@link parsePositiveInteger} used by `--pr`.
+ * Resolves `--pr`/`--prs` into an ordered, de-duplicated list of PR numbers.
+ * Validates that exactly one of the two is present itself (Copilot review,
+ * PR #2305) rather than trusting the caller to have checked first — an
+ * unconditional `args.prs as string` cast on a direct call with neither flag
+ * would otherwise throw a raw `TypeError` instead of failing consistently
+ * through {@link fail}. `--prs` splits on `,`, trims whitespace, drops empty
+ * tokens, and validates each remaining token with the same
+ * {@link parsePositiveInteger} used by `--pr`.
  */
 export function parsePrNumbers(args) {
+  if (!args.pr && !args.prs) {
+    fail('missing required --pr <number> or --prs <n1,n2,...>');
+  }
+  if (args.pr && args.prs) {
+    fail('choose only one of --pr or --prs');
+  }
   if (args.pr) {
     return [parsePositiveInteger(args.pr, '--pr')];
   }

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -90,6 +90,7 @@ async function main() {
       '--apply requires --claim-issue and --claim-id, or explicit --skip-claim-check',
     );
   }
+  assertBatchApplyClaimScope(args);
   const repository = args.repo ?? detectRepository();
   const [owner, repo] = parseRepository(repository);
   const prNumbers = parsePrNumbers(args);
@@ -121,6 +122,24 @@ async function main() {
   }
   if (anyFailed) {
     process.exit(1);
+  }
+}
+/**
+ * Rejects a claim-gated `--apply` batch (#2224, CodeRabbit review on PR
+ * #2305): `assertActiveClaim` only verifies the caller holds
+ * `--claim-issue`'s active claim; it does not bind that claim to any
+ * specific PR (`expectedLinkedPrs` only feeds forced-handoff resolution). A
+ * single-PR `--apply` already carries that weak binding, but `--prs` would
+ * let one active claim authorize `--apply` mutations across every PR in the
+ * batch at once, widening the blast radius of a single claim check.
+ * `--skip-claim-check` (the explicit maintainer override) opts out of this
+ * guard, same as it does for the existing single-PR claim requirement.
+ */
+export function assertBatchApplyClaimScope(args) {
+  if (args.apply && args.prs && !args.skipClaimCheck) {
+    fail(
+      '--prs with --apply requires --skip-claim-check (a single active claim would otherwise authorize --apply across every PR in the batch)',
+    );
   }
 }
 /**

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -1379,6 +1379,7 @@ function printUsage() {
   console.log(`usage: node scripts/audit-pr-cleanup.mjs (--pr <number> | --prs <n1,n2,...>) [options]
 
 Options:
+  --pr <number>                     single-PR mode (mutually exclusive with --prs)
   --prs <n1,n2,...>                 batch mode: audit several PRs in one
                                      invocation, emitting one report per PR
                                      in the existing output shape (mutually

--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -36,6 +36,7 @@ import {
 const AUDIT_PR_CLEANUP_FLAG_SPEC = {
   '--help': { type: 'boolean', short: 'h', default: false },
   '--pr': { type: 'string' },
+  '--prs': { type: 'string' },
   '--repo': { type: 'string' },
   '--dry-run': { type: 'boolean', default: false },
   '--apply': { type: 'boolean', default: false },
@@ -69,8 +70,11 @@ async function main() {
     printUsage();
     process.exit(0);
   }
-  if (!args.pr) {
-    fail('missing required --pr <number>');
+  if (!args.pr && !args.prs) {
+    fail('missing required --pr <number> or --prs <n1,n2,...>');
+  }
+  if (args.pr && args.prs) {
+    fail('choose only one of --pr or --prs');
   }
   if (args.apply && args.dryRun) {
     fail('choose only one of --dry-run or --apply');
@@ -94,7 +98,64 @@ async function main() {
   }
   const repository = args.repo ?? detectRepository();
   const [owner, repo] = parseRepository(repository);
-  const prNumber = parsePositiveInteger(args.pr, '--pr');
+  const prNumbers = parsePrNumbers(args);
+  if (args.claimIssue) {
+    args.claimIssue = String(
+      parsePositiveInteger(args.claimIssue, '--claim-issue'),
+    );
+  }
+  // #2224: owner/repo detection above and the module-level trust/permission
+  // caches (trustedMarkerAuthorCache, collaboratorPermissionCache,
+  // cachedConfiguredTrustedMarkerActorSources, cachedCurrentViewerLogin) are
+  // process-lifetime state, so a --prs batch already shares that
+  // per-invocation setup cost across every PR in the loop below.
+  let anyFailed = false;
+  for (const prNumber of prNumbers) {
+    if (await processOnePr(owner, repo, prNumber, args)) {
+      anyFailed = true;
+    }
+  }
+  if (anyFailed) {
+    process.exit(1);
+  }
+}
+/**
+ * Resolves `--pr`/`--prs` (exactly one is required by the caller before this
+ * runs) into an ordered, de-duplicated list of PR numbers. `--prs` splits on
+ * `,`, trims whitespace, drops empty tokens, and validates each remaining
+ * token with the same {@link parsePositiveInteger} used by `--pr`.
+ */
+export function parsePrNumbers(args) {
+  if (args.pr) {
+    return [parsePositiveInteger(args.pr, '--pr')];
+  }
+  const seen = new Set();
+  const numbers = [];
+  for (const token of args.prs.split(',')) {
+    const trimmed = token.trim();
+    if (trimmed === '') {
+      continue;
+    }
+    const value = parsePositiveInteger(trimmed, '--prs');
+    if (!seen.has(value)) {
+      seen.add(value);
+      numbers.push(value);
+    }
+  }
+  if (numbers.length === 0) {
+    fail('--prs must contain at least one PR number');
+  }
+  return numbers;
+}
+/**
+ * Runs the audit-and-optionally-apply pass for one PR (extracted verbatim
+ * from the pre-#2224 single-PR `main()` body) and prints its report in the
+ * existing single-PR output shape. Returns whether this PR's report
+ * indicates a failure instead of calling `process.exit(1)` directly, so a
+ * `--prs` batch's aggregate exit code (set by the caller) reflects any PR's
+ * failure without one PR's failure skipping the rest of the batch.
+ */
+async function processOnePr(owner, repo, prNumber, args) {
   const claimContext = {
     expectedLinkedPrs: buildExpectedLinkedPrReferences(owner, repo, prNumber),
     // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
@@ -104,11 +165,6 @@ async function main() {
       ? fetchPrFirstCommitAt(owner, repo, prNumber)
       : null,
   };
-  if (args.claimIssue) {
-    args.claimIssue = String(
-      parsePositiveInteger(args.claimIssue, '--claim-issue'),
-    );
-  }
   const report = await buildReport(owner, repo, prNumber);
   if (args.apply) {
     report.mode = 'apply';
@@ -132,14 +188,15 @@ async function main() {
     computeReportSummary(finalReport);
     if (finalReport.failed.length > 0 || finalReport.rescanError) {
       writeReport(finalReport, args.format);
-      process.exit(1);
+      return true;
     }
     computeReportSummary(finalReport);
     writeReport(finalReport, args.format);
-    return;
+    return false;
   }
   computeReportSummary(report);
   writeReport(report, args.format);
+  return false;
 }
 /**
  * Runs one whole apply pass over `report.candidates`, mutating
@@ -1289,6 +1346,7 @@ function parseArgs(argv) {
     return token;
   };
   const pr = requireNonEmpty(values.pr, '--pr');
+  const prs = requireNonEmpty(values.prs, '--prs');
   const repo = requireNonEmpty(values.repo, '--repo');
   const format = requireNonEmpty(values.format, '--format');
   if (!['json', 'table'].includes(format)) {
@@ -1301,6 +1359,7 @@ function parseArgs(argv) {
     format,
     help,
     pr,
+    prs,
     repo,
     dryRun: values['dry-run'],
     apply: values.apply,
@@ -1317,9 +1376,13 @@ function parsePositiveInteger(value, flag) {
   return Number.parseInt(value, 10);
 }
 function printUsage() {
-  console.log(`usage: node scripts/audit-pr-cleanup.mjs --pr <number> [options]
+  console.log(`usage: node scripts/audit-pr-cleanup.mjs (--pr <number> | --prs <n1,n2,...>) [options]
 
 Options:
+  --prs <n1,n2,...>                 batch mode: audit several PRs in one
+                                     invocation, emitting one report per PR
+                                     in the existing output shape (mutually
+                                     exclusive with --pr)
   --dry-run                         list candidates without mutating (default)
   --apply                           minimize safe candidates
   --claim-issue <number>            issue whose active claim protects apply mode

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -261,14 +261,6 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  if (!args.pr && !args.prs) {
-    fail('missing required --pr <number> or --prs <n1,n2,...>');
-  }
-
-  if (args.pr && args.prs) {
-    fail('choose only one of --pr or --prs');
-  }
-
   if (args.apply && args.dryRun) {
     fail('choose only one of --dry-run or --apply');
   }
@@ -322,12 +314,22 @@ async function main(): Promise<void> {
 }
 
 /**
- * Resolves `--pr`/`--prs` (exactly one is required by the caller before this
- * runs) into an ordered, de-duplicated list of PR numbers. `--prs` splits on
- * `,`, trims whitespace, drops empty tokens, and validates each remaining
- * token with the same {@link parsePositiveInteger} used by `--pr`.
+ * Resolves `--pr`/`--prs` into an ordered, de-duplicated list of PR numbers.
+ * Validates that exactly one of the two is present itself (Copilot review,
+ * PR #2305) rather than trusting the caller to have checked first — an
+ * unconditional `args.prs as string` cast on a direct call with neither flag
+ * would otherwise throw a raw `TypeError` instead of failing consistently
+ * through {@link fail}. `--prs` splits on `,`, trims whitespace, drops empty
+ * tokens, and validates each remaining token with the same
+ * {@link parsePositiveInteger} used by `--pr`.
  */
 export function parsePrNumbers(args: CleanupArgs): number[] {
+  if (!args.pr && !args.prs) {
+    fail('missing required --pr <number> or --prs <n1,n2,...>');
+  }
+  if (args.pr && args.prs) {
+    fail('choose only one of --pr or --prs');
+  }
   if (args.pr) {
     return [parsePositiveInteger(args.pr, '--pr')];
   }

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -285,6 +285,8 @@ async function main(): Promise<void> {
     );
   }
 
+  assertBatchApplyClaimScope(args);
+
   const repository = args.repo ?? detectRepository();
   const [owner, repo] = parseRepository(repository);
 
@@ -320,6 +322,25 @@ async function main(): Promise<void> {
 
   if (anyFailed) {
     process.exit(1);
+  }
+}
+
+/**
+ * Rejects a claim-gated `--apply` batch (#2224, CodeRabbit review on PR
+ * #2305): `assertActiveClaim` only verifies the caller holds
+ * `--claim-issue`'s active claim; it does not bind that claim to any
+ * specific PR (`expectedLinkedPrs` only feeds forced-handoff resolution). A
+ * single-PR `--apply` already carries that weak binding, but `--prs` would
+ * let one active claim authorize `--apply` mutations across every PR in the
+ * batch at once, widening the blast radius of a single claim check.
+ * `--skip-claim-check` (the explicit maintainer override) opts out of this
+ * guard, same as it does for the existing single-PR claim requirement.
+ */
+export function assertBatchApplyClaimScope(args: CleanupArgs): void {
+  if (args.apply && args.prs && !args.skipClaimCheck) {
+    fail(
+      '--prs with --apply requires --skip-claim-check (a single active claim would otherwise authorize --apply across every PR in the batch)',
+    );
   }
 }
 

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -1895,6 +1895,7 @@ function printUsage(): void {
   console.log(`usage: node scripts/audit-pr-cleanup.mjs (--pr <number> | --prs <n1,n2,...>) [options]
 
 Options:
+  --pr <number>                     single-PR mode (mutually exclusive with --prs)
   --prs <n1,n2,...>                 batch mode: audit several PRs in one
                                      invocation, emitting one report per PR
                                      in the existing output shape (mutually

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -186,10 +186,11 @@ export interface CleanupAuditReport extends CleanupReport {
 type ActiveClaim = ClaimValidationSummary['activeClaim'];
 
 /** Parsed CLI arguments. */
-interface CleanupArgs {
+export interface CleanupArgs {
   format: string;
   help?: boolean;
   pr?: string;
+  prs?: string;
   repo?: string;
   dryRun?: boolean;
   apply?: boolean;
@@ -216,6 +217,7 @@ interface ClaimContext {
 const AUDIT_PR_CLEANUP_FLAG_SPEC = {
   '--help': { type: 'boolean', short: 'h', default: false },
   '--pr': { type: 'string' },
+  '--prs': { type: 'string' },
   '--repo': { type: 'string' },
   '--dry-run': { type: 'boolean', default: false },
   '--apply': { type: 'boolean', default: false },
@@ -259,8 +261,12 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  if (!args.pr) {
-    fail('missing required --pr <number>');
+  if (!args.pr && !args.prs) {
+    fail('missing required --pr <number> or --prs <n1,n2,...>');
+  }
+
+  if (args.pr && args.prs) {
+    fail('choose only one of --pr or --prs');
   }
 
   if (args.apply && args.dryRun) {
@@ -290,7 +296,74 @@ async function main(): Promise<void> {
   const repository = args.repo ?? detectRepository();
   const [owner, repo] = parseRepository(repository);
 
-  const prNumber = parsePositiveInteger(args.pr, '--pr');
+  const prNumbers = parsePrNumbers(args);
+
+  if (args.claimIssue) {
+    args.claimIssue = String(
+      parsePositiveInteger(args.claimIssue, '--claim-issue'),
+    );
+  }
+
+  // #2224: owner/repo detection above and the module-level trust/permission
+  // caches (trustedMarkerAuthorCache, collaboratorPermissionCache,
+  // cachedConfiguredTrustedMarkerActorSources, cachedCurrentViewerLogin) are
+  // process-lifetime state, so a --prs batch already shares that
+  // per-invocation setup cost across every PR in the loop below.
+  let anyFailed = false;
+  for (const prNumber of prNumbers) {
+    if (await processOnePr(owner, repo, prNumber, args)) {
+      anyFailed = true;
+    }
+  }
+
+  if (anyFailed) {
+    process.exit(1);
+  }
+}
+
+/**
+ * Resolves `--pr`/`--prs` (exactly one is required by the caller before this
+ * runs) into an ordered, de-duplicated list of PR numbers. `--prs` splits on
+ * `,`, trims whitespace, drops empty tokens, and validates each remaining
+ * token with the same {@link parsePositiveInteger} used by `--pr`.
+ */
+export function parsePrNumbers(args: CleanupArgs): number[] {
+  if (args.pr) {
+    return [parsePositiveInteger(args.pr, '--pr')];
+  }
+  const seen = new Set<number>();
+  const numbers: number[] = [];
+  for (const token of (args.prs as string).split(',')) {
+    const trimmed = token.trim();
+    if (trimmed === '') {
+      continue;
+    }
+    const value = parsePositiveInteger(trimmed, '--prs');
+    if (!seen.has(value)) {
+      seen.add(value);
+      numbers.push(value);
+    }
+  }
+  if (numbers.length === 0) {
+    fail('--prs must contain at least one PR number');
+  }
+  return numbers;
+}
+
+/**
+ * Runs the audit-and-optionally-apply pass for one PR (extracted verbatim
+ * from the pre-#2224 single-PR `main()` body) and prints its report in the
+ * existing single-PR output shape. Returns whether this PR's report
+ * indicates a failure instead of calling `process.exit(1)` directly, so a
+ * `--prs` batch's aggregate exit code (set by the caller) reflects any PR's
+ * failure without one PR's failure skipping the rest of the batch.
+ */
+async function processOnePr(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  args: CleanupArgs,
+): Promise<boolean> {
   const claimContext = {
     expectedLinkedPrs: buildExpectedLinkedPrReferences(owner, repo, prNumber),
     // The PR's first-commit time backs the Part B forced-handoff rule (#1058):
@@ -300,12 +373,6 @@ async function main(): Promise<void> {
       ? fetchPrFirstCommitAt(owner, repo, prNumber)
       : null,
   };
-
-  if (args.claimIssue) {
-    args.claimIssue = String(
-      parsePositiveInteger(args.claimIssue, '--claim-issue'),
-    );
-  }
 
   const report = await buildReport(owner, repo, prNumber);
 
@@ -332,16 +399,17 @@ async function main(): Promise<void> {
     computeReportSummary(finalReport);
     if (finalReport.failed.length > 0 || finalReport.rescanError) {
       writeReport(finalReport, args.format);
-      process.exit(1);
+      return true;
     }
 
     computeReportSummary(finalReport);
     writeReport(finalReport, args.format);
-    return;
+    return false;
   }
 
   computeReportSummary(report);
   writeReport(report, args.format);
+  return false;
 }
 
 /**
@@ -1782,6 +1850,7 @@ function parseArgs(argv: string[]): CleanupArgs {
   };
 
   const pr = requireNonEmpty(values.pr as string | undefined, '--pr');
+  const prs = requireNonEmpty(values.prs as string | undefined, '--prs');
   const repo = requireNonEmpty(values.repo as string | undefined, '--repo');
   const format = requireNonEmpty(values.format as string, '--format') as string;
   if (!['json', 'table'].includes(format)) {
@@ -1804,6 +1873,7 @@ function parseArgs(argv: string[]): CleanupArgs {
     format,
     help,
     pr,
+    prs,
     repo,
     dryRun: values['dry-run'] as boolean,
     apply: values.apply as boolean,
@@ -1822,9 +1892,13 @@ function parsePositiveInteger(value: string, flag: string): number {
 }
 
 function printUsage(): void {
-  console.log(`usage: node scripts/audit-pr-cleanup.mjs --pr <number> [options]
+  console.log(`usage: node scripts/audit-pr-cleanup.mjs (--pr <number> | --prs <n1,n2,...>) [options]
 
 Options:
+  --prs <n1,n2,...>                 batch mode: audit several PRs in one
+                                     invocation, emitting one report per PR
+                                     in the existing output shape (mutually
+                                     exclusive with --pr)
   --dry-run                         list candidates without mutating (default)
   --apply                           minimize safe candidates
   --claim-issue <number>            issue whose active claim protects apply mode

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -301,8 +301,18 @@ async function main(): Promise<void> {
   // cachedConfiguredTrustedMarkerActorSources, cachedCurrentViewerLogin) are
   // process-lifetime state, so a --prs batch already shares that
   // per-invocation setup cost across every PR in the loop below.
+  //
+  // Table-format batches print a header before each PR's block: the table
+  // renderer's summary/candidate rows never include the `pr`/`repository`
+  // fields (unlike JSON, where each report object already self-identifies
+  // via its own `pr` field), so consecutive same-shaped blocks would
+  // otherwise be indistinguishable (Copilot review, PR #2305).
+  const printBatchHeader = args.format === 'table' && prNumbers.length > 1;
   let anyFailed = false;
   for (const prNumber of prNumbers) {
+    if (printBatchHeader) {
+      console.log(`=== PR #${prNumber} ===`);
+    }
     if (await processOnePr(owner, repo, prNumber, args)) {
       anyFailed = true;
     }

--- a/tests/audit-pr-cleanup.test.mts
+++ b/tests/audit-pr-cleanup.test.mts
@@ -5,7 +5,10 @@ import type {
   CleanupArgs,
   CleanupAuditReport,
 } from '../src/scripts/audit-pr-cleanup.mts';
-import { parsePrNumbers } from '../src/scripts/audit-pr-cleanup.mts';
+import {
+  assertBatchApplyClaimScope,
+  parsePrNumbers,
+} from '../src/scripts/audit-pr-cleanup.mts';
 
 // Importing the CLI module directly is only possible now that its top-level
 // statements are guarded behind `import.meta.main` (#1210, migrated from
@@ -450,8 +453,49 @@ test('parsePrNumbers: --prs with only empty/whitespace tokens fails', () => {
 test('parsePrNumbers: an invalid --prs token fails the same way as --pr', () => {
   const restore = stubExitOnFail();
   try {
-    assert.throws(() => parsePrNumbers(cleanupArgs({ prs: '1,not-a-number' })));
+    assert.throws(
+      () => parsePrNumbers(cleanupArgs({ prs: '1,not-a-number' })),
+      /process\.exit/,
+    );
   } finally {
     restore();
   }
+});
+
+// #2224 (CodeRabbit review, PR #2305): a claim-gated --apply batch must not
+// let one active claim authorize --apply across every PR in the batch.
+
+test('assertBatchApplyClaimScope: --prs with --apply and no --skip-claim-check fails', () => {
+  const restore = stubExitOnFail();
+  try {
+    assert.throws(() =>
+      assertBatchApplyClaimScope(
+        cleanupArgs({ apply: true, prs: '1,2', claimIssue: '9', claimId: 'x' }),
+      ),
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('assertBatchApplyClaimScope: --prs with --apply and --skip-claim-check is allowed', () => {
+  assert.doesNotThrow(() =>
+    assertBatchApplyClaimScope(
+      cleanupArgs({ apply: true, prs: '1,2', skipClaimCheck: true }),
+    ),
+  );
+});
+
+test('assertBatchApplyClaimScope: --pr with --apply and no --skip-claim-check is unaffected', () => {
+  assert.doesNotThrow(() =>
+    assertBatchApplyClaimScope(
+      cleanupArgs({ apply: true, pr: '1', claimIssue: '9', claimId: 'x' }),
+    ),
+  );
+});
+
+test('assertBatchApplyClaimScope: dry-run (no --apply) is never gated', () => {
+  assert.doesNotThrow(() =>
+    assertBatchApplyClaimScope(cleanupArgs({ prs: '1,2' })),
+  );
 });

--- a/tests/audit-pr-cleanup.test.mts
+++ b/tests/audit-pr-cleanup.test.mts
@@ -416,6 +416,28 @@ test('parsePrNumbers: --prs de-duplicates while preserving first-seen order', ()
   );
 });
 
+test('parsePrNumbers: neither --pr nor --prs fails instead of throwing a raw TypeError (Copilot review, PR #2305)', () => {
+  const restore = stubExitOnFail();
+  try {
+    assert.throws(
+      () => parsePrNumbers(cleanupArgs()),
+      /process\.exit/,
+      'must fail via fail()/process.exit, not an unrelated TypeError from a bare .split() on undefined',
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('parsePrNumbers: both --pr and --prs fails', () => {
+  const restore = stubExitOnFail();
+  try {
+    assert.throws(() => parsePrNumbers(cleanupArgs({ pr: '1', prs: '2,3' })));
+  } finally {
+    restore();
+  }
+});
+
 test('parsePrNumbers: --prs with only empty/whitespace tokens fails', () => {
   const restore = stubExitOnFail();
   try {

--- a/tests/audit-pr-cleanup.test.mts
+++ b/tests/audit-pr-cleanup.test.mts
@@ -366,9 +366,9 @@ test('runApplyWithRetry truncates a fractional maxAttempts instead of misreporti
 });
 
 // #2224: --prs <n1,n2,...> batch-mode parsing. --pr itself is untouched
-// (still a single string flag, asserted by the pass-through case below);
-// parsePrNumbers only resolves whichever of --pr/--prs the caller already
-// validated as present.
+// (still a single string flag, asserted by the pass-through case below).
+// parsePrNumbers validates that exactly one of --pr/--prs is present
+// itself, regardless of the caller.
 
 function cleanupArgs(overrides: Partial<CleanupArgs> = {}): CleanupArgs {
   return { format: 'json', ...overrides };

--- a/tests/audit-pr-cleanup.test.mts
+++ b/tests/audit-pr-cleanup.test.mts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import type { CleanupAuditReport } from '../src/scripts/audit-pr-cleanup.mts';
+import type {
+  CleanupArgs,
+  CleanupAuditReport,
+} from '../src/scripts/audit-pr-cleanup.mts';
+import { parsePrNumbers } from '../src/scripts/audit-pr-cleanup.mts';
 
 // Importing the CLI module directly is only possible now that its top-level
 // statements are guarded behind `import.meta.main` (#1210, migrated from
@@ -359,4 +363,73 @@ test('runApplyWithRetry truncates a fractional maxAttempts instead of misreporti
   assert.equal(rescanCalls, 2);
   assert.equal(result.attempts, 2);
   assert.equal(result.boundExhausted, true);
+});
+
+// #2224: --prs <n1,n2,...> batch-mode parsing. --pr itself is untouched
+// (still a single string flag, asserted by the pass-through case below);
+// parsePrNumbers only resolves whichever of --pr/--prs the caller already
+// validated as present.
+
+function cleanupArgs(overrides: Partial<CleanupArgs> = {}): CleanupArgs {
+  return { format: 'json', ...overrides };
+}
+
+/** Stubs process.exit (and silences console.error) so a `fail()`-triggering
+ * path can be asserted with assert.throws instead of killing the test
+ * process. */
+function stubExitOnFail(): () => void {
+  const originalExit = process.exit;
+  const originalError = console.error;
+  process.exit = ((code?: number): never => {
+    throw new Error(`process.exit(${code})`);
+  }) as typeof process.exit;
+  console.error = () => {};
+  return () => {
+    process.exit = originalExit;
+    console.error = originalError;
+  };
+}
+
+test('parsePrNumbers: --pr passes through as a single-element list unchanged', () => {
+  assert.deepEqual(parsePrNumbers(cleanupArgs({ pr: '42' })), [42]);
+});
+
+test('parsePrNumbers: --prs splits a comma-separated list in order', () => {
+  assert.deepEqual(parsePrNumbers(cleanupArgs({ prs: '1,2,3' })), [1, 2, 3]);
+});
+
+test('parsePrNumbers: --prs trims whitespace around each token', () => {
+  assert.deepEqual(
+    parsePrNumbers(cleanupArgs({ prs: ' 1 , 2 ,3  ' })),
+    [1, 2, 3],
+  );
+});
+
+test('parsePrNumbers: --prs drops empty tokens from stray commas', () => {
+  assert.deepEqual(parsePrNumbers(cleanupArgs({ prs: '1,,2,' })), [1, 2]);
+});
+
+test('parsePrNumbers: --prs de-duplicates while preserving first-seen order', () => {
+  assert.deepEqual(
+    parsePrNumbers(cleanupArgs({ prs: '3,1,3,2,1' })),
+    [3, 1, 2],
+  );
+});
+
+test('parsePrNumbers: --prs with only empty/whitespace tokens fails', () => {
+  const restore = stubExitOnFail();
+  try {
+    assert.throws(() => parsePrNumbers(cleanupArgs({ prs: ' , , ' })));
+  } finally {
+    restore();
+  }
+});
+
+test('parsePrNumbers: an invalid --prs token fails the same way as --pr', () => {
+  const restore = stubExitOnFail();
+  try {
+    assert.throws(() => parsePrNumbers(cleanupArgs({ prs: '1,not-a-number' })));
+  } finally {
+    restore();
+  }
 });


### PR DESCRIPTION
## Summary

- Adds a comma-separated `--prs <n1,n2,...>` batch flag to
  `audit-pr-cleanup.mts`, matching `discover-shared-file-overlap.mjs`'s
  `--candidates` convention, so an operator clearing a PR backlog no
  longer pays a repeated per-PR cold start.
- `--pr <number>` is unchanged for single-PR use; `--pr`/`--prs` are
  mutually exclusive and exactly one is required.
- The per-PR audit-and-optionally-apply body is extracted into
  `processOnePr()`, sharing owner/repo detection and the module-level
  trust/permission caches across the batch, and emitting one report
  per PR in the existing single-PR output shape (not array-wrapped).
- A PR failing in `--apply` mode no longer aborts the rest of the
  batch; the aggregate exit code is 1 if any PR's report has a
  failure.
- Adds unit test coverage for `--prs` parsing (comma split, whitespace
  trimming, empty-token dropping, de-duplication, both-flags/no-flags
  validation errors).

Closes #2224

## Test plan

- [x] `node --test tests/audit-pr-cleanup.test.mts` — 17/17 pass
  (10 pre-existing + 7 new `parsePrNumbers` cases)
- [x] `node --test tests/help-text-flags.test.mts
  tests/cli-entry-smoke.test.mts tests/helper-runtime-manifest.test.mts
  tests/cleanup-boundaries.test.mts` — 109 + 21 + 15 pass, including
  `audit-pr-cleanup.mjs --help documents exactly its declared flags`
- [x] `pnpm run build:check` — generated `.mjs` matches source, no drift
- [x] full `pre-push-validate` — passed (3 pre-existing, unrelated
  WARN-level `idd-doctor` notices only: profile files, worktreeGuard
  hooksPath, release-tag drift)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added batch processing for multiple pull requests using the `--prs` option.
  - Supports comma-separated pull request numbers with whitespace trimming, validation, and duplicate removal.
  - Preserves ordered, per-pull-request reports during batch processing.
  - Added aggregate failure reporting when one or more pull requests cannot be processed.

- **Improvements**
  - Single pull request mode remains available through the mutually exclusive `--pr` option.
  - Updated command usage and argument output to include batch processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->