### PR TITLE
docs(review-fix): add a round-level convergence heuristic alongside the existing E10 no-progress guard

### DIFF
--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -72,6 +72,24 @@ Convergence guardrails:
   redirected by a maintainer.
 - If the critique pass reports zero issues, proceed to E11.
 
+**Round-count heuristic for genuinely-new findings.** The guard above
+covers a _repeating_ finding; a different pattern is each round
+surfacing a genuinely new, real finding — that is convergence, not
+stagnation, so the no-progress guard never fires. This is a heuristic,
+not a hard cap: after several consecutive rounds (roughly 3-4) each
+finding something new in the _same area_, treat it as a signal that a
+shared root cause may be producing each new instance, and check
+whether one structural fix (e.g., auditing every caller of a helper
+against its contract, instead of patching one caller per round) would
+converge the loop faster than another incremental patch. Worked
+example: five review rounds each flag a different call site missing a
+validation check that a shared helper added — the fix that ends the
+loop is auditing every caller against the helper's contract once, not
+a sixth per-call-site patch. Once fixes materially address the
+finding's root cause and further comments are speculative or
+non-blocking hardening, treat them as PATH B (disposition-only,
+E4-E8) rather than opening another E9-E10 round.
+
 ## E11 — Resolve conflicts with main
 
 Check for conflicts between the feature branch and `main`. If conflicts

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -88,7 +88,7 @@ loop is auditing every caller against the helper's contract once, not
 a sixth per-call-site patch. Once fixes materially address the
 finding's root cause and further comments are speculative or
 non-blocking hardening, treat them as PATH B (disposition-only,
-E4-E8) rather than opening another E9-E10 round.
+E4-E7) rather than opening another E9-E10 round.
 
 ## E11 — Resolve conflicts with main
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -83,7 +83,7 @@ loop is auditing every caller against the helper's contract once, not
 a sixth per-call-site patch. Once fixes materially address the
 finding's root cause and further comments are speculative or
 non-blocking hardening, treat them as PATH B (disposition-only,
-E4-E8) rather than opening another E9-E10 round.
+E4-E7) rather than opening another E9-E10 round.
 
 ## E11 — Resolve conflicts with main
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -67,6 +67,24 @@ Convergence guardrails:
   redirected by a maintainer.
 - If the critique pass reports zero issues, proceed to E11.
 
+**Round-count heuristic for genuinely-new findings.** The guard above
+covers a _repeating_ finding; a different pattern is each round
+surfacing a genuinely new, real finding — that is convergence, not
+stagnation, so the no-progress guard never fires. This is a heuristic,
+not a hard cap: after several consecutive rounds (roughly 3-4) each
+finding something new in the _same area_, treat it as a signal that a
+shared root cause may be producing each new instance, and check
+whether one structural fix (e.g., auditing every caller of a helper
+against its contract, instead of patching one caller per round) would
+converge the loop faster than another incremental patch. Worked
+example: five review rounds each flag a different call site missing a
+validation check that a shared helper added — the fix that ends the
+loop is auditing every caller against the helper's contract once, not
+a sixth per-call-site patch. Once fixes materially address the
+finding's root cause and further comments are speculative or
+non-blocking hardening, treat them as PATH B (disposition-only,
+E4-E8) rather than opening another E9-E10 round.
+
 ## E11 — Resolve conflicts with main
 
 Check for conflicts between the feature branch and `main`. If conflicts


### PR DESCRIPTION
## Summary

Adds a round-count-aware heuristic to `idd-review-fix.instructions.md` (E10) for the pattern where each successive review round surfaces a genuinely new, real finding rather than repeating an old one — distinct from the existing `e10NoProgressHoldAfter` same-finding-repeats guard.

## What changed

- New paragraph after the existing E10 convergence guardrails: explains the genuinely-new-finding pattern, frames it as an explicitly non-binding heuristic (not a hard round cap), and gives one worked example (a shared-helper validation gap surfacing at a different call site each round, converged by auditing every caller once instead of patching one call site per round).
- Synced the canonical `idd-template/` source to the repo-root generated mirror via `sync-docs.mjs --apply`.

## Acceptance criteria

- [x] `idd-review-fix.instructions.md` documents a round-count-aware heuristic for the genuinely-new-findings-every-round pattern, distinct from the existing same-finding-repeats E10 guard, including at least one worked example.
- [x] The added guidance is explicitly non-binding (a heuristic, not a hard round cap), consistent with how the existing E10 guard is framed.
- [x] The file stays within its existing byte budget (`node scripts/audit-docs.mjs --check` passes; no new notice on `bundle-review-fix`) and passes Markdown lint.

## Test plan

- [x] `node scripts/audit-docs.mjs --check` — passed, no new budget notices
- [x] `pnpm test` — 4196/4196 passed
- [x] `pnpm run lint` (biome/dprint/markdownlint/cspell/audit-code-span-wrap/typecheck/build:check) — clean (4 pre-existing unrelated biome warnings in `protocol-helpers.mts`, not introduced here)
- [x] `node scripts/idd-doctor.mjs` — passed (3 pre-existing environment warnings)

Closes #2242
