### PR TITLE
chore(idd-config): configure advisoryWait.secondaryQuietWindow

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -33,7 +33,9 @@
   "orphanFirstPolicy": "none",
   "advisoryWait": {
     "convergenceScope": "idd-claimed",
-    "convergenceDeadline": "PT9H"
+    "convergenceDeadline": "PT9H",
+    "secondaryBotLogin": "coderabbitai[bot]",
+    "secondaryQuietWindow": "PT1H"
   },
   "discover": {
     "selectionDesync": "session-offset"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,17 @@ own interaction model rather than following product terms literally.
   distributed `idd-template/` default (`PT24H`) to fit this
   repository's more autonomous, higher-concurrency dogfooding setup
   (Refs #1465, #2076).
+- **Secondary-bot quiet window**: This source repository also records
+  `advisoryWait.secondaryBotLogin: "coderabbitai[bot]"` and
+  `advisoryWait.secondaryQuietWindow: "PT1H"` as a local IDD dogfooding
+  opt-in (applies only to `kurone-kito/idd-skill`), waiting one hour
+  after E-phase convergence conditions are first observed before
+  pre-merge readiness treats review as settled. This repository
+  dogfoods CodeRabbit alongside Copilot and has twice hit CodeRabbit
+  rate-limiting during a PR's review cycle, each time working around
+  it with an ad hoc one-hour wait before merging; this config turns
+  that informal practice into a proper `pre-merge-readiness` blocker
+  (Refs #2335, #2410).
 
 ## For IDD work
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,17 @@ terms literally.
   distributed `idd-template/` default (`PT24H`) to fit this
   repository's more autonomous, higher-concurrency dogfooding setup
   (Refs #1465, #2076).
+- **Secondary-bot quiet window**: This source repository also records
+  `advisoryWait.secondaryBotLogin: "coderabbitai[bot]"` and
+  `advisoryWait.secondaryQuietWindow: "PT1H"` as a local IDD dogfooding
+  opt-in (applies only to `kurone-kito/idd-skill`), waiting one hour
+  after E-phase convergence conditions are first observed before
+  pre-merge readiness treats review as settled. This repository
+  dogfoods CodeRabbit alongside Copilot and has twice hit CodeRabbit
+  rate-limiting during a PR's review cycle, each time working around
+  it with an ad hoc one-hour wait before merging; this config turns
+  that informal practice into a proper `pre-merge-readiness` blocker
+  (Refs #2335, #2410).
 
 ## For IDD work
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -109,6 +109,17 @@ own interaction model rather than following product terms literally.
   distributed `idd-template/` default (`PT24H`) to fit this
   repository's more autonomous, higher-concurrency dogfooding setup
   (Refs #1465, #2076).
+- **Secondary-bot quiet window**: This source repository also records
+  `advisoryWait.secondaryBotLogin: "coderabbitai[bot]"` and
+  `advisoryWait.secondaryQuietWindow: "PT1H"` as a local IDD dogfooding
+  opt-in (applies only to `kurone-kito/idd-skill`), waiting one hour
+  after E-phase convergence conditions are first observed before
+  pre-merge readiness treats review as settled. This repository
+  dogfoods CodeRabbit alongside Copilot and has twice hit CodeRabbit
+  rate-limiting during a PR's review cycle, each time working around
+  it with an ad hoc one-hour wait before merging; this config turns
+  that informal practice into a proper `pre-merge-readiness` blocker
+  (Refs #2335, #2410).
 
 ## For IDD work
 


### PR DESCRIPTION
## Summary

- `advisoryWait.secondaryQuietWindow` (#2335, merged) lets pre-merge
  readiness wait for a slower secondary advisory bot before declaring
  review converged, but this repository never configured it even
  though it's the one that motivated building it.
- Set `advisoryWait.secondaryBotLogin: "coderabbitai[bot]"` and
  `advisoryWait.secondaryQuietWindow: "PT1H"` in
  `.github/idd/config.json`, matching the PT1H wait two independent
  sessions already converged on manually after hitting CodeRabbit
  rate-limiting.
- Documented this as a local dogfooding policy opt-in in `CLAUDE.md`'s
  "Key workflow rules" section, in the same style as the existing
  `discover.selectionDesync` / `ciGate.externalCheckWaivers.mode` /
  `advisoryWait.convergenceDeadline` entries.
- Config + docs only — no source changes, per #2335's already-shipped
  implementation.

## Test plan

- [x] `node scripts/idd-doctor.mjs` — `.github/idd/config.json`
      validates against `policy.schema.json`
- [x] `node scripts/pre-merge-readiness.mjs --pr 2374 --claim-issue
      2332` (live dry-run against an open PR) shows
      `secondaryQuietWindow.minutes: 60`, confirming the config value
      is actually read
- [x] `pre-push-validate` (biome, dprint, markdownlint, cspell,
      audit-docs, audit-code-span-wrap, build:check, idd-doctor) — all
      green (pre-existing unrelated warnings in `protocol-helpers.mts`
      only)

Closes #2410

🤖 Generated with [Claude Code](https://claude.com/claude-code)