### PR TITLE
fix(marker-helpers): name the missing field in marker-payload validation errors

### DIFF
--- a/scripts/marker-helpers.mjs
+++ b/scripts/marker-helpers.mjs
@@ -829,6 +829,43 @@ function normalizeMarkerIsoOrNone(value) {
   }
   return normalizeIsoTimestamp(token) || null;
 }
+/**
+ * Build the field-attribution suffix for a marker-payload aggregate
+ * validation error (`#2247`): names every field whose check failed instead
+ * of leaving the generic "invalid ... marker payload" message unattributed.
+ * A field is "missing" when its raw payload value is absent, `null`, or (for
+ * a string) empty after trimming; anything else that still failed its own
+ * normalize/format check is "invalid" -- a non-empty but malformed value
+ * (a non-ISO timestamp, a non-hex-40 SHA). Every CLI-reachable renderer
+ * caller (`emit-marker.mts`, `post-idd-marker.mts`) already rejects a
+ * genuinely omitted flag before this guard runs (`#1722`, `requireFlag`), so
+ * this most commonly fires on the "invalid" branch in practice -- but a
+ * direct (non-CLI) caller can still hit "missing", so both stay covered.
+ * Returns `''` when every listed field passed (never expected to be called
+ * that way, but keeps the helper a total function).
+ */
+function describeInvalidMarkerFields(fields) {
+  const missing = [];
+  const invalid = [];
+  for (const { name, raw, failed } of fields) {
+    if (!failed) {
+      continue;
+    }
+    const rawMissing =
+      raw === undefined ||
+      raw === null ||
+      (typeof raw === 'string' && raw.trim() === '');
+    (rawMissing ? missing : invalid).push(`"${name}"`);
+  }
+  const parts = [];
+  if (missing.length > 0) {
+    parts.push(`missing ${missing.join(', ')}`);
+  }
+  if (invalid.length > 0) {
+    parts.push(`invalid ${invalid.join(', ')}`);
+  }
+  return parts.length > 0 ? `: ${parts.join('; ')}` : '';
+}
 export function renderClaimedByMarker(payload) {
   const agentId = normalizeNonWhitespaceToken(payload?.agentId);
   const claimId = normalizeNonWhitespaceToken(payload?.claimId);
@@ -846,7 +883,15 @@ export function renderClaimedByMarker(payload) {
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
   const branch = normalizeBranchToken(payload?.branch);
   if (!agentId || !claimId || !timestamp || !branch) {
-    throw new Error('invalid claimed-by marker payload');
+    throw new Error(
+      'invalid claimed-by marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'claimId', raw: payload?.claimId, failed: !claimId },
+          { name: 'timestamp', raw: payload?.timestamp, failed: !timestamp },
+          { name: 'branch', raw: payload?.branch, failed: !branch },
+        ]),
+    );
   }
   return [
     `<!-- claimed-by: ${agentId} ${claimId} supersedes: ${supersedes} ${timestamp} branch: ${branch} -->`,
@@ -860,7 +905,15 @@ export function renderActivationNonceMarker(payload) {
   const nonce = normalizeNonWhitespaceToken(payload?.nonce);
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
   if (!agentId || !claimId || !nonce || !timestamp) {
-    throw new Error('invalid activation-nonce marker payload');
+    throw new Error(
+      'invalid activation-nonce marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'claimId', raw: payload?.claimId, failed: !claimId },
+          { name: 'nonce', raw: payload?.nonce, failed: !nonce },
+          { name: 'timestamp', raw: payload?.timestamp, failed: !timestamp },
+        ]),
+    );
   }
   return [
     `<!-- activation-nonce: ${agentId} ${claimId} ${nonce} ${timestamp} -->`,
@@ -875,15 +928,38 @@ export function renderReviewWatermarkMarker(payload) {
   const maxActivityAt = normalizeMarkerIsoOrNone(payload?.maxActivityAt);
   const totalItemCount = normalizeMarkerCount(payload?.totalItemCount);
   const ciCompletedAt = normalizeMarkerIsoOrNone(payload?.ciCompletedAt);
+  const headShaValid = /^[0-9a-f]{40}$/.test(headSha);
   if (
     !agentId ||
     !claimId ||
-    !/^[0-9a-f]{40}$/.test(headSha) ||
+    !headShaValid ||
     maxActivityAt === null ||
     totalItemCount === null ||
     ciCompletedAt === null
   ) {
-    throw new Error('invalid review-watermark marker payload');
+    throw new Error(
+      'invalid review-watermark marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'claimId', raw: payload?.claimId, failed: !claimId },
+          { name: 'headSha', raw: payload?.headSha, failed: !headShaValid },
+          {
+            name: 'maxActivityAt',
+            raw: payload?.maxActivityAt,
+            failed: maxActivityAt === null,
+          },
+          {
+            name: 'totalItemCount',
+            raw: payload?.totalItemCount,
+            failed: totalItemCount === null,
+          },
+          {
+            name: 'ciCompletedAt',
+            raw: payload?.ciCompletedAt,
+            failed: ciCompletedAt === null,
+          },
+        ]),
+    );
   }
   return [
     `<!-- review-watermark: ${agentId} ${claimId} ${headSha} ${maxActivityAt} ${totalItemCount} ${ciCompletedAt} -->`,
@@ -895,8 +971,16 @@ export function renderReviewBaselineMarker(payload) {
   const agentId = normalizeNonWhitespaceToken(payload?.agentId);
   const claimId = normalizeNonWhitespaceToken(payload?.claimId);
   const sha = normalizeNonWhitespaceToken(payload?.sha).toLowerCase();
-  if (!agentId || !claimId || !/^[0-9a-f]{40}$/.test(sha)) {
-    throw new Error('invalid review-baseline marker payload');
+  const shaValid = /^[0-9a-f]{40}$/.test(sha);
+  if (!agentId || !claimId || !shaValid) {
+    throw new Error(
+      'invalid review-baseline marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'claimId', raw: payload?.claimId, failed: !claimId },
+          { name: 'sha', raw: payload?.sha, failed: !shaValid },
+        ]),
+    );
   }
   return [
     `<!-- review-baseline: ${agentId} ${claimId} ${sha} -->`,
@@ -915,7 +999,14 @@ export function renderUnclaimedByMarker(payload) {
   const claimId = normalizeNonWhitespaceToken(payload?.claimId);
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
   if (!agentId || !claimId || !timestamp) {
-    throw new Error('invalid unclaimed-by marker payload');
+    throw new Error(
+      'invalid unclaimed-by marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'claimId', raw: payload?.claimId, failed: !claimId },
+          { name: 'timestamp', raw: payload?.timestamp, failed: !timestamp },
+        ]),
+    );
   }
   return [
     `<!-- unclaimed-by: ${agentId} ${claimId} ${timestamp} -->`,
@@ -931,8 +1022,16 @@ export function renderAdvisoryWaitMarker(payload) {
   const agentId = normalizeNonWhitespaceToken(payload?.agentId);
   const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
-    throw new Error('invalid advisory-wait marker payload');
+  const headShaValid = /^[0-9a-f]{40}$/.test(headSha);
+  if (!agentId || !headShaValid || !timestamp) {
+    throw new Error(
+      'invalid advisory-wait marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'headSha', raw: payload?.headSha, failed: !headShaValid },
+          { name: 'timestamp', raw: payload?.timestamp, failed: !timestamp },
+        ]),
+    );
   }
   return `advisory-wait: ${agentId} ${headSha} ${timestamp}`;
 }
@@ -967,8 +1066,16 @@ export function renderAdvisoryWaitRecoveryMarker(payload) {
   const agentId = normalizeNonWhitespaceToken(payload?.agentId);
   const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
-    throw new Error('invalid advisory-wait-recovery marker payload');
+  const headShaValid = /^[0-9a-f]{40}$/.test(headSha);
+  if (!agentId || !headShaValid || !timestamp) {
+    throw new Error(
+      'invalid advisory-wait-recovery marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'headSha', raw: payload?.headSha, failed: !headShaValid },
+          { name: 'timestamp', raw: payload?.timestamp, failed: !timestamp },
+        ]),
+    );
   }
   const claimIdProvided =
     payload?.claimId !== undefined &&
@@ -1003,14 +1110,22 @@ export function renderCopilotUnavailableMarker(payload) {
   const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
   const attempt = normalizePositiveIntegerToken(payload?.attempt);
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  if (
-    !agentId ||
-    !claimId ||
-    !/^[0-9a-f]{40}$/.test(headSha) ||
-    attempt === null ||
-    !timestamp
-  ) {
-    throw new Error('invalid copilot-unavailable marker payload');
+  const headShaValid = /^[0-9a-f]{40}$/.test(headSha);
+  if (!agentId || !claimId || !headShaValid || attempt === null || !timestamp) {
+    throw new Error(
+      'invalid copilot-unavailable marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'claimId', raw: payload?.claimId, failed: !claimId },
+          { name: 'headSha', raw: payload?.headSha, failed: !headShaValid },
+          {
+            name: 'attempt',
+            raw: payload?.attempt,
+            failed: attempt === null,
+          },
+          { name: 'timestamp', raw: payload?.timestamp, failed: !timestamp },
+        ]),
+    );
   }
   return `copilot-unavailable: ${agentId} ${headSha} ${timestamp} claim:${claimId} attempt:${attempt}`;
 }
@@ -1024,8 +1139,16 @@ export function renderAdvisoryRerollMarker(payload) {
   const agentId = normalizeNonWhitespaceToken(payload?.agentId);
   const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
-    throw new Error('invalid advisory-reroll marker payload');
+  const headShaValid = /^[0-9a-f]{40}$/.test(headSha);
+  if (!agentId || !headShaValid || !timestamp) {
+    throw new Error(
+      'invalid advisory-reroll marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'headSha', raw: payload?.headSha, failed: !headShaValid },
+          { name: 'timestamp', raw: payload?.timestamp, failed: !timestamp },
+        ]),
+    );
   }
   return `advisory-reroll: ${agentId} ${headSha} ${timestamp}`;
 }
@@ -1045,8 +1168,16 @@ export function renderReviewAckMarker(payload) {
   const agentId = normalizeNonWhitespaceToken(payload?.agentId);
   const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
-    throw new Error('invalid review-ack marker payload');
+  const headShaValid = /^[0-9a-f]{40}$/.test(headSha);
+  if (!agentId || !headShaValid || !timestamp) {
+    throw new Error(
+      'invalid review-ack marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'headSha', raw: payload?.headSha, failed: !headShaValid },
+          { name: 'timestamp', raw: payload?.timestamp, failed: !timestamp },
+        ]),
+    );
   }
   return `review-ack: ${agentId} ${headSha} ${timestamp}`;
 }

--- a/src/scripts/marker-helpers.mts
+++ b/src/scripts/marker-helpers.mts
@@ -1177,6 +1177,46 @@ function normalizeMarkerIsoOrNone(value: unknown): string | null {
   return normalizeIsoTimestamp(token) || null;
 }
 
