### PR TITLE
fix(protocol-helpers): flag a malformed review-watermark as distinct

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -29,6 +29,7 @@ export * from './marker-helpers.mjs';
 
 import { loadIddConfig } from './idd-config.mjs';
 import {
+  detectMalformedOperationalMarker,
   findActivationNonceWinner,
   IDD_AGENT_DERIVED_MARKERS,
   isIddOriginatedReply,
@@ -2648,6 +2649,29 @@ export function resolveLatestReviewWatermark(comments, options = {}) {
     }
   }
   return latest;
+}
+/**
+ * Scans the same trusted-author comment stream `resolveLatestReviewWatermark`
+ * consumes for a `review-watermark`/`review-baseline`-shaped comment whose
+ * body fails the strict canonical `pattern` (e.g. a hand-authored note glued
+ * directly to the leading underscore, `_IDD ...` with no space, missing
+ * `OPTIONAL_IDD_VISIBLE_NOTE_PATTERN`'s `\bIDD\b` boundary). Such a comment
+ * already reads as absent to `resolveLatestReviewWatermark` (#2251) -- this
+ * gives the F2 caller a way to tell "malformed marker found" apart from
+ * "no watermark-shaped comment at all" without changing
+ * `resolveLatestReviewWatermark`'s own return shape or selection behavior.
+ */
+export function detectMalformedReviewWatermarkComments(comments, options = {}) {
+  const isTrustedAuthor = options.isTrustedAuthor ?? (() => true);
+  return comments.some((comment) => {
+    if (!isTrustedAuthor(comment.author?.login ?? comment.user?.login ?? '')) {
+      return false;
+    }
+    const label = detectMalformedOperationalMarker(comment.body ?? '');
+    return (
+      label === '<!-- review-watermark:' || label === '<!-- review-baseline:'
+    );
+  });
 }
 // Pre-merge gate invariant (unreplied regular comments -> `unrepliedComments`):
 // does NOT feed `computePreMergeReadinessBlockers` (no code-rollup blocker), but
@@ -5343,14 +5367,15 @@ export function buildPreMergeReadinessSummary(
     effectiveMaxActivityUpdatedAt: liveSnapshot.effective?.maxActivityUpdatedAt,
     now,
   });
