### PR TITLE
fix(idd-onboard): confine --source/--target to a known root

### DIFF
--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -50,7 +50,7 @@ import {
   statSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import {
   collectHelperRuntimeEvidence,
   collectVendoredFiles,
@@ -885,7 +885,15 @@ function isSafeRelativePath(relativePath) {
 /** Whether `candidate` is `boundary` itself or nested under it. */
 function isWithinBoundary(candidate, boundary) {
   const rel = relative(boundary, candidate);
-  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+  // Only an exact ".." segment or a "../"-prefixed path climbs out of
+  // `boundary` -- `rel.startsWith('..')` alone is too broad: a real child
+  // directory literally named e.g. "..foo" also produces a relative()
+  // string starting with "..", which is not a traversal at all (#2357
+  // review).
+  return (
+    rel === '' ||
+    (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel))
+  );
 }
 /**
  * Resolve `raw` (a `--source` / `--target` / `--allow-root` value) to an

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -46,10 +46,11 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   statSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname, join, relative, resolve } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 import {
   collectHelperRuntimeEvidence,
   collectVendoredFiles,
@@ -881,6 +882,50 @@ function isSafeRelativePath(relativePath) {
     .split('/')
     .every((segment) => segment !== '' && segment !== '.' && segment !== '..');
 }
+/** Whether `candidate` is `boundary` itself or nested under it. */
+function isWithinBoundary(candidate, boundary) {
+  const rel = relative(boundary, candidate);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+/**
+ * Resolve `raw` (a `--source` / `--target` / `--allow-root` value) to an
+ * existing directory, confined to the current working directory or one of
+ * `allowedRoots` (#2216). `idd-onboard` is designed for unattended
+ * dispatch, not only an interactive human operator typing the value
+ * first -- an unconfined root lets the process read from or write to any
+ * path it can reach. Confinement is in addition to, not a replacement
+ * for, `isSafeRelativePath`'s existing per-manifest-entry traversal
+ * protection below the resolved root.
+ *
+ * Confinement compares REALPATHs (symlinks resolved), not the raw
+ * `resolve()`d path, so a symlink that points outside every boundary is
+ * caught even when the symlink's own location is nested inside one.
+ * The returned path is the plain `resolve()`d value (unchanged from
+ * pre-#2216 behavior) -- only the confinement check itself resolves
+ * symlinks.
+ */
+export function resolveConfinedDirectory(raw, flagName, allowedRoots) {
+  const resolved = resolve(raw);
+  if (!statSync(resolved).isDirectory()) {
+    throw new Error(`${flagName} is not a directory: ${raw}`);
+  }
+  const realResolved = realpathSync(resolved);
+  const boundaries = [process.cwd(), ...allowedRoots].map((root) => {
+    try {
+      return realpathSync(resolve(root));
+    } catch {
+      throw new Error(`--allow-root does not exist: ${root}`);
+    }
+  });
+  if (
+    !boundaries.some((boundary) => isWithinBoundary(realResolved, boundary))
+  ) {
+    throw new Error(
+      `${flagName} resolves outside the confined root(s) (${boundaries.join(', ')}): ${raw} -> ${realResolved}. Pass --allow-root <path> to widen the confined root.`,
+    );
+  }
+  return resolved;
+}
 /**
  * Validate both sides of a manifest file entry with `isSafeRelativePath`
  * and return it unchanged, or throw a hard, fail-closed error naming
@@ -1470,10 +1515,11 @@ function runHearApplyCli(catalog, answersPath) {
   process.exit(0);
 }
 async function runHearCli(args) {
-  const targetDir = resolve(args.target);
-  if (!statSync(targetDir).isDirectory()) {
-    throw new Error(`--target is not a directory: ${args.target}`);
-  }
+  const targetDir = resolveConfinedDirectory(
+    args.target,
+    '--target',
+    args.allowRoots,
+  );
   if (args.propose && args.apply) {
     throw new Error(
       '--hear --propose and --hear --apply are mutually exclusive',
@@ -1788,10 +1834,11 @@ function runRecordPolicyCli(args) {
   if (!args.transcript) {
     throw new Error('--record-policy requires --transcript <file>');
   }
-  const targetDir = resolve(args.target);
-  if (!statSync(targetDir).isDirectory()) {
-    throw new Error(`--target is not a directory: ${args.target}`);
-  }
+  const targetDir = resolveConfinedDirectory(
+    args.target,
+    '--target',
+    args.allowRoots,
+  );
   const configPath = join(targetDir, '.github', 'idd', 'config.json');
   if (!existsSync(configPath)) {
     throw new Error(
@@ -1922,6 +1969,7 @@ function parseArgs(argv) {
     profile: undefined,
     overrides: {},
     help: false,
+    allowRoots: [],
   };
   const flagToName = new Map(
     ONBOARDING_PLACEHOLDERS.map((entry) => [entry.flag, entry.name]),
@@ -2003,6 +2051,11 @@ function parseArgs(argv) {
     }
     if (token === '--profile') {
       parsed.profile = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === '--allow-root') {
+      parsed.allowRoots.push(requireValue());
       index += 1;
       continue;
     }
@@ -2200,10 +2253,11 @@ async function runCli() {
       `--substitute does not accept import-only flag(s), --hear-only flag(s), or --record-policy-only flag(s): ${foreign.join(', ')}`,
     );
   }
-  const targetDir = resolve(args.target);
-  if (!statSync(targetDir).isDirectory()) {
-    throw new Error(`--target is not a directory: ${args.target}`);
-  }
+  const targetDir = resolveConfinedDirectory(
+    args.target,
+    '--target',
+    args.allowRoots,
+  );
   let transcriptOverrides = {};
   if (args.fromTranscript !== undefined) {
     const result = readAndValidateTranscript(args.fromTranscript);
@@ -2266,14 +2320,16 @@ function runImportCli(args) {
   if (!args.source) {
     throw new Error('--import requires --source <idd-skill-tree>');
   }
-  const sourceDir = resolve(args.source);
-  if (!statSync(sourceDir).isDirectory()) {
-    throw new Error(`--source is not a directory: ${args.source}`);
-  }
-  const targetDir = resolve(args.target);
-  if (!statSync(targetDir).isDirectory()) {
-    throw new Error(`--target is not a directory: ${args.target}`);
-  }
+  const sourceDir = resolveConfinedDirectory(
+    args.source,
+    '--source',
+    args.allowRoots,
+  );
+  const targetDir = resolveConfinedDirectory(
+    args.target,
+    '--target',
+    args.allowRoots,
+  );
   // Snapshot before the copy: --import always overwrites
   // .github/idd/config.json byte-for-byte from source (#2222), so a
   // re-import's already-customized commands table must be captured now,
@@ -2320,14 +2376,16 @@ function runVerifyCli(args) {
   if (!args.source) {
     throw new Error('--verify requires --source <idd-skill-tree>');
   }
-  const sourceDir = resolve(args.source);
-  if (!statSync(sourceDir).isDirectory()) {
-    throw new Error(`--source is not a directory: ${args.source}`);
-  }
-  const targetDir = resolve(args.target);
-  if (!statSync(targetDir).isDirectory()) {
-    throw new Error(`--target is not a directory: ${args.target}`);
-  }
+  const sourceDir = resolveConfinedDirectory(
+    args.source,
+    '--source',
+    args.allowRoots,
+  );
+  const targetDir = resolveConfinedDirectory(
+    args.target,
+    '--target',
+    args.allowRoots,
+  );
   const result = runVerify(sourceDir, targetDir, args.profile);
   const verdict = {
     protocolVersion: '1',
@@ -2381,6 +2439,10 @@ in that case); 2 usage or configuration error.
 
   --substitute         run the substitution stage
   --target <dir>       target tree to rewrite (default: current directory)
+  --allow-root <dir>   additionally confine --target to this root, on top
+                       of the current working directory (#2216); repeat
+                       for more than one. Required only when --target
+                       resolves outside both
   --from-transcript <file>
                        read placeholder answers from a confirmed --hear
                        transcript (mapsToPlaceholder items); an explicit
@@ -2412,6 +2474,10 @@ nothing in that case); 2 usage or configuration error.
   --import                          run the import stage
   --source <dir>                    local idd-skill source tree to copy from
   --target <dir>                    target repository (default: current directory)
+  --allow-root <dir>                additionally confine --source / --target
+                                     to this root, on top of the current
+                                     working directory (#2216); repeat for
+                                     more than one
   --profile <name>                  ${PROFILE_NAMES.join(' | ')}
   --force                           allow overwriting a differing target file
   --dry-run                         print the plan without writing anything
@@ -2434,6 +2500,10 @@ or placeholder residue); 2 usage or configuration error.
   --verify                           run the verify stage
   --source <dir>                     local idd-skill source tree the target was imported from
   --target <dir>                     target repository to verify (default: current directory)
+  --allow-root <dir>                 additionally confine --source / --target
+                                      to this root, on top of the current
+                                      working directory (#2216); repeat for
+                                      more than one
   --profile <name>                   ${PROFILE_NAMES.join(' | ')}
   --help, -h                         show this help
 
@@ -2468,6 +2538,9 @@ never writes .github/idd/config.json, never requires --source.
                                shape as --apply. Exit 2 when stdin/stdout
                                is not a TTY.
   --target <dir>               target repository (default: current directory)
+  --allow-root <dir>           additionally confine --target to this root,
+                               on top of the current working directory
+                               (#2216); repeat for more than one
   --answers <file>              path to the --apply answers JSON file
   --help, -h                    show this help
 
@@ -2497,6 +2570,9 @@ AGENTS.md, or GEMINI.md.
                                <path> (--apply only); without this flag the
                                template is stdout-only.
   --target <dir>               target repository (default: current directory)
+  --allow-root <dir>           additionally confine --target to this root,
+                               on top of the current working directory
+                               (#2216); repeat for more than one
   --transcript <file>          path to the confirmed --hear transcript
   --help, -h                    show this help
 `);

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -51,7 +51,7 @@ import {
   statSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 
 import {
   collectHelperRuntimeEvidence,
@@ -1086,7 +1086,15 @@ function isSafeRelativePath(relativePath: string): boolean {
 /** Whether `candidate` is `boundary` itself or nested under it. */
 function isWithinBoundary(candidate: string, boundary: string): boolean {
   const rel = relative(boundary, candidate);
-  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+  // Only an exact ".." segment or a "../"-prefixed path climbs out of
+  // `boundary` -- `rel.startsWith('..')` alone is too broad: a real child
+  // directory literally named e.g. "..foo" also produces a relative()
+  // string starting with "..", which is not a traversal at all (#2357
+  // review).
+  return (
+    rel === '' ||
+    (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel))
+  );
 }
 
 /**

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -47,10 +47,11 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   statSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname, join, relative, resolve } from 'node:path';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
 
 import {
   collectHelperRuntimeEvidence,
@@ -1082,6 +1083,56 @@ function isSafeRelativePath(relativePath: string): boolean {
     .every((segment) => segment !== '' && segment !== '.' && segment !== '..');
 }
 
+/** Whether `candidate` is `boundary` itself or nested under it. */
+function isWithinBoundary(candidate: string, boundary: string): boolean {
+  const rel = relative(boundary, candidate);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+/**
+ * Resolve `raw` (a `--source` / `--target` / `--allow-root` value) to an
+ * existing directory, confined to the current working directory or one of
+ * `allowedRoots` (#2216). `idd-onboard` is designed for unattended
+ * dispatch, not only an interactive human operator typing the value
+ * first -- an unconfined root lets the process read from or write to any
+ * path it can reach. Confinement is in addition to, not a replacement
+ * for, `isSafeRelativePath`'s existing per-manifest-entry traversal
+ * protection below the resolved root.
+ *
+ * Confinement compares REALPATHs (symlinks resolved), not the raw
+ * `resolve()`d path, so a symlink that points outside every boundary is
+ * caught even when the symlink's own location is nested inside one.
+ * The returned path is the plain `resolve()`d value (unchanged from
+ * pre-#2216 behavior) -- only the confinement check itself resolves
+ * symlinks.
+ */
+export function resolveConfinedDirectory(
+  raw: string,
+  flagName: string,
+  allowedRoots: string[],
+): string {
+  const resolved = resolve(raw);
+  if (!statSync(resolved).isDirectory()) {
+    throw new Error(`${flagName} is not a directory: ${raw}`);
+  }
+  const realResolved = realpathSync(resolved);
+  const boundaries = [process.cwd(), ...allowedRoots].map((root) => {
+    try {
+      return realpathSync(resolve(root));
+    } catch {
+      throw new Error(`--allow-root does not exist: ${root}`);
+    }
+  });
+  if (
+    !boundaries.some((boundary) => isWithinBoundary(realResolved, boundary))
+  ) {
+    throw new Error(
+      `${flagName} resolves outside the confined root(s) (${boundaries.join(', ')}): ${raw} -> ${realResolved}. Pass --allow-root <path> to widen the confined root.`,
+    );
+  }
+  return resolved;
+}
+
 /**
  * Validate both sides of a manifest file entry with `isSafeRelativePath`
  * and return it unchanged, or throw a hard, fail-closed error naming
@@ -1879,10 +1930,11 @@ function runHearApplyCli(
 }
 
 async function runHearCli(args: ParsedArgs): Promise<void> {
-  const targetDir = resolve(args.target);
-  if (!statSync(targetDir).isDirectory()) {
-    throw new Error(`--target is not a directory: ${args.target}`);
-  }
+  const targetDir = resolveConfinedDirectory(
+    args.target,
+    '--target',
+    args.allowRoots,
+  );
   if (args.propose && args.apply) {
     throw new Error(
       '--hear --propose and --hear --apply are mutually exclusive',
@@ -2253,10 +2305,11 @@ function runRecordPolicyCli(args: ParsedArgs): void {
   if (!args.transcript) {
     throw new Error('--record-policy requires --transcript <file>');
   }
-  const targetDir = resolve(args.target);
-  if (!statSync(targetDir).isDirectory()) {
-    throw new Error(`--target is not a directory: ${args.target}`);
-  }
+  const targetDir = resolveConfinedDirectory(
+    args.target,
+    '--target',
+    args.allowRoots,
+  );
   const configPath = join(targetDir, '.github', 'idd', 'config.json');
   if (!existsSync(configPath)) {
     throw new Error(
@@ -2385,6 +2438,8 @@ interface ParsedArgs {
   profile: string | undefined;
   overrides: PlaceholderOverrides;
   help: boolean;
+  /** #2216: additional confinement roots for --source / --target. */
+  allowRoots: string[];
 }
 
 // Excluded from the #1446 cli-args.mts wrapper: the placeholder-override
@@ -2412,6 +2467,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     profile: undefined,
     overrides: {},
     help: false,
+    allowRoots: [],
   };
   const flagToName = new Map(
     ONBOARDING_PLACEHOLDERS.map((entry) => [entry.flag, entry.name]),
@@ -2493,6 +2549,11 @@ function parseArgs(argv: string[]): ParsedArgs {
     }
     if (token === '--profile') {
       parsed.profile = requireValue();
+      index += 1;
+      continue;
+    }
+    if (token === '--allow-root') {
+      parsed.allowRoots.push(requireValue());
       index += 1;
       continue;
     }
@@ -2697,10 +2758,11 @@ async function runCli(): Promise<void> {
       `--substitute does not accept import-only flag(s), --hear-only flag(s), or --record-policy-only flag(s): ${foreign.join(', ')}`,
     );
   }
-  const targetDir = resolve(args.target);
-  if (!statSync(targetDir).isDirectory()) {
-    throw new Error(`--target is not a directory: ${args.target}`);
-  }
+  const targetDir = resolveConfinedDirectory(
+    args.target,
+    '--target',
+    args.allowRoots,
+  );
   let transcriptOverrides: PlaceholderOverrides = {};
   if (args.fromTranscript !== undefined) {
     const result = readAndValidateTranscript(args.fromTranscript);
@@ -2764,14 +2826,16 @@ function runImportCli(args: ParsedArgs): void {
   if (!args.source) {
     throw new Error('--import requires --source <idd-skill-tree>');
   }
-  const sourceDir = resolve(args.source);
-  if (!statSync(sourceDir).isDirectory()) {
-    throw new Error(`--source is not a directory: ${args.source}`);
-  }
-  const targetDir = resolve(args.target);
-  if (!statSync(targetDir).isDirectory()) {
-    throw new Error(`--target is not a directory: ${args.target}`);
-  }
+  const sourceDir = resolveConfinedDirectory(
+    args.source,
+    '--source',
+    args.allowRoots,
+  );
+  const targetDir = resolveConfinedDirectory(
+    args.target,
+    '--target',
+    args.allowRoots,
+  );
   // Snapshot before the copy: --import always overwrites
   // .github/idd/config.json byte-for-byte from source (#2222), so a
   // re-import's already-customized commands table must be captured now,
@@ -2819,14 +2883,16 @@ function runVerifyCli(args: ParsedArgs): void {
   if (!args.source) {
     throw new Error('--verify requires --source <idd-skill-tree>');
   }
-  const sourceDir = resolve(args.source);
-  if (!statSync(sourceDir).isDirectory()) {
-    throw new Error(`--source is not a directory: ${args.source}`);
-  }
-  const targetDir = resolve(args.target);
-  if (!statSync(targetDir).isDirectory()) {
-    throw new Error(`--target is not a directory: ${args.target}`);
-  }
+  const sourceDir = resolveConfinedDirectory(
+    args.source,
+    '--source',
+    args.allowRoots,
+  );
+  const targetDir = resolveConfinedDirectory(
+    args.target,
+    '--target',
+    args.allowRoots,
+  );
   const result = runVerify(sourceDir, targetDir, args.profile);
   const verdict = {
     protocolVersion: '1',
@@ -2881,6 +2947,10 @@ in that case); 2 usage or configuration error.
 
   --substitute         run the substitution stage
   --target <dir>       target tree to rewrite (default: current directory)
+  --allow-root <dir>   additionally confine --target to this root, on top
+                       of the current working directory (#2216); repeat
+                       for more than one. Required only when --target
+                       resolves outside both
   --from-transcript <file>
                        read placeholder answers from a confirmed --hear
                        transcript (mapsToPlaceholder items); an explicit
@@ -2912,6 +2982,10 @@ nothing in that case); 2 usage or configuration error.
   --import                          run the import stage
   --source <dir>                    local idd-skill source tree to copy from
   --target <dir>                    target repository (default: current directory)
+  --allow-root <dir>                additionally confine --source / --target
+                                     to this root, on top of the current
+                                     working directory (#2216); repeat for
+                                     more than one
   --profile <name>                  ${PROFILE_NAMES.join(' | ')}
   --force                           allow overwriting a differing target file
   --dry-run                         print the plan without writing anything
@@ -2934,6 +3008,10 @@ or placeholder residue); 2 usage or configuration error.
   --verify                           run the verify stage
   --source <dir>                     local idd-skill source tree the target was imported from
   --target <dir>                     target repository to verify (default: current directory)
+  --allow-root <dir>                 additionally confine --source / --target
+                                      to this root, on top of the current
+                                      working directory (#2216); repeat for
+                                      more than one
   --profile <name>                   ${PROFILE_NAMES.join(' | ')}
   --help, -h                         show this help
 
@@ -2968,6 +3046,9 @@ never writes .github/idd/config.json, never requires --source.
                                shape as --apply. Exit 2 when stdin/stdout
                                is not a TTY.
   --target <dir>               target repository (default: current directory)
+  --allow-root <dir>           additionally confine --target to this root,
+                               on top of the current working directory
+                               (#2216); repeat for more than one
   --answers <file>              path to the --apply answers JSON file
   --help, -h                    show this help
 
@@ -2997,6 +3078,9 @@ AGENTS.md, or GEMINI.md.
                                <path> (--apply only); without this flag the
                                template is stdout-only.
   --target <dir>               target repository (default: current directory)
+  --allow-root <dir>           additionally confine --target to this root,
+                               on top of the current working directory
+                               (#2216); repeat for more than one
   --transcript <file>          path to the confirmed --hear transcript
   --help, -h                    show this help
 `);

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -15,7 +15,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import {
@@ -44,6 +44,7 @@ import {
   ONBOARDING_PLACEHOLDERS,
   parseRemoteRepoRef,
   readExistingCommandsTable,
+  resolveConfinedDirectory,
   resolveCoreTemplateFiles,
   resolveImportFiles,
   resolvePlaceholderValues,
@@ -1544,9 +1545,18 @@ function runCliBin(args: string[]): {
   verdict: Record<string, unknown>;
 } {
   try {
-    const stdout = execFileSync(process.execPath, [BIN_PATH, ...args], {
-      encoding: 'utf8',
-    });
+    // #2216: every makeFixtureDir() root lives under the OS tmpdir, outside
+    // this test process's own cwd (REPO_ROOT) -- widen the confined root so
+    // existing fixture-based invocations keep working unchanged. A test
+    // exercising the confinement rejection itself spawns the CLI directly,
+    // bypassing this helper.
+    const stdout = execFileSync(
+      process.execPath,
+      [BIN_PATH, ...args, '--allow-root', tmpdir()],
+      {
+        encoding: 'utf8',
+      },
+    );
     return {
       status: 0,
       verdict: JSON.parse(stdout) as Record<string, unknown>,
@@ -1833,6 +1843,8 @@ test('bin/idd-onboard.mjs --import --force preserves a customized commands table
     REPO_ROOT,
     '--target',
     targetRoot,
+    '--allow-root',
+    tmpdir(),
   ]);
   execFileSync(process.execPath, [
     BIN_PATH,
@@ -1853,6 +1865,8 @@ test('bin/idd-onboard.mjs --import --force preserves a customized commands table
     'npx biome check --write (customized)',
     '--install-deps-command',
     'npm install',
+    '--allow-root',
+    tmpdir(),
   ]);
 
   const { status, verdict } = runCliBin([
@@ -2411,6 +2425,8 @@ test('bin/idd-onboard.mjs --verify exits 2 on an unknown --profile value', () =>
         targetRoot,
         '--profile',
         'not-a-real-profile',
+        '--allow-root',
+        tmpdir(),
       ],
       { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
     );
@@ -2698,10 +2714,14 @@ test('bin/idd-onboard.mjs rejects --hear-only flags (--propose, --apply, --answe
 test('bin/idd-onboard.mjs --hear exits 2 in a non-TTY context, without --propose or --apply', () => {
   const root = makeFixtureDir();
   try {
-    execFileSync(process.execPath, [BIN_PATH, '--hear', '--target', root], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+    execFileSync(
+      process.execPath,
+      [BIN_PATH, '--hear', '--target', root, '--allow-root', tmpdir()],
+      {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
     assert.fail('expected a non-zero exit');
   } catch (error) {
     const failed = error as { status?: number; stderr?: string };
@@ -3773,4 +3793,146 @@ test('bin/idd-onboard.mjs --help documents --record-policy, --transcript, and --
   assert.match(help, /--transcript/);
   assert.match(help, /--write-policy-doc/);
   assert.match(help, /--from-transcript/);
+});
+
+// ---------------------------------------------------------------------------
+// #2216: resolveConfinedDirectory (--source / --target path confinement)
+// ---------------------------------------------------------------------------
+
+// Every scenario runs with cwd temporarily pointed at a freshly
+// mkdtempSync-created sandbox (never the real repo cwd), mirroring the
+// sandboxing idd-config.test.mts's withSandboxCwd already uses.
+function withSandboxCwd<T>(run: (sandbox: string) => T): T {
+  const originalCwd = process.cwd();
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-onboard-confine-'));
+  process.chdir(sandbox);
+  try {
+    return run(sandbox);
+  } finally {
+    process.chdir(originalCwd);
+  }
+}
+
+test('resolveConfinedDirectory accepts a relative path that resolves inside the working directory', () => {
+  withSandboxCwd((sandbox) => {
+    mkdirSync(join(sandbox, 'nested'));
+    const resolved = resolveConfinedDirectory('nested', '--target', []);
+    assert.equal(resolved, join(sandbox, 'nested'));
+  });
+});
+
+test('resolveConfinedDirectory accepts the working directory itself', () => {
+  withSandboxCwd((sandbox) => {
+    assert.equal(resolveConfinedDirectory('.', '--target', []), sandbox);
+  });
+});
+
+test('resolveConfinedDirectory rejects a --target using ../ traversal that escapes the working directory', () => {
+  withSandboxCwd((sandbox) => {
+    const outside = mkdtempSync(join(tmpdir(), 'idd-onboard-outside-'));
+    const traversal = relative(sandbox, outside);
+    assert.throws(
+      () => resolveConfinedDirectory(traversal, '--target', []),
+      /--target resolves outside the confined root/,
+    );
+  });
+});
+
+test('resolveConfinedDirectory rejects an absolute path outside the confined root', () => {
+  withSandboxCwd(() => {
+    const outside = mkdtempSync(join(tmpdir(), 'idd-onboard-outside-'));
+    assert.throws(
+      () => resolveConfinedDirectory(outside, '--source', []),
+      /--source resolves outside the confined root/,
+    );
+  });
+});
+
+test('resolveConfinedDirectory rejects a symlink that resolves outside the confined root', () => {
+  withSandboxCwd((sandbox) => {
+    const outside = mkdtempSync(join(tmpdir(), 'idd-onboard-outside-'));
+    const link = join(sandbox, 'link-out');
+    symlinkSync(outside, link, 'dir');
+    assert.throws(
+      () => resolveConfinedDirectory('link-out', '--target', []),
+      /--target resolves outside the confined root/,
+    );
+  });
+});
+
+test('resolveConfinedDirectory accepts a path outside the working directory when covered by --allow-root', () => {
+  withSandboxCwd(() => {
+    const outside = mkdtempSync(join(tmpdir(), 'idd-onboard-outside-'));
+    const resolved = resolveConfinedDirectory(outside, '--target', [outside]);
+    assert.equal(resolved, resolve(outside));
+  });
+});
+
+test('resolveConfinedDirectory accepts a nested path under an --allow-root root', () => {
+  withSandboxCwd(() => {
+    const outside = mkdtempSync(join(tmpdir(), 'idd-onboard-outside-'));
+    const nested = join(outside, 'nested');
+    mkdirSync(nested);
+    const resolved = resolveConfinedDirectory(nested, '--target', [outside]);
+    assert.equal(resolved, nested);
+  });
+});
+
+test('resolveConfinedDirectory rejects a nonexistent --allow-root with a clear error', () => {
+  withSandboxCwd((sandbox) => {
+    const missing = join(sandbox, 'does-not-exist');
+    assert.throws(
+      () => resolveConfinedDirectory('.', '--target', [missing]),
+      /--allow-root does not exist/,
+    );
+  });
+});
+
+test('resolveConfinedDirectory still rejects a --target that is not a directory at all', () => {
+  withSandboxCwd((sandbox) => {
+    const file = join(sandbox, 'not-a-dir');
+    writeFileSync(file, 'x');
+    assert.throws(
+      () => resolveConfinedDirectory(file, '--target', []),
+      /--target is not a directory/,
+    );
+  });
+});
+
+test('bin/idd-onboard.mjs --import rejects a --target outside the confined root, with a clear error and exit 2', () => {
+  const outside = makeFixtureDir();
+  try {
+    execFileSync(
+      process.execPath,
+      [BIN_PATH, '--import', '--source', REPO_ROOT, '--target', outside],
+      { encoding: 'utf8', cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'pipe'] },
+    );
+    assert.fail('expected a non-zero exit');
+  } catch (error) {
+    const failed = error as { status?: number; stderr?: string };
+    assert.equal(failed.status, 2);
+    assert.match(
+      String(failed.stderr),
+      /--target resolves outside the confined root/,
+    );
+  }
+});
+
+test('bin/idd-onboard.mjs --import accepts a --target outside cwd once covered by --allow-root', () => {
+  const { status, verdict } = runCliBin([
+    '--import',
+    '--source',
+    REPO_ROOT,
+    '--target',
+    makeFixtureDir(),
+  ]);
+  assert.equal(status, 0);
+  assert.equal(typeof verdict.target, 'string');
+});
+
+test('bin/idd-onboard.mjs --help documents --allow-root', () => {
+  const help = execFileSync(process.execPath, [BIN_PATH, '--help'], {
+    encoding: 'utf8',
+  });
+  assert.match(help, /--allow-root <dir>/);
 });

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -3827,6 +3827,14 @@ test('resolveConfinedDirectory accepts the working directory itself', () => {
   });
 });
 
+test('resolveConfinedDirectory accepts a real child directory whose name happens to start with ".." (#2357 review: relative() false positive)', () => {
+  withSandboxCwd((sandbox) => {
+    mkdirSync(join(sandbox, '..foo'));
+    const resolved = resolveConfinedDirectory('..foo', '--target', []);
+    assert.equal(resolved, join(sandbox, '..foo'));
+  });
+});
+
 test('resolveConfinedDirectory rejects a --target using ../ traversal that escapes the working directory', () => {
   withSandboxCwd((sandbox) => {
     const outside = mkdtempSync(join(tmpdir(), 'idd-onboard-outside-'));


### PR DESCRIPTION
## Summary

- `idd-onboard` is designed for unattended dispatch, not only an
  interactive human operator typing the value first. `--source` and
  `--target` were accepted as raw strings with no path confinement --
  the manifest-driven copy step already runs each per-file path
  through `isSafeRelativePath`, but that check never covered the
  `--source` / `--target` roots themselves, so an unconfined value let
  the process read from or write to any path it could reach.
- Added `resolveConfinedDirectory`, replacing the duplicated
  `resolve()` + `statSync().isDirectory()` block at all five call
  sites (`--hear`, `--record-policy`, `--substitute`, `--import`,
  `--verify`): it resolves `..`/symlinks and rejects a value whose
  realpath escapes the current working directory.
- `idd-template/ONBOARDING.md`'s own documented workflow runs
  `--import`/`--verify` with `--source <idd-skill-clone> --target
  <target-repo>` as two separate checkouts, so a cwd-only boundary
  would break that primary workflow -- added an opt-in, repeatable
  `--allow-root <dir>` flag (valid in every mode that takes
  `--source`/`--target`) to widen the confined root explicitly, per
  the issue's own proposed resolution.
- New tests cover `../` traversal, an absolute path outside the
  confined root, a symlink resolving outside it, and the
  `--allow-root` widening path, at both the extracted-helper and CLI
  level. Existing tests' `runCliBin` subprocess helper and two direct
  spawn sites now widen to the OS tmpdir (where every fixture in this
  file lives), since none of them were written against a
  confined-by-default CLI.

Closes #2216

## Test plan

- [x] `node --test tests/*.test.mts` (4156 pass)
- [x] `pnpm run typecheck`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `node scripts/idd-doctor.mjs` (passed, pre-existing unrelated warnings only)
- [x] Verified `idd-template/ONBOARDING.md`'s documented `--import`/
      `--verify` invocation shape (separate `--source`/`--target`
      checkouts) before choosing the `--allow-root` design, per an
      advisor consult, to avoid breaking the tool's primary workflow
- [x] All 144 pre-existing `idd-onboard` tests still pass unmodified
      in intent (only their tmpdir-fixture invocations gained
      `--allow-root`/`cwd` to keep working against the new default
      confinement)