### PR TITLE
docs(idd-review-fix): require PR body sync when a round changes a self-review claim

### DIFF
--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -154,9 +154,11 @@ still runs immediately before push.
 
 **PR body sync.** If this round's fix changes a claim the PR body's
 self-review section makes (round count, a documented residual
-limitation, a scope statement), update the PR body in the same push
-(`gh pr edit {pr-number} --body-file <path>` or equivalent) — not
-just the code/docs.
+limitation, a scope statement), fetch the current full body, edit
+only that section in the fetched copy, and post the full result back
+(`gh pr edit {pr-number} --body-file <path>` replaces the whole
+body) in the same push — never a partial file, which would drop the
+closing-keyword line and other sections.
 
 ## E13 — Reply to feedback
 

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -158,7 +158,10 @@ limitation, a scope statement), fetch the current full body, edit
 only that section in the fetched copy, and post the full result back
 (`gh pr edit {pr-number} --body-file <path>` replaces the whole
 body) in the same push — never a partial file, which would drop the
-closing-keyword line and other sections.
+closing-keyword line and other sections. After posting, repeat D3.5's
+closing-set check (step 6) to confirm `closingIssuesReferences` still
+matches the deliberate set exactly — edited prose can introduce a
+stray keyword-adjacent reference.
 
 ## E13 — Reply to feedback
 

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -152,16 +152,18 @@ stays individual, and the
 [claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate)
 still runs immediately before push.
 
-**PR body sync.** If this round's fix changes a claim the PR body's
-self-review section makes (round count, a documented residual
-limitation, a scope statement), fetch the current full body, edit
-only that section in the fetched copy, and post the full result back
-(`gh pr edit {pr-number} --body-file <path>` replaces the whole
-body) in the same push — never a partial file, which would drop the
-closing-keyword line and other sections. After posting, repeat D3.5's
-closing-set check (step 6) to confirm `closingIssuesReferences` still
-matches the deliberate set exactly — edited prose can introduce a
-stray keyword-adjacent reference.
+**PR body sync.** If this round's fix changes a claim the PR body
+makes (round count, a documented residual limitation, a scope
+statement — wherever in the body it appears), re-run the claim
+revalidation gate immediately before this edit — it is a separate
+mutation after the already-gated push — then fetch the current full
+body, edit only that claim in the fetched copy, and post the full
+result back (`gh pr edit {pr-number} --body-file <path>` replaces the
+whole body, so never pass a partial file, which would drop the
+closing-keyword line and other sections). After posting, repeat
+D3.5's closing-set check (step 6) to confirm `closingIssuesReferences`
+still matches the deliberate set exactly — edited prose can introduce
+a stray keyword-adjacent reference.
 
 ## E13 — Reply to feedback
 

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -152,6 +152,12 @@ stays individual, and the
 [claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate)
 still runs immediately before push.
 
+**PR body sync.** If this round's fix changes a claim the PR body's
+self-review section makes (round count, a documented residual
+limitation, a scope statement), update the PR body in the same push
+(`gh pr edit {pr-number} --body-file <path>` or equivalent) — not
+just the code/docs.
+
 ## E13 — Reply to feedback
 
 For each Accepted PATH A item whose source is reviewer feedback (review

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -196,6 +196,11 @@ other GitHub side effect, confirm all of the following:
    fresh primary-bot re-review after every push. The per-HEAD
    `review-watermark` still invalidates on this push.
 10. Apply the pre-mutation guard immediately before this push.
+11. If this round's fix changes a claim the PR body's self-review
+    section makes (round count, a residual limitation, a scope
+    statement), update the PR body in the same push (`gh pr edit
+    {pr-number} --body-file <path>` or equivalent) — not just the
+    code/docs.
 
 ## E13 — Reply to feedback
 

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -198,9 +198,11 @@ other GitHub side effect, confirm all of the following:
 10. Apply the pre-mutation guard immediately before this push.
 11. If this round's fix changes a claim the PR body's self-review
     section makes (round count, a residual limitation, a scope
-    statement), update the PR body in the same push (`gh pr edit
-    {pr-number} --body-file <path>` or equivalent) — not just the
-    code/docs.
+    statement), fetch the current full body, edit only that section
+    in the fetched copy, and post the full result back with `gh pr
+    edit {pr-number} --body-file <path>` in the same push —
+    `--body-file` replaces the whole body, so never pass a partial
+    file (it would drop the closing-keyword line).
 
 ## E13 — Reply to feedback
 

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -202,7 +202,9 @@ other GitHub side effect, confirm all of the following:
     in the fetched copy, and post the full result back with `gh pr
     edit {pr-number} --body-file <path>` in the same push —
     `--body-file` replaces the whole body, so never pass a partial
