### PR TITLE
feat(critique): make the critique lenses reach lite and delegate passes

### DIFF
--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -108,13 +108,14 @@ other GitHub side effect, confirm all of the following:
 
 1. Run a critique pass to verify the E9 fixes address the root causes
    and are correct. Also apply these lenses when they fit, composing
-   when both do: **Mutation/write-side** (the diff implements a helper
-   that mutates GitHub state, mutates git state, or performs a merge) —
-   fail-closed inputs; validate/execute scope parity; unsafe-output
-   suppression; schema strictness parity. **Gate-mirroring** (the diff
-   implements a helper that predicts, mirrors, or pre-checks another
-   gate's decision) — validation-path parity; input completeness;
-   whole-identity comparison; snapshot identity; point-in-time parity.
+   when both do: **Mutation / write-side** (the diff implements a
+   helper that mutates GitHub state, mutates git state, or performs a
+   merge) — Fail-closed inputs; Validate/execute scope parity;
+   Unsafe-output suppression; Schema strictness parity.
+   **Gate-mirroring** (the diff implements a helper that predicts,
+   mirrors, or pre-checks another gate's decision) — Validation-path
+   parity; Input completeness; Whole-identity comparison; Snapshot
+   identity; Point-in-time parity.
 2. If the critique pass reports zero issues, continue to E11.
 3. If it reports additional issues, fix them, commit atomically, and
    run E10 again.

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -107,7 +107,14 @@ other GitHub side effect, confirm all of the following:
 ## E10 — Validate fixes with critique pass
 
 1. Run a critique pass to verify the E9 fixes address the root causes
-   and are correct.
+   and are correct. Also apply these lenses when they fit, composing
+   when both do: **Mutation/write-side** (the diff implements a helper
+   that mutates GitHub state, mutates git state, or performs a merge) —
+   fail-closed inputs; validate/execute scope parity; unsafe-output
+   suppression; schema strictness parity. **Gate-mirroring** (the diff
+   implements a helper that predicts, mirrors, or pre-checks another
+   gate's decision) — validation-path parity; input completeness;
+   whole-identity comparison; snapshot identity; point-in-time parity.
 2. If the critique pass reports zero issues, continue to E11.
 3. If it reports additional issues, fix them, commit atomically, and
    run E10 again.

--- a/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -214,13 +214,13 @@ a deterministic "always run one" step, not a judgment call whether to
 run it. Add any newly found issues to ReviewItems_snapshot.
 
 Also apply these lenses when they fit, composing when both do:
-**Mutation/write-side** (the diff implements a helper that mutates
-GitHub state, mutates git state, or performs a merge) — fail-closed
-inputs; validate/execute scope parity; unsafe-output suppression;
-schema strictness parity. **Gate-mirroring** (the diff implements a
+**Mutation / write-side** (the diff implements a helper that mutates
+GitHub state, mutates git state, or performs a merge) — Fail-closed
+inputs; Validate/execute scope parity; Unsafe-output suppression;
+Schema strictness parity. **Gate-mirroring** (the diff implements a
 helper that predicts, mirrors, or pre-checks another gate's decision) —
-validation-path parity; input completeness; whole-identity comparison;
-snapshot identity; point-in-time parity.
+Validation-path parity; Input completeness; Whole-identity comparison;
+Snapshot identity; Point-in-time parity.
 
 **Incremental scope**: on the second and later passes within the same
 claim, scope the review to the diff since the previous E2's head SHA,

--- a/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -213,6 +213,15 @@ Run one critique pass on the branch's changes every E1-E3 pass — this is
 a deterministic "always run one" step, not a judgment call whether to
 run it. Add any newly found issues to ReviewItems_snapshot.
 
+Also apply these lenses when they fit, composing when both do:
+**Mutation/write-side** (the diff implements a helper that mutates
+GitHub state, mutates git state, or performs a merge) — fail-closed
+inputs; validate/execute scope parity; unsafe-output suppression;
+schema strictness parity. **Gate-mirroring** (the diff implements a
+helper that predicts, mirrors, or pre-checks another gate's decision) —
+validation-path parity; input completeness; whole-identity comparison;
+snapshot identity; point-in-time parity.
+
 **Incremental scope**: on the second and later passes within the same
 claim, scope the review to the diff since the previous E2's head SHA,
 tracked by the latest trusted same-claim `review-baseline` comment.

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -251,18 +251,18 @@ pass asks, never a separate pass to run on top of the one that ran.
    this pass's whole output, which is the duplicate cost `never` exists to
    avoid.
 6. If both ran, union their reported issues.
-7. When the per-agent pass ran (step 3 or step 5), also apply these
-   lenses to the diff, composing when both fit: **Mutation / write-side**
+7. These lenses apply only within a per-agent pass (step 3 or step 5) —
+   when only the delegate ran instead (a successful delegate under
+   `fallback`, or any delegate under `never`), it never sees them, and
+   do not apply them yourself in its place. When a per-agent pass did
+   run, also apply, composing when both fit: **Mutation / write-side**
    (the diff implements a helper that mutates GitHub state, mutates git
    state, or performs a merge) — Fail-closed inputs; Validate/execute
    scope parity; Unsafe-output suppression; Schema strictness parity.
    **Gate-mirroring** (the diff implements a helper that predicts,
    mirrors, or pre-checks another gate's decision) — Validation-path
    parity; Input completeness; Whole-identity comparison; Snapshot
-   identity; Point-in-time parity. When only the delegate ran (a
-   successful delegate under `fallback`, or any delegate under
-   `never`), it never sees these lenses either — do not apply them
-   yourself in its place.
+   identity; Point-in-time parity.
 8. The floor (referenced in C2, C4, and C5) is `fix-validate` passing against
    the branch's current HEAD. Re-run it after every new commit; it does not
    substitute for D2's `pre-push-validate` gate.

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -251,7 +251,15 @@ pass asks, never a separate pass to run on top of the one that ran.
    this pass's whole output, which is the duplicate cost `never` exists to
    avoid.
 6. If both ran, union their reported issues.
-7. The floor (referenced in C2, C4, and C5) is `fix-validate` passing against
+7. Also apply these lenses to the diff when they fit, composing when both
+   do: **Mutation/write-side** (the diff implements a helper that mutates
+   GitHub state, mutates git state, or performs a merge) — fail-closed
+   inputs; validate/execute scope parity; unsafe-output suppression;
+   schema strictness parity. **Gate-mirroring** (the diff implements a
+   helper that predicts, mirrors, or pre-checks another gate's decision)
+   — validation-path parity; input completeness; whole-identity
+   comparison; snapshot identity; point-in-time parity.
+8. The floor (referenced in C2, C4, and C5) is `fix-validate` passing against
    the branch's current HEAD. Re-run it after every new commit; it does not
    substitute for D2's `pre-push-validate` gate.
 

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -251,14 +251,18 @@ pass asks, never a separate pass to run on top of the one that ran.
    this pass's whole output, which is the duplicate cost `never` exists to
    avoid.
 6. If both ran, union their reported issues.
-7. Also apply these lenses to the diff when they fit, composing when both
-   do: **Mutation/write-side** (the diff implements a helper that mutates
-   GitHub state, mutates git state, or performs a merge) — fail-closed
-   inputs; validate/execute scope parity; unsafe-output suppression;
-   schema strictness parity. **Gate-mirroring** (the diff implements a
-   helper that predicts, mirrors, or pre-checks another gate's decision)
-   — validation-path parity; input completeness; whole-identity
-   comparison; snapshot identity; point-in-time parity.
+7. When the per-agent pass ran (step 3 or step 5), also apply these
+   lenses to the diff, composing when both fit: **Mutation / write-side**
+   (the diff implements a helper that mutates GitHub state, mutates git
+   state, or performs a merge) — Fail-closed inputs; Validate/execute
+   scope parity; Unsafe-output suppression; Schema strictness parity.
+   **Gate-mirroring** (the diff implements a helper that predicts,
+   mirrors, or pre-checks another gate's decision) — Validation-path
+   parity; Input completeness; Whole-identity comparison; Snapshot
+   identity; Point-in-time parity. When only the delegate ran (a
+   successful delegate under `fallback`, or any delegate under
+   `never`), it never sees these lenses either — do not apply them
+   yourself in its place.
 8. The floor (referenced in C2, C4, and C5) is `fix-validate` passing against
    the branch's current HEAD. Re-run it after every new commit; it does not
    substitute for D2's `pre-push-validate` gate.

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -1063,15 +1063,18 @@ critique findings; the C-phase objective diff validation floor above,
 the E-phase Copilot advisory-convergence policy, required checks, and
 merge gates are all unchanged.
 
-A configured delegate receives only the branch diff, never the two
-lenses below or the rest of the per-agent checklist — passing checklist
-content to an external command is a capability change with its own
-design questions (whether the reviewer accepts input at all, what
-happens if it ignores it) that this surface does not make today. Under
-a successful delegate with `mode: fallback` (the default), or under
-`mode: never`, the per-agent pass does not run at all, so an operator
-relying solely on a delegate should expect the lenses below are not
-applied to that PR's diff.
+The critique content passed to a configured delegate is the branch diff
+only — never the two lenses below or the rest of the per-agent
+checklist. (This is about what the delegate invocation sends as
+critique input, not a sandboxing guarantee on what the command can
+otherwise access — see the executable-configuration warning above.)
+Passing checklist content to an external command is a capability change
+with its own design questions (whether the reviewer accepts input at
+all, what happens if it ignores it) that this surface does not make
+today. Under a successful delegate with `mode: fallback` (the default),
+or under `mode: never`, the per-agent pass does not run at all, so an
+operator relying solely on a delegate should expect the lenses below
+are not applied to that PR's diff.
 
 ### Mutation / write-side helper lens
 

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -1063,6 +1063,16 @@ critique findings; the C-phase objective diff validation floor above,
 the E-phase Copilot advisory-convergence policy, required checks, and
 merge gates are all unchanged.
 
+A configured delegate receives only the branch diff, never the two
+lenses below or the rest of the per-agent checklist — passing checklist
+content to an external command is a capability change with its own
+design questions (whether the reviewer accepts input at all, what
+happens if it ignores it) that this surface does not make today. Under
+`mode: fallback` with a successful delegate (the default) or `mode:
+never`, the per-agent pass does not run at all, so an operator relying
+solely on a delegate should expect the lenses below are not applied to
+that PR's diff.
+
 ### Mutation / write-side helper lens
 
 When the diff under critique implements a helper that **mutates GitHub

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -1068,10 +1068,10 @@ lenses below or the rest of the per-agent checklist — passing checklist
 content to an external command is a capability change with its own
 design questions (whether the reviewer accepts input at all, what
 happens if it ignores it) that this surface does not make today. Under
-`mode: fallback` with a successful delegate (the default) or `mode:
-never`, the per-agent pass does not run at all, so an operator relying
-solely on a delegate should expect the lenses below are not applied to
-that PR's diff.
+a successful delegate with `mode: fallback` (the default), or under
+`mode: never`, the per-agent pass does not run at all, so an operator
+relying solely on a delegate should expect the lenses below are not
+applied to that PR's diff.
 
 ### Mutation / write-side helper lens
 

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -103,13 +103,14 @@ other GitHub side effect, confirm all of the following:
 
 1. Run a critique pass to verify the E9 fixes address the root causes
    and are correct. Also apply these lenses when they fit, composing
-   when both do: **Mutation/write-side** (the diff implements a helper
-   that mutates GitHub state, mutates git state, or performs a merge) —
-   fail-closed inputs; validate/execute scope parity; unsafe-output
-   suppression; schema strictness parity. **Gate-mirroring** (the diff
-   implements a helper that predicts, mirrors, or pre-checks another
-   gate's decision) — validation-path parity; input completeness;
-   whole-identity comparison; snapshot identity; point-in-time parity.
+   when both do: **Mutation / write-side** (the diff implements a
+   helper that mutates GitHub state, mutates git state, or performs a
+   merge) — Fail-closed inputs; Validate/execute scope parity;
+   Unsafe-output suppression; Schema strictness parity.
+   **Gate-mirroring** (the diff implements a helper that predicts,
+   mirrors, or pre-checks another gate's decision) — Validation-path
+   parity; Input completeness; Whole-identity comparison; Snapshot
+   identity; Point-in-time parity.
 2. If the critique pass reports zero issues, continue to E11.
 3. If it reports additional issues, fix them, commit atomically, and
    run E10 again.

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -102,7 +102,14 @@ other GitHub side effect, confirm all of the following:
 ## E10 — Validate fixes with critique pass
 
 1. Run a critique pass to verify the E9 fixes address the root causes
-   and are correct.
+   and are correct. Also apply these lenses when they fit, composing
+   when both do: **Mutation/write-side** (the diff implements a helper
+   that mutates GitHub state, mutates git state, or performs a merge) —
+   fail-closed inputs; validate/execute scope parity; unsafe-output
+   suppression; schema strictness parity. **Gate-mirroring** (the diff
+   implements a helper that predicts, mirrors, or pre-checks another
+   gate's decision) — validation-path parity; input completeness;
+   whole-identity comparison; snapshot identity; point-in-time parity.
 2. If the critique pass reports zero issues, continue to E11.
 3. If it reports additional issues, fix them, commit atomically, and
    run E10 again.

--- a/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -209,13 +209,13 @@ a deterministic "always run one" step, not a judgment call whether to
 run it. Add any newly found issues to ReviewItems_snapshot.
 
 Also apply these lenses when they fit, composing when both do:
-**Mutation/write-side** (the diff implements a helper that mutates
-GitHub state, mutates git state, or performs a merge) — fail-closed
-inputs; validate/execute scope parity; unsafe-output suppression;
-schema strictness parity. **Gate-mirroring** (the diff implements a
+**Mutation / write-side** (the diff implements a helper that mutates
+GitHub state, mutates git state, or performs a merge) — Fail-closed
+inputs; Validate/execute scope parity; Unsafe-output suppression;
+Schema strictness parity. **Gate-mirroring** (the diff implements a
 helper that predicts, mirrors, or pre-checks another gate's decision) —
-validation-path parity; input completeness; whole-identity comparison;
-snapshot identity; point-in-time parity.
+Validation-path parity; Input completeness; Whole-identity comparison;
+Snapshot identity; Point-in-time parity.
 
 **Incremental scope**: on the second and later passes within the same
 claim, scope the review to the diff since the previous E2's head SHA,

--- a/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-snapshot-lite.instructions.md
@@ -208,6 +208,15 @@ Run one critique pass on the branch's changes every E1-E3 pass — this is
 a deterministic "always run one" step, not a judgment call whether to
 run it. Add any newly found issues to ReviewItems_snapshot.
 
+Also apply these lenses when they fit, composing when both do:
+**Mutation/write-side** (the diff implements a helper that mutates
+GitHub state, mutates git state, or performs a merge) — fail-closed
+inputs; validate/execute scope parity; unsafe-output suppression;
+schema strictness parity. **Gate-mirroring** (the diff implements a
+helper that predicts, mirrors, or pre-checks another gate's decision) —
+validation-path parity; input completeness; whole-identity comparison;
+snapshot identity; point-in-time parity.
+
 **Incremental scope**: on the second and later passes within the same
 claim, scope the review to the diff since the previous E2's head SHA,
 tracked by the latest trusted same-claim `review-baseline` comment.

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -246,14 +246,18 @@ pass asks, never a separate pass to run on top of the one that ran.
    this pass's whole output, which is the duplicate cost `never` exists to
    avoid.
 6. If both ran, union their reported issues.
-7. Also apply these lenses to the diff when they fit, composing when both
-   do: **Mutation/write-side** (the diff implements a helper that mutates
-   GitHub state, mutates git state, or performs a merge) — fail-closed
-   inputs; validate/execute scope parity; unsafe-output suppression;
-   schema strictness parity. **Gate-mirroring** (the diff implements a
-   helper that predicts, mirrors, or pre-checks another gate's decision)
-   — validation-path parity; input completeness; whole-identity
-   comparison; snapshot identity; point-in-time parity.
+7. When the per-agent pass ran (step 3 or step 5), also apply these
+   lenses to the diff, composing when both fit: **Mutation / write-side**
+   (the diff implements a helper that mutates GitHub state, mutates git
+   state, or performs a merge) — Fail-closed inputs; Validate/execute
+   scope parity; Unsafe-output suppression; Schema strictness parity.
+   **Gate-mirroring** (the diff implements a helper that predicts,
+   mirrors, or pre-checks another gate's decision) — Validation-path
+   parity; Input completeness; Whole-identity comparison; Snapshot
+   identity; Point-in-time parity. When only the delegate ran (a
+   successful delegate under `fallback`, or any delegate under
+   `never`), it never sees these lenses either — do not apply them
+   yourself in its place.
 8. The floor (referenced in C2, C4, and C5) is `fix-validate` passing against
    the branch's current HEAD. Re-run it after every new commit; it does not
    substitute for D2's `pre-push-validate` gate.

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -246,7 +246,15 @@ pass asks, never a separate pass to run on top of the one that ran.
    this pass's whole output, which is the duplicate cost `never` exists to
    avoid.
 6. If both ran, union their reported issues.
-7. The floor (referenced in C2, C4, and C5) is `fix-validate` passing against
+7. Also apply these lenses to the diff when they fit, composing when both
+   do: **Mutation/write-side** (the diff implements a helper that mutates
+   GitHub state, mutates git state, or performs a merge) — fail-closed
+   inputs; validate/execute scope parity; unsafe-output suppression;
+   schema strictness parity. **Gate-mirroring** (the diff implements a
+   helper that predicts, mirrors, or pre-checks another gate's decision)
+   — validation-path parity; input completeness; whole-identity
+   comparison; snapshot identity; point-in-time parity.
+8. The floor (referenced in C2, C4, and C5) is `fix-validate` passing against
    the branch's current HEAD. Re-run it after every new commit; it does not
    substitute for D2's `pre-push-validate` gate.
 

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -246,18 +246,18 @@ pass asks, never a separate pass to run on top of the one that ran.
    this pass's whole output, which is the duplicate cost `never` exists to
    avoid.
 6. If both ran, union their reported issues.
-7. When the per-agent pass ran (step 3 or step 5), also apply these
-   lenses to the diff, composing when both fit: **Mutation / write-side**
+7. These lenses apply only within a per-agent pass (step 3 or step 5) —
+   when only the delegate ran instead (a successful delegate under
+   `fallback`, or any delegate under `never`), it never sees them, and
+   do not apply them yourself in its place. When a per-agent pass did
+   run, also apply, composing when both fit: **Mutation / write-side**
    (the diff implements a helper that mutates GitHub state, mutates git
    state, or performs a merge) — Fail-closed inputs; Validate/execute
    scope parity; Unsafe-output suppression; Schema strictness parity.
    **Gate-mirroring** (the diff implements a helper that predicts,
    mirrors, or pre-checks another gate's decision) — Validation-path
    parity; Input completeness; Whole-identity comparison; Snapshot
-   identity; Point-in-time parity. When only the delegate ran (a
-   successful delegate under `fallback`, or any delegate under
-   `never`), it never sees these lenses either — do not apply them
-   yourself in its place.
+   identity; Point-in-time parity.
 8. The floor (referenced in C2, C4, and C5) is `fix-validate` passing against
    the branch's current HEAD. Re-run it after every new commit; it does not
    substitute for D2's `pre-push-validate` gate.

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -1042,15 +1042,18 @@ critique findings; the C-phase objective diff validation floor above,
 the E-phase Copilot advisory-convergence policy, required checks, and
 merge gates are all unchanged.
 
-A configured delegate receives only the branch diff, never the two
-lenses below or the rest of the per-agent checklist — passing checklist
-content to an external command is a capability change with its own
-design questions (whether the reviewer accepts input at all, what
-happens if it ignores it) that this surface does not make today. Under
-a successful delegate with `mode: fallback` (the default), or under
-`mode: never`, the per-agent pass does not run at all, so an operator
-relying solely on a delegate should expect the lenses below are not
-applied to that PR's diff.
+The critique content passed to a configured delegate is the branch diff
+only — never the two lenses below or the rest of the per-agent
+checklist. (This is about what the delegate invocation sends as
+critique input, not a sandboxing guarantee on what the command can
+otherwise access — see the executable-configuration warning above.)
+Passing checklist content to an external command is a capability change
+with its own design questions (whether the reviewer accepts input at
+all, what happens if it ignores it) that this surface does not make
+today. Under a successful delegate with `mode: fallback` (the default),
+or under `mode: never`, the per-agent pass does not run at all, so an
+operator relying solely on a delegate should expect the lenses below
+are not applied to that PR's diff.
 
 ### Mutation / write-side helper lens
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -1042,6 +1042,16 @@ critique findings; the C-phase objective diff validation floor above,
 the E-phase Copilot advisory-convergence policy, required checks, and
 merge gates are all unchanged.
 
+A configured delegate receives only the branch diff, never the two
+lenses below or the rest of the per-agent checklist — passing checklist
+content to an external command is a capability change with its own
+design questions (whether the reviewer accepts input at all, what
+happens if it ignores it) that this surface does not make today. Under
+`mode: fallback` with a successful delegate (the default) or `mode:
+never`, the per-agent pass does not run at all, so an operator relying
+solely on a delegate should expect the lenses below are not applied to
+that PR's diff.
+
 ### Mutation / write-side helper lens
 
 When the diff under critique implements a helper that **mutates GitHub

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -1047,10 +1047,10 @@ lenses below or the rest of the per-agent checklist — passing checklist
 content to an external command is a capability change with its own
 design questions (whether the reviewer accepts input at all, what
 happens if it ignores it) that this surface does not make today. Under
-`mode: fallback` with a successful delegate (the default) or `mode:
-never`, the per-agent pass does not run at all, so an operator relying
-solely on a delegate should expect the lenses below are not applied to
-that PR's diff.
+a successful delegate with `mode: fallback` (the default), or under
+`mode: never`, the per-agent pass does not run at all, so an operator
+relying solely on a delegate should expect the lenses below are not
+applied to that PR's diff.
 
 ### Mutation / write-side helper lens
 


### PR DESCRIPTION
## Summary

Restates the two critique lenses (Mutation/write-side, Gate-mirroring)
inline in the three lite critique surfaces that never carried them —
lite C1 (`idd-work-lite.instructions.md`), lite E2
(`idd-review-snapshot-lite.instructions.md`), and lite E10
(`idd-review-fix-lite.instructions.md`) — in the condensed form the
lite profile uses elsewhere, per `docs/weak-model-lite-profile-design.md`
content principle 1 (no cross-file "see X" pointer for lite files).

Also documents in `docs/idd-workflow.md` (and its `idd-template/` source)
that a configured `critiqueLoop.delegate` receives only the branch diff,
never these lenses or the rest of the per-agent checklist — under `mode:
fallback` with a successful delegate (the default) or `mode: never`, the
per-agent pass does not run at all. Changing the delegate invocation
itself so it *does* receive the checklist is explicitly out of scope
(own design questions on whether an external reviewer accepts input at
all).

Closes #2337

## Bundle budget

Verified with `node scripts/audit-docs.mjs --check`: all lite bundle
budgets pass, including the two tight ones this change touches
(`bundle-review-snapshot-lite` and `bundle-review-fix-lite`, both under
their ceiling after this change; `bundle-review-fix-lite` sits at a
~95% notice, not a failure).

## Test plan

- [x] `pnpm test` — 4066/4066 pass
- [x] `pre-push-validate` (biome, dprint, markdownlint, cspell,
      `audit-docs.mjs --check`, `audit-code-span-wrap.mjs`,
      `build:check`, `idd-doctor.mjs`) — all pass
- [x] `node scripts/sync-docs.mjs --apply` — no drift after the
      `idd-template/` → live sync for the three exact-mode lite files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated review guidance to include mutation/write-side and gate-mirroring checks where applicable.
  * Clarified validation, schema, identity, snapshot, scope, and point-in-time consistency expectations.
  * Documented which review information is provided to delegates and when per-agent critique is skipped.
  * Updated the `fix-validate` step reference for consistency across workflow documentation and templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->