### PR TITLE
fix(idd-merge): reorder F4 cleanup so WorkTrunk sees a fresh local main

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -459,7 +459,9 @@ Before any mutating action in F3, apply the
      rather than assuming a stale local `main` is the cause.
 
 5. If GitHub auto-delete is disabled: delete the remote branch too.
-   (WorkTrunk may be used for steps 3–5.)
+   (WorkTrunk may be used for steps 4–5, the deletion steps —
+   step 3's local `main` update is a plain git operation, not a
+   WorkTrunk one.)
 
 ## F5 — Loop
 

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -459,7 +459,7 @@ Before any mutating action in F3, apply the
      rather than assuming a stale local `main` is the cause.
 
 5. If GitHub auto-delete is disabled: delete the remote branch too.
-   (Worktrunk may be used for steps 3–5.)
+   (WorkTrunk may be used for steps 3–5.)
 
 ## F5 — Loop
 

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -406,7 +406,17 @@ Before any mutating action in F3, apply the
    See `docs/idd-comment-minimization.md` for the evidence comment
    format, cleanup-failure comment format, permission-blocked comment
    format, and fallback GraphQL commands.
-3. Run from the **primary worktree**, never from inside the worktree
+3. From the **primary worktree** — the worktree being cleaned up is
+   still checked out to its issue branch at this point, so running
+   this elsewhere would fast-forward the wrong branch — update local
+   `main` first: `git fetch origin main && git merge --ff-only
+   origin/main`. Doing this before worktree/branch deletion (next
+   step) ensures WorkTrunk's own merge-status check, which reads the
+   local default branch rather than `origin/main`, sees the
+   just-merged branch as already merged on its first attempt instead
+   of reporting `branch_outcome: retained_unmerged` and declining to
+   delete it (`#2331`).
+4. Run from the **primary worktree**, never from inside the worktree
    being removed. Any removal (plain or `--force`) silently discards
    ignored files too, including inside a submodule. Scope Git
    commands to `<path>`. Inspect leftover files under a `-`
@@ -436,13 +446,12 @@ Before any mutating action in F3, apply the
      with `git worktree remove --force <path>`. Use `--force` only
      after that review finds nothing worth preserving.
    - `git branch -d <branch-name>` (the baseline permission profile
-     denies `-D`; see `docs/permissions.md`). If it fails with `error:
-     the branch '<branch-name>' is not fully merged` despite the PR
-     being merged — `fetch --prune` can drop the remote-tracking ref
-     before local `main` fast-forwards — run step 4 first, then retry.
+     denies `-D`; see `docs/permissions.md`). Local `main` was already
+     fast-forwarded to the merge commit by the previous step, so this
+     should not fail with `error: the branch '<branch-name>' is not
+     fully merged`; if it still does, investigate before retrying
+     rather than assuming a stale local `main` is the cause.
 
-4. Update the local `main` branch (`git fetch origin main && git merge
-   --ff-only origin/main`).
 5. If GitHub auto-delete is disabled: delete the remote branch too.
    (Worktrunk may be used for steps 3–5.)
 

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -408,14 +408,20 @@ Before any mutating action in F3, apply the
    format, and fallback GraphQL commands.
 3. From the **primary worktree** — the worktree being cleaned up is
    still checked out to its issue branch at this point, so running
