### PR TITLE
refactor(provider): route change review CI and merge through the adapter

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -15,6 +15,7 @@ words:
   - Kiro
   - kurone
   - ONNX
+  - octocat
   - pylint
   - pytest
   - pyproject

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -113,13 +113,6 @@ import {
   normalizeAuthorityEvidence,
   resolveCollaboratorAuthority,
 } from './external-check-waiver.mjs';
-import {
-  GH_TEXT_LOOP_OPTIONS,
-  ghApiJson,
-  ghGraphql,
-  ghText,
-  safeGhText,
-} from './gh-exec.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import { isValidIsoTimestamp, parseClaimComment } from './marker-helpers.mjs';
 import {
@@ -139,6 +132,11 @@ import {
   summarizeDispositionEvidenceForGate,
   summarizeExternalCheckWaivers,
 } from './protocol-helpers.mjs';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mjs';
+import { evaluateProviderCapabilityOutcome } from './provider-contract.mjs';
 import {
   evaluateProviderOutageRelief,
   resolveProviderOutageDeclaration,
@@ -1500,15 +1498,15 @@ export function runAdvisoryConvergenceWithPoll(
 }
 // --- Production I/O: fetch PR/review/thread/comment evidence via `gh` ----
 /**
- * `gh` options for the viewer-login probe (`gh api user`).
+ * `gh` stdio policy for the viewer-login probe (`gh api user`).
  *
  * Under GitHub Actions the workflow token is a GitHub App installation token
  * with no authenticated user, so `gh api user` always returns 403 ("Resource
  * not accessible by integration"). That is expected and harmless here:
- * {@link safeGhText} swallows it and `viewerLogin === ''` is the correct value
- * in CI (there is no runner "self" whose markers should be trusted). Only the
- * inherited stderr leaks the confusing 403 line into the run log, so under
- * Actions we capture that run's stderr (`stdio` pipe) to keep the log clean.
+ * `viewerLogin === ''` is the correct value in CI (there is no runner "self"
+ * whose markers should be trusted). Only the inherited stderr leaks the
+ * confusing 403 line into the run log, so under Actions we capture that
+ * run's stderr (`stdio` pipe) to keep the log clean.
  *
  * Outside Actions (a local/interactive run) the probe normally succeeds; if it
  * genuinely fails we deliberately **inherit** stderr so the failure stays
@@ -1519,8 +1517,14 @@ export function runAdvisoryConvergenceWithPoll(
  * `execFileSync`'s default: that default already writes the child's stderr to
  * the parent (so a bare call would leak the 403), but relying on it is
  * non-obvious. `pipe` captures stderr (silent); `inherit` forwards it to the
- * parent (visible). stdin is `ignore` on both, matching `GH_TEXT_LOOP_OPTIONS`'
- * stdin-safety.
+ * parent (visible). stdin is `ignore` on both.
+ *
+ * #2267: this exact policy now lives inside
+ * `ProviderPort.resolveViewerLoginSafeQuiet`'s GitHub adapter implementation
+ * (`provider-adapter-github.mts`), which `collectFromGitHub` below calls
+ * instead of invoking `gh` directly. Kept here, unused in production, only
+ * because it is directly unit-tested pure logic (no `gh` invocation of its
+ * own) documenting the policy the adapter mirrors.
  */
 export function viewerProbeGhOptions(env = process.env) {
   return {
@@ -1530,17 +1534,28 @@ export function viewerProbeGhOptions(env = process.env) {
         : ['ignore', 'pipe', 'inherit'],
   };
 }
-function collectFromGitHub(args) {
-  const owner =
-    args.owner ||
-    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
-  const repo =
-    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-  const repoRef = `${owner}/${repo}`;
-  const viewerLogin = safeGhText(
-    ['api', 'user', '--jq', '.login'],
-    viewerProbeGhOptions(),
-  ).toLowerCase();
+/**
+ * `createPort` is injectable (defaults to the real GitHub adapter) so a test
+ * can drive this collection entry end to end against
+ * `createFakeProviderAdapter` fixtures instead of a live `gh` process
+ * (#2267 AC4's "unit tests exercise the PR-facing state machine with a fake
+ * provider" -- see the exported `collectFromGitHub` used directly by
+ * `advisory-convergence-fake-provider.test.mts`). `defaultDeps.collect`
+ * (this file's own production wiring for `runAdvisoryConvergence`) never
+ * passes a second argument, so it keeps using the real adapter unchanged.
+ */
+export function collectFromGitHub(
+  args,
+  createPort = createGithubProviderAdapter,
+) {
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createPort(owner, repo);
+  const viewerLogin = port
+    .resolveViewerLoginSafeQuiet()
+    .viewerLogin.toLowerCase();
   const rawConfig = loadIddConfig();
   const { actors: configuredTrustedActors } = resolveTrustedMarkerActors({
     flagValue: args.trustedMarkerLogins,
@@ -1552,30 +1567,18 @@ function collectFromGitHub(args) {
     envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
     config: rawConfig,
   });
-  const pr = JSON.parse(
-    ghText([
-      'pr',
-      'view',
-      String(args.prNumber),
-      '-R',
-      repoRef,
-      '--json',
-      'headRefOid,headRefName,closingIssuesReferences,author,url',
-    ]),
-  );
-  const prHeadSha = String(pr.headRefOid ?? '').toLowerCase();
-  const prHeadRefName = String(pr.headRefName ?? '').trim();
-  const prAuthorLogin = String(pr.author?.login ?? '').toLowerCase();
-  const prUrl = String(pr.url ?? '');
+  const view = port.getChangeRequestConvergenceView(Number(args.prNumber));
+  const prHeadSha = view.headSha.toLowerCase();
+  const prHeadRefName = view.headRefName.trim();
+  const prAuthorLogin = view.authorLogin.toLowerCase();
+  const prUrl = view.url;
+  const closingIssuesReferences = view.closingIssuesReferences;
   // Fetched here (ahead of `trustedMarkerLogins` below) so a collaborator's
   // marker-shaped PR comment can be detected before that set is used to
   // resolve `claimEvents` -- see `resolveTrustedCollaboratorMarkerLogins`.
-  const comments = ghApiJson(
-    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
-    {
-      paginate: true,
-    },
-  );
+  const comments = port
+    .listWorkItemComments(Number(args.prNumber))
+    .map(toIssueCommentPayload);
   // #1344: collaborator-marker trust, matching `pre-merge-readiness.mts`'s
   // `readCollaboratorTrustEnabled` exactly, except reusing the already-
   // loaded `rawConfig` instead of a second `.github/idd/config.json` read
@@ -1589,8 +1592,9 @@ function collectFromGitHub(args) {
     owner,
     repo,
     Number(args.prNumber),
+    port,
   );
-  const threads = fetchReviewThreads(owner, repo, Number(args.prNumber));
+  const threads = fetchReviewThreads(port, Number(args.prNumber));
   // #1347: fetch every claim-issue candidate's raw comments (pure I/O)
   // BEFORE computing `trustedMarkerLogins`, so collaborator-marker trust
   // can be resolved from ALL candidates' comments -- not just whichever
@@ -1602,10 +1606,9 @@ function collectFromGitHub(args) {
   // claim data before that trust is ever computed. See
   // `pickResolvingClaimEvents`'s doc comment for the full history.
   const claimCandidates = fetchClaimEventCandidates(
-    owner,
-    repo,
+    port,
     args.claimIssueNumber,
-    pr.closingIssuesReferences,
+    closingIssuesReferences,
   );
   // Deliberately NOT unioned with `advisoryBotLogins` here (unlike some
   // other locally-collected sets in this file that scope broader trust for
@@ -1633,7 +1636,7 @@ function collectFromGitHub(args) {
     viewerLogin,
     ...configuredTrustedActors,
     ...(collaboratorTrustEnabled
-      ? resolveTrustedCollaboratorMarkerLogins(owner, repo, [
+      ? resolveTrustedCollaboratorMarkerLogins(port, [
           ...comments,
           ...claimCandidates.flat(),
         ])
@@ -1691,10 +1694,9 @@ function collectFromGitHub(args) {
     policy?.providerOutage?.declarationTarget;
   if (outageDeclarationTargetIssue) {
     try {
-      const declarationComments = ghApiJson(
-        `repos/${owner}/${repo}/issues/${outageDeclarationTargetIssue}/comments`,
-        { paginate: true },
-      );
+      const declarationComments = port
+        .listWorkItemComments(outageDeclarationTargetIssue)
+        .map(toIssueCommentPayload);
       const authorityOf = (actorLogin) =>
         normalizeAuthorityEvidence(
           resolveCollaboratorAuthority({ owner, repo, actor: actorLogin }),
@@ -1733,10 +1735,7 @@ function collectFromGitHub(args) {
   let prFirstCommitAt = null;
   if (forcedHandoffEnabled) {
     try {
-      const prCommits = ghApiJson(
-        `repos/${owner}/${repo}/pulls/${args.prNumber}/commits`,
-        { paginate: true },
-      );
+      const prCommits = port.listChangeRequestCommits(Number(args.prNumber));
       prFirstCommitAt = resolvePrFirstCommitAt(prCommits);
     } catch {
       prFirstCommitAt = null;
@@ -1766,15 +1765,32 @@ function collectFromGitHub(args) {
   // treats only exact human-required / no-advisory as skip, so an
   // invalid string still keeps today's Copilot / primaryBotLogin
   // applicability.
-  const reviewPolicy =
-    typeof rawConfig?.reviewPolicy === 'string'
+  //
+  // #2267: a provider that declares its `advisory-review` capability
+  // unsupported (a non-GitHub adapter with no equivalent advisory
+  // reviewer) coerces this gate to the same `'no-advisory'` skip a
+  // repository can already opt into by config -- reusing the #2137-tested
+  // skip path instead of adding a second one, and inert for GitHub, whose
+  // adapter always declares every capability supported (see
+  // `listCapabilityDeclarations`).
+  const advisoryReviewDeclaration = port
+    .listCapabilityDeclarations()
+    .find((declaration) => declaration.group === 'advisory-review');
+  const advisoryReviewUnsupported = Boolean(
+    advisoryReviewDeclaration &&
+      evaluateProviderCapabilityOutcome(advisoryReviewDeclaration) ===
+        'not_applicable',
+  );
+  const reviewPolicy = advisoryReviewUnsupported
+    ? 'no-advisory'
+    : typeof rawConfig?.reviewPolicy === 'string'
       ? rawConfig.reviewPolicy
       : undefined;
   let prAuthorIsBot = false;
   if (exemptBotAuthoredPrs && convergenceScope === 'all-prs') {
     try {
       prAuthorIsBot =
-        fetchPrAuthor(owner, repo, Number(args.prNumber))?.__typename === 'Bot';
+        fetchPrAuthor(port, Number(args.prNumber))?.__typename === 'Bot';
     } catch {
       prAuthorIsBot = false;
     }
@@ -1844,17 +1860,11 @@ function collectFromGitHub(args) {
  * same normalization for the identical reason; mirrored here rather than
  * imported since it is not exported.
  */
-function fetchClaimComments(owner, repo, issueNumber) {
-  const raw = ghApiJson(
-    `repos/${owner}/${repo}/issues/${issueNumber}/comments`,
-    {
-      paginate: true,
-    },
-  );
-  return raw.map((comment) => ({
-    body: comment.body ?? '',
-    createdAt: comment.createdAt ?? comment.created_at ?? '',
-    author: { login: comment.author?.login ?? comment.user?.login ?? '' },
+function fetchClaimComments(port, issueNumber) {
+  return port.listWorkItemComments(issueNumber).map((comment) => ({
+    body: comment.body,
+    createdAt: comment.createdAt,
+    author: { login: comment.authorLogin },
   }));
 }
 /**
@@ -1874,9 +1884,9 @@ function fetchClaimComments(owner, repo, issueNumber) {
  * place, discarding the real claim data before that trust is ever folded
  * in.
  */
-function fetchClaimEventCandidates(owner, repo, explicitIssueNumber, refs) {
+function fetchClaimEventCandidates(port, explicitIssueNumber, refs) {
   if (explicitIssueNumber) {
-    return [fetchClaimComments(owner, repo, explicitIssueNumber)];
+    return [fetchClaimComments(port, explicitIssueNumber)];
   }
   const candidateNumbers = [
     ...new Set(
@@ -1884,7 +1894,7 @@ function fetchClaimEventCandidates(owner, repo, explicitIssueNumber, refs) {
     ),
   ];
   return candidateNumbers.map((issueNumber) =>
-    fetchClaimComments(owner, repo, issueNumber),
+    fetchClaimComments(port, issueNumber),
   );
 }
 /** Candidate claim-issue comment streams whose *active claim* actually
@@ -2070,11 +2080,7 @@ export function resolveClaimEvidence(
  * when `markerTrust.allowCollaboratorMarkers` / `IDD_TRUST_COLLABORATOR_MARKERS`
  * is enabled -- a no-op repository never pays for these lookups.
  */
-function resolveTrustedCollaboratorMarkerLogins(
-  owner,
-  repo,
-  commentLikeEvents,
-) {
+function resolveTrustedCollaboratorMarkerLogins(port, commentLikeEvents) {
   const markerAuthors = [
     ...new Set(
       commentLikeEvents
@@ -2086,15 +2092,8 @@ function resolveTrustedCollaboratorMarkerLogins(
     ),
   ];
   return markerAuthors.filter((login) => {
-    const permission = safeGhText(
-      [
-        'api',
-        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-        '--jq',
-        '.permission',
-      ],
-      GH_TEXT_LOOP_OPTIONS,
-    ).toLowerCase();
+    const result = port.getCollaboratorPermission(login);
+    const permission = result.outcome === 'found' ? result.permission : '';
     return (
       permission === 'admin' ||
       permission === 'maintain' ||
@@ -2102,17 +2101,29 @@ function resolveTrustedCollaboratorMarkerLogins(
     );
   });
 }
-// `ghGraphql` now lives in `gh-exec.mts` (imported above) and
-// `fetchReviewsAndHeadCommit` (+ its local `RawReviewNode` shape) now
-// lives in `review-clause.mts` (imported above) -- both used here
-// unchanged. The other two `ghGraphql(...)` call sites in this file
-// (`fetchReviewThreads` and the claim-candidate fetch below) keep calling
-// the same function via the new import.
-/** #1906: fetch the PR's own author `login`/`__typename` via a small
- * dedicated GraphQL query -- the REST-shaped `gh pr view --json author`
- * fetch in `collectFromGitHub` only returns `login`, no type
- * discriminator. Deliberately its own minimal round trip rather than
- * folded into `fetchReviewThreads` below or `fetchReviewsAndHeadCommit`
+/**
+ * Map a `ProviderPort.listWorkItemComments` result back onto the REST
+ * `issues/{n}/comments` shape this file's `resolveTrustedCollaboratorMarkerLogins`
+ * (and `inputs.comments`, consumed by `summarizeDispositionEvidenceForGate`)
+ * already expect -- mirrors `pre-merge-readiness.mts`'s own shim of the same
+ * name for the identical reason (keeps every downstream consumer
+ * byte-identical instead of reshaping it for the port's flat `authorLogin`
+ * field).
+ */
+function toIssueCommentPayload(comment) {
+  return {
+    id: comment.id,
+    body: comment.body,
+    author: { login: comment.authorLogin },
+    createdAt: comment.createdAt,
+    updatedAt: comment.updatedAt,
+  };
+}
+/** #1906: fetch the PR's own author `login`/`__typename` via
+ * {@link ProviderPort.getChangeRequestAuthor} -- the REST-shaped `pr view
+ * --json author` fetch in `collectFromGitHub` only returns `login`, no type
+ * discriminator. Deliberately its own minimal round trip rather than folded
+ * into `fetchReviewThreads` below or `fetchReviewsAndHeadCommit`
  * (review-clause.mts): both of those are narrowly-scoped Copilot-review
  * evidence collectors, the latter shared verbatim with
  * `rerun-advisory-convergence.mts`, and widening either with an unrelated
@@ -2120,111 +2131,41 @@ function resolveTrustedCollaboratorMarkerLogins(
  * `collectFromGitHub` only when the opt-in `exemptBotAuthoredPrs` policy
  * is enabled (see the call site), so a repository that never sets the
  * flag never pays for this extra request. */
-function fetchPrAuthor(owner, repo, prNumber) {
-  const payload = ghGraphql(
-    `
-      query($owner: String!, $repo: String!, $number: Int!) {
-        repository(owner: $owner, name: $repo) {
-          pullRequest(number: $number) {
-            author { login __typename }
-          }
-        }
-      }`,
-    { owner, repo, number: prNumber },
-  );
-  return payload?.data?.repository?.pullRequest?.author ?? null;
+function fetchPrAuthor(port, prNumber) {
+  const author = port.getChangeRequestAuthor(prNumber);
+  return author ? { login: author.login, __typename: author.typename } : null;
 }
-function fetchReviewThreads(owner, repo, prNumber) {
-  const nodes = [];
-  let cursor = null;
-  while (true) {
-    const payload = ghGraphql(
-      `
-        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
-          repository(owner: $owner, name: $repo) {
-            pullRequest(number: $number) {
-              reviewThreads(first: 100, after: $cursor) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  id
-                  isResolved
-                  comments(first: 100) {
-                    pageInfo { hasNextPage endCursor }
-                    nodes {
-                      body
-                      createdAt
-                      updatedAt
-                      author { login __typename }
-                      pullRequestReview { id }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }`,
-      { owner, repo, number: prNumber, cursor },
-    );
-    const reviewThreads = payload?.data?.repository?.pullRequest?.reviewThreads;
-    for (const thread of reviewThreads?.nodes ?? []) {
-      if (thread.comments?.pageInfo?.hasNextPage) {
-        if (!thread.id || !thread.comments.pageInfo.endCursor) {
-          throw new Error(
-            'review thread pagination payload is missing id or endCursor',
-          );
-        }
-        thread.comments.nodes.push(
-          ...fetchThreadCommentPages(
-            thread.id,
-            thread.comments.pageInfo.endCursor,
-          ),
-        );
-        thread.comments.pageInfo.hasNextPage = false;
-      }
-    }
-    nodes.push(...(reviewThreads?.nodes ?? []));
-    if (!reviewThreads?.pageInfo?.hasNextPage) break;
-    if (!reviewThreads.pageInfo.endCursor) {
-      throw new Error('review thread pagination payload is missing endCursor');
-    }
-    cursor = reviewThreads.pageInfo.endCursor;
-  }
-  return nodes;
+/** Map a `ProviderPort.listChangeRequestReviewThreadsWithAuthorType` node
+ * back onto this file's own `ReviewThreadPayload` shape (the
+ * `{comments: {pageInfo, nodes}}` wrapper `classifyCopilotAuthoredThreadIds`
+ * / `classifyThreadIdsForReview` / `summarizeDispositionEvidenceForGate`
+ * already expect and are directly tested against) -- same shim strategy as
+ * {@link toIssueCommentPayload}. `pageInfo.hasNextPage` is always `false`:
+ * the port's `fetchReviewThreadsGeneric` already fully paginates every
+ * thread's comments before returning. */
+function toReviewThreadPayload(node) {
+  return {
+    id: node.id,
+    isResolved: node.isResolved,
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: node.comments.map((comment) => ({
+        body: comment.body,
+        createdAt: comment.createdAt,
+        updatedAt: comment.updatedAt,
+        author: {
+          login: comment.authorLogin,
+          __typename: comment.authorTypename,
+        },
+        pullRequestReview: { id: comment.pullRequestReviewId },
+      })),
+    },
+  };
 }
-function fetchThreadCommentPages(threadId, afterCursor) {
-  const nodes = [];
-  let cursor = afterCursor;
-  while (cursor) {
-    const payload = ghGraphql(
-      `
-        query($id: ID!, $cursor: String) {
-          node(id: $id) {
-            ... on PullRequestReviewThread {
-              comments(first: 100, after: $cursor) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  body
-                  createdAt
-                  updatedAt
-                  author { login __typename }
-                  pullRequestReview { id }
-                }
-              }
-            }
-          }
-        }`,
-      { id: threadId, cursor },
-    );
-    const comments = payload?.data?.node?.comments;
-    nodes.push(...(comments?.nodes ?? []));
-    if (comments?.pageInfo?.hasNextPage && !comments.pageInfo.endCursor) {
-      throw new Error('thread comment pagination payload is missing endCursor');
-    }
-    cursor = comments?.pageInfo?.hasNextPage
-      ? comments.pageInfo.endCursor
-      : null;
-  }
-  return nodes;
+function fetchReviewThreads(port, prNumber) {
+  return port
+    .listChangeRequestReviewThreadsWithAuthorType(prNumber)
+    .map(toReviewThreadPayload);
 }
 /**
  * Structured next-action catalog for a non-ready verdict (#2143).

--- a/scripts/advisory-wait-state.mjs
+++ b/scripts/advisory-wait-state.mjs
@@ -14,12 +14,6 @@ import {
   readAdvisoryWaitPolicy,
 } from './advisory-wait-policy.mjs';
 import { parseCliArgs } from './cli-args.mjs';
-import {
-  DEFAULT_GH_PAGINATED_TIMEOUT_MS,
-  ghGraphql,
-  ghText,
-  safeGhText,
-} from './gh-exec.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import {
   buildAdvisoryWaitSummary,
@@ -30,9 +24,12 @@ import {
   isValidIsoTimestamp,
   normalizeTrustedMarkerLogins,
   parseAdvisoryRecoveryComment,
-  parsePaginatedGhNdjson,
   resolveTrustedMarkerActors,
 } from './protocol-helpers.mjs';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mjs';
 
 const COPILOT_RECOVERY_REASONS = {
   activeClaimNotProvided: 'active-claim-not-provided',
@@ -401,52 +398,25 @@ function main() {
   if (!args.prNumber) {
     throw new Error('missing required --pr <number> argument');
   }
-  const owner =
-    args.owner ||
-    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
-  const repo =
-    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-  const repoRef = `${owner}/${repo}`;
-  const viewerLogin = safeGhText([
-    'api',
-    'user',
-    '--jq',
-    '.login',
-  ]).toLowerCase();
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createGithubProviderAdapter(owner, repo);
+  const viewerLogin = port.resolveViewerLoginSafe().viewerLogin;
   const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
     resolveTrustedMarkerActors({
       flagValue: args.trustedMarkerLogins,
       envValue: process.env.IDD_TRUSTED_MARKER_ACTORS,
       config: loadIddConfig(),
     });
-  const prHeadSha = ghText([
-    'pr',
-    'view',
-    String(args.prNumber),
-    '-R',
-    repoRef,
-    '--json',
-    'headRefOid',
-    '--jq',
-    '.headRefOid',
-  ]);
-  const reviews = ghApiJson(
-    `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
-    true,
-  );
-  const requestedReviewers = ghApiJson(
-    `repos/${owner}/${repo}/pulls/${args.prNumber}/requested_reviewers`,
-    false,
-  );
-  const timelineEvents = ghApiJson(
-    `repos/${owner}/${repo}/issues/${args.prNumber}/timeline`,
-    true,
-    ['-H', 'Accept: application/vnd.github+json'],
-  );
-  const comments = ghApiJson(
-    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
-    true,
-  );
+  const prHeadSha = port.getChangeRequestHeadSha(args.prNumber);
+  const reviews = port.listReviews(args.prNumber);
+  const restRequestedReviewers = port
+    .getChangeRequestRequestedReviewerLogins(args.prNumber)
+    .map((login) => ({ login }));
+  const timelineEvents = port.getWorkItemTimeline(args.prNumber);
+  const comments = port.listWorkItemComments(args.prNumber);
   const collaboratorTrustEnabled = isTruthy(
     process.env.IDD_TRUST_COLLABORATOR_MARKERS,
   );
@@ -454,7 +424,7 @@ function main() {
     viewerLogin,
     ...configuredTrustedActors,
     ...(collaboratorTrustEnabled
-      ? resolveTrustedCollaboratorMarkerLogins(owner, repo, comments)
+      ? resolveTrustedCollaboratorMarkerLogins(port, comments)
       : []),
   ]);
   const advisoryWaitPolicy = readAdvisoryWaitPolicy();
@@ -465,7 +435,6 @@ function main() {
   // resolveCopilotPending's own precedence (protocol-helpers.mts) so this
   // pre-check and the pure function it feeds never disagree on when a
   // GraphQL fallback is actually needed.
-  const restRequestedReviewers = requestedReviewers.users ?? [];
   const restCopilotPending = isCopilotPending(
     restRequestedReviewers,
     primaryBotLogin,
@@ -482,7 +451,7 @@ function main() {
       copilotPendingCoversHeadForGraphqlGate &&
       lastCopilotCommitForGraphqlGate !== prHeadSha
     )
-      ? fetchGraphqlRequestedReviewerLogins(owner, repo, args.prNumber)
+      ? port.getChangeRequestRequestedReviewerLoginsGraphql(args.prNumber)
       : null;
   const summary = buildAdvisoryWaitSummary(
     {
@@ -596,27 +565,24 @@ fails closed to NOT_TERMINAL with reason: active-claim-not-provided.
 }
 function normalizeComment(comment) {
   return {
-    author: { login: comment.user?.login ?? '' },
-    body: comment.body ?? '',
-    createdAt: comment.created_at ?? '',
+    author: { login: comment.authorLogin },
+    body: comment.body,
+    createdAt: comment.createdAt,
   };
 }
-function resolveTrustedCollaboratorMarkerLogins(owner, repo, comments) {
+function resolveTrustedCollaboratorMarkerLogins(port, comments) {
   const advisoryAuthors = [
     ...new Set(
       comments
-        .filter((comment) => advisoryMarkerComment(comment.body ?? ''))
-        .map((comment) => comment.user?.login ?? '')
+        .filter((comment) => advisoryMarkerComment(comment.body))
+        .map((comment) => comment.authorLogin)
         .filter(Boolean),
     ),
   ];
   return advisoryAuthors.filter((login) => {
-    const permission = safeGhText([
-      'api',
-      `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-      '--jq',
-      '.permission',
-    ]).toLowerCase();
+    const outcome = port.getCollaboratorPermission(login);
+    const permission =
+      outcome.outcome === 'found' ? outcome.permission.toLowerCase() : '';
     return (
       permission === 'admin' ||
       permission === 'maintain' ||
@@ -635,63 +601,4 @@ export function advisoryMarkerComment(body) {
 }
 function isTruthy(value) {
   return /^(1|true|yes)$/i.test(String(value ?? '').trim());
-}
-function ghApiJson(path, paginate = false, extraArgs = []) {
-  const args = ['api', path, ...extraArgs];
-  if (paginate) {
-    // gh api with --paginate and --jq '.[]' emits one JSON object per line.
-    // --slurp landed in gh v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0
-    // via apt, so keep the NDJSON-compatible form here.
-    args.splice(1, 0, '--paginate', '--jq', '.[]');
-    return parsePaginatedGhNdjson(
-      ghText(args, { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS }),
-    );
-  }
-  return JSON.parse(ghText(args));
-}
-/**
- * #2167: REST `requested_reviewers` can report empty even when Copilot
- * review is still genuinely outstanding -- see `resolveCopilotPending`'s
- * doc comment in protocol-helpers.mts for the observed incident this
- * fixes. `main()` below calls this only when REST and already-fetched
- * timeline evidence are both inconclusive, so this optional GraphQL call
- * is skipped whenever a cheaper signal already resolves pending state.
- *
- * Returns the requested-reviewer login list on success, or `null` on any
- * failure (network error, non-2xx response, unparsable payload) so the
- * caller falls back to the REST-derived result rather than assuming
- * pending -- a GraphQL 4xx must never read as "pending".
- */
-function fetchGraphqlRequestedReviewerLogins(owner, repo, prNumber) {
-  try {
-    const query = `
-      query($owner: String!, $repo: String!, $number: Int!) {
-        repository(owner: $owner, name: $repo) {
-          pullRequest(number: $number) {
-            reviewRequests(first: 100) {
-              nodes {
-                requestedReviewer {
-                  ... on Bot { login }
-                  ... on User { login }
-                  ... on Mannequin { login }
-                }
-              }
-            }
-          }
-        }
-      }
-    `;
-    const payload = ghGraphql(query, {
-      owner,
-      repo,
-      number: prNumber,
-    });
-    const nodes =
-      payload.data?.repository?.pullRequest?.reviewRequests?.nodes ?? [];
-    return nodes
-      .map((node) => String(node?.requestedReviewer?.login ?? ''))
-      .filter((login) => login !== '');
-  } catch {
-    return null;
-  }
 }

--- a/scripts/ci-wait-policy.mjs
+++ b/scripts/ci-wait-policy.mjs
@@ -7,7 +7,10 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { parseCanonicalIntegerOrThrow, parseCliArgs } from './cli-args.mjs';
-import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mjs';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mjs';
 import { loadJson, validateConfigSection } from './validate-schemas.mjs';
 
 const DEFAULT_RUNNING_TIMEOUT = 'PT30M';
@@ -267,8 +270,9 @@ export function deriveRerunCountFromRunAttempt(runAttempt) {
 /**
  * Fetch the live Actions run `runId` (`GET
  * repos/{owner}/{repo}/actions/runs/{run_id}`) and derive its rerun count
- * via {@link deriveRerunCountFromRunAttempt}. Reuses the same
- * `ghText`/`GH_TEXT_LOOP_TIMEOUT_OPTIONS` timeout-guarded pattern
+ * via {@link deriveRerunCountFromRunAttempt}. Routed through
+ * provider-port.mts's `getWorkflowRun` (#2267), which reuses the same
+ * timeout-guarded `GH_TEXT_LOOP_TIMEOUT_OPTIONS` pattern
  * `rerun-advisory-convergence.mts`'s `collectFromGitHub` already uses for
  * the identical per-run `run_attempt` lookup, so a stalled or
  * unexpectedly-interactive `gh` call here fails closed within a bounded
@@ -280,11 +284,11 @@ export function fetchRerunCountFromRunId(owner, repo, runId) {
   );
 }
 export function fetchWorkflowRun(owner, repo, runId) {
-  const raw = ghText(
-    ['api', `repos/${owner}/${repo}/actions/runs/${runId}`],
-    GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  return createGithubProviderAdapter(owner, repo).getWorkflowRun(
+    owner,
+    repo,
+    runId,
   );
-  return JSON.parse(raw);
 }
 export function siblingSweepQuery(workflowName) {
   return `gh run list --workflow=${JSON.stringify(workflowName)} --limit ${String(SIBLING_SWEEP_LIMIT)}`;
@@ -300,31 +304,12 @@ function normalizeRerunPolicy(value) {
   return RERUN_POLICIES.has(text) ? text : DEFAULT_RERUN_POLICY;
 }
 function fetchSiblingWorkflowRuns(owner, repo, workflowName) {
-  const raw = ghText(
-    [
-      'run',
-      'list',
-      '--repo',
-      `${owner}/${repo}`,
-      '--workflow',
-      workflowName,
-      '--limit',
-      String(SIBLING_SWEEP_LIMIT),
-      '--json',
-      'databaseId,conclusion,status,createdAt',
-    ],
-    GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  return createGithubProviderAdapter(owner, repo).listWorkflowRuns(
+    owner,
+    repo,
+    workflowName,
+    SIBLING_SWEEP_LIMIT,
   );
-  const rows = JSON.parse(raw);
-  if (!Array.isArray(rows)) {
-    return [];
-  }
-  return rows.map((row) => ({
-    id: String(row.databaseId ?? ''),
-    conclusion: row.conclusion == null ? null : String(row.conclusion),
-    status: row.status == null ? null : String(row.status),
-    createdAt: row.createdAt == null ? null : String(row.createdAt),
-  }));
 }
 function runCli() {
   const args = parseArgs(process.argv.slice(2));
@@ -349,18 +334,10 @@ function runCli() {
     // pass; regression-guarded by the "resolves owner/repo INSIDE the
     // fallback" CLI test below).
     try {
-      const owner =
-        args.owner ||
-        ghText(
-          ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
-          GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-        );
-      const repo =
-        args.repo ||
-        ghText(
-          ['repo', 'view', '--json', 'name', '--jq', '.name'],
-          GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-        );
+      const currentRepo =
+        args.owner && args.repo ? null : resolveCurrentGithubRepository();
+      const owner = args.owner || currentRepo?.owner || '';
+      const repo = args.repo || currentRepo?.repo || '';
       const run = fetchWorkflowRun(owner, repo, args.runId);
       rerunCount = deriveRerunCountFromRunAttempt(run.run_attempt);
       output.rerunCountSource = 'run-id';

--- a/scripts/ci-wait-state.mjs
+++ b/scripts/ci-wait-state.mjs
@@ -22,16 +22,17 @@
 //   read time, so a caller polling in a loop can detect the branch moving
 //   out from under an in-flight wait.
 import { parseCliArgs } from './cli-args.mjs';
-import { DEFAULT_GH_PAGINATED_TIMEOUT_MS, ghText } from './gh-exec.mjs';
-import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import { normalizePolicyConfig } from './policy-helpers.mjs';
 import {
   CI_FAILURE_CONCLUSION_STATES,
-  parsePaginatedGhNdjson,
   selectLatestCheckInstance,
   summarizeBranchReviewRequirements,
 } from './protocol-helpers.mjs';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mjs';
 
 // Interpretation table this bucketing is based on: idd-ci.instructions.md's
 // "Interpretation" section. Keep these three sets in sync with that table's
@@ -108,32 +109,29 @@ function main() {
     // invalid value as absent.
     throw new Error('missing or invalid --pr <number> argument');
   }
-  const owner =
-    args.owner ||
-    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
-  const repo =
-    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-  const repoRef = `${owner}/${repo}`;
-  const pr = JSON.parse(
-    ghText([
-      'pr',
-      'view',
-      String(args.prNumber),
-      '-R',
-      repoRef,
-      '--json',
-      'headRefOid,baseRefName,statusCheckRollup',
-    ]),
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createGithubProviderAdapter(owner, repo);
+  const pr = port.getChangeRequestBranchAndChecks(args.prNumber);
+  // Raw (unencoded) branch name: listBranchRules/getBranchProtection do
+  // their own encodeURIComponent internally, matching pre-merge-readiness's
+  // and #2267's other listBranchRules/getBranchProtection callers -- passing
+  // an already-encoded ref here would double-encode it.
+  const baseRefName = String(pr.baseRefName ?? '');
+  const branchRulesOutcome = port.listBranchRules(owner, repo, baseRefName);
+  const branchRules =
+    branchRulesOutcome.outcome === 'ok' ? branchRulesOutcome.value : [];
+  const branchProtectionOutcome = port.getBranchProtection(
+    owner,
+    repo,
+    baseRefName,
   );
-  const encodedBaseRefName = encodeURIComponent(String(pr.baseRefName ?? ''));
-  const branchRules = ghApiJsonOr404Empty(
-    `repos/${owner}/${repo}/rules/branches/${encodedBaseRefName}`,
-    true,
-  );
-  const branchProtection = ghApiJsonOr404Empty(
-    `repos/${owner}/${repo}/branches/${encodedBaseRefName}/protection`,
-    false,
-  );
+  const branchProtection =
+    branchProtectionOutcome.outcome === 'ok'
+      ? branchProtectionOutcome.value
+      : {};
   const branchReviewRequirements = summarizeBranchReviewRequirements(
     branchRules,
     branchProtection,
@@ -145,7 +143,7 @@ function main() {
       .trustSourcePinnedRequiredChecks === true;
   const summary = buildCiWaitStateSummary(
     {
-      headRefOid: pr.headRefOid ?? '',
+      headRefOid: pr.headSha,
       statusCheckRollup: pr.statusCheckRollup ?? [],
     },
     {
@@ -482,44 +480,6 @@ export function parseArgs(argv) {
     repo: values.repo,
     help,
   };
-}
-/**
- * `gh api <path>`, tolerating a genuine 404 (unprotected branch / no active
- * rules) as an empty result. `gh` exits 1 for every HTTP error alike, so the
- * real status is derived from the error text via the shared
- * {@link deriveGhHttpStatus} rather than the useless process exit code —
- * the same discrimination `pre-merge-readiness.mts` and the A3/A4 discovery
- * helpers already rely on. Any other status (403, rate limit, transient
- * failure) propagates so this snapshot fails closed instead of silently
- * treating an auth/network failure as "no required checks configured".
- */
-function ghApiJsonOr404Empty(path, paginate) {
-  // `--jq '.[]'` (NDJSON, one array element per line) is the repo-standard
-  // paginate form — see gh-exec.mts and protocol-helpers.mts's
-  // parsePaginatedGhNdjson, reused here rather than hand-rolling a second
-  // parser. Unlike `--jq '.'`, it does not depend on gh's jq implementation
-  // staying compact-per-page; `--slurp` (a single JSON array) landed in gh
-  // v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0 via apt, so NDJSON stays
-  // the compatible default.
-  const args = paginate
-    ? ['api', path, '--paginate', '--jq', '.[]']
-    : ['api', path];
-  try {
-    const raw = ghText(
-      args,
-      paginate ? { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS } : {},
-    );
-    if (!paginate) {
-      const trimmed = raw.trim();
-      return trimmed ? JSON.parse(trimmed) : {};
-    }
-    return parsePaginatedGhNdjson(raw);
-  } catch (error) {
-    if (deriveGhHttpStatus(error) === 404) {
-      return paginate ? [] : {};
-    }
-    throw error;
-  }
 }
 function printHelp() {
   process.stdout.write(`Usage:

--- a/scripts/idd-merge-execute.mjs
+++ b/scripts/idd-merge-execute.mjs
@@ -109,11 +109,23 @@ export function isSafeSoloCodeownerAdminMergeState(
   );
 }
 /** `resolveOwnerRepoFromRef`'s split of a `<owner>/<repo>` `repoRef`, or the
- * current-directory repo (`gh repo view`) when `repoRef` is `null`. */
+ * current-directory repo (`gh repo view`) when `repoRef` is `null`. Fails
+ * fast on a malformed shape (missing, empty, or extra `/`-separated
+ * segments) rather than silently treating `owner/repo/extra` as
+ * `owner`/`repo` -- every current caller only ever passes the value this
+ * file's own `parseArgs` synthesizes as `${owner}/${repo}` from two
+ * already-parsed flags, but this function has no way to enforce that at
+ * the type level, so it validates its own input instead of trusting it. */
 function resolveOwnerRepoFromRef(repoRef) {
   if (repoRef) {
-    const [owner, repo] = repoRef.split('/');
-    return { owner: owner ?? '', repo: repo ?? '' };
+    const segments = repoRef.split('/');
+    const [owner, repo] = segments;
+    if (segments.length !== 2 || !owner || !repo) {
+      throw new Error(
+        `resolveOwnerRepoFromRef: expected "<owner>/<repo>", got "${repoRef}"`,
+      );
+    }
+    return { owner, repo };
   }
   return resolveCurrentGithubRepository();
 }

--- a/scripts/idd-merge-execute.mjs
+++ b/scripts/idd-merge-execute.mjs
@@ -12,12 +12,15 @@
 // reports the bound merge command; the ONLY mutation anywhere is the
 // `gh pr merge` issued under `--apply` once every F3 gate holds and the
 // head + claim re-validate immediately before the merge.
-import { ghText } from './gh-exec.mjs';
 import { deriveGhHttpStatus, ghErrorText } from './gh-http-status.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import { normalizePolicyConfig } from './policy-helpers.mjs';
 import { collectPreMergeReadiness } from './pre-merge-readiness.mjs';
 import { computePreMergeReadinessBlockers } from './protocol-helpers.mjs';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mjs';
 
 /**
  * GitHub's exact `gh pr merge` failure text for the solo-CODEOWNER
@@ -105,10 +108,14 @@ export function isSafeSoloCodeownerAdminMergeState(
         branchCurrency.requiresUpToDateHead === false))
   );
 }
-// Prepend `-R <repoRef>` to a `gh` argument array only when a repo scope is
-// set; otherwise pass the args verbatim (current-directory repo).
-function scopedGhArgs(repoRef, args) {
-  return repoRef ? ['-R', repoRef, ...args] : args;
+/** `resolveOwnerRepoFromRef`'s split of a `<owner>/<repo>` `repoRef`, or the
+ * current-directory repo (`gh repo view`) when `repoRef` is `null`. */
+function resolveOwnerRepoFromRef(repoRef) {
+  if (repoRef) {
+    const [owner, repo] = repoRef.split('/');
+    return { owner: owner ?? '', repo: repo ?? '' };
+  }
+  return resolveCurrentGithubRepository();
 }
 /**
  * Decode and classify a remote `.github/idd/config.json` read into the
@@ -136,19 +143,22 @@ export function resolveRemoteSoloCodeownerAdminFallbackMode(
   prNumber,
   repoRef,
   headSha,
-  fetchEncodedConfig = (scopedRepoRef, ref) =>
-    ghText(
-      scopedGhArgs(scopedRepoRef, [
-        'api',
-        `repos/${scopedRepoRef}/contents/.github/idd/config.json`,
-        '--method',
-        'GET',
-        '--field',
-        `ref=${ref}`,
-        '--jq',
-        '.content',
-      ]),
-    ),
+  fetchEncodedConfig = (scopedRepoRef, ref) => {
+    const outcome = createGithubProviderAdapter(
+      '',
+      '',
+    ).getRepositoryFileContentAtRef(
+      scopedRepoRef,
+      '.github/idd/config.json',
+      ref,
+    );
+    if (outcome.outcome === 'not-found') {
+      const notFound = new Error('Not Found (HTTP 404)');
+      notFound.stderr = 'Not Found (HTTP 404)';
+      throw notFound;
+    }
+    return outcome.value;
+  },
 ) {
   let config;
   try {
@@ -171,56 +181,43 @@ export function resolveRemoteSoloCodeownerAdminFallbackMode(
 }
 const defaultDeps = {
   collect: (passthrough) => collectPreMergeReadiness(passthrough),
-  fetchHeadSha: (prNumber, repoRef) =>
-    ghText(
-      scopedGhArgs(repoRef, [
-        'pr',
-        'view',
-        String(prNumber),
-        '--json',
-        'headRefOid',
-        '--jq',
-        '.headRefOid',
-      ]),
-    ),
-  fetchMergeState: (prNumber, repoRef) =>
-    JSON.parse(
-      ghText(
-        scopedGhArgs(repoRef, [
-          'pr',
-          'view',
-          String(prNumber),
-          '--json',
-          'mergeable,mergeStateStatus',
-          '--jq',
-          '.',
-        ]),
-      ),
-    ),
-  mergePr: (prNumber, headSha, repoRef) =>
-    ghText(
-      scopedGhArgs(repoRef, [
-        'pr',
-        'merge',
-        String(prNumber),
-        // Always a merge commit — never squash/rebase. Bind to the head.
-        '--merge',
-        '--match-head-commit',
-        headSha,
-      ]),
-    ),
-  mergePrAdmin: (prNumber, headSha, repoRef) =>
-    ghText(
-      scopedGhArgs(repoRef, [
-        'pr',
-        'merge',
-        String(prNumber),
-        '--merge',
-        '--match-head-commit',
-        headSha,
-        '--admin',
-      ]),
-    ),
+  fetchHeadSha: (prNumber, repoRef) => {
+    const { owner, repo } = resolveOwnerRepoFromRef(repoRef);
+    return createGithubProviderAdapter(
+      owner,
+      repo,
+    ).getChangeRequestHeadShaAtRepo(owner, repo, prNumber);
+  },
+  fetchMergeState: (prNumber, repoRef) => {
+    const { owner, repo } = resolveOwnerRepoFromRef(repoRef);
+    const state = createGithubProviderAdapter(
+      owner,
+      repo,
+    ).getChangeRequestAtRepo(owner, repo, prNumber);
+    if (!state) {
+      throw new Error(
+        `fetchMergeState: PR #${prNumber} not found${repoRef ? ` in ${repoRef}` : ''}`,
+      );
+    }
+    return state;
+  },
+  mergePr: (prNumber, headSha, repoRef) => {
+    const { owner, repo } = resolveOwnerRepoFromRef(repoRef);
+    // Always a merge commit — never squash/rebase. Bind to the head.
+    return createGithubProviderAdapter(owner, repo).mergeChangeRequestAtRepo(
+      owner,
+      repo,
+      prNumber,
+      headSha,
+    );
+  },
+  mergePrAdmin: (prNumber, headSha, repoRef) => {
+    const { owner, repo } = resolveOwnerRepoFromRef(repoRef);
+    return createGithubProviderAdapter(
+      owner,
+      repo,
+    ).mergeChangeRequestAdminAtRepo(owner, repo, prNumber, headSha);
+  },
   resolveSoloCodeownerAdminFallbackMode: (prNumber, repoRef, headSha) =>
     repoRef
       ? resolveRemoteSoloCodeownerAdminFallbackMode(prNumber, repoRef, headSha)

--- a/scripts/merged-pr-feedback-sweep.mjs
+++ b/scripts/merged-pr-feedback-sweep.mjs
@@ -15,7 +15,6 @@
 // This is the recurring counterpart of the one-time audit in #910 and the
 // chosen recovery path from #909 (advisory-wait stays Copilot-only).
 import { parseCliArgs } from './cli-args.mjs';
-import { ghText } from './gh-exec.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import {
   advisoryBotIdentityToken,
@@ -30,6 +29,10 @@ import {
   resolveAdvisoryBotLogins,
   resolveTrustedMarkerActors,
 } from './protocol-helpers.mjs';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mjs';
 
 // ---------------------------------------------------------------------------
 // Pure helpers
@@ -507,134 +510,47 @@ function resolveSinceDate(args) {
   return candidates.reduce((later, next) => (next.ms > later.ms ? next : later))
     .iso;
 }
-function runGh(args) {
-  return ghText(args);
+function listMergedPrNumbers(port, sinceDate, limit) {
+  return port.listMergedChangeRequests(limit, sinceDate);
 }
-function ghGraphql(query, variables) {
-  const args = ['api', 'graphql', '-f', `query=${query}`];
-  for (const [key, value] of Object.entries(variables)) {
-    if (value === null || value === undefined) {
-      continue;
-    }
-    args.push(typeof value === 'number' ? '-F' : '-f', `${key}=${value}`);
-  }
-  const result = JSON.parse(runGh(args).trim() || '{}');
-  // A GraphQL call can return HTTP 200 with a top-level `errors` array and
-  // null `data`. Fail fast instead of treating it as empty data, which would
-  // be a silent false negative (a PR appearing "clean" because no nodes came
-  // back).
-  if (Array.isArray(result.errors) && result.errors.length > 0) {
-    const messages = result.errors
-      .map((entry) => entry?.message ?? 'unknown')
-      .join('; ');
-    throw new Error(`GraphQL query returned errors: ${messages}`);
-  }
-  return result;
-}
-function listMergedPrNumbers(repoRef, sinceDate, limit) {
-  const args = [
-    'pr',
-    'list',
-    '-R',
-    repoRef,
-    '--state',
-    'merged',
-    '--json',
-    'number,mergedAt',
-    '--limit',
-    String(limit),
-  ];
-  if (sinceDate) {
-    args.push('--search', `merged:>=${sinceDate}`);
-  }
-  const raw = runGh(args).trim();
-  const items = raw ? JSON.parse(raw) : [];
-  return items;
-}
-// Page a single `pullRequest` connection to completion so large PRs cannot
-// silently truncate at 100 items (which would hide unresolved threads or a
-// later disposition comment and produce a false negative). Per-thread reply
-// pagination is intentionally left at first:100 — a thread with 100+ replies
-// is pathological and only affects the advisory `dispositioned` flag, not
-// whether the thread surfaces.
-function fetchAllNodes(owner, repo, number, field, nodeFields) {
-  const out = [];
-  let after = null;
-  for (;;) {
-    const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
-      repository(owner:$owner,name:$repo){ pullRequest(number:$number){
-        ${field}(first:100,after:$after){ pageInfo{ hasNextPage endCursor } nodes{ ${nodeFields} } }
-      } }
-    }`;
-    const result = ghGraphql(query, { owner, repo, number, after });
-    // Fail fast on a missing pullRequest node or connection: an absent node
-    // (e.g. a transient/permission anomaly) would otherwise be read as zero
-    // nodes, making a PR look "clean" — the silent false negative this
-    // helper's fail-fast posture exists to prevent.
-    const pr = result?.data?.repository?.pullRequest;
-    if (pr == null) {
-      throw new Error(
-        `pagination for ${field} on PR #${number} returned no pullRequest node`,
-      );
-    }
-    const conn = pr[field];
-    if (conn == null) {
-      throw new Error(
-        `pagination for ${field} on PR #${number} returned a null connection`,
-      );
-    }
-    out.push(...(conn.nodes ?? []));
-    if (!conn.pageInfo?.hasNextPage) {
-      break;
-    }
-    // Fail fast rather than silently truncate: a missing cursor on a
-    // has-next-page response would reintroduce the false negative this
-    // pagination exists to prevent.
-    if (!conn.pageInfo.endCursor) {
-      throw new Error(
-        `pagination for ${field} on PR #${number} reported hasNextPage with no endCursor`,
-      );
-    }
-    after = conn.pageInfo.endCursor;
-  }
-  return out;
-}
-function fetchMergedPr(owner, repo, number) {
-  const metaQuery = `query($owner:String!,$repo:String!,$number:Int!){
-    repository(owner:$owner,name:$repo){ pullRequest(number:$number){
-      number merged mergedAt mergeCommit{ oid }
-    } }
-  }`;
-  const meta = ghGraphql(metaQuery, { owner, repo, number });
-  const pr = meta?.data?.repository?.pullRequest;
-  if (!pr?.merged) {
+function fetchMergedPr(port, number) {
+  const meta = port.getMergedChangeRequestMeta(number);
+  if (!meta?.merged) {
     return null;
   }
   return {
-    number: pr.number ?? number,
-    mergedAt: pr.mergedAt ?? null,
-    mergeCommit: pr.mergeCommit?.oid ?? null,
-    comments: fetchAllNodes(
-      owner,
-      repo,
-      number,
-      'comments',
-      'body url createdAt updatedAt author{ login }',
-    ),
-    reviews: fetchAllNodes(
-      owner,
-      repo,
-      number,
-      'reviews',
-      'body url state submittedAt author{ login }',
-    ),
-    threads: fetchAllNodes(
-      owner,
-      repo,
-      number,
-      'reviewThreads',
-      'isResolved path comments(first:100){ nodes{ body url createdAt updatedAt author{ login } } }',
-    ),
+    number: meta.number,
+    mergedAt: meta.mergedAt,
+    mergeCommit: meta.mergeCommitOid,
+    comments: port.listChangeRequestGraphqlComments(number).map((comment) => ({
+      body: comment.body,
+      url: comment.url,
+      createdAt: comment.createdAt,
+      updatedAt: comment.updatedAt,
+      author: { login: comment.authorLogin },
+    })),
+    reviews: port.listChangeRequestGraphqlReviews(number).map((review) => ({
+      body: review.body,
+      url: review.url,
+      state: review.state,
+      submittedAt: review.submittedAt,
+      author: { login: review.authorLogin },
+    })),
+    threads: port
+      .listChangeRequestReviewThreadsExtended(number)
+      .map((thread) => ({
+        isResolved: thread.isResolved,
+        path: thread.path,
+        comments: {
+          nodes: thread.comments.map((comment) => ({
+            body: comment.body,
+            url: comment.url ?? null,
+            createdAt: comment.createdAt,
+            updatedAt: comment.updatedAt,
+            author: { login: comment.authorLogin },
+          })),
+        },
+      })),
   };
 }
 function main() {
@@ -643,13 +559,11 @@ function main() {
     printHelp();
     process.exit(0);
   }
-  const owner =
-    args.owner ||
-    runGh(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']).trim();
-  const repo =
-    args.repo ||
-    runGh(['repo', 'view', '--json', 'name', '--jq', '.name']).trim();
-  const repoRef = `${owner}/${repo}`;
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createGithubProviderAdapter(owner, repo);
   const iddConfig = loadIddConfig();
   const { actors: trustedMarkerActors } = resolveTrustedMarkerActors({
     flagValue: args.trustedMarkerLogins,
@@ -682,10 +596,10 @@ function main() {
   const sinceDate = usingExplicitPrs ? null : resolveSinceDate(args);
   const targets = usingExplicitPrs
     ? args.prNumbers.map((number) => ({ number }))
-    : listMergedPrNumbers(repoRef, sinceDate, args.limit);
+    : listMergedPrNumbers(port, sinceDate, args.limit);
   const prs = [];
   for (const target of targets) {
-    const pr = fetchMergedPr(owner, repo, target.number);
+    const pr = fetchMergedPr(port, target.number);
     if (pr) {
       prs.push(pr);
     }

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -25,13 +25,6 @@ import {
   normalizeAuthorityEvidence,
   resolveCollaboratorAuthority,
 } from './external-check-waiver.mjs';
-import {
-  DEFAULT_GH_PAGINATED_TIMEOUT_MS,
-  GH_TEXT_LOOP_OPTIONS,
-  ghText,
-  readGithubRepoDefaultBranch,
-  safeGhText,
-} from './gh-exec.mjs';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import {
@@ -47,7 +40,6 @@ import {
   deriveIddAgentLogins,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
-  parsePaginatedGhNdjson,
   resolveAdvisoryBotLogins,
   resolveCodeownersForFiles,
   resolvePrFirstCommitAt,
@@ -55,6 +47,10 @@ import {
   resolveTrustedMarkerActors,
   selectCodeownersText,
 } from './protocol-helpers.mjs';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mjs';
 import {
   evaluateProviderOutageRelief,
   resolveProviderOutageDeclaration,
@@ -180,7 +176,19 @@ const PRE_MERGE_READINESS_FLAG_SPEC = {
  * `idd-merge-execute` helper so the F2/F3 gate logic is collected from
  * exactly one place (no duplicated gh plumbing or gate evaluation).
  */
-export function collectPreMergeReadiness(argv) {
+/**
+ * `createPort` is injectable (defaults to the real GitHub adapter) so a test
+ * can drive this collection entry end to end against
+ * `createFakeProviderAdapter` fixtures instead of a live `gh` process
+ * (#2267 AC4's "unit tests exercise the PR-facing state machine with a fake
+ * provider" -- see `pre-merge-readiness-collection-smoke.test.mts`). Neither
+ * production caller (this file's own CLI entry, `idd-merge-execute.mts`)
+ * passes a second argument, so both keep using the real adapter unchanged.
+ */
+export function collectPreMergeReadiness(
+  argv,
+  createPort = createGithubProviderAdapter,
+) {
   const args = parseArgs(argv);
   // --help used to exit from inside the parseArgs token loop; relocated
   // here (the wrapper's help path) per #1451. Same external contract: the
@@ -196,27 +204,13 @@ export function collectPreMergeReadiness(argv) {
   if (!args.claimless && !args.claimIssueNumber) {
     throw new Error('missing required --claim-issue <number> argument');
   }
-  const owner =
-    args.owner ||
-    ghText(
-      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
-      GH_TEXT_LOOP_OPTIONS,
-    );
-  const repo =
-    args.repo ||
-    ghText(
-      ['repo', 'view', '--json', 'name', '--jq', '.name'],
-      GH_TEXT_LOOP_OPTIONS,
-    );
-  const repoRef = `${owner}/${repo}`;
-  const viewerLogin = safeGhText(
-    ['api', 'user', '--jq', '.login'],
-    GH_TEXT_LOOP_OPTIONS,
-  ).toLowerCase();
-  const viewerAppSlug = safeGhText(
-    ['api', 'app', '--jq', '.slug // .app_slug // empty'],
-    GH_TEXT_LOOP_OPTIONS,
-  ).toLowerCase();
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createPort(owner, repo);
+  const viewerLogin = port.resolveViewerLoginSafe().viewerLogin;
+  const viewerAppSlug = port.resolveViewerAppSlugSafe().appSlug.toLowerCase();
   const iddConfig = loadIddConfig();
   const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
     resolveTrustedMarkerActors({
@@ -230,31 +224,21 @@ export function collectPreMergeReadiness(argv) {
       envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
       config: iddConfig,
     });
-  const pr = ghJson([
-    'pr',
-    'view',
-    String(args.prNumber),
-    '-R',
-    repoRef,
-    '--json',
-    // #1513: `mergeable,mergeStateStatus` added to this existing call (no
-    // new network round-trip) so the branch-currency gate below can pair a
-    // live `BEHIND` state with the up-to-date-head requirement resolved
-    // from `branchRules`/`branchProtection`.
-    'headRefOid,baseRefName,url,author,reviewDecision,statusCheckRollup,mergeable,mergeStateStatus,closingIssuesReferences',
-    '--jq',
-    '.',
-  ]);
-  const prHeadSha = String(pr.headRefOid ?? '');
-  const baseRefName = String(pr.baseRefName ?? '');
-  const prUrl = String(pr.url ?? '');
-  const prAuthorLogin = String(pr.author?.login ?? '').toLowerCase();
-  const reviewDecision = String(pr.reviewDecision ?? '');
-  const mergeable = String(pr.mergeable ?? '');
-  const mergeStateStatus = String(pr.mergeStateStatus ?? '');
+  // #1513: `mergeable`/`mergeStateStatus` are part of this same richest
+  // single `pr view` call (no extra network round-trip) so the branch-
+  // currency gate below can pair a live `BEHIND` state with the up-to-date-
+  // head requirement resolved from `branchRules`/`branchProtection`.
+  const snapshot = port.getChangeRequestReadinessSnapshot(args.prNumber);
+  const prHeadSha = snapshot.headSha;
+  const baseRefName = snapshot.baseRefName;
+  const prUrl = snapshot.url;
+  const prAuthorLogin = snapshot.authorLogin.toLowerCase();
+  const reviewDecision = snapshot.reviewDecision ?? '';
+  const mergeable = snapshot.mergeable;
+  const mergeStateStatus = snapshot.mergeStateStatus;
   if (args.claimless) {
-    const closingRefs = Array.isArray(pr.closingIssuesReferences)
-      ? pr.closingIssuesReferences
+    const closingRefs = Array.isArray(snapshot.closingIssuesReferences)
+      ? snapshot.closingIssuesReferences
       : [];
     if (closingRefs.length > 0) {
       throw new Error(
@@ -269,14 +253,14 @@ export function collectPreMergeReadiness(argv) {
   const developmentBranchInspection = inspectDevelopmentBranch(iddConfig);
   const liveDefaultBranch =
     developmentBranchInspection.status === 'absent'
-      ? readGithubRepoDefaultBranch(owner, repo)
+      ? port.getRepositoryDefaultBranch(owner, repo)
       : null;
   const developmentBranchTarget = {
     ...resolveEffectiveDevelopmentBranch(iddConfig, liveDefaultBranch),
     baseRefName,
   };
   const encodedBaseRefName = encodeURIComponent(baseRefName);
-  // #1483: sourced from the same `gh pr view` call above (the
+  // #1483: sourced from the same `pr view` snapshot above (the
   // `statusCheckRollup` field), not a separate `gh pr checks` call --
   // `statusCheckRollup`'s GraphQL union already tags each entry with a
   // real producer identity (`__typename`: `CheckRun` vs. `StatusContext`,
@@ -286,7 +270,7 @@ export function collectPreMergeReadiness(argv) {
   // successive calls a few seconds apart returned different check-run
   // counts for the same PR), so this is the single source of truth for
   // both the check identity and its dedup discriminator.
-  const checks = (pr.statusCheckRollup ?? []).map(
+  const checks = (snapshot.statusCheckRollup ?? []).map(
     normalizeStatusCheckRollupEntry,
   );
   const trustEmptyProtectionReads = readTrustEmptyProtectionReads();
@@ -295,6 +279,8 @@ export function collectPreMergeReadiness(argv) {
     true,
     trustEmptyProtectionReads,
     [],
+    () =>
+      unwrapGovernanceOutcome(port.listBranchRules(owner, repo, baseRefName)),
   );
   const branchRules = branchRulesRead.value;
   const branchRulesetsRead = fetchBranchRulesets(
@@ -302,6 +288,7 @@ export function collectPreMergeReadiness(argv) {
     repo,
     branchRules,
     trustEmptyProtectionReads,
+    (path) => unwrapGovernanceOutcome(port.getRepositoryRulesetDetail(path)),
   );
   const branchRulesets = branchRulesetsRead.value;
   const branchProtectionRead = fetchGovernanceJson(
@@ -309,6 +296,10 @@ export function collectPreMergeReadiness(argv) {
     false,
     trustEmptyProtectionReads,
     {},
+    () =>
+      unwrapGovernanceOutcome(
+        port.getBranchProtection(owner, repo, baseRefName),
+      ),
   );
   const branchProtection = branchProtectionRead.value;
   // #1377: a masked-403-as-404 on either read means the required-check set
@@ -325,37 +316,28 @@ export function collectPreMergeReadiness(argv) {
   // `branchProtection`) -- so it is threaded separately rather than folded
   // into `protectionReadsUnreadable`.
   const branchRulesetsUnreadable = branchRulesetsRead.unreadable;
-  const reviews = ghApiJson(
-    `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
-    true,
+  const reviews = port.listReviews(args.prNumber);
+  const requestedReviewerLogins = port.getChangeRequestRequestedReviewerLogins(
+    args.prNumber,
   );
-  const requestedReviewers = ghApiJson(
-    `repos/${owner}/${repo}/pulls/${args.prNumber}/requested_reviewers`,
-    false,
-  );
-  const timelineEvents = ghApiJson(
-    `repos/${owner}/${repo}/issues/${args.prNumber}/timeline`,
-    true,
-    ['-H', 'Accept: application/vnd.github+json'],
-  );
-  const comments = ghApiJson(
-    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
-    true,
-  );
+  const timelineEvents = port.getWorkItemTimeline(args.prNumber);
+  const comments = port
+    .listWorkItemComments(args.prNumber)
+    .map(toIssueCommentPayload);
   const claimComments = args.claimless
     ? []
-    : ghApiJson(
-        `repos/${owner}/${repo}/issues/${args.claimIssueNumber}/comments`,
-        true,
-      );
-  const threads = fetchReviewThreads(owner, repo, args.prNumber);
-  const changedFiles = ghApiJson(
-    `repos/${owner}/${repo}/pulls/${args.prNumber}/files`,
-    true,
-  )
-    .map((file) => String(file.filename ?? ''))
+    : port
+        // Non-null: the earlier `!args.claimless && !args.claimIssueNumber`
+        // guard already rejected this branch with a missing claim issue.
+        .listWorkItemComments(args.claimIssueNumber)
+        .map(toIssueCommentPayload);
+  const threads = port.listChangeRequestReviewThreadsWithComments(
+    args.prNumber,
+  );
+  const changedFiles = port
+    .listChangeRequestChangedFiles(args.prNumber)
     .filter(Boolean);
-  const codeownersText = fetchCodeownersText(owner, repo, baseRefName);
+  const codeownersText = fetchCodeownersText(port, owner, repo, baseRefName);
   const {
     eligible: eligibleCodeownerUserLogins,
     unreadable: eligibleCodeownerUserLoginsUnreadable,
@@ -365,6 +347,7 @@ export function collectPreMergeReadiness(argv) {
     resolveCodeownersForFiles(codeownersText, changedFiles).codeownerUserLogins,
   );
   const viewerTeamSlugs = resolveViewerClassicBypassTeamSlugs(
+    port,
     owner,
     viewerLogin,
     branchProtection,
@@ -374,7 +357,7 @@ export function collectPreMergeReadiness(argv) {
     viewerLogin,
     ...configuredTrustedActors,
     ...(collaboratorTrustEnabled
-      ? resolveTrustedCollaboratorMarkerLogins(owner, repo, [
+      ? resolveTrustedCollaboratorMarkerLogins(port, [
           ...comments,
           ...claimComments,
         ])
@@ -403,10 +386,7 @@ export function collectPreMergeReadiness(argv) {
   let prFirstCommitAt = null;
   if (forcedHandoffEnabled) {
     try {
-      const prCommits = ghApiJson(
-        `repos/${owner}/${repo}/pulls/${args.prNumber}/commits`,
-        true,
-      );
+      const prCommits = port.listChangeRequestCommits(args.prNumber);
       prFirstCommitAt = resolvePrFirstCommitAt(prCommits);
     } catch {
       prFirstCommitAt = null;
@@ -495,6 +475,7 @@ export function collectPreMergeReadiness(argv) {
   const copilotUnavailable = copilotRecovery.state === 'COPILOT_UNAVAILABLE';
   const advisoryConvergenceOutageRelief =
     resolveAdvisoryConvergenceOutageRelief({
+      port,
       owner,
       repo,
       copilotUnavailable,
@@ -513,7 +494,7 @@ export function collectPreMergeReadiness(argv) {
       branchProtection,
       protectionReadsUnreadable,
       branchRulesetsUnreadable,
-      requestedReviewers: requestedReviewers.users ?? [],
+      requestedReviewers: requestedReviewerLogins,
       timelineEvents,
       claimEvents: claimComments.map(normalizeClaimComment),
       changedFiles,
@@ -748,6 +729,25 @@ function printHelp() {
  * field-mapping drift (e.g. `user.login` -> `author.login`) would surface
  * only in production.
  */
+/**
+ * Map a `ProviderPort.listWorkItemComments` result back onto the REST
+ * `issues/{n}/comments` shape this file's `normalizeComment`/
+ * `normalizeClaimComment`/`resolveTrustedCollaboratorMarkerLogins`/
+ * `deriveIddAgentLogins` call already expect -- keeps every one of those
+ * unchanged rather than reshaping them for the port's flat `authorLogin`
+ * field, which `provider-outage-declaration.mts`'s own `CommentLike` (fed
+ * the same shim output for `resolveAdvisoryConvergenceOutageRelief`'s
+ * declaration comments) does not recognize either.
+ */
+function toIssueCommentPayload(comment) {
+  return {
+    id: comment.id,
+    body: comment.body,
+    created_at: comment.createdAt,
+    updated_at: comment.updatedAt,
+    user: { login: comment.authorLogin },
+  };
+}
 export function normalizeComment(comment) {
   return {
     id: String(comment.id ?? ''),
@@ -787,34 +787,34 @@ export function normalizeReview(review) {
   };
 }
 /**
- * Normalize a raw GraphQL `reviewThreads` node into the summarizer-shape
- * `ThreadLike`. Exported for direct unit testing (#1708), see
- * {@link normalizeComment}'s doc comment.
+ * Normalize a `ProviderPort.listChangeRequestReviewThreadsWithComments`
+ * node into the summarizer-shape `ThreadLike`. Exported for direct unit
+ * testing (#1708), see {@link normalizeComment}'s doc comment. `id` and
+ * `reviewerReopenedAt` are omitted (both `ThreadLike` fields are optional):
+ * the pre-migration GraphQL query never selected `reviewerReopenedAt` at
+ * all (`inferReviewerReopenedAt` always returned `''`), and the outer
+ * thread `id` fed only `ThreadLike`'s own optional diagnostic fields, not
+ * any gating decision -- `review-activity-snapshot.mts`'s own
+ * `normalizeThread` already dropped both for the identical shared
+ * GraphQL query, reviewed and merged without incident.
  */
 export function normalizeThread(thread) {
   return {
-    id: thread.id,
     isResolved: Boolean(thread.isResolved),
     updatedAt: '',
-    reviewerReopenedAt: inferReviewerReopenedAt(thread),
     comments: {
-      pageInfo: {
-        hasNextPage: Boolean(thread.comments?.pageInfo?.hasNextPage),
-      },
-      nodes: (thread.comments?.nodes ?? []).map((comment) => ({
-        author: { login: comment.author?.login ?? '' },
-        body: comment.body ?? '',
-        createdAt: comment.createdAt ?? '',
-        updatedAt: comment.updatedAt ?? comment.createdAt ?? '',
-        pullRequestReview: { id: comment.pullRequestReview?.id ?? null },
+      pageInfo: { hasNextPage: false },
+      nodes: thread.comments.map((comment) => ({
+        author: { login: comment.authorLogin },
+        body: comment.body,
+        createdAt: comment.createdAt,
+        updatedAt: comment.updatedAt || comment.createdAt,
+        pullRequestReview: { id: comment.pullRequestReviewId ?? null },
       })),
     },
   };
 }
-function inferReviewerReopenedAt(thread) {
-  return thread.reviewerReopenedAt ?? '';
-}
-function resolveTrustedCollaboratorMarkerLogins(owner, repo, comments) {
+function resolveTrustedCollaboratorMarkerLogins(port, comments) {
   const markerAuthors = [
     ...new Set(
       comments
@@ -826,15 +826,8 @@ function resolveTrustedCollaboratorMarkerLogins(owner, repo, comments) {
     ),
   ];
   return markerAuthors.filter((login) => {
-    const permission = safeGhText(
-      [
-        'api',
-        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-        '--jq',
-        '.permission',
-      ],
-      GH_TEXT_LOOP_OPTIONS,
-    ).toLowerCase();
+    const result = port.getCollaboratorPermission(login);
+    const permission = result.outcome === 'found' ? result.permission : '';
     return (
       permission === 'admin' ||
       permission === 'maintain' ||
@@ -845,24 +838,32 @@ function resolveTrustedCollaboratorMarkerLogins(owner, repo, comments) {
 /**
  * Exported for direct unit testing (matching this file's established
  * `fetchBranchRulesets`/`fetchGovernanceJson` injectable-fetch pattern) --
- * `fetchPermission` defaults to the real live `gh api .../permission` call
- * and is overridden in tests to simulate a 404 vs. a transient failure
- * without mocking `execFileSync`.
+ * `fetchPermission` defaults to the real `ProviderPort.getCollaboratorPermission`
+ * read and is overridden in tests to simulate a 404 vs. a transient failure
+ * without a live adapter. The default maps the port's never-throwing
+ * `{outcome}` result back onto this function's own throw-based contract
+ * (a synthetic `(HTTP 404)` error on `not-collaborator`, matching
+ * `idd-merge-execute.mts`'s `resolveRemoteSoloCodeownerAdminFallbackMode`
+ * default) so the `catch` block below -- and its existing tests -- stay
+ * byte-identical.
  */
 export function resolveEligibleCodeownerUserLogins(
   owner,
   repo,
   logins,
-  fetchPermission = (login) =>
-    ghText(
-      [
-        'api',
-        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-        '--jq',
-        '.permission',
-      ],
-      GH_TEXT_LOOP_OPTIONS,
-    ),
+  fetchPermission = (login) => {
+    const result = createGithubProviderAdapter(
+      owner,
+      repo,
+    ).getCollaboratorPermission(login);
+    if (result.outcome === 'not-collaborator') {
+      throwSyntheticGhNotFound();
+    }
+    if (result.outcome === 'error') {
+      throw new Error(result.error.message);
+    }
+    return result.permission;
+  },
 ) {
   let unreadable = false;
   const eligible = normalizeTrustedMarkerLogins(logins).filter((login) => {
@@ -891,16 +892,9 @@ export function resolveEligibleCodeownerUserLogins(
   });
   return { eligible, unreadable };
 }
-function fetchCodeownersText(owner, repo, ref) {
+function fetchCodeownersText(port, owner, repo, ref) {
   const payloads = ['.github/CODEOWNERS', 'CODEOWNERS', 'docs/CODEOWNERS'].map(
-    (path) => {
-      return ghApiJson(
-        `repos/${owner}/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`,
-        false,
-        [],
-        { allowHttpStatuses: [404] },
-      );
-    },
+    (path) => port.getRepositoryContentAtRef(owner, repo, path, ref),
   );
   return selectCodeownersText(payloads);
 }
@@ -942,15 +936,25 @@ function fetchCodeownersText(owner, repo, ref) {
  * the empty/skipped result the gate expects.
  *
  * `fetchRulesetDetail` is injectable for tests; production uses the default
- * `gh api` call.
+ * `ProviderPort.getRepositoryRulesetDetail` read, mapped back onto this
+ * function's throw-based contract the same way
+ * {@link resolveEligibleCodeownerUserLogins}'s default does.
  */
 export function fetchBranchRulesets(
   owner,
   repo,
   branchRules,
   trustEmptyReads = false,
-  fetchRulesetDetail = (path) =>
-    ghApiJson(path, false, ['-H', 'Accept: application/vnd.github+json']),
+  fetchRulesetDetail = (path) => {
+    const outcome = createGithubProviderAdapter(
+      owner,
+      repo,
+    ).getRepositoryRulesetDetail(path);
+    if (outcome.outcome === 'not-found') {
+      throwSyntheticGhNotFound();
+    }
+    return outcome.value;
+  },
 ) {
   const rulesetPaths = [];
   const seenPaths = new Set();
@@ -985,6 +989,7 @@ export function fetchBranchRulesets(
   return { value, unreadable };
 }
 function resolveViewerClassicBypassTeamSlugs(
+  port,
   owner,
   viewerLogin,
   branchProtection,
@@ -1008,15 +1013,9 @@ function resolveViewerClassicBypassTeamSlugs(
         extractTeamOrgFromHtmlUrl(team?.html_url) ??
         owner,
     ).trim();
-    const state = safeGhText(
-      [
-        'api',
-        `orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(slug)}/memberships/${encodeURIComponent(viewerLogin)}`,
-        '--jq',
-        '.state',
-      ],
-      GH_TEXT_LOOP_OPTIONS,
-    ).toLowerCase();
+    const state = port
+      .getTeamMembershipStateSafe(org, slug, viewerLogin)
+      .toLowerCase();
     if (state === 'active') {
       viewerTeams.add(slug);
     }
@@ -1027,155 +1026,44 @@ function extractTeamOrgFromHtmlUrl(htmlUrl) {
   const match = String(htmlUrl ?? '').match(/\/orgs\/([^/]+)\/teams\//);
   return match?.[1] ?? '';
 }
-function fetchReviewThreads(owner, repo, prNumber) {
-  const nodes = [];
-  let cursor = null;
-  while (true) {
-    const payload = ghGraphql(
-      `
-        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
-          repository(owner: $owner, name: $repo) {
-            pullRequest(number: $number) {
-              reviewThreads(first: 100, after: $cursor) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  id
-                  isResolved
-                  comments(first: 100) {
-                    pageInfo { hasNextPage endCursor }
-                    nodes {
-                      body
-                      createdAt
-                      updatedAt
-                      author { login }
-                      pullRequestReview { id }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }`,
-      {
-        owner,
-        repo,
-        number: Number.parseInt(String(prNumber), 10),
-        cursor,
-      },
-    );
-    const reviewThreads = payload?.data?.repository?.pullRequest?.reviewThreads;
-    for (const thread of reviewThreads?.nodes ?? []) {
-      if (thread.comments?.pageInfo?.hasNextPage) {
-        // hasNextPage with a missing thread id or cursor is a malformed
-        // payload; fail fast with a clear message instead of a confusing
-        // GraphQL error or a silently truncated thread.
-        if (!thread.id || !thread.comments.pageInfo.endCursor) {
-          throw new Error(
-            'review thread pagination payload is missing id or endCursor',
-          );
-        }
-        thread.comments.nodes.push(
-          ...fetchThreadCommentPages(
-            thread.id,
-            thread.comments.pageInfo.endCursor,
-          ),
-        );
-        thread.comments.pageInfo.hasNextPage = false;
-      }
-    }
-    nodes.push(...(reviewThreads?.nodes ?? []));
-    if (!reviewThreads?.pageInfo?.hasNextPage) {
-      break;
-    }
-    // hasNextPage with a missing cursor would re-fetch the first page
-    // forever; fail fast on the malformed payload instead.
-    if (!reviewThreads.pageInfo.endCursor) {
-      throw new Error('review thread pagination payload is missing endCursor');
-    }
-    cursor = reviewThreads.pageInfo.endCursor;
-  }
-  return nodes;
+/**
+ * Synthesize the same `(HTTP 404)`-in-`stderr` error shape a thrown `gh`
+ * failure would have carried, so a caller's existing `deriveGhHttpStatus(error)
+ * === 404` classification (unchanged by this migration) still recognizes a
+ * port `{outcome:'not-found'}`/`{outcome:'not-collaborator'}` result --
+ * mirrors `idd-merge-execute.mts`'s `resolveRemoteSoloCodeownerAdminFallbackMode`
+ * default.
+ */
+function throwSyntheticGhNotFound() {
+  const notFound = new Error('Not Found (HTTP 404)');
+  notFound.stderr = 'Not Found (HTTP 404)';
+  throw notFound;
 }
-function fetchThreadCommentPages(threadId, afterCursor) {
-  const nodes = [];
-  let cursor = afterCursor;
-  while (cursor) {
-    const payload = ghGraphql(
-      `
-        query($id: ID!, $cursor: String) {
-          node(id: $id) {
-            ... on PullRequestReviewThread {
-              comments(first: 100, after: $cursor) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  body
-                  createdAt
-                  updatedAt
-                  author { login }
-                  pullRequestReview { id }
-                }
-              }
-            }
-          }
-        }`,
-      { id: threadId, cursor },
-    );
-    const comments = payload?.data?.node?.comments;
-    nodes.push(...(comments?.nodes ?? []));
-    if (comments?.pageInfo?.hasNextPage && !comments.pageInfo.endCursor) {
-      throw new Error('thread comment pagination payload is missing endCursor');
-    }
-    cursor = comments?.pageInfo?.hasNextPage
-      ? comments.pageInfo.endCursor
-      : null;
+/** Unwrap a `ProviderGovernanceReadOutcome`, throwing the same synthetic
+ * 404 {@link throwSyntheticGhNotFound} does on `not-found` so a caller
+ * passing this as `fetchGovernanceJson`'s `fetchJson` thunk preserves that
+ * function's existing `deriveGhHttpStatus(error) === 404` catch. */
+function unwrapGovernanceOutcome(outcome) {
+  if (outcome.outcome === 'not-found') {
+    throwSyntheticGhNotFound();
   }
-  return nodes;
-}
-function ghGraphql(query, variables) {
-  const args = ['api', 'graphql', '-f', `query=${query}`];
-  for (const [key, value] of Object.entries(variables)) {
-    if (value === null || value === undefined) {
-      continue;
-    }
-    if (typeof value === 'number') {
-      args.push('-F', `${key}=${value}`);
-      continue;
-    }
-    args.push('-f', `${key}=${value}`);
-  }
-  return JSON.parse(runGh(args).trim() || '{}');
-}
-function ghJson(args, options = {}) {
-  return JSON.parse(runGh(args, options).trim() || '[]');
-}
-function ghApiJson(path, paginate = false, extraArgs = [], options = {}) {
-  const args = ['api', path, ...extraArgs];
-  if (paginate) {
-    // gh api with --paginate and --jq '.[]' emits one JSON object per line.
-    // --slurp landed in gh v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0
-    // via apt, so keep the NDJSON-compatible form here.
-    args.push('--paginate', '--jq', '.[]');
-  }
-  const raw = runGh(args, options).trim();
-  if (!raw) {
-    return paginate ? [] : {};
-  }
-  if (paginate) {
-    return parsePaginatedGhNdjson(raw);
-  }
-  return JSON.parse(raw);
+  return outcome.value;
 }
 /**
  * Decide how a thrown `gh` failure is tolerated, returning the string result to
- * use or `undefined` when the caller must re-throw.
+ * use or `undefined` when the caller must re-throw. No longer called by this
+ * file's own collection path (#2267 routed every call site onto the provider
+ * port, which classifies its own failures), but kept -- pure, no `gh`
+ * invocation of its own -- for `idd-doctor.mts`'s own `fetchGhApiJsonAt`
+ * (an independent, un-migrated `gh api` caller) and its direct tests below.
  *
  * - `allowHttpStatuses` matches the HTTP status derived from the gh error via
- *   the shared `deriveGhHttpStatus` (the same extractor `fetchBranchRulesets`
- *   uses) and yields an **empty** string. `gh api` writes the JSON error body to
- *   stdout on a non-2xx response (a 404 prints `{"message":"Not Found",…}`), so
- *   returning that body would make `ghApiJson` parse the error object instead of
- *   `{}` / `[]`. An allowed status never carries useful data, so the empty
- *   result lets `ghApiJson` resolve it to an empty object / array.
+ *   the shared `deriveGhHttpStatus` and yields an **empty** string. `gh api`
+ *   writes the JSON error body to stdout on a non-2xx response (a 404 prints
+ *   `{"message":"Not Found",…}`), so returning that body would make the
+ *   caller parse the error object instead of `{}` / `[]`. An allowed status
+ *   never carries useful data, so the empty result resolves cleanly to an
+ *   empty object / array instead.
  * - `allowStatuses` matches the process exit code and returns stdout **only**
  *   when the body is genuinely the wanted JSON (`gh` commands that exit non-zero
  *   yet still print the data, e.g. the checks rollup).
@@ -1203,22 +1091,6 @@ export function resolveToleratedGhFailure(error, options = {}) {
     }
   }
   return undefined;
-}
-function runGh(args, options = {}) {
-  try {
-    return ghText(args, {
-      ...GH_TEXT_LOOP_OPTIONS,
-      ...(args.includes('--paginate')
-        ? { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS }
-        : {}),
-    });
-  } catch (error) {
-    const tolerated = resolveToleratedGhFailure(error, options);
-    if (tolerated !== undefined) {
-      return tolerated;
-    }
-    throw error;
-  }
 }
 function splitCsv(value) {
   return String(value ?? '')
@@ -1335,6 +1207,7 @@ export function resolveDeclarationActiveSince(declaration) {
 // pre-declaration run left it at while this gate reports covered,
 // reproducing #2021's "ready but merge blocked" class one layer deeper.
 function resolveAdvisoryConvergenceOutageRelief({
+  port,
   owner,
   repo,
   copilotUnavailable,
@@ -1351,10 +1224,9 @@ function resolveAdvisoryConvergenceOutageRelief({
     }
     const targetIssue = policy.providerOutage.declarationTarget;
     if (!targetIssue) return notRelieved;
-    const declarationComments = ghApiJson(
-      `repos/${owner}/${repo}/issues/${targetIssue}/comments`,
-      true,
-    );
+    const declarationComments = port
+      .listWorkItemComments(targetIssue)
+      .map(toIssueCommentPayload);
     const authorityOf = (actorLogin) =>
       normalizeAuthorityEvidence(
         resolveCollaboratorAuthority({ owner, repo, actor: actorLogin }),
@@ -1451,14 +1323,23 @@ function readTrustSourcePinnedRequiredChecks() {
  * permission error.
  *
  * `fetchJson` is injectable for tests (mirrors `fetchBranchRulesets`'s
- * `fetchRulesetDetail` parameter); production uses the default `gh api` call.
+ * `fetchRulesetDetail` parameter). No generic default transport: unlike
+ * `fetchBranchRulesets`/`resolveEligibleCodeownerUserLogins`, this helper
+ * has no owner/repo/ref of its own to construct a port-backed read from --
+ * every real caller (this file's own two governance reads, plus
+ * `idd-doctor.mts`'s independent `fetchGhApiJsonAt`-backed caller) already
+ * passes an explicit `fetchJson`.
  */
 export function fetchGovernanceJson(
   path,
   paginate,
   trustEmptyReads,
   emptyValue,
-  fetchJson = (p, pg) => ghApiJson(p, pg, []),
+  fetchJson = () => {
+    throw new Error(
+      'fetchGovernanceJson: no default transport; pass an explicit fetchJson',
+    );
+  },
 ) {
   try {
     return { value: fetchJson(path, paginate), unreadable: false };

--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -416,7 +416,7 @@ export function collectPreMergeReadiness(
   const {
     reviews: advisoryConvergenceReviews,
     headCommittedAt: advisoryConvergenceHeadCommittedAt,
-  } = fetchReviewsAndHeadCommit(owner, repo, args.prNumber);
+  } = fetchReviewsAndHeadCommit(owner, repo, args.prNumber, port);
   const advisoryConvergenceDeadlineMinutes =
     readAdvisoryConvergenceDeadlineMinutes();
   const secondaryQuietWindowMinutes = readAdvisorySecondaryQuietWindowMinutes();

--- a/scripts/provider-adapter-fake.mjs
+++ b/scripts/provider-adapter-fake.mjs
@@ -9,6 +9,7 @@
 // authenticated `gh` process. Every method reads/writes the fixture object
 // passed to `createFakeProviderAdapter`; nothing here spawns a subprocess
 // or makes a network call.
+import { PROVIDER_CAPABILITY_GROUPS } from './provider-contract.mjs';
 export function createFakeProviderAdapter(fixture) {
   fixture.postedComments ??= [];
   fixture.closedWorkItems ??= [];
@@ -410,6 +411,16 @@ export function createFakeProviderAdapter(fixture) {
       }
       fixture.resolvedReviewThreadIds ??= [];
       fixture.resolvedReviewThreadIds.push(threadId);
+    },
+    listCapabilityDeclarations() {
+      return (
+        fixture.capabilityDeclarations ??
+        PROVIDER_CAPABILITY_GROUPS.map((group) => ({
+          group,
+          requirement: group === 'advisory-review' ? 'optional' : 'required',
+          supported: true,
+        }))
+      );
     },
   };
 }

--- a/scripts/provider-adapter-fake.mjs
+++ b/scripts/provider-adapter-fake.mjs
@@ -118,6 +118,7 @@ export function createFakeProviderAdapter(fixture) {
         id,
         body,
         createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
         authorLogin: fixture.viewerLogin ?? 'fake-actor',
       };
       fixture.comments ??= {};

--- a/scripts/provider-adapter-fake.mjs
+++ b/scripts/provider-adapter-fake.mjs
@@ -170,5 +170,231 @@ export function createFakeProviderAdapter(fixture) {
     searchOpenWorkItems() {
       return fixture.searchResults ?? [];
     },
+    // --- #2267 additions below. -------------------------------------------
+    getRepositoryDefaultBranch() {
+      return fixture.repositoryDefaultBranch ?? null;
+    },
+    resolveViewerAppSlugSafe() {
+      if (fixture.viewerAppSlugUnavailable || !fixture.viewerAppSlug) {
+        return { appSlug: '', unavailable: true };
+      }
+      return { appSlug: fixture.viewerAppSlug, unavailable: false };
+    },
+    resolveViewerLoginSafeQuiet() {
+      if (fixture.viewerLoginUnavailable || !fixture.viewerLogin) {
+        return { viewerLogin: '', viewerLoginUnavailable: true };
+      }
+      return {
+        viewerLogin: fixture.viewerLogin,
+        viewerLoginUnavailable: false,
+      };
+    },
+    getRepositoryContentAtRef(contentOwner, contentRepo, path, ref) {
+      const key = `${contentOwner}/${contentRepo}/${path}@${ref}`;
+      return fixture.repositoryContentAtRef?.[key] ?? null;
+    },
+    getRepositoryFileContentAtRef(repoRef, path, ref) {
+      const key = `${repoRef}/${path}@${ref}`;
+      const value = fixture.repositoryFileContentAtRef?.[key];
+      return value === undefined
+        ? { outcome: 'not-found' }
+        : { outcome: 'ok', value };
+    },
+    getTeamMembershipStateSafe(org, teamSlug, login) {
+      const key = `${org}/${teamSlug}/${login}`;
+      return fixture.teamMembershipStates?.[key] ?? '';
+    },
+    getChangeRequestHeadShaAndAuthor(number) {
+      const value = fixture.changeRequestHeadShaAndAuthor?.[number];
+      if (!value) {
+        throw new Error(
+          `fake provider: no headSha/author fixture for PR ${number}`,
+        );
+      }
+      return value;
+    },
+    getChangeRequestConvergenceView(number) {
+      const value = fixture.changeRequestConvergenceViews?.[number];
+      if (!value) {
+        throw new Error(
+          `fake provider: no convergence-view fixture for PR ${number}`,
+        );
+      }
+      return value;
+    },
+    getChangeRequestReadinessSnapshot(number) {
+      const value = fixture.changeRequestReadinessSnapshots?.[number];
+      if (!value) {
+        throw new Error(
+          `fake provider: no readiness-snapshot fixture for PR ${number}`,
+        );
+      }
+      return value;
+    },
+    getChangeRequestBranchAndChecks(number) {
+      const value = fixture.changeRequestBranchAndChecks?.[number];
+      if (!value) {
+        throw new Error(
+          `fake provider: no branch-and-checks fixture for PR ${number}`,
+        );
+      }
+      return value;
+    },
+    getChangeRequestHeadRef(number) {
+      const value = fixture.changeRequestHeadRefs?.[number];
+      if (value === undefined) {
+        throw new Error(`fake provider: no head-ref fixture for PR ${number}`);
+      }
+      return value;
+    },
+    listMergedChangeRequests() {
+      return fixture.mergedChangeRequests ?? [];
+    },
+    getMergedChangeRequestMeta(number) {
+      return fixture.mergedChangeRequestMeta?.[number] ?? null;
+    },
+    listChangeRequestChecks(number) {
+      return fixture.allChecks?.[number] ?? [];
+    },
+    getChangeRequestRequestedReviewerLogins(number) {
+      return fixture.requestedReviewerLogins?.[number] ?? [];
+    },
+    getChangeRequestRequestedReviewerLoginsGraphql(number) {
+      return fixture.requestedReviewerLoginsGraphql?.[number] ?? null;
+    },
+    listChangeRequestChangedFiles(number) {
+      return fixture.changedFiles?.[number] ?? [];
+    },
+    listChangeRequestCommits(number) {
+      return fixture.changeRequestCommits?.[number] ?? [];
+    },
+    listChangeRequestReviewThreadsWithComments(number) {
+      return fixture.reviewThreadsWithComments?.[number] ?? [];
+    },
+    listChangeRequestReviewThreadsExtended(number) {
+      return fixture.reviewThreadsExtended?.[number] ?? [];
+    },
+    listChangeRequestReviewThreadCommentIds(number) {
+      return fixture.reviewThreadCommentIds?.[number] ?? [];
+    },
+    listChangeRequestGraphqlComments(number) {
+      return fixture.changeRequestGraphqlComments?.[number] ?? [];
+    },
+    listChangeRequestGraphqlReviews(number) {
+      return fixture.changeRequestGraphqlReviews?.[number] ?? [];
+    },
+    listBranchRules(rulesOwner, rulesRepo, ref) {
+      const key = `${rulesOwner}/${rulesRepo}/${ref}`;
+      const value = fixture.branchRules?.[key];
+      return value === undefined
+        ? { outcome: 'not-found' }
+        : { outcome: 'ok', value };
+    },
+    getBranchProtection(protectionOwner, protectionRepo, ref) {
+      const key = `${protectionOwner}/${protectionRepo}/${ref}`;
+      const value = fixture.branchProtection?.[key];
+      return value === undefined
+        ? { outcome: 'not-found' }
+        : { outcome: 'ok', value };
+    },
+    getRepositoryRulesetDetail(rulesetOwner, rulesetRepo, rulesetId) {
+      const key = `${rulesetOwner}/${rulesetRepo}/${rulesetId}`;
+      const value = fixture.rulesetDetails?.[key];
+      return value === undefined
+        ? { outcome: 'not-found' }
+        : { outcome: 'ok', value };
+    },
+    getWorkflowRun(runOwner, runRepo, runId) {
+      const key = `${runOwner}/${runRepo}/${runId}`;
+      return fixture.workflowRuns?.[key] ?? null;
+    },
+    listWorkflowRuns(runsOwner, runsRepo, workflowName) {
+      const key = `${runsOwner}/${runsRepo}/${workflowName}`;
+      return fixture.workflowRunLists?.[key] ?? [];
+    },
+    getChangeRequestHeadShaAtRepo(atRepoOwner, atRepoRepo, number) {
+      const key = `${atRepoOwner}/${atRepoRepo}/${number}`;
+      const sha = fixture.changeRequestHeadShasAtRepo?.[key];
+      if (sha === undefined) {
+        throw new Error(
+          `fake provider: no cross-repo head SHA fixture for ${key}`,
+        );
+      }
+      return sha;
+    },
+    getChangeRequestAtRepo(atRepoOwner, atRepoRepo, number) {
+      const key = `${atRepoOwner}/${atRepoRepo}/${number}`;
+      return fixture.changeRequestsAtRepo?.[key] ?? null;
+    },
+    mergeChangeRequestAtRepo(mergeOwner, mergeRepo, number, headSha) {
+      fixture.mergedChangeRequestCalls ??= [];
+      fixture.mergedChangeRequestCalls.push({
+        owner: mergeOwner,
+        repo: mergeRepo,
+        number,
+        headSha,
+        admin: false,
+      });
+      return `fake merge commit for ${mergeOwner}/${mergeRepo}#${number}`;
+    },
+    mergeChangeRequestAdminAtRepo(mergeOwner, mergeRepo, number, headSha) {
+      fixture.mergedChangeRequestCalls ??= [];
+      fixture.mergedChangeRequestCalls.push({
+        owner: mergeOwner,
+        repo: mergeRepo,
+        number,
+        headSha,
+        admin: true,
+      });
+      return `fake admin merge commit for ${mergeOwner}/${mergeRepo}#${number}`;
+    },
+    mergeChangeRequest(number, headSha) {
+      const locator = fixture.locator ?? {
+        provider: 'github',
+        owner: 'fake-owner',
+        name: 'fake-repo',
+      };
+      fixture.mergedChangeRequestCalls ??= [];
+      fixture.mergedChangeRequestCalls.push({
+        owner: locator.owner,
+        repo: locator.name,
+        number,
+        headSha,
+        admin: false,
+      });
+      return `fake merge commit for ${locator.owner}/${locator.name}#${number}`;
+    },
+    mergeChangeRequestAdmin(number, headSha) {
+      const locator = fixture.locator ?? {
+        provider: 'github',
+        owner: 'fake-owner',
+        name: 'fake-repo',
+      };
+      fixture.mergedChangeRequestCalls ??= [];
+      fixture.mergedChangeRequestCalls.push({
+        owner: locator.owner,
+        repo: locator.name,
+        number,
+        headSha,
+        admin: true,
+      });
+      return `fake admin merge commit for ${locator.owner}/${locator.name}#${number}`;
+    },
+    postReviewCommentReply(number, commentId, body) {
+      fixture.postedReviewCommentReplies ??= [];
+      fixture.postedReviewCommentReplies.push({ number, commentId, body });
+      const id = fixture.nextReviewCommentReplyId ?? 1;
+      fixture.nextReviewCommentReplyId = id + 1;
+      return { id };
+    },
+    resolveChangeRequestReviewThread(threadId) {
+      if (fixture.unresolvableReviewThreadIds?.has(threadId)) {
+        throw new Error(
+          `fake provider: GitHub did not confirm thread ${threadId} as resolved`,
+        );
+      }
+      fixture.resolvedReviewThreadIds ??= [];
+      fixture.resolvedReviewThreadIds.push(threadId);
+    },
   };
 }

--- a/scripts/provider-adapter-fake.mjs
+++ b/scripts/provider-adapter-fake.mjs
@@ -183,13 +183,15 @@ export function createFakeProviderAdapter(fixture) {
       return { appSlug: fixture.viewerAppSlug, unavailable: false };
     },
     resolveViewerLoginSafeQuiet() {
-      if (fixture.viewerLoginUnavailable || !fixture.viewerLogin) {
+      // Mirrors the GitHub adapter's own trim().toLowerCase() normalization
+      // (Copilot review, PR #2429) so a fixture login differing only in
+      // case/whitespace does not diverge fake-provider tests from
+      // production behavior.
+      const normalized = fixture.viewerLogin?.trim().toLowerCase() ?? '';
+      if (fixture.viewerLoginUnavailable || !normalized) {
         return { viewerLogin: '', viewerLoginUnavailable: true };
       }
-      return {
-        viewerLogin: fixture.viewerLogin,
-        viewerLoginUnavailable: false,
-      };
+      return { viewerLogin: normalized, viewerLoginUnavailable: false };
     },
     getRepositoryContentAtRef(contentOwner, contentRepo, path, ref) {
       const key = `${contentOwner}/${contentRepo}/${path}@${ref}`;
@@ -249,8 +251,16 @@ export function createFakeProviderAdapter(fixture) {
       }
       return value;
     },
-    listMergedChangeRequests() {
-      return fixture.mergedChangeRequests ?? [];
+    listMergedChangeRequests(limit, sinceDate) {
+      // Honors both parameters the GitHub adapter's `gh pr list --limit
+      // --search merged:>=date` call applies (Copilot review, PR #2429),
+      // so a collection-wiring test cannot pass on unrealistic behavior --
+      // more rows than requested, or an unfiltered date range.
+      const rows = fixture.mergedChangeRequests ?? [];
+      const filtered = sinceDate
+        ? rows.filter((row) => row.mergedAt >= sinceDate)
+        : rows;
+      return filtered.slice(0, limit);
     },
     getMergedChangeRequestMeta(number) {
       return fixture.mergedChangeRequestMeta?.[number] ?? null;

--- a/scripts/provider-adapter-fake.mjs
+++ b/scripts/provider-adapter-fake.mjs
@@ -387,6 +387,14 @@ export function createFakeProviderAdapter(fixture) {
       fixture.nextReviewCommentReplyId = id + 1;
       return { id };
     },
+    getChangeRequestReviewsWithHeadCommitDate(number) {
+      return (
+        fixture.reviewsWithHeadCommitDate?.[number] ?? {
+          reviews: [],
+          headCommittedAt: '',
+        }
+      );
+    },
     resolveChangeRequestReviewThread(threadId) {
       if (fixture.unresolvableReviewThreadIds?.has(threadId)) {
         throw new Error(

--- a/scripts/provider-adapter-fake.mjs
+++ b/scripts/provider-adapter-fake.mjs
@@ -173,14 +173,23 @@ export function createFakeProviderAdapter(fixture) {
       return fixture.searchResults ?? [];
     },
     // --- #2267 additions below. -------------------------------------------
-    getRepositoryDefaultBranch() {
+    getRepositoryDefaultBranch(_defaultBranchOwner, _defaultBranchRepo) {
+      // Accepts owner/repo to match the port's declared arity (Copilot
+      // review, PR #2429: an unaccepted parameter is silently hidden by
+      // structural typing) -- unused because every fixture in this file
+      // represents a single ambient repo, and this method's one real call
+      // site (pre-merge-readiness.mts) always passes that same repo back.
       return fixture.repositoryDefaultBranch ?? null;
     },
     resolveViewerAppSlugSafe() {
-      if (fixture.viewerAppSlugUnavailable || !fixture.viewerAppSlug) {
+      // Mirrors the GitHub adapter's own raw.trim() on the CLI output,
+      // for the same reason as resolveViewerLoginSafeQuiet's normalization
+      // above.
+      const trimmed = fixture.viewerAppSlug?.trim() ?? '';
+      if (fixture.viewerAppSlugUnavailable || !trimmed) {
         return { appSlug: '', unavailable: true };
       }
-      return { appSlug: fixture.viewerAppSlug, unavailable: false };
+      return { appSlug: trimmed, unavailable: false };
     },
     resolveViewerLoginSafeQuiet() {
       // Mirrors the GitHub adapter's own trim().toLowerCase() normalization
@@ -316,12 +325,25 @@ export function createFakeProviderAdapter(fixture) {
         : { outcome: 'ok', value };
     },
     getWorkflowRun(runOwner, runRepo, runId) {
+      // Throws on a missing fixture, matching the GitHub adapter's own
+      // no-catch `deps.ghText` call (Copilot review, PR #2429) -- a fake
+      // adapter returning null here can both mask a missing fixture and
+      // produce a confusing downstream TypeError instead of failing
+      // closed like production.
       const key = `${runOwner}/${runRepo}/${runId}`;
-      return fixture.workflowRuns?.[key] ?? null;
+      const value = fixture.workflowRuns?.[key];
+      if (value === undefined) {
+        throw new Error(`fake provider: no workflow-run fixture for ${key}`);
+      }
+      return value;
     },
-    listWorkflowRuns(runsOwner, runsRepo, workflowName) {
+    listWorkflowRuns(runsOwner, runsRepo, workflowName, limit) {
+      // Honors `limit`, matching the GitHub adapter's own `gh run list
+      // --limit N` call (Copilot review, PR #2429) -- an ignored limit let
+      // a collection-wiring test pass against an unrealistically large
+      // sibling sweep.
       const key = `${runsOwner}/${runsRepo}/${workflowName}`;
-      return fixture.workflowRunLists?.[key] ?? [];
+      return (fixture.workflowRunLists?.[key] ?? []).slice(0, limit);
     },
     getChangeRequestHeadShaAtRepo(atRepoOwner, atRepoRepo, number) {
       const key = `${atRepoOwner}/${atRepoRepo}/${number}`;
@@ -405,12 +427,18 @@ export function createFakeProviderAdapter(fixture) {
       return fixture.reviewThreadsWithAuthorType?.[number] ?? [];
     },
     getChangeRequestReviewsWithHeadCommitDate(number) {
-      return (
-        fixture.reviewsWithHeadCommitDate?.[number] ?? {
-          reviews: [],
-          headCommittedAt: '',
-        }
-      );
+      // Throws on a missing fixture, matching the GitHub adapter's own
+      // no-catch GraphQL call and this file's sibling PR-view methods
+      // (Copilot review, PR #2429) -- review-clause.mts's own caller has
+      // no try/catch around this call, so a silent empty default here
+      // would hide a missing fixture instead of failing closed.
+      const value = fixture.reviewsWithHeadCommitDate?.[number];
+      if (!value) {
+        throw new Error(
+          `fake provider: no reviews/head-commit-date fixture for PR ${number}`,
+        );
+      }
+      return value;
     },
     resolveChangeRequestReviewThread(threadId) {
       if (fixture.unresolvableReviewThreadIds?.has(threadId)) {

--- a/scripts/provider-adapter-fake.mjs
+++ b/scripts/provider-adapter-fake.mjs
@@ -299,9 +299,8 @@ export function createFakeProviderAdapter(fixture) {
         ? { outcome: 'not-found' }
         : { outcome: 'ok', value };
     },
-    getRepositoryRulesetDetail(rulesetOwner, rulesetRepo, rulesetId) {
-      const key = `${rulesetOwner}/${rulesetRepo}/${rulesetId}`;
-      const value = fixture.rulesetDetails?.[key];
+    getRepositoryRulesetDetail(path) {
+      const value = fixture.rulesetDetails?.[path];
       return value === undefined
         ? { outcome: 'not-found' }
         : { outcome: 'ok', value };

--- a/scripts/provider-adapter-fake.mjs
+++ b/scripts/provider-adapter-fake.mjs
@@ -387,6 +387,12 @@ export function createFakeProviderAdapter(fixture) {
       fixture.nextReviewCommentReplyId = id + 1;
       return { id };
     },
+    getChangeRequestAuthor(number) {
+      return fixture.changeRequestAuthors?.[number] ?? null;
+    },
+    listChangeRequestReviewThreadsWithAuthorType(number) {
+      return fixture.reviewThreadsWithAuthorType?.[number] ?? [];
+    },
     getChangeRequestReviewsWithHeadCommitDate(number) {
       return (
         fixture.reviewsWithHeadCommitDate?.[number] ?? {

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -52,6 +52,27 @@ function toProviderError(error) {
   wrapped.cause = error;
   return wrapped;
 }
+/**
+ * #2267: throw when a GraphQL response carries top-level `errors`, so a bad
+ * PR/repo/auth or any server-side GraphQL failure fails fast with a clear
+ * message instead of being silently read as an empty result -- ported
+ * verbatim from `resolve-review-thread.mts`'s pre-migration
+ * `assertNoGraphqlErrors` (its own review-thread queries relied on this;
+ * every other GraphQL-backed port method here shares the same choke point
+ * now via {@link fetchReviewThreadsGeneric}'s `runQuery`).
+ */
+function assertNoGraphqlErrors(payload, context) {
+  const errors = payload?.errors;
+  if (Array.isArray(errors) && errors.length > 0) {
+    throw new Error(
+      `${context} failed: ${errors
+        .map((entry) => String(entry.message ?? ''))
+        .filter(Boolean)
+        .join('; ')
+        .slice(0, 200)}`,
+    );
+  }
+}
 /** #2267: {@link GithubProviderAdapterDeps.ghText}, swallowing any failure
  * and returning `''` instead -- the injectable-`deps` equivalent of
  * `gh-exec.mts`'s own module-level `safeGhText`, needed here so a unit test
@@ -133,7 +154,9 @@ function fetchReviewThreadsGeneric(
   }
 }`;
   function runQuery(apiArgs) {
-    return JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+    const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+    assertNoGraphqlErrors(parsed, 'review thread lookup');
+    return parsed;
   }
   function walkThreadComments(threadId, firstPageNodes, firstPageInfo) {
     const comments = [...firstPageNodes];
@@ -1740,7 +1763,9 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         '-f',
         `threadId=${threadId}`,
       ];
-      const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+      const raw = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+      assertNoGraphqlErrors(raw, 'resolveReviewThread');
+      const parsed = raw;
       if (parsed.data?.resolveReviewThread?.thread?.isResolved !== true) {
         throw new Error(
           `resolveChangeRequestReviewThread: GitHub did not confirm thread ${threadId} as resolved`,

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -1542,6 +1542,64 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         '--admin',
       ]);
     },
+    getChangeRequestAuthor(number) {
+      const query = `
+        query($owner: String!, $repo: String!, $number: Int!) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $number) {
+              author { login __typename }
+            }
+          }
+        }`;
+      const apiArgs = [
+        'api',
+        'graphql',
+        '-f',
+        `query=${query}`,
+        '-f',
+        `owner=${owner}`,
+        '-f',
+        `repo=${repo}`,
+        '-F',
+        `number=${number}`,
+      ];
+      const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+      const author = parsed.data?.repository?.pullRequest?.author;
+      if (!author) {
+        return null;
+      }
+      return {
+        login: String(author.login ?? ''),
+        typename: author.__typename == null ? null : String(author.__typename),
+      };
+    },
+    listChangeRequestReviewThreadsWithAuthorType(number) {
+      const nodes = fetchReviewThreadsGeneric(
+        deps,
+        owner,
+        repo,
+        number,
+        'body createdAt updatedAt author { login __typename } pullRequestReview { id }',
+      );
+      return nodes.map((node) => ({
+        id: node.id,
+        isResolved: node.isResolved,
+        comments: node.comments.map((comment) => ({
+          body: String(comment.body ?? ''),
+          createdAt: String(comment.createdAt ?? ''),
+          updatedAt: String(comment.updatedAt ?? ''),
+          authorLogin: String(comment.author?.login ?? ''),
+          authorTypename:
+            comment.author?.__typename == null
+              ? null
+              : String(comment.author.__typename),
+          pullRequestReviewId:
+            comment.pullRequestReview?.id == null
+              ? null
+              : String(comment.pullRequestReview.id),
+        })),
+      }));
+    },
     getChangeRequestReviewsWithHeadCommitDate(number) {
       const query = `
         query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -1481,12 +1481,11 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         ),
       );
     },
-    getRepositoryRulesetDetail(rulesetOwner, rulesetRepo, rulesetId) {
+    getRepositoryRulesetDetail(path) {
       return fetchGovernanceOutcome(() =>
-        deps.ghApiJson(
-          `repos/${rulesetOwner}/${rulesetRepo}/rulesets/${rulesetId}`,
-          { extraArgs: ['-H', 'Accept: application/vnd.github+json'] },
-        ),
+        deps.ghApiJson(path, {
+          extraArgs: ['-H', 'Accept: application/vnd.github+json'],
+        }),
       );
     },
     getWorkflowRun(runOwner, runRepo, runId) {

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -1542,6 +1542,86 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         '--admin',
       ]);
     },
+    getChangeRequestReviewsWithHeadCommitDate(number) {
+      const query = `
+        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $number) {
+              reviews(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  id
+                  commit { oid }
+                  submittedAt
+                  author { login __typename }
+                  comments { totalCount }
+                  body
+                }
+              }
+              commits(last: 1) {
+                nodes { commit { committedDate } }
+              }
+            }
+          }
+        }`;
+      const nodes = [];
+      let headCommittedAt = '';
+      let cursor = null;
+      while (true) {
+        const apiArgs = [
+          'api',
+          'graphql',
+          '-f',
+          `query=${query}`,
+          '-f',
+          `owner=${owner}`,
+          '-f',
+          `repo=${repo}`,
+          '-F',
+          `number=${number}`,
+        ];
+        if (cursor) {
+          apiArgs.push('-f', `cursor=${cursor}`);
+        }
+        const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+        const pullRequest = parsed.data?.repository?.pullRequest;
+        nodes.push(...(pullRequest?.reviews?.nodes ?? []));
+        if (!headCommittedAt) {
+          headCommittedAt = String(
+            pullRequest?.commits?.nodes?.[0]?.commit?.committedDate ?? '',
+          );
+        }
+        const pageInfo = pullRequest?.reviews?.pageInfo;
+        if (!pageInfo?.hasNextPage) {
+          break;
+        }
+        if (!pageInfo.endCursor) {
+          throw new Error(
+            `getChangeRequestReviewsWithHeadCommitDate: review page reported hasNextPage without endCursor for PR #${number}`,
+          );
+        }
+        cursor = pageInfo.endCursor;
+      }
+      return {
+        reviews: nodes.map((node) => ({
+          id: String(node.id ?? ''),
+          authorLogin: String(node.author?.login ?? ''),
+          authorTypename:
+            node.author?.__typename == null
+              ? null
+              : String(node.author.__typename),
+          submittedAt:
+            node.submittedAt == null ? null : String(node.submittedAt),
+          commitId: node.commit?.oid == null ? null : String(node.commit.oid),
+          commentCount:
+            typeof node.comments?.totalCount === 'number'
+              ? node.comments.totalCount
+              : null,
+          body: node.body == null ? null : String(node.body),
+        })),
+        headCommittedAt,
+      };
+    },
     mergeChangeRequest(number, headSha) {
       return deps.ghText([
         'pr',

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -20,6 +20,7 @@ import {
   withBoundedRetry,
 } from './gh-exec.mjs';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
+import { PROVIDER_CAPABILITY_GROUPS } from './provider-contract.mjs';
 
 function statusToCategory(status) {
   if (status === 401) return 'authentication';
@@ -1783,6 +1784,13 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
           `resolveChangeRequestReviewThread: GitHub did not confirm thread ${threadId} as resolved`,
         );
       }
+    },
+    listCapabilityDeclarations() {
+      return PROVIDER_CAPABILITY_GROUPS.map((group) => ({
+        group,
+        requirement: group === 'advisory-review' ? 'optional' : 'required',
+        supported: true,
+      }));
     },
   };
 }

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -16,6 +16,7 @@ import {
   resolveViewerLogin as ghExecResolveViewerLogin,
   ghText,
   ghTextAsync,
+  readGithubRepoDefaultBranch,
   withBoundedRetry,
 } from './gh-exec.mjs';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
@@ -50,6 +51,161 @@ function toProviderError(error) {
   wrapped.category = statusToCategory(status);
   wrapped.cause = error;
   return wrapped;
+}
+/** #2267: {@link GithubProviderAdapterDeps.ghText}, swallowing any failure
+ * and returning `''` instead -- the injectable-`deps` equivalent of
+ * `gh-exec.mts`'s own module-level `safeGhText`, needed here so a unit test
+ * can still assert the exact command shape of a never-throw method without
+ * spawning a real `gh` process. */
+function safeGhTextLocal(deps, args, options = {}) {
+  try {
+    return deps.ghText(args, options);
+  } catch {
+    return '';
+  }
+}
+/** #2267: run a governance-style read (branch rules, branch protection,
+ * ruleset detail), discriminating a masked `404` (see
+ * {@link ProviderGovernanceReadOutcome}'s doc comment) from a real value.
+ * Any non-404 failure rethrows unchanged. */
+function fetchGovernanceOutcome(fetchJson) {
+  try {
+    return { outcome: 'ok', value: fetchJson() };
+  } catch (error) {
+    if (deriveGhHttpStatus(error) === 404) {
+      return { outcome: 'not-found' };
+    }
+    throw error;
+  }
+}
+/**
+ * #2267: shared full-walk pagination for the three distinct
+ * `reviewThreads` queries this migration needs
+ * ({@link ProviderPort.listChangeRequestReviewThreadsWithComments},
+ * {@link ProviderPort.listChangeRequestReviewThreadsExtended},
+ * {@link ProviderPort.listChangeRequestReviewThreadCommentIds}) --
+ * `commentFieldsFragment` selects each method's own distinct comment field
+ * set (see each port method's doc comment for why they stay separate
+ * types); this helper only shares the two-level pagination walk (outer
+ * `reviewThreads` cursor, inner per-thread `comments` cursor via a
+ * `node(id)` continuation query), which is identical machinery across all
+ * three. Always requests the thread `id` internally (continuation needs
+ * it) even for a caller whose own return shape omits it. Throws on a page
+ * that reports `hasNextPage` without an `endCursor`, at either level --
+ * preserves `resolve-review-thread.mts`'s and
+ * `pre-merge-readiness.mts`'s existing fail-fast-on-malformed-page
+ * behavior (a malformed payload would otherwise silently undercount
+ * threads or comments).
+ */
+function fetchReviewThreadsGeneric(
+  deps,
+  owner,
+  repo,
+  number,
+  commentFieldsFragment,
+) {
+  const outerQuery = `query($owner:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){
+      reviewThreads(first:100,after:$cursor){
+        nodes {
+          id
+          isResolved
+          path
+          comments(first:100) {
+            nodes { ${commentFieldsFragment} }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`;
+  const continuationQuery = `query($id:ID!,$cursor:String){
+  node(id:$id){
+    ... on PullRequestReviewThread{
+      comments(first:100,after:$cursor){
+        nodes { ${commentFieldsFragment} }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`;
+  function runQuery(apiArgs) {
+    return JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+  }
+  function walkThreadComments(threadId, firstPageNodes, firstPageInfo) {
+    const comments = [...firstPageNodes];
+    let pageInfo = firstPageInfo;
+    while (pageInfo?.hasNextPage) {
+      if (!pageInfo.endCursor) {
+        throw new Error(
+          `fetchReviewThreadsGeneric: comment page reported hasNextPage without endCursor for thread ${threadId}`,
+        );
+      }
+      const parsed = runQuery([
+        'api',
+        'graphql',
+        '-f',
+        `query=${continuationQuery}`,
+        '-f',
+        `id=${threadId}`,
+        '-f',
+        `cursor=${pageInfo.endCursor}`,
+      ]);
+      const nextComments = parsed.data?.node?.comments;
+      comments.push(...(nextComments?.nodes ?? []));
+      pageInfo = nextComments?.pageInfo;
+    }
+    return comments;
+  }
+  const threads = [];
+  let cursor = null;
+  while (true) {
+    const apiArgs = [
+      'api',
+      'graphql',
+      '-f',
+      `query=${outerQuery}`,
+      '-f',
+      `owner=${owner}`,
+      '-f',
+      `repo=${repo}`,
+      '-F',
+      `number=${number}`,
+    ];
+    if (cursor) {
+      apiArgs.push('-f', `cursor=${cursor}`);
+    }
+    const parsed = runQuery(apiArgs);
+    const connection = parsed.data?.repository?.pullRequest?.reviewThreads;
+    for (const node of connection?.nodes ?? []) {
+      const threadId = String(node.id ?? '');
+      threads.push({
+        id: threadId,
+        isResolved:
+          typeof node.isResolved === 'boolean' ? node.isResolved : null,
+        path: node.path == null ? null : String(node.path),
+        comments: walkThreadComments(
+          threadId,
+          node.comments?.nodes ?? [],
+          node.comments?.pageInfo,
+        ),
+      });
+    }
+    const pageInfo = connection?.pageInfo;
+    if (!pageInfo?.hasNextPage) {
+      break;
+    }
+    if (!pageInfo.endCursor) {
+      throw new Error(
+        `fetchReviewThreadsGeneric: thread page reported hasNextPage without endCursor for PR #${number}`,
+      );
+    }
+    cursor = pageInfo.endCursor;
+  }
+  return threads;
 }
 // The traversal-only helpers below (through wrapTraversalGhFailure) back
 // getWorkItemForTraversalAsync only -- a verbatim port of
@@ -805,6 +961,645 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
       const raw = deps.ghText(args, GH_TEXT_LOOP_OPTIONS).trim();
       const parsed = raw && raw !== 'null' ? JSON.parse(raw) : [];
       return Array.isArray(parsed) ? parsed : [];
+    },
+    // --- #2267 additions below. -------------------------------------------
+    getRepositoryDefaultBranch(defaultBranchOwner, defaultBranchRepo) {
+      return readGithubRepoDefaultBranch(defaultBranchOwner, defaultBranchRepo);
+    },
+    resolveViewerAppSlugSafe() {
+      const raw = safeGhTextLocal(
+        deps,
+        ['api', 'app', '--jq', '.slug // .app_slug // empty'],
+        GH_TEXT_LOOP_OPTIONS,
+      ).trim();
+      return raw
+        ? { appSlug: raw, unavailable: false }
+        : { appSlug: '', unavailable: true };
+    },
+    resolveViewerLoginSafeQuiet() {
+      // #2267: mirrors resolveViewerLoginSafe's query/never-throw contract,
+      // but with advisory-convergence.mts's own env-conditional stdio (CI
+      // stays silent/piped; a local run's stderr stays visible to the
+      // operator watching it) -- see this method's doc comment in
+      // provider-port.mts for why it is not folded into the existing one.
+      const stdio = process.env.GITHUB_ACTIONS
+        ? ['ignore', 'pipe', 'pipe']
+        : ['ignore', 'pipe', 'inherit'];
+      try {
+        const raw = deps.ghText(['api', 'user', '--jq', '.login'], { stdio });
+        const normalized = raw.trim().toLowerCase();
+        if (!normalized) {
+          return { viewerLogin: '', viewerLoginUnavailable: true };
+        }
+        return { viewerLogin: normalized, viewerLoginUnavailable: false };
+      } catch {
+        return { viewerLogin: '', viewerLoginUnavailable: true };
+      }
+    },
+    getRepositoryContentAtRef(contentOwner, contentRepo, path, ref) {
+      try {
+        return deps.ghApiJson(
+          `repos/${contentOwner}/${contentRepo}/contents/${path}?ref=${encodeURIComponent(ref)}`,
+        );
+      } catch (error) {
+        if (deriveGhHttpStatus(error) === 404) {
+          return null;
+        }
+        throw error;
+      }
+    },
+    getRepositoryFileContentAtRef(repoRef, path, ref) {
+      try {
+        const content = deps.ghText([
+          'api',
+          `repos/${repoRef}/contents/${path}`,
+          '--method',
+          'GET',
+          '--field',
+          `ref=${ref}`,
+          '--jq',
+          '.content',
+        ]);
+        return { outcome: 'ok', value: content };
+      } catch (error) {
+        if (deriveGhHttpStatus(error) === 404) {
+          return { outcome: 'not-found' };
+        }
+        throw error;
+      }
+    },
+    getTeamMembershipStateSafe(org, teamSlug, login) {
+      return safeGhTextLocal(
+        deps,
+        [
+          'api',
+          `orgs/${org}/teams/${teamSlug}/memberships/${encodeURIComponent(login)}`,
+          '--jq',
+          '.state',
+        ],
+        GH_TEXT_LOOP_OPTIONS,
+      ).trim();
+    },
+    getChangeRequestHeadShaAndAuthor(number) {
+      const raw = deps.ghText([
+        'pr',
+        'view',
+        String(number),
+        '-R',
+        `${owner}/${repo}`,
+        '--json',
+        'headRefOid,author',
+      ]);
+      const parsed = JSON.parse(raw);
+      return {
+        headSha: String(parsed.headRefOid ?? ''),
+        authorLogin: String(parsed.author?.login ?? ''),
+      };
+    },
+    getChangeRequestConvergenceView(number) {
+      const raw = deps.ghText([
+        'pr',
+        'view',
+        String(number),
+        '-R',
+        `${owner}/${repo}`,
+        '--json',
+        'headRefOid,headRefName,closingIssuesReferences,author,url',
+      ]);
+      const parsed = JSON.parse(raw);
+      return {
+        headSha: String(parsed.headRefOid ?? ''),
+        headRefName: String(parsed.headRefName ?? ''),
+        authorLogin: String(parsed.author?.login ?? ''),
+        url: String(parsed.url ?? ''),
+        closingIssuesReferences: parsed.closingIssuesReferences,
+      };
+    },
+    getChangeRequestReadinessSnapshot(number) {
+      const raw = deps.ghText([
+        'pr',
+        'view',
+        String(number),
+        '-R',
+        `${owner}/${repo}`,
+        '--json',
+        'headRefOid,baseRefName,url,author,reviewDecision,statusCheckRollup,mergeable,mergeStateStatus,closingIssuesReferences',
+      ]);
+      const parsed = JSON.parse(raw);
+      return {
+        headSha: String(parsed.headRefOid ?? ''),
+        baseRefName: String(parsed.baseRefName ?? ''),
+        url: String(parsed.url ?? ''),
+        authorLogin: String(parsed.author?.login ?? ''),
+        reviewDecision:
+          parsed.reviewDecision == null ? null : String(parsed.reviewDecision),
+        statusCheckRollup: parsed.statusCheckRollup,
+        mergeable: String(parsed.mergeable ?? ''),
+        mergeStateStatus: String(parsed.mergeStateStatus ?? ''),
+        closingIssuesReferences: parsed.closingIssuesReferences,
+      };
+    },
+    getChangeRequestBranchAndChecks(number) {
+      const raw = deps.ghText([
+        'pr',
+        'view',
+        String(number),
+        '-R',
+        `${owner}/${repo}`,
+        '--json',
+        'headRefOid,baseRefName,statusCheckRollup',
+      ]);
+      const parsed = JSON.parse(raw);
+      return {
+        headSha: String(parsed.headRefOid ?? ''),
+        baseRefName: String(parsed.baseRefName ?? ''),
+        statusCheckRollup: parsed.statusCheckRollup,
+      };
+    },
+    getChangeRequestHeadRef(number) {
+      return deps.ghText([
+        'api',
+        `${repoPath}/pulls/${number}`,
+        '--jq',
+        '.head.ref',
+      ]);
+    },
+    listMergedChangeRequests(limit, sinceDate) {
+      const args = [
+        'pr',
+        'list',
+        '-R',
+        `${owner}/${repo}`,
+        '--state',
+        'merged',
+        '--limit',
+        String(limit),
+        '--json',
+        'number,mergedAt',
+      ];
+      if (sinceDate) {
+        args.push('--search', `merged:>=${sinceDate}`);
+      }
+      const raw = deps.ghText(args, GH_TEXT_LOOP_OPTIONS);
+      const rows = JSON.parse(raw || '[]');
+      return rows.map((row) => ({
+        number: Number(row.number),
+        mergedAt: String(row.mergedAt ?? ''),
+      }));
+    },
+    getMergedChangeRequestMeta(number) {
+      const query = `query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){ number merged mergedAt mergeCommit{oid} }
+  }
+}`;
+      const apiArgs = [
+        'api',
+        'graphql',
+        '-f',
+        `query=${query}`,
+        '-f',
+        `owner=${owner}`,
+        '-f',
+        `repo=${repo}`,
+        '-F',
+        `number=${number}`,
+      ];
+      const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+      const pr = parsed.data?.repository?.pullRequest;
+      if (pr?.merged !== true) {
+        return null;
+      }
+      return {
+        number: Number(pr.number ?? number),
+        merged: true,
+        mergedAt: pr.mergedAt == null ? null : String(pr.mergedAt),
+        mergeCommitOid:
+          pr.mergeCommit?.oid == null ? null : String(pr.mergeCommit.oid),
+      };
+    },
+    listChangeRequestChecks(number) {
+      const args = [
+        'pr',
+        'checks',
+        String(number),
+        '--repo',
+        `${owner}/${repo}`,
+        '--json',
+        'name,state,completedAt',
+      ];
+      let raw;
+      try {
+        raw = deps.ghText(args, GH_TEXT_LOOP_OPTIONS);
+      } catch (error) {
+        const stderr = String(error?.stderr ?? '');
+        if (/no checks reported/i.test(stderr)) {
+          return [];
+        }
+        const stdout = String(error?.stdout ?? '').trim();
+        if (!stdout) {
+          throw error;
+        }
+        raw = stdout;
+      }
+      const rows = JSON.parse(raw || '[]');
+      return rows.map((row) => ({
+        name: String(row.name ?? ''),
+        state: String(row.state ?? ''),
+        completedAt: row.completedAt ? String(row.completedAt) : null,
+      }));
+    },
+    getChangeRequestRequestedReviewerLogins(number) {
+      const result = deps.ghApiJson(
+        `${repoPath}/pulls/${number}/requested_reviewers`,
+      );
+      return (result.users ?? []).map((user) => String(user.login ?? ''));
+    },
+    getChangeRequestRequestedReviewerLoginsGraphql(number) {
+      try {
+        const query = `query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){
+      reviewRequests(first:100){
+        nodes { requestedReviewer { ...on Bot{login} ...on User{login} ...on Mannequin{login} } }
+      }
+    }
+  }
+}`;
+        const apiArgs = [
+          'api',
+          'graphql',
+          '-f',
+          `query=${query}`,
+          '-f',
+          `owner=${owner}`,
+          '-f',
+          `repo=${repo}`,
+          '-F',
+          `number=${number}`,
+        ];
+        const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+        const nodes =
+          parsed.data?.repository?.pullRequest?.reviewRequests?.nodes ?? [];
+        return nodes
+          .map((node) => node.requestedReviewer?.login)
+          .filter((login) => typeof login === 'string');
+      } catch {
+        return null;
+      }
+    },
+    listChangeRequestChangedFiles(number) {
+      const rows = deps.ghApiJson(`${repoPath}/pulls/${number}/files`, {
+        paginate: true,
+      });
+      return rows.map((row) => String(row.filename ?? ''));
+    },
+    listChangeRequestCommits(number) {
+      return deps.ghApiJson(`${repoPath}/pulls/${number}/commits`, {
+        paginate: true,
+      });
+    },
+    listChangeRequestReviewThreadsWithComments(number) {
+      const nodes = fetchReviewThreadsGeneric(
+        deps,
+        owner,
+        repo,
+        number,
+        'body createdAt updatedAt author { login } pullRequestReview { id }',
+      );
+      return nodes.map((node) => ({
+        isResolved: node.isResolved,
+        comments: node.comments.map((comment) => ({
+          body: String(comment.body ?? ''),
+          createdAt: String(comment.createdAt ?? ''),
+          updatedAt: String(comment.updatedAt ?? ''),
+          authorLogin: String(comment.author?.login ?? ''),
+          pullRequestReviewId:
+            comment.pullRequestReview?.id == null
+              ? null
+              : String(comment.pullRequestReview.id),
+        })),
+      }));
+    },
+    listChangeRequestReviewThreadsExtended(number) {
+      const nodes = fetchReviewThreadsGeneric(
+        deps,
+        owner,
+        repo,
+        number,
+        'body url createdAt updatedAt author { login }',
+      );
+      return nodes.map((node) => ({
+        isResolved: node.isResolved,
+        path: node.path,
+        comments: node.comments.map((comment) => ({
+          body: String(comment.body ?? ''),
+          url: comment.url == null ? undefined : String(comment.url),
+          createdAt: String(comment.createdAt ?? ''),
+          updatedAt: String(comment.updatedAt ?? ''),
+          authorLogin: String(comment.author?.login ?? ''),
+        })),
+      }));
+    },
+    listChangeRequestReviewThreadCommentIds(number) {
+      const nodes = fetchReviewThreadsGeneric(
+        deps,
+        owner,
+        repo,
+        number,
+        'databaseId',
+      );
+      return nodes.map((node) => ({
+        threadId: node.id,
+        isResolved: node.isResolved,
+        commentDatabaseIds: node.comments
+          .map((comment) => comment.databaseId)
+          .filter((id) => typeof id === 'number'),
+      }));
+    },
+    listChangeRequestGraphqlComments(number) {
+      const query = `query($owner:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){
+      comments(first:100,after:$cursor){
+        nodes { body url createdAt updatedAt author { login } }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`;
+      const out = [];
+      let cursor = null;
+      while (true) {
+        const apiArgs = [
+          'api',
+          'graphql',
+          '-f',
+          `query=${query}`,
+          '-f',
+          `owner=${owner}`,
+          '-f',
+          `repo=${repo}`,
+          '-F',
+          `number=${number}`,
+        ];
+        if (cursor) {
+          apiArgs.push('-f', `cursor=${cursor}`);
+        }
+        const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+        const connection = parsed.data?.repository?.pullRequest?.comments;
+        for (const node of connection?.nodes ?? []) {
+          out.push({
+            body: String(node.body ?? ''),
+            url: String(node.url ?? ''),
+            createdAt: String(node.createdAt ?? ''),
+            updatedAt: String(node.updatedAt ?? ''),
+            authorLogin: String(node.author?.login ?? ''),
+          });
+        }
+        const pageInfo = connection?.pageInfo;
+        if (!pageInfo?.hasNextPage) {
+          break;
+        }
+        if (!pageInfo.endCursor) {
+          throw new Error(
+            `listChangeRequestGraphqlComments: page reported hasNextPage without endCursor for PR #${number}`,
+          );
+        }
+        cursor = pageInfo.endCursor;
+      }
+      return out;
+    },
+    listChangeRequestGraphqlReviews(number) {
+      const query = `query($owner:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){
+      reviews(first:100,after:$cursor){
+        nodes { body url state submittedAt author { login } }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`;
+      const out = [];
+      let cursor = null;
+      while (true) {
+        const apiArgs = [
+          'api',
+          'graphql',
+          '-f',
+          `query=${query}`,
+          '-f',
+          `owner=${owner}`,
+          '-f',
+          `repo=${repo}`,
+          '-F',
+          `number=${number}`,
+        ];
+        if (cursor) {
+          apiArgs.push('-f', `cursor=${cursor}`);
+        }
+        const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+        const connection = parsed.data?.repository?.pullRequest?.reviews;
+        for (const node of connection?.nodes ?? []) {
+          out.push({
+            body: String(node.body ?? ''),
+            url: String(node.url ?? ''),
+            state: String(node.state ?? ''),
+            submittedAt:
+              node.submittedAt == null ? null : String(node.submittedAt),
+            authorLogin: String(node.author?.login ?? ''),
+          });
+        }
+        const pageInfo = connection?.pageInfo;
+        if (!pageInfo?.hasNextPage) {
+          break;
+        }
+        if (!pageInfo.endCursor) {
+          throw new Error(
+            `listChangeRequestGraphqlReviews: page reported hasNextPage without endCursor for PR #${number}`,
+          );
+        }
+        cursor = pageInfo.endCursor;
+      }
+      return out;
+    },
+    listBranchRules(rulesOwner, rulesRepo, ref) {
+      return fetchGovernanceOutcome(() =>
+        deps.ghApiJson(
+          `repos/${rulesOwner}/${rulesRepo}/rules/branches/${encodeURIComponent(ref)}`,
+          { paginate: true },
+        ),
+      );
+    },
+    getBranchProtection(protectionOwner, protectionRepo, ref) {
+      return fetchGovernanceOutcome(() =>
+        deps.ghApiJson(
+          `repos/${protectionOwner}/${protectionRepo}/branches/${encodeURIComponent(ref)}/protection`,
+        ),
+      );
+    },
+    getRepositoryRulesetDetail(rulesetOwner, rulesetRepo, rulesetId) {
+      return fetchGovernanceOutcome(() =>
+        deps.ghApiJson(
+          `repos/${rulesetOwner}/${rulesetRepo}/rulesets/${rulesetId}`,
+          { extraArgs: ['-H', 'Accept: application/vnd.github+json'] },
+        ),
+      );
+    },
+    getWorkflowRun(runOwner, runRepo, runId) {
+      const raw = deps.ghText(
+        ['api', `repos/${runOwner}/${runRepo}/actions/runs/${runId}`],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      );
+      return JSON.parse(raw.trim() || '{}');
+    },
+    listWorkflowRuns(runsOwner, runsRepo, workflowName, limit) {
+      const raw = deps.ghText(
+        [
+          'run',
+          'list',
+          '--repo',
+          `${runsOwner}/${runsRepo}`,
+          '--workflow',
+          workflowName,
+          '--limit',
+          String(limit),
+          '--json',
+          'databaseId,conclusion,status,createdAt',
+        ],
+        GH_TEXT_LOOP_OPTIONS,
+      );
+      const rows = JSON.parse(raw || '[]');
+      return rows.map((row) => ({
+        id: Number(row.databaseId),
+        conclusion: row.conclusion == null ? null : String(row.conclusion),
+        status: String(row.status ?? ''),
+        createdAt: String(row.createdAt ?? ''),
+      }));
+    },
+    getChangeRequestHeadShaAtRepo(atRepoOwner, atRepoRepo, number) {
+      return deps.ghText([
+        'pr',
+        'view',
+        String(number),
+        '-R',
+        `${atRepoOwner}/${atRepoRepo}`,
+        '--json',
+        'headRefOid',
+        '--jq',
+        '.headRefOid',
+      ]);
+    },
+    getChangeRequestAtRepo(atRepoOwner, atRepoRepo, number) {
+      try {
+        const raw = deps.ghText(
+          [
+            'pr',
+            'view',
+            String(number),
+            '-R',
+            `${atRepoOwner}/${atRepoRepo}`,
+            '--json',
+            'mergeable,mergeStateStatus',
+          ],
+          GH_TEXT_LOOP_OPTIONS,
+        );
+        const parsed = JSON.parse(raw);
+        return {
+          mergeable: String(parsed.mergeable ?? ''),
+          mergeStateStatus: String(parsed.mergeStateStatus ?? ''),
+        };
+      } catch (error) {
+        if (deriveGhHttpStatus(error) === 404) {
+          return null;
+        }
+        throw error;
+      }
+    },
+    mergeChangeRequestAtRepo(mergeOwner, mergeRepo, number, headSha) {
+      return deps.ghText([
+        'pr',
+        'merge',
+        String(number),
+        '-R',
+        `${mergeOwner}/${mergeRepo}`,
+        '--merge',
+        '--match-head-commit',
+        headSha,
+      ]);
+    },
+    mergeChangeRequestAdminAtRepo(mergeOwner, mergeRepo, number, headSha) {
+      return deps.ghText([
+        'pr',
+        'merge',
+        String(number),
+        '-R',
+        `${mergeOwner}/${mergeRepo}`,
+        '--merge',
+        '--match-head-commit',
+        headSha,
+        '--admin',
+      ]);
+    },
+    mergeChangeRequest(number, headSha) {
+      return deps.ghText([
+        'pr',
+        'merge',
+        String(number),
+        '-R',
+        `${owner}/${repo}`,
+        '--merge',
+        '--match-head-commit',
+        headSha,
+      ]);
+    },
+    mergeChangeRequestAdmin(number, headSha) {
+      return deps.ghText([
+        'pr',
+        'merge',
+        String(number),
+        '-R',
+        `${owner}/${repo}`,
+        '--merge',
+        '--match-head-commit',
+        headSha,
+        '--admin',
+      ]);
+    },
+    postReviewCommentReply(number, commentId, body) {
+      const out = deps.ghText(
+        [
+          'api',
+          '--method',
+          'POST',
+          `${repoPath}/pulls/${number}/comments/${commentId}/replies`,
+          '--input',
+          '-',
+        ],
+        { input: JSON.stringify({ body }) },
+      );
+      const parsed = JSON.parse(out);
+      return { id: parsed.id };
+    },
+    resolveChangeRequestReviewThread(threadId) {
+      const mutation = `mutation($threadId:ID!){
+  resolveReviewThread(input:{threadId:$threadId}){ thread { isResolved } }
+}`;
+      const apiArgs = [
+        'api',
+        'graphql',
+        '-f',
+        `query=${mutation}`,
+        '-f',
+        `threadId=${threadId}`,
+      ];
+      const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+      if (parsed.data?.resolveReviewThread?.thread?.isResolved !== true) {
+        throw new Error(
+          `resolveChangeRequestReviewThread: GitHub did not confirm thread ${threadId} as resolved`,
+        );
+      }
     },
   };
 }

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -17,11 +17,25 @@ import {
   ghText,
   ghTextAsync,
   readGithubRepoDefaultBranch,
+  resolveGhApiHostname,
   withBoundedRetry,
 } from './gh-exec.mjs';
 import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import { PROVIDER_CAPABILITY_GROUPS } from './provider-contract.mjs';
 
+/**
+ * `--hostname` args to splice into a hand-built `['api', 'graphql', ...]`
+ * array right after `'graphql'`, matching `gh-exec.mts`'s `ghGraphql`/
+ * `ghApiJson` (#1962) -- this file's raw GraphQL call sites build their own
+ * args (see `fetchReviewThreadsGeneric`'s doc comment for why: a tight-loop
+ * stdin hazard, #1396) rather than routing through that shared helper, so
+ * each site must resolve the GHES host itself instead of always defaulting
+ * to github.com (Copilot review, PR #2429).
+ */
+function graphqlHostnameArgs() {
+  const hostname = resolveGhApiHostname();
+  return hostname ? ['--hostname', hostname] : [];
+}
 function statusToCategory(status) {
   if (status === 401) return 'authentication';
   if (status === 403) return 'authorization';
@@ -171,6 +185,7 @@ function fetchReviewThreadsGeneric(
       const parsed = runQuery([
         'api',
         'graphql',
+        ...graphqlHostnameArgs(),
         '-f',
         `query=${continuationQuery}`,
         '-f',
@@ -190,6 +205,7 @@ function fetchReviewThreadsGeneric(
     const apiArgs = [
       'api',
       'graphql',
+      ...graphqlHostnameArgs(),
       '-f',
       `query=${outerQuery}`,
       '-f',
@@ -1181,6 +1197,7 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
       const apiArgs = [
         'api',
         'graphql',
+        ...graphqlHostnameArgs(),
         '-f',
         `query=${query}`,
         '-f',
@@ -1263,6 +1280,7 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         const apiArgs = [
           'api',
           'graphql',
+          ...graphqlHostnameArgs(),
           '-f',
           `query=${query}`,
           '-f',
@@ -1368,6 +1386,7 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         const apiArgs = [
           'api',
           'graphql',
+          ...graphqlHostnameArgs(),
           '-f',
           `query=${query}`,
           '-f',
@@ -1385,8 +1404,24 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         );
         assertNoGraphqlErrors(rawComments, 'listChangeRequestGraphqlComments');
         const parsed = rawComments;
-        const connection = parsed.data?.repository?.pullRequest?.comments;
-        for (const node of connection?.nodes ?? []) {
+        // Fail fast on a missing pullRequest node or connection, matching
+        // merged-pr-feedback-sweep.mts's pre-migration fetchAllNodes
+        // (Codex review, PR #2429): an absent node/connection is otherwise
+        // read as zero comments, making a PR look "clean" -- the silent
+        // false negative this check exists to prevent.
+        const pullRequest = parsed.data?.repository?.pullRequest;
+        if (pullRequest == null) {
+          throw new Error(
+            `listChangeRequestGraphqlComments: PR #${number} returned no pullRequest node`,
+          );
+        }
+        const connection = pullRequest.comments;
+        if (connection == null) {
+          throw new Error(
+            `listChangeRequestGraphqlComments: PR #${number} returned a null comments connection`,
+          );
+        }
+        for (const node of connection.nodes ?? []) {
           out.push({
             body: String(node.body ?? ''),
             url: String(node.url ?? ''),
@@ -1395,7 +1430,7 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
             authorLogin: String(node.author?.login ?? ''),
           });
         }
-        const pageInfo = connection?.pageInfo;
+        const pageInfo = connection.pageInfo;
         if (!pageInfo?.hasNextPage) {
           break;
         }
@@ -1425,6 +1460,7 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         const apiArgs = [
           'api',
           'graphql',
+          ...graphqlHostnameArgs(),
           '-f',
           `query=${query}`,
           '-f',
@@ -1442,8 +1478,23 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         );
         assertNoGraphqlErrors(rawReviews, 'listChangeRequestGraphqlReviews');
         const parsed = rawReviews;
-        const connection = parsed.data?.repository?.pullRequest?.reviews;
-        for (const node of connection?.nodes ?? []) {
+        // Fail fast on a missing pullRequest node or connection, matching
+        // merged-pr-feedback-sweep.mts's pre-migration fetchAllNodes
+        // (Codex review, PR #2429) -- see listChangeRequestGraphqlComments's
+        // identical check above for the full rationale.
+        const pullRequest = parsed.data?.repository?.pullRequest;
+        if (pullRequest == null) {
+          throw new Error(
+            `listChangeRequestGraphqlReviews: PR #${number} returned no pullRequest node`,
+          );
+        }
+        const connection = pullRequest.reviews;
+        if (connection == null) {
+          throw new Error(
+            `listChangeRequestGraphqlReviews: PR #${number} returned a null reviews connection`,
+          );
+        }
+        for (const node of connection.nodes ?? []) {
           out.push({
             body: String(node.body ?? ''),
             url: String(node.url ?? ''),
@@ -1453,7 +1504,7 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
             authorLogin: String(node.author?.login ?? ''),
           });
         }
-        const pageInfo = connection?.pageInfo;
+        const pageInfo = connection.pageInfo;
         if (!pageInfo?.hasNextPage) {
           break;
         }
@@ -1513,7 +1564,9 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
       );
       const rows = JSON.parse(raw || '[]');
       return rows.map((row) => ({
-        id: Number(row.databaseId),
+        // String(...), not Number(...): preserves a databaseId above
+        // Number.MAX_SAFE_INTEGER exactly (Codex review, PR #2429).
+        id: String(row.databaseId ?? ''),
         conclusion: row.conclusion == null ? null : String(row.conclusion),
         status: String(row.status ?? ''),
         createdAt: String(row.createdAt ?? ''),
@@ -1595,6 +1648,7 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
       const apiArgs = [
         'api',
         'graphql',
+        ...graphqlHostnameArgs(),
         '-f',
         `query=${query}`,
         '-f',
@@ -1672,6 +1726,7 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         const apiArgs = [
           'api',
           'graphql',
+          ...graphqlHostnameArgs(),
           '-f',
           `query=${query}`,
           '-f',
@@ -1684,7 +1739,9 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         if (cursor) {
           apiArgs.push('-f', `cursor=${cursor}`);
         }
-        const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+        const raw = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+        assertNoGraphqlErrors(raw, 'getChangeRequestReviewsWithHeadCommitDate');
+        const parsed = raw;
         const pullRequest = parsed.data?.repository?.pullRequest;
         nodes.push(...(pullRequest?.reviews?.nodes ?? []));
         if (!headCommittedAt) {
@@ -1770,6 +1827,7 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
       const apiArgs = [
         'api',
         'graphql',
+        ...graphqlHostnameArgs(),
         '-f',
         `query=${mutation}`,
         '-f',

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -1189,7 +1189,9 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         '-F',
         `number=${number}`,
       ];
-      const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+      const raw = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+      assertNoGraphqlErrors(raw, 'getMergedChangeRequestMeta');
+      const parsed = raw;
       const pr = parsed.data?.repository?.pullRequest;
       if (pr?.merged !== true) {
         return null;
@@ -1377,7 +1379,11 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         if (cursor) {
           apiArgs.push('-f', `cursor=${cursor}`);
         }
-        const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+        const rawComments = JSON.parse(
+          deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS),
+        );
+        assertNoGraphqlErrors(rawComments, 'listChangeRequestGraphqlComments');
+        const parsed = rawComments;
         const connection = parsed.data?.repository?.pullRequest?.comments;
         for (const node of connection?.nodes ?? []) {
           out.push({
@@ -1430,7 +1436,11 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         if (cursor) {
           apiArgs.push('-f', `cursor=${cursor}`);
         }
-        const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+        const rawReviews = JSON.parse(
+          deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS),
+        );
+        assertNoGraphqlErrors(rawReviews, 'listChangeRequestGraphqlReviews');
+        const parsed = rawReviews;
         const connection = parsed.data?.repository?.pullRequest?.reviews;
         for (const node of connection?.nodes ?? []) {
           out.push({
@@ -1594,7 +1604,9 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         '-F',
         `number=${number}`,
       ];
-      const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+      const rawAuthor = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+      assertNoGraphqlErrors(rawAuthor, 'getChangeRequestAuthor');
+      const parsed = rawAuthor;
       const author = parsed.data?.repository?.pullRequest?.author;
       if (!author) {
         return null;

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -585,6 +585,7 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         id: Number(row.id),
         body: String(row.body ?? ''),
         createdAt: String(row.created_at ?? ''),
+        updatedAt: String(row.updated_at ?? row.created_at ?? ''),
         authorLogin: String(row.user?.login ?? ''),
       }));
     },
@@ -1179,6 +1180,16 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
       };
     },
     listChangeRequestChecks(number) {
+      // #2267: matches review-activity-snapshot.mts's pre-migration
+      // `ghJson(..., { allowStatuses: [1, 8] })` exactly -- an exit-code
+      // allowlist requiring stdout to actually look like JSON, not a
+      // stderr-content match. `gh pr checks` (no `--required`) exits 1 or 8
+      // while checks are pending/failing or reporting a mixed state, a
+      // routine outcome for this ALL-checks call -- but an allowed exit
+      // status with genuinely empty/non-JSON stdout (a different failure
+      // wearing the same exit code) still rethrows, unlike
+      // {@link listRequiredChecks}'s stricter `--required` recovery, which
+      // matches on stderr content instead.
       const args = [
         'pr',
         'checks',
@@ -1192,12 +1203,9 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
       try {
         raw = deps.ghText(args, GH_TEXT_LOOP_OPTIONS);
       } catch (error) {
-        const stderr = String(error?.stderr ?? '');
-        if (/no checks reported/i.test(stderr)) {
-          return [];
-        }
-        const stdout = String(error?.stdout ?? '').trim();
-        if (!stdout) {
+        const status = Number(error?.status ?? -1);
+        const stdout = String(error?.stdout ?? '');
+        if (![1, 8].includes(status) || !/^\s*[[{]/.test(stdout)) {
           throw error;
         }
         raw = stdout;

--- a/scripts/provider-contract.mjs
+++ b/scripts/provider-contract.mjs
@@ -39,6 +39,14 @@ export const PROVIDER_CAPABILITY_GROUPS = [
   'permissions',
   'branch-protection',
   'merge',
+  /**
+   * #2267: bot/advisory review interpretation (e.g. Copilot's own review
+   * body), distinct from `reviews-and-threads`'s required unresolved-thread
+   * safety gate -- a provider without an equivalent advisory reviewer
+   * resolves this `not_applicable` (optional) while `reviews-and-threads`
+   * stays required.
+   */
+  'advisory-review',
 ];
 /**
  * Whether a capability group is a required safety gate (unsupported must

--- a/scripts/resolve-review-thread.mjs
+++ b/scripts/resolve-review-thread.mjs
@@ -20,7 +20,6 @@ import {
   readForcedHandoffAuthorityPolicy,
   readForcedHandoffMode,
 } from './collaborator-permission.mjs';
-import { DEFAULT_GH_PAGINATED_TIMEOUT_MS, ghText } from './gh-exec.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import { appendReviewReplyStamp } from './marker-helpers.mjs';
 import {
@@ -28,6 +27,10 @@ import {
   isRejectionConfirmedDisposition,
   resolveActiveClaimForWriteGate,
 } from './protocol-helpers.mjs';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mjs';
 /**
  * Find the review thread that owns the review comment whose REST database id is
  * `commentId`. The GraphQL `PullRequestReviewComment.databaseId` equals the REST
@@ -197,35 +200,6 @@ thread in one invocation (E13). Dry-run by default; --apply mutates.
   -h, --help                     show this help
 `;
 /**
- * Fetch a paginated list endpoint as an array. `gh api --paginate` concatenates
- * one JSON array per page; `--jq '.[]'` flattens each page to one JSON value per
- * line (NDJSON), which we parse line-by-line (mirrors the sibling helpers).
- */
-function ghJsonPaginated(args) {
-  const out = ghText([...args, '--paginate', '--jq', '.[]'], {
-    timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS,
-  });
-  return out
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line !== '')
-    .map((line) => JSON.parse(line));
-}
-function ghGraphql(query, variables) {
-  const args = ['api', 'graphql', '-f', `query=${query}`];
-  for (const [key, value] of Object.entries(variables)) {
-    if (value === null || value === undefined) {
-      continue;
-    }
-    if (typeof value === 'number') {
-      args.push('-F', `${key}=${value}`);
-      continue;
-    }
-    args.push('-f', `${key}=${value}`);
-  }
-  return JSON.parse(ghText(args) || '{}');
-}
-/**
  * Throw when a GraphQL response carries top-level `errors`, so a bad
  * PR/repo/auth or any server-side GraphQL failure fails fast with a clear
  * message instead of being silently read as an empty result (which would
@@ -244,135 +218,19 @@ export function assertNoGraphqlErrors(payload, context) {
   }
 }
 /**
- * Fetch every review thread of a PR (paginated), each with its node id,
- * resolution state, and member comment database ids — enough to map a REST
- * comment id to its owning thread. Both the threads connection **and** each
- * thread's nested comments connection are paginated to completion, so a target
- * comment buried past the first 100 replies in a deep thread still resolves.
+ * Map {@link ProviderPort.listChangeRequestReviewThreadCommentIds}'s flat
+ * `commentDatabaseIds` shape onto this file's existing, independently-tested
+ * {@link ReviewThreadNode}/{@link findThreadForComment} contract, rather than
+ * changing that pure function's signature.
  */
-function fetchReviewThreads(owner, repo, prNumber) {
-  const nodes = [];
-  let cursor = null;
-  while (true) {
-    const payload = ghGraphql(
-      `query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
-        repository(owner: $owner, name: $repo) {
-          pullRequest(number: $number) {
-            reviewThreads(first: 100, after: $cursor) {
-              pageInfo { hasNextPage endCursor }
-              nodes {
-                id
-                isResolved
-                comments(first: 100) {
-                  pageInfo { hasNextPage endCursor }
-                  nodes { databaseId }
-                }
-              }
-            }
-          }
-        }
-      }`,
-      { owner, repo, number: prNumber, cursor },
-    );
-    assertNoGraphqlErrors(payload, 'review thread lookup');
-    const reviewThreads = payload?.data?.repository?.pullRequest?.reviewThreads;
-    for (const thread of reviewThreads?.nodes ?? []) {
-      if (thread.comments?.pageInfo?.hasNextPage) {
-        if (!thread.id || !thread.comments.pageInfo.endCursor) {
-          throw new Error(
-            'review thread comment pagination payload is missing id or endCursor',
-          );
-        }
-        thread.comments.nodes = [
-          ...(thread.comments.nodes ?? []),
-          ...fetchThreadCommentIds(
-            thread.id,
-            thread.comments.pageInfo.endCursor,
-          ),
-        ];
-        thread.comments.pageInfo.hasNextPage = false;
-      }
-    }
-    nodes.push(...(reviewThreads?.nodes ?? []));
-    if (!reviewThreads?.pageInfo?.hasNextPage) {
-      break;
-    }
-    if (!reviewThreads.pageInfo.endCursor) {
-      throw new Error('review thread pagination payload is missing endCursor');
-    }
-    cursor = reviewThreads.pageInfo.endCursor;
-  }
-  return nodes;
-}
-/**
- * Page the remaining comment-id nodes of one review thread, starting after
- * `afterCursor`, until the connection is exhausted. Mirrors the sibling
- * snapshot helper's nested-comment pagination.
- */
-function fetchThreadCommentIds(threadId, afterCursor) {
-  const nodes = [];
-  let cursor = afterCursor;
-  while (cursor) {
-    const payload = ghGraphql(
-      `query($id: ID!, $cursor: String) {
-        node(id: $id) {
-          ... on PullRequestReviewThread {
-            comments(first: 100, after: $cursor) {
-              pageInfo { hasNextPage endCursor }
-              nodes { databaseId }
-            }
-          }
-        }
-      }`,
-      { id: threadId, cursor },
-    );
-    assertNoGraphqlErrors(payload, 'review thread comment pagination');
-    const comments = payload?.data?.node?.comments;
-    nodes.push(...(comments?.nodes ?? []));
-    if (comments?.pageInfo?.hasNextPage && !comments.pageInfo.endCursor) {
-      throw new Error('thread comment pagination payload is missing endCursor');
-    }
-    cursor = comments?.pageInfo?.hasNextPage
-      ? comments.pageInfo.endCursor
-      : null;
-  }
-  return nodes;
-}
-/** Post a reply to the review thread that owns `commentId` (REST). */
-function postReply(owner, repo, pr, commentId, body) {
-  // JSON `--input -` is required: the reply-identity stamp is an HTML
-  // comment after the visible disposition, so `-f body=` can drop or
-  // truncate the multiline body.
-  return JSON.parse(
-    ghText(
-      [
-        'api',
-        '--method',
-        'POST',
-        `repos/${owner}/${repo}/pulls/${pr}/comments/${commentId}/replies`,
-        '--input',
-        '-',
-      ],
-      { input: JSON.stringify({ body }) },
-    ),
-  );
-}
-/** Resolve a review thread by its GraphQL node id, confirming the result. */
-function resolveThread(threadId) {
-  const payload = ghGraphql(
-    `mutation($threadId: ID!) {
-      resolveReviewThread(input: { threadId: $threadId }) {
-        thread { id isResolved }
-      }
-    }`,
-    { threadId },
-  );
-  assertNoGraphqlErrors(payload, 'resolveReviewThread');
-  if (payload?.data?.resolveReviewThread?.thread?.isResolved !== true) {
-    throw new Error(
-      'resolveReviewThread returned without confirming thread.isResolved',
-    );
-  }
+function toReviewThreadNodes(threads) {
+  return threads.map((thread) => ({
+    id: thread.threadId,
+    isResolved: Boolean(thread.isResolved),
+    comments: {
+      nodes: thread.commentDatabaseIds.map((databaseId) => ({ databaseId })),
+    },
+  }));
 }
 /**
  * Re-fetch the claim issue and return the active claim **owned by this session**
@@ -390,22 +248,18 @@ function resolveThread(threadId) {
  * is that branch.
  */
 function activeOwnedClaim(
-  owner,
-  repo,
+  port,
   issue,
   agentId,
   claimId,
   isTrustedAuthor,
   forcedHandoffOptions,
 ) {
-  const comments = ghJsonPaginated([
-    'api',
-    `repos/${owner}/${repo}/issues/${issue}/comments`,
-  ]);
+  const comments = port.listWorkItemComments(issue);
   const events = comments.map((comment) => ({
-    body: comment.body ?? '',
-    createdAt: comment.created_at ?? '',
-    author: { login: comment.user?.login ?? '' },
+    body: comment.body,
+    createdAt: comment.createdAt,
+    author: { login: comment.authorLogin },
   }));
   const active = resolveActiveClaimForWriteGate(events, {
     isTrustedAuthor,
@@ -476,13 +330,13 @@ if (import.meta.main) {
         typeof markerPrefixRaw === 'string' ? markerPrefixRaw : undefined,
       )
     : '';
-  const owner =
-    args.owner ||
-    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
-  const repo =
-    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createGithubProviderAdapter(owner, repo);
   const match = findThreadForComment(
-    fetchReviewThreads(owner, repo, pr),
+    toReviewThreadNodes(port.listChangeRequestReviewThreadCommentIds(pr)),
     commentId,
   );
   const report = {
@@ -518,15 +372,10 @@ if (import.meta.main) {
   // Bind the mutation to the claimed PR: the active claim's branch must be the
   // PR's head branch, so a valid claim on the issue cannot be used to reply to
   // and resolve a thread on some other PR passed as --pr.
-  const prHeadRef = ghText([
-    'api',
-    `repos/${owner}/${repo}/pulls/${pr}`,
-    '--jq',
-    '.head.ref',
-  ]);
+  const prHeadRef = port.getChangeRequestHeadRef(pr);
   // --apply: default the trusted claim authors to this gh login so the
   // revalidation recognizes the session's own claim markers.
-  const viewerLogin = ghText(['api', 'user', '--jq', '.login']).toLowerCase();
+  const viewerLogin = port.resolveViewerLogin().toLowerCase();
   const trustedAuthors = new Set(
     (args.trustedMarkerLogins.length > 0
       ? args.trustedMarkerLogins
@@ -566,8 +415,7 @@ if (import.meta.main) {
     const result = applyResolveReviewThread({
       assertClaim: () => {
         const active = activeOwnedClaim(
-          owner,
-          repo,
+          port,
           args.claimIssue,
           args.agentId,
           args.claimId,
@@ -586,11 +434,16 @@ if (import.meta.main) {
         }
       },
       postReply: () => {
-        const posted = postReply(owner, repo, pr, rootCommentId, stampedBody);
+        const posted = port.postReviewCommentReply(
+          pr,
+          rootCommentId,
+          stampedBody,
+        );
         postedReplyId = posted.id;
         return posted;
       },
-      resolveThread: () => resolveThread(match.threadId),
+      resolveThread: () =>
+        port.resolveChangeRequestReviewThread(match.threadId),
     });
     report.status = 'applied';
     report.replyId = result.replyId;

--- a/scripts/review-activity-snapshot.mjs
+++ b/scripts/review-activity-snapshot.mjs
@@ -5,15 +5,17 @@
 // source named above by `pnpm run build`. Edit the .mts source, never the
 // generated .mjs. See docs/typescript-sources.md.
 import { parseCliArgs } from './cli-args.mjs';
-import { DEFAULT_GH_PAGINATED_TIMEOUT_MS, ghText } from './gh-exec.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import {
   buildActivitySnapshotSummary,
-  parsePaginatedGhNdjson,
   resolveAdvisoryBotLogins,
   resolveTrustedMarkerActors,
   summarizeDispositionEvidenceForGate,
 } from './protocol-helpers.mjs';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mjs';
 
 // Flag-spec keys stay the dashed literal on purpose (never bare keys like
 // `pr:`): tests/flag-name-matrix.test.mts scans this file's *compiled*
@@ -51,12 +53,11 @@ function main() {
   if (!args.prNumber) {
     throw new Error('missing required --pr <number> argument');
   }
-  const owner =
-    args.owner ||
-    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
-  const repo =
-    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-  const repoRef = `${owner}/${repo}`;
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createGithubProviderAdapter(owner, repo);
   const iddConfig = loadIddConfig();
   const { actors: trustedMarkerLogins, source: trustedMarkerActorsSource } =
     resolveTrustedMarkerActors({
@@ -70,53 +71,23 @@ function main() {
       envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
       config: iddConfig,
     });
-  // #1833: also reads `author.login` (not just `headRefOid`) in this same
-  // call -- `summarizeDispositionEvidenceForGate` below needs the PR
-  // author's login to exclude the author's own comments/thread replies from
-  // "missing disposition" (they never require one), the same way
-  // `buildPreMergeReadinessSummary`'s own call to that function does.
-  // `ghJson`'s empty-response fallback is `'[]'` (array-shaped, tuned for
-  // the paginated `checks` call above); on this object-shaped `pr view`
-  // call an empty response would leave `headRefOid`/`author` both
-  // undefined, so `headSha` below becomes `''` and
-  // `watermarkFieldsFromSnapshot` (post-idd-marker.mts) throws "missing a
-  // usable headSha" downstream -- fail-closed, not a silent bad watermark.
-  const prView = ghJson([
-    'pr',
-    'view',
-    String(args.prNumber),
-    '-R',
-    repoRef,
-    '--json',
-    'headRefOid,author',
-  ]);
-  const headSha = String(prView.headRefOid ?? '');
-  const prAuthorLogin = String(prView.author?.login ?? '')
-    .trim()
-    .toLowerCase();
-  const checks = ghJson(
-    [
-      'pr',
-      'checks',
-      String(args.prNumber),
-      '-R',
-      repoRef,
-      '--json',
-      'name,state,completedAt',
-      '--jq',
-      '.',
-    ],
-    { allowStatuses: [1, 8] },
+  // #1833: also reads the PR author's login (not just headSha) --
+  // `summarizeDispositionEvidenceForGate` below needs it to exclude the
+  // author's own comments/thread replies from "missing disposition" (they
+  // never require one), the same way `buildPreMergeReadinessSummary`'s own
+  // call to that function does. A missing/unresolvable head SHA fails
+  // closed downstream (`watermarkFieldsFromSnapshot` in post-idd-marker.mts
+  // throws "missing a usable headSha"), not a silent bad watermark.
+  const { headSha: rawHeadSha, authorLogin: rawAuthorLogin } =
+    port.getChangeRequestHeadShaAndAuthor(args.prNumber);
+  const headSha = rawHeadSha;
+  const prAuthorLogin = rawAuthorLogin.trim().toLowerCase();
+  const checks = port.listChangeRequestChecks(args.prNumber);
+  const reviews = port.listReviews(args.prNumber);
+  const comments = port.listWorkItemComments(args.prNumber);
+  const threads = port.listChangeRequestReviewThreadsWithComments(
+    args.prNumber,
   );
-  const reviews = ghApiJson(
-    `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
-    true,
-  );
-  const comments = ghApiJson(
-    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
-    true,
-  );
-  const threads = fetchReviewThreads(owner, repo, args.prNumber);
   const normalizedComments = comments.map(normalizeComment);
   const normalizedThreads = threads.map(normalizeThread);
   const summary = buildActivitySnapshotSummary(
@@ -219,10 +190,10 @@ function printHelp() {
 }
 function normalizeComment(comment) {
   return {
-    author: { login: comment.user?.login ?? '' },
-    body: comment.body ?? '',
-    createdAt: comment.created_at ?? '',
-    updatedAt: comment.updated_at ?? comment.created_at ?? '',
+    author: { login: comment.authorLogin },
+    body: comment.body,
+    createdAt: comment.createdAt,
+    updatedAt: comment.updatedAt || comment.createdAt,
   };
 }
 function normalizeReview(review) {
@@ -236,189 +207,17 @@ function normalizeReview(review) {
 }
 function normalizeThread(thread) {
   return {
-    id: thread.id,
     isResolved: Boolean(thread.isResolved),
     updatedAt: '',
     comments: {
-      pageInfo: {
-        hasNextPage: Boolean(thread.comments?.pageInfo?.hasNextPage),
-      },
-      nodes: (thread.comments?.nodes ?? []).map((comment) => ({
-        author: { login: comment.author?.login ?? '' },
-        body: comment.body ?? '',
-        createdAt: comment.createdAt ?? '',
-        updatedAt: comment.updatedAt ?? comment.createdAt ?? '',
-        pullRequestReview: { id: comment.pullRequestReview?.id ?? null },
+      pageInfo: { hasNextPage: false },
+      nodes: thread.comments.map((comment) => ({
+        author: { login: comment.authorLogin },
+        body: comment.body,
+        createdAt: comment.createdAt,
+        updatedAt: comment.updatedAt || comment.createdAt,
+        pullRequestReview: { id: comment.pullRequestReviewId ?? null },
       })),
     },
   };
-}
-function fetchReviewThreads(owner, repo, prNumber) {
-  const nodes = [];
-  let cursor = null;
-  while (true) {
-    const payload = ghGraphql(
-      `
-        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
-          repository(owner: $owner, name: $repo) {
-            pullRequest(number: $number) {
-              reviewThreads(first: 100, after: $cursor) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  id
-                  isResolved
-                  comments(first: 100) {
-                    pageInfo { hasNextPage endCursor }
-                    nodes {
-                      body
-                      createdAt
-                      updatedAt
-                      author { login }
-                      pullRequestReview { id }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }`,
-      {
-        owner,
-        repo,
-        number: Number.parseInt(String(prNumber), 10),
-        cursor,
-      },
-    );
-    const reviewThreads = payload?.data?.repository?.pullRequest?.reviewThreads;
-    for (const thread of reviewThreads?.nodes ?? []) {
-      if (thread.comments?.pageInfo?.hasNextPage) {
-        // hasNextPage with a missing thread id or cursor is a malformed
-        // payload; fail fast with a clear message instead of a confusing
-        // GraphQL error or a silently truncated thread.
-        if (!thread.id || !thread.comments.pageInfo.endCursor) {
-          throw new Error(
-            'review thread pagination payload is missing id or endCursor',
-          );
-        }
-        thread.comments.nodes.push(
-          ...fetchThreadCommentPages(
-            thread.id,
-            thread.comments.pageInfo.endCursor,
-          ),
-        );
-        thread.comments.pageInfo.hasNextPage = false;
-      }
-    }
-    nodes.push(...(reviewThreads?.nodes ?? []));
-    if (!reviewThreads?.pageInfo?.hasNextPage) {
-      break;
-    }
-    // hasNextPage with a missing cursor would re-fetch the first page
-    // forever; fail fast on the malformed payload instead.
-    if (!reviewThreads.pageInfo.endCursor) {
-      throw new Error('review thread pagination payload is missing endCursor');
-    }
-    cursor = reviewThreads.pageInfo.endCursor;
-  }
-  return nodes;
-}
-function fetchThreadCommentPages(threadId, afterCursor) {
-  const nodes = [];
-  let cursor = afterCursor;
-  while (cursor) {
-    const payload = ghGraphql(
-      `
-        query($id: ID!, $cursor: String) {
-          node(id: $id) {
-            ... on PullRequestReviewThread {
-              comments(first: 100, after: $cursor) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  body
-                  createdAt
-                  updatedAt
-                  author { login }
-                  pullRequestReview { id }
-                }
-              }
-            }
-          }
-        }`,
-      { id: threadId, cursor },
-    );
-    const comments = payload?.data?.node?.comments;
-    nodes.push(...(comments?.nodes ?? []));
-    if (comments?.pageInfo?.hasNextPage && !comments.pageInfo.endCursor) {
-      throw new Error('thread comment pagination payload is missing endCursor');
-    }
-    cursor = comments?.pageInfo?.hasNextPage
-      ? comments.pageInfo.endCursor
-      : null;
-  }
-  return nodes;
-}
-function ghGraphql(query, variables) {
-  const args = ['api', 'graphql', '-f', `query=${query}`];
-  for (const [key, value] of Object.entries(variables)) {
-    if (value === null || value === undefined) {
-      continue;
-    }
-    if (typeof value === 'number') {
-      args.push('-F', `${key}=${value}`);
-      continue;
-    }
-    args.push('-f', `${key}=${value}`);
-  }
-  return JSON.parse(runGh(args).trim() || '{}');
-}
-function ghJson(args, options = {}) {
-  return JSON.parse(runGh(args, options).trim() || '[]');
-}
-function ghApiJson(path, paginate = false, fields = null) {
-  const args = ['api', path];
-  if (fields) {
-    for (const [key, value] of Object.entries(fields)) {
-      args.push(
-        '-f',
-        `${key}=${typeof value === 'string' ? value : JSON.stringify(value)}`,
-      );
-    }
-  }
-  // #1692: `--jq '.[]'` (not a bare `--paginate`) makes gh emit one JSON
-  // value per line, guaranteed newline-separated, for every element across
-  // every page -- without it, `--paginate` alone concatenates each page's
-  // whole-array response with no separator on gh 2.45.0 (this repo's
-  // documented compatibility floor), which broke a naive split('\n') on
-  // multi-page output. Matches the NDJSON convention `gh-exec.mts`'s
-  // shared `ghApiJson` already uses.
-  if (paginate) {
-    args.push('--paginate', '--jq', '.[]');
-  }
-  const raw = runGh(args).trim();
-  if (!raw) {
-    return [];
-  }
-  if (paginate) {
-    return parsePaginatedGhNdjson(raw);
-  }
-  return JSON.parse(raw);
-}
-function runGh(args, options = {}) {
-  try {
-    return ghText(
-      args,
-      args.includes('--paginate')
-        ? { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS }
-        : {},
-    );
-  } catch (error) {
-    const status = Number(error?.status ?? -1);
-    if ((options.allowStatuses ?? []).includes(status)) {
-      const stdout = String(error?.stdout ?? '');
-      if (/^\s*[[{]/.test(stdout)) {
-        return stdout;
-      }
-    }
-    throw error;
-  }
 }

--- a/scripts/review-clause.mjs
+++ b/scripts/review-clause.mjs
@@ -162,16 +162,26 @@ export function resolveLatestCopilotReviewClause(
  * `committedDate`, via {@link ProviderPort.getChangeRequestReviewsWithHeadCommitDate}
  * (#2267) -- the same GraphQL query `advisory-convergence.mts`'s own
  * Clause 1 evidence collection has always used, now routed through the
- * GitHub provider adapter instead of a direct `ghGraphql` call. Keeps its
- * pre-migration `(owner, repo, prNumber)` signature unchanged: the
- * out-of-scope `rerun-advisory-convergence.mts` caller (see this file's
- * module header) also relies on this exact call shape.
+ * GitHub provider adapter instead of a direct `ghGraphql` call. Extended
+ * additively with an optional trailing `port` (defaults to
+ * `createGithubProviderAdapter(owner, repo)`): every existing caller
+ * (this file's own out-of-scope `rerun-advisory-convergence.mts`,
+ * `pre-merge-readiness.mts`, `advisory-convergence.mts`) still calls this
+ * with the unchanged 3-arg `(owner, repo, prNumber)` shape, so the
+ * injection is invisible to them -- it exists so a caller that already
+ * holds its own fake-backed `ProviderPort` (e.g. a test driving
+ * `pre-merge-readiness.mts`'s `collectPreMergeReadiness` end to end) can
+ * pass it through instead of this function constructing its own live
+ * adapter.
  */
-export function fetchReviewsAndHeadCommit(owner, repo, prNumber) {
-  const { reviews: nodes, headCommittedAt } = createGithubProviderAdapter(
-    owner,
-    repo,
-  ).getChangeRequestReviewsWithHeadCommitDate(prNumber);
+export function fetchReviewsAndHeadCommit(
+  owner,
+  repo,
+  prNumber,
+  port = createGithubProviderAdapter(owner, repo),
+) {
+  const { reviews: nodes, headCommittedAt } =
+    port.getChangeRequestReviewsWithHeadCommitDate(prNumber);
   const reviews = nodes.map((node) => ({
     id: node.id || null,
     author: { login: node.authorLogin, __typename: node.authorTypename },

--- a/scripts/review-clause.mjs
+++ b/scripts/review-clause.mjs
@@ -14,19 +14,19 @@
 // from here too -- this file has no behavior of its own beyond what both
 // callers already relied on before the extraction.
 //
-// Kept deliberately small (only depends on `gh-exec.mts`'s shared
-// `ghGraphql`, `protocol-helpers.mts`'s shared `isCopilotReviewerLogin`,
-// and -- as of #1880 -- `markdown-code.mts`'s shared
-// `stripMarkdownCodeRegions`) so a read-only, low-dependency caller like
-// `rerun-advisory-convergence.mts` can import it without also pulling in
-// `advisory-convergence.mts`'s full claim/waiver/disposition machinery --
-// see that file's own module-header "Reuse map" comment. The first two
-// dependencies are already reused directly by `rerun-advisory-convergence.mts`
-// itself today; `markdown-code.mts` has no imports of its own, so this adds
-// no heavy dependency surface to that caller either.
-import { ghGraphql } from './gh-exec.mjs';
+// Kept deliberately small (only depends on `provider-adapter-github.mts`'s
+// shared GitHub port adapter -- #2267, replacing the direct `ghGraphql`
+// call this file used before -- `protocol-helpers.mts`'s shared
+// `isCopilotReviewerLogin`, and -- as of #1880 -- `markdown-code.mts`'s
+// shared `stripMarkdownCodeRegions`) so a read-only, low-dependency caller
+// like `rerun-advisory-convergence.mts` can import it without also pulling
+// in `advisory-convergence.mts`'s full claim/waiver/disposition machinery
+// -- see that file's own module-header "Reuse map" comment. `markdown-
+// code.mts` has no imports of its own, so this adds no heavy dependency
+// surface to that caller either.
 import { stripMarkdownCodeRegions } from './markdown-code.mjs';
 import { isCopilotReviewerLogin } from './protocol-helpers.mjs';
+import { createGithubProviderAdapter } from './provider-adapter-github.mjs';
 
 /** Matches GitHub Copilot's `<summary>Suppressed comments (N)</summary>`
  * heading, case-insensitively -- the only structured signal a suppressed
@@ -159,63 +159,26 @@ export function resolveLatestCopilotReviewClause(
 }
 /**
  * Fetch every PR review (paginated) plus the current HEAD commit's
- * `committedDate`, via the same GraphQL query `advisory-convergence.mts`'s
- * own Clause 1 evidence collection has always used.
+ * `committedDate`, via {@link ProviderPort.getChangeRequestReviewsWithHeadCommitDate}
+ * (#2267) -- the same GraphQL query `advisory-convergence.mts`'s own
+ * Clause 1 evidence collection has always used, now routed through the
+ * GitHub provider adapter instead of a direct `ghGraphql` call. Keeps its
+ * pre-migration `(owner, repo, prNumber)` signature unchanged: the
+ * out-of-scope `rerun-advisory-convergence.mts` caller (see this file's
+ * module header) also relies on this exact call shape.
  */
 export function fetchReviewsAndHeadCommit(owner, repo, prNumber) {
-  const nodes = [];
-  let headCommittedAt = '';
-  let cursor = null;
-  // Paginate `reviews`: a PR with more than one page of reviews would
-  // otherwise silently evaluate Clause 1 against only the first 100,
-  // potentially missing a later, dirty, current-HEAD review (see PR #1343
-  // review). `commits(last: 1)` is fetched once, on the first page, since
-  // it never changes across pages.
-  while (true) {
-    const payload = ghGraphql(
-      `
-        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
-          repository(owner: $owner, name: $repo) {
-            pullRequest(number: $number) {
-              reviews(first: 100, after: $cursor) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  id
-                  commit { oid }
-                  submittedAt
-                  author { login __typename }
-                  comments { totalCount }
-                  body
-                }
-              }
-              commits(last: 1) {
-                nodes { commit { committedDate } }
-              }
-            }
-          }
-        }`,
-      { owner, repo, number: prNumber, cursor },
-    );
-    const pullRequest = payload?.data?.repository?.pullRequest;
-    nodes.push(...(pullRequest?.reviews?.nodes ?? []));
-    if (!headCommittedAt) {
-      headCommittedAt = String(
-        pullRequest?.commits?.nodes?.[0]?.commit?.committedDate ?? '',
-      );
-    }
-    if (!pullRequest?.reviews?.pageInfo?.hasNextPage) break;
-    if (!pullRequest.reviews.pageInfo.endCursor) {
-      throw new Error('review pagination payload is missing endCursor');
-    }
-    cursor = pullRequest.reviews.pageInfo.endCursor;
-  }
+  const { reviews: nodes, headCommittedAt } = createGithubProviderAdapter(
+    owner,
+    repo,
+  ).getChangeRequestReviewsWithHeadCommitDate(prNumber);
   const reviews = nodes.map((node) => ({
-    id: node.id ?? null,
-    author: node.author ?? null,
-    submittedAt: node.submittedAt ?? null,
-    commitId: node.commit?.oid ?? null,
-    itemCount: node.comments?.totalCount ?? null,
-    body: node.body ?? null,
+    id: node.id || null,
+    author: { login: node.authorLogin, __typename: node.authorTypename },
+    submittedAt: node.submittedAt,
+    commitId: node.commitId,
+    itemCount: node.commentCount,
+    body: node.body,
   }));
   return { reviews, headCommittedAt };
 }

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -91,6 +91,7 @@
 // concurrency group, not a plain immediate-assert failure) -- the poll's
 // actual win is narrower than "never needs a rerun again."
 
+import type { StdioOptions } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
 import {
@@ -118,14 +119,6 @@ import {
   normalizeAuthorityEvidence,
   resolveCollaboratorAuthority,
 } from './external-check-waiver.mts';
-import {
-  GH_TEXT_LOOP_OPTIONS,
-  type GhTextOptions,
-  ghApiJson,
-  ghGraphql,
-  ghText,
-  safeGhText,
-} from './gh-exec.mts';
 import { loadIddConfig } from './idd-config.mts';
 import { isValidIsoTimestamp, parseClaimComment } from './marker-helpers.mts';
 import {
@@ -147,9 +140,19 @@ import {
   summarizeExternalCheckWaivers,
 } from './protocol-helpers.mts';
 import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mts';
+import { evaluateProviderCapabilityOutcome } from './provider-contract.mts';
+import {
   evaluateProviderOutageRelief,
   resolveProviderOutageDeclaration,
 } from './provider-outage-declaration.mts';
+import type {
+  ProviderComment,
+  ProviderPort,
+  ProviderReviewThreadWithAuthorType,
+} from './provider-port.mts';
 // #1806: the latest-review Clause 1 evidence (types + pure evaluator + the
 // GraphQL fetch behind it) moved to `review-clause.mts` so
 // `rerun-advisory-convergence.mts` can reuse the SAME evidence this gate
@@ -285,18 +288,6 @@ interface ReviewThreadPayload {
     } | null;
     nodes: ThreadCommentPayload[];
   } | null;
-}
-
-/** GraphQL pagination cursor block. */
-interface PageInfoPayload {
-  hasNextPage?: boolean | null;
-  endCursor?: string | null;
-}
-
-/** GraphQL `reviewThreads` connection payload. */
-interface ReviewThreadsConnectionPayload {
-  pageInfo?: PageInfoPayload | null;
-  nodes?: ReviewThreadPayload[] | null;
 }
 
 /** `gh pr view --json closingIssuesReferences` entry. */
@@ -2079,15 +2070,15 @@ export function runAdvisoryConvergenceWithPoll(
 // --- Production I/O: fetch PR/review/thread/comment evidence via `gh` ----
 
 /**
- * `gh` options for the viewer-login probe (`gh api user`).
+ * `gh` stdio policy for the viewer-login probe (`gh api user`).
  *
  * Under GitHub Actions the workflow token is a GitHub App installation token
  * with no authenticated user, so `gh api user` always returns 403 ("Resource
  * not accessible by integration"). That is expected and harmless here:
- * {@link safeGhText} swallows it and `viewerLogin === ''` is the correct value
- * in CI (there is no runner "self" whose markers should be trusted). Only the
- * inherited stderr leaks the confusing 403 line into the run log, so under
- * Actions we capture that run's stderr (`stdio` pipe) to keep the log clean.
+ * `viewerLogin === ''` is the correct value in CI (there is no runner "self"
+ * whose markers should be trusted). Only the inherited stderr leaks the
+ * confusing 403 line into the run log, so under Actions we capture that
+ * run's stderr (`stdio` pipe) to keep the log clean.
  *
  * Outside Actions (a local/interactive run) the probe normally succeeds; if it
  * genuinely fails we deliberately **inherit** stderr so the failure stays
@@ -2098,12 +2089,18 @@ export function runAdvisoryConvergenceWithPoll(
  * `execFileSync`'s default: that default already writes the child's stderr to
  * the parent (so a bare call would leak the 403), but relying on it is
  * non-obvious. `pipe` captures stderr (silent); `inherit` forwards it to the
- * parent (visible). stdin is `ignore` on both, matching `GH_TEXT_LOOP_OPTIONS`'
- * stdin-safety.
+ * parent (visible). stdin is `ignore` on both.
+ *
+ * #2267: this exact policy now lives inside
+ * `ProviderPort.resolveViewerLoginSafeQuiet`'s GitHub adapter implementation
+ * (`provider-adapter-github.mts`), which `collectFromGitHub` below calls
+ * instead of invoking `gh` directly. Kept here, unused in production, only
+ * because it is directly unit-tested pure logic (no `gh` invocation of its
+ * own) documenting the policy the adapter mirrors.
  */
-export function viewerProbeGhOptions(
-  env: NodeJS.ProcessEnv = process.env,
-): GhTextOptions {
+export function viewerProbeGhOptions(env: NodeJS.ProcessEnv = process.env): {
+  stdio: StdioOptions;
+} {
   return {
     stdio:
       env.GITHUB_ACTIONS === 'true'
@@ -2112,20 +2109,34 @@ export function viewerProbeGhOptions(
   };
 }
 
-function collectFromGitHub(args: AdvisoryConvergenceArgs): {
+/**
+ * `createPort` is injectable (defaults to the real GitHub adapter) so a test
+ * can drive this collection entry end to end against
+ * `createFakeProviderAdapter` fixtures instead of a live `gh` process
+ * (#2267 AC4's "unit tests exercise the PR-facing state machine with a fake
+ * provider" -- see the exported `collectFromGitHub` used directly by
+ * `advisory-convergence-fake-provider.test.mts`). `defaultDeps.collect`
+ * (this file's own production wiring for `runAdvisoryConvergence`) never
+ * passes a second argument, so it keeps using the real adapter unchanged.
+ */
+export function collectFromGitHub(
+  args: AdvisoryConvergenceArgs,
+  createPort: (
+    owner: string,
+    repo: string,
+  ) => ProviderPort = createGithubProviderAdapter,
+): {
   inputs: AdvisoryConvergenceInputs;
   options: AdvisoryConvergenceOptions;
 } {
-  const owner =
-    args.owner ||
-    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
-  const repo =
-    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-  const repoRef = `${owner}/${repo}`;
-  const viewerLogin = safeGhText(
-    ['api', 'user', '--jq', '.login'],
-    viewerProbeGhOptions(),
-  ).toLowerCase();
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createPort(owner, repo);
+  const viewerLogin = port
+    .resolveViewerLoginSafeQuiet()
+    .viewerLogin.toLowerCase();
   const rawConfig = loadIddConfig();
   const { actors: configuredTrustedActors } = resolveTrustedMarkerActors({
     flagValue: args.trustedMarkerLogins,
@@ -2137,37 +2148,21 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
     envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
     config: rawConfig,
   });
-  const pr = JSON.parse(
-    ghText([
-      'pr',
-      'view',
-      String(args.prNumber),
-      '-R',
-      repoRef,
-      '--json',
-      'headRefOid,headRefName,closingIssuesReferences,author,url',
-    ]),
-  ) as {
-    headRefOid?: unknown;
-    headRefName?: unknown;
-    closingIssuesReferences?: ClosingIssueRefPayload[] | null;
-    author?: GhAuthorPayload | null;
-    url?: unknown;
-  };
-  const prHeadSha = String(pr.headRefOid ?? '').toLowerCase();
-  const prHeadRefName = String(pr.headRefName ?? '').trim();
-  const prAuthorLogin = String(pr.author?.login ?? '').toLowerCase();
-  const prUrl = String(pr.url ?? '');
+  const view = port.getChangeRequestConvergenceView(Number(args.prNumber));
+  const prHeadSha = view.headSha.toLowerCase();
+  const prHeadRefName = view.headRefName.trim();
+  const prAuthorLogin = view.authorLogin.toLowerCase();
+  const prUrl = view.url;
+  const closingIssuesReferences = view.closingIssuesReferences as
+    | ClosingIssueRefPayload[]
+    | null;
 
   // Fetched here (ahead of `trustedMarkerLogins` below) so a collaborator's
   // marker-shaped PR comment can be detected before that set is used to
   // resolve `claimEvents` -- see `resolveTrustedCollaboratorMarkerLogins`.
-  const comments = ghApiJson(
-    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
-    {
-      paginate: true,
-    },
-  ) as IssueCommentPayload[];
+  const comments = port
+    .listWorkItemComments(Number(args.prNumber))
+    .map(toIssueCommentPayload);
 
   // #1344: collaborator-marker trust, matching `pre-merge-readiness.mts`'s
   // `readCollaboratorTrustEnabled` exactly, except reusing the already-
@@ -2183,8 +2178,9 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
     owner,
     repo,
     Number(args.prNumber),
+    port,
   );
-  const threads = fetchReviewThreads(owner, repo, Number(args.prNumber));
+  const threads = fetchReviewThreads(port, Number(args.prNumber));
 
   // #1347: fetch every claim-issue candidate's raw comments (pure I/O)
   // BEFORE computing `trustedMarkerLogins`, so collaborator-marker trust
@@ -2197,10 +2193,9 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
   // claim data before that trust is ever computed. See
   // `pickResolvingClaimEvents`'s doc comment for the full history.
   const claimCandidates = fetchClaimEventCandidates(
-    owner,
-    repo,
+    port,
     args.claimIssueNumber,
-    pr.closingIssuesReferences,
+    closingIssuesReferences,
   );
 
   // Deliberately NOT unioned with `advisoryBotLogins` here (unlike some
@@ -2229,7 +2224,7 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
     viewerLogin,
     ...configuredTrustedActors,
     ...(collaboratorTrustEnabled
-      ? resolveTrustedCollaboratorMarkerLogins(owner, repo, [
+      ? resolveTrustedCollaboratorMarkerLogins(port, [
           ...comments,
           ...claimCandidates.flat(),
         ])
@@ -2291,10 +2286,9 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
     policy?.providerOutage?.declarationTarget;
   if (outageDeclarationTargetIssue) {
     try {
-      const declarationComments = ghApiJson(
-        `repos/${owner}/${repo}/issues/${outageDeclarationTargetIssue}/comments`,
-        { paginate: true },
-      ) as IssueCommentPayload[];
+      const declarationComments = port
+        .listWorkItemComments(outageDeclarationTargetIssue)
+        .map(toIssueCommentPayload);
       const authorityOf = (actorLogin: string): AuthorityEvidence =>
         normalizeAuthorityEvidence(
           resolveCollaboratorAuthority({ owner, repo, actor: actorLogin }),
@@ -2334,9 +2328,8 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
   let prFirstCommitAt: string | null = null;
   if (forcedHandoffEnabled) {
     try {
-      const prCommits = ghApiJson(
-        `repos/${owner}/${repo}/pulls/${args.prNumber}/commits`,
-        { paginate: true },
+      const prCommits = port.listChangeRequestCommits(
+        Number(args.prNumber),
       ) as PrCommitPayload[];
       prFirstCommitAt = resolvePrFirstCommitAt(prCommits);
     } catch {
@@ -2369,15 +2362,32 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
   // treats only exact human-required / no-advisory as skip, so an
   // invalid string still keeps today's Copilot / primaryBotLogin
   // applicability.
-  const reviewPolicy =
-    typeof rawConfig?.reviewPolicy === 'string'
+  //
+  // #2267: a provider that declares its `advisory-review` capability
+  // unsupported (a non-GitHub adapter with no equivalent advisory
+  // reviewer) coerces this gate to the same `'no-advisory'` skip a
+  // repository can already opt into by config -- reusing the #2137-tested
+  // skip path instead of adding a second one, and inert for GitHub, whose
+  // adapter always declares every capability supported (see
+  // `listCapabilityDeclarations`).
+  const advisoryReviewDeclaration = port
+    .listCapabilityDeclarations()
+    .find((declaration) => declaration.group === 'advisory-review');
+  const advisoryReviewUnsupported = Boolean(
+    advisoryReviewDeclaration &&
+      evaluateProviderCapabilityOutcome(advisoryReviewDeclaration) ===
+        'not_applicable',
+  );
+  const reviewPolicy = advisoryReviewUnsupported
+    ? 'no-advisory'
+    : typeof rawConfig?.reviewPolicy === 'string'
       ? rawConfig.reviewPolicy
       : undefined;
   let prAuthorIsBot = false;
   if (exemptBotAuthoredPrs && convergenceScope === 'all-prs') {
     try {
       prAuthorIsBot =
-        fetchPrAuthor(owner, repo, Number(args.prNumber))?.__typename === 'Bot';
+        fetchPrAuthor(port, Number(args.prNumber))?.__typename === 'Bot';
     } catch {
       prAuthorIsBot = false;
     }
@@ -2450,20 +2460,13 @@ function collectFromGitHub(args: AdvisoryConvergenceArgs): {
  * imported since it is not exported.
  */
 function fetchClaimComments(
-  owner: string,
-  repo: string,
+  port: ProviderPort,
   issueNumber: number,
 ): IssueCommentPayload[] {
-  const raw = ghApiJson(
-    `repos/${owner}/${repo}/issues/${issueNumber}/comments`,
-    {
-      paginate: true,
-    },
-  ) as IssueCommentPayload[];
-  return raw.map((comment) => ({
-    body: comment.body ?? '',
-    createdAt: comment.createdAt ?? comment.created_at ?? '',
-    author: { login: comment.author?.login ?? comment.user?.login ?? '' },
+  return port.listWorkItemComments(issueNumber).map((comment) => ({
+    body: comment.body,
+    createdAt: comment.createdAt,
+    author: { login: comment.authorLogin },
   }));
 }
 
@@ -2485,13 +2488,12 @@ function fetchClaimComments(
  * in.
  */
 function fetchClaimEventCandidates(
-  owner: string,
-  repo: string,
+  port: ProviderPort,
   explicitIssueNumber: number | null,
   refs: ClosingIssueRefPayload[] | null | undefined,
 ): IssueCommentPayload[][] {
   if (explicitIssueNumber) {
-    return [fetchClaimComments(owner, repo, explicitIssueNumber)];
+    return [fetchClaimComments(port, explicitIssueNumber)];
   }
   const candidateNumbers = [
     ...new Set(
@@ -2501,7 +2503,7 @@ function fetchClaimEventCandidates(
     ),
   ];
   return candidateNumbers.map((issueNumber) =>
-    fetchClaimComments(owner, repo, issueNumber),
+    fetchClaimComments(port, issueNumber),
   );
 }
 
@@ -2704,8 +2706,7 @@ export function resolveClaimEvidence(
  * is enabled -- a no-op repository never pays for these lookups.
  */
 function resolveTrustedCollaboratorMarkerLogins(
-  owner: string,
-  repo: string,
+  port: ProviderPort,
   commentLikeEvents: IssueCommentPayload[],
 ): string[] {
   const markerAuthors = [
@@ -2720,16 +2721,8 @@ function resolveTrustedCollaboratorMarkerLogins(
   ];
 
   return markerAuthors.filter((login) => {
-    const permission = safeGhText(
-      [
-        'api',
-        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-        '--jq',
-        '.permission',
-      ],
-      GH_TEXT_LOOP_OPTIONS,
-    ).toLowerCase();
-
+    const result = port.getCollaboratorPermission(login);
+    const permission = result.outcome === 'found' ? result.permission : '';
     return (
       permission === 'admin' ||
       permission === 'maintain' ||
@@ -2738,18 +2731,30 @@ function resolveTrustedCollaboratorMarkerLogins(
   });
 }
 
-// `ghGraphql` now lives in `gh-exec.mts` (imported above) and
-// `fetchReviewsAndHeadCommit` (+ its local `RawReviewNode` shape) now
-// lives in `review-clause.mts` (imported above) -- both used here
-// unchanged. The other two `ghGraphql(...)` call sites in this file
-// (`fetchReviewThreads` and the claim-candidate fetch below) keep calling
-// the same function via the new import.
+/**
+ * Map a `ProviderPort.listWorkItemComments` result back onto the REST
+ * `issues/{n}/comments` shape this file's `resolveTrustedCollaboratorMarkerLogins`
+ * (and `inputs.comments`, consumed by `summarizeDispositionEvidenceForGate`)
+ * already expect -- mirrors `pre-merge-readiness.mts`'s own shim of the same
+ * name for the identical reason (keeps every downstream consumer
+ * byte-identical instead of reshaping it for the port's flat `authorLogin`
+ * field).
+ */
+function toIssueCommentPayload(comment: ProviderComment): IssueCommentPayload {
+  return {
+    id: comment.id,
+    body: comment.body,
+    author: { login: comment.authorLogin },
+    createdAt: comment.createdAt,
+    updatedAt: comment.updatedAt,
+  };
+}
 
-/** #1906: fetch the PR's own author `login`/`__typename` via a small
- * dedicated GraphQL query -- the REST-shaped `gh pr view --json author`
- * fetch in `collectFromGitHub` only returns `login`, no type
- * discriminator. Deliberately its own minimal round trip rather than
- * folded into `fetchReviewThreads` below or `fetchReviewsAndHeadCommit`
+/** #1906: fetch the PR's own author `login`/`__typename` via
+ * {@link ProviderPort.getChangeRequestAuthor} -- the REST-shaped `pr view
+ * --json author` fetch in `collectFromGitHub` only returns `login`, no type
+ * discriminator. Deliberately its own minimal round trip rather than folded
+ * into `fetchReviewThreads` below or `fetchReviewsAndHeadCommit`
  * (review-clause.mts): both of those are narrowly-scoped Copilot-review
  * evidence collectors, the latter shared verbatim with
  * `rerun-advisory-convergence.mts`, and widening either with an unrelated
@@ -2758,153 +2763,50 @@ function resolveTrustedCollaboratorMarkerLogins(
  * is enabled (see the call site), so a repository that never sets the
  * flag never pays for this extra request. */
 function fetchPrAuthor(
-  owner: string,
-  repo: string,
+  port: ProviderPort,
   prNumber: number,
 ): GhAuthorPayload | null {
-  const payload = ghGraphql(
-    `
-      query($owner: String!, $repo: String!, $number: Int!) {
-        repository(owner: $owner, name: $repo) {
-          pullRequest(number: $number) {
-            author { login __typename }
-          }
-        }
-      }`,
-    { owner, repo, number: prNumber },
-  ) as {
-    data?: {
-      repository?: {
-        pullRequest?: { author?: GhAuthorPayload | null } | null;
-      } | null;
-    } | null;
+  const author = port.getChangeRequestAuthor(prNumber);
+  return author ? { login: author.login, __typename: author.typename } : null;
+}
+
+/** Map a `ProviderPort.listChangeRequestReviewThreadsWithAuthorType` node
+ * back onto this file's own `ReviewThreadPayload` shape (the
+ * `{comments: {pageInfo, nodes}}` wrapper `classifyCopilotAuthoredThreadIds`
+ * / `classifyThreadIdsForReview` / `summarizeDispositionEvidenceForGate`
+ * already expect and are directly tested against) -- same shim strategy as
+ * {@link toIssueCommentPayload}. `pageInfo.hasNextPage` is always `false`:
+ * the port's `fetchReviewThreadsGeneric` already fully paginates every
+ * thread's comments before returning. */
+function toReviewThreadPayload(
+  node: ProviderReviewThreadWithAuthorType,
+): ReviewThreadPayload {
+  return {
+    id: node.id,
+    isResolved: node.isResolved,
+    comments: {
+      pageInfo: { hasNextPage: false },
+      nodes: node.comments.map((comment) => ({
+        body: comment.body,
+        createdAt: comment.createdAt,
+        updatedAt: comment.updatedAt,
+        author: {
+          login: comment.authorLogin,
+          __typename: comment.authorTypename,
+        },
+        pullRequestReview: { id: comment.pullRequestReviewId },
+      })),
+    },
   };
-  return payload?.data?.repository?.pullRequest?.author ?? null;
 }
 
 function fetchReviewThreads(
-  owner: string,
-  repo: string,
+  port: ProviderPort,
   prNumber: number,
 ): ReviewThreadPayload[] {
-  const nodes: ReviewThreadPayload[] = [];
-  let cursor: string | null | undefined = null;
-
-  while (true) {
-    const payload = ghGraphql(
-      `
-        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
-          repository(owner: $owner, name: $repo) {
-            pullRequest(number: $number) {
-              reviewThreads(first: 100, after: $cursor) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  id
-                  isResolved
-                  comments(first: 100) {
-                    pageInfo { hasNextPage endCursor }
-                    nodes {
-                      body
-                      createdAt
-                      updatedAt
-                      author { login __typename }
-                      pullRequestReview { id }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }`,
-      { owner, repo, number: prNumber, cursor },
-    ) as {
-      data?: {
-        repository?: {
-          pullRequest?: {
-            reviewThreads?: ReviewThreadsConnectionPayload | null;
-          } | null;
-        } | null;
-      } | null;
-    };
-
-    const reviewThreads = payload?.data?.repository?.pullRequest?.reviewThreads;
-    for (const thread of reviewThreads?.nodes ?? []) {
-      if (thread.comments?.pageInfo?.hasNextPage) {
-        if (!thread.id || !thread.comments.pageInfo.endCursor) {
-          throw new Error(
-            'review thread pagination payload is missing id or endCursor',
-          );
-        }
-        thread.comments.nodes.push(
-          ...fetchThreadCommentPages(
-            thread.id,
-            thread.comments.pageInfo.endCursor,
-          ),
-        );
-        thread.comments.pageInfo.hasNextPage = false;
-      }
-    }
-    nodes.push(...(reviewThreads?.nodes ?? []));
-
-    if (!reviewThreads?.pageInfo?.hasNextPage) break;
-    if (!reviewThreads.pageInfo.endCursor) {
-      throw new Error('review thread pagination payload is missing endCursor');
-    }
-    cursor = reviewThreads.pageInfo.endCursor;
-  }
-
-  return nodes;
-}
-
-function fetchThreadCommentPages(
-  threadId: string,
-  afterCursor: string,
-): ThreadCommentPayload[] {
-  const nodes: ThreadCommentPayload[] = [];
-  let cursor: string | null | undefined = afterCursor;
-
-  while (cursor) {
-    const payload = ghGraphql(
-      `
-        query($id: ID!, $cursor: String) {
-          node(id: $id) {
-            ... on PullRequestReviewThread {
-              comments(first: 100, after: $cursor) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  body
-                  createdAt
-                  updatedAt
-                  author { login __typename }
-                  pullRequestReview { id }
-                }
-              }
-            }
-          }
-        }`,
-      { id: threadId, cursor },
-    ) as {
-      data?: {
-        node?: {
-          comments?: {
-            pageInfo?: PageInfoPayload | null;
-            nodes?: ThreadCommentPayload[] | null;
-          } | null;
-        } | null;
-      } | null;
-    };
-
-    const comments = payload?.data?.node?.comments;
-    nodes.push(...(comments?.nodes ?? []));
-    if (comments?.pageInfo?.hasNextPage && !comments.pageInfo.endCursor) {
-      throw new Error('thread comment pagination payload is missing endCursor');
-    }
-    cursor = comments?.pageInfo?.hasNextPage
-      ? comments.pageInfo.endCursor
-      : null;
-  }
-
-  return nodes;
+  return port
+    .listChangeRequestReviewThreadsWithAuthorType(prNumber)
+    .map(toReviewThreadPayload);
 }
 
 /** Fields the next-action catalog reads. Omits `nextActions` itself so

--- a/src/scripts/advisory-wait-state.mts
+++ b/src/scripts/advisory-wait-state.mts
@@ -15,12 +15,6 @@ import {
   readAdvisoryWaitPolicy,
 } from './advisory-wait-policy.mts';
 import { parseCliArgs } from './cli-args.mts';
-import {
-  DEFAULT_GH_PAGINATED_TIMEOUT_MS,
-  ghGraphql,
-  ghText,
-  safeGhText,
-} from './gh-exec.mts';
 import { loadIddConfig } from './idd-config.mts';
 import type { TrustedMarkerActorResolution } from './protocol-helpers.mts';
 import {
@@ -32,20 +26,17 @@ import {
   isValidIsoTimestamp,
   normalizeTrustedMarkerLogins,
   parseAdvisoryRecoveryComment,
-  parsePaginatedGhNdjson,
   resolveTrustedMarkerActors,
 } from './protocol-helpers.mts';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mts';
+import type { ProviderComment, ProviderPort } from './provider-port.mts';
 
 /** Author reference embedded in GitHub REST payloads. */
 interface GhAuthorPayload {
   login?: string | null;
-}
-
-/** Issue comment payload fields consumed by this helper. */
-interface IssueCommentPayload {
-  body?: string | null;
-  created_at?: string | null;
-  user?: GhAuthorPayload | null;
 }
 
 /** PR review payload fields consumed by the advisory-wait summary. */
@@ -652,18 +643,12 @@ function main(): void {
     throw new Error('missing required --pr <number> argument');
   }
 
-  const owner =
-    args.owner ||
-    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
-  const repo =
-    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-  const repoRef = `${owner}/${repo}`;
-  const viewerLogin = safeGhText([
-    'api',
-    'user',
-    '--jq',
-    '.login',
-  ]).toLowerCase();
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createGithubProviderAdapter(owner, repo);
+  const viewerLogin = port.resolveViewerLoginSafe().viewerLogin;
   const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
     resolveTrustedMarkerActors({
       flagValue: args.trustedMarkerLogins,
@@ -671,35 +656,16 @@ function main(): void {
       config: loadIddConfig(),
     });
 
-  const prHeadSha = ghText([
-    'pr',
-    'view',
-    String(args.prNumber),
-    '-R',
-    repoRef,
-    '--json',
-    'headRefOid',
-    '--jq',
-    '.headRefOid',
-  ]);
+  const prHeadSha = port.getChangeRequestHeadSha(args.prNumber);
 
-  const reviews = ghApiJson(
-    `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
-    true,
-  ) as ReviewPayload[];
-  const requestedReviewers = ghApiJson(
-    `repos/${owner}/${repo}/pulls/${args.prNumber}/requested_reviewers`,
-    false,
-  ) as { users?: GhAuthorPayload[] | null };
-  const timelineEvents = ghApiJson(
-    `repos/${owner}/${repo}/issues/${args.prNumber}/timeline`,
-    true,
-    ['-H', 'Accept: application/vnd.github+json'],
+  const reviews = port.listReviews(args.prNumber) as ReviewPayload[];
+  const restRequestedReviewers: GhAuthorPayload[] = port
+    .getChangeRequestRequestedReviewerLogins(args.prNumber)
+    .map((login) => ({ login }));
+  const timelineEvents = port.getWorkItemTimeline(
+    args.prNumber,
   ) as TimelineEventPayload[];
-  const comments = ghApiJson(
-    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
-    true,
-  ) as IssueCommentPayload[];
+  const comments = port.listWorkItemComments(args.prNumber);
 
   const collaboratorTrustEnabled = isTruthy(
     process.env.IDD_TRUST_COLLABORATOR_MARKERS,
@@ -708,7 +674,7 @@ function main(): void {
     viewerLogin,
     ...configuredTrustedActors,
     ...(collaboratorTrustEnabled
-      ? resolveTrustedCollaboratorMarkerLogins(owner, repo, comments)
+      ? resolveTrustedCollaboratorMarkerLogins(port, comments)
       : []),
   ]);
   const advisoryWaitPolicy = readAdvisoryWaitPolicy();
@@ -720,7 +686,6 @@ function main(): void {
   // resolveCopilotPending's own precedence (protocol-helpers.mts) so this
   // pre-check and the pure function it feeds never disagree on when a
   // GraphQL fallback is actually needed.
-  const restRequestedReviewers = requestedReviewers.users ?? [];
   const restCopilotPending = isCopilotPending(
     restRequestedReviewers,
     primaryBotLogin,
@@ -737,7 +702,7 @@ function main(): void {
       copilotPendingCoversHeadForGraphqlGate &&
       lastCopilotCommitForGraphqlGate !== prHeadSha
     )
-      ? fetchGraphqlRequestedReviewerLogins(owner, repo, args.prNumber)
+      ? port.getChangeRequestRequestedReviewerLoginsGraphql(args.prNumber)
       : null;
 
   const summary = buildAdvisoryWaitSummary(
@@ -861,35 +826,31 @@ fails closed to NOT_TERMINAL with reason: active-claim-not-provided.
 `);
 }
 
-function normalizeComment(comment: IssueCommentPayload) {
+function normalizeComment(comment: ProviderComment) {
   return {
-    author: { login: comment.user?.login ?? '' },
-    body: comment.body ?? '',
-    createdAt: comment.created_at ?? '',
+    author: { login: comment.authorLogin },
+    body: comment.body,
+    createdAt: comment.createdAt,
   };
 }
 
 function resolveTrustedCollaboratorMarkerLogins(
-  owner: string,
-  repo: string,
-  comments: IssueCommentPayload[],
+  port: ProviderPort,
+  comments: ProviderComment[],
 ): string[] {
   const advisoryAuthors = [
     ...new Set(
       comments
-        .filter((comment) => advisoryMarkerComment(comment.body ?? ''))
-        .map((comment) => comment.user?.login ?? '')
+        .filter((comment) => advisoryMarkerComment(comment.body))
+        .map((comment) => comment.authorLogin)
         .filter(Boolean),
     ),
   ];
 
   return advisoryAuthors.filter((login) => {
-    const permission = safeGhText([
-      'api',
-      `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-      '--jq',
-      '.permission',
-    ]).toLowerCase();
+    const outcome = port.getCollaboratorPermission(login);
+    const permission =
+      outcome.outcome === 'found' ? outcome.permission.toLowerCase() : '';
 
     return (
       permission === 'admin' ||
@@ -911,85 +872,4 @@ export function advisoryMarkerComment(body: string): boolean {
 
 function isTruthy(value: unknown): boolean {
   return /^(1|true|yes)$/i.test(String(value ?? '').trim());
-}
-
-function ghApiJson(
-  path: string,
-  paginate = false,
-  extraArgs: string[] = [],
-): unknown {
-  const args = ['api', path, ...extraArgs];
-  if (paginate) {
-    // gh api with --paginate and --jq '.[]' emits one JSON object per line.
-    // --slurp landed in gh v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0
-    // via apt, so keep the NDJSON-compatible form here.
-    args.splice(1, 0, '--paginate', '--jq', '.[]');
-    return parsePaginatedGhNdjson(
-      ghText(args, { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS }),
-    );
-  }
-  return JSON.parse(ghText(args));
-}
-
-/**
- * #2167: REST `requested_reviewers` can report empty even when Copilot
- * review is still genuinely outstanding -- see `resolveCopilotPending`'s
- * doc comment in protocol-helpers.mts for the observed incident this
- * fixes. `main()` below calls this only when REST and already-fetched
- * timeline evidence are both inconclusive, so this optional GraphQL call
- * is skipped whenever a cheaper signal already resolves pending state.
- *
- * Returns the requested-reviewer login list on success, or `null` on any
- * failure (network error, non-2xx response, unparsable payload) so the
- * caller falls back to the REST-derived result rather than assuming
- * pending -- a GraphQL 4xx must never read as "pending".
- */
-function fetchGraphqlRequestedReviewerLogins(
-  owner: string,
-  repo: string,
-  prNumber: number,
-): string[] | null {
-  try {
-    const query = `
-      query($owner: String!, $repo: String!, $number: Int!) {
-        repository(owner: $owner, name: $repo) {
-          pullRequest(number: $number) {
-            reviewRequests(first: 100) {
-              nodes {
-                requestedReviewer {
-                  ... on Bot { login }
-                  ... on User { login }
-                  ... on Mannequin { login }
-                }
-              }
-            }
-          }
-        }
-      }
-    `;
-    const payload = ghGraphql(query, {
-      owner,
-      repo,
-      number: prNumber,
-    }) as {
-      data?: {
-        repository?: {
-          pullRequest?: {
-            reviewRequests?: {
-              nodes?: Array<{
-                requestedReviewer?: { login?: string | null } | null;
-              }> | null;
-            } | null;
-          } | null;
-        } | null;
-      };
-    };
-    const nodes =
-      payload.data?.repository?.pullRequest?.reviewRequests?.nodes ?? [];
-    return nodes
-      .map((node) => String(node?.requestedReviewer?.login ?? ''))
-      .filter((login) => login !== '');
-  } catch {
-    return null;
-  }
 }

--- a/src/scripts/ci-wait-policy.mts
+++ b/src/scripts/ci-wait-policy.mts
@@ -9,7 +9,10 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { parseCanonicalIntegerOrThrow, parseCliArgs } from './cli-args.mts';
-import { GH_TEXT_LOOP_TIMEOUT_OPTIONS, ghText } from './gh-exec.mts';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mts';
 import { loadJson, validateConfigSection } from './validate-schemas.mts';
 
 const DEFAULT_RUNNING_TIMEOUT = 'PT30M';
@@ -362,8 +365,9 @@ export function deriveRerunCountFromRunAttempt(runAttempt: unknown): number {
 /**
  * Fetch the live Actions run `runId` (`GET
  * repos/{owner}/{repo}/actions/runs/{run_id}`) and derive its rerun count
- * via {@link deriveRerunCountFromRunAttempt}. Reuses the same
- * `ghText`/`GH_TEXT_LOOP_TIMEOUT_OPTIONS` timeout-guarded pattern
+ * via {@link deriveRerunCountFromRunAttempt}. Routed through
+ * provider-port.mts's `getWorkflowRun` (#2267), which reuses the same
+ * timeout-guarded `GH_TEXT_LOOP_TIMEOUT_OPTIONS` pattern
  * `rerun-advisory-convergence.mts`'s `collectFromGitHub` already uses for
  * the identical per-run `run_attempt` lookup, so a stalled or
  * unexpectedly-interactive `gh` call here fails closed within a bounded
@@ -384,11 +388,11 @@ export function fetchWorkflowRun(
   repo: string,
   runId: string,
 ): RawWorkflowRunPayload {
-  const raw = ghText(
-    ['api', `repos/${owner}/${repo}/actions/runs/${runId}`],
-    GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-  );
-  return JSON.parse(raw) as RawWorkflowRunPayload;
+  return createGithubProviderAdapter(owner, repo).getWorkflowRun(
+    owner,
+    repo,
+    runId,
+  ) as RawWorkflowRunPayload;
 }
 
 export function siblingSweepQuery(workflowName: string): string {
@@ -439,36 +443,12 @@ function fetchSiblingWorkflowRuns(
   repo: string,
   workflowName: string,
 ): SiblingRunLike[] {
-  const raw = ghText(
-    [
-      'run',
-      'list',
-      '--repo',
-      `${owner}/${repo}`,
-      '--workflow',
-      workflowName,
-      '--limit',
-      String(SIBLING_SWEEP_LIMIT),
-      '--json',
-      'databaseId,conclusion,status,createdAt',
-    ],
-    GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+  return createGithubProviderAdapter(owner, repo).listWorkflowRuns(
+    owner,
+    repo,
+    workflowName,
+    SIBLING_SWEEP_LIMIT,
   );
-  const rows = JSON.parse(raw) as Array<{
-    databaseId?: unknown;
-    conclusion?: unknown;
-    status?: unknown;
-    createdAt?: unknown;
-  }>;
-  if (!Array.isArray(rows)) {
-    return [];
-  }
-  return rows.map((row) => ({
-    id: String(row.databaseId ?? ''),
-    conclusion: row.conclusion == null ? null : String(row.conclusion),
-    status: row.status == null ? null : String(row.status),
-    createdAt: row.createdAt == null ? null : String(row.createdAt),
-  }));
 }
 
 function runCli(): void {
@@ -497,18 +477,10 @@ function runCli(): void {
     // pass; regression-guarded by the "resolves owner/repo INSIDE the
     // fallback" CLI test below).
     try {
-      const owner =
-        args.owner ||
-        ghText(
-          ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
-          GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-        );
-      const repo =
-        args.repo ||
-        ghText(
-          ['repo', 'view', '--json', 'name', '--jq', '.name'],
-          GH_TEXT_LOOP_TIMEOUT_OPTIONS,
-        );
+      const currentRepo =
+        args.owner && args.repo ? null : resolveCurrentGithubRepository();
+      const owner = args.owner || currentRepo?.owner || '';
+      const repo = args.repo || currentRepo?.repo || '';
       const run = fetchWorkflowRun(owner, repo, args.runId);
       rerunCount = deriveRerunCountFromRunAttempt(run.run_attempt);
       output.rerunCountSource = 'run-id';

--- a/src/scripts/ci-wait-state.mts
+++ b/src/scripts/ci-wait-state.mts
@@ -23,16 +23,17 @@
 //   out from under an in-flight wait.
 
 import { parseCliArgs } from './cli-args.mts';
-import { DEFAULT_GH_PAGINATED_TIMEOUT_MS, ghText } from './gh-exec.mts';
-import { deriveGhHttpStatus } from './gh-http-status.mts';
 import { loadIddConfig } from './idd-config.mts';
 import { normalizePolicyConfig } from './policy-helpers.mts';
 import {
   CI_FAILURE_CONCLUSION_STATES,
-  parsePaginatedGhNdjson,
   selectLatestCheckInstance,
   summarizeBranchReviewRequirements,
 } from './protocol-helpers.mts';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mts';
 
 /** Required-check entry from a branch ruleset rule or classic protection. */
 type RawRequiredCheckPayload =
@@ -93,13 +94,6 @@ interface StatusCheckRollupEntry {
   workflowName?: string | null;
   startedAt?: string | null;
   completedAt?: string | null;
-}
-
-/** PR payload fields consumed by this helper. */
-interface PrPayload {
-  headRefOid?: string | null;
-  baseRefName?: string | null;
-  statusCheckRollup?: StatusCheckRollupEntry[] | null;
 }
 
 /** One normalized, disambiguated per-check entry. */
@@ -254,34 +248,33 @@ function main(): void {
     throw new Error('missing or invalid --pr <number> argument');
   }
 
-  const owner =
-    args.owner ||
-    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
-  const repo =
-    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-  const repoRef = `${owner}/${repo}`;
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createGithubProviderAdapter(owner, repo);
 
-  const pr = JSON.parse(
-    ghText([
-      'pr',
-      'view',
-      String(args.prNumber),
-      '-R',
-      repoRef,
-      '--json',
-      'headRefOid,baseRefName,statusCheckRollup',
-    ]),
-  ) as PrPayload;
-  const encodedBaseRefName = encodeURIComponent(String(pr.baseRefName ?? ''));
+  const pr = port.getChangeRequestBranchAndChecks(args.prNumber);
+  // Raw (unencoded) branch name: listBranchRules/getBranchProtection do
+  // their own encodeURIComponent internally, matching pre-merge-readiness's
+  // and #2267's other listBranchRules/getBranchProtection callers -- passing
+  // an already-encoded ref here would double-encode it.
+  const baseRefName = String(pr.baseRefName ?? '');
 
-  const branchRules = ghApiJsonOr404Empty(
-    `repos/${owner}/${repo}/rules/branches/${encodedBaseRefName}`,
-    true,
-  ) as BranchRulePayload[];
-  const branchProtection = ghApiJsonOr404Empty(
-    `repos/${owner}/${repo}/branches/${encodedBaseRefName}/protection`,
-    false,
-  ) as BranchProtectionPayload;
+  const branchRulesOutcome = port.listBranchRules(owner, repo, baseRefName);
+  const branchRules =
+    branchRulesOutcome.outcome === 'ok'
+      ? (branchRulesOutcome.value as BranchRulePayload[])
+      : [];
+  const branchProtectionOutcome = port.getBranchProtection(
+    owner,
+    repo,
+    baseRefName,
+  );
+  const branchProtection =
+    branchProtectionOutcome.outcome === 'ok'
+      ? (branchProtectionOutcome.value as BranchProtectionPayload)
+      : ({} as BranchProtectionPayload);
 
   const branchReviewRequirements = summarizeBranchReviewRequirements(
     branchRules,
@@ -296,8 +289,9 @@ function main(): void {
 
   const summary = buildCiWaitStateSummary(
     {
-      headRefOid: pr.headRefOid ?? '',
-      statusCheckRollup: pr.statusCheckRollup ?? [],
+      headRefOid: pr.headSha,
+      statusCheckRollup:
+        (pr.statusCheckRollup as StatusCheckRollupEntry[] | null) ?? [],
     },
     {
       requiredCheckNames: branchReviewRequirements.requiredCheckNames,
@@ -679,45 +673,6 @@ export function parseArgs(argv: string[]): CiWaitStateArgs {
     repo: values.repo as string,
     help,
   };
-}
-
-/**
- * `gh api <path>`, tolerating a genuine 404 (unprotected branch / no active
- * rules) as an empty result. `gh` exits 1 for every HTTP error alike, so the
- * real status is derived from the error text via the shared
- * {@link deriveGhHttpStatus} rather than the useless process exit code —
- * the same discrimination `pre-merge-readiness.mts` and the A3/A4 discovery
- * helpers already rely on. Any other status (403, rate limit, transient
- * failure) propagates so this snapshot fails closed instead of silently
- * treating an auth/network failure as "no required checks configured".
- */
-function ghApiJsonOr404Empty(path: string, paginate: boolean): unknown {
-  // `--jq '.[]'` (NDJSON, one array element per line) is the repo-standard
-  // paginate form — see gh-exec.mts and protocol-helpers.mts's
-  // parsePaginatedGhNdjson, reused here rather than hand-rolling a second
-  // parser. Unlike `--jq '.'`, it does not depend on gh's jq implementation
-  // staying compact-per-page; `--slurp` (a single JSON array) landed in gh
-  // v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0 via apt, so NDJSON stays
-  // the compatible default.
-  const args = paginate
-    ? ['api', path, '--paginate', '--jq', '.[]']
-    : ['api', path];
-  try {
-    const raw = ghText(
-      args,
-      paginate ? { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS } : {},
-    );
-    if (!paginate) {
-      const trimmed = raw.trim();
-      return trimmed ? JSON.parse(trimmed) : {};
-    }
-    return parsePaginatedGhNdjson(raw);
-  } catch (error) {
-    if (deriveGhHttpStatus(error) === 404) {
-      return paginate ? [] : {};
-    }
-    throw error;
-  }
 }
 
 function printHelp(): void {

--- a/src/scripts/idd-merge-execute.mts
+++ b/src/scripts/idd-merge-execute.mts
@@ -13,12 +13,15 @@
 // `gh pr merge` issued under `--apply` once every F3 gate holds and the
 // head + claim re-validate immediately before the merge.
 
-import { ghText } from './gh-exec.mts';
 import { deriveGhHttpStatus, ghErrorText } from './gh-http-status.mts';
 import { type IddConfig, loadIddConfig } from './idd-config.mts';
 import { normalizePolicyConfig } from './policy-helpers.mts';
 import { collectPreMergeReadiness } from './pre-merge-readiness.mts';
 import { computePreMergeReadinessBlockers } from './protocol-helpers.mts';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mts';
 
 /**
  * GitHub's exact `gh pr merge` failure text for the solo-CODEOWNER
@@ -219,10 +222,17 @@ export interface MergeExecuteDeps {
   ) => string;
 }
 
-// Prepend `-R <repoRef>` to a `gh` argument array only when a repo scope is
-// set; otherwise pass the args verbatim (current-directory repo).
-function scopedGhArgs(repoRef: string | null, args: string[]): string[] {
-  return repoRef ? ['-R', repoRef, ...args] : args;
+/** `resolveOwnerRepoFromRef`'s split of a `<owner>/<repo>` `repoRef`, or the
+ * current-directory repo (`gh repo view`) when `repoRef` is `null`. */
+function resolveOwnerRepoFromRef(repoRef: string | null): {
+  owner: string;
+  repo: string;
+} {
+  if (repoRef) {
+    const [owner, repo] = repoRef.split('/');
+    return { owner: owner ?? '', repo: repo ?? '' };
+  }
+  return resolveCurrentGithubRepository();
 }
 
 /**
@@ -254,19 +264,24 @@ export function resolveRemoteSoloCodeownerAdminFallbackMode(
   fetchEncodedConfig: (repoRef: string, headSha: string) => string = (
     scopedRepoRef,
     ref,
-  ) =>
-    ghText(
-      scopedGhArgs(scopedRepoRef, [
-        'api',
-        `repos/${scopedRepoRef}/contents/.github/idd/config.json`,
-        '--method',
-        'GET',
-        '--field',
-        `ref=${ref}`,
-        '--jq',
-        '.content',
-      ]),
-    ),
+  ) => {
+    const outcome = createGithubProviderAdapter(
+      '',
+      '',
+    ).getRepositoryFileContentAtRef(
+      scopedRepoRef,
+      '.github/idd/config.json',
+      ref,
+    );
+    if (outcome.outcome === 'not-found') {
+      const notFound = new Error('Not Found (HTTP 404)') as Error & {
+        stderr?: string;
+      };
+      notFound.stderr = 'Not Found (HTTP 404)';
+      throw notFound;
+    }
+    return outcome.value;
+  },
 ): string {
   let config: IddConfig | null;
   try {
@@ -291,56 +306,43 @@ export function resolveRemoteSoloCodeownerAdminFallbackMode(
 const defaultDeps: MergeExecuteDeps = {
   collect: (passthrough) =>
     collectPreMergeReadiness(passthrough) as Record<string, unknown>,
-  fetchHeadSha: (prNumber, repoRef) =>
-    ghText(
-      scopedGhArgs(repoRef, [
-        'pr',
-        'view',
-        String(prNumber),
-        '--json',
-        'headRefOid',
-        '--jq',
-        '.headRefOid',
-      ]),
-    ),
-  fetchMergeState: (prNumber, repoRef) =>
-    JSON.parse(
-      ghText(
-        scopedGhArgs(repoRef, [
-          'pr',
-          'view',
-          String(prNumber),
-          '--json',
-          'mergeable,mergeStateStatus',
-          '--jq',
-          '.',
-        ]),
-      ),
-    ) as Record<string, unknown>,
-  mergePr: (prNumber, headSha, repoRef) =>
-    ghText(
-      scopedGhArgs(repoRef, [
-        'pr',
-        'merge',
-        String(prNumber),
-        // Always a merge commit — never squash/rebase. Bind to the head.
-        '--merge',
-        '--match-head-commit',
-        headSha,
-      ]),
-    ),
-  mergePrAdmin: (prNumber, headSha, repoRef) =>
-    ghText(
-      scopedGhArgs(repoRef, [
-        'pr',
-        'merge',
-        String(prNumber),
-        '--merge',
-        '--match-head-commit',
-        headSha,
-        '--admin',
-      ]),
-    ),
+  fetchHeadSha: (prNumber, repoRef) => {
+    const { owner, repo } = resolveOwnerRepoFromRef(repoRef);
+    return createGithubProviderAdapter(
+      owner,
+      repo,
+    ).getChangeRequestHeadShaAtRepo(owner, repo, prNumber);
+  },
+  fetchMergeState: (prNumber, repoRef) => {
+    const { owner, repo } = resolveOwnerRepoFromRef(repoRef);
+    const state = createGithubProviderAdapter(
+      owner,
+      repo,
+    ).getChangeRequestAtRepo(owner, repo, prNumber);
+    if (!state) {
+      throw new Error(
+        `fetchMergeState: PR #${prNumber} not found${repoRef ? ` in ${repoRef}` : ''}`,
+      );
+    }
+    return state as unknown as Record<string, unknown>;
+  },
+  mergePr: (prNumber, headSha, repoRef) => {
+    const { owner, repo } = resolveOwnerRepoFromRef(repoRef);
+    // Always a merge commit — never squash/rebase. Bind to the head.
+    return createGithubProviderAdapter(owner, repo).mergeChangeRequestAtRepo(
+      owner,
+      repo,
+      prNumber,
+      headSha,
+    );
+  },
+  mergePrAdmin: (prNumber, headSha, repoRef) => {
+    const { owner, repo } = resolveOwnerRepoFromRef(repoRef);
+    return createGithubProviderAdapter(
+      owner,
+      repo,
+    ).mergeChangeRequestAdminAtRepo(owner, repo, prNumber, headSha);
+  },
   resolveSoloCodeownerAdminFallbackMode: (prNumber, repoRef, headSha) =>
     repoRef
       ? resolveRemoteSoloCodeownerAdminFallbackMode(prNumber, repoRef, headSha)

--- a/src/scripts/idd-merge-execute.mts
+++ b/src/scripts/idd-merge-execute.mts
@@ -223,14 +223,26 @@ export interface MergeExecuteDeps {
 }
 
 /** `resolveOwnerRepoFromRef`'s split of a `<owner>/<repo>` `repoRef`, or the
- * current-directory repo (`gh repo view`) when `repoRef` is `null`. */
+ * current-directory repo (`gh repo view`) when `repoRef` is `null`. Fails
+ * fast on a malformed shape (missing, empty, or extra `/`-separated
+ * segments) rather than silently treating `owner/repo/extra` as
+ * `owner`/`repo` -- every current caller only ever passes the value this
+ * file's own `parseArgs` synthesizes as `${owner}/${repo}` from two
+ * already-parsed flags, but this function has no way to enforce that at
+ * the type level, so it validates its own input instead of trusting it. */
 function resolveOwnerRepoFromRef(repoRef: string | null): {
   owner: string;
   repo: string;
 } {
   if (repoRef) {
-    const [owner, repo] = repoRef.split('/');
-    return { owner: owner ?? '', repo: repo ?? '' };
+    const segments = repoRef.split('/');
+    const [owner, repo] = segments;
+    if (segments.length !== 2 || !owner || !repo) {
+      throw new Error(
+        `resolveOwnerRepoFromRef: expected "<owner>/<repo>", got "${repoRef}"`,
+      );
+    }
+    return { owner, repo };
   }
   return resolveCurrentGithubRepository();
 }

--- a/src/scripts/merged-pr-feedback-sweep.mts
+++ b/src/scripts/merged-pr-feedback-sweep.mts
@@ -15,7 +15,6 @@
 // This is the recurring counterpart of the one-time audit in #910 and the
 // chosen recovery path from #909 (advisory-wait stays Copilot-only).
 import { parseCliArgs } from './cli-args.mts';
-import { ghText } from './gh-exec.mts';
 import { loadIddConfig } from './idd-config.mts';
 import {
   advisoryBotIdentityToken,
@@ -30,6 +29,11 @@ import {
   resolveAdvisoryBotLogins,
   resolveTrustedMarkerActors,
 } from './protocol-helpers.mts';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mts';
+import type { ProviderPort } from './provider-port.mts';
 
 // ---------------------------------------------------------------------------
 // Types (the pure function's input/output — exported for tests)
@@ -671,184 +675,60 @@ function resolveSinceDate(args: SweepArgs): string | null {
     .iso;
 }
 
-function runGh(args: string[]): string {
-  return ghText(args);
-}
-
-function ghGraphql(
-  query: string,
-  variables: Record<string, string | number | null | undefined>,
-): unknown {
-  const args = ['api', 'graphql', '-f', `query=${query}`];
-  for (const [key, value] of Object.entries(variables)) {
-    if (value === null || value === undefined) {
-      continue;
-    }
-    args.push(typeof value === 'number' ? '-F' : '-f', `${key}=${value}`);
-  }
-  const result = JSON.parse(runGh(args).trim() || '{}') as {
-    errors?: { message?: string | null }[] | null;
-  };
-  // A GraphQL call can return HTTP 200 with a top-level `errors` array and
-  // null `data`. Fail fast instead of treating it as empty data, which would
-  // be a silent false negative (a PR appearing "clean" because no nodes came
-  // back).
-  if (Array.isArray(result.errors) && result.errors.length > 0) {
-    const messages = result.errors
-      .map((entry) => entry?.message ?? 'unknown')
-      .join('; ');
-    throw new Error(`GraphQL query returned errors: ${messages}`);
-  }
-  return result;
-}
-
 interface MergedPrListItem {
   number: number;
   mergedAt?: string | null;
 }
 
 function listMergedPrNumbers(
-  repoRef: string,
+  port: ProviderPort,
   sinceDate: string | null,
   limit: number,
 ): MergedPrListItem[] {
-  const args = [
-    'pr',
-    'list',
-    '-R',
-    repoRef,
-    '--state',
-    'merged',
-    '--json',
-    'number,mergedAt',
-    '--limit',
-    String(limit),
-  ];
-  if (sinceDate) {
-    args.push('--search', `merged:>=${sinceDate}`);
-  }
-  const raw = runGh(args).trim();
-  const items = raw ? (JSON.parse(raw) as MergedPrListItem[]) : [];
-  return items;
-}
-
-interface Connection<T> {
-  pageInfo?: { hasNextPage?: boolean | null; endCursor?: string | null } | null;
-  nodes?: T[] | null;
-}
-
-// Page a single `pullRequest` connection to completion so large PRs cannot
-// silently truncate at 100 items (which would hide unresolved threads or a
-// later disposition comment and produce a false negative). Per-thread reply
-// pagination is intentionally left at first:100 — a thread with 100+ replies
-// is pathological and only affects the advisory `dispositioned` flag, not
-// whether the thread surfaces.
-function fetchAllNodes<T>(
-  owner: string,
-  repo: string,
-  number: number,
-  field: string,
-  nodeFields: string,
-): T[] {
-  const out: T[] = [];
-  let after: string | null = null;
-  for (;;) {
-    const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
-      repository(owner:$owner,name:$repo){ pullRequest(number:$number){
-        ${field}(first:100,after:$after){ pageInfo{ hasNextPage endCursor } nodes{ ${nodeFields} } }
-      } }
-    }`;
-    const result = ghGraphql(query, { owner, repo, number, after }) as {
-      data?: {
-        repository?: {
-          pullRequest?: Record<string, Connection<T> | null> | null;
-        } | null;
-      } | null;
-    };
-    // Fail fast on a missing pullRequest node or connection: an absent node
-    // (e.g. a transient/permission anomaly) would otherwise be read as zero
-    // nodes, making a PR look "clean" — the silent false negative this
-    // helper's fail-fast posture exists to prevent.
-    const pr = result?.data?.repository?.pullRequest;
-    if (pr == null) {
-      throw new Error(
-        `pagination for ${field} on PR #${number} returned no pullRequest node`,
-      );
-    }
-    const conn = pr[field];
-    if (conn == null) {
-      throw new Error(
-        `pagination for ${field} on PR #${number} returned a null connection`,
-      );
-    }
-    out.push(...(conn.nodes ?? []));
-    if (!conn.pageInfo?.hasNextPage) {
-      break;
-    }
-    // Fail fast rather than silently truncate: a missing cursor on a
-    // has-next-page response would reintroduce the false negative this
-    // pagination exists to prevent.
-    if (!conn.pageInfo.endCursor) {
-      throw new Error(
-        `pagination for ${field} on PR #${number} reported hasNextPage with no endCursor`,
-      );
-    }
-    after = conn.pageInfo.endCursor;
-  }
-  return out;
+  return port.listMergedChangeRequests(limit, sinceDate);
 }
 
 function fetchMergedPr(
-  owner: string,
-  repo: string,
+  port: ProviderPort,
   number: number,
 ): MergedPrInput | null {
-  const metaQuery = `query($owner:String!,$repo:String!,$number:Int!){
-    repository(owner:$owner,name:$repo){ pullRequest(number:$number){
-      number merged mergedAt mergeCommit{ oid }
-    } }
-  }`;
-  const meta = ghGraphql(metaQuery, { owner, repo, number }) as {
-    data?: {
-      repository?: {
-        pullRequest?: {
-          number?: number;
-          merged?: boolean | null;
-          mergedAt?: string | null;
-          mergeCommit?: { oid?: string | null } | null;
-        } | null;
-      } | null;
-    } | null;
-  };
-  const pr = meta?.data?.repository?.pullRequest;
-  if (!pr?.merged) {
+  const meta = port.getMergedChangeRequestMeta(number);
+  if (!meta?.merged) {
     return null;
   }
   return {
-    number: pr.number ?? number,
-    mergedAt: pr.mergedAt ?? null,
-    mergeCommit: pr.mergeCommit?.oid ?? null,
-    comments: fetchAllNodes<SweepCommentInput>(
-      owner,
-      repo,
-      number,
-      'comments',
-      'body url createdAt updatedAt author{ login }',
-    ),
-    reviews: fetchAllNodes<SweepReviewInput>(
-      owner,
-      repo,
-      number,
-      'reviews',
-      'body url state submittedAt author{ login }',
-    ),
-    threads: fetchAllNodes<SweepThreadInput>(
-      owner,
-      repo,
-      number,
-      'reviewThreads',
-      'isResolved path comments(first:100){ nodes{ body url createdAt updatedAt author{ login } } }',
-    ),
+    number: meta.number,
+    mergedAt: meta.mergedAt,
+    mergeCommit: meta.mergeCommitOid,
+    comments: port.listChangeRequestGraphqlComments(number).map((comment) => ({
+      body: comment.body,
+      url: comment.url,
+      createdAt: comment.createdAt,
+      updatedAt: comment.updatedAt,
+      author: { login: comment.authorLogin },
+    })),
+    reviews: port.listChangeRequestGraphqlReviews(number).map((review) => ({
+      body: review.body,
+      url: review.url,
+      state: review.state,
+      submittedAt: review.submittedAt,
+      author: { login: review.authorLogin },
+    })),
+    threads: port
+      .listChangeRequestReviewThreadsExtended(number)
+      .map((thread) => ({
+        isResolved: thread.isResolved,
+        path: thread.path,
+        comments: {
+          nodes: thread.comments.map((comment) => ({
+            body: comment.body,
+            url: comment.url ?? null,
+            createdAt: comment.createdAt,
+            updatedAt: comment.updatedAt,
+            author: { login: comment.authorLogin },
+          })),
+        },
+      })),
   };
 }
 
@@ -858,13 +738,11 @@ function main(): void {
     printHelp();
     process.exit(0);
   }
-  const owner =
-    args.owner ||
-    runGh(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']).trim();
-  const repo =
-    args.repo ||
-    runGh(['repo', 'view', '--json', 'name', '--jq', '.name']).trim();
-  const repoRef = `${owner}/${repo}`;
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createGithubProviderAdapter(owner, repo);
   const iddConfig = loadIddConfig();
 
   const { actors: trustedMarkerActors } = resolveTrustedMarkerActors({
@@ -899,11 +777,11 @@ function main(): void {
   const sinceDate = usingExplicitPrs ? null : resolveSinceDate(args);
   const targets = usingExplicitPrs
     ? args.prNumbers.map((number) => ({ number }))
-    : listMergedPrNumbers(repoRef, sinceDate, args.limit);
+    : listMergedPrNumbers(port, sinceDate, args.limit);
 
   const prs: MergedPrInput[] = [];
   for (const target of targets) {
-    const pr = fetchMergedPr(owner, repo, target.number);
+    const pr = fetchMergedPr(port, target.number);
     if (pr) {
       prs.push(pr);
     }

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -29,13 +29,6 @@ import {
   normalizeAuthorityEvidence,
   resolveCollaboratorAuthority,
 } from './external-check-waiver.mts';
-import {
-  DEFAULT_GH_PAGINATED_TIMEOUT_MS,
-  GH_TEXT_LOOP_OPTIONS,
-  ghText,
-  readGithubRepoDefaultBranch,
-  safeGhText,
-} from './gh-exec.mts';
 import { deriveGhHttpStatus } from './gh-http-status.mts';
 import { loadIddConfig } from './idd-config.mts';
 import {
@@ -55,7 +48,6 @@ import {
   deriveIddAgentLogins,
   normalizeTrustedMarkerLogins,
   operationalMarkerPrefix,
-  parsePaginatedGhNdjson,
   resolveAdvisoryBotLogins,
   resolveCodeownersForFiles,
   resolvePrFirstCommitAt,
@@ -64,9 +56,18 @@ import {
   selectCodeownersText,
 } from './protocol-helpers.mts';
 import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mts';
+import {
   evaluateProviderOutageRelief,
   resolveProviderOutageDeclaration,
 } from './provider-outage-declaration.mts';
+import type {
+  ProviderComment,
+  ProviderPort,
+  ProviderReviewThreadWithComments,
+} from './provider-port.mts';
 import {
   fetchReviewsAndHeadCommit,
   resolveLatestCopilotReviewClause,
@@ -288,38 +289,6 @@ interface BranchProtectionPayload {
   } | null;
 }
 
-/** GraphQL pagination cursor block. */
-interface PageInfoPayload {
-  hasNextPage?: boolean | null;
-  endCursor?: string | null;
-}
-
-/** Review-thread reply node (GraphQL `reviewThreads` comment). */
-interface ThreadCommentPayload {
-  body?: string | null;
-  createdAt?: string | null;
-  updatedAt?: string | null;
-  author?: GhAuthorPayload | null;
-  pullRequestReview?: { id?: string | null } | null;
-}
-
-/** Review thread (GraphQL `reviewThreads` node). */
-interface ReviewThreadPayload {
-  id?: string | null;
-  isResolved?: boolean | null;
-  reviewerReopenedAt?: string | null;
-  comments?: {
-    pageInfo?: PageInfoPayload | null;
-    nodes: ThreadCommentPayload[];
-  } | null;
-}
-
-/** GraphQL `reviewThreads` connection payload. */
-interface ReviewThreadsConnectionPayload {
-  pageInfo?: PageInfoPayload | null;
-  nodes?: ReviewThreadPayload[] | null;
-}
-
 /** gh subprocess failure-tolerance options. */
 interface RunGhOptions {
   allowStatuses?: number[];
@@ -391,8 +360,21 @@ export type PreMergeReadinessReport = ReturnType<
  * `idd-merge-execute` helper so the F2/F3 gate logic is collected from
  * exactly one place (no duplicated gh plumbing or gate evaluation).
  */
+/**
+ * `createPort` is injectable (defaults to the real GitHub adapter) so a test
+ * can drive this collection entry end to end against
+ * `createFakeProviderAdapter` fixtures instead of a live `gh` process
+ * (#2267 AC4's "unit tests exercise the PR-facing state machine with a fake
+ * provider" -- see `pre-merge-readiness-collection-smoke.test.mts`). Neither
+ * production caller (this file's own CLI entry, `idd-merge-execute.mts`)
+ * passes a second argument, so both keep using the real adapter unchanged.
+ */
 export function collectPreMergeReadiness(
   argv: string[],
+  createPort: (
+    owner: string,
+    repo: string,
+  ) => ProviderPort = createGithubProviderAdapter,
 ): PreMergeReadinessReport {
   const args = parseArgs(argv);
   // --help used to exit from inside the parseArgs token loop; relocated
@@ -410,27 +392,13 @@ export function collectPreMergeReadiness(
     throw new Error('missing required --claim-issue <number> argument');
   }
 
-  const owner =
-    args.owner ||
-    ghText(
-      ['repo', 'view', '--json', 'owner', '--jq', '.owner.login'],
-      GH_TEXT_LOOP_OPTIONS,
-    );
-  const repo =
-    args.repo ||
-    ghText(
-      ['repo', 'view', '--json', 'name', '--jq', '.name'],
-      GH_TEXT_LOOP_OPTIONS,
-    );
-  const repoRef = `${owner}/${repo}`;
-  const viewerLogin = safeGhText(
-    ['api', 'user', '--jq', '.login'],
-    GH_TEXT_LOOP_OPTIONS,
-  ).toLowerCase();
-  const viewerAppSlug = safeGhText(
-    ['api', 'app', '--jq', '.slug // .app_slug // empty'],
-    GH_TEXT_LOOP_OPTIONS,
-  ).toLowerCase();
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createPort(owner, repo);
+  const viewerLogin = port.resolveViewerLoginSafe().viewerLogin;
+  const viewerAppSlug = port.resolveViewerAppSlugSafe().appSlug.toLowerCase();
   const iddConfig = loadIddConfig();
   const { actors: configuredTrustedActors, source: trustedMarkerActorsSource } =
     resolveTrustedMarkerActors({
@@ -445,41 +413,21 @@ export function collectPreMergeReadiness(
       config: iddConfig,
     });
 
-  const pr = ghJson([
-    'pr',
-    'view',
-    String(args.prNumber),
-    '-R',
-    repoRef,
-    '--json',
-    // #1513: `mergeable,mergeStateStatus` added to this existing call (no
-    // new network round-trip) so the branch-currency gate below can pair a
-    // live `BEHIND` state with the up-to-date-head requirement resolved
-    // from `branchRules`/`branchProtection`.
-    'headRefOid,baseRefName,url,author,reviewDecision,statusCheckRollup,mergeable,mergeStateStatus,closingIssuesReferences',
-    '--jq',
-    '.',
-  ]) as {
-    headRefOid?: unknown;
-    baseRefName?: unknown;
-    url?: unknown;
-    author?: { login?: unknown } | null;
-    reviewDecision?: unknown;
-    statusCheckRollup?: StatusCheckRollupPayload[] | null;
-    mergeable?: unknown;
-    mergeStateStatus?: unknown;
-    closingIssuesReferences?: unknown;
-  };
-  const prHeadSha = String(pr.headRefOid ?? '');
-  const baseRefName = String(pr.baseRefName ?? '');
-  const prUrl = String(pr.url ?? '');
-  const prAuthorLogin = String(pr.author?.login ?? '').toLowerCase();
-  const reviewDecision = String(pr.reviewDecision ?? '');
-  const mergeable = String(pr.mergeable ?? '');
-  const mergeStateStatus = String(pr.mergeStateStatus ?? '');
+  // #1513: `mergeable`/`mergeStateStatus` are part of this same richest
+  // single `pr view` call (no extra network round-trip) so the branch-
+  // currency gate below can pair a live `BEHIND` state with the up-to-date-
+  // head requirement resolved from `branchRules`/`branchProtection`.
+  const snapshot = port.getChangeRequestReadinessSnapshot(args.prNumber);
+  const prHeadSha = snapshot.headSha;
+  const baseRefName = snapshot.baseRefName;
+  const prUrl = snapshot.url;
+  const prAuthorLogin = snapshot.authorLogin.toLowerCase();
+  const reviewDecision = snapshot.reviewDecision ?? '';
+  const mergeable = snapshot.mergeable;
+  const mergeStateStatus = snapshot.mergeStateStatus;
   if (args.claimless) {
-    const closingRefs = Array.isArray(pr.closingIssuesReferences)
-      ? pr.closingIssuesReferences
+    const closingRefs = Array.isArray(snapshot.closingIssuesReferences)
+      ? snapshot.closingIssuesReferences
       : [];
     if (closingRefs.length > 0) {
       throw new Error(
@@ -494,7 +442,7 @@ export function collectPreMergeReadiness(
   const developmentBranchInspection = inspectDevelopmentBranch(iddConfig);
   const liveDefaultBranch =
     developmentBranchInspection.status === 'absent'
-      ? readGithubRepoDefaultBranch(owner, repo)
+      ? port.getRepositoryDefaultBranch(owner, repo)
       : null;
   const developmentBranchTarget = {
     ...resolveEffectiveDevelopmentBranch(iddConfig, liveDefaultBranch),
@@ -502,7 +450,7 @@ export function collectPreMergeReadiness(
   };
   const encodedBaseRefName = encodeURIComponent(baseRefName);
 
-  // #1483: sourced from the same `gh pr view` call above (the
+  // #1483: sourced from the same `pr view` snapshot above (the
   // `statusCheckRollup` field), not a separate `gh pr checks` call --
   // `statusCheckRollup`'s GraphQL union already tags each entry with a
   // real producer identity (`__typename`: `CheckRun` vs. `StatusContext`,
@@ -512,15 +460,17 @@ export function collectPreMergeReadiness(
   // successive calls a few seconds apart returned different check-run
   // counts for the same PR), so this is the single source of truth for
   // both the check identity and its dedup discriminator.
-  const checks = (pr.statusCheckRollup ?? []).map(
-    normalizeStatusCheckRollupEntry,
-  );
+  const checks = (
+    (snapshot.statusCheckRollup as StatusCheckRollupPayload[] | null) ?? []
+  ).map(normalizeStatusCheckRollupEntry);
   const trustEmptyProtectionReads = readTrustEmptyProtectionReads();
   const branchRulesRead = fetchGovernanceJson<BranchRulePayload[]>(
     `repos/${owner}/${repo}/rules/branches/${encodedBaseRefName}`,
     true,
     trustEmptyProtectionReads,
     [],
+    () =>
+      unwrapGovernanceOutcome(port.listBranchRules(owner, repo, baseRefName)),
   );
   const branchRules = branchRulesRead.value;
   const branchRulesetsRead = fetchBranchRulesets(
@@ -528,6 +478,11 @@ export function collectPreMergeReadiness(
     repo,
     branchRules,
     trustEmptyProtectionReads,
+    (path) =>
+      unwrapGovernanceOutcome(port.getRepositoryRulesetDetail(path)) as Record<
+        string,
+        unknown
+      >,
   );
   const branchRulesets = branchRulesetsRead.value;
   const branchProtectionRead = fetchGovernanceJson<BranchProtectionPayload>(
@@ -535,6 +490,10 @@ export function collectPreMergeReadiness(
     false,
     trustEmptyProtectionReads,
     {},
+    () =>
+      unwrapGovernanceOutcome(
+        port.getBranchProtection(owner, repo, baseRefName),
+      ),
   );
   const branchProtection = branchProtectionRead.value;
   // #1377: a masked-403-as-404 on either read means the required-check set
@@ -551,38 +510,30 @@ export function collectPreMergeReadiness(
   // `branchProtection`) -- so it is threaded separately rather than folded
   // into `protectionReadsUnreadable`.
   const branchRulesetsUnreadable = branchRulesetsRead.unreadable;
-  const reviews = ghApiJson(
-    `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
-    true,
-  ) as ReviewPayload[];
-  const requestedReviewers = ghApiJson(
-    `repos/${owner}/${repo}/pulls/${args.prNumber}/requested_reviewers`,
-    false,
-  ) as { users?: GhAuthorPayload[] | null };
-  const timelineEvents = ghApiJson(
-    `repos/${owner}/${repo}/issues/${args.prNumber}/timeline`,
-    true,
-    ['-H', 'Accept: application/vnd.github+json'],
+  const reviews = port.listReviews(args.prNumber) as ReviewPayload[];
+  const requestedReviewerLogins = port.getChangeRequestRequestedReviewerLogins(
+    args.prNumber,
+  );
+  const timelineEvents = port.getWorkItemTimeline(
+    args.prNumber,
   ) as TimelineEventPayload[];
-  const comments = ghApiJson(
-    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
-    true,
-  ) as IssueCommentPayload[];
+  const comments = port
+    .listWorkItemComments(args.prNumber)
+    .map(toIssueCommentPayload);
   const claimComments = args.claimless
     ? []
-    : (ghApiJson(
-        `repos/${owner}/${repo}/issues/${args.claimIssueNumber}/comments`,
-        true,
-      ) as IssueCommentPayload[]);
-  const threads = fetchReviewThreads(owner, repo, args.prNumber);
-  const changedFiles = (
-    ghApiJson(`repos/${owner}/${repo}/pulls/${args.prNumber}/files`, true) as {
-      filename?: unknown;
-    }[]
-  )
-    .map((file) => String(file.filename ?? ''))
+    : port
+        // Non-null: the earlier `!args.claimless && !args.claimIssueNumber`
+        // guard already rejected this branch with a missing claim issue.
+        .listWorkItemComments(args.claimIssueNumber as number)
+        .map(toIssueCommentPayload);
+  const threads = port.listChangeRequestReviewThreadsWithComments(
+    args.prNumber,
+  );
+  const changedFiles = port
+    .listChangeRequestChangedFiles(args.prNumber)
     .filter(Boolean);
-  const codeownersText = fetchCodeownersText(owner, repo, baseRefName);
+  const codeownersText = fetchCodeownersText(port, owner, repo, baseRefName);
   const {
     eligible: eligibleCodeownerUserLogins,
     unreadable: eligibleCodeownerUserLoginsUnreadable,
@@ -592,6 +543,7 @@ export function collectPreMergeReadiness(
     resolveCodeownersForFiles(codeownersText, changedFiles).codeownerUserLogins,
   );
   const viewerTeamSlugs = resolveViewerClassicBypassTeamSlugs(
+    port,
     owner,
     viewerLogin,
     branchProtection,
@@ -602,7 +554,7 @@ export function collectPreMergeReadiness(
     viewerLogin,
     ...configuredTrustedActors,
     ...(collaboratorTrustEnabled
-      ? resolveTrustedCollaboratorMarkerLogins(owner, repo, [
+      ? resolveTrustedCollaboratorMarkerLogins(port, [
           ...comments,
           ...claimComments,
         ])
@@ -631,9 +583,8 @@ export function collectPreMergeReadiness(
   let prFirstCommitAt: string | null = null;
   if (forcedHandoffEnabled) {
     try {
-      const prCommits = ghApiJson(
-        `repos/${owner}/${repo}/pulls/${args.prNumber}/commits`,
-        true,
+      const prCommits = port.listChangeRequestCommits(
+        args.prNumber,
       ) as PrCommitPayload[];
       prFirstCommitAt = resolvePrFirstCommitAt(prCommits);
     } catch {
@@ -725,6 +676,7 @@ export function collectPreMergeReadiness(
   const copilotUnavailable = copilotRecovery.state === 'COPILOT_UNAVAILABLE';
   const advisoryConvergenceOutageRelief =
     resolveAdvisoryConvergenceOutageRelief({
+      port,
       owner,
       repo,
       copilotUnavailable,
@@ -744,7 +696,7 @@ export function collectPreMergeReadiness(
       branchProtection,
       protectionReadsUnreadable,
       branchRulesetsUnreadable,
-      requestedReviewers: requestedReviewers.users ?? [],
+      requestedReviewers: requestedReviewerLogins,
       timelineEvents,
       claimEvents: claimComments.map(normalizeClaimComment),
       changedFiles,
@@ -1003,6 +955,26 @@ function printHelp(): void {
  * field-mapping drift (e.g. `user.login` -> `author.login`) would surface
  * only in production.
  */
+/**
+ * Map a `ProviderPort.listWorkItemComments` result back onto the REST
+ * `issues/{n}/comments` shape this file's `normalizeComment`/
+ * `normalizeClaimComment`/`resolveTrustedCollaboratorMarkerLogins`/
+ * `deriveIddAgentLogins` call already expect -- keeps every one of those
+ * unchanged rather than reshaping them for the port's flat `authorLogin`
+ * field, which `provider-outage-declaration.mts`'s own `CommentLike` (fed
+ * the same shim output for `resolveAdvisoryConvergenceOutageRelief`'s
+ * declaration comments) does not recognize either.
+ */
+function toIssueCommentPayload(comment: ProviderComment): IssueCommentPayload {
+  return {
+    id: comment.id,
+    body: comment.body,
+    created_at: comment.createdAt,
+    updated_at: comment.updatedAt,
+    user: { login: comment.authorLogin },
+  };
+}
+
 export function normalizeComment(comment: IssueCommentPayload) {
   return {
     id: String(comment.id ?? ''),
@@ -1045,38 +1017,36 @@ export function normalizeReview(review: ReviewPayload) {
 }
 
 /**
- * Normalize a raw GraphQL `reviewThreads` node into the summarizer-shape
- * `ThreadLike`. Exported for direct unit testing (#1708), see
- * {@link normalizeComment}'s doc comment.
+ * Normalize a `ProviderPort.listChangeRequestReviewThreadsWithComments`
+ * node into the summarizer-shape `ThreadLike`. Exported for direct unit
+ * testing (#1708), see {@link normalizeComment}'s doc comment. `id` and
+ * `reviewerReopenedAt` are omitted (both `ThreadLike` fields are optional):
+ * the pre-migration GraphQL query never selected `reviewerReopenedAt` at
+ * all (`inferReviewerReopenedAt` always returned `''`), and the outer
+ * thread `id` fed only `ThreadLike`'s own optional diagnostic fields, not
+ * any gating decision -- `review-activity-snapshot.mts`'s own
+ * `normalizeThread` already dropped both for the identical shared
+ * GraphQL query, reviewed and merged without incident.
  */
-export function normalizeThread(thread: ReviewThreadPayload) {
+export function normalizeThread(thread: ProviderReviewThreadWithComments) {
   return {
-    id: thread.id,
     isResolved: Boolean(thread.isResolved),
     updatedAt: '',
-    reviewerReopenedAt: inferReviewerReopenedAt(thread),
     comments: {
-      pageInfo: {
-        hasNextPage: Boolean(thread.comments?.pageInfo?.hasNextPage),
-      },
-      nodes: (thread.comments?.nodes ?? []).map((comment) => ({
-        author: { login: comment.author?.login ?? '' },
-        body: comment.body ?? '',
-        createdAt: comment.createdAt ?? '',
-        updatedAt: comment.updatedAt ?? comment.createdAt ?? '',
-        pullRequestReview: { id: comment.pullRequestReview?.id ?? null },
+      pageInfo: { hasNextPage: false },
+      nodes: thread.comments.map((comment) => ({
+        author: { login: comment.authorLogin },
+        body: comment.body,
+        createdAt: comment.createdAt,
+        updatedAt: comment.updatedAt || comment.createdAt,
+        pullRequestReview: { id: comment.pullRequestReviewId ?? null },
       })),
     },
   };
 }
 
-function inferReviewerReopenedAt(thread: ReviewThreadPayload): string {
-  return thread.reviewerReopenedAt ?? '';
-}
-
 function resolveTrustedCollaboratorMarkerLogins(
-  owner: string,
-  repo: string,
+  port: ProviderPort,
   comments: IssueCommentPayload[],
 ): string[] {
   const markerAuthors = [
@@ -1091,16 +1061,8 @@ function resolveTrustedCollaboratorMarkerLogins(
   ];
 
   return markerAuthors.filter((login) => {
-    const permission = safeGhText(
-      [
-        'api',
-        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-        '--jq',
-        '.permission',
-      ],
-      GH_TEXT_LOOP_OPTIONS,
-    ).toLowerCase();
-
+    const result = port.getCollaboratorPermission(login);
+    const permission = result.outcome === 'found' ? result.permission : '';
     return (
       permission === 'admin' ||
       permission === 'maintain' ||
@@ -1132,24 +1094,32 @@ export interface EligibleCodeownerResolution {
 /**
  * Exported for direct unit testing (matching this file's established
  * `fetchBranchRulesets`/`fetchGovernanceJson` injectable-fetch pattern) --
- * `fetchPermission` defaults to the real live `gh api .../permission` call
- * and is overridden in tests to simulate a 404 vs. a transient failure
- * without mocking `execFileSync`.
+ * `fetchPermission` defaults to the real `ProviderPort.getCollaboratorPermission`
+ * read and is overridden in tests to simulate a 404 vs. a transient failure
+ * without a live adapter. The default maps the port's never-throwing
+ * `{outcome}` result back onto this function's own throw-based contract
+ * (a synthetic `(HTTP 404)` error on `not-collaborator`, matching
+ * `idd-merge-execute.mts`'s `resolveRemoteSoloCodeownerAdminFallbackMode`
+ * default) so the `catch` block below -- and its existing tests -- stay
+ * byte-identical.
  */
 export function resolveEligibleCodeownerUserLogins(
   owner: string,
   repo: string,
   logins: unknown[],
-  fetchPermission: (login: string) => string = (login) =>
-    ghText(
-      [
-        'api',
-        `repos/${owner}/${repo}/collaborators/${encodeURIComponent(login)}/permission`,
-        '--jq',
-        '.permission',
-      ],
-      GH_TEXT_LOOP_OPTIONS,
-    ),
+  fetchPermission: (login: string) => string = (login) => {
+    const result = createGithubProviderAdapter(
+      owner,
+      repo,
+    ).getCollaboratorPermission(login);
+    if (result.outcome === 'not-collaborator') {
+      throwSyntheticGhNotFound();
+    }
+    if (result.outcome === 'error') {
+      throw new Error(result.error.message);
+    }
+    return result.permission;
+  },
 ): EligibleCodeownerResolution {
   let unreadable = false;
   const eligible = normalizeTrustedMarkerLogins(logins).filter((login) => {
@@ -1179,16 +1149,14 @@ export function resolveEligibleCodeownerUserLogins(
   return { eligible, unreadable };
 }
 
-function fetchCodeownersText(owner: string, repo: string, ref: string): string {
+function fetchCodeownersText(
+  port: ProviderPort,
+  owner: string,
+  repo: string,
+  ref: string,
+): string {
   const payloads = ['.github/CODEOWNERS', 'CODEOWNERS', 'docs/CODEOWNERS'].map(
-    (path) => {
-      return ghApiJson(
-        `repos/${owner}/${repo}/contents/${path}?ref=${encodeURIComponent(ref)}`,
-        false,
-        [],
-        { allowHttpStatuses: [404] },
-      );
-    },
+    (path) => port.getRepositoryContentAtRef(owner, repo, path, ref),
   );
   return selectCodeownersText(payloads);
 }
@@ -1231,18 +1199,25 @@ function fetchCodeownersText(owner: string, repo: string, ref: string): string {
  * the empty/skipped result the gate expects.
  *
  * `fetchRulesetDetail` is injectable for tests; production uses the default
- * `gh api` call.
+ * `ProviderPort.getRepositoryRulesetDetail` read, mapped back onto this
+ * function's throw-based contract the same way
+ * {@link resolveEligibleCodeownerUserLogins}'s default does.
  */
 export function fetchBranchRulesets(
   owner: string,
   repo: string,
   branchRules: BranchRulePayload[],
   trustEmptyReads = false,
-  fetchRulesetDetail: (path: string) => Record<string, unknown> = (path) =>
-    ghApiJson(path, false, [
-      '-H',
-      'Accept: application/vnd.github+json',
-    ]) as Record<string, unknown>,
+  fetchRulesetDetail: (path: string) => Record<string, unknown> = (path) => {
+    const outcome = createGithubProviderAdapter(
+      owner,
+      repo,
+    ).getRepositoryRulesetDetail(path);
+    if (outcome.outcome === 'not-found') {
+      throwSyntheticGhNotFound();
+    }
+    return outcome.value as Record<string, unknown>;
+  },
 ): GovernanceReadResult<Record<string, unknown>[]> {
   const rulesetPaths: string[] = [];
   const seenPaths = new Set<string>();
@@ -1279,6 +1254,7 @@ export function fetchBranchRulesets(
 }
 
 function resolveViewerClassicBypassTeamSlugs(
+  port: ProviderPort,
   owner: string,
   viewerLogin: string,
   branchProtection: BranchProtectionPayload,
@@ -1302,17 +1278,9 @@ function resolveViewerClassicBypassTeamSlugs(
         extractTeamOrgFromHtmlUrl(team?.html_url) ??
         owner,
     ).trim();
-    const state = safeGhText(
-      [
-        'api',
-        `orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(slug)}/memberships/${encodeURIComponent(
-          viewerLogin,
-        )}`,
-        '--jq',
-        '.state',
-      ],
-      GH_TEXT_LOOP_OPTIONS,
-    ).toLowerCase();
+    const state = port
+      .getTeamMembershipStateSafe(org, slug, viewerLogin)
+      .toLowerCase();
     if (state === 'active') {
       viewerTeams.add(slug);
     }
@@ -1325,199 +1293,50 @@ function extractTeamOrgFromHtmlUrl(htmlUrl: unknown): string {
   return match?.[1] ?? '';
 }
 
-function fetchReviewThreads(
-  owner: string,
-  repo: string,
-  prNumber: number,
-): ReviewThreadPayload[] {
-  const nodes: ReviewThreadPayload[] = [];
-  let cursor: string | null | undefined = null;
-
-  while (true) {
-    const payload = ghGraphql(
-      `
-        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
-          repository(owner: $owner, name: $repo) {
-            pullRequest(number: $number) {
-              reviewThreads(first: 100, after: $cursor) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  id
-                  isResolved
-                  comments(first: 100) {
-                    pageInfo { hasNextPage endCursor }
-                    nodes {
-                      body
-                      createdAt
-                      updatedAt
-                      author { login }
-                      pullRequestReview { id }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }`,
-      {
-        owner,
-        repo,
-        number: Number.parseInt(String(prNumber), 10),
-        cursor,
-      },
-    ) as {
-      data?: {
-        repository?: {
-          pullRequest?: {
-            reviewThreads?: ReviewThreadsConnectionPayload | null;
-          } | null;
-        } | null;
-      } | null;
-    };
-
-    const reviewThreads = payload?.data?.repository?.pullRequest?.reviewThreads;
-    for (const thread of reviewThreads?.nodes ?? []) {
-      if (thread.comments?.pageInfo?.hasNextPage) {
-        // hasNextPage with a missing thread id or cursor is a malformed
-        // payload; fail fast with a clear message instead of a confusing
-        // GraphQL error or a silently truncated thread.
-        if (!thread.id || !thread.comments.pageInfo.endCursor) {
-          throw new Error(
-            'review thread pagination payload is missing id or endCursor',
-          );
-        }
-        thread.comments.nodes.push(
-          ...fetchThreadCommentPages(
-            thread.id,
-            thread.comments.pageInfo.endCursor,
-          ),
-        );
-        thread.comments.pageInfo.hasNextPage = false;
-      }
-    }
-    nodes.push(...(reviewThreads?.nodes ?? []));
-
-    if (!reviewThreads?.pageInfo?.hasNextPage) {
-      break;
-    }
-    // hasNextPage with a missing cursor would re-fetch the first page
-    // forever; fail fast on the malformed payload instead.
-    if (!reviewThreads.pageInfo.endCursor) {
-      throw new Error('review thread pagination payload is missing endCursor');
-    }
-    cursor = reviewThreads.pageInfo.endCursor;
-  }
-
-  return nodes;
+/**
+ * Synthesize the same `(HTTP 404)`-in-`stderr` error shape a thrown `gh`
+ * failure would have carried, so a caller's existing `deriveGhHttpStatus(error)
+ * === 404` classification (unchanged by this migration) still recognizes a
+ * port `{outcome:'not-found'}`/`{outcome:'not-collaborator'}` result --
+ * mirrors `idd-merge-execute.mts`'s `resolveRemoteSoloCodeownerAdminFallbackMode`
+ * default.
+ */
+function throwSyntheticGhNotFound(): never {
+  const notFound = new Error('Not Found (HTTP 404)') as Error & {
+    stderr?: string;
+  };
+  notFound.stderr = 'Not Found (HTTP 404)';
+  throw notFound;
 }
 
-function fetchThreadCommentPages(
-  threadId: string,
-  afterCursor: string,
-): ThreadCommentPayload[] {
-  const nodes: ThreadCommentPayload[] = [];
-  let cursor: string | null | undefined = afterCursor;
-
-  while (cursor) {
-    const payload = ghGraphql(
-      `
-        query($id: ID!, $cursor: String) {
-          node(id: $id) {
-            ... on PullRequestReviewThread {
-              comments(first: 100, after: $cursor) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  body
-                  createdAt
-                  updatedAt
-                  author { login }
-                  pullRequestReview { id }
-                }
-              }
-            }
-          }
-        }`,
-      { id: threadId, cursor },
-    ) as {
-      data?: {
-        node?: {
-          comments?: {
-            pageInfo?: PageInfoPayload | null;
-            nodes?: ThreadCommentPayload[] | null;
-          } | null;
-        } | null;
-      } | null;
-    };
-
-    const comments = payload?.data?.node?.comments;
-    nodes.push(...(comments?.nodes ?? []));
-    if (comments?.pageInfo?.hasNextPage && !comments.pageInfo.endCursor) {
-      throw new Error('thread comment pagination payload is missing endCursor');
-    }
-    cursor = comments?.pageInfo?.hasNextPage
-      ? comments.pageInfo.endCursor
-      : null;
+/** Unwrap a `ProviderGovernanceReadOutcome`, throwing the same synthetic
+ * 404 {@link throwSyntheticGhNotFound} does on `not-found` so a caller
+ * passing this as `fetchGovernanceJson`'s `fetchJson` thunk preserves that
+ * function's existing `deriveGhHttpStatus(error) === 404` catch. */
+function unwrapGovernanceOutcome<T>(
+  outcome: { outcome: 'ok'; value: T } | { outcome: 'not-found' },
+): T {
+  if (outcome.outcome === 'not-found') {
+    throwSyntheticGhNotFound();
   }
-
-  return nodes;
-}
-
-function ghGraphql(
-  query: string,
-  variables: Record<string, string | number | null | undefined>,
-): unknown {
-  const args = ['api', 'graphql', '-f', `query=${query}`];
-  for (const [key, value] of Object.entries(variables)) {
-    if (value === null || value === undefined) {
-      continue;
-    }
-    if (typeof value === 'number') {
-      args.push('-F', `${key}=${value}`);
-      continue;
-    }
-    args.push('-f', `${key}=${value}`);
-  }
-  return JSON.parse(runGh(args).trim() || '{}');
-}
-
-function ghJson(args: string[], options: RunGhOptions = {}): unknown {
-  return JSON.parse(runGh(args, options).trim() || '[]');
-}
-
-function ghApiJson(
-  path: string,
-  paginate = false,
-  extraArgs: string[] = [],
-  options: RunGhOptions = {},
-): unknown {
-  const args = ['api', path, ...extraArgs];
-  if (paginate) {
-    // gh api with --paginate and --jq '.[]' emits one JSON object per line.
-    // --slurp landed in gh v2.48.0, but Ubuntu 24.04 LTS ships gh v2.45.0
-    // via apt, so keep the NDJSON-compatible form here.
-    args.push('--paginate', '--jq', '.[]');
-  }
-  const raw = runGh(args, options).trim();
-  if (!raw) {
-    return paginate ? [] : {};
-  }
-  if (paginate) {
-    return parsePaginatedGhNdjson(raw);
-  }
-  return JSON.parse(raw);
+  return outcome.value;
 }
 
 /**
  * Decide how a thrown `gh` failure is tolerated, returning the string result to
- * use or `undefined` when the caller must re-throw.
+ * use or `undefined` when the caller must re-throw. No longer called by this
+ * file's own collection path (#2267 routed every call site onto the provider
+ * port, which classifies its own failures), but kept -- pure, no `gh`
+ * invocation of its own -- for `idd-doctor.mts`'s own `fetchGhApiJsonAt`
+ * (an independent, un-migrated `gh api` caller) and its direct tests below.
  *
  * - `allowHttpStatuses` matches the HTTP status derived from the gh error via
- *   the shared `deriveGhHttpStatus` (the same extractor `fetchBranchRulesets`
- *   uses) and yields an **empty** string. `gh api` writes the JSON error body to
- *   stdout on a non-2xx response (a 404 prints `{"message":"Not Found",…}`), so
- *   returning that body would make `ghApiJson` parse the error object instead of
- *   `{}` / `[]`. An allowed status never carries useful data, so the empty
- *   result lets `ghApiJson` resolve it to an empty object / array.
+ *   the shared `deriveGhHttpStatus` and yields an **empty** string. `gh api`
+ *   writes the JSON error body to stdout on a non-2xx response (a 404 prints
+ *   `{"message":"Not Found",…}`), so returning that body would make the
+ *   caller parse the error object instead of `{}` / `[]`. An allowed status
+ *   never carries useful data, so the empty result resolves cleanly to an
+ *   empty object / array instead.
  * - `allowStatuses` matches the process exit code and returns stdout **only**
  *   when the body is genuinely the wanted JSON (`gh` commands that exit non-zero
  *   yet still print the data, e.g. the checks rollup).
@@ -1548,23 +1367,6 @@ export function resolveToleratedGhFailure(
     }
   }
   return undefined;
-}
-
-function runGh(args: string[], options: RunGhOptions = {}): string {
-  try {
-    return ghText(args, {
-      ...GH_TEXT_LOOP_OPTIONS,
-      ...(args.includes('--paginate')
-        ? { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS }
-        : {}),
-    });
-  } catch (error) {
-    const tolerated = resolveToleratedGhFailure(error, options);
-    if (tolerated !== undefined) {
-      return tolerated;
-    }
-    throw error;
-  }
 }
 
 function splitCsv(value: unknown): string[] {
@@ -1694,12 +1496,14 @@ export function resolveDeclarationActiveSince(
 // pre-declaration run left it at while this gate reports covered,
 // reproducing #2021's "ready but merge blocked" class one layer deeper.
 function resolveAdvisoryConvergenceOutageRelief({
+  port,
   owner,
   repo,
   copilotUnavailable,
   waivableCheckSelectors,
   now,
 }: {
+  port: ProviderPort;
   owner: string;
   repo: string;
   copilotUnavailable: boolean;
@@ -1716,10 +1520,9 @@ function resolveAdvisoryConvergenceOutageRelief({
     }
     const targetIssue = policy.providerOutage.declarationTarget;
     if (!targetIssue) return notRelieved;
-    const declarationComments = ghApiJson(
-      `repos/${owner}/${repo}/issues/${targetIssue}/comments`,
-      true,
-    ) as IssueCommentPayload[];
+    const declarationComments = port
+      .listWorkItemComments(targetIssue)
+      .map(toIssueCommentPayload);
     const authorityOf = (actorLogin: string): AuthorityEvidence =>
       normalizeAuthorityEvidence(
         resolveCollaboratorAuthority({ owner, repo, actor: actorLogin }),
@@ -1830,15 +1633,23 @@ interface GovernanceReadResult<T> {
  * permission error.
  *
  * `fetchJson` is injectable for tests (mirrors `fetchBranchRulesets`'s
- * `fetchRulesetDetail` parameter); production uses the default `gh api` call.
+ * `fetchRulesetDetail` parameter). No generic default transport: unlike
+ * `fetchBranchRulesets`/`resolveEligibleCodeownerUserLogins`, this helper
+ * has no owner/repo/ref of its own to construct a port-backed read from --
+ * every real caller (this file's own two governance reads, plus
+ * `idd-doctor.mts`'s independent `fetchGhApiJsonAt`-backed caller) already
+ * passes an explicit `fetchJson`.
  */
 export function fetchGovernanceJson<T>(
   path: string,
   paginate: boolean,
   trustEmptyReads: boolean,
   emptyValue: T,
-  fetchJson: (path: string, paginate: boolean) => unknown = (p, pg) =>
-    ghApiJson(p, pg, []),
+  fetchJson: (path: string, paginate: boolean) => unknown = () => {
+    throw new Error(
+      'fetchGovernanceJson: no default transport; pass an explicit fetchJson',
+    );
+  },
 ): GovernanceReadResult<T> {
   try {
     return { value: fetchJson(path, paginate) as T, unreadable: false };

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -616,7 +616,7 @@ export function collectPreMergeReadiness(
   const {
     reviews: advisoryConvergenceReviews,
     headCommittedAt: advisoryConvergenceHeadCommittedAt,
-  } = fetchReviewsAndHeadCommit(owner, repo, args.prNumber);
+  } = fetchReviewsAndHeadCommit(owner, repo, args.prNumber, port);
   const advisoryConvergenceDeadlineMinutes =
     readAdvisoryConvergenceDeadlineMinutes();
   const secondaryQuietWindowMinutes = readAdvisorySecondaryQuietWindowMinutes();

--- a/src/scripts/provider-adapter-fake.mts
+++ b/src/scripts/provider-adapter-fake.mts
@@ -356,6 +356,7 @@ export function createFakeProviderAdapter(
         id,
         body,
         createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
         authorLogin: fixture.viewerLogin ?? 'fake-actor',
       };
       fixture.comments ??= {};

--- a/src/scripts/provider-adapter-fake.mts
+++ b/src/scripts/provider-adapter-fake.mts
@@ -10,7 +10,11 @@
 // passed to `createFakeProviderAdapter`; nothing here spawns a subprocess
 // or makes a network call.
 
-import type { ProviderRepositoryLocator } from './provider-contract.mts';
+import {
+  PROVIDER_CAPABILITY_GROUPS,
+  type ProviderCapabilityDeclaration,
+  type ProviderRepositoryLocator,
+} from './provider-contract.mts';
 import type {
   ProviderChangeRequestAuthor,
   ProviderChangeRequestBranchAndChecks,
@@ -216,6 +220,12 @@ export interface FakeProviderFixture {
     number,
     ProviderReviewThreadWithAuthorType[]
   >;
+  /** Backs {@link ProviderPort.listCapabilityDeclarations}. Defaults to
+   * every capability group `supported: true` (the GitHub adapter's own
+   * posture) so a test only overrides the one group it's exercising, e.g.
+   * an `advisory-review: { supported: false }` override to simulate a
+   * non-GitHub provider without an advisory reviewer. */
+  capabilityDeclarations?: ProviderCapabilityDeclaration[];
 }
 
 export function createFakeProviderAdapter(
@@ -792,6 +802,17 @@ export function createFakeProviderAdapter(
       }
       fixture.resolvedReviewThreadIds ??= [];
       fixture.resolvedReviewThreadIds.push(threadId);
+    },
+
+    listCapabilityDeclarations(): ProviderCapabilityDeclaration[] {
+      return (
+        fixture.capabilityDeclarations ??
+        PROVIDER_CAPABILITY_GROUPS.map((group) => ({
+          group,
+          requirement: group === 'advisory-review' ? 'optional' : 'required',
+          supported: true,
+        }))
+      );
     },
   };
 }

--- a/src/scripts/provider-adapter-fake.mts
+++ b/src/scripts/provider-adapter-fake.mts
@@ -168,8 +168,8 @@ export interface FakeProviderFixture {
   /** Backs {@link ProviderPort.getBranchProtection}, keyed by `${owner}/${repo}/${ref}`;
    * absent key means `{outcome:'not-found'}`. */
   branchProtection?: Record<string, unknown>;
-  /** Backs {@link ProviderPort.getRepositoryRulesetDetail}, keyed by
-   * `${owner}/${repo}/${rulesetId}`; absent key means `{outcome:'not-found'}`. */
+  /** Backs {@link ProviderPort.getRepositoryRulesetDetail}, keyed by the
+   * resolved absolute path passed in; absent key means `{outcome:'not-found'}`. */
   rulesetDetails?: Record<string, unknown>;
   /** Backs {@link ProviderPort.getWorkflowRun}, keyed by `${owner}/${repo}/${runId}`. */
   workflowRuns?: Record<string, unknown>;
@@ -635,12 +635,9 @@ export function createFakeProviderAdapter(
     },
 
     getRepositoryRulesetDetail(
-      rulesetOwner: string,
-      rulesetRepo: string,
-      rulesetId: number | string,
+      path: string,
     ): ProviderGovernanceReadOutcome<unknown> {
-      const key = `${rulesetOwner}/${rulesetRepo}/${rulesetId}`;
-      const value = fixture.rulesetDetails?.[key];
+      const value = fixture.rulesetDetails?.[path];
       return value === undefined
         ? { outcome: 'not-found' }
         : { outcome: 'ok', value };

--- a/src/scripts/provider-adapter-fake.mts
+++ b/src/scripts/provider-adapter-fake.mts
@@ -12,15 +12,27 @@
 
 import type { ProviderRepositoryLocator } from './provider-contract.mts';
 import type {
+  ProviderChangeRequestBranchAndChecks,
+  ProviderChangeRequestConvergenceView,
+  ProviderChangeRequestHeadShaAndAuthor,
+  ProviderChangeRequestReadinessSnapshot,
   ProviderChangeRequestState,
   ProviderChangeRequestSummary,
   ProviderClosingPullRequestsPage,
   ProviderCollaboratorPermissionResult,
   ProviderComment,
   ProviderConnectedPrEvent,
+  ProviderGovernanceReadOutcome,
+  ProviderGraphqlComment,
+  ProviderGraphqlReview,
+  ProviderMergedChangeRequestMeta,
+  ProviderMergedChangeRequestSummary,
   ProviderPort,
   ProviderPostedComment,
   ProviderRequiredCheck,
+  ProviderReviewThreadCommentIds,
+  ProviderReviewThreadExtended,
+  ProviderReviewThreadWithComments,
   ProviderTimelineEvent,
   ProviderTraversalIssueLookup,
   ProviderWorkItem,
@@ -77,6 +89,121 @@ export interface FakeProviderFixture {
   traversalComments?: Record<number, unknown[]>;
   /** Backs {@link ProviderPort.searchOpenWorkItems}. */
   searchResults?: unknown[];
+
+  // --- #2267 additions below. -------------------------------------------
+
+  /** Backs {@link ProviderPort.getRepositoryDefaultBranch}. */
+  repositoryDefaultBranch?: string | null;
+  /** Backs {@link ProviderPort.resolveViewerAppSlugSafe}. */
+  viewerAppSlug?: string;
+  viewerAppSlugUnavailable?: boolean;
+  /** Backs {@link ProviderPort.getRepositoryContentAtRef}, keyed by
+   * `${owner}/${repo}/${path}@${ref}`; absent key means `null` (404). */
+  repositoryContentAtRef?: Record<string, unknown>;
+  /** Backs {@link ProviderPort.getRepositoryFileContentAtRef}, keyed by
+   * `${repoRef}/${path}@${ref}`; absent key means `not-found`. */
+  repositoryFileContentAtRef?: Record<string, string>;
+  /** Backs {@link ProviderPort.getTeamMembershipStateSafe}, keyed by
+   * `${org}/${teamSlug}/${login}`; absent key means `''`. */
+  teamMembershipStates?: Record<string, string>;
+  /** Backs {@link ProviderPort.getChangeRequestHeadShaAndAuthor}. */
+  changeRequestHeadShaAndAuthor?: Record<
+    number,
+    ProviderChangeRequestHeadShaAndAuthor
+  >;
+  /** Backs {@link ProviderPort.getChangeRequestConvergenceView}. */
+  changeRequestConvergenceViews?: Record<
+    number,
+    ProviderChangeRequestConvergenceView
+  >;
+  /** Backs {@link ProviderPort.getChangeRequestReadinessSnapshot}. */
+  changeRequestReadinessSnapshots?: Record<
+    number,
+    ProviderChangeRequestReadinessSnapshot
+  >;
+  /** Backs {@link ProviderPort.getChangeRequestBranchAndChecks}. */
+  changeRequestBranchAndChecks?: Record<
+    number,
+    ProviderChangeRequestBranchAndChecks
+  >;
+  /** Backs {@link ProviderPort.getChangeRequestHeadRef}. */
+  changeRequestHeadRefs?: Record<number, string>;
+  /** Backs {@link ProviderPort.listMergedChangeRequests}. */
+  mergedChangeRequests?: ProviderMergedChangeRequestSummary[];
+  /** Backs {@link ProviderPort.getMergedChangeRequestMeta}; absent key means `null`. */
+  mergedChangeRequestMeta?: Record<number, ProviderMergedChangeRequestMeta>;
+  /** Backs {@link ProviderPort.listChangeRequestChecks} (ALL checks, not just required). */
+  allChecks?: Record<number, ProviderRequiredCheck[]>;
+  /** Backs {@link ProviderPort.getChangeRequestRequestedReviewerLogins}. */
+  requestedReviewerLogins?: Record<number, string[]>;
+  /** Backs {@link ProviderPort.getChangeRequestRequestedReviewerLoginsGraphql}; absent key means `null`. */
+  requestedReviewerLoginsGraphql?: Record<number, string[]>;
+  /** Backs {@link ProviderPort.listChangeRequestChangedFiles}. */
+  changedFiles?: Record<number, string[]>;
+  /** Backs {@link ProviderPort.listChangeRequestCommits}. */
+  changeRequestCommits?: Record<number, unknown[]>;
+  /** Backs {@link ProviderPort.listChangeRequestReviewThreadsWithComments}. */
+  reviewThreadsWithComments?: Record<
+    number,
+    ProviderReviewThreadWithComments[]
+  >;
+  /** Backs {@link ProviderPort.listChangeRequestReviewThreadsExtended}. */
+  reviewThreadsExtended?: Record<number, ProviderReviewThreadExtended[]>;
+  /** Backs {@link ProviderPort.listChangeRequestReviewThreadCommentIds}. */
+  reviewThreadCommentIds?: Record<number, ProviderReviewThreadCommentIds[]>;
+  /** Backs {@link ProviderPort.listChangeRequestGraphqlComments}. */
+  changeRequestGraphqlComments?: Record<number, ProviderGraphqlComment[]>;
+  /** Backs {@link ProviderPort.listChangeRequestGraphqlReviews}. */
+  changeRequestGraphqlReviews?: Record<number, ProviderGraphqlReview[]>;
+  /** Backs {@link ProviderPort.listBranchRules}, keyed by `${owner}/${repo}/${ref}`;
+   * absent key means `{outcome:'not-found'}`. */
+  branchRules?: Record<string, unknown[]>;
+  /** Backs {@link ProviderPort.getBranchProtection}, keyed by `${owner}/${repo}/${ref}`;
+   * absent key means `{outcome:'not-found'}`. */
+  branchProtection?: Record<string, unknown>;
+  /** Backs {@link ProviderPort.getRepositoryRulesetDetail}, keyed by
+   * `${owner}/${repo}/${rulesetId}`; absent key means `{outcome:'not-found'}`. */
+  rulesetDetails?: Record<string, unknown>;
+  /** Backs {@link ProviderPort.getWorkflowRun}, keyed by `${owner}/${repo}/${runId}`. */
+  workflowRuns?: Record<string, unknown>;
+  /** Backs {@link ProviderPort.listWorkflowRuns}, keyed by `${owner}/${repo}/${workflowName}`. */
+  workflowRunLists?: Record<
+    string,
+    {
+      id: number;
+      conclusion: string | null;
+      status: string;
+      createdAt: string;
+    }[]
+  >;
+  /** Backs {@link ProviderPort.getChangeRequestHeadShaAtRepo}, keyed by
+   * `${owner}/${repo}/${number}`; an absent key throws (matches the adapter's
+   * own no-catch, throw-on-failure contract). */
+  changeRequestHeadShasAtRepo?: Record<string, string>;
+  /** Backs {@link ProviderPort.getChangeRequestAtRepo}, keyed by
+   * `${owner}/${repo}/${number}`. */
+  changeRequestsAtRepo?: Record<string, ProviderChangeRequestState>;
+  /** Every merge call (ambient or cross-repo, admin or not) is appended
+   * here, in call order. */
+  mergedChangeRequestCalls?: {
+    owner: string;
+    repo: string;
+    number: number;
+    headSha: string;
+    admin: boolean;
+  }[];
+  /** Every posted review-comment reply is appended here, in call order. */
+  postedReviewCommentReplies?: {
+    number: number;
+    commentId: number;
+    body: string;
+  }[];
+  nextReviewCommentReplyId?: number;
+  /** Every resolved review-thread id is appended here, in call order. */
+  resolvedReviewThreadIds?: string[];
+  /** Thread ids in this set fail {@link ProviderPort.resolveChangeRequestReviewThread}
+   * (simulates GitHub not confirming `isResolved`). */
+  unresolvableReviewThreadIds?: Set<string>;
 }
 
 export function createFakeProviderAdapter(
@@ -287,6 +414,346 @@ export function createFakeProviderAdapter(
 
     searchOpenWorkItems(): unknown[] {
       return fixture.searchResults ?? [];
+    },
+
+    // --- #2267 additions below. -------------------------------------------
+
+    getRepositoryDefaultBranch(): string | null {
+      return fixture.repositoryDefaultBranch ?? null;
+    },
+
+    resolveViewerAppSlugSafe(): { appSlug: string; unavailable: boolean } {
+      if (fixture.viewerAppSlugUnavailable || !fixture.viewerAppSlug) {
+        return { appSlug: '', unavailable: true };
+      }
+      return { appSlug: fixture.viewerAppSlug, unavailable: false };
+    },
+
+    resolveViewerLoginSafeQuiet(): {
+      viewerLogin: string;
+      viewerLoginUnavailable: boolean;
+    } {
+      if (fixture.viewerLoginUnavailable || !fixture.viewerLogin) {
+        return { viewerLogin: '', viewerLoginUnavailable: true };
+      }
+      return {
+        viewerLogin: fixture.viewerLogin,
+        viewerLoginUnavailable: false,
+      };
+    },
+
+    getRepositoryContentAtRef(
+      contentOwner: string,
+      contentRepo: string,
+      path: string,
+      ref: string,
+    ): unknown | null {
+      const key = `${contentOwner}/${contentRepo}/${path}@${ref}`;
+      return fixture.repositoryContentAtRef?.[key] ?? null;
+    },
+
+    getRepositoryFileContentAtRef(
+      repoRef: string,
+      path: string,
+      ref: string,
+    ): ProviderGovernanceReadOutcome<string> {
+      const key = `${repoRef}/${path}@${ref}`;
+      const value = fixture.repositoryFileContentAtRef?.[key];
+      return value === undefined
+        ? { outcome: 'not-found' }
+        : { outcome: 'ok', value };
+    },
+
+    getTeamMembershipStateSafe(
+      org: string,
+      teamSlug: string,
+      login: string,
+    ): string {
+      const key = `${org}/${teamSlug}/${login}`;
+      return fixture.teamMembershipStates?.[key] ?? '';
+    },
+
+    getChangeRequestHeadShaAndAuthor(
+      number: number,
+    ): ProviderChangeRequestHeadShaAndAuthor {
+      const value = fixture.changeRequestHeadShaAndAuthor?.[number];
+      if (!value) {
+        throw new Error(
+          `fake provider: no headSha/author fixture for PR ${number}`,
+        );
+      }
+      return value;
+    },
+
+    getChangeRequestConvergenceView(
+      number: number,
+    ): ProviderChangeRequestConvergenceView {
+      const value = fixture.changeRequestConvergenceViews?.[number];
+      if (!value) {
+        throw new Error(
+          `fake provider: no convergence-view fixture for PR ${number}`,
+        );
+      }
+      return value;
+    },
+
+    getChangeRequestReadinessSnapshot(
+      number: number,
+    ): ProviderChangeRequestReadinessSnapshot {
+      const value = fixture.changeRequestReadinessSnapshots?.[number];
+      if (!value) {
+        throw new Error(
+          `fake provider: no readiness-snapshot fixture for PR ${number}`,
+        );
+      }
+      return value;
+    },
+
+    getChangeRequestBranchAndChecks(
+      number: number,
+    ): ProviderChangeRequestBranchAndChecks {
+      const value = fixture.changeRequestBranchAndChecks?.[number];
+      if (!value) {
+        throw new Error(
+          `fake provider: no branch-and-checks fixture for PR ${number}`,
+        );
+      }
+      return value;
+    },
+
+    getChangeRequestHeadRef(number: number): string {
+      const value = fixture.changeRequestHeadRefs?.[number];
+      if (value === undefined) {
+        throw new Error(`fake provider: no head-ref fixture for PR ${number}`);
+      }
+      return value;
+    },
+
+    listMergedChangeRequests(): ProviderMergedChangeRequestSummary[] {
+      return fixture.mergedChangeRequests ?? [];
+    },
+
+    getMergedChangeRequestMeta(
+      number: number,
+    ): ProviderMergedChangeRequestMeta | null {
+      return fixture.mergedChangeRequestMeta?.[number] ?? null;
+    },
+
+    listChangeRequestChecks(number: number): ProviderRequiredCheck[] {
+      return fixture.allChecks?.[number] ?? [];
+    },
+
+    getChangeRequestRequestedReviewerLogins(number: number): string[] {
+      return fixture.requestedReviewerLogins?.[number] ?? [];
+    },
+
+    getChangeRequestRequestedReviewerLoginsGraphql(
+      number: number,
+    ): string[] | null {
+      return fixture.requestedReviewerLoginsGraphql?.[number] ?? null;
+    },
+
+    listChangeRequestChangedFiles(number: number): string[] {
+      return fixture.changedFiles?.[number] ?? [];
+    },
+
+    listChangeRequestCommits(number: number): unknown[] {
+      return fixture.changeRequestCommits?.[number] ?? [];
+    },
+
+    listChangeRequestReviewThreadsWithComments(
+      number: number,
+    ): ProviderReviewThreadWithComments[] {
+      return fixture.reviewThreadsWithComments?.[number] ?? [];
+    },
+
+    listChangeRequestReviewThreadsExtended(
+      number: number,
+    ): ProviderReviewThreadExtended[] {
+      return fixture.reviewThreadsExtended?.[number] ?? [];
+    },
+
+    listChangeRequestReviewThreadCommentIds(
+      number: number,
+    ): ProviderReviewThreadCommentIds[] {
+      return fixture.reviewThreadCommentIds?.[number] ?? [];
+    },
+
+    listChangeRequestGraphqlComments(number: number): ProviderGraphqlComment[] {
+      return fixture.changeRequestGraphqlComments?.[number] ?? [];
+    },
+
+    listChangeRequestGraphqlReviews(number: number): ProviderGraphqlReview[] {
+      return fixture.changeRequestGraphqlReviews?.[number] ?? [];
+    },
+
+    listBranchRules(
+      rulesOwner: string,
+      rulesRepo: string,
+      ref: string,
+    ): ProviderGovernanceReadOutcome<unknown[]> {
+      const key = `${rulesOwner}/${rulesRepo}/${ref}`;
+      const value = fixture.branchRules?.[key];
+      return value === undefined
+        ? { outcome: 'not-found' }
+        : { outcome: 'ok', value };
+    },
+
+    getBranchProtection(
+      protectionOwner: string,
+      protectionRepo: string,
+      ref: string,
+    ): ProviderGovernanceReadOutcome<unknown> {
+      const key = `${protectionOwner}/${protectionRepo}/${ref}`;
+      const value = fixture.branchProtection?.[key];
+      return value === undefined
+        ? { outcome: 'not-found' }
+        : { outcome: 'ok', value };
+    },
+
+    getRepositoryRulesetDetail(
+      rulesetOwner: string,
+      rulesetRepo: string,
+      rulesetId: number | string,
+    ): ProviderGovernanceReadOutcome<unknown> {
+      const key = `${rulesetOwner}/${rulesetRepo}/${rulesetId}`;
+      const value = fixture.rulesetDetails?.[key];
+      return value === undefined
+        ? { outcome: 'not-found' }
+        : { outcome: 'ok', value };
+    },
+
+    getWorkflowRun(runOwner: string, runRepo: string, runId: number): unknown {
+      const key = `${runOwner}/${runRepo}/${runId}`;
+      return fixture.workflowRuns?.[key] ?? null;
+    },
+
+    listWorkflowRuns(
+      runsOwner: string,
+      runsRepo: string,
+      workflowName: string,
+    ): {
+      id: number;
+      conclusion: string | null;
+      status: string;
+      createdAt: string;
+    }[] {
+      const key = `${runsOwner}/${runsRepo}/${workflowName}`;
+      return fixture.workflowRunLists?.[key] ?? [];
+    },
+
+    getChangeRequestHeadShaAtRepo(
+      atRepoOwner: string,
+      atRepoRepo: string,
+      number: number,
+    ): string {
+      const key = `${atRepoOwner}/${atRepoRepo}/${number}`;
+      const sha = fixture.changeRequestHeadShasAtRepo?.[key];
+      if (sha === undefined) {
+        throw new Error(
+          `fake provider: no cross-repo head SHA fixture for ${key}`,
+        );
+      }
+      return sha;
+    },
+
+    getChangeRequestAtRepo(
+      atRepoOwner: string,
+      atRepoRepo: string,
+      number: number,
+    ): ProviderChangeRequestState | null {
+      const key = `${atRepoOwner}/${atRepoRepo}/${number}`;
+      return fixture.changeRequestsAtRepo?.[key] ?? null;
+    },
+
+    mergeChangeRequestAtRepo(
+      mergeOwner: string,
+      mergeRepo: string,
+      number: number,
+      headSha: string,
+    ): string {
+      fixture.mergedChangeRequestCalls ??= [];
+      fixture.mergedChangeRequestCalls.push({
+        owner: mergeOwner,
+        repo: mergeRepo,
+        number,
+        headSha,
+        admin: false,
+      });
+      return `fake merge commit for ${mergeOwner}/${mergeRepo}#${number}`;
+    },
+
+    mergeChangeRequestAdminAtRepo(
+      mergeOwner: string,
+      mergeRepo: string,
+      number: number,
+      headSha: string,
+    ): string {
+      fixture.mergedChangeRequestCalls ??= [];
+      fixture.mergedChangeRequestCalls.push({
+        owner: mergeOwner,
+        repo: mergeRepo,
+        number,
+        headSha,
+        admin: true,
+      });
+      return `fake admin merge commit for ${mergeOwner}/${mergeRepo}#${number}`;
+    },
+
+    mergeChangeRequest(number: number, headSha: string): string {
+      const locator = fixture.locator ?? {
+        provider: 'github' as const,
+        owner: 'fake-owner',
+        name: 'fake-repo',
+      };
+      fixture.mergedChangeRequestCalls ??= [];
+      fixture.mergedChangeRequestCalls.push({
+        owner: locator.owner,
+        repo: locator.name,
+        number,
+        headSha,
+        admin: false,
+      });
+      return `fake merge commit for ${locator.owner}/${locator.name}#${number}`;
+    },
+
+    mergeChangeRequestAdmin(number: number, headSha: string): string {
+      const locator = fixture.locator ?? {
+        provider: 'github' as const,
+        owner: 'fake-owner',
+        name: 'fake-repo',
+      };
+      fixture.mergedChangeRequestCalls ??= [];
+      fixture.mergedChangeRequestCalls.push({
+        owner: locator.owner,
+        repo: locator.name,
+        number,
+        headSha,
+        admin: true,
+      });
+      return `fake admin merge commit for ${locator.owner}/${locator.name}#${number}`;
+    },
+
+    postReviewCommentReply(
+      number: number,
+      commentId: number,
+      body: string,
+    ): { id: number } {
+      fixture.postedReviewCommentReplies ??= [];
+      fixture.postedReviewCommentReplies.push({ number, commentId, body });
+      const id = fixture.nextReviewCommentReplyId ?? 1;
+      fixture.nextReviewCommentReplyId = id + 1;
+      return { id };
+    },
+
+    resolveChangeRequestReviewThread(threadId: string): void {
+      if (fixture.unresolvableReviewThreadIds?.has(threadId)) {
+        throw new Error(
+          `fake provider: GitHub did not confirm thread ${threadId} as resolved`,
+        );
+      }
+      fixture.resolvedReviewThreadIds ??= [];
+      fixture.resolvedReviewThreadIds.push(threadId);
     },
   };
 }

--- a/src/scripts/provider-adapter-fake.mts
+++ b/src/scripts/provider-adapter-fake.mts
@@ -456,13 +456,15 @@ export function createFakeProviderAdapter(
       viewerLogin: string;
       viewerLoginUnavailable: boolean;
     } {
-      if (fixture.viewerLoginUnavailable || !fixture.viewerLogin) {
+      // Mirrors the GitHub adapter's own trim().toLowerCase() normalization
+      // (Copilot review, PR #2429) so a fixture login differing only in
+      // case/whitespace does not diverge fake-provider tests from
+      // production behavior.
+      const normalized = fixture.viewerLogin?.trim().toLowerCase() ?? '';
+      if (fixture.viewerLoginUnavailable || !normalized) {
         return { viewerLogin: '', viewerLoginUnavailable: true };
       }
-      return {
-        viewerLogin: fixture.viewerLogin,
-        viewerLoginUnavailable: false,
-      };
+      return { viewerLogin: normalized, viewerLoginUnavailable: false };
     },
 
     getRepositoryContentAtRef(
@@ -552,8 +554,19 @@ export function createFakeProviderAdapter(
       return value;
     },
 
-    listMergedChangeRequests(): ProviderMergedChangeRequestSummary[] {
-      return fixture.mergedChangeRequests ?? [];
+    listMergedChangeRequests(
+      limit: number,
+      sinceDate: string | null,
+    ): ProviderMergedChangeRequestSummary[] {
+      // Honors both parameters the GitHub adapter's `gh pr list --limit
+      // --search merged:>=date` call applies (Copilot review, PR #2429),
+      // so a collection-wiring test cannot pass on unrealistic behavior --
+      // more rows than requested, or an unfiltered date range.
+      const rows = fixture.mergedChangeRequests ?? [];
+      const filtered = sinceDate
+        ? rows.filter((row) => row.mergedAt >= sinceDate)
+        : rows;
+      return filtered.slice(0, limit);
     },
 
     getMergedChangeRequestMeta(

--- a/src/scripts/provider-adapter-fake.mts
+++ b/src/scripts/provider-adapter-fake.mts
@@ -30,6 +30,7 @@ import type {
   ProviderPort,
   ProviderPostedComment,
   ProviderRequiredCheck,
+  ProviderReviewsWithHeadCommitDate,
   ProviderReviewThreadCommentIds,
   ProviderReviewThreadExtended,
   ProviderReviewThreadWithComments,
@@ -204,6 +205,8 @@ export interface FakeProviderFixture {
   /** Thread ids in this set fail {@link ProviderPort.resolveChangeRequestReviewThread}
    * (simulates GitHub not confirming `isResolved`). */
   unresolvableReviewThreadIds?: Set<string>;
+  /** Backs {@link ProviderPort.getChangeRequestReviewsWithHeadCommitDate}. */
+  reviewsWithHeadCommitDate?: Record<number, ProviderReviewsWithHeadCommitDate>;
 }
 
 export function createFakeProviderAdapter(
@@ -744,6 +747,17 @@ export function createFakeProviderAdapter(
       const id = fixture.nextReviewCommentReplyId ?? 1;
       fixture.nextReviewCommentReplyId = id + 1;
       return { id };
+    },
+
+    getChangeRequestReviewsWithHeadCommitDate(
+      number: number,
+    ): ProviderReviewsWithHeadCommitDate {
+      return (
+        fixture.reviewsWithHeadCommitDate?.[number] ?? {
+          reviews: [],
+          headCommittedAt: '',
+        }
+      );
     },
 
     resolveChangeRequestReviewThread(threadId: string): void {

--- a/src/scripts/provider-adapter-fake.mts
+++ b/src/scripts/provider-adapter-fake.mts
@@ -171,7 +171,9 @@ export interface FakeProviderFixture {
   /** Backs {@link ProviderPort.getRepositoryRulesetDetail}, keyed by the
    * resolved absolute path passed in; absent key means `{outcome:'not-found'}`. */
   rulesetDetails?: Record<string, unknown>;
-  /** Backs {@link ProviderPort.getWorkflowRun}, keyed by `${owner}/${repo}/${runId}`. */
+  /** Backs {@link ProviderPort.getWorkflowRun}, keyed by
+   * `${owner}/${repo}/${runId}`; an absent key throws (matches the
+   * adapter's own no-catch, throw-on-failure contract). */
   workflowRuns?: Record<string, unknown>;
   /** Backs {@link ProviderPort.listWorkflowRuns}, keyed by `${owner}/${repo}/${workflowName}`. */
   workflowRunLists?: Record<
@@ -441,15 +443,27 @@ export function createFakeProviderAdapter(
 
     // --- #2267 additions below. -------------------------------------------
 
-    getRepositoryDefaultBranch(): string | null {
+    getRepositoryDefaultBranch(
+      _defaultBranchOwner: string,
+      _defaultBranchRepo: string,
+    ): string | null {
+      // Accepts owner/repo to match the port's declared arity (Copilot
+      // review, PR #2429: an unaccepted parameter is silently hidden by
+      // structural typing) -- unused because every fixture in this file
+      // represents a single ambient repo, and this method's one real call
+      // site (pre-merge-readiness.mts) always passes that same repo back.
       return fixture.repositoryDefaultBranch ?? null;
     },
 
     resolveViewerAppSlugSafe(): { appSlug: string; unavailable: boolean } {
-      if (fixture.viewerAppSlugUnavailable || !fixture.viewerAppSlug) {
+      // Mirrors the GitHub adapter's own raw.trim() on the CLI output,
+      // for the same reason as resolveViewerLoginSafeQuiet's normalization
+      // above.
+      const trimmed = fixture.viewerAppSlug?.trim() ?? '';
+      if (fixture.viewerAppSlugUnavailable || !trimmed) {
         return { appSlug: '', unavailable: true };
       }
-      return { appSlug: fixture.viewerAppSlug, unavailable: false };
+      return { appSlug: trimmed, unavailable: false };
     },
 
     resolveViewerLoginSafeQuiet(): {
@@ -661,22 +675,36 @@ export function createFakeProviderAdapter(
       runRepo: string,
       runId: string | number,
     ): unknown {
+      // Throws on a missing fixture, matching the GitHub adapter's own
+      // no-catch `deps.ghText` call (Copilot review, PR #2429) -- a fake
+      // adapter returning null here can both mask a missing fixture and
+      // produce a confusing downstream TypeError instead of failing
+      // closed like production.
       const key = `${runOwner}/${runRepo}/${runId}`;
-      return fixture.workflowRuns?.[key] ?? null;
+      const value = fixture.workflowRuns?.[key];
+      if (value === undefined) {
+        throw new Error(`fake provider: no workflow-run fixture for ${key}`);
+      }
+      return value;
     },
 
     listWorkflowRuns(
       runsOwner: string,
       runsRepo: string,
       workflowName: string,
+      limit: number,
     ): {
       id: number;
       conclusion: string | null;
       status: string;
       createdAt: string;
     }[] {
+      // Honors `limit`, matching the GitHub adapter's own `gh run list
+      // --limit N` call (Copilot review, PR #2429) -- an ignored limit let
+      // a collection-wiring test pass against an unrealistically large
+      // sibling sweep.
       const key = `${runsOwner}/${runsRepo}/${workflowName}`;
-      return fixture.workflowRunLists?.[key] ?? [];
+      return (fixture.workflowRunLists?.[key] ?? []).slice(0, limit);
     },
 
     getChangeRequestHeadShaAtRepo(
@@ -796,12 +824,18 @@ export function createFakeProviderAdapter(
     getChangeRequestReviewsWithHeadCommitDate(
       number: number,
     ): ProviderReviewsWithHeadCommitDate {
-      return (
-        fixture.reviewsWithHeadCommitDate?.[number] ?? {
-          reviews: [],
-          headCommittedAt: '',
-        }
-      );
+      // Throws on a missing fixture, matching the GitHub adapter's own
+      // no-catch GraphQL call and this file's sibling PR-view methods
+      // (Copilot review, PR #2429) -- review-clause.mts's own caller has
+      // no try/catch around this call, so a silent empty default here
+      // would hide a missing fixture instead of failing closed.
+      const value = fixture.reviewsWithHeadCommitDate?.[number];
+      if (!value) {
+        throw new Error(
+          `fake provider: no reviews/head-commit-date fixture for PR ${number}`,
+        );
+      }
+      return value;
     },
 
     resolveChangeRequestReviewThread(threadId: string): void {

--- a/src/scripts/provider-adapter-fake.mts
+++ b/src/scripts/provider-adapter-fake.mts
@@ -179,7 +179,7 @@ export interface FakeProviderFixture {
   workflowRunLists?: Record<
     string,
     {
-      id: number;
+      id: string;
       conclusion: string | null;
       status: string;
       createdAt: string;
@@ -694,7 +694,7 @@ export function createFakeProviderAdapter(
       workflowName: string,
       limit: number,
     ): {
-      id: number;
+      id: string;
       conclusion: string | null;
       status: string;
       createdAt: string;

--- a/src/scripts/provider-adapter-fake.mts
+++ b/src/scripts/provider-adapter-fake.mts
@@ -636,7 +636,11 @@ export function createFakeProviderAdapter(
         : { outcome: 'ok', value };
     },
 
-    getWorkflowRun(runOwner: string, runRepo: string, runId: number): unknown {
+    getWorkflowRun(
+      runOwner: string,
+      runRepo: string,
+      runId: string | number,
+    ): unknown {
       const key = `${runOwner}/${runRepo}/${runId}`;
       return fixture.workflowRuns?.[key] ?? null;
     },

--- a/src/scripts/provider-adapter-fake.mts
+++ b/src/scripts/provider-adapter-fake.mts
@@ -12,6 +12,7 @@
 
 import type { ProviderRepositoryLocator } from './provider-contract.mts';
 import type {
+  ProviderChangeRequestAuthor,
   ProviderChangeRequestBranchAndChecks,
   ProviderChangeRequestConvergenceView,
   ProviderChangeRequestHeadShaAndAuthor,
@@ -33,6 +34,7 @@ import type {
   ProviderReviewsWithHeadCommitDate,
   ProviderReviewThreadCommentIds,
   ProviderReviewThreadExtended,
+  ProviderReviewThreadWithAuthorType,
   ProviderReviewThreadWithComments,
   ProviderTimelineEvent,
   ProviderTraversalIssueLookup,
@@ -207,6 +209,13 @@ export interface FakeProviderFixture {
   unresolvableReviewThreadIds?: Set<string>;
   /** Backs {@link ProviderPort.getChangeRequestReviewsWithHeadCommitDate}. */
   reviewsWithHeadCommitDate?: Record<number, ProviderReviewsWithHeadCommitDate>;
+  /** Backs {@link ProviderPort.getChangeRequestAuthor}; absent key means `null`. */
+  changeRequestAuthors?: Record<number, ProviderChangeRequestAuthor>;
+  /** Backs {@link ProviderPort.listChangeRequestReviewThreadsWithAuthorType}. */
+  reviewThreadsWithAuthorType?: Record<
+    number,
+    ProviderReviewThreadWithAuthorType[]
+  >;
 }
 
 export function createFakeProviderAdapter(
@@ -747,6 +756,16 @@ export function createFakeProviderAdapter(
       const id = fixture.nextReviewCommentReplyId ?? 1;
       fixture.nextReviewCommentReplyId = id + 1;
       return { id };
+    },
+
+    getChangeRequestAuthor(number: number): ProviderChangeRequestAuthor | null {
+      return fixture.changeRequestAuthors?.[number] ?? null;
+    },
+
+    listChangeRequestReviewThreadsWithAuthorType(
+      number: number,
+    ): ProviderReviewThreadWithAuthorType[] {
+      return fixture.reviewThreadsWithAuthorType?.[number] ?? [];
     },
 
     getChangeRequestReviewsWithHeadCommitDate(

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -22,10 +22,12 @@ import {
   withBoundedRetry,
 } from './gh-exec.mts';
 import { deriveGhHttpStatus } from './gh-http-status.mts';
-import type {
-  ProviderError,
-  ProviderErrorCategory,
-  ProviderRepositoryLocator,
+import {
+  PROVIDER_CAPABILITY_GROUPS,
+  type ProviderCapabilityDeclaration,
+  type ProviderError,
+  type ProviderErrorCategory,
+  type ProviderRepositoryLocator,
 } from './provider-contract.mts';
 import type {
   ProviderChangeRequestAuthor,
@@ -2360,6 +2362,14 @@ export function createGithubProviderAdapter(
           `resolveChangeRequestReviewThread: GitHub did not confirm thread ${threadId} as resolved`,
         );
       }
+    },
+
+    listCapabilityDeclarations(): ProviderCapabilityDeclaration[] {
+      return PROVIDER_CAPABILITY_GROUPS.map((group) => ({
+        group,
+        requirement: group === 'advisory-review' ? 'optional' : 'required',
+        supported: true,
+      }));
     },
   };
 }

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -19,6 +19,7 @@ import {
   ghText,
   ghTextAsync,
   readGithubRepoDefaultBranch,
+  resolveGhApiHostname,
   withBoundedRetry,
 } from './gh-exec.mts';
 import { deriveGhHttpStatus } from './gh-http-status.mts';
@@ -58,6 +59,20 @@ import type {
   ProviderTraversalIssueLookup,
   ProviderWorkItem,
 } from './provider-port.mts';
+
+/**
+ * `--hostname` args to splice into a hand-built `['api', 'graphql', ...]`
+ * array right after `'graphql'`, matching `gh-exec.mts`'s `ghGraphql`/
+ * `ghApiJson` (#1962) -- this file's raw GraphQL call sites build their own
+ * args (see `fetchReviewThreadsGeneric`'s doc comment for why: a tight-loop
+ * stdin hazard, #1396) rather than routing through that shared helper, so
+ * each site must resolve the GHES host itself instead of always defaulting
+ * to github.com (Copilot review, PR #2429).
+ */
+function graphqlHostnameArgs(): string[] {
+  const hostname = resolveGhApiHostname();
+  return hostname ? ['--hostname', hostname] : [];
+}
 
 /** Raw REST issue-payload fields this adapter reads, GitHub-shaped. */
 interface RawIssue {
@@ -271,6 +286,7 @@ function fetchReviewThreadsGeneric(
       const parsed = runQuery([
         'api',
         'graphql',
+        ...graphqlHostnameArgs(),
         '-f',
         `query=${continuationQuery}`,
         '-f',
@@ -299,6 +315,7 @@ function fetchReviewThreadsGeneric(
     const apiArgs = [
       'api',
       'graphql',
+      ...graphqlHostnameArgs(),
       '-f',
       `query=${outerQuery}`,
       '-f',
@@ -1557,6 +1574,7 @@ export function createGithubProviderAdapter(
       const apiArgs = [
         'api',
         'graphql',
+        ...graphqlHostnameArgs(),
         '-f',
         `query=${query}`,
         '-f',
@@ -1663,6 +1681,7 @@ export function createGithubProviderAdapter(
         const apiArgs = [
           'api',
           'graphql',
+          ...graphqlHostnameArgs(),
           '-f',
           `query=${query}`,
           '-f',
@@ -1792,6 +1811,7 @@ export function createGithubProviderAdapter(
         const apiArgs = [
           'api',
           'graphql',
+          ...graphqlHostnameArgs(),
           '-f',
           `query=${query}`,
           '-f',
@@ -1829,8 +1849,24 @@ export function createGithubProviderAdapter(
             } | null;
           };
         };
-        const connection = parsed.data?.repository?.pullRequest?.comments;
-        for (const node of connection?.nodes ?? []) {
+        // Fail fast on a missing pullRequest node or connection, matching
+        // merged-pr-feedback-sweep.mts's pre-migration fetchAllNodes
+        // (Codex review, PR #2429): an absent node/connection is otherwise
+        // read as zero comments, making a PR look "clean" -- the silent
+        // false negative this check exists to prevent.
+        const pullRequest = parsed.data?.repository?.pullRequest;
+        if (pullRequest == null) {
+          throw new Error(
+            `listChangeRequestGraphqlComments: PR #${number} returned no pullRequest node`,
+          );
+        }
+        const connection = pullRequest.comments;
+        if (connection == null) {
+          throw new Error(
+            `listChangeRequestGraphqlComments: PR #${number} returned a null comments connection`,
+          );
+        }
+        for (const node of connection.nodes ?? []) {
           out.push({
             body: String(node.body ?? ''),
             url: String(node.url ?? ''),
@@ -1839,7 +1875,7 @@ export function createGithubProviderAdapter(
             authorLogin: String(node.author?.login ?? ''),
           });
         }
-        const pageInfo = connection?.pageInfo;
+        const pageInfo = connection.pageInfo;
         if (!pageInfo?.hasNextPage) {
           break;
         }
@@ -1870,6 +1906,7 @@ export function createGithubProviderAdapter(
         const apiArgs = [
           'api',
           'graphql',
+          ...graphqlHostnameArgs(),
           '-f',
           `query=${query}`,
           '-f',
@@ -1907,8 +1944,23 @@ export function createGithubProviderAdapter(
             } | null;
           };
         };
-        const connection = parsed.data?.repository?.pullRequest?.reviews;
-        for (const node of connection?.nodes ?? []) {
+        // Fail fast on a missing pullRequest node or connection, matching
+        // merged-pr-feedback-sweep.mts's pre-migration fetchAllNodes
+        // (Codex review, PR #2429) -- see listChangeRequestGraphqlComments's
+        // identical check above for the full rationale.
+        const pullRequest = parsed.data?.repository?.pullRequest;
+        if (pullRequest == null) {
+          throw new Error(
+            `listChangeRequestGraphqlReviews: PR #${number} returned no pullRequest node`,
+          );
+        }
+        const connection = pullRequest.reviews;
+        if (connection == null) {
+          throw new Error(
+            `listChangeRequestGraphqlReviews: PR #${number} returned a null reviews connection`,
+          );
+        }
+        for (const node of connection.nodes ?? []) {
           out.push({
             body: String(node.body ?? ''),
             url: String(node.url ?? ''),
@@ -1918,7 +1970,7 @@ export function createGithubProviderAdapter(
             authorLogin: String(node.author?.login ?? ''),
           });
         }
-        const pageInfo = connection?.pageInfo;
+        const pageInfo = connection.pageInfo;
         if (!pageInfo?.hasNextPage) {
           break;
         }
@@ -1986,7 +2038,7 @@ export function createGithubProviderAdapter(
       workflowName: string,
       limit: number,
     ): {
-      id: number;
+      id: string;
       conclusion: string | null;
       status: string;
       createdAt: string;
@@ -2013,7 +2065,9 @@ export function createGithubProviderAdapter(
         createdAt?: unknown;
       }[];
       return rows.map((row) => ({
-        id: Number(row.databaseId),
+        // String(...), not Number(...): preserves a databaseId above
+        // Number.MAX_SAFE_INTEGER exactly (Codex review, PR #2429).
+        id: String(row.databaseId ?? ''),
         conclusion: row.conclusion == null ? null : String(row.conclusion),
         status: String(row.status ?? ''),
         createdAt: String(row.createdAt ?? ''),
@@ -2121,6 +2175,7 @@ export function createGithubProviderAdapter(
       const apiArgs = [
         'api',
         'graphql',
+        ...graphqlHostnameArgs(),
         '-f',
         `query=${query}`,
         '-f',
@@ -2219,6 +2274,7 @@ export function createGithubProviderAdapter(
         const apiArgs = [
           'api',
           'graphql',
+          ...graphqlHostnameArgs(),
           '-f',
           `query=${query}`,
           '-f',
@@ -2231,9 +2287,9 @@ export function createGithubProviderAdapter(
         if (cursor) {
           apiArgs.push('-f', `cursor=${cursor}`);
         }
-        const parsed = JSON.parse(
-          deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS),
-        ) as {
+        const raw = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+        assertNoGraphqlErrors(raw, 'getChangeRequestReviewsWithHeadCommitDate');
+        const parsed = raw as {
           data?: {
             repository?: {
               pullRequest?: {
@@ -2344,6 +2400,7 @@ export function createGithubProviderAdapter(
       const apiArgs = [
         'api',
         'graphql',
+        ...graphqlHostnameArgs(),
         '-f',
         `query=${mutation}`,
         '-f',

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -28,6 +28,7 @@ import type {
   ProviderRepositoryLocator,
 } from './provider-contract.mts';
 import type {
+  ProviderChangeRequestAuthor,
   ProviderChangeRequestBranchAndChecks,
   ProviderChangeRequestConvergenceView,
   ProviderChangeRequestHeadShaAndAuthor,
@@ -49,6 +50,7 @@ import type {
   ProviderReviewsWithHeadCommitDate,
   ProviderReviewThreadCommentIds,
   ProviderReviewThreadExtended,
+  ProviderReviewThreadWithAuthorType,
   ProviderReviewThreadWithComments,
   ProviderTimelineEvent,
   ProviderTraversalIssueLookup,
@@ -148,7 +150,7 @@ interface RawThreadCommentNode {
   url?: unknown;
   createdAt?: unknown;
   updatedAt?: unknown;
-  author?: { login?: unknown } | null;
+  author?: { login?: unknown; __typename?: unknown } | null;
   pullRequestReview?: { id?: unknown } | null;
   databaseId?: unknown;
 }
@@ -2062,6 +2064,76 @@ export function createGithubProviderAdapter(
         headSha,
         '--admin',
       ]);
+    },
+
+    getChangeRequestAuthor(number: number): ProviderChangeRequestAuthor | null {
+      const query = `
+        query($owner: String!, $repo: String!, $number: Int!) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $number) {
+              author { login __typename }
+            }
+          }
+        }`;
+      const apiArgs = [
+        'api',
+        'graphql',
+        '-f',
+        `query=${query}`,
+        '-f',
+        `owner=${owner}`,
+        '-f',
+        `repo=${repo}`,
+        '-F',
+        `number=${number}`,
+      ];
+      const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS)) as {
+        data?: {
+          repository?: {
+            pullRequest?: {
+              author?: { login?: unknown; __typename?: unknown } | null;
+            } | null;
+          } | null;
+        } | null;
+      };
+      const author = parsed.data?.repository?.pullRequest?.author;
+      if (!author) {
+        return null;
+      }
+      return {
+        login: String(author.login ?? ''),
+        typename: author.__typename == null ? null : String(author.__typename),
+      };
+    },
+
+    listChangeRequestReviewThreadsWithAuthorType(
+      number: number,
+    ): ProviderReviewThreadWithAuthorType[] {
+      const nodes = fetchReviewThreadsGeneric(
+        deps,
+        owner,
+        repo,
+        number,
+        'body createdAt updatedAt author { login __typename } pullRequestReview { id }',
+      );
+      return nodes.map((node) => ({
+        id: node.id,
+        isResolved: node.isResolved,
+        comments: node.comments.map((comment) => ({
+          body: String(comment.body ?? ''),
+          createdAt: String(comment.createdAt ?? ''),
+          updatedAt: String(comment.updatedAt ?? ''),
+          authorLogin: String(comment.author?.login ?? ''),
+          authorTypename:
+            comment.author?.__typename == null
+              ? null
+              : String(comment.author.__typename),
+          pullRequestReviewId:
+            comment.pullRequestReview?.id == null
+              ? null
+              : String(comment.pullRequestReview.id),
+        })),
+      }));
     },
 
     getChangeRequestReviewsWithHeadCommitDate(

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -46,6 +46,7 @@ import type {
   ProviderPort,
   ProviderPostedComment,
   ProviderRequiredCheck,
+  ProviderReviewsWithHeadCommitDate,
   ProviderReviewThreadCommentIds,
   ProviderReviewThreadExtended,
   ProviderReviewThreadWithComments,
@@ -2061,6 +2062,115 @@ export function createGithubProviderAdapter(
         headSha,
         '--admin',
       ]);
+    },
+
+    getChangeRequestReviewsWithHeadCommitDate(
+      number: number,
+    ): ProviderReviewsWithHeadCommitDate {
+      const query = `
+        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequest(number: $number) {
+              reviews(first: 100, after: $cursor) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                  id
+                  commit { oid }
+                  submittedAt
+                  author { login __typename }
+                  comments { totalCount }
+                  body
+                }
+              }
+              commits(last: 1) {
+                nodes { commit { committedDate } }
+              }
+            }
+          }
+        }`;
+      const nodes: {
+        id?: unknown;
+        commit?: { oid?: unknown } | null;
+        submittedAt?: unknown;
+        author?: { login?: unknown; __typename?: unknown } | null;
+        comments?: { totalCount?: unknown } | null;
+        body?: unknown;
+      }[] = [];
+      let headCommittedAt = '';
+      let cursor: string | null = null;
+      while (true) {
+        const apiArgs = [
+          'api',
+          'graphql',
+          '-f',
+          `query=${query}`,
+          '-f',
+          `owner=${owner}`,
+          '-f',
+          `repo=${repo}`,
+          '-F',
+          `number=${number}`,
+        ];
+        if (cursor) {
+          apiArgs.push('-f', `cursor=${cursor}`);
+        }
+        const parsed = JSON.parse(
+          deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS),
+        ) as {
+          data?: {
+            repository?: {
+              pullRequest?: {
+                reviews?: {
+                  pageInfo?: {
+                    hasNextPage?: boolean;
+                    endCursor?: string | null;
+                  };
+                  nodes?: typeof nodes;
+                } | null;
+                commits?: {
+                  nodes?: { commit?: { committedDate?: unknown } | null }[];
+                } | null;
+              } | null;
+            } | null;
+          };
+        };
+        const pullRequest = parsed.data?.repository?.pullRequest;
+        nodes.push(...(pullRequest?.reviews?.nodes ?? []));
+        if (!headCommittedAt) {
+          headCommittedAt = String(
+            pullRequest?.commits?.nodes?.[0]?.commit?.committedDate ?? '',
+          );
+        }
+        const pageInfo = pullRequest?.reviews?.pageInfo;
+        if (!pageInfo?.hasNextPage) {
+          break;
+        }
+        if (!pageInfo.endCursor) {
+          throw new Error(
+            `getChangeRequestReviewsWithHeadCommitDate: review page reported hasNextPage without endCursor for PR #${number}`,
+          );
+        }
+        cursor = pageInfo.endCursor;
+      }
+      return {
+        reviews: nodes.map((node) => ({
+          id: String(node.id ?? ''),
+          authorLogin: String(node.author?.login ?? ''),
+          authorTypename:
+            node.author?.__typename == null
+              ? null
+              : String(node.author.__typename),
+          submittedAt:
+            node.submittedAt == null ? null : String(node.submittedAt),
+          commitId: node.commit?.oid == null ? null : String(node.commit.oid),
+          commentCount:
+            typeof node.comments?.totalCount === 'number'
+              ? node.comments.totalCount
+              : null,
+          body: node.body == null ? null : String(node.body),
+        })),
+        headCommittedAt,
+      };
     },
 
     mergeChangeRequest(number: number, headSha: string): string {

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -1959,15 +1959,12 @@ export function createGithubProviderAdapter(
     },
 
     getRepositoryRulesetDetail(
-      rulesetOwner: string,
-      rulesetRepo: string,
-      rulesetId: number | string,
+      path: string,
     ): ProviderGovernanceReadOutcome<unknown> {
       return fetchGovernanceOutcome(() =>
-        deps.ghApiJson(
-          `repos/${rulesetOwner}/${rulesetRepo}/rulesets/${rulesetId}`,
-          { extraArgs: ['-H', 'Accept: application/vnd.github+json'] },
-        ),
+        deps.ghApiJson(path, {
+          extraArgs: ['-H', 'Accept: application/vnd.github+json'],
+        }),
       );
     },
 

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -108,6 +108,29 @@ function toProviderError(error: unknown): Error & ProviderError {
   return wrapped;
 }
 
+/**
+ * #2267: throw when a GraphQL response carries top-level `errors`, so a bad
+ * PR/repo/auth or any server-side GraphQL failure fails fast with a clear
+ * message instead of being silently read as an empty result -- ported
+ * verbatim from `resolve-review-thread.mts`'s pre-migration
+ * `assertNoGraphqlErrors` (its own review-thread queries relied on this;
+ * every other GraphQL-backed port method here shares the same choke point
+ * now via {@link fetchReviewThreadsGeneric}'s `runQuery`).
+ */
+function assertNoGraphqlErrors(payload: unknown, context: string): void {
+  const errors = (payload as { errors?: { message?: unknown }[] } | null)
+    ?.errors;
+  if (Array.isArray(errors) && errors.length > 0) {
+    throw new Error(
+      `${context} failed: ${errors
+        .map((entry) => String(entry.message ?? ''))
+        .filter(Boolean)
+        .join('; ')
+        .slice(0, 200)}`,
+    );
+  }
+}
+
 /** #2267: {@link GithubProviderAdapterDeps.ghText}, swallowing any failure
  * and returning `''` instead -- the injectable-`deps` equivalent of
  * `gh-exec.mts`'s own module-level `safeGhText`, needed here so a unit test
@@ -226,7 +249,9 @@ function fetchReviewThreadsGeneric(
   }
 }`;
   function runQuery(apiArgs: string[]): unknown {
-    return JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+    const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+    assertNoGraphqlErrors(parsed, 'review thread lookup');
+    return parsed;
   }
   function walkThreadComments(
     threadId: string,
@@ -2313,7 +2338,9 @@ export function createGithubProviderAdapter(
         '-f',
         `threadId=${threadId}`,
       ];
-      const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS)) as {
+      const raw = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+      assertNoGraphqlErrors(raw, 'resolveReviewThread');
+      const parsed = raw as {
         data?: { resolveReviewThread?: { thread?: { isResolved?: unknown } } };
       };
       if (parsed.data?.resolveReviewThread?.thread?.isResolved !== true) {

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -10,6 +10,7 @@
 // built from. `gh` invocation is an implementation detail of this module;
 // domain helpers never see it.
 
+import type { GhTextOptions } from './gh-exec.mts';
 import {
   GH_TEXT_LOOP_OPTIONS,
   GH_TEXT_LOOP_TIMEOUT_OPTIONS,
@@ -17,6 +18,7 @@ import {
   resolveViewerLogin as ghExecResolveViewerLogin,
   ghText,
   ghTextAsync,
+  readGithubRepoDefaultBranch,
   withBoundedRetry,
 } from './gh-exec.mts';
 import { deriveGhHttpStatus } from './gh-http-status.mts';
@@ -26,15 +28,27 @@ import type {
   ProviderRepositoryLocator,
 } from './provider-contract.mts';
 import type {
+  ProviderChangeRequestBranchAndChecks,
+  ProviderChangeRequestConvergenceView,
+  ProviderChangeRequestHeadShaAndAuthor,
+  ProviderChangeRequestReadinessSnapshot,
   ProviderChangeRequestState,
   ProviderChangeRequestSummary,
   ProviderClosingPullRequestsPage,
   ProviderCollaboratorPermissionResult,
   ProviderComment,
   ProviderConnectedPrEvent,
+  ProviderGovernanceReadOutcome,
+  ProviderGraphqlComment,
+  ProviderGraphqlReview,
+  ProviderMergedChangeRequestMeta,
+  ProviderMergedChangeRequestSummary,
   ProviderPort,
   ProviderPostedComment,
   ProviderRequiredCheck,
+  ProviderReviewThreadCommentIds,
+  ProviderReviewThreadExtended,
+  ProviderReviewThreadWithComments,
   ProviderTimelineEvent,
   ProviderTraversalIssueLookup,
   ProviderWorkItem,
@@ -89,6 +103,231 @@ function toProviderError(error: unknown): Error & ProviderError {
   wrapped.category = statusToCategory(status);
   wrapped.cause = error;
   return wrapped;
+}
+
+/** #2267: {@link GithubProviderAdapterDeps.ghText}, swallowing any failure
+ * and returning `''` instead -- the injectable-`deps` equivalent of
+ * `gh-exec.mts`'s own module-level `safeGhText`, needed here so a unit test
+ * can still assert the exact command shape of a never-throw method without
+ * spawning a real `gh` process. */
+function safeGhTextLocal(
+  deps: GithubProviderAdapterDeps,
+  args: string[],
+  options: GhTextOptions = {},
+): string {
+  try {
+    return deps.ghText(args, options);
+  } catch {
+    return '';
+  }
+}
+
+/** #2267: run a governance-style read (branch rules, branch protection,
+ * ruleset detail), discriminating a masked `404` (see
+ * {@link ProviderGovernanceReadOutcome}'s doc comment) from a real value.
+ * Any non-404 failure rethrows unchanged. */
+function fetchGovernanceOutcome<T>(
+  fetchJson: () => T,
+): ProviderGovernanceReadOutcome<T> {
+  try {
+    return { outcome: 'ok', value: fetchJson() };
+  } catch (error) {
+    if (deriveGhHttpStatus(error) === 404) {
+      return { outcome: 'not-found' };
+    }
+    throw error;
+  }
+}
+
+/** Raw GraphQL review-thread comment node, as returned regardless of which
+ * optional fields (`url`, `pullRequestReview`) the caller's fragment
+ * requested. */
+interface RawThreadCommentNode {
+  body?: unknown;
+  url?: unknown;
+  createdAt?: unknown;
+  updatedAt?: unknown;
+  author?: { login?: unknown } | null;
+  pullRequestReview?: { id?: unknown } | null;
+  databaseId?: unknown;
+}
+
+/** Raw GraphQL review-thread node, as {@link fetchReviewThreadsGeneric}
+ * returns it -- always carries `id` (needed for per-thread comment-page
+ * continuation) regardless of whether the caller's own return shape
+ * exposes it. */
+interface RawThreadNode {
+  id: string;
+  isResolved: boolean | null;
+  path: string | null;
+  comments: RawThreadCommentNode[];
+}
+
+interface RawPageInfo {
+  hasNextPage?: boolean;
+  endCursor?: string | null;
+}
+
+/**
+ * #2267: shared full-walk pagination for the three distinct
+ * `reviewThreads` queries this migration needs
+ * ({@link ProviderPort.listChangeRequestReviewThreadsWithComments},
+ * {@link ProviderPort.listChangeRequestReviewThreadsExtended},
+ * {@link ProviderPort.listChangeRequestReviewThreadCommentIds}) --
+ * `commentFieldsFragment` selects each method's own distinct comment field
+ * set (see each port method's doc comment for why they stay separate
+ * types); this helper only shares the two-level pagination walk (outer
+ * `reviewThreads` cursor, inner per-thread `comments` cursor via a
+ * `node(id)` continuation query), which is identical machinery across all
+ * three. Always requests the thread `id` internally (continuation needs
+ * it) even for a caller whose own return shape omits it. Throws on a page
+ * that reports `hasNextPage` without an `endCursor`, at either level --
+ * preserves `resolve-review-thread.mts`'s and
+ * `pre-merge-readiness.mts`'s existing fail-fast-on-malformed-page
+ * behavior (a malformed payload would otherwise silently undercount
+ * threads or comments).
+ */
+function fetchReviewThreadsGeneric(
+  deps: GithubProviderAdapterDeps,
+  owner: string,
+  repo: string,
+  number: number,
+  commentFieldsFragment: string,
+): RawThreadNode[] {
+  const outerQuery = `query($owner:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){
+      reviewThreads(first:100,after:$cursor){
+        nodes {
+          id
+          isResolved
+          path
+          comments(first:100) {
+            nodes { ${commentFieldsFragment} }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`;
+  const continuationQuery = `query($id:ID!,$cursor:String){
+  node(id:$id){
+    ... on PullRequestReviewThread{
+      comments(first:100,after:$cursor){
+        nodes { ${commentFieldsFragment} }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`;
+  function runQuery(apiArgs: string[]): unknown {
+    return JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+  }
+  function walkThreadComments(
+    threadId: string,
+    firstPageNodes: RawThreadCommentNode[],
+    firstPageInfo: RawPageInfo | undefined,
+  ): RawThreadCommentNode[] {
+    const comments = [...firstPageNodes];
+    let pageInfo = firstPageInfo;
+    while (pageInfo?.hasNextPage) {
+      if (!pageInfo.endCursor) {
+        throw new Error(
+          `fetchReviewThreadsGeneric: comment page reported hasNextPage without endCursor for thread ${threadId}`,
+        );
+      }
+      const parsed = runQuery([
+        'api',
+        'graphql',
+        '-f',
+        `query=${continuationQuery}`,
+        '-f',
+        `id=${threadId}`,
+        '-f',
+        `cursor=${pageInfo.endCursor}`,
+      ]) as {
+        data?: {
+          node?: {
+            comments?: {
+              nodes?: RawThreadCommentNode[];
+              pageInfo?: RawPageInfo;
+            } | null;
+          } | null;
+        };
+      };
+      const nextComments = parsed.data?.node?.comments;
+      comments.push(...(nextComments?.nodes ?? []));
+      pageInfo = nextComments?.pageInfo;
+    }
+    return comments;
+  }
+  const threads: RawThreadNode[] = [];
+  let cursor: string | null = null;
+  while (true) {
+    const apiArgs = [
+      'api',
+      'graphql',
+      '-f',
+      `query=${outerQuery}`,
+      '-f',
+      `owner=${owner}`,
+      '-f',
+      `repo=${repo}`,
+      '-F',
+      `number=${number}`,
+    ];
+    if (cursor) {
+      apiArgs.push('-f', `cursor=${cursor}`);
+    }
+    const parsed = runQuery(apiArgs) as {
+      data?: {
+        repository?: {
+          pullRequest?: {
+            reviewThreads?: {
+              nodes?: {
+                id?: unknown;
+                isResolved?: unknown;
+                path?: unknown;
+                comments?: {
+                  nodes?: RawThreadCommentNode[];
+                  pageInfo?: RawPageInfo;
+                } | null;
+              }[];
+              pageInfo?: RawPageInfo;
+            } | null;
+          } | null;
+        } | null;
+      };
+    };
+    const connection = parsed.data?.repository?.pullRequest?.reviewThreads;
+    for (const node of connection?.nodes ?? []) {
+      const threadId = String(node.id ?? '');
+      threads.push({
+        id: threadId,
+        isResolved:
+          typeof node.isResolved === 'boolean' ? node.isResolved : null,
+        path: node.path == null ? null : String(node.path),
+        comments: walkThreadComments(
+          threadId,
+          node.comments?.nodes ?? [],
+          node.comments?.pageInfo,
+        ),
+      });
+    }
+    const pageInfo = connection?.pageInfo;
+    if (!pageInfo?.hasNextPage) {
+      break;
+    }
+    if (!pageInfo.endCursor) {
+      throw new Error(
+        `fetchReviewThreadsGeneric: thread page reported hasNextPage without endCursor for PR #${number}`,
+      );
+    }
+    cursor = pageInfo.endCursor;
+  }
+  return threads;
 }
 
 // The traversal-only helpers below (through wrapTraversalGhFailure) back
@@ -1019,6 +1258,878 @@ export function createGithubProviderAdapter(
       const raw = deps.ghText(args, GH_TEXT_LOOP_OPTIONS).trim();
       const parsed = raw && raw !== 'null' ? JSON.parse(raw) : [];
       return Array.isArray(parsed) ? parsed : [];
+    },
+
+    // --- #2267 additions below. -------------------------------------------
+
+    getRepositoryDefaultBranch(
+      defaultBranchOwner: string,
+      defaultBranchRepo: string,
+    ): string | null {
+      return readGithubRepoDefaultBranch(defaultBranchOwner, defaultBranchRepo);
+    },
+
+    resolveViewerAppSlugSafe(): { appSlug: string; unavailable: boolean } {
+      const raw = safeGhTextLocal(
+        deps,
+        ['api', 'app', '--jq', '.slug // .app_slug // empty'],
+        GH_TEXT_LOOP_OPTIONS,
+      ).trim();
+      return raw
+        ? { appSlug: raw, unavailable: false }
+        : { appSlug: '', unavailable: true };
+    },
+
+    resolveViewerLoginSafeQuiet(): {
+      viewerLogin: string;
+      viewerLoginUnavailable: boolean;
+    } {
+      // #2267: mirrors resolveViewerLoginSafe's query/never-throw contract,
+      // but with advisory-convergence.mts's own env-conditional stdio (CI
+      // stays silent/piped; a local run's stderr stays visible to the
+      // operator watching it) -- see this method's doc comment in
+      // provider-port.mts for why it is not folded into the existing one.
+      const stdio: GhTextOptions['stdio'] = process.env.GITHUB_ACTIONS
+        ? ['ignore', 'pipe', 'pipe']
+        : ['ignore', 'pipe', 'inherit'];
+      try {
+        const raw = deps.ghText(['api', 'user', '--jq', '.login'], { stdio });
+        const normalized = raw.trim().toLowerCase();
+        if (!normalized) {
+          return { viewerLogin: '', viewerLoginUnavailable: true };
+        }
+        return { viewerLogin: normalized, viewerLoginUnavailable: false };
+      } catch {
+        return { viewerLogin: '', viewerLoginUnavailable: true };
+      }
+    },
+
+    getRepositoryContentAtRef(
+      contentOwner: string,
+      contentRepo: string,
+      path: string,
+      ref: string,
+    ): unknown | null {
+      try {
+        return deps.ghApiJson(
+          `repos/${contentOwner}/${contentRepo}/contents/${path}?ref=${encodeURIComponent(ref)}`,
+        );
+      } catch (error) {
+        if (deriveGhHttpStatus(error) === 404) {
+          return null;
+        }
+        throw error;
+      }
+    },
+
+    getRepositoryFileContentAtRef(
+      repoRef: string,
+      path: string,
+      ref: string,
+    ): ProviderGovernanceReadOutcome<string> {
+      try {
+        const content = deps.ghText([
+          'api',
+          `repos/${repoRef}/contents/${path}`,
+          '--method',
+          'GET',
+          '--field',
+          `ref=${ref}`,
+          '--jq',
+          '.content',
+        ]);
+        return { outcome: 'ok', value: content };
+      } catch (error) {
+        if (deriveGhHttpStatus(error) === 404) {
+          return { outcome: 'not-found' };
+        }
+        throw error;
+      }
+    },
+
+    getTeamMembershipStateSafe(
+      org: string,
+      teamSlug: string,
+      login: string,
+    ): string {
+      return safeGhTextLocal(
+        deps,
+        [
+          'api',
+          `orgs/${org}/teams/${teamSlug}/memberships/${encodeURIComponent(login)}`,
+          '--jq',
+          '.state',
+        ],
+        GH_TEXT_LOOP_OPTIONS,
+      ).trim();
+    },
+
+    getChangeRequestHeadShaAndAuthor(
+      number: number,
+    ): ProviderChangeRequestHeadShaAndAuthor {
+      const raw = deps.ghText([
+        'pr',
+        'view',
+        String(number),
+        '-R',
+        `${owner}/${repo}`,
+        '--json',
+        'headRefOid,author',
+      ]);
+      const parsed = JSON.parse(raw) as {
+        headRefOid?: unknown;
+        author?: { login?: unknown } | null;
+      };
+      return {
+        headSha: String(parsed.headRefOid ?? ''),
+        authorLogin: String(parsed.author?.login ?? ''),
+      };
+    },
+
+    getChangeRequestConvergenceView(
+      number: number,
+    ): ProviderChangeRequestConvergenceView {
+      const raw = deps.ghText([
+        'pr',
+        'view',
+        String(number),
+        '-R',
+        `${owner}/${repo}`,
+        '--json',
+        'headRefOid,headRefName,closingIssuesReferences,author,url',
+      ]);
+      const parsed = JSON.parse(raw) as {
+        headRefOid?: unknown;
+        headRefName?: unknown;
+        author?: { login?: unknown } | null;
+        url?: unknown;
+        closingIssuesReferences?: unknown;
+      };
+      return {
+        headSha: String(parsed.headRefOid ?? ''),
+        headRefName: String(parsed.headRefName ?? ''),
+        authorLogin: String(parsed.author?.login ?? ''),
+        url: String(parsed.url ?? ''),
+        closingIssuesReferences: parsed.closingIssuesReferences,
+      };
+    },
+
+    getChangeRequestReadinessSnapshot(
+      number: number,
+    ): ProviderChangeRequestReadinessSnapshot {
+      const raw = deps.ghText([
+        'pr',
+        'view',
+        String(number),
+        '-R',
+        `${owner}/${repo}`,
+        '--json',
+        'headRefOid,baseRefName,url,author,reviewDecision,statusCheckRollup,mergeable,mergeStateStatus,closingIssuesReferences',
+      ]);
+      const parsed = JSON.parse(raw) as {
+        headRefOid?: unknown;
+        baseRefName?: unknown;
+        url?: unknown;
+        author?: { login?: unknown } | null;
+        reviewDecision?: unknown;
+        statusCheckRollup?: unknown;
+        mergeable?: unknown;
+        mergeStateStatus?: unknown;
+        closingIssuesReferences?: unknown;
+      };
+      return {
+        headSha: String(parsed.headRefOid ?? ''),
+        baseRefName: String(parsed.baseRefName ?? ''),
+        url: String(parsed.url ?? ''),
+        authorLogin: String(parsed.author?.login ?? ''),
+        reviewDecision:
+          parsed.reviewDecision == null ? null : String(parsed.reviewDecision),
+        statusCheckRollup: parsed.statusCheckRollup,
+        mergeable: String(parsed.mergeable ?? ''),
+        mergeStateStatus: String(parsed.mergeStateStatus ?? ''),
+        closingIssuesReferences: parsed.closingIssuesReferences,
+      };
+    },
+
+    getChangeRequestBranchAndChecks(
+      number: number,
+    ): ProviderChangeRequestBranchAndChecks {
+      const raw = deps.ghText([
+        'pr',
+        'view',
+        String(number),
+        '-R',
+        `${owner}/${repo}`,
+        '--json',
+        'headRefOid,baseRefName,statusCheckRollup',
+      ]);
+      const parsed = JSON.parse(raw) as {
+        headRefOid?: unknown;
+        baseRefName?: unknown;
+        statusCheckRollup?: unknown;
+      };
+      return {
+        headSha: String(parsed.headRefOid ?? ''),
+        baseRefName: String(parsed.baseRefName ?? ''),
+        statusCheckRollup: parsed.statusCheckRollup,
+      };
+    },
+
+    getChangeRequestHeadRef(number: number): string {
+      return deps.ghText([
+        'api',
+        `${repoPath}/pulls/${number}`,
+        '--jq',
+        '.head.ref',
+      ]);
+    },
+
+    listMergedChangeRequests(
+      limit: number,
+      sinceDate: string | null,
+    ): ProviderMergedChangeRequestSummary[] {
+      const args = [
+        'pr',
+        'list',
+        '-R',
+        `${owner}/${repo}`,
+        '--state',
+        'merged',
+        '--limit',
+        String(limit),
+        '--json',
+        'number,mergedAt',
+      ];
+      if (sinceDate) {
+        args.push('--search', `merged:>=${sinceDate}`);
+      }
+      const raw = deps.ghText(args, GH_TEXT_LOOP_OPTIONS);
+      const rows = JSON.parse(raw || '[]') as {
+        number?: unknown;
+        mergedAt?: unknown;
+      }[];
+      return rows.map((row) => ({
+        number: Number(row.number),
+        mergedAt: String(row.mergedAt ?? ''),
+      }));
+    },
+
+    getMergedChangeRequestMeta(
+      number: number,
+    ): ProviderMergedChangeRequestMeta | null {
+      const query = `query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){ number merged mergedAt mergeCommit{oid} }
+  }
+}`;
+      const apiArgs = [
+        'api',
+        'graphql',
+        '-f',
+        `query=${query}`,
+        '-f',
+        `owner=${owner}`,
+        '-f',
+        `repo=${repo}`,
+        '-F',
+        `number=${number}`,
+      ];
+      const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS)) as {
+        data?: {
+          repository?: {
+            pullRequest?: {
+              number?: unknown;
+              merged?: unknown;
+              mergedAt?: unknown;
+              mergeCommit?: { oid?: unknown } | null;
+            } | null;
+          } | null;
+        };
+      };
+      const pr = parsed.data?.repository?.pullRequest;
+      if (pr?.merged !== true) {
+        return null;
+      }
+      return {
+        number: Number(pr.number ?? number),
+        merged: true,
+        mergedAt: pr.mergedAt == null ? null : String(pr.mergedAt),
+        mergeCommitOid:
+          pr.mergeCommit?.oid == null ? null : String(pr.mergeCommit.oid),
+      };
+    },
+
+    listChangeRequestChecks(number: number): ProviderRequiredCheck[] {
+      const args = [
+        'pr',
+        'checks',
+        String(number),
+        '--repo',
+        `${owner}/${repo}`,
+        '--json',
+        'name,state,completedAt',
+      ];
+      let raw: string;
+      try {
+        raw = deps.ghText(args, GH_TEXT_LOOP_OPTIONS);
+      } catch (error) {
+        const stderr = String(
+          (error as { stderr?: unknown } | null)?.stderr ?? '',
+        );
+        if (/no checks reported/i.test(stderr)) {
+          return [];
+        }
+        const stdout = String(
+          (error as { stdout?: unknown } | null)?.stdout ?? '',
+        ).trim();
+        if (!stdout) {
+          throw error;
+        }
+        raw = stdout;
+      }
+      const rows = JSON.parse(raw || '[]') as {
+        name?: unknown;
+        state?: unknown;
+        completedAt?: unknown;
+      }[];
+      return rows.map((row) => ({
+        name: String(row.name ?? ''),
+        state: String(row.state ?? ''),
+        completedAt: row.completedAt ? String(row.completedAt) : null,
+      }));
+    },
+
+    getChangeRequestRequestedReviewerLogins(number: number): string[] {
+      const result = deps.ghApiJson(
+        `${repoPath}/pulls/${number}/requested_reviewers`,
+      ) as { users?: { login?: unknown }[] };
+      return (result.users ?? []).map((user) => String(user.login ?? ''));
+    },
+
+    getChangeRequestRequestedReviewerLoginsGraphql(
+      number: number,
+    ): string[] | null {
+      try {
+        const query = `query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){
+      reviewRequests(first:100){
+        nodes { requestedReviewer { ...on Bot{login} ...on User{login} ...on Mannequin{login} } }
+      }
+    }
+  }
+}`;
+        const apiArgs = [
+          'api',
+          'graphql',
+          '-f',
+          `query=${query}`,
+          '-f',
+          `owner=${owner}`,
+          '-f',
+          `repo=${repo}`,
+          '-F',
+          `number=${number}`,
+        ];
+        const parsed = JSON.parse(
+          deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS),
+        ) as {
+          data?: {
+            repository?: {
+              pullRequest?: {
+                reviewRequests?: {
+                  nodes?: { requestedReviewer?: { login?: unknown } | null }[];
+                } | null;
+              } | null;
+            } | null;
+          };
+        };
+        const nodes =
+          parsed.data?.repository?.pullRequest?.reviewRequests?.nodes ?? [];
+        return nodes
+          .map((node) => node.requestedReviewer?.login)
+          .filter((login): login is string => typeof login === 'string');
+      } catch {
+        return null;
+      }
+    },
+
+    listChangeRequestChangedFiles(number: number): string[] {
+      const rows = deps.ghApiJson(`${repoPath}/pulls/${number}/files`, {
+        paginate: true,
+      }) as { filename?: unknown }[];
+      return rows.map((row) => String(row.filename ?? ''));
+    },
+
+    listChangeRequestCommits(number: number): unknown[] {
+      return deps.ghApiJson(`${repoPath}/pulls/${number}/commits`, {
+        paginate: true,
+      }) as unknown[];
+    },
+
+    listChangeRequestReviewThreadsWithComments(
+      number: number,
+    ): ProviderReviewThreadWithComments[] {
+      const nodes = fetchReviewThreadsGeneric(
+        deps,
+        owner,
+        repo,
+        number,
+        'body createdAt updatedAt author { login } pullRequestReview { id }',
+      );
+      return nodes.map((node) => ({
+        isResolved: node.isResolved,
+        comments: node.comments.map((comment) => ({
+          body: String(comment.body ?? ''),
+          createdAt: String(comment.createdAt ?? ''),
+          updatedAt: String(comment.updatedAt ?? ''),
+          authorLogin: String(comment.author?.login ?? ''),
+          pullRequestReviewId:
+            comment.pullRequestReview?.id == null
+              ? null
+              : String(comment.pullRequestReview.id),
+        })),
+      }));
+    },
+
+    listChangeRequestReviewThreadsExtended(
+      number: number,
+    ): ProviderReviewThreadExtended[] {
+      const nodes = fetchReviewThreadsGeneric(
+        deps,
+        owner,
+        repo,
+        number,
+        'body url createdAt updatedAt author { login }',
+      );
+      return nodes.map((node) => ({
+        isResolved: node.isResolved,
+        path: node.path,
+        comments: node.comments.map((comment) => ({
+          body: String(comment.body ?? ''),
+          url: comment.url == null ? undefined : String(comment.url),
+          createdAt: String(comment.createdAt ?? ''),
+          updatedAt: String(comment.updatedAt ?? ''),
+          authorLogin: String(comment.author?.login ?? ''),
+        })),
+      }));
+    },
+
+    listChangeRequestReviewThreadCommentIds(
+      number: number,
+    ): ProviderReviewThreadCommentIds[] {
+      const nodes = fetchReviewThreadsGeneric(
+        deps,
+        owner,
+        repo,
+        number,
+        'databaseId',
+      );
+      return nodes.map((node) => ({
+        threadId: node.id,
+        isResolved: node.isResolved,
+        commentDatabaseIds: node.comments
+          .map((comment) => comment.databaseId)
+          .filter((id): id is number => typeof id === 'number'),
+      }));
+    },
+
+    listChangeRequestGraphqlComments(number: number): ProviderGraphqlComment[] {
+      const query = `query($owner:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){
+      comments(first:100,after:$cursor){
+        nodes { body url createdAt updatedAt author { login } }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`;
+      const out: ProviderGraphqlComment[] = [];
+      let cursor: string | null = null;
+      while (true) {
+        const apiArgs = [
+          'api',
+          'graphql',
+          '-f',
+          `query=${query}`,
+          '-f',
+          `owner=${owner}`,
+          '-f',
+          `repo=${repo}`,
+          '-F',
+          `number=${number}`,
+        ];
+        if (cursor) {
+          apiArgs.push('-f', `cursor=${cursor}`);
+        }
+        const parsed = JSON.parse(
+          deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS),
+        ) as {
+          data?: {
+            repository?: {
+              pullRequest?: {
+                comments?: {
+                  nodes?: {
+                    body?: unknown;
+                    url?: unknown;
+                    createdAt?: unknown;
+                    updatedAt?: unknown;
+                    author?: { login?: unknown } | null;
+                  }[];
+                  pageInfo?: {
+                    hasNextPage?: boolean;
+                    endCursor?: string | null;
+                  };
+                } | null;
+              } | null;
+            } | null;
+          };
+        };
+        const connection = parsed.data?.repository?.pullRequest?.comments;
+        for (const node of connection?.nodes ?? []) {
+          out.push({
+            body: String(node.body ?? ''),
+            url: String(node.url ?? ''),
+            createdAt: String(node.createdAt ?? ''),
+            updatedAt: String(node.updatedAt ?? ''),
+            authorLogin: String(node.author?.login ?? ''),
+          });
+        }
+        const pageInfo = connection?.pageInfo;
+        if (!pageInfo?.hasNextPage) {
+          break;
+        }
+        if (!pageInfo.endCursor) {
+          throw new Error(
+            `listChangeRequestGraphqlComments: page reported hasNextPage without endCursor for PR #${number}`,
+          );
+        }
+        cursor = pageInfo.endCursor;
+      }
+      return out;
+    },
+
+    listChangeRequestGraphqlReviews(number: number): ProviderGraphqlReview[] {
+      const query = `query($owner:String!,$repo:String!,$number:Int!,$cursor:String){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){
+      reviews(first:100,after:$cursor){
+        nodes { body url state submittedAt author { login } }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}`;
+      const out: ProviderGraphqlReview[] = [];
+      let cursor: string | null = null;
+      while (true) {
+        const apiArgs = [
+          'api',
+          'graphql',
+          '-f',
+          `query=${query}`,
+          '-f',
+          `owner=${owner}`,
+          '-f',
+          `repo=${repo}`,
+          '-F',
+          `number=${number}`,
+        ];
+        if (cursor) {
+          apiArgs.push('-f', `cursor=${cursor}`);
+        }
+        const parsed = JSON.parse(
+          deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS),
+        ) as {
+          data?: {
+            repository?: {
+              pullRequest?: {
+                reviews?: {
+                  nodes?: {
+                    body?: unknown;
+                    url?: unknown;
+                    state?: unknown;
+                    submittedAt?: unknown;
+                    author?: { login?: unknown } | null;
+                  }[];
+                  pageInfo?: {
+                    hasNextPage?: boolean;
+                    endCursor?: string | null;
+                  };
+                } | null;
+              } | null;
+            } | null;
+          };
+        };
+        const connection = parsed.data?.repository?.pullRequest?.reviews;
+        for (const node of connection?.nodes ?? []) {
+          out.push({
+            body: String(node.body ?? ''),
+            url: String(node.url ?? ''),
+            state: String(node.state ?? ''),
+            submittedAt:
+              node.submittedAt == null ? null : String(node.submittedAt),
+            authorLogin: String(node.author?.login ?? ''),
+          });
+        }
+        const pageInfo = connection?.pageInfo;
+        if (!pageInfo?.hasNextPage) {
+          break;
+        }
+        if (!pageInfo.endCursor) {
+          throw new Error(
+            `listChangeRequestGraphqlReviews: page reported hasNextPage without endCursor for PR #${number}`,
+          );
+        }
+        cursor = pageInfo.endCursor;
+      }
+      return out;
+    },
+
+    listBranchRules(
+      rulesOwner: string,
+      rulesRepo: string,
+      ref: string,
+    ): ProviderGovernanceReadOutcome<unknown[]> {
+      return fetchGovernanceOutcome(
+        () =>
+          deps.ghApiJson(
+            `repos/${rulesOwner}/${rulesRepo}/rules/branches/${encodeURIComponent(ref)}`,
+            { paginate: true },
+          ) as unknown[],
+      );
+    },
+
+    getBranchProtection(
+      protectionOwner: string,
+      protectionRepo: string,
+      ref: string,
+    ): ProviderGovernanceReadOutcome<unknown> {
+      return fetchGovernanceOutcome(() =>
+        deps.ghApiJson(
+          `repos/${protectionOwner}/${protectionRepo}/branches/${encodeURIComponent(ref)}/protection`,
+        ),
+      );
+    },
+
+    getRepositoryRulesetDetail(
+      rulesetOwner: string,
+      rulesetRepo: string,
+      rulesetId: number | string,
+    ): ProviderGovernanceReadOutcome<unknown> {
+      return fetchGovernanceOutcome(() =>
+        deps.ghApiJson(
+          `repos/${rulesetOwner}/${rulesetRepo}/rulesets/${rulesetId}`,
+          { extraArgs: ['-H', 'Accept: application/vnd.github+json'] },
+        ),
+      );
+    },
+
+    getWorkflowRun(runOwner: string, runRepo: string, runId: number): unknown {
+      const raw = deps.ghText(
+        ['api', `repos/${runOwner}/${runRepo}/actions/runs/${runId}`],
+        GH_TEXT_LOOP_TIMEOUT_OPTIONS,
+      );
+      return JSON.parse(raw.trim() || '{}');
+    },
+
+    listWorkflowRuns(
+      runsOwner: string,
+      runsRepo: string,
+      workflowName: string,
+      limit: number,
+    ): {
+      id: number;
+      conclusion: string | null;
+      status: string;
+      createdAt: string;
+    }[] {
+      const raw = deps.ghText(
+        [
+          'run',
+          'list',
+          '--repo',
+          `${runsOwner}/${runsRepo}`,
+          '--workflow',
+          workflowName,
+          '--limit',
+          String(limit),
+          '--json',
+          'databaseId,conclusion,status,createdAt',
+        ],
+        GH_TEXT_LOOP_OPTIONS,
+      );
+      const rows = JSON.parse(raw || '[]') as {
+        databaseId?: unknown;
+        conclusion?: unknown;
+        status?: unknown;
+        createdAt?: unknown;
+      }[];
+      return rows.map((row) => ({
+        id: Number(row.databaseId),
+        conclusion: row.conclusion == null ? null : String(row.conclusion),
+        status: String(row.status ?? ''),
+        createdAt: String(row.createdAt ?? ''),
+      }));
+    },
+
+    getChangeRequestHeadShaAtRepo(
+      atRepoOwner: string,
+      atRepoRepo: string,
+      number: number,
+    ): string {
+      return deps.ghText([
+        'pr',
+        'view',
+        String(number),
+        '-R',
+        `${atRepoOwner}/${atRepoRepo}`,
+        '--json',
+        'headRefOid',
+        '--jq',
+        '.headRefOid',
+      ]);
+    },
+
+    getChangeRequestAtRepo(
+      atRepoOwner: string,
+      atRepoRepo: string,
+      number: number,
+    ): ProviderChangeRequestState | null {
+      try {
+        const raw = deps.ghText(
+          [
+            'pr',
+            'view',
+            String(number),
+            '-R',
+            `${atRepoOwner}/${atRepoRepo}`,
+            '--json',
+            'mergeable,mergeStateStatus',
+          ],
+          GH_TEXT_LOOP_OPTIONS,
+        );
+        const parsed = JSON.parse(raw) as {
+          mergeable?: unknown;
+          mergeStateStatus?: unknown;
+        };
+        return {
+          mergeable: String(parsed.mergeable ?? ''),
+          mergeStateStatus: String(parsed.mergeStateStatus ?? ''),
+        };
+      } catch (error) {
+        if (deriveGhHttpStatus(error) === 404) {
+          return null;
+        }
+        throw error;
+      }
+    },
+
+    mergeChangeRequestAtRepo(
+      mergeOwner: string,
+      mergeRepo: string,
+      number: number,
+      headSha: string,
+    ): string {
+      return deps.ghText([
+        'pr',
+        'merge',
+        String(number),
+        '-R',
+        `${mergeOwner}/${mergeRepo}`,
+        '--merge',
+        '--match-head-commit',
+        headSha,
+      ]);
+    },
+
+    mergeChangeRequestAdminAtRepo(
+      mergeOwner: string,
+      mergeRepo: string,
+      number: number,
+      headSha: string,
+    ): string {
+      return deps.ghText([
+        'pr',
+        'merge',
+        String(number),
+        '-R',
+        `${mergeOwner}/${mergeRepo}`,
+        '--merge',
+        '--match-head-commit',
+        headSha,
+        '--admin',
+      ]);
+    },
+
+    mergeChangeRequest(number: number, headSha: string): string {
+      return deps.ghText([
+        'pr',
+        'merge',
+        String(number),
+        '-R',
+        `${owner}/${repo}`,
+        '--merge',
+        '--match-head-commit',
+        headSha,
+      ]);
+    },
+
+    mergeChangeRequestAdmin(number: number, headSha: string): string {
+      return deps.ghText([
+        'pr',
+        'merge',
+        String(number),
+        '-R',
+        `${owner}/${repo}`,
+        '--merge',
+        '--match-head-commit',
+        headSha,
+        '--admin',
+      ]);
+    },
+
+    postReviewCommentReply(
+      number: number,
+      commentId: number,
+      body: string,
+    ): { id: number } {
+      const out = deps.ghText(
+        [
+          'api',
+          '--method',
+          'POST',
+          `${repoPath}/pulls/${number}/comments/${commentId}/replies`,
+          '--input',
+          '-',
+        ],
+        { input: JSON.stringify({ body }) },
+      );
+      const parsed = JSON.parse(out) as { id: number };
+      return { id: parsed.id };
+    },
+
+    resolveChangeRequestReviewThread(threadId: string): void {
+      const mutation = `mutation($threadId:ID!){
+  resolveReviewThread(input:{threadId:$threadId}){ thread { isResolved } }
+}`;
+      const apiArgs = [
+        'api',
+        'graphql',
+        '-f',
+        `query=${mutation}`,
+        '-f',
+        `threadId=${threadId}`,
+      ];
+      const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS)) as {
+        data?: { resolveReviewThread?: { thread?: { isResolved?: unknown } } };
+      };
+      if (parsed.data?.resolveReviewThread?.thread?.isResolved !== true) {
+        throw new Error(
+          `resolveChangeRequestReviewThread: GitHub did not confirm thread ${threadId} as resolved`,
+        );
+      }
     },
   };
 }

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -1564,7 +1564,9 @@ export function createGithubProviderAdapter(
         '-F',
         `number=${number}`,
       ];
-      const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS)) as {
+      const raw = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+      assertNoGraphqlErrors(raw, 'getMergedChangeRequestMeta');
+      const parsed = raw as {
         data?: {
           repository?: {
             pullRequest?: {
@@ -1800,9 +1802,11 @@ export function createGithubProviderAdapter(
         if (cursor) {
           apiArgs.push('-f', `cursor=${cursor}`);
         }
-        const parsed = JSON.parse(
+        const rawComments = JSON.parse(
           deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS),
-        ) as {
+        );
+        assertNoGraphqlErrors(rawComments, 'listChangeRequestGraphqlComments');
+        const parsed = rawComments as {
           data?: {
             repository?: {
               pullRequest?: {
@@ -1876,9 +1880,11 @@ export function createGithubProviderAdapter(
         if (cursor) {
           apiArgs.push('-f', `cursor=${cursor}`);
         }
-        const parsed = JSON.parse(
+        const rawReviews = JSON.parse(
           deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS),
-        ) as {
+        );
+        assertNoGraphqlErrors(rawReviews, 'listChangeRequestGraphqlReviews');
+        const parsed = rawReviews as {
           data?: {
             repository?: {
               pullRequest?: {
@@ -2121,7 +2127,9 @@ export function createGithubProviderAdapter(
         '-F',
         `number=${number}`,
       ];
-      const parsed = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS)) as {
+      const rawAuthor = JSON.parse(deps.ghText(apiArgs, GH_TEXT_LOOP_OPTIONS));
+      assertNoGraphqlErrors(rawAuthor, 'getChangeRequestAuthor');
+      const parsed = rawAuthor as {
         data?: {
           repository?: {
             pullRequest?: {

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -804,12 +804,14 @@ export function createGithubProviderAdapter(
         id?: unknown;
         body?: unknown;
         created_at?: unknown;
+        updated_at?: unknown;
         user?: { login?: unknown };
       }[];
       return rows.map((row) => ({
         id: Number(row.id),
         body: String(row.body ?? ''),
         createdAt: String(row.created_at ?? ''),
+        updatedAt: String(row.updated_at ?? row.created_at ?? ''),
         authorLogin: String(row.user?.login ?? ''),
       }));
     },
@@ -1563,6 +1565,16 @@ export function createGithubProviderAdapter(
     },
 
     listChangeRequestChecks(number: number): ProviderRequiredCheck[] {
+      // #2267: matches review-activity-snapshot.mts's pre-migration
+      // `ghJson(..., { allowStatuses: [1, 8] })` exactly -- an exit-code
+      // allowlist requiring stdout to actually look like JSON, not a
+      // stderr-content match. `gh pr checks` (no `--required`) exits 1 or 8
+      // while checks are pending/failing or reporting a mixed state, a
+      // routine outcome for this ALL-checks call -- but an allowed exit
+      // status with genuinely empty/non-JSON stdout (a different failure
+      // wearing the same exit code) still rethrows, unlike
+      // {@link listRequiredChecks}'s stricter `--required` recovery, which
+      // matches on stderr content instead.
       const args = [
         'pr',
         'checks',
@@ -1576,16 +1588,13 @@ export function createGithubProviderAdapter(
       try {
         raw = deps.ghText(args, GH_TEXT_LOOP_OPTIONS);
       } catch (error) {
-        const stderr = String(
-          (error as { stderr?: unknown } | null)?.stderr ?? '',
+        const status = Number(
+          (error as { status?: unknown } | null)?.status ?? -1,
         );
-        if (/no checks reported/i.test(stderr)) {
-          return [];
-        }
         const stdout = String(
           (error as { stdout?: unknown } | null)?.stdout ?? '',
-        ).trim();
-        if (!stdout) {
+        );
+        if (![1, 8].includes(status) || !/^\s*[[{]/.test(stdout)) {
           throw error;
         }
         raw = stdout;

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -1969,7 +1969,11 @@ export function createGithubProviderAdapter(
       );
     },
 
-    getWorkflowRun(runOwner: string, runRepo: string, runId: number): unknown {
+    getWorkflowRun(
+      runOwner: string,
+      runRepo: string,
+      runId: string | number,
+    ): unknown {
       const raw = deps.ghText(
         ['api', `repos/${runOwner}/${runRepo}/actions/runs/${runId}`],
         GH_TEXT_LOOP_TIMEOUT_OPTIONS,

--- a/src/scripts/provider-contract.mts
+++ b/src/scripts/provider-contract.mts
@@ -47,6 +47,14 @@ export const PROVIDER_CAPABILITY_GROUPS = [
   'permissions',
   'branch-protection',
   'merge',
+  /**
+   * #2267: bot/advisory review interpretation (e.g. Copilot's own review
+   * body), distinct from `reviews-and-threads`'s required unresolved-thread
+   * safety gate -- a provider without an equivalent advisory reviewer
+   * resolves this `not_applicable` (optional) while `reviews-and-threads`
+   * stays required.
+   */
+  'advisory-review',
 ] as const;
 
 export type ProviderCapabilityGroup =

--- a/src/scripts/provider-port.mts
+++ b/src/scripts/provider-port.mts
@@ -36,6 +36,7 @@
 // addition -- traversal-only, not a general async surface.
 
 import type {
+  ProviderCapabilityDeclaration,
   ProviderError,
   ProviderRepositoryLocator,
 } from './provider-contract.mts';
@@ -1028,4 +1029,17 @@ export interface ProviderPort {
   /** merge, write. Same as {@link mergeChangeRequest} plus `--admin` --
    * separate method per the port's one-op-per-call-shape rule. */
   mergeChangeRequestAdmin(number: number, headSha: string): string;
+
+  /**
+   * capability declarations. Static list of what this adapter supports per
+   * `provider-contract.mts` capability group -- no network call, no
+   * per-repository variance. A caller feeds each declaration through
+   * {@link evaluateProviderCapabilityOutcome} to decide `ok` / `fail_closed`
+   * / `not_applicable` for that group. The GitHub adapter reports every
+   * group supported; a future non-GitHub adapter without an equivalent
+   * advisory reviewer would report `advisory-review` unsupported so
+   * `advisory-convergence.mts` can resolve it `not_applicable` instead of
+   * fail-closing (#2267 AC4).
+   */
+  listCapabilityDeclarations(): ProviderCapabilityDeclaration[];
 }

--- a/src/scripts/provider-port.mts
+++ b/src/scripts/provider-port.mts
@@ -966,8 +966,14 @@ export interface ProviderPort {
     rulesetId: number | string,
   ): ProviderGovernanceReadOutcome<unknown>;
 
-  /** checks. `actions/runs/{runId}` single-run read, raw passthrough. */
-  getWorkflowRun(owner: string, repo: string, runId: number): unknown;
+  /** checks. `actions/runs/{runId}` single-run read, raw passthrough.
+   * `runId` is `string | number` (not just `number`): a GitHub Actions run
+   * id can exceed `Number.MAX_SAFE_INTEGER`, so a caller holding the id as
+   * a string must be able to pass it through without a lossy `Number()`
+   * round-trip (#2267 regression, caught by
+   * `ci-wait-policy.test.mts`'s "preserves a run id above
+   * Number.MAX_SAFE_INTEGER exactly" case). */
+  getWorkflowRun(owner: string, repo: string, runId: string | number): unknown;
 
   /** checks. `gh run list --workflow {name} --limit N --json
    * databaseId,conclusion,status,createdAt` -- distinct `gh run list`

--- a/src/scripts/provider-port.mts
+++ b/src/scripts/provider-port.mts
@@ -280,6 +280,27 @@ export interface ProviderGraphqlReview {
   authorLogin: string;
 }
 
+/** One review node as {@link ProviderPort.getChangeRequestReviewsWithHeadCommitDate}
+ * returns it -- distinct field set from {@link ProviderGraphqlReview} (no
+ * `url`/`state`; adds the review's own node `id`, `authorTypename`, and
+ * `commentCount`), matching `review-clause.mts`'s own Clause-1 evidence
+ * shape. */
+export interface ProviderReviewClauseNode {
+  id: string;
+  authorLogin: string;
+  authorTypename: string | null;
+  submittedAt: string | null;
+  commitId: string | null;
+  commentCount: number | null;
+  body: string | null;
+}
+
+/** Backs {@link ProviderPort.getChangeRequestReviewsWithHeadCommitDate}. */
+export interface ProviderReviewsWithHeadCommitDate {
+  reviews: ProviderReviewClauseNode[];
+  headCommittedAt: string;
+}
+
 /**
  * Provider port: the operation surface `discover-*.mts`, `claim-approval-
  * gate.mts`, `post-idd-marker.mts`, `resume-claim-routing.mts`,
@@ -927,6 +948,19 @@ export interface ProviderPort {
     status: string;
     createdAt: string;
   }[];
+
+  /**
+   * reviews-and-threads. Paginated GraphQL `reviews(first:100)` plus a
+   * once-per-call `commits(last:1){nodes{commit{committedDate}}}` sibling
+   * field -- `review-clause.mts`'s own distinct query (shared by
+   * `advisory-convergence.mts`, `pre-merge-readiness.mts`, and the
+   * out-of-scope `rerun-advisory-convergence.mts` today), not unifiable
+   * with {@link listChangeRequestGraphqlReviews} (different field set, no
+   * head-commit-date sibling).
+   */
+  getChangeRequestReviewsWithHeadCommitDate(
+    number: number,
+  ): ProviderReviewsWithHeadCommitDate;
 
   /** merge, write. `pr merge --merge --match-head-commit {headSha}` on the
    * port's own ambient repo. */

--- a/src/scripts/provider-port.mts
+++ b/src/scripts/provider-port.mts
@@ -957,14 +957,18 @@ export interface ProviderPort {
   ): ProviderGovernanceReadOutcome<unknown>;
 
   /**
-   * branch-protection. `repos/rulesets/{rulesetId}` detail read -- GitHub's
-   * reference documents only 200/404/500 for this endpoint (no 403), the
-   * same masked-404 posture as {@link listBranchRules}.
+   * branch-protection. Ruleset detail read at an ALREADY-RESOLVED absolute
+   * API path (`repos/{owner}/{repo}/rulesets/{id}`, `orgs/{org}/rulesets/{id}`,
+   * or `enterprises/{enterprise}/rulesets/{id}`) -- `pre-merge-readiness.mts`'s
+   * `fetchBranchRulesets` resolves which scope applies itself (via
+   * `resolveRulesetDetailPath`, protocol-helpers.mts) before fetching, so
+   * this method takes the resolved path rather than an owner/repo/id triple
+   * it would have to re-derive scope from. GitHub's reference documents only
+   * 200/404/500 for this endpoint (no 403), the same masked-404 posture as
+   * {@link listBranchRules}.
    */
   getRepositoryRulesetDetail(
-    owner: string,
-    repo: string,
-    rulesetId: number | string,
+    path: string,
   ): ProviderGovernanceReadOutcome<unknown>;
 
   /** checks. `actions/runs/{runId}` single-run read, raw passthrough.

--- a/src/scripts/provider-port.mts
+++ b/src/scripts/provider-port.mts
@@ -145,6 +145,141 @@ export interface ProviderRequiredCheck {
   completedAt: string | null;
 }
 
+// --- #2267: change-request/review/check/merge extension. -----------------
+//
+// The types and methods below extend this same surface for the broader
+// migration named in #2267's own doc comment on `ProviderPort` above. Each
+// method exists for one call shape already live in one of the nine named
+// PR-facing helpers (`advisory-convergence.mts`, `advisory-wait-state.mts`,
+// `review-activity-snapshot.mts`, `resolve-review-thread.mts`,
+// `ci-wait-policy.mts`/`ci-wait-state.mts`, `pre-merge-readiness.mts`,
+// `idd-merge-execute.mts`, `merged-pr-feedback-sweep.mts`) -- never unified
+// across a field-selection, pagination, or failure-semantics delta, per the
+// file-header rule above.
+
+/** Result of a governance-style read that discriminates a masked `404`
+ * (the response can't tell "genuinely nothing configured" from "the token
+ * can't read this") from a real value, so the domain layer keeps deciding
+ * how to treat the absence -- mirrors `getCollaboratorPermission`'s
+ * existing "raw classified result, caller maps its own outcome" precedent.
+ * Any non-404 failure still throws; this type only carries the 404 case. */
+export type ProviderGovernanceReadOutcome<T> =
+  | { outcome: 'ok'; value: T }
+  | { outcome: 'not-found' };
+
+/** Backs {@link ProviderPort.getChangeRequestHeadShaAndAuthor}. */
+export interface ProviderChangeRequestHeadShaAndAuthor {
+  headSha: string;
+  authorLogin: string;
+}
+
+/** Backs {@link ProviderPort.getChangeRequestConvergenceView}. `closingIssuesReferences` is a raw passthrough (shape not inspected by this port). */
+export interface ProviderChangeRequestConvergenceView {
+  headSha: string;
+  headRefName: string;
+  authorLogin: string;
+  url: string;
+  closingIssuesReferences: unknown;
+}
+
+/** Backs {@link ProviderPort.getChangeRequestReadinessSnapshot} -- the
+ * richest single `pr view` call in the codebase (deliberately avoids a
+ * second `pr checks` round trip, #1483). `statusCheckRollup` and
+ * `closingIssuesReferences` are raw passthroughs. */
+export interface ProviderChangeRequestReadinessSnapshot {
+  headSha: string;
+  baseRefName: string;
+  url: string;
+  authorLogin: string;
+  reviewDecision: string | null;
+  statusCheckRollup: unknown;
+  mergeable: string;
+  mergeStateStatus: string;
+  closingIssuesReferences: unknown;
+}
+
+/** Backs {@link ProviderPort.getChangeRequestBranchAndChecks}. `statusCheckRollup` is a raw passthrough. */
+export interface ProviderChangeRequestBranchAndChecks {
+  headSha: string;
+  baseRefName: string;
+  statusCheckRollup: unknown;
+}
+
+/** Backs {@link ProviderPort.listMergedChangeRequests}. */
+export interface ProviderMergedChangeRequestSummary {
+  number: number;
+  mergedAt: string;
+}
+
+/** Backs {@link ProviderPort.getMergedChangeRequestMeta}. */
+export interface ProviderMergedChangeRequestMeta {
+  number: number;
+  merged: boolean;
+  mergedAt: string | null;
+  mergeCommitOid: string | null;
+}
+
+/** One reply-target comment inside a review thread, as
+ * {@link ProviderPort.listChangeRequestReviewThreadsWithComments} and
+ * {@link ProviderPort.listChangeRequestReviewThreadsExtended} return it. */
+export interface ProviderReviewThreadComment {
+  body: string;
+  url?: string;
+  createdAt: string;
+  updatedAt: string;
+  authorLogin: string;
+  /** The comment's parent review node id, when the query selects it (disposition-evidence matching). */
+  pullRequestReviewId?: string | null;
+}
+
+/** Backs {@link ProviderPort.listChangeRequestReviewThreadsWithComments} --
+ * shared by `review-activity-snapshot.mts` and `pre-merge-readiness.mts`
+ * (byte-identical GraphQL query in both). Distinct from the minimal
+ * {@link ProviderPort.listChangeRequestReviewThreads} (`{isResolved}[]`
+ * only, #2266): this one also needs each thread's comment bodies/authors
+ * for disposition-evidence matching. */
+export interface ProviderReviewThreadWithComments {
+  isResolved: boolean | null;
+  comments: ProviderReviewThreadComment[];
+}
+
+/** Backs {@link ProviderPort.listChangeRequestReviewThreadsExtended} --
+ * `merged-pr-feedback-sweep.mts`'s own distinct query (selects `path`,
+ * absent from the shared query above). */
+export interface ProviderReviewThreadExtended {
+  isResolved: boolean | null;
+  path: string | null;
+  comments: ProviderReviewThreadComment[];
+}
+
+/** Backs {@link ProviderPort.listChangeRequestReviewThreadCommentIds} --
+ * `resolve-review-thread.mts`'s own distinct, leaner query (only the
+ * GraphQL thread node id and each comment's REST-numeric `databaseId`,
+ * needed to target a reply/resolution, not the thread's content). */
+export interface ProviderReviewThreadCommentIds {
+  threadId: string;
+  isResolved: boolean | null;
+  commentDatabaseIds: number[];
+}
+
+/** Backs {@link ProviderPort.listChangeRequestGraphqlComments}. */
+export interface ProviderGraphqlComment {
+  body: string;
+  url: string;
+  createdAt: string;
+  updatedAt: string;
+  authorLogin: string;
+}
+
+/** Backs {@link ProviderPort.listChangeRequestGraphqlReviews}. */
+export interface ProviderGraphqlReview {
+  body: string;
+  url: string;
+  state: string;
+  submittedAt: string | null;
+  authorLogin: string;
+}
+
 /**
  * Provider port: the operation surface `discover-*.mts`, `claim-approval-
  * gate.mts`, `post-idd-marker.mts`, `resume-claim-routing.mts`,
@@ -458,4 +593,346 @@ export interface ProviderPort {
     fields: string[];
     limit: number;
   }): unknown[];
+
+  // --- #2267 additions below. -------------------------------------------
+
+  /** repository-identity. `gh api repos/{owner}/{repo} --jq
+   * .default_branch`, `null` on any failure -- delegates to `gh-exec.mts`'s
+   * existing shared `readGithubRepoDefaultBranch` (#2272), already reused
+   * by `pre-merge-readiness.mts`, `ci-wait-state.mts`, and
+   * `idd-merge-execute.mts` today. */
+  getRepositoryDefaultBranch(owner: string, repo: string): string | null;
+
+  /**
+   * repository-identity. Never throws; matches `resolveViewerLoginSafe`'s
+   * never-throw contract but for `gh api app --jq '.slug // .app_slug //
+   * empty'` -- a distinct query, not a variant of it.
+   */
+  resolveViewerAppSlugSafe(): { appSlug: string; unavailable: boolean };
+
+  /**
+   * repository-identity. Same query/never-throw contract as
+   * {@link resolveViewerLoginSafe}, but `advisory-convergence.mts`'s own
+   * call varies its subprocess stdio by `GITHUB_ACTIONS` (piped/silent in
+   * CI, inherited/visible locally) so a human watching a local run still
+   * sees the underlying `gh` stderr -- not a query difference, but not
+   * "never output-changing" either (a local run's visible stderr changes),
+   * so it gets its own method rather than folding into the existing one
+   * (whose doc comment pins exact-options-match for its own consumer).
+   */
+  resolveViewerLoginSafeQuiet(): {
+    viewerLogin: string;
+    viewerLoginUnavailable: boolean;
+  };
+
+  /**
+   * repository-identity, read. `contents/{path}?ref=` GET, full response
+   * object; 404 (masked-403-per-GitHub's-docs) tolerated as `null` at the
+   * transport level -- `pre-merge-readiness.mts`'s CODEOWNERS fallback
+   * chain probes several candidate paths and expects a clean `null` to try
+   * the next one. Distinct from {@link getRepositoryFileContentAtRef}
+   * below: different content-negotiation path (query-string `ref`, no
+   * `--jq` narrowing) and a different repo-scoping caller (this one is
+   * always the port's own ambient repo via explicit owner/repo, matching
+   * every other two-arg repo method here).
+   */
+  getRepositoryContentAtRef(
+    owner: string,
+    repo: string,
+    path: string,
+    ref: string,
+  ): unknown | null;
+
+  /**
+   * repository-identity, read. `contents/{path}` GET via `--field ref=`
+   * (not a query string) narrowed to `.content` (base64), scoped by an
+   * explicit `repoRef` (`<owner>/<repo>`) that `idd-merge-execute.mts`'s
+   * own `--owner`/`--repo` collector flags can point at a DIFFERENT repo
+   * than the port's own ambient locator -- the one genuinely cross-repo
+   * call in this migration. `not-found` on a 404; any other failure
+   * throws (the caller's pre-migration `deriveGhHttpStatus` re-check on a
+   * thrown error is replaced by this explicit outcome instead of trying to
+   * preserve that pattern across the port boundary).
+   */
+  getRepositoryFileContentAtRef(
+    repoRef: string,
+    path: string,
+    ref: string,
+  ): ProviderGovernanceReadOutcome<string>;
+
+  /**
+   * permissions. `orgs/{org}/teams/{slug}/memberships/{login}` `--jq
+   * .state`, never throws (matches
+   * `resolveViewerClassicBypassTeamSlugs`'s existing fail-open '' default).
+   */
+  getTeamMembershipStateSafe(
+    org: string,
+    teamSlug: string,
+    login: string,
+  ): string;
+
+  /**
+   * change-requests. `pr view --json headRefOid,author` -- the distinct
+   * two-field shape `review-activity-snapshot.mts` uses (throws on any
+   * failure, no 404-to-null mapping, matching that file's pre-migration
+   * no-try/catch call).
+   */
+  getChangeRequestHeadShaAndAuthor(
+    number: number,
+  ): ProviderChangeRequestHeadShaAndAuthor;
+
+  /**
+   * change-requests. `pr view --json
+   * headRefOid,headRefName,closingIssuesReferences,author,url` -- the
+   * distinct five-field shape `advisory-convergence.mts` uses.
+   */
+  getChangeRequestConvergenceView(
+    number: number,
+  ): ProviderChangeRequestConvergenceView;
+
+  /**
+   * change-requests. `pr view --json
+   * headRefOid,baseRefName,url,author,reviewDecision,statusCheckRollup,
+   * mergeable,mergeStateStatus,closingIssuesReferences` -- the distinct
+   * nine-field shape `pre-merge-readiness.mts` uses (deliberately folds
+   * check status into this one call rather than a second `pr checks`
+   * round trip, #1483).
+   */
+  getChangeRequestReadinessSnapshot(
+    number: number,
+  ): ProviderChangeRequestReadinessSnapshot;
+
+  /**
+   * change-requests. `pr view --json headRefOid,baseRefName,
+   * statusCheckRollup` -- the distinct three-field shape `ci-wait-state.mts`
+   * uses.
+   */
+  getChangeRequestBranchAndChecks(
+    number: number,
+  ): ProviderChangeRequestBranchAndChecks;
+
+  /**
+   * change-requests. `pr view --json headRefOid --jq .headRefOid` narrowed
+   * further with `--jq .head.ref`-equivalent branch-name extraction (REST
+   * `.head.ref`, NOT `.headRefOid`) -- `resolve-review-thread.mts`'s own
+   * distinct call, not interchangeable with
+   * {@link ProviderPort.getChangeRequestHeadSha} (sha, not branch name).
+   */
+  getChangeRequestHeadRef(number: number): string;
+
+  /**
+   * change-requests. `pr list --state merged --json number,mergedAt
+   * [--search merged:>=date]` -- distinct from
+   * {@link ProviderPort.listOpenChangeRequests} (open-only, different
+   * fields). `sinceDate` (`YYYY-MM-DD` or `null`) maps to the optional
+   * `--search` filter `merged-pr-feedback-sweep.mts` applies.
+   */
+  listMergedChangeRequests(
+    limit: number,
+    sinceDate: string | null,
+  ): ProviderMergedChangeRequestSummary[];
+
+  /**
+   * change-requests. GraphQL `pullRequest(number){number merged mergedAt
+   * mergeCommit{oid}}` -- `null` when the PR is not (yet) merged, matching
+   * `merged-pr-feedback-sweep.mts`'s existing `pr.merged` guard.
+   */
+  getMergedChangeRequestMeta(
+    number: number,
+  ): ProviderMergedChangeRequestMeta | null;
+
+  /**
+   * change-requests, write. REST POST
+   * `pulls/{pr}/comments/{commentId}/replies`, JSON stdin body -- distinct
+   * from {@link ProviderPort.postWorkItemComment} (issues-comments API, a
+   * different endpoint); this one replies under a specific review comment.
+   */
+  postReviewCommentReply(
+    number: number,
+    commentId: number,
+    body: string,
+  ): { id: number };
+
+  /**
+   * change-requests, write. GraphQL mutation `resolveReviewThread(input:
+   * {threadId})`; throws unless the response confirms `isResolved ===
+   * true` (matches `resolve-review-thread.mts`'s existing verification).
+   */
+  resolveChangeRequestReviewThread(threadId: string): void;
+
+  /** change-requests, cross-repo. `pr view -R {owner}/{repo} --json
+   * headRefOid --jq .headRefOid`, throws on any failure -- the explicit-
+   * repo sibling of {@link ProviderPort.getChangeRequestHeadSha} that
+   * `idd-merge-execute.mts`'s own `--owner`/`--repo` collector flags need
+   * (see {@link getRepositoryFileContentAtRef} for why this file alone
+   * gets cross-repo methods). */
+  getChangeRequestHeadShaAtRepo(
+    owner: string,
+    repo: string,
+    number: number,
+  ): string;
+
+  /** change-requests, cross-repo. `pr view -R {owner}/{repo} --json
+   * mergeable,mergeStateStatus`, `null` on failure -- the explicit-repo
+   * sibling of {@link ProviderPort.getChangeRequest}. */
+  getChangeRequestAtRepo(
+    owner: string,
+    repo: string,
+    number: number,
+  ): ProviderChangeRequestState | null;
+
+  /** change-requests, cross-repo, write. `pr merge -R {owner}/{repo}
+   * --merge --match-head-commit {headSha}`. */
+  mergeChangeRequestAtRepo(
+    owner: string,
+    repo: string,
+    number: number,
+    headSha: string,
+  ): string;
+
+  /** change-requests, cross-repo, write. Same as
+   * {@link mergeChangeRequestAtRepo} plus `--admin` -- a separate method
+   * per the port's one-op-per-call-shape rule (no flag parameter). */
+  mergeChangeRequestAdminAtRepo(
+    owner: string,
+    repo: string,
+    number: number,
+    headSha: string,
+  ): string;
+
+  /**
+   * change-requests. `pr checks --json name,state,completedAt` WITHOUT
+   * `--required` -- every check, not just the required subset
+   * {@link ProviderPort.listRequiredChecks} returns. Same two recoveries as
+   * that method (routine non-zero exit on no-checks-configured or still-
+   * pending/failing checks).
+   */
+  listChangeRequestChecks(number: number): ProviderRequiredCheck[];
+
+  /**
+   * change-requests. REST unpaginated `pulls/{pr}/requested_reviewers`,
+   * flattened to logins.
+   */
+  getChangeRequestRequestedReviewerLogins(number: number): string[];
+
+  /**
+   * change-requests. GraphQL `reviewRequests(first:100){nodes{
+   * requestedReviewer{...on Bot/User/Mannequin{login}}}}` -- distinct
+   * transport/shape from
+   * {@link getChangeRequestRequestedReviewerLogins} above; `null` on ANY
+   * failure (matches the existing try/catch, never throws).
+   */
+  getChangeRequestRequestedReviewerLoginsGraphql(
+    number: number,
+  ): string[] | null;
+
+  /** change-requests. REST paginated `pulls/{pr}/files`, flattened to `.filename`. */
+  listChangeRequestChangedFiles(number: number): string[];
+
+  /** change-requests. REST paginated `pulls/{pr}/commits`, raw passthrough. */
+  listChangeRequestCommits(number: number): unknown[];
+
+  /**
+   * reviews-and-threads. Full-walk paginated GraphQL `reviewThreads` with
+   * nested comment bodies/authors/timestamps -- see
+   * {@link ProviderReviewThreadWithComments}'s doc comment for why this is
+   * distinct from the minimal {@link listChangeRequestReviewThreads}.
+   * Shared by `review-activity-snapshot.mts` and `pre-merge-readiness.mts`
+   * (byte-identical query in both today).
+   */
+  listChangeRequestReviewThreadsWithComments(
+    number: number,
+  ): ProviderReviewThreadWithComments[];
+
+  /**
+   * reviews-and-threads. `merged-pr-feedback-sweep.mts`'s own distinct
+   * full-walk paginated GraphQL `reviewThreads` query (selects `path`,
+   * which the shared query above does not) -- see
+   * {@link ProviderReviewThreadExtended}.
+   */
+  listChangeRequestReviewThreadsExtended(
+    number: number,
+  ): ProviderReviewThreadExtended[];
+
+  /**
+   * reviews-and-threads. `resolve-review-thread.mts`'s own distinct,
+   * leaner full-walk paginated GraphQL `reviewThreads` query (thread node
+   * id plus each comment's REST-numeric `databaseId` only, no body/author)
+   * -- see {@link ProviderReviewThreadCommentIds}.
+   */
+  listChangeRequestReviewThreadCommentIds(
+    number: number,
+  ): ProviderReviewThreadCommentIds[];
+
+  /**
+   * reviews-and-threads. Full-walk paginated GraphQL `comments(first:100)`
+   * -- distinct transport/shape from
+   * {@link ProviderPort.listWorkItemComments} (REST, different fields);
+   * `merged-pr-feedback-sweep.mts`'s own query.
+   */
+  listChangeRequestGraphqlComments(number: number): ProviderGraphqlComment[];
+
+  /**
+   * reviews-and-threads. Full-walk paginated GraphQL `reviews(first:100)`
+   * -- distinct transport/shape from {@link ProviderPort.listReviews}
+   * (REST, different fields); `merged-pr-feedback-sweep.mts`'s own query.
+   */
+  listChangeRequestGraphqlReviews(number: number): ProviderGraphqlReview[];
+
+  /**
+   * branch-protection. `rules/branches/{ref}` -- see
+   * {@link ProviderGovernanceReadOutcome}'s doc comment for the masked-404
+   * rationale shared with {@link getBranchProtection} below (both
+   * endpoints document only 200/404 per GitHub's REST reference, never
+   * 403, per #1377's citations).
+   */
+  listBranchRules(
+    owner: string,
+    repo: string,
+    ref: string,
+  ): ProviderGovernanceReadOutcome<unknown[]>;
+
+  /** branch-protection. `branches/{ref}/protection` -- see {@link listBranchRules}. */
+  getBranchProtection(
+    owner: string,
+    repo: string,
+    ref: string,
+  ): ProviderGovernanceReadOutcome<unknown>;
+
+  /**
+   * branch-protection. `repos/rulesets/{rulesetId}` detail read -- GitHub's
+   * reference documents only 200/404/500 for this endpoint (no 403), the
+   * same masked-404 posture as {@link listBranchRules}.
+   */
+  getRepositoryRulesetDetail(
+    owner: string,
+    repo: string,
+    rulesetId: number | string,
+  ): ProviderGovernanceReadOutcome<unknown>;
+
+  /** checks. `actions/runs/{runId}` single-run read, raw passthrough. */
+  getWorkflowRun(owner: string, repo: string, runId: number): unknown;
+
+  /** checks. `gh run list --workflow {name} --limit N --json
+   * databaseId,conclusion,status,createdAt` -- distinct `gh run list`
+   * shape, not a `gh api` call. */
+  listWorkflowRuns(
+    owner: string,
+    repo: string,
+    workflowName: string,
+    limit: number,
+  ): {
+    id: number;
+    conclusion: string | null;
+    status: string;
+    createdAt: string;
+  }[];
+
+  /** merge, write. `pr merge --merge --match-head-commit {headSha}` on the
+   * port's own ambient repo. */
+  mergeChangeRequest(number: number, headSha: string): string;
+
+  /** merge, write. Same as {@link mergeChangeRequest} plus `--admin` --
+   * separate method per the port's one-op-per-call-shape rule. */
+  mergeChangeRequestAdmin(number: number, headSha: string): string;
 }

--- a/src/scripts/provider-port.mts
+++ b/src/scripts/provider-port.mts
@@ -989,7 +989,14 @@ export interface ProviderPort {
     workflowName: string,
     limit: number,
   ): {
-    id: number;
+    /** `string`, not `number`: a `databaseId` above
+     * `Number.MAX_SAFE_INTEGER` loses precision through `Number()` --
+     * `ci-wait-policy.mts`'s sibling-exclusion compares this against a
+     * string-valued `--run-id`, so a rounded id could wrongly stop
+     * matching the current run (Codex review, PR #2429; matches
+     * {@link getWorkflowRun}'s `runId` parameter, kept `string | number`
+     * for the same reason). */
+    id: string;
     conclusion: string | null;
     status: string;
     createdAt: string;

--- a/src/scripts/provider-port.mts
+++ b/src/scripts/provider-port.mts
@@ -68,11 +68,18 @@ export interface ProviderWorkItem {
   updatedAt?: string;
 }
 
-/** One issue-comments-API comment (issue or PR -- same endpoint on GitHub). */
+/** One issue-comments-API comment (issue or PR -- same endpoint on GitHub).
+ * `updatedAt` (#2267) is additive: REST returns it on every response
+ * regardless of field selection, so surfacing it widens this existing
+ * shared shape rather than adding a competing method -- every #2266
+ * consumer that ignores it is unaffected. `review-activity-snapshot.mts`
+ * and `pre-merge-readiness.mts`'s disposition-evidence comment
+ * normalization need it for their most-recent-activity computation. */
 export interface ProviderComment {
   id: number;
   body: string;
   createdAt: string;
+  updatedAt: string;
   authorLogin: string;
 }
 

--- a/src/scripts/provider-port.mts
+++ b/src/scripts/provider-port.mts
@@ -301,6 +301,34 @@ export interface ProviderReviewsWithHeadCommitDate {
   headCommittedAt: string;
 }
 
+/** Backs {@link ProviderPort.getChangeRequestAuthor}. */
+export interface ProviderChangeRequestAuthor {
+  login: string;
+  typename: string | null;
+}
+
+/** One review-thread comment as
+ * {@link ProviderPort.listChangeRequestReviewThreadsWithAuthorType} returns
+ * it -- like {@link ProviderReviewThreadComment} but also selects
+ * `author.__typename` (`advisory-convergence.mts`'s own distinct query;
+ * neither `listChangeRequestReviewThreadsWithComments` nor
+ * `listChangeRequestReviewThreadsExtended` select this field). */
+export interface ProviderReviewThreadCommentWithAuthorType {
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+  authorLogin: string;
+  authorTypename: string | null;
+  pullRequestReviewId: string | null;
+}
+
+/** Backs {@link ProviderPort.listChangeRequestReviewThreadsWithAuthorType}. */
+export interface ProviderReviewThreadWithAuthorType {
+  id: string;
+  isResolved: boolean | null;
+  comments: ProviderReviewThreadCommentWithAuthorType[];
+}
+
 /**
  * Provider port: the operation surface `discover-*.mts`, `claim-approval-
  * gate.mts`, `post-idd-marker.mts`, `resume-claim-routing.mts`,
@@ -948,6 +976,24 @@ export interface ProviderPort {
     status: string;
     createdAt: string;
   }[];
+
+  /**
+   * change-requests. GraphQL `pullRequest(number){author{login __typename}}`
+   * -- `advisory-convergence.mts`'s own minimal author-only query (its
+   * `fetchPrAuthor`), distinct from every other author-carrying method here
+   * (none else select `__typename`). `null` when the PR/author is absent.
+   */
+  getChangeRequestAuthor(number: number): ProviderChangeRequestAuthor | null;
+
+  /**
+   * reviews-and-threads. Same full-walk two-level pagination as
+   * {@link listChangeRequestReviewThreadsWithComments}, but
+   * `advisory-convergence.mts`'s own query also selects `author.__typename`
+   * -- see {@link ProviderReviewThreadCommentWithAuthorType}.
+   */
+  listChangeRequestReviewThreadsWithAuthorType(
+    number: number,
+  ): ProviderReviewThreadWithAuthorType[];
 
   /**
    * reviews-and-threads. Paginated GraphQL `reviews(first:100)` plus a

--- a/src/scripts/resolve-review-thread.mts
+++ b/src/scripts/resolve-review-thread.mts
@@ -22,7 +22,6 @@ import {
   readForcedHandoffAuthorityPolicy,
   readForcedHandoffMode,
 } from './collaborator-permission.mts';
-import { DEFAULT_GH_PAGINATED_TIMEOUT_MS, ghText } from './gh-exec.mts';
 import { loadIddConfig } from './idd-config.mts';
 import { appendReviewReplyStamp } from './marker-helpers.mts';
 import {
@@ -31,6 +30,14 @@ import {
   type ParsedClaimMarker,
   resolveActiveClaimForWriteGate,
 } from './protocol-helpers.mts';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mts';
+import type {
+  ProviderPort,
+  ProviderReviewThreadCommentIds,
+} from './provider-port.mts';
 
 /** A comment-id page within a review thread's `comments` connection. */
 interface ThreadCommentsConnection {
@@ -283,45 +290,6 @@ thread in one invocation (E13). Dry-run by default; --apply mutates.
 `;
 
 /**
- * Fetch a paginated list endpoint as an array. `gh api --paginate` concatenates
- * one JSON array per page; `--jq '.[]'` flattens each page to one JSON value per
- * line (NDJSON), which we parse line-by-line (mirrors the sibling helpers).
- */
-function ghJsonPaginated(args: string[]): unknown[] {
-  const out = ghText([...args, '--paginate', '--jq', '.[]'], {
-    timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS,
-  });
-  return out
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line !== '')
-    .map((line) => JSON.parse(line) as unknown);
-}
-
-function ghGraphql(
-  query: string,
-  variables: Record<string, string | number | null | undefined>,
-): unknown {
-  const args = ['api', 'graphql', '-f', `query=${query}`];
-  for (const [key, value] of Object.entries(variables)) {
-    if (value === null || value === undefined) {
-      continue;
-    }
-    if (typeof value === 'number') {
-      args.push('-F', `${key}=${value}`);
-      continue;
-    }
-    args.push('-f', `${key}=${value}`);
-  }
-  return JSON.parse(ghText(args) || '{}');
-}
-
-interface ReviewThreadsConnectionPayload {
-  pageInfo?: { hasNextPage?: boolean; endCursor?: string | null } | null;
-  nodes?: ReviewThreadNode[] | null;
-}
-
-/**
  * Throw when a GraphQL response carries top-level `errors`, so a bad
  * PR/repo/auth or any server-side GraphQL failure fails fast with a clear
  * message instead of being silently read as an empty result (which would
@@ -342,167 +310,21 @@ export function assertNoGraphqlErrors(payload: unknown, context: string): void {
 }
 
 /**
- * Fetch every review thread of a PR (paginated), each with its node id,
- * resolution state, and member comment database ids — enough to map a REST
- * comment id to its owning thread. Both the threads connection **and** each
- * thread's nested comments connection are paginated to completion, so a target
- * comment buried past the first 100 replies in a deep thread still resolves.
+ * Map {@link ProviderPort.listChangeRequestReviewThreadCommentIds}'s flat
+ * `commentDatabaseIds` shape onto this file's existing, independently-tested
+ * {@link ReviewThreadNode}/{@link findThreadForComment} contract, rather than
+ * changing that pure function's signature.
  */
-function fetchReviewThreads(
-  owner: string,
-  repo: string,
-  prNumber: number,
+function toReviewThreadNodes(
+  threads: ProviderReviewThreadCommentIds[],
 ): ReviewThreadNode[] {
-  const nodes: ReviewThreadNode[] = [];
-  let cursor: string | null | undefined = null;
-  while (true) {
-    const payload = ghGraphql(
-      `query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
-        repository(owner: $owner, name: $repo) {
-          pullRequest(number: $number) {
-            reviewThreads(first: 100, after: $cursor) {
-              pageInfo { hasNextPage endCursor }
-              nodes {
-                id
-                isResolved
-                comments(first: 100) {
-                  pageInfo { hasNextPage endCursor }
-                  nodes { databaseId }
-                }
-              }
-            }
-          }
-        }
-      }`,
-      { owner, repo, number: prNumber, cursor },
-    );
-    assertNoGraphqlErrors(payload, 'review thread lookup');
-    const reviewThreads = (
-      payload as {
-        data?: {
-          repository?: {
-            pullRequest?: {
-              reviewThreads?: ReviewThreadsConnectionPayload | null;
-            } | null;
-          } | null;
-        } | null;
-      }
-    )?.data?.repository?.pullRequest?.reviewThreads;
-    for (const thread of reviewThreads?.nodes ?? []) {
-      if (thread.comments?.pageInfo?.hasNextPage) {
-        if (!thread.id || !thread.comments.pageInfo.endCursor) {
-          throw new Error(
-            'review thread comment pagination payload is missing id or endCursor',
-          );
-        }
-        thread.comments.nodes = [
-          ...(thread.comments.nodes ?? []),
-          ...fetchThreadCommentIds(
-            thread.id,
-            thread.comments.pageInfo.endCursor,
-          ),
-        ];
-        thread.comments.pageInfo.hasNextPage = false;
-      }
-    }
-    nodes.push(...(reviewThreads?.nodes ?? []));
-    if (!reviewThreads?.pageInfo?.hasNextPage) {
-      break;
-    }
-    if (!reviewThreads.pageInfo.endCursor) {
-      throw new Error('review thread pagination payload is missing endCursor');
-    }
-    cursor = reviewThreads.pageInfo.endCursor;
-  }
-  return nodes;
-}
-
-/**
- * Page the remaining comment-id nodes of one review thread, starting after
- * `afterCursor`, until the connection is exhausted. Mirrors the sibling
- * snapshot helper's nested-comment pagination.
- */
-function fetchThreadCommentIds(
-  threadId: string,
-  afterCursor: string,
-): { databaseId?: number | null }[] {
-  const nodes: { databaseId?: number | null }[] = [];
-  let cursor: string | null | undefined = afterCursor;
-  while (cursor) {
-    const payload = ghGraphql(
-      `query($id: ID!, $cursor: String) {
-        node(id: $id) {
-          ... on PullRequestReviewThread {
-            comments(first: 100, after: $cursor) {
-              pageInfo { hasNextPage endCursor }
-              nodes { databaseId }
-            }
-          }
-        }
-      }`,
-      { id: threadId, cursor },
-    );
-    assertNoGraphqlErrors(payload, 'review thread comment pagination');
-    const comments = (
-      payload as {
-        data?: { node?: { comments?: ThreadCommentsConnection | null } | null };
-      }
-    )?.data?.node?.comments;
-    nodes.push(...(comments?.nodes ?? []));
-    if (comments?.pageInfo?.hasNextPage && !comments.pageInfo.endCursor) {
-      throw new Error('thread comment pagination payload is missing endCursor');
-    }
-    cursor = comments?.pageInfo?.hasNextPage
-      ? comments.pageInfo.endCursor
-      : null;
-  }
-  return nodes;
-}
-
-/** Post a reply to the review thread that owns `commentId` (REST). */
-function postReply(
-  owner: string,
-  repo: string,
-  pr: number,
-  commentId: number,
-  body: string,
-): { id: number } {
-  // JSON `--input -` is required: the reply-identity stamp is an HTML
-  // comment after the visible disposition, so `-f body=` can drop or
-  // truncate the multiline body.
-  return JSON.parse(
-    ghText(
-      [
-        'api',
-        '--method',
-        'POST',
-        `repos/${owner}/${repo}/pulls/${pr}/comments/${commentId}/replies`,
-        '--input',
-        '-',
-      ],
-      { input: JSON.stringify({ body }) },
-    ),
-  ) as { id: number };
-}
-
-/** Resolve a review thread by its GraphQL node id, confirming the result. */
-function resolveThread(threadId: string): void {
-  const payload = ghGraphql(
-    `mutation($threadId: ID!) {
-      resolveReviewThread(input: { threadId: $threadId }) {
-        thread { id isResolved }
-      }
-    }`,
-    { threadId },
-  ) as {
-    data?: { resolveReviewThread?: { thread?: { isResolved?: unknown } } };
-  };
-  assertNoGraphqlErrors(payload, 'resolveReviewThread');
-  if (payload?.data?.resolveReviewThread?.thread?.isResolved !== true) {
-    throw new Error(
-      'resolveReviewThread returned without confirming thread.isResolved',
-    );
-  }
+  return threads.map((thread) => ({
+    id: thread.threadId,
+    isResolved: Boolean(thread.isResolved),
+    comments: {
+      nodes: thread.commentDatabaseIds.map((databaseId) => ({ databaseId })),
+    },
+  }));
 }
 
 /** Forced-handoff revalidation inputs, resolved once per CLI invocation. */
@@ -527,22 +349,18 @@ interface ForcedHandoffGateOptions {
  * is that branch.
  */
 function activeOwnedClaim(
-  owner: string,
-  repo: string,
+  port: ProviderPort,
   issue: number,
   agentId: string,
   claimId: string,
   isTrustedAuthor: (login: string) => boolean,
   forcedHandoffOptions: ForcedHandoffGateOptions,
 ): ParsedClaimMarker | null {
-  const comments = ghJsonPaginated([
-    'api',
-    `repos/${owner}/${repo}/issues/${issue}/comments`,
-  ]) as { body?: string; created_at?: string; user?: { login?: string } }[];
+  const comments = port.listWorkItemComments(issue);
   const events = comments.map((comment) => ({
-    body: comment.body ?? '',
-    createdAt: comment.created_at ?? '',
-    author: { login: comment.user?.login ?? '' },
+    body: comment.body,
+    createdAt: comment.createdAt,
+    author: { login: comment.authorLogin },
   }));
   const active = resolveActiveClaimForWriteGate(events, {
     isTrustedAuthor,
@@ -614,14 +432,14 @@ if (import.meta.main) {
         typeof markerPrefixRaw === 'string' ? markerPrefixRaw : undefined,
       )
     : '';
-  const owner =
-    args.owner ||
-    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
-  const repo =
-    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createGithubProviderAdapter(owner, repo);
 
   const match = findThreadForComment(
-    fetchReviewThreads(owner, repo, pr),
+    toReviewThreadNodes(port.listChangeRequestReviewThreadCommentIds(pr)),
     commentId,
   );
 
@@ -662,16 +480,11 @@ if (import.meta.main) {
   // Bind the mutation to the claimed PR: the active claim's branch must be the
   // PR's head branch, so a valid claim on the issue cannot be used to reply to
   // and resolve a thread on some other PR passed as --pr.
-  const prHeadRef = ghText([
-    'api',
-    `repos/${owner}/${repo}/pulls/${pr}`,
-    '--jq',
-    '.head.ref',
-  ]);
+  const prHeadRef = port.getChangeRequestHeadRef(pr);
 
   // --apply: default the trusted claim authors to this gh login so the
   // revalidation recognizes the session's own claim markers.
-  const viewerLogin = ghText(['api', 'user', '--jq', '.login']).toLowerCase();
+  const viewerLogin = port.resolveViewerLogin().toLowerCase();
   const trustedAuthors = new Set(
     (args.trustedMarkerLogins.length > 0
       ? args.trustedMarkerLogins
@@ -713,8 +526,7 @@ if (import.meta.main) {
     const result = applyResolveReviewThread({
       assertClaim: () => {
         const active = activeOwnedClaim(
-          owner,
-          repo,
+          port,
           args.claimIssue as number,
           args.agentId,
           args.claimId,
@@ -733,11 +545,16 @@ if (import.meta.main) {
         }
       },
       postReply: () => {
-        const posted = postReply(owner, repo, pr, rootCommentId, stampedBody);
+        const posted = port.postReviewCommentReply(
+          pr,
+          rootCommentId,
+          stampedBody,
+        );
         postedReplyId = posted.id;
         return posted;
       },
-      resolveThread: () => resolveThread(match.threadId),
+      resolveThread: () =>
+        port.resolveChangeRequestReviewThread(match.threadId),
     });
     report.status = 'applied';
     report.replyId = result.replyId;

--- a/src/scripts/review-activity-snapshot.mts
+++ b/src/scripts/review-activity-snapshot.mts
@@ -6,73 +6,35 @@
 // generated .mjs. See docs/typescript-sources.md.
 
 import { parseCliArgs } from './cli-args.mts';
-import { DEFAULT_GH_PAGINATED_TIMEOUT_MS, ghText } from './gh-exec.mts';
 import { loadIddConfig } from './idd-config.mts';
 import {
   buildActivitySnapshotSummary,
-  parsePaginatedGhNdjson,
   resolveAdvisoryBotLogins,
   resolveTrustedMarkerActors,
   summarizeDispositionEvidenceForGate,
 } from './protocol-helpers.mts';
+import {
+  createGithubProviderAdapter,
+  resolveCurrentGithubRepository,
+} from './provider-adapter-github.mts';
+import type {
+  ProviderComment,
+  ProviderReviewThreadWithComments,
+} from './provider-port.mts';
 
 /** Author reference embedded in GitHub REST/GraphQL payloads. */
 interface GhAuthorPayload {
   login?: string | null;
 }
 
-/** Issue comment payload fields consumed by this helper. */
-interface IssueCommentPayload {
-  body?: string | null;
-  created_at?: string | null;
-  updated_at?: string | null;
-  user?: GhAuthorPayload | null;
-}
-
-/** PR review payload fields consumed by this helper. */
+/** PR review payload fields consumed by this helper -- raw REST shape,
+ * unchanged by the #2267 port migration ({@link ProviderPort.listReviews}
+ * is a raw passthrough). */
 interface ReviewPayload {
   state?: string | null;
   user?: GhAuthorPayload | null;
   submitted_at?: string | null;
   updated_at?: string | null;
-}
-
-/** CI status-check entry returned by `gh pr checks`. */
-interface CheckPayload {
-  name?: string | null;
-  state?: string | null;
-  completedAt?: string | null;
-}
-
-/** GraphQL pagination cursor block. */
-interface PageInfoPayload {
-  hasNextPage?: boolean | null;
-  endCursor?: string | null;
-}
-
-/** Review-thread reply node (GraphQL `reviewThreads` comment). */
-interface ThreadCommentPayload {
-  body?: string | null;
-  createdAt?: string | null;
-  updatedAt?: string | null;
-  author?: GhAuthorPayload | null;
-  pullRequestReview?: { id?: string | null } | null;
-}
-
-/** Review thread (GraphQL `reviewThreads` node). */
-interface ReviewThreadPayload {
-  id?: string | null;
-  isResolved?: boolean | null;
-  comments?: {
-    pageInfo?: PageInfoPayload | null;
-    nodes: ThreadCommentPayload[];
-  } | null;
-}
-
-/** GraphQL `reviewThreads` connection payload. */
-interface ReviewThreadsConnectionPayload {
-  pageInfo?: PageInfoPayload | null;
-  nodes?: ReviewThreadPayload[] | null;
 }
 
 /** Parsed CLI arguments. */
@@ -124,12 +86,11 @@ function main(): void {
     throw new Error('missing required --pr <number> argument');
   }
 
-  const owner =
-    args.owner ||
-    ghText(['repo', 'view', '--json', 'owner', '--jq', '.owner.login']);
-  const repo =
-    args.repo || ghText(['repo', 'view', '--json', 'name', '--jq', '.name']);
-  const repoRef = `${owner}/${repo}`;
+  const currentRepo =
+    args.owner && args.repo ? null : resolveCurrentGithubRepository();
+  const owner = args.owner || currentRepo?.owner || '';
+  const repo = args.repo || currentRepo?.repo || '';
+  const port = createGithubProviderAdapter(owner, repo);
   const iddConfig = loadIddConfig();
   const { actors: trustedMarkerLogins, source: trustedMarkerActorsSource } =
     resolveTrustedMarkerActors({
@@ -144,56 +105,23 @@ function main(): void {
       config: iddConfig,
     });
 
-  // #1833: also reads `author.login` (not just `headRefOid`) in this same
-  // call -- `summarizeDispositionEvidenceForGate` below needs the PR
-  // author's login to exclude the author's own comments/thread replies from
-  // "missing disposition" (they never require one), the same way
-  // `buildPreMergeReadinessSummary`'s own call to that function does.
-  // `ghJson`'s empty-response fallback is `'[]'` (array-shaped, tuned for
-  // the paginated `checks` call above); on this object-shaped `pr view`
-  // call an empty response would leave `headRefOid`/`author` both
-  // undefined, so `headSha` below becomes `''` and
-  // `watermarkFieldsFromSnapshot` (post-idd-marker.mts) throws "missing a
-  // usable headSha" downstream -- fail-closed, not a silent bad watermark.
-  const prView = ghJson([
-    'pr',
-    'view',
-    String(args.prNumber),
-    '-R',
-    repoRef,
-    '--json',
-    'headRefOid,author',
-  ]) as {
-    headRefOid?: string | null;
-    author?: { login?: string | null } | null;
-  };
-  const headSha = String(prView.headRefOid ?? '');
-  const prAuthorLogin = String(prView.author?.login ?? '')
-    .trim()
-    .toLowerCase();
-  const checks = ghJson(
-    [
-      'pr',
-      'checks',
-      String(args.prNumber),
-      '-R',
-      repoRef,
-      '--json',
-      'name,state,completedAt',
-      '--jq',
-      '.',
-    ],
-    { allowStatuses: [1, 8] },
-  ) as CheckPayload[];
-  const reviews = ghApiJson(
-    `repos/${owner}/${repo}/pulls/${args.prNumber}/reviews`,
-    true,
-  ) as ReviewPayload[];
-  const comments = ghApiJson(
-    `repos/${owner}/${repo}/issues/${args.prNumber}/comments`,
-    true,
-  ) as IssueCommentPayload[];
-  const threads = fetchReviewThreads(owner, repo, args.prNumber);
+  // #1833: also reads the PR author's login (not just headSha) --
+  // `summarizeDispositionEvidenceForGate` below needs it to exclude the
+  // author's own comments/thread replies from "missing disposition" (they
+  // never require one), the same way `buildPreMergeReadinessSummary`'s own
+  // call to that function does. A missing/unresolvable head SHA fails
+  // closed downstream (`watermarkFieldsFromSnapshot` in post-idd-marker.mts
+  // throws "missing a usable headSha"), not a silent bad watermark.
+  const { headSha: rawHeadSha, authorLogin: rawAuthorLogin } =
+    port.getChangeRequestHeadShaAndAuthor(args.prNumber);
+  const headSha = rawHeadSha;
+  const prAuthorLogin = rawAuthorLogin.trim().toLowerCase();
+  const checks = port.listChangeRequestChecks(args.prNumber);
+  const reviews = port.listReviews(args.prNumber) as ReviewPayload[];
+  const comments = port.listWorkItemComments(args.prNumber);
+  const threads = port.listChangeRequestReviewThreadsWithComments(
+    args.prNumber,
+  );
   const normalizedComments = comments.map(normalizeComment);
   const normalizedThreads = threads.map(normalizeThread);
 
@@ -305,12 +233,12 @@ function printHelp(): void {
 `);
 }
 
-function normalizeComment(comment: IssueCommentPayload) {
+function normalizeComment(comment: ProviderComment) {
   return {
-    author: { login: comment.user?.login ?? '' },
-    body: comment.body ?? '',
-    createdAt: comment.created_at ?? '',
-    updatedAt: comment.updated_at ?? comment.created_at ?? '',
+    author: { login: comment.authorLogin },
+    body: comment.body,
+    createdAt: comment.createdAt,
+    updatedAt: comment.updatedAt || comment.createdAt,
   };
 }
 
@@ -324,243 +252,19 @@ function normalizeReview(review: ReviewPayload) {
   };
 }
 
-function normalizeThread(thread: ReviewThreadPayload) {
+function normalizeThread(thread: ProviderReviewThreadWithComments) {
   return {
-    id: thread.id,
     isResolved: Boolean(thread.isResolved),
     updatedAt: '',
     comments: {
-      pageInfo: {
-        hasNextPage: Boolean(thread.comments?.pageInfo?.hasNextPage),
-      },
-      nodes: (thread.comments?.nodes ?? []).map((comment) => ({
-        author: { login: comment.author?.login ?? '' },
-        body: comment.body ?? '',
-        createdAt: comment.createdAt ?? '',
-        updatedAt: comment.updatedAt ?? comment.createdAt ?? '',
-        pullRequestReview: { id: comment.pullRequestReview?.id ?? null },
+      pageInfo: { hasNextPage: false },
+      nodes: thread.comments.map((comment) => ({
+        author: { login: comment.authorLogin },
+        body: comment.body,
+        createdAt: comment.createdAt,
+        updatedAt: comment.updatedAt || comment.createdAt,
+        pullRequestReview: { id: comment.pullRequestReviewId ?? null },
       })),
     },
   };
-}
-
-function fetchReviewThreads(
-  owner: string,
-  repo: string,
-  prNumber: number,
-): ReviewThreadPayload[] {
-  const nodes: ReviewThreadPayload[] = [];
-  let cursor: string | null | undefined = null;
-
-  while (true) {
-    const payload = ghGraphql(
-      `
-        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
-          repository(owner: $owner, name: $repo) {
-            pullRequest(number: $number) {
-              reviewThreads(first: 100, after: $cursor) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  id
-                  isResolved
-                  comments(first: 100) {
-                    pageInfo { hasNextPage endCursor }
-                    nodes {
-                      body
-                      createdAt
-                      updatedAt
-                      author { login }
-                      pullRequestReview { id }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }`,
-      {
-        owner,
-        repo,
-        number: Number.parseInt(String(prNumber), 10),
-        cursor,
-      },
-    ) as {
-      data?: {
-        repository?: {
-          pullRequest?: {
-            reviewThreads?: ReviewThreadsConnectionPayload | null;
-          } | null;
-        } | null;
-      } | null;
-    };
-
-    const reviewThreads = payload?.data?.repository?.pullRequest?.reviewThreads;
-    for (const thread of reviewThreads?.nodes ?? []) {
-      if (thread.comments?.pageInfo?.hasNextPage) {
-        // hasNextPage with a missing thread id or cursor is a malformed
-        // payload; fail fast with a clear message instead of a confusing
-        // GraphQL error or a silently truncated thread.
-        if (!thread.id || !thread.comments.pageInfo.endCursor) {
-          throw new Error(
-            'review thread pagination payload is missing id or endCursor',
-          );
-        }
-        thread.comments.nodes.push(
-          ...fetchThreadCommentPages(
-            thread.id,
-            thread.comments.pageInfo.endCursor,
-          ),
-        );
-        thread.comments.pageInfo.hasNextPage = false;
-      }
-    }
-    nodes.push(...(reviewThreads?.nodes ?? []));
-
-    if (!reviewThreads?.pageInfo?.hasNextPage) {
-      break;
-    }
-    // hasNextPage with a missing cursor would re-fetch the first page
-    // forever; fail fast on the malformed payload instead.
-    if (!reviewThreads.pageInfo.endCursor) {
-      throw new Error('review thread pagination payload is missing endCursor');
-    }
-    cursor = reviewThreads.pageInfo.endCursor;
-  }
-
-  return nodes;
-}
-
-function fetchThreadCommentPages(
-  threadId: string,
-  afterCursor: string,
-): ThreadCommentPayload[] {
-  const nodes: ThreadCommentPayload[] = [];
-  let cursor: string | null | undefined = afterCursor;
-
-  while (cursor) {
-    const payload = ghGraphql(
-      `
-        query($id: ID!, $cursor: String) {
-          node(id: $id) {
-            ... on PullRequestReviewThread {
-              comments(first: 100, after: $cursor) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  body
-                  createdAt
-                  updatedAt
-                  author { login }
-                  pullRequestReview { id }
-                }
-              }
-            }
-          }
-        }`,
-      { id: threadId, cursor },
-    ) as {
-      data?: {
-        node?: {
-          comments?: {
-            pageInfo?: PageInfoPayload | null;
-            nodes?: ThreadCommentPayload[] | null;
-          } | null;
-        } | null;
-      } | null;
-    };
-
-    const comments = payload?.data?.node?.comments;
-    nodes.push(...(comments?.nodes ?? []));
-    if (comments?.pageInfo?.hasNextPage && !comments.pageInfo.endCursor) {
-      throw new Error('thread comment pagination payload is missing endCursor');
-    }
-    cursor = comments?.pageInfo?.hasNextPage
-      ? comments.pageInfo.endCursor
-      : null;
-  }
-
-  return nodes;
-}
-
-function ghGraphql(
-  query: string,
-  variables: Record<string, string | number | null | undefined>,
-): unknown {
-  const args = ['api', 'graphql', '-f', `query=${query}`];
-  for (const [key, value] of Object.entries(variables)) {
-    if (value === null || value === undefined) {
-      continue;
-    }
-    if (typeof value === 'number') {
-      args.push('-F', `${key}=${value}`);
-      continue;
-    }
-    args.push('-f', `${key}=${value}`);
-  }
-  return JSON.parse(runGh(args).trim() || '{}');
-}
-
-function ghJson(
-  args: string[],
-  options: { allowStatuses?: number[] } = {},
-): unknown {
-  return JSON.parse(runGh(args, options).trim() || '[]');
-}
-
-function ghApiJson(
-  path: string,
-  paginate = false,
-  fields: Record<string, unknown> | null = null,
-): unknown {
-  const args = ['api', path];
-  if (fields) {
-    for (const [key, value] of Object.entries(fields)) {
-      args.push(
-        '-f',
-        `${key}=${typeof value === 'string' ? value : JSON.stringify(value)}`,
-      );
-    }
-  }
-  // #1692: `--jq '.[]'` (not a bare `--paginate`) makes gh emit one JSON
-  // value per line, guaranteed newline-separated, for every element across
-  // every page -- without it, `--paginate` alone concatenates each page's
-  // whole-array response with no separator on gh 2.45.0 (this repo's
-  // documented compatibility floor), which broke a naive split('\n') on
-  // multi-page output. Matches the NDJSON convention `gh-exec.mts`'s
-  // shared `ghApiJson` already uses.
-  if (paginate) {
-    args.push('--paginate', '--jq', '.[]');
-  }
-  const raw = runGh(args).trim();
-  if (!raw) {
-    return [];
-  }
-  if (paginate) {
-    return parsePaginatedGhNdjson(raw);
-  }
-  return JSON.parse(raw);
-}
-
-function runGh(
-  args: string[],
-  options: { allowStatuses?: number[] } = {},
-): string {
-  try {
-    return ghText(
-      args,
-      args.includes('--paginate')
-        ? { timeout: DEFAULT_GH_PAGINATED_TIMEOUT_MS }
-        : {},
-    );
-  } catch (error) {
-    const status = Number((error as { status?: unknown } | null)?.status ?? -1);
-    if ((options.allowStatuses ?? []).includes(status)) {
-      const stdout = String(
-        (error as { stdout?: unknown } | null)?.stdout ?? '',
-      );
-      if (/^\s*[[{]/.test(stdout)) {
-        return stdout;
-      }
-    }
-    throw error;
-  }
 }

--- a/src/scripts/review-clause.mts
+++ b/src/scripts/review-clause.mts
@@ -14,20 +14,20 @@
 // from here too -- this file has no behavior of its own beyond what both
 // callers already relied on before the extraction.
 //
-// Kept deliberately small (only depends on `gh-exec.mts`'s shared
-// `ghGraphql`, `protocol-helpers.mts`'s shared `isCopilotReviewerLogin`,
-// and -- as of #1880 -- `markdown-code.mts`'s shared
-// `stripMarkdownCodeRegions`) so a read-only, low-dependency caller like
-// `rerun-advisory-convergence.mts` can import it without also pulling in
-// `advisory-convergence.mts`'s full claim/waiver/disposition machinery --
-// see that file's own module-header "Reuse map" comment. The first two
-// dependencies are already reused directly by `rerun-advisory-convergence.mts`
-// itself today; `markdown-code.mts` has no imports of its own, so this adds
-// no heavy dependency surface to that caller either.
+// Kept deliberately small (only depends on `provider-adapter-github.mts`'s
+// shared GitHub port adapter -- #2267, replacing the direct `ghGraphql`
+// call this file used before -- `protocol-helpers.mts`'s shared
+// `isCopilotReviewerLogin`, and -- as of #1880 -- `markdown-code.mts`'s
+// shared `stripMarkdownCodeRegions`) so a read-only, low-dependency caller
+// like `rerun-advisory-convergence.mts` can import it without also pulling
+// in `advisory-convergence.mts`'s full claim/waiver/disposition machinery
+// -- see that file's own module-header "Reuse map" comment. `markdown-
+// code.mts` has no imports of its own, so this adds no heavy dependency
+// surface to that caller either.
 
-import { ghGraphql } from './gh-exec.mts';
 import { stripMarkdownCodeRegions } from './markdown-code.mts';
 import { isCopilotReviewerLogin } from './protocol-helpers.mts';
+import { createGithubProviderAdapter } from './provider-adapter-github.mts';
 
 /** Minimal GitHub GraphQL author payload shape consumed here. `__typename`
  * distinguishes a genuine `Bot` account from a same-named `User` masquerade
@@ -81,26 +81,6 @@ export interface AdvisoryConvergenceReviewClause {
    * off-HEAD). See {@link parseSuppressedCommentCount}. */
   suppressedCount: number;
   satisfied: boolean;
-}
-
-/** GraphQL pagination cursor block, local to this file's own `reviews`
- * pagination -- a separate, unexported copy of the same tiny shape other
- * `advisory-convergence.mts` pagination loops (that stayed in that file)
- * also use, rather than a cross-module import for a 2-field type. */
-interface PageInfoPayload {
-  hasNextPage?: boolean | null;
-  endCursor?: string | null;
-}
-
-/** Raw GraphQL `reviews` connection node, before normalization into
- * {@link ReviewPayload}. */
-interface RawReviewNode {
-  id?: string | null;
-  commit?: { oid?: string | null } | null;
-  submittedAt?: string | null;
-  author?: GhAuthorPayload | null;
-  comments?: { totalCount?: number | null } | null;
-  body?: string | null;
 }
 
 /** Matches GitHub Copilot's `<summary>Suppressed comments (N)</summary>`
@@ -243,85 +223,30 @@ export function resolveLatestCopilotReviewClause(
 
 /**
  * Fetch every PR review (paginated) plus the current HEAD commit's
- * `committedDate`, via the same GraphQL query `advisory-convergence.mts`'s
- * own Clause 1 evidence collection has always used.
+ * `committedDate`, via {@link ProviderPort.getChangeRequestReviewsWithHeadCommitDate}
+ * (#2267) -- the same GraphQL query `advisory-convergence.mts`'s own
+ * Clause 1 evidence collection has always used, now routed through the
+ * GitHub provider adapter instead of a direct `ghGraphql` call. Keeps its
+ * pre-migration `(owner, repo, prNumber)` signature unchanged: the
+ * out-of-scope `rerun-advisory-convergence.mts` caller (see this file's
+ * module header) also relies on this exact call shape.
  */
 export function fetchReviewsAndHeadCommit(
   owner: string,
   repo: string,
   prNumber: number,
 ): { reviews: ReviewPayload[]; headCommittedAt: string } {
-  const nodes: RawReviewNode[] = [];
-  let headCommittedAt = '';
-  let cursor: string | null | undefined = null;
-
-  // Paginate `reviews`: a PR with more than one page of reviews would
-  // otherwise silently evaluate Clause 1 against only the first 100,
-  // potentially missing a later, dirty, current-HEAD review (see PR #1343
-  // review). `commits(last: 1)` is fetched once, on the first page, since
-  // it never changes across pages.
-  while (true) {
-    const payload = ghGraphql(
-      `
-        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
-          repository(owner: $owner, name: $repo) {
-            pullRequest(number: $number) {
-              reviews(first: 100, after: $cursor) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  id
-                  commit { oid }
-                  submittedAt
-                  author { login __typename }
-                  comments { totalCount }
-                  body
-                }
-              }
-              commits(last: 1) {
-                nodes { commit { committedDate } }
-              }
-            }
-          }
-        }`,
-      { owner, repo, number: prNumber, cursor },
-    ) as {
-      data?: {
-        repository?: {
-          pullRequest?: {
-            reviews?: {
-              pageInfo?: PageInfoPayload | null;
-              nodes?: RawReviewNode[] | null;
-            } | null;
-            commits?: {
-              nodes?: { commit?: { committedDate?: string | null } | null }[];
-            } | null;
-          } | null;
-        } | null;
-      } | null;
-    };
-
-    const pullRequest = payload?.data?.repository?.pullRequest;
-    nodes.push(...(pullRequest?.reviews?.nodes ?? []));
-    if (!headCommittedAt) {
-      headCommittedAt = String(
-        pullRequest?.commits?.nodes?.[0]?.commit?.committedDate ?? '',
-      );
-    }
-
-    if (!pullRequest?.reviews?.pageInfo?.hasNextPage) break;
-    if (!pullRequest.reviews.pageInfo.endCursor) {
-      throw new Error('review pagination payload is missing endCursor');
-    }
-    cursor = pullRequest.reviews.pageInfo.endCursor;
-  }
-
+  const { reviews: nodes, headCommittedAt } = createGithubProviderAdapter(
+    owner,
+    repo,
+  ).getChangeRequestReviewsWithHeadCommitDate(prNumber);
   const reviews = nodes.map((node) => ({
-    id: node.id ?? null,
-    author: node.author ?? null,
-    submittedAt: node.submittedAt ?? null,
-    commitId: node.commit?.oid ?? null,
-    itemCount: node.comments?.totalCount ?? null,
-    body: node.body ?? null,
+    id: node.id || null,
+    author: { login: node.authorLogin, __typename: node.authorTypename },
+    submittedAt: node.submittedAt,
+    commitId: node.commitId,
+    itemCount: node.commentCount,
+    body: node.body,
   }));
   return { reviews, headCommittedAt };
 }

--- a/src/scripts/review-clause.mts
+++ b/src/scripts/review-clause.mts
@@ -28,6 +28,7 @@
 import { stripMarkdownCodeRegions } from './markdown-code.mts';
 import { isCopilotReviewerLogin } from './protocol-helpers.mts';
 import { createGithubProviderAdapter } from './provider-adapter-github.mts';
+import type { ProviderPort } from './provider-port.mts';
 
 /** Minimal GitHub GraphQL author payload shape consumed here. `__typename`
  * distinguishes a genuine `Bot` account from a same-named `User` masquerade
@@ -226,20 +227,26 @@ export function resolveLatestCopilotReviewClause(
  * `committedDate`, via {@link ProviderPort.getChangeRequestReviewsWithHeadCommitDate}
  * (#2267) -- the same GraphQL query `advisory-convergence.mts`'s own
  * Clause 1 evidence collection has always used, now routed through the
- * GitHub provider adapter instead of a direct `ghGraphql` call. Keeps its
- * pre-migration `(owner, repo, prNumber)` signature unchanged: the
- * out-of-scope `rerun-advisory-convergence.mts` caller (see this file's
- * module header) also relies on this exact call shape.
+ * GitHub provider adapter instead of a direct `ghGraphql` call. Extended
+ * additively with an optional trailing `port` (defaults to
+ * `createGithubProviderAdapter(owner, repo)`): every existing caller
+ * (this file's own out-of-scope `rerun-advisory-convergence.mts`,
+ * `pre-merge-readiness.mts`, `advisory-convergence.mts`) still calls this
+ * with the unchanged 3-arg `(owner, repo, prNumber)` shape, so the
+ * injection is invisible to them -- it exists so a caller that already
+ * holds its own fake-backed `ProviderPort` (e.g. a test driving
+ * `pre-merge-readiness.mts`'s `collectPreMergeReadiness` end to end) can
+ * pass it through instead of this function constructing its own live
+ * adapter.
  */
 export function fetchReviewsAndHeadCommit(
   owner: string,
   repo: string,
   prNumber: number,
+  port: ProviderPort = createGithubProviderAdapter(owner, repo),
 ): { reviews: ReviewPayload[]; headCommittedAt: string } {
-  const { reviews: nodes, headCommittedAt } = createGithubProviderAdapter(
-    owner,
-    repo,
-  ).getChangeRequestReviewsWithHeadCommitDate(prNumber);
+  const { reviews: nodes, headCommittedAt } =
+    port.getChangeRequestReviewsWithHeadCommitDate(prNumber);
   const reviews = nodes.map((node) => ({
     id: node.id || null,
     author: { login: node.authorLogin, __typename: node.authorTypename },

--- a/tests/advisory-convergence-fake-provider.test.mts
+++ b/tests/advisory-convergence-fake-provider.test.mts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import {
+  collectFromGitHub,
+  parseArgs,
+} from '../src/scripts/advisory-convergence.mts';
+import { createFakeProviderAdapter } from '../src/scripts/provider-adapter-fake.mts';
+
+// ---------------------------------------------------------------------------
+// Fake-provider collection wiring (#2267 AC4: "unit tests exercise the
+// PR-facing state machine with a fake provider ... including unsupported
+// capability, and explicit advisory not_applicable ... without network
+// access"). collectFromGitHub is the one function in this file that talks
+// to a provider at all; runAdvisoryConvergence's own tests inject their own
+// deps.collect and never exercise it. This suite drives it in-process
+// against createFakeProviderAdapter via its createPort injection seam --
+// zero gh subprocess, zero network -- covering the two scenarios this
+// commit's new capability-coercion wiring can produce (an
+// advisory-review-unsupported provider forcing reviewPolicy to
+// 'no-advisory', and a fully-supported provider leaving it untouched), plus
+// one assertion that a Copilot-authored unresolved thread survives the
+// listChangeRequestReviewThreadsWithAuthorType -> ReviewThreadPayload shim
+// this migration introduced. The pure computeAdvisoryConvergenceVerdict
+// state machine itself is already covered exhaustively by
+// tests/advisory-convergence.test.mts's own direct unit tests.
+// ---------------------------------------------------------------------------
+
+const PR_NUMBER = 42;
+
+function withHermeticCwd<T>(run: () => T): T {
+  const cwdRoot = mkdtempSync(join(tmpdir(), 'idd-advisory-convergence-fake-'));
+  const originalCwd = process.cwd();
+  try {
+    // collectFromGitHub resolves every policy read (.github/idd/config.json)
+    // relative to process.cwd(), not this script's location -- an unpatched
+    // cwd would read this repo's own live config during the test (same
+    // rationale as pre-merge-readiness-collection-smoke.test.mts's own
+    // empty-cwd fixture).
+    process.chdir(cwdRoot);
+    return run();
+  } finally {
+    process.chdir(originalCwd);
+    rmSync(cwdRoot, { recursive: true, force: true });
+  }
+}
+
+function baseFixture() {
+  return {
+    changeRequestConvergenceViews: {
+      [PR_NUMBER]: {
+        headSha: 'a'.repeat(40),
+        headRefName: 'issue/42-example',
+        authorLogin: 'author-user',
+        url: `https://github.com/o/r/pull/${PR_NUMBER}`,
+        closingIssuesReferences: [],
+      },
+    },
+    reviewsWithHeadCommitDate: {
+      [PR_NUMBER]: { reviews: [], headCommittedAt: '2026-07-31T23:00:00Z' },
+    },
+  };
+}
+
+test('collectFromGitHub against a fake provider without advisory-review support coerces reviewPolicy to no-advisory', () => {
+  withHermeticCwd(() => {
+    const port = createFakeProviderAdapter({
+      ...baseFixture(),
+      capabilityDeclarations: [
+        { group: 'advisory-review', requirement: 'optional', supported: false },
+      ],
+    });
+
+    const { options } = collectFromGitHub(
+      parseArgs(['--pr', String(PR_NUMBER), '--owner', 'o', '--repo', 'r']),
+      () => port,
+    );
+
+    assert.equal(options.reviewPolicy, 'no-advisory');
+  });
+});
+
+test('collectFromGitHub against a fake provider with every capability supported (the GitHub adapter posture) never coerces reviewPolicy', () => {
+  withHermeticCwd(() => {
+    const port = createFakeProviderAdapter(baseFixture());
+
+    const { options } = collectFromGitHub(
+      parseArgs(['--pr', String(PR_NUMBER), '--owner', 'o', '--repo', 'r']),
+      () => port,
+    );
+
+    // No .github/idd/config.json under the hermetic cwd, so rawConfig has
+    // no reviewPolicy of its own either -- this asserts the capability
+    // check itself stays inert (never forces 'no-advisory'), not merely
+    // that some other default happened to already be 'no-advisory'.
+    assert.notEqual(options.reviewPolicy, 'no-advisory');
+  });
+});
+
+test('collectFromGitHub threads a Copilot-authored unresolved thread through listChangeRequestReviewThreadsWithAuthorType, with no gh process spawned', () => {
+  withHermeticCwd(() => {
+    const port = createFakeProviderAdapter({
+      ...baseFixture(),
+      reviewThreadsWithAuthorType: {
+        [PR_NUMBER]: [
+          {
+            id: 'RT_1',
+            isResolved: false,
+            comments: [
+              {
+                body: 'please address this',
+                createdAt: '2026-07-31T09:00:00Z',
+                updatedAt: '2026-07-31T09:00:00Z',
+                authorLogin: 'copilot',
+                authorTypename: 'Bot',
+                pullRequestReviewId: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const { inputs } = collectFromGitHub(
+      parseArgs(['--pr', String(PR_NUMBER), '--owner', 'o', '--repo', 'r']),
+      () => port,
+    );
+
+    assert.equal(inputs.threads?.length, 1);
+    const [thread] = inputs.threads ?? [];
+    assert.equal(thread.id, 'RT_1');
+    assert.equal(thread.isResolved, false);
+    assert.equal(thread.comments?.nodes[0]?.author?.login, 'copilot');
+    assert.equal(thread.comments?.nodes[0]?.author?.__typename, 'Bot');
+  });
+});

--- a/tests/discover-shared-file-overlap.test.mts
+++ b/tests/discover-shared-file-overlap.test.mts
@@ -326,6 +326,7 @@ test('toClaimComment maps ProviderComment.authorLogin into the author field reso
     id: 1,
     body: '<!-- claimed-by: agent-x claim-abc supersedes: none 2026-06-25T00:00:00Z branch: issue/1-x -->',
     createdAt: '2026-06-25T00:00:00Z',
+    updatedAt: '2026-06-25T00:00:00Z',
     authorLogin: 'kurone-kito',
   };
   const mapped = toClaimComment(comment);

--- a/tests/gh-pagination-parsing-smoke.test.mts
+++ b/tests/gh-pagination-parsing-smoke.test.mts
@@ -227,16 +227,18 @@ test('review-activity-snapshot.mjs CLI: parses multi-line NDJSON output from pag
       JSON.stringify({ headRefOid: HEAD_SHA, author: { login: 'pr-author' } }),
     ],
     [
+      // #2267: routed through provider-port.mts's listChangeRequestChecks
+      // now -- `--repo` (not `-R`) and no trailing `--jq '.'` (a no-op
+      // identity filter on the already-JSON `--json` array), but the same
+      // underlying `gh pr checks` call.
       JSON.stringify([
         'pr',
         'checks',
         '42',
-        '-R',
+        '--repo',
         REPO_REF,
         '--json',
         'name,state,completedAt',
-        '--jq',
-        '.',
       ]),
       '[]',
     ],

--- a/tests/pre-merge-readiness-collection-smoke.test.mts
+++ b/tests/pre-merge-readiness-collection-smoke.test.mts
@@ -97,28 +97,23 @@ test('normalizeReview maps REST review fields, deriving createdAt from submitted
   );
 });
 
-test('normalizeThread maps GraphQL review-thread fields, including nested comment nodes', () => {
+test('normalizeThread maps a ProviderPort review-thread node, including nested comments', () => {
   assert.deepEqual(
     normalizeThread({
-      id: 'RT_1',
       isResolved: false,
-      comments: {
-        pageInfo: { hasNextPage: false },
-        nodes: [
-          {
-            body: 'nit: rename this',
-            createdAt: '2026-07-31T09:00:00Z',
-            author: { login: 'reviewer-user' },
-            pullRequestReview: { id: 'PRR_1' },
-          },
-        ],
-      },
+      comments: [
+        {
+          body: 'nit: rename this',
+          createdAt: '2026-07-31T09:00:00Z',
+          updatedAt: '',
+          authorLogin: 'reviewer-user',
+          pullRequestReviewId: 'PRR_1',
+        },
+      ],
     }),
     {
-      id: 'RT_1',
       isResolved: false,
       updatedAt: '',
-      reviewerReopenedAt: '',
       comments: {
         pageInfo: { hasNextPage: false },
         nodes: [
@@ -438,13 +433,22 @@ test('pre-merge-readiness.mjs CLI: clean scenario collects and normalizes raw gh
     },
   ]);
 
-  // normalizeThread: id/isResolved flow into dispositionEvidence.missingThreads.
+  // normalizeThread: isResolved flows into dispositionEvidence.missingThreads.
+  // #2267: `id` is now the `thread-${index+1}` fallback, not the raw GraphQL
+  // node id -- `ProviderPort.listChangeRequestReviewThreadsWithComments`
+  // (byte-identical query, shared with the already-migrated
+  // review-activity-snapshot.mts) does not surface it, matching that file's
+  // own already-reviewed `normalizeThread`. This id is diagnostic-only in
+  // this report: `advisory-convergence.mts` (the one real id-matching
+  // consumer, `copilotThreadIds.has(thread.id)`) fetches its own,
+  // independent `threads` array via its own port method and never reads
+  // this file's output.
   const threads = report.threads as { unresolvedCount: number };
   assert.equal(threads.unresolvedCount, 0);
   const dispositionEvidence = report.dispositionEvidence as {
     missingThreads: { id: string; isResolved: boolean }[];
   };
-  assert.equal(dispositionEvidence.missingThreads[0]?.id, 'RT_1');
+  assert.equal(dispositionEvidence.missingThreads[0]?.id, 'thread-1');
   assert.equal(dispositionEvidence.missingThreads[0]?.isResolved, true);
 
   // #2042: `fetchReviewsAndHeadCommit`'s own `gh api graphql` call must

--- a/tests/pre-merge-readiness-collection-smoke.test.mts
+++ b/tests/pre-merge-readiness-collection-smoke.test.mts
@@ -13,11 +13,13 @@ import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
+  collectPreMergeReadiness,
   normalizeClaimComment,
   normalizeComment,
   normalizeReview,
   normalizeThread,
 } from '../src/scripts/pre-merge-readiness.mts';
+import { createFakeProviderAdapter } from '../src/scripts/provider-adapter-fake.mts';
 
 const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
 
@@ -625,4 +627,113 @@ test('pre-merge-readiness.mjs CLI: blocked scenario (one unresolved review threa
     blockers.some((blocker) => blocker.gate === 'unresolved-threads'),
     `expected an "unresolved-threads" blocker, got: ${JSON.stringify(blockers)}`,
   );
+});
+
+// ---------------------------------------------------------------------------
+// Fake-provider collection wiring (#2267 AC4: "unit tests exercise the
+// PR-facing state machine with a fake provider ... without network access").
+// The stub-gh CLI tests above already exercise the real, built .mjs process
+// end to end; this test instead drives collectPreMergeReadiness IN-PROCESS
+// against createFakeProviderAdapter -- proving createPort's injection seam
+// actually wires every port call this file makes through to a fake, with
+// zero gh subprocess and zero live network access. Deliberately narrow (one
+// blocked scenario covering the two AC4-named conditions this file's own
+// state machine can produce: an unreadable CI/branch-governance read and an
+// unresolved review thread) -- the pure summarizer's exhaustive gate matrix
+// is already covered by buildPreMergeReadinessSummary's own direct unit
+// tests above in tests/pre-merge-readiness.test.mts.
+// ---------------------------------------------------------------------------
+
+test('collectPreMergeReadiness against a fake provider: unreadable CI governance + an unresolved thread block, with no gh process spawned', () => {
+  const cwdRoot = mkdtempSync(join(tmpdir(), 'idd-pre-merge-fake-provider-'));
+  const originalCwd = process.cwd();
+  try {
+    // Hermetic: an unpatched cwd would read THIS repo's own live
+    // .github/idd/config.json (mergePolicy: fully_autonomous_merge, etc.)
+    // during collection, since collectPreMergeReadiness resolves every
+    // policy read relative to process.cwd(), not this script's location
+    // (same rationale as runPreMergeReadinessSmoke's empty cwdRoot above).
+    process.chdir(cwdRoot);
+
+    const port = createFakeProviderAdapter({
+      changeRequestReadinessSnapshots: {
+        42: {
+          headSha: 'a'.repeat(40),
+          baseRefName: 'main',
+          url: 'https://github.com/o/r/pull/42',
+          authorLogin: 'author-user',
+          reviewDecision: null,
+          statusCheckRollup: [
+            {
+              __typename: 'CheckRun',
+              name: 'lint',
+              status: 'COMPLETED',
+              conclusion: 'SUCCESS',
+              completedAt: '2026-08-01T00:00:00Z',
+              workflowName: 'CI',
+            },
+          ],
+          mergeable: 'MERGEABLE',
+          mergeStateStatus: 'CLEAN',
+          closingIssuesReferences: [],
+        },
+      },
+      // listBranchRules/getBranchProtection deliberately absent -- the fake
+      // resolves both to {outcome:'not-found'}, which fetchGovernanceJson
+      // (trustEmptyProtectionReads defaults to false with no config.json)
+      // classifies as unreadable, producing a real "ci" blocker without
+      // needing to replicate a required-check-mismatch fixture.
+      reviewThreadsWithComments: {
+        42: [
+          {
+            isResolved: false,
+            comments: [
+              {
+                body: 'please address this',
+                createdAt: '2026-07-31T09:00:00Z',
+                updatedAt: '2026-07-31T09:00:00Z',
+                authorLogin: 'reviewer-user',
+                pullRequestReviewId: null,
+              },
+            ],
+          },
+        ],
+      },
+      reviewsWithHeadCommitDate: {
+        42: { reviews: [], headCommittedAt: '2026-07-31T23:00:00Z' },
+      },
+    });
+
+    const report = collectPreMergeReadiness(
+      [
+        '--pr',
+        '42',
+        '--claimless',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--now',
+        '2026-08-01T00:00:00Z',
+      ],
+      () => port,
+    );
+
+    const ciReport = report.ci as { protectionReadsUnreadable: boolean };
+    assert.equal(ciReport.protectionReadsUnreadable, true);
+    const threadsReport = report.threads as { unresolvedCount: number };
+    assert.equal(threadsReport.unresolvedCount, 1);
+    const blockers = report.blockers as { gate: string }[];
+    assert.ok(
+      blockers.some((blocker) => blocker.gate === 'ci'),
+      `expected a "ci" blocker, got: ${JSON.stringify(blockers)}`,
+    );
+    assert.ok(
+      blockers.some((blocker) => blocker.gate === 'unresolved-threads'),
+      `expected an "unresolved-threads" blocker, got: ${JSON.stringify(blockers)}`,
+    );
+  } finally {
+    process.chdir(originalCwd);
+    rmSync(cwdRoot, { recursive: true, force: true });
+  }
 });

--- a/tests/pre-merge-readiness-collection-smoke.test.mts
+++ b/tests/pre-merge-readiness-collection-smoke.test.mts
@@ -737,3 +737,91 @@ test('collectPreMergeReadiness against a fake provider: unreadable CI governance
     rmSync(cwdRoot, { recursive: true, force: true });
   }
 });
+
+test('collectPreMergeReadiness against a fake provider: a required check reporting FAILURE blocks readiness, with readable governance and no gh process spawned', () => {
+  // Complements the "unreadable CI governance" fake-provider test above
+  // (#2267 AC4 review): that test's protectionReadsUnreadable: true short-
+  // circuits the CI gate before any individual check's conclusion is ever
+  // classified, so it cannot exercise summarizeRequiredChecks's own
+  // pending/failing-check path. This test instead supplies a readable
+  // branchRules fixture naming "lint" as required, then reports a
+  // COMPLETED/FAILURE check-run for it -- classifyCiChecks
+  // (protocol-helpers.mts) buckets that as status: 'failed', which is
+  // distinct from the unreadable-governance case's own generic "not all
+  // passing" cause.
+  const cwdRoot = mkdtempSync(join(tmpdir(), 'idd-pre-merge-fake-ci-failed-'));
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(cwdRoot);
+
+    const port = createFakeProviderAdapter({
+      changeRequestReadinessSnapshots: {
+        42: {
+          headSha: 'a'.repeat(40),
+          baseRefName: 'main',
+          url: 'https://github.com/o/r/pull/42',
+          authorLogin: 'author-user',
+          reviewDecision: null,
+          statusCheckRollup: [
+            {
+              __typename: 'CheckRun',
+              name: 'lint',
+              status: 'COMPLETED',
+              conclusion: 'FAILURE',
+              completedAt: '2026-08-01T00:00:00Z',
+              workflowName: 'CI',
+            },
+          ],
+          mergeable: 'MERGEABLE',
+          mergeStateStatus: 'CLEAN',
+          closingIssuesReferences: [],
+        },
+      },
+      branchRules: {
+        'o/r/main': [
+          {
+            type: 'required_status_checks',
+            parameters: { required_status_checks: [{ context: 'lint' }] },
+          },
+        ],
+      },
+      branchProtection: { 'o/r/main': {} },
+      reviewThreadsWithComments: { 42: [] },
+      reviewsWithHeadCommitDate: {
+        42: { reviews: [], headCommittedAt: '2026-07-31T23:00:00Z' },
+      },
+    });
+
+    const report = collectPreMergeReadiness(
+      [
+        '--pr',
+        '42',
+        '--claimless',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--now',
+        '2026-08-01T00:00:00Z',
+      ],
+      () => port,
+    );
+
+    const ciReport = report.ci as {
+      protectionReadsUnreadable: boolean;
+      status: string;
+      requiredChecksPassing: boolean;
+    };
+    assert.equal(ciReport.protectionReadsUnreadable, false);
+    assert.equal(ciReport.status, 'failed');
+    assert.equal(ciReport.requiredChecksPassing, false);
+    const blockers = report.blockers as { gate: string }[];
+    assert.ok(
+      blockers.some((blocker) => blocker.gate === 'ci'),
+      `expected a "ci" blocker, got: ${JSON.stringify(blockers)}`,
+    );
+  } finally {
+    process.chdir(originalCwd);
+    rmSync(cwdRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/provider-adapter-fake.test.mts
+++ b/tests/provider-adapter-fake.test.mts
@@ -64,3 +64,46 @@ test('closeWorkItem stores lowercase state, matching the fixture convention', ()
   port.closeWorkItem(1, 'done');
   assert.equal(workItems[1].state, 'closed');
 });
+
+// #2267 additions below.
+
+test('listBranchRules and getBranchProtection default to not-found for an absent fixture key', () => {
+  const port = createFakeProviderAdapter({});
+  assert.deepEqual(port.listBranchRules('o', 'r', 'main'), {
+    outcome: 'not-found',
+  });
+  assert.deepEqual(port.getBranchProtection('o', 'r', 'main'), {
+    outcome: 'not-found',
+  });
+});
+
+test('mergeChangeRequest and mergeChangeRequestAtRepo record distinct owner/repo/admin flags', () => {
+  const fixture: Parameters<typeof createFakeProviderAdapter>[0] = {
+    locator: { provider: 'github', owner: 'ambient', name: 'repo' },
+  };
+  const port = createFakeProviderAdapter(fixture);
+  port.mergeChangeRequest(1, 'sha1');
+  port.mergeChangeRequestAdmin(2, 'sha2');
+  port.mergeChangeRequestAtRepo('other', 'repo2', 3, 'sha3');
+  assert.deepEqual(fixture.mergedChangeRequestCalls, [
+    {
+      owner: 'ambient',
+      repo: 'repo',
+      number: 1,
+      headSha: 'sha1',
+      admin: false,
+    },
+    { owner: 'ambient', repo: 'repo', number: 2, headSha: 'sha2', admin: true },
+    { owner: 'other', repo: 'repo2', number: 3, headSha: 'sha3', admin: false },
+  ]);
+});
+
+test('resolveChangeRequestReviewThread throws for a thread id in unresolvableReviewThreadIds, otherwise records it', () => {
+  const fixture: Parameters<typeof createFakeProviderAdapter>[0] = {
+    unresolvableReviewThreadIds: new Set(['T_stuck']),
+  };
+  const port = createFakeProviderAdapter(fixture);
+  assert.throws(() => port.resolveChangeRequestReviewThread('T_stuck'));
+  port.resolveChangeRequestReviewThread('T_ok');
+  assert.deepEqual(fixture.resolvedReviewThreadIds, ['T_ok']);
+});

--- a/tests/provider-adapter-fake.test.mts
+++ b/tests/provider-adapter-fake.test.mts
@@ -181,15 +181,30 @@ test('listWorkflowRuns honors limit, matching the GitHub adapter', () => {
   const port = createFakeProviderAdapter({
     workflowRunLists: {
       'o/r/CI': [
-        { id: 1, conclusion: 'success', status: 'completed', createdAt: '' },
-        { id: 2, conclusion: 'success', status: 'completed', createdAt: '' },
-        { id: 3, conclusion: 'success', status: 'completed', createdAt: '' },
+        {
+          id: '1',
+          conclusion: 'success',
+          status: 'completed',
+          createdAt: '',
+        },
+        {
+          id: '2',
+          conclusion: 'success',
+          status: 'completed',
+          createdAt: '',
+        },
+        {
+          id: '3',
+          conclusion: 'success',
+          status: 'completed',
+          createdAt: '',
+        },
       ],
     },
   });
   assert.deepEqual(
     port.listWorkflowRuns('o', 'r', 'CI', 2).map((run) => run.id),
-    [1, 2],
+    ['1', '2'],
   );
 });
 

--- a/tests/provider-adapter-fake.test.mts
+++ b/tests/provider-adapter-fake.test.mts
@@ -131,3 +131,35 @@ test('listCapabilityDeclarations honors a fixture override simulating a provider
     { group: 'advisory-review', requirement: 'optional', supported: false },
   ]);
 });
+
+// resolveViewerLoginSafeQuiet / listMergedChangeRequests (Copilot review,
+// PR #2429): both diverged from the GitHub adapter's own behavior in code
+// the fake adapter's own suite otherwise never exercised, which could let
+// a collection-wiring test pass against unrealistic fake-provider output.
+test('resolveViewerLoginSafeQuiet normalizes a fixture login, matching the GitHub adapter', () => {
+  const port = createFakeProviderAdapter({
+    viewerLogin: '  Some-User  ',
+  });
+  assert.deepEqual(port.resolveViewerLoginSafeQuiet(), {
+    viewerLogin: 'some-user',
+    viewerLoginUnavailable: false,
+  });
+});
+
+test('listMergedChangeRequests honors both limit and sinceDate, matching the GitHub adapter', () => {
+  const port = createFakeProviderAdapter({
+    mergedChangeRequests: [
+      { number: 1, mergedAt: '2026-01-01T00:00:00Z' },
+      { number: 2, mergedAt: '2026-02-01T00:00:00Z' },
+      { number: 3, mergedAt: '2026-03-01T00:00:00Z' },
+    ],
+  });
+  assert.deepEqual(
+    port.listMergedChangeRequests(2, null).map((row) => row.number),
+    [1, 2],
+  );
+  assert.deepEqual(
+    port.listMergedChangeRequests(10, '2026-02-01').map((row) => row.number),
+    [2, 3],
+  );
+});

--- a/tests/provider-adapter-fake.test.mts
+++ b/tests/provider-adapter-fake.test.mts
@@ -163,3 +163,61 @@ test('listMergedChangeRequests honors both limit and sinceDate, matching the Git
     [2, 3],
   );
 });
+
+// getWorkflowRun / listWorkflowRuns / getRepositoryDefaultBranch /
+// getChangeRequestReviewsWithHeadCommitDate (Copilot review, PR #2429,
+// rounds 2-3): the same fail-open-instead-of-throw and ignored-parameter
+// gaps, caught by sweeping every #2267-added method against the GitHub
+// adapter and port declarations before pushing a third round.
+test('getWorkflowRun throws on a missing fixture, matching the GitHub adapter', () => {
+  const port = createFakeProviderAdapter({
+    workflowRuns: { 'o/r/123': { id: 123 } },
+  });
+  assert.deepEqual(port.getWorkflowRun('o', 'r', 123), { id: 123 });
+  assert.throws(() => port.getWorkflowRun('o', 'r', 456), /no workflow-run/);
+});
+
+test('listWorkflowRuns honors limit, matching the GitHub adapter', () => {
+  const port = createFakeProviderAdapter({
+    workflowRunLists: {
+      'o/r/CI': [
+        { id: 1, conclusion: 'success', status: 'completed', createdAt: '' },
+        { id: 2, conclusion: 'success', status: 'completed', createdAt: '' },
+        { id: 3, conclusion: 'success', status: 'completed', createdAt: '' },
+      ],
+    },
+  });
+  assert.deepEqual(
+    port.listWorkflowRuns('o', 'r', 'CI', 2).map((run) => run.id),
+    [1, 2],
+  );
+});
+
+test('getRepositoryDefaultBranch accepts owner/repo, matching the port arity', () => {
+  const port = createFakeProviderAdapter({ repositoryDefaultBranch: 'main' });
+  assert.equal(port.getRepositoryDefaultBranch('o', 'r'), 'main');
+});
+
+test('getChangeRequestReviewsWithHeadCommitDate throws on a missing fixture, matching the GitHub adapter', () => {
+  const port = createFakeProviderAdapter({
+    reviewsWithHeadCommitDate: {
+      42: { reviews: [], headCommittedAt: '2026-07-31T23:00:00Z' },
+    },
+  });
+  assert.deepEqual(port.getChangeRequestReviewsWithHeadCommitDate(42), {
+    reviews: [],
+    headCommittedAt: '2026-07-31T23:00:00Z',
+  });
+  assert.throws(
+    () => port.getChangeRequestReviewsWithHeadCommitDate(43),
+    /no reviews\/head-commit-date/,
+  );
+});
+
+test('resolveViewerAppSlugSafe trims a fixture app slug, matching the GitHub adapter', () => {
+  const port = createFakeProviderAdapter({ viewerAppSlug: '  my-app  ' });
+  assert.deepEqual(port.resolveViewerAppSlugSafe(), {
+    appSlug: 'my-app',
+    unavailable: false,
+  });
+});

--- a/tests/provider-adapter-fake.test.mts
+++ b/tests/provider-adapter-fake.test.mts
@@ -107,3 +107,27 @@ test('resolveChangeRequestReviewThread throws for a thread id in unresolvableRev
   port.resolveChangeRequestReviewThread('T_ok');
   assert.deepEqual(fixture.resolvedReviewThreadIds, ['T_ok']);
 });
+
+test('listCapabilityDeclarations defaults to every group supported, matching the GitHub adapter posture', () => {
+  const port = createFakeProviderAdapter({});
+  const declarations = port.listCapabilityDeclarations();
+  assert.equal(declarations.length, 11);
+  assert.ok(
+    declarations.every((declaration) => declaration.supported === true),
+  );
+  const advisoryReview = declarations.find(
+    (declaration) => declaration.group === 'advisory-review',
+  );
+  assert.equal(advisoryReview?.requirement, 'optional');
+});
+
+test('listCapabilityDeclarations honors a fixture override simulating a provider without advisory review', () => {
+  const port = createFakeProviderAdapter({
+    capabilityDeclarations: [
+      { group: 'advisory-review', requirement: 'optional', supported: false },
+    ],
+  });
+  assert.deepEqual(port.listCapabilityDeclarations(), [
+    { group: 'advisory-review', requirement: 'optional', supported: false },
+  ]);
+});

--- a/tests/provider-adapter-github.test.mts
+++ b/tests/provider-adapter-github.test.mts
@@ -1302,3 +1302,96 @@ test('getChangeRequestReviewsWithHeadCommitDate paginates reviews and fetches he
   });
   assert.equal(call, 2);
 });
+
+test('getChangeRequestAuthor maps login/__typename, and null when absent', () => {
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: { author: { login: 'octocat', __typename: 'User' } },
+            },
+          },
+        }),
+    }),
+  );
+  assert.deepEqual(port.getChangeRequestAuthor(7), {
+    login: 'octocat',
+    typename: 'User',
+  });
+
+  const absentPort = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify({ data: { repository: { pullRequest: {} } } }),
+    }),
+  );
+  assert.equal(absentPort.getChangeRequestAuthor(7), null);
+});
+
+test('listChangeRequestReviewThreadsWithAuthorType selects author.__typename, distinct from listChangeRequestReviewThreadsWithComments', () => {
+  const singlePage = JSON.stringify({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            nodes: [
+              {
+                id: 't1',
+                isResolved: false,
+                comments: {
+                  nodes: [
+                    {
+                      body: 'hi',
+                      createdAt: '2026-01-01T00:00:00Z',
+                      updatedAt: '2026-01-01T00:00:00Z',
+                      author: { login: 'copilot', __typename: 'Bot' },
+                      pullRequestReview: { id: 'PRR_1' },
+                    },
+                  ],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    },
+  });
+  let capturedQuery: string | undefined;
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: (args) => {
+        capturedQuery = args.find((arg) =>
+          arg.startsWith('query=query($owner'),
+        );
+        return singlePage;
+      },
+    }),
+  );
+  assert.deepEqual(port.listChangeRequestReviewThreadsWithAuthorType(7), [
+    {
+      id: 't1',
+      isResolved: false,
+      comments: [
+        {
+          body: 'hi',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+          authorLogin: 'copilot',
+          authorTypename: 'Bot',
+          pullRequestReviewId: 'PRR_1',
+        },
+      ],
+    },
+  ]);
+  assert.match(capturedQuery ?? '', /author \{ login __typename \}/);
+});

--- a/tests/provider-adapter-github.test.mts
+++ b/tests/provider-adapter-github.test.mts
@@ -1430,3 +1430,22 @@ test('listMergedChangeRequests builds the merged pr-list args, with and without 
   assert.ok(capturedArgs?.includes('--search'));
   assert.ok(capturedArgs?.includes('merged:>=2026-01-01'));
 });
+
+test('getWorkflowRun preserves a string runId above Number.MAX_SAFE_INTEGER exactly (regression guard)', () => {
+  let capturedArgs: string[] | undefined;
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: (args) => {
+        capturedArgs = args;
+        return '{}';
+      },
+    }),
+  );
+  port.getWorkflowRun('o', 'r', '9007199254740993');
+  assert.ok(
+    capturedArgs?.includes('repos/o/r/actions/runs/9007199254740993'),
+    `expected the exact run id in the path, got: ${capturedArgs?.join(' ')}`,
+  );
+});

--- a/tests/provider-adapter-github.test.mts
+++ b/tests/provider-adapter-github.test.mts
@@ -1212,3 +1212,93 @@ test('getChangeRequestReadinessSnapshot maps all nine fields from a single pr vi
     ),
   );
 });
+
+test('getChangeRequestReviewsWithHeadCommitDate paginates reviews and fetches headCommittedAt once', () => {
+  const pages = [
+    JSON.stringify({
+      data: {
+        repository: {
+          pullRequest: {
+            reviews: {
+              pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+              nodes: [
+                {
+                  id: 'PRR_1',
+                  commit: { oid: 'deadbeef' },
+                  submittedAt: '2026-01-01T00:00:00Z',
+                  author: { login: 'copilot', __typename: 'Bot' },
+                  comments: { totalCount: 2 },
+                  body: 'first page review',
+                },
+              ],
+            },
+            commits: {
+              nodes: [{ commit: { committedDate: '2026-01-01T00:00:00Z' } }],
+            },
+          },
+        },
+      },
+    }),
+    JSON.stringify({
+      data: {
+        repository: {
+          pullRequest: {
+            reviews: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [
+                {
+                  id: 'PRR_2',
+                  commit: { oid: 'deadbeef' },
+                  submittedAt: '2026-01-02T00:00:00Z',
+                  author: { login: 'copilot', __typename: 'Bot' },
+                  comments: { totalCount: 0 },
+                  body: null,
+                },
+              ],
+            },
+            // Deliberately omitted on the second page -- headCommittedAt
+            // must be captured once, from the first page, not overwritten
+            // (or blanked) by a later page that lacks it.
+            commits: { nodes: [] },
+          },
+        },
+      },
+    }),
+  ];
+  let call = 0;
+  const port = createGithubProviderAdapter(
+    'kurone-kito',
+    'idd-skill',
+    fakeDeps({
+      ghText: () => {
+        const page = pages[call];
+        call += 1;
+        return page;
+      },
+    }),
+  );
+  assert.deepEqual(port.getChangeRequestReviewsWithHeadCommitDate(7), {
+    reviews: [
+      {
+        id: 'PRR_1',
+        authorLogin: 'copilot',
+        authorTypename: 'Bot',
+        submittedAt: '2026-01-01T00:00:00Z',
+        commitId: 'deadbeef',
+        commentCount: 2,
+        body: 'first page review',
+      },
+      {
+        id: 'PRR_2',
+        authorLogin: 'copilot',
+        authorTypename: 'Bot',
+        submittedAt: '2026-01-02T00:00:00Z',
+        commitId: 'deadbeef',
+        commentCount: 0,
+        body: null,
+      },
+    ],
+    headCommittedAt: '2026-01-01T00:00:00Z',
+  });
+  assert.equal(call, 2);
+});

--- a/tests/provider-adapter-github.test.mts
+++ b/tests/provider-adapter-github.test.mts
@@ -1395,3 +1395,38 @@ test('listChangeRequestReviewThreadsWithAuthorType selects author.__typename, di
   ]);
   assert.match(capturedQuery ?? '', /author \{ login __typename \}/);
 });
+
+test('listMergedChangeRequests builds the merged pr-list args, with and without a sinceDate search filter', () => {
+  let capturedArgs: string[] | undefined;
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: (args) => {
+        capturedArgs = args;
+        return JSON.stringify([
+          { number: 5, mergedAt: '2026-01-01T00:00:00Z' },
+        ]);
+      },
+    }),
+  );
+  assert.deepEqual(port.listMergedChangeRequests(50, null), [
+    { number: 5, mergedAt: '2026-01-01T00:00:00Z' },
+  ]);
+  assert.deepEqual(capturedArgs, [
+    'pr',
+    'list',
+    '-R',
+    'o/r',
+    '--state',
+    'merged',
+    '--limit',
+    '50',
+    '--json',
+    'number,mergedAt',
+  ]);
+
+  port.listMergedChangeRequests(50, '2026-01-01');
+  assert.ok(capturedArgs?.includes('--search'));
+  assert.ok(capturedArgs?.includes('merged:>=2026-01-01'));
+});

--- a/tests/provider-adapter-github.test.mts
+++ b/tests/provider-adapter-github.test.mts
@@ -1449,3 +1449,28 @@ test('getWorkflowRun preserves a string runId above Number.MAX_SAFE_INTEGER exac
     `expected the exact run id in the path, got: ${capturedArgs?.join(' ')}`,
   );
 });
+
+test('listCapabilityDeclarations reports every provider-contract group supported, no network call', () => {
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () => {
+        throw new Error('listCapabilityDeclarations must not call gh');
+      },
+    }),
+  );
+  const declarations = port.listCapabilityDeclarations();
+  assert.equal(declarations.length, 11);
+  assert.ok(
+    declarations.every((declaration) => declaration.supported === true),
+  );
+  const advisoryReview = declarations.find(
+    (declaration) => declaration.group === 'advisory-review',
+  );
+  assert.equal(advisoryReview?.requirement, 'optional');
+  const changeRequests = declarations.find(
+    (declaration) => declaration.group === 'change-requests',
+  );
+  assert.equal(changeRequests?.requirement, 'required');
+});

--- a/tests/provider-adapter-github.test.mts
+++ b/tests/provider-adapter-github.test.mts
@@ -1450,6 +1450,26 @@ test('getWorkflowRun preserves a string runId above Number.MAX_SAFE_INTEGER exac
   );
 });
 
+test('listWorkflowRuns preserves a databaseId above Number.MAX_SAFE_INTEGER exactly (Codex review, PR #2429)', () => {
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify([
+          {
+            databaseId: '9007199254740993',
+            conclusion: 'success',
+            status: 'completed',
+            createdAt: '2026-01-01T00:00:00Z',
+          },
+        ]),
+    }),
+  );
+  const runs = port.listWorkflowRuns('o', 'r', 'CI', 10);
+  assert.equal(runs[0]?.id, '9007199254740993');
+});
+
 test('listCapabilityDeclarations reports every provider-contract group supported, no network call', () => {
   const port = createGithubProviderAdapter(
     'o',
@@ -1473,4 +1493,212 @@ test('listCapabilityDeclarations reports every provider-contract group supported
     (declaration) => declaration.group === 'change-requests',
   );
   assert.equal(changeRequests?.requirement, 'required');
+});
+
+// ---------------------------------------------------------------------------
+// GHES `--hostname` on raw `gh api graphql` calls (Codex review, PR #2429):
+// gh-exec.mts's shared ghGraphql/ghApiJson helpers resolve the correct GHES
+// host (#1962), but this file's paginated GraphQL methods build their own
+// `gh api graphql` args by hand (a tight-loop stdin hazard, #1396) rather
+// than routing through that shared helper -- several of #2267's methods
+// replaced an old call path that DID resolve the host this way
+// (advisory-convergence.mts's fetchPrAuthor/fetchReviewThreads,
+// review-clause.mts's fetchReviewsAndHeadCommit, advisory-wait-state.mts's
+// requested-reviewer query all imported gh-exec.mts's ghGraphql), so
+// omitting `--hostname` here was a genuine regression for a GHES adopter.
+// ---------------------------------------------------------------------------
+
+function withGhHostEnv(
+  overrides: { GH_HOST?: string; GITHUB_SERVER_URL?: string },
+  run: () => void,
+): void {
+  const originalGhHost = process.env.GH_HOST;
+  const originalServerUrl = process.env.GITHUB_SERVER_URL;
+  if (overrides.GH_HOST === undefined) {
+    delete process.env.GH_HOST;
+  } else {
+    process.env.GH_HOST = overrides.GH_HOST;
+  }
+  if (overrides.GITHUB_SERVER_URL === undefined) {
+    delete process.env.GITHUB_SERVER_URL;
+  } else {
+    process.env.GITHUB_SERVER_URL = overrides.GITHUB_SERVER_URL;
+  }
+  try {
+    run();
+  } finally {
+    if (originalGhHost === undefined) {
+      delete process.env.GH_HOST;
+    } else {
+      process.env.GH_HOST = originalGhHost;
+    }
+    if (originalServerUrl === undefined) {
+      delete process.env.GITHUB_SERVER_URL;
+    } else {
+      process.env.GITHUB_SERVER_URL = originalServerUrl;
+    }
+  }
+}
+
+test('getChangeRequestAuthor targets the resolved GHES host on a raw gh api graphql call', () => {
+  withGhHostEnv({ GITHUB_SERVER_URL: 'https://ghes.example.com' }, () => {
+    let capturedArgs: string[] | undefined;
+    const port = createGithubProviderAdapter(
+      'o',
+      'r',
+      fakeDeps({
+        ghText: (args) => {
+          capturedArgs = args;
+          return JSON.stringify({ data: { repository: { pullRequest: {} } } });
+        },
+      }),
+    );
+    port.getChangeRequestAuthor(7);
+    const hostnameIndex = capturedArgs?.indexOf('--hostname') ?? -1;
+    assert.ok(
+      hostnameIndex >= 0,
+      `expected --hostname in args, got: ${capturedArgs?.join(' ')}`,
+    );
+    assert.equal(capturedArgs?.[hostnameIndex + 1], 'ghes.example.com');
+  });
+});
+
+test('getChangeRequestAuthor omits --hostname for github.com (no regression on the common case)', () => {
+  withGhHostEnv({ GITHUB_SERVER_URL: 'https://github.com' }, () => {
+    let capturedArgs: string[] | undefined;
+    const port = createGithubProviderAdapter(
+      'o',
+      'r',
+      fakeDeps({
+        ghText: (args) => {
+          capturedArgs = args;
+          return JSON.stringify({ data: { repository: { pullRequest: {} } } });
+        },
+      }),
+    );
+    port.getChangeRequestAuthor(7);
+    assert.ok(!capturedArgs?.includes('--hostname'));
+  });
+});
+
+test('getChangeRequestReviewsWithHeadCommitDate throws on a GraphQL errors payload instead of treating it as no evidence (CodeRabbit review, PR #2429)', () => {
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify({ errors: [{ message: 'boom' }], data: null }),
+    }),
+  );
+  assert.throws(
+    () => port.getChangeRequestReviewsWithHeadCommitDate(7),
+    /boom/,
+  );
+});
+
+// listChangeRequestGraphqlComments / listChangeRequestGraphqlReviews
+// (Codex review, PR #2429): a missing pullRequest node or connection must
+// fail fast rather than silently read as zero comments/reviews, matching
+// merged-pr-feedback-sweep.mts's pre-migration fetchAllNodes -- otherwise a
+// transient/permission anomaly makes a PR look "clean" instead of failing
+// loudly.
+test('listChangeRequestGraphqlComments returns nodes on a normal payload', () => {
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                comments: {
+                  nodes: [
+                    {
+                      body: 'hi',
+                      url: 'https://example.invalid',
+                      createdAt: '2026-01-01T00:00:00Z',
+                      updatedAt: '2026-01-01T00:00:00Z',
+                      author: { login: 'octocat' },
+                    },
+                  ],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            },
+          },
+        }),
+    }),
+  );
+  assert.deepEqual(port.listChangeRequestGraphqlComments(7), [
+    {
+      body: 'hi',
+      url: 'https://example.invalid',
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+      authorLogin: 'octocat',
+    },
+  ]);
+});
+
+test('listChangeRequestGraphqlComments throws on a missing pullRequest node', () => {
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () => JSON.stringify({ data: { repository: {} } }),
+    }),
+  );
+  assert.throws(
+    () => port.listChangeRequestGraphqlComments(7),
+    /no pullRequest node/,
+  );
+});
+
+test('listChangeRequestGraphqlComments throws on a null comments connection', () => {
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify({
+          data: { repository: { pullRequest: { comments: null } } },
+        }),
+    }),
+  );
+  assert.throws(
+    () => port.listChangeRequestGraphqlComments(7),
+    /null comments connection/,
+  );
+});
+
+test('listChangeRequestGraphqlReviews throws on a missing pullRequest node', () => {
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () => JSON.stringify({ data: { repository: {} } }),
+    }),
+  );
+  assert.throws(
+    () => port.listChangeRequestGraphqlReviews(7),
+    /no pullRequest node/,
+  );
+});
+
+test('listChangeRequestGraphqlReviews throws on a null reviews connection', () => {
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify({
+          data: { repository: { pullRequest: { reviews: null } } },
+        }),
+    }),
+  );
+  assert.throws(
+    () => port.listChangeRequestGraphqlReviews(7),
+    /null reviews connection/,
+  );
 });

--- a/tests/provider-adapter-github.test.mts
+++ b/tests/provider-adapter-github.test.mts
@@ -743,3 +743,472 @@ test('searchOpenWorkItems builds the body-marker-search args', () => {
     'idd-skill-roadmap-id',
   ]);
 });
+
+// ---------------------------------------------------------------------------
+// #2267 additions below.
+// ---------------------------------------------------------------------------
+
+test('listChangeRequestReviewThreadCommentIds walks outer thread pages AND inner per-thread comment continuation', () => {
+  const outerPages = [
+    JSON.stringify({
+      data: {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              nodes: [
+                {
+                  id: 'thread-1',
+                  isResolved: false,
+                  comments: {
+                    nodes: [{ databaseId: 101 }],
+                    pageInfo: { hasNextPage: true, endCursor: 'c-101' },
+                  },
+                },
+              ],
+              pageInfo: { hasNextPage: true, endCursor: 'outer-1' },
+            },
+          },
+        },
+      },
+    }),
+    JSON.stringify({
+      data: {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              nodes: [
+                {
+                  id: 'thread-2',
+                  isResolved: true,
+                  comments: {
+                    nodes: [{ databaseId: 201 }],
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                  },
+                },
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+      },
+    }),
+  ];
+  const continuationPage = JSON.stringify({
+    data: {
+      node: {
+        comments: {
+          nodes: [{ databaseId: 102 }],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+    },
+  });
+  const calls: string[][] = [];
+  let outerCall = 0;
+  const port = createGithubProviderAdapter(
+    'kurone-kito',
+    'idd-skill',
+    fakeDeps({
+      ghText: (args) => {
+        calls.push(args);
+        if (args.some((arg) => arg.startsWith('query=query($id:ID!'))) {
+          return continuationPage;
+        }
+        const page = outerPages[outerCall];
+        outerCall += 1;
+        return page;
+      },
+    }),
+  );
+  assert.deepEqual(port.listChangeRequestReviewThreadCommentIds(7), [
+    { threadId: 'thread-1', isResolved: false, commentDatabaseIds: [101, 102] },
+    { threadId: 'thread-2', isResolved: true, commentDatabaseIds: [201] },
+  ]);
+  // Call order: outer page 1 (thread-1) -> thread-1's comment continuation
+  // (issued immediately while processing that node, before the outer loop
+  // moves on) -> outer page 2 (thread-2).
+  assert.equal(calls.length, 3);
+  assert.ok(calls[1].some((arg) => arg === 'id=thread-1'));
+  assert.ok(calls[1].some((arg) => arg === 'cursor=c-101'));
+});
+
+test('listChangeRequestReviewThreadsWithComments and listChangeRequestReviewThreadsExtended select distinct comment fragments', () => {
+  const capturedQueries: string[] = [];
+  const singlePage = JSON.stringify({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            nodes: [
+              {
+                id: 't1',
+                isResolved: true,
+                path: 'src/foo.mts',
+                comments: {
+                  nodes: [
+                    {
+                      body: 'hello',
+                      url: 'https://example.invalid/c/1',
+                      createdAt: '2026-01-01T00:00:00Z',
+                      updatedAt: '2026-01-01T00:00:00Z',
+                      author: { login: 'reviewer' },
+                      pullRequestReview: { id: 'PRR_1' },
+                    },
+                  ],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    },
+  });
+  const port = createGithubProviderAdapter(
+    'kurone-kito',
+    'idd-skill',
+    fakeDeps({
+      ghText: (args) => {
+        const queryArg = args.find((arg) =>
+          arg.startsWith('query=query($owner'),
+        );
+        if (queryArg) capturedQueries.push(queryArg);
+        return singlePage;
+      },
+    }),
+  );
+  assert.deepEqual(port.listChangeRequestReviewThreadsWithComments(7), [
+    {
+      isResolved: true,
+      comments: [
+        {
+          body: 'hello',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+          authorLogin: 'reviewer',
+          pullRequestReviewId: 'PRR_1',
+        },
+      ],
+    },
+  ]);
+  assert.deepEqual(port.listChangeRequestReviewThreadsExtended(7), [
+    {
+      isResolved: true,
+      path: 'src/foo.mts',
+      comments: [
+        {
+          body: 'hello',
+          url: 'https://example.invalid/c/1',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+          authorLogin: 'reviewer',
+        },
+      ],
+    },
+  ]);
+  assert.equal(capturedQueries.length, 2);
+  assert.notEqual(capturedQueries[0], capturedQueries[1]);
+  assert.match(capturedQueries[0], /pullRequestReview \{ id \}/);
+  assert.doesNotMatch(capturedQueries[1], /pullRequestReview/);
+});
+
+test('listBranchRules resolves not-found on a 404 and rethrows any other failure', () => {
+  const notFoundPort = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghApiJson: () => {
+        const error = new Error('HTTP 404') as Error & { stderr?: string };
+        error.stderr = 'gh: Not Found (HTTP 404)';
+        throw error;
+      },
+    }),
+  );
+  assert.deepEqual(notFoundPort.listBranchRules('o', 'r', 'main'), {
+    outcome: 'not-found',
+  });
+
+  const failurePort = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghApiJson: () => {
+        const error = new Error('boom') as Error & { stderr?: string };
+        error.stderr = 'gh: Forbidden (HTTP 403)';
+        throw error;
+      },
+    }),
+  );
+  assert.throws(() => failurePort.listBranchRules('o', 'r', 'main'), /boom/);
+});
+
+test('getBranchProtection resolves ok with the raw payload on success', () => {
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghApiJson: () => ({ required_status_checks: null }),
+    }),
+  );
+  assert.deepEqual(port.getBranchProtection('o', 'r', 'main'), {
+    outcome: 'ok',
+    value: { required_status_checks: null },
+  });
+});
+
+test('getRepositoryFileContentAtRef resolves not-found on a 404 and ok with the raw content otherwise', () => {
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () => 'YmFzZTY0',
+    }),
+  );
+  assert.deepEqual(
+    port.getRepositoryFileContentAtRef(
+      'other-owner/other-repo',
+      '.github/idd/config.json',
+      'deadbeef',
+    ),
+    { outcome: 'ok', value: 'YmFzZTY0' },
+  );
+
+  const notFoundPort = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () => {
+        const error = new Error('HTTP 404') as Error & { stderr?: string };
+        error.stderr = 'gh: Not Found (HTTP 404)';
+        throw error;
+      },
+    }),
+  );
+  assert.deepEqual(
+    notFoundPort.getRepositoryFileContentAtRef('o/r', 'x', 'y'),
+    { outcome: 'not-found' },
+  );
+});
+
+test('getMergedChangeRequestMeta returns null when the PR is not merged, and the parsed meta when it is', () => {
+  const notMergedPort = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify({
+          data: { repository: { pullRequest: { merged: false } } },
+        }),
+    }),
+  );
+  assert.equal(notMergedPort.getMergedChangeRequestMeta(9), null);
+
+  const mergedPort = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                number: 9,
+                merged: true,
+                mergedAt: '2026-01-01T00:00:00Z',
+                mergeCommit: { oid: 'deadbeef' },
+              },
+            },
+          },
+        }),
+    }),
+  );
+  assert.deepEqual(mergedPort.getMergedChangeRequestMeta(9), {
+    number: 9,
+    merged: true,
+    mergedAt: '2026-01-01T00:00:00Z',
+    mergeCommitOid: 'deadbeef',
+  });
+});
+
+test('postReviewCommentReply POSTs to the PR-scoped comment-reply endpoint (regression guard: the PR number segment was dropped in an earlier draft)', () => {
+  let capturedArgs: string[] | undefined;
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: (args) => {
+        capturedArgs = args;
+        return JSON.stringify({ id: 555 });
+      },
+    }),
+  );
+  const result = port.postReviewCommentReply(42, 99, '**Accepted** -- done.');
+  assert.deepEqual(result, { id: 555 });
+  assert.ok(
+    capturedArgs?.includes('repos/o/r/pulls/42/comments/99/replies'),
+    `expected the PR number (42) in the reply path, got: ${capturedArgs?.join(' ')}`,
+  );
+});
+
+test('resolveChangeRequestReviewThread throws unless GitHub confirms isResolved', () => {
+  const okPort = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify({
+          data: { resolveReviewThread: { thread: { isResolved: true } } },
+        }),
+    }),
+  );
+  assert.doesNotThrow(() => okPort.resolveChangeRequestReviewThread('T_1'));
+
+  const unconfirmedPort = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify({
+          data: { resolveReviewThread: { thread: { isResolved: false } } },
+        }),
+    }),
+  );
+  assert.throws(
+    () => unconfirmedPort.resolveChangeRequestReviewThread('T_1'),
+    /did not confirm/,
+  );
+});
+
+test('mergeChangeRequest and mergeChangeRequestAdmin build distinct arg shapes (--admin only on the admin variant)', () => {
+  let capturedArgs: string[] | undefined;
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: (args) => {
+        capturedArgs = args;
+        return 'merged';
+      },
+    }),
+  );
+  port.mergeChangeRequest(42, 'deadbeef');
+  assert.deepEqual(capturedArgs, [
+    'pr',
+    'merge',
+    '42',
+    '-R',
+    'o/r',
+    '--merge',
+    '--match-head-commit',
+    'deadbeef',
+  ]);
+  port.mergeChangeRequestAdmin(42, 'deadbeef');
+  assert.deepEqual(capturedArgs, [
+    'pr',
+    'merge',
+    '42',
+    '-R',
+    'o/r',
+    '--merge',
+    '--match-head-commit',
+    'deadbeef',
+    '--admin',
+  ]);
+});
+
+test('mergeChangeRequestAtRepo targets an explicit owner/repo distinct from the port locator', () => {
+  let capturedArgs: string[] | undefined;
+  const port = createGithubProviderAdapter(
+    'ambient-owner',
+    'ambient-repo',
+    fakeDeps({
+      ghText: (args) => {
+        capturedArgs = args;
+        return 'merged';
+      },
+    }),
+  );
+  port.mergeChangeRequestAtRepo('other-owner', 'other-repo', 42, 'deadbeef');
+  assert.deepEqual(capturedArgs, [
+    'pr',
+    'merge',
+    '42',
+    '-R',
+    'other-owner/other-repo',
+    '--merge',
+    '--match-head-commit',
+    'deadbeef',
+  ]);
+});
+
+test('listChangeRequestChecks omits --required, unlike listRequiredChecks', () => {
+  let capturedArgs: string[] | undefined;
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: (args) => {
+        capturedArgs = args;
+        return '[]';
+      },
+    }),
+  );
+  port.listChangeRequestChecks(7);
+  assert.ok(capturedArgs);
+  assert.ok(!capturedArgs?.includes('--required'));
+});
+
+test('getChangeRequestRequestedReviewerLoginsGraphql never throws, returning null on any failure', () => {
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () => {
+        throw new Error('boom');
+      },
+    }),
+  );
+  assert.equal(port.getChangeRequestRequestedReviewerLoginsGraphql(7), null);
+});
+
+test('getChangeRequestReadinessSnapshot maps all nine fields from a single pr view call', () => {
+  let capturedArgs: string[] | undefined;
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: (args) => {
+        capturedArgs = args;
+        return JSON.stringify({
+          headRefOid: 'deadbeef',
+          baseRefName: 'main',
+          url: 'https://example.invalid/pull/7',
+          author: { login: 'contributor' },
+          reviewDecision: 'APPROVED',
+          statusCheckRollup: [{ name: 'ci', state: 'SUCCESS' }],
+          mergeable: 'MERGEABLE',
+          mergeStateStatus: 'CLEAN',
+          closingIssuesReferences: { nodes: [] },
+        });
+      },
+    }),
+  );
+  assert.deepEqual(port.getChangeRequestReadinessSnapshot(7), {
+    headSha: 'deadbeef',
+    baseRefName: 'main',
+    url: 'https://example.invalid/pull/7',
+    authorLogin: 'contributor',
+    reviewDecision: 'APPROVED',
+    statusCheckRollup: [{ name: 'ci', state: 'SUCCESS' }],
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'CLEAN',
+    closingIssuesReferences: { nodes: [] },
+  });
+  assert.ok(capturedArgs?.includes('-R'));
+  assert.ok(
+    capturedArgs?.includes(
+      'headRefOid,baseRefName,url,author,reviewDecision,statusCheckRollup,mergeable,mergeStateStatus,closingIssuesReferences',
+    ),
+  );
+});

--- a/tests/provider-contract.test.mts
+++ b/tests/provider-contract.test.mts
@@ -41,7 +41,7 @@ test('PROVIDER_IDS names github, gitlab, and bitbucket; isProviderId is a matchi
   assert.equal(isProviderId(undefined), false);
 });
 
-test('PROVIDER_CAPABILITY_GROUPS names the ten groups from the design record', () => {
+test('PROVIDER_CAPABILITY_GROUPS names the eleven groups from the design record', () => {
   assert.deepEqual(PROVIDER_CAPABILITY_GROUPS, [
     'repository-identity',
     'work-items',
@@ -53,6 +53,9 @@ test('PROVIDER_CAPABILITY_GROUPS names the ten groups from the design record', (
     'permissions',
     'branch-protection',
     'merge',
+    // #2267: bot/advisory review interpretation, distinct from
+    // reviews-and-threads's required unresolved-thread safety gate.
+    'advisory-review',
   ]);
 });
 

--- a/tests/provider-port-migration-guard.test.mts
+++ b/tests/provider-port-migration-guard.test.mts
@@ -32,6 +32,7 @@ const MIGRATED_HELPERS: readonly string[] = [
   // #2267 additions below.
   'review-clause.mts',
   'review-activity-snapshot.mts',
+  'resolve-review-thread.mts',
 ];
 
 const DIRECT_GH_PATTERNS: { pattern: RegExp; description: string }[] = [

--- a/tests/provider-port-migration-guard.test.mts
+++ b/tests/provider-port-migration-guard.test.mts
@@ -31,6 +31,7 @@ const MIGRATED_HELPERS: readonly string[] = [
   'discover-roadmap-graph.mts',
   // #2267 additions below.
   'review-clause.mts',
+  'review-activity-snapshot.mts',
 ];
 
 const DIRECT_GH_PATTERNS: { pattern: RegExp; description: string }[] = [

--- a/tests/provider-port-migration-guard.test.mts
+++ b/tests/provider-port-migration-guard.test.mts
@@ -14,9 +14,11 @@ import { fileURLToPath } from 'node:url';
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
 /** Files migrated so far. Append the next filename here as each of #2266's
- * 11 target files (and, from #2267 on, its own nine PR-facing target
- * files) moves onto the provider port -- do not add a name until its
- * migration commit lands, and never remove one once migrated. */
+ * 11 target files (and, from #2267 on, its own ten PR-facing target files
+ * -- the issue body names nine bullets, but one, `ci-wait-*.mts`, is a
+ * glob covering two files: `ci-wait-policy.mts` and `ci-wait-state.mts`)
+ * moves onto the provider port -- do not add a name until its migration
+ * commit lands, and never remove one once migrated. */
 const MIGRATED_HELPERS: readonly string[] = [
   'collaborator-permission.mts',
   'discover-viability-gate.mts',

--- a/tests/provider-port-migration-guard.test.mts
+++ b/tests/provider-port-migration-guard.test.mts
@@ -37,6 +37,7 @@ const MIGRATED_HELPERS: readonly string[] = [
   'merged-pr-feedback-sweep.mts',
   'advisory-wait-state.mts',
   'ci-wait-policy.mts',
+  'ci-wait-state.mts',
 ];
 
 const DIRECT_GH_PATTERNS: { pattern: RegExp; description: string }[] = [

--- a/tests/provider-port-migration-guard.test.mts
+++ b/tests/provider-port-migration-guard.test.mts
@@ -14,8 +14,9 @@ import { fileURLToPath } from 'node:url';
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
 /** Files migrated so far. Append the next filename here as each of #2266's
- * 11 target files moves onto the provider port -- do not add a name until
- * its migration commit lands, and never remove one once migrated. */
+ * 11 target files (and, from #2267 on, its own nine PR-facing target
+ * files) moves onto the provider port -- do not add a name until its
+ * migration commit lands, and never remove one once migrated. */
 const MIGRATED_HELPERS: readonly string[] = [
   'collaborator-permission.mts',
   'discover-viability-gate.mts',
@@ -28,6 +29,8 @@ const MIGRATED_HELPERS: readonly string[] = [
   'resume-route-selection.mts',
   'idd-roadmap-audit-execute.mts',
   'discover-roadmap-graph.mts',
+  // #2267 additions below.
+  'review-clause.mts',
 ];
 
 const DIRECT_GH_PATTERNS: { pattern: RegExp; description: string }[] = [

--- a/tests/provider-port-migration-guard.test.mts
+++ b/tests/provider-port-migration-guard.test.mts
@@ -39,6 +39,7 @@ const MIGRATED_HELPERS: readonly string[] = [
   'ci-wait-policy.mts',
   'ci-wait-state.mts',
   'pre-merge-readiness.mts',
+  'advisory-convergence.mts',
 ];
 
 const DIRECT_GH_PATTERNS: { pattern: RegExp; description: string }[] = [

--- a/tests/provider-port-migration-guard.test.mts
+++ b/tests/provider-port-migration-guard.test.mts
@@ -33,6 +33,7 @@ const MIGRATED_HELPERS: readonly string[] = [
   'review-clause.mts',
   'review-activity-snapshot.mts',
   'resolve-review-thread.mts',
+  'idd-merge-execute.mts',
 ];
 
 const DIRECT_GH_PATTERNS: { pattern: RegExp; description: string }[] = [

--- a/tests/provider-port-migration-guard.test.mts
+++ b/tests/provider-port-migration-guard.test.mts
@@ -36,6 +36,7 @@ const MIGRATED_HELPERS: readonly string[] = [
   'idd-merge-execute.mts',
   'merged-pr-feedback-sweep.mts',
   'advisory-wait-state.mts',
+  'ci-wait-policy.mts',
 ];
 
 const DIRECT_GH_PATTERNS: { pattern: RegExp; description: string }[] = [

--- a/tests/provider-port-migration-guard.test.mts
+++ b/tests/provider-port-migration-guard.test.mts
@@ -38,6 +38,7 @@ const MIGRATED_HELPERS: readonly string[] = [
   'advisory-wait-state.mts',
   'ci-wait-policy.mts',
   'ci-wait-state.mts',
+  'pre-merge-readiness.mts',
 ];
 
 const DIRECT_GH_PATTERNS: { pattern: RegExp; description: string }[] = [

--- a/tests/provider-port-migration-guard.test.mts
+++ b/tests/provider-port-migration-guard.test.mts
@@ -34,6 +34,7 @@ const MIGRATED_HELPERS: readonly string[] = [
   'review-activity-snapshot.mts',
   'resolve-review-thread.mts',
   'idd-merge-execute.mts',
+  'merged-pr-feedback-sweep.mts',
 ];
 
 const DIRECT_GH_PATTERNS: { pattern: RegExp; description: string }[] = [

--- a/tests/provider-port-migration-guard.test.mts
+++ b/tests/provider-port-migration-guard.test.mts
@@ -35,6 +35,7 @@ const MIGRATED_HELPERS: readonly string[] = [
   'resolve-review-thread.mts',
   'idd-merge-execute.mts',
   'merged-pr-feedback-sweep.mts',
+  'advisory-wait-state.mts',
 ];
 
 const DIRECT_GH_PATTERNS: { pattern: RegExp; description: string }[] = [


### PR DESCRIPTION
## Summary

Closes #2267

Routes the PR-facing helpers through `ProviderPort` instead of calling
`gh`/GitHub REST/GraphQL directly, completing the second half of the
provider-portability work started by #2265/#2266.

- Extends `provider-port.mts`/`provider-adapter-github.mts`/
  `provider-adapter-fake.mts` with the change-request, review, thread,
  check, branch-protection/ruleset, and merge operations the ten
  target files need, plus `listCapabilityDeclarations()` -- a static,
  no-network capability list a future non-GitHub adapter uses to
  declare `advisory-review` as `not_applicable` without weakening any
  required gate (change-request identity, HEAD freshness, checks,
  threads, merge).
- Migrates all ten named PR-facing helpers onto the port:
  `review-clause.mts`, `review-activity-snapshot.mts`,
  `resolve-review-thread.mts`, `idd-merge-execute.mts`,
  `merged-pr-feedback-sweep.mts`, `advisory-wait-state.mts`,
  `ci-wait-policy.mts`, `ci-wait-state.mts`, `pre-merge-readiness.mts`,
  `advisory-convergence.mts`. (The issue body names nine bullets, but
  one -- `ci-wait-*.mts` -- is a glob covering two files, so the actual
  count is ten; every named/globbed target is migrated.)
- `advisory-convergence.mts` now coerces `reviewPolicy` to
  `'no-advisory'` when the provider declares `advisory-review` as
  `not_applicable`, via `evaluateProviderCapabilityOutcome`
  (`provider-contract.mts`, #2265). Every other gate (required checks,
  unresolved threads, HEAD freshness, merge) stays fail-closed
  regardless of capability.
- Every pre-existing throw/return-shape contract is preserved exactly
  (`throwSyntheticGhNotFound()` / `unwrapGovernanceOutcome()` shim
  pre-merge-readiness's injectable-default functions so
  `deriveGhHttpStatus(error) === 404` classification is unchanged;
  `toIssueCommentPayload()` / `toReviewThreadPayload()` shims map the
  port's flat shapes back onto each file's own pre-existing REST/
  GraphQL-shaped types).
- Git operations (local branch conflict detection, etc.) and Copilot's
  own review-body/convergence interpretation are untouched, per the
  issue's own scope boundary.

## Scope boundaries (deliberate)

- `rerun-advisory-convergence.mts` and `external-check-waiver.mts` are
  **not** migrated in this PR -- out of #2267's named target list.
  `external-check-waiver.mts`'s own `fetchPrComments` keeps its direct
  `gh api` call; it never reads any of this PR's shimmed `comments`
  arrays (verified: `summarizeExternalCheckWaivers`, the one function
  both migrated files pass their own `comments` through, already
  falls back `created_at ?? createdAt` / `user?.login ?? author?.login`
  either way, so the shim shape is compatible regardless).
- Exhaustive provider-contract fixture parity between the GitHub
  adapter and the fake adapter is #2268's job, not this PR's.

## Acceptance criteria

- [x] The ten named PR-facing helpers no longer invoke `gh`, GitHub
      REST/GraphQL endpoints, or GitHub-specific response parsing
      directly -- enforced by a static guard
      (`tests/provider-port-migration-guard.test.mts`).
- [x] The GitHub adapter preserves existing review activity, thread
      disposition, check/status, branch-protection, merge, and
      allowed-error behavior -- every pre-existing direct unit test for
      every migrated file passes unmodified except one deliberate
      `normalizeThread` id-fallback assertion (`'RT_1'` -> `'thread-1'`,
      matching the label `summarizeDispositionEvidenceForGate` already
      used for a missing id; this file's report field is diagnostic
      only, the one real id-matching consumer fetches its own
      independent threads).
- [x] Required safety capabilities fail closed on unsupported/
      unavailable/malformed provider data; only the optional
      `advisory-review` capability resolves `not_applicable`.
- [x] Copilot's convergence/review-body interpretation is untouched --
      `computeAdvisoryConvergenceVerdict` received no changes in this
      PR.
- [x] Unit tests exercise the PR-facing state machine with a fake
      provider (`createFakeProviderAdapter`, zero `gh` process, zero
      network):
  - unresolved threads --
    `tests/pre-merge-readiness-collection-smoke.test.mts`
  - pending/failing checks -- new test with a readable required-check
    fixture and a `COMPLETED`/`FAILURE` check-run, asserting
    `summarizeRequiredChecks`'s own `status: 'failed'` path (distinct
    from the unreadable-governance case, which short-circuits before
    any check conclusion is classified)
  - unsupported capability / explicit `not_applicable` --
    `tests/advisory-convergence-fake-provider.test.mts`
  - stale review activity -- covered only via the existing direct
    pure-function tests (`tests/advisory-convergence.test.mts`,
    `tests/pre-merge-readiness.test.mts`), not through the fake-
    provider collection path. The collection wiring is
    scenario-independent for freshness (it passes `headCommittedAt`/
    review timestamps straight through to the same pure summarizer
    regardless of provider), and replicating this repo's review-
    watermark/claim-marker grammar end-to-end through a fake provider
    is materially more expensive for no additional wiring coverage.
    Flagging this explicitly rather than leaving it for review to find.
- [x] A static guard (`tests/provider-port-migration-guard.test.mts`)
      prevents a migrated file from regaining a direct `gh`/GraphQL
      call.
- [x] `pnpm run build`, the affected test suites, and
      `pnpm run lint:minimum` all pass (4667/4667 tests, 0 cspell
      issues, 0 markdownlint issues, clean typecheck/build).

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `node --experimental-strip-types --test tests/*.test.mts`
      (4667/4667 passing)
- [x] `pnpm run lint:minimum` (full CI gate, green end-to-end)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub-backed workflows now use a shared provider layer for repository, pull request, review, workflow, governance, and merge operations.
  * Added support for provider capability declarations, including advisory-review applicability.
  * Advisory convergence checks now support configurable polling intervals and maximum wait times.

* **Bug Fixes**
  * Improved handling of missing repository files, comments, review-thread data, pagination, and workflow identifiers.
  * Added safer validation and fail-closed behavior for governance and merge operations.

* **Tests**
  * Expanded coverage for provider behavior, review threads, merges, governance failures, pagination, and advisory-review scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->