### PR TITLE
docs(token-cost): retry the dogfood snapshot refresh (round 3)

### DIFF
--- a/docs/token-cost-snapshot.json
+++ b/docs/token-cost-snapshot.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-09-01T21:58:57.901Z",
+  "generatedAt": "2026-09-02T01:03:09.101Z",
   "minPublishableSamples": 10,
   "minPublishableVendors": 2,
   "publishable": false,
   "sampleCount": 0,
   "vendors": [],
-  "asOf": "2026-09-01",
+  "asOf": "2026-09-02",
   "totalUsage": {
     "inputUncached": {
       "p25": 0,


### PR DESCRIPTION
## Summary

Closes #2405.

Re-ran the harvester and reporter now that #2404 (cwd-segmentation join fix, PR #2416) has merged. `publishable` is still `false` (`n=0` issue-loop, 69 `session`-kind samples), same outcome as #2295/#2393. Per #2405's own branching acceptance criteria, this commits the refreshed stub as-is (no invented numbers) rather than re-diagnosing the join gap from scratch.

## Why the retry still shows n=0

#2404's Background paragraph already stated the premise this confirms: "a long-lived, multi-worktree Claude Code session never produces a cwd-inferable issue number" — i.e. cwd stays *fixed* for the whole session file. That is exactly the case #2404's cwd-segmentation fix cannot help, since there's no second cwd segment to split out. This PR's investigation confirmed that premise is the *actual, currently observed state* on this workstation, not a hypothetical:

- `grep -ho '"cwd":"[^"]*"' ~/.claude/projects/-home-kurone-kito-ghq-github-com-kurone-kito-idd-skill/*.jsonl | sort -u` across all 56 real Claude Code session log files returns **exactly one** distinct value: the primary worktree path. No file has ever recorded a worktree-shaped (`.issue/<n>-*`) cwd, despite many sessions (including this one) doing extensive work across multiple issue worktrees via `cd`-prefixed Bash-tool calls.
- `ls ~/.claude/projects | grep issue` returns nothing — no worktree-launched session has ever produced its own sibling encoded project directory.
- Within one session's own log, `gitBranch` is also pinned to `main` throughout, even while that session actively committed to multiple `issue/<n>-*` branches inside separate worktrees.
- Net effect: Claude Code's session JSONL records `cwd`/`gitBranch` as a fixed property of the outer process/conversation, not a value that tracks Bash-tool-internal `cd` calls. #2404's cwd-segmentation is exercised by zero real session files on this deployment shape (one long-lived session, many worktrees via Bash `cd`, never relaunching Claude Code per worktree).
- Confirmed this is not a #2404 regression: the pre-existing "skip file, no valid timestamp" behavior for a few tiny session files is unchanged and unrelated.
- Codex shares the same deployment shape and the same 0-issue-loop outcome (16 samples, 0 issue-loop).

#2404's own PR body had already investigated and declined an "event-window join as a first-class `issueNumber` supplier" direction (correlating a session's own timestamps against `token-cost-event.mjs`'s per-issue enter/exit windows, which don't depend on `cwd`), scoping it out as a follow-up. That direction is now the actual load-bearing fix needed for this workstation's dominant shape, not an optional nice-to-have.

## Follow-ups filed

- #2418 — the real root-cause fix: join issue-loop samples via event-window timestamps instead of `cwd`.
- #2419 — retry round 4, `Blocked by` #2418, same acceptance shape as this issue.
- Left a [post-merge finding comment](https://github.com/kurone-kito/idd-skill/pull/2416#issuecomment-5502808563) on PR #2416 so its "fixes multi-worktree sessions" framing isn't taken at face value without this context.
- Updated roadmap #2296's Tracks list (checked off #2404, added #2418/#2419).

## Test plan

- [x] `docs/token-cost-snapshot.json` committed; validates against `schemas/token-cost-snapshot.schema.json` (`node --test tests/schema-output-roundtrip.test.mts tests/token-cost-core.test.mts` — 41/41 pass).
- [x] `node scripts/token-cost-report.mjs --check` is green.
- [x] `publishable: false`; README/README.ja/docs/token-cost.md untouched (still on the unpublished stub); snapshot shows `n=0` and `publishable: false`; follow-up issues #2418/#2419 filed.
- [x] No vendor logs, samples JSONL, prompt text, or absolute paths in the diff (`git diff --stat` — 1 file, `docs/token-cost-snapshot.json`).
- [x] `pnpm run lint` passes (4572/4572 tests, 0 biome/cspell/markdownlint issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtcjhuuXDqQASYGXtJnmV3