### PR TITLE
docs(idd-ci): cover a stale workflow definition in Rerun mechanics

### DIFF
--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -258,7 +258,8 @@ ordering dependency, even though the tracks' own edited files never
 overlap. `gh run rerun` re-resolves against the PR branch's own copy
 of the workflow file, so a fix merged to `main` on a sibling track
 stays invisible until the dependent branch pulls it in (see
-`idd-ci.instructions.md`'s Rerun mechanics). Note this dependency in
+`.github/instructions/idd-ci.instructions.md`'s Rerun mechanics). Note
+this dependency in
 the roadmap's parallel note rather than assuming disjoint files always
 mean safe parallelism.
 

--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -250,6 +250,18 @@ verified independently. The roadmap keeps both tasks visible in its task
 list, and the short note explains the safe parallelism without adding a
 fake `Blocked by` edge.
 
+**Caveat — shared CI check definitions.** File-disjoint tracks are not
+automatically execution-order-independent: if one track edits a shared
+CI check's own workflow _definition_ (e.g. a `.yml` file), any other
+in-flight track whose CI run relies on that check inherits a hidden
+ordering dependency, even though the tracks' own edited files never
+overlap. `gh run rerun` re-resolves against the PR branch's own copy
+of the workflow file, so a fix merged to `main` on a sibling track
+stays invisible until the dependent branch pulls it in (see
+`idd-ci.instructions.md`'s Rerun mechanics). Note this dependency in
+the roadmap's parallel note rather than assuming disjoint files always
+mean safe parallelism.
+
 ### Artificial decomposition
 
 Bad serial chain:

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -264,6 +264,20 @@ next.
 rerun this SAME existing run via the mechanic above — never
 `workflow_dispatch`.
 
+**Stale workflow definition on the PR branch.** `gh run rerun`
+re-resolves the failing check against the workflow **definition
+file** as it exists on the PR branch, not on `main` — a sibling
+track's already-merged fix to a shared CI check's own `.yml` file is
+invisible to a rerun here until this branch pulls that fix in. If a
+required check keeps failing the same way after a rerun and its
+workflow file changed recently on `main`, diff the PR branch's copy
+against `main`'s; a mismatch means a branch-sync merge (merge `main`
+in, never rebase — see the E-phase branch-sync check in
+`idd-review-triage.instructions.md`) is the diagnostic recovery step.
+Treat this as reachable at D4/pre-review, not only after E8 — the
+ordering dependency a shared check-definition change creates is
+invisible to disjoint-file-set track planning.
+
 ## Interpretation
 
 <!-- dprint-ignore-start -->

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -259,6 +259,20 @@ next.
 rerun this SAME existing run via the mechanic above — never
 `workflow_dispatch`.
 
+**Stale workflow definition on the PR branch.** `gh run rerun`
+re-resolves the failing check against the workflow **definition
+file** as it exists on the PR branch, not on `main` — a sibling
+track's already-merged fix to a shared CI check's own `.yml` file is
+invisible to a rerun here until this branch pulls that fix in. If a
+required check keeps failing the same way after a rerun and its
+workflow file changed recently on `main`, diff the PR branch's copy
+against `main`'s; a mismatch means a branch-sync merge (merge `main`
+in, never rebase — see the E-phase branch-sync check in
+`idd-review-triage.instructions.md`) is the diagnostic recovery step.
+Treat this as reachable at D4/pre-review, not only after E8 — the
+ordering dependency a shared check-definition change creates is
+invisible to disjoint-file-set track planning.
+
 ## Interpretation
 
 <!-- dprint-ignore-start -->

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -258,7 +258,8 @@ ordering dependency, even though the tracks' own edited files never
 overlap. `gh run rerun` re-resolves against the PR branch's own copy
 of the workflow file, so a fix merged to `main` on a sibling track
 stays invisible until the dependent branch pulls it in (see
-`idd-ci.instructions.md`'s Rerun mechanics). Note this dependency in
+`.github/instructions/idd-ci.instructions.md`'s Rerun mechanics). Note
+this dependency in
 the roadmap's parallel note rather than assuming disjoint files always
 mean safe parallelism.
 

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -250,6 +250,18 @@ verified independently. The roadmap keeps both tasks visible in its task
 list, and the short note explains the safe parallelism without adding a
 fake `Blocked by` edge.
 
+**Caveat — shared CI check definitions.** File-disjoint tracks are not
+automatically execution-order-independent: if one track edits a shared
+CI check's own workflow _definition_ (e.g. a `.yml` file), any other
+in-flight track whose CI run relies on that check inherits a hidden
+ordering dependency, even though the tracks' own edited files never
+overlap. `gh run rerun` re-resolves against the PR branch's own copy
+of the workflow file, so a fix merged to `main` on a sibling track
+stays invisible until the dependent branch pulls it in (see
+`idd-ci.instructions.md`'s Rerun mechanics). Note this dependency in
+the roadmap's parallel note rather than assuming disjoint files always
+mean safe parallelism.
+
 ### Artificial decomposition
 
 Bad serial chain:


### PR DESCRIPTION
# Summary

Add a note to `idd-ci.instructions.md`'s Rerun mechanics section covering the case where `gh run rerun` re-resolves a failing check against the PR branch's own stale workflow definition, invisible to a sibling track's already-merged fix on `main` until a branch-sync merge pulls it in. Points to the diagnostic recovery step (diff the branch's workflow file against `main`'s, then branch-sync merge), reachable at D4/pre-review rather than only after E8. Also adds a matching caveat to the issue-authoring skill's dependency-minimization examples (`skills/issue-authoring/references/draft-patterns.md`): a shared CI check definition change is itself an ordering dependency for any other in-flight track relying on that check, even when the tracks' own file sets are otherwise disjoint.

## Linked issue

Closes #2234

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

An adopter hit this: a sibling track's merged fix to a shared CI check definition was invisible to `gh run rerun` on an unrelated PR until that PR merged `main` in. The same repository's roadmap sequencing guidance assumed disjoint-file tracks are always order-independent, missing that a shared CI check *definition* change is itself a hidden ordering dependency even when the changed files themselves do not overlap.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [ ] `pnpm test` (not applicable — no code changes)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (not applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
