### PR TITLE
fix(token-cost): classify cross-file event-window skips

### DIFF
--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -970,6 +970,24 @@ export function segmentRecordsByEventWindow(
   }
   return groups;
 }
+function computeRecordTimeRange(records, getTimestampMs) {
+  let minMs;
+  let maxMs;
+  for (const record of records) {
+    const atMs = getTimestampMs(record);
+    if (atMs === undefined) {
+      continue;
+    }
+    minMs = minMs === undefined ? atMs : Math.min(minMs, atMs);
+    maxMs = maxMs === undefined ? atMs : Math.max(maxMs, atMs);
+  }
+  return minMs === undefined || maxMs === undefined
+    ? undefined
+    : { minMs, maxMs };
+}
+function rangesOverlap(a, b) {
+  return a.minMs <= b.maxMs && b.minMs <= a.maxMs;
+}
 /**
  * #2404: a long-lived session's project JSONL file is not necessarily one
  * cwd for its whole lifetime -- `segmentRecordsByCwd` (see
@@ -1009,6 +1027,35 @@ export function segmentRecordsByEventWindow(
  * suffix from more than one segment and push a duplicate-keyed
  * `VendorSession` within a single harvest run, which the append-side
  * dedup (keyed only against samples from PRIOR runs) cannot catch.
+ *
+ * #2425: event windows carry no session/file identity, so the SAME issue
+ * number's unattributed candidates can come from more than one project
+ * log file. #2418 skips the issue entirely whenever more than one file
+ * contributes, on the theory that this is a rare, genuinely-concurrent
+ * overlap. #2419 measured this on a real workstation and found it is the
+ * DOMINANT case, not the rare one (10 of 12 completed issue-loops), which
+ * initially suggested a MERGE (rather than skip) of file candidates whose
+ * matched-record time ranges are provably disjoint -- a sequential
+ * continuation, not concurrency.
+ *
+ * That merge was investigated and explicitly REJECTED after implementing
+ * it: checked directly against real file timestamps, and the actual
+ * multi-file matches on this workstation are genuinely CONCURRENT,
+ * overlapping activity (two files both spanning the same ~24h range,
+ * both still being appended to) -- not a sequential split, so the merge
+ * recovers nothing real. Worse, a range-disjointness check is a weak
+ * discriminator for SPARSE candidates: a single stray record from an
+ * unrelated concurrent session can never "overlap" anything by
+ * definition, so a naive disjoint-range merge would misattribute that
+ * unrelated file's usage into this issue's sample under the stable
+ * `#ew<issueNumber>` id, permanently -- exactly the class of bug the
+ * original #2418 guard exists to prevent (see the test locking this in:
+ * "two DIFFERENT project log files both matching the same issue window
+ * are BOTH dropped"). This still classifies each multi-file skip as
+ * disjoint-or-overlapping (visible in stderr) for diagnostic value, but
+ * both classifications skip -- unchanged from #2418's original behavior.
+ * Resolving the cross-file case for real needs session/attempt identity
+ * on the underlying events (#2424), not a timestamp heuristic.
  */
 export function scanClaudeVendorSessions(
   projectDir,
@@ -1103,47 +1150,67 @@ export function scanClaudeVendorSessions(
       }
     }
   }
-  // Cross-file ambiguity guard: event windows carry no session identity,
-  // so two DIFFERENT project log files -- e.g. an unrelated concurrent
-  // session whose own unattributed activity happens to fall inside this
-  // issue's completed window purely by wall-clock coincidence -- can both
-  // independently match the same issue. Emitting both would not just
-  // misattribute the stray file's usage; buildSample's markAmbiguousOverlaps
-  // would then also flag the LEGITIMATE sample as ambiguous (outcome:
-  // unknown), discarding the real measurement too. Emitting for NEITHER
-  // file when more than one contributes to the same issue is strictly
-  // safer than emitting a contaminated pair.
-  const fileCountByIssue = new Map();
-  for (const candidate of eventWindowCandidates) {
-    const filesForIssue =
-      fileCountByIssue.get(candidate.issueNumber) ?? new Set();
-    filesForIssue.add(candidate.fileBasename);
-    fileCountByIssue.set(candidate.issueNumber, filesForIssue);
-  }
-  for (const candidate of eventWindowCandidates) {
-    const contributingFiles = fileCountByIssue.get(candidate.issueNumber);
-    if ((contributingFiles?.size ?? 0) > 1) {
-      process.stderr.write(
-        `token-cost-harvest: skipping event-window issue #${candidate.issueNumber}: matched by more than one project log file (${[...(contributingFiles ?? [])].join(', ')})\n`,
-      );
-      continue;
-    }
+  const harvestEventWindowCandidate = (issueNumber, fileBasename, records) => {
     try {
       const eventWindowResult = claudeAdapter.harvest({
-        records: candidate.records,
-        fileBasename: candidate.fileBasename,
-        issueNumberOverride: candidate.issueNumber,
+        records,
+        fileBasename,
+        issueNumberOverride: issueNumber,
       });
       out.push({
         vendor: 'claude',
         adapterResult: eventWindowResult,
-        timeline: extractClaudeUsageTimeline(candidate.records),
+        timeline: extractClaudeUsageTimeline(records),
       });
     } catch (error) {
       process.stderr.write(
-        `token-cost-harvest: skipping event-window issue #${candidate.issueNumber}: ${error.message}\n`,
+        `token-cost-harvest: skipping event-window issue #${issueNumber}: ${error.message}\n`,
       );
     }
+  };
+  // Cross-file resolution: event windows carry no session/file identity,
+  // so more than one project log file can independently match the same
+  // issue. Two distinct producers of that shape need different handling
+  // -- see the #2425 rationale on this function's own docstring above.
+  const candidatesByIssue = new Map();
+  for (const candidate of eventWindowCandidates) {
+    const list = candidatesByIssue.get(candidate.issueNumber) ?? [];
+    list.push({
+      fileBasename: candidate.fileBasename,
+      records: candidate.records,
+    });
+    candidatesByIssue.set(candidate.issueNumber, list);
+  }
+  for (const [issueNumber, fileCandidates] of candidatesByIssue) {
+    if (fileCandidates.length === 1) {
+      harvestEventWindowCandidate(
+        issueNumber,
+        fileCandidates[0].fileBasename,
+        fileCandidates[0].records,
+      );
+      continue;
+    }
+    const ranges = fileCandidates.map((candidate) =>
+      computeRecordTimeRange(candidate.records, extractRecordTimestampMs),
+    );
+    const fileNames = fileCandidates.map((candidate) => candidate.fileBasename);
+    const anyOverlap = ranges.some((a, i) =>
+      ranges.some(
+        (b, j) =>
+          i < j && a !== undefined && b !== undefined && rangesOverlap(a, b),
+      ),
+    );
+    // Classify-only: both shapes still skip (see the #2425 rationale on
+    // this function's own docstring above for why a disjoint-range merge
+    // was investigated and rejected). The distinction is diagnostic only
+    // -- it tells a maintainer reading stderr which residual gap this
+    // instance is, without changing behavior for either.
+    const classification = anyOverlap
+      ? 'overlapping activity ranges'
+      : 'disjoint activity ranges -- resolvable once events carry session identity, #2424';
+    process.stderr.write(
+      `token-cost-harvest: skipping event-window issue #${issueNumber}: matched by more than one project log file (${classification}: ${fileNames.join(', ')})\n`,
+    );
   }
   return out;
 }

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1200,6 +1200,34 @@ export interface VendorSession {
   timeline: UsageTimeline;
 }
 
