### PR TITLE
fix(marker-helpers): guard isValidIsoTimestamp against a TypeError

### DIFF
--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -1281,6 +1281,7 @@ function isValidForcedHandoffOperationalMarker(body) {
   return parseForcedHandoffComment(body, '') !== null;
 }
 export function isValidIsoTimestamp(value) {
+  if (typeof value !== 'string') return false;
   const time = Date.parse(value);
   if (!Number.isFinite(time)) return false;
   const normalize = (ts) => ts.replace('.000Z', 'Z');

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -1713,8 +1713,9 @@ function isValidForcedHandoffOperationalMarker(body: string): boolean {
 }
 
 export function isValidIsoTimestamp(value: unknown): value is string {
-  const time = Date.parse(value as string);
+  if (typeof value !== 'string') return false;
+  const time = Date.parse(value);
   if (!Number.isFinite(time)) return false;
   const normalize = (ts: string) => ts.replace('.000Z', 'Z');
-  return normalize(new Date(time).toISOString()) === normalize(value as string);
+  return normalize(new Date(time).toISOString()) === normalize(value);
 }

--- a/tests/marker-helpers-timestamp.test.mts
+++ b/tests/marker-helpers-timestamp.test.mts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { isValidIsoTimestamp } from '../src/scripts/marker-helpers.mts';
+
+// #2215: Date.parse coerces its argument, and a narrow band of numeric
+// values (small integers Date.parse happens to interpret as a valid
+// date/year) reached the .replace(...) call on a number instead of a
+// string, throwing instead of returning false.
+test('isValidIsoTimestamp never throws for non-string input, including the numeric band Date.parse coerces to a valid date', () => {
+  for (const value of [123, 2024, 1700000000000, null, undefined, {}, []]) {
+    assert.doesNotThrow(() => isValidIsoTimestamp(value));
+    assert.equal(isValidIsoTimestamp(value), false);
+  }
+});
+
+test('isValidIsoTimestamp still accepts a well-formed ISO-8601 UTC string', () => {
+  assert.equal(isValidIsoTimestamp('2026-01-01T00:00:00Z'), true);
+});
+
+test('isValidIsoTimestamp still rejects a malformed string', () => {
+  assert.equal(isValidIsoTimestamp('not-a-timestamp'), false);
+  assert.equal(isValidIsoTimestamp(''), false);
+});


### PR DESCRIPTION
## Summary

- `isValidIsoTimestamp` is typed as `(value: unknown): value is string`,
  signaling it should safely reject any non-string input, but its body
  called `Date.parse(value as string)` before checking the result --
  `Date.parse` coerces its argument, and a narrow band of non-string
  values (small integers such as `123` or `2024`) parse to a finite
  timestamp instead of `NaN`, so execution reached `.replace(...)` on a
  number and threw `TypeError: ts.replace is not a function`.
- Added an explicit `typeof value !== 'string'` guard at the top,
  returning `false` immediately for any non-string input before calling
  `Date.parse`. Other non-string inputs (`null`, `undefined`, objects,
  arrays, larger numeric timestamps) already returned `false` correctly
  via the existing `Number.isFinite` check -- the defect was specific to
  this narrow numeric band.
- New dedicated test file (no prior direct unit-test coverage existed
  for this function) covering the reported TypeError inputs plus
  existing string-input behavior (no regression).

Closes #2215

## Test plan

- [x] `node --test tests/*.test.mts` (4144 pass)
- [x] `pnpm run typecheck`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `pnpm run build:check` (generated `.mjs` matches `.mts` sources)
- [x] `node scripts/idd-doctor.mjs` (passed, pre-existing unrelated warnings only)
- [x] Verified the reported TypeError empirically against the
      pre-fix implementation before and after the change