### PR TITLE
fix(pre-merge-readiness): reuse the injected port for CODEOWNERS reads

### DIFF
--- a/scripts/pre-merge-readiness.mjs
+++ b/scripts/pre-merge-readiness.mjs
@@ -345,6 +345,20 @@ export function collectPreMergeReadiness(
     owner,
     repo,
     resolveCodeownersForFiles(codeownersText, changedFiles).codeownerUserLogins,
+    // Reuses the collector's own injected port instead of the default's
+    // fresh createGithubProviderAdapter(owner, repo) -- otherwise a
+    // fake/non-GitHub-provider caller with a matching CODEOWNER user
+    // unexpectedly spawns a live gh process (Codex review, PR #2429).
+    (login) => {
+      const result = port.getCollaboratorPermission(login);
+      if (result.outcome === 'not-collaborator') {
+        throwSyntheticGhNotFound();
+      }
+      if (result.outcome === 'error') {
+        throw new Error(result.error.message);
+      }
+      return result.permission;
+    },
   );
   const viewerTeamSlugs = resolveViewerClassicBypassTeamSlugs(
     port,

--- a/src/scripts/pre-merge-readiness.mts
+++ b/src/scripts/pre-merge-readiness.mts
@@ -541,6 +541,20 @@ export function collectPreMergeReadiness(
     owner,
     repo,
     resolveCodeownersForFiles(codeownersText, changedFiles).codeownerUserLogins,
+    // Reuses the collector's own injected port instead of the default's
+    // fresh createGithubProviderAdapter(owner, repo) -- otherwise a
+    // fake/non-GitHub-provider caller with a matching CODEOWNER user
+    // unexpectedly spawns a live gh process (Codex review, PR #2429).
+    (login) => {
+      const result = port.getCollaboratorPermission(login);
+      if (result.outcome === 'not-collaborator') {
+        throwSyntheticGhNotFound();
+      }
+      if (result.outcome === 'error') {
+        throw new Error(result.error.message);
+      }
+      return result.permission;
+    },
   );
   const viewerTeamSlugs = resolveViewerClassicBypassTeamSlugs(
     port,

--- a/tests/pre-merge-readiness-collection-smoke.test.mts
+++ b/tests/pre-merge-readiness-collection-smoke.test.mts
@@ -825,3 +825,88 @@ test('collectPreMergeReadiness against a fake provider: a required check reporti
     rmSync(cwdRoot, { recursive: true, force: true });
   }
 });
+
+test('collectPreMergeReadiness against a fake provider: a matching CODEOWNER resolves via the injected port, not a fresh live adapter (Codex review, PR #2429)', () => {
+  // resolveEligibleCodeownerUserLogins's default fetchPermission
+  // constructed its own createGithubProviderAdapter(owner, repo) instead
+  // of reusing this collector's own injected port -- invisible to every
+  // other fake-provider test in this file because none of them exercise a
+  // changed file that actually matches a CODEOWNERS rule. Strips `gh` from
+  // PATH so a live-adapter fallback resolves to getCollaboratorPermission's
+  // own {outcome:'error'} catch-all (a spawn ENOENT has no HTTP status),
+  // which resolveEligibleCodeownerUserLogins classifies as `unreadable`
+  // (excluded, not rethrown -- so a bare doesNotThrow would not catch the
+  // regression) -- assert codeownerEligibilityUnreadable stays false
+  // instead, which only holds when the fixture's own 'write' permission was
+  // actually read.
+  const cwdRoot = mkdtempSync(join(tmpdir(), 'idd-pre-merge-fake-codeowner-'));
+  const originalCwd = process.cwd();
+  const originalPath = process.env.PATH;
+  try {
+    process.chdir(cwdRoot);
+    process.env.PATH = '';
+
+    const codeownersContent = Buffer.from('* @reviewer-user\n', 'utf8')
+      .toString('base64')
+      .replace(/=+$/, '');
+    const port = createFakeProviderAdapter({
+      changeRequestReadinessSnapshots: {
+        42: {
+          headSha: 'a'.repeat(40),
+          baseRefName: 'main',
+          url: 'https://github.com/o/r/pull/42',
+          authorLogin: 'author-user',
+          reviewDecision: null,
+          statusCheckRollup: [],
+          mergeable: 'MERGEABLE',
+          mergeStateStatus: 'CLEAN',
+          closingIssuesReferences: [],
+        },
+      },
+      branchRules: { 'o/r/main': [] },
+      branchProtection: { 'o/r/main': {} },
+      reviewThreadsWithComments: { 42: [] },
+      reviewsWithHeadCommitDate: {
+        42: { reviews: [], headCommittedAt: '2026-07-31T23:00:00Z' },
+      },
+      repositoryContentAtRef: {
+        'o/r/.github/CODEOWNERS@main': { content: codeownersContent },
+      },
+      changedFiles: { 42: ['src/index.ts'] },
+      collaboratorPermissions: {
+        'reviewer-user': {
+          outcome: 'found',
+          permission: 'write',
+          roleName: 'write',
+        },
+      },
+    });
+
+    const report = collectPreMergeReadiness(
+      [
+        '--pr',
+        '42',
+        '--claimless',
+        '--owner',
+        'o',
+        '--repo',
+        'r',
+        '--now',
+        '2026-08-01T00:00:00Z',
+      ],
+      () => port,
+    );
+    const reviewerStates = report.reviewerStates as {
+      codeownerSelfApproval: { codeownerEligibilityUnreadable: boolean };
+    };
+    assert.equal(
+      reviewerStates.codeownerSelfApproval.codeownerEligibilityUnreadable,
+      false,
+      'expected the fixture-provided write permission to resolve cleanly via the injected port',
+    );
+  } finally {
+    process.env.PATH = originalPath;
+    process.chdir(originalCwd);
+    rmSync(cwdRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/pre-merge-readiness-collection-smoke.test.mts
+++ b/tests/pre-merge-readiness-collection-smoke.test.mts
@@ -905,7 +905,11 @@ test('collectPreMergeReadiness against a fake provider: a matching CODEOWNER res
       'expected the fixture-provided write permission to resolve cleanly via the injected port',
     );
   } finally {
-    process.env.PATH = originalPath;
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
     process.chdir(originalCwd);
     rmSync(cwdRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Closes #2267

This commit was reviewed and accepted on PR #2429
(Codex thread, [discussion `r3910806573`](https://github.com/kurone-kito/idd-skill/pull/2429#discussion_r3910806573))
but never pushed before PR #2429 merged, so it never landed on `main`.
This PR lands the commit verbatim.

- `resolveEligibleCodeownerUserLogins`'s default `fetchPermission`
  constructed its own `createGithubProviderAdapter(owner, repo)`
  instead of reusing `collectPreMergeReadiness`'s own injected `port`,
  so a fake/non-GitHub-provider caller with a changed file matching a
  CODEOWNER unexpectedly spawned a live `gh` process -- invisible to
  every existing fake-provider test since none of them exercised a
  matching CODEOWNERS rule.
- Threads the collector's `port` through as the 4th argument to
  `resolveEligibleCodeownerUserLogins`, reusing the same
  outcome-mapping the default already had.
- Adds a fake-provider test with a matching CODEOWNERS rule and `PATH`
  stripped, so a live-adapter fallback resolves to
  `getCollaboratorPermission`'s own `{outcome:'error'}` catch-all
  rather than a real network call. Manually verified this test catches
  the regression by temporarily reverting the fix
  (`codeownerEligibilityUnreadable: true` instead of `false`) and
  restoring it.

## Acceptance criteria

- [x] `collectPreMergeReadiness` never spawns a live GitHub adapter
      when a matching CODEOWNERS rule is evaluated against an injected
      fake provider -- enforced by
      `tests/pre-merge-readiness-collection-smoke.test.mts`.
- [x] `pnpm run build`, the affected test suites, and
      `pnpm run lint:minimum` all pass (4684/4684 tests, clean
      typecheck/build, 0 lint issues).

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `node --experimental-strip-types --test tests/*.test.mts`
      (4684/4684 passing)
- [x] `pnpm run lint:minimum` (full CI gate, green end-to-end)