+interface RecordTimeRange {
+  minMs: number;
+  maxMs: number;
+}
+
+function computeRecordTimeRange(
+  records: readonly unknown[],
+  getTimestampMs: (record: unknown) => number | undefined,
+): RecordTimeRange | undefined {
+  let minMs: number | undefined;
+  let maxMs: number | undefined;
+  for (const record of records) {
+    const atMs = getTimestampMs(record);
+    if (atMs === undefined) {
+      continue;
+    }
+    minMs = minMs === undefined ? atMs : Math.min(minMs, atMs);
+    maxMs = maxMs === undefined ? atMs : Math.max(maxMs, atMs);
+  }
+  return minMs === undefined || maxMs === undefined
+    ? undefined
+    : { minMs, maxMs };
+}
+
+function rangesOverlap(a: RecordTimeRange, b: RecordTimeRange): boolean {
+  return a.minMs <= b.maxMs && b.minMs <= a.maxMs;
+}
+
 /**
  * #2404: a long-lived session's project JSONL file is not necessarily one
  * cwd for its whole lifetime -- `segmentRecordsByCwd` (see
@@ -1239,6 +1267,35 @@ export interface VendorSession {
  * suffix from more than one segment and push a duplicate-keyed
  * `VendorSession` within a single harvest run, which the append-side
  * dedup (keyed only against samples from PRIOR runs) cannot catch.
+ *
+ * #2425: event windows carry no session/file identity, so the SAME issue
+ * number's unattributed candidates can come from more than one project
+ * log file. #2418 skips the issue entirely whenever more than one file
+ * contributes, on the theory that this is a rare, genuinely-concurrent
+ * overlap. #2419 measured this on a real workstation and found it is the
+ * DOMINANT case, not the rare one (10 of 12 completed issue-loops), which
+ * initially suggested a MERGE (rather than skip) of file candidates whose
+ * matched-record time ranges are provably disjoint -- a sequential
+ * continuation, not concurrency.
+ *
+ * That merge was investigated and explicitly REJECTED after implementing
+ * it: checked directly against real file timestamps, and the actual
+ * multi-file matches on this workstation are genuinely CONCURRENT,
+ * overlapping activity (two files both spanning the same ~24h range,
+ * both still being appended to) -- not a sequential split, so the merge
+ * recovers nothing real. Worse, a range-disjointness check is a weak
+ * discriminator for SPARSE candidates: a single stray record from an
+ * unrelated concurrent session can never "overlap" anything by
+ * definition, so a naive disjoint-range merge would misattribute that
+ * unrelated file's usage into this issue's sample under the stable
+ * `#ew<issueNumber>` id, permanently -- exactly the class of bug the
+ * original #2418 guard exists to prevent (see the test locking this in:
+ * "two DIFFERENT project log files both matching the same issue window
+ * are BOTH dropped"). This still classifies each multi-file skip as
+ * disjoint-or-overlapping (visible in stderr) for diagnostic value, but
+ * both classifications skip -- unchanged from #2418's original behavior.
+ * Resolving the cross-file case for real needs session/attempt identity
+ * on the underlying events (#2424), not a timestamp heuristic.
  */
 export function scanClaudeVendorSessions(
   projectDir: string,
@@ -1339,47 +1396,75 @@ export function scanClaudeVendorSessions(
     }
   }
 
-  // Cross-file ambiguity guard: event windows carry no session identity,
-  // so two DIFFERENT project log files -- e.g. an unrelated concurrent
-  // session whose own unattributed activity happens to fall inside this
-  // issue's completed window purely by wall-clock coincidence -- can both
-  // independently match the same issue. Emitting both would not just
-  // misattribute the stray file's usage; buildSample's markAmbiguousOverlaps
-  // would then also flag the LEGITIMATE sample as ambiguous (outcome:
-  // unknown), discarding the real measurement too. Emitting for NEITHER
-  // file when more than one contributes to the same issue is strictly
-  // safer than emitting a contaminated pair.
-  const fileCountByIssue = new Map<number, Set<string>>();
-  for (const candidate of eventWindowCandidates) {
-    const filesForIssue =
-      fileCountByIssue.get(candidate.issueNumber) ?? new Set();
-    filesForIssue.add(candidate.fileBasename);
-    fileCountByIssue.set(candidate.issueNumber, filesForIssue);
-  }
-  for (const candidate of eventWindowCandidates) {
-    const contributingFiles = fileCountByIssue.get(candidate.issueNumber);
-    if ((contributingFiles?.size ?? 0) > 1) {
-      process.stderr.write(
-        `token-cost-harvest: skipping event-window issue #${candidate.issueNumber}: matched by more than one project log file (${[...(contributingFiles ?? [])].join(', ')})\n`,
-      );
-      continue;
-    }
+  const harvestEventWindowCandidate = (
+    issueNumber: number,
+    fileBasename: string,
+    records: unknown[],
+  ): void => {
     try {
       const eventWindowResult = claudeAdapter.harvest({
-        records: candidate.records,
-        fileBasename: candidate.fileBasename,
-        issueNumberOverride: candidate.issueNumber,
+        records,
+        fileBasename,
+        issueNumberOverride: issueNumber,
       } satisfies ClaudeHarvestInput);
       out.push({
         vendor: 'claude',
         adapterResult: eventWindowResult,
-        timeline: extractClaudeUsageTimeline(candidate.records),
+        timeline: extractClaudeUsageTimeline(records),
       });
     } catch (error) {
       process.stderr.write(
-        `token-cost-harvest: skipping event-window issue #${candidate.issueNumber}: ${(error as Error).message}\n`,
+        `token-cost-harvest: skipping event-window issue #${issueNumber}: ${(error as Error).message}\n`,
       );
     }
+  };
+
+  // Cross-file resolution: event windows carry no session/file identity,
+  // so more than one project log file can independently match the same
+  // issue. Two distinct producers of that shape need different handling
+  // -- see the #2425 rationale on this function's own docstring above.
+  const candidatesByIssue = new Map<
+    number,
+    { fileBasename: string; records: unknown[] }[]
+  >();
+  for (const candidate of eventWindowCandidates) {
+    const list = candidatesByIssue.get(candidate.issueNumber) ?? [];
+    list.push({
+      fileBasename: candidate.fileBasename,
+      records: candidate.records,
+    });
+    candidatesByIssue.set(candidate.issueNumber, list);
+  }
+  for (const [issueNumber, fileCandidates] of candidatesByIssue) {
+    if (fileCandidates.length === 1) {
+      harvestEventWindowCandidate(
+        issueNumber,
+        fileCandidates[0].fileBasename,
+        fileCandidates[0].records,
+      );
+      continue;
+    }
+    const ranges = fileCandidates.map((candidate) =>
+      computeRecordTimeRange(candidate.records, extractRecordTimestampMs),
+    );
+    const fileNames = fileCandidates.map((candidate) => candidate.fileBasename);
+    const anyOverlap = ranges.some((a, i) =>
+      ranges.some(
+        (b, j) =>
+          i < j && a !== undefined && b !== undefined && rangesOverlap(a, b),
+      ),
+    );
+    // Classify-only: both shapes still skip (see the #2425 rationale on
+    // this function's own docstring above for why a disjoint-range merge
+    // was investigated and rejected). The distinction is diagnostic only
+    // -- it tells a maintainer reading stderr which residual gap this
+    // instance is, without changing behavior for either.
+    const classification = anyOverlap
+      ? 'overlapping activity ranges'
+      : 'disjoint activity ranges -- resolvable once events carry session identity, #2424';
+    process.stderr.write(
+      `token-cost-harvest: skipping event-window issue #${issueNumber}: matched by more than one project log file (${classification}: ${fileNames.join(', ')})\n`,
+    );
   }
   return out;
 }

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -735,6 +735,45 @@ test('scanClaudeVendorSessions: two DIFFERENT project log files both matching th
   assert.ok(sessions.every((s) => s.adapterResult.joinHints === undefined));
 });
 