-    file (it would drop the closing-keyword line).
+    file (it would drop the closing-keyword line). After posting,
+    repeat the lite pr-submit doc's step 5 closing-set check — edited
+    prose can introduce a stray keyword-adjacent reference.
 
 ## E13 — Reply to feedback
 

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -196,11 +196,12 @@ other GitHub side effect, confirm all of the following:
    fresh primary-bot re-review after every push. The per-HEAD
    `review-watermark` still invalidates on this push.
 10. Apply the pre-mutation guard immediately before this push.
-11. If this round's fix changes a claim the PR body's self-review
-    section makes (round count, a residual limitation, a scope
-    statement), fetch the current full body, edit only that section
-    in the fetched copy, and post the full result back in the same
-    push:
+11. Re-apply the pre-mutation guard immediately before this edit —
+    it is a separate mutation after the already-guarded push. If this
+    round's fix changes a claim the PR body makes (round count, a
+    residual limitation, a scope statement — wherever it appears),
+    fetch the current full body, edit only that claim in the fetched
+    copy, and post the full result back:
 
     ```sh
     gh pr edit {pr-number} --body-file <path>

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -199,8 +199,13 @@ other GitHub side effect, confirm all of the following:
 11. If this round's fix changes a claim the PR body's self-review
     section makes (round count, a residual limitation, a scope
     statement), fetch the current full body, edit only that section
-    in the fetched copy, and post the full result back with `gh pr
-    edit {pr-number} --body-file <path>` in the same push —
+    in the fetched copy, and post the full result back in the same
+    push:
+
+    ```sh
+    gh pr edit {pr-number} --body-file <path>
+    ```
+
     `--body-file` replaces the whole body, so never pass a partial
     file (it would drop the closing-keyword line). After posting,
     repeat the lite pr-submit doc's step 5 closing-set check — edited

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -147,6 +147,12 @@ stays individual, and the
 [claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate)
 still runs immediately before push.
 
+**PR body sync.** If this round's fix changes a claim the PR body's
+self-review section makes (round count, a documented residual
+limitation, a scope statement), update the PR body in the same push
+(`gh pr edit {pr-number} --body-file <path>` or equivalent) — not
+just the code/docs.
+
 ## E13 — Reply to feedback
 
 For each Accepted PATH A item whose source is reviewer feedback (review

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -149,9 +149,11 @@ still runs immediately before push.
 
 **PR body sync.** If this round's fix changes a claim the PR body's
 self-review section makes (round count, a documented residual
-limitation, a scope statement), update the PR body in the same push
-(`gh pr edit {pr-number} --body-file <path>` or equivalent) — not
-just the code/docs.
+limitation, a scope statement), fetch the current full body, edit
+only that section in the fetched copy, and post the full result back
+(`gh pr edit {pr-number} --body-file <path>` replaces the whole
+body) in the same push — never a partial file, which would drop the
+closing-keyword line and other sections.
 
 ## E13 — Reply to feedback
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -153,7 +153,10 @@ limitation, a scope statement), fetch the current full body, edit
 only that section in the fetched copy, and post the full result back
 (`gh pr edit {pr-number} --body-file <path>` replaces the whole
 body) in the same push — never a partial file, which would drop the
-closing-keyword line and other sections.
+closing-keyword line and other sections. After posting, repeat D3.5's
+closing-set check (step 6) to confirm `closingIssuesReferences` still
+matches the deliberate set exactly — edited prose can introduce a
+stray keyword-adjacent reference.
 
 ## E13 — Reply to feedback
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -147,16 +147,18 @@ stays individual, and the
 [claim revalidation gate](idd-overview-core.instructions.md#claim-revalidation-gate)
 still runs immediately before push.
 
-**PR body sync.** If this round's fix changes a claim the PR body's
-self-review section makes (round count, a documented residual
-limitation, a scope statement), fetch the current full body, edit
-only that section in the fetched copy, and post the full result back
-(`gh pr edit {pr-number} --body-file <path>` replaces the whole
-body) in the same push — never a partial file, which would drop the
-closing-keyword line and other sections. After posting, repeat D3.5's
-closing-set check (step 6) to confirm `closingIssuesReferences` still
-matches the deliberate set exactly — edited prose can introduce a
-stray keyword-adjacent reference.
+**PR body sync.** If this round's fix changes a claim the PR body
+makes (round count, a documented residual limitation, a scope
+statement — wherever in the body it appears), re-run the claim
+revalidation gate immediately before this edit — it is a separate
+mutation after the already-gated push — then fetch the current full
+body, edit only that claim in the fetched copy, and post the full
+result back (`gh pr edit {pr-number} --body-file <path>` replaces the
+whole body, so never pass a partial file, which would drop the
+closing-keyword line and other sections). After posting, repeat
+D3.5's closing-set check (step 6) to confirm `closingIssuesReferences`
+still matches the deliberate set exactly — edited prose can introduce
+a stray keyword-adjacent reference.
 
 ## E13 — Reply to feedback
 

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -197,7 +197,9 @@ other GitHub side effect, confirm all of the following:
     in the fetched copy, and post the full result back with `gh pr
     edit {pr-number} --body-file <path>` in the same push —
     `--body-file` replaces the whole body, so never pass a partial
-    file (it would drop the closing-keyword line).
+    file (it would drop the closing-keyword line). After posting,
+    repeat the lite pr-submit doc's step 5 closing-set check — edited
+    prose can introduce a stray keyword-adjacent reference.
 
 ## E13 — Reply to feedback
 

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -193,9 +193,11 @@ other GitHub side effect, confirm all of the following:
 10. Apply the pre-mutation guard immediately before this push.
 11. If this round's fix changes a claim the PR body's self-review
     section makes (round count, a residual limitation, a scope
-    statement), update the PR body in the same push (`gh pr edit
-    {pr-number} --body-file <path>` or equivalent) — not just the
-    code/docs.
+    statement), fetch the current full body, edit only that section
+    in the fetched copy, and post the full result back with `gh pr
+    edit {pr-number} --body-file <path>` in the same push —
+    `--body-file` replaces the whole body, so never pass a partial
+    file (it would drop the closing-keyword line).
 
 ## E13 — Reply to feedback
 

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -191,6 +191,11 @@ other GitHub side effect, confirm all of the following:
    fresh primary-bot re-review after every push. The per-HEAD
    `review-watermark` still invalidates on this push.
 10. Apply the pre-mutation guard immediately before this push.
+11. If this round's fix changes a claim the PR body's self-review
+    section makes (round count, a residual limitation, a scope
+    statement), update the PR body in the same push (`gh pr edit
+    {pr-number} --body-file <path>` or equivalent) — not just the
+    code/docs.
 
 ## E13 — Reply to feedback
 

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -194,8 +194,13 @@ other GitHub side effect, confirm all of the following:
 11. If this round's fix changes a claim the PR body's self-review
     section makes (round count, a residual limitation, a scope
     statement), fetch the current full body, edit only that section
-    in the fetched copy, and post the full result back with `gh pr
-    edit {pr-number} --body-file <path>` in the same push —
+    in the fetched copy, and post the full result back in the same
+    push:
+
+    ```sh
+    gh pr edit {pr-number} --body-file <path>
+    ```
+
     `--body-file` replaces the whole body, so never pass a partial
     file (it would drop the closing-keyword line). After posting,
     repeat the lite pr-submit doc's step 5 closing-set check — edited

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -191,11 +191,12 @@ other GitHub side effect, confirm all of the following:
    fresh primary-bot re-review after every push. The per-HEAD
    `review-watermark` still invalidates on this push.
 10. Apply the pre-mutation guard immediately before this push.
-11. If this round's fix changes a claim the PR body's self-review
-    section makes (round count, a residual limitation, a scope
-    statement), fetch the current full body, edit only that section
-    in the fetched copy, and post the full result back in the same
-    push:
+11. Re-apply the pre-mutation guard immediately before this edit —
+    it is a separate mutation after the already-guarded push. If this
+    round's fix changes a claim the PR body makes (round count, a
+    residual limitation, a scope statement — wherever it appears),
+    fetch the current full body, edit only that claim in the fetched
+    copy, and post the full result back:
 
     ```sh
     gh pr edit {pr-number} --body-file <path>


