### PR TITLE
feat(token-cost): parse Grok session usage into samples

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -82,6 +82,7 @@ scripts/supersession-detection.mjs linguist-generated=true
 scripts/sync-docs.mjs linguist-generated=true
 scripts/token-cost-adapter-claude.mjs linguist-generated=true
 scripts/token-cost-adapter-codex.mjs linguist-generated=true
+scripts/token-cost-adapter-grok.mjs linguist-generated=true
 scripts/token-cost-core.mjs linguist-generated=true
 scripts/token-cost-report.mjs linguist-generated=true
 scripts/update-fixtures.mjs linguist-generated=true

--- a/scripts/token-cost-adapter-grok.mjs
+++ b/scripts/token-cost-adapter-grok.mjs
@@ -1,0 +1,449 @@
+// idd-generated-from: src/scripts/token-cost-adapter-grok.mts
+//
+// The scripts/token-cost-adapter-grok.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source,
+// never the generated .mjs. See docs/typescript-sources.md.
+//
+// Grok CLI adapter (#2289) for the token-cost measurement contract
+// (#2288). Source-repo only: not HELPER_COMMANDS, not idd-template/. A
+// pure library module -- no CLI, no shebang, mirroring
+// token-cost-core.mts's own shape -- so it needs no HELPER_COMMANDS
+// registration or SOURCE_REPO_INTERNAL_ENTRY_PATHS entry.
+//
+// Reads Grok CLI session directories
+// (`~/.grok/sessions/<url-encoded-cwd>/<session-id>/`), each holding
+// `updates.jsonl` (the ACP session update stream, where this module
+// looks for a per-update `usage` snapshot), an optional `signals.json`
+// (session rollup: `compactionCount`, `toolCallCount`, `modelsUsed`),
+// and an optional `events.jsonl` (compaction/turn records, used only
+// as the `compactionCount` fallback when `signals.json` is missing or
+// carries no usable count). `signals.json`'s `contextTokensUsed` is a
+// context-window metric, not a billed-usage figure `TokenCostUsage`
+// has a field for, and is deliberately left unread here. This module
+// documents the specific record shapes it reads as local structural
+// types; only the fields actually consumed are declared, and every
+// extraction degrades gracefully (never throws) except when the
+// harvested session has no usable timestamp or no derivable
+// vendorSessionId, either of which fails closed as a malformed
+// session.
+import { readdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
+import {
+  assertTokenCostSample,
+  inferIssueNumberFromBasename,
+  redactTokenCostRecord,
+} from './token-cost-core.mjs';
+
+function isPlainObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+function getStringField(obj, key) {
+  const value = obj?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+function getUsage(record) {
+  if (!isPlainObject(record)) {
+    return undefined;
+  }
+  const usage = record.usage;
+  return isPlainObject(usage) ? usage : undefined;
+}
+/** Parse a Grok session JSONL file's text into raw, untyped records, tolerating a malformed or truncated trailing line from an interrupted process (unlike token-cost-report.mts's committed-artifact strict parse, this reads real local logs outside this repo's control). */
+export function parseGrokSessionLines(text) {
+  const out = [];
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (line.length === 0) {
+      continue;
+    }
+    try {
+      out.push(JSON.parse(line));
+    } catch {}
+  }
+  return out;
+}
+/** Whether a session's cwd names an idd-skill worktree or clone. */
+export function isIddSkillCwd(cwd) {
+  return typeof cwd === 'string' && cwd.includes('idd-skill');
+}
+/** The first non-empty top-level `sessionId` across `records`, in file order. */
+function extractSessionId(records) {
+  for (const record of records) {
+    const id = isPlainObject(record)
+      ? getStringField(record, 'sessionId')
+      : undefined;
+    if (id) {
+      return id;
+    }
+  }
+  return undefined;
+}
+/**
+ * Normalizes with `path.basename()` first (never trusts a caller's
+ * `sessionIdBasename` to already be path-free) so a full path passed in
+ * by mistake can't survive into a path-like fallback `vendorSessionId`
+ * that `redactTokenCostRecord()` would later strip to `undefined`,
+ * silently producing a schema-invalid sample instead of failing closed.
+ */
+function deriveFallbackSessionId(sessionIdBasename) {
+  if (!sessionIdBasename) {
+    return undefined;
+  }
+  const stripped = basename(sessionIdBasename);
+  return stripped.length > 0 ? stripped : undefined;
+}
+/** The first non-empty top-level `cwd` across `records`, in file order -- a fallback for when the caller has no directory-derived cwd to pass in. */
+function extractCwdFromRecords(records) {
+  for (const record of records) {
+    const cwd = isPlainObject(record)
+      ? getStringField(record, 'cwd')
+      : undefined;
+    if (cwd) {
+      return cwd;
+    }
+  }
+  return undefined;
+}
+/** Most recently reported `model` string across every record, or undefined when none exists. */
+function extractModelFromRecords(records) {
+  let model;
+  for (const record of records) {
+    const candidate = isPlainObject(record)
+      ? getStringField(record, 'model')
+      : undefined;
+    if (candidate) {
+      model = candidate;
+    }
+  }
+  return model;
+}
+/** The last entry of `signals.modelsUsed`, when it is a non-empty array of strings. */
+function extractModelFromSignals(signals) {
+  if (!isPlainObject(signals) || !Array.isArray(signals.modelsUsed)) {
+    return undefined;
+  }
+  for (let i = signals.modelsUsed.length - 1; i >= 0; i--) {
+    const candidate = signals.modelsUsed[i];
+    if (typeof candidate === 'string' && candidate.length > 0) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+function toValidTimestamp(value) {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  return Number.isFinite(Date.parse(value)) ? value : undefined;
+}
+/** First and last valid record `timestamp` fields, in file order. Undefined when no record has one. */
+function extractTimestamps(records) {
+  let startedAt;
+  let endedAt;
+  for (const record of records) {
+    if (!isPlainObject(record)) {
+      continue;
+    }
+    const ts = toValidTimestamp(record.timestamp);
+    if (!ts) {
+      continue;
+    }
+    if (startedAt === undefined) {
+      startedAt = ts;
+    }
+    endedAt = ts;
+  }
+  return startedAt !== undefined && endedAt !== undefined
+    ? { startedAt, endedAt }
+    : undefined;
+}
+function toNonNegativeInt(value) {
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : 0;
+}
+const ZERO_USAGE = {
+  inputUncached: 0,
+  cacheRead: 0,
+  cacheCreation: 0,
+  output: 0,
+  reasoning: 0,
+};
+function addUsage(a, b) {
+  return {
+    inputUncached: a.inputUncached + b.inputUncached,
+    cacheRead: a.cacheRead + b.cacheRead,
+    cacheCreation: a.cacheCreation + b.cacheCreation,
+    output: a.output + b.output,
+    reasoning: a.reasoning + b.reasoning,
+  };
+}
+/**
+ * Map one `usage` snapshot's raw fields to {@link TokenCostUsage}.
+ * `inputTokens` may already include the cache reads/writes it reports
+ * separately (an inclusive total) or may already exclude them
+ * (already-uncached) -- Grok does not flag which. Mirrors the Codex
+ * adapter's inclusive-check: when `inputTokens >= cachedReadTokens +
+ * cacheCreationTokens`, the total is inclusive, so `inputUncached` is
+ * the remainder after subtracting both; otherwise `inputTokens` is
+ * already exclusive of cache and is used as `inputUncached` directly.
+ * Kept in this one function (per fixture-per-shape, #2218's own lesson
+ * on regex precision applies equally to arithmetic: verify both shapes
+ * with a dedicated fixture rather than assuming one).
+ */
+function usageFromFields(raw) {
+  const inputTokens = toNonNegativeInt(raw.inputTokens);
+  const cacheRead = toNonNegativeInt(raw.cachedReadTokens);
+  const cacheCreation = toNonNegativeInt(raw.cacheCreationTokens);
+  const inputUncached =
+    inputTokens >= cacheRead + cacheCreation
+      ? inputTokens - cacheRead - cacheCreation
+      : inputTokens;
+  return {
+    inputUncached,
+    cacheRead,
+    cacheCreation,
+    output: toNonNegativeInt(raw.outputTokens),
+    reasoning: toNonNegativeInt(raw.reasoningTokens),
+  };
+}
+/** The last `usage` snapshot found across `records`, in file order -- treated as the session's cumulative running total, mirroring how Grok's own TUI reports a running token count. Undefined when no record carries one. */
+function extractLatestUsage(records) {
+  let latest;
+  for (const record of records) {
+    const usage = getUsage(record);
+    if (usage) {
+      latest = usageFromFields(usage);
+    }
+  }
+  return latest;
+}
+/** `signals.compactionCount`, when it is present and a finite number. */
+function extractCompactionCountFromSignals(signals) {
+  if (!isPlainObject(signals)) {
+    return undefined;
+  }
+  const value = signals.compactionCount;
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, Math.trunc(value))
+    : undefined;
+}
+/** A record whose `type` field names a compaction, matched by substring (case-insensitive) so a future vendor-added variant still counts without an enum update here. */
+function isCompactionEventRecord(record) {
+  if (!isPlainObject(record)) {
+    return false;
+  }
+  const type = getStringField(record, 'type');
+  return type !== undefined && /compact/i.test(type);
+}
+/** `signals.compactionCount` when present; otherwise counts compaction-named `eventRecords` (some short sessions have no `signals.json`). */
+function extractCompactionCount(signals, eventRecords) {
+  const fromSignals = extractCompactionCountFromSignals(signals);
+  if (fromSignals !== undefined) {
+    return fromSignals;
+  }
+  let count = 0;
+  for (const record of eventRecords) {
+    if (isCompactionEventRecord(record)) {
+      count += 1;
+    }
+  }
+  return count;
+}
+/** `signals.toolCallCount`, when it is present and a finite number. */
+function extractToolCallCount(signals) {
+  if (!isPlainObject(signals)) {
+    return undefined;
+  }
+  const value = signals.toolCallCount;
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, Math.trunc(value))
+    : undefined;
+}
+function asGrokHarvestInput(input) {
+  if (!isPlainObject(input) || !Array.isArray(input.updateRecords)) {
+    throw new Error(
+      'token-cost-adapter-grok: harvest input must be { updateRecords: unknown[] }',
+    );
+  }
+  return {
+    updateRecords: input.updateRecords,
+    signals: input.signals,
+    eventRecords: Array.isArray(input.eventRecords)
+      ? input.eventRecords
+      : undefined,
+    sessionIdBasename:
+      typeof input.sessionIdBasename === 'string'
+        ? input.sessionIdBasename
+        : undefined,
+    cwd: typeof input.cwd === 'string' ? input.cwd : undefined,
+    subagentUpdateRecords: Array.isArray(input.subagentUpdateRecords)
+      ? input.subagentUpdateRecords
+      : undefined,
+  };
+}
+/** Grok CLI vendor adapter. `input` must satisfy {@link GrokHarvestInput}. */
+export const grokAdapter = {
+  harvest(input) {
+    const {
+      updateRecords,
+      signals,
+      eventRecords = [],
+      sessionIdBasename,
+      cwd: providedCwd,
+      subagentUpdateRecords = [],
+    } = asGrokHarvestInput(input);
+    const vendorSessionId =
+      extractSessionId(updateRecords) ??
+      deriveFallbackSessionId(sessionIdBasename);
+    if (!vendorSessionId) {
+      throw new Error(
+        'token-cost-adapter-grok: unable to determine a vendorSessionId',
+      );
+    }
+    const timestamps = extractTimestamps(updateRecords);
+    if (!timestamps) {
+      throw new Error(
+        'token-cost-adapter-grok: no record has a valid timestamp',
+      );
+    }
+    const cwd = providedCwd ?? extractCwdFromRecords(updateRecords);
+    const issueNumber = cwd
+      ? inferIssueNumberFromBasename(basename(cwd))
+      : undefined;
+    let usage = extractLatestUsage(updateRecords) ?? ZERO_USAGE;
+    for (const subagentRecords of subagentUpdateRecords) {
+      const subagentUsage = extractLatestUsage(subagentRecords);
+      if (subagentUsage) {
+        usage = addUsage(usage, subagentUsage);
+      }
+    }
+    const sample = {
+      schemaVersion: 1,
+      kind: 'session',
+      vendor: 'grok',
+      model:
+        extractModelFromSignals(signals) ??
+        extractModelFromRecords(updateRecords) ??
+        'unknown',
+      attribution: 'session-unscoped',
+      outcome: 'unknown',
+      usage,
+      compactionCount: extractCompactionCount(signals, eventRecords),
+      startedAt: timestamps.startedAt,
+      endedAt: timestamps.endedAt,
+      vendorSessionId,
+      toolCallCount: extractToolCallCount(signals),
+      includesSubagents: subagentUpdateRecords.length > 0,
+    };
+    const redacted = redactTokenCostRecord(sample);
+    assertTokenCostSample(redacted);
+    return issueNumber === undefined
+      ? { sample: redacted }
+      : { sample: redacted, joinHints: { issueNumber } };
+  },
+};
+/** `~/.grok/sessions`, the default session root. */
+export function defaultGrokSessionsDir() {
+  return join(homedir(), '.grok', 'sessions');
+}
+/**
+ * Decodes one `~/.grok/sessions/<url-encoded-cwd>` directory-tree
+ * segment back to the working-directory path it names ("organized by
+ * URL-encoded working directory", per Grok CLI's own session-persistence
+ * documentation). Returns the raw segment unchanged if it is not valid
+ * percent-encoding, rather than throwing.
+ */
+export function decodeGrokEncodedCwd(encoded) {
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return encoded;
+  }
+}
+function readJsonlIfPresent(path) {
+  try {
+    return parseGrokSessionLines(readFileSync(path, 'utf8'));
+  } catch {
+    return [];
+  }
+}
+function readJsonIfPresent(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+function listSubdirNames(dir) {
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+/** Each subagent session directory's own `updates.jsonl`, parsed, when a `subagents/` subdirectory exists under `sessionDir`. */
+function readSubagentUpdateRecords(sessionDir) {
+  const subagentsDir = join(sessionDir, 'subagents');
+  const out = [];
+  for (const subagentId of listSubdirNames(subagentsDir)) {
+    const records = readJsonlIfPresent(
+      join(subagentsDir, subagentId, 'updates.jsonl'),
+    );
+    if (records.length > 0) {
+      out.push(records);
+    }
+  }
+  return out;
+}
+/**
+ * Scan `sessionsDir` (default `~/.grok/sessions`) for
+ * `<url-encoded-cwd>/<session-id>/` session directories, keep only
+ * sessions whose decoded cwd names an idd-skill worktree or clone, roll
+ * each session's own `subagents/*\/updates.jsonl` into its parent, and
+ * harvest each into a {@link TokenCostAdapterResult}.
+ */
+export function scanGrokSessions(options) {
+  const sessionsDir = options?.sessionsDir ?? defaultGrokSessionsDir();
+  const results = [];
+  for (const encodedCwd of listSubdirNames(sessionsDir)) {
+    const cwd = decodeGrokEncodedCwd(encodedCwd);
+    if (!isIddSkillCwd(cwd)) {
+      continue;
+    }
+    const cwdDir = join(sessionsDir, encodedCwd);
+    for (const sessionId of listSubdirNames(cwdDir)) {
+      // Read, parse, and harvest all live inside one try: a live Grok
+      // session can still be writing (or an unrelated process can delete)
+      // a session file between listSubdirNames and this line, and
+      // harvest() itself throws on a malformed session (no usable
+      // timestamp/vendorSessionId) -- either failure must skip just this
+      // one session, never abort the whole scan.
+      try {
+        const sessionDir = join(cwdDir, sessionId);
+        const updateRecords = readJsonlIfPresent(
+          join(sessionDir, 'updates.jsonl'),
+        );
+        const signals = readJsonIfPresent(join(sessionDir, 'signals.json'));
+        const eventRecords = readJsonlIfPresent(
+          join(sessionDir, 'events.jsonl'),
+        );
+        const subagentUpdateRecords = readSubagentUpdateRecords(sessionDir);
+        results.push(
+          grokAdapter.harvest({
+            updateRecords,
+            signals,
+            eventRecords,
+            sessionIdBasename: sessionId,
+            cwd,
+            subagentUpdateRecords,
+          }),
+        );
+      } catch {}
+    }
+  }
+  return results;
+}

--- a/scripts/token-cost-adapter-grok.mjs
+++ b/scripts/token-cost-adapter-grok.mjs
@@ -337,6 +337,18 @@ export const grokAdapter = {
       includesSubagents: subagentUpdateRecords.length > 0,
     };
     const redacted = redactTokenCostRecord(sample);
+    // assertTokenCostSample does not check vendorSessionId (it is outside
+    // that function's cross-field-constraint scope), and redaction can, in
+    // principle, strip a vendorSessionId value that happens to look like a
+    // path or a secret -- which would silently omit the key rather than
+    // producing a visibly invalid sample. Fail closed instead of returning
+    // a schema-invalid result with a missing required field (CodeRabbit
+    // review, #2289).
+    if (!redacted.vendorSessionId) {
+      throw new Error(
+        'token-cost-adapter-grok: redaction removed vendorSessionId',
+      );
+    }
     assertTokenCostSample(redacted);
     return issueNumber === undefined
       ? { sample: redacted }

--- a/scripts/token-cost-adapter-grok.mjs
+++ b/scripts/token-cost-adapter-grok.mjs
@@ -67,14 +67,24 @@ export function parseGrokSessionLines(text) {
 export function isIddSkillCwd(cwd) {
   return typeof cwd === 'string' && cwd.includes('idd-skill');
 }
-/** The first non-empty top-level `sessionId` across `records`, in file order. */
+/**
+ * The first non-empty top-level `sessionId` across `records`, in file
+ * order, normalized with `path.basename()` -- the same guard
+ * {@link deriveFallbackSessionId} applies to its own fallback value, so a
+ * path-shaped `sessionId` (however unlikely for an opaque vendor ID) does
+ * not reach `redactTokenCostRecord()` and get silently stripped to
+ * `undefined` there instead (CodeRabbit review, #2289).
+ */
 function extractSessionId(records) {
   for (const record of records) {
     const id = isPlainObject(record)
       ? getStringField(record, 'sessionId')
       : undefined;
     if (id) {
-      return id;
+      const stripped = basename(id);
+      if (stripped.length > 0) {
+        return stripped;
+      }
     }
   }
   return undefined;
@@ -277,8 +287,13 @@ function asGrokHarvestInput(input) {
         ? input.sessionIdBasename
         : undefined,
     cwd: typeof input.cwd === 'string' ? input.cwd : undefined,
+    // Validate each inner element too, not just the outer array: a
+    // non-array inner element would otherwise reach extractLatestUsage's
+    // `for...of` and throw TypeError, breaking this module's documented
+    // graceful-degradation contract for malformed direct-caller input
+    // (CodeRabbit review, #2289).
     subagentUpdateRecords: Array.isArray(input.subagentUpdateRecords)
-      ? input.subagentUpdateRecords
+      ? input.subagentUpdateRecords.filter((records) => Array.isArray(records))
       : undefined,
   };
 }
@@ -397,17 +412,22 @@ function listSubdirNames(dir) {
     return [];
   }
 }
-/** Each subagent session directory's own `updates.jsonl`, parsed, when a `subagents/` subdirectory exists under `sessionDir`. */
+/**
+ * Each subagent session directory's own `updates.jsonl`, parsed, when a
+ * `subagents/` subdirectory exists under `sessionDir`. A subagent
+ * directory is kept even when its `updates.jsonl` is missing, unreadable,
+ * or empty (an empty array) -- `includesSubagents` reflects whether a
+ * subagent session *existed*, not whether it had harvestable usage data
+ * (Copilot review, #2289); `extractLatestUsage` already no-ops on an
+ * empty records array.
+ */
 function readSubagentUpdateRecords(sessionDir) {
   const subagentsDir = join(sessionDir, 'subagents');
   const out = [];
   for (const subagentId of listSubdirNames(subagentsDir)) {
-    const records = readJsonlIfPresent(
-      join(subagentsDir, subagentId, 'updates.jsonl'),
+    out.push(
+      readJsonlIfPresent(join(subagentsDir, subagentId, 'updates.jsonl')),
     );
-    if (records.length > 0) {
-      out.push(records);
-    }
   }
   return out;
 }

--- a/src/scripts/token-cost-adapter-grok.mts
+++ b/src/scripts/token-cost-adapter-grok.mts
@@ -1,0 +1,541 @@
+// idd-generated-from: src/scripts/token-cost-adapter-grok.mts
+//
+// The scripts/token-cost-adapter-grok.mjs copy is generated from the
+// .mts source named above by `pnpm run build`. Edit the .mts source,
+// never the generated .mjs. See docs/typescript-sources.md.
+//
+// Grok CLI adapter (#2289) for the token-cost measurement contract
+// (#2288). Source-repo only: not HELPER_COMMANDS, not idd-template/. A
+// pure library module -- no CLI, no shebang, mirroring
+// token-cost-core.mts's own shape -- so it needs no HELPER_COMMANDS
+// registration or SOURCE_REPO_INTERNAL_ENTRY_PATHS entry.
+//
+// Reads Grok CLI session directories
+// (`~/.grok/sessions/<url-encoded-cwd>/<session-id>/`), each holding
+// `updates.jsonl` (the ACP session update stream, where this module
+// looks for a per-update `usage` snapshot), an optional `signals.json`
+// (session rollup: `compactionCount`, `toolCallCount`, `modelsUsed`),
+// and an optional `events.jsonl` (compaction/turn records, used only
+// as the `compactionCount` fallback when `signals.json` is missing or
+// carries no usable count). `signals.json`'s `contextTokensUsed` is a
+// context-window metric, not a billed-usage figure `TokenCostUsage`
+// has a field for, and is deliberately left unread here. This module
+// documents the specific record shapes it reads as local structural
+// types; only the fields actually consumed are declared, and every
+// extraction degrades gracefully (never throws) except when the
+// harvested session has no usable timestamp or no derivable
+// vendorSessionId, either of which fails closed as a malformed
+// session.
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
+import {
+  assertTokenCostSample,
+  inferIssueNumberFromBasename,
+  redactTokenCostRecord,
+  type TokenCostAdapterResult,
+  type TokenCostSessionSample,
+  type TokenCostUsage,
+  type TokenCostVendorAdapter,
+} from './token-cost-core.mts';
+
+/** Raw token-usage fields a Grok updates.jsonl record's `usage` snapshot reports. */
+interface GrokTokenUsageFields {
+  inputTokens?: unknown;
+  cachedReadTokens?: unknown;
+  cacheCreationTokens?: unknown;
+  outputTokens?: unknown;
+  reasoningTokens?: unknown;
+}
+
+/** Grok session harvest input: one session's parsed files, plus its subagents' updates.jsonl records (already parsed, never raw text -- this module never reads a filesystem path itself). */
+export interface GrokHarvestInput {
+  /** Parsed updates.jsonl records, in file order. */
+  updateRecords: readonly unknown[];
+  /** Parsed signals.json content, when the file exists. */
+  signals?: unknown;
+  /** Parsed events.jsonl records, when the file exists. */
+  eventRecords?: readonly unknown[];
+  /** The `<session-id>` directory basename -- last-resort vendorSessionId fallback. */
+  sessionIdBasename?: string;
+  /** The session's URL-decoded working directory, when known -- the scanner derives this from the `<url-encoded-cwd>` directory-tree segment. */
+  cwd?: string;
+  /** Each subagent session's own parsed updates.jsonl records, rolled into this sample's usage total. */
+  subagentUpdateRecords?: readonly (readonly unknown[])[];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getStringField(
+  obj: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = obj?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function getUsage(record: unknown): Record<string, unknown> | undefined {
+  if (!isPlainObject(record)) {
+    return undefined;
+  }
+  const usage = record.usage;
+  return isPlainObject(usage) ? usage : undefined;
+}
+
+/** Parse a Grok session JSONL file's text into raw, untyped records, tolerating a malformed or truncated trailing line from an interrupted process (unlike token-cost-report.mts's committed-artifact strict parse, this reads real local logs outside this repo's control). */
+export function parseGrokSessionLines(text: string): unknown[] {
+  const out: unknown[] = [];
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (line.length === 0) {
+      continue;
+    }
+    try {
+      out.push(JSON.parse(line));
+    } catch {}
+  }
+  return out;
+}
+
+/** Whether a session's cwd names an idd-skill worktree or clone. */
+export function isIddSkillCwd(cwd: string | undefined): boolean {
+  return typeof cwd === 'string' && cwd.includes('idd-skill');
+}
+
+/** The first non-empty top-level `sessionId` across `records`, in file order. */
+function extractSessionId(records: readonly unknown[]): string | undefined {
+  for (const record of records) {
+    const id = isPlainObject(record)
+      ? getStringField(record, 'sessionId')
+      : undefined;
+    if (id) {
+      return id;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Normalizes with `path.basename()` first (never trusts a caller's
+ * `sessionIdBasename` to already be path-free) so a full path passed in
+ * by mistake can't survive into a path-like fallback `vendorSessionId`
+ * that `redactTokenCostRecord()` would later strip to `undefined`,
+ * silently producing a schema-invalid sample instead of failing closed.
+ */
+function deriveFallbackSessionId(
+  sessionIdBasename: string | undefined,
+): string | undefined {
+  if (!sessionIdBasename) {
+    return undefined;
+  }
+  const stripped = basename(sessionIdBasename);
+  return stripped.length > 0 ? stripped : undefined;
+}
+
+/** The first non-empty top-level `cwd` across `records`, in file order -- a fallback for when the caller has no directory-derived cwd to pass in. */
+function extractCwdFromRecords(
+  records: readonly unknown[],
+): string | undefined {
+  for (const record of records) {
+    const cwd = isPlainObject(record)
+      ? getStringField(record, 'cwd')
+      : undefined;
+    if (cwd) {
+      return cwd;
+    }
+  }
+  return undefined;
+}
+
+/** Most recently reported `model` string across every record, or undefined when none exists. */
+function extractModelFromRecords(
+  records: readonly unknown[],
+): string | undefined {
+  let model: string | undefined;
+  for (const record of records) {
+    const candidate = isPlainObject(record)
+      ? getStringField(record, 'model')
+      : undefined;
+    if (candidate) {
+      model = candidate;
+    }
+  }
+  return model;
+}
+
+/** The last entry of `signals.modelsUsed`, when it is a non-empty array of strings. */
+function extractModelFromSignals(signals: unknown): string | undefined {
+  if (!isPlainObject(signals) || !Array.isArray(signals.modelsUsed)) {
+    return undefined;
+  }
+  for (let i = signals.modelsUsed.length - 1; i >= 0; i--) {
+    const candidate = signals.modelsUsed[i];
+    if (typeof candidate === 'string' && candidate.length > 0) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function toValidTimestamp(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  return Number.isFinite(Date.parse(value)) ? value : undefined;
+}
+
+/** First and last valid record `timestamp` fields, in file order. Undefined when no record has one. */
+function extractTimestamps(
+  records: readonly unknown[],
+): { startedAt: string; endedAt: string } | undefined {
+  let startedAt: string | undefined;
+  let endedAt: string | undefined;
+  for (const record of records) {
+    if (!isPlainObject(record)) {
+      continue;
+    }
+    const ts = toValidTimestamp(record.timestamp);
+    if (!ts) {
+      continue;
+    }
+    if (startedAt === undefined) {
+      startedAt = ts;
+    }
+    endedAt = ts;
+  }
+  return startedAt !== undefined && endedAt !== undefined
+    ? { startedAt, endedAt }
+    : undefined;
+}
+
+function toNonNegativeInt(value: unknown): number {
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : 0;
+}
+
+const ZERO_USAGE: TokenCostUsage = {
+  inputUncached: 0,
+  cacheRead: 0,
+  cacheCreation: 0,
+  output: 0,
+  reasoning: 0,
+};
+
+function addUsage(a: TokenCostUsage, b: TokenCostUsage): TokenCostUsage {
+  return {
+    inputUncached: a.inputUncached + b.inputUncached,
+    cacheRead: a.cacheRead + b.cacheRead,
+    cacheCreation: a.cacheCreation + b.cacheCreation,
+    output: a.output + b.output,
+    reasoning: a.reasoning + b.reasoning,
+  };
+}
+
+/**
+ * Map one `usage` snapshot's raw fields to {@link TokenCostUsage}.
+ * `inputTokens` may already include the cache reads/writes it reports
+ * separately (an inclusive total) or may already exclude them
+ * (already-uncached) -- Grok does not flag which. Mirrors the Codex
+ * adapter's inclusive-check: when `inputTokens >= cachedReadTokens +
+ * cacheCreationTokens`, the total is inclusive, so `inputUncached` is
+ * the remainder after subtracting both; otherwise `inputTokens` is
+ * already exclusive of cache and is used as `inputUncached` directly.
+ * Kept in this one function (per fixture-per-shape, #2218's own lesson
+ * on regex precision applies equally to arithmetic: verify both shapes
+ * with a dedicated fixture rather than assuming one).
+ */
+function usageFromFields(raw: GrokTokenUsageFields): TokenCostUsage {
+  const inputTokens = toNonNegativeInt(raw.inputTokens);
+  const cacheRead = toNonNegativeInt(raw.cachedReadTokens);
+  const cacheCreation = toNonNegativeInt(raw.cacheCreationTokens);
+  const inputUncached =
+    inputTokens >= cacheRead + cacheCreation
+      ? inputTokens - cacheRead - cacheCreation
+      : inputTokens;
+  return {
+    inputUncached,
+    cacheRead,
+    cacheCreation,
+    output: toNonNegativeInt(raw.outputTokens),
+    reasoning: toNonNegativeInt(raw.reasoningTokens),
+  };
+}
+
+/** The last `usage` snapshot found across `records`, in file order -- treated as the session's cumulative running total, mirroring how Grok's own TUI reports a running token count. Undefined when no record carries one. */
+function extractLatestUsage(
+  records: readonly unknown[],
+): TokenCostUsage | undefined {
+  let latest: TokenCostUsage | undefined;
+  for (const record of records) {
+    const usage = getUsage(record);
+    if (usage) {
+      latest = usageFromFields(usage as GrokTokenUsageFields);
+    }
+  }
+  return latest;
+}
+
+/** `signals.compactionCount`, when it is present and a finite number. */
+function extractCompactionCountFromSignals(
+  signals: unknown,
+): number | undefined {
+  if (!isPlainObject(signals)) {
+    return undefined;
+  }
+  const value = signals.compactionCount;
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, Math.trunc(value))
+    : undefined;
+}
+
+/** A record whose `type` field names a compaction, matched by substring (case-insensitive) so a future vendor-added variant still counts without an enum update here. */
+function isCompactionEventRecord(record: unknown): boolean {
+  if (!isPlainObject(record)) {
+    return false;
+  }
+  const type = getStringField(record, 'type');
+  return type !== undefined && /compact/i.test(type);
+}
+
+/** `signals.compactionCount` when present; otherwise counts compaction-named `eventRecords` (some short sessions have no `signals.json`). */
+function extractCompactionCount(
+  signals: unknown,
+  eventRecords: readonly unknown[],
+): number {
+  const fromSignals = extractCompactionCountFromSignals(signals);
+  if (fromSignals !== undefined) {
+    return fromSignals;
+  }
+  let count = 0;
+  for (const record of eventRecords) {
+    if (isCompactionEventRecord(record)) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/** `signals.toolCallCount`, when it is present and a finite number. */
+function extractToolCallCount(signals: unknown): number | undefined {
+  if (!isPlainObject(signals)) {
+    return undefined;
+  }
+  const value = signals.toolCallCount;
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, Math.trunc(value))
+    : undefined;
+}
+
+function asGrokHarvestInput(input: unknown): GrokHarvestInput {
+  if (!isPlainObject(input) || !Array.isArray(input.updateRecords)) {
+    throw new Error(
+      'token-cost-adapter-grok: harvest input must be { updateRecords: unknown[] }',
+    );
+  }
+  return {
+    updateRecords: input.updateRecords,
+    signals: input.signals,
+    eventRecords: Array.isArray(input.eventRecords)
+      ? input.eventRecords
+      : undefined,
+    sessionIdBasename:
+      typeof input.sessionIdBasename === 'string'
+        ? input.sessionIdBasename
+        : undefined,
+    cwd: typeof input.cwd === 'string' ? input.cwd : undefined,
+    subagentUpdateRecords: Array.isArray(input.subagentUpdateRecords)
+      ? (input.subagentUpdateRecords as readonly (readonly unknown[])[])
+      : undefined,
+  };
+}
+
+/** Grok CLI vendor adapter. `input` must satisfy {@link GrokHarvestInput}. */
+export const grokAdapter: TokenCostVendorAdapter = {
+  harvest(input: unknown): TokenCostAdapterResult {
+    const {
+      updateRecords,
+      signals,
+      eventRecords = [],
+      sessionIdBasename,
+      cwd: providedCwd,
+      subagentUpdateRecords = [],
+    } = asGrokHarvestInput(input);
+
+    const vendorSessionId =
+      extractSessionId(updateRecords) ??
+      deriveFallbackSessionId(sessionIdBasename);
+    if (!vendorSessionId) {
+      throw new Error(
+        'token-cost-adapter-grok: unable to determine a vendorSessionId',
+      );
+    }
+
+    const timestamps = extractTimestamps(updateRecords);
+    if (!timestamps) {
+      throw new Error(
+        'token-cost-adapter-grok: no record has a valid timestamp',
+      );
+    }
+
+    const cwd = providedCwd ?? extractCwdFromRecords(updateRecords);
+    const issueNumber = cwd
+      ? inferIssueNumberFromBasename(basename(cwd))
+      : undefined;
+
+    let usage = extractLatestUsage(updateRecords) ?? ZERO_USAGE;
+    for (const subagentRecords of subagentUpdateRecords) {
+      const subagentUsage = extractLatestUsage(subagentRecords);
+      if (subagentUsage) {
+        usage = addUsage(usage, subagentUsage);
+      }
+    }
+
+    const sample: TokenCostSessionSample = {
+      schemaVersion: 1,
+      kind: 'session',
+      vendor: 'grok',
+      model:
+        extractModelFromSignals(signals) ??
+        extractModelFromRecords(updateRecords) ??
+        'unknown',
+      attribution: 'session-unscoped',
+      outcome: 'unknown',
+      usage,
+      compactionCount: extractCompactionCount(signals, eventRecords),
+      startedAt: timestamps.startedAt,
+      endedAt: timestamps.endedAt,
+      vendorSessionId,
+      toolCallCount: extractToolCallCount(signals),
+      includesSubagents: subagentUpdateRecords.length > 0,
+    };
+
+    const redacted = redactTokenCostRecord(sample) as TokenCostSessionSample;
+    assertTokenCostSample(redacted);
+
+    return issueNumber === undefined
+      ? { sample: redacted }
+      : { sample: redacted, joinHints: { issueNumber } };
+  },
+};
+
+/** `~/.grok/sessions`, the default session root. */
+export function defaultGrokSessionsDir(): string {
+  return join(homedir(), '.grok', 'sessions');
+}
+
+/**
+ * Decodes one `~/.grok/sessions/<url-encoded-cwd>` directory-tree
+ * segment back to the working-directory path it names ("organized by
+ * URL-encoded working directory", per Grok CLI's own session-persistence
+ * documentation). Returns the raw segment unchanged if it is not valid
+ * percent-encoding, rather than throwing.
+ */
+export function decodeGrokEncodedCwd(encoded: string): string {
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return encoded;
+  }
+}
+
+function readJsonlIfPresent(path: string): unknown[] {
+  try {
+    return parseGrokSessionLines(readFileSync(path, 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+function readJsonIfPresent(path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+function listSubdirNames(dir: string): string[] {
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/** Each subagent session directory's own `updates.jsonl`, parsed, when a `subagents/` subdirectory exists under `sessionDir`. */
+function readSubagentUpdateRecords(sessionDir: string): unknown[][] {
+  const subagentsDir = join(sessionDir, 'subagents');
+  const out: unknown[][] = [];
+  for (const subagentId of listSubdirNames(subagentsDir)) {
+    const records = readJsonlIfPresent(
+      join(subagentsDir, subagentId, 'updates.jsonl'),
+    );
+    if (records.length > 0) {
+      out.push(records);
+    }
+  }
+  return out;
+}
+
+export interface ScanGrokSessionsOptions {
+  /** Override the session root. Tests must always pass this -- never scan the real home directory. */
+  sessionsDir?: string;
+}
+
+/**
+ * Scan `sessionsDir` (default `~/.grok/sessions`) for
+ * `<url-encoded-cwd>/<session-id>/` session directories, keep only
+ * sessions whose decoded cwd names an idd-skill worktree or clone, roll
+ * each session's own `subagents/*\/updates.jsonl` into its parent, and
+ * harvest each into a {@link TokenCostAdapterResult}.
+ */
+export function scanGrokSessions(
+  options?: ScanGrokSessionsOptions,
+): TokenCostAdapterResult[] {
+  const sessionsDir = options?.sessionsDir ?? defaultGrokSessionsDir();
+  const results: TokenCostAdapterResult[] = [];
+
+  for (const encodedCwd of listSubdirNames(sessionsDir)) {
+    const cwd = decodeGrokEncodedCwd(encodedCwd);
+    if (!isIddSkillCwd(cwd)) {
+      continue;
+    }
+    const cwdDir = join(sessionsDir, encodedCwd);
+    for (const sessionId of listSubdirNames(cwdDir)) {
+      // Read, parse, and harvest all live inside one try: a live Grok
+      // session can still be writing (or an unrelated process can delete)
+      // a session file between listSubdirNames and this line, and
+      // harvest() itself throws on a malformed session (no usable
+      // timestamp/vendorSessionId) -- either failure must skip just this
+      // one session, never abort the whole scan.
+      try {
+        const sessionDir = join(cwdDir, sessionId);
+        const updateRecords = readJsonlIfPresent(
+          join(sessionDir, 'updates.jsonl'),
+        );
+        const signals = readJsonIfPresent(join(sessionDir, 'signals.json'));
+        const eventRecords = readJsonlIfPresent(
+          join(sessionDir, 'events.jsonl'),
+        );
+        const subagentUpdateRecords = readSubagentUpdateRecords(sessionDir);
+        results.push(
+          grokAdapter.harvest({
+            updateRecords,
+            signals,
+            eventRecords,
+            sessionIdBasename: sessionId,
+            cwd,
+            subagentUpdateRecords,
+          } satisfies GrokHarvestInput),
+        );
+      } catch {}
+    }
+  }
+  return results;
+}

--- a/src/scripts/token-cost-adapter-grok.mts
+++ b/src/scripts/token-cost-adapter-grok.mts
@@ -413,6 +413,18 @@ export const grokAdapter: TokenCostVendorAdapter = {
     };
 
     const redacted = redactTokenCostRecord(sample) as TokenCostSessionSample;
+    // assertTokenCostSample does not check vendorSessionId (it is outside
+    // that function's cross-field-constraint scope), and redaction can, in
+    // principle, strip a vendorSessionId value that happens to look like a
+    // path or a secret -- which would silently omit the key rather than
+    // producing a visibly invalid sample. Fail closed instead of returning
+    // a schema-invalid result with a missing required field (CodeRabbit
+    // review, #2289).
+    if (!redacted.vendorSessionId) {
+      throw new Error(
+        'token-cost-adapter-grok: redaction removed vendorSessionId',
+      );
+    }
     assertTokenCostSample(redacted);
 
     return issueNumber === undefined

--- a/src/scripts/token-cost-adapter-grok.mts
+++ b/src/scripts/token-cost-adapter-grok.mts
@@ -49,7 +49,7 @@ interface GrokTokenUsageFields {
   reasoningTokens?: unknown;
 }
 
-/** Grok session harvest input: one session's parsed files, plus its subagents' updates.jsonl records (already parsed, never raw text -- this module never reads a filesystem path itself). */
+/** Grok session harvest input: one session's parsed files, plus its subagents' updates.jsonl records (already parsed, never raw text -- harvest() itself never reads a filesystem path; scanGrokSessions() below does the actual file I/O and builds this input). */
 export interface GrokHarvestInput {
   /** Parsed updates.jsonl records, in file order. */
   updateRecords: readonly unknown[];
@@ -105,14 +105,24 @@ export function isIddSkillCwd(cwd: string | undefined): boolean {
   return typeof cwd === 'string' && cwd.includes('idd-skill');
 }
 
-/** The first non-empty top-level `sessionId` across `records`, in file order. */
+/**
+ * The first non-empty top-level `sessionId` across `records`, in file
+ * order, normalized with `path.basename()` -- the same guard
+ * {@link deriveFallbackSessionId} applies to its own fallback value, so a
+ * path-shaped `sessionId` (however unlikely for an opaque vendor ID) does
+ * not reach `redactTokenCostRecord()` and get silently stripped to
+ * `undefined` there instead (CodeRabbit review, #2289).
+ */
 function extractSessionId(records: readonly unknown[]): string | undefined {
   for (const record of records) {
     const id = isPlainObject(record)
       ? getStringField(record, 'sessionId')
       : undefined;
     if (id) {
-      return id;
+      const stripped = basename(id);
+      if (stripped.length > 0) {
+        return stripped;
+      }
     }
   }
   return undefined;
@@ -346,8 +356,15 @@ function asGrokHarvestInput(input: unknown): GrokHarvestInput {
         ? input.sessionIdBasename
         : undefined,
     cwd: typeof input.cwd === 'string' ? input.cwd : undefined,
+    // Validate each inner element too, not just the outer array: a
+    // non-array inner element would otherwise reach extractLatestUsage's
+    // `for...of` and throw TypeError, breaking this module's documented
+    // graceful-degradation contract for malformed direct-caller input
+    // (CodeRabbit review, #2289).
     subagentUpdateRecords: Array.isArray(input.subagentUpdateRecords)
-      ? (input.subagentUpdateRecords as readonly (readonly unknown[])[])
+      ? input.subagentUpdateRecords.filter((records): records is unknown[] =>
+          Array.isArray(records),
+        )
       : undefined,
   };
 }
@@ -480,17 +497,22 @@ function listSubdirNames(dir: string): string[] {
   }
 }
 
-/** Each subagent session directory's own `updates.jsonl`, parsed, when a `subagents/` subdirectory exists under `sessionDir`. */
+/**
+ * Each subagent session directory's own `updates.jsonl`, parsed, when a
+ * `subagents/` subdirectory exists under `sessionDir`. A subagent
+ * directory is kept even when its `updates.jsonl` is missing, unreadable,
+ * or empty (an empty array) -- `includesSubagents` reflects whether a
+ * subagent session *existed*, not whether it had harvestable usage data
+ * (Copilot review, #2289); `extractLatestUsage` already no-ops on an
+ * empty records array.
+ */
 function readSubagentUpdateRecords(sessionDir: string): unknown[][] {
   const subagentsDir = join(sessionDir, 'subagents');
   const out: unknown[][] = [];
   for (const subagentId of listSubdirNames(subagentsDir)) {
-    const records = readJsonlIfPresent(
-      join(subagentsDir, subagentId, 'updates.jsonl'),
+    out.push(
+      readJsonlIfPresent(join(subagentsDir, subagentId, 'updates.jsonl')),
     );
-    if (records.length > 0) {
-      out.push(records);
-    }
   }
   return out;
 }

--- a/tests/fixtures/token-cost/grok/events-two-compactions.jsonl
+++ b/tests/fixtures/token-cost/grok/events-two-compactions.jsonl
@@ -1,0 +1,4 @@
+{"timestamp":"2026-08-22T11:10:00.000Z","type":"turn_end"}
+{"timestamp":"2026-08-22T11:12:00.000Z","type":"compaction"}
+{"timestamp":"2026-08-22T11:16:00.000Z","type":"turn_end"}
+{"timestamp":"2026-08-22T11:18:00.000Z","type":"compaction"}

--- a/tests/fixtures/token-cost/grok/signals-basic.json
+++ b/tests/fixtures/token-cost/grok/signals-basic.json
@@ -1,0 +1,1 @@
+{"compactionCount":0,"contextTokensUsed":15000,"toolCallCount":6,"modelsUsed":["grok-4-fast"]}

--- a/tests/fixtures/token-cost/grok/updates-basic.jsonl
+++ b/tests/fixtures/token-cost/grok/updates-basic.jsonl
@@ -1,0 +1,3 @@
+{"timestamp":"2026-08-20T10:00:00.000Z","type":"session_start","sessionId":"grok-basic-0001","cwd":"/home/testuser/ghq/github.com/kurone-kito/idd-skill","model":"grok-4-fast"}
+{"timestamp":"2026-08-20T10:05:00.000Z","type":"agent_message_chunk","usage":{"inputTokens":8000,"cachedReadTokens":6000,"cacheCreationTokens":500,"outputTokens":400,"reasoningTokens":150}}
+{"timestamp":"2026-08-20T10:10:00.000Z","type":"agent_message_chunk","usage":{"inputTokens":15000,"cachedReadTokens":12000,"cacheCreationTokens":1000,"outputTokens":800,"reasoningTokens":300}}

--- a/tests/fixtures/token-cost/grok/updates-events-fallback.jsonl
+++ b/tests/fixtures/token-cost/grok/updates-events-fallback.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-08-22T11:00:00.000Z","type":"session_start","sessionId":"grok-events-0003","cwd":"/home/testuser/ghq/github.com/kurone-kito/idd-skill"}
+{"timestamp":"2026-08-22T11:20:00.000Z","type":"agent_message_chunk","usage":{"inputTokens":500,"cachedReadTokens":0,"cacheCreationTokens":0,"outputTokens":90,"reasoningTokens":10}}

--- a/tests/fixtures/token-cost/grok/updates-exclusive-input.jsonl
+++ b/tests/fixtures/token-cost/grok/updates-exclusive-input.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-08-21T09:00:00.000Z","type":"session_start","sessionId":"grok-exclusive-0002","cwd":"/home/testuser/ghq/github.com/kurone-kito/idd-skill","model":"grok-4-fast"}
+{"timestamp":"2026-08-21T09:05:00.000Z","type":"agent_message_chunk","usage":{"inputTokens":900,"cachedReadTokens":12000,"cacheCreationTokens":1000,"outputTokens":150,"reasoningTokens":40}}

--- a/tests/fixtures/token-cost/grok/updates-issue-worktree-cwd.jsonl
+++ b/tests/fixtures/token-cost/grok/updates-issue-worktree-cwd.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-08-24T07:00:00.000Z","type":"session_start","sessionId":"grok-worktree-0007","cwd":"/home/testuser/ghq/github.com/kurone-kito/idd-skill.issue-4242-fix-something","model":"grok-4-fast"}
+{"timestamp":"2026-08-24T07:05:00.000Z","type":"agent_message_chunk","usage":{"inputTokens":400,"cachedReadTokens":50,"cacheCreationTokens":0,"outputTokens":65,"reasoningTokens":15}}

--- a/tests/fixtures/token-cost/grok/updates-no-session-id.jsonl
+++ b/tests/fixtures/token-cost/grok/updates-no-session-id.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-08-23T08:00:00.000Z","type":"session_start","cwd":"/home/testuser/ghq/github.com/kurone-kito/idd-skill"}
+{"timestamp":"2026-08-23T08:05:00.000Z","type":"agent_message_chunk","usage":{"inputTokens":300,"cachedReadTokens":0,"cacheCreationTokens":0,"outputTokens":50,"reasoningTokens":0}}

--- a/tests/fixtures/token-cost/grok/updates-other-repo-cwd.jsonl
+++ b/tests/fixtures/token-cost/grok/updates-other-repo-cwd.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-08-25T06:00:00.000Z","type":"session_start","sessionId":"grok-other-0008","cwd":"/home/testuser/ghq/github.com/kurone-kito/some-other-repo","model":"grok-4-fast"}
+{"timestamp":"2026-08-25T06:05:00.000Z","type":"agent_message_chunk","usage":{"inputTokens":100,"cachedReadTokens":0,"cacheCreationTokens":0,"outputTokens":20,"reasoningTokens":0}}

--- a/tests/fixtures/token-cost/grok/updates-sensitive-fields.jsonl
+++ b/tests/fixtures/token-cost/grok/updates-sensitive-fields.jsonl
@@ -1,0 +1,3 @@
+{"timestamp":"2026-08-26T04:00:00.000Z","type":"session_start","sessionId":"grok-sensitive-0006","cwd":"/home/testuser/ghq/github.com/kurone-kito/idd-skill"}
+{"timestamp":"2026-08-26T04:00:05.000Z","type":"user_message_chunk","content":"here is my secret token ghp_abcdefghijklmnopqrstuvwx and the file at /home/kurone-kito/.ssh/id_rsa"}
+{"timestamp":"2026-08-26T04:10:00.000Z","type":"agent_message_chunk","usage":{"inputTokens":700,"cachedReadTokens":100,"cacheCreationTokens":0,"outputTokens":90,"reasoningTokens":10}}

--- a/tests/fixtures/token-cost/grok/updates-subagent.jsonl
+++ b/tests/fixtures/token-cost/grok/updates-subagent.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-08-27T05:01:00.000Z","type":"session_start","sessionId":"grok-subagent-child-0009"}
+{"timestamp":"2026-08-27T05:04:00.000Z","type":"agent_message_chunk","usage":{"inputTokens":200,"cachedReadTokens":0,"cacheCreationTokens":0,"outputTokens":40,"reasoningTokens":5}}

--- a/tests/token-cost-adapter-grok.test.mts
+++ b/tests/token-cost-adapter-grok.test.mts
@@ -1,0 +1,359 @@
+import assert from 'node:assert/strict';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import {
+  decodeGrokEncodedCwd,
+  grokAdapter,
+  isIddSkillCwd,
+  parseGrokSessionLines,
+  scanGrokSessions,
+} from '../src/scripts/token-cost-adapter-grok.mts';
+import { loadJson, validate } from '../src/scripts/validate-schemas.mts';
+
+const FIXTURE_DIR = 'tests/fixtures/token-cost/grok';
+
+function readFixtureRecords(name: string): unknown[] {
+  return parseGrokSessionLines(readFileSync(join(FIXTURE_DIR, name), 'utf8'));
+}
+
+function readFixtureJson(name: string): unknown {
+  return JSON.parse(readFileSync(join(FIXTURE_DIR, name), 'utf8'));
+}
+
+test('a total usage snapshot maps to a schema-valid sample with reasoning, preferring signals over record-scan for model and toolCallCount', () => {
+  const { sample, joinHints } = grokAdapter.harvest({
+    updateRecords: readFixtureRecords('updates-basic.jsonl'),
+    signals: readFixtureJson('signals-basic.json'),
+    sessionIdBasename: 'updates-basic',
+  });
+  assert.equal(sample.kind, 'session');
+  assert.equal(sample.vendor, 'grok');
+  assert.equal(sample.model, 'grok-4-fast');
+  assert.equal(sample.attribution, 'session-unscoped');
+  assert.equal(sample.outcome, 'unknown');
+  assert.equal(sample.vendorSessionId, 'grok-basic-0001');
+  // inputTokens (15000) >= cacheRead + cacheCreation (13000): inclusive
+  // total, so inputUncached is the remainder after subtracting both. The
+  // last usage snapshot in the file is treated as the session's
+  // cumulative running total, not summed with the earlier one.
+  assert.deepEqual(sample.usage, {
+    inputUncached: 2000,
+    cacheRead: 12000,
+    cacheCreation: 1000,
+    output: 800,
+    reasoning: 300,
+  });
+  assert.equal(sample.compactionCount, 0);
+  assert.equal(sample.toolCallCount, 6);
+  assert.equal(sample.includesSubagents, false);
+  assert.equal(sample.startedAt, '2026-08-20T10:00:00.000Z');
+  assert.equal(sample.endedAt, '2026-08-20T10:10:00.000Z');
+  // The fixture cwd basename ("idd-skill") carries no issue-<n> suffix.
+  assert.equal(joinHints, undefined);
+  assert.doesNotMatch(JSON.stringify(sample), /ghq|\/home\//);
+  assert.deepEqual(
+    validate(sample, loadJson('schemas/token-cost-sample.schema.json')),
+    [],
+  );
+});
+
+test('inputTokens below cacheRead+cacheCreation is already exclusive of cache', () => {
+  const { sample } = grokAdapter.harvest({
+    updateRecords: readFixtureRecords('updates-exclusive-input.jsonl'),
+  });
+  // inputTokens (900) < cacheRead + cacheCreation (13000): already
+  // exclusive, so inputTokens is used as inputUncached directly.
+  assert.deepEqual(sample.usage, {
+    inputUncached: 900,
+    cacheRead: 12000,
+    cacheCreation: 1000,
+    output: 150,
+    reasoning: 40,
+  });
+});
+
+test('compactionCount is read from signals.json when present', () => {
+  const { sample } = grokAdapter.harvest({
+    updateRecords: readFixtureRecords('updates-events-fallback.jsonl'),
+    signals: { compactionCount: 2 },
+  });
+  assert.equal(sample.compactionCount, 2);
+});
+
+test('compactionCount falls back to counting compaction-named events when signals.json is missing', () => {
+  const { sample } = grokAdapter.harvest({
+    updateRecords: readFixtureRecords('updates-events-fallback.jsonl'),
+    eventRecords: readFixtureRecords('events-two-compactions.jsonl'),
+  });
+  assert.equal(sample.compactionCount, 2);
+});
+
+test('compactionCount is 0 when neither signals.json nor events.jsonl is present', () => {
+  const { sample } = grokAdapter.harvest({
+    updateRecords: readFixtureRecords('updates-events-fallback.jsonl'),
+  });
+  assert.equal(sample.compactionCount, 0);
+});
+
+test('model falls back to scanning update records when signals.json has no modelsUsed', () => {
+  const { sample } = grokAdapter.harvest({
+    updateRecords: readFixtureRecords('updates-basic.jsonl'),
+  });
+  assert.equal(sample.model, 'grok-4-fast');
+});
+
+test('model is "unknown" when neither signals.modelsUsed nor any record carries a model', () => {
+  const { sample } = grokAdapter.harvest({
+    updateRecords: readFixtureRecords('updates-no-session-id.jsonl'),
+    sessionIdBasename: 'updates-no-session-id',
+  });
+  assert.equal(sample.model, 'unknown');
+});
+
+test('a missing sessionId field falls back to the session-id directory basename', () => {
+  const { sample } = grokAdapter.harvest({
+    updateRecords: readFixtureRecords('updates-no-session-id.jsonl'),
+    sessionIdBasename: 'updates-no-session-id',
+  });
+  assert.equal(sample.vendorSessionId, 'updates-no-session-id');
+});
+
+test('a worktree cwd with an issue number yields joinHints.issueNumber, never a path string', () => {
+  const { sample, joinHints } = grokAdapter.harvest({
+    updateRecords: readFixtureRecords('updates-issue-worktree-cwd.jsonl'),
+  });
+  assert.deepEqual(joinHints, { issueNumber: 4242 });
+  assert.doesNotMatch(JSON.stringify(sample), /ghq|\/home\//);
+});
+
+test('adapter output never carries a leaked secret or absolute path from raw records', () => {
+  const { sample } = grokAdapter.harvest({
+    updateRecords: readFixtureRecords('updates-sensitive-fields.jsonl'),
+  });
+  const serialized = JSON.stringify(sample);
+  assert.doesNotMatch(serialized, /ghp_/);
+  assert.doesNotMatch(serialized, /\.ssh/);
+  assert.doesNotMatch(serialized, /\/home\//);
+  assert.equal(sample.vendorSessionId, 'grok-sensitive-0006');
+});
+
+test('subagent updates.jsonl records are summed into the parent usage and includesSubagents is set', () => {
+  const { sample } = grokAdapter.harvest({
+    updateRecords: readFixtureRecords('updates-basic.jsonl'),
+    signals: readFixtureJson('signals-basic.json'),
+    subagentUpdateRecords: [readFixtureRecords('updates-subagent.jsonl')],
+  });
+  assert.equal(sample.includesSubagents, true);
+  assert.deepEqual(sample.usage, {
+    inputUncached: 2000 + 200,
+    cacheRead: 12000,
+    cacheCreation: 1000,
+    output: 800 + 40,
+    reasoning: 300 + 5,
+  });
+});
+
+test('parseGrokSessionLines tolerates a truncated trailing line', () => {
+  const records = parseGrokSessionLines(
+    '{"type":"session_start","cwd":"/x/idd-skill"}\n{"type":"agent_message_c',
+  );
+  assert.equal(records.length, 1);
+});
+
+test('isIddSkillCwd only matches an idd-skill cwd', () => {
+  assert.equal(isIddSkillCwd('/home/me/ghq/github.com/x/idd-skill'), true);
+  assert.equal(
+    isIddSkillCwd('/home/me/ghq/github.com/x/some-other-repo'),
+    false,
+  );
+  assert.equal(isIddSkillCwd(undefined), false);
+});
+
+test('decodeGrokEncodedCwd decodes a URL-encoded working directory, and passes an invalid segment through unchanged', () => {
+  assert.equal(
+    decodeGrokEncodedCwd(
+      encodeURIComponent('/home/testuser/ghq/github.com/kurone-kito/idd-skill'),
+    ),
+    '/home/testuser/ghq/github.com/kurone-kito/idd-skill',
+  );
+  assert.equal(decodeGrokEncodedCwd('not%encoded%'), 'not%encoded%');
+});
+
+test('harvest rejects an input that is not { updateRecords: unknown[] }', () => {
+  assert.throws(() => grokAdapter.harvest('not an object'), /updateRecords/);
+  assert.throws(
+    () => grokAdapter.harvest({ updateRecords: 'not an array' }),
+    /updateRecords/,
+  );
+});
+
+test('harvest fails closed when no record has a valid timestamp', () => {
+  assert.throws(
+    () =>
+      grokAdapter.harvest({
+        updateRecords: [{ type: 'session_start', sessionId: 'sess-x' }],
+      }),
+    /timestamp/,
+  );
+});
+
+test('harvest fails closed when no vendorSessionId is derivable', () => {
+  assert.throws(
+    () =>
+      grokAdapter.harvest({
+        updateRecords: [{ timestamp: '2026-08-26T00:00:00.000Z' }],
+      }),
+    /vendorSessionId/,
+  );
+});
+
+function writeSessionDir(
+  sessionsDir: string,
+  encodedCwd: string,
+  sessionId: string,
+  fixtureName: string,
+  extras?: { signalsJson?: unknown; eventsFixtureName?: string },
+): string {
+  const sessionDir = join(sessionsDir, encodedCwd, sessionId);
+  mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(
+    join(sessionDir, 'updates.jsonl'),
+    readFileSync(join(FIXTURE_DIR, fixtureName), 'utf8'),
+  );
+  if (extras?.signalsJson !== undefined) {
+    writeFileSync(
+      join(sessionDir, 'signals.json'),
+      JSON.stringify(extras.signalsJson),
+    );
+  }
+  if (extras?.eventsFixtureName) {
+    writeFileSync(
+      join(sessionDir, 'events.jsonl'),
+      readFileSync(join(FIXTURE_DIR, extras.eventsFixtureName), 'utf8'),
+    );
+  }
+  return sessionDir;
+}
+
+test('scanGrokSessions keeps an idd-skill session and skips a non-idd-skill session, decoding the encoded-cwd directory name', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-token-cost-adapter-grok-test-'),
+  );
+  const iddCwd = '/home/testuser/ghq/github.com/kurone-kito/idd-skill';
+  const otherCwd = '/home/testuser/ghq/github.com/kurone-kito/some-other-repo';
+  writeSessionDir(
+    sandbox,
+    encodeURIComponent(iddCwd),
+    'grok-basic-0001',
+    'updates-basic.jsonl',
+    { signalsJson: readFixtureJson('signals-basic.json') },
+  );
+  writeSessionDir(
+    sandbox,
+    encodeURIComponent(otherCwd),
+    'grok-other-0008',
+    'updates-other-repo-cwd.jsonl',
+  );
+
+  const results = scanGrokSessions({ sessionsDir: sandbox });
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].sample.vendorSessionId, 'grok-basic-0001');
+});
+
+test('scanGrokSessions rolls a subagents/ subdirectory into the parent sample', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-token-cost-adapter-grok-test-'),
+  );
+  const iddCwd = '/home/testuser/ghq/github.com/kurone-kito/idd-skill';
+  const sessionDir = writeSessionDir(
+    sandbox,
+    encodeURIComponent(iddCwd),
+    'grok-basic-0001',
+    'updates-basic.jsonl',
+    { signalsJson: readFixtureJson('signals-basic.json') },
+  );
+  const subagentDir = join(sessionDir, 'subagents', 'grok-subagent-child-0009');
+  mkdirSync(subagentDir, { recursive: true });
+  writeFileSync(
+    join(subagentDir, 'updates.jsonl'),
+    readFileSync(join(FIXTURE_DIR, 'updates-subagent.jsonl'), 'utf8'),
+  );
+
+  const results = scanGrokSessions({ sessionsDir: sandbox });
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].sample.includesSubagents, true);
+  assert.equal(results[0].sample.usage.inputUncached, 2000 + 200);
+});
+
+test('scanGrokSessions skips a malformed session that fails to harvest, keeping the rest', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-token-cost-adapter-grok-test-'),
+  );
+  const iddCwd = '/home/testuser/ghq/github.com/kurone-kito/idd-skill';
+  const malformedDir = join(sandbox, encodeURIComponent(iddCwd), 'grok-bad');
+  mkdirSync(malformedDir, { recursive: true });
+  // Matches the idd-skill cwd filter but has no valid timestamp anywhere,
+  // so harvest() throws for this session specifically.
+  writeFileSync(
+    join(malformedDir, 'updates.jsonl'),
+    '{"type":"session_start","sessionId":"grok-bad"}\n',
+  );
+  writeSessionDir(
+    sandbox,
+    encodeURIComponent(iddCwd),
+    'grok-basic-0001',
+    'updates-basic.jsonl',
+  );
+
+  const results = scanGrokSessions({ sessionsDir: sandbox });
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].sample.vendorSessionId, 'grok-basic-0001');
+});
+
+test('scanGrokSessions skips an unreadable updates.jsonl, keeping the rest', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-token-cost-adapter-grok-test-'),
+  );
+  const iddCwd = '/home/testuser/ghq/github.com/kurone-kito/idd-skill';
+  const unreadableDir = writeSessionDir(
+    sandbox,
+    encodeURIComponent(iddCwd),
+    'grok-unreadable',
+    'updates-basic.jsonl',
+  );
+  const unreadableFile = join(unreadableDir, 'updates.jsonl');
+  chmodSync(unreadableFile, 0o000);
+  writeSessionDir(
+    sandbox,
+    encodeURIComponent(iddCwd),
+    'grok-exclusive-0002',
+    'updates-exclusive-input.jsonl',
+  );
+
+  try {
+    const results = scanGrokSessions({ sessionsDir: sandbox });
+    assert.equal(results.length, 1);
+    assert.equal(results[0].sample.vendorSessionId, 'grok-exclusive-0002');
+  } finally {
+    chmodSync(unreadableFile, 0o644);
+  }
+});
+
+test('scanGrokSessions on an empty directory returns no results', () => {
+  const sandbox = mkdtempSync(
+    join(tmpdir(), 'idd-token-cost-adapter-grok-test-'),
+  );
+  assert.deepEqual(scanGrokSessions({ sessionsDir: sandbox }), []);
+});

--- a/tests/token-cost-adapter-grok.test.mts
+++ b/tests/token-cost-adapter-grok.test.mts
@@ -216,6 +216,22 @@ test('harvest fails closed when no vendorSessionId is derivable', () => {
   );
 });
 
+test('harvest fails closed when redaction strips a path-shaped vendorSessionId, rather than returning a sample missing a required field -- #2289 (CodeRabbit)', () => {
+  assert.throws(
+    () =>
+      grokAdapter.harvest({
+        updateRecords: [
+          {
+            timestamp: '2026-08-26T00:00:00.000Z',
+            sessionId: '/tmp/leaked-path-session-id',
+            type: 'session_start',
+          },
+        ],
+      }),
+    /vendorSessionId/,
+  );
+});
+
 function writeSessionDir(
   sessionsDir: string,
   encodedCwd: string,

--- a/tests/token-cost-adapter-grok.test.mts
+++ b/tests/token-cost-adapter-grok.test.mts
@@ -52,6 +52,15 @@ test('a total usage snapshot maps to a schema-valid sample with reasoning, prefe
     output: 800,
     reasoning: 300,
   });
+  // The inclusive-total invariant itself, not just the hardcoded values
+  // above, so a later change to the inclusive/exclusive heuristic still
+  // fails this test even if it happens to preserve these exact numbers.
+  assert.equal(
+    sample.usage.inputUncached +
+      sample.usage.cacheRead +
+      sample.usage.cacheCreation,
+    15000,
+  );
   assert.equal(sample.compactionCount, 0);
   assert.equal(sample.toolCallCount, 6);
   assert.equal(sample.includesSubagents, false);
@@ -162,6 +171,35 @@ test('subagent updates.jsonl records are summed into the parent usage and includ
   });
 });
 
