### PR TITLE
fix(idd-doctor): narrow toolchain-residue check to documented forms

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -719,7 +719,7 @@ function isConcreteCommandValue(value) {
  * check` under `fix-validate`, whose documented form is `dprint fmt`) is
  * not exempt.
  */
-const DOCUMENTED_TOOLCHAIN_SEGMENTS = {
+export const DOCUMENTED_TOOLCHAIN_SEGMENTS = {
   'fix-validate': [
     'npx dprint fmt "**/*.md"',
     'npx markdownlint-cli2 --fix "**/*.md"',

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -663,7 +663,7 @@ function checkCommandResidueAndConsistency(
       if (normalized === null) {
         continue;
       }
-      const token = findToolchainResidueToken(normalized);
+      const token = findToolchainResidueToken(normalized, key);
       if (!token) {
         continue;
       }
@@ -710,9 +710,49 @@ function isConcreteCommandValue(value) {
   }
   return !/\{\{\s*[A-Za-z0-9_-]+\s*\}\}/.test(value);
 }
-function findToolchainResidueToken(value) {
+/**
+ * Per-key documented invocation segments from
+ * `idd-template/docs/customization.md`'s worked-example commands table,
+ * split on `&&` and trimmed. A command value's residue-token segment is
+ * exempt from the warning only when it matches one of these verbatim for
+ * the same key -- the same token under a different key (e.g. `dprint
+ * check` under `fix-validate`, whose documented form is `dprint fmt`) is
+ * not exempt.
+ */
+const DOCUMENTED_TOOLCHAIN_SEGMENTS = {
+  'fix-validate': [
+    'npx dprint fmt "**/*.md"',
+    'npx markdownlint-cli2 --fix "**/*.md"',
+    'npx markdownlint-cli2 "**/*.md"',
+    'npx cspell lint "**" --no-progress',
+  ],
+  'pre-push-validate': [
+    'npx dprint check "**/*.md"',
+    'npx markdownlint-cli2 "**/*.md"',
+    'npx cspell lint "**" --no-progress',
+  ],
+  'post-fix-validate': [
+    'npx dprint fmt "**/*.md"',
+    'npx markdownlint-cli2 --fix "**/*.md"',
+    'npx markdownlint-cli2 "**/*.md"',
+    'npx cspell lint "**" --no-progress',
+  ],
+};
+function findToolchainResidueToken(value, key) {
+  const documented = DOCUMENTED_TOOLCHAIN_SEGMENTS[key];
+  const segments = value.split('&&').map((segment) => segment.trim());
   for (const token of ['dprint', 'markdownlint-cli2', 'cspell']) {
-    if (new RegExp(`\\b${escapeRegex(token)}\\b`, 'i').test(value)) {
+    const pattern = new RegExp(`\\b${escapeRegex(token)}\\b`, 'i');
+    const matchingSegments = segments.filter((segment) =>
+      pattern.test(segment),
+    );
+    if (matchingSegments.length === 0) {
+      continue;
+    }
+    const allDocumented =
+      documented !== undefined &&
+      matchingSegments.every((segment) => documented.includes(segment));
+    if (!allDocumented) {
       return token;
     }
   }

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -798,7 +798,7 @@ function checkCommandResidueAndConsistency(
       if (normalized === null) {
         continue;
       }
-      const token = findToolchainResidueToken(normalized);
+      const token = findToolchainResidueToken(normalized, key);
       if (!token) {
         continue;
       }
@@ -853,9 +853,52 @@ function isConcreteCommandValue(value: string | null): boolean {
   return !/\{\{\s*[A-Za-z0-9_-]+\s*\}\}/.test(value);
 }
 
-function findToolchainResidueToken(value: string): string | null {
+/**
+ * Per-key documented invocation segments from
+ * `idd-template/docs/customization.md`'s worked-example commands table,
+ * split on `&&` and trimmed. A command value's residue-token segment is
+ * exempt from the warning only when it matches one of these verbatim for
+ * the same key -- the same token under a different key (e.g. `dprint
+ * check` under `fix-validate`, whose documented form is `dprint fmt`) is
+ * not exempt.
+ */
+const DOCUMENTED_TOOLCHAIN_SEGMENTS: Readonly<
+  Record<string, readonly string[]>
+> = {
+  'fix-validate': [
+    'npx dprint fmt "**/*.md"',
+    'npx markdownlint-cli2 --fix "**/*.md"',
+    'npx markdownlint-cli2 "**/*.md"',
+    'npx cspell lint "**" --no-progress',
+  ],
+  'pre-push-validate': [
+    'npx dprint check "**/*.md"',
+    'npx markdownlint-cli2 "**/*.md"',
+    'npx cspell lint "**" --no-progress',
+  ],
+  'post-fix-validate': [
+    'npx dprint fmt "**/*.md"',
+    'npx markdownlint-cli2 --fix "**/*.md"',
+    'npx markdownlint-cli2 "**/*.md"',
+    'npx cspell lint "**" --no-progress',
+  ],
+};
+
+function findToolchainResidueToken(value: string, key: string): string | null {
+  const documented = DOCUMENTED_TOOLCHAIN_SEGMENTS[key];
+  const segments = value.split('&&').map((segment) => segment.trim());
   for (const token of ['dprint', 'markdownlint-cli2', 'cspell']) {
-    if (new RegExp(`\\b${escapeRegex(token)}\\b`, 'i').test(value)) {
+    const pattern = new RegExp(`\\b${escapeRegex(token)}\\b`, 'i');
+    const matchingSegments = segments.filter((segment) =>
+      pattern.test(segment),
+    );
+    if (matchingSegments.length === 0) {
+      continue;
+    }
+    const allDocumented =
+      documented !== undefined &&
+      matchingSegments.every((segment) => documented.includes(segment));
+    if (!allDocumented) {
       return token;
     }
   }

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -862,7 +862,7 @@ function isConcreteCommandValue(value: string | null): boolean {
  * check` under `fix-validate`, whose documented form is `dprint fmt`) is
  * not exempt.
  */
