### PR TITLE
feat(suitability-triage): broaden autonomy-check coordination-language matcher

### DIFF
--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -263,8 +263,35 @@ const UNRESOLVED_CHOICE_PATTERN = new RegExp(
 // un-negated UNRESOLVED_CHOICE_PATTERN match nearby (see checkAutonomy) --
 // the either/or structure alone also describes an ordinary AC offering two
 // already-resolved, equivalent options, which must keep passing.
-const EITHER_OR_PATTERN = /\beither\b[\s\S]{0,120}?\bor\b/gi;
 const EITHER_OR_PROXIMITY_WINDOW_CHARS = 120;
+const EITHER_OR_PATTERN = new RegExp(
+  `\\beither\\b[\\s\\S]{0,${EITHER_OR_PROXIMITY_WINDOW_CHARS}}?\\bor\\b`,
+  'gi',
+);
+// Window checkAutonomy's negation checks scan on either side of a match --
+// shared by the coordination-language, unresolved-choice, and either/or
+// marker checks via isNegatedNearby below.
+const NEGATION_WINDOW_CHARS = 60;
+/**
+ * True when a negation word (NEGATION_PATTERN) appears within
+ * `windowChars` immediately before or after `matchText` at `matchIndex`
+ * in `body` -- e.g. "no longer TBD" negates a "TBD" match rather than
+ * confirming it. Used by checkAutonomy's coordination-language,
+ * unresolved-choice, and either/or marker checks (#2219).
+ */
+function isNegatedNearby(body, matchText, matchIndex, windowChars) {
+  const contextBefore = body.slice(
+    Math.max(0, matchIndex - windowChars),
+    matchIndex,
+  );
+  const contextAfter = body.slice(
+    matchIndex + matchText.length,
+    Math.min(body.length, matchIndex + matchText.length + windowChars),
+  );
+  return (
+    NEGATION_PATTERN.test(contextBefore) || NEGATION_PATTERN.test(contextAfter)
+  );
+}
 const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 // A heading line such as "## Decision (resolved 2026-06-27)" records that a
 // human has already ruled on the issue's open question (see Check 7). The
@@ -1056,6 +1083,57 @@ export function checkAutonomy(context) {
       };
     }
   }
