### PR TITLE
fix(advisory-convergence): stop reruns that cannot change the verdict

### DIFF
--- a/scripts/rerun-advisory-convergence.mjs
+++ b/scripts/rerun-advisory-convergence.mjs
@@ -53,11 +53,13 @@
 //     (fail-closed: an instance this helper cannot positively verify as
 //     safe is never recommended for rerun).
 //   - `awaiting-fresh-review`: the instance's own advisory-convergence
-//     JSON verdict (from the workflow job log) reports that the latest
-//     Copilot review does not cover the current HEAD. No number of
-//     `gh run rerun` invocations changes that outcome -- only a fresh
-//     review does -- so this is never placed in the plan and never
-//     spends the rerun-once budget (#1775, observed on PR #1772).
+//     JSON verdict (from the workflow job log) reports either that the
+//     latest Copilot review does not cover the current HEAD, or that the
+//     primary advisory bot has not reviewed the pull request AT ALL yet
+//     (#2326, observed on PR #2325). No number of `gh run rerun`
+//     invocations changes either outcome -- only a fresh review does --
+//     so this is never placed in the plan and never spends the
+//     rerun-once budget (#1775, observed on PR #1772).
 //     #1806: this historical verdict is a snapshot of the workflow job
 //     log at the time THAT run executed, and the log is immutable -- so
 //     an instance that failed BEFORE a fresh review landed keeps
@@ -69,11 +71,14 @@
 //     via `review-clause.mts`) confirms the current HEAD IS now covered,
 //     this classification recovers to `rerun-eligible` instead of
 //     staying stuck -- see `RerunPlanOptions.headCoverageSatisfied` and
-//     `classifyInstance`'s uncovered-HEAD step. Live coverage that is
+//     `classifyInstance`'s awaiting-fresh-review step. #2326 widened the
+//     same recovery to the never-reviewed reason too: once a review that
+//     covers current HEAD exists, the bot has necessarily also reviewed,
+//     so the same live signal recovers both holds. Live coverage that is
 //     unreadable, not yet established, or simply not checked (no
-//     historical uncovered-HEAD reason to recover) leaves this hold
-//     exactly as it was before #1806 -- fail-closed, never an invented
-//     rerun.
+//     historical uncovered-HEAD or never-reviewed reason to recover)
+//     leaves this hold exactly as it was before #1806 -- fail-closed,
+//     never an invented rerun.
 //   - `rerun-eligible`: non-pass, terminal, resolved -- goes into the
 //     ordered rerun plan (bot-triggered or not, unless gated per above).
 //
