### PR TITLE
fix(protocol-helpers): hint every malformed disposition reply

### DIFF
--- a/schemas/pre-merge-readiness.schema.json
+++ b/schemas/pre-merge-readiness.schema.json
@@ -1168,7 +1168,7 @@
               },
               "hint": {
                 "type": "string",
-                "description": "Diagnostic-only note, present only when applicable: this comment is a recognized advisory non-review notice with an IDD-agent reply that used the wrong disposition phrase, naming the exact phrase the notice-specific carry-forward requires."
+                "description": "Diagnostic-only note, present only when applicable: names the exact required disposition phrase or literal prefix an IDD-agent reply attempt was close to but missed -- either a recognized advisory non-review notice with a wrong-phrase reply (#1833), or any missing comment with a plain-text reply attempt that never satisfies the required bold **Accepted**/**Rejected** prefix (#2249)."
               }
             }
           }

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -3203,8 +3203,20 @@ export function summarizeDispositionEvidenceForGate(
     // apply (they cannot in practice -- see `malformedPrefixDispositions`'
     // disjointness note -- but the precedence keeps the more actionable
     // hint on top if that ever changes).
+    //
+    // Gated on `isGateAdvisoryBotLogin`, mirroring `isNoticeComment` above
+    // (Copilot review on PR #2383): `requiresDispositionPrefix` in the 1:1
+    // pairing loop above is the ONLY thing that ever requires the exact
+    // `**Accepted**`/`**Rejected**` bold prefix -- a human's outstanding
+    // comment accepts any later IDD-agent reply, presence-only (#2139).
+    // Without this gate, a single malformed reply that legitimately
+    // cleared an earlier human comment (consumed via `usedReplyIndexes`
+    // in that loop, invisible to this global `malformedPrefixDispositions`
+    // pool) could still misleadingly hint a LATER, still-missing human
+    // comment that it needs bold markdown it never required.
     const hasMalformedPrefixAttempt =
       !hasWrongPhraseAttempt &&
+      isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins) &&
       malformedPrefixDispositions.some(
         (disposition) =>
           compareIsoTimestamps(disposition.activityAt, comment.createdAt) > 0,

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -988,6 +988,15 @@ export function hasFreshDisposition(thread, options = {}) {
 // `trimStart()` first.
 const DISPOSITION_ACCEPTED_PREFIX_RE = /^\*\*Accepted[.!:]?\*\*/;
 const DISPOSITION_REJECTED_PREFIX_RE = /^\*\*Rejected[.!:]?\*\*/;
+// #2249: loose "close but not exact" detector for `missingRegularComments[].hint`
+// (`MALFORMED_DISPOSITION_PREFIX_HINT`) -- deliberately laxer than the two
+// exact-match regexes above, matching the four literal prefixes a
+// near-miss reply typically starts with: bare `Accepted`/`Rejected`
+// (no bold markdown) or `**Accepted`/`**Rejected` (bold markdown present
+// but the marker still fails `isDispositionComment`, e.g. interior text
+// before the closing `**`). Always paired with `!isDispositionComment`
+// at each call site so an already-valid disposition never matches.
+const MALFORMED_DISPOSITION_PREFIX_RE = /^\*{0,2}(?:Accepted|Rejected)/;
 export function isDispositionComment(comment) {
   const body = (comment.body ?? '').trimEnd();
   return (
@@ -1201,6 +1210,19 @@ export const NON_REVIEW_NOTICE_DISPOSITION_HINT =
   'must start with "**Rejected**" and match /\\bdid not review HEAD\\b/i -- ' +
   'canonical form: "**Rejected** — {bot} did not review HEAD {sha} ' +
   '({reason}); this is not a completed review"';
+// #2249 diagnostic-only hint text, single-sourced like
+// `NON_REVIEW_NOTICE_DISPOSITION_HINT` above: names the exact literal
+// prefix `isDispositionComment` requires, for the far more common
+// plain-text mistake -- a reply written as `Accepted — ...` or
+// `Rejected — ...` with no bold markdown at all, so it never satisfies
+// `isDispositionComment` even though it is clearly an attempted
+// disposition. Never consumed by any routing decision -- see the `hint`
+// field's own doc comment on `DispositionEvidenceSummary`.
+export const MALFORMED_DISPOSITION_PREFIX_HINT =
+  'disposition reply is missing the required literal prefix: it must ' +
+  'start with exactly "**Accepted**" or "**Rejected**" (bold markdown, ' +
+  'optionally followed by one of . ! : before the closing **) -- a plain ' +
+  '"Accepted" / "Rejected" without the bold markdown is not recognized';
 // #1122 CodeRabbit summary-walkthrough auto-disposition classifiers.
 //
 // The CodeRabbit summary walkthrough is a regular comment whose body starts with
@@ -3037,6 +3059,23 @@ export function summarizeDispositionEvidenceForGate(
       DISPOSITION_REJECTED_PREFIX_RE.test(comment.body.trimStart()) &&
       !isNonReviewNoticeDisposition({ body: comment.body }),
   );
+  // #2249: a broader "close but not exact" pool, independent of the
+  // #1833 non-review-notice pairing above. Sourced from ALL IDD-agent
+  // comments (not just `dispositionComments`, which already requires
+  // `isDispositionComment` to be true) because the motivating mistake --
+  // a plain `Accepted — ...` / `Rejected — ...` reply with no bold
+  // markdown at all -- never satisfies `isDispositionComment` in the
+  // first place, so it would never appear in `dispositionComments`.
+  // `!isDispositionComment` excludes any comment that is ALREADY a valid
+  // disposition (e.g. `**Accepted**` is well-formed and needs no hint),
+  // so this pool and `wrongPhraseRejectedDispositions` are disjoint by
+  // construction: the latter's members all satisfy `isDispositionComment`.
+  const malformedPrefixDispositions = normalizedComments.filter(
+    (comment) =>
+      iddAgentLogins.has(comment.authorLogin) &&
+      MALFORMED_DISPOSITION_PREFIX_RE.test(comment.body.trimStart()) &&
+      !isDispositionComment({ body: comment.body }),
+  );
   const outstandingNotices = outstandingComments.filter(
     (comment) =>
       isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins) &&
@@ -3154,6 +3193,18 @@ export function summarizeDispositionEvidenceForGate(
         (disposition) =>
           compareIsoTimestamps(disposition.activityAt, comment.createdAt) > 0,
       );
+    // #2249: generalizes the diagnostic above beyond the notice-specific
+    // wrong-phrase case. Checked only when `hasWrongPhraseAttempt` is
+    // false so the more specific #1833 hint always wins when both could
+    // apply (they cannot in practice -- see `malformedPrefixDispositions`'
+    // disjointness note -- but the precedence keeps the more actionable
+    // hint on top if that ever changes).
+    const hasMalformedPrefixAttempt =
+      !hasWrongPhraseAttempt &&
+      malformedPrefixDispositions.some(
+        (disposition) =>
+          compareIsoTimestamps(disposition.activityAt, comment.createdAt) > 0,
+      );
     return {
       id: comment.id || `comment-${comment.sortedIndex + 1}`,
       authorLogin: comment.authorLogin || 'unknown',
@@ -3161,7 +3212,9 @@ export function summarizeDispositionEvidenceForGate(
       bodyPreview: buildBodyPreview(comment.body),
       ...(hasWrongPhraseAttempt
         ? { hint: NON_REVIEW_NOTICE_DISPOSITION_HINT }
-        : {}),
+        : hasMalformedPrefixAttempt
+          ? { hint: MALFORMED_DISPOSITION_PREFIX_HINT }
+          : {}),
     };
   });
   // #978 advisory-only diagnostic: a blocking resolved thread is

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -990,13 +990,17 @@ const DISPOSITION_ACCEPTED_PREFIX_RE = /^\*\*Accepted[.!:]?\*\*/;
 const DISPOSITION_REJECTED_PREFIX_RE = /^\*\*Rejected[.!:]?\*\*/;
 // #2249: loose "close but not exact" detector for `missingRegularComments[].hint`
 // (`MALFORMED_DISPOSITION_PREFIX_HINT`) -- deliberately laxer than the two
-// exact-match regexes above, matching the four literal prefixes a
+// exact-match regexes above, matching only the four literal prefixes a
 // near-miss reply typically starts with: bare `Accepted`/`Rejected`
 // (no bold markdown) or `**Accepted`/`**Rejected` (bold markdown present
 // but the marker still fails `isDispositionComment`, e.g. interior text
-// before the closing `**`). Always paired with `!isDispositionComment`
-// at each call site so an already-valid disposition never matches.
-const MALFORMED_DISPOSITION_PREFIX_RE = /^\*{0,2}(?:Accepted|Rejected)/;
+// before the closing `**`). The leading `**` is optional but must be
+// exactly zero or two chars (not one, e.g. `*Accepted`), and the
+// trailing `\b` stops a longer word like `Acceptedness` from matching --
+// Copilot review on PR #2383 caught both gaps in an earlier draft.
+// Always paired with `!isDispositionComment` at each call site so an
+// already-valid disposition never matches.
+const MALFORMED_DISPOSITION_PREFIX_RE = /^(?:\*\*)?(?:Accepted|Rejected)\b/;
 export function isDispositionComment(comment) {
   const body = (comment.body ?? '').trimEnd();
   return (

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1714,13 +1714,17 @@ const DISPOSITION_REJECTED_PREFIX_RE = /^\*\*Rejected[.!:]?\*\*/;
 
 // #2249: loose "close but not exact" detector for `missingRegularComments[].hint`
 // (`MALFORMED_DISPOSITION_PREFIX_HINT`) -- deliberately laxer than the two
-// exact-match regexes above, matching the four literal prefixes a
+// exact-match regexes above, matching only the four literal prefixes a
 // near-miss reply typically starts with: bare `Accepted`/`Rejected`
 // (no bold markdown) or `**Accepted`/`**Rejected` (bold markdown present
 // but the marker still fails `isDispositionComment`, e.g. interior text
-// before the closing `**`). Always paired with `!isDispositionComment`
-// at each call site so an already-valid disposition never matches.
-const MALFORMED_DISPOSITION_PREFIX_RE = /^\*{0,2}(?:Accepted|Rejected)/;
+// before the closing `**`). The leading `**` is optional but must be
+// exactly zero or two chars (not one, e.g. `*Accepted`), and the
+// trailing `\b` stops a longer word like `Acceptedness` from matching --
+// Copilot review on PR #2383 caught both gaps in an earlier draft.
+// Always paired with `!isDispositionComment` at each call site so an
+// already-valid disposition never matches.
+const MALFORMED_DISPOSITION_PREFIX_RE = /^(?:\*\*)?(?:Accepted|Rejected)\b/;
 
 export function isDispositionComment(comment: {
   body?: string | null;

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -445,16 +445,22 @@ export interface DispositionEvidenceSummary {
     authorLogin: string;
     createdAt: string;
     bodyPreview: string;
-    // #1833 diagnostic-only (present only when applicable): set when this
-    // missing comment is itself a recognized advisory non-review notice
-    // (`isAdvisoryNonReviewNotice`) AND a later IDD-agent reply starting with
-    // `**Rejected**` exists but does not match `isNonReviewNoticeDisposition`
-    // -- an attempted disposition that used the wrong phrase, so the generic
-    // 1:1 disposition pairing accepted it as SOME disposition while the
-    // notice-specific carry-forward still rejects it and the item stays
-    // blocking. Names the exact required phrase so an agent does not have to
-    // source-dive `isNonReviewNoticeDisposition` to discover it. Never
-    // changes `route`, `reason`, or any count above.
+    // Diagnostic-only (present only when applicable), fail-open in favor of
+    // the more specific case when both could apply:
+    // - #1833: set when this missing comment is itself a recognized
+    //   advisory non-review notice (`isAdvisoryNonReviewNotice`) AND a
+    //   later IDD-agent reply starting with `**Rejected**` exists but does
+    //   not match `isNonReviewNoticeDisposition` -- an attempted
+    //   disposition that used the wrong phrase.
+    // - #2249: otherwise, set when a later IDD-agent reply starts with
+    //   `Accepted`/`Rejected`/`**Accepted`/`**Rejected` but does not
+    //   satisfy `isDispositionComment` -- e.g. a plain `Accepted — ...`
+    //   reply with no bold markdown at all.
+    // Either way the generic 1:1 disposition pairing accepted the reply as
+    // SOME disposition while the stricter check behind it still rejects it
+    // and the item stays blocking. Names the exact required phrase/prefix
+    // so an agent does not have to source-dive this file to discover it.
+    // Never changes `route`, `reason`, or any count above.
     hint?: string;
   }[];
   // `ackOnlyPostDisposition` is advisory-only: true when this blocking resolved
@@ -1706,6 +1712,16 @@ export function hasFreshDisposition(
 const DISPOSITION_ACCEPTED_PREFIX_RE = /^\*\*Accepted[.!:]?\*\*/;
 const DISPOSITION_REJECTED_PREFIX_RE = /^\*\*Rejected[.!:]?\*\*/;
 
+// #2249: loose "close but not exact" detector for `missingRegularComments[].hint`
+// (`MALFORMED_DISPOSITION_PREFIX_HINT`) -- deliberately laxer than the two
+// exact-match regexes above, matching the four literal prefixes a
+// near-miss reply typically starts with: bare `Accepted`/`Rejected`
+// (no bold markdown) or `**Accepted`/`**Rejected` (bold markdown present
+// but the marker still fails `isDispositionComment`, e.g. interior text
+// before the closing `**`). Always paired with `!isDispositionComment`
+// at each call site so an already-valid disposition never matches.
+const MALFORMED_DISPOSITION_PREFIX_RE = /^\*{0,2}(?:Accepted|Rejected)/;
+
 export function isDispositionComment(comment: {
   body?: string | null;
 }): boolean {
@@ -1935,6 +1951,20 @@ export const NON_REVIEW_NOTICE_DISPOSITION_HINT =
   'must start with "**Rejected**" and match /\\bdid not review HEAD\\b/i -- ' +
   'canonical form: "**Rejected** — {bot} did not review HEAD {sha} ' +
   '({reason}); this is not a completed review"';
+
+// #2249 diagnostic-only hint text, single-sourced like
+// `NON_REVIEW_NOTICE_DISPOSITION_HINT` above: names the exact literal
+// prefix `isDispositionComment` requires, for the far more common
+// plain-text mistake -- a reply written as `Accepted — ...` or
+// `Rejected — ...` with no bold markdown at all, so it never satisfies
+// `isDispositionComment` even though it is clearly an attempted
+// disposition. Never consumed by any routing decision -- see the `hint`
+// field's own doc comment on `DispositionEvidenceSummary`.
+export const MALFORMED_DISPOSITION_PREFIX_HINT =
+  'disposition reply is missing the required literal prefix: it must ' +
+  'start with exactly "**Accepted**" or "**Rejected**" (bold markdown, ' +
+  'optionally followed by one of . ! : before the closing **) -- a plain ' +
+  '"Accepted" / "Rejected" without the bold markdown is not recognized';
 
 // #1122 CodeRabbit summary-walkthrough auto-disposition classifiers.
 //
@@ -4015,6 +4045,23 @@ export function summarizeDispositionEvidenceForGate(
       DISPOSITION_REJECTED_PREFIX_RE.test(comment.body.trimStart()) &&
       !isNonReviewNoticeDisposition({ body: comment.body }),
   );
+  // #2249: a broader "close but not exact" pool, independent of the
+  // #1833 non-review-notice pairing above. Sourced from ALL IDD-agent
+  // comments (not just `dispositionComments`, which already requires
+  // `isDispositionComment` to be true) because the motivating mistake --
+  // a plain `Accepted — ...` / `Rejected — ...` reply with no bold
+  // markdown at all -- never satisfies `isDispositionComment` in the
+  // first place, so it would never appear in `dispositionComments`.
+  // `!isDispositionComment` excludes any comment that is ALREADY a valid
+  // disposition (e.g. `**Accepted**` is well-formed and needs no hint),
+  // so this pool and `wrongPhraseRejectedDispositions` are disjoint by
+  // construction: the latter's members all satisfy `isDispositionComment`.
+  const malformedPrefixDispositions = normalizedComments.filter(
+    (comment) =>
+      iddAgentLogins.has(comment.authorLogin) &&
+      MALFORMED_DISPOSITION_PREFIX_RE.test(comment.body.trimStart()) &&
+      !isDispositionComment({ body: comment.body }),
+  );
   const outstandingNotices = outstandingComments.filter(
     (comment) =>
       isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins) &&
@@ -4135,6 +4182,18 @@ export function summarizeDispositionEvidenceForGate(
         (disposition) =>
           compareIsoTimestamps(disposition.activityAt, comment.createdAt) > 0,
       );
+    // #2249: generalizes the diagnostic above beyond the notice-specific
+    // wrong-phrase case. Checked only when `hasWrongPhraseAttempt` is
+    // false so the more specific #1833 hint always wins when both could
+    // apply (they cannot in practice -- see `malformedPrefixDispositions`'
+    // disjointness note -- but the precedence keeps the more actionable
+    // hint on top if that ever changes).
+    const hasMalformedPrefixAttempt =
+      !hasWrongPhraseAttempt &&
+      malformedPrefixDispositions.some(
+        (disposition) =>
+          compareIsoTimestamps(disposition.activityAt, comment.createdAt) > 0,
+      );
     return {
       id: comment.id || `comment-${comment.sortedIndex + 1}`,
       authorLogin: comment.authorLogin || 'unknown',
@@ -4142,7 +4201,9 @@ export function summarizeDispositionEvidenceForGate(
       bodyPreview: buildBodyPreview(comment.body),
       ...(hasWrongPhraseAttempt
         ? { hint: NON_REVIEW_NOTICE_DISPOSITION_HINT }
-        : {}),
+        : hasMalformedPrefixAttempt
+          ? { hint: MALFORMED_DISPOSITION_PREFIX_HINT }
+          : {}),
     };
   });
 

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -4192,8 +4192,20 @@ export function summarizeDispositionEvidenceForGate(
     // apply (they cannot in practice -- see `malformedPrefixDispositions`'
     // disjointness note -- but the precedence keeps the more actionable
     // hint on top if that ever changes).
+    //
+    // Gated on `isGateAdvisoryBotLogin`, mirroring `isNoticeComment` above
+    // (Copilot review on PR #2383): `requiresDispositionPrefix` in the 1:1
+    // pairing loop above is the ONLY thing that ever requires the exact
+    // `**Accepted**`/`**Rejected**` bold prefix -- a human's outstanding
+    // comment accepts any later IDD-agent reply, presence-only (#2139).
+    // Without this gate, a single malformed reply that legitimately
+    // cleared an earlier human comment (consumed via `usedReplyIndexes`
+    // in that loop, invisible to this global `malformedPrefixDispositions`
+    // pool) could still misleadingly hint a LATER, still-missing human
+    // comment that it needs bold markdown it never required.
     const hasMalformedPrefixAttempt =
       !hasWrongPhraseAttempt &&
+      isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins) &&
       malformedPrefixDispositions.some(
         (disposition) =>
           compareIsoTimestamps(disposition.activityAt, comment.createdAt) > 0,

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
   buildActivitySnapshotSummary,
+  MALFORMED_DISPOSITION_PREFIX_HINT,
   summarizeDispositionEvidenceForGate,
 } from '../src/scripts/protocol-helpers.mts';
 
@@ -533,4 +534,75 @@ test('reviewCurrency still anchors an edited ordinary Accepted marker by created
     activitySummary.ackOnly.items.map((item) => item.id),
     ['AC-3'],
   );
+});
+
+// #2249: `summarizeDispositionEvidenceForGate`'s `missingRegularComments[].hint`
+// only named the exact required literal prefix for the narrow #1833
+// non-review-notice pairing. The far more common mistake -- an IDD-agent
+// reply written as plain `Accepted — ...` with no bold markdown at all --
+// fell into the same `missingRegularComments` list with no hint at all,
+// even though `isDispositionComment` requires exactly `**Accepted**` /
+// `**Rejected**`. This generalizes the hint to that plain-text case.
+test('disposition evidence hints at the required literal prefix when a plain-text (no bold) reply exists', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          body: 'I found a potential off-by-one in `foo.mts` at line 42 — the loop bound should be `<=` to include the final element.',
+          author: { login: 'chatgpt-codex-connector[bot]' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T01:00:00Z',
+          // A real disposition attempt in substance, but no bold markdown
+          // at all -- fails `isDispositionComment`.
+          body: 'Accepted — looks correct.',
+          author: { login: 'idd-bot' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['chatgpt-codex-connector[bot]'],
+    },
+  );
+
+  // Existing pass/fail routing is unchanged -- only the diagnostic is added.
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.reason, 'missing-disposition-evidence');
+  assert.equal(summary.missingRegularCommentCount, 1);
+  assert.equal(
+    summary.missingRegularComments[0].hint,
+    MALFORMED_DISPOSITION_PREFIX_HINT,
+  );
+});
+
+// #2249: a regular comment with no resemblance whatsoever to a disposition
+// attempt (no later IDD-agent reply at all) must still carry no hint --
+// the new generalized check must not become a blanket default.
+test('disposition evidence does not hint an unrelated regular comment with no reply attempt', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          body: 'This looks like a genuine review finding with no reply yet.',
+          author: { login: 'chatgpt-codex-connector[bot]' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['chatgpt-codex-connector[bot]'],
+    },
+  );
+
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.missingRegularCommentCount, 1);
+  assert.equal(summary.missingRegularComments[0].hint, undefined);
 });

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -657,3 +657,50 @@ test('disposition evidence does not hint from a single-asterisk or longer-word n
     assert.equal(comment.hint, undefined);
   }
 });
