### PR TITLE
docs(idd-discover): document A0-O's --autopilot suitability-floor routing

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -155,8 +155,8 @@ Apply the configured policy before passing A0-O candidates to A3.5:
 
 **Autopilot floor.** In autopilot runs, pass `--autopilot` to
 `discover-orphan-filter`; skip `routed_to_human` candidates (never
-reach A3.5). No helper: apply A4 Step 2's floor rule (same key, edge
-cases) to each footer by hand.
+reach A3.5). No helper: apply A4 Step 2's floor rule verbatim,
+including `enabled: false`, to each footer.
 
 At least one orphan issue remains after the policy is applied: pass the
 remaining set directly to **A3.5**, skipping A1–A3.

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -153,6 +153,11 @@ Apply the configured policy before passing A0-O candidates to A3.5:
 - `public-disabled`: for private or internal repositories, behave the
   same as `none`.
 
+**Autopilot floor.** In autopilot runs, pass `--autopilot` to
+`discover-orphan-filter`; skip `routed_to_human` candidates (never
+reach A3.5). No helper: read each candidate's own suitability footer,
+apply the floor by hand.
+
 At least one orphan issue remains after the policy is applied: pass the
 remaining set directly to **A3.5**, skipping A1–A3.
 
@@ -171,13 +176,10 @@ reached only when every active discovery path returns zero: both paths
 for `orphan-first` and `roadmap-first` (orphan + roadmap fallback,
 either order); just the roadmap path for `roadmap`.
 
-**Claim-state annotation (optional).** When helper support is enabled,
-`discover-orphan-filter` accepts an opt-in `--with-claim-state` flag
-(plus `--current-claim-id`) that annotates each candidate with
-active-claim eligibility, mirroring `discover-roadmap-graph`'s flag of
-the same name — see `docs/idd-helper-scripts.md`. This lets an A0-O
-caller fold live claim state into its output the same way the roadmap
-path already can.
+**Claim-state annotation (optional).** `discover-orphan-filter`
+accepts `--with-claim-state` (plus `--current-claim-id`), mirroring
+`discover-roadmap-graph`'s flag of the same name — see
+`docs/idd-helper-scripts.md`.
 
 ## A1 — Find the roadmap
 

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -155,8 +155,8 @@ Apply the configured policy before passing A0-O candidates to A3.5:
 
 **Autopilot floor.** In autopilot runs, pass `--autopilot` to
 `discover-orphan-filter`; skip `routed_to_human` candidates (never
-reach A3.5). No helper: read each candidate's own suitability footer,
-apply the floor by hand.
+reach A3.5). No helper: apply A4 Step 2's floor rule (same key, edge
+cases) to each footer by hand.
 
 At least one orphan issue remains after the policy is applied: pass the
 remaining set directly to **A3.5**, skipping A1–A3.

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -148,6 +148,11 @@ Apply the configured policy before passing A0-O candidates to A3.5:
 - `public-disabled`: for private or internal repositories, behave the
   same as `none`.
 
+**Autopilot floor.** In autopilot runs, pass `--autopilot` to
+`discover-orphan-filter`; skip `routed_to_human` candidates (never
+reach A3.5). No helper: read each candidate's own suitability footer,
+apply the floor by hand.
+
 At least one orphan issue remains after the policy is applied: pass the
 remaining set directly to **A3.5**, skipping A1–A3.
 
@@ -166,13 +171,10 @@ reached only when every active discovery path returns zero: both paths
 for `orphan-first` and `roadmap-first` (orphan + roadmap fallback,
 either order); just the roadmap path for `roadmap`.
 
-**Claim-state annotation (optional).** When helper support is enabled,
-`discover-orphan-filter` accepts an opt-in `--with-claim-state` flag
-(plus `--current-claim-id`) that annotates each candidate with
-active-claim eligibility, mirroring `discover-roadmap-graph`'s flag of
-the same name — see `docs/idd-helper-scripts.md`. This lets an A0-O
-caller fold live claim state into its output the same way the roadmap
-path already can.
+**Claim-state annotation (optional).** `discover-orphan-filter`
+accepts `--with-claim-state` (plus `--current-claim-id`), mirroring
+`discover-roadmap-graph`'s flag of the same name — see
+`docs/idd-helper-scripts.md`.
 
 ## A1 — Find the roadmap
 

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -150,8 +150,8 @@ Apply the configured policy before passing A0-O candidates to A3.5:
 
 **Autopilot floor.** In autopilot runs, pass `--autopilot` to
 `discover-orphan-filter`; skip `routed_to_human` candidates (never
-reach A3.5). No helper: apply A4 Step 2's floor rule (same key, edge
-cases) to each footer by hand.
+reach A3.5). No helper: apply A4 Step 2's floor rule verbatim,
+including `enabled: false`, to each footer.
 
 At least one orphan issue remains after the policy is applied: pass the
 remaining set directly to **A3.5**, skipping A1–A3.

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -150,8 +150,8 @@ Apply the configured policy before passing A0-O candidates to A3.5:
 
 **Autopilot floor.** In autopilot runs, pass `--autopilot` to
 `discover-orphan-filter`; skip `routed_to_human` candidates (never
-reach A3.5). No helper: read each candidate's own suitability footer,
-apply the floor by hand.
+reach A3.5). No helper: apply A4 Step 2's floor rule (same key, edge
+cases) to each footer by hand.
 
 At least one orphan issue remains after the policy is applied: pass the
 remaining set directly to **A3.5**, skipping A1–A3.


### PR DESCRIPTION
# Summary

A4 Step 2 tells an autopilot run to skip candidates below
`autopilotSuitability.floor`. A0-O (orphan discovery) had no
equivalent sentence: `discover-orphan-filter.mts` already implements
the missing behavior via an opt-in `--autopilot` flag routing
below-floor candidates to a `routed_to_human` bucket, but the
instructions never told an agent to pass it, or that the
flag/bucket existed. An issue authored below the floor could pass
every written A0-O/A3.5 check all the way to A5, with only manual
footer-reading as a backstop.

Adds a paragraph to A0-O, parallel to A4 Step 2's floor-skip
sentence: in autopilot runs, pass `--autopilot` and skip
`routed_to_human` candidates; without helper runtime, read each
candidate's own authored suitability footer by hand.

## Linked issue

Closes #2248

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

`idd-discover.instructions.md` had only ~30 bytes of headroom under
its 33000-byte per-file budget (`audit/sync-manifest.json`), so the
adjacent claim-state-annotation paragraph was trimmed to make room —
no information lost, just tightened to the same content.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4219 tests, unchanged — documentation only)
- [x] `node scripts/audit-docs.mjs --check` (including the
      per-file byte budget, which had single-digit-byte headroom)
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (not applicable)

Additional: one round of the repository's CodeRabbit C1 critique
delegate — 1 finding (duplicated across both mirrored files, counted
as one): the "Autopilot floor" instruction read as unconditional
rather than scoped to autopilot runs. Fixed by adding an explicit "In
autopilot runs," qualifier, re-verified the byte budget still holds.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (documentation only; no change to
      any merge gate)
- [x] Context budget impact reviewed (`audit-docs.mjs --check`
      passed; per-file byte budget re-verified after the fix round)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated orphan discovery by excluding items already routed to a human.
  - Added a fallback rule to preserve correct filtering when supporting tools are unavailable.

- **Documentation**
  - Clarified the available options for optional orphan claim-state annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->