### PR TITLE
feat(token-cost): harvest issue-loop samples from GitHub marker join

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -85,6 +85,7 @@ scripts/token-cost-adapter-codex.mjs linguist-generated=true
 scripts/token-cost-adapter-grok.mjs linguist-generated=true
 scripts/token-cost-core.mjs linguist-generated=true
 scripts/token-cost-event.mjs linguist-generated=true
+scripts/token-cost-harvest.mjs linguist-generated=true
 scripts/token-cost-report.mjs linguist-generated=true
 scripts/update-fixtures.mjs linguist-generated=true
 scripts/validate-schemas.mjs linguist-generated=true

--- a/docs/token-cost.md
+++ b/docs/token-cost.md
@@ -52,9 +52,10 @@ records.
 `node scripts/token-cost-harvest.mjs --repo kurone-kito/idd-skill`
 produces those local samples: it scans each installed vendor adapter's
 own session logs, joins any session whose cwd names an issue worktree
-against this repository's own GitHub IDD markers (claim, review
-snapshot) and the connected pull request's own metadata (creation and
-merge timestamps) to reconstruct that issue loop's seven stage windows,
+against this repository's own GitHub IDD markers (claim,
+review-watermark) and the connected pull request's own metadata
+(creation and merge timestamps) to reconstruct that issue loop's
+seven stage windows,
 and appends `kind: "issue-loop"` / `kind: "session"` records to
 `${XDG_STATE_HOME:-$HOME/.local/state}/idd-skill/token-cost/samples.jsonl`
 (`--out` to override, `--dry-run` to only print counts). When

--- a/docs/token-cost.md
+++ b/docs/token-cost.md
@@ -53,7 +53,8 @@ records.
 produces those local samples: it scans each installed vendor adapter's
 own session logs, joins any session whose cwd names an issue worktree
 against this repository's own GitHub IDD markers (claim, review
-snapshot, merge) to reconstruct that issue loop's seven stage windows,
+snapshot) and the connected pull request's own metadata (creation and
+merge timestamps) to reconstruct that issue loop's seven stage windows,
 and appends `kind: "issue-loop"` / `kind: "session"` records to
 `${XDG_STATE_HOME:-$HOME/.local/state}/idd-skill/token-cost/samples.jsonl`
 (`--out` to override, `--dry-run` to only print counts). When

--- a/docs/token-cost.md
+++ b/docs/token-cost.md
@@ -49,6 +49,18 @@ artifact is [`docs/token-cost-snapshot.json`](token-cost-snapshot.json):
 aggregated percentiles, cache-hit ratio, and success rates, with no raw
 records.
 
+`node scripts/token-cost-harvest.mjs --repo kurone-kito/idd-skill`
+produces those local samples: it scans each installed vendor adapter's
+own session logs, joins any session whose cwd names an issue worktree
+against this repository's own GitHub IDD markers (claim, review
+snapshot, merge) to reconstruct that issue loop's seven stage windows,
+and appends `kind: "issue-loop"` / `kind: "session"` records to
+`${XDG_STATE_HOME:-$HOME/.local/state}/idd-skill/token-cost/samples.jsonl`
+(`--out` to override, `--dry-run` to only print counts). When
+`token-cost-event.mjs`'s own explicit phase-event log exists at the
+sibling `events.jsonl` path (`--events` to override), those timestamps
+win over the marker-join reconstruction for the stages they cover.
+
 `node scripts/token-cost-report.mjs`:
 
 - `--in <samples.jsonl> [--in <samples.jsonl> ...] --apply` aggregates

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -359,24 +359,29 @@ function cumulativeSnapshotAt(points, atMs) {
   return result;
 }
 /**
- * Allocates each stage window's usage from a timeline. Windows must be
- * passed in ascending start-time order for the cumulative running
- * baseline to telescope correctly (sum of every window's delta equals
- * the timeline's final cumulative snapshot minus zero -- matching the
- * adapter's own `usage` total, which is the raw latest snapshot, not a
- * value relative to session start).
+ * Allocates each stage window's usage from a timeline. Cumulative mode
+ * looks up the snapshot at each window's own [startMs, endMs) independently
+ * (never a running baseline carried from the previous window): a gap
+ * between windows -- computeStageWindows can leave one before an event
+ * window whose predecessor is also event-sourced -- must not fold that
+ * gap's cumulative growth into the next window's delta, matching delta
+ * mode's natural gap exclusion via sumDeltaInRange. For contiguous windows
+ * (the common case) this is exactly equivalent to the running-baseline
+ * form, since each window's startMs then equals the previous window's
+ * endMs, so the exact-sum invariant (every window's delta sums to the
+ * timeline's final cumulative snapshot minus zero, matching the adapter's
+ * own `usage` total) still holds.
  */
 export function allocateStageUsage(windows, timeline) {
   const out = [];
-  let cumulativeBaseline = ZERO_USAGE;
   for (const window of windows) {
     let usage;
     if (timeline.mode === 'cumulative') {
-      const snapshot =
-        cumulativeSnapshotAt(timeline.points, window.endMs) ??
-        cumulativeBaseline;
-      usage = subtractUsageClamped(snapshot, cumulativeBaseline);
-      cumulativeBaseline = snapshot;
+      const startSnapshot =
+        cumulativeSnapshotAt(timeline.points, window.startMs) ?? ZERO_USAGE;
+      const endSnapshot =
+        cumulativeSnapshotAt(timeline.points, window.endMs) ?? startSnapshot;
+      usage = subtractUsageClamped(endSnapshot, startSnapshot);
     } else {
       usage = sumDeltaInRange(timeline.points, window.startMs, window.endMs);
     }
@@ -436,8 +441,13 @@ export function markAmbiguousOverlaps(samples) {
     }
   }
 }
+// GitHub logins are case-insensitive for account identity; compare
+// case-insensitively so a --trusted-marker-logins/config entry typed with
+// different casing than the GraphQL-reported author.login still matches,
+// rather than silently treating every marker as untrusted.
 function isTrusted(login, trustedLogins) {
-  return trustedLogins.includes(login);
+  const normalized = login.toLowerCase();
+  return trustedLogins.some((trusted) => trusted.toLowerCase() === normalized);
 }
 /** flag > config.json trustedMarkerActors > empty (fail closed: nothing is trusted). */
 export function resolveTrustedMarkerLogins(flagValue) {

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -1,0 +1,934 @@
+// idd-generated-from: src/scripts/token-cost-harvest.mts
+//
+// The scripts/token-cost-harvest.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never
+// the generated .mjs. See docs/typescript-sources.md.
+//
+// Token-cost harvest CLI (#2292). Source-repo only: not HELPER_COMMANDS,
+// registered in tests/helper-invocation-profile.test.mts's
+// SOURCE_REPO_INTERNAL_ENTRY_PATHS instead (see docs/token-cost.md).
+//
+// Scans the already-shipped vendor adapters (token-cost-adapter-claude.mts
+// #2290, token-cost-adapter-codex.mts #2291, token-cost-adapter-grok.mts
+// #2289), joins each harvested session against this repository's own
+// GitHub IDD markers (claim, review-watermark, merge) to reconstruct
+// per-issue IDD stage windows, and writes TokenCostSample JSONL. Does
+// not render the README -- that stays token-cost-report.mjs's job.
+import {
+  existsSync,
+  globSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import { parseCliArgs } from './cli-args.mjs';
+import { ghGraphql } from './gh-exec.mjs';
+import {
+  parseClaimComment,
+  parseForcedHandoffComment,
+  parseReleaseComment,
+  parseReviewWatermarkComment,
+} from './marker-helpers.mjs';
+import {
+  claudeAdapter,
+  defaultClaudeProjectDir,
+  parseClaudeProjectLines,
+} from './token-cost-adapter-claude.mjs';
+import {
+  codexAdapter,
+  defaultCodexSessionsDir,
+  extractSessionCwd,
+  isIddSkillCwd,
+  parseCodexRolloutLines,
+} from './token-cost-adapter-codex.mjs';
+import {
+  defaultGrokSessionsDir,
+  scanGrokSessions,
+} from './token-cost-adapter-grok.mjs';
+import {
+  assertTokenCostSample,
+  redactTokenCostRecord,
+  TOKEN_COST_STAGE_IDS,
+} from './token-cost-core.mjs';
+
+// ---------------------------------------------------------------------------
+// Shared usage arithmetic
+// ---------------------------------------------------------------------------
+const ZERO_USAGE = {
+  inputUncached: 0,
+  cacheRead: 0,
+  cacheCreation: 0,
+  output: 0,
+  reasoning: 0,
+};
+function addUsage(a, b) {
+  return {
+    inputUncached: a.inputUncached + b.inputUncached,
+    cacheRead: a.cacheRead + b.cacheRead,
+    cacheCreation: a.cacheCreation + b.cacheCreation,
+    output: a.output + b.output,
+    reasoning: a.reasoning + b.reasoning,
+  };
+}
+function subtractUsageClamped(a, b) {
+  const clamp = (x, y) => Math.max(0, x - y);
+  return {
+    inputUncached: clamp(a.inputUncached, b.inputUncached),
+    cacheRead: clamp(a.cacheRead, b.cacheRead),
+    cacheCreation: clamp(a.cacheCreation, b.cacheCreation),
+    output: clamp(a.output, b.output),
+    reasoning: clamp(a.reasoning, b.reasoning),
+  };
+}
+function usageTotal(u) {
+  return (
+    u.inputUncached + u.cacheRead + u.cacheCreation + u.output + u.reasoning
+  );
+}
+function toNonNegativeInt(value) {
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : 0;
+}
+function isPlainObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+function toValidTimestampMs(value) {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+/** Mirrors token-cost-adapter-claude.mts's usageFromFields (per-message delta). */
+function claudeUsageFromFields(raw) {
+  const split = raw.cache_creation;
+  const cacheCreation = isPlainObject(split)
+    ? toNonNegativeInt(split.ephemeral_5m_input_tokens) +
+      toNonNegativeInt(split.ephemeral_1h_input_tokens)
+    : toNonNegativeInt(raw.cache_creation_input_tokens);
+  return {
+    inputUncached: toNonNegativeInt(raw.input_tokens),
+    cacheRead: toNonNegativeInt(raw.cache_read_input_tokens),
+    cacheCreation,
+    output: toNonNegativeInt(raw.output_tokens),
+    reasoning: 0,
+  };
+}
+/** Mirrors token-cost-adapter-claude.mts's extractUsage's per-record source: assistant records' message.usage. */
+export function extractClaudeUsageTimeline(records) {
+  const points = [];
+  for (const record of records) {
+    if (!isPlainObject(record) || record.type !== 'assistant') {
+      continue;
+    }
+    const atMs = toValidTimestampMs(record.timestamp);
+    const message = isPlainObject(record.message) ? record.message : undefined;
+    const usageRaw =
+      message && isPlainObject(message.usage) ? message.usage : undefined;
+    if (atMs === undefined || !usageRaw) {
+      continue;
+    }
+    points.push({ atMs, usage: claudeUsageFromFields(usageRaw) });
+  }
+  points.sort((a, b) => a.atMs - b.atMs);
+  return { mode: 'delta', points };
+}
+/** Mirrors token-cost-adapter-codex.mts's usageFromTokenCounts (shared field shape for both cumulative and delta payloads). */
+function codexUsageFromTokenCounts(raw) {
+  const inputTokens = toNonNegativeInt(raw.input_tokens);
+  const cacheRead = toNonNegativeInt(raw.cached_input_tokens);
+  const cacheCreation = toNonNegativeInt(raw.cache_write_input_tokens);
+  const inputUncached =
+    inputTokens >= cacheRead + cacheCreation
+      ? inputTokens - cacheRead - cacheCreation
+      : inputTokens;
+  return {
+    inputUncached,
+    cacheRead,
+    cacheCreation,
+    output: toNonNegativeInt(raw.output_tokens),
+    reasoning: toNonNegativeInt(raw.reasoning_output_tokens),
+  };
+}
+/**
+ * Mirrors token-cost-adapter-codex.mts's extractUsage's own per-session
+ * preference (total_token_usage when any record carries one, else
+ * last_token_usage deltas) -- applied per record here instead of
+ * collapsed to one session total, since stage-window splitting needs
+ * the whole timeline, not just the final value.
+ */
+export function extractCodexUsageTimeline(records) {
+  const tokenCountRecords = [];
+  for (const record of records) {
+    if (!isPlainObject(record) || record.type !== 'token_count') {
+      continue;
+    }
+    const atMs = toValidTimestampMs(record.timestamp);
+    const payload = isPlainObject(record.payload) ? record.payload : undefined;
+    if (atMs === undefined || !payload) {
+      continue;
+    }
+    tokenCountRecords.push({ atMs, payload });
+  }
+  tokenCountRecords.sort((a, b) => a.atMs - b.atMs);
+  const hasCumulative = tokenCountRecords.some((r) =>
+    isPlainObject(r.payload.total_token_usage),
+  );
+  if (hasCumulative) {
+    const points = [];
+    for (const { atMs, payload } of tokenCountRecords) {
+      const total = payload.total_token_usage;
+      if (isPlainObject(total)) {
+        points.push({ atMs, usage: codexUsageFromTokenCounts(total) });
+      }
+    }
+    return { mode: 'cumulative', points };
+  }
+  const points = [];
+  for (const { atMs, payload } of tokenCountRecords) {
+    const last = payload.last_token_usage;
+    if (isPlainObject(last)) {
+      points.push({ atMs, usage: codexUsageFromTokenCounts(last) });
+    }
+  }
+  return { mode: 'delta', points };
+}
+const CLAIM_STAGE_CAP_MS = 15 * 60 * 1000;
+/** Thin cap for the merge stage when no cleanup marker activity is resolvable. */
+const MERGE_STAGE_THIN_CAP_MS = 15 * 60 * 1000;
+/**
+ * Builds the contiguous, gap-free stage-window tiling of
+ * [sessionStartedAtMs, sessionEndedAtMs) per the issue's marker-join
+ * table, then lets --events override individual stage boundaries.
+ * Contiguous tiling (each window starts exactly where the previous one
+ * ended) is what makes the per-stage usage allocation below sum back to
+ * the session total exactly, in both delta and cumulative modes.
+ */
+export function computeStageWindows(
+  sessionStartedAtMs,
+  sessionEndedAtMs,
+  ctx,
+  eventWindows,
+) {
+  const windows = [];
+  const push = (id, startMs, endMs) => {
+    if (endMs > startMs) {
+      windows.push({ id, startMs, endMs, source: 'marker' });
+    }
+  };
+  if (ctx.claimedAtMs === null) {
+    return { windows: [], attribution: 'marker-join' };
+  }
+  let cursor = ctx.claimedAtMs;
+  push('discover', sessionStartedAtMs, cursor);
+  const claimCap = cursor + CLAIM_STAGE_CAP_MS;
+  if (ctx.prCreatedAtMs !== null) {
+    const claimEnd = Math.min(claimCap, ctx.prCreatedAtMs);
+    push('claim', cursor, claimEnd);
+    cursor = claimEnd;
+    push('work', cursor, ctx.prCreatedAtMs);
+    cursor = ctx.prCreatedAtMs;
+    const submitPrEnd =
+      ctx.firstReviewAtMs !== null ? ctx.firstReviewAtMs : sessionEndedAtMs;
+    push('submit-pr', cursor, submitPrEnd);
+    cursor = submitPrEnd;
+    if (ctx.firstReviewAtMs !== null) {
+      const reviewEnd =
+        ctx.prMergedAtMs !== null ? ctx.prMergedAtMs : sessionEndedAtMs;
+      push('review', cursor, reviewEnd);
+      cursor = reviewEnd;
+      if (ctx.prMergedAtMs !== null) {
+        // cursor === ctx.prMergedAtMs here (reviewEnd above), matching the
+        // table's "merge: merged_at → cleanup marker or merged_at+thin cap".
+        const uncappedMergeEnd =
+          ctx.cleanupAtMs !== null
+            ? ctx.cleanupAtMs
+            : ctx.prMergedAtMs + MERGE_STAGE_THIN_CAP_MS;
+        const mergeEnd = Math.min(uncappedMergeEnd, sessionEndedAtMs);
+        push('merge', cursor, mergeEnd);
+        cursor = mergeEnd;
+        push('cleanup', cursor, sessionEndedAtMs);
+        cursor = sessionEndedAtMs;
+      }
+    }
+  } else {
+    const claimEnd = Math.min(claimCap, sessionEndedAtMs);
+    push('claim', cursor, claimEnd);
+    cursor = claimEnd;
+    push('work', cursor, sessionEndedAtMs);
+    cursor = sessionEndedAtMs;
+  }
+  let attribution = 'marker-join';
+  const byId = new Map(windows.map((w) => [w.id, w]));
+  for (const [stageId, eventWindow] of eventWindows) {
+    if (eventWindow.endMs <= eventWindow.startMs) {
+      continue;
+    }
+    const existingIndex = windows.findIndex((w) => w.id === stageId);
+    const overridden = {
+      id: stageId,
+      startMs: eventWindow.startMs,
+      endMs: eventWindow.endMs,
+      source: 'event',
+    };
+    if (existingIndex >= 0) {
+      windows[existingIndex] = overridden;
+    } else {
+      windows.push(overridden);
+    }
+    byId.set(stageId, overridden);
+    attribution = 'phase-event';
+  }
+  windows.sort((a, b) => a.startMs - b.startMs);
+  return { windows, attribution };
+}
+/** Sums every delta-mode point whose timestamp falls in [startMs, endMs). */
+function sumDeltaInRange(points, startMs, endMs) {
+  let sum = ZERO_USAGE;
+  for (const point of points) {
+    if (point.atMs >= startMs && point.atMs < endMs) {
+      sum = addUsage(sum, point.usage);
+    }
+  }
+  return sum;
+}
+/** Last cumulative snapshot at or before atMs, or null when none exists yet. */
+function cumulativeSnapshotAt(points, atMs) {
+  let result = null;
+  for (const point of points) {
+    if (point.atMs <= atMs) {
+      result = point.usage;
+    } else {
+      break;
+    }
+  }
+  return result;
+}
+/**
+ * Allocates each stage window's usage from a timeline. Windows must be
+ * passed in ascending start-time order for the cumulative running
+ * baseline to telescope correctly (sum of every window's delta equals
+ * the timeline's final cumulative snapshot minus zero -- matching the
+ * adapter's own `usage` total, which is the raw latest snapshot, not a
+ * value relative to session start).
+ */
+export function allocateStageUsage(windows, timeline) {
+  const out = [];
+  let cumulativeBaseline = ZERO_USAGE;
+  for (const window of windows) {
+    let usage;
+    if (timeline.mode === 'cumulative') {
+      const snapshot =
+        cumulativeSnapshotAt(timeline.points, window.endMs) ??
+        cumulativeBaseline;
+      usage = subtractUsageClamped(snapshot, cumulativeBaseline);
+      cumulativeBaseline = snapshot;
+    } else {
+      usage = sumDeltaInRange(timeline.points, window.startMs, window.endMs);
+    }
+    if (usageTotal(usage) > 0) {
+      out.push({ id: window.id, usage });
+    }
+  }
+  return out;
+}
+// ---------------------------------------------------------------------------
+// Outcome + ambiguity
+// ---------------------------------------------------------------------------
+export function deriveOutcome(ctx) {
+  if (ctx.prMergedAtMs !== null) {
+    return 'merged';
+  }
+  if (ctx.humanHandoff) {
+    return 'human-handoff';
+  }
+  if (ctx.unclaimedMatched) {
+    return 'unclaimed';
+  }
+  return 'aborted';
+}
+/**
+ * Two harvested issue-loop samples on the same issue with overlapping
+ * [startedAt, endedAt) ranges mean two concurrent sessions genuinely
+ * worked the same issue -- neither's usage can be cleanly attributed, so
+ * both are marked ambiguous/unknown rather than either being trusted.
+ */
+export function markAmbiguousOverlaps(samples) {
+  const byIssue = new Map();
+  for (const entry of samples) {
+    if (entry.issueNumber === undefined || entry.sample.kind !== 'issue-loop') {
+      continue;
+    }
+    const group = byIssue.get(entry.issueNumber) ?? [];
+    group.push(entry);
+    byIssue.set(entry.issueNumber, group);
+  }
+  for (const group of byIssue.values()) {
+    for (let i = 0; i < group.length; i++) {
+      for (let j = i + 1; j < group.length; j++) {
+        const a = group[i];
+        const b = group[j];
+        const overlap =
+          a.startedAtMs < b.endedAtMs && b.startedAtMs < a.endedAtMs;
+        if (overlap) {
+          const sampleA = a.sample;
+          const sampleB = b.sample;
+          sampleA.ambiguous = true;
+          sampleB.ambiguous = true;
+          sampleA.outcome = 'unknown';
+          sampleB.outcome = 'unknown';
+        }
+      }
+    }
+  }
+}
+function isTrusted(login, trustedLogins) {
+  return trustedLogins.includes(login);
+}
+/** flag > config.json trustedMarkerActors > empty (fail closed: nothing is trusted). */
+export function resolveTrustedMarkerLogins(flagValue) {
+  const fromFlag = flagValue
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  if (fromFlag.length > 0) {
+    return fromFlag;
+  }
+  try {
+    const raw = readFileSync(
+      join(process.cwd(), '.github/idd/config.json'),
+      'utf8',
+    );
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed.trustedMarkerActors)) {
+      return parsed.trustedMarkerActors.filter((v) => typeof v === 'string');
+    }
+  } catch {}
+  return [];
+}
+const ISSUE_LOOP_CONTEXT_QUERY = `
+query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      comments(first:100){nodes{body createdAt author{login}}}
+      timelineItems(last:100,itemTypes:[CONNECTED_EVENT,DISCONNECTED_EVENT]){
+        nodes{
+          __typename
+          ... on ConnectedEvent{subject{__typename ... on PullRequest{
+            number state headRefName createdAt mergedAt
+            reviews(first:1){nodes{submittedAt}}
+          }}}
+          ... on DisconnectedEvent{subject{__typename ... on PullRequest{number}}}
+        }
+      }
+    }
+  }
+}`;
+/** Fetches issue comments plus the earliest live-connected same-branch PR (with its first review + merge timestamp) via one batched GraphQL query. */
+export function fetchIssueLoopGithubContext(
+  owner,
+  repo,
+  issueNumber,
+  trustedLogins,
+) {
+  const response = ghGraphql(ISSUE_LOOP_CONTEXT_QUERY, {
+    owner,
+    repo,
+    number: issueNumber,
+  });
+  const issue = response.data?.repository?.issue;
+  const commentNodes = Array.isArray(issue?.comments?.nodes)
+    ? issue.comments.nodes
+    : [];
+  const comments = [];
+  for (const node of commentNodes) {
+    if (!isPlainObject(node)) {
+      continue;
+    }
+    const login =
+      isPlainObject(node.author) && typeof node.author.login === 'string'
+        ? node.author.login
+        : '';
+    const body = typeof node.body === 'string' ? node.body : '';
+    const createdAt = typeof node.createdAt === 'string' ? node.createdAt : '';
+    if (login && body && createdAt && isTrusted(login, trustedLogins)) {
+      comments.push({ body, createdAt, login });
+    }
+  }
+  const timelineNodes = Array.isArray(issue?.timelineItems?.nodes)
+    ? issue.timelineItems.nodes
+    : [];
+  const connected = new Map();
+  const disconnected = new Set();
+  for (const node of timelineNodes) {
+    if (!isPlainObject(node)) {
+      continue;
+    }
+    const subject = isPlainObject(node.subject) ? node.subject : undefined;
+    const prNumber =
+      subject && typeof subject.number === 'number'
+        ? subject.number
+        : undefined;
+    if (prNumber === undefined) {
+      continue;
+    }
+    if (node.__typename === 'ConnectedEvent') {
+      connected.set(prNumber, subject);
+      disconnected.delete(prNumber);
+    } else if (node.__typename === 'DisconnectedEvent') {
+      disconnected.add(prNumber);
+    }
+  }
+  let chosen = null;
+  let chosenNumber = null;
+  for (const [prNumber, subject] of connected) {
+    if (disconnected.has(prNumber)) {
+      continue;
+    }
+    const headRefName =
+      typeof subject.headRefName === 'string' ? subject.headRefName : '';
+    if (!headRefName.startsWith(`issue/${issueNumber}-`)) {
+      continue;
+    }
+    const createdAtMs = toValidTimestampMs(subject.createdAt);
+    if (createdAtMs === undefined) {
+      continue;
+    }
+    const chosenCreatedAtMs = chosen
+      ? (toValidTimestampMs(chosen.createdAt) ?? Infinity)
+      : Infinity;
+    if (createdAtMs < chosenCreatedAtMs) {
+      chosen = subject;
+      chosenNumber = prNumber;
+    }
+  }
+  if (!chosen) {
+    return {
+      comments,
+      prNumber: null,
+      prHeadRefName: null,
+      prCreatedAtMs: null,
+      prMergedAtMs: null,
+      firstReviewAtMs: null,
+    };
+  }
+  const reviews =
+    isPlainObject(chosen.reviews) && Array.isArray(chosen.reviews.nodes)
+      ? chosen.reviews.nodes
+      : [];
+  let firstReviewAtMs = null;
+  for (const review of reviews) {
+    if (!isPlainObject(review)) {
+      continue;
+    }
+    const submittedAtMs = toValidTimestampMs(review.submittedAt);
+    if (
+      submittedAtMs !== undefined &&
+      (firstReviewAtMs === null || submittedAtMs < firstReviewAtMs)
+    ) {
+      firstReviewAtMs = submittedAtMs;
+    }
+  }
+  return {
+    comments,
+    prNumber: chosenNumber,
+    prHeadRefName:
+      typeof chosen.headRefName === 'string' ? chosen.headRefName : null,
+    prCreatedAtMs: toValidTimestampMs(chosen.createdAt) ?? null,
+    prMergedAtMs: toValidTimestampMs(chosen.mergedAt) ?? null,
+    firstReviewAtMs,
+  };
+}
+/**
+ * Resolves the full {@link IssueLoopGithubContext} for one session's
+ * [sessionStartedAtMs, sessionEndedAtMs) window: the first trusted
+ * claimed-by comment posted in that range, the earliest first trusted
+ * review-watermark (compared against the linked PR's first submitted
+ * review), and whether that claim was later released or handed off
+ * before merge.
+ */
+export function resolveIssueLoopContext(
+  owner,
+  repo,
+  issueNumber,
+  sessionStartedAtMs,
+  sessionEndedAtMs,
+  trustedLogins,
+) {
+  const github = fetchIssueLoopGithubContext(
+    owner,
+    repo,
+    issueNumber,
+    trustedLogins,
+  );
+  let claimedAtMs = null;
+  let claimAgentId = null;
+  let claimId = null;
+  for (const comment of github.comments) {
+    const claim = parseClaimComment(comment.body, comment.createdAt);
+    if (!claim) {
+      continue;
+    }
+    const atMs = toValidTimestampMs(claim.createdAt);
+    if (
+      atMs === undefined ||
+      atMs < sessionStartedAtMs ||
+      atMs > sessionEndedAtMs
+    ) {
+      continue;
+    }
+    if (claimedAtMs === null || atMs < claimedAtMs) {
+      claimedAtMs = atMs;
+      claimAgentId = claim.agentId;
+      claimId = claim.claimId;
+    }
+  }
+  if (claimedAtMs === null) {
+    return null;
+  }
+  let firstWatermarkAtMs = null;
+  for (const comment of github.comments) {
+    const watermark = parseReviewWatermarkComment(
+      comment.body,
+      comment.createdAt,
+    );
+    if (!watermark) {
+      continue;
+    }
+    const atMs = toValidTimestampMs(watermark.createdAt);
+    if (
+      atMs !== undefined &&
+      (firstWatermarkAtMs === null || atMs < firstWatermarkAtMs)
+    ) {
+      firstWatermarkAtMs = atMs;
+    }
+  }
+  const firstReviewAtMs = [firstWatermarkAtMs, github.firstReviewAtMs]
+    .filter((v) => v !== null)
+    .reduce((min, v) => (min === null || v < min ? v : min), null);
+  let unclaimedMatched = false;
+  let humanHandoff = false;
+  for (const comment of github.comments) {
+    const release = parseReleaseComment(comment.body);
+    if (
+      release &&
+      release.agentId === claimAgentId &&
+      release.claimId === claimId
+    ) {
+      unclaimedMatched = true;
+    }
+    const handoff = parseForcedHandoffComment(comment.body, comment.createdAt);
+    if (
+      handoff &&
+      handoff.oldAgentId === claimAgentId &&
+      handoff.oldClaimId === claimId
+    ) {
+      humanHandoff = true;
+    }
+  }
+  return {
+    claimedAtMs,
+    prCreatedAtMs: github.prCreatedAtMs,
+    prHeadRefName: github.prHeadRefName,
+    prMergedAtMs: github.prMergedAtMs,
+    firstReviewAtMs,
+    cleanupAtMs: null,
+    unclaimedMatched,
+    humanHandoff,
+  };
+}
+// ---------------------------------------------------------------------------
+// --events file
+// ---------------------------------------------------------------------------
+function eventKey(issueNumber, stageId) {
+  return `${issueNumber}:${stageId}`;
+}
+/** Reads a --events JSONL file into per-(issueNumber, stageId) enter/exit window overrides. A missing file is not an error -- returns an empty map. */
+export function readEventWindows(path) {
+  const result = new Map();
+  if (!existsSync(path)) {
+    return result;
+  }
+  const enterAt = new Map();
+  const exitAt = new Map();
+  const text = readFileSync(path, 'utf8');
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!isPlainObject(parsed)) {
+      continue;
+    }
+    const event = parsed;
+    if (
+      typeof event.issueNumber !== 'number' ||
+      typeof event.stageId !== 'string' ||
+      !TOKEN_COST_STAGE_IDS.includes(event.stageId) ||
+      (event.event !== 'enter' && event.event !== 'exit')
+    ) {
+      continue;
+    }
+    const atMs = toValidTimestampMs(event.at);
+    if (atMs === undefined) {
+      continue;
+    }
+    const key = eventKey(event.issueNumber, event.stageId);
+    if (event.event === 'enter') {
+      enterAt.set(key, atMs);
+    } else {
+      exitAt.set(key, atMs);
+    }
+  }
+  for (const [key, start] of enterAt) {
+    const end = exitAt.get(key);
+    if (end !== undefined) {
+      result.set(key, { startMs: start, endMs: end });
+    }
+  }
+  return result;
+}
+function eventWindowsForIssue(all, issueNumber) {
+  const out = new Map();
+  for (const stageId of TOKEN_COST_STAGE_IDS) {
+    const window = all.get(eventKey(issueNumber, stageId));
+    if (window) {
+      out.set(stageId, window);
+    }
+  }
+  return out;
+}
+function scanClaudeVendorSessions(projectDir) {
+  const out = [];
+  if (!existsSync(projectDir)) {
+    return out;
+  }
+  const files = globSync('*.jsonl', { cwd: projectDir, withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => join(entry.parentPath, entry.name))
+    .sort();
+  for (const file of files) {
+    try {
+      const records = parseClaudeProjectLines(readFileSync(file, 'utf8'));
+      const adapterResult = claudeAdapter.harvest({
+        records,
+        fileBasename: basename(file),
+      });
+      out.push({
+        vendor: 'claude',
+        adapterResult,
+        timeline: extractClaudeUsageTimeline(records),
+      });
+    } catch (error) {
+      process.stderr.write(
+        `token-cost-harvest: skipping ${file}: ${error.message}\n`,
+      );
+    }
+  }
+  return out;
+}
+function scanCodexVendorSessions(sessionsDir) {
+  const out = [];
+  if (!existsSync(sessionsDir)) {
+    return out;
+  }
+  const files = globSync('**/rollout-*.jsonl', {
+    cwd: sessionsDir,
+    withFileTypes: true,
+  })
+    .filter((entry) => entry.isFile())
+    .map((entry) => join(entry.parentPath, entry.name))
+    .sort();
+  for (const file of files) {
+    try {
+      const records = parseCodexRolloutLines(readFileSync(file, 'utf8'));
+      if (!isIddSkillCwd(extractSessionCwd(records))) {
+        continue;
+      }
+      const adapterResult = codexAdapter.harvest({
+        records,
+        fileBasename: basename(file),
+      });
+      out.push({
+        vendor: 'codex',
+        adapterResult,
+        timeline: extractCodexUsageTimeline(records),
+      });
+    } catch (error) {
+      process.stderr.write(
+        `token-cost-harvest: skipping ${file}: ${error.message}\n`,
+      );
+    }
+  }
+  return out;
+}
+/**
+ * Grok sessions are joined and classified the same as claude/codex, but
+ * without per-stage usage splitting yet: `scanGrokSessions` already owns
+ * a materially more complex read (subagent updates.jsonl rollups,
+ * signals.json, events.jsonl fallback -- see token-cost-adapter-grok.mts's
+ * module doc), so replicating "read once, feed the same records to a
+ * local timeline extractor" here would mean re-deriving that whole read,
+ * not just one small per-record usage-field mapping the way the
+ * claude/codex extractors do. An empty timeline means allocateStageUsage
+ * omits every stage for a grok issue-loop sample (the session's own
+ * aggregate `usage` total is still present and correct); a follow-up
+ * issue can add extractGrokUsageTimeline once that read is worth sharing.
+ */
+function scanGrokVendorSessions(sessionsDir) {
+  return scanGrokSessions({ sessionsDir }).map((adapterResult) => ({
+    vendor: 'grok',
+    adapterResult,
+    timeline: { mode: 'delta', points: [] },
+  }));
+}
+// ---------------------------------------------------------------------------
+// Sample assembly
+// ---------------------------------------------------------------------------
+export function buildSample(
+  session,
+  owner,
+  repo,
+  eventWindowsAll,
+  trustedLogins,
+) {
+  const base = session.adapterResult.sample;
+  const startedAtMs = toValidTimestampMs(base.startedAt) ?? 0;
+  const endedAtMs = toValidTimestampMs(base.endedAt) ?? startedAtMs;
+  const issueNumber = session.adapterResult.joinHints?.issueNumber;
+  if (issueNumber === undefined) {
+    return { sample: base, startedAtMs, endedAtMs };
+  }
+  const ctx = resolveIssueLoopContext(
+    owner,
+    repo,
+    issueNumber,
+    startedAtMs,
+    endedAtMs,
+    trustedLogins,
+  );
+  if (ctx === null) {
+    return { sample: base, issueNumber, startedAtMs, endedAtMs };
+  }
+  const eventWindows = eventWindowsForIssue(eventWindowsAll, issueNumber);
+  const { windows, attribution } = computeStageWindows(
+    startedAtMs,
+    endedAtMs,
+    ctx,
+    eventWindows,
+  );
+  const stages = allocateStageUsage(windows, session.timeline);
+  const sample = {
+    ...base,
+    kind: 'issue-loop',
+    issueNumber,
+    stages,
+    attribution: attribution,
+    outcome: deriveOutcome(ctx),
+  };
+  const redacted = redactTokenCostRecord(sample);
+  return { sample: redacted, issueNumber, startedAtMs, endedAtMs };
+}
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+function defaultStateDir() {
+  const base =
+    process.env.XDG_STATE_HOME?.trim() || join(homedir(), '.local', 'state');
+  return join(base, 'idd-skill', 'token-cost');
+}
+// Flag-spec keys stay the dashed literal on purpose -- see cli-args.mts's
+// module header for the full invariant.
+const TOKEN_COST_HARVEST_FLAG_SPEC = {
+  '--repo': { type: 'string', default: '' },
+  '--out': { type: 'string', default: '' },
+  '--events': { type: 'string', default: '' },
+  '--dry-run': { type: 'boolean', default: false },
+  '--trusted-marker-logins': { type: 'string', default: '' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/token-cost-harvest.mjs --repo <owner>/<repo> [--out <path>] [--events <path>] [--dry-run]
+
+  --repo <owner/repo>          Repository to join harvested sessions against. Required.
+  --out <path>                 Output samples JSONL path (default:
+                                ${defaultStateDir()}/samples.jsonl).
+  --events <path>               Phase-event JSONL path (default:
+                                ${defaultStateDir()}/events.jsonl). Missing file is not an error.
+  --dry-run                    Print counts to stderr; write nothing.
+  --trusted-marker-logins a,b   Logins whose IDD markers are trusted (default: .github/idd/config.json's trustedMarkerActors).
+  --help, -h                   Show this help.
+`);
+}
+function runCli(argv) {
+  const { values, help } = parseCliArgs(argv, TOKEN_COST_HARVEST_FLAG_SPEC);
+  if (help) {
+    printHelp();
+    return;
+  }
+  const repoFlag = values.repo;
+  if (!repoFlag.includes('/')) {
+    process.stderr.write('--repo <owner>/<repo> is required\n');
+    process.exitCode = 2;
+    return;
+  }
+  const [owner, repo] = repoFlag.split('/');
+  const dryRun = values['dry-run'];
+  const outPath = values.out || join(defaultStateDir(), 'samples.jsonl');
+  const eventsPath = values.events || join(defaultStateDir(), 'events.jsonl');
+  const trustedLogins = resolveTrustedMarkerLogins(
+    values['trusted-marker-logins'],
+  );
+  const eventWindows = readEventWindows(eventsPath);
+  const sessions = [
+    ...scanClaudeVendorSessions(defaultClaudeProjectDir()),
+    ...scanCodexVendorSessions(defaultCodexSessionsDir()),
+    ...scanGrokVendorSessions(defaultGrokSessionsDir()),
+  ];
+  const harvested = [];
+  for (const session of sessions) {
+    try {
+      const built = buildSample(
+        session,
+        owner,
+        repo,
+        eventWindows,
+        trustedLogins,
+      );
+      assertTokenCostSample(built.sample);
+      harvested.push(built);
+    } catch (error) {
+      process.stderr.write(
+        `token-cost-harvest: skipping ${session.vendor} session: ${error.message}\n`,
+      );
+    }
+  }
+  markAmbiguousOverlaps(harvested);
+  const issueLoopCount = harvested.filter(
+    (h) => h.sample.kind === 'issue-loop',
+  ).length;
+  process.stderr.write(
+    `token-cost-harvest: ${harvested.length} sample(s) (${issueLoopCount} issue-loop, ${harvested.length - issueLoopCount} session)\n`,
+  );
+  if (dryRun) {
+    return;
+  }
+  mkdirSync(dirname(outPath), { recursive: true });
+  const body = harvested.map((h) => JSON.stringify(h.sample)).join('\n');
+  writeFileSync(outPath, harvested.length > 0 ? `${body}\n` : '');
+  process.stdout.write(
+    `token-cost-harvest: wrote ${outPath} (n=${harvested.length})\n`,
+  );
+}
+if (import.meta.main) {
+  runCli(process.argv.slice(2));
+}

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -292,9 +292,13 @@ export function computeStageWindows(
   // disagree with its marker-derived neighbors (or two overrides can
   // disagree with each other), and naively overlaying them can leave
   // windows that overlap -- which would double-count delta-mode usage in
-  // allocateStageUsage below. Clamp each window's start to a monotonic
-  // cursor and drop it if that clamp consumes the whole window; a gap is
-  // fine (its usage points simply attribute to no stage), an overlap is not.
+  // allocateStageUsage below. An event window is an authoritative explicit
+  // timestamp, so it is only ever clamped forward past a conflicting
+  // predecessor, never expanded. A marker window is a synthetic
+  // reconstruction with no independent authority, so it always starts
+  // exactly at the running cursor -- flowing backward to fill any gap an
+  // event override left behind -- rather than leaving that usage
+  // unattributed to any stage.
   const finalWindows = [];
   let normalizeCursor = sessionStartedAtMs;
   for (const stageId of TOKEN_COST_STAGE_IDS) {
@@ -302,7 +306,10 @@ export function computeStageWindows(
     if (!window) {
       continue;
     }
-    const startMs = Math.max(window.startMs, normalizeCursor);
+    const startMs =
+      window.source === 'event'
+        ? Math.max(window.startMs, normalizeCursor)
+        : normalizeCursor;
     const endMs = Math.min(window.endMs, sessionEndedAtMs);
     if (endMs > startMs) {
       finalWindows.push({ ...window, startMs, endMs });
@@ -599,10 +606,13 @@ export function resolveIssueLoopContext(
       continue;
     }
     const atMs = toValidTimestampMs(claim.createdAt);
+    // Half-open [sessionStartedAtMs, sessionEndedAtMs), matching this
+    // function's documented session window: a claim marker at exactly
+    // sessionEndedAtMs is out of range.
     if (
       atMs === undefined ||
       atMs < sessionStartedAtMs ||
-      atMs > sessionEndedAtMs
+      atMs >= sessionEndedAtMs
     ) {
       continue;
     }
@@ -906,7 +916,7 @@ function printHelp() {
   process.stdout.write(`Usage:
   node scripts/token-cost-harvest.mjs --repo <owner>/<repo> [--out <path>] [--events <path>] [--dry-run]
 
-  --repo <owner/repo>          Repository to join harvested sessions against. Required.
+  --repo <owner>/<repo>         Repository to join harvested sessions against. Required.
   --out <path>                 Output samples JSONL path (default:
                                 ${defaultStateDir()}/samples.jsonl).
   --events <path>               Phase-event JSONL path (default:
@@ -957,19 +967,28 @@ export function readExistingVendorSessionKeys(outPath) {
   }
   return keys;
 }
+/** Validates and splits a --repo <owner>/<repo> flag value; null for anything but exactly two non-empty segments. */
+export function parseRepoFlag(repoFlag) {
+  const parts = repoFlag.split('/');
+  if (parts.length !== 2 || parts.some((part) => part === '')) {
+    return null;
+  }
+  const [owner, repo] = parts;
+  return { owner, repo };
+}
 function runCli(argv) {
   const { values, help } = parseCliArgs(argv, TOKEN_COST_HARVEST_FLAG_SPEC);
   if (help) {
     printHelp();
     return;
   }
-  const repoFlag = values.repo;
-  if (!repoFlag.includes('/')) {
+  const parsedRepo = parseRepoFlag(values.repo);
+  if (!parsedRepo) {
     process.stderr.write('--repo <owner>/<repo> is required\n');
     process.exitCode = 2;
     return;
   }
-  const [owner, repo] = repoFlag.split('/');
+  const { owner, repo } = parsedRepo;
   const dryRun = values['dry-run'];
   const outPath = values.out || join(defaultStateDir(), 'samples.jsonl');
   const eventsPath = values.events || join(defaultStateDir(), 'events.jsonl');

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -15,11 +15,11 @@
 // per-issue IDD stage windows, and writes TokenCostSample JSONL. Does
 // not render the README -- that stays token-cost-report.mjs's job.
 import {
+  appendFileSync,
   existsSync,
   globSync,
   mkdirSync,
   readFileSync,
-  writeFileSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
@@ -280,23 +280,36 @@ export function computeStageWindows(
     if (eventWindow.endMs <= eventWindow.startMs) {
       continue;
     }
-    const existingIndex = windows.findIndex((w) => w.id === stageId);
-    const overridden = {
+    byId.set(stageId, {
       id: stageId,
       startMs: eventWindow.startMs,
       endMs: eventWindow.endMs,
       source: 'event',
-    };
-    if (existingIndex >= 0) {
-      windows[existingIndex] = overridden;
-    } else {
-      windows.push(overridden);
-    }
-    byId.set(stageId, overridden);
+    });
     attribution = 'phase-event';
   }
-  windows.sort((a, b) => a.startMs - b.startMs);
-  return { windows, attribution };
+  // Re-tile in canonical stage order: an --events override's timestamps can
+  // disagree with its marker-derived neighbors (or two overrides can
+  // disagree with each other), and naively overlaying them can leave
+  // windows that overlap -- which would double-count delta-mode usage in
+  // allocateStageUsage below. Clamp each window's start to a monotonic
+  // cursor and drop it if that clamp consumes the whole window; a gap is
+  // fine (its usage points simply attribute to no stage), an overlap is not.
+  const finalWindows = [];
+  let normalizeCursor = sessionStartedAtMs;
+  for (const stageId of TOKEN_COST_STAGE_IDS) {
+    const window = byId.get(stageId);
+    if (!window) {
+      continue;
+    }
+    const startMs = Math.max(window.startMs, normalizeCursor);
+    const endMs = Math.min(window.endMs, sessionEndedAtMs);
+    if (endMs > startMs) {
+      finalWindows.push({ ...window, startMs, endMs });
+      normalizeCursor = endMs;
+    }
+  }
+  return { windows: finalWindows, attribution };
 }
 /** Sums every delta-mode point whose timestamp falls in [startMs, endMs). */
 function sumDeltaInRange(points, startMs, endMs) {
@@ -608,7 +621,14 @@ export function resolveIssueLoopContext(
       comment.body,
       comment.createdAt,
     );
-    if (!watermark) {
+    if (
+      !watermark ||
+      watermark.agentId !== claimAgentId ||
+      watermark.claimId !== claimId
+    ) {
+      // Skip watermarks bound to a different claim attempt (for example a
+      // stale one from before a takeover) -- same ownership check the
+      // release/handoff matching below already applies.
       continue;
     }
     const atMs = toValidTimestampMs(watermark.createdAt);
@@ -656,10 +676,18 @@ export function resolveIssueLoopContext(
 // ---------------------------------------------------------------------------
 // --events file
 // ---------------------------------------------------------------------------
-function eventKey(issueNumber, stageId) {
-  return `${issueNumber}:${stageId}`;
+const TOKEN_COST_VENDORS = ['grok', 'claude', 'codex'];
+function isTokenCostVendor(value) {
+  return typeof value === 'string' && TOKEN_COST_VENDORS.includes(value);
 }
-/** Reads a --events JSONL file into per-(issueNumber, stageId) enter/exit window overrides. A missing file is not an error -- returns an empty map. */
+// Keyed by vendor too, not just (issueNumber, stageId): two different vendor
+// sessions can both log phase events for the same issue and stage (a
+// claude->codex handoff mid-loop), and their enter/exit timestamps must not
+// be paired across vendors into one bogus window.
+function eventKey(issueNumber, vendor, stageId) {
+  return `${issueNumber}:${vendor}:${stageId}`;
+}
+/** Reads a --events JSONL file into per-(issueNumber, vendor, stageId) enter/exit window overrides. A missing file is not an error -- returns an empty map. */
 export function readEventWindows(path) {
   const result = new Map();
   if (!existsSync(path)) {
@@ -687,6 +715,7 @@ export function readEventWindows(path) {
       typeof event.issueNumber !== 'number' ||
       typeof event.stageId !== 'string' ||
       !TOKEN_COST_STAGE_IDS.includes(event.stageId) ||
+      !isTokenCostVendor(event.vendor) ||
       (event.event !== 'enter' && event.event !== 'exit')
     ) {
       continue;
@@ -695,7 +724,7 @@ export function readEventWindows(path) {
     if (atMs === undefined) {
       continue;
     }
-    const key = eventKey(event.issueNumber, event.stageId);
+    const key = eventKey(event.issueNumber, event.vendor, event.stageId);
     if (event.event === 'enter') {
       enterAt.set(key, atMs);
     } else {
@@ -710,10 +739,10 @@ export function readEventWindows(path) {
   }
   return result;
 }
-function eventWindowsForIssue(all, issueNumber) {
+function eventWindowsForIssue(all, issueNumber, vendor) {
   const out = new Map();
   for (const stageId of TOKEN_COST_STAGE_IDS) {
-    const window = all.get(eventKey(issueNumber, stageId));
+    const window = all.get(eventKey(issueNumber, vendor, stageId));
     if (window) {
       out.set(stageId, window);
     }
@@ -832,7 +861,11 @@ export function buildSample(
   if (ctx === null) {
     return { sample: base, issueNumber, startedAtMs, endedAtMs };
   }
-  const eventWindows = eventWindowsForIssue(eventWindowsAll, issueNumber);
+  const eventWindows = eventWindowsForIssue(
+    eventWindowsAll,
+    issueNumber,
+    session.vendor,
+  );
   const { windows, attribution } = computeStageWindows(
     startedAtMs,
     endedAtMs,
@@ -882,6 +915,47 @@ function printHelp() {
   --trusted-marker-logins a,b   Logins whose IDD markers are trusted (default: .github/idd/config.json's trustedMarkerActors).
   --help, -h                   Show this help.
 `);
+}
+export function vendorSessionKey(sample) {
+  return `${sample.vendor}:${sample.vendorSessionId}`;
+}
+/**
+ * Every run rescans every vendor's full session history (there is no
+ * incremental cursor), so appending unconditionally would duplicate a
+ * session's sample on every subsequent run. Reads the current output file's
+ * existing (vendor, vendorSessionId) keys so the caller can skip samples
+ * already recorded, keeping the documented append semantics idempotent. A
+ * malformed existing line is skipped rather than failing the whole read --
+ * this is a read-side safety net, not a place to validate the file.
+ */
+export function readExistingVendorSessionKeys(outPath) {
+  const keys = new Set();
+  if (!existsSync(outPath)) {
+    return keys;
+  }
+  const lines = readFileSync(outPath, 'utf8').split('\n');
+  for (const line of lines) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(line);
+      if (
+        typeof parsed.vendor === 'string' &&
+        typeof parsed.vendorSessionId === 'string'
+      ) {
+        keys.add(
+          vendorSessionKey({
+            vendor: parsed.vendor,
+            vendorSessionId: parsed.vendorSessionId,
+          }),
+        );
+      }
+    } catch {
+      // Malformed line in an existing file: skip it, don't fail the harvest.
+    }
+  }
+  return keys;
 }
 function runCli(argv) {
   const { values, help } = parseCliArgs(argv, TOKEN_COST_HARVEST_FLAG_SPEC);
@@ -937,10 +1011,16 @@ function runCli(argv) {
     return;
   }
   mkdirSync(dirname(outPath), { recursive: true });
-  const body = harvested.map((h) => JSON.stringify(h.sample)).join('\n');
-  writeFileSync(outPath, harvested.length > 0 ? `${body}\n` : '');
+  const existingIds = readExistingVendorSessionKeys(outPath);
+  const newSamples = harvested.filter(
+    (h) => !existingIds.has(vendorSessionKey(h.sample)),
+  );
+  if (newSamples.length > 0) {
+    const body = newSamples.map((h) => JSON.stringify(h.sample)).join('\n');
+    appendFileSync(outPath, `${body}\n`);
+  }
   process.stdout.write(
-    `token-cost-harvest: wrote ${outPath} (n=${harvested.length})\n`,
+    `token-cost-harvest: appended ${newSamples.length} new sample(s) to ${outPath} (skipped ${harvested.length - newSamples.length} already present)\n`,
   );
 }
 if (import.meta.main) {

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -368,30 +368,44 @@ function cumulativeSnapshotAt(points, atMs, exclusive = false) {
   return result;
 }
 /**
- * Allocates each stage window's usage from a timeline. Cumulative mode
- * looks up the snapshot at each window's own [startMs, endMs) independently
- * (never a running baseline carried from the previous window): a gap
- * between windows -- computeStageWindows can leave one before an event
- * window whose predecessor is also event-sourced -- must not fold that
- * gap's cumulative growth into the next window's delta, matching delta
- * mode's natural gap exclusion via sumDeltaInRange. For contiguous windows
- * (the common case) this is exactly equivalent to the running-baseline
- * form, since each window's startMs then equals the previous window's
- * endMs, so the exact-sum invariant (every window's delta sums to the
- * timeline's final cumulative snapshot minus zero, matching the adapter's
- * own `usage` total) still holds.
+ * Allocates each stage window's usage from a timeline. Cumulative mode uses
+ * a running baseline carried from the previous window (the previous
+ * window's own end snapshot) whenever this window starts exactly where the
+ * previous one ended -- a point exactly at that shared boundary must be
+ * counted in exactly one of the two windows, and re-deriving the baseline
+ * from a fresh lookup instead of reusing the running value can skip past
+ * that point onto an earlier one, double-counting its growth (a point at a
+ * shared boundary would then be included via the earlier window's inclusive
+ * end AND again via the later window's own growth). When this window does
+ * NOT start where the previous one ended -- computeStageWindows can leave
+ * a gap before an event window whose predecessor is also event-sourced --
+ * the baseline is looked up fresh, exclusive of a point exactly at the gap
+ * window's own start (so that point's growth, which happened AT this
+ * window's start, is counted as this window's usage rather than treated as
+ * a prior baseline); this also covers the very first window, and is what
+ * excludes a gap's cumulative growth from folding into the next window's
+ * delta, matching delta mode's natural gap exclusion via sumDeltaInRange.
+ * For fully contiguous windows (the common case) this telescopes exactly:
+ * every window's delta sums to the timeline's final cumulative snapshot
+ * minus zero, matching the adapter's own `usage` total.
  */
 export function allocateStageUsage(windows, timeline) {
   const out = [];
+  let previousEndMs = null;
+  let previousEndSnapshot = ZERO_USAGE;
   for (const window of windows) {
     let usage;
     if (timeline.mode === 'cumulative') {
-      const startSnapshot =
-        cumulativeSnapshotAt(timeline.points, window.startMs, true) ??
-        ZERO_USAGE;
+      const contiguous = previousEndMs === window.startMs;
+      const startSnapshot = contiguous
+        ? previousEndSnapshot
+        : (cumulativeSnapshotAt(timeline.points, window.startMs, true) ??
+          ZERO_USAGE);
       const endSnapshot =
         cumulativeSnapshotAt(timeline.points, window.endMs) ?? startSnapshot;
       usage = subtractUsageClamped(endSnapshot, startSnapshot);
+      previousEndMs = window.endMs;
+      previousEndSnapshot = endSnapshot;
     } else {
       usage = sumDeltaInRange(timeline.points, window.startMs, window.endMs);
     }
@@ -1050,7 +1064,7 @@ function runCli(argv) {
   const parsedRepo = parseRepoFlag(repoFlag);
   if (!parsedRepo) {
     process.stderr.write(
-      repoFlag === ''
+      repoFlag.trim() === ''
         ? '--repo <owner>/<repo> is required\n'
         : `--repo must be in <owner>/<repo> form, got: ${repoFlag}\n`,
     );

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -207,7 +207,7 @@ const MERGE_STAGE_THIN_CAP_MS = 15 * 60 * 1000;
  * the marker-only pass always produces it. Once --events overrides are
  * applied, an event window's timestamps are authoritative and never
  * expanded, while a marker window always flows to fill the space around it
- * (forward past its own original start, backward past its own original
+ * (backward past its own original start, forward past its own original
  * end) -- so the result stays gap-free everywhere a marker window can
  * reach. A residual gap is possible only immediately before an event
  * window whose immediately preceding window is itself event-sourced (or
@@ -346,11 +346,20 @@ function sumDeltaInRange(points, startMs, endMs) {
   }
   return sum;
 }
-/** Last cumulative snapshot at or before atMs, or null when none exists yet. */
-function cumulativeSnapshotAt(points, atMs) {
+/**
+ * Last cumulative snapshot at or before atMs (or strictly before, when
+ * exclusive), or null when none exists yet. exclusive matters for a
+ * window's own START boundary: a point exactly at window.startMs
+ * represents usage that happened AT the start of this window, not before
+ * it, so it must not be picked up as the subtraction baseline (which
+ * would silently drop that point's own contribution) -- unlike the END
+ * boundary, which correctly wants an inclusive lookup so a point exactly
+ * at window.endMs still counts toward this window.
+ */
+function cumulativeSnapshotAt(points, atMs, exclusive = false) {
   let result = null;
   for (const point of points) {
-    if (point.atMs <= atMs) {
+    if (exclusive ? point.atMs < atMs : point.atMs <= atMs) {
       result = point.usage;
     } else {
       break;
@@ -378,7 +387,8 @@ export function allocateStageUsage(windows, timeline) {
     let usage;
     if (timeline.mode === 'cumulative') {
       const startSnapshot =
-        cumulativeSnapshotAt(timeline.points, window.startMs) ?? ZERO_USAGE;
+        cumulativeSnapshotAt(timeline.points, window.startMs, true) ??
+        ZERO_USAGE;
       const endSnapshot =
         cumulativeSnapshotAt(timeline.points, window.endMs) ?? startSnapshot;
       usage = subtractUsageClamped(endSnapshot, startSnapshot);

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -1020,7 +1020,10 @@ export function readExistingVendorSessionKeys(outPath) {
 }
 /** Validates and splits a --repo <owner>/<repo> flag value; null for anything but exactly two non-empty segments. */
 export function parseRepoFlag(repoFlag) {
-  const parts = repoFlag.split('/');
+  const parts = repoFlag
+    .trim()
+    .split('/')
+    .map((part) => part.trim());
   if (parts.length !== 2 || parts.some((part) => part === '')) {
     return null;
   }
@@ -1033,9 +1036,14 @@ function runCli(argv) {
     printHelp();
     return;
   }
-  const parsedRepo = parseRepoFlag(values.repo);
+  const repoFlag = values.repo;
+  const parsedRepo = parseRepoFlag(repoFlag);
   if (!parsedRepo) {
-    process.stderr.write('--repo <owner>/<repo> is required\n');
+    process.stderr.write(
+      repoFlag === ''
+        ? '--repo <owner>/<repo> is required\n'
+        : `--repo must be in <owner>/<repo> form, got: ${repoFlag}\n`,
+    );
     process.exitCode = 2;
     return;
   }

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -199,12 +199,20 @@ const CLAIM_STAGE_CAP_MS = 15 * 60 * 1000;
 /** Thin cap for the merge stage when no cleanup marker activity is resolvable. */
 const MERGE_STAGE_THIN_CAP_MS = 15 * 60 * 1000;
 /**
- * Builds the contiguous, gap-free stage-window tiling of
- * [sessionStartedAtMs, sessionEndedAtMs) per the issue's marker-join
- * table, then lets --events override individual stage boundaries.
- * Contiguous tiling (each window starts exactly where the previous one
- * ended) is what makes the per-stage usage allocation below sum back to
- * the session total exactly, in both delta and cumulative modes.
+ * Builds the stage-window tiling of [sessionStartedAtMs, sessionEndedAtMs)
+ * per the issue's marker-join table, then lets --events override individual
+ * stage boundaries. Contiguous tiling (each window starts exactly where the
+ * previous one ended) is what makes the per-stage usage allocation below sum
+ * back to the session total exactly, in both delta and cumulative modes --
+ * the marker-only pass always produces it. Once --events overrides are
+ * applied, an event window's timestamps are authoritative and never
+ * expanded, while a marker window always flows to fill the space around it
+ * (forward past its own original start, backward past its own original
+ * end) -- so the result stays gap-free everywhere a marker window can
+ * reach. A residual gap is possible only immediately before an event
+ * window whose immediately preceding window is itself event-sourced (or
+ * absent, at session start): there, no marker exists to flow into it, and
+ * that usage is genuinely unattributed to any stage rather than misattributed.
  */
 export function computeStageWindows(
   sessionStartedAtMs,
@@ -296,15 +304,25 @@ export function computeStageWindows(
   // timestamp, so it is only ever clamped forward past a conflicting
   // predecessor, never expanded. A marker window is a synthetic
   // reconstruction with no independent authority, so it always starts
-  // exactly at the running cursor -- flowing backward to fill any gap an
-  // event override left behind -- rather than leaving that usage
-  // unattributed to any stage.
+  // exactly at the running cursor (flowing backward to fill a gap an event
+  // override left behind it) and, symmetrically, is retroactively extended
+  // forward to meet the start of an event window that follows it with a
+  // gap -- rather than leaving that usage unattributed to any stage.
   const finalWindows = [];
   let normalizeCursor = sessionStartedAtMs;
   for (const stageId of TOKEN_COST_STAGE_IDS) {
     const window = byId.get(stageId);
     if (!window) {
       continue;
+    }
+    if (window.source === 'event' && window.startMs > normalizeCursor) {
+      const prevIndex = finalWindows.length - 1;
+      const prev = finalWindows[prevIndex];
+      if (prev && prev.source === 'marker') {
+        const extendedEndMs = Math.min(window.startMs, sessionEndedAtMs);
+        finalWindows[prevIndex] = { ...prev, endMs: extendedEndMs };
+        normalizeCursor = extendedEndMs;
+      }
     }
     const startMs =
       window.source === 'event'
@@ -671,6 +689,18 @@ export function resolveIssueLoopContext(
     ) {
       humanHandoff = true;
     }
+    // A later claimed-by marker naming this session's own claimId in its
+    // supersedes field, from a different agent, is a silent takeover --
+    // the outcome table's "a different actor takes the claim before
+    // merge" row, same as an explicit forced-handoff marker.
+    const takeover = parseClaimComment(comment.body, comment.createdAt);
+    if (
+      takeover &&
+      takeover.supersedes === claimId &&
+      takeover.agentId !== claimAgentId
+    ) {
+      humanHandoff = true;
+    }
   }
   return {
     claimedAtMs,
@@ -854,11 +884,22 @@ export function buildSample(
   trustedLogins,
 ) {
   const base = session.adapterResult.sample;
-  const startedAtMs = toValidTimestampMs(base.startedAt) ?? 0;
-  const endedAtMs = toValidTimestampMs(base.endedAt) ?? startedAtMs;
+  const validStartedAtMs = toValidTimestampMs(base.startedAt);
+  const validEndedAtMs = toValidTimestampMs(base.endedAt);
+  const startedAtMs = validStartedAtMs ?? 0;
+  const endedAtMs = validEndedAtMs ?? startedAtMs;
   const issueNumber = session.adapterResult.joinHints?.issueNumber;
-  if (issueNumber === undefined) {
-    return { sample: base, startedAtMs, endedAtMs };
+  if (
+    issueNumber === undefined ||
+    validStartedAtMs === undefined ||
+    validEndedAtMs === undefined
+  ) {
+    // An adapter's own timestamp fields are malformed, or there is no
+    // issue to join against: skip the GitHub join rather than resolving
+    // a context against a nonsensical (e.g. epoch-anchored) session
+    // window. assertTokenCostSample would reject a malformed startedAt
+    // downstream anyway; this just avoids the wasted join work first.
+    return { sample: base, issueNumber, startedAtMs, endedAtMs };
   }
   const ctx = resolveIssueLoopContext(
     owner,

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -230,28 +230,42 @@ export function computeStageWindows(
     cursor = claimEnd;
     push('work', cursor, ctx.prCreatedAtMs);
     cursor = ctx.prCreatedAtMs;
+    // A review submitted after the merge (e.g. a bot reviewing an
+    // admin-merged PR post hoc) must not push submit-pr's end past
+    // prMergedAtMs — otherwise the merge window below would start before
+    // submit-pr's own end and double-count the overlap. Clamp to whichever
+    // is earlier.
+    const effectiveFirstReviewAtMs =
+      ctx.firstReviewAtMs !== null && ctx.prMergedAtMs !== null
+        ? Math.min(ctx.firstReviewAtMs, ctx.prMergedAtMs)
+        : ctx.firstReviewAtMs;
     const submitPrEnd =
-      ctx.firstReviewAtMs !== null ? ctx.firstReviewAtMs : sessionEndedAtMs;
+      effectiveFirstReviewAtMs !== null
+        ? effectiveFirstReviewAtMs
+        : ctx.prMergedAtMs !== null
+          ? ctx.prMergedAtMs
+          : sessionEndedAtMs;
     push('submit-pr', cursor, submitPrEnd);
     cursor = submitPrEnd;
-    if (ctx.firstReviewAtMs !== null) {
-      const reviewEnd =
-        ctx.prMergedAtMs !== null ? ctx.prMergedAtMs : sessionEndedAtMs;
-      push('review', cursor, reviewEnd);
-      cursor = reviewEnd;
-      if (ctx.prMergedAtMs !== null) {
-        // cursor === ctx.prMergedAtMs here (reviewEnd above), matching the
-        // table's "merge: merged_at → cleanup marker or merged_at+thin cap".
-        const uncappedMergeEnd =
-          ctx.cleanupAtMs !== null
-            ? ctx.cleanupAtMs
-            : ctx.prMergedAtMs + MERGE_STAGE_THIN_CAP_MS;
-        const mergeEnd = Math.min(uncappedMergeEnd, sessionEndedAtMs);
-        push('merge', cursor, mergeEnd);
-        cursor = mergeEnd;
-        push('cleanup', cursor, sessionEndedAtMs);
-        cursor = sessionEndedAtMs;
-      }
+    if (ctx.prMergedAtMs !== null) {
+      // A merged PR always emits review/merge/cleanup, even when no
+      // pre-merge review was resolvable (review is then zero-width and
+      // omitted by push()) — merged usage must never fall entirely into
+      // submit-pr just because nobody reviewed before merging.
+      push('review', cursor, ctx.prMergedAtMs);
+      cursor = ctx.prMergedAtMs;
+      const uncappedMergeEnd =
+        ctx.cleanupAtMs !== null
+          ? ctx.cleanupAtMs
+          : ctx.prMergedAtMs + MERGE_STAGE_THIN_CAP_MS;
+      const mergeEnd = Math.min(uncappedMergeEnd, sessionEndedAtMs);
+      push('merge', cursor, mergeEnd);
+      cursor = mergeEnd;
+      push('cleanup', cursor, sessionEndedAtMs);
+      cursor = sessionEndedAtMs;
+    } else if (effectiveFirstReviewAtMs !== null) {
+      push('review', cursor, sessionEndedAtMs);
+      cursor = sessionEndedAtMs;
     }
   } else {
     const claimEnd = Math.min(claimCap, sessionEndedAtMs);

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -16,11 +16,11 @@
 // not render the README -- that stays token-cost-report.mjs's job.
 
 import {
+  appendFileSync,
   existsSync,
   globSync,
   mkdirSync,
   readFileSync,
-  writeFileSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
@@ -381,29 +381,44 @@ export function computeStageWindows(
   }
 
   let attribution: 'marker-join' | 'phase-event' = 'marker-join';
-  const byId = new Map(windows.map((w) => [w.id, w]));
+  const byId = new Map<TokenCostStageId, StageWindow>(
+    windows.map((w) => [w.id, w]),
+  );
   for (const [stageId, eventWindow] of eventWindows) {
     if (eventWindow.endMs <= eventWindow.startMs) {
       continue;
     }
-    const existingIndex = windows.findIndex((w) => w.id === stageId);
-    const overridden: StageWindow = {
+    byId.set(stageId, {
       id: stageId,
       startMs: eventWindow.startMs,
       endMs: eventWindow.endMs,
       source: 'event',
-    };
-    if (existingIndex >= 0) {
-      windows[existingIndex] = overridden;
-    } else {
-      windows.push(overridden);
-    }
-    byId.set(stageId, overridden);
+    });
     attribution = 'phase-event';
   }
 
-  windows.sort((a, b) => a.startMs - b.startMs);
-  return { windows, attribution };
+  // Re-tile in canonical stage order: an --events override's timestamps can
+  // disagree with its marker-derived neighbors (or two overrides can
+  // disagree with each other), and naively overlaying them can leave
+  // windows that overlap -- which would double-count delta-mode usage in
+  // allocateStageUsage below. Clamp each window's start to a monotonic
+  // cursor and drop it if that clamp consumes the whole window; a gap is
+  // fine (its usage points simply attribute to no stage), an overlap is not.
+  const finalWindows: StageWindow[] = [];
+  let normalizeCursor = sessionStartedAtMs;
+  for (const stageId of TOKEN_COST_STAGE_IDS) {
+    const window = byId.get(stageId);
+    if (!window) {
+      continue;
+    }
+    const startMs = Math.max(window.startMs, normalizeCursor);
+    const endMs = Math.min(window.endMs, sessionEndedAtMs);
+    if (endMs > startMs) {
+      finalWindows.push({ ...window, startMs, endMs });
+      normalizeCursor = endMs;
+    }
+  }
+  return { windows: finalWindows, attribution };
 }
 
 /** Sums every delta-mode point whose timestamp falls in [startMs, endMs). */
@@ -782,7 +797,14 @@ export function resolveIssueLoopContext(
       comment.body,
       comment.createdAt,
     );
-    if (!watermark) {
+    if (
+      !watermark ||
+      watermark.agentId !== claimAgentId ||
+      watermark.claimId !== claimId
+    ) {
+      // Skip watermarks bound to a different claim attempt (for example a
+      // stale one from before a takeover) -- same ownership check the
+      // release/handoff matching below already applies.
       continue;
     }
     const atMs = toValidTimestampMs(watermark.createdAt);
@@ -837,11 +859,28 @@ export function resolveIssueLoopContext(
 // --events file
 // ---------------------------------------------------------------------------
 
-function eventKey(issueNumber: number, stageId: TokenCostStageId): string {
-  return `${issueNumber}:${stageId}`;
+const TOKEN_COST_VENDORS = ['grok', 'claude', 'codex'] as const;
+
+function isTokenCostVendor(value: unknown): value is TokenCostVendor {
+  return (
+    typeof value === 'string' &&
+    (TOKEN_COST_VENDORS as readonly string[]).includes(value)
+  );
 }
 
-/** Reads a --events JSONL file into per-(issueNumber, stageId) enter/exit window overrides. A missing file is not an error -- returns an empty map. */
+// Keyed by vendor too, not just (issueNumber, stageId): two different vendor
+// sessions can both log phase events for the same issue and stage (a
+// claude->codex handoff mid-loop), and their enter/exit timestamps must not
+// be paired across vendors into one bogus window.
+function eventKey(
+  issueNumber: number,
+  vendor: TokenCostVendor,
+  stageId: TokenCostStageId,
+): string {
+  return `${issueNumber}:${vendor}:${stageId}`;
+}
+
+/** Reads a --events JSONL file into per-(issueNumber, vendor, stageId) enter/exit window overrides. A missing file is not an error -- returns an empty map. */
 export function readEventWindows(path: string): Map<string, StageEventWindow> {
   const result = new Map<string, StageEventWindow>();
   if (!existsSync(path)) {
@@ -869,6 +908,7 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
       typeof event.issueNumber !== 'number' ||
       typeof event.stageId !== 'string' ||
       !(TOKEN_COST_STAGE_IDS as readonly string[]).includes(event.stageId) ||
+      !isTokenCostVendor(event.vendor) ||
       (event.event !== 'enter' && event.event !== 'exit')
     ) {
       continue;
@@ -877,7 +917,11 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
     if (atMs === undefined) {
       continue;
     }
-    const key = eventKey(event.issueNumber, event.stageId as TokenCostStageId);
+    const key = eventKey(
+      event.issueNumber,
+      event.vendor,
+      event.stageId as TokenCostStageId,
+    );
     if (event.event === 'enter') {
       enterAt.set(key, atMs);
     } else {
@@ -896,10 +940,11 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
 function eventWindowsForIssue(
   all: ReadonlyMap<string, StageEventWindow>,
   issueNumber: number,
+  vendor: TokenCostVendor,
 ): Map<TokenCostStageId, StageEventWindow> {
   const out = new Map<TokenCostStageId, StageEventWindow>();
   for (const stageId of TOKEN_COST_STAGE_IDS) {
-    const window = all.get(eventKey(issueNumber, stageId));
+    const window = all.get(eventKey(issueNumber, vendor, stageId));
     if (window) {
       out.set(stageId, window);
     }
@@ -1036,7 +1081,11 @@ export function buildSample(
     return { sample: base, issueNumber, startedAtMs, endedAtMs };
   }
 
-  const eventWindows = eventWindowsForIssue(eventWindowsAll, issueNumber);
+  const eventWindows = eventWindowsForIssue(
+    eventWindowsAll,
+    issueNumber,
+    session.vendor,
+  );
   const { windows, attribution } = computeStageWindows(
     startedAtMs,
     endedAtMs,
@@ -1091,6 +1140,55 @@ function printHelp(): void {
   --trusted-marker-logins a,b   Logins whose IDD markers are trusted (default: .github/idd/config.json's trustedMarkerActors).
   --help, -h                   Show this help.
 `);
+}
+
+export function vendorSessionKey(sample: {
+  vendor: string;
+  vendorSessionId: string;
+}): string {
+  return `${sample.vendor}:${sample.vendorSessionId}`;
+}
+
+/**
+ * Every run rescans every vendor's full session history (there is no
+ * incremental cursor), so appending unconditionally would duplicate a
+ * session's sample on every subsequent run. Reads the current output file's
+ * existing (vendor, vendorSessionId) keys so the caller can skip samples
+ * already recorded, keeping the documented append semantics idempotent. A
+ * malformed existing line is skipped rather than failing the whole read --
+ * this is a read-side safety net, not a place to validate the file.
+ */
+export function readExistingVendorSessionKeys(outPath: string): Set<string> {
+  const keys = new Set<string>();
+  if (!existsSync(outPath)) {
+    return keys;
+  }
+  const lines = readFileSync(outPath, 'utf8').split('\n');
+  for (const line of lines) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(line) as {
+        vendor?: unknown;
+        vendorSessionId?: unknown;
+      };
+      if (
+        typeof parsed.vendor === 'string' &&
+        typeof parsed.vendorSessionId === 'string'
+      ) {
+        keys.add(
+          vendorSessionKey({
+            vendor: parsed.vendor,
+            vendorSessionId: parsed.vendorSessionId,
+          }),
+        );
+      }
+    } catch {
+      // Malformed line in an existing file: skip it, don't fail the harvest.
+    }
+  }
+  return keys;
 }
 
 function runCli(argv: string[]): void {
@@ -1158,10 +1256,18 @@ function runCli(argv: string[]): void {
   }
 
   mkdirSync(dirname(outPath), { recursive: true });
-  const body = harvested.map((h) => JSON.stringify(h.sample)).join('\n');
-  writeFileSync(outPath, harvested.length > 0 ? `${body}\n` : '');
+  const existingIds = readExistingVendorSessionKeys(outPath);
+  const newSamples = harvested.filter(
+    (h) => !existingIds.has(vendorSessionKey(h.sample)),
+  );
+  if (newSamples.length > 0) {
+    const body = newSamples.map((h) => JSON.stringify(h.sample)).join('\n');
+    appendFileSync(outPath, `${body}\n`);
+  }
   process.stdout.write(
-    `token-cost-harvest: wrote ${outPath} (n=${harvested.length})\n`,
+    `token-cost-harvest: appended ${newSamples.length} new sample(s) to ${outPath} (skipped ${
+      harvested.length - newSamples.length
+    } already present)\n`,
   );
 }
 

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -478,27 +478,32 @@ function cumulativeSnapshotAt(
 }
 
 /**
- * Allocates each stage window's usage from a timeline. Windows must be
- * passed in ascending start-time order for the cumulative running
- * baseline to telescope correctly (sum of every window's delta equals
- * the timeline's final cumulative snapshot minus zero -- matching the
- * adapter's own `usage` total, which is the raw latest snapshot, not a
- * value relative to session start).
+ * Allocates each stage window's usage from a timeline. Cumulative mode
+ * looks up the snapshot at each window's own [startMs, endMs) independently
+ * (never a running baseline carried from the previous window): a gap
+ * between windows -- computeStageWindows can leave one before an event
+ * window whose predecessor is also event-sourced -- must not fold that
+ * gap's cumulative growth into the next window's delta, matching delta
+ * mode's natural gap exclusion via sumDeltaInRange. For contiguous windows
+ * (the common case) this is exactly equivalent to the running-baseline
+ * form, since each window's startMs then equals the previous window's
+ * endMs, so the exact-sum invariant (every window's delta sums to the
+ * timeline's final cumulative snapshot minus zero, matching the adapter's
+ * own `usage` total) still holds.
  */
 export function allocateStageUsage(
   windows: readonly StageWindow[],
   timeline: UsageTimeline,
 ): TokenCostStageUsage[] {
   const out: TokenCostStageUsage[] = [];
-  let cumulativeBaseline = ZERO_USAGE;
   for (const window of windows) {
     let usage: TokenCostUsage;
     if (timeline.mode === 'cumulative') {
-      const snapshot =
-        cumulativeSnapshotAt(timeline.points, window.endMs) ??
-        cumulativeBaseline;
-      usage = subtractUsageClamped(snapshot, cumulativeBaseline);
-      cumulativeBaseline = snapshot;
+      const startSnapshot =
+        cumulativeSnapshotAt(timeline.points, window.startMs) ?? ZERO_USAGE;
+      const endSnapshot =
+        cumulativeSnapshotAt(timeline.points, window.endMs) ?? startSnapshot;
+      usage = subtractUsageClamped(endSnapshot, startSnapshot);
     } else {
       usage = sumDeltaInRange(timeline.points, window.startMs, window.endMs);
     }
@@ -579,8 +584,13 @@ interface TrustedComment {
   login: string;
 }
 
+// GitHub logins are case-insensitive for account identity; compare
+// case-insensitively so a --trusted-marker-logins/config entry typed with
+// different casing than the GraphQL-reported author.login still matches,
+// rather than silently treating every marker as untrusted.
 function isTrusted(login: string, trustedLogins: readonly string[]): boolean {
-  return trustedLogins.includes(login);
+  const normalized = login.toLowerCase();
+  return trustedLogins.some((trusted) => trusted.toLowerCase() === normalized);
 }
 
 /** flag > config.json trustedMarkerActors > empty (fail closed: nothing is trusted). */

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -305,7 +305,7 @@ const MERGE_STAGE_THIN_CAP_MS = 15 * 60 * 1000;
  * the marker-only pass always produces it. Once --events overrides are
  * applied, an event window's timestamps are authoritative and never
  * expanded, while a marker window always flows to fill the space around it
- * (forward past its own original start, backward past its own original
+ * (backward past its own original start, forward past its own original
  * end) -- so the result stays gap-free everywhere a marker window can
  * reach. A residual gap is possible only immediately before an event
  * window whose immediately preceding window is itself event-sourced (or
@@ -461,14 +461,24 @@ function sumDeltaInRange(
   return sum;
 }
 
-/** Last cumulative snapshot at or before atMs, or null when none exists yet. */
+/**
+ * Last cumulative snapshot at or before atMs (or strictly before, when
+ * exclusive), or null when none exists yet. exclusive matters for a
+ * window's own START boundary: a point exactly at window.startMs
+ * represents usage that happened AT the start of this window, not before
+ * it, so it must not be picked up as the subtraction baseline (which
+ * would silently drop that point's own contribution) -- unlike the END
+ * boundary, which correctly wants an inclusive lookup so a point exactly
+ * at window.endMs still counts toward this window.
+ */
 function cumulativeSnapshotAt(
   points: readonly UsagePoint[],
   atMs: number,
+  exclusive = false,
 ): TokenCostUsage | null {
   let result: TokenCostUsage | null = null;
   for (const point of points) {
-    if (point.atMs <= atMs) {
+    if (exclusive ? point.atMs < atMs : point.atMs <= atMs) {
       result = point.usage;
     } else {
       break;
@@ -500,7 +510,8 @@ export function allocateStageUsage(
     let usage: TokenCostUsage;
     if (timeline.mode === 'cumulative') {
       const startSnapshot =
-        cumulativeSnapshotAt(timeline.points, window.startMs) ?? ZERO_USAGE;
+        cumulativeSnapshotAt(timeline.points, window.startMs, true) ??
+        ZERO_USAGE;
       const endSnapshot =
         cumulativeSnapshotAt(timeline.points, window.endMs) ?? startSnapshot;
       usage = subtractUsageClamped(endSnapshot, startSnapshot);

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1,0 +1,1155 @@
+// idd-generated-from: src/scripts/token-cost-harvest.mts
+//
+// The scripts/token-cost-harvest.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never
+// the generated .mjs. See docs/typescript-sources.md.
+//
+// Token-cost harvest CLI (#2292). Source-repo only: not HELPER_COMMANDS,
+// registered in tests/helper-invocation-profile.test.mts's
+// SOURCE_REPO_INTERNAL_ENTRY_PATHS instead (see docs/token-cost.md).
+//
+// Scans the already-shipped vendor adapters (token-cost-adapter-claude.mts
+// #2290, token-cost-adapter-codex.mts #2291, token-cost-adapter-grok.mts
+// #2289), joins each harvested session against this repository's own
+// GitHub IDD markers (claim, review-watermark, merge) to reconstruct
+// per-issue IDD stage windows, and writes TokenCostSample JSONL. Does
+// not render the README -- that stays token-cost-report.mjs's job.
+
+import {
+  existsSync,
+  globSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+
+import { parseCliArgs } from './cli-args.mts';
+import { ghGraphql } from './gh-exec.mts';
+import {
+  parseClaimComment,
+  parseForcedHandoffComment,
+  parseReleaseComment,
+  parseReviewWatermarkComment,
+} from './marker-helpers.mts';
+import {
+  type ClaudeHarvestInput,
+  claudeAdapter,
+  defaultClaudeProjectDir,
+  parseClaudeProjectLines,
+} from './token-cost-adapter-claude.mts';
+import {
+  type CodexHarvestInput,
+  codexAdapter,
+  defaultCodexSessionsDir,
+  extractSessionCwd,
+  isIddSkillCwd,
+  parseCodexRolloutLines,
+} from './token-cost-adapter-codex.mts';
+import {
+  defaultGrokSessionsDir,
+  scanGrokSessions,
+} from './token-cost-adapter-grok.mts';
+import {
+  assertTokenCostSample,
+  redactTokenCostRecord,
+  TOKEN_COST_STAGE_IDS,
+  type TokenCostAdapterResult,
+  type TokenCostAttribution,
+  type TokenCostEvent,
+  type TokenCostIssueLoopSample,
+  type TokenCostOutcome,
+  type TokenCostSample,
+  type TokenCostSessionSample,
+  type TokenCostStageId,
+  type TokenCostStageUsage,
+  type TokenCostUsage,
+  type TokenCostVendor,
+} from './token-cost-core.mts';
+
+// ---------------------------------------------------------------------------
+// Shared usage arithmetic
+// ---------------------------------------------------------------------------
+
+const ZERO_USAGE: TokenCostUsage = {
+  inputUncached: 0,
+  cacheRead: 0,
+  cacheCreation: 0,
+  output: 0,
+  reasoning: 0,
+};
+
+function addUsage(a: TokenCostUsage, b: TokenCostUsage): TokenCostUsage {
+  return {
+    inputUncached: a.inputUncached + b.inputUncached,
+    cacheRead: a.cacheRead + b.cacheRead,
+    cacheCreation: a.cacheCreation + b.cacheCreation,
+    output: a.output + b.output,
+    reasoning: a.reasoning + b.reasoning,
+  };
+}
+
+function subtractUsageClamped(
+  a: TokenCostUsage,
+  b: TokenCostUsage,
+): TokenCostUsage {
+  const clamp = (x: number, y: number) => Math.max(0, x - y);
+  return {
+    inputUncached: clamp(a.inputUncached, b.inputUncached),
+    cacheRead: clamp(a.cacheRead, b.cacheRead),
+    cacheCreation: clamp(a.cacheCreation, b.cacheCreation),
+    output: clamp(a.output, b.output),
+    reasoning: clamp(a.reasoning, b.reasoning),
+  };
+}
+
+function usageTotal(u: TokenCostUsage): number {
+  return (
+    u.inputUncached + u.cacheRead + u.cacheCreation + u.output + u.reasoning
+  );
+}
+
+function toNonNegativeInt(value: unknown): number {
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.trunc(n) : 0;
+}
+
+// ---------------------------------------------------------------------------
+// Per-vendor usage timelines
+//
+// Adapters (token-cost-adapter-claude.mts / -codex.mts) intentionally
+// expose only one aggregate `usage` total per session -- their public
+// contract is one-sample-per-session. Stage-window splitting needs a
+// per-timestamp series, so this module re-derives one locally from the
+// same raw records the adapters already parse (via the already-exported
+// parseClaudeProjectLines / parseCodexRolloutLines), reading each file
+// once and feeding the identical `records` array to both the adapter's
+// own harvest() and the local timeline extractor below -- never two
+// divergent reads. The small per-record field-mapping duplication here
+// is deliberate; each function cites its adapter-module source of truth
+// so drift is visible in review.
+// ---------------------------------------------------------------------------
+
+/** One usage observation at a point in session time. */
+interface UsagePoint {
+  atMs: number;
+  usage: TokenCostUsage;
+}
+
+/** A vendor's usage timeline is either per-message deltas or cumulative snapshots. */
+export interface UsageTimeline {
+  mode: 'delta' | 'cumulative';
+  points: readonly UsagePoint[];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toValidTimestampMs(value: unknown): number | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+/** Mirrors token-cost-adapter-claude.mts's usageFromFields (per-message delta). */
+function claudeUsageFromFields(raw: Record<string, unknown>): TokenCostUsage {
+  const split = raw.cache_creation;
+  const cacheCreation = isPlainObject(split)
+    ? toNonNegativeInt(split.ephemeral_5m_input_tokens) +
+      toNonNegativeInt(split.ephemeral_1h_input_tokens)
+    : toNonNegativeInt(raw.cache_creation_input_tokens);
+  return {
+    inputUncached: toNonNegativeInt(raw.input_tokens),
+    cacheRead: toNonNegativeInt(raw.cache_read_input_tokens),
+    cacheCreation,
+    output: toNonNegativeInt(raw.output_tokens),
+    reasoning: 0,
+  };
+}
+
+/** Mirrors token-cost-adapter-claude.mts's extractUsage's per-record source: assistant records' message.usage. */
+export function extractClaudeUsageTimeline(
+  records: readonly unknown[],
+): UsageTimeline {
+  const points: UsagePoint[] = [];
+  for (const record of records) {
+    if (!isPlainObject(record) || record.type !== 'assistant') {
+      continue;
+    }
+    const atMs = toValidTimestampMs(record.timestamp);
+    const message = isPlainObject(record.message) ? record.message : undefined;
+    const usageRaw =
+      message && isPlainObject(message.usage) ? message.usage : undefined;
+    if (atMs === undefined || !usageRaw) {
+      continue;
+    }
+    points.push({ atMs, usage: claudeUsageFromFields(usageRaw) });
+  }
+  points.sort((a, b) => a.atMs - b.atMs);
+  return { mode: 'delta', points };
+}
+
+/** Mirrors token-cost-adapter-codex.mts's usageFromTokenCounts (shared field shape for both cumulative and delta payloads). */
+function codexUsageFromTokenCounts(
+  raw: Record<string, unknown>,
+): TokenCostUsage {
+  const inputTokens = toNonNegativeInt(raw.input_tokens);
+  const cacheRead = toNonNegativeInt(raw.cached_input_tokens);
+  const cacheCreation = toNonNegativeInt(raw.cache_write_input_tokens);
+  const inputUncached =
+    inputTokens >= cacheRead + cacheCreation
+      ? inputTokens - cacheRead - cacheCreation
+      : inputTokens;
+  return {
+    inputUncached,
+    cacheRead,
+    cacheCreation,
+    output: toNonNegativeInt(raw.output_tokens),
+    reasoning: toNonNegativeInt(raw.reasoning_output_tokens),
+  };
+}
+
+/**
+ * Mirrors token-cost-adapter-codex.mts's extractUsage's own per-session
+ * preference (total_token_usage when any record carries one, else
+ * last_token_usage deltas) -- applied per record here instead of
+ * collapsed to one session total, since stage-window splitting needs
+ * the whole timeline, not just the final value.
+ */
+export function extractCodexUsageTimeline(
+  records: readonly unknown[],
+): UsageTimeline {
+  const tokenCountRecords: {
+    atMs: number;
+    payload: Record<string, unknown>;
+  }[] = [];
+  for (const record of records) {
+    if (!isPlainObject(record) || record.type !== 'token_count') {
+      continue;
+    }
+    const atMs = toValidTimestampMs(record.timestamp);
+    const payload = isPlainObject(record.payload) ? record.payload : undefined;
+    if (atMs === undefined || !payload) {
+      continue;
+    }
+    tokenCountRecords.push({ atMs, payload });
+  }
+  tokenCountRecords.sort((a, b) => a.atMs - b.atMs);
+
+  const hasCumulative = tokenCountRecords.some((r) =>
+    isPlainObject(r.payload.total_token_usage),
+  );
+  if (hasCumulative) {
+    const points: UsagePoint[] = [];
+    for (const { atMs, payload } of tokenCountRecords) {
+      const total = payload.total_token_usage;
+      if (isPlainObject(total)) {
+        points.push({ atMs, usage: codexUsageFromTokenCounts(total) });
+      }
+    }
+    return { mode: 'cumulative', points };
+  }
+  const points: UsagePoint[] = [];
+  for (const { atMs, payload } of tokenCountRecords) {
+    const last = payload.last_token_usage;
+    if (isPlainObject(last)) {
+      points.push({ atMs, usage: codexUsageFromTokenCounts(last) });
+    }
+  }
+  return { mode: 'delta', points };
+}
+
+// ---------------------------------------------------------------------------
+// Stage windows
+// ---------------------------------------------------------------------------
+
+interface StageWindow {
+  id: TokenCostStageId;
+  startMs: number;
+  endMs: number;
+  source: 'marker' | 'event';
+}
+
+/** GitHub-derived context needed to reconstruct one session's stage windows. Any field left null omits the stages it would have bounded. */
+export interface IssueLoopGithubContext {
+  claimedAtMs: number | null;
+  prCreatedAtMs: number | null;
+  prHeadRefName: string | null;
+  prMergedAtMs: number | null;
+  firstReviewAtMs: number | null;
+  cleanupAtMs: number | null;
+  unclaimedMatched: boolean;
+  humanHandoff: boolean;
+}
+
+/** Event-derived window override for one (issueNumber, stageId) pair, from a trusted enter/exit pair in the --events file. */
+export interface StageEventWindow {
+  startMs: number;
+  endMs: number;
+}
+
+const CLAIM_STAGE_CAP_MS = 15 * 60 * 1000;
+/** Thin cap for the merge stage when no cleanup marker activity is resolvable. */
+const MERGE_STAGE_THIN_CAP_MS = 15 * 60 * 1000;
+
+/**
+ * Builds the contiguous, gap-free stage-window tiling of
+ * [sessionStartedAtMs, sessionEndedAtMs) per the issue's marker-join
+ * table, then lets --events override individual stage boundaries.
+ * Contiguous tiling (each window starts exactly where the previous one
+ * ended) is what makes the per-stage usage allocation below sum back to
+ * the session total exactly, in both delta and cumulative modes.
+ */
+export function computeStageWindows(
+  sessionStartedAtMs: number,
+  sessionEndedAtMs: number,
+  ctx: IssueLoopGithubContext,
+  eventWindows: ReadonlyMap<TokenCostStageId, StageEventWindow>,
+): { windows: StageWindow[]; attribution: 'marker-join' | 'phase-event' } {
+  const windows: StageWindow[] = [];
+  const push = (id: TokenCostStageId, startMs: number, endMs: number) => {
+    if (endMs > startMs) {
+      windows.push({ id, startMs, endMs, source: 'marker' });
+    }
+  };
+
+  if (ctx.claimedAtMs === null) {
+    return { windows: [], attribution: 'marker-join' };
+  }
+
+  let cursor = ctx.claimedAtMs;
+  push('discover', sessionStartedAtMs, cursor);
+
+  const claimCap = cursor + CLAIM_STAGE_CAP_MS;
+  if (ctx.prCreatedAtMs !== null) {
+    const claimEnd = Math.min(claimCap, ctx.prCreatedAtMs);
+    push('claim', cursor, claimEnd);
+    cursor = claimEnd;
+    push('work', cursor, ctx.prCreatedAtMs);
+    cursor = ctx.prCreatedAtMs;
+
+    const submitPrEnd =
+      ctx.firstReviewAtMs !== null ? ctx.firstReviewAtMs : sessionEndedAtMs;
+    push('submit-pr', cursor, submitPrEnd);
+    cursor = submitPrEnd;
+
+    if (ctx.firstReviewAtMs !== null) {
+      const reviewEnd =
+        ctx.prMergedAtMs !== null ? ctx.prMergedAtMs : sessionEndedAtMs;
+      push('review', cursor, reviewEnd);
+      cursor = reviewEnd;
+
+      if (ctx.prMergedAtMs !== null) {
+        // cursor === ctx.prMergedAtMs here (reviewEnd above), matching the
+        // table's "merge: merged_at → cleanup marker or merged_at+thin cap".
+        const uncappedMergeEnd =
+          ctx.cleanupAtMs !== null
+            ? ctx.cleanupAtMs
+            : ctx.prMergedAtMs + MERGE_STAGE_THIN_CAP_MS;
+        const mergeEnd = Math.min(uncappedMergeEnd, sessionEndedAtMs);
+        push('merge', cursor, mergeEnd);
+        cursor = mergeEnd;
+        push('cleanup', cursor, sessionEndedAtMs);
+        cursor = sessionEndedAtMs;
+      }
+    }
+  } else {
+    const claimEnd = Math.min(claimCap, sessionEndedAtMs);
+    push('claim', cursor, claimEnd);
+    cursor = claimEnd;
+    push('work', cursor, sessionEndedAtMs);
+    cursor = sessionEndedAtMs;
+  }
+
+  let attribution: 'marker-join' | 'phase-event' = 'marker-join';
+  const byId = new Map(windows.map((w) => [w.id, w]));
+  for (const [stageId, eventWindow] of eventWindows) {
+    if (eventWindow.endMs <= eventWindow.startMs) {
+      continue;
+    }
+    const existingIndex = windows.findIndex((w) => w.id === stageId);
+    const overridden: StageWindow = {
+      id: stageId,
+      startMs: eventWindow.startMs,
+      endMs: eventWindow.endMs,
+      source: 'event',
+    };
+    if (existingIndex >= 0) {
+      windows[existingIndex] = overridden;
+    } else {
+      windows.push(overridden);
+    }
+    byId.set(stageId, overridden);
+    attribution = 'phase-event';
+  }
+
+  windows.sort((a, b) => a.startMs - b.startMs);
+  return { windows, attribution };
+}
+
+/** Sums every delta-mode point whose timestamp falls in [startMs, endMs). */
+function sumDeltaInRange(
+  points: readonly UsagePoint[],
+  startMs: number,
+  endMs: number,
+): TokenCostUsage {
+  let sum = ZERO_USAGE;
+  for (const point of points) {
+    if (point.atMs >= startMs && point.atMs < endMs) {
+      sum = addUsage(sum, point.usage);
+    }
+  }
+  return sum;
+}
+
+/** Last cumulative snapshot at or before atMs, or null when none exists yet. */
+function cumulativeSnapshotAt(
+  points: readonly UsagePoint[],
+  atMs: number,
+): TokenCostUsage | null {
+  let result: TokenCostUsage | null = null;
+  for (const point of points) {
+    if (point.atMs <= atMs) {
+      result = point.usage;
+    } else {
+      break;
+    }
+  }
+  return result;
+}
+
+/**
+ * Allocates each stage window's usage from a timeline. Windows must be
+ * passed in ascending start-time order for the cumulative running
+ * baseline to telescope correctly (sum of every window's delta equals
+ * the timeline's final cumulative snapshot minus zero -- matching the
+ * adapter's own `usage` total, which is the raw latest snapshot, not a
+ * value relative to session start).
+ */
+export function allocateStageUsage(
+  windows: readonly StageWindow[],
+  timeline: UsageTimeline,
+): TokenCostStageUsage[] {
+  const out: TokenCostStageUsage[] = [];
+  let cumulativeBaseline = ZERO_USAGE;
+  for (const window of windows) {
+    let usage: TokenCostUsage;
+    if (timeline.mode === 'cumulative') {
+      const snapshot =
+        cumulativeSnapshotAt(timeline.points, window.endMs) ??
+        cumulativeBaseline;
+      usage = subtractUsageClamped(snapshot, cumulativeBaseline);
+      cumulativeBaseline = snapshot;
+    } else {
+      usage = sumDeltaInRange(timeline.points, window.startMs, window.endMs);
+    }
+    if (usageTotal(usage) > 0) {
+      out.push({ id: window.id, usage });
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Outcome + ambiguity
+// ---------------------------------------------------------------------------
+
+export function deriveOutcome(ctx: IssueLoopGithubContext): TokenCostOutcome {
+  if (ctx.prMergedAtMs !== null) {
+    return 'merged';
+  }
+  if (ctx.humanHandoff) {
+    return 'human-handoff';
+  }
+  if (ctx.unclaimedMatched) {
+    return 'unclaimed';
+  }
+  return 'aborted';
+}
+
+export interface HarvestedSample {
+  sample: TokenCostSample;
+  issueNumber?: number;
+  startedAtMs: number;
+  endedAtMs: number;
+}
+
+/**
+ * Two harvested issue-loop samples on the same issue with overlapping
+ * [startedAt, endedAt) ranges mean two concurrent sessions genuinely
+ * worked the same issue -- neither's usage can be cleanly attributed, so
+ * both are marked ambiguous/unknown rather than either being trusted.
+ */
+export function markAmbiguousOverlaps(samples: HarvestedSample[]): void {
+  const byIssue = new Map<number, HarvestedSample[]>();
+  for (const entry of samples) {
+    if (entry.issueNumber === undefined || entry.sample.kind !== 'issue-loop') {
+      continue;
+    }
+    const group = byIssue.get(entry.issueNumber) ?? [];
+    group.push(entry);
+    byIssue.set(entry.issueNumber, group);
+  }
+  for (const group of byIssue.values()) {
+    for (let i = 0; i < group.length; i++) {
+      for (let j = i + 1; j < group.length; j++) {
+        const a = group[i];
+        const b = group[j];
+        const overlap =
+          a.startedAtMs < b.endedAtMs && b.startedAtMs < a.endedAtMs;
+        if (overlap) {
+          const sampleA = a.sample as TokenCostIssueLoopSample;
+          const sampleB = b.sample as TokenCostIssueLoopSample;
+          sampleA.ambiguous = true;
+          sampleB.ambiguous = true;
+          sampleA.outcome = 'unknown';
+          sampleB.outcome = 'unknown';
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GitHub join
+// ---------------------------------------------------------------------------
+
+interface TrustedComment {
+  body: string;
+  createdAt: string;
+  login: string;
+}
+
+function isTrusted(login: string, trustedLogins: readonly string[]): boolean {
+  return trustedLogins.includes(login);
+}
+
+/** flag > config.json trustedMarkerActors > empty (fail closed: nothing is trusted). */
+export function resolveTrustedMarkerLogins(flagValue: string): string[] {
+  const fromFlag = flagValue
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  if (fromFlag.length > 0) {
+    return fromFlag;
+  }
+  try {
+    const raw = readFileSync(
+      join(process.cwd(), '.github/idd/config.json'),
+      'utf8',
+    );
+    const parsed = JSON.parse(raw) as { trustedMarkerActors?: unknown };
+    if (Array.isArray(parsed.trustedMarkerActors)) {
+      return parsed.trustedMarkerActors.filter(
+        (v): v is string => typeof v === 'string',
+      );
+    }
+  } catch {}
+  return [];
+}
+
+const ISSUE_LOOP_CONTEXT_QUERY = `
+query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      comments(first:100){nodes{body createdAt author{login}}}
+      timelineItems(last:100,itemTypes:[CONNECTED_EVENT,DISCONNECTED_EVENT]){
+        nodes{
+          __typename
+          ... on ConnectedEvent{subject{__typename ... on PullRequest{
+            number state headRefName createdAt mergedAt
+            reviews(first:1){nodes{submittedAt}}
+          }}}
+          ... on DisconnectedEvent{subject{__typename ... on PullRequest{number}}}
+        }
+      }
+    }
+  }
+}`;
+
+interface RawIssueLoopContextResponse {
+  data?: {
+    repository?: {
+      issue?: {
+        comments?: { nodes?: unknown };
+        timelineItems?: { nodes?: unknown };
+      };
+    };
+  };
+}
+
+/** Fetches issue comments plus the earliest live-connected same-branch PR (with its first review + merge timestamp) via one batched GraphQL query. */
+export function fetchIssueLoopGithubContext(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  trustedLogins: readonly string[],
+): {
+  comments: TrustedComment[];
+  prNumber: number | null;
+  prHeadRefName: string | null;
+  prCreatedAtMs: number | null;
+  prMergedAtMs: number | null;
+  firstReviewAtMs: number | null;
+} {
+  const response = ghGraphql(ISSUE_LOOP_CONTEXT_QUERY, {
+    owner,
+    repo,
+    number: issueNumber,
+  }) as RawIssueLoopContextResponse;
+
+  const issue = response.data?.repository?.issue;
+  const commentNodes = Array.isArray(issue?.comments?.nodes)
+    ? issue.comments.nodes
+    : [];
+  const comments: TrustedComment[] = [];
+  for (const node of commentNodes) {
+    if (!isPlainObject(node)) {
+      continue;
+    }
+    const login =
+      isPlainObject(node.author) && typeof node.author.login === 'string'
+        ? node.author.login
+        : '';
+    const body = typeof node.body === 'string' ? node.body : '';
+    const createdAt = typeof node.createdAt === 'string' ? node.createdAt : '';
+    if (login && body && createdAt && isTrusted(login, trustedLogins)) {
+      comments.push({ body, createdAt, login });
+    }
+  }
+
+  const timelineNodes = Array.isArray(issue?.timelineItems?.nodes)
+    ? issue.timelineItems.nodes
+    : [];
+  const connected = new Map<number, Record<string, unknown>>();
+  const disconnected = new Set<number>();
+  for (const node of timelineNodes) {
+    if (!isPlainObject(node)) {
+      continue;
+    }
+    const subject = isPlainObject(node.subject) ? node.subject : undefined;
+    const prNumber =
+      subject && typeof subject.number === 'number'
+        ? subject.number
+        : undefined;
+    if (prNumber === undefined) {
+      continue;
+    }
+    if (node.__typename === 'ConnectedEvent') {
+      connected.set(prNumber, subject as Record<string, unknown>);
+      disconnected.delete(prNumber);
+    } else if (node.__typename === 'DisconnectedEvent') {
+      disconnected.add(prNumber);
+    }
+  }
+
+  let chosen: Record<string, unknown> | null = null;
+  let chosenNumber: number | null = null;
+  for (const [prNumber, subject] of connected) {
+    if (disconnected.has(prNumber)) {
+      continue;
+    }
+    const headRefName =
+      typeof subject.headRefName === 'string' ? subject.headRefName : '';
+    if (!headRefName.startsWith(`issue/${issueNumber}-`)) {
+      continue;
+    }
+    const createdAtMs = toValidTimestampMs(subject.createdAt);
+    if (createdAtMs === undefined) {
+      continue;
+    }
+    const chosenCreatedAtMs = chosen
+      ? (toValidTimestampMs(chosen.createdAt) ?? Infinity)
+      : Infinity;
+    if (createdAtMs < chosenCreatedAtMs) {
+      chosen = subject;
+      chosenNumber = prNumber;
+    }
+  }
+
+  if (!chosen) {
+    return {
+      comments,
+      prNumber: null,
+      prHeadRefName: null,
+      prCreatedAtMs: null,
+      prMergedAtMs: null,
+      firstReviewAtMs: null,
+    };
+  }
+
+  const reviews =
+    isPlainObject(chosen.reviews) && Array.isArray(chosen.reviews.nodes)
+      ? chosen.reviews.nodes
+      : [];
+  let firstReviewAtMs: number | null = null;
+  for (const review of reviews) {
+    if (!isPlainObject(review)) {
+      continue;
+    }
+    const submittedAtMs = toValidTimestampMs(review.submittedAt);
+    if (
+      submittedAtMs !== undefined &&
+      (firstReviewAtMs === null || submittedAtMs < firstReviewAtMs)
+    ) {
+      firstReviewAtMs = submittedAtMs;
+    }
+  }
+
+  return {
+    comments,
+    prNumber: chosenNumber,
+    prHeadRefName:
+      typeof chosen.headRefName === 'string' ? chosen.headRefName : null,
+    prCreatedAtMs: toValidTimestampMs(chosen.createdAt) ?? null,
+    prMergedAtMs: toValidTimestampMs(chosen.mergedAt) ?? null,
+    firstReviewAtMs,
+  };
+}
+
+/**
+ * Resolves the full {@link IssueLoopGithubContext} for one session's
+ * [sessionStartedAtMs, sessionEndedAtMs) window: the first trusted
+ * claimed-by comment posted in that range, the earliest first trusted
+ * review-watermark (compared against the linked PR's first submitted
+ * review), and whether that claim was later released or handed off
+ * before merge.
+ */
+export function resolveIssueLoopContext(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  sessionStartedAtMs: number,
+  sessionEndedAtMs: number,
+  trustedLogins: readonly string[],
+): IssueLoopGithubContext | null {
+  const github = fetchIssueLoopGithubContext(
+    owner,
+    repo,
+    issueNumber,
+    trustedLogins,
+  );
+
+  let claimedAtMs: number | null = null;
+  let claimAgentId: string | null = null;
+  let claimId: string | null = null;
+  for (const comment of github.comments) {
+    const claim = parseClaimComment(comment.body, comment.createdAt);
+    if (!claim) {
+      continue;
+    }
+    const atMs = toValidTimestampMs(claim.createdAt);
+    if (
+      atMs === undefined ||
+      atMs < sessionStartedAtMs ||
+      atMs > sessionEndedAtMs
+    ) {
+      continue;
+    }
+    if (claimedAtMs === null || atMs < claimedAtMs) {
+      claimedAtMs = atMs;
+      claimAgentId = claim.agentId;
+      claimId = claim.claimId;
+    }
+  }
+
+  if (claimedAtMs === null) {
+    return null;
+  }
+
+  let firstWatermarkAtMs: number | null = null;
+  for (const comment of github.comments) {
+    const watermark = parseReviewWatermarkComment(
+      comment.body,
+      comment.createdAt,
+    );
+    if (!watermark) {
+      continue;
+    }
+    const atMs = toValidTimestampMs(watermark.createdAt);
+    if (
+      atMs !== undefined &&
+      (firstWatermarkAtMs === null || atMs < firstWatermarkAtMs)
+    ) {
+      firstWatermarkAtMs = atMs;
+    }
+  }
+  const firstReviewAtMs = [firstWatermarkAtMs, github.firstReviewAtMs]
+    .filter((v): v is number => v !== null)
+    .reduce(
+      (min, v) => (min === null || v < min ? v : min),
+      null as number | null,
+    );
+
+  let unclaimedMatched = false;
+  let humanHandoff = false;
+  for (const comment of github.comments) {
+    const release = parseReleaseComment(comment.body);
+    if (
+      release &&
+      release.agentId === claimAgentId &&
+      release.claimId === claimId
+    ) {
+      unclaimedMatched = true;
+    }
+    const handoff = parseForcedHandoffComment(comment.body, comment.createdAt);
+    if (
+      handoff &&
+      handoff.oldAgentId === claimAgentId &&
+      handoff.oldClaimId === claimId
+    ) {
+      humanHandoff = true;
+    }
+  }
+
+  return {
+    claimedAtMs,
+    prCreatedAtMs: github.prCreatedAtMs,
+    prHeadRefName: github.prHeadRefName,
+    prMergedAtMs: github.prMergedAtMs,
+    firstReviewAtMs,
+    cleanupAtMs: null,
+    unclaimedMatched,
+    humanHandoff,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// --events file
+// ---------------------------------------------------------------------------
+
+function eventKey(issueNumber: number, stageId: TokenCostStageId): string {
+  return `${issueNumber}:${stageId}`;
+}
+
+/** Reads a --events JSONL file into per-(issueNumber, stageId) enter/exit window overrides. A missing file is not an error -- returns an empty map. */
+export function readEventWindows(path: string): Map<string, StageEventWindow> {
+  const result = new Map<string, StageEventWindow>();
+  if (!existsSync(path)) {
+    return result;
+  }
+  const enterAt = new Map<string, number>();
+  const exitAt = new Map<string, number>();
+  const text = readFileSync(path, 'utf8');
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!isPlainObject(parsed)) {
+      continue;
+    }
+    const event = parsed as Partial<TokenCostEvent>;
+    if (
+      typeof event.issueNumber !== 'number' ||
+      typeof event.stageId !== 'string' ||
+      !(TOKEN_COST_STAGE_IDS as readonly string[]).includes(event.stageId) ||
+      (event.event !== 'enter' && event.event !== 'exit')
+    ) {
+      continue;
+    }
+    const atMs = toValidTimestampMs(event.at);
+    if (atMs === undefined) {
+      continue;
+    }
+    const key = eventKey(event.issueNumber, event.stageId as TokenCostStageId);
+    if (event.event === 'enter') {
+      enterAt.set(key, atMs);
+    } else {
+      exitAt.set(key, atMs);
+    }
+  }
+  for (const [key, start] of enterAt) {
+    const end = exitAt.get(key);
+    if (end !== undefined) {
+      result.set(key, { startMs: start, endMs: end });
+    }
+  }
+  return result;
+}
+
+function eventWindowsForIssue(
+  all: ReadonlyMap<string, StageEventWindow>,
+  issueNumber: number,
+): Map<TokenCostStageId, StageEventWindow> {
+  const out = new Map<TokenCostStageId, StageEventWindow>();
+  for (const stageId of TOKEN_COST_STAGE_IDS) {
+    const window = all.get(eventKey(issueNumber, stageId));
+    if (window) {
+      out.set(stageId, window);
+    }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Vendor scan
+// ---------------------------------------------------------------------------
+
+export interface VendorSession {
+  vendor: TokenCostVendor;
+  adapterResult: TokenCostAdapterResult;
+  timeline: UsageTimeline;
+}
+
+function scanClaudeVendorSessions(projectDir: string): VendorSession[] {
+  const out: VendorSession[] = [];
+  if (!existsSync(projectDir)) {
+    return out;
+  }
+  const files = globSync('*.jsonl', { cwd: projectDir, withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => join(entry.parentPath, entry.name))
+    .sort();
+  for (const file of files) {
+    try {
+      const records = parseClaudeProjectLines(readFileSync(file, 'utf8'));
+      const adapterResult = claudeAdapter.harvest({
+        records,
+        fileBasename: basename(file),
+      } satisfies ClaudeHarvestInput);
+      out.push({
+        vendor: 'claude',
+        adapterResult,
+        timeline: extractClaudeUsageTimeline(records),
+      });
+    } catch (error) {
+      process.stderr.write(
+        `token-cost-harvest: skipping ${file}: ${(error as Error).message}\n`,
+      );
+    }
+  }
+  return out;
+}
+
+function scanCodexVendorSessions(sessionsDir: string): VendorSession[] {
+  const out: VendorSession[] = [];
+  if (!existsSync(sessionsDir)) {
+    return out;
+  }
+  const files = globSync('**/rollout-*.jsonl', {
+    cwd: sessionsDir,
+    withFileTypes: true,
+  })
+    .filter((entry) => entry.isFile())
+    .map((entry) => join(entry.parentPath, entry.name))
+    .sort();
+  for (const file of files) {
+    try {
+      const records = parseCodexRolloutLines(readFileSync(file, 'utf8'));
+      if (!isIddSkillCwd(extractSessionCwd(records))) {
+        continue;
+      }
+      const adapterResult = codexAdapter.harvest({
+        records,
+        fileBasename: basename(file),
+      } satisfies CodexHarvestInput);
+      out.push({
+        vendor: 'codex',
+        adapterResult,
+        timeline: extractCodexUsageTimeline(records),
+      });
+    } catch (error) {
+      process.stderr.write(
+        `token-cost-harvest: skipping ${file}: ${(error as Error).message}\n`,
+      );
+    }
+  }
+  return out;
+}
+
+/**
+ * Grok sessions are joined and classified the same as claude/codex, but
+ * without per-stage usage splitting yet: `scanGrokSessions` already owns
+ * a materially more complex read (subagent updates.jsonl rollups,
+ * signals.json, events.jsonl fallback -- see token-cost-adapter-grok.mts's
+ * module doc), so replicating "read once, feed the same records to a
+ * local timeline extractor" here would mean re-deriving that whole read,
+ * not just one small per-record usage-field mapping the way the
+ * claude/codex extractors do. An empty timeline means allocateStageUsage
+ * omits every stage for a grok issue-loop sample (the session's own
+ * aggregate `usage` total is still present and correct); a follow-up
+ * issue can add extractGrokUsageTimeline once that read is worth sharing.
+ */
+function scanGrokVendorSessions(sessionsDir: string): VendorSession[] {
+  return scanGrokSessions({ sessionsDir }).map((adapterResult) => ({
+    vendor: 'grok' as const,
+    adapterResult,
+    timeline: { mode: 'delta' as const, points: [] },
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Sample assembly
+// ---------------------------------------------------------------------------
+
+export function buildSample(
+  session: VendorSession,
+  owner: string,
+  repo: string,
+  eventWindowsAll: ReadonlyMap<string, StageEventWindow>,
+  trustedLogins: readonly string[],
+): HarvestedSample {
+  const base = session.adapterResult.sample;
+  const startedAtMs = toValidTimestampMs(base.startedAt) ?? 0;
+  const endedAtMs = toValidTimestampMs(base.endedAt) ?? startedAtMs;
+  const issueNumber = session.adapterResult.joinHints?.issueNumber;
+
+  if (issueNumber === undefined) {
+    return { sample: base, startedAtMs, endedAtMs };
+  }
+
+  const ctx = resolveIssueLoopContext(
+    owner,
+    repo,
+    issueNumber,
+    startedAtMs,
+    endedAtMs,
+    trustedLogins,
+  );
+  if (ctx === null) {
+    return { sample: base, issueNumber, startedAtMs, endedAtMs };
+  }
+
+  const eventWindows = eventWindowsForIssue(eventWindowsAll, issueNumber);
+  const { windows, attribution } = computeStageWindows(
+    startedAtMs,
+    endedAtMs,
+    ctx,
+    eventWindows,
+  );
+  const stages = allocateStageUsage(windows, session.timeline);
+
+  const sample: TokenCostIssueLoopSample = {
+    ...(base as TokenCostSessionSample),
+    kind: 'issue-loop',
+    issueNumber,
+    stages,
+    attribution: attribution as TokenCostAttribution,
+    outcome: deriveOutcome(ctx),
+  };
+  const redacted = redactTokenCostRecord(sample) as TokenCostIssueLoopSample;
+  return { sample: redacted, issueNumber, startedAtMs, endedAtMs };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function defaultStateDir(): string {
+  const base =
+    process.env.XDG_STATE_HOME?.trim() || join(homedir(), '.local', 'state');
+  return join(base, 'idd-skill', 'token-cost');
+}
+
+// Flag-spec keys stay the dashed literal on purpose -- see cli-args.mts's
+// module header for the full invariant.
+const TOKEN_COST_HARVEST_FLAG_SPEC = {
+  '--repo': { type: 'string', default: '' },
+  '--out': { type: 'string', default: '' },
+  '--events': { type: 'string', default: '' },
+  '--dry-run': { type: 'boolean', default: false },
+  '--trusted-marker-logins': { type: 'string', default: '' },
+  '--help': { type: 'boolean', short: 'h' },
+} as const;
+
+function printHelp(): void {
+  process.stdout.write(`Usage:
+  node scripts/token-cost-harvest.mjs --repo <owner>/<repo> [--out <path>] [--events <path>] [--dry-run]
+
+  --repo <owner/repo>          Repository to join harvested sessions against. Required.
+  --out <path>                 Output samples JSONL path (default:
+                                ${defaultStateDir()}/samples.jsonl).
+  --events <path>               Phase-event JSONL path (default:
+                                ${defaultStateDir()}/events.jsonl). Missing file is not an error.
+  --dry-run                    Print counts to stderr; write nothing.
+  --trusted-marker-logins a,b   Logins whose IDD markers are trusted (default: .github/idd/config.json's trustedMarkerActors).
+  --help, -h                   Show this help.
+`);
+}
+
+function runCli(argv: string[]): void {
+  const { values, help } = parseCliArgs(argv, TOKEN_COST_HARVEST_FLAG_SPEC);
+  if (help) {
+    printHelp();
+    return;
+  }
+  const repoFlag = values.repo as string;
+  if (!repoFlag.includes('/')) {
+    process.stderr.write('--repo <owner>/<repo> is required\n');
+    process.exitCode = 2;
+    return;
+  }
+  const [owner, repo] = repoFlag.split('/');
+  const dryRun = values['dry-run'] as boolean;
+  const outPath =
+    (values.out as string) || join(defaultStateDir(), 'samples.jsonl');
+  const eventsPath =
+    (values.events as string) || join(defaultStateDir(), 'events.jsonl');
+  const trustedLogins = resolveTrustedMarkerLogins(
+    values['trusted-marker-logins'] as string,
+  );
+
+  const eventWindows = readEventWindows(eventsPath);
+
+  const sessions: VendorSession[] = [
+    ...scanClaudeVendorSessions(defaultClaudeProjectDir()),
+    ...scanCodexVendorSessions(defaultCodexSessionsDir()),
+    ...scanGrokVendorSessions(defaultGrokSessionsDir()),
+  ];
+
+  const harvested: HarvestedSample[] = [];
+  for (const session of sessions) {
+    try {
+      const built = buildSample(
+        session,
+        owner,
+        repo,
+        eventWindows,
+        trustedLogins,
+      );
+      assertTokenCostSample(built.sample);
+      harvested.push(built);
+    } catch (error) {
+      process.stderr.write(
+        `token-cost-harvest: skipping ${session.vendor} session: ${(error as Error).message}\n`,
+      );
+    }
+  }
+
+  markAmbiguousOverlaps(harvested);
+
+  const issueLoopCount = harvested.filter(
+    (h) => h.sample.kind === 'issue-loop',
+  ).length;
+  process.stderr.write(
+    `token-cost-harvest: ${harvested.length} sample(s) (${issueLoopCount} issue-loop, ${
+      harvested.length - issueLoopCount
+    } session)\n`,
+  );
+
+  if (dryRun) {
+    return;
+  }
+
+  mkdirSync(dirname(outPath), { recursive: true });
+  const body = harvested.map((h) => JSON.stringify(h.sample)).join('\n');
+  writeFileSync(outPath, harvested.length > 0 ? `${body}\n` : '');
+  process.stdout.write(
+    `token-cost-harvest: wrote ${outPath} (n=${harvested.length})\n`,
+  );
+}
+
+if (import.meta.main) {
+  runCli(process.argv.slice(2));
+}

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -488,33 +488,47 @@ function cumulativeSnapshotAt(
 }
 
 /**
- * Allocates each stage window's usage from a timeline. Cumulative mode
- * looks up the snapshot at each window's own [startMs, endMs) independently
- * (never a running baseline carried from the previous window): a gap
- * between windows -- computeStageWindows can leave one before an event
- * window whose predecessor is also event-sourced -- must not fold that
- * gap's cumulative growth into the next window's delta, matching delta
- * mode's natural gap exclusion via sumDeltaInRange. For contiguous windows
- * (the common case) this is exactly equivalent to the running-baseline
- * form, since each window's startMs then equals the previous window's
- * endMs, so the exact-sum invariant (every window's delta sums to the
- * timeline's final cumulative snapshot minus zero, matching the adapter's
- * own `usage` total) still holds.
+ * Allocates each stage window's usage from a timeline. Cumulative mode uses
+ * a running baseline carried from the previous window (the previous
+ * window's own end snapshot) whenever this window starts exactly where the
+ * previous one ended -- a point exactly at that shared boundary must be
+ * counted in exactly one of the two windows, and re-deriving the baseline
+ * from a fresh lookup instead of reusing the running value can skip past
+ * that point onto an earlier one, double-counting its growth (a point at a
+ * shared boundary would then be included via the earlier window's inclusive
+ * end AND again via the later window's own growth). When this window does
+ * NOT start where the previous one ended -- computeStageWindows can leave
+ * a gap before an event window whose predecessor is also event-sourced --
+ * the baseline is looked up fresh, exclusive of a point exactly at the gap
+ * window's own start (so that point's growth, which happened AT this
+ * window's start, is counted as this window's usage rather than treated as
+ * a prior baseline); this also covers the very first window, and is what
+ * excludes a gap's cumulative growth from folding into the next window's
+ * delta, matching delta mode's natural gap exclusion via sumDeltaInRange.
+ * For fully contiguous windows (the common case) this telescopes exactly:
+ * every window's delta sums to the timeline's final cumulative snapshot
+ * minus zero, matching the adapter's own `usage` total.
  */
 export function allocateStageUsage(
   windows: readonly StageWindow[],
   timeline: UsageTimeline,
 ): TokenCostStageUsage[] {
   const out: TokenCostStageUsage[] = [];
+  let previousEndMs: number | null = null;
+  let previousEndSnapshot: TokenCostUsage = ZERO_USAGE;
   for (const window of windows) {
     let usage: TokenCostUsage;
     if (timeline.mode === 'cumulative') {
-      const startSnapshot =
-        cumulativeSnapshotAt(timeline.points, window.startMs, true) ??
-        ZERO_USAGE;
+      const contiguous = previousEndMs === window.startMs;
+      const startSnapshot = contiguous
+        ? previousEndSnapshot
+        : (cumulativeSnapshotAt(timeline.points, window.startMs, true) ??
+          ZERO_USAGE);
       const endSnapshot =
         cumulativeSnapshotAt(timeline.points, window.endMs) ?? startSnapshot;
       usage = subtractUsageClamped(endSnapshot, startSnapshot);
+      previousEndMs = window.endMs;
+      previousEndSnapshot = endSnapshot;
     } else {
       usage = sumDeltaInRange(timeline.points, window.startMs, window.endMs);
     }
@@ -1288,7 +1302,7 @@ function runCli(argv: string[]): void {
   const parsedRepo = parseRepoFlag(repoFlag);
   if (!parsedRepo) {
     process.stderr.write(
-      repoFlag === ''
+      repoFlag.trim() === ''
         ? '--repo <owner>/<repo> is required\n'
         : `--repo must be in <owner>/<repo> form, got: ${repoFlag}\n`,
     );

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -332,30 +332,45 @@ export function computeStageWindows(
     push('work', cursor, ctx.prCreatedAtMs);
     cursor = ctx.prCreatedAtMs;
 
+    // A review submitted after the merge (e.g. a bot reviewing an
+    // admin-merged PR post hoc) must not push submit-pr's end past
+    // prMergedAtMs — otherwise the merge window below would start before
+    // submit-pr's own end and double-count the overlap. Clamp to whichever
+    // is earlier.
+    const effectiveFirstReviewAtMs =
+      ctx.firstReviewAtMs !== null && ctx.prMergedAtMs !== null
+        ? Math.min(ctx.firstReviewAtMs, ctx.prMergedAtMs)
+        : ctx.firstReviewAtMs;
+
     const submitPrEnd =
-      ctx.firstReviewAtMs !== null ? ctx.firstReviewAtMs : sessionEndedAtMs;
+      effectiveFirstReviewAtMs !== null
+        ? effectiveFirstReviewAtMs
+        : ctx.prMergedAtMs !== null
+          ? ctx.prMergedAtMs
+          : sessionEndedAtMs;
     push('submit-pr', cursor, submitPrEnd);
     cursor = submitPrEnd;
 
-    if (ctx.firstReviewAtMs !== null) {
-      const reviewEnd =
-        ctx.prMergedAtMs !== null ? ctx.prMergedAtMs : sessionEndedAtMs;
-      push('review', cursor, reviewEnd);
-      cursor = reviewEnd;
+    if (ctx.prMergedAtMs !== null) {
+      // A merged PR always emits review/merge/cleanup, even when no
+      // pre-merge review was resolvable (review is then zero-width and
+      // omitted by push()) — merged usage must never fall entirely into
+      // submit-pr just because nobody reviewed before merging.
+      push('review', cursor, ctx.prMergedAtMs);
+      cursor = ctx.prMergedAtMs;
 
-      if (ctx.prMergedAtMs !== null) {
-        // cursor === ctx.prMergedAtMs here (reviewEnd above), matching the
-        // table's "merge: merged_at → cleanup marker or merged_at+thin cap".
-        const uncappedMergeEnd =
-          ctx.cleanupAtMs !== null
-            ? ctx.cleanupAtMs
-            : ctx.prMergedAtMs + MERGE_STAGE_THIN_CAP_MS;
-        const mergeEnd = Math.min(uncappedMergeEnd, sessionEndedAtMs);
-        push('merge', cursor, mergeEnd);
-        cursor = mergeEnd;
-        push('cleanup', cursor, sessionEndedAtMs);
-        cursor = sessionEndedAtMs;
-      }
+      const uncappedMergeEnd =
+        ctx.cleanupAtMs !== null
+          ? ctx.cleanupAtMs
+          : ctx.prMergedAtMs + MERGE_STAGE_THIN_CAP_MS;
+      const mergeEnd = Math.min(uncappedMergeEnd, sessionEndedAtMs);
+      push('merge', cursor, mergeEnd);
+      cursor = mergeEnd;
+      push('cleanup', cursor, sessionEndedAtMs);
+      cursor = sessionEndedAtMs;
+    } else if (effectiveFirstReviewAtMs !== null) {
+      push('review', cursor, sessionEndedAtMs);
+      cursor = sessionEndedAtMs;
     }
   } else {
     const claimEnd = Math.min(claimCap, sessionEndedAtMs);

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -297,12 +297,20 @@ const CLAIM_STAGE_CAP_MS = 15 * 60 * 1000;
 const MERGE_STAGE_THIN_CAP_MS = 15 * 60 * 1000;
 
 /**
- * Builds the contiguous, gap-free stage-window tiling of
- * [sessionStartedAtMs, sessionEndedAtMs) per the issue's marker-join
- * table, then lets --events override individual stage boundaries.
- * Contiguous tiling (each window starts exactly where the previous one
- * ended) is what makes the per-stage usage allocation below sum back to
- * the session total exactly, in both delta and cumulative modes.
+ * Builds the stage-window tiling of [sessionStartedAtMs, sessionEndedAtMs)
+ * per the issue's marker-join table, then lets --events override individual
+ * stage boundaries. Contiguous tiling (each window starts exactly where the
+ * previous one ended) is what makes the per-stage usage allocation below sum
+ * back to the session total exactly, in both delta and cumulative modes --
+ * the marker-only pass always produces it. Once --events overrides are
+ * applied, an event window's timestamps are authoritative and never
+ * expanded, while a marker window always flows to fill the space around it
+ * (forward past its own original start, backward past its own original
+ * end) -- so the result stays gap-free everywhere a marker window can
+ * reach. A residual gap is possible only immediately before an event
+ * window whose immediately preceding window is itself event-sourced (or
+ * absent, at session start): there, no marker exists to flow into it, and
+ * that usage is genuinely unattributed to any stage rather than misattributed.
  */
 export function computeStageWindows(
   sessionStartedAtMs: number,
@@ -405,15 +413,25 @@ export function computeStageWindows(
   // timestamp, so it is only ever clamped forward past a conflicting
   // predecessor, never expanded. A marker window is a synthetic
   // reconstruction with no independent authority, so it always starts
-  // exactly at the running cursor -- flowing backward to fill any gap an
-  // event override left behind -- rather than leaving that usage
-  // unattributed to any stage.
+  // exactly at the running cursor (flowing backward to fill a gap an event
+  // override left behind it) and, symmetrically, is retroactively extended
+  // forward to meet the start of an event window that follows it with a
+  // gap -- rather than leaving that usage unattributed to any stage.
   const finalWindows: StageWindow[] = [];
   let normalizeCursor = sessionStartedAtMs;
   for (const stageId of TOKEN_COST_STAGE_IDS) {
     const window = byId.get(stageId);
     if (!window) {
       continue;
+    }
+    if (window.source === 'event' && window.startMs > normalizeCursor) {
+      const prevIndex = finalWindows.length - 1;
+      const prev = finalWindows[prevIndex];
+      if (prev && prev.source === 'marker') {
+        const extendedEndMs = Math.min(window.startMs, sessionEndedAtMs);
+        finalWindows[prevIndex] = { ...prev, endMs: extendedEndMs };
+        normalizeCursor = extendedEndMs;
+      }
     }
     const startMs =
       window.source === 'event'
@@ -851,6 +869,18 @@ export function resolveIssueLoopContext(
     ) {
       humanHandoff = true;
     }
+    // A later claimed-by marker naming this session's own claimId in its
+    // supersedes field, from a different agent, is a silent takeover --
+    // the outcome table's "a different actor takes the claim before
+    // merge" row, same as an explicit forced-handoff marker.
+    const takeover = parseClaimComment(comment.body, comment.createdAt);
+    if (
+      takeover &&
+      takeover.supersedes === claimId &&
+      takeover.agentId !== claimAgentId
+    ) {
+      humanHandoff = true;
+    }
   }
 
   return {
@@ -1071,12 +1101,23 @@ export function buildSample(
   trustedLogins: readonly string[],
 ): HarvestedSample {
   const base = session.adapterResult.sample;
-  const startedAtMs = toValidTimestampMs(base.startedAt) ?? 0;
-  const endedAtMs = toValidTimestampMs(base.endedAt) ?? startedAtMs;
+  const validStartedAtMs = toValidTimestampMs(base.startedAt);
+  const validEndedAtMs = toValidTimestampMs(base.endedAt);
+  const startedAtMs = validStartedAtMs ?? 0;
+  const endedAtMs = validEndedAtMs ?? startedAtMs;
   const issueNumber = session.adapterResult.joinHints?.issueNumber;
 
-  if (issueNumber === undefined) {
-    return { sample: base, startedAtMs, endedAtMs };
+  if (
+    issueNumber === undefined ||
+    validStartedAtMs === undefined ||
+    validEndedAtMs === undefined
+  ) {
+    // An adapter's own timestamp fields are malformed, or there is no
+    // issue to join against: skip the GitHub join rather than resolving
+    // a context against a nonsensical (e.g. epoch-anchored) session
+    // window. assertTokenCostSample would reject a malformed startedAt
+    // downstream anyway; this just avoids the wasted join work first.
+    return { sample: base, issueNumber, startedAtMs, endedAtMs };
   }
 
   const ctx = resolveIssueLoopContext(

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -401,9 +401,13 @@ export function computeStageWindows(
   // disagree with its marker-derived neighbors (or two overrides can
   // disagree with each other), and naively overlaying them can leave
   // windows that overlap -- which would double-count delta-mode usage in
-  // allocateStageUsage below. Clamp each window's start to a monotonic
-  // cursor and drop it if that clamp consumes the whole window; a gap is
-  // fine (its usage points simply attribute to no stage), an overlap is not.
+  // allocateStageUsage below. An event window is an authoritative explicit
+  // timestamp, so it is only ever clamped forward past a conflicting
+  // predecessor, never expanded. A marker window is a synthetic
+  // reconstruction with no independent authority, so it always starts
+  // exactly at the running cursor -- flowing backward to fill any gap an
+  // event override left behind -- rather than leaving that usage
+  // unattributed to any stage.
   const finalWindows: StageWindow[] = [];
   let normalizeCursor = sessionStartedAtMs;
   for (const stageId of TOKEN_COST_STAGE_IDS) {
@@ -411,7 +415,10 @@ export function computeStageWindows(
     if (!window) {
       continue;
     }
-    const startMs = Math.max(window.startMs, normalizeCursor);
+    const startMs =
+      window.source === 'event'
+        ? Math.max(window.startMs, normalizeCursor)
+        : normalizeCursor;
     const endMs = Math.min(window.endMs, sessionEndedAtMs);
     if (endMs > startMs) {
       finalWindows.push({ ...window, startMs, endMs });
@@ -773,10 +780,13 @@ export function resolveIssueLoopContext(
       continue;
     }
     const atMs = toValidTimestampMs(claim.createdAt);
+    // Half-open [sessionStartedAtMs, sessionEndedAtMs), matching this
+    // function's documented session window: a claim marker at exactly
+    // sessionEndedAtMs is out of range.
     if (
       atMs === undefined ||
       atMs < sessionStartedAtMs ||
-      atMs > sessionEndedAtMs
+      atMs >= sessionEndedAtMs
     ) {
       continue;
     }
@@ -1131,7 +1141,7 @@ function printHelp(): void {
   process.stdout.write(`Usage:
   node scripts/token-cost-harvest.mjs --repo <owner>/<repo> [--out <path>] [--events <path>] [--dry-run]
 
-  --repo <owner/repo>          Repository to join harvested sessions against. Required.
+  --repo <owner>/<repo>         Repository to join harvested sessions against. Required.
   --out <path>                 Output samples JSONL path (default:
                                 ${defaultStateDir()}/samples.jsonl).
   --events <path>               Phase-event JSONL path (default:
@@ -1191,19 +1201,31 @@ export function readExistingVendorSessionKeys(outPath: string): Set<string> {
   return keys;
 }
 
+/** Validates and splits a --repo <owner>/<repo> flag value; null for anything but exactly two non-empty segments. */
+export function parseRepoFlag(
+  repoFlag: string,
+): { owner: string; repo: string } | null {
+  const parts = repoFlag.split('/');
+  if (parts.length !== 2 || parts.some((part) => part === '')) {
+    return null;
+  }
+  const [owner, repo] = parts;
+  return { owner, repo };
+}
+
 function runCli(argv: string[]): void {
   const { values, help } = parseCliArgs(argv, TOKEN_COST_HARVEST_FLAG_SPEC);
   if (help) {
     printHelp();
     return;
   }
-  const repoFlag = values.repo as string;
-  if (!repoFlag.includes('/')) {
+  const parsedRepo = parseRepoFlag(values.repo as string);
+  if (!parsedRepo) {
     process.stderr.write('--repo <owner>/<repo> is required\n');
     process.exitCode = 2;
     return;
   }
-  const [owner, repo] = repoFlag.split('/');
+  const { owner, repo } = parsedRepo;
   const dryRun = values['dry-run'] as boolean;
   const outPath =
     (values.out as string) || join(defaultStateDir(), 'samples.jsonl');

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1256,7 +1256,10 @@ export function readExistingVendorSessionKeys(outPath: string): Set<string> {
 export function parseRepoFlag(
   repoFlag: string,
 ): { owner: string; repo: string } | null {
-  const parts = repoFlag.split('/');
+  const parts = repoFlag
+    .trim()
+    .split('/')
+    .map((part) => part.trim());
   if (parts.length !== 2 || parts.some((part) => part === '')) {
     return null;
   }
@@ -1270,9 +1273,14 @@ function runCli(argv: string[]): void {
     printHelp();
     return;
   }
-  const parsedRepo = parseRepoFlag(values.repo as string);
+  const repoFlag = values.repo as string;
+  const parsedRepo = parseRepoFlag(repoFlag);
   if (!parsedRepo) {
-    process.stderr.write('--repo <owner>/<repo> is required\n');
+    process.stderr.write(
+      repoFlag === ''
+        ? '--repo <owner>/<repo> is required\n'
+        : `--repo must be in <owner>/<repo> form, got: ${repoFlag}\n`,
+    );
     process.exitCode = 2;
     return;
   }

--- a/tests/fixtures/token-cost/github/issue-loop-merged.json
+++ b/tests/fixtures/token-cost/github/issue-loop-merged.json
@@ -1,0 +1,38 @@
+{
+  "data": {
+    "repository": {
+      "issue": {
+        "comments": {
+          "nodes": [
+            {
+              "body": "<!-- claimed-by: claude-test cid-merged supersedes: none 2026-01-01T00:00:00Z branch: issue/9001-test -->\n\n_claude-test: issue claim — IDD automation marker. Do not edit._",
+              "createdAt": "2026-01-01T00:00:00Z",
+              "author": { "login": "claude-test" }
+            },
+            {
+              "body": "<!-- review-watermark: claude-test cid-merged 0123456789abcdef0123456789abcdef01234567 none 3 none -->\n\n_claude-test: review snapshot watermark — IDD automation marker. Do not edit._",
+              "createdAt": "2026-01-01T00:20:00Z",
+              "author": { "login": "claude-test" }
+            }
+          ]
+        },
+        "timelineItems": {
+          "nodes": [
+            {
+              "__typename": "ConnectedEvent",
+              "subject": {
+                "__typename": "PullRequest",
+                "number": 9101,
+                "state": "MERGED",
+                "headRefName": "issue/9001-test",
+                "createdAt": "2026-01-01T00:10:00Z",
+                "mergedAt": "2026-01-01T00:30:00Z",
+                "reviews": { "nodes": [{ "submittedAt": "2026-01-01T00:22:00Z" }] }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/token-cost/github/issue-loop-resume-same-agent.json
+++ b/tests/fixtures/token-cost/github/issue-loop-resume-same-agent.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "repository": {
+      "issue": {
+        "comments": {
+          "nodes": [
+            {
+              "body": "<!-- claimed-by: claude-a cid-a1 supersedes: none 2026-01-01T00:00:00Z branch: issue/9004-test -->\n\n_claude-a: issue claim — IDD automation marker. Do not edit._",
+              "createdAt": "2026-01-01T00:00:00Z",
+              "author": { "login": "claude-a" }
+            },
+            {
+              "body": "<!-- claimed-by: claude-a cid-a2 supersedes: cid-a1 2026-01-01T00:15:00Z branch: issue/9004-test -->\n\n_claude-a: issue claim — IDD automation marker. Do not edit._",
+              "createdAt": "2026-01-01T00:15:00Z",
+              "author": { "login": "claude-a" }
+            }
+          ]
+        },
+        "timelineItems": { "nodes": [] }
+      }
+    }
+  }
+}

--- a/tests/fixtures/token-cost/github/issue-loop-takeover.json
+++ b/tests/fixtures/token-cost/github/issue-loop-takeover.json
@@ -1,0 +1,23 @@
+{
+  "data": {
+    "repository": {
+      "issue": {
+        "comments": {
+          "nodes": [
+            {
+              "body": "<!-- claimed-by: claude-a cid-a supersedes: none 2026-01-01T00:00:00Z branch: issue/9003-test -->\n\n_claude-a: issue claim — IDD automation marker. Do not edit._",
+              "createdAt": "2026-01-01T00:00:00Z",
+              "author": { "login": "claude-a" }
+            },
+            {
+              "body": "<!-- claimed-by: claude-b cid-b supersedes: cid-a 2026-01-01T00:15:00Z branch: issue/9003-test -->\n\n_claude-b: issue claim — IDD automation marker. Do not edit._",
+              "createdAt": "2026-01-01T00:15:00Z",
+              "author": { "login": "claude-b" }
+            }
+          ]
+        },
+        "timelineItems": { "nodes": [] }
+      }
+    }
+  }
+}

--- a/tests/fixtures/token-cost/github/issue-loop-unclaimed.json
+++ b/tests/fixtures/token-cost/github/issue-loop-unclaimed.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+    "repository": {
+      "issue": {
+        "comments": {
+          "nodes": [
+            {
+              "body": "<!-- claimed-by: claude-test cid-unclaimed supersedes: none 2026-02-01T00:00:00Z branch: issue/9002-test -->\n\n_claude-test: issue claim — IDD automation marker. Do not edit._",
+              "createdAt": "2026-02-01T00:00:00Z",
+              "author": { "login": "claude-test" }
+            },
+            {
+              "body": "<!-- unclaimed-by: claude-test cid-unclaimed 2026-02-01T00:05:00Z -->\n\n_claude-test: issue claim released — IDD automation marker. Do not edit._",
+              "createdAt": "2026-02-01T00:05:00Z",
+              "author": { "login": "claude-test" }
+            }
+          ]
+        },
+        "timelineItems": {
+          "nodes": []
+        }
+      }
+    }
+  }
+}

--- a/tests/help-text-flags.test.mts
+++ b/tests/help-text-flags.test.mts
@@ -175,6 +175,7 @@ const COVERED_HELPERS = [
   'claim-approval-gate',
   'claim-lock',
   'token-cost-event',
+  'token-cost-harvest',
   'token-cost-report',
   'discover-readiness-check',
   'discover-shared-file-overlap',

--- a/tests/helper-invocation-profile.test.mts
+++ b/tests/helper-invocation-profile.test.mts
@@ -120,6 +120,15 @@ const SOURCE_REPO_INTERNAL_ENTRY_PATHS = new Set([
   // never committed to git -- and is never distributed to idd-template/;
   // an adopter repository has no token-cost data to record.
   'scripts/token-cost-event.mjs',
+  // token-cost-harvest.mjs (#2292): this repository's own dogfood
+  // harvest CLI, named in docs/token-cost.md's own usage examples. It
+  // scans local vendor session logs (`~/.grok`/`~/.claude`/`~/.codex`)
+  // and this repository's own GitHub IDD markers, writing local JSONL
+  // under `${XDG_STATE_HOME:-$HOME/.local/state}/idd-skill/token-cost/`
+  // -- never committed to git -- and is never distributed to
+  // idd-template/; an adopter repository has no token-cost data to
+  // harvest.
+  'scripts/token-cost-harvest.mjs',
 ]);
 
 // A helper name that appears only as a *proposed*, not-yet-built script

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -20,10 +20,12 @@ import {
   type IssueLoopGithubContext,
   markAmbiguousOverlaps,
   readEventWindows,
+  readExistingVendorSessionKeys,
   resolveIssueLoopContext,
   resolveTrustedMarkerLogins,
   type StageEventWindow,
   type VendorSession,
+  vendorSessionKey,
 } from '../src/scripts/token-cost-harvest.mts';
 import { readJson } from './test-utils.mts';
 
@@ -357,6 +359,55 @@ test('computeStageWindows: an --events window overrides the marker-derived one a
   assert.equal(work?.endMs, ms('2026-01-01T00:19:00Z'));
 });
 
+test('computeStageWindows: an --events override that runs past a later marker-derived stage is clamped, never overlapping', () => {
+  const ctx: IssueLoopGithubContext = {
+    claimedAtMs: ms('2026-01-01T00:00:00Z'),
+    prCreatedAtMs: ms('2026-01-01T00:25:00Z'),
+    prHeadRefName: 'issue/1-test',
+    prMergedAtMs: null,
+    firstReviewAtMs: null,
+    cleanupAtMs: null,
+    unclaimedMatched: false,
+    humanHandoff: false,
+  };
+  // The marker-derived tiling would put 'work' at [00:15, 00:25). An
+  // --events override stretches 'claim' out to 00:20, past where 'work'
+  // would otherwise start.
+  const events = new Map<TokenCostStageId, StageEventWindow>([
+    [
+      'claim',
+      {
+        startMs: ms('2026-01-01T00:05:00Z'),
+        endMs: ms('2026-01-01T00:20:00Z'),
+      },
+    ],
+  ]);
+  const { windows } = computeStageWindows(
+    ms('2026-01-01T00:00:00Z'),
+    ms('2026-01-01T00:30:00Z'),
+    ctx,
+    events,
+  );
+  for (let i = 1; i < windows.length; i++) {
+    assert.ok(
+      windows[i].startMs >= windows[i - 1].endMs,
+      `${windows[i].id} [${windows[i].startMs}, ${windows[i].endMs}) overlaps ${
+        windows[i - 1].id
+      } [${windows[i - 1].startMs}, ${windows[i - 1].endMs})`,
+    );
+  }
+  const claim = windows.find((w) => w.id === 'claim');
+  assert.equal(claim?.source, 'event');
+  assert.equal(claim?.startMs, ms('2026-01-01T00:05:00Z'));
+  assert.equal(claim?.endMs, ms('2026-01-01T00:20:00Z'));
+  const work = windows.find((w) => w.id === 'work');
+  // work's marker-derived start (00:15) is clamped forward past claim's
+  // event-sourced end (00:20) instead of overlapping it.
+  assert.equal(work?.source, 'marker');
+  assert.equal(work?.startMs, ms('2026-01-01T00:20:00Z'));
+  assert.equal(work?.endMs, ms('2026-01-01T00:25:00Z'));
+});
+
 test('computeStageWindows returns no windows when there is no claim in range', () => {
   const ctx: IssueLoopGithubContext = {
     claimedAtMs: null,
@@ -580,10 +631,46 @@ test('readEventWindows: pairs a trusted enter/exit for the same (issueNumber, st
   try {
     const windows = readEventWindows(path);
     assert.equal(windows.size, 1);
-    const window = windows.get('7:work');
+    const window = windows.get('7:claude:work');
     assert.ok(window);
     assert.equal(window?.startMs, ms('2026-01-01T00:10:00Z'));
     assert.equal(window?.endMs, ms('2026-01-01T00:20:00Z'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readEventWindows: does not pair an enter/exit across two different vendors for the same issue/stage', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-token-cost-events-'));
+  const path = join(dir, 'events.jsonl');
+  writeFileSync(
+    path,
+    [
+      // claude enters 'work' but never exits (handed off).
+      JSON.stringify({
+        schemaVersion: 1,
+        event: 'enter',
+        stageId: 'work',
+        at: '2026-01-01T00:10:00Z',
+        vendor: 'claude',
+        issueNumber: 7,
+      }),
+      // codex resumes and exits 'work' -- must not pair with claude's enter.
+      JSON.stringify({
+        schemaVersion: 1,
+        event: 'exit',
+        stageId: 'work',
+        at: '2026-01-01T00:20:00Z',
+        vendor: 'codex',
+        issueNumber: 7,
+      }),
+    ].join('\n'),
+  );
+  try {
+    const windows = readEventWindows(path);
+    assert.equal(windows.size, 0);
+    assert.equal(windows.get('7:claude:work'), undefined);
+    assert.equal(windows.get('7:codex:work'), undefined);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -754,4 +841,45 @@ test('AC3: a session with no joinHints.issueNumber stays kind: session, never re
     (built.sample as { attribution: string }).attribution,
     'session-unscoped',
   );
+});
+
+// ---------------------------------------------------------------------------
+// Output-file append/dedup (every run rescans full vendor history, so the
+// documented "appends to samples.jsonl" behavior must skip sessions already
+// recorded rather than overwrite or duplicate them)
+// ---------------------------------------------------------------------------
+
+test('vendorSessionKey combines vendor and vendorSessionId', () => {
+  assert.equal(
+    vendorSessionKey({ vendor: 'claude', vendorSessionId: 'abc' }),
+    'claude:abc',
+  );
+});
+
+test('readExistingVendorSessionKeys: missing file returns an empty set', () => {
+  const keys = readExistingVendorSessionKeys(
+    join(tmpdir(), 'does-not-exist-token-cost-samples.jsonl'),
+  );
+  assert.equal(keys.size, 0);
+});
+
+test('readExistingVendorSessionKeys: reads (vendor, vendorSessionId) pairs and skips a malformed line', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-token-cost-samples-'));
+  const path = join(dir, 'samples.jsonl');
+  writeFileSync(
+    path,
+    [
+      JSON.stringify({ vendor: 'claude', vendorSessionId: 'session-1' }),
+      'not valid json',
+      JSON.stringify({ vendor: 'codex', vendorSessionId: 'session-2' }),
+    ].join('\n'),
+  );
+  try {
+    const keys = readExistingVendorSessionKeys(path);
+    assert.equal(keys.size, 2);
+    assert.ok(keys.has('claude:session-1'));
+    assert.ok(keys.has('codex:session-2'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -618,6 +618,26 @@ test('allocateStageUsage (cumulative mode): a gap between windows excludes that 
   assert.equal(sum, 9); // 12 (final snapshot) - 3 (unattributed gap growth)
 });
 
+test("allocateStageUsage (cumulative mode): a point exactly at the first window's startMs counts as usage, not as the baseline", () => {
+  const windows = [
+    {
+      id: 'claim' as const,
+      startMs: ms('2026-01-01T00:00:00Z'),
+      endMs: ms('2026-01-01T00:10:00Z'),
+      source: 'marker' as const,
+    },
+  ];
+  const points = [
+    // Coincides exactly with the window's own start -- must not be
+    // consumed as the subtraction baseline (which would silently drop
+    // this point's own usage instead of allocating it).
+    { atMs: ms('2026-01-01T00:00:00Z'), usage: usage(5) },
+    { atMs: ms('2026-01-01T00:10:00Z'), usage: usage(8) },
+  ];
+  const stages = allocateStageUsage(windows, { mode: 'cumulative', points });
+  assert.equal(stages.find((s) => s.id === 'claim')?.usage.output, 8);
+});
+
 test('allocateStageUsage omits an all-zero-usage window', () => {
   const windows = [
     {
@@ -961,7 +981,7 @@ test('resolveIssueLoopContext: a later claimed-by marker superseding this claimI
   }
 });
 
-test('resolveIssueLoopContext: a superseding claim from the SAME agent is not a takeover', () => {
+test('resolveIssueLoopContext: a superseding claim from an untrusted (filtered-out) login is invisible, not a takeover', () => {
   const fixture = readJson(
     'tests/fixtures/token-cost/github/issue-loop-takeover.json',
   );
@@ -974,8 +994,35 @@ test('resolveIssueLoopContext: a superseding claim from the SAME agent is not a 
       ms('2026-01-01T00:00:00Z'),
       ms('2026-01-01T00:10:00Z'),
       // Only claude-a is trusted here: the second (claude-b) comment is
-      // filtered out entirely, simulating "no takeover marker visible" --
-      // isolates that humanHandoff is false absent a superseding marker.
+      // filtered out entirely before parseClaimComment ever sees it --
+      // isolates that humanHandoff is false absent a visible superseding
+      // marker at all (distinct from the same-agent guard test below).
+      ['claude-a'],
+    );
+    assert.ok(ctx);
+    assert.equal(ctx?.humanHandoff, false);
+  } finally {
+    restore();
+  }
+});
+
+test('resolveIssueLoopContext: a superseding claim from the SAME agent is not a takeover', () => {
+  const fixture = readJson(
+    'tests/fixtures/token-cost/github/issue-loop-resume-same-agent.json',
+  );
+  const restore = stubGhReturningJson(fixture);
+  try {
+    // Both claimed-by comments are trusted and visible here (unlike the
+    // filtered-out case above), so this exercises the actual
+    // takeover.agentId !== claimAgentId guard: a self re-claim (same
+    // agent, superseding its own earlier claimId) must not count as
+    // human-handoff.
+    const ctx = resolveIssueLoopContext(
+      'acme',
+      'repo',
+      9004,
+      ms('2026-01-01T00:00:00Z'),
+      ms('2026-01-01T00:10:00Z'),
       ['claude-a'],
     );
     assert.ok(ctx);

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -19,6 +19,7 @@ import {
   type HarvestedSample,
   type IssueLoopGithubContext,
   markAmbiguousOverlaps,
+  parseRepoFlag,
   readEventWindows,
   readExistingVendorSessionKeys,
   resolveIssueLoopContext,
@@ -408,6 +409,59 @@ test('computeStageWindows: an --events override that runs past a later marker-de
   assert.equal(work?.endMs, ms('2026-01-01T00:25:00Z'));
 });
 
+test('computeStageWindows: a following marker window flows backward to fill the gap an event override leaves behind', () => {
+  const ctx: IssueLoopGithubContext = {
+    claimedAtMs: ms('2026-01-01T00:00:00Z'),
+    prCreatedAtMs: ms('2026-01-01T00:25:00Z'),
+    prHeadRefName: 'issue/1-test',
+    prMergedAtMs: null,
+    firstReviewAtMs: null,
+    cleanupAtMs: null,
+    unclaimedMatched: false,
+    humanHandoff: false,
+  };
+  // The marker-derived tiling would put 'work' at [00:15, 00:25). An
+  // --events override shrinks 'work' to [00:16, 00:19), well short of
+  // 00:25 -- the marker-derived 'submit-pr' that follows it must flow
+  // backward to 00:19 rather than leaving [00:19, 00:25) unattributed.
+  const events = new Map<TokenCostStageId, StageEventWindow>([
+    [
+      'work',
+      {
+        startMs: ms('2026-01-01T00:16:00Z'),
+        endMs: ms('2026-01-01T00:19:00Z'),
+      },
+    ],
+  ]);
+  const { windows } = computeStageWindows(
+    ms('2026-01-01T00:00:00Z'),
+    ms('2026-01-01T00:30:00Z'),
+    ctx,
+    events,
+  );
+  for (let i = 1; i < windows.length; i++) {
+    assert.ok(
+      windows[i].startMs >= windows[i - 1].endMs,
+      `${windows[i].id} [${windows[i].startMs}, ${windows[i].endMs}) overlaps ${
+        windows[i - 1].id
+      } [${windows[i - 1].startMs}, ${windows[i - 1].endMs})`,
+    );
+  }
+  // 'work' (event-sourced) is left with a small gap before it ([00:15,
+  // 00:16), from claim's marker-derived end to work's own explicit start)
+  // -- that gap is genuine and expected, since work's start is an
+  // authoritative timestamp, not a synthetic reconstruction to be expanded.
+  const work = windows.find((w) => w.id === 'work');
+  assert.equal(work?.startMs, ms('2026-01-01T00:16:00Z'));
+  // 'submit-pr' (marker-sourced) must flow backward to close the gap work's
+  // shrink left AFTER it, rather than leaving [00:19, 00:25) unattributed.
+  const submitPr = windows.find((w) => w.id === 'submit-pr');
+  assert.equal(submitPr?.source, 'marker');
+  assert.equal(submitPr?.startMs, work?.endMs);
+  assert.equal(submitPr?.startMs, ms('2026-01-01T00:19:00Z'));
+  assert.equal(submitPr?.endMs, ms('2026-01-01T00:30:00Z'));
+});
+
 test('computeStageWindows returns no windows when there is no claim in range', () => {
   const ctx: IssueLoopGithubContext = {
     claimedAtMs: null,
@@ -736,6 +790,30 @@ test('resolveIssueLoopContext: firstReviewAtMs is the earlier of the review-wate
   }
 });
 
+test('resolveIssueLoopContext: a claim marker at exactly sessionEndedAtMs is excluded (half-open interval)', () => {
+  const fixture = readJson(
+    'tests/fixtures/token-cost/github/issue-loop-merged.json',
+  );
+  const restore = stubGhReturningJson(fixture);
+  try {
+    // The fixture's only claimed-by marker is at 2026-01-01T00:00:00Z --
+    // set sessionEndedAtMs to exactly that instant. The documented window
+    // is [sessionStartedAtMs, sessionEndedAtMs), so the claim must not be
+    // treated as in-range, leaving no claim and thus no context.
+    const ctx = resolveIssueLoopContext(
+      'acme',
+      'repo',
+      9001,
+      ms('2025-12-31T23:55:00Z'),
+      ms('2026-01-01T00:00:00Z'),
+      ['claude-test'],
+    );
+    assert.equal(ctx, null);
+  } finally {
+    restore();
+  }
+});
+
 test('resolveIssueLoopContext: outcome is unclaimed when a matching unclaimed-by exists and nothing merged', () => {
   const fixture = readJson(
     'tests/fixtures/token-cost/github/issue-loop-unclaimed.json',
@@ -882,4 +960,20 @@ test('readExistingVendorSessionKeys: reads (vendor, vendorSessionId) pairs and s
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+// ---------------------------------------------------------------------------
+// --repo flag validation
+// ---------------------------------------------------------------------------
+
+test('parseRepoFlag accepts exactly two non-empty segments', () => {
+  assert.deepEqual(parseRepoFlag('acme/repo'), { owner: 'acme', repo: 'repo' });
+});
+
+test('parseRepoFlag rejects extra, missing, or empty segments', () => {
+  assert.equal(parseRepoFlag('owner/repo/extra'), null);
+  assert.equal(parseRepoFlag('/repo'), null);
+  assert.equal(parseRepoFlag('owner/'), null);
+  assert.equal(parseRepoFlag('owner'), null);
+  assert.equal(parseRepoFlag(''), null);
 });

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -447,12 +447,14 @@ test('computeStageWindows: a following marker window flows backward to fill the 
       } [${windows[i - 1].startMs}, ${windows[i - 1].endMs})`,
     );
   }
-  // 'work' (event-sourced) is left with a small gap before it ([00:15,
-  // 00:16), from claim's marker-derived end to work's own explicit start)
-  // -- that gap is genuine and expected, since work's start is an
-  // authoritative timestamp, not a synthetic reconstruction to be expanded.
+  // 'claim' (marker-sourced) must flow FORWARD to close the gap before
+  // 'work' (event-sourced) too: claim's own marker-derived end (00:15) is
+  // retroactively extended to meet work's explicit start (00:16).
+  const claim = windows.find((w) => w.id === 'claim');
   const work = windows.find((w) => w.id === 'work');
   assert.equal(work?.startMs, ms('2026-01-01T00:16:00Z'));
+  assert.equal(claim?.endMs, work?.startMs);
+  assert.equal(claim?.endMs, ms('2026-01-01T00:16:00Z'));
   // 'submit-pr' (marker-sourced) must flow backward to close the gap work's
   // shrink left AFTER it, rather than leaving [00:19, 00:25) unattributed.
   const submitPr = windows.find((w) => w.id === 'submit-pr');
@@ -460,6 +462,45 @@ test('computeStageWindows: a following marker window flows backward to fill the 
   assert.equal(submitPr?.startMs, work?.endMs);
   assert.equal(submitPr?.startMs, ms('2026-01-01T00:19:00Z'));
   assert.equal(submitPr?.endMs, ms('2026-01-01T00:30:00Z'));
+});
+
+test('computeStageWindows: extending a marker window to meet a later event window clamps to sessionEndedAtMs, never past it', () => {
+  const ctx: IssueLoopGithubContext = {
+    claimedAtMs: ms('2026-01-01T00:00:00Z'),
+    prCreatedAtMs: ms('2026-01-01T00:25:00Z'),
+    prHeadRefName: 'issue/1-test',
+    prMergedAtMs: null,
+    firstReviewAtMs: null,
+    cleanupAtMs: null,
+    unclaimedMatched: false,
+    humanHandoff: false,
+  };
+  // A stale --events entry (e.g. from a later/different session) whose
+  // startMs is past this session's own end -- the gap-filling extension
+  // must not stretch 'claim' past sessionEndedAtMs to reach it.
+  const events = new Map<TokenCostStageId, StageEventWindow>([
+    [
+      'work',
+      {
+        startMs: ms('2026-01-01T00:35:00Z'),
+        endMs: ms('2026-01-01T00:40:00Z'),
+      },
+    ],
+  ]);
+  const { windows } = computeStageWindows(
+    ms('2026-01-01T00:00:00Z'),
+    ms('2026-01-01T00:30:00Z'),
+    ctx,
+    events,
+  );
+  // 'work' itself is dropped: after clamping to sessionEndedAtMs, its
+  // interval is empty.
+  assert.ok(!windows.some((w) => w.id === 'work'));
+  const claim = windows.find((w) => w.id === 'claim');
+  assert.equal(claim?.endMs, ms('2026-01-01T00:30:00Z'));
+  for (const window of windows) {
+    assert.ok(window.endMs <= ms('2026-01-01T00:30:00Z'));
+  }
 });
 
 test('computeStageWindows returns no windows when there is no claim in range', () => {
@@ -836,6 +877,87 @@ test('resolveIssueLoopContext: outcome is unclaimed when a matching unclaimed-by
   } finally {
     restore();
   }
+});
+
+test('resolveIssueLoopContext: a later claimed-by marker superseding this claimId from a different agent is a takeover (human-handoff), regardless of session window', () => {
+  const fixture = readJson(
+    'tests/fixtures/token-cost/github/issue-loop-takeover.json',
+  );
+  const restore = stubGhReturningJson(fixture);
+  try {
+    // claude-a's own session ends at 00:10; the superseding claim from
+    // claude-b lands at 00:15, after this session's own window ended --
+    // takeover detection is not session-windowed (docs/token-cost.md's
+    // Attribution: an issue loop can span multiple vendor sessions).
+    const ctx = resolveIssueLoopContext(
+      'acme',
+      'repo',
+      9003,
+      ms('2026-01-01T00:00:00Z'),
+      ms('2026-01-01T00:10:00Z'),
+      ['claude-a', 'claude-b'],
+    );
+    assert.ok(ctx);
+    assert.equal(ctx?.humanHandoff, true);
+    assert.equal(deriveOutcome(ctx as IssueLoopGithubContext), 'human-handoff');
+  } finally {
+    restore();
+  }
+});
+
+test('resolveIssueLoopContext: a superseding claim from the SAME agent is not a takeover', () => {
+  const fixture = readJson(
+    'tests/fixtures/token-cost/github/issue-loop-takeover.json',
+  );
+  const restore = stubGhReturningJson(fixture);
+  try {
+    const ctx = resolveIssueLoopContext(
+      'acme',
+      'repo',
+      9003,
+      ms('2026-01-01T00:00:00Z'),
+      ms('2026-01-01T00:10:00Z'),
+      // Only claude-a is trusted here: the second (claude-b) comment is
+      // filtered out entirely, simulating "no takeover marker visible" --
+      // isolates that humanHandoff is false absent a superseding marker.
+      ['claude-a'],
+    );
+    assert.ok(ctx);
+    assert.equal(ctx?.humanHandoff, false);
+  } finally {
+    restore();
+  }
+});
+
+test('buildSample: an adapter session with an unparseable startedAt skips the GitHub join and stays kind: session', () => {
+  const session: VendorSession = {
+    vendor: 'claude',
+    adapterResult: {
+      sample: {
+        schemaVersion: 1,
+        kind: 'session',
+        vendor: 'claude',
+        model: 'fake-model',
+        attribution: 'session-unscoped',
+        outcome: 'unknown',
+        usage: usage(1),
+        compactionCount: 0,
+        startedAt: 'not-a-timestamp',
+        endedAt: '2026-01-01T00:10:00Z',
+        vendorSessionId: 'fake-session-3',
+      },
+      joinHints: { issueNumber: 9001 },
+    },
+    timeline: { mode: 'delta', points: [] },
+  };
+  // No stubGh: if buildSample attempted the join anyway, the real `gh`
+  // binary (or its absence) would make this test fail or hang, proving no
+  // network call was attempted.
+  const built = buildSample(session, 'acme', 'repo', new Map(), [
+    'claude-test',
+  ]);
+  assert.equal(built.sample.kind, 'session');
+  assert.equal(built.startedAtMs, 0);
 });
 
 test('AC1: a fake adapter session joined against fixture GitHub markers produces one issue-loop sample whose stage usage sums to the session usage, outcome merged', () => {

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -638,6 +638,34 @@ test("allocateStageUsage (cumulative mode): a point exactly at the first window'
   assert.equal(stages.find((s) => s.id === 'claim')?.usage.output, 8);
 });
 
+test('allocateStageUsage (cumulative mode): a point exactly at a shared boundary between two contiguous windows is not double-counted', () => {
+  const windows = [
+    {
+      id: 'claim' as const,
+      startMs: ms('2026-01-01T00:00:00Z'),
+      endMs: ms('2026-01-01T00:10:00Z'),
+      source: 'marker' as const,
+    },
+    {
+      id: 'work' as const,
+      startMs: ms('2026-01-01T00:10:00Z'),
+      endMs: ms('2026-01-01T00:20:00Z'),
+      source: 'marker' as const,
+    },
+  ];
+  const points = [
+    { atMs: ms('2026-01-01T00:00:00Z'), usage: usage(5) },
+    // Exactly at the shared boundary between claim and work.
+    { atMs: ms('2026-01-01T00:10:00Z'), usage: usage(8) },
+    { atMs: ms('2026-01-01T00:20:00Z'), usage: usage(12) },
+  ];
+  const stages = allocateStageUsage(windows, { mode: 'cumulative', points });
+  assert.equal(stages.find((s) => s.id === 'claim')?.usage.output, 8);
+  assert.equal(stages.find((s) => s.id === 'work')?.usage.output, 4);
+  const sum = stages.reduce((total, s) => total + usageSum(s.usage), 0);
+  assert.equal(sum, 12); // must equal the final snapshot, not 15
+});
+
 test('allocateStageUsage omits an all-zero-usage window', () => {
   const windows = [
     {

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -587,6 +587,37 @@ test('allocateStageUsage (cumulative mode): windows telescope to the final snaps
   assert.equal(sum, 100); // matches the final (latest) cumulative snapshot
 });
 
+test('allocateStageUsage (cumulative mode): a gap between windows excludes that growth, never folds it into the next window', () => {
+  const windows = [
+    {
+      id: 'claim' as const,
+      startMs: ms('2026-01-01T00:00:00Z'),
+      endMs: ms('2026-01-01T00:10:00Z'),
+      source: 'marker' as const,
+    },
+    // A genuine gap: [00:10, 00:15) is not covered by any window.
+    {
+      id: 'work' as const,
+      startMs: ms('2026-01-01T00:15:00Z'),
+      endMs: ms('2026-01-01T00:25:00Z'),
+      source: 'event' as const,
+    },
+  ];
+  const points = [
+    { atMs: ms('2026-01-01T00:05:00Z'), usage: usage(5) },
+    // Grows during the gap -- this +3 must not attribute to either window.
+    { atMs: ms('2026-01-01T00:12:00Z'), usage: usage(8) },
+    { atMs: ms('2026-01-01T00:20:00Z'), usage: usage(12) },
+  ];
+  const stages = allocateStageUsage(windows, { mode: 'cumulative', points });
+  assert.equal(stages.find((s) => s.id === 'claim')?.usage.output, 5);
+  // Not 7 (12 - the running baseline of 5): the +3 that grew during the gap
+  // (5 -> 8) is excluded, matching delta mode's gap exclusion.
+  assert.equal(stages.find((s) => s.id === 'work')?.usage.output, 4);
+  const sum = stages.reduce((total, s) => total + usageSum(s.usage), 0);
+  assert.equal(sum, 9); // 12 (final snapshot) - 3 (unattributed gap growth)
+});
+
 test('allocateStageUsage omits an all-zero-usage window', () => {
   const windows = [
     {
@@ -802,6 +833,31 @@ test('fetchIssueLoopGithubContext resolves the earliest live-connected same-bran
     // This is the PR's own first submitted review only -- resolveIssueLoopContext
     // (tested below) additionally folds in the earlier review-watermark comment.
     assert.equal(result.firstReviewAtMs, ms('2026-01-01T00:22:00Z'));
+  } finally {
+    restore();
+  }
+});
+
+test('resolveIssueLoopContext: trusted-login matching is case-insensitive', () => {
+  const fixture = readJson(
+    'tests/fixtures/token-cost/github/issue-loop-merged.json',
+  );
+  const restore = stubGhReturningJson(fixture);
+  try {
+    // The fixture's claimed-by comment author is "claude-test"; passing a
+    // differently cased trusted login must still resolve the claim (GitHub
+    // logins are case-insensitive for account identity) instead of
+    // silently treating the marker as untrusted and returning null.
+    const ctx = resolveIssueLoopContext(
+      'acme',
+      'repo',
+      9001,
+      ms('2025-12-31T23:55:00Z'),
+      ms('2026-01-01T00:35:00Z'),
+      ['Claude-Test'],
+    );
+    assert.ok(ctx);
+    assert.equal(ctx?.claimedAtMs, ms('2026-01-01T00:00:00Z'));
   } finally {
     restore();
   }

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -260,6 +260,69 @@ test('computeStageWindows omits a window that would collapse to zero width', () 
   assert.ok(!windows.some((w) => w.id === 'work'));
 });
 
+test('computeStageWindows: a review submitted after merge clamps submit-pr to mergedAt instead of overlapping merge', () => {
+  const ctx: IssueLoopGithubContext = {
+    claimedAtMs: ms('2026-01-01T00:02:00Z'),
+    prCreatedAtMs: ms('2026-01-01T00:22:00Z'),
+    prHeadRefName: 'issue/1-test',
+    prMergedAtMs: ms('2026-01-01T00:32:00Z'),
+    // A bot reviewing an admin-merged PR post hoc: firstReviewAtMs > prMergedAtMs.
+    firstReviewAtMs: ms('2026-01-01T00:45:00Z'),
+    cleanupAtMs: null,
+    unclaimedMatched: false,
+    humanHandoff: false,
+  };
+  const { windows } = computeStageWindows(
+    ms('2026-01-01T00:00:00Z'),
+    ms('2026-01-01T01:10:00Z'),
+    ctx,
+    EMPTY_EVENTS,
+  );
+  // review collapses to zero width (nothing happened between merge and the
+  // clamped submit-pr end) and is correctly omitted, not stretched past mergedAt.
+  assert.deepEqual(
+    windows.map((w) => w.id),
+    ['discover', 'claim', 'work', 'submit-pr', 'merge', 'cleanup'],
+  );
+  for (let i = 1; i < windows.length; i++) {
+    assert.equal(windows[i].startMs, windows[i - 1].endMs);
+  }
+  const submitPr = windows.find((w) => w.id === 'submit-pr');
+  assert.equal(submitPr?.endMs, ms('2026-01-01T00:32:00Z'));
+  const merge = windows.find((w) => w.id === 'merge');
+  assert.equal(merge?.startMs, ms('2026-01-01T00:32:00Z'));
+});
+
+test('computeStageWindows: a merged PR with no resolvable review still emits merge and cleanup', () => {
+  const ctx: IssueLoopGithubContext = {
+    claimedAtMs: ms('2026-01-01T00:02:00Z'),
+    prCreatedAtMs: ms('2026-01-01T00:22:00Z'),
+    prHeadRefName: 'issue/1-test',
+    prMergedAtMs: ms('2026-01-01T00:32:00Z'),
+    firstReviewAtMs: null,
+    cleanupAtMs: null,
+    unclaimedMatched: false,
+    humanHandoff: false,
+  };
+  const { windows } = computeStageWindows(
+    ms('2026-01-01T00:00:00Z'),
+    ms('2026-01-01T01:10:00Z'),
+    ctx,
+    EMPTY_EVENTS,
+  );
+  assert.deepEqual(
+    windows.map((w) => w.id),
+    ['discover', 'claim', 'work', 'submit-pr', 'merge', 'cleanup'],
+  );
+  const submitPr = windows.find((w) => w.id === 'submit-pr');
+  assert.equal(submitPr?.endMs, ms('2026-01-01T00:32:00Z'));
+  const merge = windows.find((w) => w.id === 'merge');
+  assert.equal(merge?.startMs, ms('2026-01-01T00:32:00Z'));
+  assert.equal(merge?.endMs, ms('2026-01-01T00:47:00Z'));
+  const cleanup = windows.find((w) => w.id === 'cleanup');
+  assert.equal(cleanup?.endMs, ms('2026-01-01T01:10:00Z'));
+});
+
 test('computeStageWindows: an --events window overrides the marker-derived one and flips attribution', () => {
   const ctx: IssueLoopGithubContext = {
     claimedAtMs: ms('2026-01-01T00:00:00Z'),

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -1155,3 +1155,15 @@ test('parseRepoFlag rejects extra, missing, or empty segments', () => {
   assert.equal(parseRepoFlag('owner'), null);
   assert.equal(parseRepoFlag(''), null);
 });
+
+test('parseRepoFlag trims surrounding and per-segment whitespace', () => {
+  assert.deepEqual(parseRepoFlag(' acme/repo '), {
+    owner: 'acme',
+    repo: 'repo',
+  });
+  assert.deepEqual(parseRepoFlag('acme / repo'), {
+    owner: 'acme',
+    repo: 'repo',
+  });
+  assert.equal(parseRepoFlag('  '), null);
+});

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -1,0 +1,694 @@
+import assert from 'node:assert/strict';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import type {
+  TokenCostIssueLoopSample,
+  TokenCostStageId,
+  TokenCostUsage,
+} from '../src/scripts/token-cost-core.mts';
+import {
+  allocateStageUsage,
+  buildSample,
+  computeStageWindows,
+  deriveOutcome,
+  extractClaudeUsageTimeline,
+  extractCodexUsageTimeline,
+  fetchIssueLoopGithubContext,
+  type HarvestedSample,
+  type IssueLoopGithubContext,
+  markAmbiguousOverlaps,
+  readEventWindows,
+  resolveIssueLoopContext,
+  resolveTrustedMarkerLogins,
+  type StageEventWindow,
+  type VendorSession,
+} from '../src/scripts/token-cost-harvest.mts';
+import { readJson } from './test-utils.mts';
+
+const ms = (iso: string) => Date.parse(iso);
+
+const ZERO: TokenCostUsage = {
+  inputUncached: 0,
+  cacheRead: 0,
+  cacheCreation: 0,
+  output: 0,
+  reasoning: 0,
+};
+
+function usage(output: number): TokenCostUsage {
+  return { ...ZERO, output };
+}
+
+function usageSum(...values: TokenCostUsage[]): number {
+  return values.reduce(
+    (total, v) =>
+      total +
+      v.inputUncached +
+      v.cacheRead +
+      v.cacheCreation +
+      v.output +
+      v.reasoning,
+    0,
+  );
+}
+
+// Stub `gh` on PATH (the tests/gh-exec.test.mts / discover-roadmap-graph.test.mts
+// pattern) so the GitHub-join layer runs the real execFileSync + child-process
+// contract without network access.
+function stubGh(scriptBody: string): () => void {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-test-'));
+  const ghPath = join(tempRoot, 'gh');
+  writeFileSync(ghPath, `#!/usr/bin/env node\n${scriptBody}`);
+  chmodSync(ghPath, 0o755);
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${tempRoot}:${originalPath ?? ''}`;
+  return () => {
+    process.env.PATH = originalPath;
+    rmSync(tempRoot, { recursive: true, force: true });
+  };
+}
+
+function stubGhReturningJson(fixture: unknown): () => void {
+  return stubGh(
+    `process.stdout.write(${JSON.stringify(JSON.stringify(fixture))});`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-vendor usage timelines
+// ---------------------------------------------------------------------------
+
+test('extractClaudeUsageTimeline sums per-message deltas, sorted by timestamp', () => {
+  const records = [
+    {
+      type: 'assistant',
+      timestamp: '2026-01-01T00:05:00Z',
+      message: {
+        usage: {
+          input_tokens: 10,
+          cache_read_input_tokens: 1,
+          cache_creation_input_tokens: 2,
+          output_tokens: 5,
+        },
+      },
+    },
+    {
+      type: 'assistant',
+      timestamp: '2026-01-01T00:01:00Z',
+      message: {
+        usage: {
+          input_tokens: 3,
+          cache_creation: {
+            ephemeral_5m_input_tokens: 4,
+            ephemeral_1h_input_tokens: 6,
+          },
+          output_tokens: 1,
+        },
+      },
+    },
+    { type: 'user', timestamp: '2026-01-01T00:02:00Z' },
+  ];
+
+  const timeline = extractClaudeUsageTimeline(records);
+  assert.equal(timeline.mode, 'delta');
+  assert.equal(timeline.points.length, 2);
+  assert.equal(timeline.points[0].atMs, ms('2026-01-01T00:01:00Z'));
+  assert.deepEqual(timeline.points[0].usage, {
+    inputUncached: 3,
+    cacheRead: 0,
+    cacheCreation: 10,
+    output: 1,
+    reasoning: 0,
+  });
+  assert.equal(timeline.points[1].atMs, ms('2026-01-01T00:05:00Z'));
+  assert.deepEqual(timeline.points[1].usage, {
+    inputUncached: 10,
+    cacheRead: 1,
+    cacheCreation: 2,
+    output: 5,
+    reasoning: 0,
+  });
+});
+
+test('extractCodexUsageTimeline prefers cumulative total_token_usage when any record has one', () => {
+  const records = [
+    {
+      type: 'token_count',
+      timestamp: '2026-01-01T00:01:00Z',
+      payload: { total_token_usage: { input_tokens: 100, output_tokens: 10 } },
+    },
+    {
+      type: 'token_count',
+      timestamp: '2026-01-01T00:02:00Z',
+      payload: { total_token_usage: { input_tokens: 150, output_tokens: 20 } },
+    },
+  ];
+  const timeline = extractCodexUsageTimeline(records);
+  assert.equal(timeline.mode, 'cumulative');
+  assert.equal(timeline.points.length, 2);
+  assert.equal(timeline.points[1].usage.inputUncached, 150);
+  assert.equal(timeline.points[1].usage.output, 20);
+});
+
+test('extractCodexUsageTimeline falls back to last_token_usage deltas when no record has a cumulative total', () => {
+  const records = [
+    {
+      type: 'token_count',
+      timestamp: '2026-01-01T00:01:00Z',
+      payload: { last_token_usage: { input_tokens: 5, output_tokens: 1 } },
+    },
+    {
+      type: 'token_count',
+      timestamp: '2026-01-01T00:02:00Z',
+      payload: { last_token_usage: { input_tokens: 7, output_tokens: 2 } },
+    },
+  ];
+  const timeline = extractCodexUsageTimeline(records);
+  assert.equal(timeline.mode, 'delta');
+  assert.equal(timeline.points.length, 2);
+  assert.equal(timeline.points[0].usage.inputUncached, 5);
+  assert.equal(timeline.points[1].usage.inputUncached, 7);
+});
+
+// ---------------------------------------------------------------------------
+// Stage windows
+// ---------------------------------------------------------------------------
+
+const EMPTY_EVENTS = new Map<TokenCostStageId, StageEventWindow>();
+
+test('computeStageWindows tiles all seven stages contiguously for a full merged loop', () => {
+  const ctx: IssueLoopGithubContext = {
+    claimedAtMs: ms('2026-01-01T00:02:00Z'),
+    prCreatedAtMs: ms('2026-01-01T00:25:00Z'),
+    prHeadRefName: 'issue/1-test',
+    prMergedAtMs: ms('2026-01-01T00:45:00Z'),
+    firstReviewAtMs: ms('2026-01-01T00:30:00Z'),
+    cleanupAtMs: null,
+    unclaimedMatched: false,
+    humanHandoff: false,
+  };
+  const { windows, attribution } = computeStageWindows(
+    ms('2026-01-01T00:00:00Z'),
+    ms('2026-01-01T01:10:00Z'),
+    ctx,
+    EMPTY_EVENTS,
+  );
+  assert.equal(attribution, 'marker-join');
+  assert.deepEqual(
+    windows.map((w) => w.id),
+    ['discover', 'claim', 'work', 'submit-pr', 'review', 'merge', 'cleanup'],
+  );
+  // Contiguous: each window starts exactly where the previous ended.
+  for (let i = 1; i < windows.length; i++) {
+    assert.equal(windows[i].startMs, windows[i - 1].endMs);
+  }
+  assert.equal(windows[0].startMs, ms('2026-01-01T00:00:00Z'));
+  assert.equal(windows[1].startMs, ms('2026-01-01T00:02:00Z')); // claim starts at claimedAt
+  assert.equal(windows[1].endMs, ms('2026-01-01T00:17:00Z')); // capped at claimedAt+15m (< prCreatedAt)
+  assert.equal(windows[2].endMs, ms('2026-01-01T00:25:00Z')); // work ends at prCreatedAt
+  assert.equal(windows[4].endMs, ms('2026-01-01T00:45:00Z')); // review ends at mergedAt
+  assert.equal(windows[5].endMs, ms('2026-01-01T01:00:00Z')); // merge: no cleanup marker, mergedAt+15m thin cap
+  assert.equal(windows[6].endMs, ms('2026-01-01T01:10:00Z')); // cleanup runs to session end
+});
+
+test('computeStageWindows without a PR yet: claim capped, work runs to session end, no later stages', () => {
+  const ctx: IssueLoopGithubContext = {
+    claimedAtMs: ms('2026-01-01T00:00:00Z'),
+    prCreatedAtMs: null,
+    prHeadRefName: null,
+    prMergedAtMs: null,
+    firstReviewAtMs: null,
+    cleanupAtMs: null,
+    unclaimedMatched: false,
+    humanHandoff: false,
+  };
+  const { windows } = computeStageWindows(
+    ms('2026-01-01T00:00:00Z'),
+    ms('2026-01-01T00:20:00Z'),
+    ctx,
+    EMPTY_EVENTS,
+  );
+  assert.deepEqual(
+    windows.map((w) => w.id),
+    ['claim', 'work'],
+  );
+  assert.equal(windows[0].endMs, ms('2026-01-01T00:15:00Z'));
+  assert.equal(windows[1].endMs, ms('2026-01-01T00:20:00Z'));
+});
+
+test('computeStageWindows omits a window that would collapse to zero width', () => {
+  const ctx: IssueLoopGithubContext = {
+    claimedAtMs: ms('2026-01-01T00:00:00Z'),
+    // PR created before the 15m claim cap: claim end == PR createdAt, so the
+    // 'work' window (end of claim -> PR createdAt) is empty and omitted.
+    prCreatedAtMs: ms('2026-01-01T00:10:00Z'),
+    prHeadRefName: 'issue/1-test',
+    prMergedAtMs: null,
+    firstReviewAtMs: null,
+    cleanupAtMs: null,
+    unclaimedMatched: false,
+    humanHandoff: false,
+  };
+  const { windows } = computeStageWindows(
+    ms('2026-01-01T00:00:00Z'),
+    ms('2026-01-01T00:30:00Z'),
+    ctx,
+    EMPTY_EVENTS,
+  );
+  assert.ok(!windows.some((w) => w.id === 'work'));
+});
+
+test('computeStageWindows: an --events window overrides the marker-derived one and flips attribution', () => {
+  const ctx: IssueLoopGithubContext = {
+    claimedAtMs: ms('2026-01-01T00:00:00Z'),
+    prCreatedAtMs: ms('2026-01-01T00:25:00Z'),
+    prHeadRefName: 'issue/1-test',
+    prMergedAtMs: null,
+    firstReviewAtMs: null,
+    cleanupAtMs: null,
+    unclaimedMatched: false,
+    humanHandoff: false,
+  };
+  const events = new Map<TokenCostStageId, StageEventWindow>([
+    [
+      'work',
+      {
+        startMs: ms('2026-01-01T00:16:00Z'),
+        endMs: ms('2026-01-01T00:19:00Z'),
+      },
+    ],
+  ]);
+  const { windows, attribution } = computeStageWindows(
+    ms('2026-01-01T00:00:00Z'),
+    ms('2026-01-01T00:30:00Z'),
+    ctx,
+    events,
+  );
+  assert.equal(attribution, 'phase-event');
+  const work = windows.find((w) => w.id === 'work');
+  assert.ok(work);
+  assert.equal(work?.source, 'event');
+  assert.equal(work?.startMs, ms('2026-01-01T00:16:00Z'));
+  assert.equal(work?.endMs, ms('2026-01-01T00:19:00Z'));
+});
+
+test('computeStageWindows returns no windows when there is no claim in range', () => {
+  const ctx: IssueLoopGithubContext = {
+    claimedAtMs: null,
+    prCreatedAtMs: null,
+    prHeadRefName: null,
+    prMergedAtMs: null,
+    firstReviewAtMs: null,
+    cleanupAtMs: null,
+    unclaimedMatched: false,
+    humanHandoff: false,
+  };
+  const { windows } = computeStageWindows(
+    ms('2026-01-01T00:00:00Z'),
+    ms('2026-01-01T00:10:00Z'),
+    ctx,
+    EMPTY_EVENTS,
+  );
+  assert.deepEqual(windows, []);
+});
+
+// ---------------------------------------------------------------------------
+// Usage allocation (AC1: stage usage sums to session usage)
+// ---------------------------------------------------------------------------
+
+test('allocateStageUsage (delta mode): every stage sums exactly to the session total', () => {
+  const ctx: IssueLoopGithubContext = {
+    claimedAtMs: ms('2026-01-01T00:02:00Z'),
+    prCreatedAtMs: ms('2026-01-01T00:25:00Z'),
+    prHeadRefName: 'issue/1-test',
+    prMergedAtMs: ms('2026-01-01T00:45:00Z'),
+    firstReviewAtMs: ms('2026-01-01T00:30:00Z'),
+    cleanupAtMs: null,
+    unclaimedMatched: false,
+    humanHandoff: false,
+  };
+  const { windows } = computeStageWindows(
+    ms('2026-01-01T00:00:00Z'),
+    ms('2026-01-01T01:10:00Z'),
+    ctx,
+    EMPTY_EVENTS,
+  );
+  const points = [
+    { atMs: ms('2026-01-01T00:01:00Z'), usage: usage(10) }, // discover
+    { atMs: ms('2026-01-01T00:10:00Z'), usage: usage(20) }, // claim
+    { atMs: ms('2026-01-01T00:20:00Z'), usage: usage(30) }, // work
+    { atMs: ms('2026-01-01T00:27:00Z'), usage: usage(40) }, // submit-pr
+    { atMs: ms('2026-01-01T00:35:00Z'), usage: usage(50) }, // review
+    { atMs: ms('2026-01-01T00:50:00Z'), usage: usage(60) }, // merge
+    { atMs: ms('2026-01-01T01:05:00Z'), usage: usage(70) }, // cleanup
+  ];
+  const stages = allocateStageUsage(windows, { mode: 'delta', points });
+  assert.equal(stages.length, 7);
+  const sum = stages.reduce((total, s) => total + usageSum(s.usage), 0);
+  assert.equal(sum, usageSum(...points.map((p) => p.usage)));
+  assert.equal(stages.find((s) => s.id === 'discover')?.usage.output, 10);
+  assert.equal(stages.find((s) => s.id === 'cleanup')?.usage.output, 70);
+});
+
+test('allocateStageUsage (cumulative mode): windows telescope to the final snapshot with a zero baseline', () => {
+  const windows = [
+    {
+      id: 'claim' as const,
+      startMs: ms('2026-01-01T00:00:00Z'),
+      endMs: ms('2026-01-01T00:10:00Z'),
+      source: 'marker' as const,
+    },
+    {
+      id: 'work' as const,
+      startMs: ms('2026-01-01T00:10:00Z'),
+      endMs: ms('2026-01-01T00:20:00Z'),
+      source: 'marker' as const,
+    },
+  ];
+  const points = [
+    { atMs: ms('2026-01-01T00:05:00Z'), usage: usage(40) },
+    { atMs: ms('2026-01-01T00:15:00Z'), usage: usage(100) },
+  ];
+  const stages = allocateStageUsage(windows, { mode: 'cumulative', points });
+  assert.equal(stages.find((s) => s.id === 'claim')?.usage.output, 40);
+  assert.equal(stages.find((s) => s.id === 'work')?.usage.output, 60);
+  const sum = stages.reduce((total, s) => total + usageSum(s.usage), 0);
+  assert.equal(sum, 100); // matches the final (latest) cumulative snapshot
+});
+
+test('allocateStageUsage omits an all-zero-usage window', () => {
+  const windows = [
+    {
+      id: 'discover' as const,
+      startMs: 0,
+      endMs: 1000,
+      source: 'marker' as const,
+    },
+    {
+      id: 'claim' as const,
+      startMs: 1000,
+      endMs: 2000,
+      source: 'marker' as const,
+    },
+  ];
+  const stages = allocateStageUsage(windows, {
+    mode: 'delta',
+    points: [{ atMs: 1500, usage: usage(5) }],
+  });
+  assert.deepEqual(
+    stages.map((s) => s.id),
+    ['claim'],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Outcome + ambiguity
+// ---------------------------------------------------------------------------
+
+test('deriveOutcome: merged takes priority; then human-handoff; then unclaimed; else aborted', () => {
+  const base: IssueLoopGithubContext = {
+    claimedAtMs: 0,
+    prCreatedAtMs: null,
+    prHeadRefName: null,
+    prMergedAtMs: null,
+    firstReviewAtMs: null,
+    cleanupAtMs: null,
+    unclaimedMatched: false,
+    humanHandoff: false,
+  };
+  assert.equal(deriveOutcome({ ...base, prMergedAtMs: 1 }), 'merged');
+  assert.equal(deriveOutcome({ ...base, humanHandoff: true }), 'human-handoff');
+  assert.equal(deriveOutcome({ ...base, unclaimedMatched: true }), 'unclaimed');
+  assert.equal(deriveOutcome(base), 'aborted');
+});
+
+function issueLoopSample(
+  issueNumber: number,
+  startedAt: string,
+  endedAt: string,
+): HarvestedSample {
+  const sample: TokenCostIssueLoopSample = {
+    schemaVersion: 1,
+    kind: 'issue-loop',
+    vendor: 'claude',
+    model: 'test-model',
+    attribution: 'marker-join',
+    outcome: 'merged',
+    usage: usage(1),
+    compactionCount: 0,
+    startedAt,
+    endedAt,
+    vendorSessionId: `session-${issueNumber}-${startedAt}`,
+    issueNumber,
+    stages: [],
+  };
+  return {
+    sample,
+    issueNumber,
+    startedAtMs: ms(startedAt),
+    endedAtMs: ms(endedAt),
+  };
+}
+
+test('markAmbiguousOverlaps flags two overlapping sessions on the same issue', () => {
+  const a = issueLoopSample(42, '2026-01-01T00:00:00Z', '2026-01-01T01:00:00Z');
+  const b = issueLoopSample(42, '2026-01-01T00:30:00Z', '2026-01-01T01:30:00Z');
+  markAmbiguousOverlaps([a, b]);
+  assert.equal((a.sample as TokenCostIssueLoopSample).ambiguous, true);
+  assert.equal((b.sample as TokenCostIssueLoopSample).ambiguous, true);
+  assert.equal(a.sample.outcome, 'unknown');
+  assert.equal(b.sample.outcome, 'unknown');
+});
+
+test('markAmbiguousOverlaps leaves non-overlapping sessions on the same issue untouched', () => {
+  const a = issueLoopSample(43, '2026-01-01T00:00:00Z', '2026-01-01T01:00:00Z');
+  const b = issueLoopSample(43, '2026-01-01T02:00:00Z', '2026-01-01T03:00:00Z');
+  markAmbiguousOverlaps([a, b]);
+  assert.equal((a.sample as TokenCostIssueLoopSample).ambiguous, undefined);
+  assert.equal(a.sample.outcome, 'merged');
+});
+
+// ---------------------------------------------------------------------------
+// --events file
+// ---------------------------------------------------------------------------
+
+test('readEventWindows: missing file returns an empty map', () => {
+  const windows = readEventWindows(
+    join(tmpdir(), 'does-not-exist-token-cost-events.jsonl'),
+  );
+  assert.equal(windows.size, 0);
+});
+
+test('readEventWindows: pairs a trusted enter/exit for the same (issueNumber, stageId)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-token-cost-events-'));
+  const path = join(dir, 'events.jsonl');
+  writeFileSync(
+    path,
+    [
+      JSON.stringify({
+        schemaVersion: 1,
+        event: 'enter',
+        stageId: 'work',
+        at: '2026-01-01T00:10:00Z',
+        vendor: 'claude',
+        issueNumber: 7,
+      }),
+      JSON.stringify({
+        schemaVersion: 1,
+        event: 'exit',
+        stageId: 'work',
+        at: '2026-01-01T00:20:00Z',
+        vendor: 'claude',
+        issueNumber: 7,
+      }),
+      // enter with no matching exit: must not appear in the result.
+      JSON.stringify({
+        schemaVersion: 1,
+        event: 'enter',
+        stageId: 'review',
+        at: '2026-01-01T00:30:00Z',
+        vendor: 'claude',
+        issueNumber: 7,
+      }),
+    ].join('\n'),
+  );
+  try {
+    const windows = readEventWindows(path);
+    assert.equal(windows.size, 1);
+    const window = windows.get('7:work');
+    assert.ok(window);
+    assert.equal(window?.startMs, ms('2026-01-01T00:10:00Z'));
+    assert.equal(window?.endMs, ms('2026-01-01T00:20:00Z'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Trusted marker logins
+// ---------------------------------------------------------------------------
+
+test('resolveTrustedMarkerLogins: an explicit flag wins over config', () => {
+  assert.deepEqual(resolveTrustedMarkerLogins('alice, bob'), ['alice', 'bob']);
+});
+
+test("resolveTrustedMarkerLogins: falls back to this repository's own configured trustedMarkerActors", () => {
+  assert.deepEqual(resolveTrustedMarkerLogins(''), ['kurone-kito']);
+});
+
+// ---------------------------------------------------------------------------
+// GitHub join (stubbed gh, no network) + AC1 end-to-end
+// ---------------------------------------------------------------------------
+
+test('fetchIssueLoopGithubContext resolves the earliest live-connected same-branch PR', () => {
+  const fixture = readJson(
+    'tests/fixtures/token-cost/github/issue-loop-merged.json',
+  );
+  const restore = stubGhReturningJson(fixture);
+  try {
+    const result = fetchIssueLoopGithubContext('acme', 'repo', 9001, [
+      'claude-test',
+    ]);
+    assert.equal(result.prNumber, 9101);
+    assert.equal(result.prCreatedAtMs, ms('2026-01-01T00:10:00Z'));
+    assert.equal(result.prMergedAtMs, ms('2026-01-01T00:30:00Z'));
+    // This is the PR's own first submitted review only -- resolveIssueLoopContext
+    // (tested below) additionally folds in the earlier review-watermark comment.
+    assert.equal(result.firstReviewAtMs, ms('2026-01-01T00:22:00Z'));
+  } finally {
+    restore();
+  }
+});
+
+test('resolveIssueLoopContext: firstReviewAtMs is the earlier of the review-watermark and the first submitted review', () => {
+  const fixture = readJson(
+    'tests/fixtures/token-cost/github/issue-loop-merged.json',
+  );
+  const restore = stubGhReturningJson(fixture);
+  try {
+    const ctx = resolveIssueLoopContext(
+      'acme',
+      'repo',
+      9001,
+      ms('2025-12-31T23:55:00Z'),
+      ms('2026-01-01T00:35:00Z'),
+      ['claude-test'],
+    );
+    assert.ok(ctx);
+    // The review-watermark (00:20) predates the submitted review (00:22).
+    assert.equal(ctx?.firstReviewAtMs, ms('2026-01-01T00:20:00Z'));
+    assert.equal(ctx?.prMergedAtMs, ms('2026-01-01T00:30:00Z'));
+    assert.equal(deriveOutcome(ctx as IssueLoopGithubContext), 'merged');
+  } finally {
+    restore();
+  }
+});
+
+test('resolveIssueLoopContext: outcome is unclaimed when a matching unclaimed-by exists and nothing merged', () => {
+  const fixture = readJson(
+    'tests/fixtures/token-cost/github/issue-loop-unclaimed.json',
+  );
+  const restore = stubGhReturningJson(fixture);
+  try {
+    const ctx = resolveIssueLoopContext(
+      'acme',
+      'repo',
+      9002,
+      ms('2026-02-01T00:00:00Z'),
+      ms('2026-02-01T00:10:00Z'),
+      ['claude-test'],
+    );
+    assert.ok(ctx);
+    assert.equal(ctx?.claimedAtMs, ms('2026-02-01T00:00:00Z'));
+    assert.equal(ctx?.prCreatedAtMs, null);
+    assert.equal(ctx?.unclaimedMatched, true);
+    assert.equal(deriveOutcome(ctx as IssueLoopGithubContext), 'unclaimed');
+  } finally {
+    restore();
+  }
+});
+
+test('AC1: a fake adapter session joined against fixture GitHub markers produces one issue-loop sample whose stage usage sums to the session usage, outcome merged', () => {
+  const fixture = readJson(
+    'tests/fixtures/token-cost/github/issue-loop-merged.json',
+  );
+  const restore = stubGhReturningJson(fixture);
+  try {
+    const session: VendorSession = {
+      vendor: 'claude',
+      adapterResult: {
+        sample: {
+          schemaVersion: 1,
+          kind: 'session',
+          vendor: 'claude',
+          model: 'fake-model',
+          attribution: 'session-unscoped',
+          outcome: 'unknown',
+          usage: usage(3),
+          compactionCount: 0,
+          startedAt: '2025-12-31T23:55:00Z',
+          endedAt: '2026-01-01T00:35:00Z',
+          vendorSessionId: 'fake-session-1',
+        },
+        joinHints: { issueNumber: 9001 },
+      },
+      timeline: {
+        mode: 'delta',
+        points: [
+          { atMs: ms('2025-12-31T23:56:00Z'), usage: usage(1) }, // before claim -> discover
+          { atMs: ms('2026-01-01T00:05:00Z'), usage: usage(1) }, // claim
+          { atMs: ms('2026-01-01T00:25:00Z'), usage: usage(1) }, // review (no submit-pr/work: PR precedes claim cap)
+        ],
+      },
+    };
+    const built = buildSample(session, 'acme', 'repo', new Map(), [
+      'claude-test',
+    ]);
+    assert.equal(built.sample.kind, 'issue-loop');
+    const sample = built.sample as TokenCostIssueLoopSample;
+    assert.equal(sample.outcome, 'merged');
+    assert.equal(sample.attribution, 'marker-join');
+    const stageSum = sample.stages.reduce(
+      (total, s) => total + usageSum(s.usage),
+      0,
+    );
+    assert.equal(
+      stageSum,
+      usageSum(...session.timeline.points.map((p) => p.usage)),
+    );
+  } finally {
+    restore();
+  }
+});
+
+test('AC3: a session with no joinHints.issueNumber stays kind: session, never rewritten to issue-loop', () => {
+  const session: VendorSession = {
+    vendor: 'codex',
+    adapterResult: {
+      sample: {
+        schemaVersion: 1,
+        kind: 'session',
+        vendor: 'codex',
+        model: 'fake-model',
+        attribution: 'session-unscoped',
+        outcome: 'unknown',
+        usage: usage(1),
+        compactionCount: 0,
+        startedAt: '2026-01-01T00:00:00Z',
+        endedAt: '2026-01-01T00:10:00Z',
+        vendorSessionId: 'fake-session-2',
+      },
+    },
+    timeline: { mode: 'delta', points: [] },
+  };
+  const built = buildSample(session, 'acme', 'repo', new Map(), [
+    'claude-test',
+  ]);
+  assert.equal(built.sample.kind, 'session');
+  assert.equal(
+    (built.sample as { attribution: string }).attribution,
+    'session-unscoped',
+  );
+});


### PR DESCRIPTION
# Summary

Adds `src/scripts/token-cost-harvest.mts` (→ generated
`scripts/token-cost-harvest.mjs`), a CLI that scans the already-shipped
Claude/Codex/Grok vendor session adapters, joins any session whose cwd
names an issue worktree against this repository's own GitHub IDD
markers (claim, review watermark, merge), and reconstructs each issue
loop's seven stage windows (`discover`, `claim`, `work`, `submit-pr`,
`review`, `merge`, `cleanup`). Per-stage token usage is allocated by
literally mirroring each adapter's own usage-extraction shape (delta
sum for Claude, cumulative-snapshot delta for Codex/Grok) rather than
a time-proportional split, since token spend is unevenly distributed
across stages (`review` is mostly CI-wait wall-clock with near-zero
tokens). An explicit `--events` phase-event log, when present, wins
over the marker-join reconstruction for the stages it covers.

Records are appended as `kind: "issue-loop"` / `kind: "session"` to
`${XDG_STATE_HOME:-$HOME/.local/state}/idd-skill/token-cost/samples.jsonl`
(`--out` to override, `--dry-run` to only print counts), feeding
`token-cost-report.mjs`'s existing aggregation. `docs/token-cost.md`
documents the new command.

## Linked issue

Closes #2292

## Follow-up issues (if any)

- [ ] Grok issue-loop samples join and classify correctly but ship
      `stages: []` — `scanGrokSessions` doesn't yet expose a shared
      usage timeline the way the Claude/Codex adapters do (no
      `extractGrokUsageTimeline` equivalent), and adding one was out
      of this issue's `## Candidate files` scope. Session-level totals
      are still recorded; only the stage breakdown is deferred.
- [ ] PR selection matches by branch-name prefix
      (`headRefName.startsWith(`issue/${issueNumber}-`)`), not the
      active claim's exact `branch:` field — a repeat claim attempt on
      the same issue number (a stale/abandoned earlier PR still
      connected) could be joined against the wrong session. Fixing
      this has a real tradeoff, not a one-line change: an exact-branch
      match trades wrong-liberal (joining a stale PR, silently
      misattributing usage) for wrong-conservative (a renamed or
      legacy branch yields no-PR, so a genuinely merged loop reports
      `aborted` instead). Which failure mode this measurement should
      prefer needs its own design pass and tests, not a review-cycle
      patch.

## Background / rationale (if material)

Two interpretive decisions, called out for review:

- **`claim` stage end**: the issue's own stage table has `claim`
  ending at "PR `created_at` if a PR exists" while `work` runs "end of
  claim → PR `created_at`" — as literally written `work` would always
  be empty. Resolved as `claim end = min(claimedAt + 15m, prCreatedAt)`
  when a PR exists, so `work` covers the remainder up to PR creation.
- **Review-boundary clamp**: a review submitted after merge (for
  example a bot reviewing an admin-merged PR post hoc) must not push
  `submit-pr`'s end past `mergedAt`, or the `merge` window would start
  before `submit-pr`'s own end and double-count the overlap in
  delta-mode usage. The effective review boundary is clamped to
  `min(firstReviewAtMs, mergedAt)`, and `review`/`merge`/`cleanup` are
  always emitted once a PR is merged, even when no pre-merge review
  timestamp was resolvable (previously that case silently folded all
  post-PR usage into `submit-pr`).

Known, accepted bounds (disclosed rather than fixed, to avoid an
avoidable review round on a graceful degradation):

- `comments(first: 100)` has no pagination — a 100+-comment issue
  silently drops later markers and the session falls back to
  session-unscoped. `ghGraphql` has no paginate support today, so
  fixing this isn't a one-line change.
- `timelineItems(last: 100)` has the same unpaginated bound — an issue
  with 100+ intervening timeline events (labels, cross-references,
  etc.) between the claim and the connecting PR can push the
  `ConnectedEvent` out of the fetched window, degrading that sample to
  no-PR / `claim`+`work`-only windows.
- `reviews(first: 1)`: a `PENDING` first review has a null
  `submittedAt` and is treated as no review yet.
- Harvesting from inside a session whose own issue loop is still live
  produces an `outcome: "aborted"` sample for that in-flight loop (no
  merge, no unclaim, the log just ends) — this matches the issue's own
  literal outcome table; no carve-out for in-flight sessions was added.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added token-cost harvesting for Claude, Codex, and Grok sessions.
  - Attributes usage to development stages and generates deduplicated JSONL records.
  - Supports repository selection, custom outputs, event overrides, trusted accounts, dry runs, and help output.
  - Detects overlapping sessions, handoffs, ambiguous samples, and incomplete or malformed session data.
  - Improved repository flag handling and stage-window reconstruction.

- **Documentation**
  - Added guidance for session scanning, stage reconstruction, output options, and merge timing.

- **Tests**
  - Expanded coverage for usage parsing, attribution, GitHub context, outcomes, deduplication, overlaps, and command flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