+
+// #2249, Copilot review on PR #2383: a human's outstanding comment never
+// requires the bold `**Accepted**`/`**Rejected**` prefix (presence-only,
+// #2139), so `MALFORMED_DISPOSITION_PREFIX_HINT` must never attach to a
+// human missing comment even when a malformed reply exists somewhere in
+// the thread. Two human comments, one malformed reply: the 1:1 pairing
+// consumes the reply for the EARLIER comment (clearing it), leaving the
+// LATER comment still missing -- it must get no hint, not a misleading
+// one claiming it needs bold markdown it never required.
+test('disposition evidence does not hint a still-missing human comment from a reply consumed by an earlier human comment', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          body: 'First human review comment awaiting a reply.',
+          author: { login: 'reviewer-a' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T00:30:00Z',
+          body: 'Second human review comment awaiting a reply.',
+          author: { login: 'reviewer-b' },
+        },
+        {
+          id: 3,
+          createdAt: '2026-05-12T01:00:00Z',
+          // Malformed (no bold), but presence-only suffices for a human
+          // comment -- the 1:1 pairing consumes this for comment 1 (the
+          // earlier of the two), leaving comment 2 still missing.
+          body: 'Accepted — will follow up.',
+          author: { login: 'idd-bot' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['chatgpt-codex-connector[bot]'],
+    },
+  );
+
+  assert.equal(summary.missingRegularCommentCount, 1);
+  assert.equal(summary.missingRegularComments[0].authorLogin, 'reviewer-b');
+  assert.equal(summary.missingRegularComments[0].hint, undefined);
+});

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -606,3 +606,54 @@ test('disposition evidence does not hint an unrelated regular comment with no re
   assert.equal(summary.missingRegularCommentCount, 1);
   assert.equal(summary.missingRegularComments[0].hint, undefined);
 });
+
+// #2249, Copilot review on PR #2383: `MALFORMED_DISPOSITION_PREFIX_RE` must
+// not match a single-`*` near-miss (`*Accepted`, not a real bold-markdown
+// attempt) or a longer word starting with the same prefix (`Acceptedly`),
+// so the hint stays scoped to genuine near-miss disposition attempts.
+test('disposition evidence does not hint from a single-asterisk or longer-word near-miss', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          body: 'I found a potential off-by-one in `foo.mts` at line 42 — the loop bound should be `<=` to include the final element.',
+          author: { login: 'chatgpt-codex-connector[bot]' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T01:00:00Z',
+          // Single leading `*`, not the required zero or two -- not a
+          // real bold-markdown disposition attempt.
+          body: '*Accepted — looks correct.',
+          author: { login: 'idd-bot' },
+        },
+        {
+          id: 3,
+          createdAt: '2026-05-12T00:00:00Z',
+          body: 'A second, unrelated finding awaiting its own disposition.',
+          author: { login: 'chatgpt-codex-connector[bot]' },
+        },
+        {
+          id: 4,
+          createdAt: '2026-05-12T01:00:00Z',
+          // Starts with the literal word "Accepted" but continues into a
+          // longer word -- not a disposition attempt at all.
+          body: 'Acceptedly this needs more review before merging.',
+          author: { login: 'idd-bot' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['chatgpt-codex-connector[bot]'],
+    },
+  );
+
+  assert.equal(summary.missingRegularCommentCount, 2);
+  for (const comment of summary.missingRegularComments) {
+    assert.equal(comment.hint, undefined);
+  }
+});


