### PR TITLE
docs(helpers): read the closest existing helper first

### DIFF
--- a/docs/typescript-sources.md
+++ b/docs/typescript-sources.md
@@ -87,16 +87,16 @@ independently re-deriving already-settled tradeoffs. This applies
 generally, not only to locks.
 
 Worked example: issue #2223 asked for a new clone-scoped lock for
-concurrent worktree lifecycle operations, naming `claim-lock.mts` in
+concurrent worktree lifecycle operations, naming `src/scripts/claim-lock.mts` in
 its own body as either the extension target or the natural sibling
-for a new module. The implementation (PR #2389, `clone-lock.mts`)
+for a new module. The implementation (PR #2389, `src/scripts/clone-lock.mts`)
 designed its own staleness and recovery logic from scratch instead,
 and needed several further review rounds to arrive — independently,
 through review-driven trial and error — at conclusions
-`claim-lock.mts`'s own comments already state as settled: prefer a
+`src/scripts/claim-lock.mts`'s own comments already state as settled: prefer a
 stronger external authority over ad hoc local recovery when one is
 available, and a local process-liveness check can be defeated by a
-process-lifecycle mismatch (in `clone-lock.mts`'s case, a wrapper
+process-lifecycle mismatch (in `src/scripts/clone-lock.mts`'s case, a wrapper
 process dying while the child command it spawned kept running).
 
 ## Build and verification

--- a/docs/typescript-sources.md
+++ b/docs/typescript-sources.md
@@ -77,6 +77,28 @@ collapses their diffs in review. This is distinct from
 `linguist-vendored`, which denotes third-party code and is reserved for
 adopter repositories that vendor the bundle.
 
+### Read the closest existing helper first
+
+Before drafting a new helper whose problem shares its shape with an
+existing one in `src/scripts/` — another mutual-exclusion or locking
+primitive, another marker parser, and so on — read that existing
+helper's own header and design-rationale comments first, rather than
+independently re-deriving already-settled tradeoffs. This applies
+generally, not only to locks.
+
+Worked example: issue #2223 asked for a new clone-scoped lock for
+concurrent worktree lifecycle operations, naming `claim-lock.mts` in
+its own body as either the extension target or the natural sibling
+for a new module. The implementation (PR #2389, `clone-lock.mts`)
+designed its own staleness and recovery logic from scratch instead,
+and needed several further review rounds to arrive — independently,
+through review-driven trial and error — at conclusions
+`claim-lock.mts`'s own comments already state as settled: prefer a
+stronger external authority over ad hoc local recovery when one is
+available, and a local process-liveness check can be defeated by a
+process-lifecycle mismatch (in `clone-lock.mts`'s case, a wrapper
+process dying while the child command it spawned kept running).
+
 ## Build and verification
 
 | Command                | Purpose                                                                                                                                                                                                          |


### PR DESCRIPTION
## Summary

- No document pointed the author of a new same-shape helper at
  reading an existing analogous helper's own design-rationale
  comments before drafting from scratch.
- Added a short "Read the closest existing helper first" subsection
  to `docs/typescript-sources.md`, right after the `## Layout`
  section, using issue #2223's clone-scoped lock
  (PR #2389, `clone-lock.mts`) as the worked example: it designed its
  own staleness/recovery logic independently and took several extra
  review rounds to arrive at conclusions `claim-lock.mts`'s own
  header comment already states as settled.
- `docs/typescript-sources.md` is not part of any sync pair
  (source-repo-only, not distributed to `idd-template/`), so the bare
  issue reference is unambiguous here.

## Test plan

- [x] `node scripts/audit-docs.mjs --check` — passes; `docs/*.md` is
      byte-budget-exempt so no new bundle notice
- [x] `node scripts/audit-code-span-wrap.mjs` — no mid-token wraps
- [x] `pre-push-validate` (biome, dprint, markdownlint, cspell,
      audit-docs, audit-code-span-wrap, build:check, idd-doctor) —
      all green

Closes #2402

🤖 Generated with [Claude Code](https://claude.com/claude-code)
