### PR TITLE
docs(issue-authoring): document the Candidate files section's parse contract

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -610,7 +610,7 @@ Validation expectations:
 The optional `## Candidate files` section is not free-form prose: the
 `discover-shared-file-overlap` evidence helper parses it as machine input
 for the A4 Step 2 high-contention shared-file check (see
-[High-contention shared-file overlap](../../../docs/policy-constants.md#high-contention-shared-files)).
+[High-contention shared-file overlap](https://github.com/kurone-kito/idd-skill/blob/main/docs/policy-constants.md#high-contention-shared-files)).
 Populate it accurately rather than as a loose reading aid for humans.
 
 - List each candidate file path inside backticks, one path (or one
@@ -620,10 +620,11 @@ Populate it accurately rather than as a loose reading aid for humans.
 - A bullet with no backticks at all still falls back to its leading
   path-like token, but backtick-quoting every path is the reliable form
   and should always be used.
-- The section ends at the next heading of the same or higher level.
-  Anything inside it that looks like a path — backtick-quoted or a
-  bare bulleted leading token — is parsed as a candidate file, so keep
-  unrelated notes or caveats outside the section.
+- The section ends at the next Markdown heading, **of any level** —
+  even a deeper subheading closes it. Anything inside it that looks
+  like a path — backtick-quoted or a bare bulleted leading token — is
+  parsed as a candidate file, so keep unrelated notes, caveats, or
+  subheadings outside the section.
 
 ### Orphan issue
 

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -605,6 +605,26 @@ Validation expectations:
 
 ## Required draft content
 
+### Candidate files format
+
+The optional `## Candidate files` section is not free-form prose: the
+`discover-shared-file-overlap` evidence helper parses it as machine input
+for the A4 Step 2 high-contention shared-file check (see
+[High-contention shared-file overlap](../../../docs/policy-constants.md#high-contention-shared-files)).
+Populate it accurately rather than as a loose reading aid for humans.
+
+- List each candidate file path inside backticks, one path (or one
+  bullet) per line — for example `` - `src/scripts/idd-onboard.mts` ``.
+  The parser extracts every backtick-quoted path in the section,
+  including continuation lines of a multi-line bullet.
+- A bullet with no backticks at all still falls back to its leading
+  path-like token, but backtick-quoting every path is the reliable form
+  and should always be used.
+- The section ends at the next heading of the same or higher level;
+  keep unrelated notes or caveats outside it, or they will not
+  interfere with parsing only if they do not look like a path
+  themselves.
+
 ### Orphan issue
 
 - title with a concise user-facing summary

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -620,10 +620,10 @@ Populate it accurately rather than as a loose reading aid for humans.
 - A bullet with no backticks at all still falls back to its leading
   path-like token, but backtick-quoting every path is the reliable form
   and should always be used.
-- The section ends at the next heading of the same or higher level;
-  keep unrelated notes or caveats outside it, or they will not
-  interfere with parsing only if they do not look like a path
-  themselves.
+- The section ends at the next heading of the same or higher level.
+  Anything inside it that looks like a path — backtick-quoted or a
+  bare bulleted leading token — is parsed as a candidate file, so keep
+  unrelated notes or caveats outside the section.
 
 ### Orphan issue
 

--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -170,7 +170,9 @@ Before you publish a `ready` issue, confirm:
 - `## Background` or `## Goal`
 - `## Proposed change`
 - `## Acceptance criteria`
-- optional `## Candidate files`
+- optional `## Candidate files` — see
+  [contract.md's Candidate files format](contract.md#candidate-files-format)
+  for the exact parse contract before populating it
 - an autopilot-suitability footer at the end of the body (visible
   line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -610,7 +610,7 @@ Validation expectations:
 The optional `## Candidate files` section is not free-form prose: the
 `discover-shared-file-overlap` evidence helper parses it as machine input
 for the A4 Step 2 high-contention shared-file check (see
-[High-contention shared-file overlap](../../../docs/policy-constants.md#high-contention-shared-files)).
+[High-contention shared-file overlap](https://github.com/kurone-kito/idd-skill/blob/main/docs/policy-constants.md#high-contention-shared-files)).
 Populate it accurately rather than as a loose reading aid for humans.
 
 - List each candidate file path inside backticks, one path (or one
@@ -620,10 +620,11 @@ Populate it accurately rather than as a loose reading aid for humans.
 - A bullet with no backticks at all still falls back to its leading
   path-like token, but backtick-quoting every path is the reliable form
   and should always be used.
-- The section ends at the next heading of the same or higher level.
-  Anything inside it that looks like a path — backtick-quoted or a
-  bare bulleted leading token — is parsed as a candidate file, so keep
-  unrelated notes or caveats outside the section.
+- The section ends at the next Markdown heading, **of any level** —
+  even a deeper subheading closes it. Anything inside it that looks
+  like a path — backtick-quoted or a bare bulleted leading token — is
+  parsed as a candidate file, so keep unrelated notes, caveats, or
+  subheadings outside the section.
 
 ### Orphan issue
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -605,6 +605,26 @@ Validation expectations:
 
 ## Required draft content
 
+### Candidate files format
+
+The optional `## Candidate files` section is not free-form prose: the
+`discover-shared-file-overlap` evidence helper parses it as machine input
+for the A4 Step 2 high-contention shared-file check (see
+[High-contention shared-file overlap](../../../docs/policy-constants.md#high-contention-shared-files)).
+Populate it accurately rather than as a loose reading aid for humans.
+
+- List each candidate file path inside backticks, one path (or one
+  bullet) per line — for example `` - `src/scripts/idd-onboard.mts` ``.
+  The parser extracts every backtick-quoted path in the section,
+  including continuation lines of a multi-line bullet.
+- A bullet with no backticks at all still falls back to its leading
+  path-like token, but backtick-quoting every path is the reliable form
+  and should always be used.
+- The section ends at the next heading of the same or higher level;
+  keep unrelated notes or caveats outside it, or they will not
+  interfere with parsing only if they do not look like a path
+  themselves.
+
 ### Orphan issue
 
 - title with a concise user-facing summary

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -620,10 +620,10 @@ Populate it accurately rather than as a loose reading aid for humans.
 - A bullet with no backticks at all still falls back to its leading
   path-like token, but backtick-quoting every path is the reliable form
   and should always be used.
-- The section ends at the next heading of the same or higher level;
-  keep unrelated notes or caveats outside it, or they will not
-  interfere with parsing only if they do not look like a path
-  themselves.
+- The section ends at the next heading of the same or higher level.
+  Anything inside it that looks like a path — backtick-quoted or a
+  bare bulleted leading token — is parsed as a candidate file, so keep
+  unrelated notes or caveats outside the section.
 
 ### Orphan issue
 

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -170,7 +170,9 @@ Before you publish a `ready` issue, confirm:
 - `## Background` or `## Goal`
 - `## Proposed change`
 - `## Acceptance criteria`
-- optional `## Candidate files`
+- optional `## Candidate files` — see
+  [contract.md's Candidate files format](contract.md#candidate-files-format)
+  for the exact parse contract before populating it
 - an autopilot-suitability footer at the end of the body (visible
   line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
 


### PR DESCRIPTION
## Summary

- Add a `### Candidate files format` subsection to `skills/issue-authoring/references/contract.md`, documenting that the optional `## Candidate files` section is machine-parsed by `discover-shared-file-overlap`'s evidence helper as backtick-quoted file paths for the A4 Step 2 high-contention overlap check, not free-form prose.
- Link the new subsection from `draft-patterns.md`'s example orphan issue shape so an authoring session knows to populate the section accurately.

Closes #2237

## Test plan

- `node scripts/sync-docs.mjs --apply` (synced `.claude/skills/issue-authoring/` mirror)
- `node scripts/audit-docs.mjs --check` — passed
- `pnpm run lint:minimum` — passed
