### PR TITLE
feat(advisory-convergence): refresh check on regular PR comments too

### DIFF
--- a/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/.github/workflows/idd-advisory-convergence-comment.yml
@@ -1,9 +1,9 @@
-# Non-required companion to idd-advisory-convergence.yml (#2136).
+# Non-required companion to idd-advisory-convergence.yml (#2136, #2411).
 #
-# Human review-thread chatter must not create or cancel the required
-# `idd-advisory-convergence` check-run. This workflow has a different
-# name, job id, and concurrency group so it cannot overwrite that SHA
-# verdict or cancel an in-flight required run.
+# Human review-thread and regular-comment chatter must not create or
+# cancel the required `idd-advisory-convergence` check-run. This
+# workflow has a different name, job id, and concurrency group so it
+# cannot overwrite that SHA verdict or cancel an in-flight required run.
 #
 # When the comment is IDD-originated (reply-identity stamp, disposition
 # prefix, or an operational marker the required check already honors),
@@ -11,12 +11,21 @@
 # existing pull_request-family required run for the current HEAD SHA.
 # It never asserts `ready` itself.
 #
+# Two trigger families land here (#2411): `pull_request_review_comment`
+# (inline review-thread comments) and `issue_comment` (regular PR
+# comments -- where post-idd-marker.mjs and
+# disposition-non-review-notices.mjs actually post every marker/
+# disposition type, since both use the issues-comments API). `issue_comment`
+# also fires for a comment on a plain issue, not only a PR; the job-level
+# `if:` below skips those (`github.event.issue.pull_request` is only
+# present when the commented-on issue is a PR).
+#
 # Job id is deliberately NOT `idd-advisory-convergence`.
 concurrency:
   # Do not cancel: a later human LGTM must not abort an in-flight
   # IDD-originated refresh before it reruns the required check (#2136).
   cancel-in-progress: false
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
 name: IDD advisory-convergence comment refresh
 on:
   pull_request_review_comment:
@@ -24,6 +33,9 @@ on:
       - created
       - edited
       - deleted
+  issue_comment:
+    types:
+      - created
 permissions:
   contents: read
   issues: read
@@ -33,6 +45,7 @@ jobs:
   refresh-if-idd-originated:
     runs-on: ubuntu-slim
     timeout-minutes: 10
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -70,5 +83,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # pull_request_review_comment carries the PR number at
+          # github.event.pull_request.number; issue_comment (#2411)
+          # carries it at github.event.issue.number instead.
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: node scripts/rerun-advisory-convergence.mjs --pr "$PR_NUMBER" --apply

--- a/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
+++ b/idd-template/.github/workflows/idd-advisory-convergence-comment.yml
@@ -1,15 +1,24 @@
-# Non-required companion to idd-advisory-convergence.yml (#2136).
+# Non-required companion to idd-advisory-convergence.yml (#2136, #2411).
 #
-# Human review-thread chatter must not create or cancel the required
-# `idd-advisory-convergence` check-run. This workflow has a different
-# name, job id, and concurrency group so it cannot overwrite that SHA
-# verdict or cancel an in-flight required run.
+# Human review-thread and regular-comment chatter must not create or
+# cancel the required `idd-advisory-convergence` check-run. This
+# workflow has a different name, job id, and concurrency group so it
+# cannot overwrite that SHA verdict or cancel an in-flight required run.
 #
 # When the comment is IDD-originated (reply-identity stamp, disposition
 # prefix, or an operational marker the required check already honors),
 # it reuses `rerun-advisory-convergence.mjs --apply` to refresh the
 # existing pull_request-family required run for the current HEAD SHA.
 # It never asserts `ready` itself.
+#
+# Two trigger families land here (#2411): `pull_request_review_comment`
+# (inline review-thread comments) and `issue_comment` (regular PR
+# comments -- where post-idd-marker.mjs and
+# disposition-non-review-notices.mjs actually post every marker/
+# disposition type, since both use the issues-comments API).
+# `issue_comment` also fires for a comment on a plain issue, not only a
+# PR; the job-level `if:` below skips those (`github.event.issue.pull_request`
+# is only present when the commented-on issue is a PR).
 #
 # Job id is deliberately NOT `idd-advisory-convergence`.
 #
@@ -31,10 +40,12 @@ concurrency:
   # Do not cancel: a later human LGTM must not abort an in-flight
   # IDD-originated refresh before it reruns the required check (#2136).
   cancel-in-progress: false
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
 on:
   pull_request_review_comment:
     types: [created, edited, deleted]
+  issue_comment:
+    types: [created]
 permissions:
   contents: read
   issues: read
@@ -47,6 +58,7 @@ jobs:
   refresh-if-idd-originated:
     runs-on: ${{ vars.CI_RUNNER_LABEL || 'ubuntu-slim' }}
     timeout-minutes: 10
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
     steps:
       - uses: actions/checkout@v4
         with:
@@ -218,7 +230,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_ENTERPRISE_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # pull_request_review_comment carries the PR number at
+          # github.event.pull_request.number; issue_comment (#2411)
+          # carries it at github.event.issue.number instead.
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROFILE: ${{ steps.profile.outputs.profile }}
           PACKAGE_SPEC: ${{ steps.profile.outputs.package-spec }}
           MANAGER: ${{ steps.manager.outputs.manager }}

--- a/tests/advisory-convergence-comment-workflow.test.mts
+++ b/tests/advisory-convergence-comment-workflow.test.mts
@@ -43,6 +43,11 @@ test('required advisory-convergence workflows no longer trigger on review commen
       /pull_request_review_comment/,
       `${path} on: must not include pull_request_review_comment`,
     );