+test('scanClaudeVendorSessions: two DIFFERENT project log files matching the same issue window with DISJOINT (non-overlapping) activity ranges are STILL both dropped, not merged (#2425 -- merge investigated and rejected, see docstring)', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-ew-disjointA.jsonl'),
+    // Clearly-disjoint, wide-ish range: 00:10 to 00:14.
+    '{"type":"assistant","timestamp":"2026-01-01T00:10:00.000Z","sessionId":"sess-ew-disjointA-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}\n' +
+      '{"type":"assistant","timestamp":"2026-01-01T00:14:00.000Z","sessionId":"sess-ew-disjointA-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}\n',
+  );
+  writeFileSync(
+    join(sandbox, 'session-ew-disjointB.jsonl'),
+    // A DIFFERENT file, entirely after fileA's range ends: 00:18 to 00:20.
+    // A naive range-disjointness check would call these two files
+    // "sequential continuations" and merge them; #2425 rejected that --
+    // sparse candidates like these are indistinguishable from an
+    // unrelated concurrent session that just happens not to overlap.
+    '{"type":"assistant","timestamp":"2026-01-01T00:18:00.000Z","sessionId":"sess-ew-disjointB-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":5,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":5}}}\n' +
+      '{"type":"assistant","timestamp":"2026-01-01T00:20:00.000Z","sessionId":"sess-ew-disjointB-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":5,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":5}}}\n',
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '502:claude:work',
+      stageWindow('2026-01-01T00:05:00Z', '2026-01-01T00:25:00Z'),
+    ],
+    [
+      '502:claude:cleanup',
+      stageWindow('2026-01-01T00:26:00Z', '2026-01-01T00:30:00Z'),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew'),
+  );
+
+  assert.equal(ewSamples.length, 0);
+  assert.equal(sessions.length, 2);
+  assert.ok(sessions.every((s) => s.adapterResult.joinHints === undefined));
+});
+
 test('scanClaudeVendorSessions: an event window is ignored when the segment already has a cwd-inferred issueNumber', () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
   writeFileSync(

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -735,7 +735,8 @@ test('scanClaudeVendorSessions: two DIFFERENT project log files both matching th
   assert.ok(sessions.every((s) => s.adapterResult.joinHints === undefined));
 });
 
-test('scanClaudeVendorSessions: two DIFFERENT project log files matching the same issue window with DISJOINT (non-overlapping) activity ranges are STILL both dropped, not merged (#2425 -- merge investigated and rejected, see docstring)', () => {
+test('scanClaudeVendorSessions: two DIFFERENT project log files matching the same issue window with DISJOINT (non-overlapping) activity ranges are STILL both dropped, not merged (#2425 -- merge investigated and rejected, see docstring)', (t) => {
+  const stderrWrite = t.mock.method(process.stderr, 'write', () => true);
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
   writeFileSync(
     join(sandbox, 'session-ew-disjointA.jsonl'),
@@ -772,6 +773,17 @@ test('scanClaudeVendorSessions: two DIFFERENT project log files matching the sam
   assert.equal(ewSamples.length, 0);
   assert.equal(sessions.length, 2);
   assert.ok(sessions.every((s) => s.adapterResult.joinHints === undefined));
+
+  const skipMessages = stderrWrite.mock.calls
+    .map((call) => call.arguments[0])
+    .filter(
+      (message): message is string =>
+        typeof message === 'string' &&
+        message.includes('skipping event-window issue #502'),
+    );
+  assert.equal(skipMessages.length, 1);
+  assert.match(skipMessages[0], /disjoint activity ranges/);
+  assert.match(skipMessages[0], /#2424/);
 });
 
 test('scanClaudeVendorSessions: an event window is ignored when the segment already has a cwd-inferred issueNumber', () => {


### PR DESCRIPTION
## Summary

Closes #2425.

Investigated merging same-issue event-window candidates across files when their matched-record time ranges are disjoint (the fix #2425 originally proposed), implemented it, then **rejected it before shipping any behavior change**. Behavior for #2418's original cross-file finding is unchanged (existing regression test untouched); this diff is diagnostics plus tests locking the "still skip" decision in.

## Why the merge was rejected

#2419 found that #2418's cross-file guard (skip whenever a same-issue event-window match spans more than one project log file) blocks 10 of 12 completed issue-loop windows on this workstation, and originally guessed the cause was Claude Code's own context-compaction/resume splitting one continuous session across files -- a "sequential continuation" that a disjoint-time-range merge could safely recover.

Checked that guess directly against the two largest contributing files' own first/last record timestamps: both span the SAME ~24-hour wall-clock range end to end, both with a most-recent record from seconds ago. That's genuinely concurrently ACTIVE files, not one ending where another begins -- real concurrent session activity (this repo's own "other sessions may run in parallel" case), not compaction. Compaction, as observed on this workstation, does not appear to split a session's own JSONL file at all.

With that premise gone, the disjoint-merge design was still implemented to see whether it was worth keeping anyway -- and a second problem surfaced: a range-disjointness check is a weak discriminator for SPARSE candidates. A single stray record from an unrelated concurrent session can never "overlap" anything by definition, so it would get merged just as readily as a genuine continuation would. That's exactly the shape #2418's own review already wrote a regression test to prevent (`scanClaudeVendorSessions: two DIFFERENT project log files both matching the same issue window are BOTH dropped`) -- shipping the merge would have required inverting that test's expectation to recover a scenario that doesn't actually occur on this workstation. No sample beats a wrong one.

## Change

`scanClaudeVendorSessions`'s cross-file resolution (`src/scripts/token-cost-harvest.mts`) keeps #2418's exact behavior -- skip every same-issue match spanning more than one file -- for both classifications. The only change is diagnostic: stderr now says whether the skip was due to **overlapping** or **disjoint** matched-record ranges, and the disjoint message points at #2424 (session/attempt identity), the actual path to resolving that case safely without a timestamp heuristic.

## Follow-up

Posted corrections on #2425 and #2426 (both authored by this session) reflecting the rejected-merge outcome, and a comment on #2424 with a verified design seed: `schemas/token-cost-event.schema.json` already has an unused `vendorSessionId` field, and `$CLAUDE_CODE_SESSION_ID` (a live env var) matches the current session's own `.jsonl` basename exactly -- confirmed directly on this workstation. Stamping that into `vendorSessionId` on every `token-cost-event.mjs` call and matching it against each candidate file's own `extractSessionId()` would resolve the genuine-overlap case deterministically, no new schema field needed.

## Test plan

- [x] The existing #2418 cross-file ambiguity regression test (`two DIFFERENT project log files both matching the same issue window are BOTH dropped`) passes **unmodified**.
- [x] New test: two files with clearly disjoint, wide-ish time ranges for the same issue still produce zero `#ew` samples (locks the rejected-merge decision in).
- [x] `node --test tests/token-cost-harvest.test.mts` -- 65/65 pass.
- [x] `pnpm test` -- 4638/4638 pass, no regressions.
- [x] Re-ran the harvester directly against this workstation's real `events.jsonl` / Claude project logs before and after: identical `n=0` issue-loop attribution, stderr lines now classified as "overlapping activity ranges" for every real instance observed.
- [x] `pnpm run typecheck`, `pnpm run build`, `pnpm run lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtcjhuuXDqQASYGXtJnmV3
