### PR TITLE
feat(context-tax): report snapshot medians into README and docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,6 +31,7 @@ scripts/code-span-wrap.mjs linguist-generated=true
 scripts/collaborator-permission.mjs linguist-generated=true
 scripts/consistency-helpers.mjs linguist-generated=true
 scripts/context-tax-core.mjs linguist-generated=true
+scripts/context-tax-report.mjs linguist-generated=true
 scripts/discover-orphan-filter.mjs linguist-generated=true
 scripts/discover-readiness-check.mjs linguist-generated=true
 scripts/discover-roadmap-graph.mjs linguist-generated=true

--- a/README.ja.md
+++ b/README.ja.md
@@ -64,6 +64,12 @@ IDD はデモではありません。このリポジトリ自体が IDD で作�
 
 _2026-07 時点。_
 
+<!-- context-tax-readme:start -->
+
+コンテキスト税の計測は現在進行中です。詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。
+
+<!-- context-tax-readme:end -->
+
 ## クイックスタート
 
 IDD を導入したいリポジトリで AI エージェントのセッションを開き、

--- a/README.ja.md
+++ b/README.ja.md
@@ -66,7 +66,8 @@ _2026-07 時点。_
 
 <!-- context-tax-readme:start -->
 
-コンテキスト税の計測は現在進行中です。詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。
+コンテキスト税の計測は現在進行中です。
+詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。
 
 <!-- context-tax-readme:end -->
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ IDD is not a demo. It is the workflow this repository is built with:
 
 _As of 2026-07._
 
+<!-- context-tax-readme:start -->
+
+Context-tax measurement is in progress; see
+[`docs/context-tax.md`](docs/context-tax.md) for the methodology.
+
+<!-- context-tax-readme:end -->
+
 ## Quick Start
 
 Open an AI-agent session in the repository that should adopt IDD and

--- a/docs/context-tax-snapshot.json
+++ b/docs/context-tax-snapshot.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-08-26T00:00:00.000Z",
+  "minPublishableSamples": 10,
+  "minPublishableVendors": 2,
+  "publishable": false,
+  "sampleCount": 0,
+  "vendors": [],
+  "asOf": "2026-08-26",
+  "totalUsage": {
+    "inputUncached": { "p25": 0, "p50": 0, "p75": 0 },
+    "cacheRead": { "p25": 0, "p50": 0, "p75": 0 },
+    "cacheCreation": { "p25": 0, "p50": 0, "p75": 0 },
+    "output": { "p25": 0, "p50": 0, "p75": 0 },
+    "reasoning": { "p25": 0, "p50": 0, "p75": 0 }
+  },
+  "stageUsage": [],
+  "compactionCount": { "p25": 0, "p50": 0, "p75": 0 },
+  "cacheHitRatio": 0,
+  "successRateByModel": {},
+  "successRateByVendor": {}
+}

--- a/docs/context-tax-snapshot.json
+++ b/docs/context-tax-snapshot.json
@@ -8,14 +8,38 @@
   "vendors": [],
   "asOf": "2026-08-26",
   "totalUsage": {
-    "inputUncached": { "p25": 0, "p50": 0, "p75": 0 },
-    "cacheRead": { "p25": 0, "p50": 0, "p75": 0 },
-    "cacheCreation": { "p25": 0, "p50": 0, "p75": 0 },
-    "output": { "p25": 0, "p50": 0, "p75": 0 },
-    "reasoning": { "p25": 0, "p50": 0, "p75": 0 }
+    "inputUncached": {
+      "p25": 0,
+      "p50": 0,
+      "p75": 0
+    },
+    "cacheRead": {
+      "p25": 0,
+      "p50": 0,
+      "p75": 0
+    },
+    "cacheCreation": {
+      "p25": 0,
+      "p50": 0,
+      "p75": 0
+    },
+    "output": {
+      "p25": 0,
+      "p50": 0,
+      "p75": 0
+    },
+    "reasoning": {
+      "p25": 0,
+      "p50": 0,
+      "p75": 0
+    }
   },
   "stageUsage": [],
-  "compactionCount": { "p25": 0, "p50": 0, "p75": 0 },
+  "compactionCount": {
+    "p25": 0,
+    "p50": 0,
+    "p75": 0
+  },
   "cacheHitRatio": 0,
   "successRateByModel": {},
   "successRateByVendor": {}

--- a/docs/context-tax.md
+++ b/docs/context-tax.md
@@ -1,0 +1,79 @@
+---
+type: reference
+title: Context-Tax Methodology
+description: Documents how this repository measures its own agent context-window cost per completed IDD issue loop.
+tags: [context-tax, dogfood, measurement]
+---
+
+# Context-Tax Methodology
+
+This page is dogfood-only: it is not distributed to adopter repositories.
+It documents how `kurone-kito/idd-skill` measures the agent
+context-window cost of running its own IDD loop on itself.
+
+## Scope
+
+- **Unit of measurement**: one completed IDD issue loop (claim through
+  merge or another terminal outcome), not a raw agent session. A single
+  vendor session may span multiple issue loops, or a single issue loop may
+  span multiple vendor sessions (handoffs, resumes); samples are joined
+  to the issue loop they belong to, not to a session boundary.
+- **Stages**: `discover`, `claim`, `work`, `submit-pr`, `review`, `merge`,
+  `cleanup` — the same seven IDD phases named throughout
+  [`docs/idd-workflow.md`](idd-workflow.md).
+- **Success**: an issue loop counts as `merged` only when its claim
+  lineage ends in a merged pull request. `aborted`, `unclaimed`, and
+  `human-handoff` are the other tracked outcomes; `unknown` is excluded
+  from every aggregate figure on this page.
+- **Attribution**: historical samples are reconstructed via a
+  marker-join (claim comments, PR references, timestamps) when no
+  better signal exists; an explicit phase-enter/exit event, when
+  present, wins over the marker-join reconstruction for that sample.
+- **Privacy**: raw agent logs, prompts, and file paths never enter git.
+  Only token-usage counts, timestamps, and coarse outcome/vendor/model
+  labels are committed, via the snapshot artifact described below.
+- **Cost unit**: figures on this page are token counts (a static
+  `bundleBudgets` byte budget, tracked separately per issue `#1659`,
+  measures Markdown bytes, not billed tokens). No USD figures are
+  published here or anywhere else in this repository.
+- **Coverage (v1)**: Grok, Claude Code, and Codex CLI sessions. GitHub
+  Copilot, OpenCode, and Antigravity CLI sessions are out of scope for
+  the first version of this measurement.
+
+## How the snapshot is produced
+
+Harvested samples are local JSONL files under each vendor's own session
+directory (`~/.grok`, `~/.claude`, `~/.codex`) — never committed. CI runs
+on GitHub and cannot see those directories, so the only committed
+artifact is [`docs/context-tax-snapshot.json`](context-tax-snapshot.json):
+aggregated percentiles, cache-hit ratio, and success rates, with no raw
+records.
+
+`node scripts/context-tax-report.mjs`:
+
+- `--in <samples.jsonl> [--in <samples.jsonl> ...] --apply` aggregates
+  local samples into a fresh snapshot and refreshes this page's table
+  below plus the [`README.md`](../README.md) /
+  [`README.ja.md`](../README.ja.md) blurb.
+- `--check` verifies the committed snapshot still matches the rendered
+  regions in those three files — it never re-harvests or reads raw
+  samples, only the committed snapshot. Wiring `--check` into this
+  repository's own `pre-push-validate` / `post-fix-validate` chain is
+  deferred: doing so would push the `bundle-work` documentation
+  context-ceiling budget over its configured threshold (see issue
+  `#2294`'s implementation notes), and the fix belongs to a separate,
+  deliberate byte-budget decision rather than this reporter's own
+  scope.
+
+A snapshot is `publishable` only once it has at least 10 issue-loop
+samples across at least 2 distinct vendors. Below that gate, the
+README blurb and the table below stay on an unpublished stub — no
+number is ever invented to fill the gap.
+
+## Current snapshot
+
+<!-- context-tax-docs:start -->
+
+Not yet publishable, n=0.
+
+<!-- context-tax-docs:end -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,7 @@ distinct from the phase rules in `.github/instructions/`:
 | guide | [IDD Review Policy Profiles](idd-review-policy-profiles.md) | Names the supported PR review policy profiles and the instruction files an adopter must edit to select one other than the Copilot-advisory default. |
 | guide | [Permissions and Threat Model](permissions.md) | Defines the credential profiles, merge-policy boundaries, and threat model an operator must choose before granting IDD agents GitHub access. |
 | concept | [Core IDD Concepts](concepts.md) | Introduces the loop-engineering vocabulary and mental model behind the IDD phase instructions before diving into phase-by-phase rules. |
+| reference | [Context-Tax Methodology](context-tax.md) | Documents how this repository measures its own agent context-window cost per completed IDD issue loop. |
 | reference | [IDD — Advisory-Wait Shell Fallback (AW1 / AW2 / AW3-R / AW3-S / AW3-H / F2 detail)](idd-advisory-wait-shell-fallback.md) | Provides the verbatim gh, gh api, jq, and curl commands the advisory-wait and F2 advisory-convergence shell fallbacks use when helper support cannot be trusted. |
 | reference | [IDD Autonomy Contract](idd-autonomy-contract.md) | Classifies every externally visible IDD mutation as reversible or irreversible and names the gate or undo path for each. |
 | reference | [IDD Comment Minimization](idd-comment-minimization.md) | Defines the live status digest contract and the safe procedure for minimizing completed review feedback and stale operational markers after merge. |

--- a/fixtures/schemas/context-tax-snapshot.valid.json
+++ b/fixtures/schemas/context-tax-snapshot.valid.json
@@ -5,5 +5,18 @@
   "minPublishableVendors": 2,
   "publishable": false,
   "sampleCount": 0,
-  "vendors": []
+  "vendors": [],
+  "asOf": "2026-08-25",
+  "totalUsage": {
+    "inputUncached": { "p25": 0, "p50": 0, "p75": 0 },
+    "cacheRead": { "p25": 0, "p50": 0, "p75": 0 },
+    "cacheCreation": { "p25": 0, "p50": 0, "p75": 0 },
+    "output": { "p25": 0, "p50": 0, "p75": 0 },
+    "reasoning": { "p25": 0, "p50": 0, "p75": 0 }
+  },
+  "stageUsage": [],
+  "compactionCount": { "p25": 0, "p50": 0, "p75": 0 },
+  "cacheHitRatio": 0,
+  "successRateByModel": {},
+  "successRateByVendor": {}
 }

--- a/schemas/context-tax-snapshot.schema.json
+++ b/schemas/context-tax-snapshot.schema.json
@@ -221,7 +221,7 @@
     "cacheHitRatio": {
       "type": "number",
       "minimum": 0,
-      "description": "cacheRead / max(1, cacheRead + cacheCreation + inputUncached) across aggregated total usage. In [0, 1]; the validator has no maximum keyword, enforced instead by assertContextTaxSnapshot."
+      "description": "Median across samples of each sample's own cacheRead / max(1, cacheRead + cacheCreation + inputUncached), not the ratio of the independent totalUsage medians. In [0, 1]; the validator has no maximum keyword, enforced instead by assertContextTaxSnapshot."
     },
     "successRateByModel": {
       "type": "object",

--- a/schemas/context-tax-snapshot.schema.json
+++ b/schemas/context-tax-snapshot.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://kurone-kito.github.io/idd-skill/schemas/context-tax-snapshot.schema.json",
   "title": "Context-tax snapshot",
-  "description": "Committed aggregates a later reporter renders into docs/README. This issue only describes the shape.",
+  "description": "Committed aggregates the context-tax-report reporter renders into docs/README. Fields beyond the publish gate are always present -- zero-valued and empty when sampleCount is 0.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -12,7 +12,14 @@
     "minPublishableVendors",
     "publishable",
     "sampleCount",
-    "vendors"
+    "vendors",
+    "asOf",
+    "totalUsage",
+    "stageUsage",
+    "compactionCount",
+    "cacheHitRatio",
+    "successRateByModel",
+    "successRateByVendor"
   ],
   "properties": {
     "schemaVersion": {
@@ -51,6 +58,129 @@
         "type": "string",
         "enum": ["grok", "claude", "codex"],
         "description": "A harvested agent vendor."
+      }
+    },
+    "asOf": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "description": "UTC calendar date the rendered blurb should cite, e.g. 2026-08-26."
+    },
+    "totalUsage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["inputUncached", "cacheRead", "cacheCreation", "output", "reasoning"],
+      "description": "p25/p50/p75 across all aggregated samples, per usage field. Zero-valued when sampleCount is 0.",
+      "properties": {
+        "inputUncached": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } },
+        "cacheRead": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } },
+        "cacheCreation": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } },
+        "output": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } },
+        "reasoning": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } }
+      }
+    },
+    "stageUsage": {
+      "type": "array",
+      "description": "Per-stage p25/p50/p75 usage. Empty when sampleCount is 0.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "usage"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "enum": ["discover", "claim", "work", "submit-pr", "review", "merge", "cleanup"]
+          },
+          "usage": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["inputUncached", "cacheRead", "cacheCreation", "output", "reasoning"],
+            "properties": {
+              "inputUncached": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } },
+              "cacheRead": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } },
+              "cacheCreation": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } },
+              "output": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } },
+              "reasoning": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } }
+            }
+          }
+        }
+      }
+    },
+    "compactionCount": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["p25", "p50", "p75"],
+      "description": "p25/p50/p75 compaction count across all aggregated samples.",
+      "properties": {
+        "p25": { "type": "number", "minimum": 0 },
+        "p50": { "type": "number", "minimum": 0 },
+        "p75": { "type": "number", "minimum": 0 }
+      }
+    },
+    "cacheHitRatio": {
+      "type": "number",
+      "minimum": 0,
+      "description": "cacheRead / max(1, cacheRead + cacheCreation + inputUncached) across aggregated total usage. In [0, 1]; the validator has no maximum keyword, enforced instead by assertContextTaxSnapshot."
+    },
+    "successRateByModel": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Keyed by model name. Empty when sampleCount is 0.",
+      "patternProperties": {
+        "^.+$": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["merged", "aborted", "unclaimed", "humanHandoff", "rate"],
+          "properties": {
+            "merged": { "type": "integer", "minimum": 0 },
+            "aborted": { "type": "integer", "minimum": 0 },
+            "unclaimed": { "type": "integer", "minimum": 0 },
+            "humanHandoff": { "type": "integer", "minimum": 0 },
+            "rate": { "type": "number", "minimum": 0 }
+          }
+        }
+      }
+    },
+    "successRateByVendor": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Keyed by vendor. Only vendors present in `vendors` appear.",
+      "properties": {
+        "grok": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["merged", "aborted", "unclaimed", "humanHandoff", "rate"],
+          "properties": {
+            "merged": { "type": "integer", "minimum": 0 },
+            "aborted": { "type": "integer", "minimum": 0 },
+            "unclaimed": { "type": "integer", "minimum": 0 },
+            "humanHandoff": { "type": "integer", "minimum": 0 },
+            "rate": { "type": "number", "minimum": 0 }
+          }
+        },
+        "claude": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["merged", "aborted", "unclaimed", "humanHandoff", "rate"],
+          "properties": {
+            "merged": { "type": "integer", "minimum": 0 },
+            "aborted": { "type": "integer", "minimum": 0 },
+            "unclaimed": { "type": "integer", "minimum": 0 },
+            "humanHandoff": { "type": "integer", "minimum": 0 },
+            "rate": { "type": "number", "minimum": 0 }
+          }
+        },
+        "codex": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["merged", "aborted", "unclaimed", "humanHandoff", "rate"],
+          "properties": {
+            "merged": { "type": "integer", "minimum": 0 },
+            "aborted": { "type": "integer", "minimum": 0 },
+            "unclaimed": { "type": "integer", "minimum": 0 },
+            "humanHandoff": { "type": "integer", "minimum": 0 },
+            "rate": { "type": "number", "minimum": 0 }
+          }
+        }
       }
     }
   }

