### PR TITLE
feat(template): apply profile-conditional pattern to advisory-convergence workflows

### DIFF
--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -16,6 +16,14 @@
 # Runner: shipped default is `ubuntu-slim`. Override via the
 # `CI_RUNNER_LABEL` repository variable, matching the required
 # workflow. `defaults.run.shell` pins every `run:` step to `bash`.
+#
+# Profile resolution: mirrors post-merge-cleanup.yml's
+# helperRuntime.profile resolution and per-step `if:` gating. Unlike
+# the required idd-advisory-convergence.yml companion, an
+# `instructions-only` profile here simply skips the classify/rerun
+# steps -- this workflow is a best-effort refresh, not the merge-gate
+# verdict itself, so silently doing nothing on every review comment is
+# harmless.
 name: IDD advisory-convergence comment refresh
 concurrency:
   # Do not cancel: a later human LGTM must not abort an in-flight
@@ -42,18 +50,147 @@ jobs:
         with:
           ref: main
           persist-credentials: false
+      - name: Resolve helper-runtime profile
+        id: profile
+        run: |
+          # Fail-closed default, mirroring idd-doctor.mjs's
+          # resolveConfiguredHelperRuntime: an absent, unreadable, or
+          # invalid config -- or one that simply omits helperRuntime --
+          # resolves to instructions-only (no runnable command), never a
+          # guess at a runnable profile.
+          PROFILE="instructions-only"
+          PACKAGE_SPEC=""
+          for CANDIDATE in .github/idd/config.json idd-policy.json; do
+            if [ -f "$CANDIDATE" ]; then
+              if RESOLVED=$(jq -r '.helperRuntime.profile // empty' "$CANDIDATE" 2>/dev/null); then
+                case "$RESOLVED" in
+                  vendored-node | package-manager | ephemeral-npx | instructions-only)
+                    PROFILE="$RESOLVED"
+                    PACKAGE_SPEC=$(jq -r '.helperRuntime.packageSpec // empty' "$CANDIDATE" 2>/dev/null || echo "")
+                    ;;
+                esac
+              fi
+              # First present candidate file wins outright, valid or not
+              # -- never fall through to the legacy idd-policy.json name
+              # once the canonical file has been evaluated.
+              break
+            fi
+          done
+          echo "profile=$PROFILE" >> "$GITHUB_OUTPUT"
+          echo "package-spec=$PACKAGE_SPEC" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v4
+        if: steps.profile.outputs.profile != 'instructions-only'
         with:
           node-version: 24.x
+      - name: Detect package manager
+        id: manager
+        if: steps.profile.outputs.profile == 'package-manager'
+        run: |
+          # Same precedence as helper-runtime-manifest.mts's own
+          # detector: an explicit package.json "packageManager" field
+          # wins, then lockfile presence (pnpm-lock.yaml, then
+          # package-lock.json, then yarn.lock), defaulting to npm when
+          # nothing else matches.
+          MANAGER=$(node -e "
+            const fs = require('node:fs');
+            let declared = '';
+            try {
+              const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+              declared = String(pkg.packageManager || '').split('@')[0];
+            } catch {
+              // No readable package.json: fall through to lockfile detection.
+            }
+            if (['npm', 'pnpm', 'yarn'].includes(declared)) {
+              console.log(declared);
+            } else if (fs.existsSync('pnpm-lock.yaml')) {
+              console.log('pnpm');
+            } else if (fs.existsSync('package-lock.json')) {
+              console.log('npm');
+            } else if (fs.existsSync('yarn.lock')) {
+              console.log('yarn');
+            } else {
+              console.log('npm');
+            }
+          ")
+          echo "manager=$MANAGER" >> "$GITHUB_OUTPUT"
+      - name: Install dependencies (package-manager profile)
+        if: steps.profile.outputs.profile == 'package-manager'
+        env:
+          MANAGER: ${{ steps.manager.outputs.manager }}
+        run: |
+          case "$MANAGER" in
+            pnpm)
+              corepack enable
+              pnpm install --frozen-lockfile
+              ;;
+            yarn)
+              corepack enable
+              yarn install --frozen-lockfile
+              ;;
+            *)
+              npm ci
+              ;;
+          esac
       - name: Classify review comment
         id: origin
