### PR TITLE
chore(audit): relax the doc context ceiling to a 200k baseline

### DIFF
--- a/audit/README.md
+++ b/audit/README.md
@@ -140,9 +140,9 @@ stopped the next exact-fit bump. Observed on
 [#1259](https://github.com/kurone-kito/idd-skill/issues/1259) (closed
 2026-07-04, the very next day): both recovered headroom and both fully
 regressed for lack of an upper bound. `contextCeiling` is an absolute,
-128K-context-derived cap layered on top: 126,000 bytes ≈ 31,500–38,800
+200K-context-derived cap layered on top: 196,000 bytes ≈ 49,000–60,300
 tokens at this corpus's observed 3.25–4.0 bytes/token, leaving the rest
-of a 128K context window for the harness system prompt, tool schemas,
+of a 200K context window for the harness system prompt, tool schemas,
 adopter-repo instructions, and working context.
 
 - `maxBundleLimitBytes`: no non-exempt bundle's `limitBytes` may exceed
@@ -178,6 +178,25 @@ only alongside a maintainer-authorized exception (the same
 PR-description callout the ratchet's own raise convention requires),
 and shrink it back to empty in the same PR or a tracked follow-up once
 that exception resolves.
+
+As of [#2181](https://github.com/kurone-kito/idd-skill/issues/2181)
+(resolved 2026-09-01), the ceiling's baseline moved from 128K to 200K
+contexts: `bundle-review` had re-entered `exemptBundles` pinned at the
+old 126,000-byte ceiling with no ratchet room, exactly while the
+Copilot-outage roadmap
+([#2318](https://github.com/kurone-kito/idd-skill/issues/2318)) needed
+advisory-wait instruction headroom in that bundle. The maintainer's
+priority call: outage resilience outranks the byte diet in both
+importance and urgency, and every session-model class the loop
+currently exercises holds a context of 200K tokens or more. So
+`maxBundleLimitBytes` rose to 196,000 (the same ≤ ~29%-of-window
+discipline applied at 200K), `bundle-review` ratcheted to 138,000 and
+`bundle-merge` to 122,000 (both back under the notice band), and
+`exemptBundles` returned to empty. The diet remains a best-effort
+goal: the raise-callout convention, the 98% utilization error, and the
+95% notice all stay in force, and the lite bundles' budgets are
+untouched — the 128K-class guidance in `docs/idd-workflow.md`
+continues to route weak models to the lite profile.
 
 ## Markdown Link/Anchor Audit
 

--- a/audit/README.md
+++ b/audit/README.md
@@ -180,16 +180,17 @@ and shrink it back to empty in the same PR or a tracked follow-up once
 that exception resolves.
 
 As of [#2181](https://github.com/kurone-kito/idd-skill/issues/2181)
-(resolved 2026-09-01), the ceiling's baseline moved from 128K to 200K
-contexts: `bundle-review` had re-entered `exemptBundles` pinned at the
-old 126,000-byte ceiling with no ratchet room, exactly while the
+(resolved 2026-09-01), the ceiling moved from a 128K-token to a
+200K-token context-window baseline: `bundle-review` had re-entered
+`exemptBundles` pinned at the old 126,000-byte ceiling with no ratchet
+room, exactly while the
 Copilot-outage roadmap
 ([#2318](https://github.com/kurone-kito/idd-skill/issues/2318)) needed
 advisory-wait instruction headroom in that bundle. The maintainer's
 priority call: outage resilience outranks the byte diet in both
 importance and urgency, and every session-model class the loop
 currently exercises holds a context of 200K tokens or more. So
-`maxBundleLimitBytes` rose to 196,000 (the same ≤ ~29%-of-window
+`maxBundleLimitBytes` rose to 196,000 (the same ~30%-of-window
 discipline applied at 200K), `bundle-review` ratcheted to 138,000 and
 `bundle-merge` to 122,000 (both back under the notice band), and
 `exemptBundles` returned to empty. The diet remains a best-effort

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -374,7 +374,7 @@
         ".github/instructions/idd-review-snapshot.instructions.md",
         ".github/instructions/idd-review-triage.instructions.md"
       ],
-      "limitBytes": 126000
+      "limitBytes": 138000
     },
     {
       "id": "bundle-merge",
@@ -388,15 +388,15 @@
         ".github/instructions/idd-overview-core.instructions.md",
         ".github/instructions/idd-pre-merge.instructions.md"
       ],
-      "limitBytes": 114000
+      "limitBytes": 122000
     }
   ],
   "contextCeiling": {
-    "id": "context-ceiling-128k",
-    "maxBundleLimitBytes": 126000,
+    "id": "context-ceiling-200k",
+    "maxBundleLimitBytes": 196000,
     "maxUtilizationPct": 98,
     "noticeUtilizationPct": 95,
-    "exemptBundles": ["bundle-review"]
+    "exemptBundles": []
   },
   "docBudgetGuard": {
     "id": "doc-budget-drift",

--- a/docs/bundle-review-split-feasibility.md
+++ b/docs/bundle-review-split-feasibility.md
@@ -96,13 +96,15 @@ profile entirely." A lite-opted-in session reads the full, standard
 `idd-review-triage.instructions.md` for E4-E8 exactly like a
 standard-tier session.
 
-Confirmed against the live manifest (`audit/sync-manifest.json`):
+Confirmed against the live manifest (`audit/sync-manifest.json`);
+re-confirmed 2026-09-01 after #2181 moved the ceiling to the 200K
+baseline and ratcheted `bundle-review` to 138,000:
 
 | Bundle                        | Files                                                                                                                                     | `limitBytes` |
 | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
 | `bundle-review-snapshot-lite` | `idd-advisory-wait-lite`, `idd-review-snapshot-lite`                                                                                      | 23,000       |
 | `bundle-review-fix-lite`      | `idd-advisory-wait-lite`, `idd-ci-lite`, `idd-review-fix-lite`                                                                            | 39,500       |
-| `bundle-review` (standard)    | `idd-advisory-wait`, `idd-ci`, `idd-overview-appendix`, `idd-overview-core`, `idd-review-fix`, `idd-review-snapshot`, `idd-review-triage` | 126,000      |
+| `bundle-review` (standard)    | `idd-advisory-wait`, `idd-ci`, `idd-overview-appendix`, `idd-overview-core`, `idd-review-fix`, `idd-review-snapshot`, `idd-review-triage` | 138,000      |
 
 The lite split is a **token-budget condensation** for a weak-model
 profile that deliberately excludes E4-E8 from condensation at all — it

--- a/docs/bundle-review-split-feasibility.md
+++ b/docs/bundle-review-split-feasibility.md
@@ -97,8 +97,9 @@ profile entirely." A lite-opted-in session reads the full, standard
 standard-tier session.
 
 Confirmed against the live manifest (`audit/sync-manifest.json`);
-re-confirmed 2026-09-01 after #2181 moved the ceiling to the 200K
-baseline and ratcheted `bundle-review` to 138,000:
+re-confirmed 2026-09-01 after pull request #2342 (issue #2181) moved
+the ceiling to the 200K baseline and ratcheted `bundle-review` to
+138,000:
 
 | Bundle                        | Files                                                                                                                                     | `limitBytes` |
 | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------ |

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -381,7 +381,7 @@ measure the combined byte length of all listed files.
 ### Context ceiling
 
 `audit/sync-manifest.json` `contextCeiling` layers an absolute,
-128K-context-derived cap on top of the per-bundle ratchet below, so a
+200K-context-derived cap on top of the per-bundle ratchet below, so a
 future exact-fit bump errors instead of drifting past the ~10%-margin
 convention the ratchet alone allows — see the regression history under
 "Context ceiling" in
@@ -390,11 +390,19 @@ convention the ratchet alone allows — see the regression history under
 copied template).
 
 - **Ceiling derivation**: no non-exempt bundle's `limitBytes` may exceed
-  the **126,000-byte** `maxBundleLimitBytes` ceiling — a
-  128K-context-derived cap of ≈ 31,500–38,800 tokens at this corpus's
-  observed 3.25–4.0 bytes/token, ≤ ~29% of a 128K context window,
+  the **196,000-byte** `maxBundleLimitBytes` ceiling — a
+  200K-context-derived cap of ≈ 49,000–60,300 tokens at this corpus's
+  observed 3.25–4.0 bytes/token, ≤ ~29% of a 200K context window,
   leaving the remainder for the harness system prompt, tool schemas,
-  adopter-repo instructions, and working context.
+  adopter-repo instructions, and working context. The 200K baseline is
+  the smallest context window among the session-model classes the loop
+  currently exercises; the stricter 128K-derived ceiling that
+  preceded it was relaxed on 2026-09-01 as a deliberate
+  priority call, recorded in kurone-kito/idd-skill#2181, while
+  outage-resilience work was blocked at that ceiling. The byte diet
+  stays a best-effort goal through the ratchet and notice checks below;
+  weak-model support is unaffected because the lite bundles keep their
+  own, far smaller budgets.
 - **`maxUtilizationPct` = 98%**: no non-exempt bundle's measured
   (banner-stripped) byte total may exceed this percentage of its own
   `limitBytes`. This is what stops a future exact-fit landing even for

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -392,7 +392,7 @@ copied template).
 - **Ceiling derivation**: no non-exempt bundle's `limitBytes` may exceed
   the **196,000-byte** `maxBundleLimitBytes` ceiling — a
   200K-context-derived cap of ≈ 49,000–60,300 tokens at this corpus's
-  observed 3.25–4.0 bytes/token, ≤ ~30% of a 200K context window,
+  observed 3.25–4.0 bytes/token, ≈ 24–30% of a 200K-token context window,
   leaving the remainder for the harness system prompt, tool schemas,
   adopter-repo instructions, and working context. The 200K baseline
   reflects the smallest context window among the model classes used to

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -392,14 +392,16 @@ copied template).
 - **Ceiling derivation**: no non-exempt bundle's `limitBytes` may exceed
   the **196,000-byte** `maxBundleLimitBytes` ceiling — a
   200K-context-derived cap of ≈ 49,000–60,300 tokens at this corpus's
-  observed 3.25–4.0 bytes/token, ≤ ~29% of a 200K context window,
+  observed 3.25–4.0 bytes/token, ≤ ~30% of a 200K context window,
   leaving the remainder for the harness system prompt, tool schemas,
-  adopter-repo instructions, and working context. The 200K baseline is
-  the smallest context window among the session-model classes the loop
-  currently exercises; the stricter 128K-derived ceiling that
-  preceded it was relaxed on 2026-09-01 as a deliberate
-  priority call, recorded in kurone-kito/idd-skill#2181, while
-  outage-resilience work was blocked at that ceiling. The byte diet
+  adopter-repo instructions, and working context. The 200K baseline
+  reflects the smallest context window among the model classes used to
+  validate the workflow in the source repository — not a guarantee
+  about an adopter's chosen models. The stricter 128K-derived ceiling
+  that preceded it was relaxed on 2026-09-01 as a deliberate priority
+  call, recorded in
+  [kurone-kito/idd-skill#2181](https://github.com/kurone-kito/idd-skill/issues/2181),
+  while outage-resilience work was blocked at that ceiling. The byte diet
   stays a best-effort goal through the ratchet and notice checks below;
   weak-model support is unaffected because the lite bundles keep their
   own, far smaller budgets.

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -381,7 +381,7 @@ measure the combined byte length of all listed files.
 ### Context ceiling
 
 `audit/sync-manifest.json` `contextCeiling` layers an absolute,
-128K-context-derived cap on top of the per-bundle ratchet below, so a
+200K-context-derived cap on top of the per-bundle ratchet below, so a
 future exact-fit bump errors instead of drifting past the ~10%-margin
 convention the ratchet alone allows — see the regression history under
 "Context ceiling" in
@@ -390,11 +390,19 @@ convention the ratchet alone allows — see the regression history under
 copied template).
 
 - **Ceiling derivation**: no non-exempt bundle's `limitBytes` may exceed
-  the **126,000-byte** `maxBundleLimitBytes` ceiling — a
-  128K-context-derived cap of ≈ 31,500–38,800 tokens at this corpus's
-  observed 3.25–4.0 bytes/token, ≤ ~29% of a 128K context window,
+  the **196,000-byte** `maxBundleLimitBytes` ceiling — a
+  200K-context-derived cap of ≈ 49,000–60,300 tokens at this corpus's
+  observed 3.25–4.0 bytes/token, ≤ ~29% of a 200K context window,
   leaving the remainder for the harness system prompt, tool schemas,
-  adopter-repo instructions, and working context.
+  adopter-repo instructions, and working context. The 200K baseline is
+  the smallest context window among the session-model classes the loop
+  currently exercises; the stricter 128K-derived ceiling that
+  preceded it was relaxed on 2026-09-01 as a deliberate
+  priority call, recorded in kurone-kito/idd-skill#2181, while
+  outage-resilience work was blocked at that ceiling. The byte diet
+  stays a best-effort goal through the ratchet and notice checks below;
+  weak-model support is unaffected because the lite bundles keep their
+  own, far smaller budgets.
 - **`maxUtilizationPct` = 98%**: no non-exempt bundle's measured
   (banner-stripped) byte total may exceed this percentage of its own
   `limitBytes`. This is what stops a future exact-fit landing even for

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -392,7 +392,7 @@ copied template).
 - **Ceiling derivation**: no non-exempt bundle's `limitBytes` may exceed
   the **196,000-byte** `maxBundleLimitBytes` ceiling — a
   200K-context-derived cap of ≈ 49,000–60,300 tokens at this corpus's
-  observed 3.25–4.0 bytes/token, ≤ ~30% of a 200K context window,
+  observed 3.25–4.0 bytes/token, ≈ 24–30% of a 200K-token context window,
   leaving the remainder for the harness system prompt, tool schemas,
   adopter-repo instructions, and working context. The 200K baseline
   reflects the smallest context window among the model classes used to

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -392,14 +392,16 @@ copied template).
 - **Ceiling derivation**: no non-exempt bundle's `limitBytes` may exceed
   the **196,000-byte** `maxBundleLimitBytes` ceiling — a
   200K-context-derived cap of ≈ 49,000–60,300 tokens at this corpus's
