### PR TITLE
docs(provider): document staged non-GitHub adoption

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -102,7 +102,11 @@ CI、選択したマージポリシー、後片づけまでループを進めま
 ループを最後まで実行するには、`git`、認証済みの `gh` CLI(または同等の
 GitHub MCP 連携)、`jq`、`curl` などの REST クライアント、そして helper
 スクリプトを使う場合は Node.js が必要です(詳細は
-[Tooling boundary](docs/customization.md#tooling-boundary))。無人または
+[Tooling boundary](docs/customization.md#tooling-boundary))。GitHub は
+現時点で IDD が実装している唯一のプロバイダーです。段階的でプロバイダー
+非依存のアダプター境界については
+[Provider Portability](docs/customization.md#provider-portability) を
+参照してください。無人または
 マージ可能なエージェントへ認証情報を渡す前に
 [Permissions and threat model](docs/permissions.md) を確認し、
 マージポリシーを [Customizing IDD](docs/customization.md) で 1 つ選んで

--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ path, including the optional IDD doctor validation.
 The full loop needs `git`, an authenticated `gh` CLI (or an equivalent
 GitHub MCP integration), `jq`, a REST client such as `curl`, and
 optionally Node.js for the helper scripts (see
-[Tooling boundary](docs/customization.md#tooling-boundary)). Review
+[Tooling boundary](docs/customization.md#tooling-boundary)) --
+GitHub is IDD's only implemented provider today; see
+[Provider Portability](docs/customization.md#provider-portability)
+for the staged, provider-neutral adapter boundary. Review
 [Permissions and threat model](docs/permissions.md) before granting
 credentials to unattended or merge-capable agents, and record a merge
 policy in [Customizing IDD](docs/customization.md).

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -757,13 +757,13 @@ the `Project commands` table in
 The following policy matrix defines the tooling requirements and
 fallback order for repositories adopting IDD:
 
-| Context                                  | Requirement         | Fallback order                                                                                           |
-| ---------------------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------- |
-| `git`, `gh`, `jq`, `curl`                | **Required**        | No fallback; IDD cannot run without these                                                                |
-| `install-deps` command                   | Project-dependent   | Use project's native package manager; `true` as no-op when no install step is needed                     |
-| Validate commands (`fix-validate`, etc.) | Project-dependent   | Use project tooling; `true` as no-op                                                                     |
-| Node.js / `npx`                          | Optional            | 1. Existing project Node.js tooling; 2. `npx` when available; 3. `true` when unavailable or not relevant |
-| pnpm                                     | Not required by IDD | Only needed when the adopter's project itself uses pnpm                                                  |
+| Context                                  | Requirement                         | Fallback order                                                                                           |
+| ---------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `git`, `gh`, `jq`, `curl`                | **Required for the GitHub adapter** | No fallback for GitHub; IDD's only implemented provider today needs these                                |
+| `install-deps` command                   | Project-dependent                   | Use project's native package manager; `true` as no-op when no install step is needed                     |
+| Validate commands (`fix-validate`, etc.) | Project-dependent                   | Use project tooling; `true` as no-op                                                                     |
+| Node.js / `npx`                          | Optional                            | 1. Existing project Node.js tooling; 2. `npx` when available; 3. `true` when unavailable or not relevant |
+| pnpm                                     | Not required by IDD                 | Only needed when the adopter's project itself uses pnpm                                                  |
 
 Decision points:
 
@@ -775,6 +775,29 @@ Decision points:
   Node.js project's script runner; (2) use bare `npx <tool>` when
   `npx` is available; (3) replace with `true` when `npx` is unavailable
   or the check is not relevant to the project.
+
+## Provider Portability
+
+GitHub is IDD's only implemented and fully exercised provider today,
+and `git`/`gh`/`jq`/`curl` above name the GitHub adapter's own
+requirements, not a permanent IDD-wide constraint. Internally, IDD
+defines a provider-neutral adapter boundary -- capability groups
+(work items, comments and labels, claims, change requests, reviews and
+threads, checks, permissions, branch protection, merge) each declared
+`required` or `optional`, with normalized outcomes
+(`ok`/`fail_closed`/`not_applicable`) and error categories independent
+of any one platform's status codes. A required capability an adapter
+does not support fails closed rather than silently passing; an
+optional advisory capability may resolve `not_applicable` instead.
+
+This is a staged foundation, not a shipped multi-provider release:
+GitLab SaaS is the first future adapter target, Bitbucket Cloud
+follows as its own capability check, and self-managed/Data Center
+variants each need their own verification before being claimed
+supported. Copilot review convergence stays a separate, GitHub-specific
+concern -- a future adapter's `advisory-review` capability group can
+resolve `not_applicable` on a provider with no equivalent bot reviewer
+without weakening any required gate.
 
 ## Reusable pnpm boundary guard workflow
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -757,13 +757,14 @@ the `Project commands` table in
 The following policy matrix defines the tooling requirements and
 fallback order for repositories adopting IDD:
 
-| Context                                  | Requirement                         | Fallback order                                                                                           |
-| ---------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `git`, `gh`, `jq`, `curl`                | **Required for the GitHub adapter** | No fallback for GitHub; IDD's only implemented provider today needs these                                |
-| `install-deps` command                   | Project-dependent                   | Use project's native package manager; `true` as no-op when no install step is needed                     |
-| Validate commands (`fix-validate`, etc.) | Project-dependent                   | Use project tooling; `true` as no-op                                                                     |
-| Node.js / `npx`                          | Optional                            | 1. Existing project Node.js tooling; 2. `npx` when available; 3. `true` when unavailable or not relevant |
-| pnpm                                     | Not required by IDD                 | Only needed when the adopter's project itself uses pnpm                                                  |
+| Context                                  | Requirement                         | Fallback order                                                                                                |
+| ---------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `git`                                    | **Required**                        | No fallback; IDD-wide, independent of provider (`git worktree`/`fetch`/`merge` run outside the provider port) |
+| `gh`, `jq`, `curl`                       | **Required for the GitHub adapter** | No fallback for GitHub; IDD's only implemented provider today needs these                                     |
+| `install-deps` command                   | Project-dependent                   | Use project's native package manager; `true` as no-op when no install step is needed                          |
+| Validate commands (`fix-validate`, etc.) | Project-dependent                   | Use project tooling; `true` as no-op                                                                          |
+| Node.js / `npx`                          | Optional                            | 1. Existing project Node.js tooling; 2. `npx` when available; 3. `true` when unavailable or not relevant      |
+| pnpm                                     | Not required by IDD                 | Only needed when the adopter's project itself uses pnpm                                                       |
 
 Decision points:
 
@@ -779,12 +780,13 @@ Decision points:
 ## Provider Portability
 
 GitHub is IDD's only implemented and fully exercised provider today,
-and `git`/`gh`/`jq`/`curl` above name the GitHub adapter's own
-requirements, not a permanent IDD-wide constraint. Internally, IDD
-defines a provider-neutral adapter boundary -- capability groups
-(work items, comments and labels, claims, change requests, reviews and
-threads, checks, permissions, branch protection, merge) each declared
-`required` or `optional`, with normalized outcomes
+and `gh`/`jq`/`curl` above name the GitHub adapter's own requirements,
+not a permanent IDD-wide constraint (`git` itself stays required
+IDD-wide regardless of provider). Internally, IDD defines a
+provider-neutral adapter boundary -- capability groups (repository
+identity, work items, comments and labels, claims, change requests,
+reviews and threads, checks, permissions, branch protection, merge)
+each declared `required` or `optional`, with normalized outcomes
 (`ok`/`fail_closed`/`not_applicable`) and error categories independent
 of any one platform's status codes. A required capability an adapter
 does not support fails closed rather than silently passing; an

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -19,6 +19,14 @@ Use it when you need to answer three questions quickly:
 - When does the workflow rely on GitHub Copilot review state rather than
   on my local CLI?
 
+This guide's `.github/` distribution, tooling, and Copilot-advisory
+review steps describe today's only implemented provider, GitHub. IDD
+defines a provider-neutral adapter boundary internally as a staged
+foundation for future non-GitHub adapters; see
+[Provider Portability](customization.md#provider-portability) for the
+capability-group model and staged rollout order. Nothing below assumes
+that boundary is exercised by a shipped adapter yet.
+
 ## Start sequence
 
 If you arrived here from your agent's entry file, pick up at step 2. If

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -113,7 +113,10 @@ IDD is a multi-agent GitHub automation workflow. Agents work through a
 pipeline of phases (Discover → Claim → Work → PR Submit → CI Wait →
 Review Triage → Review Fix → Merge → Loop) driven by GitHub Issues.
 The instruction files in `.github/instructions/` encode every rule for
-every phase.
+every phase. GitHub is IDD's only implemented provider today; see
+[Provider Portability](docs/customization.md#provider-portability)
+for the staged, provider-neutral adapter boundary this onboarding path
+does not depend on.
 
 Important: the distributed default workflow is cross-agent for
 execution, but its later PR phases still include a GitHub Copilot

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -757,13 +757,13 @@ the `Project commands` table in
 The following policy matrix defines the tooling requirements and
 fallback order for repositories adopting IDD:
 
-| Context                                  | Requirement         | Fallback order                                                                                           |
-| ---------------------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------- |
-| `git`, `gh`, `jq`, `curl`                | **Required**        | No fallback; IDD cannot run without these                                                                |
-| `install-deps` command                   | Project-dependent   | Use project's native package manager; `true` as no-op when no install step is needed                     |
-| Validate commands (`fix-validate`, etc.) | Project-dependent   | Use project tooling; `true` as no-op                                                                     |
-| Node.js / `npx`                          | Optional            | 1. Existing project Node.js tooling; 2. `npx` when available; 3. `true` when unavailable or not relevant |
-| pnpm                                     | Not required by IDD | Only needed when the adopter's project itself uses pnpm                                                  |
+| Context                                  | Requirement                         | Fallback order                                                                                           |
+| ---------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `git`, `gh`, `jq`, `curl`                | **Required for the GitHub adapter** | No fallback for GitHub; IDD's only implemented provider today needs these                                |
+| `install-deps` command                   | Project-dependent                   | Use project's native package manager; `true` as no-op when no install step is needed                     |
+| Validate commands (`fix-validate`, etc.) | Project-dependent                   | Use project tooling; `true` as no-op                                                                     |
+| Node.js / `npx`                          | Optional                            | 1. Existing project Node.js tooling; 2. `npx` when available; 3. `true` when unavailable or not relevant |
+| pnpm                                     | Not required by IDD                 | Only needed when the adopter's project itself uses pnpm                                                  |
 
 Decision points:
 
@@ -775,6 +775,29 @@ Decision points:
   Node.js project's script runner; (2) use bare `npx <tool>` when
   `npx` is available; (3) replace with `true` when `npx` is unavailable
   or the check is not relevant to the project.
+
+## Provider Portability
+
+GitHub is IDD's only implemented and fully exercised provider today,
+and `git`/`gh`/`jq`/`curl` above name the GitHub adapter's own
+requirements, not a permanent IDD-wide constraint. Internally, IDD
+defines a provider-neutral adapter boundary -- capability groups
+(work items, comments and labels, claims, change requests, reviews and
+threads, checks, permissions, branch protection, merge) each declared
+`required` or `optional`, with normalized outcomes
+(`ok`/`fail_closed`/`not_applicable`) and error categories independent
+of any one platform's status codes. A required capability an adapter
+does not support fails closed rather than silently passing; an
+optional advisory capability may resolve `not_applicable` instead.
+
+This is a staged foundation, not a shipped multi-provider release:
+GitLab SaaS is the first future adapter target, Bitbucket Cloud
+follows as its own capability check, and self-managed/Data Center
+variants each need their own verification before being claimed
+supported. Copilot review convergence stays a separate, GitHub-specific
+concern -- a future adapter's `advisory-review` capability group can
+resolve `not_applicable` on a provider with no equivalent bot reviewer
+without weakening any required gate.
 
 ## Reusable pnpm boundary guard workflow
 

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -757,13 +757,14 @@ the `Project commands` table in
 The following policy matrix defines the tooling requirements and
 fallback order for repositories adopting IDD:
 
-| Context                                  | Requirement                         | Fallback order                                                                                           |
-| ---------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `git`, `gh`, `jq`, `curl`                | **Required for the GitHub adapter** | No fallback for GitHub; IDD's only implemented provider today needs these                                |
-| `install-deps` command                   | Project-dependent                   | Use project's native package manager; `true` as no-op when no install step is needed                     |
-| Validate commands (`fix-validate`, etc.) | Project-dependent                   | Use project tooling; `true` as no-op                                                                     |
-| Node.js / `npx`                          | Optional                            | 1. Existing project Node.js tooling; 2. `npx` when available; 3. `true` when unavailable or not relevant |
-| pnpm                                     | Not required by IDD                 | Only needed when the adopter's project itself uses pnpm                                                  |
+| Context                                  | Requirement                         | Fallback order                                                                                                |
+| ---------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `git`                                    | **Required**                        | No fallback; IDD-wide, independent of provider (`git worktree`/`fetch`/`merge` run outside the provider port) |
+| `gh`, `jq`, `curl`                       | **Required for the GitHub adapter** | No fallback for GitHub; IDD's only implemented provider today needs these                                     |
+| `install-deps` command                   | Project-dependent                   | Use project's native package manager; `true` as no-op when no install step is needed                          |
+| Validate commands (`fix-validate`, etc.) | Project-dependent                   | Use project tooling; `true` as no-op                                                                          |
+| Node.js / `npx`                          | Optional                            | 1. Existing project Node.js tooling; 2. `npx` when available; 3. `true` when unavailable or not relevant      |
+| pnpm                                     | Not required by IDD                 | Only needed when the adopter's project itself uses pnpm                                                       |
 
 Decision points:
 
@@ -779,12 +780,13 @@ Decision points:
 ## Provider Portability
 
 GitHub is IDD's only implemented and fully exercised provider today,
-and `git`/`gh`/`jq`/`curl` above name the GitHub adapter's own
-requirements, not a permanent IDD-wide constraint. Internally, IDD
-defines a provider-neutral adapter boundary -- capability groups
-(work items, comments and labels, claims, change requests, reviews and
-threads, checks, permissions, branch protection, merge) each declared
-`required` or `optional`, with normalized outcomes
+and `gh`/`jq`/`curl` above name the GitHub adapter's own requirements,
+not a permanent IDD-wide constraint (`git` itself stays required
+IDD-wide regardless of provider). Internally, IDD defines a
+provider-neutral adapter boundary -- capability groups (repository
+identity, work items, comments and labels, claims, change requests,
+reviews and threads, checks, permissions, branch protection, merge)
+each declared `required` or `optional`, with normalized outcomes
 (`ok`/`fail_closed`/`not_applicable`) and error categories independent
 of any one platform's status codes. A required capability an adapter
 does not support fails closed rather than silently passing; an

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -19,6 +19,14 @@ Use it when you need to answer three questions quickly:
 - When does the workflow rely on GitHub Copilot review state rather than
   on my local CLI?
 
+This guide's `.github/` distribution, tooling, and Copilot-advisory
+review steps describe today's only implemented provider, GitHub. IDD
+defines a provider-neutral adapter boundary internally as a staged
+foundation for future non-GitHub adapters; see
+[Provider Portability](customization.md#provider-portability) for the
+capability-group model and staged rollout order. Nothing below assumes
+that boundary is exercised by a shipped adapter yet.
+
 ## Start sequence
 
 If you arrived here from your agent's entry file, pick up at step 2. If


### PR DESCRIPTION
## Summary

- The README pair, `docs/customization.md`'s Tooling Boundary, and
  onboarding docs described IDD as GitHub-native and presented
  `git`/`gh`/`jq`/`curl` as an unconditional requirement, making the
  existing provider-adapter seam (#2265-#2268, all merged) invisible
  to future adopters and making GitLab/Bitbucket support look like a
  full workflow rewrite.
- Added a **Provider Portability** section to
  `idd-template/docs/customization.md`'s Tooling Boundary (exact-mode
  source, propagates to `docs/customization.md` via `sync-docs.mjs
  --apply`): scoped the tooling row to "the GitHub adapter" and
  described the capability-group model
  (`src/scripts/provider-contract.mts`: required-vs-optional,
  `ok`/`fail_closed`/`not_applicable`, normalized error categories)
  and the staged rollout order (GitLab SaaS first, Bitbucket Cloud
  next, self-managed/Data Center separately). Explicitly keeps Copilot
  review convergence a separate, GitHub-specific concern.
- Added an identical pointer paragraph to both
  `idd-template/docs/idd-workflow.md` and `docs/idd-workflow.md`
  (structure-mode sync pair, manually dual-edited, no new heading so
  the heading-signature check stays green).
- One-sentence pointer added to `idd-template/ONBOARDING.md`'s "What
  you are setting up" section — no change to the operational Step 0
  `gh`-prerequisite instructions (kept the current GitHub onboarding
  behavior unchanged, per the issue).
- One added clause in `README.md` / `README.ja.md`'s Prerequisites
  paragraph, kept in sync per this repo's README-pair rule.
- Did **not** link any `idd-template/`-sourced file to
  `docs/provider-boundary.md` (the internal design record) — that file
  is source-repo-only and isn't distributed, so linking to it from
  template content would be a broken link for adopters.

## Note on A4.5 discover-viability-gate

`discover-viability-gate.mjs` discarded this issue on `limited_scope`
(matched "architecture" in a sentence describing the *current* staged
state, not proposing a redesign) — a 5th false-positive shape not
covered by #2417/PR#2422's two exclusion categories (avoidance-cue,
content-noun). Manually verified against A4 Step 1's actual scope
criteria before claiming; this is a coordinated docs-only edit across
an established sync-pair set, same class of work already merged this
session (#2402, #2413).

## Test plan

- [x] `node scripts/sync-docs.mjs --check` — all mirrored artifacts up
      to date
- [x] `node scripts/audit-docs.mjs --check` — passes, including the
      structure-mode heading-signature check for `idd-workflow.md`
- [x] `pnpm test` — full suite (4727 tests) passes
- [x] `pre-push-validate` (biome, dprint, markdownlint, cspell,
      audit-docs, audit-code-span-wrap, build:check, idd-doctor) — all
      green (pre-existing unrelated warnings in `protocol-helpers.mts`
      only)

Closes #2269

🤖 Generated with [Claude Code](https://claude.com/claude-code)