+        if: steps.profile.outputs.profile != 'instructions-only'
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
-        run: node scripts/review-comment-origin.mjs
+          PROFILE: ${{ steps.profile.outputs.profile }}
+          PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}
+          MANAGER: ${{ steps.manager.outputs.manager }}
+        run: |
+          case "$PROFILE" in
+            vendored-node)
+              node scripts/review-comment-origin.mjs
+              ;;
+            package-manager)
+              case "$MANAGER" in
+                pnpm)
+                  pnpm exec idd-review-comment-origin
+                  ;;
+                yarn)
+                  yarn idd-review-comment-origin
+                  ;;
+                *)
+                  npm exec idd-review-comment-origin --
+                  ;;
+              esac
+              ;;
+            ephemeral-npx)
+              SPEC="${PACKAGE_SPEC:-https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main}"
+              npx --yes --package "$SPEC" idd-review-comment-origin
+              ;;
+          esac
       - name: Rerun required HEAD check
         if: steps.origin.outputs.idd_originated == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: node scripts/rerun-advisory-convergence.mjs --pr "$PR_NUMBER" --apply
+          PROFILE: ${{ steps.profile.outputs.profile }}
+          PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}
+          MANAGER: ${{ steps.manager.outputs.manager }}
+        run: |
+          case "$PROFILE" in
+            vendored-node)
+              node scripts/rerun-advisory-convergence.mjs --pr "$PR_NUMBER" --apply
+              ;;
+            package-manager)
+              case "$MANAGER" in
+                pnpm)
+                  pnpm exec idd-rerun-advisory-convergence --pr "$PR_NUMBER" --apply
+                  ;;
+                yarn)
+                  yarn idd-rerun-advisory-convergence --pr "$PR_NUMBER" --apply
+                  ;;
+                *)
+                  npm exec idd-rerun-advisory-convergence -- --pr "$PR_NUMBER" --apply
+                  ;;
+              esac
+              ;;
+            ephemeral-npx)
+              SPEC="${PACKAGE_SPEC:-https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main}"
+              npx --yes --package "$SPEC" idd-rerun-advisory-convergence --pr "$PR_NUMBER" --apply
+              ;;
+          esac

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -60,22 +60,31 @@ jobs:
           # guess at a runnable profile.
           PROFILE="instructions-only"
           PACKAGE_SPEC=""
-          for CANDIDATE in .github/idd/config.json idd-policy.json; do
-            if [ -f "$CANDIDATE" ]; then
-              if RESOLVED=$(jq -r '.helperRuntime.profile // empty' "$CANDIDATE" 2>/dev/null); then
-                case "$RESOLVED" in
-                  vendored-node | package-manager | ephemeral-npx | instructions-only)
-                    PROFILE="$RESOLVED"
-                    PACKAGE_SPEC=$(jq -r '.helperRuntime.packageSpec // empty' "$CANDIDATE" 2>/dev/null || echo "")
-                    ;;
-                esac
+          if ! command -v jq >/dev/null 2>&1; then
+            # Distinguish "jq is missing" from a genuine instructions-only
+            # config: without jq, no config file can be parsed at all, so
+            # this would otherwise silently masquerade as an intentional
+            # instructions-only choice. GitHub-hosted runner images ship
+            # jq by default; this only bites a jq-less self-hosted runner.
+            echo "::warning::jq is not available on this runner, so helperRuntime.profile cannot be resolved; treating as instructions-only. Install jq on this runner, or use a runner image that provides it."
+          else
+            for CANDIDATE in .github/idd/config.json idd-policy.json; do
+              if [ -f "$CANDIDATE" ]; then
+                if RESOLVED=$(jq -r '.helperRuntime.profile // empty' "$CANDIDATE" 2>/dev/null); then
+                  case "$RESOLVED" in
+                    vendored-node | package-manager | ephemeral-npx | instructions-only)
+                      PROFILE="$RESOLVED"
+                      PACKAGE_SPEC=$(jq -r '.helperRuntime.packageSpec // empty' "$CANDIDATE" 2>/dev/null || echo "")
+                      ;;
+                  esac
+                fi
+                # First present candidate file wins outright, valid or not
+                # -- never fall through to the legacy idd-policy.json name
+                # once the canonical file has been evaluated.
+                break
               fi
