### PR TITLE
feat(onboarding): define the configured development branch

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -499,6 +499,10 @@ require explicit operator confirmation:
     share fall from ~27% to ~3.7%, kurone-kito/idd-skill#1817)
 14. bootstrap execution mode (`direct-import` default, or
     `issue-mediated`)
+15. development branch (`developmentBranch`) that receives IDD feature
+    pull requests — proposed from the repository's live GitHub default
+    branch, verified against the configured remote before recording;
+    absent resolves the live default branch
 
 Use
 [Onboarding Reference — Policy Decisions](docs/onboarding/policy-decisions.md)

--- a/idd-template/docs/onboarding/hearing-catalog.json
+++ b/idd-template/docs/onboarding/hearing-catalog.json
@@ -90,9 +90,16 @@
       "prompt": "Which session may execute the F3 merge?",
       "explanation": "fully_autonomous_merge lets one trusted agent session merge after the normal gates. human_merge stops workers at the handoff gate for a human maintainer. separate_merge_agent reserves merge for a separately authorized actor. Propose human_merge unless the operator opts in to fully_autonomous_merge; recommend keeping human_merge for public/OSS or weak-model unattended loops.",
       "options": [
-        { "value": "human_merge", "isDefault": true },
-        { "value": "fully_autonomous_merge" },
-        { "value": "separate_merge_agent" }
+        {
+          "value": "human_merge",
+          "isDefault": true
+        },
+        {
+          "value": "fully_autonomous_merge"
+        },
+        {
+          "value": "separate_merge_agent"
+        }
       ],
       "mapsToConfig": "/mergePolicy"
     },
@@ -103,10 +110,19 @@
       "prompt": "Which PR review-authority profile should this repository use?",
       "explanation": "Keep the distributed GitHub Copilot advisory profile unless the operator chooses no-advisory, human-required, or another documented profile. Non-default profiles need matching phase-file updates from docs/idd-review-policy-profiles.md.",
       "options": [
-        { "value": "copilot-advisory", "isDefault": true },
-        { "value": "no-advisory" },
-        { "value": "human-required" },
-        { "value": "external-bot" }
+        {
+          "value": "copilot-advisory",
+          "isDefault": true
+        },
+        {
+          "value": "no-advisory"
+        },
+        {
+          "value": "human-required"
+        },
+        {
+          "value": "external-bot"
+        }
       ],
       "mapsToConfig": "/reviewPolicy"
     },
@@ -117,9 +133,16 @@
       "prompt": "Which review threads may an agent resolve on its own?",
       "explanation": "fast-agent-resolve is the distributed default. hybrid-reviewer-ack and strict-reviewer-resolve require matching updates to the review snapshot, triage, review-fix, pre-merge, and merge phase files. Branch-protection conversation-resolution rules always override this policy.",
       "options": [
-        { "value": "fast-agent-resolve", "isDefault": true },
-        { "value": "hybrid-reviewer-ack" },
-        { "value": "strict-reviewer-resolve" }
+        {
+          "value": "fast-agent-resolve",
+          "isDefault": true
+        },
+        {
+          "value": "hybrid-reviewer-ack"
+        },
+        {
+          "value": "strict-reviewer-resolve"
+        }
       ],
       "mapsToConfig": "/threadResolutionPolicy"
     },
@@ -130,8 +153,13 @@
       "prompt": "Keep the distributed critique-loop defaults, or record a local override?",
       "explanation": "Confirm whether the repository uses the shipped guardrails from docs/policy-constants.md or intentionally customizes critique-loop behavior before unattended execution. This decision is recorded in human-readable policy notes, not a required config field.",
       "options": [
-        { "value": "distributed-defaults", "isDefault": true },
-        { "value": "repository-override" }
+        {
+          "value": "distributed-defaults",
+          "isDefault": true
+        },
+        {
+          "value": "repository-override"
+        }
       ]
     },
     {
@@ -148,8 +176,13 @@
       "prompt": "Keep the distributed claim-timing defaults (stale age 24 h, heartbeat 12 h)?",
       "explanation": "The onboarding entry point should confirm whether the repository keeps claim-stale-age 24 h and claim-heartbeat-interval 12 h from docs/policy-constants.md before unattended workers begin.",
       "options": [
-        { "value": "distributed-defaults", "isDefault": true },
-        { "value": "repository-override" }
+        {
+          "value": "distributed-defaults",
+          "isDefault": true
+        },
+        {
+          "value": "repository-override"
+        }
       ],
       "mapsToConfig": "/claimTiming"
     },
@@ -160,8 +193,13 @@
       "prompt": "Keep the distributed CI wait defaults, or record a local override?",
       "explanation": "Distributed defaults are runningTimeout PT30M, generationTimeout PT10M, and rerunPolicy rerun-once. Customizing any value must keep .github/idd/config.json aligned with the CI, review-fix, and pre-merge instruction files.",
       "options": [
-        { "value": "rerun-once", "isDefault": true },
-        { "value": "hold" }
+        {
+          "value": "rerun-once",
+          "isDefault": true
+        },
+        {
+          "value": "hold"
+        }
       ],
       "mapsToConfig": "/ciWait/rerunPolicy"
     },
@@ -172,8 +210,13 @@
       "prompt": "Keep the secure-by-default issue-author approval gate, or record a config opt-out?",
       "explanation": "enabled-by-default requires a self-authorizing issue author or a fresh maintainer approval before claim. Opting out sets skipIssueAuthorApprovalGate true in .github/idd/config.json and the same decision in human-readable policy notes.",
       "options": [
-        { "value": "enabled-by-default", "isDefault": true },
-        { "value": "skip-gate" }
+        {
+          "value": "enabled-by-default",
+          "isDefault": true
+        },
+        {
+          "value": "skip-gate"
+        }
       ],
       "mapsToConfig": "/skipIssueAuthorApprovalGate"
     },
@@ -184,8 +227,13 @@
       "prompt": "Who may approve issue start when the issue-author approval gate stays enabled?",
       "explanation": "owners-and-maintainers-only is the recommended default. all-write-permission-actors also admits Write collaborators. Record the same enum in maintainerApprovalActorPolicy when .github/idd/config.json is present.",
       "options": [
-        { "value": "owners-and-maintainers-only", "isDefault": true },
-        { "value": "all-write-permission-actors" }
+        {
+          "value": "owners-and-maintainers-only",
+          "isDefault": true
+        },
+        {
+          "value": "all-write-permission-actors"
+        }
       ],
       "mapsToConfig": "/maintainerApprovalActorPolicy"
     },
@@ -196,8 +244,13 @@
       "prompt": "Install the optional issue-authoring skill into one native destination?",
       "explanation": "installed copies skills/issue-authoring/ into one selected native skill directory. not-installed continues without the companion. Do not add the same skill ID to multiple runtime roots by default. This is a docs-only decision.",
       "options": [
-        { "value": "not-installed", "isDefault": true },
-        { "value": "installed" }
+        {
+          "value": "not-installed",
+          "isDefault": true
+        },
+        {
+          "value": "installed"
+        }
       ]
     },
     {
@@ -207,10 +260,19 @@
       "prompt": "Which helper runtime profile should this repository record?",
       "explanation": "Auto-propose package-manager, vendored-node, or ephemeral-npx from repository evidence, but require explicit confirmation before recording anything other than instructions-only. Repositories without Node.js stay on instructions-only.",
       "options": [
-        { "value": "instructions-only", "isDefault": true },
-        { "value": "package-manager" },
-        { "value": "vendored-node" },
-        { "value": "ephemeral-npx" }
+        {
+          "value": "instructions-only",
+          "isDefault": true
+        },
+        {
+          "value": "package-manager"
+        },
+        {
+          "value": "vendored-node"
+        },
+        {
+          "value": "ephemeral-npx"
+        }
       ],
       "mapsToConfig": "/helperRuntime/profile"
     },
@@ -221,8 +283,13 @@
       "prompt": "Keep the three distributed IDD label names, or map them onto a local taxonomy?",
       "explanation": "Distributed defaults are roadmap, status:blocked-by-human, and status:needs-decision. If a semantic auto-labeler can infer those names, adopt the reserved-label guard recipe before relying on unattended discovery. The auto-labeler follow-up is nested under this item, not a separate catalog id.",
       "options": [
-        { "value": "distributed-defaults", "isDefault": true },
-        { "value": "custom-taxonomy" }
+        {
+          "value": "distributed-defaults",
+          "isDefault": true
+        },
+        {
+          "value": "custom-taxonomy"
+        }
       ],
       "mapsToConfig": "/labels"
     },
@@ -233,8 +300,13 @@
       "prompt": "Leave GitHub's require-up-to-date-head setting disabled?",
       "explanation": "Recommended: disabled. Enabling it can force a main-sync merge on every merely-BEHIND PR and multiply Copilot advisory rounds. IDD's conflict-triggered main-sync and F1/F2 freshness checks still catch correctness-critical drift. This is a docs-only GitHub ruleset decision.",
       "options": [
-        { "value": "disabled", "isDefault": true },
-        { "value": "enabled" }
+        {
+          "value": "disabled",
+          "isDefault": true
+        },
+        {
+          "value": "enabled"
+        }
       ]
     },
     {
@@ -244,9 +316,23 @@
       "prompt": "Run the initial IDD import as a direct commit, or through a reviewable PR?",
       "explanation": "direct-import is the distributed default. issue-mediated routes the same import through issue, branch, PR, and merge using the already-confirmed placeholder values and Step 1B decisions. Propose direct-import unless the operator asks for a reviewable first mutation. This is a docs-only decision.",
       "options": [
-        { "value": "direct-import", "isDefault": true },
-        { "value": "issue-mediated" }
+        {
+          "value": "direct-import",
+          "isDefault": true
+        },
+        {
+          "value": "issue-mediated"
+        }
       ]
+    },
+    {
+      "id": "development-branch",
+      "step": "1B",
+      "kind": "policy",
+      "prompt": "Which long-lived branch should IDD feature pull requests target?",
+      "explanation": "Distinct from the repository's trusted GitHub default branch used for workflow/configuration checkout. Propose the repository's live GitHub default branch as the candidate; require explicit confirmation or correction, then verify the selected branch exists on the configured remote before recording it. Release, hotfix, and development-to-default promotion flows are outside this decision's support boundary.",
+      "derivationHook": "deriveDevelopmentBranchCandidate",
+      "mapsToConfig": "/developmentBranch"
     }
   ]
 }

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -327,6 +327,23 @@ and only switch modes on explicit confirmation. See
 Bootstrap](issue-mediated-bootstrap.md) for the full procedure and
 prerequisites.
 
+### Development branch
+
+Confirm the long-lived branch that receives IDD feature pull requests,
+distinct from the repository's trusted GitHub default branch used for
+workflow/configuration checkout. Propose the repository's live GitHub
+default branch as the candidate, then require explicit confirmation or
+correction before recording anything else. Before recording an
+explicitly selected branch, verify it exists on the configured remote
+-- report a missing or malformed branch instead of creating one or
+silently falling back to another candidate.
+
+An absent `developmentBranch` resolves the live repository default
+branch, preserving backwards compatibility for a repository already
+onboarded without this setting. Release, hotfix, and
+development-to-default promotion flows are outside this decision's
+support boundary.
+
 ## Related default policies to confirm
 
 The onboarding entry point should also confirm whether the repository
@@ -429,6 +446,11 @@ Use a structure like this:
 ## IDD Policy Configuration
 
 This repository uses the following IDD policies:
+
+### Development Branch
+
+**Branch**: `{develop | main | ...}` (absent: resolves the live
+repository default branch)
 
 ### Merge Policy
 

--- a/schemas/policy.schema.json
+++ b/schemas/policy.schema.json
@@ -30,6 +30,11 @@
       "pattern": "^[a-z][a-z0-9-]{1,31}$",
       "description": "Prefix embedded in every marker token and generated label name (for example `idd-skill-roadmap-id`). Required when `config.json` exists; no schema default, though helper code falls back to `idd-skill` when the file itself is absent."
     },
