### PR TITLE
fix(resume-claim-routing): legacy_claim_seen reflects the wrong branch, not evidence

### DIFF
--- a/scripts/resume-claim-routing.mjs
+++ b/scripts/resume-claim-routing.mjs
@@ -244,7 +244,7 @@ export function evaluateResumeClaimRouting(input, options = {}) {
     evidence: {
       trusted_event_count: events.length,
       new_format_claim_seen: state.mode === 'new-format',
-      legacy_claim_seen: state.mode === 'legacy-only',
+      legacy_claim_seen: state.hasLegacyClaimMarker,
       same_second_contenders: sameSecondContenders,
       later_competing_claim: laterCompetingClaim,
       activation_nonce_winner: activationNonceWinner,
@@ -439,6 +439,15 @@ function resolveClaimState(events, nowIso, staleAgeMs, options = {}) {
     (event) =>
       parseClaimComment(event.body ?? '', event.createdAt ?? '') !== null,
   );
+  // hasLegacyClaimMarker records whether any legacy-format marker was ever
+  // posted, independent of whether the 'new-format' branch below ignores it
+  // in favor of a co-existing new-format claim (#2317's follow-up finding:
+  // `legacyClaim` alone conflates "no legacy marker existed" with "one
+  // existed but new-format priority skipped resolving it").
+  const hasLegacyClaimMarker = events.some(
+    (event) =>
+      parseLegacyClaimComment(event.body ?? '', event.createdAt ?? '') !== null,
+  );
   const warnings = [];
   const onAnomalousHeartbeat = ({ claimId, activeBranch, heartbeatBranch }) => {
     warnings.push(
@@ -493,6 +502,7 @@ function resolveClaimState(events, nowIso, staleAgeMs, options = {}) {
       warnings,
       legacyClaim: null,
       legacyReleased: false,
+      hasLegacyClaimMarker,
     };
   }
   const orderedEvents = [...events].sort(compareEvents);
@@ -504,6 +514,7 @@ function resolveClaimState(events, nowIso, staleAgeMs, options = {}) {
     warnings,
     legacyClaim: legacy.claim,
     legacyReleased: legacy.released,
+    hasLegacyClaimMarker,
   };
 }
 function resolveLegacyClaimState(orderedEvents, _nowIso, _staleAgeMs) {

--- a/src/scripts/resume-claim-routing.mts
+++ b/src/scripts/resume-claim-routing.mts
@@ -370,7 +370,7 @@ export function evaluateResumeClaimRouting(
     evidence: {
       trusted_event_count: events.length,
       new_format_claim_seen: state.mode === 'new-format',
-      legacy_claim_seen: state.mode === 'legacy-only',
+      legacy_claim_seen: state.hasLegacyClaimMarker,
       same_second_contenders: sameSecondContenders,
       later_competing_claim: laterCompetingClaim,
       activation_nonce_winner: activationNonceWinner,
@@ -613,6 +613,15 @@ function resolveClaimState(
     (event) =>
       parseClaimComment(event.body ?? '', event.createdAt ?? '') !== null,
   );
+  // hasLegacyClaimMarker records whether any legacy-format marker was ever
+  // posted, independent of whether the 'new-format' branch below ignores it
+  // in favor of a co-existing new-format claim (#2317's follow-up finding:
+  // `legacyClaim` alone conflates "no legacy marker existed" with "one
+  // existed but new-format priority skipped resolving it").
+  const hasLegacyClaimMarker = events.some(
+    (event) =>
+      parseLegacyClaimComment(event.body ?? '', event.createdAt ?? '') !== null,
+  );
 
   const warnings: string[] = [];
   const onAnomalousHeartbeat = ({
@@ -686,6 +695,7 @@ function resolveClaimState(
       warnings,
       legacyClaim: null,
       legacyReleased: false,
+      hasLegacyClaimMarker,
     };
   }
 
@@ -698,6 +708,7 @@ function resolveClaimState(
     warnings,
     legacyClaim: legacy.claim,
     legacyReleased: legacy.released,
+    hasLegacyClaimMarker,
   };
 }
 

--- a/tests/resume-claim-routing.test.mts
+++ b/tests/resume-claim-routing.test.mts
@@ -27,6 +27,7 @@ test('returns unclaimed when no trusted markers exist', () => {
   assert.equal(result.action, 're_claim');
   assert.equal(result.reason, 'legacy-absent');
   assert.equal(result.active_claim, null);
+  assert.equal(result.evidence.legacy_claim_seen, false);
 });
 
 test('returns already_owned when active claim id matches --claim-id', () => {
@@ -48,6 +49,33 @@ test('returns already_owned when active claim id matches --claim-id', () => {
   assert.equal(result.state, 'already_owned');
   assert.equal(result.action, 'keep');
   assert.equal(result.reason, 'claim-id-match');
+  assert.equal(result.evidence.legacy_claim_seen, false);
+});
+
+test('legacy_claim_seen is true when history has both marker formats, even though new-format wins routing', () => {
+  const result = evaluateResumeClaimRouting(
+    {
+      claimId: 'claim-def',
+      now: '2026-05-12T11:00:00Z',
+      events: [
+        {
+          createdAt: '2026-05-12T08:00:00Z',
+          author: { login: 'maintainer' },
+          body: '<!-- claimed-by: old-agent 2026-05-12T08:00:00Z branch: issue/9-task -->',
+        },
+        {
+          createdAt: '2026-05-12T09:00:00Z',
+          author: { login: 'maintainer' },
+          body: '<!-- claimed-by: copilot claim-def supersedes: none 2026-05-12T09:00:00Z branch: issue/9-task -->',
+        },
+      ],
+    },
+    { isTrustedAuthor: trusted(['maintainer']) },
+  );
+
+  assert.equal(result.state, 'already_owned');
+  assert.equal(result.evidence.new_format_claim_seen, true);
+  assert.equal(result.evidence.legacy_claim_seen, true);
 });
 
 test('activation-nonce: matching local nonce keeps already_owned', () => {
@@ -449,6 +477,7 @@ test('legacy non-stale claim is non_inheritable', () => {
   assert.equal(result.state, 'non_inheritable');
   assert.equal(result.action, 'stop');
   assert.equal(result.reason, 'legacy-claim-non-stale');
+  assert.equal(result.evidence.legacy_claim_seen, true);
 });
 
 test('legacy stale claim routes to takeover', () => {


### PR DESCRIPTION
# Summary

`evidence.legacy_claim_seen` in `resume-claim-routing.mjs --fresh-claim-gate`
output reported `state.mode === 'legacy-only'` — which internal
resolution branch ran — instead of whether a legacy-format
`claimed-by` marker was actually found. A comment-less issue (never
claimed by anyone, in any format) still fell through to the
`legacy-only` branch, so `legacy_claim_seen` reported `true` even
though no legacy claim existed at all.

Fixes it by tracking legacy-marker presence directly with the same raw
`events.some(parseLegacyClaimComment)` scan `new_format_claim_seen`'s
`hasNewFormatClaim` already uses, rather than reading it off the
*resolved* `legacyClaim` value — `legacyClaim` is unconditionally
`null` on the `'new-format'` branch even when a legacy marker also
exists in the same comment history (new-format priority skips
resolving it), so a first fix attempt using `state.legacyClaim !==
null` still under-reported `legacy_claim_seen` for that mixed-format
case (found by CodeRabbit's C1 self-review). `hasLegacyClaimMarker`
now threads through both `resolveClaimState` return branches
independent of which mode wins routing.

`fresh_claim_gate.verdict` is unaffected — this only touches the
diagnostic evidence field, not routing logic.

## Linked issue

Closes #2317

## Follow-up issues (if any)

- [ ] none

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4082 tests)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (not applicable — no docs changed)
- [ ] `node scripts/idd-doctor.mjs` (not applicable)

Additional: two rounds of the repository's CodeRabbit C1 critique
delegate. Round 1 found a real gap — `state.legacyClaim !== null`
under-reports `legacy_claim_seen` for a mixed-format history where a
new-format claim supersedes a legacy one; fixed with a dedicated
`hasLegacyClaimMarker` raw scan plus a regression test. Round 2: zero
findings.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (diagnostic-field fix only;
      `fresh_claim_gate.verdict` — the actual claim-safety decision —
      is unchanged and covered by all existing tests)
- [x] Context budget impact reviewed (`audit-docs.mjs --check` passed)
