### PR TITLE
fix(suitability-triage): add a branch-naming duplicate detector to Check 4

### DIFF
--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -6,6 +6,7 @@
 // the generated .mjs. See docs/typescript-sources.md.
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { computeBranchName } from './branch-name.mjs';
 import { parseCliArgs } from './cli-args.mjs';
 import {
   DEFAULT_BUNDLE_IDS,
@@ -25,6 +26,7 @@ import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
 import { resolveTrustedMarkerActors } from './protocol-helpers.mjs';
 import {
   buildClosedByMergedPrArgs,
+  buildMergedPrByBranchArgs,
   buildMergedPrListArgs,
   buildPrDetailArgs,
   evaluateHighConfidenceDuplicate,
@@ -1257,6 +1259,7 @@ function runCli() {
   let candidateFiles = [];
   let highContentionFiles = [];
   let mergedPrs = [];
+  let branchNameMergedPr = null;
   if (shouldCollectEvidence) {
     try {
       closedByMergedPrNumbers = fetchClosedByMergedPrNumbers(
@@ -1267,6 +1270,19 @@ function runCli() {
     } catch (error) {
       collectionWarnings.push(
         `closedByPullRequestsReferences: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    // #2313, Signal 3: a separate try/catch (same pattern as the two blocks
+    // above/below) so a failure here degrades only this one signal, never
+    // discarding a sibling signal that already collected cleanly.
+    try {
+      branchNameMergedPr = fetchMergedPrByBranchName(
+        repoRef,
+        computeBranchName(issue.number, issue.title),
+      );
+    } catch (error) {
+      collectionWarnings.push(
+        `branch-name merged-PR lookup: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
     try {
@@ -1332,6 +1348,7 @@ function runCli() {
     candidateFiles,
     highContentionFiles,
     mergedPrs,
+    branchNameMergedPr,
   };
   const result = evaluateSuitability(issue, {
     repository: { owner, repo },
@@ -1726,7 +1743,22 @@ function normalizeHighConfidenceDuplicateInput(raw) {
     candidateFiles: normalizeStringArray(r.candidateFiles),
     highContentionFiles: normalizeStringArray(r.highContentionFiles),
     mergedPrs: normalizeHighConfidenceMergedPrs(r.mergedPrs),
+    branchNameMergedPr: normalizeBranchNameMergedPr(r.branchNameMergedPr),
   };
+}
+/** #2313: normalize the Signal 3 options-boundary field the same fail-safe
+ * way as every other field here -- a malformed shape degrades to `null`
+ * (no evidence), never a crash or a manufactured match. */
+function normalizeBranchNameMergedPr(value) {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const v = value;
+  const number = Number(v.number);
+  if (!Number.isInteger(number) || number <= 0) {
+    return null;
+  }
+  return { number, mergedAt: String(v.mergedAt ?? '') };
 }
 function normalizePositiveIntArray(value) {
   if (!Array.isArray(value)) {
@@ -1894,6 +1926,28 @@ function fetchIssueComments(repoRef, issueNumber) {
  * remaining work would still show its old merged closing PR and get
  * misclassified as a completed duplicate (Codex review finding on this PR).
  */
+/**
+ * #2313, Signal 3: exact-match branch-name lookup. `--head` filters
+ * server-side to PRs with this exact head branch (branch names are unique
+ * per issue by construction), so at most one entry is ever returned; this
+ * still iterates defensively rather than indexing `[0]` directly, matching
+ * the rest of this file's "never trust the shape of a `gh` JSON response"
+ * convention.
+ */
+function fetchMergedPrByBranchName(repoRef, branchName) {
+  const list = ghJsonArray(buildMergedPrByBranchArgs(repoRef, branchName));
+  for (const entry of list) {
+    const number = Number.parseInt(String(entry?.number ?? ''), 10);
+    if (!Number.isInteger(number) || number <= 0) {
+      continue;
+    }
+    if (String(entry?.headRefName ?? '') !== branchName) {
+      continue;
+    }
+    return { number, mergedAt: String(entry?.mergedAt ?? '') };
+  }
+  return null;
+}
 function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
   const parsed = ghJson(buildClosedByMergedPrArgs(owner, repo, issueNumber));
   // `gh api graphql` exits non-zero (throwing via runGh) on a schema-level

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -1927,6 +1927,31 @@ function fetchIssueComments(repoRef, issueNumber) {
  * remaining work would still show its old merged closing PR and get
  * misclassified as a completed duplicate (Codex review finding on this PR).
  */
+function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
+  const parsed = ghJson(buildClosedByMergedPrArgs(owner, repo, issueNumber));
+  // `gh api graphql` exits non-zero (throwing via runGh) on a schema-level
+  // query error, but a GraphQL response can also return HTTP 200 with a
+  // non-empty top-level `errors` array alongside partial/null `data` (a
+  // resolver-level failure on a nullable field) -- verified empirically
+  // that gh's own exit code does not always catch this shape. Treating that
+  // silently as "no evidence" would suppress a real collection failure
+  // (Copilot review finding on this PR); throw explicitly so the caller's
+  // try/catch records it in `collectionWarnings` instead.
+  if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
+    throw new Error(
+      `closedByPullRequestsReferences GraphQL response returned errors: ${JSON.stringify(parsed.errors)}`,
+    );
+  }
+  if (String(parsed.data?.repository?.issue?.state ?? '') !== 'CLOSED') {
+    return [];
+  }
+  const nodes =
+    parsed.data?.repository?.issue?.closedByPullRequestsReferences?.nodes ?? [];
+  return nodes
+    .filter((node) => String(node?.state ?? '') === 'MERGED')
+    .map((node) => Number.parseInt(String(node?.number ?? ''), 10))
+    .filter((n) => Number.isInteger(n) && n > 0);
+}
 /**
  * #2313, Signal 3: exact-match branch-name lookup. `--head` filters
  * server-side by head branch NAME only -- `gh pr list --help` documents
@@ -1963,31 +1988,6 @@ function fetchMergedPrByBranchName(repoRef, branchName, owner) {
     return { number, mergedAt: String(entry?.mergedAt ?? '') };
   }
   return null;
-}
-function fetchClosedByMergedPrNumbers(owner, repo, issueNumber) {
-  const parsed = ghJson(buildClosedByMergedPrArgs(owner, repo, issueNumber));
-  // `gh api graphql` exits non-zero (throwing via runGh) on a schema-level
-  // query error, but a GraphQL response can also return HTTP 200 with a
-  // non-empty top-level `errors` array alongside partial/null `data` (a
-  // resolver-level failure on a nullable field) -- verified empirically
-  // that gh's own exit code does not always catch this shape. Treating that
-  // silently as "no evidence" would suppress a real collection failure
-  // (Copilot review finding on this PR); throw explicitly so the caller's
-  // try/catch records it in `collectionWarnings` instead.
-  if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
-    throw new Error(
-      `closedByPullRequestsReferences GraphQL response returned errors: ${JSON.stringify(parsed.errors)}`,
-    );
-  }
-  if (String(parsed.data?.repository?.issue?.state ?? '') !== 'CLOSED') {
-    return [];
-  }
-  const nodes =
-    parsed.data?.repository?.issue?.closedByPullRequestsReferences?.nodes ?? [];
-  return nodes
-    .filter((node) => String(node?.state ?? '') === 'MERGED')
-    .map((node) => Number.parseInt(String(node?.number ?? ''), 10))
-    .filter((n) => Number.isInteger(n) && n > 0);
 }
 /**
  * Bounded two-step merged-PR file-overlap scan (list, then per-PR file

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -1279,6 +1279,7 @@ function runCli() {
       branchNameMergedPr = fetchMergedPrByBranchName(
         repoRef,
         computeBranchName(issue.number, issue.title),
+        owner,
       );
     } catch (error) {
       collectionWarnings.push(
@@ -1928,20 +1929,35 @@ function fetchIssueComments(repoRef, issueNumber) {
  */
 /**
  * #2313, Signal 3: exact-match branch-name lookup. `--head` filters
- * server-side to PRs with this exact head branch (branch names are unique
- * per issue by construction), so at most one entry is ever returned; this
- * still iterates defensively rather than indexing `[0]` directly, matching
- * the rest of this file's "never trust the shape of a `gh` JSON response"
- * convention.
+ * server-side by head branch NAME only -- `gh pr list --help` documents
+ * that `"<owner>:<branch>" syntax` is "not supported" -- so a merged PR
+ * from a FORK using the same branch name can also come back (Copilot
+ * review finding on this PR). `owner` (the repository owner, not the fork
+ * contributor) is required so every entry can be filtered to
+ * `headRepositoryOwner.login === owner` before being treated as a hit;
+ * `buildMergedPrByBranchArgs` requests that field and a `--limit` above 1
+ * for exactly this reason. Still iterates rather than indexing `[0]`
+ * directly, matching the rest of this file's "never trust the shape of a
+ * `gh` JSON response" convention.
  */
-function fetchMergedPrByBranchName(repoRef, branchName) {
+function fetchMergedPrByBranchName(repoRef, branchName, owner) {
   const list = ghJsonArray(buildMergedPrByBranchArgs(repoRef, branchName));
+  const normalizedOwner = owner.trim().toLowerCase();
   for (const entry of list) {
     const number = Number.parseInt(String(entry?.number ?? ''), 10);
     if (!Number.isInteger(number) || number <= 0) {
       continue;
     }
     if (String(entry?.headRefName ?? '') !== branchName) {
+      continue;
+    }
+    const headOwner = String(entry?.headRepositoryOwner?.login ?? '')
+      .trim()
+      .toLowerCase();
+    if (!headOwner || headOwner !== normalizedOwner) {
+      // A fork's PR (or a response missing headRepositoryOwner) never
+      // counts as a hit -- fail-safe, matching this file's "never fail
+      // toward a false high-confidence flag" contract.
       continue;
     }
     return { number, mergedAt: String(entry?.mergedAt ?? '') };

--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -298,12 +298,19 @@ export function evaluateHighConfidenceDuplicate(input, candidateIssueNumber) {
     branchNameMergedPr &&
     typeof branchNameMergedPr === 'object' &&
     Number.isInteger(branchNameMergedPr.number) &&
-    branchNameMergedPr.number > 0
+    branchNameMergedPr.number > 0 &&
+    // CodeRabbit review finding on this PR: an empty `mergedAt` must not
+    // produce Signal 3 evidence -- every other merged-PR evidence shape in
+    // this module requires a merge timestamp (see `HighConfidenceMergedPr`
+    // above), and citing a merge with no date is a malformed/incomplete
+    // input, not a genuine hit. Falls through to the other signals instead
+    // of crashing or manufacturing a false positive.
+    typeof branchNameMergedPr.mergedAt === 'string' &&
+    branchNameMergedPr.mergedAt.length > 0
   ) {
-    const mergedAt = String(branchNameMergedPr.mergedAt ?? '');
     return {
       pass: false,
-      evidence: `High-confidence duplicate: merged PR #${branchNameMergedPr.number}${mergedAt ? ` (merged ${mergedAt})` : ''} already shipped this issue's own IDD-naming-convention-computed branch, independent of closing-keyword presence or Candidate-files overlap.`,
+      evidence: `High-confidence duplicate: merged PR #${branchNameMergedPr.number} (merged ${branchNameMergedPr.mergedAt}) already shipped this issue's own IDD-naming-convention-computed branch, independent of closing-keyword presence or Candidate-files overlap.`,
       tier: 'high-confidence',
     };
   }

--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -425,6 +425,17 @@ export function buildMergedPrListArgs(repoRef, sinceIso) {
  * head branch, so this is a single targeted lookup -- unlike
  * {@link buildMergedPrListArgs}'s bounded recent-window scan above, no
  * client-side iteration over unrelated merged PRs is needed.
+ *
+ * Requests `headRepositoryOwner` alongside the other fields (Copilot review
+ * finding on this PR) and raises `--limit` above 1: `gh pr list --head
+ * <branch>` (per `gh pr list --help`, the `"<owner>:<branch>" syntax` is
+ * "not supported") matches on head branch NAME alone, which can also return
+ * a merged PR from a FORK that happens to use the same branch name -- a
+ * `headRepositoryOwner` mismatch would otherwise misclassify an issue as a
+ * high-confidence duplicate even though the in-repo convention branch was
+ * never actually merged. The caller filters to entries whose
+ * `headRepositoryOwner.login` matches the repository owner before treating
+ * any result as a hit.
  */
 export function buildMergedPrByBranchArgs(repoRef, branchName) {
   return [
@@ -437,9 +448,9 @@ export function buildMergedPrByBranchArgs(repoRef, branchName) {
     '--state',
     'merged',
     '--json',
-    'number,headRefName,mergedAt',
+    'number,headRefName,mergedAt,headRepositoryOwner',
     '--limit',
-    '1',
+    '10',
   ];
 }
 /**

--- a/scripts/supersession-detection.mjs
+++ b/scripts/supersession-detection.mjs
@@ -288,6 +288,25 @@ export function evaluateHighConfidenceDuplicate(input, candidateIssueNumber) {
   if (!input) {
     return null;
   }
+  // #2313, Signal 3: an exact-match branch-name lookup, checked first since
+  // it needs no candidate-file set and is unconditionally sufficient on its
+  // own -- a merged PR on this issue's own convention-computed branch name
+  // can only exist because it shipped this issue's work, closing keyword or
+  // Candidate-files overlap notwithstanding.
+  const branchNameMergedPr = input.branchNameMergedPr;
+  if (
+    branchNameMergedPr &&
+    typeof branchNameMergedPr === 'object' &&
+    Number.isInteger(branchNameMergedPr.number) &&
+    branchNameMergedPr.number > 0
+  ) {
+    const mergedAt = String(branchNameMergedPr.mergedAt ?? '');
+    return {
+      pass: false,
+      evidence: `High-confidence duplicate: merged PR #${branchNameMergedPr.number}${mergedAt ? ` (merged ${mergedAt})` : ''} already shipped this issue's own IDD-naming-convention-computed branch, independent of closing-keyword presence or Candidate-files overlap.`,
+      tier: 'high-confidence',
+    };
+  }
   const closedByMergedPrNumbers = (
     Array.isArray(input.closedByMergedPrNumbers)
       ? input.closedByMergedPrNumbers
@@ -396,6 +415,31 @@ export function buildMergedPrListArgs(repoRef, sinceIso) {
     'number,mergedAt',
     '--limit',
     String(MERGED_PR_SCAN_LIMIT),
+  ];
+}
+/**
+ * Argv for the exact-match merged-PR-by-branch-name lookup (#2313): finds
+ * any merged PR whose `headRefName` equals this issue's own
+ * IDD-naming-convention-computed branch name (`computeBranchName` in
+ * `branch-name.mts`). `--head` filters server-side to PRs with that exact
+ * head branch, so this is a single targeted lookup -- unlike
+ * {@link buildMergedPrListArgs}'s bounded recent-window scan above, no
+ * client-side iteration over unrelated merged PRs is needed.
+ */
+export function buildMergedPrByBranchArgs(repoRef, branchName) {
+  return [
+    'pr',
+    'list',
+    '--repo',
+    repoRef,
+    '--head',
+    branchName,
+    '--state',
+    'merged',
+    '--json',
+    'number,headRefName,mergedAt',
+    '--limit',
+    '1',
   ];
 }
 /**

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -8,6 +8,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
+import { computeBranchName } from './branch-name.mts';
 import { parseCliArgs } from './cli-args.mts';
 import {
   DEFAULT_BUNDLE_IDS,
@@ -28,6 +29,7 @@ import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
 import { resolveTrustedMarkerActors } from './protocol-helpers.mts';
 import {
   buildClosedByMergedPrArgs,
+  buildMergedPrByBranchArgs,
   buildMergedPrListArgs,
   buildPrDetailArgs,
   type CheckOutcome,
@@ -1459,6 +1461,7 @@ function runCli(): void {
   let candidateFiles: string[] = [];
   let highContentionFiles: string[] = [];
   let mergedPrs: HighConfidenceMergedPr[] = [];
+  let branchNameMergedPr: { number: number; mergedAt: string } | null = null;
 
   if (shouldCollectEvidence) {
     try {
@@ -1470,6 +1473,20 @@ function runCli(): void {
     } catch (error) {
       collectionWarnings.push(
         `closedByPullRequestsReferences: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    // #2313, Signal 3: a separate try/catch (same pattern as the two blocks
+    // above/below) so a failure here degrades only this one signal, never
+    // discarding a sibling signal that already collected cleanly.
+    try {
+      branchNameMergedPr = fetchMergedPrByBranchName(
+        repoRef,
+        computeBranchName(issue.number, issue.title),
+      );
+    } catch (error) {
+      collectionWarnings.push(
+        `branch-name merged-PR lookup: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
 
@@ -1538,6 +1555,7 @@ function runCli(): void {
       candidateFiles,
       highContentionFiles,
       mergedPrs,
+      branchNameMergedPr,
     };
 
   const result = evaluateSuitability(issue, {
@@ -1982,6 +2000,7 @@ function normalizeHighConfidenceDuplicateInput(
     candidateFiles?: unknown;
     highContentionFiles?: unknown;
     mergedPrs?: unknown;
+    branchNameMergedPr?: unknown;
   };
   return {
     closedByMergedPrNumbers: normalizePositiveIntArray(
@@ -1990,7 +2009,25 @@ function normalizeHighConfidenceDuplicateInput(
     candidateFiles: normalizeStringArray(r.candidateFiles),
     highContentionFiles: normalizeStringArray(r.highContentionFiles),
     mergedPrs: normalizeHighConfidenceMergedPrs(r.mergedPrs),
+    branchNameMergedPr: normalizeBranchNameMergedPr(r.branchNameMergedPr),
   };
+}
+
+/** #2313: normalize the Signal 3 options-boundary field the same fail-safe
+ * way as every other field here -- a malformed shape degrades to `null`
+ * (no evidence), never a crash or a manufactured match. */
+function normalizeBranchNameMergedPr(
+  value: unknown,
+): { number: number; mergedAt: string } | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const v = value as { number?: unknown; mergedAt?: unknown };
+  const number = Number(v.number);
+  if (!Number.isInteger(number) || number <= 0) {
+    return null;
+  }
+  return { number, mergedAt: String(v.mergedAt ?? '') };
 }
 
 function normalizePositiveIntArray(value: unknown): number[] {
@@ -2201,6 +2238,36 @@ function fetchIssueComments(
  * remaining work would still show its old merged closing PR and get
  * misclassified as a completed duplicate (Codex review finding on this PR).
  */
+/**
+ * #2313, Signal 3: exact-match branch-name lookup. `--head` filters
+ * server-side to PRs with this exact head branch (branch names are unique
+ * per issue by construction), so at most one entry is ever returned; this
+ * still iterates defensively rather than indexing `[0]` directly, matching
+ * the rest of this file's "never trust the shape of a `gh` JSON response"
+ * convention.
+ */
+function fetchMergedPrByBranchName(
+  repoRef: string,
+  branchName: string,
+): { number: number; mergedAt: string } | null {
+  const list = ghJsonArray(buildMergedPrByBranchArgs(repoRef, branchName)) as {
+    number?: unknown;
+    headRefName?: unknown;
+    mergedAt?: unknown;
+  }[];
+  for (const entry of list) {
+    const number = Number.parseInt(String(entry?.number ?? ''), 10);
+    if (!Number.isInteger(number) || number <= 0) {
+      continue;
+    }
+    if (String(entry?.headRefName ?? '') !== branchName) {
+      continue;
+    }
+    return { number, mergedAt: String(entry?.mergedAt ?? '') };
+  }
+  return null;
+}
+
 function fetchClosedByMergedPrNumbers(
   owner: string,
   repo: string,

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -2239,6 +2239,50 @@ function fetchIssueComments(
  * remaining work would still show its old merged closing PR and get
  * misclassified as a completed duplicate (Codex review finding on this PR).
  */
+function fetchClosedByMergedPrNumbers(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): number[] {
+  const parsed = ghJson(
+    buildClosedByMergedPrArgs(owner, repo, issueNumber),
+  ) as {
+    data?: {
+      repository?: {
+        issue?: {
+          state?: unknown;
+          closedByPullRequestsReferences?: {
+            nodes?: { number?: unknown; state?: unknown }[] | null;
+          } | null;
+        } | null;
+      } | null;
+    };
+    errors?: unknown;
+  };
+  // `gh api graphql` exits non-zero (throwing via runGh) on a schema-level
+  // query error, but a GraphQL response can also return HTTP 200 with a
+  // non-empty top-level `errors` array alongside partial/null `data` (a
+  // resolver-level failure on a nullable field) -- verified empirically
+  // that gh's own exit code does not always catch this shape. Treating that
+  // silently as "no evidence" would suppress a real collection failure
+  // (Copilot review finding on this PR); throw explicitly so the caller's
+  // try/catch records it in `collectionWarnings` instead.
+  if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
+    throw new Error(
+      `closedByPullRequestsReferences GraphQL response returned errors: ${JSON.stringify(parsed.errors)}`,
+    );
+  }
+  if (String(parsed.data?.repository?.issue?.state ?? '') !== 'CLOSED') {
+    return [];
+  }
+  const nodes =
+    parsed.data?.repository?.issue?.closedByPullRequestsReferences?.nodes ?? [];
+  return nodes
+    .filter((node) => String(node?.state ?? '') === 'MERGED')
+    .map((node) => Number.parseInt(String(node?.number ?? ''), 10))
+    .filter((n) => Number.isInteger(n) && n > 0);
+}
+
 /**
  * #2313, Signal 3: exact-match branch-name lookup. `--head` filters
  * server-side by head branch NAME only -- `gh pr list --help` documents
@@ -2284,50 +2328,6 @@ function fetchMergedPrByBranchName(
     return { number, mergedAt: String(entry?.mergedAt ?? '') };
   }
   return null;
-}
-
-function fetchClosedByMergedPrNumbers(
-  owner: string,
-  repo: string,
-  issueNumber: number,
-): number[] {
-  const parsed = ghJson(
-    buildClosedByMergedPrArgs(owner, repo, issueNumber),
-  ) as {
-    data?: {
-      repository?: {
-        issue?: {
-          state?: unknown;
-          closedByPullRequestsReferences?: {
-            nodes?: { number?: unknown; state?: unknown }[] | null;
-          } | null;
-        } | null;
-      } | null;
-    };
-    errors?: unknown;
-  };
-  // `gh api graphql` exits non-zero (throwing via runGh) on a schema-level
-  // query error, but a GraphQL response can also return HTTP 200 with a
-  // non-empty top-level `errors` array alongside partial/null `data` (a
-  // resolver-level failure on a nullable field) -- verified empirically
-  // that gh's own exit code does not always catch this shape. Treating that
-  // silently as "no evidence" would suppress a real collection failure
-  // (Copilot review finding on this PR); throw explicitly so the caller's
-  // try/catch records it in `collectionWarnings` instead.
-  if (Array.isArray(parsed.errors) && parsed.errors.length > 0) {
-    throw new Error(
-      `closedByPullRequestsReferences GraphQL response returned errors: ${JSON.stringify(parsed.errors)}`,
-    );
-  }
-  if (String(parsed.data?.repository?.issue?.state ?? '') !== 'CLOSED') {
-    return [];
-  }
-  const nodes =
-    parsed.data?.repository?.issue?.closedByPullRequestsReferences?.nodes ?? [];
-  return nodes
-    .filter((node) => String(node?.state ?? '') === 'MERGED')
-    .map((node) => Number.parseInt(String(node?.number ?? ''), 10))
-    .filter((n) => Number.isInteger(n) && n > 0);
 }
 
 /** Return shape for {@link fetchMergedPrFileOverlapEvidence} (#1484): pairs

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1483,6 +1483,7 @@ function runCli(): void {
       branchNameMergedPr = fetchMergedPrByBranchName(
         repoRef,
         computeBranchName(issue.number, issue.title),
+        owner,
       );
     } catch (error) {
       collectionWarnings.push(
@@ -2240,27 +2241,44 @@ function fetchIssueComments(
  */
 /**
  * #2313, Signal 3: exact-match branch-name lookup. `--head` filters
- * server-side to PRs with this exact head branch (branch names are unique
- * per issue by construction), so at most one entry is ever returned; this
- * still iterates defensively rather than indexing `[0]` directly, matching
- * the rest of this file's "never trust the shape of a `gh` JSON response"
- * convention.
+ * server-side by head branch NAME only -- `gh pr list --help` documents
+ * that `"<owner>:<branch>" syntax` is "not supported" -- so a merged PR
+ * from a FORK using the same branch name can also come back (Copilot
+ * review finding on this PR). `owner` (the repository owner, not the fork
+ * contributor) is required so every entry can be filtered to
+ * `headRepositoryOwner.login === owner` before being treated as a hit;
+ * `buildMergedPrByBranchArgs` requests that field and a `--limit` above 1
+ * for exactly this reason. Still iterates rather than indexing `[0]`
+ * directly, matching the rest of this file's "never trust the shape of a
+ * `gh` JSON response" convention.
  */
 function fetchMergedPrByBranchName(
   repoRef: string,
   branchName: string,
+  owner: string,
 ): { number: number; mergedAt: string } | null {
   const list = ghJsonArray(buildMergedPrByBranchArgs(repoRef, branchName)) as {
     number?: unknown;
     headRefName?: unknown;
     mergedAt?: unknown;
+    headRepositoryOwner?: { login?: unknown } | null;
   }[];
+  const normalizedOwner = owner.trim().toLowerCase();
   for (const entry of list) {
     const number = Number.parseInt(String(entry?.number ?? ''), 10);
     if (!Number.isInteger(number) || number <= 0) {
       continue;
     }
     if (String(entry?.headRefName ?? '') !== branchName) {
+      continue;
+    }
+    const headOwner = String(entry?.headRepositoryOwner?.login ?? '')
+      .trim()
+      .toLowerCase();
+    if (!headOwner || headOwner !== normalizedOwner) {
+      // A fork's PR (or a response missing headRepositoryOwner) never
+      // counts as a hit -- fail-safe, matching this file's "never fail
+      // toward a false high-confidence flag" contract.
       continue;
     }
     return { number, mergedAt: String(entry?.mergedAt ?? '') };

--- a/src/scripts/supersession-detection.mts
+++ b/src/scripts/supersession-detection.mts
@@ -601,6 +601,17 @@ export function buildMergedPrListArgs(
  * head branch, so this is a single targeted lookup -- unlike
  * {@link buildMergedPrListArgs}'s bounded recent-window scan above, no
  * client-side iteration over unrelated merged PRs is needed.
+ *
+ * Requests `headRepositoryOwner` alongside the other fields (Copilot review
+ * finding on this PR) and raises `--limit` above 1: `gh pr list --head
+ * <branch>` (per `gh pr list --help`, the `"<owner>:<branch>" syntax` is
+ * "not supported") matches on head branch NAME alone, which can also return
+ * a merged PR from a FORK that happens to use the same branch name -- a
+ * `headRepositoryOwner` mismatch would otherwise misclassify an issue as a
+ * high-confidence duplicate even though the in-repo convention branch was
+ * never actually merged. The caller filters to entries whose
+ * `headRepositoryOwner.login` matches the repository owner before treating
+ * any result as a hit.
  */
 export function buildMergedPrByBranchArgs(
   repoRef: string,
@@ -616,9 +627,9 @@ export function buildMergedPrByBranchArgs(
     '--state',
     'merged',
     '--json',
-    'number,headRefName,mergedAt',
+    'number,headRefName,mergedAt,headRepositoryOwner',
     '--limit',
-    '1',
+    '10',
   ];
 }
 

--- a/src/scripts/supersession-detection.mts
+++ b/src/scripts/supersession-detection.mts
@@ -102,6 +102,20 @@ export interface HighConfidenceDuplicateInput {
    * high-confidence evidence that THIS issue was superseded. */
   highContentionFiles: string[];
   mergedPrs: HighConfidenceMergedPr[];
+  /**
+   * #2313: a merged PR whose `headRefName` exactly matches this issue's own
+   * IDD-naming-convention-computed branch name (`computeBranchName` in
+   * `branch-name.mts`), or `null` when no such PR exists (or the caller did
+   * not collect this evidence). This is an exact-match GitHub lookup by
+   * construction -- branch names are unique per issue -- so it is
+   * independent of, and safe at the same high-confidence tier as, the two
+   * signals above: it needs neither a closing keyword nor a
+   * `## Candidate files` overlap. Fixes the gap that let issue #2222 survive
+   * as `OPEN`/`ready` for three days after PR #2254 had already merged the
+   * same work on the issue's own convention-computed branch name with no
+   * closing keyword.
+   */
+  branchNameMergedPr: { number: number; mergedAt: string } | null;
 }
 
 /**
@@ -426,6 +440,26 @@ export function evaluateHighConfidenceDuplicate(
     return null;
   }
 
+  // #2313, Signal 3: an exact-match branch-name lookup, checked first since
+  // it needs no candidate-file set and is unconditionally sufficient on its
+  // own -- a merged PR on this issue's own convention-computed branch name
+  // can only exist because it shipped this issue's work, closing keyword or
+  // Candidate-files overlap notwithstanding.
+  const branchNameMergedPr = input.branchNameMergedPr;
+  if (
+    branchNameMergedPr &&
+    typeof branchNameMergedPr === 'object' &&
+    Number.isInteger(branchNameMergedPr.number) &&
+    branchNameMergedPr.number > 0
+  ) {
+    const mergedAt = String(branchNameMergedPr.mergedAt ?? '');
+    return {
+      pass: false,
+      evidence: `High-confidence duplicate: merged PR #${branchNameMergedPr.number}${mergedAt ? ` (merged ${mergedAt})` : ''} already shipped this issue's own IDD-naming-convention-computed branch, independent of closing-keyword presence or Candidate-files overlap.`,
+      tier: 'high-confidence',
+    };
+  }
+
   const closedByMergedPrNumbers = (
     Array.isArray(input.closedByMergedPrNumbers)
       ? input.closedByMergedPrNumbers
@@ -556,6 +590,35 @@ export function buildMergedPrListArgs(
     'number,mergedAt',
     '--limit',
     String(MERGED_PR_SCAN_LIMIT),
+  ];
+}
+
+/**
+ * Argv for the exact-match merged-PR-by-branch-name lookup (#2313): finds
+ * any merged PR whose `headRefName` equals this issue's own
+ * IDD-naming-convention-computed branch name (`computeBranchName` in
+ * `branch-name.mts`). `--head` filters server-side to PRs with that exact
+ * head branch, so this is a single targeted lookup -- unlike
+ * {@link buildMergedPrListArgs}'s bounded recent-window scan above, no
+ * client-side iteration over unrelated merged PRs is needed.
+ */
+export function buildMergedPrByBranchArgs(
+  repoRef: string,
+  branchName: string,
+): string[] {
+  return [
+    'pr',
+    'list',
+    '--repo',
+    repoRef,
+    '--head',
+    branchName,
+    '--state',
+    'merged',
+    '--json',
+    'number,headRefName,mergedAt',
+    '--limit',
+    '1',
   ];
 }
 

--- a/src/scripts/supersession-detection.mts
+++ b/src/scripts/supersession-detection.mts
@@ -450,12 +450,19 @@ export function evaluateHighConfidenceDuplicate(
     branchNameMergedPr &&
     typeof branchNameMergedPr === 'object' &&
     Number.isInteger(branchNameMergedPr.number) &&
-    branchNameMergedPr.number > 0
+    branchNameMergedPr.number > 0 &&
+    // CodeRabbit review finding on this PR: an empty `mergedAt` must not
+    // produce Signal 3 evidence -- every other merged-PR evidence shape in
+    // this module requires a merge timestamp (see `HighConfidenceMergedPr`
+    // above), and citing a merge with no date is a malformed/incomplete
+    // input, not a genuine hit. Falls through to the other signals instead
+    // of crashing or manufacturing a false positive.
+    typeof branchNameMergedPr.mergedAt === 'string' &&
+    branchNameMergedPr.mergedAt.length > 0
   ) {
-    const mergedAt = String(branchNameMergedPr.mergedAt ?? '');
     return {
       pass: false,
-      evidence: `High-confidence duplicate: merged PR #${branchNameMergedPr.number}${mergedAt ? ` (merged ${mergedAt})` : ''} already shipped this issue's own IDD-naming-convention-computed branch, independent of closing-keyword presence or Candidate-files overlap.`,
+      evidence: `High-confidence duplicate: merged PR #${branchNameMergedPr.number} (merged ${branchNameMergedPr.mergedAt}) already shipped this issue's own IDD-naming-convention-computed branch, independent of closing-keyword presence or Candidate-files overlap.`,
       tier: 'high-confidence',
     };
   }

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2578,6 +2578,28 @@ test('runCli: the same-candidate-files merged-PR scan is gated behind shouldColl
   );
 });
 
+test('runCli: the branch-name merged-PR lookup is gated behind shouldCollectEvidence (#2313)', () => {
+  const source = readFileSync(
+    new URL('../src/scripts/suitability-triage.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /if \(shouldCollectEvidence\) \{[\s\S]*?fetchMergedPrByBranchName\(/,
+  );
+});
+
+test("runCli: the branch-name merged-PR lookup uses computeBranchName on the issue's own number and title (#2313)", () => {
+  const source = readFileSync(
+    new URL('../src/scripts/suitability-triage.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /fetchMergedPrByBranchName\(\s*repoRef,\s*computeBranchName\(issue\.number,\s*issue\.title\),?\s*\)/,
+  );
+});
+
 test('runCli: shouldCollectEvidence is derived from repository_fit, coherence, and trust_safety, in that order (#1815)', () => {
   const source = readFileSync(
     new URL('../src/scripts/suitability-triage.mts', import.meta.url),
@@ -2723,6 +2745,7 @@ test('checkRepositoryFit / checkCoherence / checkTrustSafety: verdict is unaffec
       blockedByHumanLabelName: 'status:blocked-by-human',
       needsDecisionLabelName: 'status:needs-decision',
       highConfidenceDuplicate: {
+        branchNameMergedPr: null,
         closedByMergedPrNumbers: [42],
         candidateFiles: ['scripts/foo.mjs'],
         highContentionFiles: [],

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2589,14 +2589,14 @@ test('runCli: the branch-name merged-PR lookup is gated behind shouldCollectEvid
   );
 });
 
-test("runCli: the branch-name merged-PR lookup uses computeBranchName on the issue's own number and title (#2313)", () => {
+test("runCli: the branch-name merged-PR lookup uses computeBranchName on the issue's own number and title, and passes owner (#2313)", () => {
   const source = readFileSync(
     new URL('../src/scripts/suitability-triage.mts', import.meta.url),
     'utf8',
   );
   assert.match(
     source,
-    /fetchMergedPrByBranchName\(\s*repoRef,\s*computeBranchName\(issue\.number,\s*issue\.title\),?\s*\)/,
+    /fetchMergedPrByBranchName\(\s*repoRef,\s*computeBranchName\(issue\.number,\s*issue\.title\),\s*owner,?\s*\)/,
   );
 });
 

--- a/tests/supersession-detection.test.mts
+++ b/tests/supersession-detection.test.mts
@@ -835,6 +835,24 @@ test('buildMergedPrByBranchArgs filters server-side to the exact head branch and
   assert.equal(fields.includes('mergedAt'), true);
 });
 
+test('buildMergedPrByBranchArgs requests headRepositoryOwner and a limit above 1, so a fork PR sharing the branch name can be filtered out (Copilot review finding, #2313)', () => {
+  // gh pr list --help documents that the "<owner>:<branch>" syntax is "not
+  // supported" for --head, so a bare branch name can also match a merged PR
+  // from a fork -- the caller needs headRepositoryOwner on every candidate
+  // (not just the first) to filter those out before treating a hit as
+  // high-confidence evidence.
+  const args = buildMergedPrByBranchArgs(
+    'kurone-kito/idd-skill',
+    'issue/2222-fix-onboard-prefer-existing-config-json',
+  );
+  const jsonIndex = args.indexOf('--json');
+  const fields = (args[jsonIndex + 1] ?? '').split(',');
+  assert.equal(fields.includes('headRepositoryOwner'), true);
+  const limitIndex = args.indexOf('--limit');
+  assert.notEqual(limitIndex, -1);
+  assert.equal(Number(args[limitIndex + 1]) > 1, true);
+});
+
 test('buildPrDetailArgs is read-only', () => {
   assertReadOnlyArgv(buildPrDetailArgs('kurone-kito/idd-skill', 1492));
 });

--- a/tests/supersession-detection.test.mts
+++ b/tests/supersession-detection.test.mts
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 
 import {
   buildClosedByMergedPrArgs,
+  buildMergedPrByBranchArgs,
   buildMergedPrListArgs,
   buildPrDetailArgs,
   evaluateHighConfidenceDuplicate,
@@ -32,6 +33,7 @@ test('evaluateHighConfidenceDuplicate: undefined input is absent, not a hit', ()
 test('evaluateHighConfidenceDuplicate: empty arrays fall through (fail-safe)', () => {
   const result = evaluateHighConfidenceDuplicate(
     {
+      branchNameMergedPr: null,
       closedByMergedPrNumbers: [],
       candidateFiles: [],
       highContentionFiles: [],
@@ -58,6 +60,7 @@ test('evaluateHighConfidenceDuplicate: malformed (non-array) fields never crash 
 test('evaluateHighConfidenceDuplicate: closing-PR-reference hit cites the PR number', () => {
   const result = evaluateHighConfidenceDuplicate(
     {
+      branchNameMergedPr: null,
       closedByMergedPrNumbers: [123],
       candidateFiles: [],
       highContentionFiles: [],
@@ -70,9 +73,81 @@ test('evaluateHighConfidenceDuplicate: closing-PR-reference hit cites the PR num
   assert.match(result?.evidence ?? '', /closedByPullRequestsReferences/);
 });
 
+test('evaluateHighConfidenceDuplicate: branch-name-match hit cites the PR number (#2313, Signal 3)', () => {
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      branchNameMergedPr: { number: 2254, mergedAt: '2026-08-23T21:47:05Z' },
+      closedByMergedPrNumbers: [],
+      candidateFiles: [],
+      highContentionFiles: [],
+      mergedPrs: [],
+    },
+    2222,
+  );
+  assert.equal(result?.pass, false);
+  assert.equal(result?.tier, 'high-confidence');
+  assert.match(result?.evidence ?? '', /#2254/);
+  assert.match(result?.evidence ?? '', /2026-08-23T21:47:05Z/);
+});
+
+test("evaluateHighConfidenceDuplicate: reproduces the exact #2222 miss -- a merged PR on the issue's own convention-computed branch, no closing keyword, no Candidate-files overlap (#2313)", () => {
+  // The real #2222 shape: PR #2254 merged on branch
+  // issue/2222-fix-onboard-prefer-existing-config-json with no closing
+  // keyword and no textual '## Candidate files' overlap -- Signals 1 and 2
+  // both miss it (closedByMergedPrNumbers empty, candidateFiles empty so
+  // the file-overlap scan never runs at all). Only Signal 3 (an exact
+  // branch-name match, collected by the CLI glue's own
+  // fetchMergedPrByBranchName lookup and passed in here as
+  // branchNameMergedPr) catches it.
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      branchNameMergedPr: { number: 2254, mergedAt: '2026-08-23T21:47:05Z' },
+      closedByMergedPrNumbers: [],
+      candidateFiles: [],
+      highContentionFiles: [],
+      mergedPrs: [],
+    },
+    2222,
+  );
+  assert.equal(result?.pass, false);
+  assert.equal(result?.tier, 'high-confidence');
+});
+
+test('evaluateHighConfidenceDuplicate: branch-name-match is checked before the other two signals (order does not change the outcome, but evidence cites signal 3)', () => {
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      branchNameMergedPr: { number: 2254, mergedAt: '2026-08-23T21:47:05Z' },
+      closedByMergedPrNumbers: [999],
+      candidateFiles: [],
+      highContentionFiles: [],
+      mergedPrs: [],
+    },
+    2222,
+  );
+  assert.equal(result?.pass, false);
+  assert.match(result?.evidence ?? '', /#2254/);
+  assert.doesNotMatch(result?.evidence ?? '', /#999/);
+});
+
+test('evaluateHighConfidenceDuplicate: a malformed branchNameMergedPr (non-positive number) falls through, never crashes', () => {
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      // deliberately malformed to exercise the defensive guard
+      branchNameMergedPr: { number: 0, mergedAt: '2026-08-23T21:47:05Z' },
+      closedByMergedPrNumbers: [],
+      candidateFiles: [],
+      highContentionFiles: [],
+      mergedPrs: [],
+    },
+    2222,
+  );
+  assert.equal(result, null);
+});
+
 test('evaluateHighConfidenceDuplicate: same-candidate-files hit cites the PR number and file', () => {
   const result = evaluateHighConfidenceDuplicate(
     {
+      branchNameMergedPr: null,
       closedByMergedPrNumbers: [],
       candidateFiles: ['scripts/foo.mjs'],
       highContentionFiles: [],
@@ -105,6 +180,7 @@ test('evaluateHighConfidenceDuplicate: reuses normalizeContentionPath so mirrore
   // that only matches identical strings.
   const result = evaluateHighConfidenceDuplicate(
     {
+      branchNameMergedPr: null,
       closedByMergedPrNumbers: [],
       candidateFiles: [
         'idd-template/.github/instructions/idd-work.instructions.md',
@@ -133,6 +209,7 @@ test('evaluateHighConfidenceDuplicate: a high-contention-only overlap is not hig
   // broadly-shared file is not evidence THIS issue was superseded.
   const result = evaluateHighConfidenceDuplicate(
     {
+      branchNameMergedPr: null,
       closedByMergedPrNumbers: [],
       candidateFiles: ['audit/sync-manifest.json'],
       highContentionFiles: ['audit/sync-manifest.json'],
@@ -158,6 +235,7 @@ test('evaluateHighConfidenceDuplicate: a genuine file still hits when a co-liste
   // still fire on the genuine file's overlap.
   const result = evaluateHighConfidenceDuplicate(
     {
+      branchNameMergedPr: null,
       closedByMergedPrNumbers: [],
       candidateFiles: ['audit/sync-manifest.json', 'scripts/genuine.mjs'],
       highContentionFiles: ['audit/sync-manifest.json'],
@@ -182,6 +260,7 @@ test('evaluateHighConfidenceDuplicate: a genuine file still hits when a co-liste
 test('evaluateHighConfidenceDuplicate: closing-PR-reference is checked before the file-overlap scan', () => {
   const result = evaluateHighConfidenceDuplicate(
     {
+      branchNameMergedPr: null,
       closedByMergedPrNumbers: [111],
       candidateFiles: ['scripts/foo.mjs'],
       highContentionFiles: [],
@@ -207,6 +286,7 @@ test('evaluateHighConfidenceDuplicate: closing-PR-reference is checked before th
 test('evaluateHighConfidenceDuplicate: a closing-PR-reference hit carries tier "high-confidence"', () => {
   const result = evaluateHighConfidenceDuplicate(
     {
+      branchNameMergedPr: null,
       closedByMergedPrNumbers: [42],
       candidateFiles: [],
       highContentionFiles: [],
@@ -220,6 +300,7 @@ test('evaluateHighConfidenceDuplicate: a closing-PR-reference hit carries tier "
 test('evaluateHighConfidenceDuplicate: a same-candidate-files hit carries tier "high-confidence"', () => {
   const result = evaluateHighConfidenceDuplicate(
     {
+      branchNameMergedPr: null,
       closedByMergedPrNumbers: [],
       candidateFiles: ['scripts/foo.mjs'],
       highContentionFiles: [],
@@ -253,6 +334,7 @@ test('evaluateHighConfidenceDuplicate: file overlap with no reference to the can
   // #1863, not #1862.
   const result = evaluateHighConfidenceDuplicate(
     {
+      branchNameMergedPr: null,
       closedByMergedPrNumbers: [],
       candidateFiles: [
         'src/scripts/markdown-code.mts',
@@ -281,6 +363,7 @@ test('evaluateHighConfidenceDuplicate: file overlap with no reference to the can
 test('evaluateHighConfidenceDuplicate: true positive preserved via closingIssuesReferences', () => {
   const result = evaluateHighConfidenceDuplicate(
     {
+      branchNameMergedPr: null,
       closedByMergedPrNumbers: [],
       candidateFiles: ['scripts/target.mjs'],
       highContentionFiles: [],
@@ -312,6 +395,7 @@ test('evaluateHighConfidenceDuplicate: true positive preserved via a title/body 
   // flipping the old assertion, so it still exercises a true positive.
   const result = evaluateHighConfidenceDuplicate(
     {
+      branchNameMergedPr: null,
       closedByMergedPrNumbers: [],
       candidateFiles: ['scripts/target.mjs'],
       highContentionFiles: [],
@@ -344,6 +428,7 @@ test('evaluateHighConfidenceDuplicate: a bare "#<n>" citation with no closing ke
   // `null` (falls through to the caller's weak heuristic), not a hit.
   const result = evaluateHighConfidenceDuplicate(
     {
+      branchNameMergedPr: null,
       closedByMergedPrNumbers: [],
       candidateFiles: ['tests/suitability-triage.test.mts'],
       highContentionFiles: [],
@@ -366,6 +451,7 @@ test('evaluateHighConfidenceDuplicate: a bare "#<n>" citation with no closing ke
 test('evaluateHighConfidenceDuplicate: scan continues past a non-qualifying overlap to a later qualifying PR', () => {
   const result = evaluateHighConfidenceDuplicate(
     {
+      branchNameMergedPr: null,
       closedByMergedPrNumbers: [],
       candidateFiles: ['scripts/shared.mjs'],
       highContentionFiles: [],
@@ -716,6 +802,37 @@ test('buildMergedPrListArgs is read-only', () => {
   assertReadOnlyArgv(
     buildMergedPrListArgs('kurone-kito/idd-skill', '2026-07-01T00:00:00Z'),
   );
+});
+
+test('buildMergedPrByBranchArgs is read-only (#2313)', () => {
+  assertReadOnlyArgv(
+    buildMergedPrByBranchArgs(
+      'kurone-kito/idd-skill',
+      'issue/2222-fix-onboard-prefer-existing-config-json',
+    ),
+  );
+});
+
+test('buildMergedPrByBranchArgs filters server-side to the exact head branch and MERGED state (#2313)', () => {
+  const args = buildMergedPrByBranchArgs(
+    'kurone-kito/idd-skill',
+    'issue/2222-fix-onboard-prefer-existing-config-json',
+  );
+  const headIndex = args.indexOf('--head');
+  assert.notEqual(headIndex, -1);
+  assert.equal(
+    args[headIndex + 1],
+    'issue/2222-fix-onboard-prefer-existing-config-json',
+  );
+  const stateIndex = args.indexOf('--state');
+  assert.notEqual(stateIndex, -1);
+  assert.equal(args[stateIndex + 1], 'merged');
+  const jsonIndex = args.indexOf('--json');
+  assert.notEqual(jsonIndex, -1);
+  const fields = (args[jsonIndex + 1] ?? '').split(',');
+  assert.equal(fields.includes('number'), true);
+  assert.equal(fields.includes('headRefName'), true);
+  assert.equal(fields.includes('mergedAt'), true);
 });
 
 test('buildPrDetailArgs is read-only', () => {

--- a/tests/supersession-detection.test.mts
+++ b/tests/supersession-detection.test.mts
@@ -144,6 +144,20 @@ test('evaluateHighConfidenceDuplicate: a malformed branchNameMergedPr (non-posit
   assert.equal(result, null);
 });
 
+test('evaluateHighConfidenceDuplicate: a positive branchNameMergedPr.number with an empty mergedAt never produces Signal 3 evidence (CodeRabbit review finding, #2313)', () => {
+  const result = evaluateHighConfidenceDuplicate(
+    {
+      branchNameMergedPr: { number: 2254, mergedAt: '' },
+      closedByMergedPrNumbers: [],
+      candidateFiles: [],
+      highContentionFiles: [],
+      mergedPrs: [],
+    },
+    2222,
+  );
+  assert.equal(result, null);
+});
+
 test('evaluateHighConfidenceDuplicate: same-candidate-files hit cites the PR number and file', () => {
   const result = evaluateHighConfidenceDuplicate(
     {


### PR DESCRIPTION
## Summary

Check 4's high-confidence tier relied on two mechanical signals only:
`closedByPullRequestsReferences` (requires a GitHub closing keyword) and a
same-`## Candidate files`-overlap merged-PR scan. Neither signal fires when
a merged PR ships an issue's work on that issue's own IDD naming-convention
branch name with no closing keyword and no textual Candidate-files overlap
— exactly what let issue #2222 survive as `OPEN`/`ready` for three days
after PR #2254 had already merged the same work.

This PR adds a third high-confidence signal: an exact-match
`gh pr list --head <computed-branch> --state merged` lookup against the
issue's own `computeBranchName()`-derived branch (the same helper this
repository's own claim tooling already uses). Branch names are unique per
issue by construction, so a hit here is safe at the same high-confidence
tier as the two existing signals — no closing keyword or Candidate-files
overlap required.

## Changes

- `src/scripts/supersession-detection.mts`: extend
  `HighConfidenceDuplicateInput` with `branchNameMergedPr`, and check it
  first in `evaluateHighConfidenceDuplicate` (Signal 3); add
  `buildMergedPrByBranchArgs` (read-only `gh pr list --head ... --state
  merged` argv builder).
- `src/scripts/suitability-triage.mts`: add `fetchMergedPrByBranchName`
  CLI glue, gated behind the existing `shouldCollectEvidence` check (same
  pattern, own try/catch, as the two existing signals); wire
  `computeBranchName(issue.number, issue.title)` into the lookup; extend
  the options-boundary normalizer.
- Tests: pure-evaluator coverage for Signal 3 including the exact #2222
  miss scenario, argv-builder read-only/shape tests, and source-text
  wiring checks matching this file's existing convention for `runCli`
  (not itself unit-tested — real `gh` I/O).

## Test plan

- [x] `node --test tests/supersession-detection.test.mts
      tests/suitability-triage.test.mts` — 277/277 pass
- [x] `pnpm test` — full suite green
- [x] `pnpm run typecheck` / `pre-push-validate` (biome, dprint,
      markdownlint, cspell, `audit-docs.mjs --check`,
      `audit-code-span-wrap.mjs`, `build:check`, `idd-doctor.mjs`) — all
      green

Closes #2313

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Smou8PbTPvD32SMHkfvEia


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection for merged pull requests matching an issue’s computed branch name.
  * Matching pull requests provide an additional high-confidence duplicate signal.
  * Invalid, malformed, fork-owned, non-matching, or incomplete results are safely ignored.

* **Bug Fixes**
  * Improved duplicate evaluation when branch-based evidence is unavailable or incomplete.

* **Tests**
  * Added coverage for branch matching, filtering, precedence, malformed input, lookup failures, and merge-state validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->