-              # First present candidate file wins outright, valid or not
-              # -- never fall through to the legacy idd-policy.json name
-              # once the canonical file has been evaluated.
-              break
-            fi
-          done
+            done
+          fi
           echo "profile=$PROFILE" >> "$GITHUB_OUTPUT"
           echo "package-spec=$PACKAGE_SPEC" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v4
@@ -172,6 +181,10 @@ jobs:
           PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}
           MANAGER: ${{ steps.manager.outputs.manager }}
         run: |
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::PR_NUMBER is empty"
+            exit 1
+          fi
           case "$PROFILE" in
             vendored-node)
               node scripts/rerun-advisory-convergence.mjs --pr "$PR_NUMBER" --apply
@@ -192,5 +205,9 @@ jobs:
             ephemeral-npx)
               SPEC="${PACKAGE_SPEC:-https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main}"
               npx --yes --package "$SPEC" idd-rerun-advisory-convergence --pr "$PR_NUMBER" --apply
+              ;;
+            *)
+              echo "::error::unrecognized helper-runtime profile \"$PROFILE\""
+              exit 1
               ;;
           esac

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -23,12 +23,15 @@ name: IDD advisory-convergence gate
 # shell syntax.
 #
 # Adjust the pinned `actions/checkout` SHA (or use the floating `@v4`
-# tag as shipped here), the checkout `ref:` (see below), and the
-# `node scripts/...` command to your own helper-runtime profile. This
-# file intentionally uses the portable `ubuntu-slim` fallback +
-# `@v4` forms rather than a repository-specific pinned SHA or a
-# hardcoded custom runner label, unlike this source repository's own
-# dogfooded copy at .github/workflows/idd-advisory-convergence.yml.
+# tag as shipped here) and the checkout `ref:` (see below) to your own
+# conventions. The invocation itself needs no hand-editing: it resolves
+# and branches on `helperRuntime.profile` automatically (see "Profile
+# resolution" below) -- configure that field in `.github/idd/config.json`
+# instead of editing the `run:` steps. This file intentionally uses the
+# portable `ubuntu-slim` fallback + `@v4` forms rather than a
+# repository-specific pinned SHA or a hardcoded custom runner label,
+# unlike this source repository's own dogfooded copy at
+# .github/workflows/idd-advisory-convergence.yml.
 #
 # Profile resolution: mirrors post-merge-cleanup.yml's
 # helperRuntime.profile resolution and per-step `if:` gating (see its
@@ -129,22 +132,31 @@ jobs:
           # guess at a runnable profile.
           PROFILE="instructions-only"
           PACKAGE_SPEC=""
