### PR TITLE
fix(idd-doctor): route a ported GHES host through an absolute API URL

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -36,6 +36,7 @@ words:
   - rollup
   - GHEC
   - GHES
+  - ghinstance
   - WHATWG
   - dedup
   - deprioritize

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -3335,56 +3335,68 @@ export function readTrustEmptyProtectionReads(root) {
   return config?.ciGate?.trustEmptyProtectionReads === true;
 }
 /**
- * Derive the `--hostname` value {@link fetchGhApiJsonAt} should pass to
- * `gh api` from the target repository's own `gh repo view --json url`
- * result (already fetched once by `checkGithubReadiness`, so this adds
- * no extra `gh` call). `gh api` resolves its target host from `GH_HOST`
- * / `--hostname` / the CLI's single authenticated host, defaulting to
- * `github.com` -- unlike a higher-level subcommand such as `gh repo
- * view`, it does **not** infer the host from the checked-out
- * repository's Git remote at all, so routing the request through `cwd:
- * root` (as every other `gh` call in this function already does) has no
- * effect on which host `gh api` targets (`gh-exec.mts`'s
- * `resolveGhApiHostname()` documents the identical `gh api` contract for
- * its own GHES fix, `#1962`; idd-skill#2010 review, Codex round 2).
- * `resolveGhApiHostname()` itself is env-based (`GH_HOST`/
- * `GITHUB_SERVER_URL`) and deliberately does not derive a host from a
- * git remote, by its own design -- the wrong signal here, since
- * `idd-doctor --repo-root <path>` may target a repository on a
- * different host than the calling environment's own default. Deriving
- * from the target repository's own resolved `url` instead is the
- * correct, `--repo-root`-specific signal. Returns the literal
- * `'github.com'` for the common `github.com` case, as an explicit
- * `--hostname` override -- unlike `resolveGhApiHostname()`'s own "no
- * override on github.com" convention, an explicit override is required
- * here: an explicit `--hostname` flag wins over `gh api`'s own
- * environment-based `GH_HOST` fallback, but `undefined` (no
- * `--hostname` at all) leaves `GH_HOST` in force, so a GHES-configured
- * `GH_HOST` in the calling environment would otherwise leak into a
- * governance read for a genuinely `github.com`-hosted target
- * repository (idd-skill#2030). Deliberately keeps the bare hostname
- * (`URL.hostname`, dropping any explicit port) for a GHES target, like
- * `resolveGhApiHostname()` (`gh-exec.mts`) already does: `gh api
- * --hostname` rejects any value containing a colon outright (confirmed
- * against a real `gh` binary: `--hostname host:port` fails argv
- * validation before a request is even attempted), so a ported GHES
- * host cannot be routed through `--hostname` at all -- correctly
- * routing one requires constructing an absolute API URL instead, which
- * neither this resolver nor its `gh-exec.mts` sibling do yet (deferred
- * to idd-skill#2052, PR #2051 review). Returns `undefined` only for an
- * unparseable or host-less `url`.
+ * Derive the host {@link fetchGhApiJsonAt} should target from the target
+ * repository's own `gh repo view --json url` result (already fetched once
+ * by `checkGithubReadiness`, so this adds no extra `gh` call). `gh api`
+ * resolves its target host from `GH_HOST` / `--hostname` / the CLI's
+ * single authenticated host, defaulting to `github.com` -- unlike a
+ * higher-level subcommand such as `gh repo view`, it does **not** infer
+ * the host from the checked-out repository's Git remote at all, so
+ * routing the request through `cwd: root` (as every other `gh` call in
+ * this function already does) has no effect on which host `gh api`
+ * targets (`gh-exec.mts`'s `resolveGhApiHostname()` documents the
+ * identical `gh api` contract for its own GHES fix, `#1962`; idd-skill#2010
+ * review, Codex round 2). `resolveGhApiHostname()` itself is env-based
+ * (`GH_HOST`/`GITHUB_SERVER_URL`) and deliberately does not derive a host
+ * from a git remote, by its own design -- the wrong signal here, since
+ * `idd-doctor --repo-root <path>` may target a repository on a different
+ * host than the calling environment's own default. Deriving from the
+ * target repository's own resolved `url` instead is the correct,
+ * `--repo-root`-specific signal. Returns the literal `'github.com'` for
+ * the common `github.com` case as an explicit override: an explicit
+ * `--hostname` flag wins over `gh api`'s own environment-based `GH_HOST`
+ * fallback, but `undefined` (no `--hostname` at all) leaves `GH_HOST` in
+ * force, so a GHES-configured `GH_HOST` in the calling environment would
+ * otherwise leak into a governance read for a genuinely
+ * `github.com`-hosted target repository (idd-skill#2030).
+ *
+ * Returns `URL.host` (hostname plus an explicit non-default port, when
+ * present -- Node's `URL` already elides an explicit-but-default `:443`
+ * on an `https:` URL, so no separate default-port branch is needed here),
+ * not `URL.hostname` -- unlike `resolveGhApiHostname()` (`gh-exec.mts`),
+ * which deliberately keeps the bare hostname for its own env-derived
+ * inputs. The distinction matters only to {@link fetchGhApiJsonAt}: `gh
+ * api --hostname` rejects any value containing a colon outright
+ * (confirmed against a real `gh` binary), so a ported value can never
+ * reach `--hostname`; {@link fetchGhApiJsonAt} instead detects the colon
+ * and routes a ported host through an absolute API URL, omitting
+ * `--hostname` entirely for that request (idd-skill#2052). Omitting it is
+ * not a regression: `gh` v2.98.0 / `cli/go-gh` v2.13.0 source
+ * (`pkg/cmd/api/http.go::httpRequest`, `api/http_client.go::
+ * AddAuthTokenHeader`, `pkg/auth/auth.go::NormalizeHostname`) confirms an
+ * absolute-URL request never consults the `--hostname`/`GH_HOST`-derived
+ * host at all -- routing and the per-request credential lookup both key
+ * off the request URL's own host (port included, `NormalizeHostname`
+ * never strips one), so a `--hostname` alongside an absolute URL would be
+ * inert, not protective. One residual, real gh limitation this fix does
+ * not and cannot change: `gh auth login --hostname` is gated by the same
+ * colon-rejecting validator, so a ported host can never have a
+ * keyring/config-stored credential either -- only `GH_ENTERPRISE_TOKEN`/
+ * `GITHUB_ENTERPRISE_TOKEN` (checked independently of the exact host
+ * string) authenticate a ported GHES host reliably today. Returns
+ * `undefined` only for an unparseable or host-less `url`.
  */
 export function resolveTargetGhHostname(url) {
   if (!url) {
     return undefined;
   }
-  let hostname;
+  let host;
   try {
-    hostname = new URL(url).hostname.toLowerCase();
+    host = new URL(url).host.toLowerCase();
   } catch {
     return undefined;
   }
-  return hostname ? hostname : undefined;
+  return host ? host : undefined;
 }
 /**
  * Root-scoped `gh api` fetch for {@link fetchGovernanceJson}'s injectable
@@ -3408,12 +3420,31 @@ export function resolveTargetGhHostname(url) {
  * `stdout`), so `fetchGovernanceJson()`'s `deriveGhHttpStatus()`-based
  * 404 detection still works, including its stdout-carried JSON-body
  * fallback. Exported for direct test coverage of that failure shape.
+ *
+ * A `hostname` carrying an explicit port (from {@link
+ * resolveTargetGhHostname}'s `URL.host`) can never be routed through
+ * `--hostname` -- `gh` rejects any value containing a colon outright --
+ * so this builds an absolute API URL instead
+ * (`https://{host}/api/v3/{path}`, mirroring `gh`'s own
+ * `ghinstance.RESTPrefix` enterprise-host convention: no `api.`
+ * subdomain, that trick is `github.com`-only) and omits `--hostname`
+ * from argv entirely for that request. This is not a functional
+ * regression: `gh`'s own request/auth pipeline never consults
+ * `--hostname` once the endpoint argument is already an absolute URL --
+ * both routing and per-request credential lookup key off the request
+ * URL's own host (idd-skill#2052; see {@link resolveTargetGhHostname}'s
+ * JSDoc for the source citations). Every non-ported `hostname` (including
+ * `undefined`) keeps the exact prior argv shape.
  */
 export function fetchGhApiJsonAt(root, hostname, path, paginate) {
+  const isPorted = hostname?.includes(':') ?? false;
+  const endpoint = isPorted
+    ? `https://${hostname}/api/v3/${path.replace(/^\//, '')}`
+    : path;
   const argv = [
     'api',
-    path,
-    ...(hostname ? ['--hostname', hostname] : []),
+    endpoint,
+    ...(!isPorted && hostname ? ['--hostname', hostname] : []),
     ...(paginate ? ['--paginate', '--jq', '.[]'] : []),
   ];
   const result = runCommand('gh', argv, root);

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -3844,44 +3844,56 @@ export function readTrustEmptyProtectionReads(root: string): boolean {
 }
 
 /**
- * Derive the `--hostname` value {@link fetchGhApiJsonAt} should pass to
- * `gh api` from the target repository's own `gh repo view --json url`
- * result (already fetched once by `checkGithubReadiness`, so this adds
- * no extra `gh` call). `gh api` resolves its target host from `GH_HOST`
- * / `--hostname` / the CLI's single authenticated host, defaulting to
- * `github.com` -- unlike a higher-level subcommand such as `gh repo
- * view`, it does **not** infer the host from the checked-out
- * repository's Git remote at all, so routing the request through `cwd:
- * root` (as every other `gh` call in this function already does) has no
- * effect on which host `gh api` targets (`gh-exec.mts`'s
- * `resolveGhApiHostname()` documents the identical `gh api` contract for
- * its own GHES fix, `#1962`; idd-skill#2010 review, Codex round 2).
- * `resolveGhApiHostname()` itself is env-based (`GH_HOST`/
- * `GITHUB_SERVER_URL`) and deliberately does not derive a host from a
- * git remote, by its own design -- the wrong signal here, since
- * `idd-doctor --repo-root <path>` may target a repository on a
- * different host than the calling environment's own default. Deriving
- * from the target repository's own resolved `url` instead is the
- * correct, `--repo-root`-specific signal. Returns the literal
- * `'github.com'` for the common `github.com` case, as an explicit
- * `--hostname` override -- unlike `resolveGhApiHostname()`'s own "no
- * override on github.com" convention, an explicit override is required
- * here: an explicit `--hostname` flag wins over `gh api`'s own
- * environment-based `GH_HOST` fallback, but `undefined` (no
- * `--hostname` at all) leaves `GH_HOST` in force, so a GHES-configured
- * `GH_HOST` in the calling environment would otherwise leak into a
- * governance read for a genuinely `github.com`-hosted target
- * repository (idd-skill#2030). Deliberately keeps the bare hostname
- * (`URL.hostname`, dropping any explicit port) for a GHES target, like
- * `resolveGhApiHostname()` (`gh-exec.mts`) already does: `gh api
- * --hostname` rejects any value containing a colon outright (confirmed
- * against a real `gh` binary: `--hostname host:port` fails argv
- * validation before a request is even attempted), so a ported GHES
- * host cannot be routed through `--hostname` at all -- correctly
- * routing one requires constructing an absolute API URL instead, which
- * neither this resolver nor its `gh-exec.mts` sibling do yet (deferred
- * to idd-skill#2052, PR #2051 review). Returns `undefined` only for an
- * unparseable or host-less `url`.
+ * Derive the host {@link fetchGhApiJsonAt} should target from the target
+ * repository's own `gh repo view --json url` result (already fetched once
+ * by `checkGithubReadiness`, so this adds no extra `gh` call). `gh api`
+ * resolves its target host from `GH_HOST` / `--hostname` / the CLI's
+ * single authenticated host, defaulting to `github.com` -- unlike a
+ * higher-level subcommand such as `gh repo view`, it does **not** infer
+ * the host from the checked-out repository's Git remote at all, so
+ * routing the request through `cwd: root` (as every other `gh` call in
+ * this function already does) has no effect on which host `gh api`
+ * targets (`gh-exec.mts`'s `resolveGhApiHostname()` documents the
+ * identical `gh api` contract for its own GHES fix, `#1962`; idd-skill#2010
+ * review, Codex round 2). `resolveGhApiHostname()` itself is env-based
+ * (`GH_HOST`/`GITHUB_SERVER_URL`) and deliberately does not derive a host
+ * from a git remote, by its own design -- the wrong signal here, since
+ * `idd-doctor --repo-root <path>` may target a repository on a different
+ * host than the calling environment's own default. Deriving from the
+ * target repository's own resolved `url` instead is the correct,
+ * `--repo-root`-specific signal. Returns the literal `'github.com'` for
+ * the common `github.com` case as an explicit override: an explicit
+ * `--hostname` flag wins over `gh api`'s own environment-based `GH_HOST`
+ * fallback, but `undefined` (no `--hostname` at all) leaves `GH_HOST` in
+ * force, so a GHES-configured `GH_HOST` in the calling environment would
+ * otherwise leak into a governance read for a genuinely
+ * `github.com`-hosted target repository (idd-skill#2030).
+ *
+ * Returns `URL.host` (hostname plus an explicit non-default port, when
+ * present -- Node's `URL` already elides an explicit-but-default `:443`
+ * on an `https:` URL, so no separate default-port branch is needed here),
+ * not `URL.hostname` -- unlike `resolveGhApiHostname()` (`gh-exec.mts`),
+ * which deliberately keeps the bare hostname for its own env-derived
+ * inputs. The distinction matters only to {@link fetchGhApiJsonAt}: `gh
+ * api --hostname` rejects any value containing a colon outright
+ * (confirmed against a real `gh` binary), so a ported value can never
+ * reach `--hostname`; {@link fetchGhApiJsonAt} instead detects the colon
+ * and routes a ported host through an absolute API URL, omitting
+ * `--hostname` entirely for that request (idd-skill#2052). Omitting it is
+ * not a regression: `gh` v2.98.0 / `cli/go-gh` v2.13.0 source
+ * (`pkg/cmd/api/http.go::httpRequest`, `api/http_client.go::
+ * AddAuthTokenHeader`, `pkg/auth/auth.go::NormalizeHostname`) confirms an
+ * absolute-URL request never consults the `--hostname`/`GH_HOST`-derived
+ * host at all -- routing and the per-request credential lookup both key
+ * off the request URL's own host (port included, `NormalizeHostname`
+ * never strips one), so a `--hostname` alongside an absolute URL would be
+ * inert, not protective. One residual, real gh limitation this fix does
+ * not and cannot change: `gh auth login --hostname` is gated by the same
+ * colon-rejecting validator, so a ported host can never have a
+ * keyring/config-stored credential either -- only `GH_ENTERPRISE_TOKEN`/
+ * `GITHUB_ENTERPRISE_TOKEN` (checked independently of the exact host
+ * string) authenticate a ported GHES host reliably today. Returns
+ * `undefined` only for an unparseable or host-less `url`.
  */
 export function resolveTargetGhHostname(
   url: string | undefined,
@@ -3889,13 +3901,13 @@ export function resolveTargetGhHostname(
   if (!url) {
     return undefined;
   }
-  let hostname: string;
+  let host: string;
   try {
-    hostname = new URL(url).hostname.toLowerCase();
+    host = new URL(url).host.toLowerCase();
   } catch {
     return undefined;
   }
-  return hostname ? hostname : undefined;
+  return host ? host : undefined;
 }
 
 /**
@@ -3920,6 +3932,21 @@ export function resolveTargetGhHostname(
  * `stdout`), so `fetchGovernanceJson()`'s `deriveGhHttpStatus()`-based
  * 404 detection still works, including its stdout-carried JSON-body
  * fallback. Exported for direct test coverage of that failure shape.
+ *
+ * A `hostname` carrying an explicit port (from {@link
+ * resolveTargetGhHostname}'s `URL.host`) can never be routed through
+ * `--hostname` -- `gh` rejects any value containing a colon outright --
+ * so this builds an absolute API URL instead
+ * (`https://{host}/api/v3/{path}`, mirroring `gh`'s own
+ * `ghinstance.RESTPrefix` enterprise-host convention: no `api.`
+ * subdomain, that trick is `github.com`-only) and omits `--hostname`
+ * from argv entirely for that request. This is not a functional
+ * regression: `gh`'s own request/auth pipeline never consults
+ * `--hostname` once the endpoint argument is already an absolute URL --
+ * both routing and per-request credential lookup key off the request
+ * URL's own host (idd-skill#2052; see {@link resolveTargetGhHostname}'s
+ * JSDoc for the source citations). Every non-ported `hostname` (including
+ * `undefined`) keeps the exact prior argv shape.
  */
 export function fetchGhApiJsonAt(
   root: string,
@@ -3927,10 +3954,14 @@ export function fetchGhApiJsonAt(
   path: string,
   paginate: boolean,
 ): unknown {
+  const isPorted = hostname?.includes(':') ?? false;
+  const endpoint = isPorted
+    ? `https://${hostname}/api/v3/${path.replace(/^\//, '')}`
+    : path;
   const argv = [
     'api',
-    path,
-    ...(hostname ? ['--hostname', hostname] : []),
+    endpoint,
+    ...(!isPorted && hostname ? ['--hostname', hostname] : []),
     ...(paginate ? ['--paginate', '--jq', '.[]'] : []),
   ];
   const result = runCommand('gh', argv, root);

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -3,6 +3,7 @@ import {
   chmodSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -4254,15 +4255,95 @@ test('resolveTargetGhHostname resolves a GHES hostname, lowercased', () => {
   );
 });
 
-// idd-skill#2030 (PR #2051 review, Copilot): `gh api --hostname` rejects
-// any value containing a colon outright (confirmed against a real `gh`
-// binary), so this resolver must never emit a ported hostname -- keeping
-// the bare host, same as `gh-exec.mts`'s `resolveGhApiHostname()` sibling,
-// is deliberate here, not an oversight. Genuine port support needs an
-// absolute-URL request path instead of `--hostname`; deferred to #2052.
-test('resolveTargetGhHostname drops an explicit non-default port for a GHES hostname (gh api --hostname cannot carry one)', () => {
+// idd-skill#2052: the resolver now preserves an explicit non-default
+// port (`URL.host`, not `URL.hostname`) -- `gh api --hostname` still
+// rejects any value containing a colon (confirmed against a real `gh`
+// binary), but that constraint is `fetchGhApiJsonAt`'s to handle (it
+// routes a ported host through an absolute API URL instead), not the
+// resolver's. See that function's own test below.
+test('resolveTargetGhHostname preserves an explicit non-default port for a GHES hostname', () => {
   assert.equal(
     resolveTargetGhHostname('https://ghe.example.com:8443/owner/repo'),
+    'ghe.example.com:8443',
+  );
+});
+
+test('resolveTargetGhHostname drops an explicit but default port (Node URL.host elision)', () => {
+  assert.equal(
+    resolveTargetGhHostname('https://ghe.example.com:443/owner/repo'),
     'ghe.example.com',
   );
+});
+
+// idd-skill#2052 (issue AC): the #2030 review finding was specifically
+// that resolver-only coverage missed the failure mode where a ported
+// hostname reached `gh api --hostname` and hard-failed argv validation --
+// so this asserts the actual argv `fetchGhApiJsonAt` builds, not just
+// `resolveTargetGhHostname`'s return value.
+test('fetchGhApiJsonAt routes a ported hostname through an absolute API URL and omits --hostname', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-doctor-fetch-gh-api-ported-'));
+  const binDir = join(dir, 'bin');
+  const argvLog = join(dir, 'argv.log');
+  const originalPath = process.env.PATH;
+  try {
+    mkdirSync(binDir, { recursive: true });
+    // Fake `gh` that records its own argv (one arg per line) instead of
+    // making a real request, then returns an empty successful response.
+    writeFileSync(
+      join(binDir, 'gh'),
+      `#!/bin/sh\nprintf '%s\\n' "$@" > ${JSON.stringify(argvLog)}\necho '{}'\n`,
+    );
+    chmodSync(join(binDir, 'gh'), 0o755);
+    process.env.PATH = `${binDir}:${originalPath ?? ''}`;
+
+    fetchGhApiJsonAt(
+      dir,
+      'ghe.example.com:8443',
+      'repos/owner/repo/branches/main/protection',
+      false,
+    );
+
+    const argv = readFileSync(argvLog, 'utf8').trim().split('\n');
+    assert.deepEqual(argv, [
+      'api',
+      'https://ghe.example.com:8443/api/v3/repos/owner/repo/branches/main/protection',
+    ]);
+  } finally {
+    process.env.PATH = originalPath;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('fetchGhApiJsonAt keeps the prior --hostname argv shape for a non-ported hostname', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-doctor-fetch-gh-api-unported-'));
+  const binDir = join(dir, 'bin');
+  const argvLog = join(dir, 'argv.log');
+  const originalPath = process.env.PATH;
+  try {
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(
+      join(binDir, 'gh'),
+      `#!/bin/sh\nprintf '%s\\n' "$@" > ${JSON.stringify(argvLog)}\necho '{}'\n`,
+    );
+    chmodSync(join(binDir, 'gh'), 0o755);
+    process.env.PATH = `${binDir}:${originalPath ?? ''}`;
+
+    fetchGhApiJsonAt(
+      dir,
+      'ghe.example.com',
+      'repos/owner/repo/branches/main/protection',
+      false,
+    );
+
+    const argv = readFileSync(argvLog, 'utf8').trim().split('\n');
+    assert.deepEqual(argv, [
+      'api',
+      'repos/owner/repo/branches/main/protection',
+      '--hostname',
+      'ghe.example.com',
+    ]);
+  } finally {
+    process.env.PATH = originalPath;
+    rmSync(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

- `resolveTargetGhHostname()` now preserves an explicit non-default port
  (`URL.host` instead of `URL.hostname`) instead of silently dropping it.
- `fetchGhApiJsonAt()` detects a ported hostname and routes the request
  through an absolute API URL (`https://{host}/api/v3/{path}`, mirroring
  `gh`'s own enterprise-host URL convention) instead of `--hostname`,
  which cannot carry a colon (`gh api --hostname` rejects it outright).

## Why this shape, not the issue's literal "keep passing --hostname too"

Verified against `gh` v2.98.0 / `cli/go-gh` v2.13.0 source
(`pkg/cmd/api/http.go`, `api/http_client.go::AddAuthTokenHeader`,
`pkg/auth/auth.go::NormalizeHostname`), plus a live empirical test against
`github.com` (`gh api --hostname example.com https://api.github.com/user`
still returned my own login, and `rate_limit` reported `5000`, ruling out
an anonymous fallback): once the endpoint argument is an absolute URL,
`gh api` never consults `--hostname` for routing **or** credential
lookup — both key off the request URL's own host. Passing `--hostname`
alongside the absolute URL would be inert, not protective, so the ported
branch omits it entirely. This is disclosed in full, with source
citations, on the issue's B2 plan comment.

One real, disclosed `gh` limitation this fix does not change: `gh auth
login --hostname` is gated by the same colon-rejecting validator, so a
`gh auth login`-stored credential can never be registered under a ported
host string. Only `GH_ENTERPRISE_TOKEN`/`GITHUB_ENTERPRISE_TOKEN`
(checked independently of the exact host string) authenticate a ported
GHES host reliably today. Not in this issue's acceptance criteria, so no
runtime guard was added — noted here for the record.

## Test plan

- [x] `node --test tests/idd-doctor.test.mts` — 294/294 pass, including
      2 updated `resolveTargetGhHostname` port tests and 2 new
      `fetchGhApiJsonAt` argv-level tests (ported vs. non-ported).
- [x] `pnpm run build` regenerates `scripts/idd-doctor.mjs`.
- [x] `pnpm run lint:minimum` passes clean (typecheck, biome, dprint,
      full `node --test tests/*.test.mts` — 4490/4490, cspell,
      markdownlint).
- [ ] No access to a real ported GHES host/token in this environment —
      the credential-routing conclusion rests on `gh`'s own source plus
      a `github.com`-based empirical test, not a live ported-GHES
      end-to-end run. Disclosed as residual risk.

Refs #2030

Closes #2052
