### PR TITLE
feat(token-cost): attempt identity on TokenCostEvent for join accuracy

### DIFF
--- a/docs/token-cost.md
+++ b/docs/token-cost.md
@@ -77,7 +77,16 @@ themselves unidentified (all historical data, and any vendor with no
 known session-id source) -- once identified events are present, an
 identified stage is never treated as compatible with a differently- or
 un-identified completion, so a stale or unrelated attempt can't be
-silently absorbed.
+silently absorbed. One accepted tradeoff from this: when a single issue
+loop legitimately spans multiple Claude sessions (a handoff or resume,
+Refs Scope above), the event-window fallback currently only harvests
+that loop's usage from the session that posted `cleanup` -- an earlier
+session's own identified stage windows are excluded rather than folded
+in, since a session-id mismatch cannot be told apart from a genuinely
+unrelated, abandoned attempt at the event level. Full multi-session
+aggregation for this path is tracked separately (Refs #2432); the
+harvested sample stays an undercount rather than risking a
+mismatched/contaminated one in the meantime.
 
 `node scripts/token-cost-report.mjs`:
 

--- a/docs/token-cost.md
+++ b/docs/token-cost.md
@@ -71,9 +71,13 @@ flag needed. When two attempts for the same issue leave events in
 attempt's own `enter`/`exit` pair is never mixed with a different
 attempt's, and a same-issue match across more than one project log file
 resolves to whichever file's own session id matches, instead of being
-skipped. An event with no identity (all historical data, and any vendor
-with no known session-id source) still joins exactly as before this
-field existed.
+skipped. Legacy (identity-agnostic) joining still applies exactly as
+before this field existed, but only when the relevant events are
+themselves unidentified (all historical data, and any vendor with no
+known session-id source) -- once identified events are present, an
+identified stage is never treated as compatible with a differently- or
+un-identified completion, so a stale or unrelated attempt can't be
+silently absorbed.
 
 `node scripts/token-cost-report.mjs`:
 

--- a/docs/token-cost.md
+++ b/docs/token-cost.md
@@ -63,6 +63,18 @@ and appends `kind: "issue-loop"` / `kind: "session"` records to
 sibling `events.jsonl` path (`--events` to override), those timestamps
 win over the marker-join reconstruction for the stages they cover.
 
+`token-cost-event.mjs` also auto-derives each event's `vendorSessionId`
+from a vendor-specific env var -- `$CLAUDE_CODE_SESSION_ID` for
+`--vendor claude`, no equivalent known yet for `grok`/`codex` -- with no
+flag needed. When two attempts for the same issue leave events in
+`events.jsonl` (a retry, a fail-open dropped call), an identified
+attempt's own `enter`/`exit` pair is never mixed with a different
+attempt's, and a same-issue match across more than one project log file
+resolves to whichever file's own session id matches, instead of being
+skipped. An event with no identity (all historical data, and any vendor
+with no known session-id source) still joins exactly as before this
+field existed.
+
 `node scripts/token-cost-report.mjs`:
 
 - `--in <samples.jsonl> [--in <samples.jsonl> ...] --apply` aggregates

--- a/scripts/token-cost-adapter-claude.mjs
+++ b/scripts/token-cost-adapter-claude.mjs
@@ -130,7 +130,7 @@ export function extractSessionId(records) {
  * `redactTokenCostRecord()` would later strip to `undefined`, silently
  * producing a schema-invalid sample instead of failing closed.
  */
-function deriveFallbackSessionId(fileBasename) {
+export function deriveFallbackSessionId(fileBasename) {
   if (!fileBasename) {
     return undefined;
   }

--- a/scripts/token-cost-adapter-claude.mjs
+++ b/scripts/token-cost-adapter-claude.mjs
@@ -112,7 +112,7 @@ export function parseClaudeProjectLines(text) {
   return out;
 }
 /** The first non-empty top-level `sessionId` across `records`, in file order -- stable per project JSONL file (it matches the file's own basename). */
-function extractSessionId(records) {
+export function extractSessionId(records) {
   for (const record of records) {
     const sessionId = isPlainObject(record)
       ? getStringField(record, 'sessionId')

--- a/scripts/token-cost-event.mjs
+++ b/scripts/token-cost-event.mjs
@@ -45,6 +45,35 @@ export function resolveOutPath(explicitOut, env = process.env) {
     env.XDG_STATE_HOME || join(env.HOME || homedir(), '.local', 'state');
   return join(stateHome, DEFAULT_OUT_RELATIVE);
 }
+// Vendor session env vars this helper knows how to auto-derive
+// `vendorSessionId` from (#2424). Claude-only for now: `$CLAUDE_CODE_SESSION_ID`
+// is a verified real env var whose value matches the session's own
+// `~/.claude/projects/<encoded-cwd>/<id>.jsonl` basename exactly (the same
+// value `extractSessionId()` reads back out of that file's own records in
+// token-cost-adapter-claude.mts). Codex/Grok have no verified equivalent
+// yet -- add a row here once one is confirmed, rather than guessing.
+const VENDOR_SESSION_ID_ENV_VAR = {
+  claude: 'CLAUDE_CODE_SESSION_ID',
+};
+/**
+ * Reads the env var mapped to `vendor` (if any) and returns its value,
+ * unless it is empty or looks like a filesystem path (`/` or `\` --
+ * schemas/token-cost-event.schema.json's own `vendorSessionId` description
+ * says "Never a filesystem path"; this stamping step is what has to honor
+ * that, since the schema's own type is a bare `["string", "null"]` with no
+ * format the validator enforces).
+ */
+function deriveVendorSessionId(vendor, env) {
+  const envVar = VENDOR_SESSION_ID_ENV_VAR[vendor];
+  if (!envVar) {
+    return undefined;
+  }
+  const value = env[envVar];
+  if (!value || value.includes('/') || value.includes('\\')) {
+    return undefined;
+  }
+  return value;
+}
 /**
  * Build one {@link TokenCostEvent} from parsed CLI values and the current
  * time. Throws a plain, human-readable message on any malformed input --
@@ -55,7 +84,7 @@ export function resolveOutPath(explicitOut, env = process.env) {
  * single source of truth for both, so an enum drift between this helper
  * and the schema can never leave one checked and the other not.
  */
-export function buildEvent(values, now) {
+export function buildEvent(values, now, env = process.env) {
   const enter = values.enter === true;
   const exit = values.exit === true;
   if (enter === exit) {
@@ -76,6 +105,10 @@ export function buildEvent(values, now) {
     at: now.toISOString(),
     vendor: vendor,
   };
+  const vendorSessionId = deriveVendorSessionId(vendor, env);
+  if (vendorSessionId !== undefined) {
+    event.vendorSessionId = vendorSessionId;
+  }
   const issueRaw = values.issue;
   if (issueRaw !== undefined) {
     if (typeof issueRaw !== 'string') {
@@ -145,6 +178,10 @@ function printHelp() {
                      fail-open warning-and-exit-0 behavior.
   --now <ISO8601>    Override the current time (tests only).
   --help, -h         Show this help.
+
+For --vendor claude, vendorSessionId is auto-derived from
+$CLAUDE_CODE_SESSION_ID when set -- no flag needed. No equivalent env var
+is known yet for grok or codex.
 
 Fail-open by default: a bad flag, a schema-invalid event, or an
 unwritable --out path prints a stderr warning and exits 0, so a

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -1126,6 +1126,27 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
     //   whether they're the same real attempt or two different
     //   unidentified ones -- byte-identical to the pre-#2424 residual;
     //   identity cannot see it either way.
+    //
+    // A third, accepted tradeoff (Codex review finding round 5, PR #2430,
+    // #2424): a `vendorSessionId` mismatch proves a different PROCESS, not
+    // a different ATTEMPT -- docs/token-cost.md's own Scope explicitly
+    // allows one issue loop to span multiple Claude sessions via a
+    // handoff or resume. This check has no way to tell that legitimate
+    // case apart from a genuinely unrelated, abandoned earlier attempt,
+    // so it excludes both alike. Widening the window to include the
+    // earlier session's own stage would not by itself recover its usage
+    // either: `scanClaudeVendorSessions` harvests one session log file
+    // per completed window, so an earlier handoff session's records live
+    // in a file this resolution never selects -- a widened-but-single-
+    // file harvest would misrepresent its own coverage (bounds spanning
+    // both sessions, records covering only one), which is worse than
+    // today's narrower-but-honest one. Merging records across a
+    // confirmed handoff's files needs a positive-evidence rule this
+    // event stream alone can't supply; tracked separately (#2432) rather
+    // than attempted here. Until then this is a documented undercount,
+    // not a bug: recoverable once #2432 ships, unlike the permanent
+    // contamination a wrong inclusion would freeze under a stable
+    // `#ew<issueNumber>` sample id.
     const idCompatible = (window) =>
       window.vendorSessionId === undefined ||
       window.vendorSessionId === cleanup.vendorSessionId;

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -1089,11 +1089,22 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
     }
     // #2424: a non-cleanup window whose vendorSessionId is known and
     // differs from cleanup's own belongs to a different attempt --
-    // exclude it outright, before either check below runs. Undefined on
-    // either side means "unidentified"; those windows are unaffected and
-    // still flow through the pre-#2424 checks.
+    // exclude it outright, before either check below runs. This is
+    // deliberately ASYMMETRIC, not "undefined on either side means
+    // unidentified, treat as compatible" (Codex review finding round 3,
+    // PR #2430: that symmetric form let an UNIDENTIFIED cleanup --
+    // e.g. a fresh retry that legitimately won readEventWindows' own
+    // recency comparison over a stale identified completion -- absorb
+    // ANY identified stage window unconditionally, including one that
+    // provably belongs to a DIFFERENT, earlier attempt). A window's own
+    // identity, once present, is real evidence of a distinct attempt --
+    // `vendorSessionId` is derived once per Claude Code process
+    // lifetime, so an identified stage and an unidentified cleanup can
+    // never legitimately be the SAME attempt. The only "no contradicting
+    // evidence" case is when the WINDOW itself lacks an identity
+    // (historical data, or a stage that predates this field even though
+    // cleanup itself is a fresh, identified completion).
     const idCompatible = (window) =>
-      cleanup.vendorSessionId === undefined ||
       window.vendorSessionId === undefined ||
       window.vendorSessionId === cleanup.vendorSessionId;
     const candidateStages = [...stages].filter(

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -34,6 +34,7 @@ import {
 import {
   claudeAdapter,
   defaultClaudeProjectDir,
+  deriveFallbackSessionId,
   extractRecordTimestampMs,
   extractSessionId,
   parseClaudeProjectLines,
@@ -1440,24 +1441,36 @@ export function scanClaudeVendorSessions(
     });
     candidatesByIssue.set(candidate.issueNumber, list);
   }
+  const vendorSessionIdByIssue = new Map();
+  for (const window of completedIssueWindows) {
+    if (!vendorSessionIdByIssue.has(window.issueNumber)) {
+      vendorSessionIdByIssue.set(window.issueNumber, window.vendorSessionId);
+    }
+  }
+  // #2424/Copilot review (PR #2430): a candidate's own session id must
+  // fall back to its file basename exactly like `claudeAdapter.harvest()`
+  // itself does -- `extractSessionId()` alone returns `undefined` for a
+  // record shape lacking a top-level `sessionId` field (already
+  // fixture-covered for the adapter's own vendorSessionId derivation),
+  // which would otherwise never match a defined `windowVendorSessionId`
+  // even when the file is genuinely the right one.
+  const resolveCandidateSessionId = (candidate) =>
+    extractSessionId(candidate.records) ??
+    deriveFallbackSessionId(candidate.fileBasename);
   for (const [issueNumber, fileCandidates] of candidatesByIssue) {
     // #2424: resolve by attempt identity before falling back to
     // classify-and-skip (or, for a single candidate, unconditional
-    // harvest). `extractSessionId` reads each candidate's own records (a
-    // subset of one file), which carry the same sessionId as the rest of
-    // that file. This also gates the length-1 case: a sole candidate is
+    // harvest). This also gates the length-1 case: a sole candidate is
     // NOT automatically the right one when the window has an identity a
     // file provably fails to match -- e.g. this loop's own event window
     // whose own session file got excluded upstream (a cwd-inferred
     // segment already claimed it), leaving only an unrelated concurrent
     // session's file as candidate.
-    const windowVendorSessionId = completedIssueWindows.find(
-      (window) => window.issueNumber === issueNumber,
-    )?.vendorSessionId;
+    const windowVendorSessionId = vendorSessionIdByIssue.get(issueNumber);
     if (windowVendorSessionId !== undefined) {
       const matching = fileCandidates.filter(
         (candidate) =>
-          extractSessionId(candidate.records) === windowVendorSessionId,
+          resolveCandidateSessionId(candidate) === windowVendorSessionId,
       );
       if (matching.length === 1) {
         harvestEventWindowCandidate(

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -805,6 +805,13 @@ export function readEventWindows(path) {
   }
   const enterAt = new Map();
   const exitAt = new Map();
+  // bareKey -> vendorSessionId of whichever event set enterAt/exitAt's
+  // CURRENT value for that key (undefined when that latest event carried
+  // no identity). Lets the legacy pairing's own trustworthiness be
+  // checked before it competes with an identified candidate -- see
+  // resolveWindow below.
+  const enterAtOwner = new Map();
+  const exitAtOwner = new Map();
   // bareKey -> vendorSessionId -> latest timestamp. Only populated for
   // events that carry a non-empty vendorSessionId.
   const enterAtByAttempt = new Map();
@@ -844,6 +851,7 @@ export function readEventWindows(path) {
       : undefined;
     if (event.event === 'enter') {
       enterAt.set(key, atMs);
+      enterAtOwner.set(key, vendorSessionId);
       if (vendorSessionId !== undefined) {
         const byAttempt = enterAtByAttempt.get(key) ?? new Map();
         byAttempt.set(vendorSessionId, atMs);
@@ -851,6 +859,7 @@ export function readEventWindows(path) {
       }
     } else {
       exitAt.set(key, atMs);
+      exitAtOwner.set(key, vendorSessionId);
       if (vendorSessionId !== undefined) {
         const byAttempt = exitAtByAttempt.get(key) ?? new Map();
         byAttempt.set(vendorSessionId, atMs);
@@ -896,23 +905,38 @@ export function readEventWindows(path) {
         : undefined;
     const legacyStartMs = enterAt.get(key);
     const legacyEndMs = exitAt.get(key);
+    // Codex review finding round 2, PR #2430: the latest enter and the
+    // latest exit for this bareKey can belong to two DIFFERENT attempts
+    // -- e.g. attempt A posts both cleanup boundaries, and a later
+    // attempt B's own `--enter` call fails to post (fail-open) while its
+    // `--exit` succeeds and lands after A's. enterAt/exitAt would then
+    // mix A's enter with B's exit into a window that looks internally
+    // valid but spans two attempts, permanently corrupting attribution
+    // if it wins the recency comparison below. legacyWindow is only
+    // trustworthy when its own latest enter and latest exit share the
+    // SAME owner (both unidentified, or the same identified attempt --
+    // the latter is always redundant with a `bestIdentified` candidate,
+    // since an identified event updates both the bucketed AND the
+    // unconditional maps together).
+    const legacyOwnersMatch = enterAtOwner.get(key) === exitAtOwner.get(key);
     const legacyWindow =
+      legacyOwnersMatch &&
       legacyStartMs !== undefined &&
       legacyEndMs !== undefined &&
       legacyStartMs < legacyEndMs
         ? { startMs: legacyStartMs, endMs: legacyEndMs }
         : undefined;
-    // Codex review finding, PR #2430: an identified valid candidate is not
-    // automatically more current than the legacy (identity-agnostic)
-    // latest-wins pairing -- e.g. a completed, identified attempt A
-    // followed by a later retry B that completes WITHOUT an identity
-    // (env var unset, a straddling deploy transient). enterAt/exitAt are
-    // populated unconditionally for every event regardless of identity,
-    // so legacyWindow already reflects B's own clean pair whenever B's
-    // own enter and exit are each individually the latest seen -- prefer
-    // whichever candidate is more recent (its own endMs), identified
-    // breaking a tie (the common single-attempt or already-identified
-    // case, where both sides describe the exact same pair).
+    // Codex review finding round 1, PR #2430: an identified valid
+    // candidate is not automatically more current than a TRUSTED legacy
+    // pairing -- e.g. a completed, identified attempt A followed by a
+    // later retry B that completes WITHOUT an identity (env var unset, a
+    // straddling deploy transient). legacyWindow already reflects B's
+    // own clean pair whenever B's own enter and exit are each
+    // individually the latest seen (and thus share the same
+    // -- undefined -- owner) -- prefer whichever candidate is more
+    // recent (its own endMs), identified breaking a tie (the common
+    // single-attempt or already-identified case, where both sides
+    // describe the exact same pair).
     if (bestIdentified && legacyWindow) {
       return bestIdentified.endMs >= legacyWindow.endMs
         ? {

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -913,11 +913,19 @@ export function readEventWindows(path) {
     // mix A's enter with B's exit into a window that looks internally
     // valid but spans two attempts, permanently corrupting attribution
     // if it wins the recency comparison below. legacyWindow is only
-    // trustworthy when its own latest enter and latest exit share the
+    // considered when its own latest enter and latest exit share the
     // SAME owner (both unidentified, or the same identified attempt --
     // the latter is always redundant with a `bestIdentified` candidate,
     // since an identified event updates both the bucketed AND the
-    // unconditional maps together).
+    // unconditional maps together). "Both unidentified" is a necessary
+    // check, not a sufficient one: it cannot distinguish one genuine
+    // unidentified attempt's own clean pair from two DIFFERENT
+    // unidentified attempts whose latest enter and exit happen to line
+    // up (e.g. concurrent sessions C and D, neither stamped, C's enter
+    // and D's exit both being the bareKey's own latest). That residual
+    // is byte-identical to the pairing ambiguity this whole function
+    // pre-#2424 could never resolve either -- identity adds no signal
+    // when neither side carries one.
     const legacyOwnersMatch = enterAtOwner.get(key) === exitAtOwner.get(key);
     const legacyWindow =
       legacyOwnersMatch &&
@@ -1104,6 +1112,20 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
     // evidence" case is when the WINDOW itself lacks an identity
     // (historical data, or a stage that predates this field even though
     // cleanup itself is a fresh, identified completion).
+    //
+    // Two residuals stay unreachable from event identity alone, both
+    // pre-answered rather than fixed:
+    // - identified cleanup + unidentified stage from a genuinely
+    //   DIFFERENT attempt is indistinguishable from the deploy-straddling
+    //   case above: no event-level signal separates "the stage predates
+    //   this field" from "the stage belongs to an unrelated attempt that
+    //   never got identified." Treated as compatible; the ambiguity
+    //   self-resolves once every event postdates this feature's rollout.
+    // - when BOTH the winning cleanup and a stage window are unidentified
+    //   (owners undefined on both sides), this check proves nothing about
+    //   whether they're the same real attempt or two different
+    //   unidentified ones -- byte-identical to the pre-#2424 residual;
+    //   identity cannot see it either way.
     const idCompatible = (window) =>
       window.vendorSessionId === undefined ||
       window.vendorSessionId === cleanup.vendorSessionId;

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -35,6 +35,7 @@ import {
   claudeAdapter,
   defaultClaudeProjectDir,
   extractRecordTimestampMs,
+  extractSessionId,
   parseClaudeProjectLines,
   segmentRecordsByCwd,
 } from './token-cost-adapter-claude.mjs';
@@ -763,7 +764,32 @@ function isTokenCostVendor(value) {
 function eventKey(issueNumber, vendor, stageId) {
   return `${issueNumber}:${vendor}:${stageId}`;
 }
-/** Reads a --events JSONL file into per-(issueNumber, vendor, stageId) enter/exit window overrides. A missing file is not an error -- returns an empty map. */
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.length > 0;
+}
+/**
+ * Reads a --events JSONL file into per-(issueNumber, vendor, stageId)
+ * enter/exit window overrides. A missing file is not an error -- returns
+ * an empty map.
+ *
+ * #2424: `TokenCostEvent.vendorSessionId`, when present on BOTH the enter
+ * and the exit an event carries, scopes pairing to that one attempt --
+ * two attempts for the same (issueNumber, vendor, stageId) key no longer
+ * silently pair one's `--enter` with the other's stale `--exit`. Per
+ * (issueNumber, vendor) group, `cleanup`'s own window is resolved first
+ * (latest VALID -- `startMs < endMs` -- pairing among identified
+ * attempts, falling back to the identity-agnostic latest-wins pairing
+ * this function used before #2424 when no identified attempt has a valid
+ * pair). Every other stage then prefers the candidate sharing `cleanup`'s
+ * own winning `vendorSessionId`; only when no such candidate exists does
+ * it fall back to the same latest-valid-among-identified-attempts rule,
+ * and finally to the identity-agnostic pairing. An event with no
+ * `vendorSessionId` (all historical data, and any vendor with no known
+ * session-id source) never populates an attempt bucket, so a bareKey
+ * whose events are entirely unidentified resolves via the untouched
+ * identity-agnostic path -- byte-identical to this function's pre-#2424
+ * behavior.
+ */
 export function readEventWindows(path) {
   const result = new Map();
   if (!existsSync(path)) {
@@ -771,6 +797,10 @@ export function readEventWindows(path) {
   }
   const enterAt = new Map();
   const exitAt = new Map();
+  // bareKey -> vendorSessionId -> latest timestamp. Only populated for
+  // events that carry a non-empty vendorSessionId.
+  const enterAtByAttempt = new Map();
+  const exitAtByAttempt = new Map();
   const text = readFileSync(path, 'utf8');
   for (const rawLine of text.split('\n')) {
     const line = rawLine.trim();
@@ -801,16 +831,93 @@ export function readEventWindows(path) {
       continue;
     }
     const key = eventKey(event.issueNumber, event.vendor, event.stageId);
+    const vendorSessionId = isNonEmptyString(event.vendorSessionId)
+      ? event.vendorSessionId
+      : undefined;
     if (event.event === 'enter') {
       enterAt.set(key, atMs);
+      if (vendorSessionId !== undefined) {
+        const byAttempt = enterAtByAttempt.get(key) ?? new Map();
+        byAttempt.set(vendorSessionId, atMs);
+        enterAtByAttempt.set(key, byAttempt);
+      }
     } else {
       exitAt.set(key, atMs);
+      if (vendorSessionId !== undefined) {
+        const byAttempt = exitAtByAttempt.get(key) ?? new Map();
+        byAttempt.set(vendorSessionId, atMs);
+        exitAtByAttempt.set(key, byAttempt);
+      }
     }
   }
-  for (const [key, start] of enterAt) {
+  const attemptCandidates = (key) => {
+    const enters = enterAtByAttempt.get(key);
+    const exits = exitAtByAttempt.get(key);
+    if (!enters || !exits) {
+      return [];
+    }
+    const candidates = [];
+    for (const [vendorSessionId, startMs] of enters) {
+      const endMs = exits.get(vendorSessionId);
+      if (endMs !== undefined) {
+        candidates.push({ vendorSessionId, startMs, endMs });
+      }
+    }
+    return candidates;
+  };
+  const resolveWindow = (key, preferredVendorSessionId) => {
+    const candidates = attemptCandidates(key);
+    if (preferredVendorSessionId !== undefined) {
+      const preferred = candidates.find(
+        (candidate) => candidate.vendorSessionId === preferredVendorSessionId,
+      );
+      if (preferred) {
+        return {
+          startMs: preferred.startMs,
+          endMs: preferred.endMs,
+          vendorSessionId: preferred.vendorSessionId,
+        };
+      }
+    }
+    const valid = candidates.filter(
+      (candidate) => candidate.startMs < candidate.endMs,
+    );
+    if (valid.length > 0) {
+      const best = valid.reduce((a, b) => (b.endMs > a.endMs ? b : a));
+      return {
+        startMs: best.startMs,
+        endMs: best.endMs,
+        vendorSessionId: best.vendorSessionId,
+      };
+    }
+    const start = enterAt.get(key);
     const end = exitAt.get(key);
-    if (end !== undefined) {
-      result.set(key, { startMs: start, endMs: end });
+    return start !== undefined && end !== undefined
+      ? { startMs: start, endMs: end }
+      : undefined;
+  };
+  const issueVendorPrefixes = new Set();
+  for (const key of enterAt.keys()) {
+    issueVendorPrefixes.add(key.slice(0, key.lastIndexOf(':')));
+  }
+  for (const key of exitAt.keys()) {
+    issueVendorPrefixes.add(key.slice(0, key.lastIndexOf(':')));
+  }
+  for (const prefix of issueVendorPrefixes) {
+    const cleanupKey = `${prefix}:cleanup`;
+    const cleanupWindow = resolveWindow(cleanupKey, undefined);
+    if (cleanupWindow) {
+      result.set(cleanupKey, cleanupWindow);
+    }
+    for (const stageId of TOKEN_COST_STAGE_IDS) {
+      if (stageId === 'cleanup') {
+        continue;
+      }
+      const key = `${prefix}:${stageId}`;
+      const window = resolveWindow(key, cleanupWindow?.vendorSessionId);
+      if (window) {
+        result.set(key, window);
+      }
     }
   }
   return result;
@@ -886,8 +993,19 @@ function eventWindowsForIssue(all, issueNumber, vendor) {
  *   happens to still be internally valid (non-reversed), e.g. because
  *   BOTH of the later attempt's own enter/exit calls for that stage
  *   failed -- is mechanically indistinguishable from a genuine early
- *   start without an attempt/session identity on `TokenCostEvent`
- *   itself; tracked as a follow-up (#2424) rather than solved here.
+ *   start WITHOUT an attempt/session identity on the underlying events.
+ *   #2424 closes this: `readEventWindows` now tags a window with the
+ *   `vendorSessionId` its enter/exit pair shared (when both events
+ *   carried one), and this function excludes a non-`cleanup` stage from
+ *   BOTH the widening loop and the contamination check above whenever
+ *   its own `vendorSessionId` is known and differs from the winning
+ *   `cleanup` window's own -- before either of those checks even runs,
+ *   so a mismatched attempt's window can neither poison the widened
+ *   `startMs` nor trigger a whole-issue skip on a different attempt's
+ *   behalf. A window with no identity on either side (historical data,
+ *   non-Claude vendors, or an issue whose loop straddles this feature's
+ *   own deployment) is unaffected: identity-compatible windows still
+ *   flow through the pre-#2424 checks exactly as before.
  */
 export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
   const stagesByIssue = new Map();
@@ -910,7 +1028,19 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
     if (!cleanup || cleanup.startMs >= cleanup.endMs) {
       continue;
     }
-    const hasContaminatedStage = [...stages].some(
+    // #2424: a non-cleanup window whose vendorSessionId is known and
+    // differs from cleanup's own belongs to a different attempt --
+    // exclude it outright, before either check below runs. Undefined on
+    // either side means "unidentified"; those windows are unaffected and
+    // still flow through the pre-#2424 checks.
+    const idCompatible = (window) =>
+      cleanup.vendorSessionId === undefined ||
+      window.vendorSessionId === undefined ||
+      window.vendorSessionId === cleanup.vendorSessionId;
+    const candidateStages = [...stages].filter(
+      ([stageId, window]) => stageId === 'cleanup' || idCompatible(window),
+    );
+    const hasContaminatedStage = candidateStages.some(
       ([stageId, window]) =>
         stageId !== 'cleanup' &&
         window.startMs >= window.endMs &&
@@ -920,12 +1050,19 @@ export function buildCompletedIssueWindows(eventWindowsAll, vendor) {
       continue;
     }
     let startMs = cleanup.startMs;
-    for (const window of stages.values()) {
+    for (const [, window] of candidateStages) {
       if (window.startMs <= cleanup.endMs && window.endMs <= cleanup.endMs) {
         startMs = Math.min(startMs, window.startMs);
       }
     }
-    out.push({ issueNumber, startMs, endMs: cleanup.endMs });
+    out.push({
+      issueNumber,
+      startMs,
+      endMs: cleanup.endMs,
+      ...(cleanup.vendorSessionId !== undefined
+        ? { vendorSessionId: cleanup.vendorSessionId }
+        : {}),
+    });
   }
   return out;
 }
@@ -1051,11 +1188,20 @@ function rangesOverlap(a, b) {
  * `#ew<issueNumber>` id, permanently -- exactly the class of bug the
  * original #2418 guard exists to prevent (see the test locking this in:
  * "two DIFFERENT project log files both matching the same issue window
- * are BOTH dropped"). This still classifies each multi-file skip as
- * disjoint-or-overlapping (visible in stderr) for diagnostic value, but
- * both classifications skip -- unchanged from #2418's original behavior.
- * Resolving the cross-file case for real needs session/attempt identity
- * on the underlying events (#2424), not a timestamp heuristic.
+ * are BOTH dropped"). Multi-file skips are still classified as
+ * disjoint-or-overlapping (visible in stderr) for diagnostic value.
+ *
+ * #2424: a `CompletedIssueWindow`'s own `vendorSessionId` (from its
+ * winning `cleanup` event, when identified) is matched against each
+ * candidate file's own `extractSessionId()` -- the SAME value a project
+ * JSONL file's own records carry throughout (stable per file, matches
+ * the file's basename). Exactly one candidate file matching resolves the
+ * issue to that file deterministically, no timestamp heuristic involved;
+ * the others are silently NOT harvested (they belong to a different,
+ * concurrent attempt for the same issue number). Zero or more than one
+ * match -- including every case where the window carries no identity at
+ * all, i.e. every issue whose loop predates this field -- falls back to
+ * the #2425 classify-and-skip behavior unchanged.
  */
 export function scanClaudeVendorSessions(
   projectDir,
@@ -1189,6 +1335,27 @@ export function scanClaudeVendorSessions(
         fileCandidates[0].records,
       );
       continue;
+    }
+    // #2424: resolve by attempt identity before falling back to
+    // classify-and-skip. `extractSessionId` reads each candidate's own
+    // records (a subset of one file), which carry the same sessionId as
+    // the rest of that file.
+    const windowVendorSessionId = completedIssueWindows.find(
+      (window) => window.issueNumber === issueNumber,
+    )?.vendorSessionId;
+    if (windowVendorSessionId !== undefined) {
+      const matching = fileCandidates.filter(
+        (candidate) =>
+          extractSessionId(candidate.records) === windowVendorSessionId,
+      );
+      if (matching.length === 1) {
+        harvestEventWindowCandidate(
+          issueNumber,
+          matching[0].fileBasename,
+          matching[0].records,
+        );
+        continue;
+      }
     }
     const ranges = fileCandidates.map((candidate) =>
       computeRecordTimeRange(candidate.records, extractRecordTimestampMs),

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -776,19 +776,27 @@ function isNonEmptyString(value) {
  * and the exit an event carries, scopes pairing to that one attempt --
  * two attempts for the same (issueNumber, vendor, stageId) key no longer
  * silently pair one's `--enter` with the other's stale `--exit`. Per
- * (issueNumber, vendor) group, `cleanup`'s own window is resolved first
- * (latest VALID -- `startMs < endMs` -- pairing among identified
- * attempts, falling back to the identity-agnostic latest-wins pairing
- * this function used before #2424 when no identified attempt has a valid
- * pair). Every other stage then prefers the candidate sharing `cleanup`'s
- * own winning `vendorSessionId`; only when no such candidate exists does
- * it fall back to the same latest-valid-among-identified-attempts rule,
- * and finally to the identity-agnostic pairing. An event with no
- * `vendorSessionId` (all historical data, and any vendor with no known
- * session-id source) never populates an attempt bucket, so a bareKey
- * whose events are entirely unidentified resolves via the untouched
- * identity-agnostic path -- byte-identical to this function's pre-#2424
- * behavior.
+ * (issueNumber, vendor) group, `cleanup`'s own window is resolved first;
+ * every other stage then prefers the candidate sharing `cleanup`'s own
+ * winning `vendorSessionId` when one exists (regardless of recency -- a
+ * same-attempt candidate is always correct once matched). Absent a
+ * preferred-identity match (including `cleanup`'s own resolution, which
+ * has no preference to match against), this compares the latest VALID
+ * (`startMs < endMs`) pairing among identified attempts against the
+ * identity-agnostic latest-wins pairing this function used before #2424,
+ * and returns whichever has the more recent `endMs` -- identified breaks
+ * a tie. An event with no `vendorSessionId` at all (all historical data,
+ * and any vendor with no known session-id source) never populates an
+ * attempt bucket, so a bareKey whose events are entirely unidentified
+ * resolves via the untouched identity-agnostic path, byte-identical to
+ * this function's pre-#2424 behavior. The recency comparison (rather
+ * than always preferring identified) matters for a completed, identified
+ * attempt followed by a later retry that completes WITHOUT an identity
+ * (env var unset, a deploy-straddling transient) -- an unconditional
+ * identified preference would freeze on the STALE identified completion
+ * forever, since the resulting window's own stable `#ew<issueNumber>` id
+ * makes a later harvest treat it as already-present (Codex review
+ * finding, PR #2430).
  */
 export function readEventWindows(path) {
   const result = new Map();
@@ -882,19 +890,46 @@ export function readEventWindows(path) {
     const valid = candidates.filter(
       (candidate) => candidate.startMs < candidate.endMs,
     );
-    if (valid.length > 0) {
-      const best = valid.reduce((a, b) => (b.endMs > a.endMs ? b : a));
+    const bestIdentified =
+      valid.length > 0
+        ? valid.reduce((a, b) => (b.endMs > a.endMs ? b : a))
+        : undefined;
+    const legacyStartMs = enterAt.get(key);
+    const legacyEndMs = exitAt.get(key);
+    const legacyWindow =
+      legacyStartMs !== undefined &&
+      legacyEndMs !== undefined &&
+      legacyStartMs < legacyEndMs
+        ? { startMs: legacyStartMs, endMs: legacyEndMs }
+        : undefined;
+    // Codex review finding, PR #2430: an identified valid candidate is not
+    // automatically more current than the legacy (identity-agnostic)
+    // latest-wins pairing -- e.g. a completed, identified attempt A
+    // followed by a later retry B that completes WITHOUT an identity
+    // (env var unset, a straddling deploy transient). enterAt/exitAt are
+    // populated unconditionally for every event regardless of identity,
+    // so legacyWindow already reflects B's own clean pair whenever B's
+    // own enter and exit are each individually the latest seen -- prefer
+    // whichever candidate is more recent (its own endMs), identified
+    // breaking a tie (the common single-attempt or already-identified
+    // case, where both sides describe the exact same pair).
+    if (bestIdentified && legacyWindow) {
+      return bestIdentified.endMs >= legacyWindow.endMs
+        ? {
+            startMs: bestIdentified.startMs,
+            endMs: bestIdentified.endMs,
+            vendorSessionId: bestIdentified.vendorSessionId,
+          }
+        : legacyWindow;
+    }
+    if (bestIdentified) {
       return {
-        startMs: best.startMs,
-        endMs: best.endMs,
-        vendorSessionId: best.vendorSessionId,
+        startMs: bestIdentified.startMs,
+        endMs: bestIdentified.endMs,
+        vendorSessionId: bestIdentified.vendorSessionId,
       };
     }
-    const start = enterAt.get(key);
-    const end = exitAt.get(key);
-    return start !== undefined && end !== undefined
-      ? { startMs: start, endMs: end }
-      : undefined;
+    return legacyWindow;
   };
   const issueVendorPrefixes = new Set();
   for (const key of enterAt.keys()) {

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -1328,18 +1328,16 @@ export function scanClaudeVendorSessions(
     candidatesByIssue.set(candidate.issueNumber, list);
   }
   for (const [issueNumber, fileCandidates] of candidatesByIssue) {
-    if (fileCandidates.length === 1) {
-      harvestEventWindowCandidate(
-        issueNumber,
-        fileCandidates[0].fileBasename,
-        fileCandidates[0].records,
-      );
-      continue;
-    }
     // #2424: resolve by attempt identity before falling back to
-    // classify-and-skip. `extractSessionId` reads each candidate's own
-    // records (a subset of one file), which carry the same sessionId as
-    // the rest of that file.
+    // classify-and-skip (or, for a single candidate, unconditional
+    // harvest). `extractSessionId` reads each candidate's own records (a
+    // subset of one file), which carry the same sessionId as the rest of
+    // that file. This also gates the length-1 case: a sole candidate is
+    // NOT automatically the right one when the window has an identity a
+    // file provably fails to match -- e.g. this loop's own event window
+    // whose own session file got excluded upstream (a cwd-inferred
+    // segment already claimed it), leaving only an unrelated concurrent
+    // session's file as candidate.
     const windowVendorSessionId = completedIssueWindows.find(
       (window) => window.issueNumber === issueNumber,
     )?.vendorSessionId;
@@ -1356,6 +1354,19 @@ export function scanClaudeVendorSessions(
         );
         continue;
       }
+      if (fileCandidates.length === 1) {
+        process.stderr.write(
+          `token-cost-harvest: skipping event-window issue #${issueNumber}: the sole candidate file's sessionId does not match the window's vendorSessionId (${fileCandidates[0].fileBasename})\n`,
+        );
+        continue;
+      }
+    } else if (fileCandidates.length === 1) {
+      harvestEventWindowCandidate(
+        issueNumber,
+        fileCandidates[0].fileBasename,
+        fileCandidates[0].records,
+      );
+      continue;
     }
     const ranges = fileCandidates.map((candidate) =>
       computeRecordTimeRange(candidate.records, extractRecordTimestampMs),

--- a/src/scripts/token-cost-adapter-claude.mts
+++ b/src/scripts/token-cost-adapter-claude.mts
@@ -193,7 +193,7 @@ export function extractSessionId(
  * `redactTokenCostRecord()` would later strip to `undefined`, silently
  * producing a schema-invalid sample instead of failing closed.
  */
-function deriveFallbackSessionId(
+export function deriveFallbackSessionId(
   fileBasename: string | undefined,
 ): string | undefined {
   if (!fileBasename) {

--- a/src/scripts/token-cost-adapter-claude.mts
+++ b/src/scripts/token-cost-adapter-claude.mts
@@ -172,7 +172,9 @@ export function parseClaudeProjectLines(text: string): unknown[] {
 }
 
 /** The first non-empty top-level `sessionId` across `records`, in file order -- stable per project JSONL file (it matches the file's own basename). */
-function extractSessionId(records: readonly unknown[]): string | undefined {
+export function extractSessionId(
+  records: readonly unknown[],
+): string | undefined {
   for (const record of records) {
     const sessionId = isPlainObject(record)
       ? getStringField(record, 'sessionId')

--- a/src/scripts/token-cost-event.mts
+++ b/src/scripts/token-cost-event.mts
@@ -56,6 +56,40 @@ export function resolveOutPath(
   return join(stateHome, DEFAULT_OUT_RELATIVE);
 }
 
+// Vendor session env vars this helper knows how to auto-derive
+// `vendorSessionId` from (#2424). Claude-only for now: `$CLAUDE_CODE_SESSION_ID`
+// is a verified real env var whose value matches the session's own
+// `~/.claude/projects/<encoded-cwd>/<id>.jsonl` basename exactly (the same
+// value `extractSessionId()` reads back out of that file's own records in
+// token-cost-adapter-claude.mts). Codex/Grok have no verified equivalent
+// yet -- add a row here once one is confirmed, rather than guessing.
+const VENDOR_SESSION_ID_ENV_VAR: Readonly<Record<string, string>> = {
+  claude: 'CLAUDE_CODE_SESSION_ID',
+};
+
+/**
+ * Reads the env var mapped to `vendor` (if any) and returns its value,
+ * unless it is empty or looks like a filesystem path (`/` or `\` --
+ * schemas/token-cost-event.schema.json's own `vendorSessionId` description
+ * says "Never a filesystem path"; this stamping step is what has to honor
+ * that, since the schema's own type is a bare `["string", "null"]` with no
+ * format the validator enforces).
+ */
+function deriveVendorSessionId(
+  vendor: string,
+  env: NodeJS.ProcessEnv,
+): string | undefined {
+  const envVar = VENDOR_SESSION_ID_ENV_VAR[vendor];
+  if (!envVar) {
+    return undefined;
+  }
+  const value = env[envVar];
+  if (!value || value.includes('/') || value.includes('\\')) {
+    return undefined;
+  }
+  return value;
+}
+
 /**
  * Build one {@link TokenCostEvent} from parsed CLI values and the current
  * time. Throws a plain, human-readable message on any malformed input --
@@ -69,6 +103,7 @@ export function resolveOutPath(
 export function buildEvent(
   values: Record<string, string | boolean | string[] | boolean[] | undefined>,
   now: Date,
+  env: NodeJS.ProcessEnv = process.env,
 ): TokenCostEvent {
   const enter = values.enter === true;
   const exit = values.exit === true;
@@ -90,6 +125,10 @@ export function buildEvent(
     at: now.toISOString(),
     vendor: vendor as TokenCostVendor,
   };
+  const vendorSessionId = deriveVendorSessionId(vendor, env);
+  if (vendorSessionId !== undefined) {
+    event.vendorSessionId = vendorSessionId;
+  }
   const issueRaw = values.issue;
   if (issueRaw !== undefined) {
     if (typeof issueRaw !== 'string') {
@@ -163,6 +202,10 @@ function printHelp(): void {
                      fail-open warning-and-exit-0 behavior.
   --now <ISO8601>    Override the current time (tests only).
   --help, -h         Show this help.
+
+For --vendor claude, vendorSessionId is auto-derived from
+$CLAUDE_CODE_SESSION_ID when set -- no flag needed. No equivalent env var
+is known yet for grok or codex.
 
 Fail-open by default: a bad flag, a schema-invalid event, or an
 unwritable --out path prints a stderr warning and exits 0, so a

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -37,6 +37,7 @@ import {
   type ClaudeHarvestInput,
   claudeAdapter,
   defaultClaudeProjectDir,
+  deriveFallbackSessionId,
   extractRecordTimestampMs,
   extractSessionId,
   parseClaudeProjectLines,
@@ -1713,24 +1714,39 @@ export function scanClaudeVendorSessions(
     });
     candidatesByIssue.set(candidate.issueNumber, list);
   }
+  const vendorSessionIdByIssue = new Map<number, string | undefined>();
+  for (const window of completedIssueWindows) {
+    if (!vendorSessionIdByIssue.has(window.issueNumber)) {
+      vendorSessionIdByIssue.set(window.issueNumber, window.vendorSessionId);
+    }
+  }
+  // #2424/Copilot review (PR #2430): a candidate's own session id must
+  // fall back to its file basename exactly like `claudeAdapter.harvest()`
+  // itself does -- `extractSessionId()` alone returns `undefined` for a
+  // record shape lacking a top-level `sessionId` field (already
+  // fixture-covered for the adapter's own vendorSessionId derivation),
+  // which would otherwise never match a defined `windowVendorSessionId`
+  // even when the file is genuinely the right one.
+  const resolveCandidateSessionId = (candidate: {
+    fileBasename: string;
+    records: unknown[];
+  }): string | undefined =>
+    extractSessionId(candidate.records) ??
+    deriveFallbackSessionId(candidate.fileBasename);
   for (const [issueNumber, fileCandidates] of candidatesByIssue) {
     // #2424: resolve by attempt identity before falling back to
     // classify-and-skip (or, for a single candidate, unconditional
-    // harvest). `extractSessionId` reads each candidate's own records (a
-    // subset of one file), which carry the same sessionId as the rest of
-    // that file. This also gates the length-1 case: a sole candidate is
+    // harvest). This also gates the length-1 case: a sole candidate is
     // NOT automatically the right one when the window has an identity a
     // file provably fails to match -- e.g. this loop's own event window
     // whose own session file got excluded upstream (a cwd-inferred
     // segment already claimed it), leaving only an unrelated concurrent
     // session's file as candidate.
-    const windowVendorSessionId = completedIssueWindows.find(
-      (window) => window.issueNumber === issueNumber,
-    )?.vendorSessionId;
+    const windowVendorSessionId = vendorSessionIdByIssue.get(issueNumber);
     if (windowVendorSessionId !== undefined) {
       const matching = fileCandidates.filter(
         (candidate) =>
-          extractSessionId(candidate.records) === windowVendorSessionId,
+          resolveCandidateSessionId(candidate) === windowVendorSessionId,
       );
       if (matching.length === 1) {
         harvestEventWindowCandidate(

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1126,11 +1126,19 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
     // mix A's enter with B's exit into a window that looks internally
     // valid but spans two attempts, permanently corrupting attribution
     // if it wins the recency comparison below. legacyWindow is only
-    // trustworthy when its own latest enter and latest exit share the
+    // considered when its own latest enter and latest exit share the
     // SAME owner (both unidentified, or the same identified attempt --
     // the latter is always redundant with a `bestIdentified` candidate,
     // since an identified event updates both the bucketed AND the
-    // unconditional maps together).
+    // unconditional maps together). "Both unidentified" is a necessary
+    // check, not a sufficient one: it cannot distinguish one genuine
+    // unidentified attempt's own clean pair from two DIFFERENT
+    // unidentified attempts whose latest enter and exit happen to line
+    // up (e.g. concurrent sessions C and D, neither stamped, C's enter
+    // and D's exit both being the bareKey's own latest). That residual
+    // is byte-identical to the pairing ambiguity this whole function
+    // pre-#2424 could never resolve either -- identity adds no signal
+    // when neither side carries one.
     const legacyOwnersMatch = enterAtOwner.get(key) === exitAtOwner.get(key);
     const legacyWindow =
       legacyOwnersMatch &&
@@ -1341,6 +1349,20 @@ export function buildCompletedIssueWindows(
     // evidence" case is when the WINDOW itself lacks an identity
     // (historical data, or a stage that predates this field even though
     // cleanup itself is a fresh, identified completion).
+    //
+    // Two residuals stay unreachable from event identity alone, both
+    // pre-answered rather than fixed:
+    // - identified cleanup + unidentified stage from a genuinely
+    //   DIFFERENT attempt is indistinguishable from the deploy-straddling
+    //   case above: no event-level signal separates "the stage predates
+    //   this field" from "the stage belongs to an unrelated attempt that
+    //   never got identified." Treated as compatible; the ambiguity
+    //   self-resolves once every event postdates this feature's rollout.
+    // - when BOTH the winning cleanup and a stage window are unidentified
+    //   (owners undefined on both sides), this check proves nothing about
+    //   whether they're the same real attempt or two different
+    //   unidentified ones -- byte-identical to the pre-#2424 residual;
+    //   identity cannot see it either way.
     const idCompatible = (window: StageEventWindow): boolean =>
       window.vendorSessionId === undefined ||
       window.vendorSessionId === cleanup.vendorSessionId;

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1326,11 +1326,22 @@ export function buildCompletedIssueWindows(
     }
     // #2424: a non-cleanup window whose vendorSessionId is known and
     // differs from cleanup's own belongs to a different attempt --
-    // exclude it outright, before either check below runs. Undefined on
-    // either side means "unidentified"; those windows are unaffected and
-    // still flow through the pre-#2424 checks.
+    // exclude it outright, before either check below runs. This is
+    // deliberately ASYMMETRIC, not "undefined on either side means
+    // unidentified, treat as compatible" (Codex review finding round 3,
+    // PR #2430: that symmetric form let an UNIDENTIFIED cleanup --
+    // e.g. a fresh retry that legitimately won readEventWindows' own
+    // recency comparison over a stale identified completion -- absorb
+    // ANY identified stage window unconditionally, including one that
+    // provably belongs to a DIFFERENT, earlier attempt). A window's own
+    // identity, once present, is real evidence of a distinct attempt --
+    // `vendorSessionId` is derived once per Claude Code process
+    // lifetime, so an identified stage and an unidentified cleanup can
+    // never legitimately be the SAME attempt. The only "no contradicting
+    // evidence" case is when the WINDOW itself lacks an identity
+    // (historical data, or a stage that predates this field even though
+    // cleanup itself is a fresh, identified completion).
     const idCompatible = (window: StageEventWindow): boolean =>
-      cleanup.vendorSessionId === undefined ||
       window.vendorSessionId === undefined ||
       window.vendorSessionId === cleanup.vendorSessionId;
     const candidateStages = [...stages].filter(

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1008,6 +1008,13 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
   }
   const enterAt = new Map<string, number>();
   const exitAt = new Map<string, number>();
+  // bareKey -> vendorSessionId of whichever event set enterAt/exitAt's
+  // CURRENT value for that key (undefined when that latest event carried
+  // no identity). Lets the legacy pairing's own trustworthiness be
+  // checked before it competes with an identified candidate -- see
+  // resolveWindow below.
+  const enterAtOwner = new Map<string, string | undefined>();
+  const exitAtOwner = new Map<string, string | undefined>();
   // bareKey -> vendorSessionId -> latest timestamp. Only populated for
   // events that carry a non-empty vendorSessionId.
   const enterAtByAttempt = new Map<string, Map<string, number>>();
@@ -1051,6 +1058,7 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
       : undefined;
     if (event.event === 'enter') {
       enterAt.set(key, atMs);
+      enterAtOwner.set(key, vendorSessionId);
       if (vendorSessionId !== undefined) {
         const byAttempt =
           enterAtByAttempt.get(key) ?? new Map<string, number>();
@@ -1059,6 +1067,7 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
       }
     } else {
       exitAt.set(key, atMs);
+      exitAtOwner.set(key, vendorSessionId);
       if (vendorSessionId !== undefined) {
         const byAttempt = exitAtByAttempt.get(key) ?? new Map<string, number>();
         byAttempt.set(vendorSessionId, atMs);
@@ -1109,23 +1118,38 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
         : undefined;
     const legacyStartMs = enterAt.get(key);
     const legacyEndMs = exitAt.get(key);
+    // Codex review finding round 2, PR #2430: the latest enter and the
+    // latest exit for this bareKey can belong to two DIFFERENT attempts
+    // -- e.g. attempt A posts both cleanup boundaries, and a later
+    // attempt B's own `--enter` call fails to post (fail-open) while its
+    // `--exit` succeeds and lands after A's. enterAt/exitAt would then
+    // mix A's enter with B's exit into a window that looks internally
+    // valid but spans two attempts, permanently corrupting attribution
+    // if it wins the recency comparison below. legacyWindow is only
+    // trustworthy when its own latest enter and latest exit share the
+    // SAME owner (both unidentified, or the same identified attempt --
+    // the latter is always redundant with a `bestIdentified` candidate,
+    // since an identified event updates both the bucketed AND the
+    // unconditional maps together).
+    const legacyOwnersMatch = enterAtOwner.get(key) === exitAtOwner.get(key);
     const legacyWindow =
+      legacyOwnersMatch &&
       legacyStartMs !== undefined &&
       legacyEndMs !== undefined &&
       legacyStartMs < legacyEndMs
         ? { startMs: legacyStartMs, endMs: legacyEndMs }
         : undefined;
-    // Codex review finding, PR #2430: an identified valid candidate is not
-    // automatically more current than the legacy (identity-agnostic)
-    // latest-wins pairing -- e.g. a completed, identified attempt A
-    // followed by a later retry B that completes WITHOUT an identity
-    // (env var unset, a straddling deploy transient). enterAt/exitAt are
-    // populated unconditionally for every event regardless of identity,
-    // so legacyWindow already reflects B's own clean pair whenever B's
-    // own enter and exit are each individually the latest seen -- prefer
-    // whichever candidate is more recent (its own endMs), identified
-    // breaking a tie (the common single-attempt or already-identified
-    // case, where both sides describe the exact same pair).
+    // Codex review finding round 1, PR #2430: an identified valid
+    // candidate is not automatically more current than a TRUSTED legacy
+    // pairing -- e.g. a completed, identified attempt A followed by a
+    // later retry B that completes WITHOUT an identity (env var unset, a
+    // straddling deploy transient). legacyWindow already reflects B's
+    // own clean pair whenever B's own enter and exit are each
+    // individually the latest seen (and thus share the same
+    // -- undefined -- owner) -- prefer whichever candidate is more
+    // recent (its own endMs), identified breaking a tie (the common
+    // single-attempt or already-identified case, where both sides
+    // describe the exact same pair).
     if (bestIdentified && legacyWindow) {
       return bestIdentified.endMs >= legacyWindow.endMs
         ? {

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1363,6 +1363,27 @@ export function buildCompletedIssueWindows(
     //   whether they're the same real attempt or two different
     //   unidentified ones -- byte-identical to the pre-#2424 residual;
     //   identity cannot see it either way.
+    //
+    // A third, accepted tradeoff (Codex review finding round 5, PR #2430,
+    // #2424): a `vendorSessionId` mismatch proves a different PROCESS, not
+    // a different ATTEMPT -- docs/token-cost.md's own Scope explicitly
+    // allows one issue loop to span multiple Claude sessions via a
+    // handoff or resume. This check has no way to tell that legitimate
+    // case apart from a genuinely unrelated, abandoned earlier attempt,
+    // so it excludes both alike. Widening the window to include the
+    // earlier session's own stage would not by itself recover its usage
+    // either: `scanClaudeVendorSessions` harvests one session log file
+    // per completed window, so an earlier handoff session's records live
+    // in a file this resolution never selects -- a widened-but-single-
+    // file harvest would misrepresent its own coverage (bounds spanning
+    // both sessions, records covering only one), which is worse than
+    // today's narrower-but-honest one. Merging records across a
+    // confirmed handoff's files needs a positive-evidence rule this
+    // event stream alone can't supply; tracked separately (#2432) rather
+    // than attempted here. Until then this is a documented undercount,
+    // not a bug: recoverable once #2432 ships, unlike the permanent
+    // contamination a wrong inclusion would freeze under a stable
+    // `#ew<issueNumber>` sample id.
     const idCompatible = (window: StageEventWindow): boolean =>
       window.vendorSessionId === undefined ||
       window.vendorSessionId === cleanup.vendorSessionId;

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1601,18 +1601,16 @@ export function scanClaudeVendorSessions(
     candidatesByIssue.set(candidate.issueNumber, list);
   }
   for (const [issueNumber, fileCandidates] of candidatesByIssue) {
-    if (fileCandidates.length === 1) {
-      harvestEventWindowCandidate(
-        issueNumber,
-        fileCandidates[0].fileBasename,
-        fileCandidates[0].records,
-      );
-      continue;
-    }
     // #2424: resolve by attempt identity before falling back to
-    // classify-and-skip. `extractSessionId` reads each candidate's own
-    // records (a subset of one file), which carry the same sessionId as
-    // the rest of that file.
+    // classify-and-skip (or, for a single candidate, unconditional
+    // harvest). `extractSessionId` reads each candidate's own records (a
+    // subset of one file), which carry the same sessionId as the rest of
+    // that file. This also gates the length-1 case: a sole candidate is
+    // NOT automatically the right one when the window has an identity a
+    // file provably fails to match -- e.g. this loop's own event window
+    // whose own session file got excluded upstream (a cwd-inferred
+    // segment already claimed it), leaving only an unrelated concurrent
+    // session's file as candidate.
     const windowVendorSessionId = completedIssueWindows.find(
       (window) => window.issueNumber === issueNumber,
     )?.vendorSessionId;
@@ -1629,6 +1627,19 @@ export function scanClaudeVendorSessions(
         );
         continue;
       }
+      if (fileCandidates.length === 1) {
+        process.stderr.write(
+          `token-cost-harvest: skipping event-window issue #${issueNumber}: the sole candidate file's sessionId does not match the window's vendorSessionId (${fileCandidates[0].fileBasename})\n`,
+        );
+        continue;
+      }
+    } else if (fileCandidates.length === 1) {
+      harvestEventWindowCandidate(
+        issueNumber,
+        fileCandidates[0].fileBasename,
+        fileCandidates[0].records,
+      );
+      continue;
     }
     const ranges = fileCandidates.map((candidate) =>
       computeRecordTimeRange(candidate.records, extractRecordTimestampMs),

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -979,19 +979,27 @@ interface AttemptCandidate {
  * and the exit an event carries, scopes pairing to that one attempt --
  * two attempts for the same (issueNumber, vendor, stageId) key no longer
  * silently pair one's `--enter` with the other's stale `--exit`. Per
- * (issueNumber, vendor) group, `cleanup`'s own window is resolved first
- * (latest VALID -- `startMs < endMs` -- pairing among identified
- * attempts, falling back to the identity-agnostic latest-wins pairing
- * this function used before #2424 when no identified attempt has a valid
- * pair). Every other stage then prefers the candidate sharing `cleanup`'s
- * own winning `vendorSessionId`; only when no such candidate exists does
- * it fall back to the same latest-valid-among-identified-attempts rule,
- * and finally to the identity-agnostic pairing. An event with no
- * `vendorSessionId` (all historical data, and any vendor with no known
- * session-id source) never populates an attempt bucket, so a bareKey
- * whose events are entirely unidentified resolves via the untouched
- * identity-agnostic path -- byte-identical to this function's pre-#2424
- * behavior.
+ * (issueNumber, vendor) group, `cleanup`'s own window is resolved first;
+ * every other stage then prefers the candidate sharing `cleanup`'s own
+ * winning `vendorSessionId` when one exists (regardless of recency -- a
+ * same-attempt candidate is always correct once matched). Absent a
+ * preferred-identity match (including `cleanup`'s own resolution, which
+ * has no preference to match against), this compares the latest VALID
+ * (`startMs < endMs`) pairing among identified attempts against the
+ * identity-agnostic latest-wins pairing this function used before #2424,
+ * and returns whichever has the more recent `endMs` -- identified breaks
+ * a tie. An event with no `vendorSessionId` at all (all historical data,
+ * and any vendor with no known session-id source) never populates an
+ * attempt bucket, so a bareKey whose events are entirely unidentified
+ * resolves via the untouched identity-agnostic path, byte-identical to
+ * this function's pre-#2424 behavior. The recency comparison (rather
+ * than always preferring identified) matters for a completed, identified
+ * attempt followed by a later retry that completes WITHOUT an identity
+ * (env var unset, a deploy-straddling transient) -- an unconditional
+ * identified preference would freeze on the STALE identified completion
+ * forever, since the resulting window's own stable `#ew<issueNumber>` id
+ * makes a later harvest treat it as already-present (Codex review
+ * finding, PR #2430).
  */
 export function readEventWindows(path: string): Map<string, StageEventWindow> {
   const result = new Map<string, StageEventWindow>();
@@ -1095,19 +1103,46 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
     const valid = candidates.filter(
       (candidate) => candidate.startMs < candidate.endMs,
     );
-    if (valid.length > 0) {
-      const best = valid.reduce((a, b) => (b.endMs > a.endMs ? b : a));
+    const bestIdentified =
+      valid.length > 0
+        ? valid.reduce((a, b) => (b.endMs > a.endMs ? b : a))
+        : undefined;
+    const legacyStartMs = enterAt.get(key);
+    const legacyEndMs = exitAt.get(key);
+    const legacyWindow =
+      legacyStartMs !== undefined &&
+      legacyEndMs !== undefined &&
+      legacyStartMs < legacyEndMs
+        ? { startMs: legacyStartMs, endMs: legacyEndMs }
+        : undefined;
+    // Codex review finding, PR #2430: an identified valid candidate is not
+    // automatically more current than the legacy (identity-agnostic)
+    // latest-wins pairing -- e.g. a completed, identified attempt A
+    // followed by a later retry B that completes WITHOUT an identity
+    // (env var unset, a straddling deploy transient). enterAt/exitAt are
+    // populated unconditionally for every event regardless of identity,
+    // so legacyWindow already reflects B's own clean pair whenever B's
+    // own enter and exit are each individually the latest seen -- prefer
+    // whichever candidate is more recent (its own endMs), identified
+    // breaking a tie (the common single-attempt or already-identified
+    // case, where both sides describe the exact same pair).
+    if (bestIdentified && legacyWindow) {
+      return bestIdentified.endMs >= legacyWindow.endMs
+        ? {
+            startMs: bestIdentified.startMs,
+            endMs: bestIdentified.endMs,
+            vendorSessionId: bestIdentified.vendorSessionId,
+          }
+        : legacyWindow;
+    }
+    if (bestIdentified) {
       return {
-        startMs: best.startMs,
-        endMs: best.endMs,
-        vendorSessionId: best.vendorSessionId,
+        startMs: bestIdentified.startMs,
+        endMs: bestIdentified.endMs,
+        vendorSessionId: bestIdentified.vendorSessionId,
       };
     }
-    const start = enterAt.get(key);
-    const end = exitAt.get(key);
-    return start !== undefined && end !== undefined
-      ? { startMs: start, endMs: end }
-      : undefined;
+    return legacyWindow;
   };
 
   const issueVendorPrefixes = new Set<string>();

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -38,6 +38,7 @@ import {
   claudeAdapter,
   defaultClaudeProjectDir,
   extractRecordTimestampMs,
+  extractSessionId,
   parseClaudeProjectLines,
   segmentRecordsByCwd,
 } from './token-cost-adapter-claude.mts';
@@ -292,6 +293,8 @@ export interface IssueLoopGithubContext {
 export interface StageEventWindow {
   startMs: number;
   endMs: number;
+  /** The enter/exit pair's shared vendorSessionId (#2424), when both events carried one. Absent for historical data and vendors with no known session-id source. */
+  vendorSessionId?: string;
 }
 
 const CLAIM_STAGE_CAP_MS = 15 * 60 * 1000;
@@ -957,7 +960,39 @@ function eventKey(
   return `${issueNumber}:${vendor}:${stageId}`;
 }
 
-/** Reads a --events JSONL file into per-(issueNumber, vendor, stageId) enter/exit window overrides. A missing file is not an error -- returns an empty map. */
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+interface AttemptCandidate {
+  vendorSessionId: string;
+  startMs: number;
+  endMs: number;
+}
+
+/**
+ * Reads a --events JSONL file into per-(issueNumber, vendor, stageId)
+ * enter/exit window overrides. A missing file is not an error -- returns
+ * an empty map.
+ *
+ * #2424: `TokenCostEvent.vendorSessionId`, when present on BOTH the enter
+ * and the exit an event carries, scopes pairing to that one attempt --
+ * two attempts for the same (issueNumber, vendor, stageId) key no longer
+ * silently pair one's `--enter` with the other's stale `--exit`. Per
+ * (issueNumber, vendor) group, `cleanup`'s own window is resolved first
+ * (latest VALID -- `startMs < endMs` -- pairing among identified
+ * attempts, falling back to the identity-agnostic latest-wins pairing
+ * this function used before #2424 when no identified attempt has a valid
+ * pair). Every other stage then prefers the candidate sharing `cleanup`'s
+ * own winning `vendorSessionId`; only when no such candidate exists does
+ * it fall back to the same latest-valid-among-identified-attempts rule,
+ * and finally to the identity-agnostic pairing. An event with no
+ * `vendorSessionId` (all historical data, and any vendor with no known
+ * session-id source) never populates an attempt bucket, so a bareKey
+ * whose events are entirely unidentified resolves via the untouched
+ * identity-agnostic path -- byte-identical to this function's pre-#2424
+ * behavior.
+ */
 export function readEventWindows(path: string): Map<string, StageEventWindow> {
   const result = new Map<string, StageEventWindow>();
   if (!existsSync(path)) {
@@ -965,6 +1000,10 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
   }
   const enterAt = new Map<string, number>();
   const exitAt = new Map<string, number>();
+  // bareKey -> vendorSessionId -> latest timestamp. Only populated for
+  // events that carry a non-empty vendorSessionId.
+  const enterAtByAttempt = new Map<string, Map<string, number>>();
+  const exitAtByAttempt = new Map<string, Map<string, number>>();
   const text = readFileSync(path, 'utf8');
   for (const rawLine of text.split('\n')) {
     const line = rawLine.trim();
@@ -999,16 +1038,101 @@ export function readEventWindows(path: string): Map<string, StageEventWindow> {
       event.vendor,
       event.stageId as TokenCostStageId,
     );
+    const vendorSessionId = isNonEmptyString(event.vendorSessionId)
+      ? event.vendorSessionId
+      : undefined;
     if (event.event === 'enter') {
       enterAt.set(key, atMs);
+      if (vendorSessionId !== undefined) {
+        const byAttempt =
+          enterAtByAttempt.get(key) ?? new Map<string, number>();
+        byAttempt.set(vendorSessionId, atMs);
+        enterAtByAttempt.set(key, byAttempt);
+      }
     } else {
       exitAt.set(key, atMs);
+      if (vendorSessionId !== undefined) {
+        const byAttempt = exitAtByAttempt.get(key) ?? new Map<string, number>();
+        byAttempt.set(vendorSessionId, atMs);
+        exitAtByAttempt.set(key, byAttempt);
+      }
     }
   }
-  for (const [key, start] of enterAt) {
+
+  const attemptCandidates = (key: string): AttemptCandidate[] => {
+    const enters = enterAtByAttempt.get(key);
+    const exits = exitAtByAttempt.get(key);
+    if (!enters || !exits) {
+      return [];
+    }
+    const candidates: AttemptCandidate[] = [];
+    for (const [vendorSessionId, startMs] of enters) {
+      const endMs = exits.get(vendorSessionId);
+      if (endMs !== undefined) {
+        candidates.push({ vendorSessionId, startMs, endMs });
+      }
+    }
+    return candidates;
+  };
+
+  const resolveWindow = (
+    key: string,
+    preferredVendorSessionId: string | undefined,
+  ): StageEventWindow | undefined => {
+    const candidates = attemptCandidates(key);
+    if (preferredVendorSessionId !== undefined) {
+      const preferred = candidates.find(
+        (candidate) => candidate.vendorSessionId === preferredVendorSessionId,
+      );
+      if (preferred) {
+        return {
+          startMs: preferred.startMs,
+          endMs: preferred.endMs,
+          vendorSessionId: preferred.vendorSessionId,
+        };
+      }
+    }
+    const valid = candidates.filter(
+      (candidate) => candidate.startMs < candidate.endMs,
+    );
+    if (valid.length > 0) {
+      const best = valid.reduce((a, b) => (b.endMs > a.endMs ? b : a));
+      return {
+        startMs: best.startMs,
+        endMs: best.endMs,
+        vendorSessionId: best.vendorSessionId,
+      };
+    }
+    const start = enterAt.get(key);
     const end = exitAt.get(key);
-    if (end !== undefined) {
-      result.set(key, { startMs: start, endMs: end });
+    return start !== undefined && end !== undefined
+      ? { startMs: start, endMs: end }
+      : undefined;
+  };
+
+  const issueVendorPrefixes = new Set<string>();
+  for (const key of enterAt.keys()) {
+    issueVendorPrefixes.add(key.slice(0, key.lastIndexOf(':')));
+  }
+  for (const key of exitAt.keys()) {
+    issueVendorPrefixes.add(key.slice(0, key.lastIndexOf(':')));
+  }
+
+  for (const prefix of issueVendorPrefixes) {
+    const cleanupKey = `${prefix}:cleanup`;
+    const cleanupWindow = resolveWindow(cleanupKey, undefined);
+    if (cleanupWindow) {
+      result.set(cleanupKey, cleanupWindow);
+    }
+    for (const stageId of TOKEN_COST_STAGE_IDS) {
+      if (stageId === 'cleanup') {
+        continue;
+      }
+      const key = `${prefix}:${stageId}`;
+      const window = resolveWindow(key, cleanupWindow?.vendorSessionId);
+      if (window) {
+        result.set(key, window);
+      }
     }
   }
   return result;
@@ -1038,6 +1162,8 @@ export interface CompletedIssueWindow {
   issueNumber: number;
   startMs: number;
   endMs: number;
+  /** The winning `cleanup` window's own vendorSessionId (#2424), when known -- lets a cross-file resolver attribute this window to the one file that actually posted it. */
+  vendorSessionId?: string;
 }
 
 /**
@@ -1101,8 +1227,19 @@ export interface CompletedIssueWindow {
  *   happens to still be internally valid (non-reversed), e.g. because
  *   BOTH of the later attempt's own enter/exit calls for that stage
  *   failed -- is mechanically indistinguishable from a genuine early
- *   start without an attempt/session identity on `TokenCostEvent`
- *   itself; tracked as a follow-up (#2424) rather than solved here.
+ *   start WITHOUT an attempt/session identity on the underlying events.
+ *   #2424 closes this: `readEventWindows` now tags a window with the
+ *   `vendorSessionId` its enter/exit pair shared (when both events
+ *   carried one), and this function excludes a non-`cleanup` stage from
+ *   BOTH the widening loop and the contamination check above whenever
+ *   its own `vendorSessionId` is known and differs from the winning
+ *   `cleanup` window's own -- before either of those checks even runs,
+ *   so a mismatched attempt's window can neither poison the widened
+ *   `startMs` nor trigger a whole-issue skip on a different attempt's
+ *   behalf. A window with no identity on either side (historical data,
+ *   non-Claude vendors, or an issue whose loop straddles this feature's
+ *   own deployment) is unaffected: identity-compatible windows still
+ *   flow through the pre-#2424 checks exactly as before.
  */
 export function buildCompletedIssueWindows(
   eventWindowsAll: ReadonlyMap<string, StageEventWindow>,
@@ -1128,7 +1265,19 @@ export function buildCompletedIssueWindows(
     if (!cleanup || cleanup.startMs >= cleanup.endMs) {
       continue;
     }
-    const hasContaminatedStage = [...stages].some(
+    // #2424: a non-cleanup window whose vendorSessionId is known and
+    // differs from cleanup's own belongs to a different attempt --
+    // exclude it outright, before either check below runs. Undefined on
+    // either side means "unidentified"; those windows are unaffected and
+    // still flow through the pre-#2424 checks.
+    const idCompatible = (window: StageEventWindow): boolean =>
+      cleanup.vendorSessionId === undefined ||
+      window.vendorSessionId === undefined ||
+      window.vendorSessionId === cleanup.vendorSessionId;
+    const candidateStages = [...stages].filter(
+      ([stageId, window]) => stageId === 'cleanup' || idCompatible(window),
+    );
+    const hasContaminatedStage = candidateStages.some(
       ([stageId, window]) =>
         stageId !== 'cleanup' &&
         window.startMs >= window.endMs &&
@@ -1138,12 +1287,19 @@ export function buildCompletedIssueWindows(
       continue;
     }
     let startMs = cleanup.startMs;
-    for (const window of stages.values()) {
+    for (const [, window] of candidateStages) {
       if (window.startMs <= cleanup.endMs && window.endMs <= cleanup.endMs) {
         startMs = Math.min(startMs, window.startMs);
       }
     }
-    out.push({ issueNumber, startMs, endMs: cleanup.endMs });
+    out.push({
+      issueNumber,
+      startMs,
+      endMs: cleanup.endMs,
+      ...(cleanup.vendorSessionId !== undefined
+        ? { vendorSessionId: cleanup.vendorSessionId }
+        : {}),
+    });
   }
   return out;
 }
@@ -1291,11 +1447,20 @@ function rangesOverlap(a: RecordTimeRange, b: RecordTimeRange): boolean {
  * `#ew<issueNumber>` id, permanently -- exactly the class of bug the
  * original #2418 guard exists to prevent (see the test locking this in:
  * "two DIFFERENT project log files both matching the same issue window
- * are BOTH dropped"). This still classifies each multi-file skip as
- * disjoint-or-overlapping (visible in stderr) for diagnostic value, but
- * both classifications skip -- unchanged from #2418's original behavior.
- * Resolving the cross-file case for real needs session/attempt identity
- * on the underlying events (#2424), not a timestamp heuristic.
+ * are BOTH dropped"). Multi-file skips are still classified as
+ * disjoint-or-overlapping (visible in stderr) for diagnostic value.
+ *
+ * #2424: a `CompletedIssueWindow`'s own `vendorSessionId` (from its
+ * winning `cleanup` event, when identified) is matched against each
+ * candidate file's own `extractSessionId()` -- the SAME value a project
+ * JSONL file's own records carry throughout (stable per file, matches
+ * the file's basename). Exactly one candidate file matching resolves the
+ * issue to that file deterministically, no timestamp heuristic involved;
+ * the others are silently NOT harvested (they belong to a different,
+ * concurrent attempt for the same issue number). Zero or more than one
+ * match -- including every case where the window carries no identity at
+ * all, i.e. every issue whose loop predates this field -- falls back to
+ * the #2425 classify-and-skip behavior unchanged.
  */
 export function scanClaudeVendorSessions(
   projectDir: string,
@@ -1443,6 +1608,27 @@ export function scanClaudeVendorSessions(
         fileCandidates[0].records,
       );
       continue;
+    }
+    // #2424: resolve by attempt identity before falling back to
+    // classify-and-skip. `extractSessionId` reads each candidate's own
+    // records (a subset of one file), which carry the same sessionId as
+    // the rest of that file.
+    const windowVendorSessionId = completedIssueWindows.find(
+      (window) => window.issueNumber === issueNumber,
+    )?.vendorSessionId;
+    if (windowVendorSessionId !== undefined) {
+      const matching = fileCandidates.filter(
+        (candidate) =>
+          extractSessionId(candidate.records) === windowVendorSessionId,
+      );
+      if (matching.length === 1) {
+        harvestEventWindowCandidate(
+          issueNumber,
+          matching[0].fileBasename,
+          matching[0].records,
+        );
+        continue;
+      }
     }
     const ranges = fileCandidates.map((candidate) =>
       computeRecordTimeRange(candidate.records, extractRecordTimestampMs),

--- a/tests/token-cost-event.test.mts
+++ b/tests/token-cost-event.test.mts
@@ -26,13 +26,27 @@ function tempDir(): string {
   return mkdtempSync(join(tmpdir(), 'idd-token-cost-event-test-'));
 }
 
-function runCli(args: readonly string[]): {
+// Stripped from the spawned child's inherited env by default so a CLI
+// test's assertions stay deterministic regardless of whether the real
+// host process (this very test run included) happens to have
+// CLAUDE_CODE_SESSION_ID set. A test exercising the stamping behavior
+// itself passes it back in via runCli's own envOverrides.
+function stripVendorSessionEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const { CLAUDE_CODE_SESSION_ID: _omit, ...rest } = env;
+  return rest;
+}
+
+function runCli(
+  args: readonly string[],
+  envOverrides: NodeJS.ProcessEnv = {},
+): {
   status: number;
   stdout: string;
   stderr: string;
 } {
   const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
     encoding: 'utf8',
+    env: { ...stripVendorSessionEnv(process.env), ...envOverrides },
   });
   return {
     status: result.status ?? -1,
@@ -82,6 +96,7 @@ test('buildEvent builds a schema-shaped enter event', () => {
   const event = buildEvent(
     { stage: 'discover', enter: true, exit: false, vendor: 'claude' },
     NOW,
+    {},
   );
   assert.deepEqual(event, {
     schemaVersion: 1,
@@ -96,6 +111,7 @@ test('buildEvent builds a schema-shaped exit event with an issue number', () => 
   const event = buildEvent(
     { stage: 'work', enter: false, exit: true, vendor: 'codex', issue: '2293' },
     NOW,
+    {},
   );
   assert.deepEqual(event, {
     schemaVersion: 1,
@@ -162,6 +178,46 @@ test('buildEvent throws on a non-positive --issue', () => {
 });
 
 // ---------------------------------------------------------------------------
+// buildEvent -- vendorSessionId auto-derive (#2424)
+// ---------------------------------------------------------------------------
+
+test('buildEvent stamps vendorSessionId from CLAUDE_CODE_SESSION_ID for vendor claude', () => {
+  const event = buildEvent(
+    { stage: 'work', enter: true, vendor: 'claude' },
+    NOW,
+    { CLAUDE_CODE_SESSION_ID: 'sess-abc123' },
+  );
+  assert.equal(event.vendorSessionId, 'sess-abc123');
+});
+
+test('buildEvent leaves vendorSessionId unset for vendor claude when CLAUDE_CODE_SESSION_ID is unset', () => {
+  const event = buildEvent(
+    { stage: 'work', enter: true, vendor: 'claude' },
+    NOW,
+    {},
+  );
+  assert.equal('vendorSessionId' in event, false);
+});
+
+test('buildEvent leaves vendorSessionId unset for a vendor with no known session env var', () => {
+  const event = buildEvent(
+    { stage: 'work', enter: true, vendor: 'grok' },
+    NOW,
+    { CLAUDE_CODE_SESSION_ID: 'sess-abc123' },
+  );
+  assert.equal('vendorSessionId' in event, false);
+});
+
+test('buildEvent rejects a path-like CLAUDE_CODE_SESSION_ID value rather than stamping it', () => {
+  const event = buildEvent(
+    { stage: 'work', enter: true, vendor: 'claude' },
+    NOW,
+    { CLAUDE_CODE_SESSION_ID: '/etc/passwd' },
+  );
+  assert.equal('vendorSessionId' in event, false);
+});
+
+// ---------------------------------------------------------------------------
 // writeEvent
 // ---------------------------------------------------------------------------
 
@@ -172,6 +228,7 @@ test('writeEvent appends one schema-valid JSONL line, creating the parent direct
     const event = buildEvent(
       { stage: 'claim', enter: true, vendor: 'grok' },
       NOW,
+      {},
     );
     writeEvent(event, outPath);
     const lines = readFileSync(outPath, 'utf8').trim().split('\n');
@@ -187,11 +244,11 @@ test('writeEvent appends without truncating an existing file', () => {
   try {
     const outPath = join(dir, 'events.jsonl');
     writeEvent(
-      buildEvent({ stage: 'claim', enter: true, vendor: 'grok' }, NOW),
+      buildEvent({ stage: 'claim', enter: true, vendor: 'grok' }, NOW, {}),
       outPath,
     );
     writeEvent(
-      buildEvent({ stage: 'claim', exit: true, vendor: 'grok' }, NOW),
+      buildEvent({ stage: 'claim', exit: true, vendor: 'grok' }, NOW, {}),
       outPath,
     );
     const lines = readFileSync(outPath, 'utf8').trim().split('\n');
@@ -208,6 +265,7 @@ test('writeEvent throws for a stageId the schema does not enumerate', () => {
     const event = buildEvent(
       { stage: 'bogus-stage', enter: true, vendor: 'claude' },
       NOW,
+      {},
     );
     assert.throws(() => writeEvent(event, outPath), /fails schema validation/);
   } finally {
@@ -222,6 +280,7 @@ test('writeEvent throws for a vendor the schema does not enumerate', () => {
     const event = buildEvent(
       { stage: 'discover', enter: true, vendor: 'bogus-vendor' },
       NOW,
+      {},
     );
     assert.throws(() => writeEvent(event, outPath), /fails schema validation/);
   } finally {
@@ -377,6 +436,57 @@ test('CLI --claim-id is accepted but not persisted in the written event', () => 
     const written = JSON.parse(readFileSync(outPath, 'utf8').trim());
     assert.equal('claimId' in written, false);
     assert.equal('claim-id' in written, false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI stamps vendorSessionId from an inherited CLAUDE_CODE_SESSION_ID for --vendor claude', () => {
+  const dir = tempDir();
+  try {
+    const outPath = join(dir, 'events.jsonl');
+    const result = runCli(
+      [
+        '--stage',
+        'work',
+        '--enter',
+        '--vendor',
+        'claude',
+        '--out',
+        outPath,
+        '--now',
+        NOW.toISOString(),
+        '--strict',
+      ],
+      { CLAUDE_CODE_SESSION_ID: 'sess-cli-test' },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const written = JSON.parse(readFileSync(outPath, 'utf8').trim());
+    assert.equal(written.vendorSessionId, 'sess-cli-test');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('CLI omits vendorSessionId by default (no CLAUDE_CODE_SESSION_ID inherited)', () => {
+  const dir = tempDir();
+  try {
+    const outPath = join(dir, 'events.jsonl');
+    const result = runCli([
+      '--stage',
+      'work',
+      '--enter',
+      '--vendor',
+      'claude',
+      '--out',
+      outPath,
+      '--now',
+      NOW.toISOString(),
+      '--strict',
+    ]);
+    assert.equal(result.status, 0, result.stderr);
+    const written = JSON.parse(readFileSync(outPath, 'utf8').trim());
+    assert.equal('vendorSessionId' in written, false);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -1957,6 +1957,47 @@ test('readEventWindows: an identified completion still wins on a tie against the
   }
 });
 
+test("readEventWindows: rejects a legacy pairing that mixes one attempt's enter with a DIFFERENT attempt's exit (Codex review finding round 2, PR #2430, #2424)", () => {
+  // Attempt A posts both cleanup boundaries (identified, valid). A later
+  // attempt B's own --enter call fails to post (token-cost-event.mjs is
+  // fail-open) but its --exit succeeds, landing after A's. The legacy
+  // (identity-agnostic) latest-enter/latest-exit pairing would combine
+  // A's enter with B's exit -- internally valid-LOOKING, but spanning two
+  // attempts. That must never win the recency comparison against A's own
+  // clean pair: A's own window is the only trustworthy result here.
+  const { dir, path } = writeEventsFile([
+    tokenCostEvent('enter', 'cleanup', '2026-01-01T00:00:01Z', 509, 'sess-A'),
+    tokenCostEvent('exit', 'cleanup', '2026-01-01T00:00:02Z', 509, 'sess-A'),
+    tokenCostEvent('exit', 'cleanup', '2026-01-01T00:00:09Z', 509, 'sess-B'),
+  ]);
+  try {
+    const windows = readEventWindows(path);
+    const cleanup = windows.get('509:claude:cleanup');
+    assert.equal(cleanup?.vendorSessionId, 'sess-A');
+    assert.equal(cleanup?.startMs, ms('2026-01-01T00:00:01Z'));
+    assert.equal(cleanup?.endMs, ms('2026-01-01T00:00:02Z'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readEventWindows: rejects a legacy pairing whose latest enter and exit belong to two DIFFERENT identified attempts, with no identified candidate to fall back to either (#2424)', () => {
+  // Neither attempt ever completes its own pair (A's exit missing, B's
+  // enter missing), so there is no bestIdentified candidate at all. The
+  // legacy pairing would still mix A's enter with B's exit if not gated
+  // -- must resolve to no window at all rather than a cross-attempt mix.
+  const { dir, path } = writeEventsFile([
+    tokenCostEvent('enter', 'cleanup', '2026-01-01T00:00:01Z', 510, 'sess-A'),
+    tokenCostEvent('exit', 'cleanup', '2026-01-01T00:00:09Z', 510, 'sess-B'),
+  ]);
+  try {
+    const windows = readEventWindows(path);
+    assert.equal(windows.get('510:claude:cleanup'), undefined);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Trusted marker logins
 // ---------------------------------------------------------------------------

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -1011,6 +1011,51 @@ test("scanClaudeVendorSessions: a cross-file match is resolved (not skipped) whe
   assert.equal(sessions.length, 3);
 });
 
+test("scanClaudeVendorSessions: a cross-file match resolves via the SAME basename fallback claudeAdapter.harvest() uses, when the winning file's own records carry no top-level sessionId (Copilot review finding, PR #2430, #2424)", () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  // No top-level "sessionId" field on this file's records -- extractSessionId()
+  // alone returns undefined here; only the basename fallback recovers the
+  // real id ($CLAUDE_CODE_SESSION_ID matches a session log's own basename).
+  writeFileSync(
+    join(sandbox, 'session-ew-idH.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:20:00.000Z","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}\n',
+  );
+  writeFileSync(
+    join(sandbox, 'session-ew-idI.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:21:00.000Z","sessionId":"sess-ew-idI-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":5,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":5}}}\n',
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow(
+        '2026-01-01T00:10:00Z',
+        '2026-01-01T00:25:00Z',
+        'session-ew-idH',
+      ),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:26:00Z',
+        '2026-01-01T00:30:00Z',
+        'session-ew-idH',
+      ),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew'),
+  );
+
+  assert.equal(ewSamples.length, 1);
+  assert.equal(
+    ewSamples[0].adapterResult.sample.vendorSessionId,
+    'session-ew-idH#ew501',
+  );
+  assert.equal(sessions.length, 3);
+});
+
 test("scanClaudeVendorSessions: falls back to classify-and-skip when no candidate file's sessionId matches the window's vendorSessionId (#2424)", () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
   writeFileSync(

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -767,6 +767,32 @@ test('buildCompletedIssueWindows: an unidentified non-cleanup window is unaffect
   assert.equal(windows[0].vendorSessionId, 'attempt-A');
 });
 
+test('buildCompletedIssueWindows: an IDENTIFIED non-cleanup window from a stale attempt is excluded when cleanup itself is UNIDENTIFIED (Codex review finding round 3, PR #2430, #2424)', () => {
+  // The reverse of the case above, and NOT symmetric: cleanup belongs to
+  // a fresh, unidentified retry (it legitimately won readEventWindows'
+  // own recency comparison over a stale identified completion). 'work'
+  // is a STALE, identified window from an EARLIER, different attempt.
+  // vendorSessionId is derived once per Claude Code process lifetime, so
+  // an identified stage and an unidentified cleanup can never
+  // legitimately be the same attempt -- 'work' must be excluded, not
+  // treated as compatible just because cleanup itself lacks an identity.
+  const all = new Map<string, StageEventWindow>([
+    [
+      '511:claude:work',
+      stageWindow('2026-01-01T00:00:01Z', '2026-01-01T00:00:02Z', 'attempt-A'),
+    ],
+    [
+      '511:claude:cleanup',
+      stageWindow('2026-01-01T00:10:00Z', '2026-01-01T00:10:05Z'),
+    ],
+  ]);
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.equal(windows.length, 1);
+  assert.equal(windows[0].startMs, ms('2026-01-01T00:10:00Z'));
+  assert.equal(windows[0].endMs, ms('2026-01-01T00:10:05Z'));
+  assert.equal('vendorSessionId' in windows[0], false);
+});
+
 test("scanClaudeVendorSessions: a completed cleanup window does not absorb a later retry's activity", () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
   writeFileSync(

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -1912,6 +1912,51 @@ test('readEventWindows: falls back to the identity-agnostic pairing when a stage
   }
 });
 
+test('readEventWindows: a fresher UNIDENTIFIED completion beats a stale identified one for the same stage (Codex review finding, PR #2430, #2424)', () => {
+  // Attempt A completes cleanup with an identity (older). Attempt B later
+  // ALSO completes cleanup, but without an identity (e.g. a straddling
+  // deploy transient, or CLAUDE_CODE_SESSION_ID unset for that run). An
+  // unconditional "prefer any identified candidate" rule would freeze on
+  // A's stale completion forever -- the resolved window's own stable
+  // #ew<issueNumber> id makes a later harvest treat it as already-present.
+  // The fix compares recency and lets B's more-recent, internally clean
+  // legacy pairing win.
+  const { dir, path } = writeEventsFile([
+    tokenCostEvent('enter', 'cleanup', '2026-01-01T00:00:01Z', 507, 'sess-A'),
+    tokenCostEvent('exit', 'cleanup', '2026-01-01T00:00:02Z', 507, 'sess-A'),
+    tokenCostEvent('enter', 'cleanup', '2026-01-01T00:00:05Z', 507),
+    tokenCostEvent('exit', 'cleanup', '2026-01-01T00:00:06Z', 507),
+  ]);
+  try {
+    const windows = readEventWindows(path);
+    const cleanup = windows.get('507:claude:cleanup');
+    assert.equal('vendorSessionId' in (cleanup ?? {}), false);
+    assert.equal(cleanup?.startMs, ms('2026-01-01T00:00:05Z'));
+    assert.equal(cleanup?.endMs, ms('2026-01-01T00:00:06Z'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readEventWindows: an identified completion still wins on a tie against the identity-agnostic pairing describing the exact same pair (#2424)', () => {
+  // The common case: a single, fully identified attempt. legacyWindow
+  // (identity-agnostic) trivially describes the SAME pair here, since
+  // enterAt/exitAt are populated unconditionally regardless of identity
+  // -- ties must resolve to the identified (tagged) result, not silently
+  // drop the identity.
+  const { dir, path } = writeEventsFile([
+    tokenCostEvent('enter', 'cleanup', '2026-01-01T00:00:01Z', 508, 'sess-A'),
+    tokenCostEvent('exit', 'cleanup', '2026-01-01T00:00:02Z', 508, 'sess-A'),
+  ]);
+  try {
+    const windows = readEventWindows(path);
+    const cleanup = windows.get('508:claude:cleanup');
+    assert.equal(cleanup?.vendorSessionId, 'sess-A');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Trusted marker logins
 // ---------------------------------------------------------------------------

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -187,8 +187,47 @@ test("scanClaudeVendorSessions scopes each cwd segment's timeline to just that s
 
 // --- #2418: event-window issue-number fallback -----------------------------
 
-function stageWindow(startIso: string, endIso: string): StageEventWindow {
-  return { startMs: ms(startIso), endMs: ms(endIso) };
+function stageWindow(
+  startIso: string,
+  endIso: string,
+  vendorSessionId?: string,
+): StageEventWindow {
+  return {
+    startMs: ms(startIso),
+    endMs: ms(endIso),
+    ...(vendorSessionId !== undefined ? { vendorSessionId } : {}),
+  };
+}
+
+// #2424: builds one raw --events JSONL line, matching TokenCostEvent's
+// own shape.
+function tokenCostEvent(
+  event: 'enter' | 'exit',
+  stageId: string,
+  atIso: string,
+  issueNumber: number,
+  vendorSessionId?: string,
+  vendor = 'claude',
+): string {
+  return JSON.stringify({
+    schemaVersion: 1,
+    event,
+    stageId,
+    at: atIso,
+    vendor,
+    issueNumber,
+    ...(vendorSessionId !== undefined ? { vendorSessionId } : {}),
+  });
+}
+
+function writeEventsFile(lines: readonly string[]): {
+  dir: string;
+  path: string;
+} {
+  const dir = mkdtempSync(join(tmpdir(), 'idd-token-cost-events-'));
+  const path = join(dir, 'events.jsonl');
+  writeFileSync(path, `${lines.join('\n')}\n`);
+  return { dir, path };
 }
 
 test('buildCompletedIssueWindows: builds an overall window only for an issue with a CLOSED cleanup stage', () => {
@@ -616,6 +655,118 @@ test('buildCompletedIssueWindows: a reversed non-cleanup stage window entirely P
   assert.equal(windows[0].endMs, ms('2026-01-01T01:00:00Z'));
 });
 
+test('buildCompletedIssueWindows: excludes a non-cleanup stage window whose vendorSessionId differs from the winning cleanup attempt, even though it is internally valid (#2424)', () => {
+  // Attempt A's own 'work' pair is internally valid (non-reversed) but
+  // belongs to an EARLIER attempt than the one that reached cleanup
+  // (attempt B). Pre-#2424, this shape was mechanically indistinguishable
+  // from a genuine early start and silently widened startMs back to A's
+  // own enter. With vendorSessionId available, the mismatch excludes it
+  // outright: startMs stays at cleanup's own startMs.
+  const all = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow('2026-01-01T00:00:00Z', '2026-01-01T00:05:00Z', 'attempt-A'),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow('2026-01-01T00:20:00Z', '2026-01-01T00:25:00Z', 'attempt-B'),
+    ],
+  ]);
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.equal(windows.length, 1);
+  assert.equal(windows[0].startMs, ms('2026-01-01T00:20:00Z'));
+  assert.equal(windows[0].endMs, ms('2026-01-01T00:25:00Z'));
+  assert.equal(windows[0].vendorSessionId, 'attempt-B');
+});
+
+test('buildCompletedIssueWindows: recovers a same-attempt stage window instead of a later, unrelated attempt shadowing it (#2424)', () => {
+  // Attempt A completes fully (work + cleanup). Attempt B later retries
+  // 'work' with its own valid pair but never reaches cleanup. Without
+  // identity, readEventWindows' latest-wins pairing would expose B's
+  // 'work' window (shadowing A's own), which buildCompletedIssueWindows
+  // would then have excluded from widening as "extends past cleanup.endMs"
+  // -- collapsing to a cleanup-only window even though A's own matching
+  // 'work' window exists. With identity, buildCompletedIssueWindows sees
+  // A's own tagged 'work' window here (this is what readEventWindows is
+  // responsible for selecting -- see its own dedicated test below) and
+  // widens startMs to it.
+  const all = new Map<string, StageEventWindow>([
+    [
+      '502:claude:work',
+      stageWindow('2026-01-01T00:00:00Z', '2026-01-01T00:01:00Z', 'attempt-A'),
+    ],
+    [
+      '502:claude:cleanup',
+      stageWindow('2026-01-01T00:02:00Z', '2026-01-01T00:03:00Z', 'attempt-A'),
+    ],
+  ]);
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.equal(windows.length, 1);
+  assert.equal(windows[0].startMs, ms('2026-01-01T00:00:00Z'));
+  assert.equal(windows[0].endMs, ms('2026-01-01T00:03:00Z'));
+});
+
+test('buildCompletedIssueWindows: an identity-matched reversed non-cleanup window is still treated as contamination (#2424)', () => {
+  // Same attempt re-enters 'work' without a matching new exit -- reversed,
+  // but the vendorSessionId matches cleanup's own, so the mismatch guard
+  // does not exclude it; the pre-#2424 reversed-window contamination check
+  // still fires and the whole issue is skipped.
+  const all = new Map<string, StageEventWindow>([
+    [
+      '503:claude:work',
+      stageWindow('2026-01-01T00:04:00Z', '2026-01-01T00:02:00Z', 'attempt-A'),
+    ],
+    [
+      '503:claude:cleanup',
+      stageWindow('2026-01-01T00:05:00Z', '2026-01-01T00:06:00Z', 'attempt-A'),
+    ],
+  ]);
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.equal(windows.length, 0);
+});
+
+test('buildCompletedIssueWindows: a valid non-cleanup window straddling cleanup.endMs is excluded by the existing boundary check regardless of a MATCHING identity (PR #2423 review, re-verified under #2424)', () => {
+  // Raised and rejected on PR #2423 review: a valid (non-reversed) window
+  // whose endMs lands after cleanup.endMs was already excluded from
+  // widening by the pre-#2424 boundary check. Confirms that stays true
+  // even when its vendorSessionId matches cleanup's own -- same-attempt
+  // jitter, not a different-attempt mismatch, but the outcome is identical.
+  const all = new Map<string, StageEventWindow>([
+    [
+      '504:claude:work',
+      stageWindow('2026-01-01T00:00:00Z', '2026-01-01T00:07:00Z', 'attempt-A'),
+    ],
+    [
+      '504:claude:cleanup',
+      stageWindow('2026-01-01T00:05:00Z', '2026-01-01T00:06:00Z', 'attempt-A'),
+    ],
+  ]);
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.equal(windows.length, 1);
+  assert.equal(windows[0].startMs, ms('2026-01-01T00:05:00Z'));
+  assert.equal(windows[0].endMs, ms('2026-01-01T00:06:00Z'));
+});
+
+test('buildCompletedIssueWindows: an unidentified non-cleanup window is unaffected when cleanup itself has an identity (mixed old/new data, #2424)', () => {
+  // cleanup carries an identity (post-#2424 event) but 'work' predates
+  // this field entirely. Absence on one side is not a mismatch -- 'work'
+  // still flows through the pre-#2424 checks exactly as before.
+  const all = new Map<string, StageEventWindow>([
+    [
+      '505:claude:work',
+      stageWindow('2026-01-01T00:00:00Z', '2026-01-01T00:01:00Z'),
+    ],
+    [
+      '505:claude:cleanup',
+      stageWindow('2026-01-01T00:02:00Z', '2026-01-01T00:03:00Z', 'attempt-A'),
+    ],
+  ]);
+  const windows = buildCompletedIssueWindows(all, 'claude');
+  assert.equal(windows.length, 1);
+  assert.equal(windows[0].startMs, ms('2026-01-01T00:00:00Z'));
+  assert.equal(windows[0].vendorSessionId, 'attempt-A');
+});
+
 test("scanClaudeVendorSessions: a completed cleanup window does not absorb a later retry's activity", () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
   writeFileSync(
@@ -784,6 +935,94 @@ test('scanClaudeVendorSessions: two DIFFERENT project log files matching the sam
   assert.equal(skipMessages.length, 1);
   assert.match(skipMessages[0], /disjoint activity ranges/);
   assert.match(skipMessages[0], /#2424/);
+});
+
+test("scanClaudeVendorSessions: a cross-file match is resolved (not skipped) when exactly one candidate file's own sessionId matches the window's vendorSessionId (#2424)", () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  // The file that actually posted the winning cleanup attempt's events.
+  writeFileSync(
+    join(sandbox, 'session-ew-idA.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:20:00.000Z","sessionId":"sess-ew-idA-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}\n',
+  );
+  // A genuinely unrelated concurrent session whose own activity happens
+  // to fall in the same wall-clock window.
+  writeFileSync(
+    join(sandbox, 'session-ew-idB.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:21:00.000Z","sessionId":"sess-ew-idB-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":5,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":5}}}\n',
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow(
+        '2026-01-01T00:10:00Z',
+        '2026-01-01T00:25:00Z',
+        'sess-ew-idA-0001',
+      ),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:26:00Z',
+        '2026-01-01T00:30:00Z',
+        'sess-ew-idA-0001',
+      ),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew'),
+  );
+
+  // Resolved to fileA only -- fileB's unrelated activity is never folded
+  // in, and this issue is no longer skipped the way an unidentified
+  // cross-file match still is (see the two tests above).
+  assert.equal(ewSamples.length, 1);
+  assert.equal(
+    ewSamples[0].adapterResult.sample.vendorSessionId,
+    'sess-ew-idA-0001#ew501',
+  );
+  assert.equal(sessions.length, 3);
+});
+
+test("scanClaudeVendorSessions: falls back to classify-and-skip when no candidate file's sessionId matches the window's vendorSessionId (#2424)", () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-ew-idC.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:20:00.000Z","sessionId":"sess-ew-idC-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}\n',
+  );
+  writeFileSync(
+    join(sandbox, 'session-ew-idD.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:21:00.000Z","sessionId":"sess-ew-idD-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":5,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":5}}}\n',
+  );
+  // Neither file's own sessionId equals the window's vendorSessionId --
+  // e.g. the events were posted from a THIRD, un-scanned file/session.
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow(
+        '2026-01-01T00:10:00Z',
+        '2026-01-01T00:25:00Z',
+        'sess-ew-idE-elsewhere',
+      ),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:26:00Z',
+        '2026-01-01T00:30:00Z',
+        'sess-ew-idE-elsewhere',
+      ),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew'),
+  );
+
+  assert.equal(ewSamples.length, 0);
+  assert.equal(sessions.length, 2);
 });
 
 test('scanClaudeVendorSessions: an event window is ignored when the segment already has a cwd-inferred issueNumber', () => {
@@ -1523,6 +1762,85 @@ test('readEventWindows: does not pair an enter/exit across two different vendors
     assert.equal(windows.size, 0);
     assert.equal(windows.get('7:claude:work'), undefined);
     assert.equal(windows.get('7:codex:work'), undefined);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readEventWindows: tags a window with vendorSessionId when both enter and exit share one (#2424)', () => {
+  const { dir, path } = writeEventsFile([
+    tokenCostEvent('enter', 'work', '2026-01-01T00:10:00Z', 7, 'sess-A'),
+    tokenCostEvent('exit', 'work', '2026-01-01T00:20:00Z', 7, 'sess-A'),
+  ]);
+  try {
+    const windows = readEventWindows(path);
+    assert.equal(windows.get('7:claude:work')?.vendorSessionId, 'sess-A');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readEventWindows: leaves a window untagged when an event carries no vendorSessionId (historical-data fallback, #2424)', () => {
+  const { dir, path } = writeEventsFile([
+    tokenCostEvent('enter', 'work', '2026-01-01T00:10:00Z', 7),
+    tokenCostEvent('exit', 'work', '2026-01-01T00:20:00Z', 7),
+  ]);
+  try {
+    const windows = readEventWindows(path);
+    const window = windows.get('7:claude:work');
+    assert.ok(window);
+    assert.equal(window?.startMs, ms('2026-01-01T00:10:00Z'));
+    assert.equal(window?.endMs, ms('2026-01-01T00:20:00Z'));
+    assert.equal('vendorSessionId' in (window ?? {}), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("readEventWindows: prefers the winning cleanup attempt's own stage candidate over a later, unrelated attempt shadowing it (#2424)", () => {
+  // Attempt A completes fully: work + cleanup, both id=sess-A. Attempt B
+  // later retries 'work' with its own valid pair (id=sess-B) but never
+  // reaches cleanup. Pure latest-wins (pre-#2424) would expose B's 'work'
+  // window here, shadowing A's own -- this locks in that the resolved
+  // 'work' window instead belongs to the SAME attempt as the winning
+  // 'cleanup' window.
+  const { dir, path } = writeEventsFile([
+    tokenCostEvent('enter', 'work', '2026-01-01T00:00:00Z', 502, 'sess-A'),
+    tokenCostEvent('exit', 'work', '2026-01-01T00:01:00Z', 502, 'sess-A'),
+    tokenCostEvent('enter', 'cleanup', '2026-01-01T00:02:00Z', 502, 'sess-A'),
+    tokenCostEvent('exit', 'cleanup', '2026-01-01T00:03:00Z', 502, 'sess-A'),
+    tokenCostEvent('enter', 'work', '2026-01-01T00:05:00Z', 502, 'sess-B'),
+    tokenCostEvent('exit', 'work', '2026-01-01T00:06:00Z', 502, 'sess-B'),
+  ]);
+  try {
+    const windows = readEventWindows(path);
+    const work = windows.get('502:claude:work');
+    assert.equal(work?.vendorSessionId, 'sess-A');
+    assert.equal(work?.startMs, ms('2026-01-01T00:00:00Z'));
+    assert.equal(work?.endMs, ms('2026-01-01T00:01:00Z'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('readEventWindows: falls back to the identity-agnostic pairing when a stage has no identified events at all, even though cleanup does (#2424)', () => {
+  // 'work' predates vendorSessionId entirely (token-cost-event.mjs's own
+  // rollout, or a vendor with no session-id source); 'cleanup' is a
+  // post-#2424 identified event. 'work' has zero identified candidates,
+  // so it resolves via the same identity-agnostic pairing this function
+  // used before #2424, untouched by cleanup's own identity.
+  const { dir, path } = writeEventsFile([
+    tokenCostEvent('enter', 'work', '2026-01-01T00:00:00Z', 503),
+    tokenCostEvent('exit', 'work', '2026-01-01T00:01:00Z', 503),
+    tokenCostEvent('enter', 'cleanup', '2026-01-01T00:07:00Z', 503, 'sess-B'),
+    tokenCostEvent('exit', 'cleanup', '2026-01-01T00:08:00Z', 503, 'sess-B'),
+  ]);
+  try {
+    const windows = readEventWindows(path);
+    const work = windows.get('503:claude:work');
+    assert.equal('vendorSessionId' in (work ?? {}), false);
+    assert.equal(work?.startMs, ms('2026-01-01T00:00:00Z'));
+    assert.equal(work?.endMs, ms('2026-01-01T00:01:00Z'));
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -1025,6 +1025,72 @@ test("scanClaudeVendorSessions: falls back to classify-and-skip when no candidat
   assert.equal(sessions.length, 2);
 });
 
+test("scanClaudeVendorSessions: a SOLE candidate file is still skipped when the window has an identity and the file's own sessionId does not match it (#2424)", () => {
+  // A single-candidate window is NOT automatically the right file: this
+  // locks in that the identity check also gates the length-1 fast path,
+  // not just the multi-file classify-and-skip branch above. Realistic
+  // shape: this loop's own event-window session file got excluded
+  // upstream (one of its segments already resolved a cwd-inferred issue
+  // number), leaving only an unrelated concurrent session as the sole
+  // candidate.
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-ew-idF.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:20:00.000Z","sessionId":"sess-ew-idF-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}\n',
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow(
+        '2026-01-01T00:10:00Z',
+        '2026-01-01T00:25:00Z',
+        'sess-ew-idG-elsewhere',
+      ),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow(
+        '2026-01-01T00:26:00Z',
+        '2026-01-01T00:30:00Z',
+        'sess-ew-idG-elsewhere',
+      ),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew'),
+  );
+
+  assert.equal(ewSamples.length, 0);
+  assert.equal(sessions.length, 1);
+});
+
+test('scanClaudeVendorSessions: a SOLE candidate file is still harvested unconditionally when the window carries no identity (backward compat, #2424)', () => {
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
+  writeFileSync(
+    join(sandbox, 'session-ew-idH.jsonl'),
+    '{"type":"assistant","timestamp":"2026-01-01T00:20:00.000Z","sessionId":"sess-ew-idH-0001","cwd":"/repo","message":{"model":"m","usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}\n',
+  );
+  const eventWindowsAll = new Map<string, StageEventWindow>([
+    [
+      '501:claude:work',
+      stageWindow('2026-01-01T00:10:00Z', '2026-01-01T00:25:00Z'),
+    ],
+    [
+      '501:claude:cleanup',
+      stageWindow('2026-01-01T00:26:00Z', '2026-01-01T00:30:00Z'),
+    ],
+  ]);
+
+  const sessions = scanClaudeVendorSessions(sandbox, eventWindowsAll);
+  const ewSamples = sessions.filter((s) =>
+    s.adapterResult.sample.vendorSessionId.includes('#ew'),
+  );
+
+  assert.equal(ewSamples.length, 1);
+});
+
 test('scanClaudeVendorSessions: an event window is ignored when the segment already has a cwd-inferred issueNumber', () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-ew-'));
   writeFileSync(


### PR DESCRIPTION
## Summary

Closes #2424.

- `token-cost-event.mjs` auto-derives `vendorSessionId` (an
  already-declared but never-stamped `TokenCostEvent` field -- no schema
  change) from `$CLAUDE_CODE_SESSION_ID` for `--vendor claude`. No new
  flag, no `CLAUDE.md`/`AGENTS.md`/`GEMINI.md`/
  `.github/copilot-instructions.md` edit needed: the id is auto-derived
  in-process, not something a caller passes.
- `readEventWindows` pairs `enter`/`exit` within the same
  `vendorSessionId` when both events carry one (a per-(issue, vendor)
  `cleanup` window resolves its own winning attempt first; every other
  stage then prefers a same-attempt candidate, falling back to
  latest-valid-among-identified, then to the pre-#2424 identity-agnostic
  pairing for events that carry no identity at all).
- `buildCompletedIssueWindows` excludes a non-`cleanup` stage window from
  both the widening loop and the reversed-window contamination check
  when its own `vendorSessionId` is known and differs from the winning
  `cleanup` window's -- before either check runs, so a mismatched
  attempt can neither poison `startMs` nor trigger a false whole-issue
  skip on a different attempt's behalf.
- `scanClaudeVendorSessions`'s event-window candidate resolution (both
  the multi-file case and the single-candidate fast path) requires the
  chosen file's own `extractSessionId()` to match the window's
  `vendorSessionId` when the window has one -- this is the actual fix
  #2425's classification diagnostics (`overlapping` vs `disjoint
  activity ranges -- resolvable once events carry session identity,
  #2424`) were waiting on.

## Design notes

- No schema change. `schemas/token-cost-event.schema.json` already
  declared `vendorSessionId`; nothing stamped it before this PR.
- Claude-only for now. No verified Codex/Grok env-var equivalent exists
  yet (matches #2418's own single-vendor-at-a-time precedent).
- Every #2418 guard (reversed-cleanup rejection, half-open boundary
  matching, cross-file ambiguity skip) stays intact and is the fallback
  whenever identity is unavailable on either side -- this PR adds a
  stronger signal on top, it does not replace them.
- Historical/unidentified events are unaffected: `readEventWindows`
  falls back to its pre-#2424 identity-agnostic pairing byte-for-byte
  when a stage has zero identified candidates, and all 65 pre-existing
  `token-cost-harvest.test.mts` tests pass unchanged.

## Expected result after merge

`docs/token-cost-snapshot.json`'s `sampleCount` stays at `0` immediately
after this merges -- every existing event in `events.jsonl`, including
this very PR's own `claim`/`work`/`submit-pr` events (posted from the
pre-fix script), has no `vendorSessionId`. Only IDD loops that *start*
after this merge produce identified events, so a real `n>0` sample needs
a follow-up harvest after at least one full post-merge loop completes.
Tracked as a follow-up, not a blocker here.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `pnpm test` (4657 tests, including new coverage for: attempt-scoped
  pairing recovering a shadowed same-attempt window, a mismatched
  identity excluded from widening/contamination, the PR #2423
  straddling-window shape re-verified under both matching and
  mismatched identity, mixed old/new-data compatibility, a cross-file
  match resolved by identity, and a single-candidate match rejected
  because its `extractSessionId()` doesn't match the window's identity)
- [x] `pnpm run lint` (includes `build:check` .mts/.mjs parity,
  `audit-code-span-wrap.mjs`, cspell, markdownlint)

Refs #2418, #2419, #2425


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude events now automatically capture valid session IDs when available.
  * Token-cost tracking more accurately pairs attempts and attributes events across log files using session identity.
  * Cleanup results retain the matched vendor session ID for clearer tracking.

* **Bug Fixes**
  * Prevented mismatched, stale, or ambiguous event windows from being incorrectly combined.
  * Preserved fallback behavior for historical events without session identities.

* **Documentation**
  * Added guidance for Claude session detection and documented unsupported vendor environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->