-          for CANDIDATE in .github/idd/config.json idd-policy.json; do
-            if [ -f "$CANDIDATE" ]; then
-              if RESOLVED=$(jq -r '.helperRuntime.profile // empty' "$CANDIDATE" 2>/dev/null); then
-                case "$RESOLVED" in
-                  vendored-node | package-manager | ephemeral-npx | instructions-only)
-                    PROFILE="$RESOLVED"
-                    PACKAGE_SPEC=$(jq -r '.helperRuntime.packageSpec // empty' "$CANDIDATE" 2>/dev/null || echo "")
-                    ;;
-                esac
+          if ! command -v jq >/dev/null 2>&1; then
+            # Distinguish "jq is missing" from a genuine instructions-only
+            # config: without jq, no config file can be parsed at all, so
+            # this would otherwise silently masquerade as an intentional
+            # instructions-only choice. GitHub-hosted runner images ship
+            # jq by default; this only bites a jq-less self-hosted runner.
+            echo "::warning::jq is not available on this runner, so helperRuntime.profile cannot be resolved; treating as instructions-only. Install jq on this runner, or use a runner image that provides it."
+          else
+            for CANDIDATE in .github/idd/config.json idd-policy.json; do
+              if [ -f "$CANDIDATE" ]; then
+                if RESOLVED=$(jq -r '.helperRuntime.profile // empty' "$CANDIDATE" 2>/dev/null); then
+                  case "$RESOLVED" in
+                    vendored-node | package-manager | ephemeral-npx | instructions-only)
+                      PROFILE="$RESOLVED"
+                      PACKAGE_SPEC=$(jq -r '.helperRuntime.packageSpec // empty' "$CANDIDATE" 2>/dev/null || echo "")
+                      ;;
+                  esac
+                fi
+                # First present candidate file wins outright, valid or not
+                # -- never fall through to the legacy idd-policy.json name
+                # once the canonical file has been evaluated.
+                break
               fi
-              # First present candidate file wins outright, valid or not
-              # -- never fall through to the legacy idd-policy.json name
-              # once the canonical file has been evaluated.
-              break
-            fi
-          done
+            done
+          fi
           echo "profile=$PROFILE" >> "$GITHUB_OUTPUT"
           echo "package-spec=$PACKAGE_SPEC" >> "$GITHUB_OUTPUT"
       - name: Fail closed when no helper runtime is configured
@@ -223,6 +235,10 @@ jobs:
           PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}
           MANAGER: ${{ steps.manager.outputs.manager }}
         run: |
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::error::PR_NUMBER is empty"
+            exit 1
+          fi
           case "$PROFILE" in
             vendored-node)
               node scripts/advisory-convergence.mjs --pr "$PR_NUMBER" --assert
@@ -245,5 +261,14 @@ jobs:
             ephemeral-npx)
               SPEC="${PACKAGE_SPEC:-https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main}"
               npx --yes --package "$SPEC" idd-advisory-convergence --pr "$PR_NUMBER" --assert
+              ;;
+            *)
+              # Unreachable by construction (the profile-resolution step
+              # only ever emits one of the four known profile values, and
+              # instructions-only already failed the job above), but a
+              # required check must never silently no-op and report
+              # success on an unexpected profile value.
+              echo "::error::unrecognized helper-runtime profile \"$PROFILE\""
+              exit 1
               ;;
           esac

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -29,6 +29,16 @@ name: IDD advisory-convergence gate
 # `@v4` forms rather than a repository-specific pinned SHA or a
 # hardcoded custom runner label, unlike this source repository's own
 # dogfooded copy at .github/workflows/idd-advisory-convergence.yml.
+#
+# Profile resolution: mirrors post-merge-cleanup.yml's
+# helperRuntime.profile resolution and per-step `if:` gating (see its
+# header for the full profile contract). This file diverges from that
+# pattern in one place: because this job is the required-check verdict
+# itself (not a best-effort cleanup with an agent-side fallback), an
+# `instructions-only` profile fails the job outright instead of
+# skipping -- a required check whose steps all silently skip would
+# report `success`, turning the merge gate into an unconditional
+# rubber stamp.
 concurrency:
   cancel-in-progress: true
   # Grouped by PR number, not github.ref: pull_request_review is not a
@@ -109,17 +119,94 @@ jobs:
           # default branch name if it differs.
           ref: main
           persist-credentials: false
-      # Preinstalled Node on a hosted image is not guaranteed to satisfy
-      # this repo's engines.node floor (package.json), regardless of
-      # whether the job uses the shipped ubuntu-slim default or an
-      # override. Pin an explicit version so the mirrored template stays
-      # portable. This source repository's own copy can skip setup-node
-      # because its runner's preinstalled Node is already known-good
-      # (see idd-doctor.yml / lint.yml).
+      - name: Resolve helper-runtime profile
+        id: profile
+        run: |
+          # Fail-closed default, mirroring idd-doctor.mjs's
+          # resolveConfiguredHelperRuntime: an absent, unreadable, or
+          # invalid config -- or one that simply omits helperRuntime --
+          # resolves to instructions-only (no runnable command), never a
+          # guess at a runnable profile.
+          PROFILE="instructions-only"
+          PACKAGE_SPEC=""
+          for CANDIDATE in .github/idd/config.json idd-policy.json; do
+            if [ -f "$CANDIDATE" ]; then
+              if RESOLVED=$(jq -r '.helperRuntime.profile // empty' "$CANDIDATE" 2>/dev/null); then
+                case "$RESOLVED" in
+                  vendored-node | package-manager | ephemeral-npx | instructions-only)
+                    PROFILE="$RESOLVED"
+                    PACKAGE_SPEC=$(jq -r '.helperRuntime.packageSpec // empty' "$CANDIDATE" 2>/dev/null || echo "")
+                    ;;
+                esac
+              fi
+              # First present candidate file wins outright, valid or not
+              # -- never fall through to the legacy idd-policy.json name
+              # once the canonical file has been evaluated.
+              break
+            fi
+          done
+          echo "profile=$PROFILE" >> "$GITHUB_OUTPUT"
+          echo "package-spec=$PACKAGE_SPEC" >> "$GITHUB_OUTPUT"
+      - name: Fail closed when no helper runtime is configured
+        if: steps.profile.outputs.profile == 'instructions-only'
+        run: |
+          echo "::error::This repository hosts idd-advisory-convergence as a required check but resolves helperRuntime.profile to instructions-only (no runnable helper command). Configure helperRuntime.profile in .github/idd/config.json, or stop hosting this workflow as a required check."
+          exit 1
       - uses: actions/setup-node@v4
+        if: steps.profile.outputs.profile != 'instructions-only'
         with:
           node-version: 24.x
-      - env:
+      - name: Detect package manager
+        id: manager
+        if: steps.profile.outputs.profile == 'package-manager'
+        run: |
+          # Same precedence as helper-runtime-manifest.mts's own
+          # detector: an explicit package.json "packageManager" field
+          # wins, then lockfile presence (pnpm-lock.yaml, then
+          # package-lock.json, then yarn.lock), defaulting to npm when
+          # nothing else matches.
+          MANAGER=$(node -e "
+            const fs = require('node:fs');
+            let declared = '';
+            try {
+              const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+              declared = String(pkg.packageManager || '').split('@')[0];
+            } catch {
+              // No readable package.json: fall through to lockfile detection.
+            }
+            if (['npm', 'pnpm', 'yarn'].includes(declared)) {
+              console.log(declared);
+            } else if (fs.existsSync('pnpm-lock.yaml')) {
+              console.log('pnpm');
+            } else if (fs.existsSync('package-lock.json')) {
+              console.log('npm');
+            } else if (fs.existsSync('yarn.lock')) {
+              console.log('yarn');
+            } else {
+              console.log('npm');
+            }
+          ")
+          echo "manager=$MANAGER" >> "$GITHUB_OUTPUT"
+      - name: Install dependencies (package-manager profile)
+        if: steps.profile.outputs.profile == 'package-manager'
+        env:
+          MANAGER: ${{ steps.manager.outputs.manager }}
+        run: |
+          case "$MANAGER" in
+            pnpm)
+              corepack enable
+              pnpm install --frozen-lockfile
+              ;;
+            yarn)
+              corepack enable
+              yarn install --frozen-lockfile
+              ;;
+            *)
+              npm ci
+              ;;
+          esac
+      - name: Run advisory-convergence check
+        env:
           GH_TOKEN: ${{ github.token }}
           # gh reads whichever of these two matches its resolved host
           # (`gh help environment`), so setting both is inert on
@@ -132,4 +219,31 @@ jobs:
           # quoted shell variable rather than interpolating the `${{ }}`
           # expression directly into the run: script.
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
-        run: node scripts/advisory-convergence.mjs --pr "$PR_NUMBER" --assert
+          PROFILE: ${{ steps.profile.outputs.profile }}
+          PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}
+          MANAGER: ${{ steps.manager.outputs.manager }}
+        run: |
+          case "$PROFILE" in
+            vendored-node)
+              node scripts/advisory-convergence.mjs --pr "$PR_NUMBER" --assert
+              ;;
+            package-manager)
+              case "$MANAGER" in
+                pnpm)
+                  pnpm exec idd-advisory-convergence --pr "$PR_NUMBER" --assert
+                  ;;
+                yarn)
+                  yarn idd-advisory-convergence --pr "$PR_NUMBER" --assert
+                  ;;
+                *)
+                  # npm requires a literal `--` before forwarded flags;
+                  # pnpm/yarn above do not.
+                  npm exec idd-advisory-convergence -- --pr "$PR_NUMBER" --assert
+                  ;;
+              esac
+              ;;
+            ephemeral-npx)
+              SPEC="${PACKAGE_SPEC:-https://codeload.github.com/kurone-kito/idd-skill/tar.gz/refs/heads/main}"
+              npx --yes --package "$SPEC" idd-advisory-convergence --pr "$PR_NUMBER" --assert
+              ;;
+          esac


### PR DESCRIPTION
## Summary

`idd-advisory-convergence.yml` and `idd-advisory-convergence-comment.yml` previously invoked `node scripts/...` unconditionally, requiring adopters to hand-adapt them to their own `helperRuntime.profile`. Applies `post-merge-cleanup.yml`'s existing profile-resolution step and per-step `if:` conditional pattern to both files, matching the shape already established there.

- Both files gain the same "Resolve helper-runtime profile" step, `setup-node`/package-manager-detect/install steps gated by `if:`, and a `case "$PROFILE"` branch inside each invocation step (vendored-node / package-manager / ephemeral-npx), using the bin names already registered in `package.json` (`idd-advisory-convergence`, `idd-review-comment-origin`, `idd-rerun-advisory-convergence`).
- `idd-advisory-convergence.yml` is the required-check verdict itself (job id `idd-advisory-convergence`), so it fails the job explicitly under `instructions-only` instead of skipping — a job whose steps all silently skip still reports `success`, which would turn the merge gate into an unconditional rubber stamp. `docs/idd-helper-scripts.md`'s existing principle ("never `no-required-checks`... a caller cannot mistake an unresolvable required-check source for a vacuous pass") applies the same way here.
- `idd-advisory-convergence-comment.yml` is the explicitly non-required companion (its own header says so), so it skips harmlessly under `instructions-only`, exactly like `post-merge-cleanup.yml` does — an empty `idd_originated` output naturally short-circuits the rerun step's existing `if:` guard.
- Only the `idd-template/` copies are touched; the dogfooded `.github/workflows/` copies deliberately diverge per their own header comments and are out of scope (not in `audit/sync-manifest.json` as a sync pair).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on both files — valid YAML
- [x] `actionlint` on both files — clean, no findings
- [x] `grep -n 'node scripts/'` on both files — every hit is inside a gated `vendored-node` case branch (AC bullet 3)
- [x] `node --test tests/advisory-convergence-comment-workflow.test.mts tests/actions-usage-workflow-guard.test.mts tests/consistency.test.mts tests/helper-invocation-profile.test.mts` — 104/104 pass
- [x] Full `pnpm run lint:minimum` on the committed tree — audit-docs, typecheck, build:check, biome, dprint, 4383/4383 tests, workshop-integrity, cspell, markdownlint all clean

Closes #2227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic helper-runtime profile resolution for advisory convergence workflows.
  - Added support for vendored, package-managed, ephemeral `npx`, and instructions-only execution modes.
  - Added package-manager detection based on project configuration and lockfiles.
  - Added conditional dependency installation and required-check reruns.

- **Bug Fixes**
  - Workflows now fail explicitly for missing pull request numbers or unrecognized profiles.
  - Instructions-only mode skips executable refresh steps safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->