### PR TITLE
chore(post-merge-cleanup): label bootstrap-era PRs distinctly

### DIFF
--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -20,6 +20,7 @@ import {
 } from './autopilot-suitability.mjs';
 import { parseCliArgs } from './cli-args.mjs';
 import { resolveHelperCommandForProfile } from './helper-runtime-manifest.mjs';
+import { isValidIsoTimestamp } from './marker-helpers.mjs';
 import {
   inspectHelperRuntimeConfig,
   POLICY_DEFAULTS,
@@ -1989,34 +1990,68 @@ export function classifyBacklog(missingPrNumbers, warnThreshold) {
       : [],
   };
 }
+const CUTOFF_DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+/**
+ * Parses a `--cleanup-backlog-bootstrap-cutoff` value (or a `gh`-supplied
+ * `mergedAt`) to a UTC millisecond timestamp, or `null` when unparsable
+ * (idd-skill#2226, CodeRabbit review on PR #2386). Deliberately stricter
+ * than plain `Date.parse`, which both silently normalizes calendar
+ * overflow (`Date.parse('2026-02-30')` resolves to March 2 instead of
+ * rejecting the date) and resolves a timestamp with a time-of-day but no
+ * explicit UTC offset in the HOST's local time zone -- so the identically
+ * configured cutoff would classify different PRs depending on which
+ * machine or CI runner evaluates it (confirmed empirically across `TZ`
+ * values before this fix).
+ *
+ * Two forms are accepted, both unambiguous everywhere:
+ * - a bare calendar date (`YYYY-MM-DD`), anchored to UTC midnight;
+ * - a full ISO8601 UTC timestamp recognized by `isValidIsoTimestamp`
+ *   (marker-helpers.mts) -- this repository's own existing canonical
+ *   timestamp contract, Z-suffixed only, no other offset forms.
+ *
+ * The date-only branch round-trips through `Date` -> `toISOString()` and
+ * compares the calendar-date portion against the input, which rejects
+ * overflow the same way `isValidIsoTimestamp` already does for its own
+ * shape.
+ */
+export function parseStrictCutoffToUtcMs(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  if (CUTOFF_DATE_ONLY_PATTERN.test(value)) {
+    const ms = Date.parse(`${value}T00:00:00.000Z`);
+    return Number.isFinite(ms) &&
+      new Date(ms).toISOString().slice(0, 10) === value
+      ? ms
+      : null;
+  }
+  return isValidIsoTimestamp(value) ? Date.parse(value) : null;
+}
 /**
  * Numbers among `missingPrNumbers` whose merge predates `cutoffIso`
  * (idd-skill#2226) -- presentation-only: never changes which PRs count as
  * missing evidence, only which of them the backlog warning labels
  * "bootstrap-era" instead of a genuine claim-marker-missing gap. A PR
  * absent from `mergedAtByNumber` (its `mergedAt` was missing or malformed
- * at fetch time) or an unparsable `cutoffIso` never counts as
- * bootstrap-era -- fails closed to "flag every PR the same as before this
- * feature existed" rather than guessing. Pure so it can be unit-tested
- * without mocking `gh`.
+ * at fetch time), whose `mergedAt` fails {@link parseStrictCutoffToUtcMs},
+ * or an unparsable `cutoffIso` never counts as bootstrap-era -- fails
+ * closed to "flag every PR the same as before this feature existed"
+ * rather than guessing. Pure so it can be unit-tested without mocking
+ * `gh`.
  */
 export function classifyBootstrapEraPrNumbers(
   missingPrNumbers,
   mergedAtByNumber,
   cutoffIso,
 ) {
-  const cutoffMs = typeof cutoffIso === 'string' ? Date.parse(cutoffIso) : NaN;
-  if (!Number.isFinite(cutoffMs)) {
+  const cutoffMs = parseStrictCutoffToUtcMs(cutoffIso);
+  if (cutoffMs === null) {
     return new Set();
   }
   const bootstrapEra = new Set();
   for (const number of missingPrNumbers) {
-    const mergedAt = mergedAtByNumber.get(number);
-    if (typeof mergedAt !== 'string') {
-      continue;
-    }
-    const mergedAtMs = Date.parse(mergedAt);
-    if (Number.isFinite(mergedAtMs) && mergedAtMs < cutoffMs) {
+    const mergedAtMs = parseStrictCutoffToUtcMs(mergedAtByNumber.get(number));
+    if (mergedAtMs !== null && mergedAtMs < cutoffMs) {
       bootstrapEra.add(number);
     }
   }
@@ -2106,8 +2141,8 @@ export function readCleanupEvidenceTrustedLogins(root) {
   return new Set([...actors, 'github-actions[bot]']);
 }
 /**
- * Filter a `gh pr list --json number,headRefName` result down to entries
- * whose head ref matches the IDD branch-naming convention -- the same
+ * Filter a `gh pr list --json number,headRefName,mergedAt` result down to
+ * entries whose head ref matches the IDD branch-naming convention -- the same
  * `worktreeGuard.branchPatterns` globs (`issue/*`, `roadmap-audit/*` by
  * default; see `readWorktreeGuardBranchPatterns`) that `classifyPrimaryHead`
  * already matches elsewhere in this file. A routine non-IDD merge (a
@@ -3448,17 +3483,20 @@ function parseArgs(argv) {
   // --cleanup-backlog-bootstrap-cutoff (idd-skill#2226): optional, no
   // default -- absent means every PR is still reported the same,
   // undifferentiated way this check has always used. Rejects an explicit
-  // empty string and anything Date.parse cannot resolve, matching
-  // --cleanup-backlog-window-days's own empty-string/malformed-value
-  // guards above.
+  // empty string (matching --cleanup-backlog-window-days's own
+  // empty-string guard above) and anything parseStrictCutoffToUtcMs
+  // cannot resolve -- a bare `Date.parse` check here would accept
+  // calendar overflow and a host-timezone-dependent offset-less
+  // timestamp, both fixed by that stricter parser (CodeRabbit review on
+  // PR #2386).
   const bootstrapCutoffToken = values['cleanup-backlog-bootstrap-cutoff'];
   if (bootstrapCutoffToken !== undefined) {
     if (!bootstrapCutoffToken) {
       throw new Error('--cleanup-backlog-bootstrap-cutoff requires a value');
     }
-    if (!Number.isFinite(Date.parse(bootstrapCutoffToken))) {
+    if (parseStrictCutoffToUtcMs(bootstrapCutoffToken) === null) {
       throw new Error(
-        `--cleanup-backlog-bootstrap-cutoff must be a valid date/timestamp (got "${bootstrapCutoffToken}")`,
+        `--cleanup-backlog-bootstrap-cutoff must be a strict YYYY-MM-DD date or a Z-suffixed ISO8601 timestamp (got "${bootstrapCutoffToken}")`,
       );
     }
     args.cleanupBacklogBootstrapCutoff = bootstrapCutoffToken;
@@ -3505,7 +3543,7 @@ options:
   --strict                                 treat a primary-worktree implementation-branch HEAD as an error (also enabled by worktreeGuard.enabled in config)
   --cleanup-backlog-window-days <N>        merged-PR window for the cleanup backlog check (default: 14)
   --cleanup-backlog-warn-threshold <N>     backlog count above which the check warns (default: 2)
-  --cleanup-backlog-bootstrap-cutoff <date> label a flagged merged PR "(bootstrap-era)" in the report when it merged before this date/timestamp, instead of a genuine claim-marker-missing gap (default: none -- every flagged PR reports the same way)
+  --cleanup-backlog-bootstrap-cutoff <YYYY-MM-DD|ISO8601Z> label a flagged merged PR "(bootstrap-era)" in the report when it merged before this UTC date/timestamp, instead of a genuine claim-marker-missing gap (default: none -- every flagged PR reports the same way)
   --workshop-cross-ref-allow-missing <list> comma-separated entry-point paths to skip in the workshop cross-reference check (default: none)
   --help, -h                               show this help
 

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -48,6 +48,7 @@ export function runDoctor({
   requireGithub,
   cleanupBacklogWindowDays,
   cleanupBacklogWarnThreshold,
+  cleanupBacklogBootstrapCutoff,
   workshopCrossRefAllowMissing,
   strict,
 }) {
@@ -87,6 +88,7 @@ export function runDoctor({
     {
       windowDays: cleanupBacklogWindowDays ?? 14,
       warnThreshold: cleanupBacklogWarnThreshold ?? 2,
+      bootstrapCutoff: cleanupBacklogBootstrapCutoff,
       requireGithub,
     },
     report,
@@ -1988,6 +1990,39 @@ export function classifyBacklog(missingPrNumbers, warnThreshold) {
   };
 }
 /**
+ * Numbers among `missingPrNumbers` whose merge predates `cutoffIso`
+ * (idd-skill#2226) -- presentation-only: never changes which PRs count as
+ * missing evidence, only which of them the backlog warning labels
+ * "bootstrap-era" instead of a genuine claim-marker-missing gap. A PR
+ * absent from `mergedAtByNumber` (its `mergedAt` was missing or malformed
+ * at fetch time) or an unparsable `cutoffIso` never counts as
+ * bootstrap-era -- fails closed to "flag every PR the same as before this
+ * feature existed" rather than guessing. Pure so it can be unit-tested
+ * without mocking `gh`.
+ */
+export function classifyBootstrapEraPrNumbers(
+  missingPrNumbers,
+  mergedAtByNumber,
+  cutoffIso,
+) {
+  const cutoffMs = typeof cutoffIso === 'string' ? Date.parse(cutoffIso) : NaN;
+  if (!Number.isFinite(cutoffMs)) {
+    return new Set();
+  }
+  const bootstrapEra = new Set();
+  for (const number of missingPrNumbers) {
+    const mergedAt = mergedAtByNumber.get(number);
+    if (typeof mergedAt !== 'string') {
+      continue;
+    }
+    const mergedAtMs = Date.parse(mergedAt);
+    if (Number.isFinite(mergedAtMs) && mergedAtMs < cutoffMs) {
+      bootstrapEra.add(number);
+    }
+  }
+  return bootstrapEra;
+}
+/**
  * Preamble line announcing how many merged PRs the backlog scan will visit.
  * Pure so tests can assert the exact wording without running the network scan.
  */
@@ -2081,6 +2116,11 @@ export function readCleanupEvidenceTrustedLogins(root) {
  * before the backlog count, evidence-fetch loop, or `Examples: ...` list
  * ever sees it (idd-skill#1829). Pure (no I/O) so it can be unit-tested
  * without mocking `gh`.
+ *
+ * The returned `mergedAt` field (#2226) is present only when the input
+ * entry carries a non-empty string value -- an entry with no `mergedAt`
+ * (or a malformed one) yields `{ number }` alone, so callers built before
+ * this field existed (and their fixtures) see an unchanged shape.
  */
 export function filterIddBranchMergedPrs(
   prs,
@@ -2098,13 +2138,33 @@ export function filterIddBranchMergedPrs(
     ) {
       continue;
     }
-    filtered.push({ number: number });
+    const mergedAt = pr?.mergedAt;
+    const entry = {
+      number: number,
+    };
+    if (typeof mergedAt === 'string' && mergedAt.length > 0) {
+      entry.mergedAt = mergedAt;
+    }
+    filtered.push(entry);
   }
   return filtered;
+}
+/**
+ * Renders the backlog warning's `Examples: ...` clause, appending a
+ * `(bootstrap-era)` tag to every listed PR number present in
+ * `bootstrapEra` (idd-skill#2226) -- a presentation-only distinction, never
+ * a change to which numbers are listed. Pure so it can be unit-tested
+ * independently of the network scan.
+ */
+export function formatCleanupBacklogExamples(examples, bootstrapEra) {
+  return examples
+    .map((n) => (bootstrapEra.has(n) ? `#${n} (bootstrap-era)` : `#${n}`))
+    .join(', ');
 }
 function checkPostMergeCleanupBacklog(root, options, report) {
   const windowDays = options.windowDays;
   const warnThreshold = options.warnThreshold;
+  const bootstrapCutoff = options.bootstrapCutoff;
   const requireGithub = options.requireGithub === true;
   // Soft GitHub-API failures (gh missing, no token, repo view fails,
   // pr list fails) are silent by default — same pattern as the other
@@ -2158,7 +2218,7 @@ function checkPostMergeCleanupBacklog(root, options, report) {
       '--search',
       `merged:>=${sinceIso}`,
       '--json',
-      'number,headRefName',
+      'number,headRefName,mergedAt',
       '--limit',
       '1000',
     ],
@@ -2198,6 +2258,12 @@ function checkPostMergeCleanupBacklog(root, options, report) {
     formatCleanupBacklogScanPreamble(iddMergedPrs.length),
   );
   const trustedLogins = readCleanupEvidenceTrustedLogins(root);
+  const mergedAtByNumber = new Map();
+  for (const pr of iddMergedPrs) {
+    if (pr.mergedAt) {
+      mergedAtByNumber.set(pr.number, pr.mergedAt);
+    }
+  }
   const missing = [];
   const evidenceFailures = [];
   let scanned = 0;
@@ -2263,7 +2329,23 @@ function checkPostMergeCleanupBacklog(root, options, report) {
   if (!verdict.warn) {
     return;
   }
-  const examplesText = verdict.examples.map((n) => `#${n}`).join(', ');
+  // idd-skill#2226: presentation-only -- `verdict.count`/`warn`/`examples`
+  // above are computed from the unmodified `missing` list, so a configured
+  // bootstrapCutoff never changes which PRs are flagged, only how the
+  // `Examples: ...` clause labels the ones merged before it.
+  const bootstrapEra = classifyBootstrapEraPrNumbers(
+    missing,
+    mergedAtByNumber,
+    bootstrapCutoff,
+  );
+  const examplesText = formatCleanupBacklogExamples(
+    verdict.examples,
+    bootstrapEra,
+  );
+  const bootstrapEraCountClause =
+    bootstrapEra.size > 0
+      ? ` (${bootstrapEra.size} bootstrap-era, merged before ${bootstrapCutoff})`
+      : '';
   const { profile, packageSpec } = resolveConfiguredHelperRuntime(root);
   const remediation = formatCleanupBacklogRemediation(profile, packageSpec);
   // State the scoping explicitly (idd-skill#1936) so an operator reading a
@@ -2272,7 +2354,7 @@ function checkPostMergeCleanupBacklog(root, options, report) {
   // never reach this count.
   const patternsText = branchPatterns.join(', ');
   report.warnings.push(
-    `post-merge cleanup backlog: ${verdict.count} merged PRs in the last ${windowDays} days lack F4 cleanup evidence (warn threshold: ${warnThreshold}; scoped to IDD branch patterns: ${patternsText}). Examples: ${examplesText}. ${remediation}`,
+    `post-merge cleanup backlog: ${verdict.count} merged PRs in the last ${windowDays} days lack F4 cleanup evidence${bootstrapEraCountClause} (warn threshold: ${warnThreshold}; scoped to IDD branch patterns: ${patternsText}). Examples: ${examplesText}. ${remediation}`,
   );
 }
 // Default drift thresholds (idd-skill#1269): warn when the checked-out HEAD
@@ -3311,6 +3393,7 @@ const IDD_DOCTOR_FLAG_SPEC = {
   '--repo-root': { type: 'string' },
   '--cleanup-backlog-window-days': { type: 'string' },
   '--cleanup-backlog-warn-threshold': { type: 'string' },
+  '--cleanup-backlog-bootstrap-cutoff': { type: 'string' },
   '--workshop-cross-ref-allow-missing': { type: 'string' },
 };
 function parseArgs(argv) {
@@ -3362,6 +3445,24 @@ function parseArgs(argv) {
     }
     args.cleanupBacklogWarnThreshold = numeric;
   }
+  // --cleanup-backlog-bootstrap-cutoff (idd-skill#2226): optional, no
+  // default -- absent means every PR is still reported the same,
+  // undifferentiated way this check has always used. Rejects an explicit
+  // empty string and anything Date.parse cannot resolve, matching
+  // --cleanup-backlog-window-days's own empty-string/malformed-value
+  // guards above.
+  const bootstrapCutoffToken = values['cleanup-backlog-bootstrap-cutoff'];
+  if (bootstrapCutoffToken !== undefined) {
+    if (!bootstrapCutoffToken) {
+      throw new Error('--cleanup-backlog-bootstrap-cutoff requires a value');
+    }
+    if (!Number.isFinite(Date.parse(bootstrapCutoffToken))) {
+      throw new Error(
+        `--cleanup-backlog-bootstrap-cutoff must be a valid date/timestamp (got "${bootstrapCutoffToken}")`,
+      );
+    }
+    args.cleanupBacklogBootstrapCutoff = bootstrapCutoffToken;
+  }
   // --workshop-cross-ref-allow-missing: pre-migration guard used
   // `=== undefined` (NOT `!value`), so an explicit empty string was
   // accepted and resolved to an empty list (''.split(',') -> [''] ->
@@ -3404,6 +3505,7 @@ options:
   --strict                                 treat a primary-worktree implementation-branch HEAD as an error (also enabled by worktreeGuard.enabled in config)
   --cleanup-backlog-window-days <N>        merged-PR window for the cleanup backlog check (default: 14)
   --cleanup-backlog-warn-threshold <N>     backlog count above which the check warns (default: 2)
+  --cleanup-backlog-bootstrap-cutoff <date> label a flagged merged PR "(bootstrap-era)" in the report when it merged before this date/timestamp, instead of a genuine claim-marker-missing gap (default: none -- every flagged PR reports the same way)
   --workshop-cross-ref-allow-missing <list> comma-separated entry-point paths to skip in the workshop cross-reference check (default: none)
   --help, -h                               show this help
 
@@ -3490,6 +3592,7 @@ if (import.meta.main) {
     requireGithub: args.requireGithub,
     cleanupBacklogWindowDays: args.cleanupBacklogWindowDays,
     cleanupBacklogWarnThreshold: args.cleanupBacklogWarnThreshold,
+    cleanupBacklogBootstrapCutoff: args.cleanupBacklogBootstrapCutoff,
     workshopCrossRefAllowMissing: args.workshopCrossRefAllowMissing,
     strict: args.strict,
   });

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -2058,6 +2058,34 @@ export function classifyBootstrapEraPrNumbers(
   return bootstrapEra;
 }
 /**
+ * Selects up to `limit` example PR numbers for display, guaranteeing at
+ * least one bootstrap-era-tagged example is visible whenever `bootstrapEra`
+ * is non-empty (idd-skill#2226 review, Copilot): a plain `slice(0, limit)`
+ * could silently omit every bootstrap-era number when none of the first
+ * `limit` entries in `missingPrNumbers` happen to be tagged, which would
+ * make the warning message's own bootstrap-era count clause look
+ * inconsistent with its own `Examples: ...` list (a non-zero count, zero
+ * `(bootstrap-era)` tags shown). Preserves the plain, order-preserving
+ * slice when `bootstrapEra` is empty or already represented in it --
+ * byte-identical to pre-#2226 behavior in the common case where no cutoff
+ * is configured at all.
+ */
+export function selectBacklogExamples(
+  missingPrNumbers,
+  bootstrapEra,
+  limit = 5,
+) {
+  const natural = missingPrNumbers.slice(0, limit);
+  if (bootstrapEra.size === 0 || natural.some((n) => bootstrapEra.has(n))) {
+    return natural;
+  }
+  const firstBootstrapEra = missingPrNumbers.find((n) => bootstrapEra.has(n));
+  if (firstBootstrapEra === undefined || natural.length === 0) {
+    return natural;
+  }
+  return [...natural.slice(0, natural.length - 1), firstBootstrapEra];
+}
+/**
  * Preamble line announcing how many merged PRs the backlog scan will visit.
  * Pure so tests can assert the exact wording without running the network scan.
  */
@@ -2373,8 +2401,12 @@ function checkPostMergeCleanupBacklog(root, options, report) {
     mergedAtByNumber,
     bootstrapCutoff,
   );
+  // idd-skill#2226 review (Copilot): select from the full `missing` list,
+  // not `verdict.examples` alone, so a non-zero bootstrapEraCountClause
+  // below is never shown alongside an Examples: list with zero
+  // (bootstrap-era) tags.
   const examplesText = formatCleanupBacklogExamples(
-    verdict.examples,
+    selectBacklogExamples(missing, bootstrapEra),
     bootstrapEra,
   );
   const bootstrapEraCountClause =

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -59,6 +59,7 @@ export interface DoctorOptions {
   requireGithub?: boolean;
   cleanupBacklogWindowDays?: number;
   cleanupBacklogWarnThreshold?: number;
+  cleanupBacklogBootstrapCutoff?: string;
   workshopCrossRefAllowMissing?: string[];
   strict?: boolean;
 }
@@ -112,6 +113,7 @@ interface DoctorCliArgs {
   strict: boolean;
   cleanupBacklogWindowDays?: number;
   cleanupBacklogWarnThreshold?: number;
+  cleanupBacklogBootstrapCutoff?: string;
   workshopCrossRefAllowMissing?: string[];
 }
 
@@ -120,6 +122,7 @@ export function runDoctor({
   requireGithub,
   cleanupBacklogWindowDays,
   cleanupBacklogWarnThreshold,
+  cleanupBacklogBootstrapCutoff,
   workshopCrossRefAllowMissing,
   strict,
 }: DoctorOptions): DoctorReport {
@@ -160,6 +163,7 @@ export function runDoctor({
     {
       windowDays: cleanupBacklogWindowDays ?? 14,
       warnThreshold: cleanupBacklogWarnThreshold ?? 2,
+      bootstrapCutoff: cleanupBacklogBootstrapCutoff,
       requireGithub,
     },
     report,
@@ -2323,6 +2327,40 @@ export function classifyBacklog(
 }
 
 /**
+ * Numbers among `missingPrNumbers` whose merge predates `cutoffIso`
+ * (idd-skill#2226) -- presentation-only: never changes which PRs count as
+ * missing evidence, only which of them the backlog warning labels
+ * "bootstrap-era" instead of a genuine claim-marker-missing gap. A PR
+ * absent from `mergedAtByNumber` (its `mergedAt` was missing or malformed
+ * at fetch time) or an unparsable `cutoffIso` never counts as
+ * bootstrap-era -- fails closed to "flag every PR the same as before this
+ * feature existed" rather than guessing. Pure so it can be unit-tested
+ * without mocking `gh`.
+ */
+export function classifyBootstrapEraPrNumbers(
+  missingPrNumbers: readonly number[],
+  mergedAtByNumber: ReadonlyMap<number, string>,
+  cutoffIso: string | undefined,
+): Set<number> {
+  const cutoffMs = typeof cutoffIso === 'string' ? Date.parse(cutoffIso) : NaN;
+  if (!Number.isFinite(cutoffMs)) {
+    return new Set();
+  }
+  const bootstrapEra = new Set<number>();
+  for (const number of missingPrNumbers) {
+    const mergedAt = mergedAtByNumber.get(number);
+    if (typeof mergedAt !== 'string') {
+      continue;
+    }
+    const mergedAtMs = Date.parse(mergedAt);
+    if (Number.isFinite(mergedAtMs) && mergedAtMs < cutoffMs) {
+      bootstrapEra.add(number);
+    }
+  }
+  return bootstrapEra;
+}
+
+/**
  * Preamble line announcing how many merged PRs the backlog scan will visit.
  * Pure so tests can assert the exact wording without running the network scan.
  */
@@ -2434,13 +2472,18 @@ export function readCleanupEvidenceTrustedLogins(root: string): Set<string> {
  * before the backlog count, evidence-fetch loop, or `Examples: ...` list
  * ever sees it (idd-skill#1829). Pure (no I/O) so it can be unit-tested
  * without mocking `gh`.
+ *
+ * The returned `mergedAt` field (#2226) is present only when the input
+ * entry carries a non-empty string value -- an entry with no `mergedAt`
+ * (or a malformed one) yields `{ number }` alone, so callers built before
+ * this field existed (and their fixtures) see an unchanged shape.
  */
 export function filterIddBranchMergedPrs(
   prs: unknown,
   patterns: string[] = DEFAULT_WORKTREE_GUARD_BRANCH_PATTERNS,
-): { number: number }[] {
+): { number: number; mergedAt?: string }[] {
   const matchers = patterns.map((pattern) => branchGlobToRegExp(pattern));
-  const filtered: { number: number }[] = [];
+  const filtered: { number: number; mergedAt?: string }[] = [];
   for (const pr of Array.isArray(prs) ? prs : []) {
     const number = (pr as { number?: unknown } | null)?.number;
     const headRefName = (pr as { headRefName?: unknown } | null)?.headRefName;
@@ -2451,9 +2494,32 @@ export function filterIddBranchMergedPrs(
     ) {
       continue;
     }
-    filtered.push({ number: number as number });
+    const mergedAt = (pr as { mergedAt?: unknown } | null)?.mergedAt;
+    const entry: { number: number; mergedAt?: string } = {
+      number: number as number,
+    };
+    if (typeof mergedAt === 'string' && mergedAt.length > 0) {
+      entry.mergedAt = mergedAt;
+    }
+    filtered.push(entry);
   }
   return filtered;
+}
+
+/**
+ * Renders the backlog warning's `Examples: ...` clause, appending a
+ * `(bootstrap-era)` tag to every listed PR number present in
+ * `bootstrapEra` (idd-skill#2226) -- a presentation-only distinction, never
+ * a change to which numbers are listed. Pure so it can be unit-tested
+ * independently of the network scan.
+ */
+export function formatCleanupBacklogExamples(
+  examples: readonly number[],
+  bootstrapEra: ReadonlySet<number>,
+): string {
+  return examples
+    .map((n) => (bootstrapEra.has(n) ? `#${n} (bootstrap-era)` : `#${n}`))
+    .join(', ');
 }
 
 function checkPostMergeCleanupBacklog(
@@ -2461,12 +2527,14 @@ function checkPostMergeCleanupBacklog(
   options: {
     windowDays: number;
     warnThreshold: number;
+    bootstrapCutoff?: string;
     requireGithub?: boolean;
   },
   report: DoctorReport,
 ) {
   const windowDays = options.windowDays;
   const warnThreshold = options.warnThreshold;
+  const bootstrapCutoff = options.bootstrapCutoff;
   const requireGithub = options.requireGithub === true;
 
   // Soft GitHub-API failures (gh missing, no token, repo view fails,
@@ -2524,7 +2592,7 @@ function checkPostMergeCleanupBacklog(
       '--search',
       `merged:>=${sinceIso}`,
       '--json',
-      'number,headRefName',
+      'number,headRefName,mergedAt',
       '--limit',
       '1000',
     ],
@@ -2567,6 +2635,12 @@ function checkPostMergeCleanupBacklog(
   );
 
   const trustedLogins = readCleanupEvidenceTrustedLogins(root);
+  const mergedAtByNumber = new Map<number, string>();
+  for (const pr of iddMergedPrs) {
+    if (pr.mergedAt) {
+      mergedAtByNumber.set(pr.number, pr.mergedAt);
+    }
+  }
   const missing: number[] = [];
   const evidenceFailures: number[] = [];
   let scanned = 0;
@@ -2635,7 +2709,23 @@ function checkPostMergeCleanupBacklog(
     return;
   }
 
-  const examplesText = verdict.examples.map((n) => `#${n}`).join(', ');
+  // idd-skill#2226: presentation-only -- `verdict.count`/`warn`/`examples`
+  // above are computed from the unmodified `missing` list, so a configured
+  // bootstrapCutoff never changes which PRs are flagged, only how the
+  // `Examples: ...` clause labels the ones merged before it.
+  const bootstrapEra = classifyBootstrapEraPrNumbers(
+    missing,
+    mergedAtByNumber,
+    bootstrapCutoff,
+  );
+  const examplesText = formatCleanupBacklogExamples(
+    verdict.examples,
+    bootstrapEra,
+  );
+  const bootstrapEraCountClause =
+    bootstrapEra.size > 0
+      ? ` (${bootstrapEra.size} bootstrap-era, merged before ${bootstrapCutoff})`
+      : '';
   const { profile, packageSpec } = resolveConfiguredHelperRuntime(root);
   const remediation = formatCleanupBacklogRemediation(profile, packageSpec);
   // State the scoping explicitly (idd-skill#1936) so an operator reading a
@@ -2644,7 +2734,7 @@ function checkPostMergeCleanupBacklog(
   // never reach this count.
   const patternsText = branchPatterns.join(', ');
   report.warnings.push(
-    `post-merge cleanup backlog: ${verdict.count} merged PRs in the last ${windowDays} days lack F4 cleanup evidence (warn threshold: ${warnThreshold}; scoped to IDD branch patterns: ${patternsText}). Examples: ${examplesText}. ${remediation}`,
+    `post-merge cleanup backlog: ${verdict.count} merged PRs in the last ${windowDays} days lack F4 cleanup evidence${bootstrapEraCountClause} (warn threshold: ${warnThreshold}; scoped to IDD branch patterns: ${patternsText}). Examples: ${examplesText}. ${remediation}`,
   );
 }
 
@@ -3827,6 +3917,7 @@ const IDD_DOCTOR_FLAG_SPEC = {
   '--repo-root': { type: 'string' },
   '--cleanup-backlog-window-days': { type: 'string' },
   '--cleanup-backlog-warn-threshold': { type: 'string' },
+  '--cleanup-backlog-bootstrap-cutoff': { type: 'string' },
   '--workshop-cross-ref-allow-missing': { type: 'string' },
 } as const;
 
@@ -3888,6 +3979,27 @@ function parseArgs(argv: string[]): DoctorCliArgs {
     args.cleanupBacklogWarnThreshold = numeric;
   }
 
+  // --cleanup-backlog-bootstrap-cutoff (idd-skill#2226): optional, no
+  // default -- absent means every PR is still reported the same,
+  // undifferentiated way this check has always used. Rejects an explicit
+  // empty string and anything Date.parse cannot resolve, matching
+  // --cleanup-backlog-window-days's own empty-string/malformed-value
+  // guards above.
+  const bootstrapCutoffToken = values['cleanup-backlog-bootstrap-cutoff'] as
+    | string
+    | undefined;
+  if (bootstrapCutoffToken !== undefined) {
+    if (!bootstrapCutoffToken) {
+      throw new Error('--cleanup-backlog-bootstrap-cutoff requires a value');
+    }
+    if (!Number.isFinite(Date.parse(bootstrapCutoffToken))) {
+      throw new Error(
+        `--cleanup-backlog-bootstrap-cutoff must be a valid date/timestamp (got "${bootstrapCutoffToken}")`,
+      );
+    }
+    args.cleanupBacklogBootstrapCutoff = bootstrapCutoffToken;
+  }
+
   // --workshop-cross-ref-allow-missing: pre-migration guard used
   // `=== undefined` (NOT `!value`), so an explicit empty string was
   // accepted and resolved to an empty list (''.split(',') -> [''] ->
@@ -3935,6 +4047,7 @@ options:
   --strict                                 treat a primary-worktree implementation-branch HEAD as an error (also enabled by worktreeGuard.enabled in config)
   --cleanup-backlog-window-days <N>        merged-PR window for the cleanup backlog check (default: 14)
   --cleanup-backlog-warn-threshold <N>     backlog count above which the check warns (default: 2)
+  --cleanup-backlog-bootstrap-cutoff <date> label a flagged merged PR "(bootstrap-era)" in the report when it merged before this date/timestamp, instead of a genuine claim-marker-missing gap (default: none -- every flagged PR reports the same way)
   --workshop-cross-ref-allow-missing <list> comma-separated entry-point paths to skip in the workshop cross-reference check (default: none)
   --help, -h                               show this help
 
@@ -4030,6 +4143,7 @@ if (import.meta.main) {
     requireGithub: args.requireGithub,
     cleanupBacklogWindowDays: args.cleanupBacklogWindowDays,
     cleanupBacklogWarnThreshold: args.cleanupBacklogWarnThreshold,
+    cleanupBacklogBootstrapCutoff: args.cleanupBacklogBootstrapCutoff,
     workshopCrossRefAllowMissing: args.workshopCrossRefAllowMissing,
     strict: args.strict,
   });

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -21,6 +21,7 @@ import {
 } from './autopilot-suitability.mts';
 import { parseCliArgs } from './cli-args.mts';
 import { resolveHelperCommandForProfile } from './helper-runtime-manifest.mts';
+import { isValidIsoTimestamp } from './marker-helpers.mts';
 import {
   inspectHelperRuntimeConfig,
   POLICY_DEFAULTS,
@@ -2326,34 +2327,70 @@ export function classifyBacklog(
   };
 }
 
+const CUTOFF_DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Parses a `--cleanup-backlog-bootstrap-cutoff` value (or a `gh`-supplied
+ * `mergedAt`) to a UTC millisecond timestamp, or `null` when unparsable
+ * (idd-skill#2226, CodeRabbit review on PR #2386). Deliberately stricter
+ * than plain `Date.parse`, which both silently normalizes calendar
+ * overflow (`Date.parse('2026-02-30')` resolves to March 2 instead of
+ * rejecting the date) and resolves a timestamp with a time-of-day but no
+ * explicit UTC offset in the HOST's local time zone -- so the identically
+ * configured cutoff would classify different PRs depending on which
+ * machine or CI runner evaluates it (confirmed empirically across `TZ`
+ * values before this fix).
+ *
+ * Two forms are accepted, both unambiguous everywhere:
+ * - a bare calendar date (`YYYY-MM-DD`), anchored to UTC midnight;
+ * - a full ISO8601 UTC timestamp recognized by `isValidIsoTimestamp`
+ *   (marker-helpers.mts) -- this repository's own existing canonical
+ *   timestamp contract, Z-suffixed only, no other offset forms.
+ *
+ * The date-only branch round-trips through `Date` -> `toISOString()` and
+ * compares the calendar-date portion against the input, which rejects
+ * overflow the same way `isValidIsoTimestamp` already does for its own
+ * shape.
+ */
+export function parseStrictCutoffToUtcMs(value: unknown): number | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  if (CUTOFF_DATE_ONLY_PATTERN.test(value)) {
+    const ms = Date.parse(`${value}T00:00:00.000Z`);
+    return Number.isFinite(ms) &&
+      new Date(ms).toISOString().slice(0, 10) === value
+      ? ms
+      : null;
+  }
+  return isValidIsoTimestamp(value) ? Date.parse(value) : null;
+}
+
 /**
  * Numbers among `missingPrNumbers` whose merge predates `cutoffIso`
  * (idd-skill#2226) -- presentation-only: never changes which PRs count as
  * missing evidence, only which of them the backlog warning labels
  * "bootstrap-era" instead of a genuine claim-marker-missing gap. A PR
  * absent from `mergedAtByNumber` (its `mergedAt` was missing or malformed
- * at fetch time) or an unparsable `cutoffIso` never counts as
- * bootstrap-era -- fails closed to "flag every PR the same as before this
- * feature existed" rather than guessing. Pure so it can be unit-tested
- * without mocking `gh`.
+ * at fetch time), whose `mergedAt` fails {@link parseStrictCutoffToUtcMs},
+ * or an unparsable `cutoffIso` never counts as bootstrap-era -- fails
+ * closed to "flag every PR the same as before this feature existed"
+ * rather than guessing. Pure so it can be unit-tested without mocking
+ * `gh`.
  */
 export function classifyBootstrapEraPrNumbers(
   missingPrNumbers: readonly number[],
   mergedAtByNumber: ReadonlyMap<number, string>,
   cutoffIso: string | undefined,
 ): Set<number> {
-  const cutoffMs = typeof cutoffIso === 'string' ? Date.parse(cutoffIso) : NaN;
-  if (!Number.isFinite(cutoffMs)) {
+  const cutoffMs = parseStrictCutoffToUtcMs(cutoffIso);
+  if (cutoffMs === null) {
     return new Set();
   }
   const bootstrapEra = new Set<number>();
   for (const number of missingPrNumbers) {
-    const mergedAt = mergedAtByNumber.get(number);
-    if (typeof mergedAt !== 'string') {
-      continue;
-    }
-    const mergedAtMs = Date.parse(mergedAt);
-    if (Number.isFinite(mergedAtMs) && mergedAtMs < cutoffMs) {
+    const mergedAtMs = parseStrictCutoffToUtcMs(mergedAtByNumber.get(number));
+    if (mergedAtMs !== null && mergedAtMs < cutoffMs) {
       bootstrapEra.add(number);
     }
   }
@@ -2462,8 +2499,8 @@ export function readCleanupEvidenceTrustedLogins(root: string): Set<string> {
 }
 
 /**
- * Filter a `gh pr list --json number,headRefName` result down to entries
- * whose head ref matches the IDD branch-naming convention -- the same
+ * Filter a `gh pr list --json number,headRefName,mergedAt` result down to
+ * entries whose head ref matches the IDD branch-naming convention -- the same
  * `worktreeGuard.branchPatterns` globs (`issue/*`, `roadmap-audit/*` by
  * default; see `readWorktreeGuardBranchPatterns`) that `classifyPrimaryHead`
  * already matches elsewhere in this file. A routine non-IDD merge (a
@@ -3982,9 +4019,12 @@ function parseArgs(argv: string[]): DoctorCliArgs {
   // --cleanup-backlog-bootstrap-cutoff (idd-skill#2226): optional, no
   // default -- absent means every PR is still reported the same,
   // undifferentiated way this check has always used. Rejects an explicit
-  // empty string and anything Date.parse cannot resolve, matching
-  // --cleanup-backlog-window-days's own empty-string/malformed-value
-  // guards above.
+  // empty string (matching --cleanup-backlog-window-days's own
+  // empty-string guard above) and anything parseStrictCutoffToUtcMs
+  // cannot resolve -- a bare `Date.parse` check here would accept
+  // calendar overflow and a host-timezone-dependent offset-less
+  // timestamp, both fixed by that stricter parser (CodeRabbit review on
+  // PR #2386).
   const bootstrapCutoffToken = values['cleanup-backlog-bootstrap-cutoff'] as
     | string
     | undefined;
@@ -3992,9 +4032,9 @@ function parseArgs(argv: string[]): DoctorCliArgs {
     if (!bootstrapCutoffToken) {
       throw new Error('--cleanup-backlog-bootstrap-cutoff requires a value');
     }
-    if (!Number.isFinite(Date.parse(bootstrapCutoffToken))) {
+    if (parseStrictCutoffToUtcMs(bootstrapCutoffToken) === null) {
       throw new Error(
-        `--cleanup-backlog-bootstrap-cutoff must be a valid date/timestamp (got "${bootstrapCutoffToken}")`,
+        `--cleanup-backlog-bootstrap-cutoff must be a strict YYYY-MM-DD date or a Z-suffixed ISO8601 timestamp (got "${bootstrapCutoffToken}")`,
       );
     }
     args.cleanupBacklogBootstrapCutoff = bootstrapCutoffToken;
@@ -4047,7 +4087,7 @@ options:
   --strict                                 treat a primary-worktree implementation-branch HEAD as an error (also enabled by worktreeGuard.enabled in config)
   --cleanup-backlog-window-days <N>        merged-PR window for the cleanup backlog check (default: 14)
   --cleanup-backlog-warn-threshold <N>     backlog count above which the check warns (default: 2)
-  --cleanup-backlog-bootstrap-cutoff <date> label a flagged merged PR "(bootstrap-era)" in the report when it merged before this date/timestamp, instead of a genuine claim-marker-missing gap (default: none -- every flagged PR reports the same way)
+  --cleanup-backlog-bootstrap-cutoff <YYYY-MM-DD|ISO8601Z> label a flagged merged PR "(bootstrap-era)" in the report when it merged before this UTC date/timestamp, instead of a genuine claim-marker-missing gap (default: none -- every flagged PR reports the same way)
   --workshop-cross-ref-allow-missing <list> comma-separated entry-point paths to skip in the workshop cross-reference check (default: none)
   --help, -h                               show this help
 

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -2398,6 +2398,35 @@ export function classifyBootstrapEraPrNumbers(
 }
 
 /**
+ * Selects up to `limit` example PR numbers for display, guaranteeing at
+ * least one bootstrap-era-tagged example is visible whenever `bootstrapEra`
+ * is non-empty (idd-skill#2226 review, Copilot): a plain `slice(0, limit)`
+ * could silently omit every bootstrap-era number when none of the first
+ * `limit` entries in `missingPrNumbers` happen to be tagged, which would
+ * make the warning message's own bootstrap-era count clause look
+ * inconsistent with its own `Examples: ...` list (a non-zero count, zero
+ * `(bootstrap-era)` tags shown). Preserves the plain, order-preserving
+ * slice when `bootstrapEra` is empty or already represented in it --
+ * byte-identical to pre-#2226 behavior in the common case where no cutoff
+ * is configured at all.
+ */
+export function selectBacklogExamples(
+  missingPrNumbers: readonly number[],
+  bootstrapEra: ReadonlySet<number>,
+  limit = 5,
+): number[] {
+  const natural = missingPrNumbers.slice(0, limit);
+  if (bootstrapEra.size === 0 || natural.some((n) => bootstrapEra.has(n))) {
+    return natural;
+  }
+  const firstBootstrapEra = missingPrNumbers.find((n) => bootstrapEra.has(n));
+  if (firstBootstrapEra === undefined || natural.length === 0) {
+    return natural;
+  }
+  return [...natural.slice(0, natural.length - 1), firstBootstrapEra];
+}
+
+/**
  * Preamble line announcing how many merged PRs the backlog scan will visit.
  * Pure so tests can assert the exact wording without running the network scan.
  */
@@ -2755,8 +2784,12 @@ function checkPostMergeCleanupBacklog(
     mergedAtByNumber,
     bootstrapCutoff,
   );
+  // idd-skill#2226 review (Copilot): select from the full `missing` list,
+  // not `verdict.examples` alone, so a non-zero bootstrapEraCountClause
+  // below is never shown alongside an Examples: list with zero
+  // (bootstrap-era) tags.
   const examplesText = formatCleanupBacklogExamples(
-    verdict.examples,
+    selectBacklogExamples(missing, bootstrapEra),
     bootstrapEra,
   );
   const bootstrapEraCountClause =

--- a/tests/idd-doctor-cleanup-backlog-cli-smoke.test.mts
+++ b/tests/idd-doctor-cleanup-backlog-cli-smoke.test.mts
@@ -55,15 +55,29 @@ function buildCleanupBacklogStubGh(config: {
   // `headRefName` scoping fix) keep exercising an IDD-branch PR without
   // being rewritten.
   headRefNameByPr?: Map<number, string>;
+  // idd-skill#2226: per-PR mergedAt, omitted from the stubbed `pr list`
+  // entry (not merely undefined) when absent for a given number -- the
+  // pre-#2226 tests above supply none, matching gh's own real output for
+  // a PR whose merge timestamp was not requested.
+  mergedAtByPr?: Map<number, string>;
 }): string {
   const owner = JSON.stringify(config.owner);
   const repo = JSON.stringify(config.repo);
   const headRefNameByPr = config.headRefNameByPr ?? new Map();
+  const mergedAtByPr = config.mergedAtByPr ?? new Map();
   const prListJson = JSON.stringify(
-    config.mergedPrNumbers.map((number) => ({
-      number,
-      headRefName: headRefNameByPr.get(number) ?? `issue/${number}-fixture`,
-    })),
+    config.mergedPrNumbers.map((number) => {
+      const entry: { number: number; headRefName: string; mergedAt?: string } =
+        {
+          number,
+          headRefName: headRefNameByPr.get(number) ?? `issue/${number}-fixture`,
+        };
+      const mergedAt = mergedAtByPr.get(number);
+      if (mergedAt !== undefined) {
+        entry.mergedAt = mergedAt;
+      }
+      return entry;
+    }),
   );
   const evidenceTable = JSON.stringify([...config.evidenceByPr.entries()]);
   const failingNumbers = JSON.stringify([...(config.failEvidenceFor ?? [])]);
@@ -94,7 +108,11 @@ process.exit(1);
 `;
 }
 
-function runIddDoctorReport(cwd: string, stubGhSource: string): DoctorReport {
+function runIddDoctorReport(
+  cwd: string,
+  stubGhSource: string,
+  extraArgs: string[] = [],
+): DoctorReport {
   const stubRoot = mkdtempSync(join(tmpdir(), 'idd-doctor-cleanup-gh-'));
   try {
     const ghPath = join(stubRoot, 'gh');
@@ -107,6 +125,7 @@ function runIddDoctorReport(cwd: string, stubGhSource: string): DoctorReport {
       cwd,
       '--cleanup-backlog-warn-threshold',
       '0',
+      ...extraArgs,
     ];
     const options = {
       encoding: 'utf8' as const,
@@ -301,5 +320,62 @@ test('checkPostMergeCleanupBacklog CLI: produces no backlog warning when every m
       !report.warnings.some((w) => w.includes(BACKLOG_WARNING_SUBSTRING)),
       `expected no cleanup-backlog warning when every PR is non-IDD, got: ${JSON.stringify(report.warnings)}`,
     );
+  });
+});
+
+// idd-skill#2226: end-to-end coverage for --cleanup-backlog-bootstrap-cutoff
+// through the real compiled CLI -- one PR merged before the configured
+// cutoff, one after, both missing evidence.
+test('checkPostMergeCleanupBacklog CLI: --cleanup-backlog-bootstrap-cutoff labels only the pre-cutoff PR, without changing the count', () => {
+  withTempCwd((cwd) => {
+    const report = runIddDoctorReport(
+      cwd,
+      buildCleanupBacklogStubGh({
+        owner: 'o',
+        repo: 'r',
+        mergedPrNumbers: [1001, 1002],
+        evidenceByPr: new Map(),
+        mergedAtByPr: new Map([
+          [1001, '2025-01-01T00:00:00Z'],
+          [1002, '2026-08-01T00:00:00Z'],
+        ]),
+      }),
+      ['--cleanup-backlog-bootstrap-cutoff', '2026-01-01T00:00:00Z'],
+    );
+    const backlogWarning = report.warnings.find((w) =>
+      w.includes(BACKLOG_WARNING_SUBSTRING),
+    );
+    assert.ok(
+      backlogWarning,
+      `expected a cleanup-backlog warning, got: ${JSON.stringify(report.warnings)}`,
+    );
+    // Count is unchanged -- still 2, the same as without the flag.
+    assert.match(
+      backlogWarning ?? '',
+      /^post-merge cleanup backlog: 2 merged PRs/,
+    );
+    assert.match(backlogWarning ?? '', /#1001 \(bootstrap-era\)/);
+    assert.match(backlogWarning ?? '', /#1002(?! \(bootstrap-era\))/);
+    assert.match(backlogWarning ?? '', /1 bootstrap-era/);
+  });
+});
+
+test('checkPostMergeCleanupBacklog CLI: without --cleanup-backlog-bootstrap-cutoff, every PR reports the same undifferentiated way (no regression)', () => {
+  withTempCwd((cwd) => {
+    const report = runIddDoctorReport(
+      cwd,
+      buildCleanupBacklogStubGh({
+        owner: 'o',
+        repo: 'r',
+        mergedPrNumbers: [1101],
+        evidenceByPr: new Map(),
+        mergedAtByPr: new Map([[1101, '2025-01-01T00:00:00Z']]),
+      }),
+    );
+    const backlogWarning = report.warnings.find((w) =>
+      w.includes(BACKLOG_WARNING_SUBSTRING),
+    );
+    assert.ok(backlogWarning);
+    assert.doesNotMatch(backlogWarning ?? '', /bootstrap-era/);
   });
 });

--- a/tests/idd-doctor-cleanup-backlog-cli-smoke.test.mts
+++ b/tests/idd-doctor-cleanup-backlog-cli-smoke.test.mts
@@ -56,9 +56,11 @@ function buildCleanupBacklogStubGh(config: {
   // being rewritten.
   headRefNameByPr?: Map<number, string>;
   // idd-skill#2226: per-PR mergedAt, omitted from the stubbed `pr list`
-  // entry (not merely undefined) when absent for a given number -- the
-  // pre-#2226 tests above supply none, matching gh's own real output for
-  // a PR whose merge timestamp was not requested.
+  // entry (not merely undefined) when absent for a given number. The
+  // compiled idd-doctor always requests mergedAt now, so this omission
+  // simulates a missing/malformed field in gh's response, not an
+  // unrequested one -- the pre-#2226 tests above supply none, exercising
+  // that fail-closed path.
   mergedAtByPr?: Map<number, string>;
 }): string {
   const owner = JSON.stringify(config.owner);

--- a/tests/idd-doctor-cleanup-backlog-cli-smoke.test.mts
+++ b/tests/idd-doctor-cleanup-backlog-cli-smoke.test.mts
@@ -362,6 +362,43 @@ test('checkPostMergeCleanupBacklog CLI: --cleanup-backlog-bootstrap-cutoff label
   });
 });
 
+test('checkPostMergeCleanupBacklog CLI: a bootstrap-era PR past the natural 5-example slice still appears in Examples: (Copilot review, PR #2386)', () => {
+  withTempCwd((cwd) => {
+    const mergedPrNumbers = [1201, 1202, 1203, 1204, 1205, 1210];
+    const report = runIddDoctorReport(
+      cwd,
+      buildCleanupBacklogStubGh({
+        owner: 'o',
+        repo: 'r',
+        mergedPrNumbers,
+        evidenceByPr: new Map(),
+        mergedAtByPr: new Map([
+          [1201, '2026-08-01T00:00:00Z'],
+          [1202, '2026-08-01T00:00:00Z'],
+          [1203, '2026-08-01T00:00:00Z'],
+          [1204, '2026-08-01T00:00:00Z'],
+          [1205, '2026-08-01T00:00:00Z'],
+          // Only #1210 is bootstrap-era, and it sorts past the natural
+          // first-5 slice -- without the fix, the warning would still
+          // claim "1 bootstrap-era" but show zero (bootstrap-era) tags.
+          [1210, '2025-01-01T00:00:00Z'],
+        ]),
+      }),
+      ['--cleanup-backlog-bootstrap-cutoff', '2026-01-01T00:00:00Z'],
+    );
+    const backlogWarning = report.warnings.find((w) =>
+      w.includes(BACKLOG_WARNING_SUBSTRING),
+    );
+    assert.ok(backlogWarning);
+    assert.match(
+      backlogWarning ?? '',
+      /^post-merge cleanup backlog: 6 merged PRs/,
+    );
+    assert.match(backlogWarning ?? '', /1 bootstrap-era/);
+    assert.match(backlogWarning ?? '', /#1210 \(bootstrap-era\)/);
+  });
+});
+
 test('checkPostMergeCleanupBacklog CLI: without --cleanup-backlog-bootstrap-cutoff, every PR reports the same undifferentiated way (no regression)', () => {
   withTempCwd((cwd) => {
     const report = runIddDoctorReport(

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -20,6 +20,7 @@ import {
   checkPolicySignals,
   checkProjectCommands,
   classifyBacklog,
+  classifyBootstrapEraPrNumbers,
   classifyClaimTimingConsistency,
   classifyLiveConfigSchemaFinding,
   classifyMergePolicyAcknowledgement,
@@ -44,6 +45,7 @@ import {
   findMissingWorkshopReferences,
   findMissingWorktreeHardening,
   findPlaceholders,
+  formatCleanupBacklogExamples,
   formatCleanupBacklogRemediation,
   formatCleanupBacklogScanPreamble,
   formatCleanupBacklogScanProgress,
@@ -731,6 +733,25 @@ test('filterIddBranchMergedPrs honors a custom pattern list instead of the defau
 // idd-skill#1936: when every merged PR's head ref fails every configured
 // pattern (all non-IDD traffic in the window), the filter must return an
 // empty array rather than falling back to the unfiltered input.
+test('filterIddBranchMergedPrs carries a valid mergedAt through, omitted when absent or empty (idd-skill#2226)', () => {
+  const result = filterIddBranchMergedPrs([
+    {
+      number: 501,
+      headRefName: 'issue/501-fix',
+      mergedAt: '2025-01-01T00:00:00Z',
+    },
+    { number: 502, headRefName: 'issue/502-fix' },
+    { number: 503, headRefName: 'issue/503-fix', mergedAt: '' },
+    { number: 504, headRefName: 'issue/504-fix', mergedAt: 12345 },
+  ]);
+  assert.deepEqual(result, [
+    { number: 501, mergedAt: '2025-01-01T00:00:00Z' },
+    { number: 502 },
+    { number: 503 },
+    { number: 504 },
+  ]);
+});
+
 test('filterIddBranchMergedPrs returns an empty array when every entry is non-matching', () => {
   const prs = [
     { number: 401, headRefName: 'dependabot/npm_and_yarn/lodash-4.17.21' },
@@ -1884,6 +1905,70 @@ test('classifyBacklog coerces non-numeric / NaN / negative thresholds to 0', () 
   assert.equal(classifyBacklog([1], -5).warn, true);
   // Zero count must not warn even with a broken threshold.
   assert.equal(classifyBacklog([], NaN).warn, false);
+});
+
+test('classifyBootstrapEraPrNumbers labels only PRs merged before the cutoff (idd-skill#2226)', () => {
+  const mergedAtByNumber = new Map([
+    [100, '2025-01-01T00:00:00Z'],
+    [101, '2026-06-01T00:00:00Z'],
+    [102, '2026-08-01T00:00:00Z'],
+  ]);
+  assert.deepEqual(
+    classifyBootstrapEraPrNumbers(
+      [100, 101, 102],
+      mergedAtByNumber,
+      '2026-01-01T00:00:00Z',
+    ),
+    new Set([100]),
+  );
+});
+
+test('classifyBootstrapEraPrNumbers is presentation-only: never adds a number missingPrNumbers did not already contain', () => {
+  const mergedAtByNumber = new Map([[100, '2025-01-01T00:00:00Z']]);
+  assert.deepEqual(
+    classifyBootstrapEraPrNumbers([], mergedAtByNumber, '2026-01-01T00:00:00Z'),
+    new Set(),
+  );
+});
+
+test('classifyBootstrapEraPrNumbers returns an empty set for an unparsable cutoff (fail closed)', () => {
+  const mergedAtByNumber = new Map([[100, '2025-01-01T00:00:00Z']]);
+  assert.deepEqual(
+    classifyBootstrapEraPrNumbers([100], mergedAtByNumber, 'not-a-date'),
+    new Set(),
+  );
+  assert.deepEqual(
+    classifyBootstrapEraPrNumbers([100], mergedAtByNumber, undefined),
+    new Set(),
+  );
+});
+
+test('classifyBootstrapEraPrNumbers skips a PR number absent from mergedAtByNumber', () => {
+  // #101 has no recorded mergedAt (fetch failed / omitted) -- never
+  // guessed as bootstrap-era.
+  const mergedAtByNumber = new Map([[100, '2025-01-01T00:00:00Z']]);
+  assert.deepEqual(
+    classifyBootstrapEraPrNumbers(
+      [100, 101],
+      mergedAtByNumber,
+      '2026-01-01T00:00:00Z',
+    ),
+    new Set([100]),
+  );
+});
+
+test('formatCleanupBacklogExamples tags only the bootstrap-era numbers (idd-skill#2226)', () => {
+  assert.equal(
+    formatCleanupBacklogExamples([100, 101, 102], new Set([100, 102])),
+    '#100 (bootstrap-era), #101, #102 (bootstrap-era)',
+  );
+});
+
+test('formatCleanupBacklogExamples matches the pre-#2226 plain format when no number is bootstrap-era', () => {
+  assert.equal(
+    formatCleanupBacklogExamples([100, 101], new Set()),
+    '#100, #101',
+  );
 });
 
 test('formatCleanupBacklogRemediation resolves the audit-pr-cleanup invocation per profile (idd-skill#1718)', () => {

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -70,6 +70,7 @@ import {
   resolveConfiguredHelperRuntimeProfile,
   resolveTargetGhHostname,
   scanFileForPlaceholders,
+  selectBacklogExamples,
   stripMarkdownNonText,
   worktreeGuardWiredAt,
 } from '../src/scripts/idd-doctor.mts';
@@ -2022,6 +2023,44 @@ test('formatCleanupBacklogExamples matches the pre-#2226 plain format when no nu
     formatCleanupBacklogExamples([100, 101], new Set()),
     '#100, #101',
   );
+});
+
+test('selectBacklogExamples preserves the plain slice when no bootstrap-era number exists', () => {
+  assert.deepEqual(
+    selectBacklogExamples([100, 101, 102, 103, 104, 105], new Set()),
+    [100, 101, 102, 103, 104],
+  );
+});
+
+test('selectBacklogExamples preserves the plain slice when a bootstrap-era number is already among it', () => {
+  assert.deepEqual(
+    selectBacklogExamples([100, 101, 102, 103, 104, 105], new Set([102])),
+    [100, 101, 102, 103, 104],
+  );
+});
+
+test('selectBacklogExamples swaps in a bootstrap-era number when the natural slice would show none (Copilot review, PR #2386)', () => {
+  // #110 is bootstrap-era but sits past the first-5 natural slice --
+  // without the fix, the warning's "(1 bootstrap-era)" count clause would
+  // pair with an Examples: list showing zero (bootstrap-era) tags.
+  const missing = [100, 101, 102, 103, 104, 110];
+  const bootstrapEra = new Set([110]);
+  const result = selectBacklogExamples(missing, bootstrapEra);
+  assert.equal(result.length, 5);
+  assert.ok(result.includes(110));
+  // Only the last natural entry is displaced -- the rest of the natural
+  // order is preserved.
+  assert.deepEqual(result.slice(0, 4), [100, 101, 102, 103]);
+});
+
+test('selectBacklogExamples respects a custom limit', () => {
+  const missing = [100, 101, 102, 110];
+  const bootstrapEra = new Set([110]);
+  assert.deepEqual(selectBacklogExamples(missing, bootstrapEra, 2), [100, 110]);
+});
+
+test('selectBacklogExamples returns an empty array for an empty missing list, even with a non-empty bootstrapEra', () => {
+  assert.deepEqual(selectBacklogExamples([], new Set([110])), []);
 });
 
 test('formatCleanupBacklogRemediation resolves the audit-pr-cleanup invocation per profile (idd-skill#1718)', () => {

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -59,6 +59,7 @@ import {
   parseLockfileImporterVersion,
   parsePrimaryWorktreePath,
   parseProjectCommandRows,
+  parseStrictCutoffToUtcMs,
   parseThresholdsProseHours,
   readCleanupEvidenceTrustedLogins,
   readTrustEmptyProtectionReads,
@@ -1905,6 +1906,58 @@ test('classifyBacklog coerces non-numeric / NaN / negative thresholds to 0', () 
   assert.equal(classifyBacklog([1], -5).warn, true);
   // Zero count must not warn even with a broken threshold.
   assert.equal(classifyBacklog([], NaN).warn, false);
+});
+
+test('parseStrictCutoffToUtcMs accepts a bare calendar date, anchored to UTC midnight (idd-skill#2226)', () => {
+  assert.equal(
+    parseStrictCutoffToUtcMs('2026-01-01'),
+    Date.parse('2026-01-01T00:00:00.000Z'),
+  );
+});
+
+test('parseStrictCutoffToUtcMs accepts a Z-suffixed ISO8601 timestamp, matching the equivalent bare date', () => {
+  assert.equal(
+    parseStrictCutoffToUtcMs('2026-01-01T00:00:00Z'),
+    parseStrictCutoffToUtcMs('2026-01-01'),
+  );
+});
+
+test('parseStrictCutoffToUtcMs rejects calendar overflow instead of silently rolling over (CodeRabbit review, PR #2386)', () => {
+  // Plain Date.parse('2026-02-30') resolves to March 2 -- confirmed
+  // empirically before this fix. The strict parser must reject it outright.
+  assert.equal(parseStrictCutoffToUtcMs('2026-02-30'), null);
+  assert.equal(parseStrictCutoffToUtcMs('2026-13-01'), null);
+});
+
+test('parseStrictCutoffToUtcMs rejects a timestamp with a time-of-day but no explicit UTC offset (host-timezone-dependent, CodeRabbit review)', () => {
+  // Plain Date.parse resolves this in the HOST's local time zone per the
+  // ECMA-262 Date Time String Format -- the same value would classify
+  // different PRs depending on which machine/CI runner evaluates it.
+  // Confirmed empirically: LA -> 2026-01-01T08:00:00.000Z, UTC ->
+  // 2026-01-01T00:00:00.000Z for the identical input string.
+  assert.equal(parseStrictCutoffToUtcMs('2026-01-01T00:00:00'), null);
+});
+
+test('parseStrictCutoffToUtcMs rejects garbage input and non-string values', () => {
+  assert.equal(parseStrictCutoffToUtcMs('not-a-date'), null);
+  assert.equal(parseStrictCutoffToUtcMs(undefined), null);
+  assert.equal(parseStrictCutoffToUtcMs(12345), null);
+});
+
+test('classifyBootstrapEraPrNumbers rejects a cutoff with calendar overflow (fail closed, CodeRabbit review)', () => {
+  const mergedAtByNumber = new Map([[100, '2025-01-01T00:00:00Z']]);
+  assert.deepEqual(
+    classifyBootstrapEraPrNumbers([100], mergedAtByNumber, '2026-02-30'),
+    new Set(),
+  );
+});
+
+test('classifyBootstrapEraPrNumbers rejects a mergedAt with a time-of-day but no UTC offset (fail closed, CodeRabbit review)', () => {
+  const mergedAtByNumber = new Map([[100, '2025-01-01T00:00:00']]);
+  assert.deepEqual(
+    classifyBootstrapEraPrNumbers([100], mergedAtByNumber, '2026-01-01'),
+    new Set(),
+  );
 });
 
 test('classifyBootstrapEraPrNumbers labels only PRs merged before the cutoff (idd-skill#2226)', () => {


### PR DESCRIPTION
## Summary

- Adds an optional `--cleanup-backlog-bootstrap-cutoff <date>` flag to `idd-doctor`'s post-merge cleanup backlog check. When configured, a flagged merged PR whose `mergedAt` predates the cutoff is labeled `(bootstrap-era)` in the `Examples: ...` clause instead of reading identically to a genuine claim-marker-missing PR.
- Presentation-only, per the issue's acceptance criteria: the flagged set, `count`, and `warn`/pass verdict are all computed from the unmodified `missing` list — the new logic only changes how the `Examples: ...` clause renders.
- `gh pr list --json` now also requests `mergedAt`; `filterIddBranchMergedPrs` carries it through (omitted, not `undefined`, when absent — existing fixtures/tests without it are byte-identical).
- Two new pure, independently-tested helpers: `classifyBootstrapEraPrNumbers` (fails closed to an empty set on an unparsable cutoff or a PR with no recorded `mergedAt`) and `formatCleanupBacklogExamples`.
- Absent the new flag (the default), every PR still reports the same undifferentiated way this check has always used — zero behavior change for anyone not opting in.

## Test plan

- [x] `pnpm run typecheck` / `pnpm run build` / `pnpm run build:check` (clean post-commit)
- [x] `node --test tests/*.test.mts` — 4353/4353 passing, including:
  - 6 new unit tests for `classifyBootstrapEraPrNumbers` / `formatCleanupBacklogExamples` (`tests/idd-doctor.test.mts`)
  - 1 new `filterIddBranchMergedPrs` test covering the `mergedAt` extension (valid / absent / empty / non-string)
  - 2 new end-to-end CLI smoke tests through the real compiled `scripts/idd-doctor.mjs` with a stubbed `gh` binary (`tests/idd-doctor-cleanup-backlog-cli-smoke.test.mts`): one proving the flag labels only the pre-cutoff PR without changing the count, one proving the no-flag case is unchanged
- [x] `biome check`, `dprint check "**/*.md"`, `markdownlint-cli2 "**/*.md"`, `cspell lint "**"` all clean
- [x] `node scripts/verify-workshop-integrity.mjs --format table` — 0 issues
- [x] `node scripts/audit-docs.mjs --check` — passes (only pre-existing bundle notices, untouched by this PR — no `.github/instructions/` files edited)

Refs #2226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional bootstrap cutoff date for cleanup-backlog reports.
  - Reports identify qualifying pre-cutoff pull requests as “bootstrap-era.”
  - Ensured bootstrap-era examples are displayed when applicable.
  - Added strict validation and help text for cutoff-date configuration.
  - Backlog counts and selection remain unchanged.

- **Bug Fixes**
  - Preserved valid merge timestamps and safely handled missing or invalid timestamps.

- **Tests**
  - Added coverage for cutoff classification, reporting labels, validation, example selection, and timestamp handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->