### PR TITLE
fix(discover-viability-gate): scope false-positives on topic words

### DIFF
--- a/scripts/discover-viability-gate.mjs
+++ b/scripts/discover-viability-gate.mjs
@@ -41,7 +41,7 @@ const BROAD_SCOPE_PATTERN =
 // 1. Avoidance-cue: the match is the disfavored option in a "rather than X"
 //    / "prefer Y over X" construction (#2401, #2413).
 const AVOIDANCE_CUE_PATTERN =
-  /\b(rather than|instead of|avoid|prefer|over a)\b/i;
+  /\b(rather than|instead of|avoid|prefer|over a)\b/gi;
 const AVOIDANCE_CUE_WINDOW = 80;
 // A comma continues the SAME clause the cue governs only when immediately
 // followed by a degree/comparative adverb ("a second, more elaborate
@@ -202,18 +202,36 @@ function isInsideCodeSpan(corpus, index) {
 function isGovernedByAvoidanceCue(corpus, matchIndex) {
   const windowStart = Math.max(0, matchIndex - AVOIDANCE_CUE_WINDOW);
   const window = corpus.slice(windowStart, matchIndex);
-  const cueMatch = AVOIDANCE_CUE_PATTERN.exec(window);
-  if (!cueMatch) {
-    return false;
+  // A single "find the first cue" check misses a real governing cue when an
+  // EARLIER, unrelated cue also sits in the window but is itself cut off by
+  // a hard clause break: "Avoid regressions. But rather than redesign the
+  // schema, ..." -- "avoid" is broken from the match by the period, but
+  // "rather than" right before "redesign" governs it cleanly. Check every
+  // cue in the window; the match is governed if any of them reach it with
+  // no break in between.
+  for (const cueMatch of window.matchAll(AVOIDANCE_CUE_PATTERN)) {
+    const linkText = window.slice(cueMatch.index + cueMatch[0].length);
+    if (HARD_CLAUSE_BREAK_PATTERN.test(linkText)) {
+      continue;
+    }
+    if (CLAUSE_CONTINUATION_COMMA_PATTERN.test(linkText)) {
+      continue;
+    }
+    return true;
   }
-  const linkText = window.slice(cueMatch.index + cueMatch[0].length);
-  if (HARD_CLAUSE_BREAK_PATTERN.test(linkText)) {
-    return false;
-  }
-  return !CLAUSE_CONTINUATION_COMMA_PATTERN.test(linkText);
+  return false;
 }
 function isFollowedByContentNoun(corpus, matchEnd) {
-  const tail = corpus.slice(matchEnd, matchEnd + CONTENT_NOUN_LOOKAHEAD_CHARS);
+  // The lookahead must stop at the first sentence/clause boundary: without
+  // it, "... redesign the public interface. Guidance: ..." would let an
+  // unrelated NEW sentence's "Guidance:" suppress a genuinely broad-scope
+  // match in the PRECEDING sentence.
+  const rawTail = corpus.slice(
+    matchEnd,
+    matchEnd + CONTENT_NOUN_LOOKAHEAD_CHARS,
+  );
+  const breakMatch = HARD_CLAUSE_BREAK_PATTERN.exec(rawTail);
+  const tail = breakMatch ? rawTail.slice(0, breakMatch.index) : rawTail;
   const tokens = tail.match(WORD_TOKEN_PATTERN) ?? [];
   return tokens
     .slice(0, CONTENT_NOUN_LOOKAHEAD_TOKENS)

--- a/scripts/discover-viability-gate.mjs
+++ b/scripts/discover-viability-gate.mjs
@@ -28,7 +28,40 @@ const CRITERIA = [
   },
 ];
 const BROAD_SCOPE_PATTERN =
-  /\b(cross-cutting|cross cutting|across (?:many|multiple)|multiple subsystems?|repository-wide|entire repo|public interface|redesign|architecture|global refactor|large refactor)\b/i;
+  /\b(cross-cutting|cross cutting|across (?:many|multiple)|multiple subsystems?|repository-wide|entire repo|public interface|redesign|architecture|global refactor|large refactor)\b/gi;
+// A broad-scope word inside a phrase describing something other than this
+// issue's own diff footprint should not count (#2417): a worked example of
+// what NOT to do, a citation of another issue's already-resolved heuristic,
+// or a mention of the documentation/guidance content itself. Two exclusion
+// shapes cover the observed false positives, matched per-occurrence rather
+// than once for the whole corpus (a genuinely broad issue usually trips the
+// pattern more than once, so excluding one occurrence still leaves the rest
+// to fail the gate).
+//
+// 1. Avoidance-cue: the match is the disfavored option in a "rather than X"
+//    / "prefer Y over X" construction (#2401, #2413).
+const AVOIDANCE_CUE_PATTERN =
+  /\b(rather than|instead of|avoid|prefer|over a)\b/i;
+const AVOIDANCE_CUE_WINDOW = 80;
+// A comma continues the SAME clause the cue governs only when immediately
+// followed by a degree/comparative adverb ("a second, more elaborate
+// redesign" -- #2401); any other comma, or a period/semicolon/em-dash,
+// starts a new clause and cuts the cue's reach short ("Instead of a
+// targeted fix, do a full redesign" -- "do" starts a fresh, un-governed
+// proposal that must still fail the gate).
+const CLAUSE_CONTINUATION_COMMA_PATTERN =
+  /,\s+(?!more\b|less\b|even\b|particularly\b|especially\b|slightly\b|somewhat\b)/;
+const HARD_CLAUSE_BREAK_PATTERN = /[.;—]|--/;
+// 2. Content-noun: the match modifies a noun naming prose/documentation
+//    content itself ("cross-cutting ... guidance" -- #2402), not this
+//    issue's own change. The noun can sit a token or two past the match
+//    (an intervening modifier), so this walks forward through the next
+//    few word tokens rather than anchoring immediately after the match.
+const CONTENT_NOUN_PATTERN =
+  /^(guidance|documentation|docs|heuristic|advice|note|policy|text|wording)$/i;
+const CONTENT_NOUN_LOOKAHEAD_CHARS = 60;
+const CONTENT_NOUN_LOOKAHEAD_TOKENS = 3;
+const WORD_TOKEN_PATTERN = /[A-Za-z][\w-]*/g;
 const NARROW_SCOPE_PATTERN =
   /\b(single module|single file|few files|targeted|small fix|localized|narrow scope)\b/i;
 const OBJECTIVE_VERIFICATION_PATTERN =
@@ -157,16 +190,67 @@ export function evaluateA4Viability(issue) {
     criteria,
   };
 }
+function isInsideCodeSpan(corpus, index) {
+  let backtickCount = 0;
+  for (let i = 0; i < index; i += 1) {
+    if (corpus[i] === '`') {
+      backtickCount += 1;
+    }
+  }
+  return backtickCount % 2 === 1;
+}
+function isGovernedByAvoidanceCue(corpus, matchIndex) {
+  const windowStart = Math.max(0, matchIndex - AVOIDANCE_CUE_WINDOW);
+  const window = corpus.slice(windowStart, matchIndex);
+  const cueMatch = AVOIDANCE_CUE_PATTERN.exec(window);
+  if (!cueMatch) {
+    return false;
+  }
+  const linkText = window.slice(cueMatch.index + cueMatch[0].length);
+  if (HARD_CLAUSE_BREAK_PATTERN.test(linkText)) {
+    return false;
+  }
+  return !CLAUSE_CONTINUATION_COMMA_PATTERN.test(linkText);
+}
+function isFollowedByContentNoun(corpus, matchEnd) {
+  const tail = corpus.slice(matchEnd, matchEnd + CONTENT_NOUN_LOOKAHEAD_CHARS);
+  const tokens = tail.match(WORD_TOKEN_PATTERN) ?? [];
+  return tokens
+    .slice(0, CONTENT_NOUN_LOOKAHEAD_TOKENS)
+    .some((token) => CONTENT_NOUN_PATTERN.test(token));
+}
+/**
+ * Finds the first BROAD_SCOPE_PATTERN occurrence that survives both
+ * exclusion checks (#2417): a match inside a code span, governed by an
+ * avoidance cue, or followed by a content noun does not describe this
+ * issue's own diff footprint and is skipped.
+ */
+function findUnexcludedBroadScopeMatch(corpus) {
+  for (const match of corpus.matchAll(BROAD_SCOPE_PATTERN)) {
+    const index = match.index;
+    const end = index + match[0].length;
+    if (
+      isInsideCodeSpan(corpus, index) ||
+      isGovernedByAvoidanceCue(corpus, index) ||
+      isFollowedByContentNoun(corpus, end)
+    ) {
+      continue;
+    }
+    return match[0];
+  }
+  return null;
+}
 export function evaluateLimitedScope(issue) {
   const corpus = `${issue.title}\n${issue.body}`;
   // Test the broad-scope signal first: a broad/A4-fail cue must fail the
   // gate even when a narrow cue is also present (e.g. "single module change
   // that redesigns a public interface"). Returning narrow-pass first would
   // let that wording bypass the gate.
-  if (BROAD_SCOPE_PATTERN.test(corpus)) {
+  const broadScopeMatch = findUnexcludedBroadScopeMatch(corpus);
+  if (broadScopeMatch !== null) {
     return {
       pass: false,
-      evidence: 'Broad or cross-cutting scope signal detected.',
+      evidence: `Broad or cross-cutting scope signal detected: "${broadScopeMatch}".`,
     };
   }
   if (NARROW_SCOPE_PATTERN.test(corpus)) {

--- a/src/scripts/discover-viability-gate.mts
+++ b/src/scripts/discover-viability-gate.mts
@@ -87,7 +87,40 @@ const CRITERIA: {
 ];
 
 const BROAD_SCOPE_PATTERN =
-  /\b(cross-cutting|cross cutting|across (?:many|multiple)|multiple subsystems?|repository-wide|entire repo|public interface|redesign|architecture|global refactor|large refactor)\b/i;
+  /\b(cross-cutting|cross cutting|across (?:many|multiple)|multiple subsystems?|repository-wide|entire repo|public interface|redesign|architecture|global refactor|large refactor)\b/gi;
+// A broad-scope word inside a phrase describing something other than this
+// issue's own diff footprint should not count (#2417): a worked example of
+// what NOT to do, a citation of another issue's already-resolved heuristic,
+// or a mention of the documentation/guidance content itself. Two exclusion
+// shapes cover the observed false positives, matched per-occurrence rather
+// than once for the whole corpus (a genuinely broad issue usually trips the
+// pattern more than once, so excluding one occurrence still leaves the rest
+// to fail the gate).
+//
+// 1. Avoidance-cue: the match is the disfavored option in a "rather than X"
+//    / "prefer Y over X" construction (#2401, #2413).
+const AVOIDANCE_CUE_PATTERN =
+  /\b(rather than|instead of|avoid|prefer|over a)\b/i;
+const AVOIDANCE_CUE_WINDOW = 80;
+// A comma continues the SAME clause the cue governs only when immediately
+// followed by a degree/comparative adverb ("a second, more elaborate
+// redesign" -- #2401); any other comma, or a period/semicolon/em-dash,
+// starts a new clause and cuts the cue's reach short ("Instead of a
+// targeted fix, do a full redesign" -- "do" starts a fresh, un-governed
+// proposal that must still fail the gate).
+const CLAUSE_CONTINUATION_COMMA_PATTERN =
+  /,\s+(?!more\b|less\b|even\b|particularly\b|especially\b|slightly\b|somewhat\b)/;
+const HARD_CLAUSE_BREAK_PATTERN = /[.;—]|--/;
+// 2. Content-noun: the match modifies a noun naming prose/documentation
+//    content itself ("cross-cutting ... guidance" -- #2402), not this
+//    issue's own change. The noun can sit a token or two past the match
+//    (an intervening modifier), so this walks forward through the next
+//    few word tokens rather than anchoring immediately after the match.
+const CONTENT_NOUN_PATTERN =
+  /^(guidance|documentation|docs|heuristic|advice|note|policy|text|wording)$/i;
+const CONTENT_NOUN_LOOKAHEAD_CHARS = 60;
+const CONTENT_NOUN_LOOKAHEAD_TOKENS = 3;
+const WORD_TOKEN_PATTERN = /[A-Za-z][\w-]*/g;
 const NARROW_SCOPE_PATTERN =
   /\b(single module|single file|few files|targeted|small fix|localized|narrow scope)\b/i;
 const OBJECTIVE_VERIFICATION_PATTERN =
@@ -236,16 +269,71 @@ export function evaluateA4Viability(issue: unknown): {
   };
 }
 
+function isInsideCodeSpan(corpus: string, index: number): boolean {
+  let backtickCount = 0;
+  for (let i = 0; i < index; i += 1) {
+    if (corpus[i] === '`') {
+      backtickCount += 1;
+    }
+  }
+  return backtickCount % 2 === 1;
+}
+
+function isGovernedByAvoidanceCue(corpus: string, matchIndex: number): boolean {
+  const windowStart = Math.max(0, matchIndex - AVOIDANCE_CUE_WINDOW);
+  const window = corpus.slice(windowStart, matchIndex);
+  const cueMatch = AVOIDANCE_CUE_PATTERN.exec(window);
+  if (!cueMatch) {
+    return false;
+  }
+  const linkText = window.slice(cueMatch.index + cueMatch[0].length);
+  if (HARD_CLAUSE_BREAK_PATTERN.test(linkText)) {
+    return false;
+  }
+  return !CLAUSE_CONTINUATION_COMMA_PATTERN.test(linkText);
+}
+
+function isFollowedByContentNoun(corpus: string, matchEnd: number): boolean {
+  const tail = corpus.slice(matchEnd, matchEnd + CONTENT_NOUN_LOOKAHEAD_CHARS);
+  const tokens = tail.match(WORD_TOKEN_PATTERN) ?? [];
+  return tokens
+    .slice(0, CONTENT_NOUN_LOOKAHEAD_TOKENS)
+    .some((token) => CONTENT_NOUN_PATTERN.test(token));
+}
+
+/**
+ * Finds the first BROAD_SCOPE_PATTERN occurrence that survives both
+ * exclusion checks (#2417): a match inside a code span, governed by an
+ * avoidance cue, or followed by a content noun does not describe this
+ * issue's own diff footprint and is skipped.
+ */
+function findUnexcludedBroadScopeMatch(corpus: string): string | null {
+  for (const match of corpus.matchAll(BROAD_SCOPE_PATTERN)) {
+    const index = match.index;
+    const end = index + match[0].length;
+    if (
+      isInsideCodeSpan(corpus, index) ||
+      isGovernedByAvoidanceCue(corpus, index) ||
+      isFollowedByContentNoun(corpus, end)
+    ) {
+      continue;
+    }
+    return match[0];
+  }
+  return null;
+}
+
 export function evaluateLimitedScope(issue: NormalizedIssue): EvalResult {
   const corpus = `${issue.title}\n${issue.body}`;
   // Test the broad-scope signal first: a broad/A4-fail cue must fail the
   // gate even when a narrow cue is also present (e.g. "single module change
   // that redesigns a public interface"). Returning narrow-pass first would
   // let that wording bypass the gate.
-  if (BROAD_SCOPE_PATTERN.test(corpus)) {
+  const broadScopeMatch = findUnexcludedBroadScopeMatch(corpus);
+  if (broadScopeMatch !== null) {
     return {
       pass: false,
-      evidence: 'Broad or cross-cutting scope signal detected.',
+      evidence: `Broad or cross-cutting scope signal detected: "${broadScopeMatch}".`,
     };
   }
   if (NARROW_SCOPE_PATTERN.test(corpus)) {

--- a/src/scripts/discover-viability-gate.mts
+++ b/src/scripts/discover-viability-gate.mts
@@ -100,7 +100,7 @@ const BROAD_SCOPE_PATTERN =
 // 1. Avoidance-cue: the match is the disfavored option in a "rather than X"
 //    / "prefer Y over X" construction (#2401, #2413).
 const AVOIDANCE_CUE_PATTERN =
-  /\b(rather than|instead of|avoid|prefer|over a)\b/i;
+  /\b(rather than|instead of|avoid|prefer|over a)\b/gi;
 const AVOIDANCE_CUE_WINDOW = 80;
 // A comma continues the SAME clause the cue governs only when immediately
 // followed by a degree/comparative adverb ("a second, more elaborate
@@ -282,19 +282,37 @@ function isInsideCodeSpan(corpus: string, index: number): boolean {
 function isGovernedByAvoidanceCue(corpus: string, matchIndex: number): boolean {
   const windowStart = Math.max(0, matchIndex - AVOIDANCE_CUE_WINDOW);
   const window = corpus.slice(windowStart, matchIndex);
-  const cueMatch = AVOIDANCE_CUE_PATTERN.exec(window);
-  if (!cueMatch) {
-    return false;
+  // A single "find the first cue" check misses a real governing cue when an
+  // EARLIER, unrelated cue also sits in the window but is itself cut off by
+  // a hard clause break: "Avoid regressions. But rather than redesign the
+  // schema, ..." -- "avoid" is broken from the match by the period, but
+  // "rather than" right before "redesign" governs it cleanly. Check every
+  // cue in the window; the match is governed if any of them reach it with
+  // no break in between.
+  for (const cueMatch of window.matchAll(AVOIDANCE_CUE_PATTERN)) {
+    const linkText = window.slice(cueMatch.index + cueMatch[0].length);
+    if (HARD_CLAUSE_BREAK_PATTERN.test(linkText)) {
+      continue;
+    }
+    if (CLAUSE_CONTINUATION_COMMA_PATTERN.test(linkText)) {
+      continue;
+    }
+    return true;
   }
-  const linkText = window.slice(cueMatch.index + cueMatch[0].length);
-  if (HARD_CLAUSE_BREAK_PATTERN.test(linkText)) {
-    return false;
-  }
-  return !CLAUSE_CONTINUATION_COMMA_PATTERN.test(linkText);
+  return false;
 }
 
 function isFollowedByContentNoun(corpus: string, matchEnd: number): boolean {
-  const tail = corpus.slice(matchEnd, matchEnd + CONTENT_NOUN_LOOKAHEAD_CHARS);
+  // The lookahead must stop at the first sentence/clause boundary: without
+  // it, "... redesign the public interface. Guidance: ..." would let an
+  // unrelated NEW sentence's "Guidance:" suppress a genuinely broad-scope
+  // match in the PRECEDING sentence.
+  const rawTail = corpus.slice(
+    matchEnd,
+    matchEnd + CONTENT_NOUN_LOOKAHEAD_CHARS,
+  );
+  const breakMatch = HARD_CLAUSE_BREAK_PATTERN.exec(rawTail);
+  const tail = breakMatch ? rawTail.slice(0, breakMatch.index) : rawTail;
   const tokens = tail.match(WORD_TOKEN_PATTERN) ?? [];
   return tokens
     .slice(0, CONTENT_NOUN_LOOKAHEAD_TOKENS)

--- a/tests/discover-viability-gate.test.mts
+++ b/tests/discover-viability-gate.test.mts
@@ -221,6 +221,41 @@ test('still fails limited scope when a content-noun word sits near a genuinely b
   assert.ok(result.failedCriteria.includes('limited_scope'));
 });
 
+test('passes limited scope when an earlier, broken cue would shadow a later cue that directly governs the match (Copilot review finding, #2422)', () => {
+  // The window contains TWO avoidance cues: "avoid" is cut off from the
+  // match by a hard clause break (the period before "But"), while "rather
+  // than" sits directly before "redesign" with nothing in between. Only
+  // checking the first-found cue would miss the second, governing one.
+  const result = evaluateA4Viability({
+    number: 25,
+    title: 'simplify the mechanism',
+    body:
+      'Attempt to avoid regressions. But rather than redesign the schema, ' +
+      'we chose a simpler patch. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.failedCriteria, []);
+});
+
+test('still fails limited scope when a content noun starts a new sentence after a genuinely broad-scope description (Copilot review finding, #2422)', () => {
+  // "Guidance:" opens an unrelated new sentence; it must not reach back
+  // across the sentence boundary and suppress the broad-scope match in the
+  // preceding sentence.
+  const result = evaluateA4Viability({
+    number: 26,
+    title: 'redesign the public interface',
+    body:
+      'This issue will redesign the public interface. Guidance: see the ' +
+      'design doc. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('limited_scope'));
+});
+
 test('renderCsv quotes titles containing commas and quotes', () => {
   const csv = renderCsv({
     viable: [{ number: 10, title: 'fix parser, escape "quotes" too' }],

--- a/tests/discover-viability-gate.test.mts
+++ b/tests/discover-viability-gate.test.mts
@@ -135,6 +135,92 @@ test('fails limited scope when a broad cue accompanies a narrow cue', () => {
   assert.ok(result.failedCriteria.includes('limited_scope'));
 });
 
+// --- #2417: limited_scope false positives on topic words, not the diff's
+// own footprint --------------------------------------------------------
+
+test('passes limited scope when a broad-scope word is the rejected option in a "rather than" clause (#2401 shape)', () => {
+  const result = evaluateA4Viability({
+    number: 20,
+    title: 'add fail-closed recovery guidance',
+    body:
+      'Replace the open-ended escalation cue with a simpler fail-closed ' +
+      'behavior plus actionable manual-recovery guidance -- rather than ' +
+      'attempting a second, more elaborate structural redesign. Keep the ' +
+      'same non-binding, heuristic framing. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.failedCriteria, []);
+});
+
+test('passes limited scope when a broad-scope word modifies documentation content, not the diff (#2402 shape)', () => {
+  const result = evaluateA4Viability({
+    number: 21,
+    title: 'add a pointer doc for helper-authoring guidance',
+    body:
+      '`docs/typescript-sources.md` (or another location already ' +
+      "established as this repository's home for cross-cutting " +
+      'helper-authoring guidance) states that a new helper sharing its ' +
+      'problem shape should reuse the existing pattern. Single-file ' +
+      'change. Verification: add unit tests and keep lint green.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.failedCriteria, []);
+});
+
+test('passes limited scope when a broad-scope word is the rejected option in a "prefer X over Y" clause (#2413 shape)', () => {
+  const result = evaluateA4Viability({
+    number: 22,
+    title: 'simplify the fragile mechanism instead of a second attempt',
+    body:
+      "If the structural fix itself doesn't converge, prefer " +
+      'simplifying/removing the fragile mechanism over a second redesign, ' +
+      'but only once removal is confirmed non-required. Verification: ' +
+      'add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.failedCriteria, []);
+});
+
+test('still fails limited scope when a cue precedes the rejected option but a genuinely broad change follows in the same sentence', () => {
+  // Adversarial case: an avoidance cue must not extend its reach across a
+  // clause boundary and exclude a broad-scope word that describes what
+  // this issue's own change actually does.
+  const result = evaluateA4Viability({
+    number: 23,
+    title: 'redesign the public interface',
+    body:
+      'Instead of a targeted fix, do a full redesign of the public ' +
+      'interface. Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('limited_scope'));
+});
+
+test('still fails limited scope when a content-noun word sits near a genuinely broad-scope diff description', () => {
+  // Adversarial case: "guidance" coincidentally following "cross-cutting"
+  // must not suppress a second, independent broad-scope signal in the same
+  // corpus ("across multiple subsystems").
+  const result = evaluateA4Viability({
+    number: 24,
+    title: 'redesign the cross-cutting authentication guidance module',
+    body:
+      'This issue redesigns the module across multiple subsystems. ' +
+      'Verification: add unit tests.',
+    state: 'OPEN',
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failedCriteria.includes('limited_scope'));
+});
+
 test('renderCsv quotes titles containing commas and quotes', () => {
   const csv = renderCsv({
     viable: [{ number: 10, title: 'fix parser, escape "quotes" too' }],


### PR DESCRIPTION
## Summary

Closes #2417.

`evaluateLimitedScope`'s `BROAD_SCOPE_PATTERN` matched any occurrence of a broad-scope word (`redesign`, `cross-cutting`, `public interface`, ...) anywhere in an issue's title+body, regardless of whether it described this issue's own diff footprint or merely appeared in prose describing something else -- a worked example of what NOT to do, a citation of another issue's already-resolved heuristic, or a mention of the documentation/guidance content itself. Four single-file, genuinely narrow-scope issues (#2401, #2402, #2413, and a clone-lock worked example in #2412) were false-positived by this gate and manually overridden after checking against the written A4 Step 1 prose in one session.

## Design

Converts `evaluateLimitedScope`'s single whole-corpus `BROAD_SCOPE_PATTERN.test(corpus)` into a `matchAll` loop with a per-match classifier (the same shape `suitability-triage.mts`'s `findPolicyOverrideMatch` uses for its own word-proximity false-positive class, #2407), excluding an occurrence when it is:

1. Inside a code span (backtick-quoted).
2. The disfavored option in a `rather than X` / `prefer Y over X` avoidance construction, bounded by a clause-boundary check (a comma cuts the cue's reach short *unless* immediately followed by a degree/comparative adverb like "more" -- this distinguishes "a second, **more** elaborate structural redesign" [#2401, comma continues the same clause] from "Instead of a targeted fix, **do** a full redesign" [comma starts a fresh, un-governed proposal]).
3. Followed within a few tokens by a noun naming documentation/prose content itself (`guidance`, `docs`, `heuristic`, ...), covering the #2402 shape ("cross-cutting helper-authoring **guidance**" describes the doc's own subject matter, not this issue's change).

Per-occurrence exclusion (not whole-corpus) means a genuinely broad issue still fails: #920's own true-positive tests keep failing because they either repeat the signal or have no nearby exclusion cue.

**Rejected: Direction 1 from the issue** (scope the match to the `## Proposed change` section). #2402's false-positive match is already inside that section -- it describes the *topic* of new documentation being added, not the diff's own footprint -- so section-scoping would not have caught it. Direction 2 (context-aware exclusion) is the only one of the issue's two suggested directions that covers all three real cases.

**Known, documented limitation**: the real #2401 issue body has a *second* "redesign" occurrence with no nearby lexical cue ("the natural default is to attempt a second, more elaborate structural redesign -- which is exactly what cost the extra rounds"), relying on longer-range discourse context (a retrospective negative judgment several words later) this fix does not attempt to parse. That issue is already closed and merged, so this is not a live blocker, but a future issue using this exact zero-cue hedge phrasing could still false-positive -- analogous to #2407's documented bare-unquoted-key limitation.

## Adversarial cases considered

- A cue governing only a *rejected* alternative, with a *genuinely proposed* broad change following in the same sentence (`"Instead of a targeted fix, do a full redesign of the public interface."`) -- correctly still fails, via the clause-boundary check.
- A content-noun word (`guidance`) coincidentally near a genuinely broad-scope description -- correctly still fails, because the corpus's *other* broad-scope word (`across multiple subsystems`) has no exclusion cue of its own (the per-occurrence design's safety margin: a genuinely broad body usually trips more than one alternative).

## Test plan

- [x] All four real false-positive shapes (#2401, #2402, #2413, plus the #2412-mirrored shape) now pass `limited_scope` as regression fixtures.
- [x] Both existing true-positive tests (#920) still fail `limited_scope` -- no regression.
- [x] Two new adversarial true-positive tests (clause-boundary cutoff, content-noun-adjacent-to-genuine-TP) added and passing.
- [x] `node --test tests/discover-viability-gate.test.mts` -- 22/22 pass.
- [x] `pnpm run build` regenerates matching `scripts/discover-viability-gate.mjs`, committed alongside the `.mts` source.
- [x] `pnpm run lint` passes (4577/4577 tests, `build:check` clean, 0 biome/cspell/markdownlint issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtcjhuuXDqQASYGXtJnmV3