### PR TITLE
test(provider): add contract fixtures and GitHub parity guards

### DIFF
--- a/scripts/provider-adapter-fake.mjs
+++ b/scripts/provider-adapter-fake.mjs
@@ -45,6 +45,12 @@ export function createFakeProviderAdapter(fixture) {
       };
     },
     getWorkItem(number) {
+      const errorFixture = fixture.workItemErrors?.[number];
+      if (errorFixture) {
+        const providerError = new Error(errorFixture.message);
+        providerError.category = errorFixture.category;
+        throw providerError;
+      }
       const item = fixture.workItems?.[number];
       if (!item) {
         return null;

--- a/src/scripts/provider-adapter-fake.mts
+++ b/src/scripts/provider-adapter-fake.mts
@@ -13,6 +13,8 @@
 import {
   PROVIDER_CAPABILITY_GROUPS,
   type ProviderCapabilityDeclaration,
+  type ProviderError,
+  type ProviderErrorCategory,
   type ProviderRepositoryLocator,
 } from './provider-contract.mts';
 import type {
@@ -50,6 +52,18 @@ export interface FakeProviderFixture {
   viewerLogin?: string;
   viewerLoginUnavailable?: boolean;
   workItems?: Record<number, ProviderWorkItem>;
+  /** Backs a thrown `ProviderError` from {@link ProviderPort.getWorkItem} --
+   * its one documented throw-on-non-404-failure contract, mirroring the
+   * real GitHub adapter's category-classified wrap of a non-404 gh
+   * failure. Keyed by issue number and checked before `workItems`, so a
+   * test can simulate an authentication/authorization/conflict/
+   * unavailable/unknown failure without a live gh process (#2268 AC1);
+   * `not-found` stays expressed the existing way, by omitting the number
+   * from both this and `workItems`. */
+  workItemErrors?: Record<
+    number,
+    { category: ProviderErrorCategory; message: string }
+  >;
   timelines?: Record<number, ProviderTimelineEvent[]>;
   comments?: Record<number, ProviderComment[]>;
   closingPullRequestPages?: Record<number, ProviderClosingPullRequestsPage[]>;
@@ -274,6 +288,13 @@ export function createFakeProviderAdapter(
     },
 
     getWorkItem(number: number): ProviderWorkItem | null {
+      const errorFixture = fixture.workItemErrors?.[number];
+      if (errorFixture) {
+        const providerError = new Error(errorFixture.message) as Error &
+          ProviderError;
+        providerError.category = errorFixture.category;
+        throw providerError;
+      }
       const item = fixture.workItems?.[number];
       if (!item) {
         return null;

--- a/src/scripts/provider-adapter-fake.mts
+++ b/src/scripts/provider-adapter-fake.mts
@@ -59,10 +59,16 @@ export interface FakeProviderFixture {
    * test can simulate an authentication/authorization/conflict/
    * unavailable/unknown failure without a live gh process (#2268 AC1);
    * `not-found` stays expressed the existing way, by omitting the number
-   * from both this and `workItems`. */
+   * from both this and `workItems` -- `Exclude`d from the category type
+   * (not just documented) so a fixture cannot contradict getWorkItem's
+   * null-for-not-found contract at the type level (CodeRabbit review,
+   * #2436). */
   workItemErrors?: Record<
     number,
-    { category: ProviderErrorCategory; message: string }
+    {
+      category: Exclude<ProviderErrorCategory, 'not-found'>;
+      message: string;
+    }
   >;
   timelines?: Record<number, ProviderTimelineEvent[]>;
   comments?: Record<number, ProviderComment[]>;

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -1118,7 +1118,7 @@ test('evaluateDiscoverReadiness runs end to end against a fake provider, no gh p
           number: 2003,
           title: 'fake roadmap',
           state: 'open',
-          body: '',
+          body: '<!-- idd-skill-roadmap-id: roadmap-fake -->',
           labels: [{ name: 'roadmap' }],
         },
       },
@@ -1126,10 +1126,16 @@ test('evaluateDiscoverReadiness runs end to end against a fake provider, no gh p
 
     const summary = await evaluateDiscoverReadiness([2001, 2002], {
       loadIssue: async (number) => port.getWorkItem(number),
+      // Filters by the actual marker in each item's body, not by a fixed
+      // issue number -- a marker-blind filter would let this test pass
+      // even if the caller searched for the wrong marker (CodeRabbit
+      // review, #2436).
       findRoadmapsByMarker: async (marker) =>
         port
           .searchWorkItems(`in:body "<!-- idd-skill-roadmap-id: ${marker} -->"`)
-          .filter((item) => item.number === 2003),
+          .filter((item) =>
+            item.body.includes(`<!-- idd-skill-roadmap-id: ${marker} -->`),
+          ),
     });
 
     assert.deepEqual(

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -17,6 +17,7 @@ import {
   parseSwarmFloorArg,
   summarizeSwarmFloorEligibility,
 } from '../src/scripts/discover-readiness-check.mts';
+import { createFakeProviderAdapter } from '../src/scripts/provider-adapter-fake.mts';
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
 
@@ -1077,4 +1078,77 @@ process.exit(1);
       ),
     /failed to load policy from .*bad-policy\.json/,
   );
+});
+
+// #2268 AC2: at least one migrated issue/claim flow must run entirely
+// against a fake provider, proving evaluateDiscoverReadiness's workflow
+// logic does not require an authenticated gh process. The change/review/
+// CI/merge half is already covered (pre-merge-readiness-collection-smoke.
+// test.mts, advisory-convergence-fake-provider.test.mts); this is the
+// issue/claim half, backed by createGithubProviderAdapter's own #2266
+// migration target (discover-readiness-check.mts's buildIssueLoader /
+// buildRoadmapMarkerResolver, which this test's loaders mirror by hand
+// against a fake port instead of a live adapter).
+test('evaluateDiscoverReadiness runs end to end against a fake provider, no gh process spawned (#2268)', async () => {
+  const originalPath = process.env.PATH;
+  try {
+    // PATH stripped: nothing in this test's call graph may fall back to a
+    // live gh process even transiently, since evaluateDiscoverReadiness's
+    // loadIssue/findRoadmapsByMarker are driven entirely by the fake port
+    // below.
+    delete process.env.PATH;
+
+    const port = createFakeProviderAdapter({
+      workItems: {
+        2001: {
+          number: 2001,
+          title: 'ready candidate',
+          state: 'open',
+          body: '',
+          labels: [],
+        },
+        2002: {
+          number: 2002,
+          title: 'blocked candidate',
+          state: 'open',
+          body: '<!-- idd-skill-blocked-by: roadmap-fake -->',
+          labels: [],
+        },
+        2003: {
+          number: 2003,
+          title: 'fake roadmap',
+          state: 'open',
+          body: '',
+          labels: [{ name: 'roadmap' }],
+        },
+      },
+    });
+
+    const summary = await evaluateDiscoverReadiness([2001, 2002], {
+      loadIssue: async (number) => port.getWorkItem(number),
+      findRoadmapsByMarker: async (marker) =>
+        port
+          .searchWorkItems(`in:body "<!-- idd-skill-roadmap-id: ${marker} -->"`)
+          .filter((item) => item.number === 2003),
+    });
+
+    assert.deepEqual(
+      summary.ready.map((item) => item.number),
+      [2001],
+      'the unlabeled, unblocked issue is ready',
+    );
+    assert.equal(summary.filteredOut.length, 1);
+    assert.equal(summary.filteredOut[0].number, 2002);
+    assert.match(
+      summary.filteredOut[0].reasons.join(','),
+      /blocked_by_open_roadmap_marker:roadmap-fake/,
+      "the blocked-by marker resolved through the fake port's searchWorkItems, not a live gh search",
+    );
+  } finally {
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+  }
 });

--- a/tests/provider-adapter-fake.test.mts
+++ b/tests/provider-adapter-fake.test.mts
@@ -236,3 +236,77 @@ test('resolveViewerAppSlugSafe trims a fixture app slug, matching the GitHub ada
     unavailable: false,
   });
 });
+
+// #2268 additions below.
+//
+// getWorkItem is the port's one method documented to throw a categorized
+// ProviderError on a non-404 failure (provider-port.mts's own doc comment
+// pins discover-viability-gate.mts's fail-closed routing -- an uncaught
+// propagation, not a swallow -- as the contract). Before workItemErrors
+// existed, the fake adapter could express only the null/not-found branch of
+// that contract; a test exercising the authentication/authorization/
+// conflict/unavailable path had no way to drive it without a live gh
+// process. not-found and unsupported-capability/not_applicable are already
+// covered elsewhere (the two 'outcome: not-found' cases above,
+// tests/advisory-convergence-fake-provider.test.mts's capabilityDeclarations
+// override) -- this fills the remaining AC1 gap (#2268).
+
+test('getWorkItem throws a categorized ProviderError for a fixture-injected authentication failure', () => {
+  const port = createFakeProviderAdapter({
+    workItemErrors: {
+      1: { category: 'authentication', message: 'gh: not authenticated' },
+    },
+  });
+  assert.throws(
+    () => port.getWorkItem(1),
+    (error: unknown) =>
+      error instanceof Error &&
+      (error as Error & { category?: string }).category === 'authentication' &&
+      error.message === 'gh: not authenticated',
+  );
+});
+
+test('getWorkItem throws a categorized ProviderError for a fixture-injected conflict', () => {
+  const port = createFakeProviderAdapter({
+    workItemErrors: {
+      2: { category: 'conflict', message: 'gh: 409 conflict' },
+    },
+  });
+  assert.throws(
+    () => port.getWorkItem(2),
+    (error: unknown) =>
+      error instanceof Error &&
+      (error as Error & { category?: string }).category === 'conflict',
+  );
+});
+
+test('getWorkItem throws a categorized ProviderError for a fixture-injected transient/unavailable failure', () => {
+  const port = createFakeProviderAdapter({
+    workItemErrors: {
+      3: { category: 'unavailable', message: 'gh: 503 service unavailable' },
+    },
+  });
+  assert.throws(
+    () => port.getWorkItem(3),
+    (error: unknown) =>
+      error instanceof Error &&
+      (error as Error & { category?: string }).category === 'unavailable',
+  );
+});
+
+test('getWorkItem still returns null for a plain not-found number, unaffected by workItemErrors', () => {
+  const port = createFakeProviderAdapter({
+    workItemErrors: { 1: { category: 'conflict', message: 'x' } },
+  });
+  assert.equal(port.getWorkItem(999), null);
+});
+
+test('getWorkItem checks workItemErrors before workItems when a number appears in both', () => {
+  const port = createFakeProviderAdapter({
+    workItems: { 1: { number: 1, title: 'x', body: '', state: 'open' } },
+    workItemErrors: {
+      1: { category: 'unknown', message: 'fixture author error' },
+    },
+  });
+  assert.throws(() => port.getWorkItem(1), /fixture author error/);
+});

--- a/tests/provider-adapter-fake.test.mts
+++ b/tests/provider-adapter-fake.test.mts
@@ -266,6 +266,20 @@ test('getWorkItem throws a categorized ProviderError for a fixture-injected auth
   );
 });
 
+test('getWorkItem throws a categorized ProviderError for a fixture-injected authorization (permission) failure', () => {
+  const port = createFakeProviderAdapter({
+    workItemErrors: {
+      4: { category: 'authorization', message: 'gh: 403 forbidden' },
+    },
+  });
+  assert.throws(
+    () => port.getWorkItem(4),
+    (error: unknown) =>
+      error instanceof Error &&
+      (error as Error & { category?: string }).category === 'authorization',
+  );
+});
+
 test('getWorkItem throws a categorized ProviderError for a fixture-injected conflict', () => {
   const port = createFakeProviderAdapter({
     workItemErrors: {

--- a/tests/provider-adapter-fake.test.mts
+++ b/tests/provider-adapter-fake.test.mts
@@ -322,5 +322,11 @@ test('getWorkItem checks workItemErrors before workItems when a number appears i
       1: { category: 'unknown', message: 'fixture author error' },
     },
   });
-  assert.throws(() => port.getWorkItem(1), /fixture author error/);
+  assert.throws(
+    () => port.getWorkItem(1),
+    (error: unknown) =>
+      error instanceof Error &&
+      (error as Error & { category?: string }).category === 'unknown' &&
+      error.message === 'fixture author error',
+  );
 });

--- a/tests/provider-adapter-parity.test.mts
+++ b/tests/provider-adapter-parity.test.mts
@@ -1,0 +1,375 @@
+// #2268 AC3: GitHub-parity guard. Both `provider-adapter-github.mts` and
+// `provider-adapter-fake.mts` implement the same `ProviderPort` -- the
+// migrated domain helpers must see identical normalized values from either
+// one for equivalent underlying state. Each test below feeds one canned raw
+// gh payload through the real GitHub adapter (stubbing its injectable
+// `GithubProviderAdapterDeps`, the lighter in-process mechanism
+// tests/provider-adapter-github.test.mts already uses -- no subprocess, no
+// PATH mock, no second harness) and an equivalent fixture through the fake
+// adapter, then asserts the two returned port values are exactly
+// `deepEqual`. A weakened assertion here would certify divergence as
+// parity, so every field the fake supplies matches the GitHub stub's
+// corresponding raw field, never a placeholder.
+//
+// Covers the seven areas #2268's acceptance criteria name: marker bodies,
+// issue selection, review disposition, check state, freshness, unresolved
+// threads, and merge readiness.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createFakeProviderAdapter } from '../src/scripts/provider-adapter-fake.mts';
+import {
+  createGithubProviderAdapter,
+  type GithubProviderAdapterDeps,
+} from '../src/scripts/provider-adapter-github.mts';
+
+function fakeDeps(
+  overrides: Partial<GithubProviderAdapterDeps>,
+): GithubProviderAdapterDeps {
+  return {
+    ghText: () => {
+      throw new Error('ghText not stubbed for this test');
+    },
+    ghApiJson: () => {
+      throw new Error('ghApiJson not stubbed for this test');
+    },
+    resolveViewerLogin: () => {
+      throw new Error('resolveViewerLogin not stubbed for this test');
+    },
+    ghTextAsync: () => {
+      throw new Error('ghTextAsync not stubbed for this test');
+    },
+    ...overrides,
+  } as GithubProviderAdapterDeps;
+}
+
+// --- issue selection ---------------------------------------------------
+
+test('getWorkItem: GitHub and fake adapters agree on the normalized shape', () => {
+  const githubPort = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghApiJson: () => ({
+        number: 500,
+        title: 'Fix bug',
+        body: 'desc',
+        state: 'open',
+        labels: [{ name: 'bug' }],
+        url: 'https://api.github.com/repos/o/r/issues/500',
+        html_url: 'https://github.com/o/r/issues/500',
+        milestone: null,
+        user: { login: 'alice' },
+        author_association: 'OWNER',
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-02T00:00:00Z',
+      }),
+    }),
+  );
+  const fakePort = createFakeProviderAdapter({
+    workItems: {
+      500: {
+        number: 500,
+        title: 'Fix bug',
+        body: 'desc',
+        state: 'open',
+        labels: [{ name: 'bug' }],
+        url: 'https://api.github.com/repos/o/r/issues/500',
+        htmlUrl: 'https://github.com/o/r/issues/500',
+        milestone: null,
+        user: { login: 'alice' },
+        authorAssociation: 'OWNER',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-02T00:00:00Z',
+      },
+    },
+  });
+
+  const githubResult = githubPort.getWorkItem(500);
+  const fakeResult = fakePort.getWorkItem(500);
+  assert.notEqual(githubResult, null);
+  // getWorkItem uppercases state on read (both adapters share this
+  // contract) -- assert it explicitly before the full deepEqual so a
+  // divergence there fails with a readable message.
+  assert.equal(githubResult?.state, 'OPEN');
+  assert.deepEqual(fakeResult, githubResult);
+});
+
+// --- marker bodies -------------------------------------------------------
+
+test('listWorkItemComments: GitHub and fake adapters agree on the normalized shape', () => {
+  const githubPort = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghApiJson: () => [
+        {
+          id: 111,
+          body: '<!-- idd-skill-claimed-by: claude-1 uuid-1 supersedes: none 2026-01-01T00:00:00Z branch: issue/1 -->',
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:05:00Z',
+          user: { login: 'claude-bot' },
+        },
+      ],
+    }),
+  );
+  const fakePort = createFakeProviderAdapter({
+    comments: {
+      500: [
+        {
+          id: 111,
+          body: '<!-- idd-skill-claimed-by: claude-1 uuid-1 supersedes: none 2026-01-01T00:00:00Z branch: issue/1 -->',
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:05:00Z',
+          authorLogin: 'claude-bot',
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(
+    fakePort.listWorkItemComments(500),
+    githubPort.listWorkItemComments(500),
+  );
+});
+
+// --- review disposition + unresolved threads -----------------------------
+
+test('listChangeRequestReviewThreadsWithComments: GitHub and fake adapters agree on the normalized shape', () => {
+  const githubPort = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      id: 'RT_resolved',
+                      isResolved: true,
+                      path: 'src/x.mts',
+                      comments: {
+                        nodes: [
+                          {
+                            body: '**Accepted** — fixed.',
+                            createdAt: '2026-01-01T00:00:00Z',
+                            updatedAt: '2026-01-01T00:00:00Z',
+                            author: { login: 'kurone-kito' },
+                            pullRequestReview: { id: 'PRR_1' },
+                          },
+                        ],
+                        pageInfo: { hasNextPage: false, endCursor: null },
+                      },
+                    },
+                    {
+                      id: 'RT_open',
+                      isResolved: false,
+                      path: 'src/y.mts',
+                      comments: {
+                        nodes: [
+                          {
+                            body: 'Please fix this too.',
+                            createdAt: '2026-01-01T01:00:00Z',
+                            updatedAt: '2026-01-01T01:00:00Z',
+                            author: { login: 'copilot-pull-request-reviewer' },
+                            pullRequestReview: null,
+                          },
+                        ],
+                        pageInfo: { hasNextPage: false, endCursor: null },
+                      },
+                    },
+                  ],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            },
+          },
+        }),
+    }),
+  );
+  const fakePort = createFakeProviderAdapter({
+    reviewThreadsWithComments: {
+      42: [
+        {
+          isResolved: true,
+          comments: [
+            {
+              body: '**Accepted** — fixed.',
+              createdAt: '2026-01-01T00:00:00Z',
+              updatedAt: '2026-01-01T00:00:00Z',
+              authorLogin: 'kurone-kito',
+              pullRequestReviewId: 'PRR_1',
+            },
+          ],
+        },
+        {
+          isResolved: false,
+          comments: [
+            {
+              body: 'Please fix this too.',
+              createdAt: '2026-01-01T01:00:00Z',
+              updatedAt: '2026-01-01T01:00:00Z',
+              authorLogin: 'copilot-pull-request-reviewer',
+              pullRequestReviewId: null,
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  const githubResult =
+    githubPort.listChangeRequestReviewThreadsWithComments(42);
+  const fakeResult = fakePort.listChangeRequestReviewThreadsWithComments(42);
+  assert.deepEqual(
+    githubResult.map((thread) => thread.isResolved),
+    [true, false],
+    'sanity: one resolved thread, one unresolved',
+  );
+  assert.deepEqual(fakeResult, githubResult);
+});
+
+// --- check state -----------------------------------------------------------
+
+test('listWorkflowRuns: GitHub and fake adapters agree on the normalized shape, precision-preserving id', () => {
+  // A databaseId above Number.MAX_SAFE_INTEGER, string-preserved by both
+  // adapters (#2267 AC, PR #2429 Codex review) -- encodes the exact
+  // divergence point the id-stringification fix closed.
+  const githubPort = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify([
+          {
+            databaseId: '9007199254740993',
+            conclusion: 'success',
+            status: 'completed',
+            createdAt: '2026-01-01T00:00:00Z',
+          },
+        ]),
+    }),
+  );
+  const fakePort = createFakeProviderAdapter({
+    workflowRunLists: {
+      'o/r/CI': [
+        {
+          id: '9007199254740993',
+          conclusion: 'success',
+          status: 'completed',
+          createdAt: '2026-01-01T00:00:00Z',
+        },
+      ],
+    },
+  });
+
+  const githubResult = githubPort.listWorkflowRuns('o', 'r', 'CI', 10);
+  assert.equal(githubResult[0]?.id, '9007199254740993');
+  assert.deepEqual(fakePort.listWorkflowRuns('o', 'r', 'CI', 10), githubResult);
+});
+
+// --- freshness ---------------------------------------------------------
+
+test('getChangeRequestReviewsWithHeadCommitDate: GitHub and fake adapters agree on the normalized shape', () => {
+  const githubPort = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviews: {
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  nodes: [
+                    {
+                      id: 'PRR_1',
+                      commit: { oid: 'abc123' },
+                      submittedAt: '2026-01-01T02:00:00Z',
+                      author: { login: 'copilot', __typename: 'Bot' },
+                      comments: { totalCount: 1 },
+                      body: 'LGTM with one comment.',
+                    },
+                  ],
+                },
+                commits: {
+                  nodes: [
+                    { commit: { committedDate: '2026-01-01T01:00:00Z' } },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+    }),
+  );
+  const fakePort = createFakeProviderAdapter({
+    reviewsWithHeadCommitDate: {
+      42: {
+        reviews: [
+          {
+            id: 'PRR_1',
+            authorLogin: 'copilot',
+            authorTypename: 'Bot',
+            submittedAt: '2026-01-01T02:00:00Z',
+            commitId: 'abc123',
+            commentCount: 1,
+            body: 'LGTM with one comment.',
+          },
+        ],
+        headCommittedAt: '2026-01-01T01:00:00Z',
+      },
+    },
+  });
+
+  assert.deepEqual(
+    fakePort.getChangeRequestReviewsWithHeadCommitDate(42),
+    githubPort.getChangeRequestReviewsWithHeadCommitDate(42),
+  );
+});
+
+// --- merge readiness -----------------------------------------------------
+
+test('getChangeRequestReadinessSnapshot: GitHub and fake adapters agree on the normalized shape', () => {
+  const githubPort = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () =>
+        JSON.stringify({
+          headRefOid: 'deadbeef',
+          baseRefName: 'main',
+          url: 'https://github.com/o/r/pull/42',
+          author: { login: 'author-user' },
+          reviewDecision: 'APPROVED',
+          statusCheckRollup: [{ name: 'lint', conclusion: 'SUCCESS' }],
+          mergeable: 'MERGEABLE',
+          mergeStateStatus: 'CLEAN',
+          closingIssuesReferences: [{ number: 7 }],
+        }),
+    }),
+  );
+  const fakePort = createFakeProviderAdapter({
+    changeRequestReadinessSnapshots: {
+      42: {
+        headSha: 'deadbeef',
+        baseRefName: 'main',
+        url: 'https://github.com/o/r/pull/42',
+        authorLogin: 'author-user',
+        reviewDecision: 'APPROVED',
+        statusCheckRollup: [{ name: 'lint', conclusion: 'SUCCESS' }],
+        mergeable: 'MERGEABLE',
+        mergeStateStatus: 'CLEAN',
+        closingIssuesReferences: [{ number: 7 }],
+      },
+    },
+  });
+
+  assert.deepEqual(
+    fakePort.getChangeRequestReadinessSnapshot(42),
+    githubPort.getChangeRequestReadinessSnapshot(42),
+  );
+});