+  // #2219: an either/or acceptance-criterion shape naming two mutually
+  // exclusive implementation paths without saying which one to take.
+  // Checked before the general coordination-language matches below: an
+  // unresolved-choice marker (see UNRESOLVED_CHOICE_PATTERN) always also
+  // matches that broader check, so checking either/or first is what makes
+  // this variant's own evidence message reachable rather than always
+  // pre-empted by the broader match on the same marker. Requires an
+  // un-negated marker touching or within EITHER_OR_PROXIMITY_WINDOW_CHARS
+  // of the either/or span -- an ordinary AC offering two already-resolved,
+  // equivalent options must keep passing, including when a resolved
+  // statement nearby happens to mention a marker word in its own negated
+  // form (e.g. "this is no longer TBD").
+  const eitherOrMatches = [...body.matchAll(EITHER_OR_PATTERN)];
+  if (eitherOrMatches.length > 0) {
+    for (const marker of body.matchAll(UNRESOLVED_CHOICE_PATTERN)) {
+      const markerText = marker[0] ?? '';
+      const markerIndex = marker.index ?? 0;
+      if (
+        isNegatedNearby(body, markerText, markerIndex, NEGATION_WINDOW_CHARS)
+      ) {
+        continue;
+      }
+      const markerEnd = markerIndex + markerText.length;
+      const isNearOrInsideEitherOr = eitherOrMatches.some((eitherOr) => {
+        const eitherOrText = eitherOr[0] ?? '';
+        const eitherOrIndex = eitherOr.index ?? 0;
+        const eitherOrEnd = eitherOrIndex + eitherOrText.length;
+        if (markerIndex < eitherOrEnd && markerEnd > eitherOrIndex) {
+          // The marker overlaps the either/or span itself (e.g. "either
+          // TBD ... or ...").
+          return true;
+        }
+        const gapAfterEitherOr = markerIndex - eitherOrEnd;
+        const gapBeforeEitherOr = eitherOrIndex - markerEnd;
+        return (
+          (gapAfterEitherOr >= 0 &&
+            gapAfterEitherOr <= EITHER_OR_PROXIMITY_WINDOW_CHARS) ||
+          (gapBeforeEitherOr >= 0 &&
+            gapBeforeEitherOr <= EITHER_OR_PROXIMITY_WINDOW_CHARS)
+        );
+      });
+      if (!isNearOrInsideEitherOr) {
+        continue;
+      }
+      return {
+        pass: false,
+        evidence:
+          'Issue presents an unresolved either/or implementation choice.',
+      };
+    }
+  }
   // Negation-aware parsing for external coordination and human decision requirements
   const coordinationMatches = [
     ...body.matchAll(
@@ -1064,21 +1142,11 @@ export function checkAutonomy(context) {
     ...body.matchAll(
       /\bstakeholder\b[\s\S]{0,80}\b(sign-?off|approval|decision)\b/gi,
     ),
-    ...body.matchAll(UNRESOLVED_CHOICE_PATTERN),
   ];
   for (const match of coordinationMatches) {
     const matchedText = match[0] ?? '';
     const matchIndex = match.index ?? 0;
-    const contextBefore = body.slice(Math.max(0, matchIndex - 60), matchIndex);
-    const contextAfter = body.slice(
-      matchIndex + matchedText.length,
-      Math.min(body.length, matchIndex + matchedText.length + 60),
-    );
-    // Check if negated (either before or immediately after)
-    if (
-      NEGATION_PATTERN.test(contextBefore) ||
-      NEGATION_PATTERN.test(contextAfter)
-    ) {
+    if (isNegatedNearby(body, matchedText, matchIndex, NEGATION_WINDOW_CHARS)) {
       // This is a negated non-requirement; skip this match
       continue;
     }
@@ -1088,56 +1156,19 @@ export function checkAutonomy(context) {
         'Issue explicitly requires external human coordination or approval.',
     };
   }
-  // #2219: an either/or acceptance-criterion shape naming two mutually
-  // exclusive implementation paths without saying which one to take.
-  // Requires an un-negated unresolved-choice marker nearby, not the
-  // either/or structure alone -- an ordinary AC offering two
-  // already-resolved, equivalent options must keep passing, including
-  // when a resolved statement nearby happens to mention a marker word in
-  // its own negated form (e.g. "this is no longer TBD").
-  const eitherOrMatches = [...body.matchAll(EITHER_OR_PATTERN)];
-  if (eitherOrMatches.length > 0) {
-    for (const marker of body.matchAll(UNRESOLVED_CHOICE_PATTERN)) {
-      const markerText = marker[0] ?? '';
-      const markerIndex = marker.index ?? 0;
-      const markerContextBefore = body.slice(
-        Math.max(0, markerIndex - 60),
-        markerIndex,
-      );
-      const markerContextAfter = body.slice(
-        markerIndex + markerText.length,
-        Math.min(body.length, markerIndex + markerText.length + 60),
-      );
-      if (
-        NEGATION_PATTERN.test(markerContextBefore) ||
-        NEGATION_PATTERN.test(markerContextAfter)
-      ) {
-        // This marker is itself negated (resolved), e.g. "no longer TBD".
-        continue;
-      }
-      const isNearEitherOr = eitherOrMatches.some((eitherOr) => {
-        const eitherOrText = eitherOr[0] ?? '';
-        const eitherOrIndex = eitherOr.index ?? 0;
-        const gapAfterEitherOr =
-          markerIndex - (eitherOrIndex + eitherOrText.length);
-        const gapBeforeEitherOr =
-          eitherOrIndex - (markerIndex + markerText.length);
-        return (
-          (gapAfterEitherOr >= 0 &&
-            gapAfterEitherOr <= EITHER_OR_PROXIMITY_WINDOW_CHARS) ||
-          (gapBeforeEitherOr >= 0 &&
-            gapBeforeEitherOr <= EITHER_OR_PROXIMITY_WINDOW_CHARS)
-        );
-      });
-      if (!isNearEitherOr) {
-        continue;
-      }
-      return {
-        pass: false,
-        evidence:
-          'Issue presents an unresolved either/or implementation choice.',
-      };
+  // #2219: a nearby-word unresolved-choice phrasing beyond the two fixed
+  // templates above -- TBD, to be determined, pending a decision, an open
+  // question for the maintainer, and similar (see UNRESOLVED_CHOICE_SOURCE).
+  for (const marker of body.matchAll(UNRESOLVED_CHOICE_PATTERN)) {
+    const markerText = marker[0] ?? '';
+    const markerIndex = marker.index ?? 0;
+    if (isNegatedNearby(body, markerText, markerIndex, NEGATION_WINDOW_CHARS)) {
+      continue;
     }
+    return {
+      pass: false,
+      evidence: 'Issue names an unresolved product or design choice.',
+    };
   }
   return {
     pass: true,

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -1085,16 +1085,16 @@ export function checkAutonomy(context) {
   }
   // #2219: an either/or acceptance-criterion shape naming two mutually
   // exclusive implementation paths without saying which one to take.
-  // Checked before the general coordination-language matches below: an
-  // unresolved-choice marker (see UNRESOLVED_CHOICE_PATTERN) always also
-  // matches that broader check, so checking either/or first is what makes
-  // this variant's own evidence message reachable rather than always
-  // pre-empted by the broader match on the same marker. Requires an
-  // un-negated marker touching or within EITHER_OR_PROXIMITY_WINDOW_CHARS
-  // of the either/or span -- an ordinary AC offering two already-resolved,
-  // equivalent options must keep passing, including when a resolved
-  // statement nearby happens to mention a marker word in its own negated
-  // form (e.g. "this is no longer TBD").
+  // Checked before the standalone unresolved-choice scan further below:
+  // both checks match against the same UNRESOLVED_CHOICE_PATTERN markers,
+  // so checking either/or first is what makes this variant's own evidence
+  // message reachable rather than always pre-empted by that later, more
+  // generic match on the same marker. Requires an un-negated marker
+  // touching or within EITHER_OR_PROXIMITY_WINDOW_CHARS of the either/or
+  // span -- an ordinary AC offering two already-resolved, equivalent
+  // options must keep passing, including when a resolved statement nearby
+  // happens to mention a marker word in its own negated form (e.g. "this
+  // is no longer TBD").
   const eitherOrMatches = [...body.matchAll(EITHER_OR_PATTERN)];
   if (eitherOrMatches.length > 0) {
     for (const marker of body.matchAll(UNRESOLVED_CHOICE_PATTERN)) {

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -243,6 +243,35 @@ const POLICY_OVERRIDE_NOUN_PATTERN = new RegExp(
   `\\b(${POLICY_OVERRIDE_NOUN_SOURCE})\\b`,
   'i',
 );
+// #2219: broadens checkAutonomy's coordination-language matcher beyond its two
+// original fixed templates (requires .../stakeholder ... sign-off) to catch
+// equally natural phrasings for the same unresolved human-coordination
+// dependency -- reported by an adopter as passing checkAutonomy under
+// different wording. Deliberately excludes a bare "unresolved" alternative:
+// this repository's own instruction files use that word constantly for
+// unrelated concepts (unresolved review threads, unresolved roadmap
+// descendants), so only the multi-word "unresolved decision/question/choice"
+// phrasing is included.
+const UNRESOLVED_CHOICE_SOURCE =
+  '(?:TBD|to be determined|still undecided|undecided|not (?:yet )?decided|unresolved (?:decision|question|choice)|pending (?:a |the )?(?:decision|approval)|open question(?:s)? for (?:the )?(?:maintainer|team|stakeholders?)|awaiting (?:a |the )?(?:decision|approval|input)|maintainer (?:to |must |needs to )?(?:decide|choose))';
+const UNRESOLVED_CHOICE_PATTERN = new RegExp(
+  `\\b${UNRESOLVED_CHOICE_SOURCE}\\b`,
+  'gi',
+);
+// Non-global sibling for proximity `.test()` calls below -- a global regex's
+// `.test()` advances `lastIndex` across calls, which would silently skip
+// matches on a second or later either/or span in the same body.
+const UNRESOLVED_CHOICE_PROXIMITY_PATTERN = new RegExp(
+  `\\b${UNRESOLVED_CHOICE_SOURCE}\\b`,
+  'i',
+);
+// #2219: an either/or acceptance-criterion shape naming two mutually
+// exclusive implementation paths. Only flagged together with
+// UNRESOLVED_CHOICE_PROXIMITY_PATTERN nearby (see checkAutonomy) -- the
+// either/or structure alone also describes an ordinary AC offering two
+// already-resolved, equivalent options, which must keep passing.
+const EITHER_OR_PATTERN = /\beither\b[\s\S]{0,120}?\bor\b/gi;
+const EITHER_OR_PROXIMITY_WINDOW_CHARS = 120;
 const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 // A heading line such as "## Decision (resolved 2026-06-27)" records that a
 // human has already ruled on the issue's open question (see Check 7). The
@@ -1042,6 +1071,7 @@ export function checkAutonomy(context) {
     ...body.matchAll(
       /\bstakeholder\b[\s\S]{0,80}\b(sign-?off|approval|decision)\b/gi,
     ),
+    ...body.matchAll(UNRESOLVED_CHOICE_PATTERN),
   ];
   for (const match of coordinationMatches) {
     const matchedText = match[0] ?? '';
@@ -1063,6 +1093,36 @@ export function checkAutonomy(context) {
       pass: false,
       evidence:
         'Issue explicitly requires external human coordination or approval.',
+    };
+  }
+  // #2219: an either/or acceptance-criterion shape naming two mutually
+  // exclusive implementation paths without saying which one to take.
+  // Requires an unresolved-choice marker nearby, not the either/or
+  // structure alone -- an ordinary AC offering two already-resolved,
+  // equivalent options must keep passing.
+  for (const match of body.matchAll(EITHER_OR_PATTERN)) {
+    const matchedText = match[0] ?? '';
+    const matchIndex = match.index ?? 0;
+    const contextBefore = body.slice(
+      Math.max(0, matchIndex - EITHER_OR_PROXIMITY_WINDOW_CHARS),
+      matchIndex,
+    );
+    const contextAfter = body.slice(
+      matchIndex + matchedText.length,
+      Math.min(
+        body.length,
+        matchIndex + matchedText.length + EITHER_OR_PROXIMITY_WINDOW_CHARS,
+      ),
+    );
+    if (
+      !UNRESOLVED_CHOICE_PROXIMITY_PATTERN.test(contextBefore) &&
+      !UNRESOLVED_CHOICE_PROXIMITY_PATTERN.test(contextAfter)
+    ) {
+      continue;
+    }
+    return {
+      pass: false,
+      evidence: 'Issue presents an unresolved either/or implementation choice.',
     };
   }
   return {

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -258,17 +258,10 @@ const UNRESOLVED_CHOICE_PATTERN = new RegExp(
   `\\b${UNRESOLVED_CHOICE_SOURCE}\\b`,
   'gi',
 );
-// Non-global sibling for proximity `.test()` calls below -- a global regex's
-// `.test()` advances `lastIndex` across calls, which would silently skip
-// matches on a second or later either/or span in the same body.
-const UNRESOLVED_CHOICE_PROXIMITY_PATTERN = new RegExp(
-  `\\b${UNRESOLVED_CHOICE_SOURCE}\\b`,
-  'i',
-);
 // #2219: an either/or acceptance-criterion shape naming two mutually
-// exclusive implementation paths. Only flagged together with
-// UNRESOLVED_CHOICE_PROXIMITY_PATTERN nearby (see checkAutonomy) -- the
-// either/or structure alone also describes an ordinary AC offering two
+// exclusive implementation paths. Only flagged together with an
+// un-negated UNRESOLVED_CHOICE_PATTERN match nearby (see checkAutonomy) --
+// the either/or structure alone also describes an ordinary AC offering two
 // already-resolved, equivalent options, which must keep passing.
 const EITHER_OR_PATTERN = /\beither\b[\s\S]{0,120}?\bor\b/gi;
 const EITHER_OR_PROXIMITY_WINDOW_CHARS = 120;
@@ -1097,33 +1090,54 @@ export function checkAutonomy(context) {
   }
   // #2219: an either/or acceptance-criterion shape naming two mutually
   // exclusive implementation paths without saying which one to take.
-  // Requires an unresolved-choice marker nearby, not the either/or
-  // structure alone -- an ordinary AC offering two already-resolved,
-  // equivalent options must keep passing.
-  for (const match of body.matchAll(EITHER_OR_PATTERN)) {
-    const matchedText = match[0] ?? '';
-    const matchIndex = match.index ?? 0;
-    const contextBefore = body.slice(
-      Math.max(0, matchIndex - EITHER_OR_PROXIMITY_WINDOW_CHARS),
-      matchIndex,
-    );
-    const contextAfter = body.slice(
-      matchIndex + matchedText.length,
-      Math.min(
-        body.length,
-        matchIndex + matchedText.length + EITHER_OR_PROXIMITY_WINDOW_CHARS,
-      ),
-    );
-    if (
-      !UNRESOLVED_CHOICE_PROXIMITY_PATTERN.test(contextBefore) &&
-      !UNRESOLVED_CHOICE_PROXIMITY_PATTERN.test(contextAfter)
-    ) {
-      continue;
+  // Requires an un-negated unresolved-choice marker nearby, not the
+  // either/or structure alone -- an ordinary AC offering two
+  // already-resolved, equivalent options must keep passing, including
+  // when a resolved statement nearby happens to mention a marker word in
+  // its own negated form (e.g. "this is no longer TBD").
+  const eitherOrMatches = [...body.matchAll(EITHER_OR_PATTERN)];
+  if (eitherOrMatches.length > 0) {
+    for (const marker of body.matchAll(UNRESOLVED_CHOICE_PATTERN)) {
+      const markerText = marker[0] ?? '';
+      const markerIndex = marker.index ?? 0;
+      const markerContextBefore = body.slice(
+        Math.max(0, markerIndex - 60),
+        markerIndex,
+      );
+      const markerContextAfter = body.slice(
+        markerIndex + markerText.length,
+        Math.min(body.length, markerIndex + markerText.length + 60),
+      );
+      if (
+        NEGATION_PATTERN.test(markerContextBefore) ||
+        NEGATION_PATTERN.test(markerContextAfter)
+      ) {
+        // This marker is itself negated (resolved), e.g. "no longer TBD".
+        continue;
+      }
+      const isNearEitherOr = eitherOrMatches.some((eitherOr) => {
+        const eitherOrText = eitherOr[0] ?? '';
+        const eitherOrIndex = eitherOr.index ?? 0;
+        const gapAfterEitherOr =
+          markerIndex - (eitherOrIndex + eitherOrText.length);
+        const gapBeforeEitherOr =
+          eitherOrIndex - (markerIndex + markerText.length);
+        return (
+          (gapAfterEitherOr >= 0 &&
+            gapAfterEitherOr <= EITHER_OR_PROXIMITY_WINDOW_CHARS) ||
+          (gapBeforeEitherOr >= 0 &&
+            gapBeforeEitherOr <= EITHER_OR_PROXIMITY_WINDOW_CHARS)
+        );
+      });
+      if (!isNearEitherOr) {
+        continue;
+      }
+      return {
+        pass: false,
+        evidence:
+          'Issue presents an unresolved either/or implementation choice.',
+      };
     }
-    return {
-      pass: false,
-      evidence: 'Issue presents an unresolved either/or implementation choice.',
-    };
   }
   return {
     pass: true,

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -380,17 +380,10 @@ const UNRESOLVED_CHOICE_PATTERN = new RegExp(
   `\\b${UNRESOLVED_CHOICE_SOURCE}\\b`,
   'gi',
 );
-// Non-global sibling for proximity `.test()` calls below -- a global regex's
-// `.test()` advances `lastIndex` across calls, which would silently skip
-// matches on a second or later either/or span in the same body.
-const UNRESOLVED_CHOICE_PROXIMITY_PATTERN = new RegExp(
-  `\\b${UNRESOLVED_CHOICE_SOURCE}\\b`,
-  'i',
-);
 // #2219: an either/or acceptance-criterion shape naming two mutually
-// exclusive implementation paths. Only flagged together with
-// UNRESOLVED_CHOICE_PROXIMITY_PATTERN nearby (see checkAutonomy) -- the
-// either/or structure alone also describes an ordinary AC offering two
+// exclusive implementation paths. Only flagged together with an
+// un-negated UNRESOLVED_CHOICE_PATTERN match nearby (see checkAutonomy) --
+// the either/or structure alone also describes an ordinary AC offering two
 // already-resolved, equivalent options, which must keep passing.
 const EITHER_OR_PATTERN = /\beither\b[\s\S]{0,120}?\bor\b/gi;
 const EITHER_OR_PROXIMITY_WINDOW_CHARS = 120;
@@ -1280,35 +1273,58 @@ export function checkAutonomy(context: Context): CheckOutcome {
 
   // #2219: an either/or acceptance-criterion shape naming two mutually
   // exclusive implementation paths without saying which one to take.
-  // Requires an unresolved-choice marker nearby, not the either/or
-  // structure alone -- an ordinary AC offering two already-resolved,
-  // equivalent options must keep passing.
-  for (const match of body.matchAll(EITHER_OR_PATTERN)) {
-    const matchedText = match[0] ?? '';
-    const matchIndex = match.index ?? 0;
-    const contextBefore = body.slice(
-      Math.max(0, matchIndex - EITHER_OR_PROXIMITY_WINDOW_CHARS),
-      matchIndex,
-    );
-    const contextAfter = body.slice(
-      matchIndex + matchedText.length,
-      Math.min(
-        body.length,
-        matchIndex + matchedText.length + EITHER_OR_PROXIMITY_WINDOW_CHARS,
-      ),
-    );
+  // Requires an un-negated unresolved-choice marker nearby, not the
+  // either/or structure alone -- an ordinary AC offering two
+  // already-resolved, equivalent options must keep passing, including
+  // when a resolved statement nearby happens to mention a marker word in
+  // its own negated form (e.g. "this is no longer TBD").
+  const eitherOrMatches = [...body.matchAll(EITHER_OR_PATTERN)];
+  if (eitherOrMatches.length > 0) {
+    for (const marker of body.matchAll(UNRESOLVED_CHOICE_PATTERN)) {
+      const markerText = marker[0] ?? '';
+      const markerIndex = marker.index ?? 0;
+      const markerContextBefore = body.slice(
+        Math.max(0, markerIndex - 60),
+        markerIndex,
+      );
+      const markerContextAfter = body.slice(
+        markerIndex + markerText.length,
+        Math.min(body.length, markerIndex + markerText.length + 60),
+      );
 
-    if (
-      !UNRESOLVED_CHOICE_PROXIMITY_PATTERN.test(contextBefore) &&
-      !UNRESOLVED_CHOICE_PROXIMITY_PATTERN.test(contextAfter)
-    ) {
-      continue;
+      if (
+        NEGATION_PATTERN.test(markerContextBefore) ||
+        NEGATION_PATTERN.test(markerContextAfter)
+      ) {
+        // This marker is itself negated (resolved), e.g. "no longer TBD".
+        continue;
+      }
+
+      const isNearEitherOr = eitherOrMatches.some((eitherOr) => {
+        const eitherOrText = eitherOr[0] ?? '';
+        const eitherOrIndex = eitherOr.index ?? 0;
+        const gapAfterEitherOr =
+          markerIndex - (eitherOrIndex + eitherOrText.length);
+        const gapBeforeEitherOr =
+          eitherOrIndex - (markerIndex + markerText.length);
+        return (
+          (gapAfterEitherOr >= 0 &&
+            gapAfterEitherOr <= EITHER_OR_PROXIMITY_WINDOW_CHARS) ||
+          (gapBeforeEitherOr >= 0 &&
+            gapBeforeEitherOr <= EITHER_OR_PROXIMITY_WINDOW_CHARS)
+        );
+      });
+
+      if (!isNearEitherOr) {
+        continue;
+      }
+
+      return {
+        pass: false,
+        evidence:
+          'Issue presents an unresolved either/or implementation choice.',
+      };
     }
-
-    return {
-      pass: false,
-      evidence: 'Issue presents an unresolved either/or implementation choice.',
-    };
   }
 
   return {

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -385,8 +385,40 @@ const UNRESOLVED_CHOICE_PATTERN = new RegExp(
 // un-negated UNRESOLVED_CHOICE_PATTERN match nearby (see checkAutonomy) --
 // the either/or structure alone also describes an ordinary AC offering two
 // already-resolved, equivalent options, which must keep passing.
-const EITHER_OR_PATTERN = /\beither\b[\s\S]{0,120}?\bor\b/gi;
 const EITHER_OR_PROXIMITY_WINDOW_CHARS = 120;
+const EITHER_OR_PATTERN = new RegExp(
+  `\\beither\\b[\\s\\S]{0,${EITHER_OR_PROXIMITY_WINDOW_CHARS}}?\\bor\\b`,
+  'gi',
+);
+// Window checkAutonomy's negation checks scan on either side of a match --
+// shared by the coordination-language, unresolved-choice, and either/or
+// marker checks via isNegatedNearby below.
+const NEGATION_WINDOW_CHARS = 60;
+/**
+ * True when a negation word (NEGATION_PATTERN) appears within
+ * `windowChars` immediately before or after `matchText` at `matchIndex`
+ * in `body` -- e.g. "no longer TBD" negates a "TBD" match rather than
+ * confirming it. Used by checkAutonomy's coordination-language,
+ * unresolved-choice, and either/or marker checks (#2219).
+ */
+function isNegatedNearby(
+  body: string,
+  matchText: string,
+  matchIndex: number,
+  windowChars: number,
+): boolean {
+  const contextBefore = body.slice(
+    Math.max(0, matchIndex - windowChars),
+    matchIndex,
+  );
+  const contextAfter = body.slice(
+    matchIndex + matchText.length,
+    Math.min(body.length, matchIndex + matchText.length + windowChars),
+  );
+  return (
+    NEGATION_PATTERN.test(contextBefore) || NEGATION_PATTERN.test(contextAfter)
+  );
+}
 const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 // A heading line such as "## Decision (resolved 2026-06-27)" records that a
 // human has already ruled on the issue's open question (see Check 7). The
@@ -1235,6 +1267,61 @@ export function checkAutonomy(context: Context): CheckOutcome {
     }
   }
 
+  // #2219: an either/or acceptance-criterion shape naming two mutually
+  // exclusive implementation paths without saying which one to take.
+  // Checked before the general coordination-language matches below: an
+  // unresolved-choice marker (see UNRESOLVED_CHOICE_PATTERN) always also
+  // matches that broader check, so checking either/or first is what makes
+  // this variant's own evidence message reachable rather than always
+  // pre-empted by the broader match on the same marker. Requires an
+  // un-negated marker touching or within EITHER_OR_PROXIMITY_WINDOW_CHARS
+  // of the either/or span -- an ordinary AC offering two already-resolved,
+  // equivalent options must keep passing, including when a resolved
+  // statement nearby happens to mention a marker word in its own negated
+  // form (e.g. "this is no longer TBD").
+  const eitherOrMatches = [...body.matchAll(EITHER_OR_PATTERN)];
+  if (eitherOrMatches.length > 0) {
+    for (const marker of body.matchAll(UNRESOLVED_CHOICE_PATTERN)) {
+      const markerText = marker[0] ?? '';
+      const markerIndex = marker.index ?? 0;
+      if (
+        isNegatedNearby(body, markerText, markerIndex, NEGATION_WINDOW_CHARS)
+      ) {
+        continue;
+      }
+
+      const markerEnd = markerIndex + markerText.length;
+      const isNearOrInsideEitherOr = eitherOrMatches.some((eitherOr) => {
+        const eitherOrText = eitherOr[0] ?? '';
+        const eitherOrIndex = eitherOr.index ?? 0;
+        const eitherOrEnd = eitherOrIndex + eitherOrText.length;
+        if (markerIndex < eitherOrEnd && markerEnd > eitherOrIndex) {
+          // The marker overlaps the either/or span itself (e.g. "either
+          // TBD ... or ...").
+          return true;
+        }
+        const gapAfterEitherOr = markerIndex - eitherOrEnd;
+        const gapBeforeEitherOr = eitherOrIndex - markerEnd;
+        return (
+          (gapAfterEitherOr >= 0 &&
+            gapAfterEitherOr <= EITHER_OR_PROXIMITY_WINDOW_CHARS) ||
+          (gapBeforeEitherOr >= 0 &&
+            gapBeforeEitherOr <= EITHER_OR_PROXIMITY_WINDOW_CHARS)
+        );
+      });
+
+      if (!isNearOrInsideEitherOr) {
+        continue;
+      }
+
+      return {
+        pass: false,
+        evidence:
+          'Issue presents an unresolved either/or implementation choice.',
+      };
+    }
+  }
+
   // Negation-aware parsing for external coordination and human decision requirements
   const coordinationMatches = [
     ...body.matchAll(
@@ -1243,23 +1330,12 @@ export function checkAutonomy(context: Context): CheckOutcome {
     ...body.matchAll(
       /\bstakeholder\b[\s\S]{0,80}\b(sign-?off|approval|decision)\b/gi,
     ),
-    ...body.matchAll(UNRESOLVED_CHOICE_PATTERN),
   ];
 
   for (const match of coordinationMatches) {
     const matchedText = match[0] ?? '';
     const matchIndex = match.index ?? 0;
-    const contextBefore = body.slice(Math.max(0, matchIndex - 60), matchIndex);
-    const contextAfter = body.slice(
-      matchIndex + matchedText.length,
-      Math.min(body.length, matchIndex + matchedText.length + 60),
-    );
-
-    // Check if negated (either before or immediately after)
-    if (
-      NEGATION_PATTERN.test(contextBefore) ||
-      NEGATION_PATTERN.test(contextAfter)
-    ) {
+    if (isNegatedNearby(body, matchedText, matchIndex, NEGATION_WINDOW_CHARS)) {
       // This is a negated non-requirement; skip this match
       continue;
     }
@@ -1271,60 +1347,20 @@ export function checkAutonomy(context: Context): CheckOutcome {
     };
   }
 
-  // #2219: an either/or acceptance-criterion shape naming two mutually
-  // exclusive implementation paths without saying which one to take.
-  // Requires an un-negated unresolved-choice marker nearby, not the
-  // either/or structure alone -- an ordinary AC offering two
-  // already-resolved, equivalent options must keep passing, including
-  // when a resolved statement nearby happens to mention a marker word in
-  // its own negated form (e.g. "this is no longer TBD").
-  const eitherOrMatches = [...body.matchAll(EITHER_OR_PATTERN)];
-  if (eitherOrMatches.length > 0) {
-    for (const marker of body.matchAll(UNRESOLVED_CHOICE_PATTERN)) {
-      const markerText = marker[0] ?? '';
-      const markerIndex = marker.index ?? 0;
-      const markerContextBefore = body.slice(
-        Math.max(0, markerIndex - 60),
-        markerIndex,
-      );
-      const markerContextAfter = body.slice(
-        markerIndex + markerText.length,
-        Math.min(body.length, markerIndex + markerText.length + 60),
-      );
-
-      if (
-        NEGATION_PATTERN.test(markerContextBefore) ||
-        NEGATION_PATTERN.test(markerContextAfter)
-      ) {
-        // This marker is itself negated (resolved), e.g. "no longer TBD".
-        continue;
-      }
-
-      const isNearEitherOr = eitherOrMatches.some((eitherOr) => {
-        const eitherOrText = eitherOr[0] ?? '';
-        const eitherOrIndex = eitherOr.index ?? 0;
-        const gapAfterEitherOr =
-          markerIndex - (eitherOrIndex + eitherOrText.length);
-        const gapBeforeEitherOr =
-          eitherOrIndex - (markerIndex + markerText.length);
-        return (
-          (gapAfterEitherOr >= 0 &&
-            gapAfterEitherOr <= EITHER_OR_PROXIMITY_WINDOW_CHARS) ||
-          (gapBeforeEitherOr >= 0 &&
-            gapBeforeEitherOr <= EITHER_OR_PROXIMITY_WINDOW_CHARS)
-        );
-      });
-
-      if (!isNearEitherOr) {
-        continue;
-      }
-
-      return {
-        pass: false,
-        evidence:
-          'Issue presents an unresolved either/or implementation choice.',
-      };
+  // #2219: a nearby-word unresolved-choice phrasing beyond the two fixed
+  // templates above -- TBD, to be determined, pending a decision, an open
+  // question for the maintainer, and similar (see UNRESOLVED_CHOICE_SOURCE).
+  for (const marker of body.matchAll(UNRESOLVED_CHOICE_PATTERN)) {
+    const markerText = marker[0] ?? '';
+    const markerIndex = marker.index ?? 0;
+    if (isNegatedNearby(body, markerText, markerIndex, NEGATION_WINDOW_CHARS)) {
+      continue;
     }
+
+    return {
+      pass: false,
+      evidence: 'Issue names an unresolved product or design choice.',
+    };
   }
 
   return {

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -365,6 +365,35 @@ const POLICY_OVERRIDE_NOUN_PATTERN = new RegExp(
   `\\b(${POLICY_OVERRIDE_NOUN_SOURCE})\\b`,
   'i',
 );
+// #2219: broadens checkAutonomy's coordination-language matcher beyond its two
+// original fixed templates (requires .../stakeholder ... sign-off) to catch
+// equally natural phrasings for the same unresolved human-coordination
+// dependency -- reported by an adopter as passing checkAutonomy under
+// different wording. Deliberately excludes a bare "unresolved" alternative:
+// this repository's own instruction files use that word constantly for
+// unrelated concepts (unresolved review threads, unresolved roadmap
+// descendants), so only the multi-word "unresolved decision/question/choice"
+// phrasing is included.
+const UNRESOLVED_CHOICE_SOURCE =
+  '(?:TBD|to be determined|still undecided|undecided|not (?:yet )?decided|unresolved (?:decision|question|choice)|pending (?:a |the )?(?:decision|approval)|open question(?:s)? for (?:the )?(?:maintainer|team|stakeholders?)|awaiting (?:a |the )?(?:decision|approval|input)|maintainer (?:to |must |needs to )?(?:decide|choose))';
+const UNRESOLVED_CHOICE_PATTERN = new RegExp(
+  `\\b${UNRESOLVED_CHOICE_SOURCE}\\b`,
+  'gi',
+);
+// Non-global sibling for proximity `.test()` calls below -- a global regex's
+// `.test()` advances `lastIndex` across calls, which would silently skip
+// matches on a second or later either/or span in the same body.
+const UNRESOLVED_CHOICE_PROXIMITY_PATTERN = new RegExp(
+  `\\b${UNRESOLVED_CHOICE_SOURCE}\\b`,
+  'i',
+);
+// #2219: an either/or acceptance-criterion shape naming two mutually
+// exclusive implementation paths. Only flagged together with
+// UNRESOLVED_CHOICE_PROXIMITY_PATTERN nearby (see checkAutonomy) -- the
+// either/or structure alone also describes an ordinary AC offering two
+// already-resolved, equivalent options, which must keep passing.
+const EITHER_OR_PATTERN = /\beither\b[\s\S]{0,120}?\bor\b/gi;
+const EITHER_OR_PROXIMITY_WINDOW_CHARS = 120;
 const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 // A heading line such as "## Decision (resolved 2026-06-27)" records that a
 // human has already ruled on the issue's open question (see Check 7). The
@@ -1221,6 +1250,7 @@ export function checkAutonomy(context: Context): CheckOutcome {
     ...body.matchAll(
       /\bstakeholder\b[\s\S]{0,80}\b(sign-?off|approval|decision)\b/gi,
     ),
+    ...body.matchAll(UNRESOLVED_CHOICE_PATTERN),
   ];
 
   for (const match of coordinationMatches) {
@@ -1245,6 +1275,39 @@ export function checkAutonomy(context: Context): CheckOutcome {
       pass: false,
       evidence:
         'Issue explicitly requires external human coordination or approval.',
+    };
+  }
+
+  // #2219: an either/or acceptance-criterion shape naming two mutually
+  // exclusive implementation paths without saying which one to take.
+  // Requires an unresolved-choice marker nearby, not the either/or
+  // structure alone -- an ordinary AC offering two already-resolved,
+  // equivalent options must keep passing.
+  for (const match of body.matchAll(EITHER_OR_PATTERN)) {
+    const matchedText = match[0] ?? '';
+    const matchIndex = match.index ?? 0;
+    const contextBefore = body.slice(
+      Math.max(0, matchIndex - EITHER_OR_PROXIMITY_WINDOW_CHARS),
+      matchIndex,
+    );
+    const contextAfter = body.slice(
+      matchIndex + matchedText.length,
+      Math.min(
+        body.length,
+        matchIndex + matchedText.length + EITHER_OR_PROXIMITY_WINDOW_CHARS,
+      ),
+    );
+
+    if (
+      !UNRESOLVED_CHOICE_PROXIMITY_PATTERN.test(contextBefore) &&
+      !UNRESOLVED_CHOICE_PROXIMITY_PATTERN.test(contextAfter)
+    ) {
+      continue;
+    }
+
+    return {
+      pass: false,
+      evidence: 'Issue presents an unresolved either/or implementation choice.',
     };
   }
 

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1269,16 +1269,16 @@ export function checkAutonomy(context: Context): CheckOutcome {
 
   // #2219: an either/or acceptance-criterion shape naming two mutually
   // exclusive implementation paths without saying which one to take.
-  // Checked before the general coordination-language matches below: an
-  // unresolved-choice marker (see UNRESOLVED_CHOICE_PATTERN) always also
-  // matches that broader check, so checking either/or first is what makes
-  // this variant's own evidence message reachable rather than always
-  // pre-empted by the broader match on the same marker. Requires an
-  // un-negated marker touching or within EITHER_OR_PROXIMITY_WINDOW_CHARS
-  // of the either/or span -- an ordinary AC offering two already-resolved,
-  // equivalent options must keep passing, including when a resolved
-  // statement nearby happens to mention a marker word in its own negated
-  // form (e.g. "this is no longer TBD").
+  // Checked before the standalone unresolved-choice scan further below:
+  // both checks match against the same UNRESOLVED_CHOICE_PATTERN markers,
+  // so checking either/or first is what makes this variant's own evidence
+  // message reachable rather than always pre-empted by that later, more
+  // generic match on the same marker. Requires an un-negated marker
+  // touching or within EITHER_OR_PROXIMITY_WINDOW_CHARS of the either/or
+  // span -- an ordinary AC offering two already-resolved, equivalent
+  // options must keep passing, including when a resolved statement nearby
+  // happens to mention a marker word in its own negated form (e.g. "this
+  // is no longer TBD").
   const eitherOrMatches = [...body.matchAll(EITHER_OR_PATTERN)];
   if (eitherOrMatches.length > 0) {
     for (const marker of body.matchAll(UNRESOLVED_CHOICE_PATTERN)) {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -1974,6 +1974,74 @@ test('autonomy fails when stakeholder sign-off is required', () => {
   assert.equal(result.pass, false);
 });
 
+test('autonomy fails on a nearby-word unresolved-choice phrasing beyond the two fixed templates -- #2219', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThe caching backend is TBD pending maintainer review.`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('autonomy fails on an either/or acceptance-criterion shape naming two unresolved implementation paths -- #2219', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\n## Acceptance Criteria\n- Either store sessions in Redis or in-memory (not yet decided which).`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('autonomy still passes an ordinary either/or acceptance criterion offering two already-resolved, equivalent options -- #2219 (no new false positive)', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\n## Acceptance Criteria\n- Either approach satisfies this requirement; both are already implemented and equivalent.`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('autonomy still passes ordinary prose using "unresolved" for an unrelated concept -- #2219 (no new false positive)', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThis change leaves no unresolved review threads once merged.`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('autonomy ignores a negated unresolved-choice phrasing -- #2219', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThis is no longer TBD; the maintainer already decided on approach A.`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('autonomy still fails both original fixed templates unchanged -- #2219 (no regression)', () => {
+  const requiresResult = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThis requires human decision before proceeding.`,
+    },
+  } as Context);
+  assert.equal(requiresResult.pass, false);
+
+  const stakeholderResult = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nStakeholder approval is needed here.`,
+    },
+  } as Context);
+  assert.equal(stakeholderResult.pass, false);
+});
+
 test('verifiability fails when acceptance criteria is subjective', () => {
   const result = checkVerifiability({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -1994,6 +1994,16 @@ test('autonomy fails on an either/or acceptance-criterion shape naming two unres
   assert.equal(result.pass, false);
 });
 
+test('autonomy still passes an either/or criterion resolved by a negated marker nearby -- #2219 (CodeRabbit, no new false positive)', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\n## Acceptance Criteria\n- Either store sessions in Redis or in-memory. This is no longer TBD -- Redis was already selected and implemented.`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
 test('autonomy still passes an ordinary either/or acceptance criterion offering two already-resolved, equivalent options -- #2219 (no new false positive)', () => {
   const result = checkAutonomy({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -1992,6 +1992,22 @@ test('autonomy fails on an either/or acceptance-criterion shape naming two unres
     },
   } as Context);
   assert.equal(result.pass, false);
+  // Proves the either/or-specific path actually fired (Copilot review
+  // finding: an unresolved-choice marker anywhere always also matches the
+  // broader coordination check below, which could otherwise mask this
+  // check and leave it permanently unreachable).
+  assert.match(result.evidence, /either\/or/);
+});
+
+test('autonomy fails when the unresolved-choice marker sits inside the either/or span itself -- #2219 (Copilot)', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\n## Acceptance Criteria\n- Either TBD caching backend or a fixed one, implementation pending.`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+  assert.match(result.evidence, /either\/or/);
 });
 
 test('autonomy still passes an either/or criterion resolved by a negated marker nearby -- #2219 (CodeRabbit, no new false positive)', () => {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -1993,9 +1993,9 @@ test('autonomy fails on an either/or acceptance-criterion shape naming two unres
   } as Context);
   assert.equal(result.pass, false);
   // Proves the either/or-specific path actually fired (Copilot review
-  // finding: an unresolved-choice marker anywhere always also matches the
-  // broader coordination check below, which could otherwise mask this
-  // check and leave it permanently unreachable).
+  // finding: the standalone unresolved-choice scan later in checkAutonomy
+  // matches the same marker, which could otherwise mask this check and
+  // leave it permanently unreachable if it ran first).
   assert.match(result.evidence, /either\/or/);
 });
 


### PR DESCRIPTION
## Summary

- `checkAutonomy` in `src/scripts/suitability-triage.mts` previously recognized only two fixed phrase templates for a human-coordination dependency (`requires .../stakeholder ... sign-off`), so an equally natural phrasing of the same idea could pass the check and reach a fully-ready verdict even though the issue still needs a decision.
- Adds a nearby-word `UNRESOLVED_CHOICE_PATTERN` (TBD, to be determined, still undecided, not yet decided, unresolved decision/question/choice, pending a decision/approval, open question for the maintainer/team/stakeholders, awaiting a decision/approval/input, maintainer to decide/choose), checked via its own negation-aware loop so a resolved statement like "no longer TBD" still passes.
- Adds a structural either/or check: an acceptance-criterion shape naming two mutually exclusive implementation paths fails only when an un-negated unresolved-choice marker sits within (or overlapping) 120 characters of the `either ... or` span -- an ordinary AC offering two already-resolved, equivalent options (e.g. "either approach satisfies this, both are already implemented and equivalent") keeps passing, per the issue's explicit no-new-false-positives acceptance criterion. Checked before the general unresolved-choice scan so its own evidence message is actually reachable rather than always pre-empted by that broader match on the same marker (a real dead-code bug Copilot's review caught and this PR fixes).
- Deliberately excludes a bare `unresolved` alternative from the new pattern: this repository's own instruction files use that word constantly for unrelated concepts (unresolved review threads, unresolved roadmap descendants), so only the multi-word `unresolved decision/question/choice` phrasing is included.

## Test plan

- [x] 8 new tests in `tests/suitability-triage.test.mts`: nearby-word unresolved-choice failure, either/or-with-unresolved-marker failure (asserting the either/or-specific evidence message), either/or marker inside the span, either/or resolved by a negated marker nearby, either/or-with-resolved-options pass (no new false positive), unrelated "unresolved" prose pass (no new false positive), negated unresolved-choice pass, and both original fixed templates still fail (no regression)
- [x] `pnpm run typecheck`
- [x] `node --test tests/*.test.mts` (4356/4356 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run lint:minimum`

Closes #2219

🤖 Generated with [Claude Code](https://claude.com/claude-code)