### PR TITLE
feat(onboard): apply hearing transcripts to substitute and policy

### DIFF
--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -1558,15 +1558,27 @@ const RECORD_POLICY_NO_LITERAL_CONFIG_IDS = new Set([
   'idd-label-names',
 ]);
 /**
+ * Sentinel patch value meaning "remove this key from the merged config"
+ * rather than "set it to this value". Used when a confirmed transcript
+ * answer reconfirms a distributed default that has no on-the-wire
+ * representation of its own (an absent key already means default) --
+ * without this, reconfirming the default would silently leave a stale
+ * non-default value from a prior run in place (#2282 review follow-up).
+ */
+const DELETE_CONFIG_KEY = Symbol('idd-record-policy-delete-config-key');
+/**
  * Translate one confirmed hearing answer into a `.github/idd/config.json`
- * patch entry (a dotted key path plus the value to write), or `null`
- * when the item is docs-only, has no literal config value (see
- * {@link RECORD_POLICY_NO_LITERAL_CONFIG_IDS}), or is one of the two
- * items whose "distributed default" answer needs no explicit record
+ * patch entry (a dotted key path plus the value to write, where the value
+ * may be {@link DELETE_CONFIG_KEY}), or `null` when the item is docs-only
+ * or has no literal config value (see
+ * {@link RECORD_POLICY_NO_LITERAL_CONFIG_IDS}). The two items whose
+ * "distributed default" answer has no positive on-the-wire representation
  * (`helper-runtime-profile`'s `instructions-only`,
- * `issue-author-approval-gate`'s `enabled-by-default`). Every other
- * mapped item's confirmed value is written verbatim, including when it
- * happens to equal that item's own documented default.
+ * `issue-author-approval-gate`'s `enabled-by-default`) delete their key
+ * instead, so reconfirming the default clears a stale override from a
+ * prior run rather than preserving it. Every other mapped item's
+ * confirmed value is written verbatim, including when it happens to
+ * equal that item's own documented default.
  */
 function translateRecordPolicyAnswer(item, value) {
   if (!item.mapsToConfig || RECORD_POLICY_NO_LITERAL_CONFIG_IDS.has(item.id)) {
@@ -1574,14 +1586,18 @@ function translateRecordPolicyAnswer(item, value) {
   }
   if (item.id === 'helper-runtime-profile' && value === 'instructions-only') {
     // The whole `helperRuntime` key defaults to the instructions-only
-    // fallback when absent (schema); omit it rather than writing the
-    // value literally.
-    return null;
+    // fallback when absent (schema); delete it rather than writing the
+    // value literally, clearing any stale non-default profile.
+    return { path: ['helperRuntime'], value: DELETE_CONFIG_KEY };
   }
   if (item.id === 'issue-author-approval-gate') {
     if (value === 'enabled-by-default') {
-      // Schema default (omitted or `false`) already keeps the gate on.
-      return null;
+      // Schema default (omitted or `false`) already keeps the gate on;
+      // delete a stale `true` opt-out rather than preserving it.
+      return {
+        path: ['skipIssueAuthorApprovalGate'],
+        value: DELETE_CONFIG_KEY,
+      };
     }
     return { path: ['skipIssueAuthorApprovalGate'], value: true };
   }
@@ -1607,11 +1623,16 @@ function setNestedValue(target, path, value) {
  * Recursively merge `patch` into `target`, preserving sibling keys in
  * any nested object both sides declare (e.g. merging `ciWait.rerunPolicy`
  * must not discard an existing `ciWait.runningTimeout`). Scalars and
- * arrays in `patch` overwrite `target` outright.
+ * arrays in `patch` overwrite `target` outright. A {@link DELETE_CONFIG_KEY}
+ * patch value removes that key from the result instead of setting it.
  */
 function deepMergeConfigPatch(target, patch) {
   const result = { ...target };
   for (const [key, value] of Object.entries(patch)) {
+    if (value === DELETE_CONFIG_KEY) {
+      delete result[key];
+      continue;
+    }
     const existing = result[key];
     if (
       typeof value === 'object' &&
@@ -1627,6 +1648,22 @@ function deepMergeConfigPatch(target, patch) {
     }
   }
   return result;
+}
+/**
+ * Render a config patch for the JSON verdict: a {@link DELETE_CONFIG_KEY}
+ * sentinel isn't itself meaningful JSON, so it renders as an explicit
+ * marker string instead of silently vanishing (a bare `Symbol` value is
+ * dropped by `JSON.stringify`).
+ */
+function renderPatchForVerdict(patch) {
+  const rendered = {};
+  for (const [key, value] of Object.entries(patch)) {
+    rendered[key] =
+      value === DELETE_CONFIG_KEY
+        ? '(reset to distributed default: key removed)'
+        : value;
+  }
+  return rendered;
 }
 /** Distributed-default sub-values the hearing catalog does not itself elicit. */
 const CLAIM_TIMING_DEFAULTS = {
@@ -1825,7 +1862,7 @@ function runRecordPolicyCli(args) {
     mode: canWrite ? 'apply' : 'dry-run',
     target: targetDir,
     transcript: resolve(args.transcript),
-    configPatch: patch,
+    configPatch: renderPatchForVerdict(patch),
     policyDocument,
     writtenPolicyDocPath:
       canWrite && args.writePolicyDoc ? resolve(args.writePolicyDoc) : null,

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -1757,9 +1757,9 @@ function runRecordPolicyCli(args) {
   // Validate only the sections this patch touched (#1359 pattern via
   // validateConfigSection), never the whole document: --record-policy
   // runs post-import, pre-substitute, so the "pristine imported"
-  // config.json still carries unresolved {{PLACEHOLDER}} tokens in
-  // required fields like markerPrefix -- a whole-document validate
-  // would reject every real invocation.
+  // config.json still carries unresolved double-brace placeholder
+  // tokens in required fields like markerPrefix -- a whole-document
+  // validate would reject every real invocation.
   const schema = loadJson('schemas/policy.schema.json');
   const schemaErrors = Object.keys(patch).flatMap((key) =>
     validateConfigSection(mergedConfig, schema, key),

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -1770,7 +1770,8 @@ function runRecordPolicyCli(args) {
     );
   }
   const policyDocument = buildFilledPolicyDocument(transcript.answers);
-  const canWrite = args.apply;
+  // --dry-run always wins over --apply, matching runImportCli's convention.
+  const canWrite = args.apply && !args.dryRun;
   if (canWrite) {
     writeFileSync(configPath, `${JSON.stringify(mergedConfig, null, 2)}\n`);
     if (args.writePolicyDoc) {

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -1831,7 +1831,20 @@ function runRecordPolicyCli(args) {
       setNestedValue(patch, translated.path, translated.value);
     }
   }
-  const existingConfig = JSON.parse(readFileSync(configPath, 'utf8'));
+  // A syntactically valid config.json can still parse to a non-object root
+  // (`null`, a number, a bare string, an array); deepMergeConfigPatch would
+  // silently spread that into `{}` (or an index-keyed object for an array)
+  // and --apply would overwrite the file with the patch alone, losing the
+  // original document. Same guard convention as readExistingCommandsTable.
+  const parsedConfig = JSON.parse(readFileSync(configPath, 'utf8'));
+  if (
+    typeof parsedConfig !== 'object' ||
+    parsedConfig === null ||
+    Array.isArray(parsedConfig)
+  ) {
+    throw new Error(`--record-policy requires a JSON object at ${configPath}`);
+  }
+  const existingConfig = parsedConfig;
   const mergedConfig = deepMergeConfigPatch(existingConfig, patch);
   // Validate only the sections this patch touched (#1359 pattern via
   // validateConfigSection), never the whole document: --record-policy

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -58,7 +58,11 @@ import {
 import { findMissingWorktreeHardening } from './idd-doctor.mjs';
 import { loadOnboardingHearingCatalog } from './onboarding-hearing.mjs';
 import { makeReadlinePrompt } from './readline-prompt.mjs';
-import { loadJson, validate } from './validate-schemas.mjs';
+import {
+  loadJson,
+  validate,
+  validateConfigSection,
+} from './validate-schemas.mjs';
 
 function placeholder(name, kind, flag) {
   return { name, token: `{{${name}}}`, kind, flag };
@@ -1470,7 +1474,7 @@ async function runHearCli(args) {
   if (!statSync(targetDir).isDirectory()) {
     throw new Error(`--target is not a directory: ${args.target}`);
   }
-  if (args.propose && args.applyHear) {
+  if (args.propose && args.apply) {
     throw new Error(
       '--hear --propose and --hear --apply are mutually exclusive',
     );
@@ -1480,7 +1484,7 @@ async function runHearCli(args) {
     runHearProposeCli(catalog, targetDir);
     return;
   }
-  if (args.applyHear) {
+  if (args.apply) {
     if (!args.answers) {
       throw new Error('--hear --apply requires --answers <file>');
     }
@@ -1496,6 +1500,295 @@ async function runHearCli(args) {
     );
   }
   process.stdout.write(`${JSON.stringify(transcript, null, 2)}\n`);
+  process.exit(0);
+}
+/**
+ * Read, parse, and schema-validate a confirmed hearing transcript file
+ * (the output of `--hear --apply` or the interactive wizard). Throws
+ * only on unparseable JSON (a usage error, exit 2, matching `--hear
+ * --apply`'s own file-reading check); a schema mismatch is returned as
+ * `errors` instead, so the caller can print the same
+ * `{valid:false, unresolved}` shape `--hear --apply` prints and exit 1
+ * -- "reject a transcript that fails the transcript schema... (exit 1,
+ * no writes)" per #2282.
+ */
+function readAndValidateTranscript(path) {
+  const raw = readFileSync(resolve(path), 'utf8');
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`transcript file is not valid JSON: ${path}`);
+  }
+  const schemaErrors = validateHearTranscriptShape(parsed);
+  if (schemaErrors.length > 0) {
+    return { transcript: null, errors: schemaErrors };
+  }
+  return { transcript: parsed, errors: [] };
+}
+/**
+ * Map a confirmed transcript's answers onto `resolvePlaceholderValues`
+ * overrides, using each catalog item's `mapsToPlaceholder` field. An
+ * answer for an item with no `mapsToPlaceholder` (a policy or check
+ * item) is not a placeholder override and is ignored here.
+ */
+function buildTranscriptPlaceholderOverrides(catalog, transcript) {
+  const byId = new Map(catalog.items.map((item) => [item.id, item]));
+  const overrides = {};
+  for (const answer of transcript.answers) {
+    const placeholderName = byId.get(answer.id)?.mapsToPlaceholder;
+    if (placeholderName !== undefined) {
+      overrides[placeholderName] = answer.value;
+    }
+  }
+  return overrides;
+}
+/**
+ * Catalog item ids whose confirmed answer is a meta-choice about
+ * whether to override the distributed default, not the override value
+ * itself -- `claimTiming` needs an ISO-duration pair
+ * (`staleAge`/`heartbeatInterval`) and `labels` needs actual label-name
+ * strings, neither derivable from `distributed-defaults` /
+ * `repository-override` / `custom-taxonomy` alone. `--record-policy`
+ * surfaces these in the filled Markdown template but never invents a
+ * config value for them (see #2282 B2 plan).
+ */
+const RECORD_POLICY_NO_LITERAL_CONFIG_IDS = new Set([
+  'claim-timing',
+  'idd-label-names',
+]);
+/**
+ * Translate one confirmed hearing answer into a `.github/idd/config.json`
+ * patch entry (a dotted key path plus the value to write), or `null`
+ * when the item is docs-only, has no literal config value (see
+ * {@link RECORD_POLICY_NO_LITERAL_CONFIG_IDS}), or is one of the two
+ * items whose "distributed default" answer needs no explicit record
+ * (`helper-runtime-profile`'s `instructions-only`,
+ * `issue-author-approval-gate`'s `enabled-by-default`). Every other
+ * mapped item's confirmed value is written verbatim, including when it
+ * happens to equal that item's own documented default.
+ */
+function translateRecordPolicyAnswer(item, value) {
+  if (!item.mapsToConfig || RECORD_POLICY_NO_LITERAL_CONFIG_IDS.has(item.id)) {
+    return null;
+  }
+  if (item.id === 'helper-runtime-profile' && value === 'instructions-only') {
+    // The whole `helperRuntime` key defaults to the instructions-only
+    // fallback when absent (schema); omit it rather than writing the
+    // value literally.
+    return null;
+  }
+  if (item.id === 'issue-author-approval-gate') {
+    if (value === 'enabled-by-default') {
+      // Schema default (omitted or `false`) already keeps the gate on.
+      return null;
+    }
+    return { path: ['skipIssueAuthorApprovalGate'], value: true };
+  }
+  const path = item.mapsToConfig
+    .split('/')
+    .filter((segment) => segment.length > 0);
+  return { path, value };
+}
+/** Set a value at a nested key path, creating intermediate objects as needed. */
+function setNestedValue(target, path, value) {
+  let cursor = target;
+  for (let depth = 0; depth < path.length - 1; depth += 1) {
+    const key = path[depth];
+    const next = cursor[key];
+    if (typeof next !== 'object' || next === null || Array.isArray(next)) {
+      cursor[key] = {};
+    }
+    cursor = cursor[key];
+  }
+  cursor[path[path.length - 1]] = value;
+}
+/**
+ * Recursively merge `patch` into `target`, preserving sibling keys in
+ * any nested object both sides declare (e.g. merging `ciWait.rerunPolicy`
+ * must not discard an existing `ciWait.runningTimeout`). Scalars and
+ * arrays in `patch` overwrite `target` outright.
+ */
+function deepMergeConfigPatch(target, patch) {
+  const result = { ...target };
+  for (const [key, value] of Object.entries(patch)) {
+    const existing = result[key];
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value) &&
+      typeof existing === 'object' &&
+      existing !== null &&
+      !Array.isArray(existing)
+    ) {
+      result[key] = deepMergeConfigPatch(existing, value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+/**
+ * Catalog-item-id-ordered rows for the filled Markdown template,
+ * mirroring `idd-template/docs/onboarding/policy-decisions.md`'s
+ * "Recording the selected policies" example structure. Only items the
+ * hearing catalog can actually answer (policy-kind items) are listed;
+ * the three Step 0 `check`-kind items are evidence, not a policy
+ * decision, and are not part of this template.
+ */
+const RECORD_POLICY_DOC_ROWS = [
+  { id: 'merge-policy', heading: 'Merge Policy', label: 'Policy' },
+  { id: 'review-policy', heading: 'PR Review Policy', label: 'Profile' },
+  {
+    id: 'thread-resolution-policy',
+    heading: 'Review-Thread Resolution Policy',
+    label: 'Policy',
+  },
+  {
+    id: 'critique-loop-profile',
+    heading: 'Critique-Loop Profile',
+    label: 'Profile',
+  },
+  { id: 'credential-scope', heading: 'Credential Scope', label: 'Scope' },
+  { id: 'claim-timing', heading: 'Claim Timing', label: 'Selection' },
+  { id: 'ci-wait-policy', heading: 'CI Wait Policy', label: 'Rerun policy' },
+  {
+    id: 'issue-author-approval-gate',
+    heading: 'Issue-Author Approval Gate',
+    label: 'Selection',
+  },
+  {
+    id: 'maintainer-approval-actor-policy',
+    heading: 'Maintainer Approval Actor Policy',
+    label: 'Policy',
+  },
+  {
+    id: 'issue-authoring-companion',
+    heading: 'Issue-Authoring Companion',
+    label: 'Status',
+  },
+  {
+    id: 'helper-runtime-profile',
+    heading: 'Helper Runtime Profile',
+    label: 'Profile',
+  },
+  { id: 'idd-label-names', heading: 'IDD Label Names', label: 'Selection' },
+  {
+    id: 'up-to-date-head-ruleset',
+    heading: 'Up-to-Date-Head Ruleset',
+    label: 'Policy',
+  },
+  {
+    id: 'bootstrap-execution-mode',
+    heading: 'Bootstrap Execution Mode',
+    label: 'Mode',
+  },
+];
+/**
+ * Render the filled `## IDD Policy Configuration` Markdown document from
+ * a confirmed transcript's answers, following the structure shown in
+ * `idd-template/docs/onboarding/policy-decisions.md`'s
+ * "Recording the selected policies" section. An item with no confirmed
+ * answer is omitted rather than printed with a placeholder value.
+ */
+function buildFilledPolicyDocument(answers) {
+  const valueById = new Map(answers.map((answer) => [answer.id, answer.value]));
+  const sections = RECORD_POLICY_DOC_ROWS.filter((row) =>
+    valueById.has(row.id),
+  ).map(
+    (row) =>
+      `### ${row.heading}\n\n**${row.label}**: \`${valueById.get(row.id)}\``,
+  );
+  return [
+    '## IDD Policy Configuration',
+    '',
+    'This repository uses the following IDD policies:',
+    '',
+    sections.join('\n\n'),
+  ].join('\n');
+}
+function runRecordPolicyCli(args) {
+  if (!args.transcript) {
+    throw new Error('--record-policy requires --transcript <file>');
+  }
+  const targetDir = resolve(args.target);
+  if (!statSync(targetDir).isDirectory()) {
+    throw new Error(`--target is not a directory: ${args.target}`);
+  }
+  const configPath = join(targetDir, '.github', 'idd', 'config.json');
+  if (!existsSync(configPath)) {
+    throw new Error(
+      `--record-policy is post-import only; missing ${configPath}`,
+    );
+  }
+  const result = readAndValidateTranscript(args.transcript);
+  if (result.transcript === null) {
+    // Matches --hear --apply's own schema-failure shape and exit code.
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          protocolVersion: '1',
+          mode: args.apply ? 'apply' : 'dry-run',
+          valid: false,
+          unresolved: result.errors,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    process.exit(1);
+  }
+  const transcript = result.transcript;
+  const catalog = loadOnboardingHearingCatalog();
+  const byId = new Map(catalog.items.map((item) => [item.id, item]));
+  const patch = {};
+  for (const answer of transcript.answers) {
+    const item = byId.get(answer.id);
+    if (!item) {
+      continue;
+    }
+    const translated = translateRecordPolicyAnswer(item, answer.value);
+    if (translated) {
+      setNestedValue(patch, translated.path, translated.value);
+    }
+  }
+  const existingConfig = JSON.parse(readFileSync(configPath, 'utf8'));
+  const mergedConfig = deepMergeConfigPatch(existingConfig, patch);
+  // Validate only the sections this patch touched (#1359 pattern via
+  // validateConfigSection), never the whole document: --record-policy
+  // runs post-import, pre-substitute, so the "pristine imported"
+  // config.json still carries unresolved {{PLACEHOLDER}} tokens in
+  // required fields like markerPrefix -- a whole-document validate
+  // would reject every real invocation.
+  const schema = loadJson('schemas/policy.schema.json');
+  const schemaErrors = Object.keys(patch).flatMap((key) =>
+    validateConfigSection(mergedConfig, schema, key),
+  );
+  if (schemaErrors.length > 0) {
+    throw new Error(
+      `config.json patch failed schema validation: ${schemaErrors.join('; ')}`,
+    );
+  }
+  const policyDocument = buildFilledPolicyDocument(transcript.answers);
+  const canWrite = args.apply;
+  if (canWrite) {
+    writeFileSync(configPath, `${JSON.stringify(mergedConfig, null, 2)}\n`);
+    if (args.writePolicyDoc) {
+      writeFileSync(resolve(args.writePolicyDoc), `${policyDocument}\n`);
+    }
+  }
+  const verdict = {
+    protocolVersion: '1',
+    mode: canWrite ? 'apply' : 'dry-run',
+    target: targetDir,
+    transcript: resolve(args.transcript),
+    configPatch: patch,
+    policyDocument,
+    writtenPolicyDocPath:
+      canWrite && args.writePolicyDoc ? resolve(args.writePolicyDoc) : null,
+    written: canWrite,
+  };
+  process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
   process.exit(0);
 }
 function main() {
@@ -1522,9 +1815,13 @@ function parseArgs(argv) {
     importMode: false,
     verify: false,
     hear: false,
+    recordPolicy: false,
     propose: false,
-    applyHear: false,
+    apply: false,
     answers: undefined,
+    fromTranscript: undefined,
+    transcript: undefined,
+    writePolicyDoc: undefined,
     source: undefined,
     target: '.',
     dryRun: false,
@@ -1561,16 +1858,35 @@ function parseArgs(argv) {
       parsed.hear = true;
       continue;
     }
+    if (token === '--record-policy') {
+      parsed.recordPolicy = true;
+      continue;
+    }
     if (token === '--propose') {
       parsed.propose = true;
       continue;
     }
     if (token === '--apply') {
-      parsed.applyHear = true;
+      parsed.apply = true;
       continue;
     }
     if (token === '--answers') {
       parsed.answers = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === '--from-transcript') {
+      parsed.fromTranscript = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === '--transcript') {
+      parsed.transcript = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === '--write-policy-doc') {
+      parsed.writePolicyDoc = requireValue();
       index += 1;
       continue;
     }
@@ -1625,11 +1941,29 @@ function importOnlyFlagsPresent(args) {
   }
   return present;
 }
-/** Substitute-only placeholder-override flags the user explicitly passed. */
+/**
+ * Substitute-only flags the user explicitly passed: every placeholder
+ * override flag, plus `--from-transcript`.
+ */
 function substituteOnlyFlagsPresent(args) {
-  return ONBOARDING_PLACEHOLDERS.filter(
+  const present = ONBOARDING_PLACEHOLDERS.filter(
     (entry) => args.overrides[entry.name] !== undefined,
   ).map((entry) => entry.flag);
+  if (args.fromTranscript !== undefined) {
+    present.push('--from-transcript');
+  }
+  return present;
+}
+/** --record-policy-only flags the user explicitly passed (present regardless of mode). */
+function recordPolicyOnlyFlagsPresent(args) {
+  const present = [];
+  if (args.transcript !== undefined) {
+    present.push('--transcript');
+  }
+  if (args.writePolicyDoc !== undefined) {
+    present.push('--write-policy-doc');
+  }
+  return present;
 }
 /**
  * Flags --verify does not accept: every substitute-only override flag (verify
@@ -1647,13 +1981,20 @@ function verifyForeignFlagsPresent(args) {
   }
   return present;
 }
-/** --hear-only flags the user explicitly passed (present regardless of mode). */
+/**
+ * --hear-only flags the user explicitly passed (present regardless of
+ * mode). Bare `--apply` is shared with `--record-policy` and reported
+ * here as `--apply`; callers that also reject record-policy-only flags
+ * separately via {@link recordPolicyOnlyFlagsPresent} still catch a
+ * `--record-policy --apply` combination through that function's own
+ * `--transcript`/`--write-policy-doc` checks.
+ */
 function hearOnlyFlagsPresent(args) {
   const present = [];
   if (args.propose) {
     present.push('--propose');
   }
-  if (args.applyHear) {
+  if (args.apply) {
     present.push('--apply');
   }
   if (args.answers !== undefined) {
@@ -1663,12 +2004,17 @@ function hearOnlyFlagsPresent(args) {
 }
 /**
  * Flags --hear does not accept: every import-only flag (`--source`,
- * `--force`, `--profile` -- --hear never imports or overwrites) plus every
+ * `--force`, `--profile` -- --hear never imports or overwrites), every
  * substitute-only placeholder-override flag (--hear derives candidates
- * read-only via the same hooks; it never accepts an explicit override).
+ * read-only via the same hooks; it never accepts an explicit override),
+ * and every record-policy-only flag.
  */
 function hearForeignFlagsPresent(args) {
-  return [...importOnlyFlagsPresent(args), ...substituteOnlyFlagsPresent(args)];
+  return [
+    ...importOnlyFlagsPresent(args),
+    ...substituteOnlyFlagsPresent(args),
+    ...recordPolicyOnlyFlagsPresent(args),
+  ];
 }
 async function runCli() {
   const args = parseArgs(process.argv.slice(2));
@@ -1681,10 +2027,11 @@ async function runCli() {
     args.importMode,
     args.verify,
     args.hear,
+    args.recordPolicy,
   ].filter(Boolean).length;
   if (modeCount > 1) {
     throw new Error(
-      '--substitute, --import, --verify, and --hear are mutually exclusive',
+      '--substitute, --import, --verify, --hear, and --record-policy are mutually exclusive',
     );
   }
   if (args.hear) {
@@ -1697,6 +2044,23 @@ async function runCli() {
     await runHearCli(args);
     return;
   }
+  if (args.recordPolicy) {
+    // Not hearOnlyFlagsPresent(args): that set includes bare --apply,
+    // which --record-policy shares and must accept.
+    const foreign = [
+      ...importOnlyFlagsPresent(args),
+      ...substituteOnlyFlagsPresent(args),
+      ...(args.propose ? ['--propose'] : []),
+      ...(args.answers !== undefined ? ['--answers'] : []),
+    ];
+    if (foreign.length > 0) {
+      throw new Error(
+        `--record-policy does not accept flag(s) it never uses: ${foreign.join(', ')}`,
+      );
+    }
+    runRecordPolicyCli(args);
+    return;
+  }
   if (args.importMode) {
     // parseArgs collects every known flag regardless of the active stage,
     // so a stage-foreign flag (e.g. a placeholder override alongside
@@ -1704,10 +2068,11 @@ async function runCli() {
     const foreign = [
       ...substituteOnlyFlagsPresent(args),
       ...hearOnlyFlagsPresent(args),
+      ...recordPolicyOnlyFlagsPresent(args),
     ];
     if (foreign.length > 0) {
       throw new Error(
-        `--import does not accept substitute-only flag(s) or --hear-only flag(s): ${foreign.join(', ')}`,
+        `--import does not accept substitute-only flag(s), --hear-only flag(s), or --record-policy-only flag(s): ${foreign.join(', ')}`,
       );
     }
     runImportCli(args);
@@ -1717,6 +2082,7 @@ async function runCli() {
     const foreign = [
       ...verifyForeignFlagsPresent(args),
       ...hearOnlyFlagsPresent(args),
+      ...recordPolicyOnlyFlagsPresent(args),
     ];
     if (foreign.length > 0) {
       throw new Error(
@@ -1728,23 +2094,54 @@ async function runCli() {
   }
   if (!args.substitute) {
     throw new Error(
-      'pass --substitute, --import, --verify, or --hear to select a stage',
+      'pass --substitute, --import, --verify, --hear, or --record-policy to select a stage',
     );
   }
   const foreign = [
     ...importOnlyFlagsPresent(args),
     ...hearOnlyFlagsPresent(args),
+    ...recordPolicyOnlyFlagsPresent(args),
   ];
   if (foreign.length > 0) {
     throw new Error(
-      `--substitute does not accept import-only flag(s) or --hear-only flag(s): ${foreign.join(', ')}`,
+      `--substitute does not accept import-only flag(s), --hear-only flag(s), or --record-policy-only flag(s): ${foreign.join(', ')}`,
     );
   }
   const targetDir = resolve(args.target);
   if (!statSync(targetDir).isDirectory()) {
     throw new Error(`--target is not a directory: ${args.target}`);
   }
-  const resolution = resolvePlaceholderValues(targetDir, args.overrides);
+  let transcriptOverrides = {};
+  if (args.fromTranscript !== undefined) {
+    const result = readAndValidateTranscript(args.fromTranscript);
+    if (result.transcript === null) {
+      // Matches --hear --apply's own schema-failure shape and exit code.
+      process.stdout.write(
+        `${JSON.stringify(
+          {
+            protocolVersion: '1',
+            mode: args.dryRun ? 'dry-run' : 'apply',
+            valid: false,
+            unresolved: result.errors,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      process.exit(1);
+    }
+    transcriptOverrides = buildTranscriptPlaceholderOverrides(
+      loadOnboardingHearingCatalog(),
+      result.transcript,
+    );
+  }
+  // Explicit per-placeholder flags win over the transcript, matching
+  // today's "explicit flags override derivation" rule.
+  const mergedOverrides = {
+    ...transcriptOverrides,
+    ...args.overrides,
+  };
+  const resolution = resolvePlaceholderValues(targetDir, mergedOverrides);
   const plan = buildSubstitutionPlan(
     scanPlaceholderTokens(targetDir),
     resolution,
@@ -1863,11 +2260,13 @@ function printHelp() {
       `  ${entry.flag} <value>${entry.kind === 'command' ? ' (accepts the no-op "true")' : ''}`,
   ).join('\n');
   process.stdout.write(`usage: node scripts/idd-onboard.mjs --substitute [options]
+       node scripts/idd-onboard.mjs --substitute --from-transcript <file> [options]
        node scripts/idd-onboard.mjs --import --source <dir> --target <dir> [options]
        node scripts/idd-onboard.mjs --verify --source <dir> --target <dir> [options]
        node scripts/idd-onboard.mjs --hear --propose --target <dir>
        node scripts/idd-onboard.mjs --hear --apply --answers <file> --target <dir>
        node scripts/idd-onboard.mjs --hear --target <dir>   (interactive TTY wizard)
+       node scripts/idd-onboard.mjs --record-policy --transcript <file> --target <dir> [--apply] [--write-policy-doc <path>]
 
 Onboarding automation.
 
@@ -1889,6 +2288,11 @@ in that case); 2 usage or configuration error.
 
   --substitute         run the substitution stage
   --target <dir>       target tree to rewrite (default: current directory)
+  --from-transcript <file>
+                       read placeholder answers from a confirmed --hear
+                       transcript (mapsToPlaceholder items); an explicit
+                       placeholder override flag below still wins over
+                       the transcript when both are present
   --dry-run            print the plan without writing anything
   --help, -h           show this help
 
@@ -1972,6 +2376,35 @@ never writes .github/idd/config.json, never requires --source.
                                is not a TTY.
   --target <dir>               target repository (default: current directory)
   --answers <file>              path to the --apply answers JSON file
+  --help, -h                    show this help
+
+--record-policy (#2282): consumes a confirmed --hear transcript's
+policy-kind answers. Post-import only: --target must already contain
+.github/idd/config.json. Never edits ONBOARDING.md, CLAUDE.md,
+AGENTS.md, or GEMINI.md.
+
+  --record-policy --transcript <file> --target <dir>
+                               dry-run (default): print the JSON verdict
+                               (config.json patch + filled Markdown
+                               policy-decisions template) without
+                               writing anything.
+  --apply                      merge the patch into .github/idd/config.json
+                               and write it. helperRuntime is omitted
+                               when the confirmed profile is
+                               instructions-only; skipIssueAuthorApprovalGate
+                               is written true only when the operator
+                               opted out. Docs-only answers (critique-loop
+                               profile, credential scope, issue-authoring
+                               companion, up-to-date-head ruleset,
+                               bootstrap execution mode) and the
+                               claim-timing / idd-label-names meta-choices
+                               never become invented config keys -- they
+                               appear in the filled Markdown template only.
+  --write-policy-doc <path>    also write the filled Markdown template to
+                               <path> (--apply only); without this flag the
+                               template is stdout-only.
+  --target <dir>               target repository (default: current directory)
+  --transcript <file>          path to the confirmed --hear transcript
   --help, -h                    show this help
 `);
 }

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -1628,6 +1628,15 @@ function deepMergeConfigPatch(target, patch) {
   }
   return result;
 }
+/** Distributed-default sub-values the hearing catalog does not itself elicit. */
+const CLAIM_TIMING_DEFAULTS = {
+  staleAge: '24 h',
+  heartbeatInterval: '12 h',
+};
+const CI_WAIT_DEFAULTS = {
+  runningTimeout: '`PT30M` / 30 min',
+  generationTimeout: '`PT10M` / 10 min',
+};
 /**
  * Catalog-item-id-ordered rows for the filled Markdown template,
  * mirroring `idd-template/docs/onboarding/policy-decisions.md`'s
@@ -1650,8 +1659,36 @@ const RECORD_POLICY_DOC_ROWS = [
     label: 'Profile',
   },
   { id: 'credential-scope', heading: 'Credential Scope', label: 'Scope' },
-  { id: 'claim-timing', heading: 'Claim Timing', label: 'Selection' },
-  { id: 'ci-wait-policy', heading: 'CI Wait Policy', label: 'Rerun policy' },
+  {
+    id: 'claim-timing',
+    heading: 'Claim Timing',
+    label: 'Selection',
+    // The catalog item confirms only the defaults-vs-override meta
+    // choice, not override sub-values, so the distributed constants
+    // are rendered as the known baseline and an override is flagged
+    // as needing manual recording rather than invented.
+    renderBody: (value) =>
+      value === 'distributed-defaults'
+        ? [
+            `- **claim-stale-age**: ${CLAIM_TIMING_DEFAULTS.staleAge} (distributed default)`,
+            `- **claim-heartbeat-interval**: ${CLAIM_TIMING_DEFAULTS.heartbeatInterval} (distributed default)`,
+          ].join('\n')
+        : `**Selection**: \`${value}\` (override values not captured by this hearing item -- record them manually)`,
+  },
+  {
+    id: 'ci-wait-policy',
+    heading: 'CI Wait Policy',
+    label: 'Rerun policy',
+    // Only rerunPolicy is a confirmed answer here; the running/generation
+    // timeouts are the distributed constants, not something this catalog
+    // item elicits, so they are labeled as unconfirmed defaults.
+    renderBody: (value) =>
+      [
+        `- **running timeout**: ${CI_WAIT_DEFAULTS.runningTimeout} (distributed default, not confirmed by this hearing item)`,
+        `- **generation timeout**: ${CI_WAIT_DEFAULTS.generationTimeout} (distributed default, not confirmed by this hearing item)`,
+        `- **rerun policy**: \`${value}\``,
+      ].join('\n'),
+  },
   {
     id: 'issue-author-approval-gate',
     heading: 'Issue-Author Approval Gate',
@@ -1695,10 +1732,13 @@ function buildFilledPolicyDocument(answers) {
   const valueById = new Map(answers.map((answer) => [answer.id, answer.value]));
   const sections = RECORD_POLICY_DOC_ROWS.filter((row) =>
     valueById.has(row.id),
-  ).map(
-    (row) =>
-      `### ${row.heading}\n\n**${row.label}**: \`${valueById.get(row.id)}\``,
-  );
+  ).map((row) => {
+    const value = valueById.get(row.id);
+    const body = row.renderBody
+      ? row.renderBody(value)
+      : `**${row.label}**: \`${value}\``;
+    return `### ${row.heading}\n\n${body}`;
+  });
   return [
     '## IDD Policy Configuration',
     '',
@@ -1724,11 +1764,13 @@ function runRecordPolicyCli(args) {
   const result = readAndValidateTranscript(args.transcript);
   if (result.transcript === null) {
     // Matches --hear --apply's own schema-failure shape and exit code.
+    // --dry-run always wins over --apply here too, matching the success
+    // path's canWrite convention below.
     process.stdout.write(
       `${JSON.stringify(
         {
           protocolVersion: '1',
-          mode: args.apply ? 'apply' : 'dry-run',
+          mode: args.apply && !args.dryRun ? 'apply' : 'dry-run',
           valid: false,
           unresolved: result.errors,
         },

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -2213,9 +2213,9 @@ function runRecordPolicyCli(args: ParsedArgs): void {
   // Validate only the sections this patch touched (#1359 pattern via
   // validateConfigSection), never the whole document: --record-policy
   // runs post-import, pre-substitute, so the "pristine imported"
-  // config.json still carries unresolved {{PLACEHOLDER}} tokens in
-  // required fields like markerPrefix -- a whole-document validate
-  // would reject every real invocation.
+  // config.json still carries unresolved double-brace placeholder
+  // tokens in required fields like markerPrefix -- a whole-document
+  // validate would reject every real invocation.
   const schema = loadJson('schemas/policy.schema.json');
   const schemaErrors = Object.keys(patch).flatMap((key) =>
     validateConfigSection(mergedConfig, schema, key),

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -65,7 +65,11 @@ import type {
 import { loadOnboardingHearingCatalog } from './onboarding-hearing.mts';
 import type { PromptFn } from './readline-prompt.mts';
 import { makeReadlinePrompt } from './readline-prompt.mts';
-import { loadJson, validate } from './validate-schemas.mts';
+import {
+  loadJson,
+  validate,
+  validateConfigSection,
+} from './validate-schemas.mts';
 
 /** Substitution role of a placeholder: only `command` rows may be `true`. */
 export type OnboardingPlaceholderKind = 'identity' | 'command';
@@ -1879,7 +1883,7 @@ async function runHearCli(args: ParsedArgs): Promise<void> {
   if (!statSync(targetDir).isDirectory()) {
     throw new Error(`--target is not a directory: ${args.target}`);
   }
-  if (args.propose && args.applyHear) {
+  if (args.propose && args.apply) {
     throw new Error(
       '--hear --propose and --hear --apply are mutually exclusive',
     );
@@ -1889,7 +1893,7 @@ async function runHearCli(args: ParsedArgs): Promise<void> {
     runHearProposeCli(catalog, targetDir);
     return;
   }
-  if (args.applyHear) {
+  if (args.apply) {
     if (!args.answers) {
       throw new Error('--hear --apply requires --answers <file>');
     }
@@ -1905,6 +1909,342 @@ async function runHearCli(args: ParsedArgs): Promise<void> {
     );
   }
   process.stdout.write(`${JSON.stringify(transcript, null, 2)}\n`);
+  process.exit(0);
+}
+
+/** Confirmed transcript document shape consumed by --from-transcript / --record-policy. */
+interface HearTranscriptDocument {
+  version: string;
+  confirmedAt?: string;
+  answers: readonly HearAnswer[];
+}
+
+/**
+ * Read, parse, and schema-validate a confirmed hearing transcript file
+ * (the output of `--hear --apply` or the interactive wizard). Throws
+ * only on unparseable JSON (a usage error, exit 2, matching `--hear
+ * --apply`'s own file-reading check); a schema mismatch is returned as
+ * `errors` instead, so the caller can print the same
+ * `{valid:false, unresolved}` shape `--hear --apply` prints and exit 1
+ * -- "reject a transcript that fails the transcript schema... (exit 1,
+ * no writes)" per #2282.
+ */
+function readAndValidateTranscript(path: string):
+  | { transcript: HearTranscriptDocument; errors: readonly [] }
+  | {
+      transcript: null;
+      errors: readonly string[];
+    } {
+  const raw = readFileSync(resolve(path), 'utf8');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`transcript file is not valid JSON: ${path}`);
+  }
+  const schemaErrors = validateHearTranscriptShape(parsed);
+  if (schemaErrors.length > 0) {
+    return { transcript: null, errors: schemaErrors };
+  }
+  return { transcript: parsed as HearTranscriptDocument, errors: [] };
+}
+
+/**
+ * Map a confirmed transcript's answers onto `resolvePlaceholderValues`
+ * overrides, using each catalog item's `mapsToPlaceholder` field. An
+ * answer for an item with no `mapsToPlaceholder` (a policy or check
+ * item) is not a placeholder override and is ignored here.
+ */
+function buildTranscriptPlaceholderOverrides(
+  catalog: OnboardingHearingCatalog,
+  transcript: HearTranscriptDocument,
+): PlaceholderOverrides {
+  const byId = new Map(catalog.items.map((item) => [item.id, item]));
+  const overrides: PlaceholderOverrides = {};
+  for (const answer of transcript.answers) {
+    const placeholderName = byId.get(answer.id)?.mapsToPlaceholder;
+    if (placeholderName !== undefined) {
+      overrides[placeholderName] = answer.value;
+    }
+  }
+  return overrides;
+}
+
+/**
+ * Catalog item ids whose confirmed answer is a meta-choice about
+ * whether to override the distributed default, not the override value
+ * itself -- `claimTiming` needs an ISO-duration pair
+ * (`staleAge`/`heartbeatInterval`) and `labels` needs actual label-name
+ * strings, neither derivable from `distributed-defaults` /
+ * `repository-override` / `custom-taxonomy` alone. `--record-policy`
+ * surfaces these in the filled Markdown template but never invents a
+ * config value for them (see #2282 B2 plan).
+ */
+const RECORD_POLICY_NO_LITERAL_CONFIG_IDS = new Set([
+  'claim-timing',
+  'idd-label-names',
+]);
+
+/**
+ * Translate one confirmed hearing answer into a `.github/idd/config.json`
+ * patch entry (a dotted key path plus the value to write), or `null`
+ * when the item is docs-only, has no literal config value (see
+ * {@link RECORD_POLICY_NO_LITERAL_CONFIG_IDS}), or is one of the two
+ * items whose "distributed default" answer needs no explicit record
+ * (`helper-runtime-profile`'s `instructions-only`,
+ * `issue-author-approval-gate`'s `enabled-by-default`). Every other
+ * mapped item's confirmed value is written verbatim, including when it
+ * happens to equal that item's own documented default.
+ */
+function translateRecordPolicyAnswer(
+  item: HearingCatalogItem,
+  value: string,
+): { path: readonly string[]; value: unknown } | null {
+  if (!item.mapsToConfig || RECORD_POLICY_NO_LITERAL_CONFIG_IDS.has(item.id)) {
+    return null;
+  }
+  if (item.id === 'helper-runtime-profile' && value === 'instructions-only') {
+    // The whole `helperRuntime` key defaults to the instructions-only
+    // fallback when absent (schema); omit it rather than writing the
+    // value literally.
+    return null;
+  }
+  if (item.id === 'issue-author-approval-gate') {
+    if (value === 'enabled-by-default') {
+      // Schema default (omitted or `false`) already keeps the gate on.
+      return null;
+    }
+    return { path: ['skipIssueAuthorApprovalGate'], value: true };
+  }
+  const path = item.mapsToConfig
+    .split('/')
+    .filter((segment) => segment.length > 0);
+  return { path, value };
+}
+
+/** Set a value at a nested key path, creating intermediate objects as needed. */
+function setNestedValue(
+  target: Record<string, unknown>,
+  path: readonly string[],
+  value: unknown,
+): void {
+  let cursor = target;
+  for (let depth = 0; depth < path.length - 1; depth += 1) {
+    const key = path[depth];
+    const next = cursor[key];
+    if (typeof next !== 'object' || next === null || Array.isArray(next)) {
+      cursor[key] = {};
+    }
+    cursor = cursor[key] as Record<string, unknown>;
+  }
+  cursor[path[path.length - 1]] = value;
+}
+
+/**
+ * Recursively merge `patch` into `target`, preserving sibling keys in
+ * any nested object both sides declare (e.g. merging `ciWait.rerunPolicy`
+ * must not discard an existing `ciWait.runningTimeout`). Scalars and
+ * arrays in `patch` overwrite `target` outright.
+ */
+function deepMergeConfigPatch(
+  target: Record<string, unknown>,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = { ...target };
+  for (const [key, value] of Object.entries(patch)) {
+    const existing = result[key];
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value) &&
+      typeof existing === 'object' &&
+      existing !== null &&
+      !Array.isArray(existing)
+    ) {
+      result[key] = deepMergeConfigPatch(
+        existing as Record<string, unknown>,
+        value as Record<string, unknown>,
+      );
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+/** One row of the filled policy-decisions Markdown template. */
+interface RecordPolicyDocRow {
+  id: string;
+  heading: string;
+  label: string;
+}
+
+/**
+ * Catalog-item-id-ordered rows for the filled Markdown template,
+ * mirroring `idd-template/docs/onboarding/policy-decisions.md`'s
+ * "Recording the selected policies" example structure. Only items the
+ * hearing catalog can actually answer (policy-kind items) are listed;
+ * the three Step 0 `check`-kind items are evidence, not a policy
+ * decision, and are not part of this template.
+ */
+const RECORD_POLICY_DOC_ROWS: readonly RecordPolicyDocRow[] = [
+  { id: 'merge-policy', heading: 'Merge Policy', label: 'Policy' },
+  { id: 'review-policy', heading: 'PR Review Policy', label: 'Profile' },
+  {
+    id: 'thread-resolution-policy',
+    heading: 'Review-Thread Resolution Policy',
+    label: 'Policy',
+  },
+  {
+    id: 'critique-loop-profile',
+    heading: 'Critique-Loop Profile',
+    label: 'Profile',
+  },
+  { id: 'credential-scope', heading: 'Credential Scope', label: 'Scope' },
+  { id: 'claim-timing', heading: 'Claim Timing', label: 'Selection' },
+  { id: 'ci-wait-policy', heading: 'CI Wait Policy', label: 'Rerun policy' },
+  {
+    id: 'issue-author-approval-gate',
+    heading: 'Issue-Author Approval Gate',
+    label: 'Selection',
+  },
+  {
+    id: 'maintainer-approval-actor-policy',
+    heading: 'Maintainer Approval Actor Policy',
+    label: 'Policy',
+  },
+  {
+    id: 'issue-authoring-companion',
+    heading: 'Issue-Authoring Companion',
+    label: 'Status',
+  },
+  {
+    id: 'helper-runtime-profile',
+    heading: 'Helper Runtime Profile',
+    label: 'Profile',
+  },
+  { id: 'idd-label-names', heading: 'IDD Label Names', label: 'Selection' },
+  {
+    id: 'up-to-date-head-ruleset',
+    heading: 'Up-to-Date-Head Ruleset',
+    label: 'Policy',
+  },
+  {
+    id: 'bootstrap-execution-mode',
+    heading: 'Bootstrap Execution Mode',
+    label: 'Mode',
+  },
+];
+
+/**
+ * Render the filled `## IDD Policy Configuration` Markdown document from
+ * a confirmed transcript's answers, following the structure shown in
+ * `idd-template/docs/onboarding/policy-decisions.md`'s
+ * "Recording the selected policies" section. An item with no confirmed
+ * answer is omitted rather than printed with a placeholder value.
+ */
+function buildFilledPolicyDocument(answers: readonly HearAnswer[]): string {
+  const valueById = new Map(answers.map((answer) => [answer.id, answer.value]));
+  const sections = RECORD_POLICY_DOC_ROWS.filter((row) =>
+    valueById.has(row.id),
+  ).map(
+    (row) =>
+      `### ${row.heading}\n\n**${row.label}**: \`${valueById.get(row.id)}\``,
+  );
+  return [
+    '## IDD Policy Configuration',
+    '',
+    'This repository uses the following IDD policies:',
+    '',
+    sections.join('\n\n'),
+  ].join('\n');
+}
+
+function runRecordPolicyCli(args: ParsedArgs): void {
+  if (!args.transcript) {
+    throw new Error('--record-policy requires --transcript <file>');
+  }
+  const targetDir = resolve(args.target);
+  if (!statSync(targetDir).isDirectory()) {
+    throw new Error(`--target is not a directory: ${args.target}`);
+  }
+  const configPath = join(targetDir, '.github', 'idd', 'config.json');
+  if (!existsSync(configPath)) {
+    throw new Error(
+      `--record-policy is post-import only; missing ${configPath}`,
+    );
+  }
+  const result = readAndValidateTranscript(args.transcript);
+  if (result.transcript === null) {
+    // Matches --hear --apply's own schema-failure shape and exit code.
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          protocolVersion: '1',
+          mode: args.apply ? 'apply' : 'dry-run',
+          valid: false,
+          unresolved: result.errors,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    process.exit(1);
+  }
+  const transcript = result.transcript;
+  const catalog = loadOnboardingHearingCatalog();
+  const byId = new Map(catalog.items.map((item) => [item.id, item]));
+  const patch: Record<string, unknown> = {};
+  for (const answer of transcript.answers) {
+    const item = byId.get(answer.id);
+    if (!item) {
+      continue;
+    }
+    const translated = translateRecordPolicyAnswer(item, answer.value);
+    if (translated) {
+      setNestedValue(patch, translated.path, translated.value);
+    }
+  }
+  const existingConfig = JSON.parse(readFileSync(configPath, 'utf8')) as Record<
+    string,
+    unknown
+  >;
+  const mergedConfig = deepMergeConfigPatch(existingConfig, patch);
+  // Validate only the sections this patch touched (#1359 pattern via
+  // validateConfigSection), never the whole document: --record-policy
+  // runs post-import, pre-substitute, so the "pristine imported"
+  // config.json still carries unresolved {{PLACEHOLDER}} tokens in
+  // required fields like markerPrefix -- a whole-document validate
+  // would reject every real invocation.
+  const schema = loadJson('schemas/policy.schema.json');
+  const schemaErrors = Object.keys(patch).flatMap((key) =>
+    validateConfigSection(mergedConfig, schema, key),
+  );
+  if (schemaErrors.length > 0) {
+    throw new Error(
+      `config.json patch failed schema validation: ${schemaErrors.join('; ')}`,
+    );
+  }
+  const policyDocument = buildFilledPolicyDocument(transcript.answers);
+  const canWrite = args.apply;
+  if (canWrite) {
+    writeFileSync(configPath, `${JSON.stringify(mergedConfig, null, 2)}\n`);
+    if (args.writePolicyDoc) {
+      writeFileSync(resolve(args.writePolicyDoc), `${policyDocument}\n`);
+    }
+  }
+  const verdict = {
+    protocolVersion: '1',
+    mode: canWrite ? 'apply' : 'dry-run',
+    target: targetDir,
+    transcript: resolve(args.transcript),
+    configPatch: patch,
+    policyDocument,
+    writtenPolicyDocPath:
+      canWrite && args.writePolicyDoc ? resolve(args.writePolicyDoc) : null,
+    written: canWrite,
+  };
+  process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
   process.exit(0);
 }
 
@@ -1928,9 +2268,14 @@ interface ParsedArgs {
   importMode: boolean;
   verify: boolean;
   hear: boolean;
+  recordPolicy: boolean;
   propose: boolean;
-  applyHear: boolean;
+  /** Bare `--apply`, shared by `--hear --apply` and `--record-policy --apply`. */
+  apply: boolean;
   answers: string | undefined;
+  fromTranscript: string | undefined;
+  transcript: string | undefined;
+  writePolicyDoc: string | undefined;
   source: string | undefined;
   target: string;
   dryRun: boolean;
@@ -1951,9 +2296,13 @@ function parseArgs(argv: string[]): ParsedArgs {
     importMode: false,
     verify: false,
     hear: false,
+    recordPolicy: false,
     propose: false,
-    applyHear: false,
+    apply: false,
     answers: undefined,
+    fromTranscript: undefined,
+    transcript: undefined,
+    writePolicyDoc: undefined,
     source: undefined,
     target: '.',
     dryRun: false,
@@ -1990,16 +2339,35 @@ function parseArgs(argv: string[]): ParsedArgs {
       parsed.hear = true;
       continue;
     }
+    if (token === '--record-policy') {
+      parsed.recordPolicy = true;
+      continue;
+    }
     if (token === '--propose') {
       parsed.propose = true;
       continue;
     }
     if (token === '--apply') {
-      parsed.applyHear = true;
+      parsed.apply = true;
       continue;
     }
     if (token === '--answers') {
       parsed.answers = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === '--from-transcript') {
+      parsed.fromTranscript = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === '--transcript') {
+      parsed.transcript = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === '--write-policy-doc') {
+      parsed.writePolicyDoc = requireValue();
       index += 1;
       continue;
     }
@@ -2056,11 +2424,30 @@ function importOnlyFlagsPresent(args: ParsedArgs): string[] {
   return present;
 }
 
-/** Substitute-only placeholder-override flags the user explicitly passed. */
+/**
+ * Substitute-only flags the user explicitly passed: every placeholder
+ * override flag, plus `--from-transcript`.
+ */
 function substituteOnlyFlagsPresent(args: ParsedArgs): string[] {
-  return ONBOARDING_PLACEHOLDERS.filter(
+  const present = ONBOARDING_PLACEHOLDERS.filter(
     (entry) => args.overrides[entry.name] !== undefined,
   ).map((entry) => entry.flag);
+  if (args.fromTranscript !== undefined) {
+    present.push('--from-transcript');
+  }
+  return present;
+}
+
+/** --record-policy-only flags the user explicitly passed (present regardless of mode). */
+function recordPolicyOnlyFlagsPresent(args: ParsedArgs): string[] {
+  const present: string[] = [];
+  if (args.transcript !== undefined) {
+    present.push('--transcript');
+  }
+  if (args.writePolicyDoc !== undefined) {
+    present.push('--write-policy-doc');
+  }
+  return present;
 }
 
 /**
@@ -2080,13 +2467,20 @@ function verifyForeignFlagsPresent(args: ParsedArgs): string[] {
   return present;
 }
 
-/** --hear-only flags the user explicitly passed (present regardless of mode). */
+/**
+ * --hear-only flags the user explicitly passed (present regardless of
+ * mode). Bare `--apply` is shared with `--record-policy` and reported
+ * here as `--apply`; callers that also reject record-policy-only flags
+ * separately via {@link recordPolicyOnlyFlagsPresent} still catch a
+ * `--record-policy --apply` combination through that function's own
+ * `--transcript`/`--write-policy-doc` checks.
+ */
 function hearOnlyFlagsPresent(args: ParsedArgs): string[] {
   const present: string[] = [];
   if (args.propose) {
     present.push('--propose');
   }
-  if (args.applyHear) {
+  if (args.apply) {
     present.push('--apply');
   }
   if (args.answers !== undefined) {
@@ -2097,12 +2491,17 @@ function hearOnlyFlagsPresent(args: ParsedArgs): string[] {
 
 /**
  * Flags --hear does not accept: every import-only flag (`--source`,
- * `--force`, `--profile` -- --hear never imports or overwrites) plus every
+ * `--force`, `--profile` -- --hear never imports or overwrites), every
  * substitute-only placeholder-override flag (--hear derives candidates
- * read-only via the same hooks; it never accepts an explicit override).
+ * read-only via the same hooks; it never accepts an explicit override),
+ * and every record-policy-only flag.
  */
 function hearForeignFlagsPresent(args: ParsedArgs): string[] {
-  return [...importOnlyFlagsPresent(args), ...substituteOnlyFlagsPresent(args)];
+  return [
+    ...importOnlyFlagsPresent(args),
+    ...substituteOnlyFlagsPresent(args),
+    ...recordPolicyOnlyFlagsPresent(args),
+  ];
 }
 
 async function runCli(): Promise<void> {
@@ -2116,10 +2515,11 @@ async function runCli(): Promise<void> {
     args.importMode,
     args.verify,
     args.hear,
+    args.recordPolicy,
   ].filter(Boolean).length;
   if (modeCount > 1) {
     throw new Error(
-      '--substitute, --import, --verify, and --hear are mutually exclusive',
+      '--substitute, --import, --verify, --hear, and --record-policy are mutually exclusive',
     );
   }
   if (args.hear) {
@@ -2132,6 +2532,23 @@ async function runCli(): Promise<void> {
     await runHearCli(args);
     return;
   }
+  if (args.recordPolicy) {
+    // Not hearOnlyFlagsPresent(args): that set includes bare --apply,
+    // which --record-policy shares and must accept.
+    const foreign = [
+      ...importOnlyFlagsPresent(args),
+      ...substituteOnlyFlagsPresent(args),
+      ...(args.propose ? ['--propose'] : []),
+      ...(args.answers !== undefined ? ['--answers'] : []),
+    ];
+    if (foreign.length > 0) {
+      throw new Error(
+        `--record-policy does not accept flag(s) it never uses: ${foreign.join(', ')}`,
+      );
+    }
+    runRecordPolicyCli(args);
+    return;
+  }
   if (args.importMode) {
     // parseArgs collects every known flag regardless of the active stage,
     // so a stage-foreign flag (e.g. a placeholder override alongside
@@ -2139,10 +2556,11 @@ async function runCli(): Promise<void> {
     const foreign = [
       ...substituteOnlyFlagsPresent(args),
       ...hearOnlyFlagsPresent(args),
+      ...recordPolicyOnlyFlagsPresent(args),
     ];
     if (foreign.length > 0) {
       throw new Error(
-        `--import does not accept substitute-only flag(s) or --hear-only flag(s): ${foreign.join(', ')}`,
+        `--import does not accept substitute-only flag(s), --hear-only flag(s), or --record-policy-only flag(s): ${foreign.join(', ')}`,
       );
     }
     runImportCli(args);
@@ -2152,6 +2570,7 @@ async function runCli(): Promise<void> {
     const foreign = [
       ...verifyForeignFlagsPresent(args),
       ...hearOnlyFlagsPresent(args),
+      ...recordPolicyOnlyFlagsPresent(args),
     ];
     if (foreign.length > 0) {
       throw new Error(
@@ -2163,23 +2582,54 @@ async function runCli(): Promise<void> {
   }
   if (!args.substitute) {
     throw new Error(
-      'pass --substitute, --import, --verify, or --hear to select a stage',
+      'pass --substitute, --import, --verify, --hear, or --record-policy to select a stage',
     );
   }
   const foreign = [
     ...importOnlyFlagsPresent(args),
     ...hearOnlyFlagsPresent(args),
+    ...recordPolicyOnlyFlagsPresent(args),
   ];
   if (foreign.length > 0) {
     throw new Error(
-      `--substitute does not accept import-only flag(s) or --hear-only flag(s): ${foreign.join(', ')}`,
+      `--substitute does not accept import-only flag(s), --hear-only flag(s), or --record-policy-only flag(s): ${foreign.join(', ')}`,
     );
   }
   const targetDir = resolve(args.target);
   if (!statSync(targetDir).isDirectory()) {
     throw new Error(`--target is not a directory: ${args.target}`);
   }
-  const resolution = resolvePlaceholderValues(targetDir, args.overrides);
+  let transcriptOverrides: PlaceholderOverrides = {};
+  if (args.fromTranscript !== undefined) {
+    const result = readAndValidateTranscript(args.fromTranscript);
+    if (result.transcript === null) {
+      // Matches --hear --apply's own schema-failure shape and exit code.
+      process.stdout.write(
+        `${JSON.stringify(
+          {
+            protocolVersion: '1',
+            mode: args.dryRun ? 'dry-run' : 'apply',
+            valid: false,
+            unresolved: result.errors,
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      process.exit(1);
+    }
+    transcriptOverrides = buildTranscriptPlaceholderOverrides(
+      loadOnboardingHearingCatalog(),
+      result.transcript,
+    );
+  }
+  // Explicit per-placeholder flags win over the transcript, matching
+  // today's "explicit flags override derivation" rule.
+  const mergedOverrides: PlaceholderOverrides = {
+    ...transcriptOverrides,
+    ...args.overrides,
+  };
+  const resolution = resolvePlaceholderValues(targetDir, mergedOverrides);
   const plan = buildSubstitutionPlan(
     scanPlaceholderTokens(targetDir),
     resolution,
@@ -2301,11 +2751,13 @@ function printHelp(): void {
       `  ${entry.flag} <value>${entry.kind === 'command' ? ' (accepts the no-op "true")' : ''}`,
   ).join('\n');
   process.stdout.write(`usage: node scripts/idd-onboard.mjs --substitute [options]
+       node scripts/idd-onboard.mjs --substitute --from-transcript <file> [options]
        node scripts/idd-onboard.mjs --import --source <dir> --target <dir> [options]
        node scripts/idd-onboard.mjs --verify --source <dir> --target <dir> [options]
        node scripts/idd-onboard.mjs --hear --propose --target <dir>
        node scripts/idd-onboard.mjs --hear --apply --answers <file> --target <dir>
        node scripts/idd-onboard.mjs --hear --target <dir>   (interactive TTY wizard)
+       node scripts/idd-onboard.mjs --record-policy --transcript <file> --target <dir> [--apply] [--write-policy-doc <path>]
 
 Onboarding automation.
 
@@ -2327,6 +2779,11 @@ in that case); 2 usage or configuration error.
 
   --substitute         run the substitution stage
   --target <dir>       target tree to rewrite (default: current directory)
+  --from-transcript <file>
+                       read placeholder answers from a confirmed --hear
+                       transcript (mapsToPlaceholder items); an explicit
+                       placeholder override flag below still wins over
+                       the transcript when both are present
   --dry-run            print the plan without writing anything
   --help, -h           show this help
 
@@ -2410,6 +2867,35 @@ never writes .github/idd/config.json, never requires --source.
                                is not a TTY.
   --target <dir>               target repository (default: current directory)
   --answers <file>              path to the --apply answers JSON file
+  --help, -h                    show this help
+
+--record-policy (#2282): consumes a confirmed --hear transcript's
+policy-kind answers. Post-import only: --target must already contain
+.github/idd/config.json. Never edits ONBOARDING.md, CLAUDE.md,
+AGENTS.md, or GEMINI.md.
+
+  --record-policy --transcript <file> --target <dir>
+                               dry-run (default): print the JSON verdict
+                               (config.json patch + filled Markdown
+                               policy-decisions template) without
+                               writing anything.
+  --apply                      merge the patch into .github/idd/config.json
+                               and write it. helperRuntime is omitted
+                               when the confirmed profile is
+                               instructions-only; skipIssueAuthorApprovalGate
+                               is written true only when the operator
+                               opted out. Docs-only answers (critique-loop
+                               profile, credential scope, issue-authoring
+                               companion, up-to-date-head ruleset,
+                               bootstrap execution mode) and the
+                               claim-timing / idd-label-names meta-choices
+                               never become invented config keys -- they
+                               appear in the filled Markdown template only.
+  --write-policy-doc <path>    also write the filled Markdown template to
+                               <path> (--apply only); without this flag the
+                               template is stdout-only.
+  --target <dir>               target repository (default: current directory)
+  --transcript <file>          path to the confirmed --hear transcript
   --help, -h                    show this help
 `);
 }

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -2226,7 +2226,8 @@ function runRecordPolicyCli(args: ParsedArgs): void {
     );
   }
   const policyDocument = buildFilledPolicyDocument(transcript.answers);
-  const canWrite = args.apply;
+  // --dry-run always wins over --apply, matching runImportCli's convention.
+  const canWrite = args.apply && !args.dryRun;
   if (canWrite) {
     writeFileSync(configPath, `${JSON.stringify(mergedConfig, null, 2)}\n`);
     if (args.writePolicyDoc) {

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -1986,15 +1986,28 @@ const RECORD_POLICY_NO_LITERAL_CONFIG_IDS = new Set([
 ]);
 
 /**
+ * Sentinel patch value meaning "remove this key from the merged config"
+ * rather than "set it to this value". Used when a confirmed transcript
+ * answer reconfirms a distributed default that has no on-the-wire
+ * representation of its own (an absent key already means default) --
+ * without this, reconfirming the default would silently leave a stale
+ * non-default value from a prior run in place (#2282 review follow-up).
+ */
+const DELETE_CONFIG_KEY = Symbol('idd-record-policy-delete-config-key');
+
+/**
  * Translate one confirmed hearing answer into a `.github/idd/config.json`
- * patch entry (a dotted key path plus the value to write), or `null`
- * when the item is docs-only, has no literal config value (see
- * {@link RECORD_POLICY_NO_LITERAL_CONFIG_IDS}), or is one of the two
- * items whose "distributed default" answer needs no explicit record
+ * patch entry (a dotted key path plus the value to write, where the value
+ * may be {@link DELETE_CONFIG_KEY}), or `null` when the item is docs-only
+ * or has no literal config value (see
+ * {@link RECORD_POLICY_NO_LITERAL_CONFIG_IDS}). The two items whose
+ * "distributed default" answer has no positive on-the-wire representation
  * (`helper-runtime-profile`'s `instructions-only`,
- * `issue-author-approval-gate`'s `enabled-by-default`). Every other
- * mapped item's confirmed value is written verbatim, including when it
- * happens to equal that item's own documented default.
+ * `issue-author-approval-gate`'s `enabled-by-default`) delete their key
+ * instead, so reconfirming the default clears a stale override from a
+ * prior run rather than preserving it. Every other mapped item's
+ * confirmed value is written verbatim, including when it happens to
+ * equal that item's own documented default.
  */
 function translateRecordPolicyAnswer(
   item: HearingCatalogItem,
@@ -2005,14 +2018,18 @@ function translateRecordPolicyAnswer(
   }
   if (item.id === 'helper-runtime-profile' && value === 'instructions-only') {
     // The whole `helperRuntime` key defaults to the instructions-only
-    // fallback when absent (schema); omit it rather than writing the
-    // value literally.
-    return null;
+    // fallback when absent (schema); delete it rather than writing the
+    // value literally, clearing any stale non-default profile.
+    return { path: ['helperRuntime'], value: DELETE_CONFIG_KEY };
   }
   if (item.id === 'issue-author-approval-gate') {
     if (value === 'enabled-by-default') {
-      // Schema default (omitted or `false`) already keeps the gate on.
-      return null;
+      // Schema default (omitted or `false`) already keeps the gate on;
+      // delete a stale `true` opt-out rather than preserving it.
+      return {
+        path: ['skipIssueAuthorApprovalGate'],
+        value: DELETE_CONFIG_KEY,
+      };
     }
     return { path: ['skipIssueAuthorApprovalGate'], value: true };
   }
@@ -2044,7 +2061,8 @@ function setNestedValue(
  * Recursively merge `patch` into `target`, preserving sibling keys in
  * any nested object both sides declare (e.g. merging `ciWait.rerunPolicy`
  * must not discard an existing `ciWait.runningTimeout`). Scalars and
- * arrays in `patch` overwrite `target` outright.
+ * arrays in `patch` overwrite `target` outright. A {@link DELETE_CONFIG_KEY}
+ * patch value removes that key from the result instead of setting it.
  */
 function deepMergeConfigPatch(
   target: Record<string, unknown>,
@@ -2052,6 +2070,10 @@ function deepMergeConfigPatch(
 ): Record<string, unknown> {
   const result: Record<string, unknown> = { ...target };
   for (const [key, value] of Object.entries(patch)) {
+    if (value === DELETE_CONFIG_KEY) {
+      delete result[key];
+      continue;
+    }
     const existing = result[key];
     if (
       typeof value === 'object' &&
@@ -2070,6 +2092,25 @@ function deepMergeConfigPatch(
     }
   }
   return result;
+}
+
+/**
+ * Render a config patch for the JSON verdict: a {@link DELETE_CONFIG_KEY}
+ * sentinel isn't itself meaningful JSON, so it renders as an explicit
+ * marker string instead of silently vanishing (a bare `Symbol` value is
+ * dropped by `JSON.stringify`).
+ */
+function renderPatchForVerdict(
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  const rendered: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(patch)) {
+    rendered[key] =
+      value === DELETE_CONFIG_KEY
+        ? '(reset to distributed default: key removed)'
+        : value;
+  }
+  return rendered;
 }
 
 /** One row of the filled policy-decisions Markdown template. */
@@ -2289,7 +2330,7 @@ function runRecordPolicyCli(args: ParsedArgs): void {
     mode: canWrite ? 'apply' : 'dry-run',
     target: targetDir,
     transcript: resolve(args.transcript),
-    configPatch: patch,
+    configPatch: renderPatchForVerdict(patch),
     policyDocument,
     writtenPolicyDocPath:
       canWrite && args.writePolicyDoc ? resolve(args.writePolicyDoc) : null,

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -2077,7 +2077,24 @@ interface RecordPolicyDocRow {
   id: string;
   heading: string;
   label: string;
+  /**
+   * Override the default `**label**: `value`` line with a structured
+   * bullet body for a row whose template section
+   * (`idd-template/docs/onboarding/policy-decisions.md`) documents more
+   * sub-fields than the hearing catalog item actually confirms.
+   */
+  renderBody?: (value: string) => string;
 }
+
+/** Distributed-default sub-values the hearing catalog does not itself elicit. */
+const CLAIM_TIMING_DEFAULTS = {
+  staleAge: '24 h',
+  heartbeatInterval: '12 h',
+} as const;
+const CI_WAIT_DEFAULTS = {
+  runningTimeout: '`PT30M` / 30 min',
+  generationTimeout: '`PT10M` / 10 min',
+} as const;
 
 /**
  * Catalog-item-id-ordered rows for the filled Markdown template,
@@ -2101,8 +2118,36 @@ const RECORD_POLICY_DOC_ROWS: readonly RecordPolicyDocRow[] = [
     label: 'Profile',
   },
   { id: 'credential-scope', heading: 'Credential Scope', label: 'Scope' },
-  { id: 'claim-timing', heading: 'Claim Timing', label: 'Selection' },
-  { id: 'ci-wait-policy', heading: 'CI Wait Policy', label: 'Rerun policy' },
+  {
+    id: 'claim-timing',
+    heading: 'Claim Timing',
+    label: 'Selection',
+    // The catalog item confirms only the defaults-vs-override meta
+    // choice, not override sub-values, so the distributed constants
+    // are rendered as the known baseline and an override is flagged
+    // as needing manual recording rather than invented.
+    renderBody: (value) =>
+      value === 'distributed-defaults'
+        ? [
+            `- **claim-stale-age**: ${CLAIM_TIMING_DEFAULTS.staleAge} (distributed default)`,
+            `- **claim-heartbeat-interval**: ${CLAIM_TIMING_DEFAULTS.heartbeatInterval} (distributed default)`,
+          ].join('\n')
+        : `**Selection**: \`${value}\` (override values not captured by this hearing item -- record them manually)`,
+  },
+  {
+    id: 'ci-wait-policy',
+    heading: 'CI Wait Policy',
+    label: 'Rerun policy',
+    // Only rerunPolicy is a confirmed answer here; the running/generation
+    // timeouts are the distributed constants, not something this catalog
+    // item elicits, so they are labeled as unconfirmed defaults.
+    renderBody: (value) =>
+      [
+        `- **running timeout**: ${CI_WAIT_DEFAULTS.runningTimeout} (distributed default, not confirmed by this hearing item)`,
+        `- **generation timeout**: ${CI_WAIT_DEFAULTS.generationTimeout} (distributed default, not confirmed by this hearing item)`,
+        `- **rerun policy**: \`${value}\``,
+      ].join('\n'),
+  },
   {
     id: 'issue-author-approval-gate',
     heading: 'Issue-Author Approval Gate',
@@ -2147,10 +2192,13 @@ function buildFilledPolicyDocument(answers: readonly HearAnswer[]): string {
   const valueById = new Map(answers.map((answer) => [answer.id, answer.value]));
   const sections = RECORD_POLICY_DOC_ROWS.filter((row) =>
     valueById.has(row.id),
-  ).map(
-    (row) =>
-      `### ${row.heading}\n\n**${row.label}**: \`${valueById.get(row.id)}\``,
-  );
+  ).map((row) => {
+    const value = valueById.get(row.id) as string;
+    const body = row.renderBody
+      ? row.renderBody(value)
+      : `**${row.label}**: \`${value}\``;
+    return `### ${row.heading}\n\n${body}`;
+  });
   return [
     '## IDD Policy Configuration',
     '',
@@ -2177,11 +2225,13 @@ function runRecordPolicyCli(args: ParsedArgs): void {
   const result = readAndValidateTranscript(args.transcript);
   if (result.transcript === null) {
     // Matches --hear --apply's own schema-failure shape and exit code.
+    // --dry-run always wins over --apply here too, matching the success
+    // path's canWrite convention below.
     process.stdout.write(
       `${JSON.stringify(
         {
           protocolVersion: '1',
-          mode: args.apply ? 'apply' : 'dry-run',
+          mode: args.apply && !args.dryRun ? 'apply' : 'dry-run',
           valid: false,
           unresolved: result.errors,
         },

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -2296,10 +2296,20 @@ function runRecordPolicyCli(args: ParsedArgs): void {
       setNestedValue(patch, translated.path, translated.value);
     }
   }
-  const existingConfig = JSON.parse(readFileSync(configPath, 'utf8')) as Record<
-    string,
-    unknown
-  >;
+  // A syntactically valid config.json can still parse to a non-object root
+  // (`null`, a number, a bare string, an array); deepMergeConfigPatch would
+  // silently spread that into `{}` (or an index-keyed object for an array)
+  // and --apply would overwrite the file with the patch alone, losing the
+  // original document. Same guard convention as readExistingCommandsTable.
+  const parsedConfig: unknown = JSON.parse(readFileSync(configPath, 'utf8'));
+  if (
+    typeof parsedConfig !== 'object' ||
+    parsedConfig === null ||
+    Array.isArray(parsedConfig)
+  ) {
+    throw new Error(`--record-policy requires a JSON object at ${configPath}`);
+  }
+  const existingConfig = parsedConfig as Record<string, unknown>;
   const mergedConfig = deepMergeConfigPatch(existingConfig, patch);
   // Validate only the sections this patch touched (#1359 pattern via
   // validateConfigSection), never the whole document: --record-policy

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -3571,6 +3571,10 @@ test('bin/idd-onboard.mjs --record-policy never turns a docs-only or meta-choice
       (entry) => entry.id === id,
     );
     assert.ok(item, `catalog missing ${id}`);
+    const topLevelKey = item?.mapsToConfig?.split('/').filter(Boolean)[0];
+    if (topLevelKey !== undefined) {
+      assert.equal(topLevelKey in patch, false, `${id} leaked into the patch`);
+    }
   }
   assert.equal('claimTiming' in patch, false);
   assert.equal('labels' in patch, false);
@@ -3661,6 +3665,33 @@ test('bin/idd-onboard.mjs --record-policy exits 2 when config.json does not alre
     { encoding: 'utf8' },
   );
   assert.equal(result.status, 2);
+});
+
+test('bin/idd-onboard.mjs --record-policy exits 2 and writes nothing when config.json parses to a non-object root (#2282 review follow-up)', () => {
+  const root = makeFixtureDir();
+  mkdirSync(join(root, '.github', 'idd'), { recursive: true });
+  writeFileSync(join(root, '.github', 'idd', 'config.json'), 'null\n');
+  const answers = buildValidHearAnswers();
+  const transcript = confirmTranscript(root, answers);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(transcript));
+  const before = snapshotTree(root);
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      BIN_PATH,
+      '--record-policy',
+      '--transcript',
+      transcriptPath,
+      '--target',
+      root,
+      '--apply',
+    ],
+    { encoding: 'utf8' },
+  );
+  assert.equal(result.status, 2);
+  assertTreeUnchanged(root, before);
 });
 
 test('bin/idd-onboard.mjs --record-policy requires --transcript', () => {

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -3309,6 +3309,30 @@ test('bin/idd-onboard.mjs --record-policy --apply merges only mapsToConfig field
   assert.equal(config.markerPrefix, '{{PROJECT_MARKER_PREFIX}}');
 });
 
+test('bin/idd-onboard.mjs --record-policy --dry-run --apply does not write: --dry-run always wins', () => {
+  const root = makeFixtureDir();
+  writeRecordPolicyFixture(root);
+  const answers = buildValidHearAnswers();
+  const transcript = confirmTranscript(root, answers);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(transcript));
+  const before = snapshotTree(root);
+
+  const { status, verdict } = runCliBin([
+    '--record-policy',
+    '--transcript',
+    transcriptPath,
+    '--target',
+    root,
+    '--dry-run',
+    '--apply',
+  ]);
+  assert.equal(status, 0);
+  assert.equal(verdict.mode, 'dry-run');
+  assert.equal(verdict.written, false);
+  assertTreeUnchanged(root, before);
+});
+
 test('bin/idd-onboard.mjs --record-policy omits the helperRuntime key when the confirmed profile is instructions-only', () => {
   const root = makeFixtureDir();
   writeRecordPolicyFixture(root);

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -3276,7 +3276,47 @@ test('bin/idd-onboard.mjs --record-policy dry-run prints the config patch and fi
   assert.equal(patch.mergePolicy, answers['merge-policy']);
   assert.match(verdict.policyDocument as string, /## IDD Policy Configuration/);
   assert.match(verdict.policyDocument as string, /### Merge Policy/);
+  // Claim Timing / CI Wait Policy render as the template's own bulleted
+  // sub-fields, not one flattened line, when the catalog's meta answer
+  // is the distributed-defaults choice (#2282 review follow-up).
+  assert.match(
+    verdict.policyDocument as string,
+    /### Claim Timing\n\n- \*\*claim-stale-age\*\*: 24 h \(distributed default\)\n- \*\*claim-heartbeat-interval\*\*: 12 h \(distributed default\)/,
+  );
+  assert.match(
+    verdict.policyDocument as string,
+    /### CI Wait Policy\n\n- \*\*running timeout\*\*: `PT30M` \/ 30 min \(distributed default, not confirmed by this hearing item\)\n- \*\*generation timeout\*\*: `PT10M` \/ 10 min \(distributed default, not confirmed by this hearing item\)\n- \*\*rerun policy\*\*: `rerun-once`/,
+  );
   assertTreeUnchanged(root, before);
+});
+
+test('bin/idd-onboard.mjs --record-policy fills a Claim Timing override with the confirmed selection, not invented sub-values, and carries a confirmed CI Wait rerun policy into its bullet', () => {
+  const root = makeFixtureDir();
+  writeRecordPolicyFixture(root);
+  const answers = buildValidHearAnswers();
+  answers['claim-timing'] = 'repository-override';
+  answers['ci-wait-policy'] = 'hold';
+  const transcript = confirmTranscript(root, answers);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(transcript));
+
+  const { verdict } = runCliBin([
+    '--record-policy',
+    '--transcript',
+    transcriptPath,
+    '--target',
+    root,
+  ]);
+  const doc = verdict.policyDocument as string;
+  assert.match(
+    doc,
+    /### Claim Timing\n\n\*\*Selection\*\*: `repository-override` \(override values not captured by this hearing item -- record them manually\)/,
+  );
+  assert.doesNotMatch(doc, /claim-stale-age/);
+  assert.match(
+    doc,
+    /### CI Wait Policy\n\n- \*\*running timeout\*\*[\s\S]*?\n- \*\*generation timeout\*\*[\s\S]*?\n- \*\*rerun policy\*\*: `hold`/,
+  );
 });
 
 test('bin/idd-onboard.mjs --record-policy --apply merges only mapsToConfig fields into config.json', () => {
@@ -3564,6 +3604,29 @@ test('bin/idd-onboard.mjs --record-policy requires --transcript', () => {
     { encoding: 'utf8' },
   );
   assert.equal(result.status, 2);
+});
+
+test('bin/idd-onboard.mjs --record-policy exits 1 on a malformed transcript, mode reflects --dry-run even with --apply also passed (#2282 review follow-up)', () => {
+  const root = makeFixtureDir();
+  writeRecordPolicyFixture(root);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify({ version: '1.0.0' }));
+  const before = snapshotTree(root);
+
+  const { status, verdict } = runCliBin([
+    '--record-policy',
+    '--transcript',
+    transcriptPath,
+    '--target',
+    root,
+    '--dry-run',
+    '--apply',
+  ]);
+  assert.equal(status, 1);
+  assert.equal(verdict.valid, false);
+  assert.equal(verdict.mode, 'dry-run');
+  assert.ok(Array.isArray(verdict.unresolved) && verdict.unresolved.length > 0);
+  assertTreeUnchanged(root, before);
 });
 
 test('bin/idd-onboard.mjs exits 2 when --record-policy is combined with --import, --substitute, --verify, or --hear', () => {

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -3373,7 +3373,7 @@ test('bin/idd-onboard.mjs --record-policy --dry-run --apply does not write: --dr
   assertTreeUnchanged(root, before);
 });
 
-test('bin/idd-onboard.mjs --record-policy omits the helperRuntime key when the confirmed profile is instructions-only', () => {
+test('bin/idd-onboard.mjs --record-policy leaves no helperRuntime key when the confirmed profile is instructions-only and none pre-existed', () => {
   const root = makeFixtureDir();
   writeRecordPolicyFixture(root);
   const answers = buildValidHearAnswers();
@@ -3391,7 +3391,41 @@ test('bin/idd-onboard.mjs --record-policy omits the helperRuntime key when the c
     '--apply',
   ]);
   const patch = verdict.configPatch as Record<string, unknown>;
-  assert.equal('helperRuntime' in patch, false);
+  assert.equal(
+    patch.helperRuntime,
+    '(reset to distributed default: key removed)',
+  );
+  const config = JSON.parse(
+    readFileSync(join(root, '.github', 'idd', 'config.json'), 'utf8'),
+  ) as Record<string, unknown>;
+  assert.equal('helperRuntime' in config, false);
+});
+
+test('bin/idd-onboard.mjs --record-policy removes a pre-existing non-default helperRuntime when the transcript reconfirms instructions-only (#2282 review follow-up)', () => {
+  const root = makeFixtureDir();
+  writeRecordPolicyFixture(root);
+  const existing = JSON.parse(
+    readFileSync(join(root, '.github', 'idd', 'config.json'), 'utf8'),
+  ) as Record<string, unknown>;
+  existing.helperRuntime = { profile: 'package-manager' };
+  writeFileSync(
+    join(root, '.github', 'idd', 'config.json'),
+    `${JSON.stringify(existing, null, 2)}\n`,
+  );
+  const answers = buildValidHearAnswers();
+  answers['helper-runtime-profile'] = 'instructions-only';
+  const transcript = confirmTranscript(root, answers);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(transcript));
+
+  runCliBin([
+    '--record-policy',
+    '--transcript',
+    transcriptPath,
+    '--target',
+    root,
+    '--apply',
+  ]);
   const config = JSON.parse(
     readFileSync(join(root, '.github', 'idd', 'config.json'), 'utf8'),
   ) as Record<string, unknown>;
@@ -3470,7 +3504,41 @@ test('bin/idd-onboard.mjs --record-policy writes skipIssueAuthorApprovalGate tru
     '--apply',
   ]);
   const patch2 = verdict2.configPatch as Record<string, unknown>;
-  assert.equal('skipIssueAuthorApprovalGate' in patch2, false);
+  assert.equal(
+    patch2.skipIssueAuthorApprovalGate,
+    '(reset to distributed default: key removed)',
+  );
+});
+
+test('bin/idd-onboard.mjs --record-policy removes a pre-existing skipIssueAuthorApprovalGate:true when the transcript reconfirms enabled-by-default (#2282 review follow-up)', () => {
+  const root = makeFixtureDir();
+  writeRecordPolicyFixture(root);
+  const existing = JSON.parse(
+    readFileSync(join(root, '.github', 'idd', 'config.json'), 'utf8'),
+  ) as Record<string, unknown>;
+  existing.skipIssueAuthorApprovalGate = true;
+  writeFileSync(
+    join(root, '.github', 'idd', 'config.json'),
+    `${JSON.stringify(existing, null, 2)}\n`,
+  );
+  const answers = buildValidHearAnswers();
+  answers['issue-author-approval-gate'] = 'enabled-by-default';
+  const transcript = confirmTranscript(root, answers);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(transcript));
+
+  runCliBin([
+    '--record-policy',
+    '--transcript',
+    transcriptPath,
+    '--target',
+    root,
+    '--apply',
+  ]);
+  const config = JSON.parse(
+    readFileSync(join(root, '.github', 'idd', 'config.json'), 'utf8'),
+  ) as Record<string, unknown>;
+  assert.equal('skipIssueAuthorApprovalGate' in config, false);
 });
 
 test('bin/idd-onboard.mjs --record-policy never turns a docs-only or meta-choice answer into a config key', () => {

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -3066,3 +3066,523 @@ test('a real import + substitute produces a doc tree that passes the documented 
     `cspell only checked ${filesChecked} files, fewer than the ${importedFileCount} files --import wrote -- enableGlobDot may have regressed`,
   );
 });
+
+// ---------------------------------------------------------------------------
+// --substitute --from-transcript / --record-policy (#2282)
+// ---------------------------------------------------------------------------
+
+/** Confirms a valid answers map into a transcript via the real --hear --apply CLI path. */
+function confirmTranscript(
+  root: string,
+  answers: Record<string, string>,
+): Record<string, unknown> {
+  const answersPath = join(root, 'hear-answers.json');
+  writeFileSync(answersPath, JSON.stringify(answers));
+  const { status, verdict } = runCliBin([
+    '--hear',
+    '--apply',
+    '--answers',
+    answersPath,
+  ]);
+  assert.equal(
+    status,
+    0,
+    `expected a valid transcript, got: ${JSON.stringify(verdict)}`,
+  );
+  return verdict;
+}
+
+test('bin/idd-onboard.mjs --substitute --from-transcript resolves placeholders from a confirmed transcript', () => {
+  const root = makeFixtureDir();
+  writeTemplateFixture(root);
+  const answers = buildValidHearAnswers();
+  for (const [key, value] of Object.entries(ALL_OVERRIDES)) {
+    answers[key] = value;
+  }
+  const transcript = confirmTranscript(root, answers);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(transcript));
+
+  const { status, verdict } = runCliBin([
+    '--substitute',
+    '--from-transcript',
+    transcriptPath,
+    '--target',
+    root,
+  ]);
+  assert.equal(status, 0);
+  assert.equal(verdict.written, true);
+  assert.deepEqual(verdict.residue, []);
+  const values = verdict.values as Record<
+    string,
+    { value: string; source: string }
+  >;
+  assert.equal(values.REPO_NAME.value, ALL_OVERRIDES.REPO_NAME);
+  assert.equal(values.REPO_NAME.source, 'flag');
+  const config = readFileSync(
+    join(root, '.github', 'idd', 'config.json'),
+    'utf8',
+  );
+  assert.match(config, /"markerPrefix": "my-app"/);
+});
+
+test('bin/idd-onboard.mjs --substitute --from-transcript: an explicit placeholder flag still wins over the transcript', () => {
+  const root = makeFixtureDir();
+  writeTemplateFixture(root);
+  const answers = buildValidHearAnswers();
+  for (const [key, value] of Object.entries(ALL_OVERRIDES)) {
+    answers[key] = value;
+  }
+  const transcript = confirmTranscript(root, answers);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(transcript));
+
+  const { status, verdict } = runCliBin([
+    '--substitute',
+    '--from-transcript',
+    transcriptPath,
+    '--target',
+    root,
+    '--repo-name',
+    'explicit-wins',
+  ]);
+  assert.equal(status, 0);
+  const values = verdict.values as Record<
+    string,
+    { value: string; source: string }
+  >;
+  assert.equal(values.REPO_NAME.value, 'explicit-wins');
+  assert.equal(values.REPO_NAME.source, 'flag');
+});
+
+test('bin/idd-onboard.mjs --substitute --from-transcript exits 1, no writes, when the transcript omits a placeholder answer entirely', () => {
+  const root = makeFixtureDir();
+  writeTemplateFixture(root);
+  const answers = buildValidHearAnswers();
+  // Every OTHER placeholder gets a pattern-valid value so the only
+  // remaining unresolved token after trimming is TRUSTED_MARKER_ACTOR
+  // (which has no automatic derivation).
+  for (const [key, value] of Object.entries(ALL_OVERRIDES)) {
+    answers[key] = value;
+  }
+  const transcript = confirmTranscript(root, answers);
+  const trimmed = {
+    ...transcript,
+    answers: (transcript.answers as { id: string; value: string }[]).filter(
+      (answer) => answer.id !== 'TRUSTED_MARKER_ACTOR',
+    ),
+  };
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(trimmed));
+  const before = snapshotTree(root);
+
+  const { status, verdict } = runCliBin([
+    '--substitute',
+    '--from-transcript',
+    transcriptPath,
+    '--target',
+    root,
+  ]);
+  assert.equal(status, 1);
+  assert.equal(verdict.written, false);
+  assert.ok(
+    (verdict.residue as unknown[]).length > 0 ||
+      (verdict.unresolved as unknown[])?.includes('TRUSTED_MARKER_ACTOR'),
+  );
+  assertTreeUnchanged(root, before);
+});
+
+test('bin/idd-onboard.mjs --substitute --from-transcript exits 1 on a malformed transcript, without touching the tree', () => {
+  const root = makeFixtureDir();
+  writeTemplateFixture(root);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify({ version: '1.0.0' }));
+  const before = snapshotTree(root);
+
+  const { status, verdict } = runCliBin([
+    '--substitute',
+    '--from-transcript',
+    transcriptPath,
+    '--target',
+    root,
+    ...CLI_OVERRIDE_FLAGS,
+  ]);
+  assert.equal(status, 1);
+  assert.equal(verdict.valid, false);
+  assert.ok(Array.isArray(verdict.unresolved) && verdict.unresolved.length > 0);
+  assertTreeUnchanged(root, before);
+});
+
+test('bin/idd-onboard.mjs --substitute rejects --record-policy-only flags (--transcript, --write-policy-doc)', () => {
+  const root = makeFixtureDir();
+  writeTemplateFixture(root);
+  const result = spawnSync(
+    process.execPath,
+    [
+      BIN_PATH,
+      '--substitute',
+      '--target',
+      root,
+      '--transcript',
+      'x.json',
+      ...CLI_OVERRIDE_FLAGS,
+    ],
+    { encoding: 'utf8' },
+  );
+  assert.equal(result.status, 2);
+});
+
+/** A pristine, post-import config.json (unsubstituted placeholders, as --record-policy expects). */
+function writeRecordPolicyFixture(root: string): void {
+  mkdirSync(join(root, '.github', 'idd'), { recursive: true });
+  writeFileSync(
+    join(root, '.github', 'idd', 'config.json'),
+    [
+      '{',
+      '  "markerPrefix": "{{PROJECT_MARKER_PREFIX}}",',
+      '  "trustedMarkerActors": ["{{TRUSTED_MARKER_ACTOR}}"],',
+      '  "commands": {',
+      '    "install-deps": "{{INSTALL_DEPS_COMMAND}}",',
+      '    "fix-validate": "{{FIX_VALIDATE_COMMANDS}}",',
+      '    "pre-push-validate": "{{PRE_PUSH_VALIDATE_COMMANDS}}",',
+      '    "post-fix-validate": "{{POST_FIX_VALIDATE_COMMANDS}}"',
+      '  }',
+      '}',
+      '',
+    ].join('\n'),
+  );
+}
+
+test('bin/idd-onboard.mjs --record-policy dry-run prints the config patch and filled template, writing nothing', () => {
+  const root = makeFixtureDir();
+  writeRecordPolicyFixture(root);
+  const answers = buildValidHearAnswers();
+  const transcript = confirmTranscript(root, answers);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(transcript));
+  const before = snapshotTree(root);
+
+  const { status, verdict } = runCliBin([
+    '--record-policy',
+    '--transcript',
+    transcriptPath,
+    '--target',
+    root,
+  ]);
+  assert.equal(status, 0);
+  assert.equal(verdict.mode, 'dry-run');
+  assert.equal(verdict.written, false);
+  const patch = verdict.configPatch as Record<string, unknown>;
+  assert.equal(patch.mergePolicy, answers['merge-policy']);
+  assert.match(verdict.policyDocument as string, /## IDD Policy Configuration/);
+  assert.match(verdict.policyDocument as string, /### Merge Policy/);
+  assertTreeUnchanged(root, before);
+});
+
+test('bin/idd-onboard.mjs --record-policy --apply merges only mapsToConfig fields into config.json', () => {
+  const root = makeFixtureDir();
+  writeRecordPolicyFixture(root);
+  const answers = buildValidHearAnswers();
+  answers['merge-policy'] = 'fully_autonomous_merge';
+  answers['review-policy'] = 'human-required';
+  const transcript = confirmTranscript(root, answers);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(transcript));
+
+  const { status, verdict } = runCliBin([
+    '--record-policy',
+    '--transcript',
+    transcriptPath,
+    '--target',
+    root,
+    '--apply',
+  ]);
+  assert.equal(status, 0);
+  assert.equal(verdict.mode, 'apply');
+  assert.equal(verdict.written, true);
+  const config = JSON.parse(
+    readFileSync(join(root, '.github', 'idd', 'config.json'), 'utf8'),
+  ) as Record<string, unknown>;
+  assert.equal(config.mergePolicy, 'fully_autonomous_merge');
+  assert.equal(config.reviewPolicy, 'human-required');
+  // The pristine placeholder fields survive untouched.
+  assert.equal(config.markerPrefix, '{{PROJECT_MARKER_PREFIX}}');
+});
+
+test('bin/idd-onboard.mjs --record-policy omits the helperRuntime key when the confirmed profile is instructions-only', () => {
+  const root = makeFixtureDir();
+  writeRecordPolicyFixture(root);
+  const answers = buildValidHearAnswers();
+  answers['helper-runtime-profile'] = 'instructions-only';
+  const transcript = confirmTranscript(root, answers);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(transcript));
+
+  const { verdict } = runCliBin([
+    '--record-policy',
+    '--transcript',
+    transcriptPath,
+    '--target',
+    root,
+    '--apply',
+  ]);
+  const patch = verdict.configPatch as Record<string, unknown>;
+  assert.equal('helperRuntime' in patch, false);
+  const config = JSON.parse(
+    readFileSync(join(root, '.github', 'idd', 'config.json'), 'utf8'),
+  ) as Record<string, unknown>;
+  assert.equal('helperRuntime' in config, false);
+});
+
+test('bin/idd-onboard.mjs --record-policy writes helperRuntime.profile for a non-default confirmed profile, preserving sibling ciWait keys', () => {
+  const root = makeFixtureDir();
+  writeRecordPolicyFixture(root);
+  const existing = JSON.parse(
+    readFileSync(join(root, '.github', 'idd', 'config.json'), 'utf8'),
+  ) as Record<string, unknown>;
+  existing.ciWait = { runningTimeout: 'PT30M' };
+  writeFileSync(
+    join(root, '.github', 'idd', 'config.json'),
+    `${JSON.stringify(existing, null, 2)}\n`,
+  );
+  const answers = buildValidHearAnswers();
+  answers['helper-runtime-profile'] = 'package-manager';
+  answers['ci-wait-policy'] = 'hold';
+  const transcript = confirmTranscript(root, answers);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(transcript));
+
+  runCliBin([
+    '--record-policy',
+    '--transcript',
+    transcriptPath,
+    '--target',
+    root,
+    '--apply',
+  ]);
+  const config = JSON.parse(
+    readFileSync(join(root, '.github', 'idd', 'config.json'), 'utf8'),
+  ) as Record<string, unknown>;
+  assert.deepEqual(config.helperRuntime, { profile: 'package-manager' });
+  assert.deepEqual(config.ciWait, {
+    runningTimeout: 'PT30M',
+    rerunPolicy: 'hold',
+  });
+});
+
+test('bin/idd-onboard.mjs --record-policy writes skipIssueAuthorApprovalGate true only when the operator opted out', () => {
+  const root = makeFixtureDir();
+  writeRecordPolicyFixture(root);
+  const answers = buildValidHearAnswers();
+  answers['issue-author-approval-gate'] = 'skip-gate';
+  const transcript = confirmTranscript(root, answers);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(transcript));
+
+  const { verdict } = runCliBin([
+    '--record-policy',
+    '--transcript',
+    transcriptPath,
+    '--target',
+    root,
+    '--apply',
+  ]);
+  const patch = verdict.configPatch as Record<string, unknown>;
+  assert.equal(patch.skipIssueAuthorApprovalGate, true);
+
+  const root2 = makeFixtureDir();
+  writeRecordPolicyFixture(root2);
+  const answers2 = buildValidHearAnswers();
+  answers2['issue-author-approval-gate'] = 'enabled-by-default';
+  const transcript2 = confirmTranscript(root2, answers2);
+  const transcriptPath2 = join(root2, 'transcript.json');
+  writeFileSync(transcriptPath2, JSON.stringify(transcript2));
+  const { verdict: verdict2 } = runCliBin([
+    '--record-policy',
+    '--transcript',
+    transcriptPath2,
+    '--target',
+    root2,
+    '--apply',
+  ]);
+  const patch2 = verdict2.configPatch as Record<string, unknown>;
+  assert.equal('skipIssueAuthorApprovalGate' in patch2, false);
+});
+
+test('bin/idd-onboard.mjs --record-policy never turns a docs-only or meta-choice answer into a config key', () => {
+  const root = makeFixtureDir();
+  writeRecordPolicyFixture(root);
+  const answers = buildValidHearAnswers();
+  answers['claim-timing'] = 'repository-override';
+  answers['idd-label-names'] = 'custom-taxonomy';
+  const transcript = confirmTranscript(root, answers);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(transcript));
+
+  const { verdict } = runCliBin([
+    '--record-policy',
+    '--transcript',
+    transcriptPath,
+    '--target',
+    root,
+  ]);
+  const patch = verdict.configPatch as Record<string, unknown>;
+  const docsOnlyIds = [
+    'critique-loop-profile',
+    'credential-scope',
+    'issue-authoring-companion',
+    'up-to-date-head-ruleset',
+    'bootstrap-execution-mode',
+  ];
+  for (const id of docsOnlyIds) {
+    const item = loadOnboardingHearingCatalog().items.find(
+      (entry) => entry.id === id,
+    );
+    assert.ok(item, `catalog missing ${id}`);
+  }
+  assert.equal('claimTiming' in patch, false);
+  assert.equal('labels' in patch, false);
+  // Still surfaced for a human, just never as an invented config key.
+  assert.match(verdict.policyDocument as string, /### Claim Timing/);
+  assert.match(verdict.policyDocument as string, /repository-override/);
+  assert.match(verdict.policyDocument as string, /### IDD Label Names/);
+  assert.match(verdict.policyDocument as string, /custom-taxonomy/);
+  assert.doesNotMatch(
+    verdict.policyDocument as string,
+    /### Merge Policy[\s\S]*### Merge Policy/,
+  );
+});
+
+test('bin/idd-onboard.mjs --record-policy --write-policy-doc writes the template only under --apply, never without it', () => {
+  const root = makeFixtureDir();
+  writeRecordPolicyFixture(root);
+  const answers = buildValidHearAnswers();
+  const transcript = confirmTranscript(root, answers);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(transcript));
+  const docPath = join(root, 'policy-doc.md');
+
+  const dryRun = runCliBin([
+    '--record-policy',
+    '--transcript',
+    transcriptPath,
+    '--target',
+    root,
+    '--write-policy-doc',
+    docPath,
+  ]);
+  assert.equal(dryRun.status, 0);
+  assert.equal(existsSync(docPath), false);
+
+  const applied = runCliBin([
+    '--record-policy',
+    '--transcript',
+    transcriptPath,
+    '--target',
+    root,
+    '--apply',
+    '--write-policy-doc',
+    docPath,
+  ]);
+  assert.equal(applied.status, 0);
+  assert.equal(existsSync(docPath), true);
+  assert.equal(applied.verdict.writtenPolicyDocPath, resolve(docPath));
+
+  const root2 = makeFixtureDir();
+  writeRecordPolicyFixture(root2);
+  const transcript2 = confirmTranscript(root2, buildValidHearAnswers());
+  const transcriptPath2 = join(root2, 'transcript.json');
+  writeFileSync(transcriptPath2, JSON.stringify(transcript2));
+  const appliedNoDocFlag = runCliBin([
+    '--record-policy',
+    '--transcript',
+    transcriptPath2,
+    '--target',
+    root2,
+    '--apply',
+  ]);
+  assert.equal(appliedNoDocFlag.status, 0);
+  assert.equal(appliedNoDocFlag.verdict.writtenPolicyDocPath, null);
+});
+
+test('bin/idd-onboard.mjs --record-policy exits 2 when config.json does not already exist (post-import only)', () => {
+  const root = makeFixtureDir();
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(
+    transcriptPath,
+    JSON.stringify({
+      version: '1.0.0',
+      confirmedAt: new Date().toISOString(),
+      answers: [],
+    }),
+  );
+  const result = spawnSync(
+    process.execPath,
+    [
+      BIN_PATH,
+      '--record-policy',
+      '--transcript',
+      transcriptPath,
+      '--target',
+      root,
+    ],
+    { encoding: 'utf8' },
+  );
+  assert.equal(result.status, 2);
+});
+
+test('bin/idd-onboard.mjs --record-policy requires --transcript', () => {
+  const root = makeFixtureDir();
+  writeRecordPolicyFixture(root);
+  const result = spawnSync(
+    process.execPath,
+    [BIN_PATH, '--record-policy', '--target', root],
+    { encoding: 'utf8' },
+  );
+  assert.equal(result.status, 2);
+});
+
+test('bin/idd-onboard.mjs exits 2 when --record-policy is combined with --import, --substitute, --verify, or --hear', () => {
+  const root = makeFixtureDir();
+  writeRecordPolicyFixture(root);
+  const combos = [
+    ['--record-policy', '--import', '--target', root],
+    ['--record-policy', '--substitute', '--target', root],
+    ['--record-policy', '--verify', '--target', root],
+    ['--record-policy', '--hear', '--target', root],
+  ];
+  for (const args of combos) {
+    const result = spawnSync(process.execPath, [BIN_PATH, ...args], {
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 2, `expected exit 2 for: ${args.join(' ')}`);
+  }
+});
+
+test('bin/idd-onboard.mjs --hear rejects --record-policy-only flags (--transcript, --write-policy-doc)', () => {
+  const root = makeFixtureDir();
+  const result = spawnSync(
+    process.execPath,
+    [
+      BIN_PATH,
+      '--hear',
+      '--propose',
+      '--target',
+      root,
+      '--transcript',
+      'x.json',
+    ],
+    { encoding: 'utf8' },
+  );
+  assert.equal(result.status, 2);
+});
+
+test('bin/idd-onboard.mjs --help documents --record-policy, --transcript, and --write-policy-doc', () => {
+  const help = execFileSync(process.execPath, [BIN_PATH, '--help'], {
+    encoding: 'utf8',
+  });
+  assert.match(help, /--record-policy/);
+  assert.match(help, /--transcript/);
+  assert.match(help, /--write-policy-doc/);
+  assert.match(help, /--from-transcript/);
+});


### PR DESCRIPTION
## Summary

- `--substitute` gains `--from-transcript <file>`, feeding a confirmed
  `--hear` transcript's `mapsToPlaceholder` answers through the
  existing `resolvePlaceholderValues` override path (explicit
  placeholder flags still win over the transcript).
- New `--record-policy` mode merges a confirmed transcript's
  `mapsToConfig` answers into an already-imported
  `.github/idd/config.json` (`--dry-run` by default, `--apply` to
  write, `--write-policy-doc <file>` to also emit the filled
  policy-decisions Markdown template — write-only under `--apply`).
- `--record-policy` validates only the config sections its patch
  touches (`validateConfigSection`), not the whole document, since it
  runs post-import/pre-substitute while other fields still carry
  unresolved `{{PLACEHOLDER}}` tokens.
- Fixed during self-review: `--record-policy --dry-run --apply` was
  writing to `config.json` because `canWrite` only checked
  `args.apply`; `--dry-run` now always wins, matching `--import`'s
  `!args.dryRun && ...` convention.
- Neither mode edits `ONBOARDING.md` or the agent-entry docs.

## Test plan

- [x] `pnpm run lint:minimum` (audit-docs, typecheck, build:check,
      biome, dprint, full `node --test` suite — 3887/3887 passing,
      workshop-link-integrity, cspell, markdownlint) — all clean.
- [x] `npx vitest run tests/idd-onboard.test.mts` — 139/139 passing,
      including the new `--from-transcript` / `--record-policy` /
      `--dry-run --apply` cases.

Closes #2282


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transcript-driven substitution for onboarding placeholders.
  * Added a record-policy workflow to generate configuration patches and policy documentation.
  * Added dry-run and apply options, including selective configuration updates and nested settings support.
  * Added safeguards for missing, malformed, or unconfirmed transcripts and invalid option combinations.

* **Bug Fixes**
  * Explicit placeholder values now take precedence over transcript values.
  * Policy documentation can only be written when changes are explicitly applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->