### PR TITLE
fix(external-check-waiver): refuse a waiver the gate cannot honor yet

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1009,6 +1009,11 @@ default `instructions-only` profile keep using the written shell /
     earliest, which is the one a deterministic reader resolves to. It does
     not delete the extras -- removing a marker another session just posted
     is a maintainer's call, not the helper's -- so minimize them by hand.
+    That post-write read degrades to a warning rather than failing closed:
+    the waiver already exists and the write cannot be undone, so a read
+    failure reports `reconcileInconclusive` and still renders the applied
+    result with its comment url. Only the pre-write read fails closed, where
+    an unreadable list could actually cause the duplicate.
 
 ### External-check waiver contract
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -999,6 +999,16 @@ default `instructions-only` profile keep using the written shell /
     one carrying the new value, matching the release-marker rule that a
     retry must never append an indistinguishable duplicate. To change an
     expiry, let the existing waiver lapse or supersede it deliberately.
+  - the reuse check and the post are **not** one atomic step, and GitHub
+    comments have no compare-and-swap -- the same limitation the claim
+    protocol records for its own markers. Two concurrent `--apply` runs
+    can therefore both observe no waiver and both post. That is reconciled
+    after the fact rather than prevented: the helper re-reads once the post
+    lands, and when more than one valid waiver exists for the selector it
+    reports them all in `concurrentWaivers`, warns on stderr, and names the
+    earliest, which is the one a deterministic reader resolves to. It does
+    not delete the extras -- removing a marker another session just posted
+    is a maintainer's call, not the helper's -- so minimize them by hand.
 
 ### External-check waiver contract
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -968,6 +968,32 @@ default `instructions-only` profile keep using the written shell /
     the consumer-side gate (`summarizeExternalCheckWaivers` in
     `protocol-helpers.mts`) when no claim resolves there, so posting one
     against a claimed PR would just be rejected `wrongClaim`.
