### PR TITLE
feat(context-tax): parse Codex rollout usage into samples

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,6 +30,7 @@ scripts/cli-args.mjs linguist-generated=true
 scripts/code-span-wrap.mjs linguist-generated=true
 scripts/collaborator-permission.mjs linguist-generated=true
 scripts/consistency-helpers.mjs linguist-generated=true
+scripts/context-tax-adapter-codex.mjs linguist-generated=true
 scripts/context-tax-core.mjs linguist-generated=true
 scripts/context-tax-report.mjs linguist-generated=true
 scripts/discover-orphan-filter.mjs linguist-generated=true

--- a/scripts/context-tax-adapter-codex.mjs
+++ b/scripts/context-tax-adapter-codex.mjs
@@ -92,7 +92,10 @@ function deriveFallbackSessionId(fileBasename) {
   if (!fileBasename) {
     return undefined;
   }
-  const stripped = fileBasename.replace(/\.jsonl$/i, '');
+  // basename() first: a caller-supplied fileBasename is never trusted to
+  // already be path-free, so a full path here would otherwise redact
+  // away as PATH_LIKE and fail closed downstream instead of just here.
+  const stripped = basename(fileBasename).replace(/\.jsonl$/i, '');
   return stripped.length > 0 ? stripped : undefined;
 }
 /** Most recently reported `payload.model` string across every record, or undefined when none exists. */
