### PR TITLE
chore(token-cost): refresh dogfood snapshot after #2424/#2425 merge

### DIFF
--- a/docs/token-cost-snapshot.json
+++ b/docs/token-cost-snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-09-02T03:45:46.810Z",
+  "generatedAt": "2026-09-02T06:48:41.425Z",
   "minPublishableSamples": 10,
   "minPublishableVendors": 2,
   "publishable": false,


### PR DESCRIPTION
Closes #2426

## Summary

Retries the harvest now that both #2424 (attempt/session identity) and
#2425 (cross-file skip classification) have merged, per #2426's own
Proposed change.

## Result

Still `n=0`, `publishable=false`. Unlike #2419's round (10 of 12 windows
dropped by a concrete cross-file-ambiguity guard), this harvest ran
completely clean — zero cross-file-ambiguity or identity-mismatch
warnings at all. The honest diagnosis: no completed issue-loop window
carries an identified event yet, since #2424 only stamps identity on
events posted after its own merge, and no post-merge loop had reached
`cleanup` at harvest time. Expected per #2424's own documented timeline.

This PR's own claim/work events already confirm the mechanism is live
end to end (they carry a real `vendorSessionId` for the first time on
this workstation).

Per #2426's acceptance criteria (still `publishable: false` → open a
follow-up with the same shape), filed #2434, linked from roadmap #2296.

## Test plan

- [x] `node scripts/token-cost-harvest.mjs --repo kurone-kito/idd-skill`
      run, clean, no warnings
- [x] `node scripts/token-cost-report.mjs --apply` run;
      `docs/token-cost-snapshot.json` refreshed (`generatedAt` only,
      `n=0`/`publishable=false` unchanged)
- [x] No README/docs table changes needed (still unpublishable stub)
- [x] Follow-up issue #2434 filed and linked from roadmap #2296

https://claude.ai/code/session_01CtcjhuuXDqQASYGXtJnmV3