### PR TITLE
fix(post-merge-cleanup): check current STATUS, not just prior

### DIFF
--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -156,9 +156,12 @@ jobs:
           # prior success alone must never suppress this run's own
           # non-success evidence (masking a later failure), and a prior
           # non-success alone must never suppress this run's own success
-          # evidence (masking a later recovery). Only a truly redundant
-          # "still converged" repeat is skipped; any status transition in
-          # either direction always posts fresh evidence.
+          # evidence (masking a later recovery). Only a run that is
+          # ALSO converged when the prior record was already converged
+          # gets skipped -- `applied` <-> `clean` between two already-
+          # converged runs stays silent, but any transition between a
+          # converged and a non-converged state always posts fresh
+          # evidence.
           # "Trusted" scoping: this workflow's own posts are authored by
           # `github-actions[bot]` (the GITHUB_TOKEN actor), and an agent's
           # local F4 post is authored by a configured `trustedMarkerActors`

--- a/.github/workflows/post-merge-cleanup.yml
+++ b/.github/workflows/post-merge-cleanup.yml
@@ -150,12 +150,15 @@ jobs:
           # this workflow's own runs; an agent F4 (or a maintainer
           # rerunning workflow_dispatch on the same PR) can still have
           # posted an evidence comment outside this run. Skip only when
-          # the latest trusted <!-- idd-cleanup-evidence: {status} ... -->
-          # comment already records `applied` or `clean` -- a trusted
-          # comment recording any other status (`failed`, `incomplete`,
-          # `rescan-failed`, `permission-blocked`) invites a retry, so a
-          # rerun must post fresh evidence for its own outcome instead of
-          # leaving stale non-success evidence as the PR's only record.
+          # BOTH the latest trusted <!-- idd-cleanup-evidence: {status}
+          # ... --> comment already records `applied`/`clean` AND this
+          # run's own outcome is also `applied`/`clean` (#2213) -- a
+          # prior success alone must never suppress this run's own
+          # non-success evidence (masking a later failure), and a prior
+          # non-success alone must never suppress this run's own success
+          # evidence (masking a later recovery). Only a truly redundant
+          # "still converged" repeat is skipped; any status transition in
+          # either direction always posts fresh evidence.
           # "Trusted" scoping: this workflow's own posts are authored by
           # `github-actions[bot]` (the GITHUB_TOKEN actor), and an agent's
           # local F4 post is authored by a configured `trustedMarkerActors`
@@ -194,8 +197,10 @@ jobs:
                 | sed -n 's/^<!-- idd-cleanup-evidence: \([^ ]*\) .*/\1/p')
             fi
           done <<< "$COMMENTS_TSV"
-          if [ -n "$EXISTING" ] && { [ "$EXISTING_STATUS" = "applied" ] || [ "$EXISTING_STATUS" = "clean" ]; }; then
-            echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment recording '${EXISTING_STATUS}' (id: ${EXISTING}); skipping workflow post."
+          if [ -n "$EXISTING" ] \
+            && { [ "$EXISTING_STATUS" = "applied" ] || [ "$EXISTING_STATUS" = "clean" ]; } \
+            && { [ "$STATUS" = "applied" ] || [ "$STATUS" = "clean" ]; }; then
+            echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment recording '${EXISTING_STATUS}', and this run's own outcome '${STATUS}' is also converged (id: ${EXISTING}); skipping workflow post."
             exit 0
           fi
           BODY=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \

--- a/idd-template/.github/workflows/post-merge-cleanup.yml
+++ b/idd-template/.github/workflows/post-merge-cleanup.yml
@@ -350,12 +350,15 @@ jobs:
           # this workflow's own runs; an agent F4 (or a maintainer
           # rerunning workflow_dispatch on the same PR) can still have
           # posted an evidence comment outside this run. Skip only when
-          # the latest trusted <!-- idd-cleanup-evidence: {status} ... -->
-          # comment already records `applied` or `clean` -- a trusted
-          # comment recording any other status (`failed`, `incomplete`,
-          # `rescan-failed`, `permission-blocked`) invites a retry, so a
-          # rerun must post fresh evidence for its own outcome instead of
-          # leaving stale non-success evidence as the PR's only record.
+          # BOTH the latest trusted <!-- idd-cleanup-evidence: {status}
+          # ... --> comment already records `applied`/`clean` AND this
+          # run's own outcome is also `applied`/`clean` (#2213) -- a
+          # prior success alone must never suppress this run's own
+          # non-success evidence (masking a later failure), and a prior
+          # non-success alone must never suppress this run's own success
+          # evidence (masking a later recovery). Only a truly redundant
+          # "still converged" repeat is skipped; any status transition in
+          # either direction always posts fresh evidence.
           # "Trusted" scoping: this workflow's own posts are authored by
           # `github-actions[bot]` (the GITHUB_TOKEN actor), and an agent's
           # local F4 post is authored by a configured `trustedMarkerActors`