@@ -202,6 +207,16 @@ const PULL_REQUEST_FAMILY_EVENTS = new Set([
  * workflow's own verdict rather than re-deriving coverage (#1775).
  */
 export const UNCOVERED_HEAD_REASON_MARKER = 'does not cover current HEAD';
+/**
+ * Stable phrase shared with `advisory-convergence.mts`'s own
+ * `isSoleCopilotNotReviewedYetReason` reason text (`${primaryBotLogin} has
+ * not reviewed this pull request yet`). Matching on this substring (not the
+ * whole templated string) keeps the classifier independent of the
+ * configured primary bot login, mirroring {@link UNCOVERED_HEAD_REASON_MARKER}
+ * (#2326).
+ */
+export const NEVER_REVIEWED_REASON_MARKER =
+  'has not reviewed this pull request yet';
 const PLAN_CAVEAT =
   'Rerun the rerun-eligible instances ONE AT A TIME, in the order listed below, waiting for each `gh run rerun` to finish before starting the next -- rerunning several concurrently makes them cancel each other via the shared concurrency group.';
 // Deliberately does NOT open with "No rerun-eligible instance exists": since
@@ -317,7 +332,7 @@ export function computeRerunPlan(input, options) {
   //
   // #1806 interaction (intentional): a live-coverage-recovered instance
   // (classified `rerun-eligible` instead of `awaiting-fresh-review` --
-  // see `classifyInstance`'s uncovered-HEAD step) enters `eligibleInstances`
+  // see `classifyInstance`'s awaiting-fresh-review step) enters `eligibleInstances`
   // like any other rerun-eligible instance. If ITS OWN `runAttempt` already
   // exhausted the rerun-once budget, rule 1 above applies to it exactly the
   // same way it already applies to any other budget-held eligible instance:
@@ -627,32 +642,43 @@ function classifyInstance(instance, options) {
         : 'triggering event is unknown; inspect manually rather than assuming it is safe to rerun',
     };
   }
-  // 7. Uncovered-HEAD hold (#1775): the instance's own
-  // advisory-convergence JSON verdict (from the workflow job log) says
-  // the latest Copilot review does not cover the current HEAD. Rerunning
-  // cannot change that -- only a fresh review can -- so never place this
-  // in the plan and never spend the rerun-once budget on it. Only fires
-  // when `verdictReasons` was actually consulted and matched; a missing
-  // / unparsed log leaves classification unchanged (no invented hold).
+  // 7. Awaiting-fresh-review hold: the instance's own advisory-convergence
+  // JSON verdict (from the workflow job log) says either that the latest
+  // Copilot review does not cover the current HEAD (#1775), or that the
+  // primary advisory bot has not reviewed the pull request AT ALL yet
+  // (#2326, observed on PR #2325 -- rerunning cannot change that either,
+  // since there is no review to re-read). Rerunning cannot change either
+  // outcome -- only a fresh review can -- so never place this in the plan
+  // and never spend the rerun-once budget on it. Only fires when
+  // `verdictReasons` was actually consulted and matched; a missing /
+  // unparsed log leaves classification unchanged (no invented hold).
   //
   // #1806 live-coverage recovery: the job log above is an IMMUTABLE
   // snapshot from when THAT run executed, so it can go stale once a
   // fresh review actually lands after the run failed (observed on PR
   // #1854). `options.headCoverageSatisfied` is a LIVE, per-PR signal
   // (see `RerunPlanOptions.headCoverageSatisfied`) that lets this hold
-  // recover instead of staying stuck forever. Only `=== true` recovers;
-  // `false`, `null`, and `undefined` all keep the historical hold exactly
-  // as before #1806 -- fail-closed, so an unreadable or not-yet-covered
-  // live signal never invents a rerun.
-  if (hasUncoveredHeadVerdictReason(instance.verdictReasons)) {
+  // recover instead of staying stuck forever -- for both reasons above,
+  // since a review whose commit matches current HEAD necessarily also
+  // means the bot has reviewed (#2326). Only `=== true` recovers; `false`,
+  // `null`, and `undefined` all keep the historical hold exactly as before
+  // #1806 -- fail-closed, so an unreadable or not-yet-covered live signal
+  // never invents a rerun.
+  if (
+    hasUncoveredHeadVerdictReason(instance.verdictReasons) ||
+    hasNeverReviewedVerdictReason(instance.verdictReasons)
+  ) {
     const matched =
-      instance.verdictReasons?.find(isUncoveredHeadVerdictReason) ??
-      UNCOVERED_HEAD_REASON_MARKER;
+      instance.verdictReasons?.find(
+        (reason) =>
+          isUncoveredHeadVerdictReason(reason) ||
+          isNeverReviewedVerdictReason(reason),
+      ) ?? UNCOVERED_HEAD_REASON_MARKER;
     if (options.headCoverageSatisfied !== true) {
       return {
         ...instance,
         classification: 'awaiting-fresh-review',
-        reason: `advisory-convergence verdict reports "${matched}"; rerunning cannot clear this -- wait for a fresh review covering the current HEAD rather than spending the rerun-once budget (#1775)`,
+        reason: `advisory-convergence verdict reports "${matched}"; rerunning cannot clear this -- wait for a fresh review covering the current HEAD rather than spending the rerun-once budget (#1775, #2326)`,
       };
     }
     return {
@@ -693,6 +719,28 @@ export function isUncoveredHeadVerdictReason(reason) {
 export function hasUncoveredHeadVerdictReason(reasons) {
   if (!reasons) return false;
   return reasons.some((reason) => isUncoveredHeadVerdictReason(reason));
+}
+/**
+ * `true` when `reason` is an advisory-convergence never-reviewed reason --
+ * the primary advisory bot has not reviewed the pull request at all yet
+ * (see {@link NEVER_REVIEWED_REASON_MARKER}). Mirrors
+ * {@link isUncoveredHeadVerdictReason}; the two are the same hold shape
+ * (#2326).
+ */
+export function isNeverReviewedVerdictReason(reason) {
+  return String(reason ?? '')
+    .toLowerCase()
+    .includes(NEVER_REVIEWED_REASON_MARKER.toLowerCase());
+}
+/**
+ * `true` when a consulted `reasons` list contains a never-reviewed reason.
+ * A `null` / `undefined` list means "not consulted" and never matches --
+ * so a missing log cannot invent an `awaiting-fresh-review` hold, mirroring
+ * {@link hasUncoveredHeadVerdictReason} (#2326).
+ */
+export function hasNeverReviewedVerdictReason(reasons) {
+  if (!reasons) return false;
+  return reasons.some((reason) => isNeverReviewedVerdictReason(reason));
 }
 /**
  * Extract the advisory-convergence JSON verdict's `reasons` array from a
@@ -1579,15 +1627,15 @@ export function sanitizeRemoteConfig(config) {
  * SAME evidence `advisory-convergence.mts`'s real `converged` verdict is
  * built on) instead of a second ad-hoc GraphQL path. Only called from
  * `collectFromGitHub` when at least one collected instance's own
- * historical `verdictReasons` already reports an uncovered-HEAD reason --
- * see that call site -- so a PR with no such instance never pays for this
- * extra fetch.
+ * historical `verdictReasons` already reports an uncovered-HEAD or a
+ * never-reviewed reason (#2326) -- see that call site -- so a PR with no
+ * such instance never pays for this extra fetch.
  *
  * Fails closed to `null` ("evidence unreadable") on ANY error -- never
  * `false` -- so a transient GraphQL/network failure can never be
  * indistinguishable from "checked, not covered" if a future caller wants
- * to tell the two apart; `classifyInstance`'s uncovered-HEAD step treats
- * both `false` and `null` identically (hold), matching the existing
+ * to tell the two apart; `classifyInstance`'s awaiting-fresh-review step
+ * treats both `false` and `null` identically (hold), matching the existing
  * `verdictReasons`-null pattern elsewhere in this file (a missing/failed
  * fetch never invents a hold OR a rerun).
  */
@@ -1700,10 +1748,11 @@ function collectFromGitHub(args) {
       runMetaById.set(runId, null);
     }
   }
-  // Per-run advisory-convergence verdict reasons (#1775). Only non-pass
-  // terminal check-runs need them -- pass / pending never reach the
-  // uncovered-HEAD classifier, so skipping those saves a log download
-  // per green instance. Failures to fetch or parse leave the map entry
+  // Per-run advisory-convergence verdict reasons (#1775, widened by
+  // #2326). Only non-pass terminal check-runs need them -- pass / pending
+  // never reach the awaiting-fresh-review classifier, so skipping those
+  // saves a log download per green instance. Failures to fetch or parse
+  // leave the map entry
   // absent (`null` on the instance) rather than inventing an empty list,
   // so a flaky log API cannot invent an awaiting-fresh-review hold.
   const runIdsNeedingVerdict = new Set(
@@ -1793,13 +1842,18 @@ function collectFromGitHub(args) {
   const { rerunPolicy } = normalizeCiWaitPolicy(rawConfig?.ciWait);
   // #1806: only pay for the live-coverage fetch when at least one
   // collected instance's own historical verdict already reports an
-  // uncovered-HEAD reason -- the ONLY situation `classifyInstance`'s
-  // uncovered-HEAD step consults `headCoverageSatisfied` at all. A PR
-  // with no such instance never triggers the extra GraphQL round trip.
-  const anyHistoricalUncoveredHead = [...verdictReasonsByRunId.values()].some(
-    (reasons) => hasUncoveredHeadVerdictReason(reasons),
+  // uncovered-HEAD or a never-reviewed reason (#2326) -- the ONLY
+  // situations `classifyInstance`'s awaiting-fresh-review step consults
+  // `headCoverageSatisfied` at all. A PR with no such instance never
+  // triggers the extra GraphQL round trip.
+  const anyHistoricalAwaitingFreshReviewReason = [
+    ...verdictReasonsByRunId.values(),
+  ].some(
+    (reasons) =>
+      hasUncoveredHeadVerdictReason(reasons) ||
+      hasNeverReviewedVerdictReason(reasons),
   );
-  const headCoverageSatisfied = anyHistoricalUncoveredHead
+  const headCoverageSatisfied = anyHistoricalAwaitingFreshReviewReason
     ? resolveLiveHeadCoverage(
         owner,
         repo,

--- a/src/scripts/rerun-advisory-convergence.mts
+++ b/src/scripts/rerun-advisory-convergence.mts
@@ -53,11 +53,13 @@
 //     (fail-closed: an instance this helper cannot positively verify as
 //     safe is never recommended for rerun).
 //   - `awaiting-fresh-review`: the instance's own advisory-convergence
-//     JSON verdict (from the workflow job log) reports that the latest
-//     Copilot review does not cover the current HEAD. No number of
-//     `gh run rerun` invocations changes that outcome -- only a fresh
-//     review does -- so this is never placed in the plan and never
-//     spends the rerun-once budget (#1775, observed on PR #1772).
+//     JSON verdict (from the workflow job log) reports either that the
+//     latest Copilot review does not cover the current HEAD, or that the
+//     primary advisory bot has not reviewed the pull request AT ALL yet
+//     (#2326, observed on PR #2325). No number of `gh run rerun`
+//     invocations changes either outcome -- only a fresh review does --
+//     so this is never placed in the plan and never spends the
+//     rerun-once budget (#1775, observed on PR #1772).
 //     #1806: this historical verdict is a snapshot of the workflow job
 //     log at the time THAT run executed, and the log is immutable -- so
 //     an instance that failed BEFORE a fresh review landed keeps
@@ -69,11 +71,14 @@
 //     via `review-clause.mts`) confirms the current HEAD IS now covered,
 //     this classification recovers to `rerun-eligible` instead of
 //     staying stuck -- see `RerunPlanOptions.headCoverageSatisfied` and
-//     `classifyInstance`'s uncovered-HEAD step. Live coverage that is
+//     `classifyInstance`'s awaiting-fresh-review step. #2326 widened the
+//     same recovery to the never-reviewed reason too: once a review that
+//     covers current HEAD exists, the bot has necessarily also reviewed,
+//     so the same live signal recovers both holds. Live coverage that is
 //     unreadable, not yet established, or simply not checked (no
-//     historical uncovered-HEAD reason to recover) leaves this hold
-//     exactly as it was before #1806 -- fail-closed, never an invented
-//     rerun.
+//     historical uncovered-HEAD or never-reviewed reason to recover)
+//     leaves this hold exactly as it was before #1806 -- fail-closed,
+//     never an invented rerun.
 //   - `rerun-eligible`: non-pass, terminal, resolved -- goes into the
 //     ordered rerun plan (bot-triggered or not, unless gated per above).
 //
@@ -222,6 +227,17 @@ export type RerunPlanClassification =
 export const UNCOVERED_HEAD_REASON_MARKER = 'does not cover current HEAD';
 
 /**
+ * Stable phrase shared with `advisory-convergence.mts`'s own
+ * `isSoleCopilotNotReviewedYetReason` reason text (`${primaryBotLogin} has
+ * not reviewed this pull request yet`). Matching on this substring (not the
+ * whole templated string) keeps the classifier independent of the
+ * configured primary bot login, mirroring {@link UNCOVERED_HEAD_REASON_MARKER}
+ * (#2326).
+ */
+export const NEVER_REVIEWED_REASON_MARKER =
+  'has not reviewed this pull request yet';
+
+/**
  * One check-run instance, already normalized and (when resolvable) already
  * enriched with its underlying workflow run's identity fields. This is what
  * the pure {@link computeRerunPlan} consumes -- fetching and enrichment
@@ -263,9 +279,10 @@ export interface RerunPlanRawInstance {
    * verdict (parsed out of the workflow job log), or `null` when the log
    * was not consulted or could not be parsed. A `null` leaves
    * classification unchanged (no invented hold); a non-null list that
-   * contains an {@link UNCOVERED_HEAD_REASON_MARKER} reason classifies
-   * the instance as `awaiting-fresh-review` instead of `rerun-eligible`
-   * (#1775). Tests inject this directly; production
+   * contains an {@link UNCOVERED_HEAD_REASON_MARKER} or
+   * {@link NEVER_REVIEWED_REASON_MARKER} reason classifies the instance as
+   * `awaiting-fresh-review` instead of `rerun-eligible` (#1775, widened by
+   * #2326). Tests inject this directly; production
    * {@link collectFromGitHub} fills it for non-pass terminal instances.
    */
   verdictReasons?: string[] | null;
@@ -440,15 +457,18 @@ export interface RerunPlanOptions {
    * Live signal (#1806): whether the latest trusted primary-bot review's
    * commit now matches the PR's current HEAD -- independent of any
    * instance's own historical (job-log) verdict. `true` lets an instance
-   * whose historical `verdictReasons` report an uncovered-HEAD hold
-   * recover to `rerun-eligible` (see `classifyInstance`'s uncovered-HEAD
-   * step); `false`, `null`, or omitted all fail closed to the existing
+   * whose historical `verdictReasons` report an uncovered-HEAD OR a
+   * never-reviewed hold (#2326) recover to `rerun-eligible` (see
+   * `classifyInstance`'s awaiting-fresh-review step) -- a review whose
+   * commit matches current HEAD necessarily also means the bot has
+   * reviewed, so the same live signal recovers both holds; `false`,
+   * `null`, or omitted all fail closed to the existing
    * `awaiting-fresh-review` hold -- this never invents a rerun when live
    * coverage could not be established or was never checked. Pure/DI: tests
    * inject this directly with no network; production `collectFromGitHub`
    * fills it (via `resolveLiveHeadCoverage`) only when at least one
    * collected instance's own historical verdict already reports an
-   * uncovered-HEAD reason, reusing `review-clause.mts`'s
+   * uncovered-HEAD or never-reviewed reason, reusing `review-clause.mts`'s
    * `fetchReviewsAndHeadCommit` + `resolveLatestCopilotReviewClause`.
    */
   headCoverageSatisfied?: boolean | null;
@@ -568,7 +588,7 @@ export function computeRerunPlan(
   //
   // #1806 interaction (intentional): a live-coverage-recovered instance
   // (classified `rerun-eligible` instead of `awaiting-fresh-review` --
-  // see `classifyInstance`'s uncovered-HEAD step) enters `eligibleInstances`
+  // see `classifyInstance`'s awaiting-fresh-review step) enters `eligibleInstances`
   // like any other rerun-eligible instance. If ITS OWN `runAttempt` already
   // exhausted the rerun-once budget, rule 1 above applies to it exactly the
   // same way it already applies to any other budget-held eligible instance:
@@ -916,32 +936,43 @@ function classifyInstance(
     };
   }
 
-  // 7. Uncovered-HEAD hold (#1775): the instance's own
-  // advisory-convergence JSON verdict (from the workflow job log) says
-  // the latest Copilot review does not cover the current HEAD. Rerunning
-  // cannot change that -- only a fresh review can -- so never place this
-  // in the plan and never spend the rerun-once budget on it. Only fires
-  // when `verdictReasons` was actually consulted and matched; a missing
-  // / unparsed log leaves classification unchanged (no invented hold).
+  // 7. Awaiting-fresh-review hold: the instance's own advisory-convergence
+  // JSON verdict (from the workflow job log) says either that the latest
+  // Copilot review does not cover the current HEAD (#1775), or that the
+  // primary advisory bot has not reviewed the pull request AT ALL yet
+  // (#2326, observed on PR #2325 -- rerunning cannot change that either,
+  // since there is no review to re-read). Rerunning cannot change either
+  // outcome -- only a fresh review can -- so never place this in the plan
+  // and never spend the rerun-once budget on it. Only fires when
+  // `verdictReasons` was actually consulted and matched; a missing /
+  // unparsed log leaves classification unchanged (no invented hold).
   //
   // #1806 live-coverage recovery: the job log above is an IMMUTABLE
   // snapshot from when THAT run executed, so it can go stale once a
   // fresh review actually lands after the run failed (observed on PR
   // #1854). `options.headCoverageSatisfied` is a LIVE, per-PR signal
   // (see `RerunPlanOptions.headCoverageSatisfied`) that lets this hold
-  // recover instead of staying stuck forever. Only `=== true` recovers;
-  // `false`, `null`, and `undefined` all keep the historical hold exactly
-  // as before #1806 -- fail-closed, so an unreadable or not-yet-covered
-  // live signal never invents a rerun.
-  if (hasUncoveredHeadVerdictReason(instance.verdictReasons)) {
+  // recover instead of staying stuck forever -- for both reasons above,
+  // since a review whose commit matches current HEAD necessarily also
+  // means the bot has reviewed (#2326). Only `=== true` recovers; `false`,
+  // `null`, and `undefined` all keep the historical hold exactly as before
+  // #1806 -- fail-closed, so an unreadable or not-yet-covered live signal
+  // never invents a rerun.
+  if (
+    hasUncoveredHeadVerdictReason(instance.verdictReasons) ||
+    hasNeverReviewedVerdictReason(instance.verdictReasons)
+  ) {
     const matched =
-      instance.verdictReasons?.find(isUncoveredHeadVerdictReason) ??
-      UNCOVERED_HEAD_REASON_MARKER;
+      instance.verdictReasons?.find(
+        (reason) =>
+          isUncoveredHeadVerdictReason(reason) ||
+          isNeverReviewedVerdictReason(reason),
+      ) ?? UNCOVERED_HEAD_REASON_MARKER;
     if (options.headCoverageSatisfied !== true) {
       return {
         ...instance,
         classification: 'awaiting-fresh-review',
-        reason: `advisory-convergence verdict reports "${matched}"; rerunning cannot clear this -- wait for a fresh review covering the current HEAD rather than spending the rerun-once budget (#1775)`,
+        reason: `advisory-convergence verdict reports "${matched}"; rerunning cannot clear this -- wait for a fresh review covering the current HEAD rather than spending the rerun-once budget (#1775, #2326)`,
       };
     }
     return {
@@ -987,6 +1018,32 @@ export function hasUncoveredHeadVerdictReason(
 ): boolean {
   if (!reasons) return false;
   return reasons.some((reason) => isUncoveredHeadVerdictReason(reason));
+}
+
+/**
+ * `true` when `reason` is an advisory-convergence never-reviewed reason --
+ * the primary advisory bot has not reviewed the pull request at all yet
+ * (see {@link NEVER_REVIEWED_REASON_MARKER}). Mirrors
+ * {@link isUncoveredHeadVerdictReason}; the two are the same hold shape
+ * (#2326).
+ */
+export function isNeverReviewedVerdictReason(reason: string): boolean {
+  return String(reason ?? '')
+    .toLowerCase()
+    .includes(NEVER_REVIEWED_REASON_MARKER.toLowerCase());
+}
+
+/**
+ * `true` when a consulted `reasons` list contains a never-reviewed reason.
+ * A `null` / `undefined` list means "not consulted" and never matches --
+ * so a missing log cannot invent an `awaiting-fresh-review` hold, mirroring
+ * {@link hasUncoveredHeadVerdictReason} (#2326).
+ */
+export function hasNeverReviewedVerdictReason(
+  reasons: readonly string[] | null | undefined,
+): boolean {
+  if (!reasons) return false;
+  return reasons.some((reason) => isNeverReviewedVerdictReason(reason));
 }
 
 /**
@@ -2089,15 +2146,15 @@ export function sanitizeRemoteConfig(
  * SAME evidence `advisory-convergence.mts`'s real `converged` verdict is
  * built on) instead of a second ad-hoc GraphQL path. Only called from
  * `collectFromGitHub` when at least one collected instance's own
- * historical `verdictReasons` already reports an uncovered-HEAD reason --
- * see that call site -- so a PR with no such instance never pays for this
- * extra fetch.
+ * historical `verdictReasons` already reports an uncovered-HEAD or a
+ * never-reviewed reason (#2326) -- see that call site -- so a PR with no
+ * such instance never pays for this extra fetch.
  *
  * Fails closed to `null` ("evidence unreadable") on ANY error -- never
  * `false` -- so a transient GraphQL/network failure can never be
  * indistinguishable from "checked, not covered" if a future caller wants
- * to tell the two apart; `classifyInstance`'s uncovered-HEAD step treats
- * both `false` and `null` identically (hold), matching the existing
+ * to tell the two apart; `classifyInstance`'s awaiting-fresh-review step
+ * treats both `false` and `null` identically (hold), matching the existing
  * `verdictReasons`-null pattern elsewhere in this file (a missing/failed
  * fetch never invents a hold OR a rerun).
  */
@@ -2229,10 +2286,11 @@ function collectFromGitHub(args: RerunPlanArgs): {
     }
   }
 
-  // Per-run advisory-convergence verdict reasons (#1775). Only non-pass
-  // terminal check-runs need them -- pass / pending never reach the
-  // uncovered-HEAD classifier, so skipping those saves a log download
-  // per green instance. Failures to fetch or parse leave the map entry
+  // Per-run advisory-convergence verdict reasons (#1775, widened by
+  // #2326). Only non-pass terminal check-runs need them -- pass / pending
+  // never reach the awaiting-fresh-review classifier, so skipping those
+  // saves a log download per green instance. Failures to fetch or parse
+  // leave the map entry
   // absent (`null` on the instance) rather than inventing an empty list,
   // so a flaky log API cannot invent an awaiting-fresh-review hold.
   const runIdsNeedingVerdict = new Set(
@@ -2327,13 +2385,18 @@ function collectFromGitHub(args: RerunPlanArgs): {
 
   // #1806: only pay for the live-coverage fetch when at least one
   // collected instance's own historical verdict already reports an
-  // uncovered-HEAD reason -- the ONLY situation `classifyInstance`'s
-  // uncovered-HEAD step consults `headCoverageSatisfied` at all. A PR
-  // with no such instance never triggers the extra GraphQL round trip.
-  const anyHistoricalUncoveredHead = [...verdictReasonsByRunId.values()].some(
-    (reasons) => hasUncoveredHeadVerdictReason(reasons),
+  // uncovered-HEAD or a never-reviewed reason (#2326) -- the ONLY
+  // situations `classifyInstance`'s awaiting-fresh-review step consults
+  // `headCoverageSatisfied` at all. A PR with no such instance never
+  // triggers the extra GraphQL round trip.
+  const anyHistoricalAwaitingFreshReviewReason = [
+    ...verdictReasonsByRunId.values(),
+  ].some(
+    (reasons) =>
+      hasUncoveredHeadVerdictReason(reasons) ||
+      hasNeverReviewedVerdictReason(reasons),
   );
-  const headCoverageSatisfied = anyHistoricalUncoveredHead
+  const headCoverageSatisfied = anyHistoricalAwaitingFreshReviewReason
     ? resolveLiveHeadCoverage(
         owner,
         repo,

--- a/tests/rerun-advisory-convergence.test.mts
+++ b/tests/rerun-advisory-convergence.test.mts
@@ -13,8 +13,11 @@ import {
   describeRecoveryRefreshHeader,
   extractAdvisoryVerdictReasonsFromLog,
   formatApplySummary,
+  hasNeverReviewedVerdictReason,
   hasUncoveredHeadVerdictReason,
+  isNeverReviewedVerdictReason,
   isUncoveredHeadVerdictReason,
+  NEVER_REVIEWED_REASON_MARKER,
   parseArgs,
   parseRunIdFromUrl,
   RERUN_PLAN_CHECK_NAME,
@@ -532,6 +535,99 @@ test('#1775: applyRerunPlan never spends budget on an awaiting-fresh-review inst
   assert.equal(result.resolved, true);
 });
 
+// --- Classification: never-reviewed (#2326) -------------------------------
+
+const NEVER_REVIEWED_HISTORICAL_REASON =
+  'copilot has not reviewed this pull request yet';
+
+test('#2326: classifies a never-reviewed verdict reason as awaiting-fresh-review, not rerun-eligible', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          conclusion: 'failure',
+          verdictReasons: [NEVER_REVIEWED_HISTORICAL_REASON],
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.instances[0]?.classification, 'awaiting-fresh-review');
+  assert.equal(plan.counts.awaitingFreshReview, 1);
+  assert.equal(plan.counts.rerunEligible, 0);
+  assert.equal(plan.plan.length, 0);
+  assert.match(plan.instances[0]?.reason ?? '', /wait for a fresh review/);
+  assert.match(
+    plan.instances[0]?.reason ?? '',
+    /has not reviewed this pull request yet/,
+  );
+});
+
+test('#2326: applyRerunPlan never spends budget on a never-reviewed instance', () => {
+  const initialPlan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          conclusion: 'failure',
+          verdictReasons: [NEVER_REVIEWED_HISTORICAL_REASON],
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(initialPlan.plan.length, 0);
+
+  let rerunCalled = false;
+  const result = applyRerunPlan(initialPlan, {
+    rerunAndWait: () => {
+      rerunCalled = true;
+    },
+    recomputePlan: () => {
+      throw new Error('recomputePlan should not be called');
+    },
+  });
+
+  assert.equal(rerunCalled, false);
+  assert.equal(result.executed.length, 0);
+  assert.equal(result.resolved, true);
+});
+
+test('#2326: headCoverageSatisfied true also recovers a never-reviewed hold to rerun-eligible', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          conclusion: 'failure',
+          verdictReasons: [NEVER_REVIEWED_HISTORICAL_REASON],
+        }),
+      ],
+    }),
+    baseOptions({ headCoverageSatisfied: true }),
+  );
+  assert.equal(plan.instances[0]?.classification, 'rerun-eligible');
+  assert.equal(plan.counts.rerunEligible, 1);
+  assert.equal(plan.counts.awaitingFreshReview, 0);
+  assert.equal(plan.plan.length, 1);
+  assert.match(plan.instances[0]?.reason ?? '', /historically reported/);
+  assert.match(plan.instances[0]?.reason ?? '', /#1806/);
+});
+
+test('#2326: headCoverageSatisfied omitted (undefined) fails closed to the never-reviewed hold', () => {
+  const plan = computeRerunPlan(
+    baseInput({
+      instances: [
+        baseInstance({
+          conclusion: 'failure',
+          verdictReasons: [NEVER_REVIEWED_HISTORICAL_REASON],
+        }),
+      ],
+    }),
+    baseOptions(),
+  );
+  assert.equal(plan.instances[0]?.classification, 'awaiting-fresh-review');
+  assert.equal(plan.plan.length, 0);
+});
+
 // --- Classification: live-coverage recovery (#1806) ----------------------
 
 const UNCOVERED_HEAD_HISTORICAL_REASON =
@@ -690,6 +786,24 @@ test('#1775: extractAdvisoryVerdictReasonsFromLog parses gh-run-view-shaped logs
   );
   assert.equal(hasUncoveredHeadVerdictReason(null), false);
   assert.match(UNCOVERED_HEAD_REASON_MARKER, /does not cover current HEAD/);
+});
+
+test('#2326: never-reviewed helpers match their marker and reject the uncovered-HEAD reason', () => {
+  const neverReviewed = 'copilot has not reviewed this pull request yet';
+  assert.equal(isNeverReviewedVerdictReason(neverReviewed), true);
+  assert.equal(hasNeverReviewedVerdictReason([neverReviewed]), true);
+  assert.equal(
+    isNeverReviewedVerdictReason(
+      'latest copilot review (commit abc) does not cover current HEAD def',
+    ),
+    false,
+  );
+  assert.equal(hasNeverReviewedVerdictReason(null), false);
+  assert.equal(hasNeverReviewedVerdictReason(undefined), false);
+  assert.match(
+    NEVER_REVIEWED_REASON_MARKER,
+    /has not reviewed this pull request yet/,
+  );
 });
 
 test('#1775: extractAdvisoryVerdictReasonsFromLog returns null when no verdict JSON is present', () => {


### PR DESCRIPTION
# Summary

`rerun-advisory-convergence.mts` already classifies an uncovered-HEAD
verdict (`... does not cover current HEAD ...`) as `awaiting-fresh-review`
instead of `rerun-eligible`, so it never wastes the rerun-once budget on a
rerun that cannot fix a stale review. It missed the same shape for a
verdict reporting that the primary advisory bot has **never** reviewed the
pull request at all -- observed live on PR #2325 during a Copilot rate
limit. That case was still classified `rerun-eligible`, so rerunning spent
the one-rerun budget with nothing to gain (there was no review to
re-read), leaving every instance `rerunBudgetHeld` and emptying the
recovery plan.

Widens the existing uncovered-HEAD branch in `classifyInstance` to also
recognize the never-reviewed reason (`has not reviewed this pull request
yet`), reusing the same branch, the same `verdictReasons` reading path, and
the same #1806 live-coverage recovery signal (`headCoverageSatisfied`):
once a review whose commit matches current HEAD exists, the bot has
necessarily also reviewed, so the same live check recovers both holds.

## Linked issue

Closes #2326

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

No new mechanism was added -- per the issue's proposed change, this widens
the recognized reason set inside the existing uncovered-HEAD branch rather
than adding a parallel one, so `headCoverageSatisfied`'s trigger condition
in `collectFromGitHub` (`anyHistoricalAwaitingFreshReviewReason`) was
widened the same way, or the live-coverage fetch would never fire for a
never-reviewed instance.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (no docs changed)
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added recognition of advisory checks indicating the primary review bot has not yet reviewed a pull request.
  - Added recovery handling when current-commit coverage becomes available.
  - Expanded recovery-plan reporting to show refresh plans, standard reruns, policy notices, and outstanding states.
  - Improved rerun prioritization and recalculation during applied recovery runs.

- **Bug Fixes**
  - Prevented unnecessary reruns while required review coverage is missing.
  - Ensured unresolved or unknown coverage states remain safely blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->