--- a/schemas/context-tax-snapshot.schema.json
+++ b/schemas/context-tax-snapshot.schema.json
@@ -71,16 +71,66 @@
       "required": ["inputUncached", "cacheRead", "cacheCreation", "output", "reasoning"],
       "description": "p25/p50/p75 across all aggregated samples, per usage field. Zero-valued when sampleCount is 0.",
       "properties": {
-        "inputUncached": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } },
-        "cacheRead": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } },
-        "cacheCreation": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } },
-        "output": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } },
-        "reasoning": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } }
+        "inputUncached": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["p25", "p50", "p75"],
+          "description": "p25/p50/p75 of total (whole-sample) uncached input token count.",
+          "properties": {
+            "p25": { "type": "number", "minimum": 0, "description": "25th percentile." },
+            "p50": { "type": "number", "minimum": 0, "description": "50th percentile (median)." },
+            "p75": { "type": "number", "minimum": 0, "description": "75th percentile." }
+          }
+        },
+        "cacheRead": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["p25", "p50", "p75"],
+          "description": "p25/p50/p75 of total (whole-sample) cache-read token count.",
+          "properties": {
+            "p25": { "type": "number", "minimum": 0, "description": "25th percentile." },
+            "p50": { "type": "number", "minimum": 0, "description": "50th percentile (median)." },
+            "p75": { "type": "number", "minimum": 0, "description": "75th percentile." }
+          }
+        },
+        "cacheCreation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["p25", "p50", "p75"],
+          "description": "p25/p50/p75 of total (whole-sample) cache-creation token count.",
+          "properties": {
+            "p25": { "type": "number", "minimum": 0, "description": "25th percentile." },
+            "p50": { "type": "number", "minimum": 0, "description": "50th percentile (median)." },
+            "p75": { "type": "number", "minimum": 0, "description": "75th percentile." }
+          }
+        },
+        "output": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["p25", "p50", "p75"],
+          "description": "p25/p50/p75 of total (whole-sample) output token count.",
+          "properties": {
+            "p25": { "type": "number", "minimum": 0, "description": "25th percentile." },
+            "p50": { "type": "number", "minimum": 0, "description": "50th percentile (median)." },
+            "p75": { "type": "number", "minimum": 0, "description": "75th percentile." }
+          }
+        },
+        "reasoning": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["p25", "p50", "p75"],
+          "description": "p25/p50/p75 of total (whole-sample) reasoning token count.",
+          "properties": {
+            "p25": { "type": "number", "minimum": 0, "description": "25th percentile." },
+            "p50": { "type": "number", "minimum": 0, "description": "50th percentile (median)." },
+            "p75": { "type": "number", "minimum": 0, "description": "75th percentile." }
+          }
+        }
       }
     },
     "stageUsage": {
       "type": "array",
-      "description": "Per-stage p25/p50/p75 usage. Empty when sampleCount is 0.",
+      "description": "Per-stage p25/p50/p75 usage, one entry per stage id that has at least one data point. Empty when sampleCount is 0.",
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -88,18 +138,70 @@
         "properties": {
           "id": {
             "type": "string",
-            "enum": ["discover", "claim", "work", "submit-pr", "review", "merge", "cleanup"]
+            "enum": ["discover", "claim", "work", "submit-pr", "review", "merge", "cleanup"],
+            "description": "The IDD stage this usage percentile bucket covers."
           },
           "usage": {
             "type": "object",
             "additionalProperties": false,
             "required": ["inputUncached", "cacheRead", "cacheCreation", "output", "reasoning"],
+            "description": "p25/p50/p75 across samples that reported usage for this stage.",
             "properties": {
-              "inputUncached": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } },
-              "cacheRead": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } },
-              "cacheCreation": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } },
-              "output": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } },
-              "reasoning": { "type": "object", "additionalProperties": false, "required": ["p25", "p50", "p75"], "properties": { "p25": { "type": "number", "minimum": 0 }, "p50": { "type": "number", "minimum": 0 }, "p75": { "type": "number", "minimum": 0 } } }
+              "inputUncached": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["p25", "p50", "p75"],
+                "description": "p25/p50/p75 of this stage's uncached input token count.",
+                "properties": {
+                  "p25": { "type": "number", "minimum": 0, "description": "25th percentile." },
+                  "p50": { "type": "number", "minimum": 0, "description": "50th percentile (median)." },
+                  "p75": { "type": "number", "minimum": 0, "description": "75th percentile." }
+                }
+              },
+              "cacheRead": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["p25", "p50", "p75"],
+                "description": "p25/p50/p75 of this stage's cache-read token count.",
+                "properties": {
+                  "p25": { "type": "number", "minimum": 0, "description": "25th percentile." },
+                  "p50": { "type": "number", "minimum": 0, "description": "50th percentile (median)." },
+                  "p75": { "type": "number", "minimum": 0, "description": "75th percentile." }
+                }
+              },
+              "cacheCreation": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["p25", "p50", "p75"],
+                "description": "p25/p50/p75 of this stage's cache-creation token count.",
+                "properties": {
+                  "p25": { "type": "number", "minimum": 0, "description": "25th percentile." },
+                  "p50": { "type": "number", "minimum": 0, "description": "50th percentile (median)." },
+                  "p75": { "type": "number", "minimum": 0, "description": "75th percentile." }
+                }
+              },
+              "output": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["p25", "p50", "p75"],
+                "description": "p25/p50/p75 of this stage's output token count.",
+                "properties": {
+                  "p25": { "type": "number", "minimum": 0, "description": "25th percentile." },
+                  "p50": { "type": "number", "minimum": 0, "description": "50th percentile (median)." },
+                  "p75": { "type": "number", "minimum": 0, "description": "75th percentile." }
+                }
+              },
+              "reasoning": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["p25", "p50", "p75"],
+                "description": "p25/p50/p75 of this stage's reasoning token count.",
+                "properties": {
+                  "p25": { "type": "number", "minimum": 0, "description": "25th percentile." },
+                  "p50": { "type": "number", "minimum": 0, "description": "50th percentile (median)." },
+                  "p75": { "type": "number", "minimum": 0, "description": "75th percentile." }
+                }
+              }
             }
           }
         }
@@ -111,9 +213,9 @@
       "required": ["p25", "p50", "p75"],
       "description": "p25/p50/p75 compaction count across all aggregated samples.",
       "properties": {
-        "p25": { "type": "number", "minimum": 0 },
-        "p50": { "type": "number", "minimum": 0 },
-        "p75": { "type": "number", "minimum": 0 }
+        "p25": { "type": "number", "minimum": 0, "description": "25th percentile." },
+        "p50": { "type": "number", "minimum": 0, "description": "50th percentile (median)." },
+        "p75": { "type": "number", "minimum": 0, "description": "75th percentile." }
       }
     },
     "cacheHitRatio": {
@@ -130,12 +232,13 @@
           "type": "object",
           "additionalProperties": false,
           "required": ["merged", "aborted", "unclaimed", "humanHandoff", "rate"],
+          "description": "Outcome counts and success rate for one model.",
           "properties": {
-            "merged": { "type": "integer", "minimum": 0 },
-            "aborted": { "type": "integer", "minimum": 0 },
-            "unclaimed": { "type": "integer", "minimum": 0 },
-            "humanHandoff": { "type": "integer", "minimum": 0 },
-            "rate": { "type": "number", "minimum": 0 }
+            "merged": { "type": "integer", "minimum": 0, "description": "Merged issue-loop count." },
+            "aborted": { "type": "integer", "minimum": 0, "description": "Aborted issue-loop count." },
+            "unclaimed": { "type": "integer", "minimum": 0, "description": "Unclaimed issue-loop count." },
+            "humanHandoff": { "type": "integer", "minimum": 0, "description": "Human-handoff issue-loop count." },
+            "rate": { "type": "number", "minimum": 0, "description": "merged / (merged + aborted + unclaimed + humanHandoff), in [0, 1]." }
           }
         }
       }
@@ -149,36 +252,39 @@
           "type": "object",
           "additionalProperties": false,
           "required": ["merged", "aborted", "unclaimed", "humanHandoff", "rate"],
+          "description": "Outcome counts and success rate for the grok vendor.",
           "properties": {
-            "merged": { "type": "integer", "minimum": 0 },
-            "aborted": { "type": "integer", "minimum": 0 },
-            "unclaimed": { "type": "integer", "minimum": 0 },
-            "humanHandoff": { "type": "integer", "minimum": 0 },
-            "rate": { "type": "number", "minimum": 0 }
+            "merged": { "type": "integer", "minimum": 0, "description": "Merged issue-loop count." },
+            "aborted": { "type": "integer", "minimum": 0, "description": "Aborted issue-loop count." },
+            "unclaimed": { "type": "integer", "minimum": 0, "description": "Unclaimed issue-loop count." },
+            "humanHandoff": { "type": "integer", "minimum": 0, "description": "Human-handoff issue-loop count." },
+            "rate": { "type": "number", "minimum": 0, "description": "merged / (merged + aborted + unclaimed + humanHandoff), in [0, 1]." }
           }
         },
         "claude": {
           "type": "object",
           "additionalProperties": false,
           "required": ["merged", "aborted", "unclaimed", "humanHandoff", "rate"],
+          "description": "Outcome counts and success rate for the claude vendor.",
           "properties": {
-            "merged": { "type": "integer", "minimum": 0 },
-            "aborted": { "type": "integer", "minimum": 0 },
-            "unclaimed": { "type": "integer", "minimum": 0 },
-            "humanHandoff": { "type": "integer", "minimum": 0 },
-            "rate": { "type": "number", "minimum": 0 }
+            "merged": { "type": "integer", "minimum": 0, "description": "Merged issue-loop count." },
+            "aborted": { "type": "integer", "minimum": 0, "description": "Aborted issue-loop count." },
+            "unclaimed": { "type": "integer", "minimum": 0, "description": "Unclaimed issue-loop count." },
+            "humanHandoff": { "type": "integer", "minimum": 0, "description": "Human-handoff issue-loop count." },
+            "rate": { "type": "number", "minimum": 0, "description": "merged / (merged + aborted + unclaimed + humanHandoff), in [0, 1]." }
           }
         },
         "codex": {
           "type": "object",
           "additionalProperties": false,
           "required": ["merged", "aborted", "unclaimed", "humanHandoff", "rate"],
+          "description": "Outcome counts and success rate for the codex vendor.",
           "properties": {
-            "merged": { "type": "integer", "minimum": 0 },
-            "aborted": { "type": "integer", "minimum": 0 },
-            "unclaimed": { "type": "integer", "minimum": 0 },
-            "humanHandoff": { "type": "integer", "minimum": 0 },
-            "rate": { "type": "number", "minimum": 0 }
+            "merged": { "type": "integer", "minimum": 0, "description": "Merged issue-loop count." },
+            "aborted": { "type": "integer", "minimum": 0, "description": "Aborted issue-loop count." },
+            "unclaimed": { "type": "integer", "minimum": 0, "description": "Unclaimed issue-loop count." },
+            "humanHandoff": { "type": "integer", "minimum": 0, "description": "Human-handoff issue-loop count." },
+            "rate": { "type": "number", "minimum": 0, "description": "merged / (merged + aborted + unclaimed + humanHandoff), in [0, 1]." }
           }
         }
       }

--- a/scripts/context-tax-core.mjs
+++ b/scripts/context-tax-core.mjs
@@ -165,12 +165,45 @@ export function assertContextTaxSample(sample) {
     );
   }
 }
+function assertPercentileOrder(label, p) {
+  if (!(p.p25 <= p.p50 && p.p50 <= p.p75)) {
+    throw new Error(
+      `snapshot ${label} percentiles must satisfy p25 <= p50 <= p75`,
+    );
+  }
+}
+function assertUsagePercentileOrder(label, usage) {
+  for (const field of [
+    'inputUncached',
+    'cacheRead',
+    'cacheCreation',
+    'output',
+    'reasoning',
+  ]) {
+    assertPercentileOrder(`${label}.${field}`, usage[field]);
+  }
+}
+function assertRateInUnitInterval(label, rate) {
+  if (!(rate.rate >= 0 && rate.rate <= 1)) {
+    throw new Error(`snapshot ${label} rate must be in [0, 1]`);
+  }
+  const denom = rate.merged + rate.aborted + rate.unclaimed + rate.humanHandoff;
+  const expected = denom === 0 ? 0 : rate.merged / denom;
+  if (Math.abs(rate.rate - expected) > 1e-9) {
+    throw new Error(
+      `snapshot ${label} rate must equal merged / (merged + aborted + unclaimed + humanHandoff)`,
+    );
+  }
+}
 /**
  * Enforce the constraints the JSON Schema cannot express: distinct
  * `vendors` (`uniqueItems` is outside `validate-schemas.mts`'s enforced
- * keyword subset), and that `publishable` agrees with the
+ * keyword subset), that `publishable` agrees with the
  * `sampleCount`/`vendors` gate the schema documents but cannot compare
- * across fields on its own.
+ * across fields on its own, that every percentile triple is ordered
+ * (the schema has no `maximum`/cross-field comparison keyword), that
+ * `cacheHitRatio` and every success rate fall in `[0, 1]`, and that each
+ * success rate's `rate` field agrees with its own raw counts.
  */
 export function assertContextTaxSnapshot(snapshot) {
   if (new Set(snapshot.vendors).size !== snapshot.vendors.length) {
@@ -183,5 +216,21 @@ export function assertContextTaxSnapshot(snapshot) {
     throw new Error(
       'snapshot publishable must match the sampleCount/vendors gate',
     );
+  }
+  assertUsagePercentileOrder('totalUsage', snapshot.totalUsage);
+  for (const stage of snapshot.stageUsage) {
+    assertUsagePercentileOrder(`stageUsage[${stage.id}].usage`, stage.usage);
+  }
+  assertPercentileOrder('compactionCount', snapshot.compactionCount);
+  if (!(snapshot.cacheHitRatio >= 0 && snapshot.cacheHitRatio <= 1)) {
+    throw new Error('snapshot cacheHitRatio must be in [0, 1]');
+  }
+  for (const [model, rate] of Object.entries(snapshot.successRateByModel)) {
+    assertRateInUnitInterval(`successRateByModel[${model}]`, rate);
+  }
+  for (const [vendor, rate] of Object.entries(snapshot.successRateByVendor)) {
+    if (rate !== undefined) {
+      assertRateInUnitInterval(`successRateByVendor[${vendor}]`, rate);
+    }
   }
 }

--- a/scripts/context-tax-core.mjs
+++ b/scripts/context-tax-core.mjs
@@ -195,15 +195,28 @@ function assertRateInUnitInterval(label, rate) {
     );
   }
 }
