### PR TITLE
fix(token-cost): warn when Claude scan dir is missing

### DIFF
--- a/docs/token-cost-snapshot.json
+++ b/docs/token-cost-snapshot.json
@@ -1,32 +1,34 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-09-02T06:48:41.425Z",
+  "generatedAt": "2026-09-02T07:29:00.865Z",
   "minPublishableSamples": 10,
   "minPublishableVendors": 2,
   "publishable": false,
-  "sampleCount": 0,
-  "vendors": [],
+  "sampleCount": 1,
+  "vendors": [
+    "claude"
+  ],
   "asOf": "2026-09-02",
   "totalUsage": {
     "inputUncached": {
-      "p25": 0,
-      "p50": 0,
-      "p75": 0
+      "p25": 1638,
+      "p50": 1638,
+      "p75": 1638
     },
     "cacheRead": {
-      "p25": 0,
-      "p50": 0,
-      "p75": 0
+      "p25": 238475137,
+      "p50": 238475137,
+      "p75": 238475137
     },
     "cacheCreation": {
-      "p25": 0,
-      "p50": 0,
-      "p75": 0
+      "p25": 1996956,
+      "p50": 1996956,
+      "p75": 1996956
     },
     "output": {
-      "p25": 0,
-      "p50": 0,
-      "p75": 0
+      "p25": 686521,
+      "p50": 686521,
+      "p75": 686521
     },
     "reasoning": {
       "p25": 0,
@@ -34,13 +36,90 @@
       "p75": 0
     }
   },
-  "stageUsage": [],
+  "stageUsage": [
+    {
+      "id": "claim",
+      "usage": {
+        "inputUncached": {
+          "p25": 16,
+          "p50": 16,
+          "p75": 16
+        },
+        "cacheRead": {
+          "p25": 3559188,
+          "p50": 3559188,
+          "p75": 3559188
+        },
+        "cacheCreation": {
+          "p25": 2813,
+          "p50": 2813,
+          "p75": 2813
+        },
+        "output": {
+          "p25": 1360,
+          "p50": 1360,
+          "p75": 1360
+        },
+        "reasoning": {
+          "p25": 0,
+          "p50": 0,
+          "p75": 0
+        }
+      }
+    },
+    {
+      "id": "work",
+      "usage": {
+        "inputUncached": {
+          "p25": 1620,
+          "p50": 1620,
+          "p75": 1620
+        },
+        "cacheRead": {
+          "p25": 234682427,
+          "p50": 234682427,
+          "p75": 234682427
+        },
+        "cacheCreation": {
+          "p25": 1993701,
+          "p50": 1993701,
+          "p75": 1993701
+        },
+        "output": {
+          "p25": 684956,
+          "p50": 684956,
+          "p75": 684956
+        },
+        "reasoning": {
+          "p25": 0,
+          "p50": 0,
+          "p75": 0
+        }
+      }
+    }
+  ],
   "compactionCount": {
-    "p25": 0,
-    "p50": 0,
-    "p75": 0
+    "p25": 2,
+    "p50": 2,
+    "p75": 2
   },
-  "cacheHitRatio": 0,
-  "successRateByModel": {},
-  "successRateByVendor": {}
+  "cacheHitRatio": 0.9916889300478313,
+  "successRateByModel": {
+    "claude-sonnet-5": {
+      "merged": 0,
+      "aborted": 0,
+      "unclaimed": 1,
+      "humanHandoff": 0,
+      "rate": 0
+    }
+  },
+  "successRateByVendor": {
+    "claude": {
+      "merged": 0,
+      "aborted": 0,
+      "unclaimed": 1,
+      "humanHandoff": 0,
+      "rate": 0
+    }
+  }
 }

--- a/docs/token-cost.md
+++ b/docs/token-cost.md
@@ -63,6 +63,17 @@ and appends `kind: "issue-loop"` / `kind: "session"` records to
 sibling `events.jsonl` path (`--events` to override), those timestamps
 win over the marker-join reconstruction for the stages they cover.
 
+`node scripts/token-cost-harvest.mjs` must be run from the **primary
+worktree**, not an issue worktree, for its Claude-vendor scan to see
+real data: Claude Code stores each project's session logs under
+`~/.claude/projects/<encoded cwd>`, encoded from whichever cwd the
+session actually launched with -- not from `--repo` or any other flag.
+An issue worktree (`<repo>.issue/<n>-*`) lives at a different path
+than the primary worktree and so has no matching, populated project
+directory of its own; running the harvest CLI from one now prints a
+warning naming the missing directory instead of silently reporting a
+misleading zero-sample result (`#2439`).
+
 `token-cost-event.mjs` also auto-derives each event's `vendorSessionId`
 from a vendor-specific env var -- `$CLAUDE_CODE_SESSION_ID` for
 `--vendor claude`, no equivalent known yet for `grok`/`codex` -- with no
@@ -113,6 +124,6 @@ number is ever invented to fill the gap.
 
 <!-- token-cost-docs:start -->
 
