### PR TITLE
feat(claim): add a clone-scoped lock for worktree lifecycle ops

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,6 +28,7 @@ scripts/ci-wait-state.mjs linguist-generated=true
 scripts/claim-approval-gate.mjs linguist-generated=true
 scripts/claim-lock.mjs linguist-generated=true
 scripts/cli-args.mjs linguist-generated=true
+scripts/clone-lock.mjs linguist-generated=true
 scripts/code-span-wrap.mjs linguist-generated=true
 scripts/collaborator-permission.mjs linguist-generated=true
 scripts/consistency-helpers.mjs linguist-generated=true

--- a/.github/instructions/idd-merge.instructions.md
+++ b/.github/instructions/idd-merge.instructions.md
@@ -415,7 +415,10 @@ Before any mutating action in F3, apply the
    See `docs/idd-comment-minimization.md` for the evidence comment
    format, cleanup-failure comment format, permission-blocked comment
    format, and fallback GraphQL commands.
-4. From the **primary worktree** — the worktree being cleaned up is
+4. Concurrent workers sharing one clone: serialize this step's fetch
+   and step 5's `worktree remove` behind the
+   [clone-scoped lock](../../docs/idd-helper-scripts.md#clone-scoped-lock).
+   From the **primary worktree** — the worktree being cleaned up is
    still checked out to its issue branch at this point, so running
    this elsewhere would fast-forward the wrong branch — switch to
    `{development-branch}` (the PR's own validated target branch;

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -13,8 +13,9 @@ planning (B2), implementation (B3), and the self-review loop (C).
 ## B1 — Create worktree (with branch)
 
 Before creating, check for local conflicts in this order. Concurrent
-workers sharing one clone: serialize the `git fetch`/`merge --ff-only`/
-worktree add/remove calls below behind the
+workers sharing one clone: serialize every `git fetch`/`merge --ff-only`/
+worktree add/remove call against the shared clone -- here, and at F4
+cleanup's own worktree removal -- behind the
 [clone-scoped lock](../../docs/idd-helper-scripts.md#clone-scoped-lock)
 (see the [fan-out variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant)
 for when this applies).

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -12,9 +12,12 @@ planning (B2), implementation (B3), and the self-review loop (C).
 
 ## B1 — Create worktree (with branch)
 
-Before creating, check for local conflicts in this order (concurrent
-clone sharing: serialize via `clone-lock.mjs --exec`, see
-[fan-out](../../docs/idd-workflow.md#orchestrator-fan-out-variant)).
+Before creating, check for local conflicts in this order. Concurrent
+workers sharing one clone: serialize the `git fetch`/worktree
+add/remove calls below behind the
+[clone-scoped lock](../../docs/idd-helper-scripts.md#clone-scoped-lock)
+(see the [fan-out variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant)
+for when this applies).
 
 1. Ensure the local `main` branch is up to date and has no local
    commits. Run this from the primary worktree while on `main`:

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -12,7 +12,9 @@ planning (B2), implementation (B3), and the self-review loop (C).
 
 ## B1 — Create worktree (with branch)
 
-Before creating, check for local conflicts in this order:
+Before creating, check for local conflicts in this order (concurrent
+clone sharing: serialize via `clone-lock.mjs --exec`, see
+[fan-out](../../docs/idd-workflow.md#orchestrator-fan-out-variant)).
 
 1. Ensure the local `main` branch is up to date and has no local
    commits. Run this from the primary worktree while on `main`:

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -217,7 +217,10 @@ mechanical file/close-based signal stronger than A4.5's title/
 declaration heuristic (a weak **title-only** match is **not** a hit
 here). Keep it cheap: one fetch plus a bounded merged-PR scan.
 
-1. `git fetch origin {development-branch}`.
+1. `git fetch origin {development-branch}` (concurrent workers sharing
+   one clone: behind the
+   [clone-scoped lock](../../docs/idd-helper-scripts.md#clone-scoped-lock),
+   same as B1).
 2. **Closed-by-a-merged-PR signal**: re-fetch the issue; if it is now closed
    with a linked closing PR, the deliverable already shipped:
 

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -13,8 +13,8 @@ planning (B2), implementation (B3), and the self-review loop (C).
 ## B1 — Create worktree (with branch)
 
 Before creating, check for local conflicts in this order. Concurrent
-workers sharing one clone: serialize the `git fetch`/worktree
-add/remove calls below behind the
+workers sharing one clone: serialize the `git fetch`/`merge --ff-only`/
+worktree add/remove calls below behind the
 [clone-scoped lock](../../docs/idd-helper-scripts.md#clone-scoped-lock)
 (see the [fan-out variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant)
 for when this applies).

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -53,6 +53,11 @@ request, or other GitHub side effect, confirm all of the following:
 
 ## B1 — Create worktree
 
+Concurrent workers sharing one clone: serialize every `fetch`/`merge
+--ff-only`/worktree add/remove call below (and F4 cleanup's own
+worktree removal) behind the
+[clone-scoped lock](../../../docs/idd-helper-scripts.md#clone-scoped-lock).
+
 1. On the primary worktree, run `git fetch origin main`.
 2. On the primary worktree, run `git log origin/main..main --oneline`.
 3. If step 2 outputs any lines, stop and report: local `main` has unpushed

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -299,7 +299,7 @@
         ".github/instructions/idd-overview-core.instructions.md",
         ".github/instructions/idd-work.instructions.md"
       ],
-      "limitBytes": 45000
+      "limitBytes": 49500
     },
     {
       "id": "bundle-work-lite",

--- a/bin/idd-clone-lock.mjs
+++ b/bin/idd-clone-lock.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-clone-lock.mts
+//
+// The bin/idd-clone-lock.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+import { runHelper } from './run-helper.mjs';
+
+runHelper('../scripts/clone-lock.mjs');

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1334,6 +1334,57 @@ Interpretation rules:
   namespace, so a helper-runtime session and an instructions-only
   session see the same lock.
 
+### Clone-scoped lock
+
+- Source repo / vendored-node commands:
+  `node scripts/clone-lock.mjs --exec --agent-id <id> [--repo <path>]
+  [--timeout-ms <n>] -- <command> [args...]`
+  and `node scripts/clone-lock.mjs --check [--repo <path>]`
+- Package-manager / ephemeral-npx command: use the profile-selected
+  `idd:clone-lock` command from the helper runtime manifest wiring
+  above; the literal invocations are:
+
+  ```sh
+  npx --yes --package <helper-package-spec> \
+    idd-clone-lock --exec --agent-id <id> [--repo <path>] \
+    [--timeout-ms <n>] -- <command> [args...]
+
+  npx --yes --package <helper-package-spec> \
+    idd-clone-lock --check [--repo <path>]
+  ```
+
+- A mutual-exclusion mutex around `git worktree add`/`remove` and
+  `git fetch` against the _shared_ primary clone — unlike the
+  worktree-local claim lock above, this blocks (retrying with backoff)
+  rather than reporting an immediate collision, and serializes
+  concurrent workers sharing one clone rather than guarding one
+  worktree's own claim identity. See the
+  [Orchestrator fan-out variant](idd-workflow.md#orchestrator-fan-out-variant)
+  for when to reach for it.
+- `--exec` acquires, runs `<command>` with stdio inherited and `cwd`
+  set to `--repo`, then releases the lock even if the command fails,
+  exiting with the command's own exit code; exits `3` if the lock
+  could not be acquired within `--timeout-ms` (default 120000).
+- `--check` reports `{ path, present, holder?, malformed? }`
+  read-only, the same shape as the worktree-local claim lock's
+  `--check` above.
+- A lock whose lease has not been refreshed for 5 minutes is treated
+  as abandoned by a dead holder and taken over; `--exec` refreshes its
+  own lease periodically while the wrapped command runs, so a
+  legitimately long-running `git fetch` is never mistaken for a dead
+  holder. Recovering an abandoned lock is itself race-free across
+  concurrent contenders: removal and recreation are each a separate
+  exclusive step, so exactly one contender ever wins a takeover.
+- **`instructions-only` helper-free fallback (no helper runtime
+  available)**: this lock is a same-machine convenience for
+  parallel autonomous fan-out, not a correctness requirement — an
+  `instructions-only` session running one worker at a time never
+  contends for it. Where an `instructions-only` profile does run
+  concurrent workers sharing one clone, serialize `git worktree
+  add`/`remove`/`fetch` by giving each worker its own clone instead
+  (see the Orchestrator fan-out variant linked above), rather than
+  hand-rolling this lock's protocol.
+
 ### Canonical branch name
 
 - Source repo / vendored-node command:

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1337,9 +1337,14 @@ Interpretation rules:
 ### Clone-scoped lock
 
 - Source repo / vendored-node commands:
-  `node scripts/clone-lock.mjs --exec --agent-id <id> [--repo <path>]
-  [--timeout-ms <n>] -- <command> [args...]`
-  and `node scripts/clone-lock.mjs --check [--repo <path>]`
+
+  ```sh
+  node scripts/clone-lock.mjs --exec --agent-id <id> [--repo <path>] \
+    [--timeout-ms <n>] -- <command> [args...]
+
+  node scripts/clone-lock.mjs --check [--repo <path>]
+  ```
+
 - Package-manager / ephemeral-npx command: use the profile-selected
   `idd:clone-lock` command from the helper runtime manifest wiring
   above; the literal invocations are:

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1370,16 +1370,18 @@ Interpretation rules:
   set to `--repo`, then releases the lock even if the command fails,
   exiting with the command's own exit code; exits `3` if the lock
   could not be acquired within `--timeout-ms` (default 120000).
-- `--check` reports `{ path, present, holder?, malformed? }`
-  read-only, the same shape as the worktree-local claim lock's
-  `--check` above.
-- A lock is eligible for takeover only once its recorded holder
-  process is confirmed dead (`process.kill(pid, 0)`), not after any
-  fixed time period; a live holder's lock is never taken over,
-  however long it is held, so a legitimately long-running `git fetch`
-  is never mistaken for a dead holder. A malformed lock body (no
-  readable `pid`) is never auto-recovered — see `--check`'s
-  `malformed: true` output for manual diagnosis.
+- `--check` reports `{ path, present, holder?, malformed?,
+  holderAlive? }` read-only; `holderAlive` (diagnostic only, from
+  `process.kill(pid, 0)`) reports whether the recorded holder still
+  appears to be running.
+- **No automatic stale-lock recovery**: a held lock is never taken
+  over, regardless of how long it has been held or whether its
+  recorded holder is still alive. `--exec` exits `3` on a
+  `--timeout-ms` timeout, naming the lock path and the recorded
+  holder's pid in the error message; once you have independently
+  confirmed that holder is gone, remove the lock file by hand and
+  retry — the same recovery git's own `index.lock` expects on a
+  stale-lock collision.
 - **`instructions-only` helper-free fallback (no helper runtime
   available)**: this lock is a same-machine convenience for
   parallel autonomous fan-out, not a correctness requirement — an

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1373,8 +1373,9 @@ Interpretation rules:
   own lease periodically while the wrapped command runs, so a
   legitimately long-running `git fetch` is never mistaken for a dead
   holder. Recovering an abandoned lock is itself race-free across
-  concurrent contenders: removal and recreation are each a separate
-  exclusive step, so exactly one contender ever wins a takeover.
+  concurrent contenders: removal and recreation happen only while
+  holding a companion PID-tagged arbiter lock, so at most one
+  contender is ever doing that at a time.
 - **`instructions-only` helper-free fallback (no helper runtime
   available)**: this lock is a same-machine convenience for
   parallel autonomous fan-out, not a correctness requirement — an

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1373,14 +1373,13 @@ Interpretation rules:
 - `--check` reports `{ path, present, holder?, malformed? }`
   read-only, the same shape as the worktree-local claim lock's
   `--check` above.
-- A lock whose lease has not been refreshed for 5 minutes is treated
-  as abandoned by a dead holder and taken over; `--exec` refreshes its
-  own lease periodically while the wrapped command runs, so a
-  legitimately long-running `git fetch` is never mistaken for a dead
-  holder. Recovering an abandoned lock is itself race-free across
-  concurrent contenders: removal and recreation happen only while
-  holding a companion PID-tagged arbiter lock, so at most one
-  contender is ever doing that at a time.
+- A lock is eligible for takeover only once its recorded holder
+  process is confirmed dead (`process.kill(pid, 0)`), not after any
+  fixed time period; a live holder's lock is never taken over,
+  however long it is held, so a legitimately long-running `git fetch`
+  is never mistaken for a dead holder. A malformed lock body (no
+  readable `pid`) is never auto-recovered — see `--check`'s
+  `malformed: true` output for manual diagnosis.
 - **`instructions-only` helper-free fallback (no helper runtime
   available)**: this lock is a same-machine convenience for
   parallel autonomous fan-out, not a correctness requirement — an

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -622,10 +622,9 @@ Running this variant safely requires:
   one clone.** Concurrent `git fetch` / `git worktree add` / `git
   worktree remove` / local `{development-branch}` updates from the
   same primary clone can collide; serialize these specific operations
-  behind a per-clone lock (`node scripts/clone-lock.mjs --exec
-  --agent-id <id> -- <command...>`, #2223), or give concurrent workers
-  separate clones, once the concurrency cap allows more than one
-  worker at a time.
+  behind the [clone-scoped lock](idd-helper-scripts.md#clone-scoped-lock),
+  or give concurrent workers separate clones, once the concurrency cap
+  allows more than one worker at a time.
 - **Resume-specific recovery when a worker dies mid-turn.** Re-verify
   claim ownership and worktree state before continuing; treat any
   uncommitted work found in the worktree as unverified input to check,

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -622,9 +622,10 @@ Running this variant safely requires:
   one clone.** Concurrent `git fetch` / `git worktree add` / `git
   worktree remove` / local `{development-branch}` updates from the
   same primary clone can collide; serialize these specific operations
-  behind a per-clone lock, or give concurrent workers separate
-  clones, once the concurrency cap allows more than one worker at a
-  time.
+  behind a per-clone lock (`node scripts/clone-lock.mjs --exec
+  --agent-id <id> -- <command...>`, #2223), or give concurrent workers
+  separate clones, once the concurrency cap allows more than one
+  worker at a time.
 - **Resume-specific recovery when a worker dies mid-turn.** Re-verify
   claim ownership and worktree state before continuing; treat any
   uncommitted work found in the worktree as unverified input to check,

--- a/docs/weak-model-lite-profile-design.md
+++ b/docs/weak-model-lite-profile-design.md
@@ -89,7 +89,7 @@ profile.
 **Why shape, not fit, is the problem.** `audit/sync-manifest.json`'s
 `bundleBudgets` already cap every phase-file bundle well inside a
 128K-token window — for example `bundle-work` (B1-C6, the primary
-single-issue execution path) is capped at 45,000 bytes, and even the
+single-issue execution path) is capped at 49,500 bytes, and even the
 largest, `bundle-review`, is capped at 129,400 bytes (roughly a quarter
 of a 128K-token window at a typical ~4-bytes-per-token ratio; read live
 values with `jq '.bundleBudgets' audit/sync-manifest.json` rather than
@@ -369,7 +369,7 @@ this design issue.
   narrowest pilot** — condense `idd-work.instructions.md` into a
   self-contained lite file following all five content principles; the
   canonical single-issue execution phase and the smallest, most
-  self-contained standard file (`bundle-work`, 45,000-byte budget),
+  self-contained standard file (`bundle-work`, 49,500-byte budget),
   making it the lowest-risk pilot.
 - **Author the lite instruction set for the claim phase (A5)** —
   condense `idd-claim.instructions.md`'s mechanical pre-checks (a)-(e)

--- a/idd-template/.github/instructions/idd-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-merge.instructions.md
@@ -410,7 +410,10 @@ Before any mutating action in F3, apply the
    See `docs/idd-comment-minimization.md` for the evidence comment
    format, cleanup-failure comment format, permission-blocked comment
    format, and fallback GraphQL commands.
-4. From the **primary worktree** — the worktree being cleaned up is
+4. Concurrent workers sharing one clone: serialize this step's fetch
+   and step 5's `worktree remove` behind the
+   [clone-scoped lock](../../docs/idd-helper-scripts.md#clone-scoped-lock).
+   From the **primary worktree** — the worktree being cleaned up is
    still checked out to its issue branch at this point, so running
    this elsewhere would fast-forward the wrong branch — switch to
    `{development-branch}` (the PR's own validated target branch;

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -7,7 +7,9 @@ planning (B2), implementation (B3), and the self-review loop (C).
 
 ## B1 — Create worktree (with branch)
 
-Before creating, check for local conflicts in this order:
+Before creating, check for local conflicts in this order (concurrent
+clone sharing: serialize via `clone-lock.mjs --exec`, see
+[fan-out](../../docs/idd-workflow.md#orchestrator-fan-out-variant)).
 
 1. Ensure the local `main` branch is up to date and has no local
    commits. Run this from the primary worktree while on `main`:

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -212,7 +212,10 @@ mechanical file/close-based signal stronger than A4.5's title/
 declaration heuristic (a weak **title-only** match is **not** a hit
 here). Keep it cheap: one fetch plus a bounded merged-PR scan.
 
-1. `git fetch origin {development-branch}`.
+1. `git fetch origin {development-branch}` (concurrent workers sharing
+   one clone: behind the
+   [clone-scoped lock](../../docs/idd-helper-scripts.md#clone-scoped-lock),
+   same as B1).
 2. **Closed-by-a-merged-PR signal**: re-fetch the issue; if it is now closed
    with a linked closing PR, the deliverable already shipped:
 

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -7,9 +7,12 @@ planning (B2), implementation (B3), and the self-review loop (C).
 
 ## B1 — Create worktree (with branch)
 
-Before creating, check for local conflicts in this order (concurrent
-clone sharing: serialize via `clone-lock.mjs --exec`, see
-[fan-out](../../docs/idd-workflow.md#orchestrator-fan-out-variant)).
+Before creating, check for local conflicts in this order. Concurrent
+workers sharing one clone: serialize the `git fetch`/worktree
+add/remove calls below behind the
+[clone-scoped lock](../../docs/idd-helper-scripts.md#clone-scoped-lock)
+(see the [fan-out variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant)
+for when this applies).
 
 1. Ensure the local `main` branch is up to date and has no local
    commits. Run this from the primary worktree while on `main`:

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -8,8 +8,8 @@ planning (B2), implementation (B3), and the self-review loop (C).
 ## B1 — Create worktree (with branch)
 
 Before creating, check for local conflicts in this order. Concurrent
-workers sharing one clone: serialize the `git fetch`/worktree
-add/remove calls below behind the
+workers sharing one clone: serialize the `git fetch`/`merge --ff-only`/
+worktree add/remove calls below behind the
 [clone-scoped lock](../../docs/idd-helper-scripts.md#clone-scoped-lock)
 (see the [fan-out variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant)
 for when this applies).

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -8,8 +8,9 @@ planning (B2), implementation (B3), and the self-review loop (C).
 ## B1 — Create worktree (with branch)
 
 Before creating, check for local conflicts in this order. Concurrent
-workers sharing one clone: serialize the `git fetch`/`merge --ff-only`/
-worktree add/remove calls below behind the
+workers sharing one clone: serialize every `git fetch`/`merge --ff-only`/
+worktree add/remove call against the shared clone -- here, and at F4
+cleanup's own worktree removal -- behind the
 [clone-scoped lock](../../docs/idd-helper-scripts.md#clone-scoped-lock)
 (see the [fan-out variant](../../docs/idd-workflow.md#orchestrator-fan-out-variant)
 for when this applies).

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -48,6 +48,11 @@ request, or other GitHub side effect, confirm all of the following:
 
 ## B1 — Create worktree
 
+Concurrent workers sharing one clone: serialize every `fetch`/`merge
+--ff-only`/worktree add/remove call below (and F4 cleanup's own
+worktree removal) behind the
+[clone-scoped lock](../../../docs/idd-helper-scripts.md#clone-scoped-lock).
+
 1. On the primary worktree, run `git fetch origin main`.
 2. On the primary worktree, run `git log origin/main..main --oneline`.
 3. If step 2 outputs any lines, stop and report: local `main` has unpushed

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1334,6 +1334,57 @@ Interpretation rules:
   namespace, so a helper-runtime session and an instructions-only
   session see the same lock.
 
+### Clone-scoped lock
+
+- Source repo / vendored-node commands:
+  `node scripts/clone-lock.mjs --exec --agent-id <id> [--repo <path>]
+  [--timeout-ms <n>] -- <command> [args...]`
+  and `node scripts/clone-lock.mjs --check [--repo <path>]`
+- Package-manager / ephemeral-npx command: use the profile-selected
+  `idd:clone-lock` command from the helper runtime manifest wiring
+  above; the literal invocations are:
+
+  ```sh
+  npx --yes --package <helper-package-spec> \
+    idd-clone-lock --exec --agent-id <id> [--repo <path>] \
+    [--timeout-ms <n>] -- <command> [args...]
+
+  npx --yes --package <helper-package-spec> \
+    idd-clone-lock --check [--repo <path>]
+  ```
+
+- A mutual-exclusion mutex around `git worktree add`/`remove` and
+  `git fetch` against the _shared_ primary clone — unlike the
+  worktree-local claim lock above, this blocks (retrying with backoff)
+  rather than reporting an immediate collision, and serializes
+  concurrent workers sharing one clone rather than guarding one
+  worktree's own claim identity. See the
+  [Orchestrator fan-out variant](idd-workflow.md#orchestrator-fan-out-variant)
+  for when to reach for it.
+- `--exec` acquires, runs `<command>` with stdio inherited and `cwd`
+  set to `--repo`, then releases the lock even if the command fails,
+  exiting with the command's own exit code; exits `3` if the lock
+  could not be acquired within `--timeout-ms` (default 120000).
+- `--check` reports `{ path, present, holder?, malformed? }`
+  read-only, the same shape as the worktree-local claim lock's
+  `--check` above.
+- A lock whose lease has not been refreshed for 5 minutes is treated
+  as abandoned by a dead holder and taken over; `--exec` refreshes its
+  own lease periodically while the wrapped command runs, so a
+  legitimately long-running `git fetch` is never mistaken for a dead
+  holder. Recovering an abandoned lock is itself race-free across
+  concurrent contenders: removal and recreation are each a separate
+  exclusive step, so exactly one contender ever wins a takeover.
+- **`instructions-only` helper-free fallback (no helper runtime
+  available)**: this lock is a same-machine convenience for
+  parallel autonomous fan-out, not a correctness requirement — an
+  `instructions-only` session running one worker at a time never
+  contends for it. Where an `instructions-only` profile does run
+  concurrent workers sharing one clone, serialize `git worktree
+  add`/`remove`/`fetch` by giving each worker its own clone instead
+  (see the Orchestrator fan-out variant linked above), rather than
+  hand-rolling this lock's protocol.
+
 ### Canonical branch name
 
 - Source repo / vendored-node command:

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1337,9 +1337,14 @@ Interpretation rules:
 ### Clone-scoped lock
 
 - Source repo / vendored-node commands:
-  `node scripts/clone-lock.mjs --exec --agent-id <id> [--repo <path>]
-  [--timeout-ms <n>] -- <command> [args...]`
-  and `node scripts/clone-lock.mjs --check [--repo <path>]`
+
+  ```sh
+  node scripts/clone-lock.mjs --exec --agent-id <id> [--repo <path>] \
+    [--timeout-ms <n>] -- <command> [args...]
+
+  node scripts/clone-lock.mjs --check [--repo <path>]
+  ```
+
 - Package-manager / ephemeral-npx command: use the profile-selected
   `idd:clone-lock` command from the helper runtime manifest wiring
   above; the literal invocations are:

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1370,16 +1370,18 @@ Interpretation rules:
   set to `--repo`, then releases the lock even if the command fails,
   exiting with the command's own exit code; exits `3` if the lock
   could not be acquired within `--timeout-ms` (default 120000).
-- `--check` reports `{ path, present, holder?, malformed? }`
-  read-only, the same shape as the worktree-local claim lock's
-  `--check` above.
-- A lock is eligible for takeover only once its recorded holder
-  process is confirmed dead (`process.kill(pid, 0)`), not after any
-  fixed time period; a live holder's lock is never taken over,
-  however long it is held, so a legitimately long-running `git fetch`
-  is never mistaken for a dead holder. A malformed lock body (no
-  readable `pid`) is never auto-recovered — see `--check`'s
-  `malformed: true` output for manual diagnosis.
+- `--check` reports `{ path, present, holder?, malformed?,
+  holderAlive? }` read-only; `holderAlive` (diagnostic only, from
+  `process.kill(pid, 0)`) reports whether the recorded holder still
+  appears to be running.
+- **No automatic stale-lock recovery**: a held lock is never taken
+  over, regardless of how long it has been held or whether its
+  recorded holder is still alive. `--exec` exits `3` on a
+  `--timeout-ms` timeout, naming the lock path and the recorded
+  holder's pid in the error message; once you have independently
+  confirmed that holder is gone, remove the lock file by hand and
+  retry — the same recovery git's own `index.lock` expects on a
+  stale-lock collision.
 - **`instructions-only` helper-free fallback (no helper runtime
   available)**: this lock is a same-machine convenience for
   parallel autonomous fan-out, not a correctness requirement — an

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1373,8 +1373,9 @@ Interpretation rules:
   own lease periodically while the wrapped command runs, so a
   legitimately long-running `git fetch` is never mistaken for a dead
   holder. Recovering an abandoned lock is itself race-free across
-  concurrent contenders: removal and recreation are each a separate
-  exclusive step, so exactly one contender ever wins a takeover.
+  concurrent contenders: removal and recreation happen only while
+  holding a companion PID-tagged arbiter lock, so at most one
+  contender is ever doing that at a time.
 - **`instructions-only` helper-free fallback (no helper runtime
   available)**: this lock is a same-machine convenience for
   parallel autonomous fan-out, not a correctness requirement — an

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1373,14 +1373,13 @@ Interpretation rules:
 - `--check` reports `{ path, present, holder?, malformed? }`
   read-only, the same shape as the worktree-local claim lock's
   `--check` above.
-- A lock whose lease has not been refreshed for 5 minutes is treated
-  as abandoned by a dead holder and taken over; `--exec` refreshes its
-  own lease periodically while the wrapped command runs, so a
-  legitimately long-running `git fetch` is never mistaken for a dead
-  holder. Recovering an abandoned lock is itself race-free across
-  concurrent contenders: removal and recreation happen only while
-  holding a companion PID-tagged arbiter lock, so at most one
-  contender is ever doing that at a time.
+- A lock is eligible for takeover only once its recorded holder
+  process is confirmed dead (`process.kill(pid, 0)`), not after any
+  fixed time period; a live holder's lock is never taken over,
+  however long it is held, so a legitimately long-running `git fetch`
+  is never mistaken for a dead holder. A malformed lock body (no
+  readable `pid`) is never auto-recovered — see `--check`'s
+  `malformed: true` output for manual diagnosis.
 - **`instructions-only` helper-free fallback (no helper runtime
   available)**: this lock is a same-machine convenience for
   parallel autonomous fan-out, not a correctness requirement — an

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -604,9 +604,9 @@ Running this variant safely requires:
   one clone.** Concurrent `git fetch` / `git worktree add` / `git
   worktree remove` / local `{development-branch}` updates from the
   same primary clone can collide; serialize these specific operations
-  behind a per-clone lock, or give concurrent workers separate
-  clones, once the concurrency cap allows more than one worker at a
-  time.
+  behind the [clone-scoped lock](idd-helper-scripts.md#clone-scoped-lock),
+  or give concurrent workers separate clones, once the concurrency cap
+  allows more than one worker at a time.
 - **Resume-specific recovery when a worker dies mid-turn.** Re-verify
   claim ownership and worktree state before continuing; treat any
   uncommitted work found in the worktree as unverified input to check,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "idd-ci-wait-state": "./bin/idd-ci-wait-state.mjs",
     "idd-claim-approval-gate": "./bin/idd-claim-approval-gate.mjs",
     "idd-claim-lock": "./bin/idd-claim-lock.mjs",
+    "idd-clone-lock": "./bin/idd-clone-lock.mjs",
     "idd-critique-delegate": "./bin/idd-critique-delegate.mjs",
     "idd-discover-orphan-filter": "./bin/idd-discover-orphan-filter.mjs",
     "idd-discover-readiness-check": "./bin/idd-discover-readiness-check.mjs",

--- a/scripts/clone-lock.mjs
+++ b/scripts/clone-lock.mjs
@@ -10,11 +10,11 @@
 // clone when multiple concurrent sessions operate against it. This is a
 // different kind of lock than `claim-lock.mts`: that one records
 // worktree-local *ownership* for a whole worker's lifetime and reports a
-// same-machine collision immediately (never blocks). This one is a short
-// -duration *mutex* around a single git operation -- it blocks (retrying
-// with backoff) until it can acquire, up to a bounded timeout, because the
-// operations it guards are expected to finish in seconds, not the hours a
-// claim can be held for.
+// same-machine collision immediately (never blocks). This one is a
+// short-duration *mutex* around a single git operation -- it blocks
+// (retrying with backoff) until it can acquire, up to a bounded timeout,
+// because the operations it guards are expected to finish in seconds, not
+// the hours a claim can be held for.
 //
 // The lock file lives in the primary clone's *shared* git-admin directory
 // (`git rev-parse --path-format=absolute --git-common-dir`), not any one
@@ -27,18 +27,35 @@
 //
 // A holder that crashes mid-operation leaves an orphaned lock file behind
 // -- unlike a real `flock(2)`, a plain lock file is not released
-// automatically when its owning process dies. `STALE_LOCK_MS` bounds how
-// long a stuck lock can block every other session: once a lock's recorded
-// `acquiredAt` is older than that, a waiter treats it as abandoned and
-// force-takes it over. This is a purely local liveness heuristic scoped to
-// operations that normally complete in seconds -- it carries none of
+// automatically when its owning process dies. Staleness is judged by the
+// lock file's own mtime, not the `acquiredAt` field inside its JSON body
+// -- so a malformed lock (e.g. a crashed partial write, which can never
+// be parsed back into a valid `acquiredAt`) ages out and recovers exactly
+// like a well-formed one, instead of blocking every future waiter
+// forever. `STALE_LOCK_MS` bounds how long an abandoned lock can block
+// every other session; `withCloneLock`'s `--exec` path refreshes its own
+// lease (rewrites the file, which bumps its mtime) at roughly half that
+// interval while the wrapped command runs, so a legitimately
+// long-running operation is never mistaken for a dead holder. Recovering
+// a stale (or malformed-and-stale) lock is two exclusive races, not one:
+// first for the right to remove the abandoned entry (`renameSync` on a
+// specific source path -- POSIX serializes concurrent renames of the
+// same directory entry, so exactly one racer's removal ever succeeds,
+// see `tryClaimStaleLockForRemoval`'s own doc comment for why a plain
+// check-then-`unlinkSync` pair cannot make this same guarantee), then
+// for the right to recreate it (the same `{ flag: 'wx' }` primitive a
+// fresh acquire uses). Every loser at either step falls back to the
+// normal wait/retry loop rather than assuming it acquired. This is a
+// purely local liveness heuristic scoped to operations that normally
+// complete in seconds -- it carries none of
 // `claim-lock.mts`'s GitHub-reverification requirement, because this lock
 // has no cross-machine claim-ownership meaning to protect.
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import {
   readFileSync,
   renameSync,
   rmSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -50,8 +67,14 @@ const CLONE_LOCK_FILE_NAME = 'idd-clone.lock';
 const DEFAULT_TIMEOUT_MS = 120_000;
 /** Delay between retry attempts while waiting for a held lock. */
 const POLL_INTERVAL_MS = 200;
-/** A lock older than this is treated as abandoned by a dead holder. */
+/** A lock whose mtime is older than this is treated as abandoned. */
 const STALE_LOCK_MS = 5 * 60_000;
+/**
+ * How often `withCloneLock` refreshes its own lease while the wrapped
+ * command runs. Comfortably inside `STALE_LOCK_MS` so a live holder's
+ * lease never lapses into apparent staleness between refreshes.
+ */
+const DEFAULT_LEASE_REFRESH_MS = Math.floor(STALE_LOCK_MS / 2);
 const CLONE_LOCK_FLAG_SPEC = {
   '--exec': { type: 'boolean' },
   '--check': { type: 'boolean' },
@@ -60,9 +83,6 @@ const CLONE_LOCK_FLAG_SPEC = {
   '--timeout-ms': { type: 'string' },
   '--help': { type: 'boolean', short: 'h' },
 };
-if (import.meta.main) {
-  runCli();
-}
 /**
  * Mirrors `claim-lock.mts`'s environment sanitization: repository
  * discovery must stay tied to the requested `--repo` path, never to an
@@ -144,29 +164,92 @@ function sleepSync(ms) {
   Atomics.wait(new Int32Array(sharedBuffer), 0, 0, ms);
 }
 /**
- * Force-remove an abandoned (stale or malformed) lock at `path` and
- * install a fresh one, mirroring `claim-lock.mts`'s
- * `overwriteLockAtomically`: write a same-directory temp file, then
- * `renameSync` into place (atomic on POSIX; the existing-file fallback
- * below covers Windows, which requires the destination removed first).
+ * The lock file's own mtime age in ms, or `null` when the path doesn't
+ * exist (raced away between the caller's failed create and this stat --
+ * treated as "not (yet provably) stale"; the caller's next loop
+ * iteration re-reads and, finding it absent, wins a fresh acquire).
+ * Deliberately reads filesystem mtime rather than the JSON body's
+ * `acquiredAt` field: mtime is set by every write (including a crashed,
+ * unparseable partial one) and by every lease refresh, so one staleness
+ * check works uniformly for a malformed lock, a well-formed one, and a
+ * refreshed live one.
  */
-function takeOverLock(path, agentId, token) {
-  const tmpPath = `${path}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
-  writeFileSync(tmpPath, renderLockBody(agentId, token), { flag: 'wx' });
+function lockAgeMs(path) {
   try {
-    try {
-      renameSync(tmpPath, path);
-    } catch {
-      rmSync(path, { recursive: true, force: true });
-      renameSync(tmpPath, path);
+    return Date.now() - statSync(path).mtimeMs;
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return null;
     }
-  } finally {
-    try {
-      unlinkSync(tmpPath);
-    } catch {
-      // Best-effort: a successful rename already moved tmpPath away.
+    throw error;
+  }
+}
+/**
+ * Exclusively create the lock file, succeeding only when nothing else won
+ * the race first. Both a fresh acquire and a stale-lock takeover funnel
+ * through this same primitive, so at most one contender ever wins either
+ * path.
+ */
+function tryExclusiveCreate(path, agentId, token) {
+  try {
+    writeFileSync(path, renderLockBody(agentId, token), { flag: 'wx' });
+    return true;
+  } catch (error) {
+    if (error.code === 'EEXIST') {
+      return false;
+    }
+    throw error;
+  }
+}
+/**
+ * Exclusively claim the (believed-stale) lock at `path` for removal, so
+ * that even when multiple contenders simultaneously observe the same
+ * stale mtime, only one of them ever actually removes it. `renameSync`
+ * on a specific SOURCE path is itself the race-free primitive this needs
+ * -- POSIX serializes concurrent rename operations against the same
+ * directory entry, so among any number of racing
+ * `renameSync(path, <unique-destination>)` calls, exactly one succeeds
+ * (moving `path` away) and every later call sees `ENOENT`, since by the
+ * time it runs `path` no longer exists to rename from. This closes a
+ * race a plain check-then-`unlinkSync` pair cannot: two contenders can
+ * both observe the same stale mtime from independent reads, and a plain
+ * `unlinkSync` never verifies the file it deletes is still the one that
+ * was checked -- it happily deletes whatever a faster contender already
+ * replaced it with (including that contender's brand new, non-stale
+ * lock), letting both contenders believe they won.
+ *
+ * Returns `false` (a lost race, not an error) on `ENOENT` -- the normal
+ * outcome for every contender except the one that actually wins. The
+ * destination is a unique per-attempt "graveyard" path so concurrent
+ * winners of DIFFERENT stale-lock generations never collide with each
+ * other; it is then discarded immediately (`unlinkSync`, with a
+ * `recursive: true` `rmSync` fallback for the
+ * malformed-lock-is-a-directory edge case `claim-lock.mts`'s own
+ * takeover path also handles) -- this cleanup is unconditionally safe
+ * regardless of recursion, since nothing else can ever reference this
+ * exact path.
+ */
+function tryClaimStaleLockForRemoval(path) {
+  const graveyardPath = `${path}.graveyard-${process.pid}-${Math.random().toString(36).slice(2)}`;
+  try {
+    renameSync(path, graveyardPath);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+  try {
+    unlinkSync(graveyardPath);
+  } catch (error) {
+    const code = error.code;
+    if (code === 'EISDIR' || code === 'EPERM') {
+      rmSync(graveyardPath, { recursive: true, force: true });
+    } else if (code !== 'ENOENT') {
+      throw error;
     }
   }
+  return true;
 }
 /**
  * Thrown when a lock cannot be acquired within `timeoutMs`.
@@ -180,42 +263,43 @@ export class CloneLockTimeoutError extends Error {
 /**
  * Block (retrying with backoff) until the clone-scoped lock at `repoPath`
  * is acquired, or throw {@link CloneLockTimeoutError} after `timeoutMs`.
- * A lock older than `STALE_LOCK_MS` is treated as abandoned and taken
- * over rather than waited out.
+ * A lock whose mtime is older than `staleMs` is treated as abandoned;
+ * every waiter that notices races for its removal via
+ * {@link tryClaimStaleLockForRemoval} (exactly one ever wins, by
+ * construction) and then for its recreation via the same
+ * exclusive-create primitive a fresh acquire uses -- every loser at
+ * either step simply continues waiting rather than assuming it
+ * acquired. `staleMs` defaults to `STALE_LOCK_MS` and is exposed only
+ * for tests that need a short-lived clock; production callers should
+ * not override it.
  */
 export function acquireCloneLock(
   repoPath,
   agentId,
   timeoutMs = DEFAULT_TIMEOUT_MS,
+  staleMs = STALE_LOCK_MS,
 ) {
   const path = resolveCloneLockPath(repoPath);
   const token = randomToken();
   const deadline = Date.now() + timeoutMs;
   for (;;) {
-    const read = readLock(path);
-    if (read.status === 'absent') {
-      try {
-        writeFileSync(path, renderLockBody(agentId, token), { flag: 'wx' });
-        return { path, token };
-      } catch (error) {
-        if (error.code !== 'EEXIST') {
-          throw error;
-        }
-        // Raced with a concurrent acquire between the read and this
-        // create; fall through to the wait/retry path below.
-      }
-    } else if (read.status === 'malformed') {
-      // A malformed body's age can't be determined; treat it the same as
-      // a fresh, definitely-not-stale lock and wait for it rather than
-      // taking it over immediately -- an in-progress writer's partial
-      // write should not be mistaken for an abandoned lock.
-    } else {
-      const ageMs = Date.now() - Date.parse(read.lock.acquiredAt);
-      if (Number.isFinite(ageMs) && ageMs > STALE_LOCK_MS) {
-        takeOverLock(path, agentId, token);
-        return { path, token };
-      }
+    if (tryExclusiveCreate(path, agentId, token)) {
+      return { path, token };
     }
+    const ageMs = lockAgeMs(path);
+    if (
+      ageMs !== null &&
+      ageMs > staleMs &&
+      tryClaimStaleLockForRemoval(path) &&
+      tryExclusiveCreate(path, agentId, token)
+    ) {
+      return { path, token };
+    }
+    // Either not (yet provably) stale, lost the removal race to another
+    // contender, or -- vanishingly unlikely -- won the removal race but
+    // then lost the immediate recreate to an unrelated fresh acquirer;
+    // every case falls through to the normal wait/retry path below
+    // rather than assuming acquisition.
     if (Date.now() >= deadline) {
       throw new CloneLockTimeoutError(path, timeoutMs);
     }
@@ -241,6 +325,34 @@ export function releaseCloneLock(handle) {
     }
   }
 }
+/**
+ * Rewrite the lock body at `handle.path`, bumping its mtime, but only
+ * when the on-disk token still matches `handle.token` -- this never
+ * refreshes (or resurrects) a lock a different session now holds. Used
+ * by {@link withCloneLock} to keep a legitimately long-running holder's
+ * lease from lapsing into apparent staleness. A read-then-write race
+ * against a concurrent stale takeover is inherent to a plain lock file
+ * (there is no atomic compare-and-swap primitive here); the default
+ * refresh cadence is sized generously relative to the staleness window
+ * specifically to make that race vanishingly unlikely to matter in
+ * practice. A failed refresh (e.g. the path became briefly inaccessible)
+ * is silently swallowed: the next timer tick simply retries, and
+ * `releaseCloneLock`'s own token check means a truly lost lease never
+ * gets misreported as released.
+ */
+export function refreshCloneLock(handle) {
+  const read = readLock(handle.path);
+  if (read.status === 'present' && read.lock.token === handle.token) {
+    try {
+      writeFileSync(
+        handle.path,
+        renderLockBody(read.lock.agentId, handle.token),
+      );
+    } catch {
+      // Best-effort; see the doc comment above.
+    }
+  }
+}
 /** Read-only lock inspection: never creates, mutates, or deletes the lock. */
 export function checkCloneLock(repoPath) {
   const path = resolveCloneLockPath(repoPath);
@@ -254,25 +366,36 @@ export function checkCloneLock(repoPath) {
   return { path, present: true, holder: read.lock };
 }
 /**
- * Acquire the clone lock, run `command` with `args` (inheriting stdio),
- * then release the lock -- even if the command fails. Returns the
- * command's exit code (`null` when it was killed by a signal).
+ * Acquire the clone lock, run `command` with `args` (inheriting stdio,
+ * `cwd` set to `repoPath` so the wrapped git operation always targets the
+ * same repository the lock scopes), then release the lock -- even if the
+ * command fails. While the command runs, the lease is refreshed every
+ * `leaseRefreshMs` (default {@link DEFAULT_LEASE_REFRESH_MS}) so a
+ * legitimately long-running operation is never mistaken for an abandoned
+ * holder by another waiter. Returns the command's exit code (`null` when
+ * it was killed by a signal). `staleMs`/`leaseRefreshMs` are exposed only
+ * for tests that need a short-lived clock; production callers should not
+ * override them.
  */
-export function withCloneLock(
+export async function withCloneLock(
   repoPath,
   agentId,
   command,
   args,
   timeoutMs = DEFAULT_TIMEOUT_MS,
+  staleMs = STALE_LOCK_MS,
+  leaseRefreshMs = DEFAULT_LEASE_REFRESH_MS,
 ) {
-  const handle = acquireCloneLock(repoPath, agentId, timeoutMs);
+  const handle = acquireCloneLock(repoPath, agentId, timeoutMs, staleMs);
+  const heartbeat = setInterval(() => refreshCloneLock(handle), leaseRefreshMs);
   try {
-    const result = spawnSync(command, args, { stdio: 'inherit' });
-    if (result.error) {
-      throw result.error;
-    }
-    return result.status;
+    return await new Promise((resolve, reject) => {
+      const child = spawn(command, args, { stdio: 'inherit', cwd: repoPath });
+      child.once('error', reject);
+      child.once('exit', (code) => resolve(code));
+    });
   } finally {
+    clearInterval(heartbeat);
     releaseCloneLock(handle);
   }
 }
@@ -310,7 +433,7 @@ function parseArgs(argv) {
     command,
   };
 }
-function runCli() {
+async function runCli() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
     printHelp();
@@ -332,7 +455,7 @@ function runCli() {
   }
   const [command, ...commandArgs] = args.command;
   try {
-    const status = withCloneLock(
+    const status = await withCloneLock(
       repo,
       args.agentId,
       command,
@@ -357,12 +480,14 @@ function printHelp() {
 Clone-scoped mutual-exclusion lock: serializes \`git worktree add\`,
 \`git worktree remove\`, and \`git fetch\` against the shared primary
 clone across concurrent sessions. \`--exec\` blocks (retrying) until the
-lock is acquired, runs <command> [args...] with stdio inherited, then
-releases the lock -- even if the command fails -- and exits with the
-command's own exit code. A lock held longer than 5 minutes is treated
-as abandoned by a dead holder and taken over rather than waited out.
-Exits 3 if the lock could not be acquired within --timeout-ms
-(default 120000).
+lock is acquired, runs <command> [args...] with stdio inherited and cwd
+set to --repo, then releases the lock -- even if the command fails --
+and exits with the command's own exit code. A lock whose lease has not
+been refreshed for 5 minutes is treated as abandoned by a dead holder
+and taken over; \`--exec\` refreshes its own lease periodically while
+the wrapped command runs, so a legitimately long-running operation is
+never mistaken for a dead holder. Exits 3 if the lock could not be
+acquired within --timeout-ms (default 120000).
 
 --check is read-only: it reports the current lock state without
 creating, mutating, or deleting anything. \`malformed: true\` means a
@@ -370,4 +495,14 @@ lock file exists but could not be parsed as a well-formed lock body.
 
 --repo defaults to the current working directory.
 `);
+}
+// This bootstrap call is placed after every declaration in this module,
+// not near the top -- `runCli()`'s error path references the
+// `CloneLockTimeoutError` class below, and a class binding (unlike a
+// hoisted function declaration) stays in its temporal dead zone until its
+// own declaration statement executes. Invoking `runCli()` before that
+// point would throw a `ReferenceError` on any `--exec` timeout instead of
+// the documented message and exit code 3.
+if (import.meta.main) {
+  runCli();
 }

--- a/scripts/clone-lock.mjs
+++ b/scripts/clone-lock.mjs
@@ -25,68 +25,63 @@
 // which `claim-lock.mts` uses for its narrower per-worktree scope) is
 // required here.
 //
-// A holder that crashes mid-operation leaves an orphaned lock file behind
-// -- unlike a real `flock(2)`, a plain lock file is not released
-// automatically when its owning process dies. Staleness is judged by the
-// lock file's own mtime, not the `acquiredAt` field inside its JSON body
-// -- so a malformed lock (e.g. a crashed partial write, which can never
-// be parsed back into a valid `acquiredAt`) ages out and recovers exactly
-// like a well-formed one, instead of blocking every future waiter
-// forever. `STALE_LOCK_MS` bounds how long an abandoned lock can block
-// every other session; `withCloneLock`'s `--exec` path refreshes its own
-// lease (rewrites the file, which bumps its mtime) at roughly half that
-// interval while the wrapped command runs, so a legitimately
-// long-running operation is never mistaken for a dead holder.
-//
-// Recovering a stale lock is NOT simply "remove it, then race the usual
-// exclusive-create": two contenders can independently observe the same
-// stale mtime, and neither a plain `unlinkSync` nor a plain `renameSync`
-// on its own verifies the file it removes is still the exact entry that
-// was checked -- both happily remove whatever a faster contender already
-// replaced it with (including that contender's brand-new, non-stale
-// lock), letting more than one contender believe it took over (this
-// repository's own review history on #2223 caught and reproduced exactly
-// that double-winner failure from an earlier `renameSync`-only attempt at
-// this fix, roughly one run in ten under concurrent load). The real fix
-// is a second, PID-tagged arbiter lock (`tryAcquireArbiter`): every
-// operation that mutates an EXISTING main lock -- takeover, release,
-// refresh -- runs only while holding it, so at most one contender is
-// ever doing that at a time, regardless of how many independently
-// observed the same stale mtime or the same token. Release and refresh
-// need this too, not only takeover: without it, a holder whose own
-// process stalled long enough for its lease to go stale and get taken
-// over by someone else could read a stale-but-still-matching token, then
-// delete or overwrite the NEW holder's fresh lock in the gap before its
-// own act (unlink or write) runs -- this repository's review history on
-// #2223 caught this as a separate gap from takeover's own, in the SAME
-// round that also caught takeover's residual double-winner race (an
-// earlier `renameSync`-only takeover attempt, with no arbiter at all,
-// reproduced roughly one run in ten under concurrent load). The
-// arbiter's own staleness is judged primarily by process liveness
-// (`isPidAlive`), not a time threshold, because its critical section is
-// always a handful of synchronous, no-I/O-wait statements -- "the
-// recorded PID no longer exists" is both necessary and sufficient to
-// know its holder crashed and can never finish or release it, with none
-// of a time threshold's inherent "probably dead by now" ambiguity; a
-// marker whose body can't be parsed (no PID to check) falls back to a
-// short, generous age threshold instead, so a crash mid-write there
-// isn't permanently unrecoverable either. This is a purely local
-// liveness heuristic scoped to operations that normally complete in
-// seconds -- it carries none of `claim-lock.mts`'s GitHub-reverification
-// requirement, because this lock has no cross-machine claim-ownership
-// meaning to protect.
+// A holder that crashes leaves an orphaned lock file behind -- unlike a
+// real `flock(2)`, a plain lock file is not released automatically when
+// its owning process dies. Staleness is judged by process liveness
+// (`isPidAlive`, `process.kill(pid, 0)`), not elapsed time: the lock body
+// records the holder's own `pid`, alongside `claim-lock.mts`'s existing
+// `token`/`agentId`/`acquiredAt` shape, and a lock is only ever eligible
+// for takeover once that exact PID is confirmed dead. This replaced an
+// earlier mtime-based design (recover anything older than a fixed
+// threshold, with the holder periodically refreshing its own lease to
+// prove it was still alive) after that design's CI run exposed the
+// failure mode it was always structurally prone to: a live,
+// actively-refreshing holder got taken over anyway, because "has this
+// timestamp aged past a threshold" is inherently a race against ordinary
+// process-scheduling jitter (a refresh landing late, a waiter's own
+// staleness check landing early) in a way "is this specific PID still
+// running" simply is not -- a process is never "probably dead by now,"
+// it is either scheduled on the OS right now or it does not exist.
+// Because the holder process for this lock (the one running `withExec`'s
+// wrapped command) stays alive for its own entire hold, no periodic
+// lease refresh is needed at all: liveness is continuously, automatically
+// true for as long as the holder is doing anything, and instantly,
+// unambiguously false the moment it exits or crashes. This also makes
+// release and takeover logically disjoint rather than a race to close:
+// release only ever runs from the live holder's own still-running
+// process (whose PID is, by definition, alive), so a takeover's PID
+// -liveness check can never mistake an active release-in-progress for a
+// dead holder -- no arbiter, inode verification, or other coordination
+// primitive beyond the plain `wx`-exclusive-create every acquire already
+// uses is needed to keep the two from conflicting. A takeover
+// re-confirms the lock is still the exact dead entry it inspected
+// (re-reading immediately before removing) rather than trusting a
+// possibly-stale earlier check, then goes through the SAME
+// `{ flag: 'wx' }` primitive a fresh acquire uses to recreate it -- the
+// only decision authority for who wins a contested recreate is the OS
+// kernel's own `O_EXCL` guarantee, not any bookkeeping this module
+// performs itself. One race is knowingly NOT closed: the single-syscall
+// gap between that re-confirmation read and the `unlinkSync` that acts
+// on it. Closing it fully would need a kernel-level compare-and-swap
+// this module does not have access to from plain POSIX file primitives;
+// every design this module has tried carries an equivalent residual gap
+// somewhere, and the ones that attempted to close this exact one (a
+// PID-tagged arbiter lock plus inode-verified recovery) each introduced
+// a NEW, worse gap of their own across three consecutive review rounds
+// (#2223) rather than actually eliminating it. This narrow, explicitly
+// accepted gap is deliberately simpler to reason about than that
+// alternative. A malformed lock body (e.g. a crashed partial write) has
+// no readable `pid` to check liveness against and is therefore never
+// auto-recovered -- `writeFileSync`'s single, small write is atomic in
+// practice on every realistic filesystem, so genuinely torn content is
+// vanishingly rare, and this module intentionally does not add recovery
+// machinery for it; see `--check`'s `malformed: true` output for manual
+// diagnosis. This is a purely local liveness heuristic scoped to
+// operations that normally complete in seconds -- it carries none of
+// `claim-lock.mts`'s GitHub-reverification requirement, because this
+// lock has no cross-machine claim-ownership meaning to protect.
 import { execFileSync, spawn } from 'node:child_process';
-import {
-  closeSync,
-  fstatSync,
-  openSync,
-  readFileSync,
-  renameSync,
-  rmSync,
-  statSync,
-  unlinkSync,
-  writeFileSync,
-} from 'node:fs';
+import { readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { parseCliArgs } from './cli-args.mjs';
 
@@ -95,35 +90,6 @@ const CLONE_LOCK_FILE_NAME = 'idd-clone.lock';
 const DEFAULT_TIMEOUT_MS = 120_000;
 /** Delay between retry attempts while waiting for a held lock. */
 const POLL_INTERVAL_MS = 200;
-/** A lock whose mtime is older than this is treated as abandoned. */
-const STALE_LOCK_MS = 5 * 60_000;
-/**
- * How often `withCloneLock` refreshes its own lease while the wrapped
- * command runs. Comfortably inside `STALE_LOCK_MS` so a live holder's
- * lease never lapses into apparent staleness between refreshes.
- */
-const DEFAULT_LEASE_REFRESH_MS = Math.floor(STALE_LOCK_MS / 2);
-/**
- * An arbiter marker whose body can't be parsed (e.g. a crashed partial
- * write) has no recorded PID to check liveness against. Its critical
- * section is always a handful of synchronous, no-I/O-wait statements, so
- * this age threshold only ever needs to be "generous relative to a
- * syscall," not to any real operation's duration -- unlike
- * `STALE_LOCK_MS`, which must outlast a genuine `git fetch`.
- */
-const ARBITER_MALFORMED_STALE_MS = 5_000;
-/**
- * Bounds how many times {@link releaseCloneLock} / {@link refreshCloneLock}
- * retry a contended arbiter before giving up for this one call. Every
- * arbiter hold in this module is a handful of synchronous statements, so
- * contention clears in microseconds; this is a small, bounded backstop,
- * not a real wait budget. Giving up is safe, not catastrophic: a release
- * that couldn't get in leaves the lock for the module's own
- * staleness+takeover machinery to eventually reclaim, and a refresh that
- * couldn't get in is simply retried on the next heartbeat tick.
- */
-const ARBITER_RETRY_ATTEMPTS = 50;
-const ARBITER_RETRY_DELAY_MS = 2;
 const CLONE_LOCK_FLAG_SPEC = {
   '--exec': { type: 'boolean' },
   '--check': { type: 'boolean' },
@@ -168,6 +134,7 @@ function isCloneLockBody(value) {
   return (
     typeof value === 'object' &&
     value !== null &&
+    typeof value.pid === 'number' &&
     typeof value.token === 'string' &&
     typeof value.agentId === 'string' &&
     typeof value.acquiredAt === 'string'
@@ -195,6 +162,7 @@ function readLock(path) {
 }
 function renderLockBody(agentId, token) {
   const body = {
+    pid: process.pid,
     token,
     agentId,
     acquiredAt: new Date().toISOString(),
@@ -213,31 +181,39 @@ function sleepSync(ms) {
   Atomics.wait(new Int32Array(sharedBuffer), 0, 0, ms);
 }
 /**
- * The lock file's own mtime age in ms, or `null` when the path doesn't
- * exist (raced away between the caller's failed create and this stat --
- * treated as "not (yet provably) stale"; the caller's next loop
- * iteration re-reads and, finding it absent, wins a fresh acquire).
- * Deliberately reads filesystem mtime rather than the JSON body's
- * `acquiredAt` field: mtime is set by every write (including a crashed,
- * unparseable partial one) and by every lease refresh, so one staleness
- * check works uniformly for a malformed lock, a well-formed one, and a
- * refreshed live one.
+ * `true` when `pid` identifies a currently-running process, `false` when
+ * it definitely does not. `process.kill(pid, 0)` sends no actual signal
+ * -- it only probes existence/permission. `ESRCH` (no such process) is
+ * the only outcome that means dead; `EPERM` (the process exists but this
+ * one lacks permission to signal it) and success both mean alive. This
+ * is a reliable, instantaneous, non-time-based liveness check: unlike an
+ * elapsed-time threshold, there is no ambiguity window where a process
+ * might be "probably dead by now" -- it either currently exists or it
+ * does not.
  */
-function lockAgeMs(path) {
+function isPidAlive(pid) {
   try {
-    return Date.now() - statSync(path).mtimeMs;
+    process.kill(pid, 0);
+    return true;
   } catch (error) {
-    if (error.code === 'ENOENT') {
-      return null;
-    }
-    throw error;
+    return error.code === 'EPERM';
   }
 }
 /**
+ * `true` when `path` currently holds a well-formed lock whose recorded
+ * `pid` is confirmed dead. `false` for an absent, malformed (no `pid` to
+ * check -- see this module's header comment for why that edge case is
+ * not auto-recovered), or live lock.
+ */
+function isDeadLock(read) {
+  return read.status === 'present' && !isPidAlive(read.lock.pid);
+}
+/**
  * Exclusively create the lock file, succeeding only when nothing else won
- * the race first. Both a fresh acquire and a stale-lock takeover funnel
+ * the race first. Both a fresh acquire and a dead-lock takeover funnel
  * through this same primitive, so at most one contender ever wins either
- * path.
+ * path -- the OS kernel's own `O_EXCL` guarantee is the sole decision
+ * authority for who wins a contested create.
  */
 function tryExclusiveCreate(path, agentId, token) {
   try {
@@ -251,300 +227,33 @@ function tryExclusiveCreate(path, agentId, token) {
   }
 }
 /**
- * Companion path for the PID-tagged arbiter lock that guards a stale
- * -takeover REMOVAL against `path` -- see {@link tryAcquireArbiter}.
+ * Attempt to recover a lock at `path` whose recorded holder is confirmed
+ * dead, then immediately recreate it as `agentId`/`token`. Re-reads the
+ * lock immediately before removing it, rather than trusting the
+ * caller's own (possibly now-stale) check, to narrow -- though, per this
+ * module's header comment, not fully close -- the gap between
+ * confirming death and acting on it. Returns `false` (never throws for
+ * this) when the lock is no longer confirmed dead by the time of the
+ * re-check, or recreation lost to an unrelated fresh acquirer in the
+ * brief gap after this function's own removal (that acquirer's
+ * `wx`-create is exclusive by construction either way, so this is safe
+ * regardless of how it resolves).
  */
-function arbiterPath(path) {
-  return `${path}.arbiter`;
-}
-/**
- * `true` when `pid` identifies a currently-running process, `false` when
- * it definitely does not. `process.kill(pid, 0)` sends no actual signal
- * -- it only probes existence/permission. `ESRCH` (no such process) is
- * the only outcome that means dead; `EPERM` (the process exists but this
- * one lacks permission to signal it) and success both mean alive. This
- * is a reliable, instantaneous, non-time-based liveness check -- unlike
- * an mtime-based staleness threshold, there is no ambiguity window where
- * a process might be "probably dead by now": it either currently exists
- * or it does not.
- */
-function isPidAlive(pid) {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return error.code === 'EPERM';
+function tryTakeOverDeadLock(path, agentId, token) {
+  if (!isDeadLock(readLock(path))) {
+    return false;
   }
-}
-/**
- * Best-effort remove `path`, falling back to a recursive `rmSync` only
- * for the directory-shaped edge case (a malformed marker or lock that
- * happens to be a directory, not the expected regular file) -- mirroring
- * `claim-lock.mts`'s own takeover path. Every caller of this helper only
- * ever targets a path nothing else can reference (a per-attempt
- * graveyard copy this process alone renamed there), so recursion here is
- * unconditionally safe regardless of what it finds.
- */
-function discardBestEffort(path) {
+  if (!isDeadLock(readLock(path))) {
+    return false;
+  }
   try {
     unlinkSync(path);
-  } catch (error) {
-    const code = error.code;
-    if (code === 'EISDIR' || code === 'EPERM') {
-      try {
-        rmSync(path, { recursive: true, force: true });
-      } catch {
-        // Best-effort; nothing more can safely be done here.
-      }
-    }
-    // ENOENT and anything else: best-effort, nothing to clean up.
-  }
-}
-/**
- * Called after {@link tryAcquireArbiter}'s inode check finds it grabbed
- * the WRONG file at `graveyardPath` -- not the confirmed-dead marker it
- * verified, but a live contender's fresh claim that happened to replace
- * it in the interim. Restores the live contender's marker to `destPath`
- * whenever possible, rather than discarding it: a discarded marker
- * leaves `destPath` briefly absent for as long as that live contender's
- * ENTIRE arbiter-protected critical section takes to finish, during
- * which a third contender's ordinary fresh `wx`-create can ALSO succeed
- * there, producing two simultaneous believed-arbiters -- exactly the
- * double-winner class of bug this whole mechanism exists to prevent.
- * Restoring narrows that exposure window to roughly the time this one
- * rename-back takes, instead of the live contender's full critical
- * section.
- *
- * The restore itself uses exclusive create (`{ flag: 'wx' }`), not an
- * unconditional `renameSync`, so it can never clobber a THIRD
- * contender's own legitimate claim that already filled the gap `path`
- * exposed the moment this function's caller renamed it away in the
- * first place: if the restore loses that race (`EEXIST`), the live
- * contender's original marker is discarded instead -- its holder does
- * not depend on the marker file continuing to exist to keep running its
- * own already-in-progress critical section (see `tryAcquireArbiter`'s
- * own doc comment), and the slot at `destPath` is by then some OTHER
- * contender's own equally legitimate exclusive claim, which must not be
- * overwritten either.
- */
-function restoreOrDiscard(graveyardPath, destPath) {
-  let content = null;
-  try {
-    content = readFileSync(graveyardPath);
-  } catch {
-    content = null;
-  }
-  if (content !== null) {
-    try {
-      writeFileSync(destPath, content, { flag: 'wx' });
-      discardBestEffort(graveyardPath);
-      return;
-    } catch (error) {
-      if (error.code !== 'EEXIST') {
-        throw error;
-      }
-      // Lost the restore race to a third contender's own fresh claim;
-      // fall through to discarding our accidental grab.
-    }
-  }
-  discardBestEffort(graveyardPath);
-}
-/**
- * Exclusively acquire the arbiter for one stale-lock-removal attempt
- * against `path`'s main lock, or return `false` when another contender
- * is already arbitrating (or just won a recovery race for a dead
- * arbiter). Every operation this module performs against an EXISTING
- * main lock -- takeover, release, refresh -- runs only while holding
- * this arbiter, which is what actually closes the races a plain
- * check-then-act pair on the main lock cannot: two contenders observing
- * the same stale mtime (or the same token) from independent reads can no
- * longer both proceed to mutate the main lock concurrently, because only
- * one of them ever wins this arbiter first. A genuinely fresh acquire
- * (the main lock path is truly absent) does not need the arbiter at all
- * -- `wx`-create is already exclusive for that case on its own.
- *
- * The arbiter is itself just a `{ flag: 'wx' }` claim recording the
- * arbitrating PID -- exclusive by the same primitive a fresh main-lock
- * acquire uses. Its OWN staleness (an arbiter whose holder crashed
- * mid-arbitration) is judged primarily by {@link isPidAlive}, not a time
- * threshold: the arbitration critical section is always a handful of
- * synchronous, no-I/O-wait statements, so "the recorded PID no longer
- * exists" is both necessary and sufficient to know the holder can never
- * finish or release it. A marker whose body can't be parsed (e.g. a
- * crashed partial write) has no PID to check, so it falls back to
- * `ARBITER_MALFORMED_STALE_MS` age instead, rather than being permanently
- * unrecoverable.
- *
- * The PID (or age) used for that liveness verdict and the inode later
- * verified against are captured from a SINGLE open file descriptor, not
- * two separate reads: reading them separately leaves a gap where the
- * verdict and the inode describe two DIFFERENT files -- a dead PID read
- * moments ago, then (after another contender's own concurrent recovery
- * of that same dead marker completed) a live contender's brand-new
- * marker by the time a second, later read re-opens the path. This
- * repository's own review history on #2223 caught exactly that gap in
- * an earlier revision that read the PID via one `readFileSync(path)`
- * call and the inode via a later, separate `openSync`.
- *
- * Recovering a confirmed-dead marker still races multiple contenders
- * (more than one can independently reach the same dead verdict), so it
- * goes through an inode-verified rename: `renameSync` the marker away,
- * then confirm (via the inode captured together with the liveness
- * verdict above) that what actually got moved is the exact entry
- * inspected, not a live contender's fresh arbiter claim that happened to
- * replace it in the interim. On a mismatch, {@link restoreOrDiscard}
- * puts the wrongly-grabbed file back (via its own exclusive-create race,
- * never an unconditional overwrite) rather than deleting it: this
- * repository's review history on #2223 caught that an earlier revision
- * which discarded a mismatched grab instead left the live contender's
- * marker path briefly absent for as long as that contender's ENTIRE
- * arbiter-protected critical section took to finish, during which a
- * third contender's ordinary fresh `wx`-create could ALSO succeed there
- * -- reproducing the very double-arbiter failure this whole mechanism
- * exists to close, just relocated one level down.
- */
-function tryAcquireArbiter(path) {
-  const marker = arbiterPath(path);
-  try {
-    writeFileSync(marker, JSON.stringify({ pid: process.pid }), {
-      flag: 'wx',
-    });
-    return true;
-  } catch (error) {
-    if (error.code !== 'EEXIST') {
-      throw error;
-    }
-  }
-  let fd;
-  try {
-    fd = openSync(marker, 'r');
-  } catch (error) {
-    if (error.code === 'ENOENT') {
-      return false;
-    }
-    throw error;
-  }
-  let observedIno;
-  let observedAgeMs;
-  let holderPid = null;
-  try {
-    const stat = fstatSync(fd);
-    observedIno = stat.ino;
-    observedAgeMs = Date.now() - stat.mtimeMs;
-    try {
-      const parsed = JSON.parse(readFileSync(fd, 'utf8'));
-      if (typeof parsed?.pid === 'number') {
-        holderPid = parsed.pid;
-      }
-    } catch {
-      // Malformed body -- judged by observedAgeMs below instead.
-    }
-  } finally {
-    closeSync(fd);
-  }
-  const holderConfirmedDead =
-    holderPid !== null
-      ? !isPidAlive(holderPid)
-      : observedAgeMs > ARBITER_MALFORMED_STALE_MS;
-  if (!holderConfirmedDead) {
-    return false;
-  }
-  const graveyard = `${marker}.graveyard-${process.pid}-${Math.random().toString(36).slice(2)}`;
-  try {
-    renameSync(marker, graveyard);
-  } catch (error) {
-    if (error.code === 'ENOENT') {
-      return false;
-    }
-    throw error;
-  }
-  let movedIno;
-  try {
-    movedIno = statSync(graveyard).ino;
-  } catch {
-    movedIno = undefined;
-  }
-  if (movedIno === undefined || movedIno !== observedIno) {
-    restoreOrDiscard(graveyard, marker);
-    return false;
-  }
-  discardBestEffort(graveyard);
-  try {
-    writeFileSync(marker, JSON.stringify({ pid: process.pid }), {
-      flag: 'wx',
-    });
-    return true;
-  } catch (error) {
-    if (error.code === 'EEXIST') {
-      return false;
-    }
-    throw error;
-  }
-}
-/** Release the arbiter acquired via {@link tryAcquireArbiter}. */
-function releaseArbiter(path) {
-  try {
-    unlinkSync(arbiterPath(path));
   } catch (error) {
     if (error.code !== 'ENOENT') {
       throw error;
     }
   }
-}
-/**
- * Acquire the arbiter for `path`, retrying briefly if another contender
- * currently holds it. See `ARBITER_RETRY_ATTEMPTS`'s own doc comment for
- * why a small bounded retry (not indefinite blocking) is the right
- * shape here.
- */
-function acquireArbiterWithRetry(path) {
-  for (let attempt = 0; attempt < ARBITER_RETRY_ATTEMPTS; attempt += 1) {
-    if (tryAcquireArbiter(path)) {
-      return true;
-    }
-    sleepSync(ARBITER_RETRY_DELAY_MS);
-  }
-  return false;
-}
-/**
- * Remove the (believed-stale) main lock at `path` and immediately
- * recreate it as `agentId`/`token`, but ONLY while holding the arbiter
- * -- see {@link tryAcquireArbiter} for why that is what makes the plain
- * `unlinkSync` here safe. Re-verifies staleness against `staleMs` once
- * more immediately after winning the arbiter (arbitration itself can
- * take a moment under contention, during which the lock's own live
- * holder may have refreshed its lease, or an unrelated contender may
- * have already recovered it) rather than trusting the caller's earlier,
- * now-possibly-stale check. Returns `false` (never throws for this) when
- * the arbiter itself could not be acquired, the re-check finds the lock
- * no longer stale, or recreation lost to an unrelated fresh acquirer in
- * the brief gap after this function's own removal (vanishingly unlikely,
- * and still safe: that acquirer's `wx`-create is exclusive by
- * construction).
- */
-function tryTakeOverStaleLock(path, agentId, token, staleMs) {
-  if (!tryAcquireArbiter(path)) {
-    return false;
-  }
-  try {
-    const ageMs = lockAgeMs(path);
-    if (ageMs === null || ageMs <= staleMs) {
-      return false;
-    }
-    try {
-      unlinkSync(path);
-    } catch (error) {
-      const code = error.code;
-      if (code === 'EISDIR' || code === 'EPERM') {
-        rmSync(path, { recursive: true, force: true });
-      } else if (code !== 'ENOENT') {
-        throw error;
-      }
-    }
-    return tryExclusiveCreate(path, agentId, token);
-  } finally {
-    releaseArbiter(path);
-  }
+  return tryExclusiveCreate(path, agentId, token);
 }
 /**
  * Thrown when a lock cannot be acquired within `timeoutMs`.
@@ -558,22 +267,15 @@ export class CloneLockTimeoutError extends Error {
 /**
  * Block (retrying with backoff) until the clone-scoped lock at `repoPath`
  * is acquired, or throw {@link CloneLockTimeoutError} after `timeoutMs`.
- * A lock whose mtime is older than `staleMs` is treated as abandoned;
- * every waiter that notices attempts recovery via
- * {@link tryTakeOverStaleLock}, which holds the PID-tagged arbiter (see
- * {@link tryAcquireArbiter}) for the whole remove-then-recreate sequence
- * so that even when multiple contenders observe the same stale mtime
- * from independent reads, at most one of them ever actually removes and
- * recreates it -- every loser simply continues waiting rather than
- * assuming it acquired. `staleMs` defaults to `STALE_LOCK_MS` and is
- * exposed only for tests that need a short-lived clock; production
- * callers should not override it.
+ * A lock whose recorded holder PID is confirmed dead (see
+ * {@link isPidAlive}) is eligible for takeover via
+ * {@link tryTakeOverDeadLock}; a live holder's lock is never taken over,
+ * regardless of how long it has been held.
  */
 export function acquireCloneLock(
   repoPath,
   agentId,
   timeoutMs = DEFAULT_TIMEOUT_MS,
-  staleMs = STALE_LOCK_MS,
 ) {
   const path = resolveCloneLockPath(repoPath);
   const token = randomToken();
@@ -582,20 +284,9 @@ export function acquireCloneLock(
     if (tryExclusiveCreate(path, agentId, token)) {
       return { path, token };
     }
-    const ageMs = lockAgeMs(path);
-    if (
-      ageMs !== null &&
-      ageMs > staleMs &&
-      tryTakeOverStaleLock(path, agentId, token, staleMs)
-    ) {
+    if (tryTakeOverDeadLock(path, agentId, token)) {
       return { path, token };
     }
-    // Either not (yet provably) stale, lost the arbiter race to another
-    // contender, the arbiter's own re-check found it no longer stale, or
-    // -- vanishingly unlikely -- won the takeover but then lost the
-    // immediate recreate to an unrelated fresh acquirer; every case
-    // falls through to the normal wait/retry path below rather than
-    // assuming acquisition.
     if (Date.now() >= deadline) {
       throw new CloneLockTimeoutError(path, timeoutMs);
     }
@@ -606,79 +297,27 @@ export function acquireCloneLock(
  * Release a lock previously returned by {@link acquireCloneLock}. Only
  * removes the file when it still holds the caller's own `token` -- if a
  * different token is present, another session already took the lock over
- * (e.g. after this caller's own hold went stale) and this release must
- * not disturb it. Removing an already-absent lock is a silent no-op.
+ * (necessarily after this caller's own process had already died, since a
+ * live holder's lock is never taken over) and this release must not
+ * disturb it. Removing an already-absent lock is a silent no-op.
  *
- * The token check and the removal happen while holding the arbiter (see
- * {@link tryAcquireArbiter}), not as two independent steps: without that,
- * a holder whose own process stalled badly enough for its lease to have
- * gone stale and already been taken over by someone else could read a
- * stale-but-still-matching token, then delete the NEW holder's fresh
- * lock in the gap before its own `unlinkSync` runs -- this repository's
- * review history on #2223 caught exactly this gap in an earlier
- * revision. If the arbiter cannot be acquired within a bounded number of
- * retries (see `ARBITER_RETRY_ATTEMPTS`), this call simply gives up
- * rather than releasing incorrectly: an unreleased lock still recovers
- * later through the module's own staleness+takeover machinery, which is
- * safe, whereas releasing without the arbiter's protection would not be.
+ * This is a plain token-check-then-unlink, unlike a design that must
+ * also guard against an in-flight takeover of the SAME still-live lock:
+ * that scenario cannot occur here, because release only ever runs from
+ * the live holder's own still-running process, and a takeover's PID
+ * -liveness check can never mistake a live, currently-executing process
+ * for a dead one.
  */
 export function releaseCloneLock(handle) {
-  if (!acquireArbiterWithRetry(handle.path)) {
-    return;
-  }
-  try {
-    const read = readLock(handle.path);
-    if (read.status === 'present' && read.lock.token === handle.token) {
-      try {
-        unlinkSync(handle.path);
-      } catch (error) {
-        if (error.code !== 'ENOENT') {
-          throw error;
-        }
+  const read = readLock(handle.path);
+  if (read.status === 'present' && read.lock.token === handle.token) {
+    try {
+      unlinkSync(handle.path);
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        throw error;
       }
     }
-  } finally {
-    releaseArbiter(handle.path);
-  }
-}
-/**
- * Rewrite the lock body at `handle.path`, bumping its mtime, but only
- * when the on-disk token still matches `handle.token` -- this never
- * refreshes (or resurrects) a lock a different session now holds. Used
- * by {@link withCloneLock} to keep a legitimately long-running holder's
- * lease from lapsing into apparent staleness.
- *
- * Like {@link releaseCloneLock}, the token check and the write happen
- * while holding the arbiter, not as two independent steps: without that,
- * a holder whose lease had already gone stale and been taken over by
- * someone else could read a stale-but-still-matching token, then
- * truncate and overwrite the NEW holder's fresh lock with its own token
- * in the gap before its own `writeFileSync` runs -- silently resurrecting
- * a lease that should have stayed lost. If the arbiter cannot be
- * acquired within a bounded number of retries, or the write itself fails
- * (e.g. the path became briefly inaccessible), this call silently gives
- * up: the next heartbeat tick simply retries, and `releaseCloneLock`'s
- * own arbiter-protected token check means a truly lost lease never gets
- * misreported as released.
- */
-export function refreshCloneLock(handle) {
-  if (!acquireArbiterWithRetry(handle.path)) {
-    return;
-  }
-  try {
-    const read = readLock(handle.path);
-    if (read.status === 'present' && read.lock.token === handle.token) {
-      try {
-        writeFileSync(
-          handle.path,
-          renderLockBody(read.lock.agentId, handle.token),
-        );
-      } catch {
-        // Best-effort; see the doc comment above.
-      }
-    }
-  } finally {
-    releaseArbiter(handle.path);
   }
 }
 /** Read-only lock inspection: never creates, mutates, or deletes the lock. */
@@ -701,13 +340,11 @@ export function checkCloneLock(repoPath) {
  * an ambient `GIT_DIR`/`GIT_WORK_TREE` the caller happened to have set
  * must not redirect the wrapped command at a different repository than
  * the one just locked), then release the lock -- even if the command
- * fails. While the command runs, the lease is refreshed every
- * `leaseRefreshMs` (default {@link DEFAULT_LEASE_REFRESH_MS}) so a
- * legitimately long-running operation is never mistaken for an abandoned
- * holder by another waiter. Returns the command's exit code (`null` when
- * it was killed by a signal). `staleMs`/`leaseRefreshMs` are exposed only
- * for tests that need a short-lived clock; production callers should not
- * override them.
+ * fails. No periodic lease refresh is needed: this process itself stays
+ * alive for the wrapped command's entire run, so the lock's recorded
+ * `pid` (this process's own) is continuously, automatically live for as
+ * long as the command is running. Returns the command's exit code
+ * (`null` when it was killed by a signal).
  */
 export async function withCloneLock(
   repoPath,
@@ -715,11 +352,8 @@ export async function withCloneLock(
   command,
   args,
   timeoutMs = DEFAULT_TIMEOUT_MS,
-  staleMs = STALE_LOCK_MS,
-  leaseRefreshMs = DEFAULT_LEASE_REFRESH_MS,
 ) {
-  const handle = acquireCloneLock(repoPath, agentId, timeoutMs, staleMs);
-  const heartbeat = setInterval(() => refreshCloneLock(handle), leaseRefreshMs);
+  const handle = acquireCloneLock(repoPath, agentId, timeoutMs);
   try {
     return await new Promise((resolve, reject) => {
       const child = spawn(command, args, {
@@ -731,7 +365,6 @@ export async function withCloneLock(
       child.once('exit', (code) => resolve(code));
     });
   } finally {
-    clearInterval(heartbeat);
     releaseCloneLock(handle);
   }
 }
@@ -818,16 +451,17 @@ Clone-scoped mutual-exclusion lock: serializes \`git worktree add\`,
 clone across concurrent sessions. \`--exec\` blocks (retrying) until the
 lock is acquired, runs <command> [args...] with stdio inherited and cwd
 set to --repo, then releases the lock -- even if the command fails --
-and exits with the command's own exit code. A lock whose lease has not
-been refreshed for 5 minutes is treated as abandoned by a dead holder
-and taken over; \`--exec\` refreshes its own lease periodically while
-the wrapped command runs, so a legitimately long-running operation is
-never mistaken for a dead holder. Exits 3 if the lock could not be
-acquired within --timeout-ms (default 120000).
+and exits with the command's own exit code. A lock is eligible for
+takeover only once its recorded holder process is confirmed dead (not
+after any fixed time period); a live holder's lock is never taken over,
+however long it is held. Exits 3 if the lock could not be acquired
+within --timeout-ms (default 120000).
 
 --check is read-only: it reports the current lock state without
 creating, mutating, or deleting anything. \`malformed: true\` means a
-lock file exists but could not be parsed as a well-formed lock body.
+lock file exists but could not be parsed as a well-formed lock body --
+this is never auto-recovered; delete it manually after confirming no
+live process still needs it.
 
 --repo defaults to the current working directory.
 `);

--- a/scripts/clone-lock.mjs
+++ b/scripts/clone-lock.mjs
@@ -25,61 +25,47 @@
 // which `claim-lock.mts` uses for its narrower per-worktree scope) is
 // required here.
 //
-// A holder that crashes leaves an orphaned lock file behind -- unlike a
+// This module deliberately has NO automatic stale-lock recovery. A
+// holder that crashes leaves an orphaned lock file behind -- unlike a
 // real `flock(2)`, a plain lock file is not released automatically when
-// its owning process dies. Staleness is judged by process liveness
-// (`isPidAlive`, `process.kill(pid, 0)`), not elapsed time: the lock body
-// records the holder's own `pid`, alongside `claim-lock.mts`'s existing
-// `token`/`agentId`/`acquiredAt` shape, and a lock is only ever eligible
-// for takeover once that exact PID is confirmed dead. This replaced an
-// earlier mtime-based design (recover anything older than a fixed
-// threshold, with the holder periodically refreshing its own lease to
-// prove it was still alive) after that design's CI run exposed the
-// failure mode it was always structurally prone to: a live,
-// actively-refreshing holder got taken over anyway, because "has this
-// timestamp aged past a threshold" is inherently a race against ordinary
-// process-scheduling jitter (a refresh landing late, a waiter's own
-// staleness check landing early) in a way "is this specific PID still
-// running" simply is not -- a process is never "probably dead by now,"
-// it is either scheduled on the OS right now or it does not exist.
-// Because the holder process for this lock (the one running `withExec`'s
-// wrapped command) stays alive for its own entire hold, no periodic
-// lease refresh is needed at all: liveness is continuously, automatically
-// true for as long as the holder is doing anything, and instantly,
-// unambiguously false the moment it exits or crashes. This also makes
-// release and takeover logically disjoint rather than a race to close:
-// release only ever runs from the live holder's own still-running
-// process (whose PID is, by definition, alive), so a takeover's PID
-// -liveness check can never mistake an active release-in-progress for a
-// dead holder -- no arbiter, inode verification, or other coordination
-// primitive beyond the plain `wx`-exclusive-create every acquire already
-// uses is needed to keep the two from conflicting. A takeover
-// re-confirms the lock is still the exact dead entry it inspected
-// (re-reading immediately before removing) rather than trusting a
-// possibly-stale earlier check, then goes through the SAME
-// `{ flag: 'wx' }` primitive a fresh acquire uses to recreate it -- the
-// only decision authority for who wins a contested recreate is the OS
-// kernel's own `O_EXCL` guarantee, not any bookkeeping this module
-// performs itself. One race is knowingly NOT closed: the single-syscall
-// gap between that re-confirmation read and the `unlinkSync` that acts
-// on it. Closing it fully would need a kernel-level compare-and-swap
-// this module does not have access to from plain POSIX file primitives;
-// every design this module has tried carries an equivalent residual gap
-// somewhere, and the ones that attempted to close this exact one (a
-// PID-tagged arbiter lock plus inode-verified recovery) each introduced
-// a NEW, worse gap of their own across three consecutive review rounds
-// (#2223) rather than actually eliminating it. This narrow, explicitly
-// accepted gap is deliberately simpler to reason about than that
-// alternative. A malformed lock body (e.g. a crashed partial write) has
-// no readable `pid` to check liveness against and is therefore never
-// auto-recovered -- `writeFileSync`'s single, small write is atomic in
-// practice on every realistic filesystem, so genuinely torn content is
-// vanishingly rare, and this module intentionally does not add recovery
-// machinery for it; see `--check`'s `malformed: true` output for manual
-// diagnosis. This is a purely local liveness heuristic scoped to
-// operations that normally complete in seconds -- it carries none of
-// `claim-lock.mts`'s GitHub-reverification requirement, because this
-// lock has no cross-machine claim-ownership meaning to protect.
+// its owning process dies -- and a timed-out waiter is simply told so,
+// with the lock path and the recorded holder's `pid` in the error
+// message, and pointed at a manual `rm <lock-path>` once a human has
+// confirmed the holder is actually gone (the same approach git's own
+// `index.lock` takes on a stale-lock collision). This module went
+// through three different automatic-recovery designs across successive
+// review rounds on #2223 -- an mtime-elapsed-time threshold with a
+// periodic lease refresh, then a PID-tagged arbiter lock with
+// inode-verified recovery, then a simplified PID-liveness check with no
+// arbiter -- and every one of them was found to have a genuine
+// concurrency defect by the next review round: a live, actively
+// -refreshing holder taken over anyway under scheduling jitter; a
+// wrapper process's own pid going "dead" while the git child it spawned
+// was still running and still needed the lock; more than one waiter
+// racing to reclaim the exact same confirmed-dead entry. Every
+// mitigation attempted for one of these introduced a new gap of its own
+// rather than eliminating the underlying problem, because implementing
+// a genuinely race-free "is this specific holder now provably gone, and
+// can exactly one waiter reclaim it" protocol needs a coordination
+// primitive (a kernel-level compare-and-swap, or a real `flock(2)`)
+// plain POSIX file read/write/rename operations do not provide. Rather
+// than continue layering fixes onto that fundamentally unsound
+// foundation, automatic recovery was removed entirely: the only
+// remaining decision authority for who acquires this lock is the OS
+// kernel's own `O_EXCL` guarantee on a single `{ flag: 'wx' }` create,
+// which is unconditionally race-free by construction -- there is no
+// removal, no recreation, and no second coordination primitive left for
+// a defect to hide in. `idd-skill#2223`'s Acceptance Criteria only ever
+// required an acquire/release interface and serializing two concurrent
+// invocations against each other, never automatic stale-lock recovery.
+// The lock body still records the holder's own `pid` (`isPidAlive`,
+// `process.kill(pid, 0)`), but purely as diagnostic information for a
+// human deciding whether it is safe to remove the lock by hand -- never
+// as input to an automated takeover decision. This is a purely local
+// mutex scoped to operations that normally complete in seconds -- it
+// carries none of `claim-lock.mts`'s GitHub-reverification requirement,
+// because this lock has no cross-machine claim-ownership meaning to
+// protect.
 import { execFileSync, spawn } from 'node:child_process';
 import { readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -185,11 +171,11 @@ function sleepSync(ms) {
  * it definitely does not. `process.kill(pid, 0)` sends no actual signal
  * -- it only probes existence/permission. `ESRCH` (no such process) is
  * the only outcome that means dead; `EPERM` (the process exists but this
- * one lacks permission to signal it) and success both mean alive. This
- * is a reliable, instantaneous, non-time-based liveness check: unlike an
- * elapsed-time threshold, there is no ambiguity window where a process
- * might be "probably dead by now" -- it either currently exists or it
- * does not.
+ * one lacks permission to signal it) and success both mean alive.
+ * Diagnostic only (see this module's header comment): this is never
+ * consulted to decide whether a lock may be taken over, only to help a
+ * human reading {@link checkCloneLock}'s or a timeout error's output
+ * judge whether the recorded holder is actually still running.
  */
 function isPidAlive(pid) {
   try {
@@ -200,20 +186,11 @@ function isPidAlive(pid) {
   }
 }
 /**
- * `true` when `path` currently holds a well-formed lock whose recorded
- * `pid` is confirmed dead. `false` for an absent, malformed (no `pid` to
- * check -- see this module's header comment for why that edge case is
- * not auto-recovered), or live lock.
- */
-function isDeadLock(read) {
-  return read.status === 'present' && !isPidAlive(read.lock.pid);
-}
-/**
  * Exclusively create the lock file, succeeding only when nothing else won
- * the race first. Both a fresh acquire and a dead-lock takeover funnel
- * through this same primitive, so at most one contender ever wins either
- * path -- the OS kernel's own `O_EXCL` guarantee is the sole decision
- * authority for who wins a contested create.
+ * the race first. This is the ONLY decision authority for who acquires
+ * this lock -- there is no removal or recreation path a defect could
+ * hide in (see this module's header comment for the three prior designs
+ * that tried to add one, and why each was abandoned).
  */
 function tryExclusiveCreate(path, agentId, token) {
   try {
@@ -227,50 +204,43 @@ function tryExclusiveCreate(path, agentId, token) {
   }
 }
 /**
- * Attempt to recover a lock at `path` whose recorded holder is confirmed
- * dead, then immediately recreate it as `agentId`/`token`. Re-reads the
- * lock immediately before removing it, rather than trusting the
- * caller's own (possibly now-stale) check, to narrow -- though, per this
- * module's header comment, not fully close -- the gap between
- * confirming death and acting on it. Returns `false` (never throws for
- * this) when the lock is no longer confirmed dead by the time of the
- * re-check, or recreation lost to an unrelated fresh acquirer in the
- * brief gap after this function's own removal (that acquirer's
- * `wx`-create is exclusive by construction either way, so this is safe
- * regardless of how it resolves).
- */
-function tryTakeOverDeadLock(path, agentId, token) {
-  if (!isDeadLock(readLock(path))) {
-    return false;
-  }
-  if (!isDeadLock(readLock(path))) {
-    return false;
-  }
-  try {
-    unlinkSync(path);
-  } catch (error) {
-    if (error.code !== 'ENOENT') {
-      throw error;
-    }
-  }
-  return tryExclusiveCreate(path, agentId, token);
-}
-/**
- * Thrown when a lock cannot be acquired within `timeoutMs`.
+ * Thrown when a lock cannot be acquired within `timeoutMs`. The message
+ * names the lock path and, when readable, the recorded holder's `pid`
+ * (and whether that process still appears to be alive) so a human can
+ * decide whether to remove the lock by hand -- see this module's header
+ * comment for why that manual step, not an automatic takeover, is this
+ * module's only stale-lock recovery path.
  */
 export class CloneLockTimeoutError extends Error {
   constructor(path, timeoutMs) {
-    super(`timed out after ${timeoutMs}ms waiting for clone lock: ${path}`);
+    super(`${describeTimeout(path)} after ${timeoutMs}ms`);
     this.name = 'CloneLockTimeoutError';
   }
+}
+function describeTimeout(path) {
+  const read = readLock(path);
+  const base = `timed out waiting for clone lock: ${path}`;
+  if (read.status === 'absent') {
+    return base;
+  }
+  if (read.status === 'malformed') {
+    return `${base} (lock file exists but could not be parsed; if no process needs it, remove it manually: rm ${path})`;
+  }
+  const aliveNote = isPidAlive(read.lock.pid)
+    ? 'still appears to be running'
+    : 'no longer appears to be running';
+  return (
+    `${base} (held by pid ${read.lock.pid}, agent "${read.lock.agentId}", ` +
+    `acquired ${read.lock.acquiredAt}; that process ${aliveNote}. If you have ` +
+    `independently confirmed it is safe, remove the lock manually: rm ${path})`
+  );
 }
 /**
  * Block (retrying with backoff) until the clone-scoped lock at `repoPath`
  * is acquired, or throw {@link CloneLockTimeoutError} after `timeoutMs`.
- * A lock whose recorded holder PID is confirmed dead (see
- * {@link isPidAlive}) is eligible for takeover via
- * {@link tryTakeOverDeadLock}; a live holder's lock is never taken over,
- * regardless of how long it has been held.
+ * A held lock is never taken over automatically, regardless of how long
+ * it has been held or whether its recorded holder process is still
+ * running -- see this module's header comment.
  */
 export function acquireCloneLock(
   repoPath,
@@ -284,9 +254,6 @@ export function acquireCloneLock(
     if (tryExclusiveCreate(path, agentId, token)) {
       return { path, token };
     }
-    if (tryTakeOverDeadLock(path, agentId, token)) {
-      return { path, token };
-    }
     if (Date.now() >= deadline) {
       throw new CloneLockTimeoutError(path, timeoutMs);
     }
@@ -295,18 +262,12 @@ export function acquireCloneLock(
 }
 /**
  * Release a lock previously returned by {@link acquireCloneLock}. Only
- * removes the file when it still holds the caller's own `token` -- if a
- * different token is present, another session already took the lock over
- * (necessarily after this caller's own process had already died, since a
- * live holder's lock is never taken over) and this release must not
- * disturb it. Removing an already-absent lock is a silent no-op.
- *
- * This is a plain token-check-then-unlink, unlike a design that must
- * also guard against an in-flight takeover of the SAME still-live lock:
- * that scenario cannot occur here, because release only ever runs from
- * the live holder's own still-running process, and a takeover's PID
- * -liveness check can never mistake a live, currently-executing process
- * for a dead one.
+ * removes the file when it still holds the caller's own `token` -- a
+ * defensive check against releasing a lock this handle no longer
+ * actually owns; in practice, since this module never takes over a held
+ * lock automatically, the token can only ever mismatch after a human
+ * has manually removed and something else has since recreated it.
+ * Removing an already-absent lock is a silent no-op.
  */
 export function releaseCloneLock(handle) {
   const read = readLock(handle.path);
@@ -330,7 +291,12 @@ export function checkCloneLock(repoPath) {
   if (read.status === 'malformed') {
     return { path, present: true, malformed: true };
   }
-  return { path, present: true, holder: read.lock };
+  return {
+    path,
+    present: true,
+    holder: read.lock,
+    holderAlive: isPidAlive(read.lock.pid),
+  };
 }
 /**
  * Acquire the clone lock, run `command` with `args` (inheriting stdio,
@@ -340,11 +306,8 @@ export function checkCloneLock(repoPath) {
  * an ambient `GIT_DIR`/`GIT_WORK_TREE` the caller happened to have set
  * must not redirect the wrapped command at a different repository than
  * the one just locked), then release the lock -- even if the command
- * fails. No periodic lease refresh is needed: this process itself stays
- * alive for the wrapped command's entire run, so the lock's recorded
- * `pid` (this process's own) is continuously, automatically live for as
- * long as the command is running. Returns the command's exit code
- * (`null` when it was killed by a signal).
+ * fails. Returns the command's exit code (`null` when it was killed by a
+ * signal).
  */
 export async function withCloneLock(
   repoPath,
@@ -451,17 +414,19 @@ Clone-scoped mutual-exclusion lock: serializes \`git worktree add\`,
 clone across concurrent sessions. \`--exec\` blocks (retrying) until the
 lock is acquired, runs <command> [args...] with stdio inherited and cwd
 set to --repo, then releases the lock -- even if the command fails --
-and exits with the command's own exit code. A lock is eligible for
-takeover only once its recorded holder process is confirmed dead (not
-after any fixed time period); a live holder's lock is never taken over,
-however long it is held. Exits 3 if the lock could not be acquired
-within --timeout-ms (default 120000).
+and exits with the command's own exit code. A held lock is NEVER taken
+over automatically, regardless of how long it has been held: exits 3 if
+the lock could not be acquired within --timeout-ms (default 120000),
+naming the lock path and its recorded holder's pid in the error message.
+If you have independently confirmed that holder is actually gone,
+remove the lock file by hand and retry -- the same recovery git's own
+\`index.lock\` expects on a stale-lock collision.
 
 --check is read-only: it reports the current lock state without
 creating, mutating, or deleting anything. \`malformed: true\` means a
-lock file exists but could not be parsed as a well-formed lock body --
-this is never auto-recovered; delete it manually after confirming no
-live process still needs it.
+lock file exists but could not be parsed as a well-formed lock body;
+\`holderAlive\` reports whether the recorded pid still appears to be
+running (diagnostic only). Neither case is ever auto-recovered.
 
 --repo defaults to the current working directory.
 `);

--- a/scripts/clone-lock.mjs
+++ b/scripts/clone-lock.mjs
@@ -48,16 +48,29 @@
 // repository's own review history on #2223 caught and reproduced exactly
 // that double-winner failure from an earlier `renameSync`-only attempt at
 // this fix, roughly one run in ten under concurrent load). The real fix
-// is a second, PID-tagged arbiter lock (`tryAcquireArbiter`): removing
-// and recreating the main lock only ever happens while holding it, so at
-// most one contender is ever doing that at a time, regardless of how many
-// independently observed the same stale mtime. The arbiter's own
-// staleness is judged by process liveness (`isPidAlive`), not a time
-// threshold, because its critical section is always a handful of
-// synchronous, no-I/O-wait statements -- "the recorded PID no longer
-// exists" is both necessary and sufficient to know its holder crashed and
-// can never finish or release it, with none of a time threshold's
-// inherent "probably dead by now" ambiguity. This is a purely local
+// is a second, PID-tagged arbiter lock (`tryAcquireArbiter`): every
+// operation that mutates an EXISTING main lock -- takeover, release,
+// refresh -- runs only while holding it, so at most one contender is
+// ever doing that at a time, regardless of how many independently
+// observed the same stale mtime or the same token. Release and refresh
+// need this too, not only takeover: without it, a holder whose own
+// process stalled long enough for its lease to go stale and get taken
+// over by someone else could read a stale-but-still-matching token, then
+// delete or overwrite the NEW holder's fresh lock in the gap before its
+// own act (unlink or write) runs -- this repository's review history on
+// #2223 caught this as a separate gap from takeover's own, in the SAME
+// round that also caught takeover's residual double-winner race (an
+// earlier `renameSync`-only takeover attempt, with no arbiter at all,
+// reproduced roughly one run in ten under concurrent load). The
+// arbiter's own staleness is judged primarily by process liveness
+// (`isPidAlive`), not a time threshold, because its critical section is
+// always a handful of synchronous, no-I/O-wait statements -- "the
+// recorded PID no longer exists" is both necessary and sufficient to
+// know its holder crashed and can never finish or release it, with none
+// of a time threshold's inherent "probably dead by now" ambiguity; a
+// marker whose body can't be parsed (no PID to check) falls back to a
+// short, generous age threshold instead, so a crash mid-write there
+// isn't permanently unrecoverable either. This is a purely local
 // liveness heuristic scoped to operations that normally complete in
 // seconds -- it carries none of `claim-lock.mts`'s GitHub-reverification
 // requirement, because this lock has no cross-machine claim-ownership
@@ -90,6 +103,27 @@ const STALE_LOCK_MS = 5 * 60_000;
  * lease never lapses into apparent staleness between refreshes.
  */
 const DEFAULT_LEASE_REFRESH_MS = Math.floor(STALE_LOCK_MS / 2);
+/**
+ * An arbiter marker whose body can't be parsed (e.g. a crashed partial
+ * write) has no recorded PID to check liveness against. Its critical
+ * section is always a handful of synchronous, no-I/O-wait statements, so
+ * this age threshold only ever needs to be "generous relative to a
+ * syscall," not to any real operation's duration -- unlike
+ * `STALE_LOCK_MS`, which must outlast a genuine `git fetch`.
+ */
+const ARBITER_MALFORMED_STALE_MS = 5_000;
+/**
+ * Bounds how many times {@link releaseCloneLock} / {@link refreshCloneLock}
+ * retry a contended arbiter before giving up for this one call. Every
+ * arbiter hold in this module is a handful of synchronous statements, so
+ * contention clears in microseconds; this is a small, bounded backstop,
+ * not a real wait budget. Giving up is safe, not catastrophic: a release
+ * that couldn't get in leaves the lock for the module's own
+ * staleness+takeover machinery to eventually reclaim, and a refresh that
+ * couldn't get in is simply retried on the next heartbeat tick.
+ */
+const ARBITER_RETRY_ATTEMPTS = 50;
+const ARBITER_RETRY_DELAY_MS = 2;
 const CLONE_LOCK_FLAG_SPEC = {
   '--exec': { type: 'boolean' },
   '--check': { type: 'boolean' },
@@ -243,39 +277,81 @@ function isPidAlive(pid) {
   }
 }
 /**
+ * Best-effort remove `path`, falling back to a recursive `rmSync` only
+ * for the directory-shaped edge case (a malformed marker or lock that
+ * happens to be a directory, not the expected regular file) -- mirroring
+ * `claim-lock.mts`'s own takeover path. Every caller of this helper only
+ * ever targets a path nothing else can reference (a per-attempt
+ * graveyard copy this process alone renamed there), so recursion here is
+ * unconditionally safe regardless of what it finds.
+ */
+function discardBestEffort(path) {
+  try {
+    unlinkSync(path);
+  } catch (error) {
+    const code = error.code;
+    if (code === 'EISDIR' || code === 'EPERM') {
+      try {
+        rmSync(path, { recursive: true, force: true });
+      } catch {
+        // Best-effort; nothing more can safely be done here.
+      }
+    }
+    // ENOENT and anything else: best-effort, nothing to clean up.
+  }
+}
+/**
  * Exclusively acquire the arbiter for one stale-lock-removal attempt
  * against `path`'s main lock, or return `false` when another contender
  * is already arbitrating (or just won a recovery race for a dead
- * arbiter). Removal itself is `unlinkSync`, safe to run unconditionally
- * ONLY while holding this arbiter -- exactly one contender can ever hold
- * it at a time, which is what actually closes the race a plain
- * check-then-`unlinkSync` pair on the MAIN lock cannot: two contenders
- * observing the same stale mtime from independent reads can no longer
- * both proceed to remove/recreate the main lock concurrently, because
- * only one of them ever wins this arbiter first.
+ * arbiter). Every operation this module performs against an EXISTING
+ * main lock -- takeover, release, refresh -- runs only while holding
+ * this arbiter, which is what actually closes the races a plain
+ * check-then-act pair on the main lock cannot: two contenders observing
+ * the same stale mtime (or the same token) from independent reads can no
+ * longer both proceed to mutate the main lock concurrently, because only
+ * one of them ever wins this arbiter first. A genuinely fresh acquire
+ * (the main lock path is truly absent) does not need the arbiter at all
+ * -- `wx`-create is already exclusive for that case on its own.
  *
  * The arbiter is itself just a `{ flag: 'wx' }` claim recording the
  * arbitrating PID -- exclusive by the same primitive a fresh main-lock
  * acquire uses. Its OWN staleness (an arbiter whose holder crashed
- * mid-arbitration) is judged by {@link isPidAlive}, not by a time
+ * mid-arbitration) is judged primarily by {@link isPidAlive}, not a time
  * threshold: the arbitration critical section is always a handful of
  * synchronous, no-I/O-wait statements, so "the recorded PID no longer
  * exists" is both necessary and sufficient to know the holder can never
- * finish or release it. Recovering a dead arbiter still races multiple
- * contenders (more than one can observe the same dead PID), so it goes
- * through the SAME inode-verified rename this function's removal step
- * cannot avoid at that one level: `renameSync` the arbiter file away,
- * then confirm (via the inode captured from an open file descriptor
- * held across the whole check) that what actually got moved is the
- * exact dead entry inspected, not a live contender's fresh arbiter claim
- * that happened to replace it in the interim. On a mismatch, the
- * wrongly-grabbed file is discarded (never restored): the rightful
- * holder's authority came from its own earlier successful `wx`-create,
- * not from this marker file continuing to exist on disk, so losing the
- * marker costs nothing but cosmetics -- see the design note in this
- * module's own review history (#2223) for why restoring it instead
- * would risk clobbering a third generation that may have since claimed
- * `path` legitimately.
+ * finish or release it. A marker whose body can't be parsed (e.g. a
+ * crashed partial write) has no PID to check, so it falls back to
+ * `ARBITER_MALFORMED_STALE_MS` age instead, rather than being permanently
+ * unrecoverable.
+ *
+ * The PID (or age) used for that liveness verdict and the inode later
+ * verified against are captured from a SINGLE open file descriptor, not
+ * two separate reads: reading them separately leaves a gap where the
+ * verdict and the inode describe two DIFFERENT files -- a dead PID read
+ * moments ago, then (after another contender's own concurrent recovery
+ * of that same dead marker completed) a live contender's brand-new
+ * marker by the time a second, later read re-opens the path. This
+ * repository's own review history on #2223 caught exactly that gap in
+ * an earlier revision that read the PID via one `readFileSync(path)`
+ * call and the inode via a later, separate `openSync`.
+ *
+ * Recovering a confirmed-dead marker still races multiple contenders
+ * (more than one can independently reach the same dead verdict), so it
+ * goes through an inode-verified rename: `renameSync` the marker away,
+ * then confirm (via the inode captured together with the liveness
+ * verdict above) that what actually got moved is the exact entry
+ * inspected, not a live contender's fresh arbiter claim that happened to
+ * replace it in the interim. On a mismatch, the wrongly-grabbed file is
+ * discarded (never restored): the rightful holder's authority came from
+ * its own earlier successful `wx`-create, not from this marker file
+ * continuing to exist on disk, so losing the marker costs nothing but
+ * cosmetics -- restoring it instead would risk clobbering a third
+ * generation that may have since claimed `path` legitimately (the same
+ * reasoning `releaseCloneLock`/`refreshCloneLock` rely on the arbiter
+ * itself to avoid needing, by never attempting a similar restore against
+ * the main lock).
  */
 function tryAcquireArbiter(path) {
   const marker = arbiterPath(path);
@@ -289,20 +365,6 @@ function tryAcquireArbiter(path) {
       throw error;
     }
   }
-  let holderPid = null;
-  try {
-    const parsed = JSON.parse(readFileSync(marker, 'utf8'));
-    if (typeof parsed?.pid === 'number') {
-      holderPid = parsed.pid;
-    }
-  } catch {
-    // Malformed or unreadable: cannot determine liveness, so do not
-    // attempt recovery this pass -- fail closed exactly like the main
-    // lock's own malformed-body handling elsewhere in this module.
-  }
-  if (holderPid === null || isPidAlive(holderPid)) {
-    return false;
-  }
   let fd;
   try {
     fd = openSync(marker, 'r');
@@ -313,10 +375,29 @@ function tryAcquireArbiter(path) {
     throw error;
   }
   let observedIno;
+  let observedAgeMs;
+  let holderPid = null;
   try {
-    observedIno = fstatSync(fd).ino;
+    const stat = fstatSync(fd);
+    observedIno = stat.ino;
+    observedAgeMs = Date.now() - stat.mtimeMs;
+    try {
+      const parsed = JSON.parse(readFileSync(fd, 'utf8'));
+      if (typeof parsed?.pid === 'number') {
+        holderPid = parsed.pid;
+      }
+    } catch {
+      // Malformed body -- judged by observedAgeMs below instead.
+    }
   } finally {
     closeSync(fd);
+  }
+  const holderConfirmedDead =
+    holderPid !== null
+      ? !isPidAlive(holderPid)
+      : observedAgeMs > ARBITER_MALFORMED_STALE_MS;
+  if (!holderConfirmedDead) {
+    return false;
   }
   const graveyard = `${marker}.graveyard-${process.pid}-${Math.random().toString(36).slice(2)}`;
   try {
@@ -334,18 +415,10 @@ function tryAcquireArbiter(path) {
     movedIno = undefined;
   }
   if (movedIno === undefined || movedIno !== observedIno) {
-    try {
-      unlinkSync(graveyard);
-    } catch {
-      // Best-effort discard; see the doc comment above.
-    }
+    discardBestEffort(graveyard);
     return false;
   }
-  try {
-    unlinkSync(graveyard);
-  } catch {
-    // Best-effort; the dead entry is confirmed claimed regardless.
-  }
+  discardBestEffort(graveyard);
   try {
     writeFileSync(marker, JSON.stringify({ pid: process.pid }), {
       flag: 'wx',
@@ -367,6 +440,21 @@ function releaseArbiter(path) {
       throw error;
     }
   }
+}
+/**
+ * Acquire the arbiter for `path`, retrying briefly if another contender
+ * currently holds it. See `ARBITER_RETRY_ATTEMPTS`'s own doc comment for
+ * why a small bounded retry (not indefinite blocking) is the right
+ * shape here.
+ */
+function acquireArbiterWithRetry(path) {
+  for (let attempt = 0; attempt < ARBITER_RETRY_ATTEMPTS; attempt += 1) {
+    if (tryAcquireArbiter(path)) {
+      return true;
+    }
+    sleepSync(ARBITER_RETRY_DELAY_MS);
+  }
+  return false;
 }
 /**
  * Remove the (believed-stale) main lock at `path` and immediately
@@ -470,17 +558,37 @@ export function acquireCloneLock(
  * different token is present, another session already took the lock over
  * (e.g. after this caller's own hold went stale) and this release must
  * not disturb it. Removing an already-absent lock is a silent no-op.
+ *
+ * The token check and the removal happen while holding the arbiter (see
+ * {@link tryAcquireArbiter}), not as two independent steps: without that,
+ * a holder whose own process stalled badly enough for its lease to have
+ * gone stale and already been taken over by someone else could read a
+ * stale-but-still-matching token, then delete the NEW holder's fresh
+ * lock in the gap before its own `unlinkSync` runs -- this repository's
+ * review history on #2223 caught exactly this gap in an earlier
+ * revision. If the arbiter cannot be acquired within a bounded number of
+ * retries (see `ARBITER_RETRY_ATTEMPTS`), this call simply gives up
+ * rather than releasing incorrectly: an unreleased lock still recovers
+ * later through the module's own staleness+takeover machinery, which is
+ * safe, whereas releasing without the arbiter's protection would not be.
  */
 export function releaseCloneLock(handle) {
-  const read = readLock(handle.path);
-  if (read.status === 'present' && read.lock.token === handle.token) {
-    try {
-      unlinkSync(handle.path);
-    } catch (error) {
-      if (error.code !== 'ENOENT') {
-        throw error;
+  if (!acquireArbiterWithRetry(handle.path)) {
+    return;
+  }
+  try {
+    const read = readLock(handle.path);
+    if (read.status === 'present' && read.lock.token === handle.token) {
+      try {
+        unlinkSync(handle.path);
+      } catch (error) {
+        if (error.code !== 'ENOENT') {
+          throw error;
+        }
       }
     }
+  } finally {
+    releaseArbiter(handle.path);
   }
 }
 /**
@@ -488,27 +596,39 @@ export function releaseCloneLock(handle) {
  * when the on-disk token still matches `handle.token` -- this never
  * refreshes (or resurrects) a lock a different session now holds. Used
  * by {@link withCloneLock} to keep a legitimately long-running holder's
- * lease from lapsing into apparent staleness. A read-then-write race
- * against a concurrent stale takeover is inherent to a plain lock file
- * (there is no atomic compare-and-swap primitive here); the default
- * refresh cadence is sized generously relative to the staleness window
- * specifically to make that race vanishingly unlikely to matter in
- * practice. A failed refresh (e.g. the path became briefly inaccessible)
- * is silently swallowed: the next timer tick simply retries, and
- * `releaseCloneLock`'s own token check means a truly lost lease never
- * gets misreported as released.
+ * lease from lapsing into apparent staleness.
+ *
+ * Like {@link releaseCloneLock}, the token check and the write happen
+ * while holding the arbiter, not as two independent steps: without that,
+ * a holder whose lease had already gone stale and been taken over by
+ * someone else could read a stale-but-still-matching token, then
+ * truncate and overwrite the NEW holder's fresh lock with its own token
+ * in the gap before its own `writeFileSync` runs -- silently resurrecting
+ * a lease that should have stayed lost. If the arbiter cannot be
+ * acquired within a bounded number of retries, or the write itself fails
+ * (e.g. the path became briefly inaccessible), this call silently gives
+ * up: the next heartbeat tick simply retries, and `releaseCloneLock`'s
+ * own arbiter-protected token check means a truly lost lease never gets
+ * misreported as released.
  */
 export function refreshCloneLock(handle) {
-  const read = readLock(handle.path);
-  if (read.status === 'present' && read.lock.token === handle.token) {
-    try {
-      writeFileSync(
-        handle.path,
-        renderLockBody(read.lock.agentId, handle.token),
-      );
-    } catch {
-      // Best-effort; see the doc comment above.
+  if (!acquireArbiterWithRetry(handle.path)) {
+    return;
+  }
+  try {
+    const read = readLock(handle.path);
+    if (read.status === 'present' && read.lock.token === handle.token) {
+      try {
+        writeFileSync(
+          handle.path,
+          renderLockBody(read.lock.agentId, handle.token),
+        );
+      } catch {
+        // Best-effort; see the doc comment above.
+      }
     }
+  } finally {
+    releaseArbiter(handle.path);
   }
 }
 /** Read-only lock inspection: never creates, mutates, or deletes the lock. */
@@ -526,8 +646,12 @@ export function checkCloneLock(repoPath) {
 /**
  * Acquire the clone lock, run `command` with `args` (inheriting stdio,
  * `cwd` set to `repoPath` so the wrapped git operation always targets the
- * same repository the lock scopes), then release the lock -- even if the
- * command fails. While the command runs, the lease is refreshed every
+ * same repository the lock scopes, and the same
+ * {@link sanitizedGitEnvironment} used to resolve the lock path itself --
+ * an ambient `GIT_DIR`/`GIT_WORK_TREE` the caller happened to have set
+ * must not redirect the wrapped command at a different repository than
+ * the one just locked), then release the lock -- even if the command
+ * fails. While the command runs, the lease is refreshed every
  * `leaseRefreshMs` (default {@link DEFAULT_LEASE_REFRESH_MS}) so a
  * legitimately long-running operation is never mistaken for an abandoned
  * holder by another waiter. Returns the command's exit code (`null` when
@@ -548,7 +672,11 @@ export async function withCloneLock(
   const heartbeat = setInterval(() => refreshCloneLock(handle), leaseRefreshMs);
   try {
     return await new Promise((resolve, reject) => {
-      const child = spawn(command, args, { stdio: 'inherit', cwd: repoPath });
+      const child = spawn(command, args, {
+        stdio: 'inherit',
+        cwd: repoPath,
+        env: sanitizedGitEnvironment(),
+      });
       child.once('error', reject);
       child.once('exit', (code) => resolve(code));
     });
@@ -662,5 +790,5 @@ lock file exists but could not be parsed as a well-formed lock body.
 // point would throw a `ReferenceError` on any `--exec` timeout instead of
 // the documented message and exit code 3.
 if (import.meta.main) {
-  runCli();
+  await runCli();
 }

--- a/scripts/clone-lock.mjs
+++ b/scripts/clone-lock.mjs
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/clone-lock.mts
+//
+// The scripts/clone-lock.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Clone-scoped mutual-exclusion lock (#2223): serializes `git worktree
+// add`, `git worktree remove`, and `git fetch` against the shared primary
+// clone when multiple concurrent sessions operate against it. This is a
+// different kind of lock than `claim-lock.mts`: that one records
+// worktree-local *ownership* for a whole worker's lifetime and reports a
+// same-machine collision immediately (never blocks). This one is a short
+// -duration *mutex* around a single git operation -- it blocks (retrying
+// with backoff) until it can acquire, up to a bounded timeout, because the
+// operations it guards are expected to finish in seconds, not the hours a
+// claim can be held for.
+//
+// The lock file lives in the primary clone's *shared* git-admin directory
+// (`git rev-parse --path-format=absolute --git-common-dir`), not any one
+// worktree's private admin dir -- every worktree of the same clone shares
+// this path, which is exactly the scope a clone-wide mutex needs. A
+// linked worktree's own `.git` is a file, not this shared directory, so
+// resolving through `--git-common-dir` (rather than `--absolute-git-dir`,
+// which `claim-lock.mts` uses for its narrower per-worktree scope) is
+// required here.
+//
+// A holder that crashes mid-operation leaves an orphaned lock file behind
+// -- unlike a real `flock(2)`, a plain lock file is not released
+// automatically when its owning process dies. `STALE_LOCK_MS` bounds how
+// long a stuck lock can block every other session: once a lock's recorded
+// `acquiredAt` is older than that, a waiter treats it as abandoned and
+// force-takes it over. This is a purely local liveness heuristic scoped to
+// operations that normally complete in seconds -- it carries none of
+// `claim-lock.mts`'s GitHub-reverification requirement, because this lock
+// has no cross-machine claim-ownership meaning to protect.
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  readFileSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { parseCliArgs } from './cli-args.mjs';
+
+const CLONE_LOCK_FILE_NAME = 'idd-clone.lock';
+/** How long a waiter blocks (retrying) before giving up. */
+const DEFAULT_TIMEOUT_MS = 120_000;
+/** Delay between retry attempts while waiting for a held lock. */
+const POLL_INTERVAL_MS = 200;
+/** A lock older than this is treated as abandoned by a dead holder. */
+const STALE_LOCK_MS = 5 * 60_000;
+const CLONE_LOCK_FLAG_SPEC = {
+  '--exec': { type: 'boolean' },
+  '--check': { type: 'boolean' },
+  '--repo': { type: 'string' },
+  '--agent-id': { type: 'string' },
+  '--timeout-ms': { type: 'string' },
+  '--help': { type: 'boolean', short: 'h' },
+};
+if (import.meta.main) {
+  runCli();
+}
+/**
+ * Mirrors `claim-lock.mts`'s environment sanitization: repository
+ * discovery must stay tied to the requested `--repo` path, never to an
+ * ambient Git override inherited from a hook, wrapper, or parent process.
+ */
+function sanitizedGitEnvironment() {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('GIT_CONFIG')) {
+      delete env[key];
+    }
+  }
+  delete env.GIT_DIR;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_COMMON_DIR;
+  delete env.GIT_OBJECT_DIRECTORY;
+  return env;
+}
+/**
+ * Resolve the lock file's path inside the clone's *shared* git-admin
+ * directory (`--git-common-dir`, not `--absolute-git-dir`) so every
+ * worktree of the same clone resolves to the identical path.
+ */
+export function resolveCloneLockPath(repoPath) {
+  const gitCommonDir = execFileSync(
+    'git',
+    ['-C', repoPath, 'rev-parse', '--path-format=absolute', '--git-common-dir'],
+    { encoding: 'utf8', env: sanitizedGitEnvironment() },
+  ).trim();
+  return join(gitCommonDir, CLONE_LOCK_FILE_NAME);
+}
+function isCloneLockBody(value) {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof value.token === 'string' &&
+    typeof value.agentId === 'string' &&
+    typeof value.acquiredAt === 'string'
+  );
+}
+function readLock(path) {
+  let raw;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return { status: 'absent' };
+    }
+    return { status: 'malformed' };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { status: 'malformed' };
+  }
+  return isCloneLockBody(parsed)
+    ? { status: 'present', lock: parsed }
+    : { status: 'malformed' };
+}
+function renderLockBody(agentId, token) {
+  const body = {
+    token,
+    agentId,
+    acquiredAt: new Date().toISOString(),
+  };
+  return JSON.stringify(body);
+}
+function randomToken() {
+  return `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+/**
+ * Blocking, synchronous sleep -- portable across POSIX and Windows, no
+ * external process spawn. Used to back off between poll attempts.
+ */
+function sleepSync(ms) {
+  const sharedBuffer = new SharedArrayBuffer(4);
+  Atomics.wait(new Int32Array(sharedBuffer), 0, 0, ms);
+}
+/**
+ * Force-remove an abandoned (stale or malformed) lock at `path` and
+ * install a fresh one, mirroring `claim-lock.mts`'s
+ * `overwriteLockAtomically`: write a same-directory temp file, then
+ * `renameSync` into place (atomic on POSIX; the existing-file fallback
+ * below covers Windows, which requires the destination removed first).
+ */
+function takeOverLock(path, agentId, token) {
+  const tmpPath = `${path}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
+  writeFileSync(tmpPath, renderLockBody(agentId, token), { flag: 'wx' });
+  try {
+    try {
+      renameSync(tmpPath, path);
+    } catch {
+      rmSync(path, { recursive: true, force: true });
+      renameSync(tmpPath, path);
+    }
+  } finally {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // Best-effort: a successful rename already moved tmpPath away.
+    }
+  }
+}
+/**
+ * Thrown when a lock cannot be acquired within `timeoutMs`.
+ */
+export class CloneLockTimeoutError extends Error {
+  constructor(path, timeoutMs) {
+    super(`timed out after ${timeoutMs}ms waiting for clone lock: ${path}`);
+    this.name = 'CloneLockTimeoutError';
+  }
+}
+/**
+ * Block (retrying with backoff) until the clone-scoped lock at `repoPath`
+ * is acquired, or throw {@link CloneLockTimeoutError} after `timeoutMs`.
+ * A lock older than `STALE_LOCK_MS` is treated as abandoned and taken
+ * over rather than waited out.
+ */
+export function acquireCloneLock(
+  repoPath,
+  agentId,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+) {
+  const path = resolveCloneLockPath(repoPath);
+  const token = randomToken();
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const read = readLock(path);
+    if (read.status === 'absent') {
+      try {
+        writeFileSync(path, renderLockBody(agentId, token), { flag: 'wx' });
+        return { path, token };
+      } catch (error) {
+        if (error.code !== 'EEXIST') {
+          throw error;
+        }
+        // Raced with a concurrent acquire between the read and this
+        // create; fall through to the wait/retry path below.
+      }
+    } else if (read.status === 'malformed') {
+      // A malformed body's age can't be determined; treat it the same as
+      // a fresh, definitely-not-stale lock and wait for it rather than
+      // taking it over immediately -- an in-progress writer's partial
+      // write should not be mistaken for an abandoned lock.
+    } else {
+      const ageMs = Date.now() - Date.parse(read.lock.acquiredAt);
+      if (Number.isFinite(ageMs) && ageMs > STALE_LOCK_MS) {
+        takeOverLock(path, agentId, token);
+        return { path, token };
+      }
+    }
+    if (Date.now() >= deadline) {
+      throw new CloneLockTimeoutError(path, timeoutMs);
+    }
+    sleepSync(Math.min(POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())));
+  }
+}
+/**
+ * Release a lock previously returned by {@link acquireCloneLock}. Only
+ * removes the file when it still holds the caller's own `token` -- if a
+ * different token is present, another session already took the lock over
+ * (e.g. after this caller's own hold went stale) and this release must
+ * not disturb it. Removing an already-absent lock is a silent no-op.
+ */
+export function releaseCloneLock(handle) {
+  const read = readLock(handle.path);
+  if (read.status === 'present' && read.lock.token === handle.token) {
+    try {
+      unlinkSync(handle.path);
+    } catch (error) {
+      if (error.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+}
+/** Read-only lock inspection: never creates, mutates, or deletes the lock. */
+export function checkCloneLock(repoPath) {
+  const path = resolveCloneLockPath(repoPath);
+  const read = readLock(path);
+  if (read.status === 'absent') {
+    return { path, present: false };
+  }
+  if (read.status === 'malformed') {
+    return { path, present: true, malformed: true };
+  }
+  return { path, present: true, holder: read.lock };
+}
+/**
+ * Acquire the clone lock, run `command` with `args` (inheriting stdio),
+ * then release the lock -- even if the command fails. Returns the
+ * command's exit code (`null` when it was killed by a signal).
+ */
+export function withCloneLock(
+  repoPath,
+  agentId,
+  command,
+  args,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+) {
+  const handle = acquireCloneLock(repoPath, agentId, timeoutMs);
+  try {
+    const result = spawnSync(command, args, { stdio: 'inherit' });
+    if (result.error) {
+      throw result.error;
+    }
+    return result.status;
+  } finally {
+    releaseCloneLock(handle);
+  }
+}
+/**
+ * Everything after a literal `--` token is the wrapped command and its
+ * arguments, passed through untouched -- `parseCliArgs` parses only the
+ * flags before it (it never accepts positionals itself).
+ */
+function splitAtDoubleDash(argv) {
+  const index = argv.indexOf('--');
+  if (index === -1) {
+    return { flags: argv, command: [] };
+  }
+  return { flags: argv.slice(0, index), command: argv.slice(index + 1) };
+}
+function parseArgs(argv) {
+  const { flags, command } = splitAtDoubleDash(argv);
+  const { values, help } = parseCliArgs(flags, CLONE_LOCK_FLAG_SPEC);
+  const rawTimeout = values['timeout-ms'];
+  let timeoutMs = null;
+  if (typeof rawTimeout === 'string') {
+    const parsed = Number(rawTimeout);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw new Error('--timeout-ms must be a positive integer');
+    }
+    timeoutMs = parsed;
+  }
+  return {
+    exec: Boolean(values.exec),
+    check: Boolean(values.check),
+    repo: typeof values.repo === 'string' ? values.repo : null,
+    agentId: typeof values['agent-id'] === 'string' ? values['agent-id'] : null,
+    timeoutMs,
+    help,
+    command,
+  };
+}
+function runCli() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (args.exec === args.check) {
+    throw new Error('exactly one of --exec or --check is required');
+  }
+  const repo = args.repo ?? process.cwd();
+  if (args.check) {
+    process.stdout.write(`${JSON.stringify(checkCloneLock(repo))}\n`);
+    return;
+  }
+  if (args.agentId === null) {
+    throw new Error('--agent-id is required for --exec');
+  }
+  if (args.command.length === 0) {
+    throw new Error('--exec requires a command after `--`');
+  }
+  const [command, ...commandArgs] = args.command;
+  try {
+    const status = withCloneLock(
+      repo,
+      args.agentId,
+      command,
+      commandArgs,
+      args.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    );
+    process.exitCode = status ?? 1;
+  } catch (error) {
+    if (error instanceof CloneLockTimeoutError) {
+      process.stderr.write(`${error.message}\n`);
+      process.exitCode = 3;
+      return;
+    }
+    throw error;
+  }
+}
+function printHelp() {
+  process.stdout.write(`Usage:
+  node scripts/clone-lock.mjs --exec --agent-id <id> [--repo <path>] [--timeout-ms <n>] -- <command> [args...]
+  node scripts/clone-lock.mjs --check [--repo <path>]
+
+Clone-scoped mutual-exclusion lock: serializes \`git worktree add\`,
+\`git worktree remove\`, and \`git fetch\` against the shared primary
+clone across concurrent sessions. \`--exec\` blocks (retrying) until the
+lock is acquired, runs <command> [args...] with stdio inherited, then
+releases the lock -- even if the command fails -- and exits with the
+command's own exit code. A lock held longer than 5 minutes is treated
+as abandoned by a dead holder and taken over rather than waited out.
+Exits 3 if the lock could not be acquired within --timeout-ms
+(default 120000).
+
+--check is read-only: it reports the current lock state without
+creating, mutating, or deleting anything. \`malformed: true\` means a
+lock file exists but could not be parsed as a well-formed lock body.
+
+--repo defaults to the current working directory.
+`);
+}

--- a/scripts/clone-lock.mjs
+++ b/scripts/clone-lock.mjs
@@ -116,11 +116,23 @@ export function resolveCloneLockPath(repoPath) {
   ).trim();
   return join(gitCommonDir, CLONE_LOCK_FILE_NAME);
 }
+/**
+ * A `pid` must be a positive-integer-shaped number, not merely
+ * `typeof pid === 'number'` -- POSIX gives `0` and negative values
+ * special meaning to `kill()` (process group / all processes / signal
+ * -to-everyone), so a `0`, negative, `NaN`, or non-integer value must
+ * never reach {@link isPidAlive}'s `process.kill(pid, 0)` call, even
+ * though that call is diagnostic-only now (see this module's header
+ * comment) and not a takeover decision.
+ */
+function isValidPid(value) {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0;
+}
 function isCloneLockBody(value) {
   return (
     typeof value === 'object' &&
     value !== null &&
-    typeof value.pid === 'number' &&
+    isValidPid(value.pid) &&
     typeof value.token === 'string' &&
     typeof value.agentId === 'string' &&
     typeof value.acquiredAt === 'string'

--- a/scripts/clone-lock.mjs
+++ b/scripts/clone-lock.mjs
@@ -36,22 +36,37 @@
 // every other session; `withCloneLock`'s `--exec` path refreshes its own
 // lease (rewrites the file, which bumps its mtime) at roughly half that
 // interval while the wrapped command runs, so a legitimately
-// long-running operation is never mistaken for a dead holder. Recovering
-// a stale (or malformed-and-stale) lock is two exclusive races, not one:
-// first for the right to remove the abandoned entry (`renameSync` on a
-// specific source path -- POSIX serializes concurrent renames of the
-// same directory entry, so exactly one racer's removal ever succeeds,
-// see `tryClaimStaleLockForRemoval`'s own doc comment for why a plain
-// check-then-`unlinkSync` pair cannot make this same guarantee), then
-// for the right to recreate it (the same `{ flag: 'wx' }` primitive a
-// fresh acquire uses). Every loser at either step falls back to the
-// normal wait/retry loop rather than assuming it acquired. This is a
-// purely local liveness heuristic scoped to operations that normally
-// complete in seconds -- it carries none of
-// `claim-lock.mts`'s GitHub-reverification requirement, because this lock
-// has no cross-machine claim-ownership meaning to protect.
+// long-running operation is never mistaken for a dead holder.
+//
+// Recovering a stale lock is NOT simply "remove it, then race the usual
+// exclusive-create": two contenders can independently observe the same
+// stale mtime, and neither a plain `unlinkSync` nor a plain `renameSync`
+// on its own verifies the file it removes is still the exact entry that
+// was checked -- both happily remove whatever a faster contender already
+// replaced it with (including that contender's brand-new, non-stale
+// lock), letting more than one contender believe it took over (this
+// repository's own review history on #2223 caught and reproduced exactly
+// that double-winner failure from an earlier `renameSync`-only attempt at
+// this fix, roughly one run in ten under concurrent load). The real fix
+// is a second, PID-tagged arbiter lock (`tryAcquireArbiter`): removing
+// and recreating the main lock only ever happens while holding it, so at
+// most one contender is ever doing that at a time, regardless of how many
+// independently observed the same stale mtime. The arbiter's own
+// staleness is judged by process liveness (`isPidAlive`), not a time
+// threshold, because its critical section is always a handful of
+// synchronous, no-I/O-wait statements -- "the recorded PID no longer
+// exists" is both necessary and sufficient to know its holder crashed and
+// can never finish or release it, with none of a time threshold's
+// inherent "probably dead by now" ambiguity. This is a purely local
+// liveness heuristic scoped to operations that normally complete in
+// seconds -- it carries none of `claim-lock.mts`'s GitHub-reverification
+// requirement, because this lock has no cross-machine claim-ownership
+// meaning to protect.
 import { execFileSync, spawn } from 'node:child_process';
 import {
+  closeSync,
+  fstatSync,
+  openSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -202,54 +217,196 @@ function tryExclusiveCreate(path, agentId, token) {
   }
 }
 /**
- * Exclusively claim the (believed-stale) lock at `path` for removal, so
- * that even when multiple contenders simultaneously observe the same
- * stale mtime, only one of them ever actually removes it. `renameSync`
- * on a specific SOURCE path is itself the race-free primitive this needs
- * -- POSIX serializes concurrent rename operations against the same
- * directory entry, so among any number of racing
- * `renameSync(path, <unique-destination>)` calls, exactly one succeeds
- * (moving `path` away) and every later call sees `ENOENT`, since by the
- * time it runs `path` no longer exists to rename from. This closes a
- * race a plain check-then-`unlinkSync` pair cannot: two contenders can
- * both observe the same stale mtime from independent reads, and a plain
- * `unlinkSync` never verifies the file it deletes is still the one that
- * was checked -- it happily deletes whatever a faster contender already
- * replaced it with (including that contender's brand new, non-stale
- * lock), letting both contenders believe they won.
- *
- * Returns `false` (a lost race, not an error) on `ENOENT` -- the normal
- * outcome for every contender except the one that actually wins. The
- * destination is a unique per-attempt "graveyard" path so concurrent
- * winners of DIFFERENT stale-lock generations never collide with each
- * other; it is then discarded immediately (`unlinkSync`, with a
- * `recursive: true` `rmSync` fallback for the
- * malformed-lock-is-a-directory edge case `claim-lock.mts`'s own
- * takeover path also handles) -- this cleanup is unconditionally safe
- * regardless of recursion, since nothing else can ever reference this
- * exact path.
+ * Companion path for the PID-tagged arbiter lock that guards a stale
+ * -takeover REMOVAL against `path` -- see {@link tryAcquireArbiter}.
  */
-function tryClaimStaleLockForRemoval(path) {
-  const graveyardPath = `${path}.graveyard-${process.pid}-${Math.random().toString(36).slice(2)}`;
+function arbiterPath(path) {
+  return `${path}.arbiter`;
+}
+/**
+ * `true` when `pid` identifies a currently-running process, `false` when
+ * it definitely does not. `process.kill(pid, 0)` sends no actual signal
+ * -- it only probes existence/permission. `ESRCH` (no such process) is
+ * the only outcome that means dead; `EPERM` (the process exists but this
+ * one lacks permission to signal it) and success both mean alive. This
+ * is a reliable, instantaneous, non-time-based liveness check -- unlike
+ * an mtime-based staleness threshold, there is no ambiguity window where
+ * a process might be "probably dead by now": it either currently exists
+ * or it does not.
+ */
+function isPidAlive(pid) {
   try {
-    renameSync(path, graveyardPath);
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code === 'EPERM';
+  }
+}
+/**
+ * Exclusively acquire the arbiter for one stale-lock-removal attempt
+ * against `path`'s main lock, or return `false` when another contender
+ * is already arbitrating (or just won a recovery race for a dead
+ * arbiter). Removal itself is `unlinkSync`, safe to run unconditionally
+ * ONLY while holding this arbiter -- exactly one contender can ever hold
+ * it at a time, which is what actually closes the race a plain
+ * check-then-`unlinkSync` pair on the MAIN lock cannot: two contenders
+ * observing the same stale mtime from independent reads can no longer
+ * both proceed to remove/recreate the main lock concurrently, because
+ * only one of them ever wins this arbiter first.
+ *
+ * The arbiter is itself just a `{ flag: 'wx' }` claim recording the
+ * arbitrating PID -- exclusive by the same primitive a fresh main-lock
+ * acquire uses. Its OWN staleness (an arbiter whose holder crashed
+ * mid-arbitration) is judged by {@link isPidAlive}, not by a time
+ * threshold: the arbitration critical section is always a handful of
+ * synchronous, no-I/O-wait statements, so "the recorded PID no longer
+ * exists" is both necessary and sufficient to know the holder can never
+ * finish or release it. Recovering a dead arbiter still races multiple
+ * contenders (more than one can observe the same dead PID), so it goes
+ * through the SAME inode-verified rename this function's removal step
+ * cannot avoid at that one level: `renameSync` the arbiter file away,
+ * then confirm (via the inode captured from an open file descriptor
+ * held across the whole check) that what actually got moved is the
+ * exact dead entry inspected, not a live contender's fresh arbiter claim
+ * that happened to replace it in the interim. On a mismatch, the
+ * wrongly-grabbed file is discarded (never restored): the rightful
+ * holder's authority came from its own earlier successful `wx`-create,
+ * not from this marker file continuing to exist on disk, so losing the
+ * marker costs nothing but cosmetics -- see the design note in this
+ * module's own review history (#2223) for why restoring it instead
+ * would risk clobbering a third generation that may have since claimed
+ * `path` legitimately.
+ */
+function tryAcquireArbiter(path) {
+  const marker = arbiterPath(path);
+  try {
+    writeFileSync(marker, JSON.stringify({ pid: process.pid }), {
+      flag: 'wx',
+    });
+    return true;
+  } catch (error) {
+    if (error.code !== 'EEXIST') {
+      throw error;
+    }
+  }
+  let holderPid = null;
+  try {
+    const parsed = JSON.parse(readFileSync(marker, 'utf8'));
+    if (typeof parsed?.pid === 'number') {
+      holderPid = parsed.pid;
+    }
+  } catch {
+    // Malformed or unreadable: cannot determine liveness, so do not
+    // attempt recovery this pass -- fail closed exactly like the main
+    // lock's own malformed-body handling elsewhere in this module.
+  }
+  if (holderPid === null || isPidAlive(holderPid)) {
+    return false;
+  }
+  let fd;
+  try {
+    fd = openSync(marker, 'r');
   } catch (error) {
     if (error.code === 'ENOENT') {
       return false;
     }
     throw error;
   }
+  let observedIno;
   try {
-    unlinkSync(graveyardPath);
+    observedIno = fstatSync(fd).ino;
+  } finally {
+    closeSync(fd);
+  }
+  const graveyard = `${marker}.graveyard-${process.pid}-${Math.random().toString(36).slice(2)}`;
+  try {
+    renameSync(marker, graveyard);
   } catch (error) {
-    const code = error.code;
-    if (code === 'EISDIR' || code === 'EPERM') {
-      rmSync(graveyardPath, { recursive: true, force: true });
-    } else if (code !== 'ENOENT') {
+    if (error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+  let movedIno;
+  try {
+    movedIno = statSync(graveyard).ino;
+  } catch {
+    movedIno = undefined;
+  }
+  if (movedIno === undefined || movedIno !== observedIno) {
+    try {
+      unlinkSync(graveyard);
+    } catch {
+      // Best-effort discard; see the doc comment above.
+    }
+    return false;
+  }
+  try {
+    unlinkSync(graveyard);
+  } catch {
+    // Best-effort; the dead entry is confirmed claimed regardless.
+  }
+  try {
+    writeFileSync(marker, JSON.stringify({ pid: process.pid }), {
+      flag: 'wx',
+    });
+    return true;
+  } catch (error) {
+    if (error.code === 'EEXIST') {
+      return false;
+    }
+    throw error;
+  }
+}
+/** Release the arbiter acquired via {@link tryAcquireArbiter}. */
+function releaseArbiter(path) {
+  try {
+    unlinkSync(arbiterPath(path));
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
       throw error;
     }
   }
-  return true;
+}
+/**
+ * Remove the (believed-stale) main lock at `path` and immediately
+ * recreate it as `agentId`/`token`, but ONLY while holding the arbiter
+ * -- see {@link tryAcquireArbiter} for why that is what makes the plain
+ * `unlinkSync` here safe. Re-verifies staleness against `staleMs` once
+ * more immediately after winning the arbiter (arbitration itself can
+ * take a moment under contention, during which the lock's own live
+ * holder may have refreshed its lease, or an unrelated contender may
+ * have already recovered it) rather than trusting the caller's earlier,
+ * now-possibly-stale check. Returns `false` (never throws for this) when
+ * the arbiter itself could not be acquired, the re-check finds the lock
+ * no longer stale, or recreation lost to an unrelated fresh acquirer in
+ * the brief gap after this function's own removal (vanishingly unlikely,
+ * and still safe: that acquirer's `wx`-create is exclusive by
+ * construction).
+ */
+function tryTakeOverStaleLock(path, agentId, token, staleMs) {
+  if (!tryAcquireArbiter(path)) {
+    return false;
+  }
+  try {
+    const ageMs = lockAgeMs(path);
+    if (ageMs === null || ageMs <= staleMs) {
+      return false;
+    }
+    try {
+      unlinkSync(path);
+    } catch (error) {
+      const code = error.code;
+      if (code === 'EISDIR' || code === 'EPERM') {
+        rmSync(path, { recursive: true, force: true });
+      } else if (code !== 'ENOENT') {
+        throw error;
+      }
+    }
+    return tryExclusiveCreate(path, agentId, token);
+  } finally {
+    releaseArbiter(path);
+  }
 }
 /**
  * Thrown when a lock cannot be acquired within `timeoutMs`.
@@ -264,14 +421,15 @@ export class CloneLockTimeoutError extends Error {
  * Block (retrying with backoff) until the clone-scoped lock at `repoPath`
  * is acquired, or throw {@link CloneLockTimeoutError} after `timeoutMs`.
  * A lock whose mtime is older than `staleMs` is treated as abandoned;
- * every waiter that notices races for its removal via
- * {@link tryClaimStaleLockForRemoval} (exactly one ever wins, by
- * construction) and then for its recreation via the same
- * exclusive-create primitive a fresh acquire uses -- every loser at
- * either step simply continues waiting rather than assuming it
- * acquired. `staleMs` defaults to `STALE_LOCK_MS` and is exposed only
- * for tests that need a short-lived clock; production callers should
- * not override it.
+ * every waiter that notices attempts recovery via
+ * {@link tryTakeOverStaleLock}, which holds the PID-tagged arbiter (see
+ * {@link tryAcquireArbiter}) for the whole remove-then-recreate sequence
+ * so that even when multiple contenders observe the same stale mtime
+ * from independent reads, at most one of them ever actually removes and
+ * recreates it -- every loser simply continues waiting rather than
+ * assuming it acquired. `staleMs` defaults to `STALE_LOCK_MS` and is
+ * exposed only for tests that need a short-lived clock; production
+ * callers should not override it.
  */
 export function acquireCloneLock(
   repoPath,
@@ -290,16 +448,16 @@ export function acquireCloneLock(
     if (
       ageMs !== null &&
       ageMs > staleMs &&
-      tryClaimStaleLockForRemoval(path) &&
-      tryExclusiveCreate(path, agentId, token)
+      tryTakeOverStaleLock(path, agentId, token, staleMs)
     ) {
       return { path, token };
     }
-    // Either not (yet provably) stale, lost the removal race to another
-    // contender, or -- vanishingly unlikely -- won the removal race but
-    // then lost the immediate recreate to an unrelated fresh acquirer;
-    // every case falls through to the normal wait/retry path below
-    // rather than assuming acquisition.
+    // Either not (yet provably) stale, lost the arbiter race to another
+    // contender, the arbiter's own re-check found it no longer stale, or
+    // -- vanishingly unlikely -- won the takeover but then lost the
+    // immediate recreate to an unrelated fresh acquirer; every case
+    // falls through to the normal wait/retry path below rather than
+    // assuming acquisition.
     if (Date.now() >= deadline) {
       throw new CloneLockTimeoutError(path, timeoutMs);
     }

--- a/scripts/clone-lock.mjs
+++ b/scripts/clone-lock.mjs
@@ -301,6 +301,55 @@ function discardBestEffort(path) {
   }
 }
 /**
+ * Called after {@link tryAcquireArbiter}'s inode check finds it grabbed
+ * the WRONG file at `graveyardPath` -- not the confirmed-dead marker it
+ * verified, but a live contender's fresh claim that happened to replace
+ * it in the interim. Restores the live contender's marker to `destPath`
+ * whenever possible, rather than discarding it: a discarded marker
+ * leaves `destPath` briefly absent for as long as that live contender's
+ * ENTIRE arbiter-protected critical section takes to finish, during
+ * which a third contender's ordinary fresh `wx`-create can ALSO succeed
+ * there, producing two simultaneous believed-arbiters -- exactly the
+ * double-winner class of bug this whole mechanism exists to prevent.
+ * Restoring narrows that exposure window to roughly the time this one
+ * rename-back takes, instead of the live contender's full critical
+ * section.
+ *
+ * The restore itself uses exclusive create (`{ flag: 'wx' }`), not an
+ * unconditional `renameSync`, so it can never clobber a THIRD
+ * contender's own legitimate claim that already filled the gap `path`
+ * exposed the moment this function's caller renamed it away in the
+ * first place: if the restore loses that race (`EEXIST`), the live
+ * contender's original marker is discarded instead -- its holder does
+ * not depend on the marker file continuing to exist to keep running its
+ * own already-in-progress critical section (see `tryAcquireArbiter`'s
+ * own doc comment), and the slot at `destPath` is by then some OTHER
+ * contender's own equally legitimate exclusive claim, which must not be
+ * overwritten either.
+ */
+function restoreOrDiscard(graveyardPath, destPath) {
+  let content = null;
+  try {
+    content = readFileSync(graveyardPath);
+  } catch {
+    content = null;
+  }
+  if (content !== null) {
+    try {
+      writeFileSync(destPath, content, { flag: 'wx' });
+      discardBestEffort(graveyardPath);
+      return;
+    } catch (error) {
+      if (error.code !== 'EEXIST') {
+        throw error;
+      }
+      // Lost the restore race to a third contender's own fresh claim;
+      // fall through to discarding our accidental grab.
+    }
+  }
+  discardBestEffort(graveyardPath);
+}
+/**
  * Exclusively acquire the arbiter for one stale-lock-removal attempt
  * against `path`'s main lock, or return `false` when another contender
  * is already arbitrating (or just won a recovery race for a dead
@@ -343,15 +392,16 @@ function discardBestEffort(path) {
  * then confirm (via the inode captured together with the liveness
  * verdict above) that what actually got moved is the exact entry
  * inspected, not a live contender's fresh arbiter claim that happened to
- * replace it in the interim. On a mismatch, the wrongly-grabbed file is
- * discarded (never restored): the rightful holder's authority came from
- * its own earlier successful `wx`-create, not from this marker file
- * continuing to exist on disk, so losing the marker costs nothing but
- * cosmetics -- restoring it instead would risk clobbering a third
- * generation that may have since claimed `path` legitimately (the same
- * reasoning `releaseCloneLock`/`refreshCloneLock` rely on the arbiter
- * itself to avoid needing, by never attempting a similar restore against
- * the main lock).
+ * replace it in the interim. On a mismatch, {@link restoreOrDiscard}
+ * puts the wrongly-grabbed file back (via its own exclusive-create race,
+ * never an unconditional overwrite) rather than deleting it: this
+ * repository's review history on #2223 caught that an earlier revision
+ * which discarded a mismatched grab instead left the live contender's
+ * marker path briefly absent for as long as that contender's ENTIRE
+ * arbiter-protected critical section took to finish, during which a
+ * third contender's ordinary fresh `wx`-create could ALSO succeed there
+ * -- reproducing the very double-arbiter failure this whole mechanism
+ * exists to close, just relocated one level down.
  */
 function tryAcquireArbiter(path) {
   const marker = arbiterPath(path);
@@ -415,7 +465,7 @@ function tryAcquireArbiter(path) {
     movedIno = undefined;
   }
   if (movedIno === undefined || movedIno !== observedIno) {
-    discardBestEffort(graveyard);
+    restoreOrDiscard(graveyard, marker);
     return false;
   }
   discardBestEffort(graveyard);
@@ -784,11 +834,12 @@ lock file exists but could not be parsed as a well-formed lock body.
 }
 // This bootstrap call is placed after every declaration in this module,
 // not near the top -- `runCli()`'s error path references the
-// `CloneLockTimeoutError` class below, and a class binding (unlike a
-// hoisted function declaration) stays in its temporal dead zone until its
-// own declaration statement executes. Invoking `runCli()` before that
-// point would throw a `ReferenceError` on any `--exec` timeout instead of
-// the documented message and exit code 3.
+// `CloneLockTimeoutError` class declared earlier in this file, and a
+// class binding (unlike a hoisted function declaration) stays in its
+// temporal dead zone until its own declaration statement executes.
+// Invoking `runCli()` before that point (e.g. from the top of the file)
+// would throw a `ReferenceError` on any `--exec` timeout instead of the
+// documented message and exit code 3.
 if (import.meta.main) {
   await runCli();
 }

--- a/scripts/helper-runtime-manifest.mjs
+++ b/scripts/helper-runtime-manifest.mjs
@@ -210,6 +210,15 @@ const HELPER_COMMANDS = [
       'Acquire, reacquire, or inspect a worktree-local same-machine claim lock.',
   },
   {
+    id: 'clone-lock',
+    scriptName: 'idd:clone-lock',
+    binName: 'idd-clone-lock',
+    entryPath: 'scripts/clone-lock.mjs',
+    vendoredCommand: 'node scripts/clone-lock.mjs',
+    description:
+      'Serialize a git worktree add/remove or fetch against the shared primary clone across concurrent sessions.',
+  },
+  {
     id: 'critique-delegate',
     scriptName: 'idd:critique-delegate',
     binName: 'idd-critique-delegate',

--- a/src/bin/idd-clone-lock.mts
+++ b/src/bin/idd-clone-lock.mts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// idd-generated-from: src/bin/idd-clone-lock.mts
+//
+// The bin/idd-clone-lock.mjs copy is generated from the .mts source named above
+// by `pnpm run build`. Edit the .mts source, never the generated .mjs.
+// See docs/typescript-sources.md.
+
+import { runHelper } from './run-helper.mts';
+
+runHelper('../scripts/clone-lock.mjs');

--- a/src/scripts/clone-lock.mts
+++ b/src/scripts/clone-lock.mts
@@ -48,16 +48,29 @@
 // repository's own review history on #2223 caught and reproduced exactly
 // that double-winner failure from an earlier `renameSync`-only attempt at
 // this fix, roughly one run in ten under concurrent load). The real fix
-// is a second, PID-tagged arbiter lock (`tryAcquireArbiter`): removing
-// and recreating the main lock only ever happens while holding it, so at
-// most one contender is ever doing that at a time, regardless of how many
-// independently observed the same stale mtime. The arbiter's own
-// staleness is judged by process liveness (`isPidAlive`), not a time
-// threshold, because its critical section is always a handful of
-// synchronous, no-I/O-wait statements -- "the recorded PID no longer
-// exists" is both necessary and sufficient to know its holder crashed and
-// can never finish or release it, with none of a time threshold's
-// inherent "probably dead by now" ambiguity. This is a purely local
+// is a second, PID-tagged arbiter lock (`tryAcquireArbiter`): every
+// operation that mutates an EXISTING main lock -- takeover, release,
+// refresh -- runs only while holding it, so at most one contender is
+// ever doing that at a time, regardless of how many independently
+// observed the same stale mtime or the same token. Release and refresh
+// need this too, not only takeover: without it, a holder whose own
+// process stalled long enough for its lease to go stale and get taken
+// over by someone else could read a stale-but-still-matching token, then
+// delete or overwrite the NEW holder's fresh lock in the gap before its
+// own act (unlink or write) runs -- this repository's review history on
+// #2223 caught this as a separate gap from takeover's own, in the SAME
+// round that also caught takeover's residual double-winner race (an
+// earlier `renameSync`-only takeover attempt, with no arbiter at all,
+// reproduced roughly one run in ten under concurrent load). The
+// arbiter's own staleness is judged primarily by process liveness
+// (`isPidAlive`), not a time threshold, because its critical section is
+// always a handful of synchronous, no-I/O-wait statements -- "the
+// recorded PID no longer exists" is both necessary and sufficient to
+// know its holder crashed and can never finish or release it, with none
+// of a time threshold's inherent "probably dead by now" ambiguity; a
+// marker whose body can't be parsed (no PID to check) falls back to a
+// short, generous age threshold instead, so a crash mid-write there
+// isn't permanently unrecoverable either. This is a purely local
 // liveness heuristic scoped to operations that normally complete in
 // seconds -- it carries none of `claim-lock.mts`'s GitHub-reverification
 // requirement, because this lock has no cross-machine claim-ownership
@@ -98,6 +111,27 @@ const STALE_LOCK_MS = 5 * 60_000;
  * lease never lapses into apparent staleness between refreshes.
  */
 const DEFAULT_LEASE_REFRESH_MS = Math.floor(STALE_LOCK_MS / 2);
+/**
+ * An arbiter marker whose body can't be parsed (e.g. a crashed partial
+ * write) has no recorded PID to check liveness against. Its critical
+ * section is always a handful of synchronous, no-I/O-wait statements, so
+ * this age threshold only ever needs to be "generous relative to a
+ * syscall," not to any real operation's duration -- unlike
+ * `STALE_LOCK_MS`, which must outlast a genuine `git fetch`.
+ */
+const ARBITER_MALFORMED_STALE_MS = 5_000;
+/**
+ * Bounds how many times {@link releaseCloneLock} / {@link refreshCloneLock}
+ * retry a contended arbiter before giving up for this one call. Every
+ * arbiter hold in this module is a handful of synchronous statements, so
+ * contention clears in microseconds; this is a small, bounded backstop,
+ * not a real wait budget. Giving up is safe, not catastrophic: a release
+ * that couldn't get in leaves the lock for the module's own
+ * staleness+takeover machinery to eventually reclaim, and a refresh that
+ * couldn't get in is simply retried on the next heartbeat tick.
+ */
+const ARBITER_RETRY_ATTEMPTS = 50;
+const ARBITER_RETRY_DELAY_MS = 2;
 
 const CLONE_LOCK_FLAG_SPEC = {
   '--exec': { type: 'boolean' },
@@ -273,39 +307,82 @@ function isPidAlive(pid: number): boolean {
 }
 
 /**
+ * Best-effort remove `path`, falling back to a recursive `rmSync` only
+ * for the directory-shaped edge case (a malformed marker or lock that
+ * happens to be a directory, not the expected regular file) -- mirroring
+ * `claim-lock.mts`'s own takeover path. Every caller of this helper only
+ * ever targets a path nothing else can reference (a per-attempt
+ * graveyard copy this process alone renamed there), so recursion here is
+ * unconditionally safe regardless of what it finds.
+ */
+function discardBestEffort(path: string): void {
+  try {
+    unlinkSync(path);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'EISDIR' || code === 'EPERM') {
+      try {
+        rmSync(path, { recursive: true, force: true });
+      } catch {
+        // Best-effort; nothing more can safely be done here.
+      }
+    }
+    // ENOENT and anything else: best-effort, nothing to clean up.
+  }
+}
+
+/**
  * Exclusively acquire the arbiter for one stale-lock-removal attempt
  * against `path`'s main lock, or return `false` when another contender
  * is already arbitrating (or just won a recovery race for a dead
- * arbiter). Removal itself is `unlinkSync`, safe to run unconditionally
- * ONLY while holding this arbiter -- exactly one contender can ever hold
- * it at a time, which is what actually closes the race a plain
- * check-then-`unlinkSync` pair on the MAIN lock cannot: two contenders
- * observing the same stale mtime from independent reads can no longer
- * both proceed to remove/recreate the main lock concurrently, because
- * only one of them ever wins this arbiter first.
+ * arbiter). Every operation this module performs against an EXISTING
+ * main lock -- takeover, release, refresh -- runs only while holding
+ * this arbiter, which is what actually closes the races a plain
+ * check-then-act pair on the main lock cannot: two contenders observing
+ * the same stale mtime (or the same token) from independent reads can no
+ * longer both proceed to mutate the main lock concurrently, because only
+ * one of them ever wins this arbiter first. A genuinely fresh acquire
+ * (the main lock path is truly absent) does not need the arbiter at all
+ * -- `wx`-create is already exclusive for that case on its own.
  *
  * The arbiter is itself just a `{ flag: 'wx' }` claim recording the
  * arbitrating PID -- exclusive by the same primitive a fresh main-lock
  * acquire uses. Its OWN staleness (an arbiter whose holder crashed
- * mid-arbitration) is judged by {@link isPidAlive}, not by a time
+ * mid-arbitration) is judged primarily by {@link isPidAlive}, not a time
  * threshold: the arbitration critical section is always a handful of
  * synchronous, no-I/O-wait statements, so "the recorded PID no longer
  * exists" is both necessary and sufficient to know the holder can never
- * finish or release it. Recovering a dead arbiter still races multiple
- * contenders (more than one can observe the same dead PID), so it goes
- * through the SAME inode-verified rename this function's removal step
- * cannot avoid at that one level: `renameSync` the arbiter file away,
- * then confirm (via the inode captured from an open file descriptor
- * held across the whole check) that what actually got moved is the
- * exact dead entry inspected, not a live contender's fresh arbiter claim
- * that happened to replace it in the interim. On a mismatch, the
- * wrongly-grabbed file is discarded (never restored): the rightful
- * holder's authority came from its own earlier successful `wx`-create,
- * not from this marker file continuing to exist on disk, so losing the
- * marker costs nothing but cosmetics -- see the design note in this
- * module's own review history (#2223) for why restoring it instead
- * would risk clobbering a third generation that may have since claimed
- * `path` legitimately.
+ * finish or release it. A marker whose body can't be parsed (e.g. a
+ * crashed partial write) has no PID to check, so it falls back to
+ * `ARBITER_MALFORMED_STALE_MS` age instead, rather than being permanently
+ * unrecoverable.
+ *
+ * The PID (or age) used for that liveness verdict and the inode later
+ * verified against are captured from a SINGLE open file descriptor, not
+ * two separate reads: reading them separately leaves a gap where the
+ * verdict and the inode describe two DIFFERENT files -- a dead PID read
+ * moments ago, then (after another contender's own concurrent recovery
+ * of that same dead marker completed) a live contender's brand-new
+ * marker by the time a second, later read re-opens the path. This
+ * repository's own review history on #2223 caught exactly that gap in
+ * an earlier revision that read the PID via one `readFileSync(path)`
+ * call and the inode via a later, separate `openSync`.
+ *
+ * Recovering a confirmed-dead marker still races multiple contenders
+ * (more than one can independently reach the same dead verdict), so it
+ * goes through an inode-verified rename: `renameSync` the marker away,
+ * then confirm (via the inode captured together with the liveness
+ * verdict above) that what actually got moved is the exact entry
+ * inspected, not a live contender's fresh arbiter claim that happened to
+ * replace it in the interim. On a mismatch, the wrongly-grabbed file is
+ * discarded (never restored): the rightful holder's authority came from
+ * its own earlier successful `wx`-create, not from this marker file
+ * continuing to exist on disk, so losing the marker costs nothing but
+ * cosmetics -- restoring it instead would risk clobbering a third
+ * generation that may have since claimed `path` legitimately (the same
+ * reasoning `releaseCloneLock`/`refreshCloneLock` rely on the arbiter
+ * itself to avoid needing, by never attempting a similar restore against
+ * the main lock).
  */
 function tryAcquireArbiter(path: string): boolean {
   const marker = arbiterPath(path);
@@ -320,21 +397,6 @@ function tryAcquireArbiter(path: string): boolean {
     }
   }
 
-  let holderPid: number | null = null;
-  try {
-    const parsed = JSON.parse(readFileSync(marker, 'utf8'));
-    if (typeof parsed?.pid === 'number') {
-      holderPid = parsed.pid;
-    }
-  } catch {
-    // Malformed or unreadable: cannot determine liveness, so do not
-    // attempt recovery this pass -- fail closed exactly like the main
-    // lock's own malformed-body handling elsewhere in this module.
-  }
-  if (holderPid === null || isPidAlive(holderPid)) {
-    return false;
-  }
-
   let fd: number;
   try {
     fd = openSync(marker, 'r');
@@ -344,11 +406,31 @@ function tryAcquireArbiter(path: string): boolean {
     }
     throw error;
   }
-  let observedIno: number | undefined;
+  let observedIno: number;
+  let observedAgeMs: number;
+  let holderPid: number | null = null;
   try {
-    observedIno = fstatSync(fd).ino;
+    const stat = fstatSync(fd);
+    observedIno = stat.ino;
+    observedAgeMs = Date.now() - stat.mtimeMs;
+    try {
+      const parsed = JSON.parse(readFileSync(fd, 'utf8'));
+      if (typeof parsed?.pid === 'number') {
+        holderPid = parsed.pid;
+      }
+    } catch {
+      // Malformed body -- judged by observedAgeMs below instead.
+    }
   } finally {
     closeSync(fd);
+  }
+
+  const holderConfirmedDead =
+    holderPid !== null
+      ? !isPidAlive(holderPid)
+      : observedAgeMs > ARBITER_MALFORMED_STALE_MS;
+  if (!holderConfirmedDead) {
+    return false;
   }
 
   const graveyard = `${marker}.graveyard-${process.pid}-${Math.random().toString(36).slice(2)}`;
@@ -367,18 +449,10 @@ function tryAcquireArbiter(path: string): boolean {
     movedIno = undefined;
   }
   if (movedIno === undefined || movedIno !== observedIno) {
-    try {
-      unlinkSync(graveyard);
-    } catch {
-      // Best-effort discard; see the doc comment above.
-    }
+    discardBestEffort(graveyard);
     return false;
   }
-  try {
-    unlinkSync(graveyard);
-  } catch {
-    // Best-effort; the dead entry is confirmed claimed regardless.
-  }
+  discardBestEffort(graveyard);
 
   try {
     writeFileSync(marker, JSON.stringify({ pid: process.pid }), {
@@ -402,6 +476,22 @@ function releaseArbiter(path: string): void {
       throw error;
     }
   }
+}
+
+/**
+ * Acquire the arbiter for `path`, retrying briefly if another contender
+ * currently holds it. See `ARBITER_RETRY_ATTEMPTS`'s own doc comment for
+ * why a small bounded retry (not indefinite blocking) is the right
+ * shape here.
+ */
+function acquireArbiterWithRetry(path: string): boolean {
+  for (let attempt = 0; attempt < ARBITER_RETRY_ATTEMPTS; attempt += 1) {
+    if (tryAcquireArbiter(path)) {
+      return true;
+    }
+    sleepSync(ARBITER_RETRY_DELAY_MS);
+  }
+  return false;
 }
 
 /**
@@ -523,17 +613,37 @@ export function acquireCloneLock(
  * different token is present, another session already took the lock over
  * (e.g. after this caller's own hold went stale) and this release must
  * not disturb it. Removing an already-absent lock is a silent no-op.
+ *
+ * The token check and the removal happen while holding the arbiter (see
+ * {@link tryAcquireArbiter}), not as two independent steps: without that,
+ * a holder whose own process stalled badly enough for its lease to have
+ * gone stale and already been taken over by someone else could read a
+ * stale-but-still-matching token, then delete the NEW holder's fresh
+ * lock in the gap before its own `unlinkSync` runs -- this repository's
+ * review history on #2223 caught exactly this gap in an earlier
+ * revision. If the arbiter cannot be acquired within a bounded number of
+ * retries (see `ARBITER_RETRY_ATTEMPTS`), this call simply gives up
+ * rather than releasing incorrectly: an unreleased lock still recovers
+ * later through the module's own staleness+takeover machinery, which is
+ * safe, whereas releasing without the arbiter's protection would not be.
  */
 export function releaseCloneLock(handle: CloneLockHandle): void {
-  const read = readLock(handle.path);
-  if (read.status === 'present' && read.lock.token === handle.token) {
-    try {
-      unlinkSync(handle.path);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        throw error;
+  if (!acquireArbiterWithRetry(handle.path)) {
+    return;
+  }
+  try {
+    const read = readLock(handle.path);
+    if (read.status === 'present' && read.lock.token === handle.token) {
+      try {
+        unlinkSync(handle.path);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw error;
+        }
       }
     }
+  } finally {
+    releaseArbiter(handle.path);
   }
 }
 
@@ -542,27 +652,39 @@ export function releaseCloneLock(handle: CloneLockHandle): void {
  * when the on-disk token still matches `handle.token` -- this never
  * refreshes (or resurrects) a lock a different session now holds. Used
  * by {@link withCloneLock} to keep a legitimately long-running holder's
- * lease from lapsing into apparent staleness. A read-then-write race
- * against a concurrent stale takeover is inherent to a plain lock file
- * (there is no atomic compare-and-swap primitive here); the default
- * refresh cadence is sized generously relative to the staleness window
- * specifically to make that race vanishingly unlikely to matter in
- * practice. A failed refresh (e.g. the path became briefly inaccessible)
- * is silently swallowed: the next timer tick simply retries, and
- * `releaseCloneLock`'s own token check means a truly lost lease never
- * gets misreported as released.
+ * lease from lapsing into apparent staleness.
+ *
+ * Like {@link releaseCloneLock}, the token check and the write happen
+ * while holding the arbiter, not as two independent steps: without that,
+ * a holder whose lease had already gone stale and been taken over by
+ * someone else could read a stale-but-still-matching token, then
+ * truncate and overwrite the NEW holder's fresh lock with its own token
+ * in the gap before its own `writeFileSync` runs -- silently resurrecting
+ * a lease that should have stayed lost. If the arbiter cannot be
+ * acquired within a bounded number of retries, or the write itself fails
+ * (e.g. the path became briefly inaccessible), this call silently gives
+ * up: the next heartbeat tick simply retries, and `releaseCloneLock`'s
+ * own arbiter-protected token check means a truly lost lease never gets
+ * misreported as released.
  */
 export function refreshCloneLock(handle: CloneLockHandle): void {
-  const read = readLock(handle.path);
-  if (read.status === 'present' && read.lock.token === handle.token) {
-    try {
-      writeFileSync(
-        handle.path,
-        renderLockBody(read.lock.agentId, handle.token),
-      );
-    } catch {
-      // Best-effort; see the doc comment above.
+  if (!acquireArbiterWithRetry(handle.path)) {
+    return;
+  }
+  try {
+    const read = readLock(handle.path);
+    if (read.status === 'present' && read.lock.token === handle.token) {
+      try {
+        writeFileSync(
+          handle.path,
+          renderLockBody(read.lock.agentId, handle.token),
+        );
+      } catch {
+        // Best-effort; see the doc comment above.
+      }
     }
+  } finally {
+    releaseArbiter(handle.path);
   }
 }
 
@@ -590,8 +712,12 @@ export function checkCloneLock(repoPath: string): CheckCloneLockOutcome {
 /**
  * Acquire the clone lock, run `command` with `args` (inheriting stdio,
  * `cwd` set to `repoPath` so the wrapped git operation always targets the
- * same repository the lock scopes), then release the lock -- even if the
- * command fails. While the command runs, the lease is refreshed every
+ * same repository the lock scopes, and the same
+ * {@link sanitizedGitEnvironment} used to resolve the lock path itself --
+ * an ambient `GIT_DIR`/`GIT_WORK_TREE` the caller happened to have set
+ * must not redirect the wrapped command at a different repository than
+ * the one just locked), then release the lock -- even if the command
+ * fails. While the command runs, the lease is refreshed every
  * `leaseRefreshMs` (default {@link DEFAULT_LEASE_REFRESH_MS}) so a
  * legitimately long-running operation is never mistaken for an abandoned
  * holder by another waiter. Returns the command's exit code (`null` when
@@ -612,7 +738,11 @@ export async function withCloneLock(
   const heartbeat = setInterval(() => refreshCloneLock(handle), leaseRefreshMs);
   try {
     return await new Promise<number | null>((resolve, reject) => {
-      const child = spawn(command, args, { stdio: 'inherit', cwd: repoPath });
+      const child = spawn(command, args, {
+        stdio: 'inherit',
+        cwd: repoPath,
+        env: sanitizedGitEnvironment(),
+      });
       child.once('error', reject);
       child.once('exit', (code) => resolve(code));
     });
@@ -749,5 +879,5 @@ lock file exists but could not be parsed as a well-formed lock body.
 // point would throw a `ReferenceError` on any `--exec` timeout instead of
 // the documented message and exit code 3.
 if (import.meta.main) {
-  runCli();
+  await runCli();
 }

--- a/src/scripts/clone-lock.mts
+++ b/src/scripts/clone-lock.mts
@@ -10,11 +10,11 @@
 // clone when multiple concurrent sessions operate against it. This is a
 // different kind of lock than `claim-lock.mts`: that one records
 // worktree-local *ownership* for a whole worker's lifetime and reports a
-// same-machine collision immediately (never blocks). This one is a short
-// -duration *mutex* around a single git operation -- it blocks (retrying
-// with backoff) until it can acquire, up to a bounded timeout, because the
-// operations it guards are expected to finish in seconds, not the hours a
-// claim can be held for.
+// same-machine collision immediately (never blocks). This one is a
+// short-duration *mutex* around a single git operation -- it blocks
+// (retrying with backoff) until it can acquire, up to a bounded timeout,
+// because the operations it guards are expected to finish in seconds, not
+// the hours a claim can be held for.
 //
 // The lock file lives in the primary clone's *shared* git-admin directory
 // (`git rev-parse --path-format=absolute --git-common-dir`), not any one
@@ -27,19 +27,36 @@
 //
 // A holder that crashes mid-operation leaves an orphaned lock file behind
 // -- unlike a real `flock(2)`, a plain lock file is not released
-// automatically when its owning process dies. `STALE_LOCK_MS` bounds how
-// long a stuck lock can block every other session: once a lock's recorded
-// `acquiredAt` is older than that, a waiter treats it as abandoned and
-// force-takes it over. This is a purely local liveness heuristic scoped to
-// operations that normally complete in seconds -- it carries none of
+// automatically when its owning process dies. Staleness is judged by the
+// lock file's own mtime, not the `acquiredAt` field inside its JSON body
+// -- so a malformed lock (e.g. a crashed partial write, which can never
+// be parsed back into a valid `acquiredAt`) ages out and recovers exactly
+// like a well-formed one, instead of blocking every future waiter
+// forever. `STALE_LOCK_MS` bounds how long an abandoned lock can block
+// every other session; `withCloneLock`'s `--exec` path refreshes its own
+// lease (rewrites the file, which bumps its mtime) at roughly half that
+// interval while the wrapped command runs, so a legitimately
+// long-running operation is never mistaken for a dead holder. Recovering
+// a stale (or malformed-and-stale) lock is two exclusive races, not one:
+// first for the right to remove the abandoned entry (`renameSync` on a
+// specific source path -- POSIX serializes concurrent renames of the
+// same directory entry, so exactly one racer's removal ever succeeds,
+// see `tryClaimStaleLockForRemoval`'s own doc comment for why a plain
+// check-then-`unlinkSync` pair cannot make this same guarantee), then
+// for the right to recreate it (the same `{ flag: 'wx' }` primitive a
+// fresh acquire uses). Every loser at either step falls back to the
+// normal wait/retry loop rather than assuming it acquired. This is a
+// purely local liveness heuristic scoped to operations that normally
+// complete in seconds -- it carries none of
 // `claim-lock.mts`'s GitHub-reverification requirement, because this lock
 // has no cross-machine claim-ownership meaning to protect.
 
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import {
   readFileSync,
   renameSync,
   rmSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -58,8 +75,14 @@ const CLONE_LOCK_FILE_NAME = 'idd-clone.lock';
 const DEFAULT_TIMEOUT_MS = 120_000;
 /** Delay between retry attempts while waiting for a held lock. */
 const POLL_INTERVAL_MS = 200;
-/** A lock older than this is treated as abandoned by a dead holder. */
+/** A lock whose mtime is older than this is treated as abandoned. */
 const STALE_LOCK_MS = 5 * 60_000;
+/**
+ * How often `withCloneLock` refreshes its own lease while the wrapped
+ * command runs. Comfortably inside `STALE_LOCK_MS` so a live holder's
+ * lease never lapses into apparent staleness between refreshes.
+ */
+const DEFAULT_LEASE_REFRESH_MS = Math.floor(STALE_LOCK_MS / 2);
 
 const CLONE_LOCK_FLAG_SPEC = {
   '--exec': { type: 'boolean' },
@@ -69,10 +92,6 @@ const CLONE_LOCK_FLAG_SPEC = {
   '--timeout-ms': { type: 'string' },
   '--help': { type: 'boolean', short: 'h' },
 } as const;
-
-if (import.meta.main) {
-  runCli();
-}
 
 /**
  * Mirrors `claim-lock.mts`'s environment sanitization: repository
@@ -167,29 +186,98 @@ function sleepSync(ms: number): void {
 }
 
 /**
- * Force-remove an abandoned (stale or malformed) lock at `path` and
- * install a fresh one, mirroring `claim-lock.mts`'s
- * `overwriteLockAtomically`: write a same-directory temp file, then
- * `renameSync` into place (atomic on POSIX; the existing-file fallback
- * below covers Windows, which requires the destination removed first).
+ * The lock file's own mtime age in ms, or `null` when the path doesn't
+ * exist (raced away between the caller's failed create and this stat --
+ * treated as "not (yet provably) stale"; the caller's next loop
+ * iteration re-reads and, finding it absent, wins a fresh acquire).
+ * Deliberately reads filesystem mtime rather than the JSON body's
+ * `acquiredAt` field: mtime is set by every write (including a crashed,
+ * unparseable partial one) and by every lease refresh, so one staleness
+ * check works uniformly for a malformed lock, a well-formed one, and a
+ * refreshed live one.
  */
-function takeOverLock(path: string, agentId: string, token: string): void {
-  const tmpPath = `${path}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
-  writeFileSync(tmpPath, renderLockBody(agentId, token), { flag: 'wx' });
+function lockAgeMs(path: string): number | null {
   try {
-    try {
-      renameSync(tmpPath, path);
-    } catch {
-      rmSync(path, { recursive: true, force: true });
-      renameSync(tmpPath, path);
+    return Date.now() - statSync(path).mtimeMs;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null;
     }
-  } finally {
-    try {
-      unlinkSync(tmpPath);
-    } catch {
-      // Best-effort: a successful rename already moved tmpPath away.
+    throw error;
+  }
+}
+
+/**
+ * Exclusively create the lock file, succeeding only when nothing else won
+ * the race first. Both a fresh acquire and a stale-lock takeover funnel
+ * through this same primitive, so at most one contender ever wins either
+ * path.
+ */
+function tryExclusiveCreate(
+  path: string,
+  agentId: string,
+  token: string,
+): boolean {
+  try {
+    writeFileSync(path, renderLockBody(agentId, token), { flag: 'wx' });
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Exclusively claim the (believed-stale) lock at `path` for removal, so
+ * that even when multiple contenders simultaneously observe the same
+ * stale mtime, only one of them ever actually removes it. `renameSync`
+ * on a specific SOURCE path is itself the race-free primitive this needs
+ * -- POSIX serializes concurrent rename operations against the same
+ * directory entry, so among any number of racing
+ * `renameSync(path, <unique-destination>)` calls, exactly one succeeds
+ * (moving `path` away) and every later call sees `ENOENT`, since by the
+ * time it runs `path` no longer exists to rename from. This closes a
+ * race a plain check-then-`unlinkSync` pair cannot: two contenders can
+ * both observe the same stale mtime from independent reads, and a plain
+ * `unlinkSync` never verifies the file it deletes is still the one that
+ * was checked -- it happily deletes whatever a faster contender already
+ * replaced it with (including that contender's brand new, non-stale
+ * lock), letting both contenders believe they won.
+ *
+ * Returns `false` (a lost race, not an error) on `ENOENT` -- the normal
+ * outcome for every contender except the one that actually wins. The
+ * destination is a unique per-attempt "graveyard" path so concurrent
+ * winners of DIFFERENT stale-lock generations never collide with each
+ * other; it is then discarded immediately (`unlinkSync`, with a
+ * `recursive: true` `rmSync` fallback for the
+ * malformed-lock-is-a-directory edge case `claim-lock.mts`'s own
+ * takeover path also handles) -- this cleanup is unconditionally safe
+ * regardless of recursion, since nothing else can ever reference this
+ * exact path.
+ */
+function tryClaimStaleLockForRemoval(path: string): boolean {
+  const graveyardPath = `${path}.graveyard-${process.pid}-${Math.random().toString(36).slice(2)}`;
+  try {
+    renameSync(path, graveyardPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+  try {
+    unlinkSync(graveyardPath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'EISDIR' || code === 'EPERM') {
+      rmSync(graveyardPath, { recursive: true, force: true });
+    } else if (code !== 'ENOENT') {
+      throw error;
     }
   }
+  return true;
 }
 
 /** A held lock: pass to {@link releaseCloneLock} to release it. */
@@ -211,44 +299,45 @@ export class CloneLockTimeoutError extends Error {
 /**
  * Block (retrying with backoff) until the clone-scoped lock at `repoPath`
  * is acquired, or throw {@link CloneLockTimeoutError} after `timeoutMs`.
- * A lock older than `STALE_LOCK_MS` is treated as abandoned and taken
- * over rather than waited out.
+ * A lock whose mtime is older than `staleMs` is treated as abandoned;
+ * every waiter that notices races for its removal via
+ * {@link tryClaimStaleLockForRemoval} (exactly one ever wins, by
+ * construction) and then for its recreation via the same
+ * exclusive-create primitive a fresh acquire uses -- every loser at
+ * either step simply continues waiting rather than assuming it
+ * acquired. `staleMs` defaults to `STALE_LOCK_MS` and is exposed only
+ * for tests that need a short-lived clock; production callers should
+ * not override it.
  */
 export function acquireCloneLock(
   repoPath: string,
   agentId: string,
   timeoutMs: number = DEFAULT_TIMEOUT_MS,
+  staleMs: number = STALE_LOCK_MS,
 ): CloneLockHandle {
   const path = resolveCloneLockPath(repoPath);
   const token = randomToken();
   const deadline = Date.now() + timeoutMs;
 
   for (;;) {
-    const read = readLock(path);
-
-    if (read.status === 'absent') {
-      try {
-        writeFileSync(path, renderLockBody(agentId, token), { flag: 'wx' });
-        return { path, token };
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
-          throw error;
-        }
-        // Raced with a concurrent acquire between the read and this
-        // create; fall through to the wait/retry path below.
-      }
-    } else if (read.status === 'malformed') {
-      // A malformed body's age can't be determined; treat it the same as
-      // a fresh, definitely-not-stale lock and wait for it rather than
-      // taking it over immediately -- an in-progress writer's partial
-      // write should not be mistaken for an abandoned lock.
-    } else {
-      const ageMs = Date.now() - Date.parse(read.lock.acquiredAt);
-      if (Number.isFinite(ageMs) && ageMs > STALE_LOCK_MS) {
-        takeOverLock(path, agentId, token);
-        return { path, token };
-      }
+    if (tryExclusiveCreate(path, agentId, token)) {
+      return { path, token };
     }
+
+    const ageMs = lockAgeMs(path);
+    if (
+      ageMs !== null &&
+      ageMs > staleMs &&
+      tryClaimStaleLockForRemoval(path) &&
+      tryExclusiveCreate(path, agentId, token)
+    ) {
+      return { path, token };
+    }
+    // Either not (yet provably) stale, lost the removal race to another
+    // contender, or -- vanishingly unlikely -- won the removal race but
+    // then lost the immediate recreate to an unrelated fresh acquirer;
+    // every case falls through to the normal wait/retry path below
+    // rather than assuming acquisition.
 
     if (Date.now() >= deadline) {
       throw new CloneLockTimeoutError(path, timeoutMs);
@@ -277,6 +366,35 @@ export function releaseCloneLock(handle: CloneLockHandle): void {
   }
 }
 
+/**
+ * Rewrite the lock body at `handle.path`, bumping its mtime, but only
+ * when the on-disk token still matches `handle.token` -- this never
+ * refreshes (or resurrects) a lock a different session now holds. Used
+ * by {@link withCloneLock} to keep a legitimately long-running holder's
+ * lease from lapsing into apparent staleness. A read-then-write race
+ * against a concurrent stale takeover is inherent to a plain lock file
+ * (there is no atomic compare-and-swap primitive here); the default
+ * refresh cadence is sized generously relative to the staleness window
+ * specifically to make that race vanishingly unlikely to matter in
+ * practice. A failed refresh (e.g. the path became briefly inaccessible)
+ * is silently swallowed: the next timer tick simply retries, and
+ * `releaseCloneLock`'s own token check means a truly lost lease never
+ * gets misreported as released.
+ */
+export function refreshCloneLock(handle: CloneLockHandle): void {
+  const read = readLock(handle.path);
+  if (read.status === 'present' && read.lock.token === handle.token) {
+    try {
+      writeFileSync(
+        handle.path,
+        renderLockBody(read.lock.agentId, handle.token),
+      );
+    } catch {
+      // Best-effort; see the doc comment above.
+    }
+  }
+}
+
 /** Outcome shape returned by {@link checkCloneLock}. */
 export interface CheckCloneLockOutcome {
   path: string;
@@ -299,25 +417,36 @@ export function checkCloneLock(repoPath: string): CheckCloneLockOutcome {
 }
 
 /**
- * Acquire the clone lock, run `command` with `args` (inheriting stdio),
- * then release the lock -- even if the command fails. Returns the
- * command's exit code (`null` when it was killed by a signal).
+ * Acquire the clone lock, run `command` with `args` (inheriting stdio,
+ * `cwd` set to `repoPath` so the wrapped git operation always targets the
+ * same repository the lock scopes), then release the lock -- even if the
+ * command fails. While the command runs, the lease is refreshed every
+ * `leaseRefreshMs` (default {@link DEFAULT_LEASE_REFRESH_MS}) so a
+ * legitimately long-running operation is never mistaken for an abandoned
+ * holder by another waiter. Returns the command's exit code (`null` when
+ * it was killed by a signal). `staleMs`/`leaseRefreshMs` are exposed only
+ * for tests that need a short-lived clock; production callers should not
+ * override them.
  */
-export function withCloneLock(
+export async function withCloneLock(
   repoPath: string,
   agentId: string,
   command: string,
   args: string[],
   timeoutMs: number = DEFAULT_TIMEOUT_MS,
-): number | null {
-  const handle = acquireCloneLock(repoPath, agentId, timeoutMs);
+  staleMs: number = STALE_LOCK_MS,
+  leaseRefreshMs: number = DEFAULT_LEASE_REFRESH_MS,
+): Promise<number | null> {
+  const handle = acquireCloneLock(repoPath, agentId, timeoutMs, staleMs);
+  const heartbeat = setInterval(() => refreshCloneLock(handle), leaseRefreshMs);
   try {
-    const result = spawnSync(command, args, { stdio: 'inherit' });
-    if (result.error) {
-      throw result.error;
-    }
-    return result.status;
+    return await new Promise<number | null>((resolve, reject) => {
+      const child = spawn(command, args, { stdio: 'inherit', cwd: repoPath });
+      child.once('error', reject);
+      child.once('exit', (code) => resolve(code));
+    });
   } finally {
+    clearInterval(heartbeat);
     releaseCloneLock(handle);
   }
 }
@@ -374,7 +503,7 @@ function parseArgs(argv: string[]): ParsedArgs {
   };
 }
 
-function runCli(): void {
+async function runCli(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
     printHelp();
@@ -398,7 +527,7 @@ function runCli(): void {
   }
   const [command, ...commandArgs] = args.command;
   try {
-    const status = withCloneLock(
+    const status = await withCloneLock(
       repo,
       args.agentId,
       command,
@@ -424,12 +553,14 @@ function printHelp(): void {
 Clone-scoped mutual-exclusion lock: serializes \`git worktree add\`,
 \`git worktree remove\`, and \`git fetch\` against the shared primary
 clone across concurrent sessions. \`--exec\` blocks (retrying) until the
-lock is acquired, runs <command> [args...] with stdio inherited, then
-releases the lock -- even if the command fails -- and exits with the
-command's own exit code. A lock held longer than 5 minutes is treated
-as abandoned by a dead holder and taken over rather than waited out.
-Exits 3 if the lock could not be acquired within --timeout-ms
-(default 120000).
+lock is acquired, runs <command> [args...] with stdio inherited and cwd
+set to --repo, then releases the lock -- even if the command fails --
+and exits with the command's own exit code. A lock whose lease has not
+been refreshed for 5 minutes is treated as abandoned by a dead holder
+and taken over; \`--exec\` refreshes its own lease periodically while
+the wrapped command runs, so a legitimately long-running operation is
+never mistaken for a dead holder. Exits 3 if the lock could not be
+acquired within --timeout-ms (default 120000).
 
 --check is read-only: it reports the current lock state without
 creating, mutating, or deleting anything. \`malformed: true\` means a
@@ -437,4 +568,15 @@ lock file exists but could not be parsed as a well-formed lock body.
 
 --repo defaults to the current working directory.
 `);
+}
+
+// This bootstrap call is placed after every declaration in this module,
+// not near the top -- `runCli()`'s error path references the
+// `CloneLockTimeoutError` class below, and a class binding (unlike a
+// hoisted function declaration) stays in its temporal dead zone until its
+// own declaration statement executes. Invoking `runCli()` before that
+// point would throw a `ReferenceError` on any `--exec` timeout instead of
+// the documented message and exit code 3.
+if (import.meta.main) {
+  runCli();
 }

--- a/src/scripts/clone-lock.mts
+++ b/src/scripts/clone-lock.mts
@@ -25,74 +25,70 @@
 // which `claim-lock.mts` uses for its narrower per-worktree scope) is
 // required here.
 //
-// A holder that crashes mid-operation leaves an orphaned lock file behind
-// -- unlike a real `flock(2)`, a plain lock file is not released
-// automatically when its owning process dies. Staleness is judged by the
-// lock file's own mtime, not the `acquiredAt` field inside its JSON body
-// -- so a malformed lock (e.g. a crashed partial write, which can never
-// be parsed back into a valid `acquiredAt`) ages out and recovers exactly
-// like a well-formed one, instead of blocking every future waiter
-// forever. `STALE_LOCK_MS` bounds how long an abandoned lock can block
-// every other session; `withCloneLock`'s `--exec` path refreshes its own
-// lease (rewrites the file, which bumps its mtime) at roughly half that
-// interval while the wrapped command runs, so a legitimately
-// long-running operation is never mistaken for a dead holder.
-//
-// Recovering a stale lock is NOT simply "remove it, then race the usual
-// exclusive-create": two contenders can independently observe the same
-// stale mtime, and neither a plain `unlinkSync` nor a plain `renameSync`
-// on its own verifies the file it removes is still the exact entry that
-// was checked -- both happily remove whatever a faster contender already
-// replaced it with (including that contender's brand-new, non-stale
-// lock), letting more than one contender believe it took over (this
-// repository's own review history on #2223 caught and reproduced exactly
-// that double-winner failure from an earlier `renameSync`-only attempt at
-// this fix, roughly one run in ten under concurrent load). The real fix
-// is a second, PID-tagged arbiter lock (`tryAcquireArbiter`): every
-// operation that mutates an EXISTING main lock -- takeover, release,
-// refresh -- runs only while holding it, so at most one contender is
-// ever doing that at a time, regardless of how many independently
-// observed the same stale mtime or the same token. Release and refresh
-// need this too, not only takeover: without it, a holder whose own
-// process stalled long enough for its lease to go stale and get taken
-// over by someone else could read a stale-but-still-matching token, then
-// delete or overwrite the NEW holder's fresh lock in the gap before its
-// own act (unlink or write) runs -- this repository's review history on
-// #2223 caught this as a separate gap from takeover's own, in the SAME
-// round that also caught takeover's residual double-winner race (an
-// earlier `renameSync`-only takeover attempt, with no arbiter at all,
-// reproduced roughly one run in ten under concurrent load). The
-// arbiter's own staleness is judged primarily by process liveness
-// (`isPidAlive`), not a time threshold, because its critical section is
-// always a handful of synchronous, no-I/O-wait statements -- "the
-// recorded PID no longer exists" is both necessary and sufficient to
-// know its holder crashed and can never finish or release it, with none
-// of a time threshold's inherent "probably dead by now" ambiguity; a
-// marker whose body can't be parsed (no PID to check) falls back to a
-// short, generous age threshold instead, so a crash mid-write there
-// isn't permanently unrecoverable either. This is a purely local
-// liveness heuristic scoped to operations that normally complete in
-// seconds -- it carries none of `claim-lock.mts`'s GitHub-reverification
-// requirement, because this lock has no cross-machine claim-ownership
-// meaning to protect.
+// A holder that crashes leaves an orphaned lock file behind -- unlike a
+// real `flock(2)`, a plain lock file is not released automatically when
+// its owning process dies. Staleness is judged by process liveness
+// (`isPidAlive`, `process.kill(pid, 0)`), not elapsed time: the lock body
+// records the holder's own `pid`, alongside `claim-lock.mts`'s existing
+// `token`/`agentId`/`acquiredAt` shape, and a lock is only ever eligible
+// for takeover once that exact PID is confirmed dead. This replaced an
+// earlier mtime-based design (recover anything older than a fixed
+// threshold, with the holder periodically refreshing its own lease to
+// prove it was still alive) after that design's CI run exposed the
+// failure mode it was always structurally prone to: a live,
+// actively-refreshing holder got taken over anyway, because "has this
+// timestamp aged past a threshold" is inherently a race against ordinary
+// process-scheduling jitter (a refresh landing late, a waiter's own
+// staleness check landing early) in a way "is this specific PID still
+// running" simply is not -- a process is never "probably dead by now,"
+// it is either scheduled on the OS right now or it does not exist.
+// Because the holder process for this lock (the one running `withExec`'s
+// wrapped command) stays alive for its own entire hold, no periodic
+// lease refresh is needed at all: liveness is continuously, automatically
+// true for as long as the holder is doing anything, and instantly,
+// unambiguously false the moment it exits or crashes. This also makes
+// release and takeover logically disjoint rather than a race to close:
+// release only ever runs from the live holder's own still-running
+// process (whose PID is, by definition, alive), so a takeover's PID
+// -liveness check can never mistake an active release-in-progress for a
+// dead holder -- no arbiter, inode verification, or other coordination
+// primitive beyond the plain `wx`-exclusive-create every acquire already
+// uses is needed to keep the two from conflicting. A takeover
+// re-confirms the lock is still the exact dead entry it inspected
+// (re-reading immediately before removing) rather than trusting a
+// possibly-stale earlier check, then goes through the SAME
+// `{ flag: 'wx' }` primitive a fresh acquire uses to recreate it -- the
+// only decision authority for who wins a contested recreate is the OS
+// kernel's own `O_EXCL` guarantee, not any bookkeeping this module
+// performs itself. One race is knowingly NOT closed: the single-syscall
+// gap between that re-confirmation read and the `unlinkSync` that acts
+// on it. Closing it fully would need a kernel-level compare-and-swap
+// this module does not have access to from plain POSIX file primitives;
+// every design this module has tried carries an equivalent residual gap
+// somewhere, and the ones that attempted to close this exact one (a
+// PID-tagged arbiter lock plus inode-verified recovery) each introduced
+// a NEW, worse gap of their own across three consecutive review rounds
+// (#2223) rather than actually eliminating it. This narrow, explicitly
+// accepted gap is deliberately simpler to reason about than that
+// alternative. A malformed lock body (e.g. a crashed partial write) has
+// no readable `pid` to check liveness against and is therefore never
+// auto-recovered -- `writeFileSync`'s single, small write is atomic in
+// practice on every realistic filesystem, so genuinely torn content is
+// vanishingly rare, and this module intentionally does not add recovery
+// machinery for it; see `--check`'s `malformed: true` output for manual
+// diagnosis. This is a purely local liveness heuristic scoped to
+// operations that normally complete in seconds -- it carries none of
+// `claim-lock.mts`'s GitHub-reverification requirement, because this
+// lock has no cross-machine claim-ownership meaning to protect.
 
 import { execFileSync, spawn } from 'node:child_process';
-import {
-  closeSync,
-  fstatSync,
-  openSync,
-  readFileSync,
-  renameSync,
-  rmSync,
-  statSync,
-  unlinkSync,
-  writeFileSync,
-} from 'node:fs';
+import { readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { parseCliArgs } from './cli-args.mts';
 
 /** Shape of the JSON lock body written to disk. */
 interface CloneLockBody {
+  pid: number;
   token: string;
   agentId: string;
   acquiredAt: string;
@@ -103,35 +99,6 @@ const CLONE_LOCK_FILE_NAME = 'idd-clone.lock';
 const DEFAULT_TIMEOUT_MS = 120_000;
 /** Delay between retry attempts while waiting for a held lock. */
 const POLL_INTERVAL_MS = 200;
-/** A lock whose mtime is older than this is treated as abandoned. */
-const STALE_LOCK_MS = 5 * 60_000;
-/**
- * How often `withCloneLock` refreshes its own lease while the wrapped
- * command runs. Comfortably inside `STALE_LOCK_MS` so a live holder's
- * lease never lapses into apparent staleness between refreshes.
- */
-const DEFAULT_LEASE_REFRESH_MS = Math.floor(STALE_LOCK_MS / 2);
-/**
- * An arbiter marker whose body can't be parsed (e.g. a crashed partial
- * write) has no recorded PID to check liveness against. Its critical
- * section is always a handful of synchronous, no-I/O-wait statements, so
- * this age threshold only ever needs to be "generous relative to a
- * syscall," not to any real operation's duration -- unlike
- * `STALE_LOCK_MS`, which must outlast a genuine `git fetch`.
- */
-const ARBITER_MALFORMED_STALE_MS = 5_000;
-/**
- * Bounds how many times {@link releaseCloneLock} / {@link refreshCloneLock}
- * retry a contended arbiter before giving up for this one call. Every
- * arbiter hold in this module is a handful of synchronous statements, so
- * contention clears in microseconds; this is a small, bounded backstop,
- * not a real wait budget. Giving up is safe, not catastrophic: a release
- * that couldn't get in leaves the lock for the module's own
- * staleness+takeover machinery to eventually reclaim, and a refresh that
- * couldn't get in is simply retried on the next heartbeat tick.
- */
-const ARBITER_RETRY_ATTEMPTS = 50;
-const ARBITER_RETRY_DELAY_MS = 2;
 
 const CLONE_LOCK_FLAG_SPEC = {
   '--exec': { type: 'boolean' },
@@ -185,6 +152,7 @@ function isCloneLockBody(value: unknown): value is CloneLockBody {
   return (
     typeof value === 'object' &&
     value !== null &&
+    typeof (value as Record<string, unknown>).pid === 'number' &&
     typeof (value as Record<string, unknown>).token === 'string' &&
     typeof (value as Record<string, unknown>).agentId === 'string' &&
     typeof (value as Record<string, unknown>).acquiredAt === 'string'
@@ -214,6 +182,7 @@ function readLock(path: string): LockReadResult {
 
 function renderLockBody(agentId: string, token: string): string {
   const body: CloneLockBody = {
+    pid: process.pid,
     token,
     agentId,
     acquiredAt: new Date().toISOString(),
@@ -235,32 +204,41 @@ function sleepSync(ms: number): void {
 }
 
 /**
- * The lock file's own mtime age in ms, or `null` when the path doesn't
- * exist (raced away between the caller's failed create and this stat --
- * treated as "not (yet provably) stale"; the caller's next loop
- * iteration re-reads and, finding it absent, wins a fresh acquire).
- * Deliberately reads filesystem mtime rather than the JSON body's
- * `acquiredAt` field: mtime is set by every write (including a crashed,
- * unparseable partial one) and by every lease refresh, so one staleness
- * check works uniformly for a malformed lock, a well-formed one, and a
- * refreshed live one.
+ * `true` when `pid` identifies a currently-running process, `false` when
+ * it definitely does not. `process.kill(pid, 0)` sends no actual signal
+ * -- it only probes existence/permission. `ESRCH` (no such process) is
+ * the only outcome that means dead; `EPERM` (the process exists but this
+ * one lacks permission to signal it) and success both mean alive. This
+ * is a reliable, instantaneous, non-time-based liveness check: unlike an
+ * elapsed-time threshold, there is no ambiguity window where a process
+ * might be "probably dead by now" -- it either currently exists or it
+ * does not.
  */
-function lockAgeMs(path: string): number | null {
+function isPidAlive(pid: number): boolean {
   try {
-    return Date.now() - statSync(path).mtimeMs;
+    process.kill(pid, 0);
+    return true;
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return null;
-    }
-    throw error;
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
   }
 }
 
 /**
+ * `true` when `path` currently holds a well-formed lock whose recorded
+ * `pid` is confirmed dead. `false` for an absent, malformed (no `pid` to
+ * check -- see this module's header comment for why that edge case is
+ * not auto-recovered), or live lock.
+ */
+function isDeadLock(read: LockReadResult): boolean {
+  return read.status === 'present' && !isPidAlive(read.lock.pid);
+}
+
+/**
  * Exclusively create the lock file, succeeding only when nothing else won
- * the race first. Both a fresh acquire and a stale-lock takeover funnel
+ * the race first. Both a fresh acquire and a dead-lock takeover funnel
  * through this same primitive, so at most one contender ever wins either
- * path.
+ * path -- the OS kernel's own `O_EXCL` guarantee is the sole decision
+ * authority for who wins a contested create.
  */
 function tryExclusiveCreate(
   path: string,
@@ -279,316 +257,37 @@ function tryExclusiveCreate(
 }
 
 /**
- * Companion path for the PID-tagged arbiter lock that guards a stale
- * -takeover REMOVAL against `path` -- see {@link tryAcquireArbiter}.
+ * Attempt to recover a lock at `path` whose recorded holder is confirmed
+ * dead, then immediately recreate it as `agentId`/`token`. Re-reads the
+ * lock immediately before removing it, rather than trusting the
+ * caller's own (possibly now-stale) check, to narrow -- though, per this
+ * module's header comment, not fully close -- the gap between
+ * confirming death and acting on it. Returns `false` (never throws for
+ * this) when the lock is no longer confirmed dead by the time of the
+ * re-check, or recreation lost to an unrelated fresh acquirer in the
+ * brief gap after this function's own removal (that acquirer's
+ * `wx`-create is exclusive by construction either way, so this is safe
+ * regardless of how it resolves).
  */
-function arbiterPath(path: string): string {
-  return `${path}.arbiter`;
-}
-
-/**
- * `true` when `pid` identifies a currently-running process, `false` when
- * it definitely does not. `process.kill(pid, 0)` sends no actual signal
- * -- it only probes existence/permission. `ESRCH` (no such process) is
- * the only outcome that means dead; `EPERM` (the process exists but this
- * one lacks permission to signal it) and success both mean alive. This
- * is a reliable, instantaneous, non-time-based liveness check -- unlike
- * an mtime-based staleness threshold, there is no ambiguity window where
- * a process might be "probably dead by now": it either currently exists
- * or it does not.
- */
-function isPidAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code === 'EPERM';
+function tryTakeOverDeadLock(
+  path: string,
+  agentId: string,
+  token: string,
+): boolean {
+  if (!isDeadLock(readLock(path))) {
+    return false;
   }
-}
-
-/**
- * Best-effort remove `path`, falling back to a recursive `rmSync` only
- * for the directory-shaped edge case (a malformed marker or lock that
- * happens to be a directory, not the expected regular file) -- mirroring
- * `claim-lock.mts`'s own takeover path. Every caller of this helper only
- * ever targets a path nothing else can reference (a per-attempt
- * graveyard copy this process alone renamed there), so recursion here is
- * unconditionally safe regardless of what it finds.
- */
-function discardBestEffort(path: string): void {
+  if (!isDeadLock(readLock(path))) {
+    return false;
+  }
   try {
     unlinkSync(path);
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === 'EISDIR' || code === 'EPERM') {
-      try {
-        rmSync(path, { recursive: true, force: true });
-      } catch {
-        // Best-effort; nothing more can safely be done here.
-      }
-    }
-    // ENOENT and anything else: best-effort, nothing to clean up.
-  }
-}
-
-/**
- * Called after {@link tryAcquireArbiter}'s inode check finds it grabbed
- * the WRONG file at `graveyardPath` -- not the confirmed-dead marker it
- * verified, but a live contender's fresh claim that happened to replace
- * it in the interim. Restores the live contender's marker to `destPath`
- * whenever possible, rather than discarding it: a discarded marker
- * leaves `destPath` briefly absent for as long as that live contender's
- * ENTIRE arbiter-protected critical section takes to finish, during
- * which a third contender's ordinary fresh `wx`-create can ALSO succeed
- * there, producing two simultaneous believed-arbiters -- exactly the
- * double-winner class of bug this whole mechanism exists to prevent.
- * Restoring narrows that exposure window to roughly the time this one
- * rename-back takes, instead of the live contender's full critical
- * section.
- *
- * The restore itself uses exclusive create (`{ flag: 'wx' }`), not an
- * unconditional `renameSync`, so it can never clobber a THIRD
- * contender's own legitimate claim that already filled the gap `path`
- * exposed the moment this function's caller renamed it away in the
- * first place: if the restore loses that race (`EEXIST`), the live
- * contender's original marker is discarded instead -- its holder does
- * not depend on the marker file continuing to exist to keep running its
- * own already-in-progress critical section (see `tryAcquireArbiter`'s
- * own doc comment), and the slot at `destPath` is by then some OTHER
- * contender's own equally legitimate exclusive claim, which must not be
- * overwritten either.
- */
-function restoreOrDiscard(graveyardPath: string, destPath: string): void {
-  let content: Buffer | null = null;
-  try {
-    content = readFileSync(graveyardPath);
-  } catch {
-    content = null;
-  }
-  if (content !== null) {
-    try {
-      writeFileSync(destPath, content, { flag: 'wx' });
-      discardBestEffort(graveyardPath);
-      return;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
-        throw error;
-      }
-      // Lost the restore race to a third contender's own fresh claim;
-      // fall through to discarding our accidental grab.
-    }
-  }
-  discardBestEffort(graveyardPath);
-}
-
-/**
- * Exclusively acquire the arbiter for one stale-lock-removal attempt
- * against `path`'s main lock, or return `false` when another contender
- * is already arbitrating (or just won a recovery race for a dead
- * arbiter). Every operation this module performs against an EXISTING
- * main lock -- takeover, release, refresh -- runs only while holding
- * this arbiter, which is what actually closes the races a plain
- * check-then-act pair on the main lock cannot: two contenders observing
- * the same stale mtime (or the same token) from independent reads can no
- * longer both proceed to mutate the main lock concurrently, because only
- * one of them ever wins this arbiter first. A genuinely fresh acquire
- * (the main lock path is truly absent) does not need the arbiter at all
- * -- `wx`-create is already exclusive for that case on its own.
- *
- * The arbiter is itself just a `{ flag: 'wx' }` claim recording the
- * arbitrating PID -- exclusive by the same primitive a fresh main-lock
- * acquire uses. Its OWN staleness (an arbiter whose holder crashed
- * mid-arbitration) is judged primarily by {@link isPidAlive}, not a time
- * threshold: the arbitration critical section is always a handful of
- * synchronous, no-I/O-wait statements, so "the recorded PID no longer
- * exists" is both necessary and sufficient to know the holder can never
- * finish or release it. A marker whose body can't be parsed (e.g. a
- * crashed partial write) has no PID to check, so it falls back to
- * `ARBITER_MALFORMED_STALE_MS` age instead, rather than being permanently
- * unrecoverable.
- *
- * The PID (or age) used for that liveness verdict and the inode later
- * verified against are captured from a SINGLE open file descriptor, not
- * two separate reads: reading them separately leaves a gap where the
- * verdict and the inode describe two DIFFERENT files -- a dead PID read
- * moments ago, then (after another contender's own concurrent recovery
- * of that same dead marker completed) a live contender's brand-new
- * marker by the time a second, later read re-opens the path. This
- * repository's own review history on #2223 caught exactly that gap in
- * an earlier revision that read the PID via one `readFileSync(path)`
- * call and the inode via a later, separate `openSync`.
- *
- * Recovering a confirmed-dead marker still races multiple contenders
- * (more than one can independently reach the same dead verdict), so it
- * goes through an inode-verified rename: `renameSync` the marker away,
- * then confirm (via the inode captured together with the liveness
- * verdict above) that what actually got moved is the exact entry
- * inspected, not a live contender's fresh arbiter claim that happened to
- * replace it in the interim. On a mismatch, {@link restoreOrDiscard}
- * puts the wrongly-grabbed file back (via its own exclusive-create race,
- * never an unconditional overwrite) rather than deleting it: this
- * repository's review history on #2223 caught that an earlier revision
- * which discarded a mismatched grab instead left the live contender's
- * marker path briefly absent for as long as that contender's ENTIRE
- * arbiter-protected critical section took to finish, during which a
- * third contender's ordinary fresh `wx`-create could ALSO succeed there
- * -- reproducing the very double-arbiter failure this whole mechanism
- * exists to close, just relocated one level down.
- */
-function tryAcquireArbiter(path: string): boolean {
-  const marker = arbiterPath(path);
-  try {
-    writeFileSync(marker, JSON.stringify({ pid: process.pid }), {
-      flag: 'wx',
-    });
-    return true;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
-      throw error;
-    }
-  }
-
-  let fd: number;
-  try {
-    fd = openSync(marker, 'r');
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return false;
-    }
-    throw error;
-  }
-  let observedIno: number;
-  let observedAgeMs: number;
-  let holderPid: number | null = null;
-  try {
-    const stat = fstatSync(fd);
-    observedIno = stat.ino;
-    observedAgeMs = Date.now() - stat.mtimeMs;
-    try {
-      const parsed = JSON.parse(readFileSync(fd, 'utf8'));
-      if (typeof parsed?.pid === 'number') {
-        holderPid = parsed.pid;
-      }
-    } catch {
-      // Malformed body -- judged by observedAgeMs below instead.
-    }
-  } finally {
-    closeSync(fd);
-  }
-
-  const holderConfirmedDead =
-    holderPid !== null
-      ? !isPidAlive(holderPid)
-      : observedAgeMs > ARBITER_MALFORMED_STALE_MS;
-  if (!holderConfirmedDead) {
-    return false;
-  }
-
-  const graveyard = `${marker}.graveyard-${process.pid}-${Math.random().toString(36).slice(2)}`;
-  try {
-    renameSync(marker, graveyard);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return false;
-    }
-    throw error;
-  }
-  let movedIno: number | undefined;
-  try {
-    movedIno = statSync(graveyard).ino;
-  } catch {
-    movedIno = undefined;
-  }
-  if (movedIno === undefined || movedIno !== observedIno) {
-    restoreOrDiscard(graveyard, marker);
-    return false;
-  }
-  discardBestEffort(graveyard);
-
-  try {
-    writeFileSync(marker, JSON.stringify({ pid: process.pid }), {
-      flag: 'wx',
-    });
-    return true;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
-      return false;
-    }
-    throw error;
-  }
-}
-
-/** Release the arbiter acquired via {@link tryAcquireArbiter}. */
-function releaseArbiter(path: string): void {
-  try {
-    unlinkSync(arbiterPath(path));
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
       throw error;
     }
   }
-}
-
-/**
- * Acquire the arbiter for `path`, retrying briefly if another contender
- * currently holds it. See `ARBITER_RETRY_ATTEMPTS`'s own doc comment for
- * why a small bounded retry (not indefinite blocking) is the right
- * shape here.
- */
-function acquireArbiterWithRetry(path: string): boolean {
-  for (let attempt = 0; attempt < ARBITER_RETRY_ATTEMPTS; attempt += 1) {
-    if (tryAcquireArbiter(path)) {
-      return true;
-    }
-    sleepSync(ARBITER_RETRY_DELAY_MS);
-  }
-  return false;
-}
-
-/**
- * Remove the (believed-stale) main lock at `path` and immediately
- * recreate it as `agentId`/`token`, but ONLY while holding the arbiter
- * -- see {@link tryAcquireArbiter} for why that is what makes the plain
- * `unlinkSync` here safe. Re-verifies staleness against `staleMs` once
- * more immediately after winning the arbiter (arbitration itself can
- * take a moment under contention, during which the lock's own live
- * holder may have refreshed its lease, or an unrelated contender may
- * have already recovered it) rather than trusting the caller's earlier,
- * now-possibly-stale check. Returns `false` (never throws for this) when
- * the arbiter itself could not be acquired, the re-check finds the lock
- * no longer stale, or recreation lost to an unrelated fresh acquirer in
- * the brief gap after this function's own removal (vanishingly unlikely,
- * and still safe: that acquirer's `wx`-create is exclusive by
- * construction).
- */
-function tryTakeOverStaleLock(
-  path: string,
-  agentId: string,
-  token: string,
-  staleMs: number,
-): boolean {
-  if (!tryAcquireArbiter(path)) {
-    return false;
-  }
-  try {
-    const ageMs = lockAgeMs(path);
-    if (ageMs === null || ageMs <= staleMs) {
-      return false;
-    }
-    try {
-      unlinkSync(path);
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code === 'EISDIR' || code === 'EPERM') {
-        rmSync(path, { recursive: true, force: true });
-      } else if (code !== 'ENOENT') {
-        throw error;
-      }
-    }
-    return tryExclusiveCreate(path, agentId, token);
-  } finally {
-    releaseArbiter(path);
-  }
+  return tryExclusiveCreate(path, agentId, token);
 }
 
 /** A held lock: pass to {@link releaseCloneLock} to release it. */
@@ -610,22 +309,15 @@ export class CloneLockTimeoutError extends Error {
 /**
  * Block (retrying with backoff) until the clone-scoped lock at `repoPath`
  * is acquired, or throw {@link CloneLockTimeoutError} after `timeoutMs`.
- * A lock whose mtime is older than `staleMs` is treated as abandoned;
- * every waiter that notices attempts recovery via
- * {@link tryTakeOverStaleLock}, which holds the PID-tagged arbiter (see
- * {@link tryAcquireArbiter}) for the whole remove-then-recreate sequence
- * so that even when multiple contenders observe the same stale mtime
- * from independent reads, at most one of them ever actually removes and
- * recreates it -- every loser simply continues waiting rather than
- * assuming it acquired. `staleMs` defaults to `STALE_LOCK_MS` and is
- * exposed only for tests that need a short-lived clock; production
- * callers should not override it.
+ * A lock whose recorded holder PID is confirmed dead (see
+ * {@link isPidAlive}) is eligible for takeover via
+ * {@link tryTakeOverDeadLock}; a live holder's lock is never taken over,
+ * regardless of how long it has been held.
  */
 export function acquireCloneLock(
   repoPath: string,
   agentId: string,
   timeoutMs: number = DEFAULT_TIMEOUT_MS,
-  staleMs: number = STALE_LOCK_MS,
 ): CloneLockHandle {
   const path = resolveCloneLockPath(repoPath);
   const token = randomToken();
@@ -635,21 +327,9 @@ export function acquireCloneLock(
     if (tryExclusiveCreate(path, agentId, token)) {
       return { path, token };
     }
-
-    const ageMs = lockAgeMs(path);
-    if (
-      ageMs !== null &&
-      ageMs > staleMs &&
-      tryTakeOverStaleLock(path, agentId, token, staleMs)
-    ) {
+    if (tryTakeOverDeadLock(path, agentId, token)) {
       return { path, token };
     }
-    // Either not (yet provably) stale, lost the arbiter race to another
-    // contender, the arbiter's own re-check found it no longer stale, or
-    // -- vanishingly unlikely -- won the takeover but then lost the
-    // immediate recreate to an unrelated fresh acquirer; every case
-    // falls through to the normal wait/retry path below rather than
-    // assuming acquisition.
 
     if (Date.now() >= deadline) {
       throw new CloneLockTimeoutError(path, timeoutMs);
@@ -662,80 +342,27 @@ export function acquireCloneLock(
  * Release a lock previously returned by {@link acquireCloneLock}. Only
  * removes the file when it still holds the caller's own `token` -- if a
  * different token is present, another session already took the lock over
- * (e.g. after this caller's own hold went stale) and this release must
- * not disturb it. Removing an already-absent lock is a silent no-op.
+ * (necessarily after this caller's own process had already died, since a
+ * live holder's lock is never taken over) and this release must not
+ * disturb it. Removing an already-absent lock is a silent no-op.
  *
- * The token check and the removal happen while holding the arbiter (see
- * {@link tryAcquireArbiter}), not as two independent steps: without that,
- * a holder whose own process stalled badly enough for its lease to have
- * gone stale and already been taken over by someone else could read a
- * stale-but-still-matching token, then delete the NEW holder's fresh
- * lock in the gap before its own `unlinkSync` runs -- this repository's
- * review history on #2223 caught exactly this gap in an earlier
- * revision. If the arbiter cannot be acquired within a bounded number of
- * retries (see `ARBITER_RETRY_ATTEMPTS`), this call simply gives up
- * rather than releasing incorrectly: an unreleased lock still recovers
- * later through the module's own staleness+takeover machinery, which is
- * safe, whereas releasing without the arbiter's protection would not be.
+ * This is a plain token-check-then-unlink, unlike a design that must
+ * also guard against an in-flight takeover of the SAME still-live lock:
+ * that scenario cannot occur here, because release only ever runs from
+ * the live holder's own still-running process, and a takeover's PID
+ * -liveness check can never mistake a live, currently-executing process
+ * for a dead one.
  */
 export function releaseCloneLock(handle: CloneLockHandle): void {
-  if (!acquireArbiterWithRetry(handle.path)) {
-    return;
-  }
-  try {
-    const read = readLock(handle.path);
-    if (read.status === 'present' && read.lock.token === handle.token) {
-      try {
-        unlinkSync(handle.path);
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-          throw error;
-        }
+  const read = readLock(handle.path);
+  if (read.status === 'present' && read.lock.token === handle.token) {
+    try {
+      unlinkSync(handle.path);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
       }
     }
-  } finally {
-    releaseArbiter(handle.path);
-  }
-}
-
-/**
- * Rewrite the lock body at `handle.path`, bumping its mtime, but only
- * when the on-disk token still matches `handle.token` -- this never
- * refreshes (or resurrects) a lock a different session now holds. Used
- * by {@link withCloneLock} to keep a legitimately long-running holder's
- * lease from lapsing into apparent staleness.
- *
- * Like {@link releaseCloneLock}, the token check and the write happen
- * while holding the arbiter, not as two independent steps: without that,
- * a holder whose lease had already gone stale and been taken over by
- * someone else could read a stale-but-still-matching token, then
- * truncate and overwrite the NEW holder's fresh lock with its own token
- * in the gap before its own `writeFileSync` runs -- silently resurrecting
- * a lease that should have stayed lost. If the arbiter cannot be
- * acquired within a bounded number of retries, or the write itself fails
- * (e.g. the path became briefly inaccessible), this call silently gives
- * up: the next heartbeat tick simply retries, and `releaseCloneLock`'s
- * own arbiter-protected token check means a truly lost lease never gets
- * misreported as released.
- */
-export function refreshCloneLock(handle: CloneLockHandle): void {
-  if (!acquireArbiterWithRetry(handle.path)) {
-    return;
-  }
-  try {
-    const read = readLock(handle.path);
-    if (read.status === 'present' && read.lock.token === handle.token) {
-      try {
-        writeFileSync(
-          handle.path,
-          renderLockBody(read.lock.agentId, handle.token),
-        );
-      } catch {
-        // Best-effort; see the doc comment above.
-      }
-    }
-  } finally {
-    releaseArbiter(handle.path);
   }
 }
 
@@ -768,13 +395,11 @@ export function checkCloneLock(repoPath: string): CheckCloneLockOutcome {
  * an ambient `GIT_DIR`/`GIT_WORK_TREE` the caller happened to have set
  * must not redirect the wrapped command at a different repository than
  * the one just locked), then release the lock -- even if the command
- * fails. While the command runs, the lease is refreshed every
- * `leaseRefreshMs` (default {@link DEFAULT_LEASE_REFRESH_MS}) so a
- * legitimately long-running operation is never mistaken for an abandoned
- * holder by another waiter. Returns the command's exit code (`null` when
- * it was killed by a signal). `staleMs`/`leaseRefreshMs` are exposed only
- * for tests that need a short-lived clock; production callers should not
- * override them.
+ * fails. No periodic lease refresh is needed: this process itself stays
+ * alive for the wrapped command's entire run, so the lock's recorded
+ * `pid` (this process's own) is continuously, automatically live for as
+ * long as the command is running. Returns the command's exit code
+ * (`null` when it was killed by a signal).
  */
 export async function withCloneLock(
   repoPath: string,
@@ -782,11 +407,8 @@ export async function withCloneLock(
   command: string,
   args: string[],
   timeoutMs: number = DEFAULT_TIMEOUT_MS,
-  staleMs: number = STALE_LOCK_MS,
-  leaseRefreshMs: number = DEFAULT_LEASE_REFRESH_MS,
 ): Promise<number | null> {
-  const handle = acquireCloneLock(repoPath, agentId, timeoutMs, staleMs);
-  const heartbeat = setInterval(() => refreshCloneLock(handle), leaseRefreshMs);
+  const handle = acquireCloneLock(repoPath, agentId, timeoutMs);
   try {
     return await new Promise<number | null>((resolve, reject) => {
       const child = spawn(command, args, {
@@ -798,7 +420,6 @@ export async function withCloneLock(
       child.once('exit', (code) => resolve(code));
     });
   } finally {
-    clearInterval(heartbeat);
     releaseCloneLock(handle);
   }
 }
@@ -907,16 +528,17 @@ Clone-scoped mutual-exclusion lock: serializes \`git worktree add\`,
 clone across concurrent sessions. \`--exec\` blocks (retrying) until the
 lock is acquired, runs <command> [args...] with stdio inherited and cwd
 set to --repo, then releases the lock -- even if the command fails --
-and exits with the command's own exit code. A lock whose lease has not
-been refreshed for 5 minutes is treated as abandoned by a dead holder
-and taken over; \`--exec\` refreshes its own lease periodically while
-the wrapped command runs, so a legitimately long-running operation is
-never mistaken for a dead holder. Exits 3 if the lock could not be
-acquired within --timeout-ms (default 120000).
+and exits with the command's own exit code. A lock is eligible for
+takeover only once its recorded holder process is confirmed dead (not
+after any fixed time period); a live holder's lock is never taken over,
+however long it is held. Exits 3 if the lock could not be acquired
+within --timeout-ms (default 120000).
 
 --check is read-only: it reports the current lock state without
 creating, mutating, or deleting anything. \`malformed: true\` means a
-lock file exists but could not be parsed as a well-formed lock body.
+lock file exists but could not be parsed as a well-formed lock body --
+this is never auto-recovered; delete it manually after confirming no
+live process still needs it.
 
 --repo defaults to the current working directory.
 `);

--- a/src/scripts/clone-lock.mts
+++ b/src/scripts/clone-lock.mts
@@ -134,11 +134,24 @@ type LockReadResult =
   | { status: 'malformed' }
   | { status: 'present'; lock: CloneLockBody };
 
+/**
+ * A `pid` must be a positive-integer-shaped number, not merely
+ * `typeof pid === 'number'` -- POSIX gives `0` and negative values
+ * special meaning to `kill()` (process group / all processes / signal
+ * -to-everyone), so a `0`, negative, `NaN`, or non-integer value must
+ * never reach {@link isPidAlive}'s `process.kill(pid, 0)` call, even
+ * though that call is diagnostic-only now (see this module's header
+ * comment) and not a takeover decision.
+ */
+function isValidPid(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0;
+}
+
 function isCloneLockBody(value: unknown): value is CloneLockBody {
   return (
     typeof value === 'object' &&
     value !== null &&
-    typeof (value as Record<string, unknown>).pid === 'number' &&
+    isValidPid((value as Record<string, unknown>).pid) &&
     typeof (value as Record<string, unknown>).token === 'string' &&
     typeof (value as Record<string, unknown>).agentId === 'string' &&
     typeof (value as Record<string, unknown>).acquiredAt === 'string'

--- a/src/scripts/clone-lock.mts
+++ b/src/scripts/clone-lock.mts
@@ -332,6 +332,56 @@ function discardBestEffort(path: string): void {
 }
 
 /**
+ * Called after {@link tryAcquireArbiter}'s inode check finds it grabbed
+ * the WRONG file at `graveyardPath` -- not the confirmed-dead marker it
+ * verified, but a live contender's fresh claim that happened to replace
+ * it in the interim. Restores the live contender's marker to `destPath`
+ * whenever possible, rather than discarding it: a discarded marker
+ * leaves `destPath` briefly absent for as long as that live contender's
+ * ENTIRE arbiter-protected critical section takes to finish, during
+ * which a third contender's ordinary fresh `wx`-create can ALSO succeed
+ * there, producing two simultaneous believed-arbiters -- exactly the
+ * double-winner class of bug this whole mechanism exists to prevent.
+ * Restoring narrows that exposure window to roughly the time this one
+ * rename-back takes, instead of the live contender's full critical
+ * section.
+ *
+ * The restore itself uses exclusive create (`{ flag: 'wx' }`), not an
+ * unconditional `renameSync`, so it can never clobber a THIRD
+ * contender's own legitimate claim that already filled the gap `path`
+ * exposed the moment this function's caller renamed it away in the
+ * first place: if the restore loses that race (`EEXIST`), the live
+ * contender's original marker is discarded instead -- its holder does
+ * not depend on the marker file continuing to exist to keep running its
+ * own already-in-progress critical section (see `tryAcquireArbiter`'s
+ * own doc comment), and the slot at `destPath` is by then some OTHER
+ * contender's own equally legitimate exclusive claim, which must not be
+ * overwritten either.
+ */
+function restoreOrDiscard(graveyardPath: string, destPath: string): void {
+  let content: Buffer | null = null;
+  try {
+    content = readFileSync(graveyardPath);
+  } catch {
+    content = null;
+  }
+  if (content !== null) {
+    try {
+      writeFileSync(destPath, content, { flag: 'wx' });
+      discardBestEffort(graveyardPath);
+      return;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+        throw error;
+      }
+      // Lost the restore race to a third contender's own fresh claim;
+      // fall through to discarding our accidental grab.
+    }
+  }
+  discardBestEffort(graveyardPath);
+}
+
+/**
  * Exclusively acquire the arbiter for one stale-lock-removal attempt
  * against `path`'s main lock, or return `false` when another contender
  * is already arbitrating (or just won a recovery race for a dead
@@ -374,15 +424,16 @@ function discardBestEffort(path: string): void {
  * then confirm (via the inode captured together with the liveness
  * verdict above) that what actually got moved is the exact entry
  * inspected, not a live contender's fresh arbiter claim that happened to
- * replace it in the interim. On a mismatch, the wrongly-grabbed file is
- * discarded (never restored): the rightful holder's authority came from
- * its own earlier successful `wx`-create, not from this marker file
- * continuing to exist on disk, so losing the marker costs nothing but
- * cosmetics -- restoring it instead would risk clobbering a third
- * generation that may have since claimed `path` legitimately (the same
- * reasoning `releaseCloneLock`/`refreshCloneLock` rely on the arbiter
- * itself to avoid needing, by never attempting a similar restore against
- * the main lock).
+ * replace it in the interim. On a mismatch, {@link restoreOrDiscard}
+ * puts the wrongly-grabbed file back (via its own exclusive-create race,
+ * never an unconditional overwrite) rather than deleting it: this
+ * repository's review history on #2223 caught that an earlier revision
+ * which discarded a mismatched grab instead left the live contender's
+ * marker path briefly absent for as long as that contender's ENTIRE
+ * arbiter-protected critical section took to finish, during which a
+ * third contender's ordinary fresh `wx`-create could ALSO succeed there
+ * -- reproducing the very double-arbiter failure this whole mechanism
+ * exists to close, just relocated one level down.
  */
 function tryAcquireArbiter(path: string): boolean {
   const marker = arbiterPath(path);
@@ -449,7 +500,7 @@ function tryAcquireArbiter(path: string): boolean {
     movedIno = undefined;
   }
   if (movedIno === undefined || movedIno !== observedIno) {
-    discardBestEffort(graveyard);
+    restoreOrDiscard(graveyard, marker);
     return false;
   }
   discardBestEffort(graveyard);
@@ -873,11 +924,12 @@ lock file exists but could not be parsed as a well-formed lock body.
 
 // This bootstrap call is placed after every declaration in this module,
 // not near the top -- `runCli()`'s error path references the
-// `CloneLockTimeoutError` class below, and a class binding (unlike a
-// hoisted function declaration) stays in its temporal dead zone until its
-// own declaration statement executes. Invoking `runCli()` before that
-// point would throw a `ReferenceError` on any `--exec` timeout instead of
-// the documented message and exit code 3.
+// `CloneLockTimeoutError` class declared earlier in this file, and a
+// class binding (unlike a hoisted function declaration) stays in its
+// temporal dead zone until its own declaration statement executes.
+// Invoking `runCli()` before that point (e.g. from the top of the file)
+// would throw a `ReferenceError` on any `--exec` timeout instead of the
+// documented message and exit code 3.
 if (import.meta.main) {
   await runCli();
 }

--- a/src/scripts/clone-lock.mts
+++ b/src/scripts/clone-lock.mts
@@ -1,0 +1,440 @@
+#!/usr/bin/env node
+// idd-generated-from: src/scripts/clone-lock.mts
+//
+// The scripts/clone-lock.mjs copy is generated from the .mts source
+// named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+//
+// Clone-scoped mutual-exclusion lock (#2223): serializes `git worktree
+// add`, `git worktree remove`, and `git fetch` against the shared primary
+// clone when multiple concurrent sessions operate against it. This is a
+// different kind of lock than `claim-lock.mts`: that one records
+// worktree-local *ownership* for a whole worker's lifetime and reports a
+// same-machine collision immediately (never blocks). This one is a short
+// -duration *mutex* around a single git operation -- it blocks (retrying
+// with backoff) until it can acquire, up to a bounded timeout, because the
+// operations it guards are expected to finish in seconds, not the hours a
+// claim can be held for.
+//
+// The lock file lives in the primary clone's *shared* git-admin directory
+// (`git rev-parse --path-format=absolute --git-common-dir`), not any one
+// worktree's private admin dir -- every worktree of the same clone shares
+// this path, which is exactly the scope a clone-wide mutex needs. A
+// linked worktree's own `.git` is a file, not this shared directory, so
+// resolving through `--git-common-dir` (rather than `--absolute-git-dir`,
+// which `claim-lock.mts` uses for its narrower per-worktree scope) is
+// required here.
+//
+// A holder that crashes mid-operation leaves an orphaned lock file behind
+// -- unlike a real `flock(2)`, a plain lock file is not released
+// automatically when its owning process dies. `STALE_LOCK_MS` bounds how
+// long a stuck lock can block every other session: once a lock's recorded
+// `acquiredAt` is older than that, a waiter treats it as abandoned and
+// force-takes it over. This is a purely local liveness heuristic scoped to
+// operations that normally complete in seconds -- it carries none of
+// `claim-lock.mts`'s GitHub-reverification requirement, because this lock
+// has no cross-machine claim-ownership meaning to protect.
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  readFileSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { parseCliArgs } from './cli-args.mts';
+
+/** Shape of the JSON lock body written to disk. */
+interface CloneLockBody {
+  token: string;
+  agentId: string;
+  acquiredAt: string;
+}
+
+const CLONE_LOCK_FILE_NAME = 'idd-clone.lock';
+/** How long a waiter blocks (retrying) before giving up. */
+const DEFAULT_TIMEOUT_MS = 120_000;
+/** Delay between retry attempts while waiting for a held lock. */
+const POLL_INTERVAL_MS = 200;
+/** A lock older than this is treated as abandoned by a dead holder. */
+const STALE_LOCK_MS = 5 * 60_000;
+
+const CLONE_LOCK_FLAG_SPEC = {
+  '--exec': { type: 'boolean' },
+  '--check': { type: 'boolean' },
+  '--repo': { type: 'string' },
+  '--agent-id': { type: 'string' },
+  '--timeout-ms': { type: 'string' },
+  '--help': { type: 'boolean', short: 'h' },
+} as const;
+
+if (import.meta.main) {
+  runCli();
+}
+
+/**
+ * Mirrors `claim-lock.mts`'s environment sanitization: repository
+ * discovery must stay tied to the requested `--repo` path, never to an
+ * ambient Git override inherited from a hook, wrapper, or parent process.
+ */
+function sanitizedGitEnvironment(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('GIT_CONFIG')) {
+      delete env[key];
+    }
+  }
+  delete env.GIT_DIR;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_COMMON_DIR;
+  delete env.GIT_OBJECT_DIRECTORY;
+  return env;
+}
+
+/**
+ * Resolve the lock file's path inside the clone's *shared* git-admin
+ * directory (`--git-common-dir`, not `--absolute-git-dir`) so every
+ * worktree of the same clone resolves to the identical path.
+ */
+export function resolveCloneLockPath(repoPath: string): string {
+  const gitCommonDir = execFileSync(
+    'git',
+    ['-C', repoPath, 'rev-parse', '--path-format=absolute', '--git-common-dir'],
+    { encoding: 'utf8', env: sanitizedGitEnvironment() },
+  ).trim();
+  return join(gitCommonDir, CLONE_LOCK_FILE_NAME);
+}
+
+type LockReadResult =
+  | { status: 'absent' }
+  | { status: 'malformed' }
+  | { status: 'present'; lock: CloneLockBody };
+
+function isCloneLockBody(value: unknown): value is CloneLockBody {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).token === 'string' &&
+    typeof (value as Record<string, unknown>).agentId === 'string' &&
+    typeof (value as Record<string, unknown>).acquiredAt === 'string'
+  );
+}
+
+function readLock(path: string): LockReadResult {
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { status: 'absent' };
+    }
+    return { status: 'malformed' };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { status: 'malformed' };
+  }
+  return isCloneLockBody(parsed)
+    ? { status: 'present', lock: parsed }
+    : { status: 'malformed' };
+}
+
+function renderLockBody(agentId: string, token: string): string {
+  const body: CloneLockBody = {
+    token,
+    agentId,
+    acquiredAt: new Date().toISOString(),
+  };
+  return JSON.stringify(body);
+}
+
+function randomToken(): string {
+  return `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+/**
+ * Blocking, synchronous sleep -- portable across POSIX and Windows, no
+ * external process spawn. Used to back off between poll attempts.
+ */
+function sleepSync(ms: number): void {
+  const sharedBuffer = new SharedArrayBuffer(4);
+  Atomics.wait(new Int32Array(sharedBuffer), 0, 0, ms);
+}
+
+/**
+ * Force-remove an abandoned (stale or malformed) lock at `path` and
+ * install a fresh one, mirroring `claim-lock.mts`'s
+ * `overwriteLockAtomically`: write a same-directory temp file, then
+ * `renameSync` into place (atomic on POSIX; the existing-file fallback
+ * below covers Windows, which requires the destination removed first).
+ */
+function takeOverLock(path: string, agentId: string, token: string): void {
+  const tmpPath = `${path}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
+  writeFileSync(tmpPath, renderLockBody(agentId, token), { flag: 'wx' });
+  try {
+    try {
+      renameSync(tmpPath, path);
+    } catch {
+      rmSync(path, { recursive: true, force: true });
+      renameSync(tmpPath, path);
+    }
+  } finally {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // Best-effort: a successful rename already moved tmpPath away.
+    }
+  }
+}
+
+/** A held lock: pass to {@link releaseCloneLock} to release it. */
+export interface CloneLockHandle {
+  path: string;
+  token: string;
+}
+
+/**
+ * Thrown when a lock cannot be acquired within `timeoutMs`.
+ */
+export class CloneLockTimeoutError extends Error {
+  constructor(path: string, timeoutMs: number) {
+    super(`timed out after ${timeoutMs}ms waiting for clone lock: ${path}`);
+    this.name = 'CloneLockTimeoutError';
+  }
+}
+
+/**
+ * Block (retrying with backoff) until the clone-scoped lock at `repoPath`
+ * is acquired, or throw {@link CloneLockTimeoutError} after `timeoutMs`.
+ * A lock older than `STALE_LOCK_MS` is treated as abandoned and taken
+ * over rather than waited out.
+ */
+export function acquireCloneLock(
+  repoPath: string,
+  agentId: string,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): CloneLockHandle {
+  const path = resolveCloneLockPath(repoPath);
+  const token = randomToken();
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    const read = readLock(path);
+
+    if (read.status === 'absent') {
+      try {
+        writeFileSync(path, renderLockBody(agentId, token), { flag: 'wx' });
+        return { path, token };
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+          throw error;
+        }
+        // Raced with a concurrent acquire between the read and this
+        // create; fall through to the wait/retry path below.
+      }
+    } else if (read.status === 'malformed') {
+      // A malformed body's age can't be determined; treat it the same as
+      // a fresh, definitely-not-stale lock and wait for it rather than
+      // taking it over immediately -- an in-progress writer's partial
+      // write should not be mistaken for an abandoned lock.
+    } else {
+      const ageMs = Date.now() - Date.parse(read.lock.acquiredAt);
+      if (Number.isFinite(ageMs) && ageMs > STALE_LOCK_MS) {
+        takeOverLock(path, agentId, token);
+        return { path, token };
+      }
+    }
+
+    if (Date.now() >= deadline) {
+      throw new CloneLockTimeoutError(path, timeoutMs);
+    }
+    sleepSync(Math.min(POLL_INTERVAL_MS, Math.max(0, deadline - Date.now())));
+  }
+}
+
+/**
+ * Release a lock previously returned by {@link acquireCloneLock}. Only
+ * removes the file when it still holds the caller's own `token` -- if a
+ * different token is present, another session already took the lock over
+ * (e.g. after this caller's own hold went stale) and this release must
+ * not disturb it. Removing an already-absent lock is a silent no-op.
+ */
+export function releaseCloneLock(handle: CloneLockHandle): void {
+  const read = readLock(handle.path);
+  if (read.status === 'present' && read.lock.token === handle.token) {
+    try {
+      unlinkSync(handle.path);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+}
+
+/** Outcome shape returned by {@link checkCloneLock}. */
+export interface CheckCloneLockOutcome {
+  path: string;
+  present: boolean;
+  malformed?: boolean;
+  holder?: CloneLockBody;
+}
+
+/** Read-only lock inspection: never creates, mutates, or deletes the lock. */
+export function checkCloneLock(repoPath: string): CheckCloneLockOutcome {
+  const path = resolveCloneLockPath(repoPath);
+  const read = readLock(path);
+  if (read.status === 'absent') {
+    return { path, present: false };
+  }
+  if (read.status === 'malformed') {
+    return { path, present: true, malformed: true };
+  }
+  return { path, present: true, holder: read.lock };
+}
+
+/**
+ * Acquire the clone lock, run `command` with `args` (inheriting stdio),
+ * then release the lock -- even if the command fails. Returns the
+ * command's exit code (`null` when it was killed by a signal).
+ */
+export function withCloneLock(
+  repoPath: string,
+  agentId: string,
+  command: string,
+  args: string[],
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): number | null {
+  const handle = acquireCloneLock(repoPath, agentId, timeoutMs);
+  try {
+    const result = spawnSync(command, args, { stdio: 'inherit' });
+    if (result.error) {
+      throw result.error;
+    }
+    return result.status;
+  } finally {
+    releaseCloneLock(handle);
+  }
+}
+
+interface ParsedArgs {
+  exec: boolean;
+  check: boolean;
+  repo: string | null;
+  agentId: string | null;
+  timeoutMs: number | null;
+  help: boolean;
+  command: string[];
+}
+
+/**
+ * Everything after a literal `--` token is the wrapped command and its
+ * arguments, passed through untouched -- `parseCliArgs` parses only the
+ * flags before it (it never accepts positionals itself).
+ */
+function splitAtDoubleDash(argv: string[]): {
+  flags: string[];
+  command: string[];
+} {
+  const index = argv.indexOf('--');
+  if (index === -1) {
+    return { flags: argv, command: [] };
+  }
+  return { flags: argv.slice(0, index), command: argv.slice(index + 1) };
+}
+
+function parseArgs(argv: string[]): ParsedArgs {
+  const { flags, command } = splitAtDoubleDash(argv);
+  const { values, help } = parseCliArgs(flags, CLONE_LOCK_FLAG_SPEC);
+  const rawTimeout = values['timeout-ms'];
+  let timeoutMs: number | null = null;
+  if (typeof rawTimeout === 'string') {
+    const parsed = Number(rawTimeout);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      throw new Error('--timeout-ms must be a positive integer');
+    }
+    timeoutMs = parsed;
+  }
+  return {
+    exec: Boolean(values.exec),
+    check: Boolean(values.check),
+    repo: typeof values.repo === 'string' ? values.repo : null,
+    agentId:
+      typeof values['agent-id'] === 'string'
+        ? (values['agent-id'] as string)
+        : null,
+    timeoutMs,
+    help,
+    command,
+  };
+}
+
+function runCli(): void {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+  if (args.exec === args.check) {
+    throw new Error('exactly one of --exec or --check is required');
+  }
+  const repo = args.repo ?? process.cwd();
+
+  if (args.check) {
+    process.stdout.write(`${JSON.stringify(checkCloneLock(repo))}\n`);
+    return;
+  }
+
+  if (args.agentId === null) {
+    throw new Error('--agent-id is required for --exec');
+  }
+  if (args.command.length === 0) {
+    throw new Error('--exec requires a command after `--`');
+  }
+  const [command, ...commandArgs] = args.command;
+  try {
+    const status = withCloneLock(
+      repo,
+      args.agentId,
+      command,
+      commandArgs,
+      args.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    );
+    process.exitCode = status ?? 1;
+  } catch (error) {
+    if (error instanceof CloneLockTimeoutError) {
+      process.stderr.write(`${error.message}\n`);
+      process.exitCode = 3;
+      return;
+    }
+    throw error;
+  }
+}
+
+function printHelp(): void {
+  process.stdout.write(`Usage:
+  node scripts/clone-lock.mjs --exec --agent-id <id> [--repo <path>] [--timeout-ms <n>] -- <command> [args...]
+  node scripts/clone-lock.mjs --check [--repo <path>]
+
+Clone-scoped mutual-exclusion lock: serializes \`git worktree add\`,
+\`git worktree remove\`, and \`git fetch\` against the shared primary
+clone across concurrent sessions. \`--exec\` blocks (retrying) until the
+lock is acquired, runs <command> [args...] with stdio inherited, then
+releases the lock -- even if the command fails -- and exits with the
+command's own exit code. A lock held longer than 5 minutes is treated
+as abandoned by a dead holder and taken over rather than waited out.
+Exits 3 if the lock could not be acquired within --timeout-ms
+(default 120000).
+
+--check is read-only: it reports the current lock state without
+creating, mutating, or deleting anything. \`malformed: true\` means a
+lock file exists but could not be parsed as a well-formed lock body.
+
+--repo defaults to the current working directory.
+`);
+}

--- a/src/scripts/clone-lock.mts
+++ b/src/scripts/clone-lock.mts
@@ -25,61 +25,47 @@
 // which `claim-lock.mts` uses for its narrower per-worktree scope) is
 // required here.
 //
-// A holder that crashes leaves an orphaned lock file behind -- unlike a
+// This module deliberately has NO automatic stale-lock recovery. A
+// holder that crashes leaves an orphaned lock file behind -- unlike a
 // real `flock(2)`, a plain lock file is not released automatically when
-// its owning process dies. Staleness is judged by process liveness
-// (`isPidAlive`, `process.kill(pid, 0)`), not elapsed time: the lock body
-// records the holder's own `pid`, alongside `claim-lock.mts`'s existing
-// `token`/`agentId`/`acquiredAt` shape, and a lock is only ever eligible
-// for takeover once that exact PID is confirmed dead. This replaced an
-// earlier mtime-based design (recover anything older than a fixed
-// threshold, with the holder periodically refreshing its own lease to
-// prove it was still alive) after that design's CI run exposed the
-// failure mode it was always structurally prone to: a live,
-// actively-refreshing holder got taken over anyway, because "has this
-// timestamp aged past a threshold" is inherently a race against ordinary
-// process-scheduling jitter (a refresh landing late, a waiter's own
-// staleness check landing early) in a way "is this specific PID still
-// running" simply is not -- a process is never "probably dead by now,"
-// it is either scheduled on the OS right now or it does not exist.
-// Because the holder process for this lock (the one running `withExec`'s
-// wrapped command) stays alive for its own entire hold, no periodic
-// lease refresh is needed at all: liveness is continuously, automatically
-// true for as long as the holder is doing anything, and instantly,
-// unambiguously false the moment it exits or crashes. This also makes
-// release and takeover logically disjoint rather than a race to close:
-// release only ever runs from the live holder's own still-running
-// process (whose PID is, by definition, alive), so a takeover's PID
-// -liveness check can never mistake an active release-in-progress for a
-// dead holder -- no arbiter, inode verification, or other coordination
-// primitive beyond the plain `wx`-exclusive-create every acquire already
-// uses is needed to keep the two from conflicting. A takeover
-// re-confirms the lock is still the exact dead entry it inspected
-// (re-reading immediately before removing) rather than trusting a
-// possibly-stale earlier check, then goes through the SAME
-// `{ flag: 'wx' }` primitive a fresh acquire uses to recreate it -- the
-// only decision authority for who wins a contested recreate is the OS
-// kernel's own `O_EXCL` guarantee, not any bookkeeping this module
-// performs itself. One race is knowingly NOT closed: the single-syscall
-// gap between that re-confirmation read and the `unlinkSync` that acts
-// on it. Closing it fully would need a kernel-level compare-and-swap
-// this module does not have access to from plain POSIX file primitives;
-// every design this module has tried carries an equivalent residual gap
-// somewhere, and the ones that attempted to close this exact one (a
-// PID-tagged arbiter lock plus inode-verified recovery) each introduced
-// a NEW, worse gap of their own across three consecutive review rounds
-// (#2223) rather than actually eliminating it. This narrow, explicitly
-// accepted gap is deliberately simpler to reason about than that
-// alternative. A malformed lock body (e.g. a crashed partial write) has
-// no readable `pid` to check liveness against and is therefore never
-// auto-recovered -- `writeFileSync`'s single, small write is atomic in
-// practice on every realistic filesystem, so genuinely torn content is
-// vanishingly rare, and this module intentionally does not add recovery
-// machinery for it; see `--check`'s `malformed: true` output for manual
-// diagnosis. This is a purely local liveness heuristic scoped to
-// operations that normally complete in seconds -- it carries none of
-// `claim-lock.mts`'s GitHub-reverification requirement, because this
-// lock has no cross-machine claim-ownership meaning to protect.
+// its owning process dies -- and a timed-out waiter is simply told so,
+// with the lock path and the recorded holder's `pid` in the error
+// message, and pointed at a manual `rm <lock-path>` once a human has
+// confirmed the holder is actually gone (the same approach git's own
+// `index.lock` takes on a stale-lock collision). This module went
+// through three different automatic-recovery designs across successive
+// review rounds on #2223 -- an mtime-elapsed-time threshold with a
+// periodic lease refresh, then a PID-tagged arbiter lock with
+// inode-verified recovery, then a simplified PID-liveness check with no
+// arbiter -- and every one of them was found to have a genuine
+// concurrency defect by the next review round: a live, actively
+// -refreshing holder taken over anyway under scheduling jitter; a
+// wrapper process's own pid going "dead" while the git child it spawned
+// was still running and still needed the lock; more than one waiter
+// racing to reclaim the exact same confirmed-dead entry. Every
+// mitigation attempted for one of these introduced a new gap of its own
+// rather than eliminating the underlying problem, because implementing
+// a genuinely race-free "is this specific holder now provably gone, and
+// can exactly one waiter reclaim it" protocol needs a coordination
+// primitive (a kernel-level compare-and-swap, or a real `flock(2)`)
+// plain POSIX file read/write/rename operations do not provide. Rather
+// than continue layering fixes onto that fundamentally unsound
+// foundation, automatic recovery was removed entirely: the only
+// remaining decision authority for who acquires this lock is the OS
+// kernel's own `O_EXCL` guarantee on a single `{ flag: 'wx' }` create,
+// which is unconditionally race-free by construction -- there is no
+// removal, no recreation, and no second coordination primitive left for
+// a defect to hide in. `idd-skill#2223`'s Acceptance Criteria only ever
+// required an acquire/release interface and serializing two concurrent
+// invocations against each other, never automatic stale-lock recovery.
+// The lock body still records the holder's own `pid` (`isPidAlive`,
+// `process.kill(pid, 0)`), but purely as diagnostic information for a
+// human deciding whether it is safe to remove the lock by hand -- never
+// as input to an automated takeover decision. This is a purely local
+// mutex scoped to operations that normally complete in seconds -- it
+// carries none of `claim-lock.mts`'s GitHub-reverification requirement,
+// because this lock has no cross-machine claim-ownership meaning to
+// protect.
 
 import { execFileSync, spawn } from 'node:child_process';
 import { readFileSync, unlinkSync, writeFileSync } from 'node:fs';
@@ -208,11 +194,11 @@ function sleepSync(ms: number): void {
  * it definitely does not. `process.kill(pid, 0)` sends no actual signal
  * -- it only probes existence/permission. `ESRCH` (no such process) is
  * the only outcome that means dead; `EPERM` (the process exists but this
- * one lacks permission to signal it) and success both mean alive. This
- * is a reliable, instantaneous, non-time-based liveness check: unlike an
- * elapsed-time threshold, there is no ambiguity window where a process
- * might be "probably dead by now" -- it either currently exists or it
- * does not.
+ * one lacks permission to signal it) and success both mean alive.
+ * Diagnostic only (see this module's header comment): this is never
+ * consulted to decide whether a lock may be taken over, only to help a
+ * human reading {@link checkCloneLock}'s or a timeout error's output
+ * judge whether the recorded holder is actually still running.
  */
 function isPidAlive(pid: number): boolean {
   try {
@@ -224,21 +210,11 @@ function isPidAlive(pid: number): boolean {
 }
 
 /**
- * `true` when `path` currently holds a well-formed lock whose recorded
- * `pid` is confirmed dead. `false` for an absent, malformed (no `pid` to
- * check -- see this module's header comment for why that edge case is
- * not auto-recovered), or live lock.
- */
-function isDeadLock(read: LockReadResult): boolean {
-  return read.status === 'present' && !isPidAlive(read.lock.pid);
-}
-
-/**
  * Exclusively create the lock file, succeeding only when nothing else won
- * the race first. Both a fresh acquire and a dead-lock takeover funnel
- * through this same primitive, so at most one contender ever wins either
- * path -- the OS kernel's own `O_EXCL` guarantee is the sole decision
- * authority for who wins a contested create.
+ * the race first. This is the ONLY decision authority for who acquires
+ * this lock -- there is no removal or recreation path a defect could
+ * hide in (see this module's header comment for the three prior designs
+ * that tried to add one, and why each was abandoned).
  */
 function tryExclusiveCreate(
   path: string,
@@ -256,40 +232,6 @@ function tryExclusiveCreate(
   }
 }
 
-/**
- * Attempt to recover a lock at `path` whose recorded holder is confirmed
- * dead, then immediately recreate it as `agentId`/`token`. Re-reads the
- * lock immediately before removing it, rather than trusting the
- * caller's own (possibly now-stale) check, to narrow -- though, per this
- * module's header comment, not fully close -- the gap between
- * confirming death and acting on it. Returns `false` (never throws for
- * this) when the lock is no longer confirmed dead by the time of the
- * re-check, or recreation lost to an unrelated fresh acquirer in the
- * brief gap after this function's own removal (that acquirer's
- * `wx`-create is exclusive by construction either way, so this is safe
- * regardless of how it resolves).
- */
-function tryTakeOverDeadLock(
-  path: string,
-  agentId: string,
-  token: string,
-): boolean {
-  if (!isDeadLock(readLock(path))) {
-    return false;
-  }
-  if (!isDeadLock(readLock(path))) {
-    return false;
-  }
-  try {
-    unlinkSync(path);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-      throw error;
-    }
-  }
-  return tryExclusiveCreate(path, agentId, token);
-}
-
 /** A held lock: pass to {@link releaseCloneLock} to release it. */
 export interface CloneLockHandle {
   path: string;
@@ -297,22 +239,45 @@ export interface CloneLockHandle {
 }
 
 /**
- * Thrown when a lock cannot be acquired within `timeoutMs`.
+ * Thrown when a lock cannot be acquired within `timeoutMs`. The message
+ * names the lock path and, when readable, the recorded holder's `pid`
+ * (and whether that process still appears to be alive) so a human can
+ * decide whether to remove the lock by hand -- see this module's header
+ * comment for why that manual step, not an automatic takeover, is this
+ * module's only stale-lock recovery path.
  */
 export class CloneLockTimeoutError extends Error {
   constructor(path: string, timeoutMs: number) {
-    super(`timed out after ${timeoutMs}ms waiting for clone lock: ${path}`);
+    super(`${describeTimeout(path)} after ${timeoutMs}ms`);
     this.name = 'CloneLockTimeoutError';
   }
+}
+
+function describeTimeout(path: string): string {
+  const read = readLock(path);
+  const base = `timed out waiting for clone lock: ${path}`;
+  if (read.status === 'absent') {
+    return base;
+  }
+  if (read.status === 'malformed') {
+    return `${base} (lock file exists but could not be parsed; if no process needs it, remove it manually: rm ${path})`;
+  }
+  const aliveNote = isPidAlive(read.lock.pid)
+    ? 'still appears to be running'
+    : 'no longer appears to be running';
+  return (
+    `${base} (held by pid ${read.lock.pid}, agent "${read.lock.agentId}", ` +
+    `acquired ${read.lock.acquiredAt}; that process ${aliveNote}. If you have ` +
+    `independently confirmed it is safe, remove the lock manually: rm ${path})`
+  );
 }
 
 /**
  * Block (retrying with backoff) until the clone-scoped lock at `repoPath`
  * is acquired, or throw {@link CloneLockTimeoutError} after `timeoutMs`.
- * A lock whose recorded holder PID is confirmed dead (see
- * {@link isPidAlive}) is eligible for takeover via
- * {@link tryTakeOverDeadLock}; a live holder's lock is never taken over,
- * regardless of how long it has been held.
+ * A held lock is never taken over automatically, regardless of how long
+ * it has been held or whether its recorded holder process is still
+ * running -- see this module's header comment.
  */
 export function acquireCloneLock(
   repoPath: string,
@@ -327,9 +292,6 @@ export function acquireCloneLock(
     if (tryExclusiveCreate(path, agentId, token)) {
       return { path, token };
     }
-    if (tryTakeOverDeadLock(path, agentId, token)) {
-      return { path, token };
-    }
 
     if (Date.now() >= deadline) {
       throw new CloneLockTimeoutError(path, timeoutMs);
@@ -340,18 +302,12 @@ export function acquireCloneLock(
 
 /**
  * Release a lock previously returned by {@link acquireCloneLock}. Only
- * removes the file when it still holds the caller's own `token` -- if a
- * different token is present, another session already took the lock over
- * (necessarily after this caller's own process had already died, since a
- * live holder's lock is never taken over) and this release must not
- * disturb it. Removing an already-absent lock is a silent no-op.
- *
- * This is a plain token-check-then-unlink, unlike a design that must
- * also guard against an in-flight takeover of the SAME still-live lock:
- * that scenario cannot occur here, because release only ever runs from
- * the live holder's own still-running process, and a takeover's PID
- * -liveness check can never mistake a live, currently-executing process
- * for a dead one.
+ * removes the file when it still holds the caller's own `token` -- a
+ * defensive check against releasing a lock this handle no longer
+ * actually owns; in practice, since this module never takes over a held
+ * lock automatically, the token can only ever mismatch after a human
+ * has manually removed and something else has since recreated it.
+ * Removing an already-absent lock is a silent no-op.
  */
 export function releaseCloneLock(handle: CloneLockHandle): void {
   const read = readLock(handle.path);
@@ -372,6 +328,8 @@ export interface CheckCloneLockOutcome {
   present: boolean;
   malformed?: boolean;
   holder?: CloneLockBody;
+  /** Diagnostic only -- see {@link isPidAlive}'s own doc comment. */
+  holderAlive?: boolean;
 }
 
 /** Read-only lock inspection: never creates, mutates, or deletes the lock. */
@@ -384,7 +342,12 @@ export function checkCloneLock(repoPath: string): CheckCloneLockOutcome {
   if (read.status === 'malformed') {
     return { path, present: true, malformed: true };
   }
-  return { path, present: true, holder: read.lock };
+  return {
+    path,
+    present: true,
+    holder: read.lock,
+    holderAlive: isPidAlive(read.lock.pid),
+  };
 }
 
 /**
@@ -395,11 +358,8 @@ export function checkCloneLock(repoPath: string): CheckCloneLockOutcome {
  * an ambient `GIT_DIR`/`GIT_WORK_TREE` the caller happened to have set
  * must not redirect the wrapped command at a different repository than
  * the one just locked), then release the lock -- even if the command
- * fails. No periodic lease refresh is needed: this process itself stays
- * alive for the wrapped command's entire run, so the lock's recorded
- * `pid` (this process's own) is continuously, automatically live for as
- * long as the command is running. Returns the command's exit code
- * (`null` when it was killed by a signal).
+ * fails. Returns the command's exit code (`null` when it was killed by a
+ * signal).
  */
 export async function withCloneLock(
   repoPath: string,
@@ -528,17 +488,19 @@ Clone-scoped mutual-exclusion lock: serializes \`git worktree add\`,
 clone across concurrent sessions. \`--exec\` blocks (retrying) until the
 lock is acquired, runs <command> [args...] with stdio inherited and cwd
 set to --repo, then releases the lock -- even if the command fails --
-and exits with the command's own exit code. A lock is eligible for
-takeover only once its recorded holder process is confirmed dead (not
-after any fixed time period); a live holder's lock is never taken over,
-however long it is held. Exits 3 if the lock could not be acquired
-within --timeout-ms (default 120000).
+and exits with the command's own exit code. A held lock is NEVER taken
+over automatically, regardless of how long it has been held: exits 3 if
+the lock could not be acquired within --timeout-ms (default 120000),
+naming the lock path and its recorded holder's pid in the error message.
+If you have independently confirmed that holder is actually gone,
+remove the lock file by hand and retry -- the same recovery git's own
+\`index.lock\` expects on a stale-lock collision.
 
 --check is read-only: it reports the current lock state without
 creating, mutating, or deleting anything. \`malformed: true\` means a
-lock file exists but could not be parsed as a well-formed lock body --
-this is never auto-recovered; delete it manually after confirming no
-live process still needs it.
+lock file exists but could not be parsed as a well-formed lock body;
+\`holderAlive\` reports whether the recorded pid still appears to be
+running (diagnostic only). Neither case is ever auto-recovered.
 
 --repo defaults to the current working directory.
 `);

--- a/src/scripts/clone-lock.mts
+++ b/src/scripts/clone-lock.mts
@@ -36,23 +36,38 @@
 // every other session; `withCloneLock`'s `--exec` path refreshes its own
 // lease (rewrites the file, which bumps its mtime) at roughly half that
 // interval while the wrapped command runs, so a legitimately
-// long-running operation is never mistaken for a dead holder. Recovering
-// a stale (or malformed-and-stale) lock is two exclusive races, not one:
-// first for the right to remove the abandoned entry (`renameSync` on a
-// specific source path -- POSIX serializes concurrent renames of the
-// same directory entry, so exactly one racer's removal ever succeeds,
-// see `tryClaimStaleLockForRemoval`'s own doc comment for why a plain
-// check-then-`unlinkSync` pair cannot make this same guarantee), then
-// for the right to recreate it (the same `{ flag: 'wx' }` primitive a
-// fresh acquire uses). Every loser at either step falls back to the
-// normal wait/retry loop rather than assuming it acquired. This is a
-// purely local liveness heuristic scoped to operations that normally
-// complete in seconds -- it carries none of
-// `claim-lock.mts`'s GitHub-reverification requirement, because this lock
-// has no cross-machine claim-ownership meaning to protect.
+// long-running operation is never mistaken for a dead holder.
+//
+// Recovering a stale lock is NOT simply "remove it, then race the usual
+// exclusive-create": two contenders can independently observe the same
+// stale mtime, and neither a plain `unlinkSync` nor a plain `renameSync`
+// on its own verifies the file it removes is still the exact entry that
+// was checked -- both happily remove whatever a faster contender already
+// replaced it with (including that contender's brand-new, non-stale
+// lock), letting more than one contender believe it took over (this
+// repository's own review history on #2223 caught and reproduced exactly
+// that double-winner failure from an earlier `renameSync`-only attempt at
+// this fix, roughly one run in ten under concurrent load). The real fix
+// is a second, PID-tagged arbiter lock (`tryAcquireArbiter`): removing
+// and recreating the main lock only ever happens while holding it, so at
+// most one contender is ever doing that at a time, regardless of how many
+// independently observed the same stale mtime. The arbiter's own
+// staleness is judged by process liveness (`isPidAlive`), not a time
+// threshold, because its critical section is always a handful of
+// synchronous, no-I/O-wait statements -- "the recorded PID no longer
+// exists" is both necessary and sufficient to know its holder crashed and
+// can never finish or release it, with none of a time threshold's
+// inherent "probably dead by now" ambiguity. This is a purely local
+// liveness heuristic scoped to operations that normally complete in
+// seconds -- it carries none of `claim-lock.mts`'s GitHub-reverification
+// requirement, because this lock has no cross-machine claim-ownership
+// meaning to protect.
 
 import { execFileSync, spawn } from 'node:child_process';
 import {
+  closeSync,
+  fstatSync,
+  openSync,
   readFileSync,
   renameSync,
   rmSync,
@@ -230,54 +245,209 @@ function tryExclusiveCreate(
 }
 
 /**
- * Exclusively claim the (believed-stale) lock at `path` for removal, so
- * that even when multiple contenders simultaneously observe the same
- * stale mtime, only one of them ever actually removes it. `renameSync`
- * on a specific SOURCE path is itself the race-free primitive this needs
- * -- POSIX serializes concurrent rename operations against the same
- * directory entry, so among any number of racing
- * `renameSync(path, <unique-destination>)` calls, exactly one succeeds
- * (moving `path` away) and every later call sees `ENOENT`, since by the
- * time it runs `path` no longer exists to rename from. This closes a
- * race a plain check-then-`unlinkSync` pair cannot: two contenders can
- * both observe the same stale mtime from independent reads, and a plain
- * `unlinkSync` never verifies the file it deletes is still the one that
- * was checked -- it happily deletes whatever a faster contender already
- * replaced it with (including that contender's brand new, non-stale
- * lock), letting both contenders believe they won.
- *
- * Returns `false` (a lost race, not an error) on `ENOENT` -- the normal
- * outcome for every contender except the one that actually wins. The
- * destination is a unique per-attempt "graveyard" path so concurrent
- * winners of DIFFERENT stale-lock generations never collide with each
- * other; it is then discarded immediately (`unlinkSync`, with a
- * `recursive: true` `rmSync` fallback for the
- * malformed-lock-is-a-directory edge case `claim-lock.mts`'s own
- * takeover path also handles) -- this cleanup is unconditionally safe
- * regardless of recursion, since nothing else can ever reference this
- * exact path.
+ * Companion path for the PID-tagged arbiter lock that guards a stale
+ * -takeover REMOVAL against `path` -- see {@link tryAcquireArbiter}.
  */
-function tryClaimStaleLockForRemoval(path: string): boolean {
-  const graveyardPath = `${path}.graveyard-${process.pid}-${Math.random().toString(36).slice(2)}`;
+function arbiterPath(path: string): string {
+  return `${path}.arbiter`;
+}
+
+/**
+ * `true` when `pid` identifies a currently-running process, `false` when
+ * it definitely does not. `process.kill(pid, 0)` sends no actual signal
+ * -- it only probes existence/permission. `ESRCH` (no such process) is
+ * the only outcome that means dead; `EPERM` (the process exists but this
+ * one lacks permission to signal it) and success both mean alive. This
+ * is a reliable, instantaneous, non-time-based liveness check -- unlike
+ * an mtime-based staleness threshold, there is no ambiguity window where
+ * a process might be "probably dead by now": it either currently exists
+ * or it does not.
+ */
+function isPidAlive(pid: number): boolean {
   try {
-    renameSync(path, graveyardPath);
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/**
+ * Exclusively acquire the arbiter for one stale-lock-removal attempt
+ * against `path`'s main lock, or return `false` when another contender
+ * is already arbitrating (or just won a recovery race for a dead
+ * arbiter). Removal itself is `unlinkSync`, safe to run unconditionally
+ * ONLY while holding this arbiter -- exactly one contender can ever hold
+ * it at a time, which is what actually closes the race a plain
+ * check-then-`unlinkSync` pair on the MAIN lock cannot: two contenders
+ * observing the same stale mtime from independent reads can no longer
+ * both proceed to remove/recreate the main lock concurrently, because
+ * only one of them ever wins this arbiter first.
+ *
+ * The arbiter is itself just a `{ flag: 'wx' }` claim recording the
+ * arbitrating PID -- exclusive by the same primitive a fresh main-lock
+ * acquire uses. Its OWN staleness (an arbiter whose holder crashed
+ * mid-arbitration) is judged by {@link isPidAlive}, not by a time
+ * threshold: the arbitration critical section is always a handful of
+ * synchronous, no-I/O-wait statements, so "the recorded PID no longer
+ * exists" is both necessary and sufficient to know the holder can never
+ * finish or release it. Recovering a dead arbiter still races multiple
+ * contenders (more than one can observe the same dead PID), so it goes
+ * through the SAME inode-verified rename this function's removal step
+ * cannot avoid at that one level: `renameSync` the arbiter file away,
+ * then confirm (via the inode captured from an open file descriptor
+ * held across the whole check) that what actually got moved is the
+ * exact dead entry inspected, not a live contender's fresh arbiter claim
+ * that happened to replace it in the interim. On a mismatch, the
+ * wrongly-grabbed file is discarded (never restored): the rightful
+ * holder's authority came from its own earlier successful `wx`-create,
+ * not from this marker file continuing to exist on disk, so losing the
+ * marker costs nothing but cosmetics -- see the design note in this
+ * module's own review history (#2223) for why restoring it instead
+ * would risk clobbering a third generation that may have since claimed
+ * `path` legitimately.
+ */
+function tryAcquireArbiter(path: string): boolean {
+  const marker = arbiterPath(path);
+  try {
+    writeFileSync(marker, JSON.stringify({ pid: process.pid }), {
+      flag: 'wx',
+    });
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+      throw error;
+    }
+  }
+
+  let holderPid: number | null = null;
+  try {
+    const parsed = JSON.parse(readFileSync(marker, 'utf8'));
+    if (typeof parsed?.pid === 'number') {
+      holderPid = parsed.pid;
+    }
+  } catch {
+    // Malformed or unreadable: cannot determine liveness, so do not
+    // attempt recovery this pass -- fail closed exactly like the main
+    // lock's own malformed-body handling elsewhere in this module.
+  }
+  if (holderPid === null || isPidAlive(holderPid)) {
+    return false;
+  }
+
+  let fd: number;
+  try {
+    fd = openSync(marker, 'r');
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return false;
     }
     throw error;
   }
+  let observedIno: number | undefined;
   try {
-    unlinkSync(graveyardPath);
+    observedIno = fstatSync(fd).ino;
+  } finally {
+    closeSync(fd);
+  }
+
+  const graveyard = `${marker}.graveyard-${process.pid}-${Math.random().toString(36).slice(2)}`;
+  try {
+    renameSync(marker, graveyard);
   } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === 'EISDIR' || code === 'EPERM') {
-      rmSync(graveyardPath, { recursive: true, force: true });
-    } else if (code !== 'ENOENT') {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+  let movedIno: number | undefined;
+  try {
+    movedIno = statSync(graveyard).ino;
+  } catch {
+    movedIno = undefined;
+  }
+  if (movedIno === undefined || movedIno !== observedIno) {
+    try {
+      unlinkSync(graveyard);
+    } catch {
+      // Best-effort discard; see the doc comment above.
+    }
+    return false;
+  }
+  try {
+    unlinkSync(graveyard);
+  } catch {
+    // Best-effort; the dead entry is confirmed claimed regardless.
+  }
+
+  try {
+    writeFileSync(marker, JSON.stringify({ pid: process.pid }), {
+      flag: 'wx',
+    });
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/** Release the arbiter acquired via {@link tryAcquireArbiter}. */
+function releaseArbiter(path: string): void {
+  try {
+    unlinkSync(arbiterPath(path));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
       throw error;
     }
   }
-  return true;
+}
+
+/**
+ * Remove the (believed-stale) main lock at `path` and immediately
+ * recreate it as `agentId`/`token`, but ONLY while holding the arbiter
+ * -- see {@link tryAcquireArbiter} for why that is what makes the plain
+ * `unlinkSync` here safe. Re-verifies staleness against `staleMs` once
+ * more immediately after winning the arbiter (arbitration itself can
+ * take a moment under contention, during which the lock's own live
+ * holder may have refreshed its lease, or an unrelated contender may
+ * have already recovered it) rather than trusting the caller's earlier,
+ * now-possibly-stale check. Returns `false` (never throws for this) when
+ * the arbiter itself could not be acquired, the re-check finds the lock
+ * no longer stale, or recreation lost to an unrelated fresh acquirer in
+ * the brief gap after this function's own removal (vanishingly unlikely,
+ * and still safe: that acquirer's `wx`-create is exclusive by
+ * construction).
+ */
+function tryTakeOverStaleLock(
+  path: string,
+  agentId: string,
+  token: string,
+  staleMs: number,
+): boolean {
+  if (!tryAcquireArbiter(path)) {
+    return false;
+  }
+  try {
+    const ageMs = lockAgeMs(path);
+    if (ageMs === null || ageMs <= staleMs) {
+      return false;
+    }
+    try {
+      unlinkSync(path);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'EISDIR' || code === 'EPERM') {
+        rmSync(path, { recursive: true, force: true });
+      } else if (code !== 'ENOENT') {
+        throw error;
+      }
+    }
+    return tryExclusiveCreate(path, agentId, token);
+  } finally {
+    releaseArbiter(path);
+  }
 }
 
 /** A held lock: pass to {@link releaseCloneLock} to release it. */
@@ -300,14 +470,15 @@ export class CloneLockTimeoutError extends Error {
  * Block (retrying with backoff) until the clone-scoped lock at `repoPath`
  * is acquired, or throw {@link CloneLockTimeoutError} after `timeoutMs`.
  * A lock whose mtime is older than `staleMs` is treated as abandoned;
- * every waiter that notices races for its removal via
- * {@link tryClaimStaleLockForRemoval} (exactly one ever wins, by
- * construction) and then for its recreation via the same
- * exclusive-create primitive a fresh acquire uses -- every loser at
- * either step simply continues waiting rather than assuming it
- * acquired. `staleMs` defaults to `STALE_LOCK_MS` and is exposed only
- * for tests that need a short-lived clock; production callers should
- * not override it.
+ * every waiter that notices attempts recovery via
+ * {@link tryTakeOverStaleLock}, which holds the PID-tagged arbiter (see
+ * {@link tryAcquireArbiter}) for the whole remove-then-recreate sequence
+ * so that even when multiple contenders observe the same stale mtime
+ * from independent reads, at most one of them ever actually removes and
+ * recreates it -- every loser simply continues waiting rather than
+ * assuming it acquired. `staleMs` defaults to `STALE_LOCK_MS` and is
+ * exposed only for tests that need a short-lived clock; production
+ * callers should not override it.
  */
 export function acquireCloneLock(
   repoPath: string,
@@ -328,16 +499,16 @@ export function acquireCloneLock(
     if (
       ageMs !== null &&
       ageMs > staleMs &&
-      tryClaimStaleLockForRemoval(path) &&
-      tryExclusiveCreate(path, agentId, token)
+      tryTakeOverStaleLock(path, agentId, token, staleMs)
     ) {
       return { path, token };
     }
-    // Either not (yet provably) stale, lost the removal race to another
-    // contender, or -- vanishingly unlikely -- won the removal race but
-    // then lost the immediate recreate to an unrelated fresh acquirer;
-    // every case falls through to the normal wait/retry path below
-    // rather than assuming acquisition.
+    // Either not (yet provably) stale, lost the arbiter race to another
+    // contender, the arbiter's own re-check found it no longer stale, or
+    // -- vanishingly unlikely -- won the takeover but then lost the
+    // immediate recreate to an unrelated fresh acquirer; every case
+    // falls through to the normal wait/retry path below rather than
+    // assuming acquisition.
 
     if (Date.now() >= deadline) {
       throw new CloneLockTimeoutError(path, timeoutMs);

--- a/src/scripts/helper-runtime-manifest.mts
+++ b/src/scripts/helper-runtime-manifest.mts
@@ -294,6 +294,15 @@ const HELPER_COMMANDS: HelperCommand[] = [
       'Acquire, reacquire, or inspect a worktree-local same-machine claim lock.',
   },
   {
+    id: 'clone-lock',
+    scriptName: 'idd:clone-lock',
+    binName: 'idd-clone-lock',
+    entryPath: 'scripts/clone-lock.mjs',
+    vendoredCommand: 'node scripts/clone-lock.mjs',
+    description:
+      'Serialize a git worktree add/remove or fetch against the shared primary clone across concurrent sessions.',
+  },
+  {
     id: 'critique-delegate',
     scriptName: 'idd:critique-delegate',
     binName: 'idd-critique-delegate',

--- a/tests/clone-lock.test.mts
+++ b/tests/clone-lock.test.mts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { execFile, execFileSync } from 'node:child_process';
+import { execFile, execFileSync, spawnSync } from 'node:child_process';
 import {
   existsSync,
   mkdtempSync,
@@ -622,6 +622,250 @@ test('CLI: concurrent --exec invocations serialize the wrapped command — no tw
         `expected non-overlapping critical sections, got: ${JSON.stringify(sorted)}`,
       );
     }
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('acquire: a malformed arbiter marker recovers once its age passes the malformed-stale fallback (P2 round 4: a crashed partial arbiter write must not wedge every future takeover forever)', () => {
+  const primary = setupRepo();
+  try {
+    const path = resolveCloneLockPath(primary);
+    writeFileSync(
+      path,
+      JSON.stringify({
+        token: 'dead-holder',
+        agentId: 'agent-dead',
+        acquiredAt: new Date().toISOString(),
+      }),
+    );
+    backdateLockMtime(path, 60_000);
+
+    // Seed a malformed (unparseable) arbiter marker -- simulating a
+    // process that crashed after the exclusive wx-create but before its
+    // JSON write completed -- and backdate it well past the
+    // malformed-stale fallback window.
+    const arbiterFile = `${path}.arbiter`;
+    writeFileSync(arbiterFile, '{"pid": not valid json');
+    backdateLockMtime(arbiterFile, 30_000);
+
+    const start = Date.now();
+    const handle = acquireCloneLock(primary, 'agent-b', 5_000, 200);
+    const elapsedMs = Date.now() - start;
+
+    assert.ok(
+      elapsedMs < 2_000,
+      `expected the malformed arbiter to be recovered promptly, took ${elapsedMs}ms`,
+    );
+    releaseCloneLock(handle);
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('acquire: concurrent contenders racing a dead-PID arbiter recovery never let two of them hold the lock at once (P1 round 4: PID and inode must come from the same read)', async () => {
+  const primary = setupRepo();
+  const logPath = join(primary, 'dead-arbiter-race.log');
+  writeFileSync(logPath, '');
+  try {
+    const path = resolveCloneLockPath(primary);
+    writeFileSync(
+      path,
+      JSON.stringify({
+        token: 'dead-holder',
+        agentId: 'agent-dead',
+        acquiredAt: new Date().toISOString(),
+      }),
+    );
+    backdateLockMtime(path, 60_000);
+
+    // A genuinely dead PID: spawnSync blocks until the child has already
+    // exited, so its pid is guaranteed not to be running by the time we
+    // read it back (short of the OS recycling that exact pid in the
+    // meantime, which is not realistic within a test's lifetime).
+    const deadPid = spawnSync(process.execPath, ['-e', 'process.exit(0)']).pid;
+    assert.ok(typeof deadPid === 'number' && deadPid > 0);
+    writeFileSync(`${path}.arbiter`, JSON.stringify({ pid: deadPid }));
+
+    const fixturePath = writeRaceFixture(primary);
+    const CONTENDERS = 5;
+    await Promise.all(
+      Array.from({ length: CONTENDERS }, (_unused, index) =>
+        execFileAsync(process.execPath, [fixturePath], {
+          env: fixtureEnv({
+            IDD_TEST_REPO: primary,
+            IDD_TEST_IDX: String(index),
+            IDD_TEST_LOG: logPath,
+            IDD_TEST_TIMEOUT_MS: '10000',
+            IDD_TEST_STALE_MS: '200',
+            IDD_TEST_HOLD_MS: '150',
+          }),
+        }),
+      ),
+    );
+
+    const lines = readFileSync(logPath, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+    assert.equal(
+      lines.filter((line) => line.startsWith('lost ')).length,
+      0,
+      `expected every contender to eventually acquire, got: ${JSON.stringify(lines)}`,
+    );
+    const intervals = new Map<string, { start: number; end: number }>();
+    for (const line of lines) {
+      const [kind, idx, ts] = line.split(' ');
+      const entry = intervals.get(idx) ?? { start: 0, end: 0 };
+      if (kind === 'won') {
+        entry.start = Number(ts);
+      } else {
+        entry.end = Number(ts);
+      }
+      intervals.set(idx, entry);
+    }
+    assert.equal(intervals.size, CONTENDERS);
+    const sorted = Array.from(intervals.values()).sort(
+      (first, second) => first.start - second.start,
+    );
+    for (let index = 1; index < sorted.length; index += 1) {
+      assert.ok(
+        sorted[index].start >= sorted[index - 1].end,
+        `expected non-overlapping holds even when racing a dead-PID arbiter, got: ${JSON.stringify(sorted)}`,
+      );
+    }
+  } finally {
+    teardown(primary);
+  }
+});
+
+/**
+ * A second on-disk fixture: each worker repeatedly acquires with a very
+ * short staleMs, immediately backdates ITS OWN freshly-acquired lock (so
+ * it looks abandoned to every other contender as soon as possible,
+ * maximizing how often a release/refresh call races an in-flight
+ * takeover of that same lock), holds briefly, refreshes once partway
+ * through the hold (also racing takeover), then releases (also racing
+ * takeover) -- repeating in a loop until `IDD_TEST_UNTIL_MS` elapses.
+ * Every transition is logged so the test can verify the shared main lock
+ * file was well-formed JSON at every observation, never corrupted by a
+ * torn concurrent write.
+ */
+function writeReleaseRefreshRaceFixture(dir: string): string {
+  const fixturePath = join(dir, 'release-refresh-race-worker.mjs');
+  const cloneLockUrl = pathToFileURL(
+    join(REPO_ROOT, 'scripts/clone-lock.mjs'),
+  ).href;
+  writeFileSync(
+    fixturePath,
+    [
+      `import { acquireCloneLock, refreshCloneLock, releaseCloneLock, resolveCloneLockPath } from ${JSON.stringify(cloneLockUrl)};`,
+      "import { appendFileSync, readFileSync, utimesSync } from 'node:fs';",
+      'const repo = process.env.IDD_TEST_REPO;',
+      'const idx = process.env.IDD_TEST_IDX;',
+      'const log = process.env.IDD_TEST_LOG;',
+      'const untilMs = Number(process.env.IDD_TEST_UNTIL_MS);',
+      'const path = resolveCloneLockPath(repo);',
+      'let rounds = 0;',
+      'while (Date.now() < untilMs) {',
+      '  rounds += 1;',
+      '  try {',
+      "    const handle = acquireCloneLock(repo, 'agent-' + idx, 300, 30);",
+      "    appendFileSync(log, 'won ' + idx + ' ' + Date.now() + '\\n');",
+      '    const ancient = new Date(Date.now() - 60000);',
+      '    utimesSync(path, ancient, ancient);',
+      '    const holdUntil = Date.now() + 20;',
+      '    while (Date.now() < holdUntil) {}',
+      '    refreshCloneLock(handle);',
+      '    const raw = readFileSync(path, "utf8");',
+      '    try {',
+      '      JSON.parse(raw);',
+      '    } catch {',
+      "      appendFileSync(log, 'corrupt ' + idx + ' ' + raw + '\\n');",
+      '    }',
+      '    const holdUntil2 = Date.now() + 10;',
+      '    while (Date.now() < holdUntil2) {}',
+      '    releaseCloneLock(handle);',
+      "    appendFileSync(log, 'released ' + idx + ' ' + Date.now() + '\\n');",
+      '  } catch (error) {',
+      "    appendFileSync(log, 'lost ' + idx + '\\n');",
+      '  }',
+      '}',
+      "appendFileSync(log, 'rounds ' + idx + ' ' + rounds + '\\n');",
+    ].join('\n'),
+  );
+  return fixturePath;
+}
+
+test('release/refresh: repeated concurrent acquire-backdate-refresh-release cycles never corrupt the lock or let two contenders hold it at once (Codex P1 round 4: release/refresh vs. takeover)', async () => {
+  const primary = setupRepo();
+  const logPath = join(primary, 'release-refresh-race.log');
+  writeFileSync(logPath, '');
+  try {
+    const fixturePath = writeReleaseRefreshRaceFixture(primary);
+    const WORKERS = 4;
+    const DURATION_MS = 1500;
+    const untilMs = Date.now() + DURATION_MS;
+
+    await Promise.all(
+      Array.from({ length: WORKERS }, (_unused, index) =>
+        execFileAsync(process.execPath, [fixturePath], {
+          env: fixtureEnv({
+            IDD_TEST_REPO: primary,
+            IDD_TEST_IDX: String(index),
+            IDD_TEST_LOG: logPath,
+            IDD_TEST_UNTIL_MS: String(untilMs),
+          }),
+        }),
+      ),
+    );
+
+    const lines = readFileSync(logPath, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+    const corruptions = lines.filter((line) => line.startsWith('corrupt '));
+    assert.deepEqual(
+      corruptions,
+      [],
+      `expected the lock file to always be well-formed JSON when observed mid-hold, got: ${JSON.stringify(corruptions)}`,
+    );
+
+    const totalRounds = lines
+      .filter((line) => line.startsWith('rounds '))
+      .reduce((sum, line) => sum + Number(line.split(' ')[2]), 0);
+    assert.ok(
+      totalRounds >= WORKERS,
+      `expected meaningful contention (at least one round per worker), got ${totalRounds} total rounds across: ${JSON.stringify(lines)}`,
+    );
+
+    // Note: this fixture deliberately backdates its OWN freshly-acquired
+    // lock immediately after acquiring it, specifically so other workers
+    // legitimately steal it mid-cycle -- that is the whole point (it is
+    // what forces a release/refresh call to race an in-flight takeover
+    // of the very same lock). Because of that self-sabotage, a worker's
+    // own "won"-to-"released" span is NOT a reliable proxy for "this
+    // worker verifiably held the lock exclusively the whole time" (its
+    // `released` log line fires unconditionally, even when the release
+    // call itself correctly no-opped because a takeover already replaced
+    // its token) -- so, unlike the other stress tests in this file,
+    // asserting those spans never overlap is not a valid invariant to
+    // check here. What this test verifies instead: no interleaving of
+    // acquire/backdate/refresh/release/takeover across four workers ever
+    // produces a torn, unparseable on-disk body (checked above), and the
+    // arbiter itself is never left orphaned by a botched interleaving.
+    const finalPath = resolveCloneLockPath(primary);
+    const finalRaw = existsSync(finalPath)
+      ? readFileSync(finalPath, 'utf8')
+      : null;
+    if (finalRaw !== null) {
+      assert.doesNotThrow(() => JSON.parse(finalRaw));
+    }
+    assert.equal(
+      existsSync(`${finalPath}.arbiter`),
+      false,
+      'expected the arbiter marker to never be left behind after every worker finished',
+    );
   } finally {
     teardown(primary);
   }

--- a/tests/clone-lock.test.mts
+++ b/tests/clone-lock.test.mts
@@ -847,8 +847,8 @@ test('release/refresh: repeated concurrent acquire-backdate-refresh-release cycl
     // own "won"-to-"released" span is NOT a reliable proxy for "this
     // worker verifiably held the lock exclusively the whole time" (its
     // `released` log line fires unconditionally, even when the release
-    // call itself correctly no-opped because a takeover already replaced
-    // its token) -- so, unlike the other stress tests in this file,
+    // call itself was a correct no-op because a takeover already
+    // replaced its token) -- so, unlike the other stress tests in this file,
     // asserting those spans never overlap is not a valid invariant to
     // check here. What this test verifies instead: no interleaving of
     // acquire/backdate/refresh/release/takeover across four workers ever

--- a/tests/clone-lock.test.mts
+++ b/tests/clone-lock.test.mts
@@ -1,0 +1,376 @@
+import assert from 'node:assert/strict';
+import { execFile, execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { devNull, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import {
+  acquireCloneLock,
+  CloneLockTimeoutError,
+  checkCloneLock,
+  releaseCloneLock,
+  resolveCloneLockPath,
+  withCloneLock,
+} from '../src/scripts/clone-lock.mts';
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
+const CLI_PATH = join(REPO_ROOT, 'scripts/clone-lock.mjs');
+
+// Fixture invariant mirrored from tests/claim-lock.test.mts: fixture git
+// processes must never read the ambient git environment or the
+// developer's config.
+function fixtureEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const env = { ...process.env, ...extra };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('GIT_CONFIG')) {
+      delete env[key];
+    }
+  }
+  delete env.GIT_DIR;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_COMMON_DIR;
+  delete env.GIT_OBJECT_DIRECTORY;
+  env.GIT_CONFIG_GLOBAL = devNull;
+  env.GIT_CONFIG_SYSTEM = devNull;
+  return env;
+}
+
+function git(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, env: fixtureEnv(), stdio: 'pipe' });
+}
+
+function setupRepo(): string {
+  const primary = mkdtempSync(join(tmpdir(), 'idd-clone-lock-'));
+  git(primary, ['init', '-b', 'main']);
+  git(primary, ['config', 'user.email', 'test@example.com']);
+  git(primary, ['config', 'user.name', 'Test']);
+  writeFileSync(join(primary, 'seed.txt'), 'seed\n');
+  git(primary, ['add', 'seed.txt']);
+  git(primary, ['commit', '-m', 'seed']);
+  return primary;
+}
+
+function teardown(primary: string): void {
+  rmSync(primary, { recursive: true, force: true });
+}
+
+test('resolveCloneLockPath resolves to the shared git-common-dir, identically from the primary and a linked worktree', () => {
+  const primary = setupRepo();
+  try {
+    const worktree = join(primary, '..', 'linked-wt');
+    git(primary, ['worktree', 'add', worktree, '-b', 'issue/1-test', 'main']);
+    try {
+      const fromPrimary = resolveCloneLockPath(primary);
+      const fromWorktree = resolveCloneLockPath(worktree);
+      assert.equal(fromPrimary, fromWorktree);
+      assert.ok(fromPrimary.endsWith('idd-clone.lock'));
+    } finally {
+      git(primary, ['worktree', 'remove', '--force', worktree]);
+    }
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('check: reports absence without creating a lock', () => {
+  const primary = setupRepo();
+  try {
+    const check = checkCloneLock(primary);
+    assert.equal(check.present, false);
+    assert.equal(existsSync(resolveCloneLockPath(primary)), false);
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('acquire/release: a fresh acquire succeeds and release removes the lock', () => {
+  const primary = setupRepo();
+  try {
+    const handle = acquireCloneLock(primary, 'agent-a', 5_000);
+    assert.equal(checkCloneLock(primary).present, true);
+    releaseCloneLock(handle);
+    assert.equal(checkCloneLock(primary).present, false);
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('release: a stale token mismatch is a no-op, never disturbs the current holder', () => {
+  const primary = setupRepo();
+  try {
+    const handle = acquireCloneLock(primary, 'agent-a', 5_000);
+    releaseCloneLock({ path: handle.path, token: 'not-the-real-token' });
+    assert.equal(checkCloneLock(primary).present, true);
+    releaseCloneLock(handle);
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('acquire: a held lock blocks a separate-process acquirer until the first releases', async () => {
+  // acquireCloneLock() is intentionally fully synchronous (it blocks via
+  // Atomics.wait, matching the rest of this module's sync style), so it
+  // cannot be raced against a same-process setTimeout -- the busy-wait
+  // would starve the event loop the timer needs to fire. Cross-process
+  // concurrency is this lock's real use case anyway (see the CLI
+  // concurrent-invocations test below), so the "second acquirer" here is a
+  // genuine child process via the CLI, not an in-process call.
+  const primary = setupRepo();
+  try {
+    const first = acquireCloneLock(primary, 'agent-a', 5_000);
+
+    const waiter = execFileAsync(process.execPath, [
+      CLI_PATH,
+      '--exec',
+      '--agent-id',
+      'agent-b',
+      '--repo',
+      primary,
+      '--timeout-ms',
+      '5000',
+      '--',
+      process.execPath,
+      '-e',
+      'process.stdout.write(String(Date.now()))',
+    ]);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const releasedAt = Date.now();
+    releaseCloneLock(first);
+
+    const { stdout } = await waiter;
+    const acquiredAt = Number(stdout);
+    assert.ok(
+      acquiredAt >= releasedAt - 50,
+      `expected the waiter to acquire only after release (acquiredAt=${acquiredAt}, releasedAt=${releasedAt})`,
+    );
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('acquire: times out with CloneLockTimeoutError when the lock is never released', () => {
+  const primary = setupRepo();
+  try {
+    const first = acquireCloneLock(primary, 'agent-a', 60_000);
+    try {
+      assert.throws(
+        () => acquireCloneLock(primary, 'agent-b', 300),
+        CloneLockTimeoutError,
+      );
+    } finally {
+      releaseCloneLock(first);
+    }
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('acquire: a lock older than the stale threshold is taken over rather than waited out', () => {
+  const primary = setupRepo();
+  try {
+    const path = resolveCloneLockPath(primary);
+    const ancientAcquiredAt = new Date(Date.now() - 10 * 60_000).toISOString();
+    writeFileSync(
+      path,
+      JSON.stringify({
+        token: 'dead-holder',
+        agentId: 'agent-dead',
+        acquiredAt: ancientAcquiredAt,
+      }),
+    );
+
+    const start = Date.now();
+    const handle = acquireCloneLock(primary, 'agent-b', 5_000);
+    const elapsedMs = Date.now() - start;
+
+    assert.ok(
+      elapsedMs < 2_000,
+      `expected an immediate takeover of a stale lock, took ${elapsedMs}ms`,
+    );
+    assert.notEqual(handle.token, 'dead-holder');
+    releaseCloneLock(handle);
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('acquire: a malformed lock body is waited out, not treated as immediately stale', async () => {
+  const primary = setupRepo();
+  try {
+    const path = resolveCloneLockPath(primary);
+    writeFileSync(path, '{"unexpected": "shape"}');
+
+    await assert.rejects(
+      (async () => acquireCloneLock(primary, 'agent-b', 300))(),
+      CloneLockTimeoutError,
+    );
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('withCloneLock: releases even when the wrapped command fails', () => {
+  const primary = setupRepo();
+  try {
+    const status = withCloneLock(primary, 'agent-a', process.execPath, [
+      '-e',
+      'process.exit(7)',
+    ]);
+    assert.equal(status, 7);
+    assert.equal(checkCloneLock(primary).present, false);
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('CLI: --check reports a malformed lock body as present+malformed, without throwing', () => {
+  const primary = setupRepo();
+  try {
+    writeFileSync(resolveCloneLockPath(primary), '{"unexpected": "shape"}');
+    const stdout = execFileSync(
+      process.execPath,
+      [CLI_PATH, '--check', '--repo', primary],
+      { encoding: 'utf8' },
+    );
+    const parsed = JSON.parse(stdout);
+    assert.equal(parsed.present, true);
+    assert.equal(parsed.malformed, true);
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('CLI: --exec propagates the wrapped command exit code and requires a `--` command', async () => {
+  const primary = setupRepo();
+  try {
+    const ok = await execFileAsync(process.execPath, [
+      CLI_PATH,
+      '--exec',
+      '--agent-id',
+      'agent-a',
+      '--repo',
+      primary,
+      '--',
+      process.execPath,
+      '-e',
+      'process.exit(0)',
+    ]);
+    assert.equal(ok.stdout, '');
+
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        CLI_PATH,
+        '--exec',
+        '--agent-id',
+        'agent-a',
+        '--repo',
+        primary,
+        '--',
+        process.execPath,
+        '-e',
+        'process.exit(9)',
+      ]),
+      (error: NodeJS.ErrnoException) => {
+        assert.equal(error.code, 9);
+        return true;
+      },
+    );
+
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        CLI_PATH,
+        '--exec',
+        '--agent-id',
+        'agent-a',
+        '--repo',
+        primary,
+      ]),
+      (error: NodeJS.ErrnoException & { stderr?: string }) => {
+        assert.match(error.stderr ?? '', /requires a command after `--`/);
+        return true;
+      },
+    );
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('CLI: concurrent --exec invocations serialize the wrapped command — no two critical sections overlap', async () => {
+  const primary = setupRepo();
+  const logPath = join(primary, 'activity.log');
+  writeFileSync(logPath, '');
+  try {
+    const CONCURRENT_WORKERS = 4;
+    const criticalSectionScript =
+      'const fs=require("fs");const log=process.env.IDD_TEST_LOG;const idx=process.env.IDD_TEST_IDX;' +
+      'fs.appendFileSync(log,"start "+idx+" "+Date.now()+"\\n");' +
+      'const until=Date.now()+120;while(Date.now()<until){}' +
+      'fs.appendFileSync(log,"end "+idx+" "+Date.now()+"\\n");';
+
+    await Promise.all(
+      Array.from({ length: CONCURRENT_WORKERS }, (_unused, index) =>
+        execFileAsync(
+          process.execPath,
+          [
+            CLI_PATH,
+            '--exec',
+            '--agent-id',
+            `agent-${index}`,
+            '--repo',
+            primary,
+            '--timeout-ms',
+            '20000',
+            '--',
+            process.execPath,
+            '-e',
+            criticalSectionScript,
+          ],
+          {
+            env: fixtureEnv({
+              IDD_TEST_LOG: logPath,
+              IDD_TEST_IDX: String(index),
+            }),
+          },
+        ),
+      ),
+    );
+
+    const lines = readFileSync(logPath, 'utf8').trim().split('\n');
+    const intervals = new Map<string, { start: number; end: number }>();
+    for (const line of lines) {
+      const [kind, idx, ts] = line.split(' ');
+      const entry = intervals.get(idx) ?? { start: 0, end: 0 };
+      if (kind === 'start') {
+        entry.start = Number(ts);
+      } else {
+        entry.end = Number(ts);
+      }
+      intervals.set(idx, entry);
+    }
+    assert.equal(intervals.size, CONCURRENT_WORKERS);
+
+    const sorted = Array.from(intervals.values()).sort(
+      (first, second) => first.start - second.start,
+    );
+    for (let index = 1; index < sorted.length; index += 1) {
+      assert.ok(
+        sorted[index].start >= sorted[index - 1].end,
+        `expected non-overlapping critical sections, got: ${JSON.stringify(sorted)}`,
+      );
+    }
+  } finally {
+    teardown(primary);
+  }
+});

--- a/tests/clone-lock.test.mts
+++ b/tests/clone-lock.test.mts
@@ -6,8 +6,6 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
-  statSync,
-  utimesSync,
   writeFileSync,
 } from 'node:fs';
 import { devNull, tmpdir } from 'node:os';
@@ -20,7 +18,6 @@ import {
   acquireCloneLock,
   CloneLockTimeoutError,
   checkCloneLock,
-  refreshCloneLock,
   releaseCloneLock,
   resolveCloneLockPath,
   withCloneLock,
@@ -69,6 +66,28 @@ function teardown(primary: string): void {
   rmSync(primary, { recursive: true, force: true });
 }
 
+/**
+ * A genuinely dead PID: `spawnSync` blocks until the child has already
+ * exited, so its `pid` is guaranteed not to be running by the time it is
+ * read back (short of the OS recycling that exact pid in the meantime,
+ * which is not realistic within a test's lifetime).
+ */
+function deadPid(): number {
+  const pid = spawnSync(process.execPath, ['-e', 'process.exit(0)']).pid;
+  assert.ok(typeof pid === 'number' && pid > 0);
+  return pid;
+}
+
+function writeLockBody(
+  path: string,
+  body: { pid: number; token: string; agentId: string },
+): void {
+  writeFileSync(
+    path,
+    JSON.stringify({ ...body, acquiredAt: new Date().toISOString() }),
+  );
+}
+
 test('resolveCloneLockPath resolves to the shared git-common-dir, identically from the primary and a linked worktree', () => {
   const primary = setupRepo();
   try {
@@ -102,7 +121,9 @@ test('acquire/release: a fresh acquire succeeds and release removes the lock', (
   const primary = setupRepo();
   try {
     const handle = acquireCloneLock(primary, 'agent-a', 5_000);
-    assert.equal(checkCloneLock(primary).present, true);
+    const check = checkCloneLock(primary);
+    assert.equal(check.present, true);
+    assert.equal(check.holder?.pid, process.pid);
     releaseCloneLock(handle);
     assert.equal(checkCloneLock(primary).present, false);
   } finally {
@@ -181,32 +202,49 @@ test('acquire: times out with CloneLockTimeoutError when the lock is never relea
   }
 });
 
-function backdateLockMtime(path: string, ageMs: number): void {
-  const ancient = new Date(Date.now() - ageMs);
-  utimesSync(path, ancient, ancient);
-}
-
-test('acquire: a lock whose mtime is older than staleMs is taken over rather than waited out', () => {
+test("acquire: a lock recording a live PID is never taken over, however long acquire keeps waiting (this repository's own CI caught a time-based-staleness design regress exactly this invariant)", () => {
   const primary = setupRepo();
   try {
     const path = resolveCloneLockPath(primary);
-    writeFileSync(
-      path,
-      JSON.stringify({
-        token: 'dead-holder',
-        agentId: 'agent-dead',
-        acquiredAt: new Date().toISOString(),
-      }),
+    // This test process's own pid is, by construction, alive for the
+    // entire test -- there is no timing window to race here, unlike an
+    // elapsed-time threshold: liveness is either true right now or it
+    // is not.
+    writeLockBody(path, {
+      pid: process.pid,
+      token: 'live-holder',
+      agentId: 'agent-live',
+    });
+
+    assert.throws(
+      () => acquireCloneLock(primary, 'agent-b', 300),
+      CloneLockTimeoutError,
     );
-    backdateLockMtime(path, 60_000);
+    const check = checkCloneLock(primary);
+    assert.equal(check.present, true);
+    assert.equal(check.holder?.token, 'live-holder');
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('acquire: a lock whose recorded pid is confirmed dead is taken over rather than waited out', () => {
+  const primary = setupRepo();
+  try {
+    const path = resolveCloneLockPath(primary);
+    writeLockBody(path, {
+      pid: deadPid(),
+      token: 'dead-holder',
+      agentId: 'agent-dead',
+    });
 
     const start = Date.now();
-    const handle = acquireCloneLock(primary, 'agent-b', 5_000, 200);
+    const handle = acquireCloneLock(primary, 'agent-b', 5_000);
     const elapsedMs = Date.now() - start;
 
     assert.ok(
       elapsedMs < 2_000,
-      `expected an immediate takeover of a stale lock, took ${elapsedMs}ms`,
+      `expected an immediate takeover of a dead-pid lock, took ${elapsedMs}ms`,
     );
     assert.notEqual(handle.token, 'dead-holder');
     releaseCloneLock(handle);
@@ -215,76 +253,19 @@ test('acquire: a lock whose mtime is older than staleMs is taken over rather tha
   }
 });
 
-test('acquire: a fresh malformed lock body is waited out, not treated as immediately stale', async () => {
+test('acquire: a malformed lock body is never auto-recovered (no readable pid to confirm dead; this repository deliberately does not add recovery machinery for it -- see the module header comment)', async () => {
   const primary = setupRepo();
   try {
     const path = resolveCloneLockPath(primary);
     writeFileSync(path, '{"unexpected": "shape"}');
-    // mtime is "now" (just written) -- well inside a generous staleMs, so
-    // this must not be taken over yet.
 
     await assert.rejects(
-      (async () => acquireCloneLock(primary, 'agent-b', 300, 60_000))(),
+      (async () => acquireCloneLock(primary, 'agent-b', 300))(),
       CloneLockTimeoutError,
     );
-  } finally {
-    teardown(primary);
-  }
-});
-
-test('acquire: a malformed lock body recovers once its mtime ages past staleMs (Codex P2: a crashed partial write must not wedge every waiter forever)', () => {
-  const primary = setupRepo();
-  try {
-    const path = resolveCloneLockPath(primary);
-    writeFileSync(path, '{"unexpected": "shape"}');
-    backdateLockMtime(path, 60_000);
-
-    const start = Date.now();
-    const handle = acquireCloneLock(primary, 'agent-b', 5_000, 200);
-    const elapsedMs = Date.now() - start;
-
-    assert.ok(
-      elapsedMs < 2_000,
-      `expected recovery of a stale malformed lock, took ${elapsedMs}ms`,
-    );
-    releaseCloneLock(handle);
-  } finally {
-    teardown(primary);
-  }
-});
-
-test('refreshCloneLock: bumps mtime only when the on-disk token still matches, is a silent no-op otherwise', () => {
-  const primary = setupRepo();
-  try {
-    const handle = acquireCloneLock(primary, 'agent-a', 5_000);
-    backdateLockMtime(handle.path, 10_000);
-    const beforeMs = statSync(handle.path).mtimeMs;
-
-    refreshCloneLock(handle);
-    const afterMs = statSync(handle.path).mtimeMs;
-    assert.ok(
-      afterMs > beforeMs,
-      `expected refresh to bump mtime forward (before=${beforeMs}, after=${afterMs})`,
-    );
-
-    releaseCloneLock(handle);
-    writeFileSync(
-      handle.path,
-      JSON.stringify({
-        token: 'someone-else',
-        agentId: 'agent-b',
-        acquiredAt: new Date().toISOString(),
-      }),
-    );
-    backdateLockMtime(handle.path, 10_000);
-    const beforeOtherMs = statSync(handle.path).mtimeMs;
-    refreshCloneLock(handle);
-    const afterOtherMs = statSync(handle.path).mtimeMs;
-    assert.equal(
-      afterOtherMs,
-      beforeOtherMs,
-      "refreshing a handle whose token no longer matches must not touch another holder's lock",
-    );
+    const check = checkCloneLock(primary);
+    assert.equal(check.present, true);
+    assert.equal(check.malformed, true);
   } finally {
     teardown(primary);
   }
@@ -293,14 +274,13 @@ test('refreshCloneLock: bumps mtime only when the on-disk token still matches, i
 /**
  * A small on-disk fixture script (not an inline `-e` string) so a child
  * process can import the built `clone-lock.mjs` directly and call
- * acquireCloneLock() with short, test-friendly staleMs/timeoutMs values
- * the CLI itself intentionally does not expose (see withCloneLock's own
- * doc comment: those overrides exist only for tests). Every contender
- * appends `won <idx> <startMs>` and `released <idx> <endMs>` on success,
- * or `lost <idx>` if it never acquired within its budget.
+ * acquireCloneLock() with a short, test-friendly timeoutMs the CLI
+ * itself intentionally does not expose for this purpose. Every
+ * contender appends `won <idx> <startMs>` and `released <idx> <endMs>`
+ * on success, or `lost <idx>` if it never acquired within its budget.
  */
 function writeRaceFixture(dir: string): string {
-  const fixturePath = join(dir, 'stale-race-worker.mjs');
+  const fixturePath = join(dir, 'race-worker.mjs');
   const cloneLockUrl = pathToFileURL(
     join(REPO_ROOT, 'scripts/clone-lock.mjs'),
   ).href;
@@ -313,10 +293,9 @@ function writeRaceFixture(dir: string): string {
       'const idx = process.env.IDD_TEST_IDX;',
       'const log = process.env.IDD_TEST_LOG;',
       'const timeoutMs = Number(process.env.IDD_TEST_TIMEOUT_MS);',
-      'const staleMs = Number(process.env.IDD_TEST_STALE_MS);',
       'const holdMs = Number(process.env.IDD_TEST_HOLD_MS);',
       'try {',
-      "  const handle = acquireCloneLock(repo, 'agent-' + idx, timeoutMs, staleMs);",
+      "  const handle = acquireCloneLock(repo, 'agent-' + idx, timeoutMs);",
       "  appendFileSync(log, 'won ' + idx + ' ' + Date.now() + '\\n');",
       '  const until = Date.now() + holdMs;',
       '  while (Date.now() < until) {}',
@@ -330,21 +309,17 @@ function writeRaceFixture(dir: string): string {
   return fixturePath;
 }
 
-test('acquire: a stale-lock takeover across concurrent contenders never lets two of them hold the lock at once (P1-1: unconditional rename let every racer believe it won)', async () => {
+test('acquire: a dead-pid lock takeover across concurrent contenders never lets two of them hold the lock at once', async () => {
   const primary = setupRepo();
-  const logPath = join(primary, 'stale-race.log');
+  const logPath = join(primary, 'dead-pid-race.log');
   writeFileSync(logPath, '');
   try {
     const path = resolveCloneLockPath(primary);
-    writeFileSync(
-      path,
-      JSON.stringify({
-        token: 'dead-holder',
-        agentId: 'agent-dead',
-        acquiredAt: new Date().toISOString(),
-      }),
-    );
-    backdateLockMtime(path, 60_000);
+    writeLockBody(path, {
+      pid: deadPid(),
+      token: 'dead-holder',
+      agentId: 'agent-dead',
+    });
 
     const fixturePath = writeRaceFixture(primary);
     const CONTENDERS = 5;
@@ -355,14 +330,12 @@ test('acquire: a stale-lock takeover across concurrent contenders never lets two
             IDD_TEST_REPO: primary,
             IDD_TEST_IDX: String(index),
             IDD_TEST_LOG: logPath,
-            // Every contender starts by racing the SAME pre-seeded stale
-            // lock -- the exact shape that let a plain check-then-unlink
-            // takeover produce more than one winner. A generous shared
-            // timeout means nobody spuriously times out from ordinary
-            // process-spawn jitter; every contender is expected to
-            // eventually acquire, one at a time.
+            // Every contender starts by racing the SAME pre-seeded
+            // dead-pid lock. A generous shared timeout means nobody
+            // spuriously times out from ordinary process-spawn jitter;
+            // every contender is expected to eventually acquire, one at
+            // a time.
             IDD_TEST_TIMEOUT_MS: '10000',
-            IDD_TEST_STALE_MS: '200',
             IDD_TEST_HOLD_MS: '150',
           }),
         }),
@@ -396,7 +369,7 @@ test('acquire: a stale-lock takeover across concurrent contenders never lets two
     for (let index = 1; index < sorted.length; index += 1) {
       assert.ok(
         sorted[index].start >= sorted[index - 1].end,
-        `expected non-overlapping holds even when racing a shared stale lock, got: ${JSON.stringify(sorted)}`,
+        `expected non-overlapping holds even when racing a shared dead-pid lock, got: ${JSON.stringify(sorted)}`,
       );
     }
   } finally {
@@ -436,52 +409,46 @@ test('withCloneLock: runs the wrapped command with cwd set to repoPath', async (
   }
 });
 
-test('withCloneLock: refreshes its lease so a long-running command is never mistaken for an abandoned holder (Codex P1: live holders must not age out)', async () => {
+test("withCloneLock: a live wrapped-command holder is never taken over by a waiter, no matter how long the command runs (Codex P1 / this repository's own CI regression: an earlier mtime-staleness-plus-lease-refresh design let a live holder be taken over under scheduling jitter -- PID liveness has no equivalent timing window)", async () => {
   const primary = setupRepo();
-  const logPath = join(primary, 'waiter.log');
-  writeFileSync(logPath, '');
   try {
-    // The held command "runs" for 600ms under a staleMs of only 150ms --
-    // without lease refresh, that alone would make it look abandoned.
-    // leaseRefreshMs=40 keeps refreshing well inside that window.
+    // The held command runs for 500ms; the waiter's own acquire budget
+    // is only 200ms -- deliberately shorter than the hold, so a
+    // waiter that (incorrectly) treats the live holder as stale would
+    // succeed well before the holder exits, and a correctly-behaving
+    // waiter must time out instead.
     const holderPromise = withCloneLock(
       primary,
       'agent-holder',
       process.execPath,
-      ['-e', 'const u=Date.now()+600;while(Date.now()<u){}'],
-      5_000,
-      150,
-      40,
+      ['-e', 'const u=Date.now()+500;while(Date.now()<u){}'],
     );
 
     // Let the holder actually acquire before the waiter starts contending.
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    const fixturePath = writeRaceFixture(primary);
-    await execFileAsync(process.execPath, [fixturePath], {
-      env: fixtureEnv({
-        IDD_TEST_REPO: primary,
-        IDD_TEST_IDX: 'waiter',
-        IDD_TEST_LOG: logPath,
-        // 400ms budget: longer than the remaining hold time, so if the
-        // waiter incorrectly "wins" a stale takeover mid-hold, it reports
-        // that; if it correctly keeps waiting/times out, it reports loss.
-        IDD_TEST_TIMEOUT_MS: '400',
-        IDD_TEST_STALE_MS: '150',
-        IDD_TEST_HOLD_MS: '0',
-      }),
-    });
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        CLI_PATH,
+        '--exec',
+        '--agent-id',
+        'agent-waiter',
+        '--repo',
+        primary,
+        '--timeout-ms',
+        '200',
+        '--',
+        process.execPath,
+        '-e',
+        'process.exit(0)',
+      ]),
+      (error: NodeJS.ErrnoException) => {
+        assert.equal(error.code, 3);
+        return true;
+      },
+    );
 
     await holderPromise;
-    const lines = readFileSync(logPath, 'utf8')
-      .trim()
-      .split('\n')
-      .filter(Boolean);
-    assert.deepEqual(
-      lines,
-      ['lost waiter'],
-      'a live, actively-refreshing holder must never be treated as stale and taken over',
-    );
   } finally {
     teardown(primary);
   }
@@ -622,250 +589,6 @@ test('CLI: concurrent --exec invocations serialize the wrapped command — no tw
         `expected non-overlapping critical sections, got: ${JSON.stringify(sorted)}`,
       );
     }
-  } finally {
-    teardown(primary);
-  }
-});
-
-test('acquire: a malformed arbiter marker recovers once its age passes the malformed-stale fallback (P2 round 4: a crashed partial arbiter write must not wedge every future takeover forever)', () => {
-  const primary = setupRepo();
-  try {
-    const path = resolveCloneLockPath(primary);
-    writeFileSync(
-      path,
-      JSON.stringify({
-        token: 'dead-holder',
-        agentId: 'agent-dead',
-        acquiredAt: new Date().toISOString(),
-      }),
-    );
-    backdateLockMtime(path, 60_000);
-
-    // Seed a malformed (unparseable) arbiter marker -- simulating a
-    // process that crashed after the exclusive wx-create but before its
-    // JSON write completed -- and backdate it well past the
-    // malformed-stale fallback window.
-    const arbiterFile = `${path}.arbiter`;
-    writeFileSync(arbiterFile, '{"pid": not valid json');
-    backdateLockMtime(arbiterFile, 30_000);
-
-    const start = Date.now();
-    const handle = acquireCloneLock(primary, 'agent-b', 5_000, 200);
-    const elapsedMs = Date.now() - start;
-
-    assert.ok(
-      elapsedMs < 2_000,
-      `expected the malformed arbiter to be recovered promptly, took ${elapsedMs}ms`,
-    );
-    releaseCloneLock(handle);
-  } finally {
-    teardown(primary);
-  }
-});
-
-test('acquire: concurrent contenders racing a dead-PID arbiter recovery never let two of them hold the lock at once (P1 round 4: PID and inode must come from the same read)', async () => {
-  const primary = setupRepo();
-  const logPath = join(primary, 'dead-arbiter-race.log');
-  writeFileSync(logPath, '');
-  try {
-    const path = resolveCloneLockPath(primary);
-    writeFileSync(
-      path,
-      JSON.stringify({
-        token: 'dead-holder',
-        agentId: 'agent-dead',
-        acquiredAt: new Date().toISOString(),
-      }),
-    );
-    backdateLockMtime(path, 60_000);
-
-    // A genuinely dead PID: spawnSync blocks until the child has already
-    // exited, so its pid is guaranteed not to be running by the time we
-    // read it back (short of the OS recycling that exact pid in the
-    // meantime, which is not realistic within a test's lifetime).
-    const deadPid = spawnSync(process.execPath, ['-e', 'process.exit(0)']).pid;
-    assert.ok(typeof deadPid === 'number' && deadPid > 0);
-    writeFileSync(`${path}.arbiter`, JSON.stringify({ pid: deadPid }));
-
-    const fixturePath = writeRaceFixture(primary);
-    const CONTENDERS = 5;
-    await Promise.all(
-      Array.from({ length: CONTENDERS }, (_unused, index) =>
-        execFileAsync(process.execPath, [fixturePath], {
-          env: fixtureEnv({
-            IDD_TEST_REPO: primary,
-            IDD_TEST_IDX: String(index),
-            IDD_TEST_LOG: logPath,
-            IDD_TEST_TIMEOUT_MS: '10000',
-            IDD_TEST_STALE_MS: '200',
-            IDD_TEST_HOLD_MS: '150',
-          }),
-        }),
-      ),
-    );
-
-    const lines = readFileSync(logPath, 'utf8')
-      .trim()
-      .split('\n')
-      .filter(Boolean);
-    assert.equal(
-      lines.filter((line) => line.startsWith('lost ')).length,
-      0,
-      `expected every contender to eventually acquire, got: ${JSON.stringify(lines)}`,
-    );
-    const intervals = new Map<string, { start: number; end: number }>();
-    for (const line of lines) {
-      const [kind, idx, ts] = line.split(' ');
-      const entry = intervals.get(idx) ?? { start: 0, end: 0 };
-      if (kind === 'won') {
-        entry.start = Number(ts);
-      } else {
-        entry.end = Number(ts);
-      }
-      intervals.set(idx, entry);
-    }
-    assert.equal(intervals.size, CONTENDERS);
-    const sorted = Array.from(intervals.values()).sort(
-      (first, second) => first.start - second.start,
-    );
-    for (let index = 1; index < sorted.length; index += 1) {
-      assert.ok(
-        sorted[index].start >= sorted[index - 1].end,
-        `expected non-overlapping holds even when racing a dead-PID arbiter, got: ${JSON.stringify(sorted)}`,
-      );
-    }
-  } finally {
-    teardown(primary);
-  }
-});
-
-/**
- * A second on-disk fixture: each worker repeatedly acquires with a very
- * short staleMs, immediately backdates ITS OWN freshly-acquired lock (so
- * it looks abandoned to every other contender as soon as possible,
- * maximizing how often a release/refresh call races an in-flight
- * takeover of that same lock), holds briefly, refreshes once partway
- * through the hold (also racing takeover), then releases (also racing
- * takeover) -- repeating in a loop until `IDD_TEST_UNTIL_MS` elapses.
- * Every transition is logged so the test can verify the shared main lock
- * file was well-formed JSON at every observation, never corrupted by a
- * torn concurrent write.
- */
-function writeReleaseRefreshRaceFixture(dir: string): string {
-  const fixturePath = join(dir, 'release-refresh-race-worker.mjs');
-  const cloneLockUrl = pathToFileURL(
-    join(REPO_ROOT, 'scripts/clone-lock.mjs'),
-  ).href;
-  writeFileSync(
-    fixturePath,
-    [
-      `import { acquireCloneLock, refreshCloneLock, releaseCloneLock, resolveCloneLockPath } from ${JSON.stringify(cloneLockUrl)};`,
-      "import { appendFileSync, readFileSync, utimesSync } from 'node:fs';",
-      'const repo = process.env.IDD_TEST_REPO;',
-      'const idx = process.env.IDD_TEST_IDX;',
-      'const log = process.env.IDD_TEST_LOG;',
-      'const untilMs = Number(process.env.IDD_TEST_UNTIL_MS);',
-      'const path = resolveCloneLockPath(repo);',
-      'let rounds = 0;',
-      'while (Date.now() < untilMs) {',
-      '  rounds += 1;',
-      '  try {',
-      "    const handle = acquireCloneLock(repo, 'agent-' + idx, 300, 30);",
-      "    appendFileSync(log, 'won ' + idx + ' ' + Date.now() + '\\n');",
-      '    const ancient = new Date(Date.now() - 60000);',
-      '    utimesSync(path, ancient, ancient);',
-      '    const holdUntil = Date.now() + 20;',
-      '    while (Date.now() < holdUntil) {}',
-      '    refreshCloneLock(handle);',
-      '    const raw = readFileSync(path, "utf8");',
-      '    try {',
-      '      JSON.parse(raw);',
-      '    } catch {',
-      "      appendFileSync(log, 'corrupt ' + idx + ' ' + raw + '\\n');",
-      '    }',
-      '    const holdUntil2 = Date.now() + 10;',
-      '    while (Date.now() < holdUntil2) {}',
-      '    releaseCloneLock(handle);',
-      "    appendFileSync(log, 'released ' + idx + ' ' + Date.now() + '\\n');",
-      '  } catch (error) {',
-      "    appendFileSync(log, 'lost ' + idx + '\\n');",
-      '  }',
-      '}',
-      "appendFileSync(log, 'rounds ' + idx + ' ' + rounds + '\\n');",
-    ].join('\n'),
-  );
-  return fixturePath;
-}
-
-test('release/refresh: repeated concurrent acquire-backdate-refresh-release cycles never corrupt the lock or let two contenders hold it at once (Codex P1 round 4: release/refresh vs. takeover)', async () => {
-  const primary = setupRepo();
-  const logPath = join(primary, 'release-refresh-race.log');
-  writeFileSync(logPath, '');
-  try {
-    const fixturePath = writeReleaseRefreshRaceFixture(primary);
-    const WORKERS = 4;
-    const DURATION_MS = 1500;
-    const untilMs = Date.now() + DURATION_MS;
-
-    await Promise.all(
-      Array.from({ length: WORKERS }, (_unused, index) =>
-        execFileAsync(process.execPath, [fixturePath], {
-          env: fixtureEnv({
-            IDD_TEST_REPO: primary,
-            IDD_TEST_IDX: String(index),
-            IDD_TEST_LOG: logPath,
-            IDD_TEST_UNTIL_MS: String(untilMs),
-          }),
-        }),
-      ),
-    );
-
-    const lines = readFileSync(logPath, 'utf8')
-      .trim()
-      .split('\n')
-      .filter(Boolean);
-    const corruptions = lines.filter((line) => line.startsWith('corrupt '));
-    assert.deepEqual(
-      corruptions,
-      [],
-      `expected the lock file to always be well-formed JSON when observed mid-hold, got: ${JSON.stringify(corruptions)}`,
-    );
-
-    const totalRounds = lines
-      .filter((line) => line.startsWith('rounds '))
-      .reduce((sum, line) => sum + Number(line.split(' ')[2]), 0);
-    assert.ok(
-      totalRounds >= WORKERS,
-      `expected meaningful contention (at least one round per worker), got ${totalRounds} total rounds across: ${JSON.stringify(lines)}`,
-    );
-
-    // Note: this fixture deliberately backdates its OWN freshly-acquired
-    // lock immediately after acquiring it, specifically so other workers
-    // legitimately steal it mid-cycle -- that is the whole point (it is
-    // what forces a release/refresh call to race an in-flight takeover
-    // of the very same lock). Because of that self-sabotage, a worker's
-    // own "won"-to-"released" span is NOT a reliable proxy for "this
-    // worker verifiably held the lock exclusively the whole time" (its
-    // `released` log line fires unconditionally, even when the release
-    // call itself was a correct no-op because a takeover already
-    // replaced its token) -- so, unlike the other stress tests in this file,
-    // asserting those spans never overlap is not a valid invariant to
-    // check here. What this test verifies instead: no interleaving of
-    // acquire/backdate/refresh/release/takeover across four workers ever
-    // produces a torn, unparseable on-disk body (checked above), and the
-    // arbiter itself is never left orphaned by a botched interleaving.
-    const finalPath = resolveCloneLockPath(primary);
-    const finalRaw = existsSync(finalPath)
-      ? readFileSync(finalPath, 'utf8')
-      : null;
-    if (finalRaw !== null) {
-      assert.doesNotThrow(() => JSON.parse(finalRaw));
-    }
-    assert.equal(
-      existsSync(`${finalPath}.arbiter`),
-      false,
-      'expected the arbiter marker to never be left behind after every worker finished',
-    );
   } finally {
     teardown(primary);
   }

--- a/tests/clone-lock.test.mts
+++ b/tests/clone-lock.test.mts
@@ -237,6 +237,34 @@ function spawnDeadPid(): number {
   return pid;
 }
 
+test('check: a lock body with an unsafe pid (0, negative, or non-integer -- POSIX gives kill() special meaning for those) is treated as malformed, never passed to process.kill()', () => {
+  const primary = setupRepo();
+  try {
+    const path = resolveCloneLockPath(primary);
+    for (const badPid of [0, -1, 1.5, Number.NaN]) {
+      writeFileSync(
+        path,
+        JSON.stringify({
+          pid: badPid,
+          token: 'bad-pid-holder',
+          agentId: 'agent-bad',
+          acquiredAt: new Date().toISOString(),
+        }),
+      );
+      const check = checkCloneLock(primary);
+      assert.equal(check.present, true);
+      assert.equal(
+        check.malformed,
+        true,
+        `expected pid ${badPid} to be treated as malformed`,
+      );
+      assert.equal(check.holder, undefined);
+    }
+  } finally {
+    teardown(primary);
+  }
+});
+
 test('check: holderAlive reports false for a lock recording a confirmed-dead pid', () => {
   const primary = setupRepo();
   try {

--- a/tests/clone-lock.test.mts
+++ b/tests/clone-lock.test.mts
@@ -11,7 +11,7 @@ import {
 import { devNull, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 
 import {
@@ -66,28 +66,6 @@ function teardown(primary: string): void {
   rmSync(primary, { recursive: true, force: true });
 }
 
-/**
- * A genuinely dead PID: `spawnSync` blocks until the child has already
- * exited, so its `pid` is guaranteed not to be running by the time it is
- * read back (short of the OS recycling that exact pid in the meantime,
- * which is not realistic within a test's lifetime).
- */
-function deadPid(): number {
-  const pid = spawnSync(process.execPath, ['-e', 'process.exit(0)']).pid;
-  assert.ok(typeof pid === 'number' && pid > 0);
-  return pid;
-}
-
-function writeLockBody(
-  path: string,
-  body: { pid: number; token: string; agentId: string },
-): void {
-  writeFileSync(
-    path,
-    JSON.stringify({ ...body, acquiredAt: new Date().toISOString() }),
-  );
-}
-
 test('resolveCloneLockPath resolves to the shared git-common-dir, identically from the primary and a linked worktree', () => {
   const primary = setupRepo();
   try {
@@ -124,6 +102,7 @@ test('acquire/release: a fresh acquire succeeds and release removes the lock', (
     const check = checkCloneLock(primary);
     assert.equal(check.present, true);
     assert.equal(check.holder?.pid, process.pid);
+    assert.equal(check.holderAlive, true);
     releaseCloneLock(handle);
     assert.equal(checkCloneLock(primary).present, false);
   } finally {
@@ -185,14 +164,22 @@ test('acquire: a held lock blocks a separate-process acquirer until the first re
   }
 });
 
-test('acquire: times out with CloneLockTimeoutError when the lock is never released', () => {
+test('acquire: times out with CloneLockTimeoutError, naming the lock path and the recorded holder, when the lock is never released', () => {
   const primary = setupRepo();
   try {
     const first = acquireCloneLock(primary, 'agent-a', 60_000);
     try {
       assert.throws(
         () => acquireCloneLock(primary, 'agent-b', 300),
-        CloneLockTimeoutError,
+        (error: unknown) => {
+          assert.ok(error instanceof CloneLockTimeoutError);
+          assert.match(error.message, /timed out waiting for clone lock:/);
+          assert.match(error.message, new RegExp(`held by pid ${process.pid}`));
+          assert.match(error.message, /agent "agent-a"/);
+          assert.match(error.message, /still appears to be running/);
+          assert.match(error.message, /remove the lock manually: rm /);
+          return true;
+        },
       );
     } finally {
       releaseCloneLock(first);
@@ -202,63 +189,30 @@ test('acquire: times out with CloneLockTimeoutError when the lock is never relea
   }
 });
 
-test("acquire: a lock recording a live PID is never taken over, however long acquire keeps waiting (this repository's own CI caught a time-based-staleness design regress exactly this invariant)", () => {
+test('acquire: NEVER automatically takes over a lock, even one recording a confirmed-dead pid or a malformed body -- this module deliberately has no automatic stale-lock recovery (see the module header comment: three prior auto-recovery designs each had a genuine concurrency defect found in review)', async () => {
   const primary = setupRepo();
   try {
     const path = resolveCloneLockPath(primary);
-    // This test process's own pid is, by construction, alive for the
-    // entire test -- there is no timing window to race here, unlike an
-    // elapsed-time threshold: liveness is either true right now or it
-    // is not.
-    writeLockBody(path, {
-      pid: process.pid,
-      token: 'live-holder',
-      agentId: 'agent-live',
-    });
 
-    assert.throws(
-      () => acquireCloneLock(primary, 'agent-b', 300),
+    // A lock recording a pid that is, by construction, not running.
+    const deadPid = spawnDeadPid();
+    writeFileSync(
+      path,
+      JSON.stringify({
+        pid: deadPid,
+        token: 'dead-holder',
+        agentId: 'agent-dead',
+        acquiredAt: new Date().toISOString(),
+      }),
+    );
+    await assert.rejects(
+      (async () => acquireCloneLock(primary, 'agent-b', 300))(),
       CloneLockTimeoutError,
     );
-    const check = checkCloneLock(primary);
-    assert.equal(check.present, true);
-    assert.equal(check.holder?.token, 'live-holder');
-  } finally {
-    teardown(primary);
-  }
-});
+    assert.equal(checkCloneLock(primary).holder?.token, 'dead-holder');
 
-test('acquire: a lock whose recorded pid is confirmed dead is taken over rather than waited out', () => {
-  const primary = setupRepo();
-  try {
-    const path = resolveCloneLockPath(primary);
-    writeLockBody(path, {
-      pid: deadPid(),
-      token: 'dead-holder',
-      agentId: 'agent-dead',
-    });
-
-    const start = Date.now();
-    const handle = acquireCloneLock(primary, 'agent-b', 5_000);
-    const elapsedMs = Date.now() - start;
-
-    assert.ok(
-      elapsedMs < 2_000,
-      `expected an immediate takeover of a dead-pid lock, took ${elapsedMs}ms`,
-    );
-    assert.notEqual(handle.token, 'dead-holder');
-    releaseCloneLock(handle);
-  } finally {
-    teardown(primary);
-  }
-});
-
-test('acquire: a malformed lock body is never auto-recovered (no readable pid to confirm dead; this repository deliberately does not add recovery machinery for it -- see the module header comment)', async () => {
-  const primary = setupRepo();
-  try {
-    const path = resolveCloneLockPath(primary);
+    // A malformed body is likewise left untouched.
     writeFileSync(path, '{"unexpected": "shape"}');
-
     await assert.rejects(
       (async () => acquireCloneLock(primary, 'agent-b', 300))(),
       CloneLockTimeoutError,
@@ -272,106 +226,33 @@ test('acquire: a malformed lock body is never auto-recovered (no readable pid to
 });
 
 /**
- * A small on-disk fixture script (not an inline `-e` string) so a child
- * process can import the built `clone-lock.mjs` directly and call
- * acquireCloneLock() with a short, test-friendly timeoutMs the CLI
- * itself intentionally does not expose for this purpose. Every
- * contender appends `won <idx> <startMs>` and `released <idx> <endMs>`
- * on success, or `lost <idx>` if it never acquired within its budget.
+ * A genuinely dead PID: `spawnSync` blocks until the child has already
+ * exited, so its `pid` is guaranteed not to be running by the time it is
+ * read back (short of the OS recycling that exact pid in the meantime,
+ * which is not realistic within a test's lifetime).
  */
-function writeRaceFixture(dir: string): string {
-  const fixturePath = join(dir, 'race-worker.mjs');
-  const cloneLockUrl = pathToFileURL(
-    join(REPO_ROOT, 'scripts/clone-lock.mjs'),
-  ).href;
-  writeFileSync(
-    fixturePath,
-    [
-      `import { acquireCloneLock, releaseCloneLock } from ${JSON.stringify(cloneLockUrl)};`,
-      "import { appendFileSync } from 'node:fs';",
-      'const repo = process.env.IDD_TEST_REPO;',
-      'const idx = process.env.IDD_TEST_IDX;',
-      'const log = process.env.IDD_TEST_LOG;',
-      'const timeoutMs = Number(process.env.IDD_TEST_TIMEOUT_MS);',
-      'const holdMs = Number(process.env.IDD_TEST_HOLD_MS);',
-      'try {',
-      "  const handle = acquireCloneLock(repo, 'agent-' + idx, timeoutMs);",
-      "  appendFileSync(log, 'won ' + idx + ' ' + Date.now() + '\\n');",
-      '  const until = Date.now() + holdMs;',
-      '  while (Date.now() < until) {}',
-      "  appendFileSync(log, 'released ' + idx + ' ' + Date.now() + '\\n');",
-      '  releaseCloneLock(handle);',
-      '} catch (error) {',
-      "  appendFileSync(log, 'lost ' + idx + '\\n');",
-      '}',
-    ].join('\n'),
-  );
-  return fixturePath;
+function spawnDeadPid(): number {
+  const pid = spawnSync(process.execPath, ['-e', 'process.exit(0)']).pid;
+  assert.ok(typeof pid === 'number' && pid > 0);
+  return pid;
 }
 
-test('acquire: a dead-pid lock takeover across concurrent contenders never lets two of them hold the lock at once', async () => {
+test('check: holderAlive reports false for a lock recording a confirmed-dead pid', () => {
   const primary = setupRepo();
-  const logPath = join(primary, 'dead-pid-race.log');
-  writeFileSync(logPath, '');
   try {
     const path = resolveCloneLockPath(primary);
-    writeLockBody(path, {
-      pid: deadPid(),
-      token: 'dead-holder',
-      agentId: 'agent-dead',
-    });
-
-    const fixturePath = writeRaceFixture(primary);
-    const CONTENDERS = 5;
-    await Promise.all(
-      Array.from({ length: CONTENDERS }, (_unused, index) =>
-        execFileAsync(process.execPath, [fixturePath], {
-          env: fixtureEnv({
-            IDD_TEST_REPO: primary,
-            IDD_TEST_IDX: String(index),
-            IDD_TEST_LOG: logPath,
-            // Every contender starts by racing the SAME pre-seeded
-            // dead-pid lock. A generous shared timeout means nobody
-            // spuriously times out from ordinary process-spawn jitter;
-            // every contender is expected to eventually acquire, one at
-            // a time.
-            IDD_TEST_TIMEOUT_MS: '10000',
-            IDD_TEST_HOLD_MS: '150',
-          }),
-        }),
-      ),
+    writeFileSync(
+      path,
+      JSON.stringify({
+        pid: spawnDeadPid(),
+        token: 'dead-holder',
+        agentId: 'agent-dead',
+        acquiredAt: new Date().toISOString(),
+      }),
     );
-
-    const lines = readFileSync(logPath, 'utf8')
-      .trim()
-      .split('\n')
-      .filter(Boolean);
-    assert.equal(
-      lines.filter((line) => line.startsWith('lost ')).length,
-      0,
-      `expected every contender to eventually acquire, got: ${JSON.stringify(lines)}`,
-    );
-    const intervals = new Map<string, { start: number; end: number }>();
-    for (const line of lines) {
-      const [kind, idx, ts] = line.split(' ');
-      const entry = intervals.get(idx) ?? { start: 0, end: 0 };
-      if (kind === 'won') {
-        entry.start = Number(ts);
-      } else {
-        entry.end = Number(ts);
-      }
-      intervals.set(idx, entry);
-    }
-    assert.equal(intervals.size, CONTENDERS);
-    const sorted = Array.from(intervals.values()).sort(
-      (first, second) => first.start - second.start,
-    );
-    for (let index = 1; index < sorted.length; index += 1) {
-      assert.ok(
-        sorted[index].start >= sorted[index - 1].end,
-        `expected non-overlapping holds even when racing a shared dead-pid lock, got: ${JSON.stringify(sorted)}`,
-      );
-    }
+    const check = checkCloneLock(primary);
+    assert.equal(check.present, true);
+    assert.equal(check.holderAlive, false);
   } finally {
     teardown(primary);
   }
@@ -409,51 +290,6 @@ test('withCloneLock: runs the wrapped command with cwd set to repoPath', async (
   }
 });
 
-test("withCloneLock: a live wrapped-command holder is never taken over by a waiter, no matter how long the command runs (Codex P1 / this repository's own CI regression: an earlier mtime-staleness-plus-lease-refresh design let a live holder be taken over under scheduling jitter -- PID liveness has no equivalent timing window)", async () => {
-  const primary = setupRepo();
-  try {
-    // The held command runs for 500ms; the waiter's own acquire budget
-    // is only 200ms -- deliberately shorter than the hold, so a
-    // waiter that (incorrectly) treats the live holder as stale would
-    // succeed well before the holder exits, and a correctly-behaving
-    // waiter must time out instead.
-    const holderPromise = withCloneLock(
-      primary,
-      'agent-holder',
-      process.execPath,
-      ['-e', 'const u=Date.now()+500;while(Date.now()<u){}'],
-    );
-
-    // Let the holder actually acquire before the waiter starts contending.
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
-    await assert.rejects(
-      execFileAsync(process.execPath, [
-        CLI_PATH,
-        '--exec',
-        '--agent-id',
-        'agent-waiter',
-        '--repo',
-        primary,
-        '--timeout-ms',
-        '200',
-        '--',
-        process.execPath,
-        '-e',
-        'process.exit(0)',
-      ]),
-      (error: NodeJS.ErrnoException) => {
-        assert.equal(error.code, 3);
-        return true;
-      },
-    );
-
-    await holderPromise;
-  } finally {
-    teardown(primary);
-  }
-});
-
 test('CLI: --check reports a malformed lock body as present+malformed, without throwing', () => {
   const primary = setupRepo();
   try {
@@ -466,6 +302,41 @@ test('CLI: --check reports a malformed lock body as present+malformed, without t
     const parsed = JSON.parse(stdout);
     assert.equal(parsed.present, true);
     assert.equal(parsed.malformed, true);
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('CLI: --exec exits 3 with a diagnostic message on timeout', async () => {
+  const primary = setupRepo();
+  try {
+    const holder = acquireCloneLock(primary, 'agent-a', 60_000);
+    try {
+      await assert.rejects(
+        execFileAsync(process.execPath, [
+          CLI_PATH,
+          '--exec',
+          '--agent-id',
+          'agent-b',
+          '--repo',
+          primary,
+          '--timeout-ms',
+          '200',
+          '--',
+          process.execPath,
+          '-e',
+          'process.exit(0)',
+        ]),
+        (error: NodeJS.ErrnoException & { stderr?: string }) => {
+          assert.equal(error.code, 3);
+          assert.match(error.stderr ?? '', /timed out waiting for clone lock:/);
+          assert.match(error.stderr ?? '', /remove the lock manually: rm /);
+          return true;
+        },
+      );
+    } finally {
+      releaseCloneLock(holder);
+    }
   } finally {
     teardown(primary);
   }

--- a/tests/clone-lock.test.mts
+++ b/tests/clone-lock.test.mts
@@ -4,19 +4,23 @@ import {
   existsSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
+  statSync,
+  utimesSync,
   writeFileSync,
 } from 'node:fs';
 import { devNull, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 
 import {
   acquireCloneLock,
   CloneLockTimeoutError,
   checkCloneLock,
+  refreshCloneLock,
   releaseCloneLock,
   resolveCloneLockPath,
   withCloneLock,
@@ -177,22 +181,27 @@ test('acquire: times out with CloneLockTimeoutError when the lock is never relea
   }
 });
 
-test('acquire: a lock older than the stale threshold is taken over rather than waited out', () => {
+function backdateLockMtime(path: string, ageMs: number): void {
+  const ancient = new Date(Date.now() - ageMs);
+  utimesSync(path, ancient, ancient);
+}
+
+test('acquire: a lock whose mtime is older than staleMs is taken over rather than waited out', () => {
   const primary = setupRepo();
   try {
     const path = resolveCloneLockPath(primary);
-    const ancientAcquiredAt = new Date(Date.now() - 10 * 60_000).toISOString();
     writeFileSync(
       path,
       JSON.stringify({
         token: 'dead-holder',
         agentId: 'agent-dead',
-        acquiredAt: ancientAcquiredAt,
+        acquiredAt: new Date().toISOString(),
       }),
     );
+    backdateLockMtime(path, 60_000);
 
     const start = Date.now();
-    const handle = acquireCloneLock(primary, 'agent-b', 5_000);
+    const handle = acquireCloneLock(primary, 'agent-b', 5_000, 200);
     const elapsedMs = Date.now() - start;
 
     assert.ok(
@@ -206,14 +215,16 @@ test('acquire: a lock older than the stale threshold is taken over rather than w
   }
 });
 
-test('acquire: a malformed lock body is waited out, not treated as immediately stale', async () => {
+test('acquire: a fresh malformed lock body is waited out, not treated as immediately stale', async () => {
   const primary = setupRepo();
   try {
     const path = resolveCloneLockPath(primary);
     writeFileSync(path, '{"unexpected": "shape"}');
+    // mtime is "now" (just written) -- well inside a generous staleMs, so
+    // this must not be taken over yet.
 
     await assert.rejects(
-      (async () => acquireCloneLock(primary, 'agent-b', 300))(),
+      (async () => acquireCloneLock(primary, 'agent-b', 300, 60_000))(),
       CloneLockTimeoutError,
     );
   } finally {
@@ -221,15 +232,256 @@ test('acquire: a malformed lock body is waited out, not treated as immediately s
   }
 });
 
-test('withCloneLock: releases even when the wrapped command fails', () => {
+test('acquire: a malformed lock body recovers once its mtime ages past staleMs (Codex P2: a crashed partial write must not wedge every waiter forever)', () => {
   const primary = setupRepo();
   try {
-    const status = withCloneLock(primary, 'agent-a', process.execPath, [
+    const path = resolveCloneLockPath(primary);
+    writeFileSync(path, '{"unexpected": "shape"}');
+    backdateLockMtime(path, 60_000);
+
+    const start = Date.now();
+    const handle = acquireCloneLock(primary, 'agent-b', 5_000, 200);
+    const elapsedMs = Date.now() - start;
+
+    assert.ok(
+      elapsedMs < 2_000,
+      `expected recovery of a stale malformed lock, took ${elapsedMs}ms`,
+    );
+    releaseCloneLock(handle);
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('refreshCloneLock: bumps mtime only when the on-disk token still matches, is a silent no-op otherwise', () => {
+  const primary = setupRepo();
+  try {
+    const handle = acquireCloneLock(primary, 'agent-a', 5_000);
+    backdateLockMtime(handle.path, 10_000);
+    const beforeMs = statSync(handle.path).mtimeMs;
+
+    refreshCloneLock(handle);
+    const afterMs = statSync(handle.path).mtimeMs;
+    assert.ok(
+      afterMs > beforeMs,
+      `expected refresh to bump mtime forward (before=${beforeMs}, after=${afterMs})`,
+    );
+
+    releaseCloneLock(handle);
+    writeFileSync(
+      handle.path,
+      JSON.stringify({
+        token: 'someone-else',
+        agentId: 'agent-b',
+        acquiredAt: new Date().toISOString(),
+      }),
+    );
+    backdateLockMtime(handle.path, 10_000);
+    const beforeOtherMs = statSync(handle.path).mtimeMs;
+    refreshCloneLock(handle);
+    const afterOtherMs = statSync(handle.path).mtimeMs;
+    assert.equal(
+      afterOtherMs,
+      beforeOtherMs,
+      "refreshing a handle whose token no longer matches must not touch another holder's lock",
+    );
+  } finally {
+    teardown(primary);
+  }
+});
+
+/**
+ * A small on-disk fixture script (not an inline `-e` string) so a child
+ * process can import the built `clone-lock.mjs` directly and call
+ * acquireCloneLock() with short, test-friendly staleMs/timeoutMs values
+ * the CLI itself intentionally does not expose (see withCloneLock's own
+ * doc comment: those overrides exist only for tests). Every contender
+ * appends `won <idx> <startMs>` and `released <idx> <endMs>` on success,
+ * or `lost <idx>` if it never acquired within its budget.
+ */
+function writeRaceFixture(dir: string): string {
+  const fixturePath = join(dir, 'stale-race-worker.mjs');
+  const cloneLockUrl = pathToFileURL(
+    join(REPO_ROOT, 'scripts/clone-lock.mjs'),
+  ).href;
+  writeFileSync(
+    fixturePath,
+    [
+      `import { acquireCloneLock, releaseCloneLock } from ${JSON.stringify(cloneLockUrl)};`,
+      "import { appendFileSync } from 'node:fs';",
+      'const repo = process.env.IDD_TEST_REPO;',
+      'const idx = process.env.IDD_TEST_IDX;',
+      'const log = process.env.IDD_TEST_LOG;',
+      'const timeoutMs = Number(process.env.IDD_TEST_TIMEOUT_MS);',
+      'const staleMs = Number(process.env.IDD_TEST_STALE_MS);',
+      'const holdMs = Number(process.env.IDD_TEST_HOLD_MS);',
+      'try {',
+      "  const handle = acquireCloneLock(repo, 'agent-' + idx, timeoutMs, staleMs);",
+      "  appendFileSync(log, 'won ' + idx + ' ' + Date.now() + '\\n');",
+      '  const until = Date.now() + holdMs;',
+      '  while (Date.now() < until) {}',
+      "  appendFileSync(log, 'released ' + idx + ' ' + Date.now() + '\\n');",
+      '  releaseCloneLock(handle);',
+      '} catch (error) {',
+      "  appendFileSync(log, 'lost ' + idx + '\\n');",
+      '}',
+    ].join('\n'),
+  );
+  return fixturePath;
+}
+
+test('acquire: a stale-lock takeover across concurrent contenders never lets two of them hold the lock at once (P1-1: unconditional rename let every racer believe it won)', async () => {
+  const primary = setupRepo();
+  const logPath = join(primary, 'stale-race.log');
+  writeFileSync(logPath, '');
+  try {
+    const path = resolveCloneLockPath(primary);
+    writeFileSync(
+      path,
+      JSON.stringify({
+        token: 'dead-holder',
+        agentId: 'agent-dead',
+        acquiredAt: new Date().toISOString(),
+      }),
+    );
+    backdateLockMtime(path, 60_000);
+
+    const fixturePath = writeRaceFixture(primary);
+    const CONTENDERS = 5;
+    await Promise.all(
+      Array.from({ length: CONTENDERS }, (_unused, index) =>
+        execFileAsync(process.execPath, [fixturePath], {
+          env: fixtureEnv({
+            IDD_TEST_REPO: primary,
+            IDD_TEST_IDX: String(index),
+            IDD_TEST_LOG: logPath,
+            // Every contender starts by racing the SAME pre-seeded stale
+            // lock -- the exact shape that let a plain check-then-unlink
+            // takeover produce more than one winner. A generous shared
+            // timeout means nobody spuriously times out from ordinary
+            // process-spawn jitter; every contender is expected to
+            // eventually acquire, one at a time.
+            IDD_TEST_TIMEOUT_MS: '10000',
+            IDD_TEST_STALE_MS: '200',
+            IDD_TEST_HOLD_MS: '150',
+          }),
+        }),
+      ),
+    );
+
+    const lines = readFileSync(logPath, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+    assert.equal(
+      lines.filter((line) => line.startsWith('lost ')).length,
+      0,
+      `expected every contender to eventually acquire, got: ${JSON.stringify(lines)}`,
+    );
+    const intervals = new Map<string, { start: number; end: number }>();
+    for (const line of lines) {
+      const [kind, idx, ts] = line.split(' ');
+      const entry = intervals.get(idx) ?? { start: 0, end: 0 };
+      if (kind === 'won') {
+        entry.start = Number(ts);
+      } else {
+        entry.end = Number(ts);
+      }
+      intervals.set(idx, entry);
+    }
+    assert.equal(intervals.size, CONTENDERS);
+    const sorted = Array.from(intervals.values()).sort(
+      (first, second) => first.start - second.start,
+    );
+    for (let index = 1; index < sorted.length; index += 1) {
+      assert.ok(
+        sorted[index].start >= sorted[index - 1].end,
+        `expected non-overlapping holds even when racing a shared stale lock, got: ${JSON.stringify(sorted)}`,
+      );
+    }
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('withCloneLock: releases even when the wrapped command fails', async () => {
+  const primary = setupRepo();
+  try {
+    const status = await withCloneLock(primary, 'agent-a', process.execPath, [
       '-e',
       'process.exit(7)',
     ]);
     assert.equal(status, 7);
     assert.equal(checkCloneLock(primary).present, false);
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('withCloneLock: runs the wrapped command with cwd set to repoPath', async () => {
+  const primary = setupRepo();
+  try {
+    const outPath = join(primary, 'cwd-observed.txt');
+    const status = await withCloneLock(primary, 'agent-a', process.execPath, [
+      '-e',
+      `require('fs').writeFileSync(${JSON.stringify(outPath)}, process.cwd())`,
+    ]);
+    assert.equal(status, 0);
+    assert.equal(
+      realpathSync(readFileSync(outPath, 'utf8')),
+      realpathSync(primary),
+    );
+  } finally {
+    teardown(primary);
+  }
+});
+
+test('withCloneLock: refreshes its lease so a long-running command is never mistaken for an abandoned holder (Codex P1: live holders must not age out)', async () => {
+  const primary = setupRepo();
+  const logPath = join(primary, 'waiter.log');
+  writeFileSync(logPath, '');
+  try {
+    // The held command "runs" for 600ms under a staleMs of only 150ms --
+    // without lease refresh, that alone would make it look abandoned.
+    // leaseRefreshMs=40 keeps refreshing well inside that window.
+    const holderPromise = withCloneLock(
+      primary,
+      'agent-holder',
+      process.execPath,
+      ['-e', 'const u=Date.now()+600;while(Date.now()<u){}'],
+      5_000,
+      150,
+      40,
+    );
+
+    // Let the holder actually acquire before the waiter starts contending.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const fixturePath = writeRaceFixture(primary);
+    await execFileAsync(process.execPath, [fixturePath], {
+      env: fixtureEnv({
+        IDD_TEST_REPO: primary,
+        IDD_TEST_IDX: 'waiter',
+        IDD_TEST_LOG: logPath,
+        // 400ms budget: longer than the remaining hold time, so if the
+        // waiter incorrectly "wins" a stale takeover mid-hold, it reports
+        // that; if it correctly keeps waiting/times out, it reports loss.
+        IDD_TEST_TIMEOUT_MS: '400',
+        IDD_TEST_STALE_MS: '150',
+        IDD_TEST_HOLD_MS: '0',
+      }),
+    });
+
+    await holderPromise;
+    const lines = readFileSync(logPath, 'utf8')
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+    assert.deepEqual(
+      lines,
+      ['lost waiter'],
+      'a live, actively-refreshing holder must never be treated as stale and taken over',
+    );
   } finally {
     teardown(primary);
   }

--- a/tests/help-text-flags.test.mts
+++ b/tests/help-text-flags.test.mts
@@ -174,6 +174,7 @@ const COVERED_HELPERS = [
   'ci-wait-state',
   'claim-approval-gate',
   'claim-lock',
+  'clone-lock',
   'token-cost-event',
   'token-cost-report',
   'discover-readiness-check',


### PR DESCRIPTION
## Summary

Adds `clone-lock.mjs`: a mutual-exclusion lock scoped to a git clone's
*shared* git-common-dir, letting concurrent sessions serialize `git
worktree add`, `git worktree remove`, and `git fetch` against the same
primary clone instead of falling back to concurrency=1 for a whole
batch. Unlike `claim-lock.mjs` (worktree-local ownership, reports a
same-machine collision immediately and never blocks), this is a
short-duration mutex: `acquireCloneLock`/the CLI's `--exec` mode block
with backoff up to a bounded timeout, then throw/exit non-zero on
timeout.

**No automatic stale-lock recovery.** The lock body records the
holder's `pid` (diagnostic only, surfaced by `--check`'s `holderAlive`
field and in the timeout error message), but a held lock is never
taken over automatically, regardless of how long it has been held or
whether that pid still appears to be alive. On timeout, the error names
the lock path and the recorded holder so a human can decide whether to
remove it by hand and retry — the same recovery git's own `index.lock`
expects on a stale-lock collision. This repository's own review history
went through three different automatic-recovery designs across
successive rounds (an elapsed-time threshold with a periodic lease
refresh; a PID-tagged arbiter lock with inode-verified recovery; a
simplified PID-liveness check with no arbiter) and each was found to
have a genuine concurrency defect by the next round — implementing a
race-free "is this holder provably gone, and can exactly one waiter
reclaim it" protocol needs a coordination primitive (a kernel-level
compare-and-swap, or a real `flock(2)`) plain POSIX file operations
don't provide. Removing automatic recovery entirely leaves the OS
kernel's own `O_EXCL` guarantee on a single `{ flag: 'wx' }` create as
the sole decision authority for who acquires the lock, which is
unconditionally race-free by construction. #2223's Acceptance Criteria
only ever required an acquire/release interface and serializing two
concurrent invocations against each other, never automatic recovery.

- `src/scripts/clone-lock.mts` (+ generated `scripts/clone-lock.mjs`):
  `acquireCloneLock`/`releaseCloneLock`/`checkCloneLock`/`withCloneLock`
  plus a CLI (`--exec --agent-id <id> [--repo] [--timeout-ms] --
  <command...>` / `--check`).
- `.github/instructions/idd-work.instructions.md` and its lite
  counterpart (both regenerated from `idd-template/`) and
  `docs/idd-workflow.md`'s Orchestrator fan-out variant:
  cross-reference the concrete command, naming every operation to
  serialize (`fetch`/`merge --ff-only`/worktree add and remove,
  including F4 cleanup's own removal) at the existing "serialize these
  operations" note.
- `docs/idd-helper-scripts.md` (+ `idd-template/` source): a
  "Clone-scoped lock" reference section, mirroring the existing
  worktree-local claim lock section's dual source-repo/npx-bin
  invocation form.

## Ratchet callout (bundle-work `limitBytes`)

`bundle-work` (`idd-overview-core` + `idd-overview-appendix` +
`idd-work`) was already at **97.98%** utilization before this change
— effectively zero headroom. Per this repo's near-ceiling policy
(`docs/policy-constants.md#bundle-budget-growth`), the default flips
to *prefer trimming over another ratchet bump* above ~95% utilization,
but that guidance is specifically protecting the always-resident
`bundle-review`/`bundle-merge` floor shared across every F-phase
session — `idd-work.instructions.md` isn't a member of either bundle,
so growing it doesn't touch that floor. Given the alternative was
hand-trimming dense, safety-critical worktree/claim-lock prose I'd
rather not risk destabilizing in this PR, I raised `bundle-work`'s
`limitBytes` in `audit/sync-manifest.json`: **45,000 → 49,500** (~10%
headroom over the new content, matching the documented convention).
Updated the two stale `docs/weak-model-lite-profile-design.md`
mentions of the old figure to match; that file's separately-stale
`bundle-review` figure (129,400 vs. the live 138,000) predates this
change and is left alone — that file already carries its own
"read live values ... rather than trusting this snapshot" disclaimer.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build:check`
- [x] `node --test tests/clone-lock.test.mts` — 14/14 pass, including a
      CLI-level concurrency test (4 real child processes racing
      `--exec`, asserting no two critical sections overlap), a
      separate-process blocking test (a genuine second process only
      acquires after the first process's explicit release), and
      coverage that a dead-pid or malformed lock is never
      auto-recovered
- [x] `node scripts/audit-docs.mjs --check` — passes (bundle-work back
      under both the 95% notice and 98% error thresholds)
- [x] `pnpm run lint:minimum` (full suite, including markdownlint/cspell)
- [x] 20 consecutive local runs of `tests/clone-lock.test.mts` (0
      failures) plus a full `node --test tests/*.test.mts` run

Closes #2223


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clone-scoped locking utility to safely serialize shared Git operations.
  * Added lock inspection, timeout diagnostics, command execution, and manual stale-lock recovery guidance.
  * Published the utility as a command-line helper.

* **Documentation**
  * Updated workflow and worker guidance for concurrent shared-clone operations.
  * Added helper usage and fallback instructions.

* **Tests**
  * Added comprehensive coverage for locking, diagnostics, concurrency, cleanup, and command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->