### PR TITLE
feat(discover): recognize a non-blocking Refs reference form

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -790,14 +790,23 @@ The linter also emits one **advisory, warning-severity-only** finding
 full GitHub issue/PR URL) that appears near coordination language (for
 example "before", "after", "once", "until", "predates", "gate"/"gated",
 "requires", "lands first") with no corresponding encoding for that
-reference as one of the three recognized forms: a `Blocked by #NNN`
-line, a `Depends on #NNN` line, or a task-list checkbox item
-(`- [ ] #NNN`) — the same three forms `extractBlockedByIssueNumbers` /
-`extractDependencyIssueNumbers` already recognize elsewhere in this
-contract. A task-list checkbox counts regardless of which heading it
-sits under, so a roadmap's own `## Tracks` membership list already
-satisfies this — it is not a separate "dependency-only" list. This
-catches the pattern this contract's own
+reference as one of four recognized forms: a `Blocked by #NNN` line, a
+`Depends on #NNN` line, a task-list checkbox item (`- [ ] #NNN`), or a
+`Refs #NNN (non-blocking)` line — the same forms
+`extractBlockedByIssueNumbers` / `extractDependencyIssueNumbers` /
+`extractNonBlockingReferenceIssueNumbers` already recognize elsewhere
+in this contract. A task-list checkbox counts regardless of which
+heading it sits under, so a roadmap's own `## Tracks` membership list
+already satisfies this — it is not a separate "dependency-only" list.
+Use `Refs #NNN (non-blocking)` (multi-target: `Refs #NNN, #NNN
+(non-blocking)`) for a reference that is deliberately informational —
+a roadmap narrative naming a related, currently-blocked follow-up
+issue with no ETA, for example — never for a real dependency: unlike
+the other three forms,
+`discover-roadmap-graph.mts`'s traversal never enters this reference's
+target at all, so it cannot become an A1.5 closure-audit blocker, and
+this check treats it as already-encoded the same as the other three
+forms (#2236). This catches the pattern this contract's own
 [Hidden human-dependency validation](#hidden-human-dependency-validation)
 check 4 warns about in prose — a hard precondition stated only in
 narrative text, not encoded as a real dependency marker. A full-URL

--- a/scripts/audit-authored-issue.mjs
+++ b/scripts/audit-authored-issue.mjs
@@ -84,6 +84,53 @@ const PROSE_DEPENDENCY_KEYWORDS = [
   'requires',
   'lands first',
 ];
+// Matches a `Refs #NNN (non-blocking)` reference (and multi-target variants
+// like `Refs #201, #202 (non-blocking)`) anywhere on a line — the visible
+// encoding discover-roadmap-graph.mts's `extractKeywordReferences`
+// recognizes as `relationship: 'non-blocking-reference'` (#2236): a
+// deliberately informational reference that must never become an A1.5
+// closure-audit blocker. Recognized here too so this check's `encoded` set
+// treats it as already-documented, the same as the three
+// Blocked-by/Depends-on/task-list forms, instead of flagging it as an
+// undocumented prose-only dependency. The captured group (everything
+// between the Refs/Ref keyword and the `(non-blocking)` annotation) is
+// parsed for its `#N` reference list by `consumeNonBlockingRefList` below,
+// mirroring the separator-tolerant list parsing
+// discover-readiness-check.mts's own `consumeDependencyRefList` already
+// uses for the same comma/`and`/whitespace-separated shape (duplicated
+// rather than imported: this repository's existing precedent for the same
+// textual encoding recognized by two independent modules for two different
+// purposes, see that function's own doc comment).
+const NON_BLOCKING_REFERENCE_LINE_PATTERN =
+  /\bRefs?\b\s*:?\s*([^.\n(]*?)\s*\(non-blocking\)/gi;
+function consumeNonBlockingRefList(segment) {
+  const numbers = [];
+  let remaining = segment;
+  while (remaining) {
+    const refMatch = remaining.match(/^#(\d+)\b/);
+    if (!refMatch) {
+      break;
+    }
+    numbers.push(Number.parseInt(refMatch[1], 10));
+    remaining = remaining.slice(refMatch[0].length);
+    const separatorMatch = remaining.match(
+      /^(?:\s*,\s*(?:and\s+)?|\s+and\s+|\s+)/i,
+    );
+    if (!separatorMatch) {
+      break;
+    }
+    remaining = remaining.slice(separatorMatch[0].length);
+  }
+  return numbers;
+}
+function extractNonBlockingReferenceIssueNumbers(text) {
+  const stripped = stripMarkdownCodeRegions(text);
+  const numbers = [];
+  for (const match of stripped.matchAll(NON_BLOCKING_REFERENCE_LINE_PATTERN)) {
+    numbers.push(...consumeNonBlockingRefList(match[1]));
+  }
+  return [...new Set(numbers)];
+}
 // Matches a Markdown link whose target is a full GitHub issue/PR URL (e.g.
 // `[PR #1391](https://github.com/owner/repo/pull/1391)`), a bare `#123`
 // issue/PR reference, a bare full GitHub issue/PR URL, or a local
@@ -580,12 +627,13 @@ function checkProseOnlyDependency(text, currentRepo) {
   const name =
     'Advisory: issue/PR references near coordination language should use a dependency marker';
   // Numbers already covered by a real machine-readable dependency encoding
-  // (Blocked by / Depends on / task-list) are never flagged, regardless of
-  // nearby prose — the whole point of this check is to catch references
-  // that carry *no* such encoding.
+  // (Blocked by / Depends on / task-list / the non-blocking Refs form,
+  // #2236) are never flagged, regardless of nearby prose — the whole point
+  // of this check is to catch references that carry *no* such encoding.
   const encoded = new Set([
     ...extractBlockedByIssueNumbers(text),
     ...extractDependencyIssueNumbers(text),
+    ...extractNonBlockingReferenceIssueNumbers(text),
   ]);
   const keywordPattern = new RegExp(
     `\\b(?:${PROSE_DEPENDENCY_KEYWORDS.map(escapeRegex).join('|')})\\b`,

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -172,6 +172,20 @@ const KEYWORD_NEGATION_PATTERN =
 // can never change whether `KEYWORD_NEGATION_PATTERN` matches — see
 // `isNegatedKeywordMatch`'s doc comment for the full argument.
 const NEGATION_LOOKBACK_TOKENS = 6;
+// #2236: a `Refs #NNN (non-blocking)` segment is a deliberately
+// informational reference -- distinct from a plain `Refs #NNN`, whose
+// target still enters the graph as a traversed node today (A2's own
+// documented traversal sources list "Closes #NNN, Refs #NNN, explicit
+// sub-issue lines" as equally allowed, with no relationship-based
+// exemption). Scoped to the keyword-matched *segment* (the text between
+// this keyword match and the next), not the whole line, so a line mixing
+// a blocking keyword and a non-blocking `Refs` mention (e.g. "Blocked by
+// #100. Also refs #101 (non-blocking).") only marks the `Refs` segment's
+// own targets non-blocking -- see the `classifyKeywordRelationship` call
+// site below, which applies this only when the keyword itself already
+// classified as 'reference' (Refs/Ref), never to Blocked-by/Depends-on/
+// Closes/Sub-issue.
+const NON_BLOCKING_ANNOTATION_PATTERN = /\(non-blocking\)/i;
 const SUB_ISSUES_QUERY = `
 query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   repository(owner:$owner, name:$repo) {
@@ -514,6 +528,19 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
         } else {
           firstReferenceBySourceTarget.set(sourceTargetKey, edge);
         }
+      }
+      // #2236: a `non-blocking-reference` edge is deliberately informational
+      // -- it is recorded above (so it is visible in the graph output and
+      // participates in duplicate-reference bookkeeping like any other
+      // edge), but its target is never visited, never recorded as a node,
+      // and never checked for a cycle. Because `executionCandidates` below
+      // is built purely from recorded nodes, a target reachable only via
+      // this relationship can never become an A1.5 `open-child` blocker --
+      // unless some OTHER, still-blocking edge elsewhere in the graph also
+      // reaches it, in which case it correctly still blocks through that
+      // other path.
+      if (edge.relationship === 'non-blocking-reference') {
+        continue;
       }
       if (path.includes(edge.target)) {
         // #1278: a plain `Refs` back-reference from a CLOSED non-roadmap leaf
@@ -1511,6 +1538,12 @@ export function extractKeywordReferences(body, options = {}) {
       const segmentStart = matchIndex + match[0].length;
       const segmentEnd = keywordMatches[index + 1]?.index ?? maskedLine.length;
       const segment = maskedLine.slice(segmentStart, segmentEnd);
+      const baseRelationship = classifyKeywordRelationship(match[1]);
+      const relationship =
+        baseRelationship === 'reference' &&
+        NON_BLOCKING_ANNOTATION_PATTERN.test(segment)
+          ? 'non-blocking-reference'
+          : baseRelationship;
       for (const target of extractKeywordReferenceTargets(
         segment,
         currentRepoRef,
@@ -1520,7 +1553,7 @@ export function extractKeywordReferences(body, options = {}) {
         }
         references.push({
           target,
-          relationship: classifyKeywordRelationship(match[1]),
+          relationship,
           evidence: rawLine.trim(),
         });
       }

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -658,13 +658,23 @@ export async function enumerateRoadmapGraph(rootIssueNumber, options = {}) {
   // Fetch one node and return its reference targets for the next BFS frontier.
   // Mirrors the DFS expansion guard: only accessible, non-PR issues are
   // expanded (PRs / inaccessible / not-found contribute no children), so the
-  // crawl's reachable set equals the DFS's.
+  // crawl's reachable set equals the DFS's. #2236: a `non-blocking-reference`
+  // target is also excluded here, mirroring `visitIssue`'s own early
+  // `continue` for that relationship -- without this, the prefetch crawl
+  // would still fetch (and transitively expand) a target `visitIssue` itself
+  // never visits, needlessly spending GitHub requests and rate-limit budget
+  // on a subgraph the real traversal was designed to skip entirely
+  // (CodeRabbit, PR #2381).
   async function expandForPrefetch(issueNumber) {
     const issue = await getIssue(issueNumber, issueCache, loadIssue);
     if (!issue || isInaccessibleIssue(issue) || issue.isPullRequest) {
       return [];
     }
-    return (await getReferences(issue)).map((reference) => reference.target);
+    return (await getReferences(issue))
+      .filter(
+        (reference) => reference.relationship !== 'non-blocking-reference',
+      )
+      .map((reference) => reference.target);
   }
   function recordNode(issue, path) {
     const existing = nodeRecords.get(issue.number);

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -790,14 +790,23 @@ The linter also emits one **advisory, warning-severity-only** finding
 full GitHub issue/PR URL) that appears near coordination language (for
 example "before", "after", "once", "until", "predates", "gate"/"gated",
 "requires", "lands first") with no corresponding encoding for that
-reference as one of the three recognized forms: a `Blocked by #NNN`
-line, a `Depends on #NNN` line, or a task-list checkbox item
-(`- [ ] #NNN`) — the same three forms `extractBlockedByIssueNumbers` /
-`extractDependencyIssueNumbers` already recognize elsewhere in this
-contract. A task-list checkbox counts regardless of which heading it
-sits under, so a roadmap's own `## Tracks` membership list already
-satisfies this — it is not a separate "dependency-only" list. This
-catches the pattern this contract's own
+reference as one of four recognized forms: a `Blocked by #NNN` line, a
+`Depends on #NNN` line, a task-list checkbox item (`- [ ] #NNN`), or a
+`Refs #NNN (non-blocking)` line — the same forms
+`extractBlockedByIssueNumbers` / `extractDependencyIssueNumbers` /
+`extractNonBlockingReferenceIssueNumbers` already recognize elsewhere
+in this contract. A task-list checkbox counts regardless of which
+heading it sits under, so a roadmap's own `## Tracks` membership list
+already satisfies this — it is not a separate "dependency-only" list.
+Use `Refs #NNN (non-blocking)` (multi-target: `Refs #NNN, #NNN
+(non-blocking)`) for a reference that is deliberately informational —
+a roadmap narrative naming a related, currently-blocked follow-up
+issue with no ETA, for example — never for a real dependency: unlike
+the other three forms,
+`discover-roadmap-graph.mts`'s traversal never enters this reference's
+target at all, so it cannot become an A1.5 closure-audit blocker, and
+this check treats it as already-encoded the same as the other three
+forms (#2236). This catches the pattern this contract's own
 [Hidden human-dependency validation](#hidden-human-dependency-validation)
 check 4 warns about in prose — a hard precondition stated only in
 narrative text, not encoded as a real dependency marker. A full-URL

--- a/src/scripts/audit-authored-issue.mts
+++ b/src/scripts/audit-authored-issue.mts
@@ -172,6 +172,56 @@ const PROSE_DEPENDENCY_KEYWORDS = [
   'lands first',
 ] as const;
 
+// Matches a `Refs #NNN (non-blocking)` reference (and multi-target variants
+// like `Refs #201, #202 (non-blocking)`) anywhere on a line — the visible
+// encoding discover-roadmap-graph.mts's `extractKeywordReferences`
+// recognizes as `relationship: 'non-blocking-reference'` (#2236): a
+// deliberately informational reference that must never become an A1.5
+// closure-audit blocker. Recognized here too so this check's `encoded` set
+// treats it as already-documented, the same as the three
+// Blocked-by/Depends-on/task-list forms, instead of flagging it as an
+// undocumented prose-only dependency. The captured group (everything
+// between the Refs/Ref keyword and the `(non-blocking)` annotation) is
+// parsed for its `#N` reference list by `consumeNonBlockingRefList` below,
+// mirroring the separator-tolerant list parsing
+// discover-readiness-check.mts's own `consumeDependencyRefList` already
+// uses for the same comma/`and`/whitespace-separated shape (duplicated
+// rather than imported: this repository's existing precedent for the same
+// textual encoding recognized by two independent modules for two different
+// purposes, see that function's own doc comment).
+const NON_BLOCKING_REFERENCE_LINE_PATTERN =
+  /\bRefs?\b\s*:?\s*([^.\n(]*?)\s*\(non-blocking\)/gi;
+
+function consumeNonBlockingRefList(segment: string): number[] {
+  const numbers: number[] = [];
+  let remaining = segment;
+  while (remaining) {
+    const refMatch = remaining.match(/^#(\d+)\b/);
+    if (!refMatch) {
+      break;
+    }
+    numbers.push(Number.parseInt(refMatch[1], 10));
+    remaining = remaining.slice(refMatch[0].length);
+    const separatorMatch = remaining.match(
+      /^(?:\s*,\s*(?:and\s+)?|\s+and\s+|\s+)/i,
+    );
+    if (!separatorMatch) {
+      break;
+    }
+    remaining = remaining.slice(separatorMatch[0].length);
+  }
+  return numbers;
+}
+
+function extractNonBlockingReferenceIssueNumbers(text: string): number[] {
+  const stripped = stripMarkdownCodeRegions(text);
+  const numbers: number[] = [];
+  for (const match of stripped.matchAll(NON_BLOCKING_REFERENCE_LINE_PATTERN)) {
+    numbers.push(...consumeNonBlockingRefList(match[1]));
+  }
+  return [...new Set(numbers)];
+}
+
 // Matches a Markdown link whose target is a full GitHub issue/PR URL (e.g.
 // `[PR #1391](https://github.com/owner/repo/pull/1391)`), a bare `#123`
 // issue/PR reference, a bare full GitHub issue/PR URL, or a local
@@ -717,12 +767,13 @@ function checkProseOnlyDependency(
   const name =
     'Advisory: issue/PR references near coordination language should use a dependency marker';
   // Numbers already covered by a real machine-readable dependency encoding
-  // (Blocked by / Depends on / task-list) are never flagged, regardless of
-  // nearby prose — the whole point of this check is to catch references
-  // that carry *no* such encoding.
+  // (Blocked by / Depends on / task-list / the non-blocking Refs form,
+  // #2236) are never flagged, regardless of nearby prose — the whole point
+  // of this check is to catch references that carry *no* such encoding.
   const encoded = new Set([
     ...extractBlockedByIssueNumbers(text),
     ...extractDependencyIssueNumbers(text),
+    ...extractNonBlockingReferenceIssueNumbers(text),
   ]);
   const keywordPattern = new RegExp(
     `\\b(?:${PROSE_DEPENDENCY_KEYWORDS.map(escapeRegex).join('|')})\\b`,

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -1174,13 +1174,23 @@ export async function enumerateRoadmapGraph(
   // Fetch one node and return its reference targets for the next BFS frontier.
   // Mirrors the DFS expansion guard: only accessible, non-PR issues are
   // expanded (PRs / inaccessible / not-found contribute no children), so the
-  // crawl's reachable set equals the DFS's.
+  // crawl's reachable set equals the DFS's. #2236: a `non-blocking-reference`
+  // target is also excluded here, mirroring `visitIssue`'s own early
+  // `continue` for that relationship -- without this, the prefetch crawl
+  // would still fetch (and transitively expand) a target `visitIssue` itself
+  // never visits, needlessly spending GitHub requests and rate-limit budget
+  // on a subgraph the real traversal was designed to skip entirely
+  // (CodeRabbit, PR #2381).
   async function expandForPrefetch(issueNumber: number): Promise<number[]> {
     const issue = await getIssue(issueNumber, issueCache, loadIssue);
     if (!issue || isInaccessibleIssue(issue) || issue.isPullRequest) {
       return [];
     }
-    return (await getReferences(issue)).map((reference) => reference.target);
+    return (await getReferences(issue))
+      .filter(
+        (reference) => reference.relationship !== 'non-blocking-reference',
+      )
+      .map((reference) => reference.target);
   }
 
   function recordNode(issue: NormalizedIssue, path: number[]) {

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -173,6 +173,20 @@ const KEYWORD_NEGATION_PATTERN =
 // can never change whether `KEYWORD_NEGATION_PATTERN` matches — see
 // `isNegatedKeywordMatch`'s doc comment for the full argument.
 const NEGATION_LOOKBACK_TOKENS = 6;
+// #2236: a `Refs #NNN (non-blocking)` segment is a deliberately
+// informational reference -- distinct from a plain `Refs #NNN`, whose
+// target still enters the graph as a traversed node today (A2's own
+// documented traversal sources list "Closes #NNN, Refs #NNN, explicit
+// sub-issue lines" as equally allowed, with no relationship-based
+// exemption). Scoped to the keyword-matched *segment* (the text between
+// this keyword match and the next), not the whole line, so a line mixing
+// a blocking keyword and a non-blocking `Refs` mention (e.g. "Blocked by
+// #100. Also refs #101 (non-blocking).") only marks the `Refs` segment's
+// own targets non-blocking -- see the `classifyKeywordRelationship` call
+// site below, which applies this only when the keyword itself already
+// classified as 'reference' (Refs/Ref), never to Blocked-by/Depends-on/
+// Closes/Sub-issue.
+const NON_BLOCKING_ANNOTATION_PATTERN = /\(non-blocking\)/i;
 const SUB_ISSUES_QUERY = `
 query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   repository(owner:$owner, name:$repo) {
@@ -1018,6 +1032,20 @@ export async function enumerateRoadmapGraph(
         } else {
           firstReferenceBySourceTarget.set(sourceTargetKey, edge);
         }
+      }
+
+      // #2236: a `non-blocking-reference` edge is deliberately informational
+      // -- it is recorded above (so it is visible in the graph output and
+      // participates in duplicate-reference bookkeeping like any other
+      // edge), but its target is never visited, never recorded as a node,
+      // and never checked for a cycle. Because `executionCandidates` below
+      // is built purely from recorded nodes, a target reachable only via
+      // this relationship can never become an A1.5 `open-child` blocker --
+      // unless some OTHER, still-blocking edge elsewhere in the graph also
+      // reaches it, in which case it correctly still blocks through that
+      // other path.
+      if (edge.relationship === 'non-blocking-reference') {
+        continue;
       }
 
       if (path.includes(edge.target)) {
@@ -2146,6 +2174,12 @@ export function extractKeywordReferences(
       const segmentStart = matchIndex + match[0].length;
       const segmentEnd = keywordMatches[index + 1]?.index ?? maskedLine.length;
       const segment = maskedLine.slice(segmentStart, segmentEnd);
+      const baseRelationship = classifyKeywordRelationship(match[1]);
+      const relationship =
+        baseRelationship === 'reference' &&
+        NON_BLOCKING_ANNOTATION_PATTERN.test(segment)
+          ? 'non-blocking-reference'
+          : baseRelationship;
       for (const target of extractKeywordReferenceTargets(
         segment,
         currentRepoRef,
@@ -2155,7 +2189,7 @@ export function extractKeywordReferences(
         }
         references.push({
           target,
-          relationship: classifyKeywordRelationship(match[1]),
+          relationship,
           evidence: rawLine.trim(),
         });
       }

--- a/tests/audit-authored-issue.test.mts
+++ b/tests/audit-authored-issue.test.mts
@@ -722,6 +722,48 @@ test('prose-dependency does not warn when the reference already has a Depends on
   assert.equal(finding.severity, undefined);
 });
 
+test('prose-dependency does not warn when the reference already has the non-blocking Refs encoding (#2236)', () => {
+  const body = childBody({
+    extraMarkers:
+      'Refs #1391 (non-blocking)\n\nOnce #1391 merges, this can start.',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+test('prose-dependency recognizes the non-blocking Refs form for a multi-target list (#2236)', () => {
+  const body = childBody({
+    extraMarkers:
+      'Refs #1391, #1392 (non-blocking)\n\n' +
+      'Once #1391 and #1392 merge, this can start.',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.ok(finding, 'prose-dependency finding should be present');
+  assert.equal(finding.severity, undefined);
+});
+
+test('prose-dependency still warns on a plain Refs mention near coordination language (no regression, #2236)', () => {
+  // The bare `Refs #NNN` form (no `(non-blocking)` annotation) was never an
+  // encoded dependency before #2236 and must still be flagged -- only the
+  // explicit non-blocking form is exempt.
+  const body = childBody({
+    extraMarkers: 'Refs #1391\n\nOnce #1391 merges, this can start.',
+  });
+  const report = auditAuthoredIssue(body, { shape: 'child' });
+  const finding = report.findings.find(
+    (entry) => entry.id === 'prose-dependency',
+  );
+  assert.equal(finding?.severity, 'warning');
+  assert.match(finding?.detail ?? '', /#1391/);
+});
+
 test('prose-dependency does not warn on a roadmap-parent breadcrumb sharing a paragraph with unrelated coordination language', () => {
   // Regression test for a real false-positive risk found while designing
   // this check: "Part of ... roadmap (#N)" is a common breadcrumb phrasing

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -776,12 +776,19 @@ test('graph traversal excludes a negated closing-keyword mention as a phantom ne
   assert.deepEqual(graph.roadmapNodes, []);
 });
 
-test('graph traversal never enters or blocks on a non-blocking Refs target (#2236)', async () => {
+test('graph traversal never enters, fetches, or blocks on a non-blocking Refs target (#2236)', async () => {
   // #2236: a roadmap can name a related, currently-blocked follow-up issue
   // as purely informational without A1.5's closure audit treating it as a
   // real child. #703 stays OPEN and unreachable via any other path -- if the
   // fix regressed, it would appear in graph.nodes and
   // graph.executionCandidates and the roadmap would never be closeable.
+  //
+  // #703's own loader throws instead of resolving (CodeRabbit, PR #2381):
+  // `expandForPrefetch`'s bounded-concurrency prefetch crawl expands every
+  // extracted reference target independently of `visitIssue`'s own skip
+  // logic, so a target reachable only via a non-blocking-reference edge must
+  // never be fetched by EITHER pass, not merely excluded from the DFS's own
+  // node bookkeeping.
   const issues = new Map([
     [
       700,
@@ -792,11 +799,17 @@ test('graph traversal never enters or blocks on a non-blocking Refs target (#223
       ),
     ],
     [701, executionIssue(701, 'the real child work')],
-    [703, executionIssue(703, 'unrelated, still open, not a real child')],
   ]);
 
   const graph = await enumerateRoadmapGraph(700, {
-    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+    loadIssue: async (issueNumber) => {
+      if (issueNumber === 703) {
+        throw new Error(
+          'issue #703 must never be fetched: it is reachable only via a non-blocking-reference edge',
+        );
+      }
+      return issues.get(issueNumber) ?? null;
+    },
   });
 
   assert.deepEqual(graph.edges, [

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -286,6 +286,50 @@ Sub issue: #208
   ]);
 });
 
+test('extractKeywordReferences recognizes the non-blocking Refs form (#2236)', () => {
+  const body = `
+Refs #501 (non-blocking)
+Refs #502, #503 (non-blocking)
+Blocked by #504
+`;
+
+  assert.deepEqual(extractKeywordReferences(body), [
+    {
+      target: 501,
+      relationship: 'non-blocking-reference',
+      evidence: 'Refs #501 (non-blocking)',
+    },
+    {
+      target: 502,
+      relationship: 'non-blocking-reference',
+      evidence: 'Refs #502, #503 (non-blocking)',
+    },
+    {
+      target: 503,
+      relationship: 'non-blocking-reference',
+      evidence: 'Refs #502, #503 (non-blocking)',
+    },
+    { target: 504, relationship: 'dependency', evidence: 'Blocked by #504' },
+  ]);
+});
+
+test('extractKeywordReferences never applies the non-blocking annotation to a blocking keyword', () => {
+  // The "(non-blocking)" annotation is scoped to the Refs/Ref keyword's own
+  // 'reference' classification only -- it must never weaken a real
+  // Blocked-by/Depends-on/Closes/Sub-issue dependency, even when the
+  // annotation happens to sit in that keyword's own segment.
+  const body = 'Blocked by #601 (non-blocking)';
+  assert.deepEqual(extractKeywordReferences(body), [
+    { target: 601, relationship: 'dependency', evidence: body },
+  ]);
+});
+
+test('extractKeywordReferences leaves a plain Refs mention as relationship "reference" (no regression)', () => {
+  assert.deepEqual(extractKeywordReferences('Refs #602'), [
+    { target: 602, relationship: 'reference', evidence: 'Refs #602' },
+  ]);
+});
+
 test('extractTaskListReferences accepts uppercase checked items', () => {
   assert.deepEqual(extractTaskListReferences('- [X] #211'), [
     { target: 211, relationship: 'task-list', evidence: '- [X] #211' },
@@ -730,6 +774,74 @@ test('graph traversal excludes a negated closing-keyword mention as a phantom ne
     false,
   );
   assert.deepEqual(graph.roadmapNodes, []);
+});
+
+test('graph traversal never enters or blocks on a non-blocking Refs target (#2236)', async () => {
+  // #2236: a roadmap can name a related, currently-blocked follow-up issue
+  // as purely informational without A1.5's closure audit treating it as a
+  // real child. #703 stays OPEN and unreachable via any other path -- if the
+  // fix regressed, it would appear in graph.nodes and
+  // graph.executionCandidates and the roadmap would never be closeable.
+  const issues = new Map([
+    [
+      700,
+      roadmapIssue(
+        700,
+        '- [ ] #701\nRefs #703 (non-blocking), a known-blocked follow-up.',
+        'non-blocking-roadmap',
+      ),
+    ],
+    [701, executionIssue(701, 'the real child work')],
+    [703, executionIssue(703, 'unrelated, still open, not a real child')],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(700, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(graph.edges, [
+    {
+      source: 700,
+      target: 701,
+      relationship: 'task-list',
+      evidence: '- [ ] #701',
+    },
+    {
+      source: 700,
+      target: 703,
+      relationship: 'non-blocking-reference',
+      evidence: 'Refs #703 (non-blocking), a known-blocked follow-up.',
+    },
+  ]);
+  assert.equal(
+    graph.nodes.some((node) => node.number === 703),
+    false,
+  );
+  assert.deepEqual(graph.executionCandidates, [701]);
+});
+
+test('graph traversal never records a cycle for a non-blocking Refs back-edge (#2236)', async () => {
+  // A closed leaf's plain `Refs #<ancestor>` back-edge is already exempt
+  // from the cycle check (#1278); the non-blocking form must be exempt too,
+  // and regardless of the leaf's open/closed state -- it never even reaches
+  // the cycle-detection branch (see the `visitIssue` early continue).
+  const issues = new Map([
+    [800, roadmapIssue(800, '- [ ] #801', 'non-blocking-cycle-roadmap')],
+    [
+      801,
+      executionIssue(
+        801,
+        'Refs #800 (non-blocking) is the parent roadmap for provenance.',
+      ),
+    ],
+  ]);
+
+  const graph = await enumerateRoadmapGraph(800, {
+    loadIssue: async (issueNumber) => issues.get(issueNumber) ?? null,
+  });
+
+  assert.deepEqual(graph.diagnostics.cycles, []);
+  assert.deepEqual(graph.executionCandidates, [801]);
 });
 
 test('enumerates a flat roadmap graph and separates execution candidates', async () => {


### PR DESCRIPTION
## Summary

- Adds a fourth recognized reference encoding, `Refs #NNN (non-blocking)` (multi-target: `Refs #NNN, #NNN (non-blocking)`), alongside the existing `Blocked by #NNN` / `Depends on #NNN` / task-list checkbox forms.
- `discover-roadmap-graph.mts`'s `extractKeywordReferences` classifies a Refs/Ref segment as `relationship: 'non-blocking-reference'` when it contains a `(non-blocking)` annotation — scoped to the `'reference'` base classification only, so `Blocked by`/`Depends on`/`Closes`/`Sub-issue` keywords are never weakened. `visitIssue` still records the edge (visible in graph output, participates in duplicate-reference bookkeeping) but skips traversal, node-recording, and cycle-detection for it, so its target can only become an `executionCandidates`/A1.5 `open-child` blocker via some *other*, still-blocking edge.
- `audit-authored-issue.mts` gets a new, self-contained `extractNonBlockingReferenceIssueNumbers` extractor feeding `checkProseOnlyDependency`'s `encoded` set, so the advisory `prose-dependency` check no longer flags an already-non-blocking-encoded reference as an undocumented dependency.
- Documents the new form in `skills/issue-authoring/references/contract.md` (canonical) and syncs its `.claude/skills/` mirror.

## Design notes

- The `(non-blocking)` annotation is deliberately duplicated as a standalone extractor in `audit-authored-issue.mts` rather than imported from `discover-roadmap-graph.mts` — matching this repository's existing precedent (`discover-readiness-check.mts`'s own `extractBlockedByIssueNumbers`/`extractDependencyIssueNumbers` already duplicate the same textual parsing independently, per that file's own doc comment) for the same textual encoding recognized by two modules for two different purposes.
- No `.github/instructions/` or `idd-template/` files touched — this issue's candidate files were scoped to `discover-roadmap-graph.mts`, `audit-authored-issue.mts`, and the issue-authoring contract only.

## Test plan

- [x] `pnpm run typecheck` / `pnpm run build` / `pnpm run build:check` (clean post-commit)
- [x] `node --test tests/*.test.mts` — 4331/4331 passing, including 5 new `discover-roadmap-graph.test.mts` tests (unit-level relationship classification + two `enumerateRoadmapGraph` integration tests proving a non-blocking target never enters `nodes`/`executionCandidates` and a non-blocking back-edge never becomes a cycle) and 4 new `audit-authored-issue.test.mts` tests (single-target, multi-target, and a regression test proving a *plain* `Refs #NNN` — no annotation — still gets flagged as before)
- [x] `biome check`, `dprint check "**/*.md"`, `markdownlint-cli2 "**/*.md"`, `cspell lint "**"` all clean
- [x] `node scripts/verify-workshop-integrity.mjs --format table` — 0 issues
- [x] `node scripts/audit-docs.mjs --check` — passes (only pre-existing bundle notices, untouched by this PR)
- [x] `diff skills/issue-authoring/references/contract.md .claude/skills/issue-authoring/references/contract.md` — byte-identical

Refs #2236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicitly marking issue references as non-blocking.
  * Non-blocking references remain visible in relationship and duplicate-reference reporting without affecting dependency traversal or closure checks.
  * Blocking dependency formats continue to behave unchanged.

* **Bug Fixes**
  * Prevented informational references from being incorrectly treated as dependency warnings, roadmap nodes, execution candidates, or cycle blockers.

* **Tests**
  * Added coverage for single and multiple non-blocking references and preserved existing behavior for plain and blocking references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->