### PR TITLE
test(branch-flow): cover development-branch parity and fail-closed gates

### DIFF
--- a/tests/branch-conflict-state.test.mts
+++ b/tests/branch-conflict-state.test.mts
@@ -390,6 +390,34 @@ test('classifyBranchConflictState: BEHIND without conflict recommends merge-base
   assert.equal(result.baseAdvancedSinceMergeBase, true);
 });
 
+// #2274: the previous test's `baseRefName: 'main'` alone cannot prove the
+// generic (branch-name-neutral) `'merge-base'` value isn't coincidentally
+// correct for the default branch specifically -- rerun the same BEHIND
+// scenario against a non-default configured `{development-branch}` and
+// assert the identical, still branch-name-free recommendation.
+test('classifyBranchConflictState: BEHIND against a non-default development branch still recommends merge-base, not a main-specific value', async () => {
+  const prData = {
+    number: 203,
+    headRefOid: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+    baseRefOid: 'ffffffffffffffffffffffffffffffffffffffff',
+    headRefName: 'feature/behind-develop',
+    baseRefName: 'develop',
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'BEHIND',
+    headRepository: { id: 'R_test', name: 'test-repo' },
+  };
+  const result = await classifyBranchConflictState(203, {
+    owner: 'test-owner',
+    repo: 'test-repo',
+    _testPrData: prData,
+    _skipGitProbe: true,
+  });
+  assert.equal(result.branchState, 'behind-no-conflict');
+  assert.equal(result.syncRecommendation, 'merge-base');
+  assert.notEqual(result.syncRecommendation, 'merge-main');
+  assert.equal(result.baseAdvancedSinceMergeBase, true);
+});
+
 test('parseConflictFiles: parses content conflict lines', () => {
   const output = 'CONFLICT (content): Merge conflict in src/foo.ts\n';
   assert.deepEqual(parseConflictFiles(output), ['src/foo.ts']);

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -2490,19 +2490,45 @@ test('collectOkfFrontmatterViolations: misconfigured roots/types fail closed, no
 });
 
 // #2274: regression guard for #2271-#2273's development-branch migration --
-// finds every standalone `main` branch-token mention in the affected D/E/F
-// phase files and asserts each is on the small allowlist of lines already
-// known-legitimate (the B1 trusted-checkout contract, which intentionally
-// keeps the primary worktree pinned to `main` regardless of
-// `{development-branch}`, and one historical ruleset-name reference). A new,
-// unlisted `main` mention here means a D/E/F instruction has silently
-// reintroduced a main-only synchronization/target assumption.
-function findBareMainMentions(text: string): string[] {
+// finds every line carrying a standalone `main` branch-token mention in the
+// affected D/E/F phase files and asserts each line's exact (trimmed) text
+// equals one already-known-legitimate entry (the B1 trusted-checkout
+// contract, which intentionally keeps the primary worktree pinned to
+// `main` regardless of `{development-branch}`, and one historical
+// ruleset-name reference). Exact-line equality, not a substring/count
+// check, so an *additional* `main` mention appended to an otherwise
+// allowed line still fails: the trimmed line no longer matches any
+// allowlist entry (review round 1 -- a per-line-count check alone could
+// not distinguish a legitimate line from the same line with a second,
+// newly reintroduced `main` mention appended to it).
+function findBareMainLines(text: string): string[] {
   return text
     .split('\n')
     .filter((line) => /\bmain\b/.test(line))
     .map((line) => line.trim());
 }
+
+/** Lines outside `allowedLines` that carry a bare `main` mention. */
+function findUnallowedMainLines(
+  text: string,
+  allowedLines: ReadonlySet<string>,
+): string[] {
+  return findBareMainLines(text).filter((line) => !allowedLines.has(line));
+}
+
+const NO_MAIN_MENTIONS_ALLOWED = new Set<string>();
+
+const REVIEW_TRIAGE_ALLOWED_MAIN_LINES = new Set([
+  // A design-rationale anchor whose slug text embeds "main"
+  // (`#merge-main-livelock-...`) -- not a branch-sync instruction.
+  '[design rationale](../../docs/idd-design-rationale.md#merge-main-livelock-under-fast-moving-main)).',
+]);
+
+const MERGE_ALLOWED_MAIN_LINES = new Set([
+  // A historical, repository-specific ruleset-name reference, not a
+  // synchronization/target instruction.
+  'current `main` ruleset (`require_code_owner_review: false`), the',
+]);
 
 const B1_TRUSTED_CHECKOUT_MAIN_LINES = new Set([
   '1. Ensure the local `main` branch is up to date and has no local',
@@ -2520,50 +2546,47 @@ const B1_TRUSTED_CHECKOUT_MAIN_LINES = new Set([
   '`main` baseline — verify with a fresh-vs-stale `node_modules` comparison',
 ]);
 
-test('idd-pr-submit/idd-review-fix/idd-review-triage instructions carry zero bare `main` branch mentions (#2274)', () => {
+test('idd-pr-submit.instructions.md and idd-review-fix.instructions.md carry zero bare `main` branch mentions (#2274)', () => {
   for (const name of [
     'idd-pr-submit.instructions.md',
     'idd-review-fix.instructions.md',
   ]) {
     const text = readText(`idd-template/.github/instructions/${name}`);
     assert.deepEqual(
-      findBareMainMentions(text),
+      findUnallowedMainLines(text, NO_MAIN_MENTIONS_ALLOWED),
       [],
       `${name} must reference {development-branch}, not a bare "main"`,
     );
   }
-
-  // idd-review-triage.instructions.md keeps one design-rationale anchor
-  // whose slug text embeds "main" (`#merge-main-livelock-...`) -- not a
-  // branch-sync instruction. Assert that is the *only* survivor.
-  const triageText = readText(
-    'idd-template/.github/instructions/idd-review-triage.instructions.md',
-  );
-  const triageMainLines = findBareMainMentions(triageText);
-  assert.equal(triageMainLines.length, 1);
-  assert.match(triageMainLines[0], /merge-main-livelock/);
 });
 
-test('idd-merge.instructions.md carries only the known historical ruleset-name `main` mention (#2274)', () => {
+test('idd-review-triage.instructions.md confines its bare `main` mention to the known design-rationale anchor (#2274)', () => {
+  const text = readText(
+    'idd-template/.github/instructions/idd-review-triage.instructions.md',
+  );
+  assert.deepEqual(
+    findUnallowedMainLines(text, REVIEW_TRIAGE_ALLOWED_MAIN_LINES),
+    [],
+  );
+});
+
+test('idd-merge.instructions.md confines its bare `main` mention to the known historical ruleset-name reference (#2274)', () => {
   const text = readText(
     'idd-template/.github/instructions/idd-merge.instructions.md',
   );
-  const mainLines = findBareMainMentions(text);
-  assert.equal(mainLines.length, 1);
-  assert.match(mainLines[0], /current `main` ruleset/);
+  assert.deepEqual(findUnallowedMainLines(text, MERGE_ALLOWED_MAIN_LINES), []);
 });
 
 test('idd-work.instructions.md confines every bare `main` mention to the B1 trusted-checkout contract (#2274)', () => {
   const text = readText(
     'idd-template/.github/instructions/idd-work.instructions.md',
   );
-  const mainLines = findBareMainMentions(text);
-  assert.ok(mainLines.length > 0, 'sanity check: B1 still documents `main`');
-  const unrecognized = mainLines.filter(
-    (line) => !B1_TRUSTED_CHECKOUT_MAIN_LINES.has(line),
+  assert.ok(
+    findBareMainLines(text).length > 0,
+    'sanity check: B1 still documents `main`',
   );
   assert.deepEqual(
-    unrecognized,
+    findUnallowedMainLines(text, B1_TRUSTED_CHECKOUT_MAIN_LINES),
     [],
     'a `main` mention outside the B1 trusted-checkout allowlist regressed the {development-branch} migration',
   );

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -2488,3 +2488,83 @@ test('collectOkfFrontmatterViolations: misconfigured roots/types fail closed, no
   assert.equal(noTypes.length, 1);
   assert.match(noTypes[0], /types must be a non-empty array of type strings/);
 });
+
+// #2274: regression guard for #2271-#2273's development-branch migration --
+// finds every standalone `main` branch-token mention in the affected D/E/F
+// phase files and asserts each is on the small allowlist of lines already
+// known-legitimate (the B1 trusted-checkout contract, which intentionally
+// keeps the primary worktree pinned to `main` regardless of
+// `{development-branch}`, and one historical ruleset-name reference). A new,
+// unlisted `main` mention here means a D/E/F instruction has silently
+// reintroduced a main-only synchronization/target assumption.
+function findBareMainMentions(text: string): string[] {
+  return text
+    .split('\n')
+    .filter((line) => /\bmain\b/.test(line))
+    .map((line) => line.trim());
+}
+
+const B1_TRUSTED_CHECKOUT_MAIN_LINES = new Set([
+  '1. Ensure the local `main` branch is up to date and has no local',
+  'commits. Run this from the primary worktree while on `main`:',
+  'git fetch origin main',
+  'git log origin/main..main --oneline',
+  'If the second command outputs any lines, local `main` has unpushed',
+  'commits — stop and report, do not force-reset `main`. Otherwise,',
+  'git merge --ff-only origin/main',
+  'After this `main` fast-forward, do **not** change the primary',
+  "worktree's HEAD off `main` for any reason during B1 — see",
+  "The primary worktree's HEAD MUST remain on `main` throughout B1; if it",
+  'ever leaves `main`, stop immediately and follow the B1 self-check',
+  '`main`.',
+  '`main` baseline — verify with a fresh-vs-stale `node_modules` comparison',
+]);
+
+test('idd-pr-submit/idd-review-fix/idd-review-triage instructions carry zero bare `main` branch mentions (#2274)', () => {
+  for (const name of [
+    'idd-pr-submit.instructions.md',
+    'idd-review-fix.instructions.md',
+  ]) {
+    const text = readText(`idd-template/.github/instructions/${name}`);
+    assert.deepEqual(
+      findBareMainMentions(text),
+      [],
+      `${name} must reference {development-branch}, not a bare "main"`,
+    );
+  }
+
+  // idd-review-triage.instructions.md keeps one design-rationale anchor
+  // whose slug text embeds "main" (`#merge-main-livelock-...`) -- not a
+  // branch-sync instruction. Assert that is the *only* survivor.
+  const triageText = readText(
+    'idd-template/.github/instructions/idd-review-triage.instructions.md',
+  );
+  const triageMainLines = findBareMainMentions(triageText);
+  assert.equal(triageMainLines.length, 1);
+  assert.match(triageMainLines[0], /merge-main-livelock/);
+});
+
+test('idd-merge.instructions.md carries only the known historical ruleset-name `main` mention (#2274)', () => {
+  const text = readText(
+    'idd-template/.github/instructions/idd-merge.instructions.md',
+  );
+  const mainLines = findBareMainMentions(text);
+  assert.equal(mainLines.length, 1);
+  assert.match(mainLines[0], /current `main` ruleset/);
+});
+
+test('idd-work.instructions.md confines every bare `main` mention to the B1 trusted-checkout contract (#2274)', () => {
+  const text = readText(
+    'idd-template/.github/instructions/idd-work.instructions.md',
+  );
+  const mainLines = findBareMainMentions(text);
+  assert.ok(mainLines.length > 0, 'sanity check: B1 still documents `main`');
+  const unrecognized = mainLines.filter(
+    (line) => !B1_TRUSTED_CHECKOUT_MAIN_LINES.has(line),
+  );
+  assert.deepEqual(
+    unrecognized,
+    [],
+    'a `main` mention outside the B1 trusted-checkout allowlist regressed the {development-branch} migration',
+  );
+});

--- a/tests/idd-merge-execute.test.mts
+++ b/tests/idd-merge-execute.test.mts
@@ -272,8 +272,11 @@ test('every F3 gate maps to its own blocker', () => {
 // live merge-state re-check (`fetchMergeState`) is otherwise clean --
 // proves the gate holds `runMergeExecute` fail-closed all the way through
 // the deps injection boundary, not just at `evaluateMergeGates` in
-// isolation.
-test('runMergeExecute never calls mergePr for a PR targeting the wrong base branch, even with an otherwise-clean live merge state', () => {
+// isolation. Uses `--apply` (like the sibling "--apply on a blocked gate
+// fails closed" test above) -- a plain dry-run never calls `mergePr`
+// regardless of any blocker, so it would prove nothing about this gate
+// specifically (review round 1).
+test('--apply on a wrong-base PR fails closed without merging, even with an otherwise-clean live merge state', () => {
   const report = readyReport();
   report.developmentBranchTarget = {
     status: 'configured',
@@ -281,7 +284,10 @@ test('runMergeExecute never calls mergePr for a PR targeting the wrong base bran
     baseRefName: 'main',
   };
   const { deps, calls } = depsFor(report);
-  const { verdict, exitCode } = runMergeExecute(BASE_ARGS, deps);
+  const { verdict, exitCode } = runMergeExecute(
+    [...BASE_ARGS, '--apply'],
+    deps,
+  );
 
   assert.equal(verdict.ready, false);
   assert.deepEqual(
@@ -292,6 +298,7 @@ test('runMergeExecute never calls mergePr for a PR targeting the wrong base bran
   assert.equal(verdict.merged, false);
   assert.deepEqual(calls.merged, []);
   assert.deepEqual(calls.adminMerged, []);
+  assert.match(verdict.mergeResult, /not-ready/);
   assert.equal(exitCode, 1);
 });
 

--- a/tests/idd-merge-execute.test.mts
+++ b/tests/idd-merge-execute.test.mts
@@ -240,6 +240,20 @@ test('every F3 gate maps to its own blocker', () => {
           requiresUpToDateHeadSource: 'ruleset',
         }),
     ],
+    // #2274: `evaluateMergeGates` is `computePreMergeReadinessBlockers`
+    // verbatim (see its one-line definition above), so the #2272
+    // development-branch-target invariant already reaches F3 merge
+    // execution without any dedicated wiring here -- this case is the
+    // parity proof for that fact at this file's own entry point.
+    [
+      'development-branch-target',
+      (r) =>
+        (r.developmentBranchTarget = {
+          status: 'configured',
+          branch: 'develop',
+          baseRefName: 'main',
+        }),
+    ],
   ];
 
   for (const [gate, mutate] of cases) {
@@ -252,6 +266,33 @@ test('every F3 gate maps to its own blocker', () => {
       `expected sole blocker ${gate}`,
     );
   }
+});
+
+// #2274: a wrong-base PR must not merge even when the full CLI path's own
+// live merge-state re-check (`fetchMergeState`) is otherwise clean --
+// proves the gate holds `runMergeExecute` fail-closed all the way through
+// the deps injection boundary, not just at `evaluateMergeGates` in
+// isolation.
+test('runMergeExecute never calls mergePr for a PR targeting the wrong base branch, even with an otherwise-clean live merge state', () => {
+  const report = readyReport();
+  report.developmentBranchTarget = {
+    status: 'configured',
+    branch: 'develop',
+    baseRefName: 'main',
+  };
+  const { deps, calls } = depsFor(report);
+  const { verdict, exitCode } = runMergeExecute(BASE_ARGS, deps);
+
+  assert.equal(verdict.ready, false);
+  assert.deepEqual(
+    verdict.blockers.map((b) => b.gate),
+    ['development-branch-target'],
+  );
+  assert.match(verdict.blockers[0]?.detail ?? '', /"main".*"develop"/);
+  assert.equal(verdict.merged, false);
+  assert.deepEqual(calls.merged, []);
+  assert.deepEqual(calls.adminMerged, []);
+  assert.equal(exitCode, 1);
 });
 
 test('disposition-evidence blocks when route is proceed but blockingCount is non-zero', () => {


### PR DESCRIPTION
Closes #2274.

## Summary

Adds hermetic regression coverage for the #2271-#2273 development-branch
support so the offline test suite -- not just live CI against this
repository's own `main` -- proves the boundary stays deterministic for
any configured `{development-branch}`.

## Coverage audit (why the diff is small)

Before adding tests, I audited what #2271-#2273 already covered directly
against this issue's acceptance criteria:

- **Missing/malformed/invalid/unavailable development-branch evidence
  fails closed** -- already covered by `policy-helpers.test.mts`
  (`resolveEffectiveDevelopmentBranch`, `inspectDevelopmentBranch`),
  `pre-merge-readiness.test.mts` (`invalid`/`unavailable`/empty-string/
  unrecognized `developmentBranchTarget.status`), and
  `idd-onboard.test.mts` (`--record-policy` rejecting a malformed value
  and a branch absent from `origin`).
- **A wrong-base PR cannot reach merge-ready even with every other gate
  green** -- already covered by `pre-merge-readiness.test.mts`'s
  `'#2272: a PR base branch that differs from the effective development
  branch blocks, even with every other gate green'` test, built on the
  fully-green `clean.json` fixture.
- **Legacy default-branch fallback vs. an explicit branch through the
  same normalized inputs** -- already covered by
  `resolveEffectiveDevelopmentBranch`'s absent-policy and
  configured-policy tests.

This PR adds only the protocol boundaries that were genuinely
untested:

1. **`tests/branch-conflict-state.test.mts`**: the existing BEHIND
   `syncRecommendation: 'merge-base'` test used `baseRefName: 'main'`,
   which cannot distinguish "genuinely branch-name-neutral" from
   "coincidentally correct for the default branch." Added the identical
   scenario against `baseRefName: 'develop'`, asserting the same
   `'merge-base'` value and explicitly rejecting the removed
   `'merge-main'` value.
2. **`tests/idd-merge-execute.test.mts`**: `evaluateMergeGates` is
   `computePreMergeReadinessBlockers` verbatim, so the
   development-branch-target gate already reaches F3 merge execution
   with no dedicated wiring -- added a case to the existing
   table-driven "every F3 gate maps to its own blocker" test plus a
   `runMergeExecute`-level test proving `mergePr`/`mergePrAdmin` are
   never called for a wrong-base PR even when the live merge-state
   re-check reports clean.
3. **`tests/consistency.test.mts`**: a static regression guard reading
   the live `idd-template/.github/instructions/{idd-pr-submit,
   idd-review-fix,idd-review-triage,idd-merge}.instructions.md` content
   and asserting every bare `` `main` `` branch mention is on a small,
   named allowlist (the B1 trusted-checkout contract that intentionally
   keeps the primary worktree pinned to `main`, plus one historical
   ruleset-name reference) -- catches any future PR that silently
   reintroduces a literal `main`-only sync/target instruction outside
   that contract.

`ci-wait-state.mts`/`ci-wait-state.test.mts` were verified via code
reading (per #2272's own report) to already read the live `baseRefName`
from the PR payload with no `main`-specific logic; its `main()` CLI body
has no pure/testable seam without a source refactor, which felt like
scope creep for a test-only issue, so I left it uncovered directly and
noted the verification here instead.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm test` (4276/4276)
- [x] `pnpm run lint:minimum`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `pnpm run build:check`
- [x] `node scripts/idd-doctor.mjs` (passed; 3 pre-existing, unrelated warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safeguards for pull requests targeting non-default development branches.
  * Prevented merges when the target branch does not match the expected development branch.
  * Ensured synchronization recommendations remain accurate for pull requests behind their target branch.

* **Tests**
  * Added coverage to verify branch migration behavior and prevent outdated default-branch references in guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->