-const DOCUMENTED_TOOLCHAIN_SEGMENTS: Readonly<
+export const DOCUMENTED_TOOLCHAIN_SEGMENTS: Readonly<
   Record<string, readonly string[]>
 > = {
   'fix-validate': [

--- a/tests/helper-runtime-profiles.test.mts
+++ b/tests/helper-runtime-profiles.test.mts
@@ -269,6 +269,33 @@ test('idd-doctor does not warn when commands match the documented worked-example
   );
 });
 
+test('idd-doctor does not warn on a fix-validate that documents the markdownlint-only subset', (t) => {
+  const root = createDoctorFixtureRepoFromConfig(
+    {
+      ...REQUIRED_CONFIG_BASE,
+      commands: {
+        'fix-validate':
+          'npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"',
+        'pre-push-validate': 'npm run lint',
+        'post-fix-validate': 'npm run test',
+        'install-deps': 'true',
+      },
+    },
+    {
+      markerPrefix: 'example-team',
+    },
+  );
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const report = runDoctor({ root, requireGithub: false });
+
+  assert.equal(report.errors.length, 0);
+  assert.ok(
+    report.warnings.every(
+      (warning) => !warning.startsWith('toolchain residue detected'),
+    ),
+  );
+});
+
 test('idd-doctor does not warn on a fix-validate that documents the cspell-only subset', (t) => {
   const root = createDoctorFixtureRepoFromConfig(
     {

--- a/tests/helper-runtime-profiles.test.mts
+++ b/tests/helper-runtime-profiles.test.mts
@@ -13,7 +13,10 @@ import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import { buildHelperRuntimeManifest } from '../src/scripts/helper-runtime-manifest.mts';
-import { runDoctor } from '../src/scripts/idd-doctor.mts';
+import {
+  DOCUMENTED_TOOLCHAIN_SEGMENTS,
+  runDoctor,
+} from '../src/scripts/idd-doctor.mts';
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 const FIXTURE_ROOT = new URL(
@@ -360,25 +363,6 @@ test('idd-doctor documented toolchain segments stay in sync with customization.m
     ['pre-push-validate', '**pre-push-validate**'],
     ['post-fix-validate', '**post-fix-validate**'],
   ];
-  const documentedSegments: Record<string, string[]> = {
-    'fix-validate': [
-      'npx dprint fmt "**/*.md"',
-      'npx markdownlint-cli2 --fix "**/*.md"',
-      'npx markdownlint-cli2 "**/*.md"',
-      'npx cspell lint "**" --no-progress',
-    ],
-    'pre-push-validate': [
-      'npx dprint check "**/*.md"',
-      'npx markdownlint-cli2 "**/*.md"',
-      'npx cspell lint "**" --no-progress',
-    ],
-    'post-fix-validate': [
-      'npx dprint fmt "**/*.md"',
-      'npx markdownlint-cli2 --fix "**/*.md"',
-      'npx markdownlint-cli2 "**/*.md"',
-      'npx cspell lint "**" --no-progress',
-    ],
-  };
   for (const [key, label] of rows) {
     const rowMatch = customizationDoc
       .split('\n')
@@ -389,9 +373,10 @@ test('idd-doctor documented toolchain segments stay in sync with customization.m
     const docSegments = (cellMatch as RegExpMatchArray)[1]
       .split('&&')
       .map((segment) => segment.trim());
+    const productionSegments = DOCUMENTED_TOOLCHAIN_SEGMENTS[key] ?? [];
     for (const segment of docSegments) {
       assert.ok(
-        documentedSegments[key].includes(segment),
+        productionSegments.includes(segment),
         `customization.md segment "${segment}" for "${key}" is missing from idd-doctor's DOCUMENTED_TOOLCHAIN_SEGMENTS`,
       );
     }

--- a/tests/helper-runtime-profiles.test.mts
+++ b/tests/helper-runtime-profiles.test.mts
@@ -240,6 +240,137 @@ test('idd-doctor skips residue warnings for idd-skill marker prefix', (t) => {
   );
 });
 
+test('idd-doctor does not warn when commands match the documented worked-example chain', (t) => {
+  const root = createDoctorFixtureRepoFromConfig(
+    {
+      ...REQUIRED_CONFIG_BASE,
+      commands: {
+        'fix-validate':
+          'npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"',
+        'pre-push-validate':
+          'npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress',
+        'post-fix-validate':
+          'npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress',
+        'install-deps': 'true',
+      },
+    },
+    {
+      markerPrefix: 'example-team',
+    },
+  );
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const report = runDoctor({ root, requireGithub: false });
+
+  assert.equal(report.errors.length, 0);
+  assert.ok(
+    report.warnings.every(
+      (warning) => !warning.startsWith('toolchain residue detected'),
+    ),
+  );
+});
+
+test('idd-doctor does not warn on a fix-validate that documents the cspell-only subset', (t) => {
+  const root = createDoctorFixtureRepoFromConfig(
+    {
+      ...REQUIRED_CONFIG_BASE,
+      commands: {
+        'fix-validate': 'npx cspell lint "**" --no-progress',
+        'pre-push-validate': 'npm run lint',
+        'post-fix-validate': 'npm run test',
+        'install-deps': 'true',
+      },
+    },
+    {
+      markerPrefix: 'example-team',
+    },
+  );
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const report = runDoctor({ root, requireGithub: false });
+
+  assert.equal(report.errors.length, 0);
+  assert.ok(
+    report.warnings.every(
+      (warning) => !warning.startsWith('toolchain residue detected'),
+    ),
+  );
+});
+
+test('idd-doctor still warns when a documented segment appears under the wrong command key', (t) => {
+  const root = createDoctorFixtureRepoFromConfig(
+    {
+      ...REQUIRED_CONFIG_BASE,
+      commands: {
+        'fix-validate': 'npm run lint',
+        'pre-push-validate': 'npx dprint fmt "**/*.md"',
+        'post-fix-validate': 'npm run test',
+        'install-deps': 'true',
+      },
+    },
+    {
+      markerPrefix: 'example-team',
+    },
+  );
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const report = runDoctor({ root, requireGithub: false });
+
+  assert.equal(report.errors.length, 0);
+  assert.ok(
+    report.warnings.some((warning) =>
+      warning.includes(
+        'toolchain residue detected for marker prefix "example-team"',
+      ),
+    ),
+  );
+});
+
+test('idd-doctor documented toolchain segments stay in sync with customization.md', () => {
+  const customizationDoc = readFileSync(
+    join(REPO_ROOT, 'idd-template/docs/customization.md'),
+    'utf8',
+  );
+  const rows: [string, string][] = [
+    ['fix-validate', '**fix-validate**'],
+    ['pre-push-validate', '**pre-push-validate**'],
+    ['post-fix-validate', '**post-fix-validate**'],
+  ];
+  const documentedSegments: Record<string, string[]> = {
+    'fix-validate': [
+      'npx dprint fmt "**/*.md"',
+      'npx markdownlint-cli2 --fix "**/*.md"',
+      'npx markdownlint-cli2 "**/*.md"',
+      'npx cspell lint "**" --no-progress',
+    ],
+    'pre-push-validate': [
+      'npx dprint check "**/*.md"',
+      'npx markdownlint-cli2 "**/*.md"',
+      'npx cspell lint "**" --no-progress',
+    ],
+    'post-fix-validate': [
+      'npx dprint fmt "**/*.md"',
+      'npx markdownlint-cli2 --fix "**/*.md"',
+      'npx markdownlint-cli2 "**/*.md"',
+      'npx cspell lint "**" --no-progress',
+    ],
+  };
+  for (const [key, label] of rows) {
+    const rowMatch = customizationDoc
+      .split('\n')
+      .find((line) => line.includes(`| ${label}`));
+    assert.ok(rowMatch, `expected a customization.md table row for ${key}`);
+    const cellMatch = rowMatch?.match(/\| `([^`]+)`\s*\|\s*$/);
+    assert.ok(cellMatch, `expected a command cell for ${key} in: ${rowMatch}`);
+    const docSegments = (cellMatch as RegExpMatchArray)[1]
+      .split('&&')
+      .map((segment) => segment.trim());
+    for (const segment of docSegments) {
+      assert.ok(
+        documentedSegments[key].includes(segment),
+        `customization.md segment "${segment}" for "${key}" is missing from idd-doctor's DOCUMENTED_TOOLCHAIN_SEGMENTS`,
+      );
+    }
+  }
+});
+
 test('idd-doctor does not warn when config and overview concrete commands agree', (t) => {
   const root = createDoctorFixtureRepoFromConfig(
     {


### PR DESCRIPTION
## Summary

`findToolchainResidueToken` in `src/scripts/idd-doctor.mts` flagged any
`fix-validate`/`pre-push-validate`/`post-fix-validate` command
containing a bare `dprint`/`markdownlint-cli2`/`cspell` token as
leftover idd-skill toolchain residue, with the only exemption being
`markerPrefix === 'idd-skill'` (which never applies to an adopter).
This misfires in two ways:

1. An adopter that deliberately chose one of these tools for its own
   linting gets a permanent, unwaivable warning.
2. `idd-template/docs/customization.md`'s own worked-example commands
   table recommends exactly these tools for non-Node adopters -- an
   adopter following the distributed template's own documented
   guidance still triggers the warning (reproduced on a real non-Node
   adopter repository: six persistent `WARN` findings).

### Fix

`findToolchainResidueToken` now splits a command value on `&&` and
compares each residue-token segment against the documented invocation
for that specific command *key*, copied verbatim from
`customization.md`'s commands table (`DOCUMENTED_TOOLCHAIN_SEGMENTS`).
A segment is exempt only when it matches the documented form for its
own key. `cspell`'s documented form is additionally allowed under
`fix-validate` (not just `pre-push-validate`/`post-fix-validate`),
matching the issue's "or the cspell equivalent" acceptance criterion.

This is deliberately key-aware, not just token-aware: the existing
`#520`/`#521` true-positive fixtures use `npx dprint check "**/*.md"`
under `fix-validate` -- but `fix-validate`'s documented `dprint` form
is `dprint fmt`, not `dprint check` (that's `pre-push-validate`'s
documented form). So that fixture still flags correctly, proving the
detector isn't just checking "does a documented segment exist
somewhere" but "does *this key* document *this* segment."

**Explicit non-goal**: this only exempts segments that are themselves
non-residue-tokens or that match a documented form. A verbatim copy of
idd-skill's own full `pre-push-validate` chain (which additionally
runs `npx biome check` and `pnpm run build:check`) is not caught by
this mechanism via those extra commands, since `biome` carries no
residue token and is a legitimate general-purpose adopter choice on
its own -- adding it as a co-signal would just recreate this same
false-positive class one tool over. Out of scope for this issue.

Closes #2217

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build` (regenerates `scripts/idd-doctor.mjs`)
- [x] `node --test tests/helper-runtime-profiles.test.mts` (16/16 pass,
      including 5 new tests: worked-example chain exempt,
      markdownlint-only subset under `fix-validate` exempt (AC1's
      named example), cspell-only subset under `fix-validate` exempt
      (AC1's "or the cspell equivalent"), a documented segment under
      the *wrong* key still flags, and a drift guard that parses
      `customization.md`'s table and asserts every segment is present
      in `DOCUMENTED_TOOLCHAIN_SEGMENTS`)
- [x] `pnpm run test:scripts` (4193/4193 pass, full suite)
- [x] `npx biome check --write && npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"` (fix-validate)
- [x] `npx biome check && npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress` (pre-push-validate)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `node scripts/idd-doctor.mjs` (passed, 3 pre-existing unrelated warnings)
- [x] `pnpm run lint:minimum` (AC4, full chain incl.
      `verify-workshop-integrity.mjs`; all green)
