### PR TITLE
perf(ci): cut Actions consumption and document adopter billing exposure

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 # their diffs collapse in review. Listed per file during the TypeScript
 # migration so hand-written .mjs are never mis-marked; see
 # docs/typescript-sources.md.
+scripts/actions-usage-report.mjs linguist-generated=true
 scripts/advisory-convergence.mjs linguist-generated=true
 scripts/advisory-wait-policy.mjs linguist-generated=true
 scripts/advisory-wait-state.mjs linguist-generated=true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,16 @@ concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.ref }}
 name: CodeQL
+# CI topology (#2322): unlike lint.yml/idd-doctor.yml/pnpm-boundary.yml,
+# this pull_request trigger deliberately carries no path filter -- CodeQL
+# is a security scan, and a path filter that misses a security-relevant
+# file (a new dependency, a workflow permission change, a helper this
+# repository's own filter-author failed to anticipate) would silently
+# narrow coverage instead of only saving minutes. This workflow is also
+# not one of the branch ruleset's required status checks (see
+# docs/customization.md's CI cost discipline appendix), so an adopter
+# who does want to bound its cost can safely add a path filter here
+# without weakening the IDD merge gate itself.
 on:
   pull_request:
     branches:

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1732,7 +1732,13 @@ distribute); build an equivalent against the same
 and
 [`GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs`](https://docs.github.com/en/rest/actions/workflow-jobs)
 endpoints, filtered by the pull request's head branch, to attribute cost the
-same way for your own workflows.
+same way for your own workflows. A branch-name filter alone can include an
+unrelated run -- a reused branch name, or a same-repository `push` /
+`workflow_dispatch` run against that branch outside this pull request --
+so also restrict to `pull_request`/`pull_request_review`/
+`pull_request_review_comment`-triggered runs and check each run's own
+`pull_requests[].number` against the target pull request (empty for a
+fork-originated pull request, where GitHub never populates that field).
 
 **Only your configured required status checks cost every pull request
 unconditionally.** A `pull_request`-triggered workflow that is _not_ one of

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1743,7 +1743,7 @@ since the gate only ever waits on the required contexts. Filtering or
 dropping a _required_ context's own trigger is the one cut this guide
 never recommends: a path-filtered required check simply never reports for
 a change outside its filter, which blocks the pull request forever rather
-than saving anything.
+than saving anything (preventive; no observed incident yet).
 
 **On a private repository, the account Actions spend limit is where this
 multiplier stops being merely a cost and becomes a hard block**: once the

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1718,5 +1718,42 @@ per-minute rates are billed per GitHub's own
 [Actions billing usage docs](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions);
 this guide does not hard-code a price since rates change.
 
+**The advisory review loop is a second, IDD-specific multiplier on top of
+re-sync cadence.** E14/F2/F3's advisory-wait protocol pushes repeatedly and
+collects a fresh bot review on each push, and every push plus every review
+event can each independently trigger the advisory-convergence required
+check -- so one pull request's total run count is a multiple of its push
+count, not a fixed cost. This repository measures its own instance of that
+multiplier with a maintainer-only reporting tool
+(`node scripts/actions-usage-report.mjs --pr <number>`, source-repo-internal
+-- an adopter's own workflow names differ, so there is nothing portable to
+distribute); build an equivalent against the same
+[`GET /repos/{owner}/{repo}/actions/runs`](https://docs.github.com/en/rest/actions/workflow-runs)
+and
+[`GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs`](https://docs.github.com/en/rest/actions/workflow-jobs)
+endpoints, filtered by the pull request's head branch, to attribute cost the
+same way for your own workflows.
+
+**Only your configured required status checks cost every pull request
+unconditionally.** A `pull_request`-triggered workflow that is _not_ one of
+your branch ruleset's required contexts -- a security scanner, a
+secondary compatibility-floor guard, anything advisory -- is safely
+droppable or path-filterable without weakening the IDD merge gate itself,
+since the gate only ever waits on the required contexts. Filtering or
+dropping a _required_ context's own trigger is the one cut this guide
+never recommends: a path-filtered required check simply never reports for
+a change outside its filter, which blocks the pull request forever rather
+than saving anything.
+
+**On a private repository, the account Actions spend limit is where this
+multiplier stops being merely a cost and becomes a hard block**: once the
+limit is hit, every workflow run -- including the required checks IDD's
+merge gate depends on -- stops dispatching, and the autonomous loop has no
+route past a metered-service outage on its own (see the degraded-mode
+roadmap this repository dogfoods, `idd-skill#2318`, for the fail-closed
+policy that applies once that happens). Sizing the spend limit with this
+multiplier in mind, before it is hit under real review-loop load, is
+cheaper than diagnosing the block afterward.
+
 These are repository-local optimizations; they do not change the IDD merge gate
 or the cross-agent workflow.

--- a/fixtures/actions-usage-report/basic.json
+++ b/fixtures/actions-usage-report/basic.json
@@ -1,0 +1,76 @@
+{
+  "input": {
+    "runs": [
+      { "id": 1, "workflowName": "Linting workflow", "event": "pull_request" },
+      { "id": 2, "workflowName": "Linting workflow", "event": "pull_request" },
+      {
+        "id": 3,
+        "workflowName": "IDD advisory-convergence gate",
+        "event": "pull_request"
+      },
+      {
+        "id": 4,
+        "workflowName": "IDD advisory-convergence gate",
+        "event": "pull_request_review"
+      },
+      {
+        "id": 5,
+        "workflowName": "IDD advisory-convergence gate",
+        "event": "pull_request_review"
+      }
+    ],
+    "jobs": [
+      {
+        "runId": 1,
+        "jobName": "lint",
+        "startedAt": "2026-01-01T00:00:00Z",
+        "completedAt": "2026-01-01T00:01:00Z"
+      },
+      {
+        "runId": 2,
+        "jobName": "lint",
+        "startedAt": "2026-01-01T00:00:00Z",
+        "completedAt": "2026-01-01T00:01:30Z"
+      },
+      {
+        "runId": 3,
+        "jobName": "idd-advisory-convergence",
+        "startedAt": "2026-01-01T00:00:00Z",
+        "completedAt": "2026-01-01T00:00:20Z"
+      },
+      {
+        "runId": 4,
+        "jobName": "idd-advisory-convergence",
+        "startedAt": "2026-01-01T00:00:00Z",
+        "completedAt": "2026-01-01T00:00:25Z"
+      },
+      {
+        "runId": 5,
+        "jobName": "idd-advisory-convergence",
+        "startedAt": "2026-01-01T00:00:00Z",
+        "completedAt": null
+      }
+    ]
+  },
+  "expected": {
+    "runCount": 5,
+    "jobCount": 4,
+    "totalDurationMs": 195000,
+    "workflows": [
+      {
+        "workflowName": "Linting workflow",
+        "runCount": 2,
+        "jobCount": 2,
+        "totalDurationMs": 150000,
+        "byEvent": { "pull_request": 2 }
+      },
+      {
+        "workflowName": "IDD advisory-convergence gate",
+        "runCount": 3,
+        "jobCount": 2,
+        "totalDurationMs": 45000,
+        "byEvent": { "pull_request": 1, "pull_request_review": 2 }
+      }
+    ]
+  }
+}

--- a/fixtures/actions-usage-report/basic.json
+++ b/fixtures/actions-usage-report/basic.json
@@ -56,12 +56,14 @@
     "runCount": 5,
     "jobCount": 4,
     "totalDurationMs": 195000,
+    "totalBilledMinutes": 5,
     "workflows": [
       {
         "workflowName": "Linting workflow",
         "runCount": 2,
         "jobCount": 2,
         "totalDurationMs": 150000,
+        "totalBilledMinutes": 3,
         "byEvent": { "pull_request": 2 }
       },
       {
@@ -69,6 +71,7 @@
         "runCount": 3,
         "jobCount": 2,
         "totalDurationMs": 45000,
+        "totalBilledMinutes": 2,
         "byEvent": { "pull_request": 1, "pull_request_review": 2 }
       }
     ]

--- a/fixtures/actions-usage-report/edge-cases.json
+++ b/fixtures/actions-usage-report/edge-cases.json
@@ -1,0 +1,61 @@
+{
+  "input": {
+    "runs": [
+      { "id": 10, "workflowName": "CodeQL", "event": "pull_request" },
+      { "id": 11, "workflowName": "Zero-job workflow", "event": "pull_request" }
+    ],
+    "jobs": [
+      {
+        "runId": 10,
+        "jobName": "Analyze (actions)",
+        "startedAt": "2026-01-01T00:00:00Z",
+        "completedAt": "2026-01-01T00:01:10Z"
+      },
+      {
+        "runId": 10,
+        "jobName": "Analyze (javascript-typescript)",
+        "startedAt": "2026-01-01T00:00:05Z",
+        "completedAt": "2026-01-01T00:01:50Z"
+      },
+      {
+        "runId": 99,
+        "jobName": "orphan job (no matching run)",
+        "startedAt": "2026-01-01T00:00:00Z",
+        "completedAt": "2026-01-01T00:01:00Z"
+      },
+      {
+        "runId": 10,
+        "jobName": "bad-clock job",
+        "startedAt": "2026-01-01T00:05:00Z",
+        "completedAt": "2026-01-01T00:00:00Z"
+      },
+      {
+        "runId": 10,
+        "jobName": "still running",
+        "startedAt": "2026-01-01T00:00:00Z",
+        "completedAt": null
+      }
+    ]
+  },
+  "expected": {
+    "runCount": 2,
+    "jobCount": 2,
+    "totalDurationMs": 175000,
+    "workflows": [
+      {
+        "workflowName": "CodeQL",
+        "runCount": 1,
+        "jobCount": 2,
+        "totalDurationMs": 175000,
+        "byEvent": { "pull_request": 1 }
+      },
+      {
+        "workflowName": "Zero-job workflow",
+        "runCount": 1,
+        "jobCount": 0,
+        "totalDurationMs": 0,
+        "byEvent": { "pull_request": 1 }
+      }
+    ]
+  }
+}

--- a/fixtures/actions-usage-report/edge-cases.json
+++ b/fixtures/actions-usage-report/edge-cases.json
@@ -41,12 +41,14 @@
     "runCount": 2,
     "jobCount": 2,
     "totalDurationMs": 175000,
+    "totalBilledMinutes": 4,
     "workflows": [
       {
         "workflowName": "CodeQL",
         "runCount": 1,
         "jobCount": 2,
         "totalDurationMs": 175000,
+        "totalBilledMinutes": 4,
         "byEvent": { "pull_request": 1 }
       },
       {
@@ -54,6 +56,7 @@
         "runCount": 1,
         "jobCount": 0,
         "totalDurationMs": 0,
+        "totalBilledMinutes": 0,
         "byEvent": { "pull_request": 1 }
       }
     ]

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1732,7 +1732,13 @@ distribute); build an equivalent against the same
 and
 [`GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs`](https://docs.github.com/en/rest/actions/workflow-jobs)
 endpoints, filtered by the pull request's head branch, to attribute cost the
-same way for your own workflows.
+same way for your own workflows. A branch-name filter alone can include an
+unrelated run -- a reused branch name, or a same-repository `push` /
+`workflow_dispatch` run against that branch outside this pull request --
+so also restrict to `pull_request`/`pull_request_review`/
+`pull_request_review_comment`-triggered runs and check each run's own
+`pull_requests[].number` against the target pull request (empty for a
+fork-originated pull request, where GitHub never populates that field).
 
 **Only your configured required status checks cost every pull request
 unconditionally.** A `pull_request`-triggered workflow that is _not_ one of

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1743,7 +1743,7 @@ since the gate only ever waits on the required contexts. Filtering or
 dropping a _required_ context's own trigger is the one cut this guide
 never recommends: a path-filtered required check simply never reports for
 a change outside its filter, which blocks the pull request forever rather
-than saving anything.
+than saving anything (preventive; no observed incident yet).
 
 **On a private repository, the account Actions spend limit is where this
 multiplier stops being merely a cost and becomes a hard block**: once the

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1718,5 +1718,42 @@ per-minute rates are billed per GitHub's own
 [Actions billing usage docs](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions);
 this guide does not hard-code a price since rates change.
 
+**The advisory review loop is a second, IDD-specific multiplier on top of
+re-sync cadence.** E14/F2/F3's advisory-wait protocol pushes repeatedly and
+collects a fresh bot review on each push, and every push plus every review
+event can each independently trigger the advisory-convergence required
+check -- so one pull request's total run count is a multiple of its push
+count, not a fixed cost. This repository measures its own instance of that
+multiplier with a maintainer-only reporting tool
+(`node scripts/actions-usage-report.mjs --pr <number>`, source-repo-internal
+-- an adopter's own workflow names differ, so there is nothing portable to
+distribute); build an equivalent against the same
+[`GET /repos/{owner}/{repo}/actions/runs`](https://docs.github.com/en/rest/actions/workflow-runs)
+and
+[`GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs`](https://docs.github.com/en/rest/actions/workflow-jobs)
+endpoints, filtered by the pull request's head branch, to attribute cost the
+same way for your own workflows.
+
+**Only your configured required status checks cost every pull request
+unconditionally.** A `pull_request`-triggered workflow that is _not_ one of
+your branch ruleset's required contexts -- a security scanner, a
+secondary compatibility-floor guard, anything advisory -- is safely
+droppable or path-filterable without weakening the IDD merge gate itself,
+since the gate only ever waits on the required contexts. Filtering or
+dropping a _required_ context's own trigger is the one cut this guide
+never recommends: a path-filtered required check simply never reports for
+a change outside its filter, which blocks the pull request forever rather
+than saving anything.
+
+**On a private repository, the account Actions spend limit is where this
+multiplier stops being merely a cost and becomes a hard block**: once the
+limit is hit, every workflow run -- including the required checks IDD's
+merge gate depends on -- stops dispatching, and the autonomous loop has no
+route past a metered-service outage on its own (see the degraded-mode
+roadmap this repository dogfoods, `idd-skill#2318`, for the fail-closed
+policy that applies once that happens). Sizing the spend limit with this
+multiplier in mind, before it is hit under real review-loop load, is
+cheaper than diagnosing the block afterward.
+
 These are repository-local optimizations; they do not change the IDD merge gate
 or the cross-agent workflow.

--- a/scripts/actions-usage-report.mjs
+++ b/scripts/actions-usage-report.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/actions-usage-report.mts
+//
+// The scripts/actions-usage-report.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Dogfood-only measurement tool (#2322): for a given pull request, reports
+// per-workflow run counts and per-job durations attributable to it, from
+// the Actions API. Maintainer/CI-only -- never distributed to
+// idd-template/ and never registered in HELPER_COMMANDS (see
+// SOURCE_REPO_INTERNAL_ENTRY_PATHS in
+// tests/helper-invocation-profile.test.mts), matching context-tax-report.mts's
+// precedent: an adopter repository has its own, entirely different set of
+// CI workflows, so a report scoped to this repository's own workflow names
+// has nothing to measure there.
+//
+// This is evidence-gathering only: it never mutates GitHub state, and its
+// output informs manual review of .github/workflows/*.yml, not an
+// automated gate.
+import { parseCliArgs } from './cli-args.mjs';
+import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
+import { parsePaginatedGhNdjson } from './protocol-helpers.mjs';
+/**
+ * Aggregate already-fetched runs and jobs into an {@link ActionsUsageReport}.
+ * Pure and offline: takes plain data, never calls `gh` itself -- the network
+ * fetch lives in {@link fetchActionsUsageForPr} below, so this function is
+ * the one covered by an offline fixture test (#2322's acceptance criterion).
+ *
+ * A job whose `runId` matches no entry in `runs`, or whose `completedAt` is
+ * `null`, is skipped: the former can only happen from mismatched fixture
+ * data (never from a real fetch, which always tags a job with the run that
+ * produced it), and the latter is a run still in flight, whose eventual
+ * duration is unknown, not zero.
+ */
+export function aggregateActionsUsage(runs, jobs) {
+  const runById = new Map(runs.map((run) => [run.id, run]));
+  const buckets = new Map();
+  for (const run of runs) {
+    const bucket = buckets.get(run.workflowName) ?? {
+      runIds: new Set(),
+      byEvent: new Map(),
+      jobCount: 0,
+      totalDurationMs: 0,
+    };
+    bucket.runIds.add(run.id);
+    const eventRunIds = bucket.byEvent.get(run.event) ?? new Set();
+    eventRunIds.add(run.id);
+    bucket.byEvent.set(run.event, eventRunIds);
+    buckets.set(run.workflowName, bucket);
+  }
+  for (const job of jobs) {
+    if (job.completedAt == null) {
+      continue;
+    }
+    const run = runById.get(job.runId);
+    if (!run) {
+      continue;
+    }
+    const durationMs = Date.parse(job.completedAt) - Date.parse(job.startedAt);
+    if (!Number.isFinite(durationMs) || durationMs < 0) {
+      continue;
+    }
+    // run.workflowName was just used to seed `buckets` in the loop above,
+    // from the same `runs` array, so this lookup always hits.
+    const bucket = buckets.get(run.workflowName);
+    if (!bucket) {
+      continue;
+    }
+    bucket.jobCount += 1;
+    bucket.totalDurationMs += durationMs;
+  }
+  const workflows = [...buckets.entries()]
+    .map(([workflowName, bucket]) => ({
+      workflowName,
+      runCount: bucket.runIds.size,
+      jobCount: bucket.jobCount,
+      totalDurationMs: bucket.totalDurationMs,
+      byEvent: Object.fromEntries(
+        [...bucket.byEvent.entries()].map(([event, ids]) => [event, ids.size]),
+      ),
+    }))
+    .sort(
+      (a, b) =>
+        b.totalDurationMs - a.totalDurationMs ||
+        a.workflowName.localeCompare(b.workflowName),
+    );
+  return {
+    runCount: runs.length,
+    jobCount: workflows.reduce((sum, row) => sum + row.jobCount, 0),
+    totalDurationMs: workflows.reduce(
+      (sum, row) => sum + row.totalDurationMs,
+      0,
+    ),
+    workflows,
+  };
+}
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+/** Formats a millisecond duration as `<minutes>m<seconds>s`, rounded to the
+ * nearest second -- matching how Actions itself bills (whole minutes), while
+ * keeping second-level precision for comparing workflows below one minute. */
+function formatDuration(ms) {
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m${String(seconds).padStart(2, '0')}s`;
+}
+export function renderTable(report) {
+  const lines = [
+    '| Workflow | Runs | Jobs | Duration |',
+    '| --- | --- | --- | --- |',
+    ...report.workflows.map(
+      (row) =>
+        `| ${row.workflowName} | ${row.runCount} | ${row.jobCount} | ${formatDuration(row.totalDurationMs)} |`,
+    ),
+    '',
+    `Total: ${report.runCount} runs, ${report.jobCount} jobs, ${formatDuration(report.totalDurationMs)}.`,
+  ];
+  return lines.join('\n');
+}
+// ---------------------------------------------------------------------------
+// GitHub fetch (I/O -- not exercised by the offline fixture test)
+// ---------------------------------------------------------------------------
+/**
+ * Run a `gh api ... --paginate --jq <program>` call and parse its output as
+ * NDJSON. Local copy of the same pattern `stalled-session-quiet-check.mts`
+ * and `rerun-advisory-convergence.mts` already use for a wrapped-object
+ * list endpoint (`{ total_count, workflow_runs: [...] }` /
+ * `{ total_count, jobs: [...] }`), which `ghApiJson`'s own `paginate`
+ * option cannot express -- it hardcodes `--jq '.[]'`, which assumes a bare
+ * top-level array.
+ */
+function ghPaginatedJson(args) {
+  return parsePaginatedGhNdjson(ghText(args, GH_TEXT_LOOP_TIMEOUT_OPTIONS));
+}
+/** Resolves `{owner, repo}` the same way other CLI helpers in this
+ * repository do: explicit flags first, else `gh repo view` auto-detection. */
+function resolveOwnerRepo(owner, repo) {
+  return {
+    owner:
+      owner ||
+      ghText(
+        ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      ),
+    repo:
+      repo ||
+      ghText(
+        ['repo', 'view', '--json', 'name', '--jq', '.name'],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      ),
+  };
+}
+/**
+ * Fetch and aggregate Actions usage for one pull request. Every workflow
+ * run tied to a pull request -- `pull_request`, `pull_request_review`, and
+ * `pull_request_review_comment` alike -- shares the PR's head branch name,
+ * so listing runs by `branch` (rather than the repository-wide recent-runs
+ * list) captures the full review-loop cost in one scoped query.
+ *
+ * One extra `gh api` call per run fetches that run's own jobs (per-job
+ * duration, not just the run's own wall-clock span, matters for a
+ * matrix-strategy workflow like CodeQL). This is O(runs) API calls -- fine
+ * for a manual, on-demand diagnostic tool investigating one merged PR, not
+ * something run in a hot path.
+ */
+export function fetchActionsUsageForPr(
+  prNumber,
+  ownerFlag = '',
+  repoFlag = '',
+) {
+  const { owner, repo } = resolveOwnerRepo(ownerFlag, repoFlag);
+  const branch = ghText(
+    [
+      'pr',
+      'view',
+      String(prNumber),
+      '--json',
+      'headRefName',
+      '--jq',
+      '.headRefName',
+    ],
+    GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  );
+  const rawRuns = ghPaginatedJson([
+    'api',
+    `repos/${owner}/${repo}/actions/runs?branch=${encodeURIComponent(branch)}&per_page=100`,
+    '--paginate',
+    '--jq',
+    '.workflow_runs[] | {id: .id, name: .name, event: .event}',
+  ]);
+  const runs = rawRuns.map((raw) => ({
+    id: raw.id,
+    workflowName: raw.name,
+    event: raw.event,
+  }));
+  const jobs = [];
+  for (const run of runs) {
+    const rawJobs = ghPaginatedJson([
+      'api',
+      `repos/${owner}/${repo}/actions/runs/${run.id}/jobs?per_page=100`,
+      '--paginate',
+      '--jq',
+      '.jobs[] | {name: .name, started_at: .started_at, completed_at: .completed_at}',
+    ]);
+    for (const rawJob of rawJobs) {
+      jobs.push({
+        runId: run.id,
+        jobName: rawJob.name,
+        startedAt: rawJob.started_at ?? '',
+        completedAt: rawJob.completed_at,
+      });
+    }
+  }
+  return aggregateActionsUsage(runs, jobs);
+}
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+// Flag-spec keys stay the dashed literal on purpose -- see cli-args.mts's
+// module header (tests/flag-name-matrix.test.mts scans each helper's own
+// compiled .mjs source text for its canonical flags as quoted literals).
+const ACTIONS_USAGE_REPORT_FLAG_SPEC = {
+  '--pr': { type: 'string' },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--format': { type: 'string', default: 'table' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/actions-usage-report.mjs --pr <number> [--owner <owner>] [--repo <repo>] [--format table|json]
+
+  --pr <number>       Pull request number to report on (required).
+  --owner <owner>     Repository owner (default: auto-detected via gh repo view).
+  --repo <repo>       Repository name (default: auto-detected via gh repo view).
+  --format <format>   Output format: table (default) or json.
+  --help, -h          Show this help.
+`);
+}
+if (import.meta.main) {
+  const { values, help } = parseCliArgs(
+    process.argv.slice(2),
+    ACTIONS_USAGE_REPORT_FLAG_SPEC,
+  );
+  if (help) {
+    printHelp();
+    process.exit(0);
+  }
+  const prRaw = values.pr;
+  const prNumber = Number(prRaw);
+  if (!prRaw || !Number.isInteger(prNumber) || prNumber <= 0) {
+    process.stderr.write(
+      `actions-usage-report: --pr must be a positive integer, got: ${prRaw ?? '(missing)'}\n`,
+    );
+    process.exit(2);
+  }
+  const format = values.format;
+  if (format !== 'table' && format !== 'json') {
+    process.stderr.write(
+      `actions-usage-report: --format must be table or json, got: ${format}\n`,
+    );
+    process.exit(2);
+  }
+  const report = fetchActionsUsageForPr(prNumber, values.owner, values.repo);
+  process.stdout.write(
+    format === 'json'
+      ? `${JSON.stringify(report, null, 2)}\n`
+      : `${renderTable(report)}\n`,
+  );
+}

--- a/scripts/actions-usage-report.mjs
+++ b/scripts/actions-usage-report.mjs
@@ -39,9 +39,28 @@ export function billedMinutesFor(durationMs) {
  * belongs when its `pull_requests` list is empty (fork case, or
  * genuinely untracked) or includes `prNumber`; a non-empty list that
  * omits `prNumber` means the run belongs to a different pull request.
+ *
+ * Empty `pull_requests` also covers a same-repository `push` /
+ * `workflow_dispatch` run against the same branch that is not part of
+ * any pull request -- GitHub never populates that field for those event
+ * types either, not only for forks. {@link isPrFamilyEvent} closes that
+ * gap: callers apply it first so a non-PR-triggered run is excluded on
+ * its event type before this empty-list allowance can apply to it.
  */
 export function runBelongsToPr(pullRequests, prNumber) {
   return pullRequests.length === 0 || pullRequests.includes(prNumber);
+}
+/** Triggering events that can only fire in the context of a pull request.
+ * A `push` or `workflow_dispatch` run sharing the PR's branch name is
+ * never one of these, regardless of its `pull_requests` association. */
+export const PR_FAMILY_EVENTS = new Set([
+  'pull_request',
+  'pull_request_review',
+  'pull_request_review_comment',
+]);
+/** Whether `event` is one of {@link PR_FAMILY_EVENTS}. */
+export function isPrFamilyEvent(event) {
+  return PR_FAMILY_EVENTS.has(event);
 }
 /**
  * Aggregate already-fetched runs and jobs into an {@link ActionsUsageReport}.
@@ -189,12 +208,17 @@ function resolveOwnerRepo(owner, repo) {
  * so listing runs by `branch` (rather than the repository-wide recent-runs
  * list) captures the full review-loop cost in one scoped query; each
  * fetched run is then narrowed to this PR specifically via
- * {@link runBelongsToPr}.
+ * {@link isPrFamilyEvent} and {@link runBelongsToPr}.
  *
  * One extra `gh api` call per run fetches that run's own jobs (per-job
  * duration, not just the run's own wall-clock span, matters for a
- * matrix-strategy workflow like CodeQL). This is O(runs) API calls -- fine
- * for a manual, on-demand diagnostic tool investigating one merged PR, not
+ * matrix-strategy workflow like CodeQL), with `filter=all` so a rerun
+ * run's earlier attempts are also counted -- the jobs endpoint's own
+ * default (`filter=latest`) would otherwise silently drop every
+ * attempt but the most recent one, undercounting exactly the repeated-
+ * push/rerun cost this tool exists to measure. This is O(runs) API
+ * calls -- fine for a manual, on-demand diagnostic tool investigating
+ * one merged PR, not
  * something run in a hot path.
  */
 export function fetchActionsUsageForPr(
@@ -225,7 +249,11 @@ export function fetchActionsUsageForPr(
     '.workflow_runs[] | {id: .id, name: .name, event: .event, pull_requests: [.pull_requests[].number]}',
   ]);
   const runs = rawRuns
-    .filter((raw) => runBelongsToPr(raw.pull_requests, prNumber))
+    .filter(
+      (raw) =>
+        isPrFamilyEvent(raw.event) &&
+        runBelongsToPr(raw.pull_requests, prNumber),
+    )
     .map((raw) => ({
       id: raw.id,
       workflowName: raw.name,
@@ -235,7 +263,7 @@ export function fetchActionsUsageForPr(
   for (const run of runs) {
     const rawJobs = ghPaginatedJson([
       'api',
-      `repos/${owner}/${repo}/actions/runs/${run.id}/jobs?per_page=100`,
+      `repos/${owner}/${repo}/actions/runs/${run.id}/jobs?filter=all&per_page=100`,
       '--paginate',
       '--jq',
       '.jobs[] | {name: .name, started_at: .started_at, completed_at: .completed_at}',

--- a/scripts/actions-usage-report.mjs
+++ b/scripts/actions-usage-report.mjs
@@ -21,6 +21,28 @@
 import { parseCliArgs } from './cli-args.mjs';
 import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
 import { parsePaginatedGhNdjson } from './protocol-helpers.mjs';
+/** Ceils a job's elapsed milliseconds to whole billed minutes, per GitHub's
+ * actual billing unit -- a job that ran for any positive duration still
+ * bills at least one minute (a batch of short jobs is not free just
+ * because none individually reached 60s). */
+export function billedMinutesFor(durationMs) {
+  return Math.max(1, Math.ceil(durationMs / 60_000));
+}
+/**
+ * A branch-name filter alone can also match a run that is not actually
+ * `prNumber`'s own (a reused branch name, or a `workflow_dispatch` /
+ * `push` run against the same branch outside this PR). `pullRequests` is a
+ * run's own `pull_requests[].number` list from the Actions API --
+ * populated by GitHub for same-repository runs, but always empty for a
+ * fork-originated PR's runs (GitHub does not associate those, so the
+ * branch filter is already the best available signal there). A run
+ * belongs when its `pull_requests` list is empty (fork case, or
+ * genuinely untracked) or includes `prNumber`; a non-empty list that
+ * omits `prNumber` means the run belongs to a different pull request.
+ */
+export function runBelongsToPr(pullRequests, prNumber) {
+  return pullRequests.length === 0 || pullRequests.includes(prNumber);
+}
 /**
  * Aggregate already-fetched runs and jobs into an {@link ActionsUsageReport}.
  * Pure and offline: takes plain data, never calls `gh` itself -- the network
@@ -42,6 +64,7 @@ export function aggregateActionsUsage(runs, jobs) {
       byEvent: new Map(),
       jobCount: 0,
       totalDurationMs: 0,
+      totalBilledMinutes: 0,
     };
     bucket.runIds.add(run.id);
     const eventRunIds = bucket.byEvent.get(run.event) ?? new Set();
@@ -69,6 +92,7 @@ export function aggregateActionsUsage(runs, jobs) {
     }
     bucket.jobCount += 1;
     bucket.totalDurationMs += durationMs;
+    bucket.totalBilledMinutes += billedMinutesFor(durationMs);
   }
   const workflows = [...buckets.entries()]
     .map(([workflowName, bucket]) => ({
@@ -76,13 +100,14 @@ export function aggregateActionsUsage(runs, jobs) {
       runCount: bucket.runIds.size,
       jobCount: bucket.jobCount,
       totalDurationMs: bucket.totalDurationMs,
+      totalBilledMinutes: bucket.totalBilledMinutes,
       byEvent: Object.fromEntries(
         [...bucket.byEvent.entries()].map(([event, ids]) => [event, ids.size]),
       ),
     }))
     .sort(
       (a, b) =>
-        b.totalDurationMs - a.totalDurationMs ||
+        b.totalBilledMinutes - a.totalBilledMinutes ||
         a.workflowName.localeCompare(b.workflowName),
     );
   return {
@@ -90,6 +115,10 @@ export function aggregateActionsUsage(runs, jobs) {
     jobCount: workflows.reduce((sum, row) => sum + row.jobCount, 0),
     totalDurationMs: workflows.reduce(
       (sum, row) => sum + row.totalDurationMs,
+      0,
+    ),
+    totalBilledMinutes: workflows.reduce(
+      (sum, row) => sum + row.totalBilledMinutes,
       0,
     ),
     workflows,
@@ -109,14 +138,14 @@ function formatDuration(ms) {
 }
 export function renderTable(report) {
   const lines = [
-    '| Workflow | Runs | Jobs | Duration |',
-    '| --- | --- | --- | --- |',
+    '| Workflow | Runs | Jobs | Duration | Billed |',
+    '| --- | --- | --- | --- | --- |',
     ...report.workflows.map(
       (row) =>
-        `| ${row.workflowName} | ${row.runCount} | ${row.jobCount} | ${formatDuration(row.totalDurationMs)} |`,
+        `| ${row.workflowName} | ${row.runCount} | ${row.jobCount} | ${formatDuration(row.totalDurationMs)} | ${row.totalBilledMinutes}m |`,
     ),
     '',
-    `Total: ${report.runCount} runs, ${report.jobCount} jobs, ${formatDuration(report.totalDurationMs)}.`,
+    `Total: ${report.runCount} runs, ${report.jobCount} jobs, ${formatDuration(report.totalDurationMs)} wall-clock, ${report.totalBilledMinutes} billed minute(s).`,
   ];
   return lines.join('\n');
 }
@@ -158,7 +187,9 @@ function resolveOwnerRepo(owner, repo) {
  * run tied to a pull request -- `pull_request`, `pull_request_review`, and
  * `pull_request_review_comment` alike -- shares the PR's head branch name,
  * so listing runs by `branch` (rather than the repository-wide recent-runs
- * list) captures the full review-loop cost in one scoped query.
+ * list) captures the full review-loop cost in one scoped query; each
+ * fetched run is then narrowed to this PR specifically via
+ * {@link runBelongsToPr}.
  *
  * One extra `gh api` call per run fetches that run's own jobs (per-job
  * duration, not just the run's own wall-clock span, matters for a
@@ -177,6 +208,8 @@ export function fetchActionsUsageForPr(
       'pr',
       'view',
       String(prNumber),
+      '-R',
+      `${owner}/${repo}`,
       '--json',
       'headRefName',
       '--jq',
@@ -189,13 +222,15 @@ export function fetchActionsUsageForPr(
     `repos/${owner}/${repo}/actions/runs?branch=${encodeURIComponent(branch)}&per_page=100`,
     '--paginate',
     '--jq',
-    '.workflow_runs[] | {id: .id, name: .name, event: .event}',
+    '.workflow_runs[] | {id: .id, name: .name, event: .event, pull_requests: [.pull_requests[].number]}',
   ]);
-  const runs = rawRuns.map((raw) => ({
-    id: raw.id,
-    workflowName: raw.name,
-    event: raw.event,
-  }));
+  const runs = rawRuns
+    .filter((raw) => runBelongsToPr(raw.pull_requests, prNumber))
+    .map((raw) => ({
+      id: raw.id,
+      workflowName: raw.name,
+      event: raw.event,
+    }));
   const jobs = [];
   for (const run of runs) {
     const rawJobs = ghPaginatedJson([

--- a/scripts/actions-usage-report.mjs
+++ b/scripts/actions-usage-report.mjs
@@ -46,6 +46,15 @@ export function billedMinutesFor(durationMs) {
  * types either, not only for forks. {@link isPrFamilyEvent} closes that
  * gap: callers apply it first so a non-PR-triggered run is excluded on
  * its event type before this empty-list allowance can apply to it.
+ *
+ * Known limitation, not closed by either check above: two different
+ * fork-originated PRs sharing an identical head branch name would both
+ * report an empty `pull_requests` list and both pass this function,
+ * merging their runs together. Disambiguating that case needs each
+ * run's `head_repository` compared against the target PR's own head
+ * repository -- out of scope for this maintainer-only, single-repository
+ * dogfood tool, whose only real callers are this repository's own
+ * same-repository `issue/<number>-*` branches, never forks.
  */
 export function runBelongsToPr(pullRequests, prNumber) {
   return pullRequests.length === 0 || pullRequests.includes(prNumber);

--- a/scripts/actions-usage-report.mjs
+++ b/scripts/actions-usage-report.mjs
@@ -166,14 +166,14 @@ function formatDuration(ms) {
 }
 export function renderTable(report) {
   const lines = [
-    '| Workflow | Runs | Jobs | Duration | Billed |',
+    '| Workflow | Runs | Jobs | Runner time | Billed |',
     '| --- | --- | --- | --- | --- |',
     ...report.workflows.map(
       (row) =>
         `| ${row.workflowName} | ${row.runCount} | ${row.jobCount} | ${formatDuration(row.totalDurationMs)} | ${row.totalBilledMinutes}m |`,
     ),
     '',
-    `Total: ${report.runCount} runs, ${report.jobCount} jobs, ${formatDuration(report.totalDurationMs)} wall-clock, ${report.totalBilledMinutes} billed minute(s).`,
+    `Total: ${report.runCount} runs, ${report.jobCount} jobs, ${formatDuration(report.totalDurationMs)} runner time, ${report.totalBilledMinutes} billed minute(s).`,
   ];
   return lines.join('\n');
 }

--- a/scripts/actions-usage-report.mjs
+++ b/scripts/actions-usage-report.mjs
@@ -61,11 +61,15 @@ export function runBelongsToPr(pullRequests, prNumber) {
 }
 /** Triggering events that can only fire in the context of a pull request.
  * A `push` or `workflow_dispatch` run sharing the PR's branch name is
- * never one of these, regardless of its `pull_requests` association. */
+ * never one of these, regardless of its `pull_requests` association.
+ * Includes `pull_request_target`: this repository's own
+ * strip-untrusted-labels.yml and post-merge-cleanup.yml trigger on it
+ * for real PRs, so omitting it silently undercounted their job time. */
 export const PR_FAMILY_EVENTS = new Set([
   'pull_request',
   'pull_request_review',
   'pull_request_review_comment',
+  'pull_request_target',
 ]);
 /** Whether `event` is one of {@link PR_FAMILY_EVENTS}. */
 export function isPrFamilyEvent(event) {

--- a/src/scripts/actions-usage-report.mts
+++ b/src/scripts/actions-usage-report.mts
@@ -1,0 +1,368 @@
+#!/usr/bin/env node
+
+// idd-generated-from: src/scripts/actions-usage-report.mts
+//
+// The scripts/actions-usage-report.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Dogfood-only measurement tool (#2322): for a given pull request, reports
+// per-workflow run counts and per-job durations attributable to it, from
+// the Actions API. Maintainer/CI-only -- never distributed to
+// idd-template/ and never registered in HELPER_COMMANDS (see
+// SOURCE_REPO_INTERNAL_ENTRY_PATHS in
+// tests/helper-invocation-profile.test.mts), matching context-tax-report.mts's
+// precedent: an adopter repository has its own, entirely different set of
+// CI workflows, so a report scoped to this repository's own workflow names
+// has nothing to measure there.
+//
+// This is evidence-gathering only: it never mutates GitHub state, and its
+// output informs manual review of .github/workflows/*.yml, not an
+// automated gate.
+
+import { parseCliArgs } from './cli-args.mts';
+import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mts';
+import { parsePaginatedGhNdjson } from './protocol-helpers.mts';
+
+// ---------------------------------------------------------------------------
+// Aggregation (pure -- offline fixture-testable, no network)
+// ---------------------------------------------------------------------------
+
+/** One workflow run, reduced to the fields aggregation needs. */
+export interface UsageRun {
+  id: number;
+  workflowName: string;
+  event: string;
+}
+
+/** One job's timing, tagged with the run it belongs to. `completedAt` is
+ * `null` for a job that has not finished yet (e.g. still `in_progress`);
+ * such jobs are excluded from the duration total rather than treated as
+ * zero-length. */
+export interface UsageJob {
+  runId: number;
+  jobName: string;
+  startedAt: string;
+  completedAt: string | null;
+}
+
+/** Per-workflow aggregate: run count (including runs with no completed
+ * job yet), completed-job count, summed job duration, and a run-count
+ * breakdown by triggering event (`pull_request`, `pull_request_review`,
+ * `pull_request_review_comment`, ...). */
+export interface WorkflowUsageRow {
+  workflowName: string;
+  runCount: number;
+  jobCount: number;
+  totalDurationMs: number;
+  byEvent: Record<string, number>;
+}
+
+/** Full report: totals plus one {@link WorkflowUsageRow} per distinct
+ * workflow name, sorted by `totalDurationMs` descending (the actual cost
+ * driver), tie-broken by workflow name ascending for a stable order. */
+export interface ActionsUsageReport {
+  runCount: number;
+  jobCount: number;
+  totalDurationMs: number;
+  workflows: WorkflowUsageRow[];
+}
+
+interface WorkflowBucket {
+  runIds: Set<number>;
+  byEvent: Map<string, Set<number>>;
+  jobCount: number;
+  totalDurationMs: number;
+}
+
+/**
+ * Aggregate already-fetched runs and jobs into an {@link ActionsUsageReport}.
+ * Pure and offline: takes plain data, never calls `gh` itself -- the network
+ * fetch lives in {@link fetchActionsUsageForPr} below, so this function is
+ * the one covered by an offline fixture test (#2322's acceptance criterion).
+ *
+ * A job whose `runId` matches no entry in `runs`, or whose `completedAt` is
+ * `null`, is skipped: the former can only happen from mismatched fixture
+ * data (never from a real fetch, which always tags a job with the run that
+ * produced it), and the latter is a run still in flight, whose eventual
+ * duration is unknown, not zero.
+ */
+export function aggregateActionsUsage(
+  runs: readonly UsageRun[],
+  jobs: readonly UsageJob[],
+): ActionsUsageReport {
+  const runById = new Map(runs.map((run) => [run.id, run]));
+  const buckets = new Map<string, WorkflowBucket>();
+  for (const run of runs) {
+    const bucket = buckets.get(run.workflowName) ?? {
+      runIds: new Set(),
+      byEvent: new Map(),
+      jobCount: 0,
+      totalDurationMs: 0,
+    };
+    bucket.runIds.add(run.id);
+    const eventRunIds = bucket.byEvent.get(run.event) ?? new Set();
+    eventRunIds.add(run.id);
+    bucket.byEvent.set(run.event, eventRunIds);
+    buckets.set(run.workflowName, bucket);
+  }
+  for (const job of jobs) {
+    if (job.completedAt == null) {
+      continue;
+    }
+    const run = runById.get(job.runId);
+    if (!run) {
+      continue;
+    }
+    const durationMs = Date.parse(job.completedAt) - Date.parse(job.startedAt);
+    if (!Number.isFinite(durationMs) || durationMs < 0) {
+      continue;
+    }
+    // run.workflowName was just used to seed `buckets` in the loop above,
+    // from the same `runs` array, so this lookup always hits.
+    const bucket = buckets.get(run.workflowName);
+    if (!bucket) {
+      continue;
+    }
+    bucket.jobCount += 1;
+    bucket.totalDurationMs += durationMs;
+  }
+  const workflows: WorkflowUsageRow[] = [...buckets.entries()]
+    .map(([workflowName, bucket]) => ({
+      workflowName,
+      runCount: bucket.runIds.size,
+      jobCount: bucket.jobCount,
+      totalDurationMs: bucket.totalDurationMs,
+      byEvent: Object.fromEntries(
+        [...bucket.byEvent.entries()].map(([event, ids]) => [event, ids.size]),
+      ),
+    }))
+    .sort(
+      (a, b) =>
+        b.totalDurationMs - a.totalDurationMs ||
+        a.workflowName.localeCompare(b.workflowName),
+    );
+  return {
+    runCount: runs.length,
+    jobCount: workflows.reduce((sum, row) => sum + row.jobCount, 0),
+    totalDurationMs: workflows.reduce(
+      (sum, row) => sum + row.totalDurationMs,
+      0,
+    ),
+    workflows,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+/** Formats a millisecond duration as `<minutes>m<seconds>s`, rounded to the
+ * nearest second -- matching how Actions itself bills (whole minutes), while
+ * keeping second-level precision for comparing workflows below one minute. */
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m${String(seconds).padStart(2, '0')}s`;
+}
+
+export function renderTable(report: ActionsUsageReport): string {
+  const lines = [
+    '| Workflow | Runs | Jobs | Duration |',
+    '| --- | --- | --- | --- |',
+    ...report.workflows.map(
+      (row) =>
+        `| ${row.workflowName} | ${row.runCount} | ${row.jobCount} | ${formatDuration(
+          row.totalDurationMs,
+        )} |`,
+    ),
+    '',
+    `Total: ${report.runCount} runs, ${report.jobCount} jobs, ${formatDuration(
+      report.totalDurationMs,
+    )}.`,
+  ];
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// GitHub fetch (I/O -- not exercised by the offline fixture test)
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a `gh api ... --paginate --jq <program>` call and parse its output as
+ * NDJSON. Local copy of the same pattern `stalled-session-quiet-check.mts`
+ * and `rerun-advisory-convergence.mts` already use for a wrapped-object
+ * list endpoint (`{ total_count, workflow_runs: [...] }` /
+ * `{ total_count, jobs: [...] }`), which `ghApiJson`'s own `paginate`
+ * option cannot express -- it hardcodes `--jq '.[]'`, which assumes a bare
+ * top-level array.
+ */
+function ghPaginatedJson(args: string[]): unknown[] {
+  return parsePaginatedGhNdjson(ghText(args, GH_TEXT_LOOP_TIMEOUT_OPTIONS));
+}
+
+interface RawRun {
+  id: number;
+  name: string;
+  event: string;
+}
+
+interface RawJob {
+  name: string;
+  started_at: string | null;
+  completed_at: string | null;
+}
+
+/** Resolves `{owner, repo}` the same way other CLI helpers in this
+ * repository do: explicit flags first, else `gh repo view` auto-detection. */
+function resolveOwnerRepo(
+  owner: string,
+  repo: string,
+): { owner: string; repo: string } {
+  return {
+    owner:
+      owner ||
+      ghText(
+        ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      ),
+    repo:
+      repo ||
+      ghText(
+        ['repo', 'view', '--json', 'name', '--jq', '.name'],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      ),
+  };
+}
+
+/**
+ * Fetch and aggregate Actions usage for one pull request. Every workflow
+ * run tied to a pull request -- `pull_request`, `pull_request_review`, and
+ * `pull_request_review_comment` alike -- shares the PR's head branch name,
+ * so listing runs by `branch` (rather than the repository-wide recent-runs
+ * list) captures the full review-loop cost in one scoped query.
+ *
+ * One extra `gh api` call per run fetches that run's own jobs (per-job
+ * duration, not just the run's own wall-clock span, matters for a
+ * matrix-strategy workflow like CodeQL). This is O(runs) API calls -- fine
+ * for a manual, on-demand diagnostic tool investigating one merged PR, not
+ * something run in a hot path.
+ */
+export function fetchActionsUsageForPr(
+  prNumber: number,
+  ownerFlag = '',
+  repoFlag = '',
+): ActionsUsageReport {
+  const { owner, repo } = resolveOwnerRepo(ownerFlag, repoFlag);
+  const branch = ghText(
+    [
+      'pr',
+      'view',
+      String(prNumber),
+      '--json',
+      'headRefName',
+      '--jq',
+      '.headRefName',
+    ],
+    GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  );
+  const rawRuns = ghPaginatedJson([
+    'api',
+    `repos/${owner}/${repo}/actions/runs?branch=${encodeURIComponent(
+      branch,
+    )}&per_page=100`,
+    '--paginate',
+    '--jq',
+    '.workflow_runs[] | {id: .id, name: .name, event: .event}',
+  ]) as RawRun[];
+  const runs: UsageRun[] = rawRuns.map((raw) => ({
+    id: raw.id,
+    workflowName: raw.name,
+    event: raw.event,
+  }));
+  const jobs: UsageJob[] = [];
+  for (const run of runs) {
+    const rawJobs = ghPaginatedJson([
+      'api',
+      `repos/${owner}/${repo}/actions/runs/${run.id}/jobs?per_page=100`,
+      '--paginate',
+      '--jq',
+      '.jobs[] | {name: .name, started_at: .started_at, completed_at: .completed_at}',
+    ]) as RawJob[];
+    for (const rawJob of rawJobs) {
+      jobs.push({
+        runId: run.id,
+        jobName: rawJob.name,
+        startedAt: rawJob.started_at ?? '',
+        completedAt: rawJob.completed_at,
+      });
+    }
+  }
+  return aggregateActionsUsage(runs, jobs);
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+// Flag-spec keys stay the dashed literal on purpose -- see cli-args.mts's
+// module header (tests/flag-name-matrix.test.mts scans each helper's own
+// compiled .mjs source text for its canonical flags as quoted literals).
+const ACTIONS_USAGE_REPORT_FLAG_SPEC = {
+  '--pr': { type: 'string' },
+  '--owner': { type: 'string', default: '' },
+  '--repo': { type: 'string', default: '' },
+  '--format': { type: 'string', default: 'table' },
+  '--help': { type: 'boolean', short: 'h' },
+} as const;
+
+function printHelp(): void {
+  process.stdout.write(`Usage:
+  node scripts/actions-usage-report.mjs --pr <number> [--owner <owner>] [--repo <repo>] [--format table|json]
+
+  --pr <number>       Pull request number to report on (required).
+  --owner <owner>     Repository owner (default: auto-detected via gh repo view).
+  --repo <repo>       Repository name (default: auto-detected via gh repo view).
+  --format <format>   Output format: table (default) or json.
+  --help, -h          Show this help.
+`);
+}
+
+if (import.meta.main) {
+  const { values, help } = parseCliArgs(
+    process.argv.slice(2),
+    ACTIONS_USAGE_REPORT_FLAG_SPEC,
+  );
+  if (help) {
+    printHelp();
+    process.exit(0);
+  }
+  const prRaw = values.pr as string | undefined;
+  const prNumber = Number(prRaw);
+  if (!prRaw || !Number.isInteger(prNumber) || prNumber <= 0) {
+    process.stderr.write(
+      `actions-usage-report: --pr must be a positive integer, got: ${
+        prRaw ?? '(missing)'
+      }\n`,
+    );
+    process.exit(2);
+  }
+  const format = values.format as string;
+  if (format !== 'table' && format !== 'json') {
+    process.stderr.write(
+      `actions-usage-report: --format must be table or json, got: ${format}\n`,
+    );
+    process.exit(2);
+  }
+  const report = fetchActionsUsageForPr(
+    prNumber,
+    values.owner as string,
+    values.repo as string,
+  );
+  process.stdout.write(
+    format === 'json'
+      ? `${JSON.stringify(report, null, 2)}\n`
+      : `${renderTable(report)}\n`,
+  );
+}

--- a/src/scripts/actions-usage-report.mts
+++ b/src/scripts/actions-usage-report.mts
@@ -107,6 +107,15 @@ export function billedMinutesFor(durationMs: number): number {
  * types either, not only for forks. {@link isPrFamilyEvent} closes that
  * gap: callers apply it first so a non-PR-triggered run is excluded on
  * its event type before this empty-list allowance can apply to it.
+ *
+ * Known limitation, not closed by either check above: two different
+ * fork-originated PRs sharing an identical head branch name would both
+ * report an empty `pull_requests` list and both pass this function,
+ * merging their runs together. Disambiguating that case needs each
+ * run's `head_repository` compared against the target PR's own head
+ * repository -- out of scope for this maintainer-only, single-repository
+ * dogfood tool, whose only real callers are this repository's own
+ * same-repository `issue/<number>-*` branches, never forks.
  */
 export function runBelongsToPr(
   pullRequests: readonly number[],

--- a/src/scripts/actions-usage-report.mts
+++ b/src/scripts/actions-usage-report.mts
@@ -47,24 +47,29 @@ export interface UsageJob {
 }
 
 /** Per-workflow aggregate: run count (including runs with no completed
- * job yet), completed-job count, summed job duration, and a run-count
- * breakdown by triggering event (`pull_request`, `pull_request_review`,
- * `pull_request_review_comment`, ...). */
+ * job yet), completed-job count, summed job duration (raw wall-clock),
+ * summed billed minutes (each job rounded up to the whole minute before
+ * summing -- GitHub's actual billing unit, distinct from the wall-clock
+ * total), and a run-count breakdown by triggering event (`pull_request`,
+ * `pull_request_review`, `pull_request_review_comment`, ...). */
 export interface WorkflowUsageRow {
   workflowName: string;
   runCount: number;
   jobCount: number;
   totalDurationMs: number;
+  totalBilledMinutes: number;
   byEvent: Record<string, number>;
 }
 
 /** Full report: totals plus one {@link WorkflowUsageRow} per distinct
- * workflow name, sorted by `totalDurationMs` descending (the actual cost
- * driver), tie-broken by workflow name ascending for a stable order. */
+ * workflow name, sorted by `totalBilledMinutes` descending (the actual
+ * billed-cost driver -- see {@link WorkflowUsageRow}), tie-broken by
+ * workflow name ascending for a stable order. */
 export interface ActionsUsageReport {
   runCount: number;
   jobCount: number;
   totalDurationMs: number;
+  totalBilledMinutes: number;
   workflows: WorkflowUsageRow[];
 }
 
@@ -73,6 +78,34 @@ interface WorkflowBucket {
   byEvent: Map<string, Set<number>>;
   jobCount: number;
   totalDurationMs: number;
+  totalBilledMinutes: number;
+}
+
+/** Ceils a job's elapsed milliseconds to whole billed minutes, per GitHub's
+ * actual billing unit -- a job that ran for any positive duration still
+ * bills at least one minute (a batch of short jobs is not free just
+ * because none individually reached 60s). */
+export function billedMinutesFor(durationMs: number): number {
+  return Math.max(1, Math.ceil(durationMs / 60_000));
+}
+
+/**
+ * A branch-name filter alone can also match a run that is not actually
+ * `prNumber`'s own (a reused branch name, or a `workflow_dispatch` /
+ * `push` run against the same branch outside this PR). `pullRequests` is a
+ * run's own `pull_requests[].number` list from the Actions API --
+ * populated by GitHub for same-repository runs, but always empty for a
+ * fork-originated PR's runs (GitHub does not associate those, so the
+ * branch filter is already the best available signal there). A run
+ * belongs when its `pull_requests` list is empty (fork case, or
+ * genuinely untracked) or includes `prNumber`; a non-empty list that
+ * omits `prNumber` means the run belongs to a different pull request.
+ */
+export function runBelongsToPr(
+  pullRequests: readonly number[],
+  prNumber: number,
+): boolean {
+  return pullRequests.length === 0 || pullRequests.includes(prNumber);
 }
 
 /**
@@ -99,6 +132,7 @@ export function aggregateActionsUsage(
       byEvent: new Map(),
       jobCount: 0,
       totalDurationMs: 0,
+      totalBilledMinutes: 0,
     };
     bucket.runIds.add(run.id);
     const eventRunIds = bucket.byEvent.get(run.event) ?? new Set();
@@ -126,6 +160,7 @@ export function aggregateActionsUsage(
     }
     bucket.jobCount += 1;
     bucket.totalDurationMs += durationMs;
+    bucket.totalBilledMinutes += billedMinutesFor(durationMs);
   }
   const workflows: WorkflowUsageRow[] = [...buckets.entries()]
     .map(([workflowName, bucket]) => ({
@@ -133,13 +168,14 @@ export function aggregateActionsUsage(
       runCount: bucket.runIds.size,
       jobCount: bucket.jobCount,
       totalDurationMs: bucket.totalDurationMs,
+      totalBilledMinutes: bucket.totalBilledMinutes,
       byEvent: Object.fromEntries(
         [...bucket.byEvent.entries()].map(([event, ids]) => [event, ids.size]),
       ),
     }))
     .sort(
       (a, b) =>
-        b.totalDurationMs - a.totalDurationMs ||
+        b.totalBilledMinutes - a.totalBilledMinutes ||
         a.workflowName.localeCompare(b.workflowName),
     );
   return {
@@ -147,6 +183,10 @@ export function aggregateActionsUsage(
     jobCount: workflows.reduce((sum, row) => sum + row.jobCount, 0),
     totalDurationMs: workflows.reduce(
       (sum, row) => sum + row.totalDurationMs,
+      0,
+    ),
+    totalBilledMinutes: workflows.reduce(
+      (sum, row) => sum + row.totalBilledMinutes,
       0,
     ),
     workflows,
@@ -169,18 +209,18 @@ function formatDuration(ms: number): string {
 
 export function renderTable(report: ActionsUsageReport): string {
   const lines = [
-    '| Workflow | Runs | Jobs | Duration |',
-    '| --- | --- | --- | --- |',
+    '| Workflow | Runs | Jobs | Duration | Billed |',
+    '| --- | --- | --- | --- | --- |',
     ...report.workflows.map(
       (row) =>
         `| ${row.workflowName} | ${row.runCount} | ${row.jobCount} | ${formatDuration(
           row.totalDurationMs,
-        )} |`,
+        )} | ${row.totalBilledMinutes}m |`,
     ),
     '',
     `Total: ${report.runCount} runs, ${report.jobCount} jobs, ${formatDuration(
       report.totalDurationMs,
-    )}.`,
+    )} wall-clock, ${report.totalBilledMinutes} billed minute(s).`,
   ];
   return lines.join('\n');
 }
@@ -206,6 +246,7 @@ interface RawRun {
   id: number;
   name: string;
   event: string;
+  pull_requests: number[];
 }
 
 interface RawJob {
@@ -241,7 +282,9 @@ function resolveOwnerRepo(
  * run tied to a pull request -- `pull_request`, `pull_request_review`, and
  * `pull_request_review_comment` alike -- shares the PR's head branch name,
  * so listing runs by `branch` (rather than the repository-wide recent-runs
- * list) captures the full review-loop cost in one scoped query.
+ * list) captures the full review-loop cost in one scoped query; each
+ * fetched run is then narrowed to this PR specifically via
+ * {@link runBelongsToPr}.
  *
  * One extra `gh api` call per run fetches that run's own jobs (per-job
  * duration, not just the run's own wall-clock span, matters for a
@@ -260,6 +303,8 @@ export function fetchActionsUsageForPr(
       'pr',
       'view',
       String(prNumber),
+      '-R',
+      `${owner}/${repo}`,
       '--json',
       'headRefName',
       '--jq',
@@ -274,13 +319,15 @@ export function fetchActionsUsageForPr(
     )}&per_page=100`,
     '--paginate',
     '--jq',
-    '.workflow_runs[] | {id: .id, name: .name, event: .event}',
+    '.workflow_runs[] | {id: .id, name: .name, event: .event, pull_requests: [.pull_requests[].number]}',
   ]) as RawRun[];
-  const runs: UsageRun[] = rawRuns.map((raw) => ({
-    id: raw.id,
-    workflowName: raw.name,
-    event: raw.event,
-  }));
+  const runs: UsageRun[] = rawRuns
+    .filter((raw) => runBelongsToPr(raw.pull_requests, prNumber))
+    .map((raw) => ({
+      id: raw.id,
+      workflowName: raw.name,
+      event: raw.event,
+    }));
   const jobs: UsageJob[] = [];
   for (const run of runs) {
     const rawJobs = ghPaginatedJson([

--- a/src/scripts/actions-usage-report.mts
+++ b/src/scripts/actions-usage-report.mts
@@ -100,12 +100,33 @@ export function billedMinutesFor(durationMs: number): number {
  * belongs when its `pull_requests` list is empty (fork case, or
  * genuinely untracked) or includes `prNumber`; a non-empty list that
  * omits `prNumber` means the run belongs to a different pull request.
+ *
+ * Empty `pull_requests` also covers a same-repository `push` /
+ * `workflow_dispatch` run against the same branch that is not part of
+ * any pull request -- GitHub never populates that field for those event
+ * types either, not only for forks. {@link isPrFamilyEvent} closes that
+ * gap: callers apply it first so a non-PR-triggered run is excluded on
+ * its event type before this empty-list allowance can apply to it.
  */
 export function runBelongsToPr(
   pullRequests: readonly number[],
   prNumber: number,
 ): boolean {
   return pullRequests.length === 0 || pullRequests.includes(prNumber);
+}
+
+/** Triggering events that can only fire in the context of a pull request.
+ * A `push` or `workflow_dispatch` run sharing the PR's branch name is
+ * never one of these, regardless of its `pull_requests` association. */
+export const PR_FAMILY_EVENTS: ReadonlySet<string> = new Set([
+  'pull_request',
+  'pull_request_review',
+  'pull_request_review_comment',
+]);
+
+/** Whether `event` is one of {@link PR_FAMILY_EVENTS}. */
+export function isPrFamilyEvent(event: string): boolean {
+  return PR_FAMILY_EVENTS.has(event);
 }
 
 /**
@@ -284,12 +305,17 @@ function resolveOwnerRepo(
  * so listing runs by `branch` (rather than the repository-wide recent-runs
  * list) captures the full review-loop cost in one scoped query; each
  * fetched run is then narrowed to this PR specifically via
- * {@link runBelongsToPr}.
+ * {@link isPrFamilyEvent} and {@link runBelongsToPr}.
  *
  * One extra `gh api` call per run fetches that run's own jobs (per-job
  * duration, not just the run's own wall-clock span, matters for a
- * matrix-strategy workflow like CodeQL). This is O(runs) API calls -- fine
- * for a manual, on-demand diagnostic tool investigating one merged PR, not
+ * matrix-strategy workflow like CodeQL), with `filter=all` so a rerun
+ * run's earlier attempts are also counted -- the jobs endpoint's own
+ * default (`filter=latest`) would otherwise silently drop every
+ * attempt but the most recent one, undercounting exactly the repeated-
+ * push/rerun cost this tool exists to measure. This is O(runs) API
+ * calls -- fine for a manual, on-demand diagnostic tool investigating
+ * one merged PR, not
  * something run in a hot path.
  */
 export function fetchActionsUsageForPr(
@@ -322,7 +348,11 @@ export function fetchActionsUsageForPr(
     '.workflow_runs[] | {id: .id, name: .name, event: .event, pull_requests: [.pull_requests[].number]}',
   ]) as RawRun[];
   const runs: UsageRun[] = rawRuns
-    .filter((raw) => runBelongsToPr(raw.pull_requests, prNumber))
+    .filter(
+      (raw) =>
+        isPrFamilyEvent(raw.event) &&
+        runBelongsToPr(raw.pull_requests, prNumber),
+    )
     .map((raw) => ({
       id: raw.id,
       workflowName: raw.name,
@@ -332,7 +362,7 @@ export function fetchActionsUsageForPr(
   for (const run of runs) {
     const rawJobs = ghPaginatedJson([
       'api',
-      `repos/${owner}/${repo}/actions/runs/${run.id}/jobs?per_page=100`,
+      `repos/${owner}/${repo}/actions/runs/${run.id}/jobs?filter=all&per_page=100`,
       '--paginate',
       '--jq',
       '.jobs[] | {name: .name, started_at: .started_at, completed_at: .completed_at}',

--- a/src/scripts/actions-usage-report.mts
+++ b/src/scripts/actions-usage-report.mts
@@ -54,7 +54,7 @@ export interface UsageJob {
  * job rounded up to the whole minute before summing -- GitHub's actual
  * billing unit), and a run-count breakdown by triggering event
  * (`pull_request`, `pull_request_review`, `pull_request_review_comment`,
- * ...). */
+ * `pull_request_target`, ...). */
 export interface WorkflowUsageRow {
   workflowName: string;
   runCount: number;
@@ -129,11 +129,15 @@ export function runBelongsToPr(
 
 /** Triggering events that can only fire in the context of a pull request.
  * A `push` or `workflow_dispatch` run sharing the PR's branch name is
- * never one of these, regardless of its `pull_requests` association. */
+ * never one of these, regardless of its `pull_requests` association.
+ * Includes `pull_request_target`: this repository's own
+ * strip-untrusted-labels.yml and post-merge-cleanup.yml trigger on it
+ * for real PRs, so omitting it silently undercounted their job time. */
 export const PR_FAMILY_EVENTS: ReadonlySet<string> = new Set([
   'pull_request',
   'pull_request_review',
   'pull_request_review_comment',
+  'pull_request_target',
 ]);
 
 /** Whether `event` is one of {@link PR_FAMILY_EVENTS}. */

--- a/src/scripts/actions-usage-report.mts
+++ b/src/scripts/actions-usage-report.mts
@@ -47,11 +47,14 @@ export interface UsageJob {
 }
 
 /** Per-workflow aggregate: run count (including runs with no completed
- * job yet), completed-job count, summed job duration (raw wall-clock),
- * summed billed minutes (each job rounded up to the whole minute before
- * summing -- GitHub's actual billing unit, distinct from the wall-clock
- * total), and a run-count breakdown by triggering event (`pull_request`,
- * `pull_request_review`, `pull_request_review_comment`, ...). */
+ * job yet), completed-job count, summed job duration (aggregate runner
+ * time -- each job's own elapsed span summed together, **not** wall-clock:
+ * parallel or overlapping jobs, such as a matrix strategy, each count in
+ * full even though they ran concurrently), summed billed minutes (each
+ * job rounded up to the whole minute before summing -- GitHub's actual
+ * billing unit), and a run-count breakdown by triggering event
+ * (`pull_request`, `pull_request_review`, `pull_request_review_comment`,
+ * ...). */
 export interface WorkflowUsageRow {
   workflowName: string;
   runCount: number;
@@ -239,7 +242,7 @@ function formatDuration(ms: number): string {
 
 export function renderTable(report: ActionsUsageReport): string {
   const lines = [
-    '| Workflow | Runs | Jobs | Duration | Billed |',
+    '| Workflow | Runs | Jobs | Runner time | Billed |',
     '| --- | --- | --- | --- | --- |',
     ...report.workflows.map(
       (row) =>
@@ -250,7 +253,7 @@ export function renderTable(report: ActionsUsageReport): string {
     '',
     `Total: ${report.runCount} runs, ${report.jobCount} jobs, ${formatDuration(
       report.totalDurationMs,
-    )} wall-clock, ${report.totalBilledMinutes} billed minute(s).`,
+    )} runner time, ${report.totalBilledMinutes} billed minute(s).`,
   ];
   return lines.join('\n');
 }

--- a/tests/actions-usage-report.test.mts
+++ b/tests/actions-usage-report.test.mts
@@ -3,7 +3,9 @@ import { test } from 'node:test';
 
 import {
   aggregateActionsUsage,
+  billedMinutesFor,
   renderTable,
+  runBelongsToPr,
   type UsageJob,
   type UsageRun,
 } from '../src/scripts/actions-usage-report.mts';
@@ -59,14 +61,42 @@ test('aggregateActionsUsage: empty input reports zero totals and no workflow row
     runCount: 0,
     jobCount: 0,
     totalDurationMs: 0,
+    totalBilledMinutes: 0,
     workflows: [],
   });
+});
+
+test('runBelongsToPr: an empty pull_requests list is kept (fork PR, no association available)', () => {
+  assert.equal(runBelongsToPr([], 2344), true);
+});
+
+test('runBelongsToPr: a non-empty list including prNumber is kept', () => {
+  assert.equal(runBelongsToPr([1200, 2344], 2344), true);
+});
+
+test('runBelongsToPr: a non-empty list omitting prNumber is dropped (a different PR reused this branch)', () => {
+  assert.equal(runBelongsToPr([1200], 2344), false);
+});
+
+test('billedMinutesFor: rounds up to the whole minute, with a one-minute floor', () => {
+  // GitHub bills a job that ran for any positive duration at least one
+  // minute -- ten five-second jobs cost ten billed minutes, not zero.
+  assert.equal(billedMinutesFor(5_000), 1);
+  assert.equal(billedMinutesFor(60_000), 1);
+  assert.equal(billedMinutesFor(60_001), 2);
+  assert.equal(billedMinutesFor(90_000), 2);
 });
 
 test('renderTable: renders one row per workflow plus a totals line', () => {
   const { input } = loadFixture('basic');
   const table = renderTable(aggregateActionsUsage(input.runs, input.jobs));
-  assert.match(table, /\| Linting workflow \| 2 \| 2 \| 2m30s \|/);
-  assert.match(table, /\| IDD advisory-convergence gate \| 3 \| 2 \| 0m45s \|/);
-  assert.match(table, /Total: 5 runs, 4 jobs, 3m15s\./);
+  assert.match(table, /\| Linting workflow \| 2 \| 2 \| 2m30s \| 3m \|/);
+  assert.match(
+    table,
+    /\| IDD advisory-convergence gate \| 3 \| 2 \| 0m45s \| 2m \|/,
+  );
+  assert.match(
+    table,
+    /Total: 5 runs, 4 jobs, 3m15s wall-clock, 5 billed minute\(s\)\./,
+  );
 });

--- a/tests/actions-usage-report.test.mts
+++ b/tests/actions-usage-report.test.mts
@@ -83,6 +83,10 @@ test('isPrFamilyEvent: accepts only pull_request-family triggers', () => {
   assert.equal(isPrFamilyEvent('pull_request'), true);
   assert.equal(isPrFamilyEvent('pull_request_review'), true);
   assert.equal(isPrFamilyEvent('pull_request_review_comment'), true);
+  // strip-untrusted-labels.yml and post-merge-cleanup.yml trigger on this
+  // event for real PRs in this repository -- excluding it would silently
+  // undercount their job time.
+  assert.equal(isPrFamilyEvent('pull_request_target'), true);
 });
 
 test('isPrFamilyEvent: rejects a push/workflow_dispatch run sharing the branch name', () => {

--- a/tests/actions-usage-report.test.mts
+++ b/tests/actions-usage-report.test.mts
@@ -4,6 +4,7 @@ import { test } from 'node:test';
 import {
   aggregateActionsUsage,
   billedMinutesFor,
+  isPrFamilyEvent,
   renderTable,
   runBelongsToPr,
   type UsageJob,
@@ -76,6 +77,21 @@ test('runBelongsToPr: a non-empty list including prNumber is kept', () => {
 
 test('runBelongsToPr: a non-empty list omitting prNumber is dropped (a different PR reused this branch)', () => {
   assert.equal(runBelongsToPr([1200], 2344), false);
+});
+
+test('isPrFamilyEvent: accepts only pull_request-family triggers', () => {
+  assert.equal(isPrFamilyEvent('pull_request'), true);
+  assert.equal(isPrFamilyEvent('pull_request_review'), true);
+  assert.equal(isPrFamilyEvent('pull_request_review_comment'), true);
+});
+
+test('isPrFamilyEvent: rejects a push/workflow_dispatch run sharing the branch name', () => {
+  // GitHub never populates pull_requests for these event types either, so
+  // the event check must run independently of runBelongsToPr's empty-list
+  // allowance -- not merely defer to it.
+  assert.equal(isPrFamilyEvent('push'), false);
+  assert.equal(isPrFamilyEvent('workflow_dispatch'), false);
+  assert.equal(isPrFamilyEvent('schedule'), false);
 });
 
 test('billedMinutesFor: rounds up to the whole minute, with a one-minute floor', () => {

--- a/tests/actions-usage-report.test.mts
+++ b/tests/actions-usage-report.test.mts
@@ -113,6 +113,6 @@ test('renderTable: renders one row per workflow plus a totals line', () => {
   );
   assert.match(
     table,
-    /Total: 5 runs, 4 jobs, 3m15s wall-clock, 5 billed minute\(s\)\./,
+    /Total: 5 runs, 4 jobs, 3m15s runner time, 5 billed minute\(s\)\./,
   );
 });

--- a/tests/actions-usage-report.test.mts
+++ b/tests/actions-usage-report.test.mts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  aggregateActionsUsage,
+  renderTable,
+  type UsageJob,
+  type UsageRun,
+} from '../src/scripts/actions-usage-report.mts';
+import { readJson } from './test-utils.mts';
+
+interface Fixture {
+  input: { runs: UsageRun[]; jobs: UsageJob[] };
+  expected: ReturnType<typeof aggregateActionsUsage>;
+}
+
+function loadFixture(name: string): Fixture {
+  return readJson(`fixtures/actions-usage-report/${name}.json`) as Fixture;
+}
+
+test('aggregateActionsUsage: sums job durations per workflow, sorted by cost descending', () => {
+  const { input, expected } = loadFixture('basic');
+  assert.deepEqual(aggregateActionsUsage(input.runs, input.jobs), expected);
+});
+
+test('aggregateActionsUsage: skips an in-progress job (no completedAt) from the duration total', () => {
+  const { input } = loadFixture('basic');
+  const report = aggregateActionsUsage(input.runs, input.jobs);
+  const advisoryRow = report.workflows.find(
+    (row) => row.workflowName === 'IDD advisory-convergence gate',
+  );
+  assert.ok(advisoryRow);
+  // 3 runs recorded, but only 2 jobs contribute a duration (the third is
+  // still in flight).
+  assert.equal(advisoryRow.runCount, 3);
+  assert.equal(advisoryRow.jobCount, 2);
+});
+
+test("aggregateActionsUsage: skips an orphan job, a negative-duration job, and counts a matrix workflow's jobs together", () => {
+  const { input, expected } = loadFixture('edge-cases');
+  assert.deepEqual(aggregateActionsUsage(input.runs, input.jobs), expected);
+});
+
+test('aggregateActionsUsage: a run with zero completed jobs still contributes to runCount, not jobCount', () => {
+  const { input } = loadFixture('edge-cases');
+  const report = aggregateActionsUsage(input.runs, input.jobs);
+  const zeroJobRow = report.workflows.find(
+    (row) => row.workflowName === 'Zero-job workflow',
+  );
+  assert.ok(zeroJobRow);
+  assert.equal(zeroJobRow.runCount, 1);
+  assert.equal(zeroJobRow.jobCount, 0);
+  assert.equal(zeroJobRow.totalDurationMs, 0);
+});
+
+test('aggregateActionsUsage: empty input reports zero totals and no workflow rows', () => {
+  const report = aggregateActionsUsage([], []);
+  assert.deepEqual(report, {
+    runCount: 0,
+    jobCount: 0,
+    totalDurationMs: 0,
+    workflows: [],
+  });
+});
+
+test('renderTable: renders one row per workflow plus a totals line', () => {
+  const { input } = loadFixture('basic');
+  const table = renderTable(aggregateActionsUsage(input.runs, input.jobs));
+  assert.match(table, /\| Linting workflow \| 2 \| 2 \| 2m30s \|/);
+  assert.match(table, /\| IDD advisory-convergence gate \| 3 \| 2 \| 0m45s \|/);
+  assert.match(table, /Total: 5 runs, 4 jobs, 3m15s\./);
+});

--- a/tests/actions-usage-workflow-guard.test.mts
+++ b/tests/actions-usage-workflow-guard.test.mts
@@ -1,0 +1,106 @@
+// Guards two of #2322's acceptance criteria against future workflow edits:
+// (1) none of the four required status-check workflows ever gains a path
+// filter on its pull_request trigger or renames its job id (a path-filtered
+// required check never reports for a change outside its filter, which
+// blocks every such pull request rather than saving anything); (2) every
+// pull_request-triggering workflow keeps some form of concurrency
+// cancellation, so a superseded push does not also pay for a stale run.
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+const WORKFLOWS_DIR = 'workflows';
+
+function readWorkflow(name: string): string {
+  return readFileSync(
+    new URL(`../.github/${WORKFLOWS_DIR}/${name}`, import.meta.url),
+    'utf8',
+  );
+}
+
+/** Same on:-block slice convention as
+ * tests/advisory-convergence-comment-workflow.test.mts: every workflow file
+ * in this repository places `permissions:` immediately after its `on:`
+ * block. */
+function extractOnBlock(text: string): string {
+  const start = text.indexOf('\non:');
+  const end = text.indexOf('\npermissions:');
+  assert.ok(
+    start !== -1 && end !== -1 && end > start,
+    'on:/permissions: block not found',
+  );
+  return text.slice(start, end);
+}
+
+const REQUIRED_CHECKS = [
+  { file: 'lint.yml', jobId: 'lint' },
+  { file: 'idd-doctor.yml', jobId: 'idd-doctor' },
+  { file: 'pnpm-boundary.yml', jobId: 'pnpm-boundary' },
+  { file: 'idd-advisory-convergence.yml', jobId: 'idd-advisory-convergence' },
+] as const;
+
+test('required-check workflows keep an unfiltered pull_request trigger and their required job id', () => {
+  for (const { file, jobId } of REQUIRED_CHECKS) {
+    const text = readWorkflow(file);
+    const onBlock = extractOnBlock(text);
+    assert.match(
+      onBlock,
+      /pull_request:/,
+      `${file}: must trigger on pull_request`,
+    );
+    assert.doesNotMatch(
+      onBlock,
+      /\bpaths(-ignore)?:/,
+      `${file}: pull_request trigger must not gain a path filter -- a path-filtered required check never reports for an out-of-filter change`,
+    );
+    assert.match(
+      text,
+      new RegExp(`^ {2}${jobId}:$`, 'm'),
+      `${file}: must keep required job id ${jobId}`,
+    );
+  }
+});
+
+/** Every workflow file that fires on `pull_request` -- excluding the
+ * PR-comment-triggered advisory-convergence companion, which is
+ * pull_request_review_comment-only and already asserted non-cancelling by
+ * tests/advisory-convergence-comment-workflow.test.mts. */
+function pullRequestTriggeredWorkflowFiles(): string[] {
+  const dir = new URL(`../.github/${WORKFLOWS_DIR}/`, import.meta.url);
+  return readdirSync(dir)
+    .filter((name) => name.endsWith('.yml'))
+    .filter((name) => {
+      const onBlock = extractOnBlock(readWorkflow(name));
+      return /^ {2}pull_request:/m.test(onBlock);
+    });
+}
+
+test('every pull_request-triggering workflow has working concurrency cancellation', () => {
+  const files = pullRequestTriggeredWorkflowFiles();
+  // Sanity: this must find the six workflows #2322 measured, not an empty
+  // or drifted set from a future rename.
+  assert.ok(
+    files.length >= 6,
+    `expected >= 6 pull_request-triggered workflows, found ${files.length}: ${files.join(', ')}`,
+  );
+  for (const file of files) {
+    const text = readWorkflow(file);
+    const hasOwnConcurrency = /^concurrency:$/m.test(text);
+    // pnpm-boundary-node22-floor.yml calls pnpm-boundary.yml as a reusable
+    // workflow (`uses: ./.github/workflows/pnpm-boundary.yml`) and declares
+    // no concurrency of its own -- it inherits the called workflow's own
+    // `concurrency: group: ${{ github.workflow }}-${{ github.ref }}` block,
+    // keyed by the *calling* workflow's name within that execution context,
+    // so it gets its own distinct group rather than colliding with direct
+    // pnpm-boundary.yml runs. Verified empirically against this
+    // repository's own run history (workflow id 324862465): historical
+    // `cancelled` conclusions exist for this workflow, which could only
+    // happen if a newer run's concurrency group evicted an older one.
+    const isReusableWorkflowCaller =
+      /\n {4}uses: \.\/\.github\/workflows\//.test(text);
+    assert.ok(
+      hasOwnConcurrency || isReusableWorkflowCaller,
+      `${file}: must declare its own concurrency: block, or be a pure reusable-workflow caller that inherits one`,
+    );
+  }
+});

--- a/tests/actions-usage-workflow-guard.test.mts
+++ b/tests/actions-usage-workflow-guard.test.mts
@@ -18,6 +18,20 @@ function readWorkflow(name: string): string {
   );
 }
 
+function hasOwnConcurrencyBlock(text: string): boolean {
+  return /^concurrency:$/m.test(text);
+}
+
+/** The called workflow's own filename, when `text`'s job body calls a
+ * local reusable workflow (`uses: ./.github/workflows/<file>`); `null`
+ * otherwise. */
+function reusableWorkflowCallTarget(text: string): string | null {
+  const match = text.match(
+    /\n {4}uses: \.\/\.github\/workflows\/([\w.-]+\.ya?ml)/,
+  );
+  return match ? match[1] : null;
+}
+
 /** Same on:-block slice convention as
  * tests/advisory-convergence-comment-workflow.test.mts: every workflow file
  * in this repository places `permissions:` immediately after its `on:`
@@ -85,7 +99,9 @@ test('every pull_request-triggering workflow has working concurrency cancellatio
   );
   for (const file of files) {
     const text = readWorkflow(file);
-    const hasOwnConcurrency = /^concurrency:$/m.test(text);
+    if (hasOwnConcurrencyBlock(text)) {
+      continue;
+    }
     // pnpm-boundary-node22-floor.yml calls pnpm-boundary.yml as a reusable
     // workflow (`uses: ./.github/workflows/pnpm-boundary.yml`) and declares
     // no concurrency of its own -- it inherits the called workflow's own
@@ -96,11 +112,20 @@ test('every pull_request-triggering workflow has working concurrency cancellatio
     // repository's own run history (workflow id 324862465): historical
     // `cancelled` conclusions exist for this workflow, which could only
     // happen if a newer run's concurrency group evicted an older one.
-    const isReusableWorkflowCaller =
-      /\n {4}uses: \.\/\.github\/workflows\//.test(text);
+    //
+    // Verify the *called* workflow actually declares concurrency too --
+    // otherwise a future workflow-call-only caller of a workflow lacking
+    // its own concurrency block would silently pass this guard.
+    const calledFile = reusableWorkflowCallTarget(text);
+    if (!calledFile) {
+      assert.fail(
+        `${file}: must declare its own concurrency: block, or be a pure reusable-workflow caller that inherits one`,
+      );
+    }
+    const calledText = readWorkflow(calledFile);
     assert.ok(
-      hasOwnConcurrency || isReusableWorkflowCaller,
-      `${file}: must declare its own concurrency: block, or be a pure reusable-workflow caller that inherits one`,
+      hasOwnConcurrencyBlock(calledText),
+      `${file}: calls ${calledFile} as a reusable workflow, but ${calledFile} declares no concurrency: block for it to inherit`,
     );
   }
 });

--- a/tests/actions-usage-workflow-guard.test.mts
+++ b/tests/actions-usage-workflow-guard.test.mts
@@ -18,8 +18,42 @@ function readWorkflow(name: string): string {
   );
 }
 
-function hasOwnConcurrencyBlock(text: string): boolean {
-  return /^concurrency:$/m.test(text);
+/** Extracts a top-level `concurrency:` block's indented body (the lines
+ * immediately following a `^concurrency:$` line), or `null` when no
+ * top-level `concurrency:` block exists. */
+function extractConcurrencyBlock(text: string): string | null {
+  const match = text.match(/^concurrency:\n((?: {2}.*\n)+)/m);
+  return match ? match[1] : null;
+}
+
+// cancel-in-progress values this repository's own workflows are known to
+// use for a genuinely self-cancelling pull_request-scoped concurrency
+// group -- a literal `true`, or pnpm-boundary.yml's own conditional
+// (documented there as always true for this repository's own
+// pull_request-triggered runs). An expression outside this allowlist
+// cannot be verified to evaluate true without actually running it, so a
+// future workflow using a different conditional must extend this list
+// deliberately rather than silently pass a guard that never checked it.
+const KNOWN_SAFE_CANCEL_IN_PROGRESS_VALUES = new Set([
+  'true',
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: a literal YAML/Actions expression matched against workflow text, not a JS template placeholder.
+  "${{ startsWith(github.ref, 'refs/pull/') }}",
+]);
+
+/** Whether `text`'s top-level `concurrency:` block sets
+ * `cancel-in-progress` to a value known to evaluate `true` for this
+ * repository's own pull_request-triggered runs -- not merely whether a
+ * `concurrency:` key is present, since `false` or an unset (default
+ * `false`) value declares a block but cancels nothing. */
+function hasEffectiveCancelInProgress(text: string): boolean {
+  const block = extractConcurrencyBlock(text);
+  if (!block) {
+    return false;
+  }
+  const match = block.match(/^ {2}cancel-in-progress: (.+)$/m);
+  return (
+    match !== null && KNOWN_SAFE_CANCEL_IN_PROGRESS_VALUES.has(match[1].trim())
+  );
 }
 
 /** The called workflow's own filename, when `text`'s job body calls a
@@ -99,7 +133,7 @@ test('every pull_request-triggering workflow has working concurrency cancellatio
   );
   for (const file of files) {
     const text = readWorkflow(file);
-    if (hasOwnConcurrencyBlock(text)) {
+    if (hasEffectiveCancelInProgress(text)) {
       continue;
     }
     // pnpm-boundary-node22-floor.yml calls pnpm-boundary.yml as a reusable
@@ -113,19 +147,19 @@ test('every pull_request-triggering workflow has working concurrency cancellatio
     // `cancelled` conclusions exist for this workflow, which could only
     // happen if a newer run's concurrency group evicted an older one.
     //
-    // Verify the *called* workflow actually declares concurrency too --
-    // otherwise a future workflow-call-only caller of a workflow lacking
-    // its own concurrency block would silently pass this guard.
+    // Verify the *called* workflow actually declares an effective
+    // cancel-in-progress too -- otherwise a future workflow-call-only
+    // caller of a workflow lacking one would silently pass this guard.
     const calledFile = reusableWorkflowCallTarget(text);
     if (!calledFile) {
       assert.fail(
-        `${file}: must declare its own concurrency: block, or be a pure reusable-workflow caller that inherits one`,
+        `${file}: must declare an effective cancel-in-progress concurrency setting, or be a pure reusable-workflow caller that inherits one`,
       );
     }
     const calledText = readWorkflow(calledFile);
     assert.ok(
-      hasOwnConcurrencyBlock(calledText),
-      `${file}: calls ${calledFile} as a reusable workflow, but ${calledFile} declares no concurrency: block for it to inherit`,
+      hasEffectiveCancelInProgress(calledText),
+      `${file}: calls ${calledFile} as a reusable workflow, but ${calledFile} declares no effective cancel-in-progress for it to inherit`,
     );
   }
 });

--- a/tests/actions-usage-workflow-guard.test.mts
+++ b/tests/actions-usage-workflow-guard.test.mts
@@ -66,6 +66,18 @@ function reusableWorkflowCallTarget(text: string): string | null {
   return match ? match[1] : null;
 }
 
+/** Every top-level job id declared under `text`'s `jobs:` key (2-space
+ * indented `<id>:` lines). Used to verify a "pure reusable-workflow
+ * caller" claim structurally: calling a reusable workflow inherits its
+ * concurrency only for *that* job, so a sibling job in the same
+ * workflow file would keep running uncancelled. */
+function jobIds(text: string): string[] {
+  const start = text.indexOf('\njobs:');
+  assert.ok(start !== -1, 'jobs: block not found');
+  const body = text.slice(start + '\njobs:'.length);
+  return [...body.matchAll(/^ {2}([\w-]+):$/gm)].map((m) => m[1]);
+}
+
 /** Extracts one job's indented body -- the lines from `^  {jobId}:$` up to
  * (but not including) the next 2-space-indented sibling key, or end of
  * file. */
@@ -180,6 +192,18 @@ test('every pull_request-triggering workflow has working concurrency cancellatio
         `${file}: must declare an effective cancel-in-progress concurrency setting, or be a pure reusable-workflow caller that inherits one`,
       );
     }
+    // The inherited concurrency only cancels *that* job -- a sibling job
+    // in the same workflow file would keep running uncancelled, so the
+    // exception applies only when the reusable-workflow call is this
+    // file's sole job.
+    const ids = jobIds(text);
+    assert.equal(
+      ids.length,
+      1,
+      `${file}: calls ${calledFile} as a reusable workflow, but declares ${ids.length} jobs (${ids.join(
+        ', ',
+      )}) -- inherited concurrency only covers the reusable-workflow job itself, so every sibling job needs its own effective cancel-in-progress`,
+    );
     const calledText = readWorkflow(calledFile);
     assert.ok(
       hasEffectiveCancelInProgress(calledText),

--- a/tests/actions-usage-workflow-guard.test.mts
+++ b/tests/actions-usage-workflow-guard.test.mts
@@ -66,6 +66,19 @@ function reusableWorkflowCallTarget(text: string): string | null {
   return match ? match[1] : null;
 }
 
+/** Extracts one job's indented body -- the lines from `^  {jobId}:$` up to
+ * (but not including) the next 2-space-indented sibling key, or end of
+ * file. */
+function extractJobBody(text: string, jobId: string): string {
+  const startMatch = text.match(new RegExp(`^ {2}${jobId}:$`, 'm'));
+  assert.ok(startMatch?.index !== undefined, `job ${jobId} not found`);
+  const afterStart = text.slice(startMatch.index + startMatch[0].length);
+  const nextSiblingMatch = afterStart.match(/^ {2}\S/m);
+  return nextSiblingMatch?.index === undefined
+    ? afterStart
+    : afterStart.slice(0, nextSiblingMatch.index);
+}
+
 /** Same on:-block slice convention as
  * tests/advisory-convergence-comment-workflow.test.mts: every workflow file
  * in this repository places `permissions:` immediately after its `on:`
@@ -105,6 +118,17 @@ test('required-check workflows keep an unfiltered pull_request trigger and their
       text,
       new RegExp(`^ {2}${jobId}:$`, 'm'),
       `${file}: must keep required job id ${jobId}`,
+    );
+    // GitHub reports a required status check under the job's effective
+    // *display name* -- its own `name:` key when present, the job id
+    // otherwise -- so a job-level `name:` addition would silently move
+    // the check the ruleset waits on, even though the job id above is
+    // unchanged and this test's own id assertion would keep passing.
+    const jobBody = extractJobBody(text, jobId);
+    assert.doesNotMatch(
+      jobBody,
+      /^ {4}name:/m,
+      `${file}: job ${jobId} must not declare its own display name -- that changes the literal required-status-check context`,
     );
   }
 });

--- a/tests/help-text-flags.test.mts
+++ b/tests/help-text-flags.test.mts
@@ -163,6 +163,7 @@ const CROSS_REFERENCE_FLAGS: Readonly<Record<string, readonly string[]>> = {
 // see the header comment above for why this isn't narrowed to only helpers
 // with a function literally named printHelp().
 const COVERED_HELPERS = [
+  'actions-usage-report',
   'advisory-convergence',
   'advisory-wait-state',
   'audit-authored-issue',

--- a/tests/helper-invocation-profile.test.mts
+++ b/tests/helper-invocation-profile.test.mts
@@ -96,6 +96,14 @@ const SOURCE_REPO_INTERNAL_ENTRY_PATHS = new Set([
   // idd-template/; an adopter repository has no context-tax data to
   // report.
   'scripts/context-tax-report.mjs',
+  // actions-usage-report.mjs (#2322): this repository's own dogfood Actions
+  // API measurement reporter, named in docs/customization.md's adopter
+  // billing-exposure section as an example of the kind of evidence-gathering
+  // this repository itself uses. It reports on THIS repository's own
+  // `.github/workflows/*.yml` names -- never distributed to idd-template/;
+  // an adopter repository has an entirely different set of workflows to
+  // measure.
+  'scripts/actions-usage-report.mjs',
 ]);
 
 // A helper name that appears only as a *proposed*, not-yet-built script


### PR DESCRIPTION
## Summary

Adds `actions-usage-report`, a maintainer-only Actions API cost measurement
tool for one pull request (per-workflow run counts and per-job durations,
covered by an offline JSONL fixture test), then applies only the Actions
consumption cuts backed by that evidence and by this repository's own live
run history:

- CodeQL's `pull_request` trigger gets the same header-comment justification
  `lint.yml`/`idd-doctor.yml`/`pnpm-boundary.yml` already carry -- it stays
  deliberately unfiltered for full security-scan coverage and is not a
  required check.
- A regression test asserts the four required status-check workflows
  (`lint`, `idd-doctor`, `pnpm-boundary`, `idd-advisory-convergence`) never
  gain a path filter or rename their job id, and that every
  `pull_request`-triggering workflow keeps working concurrency cancellation
  (including verifying, not just special-casing, that
  `pnpm-boundary-node22-floor.yml` genuinely inherits it from the reusable
  workflow it calls).
- `docs/customization.md` (+ byte-identical `idd-template/` mirror) documents
  the review-loop cost multiplier, the required-vs-optional workflow split,
  and the private-repo spend-limit stop.

Every other candidate cut in the issue's proposed-change section (removing
"redundant" triggers, path-filtering the Node-22-floor guard, adding
concurrency anywhere) was investigated and found either already safe or too
risky to change without weakening real coverage -- see the plan comment on
#2322 and the second commit's message for the verified evidence, including
this repository's own historical `cancelled` run conclusions proving
`pnpm-boundary-node22-floor.yml`'s inherited concurrency already works.

An independent C1 critique subagent reviewed the full diff (fixture math,
YAML assertions, byte-identical doc mirrors, the reusable-workflow
concurrency-inheritance claim against GitHub's documented behavior) and
found no blocking issues.

Closes #2322

## Verification

- `node --test tests/*.test.mts` (4041 tests)
- `pre-push-validate` (biome, dprint, markdownlint, cspell, `audit-docs.mjs
  --check`, `audit-code-span-wrap.mjs`, `pnpm run build:check`,
  `idd-doctor.mjs`)
- `node scripts/actions-usage-report.mjs --pr 2336` against live data
  (42 runs / ~61 minutes from a 3-push, 1-review-cycle PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line report for pull-request GitHub Actions usage with table or JSON output.
  * Reports workflow runs, completed job durations, billed minutes, and workflow-level totals, including reruns and pull-request event variants.
  * Safely excludes incomplete, invalid, unmatched, or malformed job data.

* **Documentation**
  * Added guidance on measuring CI costs, optimizing advisory checks, and protecting required workflows.

* **Tests**
  * Expanded coverage for usage reporting, edge cases, workflow protections, and command help validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->