### PR TITLE
feat(token-cost): publish the first dogfood median snapshot

### DIFF
--- a/docs/token-cost-snapshot.json
+++ b/docs/token-cost-snapshot.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-26T00:00:00.000Z",
+  "generatedAt": "2026-09-01T17:08:06.125Z",
   "minPublishableSamples": 10,
   "minPublishableVendors": 2,
   "publishable": false,
   "sampleCount": 0,
   "vendors": [],
-  "asOf": "2026-08-26",
+  "asOf": "2026-09-01",
   "totalUsage": {
     "inputUncached": {
       "p25": 0,


### PR DESCRIPTION
# Summary

Re-runs `node scripts/token-cost-harvest.mjs --repo kurone-kito/idd-skill`
and `node scripts/token-cost-report.mjs --apply` now that the
adapter/harvest/event-helper/rename chain (#2289, #2290, #2291, #2292,
#2293, #2314) has merged. This machine's local session logs still
yield `sampleCount: 0` (0 issue-loop samples, 0 vendors) — below the
`n >= 10`, 2-vendor publishable gate — so `docs/token-cost-snapshot.json`
stays `publishable: false` and `README.md` / `README.ja.md` /
`docs/token-cost.md` stay on the unpublished stub, per #2295's own
documented false-branch acceptance criteria. Only the snapshot's
`generatedAt` / `asOf` fields refresh, to record that a real dogfood
run was attempted on 2026-09-01 — no fabricated numbers.

Filed #2393 (held under `status:authoring`, not yet released) as the
required retry follow-up.

## Linked issue

Closes #2295

## Background / rationale (if material)

One observation not required by #2295's own scope, recorded here for
context rather than acted on: this run's local Claude Code session
directory is a single long-lived interactive session that worked
across multiple issue worktrees via `cd`/subagent working directories,
rather than the one-session-per-issue-worktree shape the harvester's
cwd-based issue-loop join (built in #2292) assumes — so it produced 0
issue-loop samples even though several issue loops completed under
this session on 2026-09-01. Left out of #2393's scope (which is
explicitly "retry, not new machinery") since fixing the join heuristic
is a separate design question.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `node scripts/token-cost-report.mjs --check`
- [x] `node --test tests/token-cost-core.test.mts tests/schema-type-reconciliation.test.mts tests/schema-output-roundtrip.test.mts`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
