### PR TITLE
fix(token-cost): join issue-loop samples via event-window, not cwd

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -156,8 +156,17 @@ add this call to `idd-template/` or `.github/instructions/` phase files,
 which distribute to adopters with no token-cost data to record.
 
 When running the IDD loop in this repository, call
-`node scripts/token-cost-event.mjs --stage <id> --enter --vendor <v>`
+
+```sh
+node scripts/token-cost-event.mjs --stage <id> --enter --vendor <v> --issue <n>
+```
+
 when a listed stage starts, and the same with `--exit` when it ends.
+Include `--issue <n>` on every call from `claim` onward, once an issue
+is claimed — omit it only for `discover`, which precedes any claim. A
+call with no `--issue` is unusable for per-issue attribution (#2418):
+the harvester can only join it back to an issue when the number is
+recorded on the event itself.
 `schemas/token-cost-event.schema.json`'s `vendor` enum (`grok`, `claude`,
 `codex`) has no value for GitHub Copilot yet — skip this call rather
 than pass a mismatched vendor; a wrong tag would corrupt the shared

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,12 +127,20 @@ add this call to `idd-template/` or `.github/instructions/` phase files,
 which distribute to adopters with no token-cost data to record.
 
 When running the IDD loop in this repository, call
-`node scripts/token-cost-event.mjs --stage <id> --enter --vendor <v>`
+
+```sh
+node scripts/token-cost-event.mjs --stage <id> --enter --vendor <v> --issue <n>
+```
+
 when a listed stage starts, and the same with `--exit` when it ends,
 using `--vendor codex` for Codex CLI or `--vendor grok` for Grok Build.
-OpenCode has no matching `vendor` value in
-`schemas/token-cost-event.schema.json` yet — skip this call rather than
-pass a mismatched vendor. Stage ids: `discover`, `claim`, `work`,
+Include `--issue <n>` on every call from `claim` onward, once an issue
+is claimed — omit it only for `discover`, which precedes any claim. A
+call with no `--issue` is unusable for per-issue attribution (#2418):
+the harvester can only join it back to an issue when the number is
+recorded on the event itself. OpenCode has no matching `vendor` value
+in `schemas/token-cost-event.schema.json` yet — skip this call rather
+than pass a mismatched vendor. Stage ids: `discover`, `claim`, `work`,
 `submit-pr`, `review`, `merge`, `cleanup`. Ignore any failure from this
 command — it must never block or slow the IDD loop.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,11 +127,19 @@ add this call to `idd-template/` or `.github/instructions/` phase files,
 which distribute to adopters with no token-cost data to record.
 
 When Claude runs the IDD loop in this repository, call
-`node scripts/token-cost-event.mjs --stage <id> --enter --vendor claude`
+
+```sh
+node scripts/token-cost-event.mjs --stage <id> --enter --vendor claude --issue <n>
+```
+
 when a listed stage starts, and the same with `--exit` when it ends.
-Stage ids: `discover`, `claim`, `work`, `submit-pr`, `review`, `merge`,
-`cleanup`. Ignore any failure from this command — it must never block or
-slow the IDD loop.
+Include `--issue <n>` on every call from `claim` onward, once an issue
+is claimed — omit it only for `discover`, which precedes any claim. A
+call with no `--issue` is unusable for per-issue attribution (#2418):
+the harvester can only join it back to an issue when the number is
+recorded on the event itself. Stage ids: `discover`, `claim`, `work`,
+`submit-pr`, `review`, `merge`, `cleanup`. Ignore any failure from this
+command — it must never block or slow the IDD loop.
 
 ## Issue-authoring skill (dogfooded)
 

--- a/scripts/token-cost-adapter-claude.mjs
+++ b/scripts/token-cost-adapter-claude.mjs
@@ -240,11 +240,11 @@ function toValidTimestamp(value) {
  * (if any) that record falls inside.
  */
 export function extractRecordTimestampMs(record) {
-  if (!isPlainObject(record)) {
+  if (!isPlainObject(record) || typeof record.timestamp !== 'string') {
     return undefined;
   }
-  const valid = toValidTimestamp(record.timestamp);
-  return valid === undefined ? undefined : Date.parse(valid);
+  const atMs = Date.parse(record.timestamp);
+  return Number.isFinite(atMs) ? atMs : undefined;
 }
 /** First and last valid record `timestamp` fields, in file order. Undefined when no record has one. */
 function extractTimestamps(records) {

--- a/scripts/token-cost-adapter-claude.mjs
+++ b/scripts/token-cost-adapter-claude.mjs
@@ -43,6 +43,19 @@
 // records; `claudeAdapter.harvest()` itself is unchanged in shape (still
 // one call in, one `TokenCostAdapterResult` out) and stays exactly as
 // valid for a single-segment (the common, unchanged case) as before.
+//
+// #2418: #2404's cwd-segmentation only helps when a session's `cwd`
+// actually varies mid-file. On a workstation where every session is
+// launched once from the primary worktree and moves between issue
+// worktrees only via in-conversation `cd` (never a fresh Claude Code
+// launch), `cwd` never varies at all, so #2404's fix is never exercised.
+// `ClaudeHarvestInput.issueNumberOverride` lets a caller (the
+// harvester's event-window fallback in `token-cost-harvest.mts`, which
+// this module has no events.jsonl access to implement itself) supply the
+// issue number directly, bypassing cwd-inference for that call. This
+// module stays cwd-only otherwise; `scanClaudeSessions` below never sets
+// `issueNumberOverride` (it has no events.jsonl input to derive one
+// from) and keeps its documented cwd-only contract.
 import { globSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
@@ -146,10 +159,14 @@ function deriveFallbackSessionId(fileBasename) {
  * segment, and out of scope here since it is a one-time transition, not a
  * steady-state gap.
  */
-function deriveVendorSessionId(base, segmentIndex) {
-  return base === undefined || segmentIndex === undefined
-    ? base
-    : `${base}#${segmentIndex}`;
+function deriveVendorSessionId(base, segmentIndex, eventWindowIssueNumber) {
+  if (base === undefined) {
+    return undefined;
+  }
+  if (eventWindowIssueNumber !== undefined) {
+    return `${base}#ew${eventWindowIssueNumber}`;
+  }
+  return segmentIndex === undefined ? base : `${base}#${segmentIndex}`;
 }
 /** The first non-empty top-level `cwd` across `records`, in file order. */
 function extractCwd(records) {
@@ -214,6 +231,20 @@ function toValidTimestamp(value) {
     return undefined;
   }
   return Number.isFinite(Date.parse(value)) ? value : undefined;
+}
+/**
+ * One record's own `timestamp` field, parsed to epoch milliseconds, or
+ * undefined when absent/invalid. Exported for the harvester's
+ * event-window fallback (#2418), which needs each record's own timestamp
+ * independent of any `cwd` field to determine which issue's event window
+ * (if any) that record falls inside.
+ */
+export function extractRecordTimestampMs(record) {
+  if (!isPlainObject(record)) {
+    return undefined;
+  }
+  const valid = toValidTimestamp(record.timestamp);
+  return valid === undefined ? undefined : Date.parse(valid);
 }
 /** First and last valid record `timestamp` fields, in file order. Undefined when no record has one. */
 function extractTimestamps(records) {
@@ -316,15 +347,26 @@ function asClaudeHarvestInput(input) {
     typeof input.fileBasename === 'string' ? input.fileBasename : undefined;
   const segmentIndex =
     typeof input.segmentIndex === 'number' ? input.segmentIndex : undefined;
-  return { records: input.records, fileBasename, segmentIndex };
+  const issueNumberOverride =
+    typeof input.issueNumberOverride === 'number'
+      ? input.issueNumberOverride
+      : undefined;
+  return {
+    records: input.records,
+    fileBasename,
+    segmentIndex,
+    issueNumberOverride,
+  };
 }
 /** Claude Code vendor adapter. `input` must satisfy {@link ClaudeHarvestInput}. */
 export const claudeAdapter = {
   harvest(input) {
-    const { records, fileBasename, segmentIndex } = asClaudeHarvestInput(input);
+    const { records, fileBasename, segmentIndex, issueNumberOverride } =
+      asClaudeHarvestInput(input);
     const vendorSessionId = deriveVendorSessionId(
       extractSessionId(records) ?? deriveFallbackSessionId(fileBasename),
       segmentIndex,
+      issueNumberOverride,
     );
     if (!vendorSessionId) {
       throw new Error(
@@ -338,9 +380,9 @@ export const claudeAdapter = {
       );
     }
     const cwd = extractCwd(records);
-    const issueNumber = cwd
-      ? inferIssueNumberFromBasename(basename(cwd))
-      : undefined;
+    const issueNumber =
+      issueNumberOverride ??
+      (cwd ? inferIssueNumberFromBasename(basename(cwd)) : undefined);
     const sample = {
       schemaVersion: 1,
       kind: 'session',

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -865,6 +865,29 @@ function eventWindowsForIssue(all, issueNumber, vendor) {
  *   folded into the union and permanently frozen under the stable
  *   `#ew<issueNumber>` id as if the (unfinished) retry were the
  *   completed loop.
+ * - A later attempt whose own `--enter` (or `--exit`) call for some
+ *   non-`cleanup` stage silently fails (`token-cost-event.mjs` is
+ *   deliberately fail-open) can leave that stage's pairing mixing one
+ *   attempt's enter with an EARLIER, unrelated attempt's exit, which
+ *   `readEventWindows` reports as reversed (`startMs > endMs`) once the
+ *   later attempt's own timestamp is newer than the stale one it paired
+ *   with. Excluding such a window from the union (as `startMs < endMs`
+ *   already does above) is not enough on its own: `startMs` still
+ *   silently degrades to the stable `cleanup`-only window instead of
+ *   surfacing the contamination. A reversed non-`cleanup` stage window
+ *   whose own `startMs` falls at or before the completed run's own
+ *   `cleanup.endMs` is treated as direct evidence that this issue's
+ *   event history is corrupted for THIS harvest, so the whole issue is
+ *   skipped rather than emitted with a silently narrowed window (no
+ *   sample beats a wrong one). A reversed window entirely past
+ *   `cleanup.endMs` is ordinary mid-retry noise from a later, distinct
+ *   attempt and does not block emission of the already-completed window.
+ *   The remaining case -- a stage whose stale, EARLIER-attempt pairing
+ *   happens to still be internally valid (non-reversed), e.g. because
+ *   BOTH of the later attempt's own enter/exit calls for that stage
+ *   failed -- is mechanically indistinguishable from a genuine early
+ *   start without an attempt/session identity on `TokenCostEvent`
+ *   itself; tracked as a follow-up (#2424) rather than solved here.
  */
 export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
   const stagesByIssue = new Map();
@@ -885,6 +908,15 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
   for (const [issueNumber, stages] of stagesByIssue) {
     const cleanup = stages.get('cleanup');
     if (!cleanup || cleanup.startMs >= cleanup.endMs) {
+      continue;
+    }
+    const hasContaminatedStage = [...stages].some(
+      ([stageId, window]) =>
+        stageId !== 'cleanup' &&
+        window.startMs >= window.endMs &&
+        window.startMs <= cleanup.endMs,
+    );
+    if (hasContaminatedStage) {
       continue;
     }
     let startMs = cleanup.startMs;

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -881,6 +881,10 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
  * guessed: concurrent sessions append to one shared, HOME-keyed
  * `events.jsonl`, so two different issues' windows can genuinely overlap
  * in wall-clock, and "exactly one match" is the only safe attribution.
+ * Windows are half-open (`[startMs, endMs)`, matching `computeStageWindows`'s
+ * own convention) so a record at the exact instant one issue's window ends
+ * and an adjacent issue's window begins matches only the later window,
+ * rather than being wrongly treated as ambiguous between the two.
  * Preserves each group's original file-order relative to itself.
  */
 export function segmentRecordsByEventWindow(
@@ -895,7 +899,7 @@ export function segmentRecordsByEventWindow(
       continue;
     }
     const matches = issueWindows.filter(
-      (window) => atMs >= window.startMs && atMs <= window.endMs,
+      (window) => atMs >= window.startMs && atMs < window.endMs,
     );
     if (matches.length !== 1) {
       continue;
@@ -927,19 +931,28 @@ export function segmentRecordsByEventWindow(
  * worktree and reaches other worktrees only via in-conversation `cd`
  * (never a fresh Claude Code launch), `cwd` never varies at all, so
  * #2404's segmentation is never exercised and #2404 alone still produces
- * zero issue-loop samples. For a cwd-segment whose OWN cwd-inference
- * already failed (`joinHints.issueNumber === undefined`), this
- * additionally partitions that segment's records by event window
+ * zero issue-loop samples. This additionally partitions by event window
  * (`segmentRecordsByEventWindow`, gated to CLOSED `cleanup` windows only
  * -- see `buildCompletedIssueWindows`) and calls `claudeAdapter.harvest()`
  * once more per matched issue, via `issueNumberOverride`. This is
- * additive, not a replacement: the segment's own plain cwd-only sample
- * (`kind: 'session'` when cwd-inference fails) is still produced exactly
- * as before, so nothing already working regresses. `aggregateSnapshot`
- * (`token-cost-report.mts`) only ever counts `kind: 'issue-loop'` samples
- * toward the published snapshot, so a `session`-kind sample coexisting
- * with event-window-derived `issue-loop` samples drawn from the same
- * underlying records cannot double-count anything published.
+ * additive, not a replacement: every cwd-segment's own plain cwd-only
+ * sample (`kind: 'session'` when cwd-inference fails) is still produced
+ * exactly as before, so nothing already working regresses.
+ * `aggregateSnapshot` (`token-cost-report.mts`) only ever counts
+ * `kind: 'issue-loop'` samples toward the published snapshot, so a
+ * `session`-kind sample coexisting with event-window-derived
+ * `issue-loop` samples drawn from the same underlying records cannot
+ * double-count anything published.
+ *
+ * Event-window partitioning runs ONCE per FILE, across every cwd-segment
+ * whose own cwd-inference failed, not once per segment. A file whose
+ * `cwd` changes to some non-`issue/<n>-*` value more than once (any
+ * ordinary directory switch, not just a worktree move) would otherwise
+ * split those records across separate cwd-segments; partitioning
+ * per-segment would independently re-derive the SAME `#ew<issueNumber>`
+ * suffix from more than one segment and push a duplicate-keyed
+ * `VendorSession` within a single harvest run, which the append-side
+ * dedup (keyed only against samples from PRIOR runs) cannot catch.
  */
 export function scanClaudeVendorSessions(
   projectDir,
@@ -969,6 +982,7 @@ export function scanClaudeVendorSessions(
     }
     const fileBasename = basename(file);
     const segments = segmentRecordsByCwd(records);
+    const unattributedRecords = [];
     segments.forEach((segment, index) => {
       let adapterResult;
       try {
@@ -992,35 +1006,35 @@ export function scanClaudeVendorSessions(
         adapterResult,
         timeline: extractClaudeUsageTimeline(segment.records),
       });
-      if (
-        adapterResult.joinHints?.issueNumber === undefined &&
-        completedIssueWindows.length > 0
-      ) {
-        const eventWindowGroups = segmentRecordsByEventWindow(
-          segment.records,
-          completedIssueWindows,
-          extractRecordTimestampMs,
-        );
-        for (const [issueNumber, groupRecords] of eventWindowGroups) {
-          try {
-            const eventWindowResult = claudeAdapter.harvest({
-              records: groupRecords,
-              fileBasename,
-              issueNumberOverride: issueNumber,
-            });
-            out.push({
-              vendor: 'claude',
-              adapterResult: eventWindowResult,
-              timeline: extractClaudeUsageTimeline(groupRecords),
-            });
-          } catch (error) {
-            process.stderr.write(
-              `token-cost-harvest: skipping ${file} segment ${index} event-window issue #${issueNumber}: ${error.message}\n`,
-            );
-          }
-        }
+      if (adapterResult.joinHints?.issueNumber === undefined) {
+        unattributedRecords.push(...segment.records);
       }
     });
+    if (unattributedRecords.length > 0 && completedIssueWindows.length > 0) {
+      const eventWindowGroups = segmentRecordsByEventWindow(
+        unattributedRecords,
+        completedIssueWindows,
+        extractRecordTimestampMs,
+      );
+      for (const [issueNumber, groupRecords] of eventWindowGroups) {
+        try {
+          const eventWindowResult = claudeAdapter.harvest({
+            records: groupRecords,
+            fileBasename,
+            issueNumberOverride: issueNumber,
+          });
+          out.push({
+            vendor: 'claude',
+            adapterResult: eventWindowResult,
+            timeline: extractClaudeUsageTimeline(groupRecords),
+          });
+        } catch (error) {
+          process.stderr.write(
+            `token-cost-harvest: skipping ${file} event-window issue #${issueNumber}: ${error.message}\n`,
+          );
+        }
+      }
+    }
   }
   return out;
 }

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -841,19 +841,33 @@ function eventWindowsForIssue(all, issueNumber, vendor) {
  * data-loss concern: `events.jsonl` is append-only, so a later harvest
  * picks it up if cleanup ever runs).
  *
- * `startMs < endMs` guards against `readEventWindows`'s own pairing: it
- * pairs the LATEST `--enter` seen for a (issue, vendor, stage) key with
- * the LATEST `--exit`, across the whole append-only file, with no
- * knowledge of which attempt either belongs to. A completed run followed
- * by a re-attempt that enters `cleanup` again but never exits pairs that
- * new, still-open enter with the FIRST attempt's stale exit, producing a
- * reversed window (`startMs > endMs`) -- without this guard, its mere
- * presence would still count as "closed" and the new, unfinished
- * attempt's partial usage would be harvested and permanently frozen
- * under the stable `#ew<issueNumber>` id.
+ * The window's `endMs` is ALWAYS the valid cleanup window's own `endMs`
+ * -- never a max across every stage -- and a stage only widens `startMs`
+ * when its OWN window (both ends) falls at or before that cleanup exit.
+ * This guards against `readEventWindows`'s own pairing: it pairs the
+ * LATEST `--enter` seen for a (issue, vendor, stage) key with the LATEST
+ * `--exit`, across the whole append-only file, with no knowledge of
+ * which attempt either belongs to.
+ *
+ * - A completed run followed by a re-attempt that enters `cleanup` again
+ *   but never exits pairs that new, still-open enter with the FIRST
+ *   attempt's stale exit, producing a reversed window (`startMs >
+ *   endMs`) -- `startMs < endMs` rejects this outright, so the mere
+ *   presence of a `cleanup` key is never enough on its own.
+ * - A completed run followed by a re-attempt that has NOT yet re-entered
+ *   `cleanup` at all leaves the original, still-valid cleanup pair
+ *   untouched, but the re-attempt's OTHER stage events (e.g. a fresh
+ *   `work` enter/exit) land in `eventWindowsAll` too, with timestamps
+ *   AFTER the original cleanup's own exit. Capping `endMs` at cleanup's
+ *   own exit, and excluding any stage window that extends past it from
+ *   widening `startMs`, keeps that later, still-in-progress activity out
+ *   of the completed window -- without this, its partial usage would be
+ *   folded into the union and permanently frozen under the stable
+ *   `#ew<issueNumber>` id as if the (unfinished) retry were the
+ *   completed loop.
  */
 export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
-  const byIssue = new Map();
+  const stagesByIssue = new Map();
   for (const [key, window] of eventWindowsAll) {
     const [issueNumberRaw, keyVendor, stageId] = key.split(':');
     if (keyVendor !== vendor) {
@@ -863,26 +877,23 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
     if (!Number.isInteger(issueNumber)) {
       continue;
     }
-    const existing = byIssue.get(issueNumber);
-    byIssue.set(issueNumber, {
-      startMs: existing
-        ? Math.min(existing.startMs, window.startMs)
-        : window.startMs,
-      endMs: existing ? Math.max(existing.endMs, window.endMs) : window.endMs,
-      hasClosedCleanup:
-        (existing?.hasClosedCleanup ?? false) ||
-        (stageId === 'cleanup' && window.startMs < window.endMs),
-    });
+    const stages = stagesByIssue.get(issueNumber) ?? new Map();
+    stages.set(stageId, window);
+    stagesByIssue.set(issueNumber, stages);
   }
   const out = [];
-  for (const [issueNumber, entry] of byIssue) {
-    if (entry.hasClosedCleanup) {
-      out.push({
-        issueNumber,
-        startMs: entry.startMs,
-        endMs: entry.endMs,
-      });
+  for (const [issueNumber, stages] of stagesByIssue) {
+    const cleanup = stages.get('cleanup');
+    if (!cleanup || cleanup.startMs >= cleanup.endMs) {
+      continue;
     }
+    let startMs = cleanup.startMs;
+    for (const window of stages.values()) {
+      if (window.startMs <= cleanup.endMs && window.endMs <= cleanup.endMs) {
+        startMs = Math.min(startMs, window.startMs);
+      }
+    }
+    out.push({ issueNumber, startMs, endMs: cleanup.endMs });
   }
   return out;
 }
@@ -1001,6 +1012,7 @@ export function scanClaudeVendorSessions(
     const fileBasename = basename(file);
     const segments = segmentRecordsByCwd(records);
     const unattributedRecords = [];
+    let anySegmentHadCwdIssueNumber = false;
     segments.forEach((segment, index) => {
       let adapterResult;
       try {
@@ -1026,9 +1038,25 @@ export function scanClaudeVendorSessions(
       });
       if (adapterResult.joinHints?.issueNumber === undefined) {
         unattributedRecords.push(...segment.records);
+      } else {
+        anySegmentHadCwdIssueNumber = true;
       }
     });
-    if (unattributedRecords.length > 0 && completedIssueWindows.length > 0) {
+    // Only fall back to event-window attribution when NO segment in this
+    // file resolved a cwd-inferred issue number. Otherwise a segment
+    // whose cwd merely isn't issue-shaped (an ordinary subdirectory, not
+    // a worktree move) but whose records still happen to fall inside a
+    // DIFFERENT segment's already cwd-attributed issue window would
+    // produce a second, independent issue-loop sample for that same
+    // issue -- splitting one completed loop's usage across two samples
+    // that markAmbiguousOverlaps has no reason to catch (their time
+    // ranges don't overlap; they're just both attributed to the same
+    // issue).
+    if (
+      !anySegmentHadCwdIssueNumber &&
+      unattributedRecords.length > 0 &&
+      completedIssueWindows.length > 0
+    ) {
       const eventWindowGroups = segmentRecordsByEventWindow(
         unattributedRecords,
         completedIssueWindows,

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -34,6 +34,7 @@ import {
 import {
   claudeAdapter,
   defaultClaudeProjectDir,
+  extractRecordTimestampMs,
   parseClaudeProjectLines,
   segmentRecordsByCwd,
 } from './token-cost-adapter-claude.mjs';
@@ -825,6 +826,91 @@ function eventWindowsForIssue(all, issueNumber, vendor) {
   return out;
 }
 /**
+ * Builds one overall window per issue number that has a CLOSED `cleanup`
+ * stage event window (both `--enter` and `--exit` posted) for `vendor`.
+ * The `cleanup` requirement is deliberate: an in-progress issue-loop's
+ * mid-flight harvest would otherwise permanently freeze that issue's
+ * sample at partial usage the first time it is harvested -- the
+ * `#ew<issueNumber>` `vendorSessionId` suffix this fallback produces
+ * (see `token-cost-adapter-claude.mts`) is stable, so `vendorSessionKey`
+ * dedup would silently skip every later, fuller harvest as "already
+ * present." Gating on a closed `cleanup` window matches roadmap #2296's
+ * locked "one *completed* issue-loop" unit, at the cost of never
+ * harvesting an issue whose loop was abandoned before reaching cleanup
+ * (deferred rather than wrong, not a data-loss concern: `events.jsonl`
+ * is append-only, so a later harvest picks it up if cleanup ever runs).
+ */
+export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
+  const byIssue = new Map();
+  for (const [key, window] of eventWindowsAll) {
+    const [issueNumberRaw, keyVendor, stageId] = key.split(':');
+    if (keyVendor !== vendor) {
+      continue;
+    }
+    const issueNumber = Number(issueNumberRaw);
+    if (!Number.isInteger(issueNumber)) {
+      continue;
+    }
+    const existing = byIssue.get(issueNumber);
+    byIssue.set(issueNumber, {
+      startMs: existing
+        ? Math.min(existing.startMs, window.startMs)
+        : window.startMs,
+      endMs: existing ? Math.max(existing.endMs, window.endMs) : window.endMs,
+      hasClosedCleanup:
+        (existing?.hasClosedCleanup ?? false) || stageId === 'cleanup',
+    });
+  }
+  const out = [];
+  for (const [issueNumber, entry] of byIssue) {
+    if (entry.hasClosedCleanup) {
+      out.push({
+        issueNumber,
+        startMs: entry.startMs,
+        endMs: entry.endMs,
+      });
+    }
+  }
+  return out;
+}
+/**
+ * Partitions `records` by which single `CompletedIssueWindow` (if any)
+ * each record's own timestamp falls inside, via `getTimestampMs`. A
+ * record with no valid timestamp, or one whose timestamp falls inside
+ * zero or more than one window, is left out of every group rather than
+ * guessed: concurrent sessions append to one shared, HOME-keyed
+ * `events.jsonl`, so two different issues' windows can genuinely overlap
+ * in wall-clock, and "exactly one match" is the only safe attribution.
+ * Preserves each group's original file-order relative to itself.
+ */
+export function segmentRecordsByEventWindow(
+  records,
+  issueWindows,
+  getTimestampMs,
+) {
+  const groups = new Map();
+  for (const record of records) {
+    const atMs = getTimestampMs(record);
+    if (atMs === undefined) {
+      continue;
+    }
+    const matches = issueWindows.filter(
+      (window) => atMs >= window.startMs && atMs <= window.endMs,
+    );
+    if (matches.length !== 1) {
+      continue;
+    }
+    const issueNumber = matches[0].issueNumber;
+    const group = groups.get(issueNumber);
+    if (group) {
+      group.push(record);
+    } else {
+      groups.set(issueNumber, [record]);
+    }
+  }
+  return groups;
+}
+/**
  * #2404: a long-lived session's project JSONL file is not necessarily one
  * cwd for its whole lifetime -- `segmentRecordsByCwd` (see
  * token-cost-adapter-claude.mts) splits it into contiguous per-cwd runs
@@ -835,12 +921,38 @@ function eventWindowsForIssue(all, issueNumber, vendor) {
  * records (not the whole file's), matching `claudeAdapter.harvest()`'s own
  * per-segment scoping -- otherwise a segment's stage-usage allocation
  * would double-count usage from its sibling segments.
+ *
+ * #2418: #2404 only helps a session whose `cwd` actually varies mid-file.
+ * On a workstation where every session is launched once from the primary
+ * worktree and reaches other worktrees only via in-conversation `cd`
+ * (never a fresh Claude Code launch), `cwd` never varies at all, so
+ * #2404's segmentation is never exercised and #2404 alone still produces
+ * zero issue-loop samples. For a cwd-segment whose OWN cwd-inference
+ * already failed (`joinHints.issueNumber === undefined`), this
+ * additionally partitions that segment's records by event window
+ * (`segmentRecordsByEventWindow`, gated to CLOSED `cleanup` windows only
+ * -- see `buildCompletedIssueWindows`) and calls `claudeAdapter.harvest()`
+ * once more per matched issue, via `issueNumberOverride`. This is
+ * additive, not a replacement: the segment's own plain cwd-only sample
+ * (`kind: 'session'` when cwd-inference fails) is still produced exactly
+ * as before, so nothing already working regresses. `aggregateSnapshot`
+ * (`token-cost-report.mts`) only ever counts `kind: 'issue-loop'` samples
+ * toward the published snapshot, so a `session`-kind sample coexisting
+ * with event-window-derived `issue-loop` samples drawn from the same
+ * underlying records cannot double-count anything published.
  */
-export function scanClaudeVendorSessions(projectDir) {
+export function scanClaudeVendorSessions(
+  projectDir,
+  eventWindowsAll = new Map(),
+) {
   const out = [];
   if (!existsSync(projectDir)) {
     return out;
   }
+  const completedIssueWindows = buildCompletedIssueWindows(
+    eventWindowsAll,
+    'claude',
+  );
   const files = globSync('*.jsonl', { cwd: projectDir, withFileTypes: true })
     .filter((entry) => entry.isFile())
     .map((entry) => join(entry.parentPath, entry.name))
@@ -858,8 +970,9 @@ export function scanClaudeVendorSessions(projectDir) {
     const fileBasename = basename(file);
     const segments = segmentRecordsByCwd(records);
     segments.forEach((segment, index) => {
+      let adapterResult;
       try {
-        const adapterResult = claudeAdapter.harvest({
+        adapterResult = claudeAdapter.harvest({
           records: segment.records,
           fileBasename,
           // Suffix only when the file actually produced more than one
@@ -868,15 +981,44 @@ export function scanClaudeVendorSessions(projectDir) {
           // against samples already harvested before this change.
           segmentIndex: segments.length > 1 ? index : undefined,
         });
-        out.push({
-          vendor: 'claude',
-          adapterResult,
-          timeline: extractClaudeUsageTimeline(segment.records),
-        });
       } catch (error) {
         process.stderr.write(
           `token-cost-harvest: skipping ${file} segment ${index}: ${error.message}\n`,
         );
+        return;
+      }
+      out.push({
+        vendor: 'claude',
+        adapterResult,
+        timeline: extractClaudeUsageTimeline(segment.records),
+      });
+      if (
+        adapterResult.joinHints?.issueNumber === undefined &&
+        completedIssueWindows.length > 0
+      ) {
+        const eventWindowGroups = segmentRecordsByEventWindow(
+          segment.records,
+          completedIssueWindows,
+          extractRecordTimestampMs,
+        );
+        for (const [issueNumber, groupRecords] of eventWindowGroups) {
+          try {
+            const eventWindowResult = claudeAdapter.harvest({
+              records: groupRecords,
+              fileBasename,
+              issueNumberOverride: issueNumber,
+            });
+            out.push({
+              vendor: 'claude',
+              adapterResult: eventWindowResult,
+              timeline: extractClaudeUsageTimeline(groupRecords),
+            });
+          } catch (error) {
+            process.stderr.write(
+              `token-cost-harvest: skipping ${file} segment ${index} event-window issue #${issueNumber}: ${error.message}\n`,
+            );
+          }
+        }
       }
     });
   }
@@ -1110,7 +1252,7 @@ function runCli(argv) {
   );
   const eventWindows = readEventWindows(eventsPath);
   const sessions = [
-    ...scanClaudeVendorSessions(defaultClaudeProjectDir()),
+    ...scanClaudeVendorSessions(defaultClaudeProjectDir(), eventWindows),
     ...scanCodexVendorSessions(defaultCodexSessionsDir()),
     ...scanGrokVendorSessions(defaultGrokSessionsDir()),
   ];

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -826,19 +826,31 @@ function eventWindowsForIssue(all, issueNumber, vendor) {
   return out;
 }
 /**
- * Builds one overall window per issue number that has a CLOSED `cleanup`
- * stage event window (both `--enter` and `--exit` posted) for `vendor`.
- * The `cleanup` requirement is deliberate: an in-progress issue-loop's
- * mid-flight harvest would otherwise permanently freeze that issue's
- * sample at partial usage the first time it is harvested -- the
- * `#ew<issueNumber>` `vendorSessionId` suffix this fallback produces
- * (see `token-cost-adapter-claude.mts`) is stable, so `vendorSessionKey`
- * dedup would silently skip every later, fuller harvest as "already
- * present." Gating on a closed `cleanup` window matches roadmap #2296's
- * locked "one *completed* issue-loop" unit, at the cost of never
- * harvesting an issue whose loop was abandoned before reaching cleanup
- * (deferred rather than wrong, not a data-loss concern: `events.jsonl`
- * is append-only, so a later harvest picks it up if cleanup ever runs).
+ * Builds one overall window per issue number that has a CLOSED, VALID
+ * `cleanup` stage event window (both `--enter` and `--exit` posted, with
+ * `startMs < endMs`) for `vendor`. The `cleanup` requirement is
+ * deliberate: an in-progress issue-loop's mid-flight harvest would
+ * otherwise permanently freeze that issue's sample at partial usage the
+ * first time it is harvested -- the `#ew<issueNumber>` `vendorSessionId`
+ * suffix this fallback produces (see `token-cost-adapter-claude.mts`) is
+ * stable, so `vendorSessionKey` dedup would silently skip every later,
+ * fuller harvest as "already present." Gating on a closed `cleanup`
+ * window matches roadmap #2296's locked "one *completed* issue-loop"
+ * unit, at the cost of never harvesting an issue whose loop was
+ * abandoned before reaching cleanup (deferred rather than wrong, not a
+ * data-loss concern: `events.jsonl` is append-only, so a later harvest
+ * picks it up if cleanup ever runs).
+ *
+ * `startMs < endMs` guards against `readEventWindows`'s own pairing: it
+ * pairs the LATEST `--enter` seen for a (issue, vendor, stage) key with
+ * the LATEST `--exit`, across the whole append-only file, with no
+ * knowledge of which attempt either belongs to. A completed run followed
+ * by a re-attempt that enters `cleanup` again but never exits pairs that
+ * new, still-open enter with the FIRST attempt's stale exit, producing a
+ * reversed window (`startMs > endMs`) -- without this guard, its mere
+ * presence would still count as "closed" and the new, unfinished
+ * attempt's partial usage would be harvested and permanently frozen
+ * under the stable `#ew<issueNumber>` id.
  */
 export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
   const byIssue = new Map();
@@ -858,7 +870,8 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
         : window.startMs,
       endMs: existing ? Math.max(existing.endMs, window.endMs) : window.endMs,
       hasClosedCleanup:
-        (existing?.hasClosedCleanup ?? false) || stageId === 'cleanup',
+        (existing?.hasClosedCleanup ?? false) ||
+        (stageId === 'cleanup' && window.startMs < window.endMs),
     });
   }
   const out = [];
@@ -970,6 +983,11 @@ export function scanClaudeVendorSessions(
     .filter((entry) => entry.isFile())
     .map((entry) => join(entry.parentPath, entry.name))
     .sort();
+  // Event windows carry no file/session identity (issueNumber + vendor
+  // only), so a candidate is collected per FILE here and only actually
+  // harvested after every file has been scanned -- see the cross-file
+  // ambiguity guard below.
+  const eventWindowCandidates = [];
   for (const file of files) {
     let records;
     try {
@@ -1017,23 +1035,54 @@ export function scanClaudeVendorSessions(
         extractRecordTimestampMs,
       );
       for (const [issueNumber, groupRecords] of eventWindowGroups) {
-        try {
-          const eventWindowResult = claudeAdapter.harvest({
-            records: groupRecords,
-            fileBasename,
-            issueNumberOverride: issueNumber,
-          });
-          out.push({
-            vendor: 'claude',
-            adapterResult: eventWindowResult,
-            timeline: extractClaudeUsageTimeline(groupRecords),
-          });
-        } catch (error) {
-          process.stderr.write(
-            `token-cost-harvest: skipping ${file} event-window issue #${issueNumber}: ${error.message}\n`,
-          );
-        }
+        eventWindowCandidates.push({
+          fileBasename,
+          issueNumber,
+          records: groupRecords,
+        });
       }
+    }
+  }
+  // Cross-file ambiguity guard: event windows carry no session identity,
+  // so two DIFFERENT project log files -- e.g. an unrelated concurrent
+  // session whose own unattributed activity happens to fall inside this
+  // issue's completed window purely by wall-clock coincidence -- can both
+  // independently match the same issue. Emitting both would not just
+  // misattribute the stray file's usage; buildSample's markAmbiguousOverlaps
+  // would then also flag the LEGITIMATE sample as ambiguous (outcome:
+  // unknown), discarding the real measurement too. Emitting for NEITHER
+  // file when more than one contributes to the same issue is strictly
+  // safer than emitting a contaminated pair.
+  const fileCountByIssue = new Map();
+  for (const candidate of eventWindowCandidates) {
+    const filesForIssue =
+      fileCountByIssue.get(candidate.issueNumber) ?? new Set();
+    filesForIssue.add(candidate.fileBasename);
+    fileCountByIssue.set(candidate.issueNumber, filesForIssue);
+  }
+  for (const candidate of eventWindowCandidates) {
+    const contributingFiles = fileCountByIssue.get(candidate.issueNumber);
+    if ((contributingFiles?.size ?? 0) > 1) {
+      process.stderr.write(
+        `token-cost-harvest: skipping event-window issue #${candidate.issueNumber}: matched by more than one project log file (${[...(contributingFiles ?? [])].join(', ')})\n`,
+      );
+      continue;
+    }
+    try {
+      const eventWindowResult = claudeAdapter.harvest({
+        records: candidate.records,
+        fileBasename: candidate.fileBasename,
+        issueNumberOverride: candidate.issueNumber,
+      });
+      out.push({
+        vendor: 'claude',
+        adapterResult: eventWindowResult,
+        timeline: extractClaudeUsageTimeline(candidate.records),
+      });
+    } catch (error) {
+      process.stderr.write(
+        `token-cost-harvest: skipping event-window issue #${candidate.issueNumber}: ${error.message}\n`,
+      );
     }
   }
   return out;

--- a/src/scripts/token-cost-adapter-claude.mts
+++ b/src/scripts/token-cost-adapter-claude.mts
@@ -43,6 +43,19 @@
 // records; `claudeAdapter.harvest()` itself is unchanged in shape (still
 // one call in, one `TokenCostAdapterResult` out) and stays exactly as
 // valid for a single-segment (the common, unchanged case) as before.
+//
+// #2418: #2404's cwd-segmentation only helps when a session's `cwd`
+// actually varies mid-file. On a workstation where every session is
+// launched once from the primary worktree and moves between issue
+// worktrees only via in-conversation `cd` (never a fresh Claude Code
+// launch), `cwd` never varies at all, so #2404's fix is never exercised.
+// `ClaudeHarvestInput.issueNumberOverride` lets a caller (the
+// harvester's event-window fallback in `token-cost-harvest.mts`, which
+// this module has no events.jsonl access to implement itself) supply the
+// issue number directly, bypassing cwd-inference for that call. This
+// module stays cwd-only otherwise; `scanClaudeSessions` below never sets
+// `issueNumberOverride` (it has no events.jsonl input to derive one
+// from) and keeps its documented cwd-only contract.
 
 import { globSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
@@ -83,9 +96,22 @@ export interface ClaudeHarvestInput {
    * colliding on the file's own shared `sessionId`. Leave undefined for a
    * whole-file / single-segment harvest: the common case (a file that
    * never changes `cwd`) keeps its pre-existing `vendorSessionId` exactly
-   * as before, with no suffix at all.
+   * as before, with no suffix at all. Ignored when `issueNumberOverride`
+   * is set (mutually exclusive call patterns -- see below).
    */
   segmentIndex?: number;
+  /**
+   * #2418: supplies the issue number directly, bypassing this adapter's
+   * own cwd-based inference, for a caller (the harvester's event-window
+   * fallback) that has already determined `records` belongs to this issue
+   * by correlating their own timestamps against `token-cost-event.mjs`
+   * enter/exit windows rather than any `cwd` field. Takes priority over
+   * cwd-inference when present. Also switches the `vendorSessionId` suffix
+   * scheme to `#ew<issueNumber>` (self-describing, and collision-safe
+   * against the numeric `#<segmentIndex>` scheme above) since these two
+   * fallback paths are never combined on the same harvest() call.
+   */
+  issueNumberOverride?: number;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -200,10 +226,15 @@ function deriveFallbackSessionId(
 function deriveVendorSessionId(
   base: string | undefined,
   segmentIndex: number | undefined,
+  eventWindowIssueNumber: number | undefined,
 ): string | undefined {
-  return base === undefined || segmentIndex === undefined
-    ? base
-    : `${base}#${segmentIndex}`;
+  if (base === undefined) {
+    return undefined;
+  }
+  if (eventWindowIssueNumber !== undefined) {
+    return `${base}#ew${eventWindowIssueNumber}`;
+  }
+  return segmentIndex === undefined ? base : `${base}#${segmentIndex}`;
 }
 
 /** The first non-empty top-level `cwd` across `records`, in file order. */
@@ -280,6 +311,21 @@ function toValidTimestamp(value: unknown): string | undefined {
     return undefined;
   }
   return Number.isFinite(Date.parse(value)) ? value : undefined;
+}
+
+/**
+ * One record's own `timestamp` field, parsed to epoch milliseconds, or
+ * undefined when absent/invalid. Exported for the harvester's
+ * event-window fallback (#2418), which needs each record's own timestamp
+ * independent of any `cwd` field to determine which issue's event window
+ * (if any) that record falls inside.
+ */
+export function extractRecordTimestampMs(record: unknown): number | undefined {
+  if (!isPlainObject(record)) {
+    return undefined;
+  }
+  const valid = toValidTimestamp(record.timestamp);
+  return valid === undefined ? undefined : Date.parse(valid);
 }
 
 /** First and last valid record `timestamp` fields, in file order. Undefined when no record has one. */
@@ -393,17 +439,28 @@ function asClaudeHarvestInput(input: unknown): ClaudeHarvestInput {
     typeof input.fileBasename === 'string' ? input.fileBasename : undefined;
   const segmentIndex =
     typeof input.segmentIndex === 'number' ? input.segmentIndex : undefined;
-  return { records: input.records, fileBasename, segmentIndex };
+  const issueNumberOverride =
+    typeof input.issueNumberOverride === 'number'
+      ? input.issueNumberOverride
+      : undefined;
+  return {
+    records: input.records,
+    fileBasename,
+    segmentIndex,
+    issueNumberOverride,
+  };
 }
 
 /** Claude Code vendor adapter. `input` must satisfy {@link ClaudeHarvestInput}. */
 export const claudeAdapter: TokenCostVendorAdapter = {
   harvest(input: unknown): TokenCostAdapterResult {
-    const { records, fileBasename, segmentIndex } = asClaudeHarvestInput(input);
+    const { records, fileBasename, segmentIndex, issueNumberOverride } =
+      asClaudeHarvestInput(input);
 
     const vendorSessionId = deriveVendorSessionId(
       extractSessionId(records) ?? deriveFallbackSessionId(fileBasename),
       segmentIndex,
+      issueNumberOverride,
     );
     if (!vendorSessionId) {
       throw new Error(
@@ -419,9 +476,9 @@ export const claudeAdapter: TokenCostVendorAdapter = {
     }
 
     const cwd = extractCwd(records);
-    const issueNumber = cwd
-      ? inferIssueNumberFromBasename(basename(cwd))
-      : undefined;
+    const issueNumber =
+      issueNumberOverride ??
+      (cwd ? inferIssueNumberFromBasename(basename(cwd)) : undefined);
 
     const sample: TokenCostSessionSample = {
       schemaVersion: 1,

--- a/src/scripts/token-cost-adapter-claude.mts
+++ b/src/scripts/token-cost-adapter-claude.mts
@@ -321,11 +321,11 @@ function toValidTimestamp(value: unknown): string | undefined {
  * (if any) that record falls inside.
  */
 export function extractRecordTimestampMs(record: unknown): number | undefined {
-  if (!isPlainObject(record)) {
+  if (!isPlainObject(record) || typeof record.timestamp !== 'string') {
     return undefined;
   }
-  const valid = toValidTimestamp(record.timestamp);
-  return valid === undefined ? undefined : Date.parse(valid);
+  const atMs = Date.parse(record.timestamp);
+  return Number.isFinite(atMs) ? atMs : undefined;
 }
 
 /** First and last valid record `timestamp` fields, in file order. Undefined when no record has one. */

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -37,6 +37,7 @@ import {
   type ClaudeHarvestInput,
   claudeAdapter,
   defaultClaudeProjectDir,
+  extractRecordTimestampMs,
   parseClaudeProjectLines,
   segmentRecordsByCwd,
 } from './token-cost-adapter-claude.mts';
@@ -1029,6 +1030,110 @@ function eventWindowsForIssue(
 }
 
 // ---------------------------------------------------------------------------
+// Event-window issue-number fallback (#2418)
+// ---------------------------------------------------------------------------
+
+/** One issue's overall [earliest enter, latest exit] span across every stage it has an event window for, for a single vendor. */
+export interface CompletedIssueWindow {
+  issueNumber: number;
+  startMs: number;
+  endMs: number;
+}
+
+/**
+ * Builds one overall window per issue number that has a CLOSED `cleanup`
+ * stage event window (both `--enter` and `--exit` posted) for `vendor`.
+ * The `cleanup` requirement is deliberate: an in-progress issue-loop's
+ * mid-flight harvest would otherwise permanently freeze that issue's
+ * sample at partial usage the first time it is harvested -- the
+ * `#ew<issueNumber>` `vendorSessionId` suffix this fallback produces
+ * (see `token-cost-adapter-claude.mts`) is stable, so `vendorSessionKey`
+ * dedup would silently skip every later, fuller harvest as "already
+ * present." Gating on a closed `cleanup` window matches roadmap #2296's
+ * locked "one *completed* issue-loop" unit, at the cost of never
+ * harvesting an issue whose loop was abandoned before reaching cleanup
+ * (deferred rather than wrong, not a data-loss concern: `events.jsonl`
+ * is append-only, so a later harvest picks it up if cleanup ever runs).
+ */
+export function buildCompletedIssueWindows(
+  eventWindowsAll: ReadonlyMap<string, StageEventWindow>,
+  vendor: TokenCostVendor,
+): CompletedIssueWindow[] {
+  const byIssue = new Map<
+    number,
+    { startMs: number; endMs: number; hasClosedCleanup: boolean }
+  >();
+  for (const [key, window] of eventWindowsAll) {
+    const [issueNumberRaw, keyVendor, stageId] = key.split(':');
+    if (keyVendor !== vendor) {
+      continue;
+    }
+    const issueNumber = Number(issueNumberRaw);
+    if (!Number.isInteger(issueNumber)) {
+      continue;
+    }
+    const existing = byIssue.get(issueNumber);
+    byIssue.set(issueNumber, {
+      startMs: existing
+        ? Math.min(existing.startMs, window.startMs)
+        : window.startMs,
+      endMs: existing ? Math.max(existing.endMs, window.endMs) : window.endMs,
+      hasClosedCleanup:
+        (existing?.hasClosedCleanup ?? false) || stageId === 'cleanup',
+    });
+  }
+  const out: CompletedIssueWindow[] = [];
+  for (const [issueNumber, entry] of byIssue) {
+    if (entry.hasClosedCleanup) {
+      out.push({
+        issueNumber,
+        startMs: entry.startMs,
+        endMs: entry.endMs,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Partitions `records` by which single `CompletedIssueWindow` (if any)
+ * each record's own timestamp falls inside, via `getTimestampMs`. A
+ * record with no valid timestamp, or one whose timestamp falls inside
+ * zero or more than one window, is left out of every group rather than
+ * guessed: concurrent sessions append to one shared, HOME-keyed
+ * `events.jsonl`, so two different issues' windows can genuinely overlap
+ * in wall-clock, and "exactly one match" is the only safe attribution.
+ * Preserves each group's original file-order relative to itself.
+ */
+export function segmentRecordsByEventWindow(
+  records: readonly unknown[],
+  issueWindows: readonly CompletedIssueWindow[],
+  getTimestampMs: (record: unknown) => number | undefined,
+): Map<number, unknown[]> {
+  const groups = new Map<number, unknown[]>();
+  for (const record of records) {
+    const atMs = getTimestampMs(record);
+    if (atMs === undefined) {
+      continue;
+    }
+    const matches = issueWindows.filter(
+      (window) => atMs >= window.startMs && atMs <= window.endMs,
+    );
+    if (matches.length !== 1) {
+      continue;
+    }
+    const issueNumber = matches[0].issueNumber;
+    const group = groups.get(issueNumber);
+    if (group) {
+      group.push(record);
+    } else {
+      groups.set(issueNumber, [record]);
+    }
+  }
+  return groups;
+}
+
+// ---------------------------------------------------------------------------
 // Vendor scan
 // ---------------------------------------------------------------------------
 
@@ -1049,12 +1154,38 @@ export interface VendorSession {
  * records (not the whole file's), matching `claudeAdapter.harvest()`'s own
  * per-segment scoping -- otherwise a segment's stage-usage allocation
  * would double-count usage from its sibling segments.
+ *
+ * #2418: #2404 only helps a session whose `cwd` actually varies mid-file.
+ * On a workstation where every session is launched once from the primary
+ * worktree and reaches other worktrees only via in-conversation `cd`
+ * (never a fresh Claude Code launch), `cwd` never varies at all, so
+ * #2404's segmentation is never exercised and #2404 alone still produces
+ * zero issue-loop samples. For a cwd-segment whose OWN cwd-inference
+ * already failed (`joinHints.issueNumber === undefined`), this
+ * additionally partitions that segment's records by event window
+ * (`segmentRecordsByEventWindow`, gated to CLOSED `cleanup` windows only
+ * -- see `buildCompletedIssueWindows`) and calls `claudeAdapter.harvest()`
+ * once more per matched issue, via `issueNumberOverride`. This is
+ * additive, not a replacement: the segment's own plain cwd-only sample
+ * (`kind: 'session'` when cwd-inference fails) is still produced exactly
+ * as before, so nothing already working regresses. `aggregateSnapshot`
+ * (`token-cost-report.mts`) only ever counts `kind: 'issue-loop'` samples
+ * toward the published snapshot, so a `session`-kind sample coexisting
+ * with event-window-derived `issue-loop` samples drawn from the same
+ * underlying records cannot double-count anything published.
  */
-export function scanClaudeVendorSessions(projectDir: string): VendorSession[] {
+export function scanClaudeVendorSessions(
+  projectDir: string,
+  eventWindowsAll: ReadonlyMap<string, StageEventWindow> = new Map(),
+): VendorSession[] {
   const out: VendorSession[] = [];
   if (!existsSync(projectDir)) {
     return out;
   }
+  const completedIssueWindows = buildCompletedIssueWindows(
+    eventWindowsAll,
+    'claude',
+  );
   const files = globSync('*.jsonl', { cwd: projectDir, withFileTypes: true })
     .filter((entry) => entry.isFile())
     .map((entry) => join(entry.parentPath, entry.name))
@@ -1072,8 +1203,9 @@ export function scanClaudeVendorSessions(projectDir: string): VendorSession[] {
     const fileBasename = basename(file);
     const segments = segmentRecordsByCwd(records);
     segments.forEach((segment, index) => {
+      let adapterResult: TokenCostAdapterResult;
       try {
-        const adapterResult = claudeAdapter.harvest({
+        adapterResult = claudeAdapter.harvest({
           records: segment.records,
           fileBasename,
           // Suffix only when the file actually produced more than one
@@ -1082,15 +1214,45 @@ export function scanClaudeVendorSessions(projectDir: string): VendorSession[] {
           // against samples already harvested before this change.
           segmentIndex: segments.length > 1 ? index : undefined,
         } satisfies ClaudeHarvestInput);
-        out.push({
-          vendor: 'claude',
-          adapterResult,
-          timeline: extractClaudeUsageTimeline(segment.records),
-        });
       } catch (error) {
         process.stderr.write(
           `token-cost-harvest: skipping ${file} segment ${index}: ${(error as Error).message}\n`,
         );
+        return;
+      }
+      out.push({
+        vendor: 'claude',
+        adapterResult,
+        timeline: extractClaudeUsageTimeline(segment.records),
+      });
+
+      if (
+        adapterResult.joinHints?.issueNumber === undefined &&
+        completedIssueWindows.length > 0
+      ) {
+        const eventWindowGroups = segmentRecordsByEventWindow(
+          segment.records,
+          completedIssueWindows,
+          extractRecordTimestampMs,
+        );
+        for (const [issueNumber, groupRecords] of eventWindowGroups) {
+          try {
+            const eventWindowResult = claudeAdapter.harvest({
+              records: groupRecords,
+              fileBasename,
+              issueNumberOverride: issueNumber,
+            } satisfies ClaudeHarvestInput);
+            out.push({
+              vendor: 'claude',
+              adapterResult: eventWindowResult,
+              timeline: extractClaudeUsageTimeline(groupRecords),
+            });
+          } catch (error) {
+            process.stderr.write(
+              `token-cost-harvest: skipping ${file} segment ${index} event-window issue #${issueNumber}: ${(error as Error).message}\n`,
+            );
+          }
+        }
       }
     });
   }
@@ -1352,7 +1514,7 @@ function runCli(argv: string[]): void {
   const eventWindows = readEventWindows(eventsPath);
 
   const sessions: VendorSession[] = [
-    ...scanClaudeVendorSessions(defaultClaudeProjectDir()),
+    ...scanClaudeVendorSessions(defaultClaudeProjectDir(), eventWindows),
     ...scanCodexVendorSessions(defaultCodexSessionsDir()),
     ...scanGrokVendorSessions(defaultGrokSessionsDir()),
   ];

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1080,6 +1080,29 @@ export interface CompletedIssueWindow {
  *   folded into the union and permanently frozen under the stable
  *   `#ew<issueNumber>` id as if the (unfinished) retry were the
  *   completed loop.
+ * - A later attempt whose own `--enter` (or `--exit`) call for some
+ *   non-`cleanup` stage silently fails (`token-cost-event.mjs` is
+ *   deliberately fail-open) can leave that stage's pairing mixing one
+ *   attempt's enter with an EARLIER, unrelated attempt's exit, which
+ *   `readEventWindows` reports as reversed (`startMs > endMs`) once the
+ *   later attempt's own timestamp is newer than the stale one it paired
+ *   with. Excluding such a window from the union (as `startMs < endMs`
+ *   already does above) is not enough on its own: `startMs` still
+ *   silently degrades to the stable `cleanup`-only window instead of
+ *   surfacing the contamination. A reversed non-`cleanup` stage window
+ *   whose own `startMs` falls at or before the completed run's own
+ *   `cleanup.endMs` is treated as direct evidence that this issue's
+ *   event history is corrupted for THIS harvest, so the whole issue is
+ *   skipped rather than emitted with a silently narrowed window (no
+ *   sample beats a wrong one). A reversed window entirely past
+ *   `cleanup.endMs` is ordinary mid-retry noise from a later, distinct
+ *   attempt and does not block emission of the already-completed window.
+ *   The remaining case -- a stage whose stale, EARLIER-attempt pairing
+ *   happens to still be internally valid (non-reversed), e.g. because
+ *   BOTH of the later attempt's own enter/exit calls for that stage
+ *   failed -- is mechanically indistinguishable from a genuine early
+ *   start without an attempt/session identity on `TokenCostEvent`
+ *   itself; tracked as a follow-up (#2424) rather than solved here.
  */
 export function buildCompletedIssueWindows(
   eventWindowsAll: ReadonlyMap<string, StageEventWindow>,
@@ -1103,6 +1126,15 @@ export function buildCompletedIssueWindows(
   for (const [issueNumber, stages] of stagesByIssue) {
     const cleanup = stages.get('cleanup');
     if (!cleanup || cleanup.startMs >= cleanup.endMs) {
+      continue;
+    }
+    const hasContaminatedStage = [...stages].some(
+      ([stageId, window]) =>
+        stageId !== 'cleanup' &&
+        window.startMs >= window.endMs &&
+        window.startMs <= cleanup.endMs,
+    );
+    if (hasContaminatedStage) {
       continue;
     }
     let startMs = cleanup.startMs;

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1103,6 +1103,10 @@ export function buildCompletedIssueWindows(
  * guessed: concurrent sessions append to one shared, HOME-keyed
  * `events.jsonl`, so two different issues' windows can genuinely overlap
  * in wall-clock, and "exactly one match" is the only safe attribution.
+ * Windows are half-open (`[startMs, endMs)`, matching `computeStageWindows`'s
+ * own convention) so a record at the exact instant one issue's window ends
+ * and an adjacent issue's window begins matches only the later window,
+ * rather than being wrongly treated as ambiguous between the two.
  * Preserves each group's original file-order relative to itself.
  */
 export function segmentRecordsByEventWindow(
@@ -1117,7 +1121,7 @@ export function segmentRecordsByEventWindow(
       continue;
     }
     const matches = issueWindows.filter(
-      (window) => atMs >= window.startMs && atMs <= window.endMs,
+      (window) => atMs >= window.startMs && atMs < window.endMs,
     );
     if (matches.length !== 1) {
       continue;
@@ -1160,19 +1164,28 @@ export interface VendorSession {
  * worktree and reaches other worktrees only via in-conversation `cd`
  * (never a fresh Claude Code launch), `cwd` never varies at all, so
  * #2404's segmentation is never exercised and #2404 alone still produces
- * zero issue-loop samples. For a cwd-segment whose OWN cwd-inference
- * already failed (`joinHints.issueNumber === undefined`), this
- * additionally partitions that segment's records by event window
+ * zero issue-loop samples. This additionally partitions by event window
  * (`segmentRecordsByEventWindow`, gated to CLOSED `cleanup` windows only
  * -- see `buildCompletedIssueWindows`) and calls `claudeAdapter.harvest()`
  * once more per matched issue, via `issueNumberOverride`. This is
- * additive, not a replacement: the segment's own plain cwd-only sample
- * (`kind: 'session'` when cwd-inference fails) is still produced exactly
- * as before, so nothing already working regresses. `aggregateSnapshot`
- * (`token-cost-report.mts`) only ever counts `kind: 'issue-loop'` samples
- * toward the published snapshot, so a `session`-kind sample coexisting
- * with event-window-derived `issue-loop` samples drawn from the same
- * underlying records cannot double-count anything published.
+ * additive, not a replacement: every cwd-segment's own plain cwd-only
+ * sample (`kind: 'session'` when cwd-inference fails) is still produced
+ * exactly as before, so nothing already working regresses.
+ * `aggregateSnapshot` (`token-cost-report.mts`) only ever counts
+ * `kind: 'issue-loop'` samples toward the published snapshot, so a
+ * `session`-kind sample coexisting with event-window-derived
+ * `issue-loop` samples drawn from the same underlying records cannot
+ * double-count anything published.
+ *
+ * Event-window partitioning runs ONCE per FILE, across every cwd-segment
+ * whose own cwd-inference failed, not once per segment. A file whose
+ * `cwd` changes to some non-`issue/<n>-*` value more than once (any
+ * ordinary directory switch, not just a worktree move) would otherwise
+ * split those records across separate cwd-segments; partitioning
+ * per-segment would independently re-derive the SAME `#ew<issueNumber>`
+ * suffix from more than one segment and push a duplicate-keyed
+ * `VendorSession` within a single harvest run, which the append-side
+ * dedup (keyed only against samples from PRIOR runs) cannot catch.
  */
 export function scanClaudeVendorSessions(
   projectDir: string,
@@ -1202,6 +1215,7 @@ export function scanClaudeVendorSessions(
     }
     const fileBasename = basename(file);
     const segments = segmentRecordsByCwd(records);
+    const unattributedRecords: unknown[] = [];
     segments.forEach((segment, index) => {
       let adapterResult: TokenCostAdapterResult;
       try {
@@ -1225,36 +1239,36 @@ export function scanClaudeVendorSessions(
         adapterResult,
         timeline: extractClaudeUsageTimeline(segment.records),
       });
-
-      if (
-        adapterResult.joinHints?.issueNumber === undefined &&
-        completedIssueWindows.length > 0
-      ) {
-        const eventWindowGroups = segmentRecordsByEventWindow(
-          segment.records,
-          completedIssueWindows,
-          extractRecordTimestampMs,
-        );
-        for (const [issueNumber, groupRecords] of eventWindowGroups) {
-          try {
-            const eventWindowResult = claudeAdapter.harvest({
-              records: groupRecords,
-              fileBasename,
-              issueNumberOverride: issueNumber,
-            } satisfies ClaudeHarvestInput);
-            out.push({
-              vendor: 'claude',
-              adapterResult: eventWindowResult,
-              timeline: extractClaudeUsageTimeline(groupRecords),
-            });
-          } catch (error) {
-            process.stderr.write(
-              `token-cost-harvest: skipping ${file} segment ${index} event-window issue #${issueNumber}: ${(error as Error).message}\n`,
-            );
-          }
-        }
+      if (adapterResult.joinHints?.issueNumber === undefined) {
+        unattributedRecords.push(...segment.records);
       }
     });
+
+    if (unattributedRecords.length > 0 && completedIssueWindows.length > 0) {
+      const eventWindowGroups = segmentRecordsByEventWindow(
+        unattributedRecords,
+        completedIssueWindows,
+        extractRecordTimestampMs,
+      );
+      for (const [issueNumber, groupRecords] of eventWindowGroups) {
+        try {
+          const eventWindowResult = claudeAdapter.harvest({
+            records: groupRecords,
+            fileBasename,
+            issueNumberOverride: issueNumber,
+          } satisfies ClaudeHarvestInput);
+          out.push({
+            vendor: 'claude',
+            adapterResult: eventWindowResult,
+            timeline: extractClaudeUsageTimeline(groupRecords),
+          });
+        } catch (error) {
+          process.stderr.write(
+            `token-cost-harvest: skipping ${file} event-window issue #${issueNumber}: ${(error as Error).message}\n`,
+          );
+        }
+      }
+    }
   }
   return out;
 }

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1041,19 +1041,31 @@ export interface CompletedIssueWindow {
 }
 
 /**
- * Builds one overall window per issue number that has a CLOSED `cleanup`
- * stage event window (both `--enter` and `--exit` posted) for `vendor`.
- * The `cleanup` requirement is deliberate: an in-progress issue-loop's
- * mid-flight harvest would otherwise permanently freeze that issue's
- * sample at partial usage the first time it is harvested -- the
- * `#ew<issueNumber>` `vendorSessionId` suffix this fallback produces
- * (see `token-cost-adapter-claude.mts`) is stable, so `vendorSessionKey`
- * dedup would silently skip every later, fuller harvest as "already
- * present." Gating on a closed `cleanup` window matches roadmap #2296's
- * locked "one *completed* issue-loop" unit, at the cost of never
- * harvesting an issue whose loop was abandoned before reaching cleanup
- * (deferred rather than wrong, not a data-loss concern: `events.jsonl`
- * is append-only, so a later harvest picks it up if cleanup ever runs).
+ * Builds one overall window per issue number that has a CLOSED, VALID
+ * `cleanup` stage event window (both `--enter` and `--exit` posted, with
+ * `startMs < endMs`) for `vendor`. The `cleanup` requirement is
+ * deliberate: an in-progress issue-loop's mid-flight harvest would
+ * otherwise permanently freeze that issue's sample at partial usage the
+ * first time it is harvested -- the `#ew<issueNumber>` `vendorSessionId`
+ * suffix this fallback produces (see `token-cost-adapter-claude.mts`) is
+ * stable, so `vendorSessionKey` dedup would silently skip every later,
+ * fuller harvest as "already present." Gating on a closed `cleanup`
+ * window matches roadmap #2296's locked "one *completed* issue-loop"
+ * unit, at the cost of never harvesting an issue whose loop was
+ * abandoned before reaching cleanup (deferred rather than wrong, not a
+ * data-loss concern: `events.jsonl` is append-only, so a later harvest
+ * picks it up if cleanup ever runs).
+ *
+ * `startMs < endMs` guards against `readEventWindows`'s own pairing: it
+ * pairs the LATEST `--enter` seen for a (issue, vendor, stage) key with
+ * the LATEST `--exit`, across the whole append-only file, with no
+ * knowledge of which attempt either belongs to. A completed run followed
+ * by a re-attempt that enters `cleanup` again but never exits pairs that
+ * new, still-open enter with the FIRST attempt's stale exit, producing a
+ * reversed window (`startMs > endMs`) -- without this guard, its mere
+ * presence would still count as "closed" and the new, unfinished
+ * attempt's partial usage would be harvested and permanently frozen
+ * under the stable `#ew<issueNumber>` id.
  */
 export function buildCompletedIssueWindows(
   eventWindowsAll: ReadonlyMap<string, StageEventWindow>,
@@ -1079,7 +1091,8 @@ export function buildCompletedIssueWindows(
         : window.startMs,
       endMs: existing ? Math.max(existing.endMs, window.endMs) : window.endMs,
       hasClosedCleanup:
-        (existing?.hasClosedCleanup ?? false) || stageId === 'cleanup',
+        (existing?.hasClosedCleanup ?? false) ||
+        (stageId === 'cleanup' && window.startMs < window.endMs),
     });
   }
   const out: CompletedIssueWindow[] = [];
@@ -1203,6 +1216,15 @@ export function scanClaudeVendorSessions(
     .filter((entry) => entry.isFile())
     .map((entry) => join(entry.parentPath, entry.name))
     .sort();
+  // Event windows carry no file/session identity (issueNumber + vendor
+  // only), so a candidate is collected per FILE here and only actually
+  // harvested after every file has been scanned -- see the cross-file
+  // ambiguity guard below.
+  const eventWindowCandidates: {
+    fileBasename: string;
+    issueNumber: number;
+    records: unknown[];
+  }[] = [];
   for (const file of files) {
     let records: unknown[];
     try {
@@ -1251,23 +1273,55 @@ export function scanClaudeVendorSessions(
         extractRecordTimestampMs,
       );
       for (const [issueNumber, groupRecords] of eventWindowGroups) {
-        try {
-          const eventWindowResult = claudeAdapter.harvest({
-            records: groupRecords,
-            fileBasename,
-            issueNumberOverride: issueNumber,
-          } satisfies ClaudeHarvestInput);
-          out.push({
-            vendor: 'claude',
-            adapterResult: eventWindowResult,
-            timeline: extractClaudeUsageTimeline(groupRecords),
-          });
-        } catch (error) {
-          process.stderr.write(
-            `token-cost-harvest: skipping ${file} event-window issue #${issueNumber}: ${(error as Error).message}\n`,
-          );
-        }
+        eventWindowCandidates.push({
+          fileBasename,
+          issueNumber,
+          records: groupRecords,
+        });
       }
+    }
+  }
+
+  // Cross-file ambiguity guard: event windows carry no session identity,
+  // so two DIFFERENT project log files -- e.g. an unrelated concurrent
+  // session whose own unattributed activity happens to fall inside this
+  // issue's completed window purely by wall-clock coincidence -- can both
+  // independently match the same issue. Emitting both would not just
+  // misattribute the stray file's usage; buildSample's markAmbiguousOverlaps
+  // would then also flag the LEGITIMATE sample as ambiguous (outcome:
+  // unknown), discarding the real measurement too. Emitting for NEITHER
+  // file when more than one contributes to the same issue is strictly
+  // safer than emitting a contaminated pair.
+  const fileCountByIssue = new Map<number, Set<string>>();
+  for (const candidate of eventWindowCandidates) {
+    const filesForIssue =
+      fileCountByIssue.get(candidate.issueNumber) ?? new Set();
+    filesForIssue.add(candidate.fileBasename);
+    fileCountByIssue.set(candidate.issueNumber, filesForIssue);
+  }
+  for (const candidate of eventWindowCandidates) {
+    const contributingFiles = fileCountByIssue.get(candidate.issueNumber);
+    if ((contributingFiles?.size ?? 0) > 1) {
+      process.stderr.write(
+        `token-cost-harvest: skipping event-window issue #${candidate.issueNumber}: matched by more than one project log file (${[...(contributingFiles ?? [])].join(', ')})\n`,
+      );
+      continue;
+    }
+    try {
+      const eventWindowResult = claudeAdapter.harvest({
+        records: candidate.records,
+        fileBasename: candidate.fileBasename,
+        issueNumberOverride: candidate.issueNumber,
+      } satisfies ClaudeHarvestInput);
+      out.push({
+        vendor: 'claude',
+        adapterResult: eventWindowResult,
+        timeline: extractClaudeUsageTimeline(candidate.records),
+      });
+    } catch (error) {
+      process.stderr.write(
+        `token-cost-harvest: skipping event-window issue #${candidate.issueNumber}: ${(error as Error).message}\n`,
+      );
     }
   }
   return out;

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1056,25 +1056,36 @@ export interface CompletedIssueWindow {
  * data-loss concern: `events.jsonl` is append-only, so a later harvest
  * picks it up if cleanup ever runs).
  *
- * `startMs < endMs` guards against `readEventWindows`'s own pairing: it
- * pairs the LATEST `--enter` seen for a (issue, vendor, stage) key with
- * the LATEST `--exit`, across the whole append-only file, with no
- * knowledge of which attempt either belongs to. A completed run followed
- * by a re-attempt that enters `cleanup` again but never exits pairs that
- * new, still-open enter with the FIRST attempt's stale exit, producing a
- * reversed window (`startMs > endMs`) -- without this guard, its mere
- * presence would still count as "closed" and the new, unfinished
- * attempt's partial usage would be harvested and permanently frozen
- * under the stable `#ew<issueNumber>` id.
+ * The window's `endMs` is ALWAYS the valid cleanup window's own `endMs`
+ * -- never a max across every stage -- and a stage only widens `startMs`
+ * when its OWN window (both ends) falls at or before that cleanup exit.
+ * This guards against `readEventWindows`'s own pairing: it pairs the
+ * LATEST `--enter` seen for a (issue, vendor, stage) key with the LATEST
+ * `--exit`, across the whole append-only file, with no knowledge of
+ * which attempt either belongs to.
+ *
+ * - A completed run followed by a re-attempt that enters `cleanup` again
+ *   but never exits pairs that new, still-open enter with the FIRST
+ *   attempt's stale exit, producing a reversed window (`startMs >
+ *   endMs`) -- `startMs < endMs` rejects this outright, so the mere
+ *   presence of a `cleanup` key is never enough on its own.
+ * - A completed run followed by a re-attempt that has NOT yet re-entered
+ *   `cleanup` at all leaves the original, still-valid cleanup pair
+ *   untouched, but the re-attempt's OTHER stage events (e.g. a fresh
+ *   `work` enter/exit) land in `eventWindowsAll` too, with timestamps
+ *   AFTER the original cleanup's own exit. Capping `endMs` at cleanup's
+ *   own exit, and excluding any stage window that extends past it from
+ *   widening `startMs`, keeps that later, still-in-progress activity out
+ *   of the completed window -- without this, its partial usage would be
+ *   folded into the union and permanently frozen under the stable
+ *   `#ew<issueNumber>` id as if the (unfinished) retry were the
+ *   completed loop.
  */
 export function buildCompletedIssueWindows(
   eventWindowsAll: ReadonlyMap<string, StageEventWindow>,
   vendor: TokenCostVendor,
 ): CompletedIssueWindow[] {
-  const byIssue = new Map<
-    number,
-    { startMs: number; endMs: number; hasClosedCleanup: boolean }
-  >();
+  const stagesByIssue = new Map<number, Map<string, StageEventWindow>>();
   for (const [key, window] of eventWindowsAll) {
     const [issueNumberRaw, keyVendor, stageId] = key.split(':');
     if (keyVendor !== vendor) {
@@ -1084,26 +1095,23 @@ export function buildCompletedIssueWindows(
     if (!Number.isInteger(issueNumber)) {
       continue;
     }
-    const existing = byIssue.get(issueNumber);
-    byIssue.set(issueNumber, {
-      startMs: existing
-        ? Math.min(existing.startMs, window.startMs)
-        : window.startMs,
-      endMs: existing ? Math.max(existing.endMs, window.endMs) : window.endMs,
-      hasClosedCleanup:
-        (existing?.hasClosedCleanup ?? false) ||
-        (stageId === 'cleanup' && window.startMs < window.endMs),
-    });
+    const stages = stagesByIssue.get(issueNumber) ?? new Map();
+    stages.set(stageId, window);
+    stagesByIssue.set(issueNumber, stages);
   }
   const out: CompletedIssueWindow[] = [];
-  for (const [issueNumber, entry] of byIssue) {
-    if (entry.hasClosedCleanup) {
-      out.push({
-        issueNumber,
-        startMs: entry.startMs,
-        endMs: entry.endMs,
-      });
+  for (const [issueNumber, stages] of stagesByIssue) {
+    const cleanup = stages.get('cleanup');
+    if (!cleanup || cleanup.startMs >= cleanup.endMs) {
+      continue;
     }
+    let startMs = cleanup.startMs;
+    for (const window of stages.values()) {
+      if (window.startMs <= cleanup.endMs && window.endMs <= cleanup.endMs) {
+        startMs = Math.min(startMs, window.startMs);
+      }
+    }
+    out.push({ issueNumber, startMs, endMs: cleanup.endMs });
   }
   return out;
 }
@@ -1238,6 +1246,7 @@ export function scanClaudeVendorSessions(
     const fileBasename = basename(file);
     const segments = segmentRecordsByCwd(records);
     const unattributedRecords: unknown[] = [];
+    let anySegmentHadCwdIssueNumber = false;
     segments.forEach((segment, index) => {
       let adapterResult: TokenCostAdapterResult;
       try {
@@ -1263,10 +1272,26 @@ export function scanClaudeVendorSessions(
       });
       if (adapterResult.joinHints?.issueNumber === undefined) {
         unattributedRecords.push(...segment.records);
+      } else {
+        anySegmentHadCwdIssueNumber = true;
       }
     });
 
-    if (unattributedRecords.length > 0 && completedIssueWindows.length > 0) {
+    // Only fall back to event-window attribution when NO segment in this
+    // file resolved a cwd-inferred issue number. Otherwise a segment
+    // whose cwd merely isn't issue-shaped (an ordinary subdirectory, not
+    // a worktree move) but whose records still happen to fall inside a
+    // DIFFERENT segment's already cwd-attributed issue window would
+    // produce a second, independent issue-loop sample for that same
+    // issue -- splitting one completed loop's usage across two samples
+    // that markAmbiguousOverlaps has no reason to catch (their time
+    // ranges don't overlap; they're just both attributed to the same
+    // issue).
+    if (
+      !anySegmentHadCwdIssueNumber &&
+      unattributedRecords.length > 0 &&
+      completedIssueWindows.length > 0
+    ) {
       const eventWindowGroups = segmentRecordsByEventWindow(
         unattributedRecords,
         completedIssueWindows,

--- a/tests/token-cost-adapter-claude.test.mts
+++ b/tests/token-cost-adapter-claude.test.mts
@@ -9,6 +9,7 @@ import {
   defaultClaudeProjectDir,
   defaultClaudeProjectsRoot,
   encodeClaudeProjectDirName,
+  extractRecordTimestampMs,
   parseClaudeProjectLines,
   scanClaudeSessions,
   segmentRecordsByCwd,
@@ -113,6 +114,105 @@ test('a worktree cwd with an issue number yields joinHints.issueNumber, never a 
   assert.doesNotMatch(JSON.stringify(sample), /ghq|\/home\/|issue\/4242/);
 });
 
+test('issueNumberOverride supplies joinHints.issueNumber even when cwd-inference would fail -- #2418', () => {
+  const { sample, joinHints } = claudeAdapter.harvest({
+    records: [
+      {
+        type: 'assistant',
+        timestamp: '2026-01-01T00:00:00Z',
+        sessionId: 'sess-ew-0001',
+        cwd: '/repo',
+        message: {
+          model: 'm',
+          usage: {
+            input_tokens: 1,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            output_tokens: 1,
+          },
+        },
+      },
+    ],
+    issueNumberOverride: 501,
+  });
+  assert.deepEqual(joinHints, { issueNumber: 501 });
+  assert.equal(sample.vendorSessionId, 'sess-ew-0001#ew501');
+});
+
+test('issueNumberOverride takes priority over a real cwd-inferable issue number', () => {
+  const { joinHints, sample } = claudeAdapter.harvest({
+    records: [
+      {
+        type: 'assistant',
+        timestamp: '2026-01-01T00:00:00Z',
+        sessionId: 'sess-ew-0002',
+        cwd: '/repo.issue-4242-x',
+        message: {
+          model: 'm',
+          usage: {
+            input_tokens: 1,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            output_tokens: 1,
+          },
+        },
+      },
+    ],
+    issueNumberOverride: 999,
+  });
+  assert.deepEqual(joinHints, { issueNumber: 999 });
+  assert.equal(sample.vendorSessionId, 'sess-ew-0002#ew999');
+});
+
+test('segmentIndex is ignored (not appended) when issueNumberOverride is also present', () => {
+  const { sample } = claudeAdapter.harvest({
+    records: [
+      {
+        type: 'assistant',
+        timestamp: '2026-01-01T00:00:00Z',
+        sessionId: 'sess-ew-0003',
+        cwd: '/repo',
+        message: {
+          model: 'm',
+          usage: {
+            input_tokens: 1,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            output_tokens: 1,
+          },
+        },
+      },
+    ],
+    segmentIndex: 7,
+    issueNumberOverride: 501,
+  });
+  assert.equal(sample.vendorSessionId, 'sess-ew-0003#ew501');
+});
+
+test('no issueNumberOverride and no cwd: behavior is unchanged from before #2418', () => {
+  const { joinHints, sample } = claudeAdapter.harvest({
+    records: [
+      {
+        type: 'assistant',
+        timestamp: '2026-01-01T00:00:00Z',
+        sessionId: 'sess-plain-0001',
+        cwd: '/repo',
+        message: {
+          model: 'm',
+          usage: {
+            input_tokens: 1,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            output_tokens: 1,
+          },
+        },
+      },
+    ],
+  });
+  assert.equal(joinHints, undefined);
+  assert.equal(sample.vendorSessionId, 'sess-plain-0001');
+});
+
 test('adapter output never carries a leaked secret, prompt text, or absolute path from raw records', () => {
   const { sample } = harvestFixture('session-sensitive-fields.jsonl');
   const serialized = JSON.stringify(sample);
@@ -194,6 +294,24 @@ test('scanClaudeSessions on an empty directory returns no results', () => {
   );
   mkdirSync(sandbox, { recursive: true });
   assert.deepEqual(scanClaudeSessions({ projectDir: sandbox }), []);
+});
+
+test("extractRecordTimestampMs: reads a record's own valid timestamp -- #2418", () => {
+  assert.equal(
+    extractRecordTimestampMs({ timestamp: '2026-01-01T00:00:00Z' }),
+    Date.parse('2026-01-01T00:00:00Z'),
+  );
+});
+
+test('extractRecordTimestampMs: undefined for a missing, malformed, or non-string timestamp', () => {
+  assert.equal(extractRecordTimestampMs({}), undefined);
+  assert.equal(
+    extractRecordTimestampMs({ timestamp: 'not-a-date' }),
+    undefined,
+  );
+  assert.equal(extractRecordTimestampMs({ timestamp: 12345 }), undefined);
+  assert.equal(extractRecordTimestampMs('not an object'), undefined);
+  assert.equal(extractRecordTimestampMs(null), undefined);
 });
 
 test('harvest rejects an input that is not { records: unknown[] }', () => {

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -494,6 +494,86 @@ test('scanClaudeVendorSessions: an OPEN event window (no cleanup exit yet) never
   assert.equal(sessions[0].adapterResult.joinHints, undefined);
 });
 
+test("buildCompletedIssueWindows: a REVERSED cleanup window (a re-attempt's enter paired with a stale earlier exit) is not treated as closed (Codex review finding, #2423)", () => {
+  const all = new Map<string, StageEventWindow>([
+    // A completed first attempt's cleanup enter/exit...
+    // ...then a second attempt re-enters cleanup later than the first
+    // attempt's own exit. readEventWindows pairs the LATEST enter with
+    // the LATEST exit regardless of attempt, producing a reversed
+    // window here (startMs > endMs).
+    [
+      '501:claude:cleanup',
+      {
+        startMs: ms('2026-01-01T02:00:00Z'),
+        endMs: ms('2026-01-01T01:00:00Z'),
+      },
+    ],
+  ]);
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.deepEqual(windows, []);
+});
+
+test('scanClaudeVendorSessions: a reversed cleanup window never produces an event-window sample', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-ew-reversed.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T01:30:00.000Z","sessionId":"sess-ew-reversed-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}\n',
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '501:claude:cleanup',
+      {
+        startMs: ms('2026-01-01T02:00:00Z'),
+        endMs: ms('2026-01-01T01:00:00Z'),
+      },
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+
+  assert.equal(sessions.length, 1);
+  assert.equal(sessions[0].adapterResult.joinHints, undefined);
+});
+
+test('scanClaudeVendorSessions: two DIFFERENT project log files both matching the same issue window are BOTH dropped (cross-file ambiguity guard, Codex review finding, #2423)', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-ew-fileA.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:20:00.000Z","sessionId":"sess-ew-fileA-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}\n',
+  );
+  writeFileSync(
+    join(sandbox, 'session-ew-fileB.jsonl'),
+    // An unrelated concurrent session whose own unattributed activity
+    // happens to fall inside the SAME wall-clock window purely by
+    // coincidence.
+    '{"type":"assistant","timestamp":"2026-01-01T00:21:00.000Z","sessionId":"sess-ew-fileB-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":5,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":5}}}\n',
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow('2026-01-01T00:10:00Z', '2026-01-01T00:25:00Z'),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow('2026-01-01T00:26:00Z', '2026-01-01T00:30:00Z'),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew'),
+  );
+
+  // Neither file's activity is attributed to issue 501 -- emitting one
+  // (or both) would risk crediting an unrelated session's usage to this
+  // issue, and would also make markAmbiguousOverlaps flag any genuine
+  // future sample as ambiguous too. Both files' own plain base samples
+  // are still produced normally.
+  assert.equal(ewSamples.length, 0);
+  assert.equal(sessions.length, 2);
+  assert.ok(sessions.every((s) => s.adapterResult.joinHints === undefined));
+});
+
 test('scanClaudeVendorSessions: an event window is ignored when the segment already has a cwd-inferred issueNumber', () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
   writeFileSync(

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -571,6 +571,51 @@ test('buildCompletedIssueWindows: a valid, closed cleanup pair caps the window e
   assert.equal(windows[0].startMs, ms('2026-01-01T00:55:00Z'));
 });
 
+test('buildCompletedIssueWindows: a reversed non-cleanup stage window overlapping the completed run is treated as contamination, not silently narrowed (Codex review finding round 3, #2423)', () => {
+  // A later attempt's OWN `work` enter posts (00:58), but its `work` exit
+  // fails to post (token-cost-event.mjs is deliberately fail-open) --
+  // readEventWindows still pairs that enter with an EARLIER, unrelated
+  // attempt's stale exit (00:30), producing a reversed window whose own
+  // startMs falls at or before this run's cleanup.endMs. That is direct
+  // evidence the issue's event history is corrupted for this harvest, so
+  // the whole issue must be skipped rather than emitted with a
+  // cleanup-only window that silently hides the contamination.
+  const all = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow('2026-01-01T00:58:00Z', '2026-01-01T00:30:00Z'),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow('2026-01-01T00:55:00Z', '2026-01-01T01:00:00Z'),
+    ],
+  ]);
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.deepEqual(windows, []);
+});
+
+test('buildCompletedIssueWindows: a reversed non-cleanup stage window entirely PAST the completed run is ordinary retry noise, not contamination (Codex review finding round 3, #2423)', () => {
+  // Same reversed-pairing shape as above, but this time both ends of the
+  // reversed window fall AFTER the completed run's own cleanup.endMs --
+  // ordinary mid-retry noise from a later, distinct attempt that has not
+  // yet reached its own valid cleanup. It must not block emission of the
+  // already-completed window.
+  const all = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow('2026-01-01T02:00:00Z', '2026-01-01T01:30:00Z'),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow('2026-01-01T00:55:00Z', '2026-01-01T01:00:00Z'),
+    ],
+  ]);
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.equal(windows.length, 1);
+  assert.equal(windows[0].startMs, ms('2026-01-01T00:55:00Z'));
+  assert.equal(windows[0].endMs, ms('2026-01-01T01:00:00Z'));
+});
+
 test("scanClaudeVendorSessions: a completed cleanup window does not absorb a later retry's activity", () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
   writeFileSync(

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -310,6 +310,30 @@ test('segmentRecordsByEventWindow: drops a record matching MORE than one window 
   assert.equal(groups.size, 0);
 });
 
+test('segmentRecordsByEventWindow: a record at the exact instant one window ends and an adjacent one begins matches only the later window (half-open interval, Copilot review finding, #2423)', () => {
+  const windows: CompletedIssueWindow[] = [
+    {
+      issueNumber: 501,
+      startMs: ms('2026-01-01T00:00:00Z'),
+      endMs: ms('2026-01-01T01:00:00Z'),
+    },
+    {
+      issueNumber: 502,
+      startMs: ms('2026-01-01T01:00:00Z'),
+      endMs: ms('2026-01-01T02:00:00Z'),
+    },
+  ];
+  const records = [{ id: 'boundary', timestamp: '2026-01-01T01:00:00Z' }];
+  const groups = segmentRecordsByEventWindow(records, windows, (r) =>
+    Date.parse((r as { timestamp: string }).timestamp),
+  );
+  assert.deepEqual(
+    (groups.get(502) as { id: string }[]).map((r) => r.id),
+    ['boundary'],
+  );
+  assert.equal(groups.has(501), false);
+});
+
 test('scanClaudeVendorSessions: a CLOSED event window supplies issueNumber when cwd-inference fails', () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
   writeFileSync(
@@ -403,6 +427,46 @@ test('scanClaudeVendorSessions: two CLOSED event windows in one file produce two
   assert.deepEqual(byId.get('sess-ew2-0001#ew502')?.adapterResult.joinHints, {
     issueNumber: 502,
   });
+});
+
+test('scanClaudeVendorSessions: two DIFFERENT cwd-segments in one file that both fall in the SAME issue window produce exactly one #ew sample, not a duplicate-keyed pair (Copilot review finding, #2423)', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-ew-multiseg.jsonl'),
+    `${[
+      // Segment 0: cwd "/repo" -- cwd-inference fails.
+      '{"type":"assistant","timestamp":"2026-01-01T00:15:00.000Z","sessionId":"sess-ew-ms-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}',
+      // Segment 1: cwd changes to an ordinary, non-issue-shaped directory
+      // (a ordinary "cd", not a worktree move) -- cwd-inference also
+      // fails here, and this record ALSO falls in issue 501's window.
+      '{"type":"assistant","timestamp":"2026-01-01T00:20:00.000Z","sessionId":"sess-ew-ms-0001","cwd":"/repo/some/subdir","message":{"model":"m","usage":{"input_tokens":2,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":2}}}',
+    ].join('\n')}\n`,
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow('2026-01-01T00:10:00Z', '2026-01-01T00:25:00Z'),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow('2026-01-01T00:26:00Z', '2026-01-01T00:30:00Z'),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew'),
+  );
+
+  // Exactly one #ew501 sample, combining both segments' matching records --
+  // not two duplicate-keyed ones (the bug: partitioning per-segment would
+  // independently re-derive the same #ew501 suffix from each segment).
+  assert.equal(ewSamples.length, 1);
+  assert.equal(
+    ewSamples[0].adapterResult.sample.vendorSessionId,
+    'sess-ew-ms-0001#ew501',
+  );
+  assert.equal(ewSamples[0].timeline.points.length, 2);
 });
 
 test('scanClaudeVendorSessions: an OPEN event window (no cleanup exit yet) never produces an event-window sample', () => {

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -535,6 +535,122 @@ test('scanClaudeVendorSessions: a reversed cleanup window never produces an even
   assert.equal(sessions[0].adapterResult.joinHints, undefined);
 });
 
+test('buildCompletedIssueWindows: a valid, closed cleanup pair caps the window even when a LATER retry stage extends past it (Codex review finding round 2, #2423)', () => {
+  // Issue 501 completed once: cleanup enter@00:55, exit@01:00 (valid).
+  // A re-attempt later did a fresh `work` enter/exit (02:00-02:30) that
+  // has NOT yet reached its own cleanup -- the original cleanup pair is
+  // untouched (still valid), but the retry's work window must not widen
+  // the completed span past the original cleanup's own exit.
+  const all = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow('2026-01-01T00:00:00Z', '2026-01-01T00:30:00Z'),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow('2026-01-01T00:55:00Z', '2026-01-01T01:00:00Z'),
+    ],
+    // Careful: eventKey is `${issueNumber}:${vendor}:${stageId}`, one
+    // entry per stageId -- a real retry would overwrite the SAME 'work'
+    // key via readEventWindows' own latest-wins pairing. Modeling that
+    // directly: 'work' now reflects the RETRY's later window, not the
+    // original run's.
+  ]);
+  all.set(
+    '501:claude:work',
+    stageWindow('2026-01-01T02:00:00Z', '2026-01-01T02:30:00Z'),
+  );
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.equal(windows.length, 1);
+  // endMs stays at cleanup's own exit, never extended by the retry's
+  // later work window.
+  assert.equal(windows[0].endMs, ms('2026-01-01T01:00:00Z'));
+  // startMs is NOT widened back to the retry's work window either (it
+  // falls after cleanup's endMs, so it doesn't qualify) -- it stays
+  // anchored at cleanup's own start.
+  assert.equal(windows[0].startMs, ms('2026-01-01T00:55:00Z'));
+});
+
+test("scanClaudeVendorSessions: a completed cleanup window does not absorb a later retry's activity", () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-ew-retry.jsonl'),
+    `${[
+      // Inside the original completed window (00:55-01:00).
+      '{"type":"assistant","timestamp":"2026-01-01T00:57:00.000Z","sessionId":"sess-ew-retry-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}',
+      // During the later, still-in-progress retry -- must NOT be folded
+      // into issue 501's completed sample.
+      '{"type":"assistant","timestamp":"2026-01-01T02:15:00.000Z","sessionId":"sess-ew-retry-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":99,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":99}}}',
+    ].join('\n')}\n`,
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '501:claude:cleanup',
+      stageWindow('2026-01-01T00:55:00Z', '2026-01-01T01:00:00Z'),
+    ],
+    [
+      '501:claude:work',
+      stageWindow('2026-01-01T02:00:00Z', '2026-01-01T02:30:00Z'),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSample = sessions.find((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew'),
+  );
+
+  assert.ok(ewSample);
+  assert.equal(ewSample.timeline.points.length, 1);
+  assert.equal(
+    ewSample.timeline.points[0].atMs,
+    ms('2026-01-01T00:57:00.000Z'),
+  );
+});
+
+test('scanClaudeVendorSessions: the event-window fallback is skipped for the whole file when ANY segment already resolved a cwd-inferred issue number (Copilot review finding round 2, #2423)', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-ew-mixed.jsonl'),
+    `${[
+      // Segment 0: a real worktree cwd -- resolves issue 4242 via cwd.
+      '{"type":"assistant","timestamp":"2026-01-01T00:00:00.000Z","sessionId":"sess-ew-mixed-0001","cwd":"/repo.issue-4242-x","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}',
+      // Segment 1: an ordinary subdirectory -- cwd-inference fails, but
+      // its own timestamp happens to fall inside issue 501's completed
+      // window purely by coincidence.
+      '{"type":"assistant","timestamp":"2026-01-01T00:20:00.000Z","sessionId":"sess-ew-mixed-0001","cwd":"/repo/some/subdir","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}',
+    ].join('\n')}\n`,
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow('2026-01-01T00:10:00Z', '2026-01-01T00:25:00Z'),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow('2026-01-01T00:26:00Z', '2026-01-01T00:30:00Z'),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew'),
+  );
+
+  // No event-window sample at all -- the file already produced a real,
+  // cwd-attributed issue-loop sample (4242) from segment 0.
+  assert.equal(ewSamples.length, 0);
+  const byId = new Map(
+    sessions.map((s) => [s.adapterResult.sample.vendorSessionId, s]),
+  );
+  assert.deepEqual(byId.get('sess-ew-mixed-0001#0')?.adapterResult.joinHints, {
+    issueNumber: 4242,
+  });
+  assert.equal(
+    byId.get('sess-ew-mixed-0001#1')?.adapterResult.joinHints,
+    undefined,
+  );
+});
+
 test('scanClaudeVendorSessions: two DIFFERENT project log files both matching the same issue window are BOTH dropped (cross-file ambiguity guard, Codex review finding, #2423)', () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
   writeFileSync(

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -10,7 +10,9 @@ import type {
 } from '../src/scripts/token-cost-core.mts';
 import {
   allocateStageUsage,
+  buildCompletedIssueWindows,
   buildSample,
+  type CompletedIssueWindow,
   computeStageWindows,
   deriveOutcome,
   extractClaudeUsageTimeline,
@@ -26,6 +28,7 @@ import {
   resolveTrustedMarkerLogins,
   type StageEventWindow,
   scanClaudeVendorSessions,
+  segmentRecordsByEventWindow,
   type VendorSession,
   vendorSessionKey,
 } from '../src/scripts/token-cost-harvest.mts';
@@ -180,6 +183,278 @@ test("scanClaudeVendorSessions scopes each cwd segment's timeline to just that s
   assert.equal(primary0?.adapterResult.joinHints, undefined);
   assert.equal(primary2?.timeline.points.length, 1);
   assert.equal(primary2?.adapterResult.joinHints, undefined);
+});
+
+// --- #2418: event-window issue-number fallback -----------------------------
+
+function stageWindow(startIso: string, endIso: string): StageEventWindow {
+  return { startMs: ms(startIso), endMs: ms(endIso) };
+}
+
+test('buildCompletedIssueWindows: builds an overall window only for an issue with a CLOSED cleanup stage', () => {
+  const all = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow('2026-01-01T00:00:00Z', '2026-01-01T00:30:00Z'),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow('2026-01-01T00:55:00Z', '2026-01-01T01:00:00Z'),
+    ],
+    // issue 502 never closed its cleanup stage -- excluded even though it
+    // has other stage windows.
+    [
+      '502:claude:work',
+      stageWindow('2026-01-02T00:00:00Z', '2026-01-02T00:30:00Z'),
+    ],
+  ]);
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.deepEqual(windows, [
+    {
+      issueNumber: 501,
+      startMs: ms('2026-01-01T00:00:00Z'),
+      endMs: ms('2026-01-01T01:00:00Z'),
+    },
+  ]);
+});
+
+test('buildCompletedIssueWindows: filters by vendor', () => {
+  const all = new Map<string, StageEventWindow>([
+    [
+      '501:claude:cleanup',
+      stageWindow('2026-01-01T00:00:00Z', '2026-01-01T00:10:00Z'),
+    ],
+    [
+      '501:codex:cleanup',
+      stageWindow('2026-01-01T02:00:00Z', '2026-01-01T02:10:00Z'),
+    ],
+  ]);
+  const claudeWindows = buildCompletedIssueWindows(all, 'claude');
+  assert.equal(claudeWindows.length, 1);
+  assert.equal(claudeWindows[0].startMs, ms('2026-01-01T00:00:00Z'));
+  const codexWindows = buildCompletedIssueWindows(all, 'codex');
+  assert.equal(codexWindows.length, 1);
+  assert.equal(codexWindows[0].startMs, ms('2026-01-01T02:00:00Z'));
+});
+
+test('segmentRecordsByEventWindow: groups records by the single window each timestamp falls inside', () => {
+  const windows: CompletedIssueWindow[] = [
+    {
+      issueNumber: 501,
+      startMs: ms('2026-01-01T00:00:00Z'),
+      endMs: ms('2026-01-01T01:00:00Z'),
+    },
+    {
+      issueNumber: 502,
+      startMs: ms('2026-01-02T00:00:00Z'),
+      endMs: ms('2026-01-02T01:00:00Z'),
+    },
+  ];
+  const records = [
+    { id: 'a', timestamp: '2026-01-01T00:10:00Z' },
+    { id: 'b', timestamp: '2026-01-02T00:10:00Z' },
+    { id: 'c', timestamp: '2026-01-01T00:20:00Z' },
+  ];
+  const groups = segmentRecordsByEventWindow(records, windows, (r) =>
+    Date.parse((r as { timestamp: string }).timestamp),
+  );
+  assert.deepEqual(
+    (groups.get(501) as { id: string }[]).map((r) => r.id),
+    ['a', 'c'],
+  );
+  assert.deepEqual(
+    (groups.get(502) as { id: string }[]).map((r) => r.id),
+    ['b'],
+  );
+});
+
+test('segmentRecordsByEventWindow: drops a record with no timestamp, and one matching zero windows', () => {
+  const windows: CompletedIssueWindow[] = [
+    {
+      issueNumber: 501,
+      startMs: ms('2026-01-01T00:00:00Z'),
+      endMs: ms('2026-01-01T01:00:00Z'),
+    },
+  ];
+  const records = [
+    { id: 'no-ts' },
+    { id: 'outside', timestamp: '2026-03-01T00:00:00Z' },
+  ];
+  const groups = segmentRecordsByEventWindow(records, windows, (r) =>
+    typeof (r as { timestamp?: string }).timestamp === 'string'
+      ? Date.parse((r as { timestamp: string }).timestamp)
+      : undefined,
+  );
+  assert.equal(groups.size, 0);
+});
+
+test('segmentRecordsByEventWindow: drops a record matching MORE than one window (concurrent-session overlap)', () => {
+  // Two different issues' windows genuinely overlap in wall-clock -- two
+  // concurrent sessions writing to the same shared events.jsonl.
+  const windows: CompletedIssueWindow[] = [
+    {
+      issueNumber: 501,
+      startMs: ms('2026-01-01T00:00:00Z'),
+      endMs: ms('2026-01-01T02:00:00Z'),
+    },
+    {
+      issueNumber: 502,
+      startMs: ms('2026-01-01T01:00:00Z'),
+      endMs: ms('2026-01-01T03:00:00Z'),
+    },
+  ];
+  const records = [{ id: 'ambiguous', timestamp: '2026-01-01T01:30:00Z' }];
+  const groups = segmentRecordsByEventWindow(records, windows, (r) =>
+    Date.parse((r as { timestamp: string }).timestamp),
+  );
+  assert.equal(groups.size, 0);
+});
+
+test('scanClaudeVendorSessions: a CLOSED event window supplies issueNumber when cwd-inference fails', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-ew.jsonl'),
+    `${[
+      // Before the window -- stays unattributed, only counted in the base
+      // session-kind sample.
+      '{"type":"assistant","timestamp":"2026-01-01T00:00:00.000Z","sessionId":"sess-ew-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}',
+      // Inside issue 501's closed window.
+      '{"type":"assistant","timestamp":"2026-01-01T00:20:00.000Z","sessionId":"sess-ew-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":10,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":5}}}',
+    ].join('\n')}\n`,
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow('2026-01-01T00:10:00Z', '2026-01-01T00:25:00Z'),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow('2026-01-01T00:26:00Z', '2026-01-01T00:30:00Z'),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+
+  assert.equal(sessions.length, 2);
+  const byId = new Map(
+    sessions.map((s) => [s.adapterResult.sample.vendorSessionId, s]),
+  );
+  const base = byId.get('sess-ew-0001');
+  const eventWindowSample = byId.get('sess-ew-0001#ew501');
+
+  assert.equal(base?.adapterResult.joinHints, undefined);
+  assert.equal(base?.timeline.points.length, 2);
+
+  assert.deepEqual(eventWindowSample?.adapterResult.joinHints, {
+    issueNumber: 501,
+  });
+  assert.equal(eventWindowSample?.timeline.points.length, 1);
+  assert.equal(
+    eventWindowSample?.timeline.points[0].atMs,
+    ms('2026-01-01T00:20:00.000Z'),
+  );
+
+  // Deterministic: re-running against the same inputs produces the same
+  // vendorSessionId, so the harvester's own dedup (readExistingVendorSessionKeys)
+  // treats a second run as already-present rather than a new sample.
+  const rerun = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  assert.deepEqual(
+    rerun.map((s) => s.adapterResult.sample.vendorSessionId).sort(),
+    sessions.map((s) => s.adapterResult.sample.vendorSessionId).sort(),
+  );
+});
+
+test('scanClaudeVendorSessions: two CLOSED event windows in one file produce two distinct #ew samples', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-ew2.jsonl'),
+    `${[
+      '{"type":"assistant","timestamp":"2026-01-01T00:20:00.000Z","sessionId":"sess-ew2-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}',
+      '{"type":"assistant","timestamp":"2026-01-02T00:20:00.000Z","sessionId":"sess-ew2-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":2,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":2}}}',
+    ].join('\n')}\n`,
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow('2026-01-01T00:10:00Z', '2026-01-01T00:25:00Z'),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow('2026-01-01T00:26:00Z', '2026-01-01T00:30:00Z'),
+    ],
+    [
+      '502:claude:work',
+      stageWindow('2026-01-02T00:10:00Z', '2026-01-02T00:25:00Z'),
+    ],
+    [
+      '502:claude:cleanup',
+      stageWindow('2026-01-02T00:26:00Z', '2026-01-02T00:30:00Z'),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const byId = new Map(
+    sessions.map((s) => [s.adapterResult.sample.vendorSessionId, s]),
+  );
+
+  assert.deepEqual(byId.get('sess-ew2-0001#ew501')?.adapterResult.joinHints, {
+    issueNumber: 501,
+  });
+  assert.deepEqual(byId.get('sess-ew2-0001#ew502')?.adapterResult.joinHints, {
+    issueNumber: 502,
+  });
+});
+
+test('scanClaudeVendorSessions: an OPEN event window (no cleanup exit yet) never produces an event-window sample', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-ew-open.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:20:00.000Z","sessionId":"sess-ew-open-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}\n',
+  );
+  // work is closed, but cleanup only has an enter -- the loop is still
+  // in-flight from this agent's perspective.
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow('2026-01-01T00:10:00Z', '2026-01-01T00:25:00Z'),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+
+  assert.equal(sessions.length, 1);
+  assert.equal(
+    sessions[0].adapterResult.sample.vendorSessionId,
+    'sess-ew-open-0001',
+  );
+  assert.equal(sessions[0].adapterResult.joinHints, undefined);
+});
+
+test('scanClaudeVendorSessions: an event window is ignored when the segment already has a cwd-inferred issueNumber', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-ew-cwd.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:20:00.000Z","sessionId":"sess-ew-cwd-0001","cwd":"/repo.issue-777-x","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}\n',
+  );
+  // A closed window exists for a DIFFERENT issue at this same timestamp --
+  // must not override the already-successful cwd inference (777), and
+  // must not additionally emit an event-window sample for 501 either,
+  // since the fallback only runs when cwd-inference itself failed.
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow('2026-01-01T00:10:00Z', '2026-01-01T00:25:00Z'),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow('2026-01-01T00:26:00Z', '2026-01-01T00:30:00Z'),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+
+  assert.equal(sessions.length, 1);
+  assert.deepEqual(sessions[0].adapterResult.joinHints, { issueNumber: 777 });
 });
 
 test('extractCodexUsageTimeline prefers cumulative total_token_usage when any record has one', () => {


### PR DESCRIPTION
## Summary

Closes #2418.

#2404 fixed the harvester's Claude-adapter join for a session whose `cwd` genuinely varies mid-file, but that premise doesn't hold on this workstation: every session launches once from the primary worktree and only reaches other worktrees via in-conversation `cd` (never a fresh Claude Code launch), so `cwd` never varies at all -- #2404's fix is never exercised, and the harvest still produces zero `issue-loop` samples (confirmed empirically in #2405).

## Design

Adds a fallback that correlates a cwd-segment's own record timestamps against `token-cost-event.mjs`'s per-issue enter/exit windows (`readEventWindows`, which already existed for stage-*timing* overrides -- this is the first thing to also use it as an issue-number *source*). `TokenCostAttribution` already had a `'phase-event'` value pre-planned for exactly this (`token-cost-core.mts`), previously unused.

- **`ClaudeHarvestInput.issueNumberOverride?: number`** (mirrors the `segmentIndex` precedent from #2404: input widens, `TokenCostAdapterResult`'s shape stays unchanged). `claudeAdapter.harvest()` uses it in place of cwd-inference when present; every existing caller that doesn't pass it is unaffected. Suffix scheme `#ew<issueNumber>` -- self-describing, collision-safe against the numeric `#<segmentIndex>` scheme.
- **`buildCompletedIssueWindows` / `segmentRecordsByEventWindow`** (`token-cost-harvest.mts`, the real CLI production path -- the adapter module's own `scanClaudeSessions` has no `events.jsonl` access and stays cwd-only, deliberately, per #2404's "fixed the wrong function" lesson). For a cwd-segment whose own cwd-inference already failed, partitions that segment's records by which known issue+vendor event window (if any) each record's own timestamp falls into.
- **Gate: only a CLOSED `cleanup` stage window counts**, and the completed window is always anchored to that `cleanup` pair's own bounds -- `endMs` is never a max across every stage, and a stage only widens `startMs` when its own window falls entirely at or before `cleanup.endMs`. An in-progress issue-loop's mid-flight harvest would otherwise permanently freeze that issue's sample at partial usage the first time it's harvested -- the `#ew<issueNumber>` suffix is stable, so `vendorSessionKey` dedup would skip every later, fuller harvest as "already present." This is a steady-state risk on a workstation with sessions routinely still mid-loop, not a one-time migration edge like #2404's. Matches roadmap #2296's locked "one *completed* issue-loop" unit.
- **Reversed-pairing guards.** `readEventWindows` pairs the LATEST `--enter` seen for a (issue, vendor, stage) key with the LATEST `--exit`, across the whole append-only file, with no knowledge of which attempt either belongs to. Review caught three concrete ways that produces a corrupted window: a re-attempt's still-open `cleanup` enter pairing with the first attempt's stale exit (rejected via `startMs < endMs`); a later retry's OTHER stage activity (e.g. a fresh `work` enter/exit) landing after the original cleanup's own exit (excluded from widening `startMs`, capped by the anchor above); and a later attempt's own enter for a non-`cleanup` stage pairing (because its own exit call silently failed -- `token-cost-event.mjs` is deliberately fail-open) with an *earlier*, unrelated attempt's stale exit, producing a reversed window that still overlaps the completed run. That last case now skips the whole issue for this harvest rather than emitting a silently narrowed window -- no sample beats a wrong one. The remaining variant (a stale pairing that stays internally valid, e.g. because *both* of the later attempt's own calls for that stage failed) needs attempt/session identity on `TokenCostEvent` to close; filed as a follow-up, #2424.
- **Ambiguous overlap → unattributed or skipped.** Concurrent sessions append to one shared, HOME-keyed `events.jsonl`, so two different issues' windows can genuinely overlap in wall-clock, and the same issue number's event-window candidates can legitimately come from more than one log file. A record matching zero or more than one window is dropped from event-window attribution rather than guessed; a same-issue match spanning multiple files, or a file whose segments mix cwd-inferred and event-window-inferred attribution, is skipped for that harvest with a stderr warning rather than picking a side.
- **Additive, not a replacement.** The segment's own plain cwd-only sample (`kind: 'session'` when cwd-inference fails) is still produced exactly as before. Verified `aggregateSnapshot` (`token-cost-report.mts`) filters strictly to `kind === 'issue-loop'` with a non-`'unknown'` outcome, so a coexisting `session`-kind sample from the same records cannot double-count anything published.
- **Docs**: `CLAUDE.md` / `AGENTS.md` / `.github/copilot-instructions.md`'s dogfooding invocation examples never showed `--issue` on the `token-cost-event.mjs` call -- verified against the real `events.jsonl` that 117/238 recorded events lacked `issueNumber` as a direct result. All three now show `--issue <n>` and explain when to omit it (only `discover`, which precedes any claim). This changes the standing per-phase-event instructions every future session in this repository follows, not just this PR's own code.

## Scope

- **Claude only.** Codex shares this deployment shape and gap (own adapter/session-storage code, not touched here) -- a same-shape follow-up is a reasonable next candidate, named but not filed (this issue explicitly scoped Claude first).
- **Grok**: untouched, structurally immune (confirmed in #2404 -- keys one `cwd` per session via its own directory tree).
- No schema changes to `TokenCostEvent`/`TokenCostAdapterResult`; #2424 tracks the schema change needed to close the last reversed-pairing residual.

## Test plan

- [x] `buildCompletedIssueWindows`: only an issue with a CLOSED `cleanup` window produces an overall span; filters by vendor; a reversed `cleanup` window is rejected outright; a later retry's stage activity past `cleanup.endMs` never widens the window; a reversed non-`cleanup` stage window overlapping the completed run skips the issue entirely; the same reversed shape entirely past `cleanup.endMs` is ordinary retry noise and doesn't block emission.
- [x] `segmentRecordsByEventWindow`: groups by single-match window (half-open `[startMs, endMs)`); drops no-timestamp records; drops records matching zero or more than one window (concurrent-overlap case).
- [x] `scanClaudeVendorSessions`: a closed window supplies `issueNumber` when cwd-inference fails; two closed windows in one file produce two distinct `#ew`-suffixed samples; an OPEN window (`cleanup` enter only, no exit) never produces a sample; a segment with a real cwd-inferred `issueNumber` is left alone (fallback doesn't fire); a same-issue match spanning multiple files is skipped with a warning; a file mixing cwd-inferred and event-window segments is skipped; re-running against identical inputs is deterministic (same `vendorSessionId`s), which is what makes the harvester's own append-dedup idempotent.
- [x] `claudeAdapter.harvest()`: `issueNumberOverride` takes priority over cwd-inference; `segmentIndex` is ignored when `issueNumberOverride` is present; behavior with neither flag is byte-identical to before #2418.
- [x] `extractRecordTimestampMs`: valid/missing/malformed timestamp cases.
- [x] `node --test tests/*.test.mts` -- 4604/4604 pass, no regressions.
- [x] `pnpm run build` regenerates matching `.mjs` output, committed alongside the `.mts` sources.
- [x] `pnpm run lint` passes (`build:check` clean once committed, 0 biome/cspell/markdownlint/dprint issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtcjhuuXDqQASYGXtJnmV3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Claude token-cost harvesting by attributing previously unattributed records to uniquely matching completed issue windows.
  - Added support for explicit issue attribution, which takes precedence over inferred issue information.
  - Preserved existing session and issue attribution behavior when no explicit override is provided.

- **Bug Fixes**
  - Reduced incorrect attribution by excluding open, overlapping, reversed, or ambiguously matched issue windows.
  - Improved handling of record timestamps, including invalid or missing timestamp data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