+  const isTrustedWatermarkAuthor = (login) =>
+    trustedMarkerLogins.includes(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
   const watermark = resolveLatestReviewWatermark(comments, {
     expectedClaimId: options.expectedClaimId,
-    isTrustedAuthor: (login) =>
-      trustedMarkerLogins.includes(
-        String(login ?? '')
-          .trim()
-          .toLowerCase(),
-      ),
+    isTrustedAuthor: isTrustedWatermarkAuthor,
   });
   const reviewCurrency = watermark
     ? diffReviewSnapshot(
@@ -5365,7 +5390,11 @@ export function buildPreMergeReadinessSummary(
           ...liveSnapshot,
         },
       )
-    : { route: 'return-to-e1', reason: 'missing-watermark' };
+    : detectMalformedReviewWatermarkComments(comments, {
+          isTrustedAuthor: isTrustedWatermarkAuthor,
+        })
+      ? { route: 'return-to-e1', reason: 'malformed-watermark' }
+      : { route: 'return-to-e1', reason: 'missing-watermark' };
   const threadSummary = summarizeReviewThreadsForGate(threads, {
     iddAgentLogins,
     prAuthorLogin,

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -2660,17 +2660,46 @@ export function resolveLatestReviewWatermark(comments, options = {}) {
  * gives the F2 caller a way to tell "malformed marker found" apart from
  * "no watermark-shaped comment at all" without changing
  * `resolveLatestReviewWatermark`'s own return shape or selection behavior.
+ *
+ * `options.expectedClaimId`, when set, restricts the scan to a malformed
+ * comment whose own claim-id token (the second token after the marker
+ * label -- both `review-watermark` and `review-baseline` share that
+ * position) matches, mirroring `resolveLatestReviewWatermark`'s own
+ * exact claim-id filtering (#2080). Without this, a different claim's
+ * malformed marker would flip `comparisonReason` to `'malformed-watermark'`
+ * for a claim whose watermark is simply, genuinely absent (#2251 review
+ * follow-up on PR #2387). The claim-id token is pulled directly from the
+ * raw body (not via the full canonical parser, since a malformed comment
+ * by definition fails that parse) -- both marker shapes' `malformedPrefixPattern`
+ * guarantee `\S+\s+\S+` (agent, then claim id) immediately after the label.
  */
+const MALFORMED_REVIEW_WATERMARK_CLAIM_ID_RE =
+  /^<!--\s*(?:review-watermark|review-baseline):\s+\S+\s+(\S+)/i;
 export function detectMalformedReviewWatermarkComments(comments, options = {}) {
   const isTrustedAuthor = options.isTrustedAuthor ?? (() => true);
+  const expectedClaimId = String(options.expectedClaimId ?? '').trim();
   return comments.some((comment) => {
     if (!isTrustedAuthor(comment.author?.login ?? comment.user?.login ?? '')) {
       return false;
     }
-    const label = detectMalformedOperationalMarker(comment.body ?? '');
-    return (
-      label === '<!-- review-watermark:' || label === '<!-- review-baseline:'
-    );
+    const body = comment.body ?? '';
+    const label = detectMalformedOperationalMarker(body);
+    if (
+      label !== '<!-- review-watermark:' &&
+      label !== '<!-- review-baseline:'
+    ) {
+      return false;
+    }
+    if (!expectedClaimId) {
+      return true;
+    }
+    // No trimStart: detectMalformedOperationalMarker already matched this
+    // body's raw (untrimmed) bytes against the label's `^`-anchored
+    // malformedPrefixPattern by this point (no leading-whitespace
+    // tolerance, by design -- see that pattern's anti-spoofing note), so
+    // matching raw `body` here stays consistent with that same anchor.
+    const claimId = body.match(MALFORMED_REVIEW_WATERMARK_CLAIM_ID_RE)?.[1];
+    return claimId === expectedClaimId;
   });
 }
 // Pre-merge gate invariant (unreplied regular comments -> `unrepliedComments`):
@@ -5392,6 +5421,7 @@ export function buildPreMergeReadinessSummary(
       )
     : detectMalformedReviewWatermarkComments(comments, {
           isTrustedAuthor: isTrustedWatermarkAuthor,
+          expectedClaimId: options.expectedClaimId,
         })
       ? { route: 'return-to-e1', reason: 'malformed-watermark' }
       : { route: 'return-to-e1', reason: 'missing-watermark' };

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -36,6 +36,7 @@ import type {
   ParsedReviewWatermark,
 } from './marker-helpers.mts';
 import {
+  detectMalformedOperationalMarker,
   findActivationNonceWinner,
   IDD_AGENT_DERIVED_MARKERS,
   isIddOriginatedReply,
@@ -3592,6 +3593,33 @@ export function resolveLatestReviewWatermark(
   return latest;
 }
 
+/**
+ * Scans the same trusted-author comment stream `resolveLatestReviewWatermark`
+ * consumes for a `review-watermark`/`review-baseline`-shaped comment whose
+ * body fails the strict canonical `pattern` (e.g. a hand-authored note glued
+ * directly to the leading underscore, `_IDD ...` with no space, missing
+ * `OPTIONAL_IDD_VISIBLE_NOTE_PATTERN`'s `\bIDD\b` boundary). Such a comment
+ * already reads as absent to `resolveLatestReviewWatermark` (#2251) -- this
+ * gives the F2 caller a way to tell "malformed marker found" apart from
+ * "no watermark-shaped comment at all" without changing
+ * `resolveLatestReviewWatermark`'s own return shape or selection behavior.
+ */
+export function detectMalformedReviewWatermarkComments(
+  comments: CommentLike[],
+  options: { isTrustedAuthor?: (login: string) => boolean } = {},
+): boolean {
+  const isTrustedAuthor = options.isTrustedAuthor ?? (() => true);
+  return comments.some((comment) => {
+    if (!isTrustedAuthor(comment.author?.login ?? comment.user?.login ?? '')) {
+      return false;
+    }
+    const label = detectMalformedOperationalMarker(comment.body ?? '');
+    return (
+      label === '<!-- review-watermark:' || label === '<!-- review-baseline:'
+    );
+  });
+}
+
 // Pre-merge gate invariant (unreplied regular comments -> `unrepliedComments`):
 // does NOT feed `computePreMergeReadinessBlockers` (no code-rollup blocker), but
 // it is NOT harmless -- the written F2 gate "Unreplied comments = 0" in
@@ -6901,14 +6929,15 @@ export function buildPreMergeReadinessSummary(
     effectiveMaxActivityUpdatedAt: liveSnapshot.effective?.maxActivityUpdatedAt,
     now,
   });
+  const isTrustedWatermarkAuthor = (login: string) =>
+    trustedMarkerLogins.includes(
+      String(login ?? '')
+        .trim()
+        .toLowerCase(),
+    );
   const watermark = resolveLatestReviewWatermark(comments, {
     expectedClaimId: options.expectedClaimId,
-    isTrustedAuthor: (login: string) =>
-      trustedMarkerLogins.includes(
-        String(login ?? '')
-          .trim()
-          .toLowerCase(),
-      ),
+    isTrustedAuthor: isTrustedWatermarkAuthor,
   });
   const reviewCurrency = watermark
     ? diffReviewSnapshot(
@@ -6923,7 +6952,11 @@ export function buildPreMergeReadinessSummary(
           ...liveSnapshot,
         },
       )
-    : { route: 'return-to-e1', reason: 'missing-watermark' };
+    : detectMalformedReviewWatermarkComments(comments, {
+          isTrustedAuthor: isTrustedWatermarkAuthor,
+        })
+      ? { route: 'return-to-e1', reason: 'malformed-watermark' }
+      : { route: 'return-to-e1', reason: 'missing-watermark' };
   const threadSummary = summarizeReviewThreadsForGate(threads, {
     iddAgentLogins,
     prAuthorLogin,

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -3603,20 +3603,53 @@ export function resolveLatestReviewWatermark(
  * gives the F2 caller a way to tell "malformed marker found" apart from
  * "no watermark-shaped comment at all" without changing
  * `resolveLatestReviewWatermark`'s own return shape or selection behavior.
+ *
+ * `options.expectedClaimId`, when set, restricts the scan to a malformed
+ * comment whose own claim-id token (the second token after the marker
+ * label -- both `review-watermark` and `review-baseline` share that
+ * position) matches, mirroring `resolveLatestReviewWatermark`'s own
+ * exact claim-id filtering (#2080). Without this, a different claim's
+ * malformed marker would flip `comparisonReason` to `'malformed-watermark'`
+ * for a claim whose watermark is simply, genuinely absent (#2251 review
+ * follow-up on PR #2387). The claim-id token is pulled directly from the
+ * raw body (not via the full canonical parser, since a malformed comment
+ * by definition fails that parse) -- both marker shapes' `malformedPrefixPattern`
+ * guarantee `\S+\s+\S+` (agent, then claim id) immediately after the label.
  */
+const MALFORMED_REVIEW_WATERMARK_CLAIM_ID_RE =
+  /^<!--\s*(?:review-watermark|review-baseline):\s+\S+\s+(\S+)/i;
+
 export function detectMalformedReviewWatermarkComments(
   comments: CommentLike[],
-  options: { isTrustedAuthor?: (login: string) => boolean } = {},
+  options: {
+    isTrustedAuthor?: (login: string) => boolean;
+    expectedClaimId?: unknown;
+  } = {},
 ): boolean {
   const isTrustedAuthor = options.isTrustedAuthor ?? (() => true);
+  const expectedClaimId = String(options.expectedClaimId ?? '').trim();
   return comments.some((comment) => {
     if (!isTrustedAuthor(comment.author?.login ?? comment.user?.login ?? '')) {
       return false;
     }
-    const label = detectMalformedOperationalMarker(comment.body ?? '');
-    return (
-      label === '<!-- review-watermark:' || label === '<!-- review-baseline:'
-    );
+    const body = comment.body ?? '';
+    const label = detectMalformedOperationalMarker(body);
+    if (
+      label !== '<!-- review-watermark:' &&
+      label !== '<!-- review-baseline:'
+    ) {
+      return false;
+    }
+    if (!expectedClaimId) {
+      return true;
+    }
+    // No trimStart: detectMalformedOperationalMarker already matched this
+    // body's raw (untrimmed) bytes against the label's `^`-anchored
+    // malformedPrefixPattern by this point (no leading-whitespace
+    // tolerance, by design -- see that pattern's anti-spoofing note), so
+    // matching raw `body` here stays consistent with that same anchor.
+    const claimId = body.match(MALFORMED_REVIEW_WATERMARK_CLAIM_ID_RE)?.[1];
+    return claimId === expectedClaimId;
   });
 }
 
@@ -6954,6 +6987,7 @@ export function buildPreMergeReadinessSummary(
       )
     : detectMalformedReviewWatermarkComments(comments, {
           isTrustedAuthor: isTrustedWatermarkAuthor,
+          expectedClaimId: options.expectedClaimId,
         })
       ? { route: 'return-to-e1', reason: 'malformed-watermark' }
       : { route: 'return-to-e1', reason: 'missing-watermark' };

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -692,6 +692,42 @@ test('buildPreMergeReadinessSummary: primaryBotLogin is excluded from human appr
   assert.equal(reviewerStates.codeownerApprovalSatisfied, false);
 });
 
+// #2251 (Copilot review follow-up on PR #2387): detectMalformedReviewWatermarkComments
+// has its own unit coverage in review-gate.test.mts, but nothing previously
+// exercised buildPreMergeReadinessSummary's end-to-end wiring of it into
+// reviewCurrency.comparisonReason -- a future refactor could silently break
+// that wiring without a red test. This proves a review-watermark-shaped
+// comment whose note is glued directly to the leading underscore (`_IDD ...`,
+// no space, missing OPTIONAL_IDD_VISIBLE_NOTE_PATTERN's `\bIDD\b` boundary)
+// surfaces as 'malformed-watermark', not the generic 'missing-watermark'.
+test('buildPreMergeReadinessSummary: a malformed review-watermark comment surfaces a distinct comparisonReason', () => {
+  const prHeadSha = '7777777777777777777777777777777777777777';
+  const summary = buildPreMergeReadinessSummary(
+    {
+      prHeadSha,
+      comments: [
+        {
+          author: { login: 'kurone-kito' },
+          body: [
+            `<!-- review-watermark: claude-x claim-1 ${prHeadSha} none 0 none -->`,
+            '_IDD note glued directly to the leading underscore, no space before it_',
+          ].join('\n'),
+          createdAt: '2026-08-02T00:00:00Z',
+        },
+      ],
+    },
+    {
+      now: '2026-08-02T00:05:00Z',
+      trustedMarkerLogins: ['kurone-kito'],
+      expectedClaimId: 'claim-1',
+    },
+  );
+
+  const reviewCurrency = summary.reviewCurrency as Record<string, unknown>;
+  assert.equal(reviewCurrency.comparisonRoute, 'return-to-e1');
+  assert.equal(reviewCurrency.comparisonReason, 'malformed-watermark');
+});
+
 test('buildPreMergeReadinessSummary: primaryBotLogin CHANGES_REQUESTED does not block via reviewer-approval counting', () => {
   const prHeadSha = '5555555555555555555555555555555555555555';
   const customBotLogin = 'my-custom-review-bot[bot]';

--- a/tests/review-gate.test.mts
+++ b/tests/review-gate.test.mts
@@ -165,6 +165,44 @@ test('detects a review-watermark comment whose note is glued to the leading unde
   );
 });
 
+// #2251 (Copilot review follow-up on PR #2387): resolveLatestReviewWatermark
+// filters by options.expectedClaimId, but the malformed-marker fallback
+// initially had no equivalent filter -- a different claim's malformed
+// review-watermark/review-baseline comment would flip comparisonReason to
+// 'malformed-watermark' even though the *expected* claim's watermark is
+// simply, genuinely absent.
+test('a malformed review-watermark comment scoped to a different claim id does not count against the expected claim', () => {
+  const gluedNoteBody = [
+    `<!-- review-watermark: claude-x other-claim ${'a'.repeat(40)} none 0 none -->`,
+    '_IDD note glued directly to the leading underscore, no space before it_',
+  ].join('\n');
+  const comments = [
+    {
+      author: { login: 'claude-x' },
+      body: gluedNoteBody,
+      createdAt: '2026-05-10T00:00:00Z',
+    },
+  ];
+
+  assert.equal(
+    detectMalformedReviewWatermarkComments(comments, {
+      isTrustedAuthor: () => true,
+      expectedClaimId: 'claim-1',
+    }),
+    false,
+    "a different claim's malformed marker must not mask a genuinely missing watermark for the expected claim",
+  );
+  // Sanity check: the same malformed comment DOES count for its own claim.
+  assert.equal(
+    detectMalformedReviewWatermarkComments(comments, {
+      isTrustedAuthor: () => true,
+      expectedClaimId: 'other-claim',
+    }),
+    true,
+    'the expectedClaimId filter must still recognize a matching malformed comment',
+  );
+});
+
 test('does not flag a genuinely valid review-watermark comment as malformed', () => {
   const validBody = `<!-- review-watermark: claude-x claim-1 ${'a'.repeat(40)} none 0 none -->`;
   const comments = [

--- a/tests/review-gate.test.mts
+++ b/tests/review-gate.test.mts
@@ -3,6 +3,7 @@ import { test } from 'node:test';
 
 import {
   classifyReviewThreadForGate,
+  detectMalformedReviewWatermarkComments,
   diffReviewSnapshot,
   resolveLatestReviewWatermark,
   routeRejectedChangesRequestedReview,
@@ -120,4 +121,93 @@ test('classifies unresolved threads for awaiting-reviewer and conversation-resol
       );
     }
   }
+});
+
+// #2251: a review-watermark/review-baseline-shaped comment that fails the
+// strict canonical `pattern` already reads as absent to
+// resolveLatestReviewWatermark (its own `parseReviewWatermarkComment` call
+// returns null and the loop `continue`s past it) -- these three cases prove
+// detectMalformedReviewWatermarkComments lets a caller tell "malformed
+// marker found" apart from "no watermark-shaped comment at all" without
+// resolveLatestReviewWatermark's own selection behavior changing.
+test('detects a review-watermark comment whose note is glued to the leading underscore as malformed, not absent', () => {
+  // OPTIONAL_IDD_VISIBLE_NOTE_PATTERN requires `\bIDD\b`; `_` is a \w
+  // character, so a note glued directly to the underscore with no space
+  // (`_IDD ...`) never satisfies the boundary and the whole body fails the
+  // canonical `pattern` even though its marker prefix is well-formed.
+  const gluedNoteBody = [
+    `<!-- review-watermark: claude-x claim-1 ${'a'.repeat(40)} none 0 none -->`,
+    '_IDD note glued directly to the leading underscore, no space before it_',
+  ].join('\n');
+  const comments = [
+    {
+      author: { login: 'claude-x' },
+      body: gluedNoteBody,
+      createdAt: '2026-05-10T00:00:00Z',
+    },
+  ];
+
+  const watermark = resolveLatestReviewWatermark(comments, {
+    expectedClaimId: 'claim-1',
+    isTrustedAuthor: () => true,
+  });
+  assert.equal(
+    watermark,
+    null,
+    'a malformed watermark comment must not parse as a valid watermark',
+  );
+  assert.equal(
+    detectMalformedReviewWatermarkComments(comments, {
+      isTrustedAuthor: () => true,
+    }),
+    true,
+    'the malformed marker must be distinguishable from a genuinely absent one',
+  );
+});
+
+test('does not flag a genuinely valid review-watermark comment as malformed', () => {
+  const validBody = `<!-- review-watermark: claude-x claim-1 ${'a'.repeat(40)} none 0 none -->`;
+  const comments = [
+    {
+      author: { login: 'claude-x' },
+      body: validBody,
+      createdAt: '2026-05-10T00:00:00Z',
+    },
+  ];
+
+  const watermark = resolveLatestReviewWatermark(comments, {
+    expectedClaimId: 'claim-1',
+    isTrustedAuthor: () => true,
+  });
+  assert.ok(watermark, 'a well-formed watermark must still parse as before');
+  assert.equal(
+    detectMalformedReviewWatermarkComments(comments, {
+      isTrustedAuthor: () => true,
+    }),
+    false,
+    'a valid watermark comment must never be reported as malformed',
+  );
+});
+
+test('reports no malformed marker when no watermark-shaped comment exists at all', () => {
+  const comments = [
+    {
+      author: { login: 'claude-x' },
+      body: 'just an ordinary regular comment, not marker-shaped at all',
+      createdAt: '2026-05-10T00:00:00Z',
+    },
+  ];
+
+  const watermark = resolveLatestReviewWatermark(comments, {
+    expectedClaimId: 'claim-1',
+    isTrustedAuthor: () => true,
+  });
+  assert.equal(watermark, null);
+  assert.equal(
+    detectMalformedReviewWatermarkComments(comments, {
+      isTrustedAuthor: () => true,
+    }),
+    false,
+    'a genuinely absent watermark must stay distinct from a malformed one',
+  );
 });


### PR DESCRIPTION
## Summary

`resolveLatestReviewWatermark` silently skips a `review-watermark`/
`review-baseline`-shaped comment whose body fails the strict canonical
`pattern` (e.g. a hand-authored note glued directly to the leading
underscore, `_IDD ...` with no space, missing the `\bIDD\b` word
boundary), falling back to a stale or absent watermark with no
diagnostic distinguishing "malformed marker found" from "no watermark
at all" — the F2 verdict looked identical either way.

Adds `detectMalformedReviewWatermarkComments`, which reuses the
already-implemented `detectMalformedOperationalMarker` to scan the
same trusted-author comment stream for a malformed `review-watermark`/
`review-baseline` comment. Wires it into the F2 review-currency
assembly: when no valid watermark resolves, reports a distinct
`reason: 'malformed-watermark'` instead of `'missing-watermark'` when
one is found. `resolveLatestReviewWatermark`'s own selection behavior
and return shape are unchanged.

## Test plan

- [x] `node --test tests/review-gate.test.mts` — 7/7 pass (3 new:
      malformed-marker, valid-watermark, genuinely-absent)
- [x] `node --test tests/protocol-helpers.test.mts
      tests/pre-merge-readiness.test.mts` — 321/321 pass, no
      regressions
- [x] `pnpm run typecheck` clean
- [x] `pnpm run build:check` clean

Closes #2251


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review readiness reporting to distinguish malformed watermark comments from completely missing watermarks.
  * Malformed trusted review markers now produce a specific diagnostic and the appropriate comparison route.
  * Valid watermark resolution remains unchanged, while malformed markers continue to be rejected.

* **Tests**
  * Added coverage for malformed, valid, and ordinary comments.
  * Added end-to-end regression coverage for pre-merge readiness behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->