### PR TITLE
feat(advisory-convergence): make Copilot review poll timing configurable

### DIFF
--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -266,6 +266,31 @@ branch-mismatch case specifically, so it stays genuinely waivable; the
 to bind to and are effectively not waivable in practice -- see
 `docs/idd-helper-scripts.md`.
 
+### `idd-advisory-convergence` Copilot-review poll (`advisoryConvergence`)
+
+`advisoryConvergence.copilotReviewPollInterval` and
+`advisoryConvergence.copilotReviewPollMaxWait` (#2333) configure the
+short, bounded poll `advisory-convergence.mjs` itself runs when the
+`idd-advisory-convergence` required check's only blocking reason is that
+the primary bot has not reviewed the pull request at all yet -- absorbing
+the common race between the `pull_request: synchronize` trigger (fires
+immediately on push) and the separate `pull_request_review` trigger
+(fires once the bot's review actually lands). This is a **distinct
+config subtree from `advisoryWait.pollInterval`** above: that key governs
+the whole-minute-only E-phase advisory-wait protocol's own longer-horizon
+wait loop, entered only after this check has already resolved; this
+poll runs entirely inside the check itself, before the E-phase protocol
+ever engages, and needs sub-minute precision the whole-minute duration
+pattern cannot express. Both keys accept positive ISO 8601 durations down
+to whole-second precision (matching `ciWait`'s duration pattern, not
+`advisoryWait`'s whole-minute-only one). Omitting either key keeps the
+pre-#2333 hardcoded default exactly.
+
+| Policy default                                                                 | Distributed value                                                            | Owning surface                          | Onboarding expectation                                                                                                                                                                                                                                |
+| ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Copilot-review poll interval (`advisoryConvergence.copilotReviewPollInterval`) | 7500 ms (not expressible as a whole-second duration string; omit to keep it) | [Helper scripts](idd-helper-scripts.md) | Raise only if the repository's measured Copilot review latency shows the default cadence wastes re-checks against a known-longer landing time.                                                                                                        |
+| Copilot-review poll ceiling (`advisoryConvergence.copilotReviewPollMaxWait`)   | `PT60S` (60 s)                                                               | [Helper scripts](idd-helper-scripts.md) | Raise when the repository's measured Copilot review latency regularly exceeds 60 s (see `#2333`'s field evidence: 166-229 s observed on a `vendored-node` adopter); keep the hosting workflow's own `timeout-minutes` comfortably above this ceiling. |
+
 ## CI Wait Defaults
 
 | Policy default                                         | Distributed value                                                                                                                                                                                             | Owning surface                                                                                                                                                                                         | Onboarding expectation                                                                      |

--- a/idd-template/docs/policy-constants.md
+++ b/idd-template/docs/policy-constants.md
@@ -266,6 +266,31 @@ branch-mismatch case specifically, so it stays genuinely waivable; the
 to bind to and are effectively not waivable in practice -- see
 `docs/idd-helper-scripts.md`.
 
+### `idd-advisory-convergence` Copilot-review poll (`advisoryConvergence`)
+
+`advisoryConvergence.copilotReviewPollInterval` and
+`advisoryConvergence.copilotReviewPollMaxWait` (#2333) configure the
+short, bounded poll `advisory-convergence.mjs` itself runs when the
+`idd-advisory-convergence` required check's only blocking reason is that
+the primary bot has not reviewed the pull request at all yet -- absorbing
+the common race between the `pull_request: synchronize` trigger (fires
+immediately on push) and the separate `pull_request_review` trigger
+(fires once the bot's review actually lands). This is a **distinct
+config subtree from `advisoryWait.pollInterval`** above: that key governs
+the whole-minute-only E-phase advisory-wait protocol's own longer-horizon
+wait loop, entered only after this check has already resolved; this
+poll runs entirely inside the check itself, before the E-phase protocol
+ever engages, and needs sub-minute precision the whole-minute duration
+pattern cannot express. Both keys accept positive ISO 8601 durations down
+to whole-second precision (matching `ciWait`'s duration pattern, not
+`advisoryWait`'s whole-minute-only one). Omitting either key keeps the
+pre-#2333 hardcoded default exactly.
+
+| Policy default                                                                 | Distributed value                                                            | Owning surface                          | Onboarding expectation                                                                                                                                                                                                                                |
+| ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Copilot-review poll interval (`advisoryConvergence.copilotReviewPollInterval`) | 7500 ms (not expressible as a whole-second duration string; omit to keep it) | [Helper scripts](idd-helper-scripts.md) | Raise only if the repository's measured Copilot review latency shows the default cadence wastes re-checks against a known-longer landing time.                                                                                                        |
+| Copilot-review poll ceiling (`advisoryConvergence.copilotReviewPollMaxWait`)   | `PT60S` (60 s)                                                               | [Helper scripts](idd-helper-scripts.md) | Raise when the repository's measured Copilot review latency regularly exceeds 60 s (see `#2333`'s field evidence: 166-229 s observed on a `vendored-node` adopter); keep the hosting workflow's own `timeout-minutes` comfortably above this ceiling. |
+
 ## CI Wait Defaults
 
 | Policy default                                         | Distributed value                                                                                                                                                                                             | Owning surface                                                                                                                                                                                         | Onboarding expectation                                                                      |

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -362,6 +362,23 @@
       },
       "description": "Container for Copilot/primary-bot advisory review timing, caps, and bot identity. Optional; omitting any nested key keeps that key's own distributed default."
     },
+    "advisoryConvergence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "copilotReviewPollInterval": {
+          "type": "string",
+          "pattern": "^(?=.*[1-9])P(?=\\d|T\\d)(?:\\d+D)?(?:T(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?)?$",
+          "description": "ISO 8601 duration (whole seconds or larger) between re-checks in the idd-advisory-convergence required check's own short bounded poll for a primary-bot review that has not landed yet. Distinct from advisoryWait.pollInterval (a separate, whole-minute-only, longer-horizon E-phase wait). Optional; omitting it keeps the pre-#2333 hardcoded 7500ms interval, which is not itself expressible as a whole-second duration string."
+        },
+        "copilotReviewPollMaxWait": {
+          "type": "string",
+          "pattern": "^(?=.*[1-9])P(?=\\d|T\\d)(?:\\d+D)?(?:T(?=\\d)(?:\\d+H)?(?:\\d+M)?(?:\\d+S)?)?$",
+          "description": "ISO 8601 duration ceiling, across all re-checks, for the same bounded poll. Optional; defaults to `PT60S`, matching the pre-#2333 hardcoded 60000ms ceiling."
+        }
+      },
+      "description": "Container for the idd-advisory-convergence required check's own short, bounded Copilot-review poll (#2333). Optional; omitting any nested key keeps that key's own distributed default."
+    },
     "ciWait": {
       "type": "object",
       "additionalProperties": false,

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -90,6 +90,7 @@
 // mechanism (this run gets cancelled by the hosting workflow's own
 // concurrency group, not a plain immediate-assert failure) -- the poll's
 // actual win is narrower than "never needs a rerun again."
+import { readFileSync } from 'node:fs';
 import {
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
   DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES,
@@ -139,6 +140,7 @@ import {
   isVerifiedCopilotAuthor,
   resolveLatestCopilotReviewClause,
 } from './review-clause.mjs';
+import { loadJson, validateConfigSection } from './validate-schemas.mjs';
 /** The external-check-waiver selector this gate recognizes (documented in
  * docs/idd-helper-scripts.md and docs/policy-constants.md; #1341's required
  * check is expected to register under the same name). #1570: re-exported
@@ -1277,6 +1279,53 @@ export const DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS = 7_500;
  * {@link runAdvisoryConvergenceWithPoll} (#2015) -- the issue's suggested
  * ~60s ceiling. */
 export const DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS = 60_000;
+const POLICY_SCHEMA = loadJson('schemas/policy.schema.json');
+/**
+ * Resolve the configured Copilot-review bounded-poll interval/ceiling
+ * (#2333) from `.github/idd/config.json`'s `advisoryConvergence` section,
+ * scoped-validated the same way every policy reader in this file's
+ * `advisory-wait-policy.mts` siblings validates its own subtree (#1359): an
+ * unrelated invalid field elsewhere in the document must not zero out an
+ * otherwise-valid `advisoryConvergence` section. Missing config, an
+ * unreadable/malformed file, or a schema-invalid `advisoryConvergence`
+ * section all fail closed to today's hardcoded defaults -- reproducing the
+ * pre-#2333 behavior exactly, per that issue's own acceptance criterion.
+ *
+ * Deliberately a separate config subtree from `advisoryWait.pollInterval`
+ * (`advisory-wait-policy.mts`, a whole-minute-only ISO 8601 duration): that
+ * key governs the E-phase advisory-wait protocol's own longer-horizon wait
+ * loop. This poll is shorter-lived and runs entirely inside the
+ * `idd-advisory-convergence` required check itself, before the E-phase
+ * protocol ever engages, so it needs sub-minute precision the whole-minute
+ * pattern cannot express -- reusing that key's name or pattern here would
+ * misrepresent this as the same setting.
+ */
+export function readCopilotReviewPollPolicy(path = '.github/idd/config.json') {
+  const fallback = {
+    pollIntervalMs: DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS,
+    maxWaitMs: DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS,
+  };
+  try {
+    const config = JSON.parse(readFileSync(path, 'utf8'));
+    if (
+      validateConfigSection(config, POLICY_SCHEMA, 'advisoryConvergence')
+        .length > 0
+    ) {
+      return fallback;
+    }
+    const section = config?.advisoryConvergence ?? {};
+    return {
+      pollIntervalMs:
+        parseIsoDurationToMs(section.copilotReviewPollInterval) ??
+        fallback.pollIntervalMs,
+      maxWaitMs:
+        parseIsoDurationToMs(section.copilotReviewPollMaxWait) ??
+        fallback.maxWaitMs,
+    };
+  } catch {
+    return fallback;
+  }
+}
 /** Falls back to `fallback` for a non-finite or non-positive value --
  * mirrors `gh-exec.mts`'s `withBoundedRetry` guard on its own duration
  * options, so a `NaN`/zero/negative caller-supplied interval or budget
@@ -2284,8 +2333,11 @@ export function writeAdvisoryConvergenceCliOutput(verdict, options = {}) {
 // Guarded behind `import.meta.main` so importing this module (for unit
 // tests) never parses process.argv, prints usage, or makes a `gh` call.
 if (import.meta.main) {
+  const { pollIntervalMs, maxWaitMs } = readCopilotReviewPollPolicy();
   const { verdict, exitCode, help } = runAdvisoryConvergenceWithPoll(
     process.argv.slice(2),
+    defaultDeps,
+    { pollIntervalMs, maxWaitMs },
   );
   if (help) {
     printHelp();

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -91,6 +91,8 @@
 // concurrency group, not a plain immediate-assert failure) -- the poll's
 // actual win is narrower than "never needs a rerun again."
 
+import { readFileSync } from 'node:fs';
+
 import {
   DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
   DEFAULT_ADVISORY_CONVERGENCE_DEADLINE_MINUTES,
@@ -154,6 +156,7 @@ import {
   isVerifiedCopilotAuthor,
   resolveLatestCopilotReviewClause,
 } from './review-clause.mts';
+import { loadJson, validateConfigSection } from './validate-schemas.mts';
 
 /** The external-check-waiver selector this gate recognizes (documented in
  * docs/idd-helper-scripts.md and docs/policy-constants.md; #1341's required
@@ -1799,6 +1802,61 @@ export const DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS = 7_500;
  * ~60s ceiling. */
 export const DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS = 60_000;
 
+const POLICY_SCHEMA = loadJson('schemas/policy.schema.json');
+
+/**
+ * Resolve the configured Copilot-review bounded-poll interval/ceiling
+ * (#2333) from `.github/idd/config.json`'s `advisoryConvergence` section,
+ * scoped-validated the same way every policy reader in this file's
+ * `advisory-wait-policy.mts` siblings validates its own subtree (#1359): an
+ * unrelated invalid field elsewhere in the document must not zero out an
+ * otherwise-valid `advisoryConvergence` section. Missing config, an
+ * unreadable/malformed file, or a schema-invalid `advisoryConvergence`
+ * section all fail closed to today's hardcoded defaults -- reproducing the
+ * pre-#2333 behavior exactly, per that issue's own acceptance criterion.
+ *
+ * Deliberately a separate config subtree from `advisoryWait.pollInterval`
+ * (`advisory-wait-policy.mts`, a whole-minute-only ISO 8601 duration): that
+ * key governs the E-phase advisory-wait protocol's own longer-horizon wait
+ * loop. This poll is shorter-lived and runs entirely inside the
+ * `idd-advisory-convergence` required check itself, before the E-phase
+ * protocol ever engages, so it needs sub-minute precision the whole-minute
+ * pattern cannot express -- reusing that key's name or pattern here would
+ * misrepresent this as the same setting.
+ */
+export function readCopilotReviewPollPolicy(
+  path: string = '.github/idd/config.json',
+): { pollIntervalMs: number; maxWaitMs: number } {
+  const fallback = {
+    pollIntervalMs: DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS,
+    maxWaitMs: DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS,
+  };
+  try {
+    const config = JSON.parse(readFileSync(path, 'utf8'));
+    if (
+      validateConfigSection(config, POLICY_SCHEMA, 'advisoryConvergence')
+        .length > 0
+    ) {
+      return fallback;
+    }
+    const section = ((config as { advisoryConvergence?: unknown } | null)
+      ?.advisoryConvergence ?? {}) as {
+      copilotReviewPollInterval?: unknown;
+      copilotReviewPollMaxWait?: unknown;
+    };
+    return {
+      pollIntervalMs:
+        parseIsoDurationToMs(section.copilotReviewPollInterval) ??
+        fallback.pollIntervalMs,
+      maxWaitMs:
+        parseIsoDurationToMs(section.copilotReviewPollMaxWait) ??
+        fallback.maxWaitMs,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
 /** Options accepted by {@link runAdvisoryConvergenceWithPoll}. All optional
  * -- `sleep` and `now` exist solely so tests can inject a deterministic,
  * instant fake clock instead of a real bounded wait; production always uses
@@ -2980,8 +3038,11 @@ export function writeAdvisoryConvergenceCliOutput(
 // Guarded behind `import.meta.main` so importing this module (for unit
 // tests) never parses process.argv, prints usage, or makes a `gh` call.
 if (import.meta.main) {
+  const { pollIntervalMs, maxWaitMs } = readCopilotReviewPollPolicy();
   const { verdict, exitCode, help } = runAdvisoryConvergenceWithPoll(
     process.argv.slice(2),
+    defaultDeps,
+    { pollIntervalMs, maxWaitMs },
   );
   if (help) {
     printHelp();

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -1,5 +1,13 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { test } from 'node:test';
 
 import {
@@ -11,11 +19,14 @@ import {
   classifyCopilotAuthoredThreadIds,
   collectAssertNextActions,
   computeAdvisoryConvergenceVerdict,
+  DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS,
+  DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS,
   formatAssertNextActions,
   hasTrustedClaimMarkerHistory,
   isSoleCopilotNotReviewedYetReason,
   parseArgs,
   pickResolvingClaimEvents,
+  readCopilotReviewPollPolicy,
   resolveClaimEvidence,
   reviewPolicyNotApplicableReason,
   runAdvisoryConvergence,
@@ -4003,6 +4014,109 @@ test('runAdvisoryConvergenceWithPoll: review lands on HEAD mid-poll with outstan
   // it must not keep polling out the rest of the window.
   assert.equal(calls(), 1);
   assert.equal(collectCalls(), 2);
+});
+
+function baseValidConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    iddVersion: '0.1.0',
+    markerPrefix: 'idd-skill',
+    mergePolicy: 'fully_autonomous_merge',
+    reviewPolicy: 'copilot-advisory',
+    threadResolutionPolicy: 'fast-agent-resolve',
+    claimTiming: { staleAge: 'PT24H', heartbeatInterval: 'PT12H' },
+    trustedMarkerActors: ['kurone-kito'],
+    commands: {
+      'install-deps': 'true',
+      'fix-validate': 'true',
+      'pre-push-validate': 'true',
+      'post-fix-validate': 'true',
+    },
+    ...overrides,
+  };
+}
+
+function writeConfigFixture(
+  sandbox: string,
+  config: Record<string, unknown>,
+): string {
+  const configPath = join(sandbox, '.github', 'idd', 'config.json');
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  return configPath;
+}
+
+test('readCopilotReviewPollPolicy: absent config path reproduces the hardcoded defaults exactly (#2333)', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-advisory-convergence-poll-'));
+  try {
+    assert.deepEqual(
+      readCopilotReviewPollPolicy(join(sandbox, 'does-not-exist.json')),
+      {
+        pollIntervalMs: DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS,
+        maxWaitMs: DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS,
+      },
+    );
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+test('readCopilotReviewPollPolicy: reads a configured advisoryConvergence section', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-advisory-convergence-poll-'));
+  try {
+    const configPath = writeConfigFixture(
+      sandbox,
+      baseValidConfig({
+        advisoryConvergence: {
+          copilotReviewPollInterval: 'PT10S',
+          copilotReviewPollMaxWait: 'PT2M',
+        },
+      }),
+    );
+    assert.deepEqual(readCopilotReviewPollPolicy(configPath), {
+      pollIntervalMs: 10_000,
+      maxWaitMs: 120_000,
+    });
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+test('readCopilotReviewPollPolicy: still honors advisoryConvergence when an unrelated top-level field is schema-invalid (#1359)', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-advisory-convergence-poll-'));
+  try {
+    const configPath = writeConfigFixture(
+      sandbox,
+      baseValidConfig({
+        advisoryConvergence: { copilotReviewPollInterval: 'PT10S' },
+        unsupportedTopLevelKey: true,
+      }),
+    );
+    assert.deepEqual(readCopilotReviewPollPolicy(configPath), {
+      pollIntervalMs: 10_000,
+      maxWaitMs: DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS,
+    });
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+});
+
+test('readCopilotReviewPollPolicy: falls back to defaults when its own advisoryConvergence section is schema-invalid', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-advisory-convergence-poll-'));
+  try {
+    const configPath = writeConfigFixture(
+      sandbox,
+      baseValidConfig({
+        // Fractional seconds are not a valid whole-second duration.
+        advisoryConvergence: { copilotReviewPollInterval: 'PT7.5S' },
+      }),
+    );
+    assert.deepEqual(readCopilotReviewPollPolicy(configPath), {
+      pollIntervalMs: DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS,
+      maxWaitMs: DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS,
+    });
+  } finally {
+    rmSync(sandbox, { recursive: true, force: true });
+  }
 });
 
 test('viewerProbeGhOptions captures gh stderr only under GitHub Actions', () => {

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -200,6 +200,10 @@ interface PolicyConfigFile {
     pollInterval?: string;
     capExhaustedRoute?: 'phase-specific' | 'hold';
   };
+  advisoryConvergence?: {
+    copilotReviewPollInterval?: string;
+    copilotReviewPollMaxWait?: string;
+  };
   ciWait?: {
     runningTimeout?: string;
     generationTimeout?: string;
@@ -497,6 +501,7 @@ export const policyConfigKeys = [
   'markerTrustAllowCollaboratorMarkers',
   'allowCollaboratorMarkers',
   'advisoryWait',
+  'advisoryConvergence',
   'ciWait',
   'ciGate',
   'discover',


### PR DESCRIPTION
# Summary

`runAdvisoryConvergenceWithPoll`'s bounded poll for a not-yet-landed
Copilot review was hardcoded at `DEFAULT_COPILOT_REVIEW_POLL_INTERVAL_MS`
(7.5s) / `DEFAULT_COPILOT_REVIEW_POLL_MAX_WAIT_MS` (60s), with no CLI flag
or config path to raise them. A `vendored-node` adopter (private business
repository) directly measured Copilot's real-world review latency at
166s and 229s from the check run's own start to Copilot's review
`submittedAt` on two independent PRs -- 4-15x longer than the default was
calibrated against -- and the check converged to green on its own in 0
of 6 PRs merged that session; every one needed a manual rerun.

Adds `advisoryConvergence.copilotReviewPollInterval` and
`advisoryConvergence.copilotReviewPollMaxWait` to the policy schema, read
by a new `readCopilotReviewPollPolicy` and wired into the CLI entry
point. Both are sub-minute-precision ISO 8601 durations (matching
`ciWait`'s duration pattern), reusing `parseIsoDurationToMs` from
`policy-helpers.mts` with no new duration parser. Deliberately a
**separate config subtree from `advisoryWait.pollInterval`**
(`advisory-wait-policy.mts`, whole-minute-only): that key governs the
E-phase advisory-wait protocol's own longer-horizon wait loop entered
only after this check has already resolved; this poll runs entirely
inside the `idd-advisory-convergence` check itself, before the E-phase
protocol ever engages. Absent or schema-invalid configuration reproduces
the pre-#2333 hardcoded behavior exactly (unit-tested).

## Linked issue

Closes #2333

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Refs #2326 (complementary, not duplicative): #2326 stops
`rerun-advisory-convergence.mts` from wasting its rerun-once budget when
a review has genuinely never landed. This issue lets more PRs catch a
late-but-real review before that rerun-budget question is ever reached,
by giving the in-check poll itself a configurable, longer ceiling.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `node scripts/validate-schemas.mjs`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
