### PR TITLE
docs(review-fix-lite): mirror the round-count/escalation heuristic

### DIFF
--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -131,12 +131,12 @@ other GitHub side effect, confirm all of the following:
 6. Do not use step 5 to bypass a serious issue: unresolved High or
    Medium findings stay blockers until fixed or explicitly redirected
    by a maintainer.
-7. Heuristic: several rounds (3-4) each finding something genuinely
-   new in the same area (not a repeat) may mean one structural fix
-   converges faster than another patch. If that fix itself keeps
-   drawing new findings, prefer simplifying/removing the mechanism
-   over a second redesign -- only once confirmed non-required by the
-   acceptance criteria.
+7. Heuristic: several new, non-repeated same-area findings across
+   rounds (3-4) may mean one structural fix converges faster than
+   another patch. If that fix keeps drawing new findings, prefer
+   simplifying/removing the mechanism over a second redesign -- only
+   once confirmed non-required by the issue's acceptance criteria or
+   contract; if required, stop for a maintainer decision.
 
 ## E11 — Resolve conflicts with main
 

--- a/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -131,6 +131,12 @@ other GitHub side effect, confirm all of the following:
 6. Do not use step 5 to bypass a serious issue: unresolved High or
    Medium findings stay blockers until fixed or explicitly redirected
    by a maintainer.
+7. Heuristic: several rounds (3-4) each finding something genuinely
+   new in the same area (not a repeat) may mean one structural fix
+   converges faster than another patch. If that fix itself keeps
+   drawing new findings, prefer simplifying/removing the mechanism
+   over a second redesign -- only once confirmed non-required by the
+   acceptance criteria.
 
 ## E11 — Resolve conflicts with main
 

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -126,12 +126,12 @@ other GitHub side effect, confirm all of the following:
 6. Do not use step 5 to bypass a serious issue: unresolved High or
    Medium findings stay blockers until fixed or explicitly redirected
    by a maintainer.
-7. Heuristic: several rounds (3-4) each finding something genuinely
-   new in the same area (not a repeat) may mean one structural fix
-   converges faster than another patch. If that fix itself keeps
-   drawing new findings, prefer simplifying/removing the mechanism
-   over a second redesign -- only once confirmed non-required by the
-   acceptance criteria.
+7. Heuristic: several new, non-repeated same-area findings across
+   rounds (3-4) may mean one structural fix converges faster than
+   another patch. If that fix keeps drawing new findings, prefer
+   simplifying/removing the mechanism over a second redesign -- only
+   once confirmed non-required by the issue's acceptance criteria or
+   contract; if required, stop for a maintainer decision.
 
 ## E11 — Resolve conflicts with main
 

--- a/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-review-fix-lite.instructions.md
@@ -126,6 +126,12 @@ other GitHub side effect, confirm all of the following:
 6. Do not use step 5 to bypass a serious issue: unresolved High or
    Medium findings stay blockers until fixed or explicitly redirected
    by a maintainer.
+7. Heuristic: several rounds (3-4) each finding something genuinely
+   new in the same area (not a repeat) may mean one structural fix
+   converges faster than another patch. If that fix itself keeps
+   drawing new findings, prefer simplifying/removing the mechanism
+   over a second redesign -- only once confirmed non-required by the
+   acceptance criteria.
 
 ## E11 — Resolve conflicts with main
 


### PR DESCRIPTION
## Summary

- `idd-review-fix-lite.instructions.md` states an explicit
  same-semantics contract with the full `idd-review-fix.instructions.md`
  but its E10 section never had the "Round-count heuristic for
  genuinely-new findings" or #2401's second escalation tier — a
  weak/local model on the lite profile had no guidance for either
  pattern.
- Added a condensed equivalent as E10 step 7, in this file's existing
  terse numbered-step style rather than the full file's paragraph
  style, preserving the same non-binding/heuristic framing.
- `bundle-review-fix-lite` (`limitBytes: 39500`) was already at
  96.98% of its 98% ceiling. Went through several drafting rounds —
  verified against the real `audit-docs.mjs --check` output each
  time, not hand-counted bytes — before landing at a version that
  fits (97.89% final).

## Test plan

- [x] `node scripts/sync-docs.mjs --apply` — mirror regenerated from
      the canonical `idd-template/` source, no drift
- [x] `node scripts/audit-docs.mjs --check` — passes,
      `bundle-review-fix-lite` at 97.89% (under the 98% ceiling)
- [x] `node scripts/audit-code-span-wrap.mjs` — no mid-token wraps
- [x] `pre-push-validate` (biome, dprint, markdownlint, cspell,
      audit-docs, audit-code-span-wrap, build:check, idd-doctor) —
      all green

Closes #2413

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for handling repeated, genuinely new findings in the same area.
  * Recommends applying a structural fix first, then simplifying or removing non-required mechanisms if issues persist after several review rounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->