+    "developmentBranch": {
+      "type": "string",
+      "pattern": "^(?!refs/heads/)\\S+$",
+      "description": "Long-lived branch that receives IDD feature pull requests, distinct from the repository's trusted GitHub default branch used for workflow/configuration checkout (#2271). A short branch name only, never a `refs/heads/` ref. Optional; absent resolves the repository's live GitHub default branch, and onboarding records this only after verifying the branch exists on the configured remote. Release, hotfix, and development-to-default promotion flows are outside this field's support boundary."
+    },
     "mergePolicy": {
       "type": "string",
       "enum": ["fully_autonomous_merge", "human_merge", "separate_merge_agent"],

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -51,6 +51,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { safeGhText } from './gh-exec.mjs';
 import {
   collectHelperRuntimeEvidence,
   collectVendoredFiles,
@@ -557,6 +558,80 @@ export function readGitRemoteUrl(targetDir) {
   } catch {
     return null;
   }
+}
+/**
+ * Default GitHub default-branch reader: `gh repo view <owner>/<repo>
+ * --json defaultBranchRef` (#2271), via the shared `gh-exec.mts` layer
+ * (#1675 -- every `gh` spawn routes through it, never a direct spawn of
+ * the `gh` executable itself). The explicit `owner/repo` positional (derived
+ * from the target's own `remote.origin.url`, the same evidence
+ * `resolvePlaceholderValues`'s `REPO_NAME` already reads) means this
+ * never depends on this *process's* cwd matching `targetDir`, unlike a
+ * bare `gh repo view`. Returns `null` on any failure -- unparsable
+ * remote, missing `gh`, no auth, no network, or an incomplete response --
+ * so callers fall back to treating the candidate as undetermined.
+ */
+export function readGithubDefaultBranch(targetDir) {
+  const remoteRef = parseRemoteRepoRef(readGitRemoteUrl(targetDir));
+  if (!remoteRef || remoteRef.owner === null) {
+    return null;
+  }
+  const output = safeGhText([
+    'repo',
+    'view',
+    `${remoteRef.owner}/${remoteRef.repo}`,
+    '--json',
+    'defaultBranchRef',
+  ]);
+  if (output === '') {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(output);
+    const branch = parsed.defaultBranchRef?.name;
+    return typeof branch === 'string' && branch.length > 0 ? branch : null;
+  } catch {
+    return null;
+  }
+}
+/**
+ * Default remote-branch-existence reader: `git ls-remote --exit-code
+ * --heads origin <branch>` (#2271). Deliberately independent of `gh` --
+ * a plain `git`-only check so recording an explicitly-selected
+ * development branch never requires GitHub CLI auth, only the `origin`
+ * remote already required for `readGitRemoteUrl` above.
+ */
+export function checkGitRemoteBranchExists(targetDir, branch) {
+  try {
+    execFileSync(
+      'git',
+      [
+        '-C',
+        targetDir,
+        'ls-remote',
+        '--exit-code',
+        '--heads',
+        'origin',
+        branch,
+      ],
+      { stdio: 'ignore' },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+/**
+ * Derive the onboarding candidate for `developmentBranch` (#2271): the
+ * repository's live GitHub default branch, via the injectable
+ * {@link OnboardEvidenceReaders.readDefaultBranch} (default
+ * {@link readGithubDefaultBranch}). Returns `null` when undetermined --
+ * the hearing flow then falls back to prompting with no derived default.
+ */
+export function deriveDevelopmentBranchCandidate(targetDir, readers = {}) {
+  const readDefaultBranch =
+    readers.readDefaultBranch ?? readGithubDefaultBranch;
+  return readDefaultBranch(targetDir);
 }
 /**
  * Resolve the seven placeholder values: explicit flag overrides win;
@@ -1230,14 +1305,29 @@ export function runVerify(sourceRoot, targetRoot, profile) {
 function isAnswerableHearingItem(item) {
   return item.kind !== 'check';
 }
-function buildHearCatalogItemViews(items, targetDir) {
-  const resolution = resolvePlaceholderValues(targetDir);
+/**
+ * Runtime derivation hooks for `policy`-kind catalog items (#2271's
+ * `development-branch` is the first). Distinct from `resolvePlaceholderValues`
+ * above, which only ever derives the seven PLACEHOLDER substitution
+ * values -- a policy item's `derivationHook` looks itself up here instead.
+ */
+const POLICY_DERIVATION_HOOKS = {
+  deriveDevelopmentBranchCandidate,
+};
+function buildHearCatalogItemViews(items, targetDir, readers = {}) {
+  const resolution = resolvePlaceholderValues(targetDir, {}, readers);
   return items.map((item) => {
     const documentedDefault =
       item.options?.find((o) => o.isDefault)?.value ?? null;
     const resolved = resolution.values[item.id];
+    const policyHook =
+      item.kind === 'policy' && item.derivationHook !== undefined
+        ? POLICY_DERIVATION_HOOKS[item.derivationHook]
+        : undefined;
     const derived =
-      resolved != null && resolved.source === 'derived' ? resolved.value : null;
+      resolved != null && resolved.source === 'derived'
+        ? resolved.value
+        : (policyHook?.(targetDir, readers) ?? null);
     const view = {
       id: item.id,
       step: item.step,
@@ -1397,14 +1487,17 @@ export async function runHearWizard(catalog, targetDir, options = {}) {
   const {
     isTTY = Boolean(process.stdin.isTTY && process.stdout.isTTY),
     prompt: promptFn,
+    readers = {},
   } = options;
   if (!isTTY) {
     throw new Error(HEAR_NON_TTY_ERROR);
   }
   const ask = promptFn ?? makeReadlinePrompt();
-  const views = buildHearCatalogItemViews(catalog.items, targetDir).filter(
-    (view) => view.kind !== 'check',
-  );
+  const views = buildHearCatalogItemViews(
+    catalog.items,
+    targetDir,
+    readers,
+  ).filter((view) => view.kind !== 'check');
   const byId = new Map(catalog.items.map((item) => [item.id, item]));
   const answers = [];
   for (const view of views) {
@@ -1737,6 +1830,7 @@ const CI_WAIT_DEFAULTS = {
  * decision, and are not part of this template.
  */
 const RECORD_POLICY_DOC_ROWS = [
+  { id: 'development-branch', heading: 'Development Branch', label: 'Branch' },
   { id: 'merge-policy', heading: 'Merge Policy', label: 'Policy' },
   { id: 'review-policy', heading: 'PR Review Policy', label: 'Profile' },
   {
@@ -1884,6 +1978,31 @@ function runRecordPolicyCli(args) {
     const translated = translateRecordPolicyAnswer(item, answer.value);
     if (translated) {
       setNestedValue(patch, translated.path, translated.value);
+    }
+  }
+  // #2271: a schema-valid developmentBranch string can still name a
+  // branch that does not exist on the configured remote -- verify before
+  // recording rather than creating the branch or silently falling back
+  // to another one. Local-git-only (`git ls-remote`), so this needs no
+  // GitHub CLI auth, only the `origin` remote --import already requires.
+  if (typeof patch.developmentBranch === 'string') {
+    const developmentBranch = patch.developmentBranch;
+    if (!checkGitRemoteBranchExists(targetDir, developmentBranch)) {
+      process.stdout.write(
+        `${JSON.stringify(
+          {
+            protocolVersion: '1',
+            mode: args.apply && !args.dryRun ? 'apply' : 'dry-run',
+            valid: false,
+            unresolved: [
+              `development-branch: "${developmentBranch}" was not found on the configured origin remote`,
+            ],
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      process.exit(1);
     }
   }
   // A syntactically valid config.json can still parse to a non-object root

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -59,6 +59,7 @@ import {
 } from './helper-runtime-manifest.mjs';
 import { findMissingWorktreeHardening } from './idd-doctor.mjs';
 import { loadOnboardingHearingCatalog } from './onboarding-hearing.mjs';
+import { inspectDevelopmentBranch } from './policy-helpers.mjs';
 import { makeReadlinePrompt } from './readline-prompt.mjs';
 import {
   loadJson,
@@ -1932,7 +1933,13 @@ function buildFilledPolicyDocument(answers) {
     sections.join('\n\n'),
   ].join('\n');
 }
-function runRecordPolicyCli(args) {
+/**
+ * Exported (not just called from the CLI dispatcher below) so the
+ * `readers` parameter is a genuine injection point unit tests can reach
+ * directly, matching {@link OnboardEvidenceReaders.readRemoteBranchExists}'s
+ * own doc comment (#2271 review).
+ */
+export function runRecordPolicyCli(args, readers = {}) {
   if (!args.transcript) {
     throw new Error('--record-policy requires --transcript <file>');
   }
@@ -1980,14 +1987,40 @@ function runRecordPolicyCli(args) {
       setNestedValue(patch, translated.path, translated.value);
     }
   }
-  // #2271: a schema-valid developmentBranch string can still name a
-  // branch that does not exist on the configured remote -- verify before
-  // recording rather than creating the branch or silently falling back
-  // to another one. Local-git-only (`git ls-remote`), so this needs no
-  // GitHub CLI auth, only the `origin` remote --import already requires.
+  // #2271: verify developmentBranch before recording rather than creating
+  // the branch or silently falling back to another one.
   if (typeof patch.developmentBranch === 'string') {
     const developmentBranch = patch.developmentBranch;
-    if (!checkGitRemoteBranchExists(targetDir, developmentBranch)) {
+    // Shape first (inspectDevelopmentBranch -- the one real non-test call
+    // site its own doc comment describes, #2271 review): a malformed
+    // value (whitespace, a `refs/heads/` prefix) gets its own specific
+    // reason instead of a misleading "not found on remote" message, and
+    // never reaches the git ls-remote call below at all.
+    const inspection = inspectDevelopmentBranch({ developmentBranch });
+    // Only a non-string/whitespace/refs-heads-prefixed value reaches
+    // 'invalid' here -- translateRecordPolicyAnswer already produced a
+    // plain string from the transcript, so 'absent' cannot occur.
+    if (inspection.status === 'invalid') {
+      process.stdout.write(
+        `${JSON.stringify(
+          {
+            protocolVersion: '1',
+            mode: args.apply && !args.dryRun ? 'apply' : 'dry-run',
+            valid: false,
+            unresolved: [`development-branch: ${inspection.reason}`],
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      process.exit(1);
+    }
+    // Local-git-only (`git ls-remote`, or the injected reader in tests),
+    // so this needs no GitHub CLI auth, only the `origin` remote --import
+    // already requires.
+    const remoteBranchExists =
+      readers.readRemoteBranchExists ?? checkGitRemoteBranchExists;
+    if (!remoteBranchExists(targetDir, developmentBranch)) {
       process.stdout.write(
         `${JSON.stringify(
           {

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -3,6 +3,49 @@
 // The scripts/policy-helpers.mjs copy is generated from the .mts source
 // named above by `pnpm run build`. Edit the .mts source, never the
 // generated .mjs. See docs/typescript-sources.md.
+/**
+ * A qualified branch name: non-empty, no whitespace anywhere (rejects
+ * both a blank string and internal/leading/trailing whitespace in one
+ * check), and -- checked separately below -- no `refs/heads/` prefix
+ * (this policy stores the short branch name IDD's own claim `branch:`
+ * field and `git worktree add <branch>` already expect, not a full ref).
+ */
+const DEVELOPMENT_BRANCH_PATTERN = /^\S+$/;
+const DEVELOPMENT_BRANCH_REFS_HEADS_PREFIX = 'refs/heads/';
+/**
+ * Inspect `developmentBranch` on a raw policy document without applying
+ * `normalizePolicyConfig`'s fail-safe-to-absent collapse -- mirrors
+ * {@link inspectCritiqueLoopDelegateLayer}'s absent/configured/malformed
+ * shape. Onboarding (and any future consumer) uses this to distinguish
+ * "no opinion, use the live default branch" from "operator configured an
+ * invalid value, fail closed" rather than treating both alike.
+ */
+export function inspectDevelopmentBranch(config) {
+  if (typeof config !== 'object' || config === null || Array.isArray(config)) {
+    return { status: 'absent' };
+  }
+  if (!Object.hasOwn(config, 'developmentBranch')) {
+    return { status: 'absent' };
+  }
+  const value = config.developmentBranch;
+  if (typeof value !== 'string') {
+    return { status: 'invalid', reason: 'developmentBranch must be a string' };
+  }
+  if (!DEVELOPMENT_BRANCH_PATTERN.test(value)) {
+    return {
+      status: 'invalid',
+      reason:
+        'developmentBranch must be non-empty and must not contain whitespace',
+    };
+  }
+  if (value.startsWith(DEVELOPMENT_BRANCH_REFS_HEADS_PREFIX)) {
+    return {
+      status: 'invalid',
+      reason: 'developmentBranch must be a branch name, not a refs/heads/ ref',
+    };
+  }
+  return { status: 'configured', branch: value };
+}
 const HELPER_RUNTIME_PROFILES = new Set([
   'package-manager',
   'vendored-node',
@@ -268,6 +311,12 @@ export function inspectHelperRuntimeConfig(config) {
 }
 export function normalizePolicyConfig(config) {
   if (typeof config !== 'object' || config === null || Array.isArray(config)) {
+    // Cast so this early-return branch structurally unifies with the main
+    // return below on the optional `developmentBranch` key -- otherwise
+    // the function's inferred return type is a union where one member
+    // lacks the key entirely, and every call site reading
+    // `.developmentBranch` fails to typecheck regardless of which branch
+    // its own arguments would actually take.
     return clone(POLICY_DEFAULTS);
   }
   const c = config;
@@ -337,7 +386,24 @@ export function normalizePolicyConfig(config) {
       POLICY_DEFAULTS.localValidationEvidence.maxAge,
     ),
   };
+  // #2271: own-property-omitted on both 'absent' and 'invalid' -- mirrors
+  // `providerOutage.declarationTarget` above. Normalization never throws;
+  // a caller that must distinguish "no opinion" from "operator configured
+  // an invalid value" (fail closed rather than silently inheriting the
+  // live default) uses inspectDevelopmentBranch() directly on the raw
+  // config instead of this collapsed result.
+  const developmentBranchInspection = inspectDevelopmentBranch(config);
+  // Explicitly typed for the same reason as the `critiqueLoop`/`delegate`
+  // comment above: a conditional spread's own literal-object branches
+  // don't narrow into one stable optional-key type, so a caller reading
+  // `.developmentBranch` off the inferred return type sees it as missing
+  // on the "absent" union member instead of merely optional.
+  const developmentBranchField =
+    developmentBranchInspection.status === 'configured'
+      ? { developmentBranch: developmentBranchInspection.branch }
+      : {};
   return {
+    ...developmentBranchField,
     issueScope: parseEnum(
       c?.issueScope,
       ISSUE_SCOPES,

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -53,6 +53,7 @@ import {
 } from 'node:fs';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 
+import { safeGhText } from './gh-exec.mts';
 import {
   collectHelperRuntimeEvidence,
   collectVendoredFiles,
@@ -641,6 +642,19 @@ export type PlaceholderOverrides = Partial<Record<string, string>>;
 export interface OnboardEvidenceReaders {
   /** Returns the target tree's `remote.origin.url`, or `null`. */
   readRemoteUrl?: (targetDir: string) => string | null;
+  /**
+   * Returns the repository's live GitHub default branch (#2271), or
+   * `null` when `gh` is unavailable, unauthenticated, or the read fails.
+   * Injectable so hearing-flow tests never need real `gh` credentials.
+   */
+  readDefaultBranch?: (targetDir: string) => string | null;
+  /**
+   * True when `branch` exists on the configured `origin` remote (#2271).
+   * Injectable for the same reason as {@link readDefaultBranch} -- the
+   * default implementation shells out to `git ls-remote`, which real
+   * unit tests must not depend on.
+   */
+  readRemoteBranchExists?: (targetDir: string, branch: string) => boolean;
 }
 
 /** Default remote-URL reader: `git -C <target> config remote.origin.url`. */
@@ -655,6 +669,91 @@ export function readGitRemoteUrl(targetDir: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Default GitHub default-branch reader: `gh repo view <owner>/<repo>
+ * --json defaultBranchRef` (#2271), via the shared `gh-exec.mts` layer
+ * (#1675 -- every `gh` spawn routes through it, never a direct spawn of
+ * the `gh` executable itself). The explicit `owner/repo` positional (derived
+ * from the target's own `remote.origin.url`, the same evidence
+ * `resolvePlaceholderValues`'s `REPO_NAME` already reads) means this
+ * never depends on this *process's* cwd matching `targetDir`, unlike a
+ * bare `gh repo view`. Returns `null` on any failure -- unparsable
+ * remote, missing `gh`, no auth, no network, or an incomplete response --
+ * so callers fall back to treating the candidate as undetermined.
+ */
+export function readGithubDefaultBranch(targetDir: string): string | null {
+  const remoteRef = parseRemoteRepoRef(readGitRemoteUrl(targetDir));
+  if (!remoteRef || remoteRef.owner === null) {
+    return null;
+  }
+  const output = safeGhText([
+    'repo',
+    'view',
+    `${remoteRef.owner}/${remoteRef.repo}`,
+    '--json',
+    'defaultBranchRef',
+  ]);
+  if (output === '') {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(output) as {
+      defaultBranchRef?: { name?: unknown };
+    };
+    const branch = parsed.defaultBranchRef?.name;
+    return typeof branch === 'string' && branch.length > 0 ? branch : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Default remote-branch-existence reader: `git ls-remote --exit-code
+ * --heads origin <branch>` (#2271). Deliberately independent of `gh` --
+ * a plain `git`-only check so recording an explicitly-selected
+ * development branch never requires GitHub CLI auth, only the `origin`
+ * remote already required for `readGitRemoteUrl` above.
+ */
+export function checkGitRemoteBranchExists(
+  targetDir: string,
+  branch: string,
+): boolean {
+  try {
+    execFileSync(
+      'git',
+      [
+        '-C',
+        targetDir,
+        'ls-remote',
+        '--exit-code',
+        '--heads',
+        'origin',
+        branch,
+      ],
+      { stdio: 'ignore' },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Derive the onboarding candidate for `developmentBranch` (#2271): the
+ * repository's live GitHub default branch, via the injectable
+ * {@link OnboardEvidenceReaders.readDefaultBranch} (default
+ * {@link readGithubDefaultBranch}). Returns `null` when undetermined --
+ * the hearing flow then falls back to prompting with no derived default.
+ */
+export function deriveDevelopmentBranchCandidate(
+  targetDir: string,
+  readers: OnboardEvidenceReaders = {},
+): string | null {
+  const readDefaultBranch =
+    readers.readDefaultBranch ?? readGithubDefaultBranch;
+  return readDefaultBranch(targetDir);
 }
 
 /** Outcome of resolving all seven placeholder values for a target tree. */
@@ -1571,17 +1670,37 @@ interface HearCatalogItemView {
   derived: string | null;
 }
 
+/**
+ * Runtime derivation hooks for `policy`-kind catalog items (#2271's
+ * `development-branch` is the first). Distinct from `resolvePlaceholderValues`
+ * above, which only ever derives the seven PLACEHOLDER substitution
+ * values -- a policy item's `derivationHook` looks itself up here instead.
+ */
+const POLICY_DERIVATION_HOOKS: Record<
+  string,
+  (targetDir: string, readers: OnboardEvidenceReaders) => string | null
+> = {
+  deriveDevelopmentBranchCandidate,
+};
+
 function buildHearCatalogItemViews(
   items: readonly HearingCatalogItem[],
   targetDir: string,
+  readers: OnboardEvidenceReaders = {},
 ): HearCatalogItemView[] {
-  const resolution = resolvePlaceholderValues(targetDir);
+  const resolution = resolvePlaceholderValues(targetDir, {}, readers);
   return items.map((item) => {
     const documentedDefault =
       item.options?.find((o) => o.isDefault)?.value ?? null;
     const resolved = resolution.values[item.id];
+    const policyHook =
+      item.kind === 'policy' && item.derivationHook !== undefined
+        ? POLICY_DERIVATION_HOOKS[item.derivationHook]
+        : undefined;
     const derived =
-      resolved != null && resolved.source === 'derived' ? resolved.value : null;
+      resolved != null && resolved.source === 'derived'
+        ? resolved.value
+        : (policyHook?.(targetDir, readers) ?? null);
     const view: HearCatalogItemView = {
       id: item.id,
       step: item.step,
@@ -1779,6 +1898,8 @@ function validateHearTranscriptShape(transcript: unknown): string[] {
 interface RunHearWizardOptions {
   isTTY?: boolean;
   prompt?: PromptFn;
+  /** Injected evidence readers (#2271); tests use this to avoid real `gh`/`git` network calls. */
+  readers?: OnboardEvidenceReaders;
 }
 
 export const HEAR_NON_TTY_ERROR =
@@ -1800,14 +1921,17 @@ export async function runHearWizard(
   const {
     isTTY = Boolean(process.stdin.isTTY && process.stdout.isTTY),
     prompt: promptFn,
+    readers = {},
   } = options;
   if (!isTTY) {
     throw new Error(HEAR_NON_TTY_ERROR);
   }
   const ask = promptFn ?? makeReadlinePrompt();
-  const views = buildHearCatalogItemViews(catalog.items, targetDir).filter(
-    (view) => view.kind !== 'check',
-  );
+  const views = buildHearCatalogItemViews(
+    catalog.items,
+    targetDir,
+    readers,
+  ).filter((view) => view.kind !== 'check');
   const byId = new Map(catalog.items.map((item) => [item.id, item]));
   const answers: HearAnswer[] = [];
   for (const view of views) {
@@ -2206,6 +2330,7 @@ const CI_WAIT_DEFAULTS = {
  * decision, and are not part of this template.
  */
 const RECORD_POLICY_DOC_ROWS: readonly RecordPolicyDocRow[] = [
+  { id: 'development-branch', heading: 'Development Branch', label: 'Branch' },
   { id: 'merge-policy', heading: 'Merge Policy', label: 'Policy' },
   { id: 'review-policy', heading: 'PR Review Policy', label: 'Profile' },
   {
@@ -2355,6 +2480,31 @@ function runRecordPolicyCli(args: ParsedArgs): void {
     const translated = translateRecordPolicyAnswer(item, answer.value);
     if (translated) {
       setNestedValue(patch, translated.path, translated.value);
+    }
+  }
+  // #2271: a schema-valid developmentBranch string can still name a
+  // branch that does not exist on the configured remote -- verify before
+  // recording rather than creating the branch or silently falling back
+  // to another one. Local-git-only (`git ls-remote`), so this needs no
+  // GitHub CLI auth, only the `origin` remote --import already requires.
+  if (typeof patch.developmentBranch === 'string') {
+    const developmentBranch = patch.developmentBranch;
+    if (!checkGitRemoteBranchExists(targetDir, developmentBranch)) {
+      process.stdout.write(
+        `${JSON.stringify(
+          {
+            protocolVersion: '1',
+            mode: args.apply && !args.dryRun ? 'apply' : 'dry-run',
+            valid: false,
+            unresolved: [
+              `development-branch: "${developmentBranch}" was not found on the configured origin remote`,
+            ],
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      process.exit(1);
     }
   }
   // A syntactically valid config.json can still parse to a non-object root

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -65,6 +65,7 @@ import type {
   OnboardingHearingCatalog,
 } from './onboarding-hearing.mts';
 import { loadOnboardingHearingCatalog } from './onboarding-hearing.mts';
+import { inspectDevelopmentBranch } from './policy-helpers.mts';
 import type { PromptFn } from './readline-prompt.mts';
 import { makeReadlinePrompt } from './readline-prompt.mts';
 import {
@@ -2434,7 +2435,16 @@ function buildFilledPolicyDocument(answers: readonly HearAnswer[]): string {
   ].join('\n');
 }
 
-function runRecordPolicyCli(args: ParsedArgs): void {
+/**
+ * Exported (not just called from the CLI dispatcher below) so the
+ * `readers` parameter is a genuine injection point unit tests can reach
+ * directly, matching {@link OnboardEvidenceReaders.readRemoteBranchExists}'s
+ * own doc comment (#2271 review).
+ */
+export function runRecordPolicyCli(
+  args: ParsedArgs,
+  readers: OnboardEvidenceReaders = {},
+): void {
   if (!args.transcript) {
     throw new Error('--record-policy requires --transcript <file>');
   }
@@ -2482,14 +2492,40 @@ function runRecordPolicyCli(args: ParsedArgs): void {
       setNestedValue(patch, translated.path, translated.value);
     }
   }
-  // #2271: a schema-valid developmentBranch string can still name a
-  // branch that does not exist on the configured remote -- verify before
-  // recording rather than creating the branch or silently falling back
-  // to another one. Local-git-only (`git ls-remote`), so this needs no
-  // GitHub CLI auth, only the `origin` remote --import already requires.
+  // #2271: verify developmentBranch before recording rather than creating
+  // the branch or silently falling back to another one.
   if (typeof patch.developmentBranch === 'string') {
     const developmentBranch = patch.developmentBranch;
-    if (!checkGitRemoteBranchExists(targetDir, developmentBranch)) {
+    // Shape first (inspectDevelopmentBranch -- the one real non-test call
+    // site its own doc comment describes, #2271 review): a malformed
+    // value (whitespace, a `refs/heads/` prefix) gets its own specific
+    // reason instead of a misleading "not found on remote" message, and
+    // never reaches the git ls-remote call below at all.
+    const inspection = inspectDevelopmentBranch({ developmentBranch });
+    // Only a non-string/whitespace/refs-heads-prefixed value reaches
+    // 'invalid' here -- translateRecordPolicyAnswer already produced a
+    // plain string from the transcript, so 'absent' cannot occur.
+    if (inspection.status === 'invalid') {
+      process.stdout.write(
+        `${JSON.stringify(
+          {
+            protocolVersion: '1',
+            mode: args.apply && !args.dryRun ? 'apply' : 'dry-run',
+            valid: false,
+            unresolved: [`development-branch: ${inspection.reason}`],
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      process.exit(1);
+    }
+    // Local-git-only (`git ls-remote`, or the injected reader in tests),
+    // so this needs no GitHub CLI auth, only the `origin` remote --import
+    // already requires.
+    const remoteBranchExists =
+      readers.readRemoteBranchExists ?? checkGitRemoteBranchExists;
+    if (!remoteBranchExists(targetDir, developmentBranch)) {
       process.stdout.write(
         `${JSON.stringify(
           {

--- a/src/scripts/policy-helpers.mts
+++ b/src/scripts/policy-helpers.mts
@@ -86,6 +86,70 @@ export interface EffectiveCritiqueLoopDelegate {
   reason?: string;
 }
 
+/**
+ * How one policy document presents `developmentBranch` (#2271). `absent`
+ * means "no explicit value" -- callers fall back to the repository's live
+ * GitHub default branch. `invalid` is fail-closed: a present-but-malformed
+ * value must never silently resolve to the live default, unlike `absent`.
+ */
+export type DevelopmentBranchStatus = 'absent' | 'configured' | 'invalid';
+
+export interface DevelopmentBranchInspection {
+  status: DevelopmentBranchStatus;
+  /** Present only when `status` is `'configured'`. */
+  branch?: string;
+  /** Present only when `status` is `'invalid'`. */
+  reason?: string;
+}
+
+/**
+ * A qualified branch name: non-empty, no whitespace anywhere (rejects
+ * both a blank string and internal/leading/trailing whitespace in one
+ * check), and -- checked separately below -- no `refs/heads/` prefix
+ * (this policy stores the short branch name IDD's own claim `branch:`
+ * field and `git worktree add <branch>` already expect, not a full ref).
+ */
+const DEVELOPMENT_BRANCH_PATTERN = /^\S+$/;
+const DEVELOPMENT_BRANCH_REFS_HEADS_PREFIX = 'refs/heads/';
+
+/**
+ * Inspect `developmentBranch` on a raw policy document without applying
+ * `normalizePolicyConfig`'s fail-safe-to-absent collapse -- mirrors
+ * {@link inspectCritiqueLoopDelegateLayer}'s absent/configured/malformed
+ * shape. Onboarding (and any future consumer) uses this to distinguish
+ * "no opinion, use the live default branch" from "operator configured an
+ * invalid value, fail closed" rather than treating both alike.
+ */
+export function inspectDevelopmentBranch(
+  config: unknown,
+): DevelopmentBranchInspection {
+  if (typeof config !== 'object' || config === null || Array.isArray(config)) {
+    return { status: 'absent' };
+  }
+  if (!Object.hasOwn(config, 'developmentBranch')) {
+    return { status: 'absent' };
+  }
+
+  const value = (config as RawConfig).developmentBranch;
+  if (typeof value !== 'string') {
+    return { status: 'invalid', reason: 'developmentBranch must be a string' };
+  }
+  if (!DEVELOPMENT_BRANCH_PATTERN.test(value)) {
+    return {
+      status: 'invalid',
+      reason:
+        'developmentBranch must be non-empty and must not contain whitespace',
+    };
+  }
+  if (value.startsWith(DEVELOPMENT_BRANCH_REFS_HEADS_PREFIX)) {
+    return {
+      status: 'invalid',
+      reason: 'developmentBranch must be a branch name, not a refs/heads/ ref',
+    };
+  }
+  return { status: 'configured', branch: value };
+}
+
 // Structural view of the untrusted config object parsed from an
 // adopter-controlled JSON file. Every field is optional and weakly
 // typed; the runtime guards below perform the real validation.
@@ -159,6 +223,7 @@ interface RawConfig {
   mergeGate?: { soloCodeownerAdminFallback?: unknown };
   providerOutage?: { declarationTarget?: unknown; maxValidity?: unknown };
   localValidationEvidence?: { maxAge?: unknown };
+  developmentBranch?: unknown;
 }
 
 const HELPER_RUNTIME_PROFILES = new Set([
@@ -443,7 +508,15 @@ export function inspectHelperRuntimeConfig(
 
 export function normalizePolicyConfig(config: unknown) {
   if (typeof config !== 'object' || config === null || Array.isArray(config)) {
-    return clone(POLICY_DEFAULTS);
+    // Cast so this early-return branch structurally unifies with the main
+    // return below on the optional `developmentBranch` key -- otherwise
+    // the function's inferred return type is a union where one member
+    // lacks the key entirely, and every call site reading
+    // `.developmentBranch` fails to typecheck regardless of which branch
+    // its own arguments would actually take.
+    return clone(POLICY_DEFAULTS) as typeof POLICY_DEFAULTS & {
+      developmentBranch?: string;
+    };
   }
 
   const c = config as RawConfig;
@@ -514,8 +587,25 @@ export function normalizePolicyConfig(config: unknown) {
       POLICY_DEFAULTS.localValidationEvidence.maxAge,
     ),
   };
+  // #2271: own-property-omitted on both 'absent' and 'invalid' -- mirrors
+  // `providerOutage.declarationTarget` above. Normalization never throws;
+  // a caller that must distinguish "no opinion" from "operator configured
+  // an invalid value" (fail closed rather than silently inheriting the
+  // live default) uses inspectDevelopmentBranch() directly on the raw
+  // config instead of this collapsed result.
+  const developmentBranchInspection = inspectDevelopmentBranch(config);
+  // Explicitly typed for the same reason as the `critiqueLoop`/`delegate`
+  // comment above: a conditional spread's own literal-object branches
+  // don't narrow into one stable optional-key type, so a caller reading
+  // `.developmentBranch` off the inferred return type sees it as missing
+  // on the "absent" union member instead of merely optional.
+  const developmentBranchField: { developmentBranch?: string } =
+    developmentBranchInspection.status === 'configured'
+      ? { developmentBranch: developmentBranchInspection.branch as string }
+      : {};
 
   return {
+    ...developmentBranchField,
     issueScope: parseEnum(
       c?.issueScope,
       ISSUE_SCOPES,

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -52,6 +52,7 @@ import {
   resolvePlaceholderValues,
   restoreExistingCommandsTable,
   runHearWizard,
+  runRecordPolicyCli,
   runVerify,
   SCAN_EXCLUDED_PATHS,
   scanPlaceholderTokens,
@@ -2985,6 +2986,124 @@ test('bin/idd-onboard.mjs --record-policy exits 1 and writes nothing when develo
     readFileSync(join(root, '.github', 'idd', 'config.json'), 'utf8'),
   ) as Record<string, unknown>;
   assert.equal('developmentBranch' in config, false);
+});
+
+test('bin/idd-onboard.mjs --record-policy exits 1 on a malformed developmentBranch before ever checking the remote (#2271 review)', () => {
+  const { root } = makeGitRemoteFixture();
+  mkdirSync(join(root, '.github', 'idd'), { recursive: true });
+  writeFileSync(
+    join(root, '.github', 'idd', 'config.json'),
+    [
+      '{',
+      '  "markerPrefix": "{{PROJECT_MARKER_PREFIX}}",',
+      '  "trustedMarkerActors": ["{{TRUSTED_MARKER_ACTOR}}"],',
+      '  "commands": {',
+      '    "install-deps": "{{INSTALL_DEPS_COMMAND}}",',
+      '    "fix-validate": "{{FIX_VALIDATE_COMMANDS}}",',
+      '    "pre-push-validate": "{{PRE_PUSH_VALIDATE_COMMANDS}}",',
+      '    "post-fix-validate": "{{POST_FIX_VALIDATE_COMMANDS}}"',
+      '  }',
+      '}',
+      '',
+    ].join('\n'),
+  );
+  // Non-empty (passes --hear --apply's generic non-empty check) but
+  // contains whitespace, so only inspectDevelopmentBranch's stricter
+  // shape check rejects it -- a hand-edited-transcript scenario.
+  const answers = buildValidHearAnswers();
+  answers['development-branch'] = 'my branch';
+  const transcript = confirmTranscript(root, answers);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(transcript));
+
+  const { status, verdict } = runCliBin([
+    '--record-policy',
+    '--transcript',
+    transcriptPath,
+    '--target',
+    root,
+    '--apply',
+  ]);
+  assert.equal(status, 1);
+  assert.equal(verdict.valid, false);
+  assert.ok(
+    (verdict.unresolved as string[]).some(
+      (message) =>
+        message.includes('development-branch') &&
+        message.includes('whitespace') &&
+        !message.includes('not found on the configured origin remote'),
+    ),
+    `expected a shape-validation message, got: ${JSON.stringify(verdict.unresolved)}`,
+  );
+});
+
+test('runRecordPolicyCli uses the injected readRemoteBranchExists reader instead of a real git ls-remote (#2271 review)', () => {
+  const root = makeFixtureDir();
+  mkdirSync(join(root, '.github', 'idd'), { recursive: true });
+  writeFileSync(
+    join(root, '.github', 'idd', 'config.json'),
+    '{"markerPrefix":"m","trustedMarkerActors":[],"commands":{"install-deps":"x","fix-validate":"x","pre-push-validate":"x","post-fix-validate":"x"}}\n',
+  );
+  const answers = buildValidHearAnswers();
+  answers['development-branch'] = 'develop';
+  const transcript = confirmTranscript(root, answers);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(transcript));
+
+  let calledWith: [string, string] | null = null;
+  const originalExit = process.exit;
+  const originalWrite = process.stdout.write;
+  const chunks: string[] = [];
+  process.stdout.write = ((chunk: string) => {
+    chunks.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  process.exit = ((code?: number) => {
+    throw new Error(`process.exit(${code})`);
+  }) as typeof process.exit;
+  try {
+    runRecordPolicyCli(
+      {
+        substitute: false,
+        importMode: false,
+        verify: false,
+        hear: false,
+        recordPolicy: true,
+        propose: false,
+        apply: true,
+        answers: undefined,
+        fromTranscript: undefined,
+        transcript: transcriptPath,
+        writePolicyDoc: undefined,
+        source: undefined,
+        target: root,
+        dryRun: false,
+        force: false,
+        profile: undefined,
+        overrides: {},
+        help: false,
+        allowRoots: [tmpdir()],
+      },
+      {
+        readRemoteBranchExists: (targetDir, branch) => {
+          calledWith = [targetDir, branch];
+          return true;
+        },
+      },
+    );
+  } catch (error) {
+    assert.match(String(error), /process\.exit\(0\)/);
+  } finally {
+    process.exit = originalExit;
+    process.stdout.write = originalWrite;
+  }
+  assert.deepEqual(calledWith, [root, 'develop']);
+  const verdict = JSON.parse(chunks.join('')) as Record<string, unknown>;
+  assert.equal(verdict.written, true);
+  const config = JSON.parse(
+    readFileSync(join(root, '.github', 'idd', 'config.json'), 'utf8'),
+  ) as Record<string, unknown>;
+  assert.equal(config.developmentBranch, 'develop');
 });
 
 test('importing idd-onboard.mts has no import-time side effect', async () => {

--- a/tests/idd-onboard.test.mts
+++ b/tests/idd-onboard.test.mts
@@ -31,9 +31,11 @@ import {
   applySubstitutionPlan,
   buildImportPlan,
   buildSubstitutionPlan,
+  checkGitRemoteBranchExists,
   checkManifestCompleteness,
   checkPlaceholderResidue,
   checkStaleImportSignal,
+  deriveDevelopmentBranchCandidate,
   deriveInstallDepsCommand,
   deriveMarkerPrefix,
   deriveValidateCommands,
@@ -2839,6 +2841,152 @@ test('runHearWizard shows each explanation, confirms the shown default on empty 
   assert.deepEqual(validate(transcript, schema), []);
 });
 
+// ---------------------------------------------------------------------------
+// #2271: developmentBranch onboarding hearing item
+// ---------------------------------------------------------------------------
+
+test('deriveDevelopmentBranchCandidate returns the injected default-branch reader value, or null when undetermined', () => {
+  assert.equal(
+    deriveDevelopmentBranchCandidate('/unused', {
+      readDefaultBranch: () => 'develop',
+    }),
+    'develop',
+  );
+  assert.equal(
+    deriveDevelopmentBranchCandidate('/unused', {
+      readDefaultBranch: () => null,
+    }),
+    null,
+  );
+  // No injected reader and no real `gh` evidence for this bogus path:
+  // falls back to the real readGithubDefaultBranch, which fails closed to
+  // null rather than throwing.
+  assert.equal(
+    deriveDevelopmentBranchCandidate(
+      join(tmpdir(), 'idd-onboard-nonexistent-path'),
+    ),
+    null,
+  );
+});
+
+/** A git repo with a local `origin` remote whose only branch is `main`. */
+function makeGitRemoteFixture(): { root: string; remoteRoot: string } {
+  const remoteRoot = mkdtempSync(join(tmpdir(), 'idd-onboard-remote-'));
+  execFileSync('git', ['init', '--initial-branch=main', remoteRoot], {
+    stdio: 'ignore',
+  });
+  execFileSync(
+    'git',
+    ['-C', remoteRoot, 'config', 'user.email', 'fixture@example.com'],
+    { stdio: 'ignore' },
+  );
+  execFileSync('git', ['-C', remoteRoot, 'config', 'user.name', 'Fixture'], {
+    stdio: 'ignore',
+  });
+  writeFileSync(join(remoteRoot, 'README.md'), '# fixture\n');
+  execFileSync('git', ['-C', remoteRoot, 'add', 'README.md'], {
+    stdio: 'ignore',
+  });
+  execFileSync(
+    'git',
+    ['-C', remoteRoot, 'commit', '--no-gpg-sign', '-m', 'fixture'],
+    { stdio: 'ignore' },
+  );
+  const root = makeFixtureDir();
+  execFileSync('git', ['init', '--initial-branch=main', root], {
+    stdio: 'ignore',
+  });
+  execFileSync('git', ['-C', root, 'remote', 'add', 'origin', remoteRoot], {
+    stdio: 'ignore',
+  });
+  return { root, remoteRoot };
+}
+
+test('checkGitRemoteBranchExists is true for a branch present on origin, false otherwise -- purely local, no credentials', () => {
+  const { root } = makeGitRemoteFixture();
+  assert.equal(checkGitRemoteBranchExists(root, 'main'), true);
+  assert.equal(checkGitRemoteBranchExists(root, 'no-such-branch'), false);
+});
+
+test("runHearWizard offers the injected default-branch candidate as development-branch's effective default", async () => {
+  const root = makeFixtureDir();
+  writeHearFixture(root);
+  const catalog = loadOnboardingHearingCatalog();
+  const prompt: PromptFn = async (question: string) => {
+    if (question.startsWith('development-branch')) {
+      // Confirm the shown default via empty input, same convention as the
+      // broader wizard test above.
+      assert.match(question, /\[develop\]/);
+      return '';
+    }
+    const hasShownDefault = / \[/.test(question);
+    if (hasShownDefault) {
+      return '';
+    }
+    const id = question.split(/ \[|: /)[0] ?? '';
+    return id === 'TRUSTED_MARKER_ACTOR'
+      ? 'trusted-user-a'
+      : id === 'credential-scope'
+        ? 'repository-scoped-pat'
+        : `fixture-${id}`;
+  };
+  const answers = await runHearWizard(catalog, root, {
+    isTTY: true,
+    prompt,
+    readers: { readDefaultBranch: () => 'develop' },
+  });
+  assert.equal(
+    answers.find((answer) => answer.id === 'development-branch')?.value,
+    'develop',
+  );
+});
+
+test('bin/idd-onboard.mjs --record-policy exits 1 and writes nothing when developmentBranch names a branch absent from origin (#2271)', () => {
+  const { root } = makeGitRemoteFixture();
+  mkdirSync(join(root, '.github', 'idd'), { recursive: true });
+  writeFileSync(
+    join(root, '.github', 'idd', 'config.json'),
+    [
+      '{',
+      '  "markerPrefix": "{{PROJECT_MARKER_PREFIX}}",',
+      '  "trustedMarkerActors": ["{{TRUSTED_MARKER_ACTOR}}"],',
+      '  "commands": {',
+      '    "install-deps": "{{INSTALL_DEPS_COMMAND}}",',
+      '    "fix-validate": "{{FIX_VALIDATE_COMMANDS}}",',
+      '    "pre-push-validate": "{{PRE_PUSH_VALIDATE_COMMANDS}}",',
+      '    "post-fix-validate": "{{POST_FIX_VALIDATE_COMMANDS}}"',
+      '  }',
+      '}',
+      '',
+    ].join('\n'),
+  );
+  const answers = buildValidHearAnswers();
+  answers['development-branch'] = 'no-such-branch';
+  const transcript = confirmTranscript(root, answers);
+  const transcriptPath = join(root, 'transcript.json');
+  writeFileSync(transcriptPath, JSON.stringify(transcript));
+
+  const { status, verdict } = runCliBin([
+    '--record-policy',
+    '--transcript',
+    transcriptPath,
+    '--target',
+    root,
+    '--apply',
+  ]);
+  assert.equal(status, 1);
+  assert.equal(verdict.valid, false);
+  assert.ok(
+    (verdict.unresolved as string[]).some((message) =>
+      message.includes('no-such-branch'),
+    ),
+  );
+  const config = JSON.parse(
+    readFileSync(join(root, '.github', 'idd', 'config.json'), 'utf8'),
+  ) as Record<string, unknown>;
+  assert.equal('developmentBranch' in config, false);
+});
+
 test('importing idd-onboard.mts has no import-time side effect', async () => {
   const originalPath = process.env.PATH;
   process.env.PATH = '';
@@ -3255,6 +3403,14 @@ test('bin/idd-onboard.mjs --substitute rejects --record-policy-only flags (--tra
 });
 
 /** A pristine, post-import config.json (unsubstituted placeholders, as --record-policy expects). */
+/**
+ * `buildValidHearAnswers()` synthesizes `fixture-development-branch` for
+ * the `development-branch` item (no documented default). Kept in sync
+ * with that helper by name, not by import, the same way the two already
+ * cooperate through the fixed `fixture-${item.id}` convention.
+ */
+const RECORD_POLICY_FIXTURE_DEVELOPMENT_BRANCH = 'fixture-development-branch';
+
 function writeRecordPolicyFixture(root: string): void {
   mkdirSync(join(root, '.github', 'idd'), { recursive: true });
   writeFileSync(
@@ -3273,6 +3429,47 @@ function writeRecordPolicyFixture(root: string): void {
       '',
     ].join('\n'),
   );
+  // #2271: --record-policy verifies developmentBranch against the
+  // configured remote via local `git ls-remote` (no GitHub CLI, no
+  // network) -- give the fixture a real local `origin` carrying the
+  // exact branch buildValidHearAnswers() answers with, so every existing
+  // record-policy scenario below satisfies that gate the same way a real
+  // onboarded repository would, without any credentials or egress.
+  const remoteRoot = mkdtempSync(join(tmpdir(), 'idd-onboard-remote-'));
+  execFileSync(
+    'git',
+    [
+      'init',
+      `--initial-branch=${RECORD_POLICY_FIXTURE_DEVELOPMENT_BRANCH}`,
+      remoteRoot,
+    ],
+    { stdio: 'ignore' },
+  );
+  execFileSync(
+    'git',
+    ['-C', remoteRoot, 'config', 'user.email', 'fixture@example.com'],
+    {
+      stdio: 'ignore',
+    },
+  );
+  execFileSync('git', ['-C', remoteRoot, 'config', 'user.name', 'Fixture'], {
+    stdio: 'ignore',
+  });
+  writeFileSync(join(remoteRoot, 'README.md'), '# fixture remote\n');
+  execFileSync('git', ['-C', remoteRoot, 'add', 'README.md'], {
+    stdio: 'ignore',
+  });
+  execFileSync(
+    'git',
+    ['-C', remoteRoot, 'commit', '--no-gpg-sign', '-m', 'fixture'],
+    { stdio: 'ignore' },
+  );
+  execFileSync('git', ['init', '--initial-branch=main', root], {
+    stdio: 'ignore',
+  });
+  execFileSync('git', ['-C', root, 'remote', 'add', 'origin', remoteRoot], {
+    stdio: 'ignore',
+  });
 }
 
 test('bin/idd-onboard.mjs --record-policy dry-run prints the config patch and filled template, writing nothing', () => {

--- a/tests/onboarding-hearing.test.mts
+++ b/tests/onboarding-hearing.test.mts
@@ -46,6 +46,7 @@ const STEP1B_IDS = [
   'idd-label-names',
   'up-to-date-head-ruleset',
   'bootstrap-execution-mode',
+  'development-branch',
 ] as const;
 
 const DOCS_ONLY_IDS = new Set<string>([
@@ -72,6 +73,7 @@ const STEP1B_COMPANION = {
   'idd-label-names': '### IDD label names',
   'up-to-date-head-ruleset': 'up to date before merging',
   'bootstrap-execution-mode': '### Bootstrap execution mode',
+  'development-branch': '### Development branch',
 } as const;
 
 function extractH2Section(doc: string, heading: string): string {

--- a/tests/policy-helpers.test.mts
+++ b/tests/policy-helpers.test.mts
@@ -5,6 +5,7 @@ import {
   clone,
   getReviewEscalationChangesRequestedPolicy,
   inspectCritiqueLoopDelegateLayer,
+  inspectDevelopmentBranch,
   normalizePolicyConfig,
   POLICY_DEFAULTS,
   parseIsoDurationToMs,
@@ -846,4 +847,61 @@ test('clone() deep-copies independently of the source, including through undefin
   // ever contains an undefined-valued key (see the clone() doc comment).
   assert.equal('b' in copy, true);
   assert.equal(copy.b, undefined);
+});
+
+test('inspectDevelopmentBranch distinguishes absent, configured, and invalid (#2271)', () => {
+  assert.deepEqual(inspectDevelopmentBranch({}), { status: 'absent' });
+  assert.deepEqual(inspectDevelopmentBranch(null), { status: 'absent' });
+  assert.deepEqual(inspectDevelopmentBranch('not-an-object'), {
+    status: 'absent',
+  });
+  assert.deepEqual(inspectDevelopmentBranch({ developmentBranch: 'develop' }), {
+    status: 'configured',
+    branch: 'develop',
+  });
+  assert.deepEqual(
+    inspectDevelopmentBranch({ developmentBranch: 'release/2.0' }),
+    { status: 'configured', branch: 'release/2.0' },
+  );
+  assert.equal(
+    inspectDevelopmentBranch({ developmentBranch: '' }).status,
+    'invalid',
+  );
+  assert.equal(
+    inspectDevelopmentBranch({ developmentBranch: '  ' }).status,
+    'invalid',
+  );
+  assert.equal(
+    inspectDevelopmentBranch({ developmentBranch: 'my branch' }).status,
+    'invalid',
+  );
+  assert.equal(
+    inspectDevelopmentBranch({ developmentBranch: 'refs/heads/main' }).status,
+    'invalid',
+  );
+  assert.equal(
+    inspectDevelopmentBranch({ developmentBranch: 42 }).status,
+    'invalid',
+  );
+  assert.equal(
+    inspectDevelopmentBranch({ developmentBranch: null }).status,
+    'invalid',
+  );
+});
+
+test('normalizePolicyConfig omits developmentBranch when absent or invalid, includes it verbatim when configured (#2271)', () => {
+  assert.equal('developmentBranch' in normalizePolicyConfig({}), false);
+  assert.equal(
+    'developmentBranch' in
+      normalizePolicyConfig({ developmentBranch: 'refs/heads/main' }),
+    false,
+  );
+  assert.equal(
+    'developmentBranch' in normalizePolicyConfig({ developmentBranch: '' }),
+    false,
+  );
+  assert.equal(
+    normalizePolicyConfig({ developmentBranch: 'develop' }).developmentBranch,
+    'develop',
+  );
 });

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -141,6 +141,7 @@ interface PolicyConfigFile {
   $schema?: string;
   iddVersion: string;
   markerPrefix: string;
+  developmentBranch?: string;
   mergePolicy:
     | 'fully_autonomous_merge'
     | 'human_merge'
@@ -498,6 +499,7 @@ export const policyConfigKeys = [
   '$schema',
   'iddVersion',
   'markerPrefix',
+  'developmentBranch',
   'mergePolicy',
   'mergePolicyAck',
   'reviewPolicy',


### PR DESCRIPTION
## Summary

Adds an optional top-level `developmentBranch` policy value, distinct from the repository's trusted GitHub default branch, so IDD's feature pull requests can target a separate long-lived integration branch. Preserves backwards compatibility: an absent value resolves the live GitHub default branch.

- `schemas/policy.schema.json` validates a non-empty, whitespace-free, non-`refs/heads/`-prefixed branch name.
- `inspectDevelopmentBranch` (`policy-helpers.mts`) distinguishes absent / configured / invalid raw config values (fail-closed on an explicit invalid value); `normalizePolicyConfig` includes the field only when configured.
- A new onboarding hearing item (`development-branch`, Step 1B) proposes the repository's live GitHub default branch via `deriveDevelopmentBranchCandidate`, and `--record-policy` verifies an explicitly-selected branch exists on the configured remote before writing it, reporting a missing branch instead of creating one or silently selecting another.
- New evidence readers (`readGithubDefaultBranch`, `checkGitRemoteBranchExists`) are injectable via `OnboardEvidenceReaders` so hearing-flow tests never need real `gh` credentials; `readGithubDefaultBranch` routes through the shared `gh-exec.mts` layer instead of spawning `gh` directly (#1675).
- Documented in `idd-template/ONBOARDING.md` and `idd-template/docs/onboarding/policy-decisions.md`; `RECORD_POLICY_DOC_ROWS` renders it in the filled policy document.

This policy selects the integration target only. Release, hotfix, and development-to-default promotion flows are explicitly out of scope (per the issue), as is wiring `developmentBranch` into the actual PR-target base branch (currently `main` everywhere) — a future issue.

## Test plan

- [x] `pnpm test` — 4202/4202 pass, including new unit tests for `inspectDevelopmentBranch`, `deriveDevelopmentBranchCandidate`, `checkGitRemoteBranchExists`, the `runHearWizard` derived-default path, and a `--record-policy` negative test (branch absent from remote → exit 1, no write)
- [x] `pnpm run typecheck`, `pnpm run build:check`
- [x] `node scripts/idd-doctor.mjs` — passed (pre-existing warnings only)
- [x] `node scripts/audit-docs.mjs --check`, `node scripts/audit-code-span-wrap.mjs`
- [x] `npx biome check`, `npx dprint check`, `npx markdownlint-cli2`, `npx cspell lint`

Closes #2271

🤖 Generated with [Claude Code](https://claude.com/claude-code)