+test('includesSubagents is true even when a subagent directory has no harvestable updates.jsonl -- #2289 (Copilot)', () => {
+  // A subagent session directory existed (the caller pushed an entry),
+  // even though its updates.jsonl was missing/unreadable/empty. Presence
+  // of the directory, not usage data, drives includesSubagents.
+  const { sample } = grokAdapter.harvest({
+    updateRecords: readFixtureRecords('updates-basic.jsonl'),
+    signals: readFixtureJson('signals-basic.json'),
+    subagentUpdateRecords: [[]],
+  });
+  assert.equal(sample.includesSubagents, true);
+  assert.deepEqual(sample.usage, {
+    inputUncached: 2000,
+    cacheRead: 12000,
+    cacheCreation: 1000,
+    output: 800,
+    reasoning: 300,
+  });
+});
+
+test('harvest ignores a non-array inner subagentUpdateRecords element instead of throwing -- #2289 (CodeRabbit)', () => {
+  const { sample } = grokAdapter.harvest({
+    updateRecords: readFixtureRecords('updates-basic.jsonl'),
+    // The outer array passes Array.isArray; the inner element does not.
+    subagentUpdateRecords: [123, readFixtureRecords('updates-subagent.jsonl')],
+  });
+  assert.equal(sample.includesSubagents, true);
+  assert.equal(sample.usage.inputUncached, 2000 + 200);
+});
+
 test('parseGrokSessionLines tolerates a truncated trailing line', () => {
   const records = parseGrokSessionLines(
     '{"type":"session_start","cwd":"/x/idd-skill"}\n{"type":"agent_message_c',
@@ -216,14 +254,27 @@ test('harvest fails closed when no vendorSessionId is derivable', () => {
   );
 });
 
-test('harvest fails closed when redaction strips a path-shaped vendorSessionId, rather than returning a sample missing a required field -- #2289 (CodeRabbit)', () => {
+test('a path-shaped sessionId is normalized with basename() before redaction, so a session with an unusual but legitimate id still harvests -- #2289 (CodeRabbit)', () => {
+  const { sample } = grokAdapter.harvest({
+    updateRecords: [
+      {
+        timestamp: '2026-08-26T00:00:00.000Z',
+        sessionId: '/tmp/leaked-path-session-id',
+        type: 'session_start',
+      },
+    ],
+  });
+  assert.equal(sample.vendorSessionId, 'leaked-path-session-id');
+});
+
+test('harvest fails closed when redaction still strips a secret-shaped vendorSessionId (basename() does not change it), rather than returning a sample missing a required field -- #2289 (CodeRabbit)', () => {
   assert.throws(
     () =>
       grokAdapter.harvest({
         updateRecords: [
           {
             timestamp: '2026-08-26T00:00:00.000Z',
-            sessionId: '/tmp/leaked-path-session-id',
+            sessionId: 'ghp_abcdefghijklmnopqrstuvwx',
             type: 'session_start',
           },
         ],


### PR DESCRIPTION
# Summary

Add the Grok CLI adapter (`src/scripts/token-cost-adapter-grok.mts`)
for the token-cost measurement contract (#2288), mirroring the
existing Codex/Claude adapters' shape.

Reads `~/.grok/sessions/<url-encoded-cwd>/<session-id>/`:

- `updates.jsonl` — the ACP session update stream; the last per-update
  `usage` snapshot found is treated as the session's cumulative
  running total. `inputTokens` is treated as inclusive of cache when
  `inputTokens >= cachedReadTokens + cacheCreationTokens` (else
  already exclusive), mirroring the Codex adapter's own inclusive
  check, kept in one function with a fixture for each shape.
- `signals.json` (optional) — `compactionCount`, `toolCallCount`,
  `modelsUsed`. `contextTokensUsed` is a context-window metric, not a
  billed-usage figure `TokenCostUsage` has a field for, and is
  deliberately left unread.
- `events.jsonl` (optional) — used only as the `compactionCount`
  fallback (counting compaction-named records) when `signals.json` is
  missing or carries no usable count.

A session's own `subagents/*/updates.jsonl` directories are rolled
into the parent sample's usage total, and `includesSubagents` is set
when any exist. The scanner filters sessions by the `<url-encoded-cwd>`
directory segment (`decodeURIComponent`, matching Grok CLI's own
documented "organized by URL-encoded working directory" storage
layout) containing `idd-skill`, so other clones are ignored.

This is the Grok adapter only. It does not harvest GitHub state, write
the README, or add Claude/Codex parsers.

## Self-review

The exact `updates.jsonl`/`signals.json`/`events.jsonl` record shapes
are not fully documented publicly beyond the field names and directory
layout named in the issue (cross-checked against the local Grok CLI's
own `~/.grok/README.md` Session Persistence section for the directory
layout, which matches); this module documents the specific shapes it
reads as local structural types and degrades gracefully on anything
else, matching the sibling adapters' own stated convention. All tests
use tiny synthetic fixtures under `tests/fixtures/token-cost/grok/`,
never live `~/.grok` logs.

Closes #2289

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Parent roadmap: #2296. Blocked-by #2314 (context-tax → token-cost
rename) is already merged.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for collecting and analyzing Grok CLI token usage, including model, cache, reasoning, tool-call, compaction, session, and subagent metrics.
  - Added session scanning with filtering for relevant project worktrees.
  - Added validation and redaction of collected session samples.

- **Tests**
  - Added comprehensive coverage for usage aggregation, fallbacks, malformed sessions, sensitive-data handling, scanning, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->