+/**
+ * Build the field-attribution suffix for a marker-payload aggregate
+ * validation error (`#2247`): names every field whose check failed instead
+ * of leaving the generic "invalid ... marker payload" message unattributed.
+ * A field is "missing" when its raw payload value is absent, `null`, or (for
+ * a string) empty after trimming; anything else that still failed its own
+ * normalize/format check is "invalid" -- a non-empty but malformed value
+ * (a non-ISO timestamp, a non-hex-40 SHA). Every CLI-reachable renderer
+ * caller (`emit-marker.mts`, `post-idd-marker.mts`) already rejects a
+ * genuinely omitted flag before this guard runs (`#1722`, `requireFlag`), so
+ * this most commonly fires on the "invalid" branch in practice -- but a
+ * direct (non-CLI) caller can still hit "missing", so both stay covered.
+ * Returns `''` when every listed field passed (never expected to be called
+ * that way, but keeps the helper a total function).
+ */
+function describeInvalidMarkerFields(
+  fields: Array<{ name: string; raw: unknown; failed: boolean }>,
+): string {
+  const missing: string[] = [];
+  const invalid: string[] = [];
+  for (const { name, raw, failed } of fields) {
+    if (!failed) {
+      continue;
+    }
+    const rawMissing =
+      raw === undefined ||
+      raw === null ||
+      (typeof raw === 'string' && raw.trim() === '');
+    (rawMissing ? missing : invalid).push(`"${name}"`);
+  }
+  const parts: string[] = [];
+  if (missing.length > 0) {
+    parts.push(`missing ${missing.join(', ')}`);
+  }
+  if (invalid.length > 0) {
+    parts.push(`invalid ${invalid.join(', ')}`);
+  }
+  return parts.length > 0 ? `: ${parts.join('; ')}` : '';
+}
+
 export function renderClaimedByMarker(payload: {
   agentId?: unknown;
   claimId?: unknown;
@@ -1200,7 +1240,15 @@ export function renderClaimedByMarker(payload: {
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
   const branch = normalizeBranchToken(payload?.branch);
   if (!agentId || !claimId || !timestamp || !branch) {
-    throw new Error('invalid claimed-by marker payload');
+    throw new Error(
+      'invalid claimed-by marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'claimId', raw: payload?.claimId, failed: !claimId },
+          { name: 'timestamp', raw: payload?.timestamp, failed: !timestamp },
+          { name: 'branch', raw: payload?.branch, failed: !branch },
+        ]),
+    );
   }
   return [
     `<!-- claimed-by: ${agentId} ${claimId} supersedes: ${supersedes} ${timestamp} branch: ${branch} -->`,
@@ -1220,7 +1268,15 @@ export function renderActivationNonceMarker(payload: {
   const nonce = normalizeNonWhitespaceToken(payload?.nonce);
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
   if (!agentId || !claimId || !nonce || !timestamp) {
-    throw new Error('invalid activation-nonce marker payload');
+    throw new Error(
+      'invalid activation-nonce marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'claimId', raw: payload?.claimId, failed: !claimId },
+          { name: 'nonce', raw: payload?.nonce, failed: !nonce },
+          { name: 'timestamp', raw: payload?.timestamp, failed: !timestamp },
+        ]),
+    );
   }
   return [
     `<!-- activation-nonce: ${agentId} ${claimId} ${nonce} ${timestamp} -->`,
@@ -1243,15 +1299,38 @@ export function renderReviewWatermarkMarker(payload: {
   const maxActivityAt = normalizeMarkerIsoOrNone(payload?.maxActivityAt);
   const totalItemCount = normalizeMarkerCount(payload?.totalItemCount);
   const ciCompletedAt = normalizeMarkerIsoOrNone(payload?.ciCompletedAt);
+  const headShaValid = /^[0-9a-f]{40}$/.test(headSha);
   if (
     !agentId ||
     !claimId ||
-    !/^[0-9a-f]{40}$/.test(headSha) ||
+    !headShaValid ||
     maxActivityAt === null ||
     totalItemCount === null ||
     ciCompletedAt === null
   ) {
-    throw new Error('invalid review-watermark marker payload');
+    throw new Error(
+      'invalid review-watermark marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'claimId', raw: payload?.claimId, failed: !claimId },
+          { name: 'headSha', raw: payload?.headSha, failed: !headShaValid },
+          {
+            name: 'maxActivityAt',
+            raw: payload?.maxActivityAt,
+            failed: maxActivityAt === null,
+          },
+          {
+            name: 'totalItemCount',
+            raw: payload?.totalItemCount,
+            failed: totalItemCount === null,
+          },
+          {
+            name: 'ciCompletedAt',
+            raw: payload?.ciCompletedAt,
+            failed: ciCompletedAt === null,
+          },
+        ]),
+    );
   }
   return [
     `<!-- review-watermark: ${agentId} ${claimId} ${headSha} ${maxActivityAt} ${totalItemCount} ${ciCompletedAt} -->`,
@@ -1268,8 +1347,16 @@ export function renderReviewBaselineMarker(payload: {
   const agentId = normalizeNonWhitespaceToken(payload?.agentId);
   const claimId = normalizeNonWhitespaceToken(payload?.claimId);
   const sha = normalizeNonWhitespaceToken(payload?.sha).toLowerCase();
-  if (!agentId || !claimId || !/^[0-9a-f]{40}$/.test(sha)) {
-    throw new Error('invalid review-baseline marker payload');
+  const shaValid = /^[0-9a-f]{40}$/.test(sha);
+  if (!agentId || !claimId || !shaValid) {
+    throw new Error(
+      'invalid review-baseline marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'claimId', raw: payload?.claimId, failed: !claimId },
+          { name: 'sha', raw: payload?.sha, failed: !shaValid },
+        ]),
+    );
   }
   return [
     `<!-- review-baseline: ${agentId} ${claimId} ${sha} -->`,
@@ -1294,7 +1381,14 @@ export function renderUnclaimedByMarker(payload: {
   const claimId = normalizeNonWhitespaceToken(payload?.claimId);
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
   if (!agentId || !claimId || !timestamp) {
-    throw new Error('invalid unclaimed-by marker payload');
+    throw new Error(
+      'invalid unclaimed-by marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'claimId', raw: payload?.claimId, failed: !claimId },
+          { name: 'timestamp', raw: payload?.timestamp, failed: !timestamp },
+        ]),
+    );
   }
   return [
     `<!-- unclaimed-by: ${agentId} ${claimId} ${timestamp} -->`,
@@ -1315,8 +1409,16 @@ export function renderAdvisoryWaitMarker(payload: {
   const agentId = normalizeNonWhitespaceToken(payload?.agentId);
   const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
-    throw new Error('invalid advisory-wait marker payload');
+  const headShaValid = /^[0-9a-f]{40}$/.test(headSha);
+  if (!agentId || !headShaValid || !timestamp) {
+    throw new Error(
+      'invalid advisory-wait marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'headSha', raw: payload?.headSha, failed: !headShaValid },
+          { name: 'timestamp', raw: payload?.timestamp, failed: !timestamp },
+        ]),
+    );
   }
   return `advisory-wait: ${agentId} ${headSha} ${timestamp}`;
 }
@@ -1359,8 +1461,16 @@ export function renderAdvisoryWaitRecoveryMarker(payload: {
   const agentId = normalizeNonWhitespaceToken(payload?.agentId);
   const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
-    throw new Error('invalid advisory-wait-recovery marker payload');
+  const headShaValid = /^[0-9a-f]{40}$/.test(headSha);
+  if (!agentId || !headShaValid || !timestamp) {
+    throw new Error(
+      'invalid advisory-wait-recovery marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'headSha', raw: payload?.headSha, failed: !headShaValid },
+          { name: 'timestamp', raw: payload?.timestamp, failed: !timestamp },
+        ]),
+    );
   }
   const claimIdProvided =
     payload?.claimId !== undefined &&
@@ -1402,14 +1512,22 @@ export function renderCopilotUnavailableMarker(payload: {
   const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
   const attempt = normalizePositiveIntegerToken(payload?.attempt);
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  if (
-    !agentId ||
-    !claimId ||
-    !/^[0-9a-f]{40}$/.test(headSha) ||
-    attempt === null ||
-    !timestamp
-  ) {
-    throw new Error('invalid copilot-unavailable marker payload');
+  const headShaValid = /^[0-9a-f]{40}$/.test(headSha);
+  if (!agentId || !claimId || !headShaValid || attempt === null || !timestamp) {
+    throw new Error(
+      'invalid copilot-unavailable marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'claimId', raw: payload?.claimId, failed: !claimId },
+          { name: 'headSha', raw: payload?.headSha, failed: !headShaValid },
+          {
+            name: 'attempt',
+            raw: payload?.attempt,
+            failed: attempt === null,
+          },
+          { name: 'timestamp', raw: payload?.timestamp, failed: !timestamp },
+        ]),
+    );
   }
   return `copilot-unavailable: ${agentId} ${headSha} ${timestamp} claim:${claimId} attempt:${attempt}`;
 }
@@ -1428,8 +1546,16 @@ export function renderAdvisoryRerollMarker(payload: {
   const agentId = normalizeNonWhitespaceToken(payload?.agentId);
   const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
-    throw new Error('invalid advisory-reroll marker payload');
+  const headShaValid = /^[0-9a-f]{40}$/.test(headSha);
+  if (!agentId || !headShaValid || !timestamp) {
+    throw new Error(
+      'invalid advisory-reroll marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'headSha', raw: payload?.headSha, failed: !headShaValid },
+          { name: 'timestamp', raw: payload?.timestamp, failed: !timestamp },
+        ]),
+    );
   }
   return `advisory-reroll: ${agentId} ${headSha} ${timestamp}`;
 }
@@ -1454,8 +1580,16 @@ export function renderReviewAckMarker(payload: {
   const agentId = normalizeNonWhitespaceToken(payload?.agentId);
   const headSha = normalizeNonWhitespaceToken(payload?.headSha).toLowerCase();
   const timestamp = normalizeSecondPrecisionIsoTimestamp(payload?.timestamp);
-  if (!agentId || !/^[0-9a-f]{40}$/.test(headSha) || !timestamp) {
-    throw new Error('invalid review-ack marker payload');
+  const headShaValid = /^[0-9a-f]{40}$/.test(headSha);
+  if (!agentId || !headShaValid || !timestamp) {
+    throw new Error(
+      'invalid review-ack marker payload' +
+        describeInvalidMarkerFields([
+          { name: 'agentId', raw: payload?.agentId, failed: !agentId },
+          { name: 'headSha', raw: payload?.headSha, failed: !headShaValid },
+          { name: 'timestamp', raw: payload?.timestamp, failed: !timestamp },
+        ]),
+    );
   }
   return `review-ack: ${agentId} ${headSha} ${timestamp}`;
 }

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -385,13 +385,24 @@ test('buildMarkerBody throws on copilot-unavailable with any field missing', () 
     attempt: '1',
     timestamp: TS,
   };
+  const fieldNames: Record<string, string> = {
+    'agent-id': 'agentId',
+    'claim-id': 'claimId',
+    'head-sha': 'headSha',
+    attempt: 'attempt',
+    timestamp: 'timestamp',
+  };
   for (const omit of Object.keys(fullFields)) {
     const fields = { ...fullFields };
     delete (fields as Record<string, string>)[omit];
+    // #2247: the aggregate guard names the specific failing field, not just
+    // the marker kind.
     assert.throws(
       () => buildMarkerBody('copilot-unavailable', fields),
-      /invalid copilot-unavailable marker payload/,
-      `omitting ${omit} should throw`,
+      new RegExp(
+        `invalid copilot-unavailable marker payload:.*"${fieldNames[omit]}"`,
+      ),
+      `omitting ${omit} should throw and name "${fieldNames[omit]}"`,
     );
   }
 });
@@ -524,6 +535,8 @@ test('buildMarkerBody throws on an unknown type', () => {
 });
 
 test('buildMarkerBody throws on an invalid field set (renderer validation)', () => {
+  // #2247: the aggregate guard names the specific failing field, not just
+  // the marker kind.
   // Missing branch for a claim.
   assert.throws(
     () =>
@@ -532,9 +545,10 @@ test('buildMarkerBody throws on an invalid field set (renderer validation)', () 
         'claim-id': 'c',
         timestamp: TS,
       }),
-    /invalid claimed-by marker payload/,
+    /invalid claimed-by marker payload:.*missing "branch"/,
   );
-  // Non-hex head SHA for an advisory marker.
+  // Non-hex head SHA for an advisory marker -- present but malformed, so
+  // "invalid", not "missing".
   assert.throws(
     () =>
       buildMarkerBody('advisory', {
@@ -542,12 +556,12 @@ test('buildMarkerBody throws on an invalid field set (renderer validation)', () 
         'head-sha': 'not-a-sha',
         timestamp: TS,
       }),
-    /invalid advisory-wait marker payload/,
+    /invalid advisory-wait marker payload:.*invalid "headSha"/,
   );
   // Missing timestamp for an unclaim.
   assert.throws(
     () => buildMarkerBody('unclaim', { 'agent-id': 'a', 'claim-id': 'c' }),
-    /invalid unclaimed-by marker payload/,
+    /invalid unclaimed-by marker payload:.*missing "timestamp"/,
   );
   // Missing nonce for an activation-nonce marker.
   assert.throws(
@@ -557,7 +571,22 @@ test('buildMarkerBody throws on an invalid field set (renderer validation)', () 
         'claim-id': 'c',
         timestamp: TS,
       }),
-    /invalid activation-nonce marker payload/,
+    /invalid activation-nonce marker payload:.*missing "nonce"/,
+  );
+  // Two failing fields at once, one missing and one malformed, both named
+  // together. max-activity-at / ci-completed-at both default to the "none"
+  // sentinel when absent (renderer-defaulted, like --supersedes above), so
+  // total-item-count is the field genuinely absent here.
+  assert.throws(
+    () =>
+      buildMarkerBody('watermark', {
+        'agent-id': 'a',
+        'claim-id': 'c',
+        'head-sha': 'not-a-sha',
+        'max-activity-at': 'none',
+        'ci-completed-at': 'none',
+      }),
+    /invalid review-watermark marker payload:.*missing "totalItemCount".*invalid "headSha"/,
   );
 });
 


### PR DESCRIPTION
# Summary

Every `renderXMarker` function in `marker-helpers.mts` threw an
unattributed `'invalid X marker payload'` whenever any required field
failed validation, with no indication of which field. This helper is
reachable from two CLI surfaces (`emit-marker.mts`,
`post-idd-marker.mts`), and both already name a genuinely *omitted*
flag by name (`#1722`, `requireFlag`) — so the aggregate guard was
already mostly hit by the other, unattributed case: a flag that was
*provided* but whose value is malformed (a non-ISO timestamp, a
non-hex-40 SHA) — present, not missing, but still unnamed.

Adds `describeInvalidMarkerFields`, a small shared helper that
appends a `missing`/`invalid` field-name suffix to the aggregate
message, applied to all 10 marker-payload guards reachable from
either CLI's `--type` surface: `claimed-by`, `activation-nonce`,
`review-watermark`, `review-baseline`, `unclaimed-by`,
`advisory-wait`, `advisory-wait-recovery`'s aggregate guard,
`copilot-unavailable`, `advisory-reroll`, `review-ack`.

## Linked issue

Closes #2247

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

The renderer's own separate `"claimId and attempt must both be
provided together"` message for `advisory-wait-recovery` is already
field-specific and left untouched. Six other generic guards
(`forced-handoff`, `external-check-waiver`,
`provider-outage-declaration`/`advancement`,
`local-validation-evidence`) are not reachable from either CLI's
`--type` list, so are out of this issue's scope.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4211 tests)
- [x] `node scripts/audit-docs.mjs --check`
- [ ] `pnpm run docs:sync:check` (not applicable — no docs changed)
- [ ] `node scripts/idd-doctor.mjs` (not applicable)

Tightened the two existing tests asserting the old generic message
text to also assert the new field name(s), including a
two-fields-at-once case (one missing, one malformed, both named
together).

Additional: one round of the repository's CodeRabbit C1 critique
delegate — zero findings.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (diagnostic error-message
      improvement only; no change to marker parsing or claim-safety
      logic)
- [x] Context budget impact reviewed (`audit-docs.mjs --check` passed)