+function assertUtcCalendarDate(value) {
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  if (
+    !/^\d{4}-\d{2}-\d{2}$/.test(value) ||
+    Number.isNaN(parsed.getTime()) ||
+    parsed.toISOString().slice(0, 10) !== value
+  ) {
+    throw new Error('snapshot asOf must be a valid UTC calendar date');
+  }
+}
 /**
  * Enforce the constraints the JSON Schema cannot express: distinct
  * `vendors` (`uniqueItems` is outside `validate-schemas.mts`'s enforced
  * keyword subset), that `publishable` agrees with the
  * `sampleCount`/`vendors` gate the schema documents but cannot compare
- * across fields on its own, that every percentile triple is ordered
- * (the schema has no `maximum`/cross-field comparison keyword), that
- * `cacheHitRatio` and every success rate fall in `[0, 1]`, and that each
- * success rate's `rate` field agrees with its own raw counts.
+ * across fields on its own, that `asOf` is a real UTC calendar date (the
+ * schema's `pattern` accepts a shape like `2026-02-30`), that every
+ * percentile triple is ordered (the schema has no `maximum`/cross-field
+ * comparison keyword), that `stageUsage` has at most one entry per stage
+ * id, that `cacheHitRatio` and every success rate fall in `[0, 1]`, that
+ * each success rate's `rate` field agrees with its own raw counts, and
+ * that `successRateByVendor` names only vendors present in `vendors`.
  */
 export function assertContextTaxSnapshot(snapshot) {
   if (new Set(snapshot.vendors).size !== snapshot.vendors.length) {
@@ -217,8 +230,16 @@ export function assertContextTaxSnapshot(snapshot) {
       'snapshot publishable must match the sampleCount/vendors gate',
     );
   }
+  assertUtcCalendarDate(snapshot.asOf);
   assertUsagePercentileOrder('totalUsage', snapshot.totalUsage);
+  const seenStageIds = new Set();
   for (const stage of snapshot.stageUsage) {
+    if (seenStageIds.has(stage.id)) {
+      throw new Error(
+        `snapshot stageUsage has a duplicate entry for "${stage.id}"`,
+      );
+    }
+    seenStageIds.add(stage.id);
     assertUsagePercentileOrder(`stageUsage[${stage.id}].usage`, stage.usage);
   }
   assertPercentileOrder('compactionCount', snapshot.compactionCount);
@@ -228,9 +249,16 @@ export function assertContextTaxSnapshot(snapshot) {
   for (const [model, rate] of Object.entries(snapshot.successRateByModel)) {
     assertRateInUnitInterval(`successRateByModel[${model}]`, rate);
   }
+  const vendorSet = new Set(snapshot.vendors);
   for (const [vendor, rate] of Object.entries(snapshot.successRateByVendor)) {
-    if (rate !== undefined) {
-      assertRateInUnitInterval(`successRateByVendor[${vendor}]`, rate);
+    if (rate === undefined) {
+      continue;
     }
+    if (!vendorSet.has(vendor)) {
+      throw new Error(
+        `snapshot successRateByVendor names "${vendor}", which is not present in vendors`,
+      );
+    }
+    assertRateInUnitInterval(`successRateByVendor[${vendor}]`, rate);
   }
 }

--- a/scripts/context-tax-report.mjs
+++ b/scripts/context-tax-report.mjs
@@ -541,7 +541,16 @@ if (import.meta.main) {
     process.exit(2);
   }
   const snapshotPath = values.snapshot;
-  const now = values.now ? new Date(values.now) : new Date();
+  let now = new Date();
+  if (values.now) {
+    now = new Date(values.now);
+    if (Number.isNaN(now.getTime())) {
+      process.stderr.write(
+        `--now is not a valid ISO8601 timestamp: ${values.now}\n`,
+      );
+      process.exit(2);
+    }
+  }
   if (apply) {
     const inPaths = values.in ?? [];
     if (inPaths.length === 0) {

--- a/scripts/context-tax-report.mjs
+++ b/scripts/context-tax-report.mjs
@@ -40,28 +40,32 @@ const README_START = '<!-- context-tax-readme:start -->';
 const README_END = '<!-- context-tax-readme:end -->';
 const DOCS_START = '<!-- context-tax-docs:start -->';
 const DOCS_END = '<!-- context-tax-docs:end -->';
-// ---------------------------------------------------------------------------
-// JSONL input
-// ---------------------------------------------------------------------------
-/** Parse one JSONL file into non-blank, trimmed lines. */
+/** Parse one JSONL file into non-blank, trimmed lines, each tagged with its line number. */
 function readJsonlLines(path) {
   const raw = readFileSync(path, 'utf8');
   return raw
     .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
+    .map((text, index) => ({ lineNumber: index + 1, text: text.trim() }))
+    .filter((line) => line.text.length > 0);
 }
 /**
  * Read and validate every `--in` file's samples. A line that fails to
- * parse as JSON or fails {@link assertContextTaxSample} throws immediately
- * (fail closed -- a malformed harvested record must not silently vanish
- * from the aggregate).
+ * parse as JSON or fails {@link assertContextTaxSample} throws immediately,
+ * quoting the source file and line number (fail closed -- a malformed
+ * harvested record must not silently vanish from the aggregate).
  */
 export function readSamples(paths) {
   const samples = [];
   for (const path of paths) {
-    for (const line of readJsonlLines(path)) {
-      const sample = JSON.parse(line);
+    for (const { lineNumber, text } of readJsonlLines(path)) {
+      let sample;
+      try {
+        sample = JSON.parse(text);
+      } catch (error) {
+        throw new Error(
+          `${path}:${lineNumber}: invalid JSON (${error.message})`,
+        );
+      }
       assertContextTaxSample(sample);
       samples.push(sample);
     }
@@ -80,10 +84,19 @@ export function readSamples(paths) {
 export function readEvents(paths) {
   const events = [];
   for (const path of paths) {
-    for (const line of readJsonlLines(path)) {
-      const event = JSON.parse(line);
+    for (const { lineNumber, text } of readJsonlLines(path)) {
+      let event;
+      try {
+        event = JSON.parse(text);
+      } catch (error) {
+        throw new Error(
+          `${path}:${lineNumber}: invalid JSON (${error.message})`,
+        );
+      }
       if (typeof event !== 'object' || event === null) {
-        throw new Error(`${path}: event line is not a JSON object: ${line}`);
+        throw new Error(
+          `${path}:${lineNumber}: event line is not a JSON object: ${text}`,
+        );
       }
       events.push(event);
     }
@@ -263,7 +276,34 @@ function wrapProse(text, width = 76) {
   }
   return lines.join('\n');
 }
-function renderReadmeRegionEn(snapshot) {
+/**
+ * Wrap Japanese (space-free) prose at `、`/`。` boundaries so every line
+ * stays within `width`. Unlike {@link wrapProse}, a chunk boundary is a
+ * punctuation mark, not whitespace: joining chunks with a bare `\n`
+ * (no inserted space) keeps the rendered text correct, since CommonMark
+ * renders a soft line break as a space and Japanese prose has none there
+ * naturally. A single chunk longer than `width` on its own (for example
+ * one holding the markdown link) is still emitted as its own line rather
+ * than being force-split mid-token.
+ */
+function wrapCjkProse(text, width = 38) {
+  const chunks = text.split(/(?<=[、。])/);
+  const lines = [];
+  let current = '';
+  for (const chunk of chunks) {
+    if (current.length > 0 && current.length + chunk.length > width) {
+      lines.push(current);
+      current = chunk;
+    } else {
+      current += chunk;
+    }
+  }
+  if (current.length > 0) {
+    lines.push(current);
+  }
+  return lines.join('\n');
+}
+export function renderReadmeRegionEn(snapshot) {
   if (!snapshot.publishable) {
     return wrapProse(
       'Context-tax measurement is in progress; see [`docs/context-tax.md`](docs/context-tax.md) for the methodology.',
@@ -277,23 +317,44 @@ function renderReadmeRegionEn(snapshot) {
       'See [`docs/context-tax.md`](docs/context-tax.md) for the full methodology.',
   );
 }
-function renderReadmeRegionJa(snapshot) {
+export function renderReadmeRegionJa(snapshot) {
   if (!snapshot.publishable) {
-    return 'コンテキスト税の計測は現在進行中です。詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。';
+    return wrapCjkProse(
+      'コンテキスト税の計測は現在進行中です。詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。',
+    );
   }
   const cacheHitPct = Math.round(snapshot.cacheHitRatio * 100);
-  return (
+  return wrapCjkProse(
     `コンテキスト税: issue ループ1件あたり中央値 ${Math.round(snapshot.totalUsage.inputUncached.p50)} 入力トークン、` +
-    `キャッシュヒット率 ${cacheHitPct}%、コンパクション ${Math.round(snapshot.compactionCount.p50)} 回` +
-    `(n=${snapshot.sampleCount}、${formatVendorList(snapshot.vendors)}、${snapshot.asOf} 時点)。` +
-    '詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。'
+      `キャッシュヒット率 ${cacheHitPct}%、コンパクション ${Math.round(snapshot.compactionCount.p50)} 回` +
+      `(n=${snapshot.sampleCount}、${formatVendorList(snapshot.vendors)}、${snapshot.asOf} 時点)。` +
+      '詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。',
   );
 }
-function renderDocsTableRegion(snapshot) {
+function renderSuccessRateTable(title, rates) {
+  const keys = Object.keys(rates).sort();
+  if (keys.length === 0) {
+    return [];
+  }
+  return [
+    `### ${title}`,
+    '',
+    '| Key | Merged | Aborted | Unclaimed | Human handoff | Rate |',
+    '| --- | --- | --- | --- | --- | --- |',
+    ...keys.map((key) => {
+      const r = rates[key];
+      return `| ${key} | ${r.merged} | ${r.aborted} | ${r.unclaimed} | ${r.humanHandoff} | ${(r.rate * 100).toFixed(1)}% |`;
+    }),
+    '',
+  ];
+}
+export function renderDocsTableRegion(snapshot) {
   if (!snapshot.publishable) {
     return `Not yet publishable, n=${snapshot.sampleCount}.`;
   }
   const lines = [
+    '### Total usage',
+    '',
     '| Metric | p25 | p50 | p75 |',
     '| --- | --- | --- | --- |',
     ...USAGE_FIELDS.map((field) => {
@@ -302,8 +363,37 @@ function renderDocsTableRegion(snapshot) {
     }),
     `| compactionCount | ${Math.round(snapshot.compactionCount.p25)} | ${Math.round(snapshot.compactionCount.p50)} | ${Math.round(snapshot.compactionCount.p75)} |`,
     '',
-    `n=${snapshot.sampleCount}, vendors=${formatVendorList(snapshot.vendors)}, cache-hit ratio=${(snapshot.cacheHitRatio * 100).toFixed(1)}%, as of ${snapshot.asOf}.`,
   ];
+  if (snapshot.stageUsage.length > 0) {
+    lines.push(
+      '### By stage (inputUncached)',
+      '',
+      '| Stage | p25 | p50 | p75 |',
+      '| --- | --- | --- | --- |',
+    );
+    for (const stage of snapshot.stageUsage) {
+      const p = stage.usage.inputUncached;
+      lines.push(
+        `| ${stage.id} | ${Math.round(p.p25)} | ${Math.round(p.p50)} | ${Math.round(p.p75)} |`,
+      );
+    }
+    lines.push('');
+  }
+  lines.push(
+    ...renderSuccessRateTable(
+      'Success rate by model',
+      snapshot.successRateByModel,
+    ),
+  );
+  lines.push(
+    ...renderSuccessRateTable(
+      'Success rate by vendor',
+      snapshot.successRateByVendor,
+    ),
+  );
+  lines.push(
+    `n=${snapshot.sampleCount}, vendors=${formatVendorList(snapshot.vendors)}, cache-hit ratio=${(snapshot.cacheHitRatio * 100).toFixed(1)}%, as of ${snapshot.asOf}.`,
+  );
   return lines.join('\n');
 }
 /** Replace the text strictly between two marker lines, keeping the markers. */
@@ -314,8 +404,15 @@ export function replaceMarkedRegion(
   innerContent,
 ) {
   const startIndex = text.indexOf(startMarker);
-  const endIndex = text.indexOf(endMarker);
-  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+  // Search for endMarker only after startMarker, not from the start of the
+  // file -- otherwise a same-named marker (or endMarker text) appearing
+  // earlier in the file would match first and silently pick the wrong
+  // region boundary.
+  const endIndex =
+    startIndex === -1
+      ? -1
+      : text.indexOf(endMarker, startIndex + startMarker.length);
+  if (startIndex === -1 || endIndex === -1) {
     throw new Error(`marked region ${startMarker} .. ${endMarker} not found`);
   }
   const before = text.slice(0, startIndex + startMarker.length);

--- a/scripts/context-tax-report.mjs
+++ b/scripts/context-tax-report.mjs
@@ -12,8 +12,8 @@
 // `~/.codex`) -- `--check` only compares the committed snapshot against the
 // committed regions, so it never needs `--in`. Not registered in
 // HELPER_COMMANDS: this is a maintainer/CI-only dogfood tool, never an
-// adopter-facing helper (see SOURCE_REPO_INTERNAL_ENTRY_PATHS /
-// DOGFOOD_ONLY_CONCRETE_TOOLS in the two guard test files).
+// adopter-facing helper (see SOURCE_REPO_INTERNAL_ENTRY_PATHS in
+// tests/helper-invocation-profile.test.mts).
 import { readFileSync, writeFileSync } from 'node:fs';
 import { parseCliArgs } from './cli-args.mjs';
 import {
@@ -140,11 +140,18 @@ function computeStageUsage(samples) {
   }
   return out;
 }
-function computeCacheHitRatio(totalUsage) {
-  const cacheRead = totalUsage.cacheRead.p50;
-  const cacheCreation = totalUsage.cacheCreation.p50;
-  const inputUncached = totalUsage.inputUncached.p50;
-  return cacheRead / Math.max(1, cacheRead + cacheCreation + inputUncached);
+/**
+ * Median of each sample's own cache-hit ratio, not the ratio of the three
+ * usage fields' independent medians -- each field's p50 can come from a
+ * different sample, so dividing them directly can report a figure outside
+ * every observed per-sample ratio on a skewed sample set.
+ */
+function computeCacheHitRatio(samples) {
+  const ratios = samples.map(({ usage }) => {
+    const denom = usage.cacheRead + usage.cacheCreation + usage.inputUncached;
+    return usage.cacheRead / Math.max(1, denom);
+  });
+  return computePercentiles(ratios).p50;
 }
 function computeSuccessRate(samples, keyOf) {
   const buckets = new Map();
@@ -210,7 +217,7 @@ export function aggregateSnapshot(samples, now) {
     compactionCount: computePercentiles(
       issueLoopSamples.map((sample) => sample.compactionCount),
     ),
-    cacheHitRatio: computeCacheHitRatio(totalUsage),
+    cacheHitRatio: computeCacheHitRatio(issueLoopSamples),
     successRateByModel: computeSuccessRate(
       issueLoopSamples,
       (sample) => sample.model,

--- a/scripts/context-tax-report.mjs
+++ b/scripts/context-tax-report.mjs
@@ -1,0 +1,469 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/context-tax-report.mts
+//
+// The scripts/context-tax-report.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Source-repo-only dogfood reporter (#2294): aggregates locally-harvested
+// context-tax samples (#2288's contract) into a committed snapshot, then
+// renders that snapshot into fixed-template README/docs regions. CI never
+// sees the raw JSONL (it lives outside git, under `~/.grok` / `~/.claude` /
+// `~/.codex`) -- `--check` only compares the committed snapshot against the
+// committed regions, so it never needs `--in`. Not registered in
+// HELPER_COMMANDS: this is a maintainer/CI-only dogfood tool, never an
+// adopter-facing helper (see SOURCE_REPO_INTERNAL_ENTRY_PATHS /
+// DOGFOOD_ONLY_CONCRETE_TOOLS in the two guard test files).
+import { readFileSync, writeFileSync } from 'node:fs';
+import { parseCliArgs } from './cli-args.mjs';
+import {
+  assertContextTaxSample,
+  assertContextTaxSnapshot,
+  CONTEXT_TAX_STAGE_IDS,
+  isIssueLoopSample,
+} from './context-tax-core.mjs';
+
+const DEFAULT_SNAPSHOT_PATH = 'docs/context-tax-snapshot.json';
+const README_PATH = 'README.md';
+const README_JA_PATH = 'README.ja.md';
+const CONTEXT_TAX_DOCS_PATH = 'docs/context-tax.md';
+const MIN_PUBLISHABLE_SAMPLES = 10;
+const MIN_PUBLISHABLE_VENDORS = 2;
+const USAGE_FIELDS = [
+  'inputUncached',
+  'cacheRead',
+  'cacheCreation',
+  'output',
+  'reasoning',
+];
+const README_START = '<!-- context-tax-readme:start -->';
+const README_END = '<!-- context-tax-readme:end -->';
+const DOCS_START = '<!-- context-tax-docs:start -->';
+const DOCS_END = '<!-- context-tax-docs:end -->';
+// ---------------------------------------------------------------------------
+// JSONL input
+// ---------------------------------------------------------------------------
+/** Parse one JSONL file into non-blank, trimmed lines. */
+function readJsonlLines(path) {
+  const raw = readFileSync(path, 'utf8');
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+/**
+ * Read and validate every `--in` file's samples. A line that fails to
+ * parse as JSON or fails {@link assertContextTaxSample} throws immediately
+ * (fail closed -- a malformed harvested record must not silently vanish
+ * from the aggregate).
+ */
+export function readSamples(paths) {
+  const samples = [];
+  for (const path of paths) {
+    for (const line of readJsonlLines(path)) {
+      const sample = JSON.parse(line);
+      assertContextTaxSample(sample);
+      samples.push(sample);
+    }
+  }
+  return samples;
+}
+/**
+ * Read every `--events` file. Events are accepted for CLI-surface parity
+ * with the harvest/adapter issues that produce them, and validated as
+ * well-formed JSON objects, but this reporter does not join them into the
+ * aggregate: an `issue-loop` sample already carries its own per-stage
+ * `usage` breakdown (required by its own schema), so no further join is
+ * needed at report time -- any marker-join/phase-event reconciliation
+ * happens upstream, at harvest time.
+ */
+export function readEvents(paths) {
+  const events = [];
+  for (const path of paths) {
+    for (const line of readJsonlLines(path)) {
+      const event = JSON.parse(line);
+      if (typeof event !== 'object' || event === null) {
+        throw new Error(`${path}: event line is not a JSON object: ${line}`);
+      }
+      events.push(event);
+    }
+  }
+  return events;
+}
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+/** Linear-interpolation percentile over an already-sorted ascending array. */
+function interpolatedPercentile(sorted, p) {
+  if (sorted.length === 0) {
+    return 0;
+  }
+  const rank = (p / 100) * (sorted.length - 1);
+  const lower = Math.floor(rank);
+  const upper = Math.ceil(rank);
+  if (lower === upper) {
+    return sorted[lower];
+  }
+  const weight = rank - lower;
+  return sorted[lower] * (1 - weight) + sorted[upper] * weight;
+}
+function computePercentiles(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  return {
+    p25: interpolatedPercentile(sorted, 25),
+    p50: interpolatedPercentile(sorted, 50),
+    p75: interpolatedPercentile(sorted, 75),
+  };
+}
+function computeUsagePercentiles(usages) {
+  const out = {};
+  for (const field of USAGE_FIELDS) {
+    out[field] = computePercentiles(usages.map((usage) => usage[field]));
+  }
+  return out;
+}
+function computeStageUsage(samples) {
+  const byStage = new Map();
+  for (const sample of samples) {
+    for (const stage of sample.stages) {
+      const bucket = byStage.get(stage.id) ?? [];
+      bucket.push(stage.usage);
+      byStage.set(stage.id, bucket);
+    }
+  }
+  const out = [];
+  for (const id of CONTEXT_TAX_STAGE_IDS) {
+    const usages = byStage.get(id);
+    if (usages && usages.length > 0) {
+      out.push({ id, usage: computeUsagePercentiles(usages) });
+    }
+  }
+  return out;
+}
+function computeCacheHitRatio(totalUsage) {
+  const cacheRead = totalUsage.cacheRead.p50;
+  const cacheCreation = totalUsage.cacheCreation.p50;
+  const inputUncached = totalUsage.inputUncached.p50;
+  return cacheRead / Math.max(1, cacheRead + cacheCreation + inputUncached);
+}
+function computeSuccessRate(samples, keyOf) {
+  const buckets = new Map();
+  for (const sample of samples) {
+    const key = keyOf(sample);
+    const bucket = buckets.get(key) ?? {
+      merged: 0,
+      aborted: 0,
+      unclaimed: 0,
+      humanHandoff: 0,
+    };
+    if (sample.outcome === 'merged') {
+      bucket.merged += 1;
+    } else if (sample.outcome === 'aborted') {
+      bucket.aborted += 1;
+    } else if (sample.outcome === 'unclaimed') {
+      bucket.unclaimed += 1;
+    } else if (sample.outcome === 'human-handoff') {
+      bucket.humanHandoff += 1;
+    }
+    buckets.set(key, bucket);
+  }
+  const out = {};
+  for (const [key, bucket] of buckets) {
+    const denom =
+      bucket.merged + bucket.aborted + bucket.unclaimed + bucket.humanHandoff;
+    out[key] = { ...bucket, rate: denom === 0 ? 0 : bucket.merged / denom };
+  }
+  return out;
+}
+/**
+ * Aggregate raw samples into a committed {@link ContextTaxSnapshot}. Only
+ * `kind: 'issue-loop'` samples with a non-`'unknown'` outcome count -- per
+ * #2294's spec, `outcome: 'unknown'` and session-unscoped records are
+ * excluded from every figure in the snapshot, not only the success-rate
+ * breakdown.
+ */
+export function aggregateSnapshot(samples, now) {
+  const issueLoopSamples = samples
+    .filter(isIssueLoopSample)
+    .filter((sample) => sample.outcome !== 'unknown');
+  const sampleCount = issueLoopSamples.length;
+  const vendors = [
+    ...new Set(issueLoopSamples.map((sample) => sample.vendor)),
+  ].sort();
+  const publishable =
+    sampleCount >= MIN_PUBLISHABLE_SAMPLES &&
+    vendors.length >= MIN_PUBLISHABLE_VENDORS;
+  const totalUsage = computeUsagePercentiles(
+    issueLoopSamples.map((sample) => sample.usage),
+  );
+  const snapshot = {
+    schemaVersion: 1,
+    generatedAt: now.toISOString(),
+    minPublishableSamples: MIN_PUBLISHABLE_SAMPLES,
+    minPublishableVendors: MIN_PUBLISHABLE_VENDORS,
+    publishable,
+    sampleCount,
+    vendors,
+    asOf: now.toISOString().slice(0, 10),
+    totalUsage,
+    stageUsage: computeStageUsage(issueLoopSamples),
+    compactionCount: computePercentiles(
+      issueLoopSamples.map((sample) => sample.compactionCount),
+    ),
+    cacheHitRatio: computeCacheHitRatio(totalUsage),
+    successRateByModel: computeSuccessRate(
+      issueLoopSamples,
+      (sample) => sample.model,
+    ),
+    successRateByVendor: computeSuccessRate(
+      issueLoopSamples,
+      (sample) => sample.vendor,
+    ),
+  };
+  assertContextTaxSnapshot(snapshot);
+  return snapshot;
+}
+// ---------------------------------------------------------------------------
+// Rendering (fixed templates only -- never a live translation)
+// ---------------------------------------------------------------------------
+function formatVendorList(vendors) {
+  return [...vendors].sort().join(', ');
+}
+/**
+ * Word-wrap at whitespace so every line stays within `width` (MD013's
+ * default `line_length`, minus a safety margin) -- Markdown collapses a
+ * single newline inside a paragraph to a space, so this never changes the
+ * rendered meaning. Space-delimited (English) content only: CJK prose has
+ * no spaces to break on, and this repository's markdownlint config does
+ * not flag long space-free lines, so the Japanese blurb is left as one
+ * line.
+ */
+function wrapProse(text, width = 76) {
+  const words = text.split(' ');
+  const lines = [];
+  let current = '';
+  for (const word of words) {
+    const candidate = current.length === 0 ? word : `${current} ${word}`;
+    if (candidate.length > width && current.length > 0) {
+      lines.push(current);
+      current = word;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current.length > 0) {
+    lines.push(current);
+  }
+  return lines.join('\n');
+}
+function renderReadmeRegionEn(snapshot) {
+  if (!snapshot.publishable) {
+    return wrapProse(
+      'Context-tax measurement is in progress; see [`docs/context-tax.md`](docs/context-tax.md) for the methodology.',
+    );
+  }
+  const cacheHitPct = Math.round(snapshot.cacheHitRatio * 100);
+  return wrapProse(
+    `Context tax: median ${Math.round(snapshot.totalUsage.inputUncached.p50)} input tokens, ` +
+      `${cacheHitPct}% cache-hit rate, ${Math.round(snapshot.compactionCount.p50)} compactions ` +
+      `per issue loop (n=${snapshot.sampleCount}, ${formatVendorList(snapshot.vendors)}, as of ${snapshot.asOf}). ` +
+      'See [`docs/context-tax.md`](docs/context-tax.md) for the full methodology.',
+  );
+}
+function renderReadmeRegionJa(snapshot) {
+  if (!snapshot.publishable) {
+    return 'コンテキスト税の計測は現在進行中です。詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。';
+  }
+  const cacheHitPct = Math.round(snapshot.cacheHitRatio * 100);
+  return (
+    `コンテキスト税: issue ループ1件あたり中央値 ${Math.round(snapshot.totalUsage.inputUncached.p50)} 入力トークン、` +
+    `キャッシュヒット率 ${cacheHitPct}%、コンパクション ${Math.round(snapshot.compactionCount.p50)} 回` +
+    `(n=${snapshot.sampleCount}、${formatVendorList(snapshot.vendors)}、${snapshot.asOf} 時点)。` +
+    '詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。'
+  );
+}
+function renderDocsTableRegion(snapshot) {
+  if (!snapshot.publishable) {
+    return `Not yet publishable, n=${snapshot.sampleCount}.`;
+  }
+  const lines = [
+    '| Metric | p25 | p50 | p75 |',
+    '| --- | --- | --- | --- |',
+    ...USAGE_FIELDS.map((field) => {
+      const p = snapshot.totalUsage[field];
+      return `| ${field} | ${Math.round(p.p25)} | ${Math.round(p.p50)} | ${Math.round(p.p75)} |`;
+    }),
+    `| compactionCount | ${Math.round(snapshot.compactionCount.p25)} | ${Math.round(snapshot.compactionCount.p50)} | ${Math.round(snapshot.compactionCount.p75)} |`,
+    '',
+    `n=${snapshot.sampleCount}, vendors=${formatVendorList(snapshot.vendors)}, cache-hit ratio=${(snapshot.cacheHitRatio * 100).toFixed(1)}%, as of ${snapshot.asOf}.`,
+  ];
+  return lines.join('\n');
+}
+/** Replace the text strictly between two marker lines, keeping the markers. */
+export function replaceMarkedRegion(
+  text,
+  startMarker,
+  endMarker,
+  innerContent,
+) {
+  const startIndex = text.indexOf(startMarker);
+  const endIndex = text.indexOf(endMarker);
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    throw new Error(`marked region ${startMarker} .. ${endMarker} not found`);
+  }
+  const before = text.slice(0, startIndex + startMarker.length);
+  const after = text.slice(endIndex);
+  return `${before}\n\n${innerContent}\n\n${after}`;
+}
+// ---------------------------------------------------------------------------
+// Apply / check
+// ---------------------------------------------------------------------------
+function writeRenderedFiles(snapshot) {
+  const readme = readFileSync(README_PATH, 'utf8');
+  writeFileSync(
+    README_PATH,
+    replaceMarkedRegion(
+      readme,
+      README_START,
+      README_END,
+      renderReadmeRegionEn(snapshot),
+    ),
+  );
+  const readmeJa = readFileSync(README_JA_PATH, 'utf8');
+  writeFileSync(
+    README_JA_PATH,
+    replaceMarkedRegion(
+      readmeJa,
+      README_START,
+      README_END,
+      renderReadmeRegionJa(snapshot),
+    ),
+  );
+  const docsPage = readFileSync(CONTEXT_TAX_DOCS_PATH, 'utf8');
+  writeFileSync(
+    CONTEXT_TAX_DOCS_PATH,
+    replaceMarkedRegion(
+      docsPage,
+      DOCS_START,
+      DOCS_END,
+      renderDocsTableRegion(snapshot),
+    ),
+  );
+}
+/**
+ * Returns the list of files whose marked region does not match what the
+ * committed snapshot would render (empty when everything is in sync).
+ */
+export function checkRenderedFiles(snapshot) {
+  const drifted = [];
+  const checks = [
+    [README_PATH, renderReadmeRegionEn(snapshot)],
+    [README_JA_PATH, renderReadmeRegionJa(snapshot)],
+    [CONTEXT_TAX_DOCS_PATH, renderDocsTableRegion(snapshot)],
+  ];
+  for (const [path, expectedInner] of checks) {
+    const content = readFileSync(path, 'utf8');
+    const marker =
+      path === CONTEXT_TAX_DOCS_PATH
+        ? [DOCS_START, DOCS_END]
+        : [README_START, README_END];
+    let expected;
+    try {
+      expected = replaceMarkedRegion(
+        content,
+        marker[0],
+        marker[1],
+        expectedInner,
+      );
+    } catch (error) {
+      drifted.push(`${path}: ${error.message}`);
+      continue;
+    }
+    if (expected !== content) {
+      drifted.push(
+        `${path}: marked region drifted from the committed snapshot`,
+      );
+    }
+  }
+  return drifted;
+}
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+// Flag-spec keys stay the dashed literal on purpose -- see cli-args.mts's
+// module header (tests/flag-name-matrix.test.mts scans each helper's own
+// compiled .mjs source text for its canonical flags as quoted literals).
+const CONTEXT_TAX_REPORT_FLAG_SPEC = {
+  '--in': { type: 'string', multiple: true },
+  '--events': { type: 'string', multiple: true },
+  '--snapshot': { type: 'string', default: DEFAULT_SNAPSHOT_PATH },
+  '--apply': { type: 'boolean', default: false },
+  '--check': { type: 'boolean', default: false },
+  '--now': { type: 'string', default: '' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/context-tax-report.mjs --in <samples.jsonl> [--in <samples.jsonl> ...] [--events <events.jsonl> ...] [--snapshot <path>] --apply
+  node scripts/context-tax-report.mjs [--snapshot <path>] --check
+
+  --in <path>        Sample JSONL file (repeatable). Required with --apply.
+  --events <path>     Event JSONL file (repeatable, optional). Accepted for
+                      CLI-surface parity; not joined into the aggregate.
+  --snapshot <path>   Snapshot artifact path (default: ${DEFAULT_SNAPSHOT_PATH}).
+  --apply             Aggregate --in samples, write the snapshot, and
+                      refresh the README.md / README.ja.md / docs/context-tax.md
+                      marked regions.
+  --check             Verify the committed snapshot's regions have not
+                      drifted from README.md / README.ja.md / docs/context-tax.md.
+                      Exits non-zero on drift. Does not read --in.
+  --now <ISO8601>     Override the current time (tests only).
+  --help, -h          Show this help.
+`);
+}
+if (import.meta.main) {
+  const { values, help } = parseCliArgs(
+    process.argv.slice(2),
+    CONTEXT_TAX_REPORT_FLAG_SPEC,
+  );
+  if (help) {
+    printHelp();
+    process.exit(0);
+  }
+  const apply = values.apply;
+  const check = values.check;
+  if (apply === check) {
+    process.stderr.write('exactly one of --apply or --check is required\n');
+    process.exit(2);
+  }
+  const snapshotPath = values.snapshot;
+  const now = values.now ? new Date(values.now) : new Date();
+  if (apply) {
+    const inPaths = values.in ?? [];
+    if (inPaths.length === 0) {
+      process.stderr.write(
+        '--apply requires at least one --in <samples.jsonl>\n',
+      );
+      process.exit(2);
+    }
+    readEvents(values.events ?? []);
+    const samples = readSamples(inPaths);
+    const snapshot = aggregateSnapshot(samples, now);
+    writeFileSync(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+    writeRenderedFiles(snapshot);
+    process.stdout.write(
+      `context-tax-report: wrote ${snapshotPath} (n=${snapshot.sampleCount}, publishable=${snapshot.publishable})\n`,
+    );
+  } else {
+    const snapshot = JSON.parse(readFileSync(snapshotPath, 'utf8'));
+    assertContextTaxSnapshot(snapshot);
+    const drifted = checkRenderedFiles(snapshot);
+    if (drifted.length > 0) {
+      process.stderr.write(
+        `context-tax-report --check: drift found:\n${drifted.map((d) => `  - ${d}`).join('\n')}\n`,
+      );
+      process.exit(1);
+    }
+    process.stdout.write('context-tax-report: no drift.\n');
+  }
+}

--- a/src/scripts/context-tax-core.mts
+++ b/src/scripts/context-tax-core.mts
@@ -378,15 +378,29 @@ function assertRateInUnitInterval(
   }
 }
 
+function assertUtcCalendarDate(value: string): void {
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  if (
+    !/^\d{4}-\d{2}-\d{2}$/.test(value) ||
+    Number.isNaN(parsed.getTime()) ||
+    parsed.toISOString().slice(0, 10) !== value
+  ) {
+    throw new Error('snapshot asOf must be a valid UTC calendar date');
+  }
+}
+
 /**
  * Enforce the constraints the JSON Schema cannot express: distinct
  * `vendors` (`uniqueItems` is outside `validate-schemas.mts`'s enforced
  * keyword subset), that `publishable` agrees with the
  * `sampleCount`/`vendors` gate the schema documents but cannot compare
- * across fields on its own, that every percentile triple is ordered
- * (the schema has no `maximum`/cross-field comparison keyword), that
- * `cacheHitRatio` and every success rate fall in `[0, 1]`, and that each
- * success rate's `rate` field agrees with its own raw counts.
+ * across fields on its own, that `asOf` is a real UTC calendar date (the
+ * schema's `pattern` accepts a shape like `2026-02-30`), that every
+ * percentile triple is ordered (the schema has no `maximum`/cross-field
+ * comparison keyword), that `stageUsage` has at most one entry per stage
+ * id, that `cacheHitRatio` and every success rate fall in `[0, 1]`, that
+ * each success rate's `rate` field agrees with its own raw counts, and
+ * that `successRateByVendor` names only vendors present in `vendors`.
  */
 export function assertContextTaxSnapshot(snapshot: ContextTaxSnapshot): void {
   if (new Set(snapshot.vendors).size !== snapshot.vendors.length) {
@@ -400,8 +414,16 @@ export function assertContextTaxSnapshot(snapshot: ContextTaxSnapshot): void {
       'snapshot publishable must match the sampleCount/vendors gate',
     );
   }
+  assertUtcCalendarDate(snapshot.asOf);
   assertUsagePercentileOrder('totalUsage', snapshot.totalUsage);
+  const seenStageIds = new Set<string>();
   for (const stage of snapshot.stageUsage) {
+    if (seenStageIds.has(stage.id)) {
+      throw new Error(
+        `snapshot stageUsage has a duplicate entry for "${stage.id}"`,
+      );
+    }
+    seenStageIds.add(stage.id);
     assertUsagePercentileOrder(`stageUsage[${stage.id}].usage`, stage.usage);
   }
   assertPercentileOrder('compactionCount', snapshot.compactionCount);
@@ -411,9 +433,16 @@ export function assertContextTaxSnapshot(snapshot: ContextTaxSnapshot): void {
   for (const [model, rate] of Object.entries(snapshot.successRateByModel)) {
     assertRateInUnitInterval(`successRateByModel[${model}]`, rate);
   }
+  const vendorSet = new Set(snapshot.vendors);
   for (const [vendor, rate] of Object.entries(snapshot.successRateByVendor)) {
-    if (rate !== undefined) {
-      assertRateInUnitInterval(`successRateByVendor[${vendor}]`, rate);
+    if (rate === undefined) {
+      continue;
     }
+    if (!vendorSet.has(vendor as ContextTaxVendor)) {
+      throw new Error(
+        `snapshot successRateByVendor names "${vendor}", which is not present in vendors`,
+      );
+    }
+    assertRateInUnitInterval(`successRateByVendor[${vendor}]`, rate);
   }
 }

--- a/src/scripts/context-tax-core.mts
+++ b/src/scripts/context-tax-core.mts
@@ -108,6 +108,36 @@ export interface ContextTaxEvent {
   usage?: ContextTaxUsage | null;
 }
 
+/** p25/p50/p75 for one measured quantity. */
+export interface ContextTaxPercentiles {
+  p25: number;
+  p50: number;
+  p75: number;
+}
+
+/** p25/p50/p75 for every {@link ContextTaxUsage} field. */
+export interface ContextTaxUsagePercentiles {
+  inputUncached: ContextTaxPercentiles;
+  cacheRead: ContextTaxPercentiles;
+  cacheCreation: ContextTaxPercentiles;
+  output: ContextTaxPercentiles;
+  reasoning: ContextTaxPercentiles;
+}
+
+export interface ContextTaxStageUsagePercentiles {
+  id: ContextTaxStageId;
+  usage: ContextTaxUsagePercentiles;
+}
+
+/** merged/(merged+aborted+unclaimed+humanHandoff), plus the raw counts. */
+export interface ContextTaxSuccessRate {
+  merged: number;
+  aborted: number;
+  unclaimed: number;
+  humanHandoff: number;
+  rate: number;
+}
+
 /** Committed aggregates a later reporter renders. */
 export interface ContextTaxSnapshot {
   schemaVersion: 1;
@@ -117,6 +147,17 @@ export interface ContextTaxSnapshot {
   publishable: boolean;
   sampleCount: number;
   vendors: readonly ContextTaxVendor[];
+  /** UTC calendar date (`YYYY-MM-DD`) the rendered blurb should cite. */
+  asOf: string;
+  totalUsage: ContextTaxUsagePercentiles;
+  stageUsage: readonly ContextTaxStageUsagePercentiles[];
+  compactionCount: ContextTaxPercentiles;
+  /** cacheRead / max(1, cacheRead + cacheCreation + inputUncached), in [0, 1]. */
+  cacheHitRatio: number;
+  successRateByModel: Readonly<Record<string, ContextTaxSuccessRate>>;
+  successRateByVendor: Readonly<
+    Partial<Record<ContextTaxVendor, ContextTaxSuccessRate>>
+  >;
 }
 
 /**
@@ -298,12 +339,54 @@ export function assertContextTaxSample(sample: ContextTaxSample): void {
   }
 }
 
+function assertPercentileOrder(label: string, p: ContextTaxPercentiles): void {
+  if (!(p.p25 <= p.p50 && p.p50 <= p.p75)) {
+    throw new Error(
+      `snapshot ${label} percentiles must satisfy p25 <= p50 <= p75`,
+    );
+  }
+}
+
+function assertUsagePercentileOrder(
+  label: string,
+  usage: ContextTaxUsagePercentiles,
+): void {
+  for (const field of [
+    'inputUncached',
+    'cacheRead',
+    'cacheCreation',
+    'output',
+    'reasoning',
+  ] as const) {
+    assertPercentileOrder(`${label}.${field}`, usage[field]);
+  }
+}
+
+function assertRateInUnitInterval(
+  label: string,
+  rate: ContextTaxSuccessRate,
+): void {
+  if (!(rate.rate >= 0 && rate.rate <= 1)) {
+    throw new Error(`snapshot ${label} rate must be in [0, 1]`);
+  }
+  const denom = rate.merged + rate.aborted + rate.unclaimed + rate.humanHandoff;
+  const expected = denom === 0 ? 0 : rate.merged / denom;
+  if (Math.abs(rate.rate - expected) > 1e-9) {
+    throw new Error(
+      `snapshot ${label} rate must equal merged / (merged + aborted + unclaimed + humanHandoff)`,
+    );
+  }
+}
+
 /**
  * Enforce the constraints the JSON Schema cannot express: distinct
  * `vendors` (`uniqueItems` is outside `validate-schemas.mts`'s enforced
- * keyword subset), and that `publishable` agrees with the
+ * keyword subset), that `publishable` agrees with the
  * `sampleCount`/`vendors` gate the schema documents but cannot compare
- * across fields on its own.
+ * across fields on its own, that every percentile triple is ordered
+ * (the schema has no `maximum`/cross-field comparison keyword), that
+ * `cacheHitRatio` and every success rate fall in `[0, 1]`, and that each
+ * success rate's `rate` field agrees with its own raw counts.
  */
 export function assertContextTaxSnapshot(snapshot: ContextTaxSnapshot): void {
   if (new Set(snapshot.vendors).size !== snapshot.vendors.length) {
@@ -316,5 +399,21 @@ export function assertContextTaxSnapshot(snapshot: ContextTaxSnapshot): void {
     throw new Error(
       'snapshot publishable must match the sampleCount/vendors gate',
     );
+  }
+  assertUsagePercentileOrder('totalUsage', snapshot.totalUsage);
+  for (const stage of snapshot.stageUsage) {
+    assertUsagePercentileOrder(`stageUsage[${stage.id}].usage`, stage.usage);
+  }
+  assertPercentileOrder('compactionCount', snapshot.compactionCount);
+  if (!(snapshot.cacheHitRatio >= 0 && snapshot.cacheHitRatio <= 1)) {
+    throw new Error('snapshot cacheHitRatio must be in [0, 1]');
+  }
+  for (const [model, rate] of Object.entries(snapshot.successRateByModel)) {
+    assertRateInUnitInterval(`successRateByModel[${model}]`, rate);
+  }
+  for (const [vendor, rate] of Object.entries(snapshot.successRateByVendor)) {
+    if (rate !== undefined) {
+      assertRateInUnitInterval(`successRateByVendor[${vendor}]`, rate);
+    }
   }
 }

--- a/src/scripts/context-tax-report.mts
+++ b/src/scripts/context-tax-report.mts
@@ -58,26 +58,39 @@ const DOCS_END = '<!-- context-tax-docs:end -->';
 // JSONL input
 // ---------------------------------------------------------------------------
 
-/** Parse one JSONL file into non-blank, trimmed lines. */
-function readJsonlLines(path: string): string[] {
+/** One non-blank, trimmed JSONL line with its 1-based line number. */
+interface JsonlLine {
+  lineNumber: number;
+  text: string;
+}
+
+/** Parse one JSONL file into non-blank, trimmed lines, each tagged with its line number. */
+function readJsonlLines(path: string): JsonlLine[] {
   const raw = readFileSync(path, 'utf8');
   return raw
     .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
+    .map((text, index) => ({ lineNumber: index + 1, text: text.trim() }))
+    .filter((line) => line.text.length > 0);
 }
 
 /**
  * Read and validate every `--in` file's samples. A line that fails to
- * parse as JSON or fails {@link assertContextTaxSample} throws immediately
- * (fail closed -- a malformed harvested record must not silently vanish
- * from the aggregate).
+ * parse as JSON or fails {@link assertContextTaxSample} throws immediately,
+ * quoting the source file and line number (fail closed -- a malformed
+ * harvested record must not silently vanish from the aggregate).
  */
 export function readSamples(paths: readonly string[]): ContextTaxSample[] {
   const samples: ContextTaxSample[] = [];
   for (const path of paths) {
-    for (const line of readJsonlLines(path)) {
-      const sample = JSON.parse(line) as ContextTaxSample;
+    for (const { lineNumber, text } of readJsonlLines(path)) {
+      let sample: ContextTaxSample;
+      try {
+        sample = JSON.parse(text) as ContextTaxSample;
+      } catch (error) {
+        throw new Error(
+          `${path}:${lineNumber}: invalid JSON (${(error as Error).message})`,
+        );
+      }
       assertContextTaxSample(sample);
       samples.push(sample);
     }
@@ -97,10 +110,19 @@ export function readSamples(paths: readonly string[]): ContextTaxSample[] {
 export function readEvents(paths: readonly string[]): unknown[] {
   const events: unknown[] = [];
   for (const path of paths) {
-    for (const line of readJsonlLines(path)) {
-      const event = JSON.parse(line);
+    for (const { lineNumber, text } of readJsonlLines(path)) {
+      let event: unknown;
+      try {
+        event = JSON.parse(text);
+      } catch (error) {
+        throw new Error(
+          `${path}:${lineNumber}: invalid JSON (${(error as Error).message})`,
+        );
+      }
       if (typeof event !== 'object' || event === null) {
-        throw new Error(`${path}: event line is not a JSON object: ${line}`);
+        throw new Error(
+          `${path}:${lineNumber}: event line is not a JSON object: ${text}`,
+        );
       }
       events.push(event);
     }
@@ -310,7 +332,35 @@ function wrapProse(text: string, width = 76): string {
   return lines.join('\n');
 }
 
-function renderReadmeRegionEn(snapshot: ContextTaxSnapshot): string {
+/**
+ * Wrap Japanese (space-free) prose at `、`/`。` boundaries so every line
+ * stays within `width`. Unlike {@link wrapProse}, a chunk boundary is a
+ * punctuation mark, not whitespace: joining chunks with a bare `\n`
+ * (no inserted space) keeps the rendered text correct, since CommonMark
+ * renders a soft line break as a space and Japanese prose has none there
+ * naturally. A single chunk longer than `width` on its own (for example
+ * one holding the markdown link) is still emitted as its own line rather
+ * than being force-split mid-token.
+ */
+function wrapCjkProse(text: string, width = 38): string {
+  const chunks = text.split(/(?<=[、。])/);
+  const lines: string[] = [];
+  let current = '';
+  for (const chunk of chunks) {
+    if (current.length > 0 && current.length + chunk.length > width) {
+      lines.push(current);
+      current = chunk;
+    } else {
+      current += chunk;
+    }
+  }
+  if (current.length > 0) {
+    lines.push(current);
+  }
+  return lines.join('\n');
+}
+
+export function renderReadmeRegionEn(snapshot: ContextTaxSnapshot): string {
   if (!snapshot.publishable) {
     return wrapProse(
       'Context-tax measurement is in progress; see [`docs/context-tax.md`](docs/context-tax.md) for the methodology.',
@@ -325,24 +375,49 @@ function renderReadmeRegionEn(snapshot: ContextTaxSnapshot): string {
   );
 }
 
-function renderReadmeRegionJa(snapshot: ContextTaxSnapshot): string {
+export function renderReadmeRegionJa(snapshot: ContextTaxSnapshot): string {
   if (!snapshot.publishable) {
-    return 'コンテキスト税の計測は現在進行中です。詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。';
+    return wrapCjkProse(
+      'コンテキスト税の計測は現在進行中です。詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。',
+    );
   }
   const cacheHitPct = Math.round(snapshot.cacheHitRatio * 100);
-  return (
+  return wrapCjkProse(
     `コンテキスト税: issue ループ1件あたり中央値 ${Math.round(snapshot.totalUsage.inputUncached.p50)} 入力トークン、` +
-    `キャッシュヒット率 ${cacheHitPct}%、コンパクション ${Math.round(snapshot.compactionCount.p50)} 回` +
-    `(n=${snapshot.sampleCount}、${formatVendorList(snapshot.vendors)}、${snapshot.asOf} 時点)。` +
-    '詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。'
+      `キャッシュヒット率 ${cacheHitPct}%、コンパクション ${Math.round(snapshot.compactionCount.p50)} 回` +
+      `(n=${snapshot.sampleCount}、${formatVendorList(snapshot.vendors)}、${snapshot.asOf} 時点)。` +
+      '詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。',
   );
 }
 
-function renderDocsTableRegion(snapshot: ContextTaxSnapshot): string {
+function renderSuccessRateTable(
+  title: string,
+  rates: Readonly<Record<string, ContextTaxSuccessRate>>,
+): string[] {
+  const keys = Object.keys(rates).sort();
+  if (keys.length === 0) {
+    return [];
+  }
+  return [
+    `### ${title}`,
+    '',
+    '| Key | Merged | Aborted | Unclaimed | Human handoff | Rate |',
+    '| --- | --- | --- | --- | --- | --- |',
+    ...keys.map((key) => {
+      const r = rates[key];
+      return `| ${key} | ${r.merged} | ${r.aborted} | ${r.unclaimed} | ${r.humanHandoff} | ${(r.rate * 100).toFixed(1)}% |`;
+    }),
+    '',
+  ];
+}
+
+export function renderDocsTableRegion(snapshot: ContextTaxSnapshot): string {
   if (!snapshot.publishable) {
     return `Not yet publishable, n=${snapshot.sampleCount}.`;
   }
   const lines = [
+    '### Total usage',
+    '',
     '| Metric | p25 | p50 | p75 |',
     '| --- | --- | --- | --- |',
     ...USAGE_FIELDS.map((field) => {
@@ -351,8 +426,37 @@ function renderDocsTableRegion(snapshot: ContextTaxSnapshot): string {
     }),
     `| compactionCount | ${Math.round(snapshot.compactionCount.p25)} | ${Math.round(snapshot.compactionCount.p50)} | ${Math.round(snapshot.compactionCount.p75)} |`,
     '',
-    `n=${snapshot.sampleCount}, vendors=${formatVendorList(snapshot.vendors)}, cache-hit ratio=${(snapshot.cacheHitRatio * 100).toFixed(1)}%, as of ${snapshot.asOf}.`,
   ];
+  if (snapshot.stageUsage.length > 0) {
+    lines.push(
+      '### By stage (inputUncached)',
+      '',
+      '| Stage | p25 | p50 | p75 |',
+      '| --- | --- | --- | --- |',
+    );
+    for (const stage of snapshot.stageUsage) {
+      const p = stage.usage.inputUncached;
+      lines.push(
+        `| ${stage.id} | ${Math.round(p.p25)} | ${Math.round(p.p50)} | ${Math.round(p.p75)} |`,
+      );
+    }
+    lines.push('');
+  }
+  lines.push(
+    ...renderSuccessRateTable(
+      'Success rate by model',
+      snapshot.successRateByModel,
+    ),
+  );
+  lines.push(
+    ...renderSuccessRateTable(
+      'Success rate by vendor',
+      snapshot.successRateByVendor,
+    ),
+  );
+  lines.push(
+    `n=${snapshot.sampleCount}, vendors=${formatVendorList(snapshot.vendors)}, cache-hit ratio=${(snapshot.cacheHitRatio * 100).toFixed(1)}%, as of ${snapshot.asOf}.`,
+  );
   return lines.join('\n');
 }
 
@@ -364,8 +468,15 @@ export function replaceMarkedRegion(
   innerContent: string,
 ): string {
   const startIndex = text.indexOf(startMarker);
-  const endIndex = text.indexOf(endMarker);
-  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+  // Search for endMarker only after startMarker, not from the start of the
+  // file -- otherwise a same-named marker (or endMarker text) appearing
+  // earlier in the file would match first and silently pick the wrong
+  // region boundary.
+  const endIndex =
+    startIndex === -1
+      ? -1
+      : text.indexOf(endMarker, startIndex + startMarker.length);
+  if (startIndex === -1 || endIndex === -1) {
     throw new Error(`marked region ${startMarker} .. ${endMarker} not found`);
   }
   const before = text.slice(0, startIndex + startMarker.length);

--- a/src/scripts/context-tax-report.mts
+++ b/src/scripts/context-tax-report.mts
@@ -12,8 +12,8 @@
 // `~/.codex`) -- `--check` only compares the committed snapshot against the
 // committed regions, so it never needs `--in`. Not registered in
 // HELPER_COMMANDS: this is a maintainer/CI-only dogfood tool, never an
-// adopter-facing helper (see SOURCE_REPO_INTERNAL_ENTRY_PATHS /
-// DOGFOOD_ONLY_CONCRETE_TOOLS in the two guard test files).
+// adopter-facing helper (see SOURCE_REPO_INTERNAL_ENTRY_PATHS in
+// tests/helper-invocation-profile.test.mts).
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { parseCliArgs } from './cli-args.mts';
@@ -170,11 +170,20 @@ function computeStageUsage(
   return out;
 }
 
-function computeCacheHitRatio(totalUsage: ContextTaxUsagePercentiles): number {
-  const cacheRead = totalUsage.cacheRead.p50;
-  const cacheCreation = totalUsage.cacheCreation.p50;
-  const inputUncached = totalUsage.inputUncached.p50;
-  return cacheRead / Math.max(1, cacheRead + cacheCreation + inputUncached);
+/**
+ * Median of each sample's own cache-hit ratio, not the ratio of the three
+ * usage fields' independent medians -- each field's p50 can come from a
+ * different sample, so dividing them directly can report a figure outside
+ * every observed per-sample ratio on a skewed sample set.
+ */
+function computeCacheHitRatio(
+  samples: readonly ContextTaxIssueLoopSample[],
+): number {
+  const ratios = samples.map(({ usage }) => {
+    const denom = usage.cacheRead + usage.cacheCreation + usage.inputUncached;
+    return usage.cacheRead / Math.max(1, denom);
+  });
+  return computePercentiles(ratios).p50;
 }
 
 function computeSuccessRate<K extends string>(
@@ -251,7 +260,7 @@ export function aggregateSnapshot(
     compactionCount: computePercentiles(
       issueLoopSamples.map((sample) => sample.compactionCount),
     ),
-    cacheHitRatio: computeCacheHitRatio(totalUsage),
+    cacheHitRatio: computeCacheHitRatio(issueLoopSamples),
     successRateByModel: computeSuccessRate(
       issueLoopSamples,
       (sample) => sample.model,

--- a/src/scripts/context-tax-report.mts
+++ b/src/scripts/context-tax-report.mts
@@ -1,0 +1,527 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/context-tax-report.mts
+//
+// The scripts/context-tax-report.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Source-repo-only dogfood reporter (#2294): aggregates locally-harvested
+// context-tax samples (#2288's contract) into a committed snapshot, then
+// renders that snapshot into fixed-template README/docs regions. CI never
+// sees the raw JSONL (it lives outside git, under `~/.grok` / `~/.claude` /
+// `~/.codex`) -- `--check` only compares the committed snapshot against the
+// committed regions, so it never needs `--in`. Not registered in
+// HELPER_COMMANDS: this is a maintainer/CI-only dogfood tool, never an
+// adopter-facing helper (see SOURCE_REPO_INTERNAL_ENTRY_PATHS /
+// DOGFOOD_ONLY_CONCRETE_TOOLS in the two guard test files).
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { parseCliArgs } from './cli-args.mts';
+import {
+  assertContextTaxSample,
+  assertContextTaxSnapshot,
+  CONTEXT_TAX_STAGE_IDS,
+  type ContextTaxIssueLoopSample,
+  type ContextTaxPercentiles,
+  type ContextTaxSample,
+  type ContextTaxSnapshot,
+  type ContextTaxStageId,
+  type ContextTaxStageUsagePercentiles,
+  type ContextTaxSuccessRate,
+  type ContextTaxUsage,
+  type ContextTaxUsagePercentiles,
+  type ContextTaxVendor,
+  isIssueLoopSample,
+} from './context-tax-core.mts';
+
+const DEFAULT_SNAPSHOT_PATH = 'docs/context-tax-snapshot.json';
+const README_PATH = 'README.md';
+const README_JA_PATH = 'README.ja.md';
+const CONTEXT_TAX_DOCS_PATH = 'docs/context-tax.md';
+const MIN_PUBLISHABLE_SAMPLES = 10;
+const MIN_PUBLISHABLE_VENDORS = 2;
+
+const USAGE_FIELDS = [
+  'inputUncached',
+  'cacheRead',
+  'cacheCreation',
+  'output',
+  'reasoning',
+] as const;
+
+const README_START = '<!-- context-tax-readme:start -->';
+const README_END = '<!-- context-tax-readme:end -->';
+const DOCS_START = '<!-- context-tax-docs:start -->';
+const DOCS_END = '<!-- context-tax-docs:end -->';
+
+// ---------------------------------------------------------------------------
+// JSONL input
+// ---------------------------------------------------------------------------
+
+/** Parse one JSONL file into non-blank, trimmed lines. */
+function readJsonlLines(path: string): string[] {
+  const raw = readFileSync(path, 'utf8');
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/**
+ * Read and validate every `--in` file's samples. A line that fails to
+ * parse as JSON or fails {@link assertContextTaxSample} throws immediately
+ * (fail closed -- a malformed harvested record must not silently vanish
+ * from the aggregate).
+ */
+export function readSamples(paths: readonly string[]): ContextTaxSample[] {
+  const samples: ContextTaxSample[] = [];
+  for (const path of paths) {
+    for (const line of readJsonlLines(path)) {
+      const sample = JSON.parse(line) as ContextTaxSample;
+      assertContextTaxSample(sample);
+      samples.push(sample);
+    }
+  }
+  return samples;
+}
+
+/**
+ * Read every `--events` file. Events are accepted for CLI-surface parity
+ * with the harvest/adapter issues that produce them, and validated as
+ * well-formed JSON objects, but this reporter does not join them into the
+ * aggregate: an `issue-loop` sample already carries its own per-stage
+ * `usage` breakdown (required by its own schema), so no further join is
+ * needed at report time -- any marker-join/phase-event reconciliation
+ * happens upstream, at harvest time.
+ */
+export function readEvents(paths: readonly string[]): unknown[] {
+  const events: unknown[] = [];
+  for (const path of paths) {
+    for (const line of readJsonlLines(path)) {
+      const event = JSON.parse(line);
+      if (typeof event !== 'object' || event === null) {
+        throw new Error(`${path}: event line is not a JSON object: ${line}`);
+      }
+      events.push(event);
+    }
+  }
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation
+// ---------------------------------------------------------------------------
+
+/** Linear-interpolation percentile over an already-sorted ascending array. */
+function interpolatedPercentile(sorted: readonly number[], p: number): number {
+  if (sorted.length === 0) {
+    return 0;
+  }
+  const rank = (p / 100) * (sorted.length - 1);
+  const lower = Math.floor(rank);
+  const upper = Math.ceil(rank);
+  if (lower === upper) {
+    return sorted[lower];
+  }
+  const weight = rank - lower;
+  return sorted[lower] * (1 - weight) + sorted[upper] * weight;
+}
+
+function computePercentiles(values: readonly number[]): ContextTaxPercentiles {
+  const sorted = [...values].sort((a, b) => a - b);
+  return {
+    p25: interpolatedPercentile(sorted, 25),
+    p50: interpolatedPercentile(sorted, 50),
+    p75: interpolatedPercentile(sorted, 75),
+  };
+}
+
+function computeUsagePercentiles(
+  usages: readonly ContextTaxUsage[],
+): ContextTaxUsagePercentiles {
+  const out = {} as Record<
+    (typeof USAGE_FIELDS)[number],
+    ContextTaxPercentiles
+  >;
+  for (const field of USAGE_FIELDS) {
+    out[field] = computePercentiles(usages.map((usage) => usage[field]));
+  }
+  return out as ContextTaxUsagePercentiles;
+}
+
+function computeStageUsage(
+  samples: readonly ContextTaxIssueLoopSample[],
+): ContextTaxStageUsagePercentiles[] {
+  const byStage = new Map<ContextTaxStageId, ContextTaxUsage[]>();
+  for (const sample of samples) {
+    for (const stage of sample.stages) {
+      const bucket = byStage.get(stage.id) ?? [];
+      bucket.push(stage.usage);
+      byStage.set(stage.id, bucket);
+    }
+  }
+  const out: ContextTaxStageUsagePercentiles[] = [];
+  for (const id of CONTEXT_TAX_STAGE_IDS) {
+    const usages = byStage.get(id);
+    if (usages && usages.length > 0) {
+      out.push({ id, usage: computeUsagePercentiles(usages) });
+    }
+  }
+  return out;
+}
+
+function computeCacheHitRatio(totalUsage: ContextTaxUsagePercentiles): number {
+  const cacheRead = totalUsage.cacheRead.p50;
+  const cacheCreation = totalUsage.cacheCreation.p50;
+  const inputUncached = totalUsage.inputUncached.p50;
+  return cacheRead / Math.max(1, cacheRead + cacheCreation + inputUncached);
+}
+
+function computeSuccessRate<K extends string>(
+  samples: readonly ContextTaxIssueLoopSample[],
+  keyOf: (sample: ContextTaxIssueLoopSample) => K,
+): Record<K, ContextTaxSuccessRate> {
+  const buckets = new Map<
+    K,
+    { merged: number; aborted: number; unclaimed: number; humanHandoff: number }
+  >();
+  for (const sample of samples) {
+    const key = keyOf(sample);
+    const bucket = buckets.get(key) ?? {
+      merged: 0,
+      aborted: 0,
+      unclaimed: 0,
+      humanHandoff: 0,
+    };
+    if (sample.outcome === 'merged') {
+      bucket.merged += 1;
+    } else if (sample.outcome === 'aborted') {
+      bucket.aborted += 1;
+    } else if (sample.outcome === 'unclaimed') {
+      bucket.unclaimed += 1;
+    } else if (sample.outcome === 'human-handoff') {
+      bucket.humanHandoff += 1;
+    }
+    buckets.set(key, bucket);
+  }
+  const out = {} as Record<K, ContextTaxSuccessRate>;
+  for (const [key, bucket] of buckets) {
+    const denom =
+      bucket.merged + bucket.aborted + bucket.unclaimed + bucket.humanHandoff;
+    out[key] = { ...bucket, rate: denom === 0 ? 0 : bucket.merged / denom };
+  }
+  return out;
+}
+
+/**
+ * Aggregate raw samples into a committed {@link ContextTaxSnapshot}. Only
+ * `kind: 'issue-loop'` samples with a non-`'unknown'` outcome count -- per
+ * #2294's spec, `outcome: 'unknown'` and session-unscoped records are
+ * excluded from every figure in the snapshot, not only the success-rate
+ * breakdown.
+ */
+export function aggregateSnapshot(
+  samples: readonly ContextTaxSample[],
+  now: Date,
+): ContextTaxSnapshot {
+  const issueLoopSamples = samples
+    .filter(isIssueLoopSample)
+    .filter((sample) => sample.outcome !== 'unknown');
+  const sampleCount = issueLoopSamples.length;
+  const vendors = [
+    ...new Set(issueLoopSamples.map((sample) => sample.vendor)),
+  ].sort() as ContextTaxVendor[];
+  const publishable =
+    sampleCount >= MIN_PUBLISHABLE_SAMPLES &&
+    vendors.length >= MIN_PUBLISHABLE_VENDORS;
+  const totalUsage = computeUsagePercentiles(
+    issueLoopSamples.map((sample) => sample.usage),
+  );
+  const snapshot: ContextTaxSnapshot = {
+    schemaVersion: 1,
+    generatedAt: now.toISOString(),
+    minPublishableSamples: MIN_PUBLISHABLE_SAMPLES,
+    minPublishableVendors: MIN_PUBLISHABLE_VENDORS,
+    publishable,
+    sampleCount,
+    vendors,
+    asOf: now.toISOString().slice(0, 10),
+    totalUsage,
+    stageUsage: computeStageUsage(issueLoopSamples),
+    compactionCount: computePercentiles(
+      issueLoopSamples.map((sample) => sample.compactionCount),
+    ),
+    cacheHitRatio: computeCacheHitRatio(totalUsage),
+    successRateByModel: computeSuccessRate(
+      issueLoopSamples,
+      (sample) => sample.model,
+    ),
+    successRateByVendor: computeSuccessRate(
+      issueLoopSamples,
+      (sample) => sample.vendor,
+    ),
+  };
+  assertContextTaxSnapshot(snapshot);
+  return snapshot;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering (fixed templates only -- never a live translation)
+// ---------------------------------------------------------------------------
+
+function formatVendorList(vendors: readonly ContextTaxVendor[]): string {
+  return [...vendors].sort().join(', ');
+}
+
+/**
+ * Word-wrap at whitespace so every line stays within `width` (MD013's
+ * default `line_length`, minus a safety margin) -- Markdown collapses a
+ * single newline inside a paragraph to a space, so this never changes the
+ * rendered meaning. Space-delimited (English) content only: CJK prose has
+ * no spaces to break on, and this repository's markdownlint config does
+ * not flag long space-free lines, so the Japanese blurb is left as one
+ * line.
+ */
+function wrapProse(text: string, width = 76): string {
+  const words = text.split(' ');
+  const lines: string[] = [];
+  let current = '';
+  for (const word of words) {
+    const candidate = current.length === 0 ? word : `${current} ${word}`;
+    if (candidate.length > width && current.length > 0) {
+      lines.push(current);
+      current = word;
+    } else {
+      current = candidate;
+    }
+  }
+  if (current.length > 0) {
+    lines.push(current);
+  }
+  return lines.join('\n');
+}
+
+function renderReadmeRegionEn(snapshot: ContextTaxSnapshot): string {
+  if (!snapshot.publishable) {
+    return wrapProse(
+      'Context-tax measurement is in progress; see [`docs/context-tax.md`](docs/context-tax.md) for the methodology.',
+    );
+  }
+  const cacheHitPct = Math.round(snapshot.cacheHitRatio * 100);
+  return wrapProse(
+    `Context tax: median ${Math.round(snapshot.totalUsage.inputUncached.p50)} input tokens, ` +
+      `${cacheHitPct}% cache-hit rate, ${Math.round(snapshot.compactionCount.p50)} compactions ` +
+      `per issue loop (n=${snapshot.sampleCount}, ${formatVendorList(snapshot.vendors)}, as of ${snapshot.asOf}). ` +
+      'See [`docs/context-tax.md`](docs/context-tax.md) for the full methodology.',
+  );
+}
+
+function renderReadmeRegionJa(snapshot: ContextTaxSnapshot): string {
+  if (!snapshot.publishable) {
+    return 'コンテキスト税の計測は現在進行中です。詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。';
+  }
+  const cacheHitPct = Math.round(snapshot.cacheHitRatio * 100);
+  return (
+    `コンテキスト税: issue ループ1件あたり中央値 ${Math.round(snapshot.totalUsage.inputUncached.p50)} 入力トークン、` +
+    `キャッシュヒット率 ${cacheHitPct}%、コンパクション ${Math.round(snapshot.compactionCount.p50)} 回` +
+    `(n=${snapshot.sampleCount}、${formatVendorList(snapshot.vendors)}、${snapshot.asOf} 時点)。` +
+    '詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。'
+  );
+}
+
+function renderDocsTableRegion(snapshot: ContextTaxSnapshot): string {
+  if (!snapshot.publishable) {
+    return `Not yet publishable, n=${snapshot.sampleCount}.`;
+  }
+  const lines = [
+    '| Metric | p25 | p50 | p75 |',
+    '| --- | --- | --- | --- |',
+    ...USAGE_FIELDS.map((field) => {
+      const p = snapshot.totalUsage[field];
+      return `| ${field} | ${Math.round(p.p25)} | ${Math.round(p.p50)} | ${Math.round(p.p75)} |`;
+    }),
+    `| compactionCount | ${Math.round(snapshot.compactionCount.p25)} | ${Math.round(snapshot.compactionCount.p50)} | ${Math.round(snapshot.compactionCount.p75)} |`,
+    '',
+    `n=${snapshot.sampleCount}, vendors=${formatVendorList(snapshot.vendors)}, cache-hit ratio=${(snapshot.cacheHitRatio * 100).toFixed(1)}%, as of ${snapshot.asOf}.`,
+  ];
+  return lines.join('\n');
+}
+
+/** Replace the text strictly between two marker lines, keeping the markers. */
+export function replaceMarkedRegion(
+  text: string,
+  startMarker: string,
+  endMarker: string,
+  innerContent: string,
+): string {
+  const startIndex = text.indexOf(startMarker);
+  const endIndex = text.indexOf(endMarker);
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    throw new Error(`marked region ${startMarker} .. ${endMarker} not found`);
+  }
+  const before = text.slice(0, startIndex + startMarker.length);
+  const after = text.slice(endIndex);
+  return `${before}\n\n${innerContent}\n\n${after}`;
+}
+
+// ---------------------------------------------------------------------------
+// Apply / check
+// ---------------------------------------------------------------------------
+
+function writeRenderedFiles(snapshot: ContextTaxSnapshot): void {
+  const readme = readFileSync(README_PATH, 'utf8');
+  writeFileSync(
+    README_PATH,
+    replaceMarkedRegion(
+      readme,
+      README_START,
+      README_END,
+      renderReadmeRegionEn(snapshot),
+    ),
+  );
+  const readmeJa = readFileSync(README_JA_PATH, 'utf8');
+  writeFileSync(
+    README_JA_PATH,
+    replaceMarkedRegion(
+      readmeJa,
+      README_START,
+      README_END,
+      renderReadmeRegionJa(snapshot),
+    ),
+  );
+  const docsPage = readFileSync(CONTEXT_TAX_DOCS_PATH, 'utf8');
+  writeFileSync(
+    CONTEXT_TAX_DOCS_PATH,
+    replaceMarkedRegion(
+      docsPage,
+      DOCS_START,
+      DOCS_END,
+      renderDocsTableRegion(snapshot),
+    ),
+  );
+}
+
+/**
+ * Returns the list of files whose marked region does not match what the
+ * committed snapshot would render (empty when everything is in sync).
+ */
+export function checkRenderedFiles(snapshot: ContextTaxSnapshot): string[] {
+  const drifted: string[] = [];
+  const checks: [string, string][] = [
+    [README_PATH, renderReadmeRegionEn(snapshot)],
+    [README_JA_PATH, renderReadmeRegionJa(snapshot)],
+    [CONTEXT_TAX_DOCS_PATH, renderDocsTableRegion(snapshot)],
+  ];
+  for (const [path, expectedInner] of checks) {
+    const content = readFileSync(path, 'utf8');
+    const marker =
+      path === CONTEXT_TAX_DOCS_PATH
+        ? [DOCS_START, DOCS_END]
+        : [README_START, README_END];
+    let expected: string;
+    try {
+      expected = replaceMarkedRegion(
+        content,
+        marker[0],
+        marker[1],
+        expectedInner,
+      );
+    } catch (error) {
+      drifted.push(`${path}: ${(error as Error).message}`);
+      continue;
+    }
+    if (expected !== content) {
+      drifted.push(
+        `${path}: marked region drifted from the committed snapshot`,
+      );
+    }
+  }
+  return drifted;
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+// Flag-spec keys stay the dashed literal on purpose -- see cli-args.mts's
+// module header (tests/flag-name-matrix.test.mts scans each helper's own
+// compiled .mjs source text for its canonical flags as quoted literals).
+const CONTEXT_TAX_REPORT_FLAG_SPEC = {
+  '--in': { type: 'string', multiple: true },
+  '--events': { type: 'string', multiple: true },
+  '--snapshot': { type: 'string', default: DEFAULT_SNAPSHOT_PATH },
+  '--apply': { type: 'boolean', default: false },
+  '--check': { type: 'boolean', default: false },
+  '--now': { type: 'string', default: '' },
+  '--help': { type: 'boolean', short: 'h' },
+} as const;
+
+function printHelp(): void {
+  process.stdout.write(`Usage:
+  node scripts/context-tax-report.mjs --in <samples.jsonl> [--in <samples.jsonl> ...] [--events <events.jsonl> ...] [--snapshot <path>] --apply
+  node scripts/context-tax-report.mjs [--snapshot <path>] --check
+
+  --in <path>        Sample JSONL file (repeatable). Required with --apply.
+  --events <path>     Event JSONL file (repeatable, optional). Accepted for
+                      CLI-surface parity; not joined into the aggregate.
+  --snapshot <path>   Snapshot artifact path (default: ${DEFAULT_SNAPSHOT_PATH}).
+  --apply             Aggregate --in samples, write the snapshot, and
+                      refresh the README.md / README.ja.md / docs/context-tax.md
+                      marked regions.
+  --check             Verify the committed snapshot's regions have not
+                      drifted from README.md / README.ja.md / docs/context-tax.md.
+                      Exits non-zero on drift. Does not read --in.
+  --now <ISO8601>     Override the current time (tests only).
+  --help, -h          Show this help.
+`);
+}
+
+if (import.meta.main) {
+  const { values, help } = parseCliArgs(
+    process.argv.slice(2),
+    CONTEXT_TAX_REPORT_FLAG_SPEC,
+  );
+  if (help) {
+    printHelp();
+    process.exit(0);
+  }
+  const apply = values.apply as boolean;
+  const check = values.check as boolean;
+  if (apply === check) {
+    process.stderr.write('exactly one of --apply or --check is required\n');
+    process.exit(2);
+  }
+  const snapshotPath = values.snapshot as string;
+  const now = values.now ? new Date(values.now as string) : new Date();
+
+  if (apply) {
+    const inPaths = (values.in as string[] | undefined) ?? [];
+    if (inPaths.length === 0) {
+      process.stderr.write(
+        '--apply requires at least one --in <samples.jsonl>\n',
+      );
+      process.exit(2);
+    }
+    readEvents((values.events as string[] | undefined) ?? []);
+    const samples = readSamples(inPaths);
+    const snapshot = aggregateSnapshot(samples, now);
+    writeFileSync(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`);
+    writeRenderedFiles(snapshot);
+    process.stdout.write(
+      `context-tax-report: wrote ${snapshotPath} (n=${snapshot.sampleCount}, publishable=${snapshot.publishable})\n`,
+    );
+  } else {
+    const snapshot = JSON.parse(
+      readFileSync(snapshotPath, 'utf8'),
+    ) as ContextTaxSnapshot;
+    assertContextTaxSnapshot(snapshot);
+    const drifted = checkRenderedFiles(snapshot);
+    if (drifted.length > 0) {
+      process.stderr.write(
+        `context-tax-report --check: drift found:\n${drifted.map((d) => `  - ${d}`).join('\n')}\n`,
+      );
+      process.exit(1);
+    }
+    process.stdout.write('context-tax-report: no drift.\n');
+  }
+}

--- a/src/scripts/context-tax-report.mts
+++ b/src/scripts/context-tax-report.mts
@@ -612,7 +612,16 @@ if (import.meta.main) {
     process.exit(2);
   }
   const snapshotPath = values.snapshot as string;
-  const now = values.now ? new Date(values.now as string) : new Date();
+  let now = new Date();
+  if (values.now) {
+    now = new Date(values.now as string);
+    if (Number.isNaN(now.getTime())) {
+      process.stderr.write(
+        `--now is not a valid ISO8601 timestamp: ${values.now as string}\n`,
+      );
+      process.exit(2);
+    }
+  }
 
   if (apply) {
     const inPaths = (values.in as string[] | undefined) ?? [];

--- a/tests/context-tax-core.test.mts
+++ b/tests/context-tax-core.test.mts
@@ -13,6 +13,24 @@ import {
 } from '../src/scripts/context-tax-core.mts';
 import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
 
+const ZERO_PERCENTILES = { p25: 0, p50: 0, p75: 0 };
+const ZERO_USAGE_PERCENTILES = {
+  inputUncached: ZERO_PERCENTILES,
+  cacheRead: ZERO_PERCENTILES,
+  cacheCreation: ZERO_PERCENTILES,
+  output: ZERO_PERCENTILES,
+  reasoning: ZERO_PERCENTILES,
+};
+const SNAPSHOT_BASE_FIELDS = {
+  asOf: '2026-08-25',
+  totalUsage: ZERO_USAGE_PERCENTILES,
+  stageUsage: [],
+  compactionCount: ZERO_PERCENTILES,
+  cacheHitRatio: 0,
+  successRateByModel: {},
+  successRateByVendor: {},
+};
+
 test('stage id list is the seven IDD stages', () => {
   assert.deepEqual(
     [...CONTEXT_TAX_STAGE_IDS],
@@ -261,6 +279,7 @@ test('assertContextTaxSnapshot rejects duplicate vendors', () => {
     publishable: false,
     sampleCount: 3,
     vendors: ['grok', 'claude'],
+    ...SNAPSHOT_BASE_FIELDS,
   };
   assert.doesNotThrow(() => assertContextTaxSnapshot(snapshot));
   assert.throws(
@@ -278,6 +297,7 @@ test('assertContextTaxSnapshot requires publishable to match the sample/vendor g
     publishable: true,
     sampleCount: 10,
     vendors: ['grok', 'claude'],
+    ...SNAPSHOT_BASE_FIELDS,
   };
   assert.doesNotThrow(() => assertContextTaxSnapshot(eligible));
   assert.throws(
@@ -396,4 +416,141 @@ test('committed sample fixture validates against the sample schema', () => {
     loadJson('schemas/context-tax-sample.schema.json'),
   );
   assert.deepEqual(errors, []);
+});
+
+test('committed snapshot fixture validates against the snapshot schema', () => {
+  const errors = validate(
+    loadJson('fixtures/schemas/context-tax-snapshot.valid.json'),
+    loadJson('schemas/context-tax-snapshot.schema.json'),
+  );
+  assert.deepEqual(errors, []);
+});
+
+test('assertContextTaxSnapshot rejects an out-of-order percentile triple', () => {
+  const snapshot: ContextTaxSnapshot = {
+    schemaVersion: 1,
+    generatedAt: '2026-08-25T00:00:00Z',
+    minPublishableSamples: 10,
+    minPublishableVendors: 2,
+    publishable: false,
+    sampleCount: 3,
+    vendors: ['grok'],
+    ...SNAPSHOT_BASE_FIELDS,
+  };
+  assert.doesNotThrow(() => assertContextTaxSnapshot(snapshot));
+  assert.throws(
+    () =>
+      assertContextTaxSnapshot({
+        ...snapshot,
+        totalUsage: {
+          ...ZERO_USAGE_PERCENTILES,
+          inputUncached: { p25: 100, p50: 50, p75: 200 },
+        },
+      }),
+    /totalUsage\.inputUncached percentiles must satisfy p25 <= p50 <= p75/,
+  );
+  assert.throws(
+    () =>
+      assertContextTaxSnapshot({
+        ...snapshot,
+        compactionCount: { p25: 5, p50: 4, p75: 6 },
+      }),
+    /compactionCount percentiles must satisfy p25 <= p50 <= p75/,
+  );
+  assert.throws(
+    () =>
+      assertContextTaxSnapshot({
+        ...snapshot,
+        stageUsage: [
+          {
+            id: 'work',
+            usage: {
+              ...ZERO_USAGE_PERCENTILES,
+              output: { p25: 10, p50: 20, p75: 15 },
+            },
+          },
+        ],
+      }),
+    /stageUsage\[work\]\.usage\.output percentiles must satisfy p25 <= p50 <= p75/,
+  );
+});
+
+test('assertContextTaxSnapshot rejects cacheHitRatio outside [0, 1]', () => {
+  const snapshot: ContextTaxSnapshot = {
+    schemaVersion: 1,
+    generatedAt: '2026-08-25T00:00:00Z',
+    minPublishableSamples: 10,
+    minPublishableVendors: 2,
+    publishable: false,
+    sampleCount: 3,
+    vendors: ['grok'],
+    ...SNAPSHOT_BASE_FIELDS,
+  };
+  assert.throws(
+    () => assertContextTaxSnapshot({ ...snapshot, cacheHitRatio: 1.1 }),
+    /snapshot cacheHitRatio must be in \[0, 1\]/,
+  );
+  assert.throws(
+    () => assertContextTaxSnapshot({ ...snapshot, cacheHitRatio: -0.1 }),
+    /snapshot cacheHitRatio must be in \[0, 1\]/,
+  );
+});
+
+test('assertContextTaxSnapshot rejects a success rate that disagrees with its own counts', () => {
+  const snapshot: ContextTaxSnapshot = {
+    schemaVersion: 1,
+    generatedAt: '2026-08-25T00:00:00Z',
+    minPublishableSamples: 10,
+    minPublishableVendors: 2,
+    publishable: false,
+    sampleCount: 3,
+    vendors: ['grok'],
+    ...SNAPSHOT_BASE_FIELDS,
+  };
+  assert.doesNotThrow(() =>
+    assertContextTaxSnapshot({
+      ...snapshot,
+      successRateByModel: {
+        'grok-4.6': {
+          merged: 3,
+          aborted: 1,
+          unclaimed: 0,
+          humanHandoff: 0,
+          rate: 0.75,
+        },
+      },
+    }),
+  );
+  assert.throws(
+    () =>
+      assertContextTaxSnapshot({
+        ...snapshot,
+        successRateByModel: {
+          'grok-4.6': {
+            merged: 3,
+            aborted: 1,
+            unclaimed: 0,
+            humanHandoff: 0,
+            rate: 0.5,
+          },
+        },
+      }),
+    /successRateByModel\[grok-4\.6\] rate must equal merged \/ \(merged \+ aborted \+ unclaimed \+ humanHandoff\)/,
+  );
+  assert.throws(
+    () =>
+      assertContextTaxSnapshot({
+        ...snapshot,
+        successRateByVendor: {
+          grok: {
+            merged: 3,
+            aborted: 1,
+            unclaimed: 0,
+            humanHandoff: 0,
+            rate: 1.2,
+          },
+        },
+      }),
+    /successRateByVendor\[grok\] rate must be in \[0, 1\]/,
+  );
 });

--- a/tests/context-tax-core.test.mts
+++ b/tests/context-tax-core.test.mts
@@ -554,3 +554,78 @@ test('assertContextTaxSnapshot rejects a success rate that disagrees with its ow
     /successRateByVendor\[grok\] rate must be in \[0, 1\]/,
   );
 });
+
+test('assertContextTaxSnapshot rejects a schema-valid but nonexistent asOf date', () => {
+  const snapshot: ContextTaxSnapshot = {
+    schemaVersion: 1,
+    generatedAt: '2026-08-25T00:00:00Z',
+    minPublishableSamples: 10,
+    minPublishableVendors: 2,
+    publishable: false,
+    sampleCount: 3,
+    vendors: ['grok'],
+    ...SNAPSHOT_BASE_FIELDS,
+  };
+  assert.doesNotThrow(() => assertContextTaxSnapshot(snapshot));
+  assert.throws(
+    () => assertContextTaxSnapshot({ ...snapshot, asOf: '2026-02-30' }),
+    /snapshot asOf must be a valid UTC calendar date/,
+  );
+  assert.throws(
+    () => assertContextTaxSnapshot({ ...snapshot, asOf: 'not-a-date' }),
+    /snapshot asOf must be a valid UTC calendar date/,
+  );
+});
+
+test('assertContextTaxSnapshot rejects a duplicate stageUsage entry', () => {
+  const snapshot: ContextTaxSnapshot = {
+    schemaVersion: 1,
+    generatedAt: '2026-08-25T00:00:00Z',
+    minPublishableSamples: 10,
+    minPublishableVendors: 2,
+    publishable: false,
+    sampleCount: 3,
+    vendors: ['grok'],
+    ...SNAPSHOT_BASE_FIELDS,
+  };
+  assert.throws(
+    () =>
+      assertContextTaxSnapshot({
+        ...snapshot,
+        stageUsage: [
+          { id: 'work', usage: ZERO_USAGE_PERCENTILES },
+          { id: 'work', usage: ZERO_USAGE_PERCENTILES },
+        ],
+      }),
+    /snapshot stageUsage has a duplicate entry for "work"/,
+  );
+});
+
+test('assertContextTaxSnapshot rejects a successRateByVendor key absent from vendors', () => {
+  const snapshot: ContextTaxSnapshot = {
+    schemaVersion: 1,
+    generatedAt: '2026-08-25T00:00:00Z',
+    minPublishableSamples: 10,
+    minPublishableVendors: 2,
+    publishable: false,
+    sampleCount: 3,
+    vendors: ['grok'],
+    ...SNAPSHOT_BASE_FIELDS,
+  };
+  assert.throws(
+    () =>
+      assertContextTaxSnapshot({
+        ...snapshot,
+        successRateByVendor: {
+          claude: {
+            merged: 1,
+            aborted: 0,
+            unclaimed: 0,
+            humanHandoff: 0,
+            rate: 1,
+          },
+        },
+      }),
+    /successRateByVendor names "claude", which is not present in vendors/,
+  );
+});

--- a/tests/context-tax-report.test.mts
+++ b/tests/context-tax-report.test.mts
@@ -1,0 +1,296 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import type { ContextTaxSample } from '../src/scripts/context-tax-core.mts';
+import {
+  aggregateSnapshot,
+  checkRenderedFiles,
+  readEvents,
+  readSamples,
+  replaceMarkedRegion,
+} from '../src/scripts/context-tax-report.mts';
+
+const NOW = new Date('2026-08-26T00:00:00Z');
+
+const README_START = '<!-- context-tax-readme:start -->';
+const README_END = '<!-- context-tax-readme:end -->';
+const DOCS_START = '<!-- context-tax-docs:start -->';
+const DOCS_END = '<!-- context-tax-docs:end -->';
+
+const UNPUBLISHABLE_EN =
+  'Context-tax measurement is in progress; see\n[`docs/context-tax.md`](docs/context-tax.md) for the methodology.';
+const UNPUBLISHABLE_JA =
+  'コンテキスト税の計測は現在進行中です。詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。';
+const UNPUBLISHABLE_DOCS = 'Not yet publishable, n=0.';
+
+function stubReadmeText(): string {
+  return `# Title\n\n## Proven in production\n\n${README_START}\n\nstub\n\n${README_END}\n\n## Quick Start\n`;
+}
+
+function stubDocsText(): string {
+  return `# Context-Tax Methodology\n\n## Current snapshot\n\n${DOCS_START}\n\nstub\n\n${DOCS_END}\n`;
+}
+
+function issueLoopSample(
+  overrides: Partial<ContextTaxSample> & { issueNumber: number },
+): ContextTaxSample {
+  return {
+    schemaVersion: 1,
+    kind: 'issue-loop',
+    vendor: 'grok',
+    model: 'grok-4.6',
+    attribution: 'marker-join',
+    outcome: 'merged',
+    usage: {
+      inputUncached: 1000,
+      cacheRead: 500,
+      cacheCreation: 50,
+      output: 200,
+      reasoning: 10,
+    },
+    compactionCount: 1,
+    startedAt: '2026-08-25T00:00:00Z',
+    endedAt: '2026-08-25T01:00:00Z',
+    vendorSessionId: `sess-${overrides.issueNumber}`,
+    stages: [
+      {
+        id: 'work',
+        usage: {
+          inputUncached: 500,
+          cacheRead: 200,
+          cacheCreation: 10,
+          output: 100,
+          reasoning: 5,
+        },
+      },
+    ],
+    ...overrides,
+  } as ContextTaxSample;
+}
+
+/** Run `fn` inside a fresh sandbox cwd with README.md/README.ja.md/docs/context-tax.md seeded to the unpublishable stub. */
+function withSandboxCwd(fn: () => void): void {
+  const originalCwd = process.cwd();
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-context-tax-report-test-'));
+  process.chdir(sandbox);
+  try {
+    mkdirSync('docs', { recursive: true });
+    writeFileSync(
+      'README.md',
+      replaceMarkedRegion(
+        stubReadmeText(),
+        README_START,
+        README_END,
+        UNPUBLISHABLE_EN,
+      ),
+    );
+    writeFileSync(
+      'README.ja.md',
+      replaceMarkedRegion(
+        stubReadmeText(),
+        README_START,
+        README_END,
+        UNPUBLISHABLE_JA,
+      ),
+    );
+    writeFileSync(
+      'docs/context-tax.md',
+      replaceMarkedRegion(
+        stubDocsText(),
+        DOCS_START,
+        DOCS_END,
+        UNPUBLISHABLE_DOCS,
+      ),
+    );
+    fn();
+  } finally {
+    process.chdir(originalCwd);
+  }
+}
+
+test('aggregateSnapshot below the publish gate stays unpublishable with n samples', () => {
+  const samples = Array.from({ length: 5 }, (_, i) =>
+    issueLoopSample({ issueNumber: 100 + i, vendor: 'grok' }),
+  );
+  const snapshot = aggregateSnapshot(samples, NOW);
+  assert.equal(snapshot.publishable, false);
+  assert.equal(snapshot.sampleCount, 5);
+  assert.deepEqual(snapshot.vendors, ['grok']);
+});
+
+test('aggregateSnapshot at the gate (10 samples, 2 vendors) is publishable', () => {
+  const samples = Array.from({ length: 10 }, (_, i) =>
+    issueLoopSample({
+      issueNumber: 200 + i,
+      vendor: i % 2 === 0 ? 'grok' : 'claude',
+      usage: {
+        inputUncached: 900 + i * 100,
+        cacheRead: 400,
+        cacheCreation: 40,
+        output: 150,
+        reasoning: 5,
+      },
+    }),
+  );
+  const snapshot = aggregateSnapshot(samples, NOW);
+  assert.equal(snapshot.publishable, true);
+  assert.equal(snapshot.sampleCount, 10);
+  assert.deepEqual(snapshot.vendors, ['claude', 'grok']);
+  // 10 evenly-spaced values from 900 to 1800 (step 100); p50 sits at the
+  // interpolated midpoint between the 5th and 6th sorted values.
+  assert.equal(snapshot.totalUsage.inputUncached.p50, 1350);
+});
+
+test('aggregateSnapshot excludes outcome: unknown and non-issue-loop samples from every figure', () => {
+  const samples: ContextTaxSample[] = [
+    ...Array.from({ length: 9 }, (_, i) =>
+      issueLoopSample({ issueNumber: 300 + i, vendor: 'grok' }),
+    ),
+    issueLoopSample({ issueNumber: 400, vendor: 'claude', outcome: 'unknown' }),
+    {
+      schemaVersion: 1,
+      kind: 'session',
+      vendor: 'codex',
+      model: 'gpt-test',
+      attribution: 'session-unscoped',
+      outcome: 'merged',
+      usage: {
+        inputUncached: 1,
+        cacheRead: 1,
+        cacheCreation: 1,
+        output: 1,
+        reasoning: 1,
+      },
+      compactionCount: 0,
+      startedAt: '2026-08-25T00:00:00Z',
+      endedAt: '2026-08-25T01:00:00Z',
+      vendorSessionId: 'sess-session-only',
+    },
+  ];
+  const snapshot = aggregateSnapshot(samples, NOW);
+  // Only the 9 issue-loop/non-unknown grok samples count: gate not met.
+  assert.equal(snapshot.sampleCount, 9);
+  assert.deepEqual(snapshot.vendors, ['grok']);
+});
+
+test('aggregateSnapshot computes cache-hit ratio and per-model/vendor success rates', () => {
+  const samples = [
+    ...Array.from({ length: 6 }, (_, i) =>
+      issueLoopSample({
+        issueNumber: 500 + i,
+        vendor: 'grok',
+        model: 'grok-4.6',
+        outcome: 'merged',
+      }),
+    ),
+    ...Array.from({ length: 2 }, (_, i) =>
+      issueLoopSample({
+        issueNumber: 510 + i,
+        vendor: 'grok',
+        model: 'grok-4.6',
+        outcome: 'aborted',
+      }),
+    ),
+    ...Array.from({ length: 4 }, (_, i) =>
+      issueLoopSample({
+        issueNumber: 520 + i,
+        vendor: 'claude',
+        model: 'claude-opus',
+        outcome: 'merged',
+      }),
+    ),
+  ];
+  const snapshot = aggregateSnapshot(samples, NOW);
+  assert.equal(snapshot.sampleCount, 12);
+  // cacheRead=500, cacheCreation=50, inputUncached=1000 for every sample.
+  assert.equal(snapshot.cacheHitRatio, 500 / (500 + 50 + 1000));
+  assert.equal(snapshot.successRateByModel['grok-4.6'].merged, 6);
+  assert.equal(snapshot.successRateByModel['grok-4.6'].aborted, 2);
+  assert.equal(snapshot.successRateByModel['grok-4.6'].rate, 6 / 8);
+  assert.equal(snapshot.successRateByVendor.claude?.rate, 1);
+});
+
+test('readSamples rejects a malformed line', () => {
+  withSandboxCwd(() => {
+    writeFileSync(
+      'samples.jsonl',
+      `${JSON.stringify(issueLoopSample({ issueNumber: 1 }))}\nnot json\n`,
+    );
+    assert.throws(() => readSamples(['samples.jsonl']));
+  });
+});
+
+test('readEvents rejects a non-object line', () => {
+  withSandboxCwd(() => {
+    writeFileSync('events.jsonl', '"just a string"\n');
+    assert.throws(() => readEvents(['events.jsonl']), /not a JSON object/);
+  });
+});
+
+test('replaceMarkedRegion swaps only the content between the markers', () => {
+  const text = `before\n${README_START}\nold\n${README_END}\nafter`;
+  const result = replaceMarkedRegion(
+    text,
+    README_START,
+    README_END,
+    'new content',
+  );
+  assert.match(result, /before/);
+  assert.match(result, /after/);
+  assert.doesNotMatch(result, /old/);
+  assert.match(result, /new content/);
+});
+
+test('replaceMarkedRegion throws when a marker is missing', () => {
+  assert.throws(
+    () => replaceMarkedRegion('no markers here', README_START, README_END, 'x'),
+    /marked region .* not found/,
+  );
+});
+
+test('checkRenderedFiles reports no drift when regions match the unpublishable stub', () => {
+  withSandboxCwd(() => {
+    const snapshot = aggregateSnapshot([], NOW);
+    const drifted = checkRenderedFiles(snapshot);
+    assert.deepEqual(drifted, []);
+  });
+});
+
+test('checkRenderedFiles reports drift when a README region is mutated without updating the snapshot', () => {
+  withSandboxCwd(() => {
+    const snapshot = aggregateSnapshot([], NOW);
+    writeFileSync(
+      'README.md',
+      replaceMarkedRegion(
+        stubReadmeText(),
+        README_START,
+        README_END,
+        'hand-edited, does not match the snapshot',
+      ),
+    );
+    const drifted = checkRenderedFiles(snapshot);
+    assert.equal(drifted.length, 1);
+    assert.match(drifted[0], /README\.md/);
+  });
+});
+
+test('checkRenderedFiles reports drift when the docs table region is mutated without updating the snapshot', () => {
+  withSandboxCwd(() => {
+    const snapshot = aggregateSnapshot([], NOW);
+    writeFileSync(
+      'docs/context-tax.md',
+      replaceMarkedRegion(
+        stubDocsText(),
+        DOCS_START,
+        DOCS_END,
+        'hand-edited table',
+      ),
+    );
+    const drifted = checkRenderedFiles(snapshot);
+    assert.equal(drifted.length, 1);
+    assert.match(drifted[0], /context-tax\.md/);
+  });
+});

--- a/tests/context-tax-report.test.mts
+++ b/tests/context-tax-report.test.mts
@@ -10,6 +10,9 @@ import {
   checkRenderedFiles,
   readEvents,
   readSamples,
+  renderDocsTableRegion,
+  renderReadmeRegionEn,
+  renderReadmeRegionJa,
   replaceMarkedRegion,
 } from '../src/scripts/context-tax-report.mts';
 
@@ -23,7 +26,7 @@ const DOCS_END = '<!-- context-tax-docs:end -->';
 const UNPUBLISHABLE_EN =
   'Context-tax measurement is in progress; see\n[`docs/context-tax.md`](docs/context-tax.md) for the methodology.';
 const UNPUBLISHABLE_JA =
-  'コンテキスト税の計測は現在進行中です。詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。';
+  'コンテキスト税の計測は現在進行中です。\n詳しい方法論は [`docs/context-tax.md`](docs/context-tax.md) を参照してください。';
 const UNPUBLISHABLE_DOCS = 'Not yet publishable, n=0.';
 
 function stubReadmeText(): string {
@@ -258,23 +261,6 @@ test("aggregateSnapshot cacheHitRatio is the median of each sample's own ratio, 
   assert.equal(snapshot.cacheHitRatio, 0.5);
 });
 
-test('readSamples rejects a malformed line', () => {
-  withSandboxCwd(() => {
-    writeFileSync(
-      'samples.jsonl',
-      `${JSON.stringify(issueLoopSample({ issueNumber: 1 }))}\nnot json\n`,
-    );
-    assert.throws(() => readSamples(['samples.jsonl']));
-  });
-});
-
-test('readEvents rejects a non-object line', () => {
-  withSandboxCwd(() => {
-    writeFileSync('events.jsonl', '"just a string"\n');
-    assert.throws(() => readEvents(['events.jsonl']), /not a JSON object/);
-  });
-});
-
 test('replaceMarkedRegion swaps only the content between the markers', () => {
   const text = `before\n${README_START}\nold\n${README_END}\nafter`;
   const result = replaceMarkedRegion(
@@ -337,5 +323,95 @@ test('checkRenderedFiles reports drift when the docs table region is mutated wit
     const drifted = checkRenderedFiles(snapshot);
     assert.equal(drifted.length, 1);
     assert.match(drifted[0], /context-tax\.md/);
+  });
+});
+
+test('renderReadmeRegionEn/Ja never exceed markdownlint MD013 line length (80) even with large dynamic values', () => {
+  // Deliberately large-magnitude figures, well beyond any realistic
+  // sample, to guard against a future regression once real data flows
+  // through this path (#2294's snapshot data is currently only a
+  // synthetic n=0 stub).
+  const samples = Array.from({ length: 12 }, (_, i) =>
+    issueLoopSample({
+      issueNumber: 800 + i,
+      vendor: i % 2 === 0 ? 'grok' : 'claude',
+      usage: {
+        inputUncached: 1234567,
+        cacheRead: 234567,
+        cacheCreation: 3456,
+        output: 4567,
+        reasoning: 567,
+      },
+      compactionCount: 4321,
+    }),
+  );
+  const snapshot = aggregateSnapshot(samples, NOW);
+  assert.equal(snapshot.publishable, true);
+  for (const line of renderReadmeRegionEn(snapshot).split('\n')) {
+    assert.ok(
+      line.length <= 80,
+      `EN line exceeds 80 chars: "${line}" (${line.length})`,
+    );
+  }
+  for (const line of renderReadmeRegionJa(snapshot).split('\n')) {
+    assert.ok(
+      line.length <= 80,
+      `JA line exceeds 80 chars: "${line}" (${line.length})`,
+    );
+  }
+});
+
+test('renderDocsTableRegion includes per-stage usage and success-rate breakdowns when publishable', () => {
+  const samples = Array.from({ length: 10 }, (_, i) =>
+    issueLoopSample({
+      issueNumber: 700 + i,
+      vendor: i % 2 === 0 ? 'grok' : 'claude',
+      model: 'grok-4.6',
+      outcome: i < 9 ? 'merged' : 'aborted',
+    }),
+  );
+  const snapshot = aggregateSnapshot(samples, NOW);
+  assert.equal(snapshot.publishable, true);
+  const rendered = renderDocsTableRegion(snapshot);
+  assert.match(rendered, /### Total usage/);
+  assert.match(rendered, /### By stage \(inputUncached\)/);
+  assert.match(rendered, /\| work \|/);
+  assert.match(rendered, /### Success rate by model/);
+  assert.match(rendered, /\| grok-4\.6 \| 9 \| 1 \| 0 \| 0 \| 90\.0% \|/);
+  assert.match(rendered, /### Success rate by vendor/);
+});
+
+test('replaceMarkedRegion searches for the end marker only after the start marker', () => {
+  const text = `${README_END}\nnoise\n${README_START}\nold\n${README_END}\nafter`;
+  const result = replaceMarkedRegion(text, README_START, README_END, 'new');
+  // The first line (a stray END marker before START) must be left alone;
+  // only the pair after START should be replaced.
+  assert.match(result, new RegExp(`^${README_END}\\nnoise\\n${README_START}`));
+  assert.equal(
+    result,
+    `${README_END}\nnoise\n${README_START}\n\nnew\n\n${README_END}\nafter`,
+  );
+});
+
+test('readSamples reports the source path and line number on invalid JSON', () => {
+  withSandboxCwd(() => {
+    writeFileSync(
+      'samples.jsonl',
+      `${JSON.stringify(issueLoopSample({ issueNumber: 1 }))}\nnot json\n`,
+    );
+    assert.throws(
+      () => readSamples(['samples.jsonl']),
+      /samples\.jsonl:2: invalid JSON/,
+    );
+  });
+});
+
+test('readEvents reports the source path and line number on a non-object line', () => {
+  withSandboxCwd(() => {
+    writeFileSync('events.jsonl', '{}\n"just a string"\n');
+    assert.throws(
+      () => readEvents(['events.jsonl']),
+      /events\.jsonl:2: event line is not a JSON object/,
+    );
   });
 });

--- a/tests/context-tax-report.test.mts
+++ b/tests/context-tax-report.test.mts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import type { ContextTaxSample } from '../src/scripts/context-tax-core.mts';
 import {
@@ -15,6 +17,8 @@ import {
   renderReadmeRegionJa,
   replaceMarkedRegion,
 } from '../src/scripts/context-tax-report.mts';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
 const NOW = new Date('2026-08-26T00:00:00Z');
 
@@ -413,5 +417,33 @@ test('readEvents reports the source path and line number on a non-object line', 
       () => readEvents(['events.jsonl']),
       /events\.jsonl:2: event line is not a JSON object/,
     );
+  });
+});
+
+test('CLI: --now rejects an invalid timestamp with a clean usage error, not a raw exception', () => {
+  withSandboxCwd(() => {
+    let threw = false;
+    try {
+      execFileSync(
+        process.execPath,
+        [
+          join(REPO_ROOT, 'scripts/context-tax-report.mjs'),
+          '--check',
+          '--now',
+          'not-a-date',
+        ],
+        { encoding: 'utf8', stdio: 'pipe' },
+      );
+    } catch (error) {
+      threw = true;
+      const e = error as { status: number; stderr: string };
+      assert.equal(e.status, 2);
+      assert.match(
+        e.stderr,
+        /--now is not a valid ISO8601 timestamp: not-a-date/,
+      );
+      assert.doesNotMatch(e.stderr, /RangeError|Invalid time value/);
+    }
+    assert.ok(threw, 'expected the CLI to exit non-zero');
   });
 });

--- a/tests/context-tax-report.test.mts
+++ b/tests/context-tax-report.test.mts
@@ -213,6 +213,51 @@ test('aggregateSnapshot computes cache-hit ratio and per-model/vendor success ra
   assert.equal(snapshot.successRateByVendor.claude?.rate, 1);
 });
 
+test("aggregateSnapshot cacheHitRatio is the median of each sample's own ratio, not the ratio of independent medians", () => {
+  // Three samples with wildly different per-sample cache-hit ratios:
+  // 0.0, 0.5, and 1.0. The ratio-of-medians bug this test guards against
+  // would divide the p50 of each usage field independently -- which,
+  // because each field's median can come from a different sample, need
+  // not equal any real sample's own ratio.
+  const samples = [
+    issueLoopSample({
+      issueNumber: 600,
+      usage: {
+        inputUncached: 1000,
+        cacheRead: 0,
+        cacheCreation: 0,
+        output: 1,
+        reasoning: 1,
+      },
+    }),
+    issueLoopSample({
+      issueNumber: 601,
+      usage: {
+        inputUncached: 500,
+        cacheRead: 500,
+        cacheCreation: 0,
+        output: 1,
+        reasoning: 1,
+      },
+    }),
+    issueLoopSample({
+      issueNumber: 602,
+      usage: {
+        inputUncached: 0,
+        cacheRead: 1000,
+        cacheCreation: 0,
+        output: 1,
+        reasoning: 1,
+      },
+    }),
+  ];
+  const snapshot = aggregateSnapshot(samples, NOW);
+  assert.equal(snapshot.sampleCount, 3);
+  // Per-sample ratios sorted: [0, 0.5, 1] -> median 0.5, matching the
+  // middle sample's own ratio exactly.
+  assert.equal(snapshot.cacheHitRatio, 0.5);
+});
+
 test('readSamples rejects a malformed line', () => {
   withSandboxCwd(() => {
     writeFileSync(

--- a/tests/help-text-flags.test.mts
+++ b/tests/help-text-flags.test.mts
@@ -173,6 +173,7 @@ const COVERED_HELPERS = [
   'ci-wait-state',
   'claim-approval-gate',
   'claim-lock',
+  'context-tax-report',
   'discover-readiness-check',
   'discover-shared-file-overlap',
   'discover-viability-gate',

--- a/tests/helper-invocation-profile.test.mts
+++ b/tests/helper-invocation-profile.test.mts
@@ -89,6 +89,14 @@ const SOURCE_REPO_INTERNAL_ENTRY_PATHS = new Set([
   // check-untracked-artifacts.mjs: `build:check`-internal verification
   // tooling (see docs/typescript-sources.md), never adopter-facing.
   'scripts/check-untracked-artifacts.mjs',
+  // context-tax-report.mjs (#2294): this repository's own dogfood
+  // measurement reporter, invoked from `.github/idd/config.json`'s
+  // `pre-push-validate`/`post-fix-validate` and named in
+  // docs/context-tax.md. It reads only local, ungitted JSONL under
+  // `~/.grok`/`~/.claude`/`~/.codex` and is never distributed to
+  // idd-template/ -- an adopter repository has no context-tax data to
+  // report.
+  'scripts/context-tax-report.mjs',
 ]);
 
 // A helper name that appears only as a *proposed*, not-yet-built script

--- a/tests/helper-invocation-profile.test.mts
+++ b/tests/helper-invocation-profile.test.mts
@@ -90,11 +90,10 @@ const SOURCE_REPO_INTERNAL_ENTRY_PATHS = new Set([
   // tooling (see docs/typescript-sources.md), never adopter-facing.
   'scripts/check-untracked-artifacts.mjs',
   // context-tax-report.mjs (#2294): this repository's own dogfood
-  // measurement reporter, invoked from `.github/idd/config.json`'s
-  // `pre-push-validate`/`post-fix-validate` and named in
-  // docs/context-tax.md. It reads only local, ungitted JSONL under
-  // `~/.grok`/`~/.claude`/`~/.codex` and is never distributed to
-  // idd-template/ -- an adopter repository has no context-tax data to
+  // measurement reporter, named in docs/context-tax.md's own usage
+  // examples. It reads only local JSONL under `~/.grok`/`~/.claude`/
+  // `~/.codex` -- never committed to git -- and is never distributed to
+  // idd-template/; an adopter repository has no context-tax data to
   // report.
   'scripts/context-tax-report.mjs',
 ]);

--- a/tests/helper-runtime-manifest.test.mts
+++ b/tests/helper-runtime-manifest.test.mts
@@ -723,12 +723,6 @@ const DOGFOOD_ONLY_CONCRETE_TOOLS = new Set([
   'scripts/verify-install-deps.mjs',
   'scripts/audit-docs.mjs',
   'scripts/audit-code-span-wrap.mjs',
-  // context-tax-report.mjs (#2294): dogfood-only reporter concreted into
-  // this repository's own pre-push-validate/post-fix-validate rows, same
-  // reason as the four entries above -- see
-  // tests/helper-invocation-profile.test.mts's SOURCE_REPO_INTERNAL_ENTRY_PATHS
-  // for the fuller justification.
-  'scripts/context-tax-report.mjs',
 ]);
 
 // Collect every helper the instruction files tell adopters to RUN as

--- a/tests/helper-runtime-manifest.test.mts
+++ b/tests/helper-runtime-manifest.test.mts
@@ -723,6 +723,12 @@ const DOGFOOD_ONLY_CONCRETE_TOOLS = new Set([
   'scripts/verify-install-deps.mjs',
   'scripts/audit-docs.mjs',
   'scripts/audit-code-span-wrap.mjs',
+  // context-tax-report.mjs (#2294): dogfood-only reporter concreted into
+  // this repository's own pre-push-validate/post-fix-validate rows, same
+  // reason as the four entries above -- see
+  // tests/helper-invocation-profile.test.mts's SOURCE_REPO_INTERNAL_ENTRY_PATHS
+  // for the fuller justification.
+  'scripts/context-tax-report.mjs',
 ]);
 
 // Collect every helper the instruction files tell adopters to RUN as

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -454,6 +454,13 @@ export const contextTaxSnapshotKeys = [
   'publishable',
   'sampleCount',
   'vendors',
+  'asOf',
+  'totalUsage',
+  'stageUsage',
+  'compactionCount',
+  'cacheHitRatio',
+  'successRateByModel',
+  'successRateByVendor',
 ] as const satisfies readonly (keyof ContextTaxSnapshot)[];
 
 export const policyConfigKeys = [
@@ -991,6 +998,15 @@ const contextTaxEventFixture = {
   vendor: 'claude',
 } satisfies ContextTaxEvent;
 
+const contextTaxZeroPercentiles = { p25: 0, p50: 0, p75: 0 };
+const contextTaxZeroUsagePercentiles = {
+  inputUncached: contextTaxZeroPercentiles,
+  cacheRead: contextTaxZeroPercentiles,
+  cacheCreation: contextTaxZeroPercentiles,
+  output: contextTaxZeroPercentiles,
+  reasoning: contextTaxZeroPercentiles,
+};
+
 const contextTaxSnapshotFixture = {
   schemaVersion: 1,
   generatedAt: '2026-08-25T16:00:00Z',
@@ -999,6 +1015,13 @@ const contextTaxSnapshotFixture = {
   publishable: false,
   sampleCount: 0,
   vendors: [],
+  asOf: '2026-08-25',
+  totalUsage: contextTaxZeroUsagePercentiles,
+  stageUsage: [],
+  compactionCount: contextTaxZeroPercentiles,
+  cacheHitRatio: 0,
+  successRateByModel: {},
+  successRateByVendor: {},
 } satisfies ContextTaxSnapshot;
 
 const policyConfigFixture = {


### PR DESCRIPTION
## Summary

- Adds `context-tax-report.mjs` (`--in`/`--apply` aggregates local JSONL samples into a committed snapshot and renders README/docs regions from fixed templates; `--check` verifies committed regions have not drifted).
- Extends the `#2288` snapshot contract (schema + `ContextTaxSnapshot` type) with percentiles, cache-hit ratio, and success-rate fields.
- Adds the `docs/context-tax.md` methodology page and an initial unpublished (`n=0`) snapshot.
- Adds `<!-- context-tax-readme:start/end -->` stub regions to `README.md`/`README.ja.md`.

## Deliberately deferred

Wiring `--check` into this repository's `pre-push-validate`/`post-fix-validate` command chain, as the issue's "Dogfood CI wiring" section proposed. Growing the shared Project commands table by the ~94 bytes both rows need pushes the `bundle-work` documentation context-ceiling bundle (idd-overview-appendix + idd-overview-core + idd-work) from ~97.97% to 98.18%, past its 98% hard-error threshold — and the only bundle-work bytes not sourced from `idd-template/` are already fully used.

Every path to recover headroom (trimming `idd-template/` prose, raising `context-ceiling-128k.maxBundleLimitBytes`, or adding `bundle-work` to `exemptBundles`) either violates this issue's own "No idd-template/ instruction edits" acceptance criterion or is a documentation-budget governance change outside a reporter issue's scope. `--check` remains fully usable as a direct/manual invocation, and this is called out explicitly in `docs/context-tax.md` as a deferred follow-up.

Refs #2294

## Test plan

- [x] `pnpm run lint:minimum` passes (3951 tests, 0 issues)
- [x] `node scripts/context-tax-report.mjs --check` passes against the committed stub snapshot
- [x] `node scripts/context-tax-report.mjs --help` renders usage
- [x] Manual smoke test of `--apply` with a synthetic 12-sample fixture (publishable path), reverted before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a maintainer-only context-cost reporting workflow with snapshot generation, validation, and documentation updates.
  * Added metrics for usage percentiles, stages, compaction, cache performance, and success rates.
  * Added English and Japanese README references explaining the measurement approach.

* **Documentation**
  * Added context-cost measurement guidance, privacy details, reporting criteria, and current snapshot status.

* **Tests**
  * Expanded coverage for snapshot validation, aggregation, malformed input, documentation drift, and command-line behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->