### PR TITLE
docs(review-fix): add a second escalation tier for stuck fixes

### DIFF
--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -111,7 +111,8 @@ kurone-kito/idd-skill#2223's clone-scoped lock
 across several rounds even after replacing mtime-based staleness with
 PID-liveness-based staleness; convergence only happened once automatic
 stale-lock takeover was removed entirely, replaced with a timeout that
-reports the lock path and holder for manual recovery — the same shape
+reports the lock path and the recorded holder's PID for manual
+recovery — the same shape
 `git`'s own `index.lock` uses on collision. Removal was safe there
 specifically because the issue's acceptance criteria only ever
 required an acquire/release interface, never automatic stale-lock

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -90,6 +90,24 @@ finding's root cause and further comments are speculative or
 non-blocking hardening, treat them as PATH B (disposition-only,
 E4-E7) rather than opening another E9-E10 round.
 
+**Second escalation tier: when the structural fix itself doesn't
+converge.** The heuristic above names one escalation (patch-by-patch
+→ one structural fix); it does not say what to do when that
+structural fix keeps drawing new same-area findings for a further few
+rounds. The natural default — a second, more elaborate structural
+redesign — tends to cost more rounds, not fewer, since the same race
+or defect class often regenerates at each added layer of recovery
+machinery. Prefer removing or substantially simplifying the fragile
+mechanism instead: replace an automatic-recovery path with a simpler
+fail-closed behavior plus actionable manual-recovery guidance, rather
+than a second redesign. Worked example: #2223's clone-scoped lock
+(PR #2389) kept drawing new P1 concurrency findings across several
+rounds even after replacing mtime-based staleness with
+PID-liveness-based staleness; convergence only happened once automatic
+stale-lock takeover was removed entirely, replaced with a timeout that
+reports the lock path and holder for manual recovery — the same shape
+`git`'s own `index.lock` uses on collision.
+
 ## E11 — Resolve conflicts with {development-branch}
 
 Check for conflicts between the feature branch and `{development-branch}`

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -101,21 +101,21 @@ added layer of recovery machinery. Prefer removing or substantially
 simplifying the fragile mechanism instead — replacing an
 automatic-recovery path with a simpler fail-closed behavior plus
 actionable manual-recovery guidance, rather than a second redesign —
-**but only once removal is confirmed safe**: check the issue's
-acceptance criteria and any established external contract for whether
-the mechanism being removed was actually required behavior; if so,
-stop for a maintainer decision instead of deleting it to converge
-review. Worked example: issue #2223's clone-scoped lock (PR #2389)
-kept drawing new P1 concurrency findings across several rounds even
-after replacing mtime-based staleness with PID-liveness-based
-staleness; convergence only happened once automatic stale-lock
-takeover was removed entirely, replaced with a timeout that reports
-the lock path and holder for manual recovery — the same shape
+**but only once confirmed safe**: before removing or simplifying away
+any part of the mechanism's behavior, check the issue's acceptance
+criteria and any established external contract for whether that
+behavior was actually required; if so, stop for a maintainer decision
+instead of dropping it to converge review. Worked example:
+kurone-kito/idd-skill#2223's clone-scoped lock
+(kurone-kito/idd-skill#2389) kept drawing new P1 concurrency findings
+across several rounds even after replacing mtime-based staleness with
+PID-liveness-based staleness; convergence only happened once automatic
+stale-lock takeover was removed entirely, replaced with a timeout that
+reports the lock path and holder for manual recovery — the same shape
 `git`'s own `index.lock` uses on collision. Removal was safe there
-specifically because issue #2223's acceptance criteria only ever
+specifically because the issue's acceptance criteria only ever
 required an acquire/release interface, never automatic stale-lock
-recovery (`src/scripts/clone-lock.mts`'s own header comment records
-this).
+recovery.
 
 ## E11 — Resolve conflicts with {development-branch}
 

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -90,23 +90,32 @@ finding's root cause and further comments are speculative or
 non-blocking hardening, treat them as PATH B (disposition-only,
 E4-E7) rather than opening another E9-E10 round.
 
-**Second escalation tier: when the structural fix itself doesn't
-converge.** The heuristic above names one escalation (patch-by-patch
-→ one structural fix); it does not say what to do when that
-structural fix keeps drawing new same-area findings for a further few
-rounds. The natural default — a second, more elaborate structural
-redesign — tends to cost more rounds, not fewer, since the same race
-or defect class often regenerates at each added layer of recovery
-machinery. Prefer removing or substantially simplifying the fragile
-mechanism instead: replace an automatic-recovery path with a simpler
-fail-closed behavior plus actionable manual-recovery guidance, rather
-than a second redesign. Worked example: #2223's clone-scoped lock
-(PR #2389) kept drawing new P1 concurrency findings across several
-rounds even after replacing mtime-based staleness with
-PID-liveness-based staleness; convergence only happened once automatic
-stale-lock takeover was removed entirely, replaced with a timeout that
-reports the lock path and holder for manual recovery — the same shape
-`git`'s own `index.lock` uses on collision.
+**Second escalation tier (heuristic, not a hard rule): when the
+structural fix itself doesn't converge.** The heuristic above names
+one escalation (patch-by-patch → one structural fix); it does not say
+what to do when that structural fix keeps drawing new same-area
+findings for a further few rounds. The natural default — a second,
+more elaborate structural redesign — tends to cost more rounds, not
+fewer, since the same race or defect class often regenerates at each
+added layer of recovery machinery. Prefer removing or substantially
+simplifying the fragile mechanism instead — replacing an
+automatic-recovery path with a simpler fail-closed behavior plus
+actionable manual-recovery guidance, rather than a second redesign —
+**but only once removal is confirmed safe**: check the issue's
+acceptance criteria and any established external contract for whether
+the mechanism being removed was actually required behavior; if so,
+stop for a maintainer decision instead of deleting it to converge
+review. Worked example: issue #2223's clone-scoped lock (PR #2389)
+kept drawing new P1 concurrency findings across several rounds even
+after replacing mtime-based staleness with PID-liveness-based
+staleness; convergence only happened once automatic stale-lock
+takeover was removed entirely, replaced with a timeout that reports
+the lock path and holder for manual recovery — the same shape
+`git`'s own `index.lock` uses on collision. Removal was safe there
+specifically because issue #2223's acceptance criteria only ever
+required an acquire/release interface, never automatic stale-lock
+recovery (`src/scripts/clone-lock.mts`'s own header comment records
+this).
 
 ## E11 — Resolve conflicts with {development-branch}
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -96,21 +96,21 @@ added layer of recovery machinery. Prefer removing or substantially
 simplifying the fragile mechanism instead — replacing an
 automatic-recovery path with a simpler fail-closed behavior plus
 actionable manual-recovery guidance, rather than a second redesign —
-**but only once removal is confirmed safe**: check the issue's
-acceptance criteria and any established external contract for whether
-the mechanism being removed was actually required behavior; if so,
-stop for a maintainer decision instead of deleting it to converge
-review. Worked example: issue #2223's clone-scoped lock (PR #2389)
-kept drawing new P1 concurrency findings across several rounds even
-after replacing mtime-based staleness with PID-liveness-based
-staleness; convergence only happened once automatic stale-lock
-takeover was removed entirely, replaced with a timeout that reports
-the lock path and holder for manual recovery — the same shape
+**but only once confirmed safe**: before removing or simplifying away
+any part of the mechanism's behavior, check the issue's acceptance
+criteria and any established external contract for whether that
+behavior was actually required; if so, stop for a maintainer decision
+instead of dropping it to converge review. Worked example:
+kurone-kito/idd-skill#2223's clone-scoped lock
+(kurone-kito/idd-skill#2389) kept drawing new P1 concurrency findings
+across several rounds even after replacing mtime-based staleness with
+PID-liveness-based staleness; convergence only happened once automatic
+stale-lock takeover was removed entirely, replaced with a timeout that
+reports the lock path and holder for manual recovery — the same shape
 `git`'s own `index.lock` uses on collision. Removal was safe there
-specifically because issue #2223's acceptance criteria only ever
+specifically because the issue's acceptance criteria only ever
 required an acquire/release interface, never automatic stale-lock
-recovery (`src/scripts/clone-lock.mts`'s own header comment records
-this).
+recovery.
 
 ## E11 — Resolve conflicts with {development-branch}
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -85,6 +85,24 @@ finding's root cause and further comments are speculative or
 non-blocking hardening, treat them as PATH B (disposition-only,
 E4-E7) rather than opening another E9-E10 round.
 
+**Second escalation tier: when the structural fix itself doesn't
+converge.** The heuristic above names one escalation (patch-by-patch
+→ one structural fix); it does not say what to do when that
+structural fix keeps drawing new same-area findings for a further few
+rounds. The natural default — a second, more elaborate structural
+redesign — tends to cost more rounds, not fewer, since the same race
+or defect class often regenerates at each added layer of recovery
+machinery. Prefer removing or substantially simplifying the fragile
+mechanism instead: replace an automatic-recovery path with a simpler
+fail-closed behavior plus actionable manual-recovery guidance, rather
+than a second redesign. Worked example: #2223's clone-scoped lock
+(PR #2389) kept drawing new P1 concurrency findings across several
+rounds even after replacing mtime-based staleness with
+PID-liveness-based staleness; convergence only happened once automatic
+stale-lock takeover was removed entirely, replaced with a timeout that
+reports the lock path and holder for manual recovery — the same shape
+`git`'s own `index.lock` uses on collision.
+
 ## E11 — Resolve conflicts with {development-branch}
 
 Check for conflicts between the feature branch and `{development-branch}`

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -85,23 +85,32 @@ finding's root cause and further comments are speculative or
 non-blocking hardening, treat them as PATH B (disposition-only,
 E4-E7) rather than opening another E9-E10 round.
 
-**Second escalation tier: when the structural fix itself doesn't
-converge.** The heuristic above names one escalation (patch-by-patch
-→ one structural fix); it does not say what to do when that
-structural fix keeps drawing new same-area findings for a further few
-rounds. The natural default — a second, more elaborate structural
-redesign — tends to cost more rounds, not fewer, since the same race
-or defect class often regenerates at each added layer of recovery
-machinery. Prefer removing or substantially simplifying the fragile
-mechanism instead: replace an automatic-recovery path with a simpler
-fail-closed behavior plus actionable manual-recovery guidance, rather
-than a second redesign. Worked example: #2223's clone-scoped lock
-(PR #2389) kept drawing new P1 concurrency findings across several
-rounds even after replacing mtime-based staleness with
-PID-liveness-based staleness; convergence only happened once automatic
-stale-lock takeover was removed entirely, replaced with a timeout that
-reports the lock path and holder for manual recovery — the same shape
-`git`'s own `index.lock` uses on collision.
+**Second escalation tier (heuristic, not a hard rule): when the
+structural fix itself doesn't converge.** The heuristic above names
+one escalation (patch-by-patch → one structural fix); it does not say
+what to do when that structural fix keeps drawing new same-area
+findings for a further few rounds. The natural default — a second,
+more elaborate structural redesign — tends to cost more rounds, not
+fewer, since the same race or defect class often regenerates at each
+added layer of recovery machinery. Prefer removing or substantially
+simplifying the fragile mechanism instead — replacing an
+automatic-recovery path with a simpler fail-closed behavior plus
+actionable manual-recovery guidance, rather than a second redesign —
+**but only once removal is confirmed safe**: check the issue's
+acceptance criteria and any established external contract for whether
+the mechanism being removed was actually required behavior; if so,
+stop for a maintainer decision instead of deleting it to converge
+review. Worked example: issue #2223's clone-scoped lock (PR #2389)
+kept drawing new P1 concurrency findings across several rounds even
+after replacing mtime-based staleness with PID-liveness-based
+staleness; convergence only happened once automatic stale-lock
+takeover was removed entirely, replaced with a timeout that reports
+the lock path and holder for manual recovery — the same shape
+`git`'s own `index.lock` uses on collision. Removal was safe there
+specifically because issue #2223's acceptance criteria only ever
+required an acquire/release interface, never automatic stale-lock
+recovery (`src/scripts/clone-lock.mts`'s own header comment records
+this).
 
 ## E11 — Resolve conflicts with {development-branch}
 

--- a/idd-template/.github/instructions/idd-review-fix.instructions.md
+++ b/idd-template/.github/instructions/idd-review-fix.instructions.md
@@ -106,7 +106,8 @@ kurone-kito/idd-skill#2223's clone-scoped lock
 across several rounds even after replacing mtime-based staleness with
 PID-liveness-based staleness; convergence only happened once automatic
 stale-lock takeover was removed entirely, replaced with a timeout that
-reports the lock path and holder for manual recovery — the same shape
+reports the lock path and the recorded holder's PID for manual
+recovery — the same shape
 `git`'s own `index.lock` uses on collision. Removal was safe there
 specifically because the issue's acceptance criteria only ever
 required an acquire/release interface, never automatic stale-lock


### PR DESCRIPTION
## Summary

- The "Round-count heuristic for genuinely-new findings" in
  `idd-review-fix.instructions.md` names one escalation tier
  (patch-by-patch → one structural fix) but not what to do when that
  structural fix itself keeps drawing new same-area findings.
- Added a short, non-binding addendum (same framing as the existing
  paragraph and the E10 no-progress guard): prefer removing or
  substantially simplifying the fragile mechanism over a second,
  more elaborate structural redesign — using #2223's clone-scoped
  lock (PR #2389) as the compact worked example.
- Edited the canonical `idd-template/` source and regenerated the
  mirrored `.github/instructions/` copy via `node scripts/sync-docs.mjs
  --apply`; both files are identical byte-for-byte in the changed
  region.
- Byte budget checked before drafting: `bundle-review` (the containing
  bundle, `limitBytes: 138000`) had headroom before this change and is
  now at 95.52% utilization (`audit-docs.mjs --check` notice, not a
  failure) — comfortably under the 98% hard ceiling. The lite variant
  (`idd-review-fix-lite.instructions.md`, part of the already-tight
  `bundle-review-fix-lite` at 96.98%) has no matching section, so no
  lite-side edit was needed.

## Test plan

- [x] `node scripts/sync-docs.mjs --apply` — mirror regenerated, no
      drift
- [x] `node scripts/audit-docs.mjs --check` — passes; only a new
      95.52%-utilization notice on `bundle-review` (informational,
      below the 98% ceiling)
- [x] `node scripts/audit-code-span-wrap.mjs` — no mid-token wraps
- [x] `pre-push-validate` (biome, dprint, markdownlint, cspell,
      audit-docs, audit-code-span-wrap, build:check, idd-doctor) —
      all green

Closes #2401

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that second-tier escalation is heuristic rather than mandatory.
  - Added checks for acceptance criteria and external contracts before removing automatic recovery.
  - Requires maintainer direction when removing a mechanism could violate required behavior.
  - Documented why stale-lock removal is safe when only acquire/release behavior is required.
  - Applied the guidance consistently across the main instructions and template instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->