@@ -403,8 +406,10 @@ jobs:
                 | sed -n 's/^<!-- idd-cleanup-evidence: \([^ ]*\) .*/\1/p')
             fi
           done <<< "$COMMENTS_TSV"
-          if [ -n "$EXISTING" ] && { [ "$EXISTING_STATUS" = "applied" ] || [ "$EXISTING_STATUS" = "clean" ]; }; then
-            echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment recording '${EXISTING_STATUS}' (id: ${EXISTING}); skipping workflow post."
+          if [ -n "$EXISTING" ] \
+            && { [ "$EXISTING_STATUS" = "applied" ] || [ "$EXISTING_STATUS" = "clean" ]; } \
+            && { [ "$STATUS" = "applied" ] || [ "$STATUS" = "clean" ]; }; then
+            echo "::notice::PR #${PR_NUMBER} already has a trusted-author idd-cleanup-evidence comment recording '${EXISTING_STATUS}', and this run's own outcome '${STATUS}' is also converged (id: ${EXISTING}); skipping workflow post."
             exit 0
           fi
           BODY=$(printf '%s\n\n%s\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \

--- a/idd-template/.github/workflows/post-merge-cleanup.yml
+++ b/idd-template/.github/workflows/post-merge-cleanup.yml
@@ -356,9 +356,12 @@ jobs:
           # prior success alone must never suppress this run's own
           # non-success evidence (masking a later failure), and a prior
           # non-success alone must never suppress this run's own success
-          # evidence (masking a later recovery). Only a truly redundant
-          # "still converged" repeat is skipped; any status transition in
-          # either direction always posts fresh evidence.
+          # evidence (masking a later recovery). Only a run that is
+          # ALSO converged when the prior record was already converged
+          # gets skipped -- `applied` <-> `clean` between two already-
+          # converged runs stays silent, but any transition between a
+          # converged and a non-converged state always posts fresh
+          # evidence.
           # "Trusted" scoping: this workflow's own posts are authored by
           # `github-actions[bot]` (the GITHUB_TOKEN actor), and an agent's
           # local F4 post is authored by a configured `trustedMarkerActors`

--- a/tests/post-merge-cleanup-workflow.test.mts
+++ b/tests/post-merge-cleanup-workflow.test.mts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+const WORKFLOW_PATHS = [
+  '.github/workflows/post-merge-cleanup.yml',
+  'idd-template/.github/workflows/post-merge-cleanup.yml',
+] as const;
+
+function readWorkflow(rel: string): string {
+  return readFileSync(new URL(`../${rel}`, import.meta.url), 'utf8');
+}
+
+test("duplicate-evidence-skip guard also requires the current run's own STATUS to be converged (#2213)", () => {
+  for (const path of WORKFLOW_PATHS) {
+    const text = readWorkflow(path);
+    const guardStart = text.indexOf('if [ -n "$EXISTING" ]');
+    assert.notEqual(
+      guardStart,
+      -1,
+      `${path} must keep the duplicate-evidence-skip guard`,
+    );
+    const guardEnd = text.indexOf('; then', guardStart);
+    const guard = text.slice(guardStart, guardEnd);
+
+    assert.match(
+      guard,
+      /\[ "\$EXISTING_STATUS" = "applied" \]/,
+      `${path} guard must still check the prior comment's EXISTING_STATUS`,
+    );
+    assert.match(
+      guard,
+      /\[ "\$STATUS" = "applied" \]/,
+      `${path} guard must also check the current run's own STATUS, not only EXISTING_STATUS`,
+    );
+    assert.match(
+      guard,
+      /\[ "\$STATUS" = "clean" \]/,
+      `${path} guard must also check STATUS = clean, not only EXISTING_STATUS`,
+    );
+  }
+});
+
+test('duplicate-evidence-skip guard is a strict superset of the prior EXISTING_STATUS-only condition', () => {
+  for (const path of WORKFLOW_PATHS) {
+    const text = readWorkflow(path);
+    // A bare "EXISTING_STATUS = applied" check with no accompanying
+    // "STATUS = applied" check anywhere nearby would mean the fix
+    // regressed back to comparing only the prior comment's status.
+    const skipBlockStart = text.indexOf('# Avoid duplicate evidence comments');
+    const skipBlockEnd = text.indexOf('BODY=$(printf', skipBlockStart);
+    const skipBlock = text.slice(skipBlockStart, skipBlockEnd);
+    const statusMentions = (skipBlock.match(/"\$STATUS"/g) ?? []).length;
+    assert.ok(
+      statusMentions >= 2,
+      `${path} skip block must reference $STATUS at least twice (applied and clean), found ${statusMentions}`,
+    );
+  }
+});

--- a/tests/post-merge-cleanup-workflow.test.mts
+++ b/tests/post-merge-cleanup-workflow.test.mts
@@ -15,12 +15,17 @@ test("duplicate-evidence-skip guard also requires the current run's own STATUS t
   for (const path of WORKFLOW_PATHS) {
     const text = readWorkflow(path);
     const guardStart = text.indexOf('if [ -n "$EXISTING" ]');
-    assert.notEqual(
+    assert.notStrictEqual(
       guardStart,
       -1,
       `${path} must keep the duplicate-evidence-skip guard`,
     );
     const guardEnd = text.indexOf('; then', guardStart);
+    assert.notStrictEqual(
+      guardEnd,
+      -1,
+      `${path} guard must be closed with "; then"`,
+    );
     const guard = text.slice(guardStart, guardEnd);
 
     assert.match(
@@ -48,7 +53,17 @@ test('duplicate-evidence-skip guard is a strict superset of the prior EXISTING_S
     // "STATUS = applied" check anywhere nearby would mean the fix
     // regressed back to comparing only the prior comment's status.
     const skipBlockStart = text.indexOf('# Avoid duplicate evidence comments');
+    assert.notStrictEqual(
+      skipBlockStart,
+      -1,
+      `${path} must keep the duplicate-evidence-skip comment block`,
+    );
     const skipBlockEnd = text.indexOf('BODY=$(printf', skipBlockStart);
+    assert.notStrictEqual(
+      skipBlockEnd,
+      -1,
+      `${path} must keep the BODY=$(printf anchor after the skip block`,
+    );
     const skipBlock = text.slice(skipBlockStart, skipBlockEnd);
     const statusMentions = (skipBlock.match(/"\$STATUS"/g) ?? []).length;
     assert.ok(


### PR DESCRIPTION
## Summary

- `post-merge-cleanup.yml`'s duplicate-evidence-skip guard suppressed
  the workflow's own comment post whenever a prior trusted comment
  recorded `applied`/`clean`, without checking this run's own outcome
  — a later rerun's genuine failure could be silently masked by an
  earlier success.
- Fixed by requiring BOTH the prior comment's `EXISTING_STATUS` AND
  this run's own `STATUS` to already be `applied`/`clean` before
  skipping. Chose AND (not replacing the prior check outright, as a
  literal one-line reading of the issue's suggestion might imply)
  because replacing it would introduce the symmetric bug — a genuine
  recovery (prior `failed` → current `applied`) getting suppressed
  too. Only a truly redundant "still converged" repeat is skipped now;
  any status transition in either direction always posts fresh
  evidence.
- Applied identically to both `.github/workflows/post-merge-cleanup.yml`
  and its `idd-template/` mirror.
- Added `tests/post-merge-cleanup-workflow.test.mts` — static-pattern
  assertions on the embedded shell guard (following this repo's
  existing convention for `.yml`-embedded shell logic, e.g.
  `tests/advisory-convergence-comment-workflow.test.mts`; there is no
  precedent here for executing embedded workflow shell blocks
  directly). Verified the new test genuinely fails against the
  pre-fix files (via a local `git stash` of just the two workflow
  files) and passes after the fix.

## Test plan

- [x] `node --test tests/post-merge-cleanup-workflow.test.mts` — new
      regression test passes; confirmed it fails against the unfixed
      workflow files
- [x] `pnpm test` — full suite (4711 tests) passes
- [x] `pre-push-validate` (biome, dprint, markdownlint, cspell,
      audit-docs, audit-code-span-wrap, build:check, idd-doctor) — all
      green (pre-existing unrelated warnings in `protocol-helpers.mts`
      only)

Closes #2213

🤖 Generated with [Claude Code](https://claude.com/claude-code)