### PR TITLE
feat(helpers): enforce development-branch target invariant

### DIFF
--- a/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -132,7 +132,7 @@ This section's rebase only applies **before the branch's first push**.
        re-run the helper after a short wait, up to 3 attempts; only a
        result still `"recheck"` after that budget falls through to stop
        per the condition above.
-     - Any other value (`"merge-main"`, `"policy-required-update"`,
+     - Any other value (`"merge-base"`, `"policy-required-update"`,
        `"force-push-exception"`, `"hold-unknown"`, or the helper is
        unavailable, fails, or disagrees with live GitHub state): stop
        per the condition above — this needs either the merge-based

--- a/.github/instructions/lite/idd-pre-merge-lite.instructions.md
+++ b/.github/instructions/lite/idd-pre-merge-lite.instructions.md
@@ -60,7 +60,7 @@ This check never rebases, merges, or pushes.
      re-run the helper after a short wait, up to 3 attempts; only a
      result still `"recheck"` after that budget falls through to stop
      per the condition above.
-   - Any other value the helper currently reports (`"merge-main"` or
+   - Any other value the helper currently reports (`"merge-base"` or
      `"hold-unknown"`), or the helper is unavailable, fails, or
      disagrees with live state: stop per the
      condition above — the merge-based resync and any content-conflict

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -99,7 +99,7 @@ In the idd-skill source repository, the following optional helpers were adopted:
 
 - `scripts/branch-conflict-state.mjs` for read-only branch conflict and
   synchronization state classification; used by D/E/F routing to decide
-  whether `merge-main`, `hold-unknown`, or no action is needed without
+  whether `merge-base`, `hold-unknown`, or no action is needed without
   mutating the worktree or PR branch (added in 0.2.0)
 - `scripts/verify-install-deps.mjs` for B1 Step 3 `install-deps`: runs
   the underlying install command, verifies a key post-install binary
@@ -2540,7 +2540,7 @@ same as `AW4`/`AW5`.
   `dirty`, `force-push-exception`, `computing`, `unknown` (`computing` is the
   transient still-computing mergeability that callers re-poll; `unknown` stays
   terminal)
-- `syncRecommendation` values: `none`, `merge-main`, `policy-required-update`,
+- `syncRecommendation` values: `none`, `merge-base`, `policy-required-update`,
   `force-push-exception`, `recheck`, `hold-unknown` (`recheck` pairs with
   `computing`)
 - `baseAdvancedSinceMergeBase` (boolean): `true` when the base ref has moved

--- a/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-pr-submit-lite.instructions.md
@@ -127,7 +127,7 @@ This section's rebase only applies **before the branch's first push**.
        re-run the helper after a short wait, up to 3 attempts; only a
        result still `"recheck"` after that budget falls through to stop
        per the condition above.
-     - Any other value (`"merge-main"`, `"policy-required-update"`,
+     - Any other value (`"merge-base"`, `"policy-required-update"`,
        `"force-push-exception"`, `"hold-unknown"`, or the helper is
        unavailable, fails, or disagrees with live GitHub state): stop
        per the condition above — this needs either the merge-based

--- a/idd-template/.github/instructions/lite/idd-pre-merge-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-pre-merge-lite.instructions.md
@@ -55,7 +55,7 @@ This check never rebases, merges, or pushes.
      re-run the helper after a short wait, up to 3 attempts; only a
      result still `"recheck"` after that budget falls through to stop
      per the condition above.
-   - Any other value the helper currently reports (`"merge-main"` or
+   - Any other value the helper currently reports (`"merge-base"` or
      `"hold-unknown"`), or the helper is unavailable, fails, or
      disagrees with live state: stop per the
      condition above — the merge-based resync and any content-conflict

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -99,7 +99,7 @@ In the idd-skill source repository, the following optional helpers were adopted:
 
 - `scripts/branch-conflict-state.mjs` for read-only branch conflict and
   synchronization state classification; used by D/E/F routing to decide
-  whether `merge-main`, `hold-unknown`, or no action is needed without
+  whether `merge-base`, `hold-unknown`, or no action is needed without
   mutating the worktree or PR branch (added in 0.2.0)
 - `scripts/verify-install-deps.mjs` for B1 Step 3 `install-deps`: runs
   the underlying install command, verifies a key post-install binary
@@ -2540,7 +2540,7 @@ same as `AW4`/`AW5`.
   `dirty`, `force-push-exception`, `computing`, `unknown` (`computing` is the
   transient still-computing mergeability that callers re-poll; `unknown` stays
   terminal)
-- `syncRecommendation` values: `none`, `merge-main`, `policy-required-update`,
+- `syncRecommendation` values: `none`, `merge-base`, `policy-required-update`,
   `force-push-exception`, `recheck`, `hold-unknown` (`recheck` pairs with
   `computing`)
 - `baseAdvancedSinceMergeBase` (boolean): `true` when the base ref has moved

--- a/schemas/branch-conflict-state.schema.json
+++ b/schemas/branch-conflict-state.schema.json
@@ -68,7 +68,7 @@
       "type": "string",
       "enum": [
         "none",
-        "merge-main",
+        "merge-base",
         "policy-required-update",
         "force-push-exception",
         "recheck",

--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -1609,6 +1609,31 @@
       "description": "#2323: the caller-precomputed resolveLocalValidationEvidence result (local-validation-evidence.mts), reported verbatim. Omitted entirely when the caller does not pass it. Purely informational -- computePreMergeReadinessBlockers has no reference to this field, so it can never remove or downgrade a required-check blocker; an unavailable required check stays a blocker regardless of this field's contents.",
       "additionalProperties": true
     },
+    "developmentBranchTarget": {
+      "type": "object",
+      "description": "#2272: the caller-precomputed resolveEffectiveDevelopmentBranch result (policy-helpers.mts) paired with the live PR baseRefName, reported verbatim. Omitted entirely when the caller does not pass it. Unlike localValidationEvidence above, this DOES feed computePreMergeReadinessBlockers: an invalid/unavailable status, or a branch that differs from baseRefName, adds a development-branch-target blocker.",
+      "required": ["status", "baseRefName"],
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "'configured' (an explicit developmentBranch policy value) or 'default' (policy absent, live repository default branch used) never block; 'invalid' (malformed policy value) or 'unavailable' (policy absent and the live default branch could not be read) always block.",
+          "enum": ["configured", "default", "invalid", "unavailable"]
+        },
+        "branch": {
+          "type": "string",
+          "description": "Present when status is 'configured' or 'default'."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Present when status is 'invalid'."
+        },
+        "baseRefName": {
+          "type": "string",
+          "description": "The PR's live base branch, read alongside the same headRefOid/baseRefName pr view fetch this report already performs."
+        }
+      }
+    },
     "ready": {
       "description": "Strict merge-gate rollup: true only when blockers is empty. Does NOT apply the dispositionEvidence.soleCauseAckOnlyPostDisposition override (a separate flag the F2 checklist layers on top).",
       "type": "boolean"

--- a/scripts/branch-conflict-state.mjs
+++ b/scripts/branch-conflict-state.mjs
@@ -227,7 +227,7 @@ function deriveBranchState({
     if (skipGitProbe) {
       return {
         branchState: 'behind-no-conflict',
-        syncRecommendation: 'merge-main',
+        syncRecommendation: 'merge-base',
         conflictFiles: [],
         mergeableSource: 'github-merge-state',
         baseAdvancedSinceMergeBase,
@@ -262,7 +262,7 @@ function deriveBranchState({
     }
     return {
       branchState: 'behind-no-conflict',
-      syncRecommendation: 'merge-main',
+      syncRecommendation: 'merge-base',
       conflictFiles: [],
       mergeableSource: 'git-merge-tree',
       baseAdvancedSinceMergeBase,

--- a/scripts/gh-exec.mjs
+++ b/scripts/gh-exec.mjs
@@ -91,6 +91,25 @@ export function safeGhText(args, options = {}) {
   }
 }
 /**
+ * Live GitHub default branch for `{owner}/{repo}` (#2272), via `gh api
+ * repos/{owner}/{repo}` and the `default_branch` field. Extracted here so
+ * `pre-merge-readiness.mts`, `ci-wait-state.mts`, `branch-conflict-state.mts`,
+ * and `idd-merge-execute.mts` share one reader instead of four near-identical
+ * `gh api` calls, matching this module's existing role as the shared `gh`
+ * CLI layer. Returns `null` on any failure (unreadable, unauthenticated,
+ * missing repo) so callers treat the branch as undetermined rather than
+ * throwing -- distinct from `idd-onboard.mts`'s own `readGithubDefaultBranch`,
+ * which derives `owner`/`repo` from a local checkout's `remote.origin.url`
+ * instead of accepting them directly.
+ */
+export function readGithubRepoDefaultBranch(owner, repo) {
+  const output = safeGhText(
+    ['api', `repos/${owner}/${repo}`, '--jq', '.default_branch // empty'],
+    GH_TEXT_LOOP_OPTIONS,
+  );
+  return output === '' ? null : output;
+}
+/**
  * Async sibling of {@link ghText}, for callers that need several `gh`
  * subprocesses running concurrently (`execFileSync` serializes even
  * concurrent `await`s because it holds the event loop). Extracted from

--- a/scripts/policy-helpers.mjs
+++ b/scripts/policy-helpers.mjs
@@ -46,6 +46,33 @@ export function inspectDevelopmentBranch(config) {
   }
   return { status: 'configured', branch: value };
 }
+/**
+ * Resolve the effective development-branch target for enforcement
+ * (#2272): a configured `developmentBranch` policy value wins outright;
+ * an absent policy falls back to the caller-supplied live default branch
+ * (`null` when that read failed or was never attempted, yielding
+ * `'unavailable'`); an invalid policy value fails closed regardless of
+ * whether a live default branch is available, since a present-but-broken
+ * policy must never be silently ignored in favor of the fallback.
+ *
+ * Pure and injectable by design -- `policy-helpers.mts` performs no `gh`
+ * I/O itself; every caller resolves `liveDefaultBranch` (or passes `null`
+ * when unread) via its own evidence reader, mirroring the onboarding
+ * `OnboardEvidenceReaders` injection pattern.
+ */
+export function resolveEffectiveDevelopmentBranch(config, liveDefaultBranch) {
+  const inspection = inspectDevelopmentBranch(config);
+  if (inspection.status === 'configured') {
+    return { status: 'configured', branch: inspection.branch };
+  }
+  if (inspection.status === 'invalid') {
+    return { status: 'invalid', reason: inspection.reason };
+  }
+  if (liveDefaultBranch === null || liveDefaultBranch === '') {
+    return { status: 'unavailable' };
+  }
+  return { status: 'default', branch: liveDefaultBranch };
+}
 const HELPER_RUNTIME_PROFILES = new Set([
   'package-manager',
   'vendored-node',

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -24,14 +24,17 @@ import {
   DEFAULT_GH_PAGINATED_TIMEOUT_MS,
   GH_TEXT_LOOP_OPTIONS,
   ghText,
+  readGithubRepoDefaultBranch,
   safeGhText,
 } from './gh-exec.mjs';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import {
+  inspectDevelopmentBranch,
   normalizePolicyConfig,
   parseIsoDurationToMs,
   resolveCollaboratorMarkerTrust,
+  resolveEffectiveDevelopmentBranch,
 } from './policy-helpers.mjs';
 import {
   buildPreMergeReadinessSummary,
@@ -245,6 +248,19 @@ export function collectPreMergeReadiness(argv) {
       );
     }
   }
+  // #2272: fail-closed development-branch invariant. Only reads the live
+  // repository default branch when the policy is silent (`'absent'`) --
+  // a configured or malformed value never needs it, so a repo with an
+  // explicit `developmentBranch` never pays this extra `gh api` call.
+  const developmentBranchInspection = inspectDevelopmentBranch(iddConfig);
+  const liveDefaultBranch =
+    developmentBranchInspection.status === 'absent'
+      ? readGithubRepoDefaultBranch(owner, repo)
+      : null;
+  const developmentBranchTarget = {
+    ...resolveEffectiveDevelopmentBranch(iddConfig, liveDefaultBranch),
+    baseRefName,
+  };
   const encodedBaseRefName = encodeURIComponent(baseRefName);
   // #1483: sourced from the same `gh pr view` call above (the
   // `statusCheckRollup` field), not a separate `gh pr checks` call --
@@ -513,6 +529,7 @@ export function collectPreMergeReadiness(argv) {
       pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
       capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
       primaryBotLogin,
+      developmentBranchTarget,
       copilotUnavailable,
       advisoryConvergenceHeadCommittedAt,
       advisoryConvergenceDeadlineMinutes,

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -5085,6 +5085,37 @@ export function computePreMergeReadinessBlockers(report) {
       detail: `mergeStateStatus is "BLOCKED" and ci.discardedNonPassingRequiredChecks has ${String(discardedSiblings.length)} discarded same-named required-check sibling(s); recover via rerun-advisory-convergence, do not merge or --admin`,
     });
   }
+  // #2272: fail-closed development-branch invariant. Absent entirely
+  // (unmigrated caller / unit fixture) means no gate at all -- distinct
+  // from a present-but-empty-`status` value, which this treats as
+  // `'unavailable'` (fail closed) rather than silently skipping.
+  if (report.developmentBranchTarget) {
+    const developmentBranchTarget = preMergeAsRecord(
+      report.developmentBranchTarget,
+    );
+    const status = String(developmentBranchTarget.status ?? 'unavailable');
+    const baseRefName = String(developmentBranchTarget.baseRefName ?? '');
+    if (status === 'invalid') {
+      blockers.push({
+        gate: 'development-branch-target',
+        detail: `configured developmentBranch is invalid: ${String(developmentBranchTarget.reason ?? 'unknown reason')}`,
+      });
+    } else if (status === 'unavailable') {
+      blockers.push({
+        gate: 'development-branch-target',
+        detail:
+          'effective development branch could not be resolved (no developmentBranch policy value and the live repository default branch could not be read)',
+      });
+    } else {
+      const effectiveBranch = String(developmentBranchTarget.branch ?? '');
+      if (effectiveBranch === '' || effectiveBranch !== baseRefName) {
+        blockers.push({
+          gate: 'development-branch-target',
+          detail: `PR base branch "${baseRefName}" does not match the effective development branch "${effectiveBranch}" (status="${status}")`,
+        });
+      }
+    }
+  }
   return blockers;
 }
 export function buildPreMergeReadinessSummary(
@@ -5498,6 +5529,12 @@ export function buildPreMergeReadinessSummary(
   // this can never change `ready`/`blockers`.
   if (options.localValidationEvidenceSummary) {
     summary.localValidationEvidence = options.localValidationEvidenceSummary;
+  }
+  // #2272: omitted entirely (not even `null`) when the caller does not
+  // pass it, so `computePreMergeReadinessBlockers` below can distinguish
+  // "no gate" from "gate present" -- see the option's doc comment above.
+  if (options.developmentBranchTarget) {
+    summary.developmentBranchTarget = options.developmentBranchTarget;
   }
   // Top-level rollup so a consumer reads one `ready` boolean + `blockers[]`
   // instead of hand-ANDing ~8 nested gates (a dropped clause would fail open).

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -5108,7 +5108,7 @@ export function computePreMergeReadinessBlockers(report) {
         detail:
           'effective development branch could not be resolved (no developmentBranch policy value and the live repository default branch could not be read)',
       });
-    } else {
+    } else if (status === 'configured' || status === 'default') {
       const effectiveBranch = String(developmentBranchTarget.branch ?? '');
       if (effectiveBranch === '' || effectiveBranch !== baseRefName) {
         blockers.push({
@@ -5116,6 +5116,17 @@ export function computePreMergeReadinessBlockers(report) {
           detail: `PR base branch "${baseRefName}" does not match the effective development branch "${effectiveBranch}" (status="${status}")`,
         });
       }
+    } else {
+      // Whitelist, not a denylist: an unrecognized status (a typo, a
+      // future enum value this file does not know about yet, or any
+      // other coerced-`String(...)` garbage) must fail closed rather
+      // than fall through to the branch comparison, where a coincidental
+      // `branch === baseRefName` (including both empty) would otherwise
+      // silently pass an invariant this file cannot actually vouch for.
+      blockers.push({
+        gate: 'development-branch-target',
+        detail: `unrecognized developmentBranchTarget.status "${status}" (expected "configured", "default", "invalid", or "unavailable")`,
+      });
     }
   }
   return blockers;

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -5093,7 +5093,9 @@ export function computePreMergeReadinessBlockers(report) {
     const developmentBranchTarget = preMergeAsRecord(
       report.developmentBranchTarget,
     );
-    const status = String(developmentBranchTarget.status ?? 'unavailable');
+    // `||`, not `??`: an empty-string status (garbled/absent field) must
+    // fail closed to 'unavailable' too, not pass '' through unmatched.
+    const status = String(developmentBranchTarget.status || 'unavailable');
     const baseRefName = String(developmentBranchTarget.baseRefName ?? '');
     if (status === 'invalid') {
       blockers.push({

--- a/src/scripts/branch-conflict-state.mts
+++ b/src/scripts/branch-conflict-state.mts
@@ -308,7 +308,7 @@ function deriveBranchState({
     if (skipGitProbe) {
       return {
         branchState: 'behind-no-conflict',
-        syncRecommendation: 'merge-main',
+        syncRecommendation: 'merge-base',
         conflictFiles: [],
         mergeableSource: 'github-merge-state',
         baseAdvancedSinceMergeBase,
@@ -343,7 +343,7 @@ function deriveBranchState({
     }
     return {
       branchState: 'behind-no-conflict',
-      syncRecommendation: 'merge-main',
+      syncRecommendation: 'merge-base',
       conflictFiles: [],
       mergeableSource: 'git-merge-tree',
       baseAdvancedSinceMergeBase,

--- a/src/scripts/gh-exec.mts
+++ b/src/scripts/gh-exec.mts
@@ -136,6 +136,29 @@ export function safeGhText(
   }
 }
 
+/**
+ * Live GitHub default branch for `{owner}/{repo}` (#2272), via `gh api
+ * repos/{owner}/{repo}` and the `default_branch` field. Extracted here so
+ * `pre-merge-readiness.mts`, `ci-wait-state.mts`, `branch-conflict-state.mts`,
+ * and `idd-merge-execute.mts` share one reader instead of four near-identical
+ * `gh api` calls, matching this module's existing role as the shared `gh`
+ * CLI layer. Returns `null` on any failure (unreadable, unauthenticated,
+ * missing repo) so callers treat the branch as undetermined rather than
+ * throwing -- distinct from `idd-onboard.mts`'s own `readGithubDefaultBranch`,
+ * which derives `owner`/`repo` from a local checkout's `remote.origin.url`
+ * instead of accepting them directly.
+ */
+export function readGithubRepoDefaultBranch(
+  owner: string,
+  repo: string,
+): string | null {
+  const output = safeGhText(
+    ['api', `repos/${owner}/${repo}`, '--jq', '.default_branch // empty'],
+    GH_TEXT_LOOP_OPTIONS,
+  );
+  return output === '' ? null : output;
+}
+
 /** Optional overrides accepted by {@link ghTextAsync}. */
 export interface GhTextAsyncOptions {
   /**

--- a/src/scripts/policy-helpers.mts
+++ b/src/scripts/policy-helpers.mts
@@ -150,6 +150,58 @@ export function inspectDevelopmentBranch(
   return { status: 'configured', branch: value };
 }
 
+/**
+ * Resolved outcome of combining {@link inspectDevelopmentBranch} with the
+ * live GitHub default branch (#2272). Unlike {@link DevelopmentBranchStatus}
+ * this always yields a usable `branch` except for the two fail-closed
+ * outcomes: `invalid` (a malformed policy value) and `unavailable` (no
+ * policy value, and the live default branch could not be read either).
+ */
+export type DevelopmentBranchTargetStatus =
+  | 'configured'
+  | 'default'
+  | 'invalid'
+  | 'unavailable';
+
+export interface DevelopmentBranchTarget {
+  status: DevelopmentBranchTargetStatus;
+  /** Present when `status` is `'configured'` or `'default'`. */
+  branch?: string;
+  /** Present when `status` is `'invalid'`. */
+  reason?: string;
+}
+
+/**
+ * Resolve the effective development-branch target for enforcement
+ * (#2272): a configured `developmentBranch` policy value wins outright;
+ * an absent policy falls back to the caller-supplied live default branch
+ * (`null` when that read failed or was never attempted, yielding
+ * `'unavailable'`); an invalid policy value fails closed regardless of
+ * whether a live default branch is available, since a present-but-broken
+ * policy must never be silently ignored in favor of the fallback.
+ *
+ * Pure and injectable by design -- `policy-helpers.mts` performs no `gh`
+ * I/O itself; every caller resolves `liveDefaultBranch` (or passes `null`
+ * when unread) via its own evidence reader, mirroring the onboarding
+ * `OnboardEvidenceReaders` injection pattern.
+ */
+export function resolveEffectiveDevelopmentBranch(
+  config: unknown,
+  liveDefaultBranch: string | null,
+): DevelopmentBranchTarget {
+  const inspection = inspectDevelopmentBranch(config);
+  if (inspection.status === 'configured') {
+    return { status: 'configured', branch: inspection.branch };
+  }
+  if (inspection.status === 'invalid') {
+    return { status: 'invalid', reason: inspection.reason };
+  }
+  if (liveDefaultBranch === null || liveDefaultBranch === '') {
+    return { status: 'unavailable' };
+  }
+  return { status: 'default', branch: liveDefaultBranch };
+}
+
 // Structural view of the untrusted config object parsed from an
 // adopter-controlled JSON file. Every field is optional and weakly
 // typed; the runtime guards below perform the real validation.

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -27,14 +27,17 @@ import {
   DEFAULT_GH_PAGINATED_TIMEOUT_MS,
   GH_TEXT_LOOP_OPTIONS,
   ghText,
+  readGithubRepoDefaultBranch,
   safeGhText,
 } from './gh-exec.mts';
 import { deriveGhHttpStatus } from './gh-http-status.mts';
 import { loadIddConfig } from './idd-config.mts';
 import {
+  inspectDevelopmentBranch,
   normalizePolicyConfig,
   parseIsoDurationToMs,
   resolveCollaboratorMarkerTrust,
+  resolveEffectiveDevelopmentBranch,
 } from './policy-helpers.mts';
 import type {
   PrCommitPayload,
@@ -464,6 +467,19 @@ export function collectPreMergeReadiness(
       );
     }
   }
+  // #2272: fail-closed development-branch invariant. Only reads the live
+  // repository default branch when the policy is silent (`'absent'`) --
+  // a configured or malformed value never needs it, so a repo with an
+  // explicit `developmentBranch` never pays this extra `gh api` call.
+  const developmentBranchInspection = inspectDevelopmentBranch(iddConfig);
+  const liveDefaultBranch =
+    developmentBranchInspection.status === 'absent'
+      ? readGithubRepoDefaultBranch(owner, repo)
+      : null;
+  const developmentBranchTarget = {
+    ...resolveEffectiveDevelopmentBranch(iddConfig, liveDefaultBranch),
+    baseRefName,
+  };
   const encodedBaseRefName = encodeURIComponent(baseRefName);
 
   // #1483: sourced from the same `gh pr view` call above (the
@@ -738,6 +754,7 @@ export function collectPreMergeReadiness(
       pollIntervalMinutes: advisoryWaitPolicy.pollIntervalMinutes,
       capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
       primaryBotLogin,
+      developmentBranchTarget,
       copilotUnavailable,
       advisoryConvergenceHeadCommittedAt,
       advisoryConvergenceDeadlineMinutes,

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -6406,7 +6406,7 @@ export function computePreMergeReadinessBlockers(
         detail:
           'effective development branch could not be resolved (no developmentBranch policy value and the live repository default branch could not be read)',
       });
-    } else {
+    } else if (status === 'configured' || status === 'default') {
       const effectiveBranch = String(developmentBranchTarget.branch ?? '');
       if (effectiveBranch === '' || effectiveBranch !== baseRefName) {
         blockers.push({
@@ -6414,6 +6414,17 @@ export function computePreMergeReadinessBlockers(
           detail: `PR base branch "${baseRefName}" does not match the effective development branch "${effectiveBranch}" (status="${status}")`,
         });
       }
+    } else {
+      // Whitelist, not a denylist: an unrecognized status (a typo, a
+      // future enum value this file does not know about yet, or any
+      // other coerced-`String(...)` garbage) must fail closed rather
+      // than fall through to the branch comparison, where a coincidental
+      // `branch === baseRefName` (including both empty) would otherwise
+      // silently pass an invariant this file cannot actually vouch for.
+      blockers.push({
+        gate: 'development-branch-target',
+        detail: `unrecognized developmentBranchTarget.status "${status}" (expected "configured", "default", "invalid", or "unavailable")`,
+      });
     }
   }
 

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -6389,7 +6389,9 @@ export function computePreMergeReadinessBlockers(
     const developmentBranchTarget = preMergeAsRecord(
       report.developmentBranchTarget,
     );
-    const status = String(developmentBranchTarget.status ?? 'unavailable');
+    // `||`, not `??`: an empty-string status (garbled/absent field) must
+    // fail closed to 'unavailable' too, not pass '' through unmatched.
+    const status = String(developmentBranchTarget.status || 'unavailable');
     const baseRefName = String(developmentBranchTarget.baseRefName ?? '');
     if (status === 'invalid') {
       blockers.push({

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -6381,6 +6381,40 @@ export function computePreMergeReadinessBlockers(
     });
   }
 
+  // #2272: fail-closed development-branch invariant. Absent entirely
+  // (unmigrated caller / unit fixture) means no gate at all -- distinct
+  // from a present-but-empty-`status` value, which this treats as
+  // `'unavailable'` (fail closed) rather than silently skipping.
+  if (report.developmentBranchTarget) {
+    const developmentBranchTarget = preMergeAsRecord(
+      report.developmentBranchTarget,
+    );
+    const status = String(developmentBranchTarget.status ?? 'unavailable');
+    const baseRefName = String(developmentBranchTarget.baseRefName ?? '');
+    if (status === 'invalid') {
+      blockers.push({
+        gate: 'development-branch-target',
+        detail: `configured developmentBranch is invalid: ${String(
+          developmentBranchTarget.reason ?? 'unknown reason',
+        )}`,
+      });
+    } else if (status === 'unavailable') {
+      blockers.push({
+        gate: 'development-branch-target',
+        detail:
+          'effective development branch could not be resolved (no developmentBranch policy value and the live repository default branch could not be read)',
+      });
+    } else {
+      const effectiveBranch = String(developmentBranchTarget.branch ?? '');
+      if (effectiveBranch === '' || effectiveBranch !== baseRefName) {
+        blockers.push({
+          gate: 'development-branch-target',
+          detail: `PR base branch "${baseRefName}" does not match the effective development branch "${effectiveBranch}" (status="${status}")`,
+        });
+      }
+    }
+  }
+
   return blockers;
 }
 
@@ -6566,6 +6600,23 @@ export function buildPreMergeReadinessSummary(
     // (field is omitted entirely -- not even `null` -- unchanged
     // pre-#2323 behavior).
     localValidationEvidenceSummary?: Record<string, unknown> | null;
+    // #2272: caller-precomputed effective development-branch resolution
+    // (`resolveEffectiveDevelopmentBranch` in policy-helpers.mts) paired
+    // with the live PR `baseRefName`. This file never resolves policy or
+    // shells out to `gh` itself, mirroring `copilotUnavailable`'s
+    // caller-precomputed pattern -- it only rolls the caller's evidence
+    // into the blocker list below. Unlike `localValidationEvidenceSummary`
+    // above, this DOES feed `computePreMergeReadinessBlockers`: an
+    // `'invalid'`/`'unavailable'` status, or a `branch` that differs from
+    // `baseRefName`, blocks. Omitted (the default) skips this gate
+    // entirely, so every pre-#2272 fixture/caller is unaffected;
+    // `collectPreMergeReadiness` always resolves and passes a value.
+    developmentBranchTarget?: {
+      status: string;
+      branch?: string;
+      reason?: string;
+      baseRefName: string;
+    } | null;
     // Configured `advisoryWait.secondaryQuietWindow` in minutes (#2335),
     // resolved by the caller, mirroring `advisoryConvergenceDeadlineMinutes`
     // above's "policy value resolved by the CLI layer" pattern. Omitted or
@@ -6973,6 +7024,13 @@ export function buildPreMergeReadinessSummary(
   // this can never change `ready`/`blockers`.
   if (options.localValidationEvidenceSummary) {
     summary.localValidationEvidence = options.localValidationEvidenceSummary;
+  }
+
+  // #2272: omitted entirely (not even `null`) when the caller does not
+  // pass it, so `computePreMergeReadinessBlockers` below can distinguish
+  // "no gate" from "gate present" -- see the option's doc comment above.
+  if (options.developmentBranchTarget) {
+    summary.developmentBranchTarget = options.developmentBranchTarget;
   }
 
   // Top-level rollup so a consumer reads one `ready` boolean + `blockers[]`

--- a/tests/branch-conflict-state.test.mts
+++ b/tests/branch-conflict-state.test.mts
@@ -366,7 +366,7 @@ test('classifyBranchConflictState: result always reports readOnly and worktreeUn
   assert.equal(result.worktreeUnchanged, true);
 });
 
-test('classifyBranchConflictState: BEHIND without conflict recommends merge-main', async () => {
+test('classifyBranchConflictState: BEHIND without conflict recommends merge-base', async () => {
   const prData = {
     number: 201,
     headRefOid: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -384,7 +384,7 @@ test('classifyBranchConflictState: BEHIND without conflict recommends merge-main
     _skipGitProbe: true,
   });
   assert.equal(result.branchState, 'behind-no-conflict');
-  assert.equal(result.syncRecommendation, 'merge-main');
+  assert.equal(result.syncRecommendation, 'merge-base');
   // BEHIND is definitional: base has already advanced past the merge-base,
   // so this is `true` even though the git probe itself was skipped.
   assert.equal(result.baseAdvancedSinceMergeBase, true);
@@ -424,7 +424,7 @@ test('parseConflictFiles: returns empty array for clean merge output', () => {
   assert.deepEqual(parseConflictFiles(output), []);
 });
 
-test('classifyBranchConflictState: post-push merge recommendation for BEHIND is merge-main', async () => {
+test('classifyBranchConflictState: post-push merge recommendation for BEHIND is merge-base', async () => {
   const prData = {
     number: 202,
     headRefOid: 'cccccccccccccccccccccccccccccccccccccccc',
@@ -441,7 +441,7 @@ test('classifyBranchConflictState: post-push merge recommendation for BEHIND is 
     _testPrData: prData,
     _skipGitProbe: true,
   });
-  assert.equal(result.syncRecommendation, 'merge-main');
+  assert.equal(result.syncRecommendation, 'merge-base');
   assert.equal(result.baseAdvancedSinceMergeBase, true);
 });
 

--- a/tests/policy-helpers.test.mts
+++ b/tests/policy-helpers.test.mts
@@ -10,6 +10,7 @@ import {
   POLICY_DEFAULTS,
   parseIsoDurationToMs,
   resolveEffectiveCritiqueLoopDelegate,
+  resolveEffectiveDevelopmentBranch,
   selectDesyncedIndex,
 } from '../src/scripts/policy-helpers.mts';
 
@@ -903,5 +904,57 @@ test('normalizePolicyConfig omits developmentBranch when absent or invalid, incl
   assert.equal(
     normalizePolicyConfig({ developmentBranch: 'develop' }).developmentBranch,
     'develop',
+  );
+});
+
+test('resolveEffectiveDevelopmentBranch: a configured value wins outright, live default branch ignored (#2272)', () => {
+  assert.deepEqual(
+    resolveEffectiveDevelopmentBranch({ developmentBranch: 'develop' }, 'main'),
+    { status: 'configured', branch: 'develop' },
+  );
+  // Even a null/unread live default branch never affects a configured value.
+  assert.deepEqual(
+    resolveEffectiveDevelopmentBranch({ developmentBranch: 'develop' }, null),
+    { status: 'configured', branch: 'develop' },
+  );
+});
+
+test('resolveEffectiveDevelopmentBranch: an absent policy falls back to the live default branch (#2272)', () => {
+  assert.deepEqual(resolveEffectiveDevelopmentBranch({}, 'main'), {
+    status: 'default',
+    branch: 'main',
+  });
+  assert.deepEqual(resolveEffectiveDevelopmentBranch(null, 'trunk'), {
+    status: 'default',
+    branch: 'trunk',
+  });
+});
+
+test('resolveEffectiveDevelopmentBranch: an absent policy with an unread live default branch is unavailable, not silently absent (#2272)', () => {
+  assert.deepEqual(resolveEffectiveDevelopmentBranch({}, null), {
+    status: 'unavailable',
+  });
+  assert.deepEqual(resolveEffectiveDevelopmentBranch({}, ''), {
+    status: 'unavailable',
+  });
+});
+
+test('resolveEffectiveDevelopmentBranch: an invalid policy fails closed regardless of a live default branch (#2272)', () => {
+  assert.deepEqual(
+    resolveEffectiveDevelopmentBranch(
+      { developmentBranch: 'refs/heads/main' },
+      'main',
+    ),
+    {
+      status: 'invalid',
+      reason: 'developmentBranch must be a branch name, not a refs/heads/ ref',
+    },
+  );
+  // Even a fully-readable live default branch must not paper over a
+  // present-but-broken policy value -- that would silently ignore an
+  // operator's malformed configuration instead of surfacing it.
+  assert.equal(
+    resolveEffectiveDevelopmentBranch({ developmentBranch: '' }, 'main').status,
+    'invalid',
   );
 });

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -8504,3 +8504,103 @@ test('#2335: a new unresolved finding arriving inside an already-elapsed window 
     ),
   );
 });
+
+// #2272: the development-branch-target gate is a fail-closed invariant
+// distinct from every other pre-merge gate above -- absent entirely
+// (unmigrated caller / every fixture above) adds no blocker at all,
+// matching this file's own "every pre-#2272 caller unaffected" contract.
+test('#2272: developmentBranchTarget omitted never adds a development-branch-target blocker (unmigrated caller, unchanged behavior)', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const ready = buildPreMergeReadinessSummary(fixture.input, {
+    ...fixture.options,
+    includeDispositionEvidence: true,
+  });
+  assert.deepEqual(ready.blockers, computePreMergeReadinessBlockers(ready));
+  assert.ok(
+    !(ready.blockers as { gate: string }[]).some(
+      (blocker) => blocker.gate === 'development-branch-target',
+    ),
+  );
+  assert.equal('developmentBranchTarget' in ready, false);
+});
+
+test('#2272: a matching baseRefName never blocks (configured or default status)', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  for (const status of ['configured', 'default']) {
+    const summary = buildPreMergeReadinessSummary(fixture.input, {
+      ...fixture.options,
+      includeDispositionEvidence: true,
+      developmentBranchTarget: {
+        status,
+        branch: 'develop',
+        baseRefName: 'develop',
+      },
+    });
+    assert.deepEqual(
+      summary.blockers,
+      computePreMergeReadinessBlockers(summary),
+    );
+    assert.ok(
+      !(summary.blockers as { gate: string }[]).some(
+        (blocker) => blocker.gate === 'development-branch-target',
+      ),
+    );
+  }
+});
+
+test('#2272: a PR base branch that differs from the effective development branch blocks, even with every other gate green', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const summary = buildPreMergeReadinessSummary(fixture.input, {
+    ...fixture.options,
+    includeDispositionEvidence: true,
+    developmentBranchTarget: {
+      status: 'configured',
+      branch: 'develop',
+      baseRefName: 'main',
+    },
+  });
+  assert.equal(summary.ready, false);
+  assert.deepEqual(summary.blockers, computePreMergeReadinessBlockers(summary));
+  const blocker = (summary.blockers as { gate: string; detail: string }[]).find(
+    (item) => item.gate === 'development-branch-target',
+  );
+  assert.ok(blocker);
+  assert.match(blocker.detail, /"main".*"develop"/);
+});
+
+test('#2272: an invalid developmentBranch policy value fails closed, ignoring any live default branch', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const summary = buildPreMergeReadinessSummary(fixture.input, {
+    ...fixture.options,
+    includeDispositionEvidence: true,
+    developmentBranchTarget: {
+      status: 'invalid',
+      reason: 'developmentBranch must be a string',
+      baseRefName: 'main',
+    },
+  });
+  assert.equal(summary.ready, false);
+  const blocker = (summary.blockers as { gate: string; detail: string }[]).find(
+    (item) => item.gate === 'development-branch-target',
+  );
+  assert.ok(blocker);
+  assert.match(blocker.detail, /invalid/);
+});
+
+test('#2272: an unavailable effective development branch (no policy, unread live default) fails closed', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const summary = buildPreMergeReadinessSummary(fixture.input, {
+    ...fixture.options,
+    includeDispositionEvidence: true,
+    developmentBranchTarget: {
+      status: 'unavailable',
+      baseRefName: 'main',
+    },
+  });
+  assert.equal(summary.ready, false);
+  const blocker = (summary.blockers as { gate: string; detail: string }[]).find(
+    (item) => item.gate === 'development-branch-target',
+  );
+  assert.ok(blocker);
+  assert.match(blocker.detail, /could not be resolved/);
+});

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -8604,3 +8604,21 @@ test('#2272: an unavailable effective development branch (no policy, unread live
   assert.ok(blocker);
   assert.match(blocker.detail, /could not be resolved/);
 });
+
+test('#2272: an empty-string developmentBranchTarget.status fails closed to unavailable, not a silent passthrough', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const summary = buildPreMergeReadinessSummary(fixture.input, {
+    ...fixture.options,
+    includeDispositionEvidence: true,
+    developmentBranchTarget: {
+      status: '',
+      baseRefName: 'main',
+    },
+  });
+  assert.equal(summary.ready, false);
+  const blocker = (summary.blockers as { gate: string; detail: string }[]).find(
+    (item) => item.gate === 'development-branch-target',
+  );
+  assert.ok(blocker);
+  assert.match(blocker.detail, /could not be resolved/);
+});

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -8622,3 +8622,22 @@ test('#2272: an empty-string developmentBranchTarget.status fails closed to unav
   assert.ok(blocker);
   assert.match(blocker.detail, /could not be resolved/);
 });
+
+test('#2272: an unrecognized developmentBranchTarget.status fails closed even when branch coincidentally matches baseRefName', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const summary = buildPreMergeReadinessSummary(fixture.input, {
+    ...fixture.options,
+    includeDispositionEvidence: true,
+    developmentBranchTarget: {
+      status: 'bogus',
+      branch: 'main',
+      baseRefName: 'main',
+    },
+  });
+  assert.equal(summary.ready, false);
+  const blocker = (summary.blockers as { gate: string; detail: string }[]).find(
+    (item) => item.gate === 'development-branch-target',
+  );
+  assert.ok(blocker);
+  assert.match(blocker.detail, /unrecognized/);
+});

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -574,6 +574,7 @@ export const preMergeReadinessKeys = [
   'trustedMarkerActors',
   'trustedMarkerActorsSource',
   'localValidationEvidence',
+  'developmentBranchTarget',
   'ready',
   'blockers',
 ] as const satisfies readonly (keyof PreMergeReadinessReport)[];


### PR DESCRIPTION
## Summary

Adds a fail-closed development-branch invariant to the helper runtime
(#2272, follow-up to #2271's `developmentBranch` policy field) and makes
branch-conflict-state's synchronization recommendation branch-name-neutral.

- `resolveEffectiveDevelopmentBranch` (`policy-helpers.mts`) combines
  `inspectDevelopmentBranch` with an injectable live default-branch reader:
  `configured` wins outright, `absent` falls back to the live default branch
  (`unavailable` if that read failed too), `invalid` fails closed regardless
  of a readable live default.
- `readGithubRepoDefaultBranch(owner, repo)` (`gh-exec.mts`) is the shared
  `gh api repos/{owner}/{repo}` reader four helpers would otherwise
  duplicate; returns `null` on any failure.
- `computePreMergeReadinessBlockers`/`buildPreMergeReadinessSummary`
  (`protocol-helpers.mts`) gain a `development-branch-target` gate: absent
  entirely (unmigrated caller) adds no blocker; present with `invalid` or
  `unavailable` status, or a PR base branch that differs from the effective
  development branch, blocks even when every other gate is green.
- `collectPreMergeReadiness` (`pre-merge-readiness.mts`) resolves the
  effective branch once per run — fetching the live default branch only
  when the policy is silent — and passes it through. `idd-merge-execute.mts`
  inherits the gate automatically: it delegates to the same shared
  blocker rollup, so no separate wiring was needed there.
- `ci-wait-state.mts` already scopes required-check/branch-protection
  reads to the live PR `baseRefName` exclusively (never the repository
  default merely because it's the default); confirmed unchanged, no code
  touched.
- Renamed `branch-conflict-state.mts`'s `syncRecommendation` value
  `merge-main` → `merge-base` (schema, tests, and the lite
  instructions/docs describing the current output contract), so a
  consumer never sees a GitHub-`main`-specific value regardless of the
  configured development branch.
- Left `docs/idd-design-rationale.md`'s `#merge-main-livelock-under-fast-moving-main`
  anchor link untouched — historical section title describing the design
  rationale, not an assertion about the current runtime output value.
- Did not touch any `.github/workflows/*.yml` checkout step: the default
  branch stays the trusted source for checking out IDD enforcement
  code/configuration, unaffected by this change (no release-branch merge
  path added).

## Test plan

- [x] `pnpm test` — 4228/4228 pass, including new coverage in
      `tests/policy-helpers.test.mts` (configured/default/absent-unavailable/
      invalid resolution) and `tests/pre-merge-readiness.test.mts`
      (omitted-gate backward compatibility, matching base, mismatched base,
      invalid policy, unavailable resolution).
- [x] `pnpm run typecheck`, `pnpm run build:check` (after commit)
- [x] `node scripts/validate-schemas.mjs`
- [x] `node scripts/audit-docs.mjs --check` — no budget regressions
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `node scripts/idd-doctor.mjs` — passed (pre-existing unrelated warnings only)
- [x] biome/dprint/markdownlint/cspell — clean (2 pre-existing unrelated
      `protocol-helpers.mts` warnings, not introduced by this PR)

Closes #2272.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of the repository’s default development branch when no branch policy is configured.
  * Added pre-merge checks that block pull requests targeting the wrong, invalid, or unavailable development branch.

* **Updates**
  * Renamed the branch synchronization recommendation from `merge-main` to `merge-base` across workflows and documentation.

* **Tests**
  * Added coverage for branch resolution, compatibility, mismatches, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->