### PR TITLE
chore(token-cost): refresh dogfood snapshot, n=0 to n=1

### DIFF
--- a/docs/token-cost-snapshot.json
+++ b/docs/token-cost-snapshot.json
@@ -1,32 +1,34 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-09-02T06:48:41.425Z",
+  "generatedAt": "2026-09-02T07:18:10.954Z",
   "minPublishableSamples": 10,
   "minPublishableVendors": 2,
   "publishable": false,
-  "sampleCount": 0,
-  "vendors": [],
+  "sampleCount": 1,
+  "vendors": [
+    "claude"
+  ],
   "asOf": "2026-09-02",
   "totalUsage": {
     "inputUncached": {
-      "p25": 0,
-      "p50": 0,
-      "p75": 0
+      "p25": 1638,
+      "p50": 1638,
+      "p75": 1638
     },
     "cacheRead": {
-      "p25": 0,
-      "p50": 0,
-      "p75": 0
+      "p25": 238475137,
+      "p50": 238475137,
+      "p75": 238475137
     },
     "cacheCreation": {
-      "p25": 0,
-      "p50": 0,
-      "p75": 0
+      "p25": 1996956,
+      "p50": 1996956,
+      "p75": 1996956
     },
     "output": {
-      "p25": 0,
-      "p50": 0,
-      "p75": 0
+      "p25": 686521,
+      "p50": 686521,
+      "p75": 686521
     },
     "reasoning": {
       "p25": 0,
@@ -34,13 +36,90 @@
       "p75": 0
     }
   },
-  "stageUsage": [],
+  "stageUsage": [
+    {
+      "id": "claim",
+      "usage": {
+        "inputUncached": {
+          "p25": 16,
+          "p50": 16,
+          "p75": 16
+        },
+        "cacheRead": {
+          "p25": 3559188,
+          "p50": 3559188,
+          "p75": 3559188
+        },
+        "cacheCreation": {
+          "p25": 2813,
+          "p50": 2813,
+          "p75": 2813
+        },
+        "output": {
+          "p25": 1360,
+          "p50": 1360,
+          "p75": 1360
+        },
+        "reasoning": {
+          "p25": 0,
+          "p50": 0,
+          "p75": 0
+        }
+      }
+    },
+    {
+      "id": "work",
+      "usage": {
+        "inputUncached": {
+          "p25": 1620,
+          "p50": 1620,
+          "p75": 1620
+        },
+        "cacheRead": {
+          "p25": 234682427,
+          "p50": 234682427,
+          "p75": 234682427
+        },
+        "cacheCreation": {
+          "p25": 1993701,
+          "p50": 1993701,
+          "p75": 1993701
+        },
+        "output": {
+          "p25": 684956,
+          "p50": 684956,
+          "p75": 684956
+        },
+        "reasoning": {
+          "p25": 0,
+          "p50": 0,
+          "p75": 0
+        }
+      }
+    }
+  ],
   "compactionCount": {
-    "p25": 0,
-    "p50": 0,
-    "p75": 0
+    "p25": 2,
+    "p50": 2,
+    "p75": 2
   },
-  "cacheHitRatio": 0,
-  "successRateByModel": {},
-  "successRateByVendor": {}
+  "cacheHitRatio": 0.9916889300478313,
+  "successRateByModel": {
+    "claude-sonnet-5": {
+      "merged": 0,
+      "aborted": 0,
+      "unclaimed": 1,
+      "humanHandoff": 0,
+      "rate": 0
+    }
+  },
+  "successRateByVendor": {
+    "claude": {
+      "merged": 0,
+      "aborted": 0,
+      "unclaimed": 1,
+      "humanHandoff": 0,
+      "rate": 0
+    }
+  }
 }

--- a/docs/token-cost.md
+++ b/docs/token-cost.md
@@ -113,6 +113,6 @@ number is ever invented to fill the gap.
 
 <!-- token-cost-docs:start -->
 
-Not yet publishable, n=0.
+Not yet publishable, n=1.
 
 <!-- token-cost-docs:end -->

--- a/docs/token-cost.md
+++ b/docs/token-cost.md
@@ -109,6 +109,16 @@ samples across at least 2 distinct vendors. Below that gate, the
 README blurb and the table below stay on an unpublished stub — no
 number is ever invented to fill the gap.
 
