### PR TITLE
chore(token-cost): refresh dogfood snapshot after event-window join

### DIFF
--- a/docs/token-cost-snapshot.json
+++ b/docs/token-cost-snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-09-02T01:03:09.101Z",
+  "generatedAt": "2026-09-02T03:45:46.810Z",
   "minPublishableSamples": 10,
   "minPublishableVendors": 2,
   "publishable": false,


### PR DESCRIPTION
## Summary

Closes #2419.

Retried the token-cost dogfood snapshot refresh now that #2418 (event-window join) is merged. Still `publishable: false` (`n=0` issue-loop), but this time root-caused and quantified rather than just "still zero":

- `buildCompletedIssueWindows` correctly computes **12** completed issue-loop windows from this workstation's real `events.jsonl`.
- **2 of 12** are correctly excluded by the existing (working-as-designed) zero-or-multiple-window-match rule: their windows fully nest inside a sibling issue's window (e.g. #2392 inside #2223, #2052 inside #2233), so every candidate record in that overlap ambiguously matches 2+ windows and is dropped rather than guessed.
- **10 of 12** are dropped by #2418's cross-file event-window guard, which skips a same-issue match spanning more than one project log file. On this workstation that guard fires for essentially every completed issue-loop, because a single, continuous work session on one issue routinely spans multiple physical `.jsonl` files due to Claude Code's own context-compaction/resume behavior -- not genuine concurrent, overlapping sessions. (This very PR's own dogfooding chain is a live example: the conversation that produced #2418 already spans multiple session files.)

The stderr warnings from `#2418`'s guard (`skipping event-window issue #NNNN: matched by more than one project log file (...)`) made this a ~15 minute diagnosis rather than another opaque "n=0" -- the guard failed loud exactly as designed.

## Change

`docs/token-cost-snapshot.json`: refreshed `generatedAt` via `token-cost-report.mjs --apply`. `publishable`, `sampleCount` unchanged (`false`, `0`).

## Follow-up

Per this diagnosis, filed two follow-ups on roadmap #2296:

- #2425 -- teach the cross-file guard to merge same-issue candidates across files when their matched-record time ranges are DISJOINT (the compaction/resume-continuation case), while still skipping on a genuine wall-clock OVERLAP (still a real ambiguity, tracked separately by #2424's attempt/session-identity scope).
- #2426 -- retry this same snapshot refresh again, `Blocked by #2425`.

Also narrowed #2424's own scope with a note: its "cross-file fallback" acceptance bullet assumed attempt identity would be the fix for the cross-file case; #2425's timestamp-only disjoint-merge lands first and doesn't need it, so #2424's remaining cross-file scope should be re-evaluated once #2425 ships.

## Test plan

- [x] `node scripts/token-cost-harvest.mjs --repo kurone-kito/idd-skill` -- 16 fresh session-kind samples, 0 issue-loop (root cause traced via a scratch script directly against `buildCompletedIssueWindows`/`scanClaudeVendorSessions`, not guessed).
- [x] `node scripts/token-cost-report.mjs --in <samples.jsonl> --apply` -- writes `docs/token-cost-snapshot.json` (n=0, publishable=false).
- [x] `node scripts/token-cost-report.mjs --check` -- no drift between the snapshot and the README/docs marked regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtcjhuuXDqQASYGXtJnmV3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed the token cost snapshot metadata with a new generation timestamp.
  * No user-facing functionality or public interfaces were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->