### PR TITLE
fix(template): validate helperRuntime, refuse ambiguous manager

### DIFF
--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -89,7 +89,7 @@ jobs:
                       | ($profile != null and ($profile|type) == "string" and ($profile|length) > 0 and (["vendored-node","package-manager","ephemeral-npx","instructions-only"] | index($profile)) != null) as $profile_ok
                       | (if ($hr | has("packageSpec")) then
                            ($hr.packageSpec) as $spec
-                           | ($spec != null and ($spec|type) == "string" and ($spec | test("^[A-Za-z0-9@:/_.+^#%-]+$")))
+                           | ($spec != null and ($spec|type) == "string" and ($spec | test("\\A[A-Za-z0-9@:/_.+^#%-]+\\z")))
                          else true end) as $spec_ok
                       | if ($keys_ok and $profile_ok and $spec_ok) then
                           "\($hr.profile)\t\($hr.packageSpec // "")"
@@ -116,15 +116,24 @@ jobs:
         if: steps.profile.outputs.profile == 'package-manager'
         run: |
           # Same precedence as helper-runtime-manifest.mts's own
-          # detector: an explicit package.json "packageManager" field
-          # wins, then lockfile presence when exactly one supported
-          # lockfile exists, defaulting to npm when none exist. When
-          # more than one supported lockfile coexists with no declared
-          # field, this mirrors collectHelperRuntimeEvidence's own
-          # "do not guess an install path" stance (ambiguousPackageManager)
-          # instead of silently picking by a fixed pnpm/npm/yarn priority
-          # order, which could select a manager whose lockfile lacks the
-          # IDD helper dependency and fail with a confusing error.
+          # collectHelperRuntimeEvidence for the "declared field" and
+          # "exactly one lockfile" cases: an explicit package.json
+          # "packageManager" field wins, then lockfile presence when
+          # exactly one supported lockfile exists. When more than one
+          # supported lockfile coexists with no declared field, this
+          # mirrors collectHelperRuntimeEvidence's own "do not guess an
+          # install path" stance (ambiguousPackageManager) instead of
+          # silently picking by a fixed pnpm/npm/yarn priority order,
+          # which could select a manager whose lockfile lacks the IDD
+          # helper dependency and fail with a confusing error. When
+          # there is no evidence at all (no declared field, no
+          # lockfile), this is a workflow-specific fallback to npm, NOT
+          # a mirror of collectHelperRuntimeEvidence (which leaves the
+          # manager unset in that case, cascading to instructions-only
+          # via recommendHelperRuntimeProfile) -- npm ships with every
+          # setup-node Node.js install, so defaulting to it here is
+          # safe even though the canonical onboarding recommender is
+          # more conservative about "no evidence" (idd-skill#2392).
           MANAGER=$(node -e "
             const fs = require('node:fs');
             let declared = '';

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -23,7 +23,9 @@
 # `instructions-only` profile here simply skips the classify/rerun
 # steps -- this workflow is a best-effort refresh, not the merge-gate
 # verdict itself, so silently doing nothing on every review comment is
-# harmless.
+# harmless. The same skip applies when `package-manager` resolves but
+# which package manager to use is ambiguous (see "Detect package
+# manager" below).
 name: IDD advisory-convergence comment refresh
 concurrency:
   # Do not cancel: a later human LGTM must not abort an in-flight
@@ -57,7 +59,14 @@ jobs:
           # resolveConfiguredHelperRuntime: an absent, unreadable, or
           # invalid config -- or one that simply omits helperRuntime --
           # resolves to instructions-only (no runnable command), never a
-          # guess at a runnable profile.
+          # guess at a runnable profile. Validates the WHOLE
+          # helperRuntime object -- object type, only "profile"/
+          # "packageSpec" keys, profile enum membership, packageSpec
+          # shell-safe-character allowlist -- against the same rules as
+          # policy-helpers.mts's inspectHelperRuntimeConfig, instead of
+          # only the "profile" field, so a malformed sibling field
+          # cannot silently activate a profile the canonical validator
+          # would reject.
           PROFILE="instructions-only"
           PACKAGE_SPEC=""
           if ! command -v jq >/dev/null 2>&1; then
@@ -70,13 +79,24 @@ jobs:
           else
             for CANDIDATE in .github/idd/config.json idd-policy.json; do
               if [ -f "$CANDIDATE" ]; then
-                if RESOLVED=$(jq -r '.helperRuntime.profile // empty' "$CANDIDATE" 2>/dev/null); then
-                  case "$RESOLVED" in
-                    vendored-node | package-manager | ephemeral-npx | instructions-only)
-                      PROFILE="$RESOLVED"
-                      PACKAGE_SPEC=$(jq -r '.helperRuntime.packageSpec // empty' "$CANDIDATE" 2>/dev/null || echo "")
-                      ;;
-                  esac
+                if RESOLVED=$(jq -r '
+                  (.helperRuntime) as $hr
+                  | ($hr != null and ($hr|type) == "object") as $is_object
+                  | if $is_object then
+                      (($hr | keys) - ["profile","packageSpec"]) as $extra
+                      | ($hr.profile) as $profile
+                      | ($extra | length == 0) as $keys_ok
+                      | ($profile != null and ($profile|type) == "string" and ($profile|length) > 0 and (["vendored-node","package-manager","ephemeral-npx","instructions-only"] | index($profile)) != null) as $profile_ok
+                      | (if ($hr | has("packageSpec")) then
+                           ($hr.packageSpec) as $spec
+                           | ($spec != null and ($spec|type) == "string" and ($spec | test("^[A-Za-z0-9@:/_.+^#%-]+$")))
+                         else true end) as $spec_ok
+                      | if ($keys_ok and $profile_ok and $spec_ok) then
+                          "\($hr.profile)\t\($hr.packageSpec // "")"
+                        else empty end
+                    else empty end
+                ' "$CANDIDATE" 2>/dev/null) && [ -n "$RESOLVED" ]; then
+                  IFS=$'\t' read -r PROFILE PACKAGE_SPEC <<<"$RESOLVED"
                 fi
                 # First present candidate file wins outright, valid or not
                 # -- never fall through to the legacy idd-policy.json name
@@ -97,9 +117,14 @@ jobs:
         run: |
           # Same precedence as helper-runtime-manifest.mts's own
           # detector: an explicit package.json "packageManager" field
-          # wins, then lockfile presence (pnpm-lock.yaml, then
-          # package-lock.json, then yarn.lock), defaulting to npm when
-          # nothing else matches.
+          # wins, then lockfile presence when exactly one supported
+          # lockfile exists, defaulting to npm when none exist. When
+          # more than one supported lockfile coexists with no declared
+          # field, this mirrors collectHelperRuntimeEvidence's own
+          # "do not guess an install path" stance (ambiguousPackageManager)
+          # instead of silently picking by a fixed pnpm/npm/yarn priority
+          # order, which could select a manager whose lockfile lacks the
+          # IDD helper dependency and fail with a confusing error.
           MANAGER=$(node -e "
             const fs = require('node:fs');
             let declared = '';
@@ -111,19 +136,27 @@ jobs:
             }
             if (['npm', 'pnpm', 'yarn'].includes(declared)) {
               console.log(declared);
-            } else if (fs.existsSync('pnpm-lock.yaml')) {
-              console.log('pnpm');
-            } else if (fs.existsSync('package-lock.json')) {
-              console.log('npm');
-            } else if (fs.existsSync('yarn.lock')) {
-              console.log('yarn');
             } else {
-              console.log('npm');
+              const lockfiles = [
+                ['pnpm-lock.yaml', 'pnpm'],
+                ['package-lock.json', 'npm'],
+                ['yarn.lock', 'yarn'],
+              ].filter(([file]) => fs.existsSync(file));
+              if (lockfiles.length === 1) {
+                console.log(lockfiles[0][1]);
+              } else if (lockfiles.length === 0) {
+                console.log('npm');
+              } else {
+                console.log('ambiguous');
+              }
             }
           ")
+          if [ "$MANAGER" = "ambiguous" ]; then
+            echo "::warning::Multiple package-manager lockfiles were found with no declared \"packageManager\" field in package.json; refusing to guess which one to use. Add a \"packageManager\": \"<name>@<version>\" field to package.json, or remove the stale lockfile(s)."
+          fi
           echo "manager=$MANAGER" >> "$GITHUB_OUTPUT"
       - name: Install dependencies (package-manager profile)
-        if: steps.profile.outputs.profile == 'package-manager'
+        if: steps.profile.outputs.profile == 'package-manager' && steps.manager.outputs.manager != 'ambiguous'
         env:
           MANAGER: ${{ steps.manager.outputs.manager }}
         run: |
@@ -142,7 +175,7 @@ jobs:
           esac
       - name: Classify review comment
         id: origin
-        if: steps.profile.outputs.profile != 'instructions-only'
+        if: steps.profile.outputs.profile != 'instructions-only' && steps.manager.outputs.manager != 'ambiguous'
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
           PROFILE: ${{ steps.profile.outputs.profile }}

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -162,7 +162,7 @@ jobs:
                       | ($profile != null and ($profile|type) == "string" and ($profile|length) > 0 and (["vendored-node","package-manager","ephemeral-npx","instructions-only"] | index($profile)) != null) as $profile_ok
                       | (if ($hr | has("packageSpec")) then
                            ($hr.packageSpec) as $spec
-                           | ($spec != null and ($spec|type) == "string" and ($spec | test("^[A-Za-z0-9@:/_.+^#%-]+$")))
+                           | ($spec != null and ($spec|type) == "string" and ($spec | test("\\A[A-Za-z0-9@:/_.+^#%-]+\\z")))
                          else true end) as $spec_ok
                       | if ($keys_ok and $profile_ok and $spec_ok) then
                           "\($hr.profile)\t\($hr.packageSpec // "")"
@@ -194,15 +194,24 @@ jobs:
         if: steps.profile.outputs.profile == 'package-manager'
         run: |
           # Same precedence as helper-runtime-manifest.mts's own
-          # detector: an explicit package.json "packageManager" field
-          # wins, then lockfile presence when exactly one supported
-          # lockfile exists, defaulting to npm when none exist. When
-          # more than one supported lockfile coexists with no declared
-          # field, this mirrors collectHelperRuntimeEvidence's own
-          # "do not guess an install path" stance (ambiguousPackageManager)
-          # instead of silently picking by a fixed pnpm/npm/yarn priority
-          # order, which could select a manager whose lockfile lacks the
-          # IDD helper dependency and fail with a confusing error.
+          # collectHelperRuntimeEvidence for the "declared field" and
+          # "exactly one lockfile" cases: an explicit package.json
+          # "packageManager" field wins, then lockfile presence when
+          # exactly one supported lockfile exists. When more than one
+          # supported lockfile coexists with no declared field, this
+          # mirrors collectHelperRuntimeEvidence's own "do not guess an
+          # install path" stance (ambiguousPackageManager) instead of
+          # silently picking by a fixed pnpm/npm/yarn priority order,
+          # which could select a manager whose lockfile lacks the IDD
+          # helper dependency and fail with a confusing error. When
+          # there is no evidence at all (no declared field, no
+          # lockfile), this is a workflow-specific fallback to npm, NOT
+          # a mirror of collectHelperRuntimeEvidence (which leaves the
+          # manager unset in that case, cascading to instructions-only
+          # via recommendHelperRuntimeProfile) -- npm ships with every
+          # setup-node Node.js install, so defaulting to it here is
+          # safe even though the canonical onboarding recommender is
+          # more conservative about "no evidence" (idd-skill#2392).
           MANAGER=$(node -e "
             const fs = require('node:fs');
             let declared = '';

--- a/idd-template/.github/workflows/idd-advisory-convergence.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence.yml
@@ -41,7 +41,10 @@ name: IDD advisory-convergence gate
 # `instructions-only` profile fails the job outright instead of
 # skipping -- a required check whose steps all silently skip would
 # report `success`, turning the merge gate into an unconditional
-# rubber stamp.
+# rubber stamp. The same applies when `package-manager` resolves but
+# which package manager to use is ambiguous (see "Detect package
+# manager" below): "Fail closed on ambiguous package manager" stops the
+# job outright rather than silently skipping.
 concurrency:
   cancel-in-progress: true
   # Grouped by PR number, not github.ref: pull_request_review is not a
@@ -129,7 +132,14 @@ jobs:
           # resolveConfiguredHelperRuntime: an absent, unreadable, or
           # invalid config -- or one that simply omits helperRuntime --
           # resolves to instructions-only (no runnable command), never a
-          # guess at a runnable profile.
+          # guess at a runnable profile. Validates the WHOLE
+          # helperRuntime object -- object type, only "profile"/
+          # "packageSpec" keys, profile enum membership, packageSpec
+          # shell-safe-character allowlist -- against the same rules as
+          # policy-helpers.mts's inspectHelperRuntimeConfig, instead of
+          # only the "profile" field, so a malformed sibling field
+          # cannot silently activate a profile the canonical validator
+          # would reject.
           PROFILE="instructions-only"
           PACKAGE_SPEC=""
           if ! command -v jq >/dev/null 2>&1; then
@@ -142,13 +152,24 @@ jobs:
           else
             for CANDIDATE in .github/idd/config.json idd-policy.json; do
               if [ -f "$CANDIDATE" ]; then
-                if RESOLVED=$(jq -r '.helperRuntime.profile // empty' "$CANDIDATE" 2>/dev/null); then
-                  case "$RESOLVED" in
-                    vendored-node | package-manager | ephemeral-npx | instructions-only)
-                      PROFILE="$RESOLVED"
-                      PACKAGE_SPEC=$(jq -r '.helperRuntime.packageSpec // empty' "$CANDIDATE" 2>/dev/null || echo "")
-                      ;;
-                  esac
+                if RESOLVED=$(jq -r '
+                  (.helperRuntime) as $hr
+                  | ($hr != null and ($hr|type) == "object") as $is_object
+                  | if $is_object then
+                      (($hr | keys) - ["profile","packageSpec"]) as $extra
+                      | ($hr.profile) as $profile
+                      | ($extra | length == 0) as $keys_ok
+                      | ($profile != null and ($profile|type) == "string" and ($profile|length) > 0 and (["vendored-node","package-manager","ephemeral-npx","instructions-only"] | index($profile)) != null) as $profile_ok
+                      | (if ($hr | has("packageSpec")) then
+                           ($hr.packageSpec) as $spec
+                           | ($spec != null and ($spec|type) == "string" and ($spec | test("^[A-Za-z0-9@:/_.+^#%-]+$")))
+                         else true end) as $spec_ok
+                      | if ($keys_ok and $profile_ok and $spec_ok) then
+                          "\($hr.profile)\t\($hr.packageSpec // "")"
+                        else empty end
+                    else empty end
+                ' "$CANDIDATE" 2>/dev/null) && [ -n "$RESOLVED" ]; then
+                  IFS=$'\t' read -r PROFILE PACKAGE_SPEC <<<"$RESOLVED"
                 fi
                 # First present candidate file wins outright, valid or not
                 # -- never fall through to the legacy idd-policy.json name
@@ -174,9 +195,14 @@ jobs:
         run: |
           # Same precedence as helper-runtime-manifest.mts's own
           # detector: an explicit package.json "packageManager" field
-          # wins, then lockfile presence (pnpm-lock.yaml, then
-          # package-lock.json, then yarn.lock), defaulting to npm when
-          # nothing else matches.
+          # wins, then lockfile presence when exactly one supported
+          # lockfile exists, defaulting to npm when none exist. When
+          # more than one supported lockfile coexists with no declared
+          # field, this mirrors collectHelperRuntimeEvidence's own
+          # "do not guess an install path" stance (ambiguousPackageManager)
+          # instead of silently picking by a fixed pnpm/npm/yarn priority
+          # order, which could select a manager whose lockfile lacks the
+          # IDD helper dependency and fail with a confusing error.
           MANAGER=$(node -e "
             const fs = require('node:fs');
             let declared = '';
@@ -188,17 +214,30 @@ jobs:
             }
             if (['npm', 'pnpm', 'yarn'].includes(declared)) {
               console.log(declared);
-            } else if (fs.existsSync('pnpm-lock.yaml')) {
-              console.log('pnpm');
-            } else if (fs.existsSync('package-lock.json')) {
-              console.log('npm');
-            } else if (fs.existsSync('yarn.lock')) {
-              console.log('yarn');
             } else {
-              console.log('npm');
+              const lockfiles = [
+                ['pnpm-lock.yaml', 'pnpm'],
+                ['package-lock.json', 'npm'],
+                ['yarn.lock', 'yarn'],
+              ].filter(([file]) => fs.existsSync(file));
+              if (lockfiles.length === 1) {
+                console.log(lockfiles[0][1]);
+              } else if (lockfiles.length === 0) {
+                console.log('npm');
+              } else {
+                console.log('ambiguous');
+              }
             }
           ")
+          if [ "$MANAGER" = "ambiguous" ]; then
+            echo "::warning::Multiple package-manager lockfiles were found with no declared \"packageManager\" field in package.json; refusing to guess which one to use. Add a \"packageManager\": \"<name>@<version>\" field to package.json, or remove the stale lockfile(s)."
+          fi
           echo "manager=$MANAGER" >> "$GITHUB_OUTPUT"
+      - name: Fail closed on ambiguous package manager
+        if: steps.manager.outputs.manager == 'ambiguous'
+        run: |
+          echo "::error::This repository hosts idd-advisory-convergence as a required check with helperRuntime.profile resolved to package-manager, but multiple package-manager lockfiles were found with no declared \"packageManager\" field in package.json, so which manager to use cannot be determined. Add a \"packageManager\": \"<name>@<version>\" field to package.json, or remove the stale lockfile(s)."
+          exit 1
       - name: Install dependencies (package-manager profile)
         if: steps.profile.outputs.profile == 'package-manager'
         env:

--- a/idd-template/.github/workflows/post-merge-cleanup.yml
+++ b/idd-template/.github/workflows/post-merge-cleanup.yml
@@ -57,9 +57,12 @@
 # `idd-policy.json` filename with the same first-present-file precedence
 # idd-doctor.mjs's own resolver uses) -- see docs/idd-helper-scripts.md's
 # "Helper Runtime Profiles" section. Under `instructions-only` (no runnable
-# helper command exists for any profile), or when no profile can be
-# resolved at all, the audit and evidence-comment steps are skipped
-# entirely and nothing is posted: the agent's own F4 cleanup step in
+# helper command exists for any profile), when no profile can be resolved
+# at all, or when `package-manager` resolves but which package manager to
+# use is ambiguous (more than one supported lockfile with no declared
+# `package.json` "packageManager" field -- see "Detect package manager"
+# below), the audit and evidence-comment steps are skipped entirely and
+# nothing is posted: the agent's own F4 cleanup step in
 # idd-merge.instructions.md remains the canonical, mandatory contract in
 # every profile, including this one.
 name: Post-merge cleanup
@@ -106,18 +109,36 @@ jobs:
           # resolveConfiguredHelperRuntime: an absent, unreadable, or
           # invalid config -- or one that simply omits helperRuntime --
           # resolves to instructions-only (no runnable command), never a
-          # guess at a runnable profile.
+          # guess at a runnable profile. Validates the WHOLE
+          # helperRuntime object -- object type, only "profile"/
+          # "packageSpec" keys, profile enum membership, packageSpec
+          # shell-safe-character allowlist -- against the same rules as
+          # policy-helpers.mts's inspectHelperRuntimeConfig, instead of
+          # only the "profile" field, so a malformed sibling field
+          # cannot silently activate a profile the canonical validator
+          # would reject.
           PROFILE="instructions-only"
           PACKAGE_SPEC=""
           for CANDIDATE in .github/idd/config.json idd-policy.json; do
             if [ -f "$CANDIDATE" ]; then
-              if RESOLVED=$(jq -r '.helperRuntime.profile // empty' "$CANDIDATE" 2>/dev/null); then
-                case "$RESOLVED" in
-                  vendored-node | package-manager | ephemeral-npx | instructions-only)
-                    PROFILE="$RESOLVED"
-                    PACKAGE_SPEC=$(jq -r '.helperRuntime.packageSpec // empty' "$CANDIDATE" 2>/dev/null || echo "")
-                    ;;
-                esac
+              if RESOLVED=$(jq -r '
+                (.helperRuntime) as $hr
+                | ($hr != null and ($hr|type) == "object") as $is_object
+                | if $is_object then
+                    (($hr | keys) - ["profile","packageSpec"]) as $extra
+                    | ($hr.profile) as $profile
+                    | ($extra | length == 0) as $keys_ok
+                    | ($profile != null and ($profile|type) == "string" and ($profile|length) > 0 and (["vendored-node","package-manager","ephemeral-npx","instructions-only"] | index($profile)) != null) as $profile_ok
+                    | (if ($hr | has("packageSpec")) then
+                         ($hr.packageSpec) as $spec
+                         | ($spec != null and ($spec|type) == "string" and ($spec | test("^[A-Za-z0-9@:/_.+^#%-]+$")))
+                       else true end) as $spec_ok
+                    | if ($keys_ok and $profile_ok and $spec_ok) then
+                        "\($hr.profile)\t\($hr.packageSpec // "")"
+                      else empty end
+                  else empty end
+              ' "$CANDIDATE" 2>/dev/null) && [ -n "$RESOLVED" ]; then
+                IFS=$'\t' read -r PROFILE PACKAGE_SPEC <<<"$RESOLVED"
               fi
               # First present candidate file wins outright, valid or not
               # -- never fall through to the legacy idd-policy.json name
@@ -138,9 +159,14 @@ jobs:
         run: |
           # Same precedence as helper-runtime-manifest.mts's own
           # detector: an explicit package.json "packageManager" field
-          # wins, then lockfile presence (pnpm-lock.yaml, then
-          # package-lock.json, then yarn.lock), defaulting to npm when
-          # nothing else matches.
+          # wins, then lockfile presence when exactly one supported
+          # lockfile exists, defaulting to npm when none exist. When
+          # more than one supported lockfile coexists with no declared
+          # field, this mirrors collectHelperRuntimeEvidence's own
+          # "do not guess an install path" stance (ambiguousPackageManager)
+          # instead of silently picking by a fixed pnpm/npm/yarn priority
+          # order, which could select a manager whose lockfile lacks the
+          # IDD helper dependency and fail with a confusing error.
           MANAGER=$(node -e "
             const fs = require('node:fs');
             let declared = '';
@@ -152,19 +178,27 @@ jobs:
             }
             if (['npm', 'pnpm', 'yarn'].includes(declared)) {
               console.log(declared);
-            } else if (fs.existsSync('pnpm-lock.yaml')) {
-              console.log('pnpm');
-            } else if (fs.existsSync('package-lock.json')) {
-              console.log('npm');
-            } else if (fs.existsSync('yarn.lock')) {
-              console.log('yarn');
             } else {
-              console.log('npm');
+              const lockfiles = [
+                ['pnpm-lock.yaml', 'pnpm'],
+                ['package-lock.json', 'npm'],
+                ['yarn.lock', 'yarn'],
+              ].filter(([file]) => fs.existsSync(file));
+              if (lockfiles.length === 1) {
+                console.log(lockfiles[0][1]);
+              } else if (lockfiles.length === 0) {
+                console.log('npm');
+              } else {
+                console.log('ambiguous');
+              }
             }
           ")
+          if [ "$MANAGER" = "ambiguous" ]; then
+            echo "::warning::Multiple package-manager lockfiles were found with no declared \"packageManager\" field in package.json; refusing to guess which one to use. Add a \"packageManager\": \"<name>@<version>\" field to package.json, or remove the stale lockfile(s)."
+          fi
           echo "manager=$MANAGER" >> "$GITHUB_OUTPUT"
       - name: Install dependencies (package-manager profile)
-        if: steps.profile.outputs.profile == 'package-manager'
+        if: steps.profile.outputs.profile == 'package-manager' && steps.manager.outputs.manager != 'ambiguous'
         env:
           MANAGER: ${{ steps.manager.outputs.manager }}
         run: |
@@ -183,7 +217,7 @@ jobs:
           esac
       - name: Run F4 cleanup (server-side fallback)
         id: cleanup
-        if: steps.profile.outputs.profile != 'instructions-only'
+        if: steps.profile.outputs.profile != 'instructions-only' && steps.manager.outputs.manager != 'ambiguous'
         env:
           GH_TOKEN: ${{ github.token }}
           # gh reads whichever of these two matches its resolved host
@@ -285,7 +319,7 @@ jobs:
             echo "retry_bound_exhausted=$RETRY_BOUND_EXHAUSTED"
           } >> "$GITHUB_OUTPUT"
       - name: Post cleanup evidence comment
-        if: steps.profile.outputs.profile != 'instructions-only'
+        if: steps.profile.outputs.profile != 'instructions-only' && steps.manager.outputs.manager != 'ambiguous'
         env:
           GH_TOKEN: ${{ github.token }}
           # gh reads whichever of these two matches its resolved host

--- a/idd-template/.github/workflows/post-merge-cleanup.yml
+++ b/idd-template/.github/workflows/post-merge-cleanup.yml
@@ -131,7 +131,7 @@ jobs:
                     | ($profile != null and ($profile|type) == "string" and ($profile|length) > 0 and (["vendored-node","package-manager","ephemeral-npx","instructions-only"] | index($profile)) != null) as $profile_ok
                     | (if ($hr | has("packageSpec")) then
                          ($hr.packageSpec) as $spec
-                         | ($spec != null and ($spec|type) == "string" and ($spec | test("^[A-Za-z0-9@:/_.+^#%-]+$")))
+                         | ($spec != null and ($spec|type) == "string" and ($spec | test("\\A[A-Za-z0-9@:/_.+^#%-]+\\z")))
                        else true end) as $spec_ok
                     | if ($keys_ok and $profile_ok and $spec_ok) then
                         "\($hr.profile)\t\($hr.packageSpec // "")"
@@ -158,15 +158,24 @@ jobs:
         if: steps.profile.outputs.profile == 'package-manager'
         run: |
           # Same precedence as helper-runtime-manifest.mts's own
-          # detector: an explicit package.json "packageManager" field
-          # wins, then lockfile presence when exactly one supported
-          # lockfile exists, defaulting to npm when none exist. When
-          # more than one supported lockfile coexists with no declared
-          # field, this mirrors collectHelperRuntimeEvidence's own
-          # "do not guess an install path" stance (ambiguousPackageManager)
-          # instead of silently picking by a fixed pnpm/npm/yarn priority
-          # order, which could select a manager whose lockfile lacks the
-          # IDD helper dependency and fail with a confusing error.
+          # collectHelperRuntimeEvidence for the "declared field" and
+          # "exactly one lockfile" cases: an explicit package.json
+          # "packageManager" field wins, then lockfile presence when
+          # exactly one supported lockfile exists. When more than one
+          # supported lockfile coexists with no declared field, this
+          # mirrors collectHelperRuntimeEvidence's own "do not guess an
+          # install path" stance (ambiguousPackageManager) instead of
+          # silently picking by a fixed pnpm/npm/yarn priority order,
+          # which could select a manager whose lockfile lacks the IDD
+          # helper dependency and fail with a confusing error. When
+          # there is no evidence at all (no declared field, no
+          # lockfile), this is a workflow-specific fallback to npm, NOT
+          # a mirror of collectHelperRuntimeEvidence (which leaves the
+          # manager unset in that case, cascading to instructions-only
+          # via recommendHelperRuntimeProfile) -- npm ships with every
+          # setup-node Node.js install, so defaulting to it here is
+          # safe even though the canonical onboarding recommender is
+          # more conservative about "no evidence" (idd-skill#2392).
           MANAGER=$(node -e "
             const fs = require('node:fs');
             let declared = '';

--- a/tests/consistency.test.mts
+++ b/tests/consistency.test.mts
@@ -753,6 +753,46 @@ test('helper runtime inspection rejects a shell-metacharacter packageSpec and ac
   }
 });
 
+test('the "Detect package manager" workflow step body is byte-identical across the three files that share it (idd-skill#2392)', () => {
+  const WORKFLOW_FILES = [
+    'idd-template/.github/workflows/post-merge-cleanup.yml',
+    'idd-template/.github/workflows/idd-advisory-convergence.yml',
+    'idd-template/.github/workflows/idd-advisory-convergence-comment.yml',
+  ];
+  const STEP_START = '      - name: Detect package manager\n';
+  const STEP_END_RE = /\n {6}- name: /;
+
+  function extractDetectPackageManagerStep(relativePath: string): string {
+    const content = readText(relativePath);
+    const startIndex = content.indexOf(STEP_START);
+    assert.notEqual(
+      startIndex,
+      -1,
+      `expected to find a "Detect package manager" step in ${relativePath}`,
+    );
+    const afterStart = content.slice(startIndex + STEP_START.length);
+    const endIndex = afterStart.search(STEP_END_RE);
+    assert.notEqual(
+      endIndex,
+      -1,
+      `expected a step boundary after "Detect package manager" in ${relativePath}`,
+    );
+    return afterStart.slice(0, endIndex);
+  }
+
+  const [reference, ...rest] = WORKFLOW_FILES.map((path) => ({
+    path,
+    body: extractDetectPackageManagerStep(path),
+  }));
+  for (const other of rest) {
+    assert.equal(
+      other.body,
+      reference.body,
+      `"Detect package manager" step body in ${other.path} drifted from ${reference.path}`,
+    );
+  }
+});
+
 test('policy normalization provides default-safe values and supports aliases', () => {
   assert.deepEqual(normalizePolicyConfig(null), {
     issueScope: 'roadmap-first',


### PR DESCRIPTION
## Summary

Fixes both findings from #2392 (surfaced by Codex's review on PR #2391),
choosing a different shape for the package-manager finding than either
of the issue's two proposed directions — see the
[B2 plan comment](https://github.com/kurone-kito/idd-skill/issues/2392#issuecomment-5497882797)
for the full rationale (including why persisting `packageManager` into
`package.json` was rejected — it risks breaking `corepack enable`,
which these workflows already invoke unconditionally for the
pnpm/yarn branches).

- **Full `helperRuntime` object validation**: the shell profile
  resolver now runs a single `jq` filter that mirrors
  `inspectHelperRuntimeConfig`'s complete decision table (object type,
  key allowlist, profile enum, `packageSpec` shell-safe-character
  regex) instead of only checking `.helperRuntime.profile`. Probed
  against 9 fixture configs — valid with/without spec, extra key, bad
  profile, non-enum profile, non-object `helperRuntime`, missing
  `helperRuntime`, empty object, empty-string `packageSpec` — and
  confirmed to agree with the canonical TypeScript validator on every
  case, disproving the issue's own "likely infeasible without a Node
  dependency" guess.
- **Ambiguous package-manager detection**: the shared `node -e`
  detector now mirrors `collectHelperRuntimeEvidence`'s own
  `ambiguousPackageManager` stance ("do not guess an install path")
  instead of silently picking a manager by a fixed pnpm→npm→yarn
  lockfile-priority order when no `packageManager` field is declared
  and more than one supported lockfile coexists. On ambiguity it emits
  a `::warning::` and either fails closed
  (`idd-advisory-convergence.yml`, the required-check verdict itself)
  or skips cleanly the same way `instructions-only` already does
  (`post-merge-cleanup.yml`, `idd-advisory-convergence-comment.yml`,
  both best-effort).

The detection logic is byte-identical across all three files (enforced
by a new parity test); the downstream reaction to ambiguity/invalidity
follows each file's own pre-existing posture, unchanged by this PR.

Only the `idd-template/` copies are touched — this source repository's
own dogfooded workflows at repo-root never adopted this
profile-conditional shell pattern (confirmed by grep: none of the
three contain `helperRuntime.profile` or a "Detect package manager"
step).

## Test plan

- [x] `pnpm run lint:minimum` (audit-docs, typecheck, build:check,
      biome, dprint, `node --test` — 4471 passing, markdownlint,
      cspell)
- [x] `actionlint` against all three edited workflow files
- [x] New parity test: the "Detect package manager" step body is
      byte-identical across the three files
- [x] The `jq` validation filter and the ambiguity-aware `node -e`
      detector were extracted from all three files' actual embedded
      text and run under real `bash -euo pipefail` (GitHub Actions'
      own shell mode) against 9 config fixtures and 5 package-manager
      scenarios, confirming identical, correct results everywhere —
      not just checked against a standalone copy of the logic
- [x] Workflow headers updated to describe the new
      ambiguous-package-manager skip/fail path alongside the existing
      `instructions-only` one; grepped `docs/` and
      `idd-template/ONBOARDING.md` for stale lockfile-priority prose
      (none found — the only doc mention of "ambiguous" already
      describes the unrelated onboarding recommender, which was
      already correct)

Refs #2392