-   this elsewhere would fast-forward the wrong branch — update local
-   `main` first: `git fetch origin main && git merge --ff-only
-   origin/main`. Doing this before worktree/branch deletion (next
-   step) ensures WorkTrunk's own merge-status check, which reads the
-   local default branch rather than `origin/main`, sees the
-   just-merged branch as already merged on its first attempt instead
-   of reporting `branch_outcome: retained_unmerged` and declining to
-   delete it (`#2331`).
+   this elsewhere would fast-forward the wrong branch — switch to
+   `main` explicitly before fast-forwarding it, rather than assuming
+   it is already checked out there:
+
+   ```sh
+   git switch main && git fetch origin main && git merge --ff-only origin/main
+   ```
+
+   Doing this before worktree/branch deletion (next step) ensures
+   WorkTrunk's own merge-status check, which reads the local default
+   branch rather than `origin/main`, sees the just-merged branch as
+   already merged on its first attempt instead of reporting
+   `branch_outcome: retained_unmerged` and declining to delete it
+   (`#2331`).
 4. Run from the **primary worktree**, never from inside the worktree
    being removed. Any removal (plain or `--force`) silently discards
    ignored files too, including inside a submodule. Scope Git

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -401,7 +401,17 @@ Before any mutating action in F3, apply the
    See `docs/idd-comment-minimization.md` for the evidence comment
    format, cleanup-failure comment format, permission-blocked comment
    format, and fallback GraphQL commands.
-3. Run from the **primary worktree**, never from inside the worktree
+3. From the **primary worktree** — the worktree being cleaned up is
+   still checked out to its issue branch at this point, so running
+   this elsewhere would fast-forward the wrong branch — update local
+   `main` first: `git fetch origin main && git merge --ff-only
+   origin/main`. Doing this before worktree/branch deletion (next
+   step) ensures WorkTrunk's own merge-status check, which reads the
+   local default branch rather than `origin/main`, sees the
+   just-merged branch as already merged on its first attempt instead
+   of reporting `branch_outcome: retained_unmerged` and declining to
+   delete it (`#2331`).
+4. Run from the **primary worktree**, never from inside the worktree
    being removed. Any removal (plain or `--force`) silently discards
    ignored files too, including inside a submodule. Scope Git
    commands to `<path>`. Inspect leftover files under a `-`
@@ -431,13 +441,12 @@ Before any mutating action in F3, apply the
      with `git worktree remove --force <path>`. Use `--force` only
      after that review finds nothing worth preserving.
    - `git branch -d <branch-name>` (the baseline permission profile
-     denies `-D`; see `docs/permissions.md`). If it fails with `error:
-     the branch '<branch-name>' is not fully merged` despite the PR
-     being merged — `fetch --prune` can drop the remote-tracking ref
-     before local `main` fast-forwards — run step 4 first, then retry.
+     denies `-D`; see `docs/permissions.md`). Local `main` was already
+     fast-forwarded to the merge commit by the previous step, so this
+     should not fail with `error: the branch '<branch-name>' is not
+     fully merged`; if it still does, investigate before retrying
+     rather than assuming a stale local `main` is the cause.
 
-4. Update the local `main` branch (`git fetch origin main && git merge
-   --ff-only origin/main`).
 5. If GitHub auto-delete is disabled: delete the remote branch too.
    (Worktrunk may be used for steps 3–5.)
 

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -454,7 +454,9 @@ Before any mutating action in F3, apply the
      rather than assuming a stale local `main` is the cause.
 
 5. If GitHub auto-delete is disabled: delete the remote branch too.
-   (WorkTrunk may be used for steps 3–5.)
+   (WorkTrunk may be used for steps 4–5, the deletion steps —
+   step 3's local `main` update is a plain git operation, not a
+   WorkTrunk one.)
 
 ## F5 — Loop
 

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -454,7 +454,7 @@ Before any mutating action in F3, apply the
      rather than assuming a stale local `main` is the cause.
 
 5. If GitHub auto-delete is disabled: delete the remote branch too.
-   (Worktrunk may be used for steps 3–5.)
+   (WorkTrunk may be used for steps 3–5.)
 
 ## F5 — Loop
 

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -403,14 +403,20 @@ Before any mutating action in F3, apply the
    format, and fallback GraphQL commands.
 3. From the **primary worktree** — the worktree being cleaned up is
    still checked out to its issue branch at this point, so running
-   this elsewhere would fast-forward the wrong branch — update local
-   `main` first: `git fetch origin main && git merge --ff-only
-   origin/main`. Doing this before worktree/branch deletion (next
-   step) ensures WorkTrunk's own merge-status check, which reads the
-   local default branch rather than `origin/main`, sees the
-   just-merged branch as already merged on its first attempt instead
-   of reporting `branch_outcome: retained_unmerged` and declining to
-   delete it (`#2331`).
+   this elsewhere would fast-forward the wrong branch — switch to
+   `main` explicitly before fast-forwarding it, rather than assuming
+   it is already checked out there:
+
+   ```sh
+   git switch main && git fetch origin main && git merge --ff-only origin/main
+   ```
+
+   Doing this before worktree/branch deletion (next step) ensures
+   WorkTrunk's own merge-status check, which reads the local default
+   branch rather than `origin/main`, sees the just-merged branch as
+   already merged on its first attempt instead of reporting
+   `branch_outcome: retained_unmerged` and declining to delete it
+   (`#2331`).
 4. Run from the **primary worktree**, never from inside the worktree
    being removed. Any removal (plain or `--force`) silently discards
    ignored files too, including inside a submodule. Scope Git


### PR DESCRIPTION
# Summary

`idd-merge.instructions.md`'s F4 (Cleanup) ran worktree/branch
deletion (step 3) before the local `main` fast-forward (step 4). At
that point local `main` still points at the pre-merge commit —
GitHub's merge only landed on `origin/main`. WorkTrunk's own `wt
remove` (one of the two documented step-3 mechanisms) consults the
local default branch's freshness, not `origin/main`'s, so it reports
the just-merged branch as `branch_outcome: retained_unmerged` and
declines to delete it, even though the branch is provably merged on
the remote. An adopter (`kurone-kito/builder-config`, iddVersion
0.7.0) reproduced this twice in one session, each requiring a manual
`wt remove -D <branch>` fallback.

Reorders the two steps: fast-forward local `main` first, then delete
the worktree/branch. This makes WorkTrunk's merge-status check see an
up-to-date local `main` on its first attempt, for both the WorkTrunk
and manual `git worktree remove`/`git branch -d` paths.

## Linked issue

Closes #2331

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Plain `git branch -d` was already unaffected by this specific bug — it
checks the branch's own upstream tracking ref (set by this workflow's
own `git push -u origin <branch>` in D2), not the local default
branch WorkTrunk's own detection consults — so this is a
WorkTrunk-specific gap, not a general git-cleanup-ordering bug.

The reorder also surfaced a correctness note worth documenting inline:
the new step 3 (main fast-forward) must still run from the **primary**
worktree, not the worktree being cleaned up — at that point in the new
order, the issue worktree is still checked out to its own branch, so
running `git merge --ff-only origin/main` from there would fast-forward
the wrong branch. The old step 3's "run from the primary worktree"
caveat existed for a different reason (worktree-deletion safety) and
didn't need to say this, because by the time old step 4 ran, the other
worktree no longer existed to be a hazard.

The old branch-delete retry sentence ("if it fails with `not fully
merged`... run step 4 first, then retry") targeted a narrower,
different symptom (`fetch --prune` dropping the remote-tracking ref
before local `main` advanced) than the WorkTrunk bug this issue closes.
That symptom becomes structurally unreachable once `main` is
guaranteed fresh before branch deletion runs, so per the issue's own
instruction to replace rather than append to it, it's replaced with a
note that a failure there now means something else is wrong, not a
stale local `main`.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4082 tests)
- [x] `node scripts/audit-docs.mjs --check` (including the
      `bundle-merge` byte-budget check)
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (not applicable)

Additional: one round of the repository's CodeRabbit C1 critique
delegate — zero findings.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (F4 cleanup-mechanics reorder only;
      no change to any merge gate or F3 decision logic)
- [x] Context budget impact reviewed (`audit-docs.mjs --check` passed;
      `bundle-merge` stays under its byte limit)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated merge cleanup guidance to update the local `main` branch before removing merged worktrees and branches.
  * Clarified that “not fully merged” deletion errors require investigation rather than a later branch update.
  * Applied the guidance consistently across both instruction sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->