### PR DESCRIPTION
## Summary

`summarizeDispositionEvidenceForGate`'s `missingRegularComments[].hint`
only named the required literal prefix for the narrow #1833
non-review-notice/wrong-phrase pairing case. The far more common
mistake — an IDD-agent reply written as plain `Accepted — ...` with no
bold markdown at all, so it never satisfies `isDispositionComment` —
left the required literal prefix completely undiscoverable from the
gate's own diagnostic output.

This generalizes the hint: any `missingRegularComments[]` entry with a
later IDD-agent reply that starts with `Accepted`/`Rejected`/
`**Accepted`/`**Rejected` but fails `isDispositionComment` now carries
a hint naming the exact required `**Accepted**`/`**Rejected**` prefix
— independent of the existing non-review-notice case, which keeps its
own more specific `NON_REVIEW_NOTICE_DISPOSITION_HINT` unchanged and
takes precedence when both could apply (they cannot in practice, since
the two source pools are disjoint by construction).

## Changes

- `src/scripts/protocol-helpers.mts`: add `MALFORMED_DISPOSITION_PREFIX_RE`
  (loose "close but not exact" detector) and
  `MALFORMED_DISPOSITION_PREFIX_HINT` (the new hint text); compute a
  `malformedPrefixDispositions` pool alongside the existing
  `wrongPhraseRejectedDispositions`, and attach the new hint when the
  existing #1833 hint does not apply.
- `schemas/pre-merge-readiness.schema.json`: update the `hint` field's
  description to cover both cases.
- `tests/protocol-helpers.test.mts`: two new unit tests — a plain
  `Accepted — ...` reply (no bold markdown) now receives a hint, and
  an unrelated regular comment with no reply attempt still receives
  none.

## Test plan

- [x] `node --test tests/protocol-helpers.test.mts` — 9/9 pass
- [x] `node --test tests/pre-merge-readiness.test.mts` — 310/310 pass
  (no regression on the existing #1833 hint tests)
- [x] `pnpm run typecheck`
- [x] `pnpm run build:check`

Closes #2249