-Not yet publishable, n=0.
+Not yet publishable, n=1.
 
 <!-- token-cost-docs:end -->

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -1323,6 +1323,15 @@ export function scanClaudeVendorSessions(
 ) {
   const out = [];
   if (!existsSync(projectDir)) {
+    // Unlike Codex/Grok's session directories, this one is cwd-encoded
+    // (#2439): a missing directory here usually means the CLI was
+    // invoked from an issue worktree rather than the primary worktree
+    // Claude Code actually launched the session from, not a genuine
+    // "no sessions yet" case -- silently returning [] made that gap
+    // indistinguishable from a real empty result (#2426).
+    process.stderr.write(
+      `token-cost-harvest: Claude project directory ${projectDir} does not exist -- this CLI's Claude scan is cwd-sensitive; re-run from the workstation's primary worktree (the cwd Claude Code sessions actually launch from), not an issue-specific worktree.\n`,
+    );
     return out;
   }
   const completedIssueWindows = buildCompletedIssueWindows(

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -1582,6 +1582,15 @@ export function scanClaudeVendorSessions(
 ): VendorSession[] {
   const out: VendorSession[] = [];
   if (!existsSync(projectDir)) {
+    // Unlike Codex/Grok's session directories, this one is cwd-encoded
+    // (#2439): a missing directory here usually means the CLI was
+    // invoked from an issue worktree rather than the primary worktree
+    // Claude Code actually launched the session from, not a genuine
+    // "no sessions yet" case -- silently returning [] made that gap
+    // indistinguishable from a real empty result (#2426).
+    process.stderr.write(
+      `token-cost-harvest: Claude project directory ${projectDir} does not exist -- this CLI's Claude scan is cwd-sensitive; re-run from the workstation's primary worktree (the cwd Claude Code sessions actually launch from), not an issue-specific worktree.\n`,
+    );
     return out;
   }
   const completedIssueWindows = buildCompletedIssueWindows(

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -139,6 +139,32 @@ test('extractClaudeUsageTimeline sums per-message deltas, sorted by timestamp', 
   });
 });
 
+test('scanClaudeVendorSessions warns (not silently returns []) when projectDir does not exist -- #2439', (t) => {
+  const stderrWrite = t.mock.method(process.stderr, 'write', () => true);
+  const missingDir = join(
+    mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-missing-')),
+    'does-not-exist',
+  );
+
+  const sessions = scanClaudeVendorSessions(missingDir);
+
+  assert.deepEqual(sessions, []);
+  const warnings = stderrWrite.mock.calls
+    .map((call) => call.arguments[0])
+    .filter(
+      (message): message is string =>
+        typeof message === 'string' &&
+        message.includes('Claude project directory'),
+    );
+  assert.equal(warnings.length, 1);
+  assert.match(
+    warnings[0],
+    new RegExp(missingDir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+  );
+  assert.match(warnings[0], /does not exist/);
+  assert.match(warnings[0], /primary worktree/);
+});
+
 test("scanClaudeVendorSessions scopes each cwd segment's timeline to just that segment's records -- #2404", () => {
   const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-harvest-test-'));
   writeFileSync(


### PR DESCRIPTION
## Summary

`scanClaudeVendorSessions` (`token-cost-harvest.mts`) silently
returned `[]` when the resolved `~/.claude/projects/<encoded-cwd>`
directory did not exist. That directory is encoded from the invoking
shell's own cwd, so running `node scripts/token-cost-harvest.mjs` from
an issue worktree (rather than the primary worktree a Claude Code
session actually launches from) silently scans nothing -- this
produced a misleading `n=0` diagnosis in #2426.

## Changes

- `scanClaudeVendorSessions` now writes a clear stderr warning naming
  the missing directory and the fix (re-run from the primary
  worktree) before returning `[]`. Exit code stays 0; Grok/Codex
  scanning is unaffected (their session directories are not
  cwd-encoded, so they don't share this footgun).
- `docs/token-cost.md` documents the cwd-sensitivity and the correct
  invocation location.
- `docs/token-cost-snapshot.json` refreshed: a primary-worktree
  harvest run found one new sample since the last commit (`n=0` ->
  `n=1`; still below the publishable floor of 10, so no README/table
  change).
- `tests/token-cost-harvest.test.mts`: new test asserting the warning
  fires exactly once, names the missing directory, and mentions the
  primary-worktree fix, for a `scanClaudeVendorSessions` call against
  a non-existent `projectDir`.

## Verification

- `node --test tests/token-cost-harvest.test.mts` -- 85/85 pass
  (including the new test)
- `pnpm run typecheck` -- clean
- `pnpm run build:check` -- clean (generated `.mjs` matches source)
- Manually re-ran `node scripts/token-cost-harvest.mjs --repo
  kurone-kito/idd-skill --dry-run` from both this issue worktree (new
  warning fires) and the primary worktree (no warning, output
  unaffected)
- `node scripts/token-cost-report.mjs --check` -- no drift

Closes #2439