+    assert.doesNotMatch(
+      onBlock,
+      /issue_comment/,
+      `${path} on: must not include issue_comment`,
+    );
     assert.match(onBlock, /pull_request:/);
     assert.match(onBlock, /pull_request_review:/);
   }
@@ -64,6 +69,32 @@ test('comment-refresh workflows are non-required and use a different job id', ()
       text,
       /cancel-in-progress:\s*false/,
       `${path} must not cancel an in-flight IDD refresh`,
+    );
+  }
+});
+
+// #2411: IDD's own operational markers (post-idd-marker.mjs,
+// disposition-non-review-notices.mjs) post through the issues-comments
+// API (issue_comment events), not the review-comment API -- the
+// comment-refresh workflows need this trigger too, plus a guard so a
+// comment on a plain issue (not a PR) is a no-op.
+test('comment-refresh workflows also trigger on issue_comment and guard non-PR issues', () => {
+  for (const path of COMMENT_PATHS) {
+    const text = readWorkflow(path);
+    assert.match(
+      text,
+      /issue_comment:/,
+      `${path} on: must include issue_comment`,
+    );
+    assert.match(
+      text,
+      /github\.event_name\s*!=\s*'issue_comment'\s*\|\|\s*github\.event\.issue\.pull_request\s*!=\s*null/,
+      `${path} must skip a plain-issue issue_comment event`,
+    );
+    assert.match(
+      text,
+      /github\.event\.pull_request\.number\s*\|\|\s*github\.event\.issue\.number/,
+      `${path} must resolve PR_NUMBER from either event shape`,
     );
   }
 });

--- a/tests/advisory-convergence-comment-workflow.test.mts
+++ b/tests/advisory-convergence-comment-workflow.test.mts
@@ -91,10 +91,28 @@ test('comment-refresh workflows also trigger on issue_comment and guard non-PR i
       /github\.event_name\s*!=\s*'issue_comment'\s*\|\|\s*github\.event\.issue\.pull_request\s*!=\s*null/,
       `${path} must skip a plain-issue issue_comment event`,
     );
+    // Scope this assertion to the "Rerun required HEAD check" step's own
+    // env block -- the concurrency.group expression coincidentally shares
+    // the same `pull_request.number || issue.number` substring, so a
+    // whole-file match would still pass even if the step's own PR_NUMBER
+    // assignment regressed back to the pull_request-only form.
+    const rerunStepIndex = text.indexOf('- name: Rerun required HEAD check');
+    assert.notEqual(
+      rerunStepIndex,
+      -1,
+      `${path} must have a "Rerun required HEAD check" step`,
+    );
+    const prNumberAssignment = text
+      .slice(rerunStepIndex)
+      .match(/PR_NUMBER:\s*\$\{\{\s*([^}]+)\}\}/);
+    assert.ok(
+      prNumberAssignment,
+      `${path} Rerun required HEAD check step must assign PR_NUMBER`,
+    );
     assert.match(
-      text,
+      prNumberAssignment[1],
       /github\.event\.pull_request\.number\s*\|\|\s*github\.event\.issue\.number/,
-      `${path} must resolve PR_NUMBER from either event shape`,
+      `${path} PR_NUMBER must resolve from either event shape`,
     );
   }
 });


### PR DESCRIPTION
## Summary

`idd-advisory-convergence-comment.yml` (#2136) refreshes the required
`idd-advisory-convergence` check-run for the current HEAD SHA when an
IDD-originated comment lands, without a new push. Its trigger was
`pull_request_review_comment` only (inline review-thread replies).

Most of IDD's own operational markers post through the
**issues-comments API** instead (`post-idd-marker.mjs`,
`disposition-non-review-notices.mjs`), which fires `issue_comment`, not
`pull_request_review_comment`. Those posts left the required check
stale until a manual `rerun-advisory-convergence.mjs --apply` — directly
observed on PR #2400 after several `review-ack:` /
`advisory-wait-recovery:` markers and a disposition reply.

## Changes

- `.github/workflows/idd-advisory-convergence-comment.yml` and its
  `idd-template/` mirror: add `issue_comment: [created]` to the `on:`
  block, add a job-level `if:` guard skipping a comment on a plain
  (non-PR) issue, generalize `PR_NUMBER` resolution to
  `github.event.pull_request.number || github.event.issue.number`, and
  update the header comment / concurrency group accordingly. The
  `idd-template/` copy's helperRuntime profile-resolution logic
  (vendored-node / package-manager / ephemeral-npx / instructions-only)
  is untouched.
- `tests/advisory-convergence-comment-workflow.test.mts`: extended the
  existing required-workflow test with a `doesNotMatch` assertion for
  `issue_comment`, and added a new test asserting both comment-workflow
  copies carry the `issue_comment:` trigger, the non-PR guard, and the
  `PR_NUMBER` fallback resolution.

Every existing #2136 invariant is unchanged: this workflow stays
non-required, never shares the required job's concurrency group, and
never asserts `ready` on its own.

## Verification

- `node --test tests/advisory-convergence-comment-workflow.test.mts` — 5/5 pass
- `actionlint` on both workflow files — clean
- Python `yaml.safe_load()` on both workflow files — parses cleanly
- `pnpm run typecheck` — clean
- Full `node --test` — 4711/4711 pass
- `pnpm run lint:minimum` — clean (cspell, markdownlint, biome, dprint all 0 issues)

Closes #2411
