### PR TITLE
feat(token-cost): add a dogfood phase-event helper and source-repo hooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -83,6 +83,7 @@ scripts/sync-docs.mjs linguist-generated=true
 scripts/token-cost-adapter-claude.mjs linguist-generated=true
 scripts/token-cost-adapter-codex.mjs linguist-generated=true
 scripts/token-cost-core.mjs linguist-generated=true
+scripts/token-cost-event.mjs linguist-generated=true
 scripts/token-cost-report.mjs linguist-generated=true
 scripts/update-fixtures.mjs linguist-generated=true
 scripts/validate-schemas.mjs linguist-generated=true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -148,6 +148,23 @@ routine substitute for a fresh Copilot review. See
 [`docs/idd-helper-scripts.md`](../docs/idd-helper-scripts.md#external-check-waiver-contract)
 for the general mechanism.
 
+## Dogfood: token-cost events
+
+This source repository records IDD phase-boundary timestamps as a local
+dogfooding measurement (`docs/token-cost.md`). Source-repo only — never
+add this call to `idd-template/` or `.github/instructions/` phase files,
+which distribute to adopters with no token-cost data to record.
+
+When running the IDD loop in this repository, call
+`node scripts/token-cost-event.mjs --stage <id> --enter --vendor <v>`
+when a listed stage starts, and the same with `--exit` when it ends.
+`schemas/token-cost-event.schema.json`'s `vendor` enum (`grok`, `claude`,
+`codex`) has no value for GitHub Copilot yet — skip this call rather
+than pass a mismatched vendor; a wrong tag would corrupt the shared
+dataset. Stage ids: `discover`, `claim`, `work`, `submit-pr`, `review`,
+`merge`, `cleanup`. Ignore any failure from this command — it must
+never block or slow the IDD loop.
+
 ## Commit rules
 
 This project follows

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,23 @@ entry path and phase routing. See
 [Model capability expectations](docs/idd-workflow.md#model-capability-expectations)
 before running this loop on a lightweight local or compact cloud model.
 
+## Dogfood: token-cost events
+
+This source repository records IDD phase-boundary timestamps as a local
+dogfooding measurement (`docs/token-cost.md`). Source-repo only — never
+add this call to `idd-template/` or `.github/instructions/` phase files,
+which distribute to adopters with no token-cost data to record.
+
+When running the IDD loop in this repository, call
+`node scripts/token-cost-event.mjs --stage <id> --enter --vendor <v>`
+when a listed stage starts, and the same with `--exit` when it ends,
+using `--vendor codex` for Codex CLI or `--vendor grok` for Grok Build.
+OpenCode has no matching `vendor` value in
+`schemas/token-cost-event.schema.json` yet — skip this call rather than
+pass a mismatched vendor. Stage ids: `discover`, `claim`, `work`,
+`submit-pr`, `review`, `merge`, `cleanup`. Ignore any failure from this
+command — it must never block or slow the IDD loop.
+
 ## Issue-authoring skill (dogfooded)
 
 The canonical issue-authoring skill bundle lives at

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,20 @@ entry path and phase routing. See
 [Model capability expectations](docs/idd-workflow.md#model-capability-expectations)
 before running this loop on a lightweight local or compact cloud model.
 
+## Dogfood: token-cost events
+
+This source repository records IDD phase-boundary timestamps as a local
+dogfooding measurement (`docs/token-cost.md`). Source-repo only — never
+add this call to `idd-template/` or `.github/instructions/` phase files,
+which distribute to adopters with no token-cost data to record.
+
+When Claude runs the IDD loop in this repository, call
+`node scripts/token-cost-event.mjs --stage <id> --enter --vendor claude`
+when a listed stage starts, and the same with `--exit` when it ends.
+Stage ids: `discover`, `claim`, `work`, `submit-pr`, `review`, `merge`,
+`cleanup`. Ignore any failure from this command — it must never block or
+slow the IDD loop.
+
 ## Issue-authoring skill (dogfooded)
 
 The canonical issue-authoring skill bundle lives at

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -119,6 +119,20 @@ entry path and phase routing. See
 [Model capability expectations](docs/idd-workflow.md#model-capability-expectations)
 before running this loop on a lightweight local or compact cloud model.
 
+## Dogfood: token-cost events
+
+This source repository records IDD phase-boundary timestamps as a local
+dogfooding measurement (`docs/token-cost.md`). Source-repo only — never
+add this call to `idd-template/` or `.github/instructions/` phase files,
+which distribute to adopters with no token-cost data to record.
+
+`schemas/token-cost-event.schema.json`'s `vendor` enum has no value for
+Antigravity yet (`grok`, `claude`, `codex` only), so skip calling
+`node scripts/token-cost-event.mjs` for now rather than passing a
+mismatched vendor — a wrong tag would corrupt the shared dataset.
+Stage ids, for when a vendor value exists: `discover`, `claim`, `work`,
+`submit-pr`, `review`, `merge`, `cleanup`.
+
 ## Issue-authoring skill (dogfooded)
 
 The canonical issue-authoring skill bundle lives at

--- a/scripts/token-cost-event.mjs
+++ b/scripts/token-cost-event.mjs
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/token-cost-event.mts
+//
+// The scripts/token-cost-event.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Source-repo-only dogfood phase-event helper (#2293), called from
+// source-repo agent guidelines only (CLAUDE.md / AGENTS.md / GEMINI.md /
+// .github/copilot-instructions.md's "Dogfood: token-cost events" note) --
+// never from idd-template/ or .github/instructions/, which distribute to
+// adopters with no token-cost data to record. Appends one explicit
+// phase enter/exit line (schemas/token-cost-event.schema.json) so a later
+// harvest can prefer these timestamps over marker-join reconstruction.
+// Not registered in HELPER_COMMANDS: a maintainer/CI-only dogfood tool,
+// never an adopter-facing helper (see SOURCE_REPO_INTERNAL_ENTRY_PATHS in
+// tests/helper-invocation-profile.test.mts and DOGFOOD_ONLY_CONCRETE_TOOLS
+// in tests/helper-runtime-manifest.test.mts).
+//
+// Fail-open by design: this is called from an agent's own phase-transition
+// hook, so a typo'd flag or an unwritable --out path must never block the
+// IDD loop it is merely observing. Default mode swallows any failure
+// (bad args, schema-invalid event, unwritable path) into a stderr warning
+// and exit 0. --strict (tests, and any caller that wants to know) turns
+// every one of those into a loud, non-zero-exit failure instead.
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { parseCliArgs } from './cli-args.mjs';
+import { loadJson, validate } from './validate-schemas.mjs';
+
+const SCHEMA_PATH = 'schemas/token-cost-event.schema.json';
+const DEFAULT_OUT_RELATIVE = join('idd-skill', 'token-cost', 'events.jsonl');
+/**
+ * `${XDG_STATE_HOME:-$HOME/.local/state}/idd-skill/token-cost/events.jsonl`,
+ * or `--out`'s explicit override. Never created eagerly -- the caller
+ * creates the parent directory right before the one append this process
+ * performs.
+ */
+export function resolveOutPath(explicitOut, env = process.env) {
+  if (explicitOut) {
+    return explicitOut;
+  }
+  const stateHome =
+    env.XDG_STATE_HOME || join(env.HOME || homedir(), '.local', 'state');
+  return join(stateHome, DEFAULT_OUT_RELATIVE);
+}
+/**
+ * Build one {@link TokenCostEvent} from parsed CLI values and the current
+ * time. Throws a plain, human-readable message on any malformed input --
+ * the CLI's own try/catch below decides whether that throw is fatal
+ * (--strict) or a swallowed warning (default, fail-open). Stage id and
+ * vendor are NOT pre-validated against their enums here: {@link validate}
+ * against the schema (called by the CLI body, not this function) is the
+ * single source of truth for both, so an enum drift between this helper
+ * and the schema can never leave one checked and the other not.
+ */
+export function buildEvent(values, now) {
+  const enter = values.enter === true;
+  const exit = values.exit === true;
+  if (enter === exit) {
+    throw new Error('exactly one of --enter or --exit is required');
+  }
+  const stageId = values.stage;
+  if (typeof stageId !== 'string' || stageId.length === 0) {
+    throw new Error('--stage is required');
+  }
+  const vendor = values.vendor;
+  if (typeof vendor !== 'string' || vendor.length === 0) {
+    throw new Error('--vendor is required');
+  }
+  const event = {
+    schemaVersion: 1,
+    event: enter ? 'enter' : 'exit',
+    stageId: stageId,
+    at: now.toISOString(),
+    vendor: vendor,
+  };
+  const issueRaw = values.issue;
+  if (issueRaw !== undefined) {
+    if (typeof issueRaw !== 'string') {
+      throw new Error('--issue must be a single value');
+    }
+    const issueNumber = Number(issueRaw);
+    if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+      throw new Error(`--issue must be a positive integer, got "${issueRaw}"`);
+    }
+    event.issueNumber = issueNumber;
+  }
+  return event;
+}
+/**
+ * Validate `event` against the committed schema and append it as one
+ * JSONL line to `outPath`, creating the parent directory first. Throws on
+ * either a schema violation or a filesystem failure (unwritable path,
+ * missing permissions) -- the caller decides whether that throw is fatal.
+ */
+export function writeEvent(event, outPath) {
+  const schema = loadJson(SCHEMA_PATH);
+  const errors = validate(event, schema);
+  if (errors.length > 0) {
+    throw new Error(`event fails schema validation: ${errors.join('; ')}`);
+  }
+  mkdirSync(dirname(outPath), { recursive: true });
+  appendFileSync(outPath, `${JSON.stringify(event)}\n`);
+}
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+// Flag-spec keys stay the dashed literal on purpose -- see cli-args.mts's
+// module header (tests/flag-name-matrix.test.mts scans each helper's own
+// compiled .mjs source text for its canonical flags as quoted literals).
+const TOKEN_COST_EVENT_FLAG_SPEC = {
+  '--stage': { type: 'string' },
+  '--enter': { type: 'boolean', default: false },
+  '--exit': { type: 'boolean', default: false },
+  '--issue': { type: 'string' },
+  '--vendor': { type: 'string' },
+  // Accepted for CLI-surface symmetry with the calling convention this
+  // issue's own sketch shows -- not persisted, since
+  // schemas/token-cost-event.schema.json has no field for an IDD claim id
+  // (distinct from vendorSessionId, the AI vendor's own session
+  // identifier).
+  '--claim-id': { type: 'string' },
+  '--out': { type: 'string' },
+  '--strict': { type: 'boolean', default: false },
+  '--now': { type: 'string', default: '' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/token-cost-event.mjs --stage <id> --enter [options]
+  node scripts/token-cost-event.mjs --stage <id> --exit [options]
+
+  --stage <id>      IDD stage id: discover, claim, work, submit-pr,
+                     review, merge, cleanup. Required.
+  --enter / --exit   Exactly one is required.
+  --issue <n>        Issue number, when this event is issue-scoped.
+  --vendor <v>       Agent vendor: grok, claude, or codex. Required.
+  --claim-id <id>    Accepted for calling-convention symmetry; not
+                      persisted (no schema field for it).
+  --out <path>       JSONL append target (default:
+                     \${XDG_STATE_HOME:-$HOME/.local/state}/idd-skill/token-cost/events.jsonl).
+  --strict           Exit non-zero on any failure instead of the default
+                     fail-open warning-and-exit-0 behavior.
+  --now <ISO8601>    Override the current time (tests only).
+  --help, -h         Show this help.
+
+Fail-open by default: a bad flag, a schema-invalid event, or an
+unwritable --out path prints a stderr warning and exits 0, so a
+forgotten or misconfigured hook never blocks the IDD loop. Pass
+--strict to turn every one of those into a non-zero exit instead.
+`);
+}
+if (import.meta.main) {
+  // Decided before parseCliArgs runs, from the raw argv, so a parse
+  // failure itself (unknown flag, missing value) still respects
+  // --strict -- the flag whose own presence that same parse call would
+  // otherwise be needed to report.
+  const strict = process.argv.slice(2).includes('--strict');
+  try {
+    const { values, help } = parseCliArgs(
+      process.argv.slice(2),
+      TOKEN_COST_EVENT_FLAG_SPEC,
+    );
+    if (help) {
+      printHelp();
+      process.exit(0);
+    }
+    let now = new Date();
+    if (values.now) {
+      now = new Date(values.now);
+      if (Number.isNaN(now.getTime())) {
+        throw new Error(
+          `--now is not a valid ISO8601 timestamp: ${values.now}`,
+        );
+      }
+    }
+    const event = buildEvent(values, now);
+    const outPath = resolveOutPath(values.out);
+    writeEvent(event, outPath);
+    process.stdout.write(`token-cost-event: wrote ${outPath}\n`);
+  } catch (error) {
+    const message = error.message;
+    if (strict) {
+      process.stderr.write(`token-cost-event: ${message}\n`);
+      process.exit(1);
+    }
+    process.stderr.write(`token-cost-event: warning: ${message}\n`);
+    process.exit(0);
+  }
+}

--- a/src/scripts/token-cost-event.mts
+++ b/src/scripts/token-cost-event.mts
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/token-cost-event.mts
+//
+// The scripts/token-cost-event.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Source-repo-only dogfood phase-event helper (#2293), called from
+// source-repo agent guidelines only (CLAUDE.md / AGENTS.md / GEMINI.md /
+// .github/copilot-instructions.md's "Dogfood: token-cost events" note) --
+// never from idd-template/ or .github/instructions/, which distribute to
+// adopters with no token-cost data to record. Appends one explicit
+// phase enter/exit line (schemas/token-cost-event.schema.json) so a later
+// harvest can prefer these timestamps over marker-join reconstruction.
+// Not registered in HELPER_COMMANDS: a maintainer/CI-only dogfood tool,
+// never an adopter-facing helper (see SOURCE_REPO_INTERNAL_ENTRY_PATHS in
+// tests/helper-invocation-profile.test.mts and DOGFOOD_ONLY_CONCRETE_TOOLS
+// in tests/helper-runtime-manifest.test.mts).
+//
+// Fail-open by design: this is called from an agent's own phase-transition
+// hook, so a typo'd flag or an unwritable --out path must never block the
+// IDD loop it is merely observing. Default mode swallows any failure
+// (bad args, schema-invalid event, unwritable path) into a stderr warning
+// and exit 0. --strict (tests, and any caller that wants to know) turns
+// every one of those into a loud, non-zero-exit failure instead.
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { parseCliArgs } from './cli-args.mts';
+import type {
+  TokenCostEvent,
+  TokenCostStageId,
+  TokenCostVendor,
+} from './token-cost-core.mts';
+import { loadJson, validate } from './validate-schemas.mts';
+
+const SCHEMA_PATH = 'schemas/token-cost-event.schema.json';
+const DEFAULT_OUT_RELATIVE = join('idd-skill', 'token-cost', 'events.jsonl');
+
+/**
+ * `${XDG_STATE_HOME:-$HOME/.local/state}/idd-skill/token-cost/events.jsonl`,
+ * or `--out`'s explicit override. Never created eagerly -- the caller
+ * creates the parent directory right before the one append this process
+ * performs.
+ */
+export function resolveOutPath(
+  explicitOut: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  if (explicitOut) {
+    return explicitOut;
+  }
+  const stateHome =
+    env.XDG_STATE_HOME || join(env.HOME || homedir(), '.local', 'state');
+  return join(stateHome, DEFAULT_OUT_RELATIVE);
+}
+
+/**
+ * Build one {@link TokenCostEvent} from parsed CLI values and the current
+ * time. Throws a plain, human-readable message on any malformed input --
+ * the CLI's own try/catch below decides whether that throw is fatal
+ * (--strict) or a swallowed warning (default, fail-open). Stage id and
+ * vendor are NOT pre-validated against their enums here: {@link validate}
+ * against the schema (called by the CLI body, not this function) is the
+ * single source of truth for both, so an enum drift between this helper
+ * and the schema can never leave one checked and the other not.
+ */
+export function buildEvent(
+  values: Record<string, string | boolean | string[] | boolean[] | undefined>,
+  now: Date,
+): TokenCostEvent {
+  const enter = values.enter === true;
+  const exit = values.exit === true;
+  if (enter === exit) {
+    throw new Error('exactly one of --enter or --exit is required');
+  }
+  const stageId = values.stage;
+  if (typeof stageId !== 'string' || stageId.length === 0) {
+    throw new Error('--stage is required');
+  }
+  const vendor = values.vendor;
+  if (typeof vendor !== 'string' || vendor.length === 0) {
+    throw new Error('--vendor is required');
+  }
+  const event: TokenCostEvent = {
+    schemaVersion: 1,
+    event: enter ? 'enter' : 'exit',
+    stageId: stageId as TokenCostStageId,
+    at: now.toISOString(),
+    vendor: vendor as TokenCostVendor,
+  };
+  const issueRaw = values.issue;
+  if (issueRaw !== undefined) {
+    if (typeof issueRaw !== 'string') {
+      throw new Error('--issue must be a single value');
+    }
+    const issueNumber = Number(issueRaw);
+    if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+      throw new Error(`--issue must be a positive integer, got "${issueRaw}"`);
+    }
+    event.issueNumber = issueNumber;
+  }
+  return event;
+}
+
+/**
+ * Validate `event` against the committed schema and append it as one
+ * JSONL line to `outPath`, creating the parent directory first. Throws on
+ * either a schema violation or a filesystem failure (unwritable path,
+ * missing permissions) -- the caller decides whether that throw is fatal.
+ */
+export function writeEvent(event: TokenCostEvent, outPath: string): void {
+  const schema = loadJson(SCHEMA_PATH);
+  const errors = validate(event, schema);
+  if (errors.length > 0) {
+    throw new Error(`event fails schema validation: ${errors.join('; ')}`);
+  }
+  mkdirSync(dirname(outPath), { recursive: true });
+  appendFileSync(outPath, `${JSON.stringify(event)}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+// Flag-spec keys stay the dashed literal on purpose -- see cli-args.mts's
+// module header (tests/flag-name-matrix.test.mts scans each helper's own
+// compiled .mjs source text for its canonical flags as quoted literals).
+const TOKEN_COST_EVENT_FLAG_SPEC = {
+  '--stage': { type: 'string' },
+  '--enter': { type: 'boolean', default: false },
+  '--exit': { type: 'boolean', default: false },
+  '--issue': { type: 'string' },
+  '--vendor': { type: 'string' },
+  // Accepted for CLI-surface symmetry with the calling convention this
+  // issue's own sketch shows -- not persisted, since
+  // schemas/token-cost-event.schema.json has no field for an IDD claim id
+  // (distinct from vendorSessionId, the AI vendor's own session
+  // identifier).
+  '--claim-id': { type: 'string' },
+  '--out': { type: 'string' },
+  '--strict': { type: 'boolean', default: false },
+  '--now': { type: 'string', default: '' },
+  '--help': { type: 'boolean', short: 'h' },
+} as const;
+
+function printHelp(): void {
+  process.stdout.write(`Usage:
+  node scripts/token-cost-event.mjs --stage <id> --enter [options]
+  node scripts/token-cost-event.mjs --stage <id> --exit [options]
+
+  --stage <id>      IDD stage id: discover, claim, work, submit-pr,
+                     review, merge, cleanup. Required.
+  --enter / --exit   Exactly one is required.
+  --issue <n>        Issue number, when this event is issue-scoped.
+  --vendor <v>       Agent vendor: grok, claude, or codex. Required.
+  --claim-id <id>    Accepted for calling-convention symmetry; not
+                      persisted (no schema field for it).
+  --out <path>       JSONL append target (default:
+                     \${XDG_STATE_HOME:-$HOME/.local/state}/idd-skill/token-cost/events.jsonl).
+  --strict           Exit non-zero on any failure instead of the default
+                     fail-open warning-and-exit-0 behavior.
+  --now <ISO8601>    Override the current time (tests only).
+  --help, -h         Show this help.
+
+Fail-open by default: a bad flag, a schema-invalid event, or an
+unwritable --out path prints a stderr warning and exits 0, so a
+forgotten or misconfigured hook never blocks the IDD loop. Pass
+--strict to turn every one of those into a non-zero exit instead.
+`);
+}
+
+if (import.meta.main) {
+  // Decided before parseCliArgs runs, from the raw argv, so a parse
+  // failure itself (unknown flag, missing value) still respects
+  // --strict -- the flag whose own presence that same parse call would
+  // otherwise be needed to report.
+  const strict = process.argv.slice(2).includes('--strict');
+  try {
+    const { values, help } = parseCliArgs(
+      process.argv.slice(2),
+      TOKEN_COST_EVENT_FLAG_SPEC,
+    );
+    if (help) {
+      printHelp();
+      process.exit(0);
+    }
+    let now = new Date();
+    if (values.now) {
+      now = new Date(values.now as string);
+      if (Number.isNaN(now.getTime())) {
+        throw new Error(
+          `--now is not a valid ISO8601 timestamp: ${values.now as string}`,
+        );
+      }
+    }
+    const event = buildEvent(values, now);
+    const outPath = resolveOutPath(values.out as string | undefined);
+    writeEvent(event, outPath);
+    process.stdout.write(`token-cost-event: wrote ${outPath}\n`);
+  } catch (error) {
+    const message = (error as Error).message;
+    if (strict) {
+      process.stderr.write(`token-cost-event: ${message}\n`);
+      process.exit(1);
+    }
+    process.stderr.write(`token-cost-event: warning: ${message}\n`);
+    process.exit(0);
+  }
+}

--- a/tests/help-text-flags.test.mts
+++ b/tests/help-text-flags.test.mts
@@ -174,6 +174,7 @@ const COVERED_HELPERS = [
   'ci-wait-state',
   'claim-approval-gate',
   'claim-lock',
+  'token-cost-event',
   'token-cost-report',
   'discover-readiness-check',
   'discover-shared-file-overlap',

--- a/tests/helper-invocation-profile.test.mts
+++ b/tests/helper-invocation-profile.test.mts
@@ -104,6 +104,22 @@ const SOURCE_REPO_INTERNAL_ENTRY_PATHS = new Set([
   // an adopter repository has an entirely different set of workflows to
   // measure.
   'scripts/actions-usage-report.mjs',
+  // token-cost-event.mjs (#2293): this repository's own dogfood
+  // phase-event helper, named only in the four root guideline files'
+  // (CLAUDE.md / AGENTS.md / GEMINI.md / .github/copilot-instructions.md)
+  // "Dogfood: token-cost events" note -- none of which
+  // `readRealScanFiles()` below scans (docs/**, idd-template/docs/**,
+  // .github/instructions/**, idd-template/.github/instructions/** only),
+  // so this entry is currently inert against that scan. Registered anyway
+  // per #2293's own design (kept in sync with
+  // DOGFOOD_ONLY_CONCRETE_TOOLS in tests/helper-runtime-manifest.test.mts,
+  // same rationale) so a future guideline-file edit that duplicates this
+  // invocation into a scanned path does not silently need this same
+  // exemption re-derived from scratch. It writes only to
+  // `${XDG_STATE_HOME:-$HOME/.local/state}/idd-skill/token-cost/` --
+  // never committed to git -- and is never distributed to idd-template/;
+  // an adopter repository has no token-cost data to record.
+  'scripts/token-cost-event.mjs',
 ]);
 
 // A helper name that appears only as a *proposed*, not-yet-built script

--- a/tests/helper-runtime-manifest.test.mts
+++ b/tests/helper-runtime-manifest.test.mts
@@ -718,6 +718,17 @@ function readInstructionFiles(): { name: string; source: string }[] {
 // mention slip past the guard silently. Only add a tool to this set when it is
 // genuinely `node`-invoked in the dogfood instructions AND provably invisible
 // to idd-template adopters, as justified above.
+// token-cost-event.mjs (#2293) is also dogfood-only, but it is named only
+// in the four root guideline files (CLAUDE.md / AGENTS.md / GEMINI.md /
+// .github/copilot-instructions.md), never inside `.github/instructions/`
+// -- so `readInstructionFiles()` below never scans it in and this set
+// needs no entry for it. Kept out on purpose, mirroring the
+// SOURCE_REPO_INTERNAL_ENTRY_PATHS comment in
+// tests/helper-invocation-profile.test.mts, whose broader scan does
+// register it (currently inert there for the identical reason) so a
+// future guideline-file edit that duplicates the invocation into a
+// scanned path finds the exemption already recorded in the set that
+// would actually need it.
 const DOGFOOD_ONLY_CONCRETE_TOOLS = new Set([
   'scripts/sync-docs.mjs',
   'scripts/verify-install-deps.mjs',

--- a/tests/token-cost-event.test.mts
+++ b/tests/token-cost-event.test.mts
@@ -1,0 +1,383 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildEvent,
+  resolveOutPath,
+  writeEvent,
+} from '../src/scripts/token-cost-event.mts';
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+const CLI_PATH = join(REPO_ROOT, 'scripts/token-cost-event.mjs');
+const NOW = new Date('2026-09-01T12:00:00.000Z');
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'idd-token-cost-event-test-'));
+}
+
+function runCli(args: readonly string[]): {
+  status: number;
+  stdout: string;
+  stderr: string;
+} {
+  const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
+    encoding: 'utf8',
+  });
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// resolveOutPath
+// ---------------------------------------------------------------------------
+
+test('resolveOutPath prefers an explicit --out', () => {
+  assert.equal(
+    resolveOutPath('/explicit/path/events.jsonl', {}),
+    '/explicit/path/events.jsonl',
+  );
+});
+
+test('resolveOutPath falls back to XDG_STATE_HOME', () => {
+  assert.equal(
+    resolveOutPath(undefined, { XDG_STATE_HOME: '/xdg-state' }),
+    join('/xdg-state', 'idd-skill', 'token-cost', 'events.jsonl'),
+  );
+});
+
+test('resolveOutPath falls back to $HOME/.local/state when XDG_STATE_HOME is unset', () => {
+  const out = resolveOutPath(undefined, { HOME: '/home/example' });
+  assert.equal(
+    out,
+    join(
+      '/home/example',
+      '.local',
+      'state',
+      'idd-skill',
+      'token-cost',
+      'events.jsonl',
+    ),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// buildEvent
+// ---------------------------------------------------------------------------
+
+test('buildEvent builds a schema-shaped enter event', () => {
+  const event = buildEvent(
+    { stage: 'discover', enter: true, exit: false, vendor: 'claude' },
+    NOW,
+  );
+  assert.deepEqual(event, {
+    schemaVersion: 1,
+    event: 'enter',
+    stageId: 'discover',
+    at: NOW.toISOString(),
+    vendor: 'claude',
+  });
+});
+
+test('buildEvent builds a schema-shaped exit event with an issue number', () => {
+  const event = buildEvent(
+    { stage: 'work', enter: false, exit: true, vendor: 'codex', issue: '2293' },
+    NOW,
+  );
+  assert.deepEqual(event, {
+    schemaVersion: 1,
+    event: 'exit',
+    stageId: 'work',
+    at: NOW.toISOString(),
+    vendor: 'codex',
+    issueNumber: 2293,
+  });
+});
+
+test('buildEvent throws when neither --enter nor --exit is given', () => {
+  assert.throws(
+    () => buildEvent({ stage: 'discover', vendor: 'claude' }, NOW),
+    /exactly one of --enter or --exit is required/,
+  );
+});
+
+test('buildEvent throws when both --enter and --exit are given', () => {
+  assert.throws(
+    () =>
+      buildEvent(
+        { stage: 'discover', enter: true, exit: true, vendor: 'claude' },
+        NOW,
+      ),
+    /exactly one of --enter or --exit is required/,
+  );
+});
+
+test('buildEvent throws when --stage is missing', () => {
+  assert.throws(
+    () => buildEvent({ enter: true, vendor: 'claude' }, NOW),
+    /--stage is required/,
+  );
+});
+
+test('buildEvent throws when --vendor is missing', () => {
+  assert.throws(
+    () => buildEvent({ stage: 'discover', enter: true }, NOW),
+    /--vendor is required/,
+  );
+});
+
+test('buildEvent throws on a non-integer --issue', () => {
+  assert.throws(
+    () =>
+      buildEvent(
+        { stage: 'discover', enter: true, vendor: 'claude', issue: 'abc' },
+        NOW,
+      ),
+    /--issue must be a positive integer/,
+  );
+});
+
+test('buildEvent throws on a non-positive --issue', () => {
+  assert.throws(
+    () =>
+      buildEvent(
+        { stage: 'discover', enter: true, vendor: 'claude', issue: '0' },
+        NOW,
+      ),
+    /--issue must be a positive integer/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// writeEvent
+// ---------------------------------------------------------------------------
+
+test('writeEvent appends one schema-valid JSONL line, creating the parent directory', () => {
+  const dir = tempDir();
+  try {
+    const outPath = join(dir, 'nested', 'events.jsonl');
+    const event = buildEvent(
+      { stage: 'claim', enter: true, vendor: 'grok' },
+      NOW,
+    );
+    writeEvent(event, outPath);
+    const lines = readFileSync(outPath, 'utf8').trim().split('\n');
+    assert.equal(lines.length, 1);
+    assert.deepEqual(JSON.parse(lines[0]), event);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('writeEvent appends without truncating an existing file', () => {
+  const dir = tempDir();
+  try {
+    const outPath = join(dir, 'events.jsonl');
+    writeEvent(
+      buildEvent({ stage: 'claim', enter: true, vendor: 'grok' }, NOW),
+      outPath,
+    );
+    writeEvent(
+      buildEvent({ stage: 'claim', exit: true, vendor: 'grok' }, NOW),
+      outPath,
+    );
+    const lines = readFileSync(outPath, 'utf8').trim().split('\n');
+    assert.equal(lines.length, 2);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('writeEvent throws for a stageId the schema does not enumerate', () => {
+  const dir = tempDir();
+  try {
+    const outPath = join(dir, 'events.jsonl');
+    const event = buildEvent(
+      { stage: 'bogus-stage', enter: true, vendor: 'claude' },
+      NOW,
+    );
+    assert.throws(() => writeEvent(event, outPath), /fails schema validation/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('writeEvent throws for a vendor the schema does not enumerate', () => {
+  const dir = tempDir();
+  try {
+    const outPath = join(dir, 'events.jsonl');
+    const event = buildEvent(
+      { stage: 'discover', enter: true, vendor: 'bogus-vendor' },
+      NOW,
+    );
+    assert.throws(() => writeEvent(event, outPath), /fails schema validation/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// CLI (spawns the compiled scripts/token-cost-event.mjs)
+// ---------------------------------------------------------------------------
+
+test('CLI --strict writes a schema-valid JSONL line for a legal --stage/--enter pair', () => {
+  const dir = tempDir();
+  try {
+    const outPath = join(dir, 'events.jsonl');
+    const result = runCli([
+      '--stage',
+      'discover',
+      '--enter',
+      '--vendor',
+      'claude',
+      '--issue',
+      '2293',
+      '--out',
+      outPath,
+      '--now',
+      NOW.toISOString(),
+      '--strict',
+    ]);
+    assert.equal(result.status, 0, result.stderr);
+    const lines = readFileSync(outPath, 'utf8').trim().split('\n');
+    assert.equal(lines.length, 1);
+    assert.deepEqual(JSON.parse(lines[0]), {
+      schemaVersion: 1,
+      event: 'enter',
+      stageId: 'discover',
+      at: NOW.toISOString(),
+      vendor: 'claude',
+      issueNumber: 2293,
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI --strict rejects an unknown --stage and writes nothing', () => {
+  const dir = tempDir();
+  try {
+    const outPath = join(dir, 'events.jsonl');
+    const result = runCli([
+      '--stage',
+      'bogus-stage',
+      '--enter',
+      '--vendor',
+      'claude',
+      '--out',
+      outPath,
+      '--strict',
+    ]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /fails schema validation/);
+    assert.throws(() => readFileSync(outPath, 'utf8'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI default (non-strict) mode exits 0 with a warning when --out is on a read-only path', () => {
+  const dir = tempDir();
+  try {
+    const readonlyDir = join(dir, 'readonly');
+    mkdirSync(readonlyDir);
+    chmodSync(readonlyDir, 0o500);
+    const outPath = join(readonlyDir, 'nested', 'events.jsonl');
+    const result = runCli([
+      '--stage',
+      'discover',
+      '--enter',
+      '--vendor',
+      'claude',
+      '--out',
+      outPath,
+    ]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stderr, /token-cost-event: warning:/);
+  } finally {
+    chmodSync(join(dir, 'readonly'), 0o700);
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI default (non-strict) mode exits 0 with a warning on a malformed invocation (missing --stage)', () => {
+  const dir = tempDir();
+  try {
+    const outPath = join(dir, 'events.jsonl');
+    const result = runCli(['--enter', '--vendor', 'claude', '--out', outPath]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(
+      result.stderr,
+      /token-cost-event: warning: --stage is required/,
+    );
+    assert.throws(() => readFileSync(outPath, 'utf8'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI --strict mode exits non-zero on the same malformed invocation (missing --stage)', () => {
+  const dir = tempDir();
+  try {
+    const outPath = join(dir, 'events.jsonl');
+    const result = runCli([
+      '--enter',
+      '--vendor',
+      'claude',
+      '--out',
+      outPath,
+      '--strict',
+    ]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /--stage is required/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI --help exits 0 and prints usage without touching --out', () => {
+  const result = runCli(['--help']);
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /Usage:/);
+  assert.match(result.stdout, /--stage <id>/);
+});
+
+test('CLI --claim-id is accepted but not persisted in the written event', () => {
+  const dir = tempDir();
+  try {
+    const outPath = join(dir, 'events.jsonl');
+    const result = runCli([
+      '--stage',
+      'work',
+      '--exit',
+      '--vendor',
+      'grok',
+      '--claim-id',
+      'abc123',
+      '--out',
+      outPath,
+      '--now',
+      NOW.toISOString(),
+      '--strict',
+    ]);
+    assert.equal(result.status, 0, result.stderr);
+    const written = JSON.parse(readFileSync(outPath, 'utf8').trim());
+    assert.equal('claimId' in written, false);
+    assert.equal('claim-id' in written, false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/token-cost-event.mjs` (source: `src/scripts/token-cost-event.mts`), a source-repo-only, fail-open CLI that appends one explicit phase enter/exit line to `schemas/token-cost-event.schema.json`'s JSONL contract, so a later harvest can prefer these timestamps over marker-join reconstruction.
- Adds a short **Dogfood: token-cost events** note to `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, and `.github/copilot-instructions.md`. Three of the four (`AGENTS.md`/OpenCode, `GEMINI.md`, `.github/copilot-instructions.md`/Copilot) currently have no matching `vendor` enum value in the schema and are told to skip the call rather than risk a mismatched tag corrupting the shared dataset.
- Registers the helper in `SOURCE_REPO_INTERNAL_ENTRY_PATHS` (`tests/helper-invocation-profile.test.mts`) and `COVERED_HELPERS` (`tests/help-text-flags.test.mts`). Kept off `HELPER_COMMANDS` per the issue's own requirement.

## Deviation from the issue's proposed change

The issue's "Proposed change" section says to register the helper in both `SOURCE_REPO_INTERNAL_ENTRY_PATHS` **and** `DOGFOOD_ONLY_CONCRETE_TOOLS`. I registered only the former. `DOGFOOD_ONLY_CONCRETE_TOOLS`'s own scan (`tests/helper-runtime-manifest.test.mts`) is limited to `.github/instructions/**` — this helper is invoked only from the four root guideline files, which that scan never reaches, so an entry there would be dead weight against the file's own documented discipline ("Only add a tool to this set when it is genuinely `node`-invoked in the dogfood instructions"). Left an inline comment in both files explaining the reasoning so a future edit that changes either scope finds it already recorded. `pnpm test` passes either way.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build` / `pnpm run build:check` (clean post-commit)
- [x] `node --test tests/*.test.mts` — 4297/4297 passing, including the new `tests/token-cost-event.test.mts` (22 tests: `resolveOutPath`/`buildEvent`/`writeEvent` units + CLI-level `--strict`/fail-open/`--help`/`--claim-id` integration tests) and the updated `tests/help-text-flags.test.mts`/`tests/helper-invocation-profile.test.mts`/`tests/helper-runtime-manifest.test.mts` guards
- [x] `biome check`, `dprint check "**/*.md"`, `markdownlint-cli2 "**/*.md"`, `cspell lint "**"` all clean
- [x] `node scripts/verify-workshop-integrity.mjs --format table` — 0 issues
- [x] `node scripts/audit-docs.mjs --check` — passes (only pre-existing `bundle-work`/other bundle notices, untouched by this PR)
- [x] Manually confirmed no `idd-template/` or `.github/instructions/` files changed

Refs #2293