--- a/tests/provider-port-migration-guard.test.mts
+++ b/tests/provider-port-migration-guard.test.mts
@@ -54,7 +54,10 @@ const DIRECT_GH_PATTERNS: { pattern: RegExp; description: string }[] = [
     // `.mjs` counterpart's `from './gh-exec.mjs'` (#2268) -- a guard that
     // only recognized the source extension would stay vacuous against a
     // regression introduced solely in committed generated output.
-    pattern: /from ['"]\.\/gh-exec\.mjs?['"]/,
+    // `\.mjs?` (optional trailing 's') matches only '.mj'/'.mjs', never
+    // '.mts' -- an explicit two-way alternation is required (Copilot +
+    // CodeRabbit review, #2436).
+    pattern: /from ['"]\.\/gh-exec\.(?:mts|mjs)['"]/,
     description: 'import from the gh-exec transport primitive',
   },
   {
@@ -113,6 +116,16 @@ test('the direct-gh pattern set catches a bare ghTextAsync() call (CodeRabbit re
   ) as { pattern: RegExp };
   assert.match('await ghTextAsync(args)', pattern);
   assert.match('ghTextAsync (args)', pattern);
+});
+
+test('the gh-exec import pattern matches both .mts and .mjs, and only those (Copilot + CodeRabbit review, #2436)', () => {
+  const { pattern } = DIRECT_GH_PATTERNS.find((entry) =>
+    entry.description.includes('gh-exec'),
+  ) as { pattern: RegExp };
+  assert.match("from './gh-exec.mts'", pattern);
+  assert.match("from './gh-exec.mjs'", pattern);
+  assert.doesNotMatch("from './gh-exec.mj'", pattern);
+  assert.doesNotMatch("from './gh-exec.ts'", pattern);
 });
 
 test('the adapter modules themselves are exempt and still exist', () => {

--- a/tests/provider-port-migration-guard.test.mts
+++ b/tests/provider-port-migration-guard.test.mts
@@ -50,8 +50,12 @@ const DIRECT_GH_PATTERNS: { pattern: RegExp; description: string }[] = [
     description: 'direct execFileSync("gh", ...) invocation',
   },
   {
-    pattern: /from ['"]\.\/gh-exec\.mts['"]/,
-    description: 'import from the gh-exec.mts transport primitive',
+    // Matches both the `.mts` source's own import and the generated
+    // `.mjs` counterpart's `from './gh-exec.mjs'` (#2268) -- a guard that
+    // only recognized the source extension would stay vacuous against a
+    // regression introduced solely in committed generated output.
+    pattern: /from ['"]\.\/gh-exec\.mjs?['"]/,
+    description: 'import from the gh-exec transport primitive',
   },
   {
     // ghTextAsync checked before ghText -- \bghText\s*\( alone does not
@@ -69,6 +73,14 @@ function readSource(relativePath: string): string {
   return readFileSync(`${REPO_ROOT}/src/scripts/${relativePath}`, 'utf8');
 }
 
+/** `.mts` -> generated `.mjs` counterpart under `scripts/` (#2268) --
+ * `pnpm run build` commits this file 1:1 per source, so every migrated
+ * helper has one. */
+function readGeneratedOutput(sourceFilename: string): string {
+  const generatedFilename = sourceFilename.replace(/\.mts$/, '.mjs');
+  return readFileSync(`${REPO_ROOT}/scripts/${generatedFilename}`, 'utf8');
+}
+
 test('migrated helpers no longer construct gh/GitHub calls directly', () => {
   for (const filename of MIGRATED_HELPERS) {
     const source = readSource(filename);
@@ -77,6 +89,19 @@ test('migrated helpers no longer construct gh/GitHub calls directly', () => {
         source,
         pattern,
         `${filename} regained ${description} after migrating onto provider-port.mts`,
+      );
+    }
+  }
+});
+
+test('migrated helpers: committed generated output no longer constructs gh/GitHub calls directly (#2268)', () => {
+  for (const filename of MIGRATED_HELPERS) {
+    const generated = readGeneratedOutput(filename);
+    for (const { pattern, description } of DIRECT_GH_PATTERNS) {
+      assert.doesNotMatch(
+        generated,
+        pattern,
+        `${filename.replace(/\.mts$/, '.mjs')} regained ${description} in committed generated output`,
       );
     }
   }


### PR DESCRIPTION
## Summary

Closes #2268

Adds the provider contract fixture/parity/guard coverage #2267's own PR
body deferred to this issue ("exhaustive provider-contract fixture
parity between the GitHub adapter and the fake adapter is #2268's job,
not this PR's").

- **AC4 (static guard, generated output):**
  `tests/provider-port-migration-guard.test.mts` only scanned
  `src/scripts/*.mts` for a direct `gh`/GitHub call, never the
  committed generated `scripts/*.mjs` counterpart the issue's own
  text names ("including generated helper output"). Extended the
  import-pattern regex to match both extensions and added a second
  scan pass over each migrated helper's generated output.
- **AC2 (issue/claim fake-provider flow):** the change/review/CI/merge
  half of #2267's migration already had fake-provider coverage
  (`pre-merge-readiness-collection-smoke.test.mts`,
  `advisory-convergence-fake-provider.test.mts`), but no test drove
  any of #2266's issue/claim-side helpers through
  `createFakeProviderAdapter` -- every existing
  `evaluateDiscoverReadiness` test hand-rolled its
  `loadIssue`/`findRoadmapsByMarker` closures with plain in-memory
  data. Added a test wiring those loaders to a fake port's
  `getWorkItem`/`searchWorkItems` methods instead, PATH stripped,
  proving readiness classification and blocked-by-open-roadmap-marker
  resolution work with zero live `gh` process involved.
- **AC1 (fixture error-shape expressiveness):** `not-found`,
  unsupported-capability, and `not_applicable` were already
  expressible; `getWorkItem` -- the port's one method documented to
  throw a categorized `ProviderError` on a non-404 failure -- could
  only ever return an item or `null` in the fake adapter. Added a
  `workItemErrors` fixture (checked before `workItems`) so a test can
  inject `authentication`, `authorization`, `conflict`, or
  `unavailable` ("transient") failures without a live `gh` process.
- **AC3 (GitHub-vs-fake parity guard, new artifact):** no test
  compared the two adapters' normalized output for equivalent
  underlying state. Added `tests/provider-adapter-parity.test.mts`
  covering all seven areas the issue names -- marker bodies, issue
  selection, review disposition, check state, freshness, unresolved
  threads, merge readiness -- via six representative port methods.
  Each test feeds one canned raw `gh` payload through the real GitHub
  adapter (stubbing `GithubProviderAdapterDeps` in-process, the same
  lighter mechanism `provider-adapter-github.test.mts` already uses --
  no subprocess, no PATH-mock binary, no second harness) and an
  equivalent fixture through the fake adapter, then `deepEqual`-asserts
  the two returned values. The `listWorkflowRuns` case also encodes
  the #2267 `databaseId`-precision fix as a parity point.

## Scope boundaries (deliberate)

- Live GitLab/Bitbucket adapters, credential-dependent CI, and any move
  off the current distribution path are out of scope, per #2270's own
  roadmap boundary.
- The parity guard covers one representative method per named area,
  not every port method -- exhaustive per-method parity would gold-plate
  an M-effort issue without adding coverage the seven named areas don't
  already exercise.

## Acceptance criteria

- [x] The contract fixture suite covers the success and failure shapes
      required by both adapter tracks, including
      authentication/permission failure, not-found, conflict,
      transient, malformed response, unsupported capability, and
      optional advisory `not_applicable`. (Malformed-response coverage
      is GitHub-adapter-specific -- the fake adapter has no wire format
      to corrupt -- and was already covered by #2267's
      `assertNoGraphqlErrors`/null-connection-check tests.)
- [x] At least one migrated issue/claim flow and one migrated
      change/review/CI/merge flow run entirely against a fake
      provider, proving that workflow logic does not require an
      authenticated `gh` process.
- [x] GitHub parity tests assert the normalized values that current
      helpers use for marker bodies, issue selection, review
      disposition, check state, freshness, unresolved threads, and
      merge readiness.
- [x] The direct-provider-call guard fails on a new `gh`/GitHub API
      call in a migrated domain helper and passes for the approved
      shared transport and GitHub adapter modules.
- [x] The fixture and guard tests do not contact GitHub, GitLab,
      Bitbucket, or any other external service -- every test uses
      in-memory fixtures or in-process dependency stubs, zero
      subprocess spawns, zero network calls.
- [x] `pnpm run build` regenerates matching committed output, the full
      test suite passes (4723/4723), and `pnpm run lint:minimum`
      passes end to end.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `node --experimental-strip-types --test tests/*.test.mts`
      (4723/4723 passing)
- [x] `pnpm run lint:minimum` (full CI gate, green end-to-end)
- [x] Manually verified two new guards are not vacuous: temporarily
      reintroduced a stray `gh-exec.mjs` import into a generated file
      (migration guard caught it) and temporarily mismatched one
      fixture id (parity guard caught it), then restored both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of provider errors, including authentication, authorization, conflicts, and service availability issues.
  - Preserved clear not-found behavior when requested work items do not exist.

- **Reliability**
  - Improved consistency between supported provider integrations for work items, comments, review threads, workflow runs, and merge readiness.
  - Enhanced readiness checks when external command-line tools are unavailable.

- **Tests**
  - Added broader coverage for error propagation, provider behavior parity, review freshness, unresolved threads, and workflow identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->