+**Known caveat**: an event-window sample's `outcome` currently
+misclassifies a genuinely merged loop as `unclaimed` whenever the
+closing PR used the standard `Closes #N` keyword link instead of
+GitHub's manual Development-panel link (every PR this repository's own
+IDD workflow opens) — `fetchIssueLoopGithubContext` resolves the
+connected PR via `ConnectedEvent`, which only the manual link
+produces. Tracked separately (Refs #2444); until fixed, treat any
+`unclaimed` outcome on an event-window (`#ew<issueNumber>`) sample as
+unverified rather than a genuine abandoned-claim signal.
+
 ## Current snapshot
 
 <!-- token-cost-docs:start -->


### PR DESCRIPTION
Closes #2434

## Summary

Retries the snapshot harvest per #2434's own Proposed change, after
correcting a wrong diagnosis discovered while starting this issue's
own work.

## The correction

#2426's PR (#2435) reported `n=0` with a completely clean harvest (zero
stderr warnings) and concluded "no completed issue-loop carries an
identified event yet." That conclusion was wrong: #2426's harvest
command was run from that issue's own worktree, and
`defaultClaudeProjectDir()` defaults to `~/.claude/projects/<encoded
process.cwd()>` — a directory that never existed for that worktree's
path, since Claude Code's own session logs are recorded under the
encoded *primary* worktree path. `globSync` against a missing
directory returns `[]` silently, with no error and no stderr warning —
so #2426's "clean" result was an artifact of scanning nothing, not
evidence that nothing was there to find.

Posted a correction on PR #2435 and fixed roadmap #2296's own #2426
line. Filed #2439 to fix the underlying footgun in the harvest CLI
itself (warn instead of silently scanning nothing), which folds in the
next snapshot retry rather than spawning a separate round-7 issue —
avoiding the treadmill this retry chain (#2419 → #2426 → #2434 → ...)
could otherwise fall into.

## Result

`n=1` (up from `n=0`), still `publishable: false` (floor is 10 samples
across 2+ vendors). The one real sample is issue #2424's own loop
(`#ew2424`) — its late-lifecycle events picked up `vendorSessionId`
once posted from the fast-forwarded primary worktree after that
issue's own merge. Real, non-zero forward progress for the first time
in this whole retry chain.

**Second correction, found via Copilot review on this PR**: the
committed sample records `outcome: unclaimed` even though issue
#2424's loop genuinely merged (PR #2430). Verified against the live
GraphQL API: `fetchIssueLoopGithubContext`'s PR resolution relies on
`ConnectedEvent`, which only GitHub's manual Development-panel link
produces — never the `Closes #N` keyword link every PR this repo's IDD
workflow opens uses (confirmed empty `timelineItems` for both #2424
and #2426). `prMergedAtMs` never resolves, so the routine F4
`unclaimed-by` marker (posted after every merge, per protocol) becomes
`deriveOutcome`'s fallback answer instead of `merged`. The sample data
itself is a faithful (if mis-labeled) harvest result, not invented or
hand-edited — filed #2444 for the actual fix, out of scope for this
run-and-record issue, and added a caveat to `docs/token-cost.md` in
the meantime.

## Test plan

- [x] Harvest run from the **primary worktree** (per the corrected
      Proposed change): `node scripts/token-cost-harvest.mjs --repo
      kurone-kito/idd-skill` — `78 sample(s) (1 issue-loop, 77
      session)`
- [x] Report run from this issue's own worktree, `--in` pointed at the
      shared samples path: `docs/token-cost-snapshot.json` refreshed,
      `n=1`/`publishable=false`
- [x] `docs/token-cost.md`'s unpublishable stub updated (`n=1`)
- [x] No README changes needed (still unpublishable)
- [x] Correction comment posted on PR #2435; roadmap #2296 line fixed
- [x] Follow-up #2439 filed and linked from roadmap #2296
- [x] Verified the `ConnectedEvent` gap and the `closedByPullRequestsReferences`
      replacement signal directly against the live GraphQL API for
      both #2424 and #2426 before filing #2444
- [x] `docs/token-cost.md` caveat added and linked from #2444

## Note: #2439 was picked up and merged concurrently (PR #2443)

A different session claimed and merged #2439 (the harvest-CLI
cwd-sensitivity footgun this PR also flagged) as PR #2443 while this
PR was in review — including its own independent primary-worktree
harvest run, which converged on the exact same `n=1` result (only
`generatedAt` differed). Merged `origin/main` into this branch;
`docs/token-cost-snapshot.json`'s only conflict was that timestamp
(resolved by taking `main`'s, then reconfirmed via `token-cost-report.mjs
--check` — no drift); `docs/token-cost.md`'s two additions (#2443's
cwd-sensitivity note, this PR's outcome-misclassification caveat) merged
cleanly since they're in different sections. Full suite re-verified
post-merge: 4728/4728 passing. This PR's own remaining unique
contribution is the outcome-misclassification finding and #2444.

https://claude.ai/code/session_01CtcjhuuXDqQASYGXtJnmV3

