### PR TITLE
fix(roadmap-audit): harden branch/worktree state checks before apply

### DIFF
--- a/schemas/idd-roadmap-audit-execute.schema.json
+++ b/schemas/idd-roadmap-audit-execute.schema.json
@@ -103,6 +103,10 @@
       "type": "boolean",
       "enum": [true],
       "description": "Present (and true) only when the production viewer-login lookup (gh api user) failed for this run; absent when it succeeded."
+    },
+    "localCoordinationNote": {
+      "type": "string",
+      "description": "Present only when the local worktree/branch state check (#2225) found something worth a human's attention: a positively broken matched worktree (which also blocks the apply), or a non-blocking informational signal (a present-but-clean matched worktree, an unreadable local git state, or a repo-wide detached worktree). Absent when no local worktree exists for the branch at all."
     }
   },
   "additionalProperties": false

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -523,11 +523,15 @@ function runLocalGitCommand(argv, cwd) {
     });
     return { ok: true, stdout, stderr: '' };
   } catch (err) {
+    // `encoding: 'utf8'` above decodes the happy path, but a spawn-level
+    // failure (signal, maxBuffer) can still leave stdout/stderr as a Buffer
+    // on the thrown error — coerce via toString() (mirrors idd-doctor.mts's
+    // runCommand) rather than discarding non-string output as empty.
     const failure = err;
     return {
       ok: false,
-      stdout: typeof failure.stdout === 'string' ? failure.stdout : '',
-      stderr: typeof failure.stderr === 'string' ? failure.stderr : '',
+      stdout: failure.stdout?.toString?.() ?? '',
+      stderr: failure.stderr?.toString?.() ?? '',
     };
   }
 }
@@ -587,21 +591,28 @@ function branchNameFromRef(ref) {
   return ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref;
 }
 /**
- * Find the worktree entry whose checked-out branch content-exactly matches
- * `branchName` (#2225, AC1). Content-exact, not identity-only: this compares
- * the porcelain `branch` ref itself — what is actually checked out — rather
- * than trusting that a claim record's own `branch` field (which may be
- * released or stale) says the branch is unowned. A detached entry has no
- * `branchRef` and can never match here by construction.
+ * Find every worktree entry whose checked-out branch content-exactly
+ * matches `branchName` (#2225, AC1). Content-exact, not identity-only: this
+ * compares the porcelain `branch` ref itself — what is actually checked
+ * out — rather than trusting that a claim record's own `branch` field
+ * (which may be released or stale) says the branch is unowned. Git
+ * normally refuses to check the same branch out in a second worktree, but
+ * `git checkout --ignore-other-worktrees` (documented in `git checkout -h`)
+ * can force it, so this returns every match rather than only the first —
+ * a caller that only checks the first could see a clean worktree while a
+ * second one silently sits broken. A detached entry has no `branchRef` and
+ * can never match here by construction.
  */
-export function findWorktreeEntryForBranch(entries, branchName) {
-  return (
-    entries.find(
-      (entry) =>
-        entry.branchRef !== null &&
-        branchNameFromRef(entry.branchRef) === branchName,
-    ) ?? null
+export function findWorktreeEntriesForBranch(entries, branchName) {
+  return entries.filter(
+    (entry) =>
+      entry.branchRef !== null &&
+      branchNameFromRef(entry.branchRef) === branchName,
   );
+}
+/** The first entry {@link findWorktreeEntriesForBranch} would return, or null. */
+export function findWorktreeEntryForBranch(entries, branchName) {
+  return findWorktreeEntriesForBranch(entries, branchName)[0] ?? null;
 }
 /**
  * True when a rebase sequencer directory exists for `worktreePath` (#2225,
@@ -666,21 +677,51 @@ function resolveDetachedRebaseBranch(worktreePath, inputs) {
   return null;
 }
 /**
- * Find a DETACHED worktree entry whose rebase sequencer records `branchName`
- * as the branch being rebased (#2225, AC4). See
+ * Find every DETACHED worktree entry whose rebase sequencer records
+ * `branchName` as the branch being rebased (#2225, AC4). See
  * {@link resolveDetachedRebaseBranch} for why a plain branch-ref match on a
- * mid-rebase worktree always fails.
+ * mid-rebase worktree always fails. Plural for the same reason as
+ * {@link findWorktreeEntriesForBranch}: more than one worktree can end up
+ * mid-rebase against the same original branch.
  */
-function findDetachedRebaseEntryForBranch(entries, branchName, inputs) {
-  for (const entry of entries) {
-    if (!entry.detached) {
-      continue;
+function findDetachedRebaseEntriesForBranch(entries, branchName, inputs) {
+  return entries.filter(
+    (entry) =>
+      entry.detached &&
+      resolveDetachedRebaseBranch(entry.path, inputs) === branchName,
+  );
+}
+/**
+ * Evaluate one matched worktree entry for the broken-reason signals
+ * {@link evaluateLocalCoordinationState} reports (#2225): porcelain
+ * `locked`/`prunable` flags first (a locked/prunable entry's directory may
+ * not even exist on disk — do not probe further), then uncommitted content
+ * and an in-progress rebase.
+ */
+function evaluateMatchedWorktreeEntry(entry, inputs) {
+  const reasons = [];
+  if (entry.locked) {
+    reasons.push(`locked${entry.lockReason ? `: ${entry.lockReason}` : ''}`);
+  }
+  if (entry.prunable) {
+    reasons.push(
+      `prunable${entry.prunableReason ? `: ${entry.prunableReason}` : ''}`,
+    );
+  }
+  if (reasons.length === 0) {
+    const status = inputs.statusPorcelain(entry.path);
+    if (!status.ok) {
+      reasons.push('working tree status could not be read');
+    } else if (status.stdout.trim().length > 0) {
+      reasons.push('uncommitted content present');
     }
-    if (resolveDetachedRebaseBranch(entry.path, inputs) === branchName) {
-      return entry;
+    if (
+      hasInProgressRebase(entry.path, inputs.resolveGitPath, inputs.pathExists)
+    ) {
+      reasons.push('rebase in progress');
     }
   }
-  return null;
+  return reasons;
 }
 /**
  * Evaluate whether `branchName`'s local worktree state is safe to treat as
@@ -695,8 +736,11 @@ function findDetachedRebaseEntryForBranch(entries, branchName, inputs) {
  * branch, a failure to read ITS status is treated as broken rather than
  * unreadable: unlike the top-level enumeration failure, a positively
  * identified worktree that suddenly cannot be probed is exactly the
- * ambiguous case this hardening exists to catch, so it fails closed. Pure:
- * every git read is injected.
+ * ambiguous case this hardening exists to catch, so it fails closed. Every
+ * worktree matching `branchName` is evaluated, not just the first (#2225,
+ * P2 review finding): `git checkout --ignore-other-worktrees` can check the
+ * same branch out in more than one worktree, and a clean first match must
+ * not hide a broken second one. Pure: every git read is injected.
  */
 export function evaluateLocalCoordinationState(branchName, inputs) {
   const listing = inputs.listWorktrees();
@@ -712,17 +756,20 @@ export function evaluateLocalCoordinationState(branchName, inputs) {
     };
   }
   const entries = parseWorktreeListPorcelain(listing.stdout);
-  const matched =
-    findWorktreeEntryForBranch(entries, branchName) ??
-    findDetachedRebaseEntryForBranch(entries, branchName, inputs);
-  // A detached entry recovered via its rebase sequencer above (AC4) IS the
-  // matched worktree for this branch, not a mystery unrelated one — exclude
-  // it from the generic informational list so it is reported exactly once,
-  // as the matched (and, via the checks below, broken) worktree.
+  const matchedEntries = [
+    ...findWorktreeEntriesForBranch(entries, branchName),
+    ...findDetachedRebaseEntriesForBranch(entries, branchName, inputs),
+  ];
+  const matchedPaths = new Set(matchedEntries.map((entry) => entry.path));
+  // Every detached entry recovered via its rebase sequencer above (AC4) IS
+  // a matched worktree for this branch, not a mystery unrelated one —
+  // exclude matched paths from the generic informational list so each is
+  // reported exactly once, as a matched (and, via the checks below,
+  // possibly broken) worktree.
   const detachedWorktreePaths = entries
-    .filter((entry) => entry.detached && entry.path !== matched?.path)
+    .filter((entry) => entry.detached && !matchedPaths.has(entry.path))
     .map((entry) => entry.path);
-  if (!matched) {
+  if (matchedEntries.length === 0) {
     return {
       presence: 'absent',
       path: null,
@@ -733,38 +780,15 @@ export function evaluateLocalCoordinationState(branchName, inputs) {
     };
   }
   const brokenReasons = [];
-  if (matched.locked) {
-    brokenReasons.push(
-      `locked${matched.lockReason ? `: ${matched.lockReason}` : ''}`,
-    );
-  }
-  if (matched.prunable) {
-    brokenReasons.push(
-      `prunable${matched.prunableReason ? `: ${matched.prunableReason}` : ''}`,
-    );
-  }
-  // A locked/prunable worktree's directory may not even exist on disk
-  // (prunable in particular is exactly that case) — do not probe further.
-  if (brokenReasons.length === 0) {
-    const status = inputs.statusPorcelain(matched.path);
-    if (!status.ok) {
-      brokenReasons.push('working tree status could not be read');
-    } else if (status.stdout.trim().length > 0) {
-      brokenReasons.push('uncommitted content present');
+  matchedEntries.forEach((entry, index) => {
+    const prefix = index > 0 ? `at ${entry.path}: ` : '';
+    for (const reason of evaluateMatchedWorktreeEntry(entry, inputs)) {
+      brokenReasons.push(`${prefix}${reason}`);
     }
-    if (
-      hasInProgressRebase(
-        matched.path,
-        inputs.resolveGitPath,
-        inputs.pathExists,
-      )
-    ) {
-      brokenReasons.push('rebase in progress');
-    }
-  }
+  });
   return {
     presence: brokenReasons.length > 0 ? 'present-broken' : 'present-clean',
-    path: matched.path,
+    path: matchedEntries[0].path,
     brokenReasons,
     detachedWorktreePaths,
     unreadable: false,
@@ -843,6 +867,36 @@ export function safeHasTrustedCompletionEvidence(check) {
   } catch {
     return false;
   }
+}
+/**
+ * Apply the local coordination-state gate (#2225) at one point in the apply
+ * sequence: populate `verdict.localCoordinationNote` (and, when unsafe,
+ * `verdict.result` too), and report whether the apply must stop here.
+ * Called at every point claim ownership is re-validated below — the early
+ * check, immediately after the potentially long graph re-fetch, and
+ * immediately before the close — because local state is not immutable
+ * within a single run any more than claim ownership is: another local
+ * process can dirty, lock, prune, or begin rebasing the matched worktree
+ * while this run is still in flight (#2225, P2 review finding).
+ */
+function applyLocalCoordinationGate(resolvedDeps, branchName, verdict) {
+  if (!resolvedDeps.inspectLocalCoordinationState) {
+    return false;
+  }
+  const localState = resolvedDeps.inspectLocalCoordinationState(branchName);
+  if (localState.presence === 'present-broken') {
+    verdict.localCoordinationNote = `branch "${branchName}" has a local worktree at ${localState.path} that is not safe to treat as reusable (${localState.brokenReasons.join(', ')})`;
+    verdict.result = `local coordination state unsafe (${localState.brokenReasons.join(', ')}); no mutation`;
+    return true;
+  }
+  if (localState.unreadable) {
+    verdict.localCoordinationNote = `local coordination state unreadable (${localState.unreadableReason ?? 'unknown reason'}); proceeding`;
+  } else if (localState.presence === 'present-clean') {
+    verdict.localCoordinationNote = `branch "${branchName}" has a clean local worktree at ${localState.path}`;
+  } else if (localState.detachedWorktreePaths.length > 0) {
+    verdict.localCoordinationNote = `${localState.detachedWorktreePaths.length} detached local worktree(s) present (unrelated to this branch by definition): ${localState.detachedWorktreePaths.join(', ')}`;
+  }
+  return false;
 }
 /**
  * Build the A1.5 verdict and, under `--apply`, execute the audit. The dry-run
@@ -966,27 +1020,18 @@ export async function runRoadmapAuditExecute(argv, deps) {
     return { verdict, exitCode: 1 };
   }
   // Local worktree/branch safety (#2225): a released/stale claim record
-  // proves nothing about what is actually checked out locally. Evaluated
-  // once, right after ownership is confirmed and before ANY mutation
-  // (including the evidence comment) — local state does not change within a
-  // single run, so there is no need to repeat this at the later
-  // re-validations the way claim ownership itself is repeated.
-  if (resolvedDeps.inspectLocalCoordinationState) {
-    const localState = resolvedDeps.inspectLocalCoordinationState(
+  // proves nothing about what is actually checked out locally. Re-checked
+  // again below, after the graph re-fetch and immediately before the close
+  // — see applyLocalCoordinationGate's doc comment for why a single early
+  // check alone would leave a TOCTOU gap.
+  if (
+    applyLocalCoordinationGate(
+      resolvedDeps,
       earlyClaim.activeClaim.branch,
-    );
-    if (localState.presence === 'present-broken') {
-      verdict.localCoordinationNote = `branch "${earlyClaim.activeClaim.branch}" has a local worktree at ${localState.path} that is not safe to treat as reusable (${localState.brokenReasons.join(', ')})`;
-      verdict.result = `local coordination state unsafe (${localState.brokenReasons.join(', ')}); no mutation`;
-      return { verdict, exitCode: 1 };
-    }
-    if (localState.unreadable) {
-      verdict.localCoordinationNote = `local coordination state unreadable (${localState.unreadableReason ?? 'unknown reason'}); proceeding`;
-    } else if (localState.presence === 'present-clean') {
-      verdict.localCoordinationNote = `branch "${earlyClaim.activeClaim.branch}" has a clean local worktree at ${localState.path}`;
-    } else if (localState.detachedWorktreePaths.length > 0) {
-      verdict.localCoordinationNote = `${localState.detachedWorktreePaths.length} detached local worktree(s) present (unrelated to this branch by definition): ${localState.detachedWorktreePaths.join(', ')}`;
-    }
+      verdict,
+    )
+  ) {
+    return { verdict, exitCode: 1 };
   }
   // Re-fetch the roadmap + child state and confirm the audit input still
   // holds; a roadmap that gained an open / unresolved / nested-roadmap /
@@ -1021,6 +1066,15 @@ export async function runRoadmapAuditExecute(argv, deps) {
     verdict.result = `claim not owned immediately before mutation (reason="${claim.reason}": ${explainRoadmapClaimReason(claim.reason)}); no mutation${viewerLoginUnavailableCaveat(resolvedDeps.viewerLoginUnavailable)}`;
     return { verdict, exitCode: 1 };
   }
+  // Re-check local state too: the graph re-fetch just above can span many
+  // API calls, during which another local process can dirty, lock, prune,
+  // or begin rebasing the matched worktree just as easily as another
+  // session can take over the claim.
+  if (
+    applyLocalCoordinationGate(resolvedDeps, claim.activeClaim.branch, verdict)
+  ) {
+    return { verdict, exitCode: 1 };
+  }
   // Post the evidence comment (non-destructive), THEN re-validate ownership one
   // final time immediately before the CLOSE: a takeover landing in the
   // comment→close gap must not let us close under a claim we no longer own. An
@@ -1038,6 +1092,18 @@ export async function runRoadmapAuditExecute(argv, deps) {
   });
   if (!preCloseClaim.owned) {
     verdict.result = `claim lost in the comment→close gap (reason="${preCloseClaim.reason}": ${explainRoadmapClaimReason(preCloseClaim.reason)}); evidence comment posted but roadmap NOT closed${viewerLoginUnavailableCaveat(resolvedDeps.viewerLoginUnavailable)}`;
+    return { verdict, exitCode: 1 };
+  }
+  // One last local-state check, immediately before the close itself, for
+  // the same comment→close gap the claim re-validation just above guards.
+  if (
+    applyLocalCoordinationGate(
+      resolvedDeps,
+      preCloseClaim.activeClaim.branch,
+      verdict,
+    )
+  ) {
+    verdict.result = `${verdict.result} (evidence comment posted but roadmap NOT closed)`;
     return { verdict, exitCode: 1 };
   }
   // Ownership held through the comment: close, then release using the last

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -832,12 +832,20 @@ export function createLocalCoordinationInputs(cwd) {
     listWorktrees: () =>
       runLocalGitCommand(['worktree', 'list', '--porcelain'], cwd),
     // --untracked-files=all overrides a repo/global status.showUntrackedFiles
-    // config (review finding, #2225): without it, `no` would make an
-    // untracked-only leftover file report as clean, silently weakening this
-    // exact safety gate through user configuration this tool never chose.
+    // config, and --ignore-submodules=none overrides diff.ignoreSubmodules
+    // (both review findings, #2225): without them, `status.showUntrackedFiles
+    // = no` would hide an untracked-only leftover, and
+    // `diff.ignoreSubmodules = all` would hide a dirty submodule — either
+    // way silently weakening this exact safety gate through user
+    // configuration this tool never chose.
     statusPorcelain: (worktreePath) =>
       runLocalGitCommand(
-        ['status', '--porcelain', '--untracked-files=all'],
+        [
+          'status',
+          '--porcelain',
+          '--untracked-files=all',
+          '--ignore-submodules=none',
+        ],
         worktreePath,
       ),
     resolveGitPath: (worktreePath, name) =>

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -16,6 +16,13 @@
 // with an open / unresolved / inaccessible / nested-roadmap descendant, a
 // closed child with an open linked PR, a traversal cycle, or no explicit child
 // work is NEVER closed.
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import {
+  isAbsolute,
+  join as joinPath,
+  resolve as resolvePath,
+} from 'node:path';
 import { parseCliArgs } from './cli-args.mjs';
 import {
   buildIssueLoader,
@@ -502,6 +509,291 @@ export function explainRoadmapClaimReason(reason) {
   return CLAIM_REASON_EXPLANATIONS[reason] ?? UNKNOWN_CLAIM_REASON_EXPLANATION;
 }
 /**
+ * Run `git <argv>` in `cwd`, capturing stdout/stderr without throwing
+ * (#2225). A local, file-scoped port of idd-doctor.mts's `runCommand` —
+ * not extracted to a shared module because idd-doctor.mts is outside this
+ * issue's candidate-files list.
+ */
+function runLocalGitCommand(argv, cwd) {
+  try {
+    const stdout = execFileSync('git', argv, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { ok: true, stdout, stderr: '' };
+  } catch (err) {
+    const failure = err;
+    return {
+      ok: false,
+      stdout: typeof failure.stdout === 'string' ? failure.stdout : '',
+      stderr: typeof failure.stderr === 'string' ? failure.stderr : '',
+    };
+  }
+}
+/**
+ * Parse `git worktree list --porcelain` output into structured entries
+ * (#2225, AC3). Porcelain is the only enumeration this repo can rely on to
+ * surface a detached worktree at all: a branch-name grep (the previous
+ * approach) has nothing to match against, since a detached worktree carries
+ * no branch. Stanzas are separated by a blank line; each starts with a
+ * `worktree <path>` line. Malformed or empty input yields an empty array
+ * rather than throwing.
+ */
+export function parseWorktreeListPorcelain(output) {
+  const entries = [];
+  for (const stanza of output.split(/\r?\n\r?\n/)) {
+    const lines = stanza.split(/\r?\n/).filter((line) => line.length > 0);
+    const worktreeLine = lines.find((line) => line.startsWith('worktree '));
+    if (!worktreeLine) {
+      continue;
+    }
+    const entry = {
+      path: worktreeLine.slice('worktree '.length).trim(),
+      headSha: null,
+      branchRef: null,
+      bare: false,
+      detached: false,
+      locked: false,
+      lockReason: null,
+      prunable: false,
+      prunableReason: null,
+    };
+    for (const line of lines) {
+      if (line.startsWith('HEAD ')) {
+        entry.headSha = line.slice('HEAD '.length).trim();
+      } else if (line.startsWith('branch ')) {
+        entry.branchRef = line.slice('branch '.length).trim();
+      } else if (line === 'bare') {
+        entry.bare = true;
+      } else if (line === 'detached') {
+        entry.detached = true;
+      } else if (line === 'locked' || line.startsWith('locked ')) {
+        entry.locked = true;
+        const reason = line.slice('locked'.length).trim();
+        entry.lockReason = reason.length > 0 ? reason : null;
+      } else if (line === 'prunable' || line.startsWith('prunable ')) {
+        entry.prunable = true;
+        const reason = line.slice('prunable'.length).trim();
+        entry.prunableReason = reason.length > 0 ? reason : null;
+      }
+    }
+    entries.push(entry);
+  }
+  return entries;
+}
+/** `refs/heads/main` -> `main`; a non-branch ref passes through unchanged. */
+function branchNameFromRef(ref) {
+  return ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref;
+}
+/**
+ * Find the worktree entry whose checked-out branch content-exactly matches
+ * `branchName` (#2225, AC1). Content-exact, not identity-only: this compares
+ * the porcelain `branch` ref itself — what is actually checked out — rather
+ * than trusting that a claim record's own `branch` field (which may be
+ * released or stale) says the branch is unowned. A detached entry has no
+ * `branchRef` and can never match here by construction.
+ */
+export function findWorktreeEntryForBranch(entries, branchName) {
+  return (
+    entries.find(
+      (entry) =>
+        entry.branchRef !== null &&
+        branchNameFromRef(entry.branchRef) === branchName,
+    ) ?? null
+  );
+}
+/**
+ * True when a rebase sequencer directory exists for `worktreePath` (#2225,
+ * AC4), resolved via `git -C <worktreePath> rev-parse --git-path <name>`
+ * rather than a hardcoded `.git/rebase-merge` / `.git/rebase-apply` path. A
+ * linked worktree's `.git` is a pointer FILE, not a directory: the real
+ * sequencer state lives under the primary repo's
+ * `.git/worktrees/<name>/` admin directory, and only `--git-path` resolves
+ * that correctly for a worktree other than the primary one.
+ */
+function hasInProgressRebase(worktreePath, resolveGitPath, pathExists) {
+  for (const name of ['rebase-merge', 'rebase-apply']) {
+    const result = resolveGitPath(worktreePath, name);
+    if (!result.ok) {
+      continue;
+    }
+    const resolved = result.stdout.trim();
+    if (resolved.length === 0) {
+      continue;
+    }
+    const absolute = isAbsolute(resolved)
+      ? resolved
+      : resolvePath(worktreePath, resolved);
+    if (pathExists(absolute)) {
+      return true;
+    }
+  }
+  return false;
+}
+/**
+ * Resolve the ORIGINAL branch a detached, mid-rebase worktree was checked
+ * out on (#2225, AC4). `git rebase` detaches HEAD while it sequences — a
+ * mid-rebase worktree reports `detached` in `git worktree list --porcelain`,
+ * not its real branch (empirically confirmed) — so
+ * {@link findWorktreeEntryForBranch} alone can never match it. The rebase
+ * sequencer's own `head-name` file records the original ref for exactly
+ * this reason (`git rebase --abort` restores it from there), so this reads
+ * it directly via the same resolved `--git-path` used by
+ * {@link hasInProgressRebase}.
+ */
+function resolveDetachedRebaseBranch(worktreePath, inputs) {
+  for (const name of ['rebase-merge', 'rebase-apply']) {
+    const result = inputs.resolveGitPath(worktreePath, name);
+    if (!result.ok) {
+      continue;
+    }
+    const resolved = result.stdout.trim();
+    if (resolved.length === 0) {
+      continue;
+    }
+    const absolute = isAbsolute(resolved)
+      ? resolved
+      : resolvePath(worktreePath, resolved);
+    if (!inputs.pathExists(absolute)) {
+      continue;
+    }
+    const headName = inputs.readFile(joinPath(absolute, 'head-name'));
+    if (headName && headName.trim().length > 0) {
+      return branchNameFromRef(headName.trim());
+    }
+  }
+  return null;
+}
+/**
+ * Find a DETACHED worktree entry whose rebase sequencer records `branchName`
+ * as the branch being rebased (#2225, AC4). See
+ * {@link resolveDetachedRebaseBranch} for why a plain branch-ref match on a
+ * mid-rebase worktree always fails.
+ */
+function findDetachedRebaseEntryForBranch(entries, branchName, inputs) {
+  for (const entry of entries) {
+    if (!entry.detached) {
+      continue;
+    }
+    if (resolveDetachedRebaseBranch(entry.path, inputs) === branchName) {
+      return entry;
+    }
+  }
+  return null;
+}
+/**
+ * Evaluate whether `branchName`'s local worktree state is safe to treat as
+ * reusable/reclaimable (#2225). `presence: 'absent'` — no local worktree at
+ * all — is the expected common case per the instructions text quoted above,
+ * not an error, and is treated identically to `unreadable: true` (git
+ * missing, not a repository, or any other enumeration failure): both fail
+ * OPEN, because the hazard these checks exist to catch is leftover LOCAL
+ * content, which cannot exist if there is no local state to read. Only a
+ * POSITIVELY confirmed unsafe worktree — dirty, locked, prunable, or
+ * mid-rebase — reports `present-broken`. Once a worktree is matched by
+ * branch, a failure to read ITS status is treated as broken rather than
+ * unreadable: unlike the top-level enumeration failure, a positively
+ * identified worktree that suddenly cannot be probed is exactly the
+ * ambiguous case this hardening exists to catch, so it fails closed. Pure:
+ * every git read is injected.
+ */
+export function evaluateLocalCoordinationState(branchName, inputs) {
+  const listing = inputs.listWorktrees();
+  if (!listing.ok) {
+    return {
+      presence: 'absent',
+      path: null,
+      brokenReasons: [],
+      detachedWorktreePaths: [],
+      unreadable: true,
+      unreadableReason:
+        listing.stderr || 'git worktree list --porcelain failed',
+    };
+  }
+  const entries = parseWorktreeListPorcelain(listing.stdout);
+  const matched =
+    findWorktreeEntryForBranch(entries, branchName) ??
+    findDetachedRebaseEntryForBranch(entries, branchName, inputs);
+  // A detached entry recovered via its rebase sequencer above (AC4) IS the
+  // matched worktree for this branch, not a mystery unrelated one — exclude
+  // it from the generic informational list so it is reported exactly once,
+  // as the matched (and, via the checks below, broken) worktree.
+  const detachedWorktreePaths = entries
+    .filter((entry) => entry.detached && entry.path !== matched?.path)
+    .map((entry) => entry.path);
+  if (!matched) {
+    return {
+      presence: 'absent',
+      path: null,
+      brokenReasons: [],
+      detachedWorktreePaths,
+      unreadable: false,
+      unreadableReason: null,
+    };
+  }
+  const brokenReasons = [];
+  if (matched.locked) {
+    brokenReasons.push(
+      `locked${matched.lockReason ? `: ${matched.lockReason}` : ''}`,
+    );
+  }
+  if (matched.prunable) {
+    brokenReasons.push(
+      `prunable${matched.prunableReason ? `: ${matched.prunableReason}` : ''}`,
+    );
+  }
+  // A locked/prunable worktree's directory may not even exist on disk
+  // (prunable in particular is exactly that case) — do not probe further.
+  if (brokenReasons.length === 0) {
+    const status = inputs.statusPorcelain(matched.path);
+    if (!status.ok) {
+      brokenReasons.push('working tree status could not be read');
+    } else if (status.stdout.trim().length > 0) {
+      brokenReasons.push('uncommitted content present');
+    }
+    if (
+      hasInProgressRebase(
+        matched.path,
+        inputs.resolveGitPath,
+        inputs.pathExists,
+      )
+    ) {
+      brokenReasons.push('rebase in progress');
+    }
+  }
+  return {
+    presence: brokenReasons.length > 0 ? 'present-broken' : 'present-clean',
+    path: matched.path,
+    brokenReasons,
+    detachedWorktreePaths,
+    unreadable: false,
+    unreadableReason: null,
+  };
+}
+/**
+ * Production {@link LocalCoordinationInputs}: local git shell-outs scoped to
+ * `cwd` (#2225).
+ */
+function createLocalCoordinationInputs(cwd) {
+  return {
+    listWorktrees: () =>
+      runLocalGitCommand(['worktree', 'list', '--porcelain'], cwd),
+    statusPorcelain: (worktreePath) =>
+      runLocalGitCommand(['status', '--porcelain'], worktreePath),
+    resolveGitPath: (worktreePath, name) =>
+      runLocalGitCommand(['rev-parse', '--git-path', name], worktreePath),
+    pathExists: (path) => existsSync(path),
+    readFile: (path) => {
+      try {
+        return readFileSync(path, 'utf8');
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+/**
  * Trailing caveat appended to a claim-not-owned `result` message when the
  * production viewer-login lookup failed (#1396). Empty string when the
  * lookup succeeded (or was never attempted, e.g. injected test deps), so the
@@ -672,6 +964,29 @@ export async function runRoadmapAuditExecute(argv, deps) {
     }
     verdict.result = `claim not owned on re-validation (reason="${earlyClaim.reason}": ${explainRoadmapClaimReason(earlyClaim.reason)}); no mutation${viewerLoginUnavailableCaveat(resolvedDeps.viewerLoginUnavailable)}`;
     return { verdict, exitCode: 1 };
+  }
+  // Local worktree/branch safety (#2225): a released/stale claim record
+  // proves nothing about what is actually checked out locally. Evaluated
+  // once, right after ownership is confirmed and before ANY mutation
+  // (including the evidence comment) — local state does not change within a
+  // single run, so there is no need to repeat this at the later
+  // re-validations the way claim ownership itself is repeated.
+  if (resolvedDeps.inspectLocalCoordinationState) {
+    const localState = resolvedDeps.inspectLocalCoordinationState(
+      earlyClaim.activeClaim.branch,
+    );
+    if (localState.presence === 'present-broken') {
+      verdict.localCoordinationNote = `branch "${earlyClaim.activeClaim.branch}" has a local worktree at ${localState.path} that is not safe to treat as reusable (${localState.brokenReasons.join(', ')})`;
+      verdict.result = `local coordination state unsafe (${localState.brokenReasons.join(', ')}); no mutation`;
+      return { verdict, exitCode: 1 };
+    }
+    if (localState.unreadable) {
+      verdict.localCoordinationNote = `local coordination state unreadable (${localState.unreadableReason ?? 'unknown reason'}); proceeding`;
+    } else if (localState.presence === 'present-clean') {
+      verdict.localCoordinationNote = `branch "${earlyClaim.activeClaim.branch}" has a clean local worktree at ${localState.path}`;
+    } else if (localState.detachedWorktreePaths.length > 0) {
+      verdict.localCoordinationNote = `${localState.detachedWorktreePaths.length} detached local worktree(s) present (unrelated to this branch by definition): ${localState.detachedWorktreePaths.join(', ')}`;
+    }
   }
   // Re-fetch the roadmap + child state and confirm the audit input still
   // holds; a roadmap that gained an open / unresolved / nested-roadmap /
@@ -906,6 +1221,11 @@ function createProductionDeps(args) {
     // Honor a caller-supplied --now (deterministic staleness + release
     // timestamps for tests / replays); fall back to the wall clock.
     now: () => args.now || new Date().toISOString(),
+    inspectLocalCoordinationState: (branchName) =>
+      evaluateLocalCoordinationState(
+        branchName,
+        createLocalCoordinationInputs(process.cwd()),
+      ),
   };
 }
 /**

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -562,18 +562,24 @@ function runLocalGitCommand(argv, cwd) {
   }
 }
 /**
- * Parse `git worktree list --porcelain` output into structured entries
+ * Parse `git worktree list --porcelain -z` output into structured entries
  * (#2225, AC3). Porcelain is the only enumeration this repo can rely on to
  * surface a detached worktree at all: a branch-name grep (the previous
  * approach) has nothing to match against, since a detached worktree carries
- * no branch. Stanzas are separated by a blank line; each starts with a
- * `worktree <path>` line. Malformed or empty input yields an empty array
- * rather than throwing.
+ * no branch. `-z` (NUL-delimited fields, a record terminated by an extra
+ * NUL) is required, not merely accepted (review finding, #2225): the plain
+ * newline-delimited form has no way to distinguish a literal newline inside
+ * a worktree path from the blank line that separates records, so a path
+ * containing `\n\n` would silently corrupt the stanza split and hide
+ * exactly the branch this hardening exists to protect — empirically
+ * reproduced with a real dirty linked worktree at such a path. A NUL byte
+ * cannot appear in a path at all, so this ambiguity does not exist for `-z`.
+ * Malformed or empty input yields an empty array rather than throwing.
  */
 export function parseWorktreeListPorcelain(output) {
   const entries = [];
-  for (const stanza of output.split(/\r?\n\r?\n/)) {
-    const lines = stanza.split(/\r?\n/).filter((line) => line.length > 0);
+  for (const stanza of output.split('\0\0')) {
+    const lines = stanza.split('\0').filter((line) => line.length > 0);
     const worktreeLine = lines.find((line) => line.startsWith('worktree '));
     if (!worktreeLine) {
       continue;
@@ -830,7 +836,7 @@ export function evaluateLocalCoordinationState(branchName, inputs) {
 export function createLocalCoordinationInputs(cwd) {
   return {
     listWorktrees: () =>
-      runLocalGitCommand(['worktree', 'list', '--porcelain'], cwd),
+      runLocalGitCommand(['worktree', 'list', '--porcelain', '-z'], cwd),
     // --untracked-files=all overrides a repo/global status.showUntrackedFiles
     // config, and --ignore-submodules=none overrides diff.ignoreSubmodules
     // (both review findings, #2225): without them, `status.showUntrackedFiles

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -554,10 +554,17 @@ function runLocalGitCommand(argv, cwd) {
     // on the thrown error — coerce via toString() (mirrors idd-doctor.mts's
     // runCommand) rather than discarding non-string output as empty.
     const failure = err;
+    // A failure BEFORE git could even emit stderr (e.g. ENOENT for a
+    // missing `git` binary) leaves stdout/stderr empty (review finding,
+    // #2225): fall back to the thrown error's own message so
+    // unreadableReason stays actionable instead of a generic "failed".
+    const stderr =
+      failure.stderr?.toString?.() ||
+      (typeof failure.message === 'string' ? failure.message : '');
     return {
       ok: false,
       stdout: failure.stdout?.toString?.() ?? '',
-      stderr: failure.stderr?.toString?.() ?? '',
+      stderr,
     };
   }
 }
@@ -585,7 +592,11 @@ export function parseWorktreeListPorcelain(output) {
       continue;
     }
     const entry = {
-      path: worktreeLine.slice('worktree '.length).trim(),
+      // No .trim() here (review finding, #2225): -z's NUL delimiter already
+      // gives the field's exact bytes, and a path can legitimately end in
+      // whitespace — trimming would silently point every downstream check
+      // at a directory that does not exist.
+      path: worktreeLine.slice('worktree '.length),
       headSha: null,
       branchRef: null,
       bare: false,

--- a/scripts/idd-roadmap-audit-execute.mjs
+++ b/scripts/idd-roadmap-audit-execute.mjs
@@ -509,6 +509,31 @@ export function explainRoadmapClaimReason(reason) {
   return CLAIM_REASON_EXPLANATIONS[reason] ?? UNKNOWN_CLAIM_REASON_EXPLANATION;
 }
 /**
+ * Keep repository discovery tied to the requested `cwd` rather than to
+ * ambient Git overrides inherited from a hook, wrapper, or parent process
+ * (#2225, review finding). Without this, an inherited `GIT_DIR`/
+ * `GIT_WORK_TREE`/`GIT_INDEX_FILE`/`GIT_COMMON_DIR` could silently redirect
+ * every check onto the wrong repository, defeating the safety gate
+ * entirely. A local, file-scoped port of claim-lock.mts's
+ * `sanitizedGitEnvironment` — not imported because that function is not
+ * exported there, and claim-lock.mts is outside this issue's
+ * candidate-files list.
+ */
+function sanitizedGitEnvironment() {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('GIT_CONFIG')) {
+      delete env[key];
+    }
+  }
+  delete env.GIT_DIR;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_COMMON_DIR;
+  delete env.GIT_OBJECT_DIRECTORY;
+  return env;
+}
+/**
  * Run `git <argv>` in `cwd`, capturing stdout/stderr without throwing
  * (#2225). A local, file-scoped port of idd-doctor.mts's `runCommand` —
  * not extracted to a shared module because idd-doctor.mts is outside this
@@ -518,6 +543,7 @@ function runLocalGitCommand(argv, cwd) {
   try {
     const stdout = execFileSync('git', argv, {
       cwd,
+      env: sanitizedGitEnvironment(),
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -797,14 +823,23 @@ export function evaluateLocalCoordinationState(branchName, inputs) {
 }
 /**
  * Production {@link LocalCoordinationInputs}: local git shell-outs scoped to
- * `cwd` (#2225).
+ * `cwd` (#2225). Exported so tests can exercise the real git-backed wiring
+ * (env sanitization, untracked-file handling) against a throwaway
+ * repository, not just a hand-rolled duplicate of it.
  */
-function createLocalCoordinationInputs(cwd) {
+export function createLocalCoordinationInputs(cwd) {
   return {
     listWorktrees: () =>
       runLocalGitCommand(['worktree', 'list', '--porcelain'], cwd),
+    // --untracked-files=all overrides a repo/global status.showUntrackedFiles
+    // config (review finding, #2225): without it, `no` would make an
+    // untracked-only leftover file report as clean, silently weakening this
+    // exact safety gate through user configuration this tool never chose.
     statusPorcelain: (worktreePath) =>
-      runLocalGitCommand(['status', '--porcelain'], worktreePath),
+      runLocalGitCommand(
+        ['status', '--porcelain', '--untracked-files=all'],
+        worktreePath,
+      ),
     resolveGitPath: (worktreePath, name) =>
       runLocalGitCommand(['rev-parse', '--git-path', name], worktreePath),
     pathExists: (path) => existsSync(path),

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -741,13 +741,21 @@ function runLocalGitCommand(
     // on the thrown error — coerce via toString() (mirrors idd-doctor.mts's
     // runCommand) rather than discarding non-string output as empty.
     const failure = err as {
+      message?: unknown;
       stdout?: { toString?: () => string };
       stderr?: { toString?: () => string };
     };
+    // A failure BEFORE git could even emit stderr (e.g. ENOENT for a
+    // missing `git` binary) leaves stdout/stderr empty (review finding,
+    // #2225): fall back to the thrown error's own message so
+    // unreadableReason stays actionable instead of a generic "failed".
+    const stderr =
+      failure.stderr?.toString?.() ||
+      (typeof failure.message === 'string' ? failure.message : '');
     return {
       ok: false,
       stdout: failure.stdout?.toString?.() ?? '',
-      stderr: failure.stderr?.toString?.() ?? '',
+      stderr,
     };
   }
 }
@@ -792,7 +800,11 @@ export function parseWorktreeListPorcelain(
       continue;
     }
     const entry: WorktreeListEntry = {
-      path: worktreeLine.slice('worktree '.length).trim(),
+      // No .trim() here (review finding, #2225): -z's NUL delimiter already
+      // gives the field's exact bytes, and a path can legitimately end in
+      // whitespace — trimming would silently point every downstream check
+      // at a directory that does not exist.
+      path: worktreeLine.slice('worktree '.length),
       headSha: null,
       branchRef: null,
       bare: false,

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -1129,12 +1129,20 @@ export function createLocalCoordinationInputs(
     listWorktrees: () =>
       runLocalGitCommand(['worktree', 'list', '--porcelain'], cwd),
     // --untracked-files=all overrides a repo/global status.showUntrackedFiles
-    // config (review finding, #2225): without it, `no` would make an
-    // untracked-only leftover file report as clean, silently weakening this
-    // exact safety gate through user configuration this tool never chose.
+    // config, and --ignore-submodules=none overrides diff.ignoreSubmodules
+    // (both review findings, #2225): without them, `status.showUntrackedFiles
+    // = no` would hide an untracked-only leftover, and
+    // `diff.ignoreSubmodules = all` would hide a dirty submodule — either
+    // way silently weakening this exact safety gate through user
+    // configuration this tool never chose.
     statusPorcelain: (worktreePath) =>
       runLocalGitCommand(
-        ['status', '--porcelain', '--untracked-files=all'],
+        [
+          'status',
+          '--porcelain',
+          '--untracked-files=all',
+          '--ignore-submodules=none',
+        ],
         worktreePath,
       ),
     resolveGitPath: (worktreePath, name) =>

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -17,6 +17,14 @@
 // closed child with an open linked PR, a traversal cycle, or no explicit child
 // work is NEVER closed.
 
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import {
+  isAbsolute,
+  join as joinPath,
+  resolve as resolvePath,
+} from 'node:path';
+
 import { parseCliArgs } from './cli-args.mts';
 import {
   buildIssueLoader,
@@ -119,6 +127,17 @@ export interface IddRoadmapAuditExecuteVerdict {
    * this flag as inconclusive rather than a confirmed claim loss.
    */
   viewerLoginUnavailable?: true;
+  /**
+   * Set only when {@link evaluateLocalCoordinationState} found something
+   * worth a human's attention (#2225): a positively broken matched
+   * worktree (which also blocks the apply), or a non-blocking
+   * informational signal (a present-but-clean matched worktree, an
+   * unreadable local git state, or a repo-wide detached worktree). Absent
+   * in the common case — no local worktree exists for the branch at all —
+   * so the common healthy-path JSON stays byte-identical to before this
+   * field existed.
+   */
+  localCoordinationNote?: string;
 }
 
 /** Outcome of re-validating the roadmap-audit claim before any mutation. */
@@ -649,6 +668,409 @@ export function explainRoadmapClaimReason(reason: string): string {
   return CLAIM_REASON_EXPLANATIONS[reason] ?? UNKNOWN_CLAIM_REASON_EXPLANATION;
 }
 
+// ---------------------------------------------------------------------------
+// Local coordination-state hardening (#2225).
+//
+// `evaluateRoadmapClaim` above proves who owns the CLAIM RECORD; it says
+// nothing about what is actually sitting on disk under the claimed
+// `roadmap-audit/<n>-…` branch. Per idd-roadmap-audit.instructions.md, that
+// branch field "is a logical coordination name, not a work branch, and it
+// does not require creating a branch or worktree unless the audit also
+// needs git changes" — so the expected common case is that NO local
+// worktree exists for it at all. These checks exist for the exceptional
+// case where one does, and it was left behind broken (dirty, locked,
+// prunable, or mid-rebase) by a previous session: treating a
+// released/stale claim record as proof the branch is safely reusable
+// misses exactly that leftover local content.
+// ---------------------------------------------------------------------------
+
+/** Structured result of a local git shell-out (#2225): never throws. */
+interface LocalGitCommandResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Run `git <argv>` in `cwd`, capturing stdout/stderr without throwing
+ * (#2225). A local, file-scoped port of idd-doctor.mts's `runCommand` —
+ * not extracted to a shared module because idd-doctor.mts is outside this
+ * issue's candidate-files list.
+ */
+function runLocalGitCommand(
+  argv: string[],
+  cwd: string,
+): LocalGitCommandResult {
+  try {
+    const stdout = execFileSync('git', argv, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { ok: true, stdout, stderr: '' };
+  } catch (err) {
+    const failure = err as { stdout?: unknown; stderr?: unknown };
+    return {
+      ok: false,
+      stdout: typeof failure.stdout === 'string' ? failure.stdout : '',
+      stderr: typeof failure.stderr === 'string' ? failure.stderr : '',
+    };
+  }
+}
+
+/** One `git worktree list --porcelain` stanza (#2225). */
+export interface WorktreeListEntry {
+  path: string;
+  headSha: string | null;
+  /** `refs/heads/<name>`; null for a detached or bare entry. */
+  branchRef: string | null;
+  bare: boolean;
+  detached: boolean;
+  locked: boolean;
+  lockReason: string | null;
+  prunable: boolean;
+  prunableReason: string | null;
+}
+
+/**
+ * Parse `git worktree list --porcelain` output into structured entries
+ * (#2225, AC3). Porcelain is the only enumeration this repo can rely on to
+ * surface a detached worktree at all: a branch-name grep (the previous
+ * approach) has nothing to match against, since a detached worktree carries
+ * no branch. Stanzas are separated by a blank line; each starts with a
+ * `worktree <path>` line. Malformed or empty input yields an empty array
+ * rather than throwing.
+ */
+export function parseWorktreeListPorcelain(
+  output: string,
+): WorktreeListEntry[] {
+  const entries: WorktreeListEntry[] = [];
+  for (const stanza of output.split(/\r?\n\r?\n/)) {
+    const lines = stanza.split(/\r?\n/).filter((line) => line.length > 0);
+    const worktreeLine = lines.find((line) => line.startsWith('worktree '));
+    if (!worktreeLine) {
+      continue;
+    }
+    const entry: WorktreeListEntry = {
+      path: worktreeLine.slice('worktree '.length).trim(),
+      headSha: null,
+      branchRef: null,
+      bare: false,
+      detached: false,
+      locked: false,
+      lockReason: null,
+      prunable: false,
+      prunableReason: null,
+    };
+    for (const line of lines) {
+      if (line.startsWith('HEAD ')) {
+        entry.headSha = line.slice('HEAD '.length).trim();
+      } else if (line.startsWith('branch ')) {
+        entry.branchRef = line.slice('branch '.length).trim();
+      } else if (line === 'bare') {
+        entry.bare = true;
+      } else if (line === 'detached') {
+        entry.detached = true;
+      } else if (line === 'locked' || line.startsWith('locked ')) {
+        entry.locked = true;
+        const reason = line.slice('locked'.length).trim();
+        entry.lockReason = reason.length > 0 ? reason : null;
+      } else if (line === 'prunable' || line.startsWith('prunable ')) {
+        entry.prunable = true;
+        const reason = line.slice('prunable'.length).trim();
+        entry.prunableReason = reason.length > 0 ? reason : null;
+      }
+    }
+    entries.push(entry);
+  }
+  return entries;
+}
+
+/** `refs/heads/main` -> `main`; a non-branch ref passes through unchanged. */
+function branchNameFromRef(ref: string): string {
+  return ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref;
+}
+
+/**
+ * Find the worktree entry whose checked-out branch content-exactly matches
+ * `branchName` (#2225, AC1). Content-exact, not identity-only: this compares
+ * the porcelain `branch` ref itself — what is actually checked out — rather
+ * than trusting that a claim record's own `branch` field (which may be
+ * released or stale) says the branch is unowned. A detached entry has no
+ * `branchRef` and can never match here by construction.
+ */
+export function findWorktreeEntryForBranch(
+  entries: readonly WorktreeListEntry[],
+  branchName: string,
+): WorktreeListEntry | null {
+  return (
+    entries.find(
+      (entry) =>
+        entry.branchRef !== null &&
+        branchNameFromRef(entry.branchRef) === branchName,
+    ) ?? null
+  );
+}
+
+/**
+ * True when a rebase sequencer directory exists for `worktreePath` (#2225,
+ * AC4), resolved via `git -C <worktreePath> rev-parse --git-path <name>`
+ * rather than a hardcoded `.git/rebase-merge` / `.git/rebase-apply` path. A
+ * linked worktree's `.git` is a pointer FILE, not a directory: the real
+ * sequencer state lives under the primary repo's
+ * `.git/worktrees/<name>/` admin directory, and only `--git-path` resolves
+ * that correctly for a worktree other than the primary one.
+ */
+function hasInProgressRebase(
+  worktreePath: string,
+  resolveGitPath: (
+    worktreePath: string,
+    name: 'rebase-merge' | 'rebase-apply',
+  ) => LocalGitCommandResult,
+  pathExists: (path: string) => boolean,
+): boolean {
+  for (const name of ['rebase-merge', 'rebase-apply'] as const) {
+    const result = resolveGitPath(worktreePath, name);
+    if (!result.ok) {
+      continue;
+    }
+    const resolved = result.stdout.trim();
+    if (resolved.length === 0) {
+      continue;
+    }
+    const absolute = isAbsolute(resolved)
+      ? resolved
+      : resolvePath(worktreePath, resolved);
+    if (pathExists(absolute)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Distinct presence outcomes a local coordination-state check can report. */
+export type LocalCoordinationPresence =
+  | 'absent'
+  | 'present-clean'
+  | 'present-broken';
+
+/** Outcome of {@link evaluateLocalCoordinationState}. */
+export interface LocalCoordinationVerdict {
+  presence: LocalCoordinationPresence;
+  /** The matched worktree's path; null when `presence` is `absent`. */
+  path: string | null;
+  /** Populated only when `presence` is `present-broken`. */
+  brokenReasons: string[];
+  /**
+   * Detached worktree paths found while enumerating (#2225, AC3), OTHER
+   * than the matched worktree itself. A detached entry whose rebase
+   * sequencer records `branchName` (see
+   * {@link resolveDetachedRebaseBranch}) is reported as the matched
+   * worktree instead, and blocks like any other match; every remaining
+   * detached entry cannot be tied to any branch at all and is
+   * informational only.
+   */
+  detachedWorktreePaths: string[];
+  /** True when local git state could not be read at all (no git, not a repo). */
+  unreadable: boolean;
+  unreadableReason: string | null;
+}
+
+/** Injected git reads for {@link evaluateLocalCoordinationState}; keeps it pure and unit-testable without a real repository. */
+export interface LocalCoordinationInputs {
+  listWorktrees: () => LocalGitCommandResult;
+  statusPorcelain: (worktreePath: string) => LocalGitCommandResult;
+  resolveGitPath: (
+    worktreePath: string,
+    name: 'rebase-merge' | 'rebase-apply',
+  ) => LocalGitCommandResult;
+  pathExists: (path: string) => boolean;
+  /** Read a file's content, or null when it does not exist / cannot be read. */
+  readFile: (path: string) => string | null;
+}
+
+/**
+ * Resolve the ORIGINAL branch a detached, mid-rebase worktree was checked
+ * out on (#2225, AC4). `git rebase` detaches HEAD while it sequences — a
+ * mid-rebase worktree reports `detached` in `git worktree list --porcelain`,
+ * not its real branch (empirically confirmed) — so
+ * {@link findWorktreeEntryForBranch} alone can never match it. The rebase
+ * sequencer's own `head-name` file records the original ref for exactly
+ * this reason (`git rebase --abort` restores it from there), so this reads
+ * it directly via the same resolved `--git-path` used by
+ * {@link hasInProgressRebase}.
+ */
+function resolveDetachedRebaseBranch(
+  worktreePath: string,
+  inputs: Pick<
+    LocalCoordinationInputs,
+    'resolveGitPath' | 'pathExists' | 'readFile'
+  >,
+): string | null {
+  for (const name of ['rebase-merge', 'rebase-apply'] as const) {
+    const result = inputs.resolveGitPath(worktreePath, name);
+    if (!result.ok) {
+      continue;
+    }
+    const resolved = result.stdout.trim();
+    if (resolved.length === 0) {
+      continue;
+    }
+    const absolute = isAbsolute(resolved)
+      ? resolved
+      : resolvePath(worktreePath, resolved);
+    if (!inputs.pathExists(absolute)) {
+      continue;
+    }
+    const headName = inputs.readFile(joinPath(absolute, 'head-name'));
+    if (headName && headName.trim().length > 0) {
+      return branchNameFromRef(headName.trim());
+    }
+  }
+  return null;
+}
+
+/**
+ * Find a DETACHED worktree entry whose rebase sequencer records `branchName`
+ * as the branch being rebased (#2225, AC4). See
+ * {@link resolveDetachedRebaseBranch} for why a plain branch-ref match on a
+ * mid-rebase worktree always fails.
+ */
+function findDetachedRebaseEntryForBranch(
+  entries: readonly WorktreeListEntry[],
+  branchName: string,
+  inputs: Pick<
+    LocalCoordinationInputs,
+    'resolveGitPath' | 'pathExists' | 'readFile'
+  >,
+): WorktreeListEntry | null {
+  for (const entry of entries) {
+    if (!entry.detached) {
+      continue;
+    }
+    if (resolveDetachedRebaseBranch(entry.path, inputs) === branchName) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+/**
+ * Evaluate whether `branchName`'s local worktree state is safe to treat as
+ * reusable/reclaimable (#2225). `presence: 'absent'` — no local worktree at
+ * all — is the expected common case per the instructions text quoted above,
+ * not an error, and is treated identically to `unreadable: true` (git
+ * missing, not a repository, or any other enumeration failure): both fail
+ * OPEN, because the hazard these checks exist to catch is leftover LOCAL
+ * content, which cannot exist if there is no local state to read. Only a
+ * POSITIVELY confirmed unsafe worktree — dirty, locked, prunable, or
+ * mid-rebase — reports `present-broken`. Once a worktree is matched by
+ * branch, a failure to read ITS status is treated as broken rather than
+ * unreadable: unlike the top-level enumeration failure, a positively
+ * identified worktree that suddenly cannot be probed is exactly the
+ * ambiguous case this hardening exists to catch, so it fails closed. Pure:
+ * every git read is injected.
+ */
+export function evaluateLocalCoordinationState(
+  branchName: string,
+  inputs: LocalCoordinationInputs,
+): LocalCoordinationVerdict {
+  const listing = inputs.listWorktrees();
+  if (!listing.ok) {
+    return {
+      presence: 'absent',
+      path: null,
+      brokenReasons: [],
+      detachedWorktreePaths: [],
+      unreadable: true,
+      unreadableReason:
+        listing.stderr || 'git worktree list --porcelain failed',
+    };
+  }
+  const entries = parseWorktreeListPorcelain(listing.stdout);
+  const matched =
+    findWorktreeEntryForBranch(entries, branchName) ??
+    findDetachedRebaseEntryForBranch(entries, branchName, inputs);
+  // A detached entry recovered via its rebase sequencer above (AC4) IS the
+  // matched worktree for this branch, not a mystery unrelated one — exclude
+  // it from the generic informational list so it is reported exactly once,
+  // as the matched (and, via the checks below, broken) worktree.
+  const detachedWorktreePaths = entries
+    .filter((entry) => entry.detached && entry.path !== matched?.path)
+    .map((entry) => entry.path);
+  if (!matched) {
+    return {
+      presence: 'absent',
+      path: null,
+      brokenReasons: [],
+      detachedWorktreePaths,
+      unreadable: false,
+      unreadableReason: null,
+    };
+  }
+  const brokenReasons: string[] = [];
+  if (matched.locked) {
+    brokenReasons.push(
+      `locked${matched.lockReason ? `: ${matched.lockReason}` : ''}`,
+    );
+  }
+  if (matched.prunable) {
+    brokenReasons.push(
+      `prunable${matched.prunableReason ? `: ${matched.prunableReason}` : ''}`,
+    );
+  }
+  // A locked/prunable worktree's directory may not even exist on disk
+  // (prunable in particular is exactly that case) — do not probe further.
+  if (brokenReasons.length === 0) {
+    const status = inputs.statusPorcelain(matched.path);
+    if (!status.ok) {
+      brokenReasons.push('working tree status could not be read');
+    } else if (status.stdout.trim().length > 0) {
+      brokenReasons.push('uncommitted content present');
+    }
+    if (
+      hasInProgressRebase(
+        matched.path,
+        inputs.resolveGitPath,
+        inputs.pathExists,
+      )
+    ) {
+      brokenReasons.push('rebase in progress');
+    }
+  }
+  return {
+    presence: brokenReasons.length > 0 ? 'present-broken' : 'present-clean',
+    path: matched.path,
+    brokenReasons,
+    detachedWorktreePaths,
+    unreadable: false,
+    unreadableReason: null,
+  };
+}
+
+/**
+ * Production {@link LocalCoordinationInputs}: local git shell-outs scoped to
+ * `cwd` (#2225).
+ */
+function createLocalCoordinationInputs(cwd: string): LocalCoordinationInputs {
+  return {
+    listWorktrees: () =>
+      runLocalGitCommand(['worktree', 'list', '--porcelain'], cwd),
+    statusPorcelain: (worktreePath) =>
+      runLocalGitCommand(['status', '--porcelain'], worktreePath),
+    resolveGitPath: (worktreePath, name) =>
+      runLocalGitCommand(['rev-parse', '--git-path', name], worktreePath),
+    pathExists: (path) => existsSync(path),
+    readFile: (path) => {
+      try {
+        return readFileSync(path, 'utf8');
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
 /**
  * Trailing caveat appended to a claim-not-owned `result` message when the
  * production viewer-login lookup failed (#1396). Empty string when the
@@ -768,6 +1190,16 @@ export interface RoadmapAuditExecuteDeps {
    * never silently indistinguishable from a genuine not-owned claim.
    */
   viewerLoginUnavailable?: boolean;
+  /**
+   * Evaluate local worktree/branch state for `branchName` (#2225). Optional:
+   * absent entirely, the check is simply skipped, matching production's own
+   * fail-open behavior when no local state is knowable — every existing
+   * test's deps object stays valid unmodified. Called once, immediately
+   * after the early claim re-validation and before any mutation.
+   */
+  inspectLocalCoordinationState?: (
+    branchName: string,
+  ) => LocalCoordinationVerdict;
 }
 
 /**
@@ -901,6 +1333,30 @@ export async function runRoadmapAuditExecute(
     }
     verdict.result = `claim not owned on re-validation (reason="${earlyClaim.reason}": ${explainRoadmapClaimReason(earlyClaim.reason)}); no mutation${viewerLoginUnavailableCaveat(resolvedDeps.viewerLoginUnavailable)}`;
     return { verdict, exitCode: 1 };
+  }
+
+  // Local worktree/branch safety (#2225): a released/stale claim record
+  // proves nothing about what is actually checked out locally. Evaluated
+  // once, right after ownership is confirmed and before ANY mutation
+  // (including the evidence comment) — local state does not change within a
+  // single run, so there is no need to repeat this at the later
+  // re-validations the way claim ownership itself is repeated.
+  if (resolvedDeps.inspectLocalCoordinationState) {
+    const localState = resolvedDeps.inspectLocalCoordinationState(
+      earlyClaim.activeClaim.branch,
+    );
+    if (localState.presence === 'present-broken') {
+      verdict.localCoordinationNote = `branch "${earlyClaim.activeClaim.branch}" has a local worktree at ${localState.path} that is not safe to treat as reusable (${localState.brokenReasons.join(', ')})`;
+      verdict.result = `local coordination state unsafe (${localState.brokenReasons.join(', ')}); no mutation`;
+      return { verdict, exitCode: 1 };
+    }
+    if (localState.unreadable) {
+      verdict.localCoordinationNote = `local coordination state unreadable (${localState.unreadableReason ?? 'unknown reason'}); proceeding`;
+    } else if (localState.presence === 'present-clean') {
+      verdict.localCoordinationNote = `branch "${earlyClaim.activeClaim.branch}" has a clean local worktree at ${localState.path}`;
+    } else if (localState.detachedWorktreePaths.length > 0) {
+      verdict.localCoordinationNote = `${localState.detachedWorktreePaths.length} detached local worktree(s) present (unrelated to this branch by definition): ${localState.detachedWorktreePaths.join(', ')}`;
+    }
   }
 
   // Re-fetch the roadmap + child state and confirm the audit input still
@@ -1157,6 +1613,11 @@ function createProductionDeps(
     // Honor a caller-supplied --now (deterministic staleness + release
     // timestamps for tests / replays); fall back to the wall clock.
     now: () => args.now || new Date().toISOString(),
+    inspectLocalCoordinationState: (branchName) =>
+      evaluateLocalCoordinationState(
+        branchName,
+        createLocalCoordinationInputs(process.cwd()),
+      ),
   };
 }
 

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -692,6 +692,32 @@ interface LocalGitCommandResult {
 }
 
 /**
+ * Keep repository discovery tied to the requested `cwd` rather than to
+ * ambient Git overrides inherited from a hook, wrapper, or parent process
+ * (#2225, review finding). Without this, an inherited `GIT_DIR`/
+ * `GIT_WORK_TREE`/`GIT_INDEX_FILE`/`GIT_COMMON_DIR` could silently redirect
+ * every check onto the wrong repository, defeating the safety gate
+ * entirely. A local, file-scoped port of claim-lock.mts's
+ * `sanitizedGitEnvironment` — not imported because that function is not
+ * exported there, and claim-lock.mts is outside this issue's
+ * candidate-files list.
+ */
+function sanitizedGitEnvironment(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('GIT_CONFIG')) {
+      delete env[key];
+    }
+  }
+  delete env.GIT_DIR;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_COMMON_DIR;
+  delete env.GIT_OBJECT_DIRECTORY;
+  return env;
+}
+
+/**
  * Run `git <argv>` in `cwd`, capturing stdout/stderr without throwing
  * (#2225). A local, file-scoped port of idd-doctor.mts's `runCommand` —
  * not extracted to a shared module because idd-doctor.mts is outside this
@@ -704,6 +730,7 @@ function runLocalGitCommand(
   try {
     const stdout = execFileSync('git', argv, {
       cwd,
+      env: sanitizedGitEnvironment(),
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -1091,14 +1118,25 @@ export function evaluateLocalCoordinationState(
 
 /**
  * Production {@link LocalCoordinationInputs}: local git shell-outs scoped to
- * `cwd` (#2225).
+ * `cwd` (#2225). Exported so tests can exercise the real git-backed wiring
+ * (env sanitization, untracked-file handling) against a throwaway
+ * repository, not just a hand-rolled duplicate of it.
  */
-function createLocalCoordinationInputs(cwd: string): LocalCoordinationInputs {
+export function createLocalCoordinationInputs(
+  cwd: string,
+): LocalCoordinationInputs {
   return {
     listWorktrees: () =>
       runLocalGitCommand(['worktree', 'list', '--porcelain'], cwd),
+    // --untracked-files=all overrides a repo/global status.showUntrackedFiles
+    // config (review finding, #2225): without it, `no` would make an
+    // untracked-only leftover file report as clean, silently weakening this
+    // exact safety gate through user configuration this tool never chose.
     statusPorcelain: (worktreePath) =>
-      runLocalGitCommand(['status', '--porcelain'], worktreePath),
+      runLocalGitCommand(
+        ['status', '--porcelain', '--untracked-files=all'],
+        worktreePath,
+      ),
     resolveGitPath: (worktreePath, name) =>
       runLocalGitCommand(['rev-parse', '--git-path', name], worktreePath),
     pathExists: (path) => existsSync(path),
@@ -1235,8 +1273,12 @@ export interface RoadmapAuditExecuteDeps {
    * Evaluate local worktree/branch state for `branchName` (#2225). Optional:
    * absent entirely, the check is simply skipped, matching production's own
    * fail-open behavior when no local state is knowable — every existing
-   * test's deps object stays valid unmodified. Called once, immediately
-   * after the early claim re-validation and before any mutation.
+   * test's deps object stays valid unmodified. Called at all three points
+   * claim ownership itself is re-validated below — the early check,
+   * immediately after the graph re-fetch, and immediately before the
+   * close — via {@link applyLocalCoordinationGate}, since local state can
+   * change mid-run just as easily as claim ownership can (review finding,
+   * #2225).
    */
   inspectLocalCoordinationState?: (
     branchName: string,

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -767,20 +767,26 @@ export interface WorktreeListEntry {
 }
 
 /**
- * Parse `git worktree list --porcelain` output into structured entries
+ * Parse `git worktree list --porcelain -z` output into structured entries
  * (#2225, AC3). Porcelain is the only enumeration this repo can rely on to
  * surface a detached worktree at all: a branch-name grep (the previous
  * approach) has nothing to match against, since a detached worktree carries
- * no branch. Stanzas are separated by a blank line; each starts with a
- * `worktree <path>` line. Malformed or empty input yields an empty array
- * rather than throwing.
+ * no branch. `-z` (NUL-delimited fields, a record terminated by an extra
+ * NUL) is required, not merely accepted (review finding, #2225): the plain
+ * newline-delimited form has no way to distinguish a literal newline inside
+ * a worktree path from the blank line that separates records, so a path
+ * containing `\n\n` would silently corrupt the stanza split and hide
+ * exactly the branch this hardening exists to protect — empirically
+ * reproduced with a real dirty linked worktree at such a path. A NUL byte
+ * cannot appear in a path at all, so this ambiguity does not exist for `-z`.
+ * Malformed or empty input yields an empty array rather than throwing.
  */
 export function parseWorktreeListPorcelain(
   output: string,
 ): WorktreeListEntry[] {
   const entries: WorktreeListEntry[] = [];
-  for (const stanza of output.split(/\r?\n\r?\n/)) {
-    const lines = stanza.split(/\r?\n/).filter((line) => line.length > 0);
+  for (const stanza of output.split('\0\0')) {
+    const lines = stanza.split('\0').filter((line) => line.length > 0);
     const worktreeLine = lines.find((line) => line.startsWith('worktree '));
     if (!worktreeLine) {
       continue;
@@ -1127,7 +1133,7 @@ export function createLocalCoordinationInputs(
 ): LocalCoordinationInputs {
   return {
     listWorktrees: () =>
-      runLocalGitCommand(['worktree', 'list', '--porcelain'], cwd),
+      runLocalGitCommand(['worktree', 'list', '--porcelain', '-z'], cwd),
     // --untracked-files=all overrides a repo/global status.showUntrackedFiles
     // config, and --ignore-submodules=none overrides diff.ignoreSubmodules
     // (both review findings, #2225): without them, `status.showUntrackedFiles

--- a/src/scripts/idd-roadmap-audit-execute.mts
+++ b/src/scripts/idd-roadmap-audit-execute.mts
@@ -709,11 +709,18 @@ function runLocalGitCommand(
     });
     return { ok: true, stdout, stderr: '' };
   } catch (err) {
-    const failure = err as { stdout?: unknown; stderr?: unknown };
+    // `encoding: 'utf8'` above decodes the happy path, but a spawn-level
+    // failure (signal, maxBuffer) can still leave stdout/stderr as a Buffer
+    // on the thrown error — coerce via toString() (mirrors idd-doctor.mts's
+    // runCommand) rather than discarding non-string output as empty.
+    const failure = err as {
+      stdout?: { toString?: () => string };
+      stderr?: { toString?: () => string };
+    };
     return {
       ok: false,
-      stdout: typeof failure.stdout === 'string' ? failure.stdout : '',
-      stderr: typeof failure.stderr === 'string' ? failure.stderr : '',
+      stdout: failure.stdout?.toString?.() ?? '',
+      stderr: failure.stderr?.toString?.() ?? '',
     };
   }
 }
@@ -792,24 +799,35 @@ function branchNameFromRef(ref: string): string {
 }
 
 /**
- * Find the worktree entry whose checked-out branch content-exactly matches
- * `branchName` (#2225, AC1). Content-exact, not identity-only: this compares
- * the porcelain `branch` ref itself — what is actually checked out — rather
- * than trusting that a claim record's own `branch` field (which may be
- * released or stale) says the branch is unowned. A detached entry has no
- * `branchRef` and can never match here by construction.
+ * Find every worktree entry whose checked-out branch content-exactly
+ * matches `branchName` (#2225, AC1). Content-exact, not identity-only: this
+ * compares the porcelain `branch` ref itself — what is actually checked
+ * out — rather than trusting that a claim record's own `branch` field
+ * (which may be released or stale) says the branch is unowned. Git
+ * normally refuses to check the same branch out in a second worktree, but
+ * `git checkout --ignore-other-worktrees` (documented in `git checkout -h`)
+ * can force it, so this returns every match rather than only the first —
+ * a caller that only checks the first could see a clean worktree while a
+ * second one silently sits broken. A detached entry has no `branchRef` and
+ * can never match here by construction.
  */
+export function findWorktreeEntriesForBranch(
+  entries: readonly WorktreeListEntry[],
+  branchName: string,
+): WorktreeListEntry[] {
+  return entries.filter(
+    (entry) =>
+      entry.branchRef !== null &&
+      branchNameFromRef(entry.branchRef) === branchName,
+  );
+}
+
+/** The first entry {@link findWorktreeEntriesForBranch} would return, or null. */
 export function findWorktreeEntryForBranch(
   entries: readonly WorktreeListEntry[],
   branchName: string,
 ): WorktreeListEntry | null {
-  return (
-    entries.find(
-      (entry) =>
-        entry.branchRef !== null &&
-        branchNameFromRef(entry.branchRef) === branchName,
-    ) ?? null
-  );
+  return findWorktreeEntriesForBranch(entries, branchName)[0] ?? null;
 }
 
 /**
@@ -857,9 +875,15 @@ export type LocalCoordinationPresence =
 /** Outcome of {@link evaluateLocalCoordinationState}. */
 export interface LocalCoordinationVerdict {
   presence: LocalCoordinationPresence;
-  /** The matched worktree's path; null when `presence` is `absent`. */
+  /**
+   * The first matched worktree's path; null when `presence` is `absent`.
+   * More than one worktree can match the same branch (see
+   * {@link findWorktreeEntriesForBranch}) — `brokenReasons` covers every
+   * match, path-qualified beyond the first, even though only the first
+   * match's path is surfaced here.
+   */
   path: string | null;
-  /** Populated only when `presence` is `present-broken`. */
+  /** Populated only when `presence` is `present-broken`; covers every matched worktree, not just the first. */
   brokenReasons: string[];
   /**
    * Detached worktree paths found while enumerating (#2225, AC3), OTHER
@@ -931,28 +955,62 @@ function resolveDetachedRebaseBranch(
 }
 
 /**
- * Find a DETACHED worktree entry whose rebase sequencer records `branchName`
- * as the branch being rebased (#2225, AC4). See
+ * Find every DETACHED worktree entry whose rebase sequencer records
+ * `branchName` as the branch being rebased (#2225, AC4). See
  * {@link resolveDetachedRebaseBranch} for why a plain branch-ref match on a
- * mid-rebase worktree always fails.
+ * mid-rebase worktree always fails. Plural for the same reason as
+ * {@link findWorktreeEntriesForBranch}: more than one worktree can end up
+ * mid-rebase against the same original branch.
  */
-function findDetachedRebaseEntryForBranch(
+function findDetachedRebaseEntriesForBranch(
   entries: readonly WorktreeListEntry[],
   branchName: string,
   inputs: Pick<
     LocalCoordinationInputs,
     'resolveGitPath' | 'pathExists' | 'readFile'
   >,
-): WorktreeListEntry | null {
-  for (const entry of entries) {
-    if (!entry.detached) {
-      continue;
+): WorktreeListEntry[] {
+  return entries.filter(
+    (entry) =>
+      entry.detached &&
+      resolveDetachedRebaseBranch(entry.path, inputs) === branchName,
+  );
+}
+
+/**
+ * Evaluate one matched worktree entry for the broken-reason signals
+ * {@link evaluateLocalCoordinationState} reports (#2225): porcelain
+ * `locked`/`prunable` flags first (a locked/prunable entry's directory may
+ * not even exist on disk — do not probe further), then uncommitted content
+ * and an in-progress rebase.
+ */
+function evaluateMatchedWorktreeEntry(
+  entry: WorktreeListEntry,
+  inputs: LocalCoordinationInputs,
+): string[] {
+  const reasons: string[] = [];
+  if (entry.locked) {
+    reasons.push(`locked${entry.lockReason ? `: ${entry.lockReason}` : ''}`);
+  }
+  if (entry.prunable) {
+    reasons.push(
+      `prunable${entry.prunableReason ? `: ${entry.prunableReason}` : ''}`,
+    );
+  }
+  if (reasons.length === 0) {
+    const status = inputs.statusPorcelain(entry.path);
+    if (!status.ok) {
+      reasons.push('working tree status could not be read');
+    } else if (status.stdout.trim().length > 0) {
+      reasons.push('uncommitted content present');
     }
-    if (resolveDetachedRebaseBranch(entry.path, inputs) === branchName) {
-      return entry;
+    if (
+      hasInProgressRebase(entry.path, inputs.resolveGitPath, inputs.pathExists)
+    ) {
+      reasons.push('rebase in progress');
     }
   }
-  return null;
+  return reasons;
 }
 
 /**
@@ -968,8 +1026,11 @@ function findDetachedRebaseEntryForBranch(
  * branch, a failure to read ITS status is treated as broken rather than
  * unreadable: unlike the top-level enumeration failure, a positively
  * identified worktree that suddenly cannot be probed is exactly the
- * ambiguous case this hardening exists to catch, so it fails closed. Pure:
- * every git read is injected.
+ * ambiguous case this hardening exists to catch, so it fails closed. Every
+ * worktree matching `branchName` is evaluated, not just the first (#2225,
+ * P2 review finding): `git checkout --ignore-other-worktrees` can check the
+ * same branch out in more than one worktree, and a clean first match must
+ * not hide a broken second one. Pure: every git read is injected.
  */
 export function evaluateLocalCoordinationState(
   branchName: string,
@@ -988,17 +1049,20 @@ export function evaluateLocalCoordinationState(
     };
   }
   const entries = parseWorktreeListPorcelain(listing.stdout);
-  const matched =
-    findWorktreeEntryForBranch(entries, branchName) ??
-    findDetachedRebaseEntryForBranch(entries, branchName, inputs);
-  // A detached entry recovered via its rebase sequencer above (AC4) IS the
-  // matched worktree for this branch, not a mystery unrelated one — exclude
-  // it from the generic informational list so it is reported exactly once,
-  // as the matched (and, via the checks below, broken) worktree.
+  const matchedEntries = [
+    ...findWorktreeEntriesForBranch(entries, branchName),
+    ...findDetachedRebaseEntriesForBranch(entries, branchName, inputs),
+  ];
+  const matchedPaths = new Set(matchedEntries.map((entry) => entry.path));
+  // Every detached entry recovered via its rebase sequencer above (AC4) IS
+  // a matched worktree for this branch, not a mystery unrelated one —
+  // exclude matched paths from the generic informational list so each is
+  // reported exactly once, as a matched (and, via the checks below,
+  // possibly broken) worktree.
   const detachedWorktreePaths = entries
-    .filter((entry) => entry.detached && entry.path !== matched?.path)
+    .filter((entry) => entry.detached && !matchedPaths.has(entry.path))
     .map((entry) => entry.path);
-  if (!matched) {
+  if (matchedEntries.length === 0) {
     return {
       presence: 'absent',
       path: null,
@@ -1009,38 +1073,15 @@ export function evaluateLocalCoordinationState(
     };
   }
   const brokenReasons: string[] = [];
-  if (matched.locked) {
-    brokenReasons.push(
-      `locked${matched.lockReason ? `: ${matched.lockReason}` : ''}`,
-    );
-  }
-  if (matched.prunable) {
-    brokenReasons.push(
-      `prunable${matched.prunableReason ? `: ${matched.prunableReason}` : ''}`,
-    );
-  }
-  // A locked/prunable worktree's directory may not even exist on disk
-  // (prunable in particular is exactly that case) — do not probe further.
-  if (brokenReasons.length === 0) {
-    const status = inputs.statusPorcelain(matched.path);
-    if (!status.ok) {
-      brokenReasons.push('working tree status could not be read');
-    } else if (status.stdout.trim().length > 0) {
-      brokenReasons.push('uncommitted content present');
+  matchedEntries.forEach((entry, index) => {
+    const prefix = index > 0 ? `at ${entry.path}: ` : '';
+    for (const reason of evaluateMatchedWorktreeEntry(entry, inputs)) {
+      brokenReasons.push(`${prefix}${reason}`);
     }
-    if (
-      hasInProgressRebase(
-        matched.path,
-        inputs.resolveGitPath,
-        inputs.pathExists,
-      )
-    ) {
-      brokenReasons.push('rebase in progress');
-    }
-  }
+  });
   return {
     presence: brokenReasons.length > 0 ? 'present-broken' : 'present-clean',
-    path: matched.path,
+    path: matchedEntries[0].path,
     brokenReasons,
     detachedWorktreePaths,
     unreadable: false,
@@ -1203,6 +1244,41 @@ export interface RoadmapAuditExecuteDeps {
 }
 
 /**
+ * Apply the local coordination-state gate (#2225) at one point in the apply
+ * sequence: populate `verdict.localCoordinationNote` (and, when unsafe,
+ * `verdict.result` too), and report whether the apply must stop here.
+ * Called at every point claim ownership is re-validated below — the early
+ * check, immediately after the potentially long graph re-fetch, and
+ * immediately before the close — because local state is not immutable
+ * within a single run any more than claim ownership is: another local
+ * process can dirty, lock, prune, or begin rebasing the matched worktree
+ * while this run is still in flight (#2225, P2 review finding).
+ */
+function applyLocalCoordinationGate(
+  resolvedDeps: RoadmapAuditExecuteDeps,
+  branchName: string,
+  verdict: IddRoadmapAuditExecuteVerdict,
+): boolean {
+  if (!resolvedDeps.inspectLocalCoordinationState) {
+    return false;
+  }
+  const localState = resolvedDeps.inspectLocalCoordinationState(branchName);
+  if (localState.presence === 'present-broken') {
+    verdict.localCoordinationNote = `branch "${branchName}" has a local worktree at ${localState.path} that is not safe to treat as reusable (${localState.brokenReasons.join(', ')})`;
+    verdict.result = `local coordination state unsafe (${localState.brokenReasons.join(', ')}); no mutation`;
+    return true;
+  }
+  if (localState.unreadable) {
+    verdict.localCoordinationNote = `local coordination state unreadable (${localState.unreadableReason ?? 'unknown reason'}); proceeding`;
+  } else if (localState.presence === 'present-clean') {
+    verdict.localCoordinationNote = `branch "${branchName}" has a clean local worktree at ${localState.path}`;
+  } else if (localState.detachedWorktreePaths.length > 0) {
+    verdict.localCoordinationNote = `${localState.detachedWorktreePaths.length} detached local worktree(s) present (unrelated to this branch by definition): ${localState.detachedWorktreePaths.join(', ')}`;
+  }
+  return false;
+}
+
+/**
  * Build the A1.5 verdict and, under `--apply`, execute the audit. The dry-run
  * path performs NO mutation. The apply path fails closed: if the roadmap is
  * not ready it exits without mutating; if it is ready it RE-VALIDATES the
@@ -1336,27 +1412,18 @@ export async function runRoadmapAuditExecute(
   }
 
   // Local worktree/branch safety (#2225): a released/stale claim record
-  // proves nothing about what is actually checked out locally. Evaluated
-  // once, right after ownership is confirmed and before ANY mutation
-  // (including the evidence comment) — local state does not change within a
-  // single run, so there is no need to repeat this at the later
-  // re-validations the way claim ownership itself is repeated.
-  if (resolvedDeps.inspectLocalCoordinationState) {
-    const localState = resolvedDeps.inspectLocalCoordinationState(
+  // proves nothing about what is actually checked out locally. Re-checked
+  // again below, after the graph re-fetch and immediately before the close
+  // — see applyLocalCoordinationGate's doc comment for why a single early
+  // check alone would leave a TOCTOU gap.
+  if (
+    applyLocalCoordinationGate(
+      resolvedDeps,
       earlyClaim.activeClaim.branch,
-    );
-    if (localState.presence === 'present-broken') {
-      verdict.localCoordinationNote = `branch "${earlyClaim.activeClaim.branch}" has a local worktree at ${localState.path} that is not safe to treat as reusable (${localState.brokenReasons.join(', ')})`;
-      verdict.result = `local coordination state unsafe (${localState.brokenReasons.join(', ')}); no mutation`;
-      return { verdict, exitCode: 1 };
-    }
-    if (localState.unreadable) {
-      verdict.localCoordinationNote = `local coordination state unreadable (${localState.unreadableReason ?? 'unknown reason'}); proceeding`;
-    } else if (localState.presence === 'present-clean') {
-      verdict.localCoordinationNote = `branch "${earlyClaim.activeClaim.branch}" has a clean local worktree at ${localState.path}`;
-    } else if (localState.detachedWorktreePaths.length > 0) {
-      verdict.localCoordinationNote = `${localState.detachedWorktreePaths.length} detached local worktree(s) present (unrelated to this branch by definition): ${localState.detachedWorktreePaths.join(', ')}`;
-    }
+      verdict,
+    )
+  ) {
+    return { verdict, exitCode: 1 };
   }
 
   // Re-fetch the roadmap + child state and confirm the audit input still
@@ -1394,6 +1461,16 @@ export async function runRoadmapAuditExecute(
     return { verdict, exitCode: 1 };
   }
 
+  // Re-check local state too: the graph re-fetch just above can span many
+  // API calls, during which another local process can dirty, lock, prune,
+  // or begin rebasing the matched worktree just as easily as another
+  // session can take over the claim.
+  if (
+    applyLocalCoordinationGate(resolvedDeps, claim.activeClaim.branch, verdict)
+  ) {
+    return { verdict, exitCode: 1 };
+  }
+
   // Post the evidence comment (non-destructive), THEN re-validate ownership one
   // final time immediately before the CLOSE: a takeover landing in the
   // comment→close gap must not let us close under a claim we no longer own. An
@@ -1412,6 +1489,19 @@ export async function runRoadmapAuditExecute(
   });
   if (!preCloseClaim.owned) {
     verdict.result = `claim lost in the comment→close gap (reason="${preCloseClaim.reason}": ${explainRoadmapClaimReason(preCloseClaim.reason)}); evidence comment posted but roadmap NOT closed${viewerLoginUnavailableCaveat(resolvedDeps.viewerLoginUnavailable)}`;
+    return { verdict, exitCode: 1 };
+  }
+
+  // One last local-state check, immediately before the close itself, for
+  // the same comment→close gap the claim re-validation just above guards.
+  if (
+    applyLocalCoordinationGate(
+      resolvedDeps,
+      preCloseClaim.activeClaim.branch,
+      verdict,
+    )
+  ) {
+    verdict.result = `${verdict.result} (evidence comment posted but roadmap NOT closed)`;
     return { verdict, exitCode: 1 };
   }
 

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -1,12 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import {
-  existsSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { devNull, tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 import { test } from 'node:test';
@@ -18,6 +12,7 @@ import {
 import {
   buildRoadmapCompletionAuditBody,
   type ConnectedPrEvent,
+  createLocalCoordinationInputs,
   evaluateLocalCoordinationState,
   evaluateRoadmapAuditGates,
   evaluateRoadmapClaim,
@@ -2117,40 +2112,13 @@ function fixtureGitOut(cwd: string, args: string[]): string {
   }).trim();
 }
 
-/** Real git shell-outs, mirroring production's createLocalCoordinationInputs. */
-function realLocalInputs(primary: string): LocalCoordinationInputs {
-  const run = (cwd: string, args: string[]) => {
-    try {
-      return {
-        ok: true as const,
-        stdout: fixtureGitOut(cwd, args),
-        stderr: '',
-      };
-    } catch (err) {
-      const failure = err as { stderr?: unknown };
-      return {
-        ok: false as const,
-        stdout: '',
-        stderr: typeof failure.stderr === 'string' ? failure.stderr : '',
-      };
-    }
-  };
-  return {
-    listWorktrees: () => run(primary, ['worktree', 'list', '--porcelain']),
-    statusPorcelain: (worktreePath) =>
-      run(worktreePath, ['status', '--porcelain']),
-    resolveGitPath: (worktreePath, name) =>
-      run(worktreePath, ['rev-parse', '--git-path', name]),
-    pathExists: (path) => existsSync(path),
-    readFile: (path) => {
-      try {
-        return readFileSync(path, 'utf8');
-      } catch {
-        return null;
-      }
-    },
-  };
-}
+/**
+ * Real git shell-outs for the AC2-AC4 fixture tests: the REAL production
+ * `createLocalCoordinationInputs` wiring (not a hand-rolled duplicate), so
+ * these tests exercise the actual env-sanitization and
+ * `--untracked-files=all` behavior, not just the pure logic on top of it.
+ */
+const realLocalInputs = createLocalCoordinationInputs;
 
 function setupPrimaryRepo(): string {
   const primary = mkdtempSync(join(tmpdir(), 'idd-roadmap-local-'));
@@ -2309,6 +2277,126 @@ test('AC4 real fixture: an in-progress rebase in a LINKED worktree is detected v
     }
     rmSync(worktree, { recursive: true, force: true });
     rmSync(primary, { recursive: true, force: true });
+  }
+});
+
+test('real fixture: an untracked-only leftover reports present-broken even under status.showUntrackedFiles=no (review finding, #2225)', () => {
+  const primary = setupPrimaryRepo();
+  const worktree = join(primary, '..', `${basename(primary)}-wt`);
+  try {
+    fixtureGit(primary, [
+      'worktree',
+      'add',
+      worktree,
+      '-b',
+      'roadmap-audit/995-slug',
+      'main',
+    ]);
+    fixtureGit(worktree, ['config', 'status.showUntrackedFiles', 'no']);
+    writeFileSync(join(worktree, 'untracked-leftover.txt'), 'oops\n');
+
+    // Sanity: an UNQUALIFIED status --porcelain really does go empty under
+    // this config, which is exactly the bypass the fix guards against.
+    assert.equal(fixtureGitOut(worktree, ['status', '--porcelain']), '');
+
+    const verdict = evaluateLocalCoordinationState(
+      'roadmap-audit/995-slug',
+      realLocalInputs(primary),
+    );
+    assert.equal(verdict.presence, 'present-broken');
+    assert.deepEqual(verdict.brokenReasons, ['uncommitted content present']);
+  } finally {
+    try {
+      fixtureGit(primary, ['worktree', 'remove', '--force', worktree]);
+    } catch {
+      // best-effort cleanup
+    }
+    rmSync(worktree, { recursive: true, force: true });
+    rmSync(primary, { recursive: true, force: true });
+  }
+});
+
+test('real fixture: local git shell-outs ignore ambient GIT_* overrides and never reach a sentinel repo (review finding, #2225)', () => {
+  // Differential test: `sentinel` has NO roadmap-audit branch at all, while
+  // `primary` has a real, clean worktree checked out on one. An unsanitized
+  // `runLocalGitCommand` that let the poisoned GIT_DIR/GIT_WORK_TREE
+  // redirect it onto `sentinel` would silently see neither the worktree nor
+  // the branch and misreport `absent` — a strictly stronger assertion than
+  // just checking `sentinel` was left untouched (read-only code would pass
+  // that trivially either way).
+  const sentinel = mkdtempSync(join(tmpdir(), 'idd-roadmap-sentinel-'));
+  let primary: string | undefined;
+  let worktree: string | undefined;
+  try {
+    fixtureGit(sentinel, ['init', '-b', 'main']);
+    fixtureGit(sentinel, ['config', 'user.email', 'sentinel@example.com']);
+    fixtureGit(sentinel, ['config', 'user.name', 'Sentinel']);
+    writeFileSync(join(sentinel, 'README.md'), 'sentinel\n');
+    fixtureGit(sentinel, ['add', 'README.md']);
+    fixtureGit(sentinel, ['commit', '-m', 'sentinel']);
+    const headBefore = fixtureGitOut(sentinel, ['rev-parse', 'HEAD']);
+    const branchesBefore = fixtureGitOut(sentinel, ['branch', '--list']);
+
+    primary = setupPrimaryRepo();
+    worktree = join(primary, '..', `${basename(primary)}-wt`);
+    fixtureGit(primary, [
+      'worktree',
+      'add',
+      worktree,
+      '-b',
+      'roadmap-audit/995-slug',
+      'main',
+    ]);
+
+    const saved = new Map(
+      [
+        'GIT_DIR',
+        'GIT_INDEX_FILE',
+        'GIT_WORK_TREE',
+        'GIT_COMMON_DIR',
+        'GIT_OBJECT_DIRECTORY',
+      ].map((key) => [key, process.env[key]]),
+    );
+    try {
+      process.env.GIT_DIR = join(sentinel, '.git');
+      process.env.GIT_INDEX_FILE = join(sentinel, '.git', 'index');
+      process.env.GIT_WORK_TREE = sentinel;
+      process.env.GIT_COMMON_DIR = join(sentinel, '.git');
+      process.env.GIT_OBJECT_DIRECTORY = join(sentinel, '.git', 'objects');
+
+      const verdict = evaluateLocalCoordinationState(
+        'roadmap-audit/995-slug',
+        createLocalCoordinationInputs(primary),
+      );
+      assert.equal(verdict.presence, 'present-clean');
+      assert.equal(verdict.path, worktree);
+      assert.equal(verdict.unreadable, false);
+    } finally {
+      for (const [key, value] of saved) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
+
+    assert.equal(fixtureGitOut(sentinel, ['rev-parse', 'HEAD']), headBefore);
+    assert.equal(fixtureGitOut(sentinel, ['branch', '--list']), branchesBefore);
+    assert.equal(fixtureGitOut(sentinel, ['status', '--porcelain']), '');
+  } finally {
+    if (primary && worktree) {
+      try {
+        fixtureGit(primary, ['worktree', 'remove', '--force', worktree]);
+      } catch {
+        // best-effort cleanup
+      }
+      rmSync(worktree, { recursive: true, force: true });
+    }
+    if (primary) {
+      rmSync(primary, { recursive: true, force: true });
+    }
+    rmSync(sentinel, { recursive: true, force: true });
   }
 });
 

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -1,4 +1,14 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { devNull, tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
 import { test } from 'node:test';
 
 import {
@@ -8,10 +18,14 @@ import {
 import {
   buildRoadmapCompletionAuditBody,
   type ConnectedPrEvent,
+  evaluateLocalCoordinationState,
   evaluateRoadmapAuditGates,
   evaluateRoadmapClaim,
   explainRoadmapClaimReason,
+  findWorktreeEntryForBranch,
   hasTrustedCompletionEvidenceComment,
+  type LocalCoordinationInputs,
+  parseWorktreeListPorcelain,
   type RoadmapAuditExecuteDeps,
   reconcileConnectedOpenPrs,
   resolveOpenLinkedPrIssues,
@@ -1622,4 +1636,725 @@ test('missing --roadmap is rejected', async () => {
     () => runRoadmapAuditExecute(['--claim-id', CLAIM_ID], deps),
     /missing required --roadmap/,
   );
+});
+
+// ---------------------------------------------------------------------------
+// parseWorktreeListPorcelain (pure, #2225)
+// ---------------------------------------------------------------------------
+
+test('parseWorktreeListPorcelain parses a normal branch stanza', () => {
+  const entries = parseWorktreeListPorcelain(
+    'worktree /repo/main\nHEAD abc123\nbranch refs/heads/main\n',
+  );
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0]?.path, '/repo/main');
+  assert.equal(entries[0]?.headSha, 'abc123');
+  assert.equal(entries[0]?.branchRef, 'refs/heads/main');
+  assert.equal(entries[0]?.detached, false);
+});
+
+test('parseWorktreeListPorcelain flags a detached stanza with no branch', () => {
+  const entries = parseWorktreeListPorcelain(
+    'worktree /repo/detached\nHEAD abc123\ndetached\n',
+  );
+  assert.equal(entries[0]?.detached, true);
+  assert.equal(entries[0]?.branchRef, null);
+});
+
+test('parseWorktreeListPorcelain captures a locked reason', () => {
+  const entries = parseWorktreeListPorcelain(
+    'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/feature\nlocked manual lock test\n',
+  );
+  assert.equal(entries[0]?.locked, true);
+  assert.equal(entries[0]?.lockReason, 'manual lock test');
+});
+
+test('parseWorktreeListPorcelain treats a bare "locked" line as lock-with-no-reason', () => {
+  const entries = parseWorktreeListPorcelain(
+    'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/feature\nlocked\n',
+  );
+  assert.equal(entries[0]?.locked, true);
+  assert.equal(entries[0]?.lockReason, null);
+});
+
+test('parseWorktreeListPorcelain captures a prunable reason', () => {
+  const entries = parseWorktreeListPorcelain(
+    'worktree /repo/gone\nHEAD abc123\nbranch refs/heads/gone-branch\nprunable gitdir file points to non-existent location\n',
+  );
+  assert.equal(entries[0]?.prunable, true);
+  assert.equal(
+    entries[0]?.prunableReason,
+    'gitdir file points to non-existent location',
+  );
+});
+
+test('parseWorktreeListPorcelain parses multiple blank-line-separated stanzas', () => {
+  const output = [
+    'worktree /repo/main',
+    'HEAD abc123',
+    'branch refs/heads/main',
+    '',
+    'worktree /repo/feature',
+    'HEAD def456',
+    'branch refs/heads/feature',
+    '',
+  ].join('\n');
+  const entries = parseWorktreeListPorcelain(output);
+  assert.deepEqual(
+    entries.map((entry) => entry.path),
+    ['/repo/main', '/repo/feature'],
+  );
+});
+
+test('parseWorktreeListPorcelain tolerates CRLF line endings', () => {
+  const entries = parseWorktreeListPorcelain(
+    'worktree /repo/main\r\nHEAD abc123\r\nbranch refs/heads/main\r\n',
+  );
+  assert.equal(entries[0]?.path, '/repo/main');
+  assert.equal(entries[0]?.branchRef, 'refs/heads/main');
+});
+
+test('parseWorktreeListPorcelain returns an empty array for malformed/empty input', () => {
+  assert.deepEqual(parseWorktreeListPorcelain(''), []);
+  assert.deepEqual(parseWorktreeListPorcelain('not a worktree listing\n'), []);
+});
+
+// ---------------------------------------------------------------------------
+// findWorktreeEntryForBranch (pure, #2225, AC1)
+// ---------------------------------------------------------------------------
+
+test('findWorktreeEntryForBranch matches by content-exact branch name', () => {
+  const entries = parseWorktreeListPorcelain(
+    'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+  );
+  const match = findWorktreeEntryForBranch(entries, 'roadmap-audit/995-slug');
+  assert.equal(match?.path, '/repo/wt');
+});
+
+test('findWorktreeEntryForBranch returns null when no entry matches', () => {
+  const entries = parseWorktreeListPorcelain(
+    'worktree /repo/main\nHEAD abc123\nbranch refs/heads/main\n',
+  );
+  assert.equal(
+    findWorktreeEntryForBranch(entries, 'roadmap-audit/995-slug'),
+    null,
+  );
+});
+
+test('findWorktreeEntryForBranch never matches a detached entry', () => {
+  const entries = parseWorktreeListPorcelain(
+    'worktree /repo/detached\nHEAD abc123\ndetached\n',
+  );
+  assert.equal(
+    findWorktreeEntryForBranch(entries, 'roadmap-audit/995-slug'),
+    null,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// evaluateLocalCoordinationState (pure, injected inputs, #2225)
+// ---------------------------------------------------------------------------
+
+const OK = (stdout = ''): { ok: true; stdout: string; stderr: string } => ({
+  ok: true,
+  stdout,
+  stderr: '',
+});
+const FAIL = (
+  stderr = 'boom',
+): { ok: false; stdout: string; stderr: string } => ({
+  ok: false,
+  stdout: '',
+  stderr,
+});
+
+function localInputs(
+  overrides: Partial<LocalCoordinationInputs> & {
+    calls?: { status: number; gitPath: number };
+  } = {},
+): LocalCoordinationInputs {
+  const { calls, ...rest } = overrides;
+  return {
+    listWorktrees: () => OK(''),
+    statusPorcelain: () => {
+      if (calls) calls.status += 1;
+      return OK('');
+    },
+    resolveGitPath: () => {
+      if (calls) calls.gitPath += 1;
+      return FAIL('no such path');
+    },
+    pathExists: () => false,
+    readFile: () => null,
+    ...rest,
+  };
+}
+
+test('evaluateLocalCoordinationState reports absent when no worktree matches (the expected common case)', () => {
+  const verdict = evaluateLocalCoordinationState(
+    'roadmap-audit/995-slug',
+    localInputs({
+      listWorktrees: () =>
+        OK('worktree /repo/main\nHEAD abc123\nbranch refs/heads/main\n'),
+    }),
+  );
+  assert.equal(verdict.presence, 'absent');
+  assert.equal(verdict.path, null);
+  assert.equal(verdict.unreadable, false);
+});
+
+test('evaluateLocalCoordinationState fails open (absent + unreadable) when the listing itself cannot be read', () => {
+  const verdict = evaluateLocalCoordinationState(
+    'roadmap-audit/995-slug',
+    localInputs({ listWorktrees: () => FAIL('git: command not found') }),
+  );
+  assert.equal(verdict.presence, 'absent');
+  assert.equal(verdict.unreadable, true);
+  assert.match(verdict.unreadableReason ?? '', /command not found/);
+});
+
+test('evaluateLocalCoordinationState reports present-clean for a matched, clean, non-rebasing worktree', () => {
+  const verdict = evaluateLocalCoordinationState(
+    'roadmap-audit/995-slug',
+    localInputs({
+      listWorktrees: () =>
+        OK(
+          'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+        ),
+      statusPorcelain: () => OK(''),
+      resolveGitPath: () => FAIL('no such path'),
+    }),
+  );
+  assert.equal(verdict.presence, 'present-clean');
+  assert.equal(verdict.path, '/repo/wt');
+  assert.deepEqual(verdict.brokenReasons, []);
+});
+
+test('evaluateLocalCoordinationState reports present-broken with uncommitted content on a dirty status', () => {
+  const verdict = evaluateLocalCoordinationState(
+    'roadmap-audit/995-slug',
+    localInputs({
+      listWorktrees: () =>
+        OK(
+          'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+        ),
+      statusPorcelain: () => OK(' M file.txt\n'),
+      resolveGitPath: () => FAIL('no such path'),
+    }),
+  );
+  assert.equal(verdict.presence, 'present-broken');
+  assert.deepEqual(verdict.brokenReasons, ['uncommitted content present']);
+});
+
+test('evaluateLocalCoordinationState reports present-broken with rebase in progress when the resolved git-path exists', () => {
+  const verdict = evaluateLocalCoordinationState(
+    'roadmap-audit/995-slug',
+    localInputs({
+      listWorktrees: () =>
+        OK(
+          'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+        ),
+      statusPorcelain: () => OK(''),
+      resolveGitPath: (_worktreePath, name) =>
+        name === 'rebase-merge'
+          ? OK('/repo/.git/worktrees/wt/rebase-merge\n')
+          : FAIL('no such path'),
+      pathExists: (path) => path === '/repo/.git/worktrees/wt/rebase-merge',
+    }),
+  );
+  assert.equal(verdict.presence, 'present-broken');
+  assert.deepEqual(verdict.brokenReasons, ['rebase in progress']);
+});
+
+test('evaluateLocalCoordinationState resolves a RELATIVE --git-path output against the worktree path', () => {
+  const verdict = evaluateLocalCoordinationState(
+    'roadmap-audit/995-slug',
+    localInputs({
+      listWorktrees: () =>
+        OK(
+          'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+        ),
+      statusPorcelain: () => OK(''),
+      resolveGitPath: (_worktreePath, name) =>
+        name === 'rebase-merge' ? OK('.git/rebase-merge\n') : FAIL('none'),
+      pathExists: (path) => path === '/repo/wt/.git/rebase-merge',
+    }),
+  );
+  assert.equal(verdict.presence, 'present-broken');
+  assert.deepEqual(verdict.brokenReasons, ['rebase in progress']);
+});
+
+test('evaluateLocalCoordinationState reports locked directly from porcelain without probing status or rebase', () => {
+  const calls = { status: 0, gitPath: 0 };
+  const verdict = evaluateLocalCoordinationState(
+    'roadmap-audit/995-slug',
+    localInputs({
+      listWorktrees: () =>
+        OK(
+          'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\nlocked manual lock test\n',
+        ),
+      calls,
+    }),
+  );
+  assert.equal(verdict.presence, 'present-broken');
+  assert.deepEqual(verdict.brokenReasons, ['locked: manual lock test']);
+  assert.equal(calls.status, 0);
+  assert.equal(calls.gitPath, 0);
+});
+
+test('evaluateLocalCoordinationState reports prunable directly from porcelain without probing status or rebase', () => {
+  const calls = { status: 0, gitPath: 0 };
+  const verdict = evaluateLocalCoordinationState(
+    'roadmap-audit/995-slug',
+    localInputs({
+      listWorktrees: () =>
+        OK(
+          'worktree /repo/gone\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\nprunable gitdir file points to non-existent location\n',
+        ),
+      calls,
+    }),
+  );
+  assert.equal(verdict.presence, 'present-broken');
+  assert.deepEqual(verdict.brokenReasons, [
+    'prunable: gitdir file points to non-existent location',
+  ]);
+  assert.equal(calls.status, 0);
+  assert.equal(calls.gitPath, 0);
+});
+
+test('evaluateLocalCoordinationState treats a matched worktree with an unreadable status as broken, not unreadable', () => {
+  const verdict = evaluateLocalCoordinationState(
+    'roadmap-audit/995-slug',
+    localInputs({
+      listWorktrees: () =>
+        OK(
+          'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+        ),
+      statusPorcelain: () => FAIL('no such directory'),
+      resolveGitPath: () => FAIL('no such path'),
+    }),
+  );
+  assert.equal(verdict.presence, 'present-broken');
+  assert.equal(verdict.unreadable, false);
+  assert.deepEqual(verdict.brokenReasons, [
+    'working tree status could not be read',
+  ]);
+});
+
+test('evaluateLocalCoordinationState surfaces repo-wide detached worktrees as informational, non-blocking', () => {
+  const verdict = evaluateLocalCoordinationState(
+    'roadmap-audit/995-slug',
+    localInputs({
+      listWorktrees: () =>
+        OK(
+          [
+            'worktree /repo/main',
+            'HEAD abc123',
+            'branch refs/heads/main',
+            '',
+            'worktree /repo/detached',
+            'HEAD def456',
+            'detached',
+            '',
+          ].join('\n'),
+        ),
+    }),
+  );
+  assert.equal(verdict.presence, 'absent');
+  assert.deepEqual(verdict.detachedWorktreePaths, ['/repo/detached']);
+});
+
+test('evaluateLocalCoordinationState matches a DETACHED mid-rebase worktree via its head-name (git rebase detaches HEAD; branch-ref matching alone would miss it)', () => {
+  const verdict = evaluateLocalCoordinationState(
+    'roadmap-audit/995-slug',
+    localInputs({
+      listWorktrees: () => OK('worktree /repo/wt\nHEAD abc123\ndetached\n'),
+      statusPorcelain: () => OK(''),
+      resolveGitPath: (_worktreePath, name) =>
+        name === 'rebase-merge'
+          ? OK('/repo/.git/worktrees/wt/rebase-merge\n')
+          : FAIL('none'),
+      pathExists: (path) => path === '/repo/.git/worktrees/wt/rebase-merge',
+      readFile: (path) =>
+        path === '/repo/.git/worktrees/wt/rebase-merge/head-name'
+          ? 'refs/heads/roadmap-audit/995-slug\n'
+          : null,
+    }),
+  );
+  assert.equal(verdict.presence, 'present-broken');
+  assert.equal(verdict.path, '/repo/wt');
+  assert.ok(verdict.brokenReasons.includes('rebase in progress'));
+  // Reported once, as the matched worktree — not also as an unrelated detached one.
+  assert.deepEqual(verdict.detachedWorktreePaths, []);
+});
+
+test('evaluateLocalCoordinationState leaves an UNRELATED detached/rebasing worktree in detachedWorktreePaths (head-name does not match)', () => {
+  const verdict = evaluateLocalCoordinationState(
+    'roadmap-audit/995-slug',
+    localInputs({
+      listWorktrees: () =>
+        OK('worktree /repo/other-wt\nHEAD abc123\ndetached\n'),
+      resolveGitPath: (_worktreePath, name) =>
+        name === 'rebase-merge'
+          ? OK('/repo/.git/worktrees/other-wt/rebase-merge\n')
+          : FAIL('none'),
+      pathExists: (path) =>
+        path === '/repo/.git/worktrees/other-wt/rebase-merge',
+      readFile: (path) =>
+        path === '/repo/.git/worktrees/other-wt/rebase-merge/head-name'
+          ? 'refs/heads/some-unrelated-branch\n'
+          : null,
+    }),
+  );
+  assert.equal(verdict.presence, 'absent');
+  assert.deepEqual(verdict.detachedWorktreePaths, ['/repo/other-wt']);
+});
+
+// ---------------------------------------------------------------------------
+// evaluateLocalCoordinationState against REAL git fixtures (#2225, AC2-AC4)
+// ---------------------------------------------------------------------------
+
+// Fixture invariant mirrored from tests/worktree-guard-hook.test.mts and
+// tests/claim-lock.test.mts: fixture git processes must never read the
+// ambient git environment or the developer's config, so a signing-enabled
+// global config or an inherited GIT_DIR cannot leak into these throwaway
+// repos.
+function fixtureEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('GIT_CONFIG')) {
+      delete env[key];
+    }
+  }
+  delete env.GIT_DIR;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_COMMON_DIR;
+  delete env.GIT_OBJECT_DIRECTORY;
+  env.GIT_CONFIG_GLOBAL = devNull;
+  env.GIT_CONFIG_SYSTEM = devNull;
+  return env;
+}
+
+function fixtureGit(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, env: fixtureEnv(), stdio: 'pipe' });
+}
+
+function fixtureGitOut(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    env: fixtureEnv(),
+    encoding: 'utf8',
+    stdio: 'pipe',
+  }).trim();
+}
+
+/** Real git shell-outs, mirroring production's createLocalCoordinationInputs. */
+function realLocalInputs(primary: string): LocalCoordinationInputs {
+  const run = (cwd: string, args: string[]) => {
+    try {
+      return {
+        ok: true as const,
+        stdout: fixtureGitOut(cwd, args),
+        stderr: '',
+      };
+    } catch (err) {
+      const failure = err as { stderr?: unknown };
+      return {
+        ok: false as const,
+        stdout: '',
+        stderr: typeof failure.stderr === 'string' ? failure.stderr : '',
+      };
+    }
+  };
+  return {
+    listWorktrees: () => run(primary, ['worktree', 'list', '--porcelain']),
+    statusPorcelain: (worktreePath) =>
+      run(worktreePath, ['status', '--porcelain']),
+    resolveGitPath: (worktreePath, name) =>
+      run(worktreePath, ['rev-parse', '--git-path', name]),
+    pathExists: (path) => existsSync(path),
+    readFile: (path) => {
+      try {
+        return readFileSync(path, 'utf8');
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+function setupPrimaryRepo(): string {
+  const primary = mkdtempSync(join(tmpdir(), 'idd-roadmap-local-'));
+  fixtureGit(primary, ['init', '-b', 'main']);
+  fixtureGit(primary, ['config', 'user.email', 'test@example.com']);
+  fixtureGit(primary, ['config', 'user.name', 'Test']);
+  writeFileSync(join(primary, 'seed.txt'), 'seed\n');
+  fixtureGit(primary, ['add', 'seed.txt']);
+  fixtureGit(primary, ['commit', '-m', 'seed']);
+  return primary;
+}
+
+test('AC2 real fixture: no worktree for the claim branch is cleanly absent', () => {
+  const primary = setupPrimaryRepo();
+  try {
+    const verdict = evaluateLocalCoordinationState(
+      'roadmap-audit/995-slug',
+      realLocalInputs(primary),
+    );
+    assert.equal(verdict.presence, 'absent');
+    assert.equal(verdict.unreadable, false);
+  } finally {
+    rmSync(primary, { recursive: true, force: true });
+  }
+});
+
+test('AC2 real fixture: a checked-out claim branch with uncommitted content is present-broken (not absent)', () => {
+  const primary = setupPrimaryRepo();
+  const worktree = join(primary, '..', `${basename(primary)}-wt`);
+  try {
+    fixtureGit(primary, [
+      'worktree',
+      'add',
+      worktree,
+      '-b',
+      'roadmap-audit/995-slug',
+      'main',
+    ]);
+    writeFileSync(join(worktree, 'leftover.txt'), 'uncommitted\n');
+
+    const verdict = evaluateLocalCoordinationState(
+      'roadmap-audit/995-slug',
+      realLocalInputs(primary),
+    );
+    assert.equal(verdict.presence, 'present-broken');
+    assert.deepEqual(verdict.brokenReasons, ['uncommitted content present']);
+  } finally {
+    try {
+      fixtureGit(primary, ['worktree', 'remove', '--force', worktree]);
+    } catch {
+      // best-effort cleanup
+    }
+    rmSync(worktree, { recursive: true, force: true });
+    rmSync(primary, { recursive: true, force: true });
+  }
+});
+
+test('AC3 real fixture: a detached worktree is correctly detected via porcelain enumeration (branch-name grep would miss it)', () => {
+  const primary = setupPrimaryRepo();
+  const detached = join(primary, '..', `${basename(primary)}-detached`);
+  try {
+    const head = fixtureGitOut(primary, ['rev-parse', 'HEAD']);
+    fixtureGit(primary, ['worktree', 'add', '--detach', detached, head]);
+
+    const porcelain = fixtureGitOut(primary, [
+      'worktree',
+      'list',
+      '--porcelain',
+    ]);
+    const entries = parseWorktreeListPorcelain(porcelain);
+    const detachedEntry = entries.find((entry) => entry.path === detached);
+    assert.equal(detachedEntry?.detached, true);
+    assert.equal(detachedEntry?.branchRef, null);
+
+    // A branch-name grep has nothing to match here (#2225's whole premise):
+    // no entry in the listing carries a `branch` line for this worktree.
+    const verdict = evaluateLocalCoordinationState(
+      'roadmap-audit/995-slug',
+      realLocalInputs(primary),
+    );
+    assert.deepEqual(verdict.detachedWorktreePaths, [detached]);
+  } finally {
+    try {
+      fixtureGit(primary, ['worktree', 'remove', '--force', detached]);
+    } catch {
+      // best-effort cleanup
+    }
+    rmSync(detached, { recursive: true, force: true });
+    rmSync(primary, { recursive: true, force: true });
+  }
+});
+
+test('AC4 real fixture: an in-progress rebase in a LINKED worktree is detected via the resolved git-path (hardcoded .git/rebase-merge would miss it)', () => {
+  const primary = setupPrimaryRepo();
+  const worktree = join(primary, '..', `${basename(primary)}-wt`);
+  try {
+    fixtureGit(primary, [
+      'worktree',
+      'add',
+      worktree,
+      '-b',
+      'roadmap-audit/995-slug',
+      'main',
+    ]);
+    // Diverge main and the claim branch so rebasing produces a real conflict.
+    fixtureGit(primary, ['checkout', '-b', 'conflict-base', 'main']);
+    writeFileSync(join(primary, 'seed.txt'), 'main change\n');
+    fixtureGit(primary, ['add', 'seed.txt']);
+    fixtureGit(primary, ['commit', '-m', 'main change']);
+
+    writeFileSync(join(worktree, 'seed.txt'), 'branch change\n');
+    fixtureGit(worktree, ['add', 'seed.txt']);
+    fixtureGit(worktree, ['commit', '-m', 'branch change']);
+    try {
+      fixtureGit(worktree, ['rebase', 'conflict-base']);
+      assert.fail('expected the rebase to conflict');
+    } catch {
+      // expected: the rebase stops mid-way with a conflict.
+    }
+
+    // The naive hardcoded path a branch-name-only implementation would use
+    // does not exist for a LINKED worktree — `.git` there is a pointer file,
+    // so the real sequencer state is NOT under `<worktree>/.git/rebase-merge`.
+    assert.equal(existsSync(join(worktree, '.git', 'rebase-merge')), false);
+    // The resolved --git-path DOES exist — this is what a caller must use.
+    const resolvedRebaseMerge = fixtureGitOut(worktree, [
+      'rev-parse',
+      '--git-path',
+      'rebase-merge',
+    ]);
+    assert.equal(
+      existsSync(join(worktree, resolvedRebaseMerge)) ||
+        existsSync(resolvedRebaseMerge),
+      true,
+    );
+
+    const verdict = evaluateLocalCoordinationState(
+      'roadmap-audit/995-slug',
+      realLocalInputs(primary),
+    );
+    assert.equal(verdict.presence, 'present-broken');
+    assert.ok(
+      verdict.brokenReasons.includes('rebase in progress'),
+      `expected rebase in progress among: ${verdict.brokenReasons.join(', ')}`,
+    );
+  } finally {
+    try {
+      fixtureGit(worktree, ['rebase', '--abort']);
+    } catch {
+      // best-effort: only present if the conflict was never resolved
+    }
+    try {
+      fixtureGit(primary, ['worktree', 'remove', '--force', worktree]);
+    } catch {
+      // best-effort cleanup
+    }
+    rmSync(worktree, { recursive: true, force: true });
+    rmSync(primary, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// runRoadmapAuditExecute wiring: inspectLocalCoordinationState (#2225)
+// ---------------------------------------------------------------------------
+
+test('--apply skips the local coordination check entirely when the dep is absent (default deps stay valid)', async () => {
+  const { deps } = makeDeps(readyReport());
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+  assert.equal(exitCode, 0);
+  assert.equal(verdict.closed, true);
+  assert.equal(verdict.localCoordinationNote, undefined);
+});
+
+test('--apply proceeds and omits the note when the local coordination state is absent (common case)', async () => {
+  let receivedBranch: string | null = null;
+  const { deps, calls } = makeDeps(readyReport(), {
+    inspectLocalCoordinationState: (branchName) => {
+      receivedBranch = branchName;
+      return {
+        presence: 'absent',
+        path: null,
+        brokenReasons: [],
+        detachedWorktreePaths: [],
+        unreadable: false,
+        unreadableReason: null,
+      };
+    },
+  });
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+  assert.equal(exitCode, 0);
+  assert.equal(verdict.closed, true);
+  assert.equal(verdict.localCoordinationNote, undefined);
+  assert.equal(receivedBranch, CLAIM_BRANCH);
+  assert.deepEqual(calls.closed, [ROADMAP]);
+});
+
+test('--apply proceeds with an informational note when the local worktree is present-clean', async () => {
+  const { deps, calls } = makeDeps(readyReport(), {
+    inspectLocalCoordinationState: () => ({
+      presence: 'present-clean',
+      path: '/repo/wt',
+      brokenReasons: [],
+      detachedWorktreePaths: [],
+      unreadable: false,
+      unreadableReason: null,
+    }),
+  });
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+  assert.equal(exitCode, 0);
+  assert.equal(verdict.closed, true);
+  assert.match(verdict.localCoordinationNote ?? '', /clean local worktree/);
+  assert.deepEqual(calls.closed, [ROADMAP]);
+});
+
+test('--apply proceeds with an informational note when local state is unreadable (fail-open)', async () => {
+  const { deps, calls } = makeDeps(readyReport(), {
+    inspectLocalCoordinationState: () => ({
+      presence: 'absent',
+      path: null,
+      brokenReasons: [],
+      detachedWorktreePaths: [],
+      unreadable: true,
+      unreadableReason: 'git: command not found',
+    }),
+  });
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+  assert.equal(exitCode, 0);
+  assert.equal(verdict.closed, true);
+  assert.match(verdict.localCoordinationNote ?? '', /unreadable/);
+  assert.deepEqual(calls.closed, [ROADMAP]);
+});
+
+test('--apply fails closed (no mutation) when the local worktree is present-broken', async () => {
+  const { deps, calls } = makeDeps(readyReport(), {
+    inspectLocalCoordinationState: () => ({
+      presence: 'present-broken',
+      path: '/repo/wt',
+      brokenReasons: ['uncommitted content present'],
+      detachedWorktreePaths: [],
+      unreadable: false,
+      unreadableReason: null,
+    }),
+  });
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+  assert.equal(exitCode, 1);
+  assert.equal(verdict.closed, false);
+  assert.match(verdict.result, /local coordination state unsafe/);
+  assert.match(
+    verdict.localCoordinationNote ?? '',
+    /not safe to treat as reusable/,
+  );
+  assert.deepEqual(calls.closed, []);
+  assert.deepEqual(calls.comments, []);
+  assert.deepEqual(calls.released, []);
+});
+
+test('--apply calls inspectLocalCoordinationState exactly once, before the graph re-fetch', async () => {
+  let calls = 0;
+  const { deps } = makeDeps(readyReport(), {
+    inspectLocalCoordinationState: () => {
+      calls += 1;
+      return {
+        presence: 'absent',
+        path: null,
+        brokenReasons: [],
+        detachedWorktreePaths: [],
+        unreadable: false,
+        unreadableReason: null,
+      };
+    },
+  });
+  const { exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+  assert.equal(exitCode, 0);
+  assert.equal(calls, 1);
 });

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -22,6 +22,7 @@ import {
   evaluateRoadmapAuditGates,
   evaluateRoadmapClaim,
   explainRoadmapClaimReason,
+  findWorktreeEntriesForBranch,
   findWorktreeEntryForBranch,
   hasTrustedCompletionEvidenceComment,
   type LocalCoordinationInputs,
@@ -1751,6 +1752,34 @@ test('findWorktreeEntryForBranch never matches a detached entry', () => {
   );
 });
 
+test('findWorktreeEntriesForBranch returns EVERY match, not just the first (git checkout --ignore-other-worktrees can duplicate a checkout)', () => {
+  const entries = parseWorktreeListPorcelain(
+    [
+      'worktree /repo/first',
+      'HEAD abc123',
+      'branch refs/heads/roadmap-audit/995-slug',
+      '',
+      'worktree /repo/second',
+      'HEAD abc123',
+      'branch refs/heads/roadmap-audit/995-slug',
+      '',
+    ].join('\n'),
+  );
+  const matches = findWorktreeEntriesForBranch(
+    entries,
+    'roadmap-audit/995-slug',
+  );
+  assert.deepEqual(
+    matches.map((entry) => entry.path),
+    ['/repo/first', '/repo/second'],
+  );
+  // findWorktreeEntryForBranch stays the first-match convenience wrapper.
+  assert.equal(
+    findWorktreeEntryForBranch(entries, 'roadmap-audit/995-slug')?.path,
+    '/repo/first',
+  );
+});
+
 // ---------------------------------------------------------------------------
 // evaluateLocalCoordinationState (pure, injected inputs, #2225)
 // ---------------------------------------------------------------------------
@@ -2008,6 +2037,45 @@ test('evaluateLocalCoordinationState leaves an UNRELATED detached/rebasing workt
   );
   assert.equal(verdict.presence, 'absent');
   assert.deepEqual(verdict.detachedWorktreePaths, ['/repo/other-wt']);
+});
+
+test('evaluateLocalCoordinationState evaluates EVERY matched worktree, not just the first: a clean first match does not hide a broken second one', () => {
+  const calls = { status: 0, gitPath: 0 };
+  const verdict = evaluateLocalCoordinationState(
+    'roadmap-audit/995-slug',
+    localInputs({
+      listWorktrees: () =>
+        OK(
+          [
+            'worktree /repo/first',
+            'HEAD abc123',
+            'branch refs/heads/roadmap-audit/995-slug',
+            '',
+            'worktree /repo/second',
+            'HEAD abc123',
+            'branch refs/heads/roadmap-audit/995-slug',
+            '',
+          ].join('\n'),
+        ),
+      statusPorcelain: (worktreePath) => {
+        calls.status += 1;
+        return worktreePath === '/repo/second' ? OK(' M file.txt\n') : OK('');
+      },
+      resolveGitPath: () => {
+        calls.gitPath += 1;
+        return FAIL('no such path');
+      },
+    }),
+  );
+  assert.equal(verdict.presence, 'present-broken');
+  // First match's path stays the reported `path`; its own reason (if any)
+  // is unprefixed, matching the pre-#2225-P2-fix single-match behavior.
+  assert.equal(verdict.path, '/repo/first');
+  assert.deepEqual(verdict.brokenReasons, [
+    'at /repo/second: uncommitted content present',
+  ]);
+  // Both matched worktrees were actually probed, not just the first.
+  assert.equal(calls.status, 2);
 });
 
 // ---------------------------------------------------------------------------
@@ -2339,7 +2407,7 @@ test('--apply fails closed (no mutation) when the local worktree is present-brok
   assert.deepEqual(calls.released, []);
 });
 
-test('--apply calls inspectLocalCoordinationState exactly once, before the graph re-fetch', async () => {
+test('--apply calls inspectLocalCoordinationState at all three claim re-validation points (TOCTOU coverage, #2225)', async () => {
   let calls = 0;
   const { deps } = makeDeps(readyReport(), {
     inspectLocalCoordinationState: () => {
@@ -2356,5 +2424,65 @@ test('--apply calls inspectLocalCoordinationState exactly once, before the graph
   });
   const { exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
   assert.equal(exitCode, 0);
-  assert.equal(calls, 1);
+  // early + post-refetch + pre-close, mirroring the claim re-validation count.
+  assert.equal(calls, 3);
+});
+
+test('--apply fails closed when the local worktree turns broken DURING the graph re-fetch (TOCTOU, #2225)', async () => {
+  let calls = 0;
+  const { deps, calls: mutationCalls } = makeDeps(readyReport(), {
+    inspectLocalCoordinationState: () => {
+      calls += 1;
+      const broken = calls >= 2;
+      return {
+        presence: broken ? 'present-broken' : 'absent',
+        path: broken ? '/repo/wt' : null,
+        brokenReasons: broken ? ['uncommitted content present'] : [],
+        detachedWorktreePaths: [],
+        unreadable: false,
+        unreadableReason: null,
+      };
+    },
+  });
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+  assert.equal(exitCode, 1);
+  assert.equal(verdict.closed, false);
+  assert.match(verdict.result, /local coordination state unsafe/);
+  assert.deepEqual(mutationCalls.closed, []);
+  assert.deepEqual(mutationCalls.comments, []);
+  // Caught at the post-refetch check, before the evidence comment ever posts.
+  assert.equal(calls, 2);
+});
+
+test('--apply fails closed when the local worktree turns broken in the comment→close gap (TOCTOU, #2225)', async () => {
+  let calls = 0;
+  const { deps, calls: mutationCalls } = makeDeps(readyReport(), {
+    inspectLocalCoordinationState: () => {
+      calls += 1;
+      const broken = calls >= 3;
+      return {
+        presence: broken ? 'present-broken' : 'absent',
+        path: broken ? '/repo/wt' : null,
+        brokenReasons: broken ? ['rebase in progress'] : [],
+        detachedWorktreePaths: [],
+        unreadable: false,
+        unreadableReason: null,
+      };
+    },
+  });
+  const { verdict, exitCode } = await runRoadmapAuditExecute(APPLY_ARGS, deps);
+  assert.equal(exitCode, 1);
+  assert.equal(verdict.closed, false);
+  assert.match(verdict.result, /local coordination state unsafe/);
+  // The evidence comment DID post (posted before this final check runs) but
+  // the close/release must not — mirrors the existing comment→close claim
+  // re-validation's own message shape.
+  assert.match(
+    verdict.result,
+    /evidence comment posted but roadmap NOT closed/,
+  );
+  assert.equal(mutationCalls.comments.length, 1);
+  assert.deepEqual(mutationCalls.closed, []);
+  assert.deepEqual(mutationCalls.released, []);
+  assert.equal(calls, 3);
 });

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -1634,13 +1634,36 @@ test('missing --roadmap is rejected', async () => {
   );
 });
 
+/**
+ * Convert a "friendly" newline-delimited fixture (a field per line, a
+ * blank line between stanzas — the pre-#2225-P2-fix text porcelain shape)
+ * into the real `git worktree list --porcelain -z` wire format the parser
+ * now requires: each field NUL-terminated, each record terminated by an
+ * extra NUL. Keeps the many existing fixtures readable while still
+ * exercising the actual NUL-delimited parsing path.
+ */
+function toZ(text: string): string {
+  return text
+    .trim()
+    .split(/\n\n+/)
+    .map(
+      (stanza) =>
+        `${stanza
+          .trim()
+          .split('\n')
+          .filter((line) => line.length > 0)
+          .join('\0')}\0\0`,
+    )
+    .join('');
+}
+
 // ---------------------------------------------------------------------------
 // parseWorktreeListPorcelain (pure, #2225)
 // ---------------------------------------------------------------------------
 
 test('parseWorktreeListPorcelain parses a normal branch stanza', () => {
   const entries = parseWorktreeListPorcelain(
-    'worktree /repo/main\nHEAD abc123\nbranch refs/heads/main\n',
+    toZ('worktree /repo/main\nHEAD abc123\nbranch refs/heads/main\n'),
   );
   assert.equal(entries.length, 1);
   assert.equal(entries[0]?.path, '/repo/main');
@@ -1651,7 +1674,7 @@ test('parseWorktreeListPorcelain parses a normal branch stanza', () => {
 
 test('parseWorktreeListPorcelain flags a detached stanza with no branch', () => {
   const entries = parseWorktreeListPorcelain(
-    'worktree /repo/detached\nHEAD abc123\ndetached\n',
+    toZ('worktree /repo/detached\nHEAD abc123\ndetached\n'),
   );
   assert.equal(entries[0]?.detached, true);
   assert.equal(entries[0]?.branchRef, null);
@@ -1659,7 +1682,9 @@ test('parseWorktreeListPorcelain flags a detached stanza with no branch', () => 
 
 test('parseWorktreeListPorcelain captures a locked reason', () => {
   const entries = parseWorktreeListPorcelain(
-    'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/feature\nlocked manual lock test\n',
+    toZ(
+      'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/feature\nlocked manual lock test\n',
+    ),
   );
   assert.equal(entries[0]?.locked, true);
   assert.equal(entries[0]?.lockReason, 'manual lock test');
@@ -1667,7 +1692,7 @@ test('parseWorktreeListPorcelain captures a locked reason', () => {
 
 test('parseWorktreeListPorcelain treats a bare "locked" line as lock-with-no-reason', () => {
   const entries = parseWorktreeListPorcelain(
-    'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/feature\nlocked\n',
+    toZ('worktree /repo/wt\nHEAD abc123\nbranch refs/heads/feature\nlocked\n'),
   );
   assert.equal(entries[0]?.locked, true);
   assert.equal(entries[0]?.lockReason, null);
@@ -1675,7 +1700,9 @@ test('parseWorktreeListPorcelain treats a bare "locked" line as lock-with-no-rea
 
 test('parseWorktreeListPorcelain captures a prunable reason', () => {
   const entries = parseWorktreeListPorcelain(
-    'worktree /repo/gone\nHEAD abc123\nbranch refs/heads/gone-branch\nprunable gitdir file points to non-existent location\n',
+    toZ(
+      'worktree /repo/gone\nHEAD abc123\nbranch refs/heads/gone-branch\nprunable gitdir file points to non-existent location\n',
+    ),
   );
   assert.equal(entries[0]?.prunable, true);
   assert.equal(
@@ -1684,17 +1711,19 @@ test('parseWorktreeListPorcelain captures a prunable reason', () => {
   );
 });
 
-test('parseWorktreeListPorcelain parses multiple blank-line-separated stanzas', () => {
-  const output = [
-    'worktree /repo/main',
-    'HEAD abc123',
-    'branch refs/heads/main',
-    '',
-    'worktree /repo/feature',
-    'HEAD def456',
-    'branch refs/heads/feature',
-    '',
-  ].join('\n');
+test('parseWorktreeListPorcelain parses multiple record-separated stanzas', () => {
+  const output = toZ(
+    [
+      'worktree /repo/main',
+      'HEAD abc123',
+      'branch refs/heads/main',
+      '',
+      'worktree /repo/feature',
+      'HEAD def456',
+      'branch refs/heads/feature',
+      '',
+    ].join('\n'),
+  );
   const entries = parseWorktreeListPorcelain(output);
   assert.deepEqual(
     entries.map((entry) => entry.path),
@@ -1702,11 +1731,15 @@ test('parseWorktreeListPorcelain parses multiple blank-line-separated stanzas', 
   );
 });
 
-test('parseWorktreeListPorcelain tolerates CRLF line endings', () => {
-  const entries = parseWorktreeListPorcelain(
-    'worktree /repo/main\r\nHEAD abc123\r\nbranch refs/heads/main\r\n',
-  );
-  assert.equal(entries[0]?.path, '/repo/main');
+test('parseWorktreeListPorcelain is immune to a path containing a literal blank line (review finding, #2225: the prior newline-delimited format was not)', () => {
+  // A path with an embedded "\n\n" used to be indistinguishable from a
+  // record separator under the old newline-delimited format, silently
+  // hiding this worktree/branch from every downstream check.
+  const trickyPath = '/repo/oh\n\nno';
+  const output = `worktree ${trickyPath}\0HEAD abc123\0branch refs/heads/main\0\0`;
+  const entries = parseWorktreeListPorcelain(output);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0]?.path, trickyPath);
   assert.equal(entries[0]?.branchRef, 'refs/heads/main');
 });
 
@@ -1721,7 +1754,9 @@ test('parseWorktreeListPorcelain returns an empty array for malformed/empty inpu
 
 test('findWorktreeEntryForBranch matches by content-exact branch name', () => {
   const entries = parseWorktreeListPorcelain(
-    'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+    toZ(
+      'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+    ),
   );
   const match = findWorktreeEntryForBranch(entries, 'roadmap-audit/995-slug');
   assert.equal(match?.path, '/repo/wt');
@@ -1729,7 +1764,7 @@ test('findWorktreeEntryForBranch matches by content-exact branch name', () => {
 
 test('findWorktreeEntryForBranch returns null when no entry matches', () => {
   const entries = parseWorktreeListPorcelain(
-    'worktree /repo/main\nHEAD abc123\nbranch refs/heads/main\n',
+    toZ('worktree /repo/main\nHEAD abc123\nbranch refs/heads/main\n'),
   );
   assert.equal(
     findWorktreeEntryForBranch(entries, 'roadmap-audit/995-slug'),
@@ -1739,7 +1774,7 @@ test('findWorktreeEntryForBranch returns null when no entry matches', () => {
 
 test('findWorktreeEntryForBranch never matches a detached entry', () => {
   const entries = parseWorktreeListPorcelain(
-    'worktree /repo/detached\nHEAD abc123\ndetached\n',
+    toZ('worktree /repo/detached\nHEAD abc123\ndetached\n'),
   );
   assert.equal(
     findWorktreeEntryForBranch(entries, 'roadmap-audit/995-slug'),
@@ -1749,16 +1784,18 @@ test('findWorktreeEntryForBranch never matches a detached entry', () => {
 
 test('findWorktreeEntriesForBranch returns EVERY match, not just the first (git checkout --ignore-other-worktrees can duplicate a checkout)', () => {
   const entries = parseWorktreeListPorcelain(
-    [
-      'worktree /repo/first',
-      'HEAD abc123',
-      'branch refs/heads/roadmap-audit/995-slug',
-      '',
-      'worktree /repo/second',
-      'HEAD abc123',
-      'branch refs/heads/roadmap-audit/995-slug',
-      '',
-    ].join('\n'),
+    toZ(
+      [
+        'worktree /repo/first',
+        'HEAD abc123',
+        'branch refs/heads/roadmap-audit/995-slug',
+        '',
+        'worktree /repo/second',
+        'HEAD abc123',
+        'branch refs/heads/roadmap-audit/995-slug',
+        '',
+      ].join('\n'),
+    ),
   );
   const matches = findWorktreeEntriesForBranch(
     entries,
@@ -1819,7 +1856,7 @@ test('evaluateLocalCoordinationState reports absent when no worktree matches (th
     'roadmap-audit/995-slug',
     localInputs({
       listWorktrees: () =>
-        OK('worktree /repo/main\nHEAD abc123\nbranch refs/heads/main\n'),
+        OK(toZ('worktree /repo/main\nHEAD abc123\nbranch refs/heads/main\n')),
     }),
   );
   assert.equal(verdict.presence, 'absent');
@@ -1843,7 +1880,9 @@ test('evaluateLocalCoordinationState reports present-clean for a matched, clean,
     localInputs({
       listWorktrees: () =>
         OK(
-          'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+          toZ(
+            'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+          ),
         ),
       statusPorcelain: () => OK(''),
       resolveGitPath: () => FAIL('no such path'),
@@ -1860,7 +1899,9 @@ test('evaluateLocalCoordinationState reports present-broken with uncommitted con
     localInputs({
       listWorktrees: () =>
         OK(
-          'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+          toZ(
+            'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+          ),
         ),
       statusPorcelain: () => OK(' M file.txt\n'),
       resolveGitPath: () => FAIL('no such path'),
@@ -1876,7 +1917,9 @@ test('evaluateLocalCoordinationState reports present-broken with rebase in progr
     localInputs({
       listWorktrees: () =>
         OK(
-          'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+          toZ(
+            'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+          ),
         ),
       statusPorcelain: () => OK(''),
       resolveGitPath: (_worktreePath, name) =>
@@ -1896,7 +1939,9 @@ test('evaluateLocalCoordinationState resolves a RELATIVE --git-path output again
     localInputs({
       listWorktrees: () =>
         OK(
-          'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+          toZ(
+            'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+          ),
         ),
       statusPorcelain: () => OK(''),
       resolveGitPath: (_worktreePath, name) =>
@@ -1915,7 +1960,9 @@ test('evaluateLocalCoordinationState reports locked directly from porcelain with
     localInputs({
       listWorktrees: () =>
         OK(
-          'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\nlocked manual lock test\n',
+          toZ(
+            'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\nlocked manual lock test\n',
+          ),
         ),
       calls,
     }),
@@ -1933,7 +1980,9 @@ test('evaluateLocalCoordinationState reports prunable directly from porcelain wi
     localInputs({
       listWorktrees: () =>
         OK(
-          'worktree /repo/gone\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\nprunable gitdir file points to non-existent location\n',
+          toZ(
+            'worktree /repo/gone\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\nprunable gitdir file points to non-existent location\n',
+          ),
         ),
       calls,
     }),
@@ -1952,7 +2001,9 @@ test('evaluateLocalCoordinationState treats a matched worktree with an unreadabl
     localInputs({
       listWorktrees: () =>
         OK(
-          'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+          toZ(
+            'worktree /repo/wt\nHEAD abc123\nbranch refs/heads/roadmap-audit/995-slug\n',
+          ),
         ),
       statusPorcelain: () => FAIL('no such directory'),
       resolveGitPath: () => FAIL('no such path'),
@@ -1971,16 +2022,18 @@ test('evaluateLocalCoordinationState surfaces repo-wide detached worktrees as in
     localInputs({
       listWorktrees: () =>
         OK(
-          [
-            'worktree /repo/main',
-            'HEAD abc123',
-            'branch refs/heads/main',
-            '',
-            'worktree /repo/detached',
-            'HEAD def456',
-            'detached',
-            '',
-          ].join('\n'),
+          toZ(
+            [
+              'worktree /repo/main',
+              'HEAD abc123',
+              'branch refs/heads/main',
+              '',
+              'worktree /repo/detached',
+              'HEAD def456',
+              'detached',
+              '',
+            ].join('\n'),
+          ),
         ),
     }),
   );
@@ -1992,7 +2045,8 @@ test('evaluateLocalCoordinationState matches a DETACHED mid-rebase worktree via 
   const verdict = evaluateLocalCoordinationState(
     'roadmap-audit/995-slug',
     localInputs({
-      listWorktrees: () => OK('worktree /repo/wt\nHEAD abc123\ndetached\n'),
+      listWorktrees: () =>
+        OK(toZ('worktree /repo/wt\nHEAD abc123\ndetached\n')),
       statusPorcelain: () => OK(''),
       resolveGitPath: (_worktreePath, name) =>
         name === 'rebase-merge'
@@ -2017,7 +2071,7 @@ test('evaluateLocalCoordinationState leaves an UNRELATED detached/rebasing workt
     'roadmap-audit/995-slug',
     localInputs({
       listWorktrees: () =>
-        OK('worktree /repo/other-wt\nHEAD abc123\ndetached\n'),
+        OK(toZ('worktree /repo/other-wt\nHEAD abc123\ndetached\n')),
       resolveGitPath: (_worktreePath, name) =>
         name === 'rebase-merge'
           ? OK('/repo/.git/worktrees/other-wt/rebase-merge\n')
@@ -2041,16 +2095,18 @@ test('evaluateLocalCoordinationState evaluates EVERY matched worktree, not just 
     localInputs({
       listWorktrees: () =>
         OK(
-          [
-            'worktree /repo/first',
-            'HEAD abc123',
-            'branch refs/heads/roadmap-audit/995-slug',
-            '',
-            'worktree /repo/second',
-            'HEAD abc123',
-            'branch refs/heads/roadmap-audit/995-slug',
-            '',
-          ].join('\n'),
+          toZ(
+            [
+              'worktree /repo/first',
+              'HEAD abc123',
+              'branch refs/heads/roadmap-audit/995-slug',
+              '',
+              'worktree /repo/second',
+              'HEAD abc123',
+              'branch refs/heads/roadmap-audit/995-slug',
+              '',
+            ].join('\n'),
+          ),
         ),
       statusPorcelain: (worktreePath) => {
         calls.status += 1;
@@ -2187,6 +2243,7 @@ test('AC3 real fixture: a detached worktree is correctly detected via porcelain 
       'worktree',
       'list',
       '--porcelain',
+      '-z',
     ]);
     const entries = parseWorktreeListPorcelain(porcelain);
     const detachedEntry = entries.find((entry) => entry.path === detached);

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -2436,6 +2436,56 @@ test('real fixture: a dirty submodule reports present-broken even under diff.ign
   }
 });
 
+test('real fixture: a worktree path with trailing whitespace is matched correctly, not silently trimmed away (review finding, #2225)', () => {
+  const primary = setupPrimaryRepo();
+  // A trailing space in the directory name: `-z`'s exact field boundary
+  // preserves it, and the parser must not strip it back off.
+  const worktree = join(primary, '..', `${basename(primary)}-wt `);
+  try {
+    fixtureGit(primary, [
+      'worktree',
+      'add',
+      worktree,
+      '-b',
+      'roadmap-audit/995-slug',
+      'main',
+    ]);
+    writeFileSync(join(worktree, 'leftover.txt'), 'uncommitted\n');
+
+    const verdict = evaluateLocalCoordinationState(
+      'roadmap-audit/995-slug',
+      realLocalInputs(primary),
+    );
+    assert.equal(verdict.presence, 'present-broken');
+    assert.equal(verdict.path, worktree);
+    assert.deepEqual(verdict.brokenReasons, ['uncommitted content present']);
+  } finally {
+    try {
+      fixtureGit(primary, ['worktree', 'remove', '--force', worktree]);
+    } catch {
+      // best-effort cleanup
+    }
+    rmSync(worktree, { recursive: true, force: true });
+    rmSync(primary, { recursive: true, force: true });
+  }
+});
+
+test('real fixture: a spawn-level failure (missing cwd) surfaces its own error message, not just a generic fallback (review finding, #2225)', () => {
+  const verdict = evaluateLocalCoordinationState(
+    'roadmap-audit/995-slug',
+    createLocalCoordinationInputs(
+      join(tmpdir(), 'idd-roadmap-nonexistent-cwd-does-not-exist'),
+    ),
+  );
+  assert.equal(verdict.presence, 'absent');
+  assert.equal(verdict.unreadable, true);
+  assert.notEqual(
+    verdict.unreadableReason,
+    'git worktree list --porcelain failed',
+  );
+  assert.match(verdict.unreadableReason ?? '', /ENOENT/);
+});
+
 test('real fixture: local git shell-outs ignore ambient GIT_* overrides and never reach a sentinel repo (review finding, #2225)', () => {
   // Differential test: `sentinel` has NO roadmap-audit branch at all, while
   // `primary` has a real, clean worktree checked out on one. An unsanitized

--- a/tests/idd-roadmap-audit-execute.test.mts
+++ b/tests/idd-roadmap-audit-execute.test.mts
@@ -2316,6 +2316,69 @@ test('real fixture: an untracked-only leftover reports present-broken even under
   }
 });
 
+test('real fixture: a dirty submodule reports present-broken even under diff.ignoreSubmodules=all (review finding, #2225)', () => {
+  const submoduleUpstream = mkdtempSync(join(tmpdir(), 'idd-roadmap-submod-'));
+  const primary = setupPrimaryRepo();
+  const worktree = join(primary, '..', `${basename(primary)}-wt`);
+  try {
+    fixtureGit(submoduleUpstream, ['init', '-b', 'main']);
+    fixtureGit(submoduleUpstream, ['config', 'user.email', 'test@example.com']);
+    fixtureGit(submoduleUpstream, ['config', 'user.name', 'Test']);
+    writeFileSync(join(submoduleUpstream, 'f.txt'), 'one\n');
+    fixtureGit(submoduleUpstream, ['add', 'f.txt']);
+    fixtureGit(submoduleUpstream, ['commit', '-m', 'init']);
+
+    fixtureGit(primary, [
+      '-c',
+      'protocol.file.allow=always',
+      'submodule',
+      'add',
+      submoduleUpstream,
+      'sub',
+    ]);
+    fixtureGit(primary, ['commit', '-m', 'add submodule']);
+    fixtureGit(primary, [
+      'worktree',
+      'add',
+      worktree,
+      '-b',
+      'roadmap-audit/995-slug',
+      'main',
+    ]);
+    // `worktree add` does not check the submodule out on its own; the new
+    // worktree's `sub/` starts empty until explicitly initialized.
+    fixtureGit(worktree, [
+      '-c',
+      'protocol.file.allow=always',
+      'submodule',
+      'update',
+      '--init',
+    ]);
+    fixtureGit(worktree, ['config', 'diff.ignoreSubmodules', 'all']);
+    writeFileSync(join(worktree, 'sub', 'f.txt'), 'two\n');
+
+    // Sanity: an UNQUALIFIED status --porcelain really does go empty under
+    // this config, which is exactly the bypass the fix guards against.
+    assert.equal(fixtureGitOut(worktree, ['status', '--porcelain']), '');
+
+    const verdict = evaluateLocalCoordinationState(
+      'roadmap-audit/995-slug',
+      realLocalInputs(primary),
+    );
+    assert.equal(verdict.presence, 'present-broken');
+    assert.deepEqual(verdict.brokenReasons, ['uncommitted content present']);
+  } finally {
+    try {
+      fixtureGit(primary, ['worktree', 'remove', '--force', worktree]);
+    } catch {
+      // best-effort cleanup
+    }
+    rmSync(worktree, { recursive: true, force: true });
+    rmSync(primary, { recursive: true, force: true });
+    rmSync(submoduleUpstream, { recursive: true, force: true });
+  }
+});
+
 test('real fixture: local git shell-outs ignore ambient GIT_* overrides and never reach a sentinel repo (review finding, #2225)', () => {
   // Differential test: `sentinel` has NO roadmap-audit branch at all, while
   // `primary` has a real, clean worktree checked out on one. An unsanitized

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -403,6 +403,7 @@ export const iddRoadmapAuditExecuteKeys = [
   'claimReleased',
   'result',
   'viewerLoginUnavailable',
+  'localCoordinationNote',
 ] as const satisfies readonly (keyof IddRoadmapAuditExecuteVerdict)[];
 
 export const forcedHandoffMarkerKeys = [


### PR DESCRIPTION
## Summary

`idd-roadmap-audit-execute.mts`'s claim re-validation proved who owns
the claim *record*, but never checked what was actually on disk under
the claimed `roadmap-audit/<n>-*` branch. This adds
`evaluateLocalCoordinationState`, wired into `--apply` immediately
after claim ownership is confirmed and before any mutation:

- Content-exact (not identity-only) branch matching via
  `git worktree list --porcelain`, since a branch-name grep cannot
  see a detached worktree at all.
- A distinct `present-clean` vs. `present-broken` outcome, driven by
  uncommitted content, porcelain `locked`/`prunable` flags, or an
  in-progress rebase.
- The rebase-sequencer path is resolved per-worktree via
  `git rev-parse --git-path rebase-merge`/`rebase-apply` rather than a
  hardcoded `.git/`-relative path, which only resolves for the primary
  worktree.
- A detached, mid-rebase worktree is matched via its rebase
  sequencer's own `head-name` file: `git rebase` detaches HEAD while
  sequencing, so porcelain never reports the real branch for it —
  empirically confirmed this was otherwise silently missed by
  branch-name matching alone, which is exactly the in-progress-rebase
  case these checks exist to catch.

No local worktree for the branch (the expected common case per
`idd-roadmap-audit.instructions.md`, which notes the coordination
branch normally requires no local checkout) and any local-git-read
failure both fail open; only a positively confirmed unsafe worktree
blocks the apply.

Refs #2225

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build` / `pnpm run build:check` (no drift)
- [x] `node --test tests/*.test.mts` (4403/4403 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `node scripts/verify-workshop-integrity.mjs --format table`
- [x] `cspell lint "**" --no-progress`
- [x] `markdownlint-cli2 "**/*.md"`
- [x] New tests include real-git fixtures (throwaway repos with actual
      linked/detached worktrees and a genuine conflicting rebase) for
      AC2–AC4, not just synthetic porcelain-text fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtcjhuuXDqQASYGXtJnmV3