### PR TITLE
docs(idd-work): caveat B1 for WorkTrunk cwd diagnostic

### DIFF
--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -205,9 +205,9 @@ not continue to B2 from the primary worktree. Repair by removing the
 misplaced branch (after confirming no work is lost) and recreating the
 sibling worktree through the Worktree creation steps above.
 
-If WorkTrunk reports its `shell integration installed but not active`
-diagnostic, re-verify the current working directory on every later
-command — see
+If WorkTrunk reports its `Cannot change directory — shell integration
+installed but not active` diagnostic, re-verify the current working
+directory on every later command — see
 [rationale](../../docs/idd-design-rationale.md#worktrunk-cwd-caveat).
 
 ## B2 — Create and refine plan

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -205,6 +205,10 @@ not continue to B2 from the primary worktree. Repair by removing the
 misplaced branch (after confirming no work is lost) and recreating the
 sibling worktree through the Worktree creation steps above.
 
+If WorkTrunk reports its `shell integration installed but not active`
+diagnostic, re-verify cwd on every later command — see
+[rationale](../../docs/idd-design-rationale.md#worktrunk-cwd-caveat).
+
 ## B2 — Create and refine plan
 
 ### B2.0 — Supersession re-check (before planning)

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -206,7 +206,8 @@ misplaced branch (after confirming no work is lost) and recreating the
 sibling worktree through the Worktree creation steps above.
 
 If WorkTrunk reports its `shell integration installed but not active`
-diagnostic, re-verify cwd on every later command — see
+diagnostic, re-verify the current working directory on every later
+command — see
 [rationale](../../docs/idd-design-rationale.md#worktrunk-cwd-caveat).
 
 ## B2 — Create and refine plan

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -118,6 +118,10 @@ worktree removal) behind the
 31. Repair a contract violation by removing the misplaced branch from the
     primary worktree, after confirming no work is lost, then recreate the
     sibling worktree from step 12.
+32. If WorkTrunk reported `Cannot change directory — shell integration
+    installed but not active`, treat every later command's working
+    directory as unverified until confirmed (e.g. `pwd`), not only at
+    steps 27-29.
 
 ## B2 — Create and refine plan
 

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -341,6 +341,11 @@ self-check gives no signal to keep re-verifying the working directory after
 this diagnostic appears, even though the "working directory persists between
 commands" assumption can silently stop holding from that point on (#2332).
 
+**What to do**: once this diagnostic appears, treat the working directory
+as unverified for every later command in the session — confirm it (e.g.
+`pwd`) before trusting a command that depends on the current directory,
+rather than assuming it still matches the last-known worktree.
+
 ### B2.1 — Premise verification (decision-transcription issues)
 
 Field evidence showed a worker asked to transcribe a maintainer's

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -325,6 +325,23 @@ install-deps idempotency contract is preserved — the wrapper never
 deletes or resets state, so reruns in fresh, reused, or recreated
 worktrees still need no manual cleanup (#1237).
 
+### WorkTrunk cwd caveat
+
+An adopter session, using WorkTrunk's automation-safe invocation (`wt
+switch --create ... -x true`), observed a `Cannot change directory —
+shell integration installed but not active` diagnostic that did not
+fail the command. From that point onward, the agent harness's own tool
+output repeatedly reported the shell's working directory as reverted to
+the primary worktree root, even immediately after a command that had
+run correctly in the sibling worktree. Attribution between the
+harness's own cwd tracking and WorkTrunk's shell-integration hook could
+not be isolated (no control-group session was available), so this
+stays a documented structural gap in B1's guidance, not a claim against
+either component: the one-time B1 self-check gives no signal to keep
+re-verifying cwd after this diagnostic appears, even though the
+"working directory persists between commands" assumption can silently
+stop holding from that point on (#2332).
+
 ### B2.1 — Premise verification (decision-transcription issues)
 
 Field evidence showed a worker asked to transcribe a maintainer's

--- a/docs/idd-design-rationale.md
+++ b/docs/idd-design-rationale.md
@@ -329,18 +329,17 @@ worktrees still need no manual cleanup (#1237).
 
 An adopter session, using WorkTrunk's automation-safe invocation (`wt
 switch --create ... -x true`), observed a `Cannot change directory —
-shell integration installed but not active` diagnostic that did not
-fail the command. From that point onward, the agent harness's own tool
-output repeatedly reported the shell's working directory as reverted to
-the primary worktree root, even immediately after a command that had
-run correctly in the sibling worktree. Attribution between the
-harness's own cwd tracking and WorkTrunk's shell-integration hook could
-not be isolated (no control-group session was available), so this
-stays a documented structural gap in B1's guidance, not a claim against
-either component: the one-time B1 self-check gives no signal to keep
-re-verifying cwd after this diagnostic appears, even though the
-"working directory persists between commands" assumption can silently
-stop holding from that point on (#2332).
+shell integration installed but not active` diagnostic that did not fail
+the command. From that point onward, the agent harness's own tool output
+repeatedly reported the shell's working directory as reverted to the primary
+worktree root, even immediately after a command that had run correctly in the
+sibling worktree. Attribution between the harness's own working-directory
+tracking and WorkTrunk's shell-integration hook could not be isolated (no
+control-group session was available), so this stays a documented structural
+gap in B1's guidance, not a claim against either component: the one-time B1
+self-check gives no signal to keep re-verifying the working directory after
+this diagnostic appears, even though the "working directory persists between
+commands" assumption can silently stop holding from that point on (#2332).
 
 ### B2.1 — Premise verification (decision-transcription issues)
 

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -200,9 +200,9 @@ not continue to B2 from the primary worktree. Repair by removing the
 misplaced branch (after confirming no work is lost) and recreating the
 sibling worktree through the Worktree creation steps above.
 
-If WorkTrunk reports its `shell integration installed but not active`
-diagnostic, re-verify the current working directory on every later
-command — see
+If WorkTrunk reports its `Cannot change directory — shell integration
+installed but not active` diagnostic, re-verify the current working
+directory on every later command — see
 [rationale](../../docs/idd-design-rationale.md#worktrunk-cwd-caveat).
 
 ## B2 — Create and refine plan

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -200,6 +200,10 @@ not continue to B2 from the primary worktree. Repair by removing the
 misplaced branch (after confirming no work is lost) and recreating the
 sibling worktree through the Worktree creation steps above.
 
+If WorkTrunk reports its `shell integration installed but not active`
+diagnostic, re-verify cwd on every later command — see
+[rationale](../../docs/idd-design-rationale.md#worktrunk-cwd-caveat).
+
 ## B2 — Create and refine plan
 
 ### B2.0 — Supersession re-check (before planning)

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -201,7 +201,8 @@ misplaced branch (after confirming no work is lost) and recreating the
 sibling worktree through the Worktree creation steps above.
 
 If WorkTrunk reports its `shell integration installed but not active`
-diagnostic, re-verify cwd on every later command — see
+diagnostic, re-verify the current working directory on every later
+command — see
 [rationale](../../docs/idd-design-rationale.md#worktrunk-cwd-caveat).
 
 ## B2 — Create and refine plan

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -113,6 +113,10 @@ worktree removal) behind the
 31. Repair a contract violation by removing the misplaced branch from the
     primary worktree, after confirming no work is lost, then recreate the
     sibling worktree from step 12.
+32. If WorkTrunk reported `Cannot change directory — shell integration
+    installed but not active`, treat every later command's working
+    directory as unverified until confirmed (e.g. `pwd`), not only at
+    steps 27-29.
 
 ## B2 — Create and refine plan
 

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -343,6 +343,11 @@ after this diagnostic appears, even though the "working directory persists
 between commands" assumption can silently stop holding from that point
 on (kurone-kito/idd-skill#2332).
 
+**What to do**: once this diagnostic appears, treat the working directory
+as unverified for every later command in the session — confirm it (e.g.
+`pwd`) before trusting a command that depends on the current directory,
+rather than assuming it still matches the last-known worktree.
+
 ### B2.1 — Premise verification (decision-transcription issues)
 
 Field evidence showed a worker asked to transcribe a maintainer's

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -326,6 +326,24 @@ existing install-deps idempotency contract is preserved — the wrapper
 never deletes or resets state, so reruns in fresh, reused, or recreated
 worktrees still need no manual cleanup (kurone-kito/idd-skill#1237).
 
+### WorkTrunk cwd caveat
+
+An adopter session, using WorkTrunk's automation-safe invocation (`wt
+switch --create ... -x true`), observed a `Cannot change directory —
+shell integration installed but not active` diagnostic that did not
+fail the command. From that point onward, the agent harness's own tool
+output repeatedly reported the shell's working directory as reverted to
+the primary worktree root, even immediately after a command that had
+run correctly in the sibling worktree. Attribution between the
+harness's own cwd tracking and WorkTrunk's shell-integration hook could
+not be isolated (no control-group session was available), so this
+stays a documented structural gap in B1's guidance, not a claim against
+either component: the one-time B1 self-check gives no signal to keep
+re-verifying cwd after this diagnostic appears, even though the
+"working directory persists between commands" assumption can silently
+stop holding from that point on
+(kurone-kito/idd-skill#2332).
+
 ### B2.1 — Premise verification (decision-transcription issues)
 
 Field evidence showed a worker asked to transcribe a maintainer's

--- a/idd-template/docs/idd-design-rationale.md
+++ b/idd-template/docs/idd-design-rationale.md
@@ -330,19 +330,18 @@ worktrees still need no manual cleanup (kurone-kito/idd-skill#1237).
 
 An adopter session, using WorkTrunk's automation-safe invocation (`wt
 switch --create ... -x true`), observed a `Cannot change directory —
-shell integration installed but not active` diagnostic that did not
-fail the command. From that point onward, the agent harness's own tool
-output repeatedly reported the shell's working directory as reverted to
-the primary worktree root, even immediately after a command that had
-run correctly in the sibling worktree. Attribution between the
-harness's own cwd tracking and WorkTrunk's shell-integration hook could
-not be isolated (no control-group session was available), so this
-stays a documented structural gap in B1's guidance, not a claim against
-either component: the one-time B1 self-check gives no signal to keep
-re-verifying cwd after this diagnostic appears, even though the
-"working directory persists between commands" assumption can silently
-stop holding from that point on
-(kurone-kito/idd-skill#2332).
+shell integration installed but not active` diagnostic that did not fail
+the command. From that point onward, the agent harness's own tool output
+repeatedly reported the shell's working directory as reverted to the primary
+worktree root, even immediately after a command that had run correctly in the
+sibling worktree. Attribution between the harness's own working-directory
+tracking and WorkTrunk's shell-integration hook could not be isolated (no
+control-group session was available), so this stays a documented structural
+gap in B1's guidance, not a claim against either component: the one-time
+B1 self-check gives no signal to keep re-verifying the working directory
+after this diagnostic appears, even though the "working directory persists
+between commands" assumption can silently stop holding from that point
+on (kurone-kito/idd-skill#2332).
 
 ### B2.1 — Premise verification (decision-transcription issues)
 


### PR DESCRIPTION
## Summary

- Add a caveat to B1's self-check: once WorkTrunk reports its `shell integration installed but not active` diagnostic, treat every later command's working directory as unverified until independently confirmed, not only at the one-time B1 self-check.
- Full rationale lives in `docs/idd-design-rationale.md` (budget-exempt); `idd-work.instructions.md`'s B1 self-check carries only a minimal one-line cross-reference hook.
- Mirrored into the lite twin (`idd-work-lite.instructions.md`, self-contained condensed form since the lite bundle never cross-references `docs/`) and both `idd-template/` sync sources (canonical for these `concreted`/`exact`-mode pairs — edited there, regenerated locally via `sync-docs.mjs --apply`).

## Byte-budget note for reviewers

`bundle-work` (`idd-overview-appendix` + `idd-overview-core` + `idd-work.instructions.md`) had only ~27 bytes of headroom against its 45000-byte / 98%-utilization ceiling before this change — not enough for the hook alone. Funded it by de-duplicating the "Harness-native worktree tools" paragraph's repeated "never use it/them to create the B1 worktree" phrasing (stated once for `EnterWorktree`, then restated for Grok Build/subagent/`x.ai` tools, when the paragraph's closing sentence already generalizes "use the documented path instead" for any harness-native tool that can't pin both). No normative content was removed — same tools named, same `#1930` reference, same fallback instruction. After this change `bundle-work` sits at 97.90% utilization, so headroom remains near-zero; a future addition to this bundle will likely need the same treatment or a maintainer-authorized ceiling bump (the `#2181` precedent).

## Test plan

- [x] `node scripts/audit-docs.mjs --check` passes, including the `bundle-work` byte-budget check
- [x] `node scripts/audit-code-span-wrap.mjs` — no mid-token code-span wraps
- [x] `pnpm run typecheck`
- [x] `pnpm run build:check`
- [x] `npx dprint fmt "**/*.md"` / `npx markdownlint-cli2 "**/*.md"` — clean
- [x] `npx cspell lint "**" --no-progress` — clean
- [x] `node --test tests/*.test.mts` — 4261/4261 passing
- [x] `node scripts/verify-workshop-integrity.mjs --format table` — 0 issues

Closes #2332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtcjhuuXDqQASYGXtJnmV3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for verifying the working directory after shell-integration diagnostics during automated worktree operations.
  - Documented a caveat where command execution may unexpectedly return to the primary worktree.
  - Updated both standard and lightweight workflow instructions, including the corresponding template documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->