### PR TITLE
docs(idd-merge): require unclaimed-by marker post in F4 cleanup

### DIFF
--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -462,6 +462,13 @@ Before any mutating action in F3, apply the
    (WorkTrunk may be used for steps 4–5, the deletion steps —
    step 3's local `main` update is a plain git operation, not a
    WorkTrunk one.)
+6. Re-validate the active claim one final time. If it still uses your
+   `{claim-id}`, post `unclaimed-by` for your own `{agent-id}` /
+   `{claim-id}` (see
+   [Unclaim format](idd-overview-core.instructions.md#unclaim-format))
+   to release the claim now that cleanup is complete (`#2220`). If it
+   no longer uses your `{claim-id}`, do not post a release comment —
+   another session already took over.
 
 ## F5 — Loop
 

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -457,6 +457,13 @@ Before any mutating action in F3, apply the
    (WorkTrunk may be used for steps 4–5, the deletion steps —
    step 3's local `main` update is a plain git operation, not a
    WorkTrunk one.)
+6. Re-validate the active claim one final time. If it still uses your
+   `{claim-id}`, post `unclaimed-by` for your own `{agent-id}` /
+   `{claim-id}` (see
+   [Unclaim format](idd-overview-core.instructions.md#unclaim-format))
+   to release the claim now that cleanup is complete (`#2220`). If it
+   no longer uses your `{claim-id}`, do not post a release comment —
+   another session already took over.
 
 ## F5 — Loop
 


### PR DESCRIPTION
# Summary

`idd-merge.instructions.md`'s F4 (Cleanup) section never mentioned
posting an `unclaimed-by` marker as part of cleanup — the release
step existed only in the Abort path
(`idd-overview-appendix.instructions.md`), never in the
successful-completion path. An adopter who added their own explicit
standalone instruction line requiring this marker post observed the
gap close immediately and stay closed across several subsequent
runs, suggesting the omission itself (not an unrelated
cleanup-ordering issue) caused the marker to be silently skipped.

Self-confirmed this session: across six F4 cleanup passes earlier in
this run, none posted `unclaimed-by`, because nothing instructed it
to — retroactively posted all six once this gap was found.

Adds step 6 to F4: re-validate the active claim one final time and
post `unclaimed-by` to release it, now that cleanup is complete —
mirroring the same re-validate-then-release pattern the Abort section
already documents.

## Linked issue

Closes #2220

## Follow-up issues (if any)

- [ ] none

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4196 tests, unchanged — documentation only)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (not applicable)

Additional: one round of the repository's CodeRabbit C1 critique
delegate — zero findings.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (documentation only; adds a
      cleanup-hygiene step, no change to any merge gate)
- [x] Context budget impact reviewed (`audit-docs.mjs --check` passed)