+  - for the `idd-advisory-convergence` selector specifically (#2328), the
+    report carries `advisoryConvergenceWaiverPrecondition`, built by the
+    same shared function `pre-merge-readiness` publishes it from, and a
+    closed hatch is a blocking reason. That check never treats a posted
+    waiver as active until its precondition opens, so posting one earlier
+    produces a marker the gate ignores. Only the exact selector is gated:
+    the gate itself never counts a glob waiver for this check either.
+  - the helper evaluates only the **deadline** opener, never terminal
+    Copilot unavailability, which needs trusted advisory-wait
+    recovery-marker state it does not collect. The report says so with
+    `terminalEvaluated: false`, and the blocking reason states that the
+    deadline has not passed rather than claiming no opener applies.
+    `--allow-closed-precondition` posts anyway, for an operator who knows
+    the terminal opener does apply; the precondition is still reported as
+    closed, so the override is visible in the output.
+  - the deadline itself is read from the **raw** policy document, not the
+    normalized one: `normalizePolicyConfig` does not carry
+    `advisoryWait.convergenceDeadline` through, so reading it from the
+    normalized policy would silently substitute the 24h default for a
+    repository that configured something shorter.
+  - `--apply` is idempotent (#2328): it reuses an existing valid waiver
+    for the same selector, HEAD, and claim instead of appending a second
+    marker, reporting `reusedWaiver` with that comment's id and url and
+    posting nothing. The earliest match wins, so a retry converges on one
+    marker. Validity comes from `summarizeExternalCheckWaivers`, so an
+    expired, wrong-HEAD, or wrong-claim waiver is never reused.
 
 ### External-check waiver contract
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -993,7 +993,12 @@ default `instructions-only` profile keep using the written shell /
     marker, reporting `reusedWaiver` with that comment's id and url and
     posting nothing. The earliest match wins, so a retry converges on one
     marker. Validity comes from `summarizeExternalCheckWaivers`, so an
-    expired, wrong-HEAD, or wrong-claim waiver is never reused.
+    expired, wrong-HEAD, or wrong-claim waiver is never reused. Reuse wins
+    over a freshly requested expiry: re-running with a different
+    `--expires-in` reports the existing marker rather than posting a second
+    one carrying the new value, matching the release-marker rule that a
+    retry must never append an indistinguishable duplicate. To change an
+    expiry, let the existing waiver lapse or supersede it deliberately.
 
 ### External-check waiver contract
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1009,6 +1009,11 @@ default `instructions-only` profile keep using the written shell /
     earliest, which is the one a deterministic reader resolves to. It does
     not delete the extras -- removing a marker another session just posted
     is a maintainer's call, not the helper's -- so minimize them by hand.
+    That post-write read degrades to a warning rather than failing closed:
+    the waiver already exists and the write cannot be undone, so a read
+    failure reports `reconcileInconclusive` and still renders the applied
+    result with its comment url. Only the pre-write read fails closed, where
+    an unreadable list could actually cause the duplicate.
 
 ### External-check waiver contract
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -999,6 +999,16 @@ default `instructions-only` profile keep using the written shell /
     one carrying the new value, matching the release-marker rule that a
     retry must never append an indistinguishable duplicate. To change an
     expiry, let the existing waiver lapse or supersede it deliberately.
+  - the reuse check and the post are **not** one atomic step, and GitHub
+    comments have no compare-and-swap -- the same limitation the claim
+    protocol records for its own markers. Two concurrent `--apply` runs
+    can therefore both observe no waiver and both post. That is reconciled
+    after the fact rather than prevented: the helper re-reads once the post
+    lands, and when more than one valid waiver exists for the selector it
+    reports them all in `concurrentWaivers`, warns on stderr, and names the
+    earliest, which is the one a deterministic reader resolves to. It does
+    not delete the extras -- removing a marker another session just posted
+    is a maintainer's call, not the helper's -- so minimize them by hand.
 
 ### External-check waiver contract
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -968,6 +968,32 @@ default `instructions-only` profile keep using the written shell /
     the consumer-side gate (`summarizeExternalCheckWaivers` in
     `protocol-helpers.mts`) when no claim resolves there, so posting one
     against a claimed PR would just be rejected `wrongClaim`.
+  - for the `idd-advisory-convergence` selector specifically (#2328), the
+    report carries `advisoryConvergenceWaiverPrecondition`, built by the
+    same shared function `pre-merge-readiness` publishes it from, and a
+    closed hatch is a blocking reason. That check never treats a posted
+    waiver as active until its precondition opens, so posting one earlier
+    produces a marker the gate ignores. Only the exact selector is gated:
+    the gate itself never counts a glob waiver for this check either.
+  - the helper evaluates only the **deadline** opener, never terminal
+    Copilot unavailability, which needs trusted advisory-wait
+    recovery-marker state it does not collect. The report says so with
+    `terminalEvaluated: false`, and the blocking reason states that the
+    deadline has not passed rather than claiming no opener applies.
+    `--allow-closed-precondition` posts anyway, for an operator who knows
+    the terminal opener does apply; the precondition is still reported as
+    closed, so the override is visible in the output.
+  - the deadline itself is read from the **raw** policy document, not the
+    normalized one: `normalizePolicyConfig` does not carry
+    `advisoryWait.convergenceDeadline` through, so reading it from the
+    normalized policy would silently substitute the 24h default for a
+    repository that configured something shorter.
+  - `--apply` is idempotent (#2328): it reuses an existing valid waiver
+    for the same selector, HEAD, and claim instead of appending a second
+    marker, reporting `reusedWaiver` with that comment's id and url and
+    posting nothing. The earliest match wins, so a retry converges on one
+    marker. Validity comes from `summarizeExternalCheckWaivers`, so an
+    expired, wrong-HEAD, or wrong-claim waiver is never reused.
 
 ### External-check waiver contract
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -993,7 +993,12 @@ default `instructions-only` profile keep using the written shell /
     marker, reporting `reusedWaiver` with that comment's id and url and
     posting nothing. The earliest match wins, so a retry converges on one
     marker. Validity comes from `summarizeExternalCheckWaivers`, so an
-    expired, wrong-HEAD, or wrong-claim waiver is never reused.
+    expired, wrong-HEAD, or wrong-claim waiver is never reused. Reuse wins
+    over a freshly requested expiry: re-running with a different
+    `--expires-in` reports the existing marker rather than posting a second
+    one carrying the new value, matching the release-marker rule that a
+    retry must never append an indistinguishable duplicate. To change an
+    expiry, let the existing waiver lapse or supersede it deliberately.
 
 ### External-check waiver contract
 

--- a/scripts/advisory-wait-policy.mjs
+++ b/scripts/advisory-wait-policy.mjs
@@ -447,13 +447,20 @@ export function buildAdvisoryConvergenceWaiverPrecondition({
     : DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
   const resolvedHeadCommittedAt = String(headCommittedAt ?? '');
   const headCommittedAtValid = isValidIsoTimestamp(resolvedHeadCommittedAt);
-  const elapsedMinutes = headCommittedAtValid
-    ? Math.floor(
-        (new Date(now).getTime() -
-          new Date(resolvedHeadCommittedAt).getTime()) /
-          60000,
-      )
-    : null;
+  // Clamped exactly as `minutesBetweenIso` does, which is what
+  // `pre-merge-readiness` used before this extraction and what
+  // `advisory-convergence.mts` still uses: a HEAD commit dated ahead of the
+  // runner clock yields 0, never a negative elapsed. Subtracting directly
+  // would make this shared report disagree with the gate on a clock-skewed
+  // or deliberately future-dated commit.
+  const nowMs = Date.parse(now);
+  const headMs = Date.parse(resolvedHeadCommittedAt);
+  const elapsedMinutes =
+    headCommittedAtValid && Number.isFinite(nowMs) && Number.isFinite(headMs)
+      ? nowMs < headMs
+        ? 0
+        : Math.floor((nowMs - headMs) / 60000)
+      : null;
   const deadlinePassed =
     elapsedMinutes !== null && elapsedMinutes >= resolvedDeadlineMinutes;
   const resolvedTerminalUnavailable = terminalUnavailable === true;

--- a/scripts/advisory-wait-policy.mjs
+++ b/scripts/advisory-wait-policy.mjs
@@ -4,6 +4,7 @@
 // source named above by `pnpm run build`. Edit the .mts source, never the
 // generated .mjs. See docs/typescript-sources.md.
 import { readFileSync } from 'node:fs';
+import { isValidIsoTimestamp } from './marker-helpers.mjs';
 import { loadJson, validateConfigSection } from './validate-schemas.mjs';
 export const DEFAULT_ADVISORY_REQUEST_CAP = 30;
 export const DEFAULT_ADVISORY_PENDING_WINDOW_MINUTES = 30;
@@ -411,4 +412,67 @@ function parseConfiguredDurationToMs(value) {
     return null;
   }
   return totalMilliseconds;
+}
+/**
+ * Build the `idd-advisory-convergence` waiver precondition (#2021) from its
+ * two independent openers: a deadline anchored on the current HEAD commit's
+ * own timestamp, and proven terminal Copilot unavailability (#1570).
+ *
+ * Extracted from `pre-merge-readiness`'s reducer (#2328) so every consumer
+ * reads one implementation. `external-check-waiver.mts` accepted and posted
+ * a waiver while this precondition was closed, disagreeing with the gate it
+ * is supposed to predict; a second copy of this arithmetic is exactly how
+ * that disagreement arose, so callers must not re-derive it.
+ *
+ * `terminalUnavailable` is supplied by the caller rather than computed here:
+ * proving it needs trusted advisory-wait recovery-marker state, which not
+ * every caller has. A caller that cannot evaluate it passes `false` and must
+ * report the resulting verdict as "deadline not passed" rather than as a bare
+ * closed hatch, since the terminal opener may still be open unseen.
+ *
+ * `deadlineOpensAt` is the deadline path's open moment as a real timestamp
+ * (#2034), used to override a waiver's active-since cutoff. It is empty
+ * unless the deadline itself has passed: the terminal path has no equivalent
+ * anchor and intentionally falls back to the waiver comment's own
+ * `createdAt`.
+ */
+export function buildAdvisoryConvergenceWaiverPrecondition({
+  headCommittedAt,
+  deadlineMinutes,
+  terminalUnavailable = false,
+  now,
+}) {
+  const resolvedDeadlineMinutes = Number.isFinite(deadlineMinutes)
+    ? Number(deadlineMinutes)
+    : DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
+  const resolvedHeadCommittedAt = String(headCommittedAt ?? '');
+  const headCommittedAtValid = isValidIsoTimestamp(resolvedHeadCommittedAt);
+  const elapsedMinutes = headCommittedAtValid
+    ? Math.floor(
+        (new Date(now).getTime() -
+          new Date(resolvedHeadCommittedAt).getTime()) /
+          60000,
+      )
+    : null;
+  const deadlinePassed =
+    elapsedMinutes !== null && elapsedMinutes >= resolvedDeadlineMinutes;
+  const resolvedTerminalUnavailable = terminalUnavailable === true;
+  return {
+    precondition: {
+      checkSelector: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      deadlineMinutes: resolvedDeadlineMinutes,
+      headCommittedAt: resolvedHeadCommittedAt || 'none',
+      elapsedMinutes,
+      deadlinePassed,
+      terminalUnavailable: resolvedTerminalUnavailable,
+      open: deadlinePassed || resolvedTerminalUnavailable,
+    },
+    deadlineOpensAt:
+      deadlinePassed && headCommittedAtValid
+        ? new Date(
+            new Date(resolvedHeadCommittedAt).getTime() +
+              resolvedDeadlineMinutes * 60000,
+          ).toISOString()
+        : '',
+  };
 }

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -398,6 +398,7 @@ export async function runExternalCheckWaiver(options = {}) {
     fetchPullRequest({ owner, repo: name, prNumber: args.prNumber });
   const issueCandidates =
     options.issueCandidates ??
+    options.resolveIssueCandidates?.() ??
     resolveLinkedIssueCandidates({
       owner,
       repo: name,
@@ -503,17 +504,16 @@ export async function runExternalCheckWaiver(options = {}) {
   );
   // One evidence build for both the pre-write scan and the post-write
   // reconcile, so the two can never classify the same marker differently.
-  const buildWaiverEvidence = (comments) =>
+  const buildWaiverEvidence = (comments, binding) =>
     wouldPost
       ? summarizeExternalCheckWaivers(comments, {
           prHeadSha: wouldPost.headSha,
-          activeClaimId: wouldPost.claimId,
+          activeClaimId: binding.claimId,
           // The gate accepts a waiver bound to the immediate predecessor
           // claim through its one-hop takeover exception. Omitting this
           // would classify such a waiver `wrongClaim` here and append a
           // second one after every takeover.
-          activeClaimSupersedes:
-            report.linkedIssue?.activeClaim?.supersedes ?? '',
+          activeClaimSupersedes: binding.supersedes,
           // Derived from the SAME snapshot being summarized, never from the
           // pre-write one. With collaborator-marker trust enabled, a
           // maintainer absent from the earlier read would otherwise be
@@ -546,18 +546,20 @@ export async function runExternalCheckWaiver(options = {}) {
   // The marker this invocation would post defines the binding a reusable
   // waiver must share; the predecessor claim is accepted too, matching the
   // gate's one-hop takeover exception.
-  const allowedClaimIds = wouldPost
-    ? [
-        wouldPost.claimId,
-        String(report.linkedIssue?.activeClaim?.supersedes ?? ''),
-      ].filter((value) => value && value !== 'none')
-    : [];
+  const toAllowedClaimIds = (binding) =>
+    [binding.claimId, binding.supersedes].filter(
+      (value) => value && value !== 'none',
+    );
+  const preWriteBinding = {
+    claimId: wouldPost?.claimId ?? '',
+    supersedes: String(report.linkedIssue?.activeClaim?.supersedes ?? ''),
+  };
   const existingWaiver = findReusableWaiverComment({
     comments: prComments,
-    evidence: buildWaiverEvidence(prComments),
+    evidence: buildWaiverEvidence(prComments, preWriteBinding),
     checkSelector: report.requested.selector,
     expectedHeadSha: wouldPost?.headSha ?? '',
-    allowedClaimIds,
+    allowedClaimIds: toAllowedClaimIds(preWriteBinding),
   });
   if (existingWaiver) {
     const reusedReport = {
@@ -614,14 +616,58 @@ export async function runExternalCheckWaiver(options = {}) {
       );
     }
   }
+  // #2328 (review): re-resolve the claim for the reconcile rather than
+  // reusing the pre-write binding. If a takeover lands between the two, the
+  // gate resolves the successor with the predecessor as `supersedes` and
+  // accepts BOTH waivers, while a summarizer still pinned to the predecessor
+  // classifies the successor's as `wrongClaim` and reports no duplicate --
+  // silence exactly where the operator most needs the warning. A failure to
+  // re-resolve makes the reconcile inconclusive rather than wrong; the apply
+  // itself already succeeded and is never retracted for this.
+  let postWriteBinding = preWriteBinding;
+  if (wouldPost && !reconcileInconclusive) {
+    try {
+      const refreshed = selectLinkedIssueCandidate(
+        options.issueCandidates ??
+          options.resolveIssueCandidates?.() ??
+          resolveLinkedIssueCandidates({
+            owner,
+            repo: name,
+            rawConfig,
+            viewerLogin: actor,
+            linkedIssues: pr.closingIssuesReferences,
+            issueNumber: args.issueNumber,
+            expectedClaimId: '',
+            headRefName: pr.headRefName,
+            prNumber: args.prNumber,
+          }),
+        {
+          issueNumber: args.issueNumber,
+          headRefName: String(pr.headRefName ?? ''),
+        },
+      );
+      if (refreshed.ok) {
+        postWriteBinding = {
+          claimId: refreshed.issue.activeClaim.claimId,
+          supersedes: String(refreshed.issue.activeClaim.supersedes ?? ''),
+        };
+      }
+    } catch (error) {
+      reconcileInconclusive = true;
+      process.stderr.write(
+        `warning: the waiver was posted, but re-resolving the active claim failed, ` +
+          `so a concurrent duplicate could not be ruled out: ${String(error?.message ?? error)}\n`,
+      );
+    }
+  }
   const concurrentWaivers =
     wouldPost && !reconcileInconclusive
       ? collectValidWaiverComments({
           comments: postWriteComments,
-          evidence: buildWaiverEvidence(postWriteComments),
+          evidence: buildWaiverEvidence(postWriteComments, postWriteBinding),
           checkSelector: report.requested.selector,
           expectedHeadSha: wouldPost?.headSha ?? '',
-          allowedClaimIds,
+          allowedClaimIds: toAllowedClaimIds(postWriteBinding),
         })
       : [];
   if (concurrentWaivers.length > 1) {

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -543,10 +543,21 @@ export async function runExternalCheckWaiver(options = {}) {
             .mode,
         })
       : null;
+  // The marker this invocation would post defines the binding a reusable
+  // waiver must share; the predecessor claim is accepted too, matching the
+  // gate's one-hop takeover exception.
+  const allowedClaimIds = wouldPost
+    ? [
+        wouldPost.claimId,
+        String(report.linkedIssue?.activeClaim?.supersedes ?? ''),
+      ].filter((value) => value && value !== 'none')
+    : [];
   const existingWaiver = findReusableWaiverComment({
     comments: prComments,
     evidence: buildWaiverEvidence(prComments),
     checkSelector: report.requested.selector,
+    expectedHeadSha: wouldPost?.headSha ?? '',
+    allowedClaimIds,
   });
   if (existingWaiver) {
     const reusedReport = {
@@ -609,6 +620,8 @@ export async function runExternalCheckWaiver(options = {}) {
           comments: postWriteComments,
           evidence: buildWaiverEvidence(postWriteComments),
           checkSelector: report.requested.selector,
+          expectedHeadSha: wouldPost?.headSha ?? '',
+          allowedClaimIds,
         })
       : [];
   if (concurrentWaivers.length > 1) {
@@ -680,6 +693,8 @@ export function collectValidWaiverComments({
   comments,
   evidence,
   checkSelector,
+  expectedHeadSha = '',
+  allowedClaimIds = [],
 }) {
   const selector = String(checkSelector ?? '').trim();
   if (!selector) return [];
@@ -711,6 +726,30 @@ export function collectValidWaiverComments({
     )
       .trim()
       .toLowerCase();
+    // The evidence entry carries no HEAD or claim binding, so those are
+    // checked against the expected values directly. Without this a
+    // wrong-HEAD or wrong-claim marker sharing all four entry fields with a
+    // genuinely valid sibling would still correlate.
+    const normalizedHead = String(expectedHeadSha ?? '')
+      .trim()
+      .toLowerCase();
+    if (
+      normalizedHead &&
+      String(parsed.headSha ?? '')
+        .trim()
+        .toLowerCase() !== normalizedHead
+    ) {
+      continue;
+    }
+    const acceptedClaimIds = (allowedClaimIds ?? [])
+      .map((value) => String(value ?? '').trim())
+      .filter((value) => value.length > 0);
+    if (
+      acceptedClaimIds.length > 0 &&
+      !acceptedClaimIds.includes(String(parsed.claimId ?? '').trim())
+    ) {
+      continue;
+    }
     const matchesValidEntry = validForSelector.some(
       (entry) =>
         entry.authorLogin === commentAuthorLogin &&

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -8,7 +8,7 @@ import { readFileSync } from 'node:fs';
 import {
   buildAdvisoryConvergenceWaiverPrecondition,
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
-  resolveAdvisoryConvergenceDeadlineMinutes,
+  readAdvisoryConvergenceDeadlineMinutes,
 } from './advisory-wait-policy.mjs';
 import { parseCliArgs } from './cli-args.mjs';
 import { resolveTrustedCollaboratorMarkerLogins } from './collaborator-permission.mjs';
@@ -438,8 +438,14 @@ export async function runExternalCheckWaiver(options = {}) {
           headRefOid: String(pr.headRefOid ?? '').trim(),
         }),
       allowClosedPrecondition: args.allowClosedPrecondition,
+      // Read through the SAME validating reader the gate uses, not the raw
+      // resolver: the gate rejects the whole `advisoryWait` section when any
+      // sibling key is schema-invalid and falls back to the 24h default. A
+      // resolver that skips that validation would report the configured value
+      // where the gate reports the default, reproducing the very disagreement
+      // this change removes.
       advisoryConvergenceDeadlineMinutes:
-        resolveAdvisoryConvergenceDeadlineMinutes(rawConfig),
+        readAdvisoryConvergenceDeadlineMinutes(),
     },
     { now: options.now, repoOwner: owner },
   );
@@ -481,8 +487,10 @@ export async function runExternalCheckWaiver(options = {}) {
   // for this selector first. A repeated `--apply` previously posted a second
   // identical marker, leaving two live waivers on the pull request.
   const prComments =
-    options.prComments ??
-    fetchPrComments({ owner, repo: name, prNumber: args.prNumber });
+    typeof options.prComments === 'function'
+      ? options.prComments()
+      : (options.prComments ??
+        fetchPrComments({ owner, repo: name, prNumber: args.prNumber }));
   // The marker this invocation would post is the exact context a reusable
   // waiver must match, so recover the HEAD and claim from it rather than
   // threading them separately and risking a mismatch.
@@ -555,19 +563,19 @@ export async function runExternalCheckWaiver(options = {}) {
  * a duplicate to be appended.
  */
 function fetchPrComments({ owner, repo, prNumber }) {
-  try {
-    const payload = ghJson(
-      [
-        'api',
-        '--paginate',
-        `repos/${owner}/${repo}/issues/${prNumber}/comments`,
-      ],
-      true,
+  // Never fail open: an unreadable list is not an empty one. Swallowing the
+  // error would hide an existing waiver and let `--apply` append a duplicate,
+  // which is the regression this change exists to remove.
+  const payload = ghJson(
+    ['api', '--paginate', `repos/${owner}/${repo}/issues/${prNumber}/comments`],
+    true,
+  );
+  if (!Array.isArray(payload)) {
+    throw new Error(
+      `external-check waiver apply blocked: could not read PR #${prNumber} comments to check for an existing waiver`,
     );
-    return Array.isArray(payload) ? payload : [];
-  } catch {
-    return [];
   }
+  return payload;
 }
 /**
  * #2328: find an existing valid waiver for this exact selector so a repeated

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -514,13 +514,19 @@ export async function runExternalCheckWaiver(options = {}) {
           // second one after every takeover.
           activeClaimSupersedes:
             report.linkedIssue?.activeClaim?.supersedes ?? '',
+          // Derived from the SAME snapshot being summarized, never from the
+          // pre-write one. With collaborator-marker trust enabled, a
+          // maintainer absent from the earlier read would otherwise be
+          // classified unauthorized here while the gate — which derives
+          // trust from the final comments — accepts their waiver, so the
+          // reconcile would miss exactly the duplicate it exists to find.
           trustedMarkerLogins: [
             ...buildTrustedMarkerLogins({
               owner,
               repo: name,
               rawConfig,
               viewerLogin: actor,
-              issueComments: prComments,
+              issueComments: comments,
             }),
           ],
           now: (options.now instanceof Date
@@ -571,10 +577,17 @@ export async function runExternalCheckWaiver(options = {}) {
   // all and identify the earliest, which is the one a deterministic reader
   // resolves to. Reporting rather than deleting -- removing a marker another
   // session just posted is not this helper's call to make.
+  // ONE snapshot for both arguments. Two sequential reads would let a waiver
+  // land between them, leaving `comments` older than `evidence`;
+  // `collectValidWaiverComments` can only correlate entries it can find in
+  // `comments`, so the newer marker would be dropped and the duplicate
+  // silently missed — a snapshot mismatch inside the code that exists to
+  // catch mismatches.
+  const postWriteComments = wouldPost ? readPrComments() : [];
   const concurrentWaivers = wouldPost
     ? collectValidWaiverComments({
-        comments: readPrComments(),
-        evidence: buildWaiverEvidence(readPrComments()),
+        comments: postWriteComments,
+        evidence: buildWaiverEvidence(postWriteComments),
         checkSelector: report.requested.selector,
       })
     : [];

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -430,11 +430,13 @@ export async function runExternalCheckWaiver(options = {}) {
       }),
       repoOwner: owner,
       claimless: args.claimless,
-      headCommittedAt: fetchHeadCommittedAt({
-        owner,
-        repo: name,
-        headRefOid: String(pr.headRefOid ?? '').trim(),
-      }),
+      headCommittedAt:
+        options.headCommittedAt ??
+        fetchHeadCommittedAt({
+          owner,
+          repo: name,
+          headRefOid: String(pr.headRefOid ?? '').trim(),
+        }),
       allowClosedPrecondition: args.allowClosedPrecondition,
       advisoryConvergenceDeadlineMinutes:
         resolveAdvisoryConvergenceDeadlineMinutes(rawConfig),

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -699,8 +699,22 @@ export function collectValidWaiverComments({
       String(comment?.created_at ?? ''),
     );
     if (!parsed || parsed.checkSelector !== selector) continue;
+    // #2328 (review): correlate on EVERY field the evidence entry carries,
+    // not just expiry and timestamp. `created_at` has second resolution, so a
+    // valid maintainer waiver and an unauthorized, wrong-HEAD, or wrong-claim
+    // marker posted in the same second would otherwise both correlate to the
+    // single valid entry — letting the reuse path report the invalid comment
+    // as authoritative, and the reconcile invent a duplicate and point the
+    // operator at the genuinely valid marker to minimize.
+    const commentAuthorLogin = String(
+      comment?.author?.login ?? comment?.user?.login ?? '',
+    )
+      .trim()
+      .toLowerCase();
     const matchesValidEntry = validForSelector.some(
       (entry) =>
+        entry.authorLogin === commentAuthorLogin &&
+        entry.reason === parsed.reason &&
         entry.expiresAt === parsed.expiresAt &&
         entry.createdAt === parsed.createdAt,
     );

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -583,14 +583,34 @@ export async function runExternalCheckWaiver(options = {}) {
   // `comments`, so the newer marker would be dropped and the duplicate
   // silently missed — a snapshot mismatch inside the code that exists to
   // catch mismatches.
-  const postWriteComments = wouldPost ? readPrComments() : [];
-  const concurrentWaivers = wouldPost
-    ? collectValidWaiverComments({
-        comments: postWriteComments,
-        evidence: buildWaiverEvidence(postWriteComments),
-        checkSelector: report.requested.selector,
-      })
-    : [];
+  //
+  // Failing closed is right BEFORE the post, where an unreadable list can
+  // cause a duplicate. After it the waiver already exists and the write is
+  // irreversible, so throwing here would report a failed apply for work that
+  // succeeded and would withhold the posted comment URL — pushing an operator
+  // toward a retry that can only make things worse. Degrade to a warning and
+  // still render the applied result; only duplicate detection is lost.
+  let postWriteComments = [];
+  let reconcileInconclusive = false;
+  if (wouldPost) {
+    try {
+      postWriteComments = readPrComments();
+    } catch (error) {
+      reconcileInconclusive = true;
+      process.stderr.write(
+        `warning: the waiver was posted, but re-reading PR #${args.prNumber} comments failed, ` +
+          `so a concurrent duplicate could not be ruled out: ${String(error?.message ?? error)}\n`,
+      );
+    }
+  }
+  const concurrentWaivers =
+    wouldPost && !reconcileInconclusive
+      ? collectValidWaiverComments({
+          comments: postWriteComments,
+          evidence: buildWaiverEvidence(postWriteComments),
+          checkSelector: report.requested.selector,
+        })
+      : [];
   if (concurrentWaivers.length > 1) {
     const earliest = concurrentWaivers[0];
     process.stderr.write(
@@ -605,6 +625,7 @@ export async function runExternalCheckWaiver(options = {}) {
     applied: true,
     commentUrl: String(result.html_url ?? result.url ?? ''),
     ...(concurrentWaivers.length > 1 ? { concurrentWaivers } : {}),
+    ...(reconcileInconclusive ? { reconcileInconclusive: true } : {}),
   };
   renderReport(appliedReport, args.format);
   return { exitCode: 0, report: appliedReport };

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -25,8 +25,10 @@ import {
   resolveCollaboratorMarkerTrust,
 } from './policy-helpers.mjs';
 import {
+  parseExternalCheckWaiverComment,
   parsePaginatedGhNdjson,
   renderExternalCheckWaiverComment,
+  summarizeExternalCheckWaivers,
 } from './protocol-helpers.mjs';
 import { makeReadlinePrompt } from './readline-prompt.mjs';
 
@@ -473,6 +475,60 @@ export async function runExternalCheckWaiver(options = {}) {
       return { exitCode: 0, report: { ...report, applied: false } };
     }
   }
+  // #2328: appending is not idempotent, so look for an existing valid waiver
+  // for this selector first. A repeated `--apply` previously posted a second
+  // identical marker, leaving two live waivers on the pull request.
+  const prComments =
+    options.prComments ??
+    fetchPrComments({ owner, repo: name, prNumber: args.prNumber });
+  // The marker this invocation would post is the exact context a reusable
+  // waiver must match, so recover the HEAD and claim from it rather than
+  // threading them separately and risking a mismatch.
+  const wouldPost = parseExternalCheckWaiverComment(
+    report.body,
+    new Date().toISOString(),
+  );
+  const existingWaiver = wouldPost
+    ? findReusableWaiverComment({
+        comments: prComments,
+        evidence: summarizeExternalCheckWaivers(prComments, {
+          prHeadSha: wouldPost.headSha,
+          activeClaimId: wouldPost.claimId,
+          trustedMarkerLogins: [
+            ...buildTrustedMarkerLogins({
+              owner,
+              repo: name,
+              rawConfig,
+              viewerLogin: actor,
+              issueComments: prComments,
+            }),
+          ],
+          now: (options.now instanceof Date
+            ? options.now
+            : new Date()
+          ).toISOString(),
+          waivableSelectors: [
+            ...normalizePolicyConfig(rawConfig).ciGate.externalChecks.waivable,
+          ],
+          maxValidity:
+            normalizePolicyConfig(rawConfig).ciGate.externalCheckWaivers
+              .maxValidity,
+          mode: normalizePolicyConfig(rawConfig).ciGate.externalCheckWaivers
+            .mode,
+        }),
+        checkSelector: report.requested.selector,
+      })
+    : null;
+  if (existingWaiver) {
+    const reusedReport = {
+      ...report,
+      applied: false,
+      reusedWaiver: existingWaiver,
+      commentUrl: existingWaiver.commentUrl,
+    };
+    renderReport(reusedReport, args.format);
+    return { exitCode: 0, report: reusedReport };
+  }
   const result = options.postComment
     ? await options.postComment(args.prNumber, report.body)
     : ghJson([
@@ -490,6 +546,80 @@ export async function runExternalCheckWaiver(options = {}) {
   };
   renderReport(appliedReport, args.format);
   return { exitCode: 0, report: appliedReport };
+}
+/**
+ * #2328: the pull request's own issue comments, where waiver markers live.
+ * Paginated so a long conversation cannot hide an existing waiver and cause
+ * a duplicate to be appended.
+ */
+function fetchPrComments({ owner, repo, prNumber }) {
+  try {
+    const payload = ghJson(
+      [
+        'api',
+        '--paginate',
+        `repos/${owner}/${repo}/issues/${prNumber}/comments`,
+      ],
+      true,
+    );
+    return Array.isArray(payload) ? payload : [];
+  } catch {
+    return [];
+  }
+}
+/**
+ * #2328: find an existing valid waiver for this exact selector so a repeated
+ * `--apply` reuses it instead of appending a second marker. Re-running the
+ * same command posted a duplicate on pull request #2325, leaving two live
+ * waivers a later session had to disambiguate by hand.
+ *
+ * Validity is not re-derived here: `summarizeExternalCheckWaivers` already
+ * classifies every marker into valid / expired / wrong-HEAD / wrong-claim,
+ * and both `pre-merge-readiness` and `advisory-convergence` read it. This
+ * function only correlates a `valid` entry back to the comment that carried
+ * it, so an expired, wrong-HEAD, or wrong-claim waiver is never reused —
+ * it simply never appears in `evidence.valid`.
+ *
+ * The earliest matching comment wins, mirroring the release-marker path's
+ * reuse-the-earliest rule, so a retry converges on one marker rather than
+ * picking a different one each pass.
+ */
+export function findReusableWaiverComment({
+  comments,
+  evidence,
+  checkSelector,
+}) {
+  const selector = String(checkSelector ?? '').trim();
+  if (!selector) return null;
+  const validForSelector = (evidence?.valid ?? []).filter(
+    (entry) => entry.checkSelector === selector,
+  );
+  if (validForSelector.length === 0) return null;
+  const ordered = [...(comments ?? [])].sort((left, right) =>
+    String(left?.created_at ?? '').localeCompare(
+      String(right?.created_at ?? ''),
+    ),
+  );
+  for (const comment of ordered) {
+    const parsed = parseExternalCheckWaiverComment(
+      String(comment?.body ?? ''),
+      String(comment?.created_at ?? ''),
+    );
+    if (!parsed || parsed.checkSelector !== selector) continue;
+    const matchesValidEntry = validForSelector.some(
+      (entry) =>
+        entry.expiresAt === parsed.expiresAt &&
+        entry.createdAt === parsed.createdAt,
+    );
+    if (!matchesValidEntry) continue;
+    return {
+      commentId: String(comment?.id ?? ''),
+      commentUrl: String(comment?.html_url ?? comment?.url ?? ''),
+      checkSelector: selector,
+      expiresAt: parsed.expiresAt,
+    };
+  }
+  return null;
 }
 function selectorRequestsGlob(selector) {
   return /[*]/.test(String(selector ?? ''));

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -5,6 +5,11 @@
 // above by `pnpm run build`. Edit the .mts source, never the generated
 // .mjs. See docs/typescript-sources.md.
 import { readFileSync } from 'node:fs';
+import {
+  buildAdvisoryConvergenceWaiverPrecondition,
+  DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+  resolveAdvisoryConvergenceDeadlineMinutes,
+} from './advisory-wait-policy.mjs';
 import { parseCliArgs } from './cli-args.mjs';
 import { resolveTrustedCollaboratorMarkerLogins } from './collaborator-permission.mjs';
 import { resolveHelperActiveClaim } from './forced-handoff-marker.mjs';
@@ -205,6 +210,47 @@ export function planExternalCheckWaiver(input, options = {}) {
       'one or more matched checks are not configured as waivable external checks',
     );
   }
+  // #2328: `idd-advisory-convergence` never treats a posted waiver as active
+  // until its own precondition opens, so rendering one before then produces a
+  // marker the gate ignores. Report that precondition from the shared builder
+  // -- the same one `pre-merge-readiness` uses -- and block on a closed hatch,
+  // rather than reporting no blocking reasons while the gate reports the hatch
+  // shut. Only the EXACT selector is gated: a glob waiver is never treated as
+  // covering this check by the gate either (#2021), so gating one here would
+  // block for the wrong reason.
+  //
+  // The terminal opener is deliberately NOT evaluated: proving it needs
+  // trusted advisory-wait recovery-marker state this helper does not collect.
+  // The blocking reason therefore says the deadline has not passed, never that
+  // no opener applies -- an unevaluated terminal opener may well be open.
+  const preconditionGatedSelector =
+    requestedMatchMode === 'exact' &&
+    requestedSelector === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR;
+  const advisoryConvergenceWaiverPrecondition = preconditionGatedSelector
+    ? (() => {
+        const { precondition } = buildAdvisoryConvergenceWaiverPrecondition({
+          headCommittedAt: input?.headCommittedAt,
+          deadlineMinutes: input?.advisoryConvergenceDeadlineMinutes,
+          now: now.toISOString(),
+        });
+        return { ...precondition, terminalEvaluated: false };
+      })()
+    : undefined;
+  const allowClosedPrecondition = input?.allowClosedPrecondition === true;
+  if (
+    advisoryConvergenceWaiverPrecondition &&
+    !advisoryConvergenceWaiverPrecondition.open &&
+    !allowClosedPrecondition
+  ) {
+    const elapsed = advisoryConvergenceWaiverPrecondition.elapsedMinutes;
+    blockingReasons.push(
+      `${DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR} waiver deadline has not passed ` +
+        `(${elapsed === null ? 'elapsed unknown' : `${elapsed} of ${advisoryConvergenceWaiverPrecondition.deadlineMinutes} minutes`}` +
+        `, anchored on HEAD commit ${advisoryConvergenceWaiverPrecondition.headCommittedAt}); ` +
+        'terminal Copilot unavailability was not evaluated here, so pass ' +
+        '--allow-closed-precondition if that opener already applies',
+    );
+  }
   // #1905: --claimless binds the marker to the sentinel claim-id `none` and
   // the acting maintainer's own identity as agentId (there is no
   // issue-claim agentId to reuse when the PR carries no active claim by
@@ -279,6 +325,9 @@ export function planExternalCheckWaiver(input, options = {}) {
       uncoveredChecks,
     },
     blockingReasons,
+    ...(advisoryConvergenceWaiverPrecondition
+      ? { advisoryConvergenceWaiverPrecondition }
+      : {}),
     body,
   };
 }
@@ -379,6 +428,14 @@ export async function runExternalCheckWaiver(options = {}) {
       }),
       repoOwner: owner,
       claimless: args.claimless,
+      headCommittedAt: fetchHeadCommittedAt({
+        owner,
+        repo: name,
+        headRefOid: String(pr.headRefOid ?? '').trim(),
+      }),
+      allowClosedPrecondition: args.allowClosedPrecondition,
+      advisoryConvergenceDeadlineMinutes:
+        resolveAdvisoryConvergenceDeadlineMinutes(rawConfig),
     },
     { now: options.now, repoOwner: owner },
   );
@@ -685,6 +742,25 @@ function fetchPullRequest({ owner, repo, prNumber }) {
     'number,state,url,headRefName,headRefOid,statusCheckRollup,closingIssuesReferences',
   ]);
 }
+/**
+ * #2328: the HEAD commit's own `committer.date`, the anchor the
+ * `idd-advisory-convergence` waiver deadline is measured from. Returns an
+ * empty string on any failure — a missing anchor keeps the hatch shut, which
+ * is the safe direction, and never blocks a selector that is not
+ * precondition-gated.
+ */
+function fetchHeadCommittedAt({ owner, repo, headRefOid }) {
+  if (!headRefOid) return '';
+  try {
+    const payload = ghJson([
+      'api',
+      `repos/${owner}/${repo}/commits/${headRefOid}`,
+    ]);
+    return String(payload?.commit?.committer?.date ?? '').trim();
+  } catch {
+    return '';
+  }
+}
 function resolveCollaboratorAuthority({ owner, repo, actor }) {
   const normalized = String(actor ?? '')
     .trim()
@@ -889,6 +965,7 @@ const EXTERNAL_CHECK_WAIVER_FLAG_SPEC = {
   '--yes': { type: 'boolean', default: false },
   '--format': { type: 'string', default: 'json' },
   '--claimless': { type: 'boolean', default: false },
+  '--allow-closed-precondition': { type: 'boolean', default: false },
   '--help': { type: 'boolean', short: 'h' },
 };
 export function parseArgs(argv) {
@@ -920,6 +997,7 @@ export function parseArgs(argv) {
     yes: values.yes,
     format,
     claimless: values.claimless,
+    allowClosedPrecondition: values['allow-closed-precondition'],
     help,
   };
   if (!parsed.help) {
@@ -977,6 +1055,11 @@ Options:
                                      resolving a linked issue's active claim; for a PR with
                                      no IDD claim at all (e.g. Dependabot). Cannot combine
                                      with --issue or --claim-id.
+  --allow-closed-precondition       post an idd-advisory-convergence waiver even though its
+                                     deadline has not passed. The marker stays inert until a
+                                     precondition opens; use it when terminal Copilot
+                                     unavailability already applies, which this helper does
+                                     not evaluate.
   --actor <login>                   override the GitHub actor used for authority evaluation
   --repo <owner/name>               repository override
   --apply                           post the canonical waiver comment after validation

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -504,6 +504,12 @@ export async function runExternalCheckWaiver(options = {}) {
         evidence: summarizeExternalCheckWaivers(prComments, {
           prHeadSha: wouldPost.headSha,
           activeClaimId: wouldPost.claimId,
+          // The gate accepts a waiver bound to the immediate predecessor
+          // claim through its one-hop takeover exception. Omitting this
+          // would classify such a waiver `wrongClaim` here and append a
+          // second one after every takeover.
+          activeClaimSupersedes:
+            report.linkedIssue?.activeClaim?.supersedes ?? '',
           trustedMarkerLogins: [
             ...buildTrustedMarkerLogins({
               owner,

--- a/scripts/external-check-waiver.mjs
+++ b/scripts/external-check-waiver.mjs
@@ -486,11 +486,14 @@ export async function runExternalCheckWaiver(options = {}) {
   // #2328: appending is not idempotent, so look for an existing valid waiver
   // for this selector first. A repeated `--apply` previously posted a second
   // identical marker, leaving two live waivers on the pull request.
-  const prComments =
+  // Repeatable: called again after the POST for the concurrency reconcile
+  // below, so the second read observes anything that landed meanwhile.
+  const readPrComments = () =>
     typeof options.prComments === 'function'
       ? options.prComments()
       : (options.prComments ??
         fetchPrComments({ owner, repo: name, prNumber: args.prNumber }));
+  const prComments = readPrComments();
   // The marker this invocation would post is the exact context a reusable
   // waiver must match, so recover the HEAD and claim from it rather than
   // threading them separately and risking a mismatch.
@@ -498,10 +501,11 @@ export async function runExternalCheckWaiver(options = {}) {
     report.body,
     new Date().toISOString(),
   );
-  const existingWaiver = wouldPost
-    ? findReusableWaiverComment({
-        comments: prComments,
-        evidence: summarizeExternalCheckWaivers(prComments, {
+  // One evidence build for both the pre-write scan and the post-write
+  // reconcile, so the two can never classify the same marker differently.
+  const buildWaiverEvidence = (comments) =>
+    wouldPost
+      ? summarizeExternalCheckWaivers(comments, {
           prHeadSha: wouldPost.headSha,
           activeClaimId: wouldPost.claimId,
           // The gate accepts a waiver bound to the immediate predecessor
@@ -531,10 +535,13 @@ export async function runExternalCheckWaiver(options = {}) {
               .maxValidity,
           mode: normalizePolicyConfig(rawConfig).ciGate.externalCheckWaivers
             .mode,
-        }),
-        checkSelector: report.requested.selector,
-      })
-    : null;
+        })
+      : null;
+  const existingWaiver = findReusableWaiverComment({
+    comments: prComments,
+    evidence: buildWaiverEvidence(prComments),
+    checkSelector: report.requested.selector,
+  });
   if (existingWaiver) {
     const reusedReport = {
       ...report,
@@ -555,10 +562,36 @@ export async function runExternalCheckWaiver(options = {}) {
         '-f',
         `body=${report.body}`,
       ]);
+  // #2328 (review): the reuse check above and this POST are not one atomic
+  // step, and GitHub comments have no compare-and-swap -- the same limitation
+  // `idd-claim.instructions.md` records for claim markers. Two concurrent
+  // `--apply` runs can therefore both observe no waiver and both post.
+  // Reconcile after the fact the way the claim protocol does: re-read, and
+  // when more than one valid waiver now exists for this selector, name them
+  // all and identify the earliest, which is the one a deterministic reader
+  // resolves to. Reporting rather than deleting -- removing a marker another
+  // session just posted is not this helper's call to make.
+  const concurrentWaivers = wouldPost
+    ? collectValidWaiverComments({
+        comments: readPrComments(),
+        evidence: buildWaiverEvidence(readPrComments()),
+        checkSelector: report.requested.selector,
+      })
+    : [];
+  if (concurrentWaivers.length > 1) {
+    const earliest = concurrentWaivers[0];
+    process.stderr.write(
+      `warning: ${concurrentWaivers.length} valid ${report.requested.selector} waivers now exist on PR #${args.prNumber} ` +
+        `(comment ids ${concurrentWaivers.map((entry) => entry.commentId).join(', ')}). ` +
+        `A concurrent apply raced this one. Readers resolve to the earliest, ${earliest?.commentId}; ` +
+        'minimize the rest so a later session does not have to disambiguate.\n',
+    );
+  }
   const appliedReport = {
     ...report,
     applied: true,
     commentUrl: String(result.html_url ?? result.url ?? ''),
+    ...(concurrentWaivers.length > 1 ? { concurrentWaivers } : {}),
   };
   renderReport(appliedReport, args.format);
   return { exitCode: 0, report: appliedReport };
@@ -600,22 +633,32 @@ function fetchPrComments({ owner, repo, prNumber }) {
  * reuse-the-earliest rule, so a retry converges on one marker rather than
  * picking a different one each pass.
  */
-export function findReusableWaiverComment({
+export function findReusableWaiverComment(input) {
+  return collectValidWaiverComments(input)[0] ?? null;
+}
+/**
+ * #2328 (review): every valid waiver for one selector, earliest first. The
+ * reuse scan takes the first; the post-write reconcile uses the whole list to
+ * detect a concurrent apply that raced this one. Sharing this function keeps
+ * the two from classifying the same marker differently.
+ */
+export function collectValidWaiverComments({
   comments,
   evidence,
   checkSelector,
 }) {
   const selector = String(checkSelector ?? '').trim();
-  if (!selector) return null;
+  if (!selector) return [];
   const validForSelector = (evidence?.valid ?? []).filter(
     (entry) => entry.checkSelector === selector,
   );
-  if (validForSelector.length === 0) return null;
+  if (validForSelector.length === 0) return [];
   const ordered = [...(comments ?? [])].sort((left, right) =>
     String(left?.created_at ?? '').localeCompare(
       String(right?.created_at ?? ''),
     ),
   );
+  const found = [];
   for (const comment of ordered) {
     const parsed = parseExternalCheckWaiverComment(
       String(comment?.body ?? ''),
@@ -628,14 +671,14 @@ export function findReusableWaiverComment({
         entry.createdAt === parsed.createdAt,
     );
     if (!matchesValidEntry) continue;
-    return {
+    found.push({
       commentId: String(comment?.id ?? ''),
       commentUrl: String(comment?.html_url ?? comment?.url ?? ''),
       checkSelector: selector,
       expiresAt: parsed.expiresAt,
-    };
+    });
   }
-  return null;
+  return found;
 }
 function selectorRequestsGlob(selector) {
   return /[*]/.test(String(selector ?? ''));

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -5,6 +5,7 @@
 // generated .mjs. See docs/typescript-sources.md.
 import { Buffer } from 'node:buffer';
 import {
+  buildAdvisoryConvergenceWaiverPrecondition,
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
   DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES,
   DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
@@ -5289,50 +5290,21 @@ export function buildPreMergeReadinessSummary(
   // `advisory-convergence.mts` itself would ever call the waiver `waived`,
   // sending an otherwise-correct session into a `gh pr merge` GitHub rejects
   // outright (root cause: kurone-kito/idd-skill#2021).
-  const advisoryConvergenceDeadlineMinutes = Number.isFinite(
-    options.advisoryConvergenceDeadlineMinutes,
-  )
-    ? Number(options.advisoryConvergenceDeadlineMinutes)
-    : DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
-  const advisoryConvergenceHeadCommittedAt = String(
-    options.advisoryConvergenceHeadCommittedAt ?? '',
-  );
-  const advisoryConvergenceElapsedMinutes = isValidIsoTimestamp(
-    advisoryConvergenceHeadCommittedAt,
-  )
-    ? minutesBetweenIso(advisoryConvergenceHeadCommittedAt, now)
-    : null;
+  const advisoryConvergencePreconditionResult =
+    buildAdvisoryConvergenceWaiverPrecondition({
+      headCommittedAt: options.advisoryConvergenceHeadCommittedAt,
+      deadlineMinutes: options.advisoryConvergenceDeadlineMinutes,
+      terminalUnavailable: copilotUnavailable,
+      now,
+    });
+  const advisoryConvergenceWaiverPrecondition =
+    advisoryConvergencePreconditionResult.precondition;
   const advisoryConvergenceDeadlinePassed =
-    advisoryConvergenceElapsedMinutes !== null &&
-    advisoryConvergenceElapsedMinutes >= advisoryConvergenceDeadlineMinutes;
+    advisoryConvergenceWaiverPrecondition.deadlinePassed;
   const advisoryConvergencePreconditionOpen =
-    advisoryConvergenceDeadlinePassed || copilotUnavailable;
-  // #2034: the deadline-path precondition-open moment as an actual ISO
-  // timestamp, used to override the waiver-active cutoff `summarizeRequiredChecks`
-  // applies to `idd-advisory-convergence` specifically -- that check's waiver
-  // only becomes genuinely active once this precondition opens, which can be
-  // later than the waiver comment's own `createdAt`. Only computed for the
-  // deadline path (`advisoryConvergenceDeadlinePassed`); the terminal-
-  // unavailability path has no equivalent real timestamp to anchor on, so it
-  // intentionally falls back to the waiver's own `createdAt` (see
-  // `waiverActiveSinceOverride` below).
+    advisoryConvergenceWaiverPrecondition.open;
   const advisoryConvergenceDeadlineOpensAt =
-    advisoryConvergenceDeadlinePassed &&
-    isValidIsoTimestamp(advisoryConvergenceHeadCommittedAt)
-      ? new Date(
-          new Date(advisoryConvergenceHeadCommittedAt).getTime() +
-            advisoryConvergenceDeadlineMinutes * 60000,
-        ).toISOString()
-      : '';
-  const advisoryConvergenceWaiverPrecondition = {
-    checkSelector: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
-    deadlineMinutes: advisoryConvergenceDeadlineMinutes,
-    headCommittedAt: advisoryConvergenceHeadCommittedAt || 'none',
-    elapsedMinutes: advisoryConvergenceElapsedMinutes,
-    deadlinePassed: advisoryConvergenceDeadlinePassed,
-    terminalUnavailable: copilotUnavailable,
-    open: advisoryConvergencePreconditionOpen,
-  };
+    advisoryConvergencePreconditionResult.deadlineOpensAt;
   // #2021 (Codex review on PR #2033, two findings): `advisory-convergence.mts`'s
   // own `waived` computation only counts a waiver whose `checkSelector` is an
   // EXACT match to its selector constant (`entry.checkSelector ===

--- a/src/scripts/advisory-wait-policy.mts
+++ b/src/scripts/advisory-wait-policy.mts
@@ -6,6 +6,7 @@
 
 import { readFileSync } from 'node:fs';
 
+import { isValidIsoTimestamp } from './marker-helpers.mts';
 import { loadJson, validateConfigSection } from './validate-schemas.mts';
 
 export const DEFAULT_ADVISORY_REQUEST_CAP = 30;
@@ -475,4 +476,92 @@ function parseConfiguredDurationToMs(value: unknown): number | null {
     return null;
   }
   return totalMilliseconds;
+}
+
+/**
+ * The `idd-advisory-convergence` waiver precondition, in the shape
+ * `pre-merge-readiness` publishes it as
+ * `advisoryConvergenceWaiverPrecondition`.
+ */
+export interface AdvisoryConvergenceWaiverPrecondition {
+  checkSelector: string;
+  deadlineMinutes: number;
+  headCommittedAt: string;
+  elapsedMinutes: number | null;
+  deadlinePassed: boolean;
+  terminalUnavailable: boolean;
+  open: boolean;
+}
+
+/**
+ * Build the `idd-advisory-convergence` waiver precondition (#2021) from its
+ * two independent openers: a deadline anchored on the current HEAD commit's
+ * own timestamp, and proven terminal Copilot unavailability (#1570).
+ *
+ * Extracted from `pre-merge-readiness`'s reducer (#2328) so every consumer
+ * reads one implementation. `external-check-waiver.mts` accepted and posted
+ * a waiver while this precondition was closed, disagreeing with the gate it
+ * is supposed to predict; a second copy of this arithmetic is exactly how
+ * that disagreement arose, so callers must not re-derive it.
+ *
+ * `terminalUnavailable` is supplied by the caller rather than computed here:
+ * proving it needs trusted advisory-wait recovery-marker state, which not
+ * every caller has. A caller that cannot evaluate it passes `false` and must
+ * report the resulting verdict as "deadline not passed" rather than as a bare
+ * closed hatch, since the terminal opener may still be open unseen.
+ *
+ * `deadlineOpensAt` is the deadline path's open moment as a real timestamp
+ * (#2034), used to override a waiver's active-since cutoff. It is empty
+ * unless the deadline itself has passed: the terminal path has no equivalent
+ * anchor and intentionally falls back to the waiver comment's own
+ * `createdAt`.
+ */
+export function buildAdvisoryConvergenceWaiverPrecondition({
+  headCommittedAt,
+  deadlineMinutes,
+  terminalUnavailable = false,
+  now,
+}: {
+  headCommittedAt?: unknown;
+  deadlineMinutes?: unknown;
+  terminalUnavailable?: boolean;
+  now: string;
+}): {
+  precondition: AdvisoryConvergenceWaiverPrecondition;
+  deadlineOpensAt: string;
+} {
+  const resolvedDeadlineMinutes = Number.isFinite(deadlineMinutes)
+    ? Number(deadlineMinutes)
+    : DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
+  const resolvedHeadCommittedAt = String(headCommittedAt ?? '');
+  const headCommittedAtValid = isValidIsoTimestamp(resolvedHeadCommittedAt);
+  const elapsedMinutes = headCommittedAtValid
+    ? Math.floor(
+        (new Date(now).getTime() -
+          new Date(resolvedHeadCommittedAt).getTime()) /
+          60000,
+      )
+    : null;
+  const deadlinePassed =
+    elapsedMinutes !== null && elapsedMinutes >= resolvedDeadlineMinutes;
+  const resolvedTerminalUnavailable = terminalUnavailable === true;
+
+  return {
+    precondition: {
+      checkSelector: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      deadlineMinutes: resolvedDeadlineMinutes,
+      headCommittedAt: resolvedHeadCommittedAt || 'none',
+      elapsedMinutes,
+      deadlinePassed,
+      terminalUnavailable: resolvedTerminalUnavailable,
+      open: deadlinePassed || resolvedTerminalUnavailable,
+    },
+    deadlineOpensAt:
+      deadlinePassed && headCommittedAtValid
+        ? new Date(
+            new Date(resolvedHeadCommittedAt).getTime() +
+              resolvedDeadlineMinutes * 60000,
+          ).toISOString()
+        : '',
+  };
 }

--- a/src/scripts/advisory-wait-policy.mts
+++ b/src/scripts/advisory-wait-policy.mts
@@ -535,13 +535,20 @@ export function buildAdvisoryConvergenceWaiverPrecondition({
     : DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
   const resolvedHeadCommittedAt = String(headCommittedAt ?? '');
   const headCommittedAtValid = isValidIsoTimestamp(resolvedHeadCommittedAt);
-  const elapsedMinutes = headCommittedAtValid
-    ? Math.floor(
-        (new Date(now).getTime() -
-          new Date(resolvedHeadCommittedAt).getTime()) /
-          60000,
-      )
-    : null;
+  // Clamped exactly as `minutesBetweenIso` does, which is what
+  // `pre-merge-readiness` used before this extraction and what
+  // `advisory-convergence.mts` still uses: a HEAD commit dated ahead of the
+  // runner clock yields 0, never a negative elapsed. Subtracting directly
+  // would make this shared report disagree with the gate on a clock-skewed
+  // or deliberately future-dated commit.
+  const nowMs = Date.parse(now);
+  const headMs = Date.parse(resolvedHeadCommittedAt);
+  const elapsedMinutes =
+    headCommittedAtValid && Number.isFinite(nowMs) && Number.isFinite(headMs)
+      ? nowMs < headMs
+        ? 0
+        : Math.floor((nowMs - headMs) / 60000)
+      : null;
   const deadlinePassed =
     elapsedMinutes !== null && elapsedMinutes >= resolvedDeadlineMinutes;
   const resolvedTerminalUnavailable = terminalUnavailable === true;

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -315,6 +315,8 @@ interface RunExternalCheckWaiverOptions {
   prompt?: PromptFn;
   /** #2328: injected PR issue comments, for the reuse scan under test. */
   prComments?: WaiverCommentPayload[];
+  /** #2328: injected HEAD commit timestamp, so tests skip the commit read. */
+  headCommittedAt?: string;
   postComment?: (
     prNumber: number,
     body: string,
@@ -748,11 +750,13 @@ export async function runExternalCheckWaiver(
       }),
       repoOwner: owner,
       claimless: args.claimless,
-      headCommittedAt: fetchHeadCommittedAt({
-        owner,
-        repo: name,
-        headRefOid: String(pr.headRefOid ?? '').trim(),
-      }),
+      headCommittedAt:
+        options.headCommittedAt ??
+        fetchHeadCommittedAt({
+          owner,
+          repo: name,
+          headRefOid: String(pr.headRefOid ?? '').trim(),
+        }),
       allowClosedPrecondition: args.allowClosedPrecondition,
       advisoryConvergenceDeadlineMinutes:
         resolveAdvisoryConvergenceDeadlineMinutes(rawConfig),

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -883,10 +883,21 @@ export async function runExternalCheckWaiver(
             .mode,
         })
       : null;
+  // The marker this invocation would post defines the binding a reusable
+  // waiver must share; the predecessor claim is accepted too, matching the
+  // gate's one-hop takeover exception.
+  const allowedClaimIds = wouldPost
+    ? [
+        wouldPost.claimId,
+        String(report.linkedIssue?.activeClaim?.supersedes ?? ''),
+      ].filter((value) => value && value !== 'none')
+    : [];
   const existingWaiver = findReusableWaiverComment({
     comments: prComments,
     evidence: buildWaiverEvidence(prComments),
     checkSelector: report.requested.selector,
+    expectedHeadSha: wouldPost?.headSha ?? '',
+    allowedClaimIds,
   });
   if (existingWaiver) {
     const reusedReport = {
@@ -953,6 +964,8 @@ export async function runExternalCheckWaiver(
           comments: postWriteComments,
           evidence: buildWaiverEvidence(postWriteComments),
           checkSelector: report.requested.selector,
+          expectedHeadSha: wouldPost?.headSha ?? '',
+          allowedClaimIds,
         })
       : [];
   if (concurrentWaivers.length > 1) {
@@ -1045,6 +1058,8 @@ export function findReusableWaiverComment(input: {
   comments: WaiverCommentPayload[] | null | undefined;
   evidence: ExternalCheckWaiverEvidence | null | undefined;
   checkSelector: string;
+  expectedHeadSha?: string;
+  allowedClaimIds?: string[];
 }): ReusableWaiver | null {
   return collectValidWaiverComments(input)[0] ?? null;
 }
@@ -1059,10 +1074,26 @@ export function collectValidWaiverComments({
   comments,
   evidence,
   checkSelector,
+  expectedHeadSha = '',
+  allowedClaimIds = [],
 }: {
   comments: WaiverCommentPayload[] | null | undefined;
   evidence: ExternalCheckWaiverEvidence | null | undefined;
   checkSelector: string;
+  /**
+   * #2328 (review): the HEAD the waiver must bind to. The summarizer keeps a
+   * wrong-HEAD marker out of `valid`, but a wrong-HEAD comment can still
+   * match a valid entry produced by a DIFFERENT comment when author, reason,
+   * expiry, and second all coincide — the entry carries no binding of its
+   * own to rule that out. Empty skips the check.
+   */
+  expectedHeadSha?: string;
+  /**
+   * #2328 (review): the claim ids a waiver may bind to — the active claim,
+   * plus its immediate predecessor for the gate's one-hop takeover
+   * exception. Empty skips the check.
+   */
+  allowedClaimIds?: string[];
 }): ReusableWaiver[] {
   const selector = String(checkSelector ?? '').trim();
   if (!selector) return [];
@@ -1095,6 +1126,30 @@ export function collectValidWaiverComments({
     )
       .trim()
       .toLowerCase();
+    // The evidence entry carries no HEAD or claim binding, so those are
+    // checked against the expected values directly. Without this a
+    // wrong-HEAD or wrong-claim marker sharing all four entry fields with a
+    // genuinely valid sibling would still correlate.
+    const normalizedHead = String(expectedHeadSha ?? '')
+      .trim()
+      .toLowerCase();
+    if (
+      normalizedHead &&
+      String(parsed.headSha ?? '')
+        .trim()
+        .toLowerCase() !== normalizedHead
+    ) {
+      continue;
+    }
+    const acceptedClaimIds = (allowedClaimIds ?? [])
+      .map((value) => String(value ?? '').trim())
+      .filter((value) => value.length > 0);
+    if (
+      acceptedClaimIds.length > 0 &&
+      !acceptedClaimIds.includes(String(parsed.claimId ?? '').trim())
+    ) {
+      continue;
+    }
     const matchesValidEntry = validForSelector.some(
       (entry) =>
         entry.authorLogin === commentAuthorLogin &&

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -6,7 +6,11 @@
 // .mjs. See docs/typescript-sources.md.
 
 import { readFileSync } from 'node:fs';
-
+import {
+  buildAdvisoryConvergenceWaiverPrecondition,
+  DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+  resolveAdvisoryConvergenceDeadlineMinutes,
+} from './advisory-wait-policy.mts';
 import { parseCliArgs } from './cli-args.mts';
 import { resolveTrustedCollaboratorMarkerLogins } from './collaborator-permission.mts';
 import { resolveHelperActiveClaim } from './forced-handoff-marker.mts';
@@ -161,6 +165,28 @@ interface ExternalCheckWaiverPlanInput {
   expiresAt?: string;
   repoOwner?: string;
   /**
+   * #2328: the current HEAD commit's own timestamp, the anchor the
+   * `idd-advisory-convergence` waiver deadline is measured from. Absent or
+   * unparseable keeps the hatch shut, which is the safe direction.
+   */
+  headCommittedAt?: string;
+  /**
+   * #2328: the configured `advisoryWait.convergenceDeadline` in minutes.
+   * Supplied by the caller from the RAW policy document, exactly as
+   * `pre-merge-readiness` receives it: `normalizePolicyConfig` does not carry
+   * `convergenceDeadline` through, so reading it off the normalized policy
+   * would silently substitute the 24h default for a repository that
+   * configured something shorter.
+   */
+  advisoryConvergenceDeadlineMinutes?: number;
+  /**
+   * #2328: post an `idd-advisory-convergence` waiver even though its hatch
+   * has not opened. The marker is inert until the hatch opens, so this is
+   * for an operator who knows the terminal opener applies -- which this
+   * helper does not evaluate.
+   */
+  allowClosedPrecondition?: boolean;
+  /**
    * #1905: render a claimless waiver -- claim-id `none` -- instead of
    * resolving the claim-id from a linked issue's active IDD claim. Skips
    * the linked-issue-claim requirement entirely; blocks instead when a
@@ -210,6 +236,23 @@ interface ExternalCheckWaiverReport {
     uncoveredChecks: NormalizedCheck[];
   };
   blockingReasons: string[];
+  /**
+   * #2328: present only for the precondition-gated
+   * `idd-advisory-convergence` selector. `terminalUnavailable` is always
+   * `false` here: this helper evaluates the deadline opener only, so a
+   * closed verdict means "the deadline has not passed", never "no opener
+   * applies".
+   */
+  advisoryConvergenceWaiverPrecondition?: {
+    checkSelector: string;
+    deadlineMinutes: number;
+    headCommittedAt: string;
+    elapsedMinutes: number | null;
+    deadlinePassed: boolean;
+    terminalUnavailable: boolean;
+    open: boolean;
+    terminalEvaluated: boolean;
+  };
   body: string;
   applied?: boolean;
   commentUrl?: string;
@@ -230,6 +273,7 @@ interface ExternalCheckWaiverArgs {
   yes: boolean;
   format: string;
   claimless: boolean;
+  allowClosedPrecondition: boolean;
   help: boolean;
 }
 
@@ -461,6 +505,48 @@ export function planExternalCheckWaiver(
     );
   }
 
+  // #2328: `idd-advisory-convergence` never treats a posted waiver as active
+  // until its own precondition opens, so rendering one before then produces a
+  // marker the gate ignores. Report that precondition from the shared builder
+  // -- the same one `pre-merge-readiness` uses -- and block on a closed hatch,
+  // rather than reporting no blocking reasons while the gate reports the hatch
+  // shut. Only the EXACT selector is gated: a glob waiver is never treated as
+  // covering this check by the gate either (#2021), so gating one here would
+  // block for the wrong reason.
+  //
+  // The terminal opener is deliberately NOT evaluated: proving it needs
+  // trusted advisory-wait recovery-marker state this helper does not collect.
+  // The blocking reason therefore says the deadline has not passed, never that
+  // no opener applies -- an unevaluated terminal opener may well be open.
+  const preconditionGatedSelector =
+    requestedMatchMode === 'exact' &&
+    requestedSelector === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR;
+  const advisoryConvergenceWaiverPrecondition = preconditionGatedSelector
+    ? (() => {
+        const { precondition } = buildAdvisoryConvergenceWaiverPrecondition({
+          headCommittedAt: input?.headCommittedAt,
+          deadlineMinutes: input?.advisoryConvergenceDeadlineMinutes,
+          now: now.toISOString(),
+        });
+        return { ...precondition, terminalEvaluated: false };
+      })()
+    : undefined;
+  const allowClosedPrecondition = input?.allowClosedPrecondition === true;
+  if (
+    advisoryConvergenceWaiverPrecondition &&
+    !advisoryConvergenceWaiverPrecondition.open &&
+    !allowClosedPrecondition
+  ) {
+    const elapsed = advisoryConvergenceWaiverPrecondition.elapsedMinutes;
+    blockingReasons.push(
+      `${DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR} waiver deadline has not passed ` +
+        `(${elapsed === null ? 'elapsed unknown' : `${elapsed} of ${advisoryConvergenceWaiverPrecondition.deadlineMinutes} minutes`}` +
+        `, anchored on HEAD commit ${advisoryConvergenceWaiverPrecondition.headCommittedAt}); ` +
+        'terminal Copilot unavailability was not evaluated here, so pass ' +
+        '--allow-closed-precondition if that opener already applies',
+    );
+  }
+
   // #1905: --claimless binds the marker to the sentinel claim-id `none` and
   // the acting maintainer's own identity as agentId (there is no
   // issue-claim agentId to reuse when the PR carries no active claim by
@@ -536,6 +622,9 @@ export function planExternalCheckWaiver(
       uncoveredChecks,
     },
     blockingReasons,
+    ...(advisoryConvergenceWaiverPrecondition
+      ? { advisoryConvergenceWaiverPrecondition }
+      : {}),
     body,
   };
 }
@@ -647,6 +736,14 @@ export async function runExternalCheckWaiver(
       }),
       repoOwner: owner,
       claimless: args.claimless,
+      headCommittedAt: fetchHeadCommittedAt({
+        owner,
+        repo: name,
+        headRefOid: String(pr.headRefOid ?? '').trim(),
+      }),
+      allowClosedPrecondition: args.allowClosedPrecondition,
+      advisoryConvergenceDeadlineMinutes:
+        resolveAdvisoryConvergenceDeadlineMinutes(rawConfig),
     },
     { now: options.now, repoOwner: owner },
   );
@@ -1016,6 +1113,34 @@ function fetchPullRequest({
   ]) as PrPayload;
 }
 
+/**
+ * #2328: the HEAD commit's own `committer.date`, the anchor the
+ * `idd-advisory-convergence` waiver deadline is measured from. Returns an
+ * empty string on any failure — a missing anchor keeps the hatch shut, which
+ * is the safe direction, and never blocks a selector that is not
+ * precondition-gated.
+ */
+function fetchHeadCommittedAt({
+  owner,
+  repo,
+  headRefOid,
+}: {
+  owner: string;
+  repo: string;
+  headRefOid: string;
+}): string {
+  if (!headRefOid) return '';
+  try {
+    const payload = ghJson([
+      'api',
+      `repos/${owner}/${repo}/commits/${headRefOid}`,
+    ]) as { commit?: { committer?: { date?: unknown } } } | null;
+    return String(payload?.commit?.committer?.date ?? '').trim();
+  } catch {
+    return '';
+  }
+}
+
 function resolveCollaboratorAuthority({
   owner,
   repo,
@@ -1249,6 +1374,7 @@ const EXTERNAL_CHECK_WAIVER_FLAG_SPEC = {
   '--yes': { type: 'boolean', default: false },
   '--format': { type: 'string', default: 'json' },
   '--claimless': { type: 'boolean', default: false },
+  '--allow-closed-precondition': { type: 'boolean', default: false },
   '--help': { type: 'boolean', short: 'h' },
 } as const;
 
@@ -1285,6 +1411,7 @@ export function parseArgs(argv: string[]): ExternalCheckWaiverArgs {
     yes: values.yes as boolean,
     format,
     claimless: values.claimless as boolean,
+    allowClosedPrecondition: values['allow-closed-precondition'] as boolean,
     help,
   };
 
@@ -1348,6 +1475,11 @@ Options:
                                      resolving a linked issue's active claim; for a PR with
                                      no IDD claim at all (e.g. Dependabot). Cannot combine
                                      with --issue or --claim-id.
+  --allow-closed-precondition       post an idd-advisory-convergence waiver even though its
+                                     deadline has not passed. The marker stays inert until a
+                                     precondition opens; use it when terminal Copilot
+                                     unavailability already applies, which this helper does
+                                     not evaluate.
   --actor <login>                   override the GitHub actor used for authority evaluation
   --repo <owner/name>               repository override
   --apply                           post the canonical waiver comment after validation

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -833,6 +833,12 @@ export async function runExternalCheckWaiver(
         evidence: summarizeExternalCheckWaivers(prComments, {
           prHeadSha: wouldPost.headSha,
           activeClaimId: wouldPost.claimId,
+          // The gate accepts a waiver bound to the immediate predecessor
+          // claim through its one-hop takeover exception. Omitting this
+          // would classify such a waiver `wrongClaim` here and append a
+          // second one after every takeover.
+          activeClaimSupersedes:
+            report.linkedIssue?.activeClaim?.supersedes ?? '',
           trustedMarkerLogins: [
             ...buildTrustedMarkerLogins({
               owner,

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -848,13 +848,19 @@ export async function runExternalCheckWaiver(
           // second one after every takeover.
           activeClaimSupersedes:
             report.linkedIssue?.activeClaim?.supersedes ?? '',
+          // Derived from the SAME snapshot being summarized, never from the
+          // pre-write one. With collaborator-marker trust enabled, a
+          // maintainer absent from the earlier read would otherwise be
+          // classified unauthorized here while the gate — which derives
+          // trust from the final comments — accepts their waiver, so the
+          // reconcile would miss exactly the duplicate it exists to find.
           trustedMarkerLogins: [
             ...buildTrustedMarkerLogins({
               owner,
               repo: name,
               rawConfig,
               viewerLogin: actor,
-              issueComments: prComments,
+              issueComments: comments,
             }),
           ],
           now: (options.now instanceof Date
@@ -907,10 +913,17 @@ export async function runExternalCheckWaiver(
   // all and identify the earliest, which is the one a deterministic reader
   // resolves to. Reporting rather than deleting -- removing a marker another
   // session just posted is not this helper's call to make.
+  // ONE snapshot for both arguments. Two sequential reads would let a waiver
+  // land between them, leaving `comments` older than `evidence`;
+  // `collectValidWaiverComments` can only correlate entries it can find in
+  // `comments`, so the newer marker would be dropped and the duplicate
+  // silently missed — a snapshot mismatch inside the code that exists to
+  // catch mismatches.
+  const postWriteComments = wouldPost ? readPrComments() : [];
   const concurrentWaivers = wouldPost
     ? collectValidWaiverComments({
-        comments: readPrComments(),
-        evidence: buildWaiverEvidence(readPrComments()),
+        comments: postWriteComments,
+        evidence: buildWaiverEvidence(postWriteComments),
         checkSelector: report.requested.selector,
       })
     : [];

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -271,6 +271,12 @@ interface ExternalCheckWaiverReport {
    * present only when a concurrent apply raced this one into a duplicate.
    */
   concurrentWaivers?: ReusableWaiver[];
+  /**
+   * #2328 (review): the waiver was posted, but the post-write re-read failed,
+   * so a concurrent duplicate could not be ruled out. The apply still
+   * succeeded — only the reconcile is unknown.
+   */
+  reconcileInconclusive?: boolean;
 }
 
 /** Parsed CLI arguments. */
@@ -919,14 +925,36 @@ export async function runExternalCheckWaiver(
   // `comments`, so the newer marker would be dropped and the duplicate
   // silently missed — a snapshot mismatch inside the code that exists to
   // catch mismatches.
-  const postWriteComments = wouldPost ? readPrComments() : [];
-  const concurrentWaivers = wouldPost
-    ? collectValidWaiverComments({
-        comments: postWriteComments,
-        evidence: buildWaiverEvidence(postWriteComments),
-        checkSelector: report.requested.selector,
-      })
-    : [];
+  //
+  // Failing closed is right BEFORE the post, where an unreadable list can
+  // cause a duplicate. After it the waiver already exists and the write is
+  // irreversible, so throwing here would report a failed apply for work that
+  // succeeded and would withhold the posted comment URL — pushing an operator
+  // toward a retry that can only make things worse. Degrade to a warning and
+  // still render the applied result; only duplicate detection is lost.
+  let postWriteComments: WaiverCommentPayload[] = [];
+  let reconcileInconclusive = false;
+  if (wouldPost) {
+    try {
+      postWriteComments = readPrComments();
+    } catch (error) {
+      reconcileInconclusive = true;
+      process.stderr.write(
+        `warning: the waiver was posted, but re-reading PR #${args.prNumber} comments failed, ` +
+          `so a concurrent duplicate could not be ruled out: ${String(
+            (error as { message?: unknown })?.message ?? error,
+          )}\n`,
+      );
+    }
+  }
+  const concurrentWaivers =
+    wouldPost && !reconcileInconclusive
+      ? collectValidWaiverComments({
+          comments: postWriteComments,
+          evidence: buildWaiverEvidence(postWriteComments),
+          checkSelector: report.requested.selector,
+        })
+      : [];
   if (concurrentWaivers.length > 1) {
     const earliest = concurrentWaivers[0];
     process.stderr.write(
@@ -942,6 +970,7 @@ export async function runExternalCheckWaiver(
     applied: true,
     commentUrl: String(result.html_url ?? result.url ?? ''),
     ...(concurrentWaivers.length > 1 ? { concurrentWaivers } : {}),
+    ...(reconcileInconclusive ? { reconcileInconclusive: true } : {}),
   };
   renderReport(appliedReport, args.format);
   return { exitCode: 0, report: appliedReport };

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -332,6 +332,12 @@ interface RunExternalCheckWaiverOptions {
   prComments?: WaiverCommentPayload[] | (() => WaiverCommentPayload[]);
   /** #2328: injected HEAD commit timestamp, so tests skip the commit read. */
   headCommittedAt?: string;
+  /**
+   * #2328 (review): injected linked-issue resolver, called once before the
+   * post and once for the reconcile, so a test can model a takeover landing
+   * between them.
+   */
+  resolveIssueCandidates?: () => IssueCandidatePayload[];
   postComment?: (
     prNumber: number,
     body: string,
@@ -732,6 +738,7 @@ export async function runExternalCheckWaiver(
     fetchPullRequest({ owner, repo: name, prNumber: args.prNumber });
   const issueCandidates =
     options.issueCandidates ??
+    options.resolveIssueCandidates?.() ??
     resolveLinkedIssueCandidates({
       owner,
       repo: name,
@@ -843,17 +850,19 @@ export async function runExternalCheckWaiver(
   );
   // One evidence build for both the pre-write scan and the post-write
   // reconcile, so the two can never classify the same marker differently.
-  const buildWaiverEvidence = (comments: WaiverCommentPayload[]) =>
+  const buildWaiverEvidence = (
+    comments: WaiverCommentPayload[],
+    binding: { claimId: string; supersedes: string },
+  ) =>
     wouldPost
       ? summarizeExternalCheckWaivers(comments, {
           prHeadSha: wouldPost.headSha,
-          activeClaimId: wouldPost.claimId,
+          activeClaimId: binding.claimId,
           // The gate accepts a waiver bound to the immediate predecessor
           // claim through its one-hop takeover exception. Omitting this
           // would classify such a waiver `wrongClaim` here and append a
           // second one after every takeover.
-          activeClaimSupersedes:
-            report.linkedIssue?.activeClaim?.supersedes ?? '',
+          activeClaimSupersedes: binding.supersedes,
           // Derived from the SAME snapshot being summarized, never from the
           // pre-write one. With collaborator-marker trust enabled, a
           // maintainer absent from the earlier read would otherwise be
@@ -886,18 +895,23 @@ export async function runExternalCheckWaiver(
   // The marker this invocation would post defines the binding a reusable
   // waiver must share; the predecessor claim is accepted too, matching the
   // gate's one-hop takeover exception.
-  const allowedClaimIds = wouldPost
-    ? [
-        wouldPost.claimId,
-        String(report.linkedIssue?.activeClaim?.supersedes ?? ''),
-      ].filter((value) => value && value !== 'none')
-    : [];
+  const toAllowedClaimIds = (binding: {
+    claimId: string;
+    supersedes: string;
+  }): string[] =>
+    [binding.claimId, binding.supersedes].filter(
+      (value) => value && value !== 'none',
+    );
+  const preWriteBinding = {
+    claimId: wouldPost?.claimId ?? '',
+    supersedes: String(report.linkedIssue?.activeClaim?.supersedes ?? ''),
+  };
   const existingWaiver = findReusableWaiverComment({
     comments: prComments,
-    evidence: buildWaiverEvidence(prComments),
+    evidence: buildWaiverEvidence(prComments, preWriteBinding),
     checkSelector: report.requested.selector,
     expectedHeadSha: wouldPost?.headSha ?? '',
-    allowedClaimIds,
+    allowedClaimIds: toAllowedClaimIds(preWriteBinding),
   });
   if (existingWaiver) {
     const reusedReport = {
@@ -958,14 +972,60 @@ export async function runExternalCheckWaiver(
       );
     }
   }
+  // #2328 (review): re-resolve the claim for the reconcile rather than
+  // reusing the pre-write binding. If a takeover lands between the two, the
+  // gate resolves the successor with the predecessor as `supersedes` and
+  // accepts BOTH waivers, while a summarizer still pinned to the predecessor
+  // classifies the successor's as `wrongClaim` and reports no duplicate --
+  // silence exactly where the operator most needs the warning. A failure to
+  // re-resolve makes the reconcile inconclusive rather than wrong; the apply
+  // itself already succeeded and is never retracted for this.
+  let postWriteBinding = preWriteBinding;
+  if (wouldPost && !reconcileInconclusive) {
+    try {
+      const refreshed = selectLinkedIssueCandidate(
+        options.issueCandidates ??
+          options.resolveIssueCandidates?.() ??
+          resolveLinkedIssueCandidates({
+            owner,
+            repo: name,
+            rawConfig,
+            viewerLogin: actor,
+            linkedIssues: pr.closingIssuesReferences,
+            issueNumber: args.issueNumber,
+            expectedClaimId: '',
+            headRefName: pr.headRefName,
+            prNumber: args.prNumber,
+          }),
+        {
+          issueNumber: args.issueNumber,
+          headRefName: String(pr.headRefName ?? ''),
+        },
+      );
+      if (refreshed.ok) {
+        postWriteBinding = {
+          claimId: refreshed.issue.activeClaim.claimId,
+          supersedes: String(refreshed.issue.activeClaim.supersedes ?? ''),
+        };
+      }
+    } catch (error) {
+      reconcileInconclusive = true;
+      process.stderr.write(
+        `warning: the waiver was posted, but re-resolving the active claim failed, ` +
+          `so a concurrent duplicate could not be ruled out: ${String(
+            (error as { message?: unknown })?.message ?? error,
+          )}\n`,
+      );
+    }
+  }
   const concurrentWaivers =
     wouldPost && !reconcileInconclusive
       ? collectValidWaiverComments({
           comments: postWriteComments,
-          evidence: buildWaiverEvidence(postWriteComments),
+          evidence: buildWaiverEvidence(postWriteComments, postWriteBinding),
           checkSelector: report.requested.selector,
           expectedHeadSha: wouldPost?.headSha ?? '',
-          allowedClaimIds,
+          allowedClaimIds: toAllowedClaimIds(postWriteBinding),
         })
       : [];
   if (concurrentWaivers.length > 1) {

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -266,6 +266,11 @@ interface ExternalCheckWaiverReport {
    * selector and reused it rather than appending a second marker.
    */
   reusedWaiver?: ReusableWaiver;
+  /**
+   * #2328 (review): every valid waiver for this selector after the POST,
+   * present only when a concurrent apply raced this one into a duplicate.
+   */
+  concurrentWaivers?: ReusableWaiver[];
 }
 
 /** Parsed CLI arguments. */
@@ -815,11 +820,14 @@ export async function runExternalCheckWaiver(
   // #2328: appending is not idempotent, so look for an existing valid waiver
   // for this selector first. A repeated `--apply` previously posted a second
   // identical marker, leaving two live waivers on the pull request.
-  const prComments =
+  // Repeatable: called again after the POST for the concurrency reconcile
+  // below, so the second read observes anything that landed meanwhile.
+  const readPrComments = (): WaiverCommentPayload[] =>
     typeof options.prComments === 'function'
       ? options.prComments()
       : (options.prComments ??
         fetchPrComments({ owner, repo: name, prNumber: args.prNumber }));
+  const prComments = readPrComments();
   // The marker this invocation would post is the exact context a reusable
   // waiver must match, so recover the HEAD and claim from it rather than
   // threading them separately and risking a mismatch.
@@ -827,10 +835,11 @@ export async function runExternalCheckWaiver(
     report.body,
     new Date().toISOString(),
   );
-  const existingWaiver = wouldPost
-    ? findReusableWaiverComment({
-        comments: prComments,
-        evidence: summarizeExternalCheckWaivers(prComments, {
+  // One evidence build for both the pre-write scan and the post-write
+  // reconcile, so the two can never classify the same marker differently.
+  const buildWaiverEvidence = (comments: WaiverCommentPayload[]) =>
+    wouldPost
+      ? summarizeExternalCheckWaivers(comments, {
           prHeadSha: wouldPost.headSha,
           activeClaimId: wouldPost.claimId,
           // The gate accepts a waiver bound to the immediate predecessor
@@ -860,10 +869,13 @@ export async function runExternalCheckWaiver(
               .maxValidity,
           mode: normalizePolicyConfig(rawConfig).ciGate.externalCheckWaivers
             .mode,
-        }),
-        checkSelector: report.requested.selector,
-      })
-    : null;
+        })
+      : null;
+  const existingWaiver = findReusableWaiverComment({
+    comments: prComments,
+    evidence: buildWaiverEvidence(prComments),
+    checkSelector: report.requested.selector,
+  });
   if (existingWaiver) {
     const reusedReport = {
       ...report,
@@ -886,10 +898,37 @@ export async function runExternalCheckWaiver(
         `body=${report.body}`,
       ]) as PostedCommentPayload);
 
+  // #2328 (review): the reuse check above and this POST are not one atomic
+  // step, and GitHub comments have no compare-and-swap -- the same limitation
+  // `idd-claim.instructions.md` records for claim markers. Two concurrent
+  // `--apply` runs can therefore both observe no waiver and both post.
+  // Reconcile after the fact the way the claim protocol does: re-read, and
+  // when more than one valid waiver now exists for this selector, name them
+  // all and identify the earliest, which is the one a deterministic reader
+  // resolves to. Reporting rather than deleting -- removing a marker another
+  // session just posted is not this helper's call to make.
+  const concurrentWaivers = wouldPost
+    ? collectValidWaiverComments({
+        comments: readPrComments(),
+        evidence: buildWaiverEvidence(readPrComments()),
+        checkSelector: report.requested.selector,
+      })
+    : [];
+  if (concurrentWaivers.length > 1) {
+    const earliest = concurrentWaivers[0];
+    process.stderr.write(
+      `warning: ${concurrentWaivers.length} valid ${report.requested.selector} waivers now exist on PR #${args.prNumber} ` +
+        `(comment ids ${concurrentWaivers.map((entry) => entry.commentId).join(', ')}). ` +
+        `A concurrent apply raced this one. Readers resolve to the earliest, ${earliest?.commentId}; ` +
+        'minimize the rest so a later session does not have to disambiguate.\n',
+    );
+  }
+
   const appliedReport = {
     ...report,
     applied: true,
     commentUrl: String(result.html_url ?? result.url ?? ''),
+    ...(concurrentWaivers.length > 1 ? { concurrentWaivers } : {}),
   };
   renderReport(appliedReport, args.format);
   return { exitCode: 0, report: appliedReport };
@@ -960,7 +999,21 @@ export interface ReusableWaiver {
  * reuse-the-earliest rule, so a retry converges on one marker rather than
  * picking a different one each pass.
  */
-export function findReusableWaiverComment({
+export function findReusableWaiverComment(input: {
+  comments: WaiverCommentPayload[] | null | undefined;
+  evidence: ExternalCheckWaiverEvidence | null | undefined;
+  checkSelector: string;
+}): ReusableWaiver | null {
+  return collectValidWaiverComments(input)[0] ?? null;
+}
+
+/**
+ * #2328 (review): every valid waiver for one selector, earliest first. The
+ * reuse scan takes the first; the post-write reconcile uses the whole list to
+ * detect a concurrent apply that raced this one. Sharing this function keeps
+ * the two from classifying the same marker differently.
+ */
+export function collectValidWaiverComments({
   comments,
   evidence,
   checkSelector,
@@ -968,19 +1021,20 @@ export function findReusableWaiverComment({
   comments: WaiverCommentPayload[] | null | undefined;
   evidence: ExternalCheckWaiverEvidence | null | undefined;
   checkSelector: string;
-}): ReusableWaiver | null {
+}): ReusableWaiver[] {
   const selector = String(checkSelector ?? '').trim();
-  if (!selector) return null;
+  if (!selector) return [];
   const validForSelector = (evidence?.valid ?? []).filter(
     (entry) => entry.checkSelector === selector,
   );
-  if (validForSelector.length === 0) return null;
+  if (validForSelector.length === 0) return [];
 
   const ordered = [...(comments ?? [])].sort((left, right) =>
     String(left?.created_at ?? '').localeCompare(
       String(right?.created_at ?? ''),
     ),
   );
+  const found: ReusableWaiver[] = [];
   for (const comment of ordered) {
     const parsed = parseExternalCheckWaiverComment(
       String(comment?.body ?? ''),
@@ -993,14 +1047,14 @@ export function findReusableWaiverComment({
         entry.createdAt === parsed.createdAt,
     );
     if (!matchesValidEntry) continue;
-    return {
+    found.push({
       commentId: String(comment?.id ?? ''),
       commentUrl: String(comment?.html_url ?? comment?.url ?? ''),
       checkSelector: selector,
       expiresAt: parsed.expiresAt,
-    };
+    });
   }
-  return null;
+  return found;
 }
 
 function selectorRequestsGlob(selector: unknown): boolean {

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -25,10 +25,15 @@ import {
   parseIsoDurationToMs,
   resolveCollaboratorMarkerTrust,
 } from './policy-helpers.mts';
-import type { ClaimValidationSummary } from './protocol-helpers.mts';
+import type {
+  ClaimValidationSummary,
+  ExternalCheckWaiverEvidence,
+} from './protocol-helpers.mts';
 import {
+  parseExternalCheckWaiverComment,
   parsePaginatedGhNdjson,
   renderExternalCheckWaiverComment,
+  summarizeExternalCheckWaivers,
 } from './protocol-helpers.mts';
 import type { PromptFn } from './readline-prompt.mts';
 import { makeReadlinePrompt } from './readline-prompt.mts';
@@ -256,6 +261,11 @@ interface ExternalCheckWaiverReport {
   body: string;
   applied?: boolean;
   commentUrl?: string;
+  /**
+   * #2328: set when `--apply` found an existing valid waiver for this
+   * selector and reused it rather than appending a second marker.
+   */
+  reusedWaiver?: ReusableWaiver;
 }
 
 /** Parsed CLI arguments. */
@@ -303,6 +313,8 @@ interface RunExternalCheckWaiverOptions {
   now?: Date;
   isTTY?: boolean;
   prompt?: PromptFn;
+  /** #2328: injected PR issue comments, for the reuse scan under test. */
+  prComments?: WaiverCommentPayload[];
   postComment?: (
     prNumber: number,
     body: string,
@@ -786,6 +798,61 @@ export async function runExternalCheckWaiver(
     }
   }
 
+  // #2328: appending is not idempotent, so look for an existing valid waiver
+  // for this selector first. A repeated `--apply` previously posted a second
+  // identical marker, leaving two live waivers on the pull request.
+  const prComments =
+    options.prComments ??
+    fetchPrComments({ owner, repo: name, prNumber: args.prNumber });
+  // The marker this invocation would post is the exact context a reusable
+  // waiver must match, so recover the HEAD and claim from it rather than
+  // threading them separately and risking a mismatch.
+  const wouldPost = parseExternalCheckWaiverComment(
+    report.body,
+    new Date().toISOString(),
+  );
+  const existingWaiver = wouldPost
+    ? findReusableWaiverComment({
+        comments: prComments,
+        evidence: summarizeExternalCheckWaivers(prComments, {
+          prHeadSha: wouldPost.headSha,
+          activeClaimId: wouldPost.claimId,
+          trustedMarkerLogins: [
+            ...buildTrustedMarkerLogins({
+              owner,
+              repo: name,
+              rawConfig,
+              viewerLogin: actor,
+              issueComments: prComments,
+            }),
+          ],
+          now: (options.now instanceof Date
+            ? options.now
+            : new Date()
+          ).toISOString(),
+          waivableSelectors: [
+            ...normalizePolicyConfig(rawConfig).ciGate.externalChecks.waivable,
+          ],
+          maxValidity:
+            normalizePolicyConfig(rawConfig).ciGate.externalCheckWaivers
+              .maxValidity,
+          mode: normalizePolicyConfig(rawConfig).ciGate.externalCheckWaivers
+            .mode,
+        }),
+        checkSelector: report.requested.selector,
+      })
+    : null;
+  if (existingWaiver) {
+    const reusedReport = {
+      ...report,
+      applied: false,
+      reusedWaiver: existingWaiver,
+      commentUrl: existingWaiver.commentUrl,
+    };
+    renderReport(reusedReport, args.format);
+    return { exitCode: 0, report: reusedReport };
+  }
+
   const result = options.postComment
     ? await options.postComment(args.prNumber, report.body)
     : (ghJson([
@@ -804,6 +871,114 @@ export async function runExternalCheckWaiver(
   };
   renderReport(appliedReport, args.format);
   return { exitCode: 0, report: appliedReport };
+}
+
+/**
+ * #2328: the pull request's own issue comments, where waiver markers live.
+ * Paginated so a long conversation cannot hide an existing waiver and cause
+ * a duplicate to be appended.
+ */
+function fetchPrComments({
+  owner,
+  repo,
+  prNumber,
+}: {
+  owner: string;
+  repo: string;
+  prNumber: number;
+}): WaiverCommentPayload[] {
+  try {
+    const payload = ghJson(
+      [
+        'api',
+        '--paginate',
+        `repos/${owner}/${repo}/issues/${prNumber}/comments`,
+      ],
+      true,
+    );
+    return Array.isArray(payload) ? (payload as WaiverCommentPayload[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/** One issue comment, in the shape the GitHub REST list endpoint returns. */
+interface WaiverCommentPayload {
+  id?: string | number | null;
+  html_url?: string | null;
+  url?: string | null;
+  body?: string | null;
+  created_at?: string | null;
+  user?: GhAuthorPayload | null;
+  author?: GhAuthorPayload | null;
+}
+
+/** An existing waiver this invocation should reuse instead of appending. */
+export interface ReusableWaiver {
+  commentId: string;
+  commentUrl: string;
+  checkSelector: string;
+  expiresAt: string;
+}
+
+/**
+ * #2328: find an existing valid waiver for this exact selector so a repeated
+ * `--apply` reuses it instead of appending a second marker. Re-running the
+ * same command posted a duplicate on pull request #2325, leaving two live
+ * waivers a later session had to disambiguate by hand.
+ *
+ * Validity is not re-derived here: `summarizeExternalCheckWaivers` already
+ * classifies every marker into valid / expired / wrong-HEAD / wrong-claim,
+ * and both `pre-merge-readiness` and `advisory-convergence` read it. This
+ * function only correlates a `valid` entry back to the comment that carried
+ * it, so an expired, wrong-HEAD, or wrong-claim waiver is never reused —
+ * it simply never appears in `evidence.valid`.
+ *
+ * The earliest matching comment wins, mirroring the release-marker path's
+ * reuse-the-earliest rule, so a retry converges on one marker rather than
+ * picking a different one each pass.
+ */
+export function findReusableWaiverComment({
+  comments,
+  evidence,
+  checkSelector,
+}: {
+  comments: WaiverCommentPayload[] | null | undefined;
+  evidence: ExternalCheckWaiverEvidence | null | undefined;
+  checkSelector: string;
+}): ReusableWaiver | null {
+  const selector = String(checkSelector ?? '').trim();
+  if (!selector) return null;
+  const validForSelector = (evidence?.valid ?? []).filter(
+    (entry) => entry.checkSelector === selector,
+  );
+  if (validForSelector.length === 0) return null;
+
+  const ordered = [...(comments ?? [])].sort((left, right) =>
+    String(left?.created_at ?? '').localeCompare(
+      String(right?.created_at ?? ''),
+    ),
+  );
+  for (const comment of ordered) {
+    const parsed = parseExternalCheckWaiverComment(
+      String(comment?.body ?? ''),
+      String(comment?.created_at ?? ''),
+    );
+    if (!parsed || parsed.checkSelector !== selector) continue;
+    const matchesValidEntry = validForSelector.some(
+      (entry) =>
+        entry.expiresAt === parsed.expiresAt &&
+        entry.createdAt === parsed.createdAt,
+    );
+    if (!matchesValidEntry) continue;
+    return {
+      commentId: String(comment?.id ?? ''),
+      commentUrl: String(comment?.html_url ?? comment?.url ?? ''),
+      checkSelector: selector,
+      expiresAt: parsed.expiresAt,
+    };
+  }
+  return null;
 }
 
 function selectorRequestsGlob(selector: unknown): boolean {

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -1083,8 +1083,22 @@ export function collectValidWaiverComments({
       String(comment?.created_at ?? ''),
     );
     if (!parsed || parsed.checkSelector !== selector) continue;
+    // #2328 (review): correlate on EVERY field the evidence entry carries,
+    // not just expiry and timestamp. `created_at` has second resolution, so a
+    // valid maintainer waiver and an unauthorized, wrong-HEAD, or wrong-claim
+    // marker posted in the same second would otherwise both correlate to the
+    // single valid entry — letting the reuse path report the invalid comment
+    // as authoritative, and the reconcile invent a duplicate and point the
+    // operator at the genuinely valid marker to minimize.
+    const commentAuthorLogin = String(
+      comment?.author?.login ?? comment?.user?.login ?? '',
+    )
+      .trim()
+      .toLowerCase();
     const matchesValidEntry = validForSelector.some(
       (entry) =>
+        entry.authorLogin === commentAuthorLogin &&
+        entry.reason === parsed.reason &&
         entry.expiresAt === parsed.expiresAt &&
         entry.createdAt === parsed.createdAt,
     );

--- a/src/scripts/external-check-waiver.mts
+++ b/src/scripts/external-check-waiver.mts
@@ -9,7 +9,7 @@ import { readFileSync } from 'node:fs';
 import {
   buildAdvisoryConvergenceWaiverPrecondition,
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
-  resolveAdvisoryConvergenceDeadlineMinutes,
+  readAdvisoryConvergenceDeadlineMinutes,
 } from './advisory-wait-policy.mts';
 import { parseCliArgs } from './cli-args.mts';
 import { resolveTrustedCollaboratorMarkerLogins } from './collaborator-permission.mts';
@@ -313,8 +313,12 @@ interface RunExternalCheckWaiverOptions {
   now?: Date;
   isTTY?: boolean;
   prompt?: PromptFn;
-  /** #2328: injected PR issue comments, for the reuse scan under test. */
-  prComments?: WaiverCommentPayload[];
+  /**
+   * #2328: injected PR issue comments for the reuse scan under test. A
+   * function is called, so a test can exercise the fail-closed path by
+   * throwing from it.
+   */
+  prComments?: WaiverCommentPayload[] | (() => WaiverCommentPayload[]);
   /** #2328: injected HEAD commit timestamp, so tests skip the commit read. */
   headCommittedAt?: string;
   postComment?: (
@@ -758,8 +762,14 @@ export async function runExternalCheckWaiver(
           headRefOid: String(pr.headRefOid ?? '').trim(),
         }),
       allowClosedPrecondition: args.allowClosedPrecondition,
+      // Read through the SAME validating reader the gate uses, not the raw
+      // resolver: the gate rejects the whole `advisoryWait` section when any
+      // sibling key is schema-invalid and falls back to the 24h default. A
+      // resolver that skips that validation would report the configured value
+      // where the gate reports the default, reproducing the very disagreement
+      // this change removes.
       advisoryConvergenceDeadlineMinutes:
-        resolveAdvisoryConvergenceDeadlineMinutes(rawConfig),
+        readAdvisoryConvergenceDeadlineMinutes(),
     },
     { now: options.now, repoOwner: owner },
   );
@@ -806,8 +816,10 @@ export async function runExternalCheckWaiver(
   // for this selector first. A repeated `--apply` previously posted a second
   // identical marker, leaving two live waivers on the pull request.
   const prComments =
-    options.prComments ??
-    fetchPrComments({ owner, repo: name, prNumber: args.prNumber });
+    typeof options.prComments === 'function'
+      ? options.prComments()
+      : (options.prComments ??
+        fetchPrComments({ owner, repo: name, prNumber: args.prNumber }));
   // The marker this invocation would post is the exact context a reusable
   // waiver must match, so recover the HEAD and claim from it rather than
   // threading them separately and risking a mismatch.
@@ -891,19 +903,19 @@ function fetchPrComments({
   repo: string;
   prNumber: number;
 }): WaiverCommentPayload[] {
-  try {
-    const payload = ghJson(
-      [
-        'api',
-        '--paginate',
-        `repos/${owner}/${repo}/issues/${prNumber}/comments`,
-      ],
-      true,
+  // Never fail open: an unreadable list is not an empty one. Swallowing the
+  // error would hide an existing waiver and let `--apply` append a duplicate,
+  // which is the regression this change exists to remove.
+  const payload = ghJson(
+    ['api', '--paginate', `repos/${owner}/${repo}/issues/${prNumber}/comments`],
+    true,
+  );
+  if (!Array.isArray(payload)) {
+    throw new Error(
+      `external-check waiver apply blocked: could not read PR #${prNumber} comments to check for an existing waiver`,
     );
-    return Array.isArray(payload) ? (payload as WaiverCommentPayload[]) : [];
-  } catch {
-    return [];
   }
+  return payload as WaiverCommentPayload[];
 }
 
 /** One issue comment, in the shape the GitHub REST list endpoint returns. */

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -6,6 +6,7 @@
 
 import { Buffer } from 'node:buffer';
 import {
+  buildAdvisoryConvergenceWaiverPrecondition,
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
   DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES,
   DEFAULT_ADVISORY_PRIMARY_BOT_LOGIN,
@@ -6721,50 +6722,21 @@ export function buildPreMergeReadinessSummary(
   // `advisory-convergence.mts` itself would ever call the waiver `waived`,
   // sending an otherwise-correct session into a `gh pr merge` GitHub rejects
   // outright (root cause: kurone-kito/idd-skill#2021).
-  const advisoryConvergenceDeadlineMinutes = Number.isFinite(
-    options.advisoryConvergenceDeadlineMinutes,
-  )
-    ? Number(options.advisoryConvergenceDeadlineMinutes)
-    : DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES;
-  const advisoryConvergenceHeadCommittedAt = String(
-    options.advisoryConvergenceHeadCommittedAt ?? '',
-  );
-  const advisoryConvergenceElapsedMinutes = isValidIsoTimestamp(
-    advisoryConvergenceHeadCommittedAt,
-  )
-    ? minutesBetweenIso(advisoryConvergenceHeadCommittedAt, now)
-    : null;
+  const advisoryConvergencePreconditionResult =
+    buildAdvisoryConvergenceWaiverPrecondition({
+      headCommittedAt: options.advisoryConvergenceHeadCommittedAt,
+      deadlineMinutes: options.advisoryConvergenceDeadlineMinutes,
+      terminalUnavailable: copilotUnavailable,
+      now,
+    });
+  const advisoryConvergenceWaiverPrecondition =
+    advisoryConvergencePreconditionResult.precondition;
   const advisoryConvergenceDeadlinePassed =
-    advisoryConvergenceElapsedMinutes !== null &&
-    advisoryConvergenceElapsedMinutes >= advisoryConvergenceDeadlineMinutes;
+    advisoryConvergenceWaiverPrecondition.deadlinePassed;
   const advisoryConvergencePreconditionOpen =
-    advisoryConvergenceDeadlinePassed || copilotUnavailable;
-  // #2034: the deadline-path precondition-open moment as an actual ISO
-  // timestamp, used to override the waiver-active cutoff `summarizeRequiredChecks`
-  // applies to `idd-advisory-convergence` specifically -- that check's waiver
-  // only becomes genuinely active once this precondition opens, which can be
-  // later than the waiver comment's own `createdAt`. Only computed for the
-  // deadline path (`advisoryConvergenceDeadlinePassed`); the terminal-
-  // unavailability path has no equivalent real timestamp to anchor on, so it
-  // intentionally falls back to the waiver's own `createdAt` (see
-  // `waiverActiveSinceOverride` below).
+    advisoryConvergenceWaiverPrecondition.open;
   const advisoryConvergenceDeadlineOpensAt =
-    advisoryConvergenceDeadlinePassed &&
-    isValidIsoTimestamp(advisoryConvergenceHeadCommittedAt)
-      ? new Date(
-          new Date(advisoryConvergenceHeadCommittedAt).getTime() +
-            advisoryConvergenceDeadlineMinutes * 60000,
-        ).toISOString()
-      : '';
-  const advisoryConvergenceWaiverPrecondition = {
-    checkSelector: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
-    deadlineMinutes: advisoryConvergenceDeadlineMinutes,
-    headCommittedAt: advisoryConvergenceHeadCommittedAt || 'none',
-    elapsedMinutes: advisoryConvergenceElapsedMinutes,
-    deadlinePassed: advisoryConvergenceDeadlinePassed,
-    terminalUnavailable: copilotUnavailable,
-    open: advisoryConvergencePreconditionOpen,
-  };
+    advisoryConvergencePreconditionResult.deadlineOpensAt;
 
   // #2021 (Codex review on PR #2033, two findings): `advisory-convergence.mts`'s
   // own `waived` computation only counts a waiver whose `checkSelector` is an

--- a/tests/advisory-wait-policy.test.mts
+++ b/tests/advisory-wait-policy.test.mts
@@ -233,3 +233,29 @@ test('buildAdvisoryConvergenceWaiverPrecondition defaults the deadline when it i
     assert.equal(precondition.deadlineMinutes, 1440);
   }
 });
+
+test('buildAdvisoryConvergenceWaiverPrecondition clamps a future-dated HEAD commit to zero (#2328 review)', () => {
+  // `minutesBetweenIso` — what pre-merge-readiness used before this
+  // extraction, and what advisory-convergence still uses — returns 0 when the
+  // end precedes the start. A raw subtraction would report a negative elapsed
+  // and disagree with the gate on a clock-skewed or deliberately future-dated
+  // commit.
+  const { precondition } = buildAdvisoryConvergenceWaiverPrecondition({
+    headCommittedAt: '2026-08-31T06:00:00Z',
+    deadlineMinutes: 540,
+    now: '2026-08-30T22:00:00Z',
+  });
+  assert.equal(precondition.elapsedMinutes, 0);
+  assert.equal(precondition.deadlinePassed, false);
+  assert.equal(precondition.open, false);
+});
+
+test('buildAdvisoryConvergenceWaiverPrecondition reports null elapsed on an unusable now (#2328 review)', () => {
+  const { precondition } = buildAdvisoryConvergenceWaiverPrecondition({
+    headCommittedAt: '2026-08-30T18:13:24Z',
+    deadlineMinutes: 540,
+    now: 'not-a-timestamp',
+  });
+  assert.equal(precondition.elapsedMinutes, null);
+  assert.equal(precondition.deadlinePassed, false);
+});

--- a/tests/advisory-wait-policy.test.mts
+++ b/tests/advisory-wait-policy.test.mts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { normalizeAdvisoryWaitRuntimeOptions } from '../src/scripts/advisory-wait-policy.mts';
+import {
+  buildAdvisoryConvergenceWaiverPrecondition,
+  normalizeAdvisoryWaitRuntimeOptions,
+} from '../src/scripts/advisory-wait-policy.mts';
 
 // normalizeAdvisoryWaitRuntimeOptions is the only export of this module
 // without direct dedicated coverage: readAdvisoryWaitPolicy,
@@ -130,4 +133,103 @@ test('normalizeAdvisoryWaitRuntimeOptions accepts only a recognized capExhausted
       .capExhaustedRoute,
     'phase-specific',
   );
+});
+
+// #2328: the waiver precondition was built inline inside
+// pre-merge-readiness's reducer; extracting it is what lets
+// external-check-waiver report the same verdict instead of a second
+// implementation that can disagree with the gate.
+
+test('buildAdvisoryConvergenceWaiverPrecondition keeps the hatch closed before the deadline (#2328)', () => {
+  const { precondition, deadlineOpensAt } =
+    buildAdvisoryConvergenceWaiverPrecondition({
+      headCommittedAt: '2026-08-30T18:13:24Z',
+      deadlineMinutes: 540,
+      now: '2026-08-30T22:02:24Z',
+    });
+  assert.deepEqual(precondition, {
+    checkSelector: 'idd-advisory-convergence',
+    deadlineMinutes: 540,
+    headCommittedAt: '2026-08-30T18:13:24Z',
+    elapsedMinutes: 229,
+    deadlinePassed: false,
+    terminalUnavailable: false,
+    open: false,
+  });
+  // No open moment while the deadline itself has not passed.
+  assert.equal(deadlineOpensAt, '');
+});
+
+test('buildAdvisoryConvergenceWaiverPrecondition opens on the deadline and reports its moment (#2328)', () => {
+  const { precondition, deadlineOpensAt } =
+    buildAdvisoryConvergenceWaiverPrecondition({
+      headCommittedAt: '2026-08-30T18:13:24Z',
+      deadlineMinutes: 540,
+      now: '2026-08-31T03:13:24Z',
+    });
+  assert.equal(precondition.elapsedMinutes, 540);
+  assert.equal(precondition.deadlinePassed, true);
+  assert.equal(precondition.open, true);
+  assert.equal(deadlineOpensAt, '2026-08-31T03:13:24.000Z');
+});
+
+test('buildAdvisoryConvergenceWaiverPrecondition opens on terminal unavailability alone (#2328)', () => {
+  const { precondition, deadlineOpensAt } =
+    buildAdvisoryConvergenceWaiverPrecondition({
+      headCommittedAt: '2026-08-30T18:13:24Z',
+      deadlineMinutes: 540,
+      terminalUnavailable: true,
+      now: '2026-08-30T22:02:24Z',
+    });
+  assert.equal(precondition.deadlinePassed, false);
+  assert.equal(precondition.terminalUnavailable, true);
+  assert.equal(precondition.open, true);
+  // The terminal path has no anchor of its own, so it reports no moment
+  // even though the hatch is open.
+  assert.equal(deadlineOpensAt, '');
+});
+
+test('buildAdvisoryConvergenceWaiverPrecondition never opens on an unusable head timestamp (#2328)', () => {
+  // `none` is reported only for an absent value; a present-but-unparseable
+  // string is echoed back verbatim so the operator can see what was
+  // configured. Either way the hatch must stay shut, which is the half that
+  // matters: an unusable anchor can never prove the deadline elapsed.
+  for (const headCommittedAt of ['', null, undefined]) {
+    const { precondition } = buildAdvisoryConvergenceWaiverPrecondition({
+      headCommittedAt,
+      deadlineMinutes: 540,
+      now: '2026-08-30T22:02:24Z',
+    });
+    assert.equal(precondition.headCommittedAt, 'none');
+    assert.equal(precondition.elapsedMinutes, null);
+    assert.equal(precondition.deadlinePassed, false);
+    assert.equal(precondition.open, false);
+  }
+
+  const { precondition, deadlineOpensAt } =
+    buildAdvisoryConvergenceWaiverPrecondition({
+      headCommittedAt: 'not-a-timestamp',
+      deadlineMinutes: 540,
+      now: '2026-08-30T22:02:24Z',
+    });
+  assert.equal(precondition.headCommittedAt, 'not-a-timestamp');
+  assert.equal(precondition.elapsedMinutes, null);
+  assert.equal(
+    precondition.deadlinePassed,
+    false,
+    'an unparseable anchor must never open the hatch',
+  );
+  assert.equal(precondition.open, false);
+  assert.equal(deadlineOpensAt, '');
+});
+
+test('buildAdvisoryConvergenceWaiverPrecondition defaults the deadline when it is not finite (#2328)', () => {
+  for (const deadlineMinutes of [undefined, null, 'soon', Number.NaN]) {
+    const { precondition } = buildAdvisoryConvergenceWaiverPrecondition({
+      headCommittedAt: '2026-08-30T18:13:24Z',
+      deadlineMinutes,
+      now: '2026-08-30T22:02:24Z',
+    });
+    assert.equal(precondition.deadlineMinutes, 1440);
+  }
 });

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -6,6 +6,7 @@ import { test } from 'node:test';
 import { readAdvisoryConvergenceDeadlineMinutes } from '../src/scripts/advisory-wait-policy.mts';
 import {
   buildTrustedMarkerLogins,
+  collectValidWaiverComments,
   deriveGhApiStatusFromError,
   findReusableWaiverComment,
   parseArgs,
@@ -1103,4 +1104,203 @@ test('runExternalCheckWaiver fails closed when the comment list cannot be read (
   // An unreadable list must never be read as "no existing waiver": posting
   // then would recreate the duplicate this change removes.
   assert.equal(postCalls, 0);
+});
+
+// --- #2328 review: the check-then-post race ---------------------------------
+// The reuse scan and the POST are not one atomic step, and GitHub comments
+// have no compare-and-swap. Two concurrent applies can both see no waiver and
+// both post, so the duplicate is reconciled after the fact instead.
+
+test('collectValidWaiverComments returns every valid marker, earliest first (#2328 review)', () => {
+  const comments = [
+    waiverComment({ id: 200, createdAt: '2026-08-30T22:05:13Z' }),
+    waiverComment({ id: 100, createdAt: '2026-08-30T22:05:01Z' }),
+  ];
+  const found = collectValidWaiverComments({
+    comments,
+    evidence: evidenceWithValid([
+      {
+        checkSelector: 'idd-advisory-convergence',
+        expiresAt: '2026-08-31T10:00:00Z',
+        createdAt: '2026-08-30T22:05:01Z',
+      },
+      {
+        checkSelector: 'idd-advisory-convergence',
+        expiresAt: '2026-08-31T10:00:00Z',
+        createdAt: '2026-08-30T22:05:13Z',
+      },
+    ]),
+    checkSelector: 'idd-advisory-convergence',
+  });
+
+  assert.deepEqual(
+    found.map((entry) => entry.commentId),
+    ['100', '200'],
+  );
+  // The reuse scan is the first element of this same list, so the two can
+  // never disagree about which marker is authoritative.
+  assert.equal(
+    findReusableWaiverComment({
+      comments,
+      evidence: evidenceWithValid([
+        {
+          checkSelector: 'idd-advisory-convergence',
+          expiresAt: '2026-08-31T10:00:00Z',
+          createdAt: '2026-08-30T22:05:01Z',
+        },
+      ]),
+      checkSelector: 'idd-advisory-convergence',
+    })?.commentId,
+    '100',
+  );
+});
+
+test('runExternalCheckWaiver reports a waiver that raced its own post (#2328 review)', async () => {
+  let reads = 0;
+  const raced = waiverComment({
+    id: 300,
+    createdAt: '2026-08-30T22:29:00Z',
+    claimId: 'claim-20260830T222316Z-2328',
+  });
+  const mine = waiverComment({
+    id: 400,
+    createdAt: '2026-08-30T22:30:00Z',
+    claimId: 'claim-20260830T222316Z-2328',
+  });
+
+  const { report } = await runExternalCheckWaiver({
+    args: {
+      ...parseArgs([
+        '--pr',
+        '2325',
+        '--check',
+        'idd-advisory-convergence',
+        '--reason',
+        'rate limit',
+        '--expires-in',
+        'PT8H',
+        '--apply',
+        '--yes',
+        '--allow-closed-precondition',
+      ]),
+      repo: 'kurone-kito/idd-skill',
+      issueNumber: 2328,
+    },
+    actor: 'kurone-kito',
+    authority: { known: true, permission: 'admin', roleName: 'admin' },
+    pr: {
+      number: 2325,
+      state: 'OPEN',
+      url: 'https://github.com/kurone-kito/idd-skill/pull/2325',
+      headRefName: 'issue/2328-fix-external-check-waiver-refuse-waiver',
+      headRefOid: REUSE_HEAD_SHA,
+      statusCheckRollup: [
+        {
+          __typename: 'CheckRun',
+          name: 'idd-advisory-convergence',
+          status: 'COMPLETED',
+          conclusion: 'FAILURE',
+        },
+      ],
+    },
+    issueCandidates: [
+      {
+        number: 2328,
+        url: 'https://github.com/kurone-kito/idd-skill/issues/2328',
+        activeClaim: {
+          agentId: 'claude-6043e89f',
+          claimId: 'claim-20260830T222316Z-2328',
+          supersedes: 'none',
+          branch: 'issue/2328-fix-external-check-waiver-refuse-waiver',
+          createdAt: '2026-08-30T22:23:26Z',
+        },
+      },
+    ],
+    // First read: empty, so the reuse scan lets the post through. Later
+    // reads: a competitor's marker plus this run's own — the race.
+    prComments: () => {
+      reads += 1;
+      return reads === 1 ? [] : [raced, mine];
+    },
+    headCommittedAt: '2026-08-30T18:13:24Z',
+    now: new Date('2026-08-30T22:30:00Z'),
+    isTTY: false,
+    postComment: () => ({ html_url: 'https://example.invalid/posted' }),
+  });
+
+  assert.equal(report?.applied, true);
+  assert.deepEqual(
+    report?.concurrentWaivers?.map((entry) => entry.commentId),
+    ['300', '400'],
+  );
+});
+
+test('runExternalCheckWaiver reports no race when its own marker stands alone (#2328 review)', async () => {
+  let reads = 0;
+  const mine = waiverComment({
+    id: 400,
+    createdAt: '2026-08-30T22:30:00Z',
+    claimId: 'claim-20260830T222316Z-2328',
+  });
+
+  const { report } = await runExternalCheckWaiver({
+    args: {
+      ...parseArgs([
+        '--pr',
+        '2325',
+        '--check',
+        'idd-advisory-convergence',
+        '--reason',
+        'rate limit',
+        '--expires-in',
+        'PT8H',
+        '--apply',
+        '--yes',
+        '--allow-closed-precondition',
+      ]),
+      repo: 'kurone-kito/idd-skill',
+      issueNumber: 2328,
+    },
+    actor: 'kurone-kito',
+    authority: { known: true, permission: 'admin', roleName: 'admin' },
+    pr: {
+      number: 2325,
+      state: 'OPEN',
+      url: 'https://github.com/kurone-kito/idd-skill/pull/2325',
+      headRefName: 'issue/2328-fix-external-check-waiver-refuse-waiver',
+      headRefOid: REUSE_HEAD_SHA,
+      statusCheckRollup: [
+        {
+          __typename: 'CheckRun',
+          name: 'idd-advisory-convergence',
+          status: 'COMPLETED',
+          conclusion: 'FAILURE',
+        },
+      ],
+    },
+    issueCandidates: [
+      {
+        number: 2328,
+        url: 'https://github.com/kurone-kito/idd-skill/issues/2328',
+        activeClaim: {
+          agentId: 'claude-6043e89f',
+          claimId: 'claim-20260830T222316Z-2328',
+          supersedes: 'none',
+          branch: 'issue/2328-fix-external-check-waiver-refuse-waiver',
+          createdAt: '2026-08-30T22:23:26Z',
+        },
+      },
+    ],
+    prComments: () => {
+      reads += 1;
+      return reads === 1 ? [] : [mine];
+    },
+    headCommittedAt: '2026-08-30T18:13:24Z',
+    now: new Date('2026-08-30T22:30:00Z'),
+    isTTY: false,
+    postComment: () => ({ html_url: 'https://example.invalid/posted' }),
+  });
+
+  assert.equal(report?.applied, true);
+  assert.equal(report?.concurrentWaivers, undefined);
 });

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -1391,3 +1391,77 @@ test('runExternalCheckWaiver reads one post-write snapshot for the reconcile (#2
     ['300', '400'],
   );
 });
+
+test('runExternalCheckWaiver keeps the applied result when the reconcile read fails (#2328 review)', async () => {
+  // Fail-closed is correct before the post, where an unreadable list can
+  // cause a duplicate. After it the write already happened and is
+  // irreversible, so throwing would report a failed apply for successful
+  // work and withhold the comment URL.
+  let reads = 0;
+  const { report, exitCode } = await runExternalCheckWaiver({
+    args: {
+      ...parseArgs([
+        '--pr',
+        '2325',
+        '--check',
+        'idd-advisory-convergence',
+        '--reason',
+        'rate limit',
+        '--expires-in',
+        'PT8H',
+        '--apply',
+        '--yes',
+        '--allow-closed-precondition',
+      ]),
+      repo: 'kurone-kito/idd-skill',
+      issueNumber: 2328,
+    },
+    actor: 'kurone-kito',
+    authority: { known: true, permission: 'admin', roleName: 'admin' },
+    pr: {
+      number: 2325,
+      state: 'OPEN',
+      url: 'https://github.com/kurone-kito/idd-skill/pull/2325',
+      headRefName: 'issue/2328-fix-external-check-waiver-refuse-waiver',
+      headRefOid: REUSE_HEAD_SHA,
+      statusCheckRollup: [
+        {
+          __typename: 'CheckRun',
+          name: 'idd-advisory-convergence',
+          status: 'COMPLETED',
+          conclusion: 'FAILURE',
+        },
+      ],
+    },
+    issueCandidates: [
+      {
+        number: 2328,
+        url: 'https://github.com/kurone-kito/idd-skill/issues/2328',
+        activeClaim: {
+          agentId: 'claude-6043e89f',
+          claimId: 'claim-20260830T222316Z-2328',
+          supersedes: 'none',
+          branch: 'issue/2328-fix-external-check-waiver-refuse-waiver',
+          createdAt: '2026-08-30T22:23:26Z',
+        },
+      },
+    ],
+    // Read 1 (pre-write) succeeds and lets the post through; read 2
+    // (post-write reconcile) fails.
+    prComments: () => {
+      reads += 1;
+      if (reads === 1) return [];
+      throw new Error('gh api failed');
+    },
+    headCommittedAt: '2026-08-30T18:13:24Z',
+    now: new Date('2026-08-30T22:30:00Z'),
+    isTTY: false,
+    postComment: () => ({ html_url: 'https://example.invalid/posted' }),
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(report?.applied, true);
+  assert.equal(report?.commentUrl, 'https://example.invalid/posted');
+  assert.equal(report?.reconcileInconclusive, true);
+  assert.equal(report?.concurrentWaivers, undefined);
+});

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -716,7 +716,7 @@ test('planExternalCheckWaiver keeps the hatch shut without a HEAD commit anchor 
   assert.match(report.blockingReasons.join(' | '), /elapsed unknown/);
 });
 
-test('planExternalCheckWaiver leaves other selectors ungated (#2328)', () => {
+test('planExternalCheckWaiver leaves other selectors unaffected (#2328)', () => {
   // A glob waiver is never treated as covering idd-advisory-convergence by
   // the gate either (#2021), so gating one here would block for the wrong
   // reason; an unrelated selector must be untouched.

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -4,6 +4,7 @@ import { test } from 'node:test';
 import {
   buildTrustedMarkerLogins,
   deriveGhApiStatusFromError,
+  findReusableWaiverComment,
   parseArgs,
   planExternalCheckWaiver,
   resolveActorLogin,
@@ -734,5 +735,163 @@ test('parseArgs: --allow-closed-precondition defaults off and parses (#2328)', (
   assert.equal(
     parseArgs([...base, '--allow-closed-precondition']).allowClosedPrecondition,
     true,
+  );
+});
+
+// --- #2328: --apply idempotency ---------------------------------------------
+// Re-running the same --apply appended a second identical marker on pull
+// request #2325, leaving two live waivers a later session had to
+// disambiguate by hand.
+
+const REUSE_HEAD_SHA = 'b'.repeat(40);
+
+function waiverComment({
+  id,
+  createdAt,
+  checkSelector = 'idd-advisory-convergence',
+  expiresAt = '2026-08-31T10:00:00Z',
+  claimId = 'claim-abc',
+  headSha = REUSE_HEAD_SHA,
+}: {
+  id: number;
+  createdAt: string;
+  checkSelector?: string;
+  expiresAt?: string;
+  claimId?: string;
+  headSha?: string;
+}) {
+  return {
+    id,
+    html_url: `https://github.com/kurone-kito/idd-skill/pull/2325#issuecomment-${id}`,
+    created_at: createdAt,
+    user: { login: 'kurone-kito' },
+    body: renderExternalCheckWaiverComment({
+      actor: 'kurone-kito',
+      agentId: 'claude-6043e89f',
+      claimId,
+      headSha,
+      checkSelector,
+      reason: 'rate limit',
+      expiresAt,
+    }),
+  };
+}
+
+/** Evidence in the shape summarizeExternalCheckWaivers returns. */
+function evidenceWithValid(
+  entries: { checkSelector: string; expiresAt: string; createdAt: string }[],
+) {
+  return {
+    valid: entries.map((entry) => ({
+      authorLogin: 'kurone-kito',
+      reason: 'rate limit',
+      ...entry,
+    })),
+    expired: [],
+    wrongHead: [],
+    wrongClaim: [],
+    unauthorized: [],
+    malformed: [],
+    notConfigured: [],
+    modeDisabled: [],
+  } as never;
+}
+
+test('findReusableWaiverComment reuses the earliest valid marker for the selector (#2328)', () => {
+  const comments = [
+    waiverComment({ id: 5471539677, createdAt: '2026-08-30T22:05:13Z' }),
+    waiverComment({ id: 5471538618, createdAt: '2026-08-30T22:05:01Z' }),
+  ];
+  const found = findReusableWaiverComment({
+    comments,
+    evidence: evidenceWithValid([
+      {
+        checkSelector: 'idd-advisory-convergence',
+        expiresAt: '2026-08-31T10:00:00Z',
+        createdAt: '2026-08-30T22:05:01Z',
+      },
+    ]),
+    checkSelector: 'idd-advisory-convergence',
+  });
+
+  // The earliest wins even though the later one is listed first, so a retry
+  // converges on one marker instead of picking a different one each pass.
+  assert.equal(found?.commentId, '5471538618');
+  assert.equal(found?.checkSelector, 'idd-advisory-convergence');
+});
+
+test('findReusableWaiverComment never reuses a marker the shared parser rejected (#2328)', () => {
+  const comments = [
+    waiverComment({ id: 1, createdAt: '2026-08-30T22:05:01Z' }),
+  ];
+  // An expired, wrong-HEAD, or wrong-claim waiver simply never reaches the
+  // `valid` bucket, so an empty bucket must produce no reuse.
+  assert.equal(
+    findReusableWaiverComment({
+      comments,
+      evidence: evidenceWithValid([]),
+      checkSelector: 'idd-advisory-convergence',
+    }),
+    null,
+  );
+});
+
+test('findReusableWaiverComment does not cross selectors (#2328)', () => {
+  const comments = [
+    waiverComment({
+      id: 1,
+      createdAt: '2026-08-30T22:05:01Z',
+      checkSelector: 'CodeRabbit',
+    }),
+  ];
+  assert.equal(
+    findReusableWaiverComment({
+      comments,
+      evidence: evidenceWithValid([
+        {
+          checkSelector: 'CodeRabbit',
+          expiresAt: '2026-08-31T10:00:00Z',
+          createdAt: '2026-08-30T22:05:01Z',
+        },
+      ]),
+      checkSelector: 'idd-advisory-convergence',
+    }),
+    null,
+  );
+});
+
+test('findReusableWaiverComment ignores non-waiver comments and empty input (#2328)', () => {
+  const evidence = evidenceWithValid([
+    {
+      checkSelector: 'idd-advisory-convergence',
+      expiresAt: '2026-08-31T10:00:00Z',
+      createdAt: '2026-08-30T22:05:01Z',
+    },
+  ]);
+  assert.equal(
+    findReusableWaiverComment({
+      comments: [
+        { id: 9, created_at: '2026-08-30T22:00:00Z', body: 'looks good to me' },
+      ],
+      evidence,
+      checkSelector: 'idd-advisory-convergence',
+    }),
+    null,
+  );
+  assert.equal(
+    findReusableWaiverComment({
+      comments: [],
+      evidence,
+      checkSelector: 'idd-advisory-convergence',
+    }),
+    null,
+  );
+  assert.equal(
+    findReusableWaiverComment({
+      comments: null,
+      evidence: null,
+      checkSelector: '',
+    }),
+    null,
   );
 });

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -1606,3 +1606,98 @@ test('collectValidWaiverComments rejects a wrong-HEAD or wrong-claim twin (#2328
     ['100'],
   );
 });
+
+test('runExternalCheckWaiver reconciles against the refreshed claim after a takeover (#2328 review)', async () => {
+  // Claim B supersedes A between the initial resolution and the post-write
+  // read. The gate resolves B with `supersedes: A` and accepts both waivers,
+  // so a summarizer still pinned to A classifies B's as wrongClaim and
+  // reports no duplicate — silence exactly where the warning matters.
+  let reads = 0;
+  let candidateCalls = 0;
+  const claimA = 'claim-A';
+  const claimB = 'claim-B';
+  const mine = waiverComment({
+    id: 500,
+    createdAt: '2026-08-30T22:29:00Z',
+    claimId: claimA,
+  });
+  const theirs = waiverComment({
+    id: 501,
+    createdAt: '2026-08-30T22:29:30Z',
+    claimId: claimB,
+  });
+  const candidateFor = (claimId: string, supersedes: string) => [
+    {
+      number: 2328,
+      url: 'https://github.com/kurone-kito/idd-skill/issues/2328',
+      activeClaim: {
+        agentId: 'claude-6043e89f',
+        claimId,
+        supersedes,
+        branch: 'issue/2328-fix-external-check-waiver-refuse-waiver',
+        createdAt: '2026-08-30T22:23:26Z',
+      },
+    },
+  ];
+
+  const { report } = await runExternalCheckWaiver({
+    args: {
+      ...parseArgs([
+        '--pr',
+        '2325',
+        '--check',
+        'idd-advisory-convergence',
+        '--reason',
+        'rate limit',
+        '--expires-in',
+        'PT8H',
+        '--apply',
+        '--yes',
+        '--allow-closed-precondition',
+      ]),
+      repo: 'kurone-kito/idd-skill',
+      issueNumber: 2328,
+    },
+    actor: 'kurone-kito',
+    authority: { known: true, permission: 'admin', roleName: 'admin' },
+    pr: {
+      number: 2325,
+      state: 'OPEN',
+      url: 'https://github.com/kurone-kito/idd-skill/pull/2325',
+      headRefName: 'issue/2328-fix-external-check-waiver-refuse-waiver',
+      headRefOid: REUSE_HEAD_SHA,
+      statusCheckRollup: [
+        {
+          __typename: 'CheckRun',
+          name: 'idd-advisory-convergence',
+          status: 'COMPLETED',
+          conclusion: 'FAILURE',
+        },
+      ],
+    },
+    // First resolution binds to A; the reconcile re-resolves and sees B
+    // superseding A.
+    issueCandidates: undefined,
+    resolveIssueCandidates: () => {
+      candidateCalls += 1;
+      return candidateCalls === 1
+        ? candidateFor(claimA, 'none')
+        : candidateFor(claimB, claimA);
+    },
+    prComments: () => {
+      reads += 1;
+      return reads === 1 ? [] : [mine, theirs];
+    },
+    headCommittedAt: '2026-08-30T18:13:24Z',
+    now: new Date('2026-08-30T22:30:00Z'),
+    isTTY: false,
+    postComment: () => ({ html_url: 'https://example.invalid/posted' }),
+  });
+
+  assert.equal(report?.applied, true);
+  assert.deepEqual(
+    report?.concurrentWaivers?.map((entry) => entry.commentId),
+    ['500', '501'],
+    'both the A-bound and B-bound waivers are live to the gate after the takeover',
+  );
+});

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -1540,3 +1540,69 @@ test('collectValidWaiverComments distinguishes entries by reason too (#2328 revi
     ['200'],
   );
 });
+
+test('collectValidWaiverComments rejects a wrong-HEAD or wrong-claim twin (#2328 review)', () => {
+  // The summarizer keeps a wrong-HEAD or wrong-claim marker out of `valid`,
+  // but the entry it produces for a genuine sibling carries no binding of its
+  // own. A twin sharing author, reason, expiry, and second would therefore
+  // still correlate to that entry unless the binding is checked directly.
+  const sameSecond = '2026-08-30T22:05:01Z';
+  const genuine = waiverComment({ id: 100, createdAt: sameSecond });
+  const wrongHead = {
+    ...genuine,
+    id: 101,
+    body: renderExternalCheckWaiverComment({
+      actor: 'kurone-kito',
+      agentId: 'claude-6043e89f',
+      claimId: 'claim-abc',
+      headSha: 'c'.repeat(40),
+      checkSelector: 'idd-advisory-convergence',
+      reason: 'rate limit',
+      expiresAt: '2026-08-31T10:00:00Z',
+    }),
+  };
+  const wrongClaim = {
+    ...genuine,
+    id: 102,
+    body: renderExternalCheckWaiverComment({
+      actor: 'kurone-kito',
+      agentId: 'claude-6043e89f',
+      claimId: 'claim-someone-else',
+      headSha: REUSE_HEAD_SHA,
+      checkSelector: 'idd-advisory-convergence',
+      reason: 'rate limit',
+      expiresAt: '2026-08-31T10:00:00Z',
+    }),
+  };
+  const evidence = evidenceWithValid([
+    {
+      checkSelector: 'idd-advisory-convergence',
+      expiresAt: '2026-08-31T10:00:00Z',
+      createdAt: sameSecond,
+    },
+  ]);
+
+  assert.deepEqual(
+    collectValidWaiverComments({
+      comments: [wrongHead, wrongClaim, genuine],
+      evidence,
+      checkSelector: 'idd-advisory-convergence',
+      expectedHeadSha: REUSE_HEAD_SHA,
+      allowedClaimIds: ['claim-abc'],
+    }).map((entry) => entry.commentId),
+    ['100'],
+  );
+
+  // The predecessor claim is accepted, matching the gate's one-hop takeover
+  // exception, so a takeover does not append a second marker.
+  assert.deepEqual(
+    collectValidWaiverComments({
+      comments: [wrongClaim, genuine],
+      evidence,
+      checkSelector: 'idd-advisory-convergence',
+      expectedHeadSha: REUSE_HEAD_SHA,
+      allowedClaimIds: ['claim-successor', 'claim-abc'],
+    }).map((entry) => entry.commentId),
+    ['100'],
+  );
+});

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
-
+import { readAdvisoryConvergenceDeadlineMinutes } from '../src/scripts/advisory-wait-policy.mts';
 import {
   buildTrustedMarkerLogins,
   deriveGhApiStatusFromError,
@@ -1001,4 +1004,103 @@ test('runExternalCheckWaiver posts nothing when it reuses an existing waiver (#2
   assert.equal(report?.applied, false);
   assert.equal(report?.reusedWaiver?.commentId, '100');
   assert.match(String(report?.commentUrl), /issuecomment-100$/);
+});
+
+test('the deadline reader rejects a schema-invalid advisoryWait section (#2328 review)', () => {
+  // The gate validates the whole `advisoryWait` subtree and falls back to the
+  // 24h default when any sibling key is invalid. Resolving the deadline
+  // without that validation would report 540 where the gate reports 1440,
+  // reproducing the disagreement this issue removes.
+  const dir = mkdtempSync(join(tmpdir(), 'idd-waiver-deadline-'));
+  try {
+    const good = join(dir, 'good.json');
+    writeFileSync(
+      good,
+      JSON.stringify({ advisoryWait: { convergenceDeadline: 'PT9H' } }),
+    );
+    assert.equal(readAdvisoryConvergenceDeadlineMinutes(good), 540);
+
+    const poisoned = join(dir, 'poisoned.json');
+    writeFileSync(
+      poisoned,
+      JSON.stringify({
+        advisoryWait: { convergenceDeadline: 'PT9H', requestCap: 'bad' },
+      }),
+    );
+    assert.equal(
+      readAdvisoryConvergenceDeadlineMinutes(poisoned),
+      1440,
+      'an invalid sibling must sink the whole section, as the gate does',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('runExternalCheckWaiver fails closed when the comment list cannot be read (#2328 review)', async () => {
+  let postCalls = 0;
+  await assert.rejects(
+    runExternalCheckWaiver({
+      args: {
+        ...parseArgs([
+          '--pr',
+          '2325',
+          '--check',
+          'idd-advisory-convergence',
+          '--reason',
+          'rate limit',
+          '--expires-in',
+          'PT8H',
+          '--apply',
+          '--yes',
+          '--allow-closed-precondition',
+        ]),
+        repo: 'kurone-kito/idd-skill',
+        issueNumber: 2328,
+      },
+      actor: 'kurone-kito',
+      authority: { known: true, permission: 'admin', roleName: 'admin' },
+      pr: {
+        number: 2325,
+        state: 'OPEN',
+        url: 'https://github.com/kurone-kito/idd-skill/pull/2325',
+        headRefName: 'issue/2328-fix-external-check-waiver-refuse-waiver',
+        headRefOid: REUSE_HEAD_SHA,
+        statusCheckRollup: [
+          {
+            __typename: 'CheckRun',
+            name: 'idd-advisory-convergence',
+            status: 'COMPLETED',
+            conclusion: 'FAILURE',
+          },
+        ],
+      },
+      issueCandidates: [
+        {
+          number: 2328,
+          url: 'https://github.com/kurone-kito/idd-skill/issues/2328',
+          activeClaim: {
+            agentId: 'claude-6043e89f',
+            claimId: 'claim-20260830T222316Z-2328',
+            supersedes: 'none',
+            branch: 'issue/2328-fix-external-check-waiver-refuse-waiver',
+            createdAt: '2026-08-30T22:23:26Z',
+          },
+        },
+      ],
+      prComments: () => {
+        throw new Error('gh api failed');
+      },
+      headCommittedAt: '2026-08-30T18:13:24Z',
+      now: new Date('2026-08-30T22:30:00Z'),
+      isTTY: false,
+      postComment: () => {
+        postCalls += 1;
+        return { html_url: 'should-not-be-reached' };
+      },
+    }),
+  );
+  // An unreadable list must never be read as "no existing waiver": posting
+  // then would recreate the duplicate this change removes.
+  assert.equal(postCalls, 0);
 });

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -1465,3 +1465,78 @@ test('runExternalCheckWaiver keeps the applied result when the reconcile read fa
   assert.equal(report?.reconcileInconclusive, true);
   assert.equal(report?.concurrentWaivers, undefined);
 });
+
+test('collectValidWaiverComments does not correlate a same-second impostor (#2328 review)', () => {
+  // `created_at` has second resolution. A valid maintainer waiver and an
+  // unauthorized marker posted in the same second share selector, expiry, and
+  // timestamp, so correlating on those three alone matches both against the
+  // one valid entry: the reuse path could report the impostor as
+  // authoritative, and the reconcile could invent a duplicate and point the
+  // operator at the genuine marker to minimize.
+  const sameSecond = '2026-08-30T22:05:01Z';
+  const genuine = {
+    ...waiverComment({ id: 100, createdAt: sameSecond }),
+    user: { login: 'kurone-kito' },
+  };
+  const impostor = {
+    ...waiverComment({ id: 101, createdAt: sameSecond }),
+    user: { login: 'drive-by-contributor' },
+  };
+
+  const found = collectValidWaiverComments({
+    // The impostor sorts first on a stable sort, so a correlation that
+    // ignores the author would return it as the earliest.
+    comments: [impostor, genuine],
+    evidence: evidenceWithValid([
+      {
+        checkSelector: 'idd-advisory-convergence',
+        expiresAt: '2026-08-31T10:00:00Z',
+        createdAt: sameSecond,
+      },
+    ]),
+    checkSelector: 'idd-advisory-convergence',
+  });
+
+  assert.deepEqual(
+    found.map((entry) => entry.commentId),
+    ['100'],
+    'only the comment whose author matches the valid entry correlates',
+  );
+});
+
+test('collectValidWaiverComments distinguishes entries by reason too (#2328 review)', () => {
+  // Same author, selector, expiry, and second — different reason. Only the
+  // marker whose reason matches the evidence entry is the valid one.
+  const sameSecond = '2026-08-30T22:05:01Z';
+  const matching = waiverComment({ id: 200, createdAt: sameSecond });
+  const other = {
+    ...matching,
+    id: 201,
+    body: renderExternalCheckWaiverComment({
+      actor: 'kurone-kito',
+      agentId: 'claude-6043e89f',
+      claimId: 'claim-abc',
+      headSha: REUSE_HEAD_SHA,
+      checkSelector: 'idd-advisory-convergence',
+      reason: 'a different reason',
+      expiresAt: '2026-08-31T10:00:00Z',
+    }),
+  };
+
+  const found = collectValidWaiverComments({
+    comments: [other, matching],
+    evidence: evidenceWithValid([
+      {
+        checkSelector: 'idd-advisory-convergence',
+        expiresAt: '2026-08-31T10:00:00Z',
+        createdAt: sameSecond,
+      },
+    ]),
+    checkSelector: 'idd-advisory-convergence',
+  });
+
+  assert.deepEqual(
+    found.map((entry) => entry.commentId),
+    ['200'],
+  );
+});

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -1304,3 +1304,90 @@ test('runExternalCheckWaiver reports no race when its own marker stands alone (#
   assert.equal(report?.applied, true);
   assert.equal(report?.concurrentWaivers, undefined);
 });
+
+test('runExternalCheckWaiver reads one post-write snapshot for the reconcile (#2328 review)', async () => {
+  // Two sequential reads would leave `comments` older than `evidence`, and
+  // the correlation can only find markers present in `comments` — so a
+  // waiver landing between them would be dropped and the duplicate missed.
+  // Counting reads pins the single-snapshot contract: one before the post,
+  // one after.
+  let reads = 0;
+  const raced = waiverComment({
+    id: 300,
+    createdAt: '2026-08-30T22:29:00Z',
+    claimId: 'claim-20260830T222316Z-2328',
+  });
+  const mine = waiverComment({
+    id: 400,
+    createdAt: '2026-08-30T22:30:00Z',
+    claimId: 'claim-20260830T222316Z-2328',
+  });
+
+  const { report } = await runExternalCheckWaiver({
+    args: {
+      ...parseArgs([
+        '--pr',
+        '2325',
+        '--check',
+        'idd-advisory-convergence',
+        '--reason',
+        'rate limit',
+        '--expires-in',
+        'PT8H',
+        '--apply',
+        '--yes',
+        '--allow-closed-precondition',
+      ]),
+      repo: 'kurone-kito/idd-skill',
+      issueNumber: 2328,
+    },
+    actor: 'kurone-kito',
+    authority: { known: true, permission: 'admin', roleName: 'admin' },
+    pr: {
+      number: 2325,
+      state: 'OPEN',
+      url: 'https://github.com/kurone-kito/idd-skill/pull/2325',
+      headRefName: 'issue/2328-fix-external-check-waiver-refuse-waiver',
+      headRefOid: REUSE_HEAD_SHA,
+      statusCheckRollup: [
+        {
+          __typename: 'CheckRun',
+          name: 'idd-advisory-convergence',
+          status: 'COMPLETED',
+          conclusion: 'FAILURE',
+        },
+      ],
+    },
+    issueCandidates: [
+      {
+        number: 2328,
+        url: 'https://github.com/kurone-kito/idd-skill/issues/2328',
+        activeClaim: {
+          agentId: 'claude-6043e89f',
+          claimId: 'claim-20260830T222316Z-2328',
+          supersedes: 'none',
+          branch: 'issue/2328-fix-external-check-waiver-refuse-waiver',
+          createdAt: '2026-08-30T22:23:26Z',
+        },
+      },
+    ],
+    // Read 1 (pre-write): empty. Read 2 (post-write): the race. A third
+    // read would mean the reconcile took two snapshots, which is the defect.
+    prComments: () => {
+      reads += 1;
+      if (reads === 1) return [];
+      if (reads === 2) return [raced, mine];
+      throw new Error(`reconcile took ${reads} snapshots; expected exactly 2`);
+    },
+    headCommittedAt: '2026-08-30T18:13:24Z',
+    now: new Date('2026-08-30T22:30:00Z'),
+    isTTY: false,
+    postComment: () => ({ html_url: 'https://example.invalid/posted' }),
+  });
+
+  assert.equal(reads, 2, 'exactly one pre-write and one post-write read');
+  assert.deepEqual(
+    report?.concurrentWaivers?.map((entry) => entry.commentId),
+    ['300', '400'],
+  );
+});

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -596,3 +596,143 @@ test('planExternalCheckWaiver fails closed when authority lookup returns unknown
   assert.equal(report.canApply, false);
   assert.ok(report.blockingReasons.some((r) => /authority|proven/.test(r)));
 });
+
+// --- #2328: the idd-advisory-convergence waiver precondition ---------------
+// The gate never treats a posted waiver as active until its precondition
+// opens, so rendering one before then produces a marker the gate ignores.
+// Observed live: this helper reported no blocking reasons while
+// pre-merge-readiness reported the hatch shut for the same PR and HEAD.
+
+/** Base input aimed at the precondition-gated selector. */
+function buildAdvisoryConvergenceInput(): BaseInput {
+  const input = buildBaseInput();
+  input.policy = normalizePolicyConfig({
+    ciGate: {
+      externalChecks: {
+        waivable: [
+          { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+        ],
+      },
+      externalCheckWaivers: {
+        mode: 'maintainer-authorized',
+        authorityPolicy: 'owners-and-maintainers-only',
+        maxValidity: 'PT24H',
+      },
+    },
+  });
+  input.pr.statusCheckRollup = [
+    {
+      __typename: 'CheckRun',
+      name: 'idd-advisory-convergence',
+      status: 'COMPLETED',
+      conclusion: 'FAILURE',
+    },
+  ];
+  input.requestedSelector = 'idd-advisory-convergence';
+  input.headCommittedAt = '2026-08-30T18:13:24Z';
+  // Supplied by the caller from the RAW config, as pre-merge-readiness
+  // receives it: normalizePolicyConfig drops `convergenceDeadline`, so
+  // reading it off the normalized policy would silently use the 24h default
+  // for this repository's configured PT9H.
+  input.advisoryConvergenceDeadlineMinutes = 540;
+  // The base fixture's expiry predates every `now` used below; leaving it
+  // would add an unrelated expiry blocker and mask what these cases assert.
+  input.expiresAt = '2026-08-31T09:00:00Z';
+  return input;
+}
+
+test('planExternalCheckWaiver blocks an advisory-convergence waiver before its deadline (#2328)', () => {
+  const report = planExternalCheckWaiver(buildAdvisoryConvergenceInput(), {
+    // 229 of 540 minutes -- the live observation this issue was filed from.
+    now: new Date('2026-08-30T22:02:24Z'),
+    repoOwner: 'kurone-kito',
+  });
+
+  assert.equal(report.canApply, false);
+  assert.deepEqual(report.advisoryConvergenceWaiverPrecondition, {
+    checkSelector: 'idd-advisory-convergence',
+    deadlineMinutes: 540,
+    headCommittedAt: '2026-08-30T18:13:24Z',
+    elapsedMinutes: 229,
+    deadlinePassed: false,
+    terminalUnavailable: false,
+    open: false,
+    terminalEvaluated: false,
+  });
+  const blocked = report.blockingReasons.join(' | ');
+  assert.match(blocked, /deadline has not passed/);
+  assert.match(blocked, /229 of 540 minutes/);
+  // The reason must not claim the hatch is shut outright: the terminal
+  // opener is never evaluated here, so it may be open unseen.
+  assert.match(blocked, /terminal Copilot unavailability was not evaluated/);
+});
+
+test('planExternalCheckWaiver allows an advisory-convergence waiver once the deadline passes (#2328)', () => {
+  const report = planExternalCheckWaiver(buildAdvisoryConvergenceInput(), {
+    now: new Date('2026-08-31T03:13:24Z'),
+    repoOwner: 'kurone-kito',
+  });
+
+  assert.equal(report.advisoryConvergenceWaiverPrecondition?.open, true);
+  assert.equal(report.canApply, true);
+  assert.equal(
+    report.blockingReasons.filter((entry) =>
+      /deadline has not passed/.test(entry),
+    ).length,
+    0,
+  );
+});
+
+test('planExternalCheckWaiver honors the closed-precondition opt-in (#2328)', () => {
+  const input = buildAdvisoryConvergenceInput();
+  input.allowClosedPrecondition = true;
+
+  const report = planExternalCheckWaiver(input, {
+    now: new Date('2026-08-30T22:02:24Z'),
+    repoOwner: 'kurone-kito',
+  });
+
+  // The precondition is still reported honestly as closed; only the block
+  // is lifted, so the operator sees exactly what they are overriding.
+  assert.equal(report.advisoryConvergenceWaiverPrecondition?.open, false);
+  assert.equal(report.canApply, true);
+});
+
+test('planExternalCheckWaiver keeps the hatch shut without a HEAD commit anchor (#2328)', () => {
+  const input = buildAdvisoryConvergenceInput();
+  input.headCommittedAt = '';
+
+  const report = planExternalCheckWaiver(input, {
+    now: new Date('2026-08-31T03:13:24Z'),
+    repoOwner: 'kurone-kito',
+  });
+
+  assert.equal(
+    report.advisoryConvergenceWaiverPrecondition?.elapsedMinutes,
+    null,
+  );
+  assert.equal(report.canApply, false);
+  assert.match(report.blockingReasons.join(' | '), /elapsed unknown/);
+});
+
+test('planExternalCheckWaiver leaves other selectors ungated (#2328)', () => {
+  // A glob waiver is never treated as covering idd-advisory-convergence by
+  // the gate either (#2021), so gating one here would block for the wrong
+  // reason; an unrelated selector must be untouched.
+  const report = planExternalCheckWaiver(buildBaseInput(), {
+    now: new Date('2026-05-17T06:00:00Z'),
+    repoOwner: 'kurone-kito',
+  });
+
+  assert.equal(report.advisoryConvergenceWaiverPrecondition, undefined);
+  assert.equal(report.canApply, true);
+});
+
+test('parseArgs: --allow-closed-precondition defaults off and parses (#2328)', () => {
+  const base = ['--pr', '5', '--check', 'x', '--reason', 'y'];
+  assert.equal(parseArgs(base).allowClosedPrecondition, false);
+  assert.equal(
+    parseArgs([...base, '--allow-closed-precondition']).allowClosedPrecondition,
+    true,
+  );
+});

--- a/tests/external-check-waiver.test.mts
+++ b/tests/external-check-waiver.test.mts
@@ -8,6 +8,7 @@ import {
   parseArgs,
   planExternalCheckWaiver,
   resolveActorLogin,
+  runExternalCheckWaiver,
 } from '../src/scripts/external-check-waiver.mts';
 import { normalizePolicyConfig } from '../src/scripts/policy-helpers.mts';
 import {
@@ -894,4 +895,110 @@ test('findReusableWaiverComment ignores non-waiver comments and empty input (#23
     }),
     null,
   );
+});
+
+test('findReusableWaiverComment reuses regardless of a newly requested expiry (#2328)', () => {
+  // The reused marker keeps its own expiry: a retry must never append an
+  // indistinguishable duplicate carrying a different one, mirroring the
+  // release-marker rule. Documented so the discarded request is not a
+  // surprise.
+  const comments = [
+    waiverComment({
+      id: 100,
+      createdAt: '2026-08-30T22:05:01Z',
+      expiresAt: '2026-08-31T10:00:00Z',
+    }),
+  ];
+  const found = findReusableWaiverComment({
+    comments,
+    evidence: evidenceWithValid([
+      {
+        checkSelector: 'idd-advisory-convergence',
+        expiresAt: '2026-08-31T10:00:00Z',
+        createdAt: '2026-08-30T22:05:01Z',
+      },
+    ]),
+    checkSelector: 'idd-advisory-convergence',
+  });
+
+  assert.equal(found?.commentId, '100');
+  assert.equal(found?.expiresAt, '2026-08-31T10:00:00Z');
+});
+
+test('runExternalCheckWaiver posts nothing when it reuses an existing waiver (#2328)', async () => {
+  let postCalls = 0;
+  const comments = [
+    waiverComment({
+      id: 100,
+      createdAt: '2026-08-30T22:05:01Z',
+      checkSelector: 'idd-advisory-convergence',
+      claimId: 'claim-20260830T222316Z-2328',
+      headSha: REUSE_HEAD_SHA,
+    }),
+  ];
+
+  const { report } = await runExternalCheckWaiver({
+    args: {
+      ...parseArgs([
+        '--pr',
+        '2325',
+        '--check',
+        'idd-advisory-convergence',
+        '--reason',
+        'rate limit',
+        '--expires-in',
+        'PT8H',
+        '--apply',
+        '--yes',
+        '--allow-closed-precondition',
+      ]),
+      repo: 'kurone-kito/idd-skill',
+      issueNumber: 2328,
+    },
+    actor: 'kurone-kito',
+    authority: { known: true, permission: 'admin', roleName: 'admin' },
+    pr: {
+      number: 2325,
+      state: 'OPEN',
+      url: 'https://github.com/kurone-kito/idd-skill/pull/2325',
+      headRefName: 'issue/2328-fix-external-check-waiver-refuse-waiver',
+      headRefOid: REUSE_HEAD_SHA,
+      statusCheckRollup: [
+        {
+          __typename: 'CheckRun',
+          name: 'idd-advisory-convergence',
+          status: 'COMPLETED',
+          conclusion: 'FAILURE',
+        },
+      ],
+    },
+    issueCandidates: [
+      {
+        number: 2328,
+        url: 'https://github.com/kurone-kito/idd-skill/issues/2328',
+        activeClaim: {
+          agentId: 'claude-6043e89f',
+          claimId: 'claim-20260830T222316Z-2328',
+          supersedes: 'none',
+          branch: 'issue/2328-fix-external-check-waiver-refuse-waiver',
+          createdAt: '2026-08-30T22:23:26Z',
+        },
+      },
+    ],
+    prComments: comments,
+    headCommittedAt: '2026-08-30T18:13:24Z',
+    now: new Date('2026-08-30T22:30:00Z'),
+    isTTY: false,
+    postComment: () => {
+      postCalls += 1;
+      return { html_url: 'should-not-be-reached' };
+    },
+  });
+
+  // The AC clause this covers directly: nothing is appended, so the pull
+  // request's comment count is unchanged.
+  assert.equal(postCalls, 0);
+  assert.equal(report?.applied, false);
+  assert.equal(report?.reusedWaiver?.commentId, '100');
+  assert.match(String(report?.commentUrl), /issuecomment-100$/);
 });


### PR DESCRIPTION
## Summary

`external-check-waiver` could report no blocking reasons while
`pre-merge-readiness` reported the waiver hatch shut for the same pull
request and HEAD, and a repeated `--apply` appended a second identical
marker. Both were observed live on #2325 during a Copilot rate limit.

## Why the first commit is a refactor

The precondition the gate applies was built inline inside
`pre-merge-readiness`'s reducer, so no other consumer could ask what the
gate would do. Copying that arithmetic into the waiver helper is exactly
how two helpers come to disagree, so the fix starts by extracting it
into `advisory-wait-policy.mts` — which already owns both the deadline
default and the selector constant — and having `pre-merge-readiness`
call it. Behavior is unchanged there; the existing pre-merge tests pass
untouched, which is the assertion.

## What the helper now refuses

- A closed hatch is a blocking reason for the exact
  `idd-advisory-convergence` selector. Only the exact selector is gated,
  because the gate itself never counts a glob waiver for that check.
- The **terminal** opener is deliberately not evaluated: proving it needs
  trusted advisory-wait recovery-marker state this helper does not
  collect. So the report carries `terminalEvaluated: false` and the
  blocking reason says the deadline has not passed, never that no opener
  applies — a bare "hatch closed" would be false whenever terminal
  unavailability is genuinely open.
- `--allow-closed-precondition` is the escape for an operator who knows
  the terminal opener applies. It lifts the block while still reporting
  the precondition as closed, so the override stays visible.
- `--apply` reuses an existing valid waiver for the same selector, HEAD,
  and claim instead of appending. Validity is not re-derived:
  `summarizeExternalCheckWaivers` already classifies every marker, so an
  expired, wrong-HEAD, or wrong-claim waiver is never reused.

## Two findings worth a reviewer's attention

**The deadline must be read from the raw config.**
`normalizePolicyConfig` does not carry `advisoryWait.convergenceDeadline`
through, so reading it from the normalized policy silently substitutes
the 24h default for a repository that configured something shorter — this
one configures `PT9H`. The caller now supplies it from the raw document,
exactly as `pre-merge-readiness` receives it. This was caught only
because a test asserted the real number rather than "some number".

**Reuse wins over a freshly requested expiry.** Re-running with a
different `--expires-in` reports the existing marker rather than posting
a second one carrying the new value. That follows the release-marker rule
against indistinguishable duplicates, but it does discard what the
operator asked for, so it is documented and tested rather than left as a
surprise.

## This pull request does not self-test the fix

It changes the helper used at its own merge gate, but the fix only takes
effect once merged, and this branch's own convergence deadline will not
have passed at merge time either. Copilot is rate-limited, so
`idd-advisory-convergence` cannot go green here regardless. The merge
path is convergence, a one-hour quiet re-check, then an administrative
merge under the recorded outage — not a demonstration of the new
behaviour.

## Verification

- `pre-push-validate` passes end to end. The three `idd-doctor` warnings
  are pre-existing environment findings unrelated to this diff.
- 12 new tests: the extracted precondition across both openers and its
  fail-closed inputs, the blocking and opt-in paths, selector scoping,
  and the reuse path including a spy asserting that nothing is posted.
- No instruction files are touched, so no byte-budget interaction.

Closes #2328

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EbZ69oeZv9wr7Npre9UXTT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deadline-based gating for advisory convergence waivers.
  * Added an option to apply waivers before the deadline while reporting the closed precondition.
  * Existing valid waivers are reused instead of creating duplicates.
  * Reports now include precondition status, reuse details, and concurrent waiver detection.
  * Failed comment retrieval stops processing safely without posting.
  * Post-write reconciliation failures now preserve the applied result while reporting an inconclusive warning.

* **Documentation**
  * Updated helper documentation to explain timing, reuse, concurrency, and reconciliation behavior.

* **Tests**
  * Expanded coverage for deadlines, preconditions, reuse, failures, and concurrent applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->