### PR TITLE
feat(token-cost): retry dogfood snapshot refresh, still n=0

### DIFF
--- a/docs/token-cost-snapshot.json
+++ b/docs/token-cost-snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-09-01T17:08:06.125Z",
+  "generatedAt": "2026-09-01T21:58:57.901Z",
   "minPublishableSamples": 10,
   "minPublishableVendors": 2,
   "publishable": false,


### PR DESCRIPTION
## Summary

- Re-ran `scripts/token-cost-harvest.mjs` and
  `scripts/token-cost-report.mjs --apply` per #2393's own instructions,
  after more dogfood IDD-loop activity accumulated since #2295's
  attempt.
- `publishable` is still `false` (`sampleCount: 0` issue-loop samples),
  so per #2393's own false-branch acceptance criteria this PR only
  commits the refreshed snapshot (`generatedAt` is the only field that
  changed) — no README/docs edits, no fabricated numbers.
- Root-caused the persistent `n=0` to the harvester's Claude-adapter
  issue-loop join being keyed off a single whole-session `cwd`, which a
  long-lived multi-worktree session (like the one that did this work)
  never satisfies. Filed #2404 to fix the join and #2405 to retry once
  #2404 lands (`Blocked by #2404`), and wired both into roadmap #2296's
  task list.

## Test plan

- [x] `node scripts/validate-schemas.mjs` — fixture suite green
- [x] Direct schema validation of the live
      `docs/token-cost-snapshot.json` against
      `schemas/token-cost-snapshot.schema.json` via the repo's own
      `validate` function — zero errors
- [x] `node scripts/token-cost-report.mjs --check` — no drift
- [x] `pnpm run lint` (via `fix-validate`/`pre-push-validate`: biome,
      dprint, markdownlint, cspell, audit-docs, audit-code-span-wrap,
      build:check, idd-doctor) — all green
- [x] `git status` confirms only `docs/token-cost-snapshot.json`
      changed; README.md/README.ja.md/docs/token-cost.md untouched

Closes #2393

🤖 Generated with [Claude Code](https://claude.com/claude-code)