-  observed 3.25–4.0 bytes/token, ≤ ~29% of a 200K context window,
+  observed 3.25–4.0 bytes/token, ≤ ~30% of a 200K context window,
   leaving the remainder for the harness system prompt, tool schemas,
-  adopter-repo instructions, and working context. The 200K baseline is
-  the smallest context window among the session-model classes the loop
-  currently exercises; the stricter 128K-derived ceiling that
-  preceded it was relaxed on 2026-09-01 as a deliberate
-  priority call, recorded in kurone-kito/idd-skill#2181, while
-  outage-resilience work was blocked at that ceiling. The byte diet
+  adopter-repo instructions, and working context. The 200K baseline
+  reflects the smallest context window among the model classes used to
+  validate the workflow in the source repository — not a guarantee
+  about an adopter's chosen models. The stricter 128K-derived ceiling
+  that preceded it was relaxed on 2026-09-01 as a deliberate priority
+  call, recorded in
+  [kurone-kito/idd-skill#2181](https://github.com/kurone-kito/idd-skill/issues/2181),
+  while outage-resilience work was blocked at that ceiling. The byte diet
   stays a best-effort goal through the ratchet and notice checks below;
   weak-model support is unaffected because the lite bundles keep their
   own, far smaller budgets.

--- a/scripts/consistency-helpers.mjs
+++ b/scripts/consistency-helpers.mjs
@@ -221,7 +221,7 @@ function normalizeNonNegativeNumber(value) {
   return value;
 }
 /**
- * Collect "context ceiling" violations: an absolute, 128K-context-derived
+ * Collect "context ceiling" violations: an absolute, context-window-derived
  * cap layered on top of the per-bundle `bundleBudgets` ratchet, so a future
  * exact-fit bump errors instead of drifting past the documented ~10%-margin
  * convention the way `bundleBudgets` alone allowed (#1213, #1259 both

--- a/src/scripts/consistency-helpers.mts
+++ b/src/scripts/consistency-helpers.mts
@@ -279,7 +279,7 @@ function normalizePositiveIntegerBudget(
   return value;
 }
 
-/** Declarative config for the absolute 128K context-ceiling guard. */
+/** Declarative config for the absolute context-window-derived ceiling guard. */
 export interface ContextCeilingConfig {
   id?: unknown;
   maxBundleLimitBytes?: unknown;
@@ -303,7 +303,7 @@ function normalizeNonNegativeNumber(value: unknown): number | null {
 }
 
 /**
- * Collect "context ceiling" violations: an absolute, 128K-context-derived
+ * Collect "context ceiling" violations: an absolute, context-window-derived
  * cap layered on top of the per-bundle `bundleBudgets` ratchet, so a future
  * exact-fit bump errors instead of drifting past the documented ~10%-margin
  * convention the way `bundleBudgets` alone allowed (#1213, #1259 both

--- a/tests/context-ceiling.test.mts
+++ b/tests/context-ceiling.test.mts
@@ -4,7 +4,7 @@ import { test } from 'node:test';
 import { collectContextCeilingViolations } from '../src/scripts/consistency-helpers.mts';
 
 const BASE_CONFIG = {
-  id: 'context-ceiling-128k',
+  id: 'context-ceiling-200k',
   maxBundleLimitBytes: 120000,
   maxUtilizationPct: 98,
   noticeUtilizationPct: 95,
@@ -191,7 +191,7 @@ test('an exemptBundles list only silences the named violators, not the rest', ()
   // to stay well within both, mirroring the day-one exemption shape
   // documented in audit/sync-manifest.json without depending on it.
   const config = {
-    id: 'context-ceiling-128k',
+    id: 'context-ceiling-200k',
     maxBundleLimitBytes: 120000,
     maxUtilizationPct: 98,
     noticeUtilizationPct: 95,


### PR DESCRIPTION
## Why

The Copilot advisory outage is the urgent, critical problem; the byte diet is one step lower in importance and two steps lower in urgency (maintainer priority ruling on issue #2181, 2026-09-01). `bundle-review` sat in `exemptBundles` pinned at the old 128K-derived 126,000-byte ceiling with zero ratchet room — exactly while four v0.8.0 issues (#2327, #2338, #2335, then #2320) need advisory-wait instruction headroom in that bundle.

## Ratchet raise callout (required by the bundle-budget growth convention)

**This PR raises two `limitBytes` values and the ceiling itself, maintainer-authorized:**

- `contextCeiling`: id `context-ceiling-128k` → `context-ceiling-200k`, `maxBundleLimitBytes` 126,000 → **196,000**. Baseline justification: every session-model class currently exercising the loop (Sonnet 5, GPT-5.6 Luna, Grok 4.6) holds ≥ 200K context; 196,000 bytes keeps the same ~30%-of-window discipline (60,300 tokens ≈ 30.2% of a 200,000-token window at 3.25 bytes/token) the 128K derivation used (≈ 49,000–60,300 tokens at the corpus's observed 3.25–4.0 bytes/token).
- `bundle-review` 126,000 → **138,000** (measured 124,264 → 90.0% utilization; ~10% headroom convention, not exact-fit).
- `bundle-merge` 114,000 → **122,000** (measured 110,221 → 90.3%).
- `exemptBundles` returns to **empty** — bundle-review clears both error checks under the new limits, so the notice/error machinery re-engages as the best-effort diet mechanism.

The diet remains best-effort by design: raise-callout convention, 98% utilization error, 95% notice, and every lite bundle budget are unchanged. Weak-model support is unaffected (lite profile budgets untouched; 128K-class routing guidance in `docs/idd-workflow.md` stands).

## What changed

- `audit/sync-manifest.json`: the three values above.
- `idd-template/docs/policy-constants.md` (source) + regenerated `docs/policy-constants.md`: ceiling derivation rewritten for the 200K baseline with the decision provenance.
- `audit/README.md`: dated decision record appended to the Context ceiling section.

## Verification

- `node scripts/audit-docs.mjs --check`: passed (no bundle in the notice band afterwards).
- Full `pre-push-validate` chain: passed (3 pre-existing benign warnings, including the v0.7.0 release-drift warning this milestone exists to resolve).

Refs #2318

Closes #2181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtcjhuuXDqQASYGXtJnmV3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the maximum context ceiling to support larger bundles.
  * Raised review and merge bundle size limits.
  * Removed the review-bundle exemption while retaining existing utilization thresholds and lite-bundle guidance.

* **Documentation**
  * Updated policy and feasibility guidance with revised limits, token estimates, context-share details, rationale, validation scope, and effective-date information.
  * Clarified that limits are derived from the available context window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