@@ -293,11 +296,16 @@ export function scanCodexSessions(options) {
     .sort();
   const results = [];
   for (const file of files) {
-    const records = parseCodexRolloutLines(readFileSync(file, 'utf8'));
-    if (!isIddSkillCwd(extractSessionCwd(records))) {
-      continue;
-    }
+    // Read, parse, cwd-filter, and harvest all live inside one try: Codex
+    // rotates/deletes rollout files while sessions run, so readFileSync
+    // itself can throw (ENOENT/EACCES) between globSync and this line,
+    // not only harvest() on malformed content -- either failure must
+    // skip just this one file, never abort the whole scan.
     try {
+      const records = parseCodexRolloutLines(readFileSync(file, 'utf8'));
+      if (!isIddSkillCwd(extractSessionCwd(records))) {
+        continue;
+      }
       results.push(
         codexAdapter.harvest({
           records,

--- a/scripts/context-tax-adapter-codex.mjs
+++ b/scripts/context-tax-adapter-codex.mjs
@@ -1,0 +1,310 @@
+// idd-generated-from: src/scripts/context-tax-adapter-codex.mts
+//
+// The scripts/context-tax-adapter-codex.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source,
+// never the generated .mjs. See docs/typescript-sources.md.
+//
+// Codex CLI adapter (#2291) for the context-tax measurement contract
+// (#2288). Source-repo only: not HELPER_COMMANDS, not idd-template/. A
+// pure library module -- no CLI, no shebang, mirroring
+// context-tax-core.mts's own shape -- so it needs no HELPER_COMMANDS
+// registration or SOURCE_REPO_INTERNAL_ENTRY_PATHS entry.
+//
+// Reads Codex CLI rollout files
+// (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`), each a newline-
+// delimited stream of `{ timestamp, type, payload }` lines. This module
+// documents the specific record shapes it reads (`session_meta`,
+// `turn_context`, `token_count`, `compacted`) as local structural types;
+// only the fields actually consumed are declared, and every extraction
+// degrades gracefully (never throws) except when the harvested session
+// has no usable timestamp at all, which fails closed as a malformed
+// rollout.
+import { globSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
+import {
+  assertContextTaxSample,
+  inferIssueNumberFromBasename,
+  redactContextTaxRecord,
+} from './context-tax-core.mjs';
+
+function isPlainObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+function getPayload(record) {
+  if (!isPlainObject(record)) {
+    return undefined;
+  }
+  const payload = record.payload;
+  return isPlainObject(payload) ? payload : undefined;
+}
+function getStringField(obj, key) {
+  const value = obj?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+function getObjectField(obj, key) {
+  const value = obj?.[key];
+  return isPlainObject(value) ? value : undefined;
+}
+function isRecordOfType(record, type) {
+  return isPlainObject(record) && record.type === type;
+}
+function findRecordByType(records, type) {
+  return records.find((record) => isRecordOfType(record, type));
+}
+/** Parse a Codex rollout JSONL file's text into raw, untyped records, tolerating a malformed or truncated trailing line from an interrupted process (unlike context-tax-report.mts's committed-artifact strict parse, this reads real local logs outside this repo's control). */
+export function parseCodexRolloutLines(text) {
+  const out = [];
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (line.length === 0) {
+      continue;
+    }
+    try {
+      out.push(JSON.parse(line));
+    } catch {}
+  }
+  return out;
+}
+/** The session's working directory, from `session_meta.payload.cwd` first, falling back to any record carrying a `payload.cwd` string. */
+export function extractSessionCwd(records) {
+  const sessionMeta = findRecordByType(records, 'session_meta');
+  const fromMeta = getStringField(getPayload(sessionMeta), 'cwd');
+  if (fromMeta) {
+    return fromMeta;
+  }
+  for (const record of records) {
+    const cwd = getStringField(getPayload(record), 'cwd');
+    if (cwd) {
+      return cwd;
+    }
+  }
+  return undefined;
+}
+/** Whether a session's cwd names an idd-skill worktree or clone. */
+export function isIddSkillCwd(cwd) {
+  return typeof cwd === 'string' && cwd.includes('idd-skill');
+}
+function extractSessionId(sessionMeta) {
+  return getStringField(getPayload(sessionMeta), 'id');
+}
+function deriveFallbackSessionId(fileBasename) {
+  if (!fileBasename) {
+    return undefined;
+  }
+  const stripped = fileBasename.replace(/\.jsonl$/i, '');
+  return stripped.length > 0 ? stripped : undefined;
+}
+/** Most recently reported `payload.model` string across every record, or undefined when none exists. */
+function extractModel(records) {
+  let model;
+  for (const record of records) {
+    const candidate = getStringField(getPayload(record), 'model');
+    if (candidate) {
+      model = candidate;
+    }
+  }
+  return model;
+}
+function toValidTimestamp(value) {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  return Number.isFinite(Date.parse(value)) ? value : undefined;
+}
+/** First and last valid record `timestamp` fields, in file order. Undefined when no record has one. */
+function extractTimestamps(records) {
+  let startedAt;
+  let endedAt;
+  for (const record of records) {
+    if (!isPlainObject(record)) {
+      continue;
+    }
+    const ts = toValidTimestamp(record.timestamp);
+    if (!ts) {
+      continue;
+    }
+    if (startedAt === undefined) {
+      startedAt = ts;
+    }
+    endedAt = ts;
+  }
+  return startedAt !== undefined && endedAt !== undefined
+    ? { startedAt, endedAt }
+    : undefined;
+}
+function toNonNegativeInt(value) {
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : 0;
+}
+/**
+ * Map one `token_count` payload's raw fields to {@link ContextTaxUsage}.
+ * `input_tokens` may already include the cache reads/writes it reports
+ * separately (an inclusive total) or may already exclude them
+ * (already-uncached) -- Codex CLI does not flag which. Mirrors the Grok
+ * adapter's inclusive-check: when `input_tokens >= cacheRead +
+ * cacheCreation`, the total is inclusive, so `inputUncached` is the
+ * remainder after subtracting both; otherwise `input_tokens` is already
+ * exclusive of cache and is used as `inputUncached` directly.
+ */
+function usageFromTokenCounts(raw) {
+  const inputTokens = toNonNegativeInt(raw.input_tokens);
+  const cacheRead = toNonNegativeInt(raw.cached_input_tokens);
+  const cacheCreation = toNonNegativeInt(raw.cache_write_input_tokens);
+  const inputUncached =
+    inputTokens >= cacheRead + cacheCreation
+      ? inputTokens - cacheRead - cacheCreation
+      : inputTokens;
+  return {
+    inputUncached,
+    cacheRead,
+    cacheCreation,
+    output: toNonNegativeInt(raw.output_tokens),
+    reasoning: toNonNegativeInt(raw.reasoning_output_tokens),
+  };
+}
+const ZERO_USAGE = {
+  inputUncached: 0,
+  cacheRead: 0,
+  cacheCreation: 0,
+  output: 0,
+  reasoning: 0,
+};
+function addUsage(a, b) {
+  return {
+    inputUncached: a.inputUncached + b.inputUncached,
+    cacheRead: a.cacheRead + b.cacheRead,
+    cacheCreation: a.cacheCreation + b.cacheCreation,
+    output: a.output + b.output,
+    reasoning: a.reasoning + b.reasoning,
+  };
+}
+/**
+ * Prefer the latest `token_count` payload's `total_token_usage` snapshot
+ * (a cumulative total) when any `token_count` record carries one;
+ * otherwise sum every record's `last_token_usage` (per-event deltas). A
+ * session with no `token_count` records at all yields all-zero usage,
+ * which is a valid, publishable-gate-excluded sample, not an error.
+ */
+function extractUsage(records) {
+  const tokenCountPayloads = [];
+  for (const record of records) {
+    if (isRecordOfType(record, 'token_count')) {
+      const payload = getPayload(record);
+      if (payload) {
+        tokenCountPayloads.push(payload);
+      }
+    }
+  }
+  for (let i = tokenCountPayloads.length - 1; i >= 0; i--) {
+    const total = getObjectField(tokenCountPayloads[i], 'total_token_usage');
+    if (total) {
+      return usageFromTokenCounts(total);
+    }
+  }
+  let summed = ZERO_USAGE;
+  for (const payload of tokenCountPayloads) {
+    const last = getObjectField(payload, 'last_token_usage');
+    if (last) {
+      summed = addUsage(summed, usageFromTokenCounts(last));
+    }
+  }
+  return summed;
+}
+function countCompactions(records) {
+  let count = 0;
+  for (const record of records) {
+    if (isRecordOfType(record, 'compacted')) {
+      count += 1;
+    }
+  }
+  return count;
+}
+function asCodexHarvestInput(input) {
+  if (!isPlainObject(input) || !Array.isArray(input.records)) {
+    throw new Error(
+      'context-tax-adapter-codex: harvest input must be { records: unknown[] }',
+    );
+  }
+  const fileBasename =
+    typeof input.fileBasename === 'string' ? input.fileBasename : undefined;
+  return { records: input.records, fileBasename };
+}
+/** Codex CLI vendor adapter. `input` must satisfy {@link CodexHarvestInput}. */
+export const codexAdapter = {
+  harvest(input) {
+    const { records, fileBasename } = asCodexHarvestInput(input);
+    const sessionMeta = findRecordByType(records, 'session_meta');
+    const vendorSessionId =
+      extractSessionId(sessionMeta) ?? deriveFallbackSessionId(fileBasename);
+    if (!vendorSessionId) {
+      throw new Error(
+        'context-tax-adapter-codex: unable to determine a vendorSessionId',
+      );
+    }
+    const timestamps = extractTimestamps(records);
+    if (!timestamps) {
+      throw new Error(
+        'context-tax-adapter-codex: no record has a valid timestamp',
+      );
+    }
+    const cwd = extractSessionCwd(records);
+    const issueNumber = cwd
+      ? inferIssueNumberFromBasename(basename(cwd))
+      : undefined;
+    const sample = {
+      schemaVersion: 1,
+      kind: 'session',
+      vendor: 'codex',
+      model: extractModel(records) ?? 'unknown',
+      attribution: 'session-unscoped',
+      outcome: 'unknown',
+      usage: extractUsage(records),
+      compactionCount: countCompactions(records),
+      startedAt: timestamps.startedAt,
+      endedAt: timestamps.endedAt,
+      vendorSessionId,
+    };
+    const redacted = redactContextTaxRecord(sample);
+    assertContextTaxSample(redacted);
+    return issueNumber === undefined
+      ? { sample: redacted }
+      : { sample: redacted, joinHints: { issueNumber } };
+  },
+};
+/** `~/.codex/sessions`, the default rollout root. */
+export function defaultCodexSessionsDir() {
+  return join(homedir(), '.codex', 'sessions');
+}
+/**
+ * Scan `sessionsDir` (default `~/.codex/sessions`) for
+ * `**\/rollout-*.jsonl` files, keep only sessions whose cwd names an
+ * idd-skill worktree or clone, and harvest each into a
+ * {@link ContextTaxAdapterResult}.
+ */
+export function scanCodexSessions(options) {
+  const sessionsDir = options?.sessionsDir ?? defaultCodexSessionsDir();
+  const files = globSync('**/rollout-*.jsonl', {
+    cwd: sessionsDir,
+    withFileTypes: true,
+  })
+    .filter((entry) => entry.isFile())
+    .map((entry) => join(entry.parentPath, entry.name))
+    .sort();
+  const results = [];
+  for (const file of files) {
+    const records = parseCodexRolloutLines(readFileSync(file, 'utf8'));
+    if (!isIddSkillCwd(extractSessionCwd(records))) {
+      continue;
+    }
+    try {
+      results.push(
+        codexAdapter.harvest({
+          records,
+          fileBasename: basename(file),
+        }),
+      );
+    } catch {}
+  }
+  return results;
+}

--- a/src/scripts/context-tax-adapter-codex.mts
+++ b/src/scripts/context-tax-adapter-codex.mts
@@ -134,7 +134,10 @@ function deriveFallbackSessionId(
   if (!fileBasename) {
     return undefined;
   }
-  const stripped = fileBasename.replace(/\.jsonl$/i, '');
+  // basename() first: a caller-supplied fileBasename is never trusted to
+  // already be path-free, so a full path here would otherwise redact
+  // away as PATH_LIKE and fail closed downstream instead of just here.
+  const stripped = basename(fileBasename).replace(/\.jsonl$/i, '');
   return stripped.length > 0 ? stripped : undefined;
 }
 
@@ -367,11 +370,16 @@ export function scanCodexSessions(
 
   const results: ContextTaxAdapterResult[] = [];
   for (const file of files) {
-    const records = parseCodexRolloutLines(readFileSync(file, 'utf8'));
-    if (!isIddSkillCwd(extractSessionCwd(records))) {
-      continue;
-    }
+    // Read, parse, cwd-filter, and harvest all live inside one try: Codex
+    // rotates/deletes rollout files while sessions run, so readFileSync
+    // itself can throw (ENOENT/EACCES) between globSync and this line,
+    // not only harvest() on malformed content -- either failure must
+    // skip just this one file, never abort the whole scan.
     try {
+      const records = parseCodexRolloutLines(readFileSync(file, 'utf8'));
+      if (!isIddSkillCwd(extractSessionCwd(records))) {
+        continue;
+      }
       results.push(
         codexAdapter.harvest({
           records,

--- a/src/scripts/context-tax-adapter-codex.mts
+++ b/src/scripts/context-tax-adapter-codex.mts
@@ -1,0 +1,384 @@
+// idd-generated-from: src/scripts/context-tax-adapter-codex.mts
+//
+// The scripts/context-tax-adapter-codex.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source,
+// never the generated .mjs. See docs/typescript-sources.md.
+//
+// Codex CLI adapter (#2291) for the context-tax measurement contract
+// (#2288). Source-repo only: not HELPER_COMMANDS, not idd-template/. A
+// pure library module -- no CLI, no shebang, mirroring
+// context-tax-core.mts's own shape -- so it needs no HELPER_COMMANDS
+// registration or SOURCE_REPO_INTERNAL_ENTRY_PATHS entry.
+//
+// Reads Codex CLI rollout files
+// (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`), each a newline-
+// delimited stream of `{ timestamp, type, payload }` lines. This module
+// documents the specific record shapes it reads (`session_meta`,
+// `turn_context`, `token_count`, `compacted`) as local structural types;
+// only the fields actually consumed are declared, and every extraction
+// degrades gracefully (never throws) except when the harvested session
+// has no usable timestamp at all, which fails closed as a malformed
+// rollout.
+
+import { globSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
+import {
+  assertContextTaxSample,
+  type ContextTaxAdapterResult,
+  type ContextTaxSessionSample,
+  type ContextTaxUsage,
+  type ContextTaxVendorAdapter,
+  inferIssueNumberFromBasename,
+  redactContextTaxRecord,
+} from './context-tax-core.mts';
+
+/** Raw token-usage fields Codex CLI reports on a `token_count` payload. */
+interface CodexTokenUsageFields {
+  input_tokens?: unknown;
+  cached_input_tokens?: unknown;
+  cache_write_input_tokens?: unknown;
+  output_tokens?: unknown;
+  reasoning_output_tokens?: unknown;
+}
+
+/** One rollout file's parsed lines, plus the filename this adapter's harvest() needs as a last-resort session-id fallback. */
+export interface CodexHarvestInput {
+  /** One rollout file's parsed JSONL lines, in file order. */
+  records: readonly unknown[];
+  /** Rollout filename basename only -- never a directory path. */
+  fileBasename?: string;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getPayload(record: unknown): Record<string, unknown> | undefined {
+  if (!isPlainObject(record)) {
+    return undefined;
+  }
+  const payload = record.payload;
+  return isPlainObject(payload) ? payload : undefined;
+}
+
+function getStringField(
+  obj: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = obj?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function getObjectField(
+  obj: Record<string, unknown> | undefined,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = obj?.[key];
+  return isPlainObject(value) ? value : undefined;
+}
+
+function isRecordOfType(record: unknown, type: string): boolean {
+  return isPlainObject(record) && record.type === type;
+}
+
+function findRecordByType(records: readonly unknown[], type: string): unknown {
+  return records.find((record) => isRecordOfType(record, type));
+}
+
+/** Parse a Codex rollout JSONL file's text into raw, untyped records, tolerating a malformed or truncated trailing line from an interrupted process (unlike context-tax-report.mts's committed-artifact strict parse, this reads real local logs outside this repo's control). */
+export function parseCodexRolloutLines(text: string): unknown[] {
+  const out: unknown[] = [];
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (line.length === 0) {
+      continue;
+    }
+    try {
+      out.push(JSON.parse(line));
+    } catch {}
+  }
+  return out;
+}
+
+/** The session's working directory, from `session_meta.payload.cwd` first, falling back to any record carrying a `payload.cwd` string. */
+export function extractSessionCwd(
+  records: readonly unknown[],
+): string | undefined {
+  const sessionMeta = findRecordByType(records, 'session_meta');
+  const fromMeta = getStringField(getPayload(sessionMeta), 'cwd');
+  if (fromMeta) {
+    return fromMeta;
+  }
+  for (const record of records) {
+    const cwd = getStringField(getPayload(record), 'cwd');
+    if (cwd) {
+      return cwd;
+    }
+  }
+  return undefined;
+}
+
+/** Whether a session's cwd names an idd-skill worktree or clone. */
+export function isIddSkillCwd(cwd: string | undefined): boolean {
+  return typeof cwd === 'string' && cwd.includes('idd-skill');
+}
+
+function extractSessionId(sessionMeta: unknown): string | undefined {
+  return getStringField(getPayload(sessionMeta), 'id');
+}
+
+function deriveFallbackSessionId(
+  fileBasename: string | undefined,
+): string | undefined {
+  if (!fileBasename) {
+    return undefined;
+  }
+  const stripped = fileBasename.replace(/\.jsonl$/i, '');
+  return stripped.length > 0 ? stripped : undefined;
+}
+
+/** Most recently reported `payload.model` string across every record, or undefined when none exists. */
+function extractModel(records: readonly unknown[]): string | undefined {
+  let model: string | undefined;
+  for (const record of records) {
+    const candidate = getStringField(getPayload(record), 'model');
+    if (candidate) {
+      model = candidate;
+    }
+  }
+  return model;
+}
+
+function toValidTimestamp(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  return Number.isFinite(Date.parse(value)) ? value : undefined;
+}
+
+/** First and last valid record `timestamp` fields, in file order. Undefined when no record has one. */
+function extractTimestamps(
+  records: readonly unknown[],
+): { startedAt: string; endedAt: string } | undefined {
+  let startedAt: string | undefined;
+  let endedAt: string | undefined;
+  for (const record of records) {
+    if (!isPlainObject(record)) {
+      continue;
+    }
+    const ts = toValidTimestamp(record.timestamp);
+    if (!ts) {
+      continue;
+    }
+    if (startedAt === undefined) {
+      startedAt = ts;
+    }
+    endedAt = ts;
+  }
+  return startedAt !== undefined && endedAt !== undefined
+    ? { startedAt, endedAt }
+    : undefined;
+}
+
+function toNonNegativeInt(value: unknown): number {
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : 0;
+}
+
+/**
+ * Map one `token_count` payload's raw fields to {@link ContextTaxUsage}.
+ * `input_tokens` may already include the cache reads/writes it reports
+ * separately (an inclusive total) or may already exclude them
+ * (already-uncached) -- Codex CLI does not flag which. Mirrors the Grok
+ * adapter's inclusive-check: when `input_tokens >= cacheRead +
+ * cacheCreation`, the total is inclusive, so `inputUncached` is the
+ * remainder after subtracting both; otherwise `input_tokens` is already
+ * exclusive of cache and is used as `inputUncached` directly.
+ */
+function usageFromTokenCounts(raw: CodexTokenUsageFields): ContextTaxUsage {
+  const inputTokens = toNonNegativeInt(raw.input_tokens);
+  const cacheRead = toNonNegativeInt(raw.cached_input_tokens);
+  const cacheCreation = toNonNegativeInt(raw.cache_write_input_tokens);
+  const inputUncached =
+    inputTokens >= cacheRead + cacheCreation
+      ? inputTokens - cacheRead - cacheCreation
+      : inputTokens;
+  return {
+    inputUncached,
+    cacheRead,
+    cacheCreation,
+    output: toNonNegativeInt(raw.output_tokens),
+    reasoning: toNonNegativeInt(raw.reasoning_output_tokens),
+  };
+}
+
+const ZERO_USAGE: ContextTaxUsage = {
+  inputUncached: 0,
+  cacheRead: 0,
+  cacheCreation: 0,
+  output: 0,
+  reasoning: 0,
+};
+
+function addUsage(a: ContextTaxUsage, b: ContextTaxUsage): ContextTaxUsage {
+  return {
+    inputUncached: a.inputUncached + b.inputUncached,
+    cacheRead: a.cacheRead + b.cacheRead,
+    cacheCreation: a.cacheCreation + b.cacheCreation,
+    output: a.output + b.output,
+    reasoning: a.reasoning + b.reasoning,
+  };
+}
+
+/**
+ * Prefer the latest `token_count` payload's `total_token_usage` snapshot
+ * (a cumulative total) when any `token_count` record carries one;
+ * otherwise sum every record's `last_token_usage` (per-event deltas). A
+ * session with no `token_count` records at all yields all-zero usage,
+ * which is a valid, publishable-gate-excluded sample, not an error.
+ */
+function extractUsage(records: readonly unknown[]): ContextTaxUsage {
+  const tokenCountPayloads: Record<string, unknown>[] = [];
+  for (const record of records) {
+    if (isRecordOfType(record, 'token_count')) {
+      const payload = getPayload(record);
+      if (payload) {
+        tokenCountPayloads.push(payload);
+      }
+    }
+  }
+  for (let i = tokenCountPayloads.length - 1; i >= 0; i--) {
+    const total = getObjectField(tokenCountPayloads[i], 'total_token_usage');
+    if (total) {
+      return usageFromTokenCounts(total as CodexTokenUsageFields);
+    }
+  }
+  let summed = ZERO_USAGE;
+  for (const payload of tokenCountPayloads) {
+    const last = getObjectField(payload, 'last_token_usage');
+    if (last) {
+      summed = addUsage(
+        summed,
+        usageFromTokenCounts(last as CodexTokenUsageFields),
+      );
+    }
+  }
+  return summed;
+}
+
+function countCompactions(records: readonly unknown[]): number {
+  let count = 0;
+  for (const record of records) {
+    if (isRecordOfType(record, 'compacted')) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function asCodexHarvestInput(input: unknown): CodexHarvestInput {
+  if (!isPlainObject(input) || !Array.isArray(input.records)) {
+    throw new Error(
+      'context-tax-adapter-codex: harvest input must be { records: unknown[] }',
+    );
+  }
+  const fileBasename =
+    typeof input.fileBasename === 'string' ? input.fileBasename : undefined;
+  return { records: input.records, fileBasename };
+}
+
+/** Codex CLI vendor adapter. `input` must satisfy {@link CodexHarvestInput}. */
+export const codexAdapter: ContextTaxVendorAdapter = {
+  harvest(input: unknown): ContextTaxAdapterResult {
+    const { records, fileBasename } = asCodexHarvestInput(input);
+
+    const sessionMeta = findRecordByType(records, 'session_meta');
+    const vendorSessionId =
+      extractSessionId(sessionMeta) ?? deriveFallbackSessionId(fileBasename);
+    if (!vendorSessionId) {
+      throw new Error(
+        'context-tax-adapter-codex: unable to determine a vendorSessionId',
+      );
+    }
+
+    const timestamps = extractTimestamps(records);
+    if (!timestamps) {
+      throw new Error(
+        'context-tax-adapter-codex: no record has a valid timestamp',
+      );
+    }
+
+    const cwd = extractSessionCwd(records);
+    const issueNumber = cwd
+      ? inferIssueNumberFromBasename(basename(cwd))
+      : undefined;
+
+    const sample: ContextTaxSessionSample = {
+      schemaVersion: 1,
+      kind: 'session',
+      vendor: 'codex',
+      model: extractModel(records) ?? 'unknown',
+      attribution: 'session-unscoped',
+      outcome: 'unknown',
+      usage: extractUsage(records),
+      compactionCount: countCompactions(records),
+      startedAt: timestamps.startedAt,
+      endedAt: timestamps.endedAt,
+      vendorSessionId,
+    };
+
+    const redacted = redactContextTaxRecord(sample) as ContextTaxSessionSample;
+    assertContextTaxSample(redacted);
+
+    return issueNumber === undefined
+      ? { sample: redacted }
+      : { sample: redacted, joinHints: { issueNumber } };
+  },
+};
+
+/** `~/.codex/sessions`, the default rollout root. */
+export function defaultCodexSessionsDir(): string {
+  return join(homedir(), '.codex', 'sessions');
+}
+
+export interface ScanCodexSessionsOptions {
+  /** Override the rollout root. Tests must always pass this -- never scan the real home directory. */
+  sessionsDir?: string;
+}
+
+/**
+ * Scan `sessionsDir` (default `~/.codex/sessions`) for
+ * `**\/rollout-*.jsonl` files, keep only sessions whose cwd names an
+ * idd-skill worktree or clone, and harvest each into a
+ * {@link ContextTaxAdapterResult}.
+ */
+export function scanCodexSessions(
+  options?: ScanCodexSessionsOptions,
+): ContextTaxAdapterResult[] {
+  const sessionsDir = options?.sessionsDir ?? defaultCodexSessionsDir();
+  const files = globSync('**/rollout-*.jsonl', {
+    cwd: sessionsDir,
+    withFileTypes: true,
+  })
+    .filter((entry) => entry.isFile())
+    .map((entry) => join(entry.parentPath, entry.name))
+    .sort();
+
+  const results: ContextTaxAdapterResult[] = [];
+  for (const file of files) {
+    const records = parseCodexRolloutLines(readFileSync(file, 'utf8'));
+    if (!isIddSkillCwd(extractSessionCwd(records))) {
+      continue;
+    }
+    try {
+      results.push(
+        codexAdapter.harvest({
+          records,
+          fileBasename: basename(file),
+        } satisfies CodexHarvestInput),
+      );
+    } catch {}
+  }
+  return results;
+}

--- a/tests/context-tax-adapter-codex.test.mts
+++ b/tests/context-tax-adapter-codex.test.mts
@@ -1,5 +1,11 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -173,6 +179,35 @@ test('scanCodexSessions skips a malformed session that fails to harvest, keeping
 
   assert.equal(results.length, 1);
   assert.equal(results[0].sample.vendorSessionId, 'sess-basic-0001');
+});
+
+test('scanCodexSessions skips an unreadable file, keeping the rest', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-context-tax-adapter-codex-test-'),
+  );
+  const dayDir = join(sandbox, '2026', '08', '26');
+  mkdirSync(dayDir, { recursive: true });
+  const unreadable = join(
+    dayDir,
+    'rollout-2026-08-26T00-00-00-unreadable.jsonl',
+  );
+  writeFileSync(
+    unreadable,
+    readFileSync(join(FIXTURE_DIR, 'rollout-basic.jsonl'), 'utf8'),
+  );
+  chmodSync(unreadable, 0o000);
+  writeFileSync(
+    join(dayDir, 'rollout-2026-08-26T01-00-00-kept.jsonl'),
+    readFileSync(join(FIXTURE_DIR, 'rollout-summed-last-usage.jsonl'), 'utf8'),
+  );
+
+  try {
+    const results = scanCodexSessions({ sessionsDir: sandbox });
+    assert.equal(results.length, 1);
+    assert.equal(results[0].sample.vendorSessionId, 'sess-summed-0004');
+  } finally {
+    chmodSync(unreadable, 0o644);
+  }
 });
 
 test('scanCodexSessions on an empty directory returns no results', () => {

--- a/tests/context-tax-adapter-codex.test.mts
+++ b/tests/context-tax-adapter-codex.test.mts
@@ -1,0 +1,222 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import {
+  codexAdapter,
+  extractSessionCwd,
+  isIddSkillCwd,
+  parseCodexRolloutLines,
+  scanCodexSessions,
+} from '../src/scripts/context-tax-adapter-codex.mts';
+import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
+
+const FIXTURE_DIR = 'tests/fixtures/context-tax/codex';
+
+function readFixtureRecords(name: string): unknown[] {
+  return parseCodexRolloutLines(readFileSync(join(FIXTURE_DIR, name), 'utf8'));
+}
+
+function harvestFixture(name: string) {
+  return codexAdapter.harvest({
+    records: readFixtureRecords(name),
+    fileBasename: name,
+  });
+}
+
+test('a total_token_usage snapshot maps to a schema-valid sample with reasoning', () => {
+  const { sample, joinHints } = harvestFixture('rollout-basic.jsonl');
+  assert.equal(sample.kind, 'session');
+  assert.equal(sample.vendor, 'codex');
+  assert.equal(sample.model, 'gpt-5.1-codex');
+  assert.equal(sample.attribution, 'session-unscoped');
+  assert.equal(sample.outcome, 'unknown');
+  assert.equal(sample.vendorSessionId, 'sess-basic-0001');
+  // input_tokens (15000) >= cacheRead + cacheCreation (13000): inclusive
+  // total, so inputUncached is the remainder after subtracting both.
+  assert.deepEqual(sample.usage, {
+    inputUncached: 2000,
+    cacheRead: 12000,
+    cacheCreation: 1000,
+    output: 800,
+    reasoning: 300,
+  });
+  assert.equal(sample.compactionCount, 0);
+  assert.equal(sample.startedAt, '2026-08-20T10:00:00.000Z');
+  assert.equal(sample.endedAt, '2026-08-20T10:10:00.000Z');
+  // The fixture cwd basename ("idd-skill") carries no issue-<n> suffix.
+  assert.equal(joinHints, undefined);
+  assert.doesNotMatch(JSON.stringify(sample), /ghq|\/home\//);
+  assert.deepEqual(
+    validate(sample, loadJson('schemas/context-tax-sample.schema.json')),
+    [],
+  );
+});
+
+test('input_tokens below cacheRead+cacheCreation is already exclusive of cache', () => {
+  const { sample } = harvestFixture('rollout-exclusive-input.jsonl');
+  // input_tokens (900) < cacheRead + cacheCreation (13000): already
+  // exclusive, so input_tokens is used as inputUncached directly.
+  assert.deepEqual(sample.usage, {
+    inputUncached: 900,
+    cacheRead: 12000,
+    cacheCreation: 1000,
+    output: 150,
+    reasoning: 40,
+  });
+});
+
+test('three compacted records yield compactionCount 3', () => {
+  const { sample } = harvestFixture('rollout-three-compactions.jsonl');
+  assert.equal(sample.compactionCount, 3);
+  assert.equal(sample.model, 'unknown');
+});
+
+test('no total_token_usage anywhere sums every last_token_usage delta', () => {
+  const { sample } = harvestFixture('rollout-summed-last-usage.jsonl');
+  assert.deepEqual(sample.usage, {
+    inputUncached: 280,
+    cacheRead: 50,
+    cacheCreation: 0,
+    output: 65,
+    reasoning: 15,
+  });
+});
+
+test('a missing session_meta.payload.id falls back to the rollout filename', () => {
+  const { sample } = harvestFixture('rollout-no-session-id.jsonl');
+  assert.equal(sample.vendorSessionId, 'rollout-no-session-id');
+});
+
+test('a worktree cwd with an issue number yields joinHints.issueNumber, never a path string', () => {
+  const { sample, joinHints } = harvestFixture(
+    'rollout-issue-worktree-cwd.jsonl',
+  );
+  assert.deepEqual(joinHints, { issueNumber: 4242 });
+  assert.doesNotMatch(JSON.stringify(sample), /ghq|\/home\//);
+});
+
+test('adapter output never carries a leaked secret or absolute path from raw records', () => {
+  const { sample } = harvestFixture('rollout-sensitive-fields.jsonl');
+  const serialized = JSON.stringify(sample);
+  assert.doesNotMatch(serialized, /ghp_/);
+  assert.doesNotMatch(serialized, /\.ssh/);
+  assert.doesNotMatch(serialized, /\/home\//);
+  assert.equal(sample.vendorSessionId, 'sess-sensitive-0006');
+});
+
+test('extractSessionCwd prefers session_meta over any other record', () => {
+  const records = readFixtureRecords('rollout-basic.jsonl');
+  assert.equal(
+    extractSessionCwd(records),
+    '/home/testuser/ghq/github.com/kurone-kito/idd-skill',
+  );
+});
+
+test('isIddSkillCwd only matches an idd-skill cwd', () => {
+  assert.equal(isIddSkillCwd('/home/me/ghq/github.com/x/idd-skill'), true);
+  assert.equal(
+    isIddSkillCwd('/home/me/ghq/github.com/x/some-other-repo'),
+    false,
+  );
+  assert.equal(isIddSkillCwd(undefined), false);
+});
+
+test('parseCodexRolloutLines tolerates a truncated trailing line', () => {
+  const records = parseCodexRolloutLines(
+    '{"type":"session_meta","payload":{"cwd":"/x/idd-skill"}}\n{"type":"token_cou',
+  );
+  assert.equal(records.length, 1);
+});
+
+test('scanCodexSessions keeps an idd-skill session and skips a non-idd-skill session', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-context-tax-adapter-codex-test-'),
+  );
+  const dayDir = join(sandbox, '2026', '08', '26');
+  mkdirSync(dayDir, { recursive: true });
+  writeFileSync(
+    join(dayDir, 'rollout-2026-08-26T00-00-00-kept.jsonl'),
+    readFileSync(join(FIXTURE_DIR, 'rollout-basic.jsonl'), 'utf8'),
+  );
+  writeFileSync(
+    join(dayDir, 'rollout-2026-08-26T01-00-00-skipped.jsonl'),
+    readFileSync(join(FIXTURE_DIR, 'rollout-other-repo-cwd.jsonl'), 'utf8'),
+  );
+
+  const results = scanCodexSessions({ sessionsDir: sandbox });
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].sample.vendorSessionId, 'sess-basic-0001');
+});
+
+test('scanCodexSessions skips a malformed session that fails to harvest, keeping the rest', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-context-tax-adapter-codex-test-'),
+  );
+  const dayDir = join(sandbox, '2026', '08', '26');
+  mkdirSync(dayDir, { recursive: true });
+  // Matches the idd-skill cwd filter but has no valid timestamp anywhere,
+  // so harvest() throws for this file specifically.
+  writeFileSync(
+    join(dayDir, 'rollout-2026-08-26T00-00-00-malformed.jsonl'),
+    '{"type":"session_meta","payload":{"id":"sess-bad","cwd":"/x/idd-skill"}}\n',
+  );
+  writeFileSync(
+    join(dayDir, 'rollout-2026-08-26T01-00-00-kept.jsonl'),
+    readFileSync(join(FIXTURE_DIR, 'rollout-basic.jsonl'), 'utf8'),
+  );
+
+  const results = scanCodexSessions({ sessionsDir: sandbox });
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].sample.vendorSessionId, 'sess-basic-0001');
+});
+
+test('scanCodexSessions on an empty directory returns no results', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-context-tax-adapter-codex-test-'),
+  );
+  assert.deepEqual(scanCodexSessions({ sessionsDir: sandbox }), []);
+});
+
+test('harvest rejects an input that is not { records: unknown[] }', () => {
+  assert.throws(() => codexAdapter.harvest('not an object'), /records/);
+  assert.throws(
+    () => codexAdapter.harvest({ records: 'not an array' }),
+    /records/,
+  );
+});
+
+test('harvest fails closed when no record has a valid timestamp', () => {
+  assert.throws(
+    () =>
+      codexAdapter.harvest({
+        records: [
+          {
+            type: 'session_meta',
+            payload: { id: 'sess-x', cwd: '/x/idd-skill' },
+          },
+        ],
+      }),
+    /timestamp/,
+  );
+});
+
+test('harvest fails closed when no vendorSessionId is derivable', () => {
+  assert.throws(
+    () =>
+      codexAdapter.harvest({
+        records: [
+          {
+            timestamp: '2026-08-26T00:00:00.000Z',
+            type: 'session_meta',
+            payload: {},
+          },
+        ],
+      }),
+    /vendorSessionId/,
+  );
+});

--- a/tests/fixtures/context-tax/codex/rollout-basic.jsonl
+++ b/tests/fixtures/context-tax/codex/rollout-basic.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2026-08-20T10:00:00.000Z","type":"session_meta","payload":{"id":"sess-basic-0001","cwd":"/home/testuser/ghq/github.com/kurone-kito/idd-skill","originator":"codex_cli_rs"}}
+{"timestamp":"2026-08-20T10:00:01.000Z","type":"turn_context","payload":{"model":"gpt-5.1-codex","cwd":"/home/testuser/ghq/github.com/kurone-kito/idd-skill"}}
+{"timestamp":"2026-08-20T10:05:30.000Z","type":"event_msg","payload":{"kind":"agent_message","text":"working on it"}}
+{"timestamp":"2026-08-20T10:10:00.000Z","type":"token_count","payload":{"total_token_usage":{"input_tokens":15000,"cached_input_tokens":12000,"cache_write_input_tokens":1000,"output_tokens":800,"reasoning_output_tokens":300},"last_token_usage":{"input_tokens":500,"cached_input_tokens":400,"cache_write_input_tokens":0,"output_tokens":80,"reasoning_output_tokens":20}}}

--- a/tests/fixtures/context-tax/codex/rollout-exclusive-input.jsonl
+++ b/tests/fixtures/context-tax/codex/rollout-exclusive-input.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-08-24T06:00:00.000Z","type":"session_meta","payload":{"id":"sess-exclusive-0005","cwd":"/home/testuser/ghq/github.com/kurone-kito/idd-skill"}}
+{"timestamp":"2026-08-24T06:20:00.000Z","type":"token_count","payload":{"total_token_usage":{"input_tokens":900,"cached_input_tokens":12000,"cache_write_input_tokens":1000,"output_tokens":150,"reasoning_output_tokens":40}}}

--- a/tests/fixtures/context-tax/codex/rollout-issue-worktree-cwd.jsonl
+++ b/tests/fixtures/context-tax/codex/rollout-issue-worktree-cwd.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-08-26T05:00:00.000Z","type":"session_meta","payload":{"id":"sess-joinhint-0007","cwd":"/home/kurone-kito/ghq/github.com/kurone-kito/idd-skill.issue-4242-some-slug"}}
+{"timestamp":"2026-08-26T05:10:00.000Z","type":"token_count","payload":{"total_token_usage":{"input_tokens":600,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":60,"reasoning_output_tokens":0}}}

--- a/tests/fixtures/context-tax/codex/rollout-no-session-id.jsonl
+++ b/tests/fixtures/context-tax/codex/rollout-no-session-id.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-08-25T05:00:00.000Z","type":"session_meta","payload":{"cwd":"/home/testuser/ghq/github.com/kurone-kito/idd-skill"}}
+{"timestamp":"2026-08-25T05:05:00.000Z","type":"token_count","payload":{"total_token_usage":{"input_tokens":300,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":40,"reasoning_output_tokens":0}}}

--- a/tests/fixtures/context-tax/codex/rollout-other-repo-cwd.jsonl
+++ b/tests/fixtures/context-tax/codex/rollout-other-repo-cwd.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-08-22T08:00:00.000Z","type":"session_meta","payload":{"id":"sess-other-0003","cwd":"/home/kurone-kito/ghq/github.com/kurone-kito/some-other-repo"}}
+{"timestamp":"2026-08-22T08:10:00.000Z","type":"token_count","payload":{"total_token_usage":{"input_tokens":500,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":50,"reasoning_output_tokens":0}}}

--- a/tests/fixtures/context-tax/codex/rollout-sensitive-fields.jsonl
+++ b/tests/fixtures/context-tax/codex/rollout-sensitive-fields.jsonl
@@ -1,0 +1,3 @@
+{"timestamp":"2026-08-26T04:00:00.000Z","type":"session_meta","payload":{"id":"sess-sensitive-0006","cwd":"/home/testuser/ghq/github.com/kurone-kito/idd-skill"}}
+{"timestamp":"2026-08-26T04:00:05.000Z","type":"response_item","payload":{"role":"user","content":"here is my secret token ghp_abcdefghijklmnopqrstuvwx and the file at /home/kurone-kito/.ssh/id_rsa"}}
+{"timestamp":"2026-08-26T04:10:00.000Z","type":"token_count","payload":{"total_token_usage":{"input_tokens":700,"cached_input_tokens":100,"cache_write_input_tokens":0,"output_tokens":90,"reasoning_output_tokens":10}}}

--- a/tests/fixtures/context-tax/codex/rollout-summed-last-usage.jsonl
+++ b/tests/fixtures/context-tax/codex/rollout-summed-last-usage.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2026-08-23T07:00:00.000Z","type":"session_meta","payload":{"id":"sess-summed-0004","cwd":"/home/testuser/ghq/github.com/kurone-kito/idd-skill"}}
+{"timestamp":"2026-08-23T07:05:00.000Z","type":"token_count","payload":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":20,"reasoning_output_tokens":5}}}
+{"timestamp":"2026-08-23T07:10:00.000Z","type":"token_count","payload":{"last_token_usage":{"input_tokens":150,"cached_input_tokens":50,"cache_write_input_tokens":0,"output_tokens":30,"reasoning_output_tokens":10}}}
+{"timestamp":"2026-08-23T07:15:00.000Z","type":"token_count","payload":{"last_token_usage":{"input_tokens":80,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":15,"reasoning_output_tokens":0}}}

--- a/tests/fixtures/context-tax/codex/rollout-three-compactions.jsonl
+++ b/tests/fixtures/context-tax/codex/rollout-three-compactions.jsonl
@@ -1,0 +1,5 @@
+{"timestamp":"2026-08-21T09:00:00.000Z","type":"session_meta","payload":{"id":"sess-compact-0002","cwd":"/home/testuser/ghq/github.com/kurone-kito/idd-skill"}}
+{"timestamp":"2026-08-21T09:05:00.000Z","type":"compacted","payload":{"reason":"context-window"}}
+{"timestamp":"2026-08-21T09:10:00.000Z","type":"compacted","payload":{"reason":"context-window"}}
+{"timestamp":"2026-08-21T09:15:00.000Z","type":"token_count","payload":{"total_token_usage":{"input_tokens":4000,"cached_input_tokens":1000,"cache_write_input_tokens":0,"output_tokens":200,"reasoning_output_tokens":0}}}
+{"timestamp":"2026-08-21T09:20:00.000Z","type":"compacted","payload":{"reason":"context-window"}}


### PR DESCRIPTION
# Summary

Adds the Codex CLI adapter for the context-tax measurement contract (#2288): a pure library module `src/scripts/context-tax-adapter-codex.mts` that scans `~/.codex/sessions/**/rollout-*.jsonl`, keeps only sessions whose cwd names an idd-skill worktree or clone, and harvests each into a schema-valid `ContextTaxSessionSample`. Token accounting mirrors the Grok adapter's inclusive-check for whether `input_tokens` already includes reported cache reads/writes. A single malformed rollout file is skipped rather than aborting the whole scan.

## Linked issue

Closes #2291

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

The exact Codex CLI rollout record shapes (`session_meta`, `turn_context`, `token_count` with `total_token_usage`/`last_token_usage`, `compacted`) are documented in the issue's own field names; this PR implements exactly those names and covers them with synthetic fixtures under `tests/fixtures/context-tax/codex/` rather than reading any real local rollout data (none is read in CI). Not registered in `HELPER_COMMANDS`: this module has no CLI entry point at all, mirroring `context-tax-core.mts`'s own shape.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs changed)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for measuring context usage from Codex CLI sessions.
  * Captures session metadata, timestamps, token usage, and context-compaction counts.
  * Automatically discovers eligible sessions and derives missing session details when possible.
  * Filters sensitive information and safely handles incomplete or malformed session records.

* **Bug Fixes**
  * Invalid or incomplete sessions are skipped without interrupting collection.

* **Tests**
  * Added comprehensive coverage for usage tracking, redaction, session discovery, validation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->