### PR TITLE
feat(outage-relief): wire the provider-outage declaration into the gates

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1155,13 +1155,18 @@ Interpretation rules:
   invalidates an otherwise-valid declaration, and this helper accepts no
   verdict input at all.
 - Consumed by both gates the `idd-advisory-convergence` waiver already
-  relieves (#2353): `advisory-convergence.mjs`'s own CI-check verdict and
+  relieves
+  ([kurone-kito/idd-skill#2353](https://github.com/kurone-kito/idd-skill/issues/2353)):
+  `advisory-convergence.mjs`'s own CI-check verdict and
   `pre-merge-readiness.mjs`'s F2/F3 merge gate each independently resolve
   a declaration for service `idd-advisory-convergence` on the configured
   `providerOutage.declarationTarget` issue, gated exactly as the
-  non-bypassing bullet above describes. Declare with that exact service
-  name (`--service idd-advisory-convergence`) for either gate to honor
-  it; a declaration for any other service name relieves nothing here.
+  non-bypassing bullet above describes -- and both additionally require
+  `ciGate.externalCheckWaivers.mode` to be `maintainer-authorized`, the
+  same mode gate a direct per-pull-request waiver already requires.
+  Declare with that exact service name (`--service
+  idd-advisory-convergence`) for either gate to honor it; a declaration
+  for any other service name relieves nothing here.
 
 ### Local validation evidence helper
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1154,6 +1154,14 @@ Interpretation rules:
   expiry only. An absent or `unknown` provider-health verdict never
   invalidates an otherwise-valid declaration, and this helper accepts no
   verdict input at all.
+- Consumed by both gates the `idd-advisory-convergence` waiver already
+  relieves (#2353): `advisory-convergence.mjs`'s own CI-check verdict and
+  `pre-merge-readiness.mjs`'s F2/F3 merge gate each independently resolve
+  a declaration for service `idd-advisory-convergence` on the configured
+  `providerOutage.declarationTarget` issue, gated exactly as the
+  non-bypassing bullet above describes. Declare with that exact service
+  name (`--service idd-advisory-convergence`) for either gate to honor
+  it; a declaration for any other service name relieves nothing here.
 
 ### Local validation evidence helper
 

--- a/fixtures/schemas/advisory-convergence.invalid.json
+++ b/fixtures/schemas/advisory-convergence.invalid.json
@@ -35,7 +35,8 @@
     "mode": "disabled",
     "checkSelector": "idd-advisory-convergence",
     "activeClaimId": "",
-    "validCount": 0
+    "validCount": 0,
+    "outageRelieved": false
   },
   "sameHeadReroll": {
     "eligible": false,

--- a/fixtures/schemas/advisory-convergence.valid.json
+++ b/fixtures/schemas/advisory-convergence.valid.json
@@ -37,7 +37,8 @@
     "mode": "disabled",
     "checkSelector": "idd-advisory-convergence",
     "activeClaimId": "",
-    "validCount": 0
+    "validCount": 0,
+    "outageRelieved": false
   },
   "dispositionEvidence": {
     "missingRegularCommentCount": 0,

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1155,13 +1155,18 @@ Interpretation rules:
   invalidates an otherwise-valid declaration, and this helper accepts no
   verdict input at all.
 - Consumed by both gates the `idd-advisory-convergence` waiver already
-  relieves (#2353): `advisory-convergence.mjs`'s own CI-check verdict and
+  relieves
+  ([kurone-kito/idd-skill#2353](https://github.com/kurone-kito/idd-skill/issues/2353)):
+  `advisory-convergence.mjs`'s own CI-check verdict and
   `pre-merge-readiness.mjs`'s F2/F3 merge gate each independently resolve
   a declaration for service `idd-advisory-convergence` on the configured
   `providerOutage.declarationTarget` issue, gated exactly as the
-  non-bypassing bullet above describes. Declare with that exact service
-  name (`--service idd-advisory-convergence`) for either gate to honor
-  it; a declaration for any other service name relieves nothing here.
+  non-bypassing bullet above describes -- and both additionally require
+  `ciGate.externalCheckWaivers.mode` to be `maintainer-authorized`, the
+  same mode gate a direct per-pull-request waiver already requires.
+  Declare with that exact service name (`--service
+  idd-advisory-convergence`) for either gate to honor it; a declaration
+  for any other service name relieves nothing here.
 
 ### Local validation evidence helper
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1154,6 +1154,14 @@ Interpretation rules:
   expiry only. An absent or `unknown` provider-health verdict never
   invalidates an otherwise-valid declaration, and this helper accepts no
   verdict input at all.
+- Consumed by both gates the `idd-advisory-convergence` waiver already
+  relieves (#2353): `advisory-convergence.mjs`'s own CI-check verdict and
+  `pre-merge-readiness.mjs`'s F2/F3 merge gate each independently resolve
+  a declaration for service `idd-advisory-convergence` on the configured
+  `providerOutage.declarationTarget` issue, gated exactly as the
+  non-bypassing bullet above describes. Declare with that exact service
+  name (`--service idd-advisory-convergence`) for either gate to honor
+  it; a declaration for any other service name relieves nothing here.
 
 ### Local validation evidence helper
 

--- a/schemas/advisory-convergence.schema.json
+++ b/schemas/advisory-convergence.schema.json
@@ -188,7 +188,7 @@
     "waiver": {
       "type": "object",
       "description": "Escape-hatch evidence for a maintainer-authorized external-check waiver, evaluated only once deadline.passed or terminal.state is COPILOT_UNAVAILABLE.",
-      "required": ["mode", "checkSelector", "activeClaimId", "validCount"],
+      "required": ["mode", "checkSelector", "activeClaimId", "validCount", "outageRelieved"],
       "additionalProperties": false,
       "properties": {
         "mode": {
@@ -207,6 +207,10 @@
           "type": "integer",
           "description": "Count of valid external-check-waiver markers matching checkSelector.",
           "minimum": 0
+        },
+        "outageRelieved": {
+          "type": "boolean",
+          "description": "kurone-kito/idd-skill#2353: true when a repository-scoped providerOutage.declarationTarget declaration relieves this gate's own selector, independent of validCount (which stays direct-per-pull-request-waiver-marker-only). Still requires this pull request's own proven terminal-unavailable state and a waivableSelectors match, never the deadline-only opener."
         }
       }
     },
@@ -369,7 +373,7 @@
     },
     "waived": {
       "type": "boolean",
-      "description": "True when applicability.status is applicable or indeterminate (never not_applicable) and at least one valid external-check waiver covers this gate; deliberately still reachable when indeterminate."
+      "description": "True when applicability.status is applicable or indeterminate (never not_applicable) and either at least one valid external-check waiver covers this gate, or an active provider-outage declaration relieves it (kurone-kito/idd-skill#2353); deliberately still reachable when indeterminate."
     },
     "ready": {
       "type": "boolean",

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -110,6 +110,10 @@ import { buildCopilotRecoverySummary } from './advisory-wait-state.mjs';
 import { parseCanonicalIntegerOrNull, parseCliArgs } from './cli-args.mjs';
 import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mjs';
 import {
+  normalizeAuthorityEvidence,
+  resolveCollaboratorAuthority,
+} from './external-check-waiver.mjs';
+import {
   GH_TEXT_LOOP_OPTIONS,
   ghApiJson,
   ghGraphql,
@@ -135,6 +139,10 @@ import {
   summarizeDispositionEvidenceForGate,
   summarizeExternalCheckWaivers,
 } from './protocol-helpers.mjs';
+import {
+  evaluateProviderOutageRelief,
+  resolveProviderOutageDeclaration,
+} from './provider-outage-declaration.mjs';
 import {
   fetchReviewsAndHeadCommit,
   isVerifiedCopilotAuthor,
@@ -848,6 +856,13 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     String(options.waiverCheckSelector ?? '').trim() ||
     ADVISORY_CONVERGENCE_CHECK_SELECTOR;
   let validWaiverCount = 0;
+  // #2353: default when the enclosing precondition never opens -- no
+  // declaration relief can apply before the SAME precondition the direct
+  // waiver above requires has opened.
+  let outageRelief = {
+    relieved: false,
+    reason: 'waiver precondition not open',
+  };
   if (
     !converged &&
     (deadlinePassed || terminalUnavailable) &&
@@ -882,24 +897,41 @@ export function computeAdvisoryConvergenceVerdict(inputs, options) {
     validWaiverCount = waiverEvidence.valid.filter(
       (entry) => entry.checkSelector === waiverCheckSelector,
     ).length;
+    // #2353: a repository-scoped `providerOutage.declarationTarget`
+    // declaration substitutes for a per-pull-request waiver marker on THIS
+    // selector, gated by the SAME enclosing precondition as the direct
+    // waiver above, plus `evaluateProviderOutageRelief`'s own additional
+    // requirement that THIS pull request's own terminal-unavailable state
+    // independently holds -- never the deadline-only opener, even though
+    // the deadline path can also reach this branch. A declaration active
+    // only under a passed deadline (no proven terminal state) therefore
+    // still yields `relieved: false` here, by that function's own contract.
+    outageRelief = evaluateProviderOutageRelief({
+      declarationActive: options.outageDeclarationActive === true,
+      prTerminalUnavailable: terminalUnavailable,
+      requestedSelector: waiverCheckSelector,
+      waivableSelectors: [...(options.waivableSelectors ?? [])],
+    });
   }
   const waiver = {
     mode: waiverMode,
     checkSelector: waiverCheckSelector,
     activeClaimId,
     validCount: validWaiverCount,
+    outageRelieved: outageRelief.relieved,
   };
-  const waived = !scopeNotApplicable && validWaiverCount > 0;
+  const waived =
+    !scopeNotApplicable && (validWaiverCount > 0 || outageRelief.relieved);
   if (!scopeNotApplicable && !converged && terminalUnavailable && !waived) {
     reasons.push(
       waiverMode === 'maintainer-authorized'
-        ? `Copilot is terminally unavailable (recovery cap exhausted and terminal window elapsed with no current-HEAD review) with no valid maintainer external-check waiver for selector "${waiverCheckSelector}" on current HEAD`
+        ? `Copilot is terminally unavailable (recovery cap exhausted and terminal window elapsed with no current-HEAD review) with no valid maintainer external-check waiver and no active provider-outage declaration relief for selector "${waiverCheckSelector}" on current HEAD`
         : `Copilot is terminally unavailable (recovery cap exhausted and terminal window elapsed with no current-HEAD review) and no waiver is available (ciGate.externalCheckWaivers.mode is "${waiverMode}", not "maintainer-authorized")`,
     );
   } else if (!scopeNotApplicable && !converged && deadlinePassed && !waived) {
     reasons.push(
       waiverMode === 'maintainer-authorized'
-        ? `deadline (${deadlineMinutes}m) passed with no valid maintainer external-check waiver for selector "${waiverCheckSelector}" on current HEAD`
+        ? `deadline (${deadlineMinutes}m) passed with no valid maintainer external-check waiver for selector "${waiverCheckSelector}" on current HEAD (a provider-outage declaration cannot relieve the deadline-only path -- it requires this pull request's own proven terminal-unavailable state)`
         : `deadline (${deadlineMinutes}m) passed and no waiver is available (ciGate.externalCheckWaivers.mode is "${waiverMode}", not "maintainer-authorized")`,
     );
   }
@@ -1638,6 +1670,40 @@ function collectFromGitHub(args) {
   // pattern) -- re-declaring the shape here would silently stop tracking
   // that source of truth on drift.
   const policy = normalizePolicyConfig(rawConfig);
+  // #2353: resolve whether a repository-scoped `providerOutage.
+  // declarationTarget` declaration is active for THIS gate's own selector
+  // (`idd-advisory-convergence` -- see idd-advisory-wait.instructions.md's
+  // "Sustained outage" note). Fails closed to inactive on ANY error (unset
+  // target, unreadable/unparseable comments, authority-lookup failure),
+  // matching `prFirstCommitAt` below: a transient fetch failure must never
+  // widen what this gate accepts.
+  let outageDeclarationActive = false;
+  const outageDeclarationTargetIssue =
+    policy?.providerOutage?.declarationTarget;
+  if (outageDeclarationTargetIssue) {
+    try {
+      const declarationComments = ghApiJson(
+        `repos/${owner}/${repo}/issues/${outageDeclarationTargetIssue}/comments`,
+        { paginate: true },
+      );
+      const authorityOf = (actorLogin) =>
+        normalizeAuthorityEvidence(
+          resolveCollaboratorAuthority({ owner, repo, actor: actorLogin }),
+          actorLogin,
+          owner,
+          policy.ciGate.externalCheckWaivers.authorityPolicy,
+        );
+      outageDeclarationActive = resolveProviderOutageDeclaration({
+        declarationTargetConfigured: true,
+        comments: declarationComments,
+        service: ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+        policy,
+        authorityOf,
+      }).active;
+    } catch {
+      outageDeclarationActive = false;
+    }
+  }
   // #1344: forced-handoff-aware claim resolution, matching
   // `pre-merge-readiness.mts` exactly, except reading `forcedHandoff.mode`/
   // `authorityPolicy` off the already-loaded/normalized `policy` above
@@ -1735,6 +1801,7 @@ function collectFromGitHub(args) {
       ),
       waiverCheckSelector: ADVISORY_CONVERGENCE_CHECK_SELECTOR,
       waivableSelectors: policy?.ciGate?.externalChecks?.waivable ?? [],
+      outageDeclarationActive,
       sameHeadRerollCap,
       pendingWindowMinutes,
       recoveryCycleCap,

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -1670,6 +1670,15 @@ function collectFromGitHub(args) {
   // pattern) -- re-declaring the shape here would silently stop tracking
   // that source of truth on drift.
   const policy = normalizePolicyConfig(rawConfig);
+  // Resolved once and reused below AND in the returned `options.now` --
+  // #2353 (Codex review on PR #2370): the declaration-validity read must
+  // evaluate at the SAME instant the rest of this verdict does (deadline,
+  // waiver expiry, terminal evidence), or a `--now`-overridden invocation
+  // (deterministic replay, tests) would resolve `outageDeclarationActive`
+  // against the real wall clock instead, an inconsistency within the same
+  // verdict.
+  const resolvedNow =
+    args.now || new Date().toISOString().replace('.000Z', 'Z');
   // #2353: resolve whether a repository-scoped `providerOutage.
   // declarationTarget` declaration is active for THIS gate's own selector
   // (`idd-advisory-convergence` -- see idd-advisory-wait.instructions.md's
@@ -1699,6 +1708,7 @@ function collectFromGitHub(args) {
         service: ADVISORY_CONVERGENCE_CHECK_SELECTOR,
         policy,
         authorityOf,
+        now: new Date(resolvedNow),
       }).active;
     } catch {
       outageDeclarationActive = false;
@@ -1782,7 +1792,7 @@ function collectFromGitHub(args) {
       prAuthorIsBot,
     },
     options: {
-      now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
+      now: resolvedNow,
       primaryBotLogin,
       trustedMarkerLogins,
       advisoryBotLogins,

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -1273,7 +1273,14 @@ function readExternalCheckWaiverMode() {
 // evidence `evaluateProviderOutageRelief` requires independently of the
 // declaration itself (never itself sufficient) -- the same terminal-
 // unavailability verdict this file's own `copilot-terminal-unavailable`
-// blocker already consumes.
+// blocker already consumes. Requires `ciGate.externalCheckWaivers.mode`
+// to be `maintainer-authorized` (Codex review on PR #2370): without this,
+// an adopter that leaves `mode` at its `disabled` default but configures
+// the waivable selector and posts a declaration would relieve here while
+// `computeAdvisoryConvergenceVerdict`'s own gate -- gated on the SAME
+// `waiverMode === 'maintainer-authorized'` check -- still rejects it,
+// exactly the two-gate disagreement #2021 already fixed for the direct
+// per-pull-request waiver path.
 function resolveAdvisoryConvergenceOutageRelief({
   owner,
   repo,
@@ -1285,6 +1292,9 @@ function resolveAdvisoryConvergenceOutageRelief({
     const policy = normalizePolicyConfig(
       JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
     );
+    if (policy.ciGate.externalCheckWaivers.mode !== 'maintainer-authorized') {
+      return false;
+    }
     const targetIssue = policy.providerOutage.declarationTarget;
     if (!targetIssue) return false;
     const declarationComments = ghApiJson(

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -6,6 +6,7 @@
 // generated .mjs. See docs/typescript-sources.md.
 import { readFileSync } from 'node:fs';
 import {
+  DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
   readAdvisoryConvergenceDeadlineMinutes,
   readAdvisoryPrimaryBotLogin,
   readAdvisoryRecoveryCycleCap,
@@ -20,6 +21,10 @@ import {
   readForcedHandoffAuthorityPolicy,
   readForcedHandoffMode,
 } from './collaborator-permission.mjs';
+import {
+  normalizeAuthorityEvidence,
+  resolveCollaboratorAuthority,
+} from './external-check-waiver.mjs';
 import {
   DEFAULT_GH_PAGINATED_TIMEOUT_MS,
   GH_TEXT_LOOP_OPTIONS,
@@ -47,6 +52,10 @@ import {
   resolveTrustedMarkerActors,
   selectCodeownersText,
 } from './protocol-helpers.mjs';
+import {
+  evaluateProviderOutageRelief,
+  resolveProviderOutageDeclaration,
+} from './provider-outage-declaration.mjs';
 import {
   fetchReviewsAndHeadCommit,
   resolveLatestCopilotReviewClause,
@@ -463,6 +472,14 @@ export function collectPreMergeReadiness(argv) {
     },
   );
   const copilotUnavailable = copilotRecovery.state === 'COPILOT_UNAVAILABLE';
+  const advisoryConvergenceOutageRelieved =
+    resolveAdvisoryConvergenceOutageRelief({
+      owner,
+      repo,
+      copilotUnavailable,
+      waivableCheckSelectors,
+      now,
+    });
   const summary = buildPreMergeReadinessSummary(
     {
       prHeadSha,
@@ -514,6 +531,7 @@ export function collectPreMergeReadiness(argv) {
       capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
       primaryBotLogin,
       copilotUnavailable,
+      advisoryConvergenceOutageRelieved,
       advisoryConvergenceHeadCommittedAt,
       advisoryConvergenceDeadlineMinutes,
       secondaryQuietWindowMinutes,
@@ -1240,6 +1258,68 @@ function readExternalCheckWaiverMode() {
     ).ciGate.externalCheckWaivers.mode;
   } catch {
     return 'disabled';
+  }
+}
+// #2353: resolve whether a repository-scoped `providerOutage.
+// declarationTarget` declaration relieves the `idd-advisory-convergence`
+// selector for this pull request -- the SAME selector
+// `advisory-convergence.mts`'s own gate relieves via its own,
+// independently-fetched declaration (see that file's `collectFromGitHub`).
+// Fails closed to `false` on ANY error (unset target, unreadable/
+// unparseable declaration-target comments, authority-lookup failure) --
+// a transient fetch failure must never widen what this gate accepts,
+// matching `prFirstCommitAt`'s own fail-closed contract above.
+// `copilotUnavailable` is the caller-supplied `prTerminalUnavailable`
+// evidence `evaluateProviderOutageRelief` requires independently of the
+// declaration itself (never itself sufficient) -- the same terminal-
+// unavailability verdict this file's own `copilot-terminal-unavailable`
+// blocker already consumes.
+function resolveAdvisoryConvergenceOutageRelief({
+  owner,
+  repo,
+  copilotUnavailable,
+  waivableCheckSelectors,
+  now,
+}) {
+  try {
+    const policy = normalizePolicyConfig(
+      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
+    );
+    const targetIssue = policy.providerOutage.declarationTarget;
+    if (!targetIssue) return false;
+    const declarationComments = ghApiJson(
+      `repos/${owner}/${repo}/issues/${targetIssue}/comments`,
+      true,
+    );
+    const authorityOf = (actorLogin) =>
+      normalizeAuthorityEvidence(
+        resolveCollaboratorAuthority({ owner, repo, actor: actorLogin }),
+        actorLogin,
+        owner,
+        policy.ciGate.externalCheckWaivers.authorityPolicy,
+      );
+    const declaration = resolveProviderOutageDeclaration({
+      declarationTargetConfigured: true,
+      comments: declarationComments,
+      service: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      policy,
+      authorityOf,
+      now: new Date(now),
+    });
+    return evaluateProviderOutageRelief({
+      declarationActive: declaration.active,
+      prTerminalUnavailable: copilotUnavailable,
+      requestedSelector: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      waivableSelectors: waivableCheckSelectors
+        .map((entry) => ({
+          selector: String(entry.selector ?? ''),
+          matchMode:
+            typeof entry.matchMode === 'string' ? entry.matchMode : undefined,
+        }))
+        .filter((entry) => entry.selector.length > 0),
+    }).relieved;
+  } catch {
+    return false;
   }
 }
 // Configured claim-staleness window (`claimTiming.staleAge`, #1310), parsed

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -1263,6 +1263,26 @@ function readExternalCheckWaiverMode() {
     return 'disabled';
   }
 }
+// #2353 (Codex review on PR #2370, second follow-up): a declaration's own
+// `startedAt` is generated before the `--declare --apply` interactive
+// confirmation prompt, while the GitHub comment's `createdAt` is stamped
+// only once the maintainer actually confirms posting it. A failed check
+// that completes during that pause satisfies a `startedAt`-only cutoff
+// even though the declaration did not verifiably exist on GitHub yet and
+// the check never reran under it. Use the LATER of the two timestamps as
+// the true "this declaration became a real, postable fact" moment.
+// `createdAt` may be the literal string `"none"` (schema-documented) or
+// otherwise unparseable; in that case this falls back to `startedAt`
+// alone, unchanged from before this fix -- never widening the cutoff.
+export function resolveDeclarationActiveSince(declaration) {
+  const startedAtMs = Date.parse(String(declaration?.startedAt ?? ''));
+  const createdAtMs = Date.parse(String(declaration?.createdAt ?? ''));
+  const candidates = [startedAtMs, createdAtMs].filter((ms) =>
+    Number.isFinite(ms),
+  );
+  if (candidates.length === 0) return '';
+  return new Date(Math.max(...candidates)).toISOString();
+}
 // #2353: resolve whether a repository-scoped `providerOutage.
 // declarationTarget` declaration relieves the `idd-advisory-convergence`
 // selector for this pull request -- the SAME selector
@@ -1340,7 +1360,9 @@ function resolveAdvisoryConvergenceOutageRelief({
     }).relieved;
     return {
       relieved,
-      since: relieved ? String(declaration.declaration?.startedAt ?? '') : '',
+      since: relieved
+        ? resolveDeclarationActiveSince(declaration.declaration)
+        : '',
     };
   } catch {
     return notRelieved;

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -472,7 +472,7 @@ export function collectPreMergeReadiness(argv) {
     },
   );
   const copilotUnavailable = copilotRecovery.state === 'COPILOT_UNAVAILABLE';
-  const advisoryConvergenceOutageRelieved =
+  const advisoryConvergenceOutageRelief =
     resolveAdvisoryConvergenceOutageRelief({
       owner,
       repo,
@@ -531,7 +531,10 @@ export function collectPreMergeReadiness(argv) {
       capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
       primaryBotLogin,
       copilotUnavailable,
-      advisoryConvergenceOutageRelieved,
+      advisoryConvergenceOutageRelieved:
+        advisoryConvergenceOutageRelief.relieved,
+      advisoryConvergenceOutageRelievedSince:
+        advisoryConvergenceOutageRelief.since,
       advisoryConvergenceHeadCommittedAt,
       advisoryConvergenceDeadlineMinutes,
       secondaryQuietWindowMinutes,
@@ -1265,11 +1268,11 @@ function readExternalCheckWaiverMode() {
 // selector for this pull request -- the SAME selector
 // `advisory-convergence.mts`'s own gate relieves via its own,
 // independently-fetched declaration (see that file's `collectFromGitHub`).
-// Fails closed to `false` on ANY error (unset target, unreadable/
-// unparseable declaration-target comments, authority-lookup failure) --
-// a transient fetch failure must never widen what this gate accepts,
-// matching `prFirstCommitAt`'s own fail-closed contract above.
-// `copilotUnavailable` is the caller-supplied `prTerminalUnavailable`
+// Fails closed to `{ relieved: false, since: '' }` on ANY error (unset
+// target, unreadable/unparseable declaration-target comments, authority-
+// lookup failure) -- a transient fetch failure must never widen what this
+// gate accepts, matching `prFirstCommitAt`'s own fail-closed contract
+// above. `copilotUnavailable` is the caller-supplied `prTerminalUnavailable`
 // evidence `evaluateProviderOutageRelief` requires independently of the
 // declaration itself (never itself sufficient) -- the same terminal-
 // unavailability verdict this file's own `copilot-terminal-unavailable`
@@ -1280,7 +1283,13 @@ function readExternalCheckWaiverMode() {
 // `computeAdvisoryConvergenceVerdict`'s own gate -- gated on the SAME
 // `waiverMode === 'maintainer-authorized'` check -- still rejects it,
 // exactly the two-gate disagreement #2021 already fixed for the direct
-// per-pull-request waiver path.
+// per-pull-request waiver path. `since` is the declaration's own
+// `startedAt` (Codex review on PR #2370): a required check's live run
+// must have completed AT OR AFTER this moment to count as covered --
+// otherwise the check was never actually rerun during the declared
+// outage window, and GitHub's own required-check state stays whatever a
+// stale pre-declaration run left it at while this gate reports covered,
+// reproducing #2021's "ready but merge blocked" class one layer deeper.
 function resolveAdvisoryConvergenceOutageRelief({
   owner,
   repo,
@@ -1288,15 +1297,16 @@ function resolveAdvisoryConvergenceOutageRelief({
   waivableCheckSelectors,
   now,
 }) {
+  const notRelieved = { relieved: false, since: '' };
   try {
     const policy = normalizePolicyConfig(
       JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
     );
     if (policy.ciGate.externalCheckWaivers.mode !== 'maintainer-authorized') {
-      return false;
+      return notRelieved;
     }
     const targetIssue = policy.providerOutage.declarationTarget;
-    if (!targetIssue) return false;
+    if (!targetIssue) return notRelieved;
     const declarationComments = ghApiJson(
       `repos/${owner}/${repo}/issues/${targetIssue}/comments`,
       true,
@@ -1316,7 +1326,7 @@ function resolveAdvisoryConvergenceOutageRelief({
       authorityOf,
       now: new Date(now),
     });
-    return evaluateProviderOutageRelief({
+    const relieved = evaluateProviderOutageRelief({
       declarationActive: declaration.active,
       prTerminalUnavailable: copilotUnavailable,
       requestedSelector: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
@@ -1328,8 +1338,12 @@ function resolveAdvisoryConvergenceOutageRelief({
         }))
         .filter((entry) => entry.selector.length > 0),
     }).relieved;
+    return {
+      relieved,
+      since: relieved ? String(declaration.declaration?.startedAt ?? '') : '',
+    };
   } catch {
-    return false;
+    return notRelieved;
   }
 }
 // Configured claim-staleness window (`claimTiming.staleAge`, #1310), parsed

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -1309,11 +1309,13 @@ export function resolveDeclarationActiveSince(declaration) {
 // `waiverMode === 'maintainer-authorized'` check -- still rejects it,
 // exactly the two-gate disagreement #2021 already fixed for the direct
 // per-pull-request waiver path. `since` is the declaration's own
-// `startedAt` (Codex review on PR #2370): a required check's live run
-// must have completed AT OR AFTER this moment to count as covered --
-// otherwise the check was never actually rerun during the declared
-// outage window, and GitHub's own required-check state stays whatever a
-// stale pre-declaration run left it at while this gate reports covered,
+// active-since moment (Codex review on PR #2370): a required check's live
+// run must have STARTED (Copilot review, round 5: not "completed" --
+// `summarizeRequiredChecks`'s `treatAsCoveredByWaiver` cutoff anchors on
+// `startedAt`) AT OR AFTER this moment to count as covered -- otherwise
+// the check was never actually rerun during the declared outage window,
+// and GitHub's own required-check state stays whatever a stale
+// pre-declaration run left it at while this gate reports covered,
 // reproducing #2021's "ready but merge blocked" class one layer deeper.
 function resolveAdvisoryConvergenceOutageRelief({
   owner,

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -122,6 +122,10 @@ export function normalizeStatusCheckRollupEntry(entry) {
       name: String(entry?.context ?? '').trim(),
       state: STATUS_CONTEXT_STATE_ALIASES[rawState] ?? rawState,
       completedAt: String(entry?.completedAt ?? ZERO_SENTINEL_TIMESTAMP),
+      // A legacy commit status has no separate start/complete lifecycle --
+      // it is reported as a single instant -- so `startedAt` reuses the
+      // same `completedAt` value rather than exposing a fabricated one.
+      startedAt: String(entry?.completedAt ?? ZERO_SENTINEL_TIMESTAMP),
       type: 'status-context',
       workflowName: '',
     };
@@ -137,6 +141,7 @@ export function normalizeStatusCheckRollupEntry(entry) {
     state:
       status === 'COMPLETED' ? conclusion || 'UNKNOWN' : status || 'UNKNOWN',
     completedAt: String(entry?.completedAt ?? ZERO_SENTINEL_TIMESTAMP),
+    startedAt: String(entry?.startedAt ?? ZERO_SENTINEL_TIMESTAMP),
     type: 'check-run',
     workflowName: String(entry?.workflowName ?? '').trim(),
   };

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3689,8 +3689,17 @@ export function summarizeRequiredChecks(
     // #2353: an independent positive path -- see `treatAsCoveredByWaiver`'s
     // own doc comment for why it deliberately bypasses
     // `excludeFromWaiverCoverage`/`hasFreshWaiverCoverage`/`waivableSelectors`
-    // below rather than feeding into the same conjunction.
+    // below rather than feeding into the same conjunction. Still requires
+    // `completedAtMs !== null` (Copilot + Codex review on PR #2370): the
+    // SAME #2034 fail-closed live-run requirement `hasFreshWaiverCoverage`
+    // already enforces -- a check that is still QUEUED/IN_PROGRESS/PENDING
+    // with no parseable `completedAt` has never actually produced a verdict
+    // at all, and treating it as covered would report `success` while
+    // GitHub's own required-check state is still pending, reproducing the
+    // exact "ready but merge blocked" failure mode #2021 fixed for the
+    // direct-waiver path.
     const treatedAsCoveredByWaiver =
+      completedAtMs !== null &&
       typeof treatAsCoveredByWaiver === 'function' &&
       treatAsCoveredByWaiver(name);
     const coveredByWaiver =

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3654,12 +3654,28 @@ export function summarizeRequiredChecks(
     const name = String(check.name ?? '');
     const state = String(check.state ?? '').toUpperCase();
     const completedAt = String(check.completedAt ?? '');
-    const completedAtMs = isValidIsoTimestamp(completedAt)
-      ? new Date(completedAt).getTime()
+    // #2353 (Copilot + Codex + CodeRabbit review on PR #2370, round 5):
+    // `isValidIsoTimestamp` alone accepts GitHub's `0001-01-01T00:00:00Z`
+    // zero-value sentinel -- `normalizeStatusCheckRollupEntry` substitutes
+    // it for BOTH an absent `completedAt` (still QUEUED/IN_PROGRESS) and an
+    // absent `startedAt` (not yet started), the same non-nullable-DateTime
+    // convention `isCompletedCiTimestamp` already exists to reject (see its
+    // doc comment / `parseCompletedAt` above). Reusing it here -- despite
+    // its "completed" name -- because the sentinel isn't completion-
+    // specific: it is GitHub's stand-in for "this lifecycle moment hasn't
+    // happened yet," which applies equally to `startedAt`. Without this, an
+    // IN_PROGRESS run (sentinel `completedAt`, but a genuine, fresh
+    // `startedAt`) would pass BOTH `completedAtMs !== null` (the sentinel
+    // parses as a valid, merely very-old, timestamp) and the `startedAt`
+    // freshness cutoff below, reporting a still-running required check
+    // `coveredByWaiver: true` while GitHub's own check is neither passed
+    // nor even finished.
+    const completedAtMs = isCompletedCiTimestamp(completedAt)
+      ? Date.parse(completedAt)
       : null;
     const startedAt = String(check.startedAt ?? '');
-    const startedAtMs = isValidIsoTimestamp(startedAt)
-      ? new Date(startedAt).getTime()
+    const startedAtMs = isCompletedCiTimestamp(startedAt)
+      ? Date.parse(startedAt)
       : null;
     const matchingWaivers = validWaivers.filter((w) =>
       matchCheckSelectorLocal(name, w.checkSelector),

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3639,6 +3639,7 @@ export function summarizeRequiredChecks(
     trustSourcePinnedRequiredChecks = false,
     excludeFromWaiverCoverage = null,
     waiverActiveSinceOverride = null,
+    treatAsCoveredByWaiver = null,
   } = {},
 ) {
   const branchReviewRequirements = summarizeBranchReviewRequirements(
@@ -3685,18 +3686,26 @@ export function summarizeRequiredChecks(
             : waiverCreatedAtMs;
         return completedAtMs >= activeSinceMs;
       });
+    // #2353: an independent positive path -- see `treatAsCoveredByWaiver`'s
+    // own doc comment for why it deliberately bypasses
+    // `excludeFromWaiverCoverage`/`hasFreshWaiverCoverage`/`waivableSelectors`
+    // below rather than feeding into the same conjunction.
+    const treatedAsCoveredByWaiver =
+      typeof treatAsCoveredByWaiver === 'function' &&
+      treatAsCoveredByWaiver(name);
     const coveredByWaiver =
       !CHECK_PASS_EQUIVALENT_STATES.has(state) &&
-      !(
-        typeof excludeFromWaiverCoverage === 'function' &&
-        excludeFromWaiverCoverage(name)
-      ) &&
-      hasFreshWaiverCoverage &&
-      // The check must also sit on the policy's waivable surface. A
-      // null/undefined list keeps the legacy behavior with no gate; an empty
-      // configured list covers nothing.
-      (!Array.isArray(waivableSelectors) ||
-        isCheckNameConfiguredWaivable(name, waivableSelectors));
+      (treatedAsCoveredByWaiver ||
+        (!(
+          typeof excludeFromWaiverCoverage === 'function' &&
+          excludeFromWaiverCoverage(name)
+        ) &&
+          hasFreshWaiverCoverage &&
+          // The check must also sit on the policy's waivable surface. A
+          // null/undefined list keeps the legacy behavior with no gate; an
+          // empty configured list covers nothing.
+          (!Array.isArray(waivableSelectors) ||
+            isCheckNameConfiguredWaivable(name, waivableSelectors))));
     return {
       name,
       state,
@@ -4813,7 +4822,7 @@ export function computePreMergeReadinessBlockers(report) {
     blockers.push({
       gate: 'copilot-terminal-unavailable',
       detail:
-        'Copilot is terminally unavailable on current HEAD (recovery cap exhausted and terminal window elapsed with no current-HEAD review) with no valid maintainer external-check waiver for selector ' +
+        'Copilot is terminally unavailable on current HEAD (recovery cap exhausted and terminal window elapsed with no current-HEAD review) with no valid maintainer external-check waiver and no active provider-outage declaration relief for selector ' +
         `"${DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR}"`,
     });
   }
@@ -5359,6 +5368,17 @@ export function buildPreMergeReadinessSummary(
   );
   const advisoryConvergenceGenuinelyCovered =
     advisoryConvergencePreconditionOpen && advisoryConvergenceExactWaiverValid;
+  // #2353: the caller-precomputed provider-outage-declaration relief
+  // verdict, re-ANDed here with the SAME precondition-open evidence the
+  // direct-waiver path above requires -- cheap insurance against a future
+  // caller passing a relief verdict that was somehow computed without the
+  // precondition it logically implies (evaluateProviderOutageRelief's own
+  // `prTerminalUnavailable` requirement already implies `terminalUnavailable`,
+  // which already implies `advisoryConvergencePreconditionOpen` via the OR,
+  // so this is redundant today, not a new gate).
+  const advisoryConvergenceOutageRelieved =
+    advisoryConvergencePreconditionOpen &&
+    options.advisoryConvergenceOutageRelieved === true;
   const ci = summarizeRequiredChecks(checks, branchRules, branchProtection, {
     // Raw, UNFILTERED `waiverEvidence` -- deliberately not a caller-side
     // pre-filtered copy. A pre-filter that removed a whole `valid` entry
@@ -5385,6 +5405,13 @@ export function buildPreMergeReadinessSummary(
       advisoryConvergenceDeadlineOpensAt
         ? advisoryConvergenceDeadlineOpensAt
         : null,
+    // #2353: a repository-scoped provider-outage declaration relieves
+    // `idd-advisory-convergence` specifically, through a positive path
+    // that bypasses `excludeFromWaiverCoverage` above entirely -- see
+    // `treatAsCoveredByWaiver`'s own doc comment for why.
+    treatAsCoveredByWaiver: (name) =>
+      name === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
+      advisoryConvergenceOutageRelieved,
   });
   // #1570: reuse the SAME raw waiver evidence above (already validated for
   // selector/HEAD/claim/authority/expiry) to decide whether the caller-
@@ -5400,10 +5427,13 @@ export function buildPreMergeReadinessSummary(
   // here.
   const copilotUnavailableWaived =
     copilotUnavailable &&
-    waiverEvidence.valid.some(
+    (waiverEvidence.valid.some(
       (entry) =>
         entry.checkSelector === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
-    );
+    ) ||
+      // #2353: a repository-scoped provider-outage declaration also clears
+      // this dedicated blocker, same as a direct maintainer waiver.
+      advisoryConvergenceOutageRelieved);
   const dispositionEvidence = options.includeDispositionEvidence
     ? summarizeDispositionEvidenceForGate(
         { comments, threads },

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3657,6 +3657,10 @@ export function summarizeRequiredChecks(
     const completedAtMs = isValidIsoTimestamp(completedAt)
       ? new Date(completedAt).getTime()
       : null;
+    const startedAt = String(check.startedAt ?? '');
+    const startedAtMs = isValidIsoTimestamp(startedAt)
+      ? new Date(startedAt).getTime()
+      : null;
     const matchingWaivers = validWaivers.filter((w) =>
       matchCheckSelectorLocal(name, w.checkSelector),
     );
@@ -3699,11 +3703,16 @@ export function summarizeRequiredChecks(
     // GitHub's own required-check state is still pending, reproducing the
     // exact "ready but merge blocked" failure mode #2021 fixed for the
     // direct-waiver path. Also requires the live run to be fresh relative
-    // to `treatAsCoveredByWaiverSince` when the caller supplies one
-    // (Codex review on PR #2370): a run that completed before that moment
-    // was never actually rerun under whatever condition made this check
-    // relieved, reproducing the same staleness gap #2034 already closed
-    // for the direct-waiver path.
+    // to `treatAsCoveredByWaiverSince` when the caller supplies one, and
+    // (Codex review on PR #2370, second follow-up) anchors that freshness
+    // check on `startedAt` rather than `completedAt`: a run that began
+    // evaluating state before the cutoff never observed whatever made this
+    // check relieved, even if it happens to finish (and post `completedAt`)
+    // moments after the cutoff passes -- the run's own verdict was already
+    // decided using stale state by then. Requires `startedAtMs !== null`
+    // for the same fail-closed reason as `completedAtMs !== null` above: a
+    // run with no parseable `startedAt` has no evidence it observed
+    // anything at all.
     const treatAsCoveredByWaiverSinceOverride =
       typeof treatAsCoveredByWaiverSince === 'function'
         ? treatAsCoveredByWaiverSince(name)
@@ -3715,10 +3724,11 @@ export function summarizeRequiredChecks(
       : null;
     const treatedAsCoveredByWaiver =
       completedAtMs !== null &&
+      startedAtMs !== null &&
       typeof treatAsCoveredByWaiver === 'function' &&
       treatAsCoveredByWaiver(name) &&
       (treatAsCoveredByWaiverSinceMs === null ||
-        completedAtMs >= treatAsCoveredByWaiverSinceMs);
+        startedAtMs >= treatAsCoveredByWaiverSinceMs);
     const coveredByWaiver =
       !CHECK_PASS_EQUIVALENT_STATES.has(state) &&
       (treatedAsCoveredByWaiver ||

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3640,6 +3640,7 @@ export function summarizeRequiredChecks(
     excludeFromWaiverCoverage = null,
     waiverActiveSinceOverride = null,
     treatAsCoveredByWaiver = null,
+    treatAsCoveredByWaiverSince = null,
   } = {},
 ) {
   const branchReviewRequirements = summarizeBranchReviewRequirements(
@@ -3697,11 +3698,27 @@ export function summarizeRequiredChecks(
     // at all, and treating it as covered would report `success` while
     // GitHub's own required-check state is still pending, reproducing the
     // exact "ready but merge blocked" failure mode #2021 fixed for the
-    // direct-waiver path.
+    // direct-waiver path. Also requires the live run to be fresh relative
+    // to `treatAsCoveredByWaiverSince` when the caller supplies one
+    // (Codex review on PR #2370): a run that completed before that moment
+    // was never actually rerun under whatever condition made this check
+    // relieved, reproducing the same staleness gap #2034 already closed
+    // for the direct-waiver path.
+    const treatAsCoveredByWaiverSinceOverride =
+      typeof treatAsCoveredByWaiverSince === 'function'
+        ? treatAsCoveredByWaiverSince(name)
+        : null;
+    const treatAsCoveredByWaiverSinceMs = isValidIsoTimestamp(
+      treatAsCoveredByWaiverSinceOverride,
+    )
+      ? new Date(treatAsCoveredByWaiverSinceOverride).getTime()
+      : null;
     const treatedAsCoveredByWaiver =
       completedAtMs !== null &&
       typeof treatAsCoveredByWaiver === 'function' &&
-      treatAsCoveredByWaiver(name);
+      treatAsCoveredByWaiver(name) &&
+      (treatAsCoveredByWaiverSinceMs === null ||
+        completedAtMs >= treatAsCoveredByWaiverSinceMs);
     const coveredByWaiver =
       !CHECK_PASS_EQUIVALENT_STATES.has(state) &&
       (treatedAsCoveredByWaiver ||
@@ -5421,6 +5438,15 @@ export function buildPreMergeReadinessSummary(
     treatAsCoveredByWaiver: (name) =>
       name === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
       advisoryConvergenceOutageRelieved,
+    // #2353 (Codex review on PR #2370): the declaration's own `startedAt`
+    // -- a required check's live run must have completed at or after this
+    // moment, or a stale pre-declaration failed run would be reported
+    // covered without ever having actually rerun under the outage window.
+    treatAsCoveredByWaiverSince: (name) =>
+      name === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
+      options.advisoryConvergenceOutageRelievedSince
+        ? options.advisoryConvergenceOutageRelievedSince
+        : null,
   });
   // #1570: reuse the SAME raw waiver evidence above (already validated for
   // selector/HEAD/claim/authority/expiry) to decide whether the caller-

--- a/scripts/provider-outage-declaration.mjs
+++ b/scripts/provider-outage-declaration.mjs
@@ -81,6 +81,7 @@ export function resolveProviderOutageDeclaration(input) {
     expired: [],
     exceedsMaxValidity: [],
     notYetStarted: [],
+    notYetPosted: [],
     wrongService: [],
     unauthorized: [],
     malformed: [],
@@ -109,6 +110,7 @@ export function resolveProviderOutageDeclaration(input) {
   const expired = [];
   const exceedsMaxValidity = [];
   const notYetStarted = [];
+  const notYetPosted = [];
   const wrongService = [];
   const unauthorized = [];
   const malformed = [];
@@ -163,6 +165,23 @@ export function resolveProviderOutageDeclaration(input) {
       notYetStarted.push(parsed);
       continue;
     }
+    // #2353 (Codex review on PR #2370, round 5): `startedAt` is the
+    // declaration's own self-reported field, authored at `--declare` time
+    // -- BEFORE the `--apply` confirmation that actually posts the GitHub
+    // comment `parsed.createdAt` records. A caller replaying a past `now`
+    // (e.g. `--now`) could see `nowMs >= startedMs` even though, at that
+    // replayed moment, the comment recording the declaration did not yet
+    // exist on GitHub -- a live-time caller can never hit this, since
+    // `createdAt` is necessarily in the past by the time the comment is
+    // fetched at all. Skips the check when `createdAt` is the
+    // schema-documented `'none'` sentinel (unparseable), matching
+    // `resolveDeclarationActiveSince`'s (pre-merge-readiness.mts) same
+    // fallback-to-`startedAt`-alone convention.
+    const createdAtMs = Date.parse(parsed.createdAt);
+    if (Number.isFinite(createdAtMs) && nowMs < createdAtMs) {
+      notYetPosted.push(parsed);
+      continue;
+    }
     valid.push(parsed);
   }
   const declaration = latestByCreatedAt(valid);
@@ -175,6 +194,7 @@ export function resolveProviderOutageDeclaration(input) {
       expired,
       exceedsMaxValidity,
       notYetStarted,
+      notYetPosted,
       wrongService,
       unauthorized,
       malformed,
@@ -189,6 +209,9 @@ export function resolveProviderOutageDeclaration(input) {
   } else if (notYetStarted.length > 0) {
     const latest = latestByCreatedAt(notYetStarted);
     reason = `declaration has not started yet (starts at ${latest?.startedAt})`;
+  } else if (notYetPosted.length > 0) {
+    const latest = latestByCreatedAt(notYetPosted);
+    reason = `declaration comment was not yet posted as of the evaluated moment (posted at ${latest?.createdAt})`;
   } else if (exceedsMaxValidity.length > 0) {
     reason = `declaration expiry exceeds configured providerOutage.maxValidity`;
   } else if (unauthorized.length > 0) {
@@ -208,6 +231,7 @@ export function resolveProviderOutageDeclaration(input) {
     expired,
     exceedsMaxValidity,
     notYetStarted,
+    notYetPosted,
     wrongService,
     unauthorized,
     malformed,

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -114,6 +114,11 @@ import { parseCanonicalIntegerOrNull, parseCliArgs } from './cli-args.mts';
 import type { CollaboratorPermissionCache } from './collaborator-permission.mts';
 import { isAuthorizedForcedHandoffActor } from './collaborator-permission.mts';
 import {
+  type AuthorityEvidence,
+  normalizeAuthorityEvidence,
+  resolveCollaboratorAuthority,
+} from './external-check-waiver.mts';
+import {
   GH_TEXT_LOOP_OPTIONS,
   type GhTextOptions,
   ghApiJson,
@@ -141,6 +146,10 @@ import {
   summarizeDispositionEvidenceForGate,
   summarizeExternalCheckWaivers,
 } from './protocol-helpers.mts';
+import {
+  evaluateProviderOutageRelief,
+  resolveProviderOutageDeclaration,
+} from './provider-outage-declaration.mts';
 // #1806: the latest-review Clause 1 evidence (types + pure evaluator + the
 // GraphQL fetch behind it) moved to `review-clause.mts` so
 // `rerun-advisory-convergence.mts` can reuse the SAME evidence this gate
@@ -326,6 +335,12 @@ export interface AdvisoryConvergenceWaiver {
   checkSelector: string;
   activeClaimId: string;
   validCount: number;
+  /** #2353: whether a repository-scoped `providerOutage.declarationTarget`
+   * declaration relieves this gate's own selector -- independent of
+   * `validCount`, which stays direct-per-pull-request-waiver-marker-only
+   * (the schema-locked, truthfully-reported count #2021 already
+   * established). See {@link evaluateProviderOutageRelief}. */
+  outageRelieved: boolean;
 }
 
 /** Scope gate evidence for the advisory-convergence verdict.
@@ -564,6 +579,16 @@ export interface AdvisoryConvergenceOptions {
   waiverMode?: string;
   waiverMaxValidity?: string;
   waiverCheckSelector?: string;
+  /** #2353: whether an active `providerOutage.declarationTarget`
+   * declaration exists for THIS gate's own selector, already resolved by
+   * the caller (fetch, validity, actor authority -- see
+   * `resolveProviderOutageDeclaration`). Purely additive and never itself
+   * sufficient: the waiver escape-hatch computation below still requires
+   * this PR's own `terminalUnavailable` state (never the deadline-only
+   * opener) and a `waivableSelectors` match, mirroring the direct
+   * per-pull-request waiver's own requirements exactly. Omitted/false (the
+   * default) never relieves anything, unchanged pre-#2353 behavior. */
+  outageDeclarationActive?: boolean;
   /** Bounded same-HEAD advisory reroll cap (#1511), `advisoryWait.same-
    * HeadRerollCap`. Defaults to {@link DEFAULT_ADVISORY_SAME_HEAD_REROLL_CAP}
    * when omitted or non-finite. */
@@ -1312,6 +1337,13 @@ export function computeAdvisoryConvergenceVerdict(
     String(options.waiverCheckSelector ?? '').trim() ||
     ADVISORY_CONVERGENCE_CHECK_SELECTOR;
   let validWaiverCount = 0;
+  // #2353: default when the enclosing precondition never opens -- no
+  // declaration relief can apply before the SAME precondition the direct
+  // waiver above requires has opened.
+  let outageRelief = {
+    relieved: false,
+    reason: 'waiver precondition not open',
+  };
   if (
     !converged &&
     (deadlinePassed || terminalUnavailable) &&
@@ -1346,24 +1378,42 @@ export function computeAdvisoryConvergenceVerdict(
     validWaiverCount = waiverEvidence.valid.filter(
       (entry) => entry.checkSelector === waiverCheckSelector,
     ).length;
+
+    // #2353: a repository-scoped `providerOutage.declarationTarget`
+    // declaration substitutes for a per-pull-request waiver marker on THIS
+    // selector, gated by the SAME enclosing precondition as the direct
+    // waiver above, plus `evaluateProviderOutageRelief`'s own additional
+    // requirement that THIS pull request's own terminal-unavailable state
+    // independently holds -- never the deadline-only opener, even though
+    // the deadline path can also reach this branch. A declaration active
+    // only under a passed deadline (no proven terminal state) therefore
+    // still yields `relieved: false` here, by that function's own contract.
+    outageRelief = evaluateProviderOutageRelief({
+      declarationActive: options.outageDeclarationActive === true,
+      prTerminalUnavailable: terminalUnavailable,
+      requestedSelector: waiverCheckSelector,
+      waivableSelectors: [...(options.waivableSelectors ?? [])],
+    });
   }
   const waiver: AdvisoryConvergenceWaiver = {
     mode: waiverMode,
     checkSelector: waiverCheckSelector,
     activeClaimId,
     validCount: validWaiverCount,
+    outageRelieved: outageRelief.relieved,
   };
-  const waived = !scopeNotApplicable && validWaiverCount > 0;
+  const waived =
+    !scopeNotApplicable && (validWaiverCount > 0 || outageRelief.relieved);
   if (!scopeNotApplicable && !converged && terminalUnavailable && !waived) {
     reasons.push(
       waiverMode === 'maintainer-authorized'
-        ? `Copilot is terminally unavailable (recovery cap exhausted and terminal window elapsed with no current-HEAD review) with no valid maintainer external-check waiver for selector "${waiverCheckSelector}" on current HEAD`
+        ? `Copilot is terminally unavailable (recovery cap exhausted and terminal window elapsed with no current-HEAD review) with no valid maintainer external-check waiver and no active provider-outage declaration relief for selector "${waiverCheckSelector}" on current HEAD`
         : `Copilot is terminally unavailable (recovery cap exhausted and terminal window elapsed with no current-HEAD review) and no waiver is available (ciGate.externalCheckWaivers.mode is "${waiverMode}", not "maintainer-authorized")`,
     );
   } else if (!scopeNotApplicable && !converged && deadlinePassed && !waived) {
     reasons.push(
       waiverMode === 'maintainer-authorized'
-        ? `deadline (${deadlineMinutes}m) passed with no valid maintainer external-check waiver for selector "${waiverCheckSelector}" on current HEAD`
+        ? `deadline (${deadlineMinutes}m) passed with no valid maintainer external-check waiver for selector "${waiverCheckSelector}" on current HEAD (a provider-outage declaration cannot relieve the deadline-only path -- it requires this pull request's own proven terminal-unavailable state)`
         : `deadline (${deadlineMinutes}m) passed and no waiver is available (ciGate.externalCheckWaivers.mode is "${waiverMode}", not "maintainer-authorized")`,
     );
   }
@@ -2219,6 +2269,41 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
   // that source of truth on drift.
   const policy = normalizePolicyConfig(rawConfig);
 
+  // #2353: resolve whether a repository-scoped `providerOutage.
+  // declarationTarget` declaration is active for THIS gate's own selector
+  // (`idd-advisory-convergence` -- see idd-advisory-wait.instructions.md's
+  // "Sustained outage" note). Fails closed to inactive on ANY error (unset
+  // target, unreadable/unparseable comments, authority-lookup failure),
+  // matching `prFirstCommitAt` below: a transient fetch failure must never
+  // widen what this gate accepts.
+  let outageDeclarationActive = false;
+  const outageDeclarationTargetIssue =
+    policy?.providerOutage?.declarationTarget;
+  if (outageDeclarationTargetIssue) {
+    try {
+      const declarationComments = ghApiJson(
+        `repos/${owner}/${repo}/issues/${outageDeclarationTargetIssue}/comments`,
+        { paginate: true },
+      ) as IssueCommentPayload[];
+      const authorityOf = (actorLogin: string): AuthorityEvidence =>
+        normalizeAuthorityEvidence(
+          resolveCollaboratorAuthority({ owner, repo, actor: actorLogin }),
+          actorLogin,
+          owner,
+          policy.ciGate.externalCheckWaivers.authorityPolicy,
+        );
+      outageDeclarationActive = resolveProviderOutageDeclaration({
+        declarationTargetConfigured: true,
+        comments: declarationComments,
+        service: ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+        policy,
+        authorityOf,
+      }).active;
+    } catch {
+      outageDeclarationActive = false;
+    }
+  }
+
   // #1344: forced-handoff-aware claim resolution, matching
   // `pre-merge-readiness.mts` exactly, except reading `forcedHandoff.mode`/
   // `authorityPolicy` off the already-loaded/normalized `policy` above
@@ -2319,6 +2404,7 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
       ),
       waiverCheckSelector: ADVISORY_CONVERGENCE_CHECK_SELECTOR,
       waivableSelectors: policy?.ciGate?.externalChecks?.waivable ?? [],
+      outageDeclarationActive,
       sameHeadRerollCap,
       pendingWindowMinutes,
       recoveryCycleCap,

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -2269,6 +2269,16 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
   // that source of truth on drift.
   const policy = normalizePolicyConfig(rawConfig);
 
+  // Resolved once and reused below AND in the returned `options.now` --
+  // #2353 (Codex review on PR #2370): the declaration-validity read must
+  // evaluate at the SAME instant the rest of this verdict does (deadline,
+  // waiver expiry, terminal evidence), or a `--now`-overridden invocation
+  // (deterministic replay, tests) would resolve `outageDeclarationActive`
+  // against the real wall clock instead, an inconsistency within the same
+  // verdict.
+  const resolvedNow =
+    args.now || new Date().toISOString().replace('.000Z', 'Z');
+
   // #2353: resolve whether a repository-scoped `providerOutage.
   // declarationTarget` declaration is active for THIS gate's own selector
   // (`idd-advisory-convergence` -- see idd-advisory-wait.instructions.md's
@@ -2298,6 +2308,7 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
         service: ADVISORY_CONVERGENCE_CHECK_SELECTOR,
         policy,
         authorityOf,
+        now: new Date(resolvedNow),
       }).active;
     } catch {
       outageDeclarationActive = false;
@@ -2385,7 +2396,7 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
       prAuthorIsBot,
     },
     options: {
-      now: args.now || new Date().toISOString().replace('.000Z', 'Z'),
+      now: resolvedNow,
       primaryBotLogin,
       trustedMarkerLogins,
       advisoryBotLogins,

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -1614,6 +1614,29 @@ function readExternalCheckWaiverMode(): string {
   }
 }
 
+// #2353 (Codex review on PR #2370, second follow-up): a declaration's own
+// `startedAt` is generated before the `--declare --apply` interactive
+// confirmation prompt, while the GitHub comment's `createdAt` is stamped
+// only once the maintainer actually confirms posting it. A failed check
+// that completes during that pause satisfies a `startedAt`-only cutoff
+// even though the declaration did not verifiably exist on GitHub yet and
+// the check never reran under it. Use the LATER of the two timestamps as
+// the true "this declaration became a real, postable fact" moment.
+// `createdAt` may be the literal string `"none"` (schema-documented) or
+// otherwise unparseable; in that case this falls back to `startedAt`
+// alone, unchanged from before this fix -- never widening the cutoff.
+export function resolveDeclarationActiveSince(
+  declaration: { startedAt?: unknown; createdAt?: unknown } | null,
+): string {
+  const startedAtMs = Date.parse(String(declaration?.startedAt ?? ''));
+  const createdAtMs = Date.parse(String(declaration?.createdAt ?? ''));
+  const candidates = [startedAtMs, createdAtMs].filter((ms) =>
+    Number.isFinite(ms),
+  );
+  if (candidates.length === 0) return '';
+  return new Date(Math.max(...candidates)).toISOString();
+}
+
 // #2353: resolve whether a repository-scoped `providerOutage.
 // declarationTarget` declaration relieves the `idd-advisory-convergence`
 // selector for this pull request -- the SAME selector
@@ -1697,7 +1720,9 @@ function resolveAdvisoryConvergenceOutageRelief({
     }).relieved;
     return {
       relieved,
-      since: relieved ? String(declaration.declaration?.startedAt ?? '') : '',
+      since: relieved
+        ? resolveDeclarationActiveSince(declaration.declaration)
+        : '',
     };
   } catch {
     return notRelieved;

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -105,6 +105,10 @@ interface CheckPayload {
   name?: string | null;
   state?: string | null;
   completedAt?: string | null;
+  // #2353 (Codex review on PR #2370): see `CheckLike` in
+  // `protocol-helpers.mts` for why this is threaded through separately
+  // from `completedAt`.
+  startedAt?: string | null;
   type?: string | null;
   workflowName?: string | null;
 }
@@ -127,6 +131,7 @@ interface StatusCheckRollupPayload {
   status?: string | null;
   conclusion?: string | null;
   completedAt?: string | null;
+  startedAt?: string | null;
   workflowName?: string | null;
 }
 
@@ -195,6 +200,10 @@ export function normalizeStatusCheckRollupEntry(
       name: String(entry?.context ?? '').trim(),
       state: STATUS_CONTEXT_STATE_ALIASES[rawState] ?? rawState,
       completedAt: String(entry?.completedAt ?? ZERO_SENTINEL_TIMESTAMP),
+      // A legacy commit status has no separate start/complete lifecycle --
+      // it is reported as a single instant -- so `startedAt` reuses the
+      // same `completedAt` value rather than exposing a fabricated one.
+      startedAt: String(entry?.completedAt ?? ZERO_SENTINEL_TIMESTAMP),
       type: 'status-context',
       workflowName: '',
     };
@@ -210,6 +219,7 @@ export function normalizeStatusCheckRollupEntry(
     state:
       status === 'COMPLETED' ? conclusion || 'UNKNOWN' : status || 'UNKNOWN',
     completedAt: String(entry?.completedAt ?? ZERO_SENTINEL_TIMESTAMP),
+    startedAt: String(entry?.startedAt ?? ZERO_SENTINEL_TIMESTAMP),
     type: 'check-run',
     workflowName: String(entry?.workflowName ?? '').trim(),
   };

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -1624,7 +1624,14 @@ function readExternalCheckWaiverMode(): string {
 // evidence `evaluateProviderOutageRelief` requires independently of the
 // declaration itself (never itself sufficient) -- the same terminal-
 // unavailability verdict this file's own `copilot-terminal-unavailable`
-// blocker already consumes.
+// blocker already consumes. Requires `ciGate.externalCheckWaivers.mode`
+// to be `maintainer-authorized` (Codex review on PR #2370): without this,
+// an adopter that leaves `mode` at its `disabled` default but configures
+// the waivable selector and posts a declaration would relieve here while
+// `computeAdvisoryConvergenceVerdict`'s own gate -- gated on the SAME
+// `waiverMode === 'maintainer-authorized'` check -- still rejects it,
+// exactly the two-gate disagreement #2021 already fixed for the direct
+// per-pull-request waiver path.
 function resolveAdvisoryConvergenceOutageRelief({
   owner,
   repo,
@@ -1642,6 +1649,9 @@ function resolveAdvisoryConvergenceOutageRelief({
     const policy = normalizePolicyConfig(
       JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
     );
+    if (policy.ciGate.externalCheckWaivers.mode !== 'maintainer-authorized') {
+      return false;
+    }
     const targetIssue = policy.providerOutage.declarationTarget;
     if (!targetIssue) return false;
     const declarationComments = ghApiJson(

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -8,6 +8,7 @@
 import { readFileSync } from 'node:fs';
 
 import {
+  DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
   readAdvisoryConvergenceDeadlineMinutes,
   readAdvisoryPrimaryBotLogin,
   readAdvisoryRecoveryCycleCap,
@@ -23,6 +24,11 @@ import {
   readForcedHandoffAuthorityPolicy,
   readForcedHandoffMode,
 } from './collaborator-permission.mts';
+import {
+  type AuthorityEvidence,
+  normalizeAuthorityEvidence,
+  resolveCollaboratorAuthority,
+} from './external-check-waiver.mts';
 import {
   DEFAULT_GH_PAGINATED_TIMEOUT_MS,
   GH_TEXT_LOOP_OPTIONS,
@@ -54,6 +60,10 @@ import {
   resolveTrustedMarkerActors,
   selectCodeownersText,
 } from './protocol-helpers.mts';
+import {
+  evaluateProviderOutageRelief,
+  resolveProviderOutageDeclaration,
+} from './provider-outage-declaration.mts';
 import {
   fetchReviewsAndHeadCommit,
   resolveLatestCopilotReviewClause,
@@ -687,6 +697,14 @@ export function collectPreMergeReadiness(
     },
   );
   const copilotUnavailable = copilotRecovery.state === 'COPILOT_UNAVAILABLE';
+  const advisoryConvergenceOutageRelieved =
+    resolveAdvisoryConvergenceOutageRelief({
+      owner,
+      repo,
+      copilotUnavailable,
+      waivableCheckSelectors,
+      now,
+    });
 
   const summary = buildPreMergeReadinessSummary(
     {
@@ -739,6 +757,7 @@ export function collectPreMergeReadiness(
       capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
       primaryBotLogin,
       copilotUnavailable,
+      advisoryConvergenceOutageRelieved,
       advisoryConvergenceHeadCommittedAt,
       advisoryConvergenceDeadlineMinutes,
       secondaryQuietWindowMinutes,
@@ -1589,6 +1608,75 @@ function readExternalCheckWaiverMode(): string {
     ).ciGate.externalCheckWaivers.mode;
   } catch {
     return 'disabled';
+  }
+}
+
+// #2353: resolve whether a repository-scoped `providerOutage.
+// declarationTarget` declaration relieves the `idd-advisory-convergence`
+// selector for this pull request -- the SAME selector
+// `advisory-convergence.mts`'s own gate relieves via its own,
+// independently-fetched declaration (see that file's `collectFromGitHub`).
+// Fails closed to `false` on ANY error (unset target, unreadable/
+// unparseable declaration-target comments, authority-lookup failure) --
+// a transient fetch failure must never widen what this gate accepts,
+// matching `prFirstCommitAt`'s own fail-closed contract above.
+// `copilotUnavailable` is the caller-supplied `prTerminalUnavailable`
+// evidence `evaluateProviderOutageRelief` requires independently of the
+// declaration itself (never itself sufficient) -- the same terminal-
+// unavailability verdict this file's own `copilot-terminal-unavailable`
+// blocker already consumes.
+function resolveAdvisoryConvergenceOutageRelief({
+  owner,
+  repo,
+  copilotUnavailable,
+  waivableCheckSelectors,
+  now,
+}: {
+  owner: string;
+  repo: string;
+  copilotUnavailable: boolean;
+  waivableCheckSelectors: { selector?: unknown; matchMode?: unknown }[];
+  now: string;
+}): boolean {
+  try {
+    const policy = normalizePolicyConfig(
+      JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
+    );
+    const targetIssue = policy.providerOutage.declarationTarget;
+    if (!targetIssue) return false;
+    const declarationComments = ghApiJson(
+      `repos/${owner}/${repo}/issues/${targetIssue}/comments`,
+      true,
+    ) as IssueCommentPayload[];
+    const authorityOf = (actorLogin: string): AuthorityEvidence =>
+      normalizeAuthorityEvidence(
+        resolveCollaboratorAuthority({ owner, repo, actor: actorLogin }),
+        actorLogin,
+        owner,
+        policy.ciGate.externalCheckWaivers.authorityPolicy,
+      );
+    const declaration = resolveProviderOutageDeclaration({
+      declarationTargetConfigured: true,
+      comments: declarationComments,
+      service: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      policy,
+      authorityOf,
+      now: new Date(now),
+    });
+    return evaluateProviderOutageRelief({
+      declarationActive: declaration.active,
+      prTerminalUnavailable: copilotUnavailable,
+      requestedSelector: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
+      waivableSelectors: waivableCheckSelectors
+        .map((entry) => ({
+          selector: String(entry.selector ?? ''),
+          matchMode:
+            typeof entry.matchMode === 'string' ? entry.matchMode : undefined,
+        }))
+        .filter((entry) => entry.selector.length > 0),
+    }).relieved;
+  } catch {
+    return false;
   }
 }
 

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -1668,11 +1668,13 @@ export function resolveDeclarationActiveSince(
 // `waiverMode === 'maintainer-authorized'` check -- still rejects it,
 // exactly the two-gate disagreement #2021 already fixed for the direct
 // per-pull-request waiver path. `since` is the declaration's own
-// `startedAt` (Codex review on PR #2370): a required check's live run
-// must have completed AT OR AFTER this moment to count as covered --
-// otherwise the check was never actually rerun during the declared
-// outage window, and GitHub's own required-check state stays whatever a
-// stale pre-declaration run left it at while this gate reports covered,
+// active-since moment (Codex review on PR #2370): a required check's live
+// run must have STARTED (Copilot review, round 5: not "completed" --
+// `summarizeRequiredChecks`'s `treatAsCoveredByWaiver` cutoff anchors on
+// `startedAt`) AT OR AFTER this moment to count as covered -- otherwise
+// the check was never actually rerun during the declared outage window,
+// and GitHub's own required-check state stays whatever a stale
+// pre-declaration run left it at while this gate reports covered,
 // reproducing #2021's "ready but merge blocked" class one layer deeper.
 function resolveAdvisoryConvergenceOutageRelief({
   owner,

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -697,7 +697,7 @@ export function collectPreMergeReadiness(
     },
   );
   const copilotUnavailable = copilotRecovery.state === 'COPILOT_UNAVAILABLE';
-  const advisoryConvergenceOutageRelieved =
+  const advisoryConvergenceOutageRelief =
     resolveAdvisoryConvergenceOutageRelief({
       owner,
       repo,
@@ -757,7 +757,10 @@ export function collectPreMergeReadiness(
       capExhaustedRoute: advisoryWaitPolicy.capExhaustedRoute,
       primaryBotLogin,
       copilotUnavailable,
-      advisoryConvergenceOutageRelieved,
+      advisoryConvergenceOutageRelieved:
+        advisoryConvergenceOutageRelief.relieved,
+      advisoryConvergenceOutageRelievedSince:
+        advisoryConvergenceOutageRelief.since,
       advisoryConvergenceHeadCommittedAt,
       advisoryConvergenceDeadlineMinutes,
       secondaryQuietWindowMinutes,
@@ -1616,11 +1619,11 @@ function readExternalCheckWaiverMode(): string {
 // selector for this pull request -- the SAME selector
 // `advisory-convergence.mts`'s own gate relieves via its own,
 // independently-fetched declaration (see that file's `collectFromGitHub`).
-// Fails closed to `false` on ANY error (unset target, unreadable/
-// unparseable declaration-target comments, authority-lookup failure) --
-// a transient fetch failure must never widen what this gate accepts,
-// matching `prFirstCommitAt`'s own fail-closed contract above.
-// `copilotUnavailable` is the caller-supplied `prTerminalUnavailable`
+// Fails closed to `{ relieved: false, since: '' }` on ANY error (unset
+// target, unreadable/unparseable declaration-target comments, authority-
+// lookup failure) -- a transient fetch failure must never widen what this
+// gate accepts, matching `prFirstCommitAt`'s own fail-closed contract
+// above. `copilotUnavailable` is the caller-supplied `prTerminalUnavailable`
 // evidence `evaluateProviderOutageRelief` requires independently of the
 // declaration itself (never itself sufficient) -- the same terminal-
 // unavailability verdict this file's own `copilot-terminal-unavailable`
@@ -1631,7 +1634,13 @@ function readExternalCheckWaiverMode(): string {
 // `computeAdvisoryConvergenceVerdict`'s own gate -- gated on the SAME
 // `waiverMode === 'maintainer-authorized'` check -- still rejects it,
 // exactly the two-gate disagreement #2021 already fixed for the direct
-// per-pull-request waiver path.
+// per-pull-request waiver path. `since` is the declaration's own
+// `startedAt` (Codex review on PR #2370): a required check's live run
+// must have completed AT OR AFTER this moment to count as covered --
+// otherwise the check was never actually rerun during the declared
+// outage window, and GitHub's own required-check state stays whatever a
+// stale pre-declaration run left it at while this gate reports covered,
+// reproducing #2021's "ready but merge blocked" class one layer deeper.
 function resolveAdvisoryConvergenceOutageRelief({
   owner,
   repo,
@@ -1644,16 +1653,17 @@ function resolveAdvisoryConvergenceOutageRelief({
   copilotUnavailable: boolean;
   waivableCheckSelectors: { selector?: unknown; matchMode?: unknown }[];
   now: string;
-}): boolean {
+}): { relieved: boolean; since: string } {
+  const notRelieved = { relieved: false, since: '' };
   try {
     const policy = normalizePolicyConfig(
       JSON.parse(readFileSync('.github/idd/config.json', 'utf8')),
     );
     if (policy.ciGate.externalCheckWaivers.mode !== 'maintainer-authorized') {
-      return false;
+      return notRelieved;
     }
     const targetIssue = policy.providerOutage.declarationTarget;
-    if (!targetIssue) return false;
+    if (!targetIssue) return notRelieved;
     const declarationComments = ghApiJson(
       `repos/${owner}/${repo}/issues/${targetIssue}/comments`,
       true,
@@ -1673,7 +1683,7 @@ function resolveAdvisoryConvergenceOutageRelief({
       authorityOf,
       now: new Date(now),
     });
-    return evaluateProviderOutageRelief({
+    const relieved = evaluateProviderOutageRelief({
       declarationActive: declaration.active,
       prTerminalUnavailable: copilotUnavailable,
       requestedSelector: DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
@@ -1685,8 +1695,12 @@ function resolveAdvisoryConvergenceOutageRelief({
         }))
         .filter((entry) => entry.selector.length > 0),
     }).relieved;
+    return {
+      relieved,
+      since: relieved ? String(declaration.declaration?.startedAt ?? '') : '',
+    };
   } catch {
-    return false;
+    return notRelieved;
   }
 }
 

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4650,6 +4650,7 @@ export function summarizeRequiredChecks(
     trustSourcePinnedRequiredChecks = false,
     excludeFromWaiverCoverage = null,
     waiverActiveSinceOverride = null,
+    treatAsCoveredByWaiver = null,
   }: {
     waivers?: {
       valid?: { checkSelector?: unknown; createdAt?: unknown }[] | null;
@@ -4710,6 +4711,26 @@ export function summarizeRequiredChecks(
     // `noRequiredChecksConfigured`'s own `!sourcePinned` guard, since there
     // is no check name to correlate with a live run at all in that case.
     trustSourcePinnedRequiredChecks?: boolean;
+    // #2353: surgical per-CHECK-NAME positive override treating a check as
+    // covered-by-waiver through a mechanism OTHER than a matched
+    // `waivers.valid` entry -- a repository-scoped provider-outage
+    // declaration, which has no per-check waiver-marker `createdAt` to
+    // compare against a live run's `completedAt` and no `waivableSelectors`
+    // re-check to perform here (the caller, `evaluateProviderOutageRelief`,
+    // already independently required both the PR's own proven
+    // terminal-unavailable state and a `ciGate.externalChecks.waivable`
+    // match before ever returning `true`). Deliberately bypasses
+    // `excludeFromWaiverCoverage` too: that callback's own purpose is to
+    // withhold coverage a matched `waivers.valid` entry would otherwise
+    // grant when its OWN precondition/selector-exactness/freshness
+    // requirements are unmet -- a declaration-relief case never reaches
+    // `excludeFromWaiverCoverage`'s reasoning at all, so vetoing it there
+    // too would just reproduce this same relief gap one layer down. Still
+    // subject to the pass-equivalent-state check below like every other
+    // coverage path -- an already-passing check needs no coverage from
+    // either mechanism. `null`/omitted (the default) never covers anything,
+    // unchanged pre-#2353 behavior for every caller that doesn't pass it.
+    treatAsCoveredByWaiver?: ((checkName: string) => boolean) | null;
   } = {},
 ) {
   const branchReviewRequirements = summarizeBranchReviewRequirements(
@@ -4757,18 +4778,26 @@ export function summarizeRequiredChecks(
             : waiverCreatedAtMs;
         return completedAtMs >= activeSinceMs;
       });
+    // #2353: an independent positive path -- see `treatAsCoveredByWaiver`'s
+    // own doc comment for why it deliberately bypasses
+    // `excludeFromWaiverCoverage`/`hasFreshWaiverCoverage`/`waivableSelectors`
+    // below rather than feeding into the same conjunction.
+    const treatedAsCoveredByWaiver =
+      typeof treatAsCoveredByWaiver === 'function' &&
+      treatAsCoveredByWaiver(name);
     const coveredByWaiver =
       !CHECK_PASS_EQUIVALENT_STATES.has(state) &&
-      !(
-        typeof excludeFromWaiverCoverage === 'function' &&
-        excludeFromWaiverCoverage(name)
-      ) &&
-      hasFreshWaiverCoverage &&
-      // The check must also sit on the policy's waivable surface. A
-      // null/undefined list keeps the legacy behavior with no gate; an empty
-      // configured list covers nothing.
-      (!Array.isArray(waivableSelectors) ||
-        isCheckNameConfiguredWaivable(name, waivableSelectors));
+      (treatedAsCoveredByWaiver ||
+        (!(
+          typeof excludeFromWaiverCoverage === 'function' &&
+          excludeFromWaiverCoverage(name)
+        ) &&
+          hasFreshWaiverCoverage &&
+          // The check must also sit on the policy's waivable surface. A
+          // null/undefined list keeps the legacy behavior with no gate; an
+          // empty configured list covers nothing.
+          (!Array.isArray(waivableSelectors) ||
+            isCheckNameConfiguredWaivable(name, waivableSelectors))));
     return {
       name,
       state,
@@ -6075,7 +6104,7 @@ export function computePreMergeReadinessBlockers(
     blockers.push({
       gate: 'copilot-terminal-unavailable',
       detail:
-        'Copilot is terminally unavailable on current HEAD (recovery cap exhausted and terminal window elapsed with no current-HEAD review) with no valid maintainer external-check waiver for selector ' +
+        'Copilot is terminally unavailable on current HEAD (recovery cap exhausted and terminal window elapsed with no current-HEAD review) with no valid maintainer external-check waiver and no active provider-outage declaration relief for selector ' +
         `"${DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR}"`,
     });
   }
@@ -6523,6 +6552,15 @@ export function buildPreMergeReadinessSummary(
     // unavailable` blocker below, so an unmigrated caller sees unchanged
     // behavior.
     copilotUnavailable?: boolean;
+    // #2353: the caller-precomputed provider-outage-declaration relief
+    // verdict for the `idd-advisory-convergence` selector (fetch,
+    // `resolveProviderOutageDeclaration`, `evaluateProviderOutageRelief`,
+    // ALL already gated on `copilotUnavailable` above as the PR's own
+    // proven terminal-unavailable state). Computed by the CALLER, not
+    // here: `provider-outage-declaration.mts` already imports FROM this
+    // file, so importing it back here would be a cycle. Omitted/false (the
+    // default) never relieves anything, unchanged pre-#2353 behavior.
+    advisoryConvergenceOutageRelieved?: boolean;
     // #2021: the current HEAD commit's own `committedDate` (GraphQL),
     // anchoring the SAME 24h deadline clock `advisory-convergence.mts`'s own
     // gate uses before treating a posted `idd-advisory-convergence` waiver as
@@ -6826,6 +6864,18 @@ export function buildPreMergeReadinessSummary(
   const advisoryConvergenceGenuinelyCovered =
     advisoryConvergencePreconditionOpen && advisoryConvergenceExactWaiverValid;
 
+  // #2353: the caller-precomputed provider-outage-declaration relief
+  // verdict, re-ANDed here with the SAME precondition-open evidence the
+  // direct-waiver path above requires -- cheap insurance against a future
+  // caller passing a relief verdict that was somehow computed without the
+  // precondition it logically implies (evaluateProviderOutageRelief's own
+  // `prTerminalUnavailable` requirement already implies `terminalUnavailable`,
+  // which already implies `advisoryConvergencePreconditionOpen` via the OR,
+  // so this is redundant today, not a new gate).
+  const advisoryConvergenceOutageRelieved =
+    advisoryConvergencePreconditionOpen &&
+    options.advisoryConvergenceOutageRelieved === true;
+
   const ci = summarizeRequiredChecks(checks, branchRules, branchProtection, {
     // Raw, UNFILTERED `waiverEvidence` -- deliberately not a caller-side
     // pre-filtered copy. A pre-filter that removed a whole `valid` entry
@@ -6852,6 +6902,13 @@ export function buildPreMergeReadinessSummary(
       advisoryConvergenceDeadlineOpensAt
         ? advisoryConvergenceDeadlineOpensAt
         : null,
+    // #2353: a repository-scoped provider-outage declaration relieves
+    // `idd-advisory-convergence` specifically, through a positive path
+    // that bypasses `excludeFromWaiverCoverage` above entirely -- see
+    // `treatAsCoveredByWaiver`'s own doc comment for why.
+    treatAsCoveredByWaiver: (name) =>
+      name === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
+      advisoryConvergenceOutageRelieved,
   });
 
   // #1570: reuse the SAME raw waiver evidence above (already validated for
@@ -6868,10 +6925,13 @@ export function buildPreMergeReadinessSummary(
   // here.
   const copilotUnavailableWaived =
     copilotUnavailable &&
-    waiverEvidence.valid.some(
+    (waiverEvidence.valid.some(
       (entry) =>
         entry.checkSelector === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR,
-    );
+    ) ||
+      // #2353: a repository-scoped provider-outage declaration also clears
+      // this dedicated blocker, same as a direct maintainer waiver.
+      advisoryConvergenceOutageRelieved);
 
   const dispositionEvidence = options.includeDispositionEvidence
     ? summarizeDispositionEvidenceForGate(

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4771,12 +4771,28 @@ export function summarizeRequiredChecks(
     const name = String(check.name ?? '');
     const state = String(check.state ?? '').toUpperCase();
     const completedAt = String(check.completedAt ?? '');
-    const completedAtMs = isValidIsoTimestamp(completedAt)
-      ? new Date(completedAt).getTime()
+    // #2353 (Copilot + Codex + CodeRabbit review on PR #2370, round 5):
+    // `isValidIsoTimestamp` alone accepts GitHub's `0001-01-01T00:00:00Z`
+    // zero-value sentinel -- `normalizeStatusCheckRollupEntry` substitutes
+    // it for BOTH an absent `completedAt` (still QUEUED/IN_PROGRESS) and an
+    // absent `startedAt` (not yet started), the same non-nullable-DateTime
+    // convention `isCompletedCiTimestamp` already exists to reject (see its
+    // doc comment / `parseCompletedAt` above). Reusing it here -- despite
+    // its "completed" name -- because the sentinel isn't completion-
+    // specific: it is GitHub's stand-in for "this lifecycle moment hasn't
+    // happened yet," which applies equally to `startedAt`. Without this, an
+    // IN_PROGRESS run (sentinel `completedAt`, but a genuine, fresh
+    // `startedAt`) would pass BOTH `completedAtMs !== null` (the sentinel
+    // parses as a valid, merely very-old, timestamp) and the `startedAt`
+    // freshness cutoff below, reporting a still-running required check
+    // `coveredByWaiver: true` while GitHub's own check is neither passed
+    // nor even finished.
+    const completedAtMs = isCompletedCiTimestamp(completedAt)
+      ? Date.parse(completedAt)
       : null;
     const startedAt = String(check.startedAt ?? '');
-    const startedAtMs = isValidIsoTimestamp(startedAt)
-      ? new Date(startedAt).getTime()
+    const startedAtMs = isCompletedCiTimestamp(startedAt)
+      ? Date.parse(startedAt)
       : null;
     const matchingWaivers = validWaivers.filter((w) =>
       matchCheckSelectorLocal(name, w.checkSelector),

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4726,10 +4726,14 @@ export function summarizeRequiredChecks(
     // requirements are unmet -- a declaration-relief case never reaches
     // `excludeFromWaiverCoverage`'s reasoning at all, so vetoing it there
     // too would just reproduce this same relief gap one layer down. Still
-    // subject to the pass-equivalent-state check below like every other
-    // coverage path -- an already-passing check needs no coverage from
-    // either mechanism. `null`/omitted (the default) never covers anything,
-    // unchanged pre-#2353 behavior for every caller that doesn't pass it.
+    // subject to the pass-equivalent-state check AND the #2034 live-run
+    // requirement below (Copilot + Codex review on PR #2370): a check with
+    // no parseable `completedAt` -- still QUEUED/IN_PROGRESS/PENDING, never
+    // actually produced a verdict -- must never be reported covered by
+    // EITHER mechanism, or this gate would report `success` while GitHub's
+    // own required-check state is still pending. `null`/omitted (the
+    // default) never covers anything, unchanged pre-#2353 behavior for
+    // every caller that doesn't pass it.
     treatAsCoveredByWaiver?: ((checkName: string) => boolean) | null;
   } = {},
 ) {
@@ -4781,8 +4785,17 @@ export function summarizeRequiredChecks(
     // #2353: an independent positive path -- see `treatAsCoveredByWaiver`'s
     // own doc comment for why it deliberately bypasses
     // `excludeFromWaiverCoverage`/`hasFreshWaiverCoverage`/`waivableSelectors`
-    // below rather than feeding into the same conjunction.
+    // below rather than feeding into the same conjunction. Still requires
+    // `completedAtMs !== null` (Copilot + Codex review on PR #2370): the
+    // SAME #2034 fail-closed live-run requirement `hasFreshWaiverCoverage`
+    // already enforces -- a check that is still QUEUED/IN_PROGRESS/PENDING
+    // with no parseable `completedAt` has never actually produced a verdict
+    // at all, and treating it as covered would report `success` while
+    // GitHub's own required-check state is still pending, reproducing the
+    // exact "ready but merge blocked" failure mode #2021 fixed for the
+    // direct-waiver path.
     const treatedAsCoveredByWaiver =
+      completedAtMs !== null &&
       typeof treatAsCoveredByWaiver === 'function' &&
       treatAsCoveredByWaiver(name);
     const coveredByWaiver =

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4651,6 +4651,7 @@ export function summarizeRequiredChecks(
     excludeFromWaiverCoverage = null,
     waiverActiveSinceOverride = null,
     treatAsCoveredByWaiver = null,
+    treatAsCoveredByWaiverSince = null,
   }: {
     waivers?: {
       valid?: { checkSelector?: unknown; createdAt?: unknown }[] | null;
@@ -4714,27 +4715,38 @@ export function summarizeRequiredChecks(
     // #2353: surgical per-CHECK-NAME positive override treating a check as
     // covered-by-waiver through a mechanism OTHER than a matched
     // `waivers.valid` entry -- a repository-scoped provider-outage
-    // declaration, which has no per-check waiver-marker `createdAt` to
-    // compare against a live run's `completedAt` and no `waivableSelectors`
-    // re-check to perform here (the caller, `evaluateProviderOutageRelief`,
-    // already independently required both the PR's own proven
-    // terminal-unavailable state and a `ciGate.externalChecks.waivable`
-    // match before ever returning `true`). Deliberately bypasses
-    // `excludeFromWaiverCoverage` too: that callback's own purpose is to
-    // withhold coverage a matched `waivers.valid` entry would otherwise
-    // grant when its OWN precondition/selector-exactness/freshness
-    // requirements are unmet -- a declaration-relief case never reaches
-    // `excludeFromWaiverCoverage`'s reasoning at all, so vetoing it there
-    // too would just reproduce this same relief gap one layer down. Still
-    // subject to the pass-equivalent-state check AND the #2034 live-run
-    // requirement below (Copilot + Codex review on PR #2370): a check with
-    // no parseable `completedAt` -- still QUEUED/IN_PROGRESS/PENDING, never
-    // actually produced a verdict -- must never be reported covered by
-    // EITHER mechanism, or this gate would report `success` while GitHub's
-    // own required-check state is still pending. `null`/omitted (the
-    // default) never covers anything, unchanged pre-#2353 behavior for
-    // every caller that doesn't pass it.
+    // declaration. No `waivableSelectors` re-check is performed here: the
+    // caller, `evaluateProviderOutageRelief`, already independently
+    // required both the PR's own proven terminal-unavailable state and a
+    // `ciGate.externalChecks.waivable` match before ever returning `true`.
+    // Deliberately bypasses `excludeFromWaiverCoverage` too: that
+    // callback's own purpose is to withhold coverage a matched
+    // `waivers.valid` entry would otherwise grant when its OWN
+    // precondition/selector-exactness/freshness requirements are unmet --
+    // a declaration-relief case never reaches `excludeFromWaiverCoverage`'s
+    // reasoning at all, so vetoing it there too would just reproduce this
+    // same relief gap one layer down. Still subject to the
+    // pass-equivalent-state check, the #2034 live-run requirement, AND
+    // `treatAsCoveredByWaiverSince` below (Copilot + Codex review on PR
+    // #2370): a check with no parseable `completedAt` -- still QUEUED/
+    // IN_PROGRESS/PENDING, never actually produced a verdict -- must never
+    // be reported covered by EITHER mechanism, or this gate would report
+    // `success` while GitHub's own required-check state is still pending.
+    // `null`/omitted (the default) never covers anything, unchanged
+    // pre-#2353 behavior for every caller that doesn't pass it.
     treatAsCoveredByWaiver?: ((checkName: string) => boolean) | null;
+    // #2353 (Codex review on PR #2370): per-CHECK-NAME freshness cutoff
+    // paired with `treatAsCoveredByWaiver` above -- a check only counts as
+    // covered through that positive path once its live run's `completedAt`
+    // is at or after this moment, mirroring `waiverActiveSinceOverride`'s
+    // freshness role for the direct-waiver path but evaluated as a
+    // standalone cutoff (no waiver-entry `createdAt` to `Math.max` against).
+    // A stale run that completed before a declaration's own window opened
+    // was never actually rerun during the declared outage; treating it
+    // covered would diverge from GitHub's own required-check state.
+    // `null`/omitted (the default, and every caller that doesn't pass it)
+    // applies no cutoff -- unchanged pre-fix behavior.
+    treatAsCoveredByWaiverSince?: ((checkName: string) => string | null) | null;
   } = {},
 ) {
   const branchReviewRequirements = summarizeBranchReviewRequirements(
@@ -4793,11 +4805,27 @@ export function summarizeRequiredChecks(
     // at all, and treating it as covered would report `success` while
     // GitHub's own required-check state is still pending, reproducing the
     // exact "ready but merge blocked" failure mode #2021 fixed for the
-    // direct-waiver path.
+    // direct-waiver path. Also requires the live run to be fresh relative
+    // to `treatAsCoveredByWaiverSince` when the caller supplies one
+    // (Codex review on PR #2370): a run that completed before that moment
+    // was never actually rerun under whatever condition made this check
+    // relieved, reproducing the same staleness gap #2034 already closed
+    // for the direct-waiver path.
+    const treatAsCoveredByWaiverSinceOverride =
+      typeof treatAsCoveredByWaiverSince === 'function'
+        ? treatAsCoveredByWaiverSince(name)
+        : null;
+    const treatAsCoveredByWaiverSinceMs = isValidIsoTimestamp(
+      treatAsCoveredByWaiverSinceOverride,
+    )
+      ? new Date(treatAsCoveredByWaiverSinceOverride).getTime()
+      : null;
     const treatedAsCoveredByWaiver =
       completedAtMs !== null &&
       typeof treatAsCoveredByWaiver === 'function' &&
-      treatAsCoveredByWaiver(name);
+      treatAsCoveredByWaiver(name) &&
+      (treatAsCoveredByWaiverSinceMs === null ||
+        completedAtMs >= treatAsCoveredByWaiverSinceMs);
     const coveredByWaiver =
       !CHECK_PASS_EQUIVALENT_STATES.has(state) &&
       (treatedAsCoveredByWaiver ||
@@ -6574,6 +6602,17 @@ export function buildPreMergeReadinessSummary(
     // file, so importing it back here would be a cycle. Omitted/false (the
     // default) never relieves anything, unchanged pre-#2353 behavior.
     advisoryConvergenceOutageRelieved?: boolean;
+    // #2353 (Codex review on PR #2370): the caller-resolved outage
+    // declaration's own `startedAt` when `advisoryConvergenceOutageRelieved`
+    // is true, empty otherwise. A required check's live run must have
+    // completed AT OR AFTER this moment to count as covered -- a run that
+    // completed before the declaration's window opened was never actually
+    // rerun during the declared outage, and reporting it covered would
+    // diverge from what GitHub's own required-check state still shows,
+    // reproducing #2021's "ready but merge blocked" class one layer
+    // deeper. Omitted/empty applies no cutoff (unchanged pre-fix
+    // behavior for a caller that doesn't pass it).
+    advisoryConvergenceOutageRelievedSince?: string;
     // #2021: the current HEAD commit's own `committedDate` (GraphQL),
     // anchoring the SAME 24h deadline clock `advisory-convergence.mts`'s own
     // gate uses before treating a posted `idd-advisory-convergence` waiver as
@@ -6922,6 +6961,15 @@ export function buildPreMergeReadinessSummary(
     treatAsCoveredByWaiver: (name) =>
       name === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
       advisoryConvergenceOutageRelieved,
+    // #2353 (Codex review on PR #2370): the declaration's own `startedAt`
+    // -- a required check's live run must have completed at or after this
+    // moment, or a stale pre-declaration failed run would be reported
+    // covered without ever having actually rerun under the outage window.
+    treatAsCoveredByWaiverSince: (name) =>
+      name === DEFAULT_ADVISORY_CONVERGENCE_CHECK_SELECTOR &&
+      options.advisoryConvergenceOutageRelievedSince
+        ? options.advisoryConvergenceOutageRelievedSince
+        : null,
   });
 
   // #1570: reuse the SAME raw waiver evidence above (already validated for

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -126,6 +126,13 @@ interface CheckLike {
   name?: string | null;
   state?: string | null;
   completedAt?: string | null;
+  // #2353 (Codex review on PR #2370): when the live run itself began, as
+  // opposed to when it finished. `treatAsCoveredByWaiver`'s freshness
+  // cutoff anchors on this instead of `completedAt` -- a run that starts
+  // evaluating state before a provider-outage declaration is posted never
+  // observed it, even if the run doesn't finish (and post `completedAt`)
+  // until moments after the declaration lands.
+  startedAt?: string | null;
   type?: string | null;
   workflowName?: string | null;
 }
@@ -4737,15 +4744,18 @@ export function summarizeRequiredChecks(
     treatAsCoveredByWaiver?: ((checkName: string) => boolean) | null;
     // #2353 (Codex review on PR #2370): per-CHECK-NAME freshness cutoff
     // paired with `treatAsCoveredByWaiver` above -- a check only counts as
-    // covered through that positive path once its live run's `completedAt`
-    // is at or after this moment, mirroring `waiverActiveSinceOverride`'s
-    // freshness role for the direct-waiver path but evaluated as a
-    // standalone cutoff (no waiver-entry `createdAt` to `Math.max` against).
-    // A stale run that completed before a declaration's own window opened
-    // was never actually rerun during the declared outage; treating it
-    // covered would diverge from GitHub's own required-check state.
-    // `null`/omitted (the default, and every caller that doesn't pass it)
-    // applies no cutoff -- unchanged pre-fix behavior.
+    // covered through that positive path once its live run's `startedAt`
+    // (Codex review, second follow-up: NOT `completedAt` -- a run that
+    // started evaluating state before the cutoff never observed whatever
+    // made the check relieved, even if it finished afterward) is at or
+    // after this moment, mirroring `waiverActiveSinceOverride`'s freshness
+    // role for the direct-waiver path but evaluated as a standalone cutoff
+    // (no waiver-entry `createdAt` to `Math.max` against). A stale run that
+    // started before a declaration's own window opened was never actually
+    // rerun during the declared outage; treating it covered would diverge
+    // from GitHub's own required-check state. `null`/omitted (the default,
+    // and every caller that doesn't pass it) applies no cutoff -- unchanged
+    // pre-fix behavior.
     treatAsCoveredByWaiverSince?: ((checkName: string) => string | null) | null;
   } = {},
 ) {
@@ -4763,6 +4773,10 @@ export function summarizeRequiredChecks(
     const completedAt = String(check.completedAt ?? '');
     const completedAtMs = isValidIsoTimestamp(completedAt)
       ? new Date(completedAt).getTime()
+      : null;
+    const startedAt = String(check.startedAt ?? '');
+    const startedAtMs = isValidIsoTimestamp(startedAt)
+      ? new Date(startedAt).getTime()
       : null;
     const matchingWaivers = validWaivers.filter((w) =>
       matchCheckSelectorLocal(name, w.checkSelector),
@@ -4806,11 +4820,16 @@ export function summarizeRequiredChecks(
     // GitHub's own required-check state is still pending, reproducing the
     // exact "ready but merge blocked" failure mode #2021 fixed for the
     // direct-waiver path. Also requires the live run to be fresh relative
-    // to `treatAsCoveredByWaiverSince` when the caller supplies one
-    // (Codex review on PR #2370): a run that completed before that moment
-    // was never actually rerun under whatever condition made this check
-    // relieved, reproducing the same staleness gap #2034 already closed
-    // for the direct-waiver path.
+    // to `treatAsCoveredByWaiverSince` when the caller supplies one, and
+    // (Codex review on PR #2370, second follow-up) anchors that freshness
+    // check on `startedAt` rather than `completedAt`: a run that began
+    // evaluating state before the cutoff never observed whatever made this
+    // check relieved, even if it happens to finish (and post `completedAt`)
+    // moments after the cutoff passes -- the run's own verdict was already
+    // decided using stale state by then. Requires `startedAtMs !== null`
+    // for the same fail-closed reason as `completedAtMs !== null` above: a
+    // run with no parseable `startedAt` has no evidence it observed
+    // anything at all.
     const treatAsCoveredByWaiverSinceOverride =
       typeof treatAsCoveredByWaiverSince === 'function'
         ? treatAsCoveredByWaiverSince(name)
@@ -4822,10 +4841,11 @@ export function summarizeRequiredChecks(
       : null;
     const treatedAsCoveredByWaiver =
       completedAtMs !== null &&
+      startedAtMs !== null &&
       typeof treatAsCoveredByWaiver === 'function' &&
       treatAsCoveredByWaiver(name) &&
       (treatAsCoveredByWaiverSinceMs === null ||
-        completedAtMs >= treatAsCoveredByWaiverSinceMs);
+        startedAtMs >= treatAsCoveredByWaiverSinceMs);
     const coveredByWaiver =
       !CHECK_PASS_EQUIVALENT_STATES.has(state) &&
       (treatedAsCoveredByWaiver ||
@@ -6603,15 +6623,17 @@ export function buildPreMergeReadinessSummary(
     // default) never relieves anything, unchanged pre-#2353 behavior.
     advisoryConvergenceOutageRelieved?: boolean;
     // #2353 (Codex review on PR #2370): the caller-resolved outage
-    // declaration's own `startedAt` when `advisoryConvergenceOutageRelieved`
-    // is true, empty otherwise. A required check's live run must have
-    // completed AT OR AFTER this moment to count as covered -- a run that
-    // completed before the declaration's window opened was never actually
-    // rerun during the declared outage, and reporting it covered would
-    // diverge from what GitHub's own required-check state still shows,
-    // reproducing #2021's "ready but merge blocked" class one layer
-    // deeper. Omitted/empty applies no cutoff (unchanged pre-fix
-    // behavior for a caller that doesn't pass it).
+    // declaration's own active-since moment when
+    // `advisoryConvergenceOutageRelieved` is true, empty otherwise. A
+    // required check's live run must have STARTED (not merely completed --
+    // second follow-up review, round 4) AT OR AFTER this moment to count as
+    // covered -- a run that began evaluating state before the declaration's
+    // window opened never actually observed it, even if the run happens to
+    // finish afterward, and reporting it covered would diverge from what
+    // GitHub's own required-check state still shows, reproducing #2021's
+    // "ready but merge blocked" class one layer deeper. Omitted/empty
+    // applies no cutoff (unchanged pre-fix behavior for a caller that
+    // doesn't pass it).
     advisoryConvergenceOutageRelievedSince?: string;
     // #2021: the current HEAD commit's own `committedDate` (GraphQL),
     // anchoring the SAME 24h deadline clock `advisory-convergence.mts`'s own

--- a/src/scripts/provider-outage-declaration.mts
+++ b/src/scripts/provider-outage-declaration.mts
@@ -73,6 +73,13 @@ export interface ProviderOutageDeclarationResolution {
   expired: ParsedProviderOutageDeclaration[];
   exceedsMaxValidity: ParsedProviderOutageDeclaration[];
   notYetStarted: ParsedProviderOutageDeclaration[];
+  // #2353 (Codex review on PR #2370, round 5): distinct from `notYetStarted`
+  // -- a declaration whose self-reported `startedAt` has already passed but
+  // whose GitHub comment `createdAt` postdates `now`. Only reachable when a
+  // caller replays a past `now` (e.g. `--now`): in real-time operation
+  // `createdAt` is always in the past relative to a live `now`, since the
+  // comment must already exist to be fetched at all.
+  notYetPosted: ParsedProviderOutageDeclaration[];
   wrongService: ParsedProviderOutageDeclaration[];
   unauthorized: { authorLogin: string; service: string; expiresAt: string }[];
   malformed: { authorLogin: string; bodyPreview: string }[];
@@ -126,6 +133,7 @@ export function resolveProviderOutageDeclaration(input: {
     expired: [],
     exceedsMaxValidity: [],
     notYetStarted: [],
+    notYetPosted: [],
     wrongService: [],
     unauthorized: [],
     malformed: [],
@@ -157,6 +165,7 @@ export function resolveProviderOutageDeclaration(input: {
   const expired: ParsedProviderOutageDeclaration[] = [];
   const exceedsMaxValidity: ParsedProviderOutageDeclaration[] = [];
   const notYetStarted: ParsedProviderOutageDeclaration[] = [];
+  const notYetPosted: ParsedProviderOutageDeclaration[] = [];
   const wrongService: ParsedProviderOutageDeclaration[] = [];
   const unauthorized: ProviderOutageDeclarationResolution['unauthorized'] = [];
   const malformed: ProviderOutageDeclarationResolution['malformed'] = [];
@@ -216,6 +225,23 @@ export function resolveProviderOutageDeclaration(input: {
       notYetStarted.push(parsed);
       continue;
     }
+    // #2353 (Codex review on PR #2370, round 5): `startedAt` is the
+    // declaration's own self-reported field, authored at `--declare` time
+    // -- BEFORE the `--apply` confirmation that actually posts the GitHub
+    // comment `parsed.createdAt` records. A caller replaying a past `now`
+    // (e.g. `--now`) could see `nowMs >= startedMs` even though, at that
+    // replayed moment, the comment recording the declaration did not yet
+    // exist on GitHub -- a live-time caller can never hit this, since
+    // `createdAt` is necessarily in the past by the time the comment is
+    // fetched at all. Skips the check when `createdAt` is the
+    // schema-documented `'none'` sentinel (unparseable), matching
+    // `resolveDeclarationActiveSince`'s (pre-merge-readiness.mts) same
+    // fallback-to-`startedAt`-alone convention.
+    const createdAtMs = Date.parse(parsed.createdAt);
+    if (Number.isFinite(createdAtMs) && nowMs < createdAtMs) {
+      notYetPosted.push(parsed);
+      continue;
+    }
 
     valid.push(parsed);
   }
@@ -230,6 +256,7 @@ export function resolveProviderOutageDeclaration(input: {
       expired,
       exceedsMaxValidity,
       notYetStarted,
+      notYetPosted,
       wrongService,
       unauthorized,
       malformed,
@@ -245,6 +272,9 @@ export function resolveProviderOutageDeclaration(input: {
   } else if (notYetStarted.length > 0) {
     const latest = latestByCreatedAt(notYetStarted);
     reason = `declaration has not started yet (starts at ${latest?.startedAt})`;
+  } else if (notYetPosted.length > 0) {
+    const latest = latestByCreatedAt(notYetPosted);
+    reason = `declaration comment was not yet posted as of the evaluated moment (posted at ${latest?.createdAt})`;
   } else if (exceedsMaxValidity.length > 0) {
     reason = `declaration expiry exceeds configured providerOutage.maxValidity`;
   } else if (unauthorized.length > 0) {
@@ -265,6 +295,7 @@ export function resolveProviderOutageDeclaration(input: {
     expired,
     exceedsMaxValidity,
     notYetStarted,
+    notYetPosted,
     wrongService,
     unauthorized,
     malformed,

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -3651,6 +3651,25 @@ test('collectFromGitHub sources reviewPolicy into the returned options (#2137: p
   assert.match(source, /options:\s*\{[^}]*\breviewPolicy,[^}]*\}/s);
 });
 
+test('collectFromGitHub resolves the provider-outage declaration at the SAME injected now the returned verdict uses (#2353, Codex review on PR #2370)', () => {
+  // Same "pin the call site" spirit as the #1810/#1906/#2137 tests above:
+  // `resolveProviderOutageDeclaration` must read the resolved `resolvedNow`
+  // variable (which also becomes `options.now`), never a second,
+  // independently-computed wall-clock `new Date()` -- a `--now`-overridden
+  // invocation must evaluate declaration validity at that SAME instant,
+  // not the real clock, matching every other deadline/waiver/terminal
+  // computation in this same verdict.
+  const source = readFileSync(
+    new URL('../src/scripts/advisory-convergence.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /resolveProviderOutageDeclaration\(\{[^}]*now:\s*new Date\(resolvedNow\),?[^}]*\}\)/s,
+  );
+  assert.match(source, /options:\s*\{\s*now:\s*resolvedNow,/);
+});
+
 // --- parseArgs ---------------------------------------------------------------
 
 test('parseArgs: parses --pr, --assert, and --claim-issue', () => {

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -2899,6 +2899,7 @@ test('terminal-unavailable-no-waiver: COPILOT_UNAVAILABLE alone never flips read
   assert.equal(verdict.terminal.windowElapsed, true);
   assert.equal(verdict.deadline.passed, false);
   assert.equal(verdict.converged, false);
+  assert.equal(verdict.waiver.outageRelieved, false);
   assert.equal(verdict.waived, false);
   assert.equal(verdict.ready, false);
   assert.ok(
@@ -3028,6 +3029,90 @@ test('terminal-unavailable: an otherwise-valid waiver does not satisfy the termi
   );
   assert.equal(verdict.terminal.state, 'COPILOT_UNAVAILABLE');
   assert.equal(verdict.waiver.validCount, 0);
+  assert.equal(verdict.ready, false);
+});
+
+// --- #2353: provider-outage declaration relief -----------------------
+
+test('outage-relief: an active provider-outage declaration satisfies the terminal path with no waiver marker posted (AC1)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [], // Copilot never reviewed this HEAD -- CI check un-rerun
+      claimEvents: [claimComment()],
+      comments: terminalRecoveryComments(), // proves terminalUnavailable, no waiver comment
+    }),
+    baseOptions({
+      headCommittedAt: RECENT, // the ordinary 24h deadline has NOT passed
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      outageDeclarationActive: true,
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.terminal.state, 'COPILOT_UNAVAILABLE');
+  assert.equal(verdict.waiver.validCount, 0); // stays direct-waiver-only, per #2021
+  assert.equal(verdict.waiver.outageRelieved, true);
+  assert.equal(verdict.waived, true);
+  assert.equal(verdict.ready, true);
+});
+
+test('outage-relief: an active declaration does NOT relieve the deadline-only path (no proven terminal-unavailable state) (AC4)', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment()],
+      comments: [], // no recovery markers at all -- terminal stays NOT_TERMINAL
+    }),
+    baseOptions({
+      headCommittedAt: OLD, // the ordinary 24h deadline HAS passed
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      outageDeclarationActive: true,
+    }),
+  );
+  assertValidVerdict(verdict);
+  assert.equal(verdict.terminal.state, 'NOT_TERMINAL');
+  assert.equal(verdict.deadline.passed, true);
+  assert.equal(verdict.waiver.outageRelieved, false);
+  assert.equal(verdict.waived, false);
+  assert.equal(verdict.ready, false);
+});
+
+test('outage-relief: an active declaration does not relieve a selector outside the configured waivable scope', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment()],
+      comments: terminalRecoveryComments(),
+    }),
+    baseOptions({
+      headCommittedAt: RECENT,
+      waiverMode: 'maintainer-authorized',
+      waivableSelectors: [], // idd-advisory-convergence never registered
+      outageDeclarationActive: true,
+    }),
+  );
+  assert.equal(verdict.terminal.state, 'COPILOT_UNAVAILABLE');
+  assert.equal(verdict.waiver.outageRelieved, false);
+  assert.equal(verdict.ready, false);
+});
+
+test('outage-relief: waiverMode not maintainer-authorized never relieves via a declaration either', () => {
+  const verdict = computeAdvisoryConvergenceVerdict(
+    baseInputs({
+      reviews: [],
+      claimEvents: [claimComment()],
+      comments: terminalRecoveryComments(),
+    }),
+    baseOptions({
+      headCommittedAt: RECENT,
+      waiverMode: 'disabled',
+      waivableSelectors: ADVISORY_CONVERGENCE_WAIVABLE,
+      outageDeclarationActive: true,
+    }),
+  );
+  assert.equal(verdict.terminal.state, 'COPILOT_UNAVAILABLE');
+  assert.equal(verdict.waiver.outageRelieved, false);
   assert.equal(verdict.ready, false);
 });
 

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -5023,7 +5023,7 @@ test('resolveAdvisoryConvergenceOutageRelief requires ciGate.externalCheckWaiver
   );
   assert.match(
     source,
-    /function resolveAdvisoryConvergenceOutageRelief\([\s\S]*?if \(policy\.ciGate\.externalCheckWaivers\.mode !== 'maintainer-authorized'\) \{\s*\n\s*return false;\s*\n\s*\}/,
+    /function resolveAdvisoryConvergenceOutageRelief\([\s\S]*?if \(policy\.ciGate\.externalCheckWaivers\.mode !== 'maintainer-authorized'\) \{\s*\n\s*return notRelieved;\s*\n\s*\}/,
   );
 });
 
@@ -5046,6 +5046,72 @@ test('summarizeRequiredChecks: treatAsCoveredByWaiver never covers a check with 
   );
   assert.equal(result.checks[0].coveredByWaiver, undefined);
   assert.notEqual(result.status, 'success');
+});
+
+// Codex review (PR #2370, follow-up finding after the first fix round): a
+// live run existing (completedAt parseable) is not enough -- it must ALSO
+// have completed AT OR AFTER the moment `treatAsCoveredByWaiverSince`
+// names. A failed run that completed BEFORE an outage declaration's own
+// window opened was never actually rerun during the declared outage;
+// treating it covered would report `success` while GitHub's own
+// required-check state still shows the stale failure.
+test('summarizeRequiredChecks: treatAsCoveredByWaiverSince withholds coverage from a run that completed before the cutoff', () => {
+  const result = summarizeRequiredChecks(
+    [
+      {
+        name: 'idd-advisory-convergence',
+        state: 'FAILURE',
+        completedAt: '2026-05-11T00:00:00Z', // before the declaration opened
+      },
+    ],
+    [],
+    { required_status_checks: { contexts: ['idd-advisory-convergence'] } },
+    {
+      treatAsCoveredByWaiver: (name) => name === 'idd-advisory-convergence',
+      treatAsCoveredByWaiverSince: () => '2026-05-12T00:00:00Z',
+    },
+  );
+  assert.equal(result.checks[0].coveredByWaiver, undefined);
+  assert.notEqual(result.status, 'success');
+});
+
+test('summarizeRequiredChecks: treatAsCoveredByWaiverSince covers a run that completed at or after the cutoff', () => {
+  const result = summarizeRequiredChecks(
+    [
+      {
+        name: 'idd-advisory-convergence',
+        state: 'FAILURE',
+        completedAt: '2026-05-12T00:30:00Z', // after the declaration opened
+      },
+    ],
+    [],
+    { required_status_checks: { contexts: ['idd-advisory-convergence'] } },
+    {
+      treatAsCoveredByWaiver: (name) => name === 'idd-advisory-convergence',
+      treatAsCoveredByWaiverSince: () => '2026-05-12T00:00:00Z',
+    },
+  );
+  assert.equal(result.checks[0].coveredByWaiver, true);
+  assert.equal(result.status, 'success');
+});
+
+test('summarizeRequiredChecks: omitted treatAsCoveredByWaiverSince applies no cutoff (unchanged pre-fix behavior)', () => {
+  const result = summarizeRequiredChecks(
+    [
+      {
+        name: 'idd-advisory-convergence',
+        state: 'FAILURE',
+        completedAt: '2026-05-11T00:00:00Z',
+      },
+    ],
+    [],
+    { required_status_checks: { contexts: ['idd-advisory-convergence'] } },
+    {
+      treatAsCoveredByWaiver: (name) => name === 'idd-advisory-convergence',
+    },
+  );
+  assert.equal(result.checks[0].coveredByWaiver, true);
+  assert.equal(result.status, 'success');
 });
 
 test('summarizeRequiredChecks: waiver does not affect already-passing check', () => {
@@ -7451,6 +7517,62 @@ test('#2353: advisoryConvergenceOutageRelieved is re-gated on the precondition b
   const check = ciCheckByName(blocked, 'idd-advisory-convergence');
   assert.equal(check?.coveredByWaiver, undefined);
   assert.equal(advisoryWaitOf(blocked).copilotUnavailableWaived, false);
+});
+
+// Codex review (PR #2370, follow-up finding): the required check's live
+// run must have completed AT OR AFTER the declaration's own `startedAt`
+// -- a stale run that failed BEFORE the declaration's window opened was
+// never actually rerun under the outage, and reporting it covered would
+// diverge from GitHub's own required-check state (the same #2021 "ready
+// but merge blocked" class one layer deeper).
+test('#2353: advisoryConvergenceOutageRelievedSince withholds coverage from a stale pre-declaration run', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  // withAdvisoryConvergenceRequiredCheck's injected check completes at
+  // 2026-05-12T00:30:00Z -- anchor the declaration's own window AFTER
+  // that moment, so the run predates it.
+  const input = withAdvisoryConvergenceRequiredCheck(fixture);
+  const waivableCheckSelectors = [
+    { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+  ];
+
+  const stillBlocked = buildPreMergeReadinessSummary(input, {
+    ...fixture.options,
+    includeDispositionEvidence: true,
+    waivableCheckSelectors,
+    externalCheckWaiverMaxValidity: 'PT24H',
+    copilotUnavailable: true,
+    advisoryConvergenceOutageRelieved: true,
+    advisoryConvergenceOutageRelievedSince: '2026-05-13T00:00:00Z',
+  });
+
+  const check = ciCheckByName(stillBlocked, 'idd-advisory-convergence');
+  assert.equal(check?.coveredByWaiver, undefined);
+  assert.notEqual(
+    (stillBlocked.ci as Record<string, unknown>).status,
+    'success',
+  );
+});
+
+test('#2353: advisoryConvergenceOutageRelievedSince covers a run that completed after the declaration opened', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const input = withAdvisoryConvergenceRequiredCheck(fixture);
+  const waivableCheckSelectors = [
+    { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+  ];
+
+  const relieved = buildPreMergeReadinessSummary(input, {
+    ...fixture.options,
+    includeDispositionEvidence: true,
+    waivableCheckSelectors,
+    externalCheckWaiverMaxValidity: 'PT24H',
+    copilotUnavailable: true,
+    advisoryConvergenceOutageRelieved: true,
+    advisoryConvergenceOutageRelievedSince: '2026-05-12T00:00:00Z',
+  });
+
+  const check = ciCheckByName(relieved, 'idd-advisory-convergence');
+  assert.equal(check?.coveredByWaiver, true);
+  assert.equal((relieved.ci as Record<string, unknown>).status, 'success');
 });
 
 // #2046: a waiver that is otherwise valid, precondition-open, and

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -11,6 +11,7 @@ import {
   fetchGovernanceJson,
   normalizeStatusCheckRollupEntry,
   parseArgs,
+  resolveDeclarationActiveSince,
   resolveEligibleCodeownerUserLogins,
   resolveToleratedGhFailure,
 } from '../src/scripts/pre-merge-readiness.mts';
@@ -6561,6 +6562,52 @@ test('resolveToleratedGhFailure ignores non-JSON allowStatuses stdout and falls 
     resolveToleratedGhFailure(error, { allowStatuses: [1] }),
     undefined,
   );
+});
+
+// #2353 (Codex review on PR #2370, second follow-up): a declaration's own
+// `startedAt` is generated before the `--declare --apply` interactive
+// confirmation prompt, while the GitHub comment's `createdAt` is stamped
+// only once the maintainer confirms posting. Use the LATER of the two as
+// the "declaration became a real, postable fact" cutoff.
+test('resolveDeclarationActiveSince uses createdAt when it is later than startedAt (the pause-at-prompt case)', () => {
+  assert.equal(
+    resolveDeclarationActiveSince({
+      startedAt: '2026-05-12T00:00:00Z',
+      createdAt: '2026-05-12T00:05:00Z', // maintainer paused 5 minutes at the prompt
+    }),
+    '2026-05-12T00:05:00.000Z',
+  );
+});
+
+test('resolveDeclarationActiveSince uses startedAt when it is later than createdAt (the ordinary case)', () => {
+  assert.equal(
+    resolveDeclarationActiveSince({
+      startedAt: '2026-05-12T00:05:00Z',
+      createdAt: '2026-05-12T00:00:00Z',
+    }),
+    '2026-05-12T00:05:00.000Z',
+  );
+});
+
+test('resolveDeclarationActiveSince falls back to startedAt alone when createdAt is the schema-documented "none" sentinel', () => {
+  assert.equal(
+    resolveDeclarationActiveSince({
+      startedAt: '2026-05-12T00:00:00Z',
+      createdAt: 'none',
+    }),
+    '2026-05-12T00:00:00.000Z',
+  );
+});
+
+test('resolveDeclarationActiveSince returns empty when both timestamps are unparseable', () => {
+  assert.equal(
+    resolveDeclarationActiveSince({ startedAt: '', createdAt: 'none' }),
+    '',
+  );
+});
+
+test('resolveDeclarationActiveSince returns empty for a null declaration', () => {
+  assert.equal(resolveDeclarationActiveSince(null), '');
 });
 
 // #1483: normalizeStatusCheckRollupEntry replaced the old `gh pr checks`

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -4938,7 +4938,8 @@ test('summarizeRequiredChecks: treatAsCoveredByWaiver covers a failing required 
       {
         name: 'idd-advisory-convergence',
         state: 'FAILURE',
-        completedAt: '2026-05-17T00:00:00Z',
+        startedAt: '2026-05-17T00:00:00Z',
+        completedAt: '2026-05-17T00:03:00Z',
       },
     ],
     [],
@@ -4957,7 +4958,8 @@ test('summarizeRequiredChecks: treatAsCoveredByWaiver bypasses excludeFromWaiver
       {
         name: 'idd-advisory-convergence',
         state: 'FAILURE',
-        completedAt: '2026-05-17T00:00:00Z',
+        startedAt: '2026-05-17T00:00:00Z',
+        completedAt: '2026-05-17T00:03:00Z',
       },
     ],
     [],
@@ -4977,7 +4979,8 @@ test('summarizeRequiredChecks: treatAsCoveredByWaiver has nothing to cover on an
       {
         name: 'idd-advisory-convergence',
         state: 'SUCCESS',
-        completedAt: '2026-05-17T00:00:00Z',
+        startedAt: '2026-05-17T00:00:00Z',
+        completedAt: '2026-05-17T00:03:00Z',
       },
     ],
     [],
@@ -4996,7 +4999,8 @@ test('summarizeRequiredChecks: omitted treatAsCoveredByWaiver never covers anyth
       {
         name: 'idd-advisory-convergence',
         state: 'FAILURE',
-        completedAt: '2026-05-17T00:00:00Z',
+        startedAt: '2026-05-17T00:00:00Z',
+        completedAt: '2026-05-17T00:03:00Z',
       },
     ],
     [],
@@ -5038,7 +5042,38 @@ test('resolveAdvisoryConvergenceOutageRelief requires ciGate.externalCheckWaiver
 // failure mode #2021 fixed.
 test('summarizeRequiredChecks: treatAsCoveredByWaiver never covers a check with no live run at all, even when it returns true', () => {
   const result = summarizeRequiredChecks(
-    [{ name: 'idd-advisory-convergence', state: 'PENDING', completedAt: '' }],
+    [
+      {
+        name: 'idd-advisory-convergence',
+        state: 'PENDING',
+        startedAt: '',
+        completedAt: '',
+      },
+    ],
+    [],
+    { required_status_checks: { contexts: ['idd-advisory-convergence'] } },
+    {
+      treatAsCoveredByWaiver: (name) => name === 'idd-advisory-convergence',
+    },
+  );
+  assert.equal(result.checks[0].coveredByWaiver, undefined);
+  assert.notEqual(result.status, 'success');
+});
+
+// Codex review (PR #2370): a run whose live `completedAt` is parseable but
+// whose `startedAt` is not (an inconsistent/malformed entry) must also be
+// withheld -- the same fail-closed posture `completedAtMs !== null` already
+// enforces, mirrored for `startedAtMs`.
+test('summarizeRequiredChecks: treatAsCoveredByWaiver never covers a check with a parseable completedAt but no parseable startedAt', () => {
+  const result = summarizeRequiredChecks(
+    [
+      {
+        name: 'idd-advisory-convergence',
+        state: 'FAILURE',
+        startedAt: '',
+        completedAt: '2026-05-17T00:03:00Z',
+      },
+    ],
     [],
     { required_status_checks: { contexts: ['idd-advisory-convergence'] } },
     {
@@ -5062,6 +5097,7 @@ test('summarizeRequiredChecks: treatAsCoveredByWaiverSince withholds coverage fr
       {
         name: 'idd-advisory-convergence',
         state: 'FAILURE',
+        startedAt: '2026-05-10T23:57:00Z', // before the declaration opened
         completedAt: '2026-05-11T00:00:00Z', // before the declaration opened
       },
     ],
@@ -5076,12 +5112,13 @@ test('summarizeRequiredChecks: treatAsCoveredByWaiverSince withholds coverage fr
   assert.notEqual(result.status, 'success');
 });
 
-test('summarizeRequiredChecks: treatAsCoveredByWaiverSince covers a run that completed at or after the cutoff', () => {
+test('summarizeRequiredChecks: treatAsCoveredByWaiverSince covers a run that started at or after the cutoff', () => {
   const result = summarizeRequiredChecks(
     [
       {
         name: 'idd-advisory-convergence',
         state: 'FAILURE',
+        startedAt: '2026-05-12T00:25:00Z', // after the declaration opened
         completedAt: '2026-05-12T00:30:00Z', // after the declaration opened
       },
     ],
@@ -5096,12 +5133,40 @@ test('summarizeRequiredChecks: treatAsCoveredByWaiverSince covers a run that com
   assert.equal(result.status, 'success');
 });
 
+// Codex review (PR #2370, second follow-up finding, round 4): the
+// freshness cutoff must anchor on `startedAt`, not `completedAt`. A run
+// that BEGAN evaluating state before the declaration's own window opened
+// never observed it, even though this particular run happens to finish
+// (and post `completedAt`) a few minutes after the cutoff passes -- its
+// verdict was already decided using stale, pre-declaration state by then.
+test('summarizeRequiredChecks: treatAsCoveredByWaiverSince withholds coverage from a run that started before the cutoff but completed after it', () => {
+  const result = summarizeRequiredChecks(
+    [
+      {
+        name: 'idd-advisory-convergence',
+        state: 'FAILURE',
+        startedAt: '2026-05-11T23:58:00Z', // started before the declaration opened
+        completedAt: '2026-05-12T00:05:00Z', // finished after the declaration opened
+      },
+    ],
+    [],
+    { required_status_checks: { contexts: ['idd-advisory-convergence'] } },
+    {
+      treatAsCoveredByWaiver: (name) => name === 'idd-advisory-convergence',
+      treatAsCoveredByWaiverSince: () => '2026-05-12T00:00:00Z',
+    },
+  );
+  assert.equal(result.checks[0].coveredByWaiver, undefined);
+  assert.notEqual(result.status, 'success');
+});
+
 test('summarizeRequiredChecks: omitted treatAsCoveredByWaiverSince applies no cutoff (unchanged pre-fix behavior)', () => {
   const result = summarizeRequiredChecks(
     [
       {
         name: 'idd-advisory-convergence',
         state: 'FAILURE',
+        startedAt: '2026-05-10T23:57:00Z',
         completedAt: '2026-05-11T00:00:00Z',
       },
     ],
@@ -6623,12 +6688,14 @@ test('normalizeStatusCheckRollupEntry: a completed CheckRun reports its conclusi
     status: 'COMPLETED',
     conclusion: 'SUCCESS',
     completedAt: '2026-07-18T03:47:01Z',
+    startedAt: '2026-07-18T03:44:12Z',
     workflowName: 'IDD advisory-convergence gate',
   });
   assert.deepEqual(result, {
     name: 'idd-advisory-convergence',
     state: 'SUCCESS',
     completedAt: '2026-07-18T03:47:01Z',
+    startedAt: '2026-07-18T03:44:12Z',
     type: 'check-run',
     workflowName: 'IDD advisory-convergence gate',
   });
@@ -6658,6 +6725,7 @@ test('normalizeStatusCheckRollupEntry: a StatusContext reports its own state and
     name: 'CodeRabbit',
     state: 'SUCCESS',
     completedAt: '0001-01-01T00:00:00Z',
+    startedAt: '0001-01-01T00:00:00Z',
     type: 'status-context',
     workflowName: '',
   });
@@ -7038,6 +7106,10 @@ function withAdvisoryConvergenceRequiredCheck(fixture: {
       // helper's callers post, so the rerun-freshness gate does not withhold
       // coverage in the "should be covered" cases below -- those tests cover
       // #2021's precondition and #2046's mode gating specifically, not #2034.
+      // `startedAt` is also after that same moment (Codex review round 4 on
+      // PR #2370: the #2353 `treatAsCoveredByWaiver` cutoff anchors on
+      // `startedAt`, not `completedAt`).
+      startedAt: '2026-05-12T00:15:00Z',
       completedAt: '2026-05-12T00:30:00Z',
     },
   ];
@@ -7620,6 +7692,63 @@ test('#2353: advisoryConvergenceOutageRelievedSince covers a run that completed 
   const check = ciCheckByName(relieved, 'idd-advisory-convergence');
   assert.equal(check?.coveredByWaiver, true);
   assert.equal((relieved.ci as Record<string, unknown>).status, 'success');
+});
+
+// Codex review (PR #2370, second follow-up, round 4): a run that STARTED
+// before the declaration's window opened but happened to COMPLETE after it
+// must still be withheld -- it never observed the declaration during its
+// own evaluation, even though `completedAt` alone would suggest freshness.
+test('#2353: advisoryConvergenceOutageRelievedSince withholds coverage from a run that started before the declaration but completed after it', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const branchRules = (fixture.input.branchRules ?? []).map(
+    (rule: { type?: string }) =>
+      rule.type === 'required_status_checks'
+        ? {
+            type: 'required_status_checks',
+            parameters: {
+              required_status_checks: [
+                { context: 'lint' },
+                { context: 'idd-advisory-convergence' },
+              ],
+            },
+          }
+        : rule,
+  );
+  const input = {
+    ...fixture.input,
+    branchRules,
+    checks: [
+      ...(fixture.input.checks ?? []),
+      {
+        name: 'idd-advisory-convergence',
+        state: 'FAILURE',
+        // Started before the declaration's window opens below
+        // (2026-05-12T00:00:00Z) but finishes after it.
+        startedAt: '2026-05-11T23:58:00Z',
+        completedAt: '2026-05-12T00:05:00Z',
+      },
+    ],
+  };
+  const waivableCheckSelectors = [
+    { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+  ];
+
+  const stillBlocked = buildPreMergeReadinessSummary(input, {
+    ...fixture.options,
+    includeDispositionEvidence: true,
+    waivableCheckSelectors,
+    externalCheckWaiverMaxValidity: 'PT24H',
+    copilotUnavailable: true,
+    advisoryConvergenceOutageRelieved: true,
+    advisoryConvergenceOutageRelievedSince: '2026-05-12T00:00:00Z',
+  });
+
+  const check = ciCheckByName(stillBlocked, 'idd-advisory-convergence');
+  assert.equal(check?.coveredByWaiver, undefined);
+  assert.notEqual(
+    (stillBlocked.ci as Record<string, unknown>).status,
+    'success',
+  );
 });
 
 // #2046: a waiver that is otherwise valid, precondition-open, and

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -5060,6 +5060,60 @@ test('summarizeRequiredChecks: treatAsCoveredByWaiver never covers a check with 
   assert.notEqual(result.status, 'success');
 });
 
+// Copilot + Codex + CodeRabbit review (PR #2370, round 5): GitHub's
+// non-nullable `DateTime` scalar reports the `0001-01-01T00:00:00Z`
+// zero-value sentinel for a `completedAt` that hasn't happened yet
+// (`normalizeStatusCheckRollupEntry` supplies it for a still-running
+// CheckRun) -- and `isValidIsoTimestamp` alone accepts that value as a
+// technically-well-formed, merely very-old timestamp. Before this fix,
+// that meant `completedAtMs !== null` did NOT actually reject an
+// in-progress run: an IN_PROGRESS check with a genuine, fresh `startedAt`
+// would pass every gate and report `coveredByWaiver: true` while GitHub's
+// own required check had not even finished running.
+test('summarizeRequiredChecks: treatAsCoveredByWaiver never covers a still-running check even with a fresh startedAt (zero-value completedAt sentinel)', () => {
+  const result = summarizeRequiredChecks(
+    [
+      {
+        name: 'idd-advisory-convergence',
+        state: 'IN_PROGRESS',
+        startedAt: '2026-05-12T00:25:00Z', // fresh, after the cutoff below
+        completedAt: '0001-01-01T00:00:00Z', // GitHub's not-yet-completed sentinel
+      },
+    ],
+    [],
+    { required_status_checks: { contexts: ['idd-advisory-convergence'] } },
+    {
+      treatAsCoveredByWaiver: (name) => name === 'idd-advisory-convergence',
+      treatAsCoveredByWaiverSince: () => '2026-05-12T00:00:00Z',
+    },
+  );
+  assert.equal(result.checks[0].coveredByWaiver, undefined);
+  assert.notEqual(result.status, 'success');
+});
+
+// Same sentinel gap, mirrored for `startedAt`: a not-yet-started (QUEUED)
+// run's `startedAt` also reports the zero-value sentinel, which must not
+// be accepted as a genuine "observed the declaration" moment either.
+test('summarizeRequiredChecks: treatAsCoveredByWaiver never covers a not-yet-started check (zero-value startedAt sentinel)', () => {
+  const result = summarizeRequiredChecks(
+    [
+      {
+        name: 'idd-advisory-convergence',
+        state: 'QUEUED',
+        startedAt: '0001-01-01T00:00:00Z', // GitHub's not-yet-started sentinel
+        completedAt: '0001-01-01T00:00:00Z',
+      },
+    ],
+    [],
+    { required_status_checks: { contexts: ['idd-advisory-convergence'] } },
+    {
+      treatAsCoveredByWaiver: (name) => name === 'idd-advisory-convergence',
+    },
+  );
+  assert.equal(result.checks[0].coveredByWaiver, undefined);
+  assert.notEqual(result.status, 'success');
+});
+
 // Codex review (PR #2370): a run whose live `completedAt` is parseable but
 // whose `startedAt` is not (an inconsistent/malformed entry) must also be
 // withheld -- the same fail-closed posture `completedAtMs !== null` already

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -4924,6 +4924,87 @@ test('summarizeRequiredChecks: a check with no live run at all is never covered 
   assert.notEqual(result.status, 'success');
 });
 
+// #2353: `treatAsCoveredByWaiver` covers a check through a mechanism OTHER
+// than a matched `waivers.valid` entry (a provider-outage declaration) --
+// with no waiver entry at all, and deliberately bypassing
+// `excludeFromWaiverCoverage`'s own veto, since that callback's purpose
+// (withholding coverage a matched waiver entry would otherwise grant) does
+// not apply to this independent positive path.
+test('summarizeRequiredChecks: treatAsCoveredByWaiver covers a failing required check with zero waiver entries', () => {
+  const result = summarizeRequiredChecks(
+    [
+      {
+        name: 'idd-advisory-convergence',
+        state: 'FAILURE',
+        completedAt: '2026-05-17T00:00:00Z',
+      },
+    ],
+    [],
+    { required_status_checks: { contexts: ['idd-advisory-convergence'] } },
+    {
+      treatAsCoveredByWaiver: (name) => name === 'idd-advisory-convergence',
+    },
+  );
+  assert.equal(result.checks[0].coveredByWaiver, true);
+  assert.equal(result.status, 'success');
+});
+
+test('summarizeRequiredChecks: treatAsCoveredByWaiver bypasses excludeFromWaiverCoverage for the same check name', () => {
+  const result = summarizeRequiredChecks(
+    [
+      {
+        name: 'idd-advisory-convergence',
+        state: 'FAILURE',
+        completedAt: '2026-05-17T00:00:00Z',
+      },
+    ],
+    [],
+    { required_status_checks: { contexts: ['idd-advisory-convergence'] } },
+    {
+      excludeFromWaiverCoverage: () => true, // vetoes every check, as advisory-convergence.mts's own callback does when not genuinely covered
+      treatAsCoveredByWaiver: (name) => name === 'idd-advisory-convergence',
+    },
+  );
+  assert.equal(result.checks[0].coveredByWaiver, true);
+  assert.equal(result.status, 'success');
+});
+
+test('summarizeRequiredChecks: treatAsCoveredByWaiver has nothing to cover on an already-passing check', () => {
+  const result = summarizeRequiredChecks(
+    [
+      {
+        name: 'idd-advisory-convergence',
+        state: 'SUCCESS',
+        completedAt: '2026-05-17T00:00:00Z',
+      },
+    ],
+    [],
+    { required_status_checks: { contexts: ['idd-advisory-convergence'] } },
+    {
+      treatAsCoveredByWaiver: (name) => name === 'idd-advisory-convergence',
+    },
+  );
+  assert.equal(result.checks[0].coveredByWaiver, undefined);
+  assert.equal(result.status, 'success');
+});
+
+test('summarizeRequiredChecks: omitted treatAsCoveredByWaiver never covers anything (unchanged pre-#2353 behavior)', () => {
+  const result = summarizeRequiredChecks(
+    [
+      {
+        name: 'idd-advisory-convergence',
+        state: 'FAILURE',
+        completedAt: '2026-05-17T00:00:00Z',
+      },
+    ],
+    [],
+    { required_status_checks: { contexts: ['idd-advisory-convergence'] } },
+    {},
+  );
+  assert.equal(result.checks[0].coveredByWaiver, undefined);
+  assert.notEqual(result.status, 'success');
+});
+
 test('summarizeRequiredChecks: waiver does not affect already-passing check', () => {
   const waivers = {
     valid: [
@@ -7249,6 +7330,84 @@ test('#2021: idd-advisory-convergence waiver posted and terminal Copilot unavail
   // the same waiver (#1570's pre-existing behavior, unaffected by #2021).
   assert.ok(!waivedGates.includes('copilot-terminal-unavailable'));
   assert.deepEqual(waived.blockers, computePreMergeReadinessBlockers(waived));
+});
+
+// #2353: a repository-scoped provider-outage declaration relieves the
+// idd-advisory-convergence required check and the dedicated
+// copilot-terminal-unavailable blocker the SAME way a direct maintainer
+// waiver does (#2021/#1570 above), but via the caller-precomputed
+// `advisoryConvergenceOutageRelieved` boolean instead of a posted waiver
+// comment -- no `idd-external-check-waiver:` marker exists in either
+// fixture below. Mirrors AC2: F2's blocker/disposition evidence must
+// reflect the same declaration-based relief the CI check's own verdict
+// (advisory-convergence.mts) reports for the same HEAD.
+test('#2353: an active provider-outage declaration covers idd-advisory-convergence with no waiver marker posted (AC1/AC2)', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const input = withAdvisoryConvergenceRequiredCheck(fixture);
+  const waivableCheckSelectors = [
+    { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+  ];
+
+  const relieved = buildPreMergeReadinessSummary(input, {
+    ...fixture.options,
+    includeDispositionEvidence: true,
+    waivableCheckSelectors,
+    externalCheckWaiverMaxValidity: 'PT24H',
+    copilotUnavailable: true,
+    advisoryConvergenceOutageRelieved: true,
+  });
+
+  const precondition = (
+    relieved as {
+      advisoryConvergenceWaiverPrecondition: Record<string, unknown>;
+    }
+  ).advisoryConvergenceWaiverPrecondition;
+  assert.equal(precondition.terminalUnavailable, true);
+  assert.equal(precondition.open, true);
+
+  const check = ciCheckByName(relieved, 'idd-advisory-convergence');
+  assert.equal(check?.coveredByWaiver, true);
+  assert.equal((relieved.ci as Record<string, unknown>).status, 'success');
+  assert.equal(advisoryWaitOf(relieved).copilotUnavailableWaived, true);
+  const relievedGates = (relieved.blockers as { gate: string }[]).map(
+    (blocker) => blocker.gate,
+  );
+  assert.ok(!relievedGates.includes('ci'));
+  assert.ok(!relievedGates.includes('copilot-terminal-unavailable'));
+  assert.deepEqual(
+    relieved.blockers,
+    computePreMergeReadinessBlockers(relieved),
+  );
+});
+
+test('#2353: advisoryConvergenceOutageRelieved is re-gated on the precondition being open (AC4 -- cheap insurance against a caller passing relief without proof)', () => {
+  const fixture = readJson('fixtures/pre-merge-readiness/clean.json');
+  const input = withAdvisoryConvergenceRequiredCheck(fixture);
+  const waivableCheckSelectors = [
+    { selector: 'idd-advisory-convergence', matchMode: 'exact' },
+  ];
+
+  const blocked = buildPreMergeReadinessSummary(input, {
+    ...fixture.options,
+    includeDispositionEvidence: true,
+    waivableCheckSelectors,
+    externalCheckWaiverMaxValidity: 'PT24H',
+    // Neither opener is proven: copilotUnavailable is false and the
+    // fixture's own headCommittedAt keeps the ordinary deadline open.
+    copilotUnavailable: false,
+    advisoryConvergenceOutageRelieved: true,
+  });
+
+  const precondition = (
+    blocked as {
+      advisoryConvergenceWaiverPrecondition: Record<string, unknown>;
+    }
+  ).advisoryConvergenceWaiverPrecondition;
+  assert.equal(precondition.open, false);
+
+  const check = ciCheckByName(blocked, 'idd-advisory-convergence');
+  assert.equal(check?.coveredByWaiver, undefined);
+  assert.equal(advisoryWaitOf(blocked).copilotUnavailableWaived, false);
 });
 
 // #2046: a waiver that is otherwise valid, precondition-open, and

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 import {
@@ -5000,6 +5001,48 @@ test('summarizeRequiredChecks: omitted treatAsCoveredByWaiver never covers anyth
     [],
     { required_status_checks: { contexts: ['idd-advisory-convergence'] } },
     {},
+  );
+  assert.equal(result.checks[0].coveredByWaiver, undefined);
+  assert.notEqual(result.status, 'success');
+});
+
+// Codex review (PR #2370): `resolveAdvisoryConvergenceOutageRelief` (the
+// CLI-layer function that fetches/resolves the declaration for
+// pre-merge-readiness.mts) is not exported and does live `gh api` calls,
+// so it is pinned by source text -- same "pin the call site" spirit as
+// advisory-convergence.test.mts's #1810/#1906/#2137/#2353 tests. Without
+// this gate, an adopter that leaves `ciGate.externalCheckWaivers.mode` at
+// its `disabled` default but configures the waivable selector and posts a
+// declaration would relieve here while `computeAdvisoryConvergenceVerdict`
+// -- gated on the SAME check -- still rejects it, disagreeing with the CI
+// check's own verdict for the same pull request and HEAD.
+test('resolveAdvisoryConvergenceOutageRelief requires ciGate.externalCheckWaivers.mode to be maintainer-authorized (#2353, Codex review on PR #2370)', () => {
+  const source = readFileSync(
+    new URL('../src/scripts/pre-merge-readiness.mts', import.meta.url),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /function resolveAdvisoryConvergenceOutageRelief\([\s\S]*?if \(policy\.ciGate\.externalCheckWaivers\.mode !== 'maintainer-authorized'\) \{\s*\n\s*return false;\s*\n\s*\}/,
+  );
+});
+
+// Copilot + Codex review (PR #2370): `treatAsCoveredByWaiver` returning
+// `true` must never cover a check whose live run has not actually
+// completed (QUEUED/IN_PROGRESS/PENDING with an empty/unparseable
+// `completedAt`) -- the same #2034 fail-closed live-run requirement the
+// direct-waiver path already enforces via `hasFreshWaiverCoverage`.
+// Reporting `success` here while GitHub's own required-check state is
+// still pending would recreate the exact "ready but merge blocked"
+// failure mode #2021 fixed.
+test('summarizeRequiredChecks: treatAsCoveredByWaiver never covers a check with no live run at all, even when it returns true', () => {
+  const result = summarizeRequiredChecks(
+    [{ name: 'idd-advisory-convergence', state: 'PENDING', completedAt: '' }],
+    [],
+    { required_status_checks: { contexts: ['idd-advisory-convergence'] } },
+    {
+      treatAsCoveredByWaiver: (name) => name === 'idd-advisory-convergence',
+    },
   );
   assert.equal(result.checks[0].coveredByWaiver, undefined);
   assert.notEqual(result.status, 'success');

--- a/tests/provider-outage-declaration.test.mts
+++ b/tests/provider-outage-declaration.test.mts
@@ -251,6 +251,91 @@ test('resolveProviderOutageDeclaration: becomes active once its own startedAt is
   assert.equal(atStart.active, true);
 });
 
+// #2353 (Codex review on PR #2370, round 5): `startedAt` is authored at
+// `--declare` time, before the `--apply` confirmation that actually posts
+// the GitHub comment `createdAt` records. A caller replaying a past `now`
+// (e.g. `--now`) between those two moments must not see the declaration as
+// active -- at that replayed moment, the comment recording it did not yet
+// exist on GitHub, even though the declaration's own self-reported window
+// had already opened.
+test('resolveProviderOutageDeclaration: a declaration whose startedAt has passed but whose comment was not yet posted is not active (#2353 review, Codex, round 5)', () => {
+  const result = resolveProviderOutageDeclaration({
+    declarationTargetConfigured: true,
+    comments: [
+      declarationComment({
+        startedAt: '2026-09-01T05:00:00Z', // before NOW (06:00:00Z)
+        expiresAt: '2026-09-02T05:00:00Z',
+        createdAt: '2026-09-01T06:30:00Z', // posted after NOW
+      }),
+    ],
+    service: 'idd-advisory-convergence',
+    policy: basePolicy,
+    authorityOf: authorizedActor,
+    now: NOW,
+  });
+  assert.equal(result.active, false);
+  assert.match(result.reason, /not yet posted/);
+  assert.equal(result.notYetPosted.length, 1);
+  assert.equal(result.valid.length, 0);
+});
+
+test('resolveProviderOutageDeclaration: becomes active once its own comment is posted, even with an earlier startedAt (#2353 review, Codex, round 5)', () => {
+  const comments = [
+    declarationComment({
+      startedAt: '2026-09-01T05:00:00Z',
+      expiresAt: '2026-09-02T05:00:00Z',
+      createdAt: '2026-09-01T06:30:00Z',
+    }),
+  ];
+  const beforePosted = resolveProviderOutageDeclaration({
+    declarationTargetConfigured: true,
+    comments,
+    service: 'idd-advisory-convergence',
+    policy: basePolicy,
+    authorityOf: authorizedActor,
+    now: new Date('2026-09-01T06:29:59Z'),
+  });
+  const atPosted = resolveProviderOutageDeclaration({
+    declarationTargetConfigured: true,
+    comments,
+    service: 'idd-advisory-convergence',
+    policy: basePolicy,
+    authorityOf: authorizedActor,
+    now: new Date('2026-09-01T06:30:00Z'),
+  });
+  assert.equal(beforePosted.active, false);
+  assert.equal(atPosted.active, true);
+});
+
+// A `createdAt` that fails to parse (the schema-documented `'none'`
+// sentinel `parseProviderOutageDeclarationComment` falls back to) must
+// never withhold an otherwise-valid declaration -- mirrors
+// `resolveDeclarationActiveSince`'s (pre-merge-readiness.mts) identical
+// fallback-to-`startedAt`-alone convention for the same sentinel.
+test('resolveProviderOutageDeclaration: an unparseable createdAt never withholds an otherwise-valid declaration', () => {
+  const result = resolveProviderOutageDeclaration({
+    declarationTargetConfigured: true,
+    comments: [
+      {
+        body: renderProviderOutageDeclarationComment({
+          actor: 'kurone-kito',
+          service: 'idd-advisory-convergence',
+          startedAt: '2026-09-01T05:00:00Z',
+          expiresAt: '2026-09-02T05:00:00Z',
+        }),
+        created_at: undefined,
+        author: { login: 'kurone-kito' },
+      },
+    ],
+    service: 'idd-advisory-convergence',
+    policy: basePolicy,
+    authorityOf: authorizedActor,
+    now: NOW,
+  });
+  assert.equal(result.active, true);
+  assert.equal(result.declaration?.createdAt, 'none');
+});
+
 test('resolveProviderOutageDeclaration: malformed case', () => {
   const result = resolveProviderOutageDeclaration({
     declarationTargetConfigured: true,

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -731,6 +731,7 @@ const advisoryConvergenceFixture = {
     checkSelector: 'idd-advisory-convergence',
     activeClaimId: '',
     validCount: 0,
+    outageRelieved: false,
   },
   dispositionEvidence: {
     missingRegularCommentCount: 0,


### PR DESCRIPTION
## Summary

`#2320` added a repository-scoped, time-boxed outage-relief declaration
(`resolveProviderOutageDeclaration` / `evaluateProviderOutageRelief` in
`provider-outage-declaration.mts`), documented as a substitute for
posting a per-pull-request `idd-external-check-waiver:` marker on the
`idd-advisory-convergence` selector during a sustained provider outage.
That instruction claim was not backed by runtime behavior: a
repository-wide search found `evaluateProviderOutageRelief` used only
by `provider-outage-declaration.mts` itself and its own tests -- neither
`advisory-convergence.mts` (the CI-check verdict) nor
`pre-merge-readiness.mts` (the F2/F3 merge gate) consumed a declaration,
so an active declaration changed nothing during a real outage.

### Fix

Consume it in both, alongside the existing per-pull-request waiver path
(never replacing it), using service `"idd-advisory-convergence"` (the
same name `idd-advisory-wait.instructions.md`'s existing "Sustained
outage" note already documents):

- **`advisory-convergence.mts`**: fetches and resolves the declaration
  in its own gather step (fail-closed to inactive on any error --
  unset target, unreadable comments, authority-lookup failure), and its
  pure `computeAdvisoryConvergenceVerdict` folds
  `evaluateProviderOutageRelief`'s verdict into `waived` alongside the
  direct-waiver count. `waiver.validCount` stays direct-waiver-only
  (the schema-locked, truthfully-reported count `#2021` established); a
  new `waiver.outageRelieved` field reports the declaration path
  separately (schema updated to match).
- **`pre-merge-readiness.mts`**: resolves the same declaration/relief in
  its own CLI layer -- `provider-outage-declaration.mts` already imports
  FROM `protocol-helpers.mts`, so `protocol-helpers.mts` cannot import
  it back without a cycle -- and passes a caller-precomputed
  `advisoryConvergenceOutageRelieved` boolean into
  `buildPreMergeReadinessSummary`, re-ANDed there with the same
  precondition-open evidence the direct-waiver path already requires
  (cheap insurance, since the boolean already implies it upstream).
  `summarizeRequiredChecks` gains a new `treatAsCoveredByWaiver` hook: an
  independent positive coverage path (no waiver-entry `createdAt` to
  compare against a live run, no `excludeFromWaiverCoverage` veto to
  honor -- that callback's own purpose, withholding coverage a matched
  waiver entry would otherwise grant, does not apply to a mechanism
  other than a matched waiver entry) that also clears the dedicated
  `copilot-terminal-unavailable` blocker.

Relief always requires the pull request's OWN proven terminal-
unavailable state independently (never the deadline-only opener) and a
`ciGate.externalChecks.waivable` match -- matching `#2320`'s own
non-bypassing contract exactly. It never relieves a CI conclusion,
branch freshness, claim state, or unresolved threads.

Also documents the two consumers and the required service name in
`idd-template/docs/idd-helper-scripts.md`'s provider-outage-declaration
section (canonical; synced to `docs/`).

Closes #2353

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build` (regenerates `scripts/advisory-convergence.mjs`,
      `scripts/pre-merge-readiness.mjs`, `scripts/protocol-helpers.mjs`)
- [x] `node --test tests/advisory-convergence.test.mts` (183/183 pass,
      including 4 new `outage-relief:` tests: an active declaration
      satisfies the terminal path with no waiver marker posted, an
      active declaration does NOT relieve the deadline-only path (no
      proven terminal-unavailable state -- pins AC4), an active
      declaration outside the configured waivable scope does not
      relieve, and `waiverMode` not `maintainer-authorized` never
      relieves via a declaration either)
- [x] `node --test tests/pre-merge-readiness.test.mts` (286/286 pass,
      including 6 new tests: two `buildPreMergeReadinessSummary`
      integration tests (relief covers the check + clears the
      dedicated blocker with no waiver marker; the boolean is
      re-gated on the precondition being open) and four direct
      `summarizeRequiredChecks: treatAsCoveredByWaiver` unit tests
      (covers with zero waiver entries, bypasses
      `excludeFromWaiverCoverage`, has nothing to cover on an
      already-passing check, and omitted never covers anything))
- [x] `pnpm test` (4229/4229 pass, full suite)
- [x] `node scripts/validate-schemas.mjs` (all schema/fixture pairs
      pass, including the updated `advisory-convergence.schema.json`
      `valid`/`invalid` fixtures)
- [x] `node scripts/sync-docs.mjs --apply` +
      `node scripts/audit-docs.mjs --check` (canonical/mirror docs in
      sync)
- [x] `pnpm run lint:minimum` (full chain incl.
      `verify-workshop-integrity.mjs`, cspell, markdownlint; all green)
- [x] `node scripts/idd-doctor.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for authorized provider-outage declarations to relieve the advisory convergence readiness gate when qualifying outage conditions are met.
  * Added outage-relief status and activation timing to readiness summaries.

* **Documentation**
  * Clarified that only declarations for the exact advisory convergence service affect readiness checks.

* **Bug Fixes**
  * Improved timestamp handling and validation for waiver and outage-based readiness decisions.
  * Ensured invalid or unauthorized declarations fail closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->