### PR DESCRIPTION
# Summary

The PR body's self-review section is composed once, during the
C-phase self-review loop, before any live-review round exists.
`idd-review-fix.instructions.md` covers responding to reviewer
findings and pushing fix commits, but had no step reminding an agent
to also update the PR body when a round's fix invalidates a claim it
makes (round count, a documented residual limitation, a scope
statement) — neither the full nor `lite` variant mentioned
`--body-file`/`gh pr edit` for updating the body at all.

In an observed adopter session, an agent updated code and docs each
review-fix round but never touched the PR's own self-review section;
by round five the body still described three rounds and a limitation
a later round had already closed, and a reviewer bot required a
sixth, dedicated round purely to reconcile the body — work the fix
itself did not otherwise need.

Adds a step to E12's fix-and-push flow, in both the full and `lite`
variants, worded to each file's existing level of detail: update the
PR body in the same push when a round's fix changes a claim it makes.

## Linked issue

Closes #2250

## Follow-up issues (if any)

- [ ] none

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4230 tests, unchanged — documentation only)
- [x] `node scripts/audit-docs.mjs --check` (both byte-budget bundles
      — `bundle-review` and `bundle-review-fix-lite` — clean)
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (not applicable)

Additional: one round of the repository's CodeRabbit C1 critique
delegate — zero findings.

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (documentation only; no change to
      any merge gate)
- [x] Context budget impact reviewed (`audit-docs.mjs --check`
      passed; `bundle-review-fix-lite` moved from ~95.2% to ~95.9%
      utilization, still under its limit)
