### PR TITLE
fix(token-cost): resolve closing PR via closedByPullRequestsReferences

### DIFF
--- a/docs/token-cost-snapshot.json
+++ b/docs/token-cost-snapshot.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-09-02T07:29:00.865Z",
+  "generatedAt": "2026-09-02T07:50:54.454Z",
   "minPublishableSamples": 10,
   "minPublishableVendors": 2,
   "publishable": false,
@@ -71,24 +71,144 @@
       "id": "work",
       "usage": {
         "inputUncached": {
-          "p25": 1620,
-          "p50": 1620,
-          "p75": 1620
+          "p25": 522,
+          "p50": 522,
+          "p75": 522
         },
         "cacheRead": {
-          "p25": 234682427,
-          "p50": 234682427,
-          "p75": 234682427
+          "p25": 64751695,
+          "p50": 64751695,
+          "p75": 64751695
         },
         "cacheCreation": {
-          "p25": 1993701,
-          "p50": 1993701,
-          "p75": 1993701
+          "p25": 525614,
+          "p50": 525614,
+          "p75": 525614
         },
         "output": {
-          "p25": 684956,
-          "p50": 684956,
-          "p75": 684956
+          "p25": 344270,
+          "p50": 344270,
+          "p75": 344270
+        },
+        "reasoning": {
+          "p25": 0,
+          "p50": 0,
+          "p75": 0
+        }
+      }
+    },
+    {
+      "id": "submit-pr",
+      "usage": {
+        "inputUncached": {
+          "p25": 24,
+          "p50": 24,
+          "p75": 24
+        },
+        "cacheRead": {
+          "p25": 3874649,
+          "p50": 3874649,
+          "p75": 3874649
+        },
+        "cacheCreation": {
+          "p25": 10198,
+          "p50": 10198,
+          "p75": 10198
+        },
+        "output": {
+          "p25": 4591,
+          "p50": 4591,
+          "p75": 4591
+        },
+        "reasoning": {
+          "p25": 0,
+          "p50": 0,
+          "p75": 0
+        }
+      }
+    },
+    {
+      "id": "review",
+      "usage": {
+        "inputUncached": {
+          "p25": 70,
+          "p50": 70,
+          "p75": 70
+        },
+        "cacheRead": {
+          "p25": 11070993,
+          "p50": 11070993,
+          "p75": 11070993
+        },
+        "cacheCreation": {
+          "p25": 593528,
+          "p50": 593528,
+          "p75": 593528
+        },
+        "output": {
+          "p25": 13129,
+          "p50": 13129,
+          "p75": 13129
+        },
+        "reasoning": {
+          "p25": 0,
+          "p50": 0,
+          "p75": 0
+        }
+      }
+    },
+    {
+      "id": "merge",
+      "usage": {
+        "inputUncached": {
+          "p25": 10,
+          "p50": 10,
+          "p75": 10
+        },
+        "cacheRead": {
+          "p25": 1058534,
+          "p50": 1058534,
+          "p75": 1058534
+        },
+        "cacheCreation": {
+          "p25": 1426,
+          "p50": 1426,
+          "p75": 1426
+        },
+        "output": {
+          "p25": 1264,
+          "p50": 1264,
+          "p75": 1264
+        },
+        "reasoning": {
+          "p25": 0,
+          "p50": 0,
+          "p75": 0
+        }
+      }
+    },
+    {
+      "id": "cleanup",
+      "usage": {
+        "inputUncached": {
+          "p25": 76,
+          "p50": 76,
+          "p75": 76
+        },
+        "cacheRead": {
+          "p25": 8559197,
+          "p50": 8559197,
+          "p75": 8559197
+        },
+        "cacheCreation": {
+          "p25": 42211,
+          "p50": 42211,
+          "p75": 42211
+        },
+        "output": {
+          "p25": 10310,
+          "p50": 10310,
+          "p75": 10310
         },
         "reasoning": {
           "p25": 0,
@@ -106,20 +226,20 @@
   "cacheHitRatio": 0.9916889300478313,
   "successRateByModel": {
     "claude-sonnet-5": {
-      "merged": 0,
+      "merged": 1,
       "aborted": 0,
-      "unclaimed": 1,
+      "unclaimed": 0,
       "humanHandoff": 0,
-      "rate": 0
+      "rate": 1
     }
   },
   "successRateByVendor": {
     "claude": {
-      "merged": 0,
+      "merged": 1,
       "aborted": 0,
-      "unclaimed": 1,
+      "unclaimed": 0,
       "humanHandoff": 0,
-      "rate": 0
+      "rate": 1
     }
   }
 }

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -543,15 +543,16 @@ export function fetchIssueLoopGithubContext(
       comments.push({ body, createdAt, login });
     }
   }
-  // closedByPullRequestsReferences already scopes to PRs that actually
-  // closed THIS issue -- via the keyword this repository's own IDD
-  // workflow exclusively uses ("Closes #N"), or a manual Development-panel
-  // link -- so no branch-name guard is needed here (#2439's predecessor,
-  // ConnectedEvent/DisconnectedEvent, only recorded manual links, which
-  // this repository's automated PRs never produce; see #2444). Normally
-  // exactly one PR closes a given issue in this repository's workflow;
-  // the earliest-createdAt tie-break below is defensive for the rare case
-  // of more than one.
+  // closedByPullRequestsReferences already scopes to PRs GitHub recorded
+  // as actually CLOSING this issue (the "Closes #N" keyword this
+  // repository's own IDD workflow exclusively uses), so no branch-name
+  // guard is needed here. This field's predecessor,
+  // ConnectedEvent/DisconnectedEvent, only recorded a manual
+  // Development-panel LINK -- which merely connects a PR to an issue
+  // without closing it -- so it never matched this repository's automated
+  // keyword-closed PRs at all (#2444). Normally exactly one PR closes a
+  // given issue in this repository's workflow; the earliest-createdAt
+  // tie-break below is defensive for the rare case of more than one.
   const prNodes = Array.isArray(issue?.closedByPullRequestsReferences?.nodes)
     ? issue.closedByPullRequestsReferences.nodes
     : [];

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -503,20 +503,16 @@ query($owner:String!,$repo:String!,$number:Int!){
   repository(owner:$owner,name:$repo){
     issue(number:$number){
       comments(first:100){nodes{body createdAt author{login}}}
-      timelineItems(last:100,itemTypes:[CONNECTED_EVENT,DISCONNECTED_EVENT]){
+      closedByPullRequestsReferences(first:10){
         nodes{
-          __typename
-          ... on ConnectedEvent{subject{__typename ... on PullRequest{
-            number state headRefName createdAt mergedAt
-            reviews(first:1){nodes{submittedAt}}
-          }}}
-          ... on DisconnectedEvent{subject{__typename ... on PullRequest{number}}}
+          number headRefName createdAt mergedAt
+          reviews(first:1){nodes{submittedAt}}
         }
       }
     }
   }
 }`;
-/** Fetches issue comments plus the earliest live-connected same-branch PR (with its first review + merge timestamp) via one batched GraphQL query. */
+/** Fetches issue comments plus the earliest PR that closed this issue (with its first review + merge timestamp) via one batched GraphQL query. */
 export function fetchIssueLoopGithubContext(
   owner,
   repo,
@@ -547,42 +543,25 @@ export function fetchIssueLoopGithubContext(
       comments.push({ body, createdAt, login });
     }
   }
-  const timelineNodes = Array.isArray(issue?.timelineItems?.nodes)
-    ? issue.timelineItems.nodes
+  // closedByPullRequestsReferences already scopes to PRs that actually
+  // closed THIS issue -- via the keyword this repository's own IDD
+  // workflow exclusively uses ("Closes #N"), or a manual Development-panel
+  // link -- so no branch-name guard is needed here (#2439's predecessor,
+  // ConnectedEvent/DisconnectedEvent, only recorded manual links, which
+  // this repository's automated PRs never produce; see #2444). Normally
+  // exactly one PR closes a given issue in this repository's workflow;
+  // the earliest-createdAt tie-break below is defensive for the rare case
+  // of more than one.
+  const prNodes = Array.isArray(issue?.closedByPullRequestsReferences?.nodes)
+    ? issue.closedByPullRequestsReferences.nodes
     : [];
-  const connected = new Map();
-  const disconnected = new Set();
-  for (const node of timelineNodes) {
-    if (!isPlainObject(node)) {
-      continue;
-    }
-    const subject = isPlainObject(node.subject) ? node.subject : undefined;
-    const prNumber =
-      subject && typeof subject.number === 'number'
-        ? subject.number
-        : undefined;
-    if (prNumber === undefined) {
-      continue;
-    }
-    if (node.__typename === 'ConnectedEvent') {
-      connected.set(prNumber, subject);
-      disconnected.delete(prNumber);
-    } else if (node.__typename === 'DisconnectedEvent') {
-      disconnected.add(prNumber);
-    }
-  }
   let chosen = null;
   let chosenNumber = null;
-  for (const [prNumber, subject] of connected) {
-    if (disconnected.has(prNumber)) {
+  for (const node of prNodes) {
+    if (!isPlainObject(node) || typeof node.number !== 'number') {
       continue;
     }
-    const headRefName =
-      typeof subject.headRefName === 'string' ? subject.headRefName : '';
-    if (!headRefName.startsWith(`issue/${issueNumber}-`)) {
-      continue;
-    }
-    const createdAtMs = toValidTimestampMs(subject.createdAt);
+    const createdAtMs = toValidTimestampMs(node.createdAt);
     if (createdAtMs === undefined) {
       continue;
     }
@@ -590,8 +569,8 @@ export function fetchIssueLoopGithubContext(
       ? (toValidTimestampMs(chosen.createdAt) ?? Infinity)
       : Infinity;
     if (createdAtMs < chosenCreatedAtMs) {
-      chosen = subject;
-      chosenNumber = prNumber;
+      chosen = node;
+      chosenNumber = node.number;
     }
   }
   if (!chosen) {

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -653,14 +653,10 @@ query($owner:String!,$repo:String!,$number:Int!){
   repository(owner:$owner,name:$repo){
     issue(number:$number){
       comments(first:100){nodes{body createdAt author{login}}}
-      timelineItems(last:100,itemTypes:[CONNECTED_EVENT,DISCONNECTED_EVENT]){
+      closedByPullRequestsReferences(first:10){
         nodes{
-          __typename
-          ... on ConnectedEvent{subject{__typename ... on PullRequest{
-            number state headRefName createdAt mergedAt
-            reviews(first:1){nodes{submittedAt}}
-          }}}
-          ... on DisconnectedEvent{subject{__typename ... on PullRequest{number}}}
+          number headRefName createdAt mergedAt
+          reviews(first:1){nodes{submittedAt}}
         }
       }
     }
@@ -672,13 +668,13 @@ interface RawIssueLoopContextResponse {
     repository?: {
       issue?: {
         comments?: { nodes?: unknown };
-        timelineItems?: { nodes?: unknown };
+        closedByPullRequestsReferences?: { nodes?: unknown };
       };
     };
   };
 }
 
-/** Fetches issue comments plus the earliest live-connected same-branch PR (with its first review + merge timestamp) via one batched GraphQL query. */
+/** Fetches issue comments plus the earliest PR that closed this issue (with its first review + merge timestamp) via one batched GraphQL query. */
 export function fetchIssueLoopGithubContext(
   owner: string,
   repo: string,
@@ -718,43 +714,25 @@ export function fetchIssueLoopGithubContext(
     }
   }
 
-  const timelineNodes = Array.isArray(issue?.timelineItems?.nodes)
-    ? issue.timelineItems.nodes
+  // closedByPullRequestsReferences already scopes to PRs that actually
+  // closed THIS issue -- via the keyword this repository's own IDD
+  // workflow exclusively uses ("Closes #N"), or a manual Development-panel
+  // link -- so no branch-name guard is needed here (#2439's predecessor,
+  // ConnectedEvent/DisconnectedEvent, only recorded manual links, which
+  // this repository's automated PRs never produce; see #2444). Normally
+  // exactly one PR closes a given issue in this repository's workflow;
+  // the earliest-createdAt tie-break below is defensive for the rare case
+  // of more than one.
+  const prNodes = Array.isArray(issue?.closedByPullRequestsReferences?.nodes)
+    ? issue.closedByPullRequestsReferences.nodes
     : [];
-  const connected = new Map<number, Record<string, unknown>>();
-  const disconnected = new Set<number>();
-  for (const node of timelineNodes) {
-    if (!isPlainObject(node)) {
-      continue;
-    }
-    const subject = isPlainObject(node.subject) ? node.subject : undefined;
-    const prNumber =
-      subject && typeof subject.number === 'number'
-        ? subject.number
-        : undefined;
-    if (prNumber === undefined) {
-      continue;
-    }
-    if (node.__typename === 'ConnectedEvent') {
-      connected.set(prNumber, subject as Record<string, unknown>);
-      disconnected.delete(prNumber);
-    } else if (node.__typename === 'DisconnectedEvent') {
-      disconnected.add(prNumber);
-    }
-  }
-
   let chosen: Record<string, unknown> | null = null;
   let chosenNumber: number | null = null;
-  for (const [prNumber, subject] of connected) {
-    if (disconnected.has(prNumber)) {
+  for (const node of prNodes) {
+    if (!isPlainObject(node) || typeof node.number !== 'number') {
       continue;
     }
-    const headRefName =
-      typeof subject.headRefName === 'string' ? subject.headRefName : '';
-    if (!headRefName.startsWith(`issue/${issueNumber}-`)) {
-      continue;
-    }
-    const createdAtMs = toValidTimestampMs(subject.createdAt);
+    const createdAtMs = toValidTimestampMs(node.createdAt);
     if (createdAtMs === undefined) {
       continue;
     }
@@ -762,8 +740,8 @@ export function fetchIssueLoopGithubContext(
       ? (toValidTimestampMs(chosen.createdAt) ?? Infinity)
       : Infinity;
     if (createdAtMs < chosenCreatedAtMs) {
-      chosen = subject;
-      chosenNumber = prNumber;
+      chosen = node;
+      chosenNumber = node.number;
     }
   }
 

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -714,15 +714,16 @@ export function fetchIssueLoopGithubContext(
     }
   }
 
-  // closedByPullRequestsReferences already scopes to PRs that actually
-  // closed THIS issue -- via the keyword this repository's own IDD
-  // workflow exclusively uses ("Closes #N"), or a manual Development-panel
-  // link -- so no branch-name guard is needed here (#2439's predecessor,
-  // ConnectedEvent/DisconnectedEvent, only recorded manual links, which
-  // this repository's automated PRs never produce; see #2444). Normally
-  // exactly one PR closes a given issue in this repository's workflow;
-  // the earliest-createdAt tie-break below is defensive for the rare case
-  // of more than one.
+  // closedByPullRequestsReferences already scopes to PRs GitHub recorded
+  // as actually CLOSING this issue (the "Closes #N" keyword this
+  // repository's own IDD workflow exclusively uses), so no branch-name
+  // guard is needed here. This field's predecessor,
+  // ConnectedEvent/DisconnectedEvent, only recorded a manual
+  // Development-panel LINK -- which merely connects a PR to an issue
+  // without closing it -- so it never matched this repository's automated
+  // keyword-closed PRs at all (#2444). Normally exactly one PR closes a
+  // given issue in this repository's workflow; the earliest-createdAt
+  // tie-break below is defensive for the rare case of more than one.
   const prNodes = Array.isArray(issue?.closedByPullRequestsReferences?.nodes)
     ? issue.closedByPullRequestsReferences.nodes
     : [];

--- a/tests/fixtures/token-cost/github/issue-loop-merged.json
+++ b/tests/fixtures/token-cost/github/issue-loop-merged.json
@@ -16,19 +16,14 @@
             }
           ]
         },
-        "timelineItems": {
+        "closedByPullRequestsReferences": {
           "nodes": [
             {
-              "__typename": "ConnectedEvent",
-              "subject": {
-                "__typename": "PullRequest",
-                "number": 9101,
-                "state": "MERGED",
-                "headRefName": "issue/9001-test",
-                "createdAt": "2026-01-01T00:10:00Z",
-                "mergedAt": "2026-01-01T00:30:00Z",
-                "reviews": { "nodes": [{ "submittedAt": "2026-01-01T00:22:00Z" }] }
-              }
+              "number": 9101,
+              "headRefName": "issue/9001-test",
+              "createdAt": "2026-01-01T00:10:00Z",
+              "mergedAt": "2026-01-01T00:30:00Z",
+              "reviews": { "nodes": [{ "submittedAt": "2026-01-01T00:22:00Z" }] }
             }
           ]
         }

--- a/tests/fixtures/token-cost/github/issue-loop-resume-same-agent.json
+++ b/tests/fixtures/token-cost/github/issue-loop-resume-same-agent.json
@@ -7,16 +7,22 @@
             {
               "body": "<!-- claimed-by: claude-a cid-a1 supersedes: none 2026-01-01T00:00:00Z branch: issue/9004-test -->\n\n_claude-a: issue claim — IDD automation marker. Do not edit._",
               "createdAt": "2026-01-01T00:00:00Z",
-              "author": { "login": "claude-a" }
+              "author": {
+                "login": "claude-a"
+              }
             },
             {
               "body": "<!-- claimed-by: claude-a cid-a2 supersedes: cid-a1 2026-01-01T00:15:00Z branch: issue/9004-test -->\n\n_claude-a: issue claim — IDD automation marker. Do not edit._",
               "createdAt": "2026-01-01T00:15:00Z",
-              "author": { "login": "claude-a" }
+              "author": {
+                "login": "claude-a"
+              }
             }
           ]
         },
-        "timelineItems": { "nodes": [] }
+        "closedByPullRequestsReferences": {
+          "nodes": []
+        }
       }
     }
   }

--- a/tests/fixtures/token-cost/github/issue-loop-takeover.json
+++ b/tests/fixtures/token-cost/github/issue-loop-takeover.json
@@ -7,16 +7,22 @@
             {
               "body": "<!-- claimed-by: claude-a cid-a supersedes: none 2026-01-01T00:00:00Z branch: issue/9003-test -->\n\n_claude-a: issue claim — IDD automation marker. Do not edit._",
               "createdAt": "2026-01-01T00:00:00Z",
-              "author": { "login": "claude-a" }
+              "author": {
+                "login": "claude-a"
+              }
             },
             {
               "body": "<!-- claimed-by: claude-b cid-b supersedes: cid-a 2026-01-01T00:15:00Z branch: issue/9003-test -->\n\n_claude-b: issue claim — IDD automation marker. Do not edit._",
               "createdAt": "2026-01-01T00:15:00Z",
-              "author": { "login": "claude-b" }
+              "author": {
+                "login": "claude-b"
+              }
             }
           ]
         },
-        "timelineItems": { "nodes": [] }
+        "closedByPullRequestsReferences": {
+          "nodes": []
+        }
       }
     }
   }

--- a/tests/fixtures/token-cost/github/issue-loop-unclaimed.json
+++ b/tests/fixtures/token-cost/github/issue-loop-unclaimed.json
@@ -7,16 +7,20 @@
             {
               "body": "<!-- claimed-by: claude-test cid-unclaimed supersedes: none 2026-02-01T00:00:00Z branch: issue/9002-test -->\n\n_claude-test: issue claim — IDD automation marker. Do not edit._",
               "createdAt": "2026-02-01T00:00:00Z",
-              "author": { "login": "claude-test" }
+              "author": {
+                "login": "claude-test"
+              }
             },
             {
               "body": "<!-- unclaimed-by: claude-test cid-unclaimed 2026-02-01T00:05:00Z -->\n\n_claude-test: issue claim released — IDD automation marker. Do not edit._",
               "createdAt": "2026-02-01T00:05:00Z",
-              "author": { "login": "claude-test" }
+              "author": {
+                "login": "claude-test"
+              }
             }
           ]
         },
-        "timelineItems": {
+        "closedByPullRequestsReferences": {
           "nodes": []
         }
       }

--- a/tests/token-cost-harvest.test.mts
+++ b/tests/token-cost-harvest.test.mts
@@ -2111,7 +2111,7 @@ test("resolveTrustedMarkerLogins: falls back to this repository's own configured
 // GitHub join (stubbed gh, no network) + AC1 end-to-end
 // ---------------------------------------------------------------------------
 
-test('fetchIssueLoopGithubContext resolves the earliest live-connected same-branch PR', () => {
+test('fetchIssueLoopGithubContext resolves the earliest PR that closed the issue via closedByPullRequestsReferences (#2444)', () => {
   const fixture = readJson(
     'tests/fixtures/token-cost/github/issue-loop-merged.json',
   );
@@ -2126,6 +2126,42 @@ test('fetchIssueLoopGithubContext resolves the earliest live-connected same-bran
     // This is the PR's own first submitted review only -- resolveIssueLoopContext
     // (tested below) additionally folds in the earlier review-watermark comment.
     assert.equal(result.firstReviewAtMs, ms('2026-01-01T00:22:00Z'));
+  } finally {
+    restore();
+  }
+});
+
+test('fetchIssueLoopGithubContext resolves prMergedAtMs even when the closing PR is on an unconventionally-named branch (#2444: closedByPullRequestsReferences scopes by CLOSING relationship, not branch-name pattern)', () => {
+  const fixture = readJson(
+    'tests/fixtures/token-cost/github/issue-loop-merged.json',
+  );
+  const patched = JSON.parse(JSON.stringify(fixture));
+  patched.data.repository.issue.closedByPullRequestsReferences.nodes[0].headRefName =
+    'hotfix/unrelated-branch-name';
+  const restore = stubGhReturningJson(patched);
+  try {
+    const result = fetchIssueLoopGithubContext('acme', 'repo', 9001, [
+      'claude-test',
+    ]);
+    assert.equal(result.prNumber, 9101);
+    assert.equal(result.prMergedAtMs, ms('2026-01-01T00:30:00Z'));
+    assert.equal(result.prHeadRefName, 'hotfix/unrelated-branch-name');
+  } finally {
+    restore();
+  }
+});
+
+test('fetchIssueLoopGithubContext resolves prMergedAtMs: null when the issue has no closing PR (#2444)', () => {
+  const fixture = readJson(
+    'tests/fixtures/token-cost/github/issue-loop-unclaimed.json',
+  );
+  const restore = stubGhReturningJson(fixture);
+  try {
+    const result = fetchIssueLoopGithubContext('acme', 'repo', 9002, [
+      'claude-test',
+    ]);
+    assert.equal(result.prNumber, null);
+    assert.equal(result.prMergedAtMs, null);
   } finally {
     restore();
   }


### PR DESCRIPTION
## Summary

`fetchIssueLoopGithubContext` resolved the PR connected to an issue via
`timelineItems(itemTypes: [CONNECTED_EVENT, DISCONNECTED_EVENT])`.
`ConnectedEvent`/`DisconnectedEvent` are GitHub's *manual*
Development-panel link mechanism -- never produced by the standard
`Closes #N` keyword every PR this repository's own IDD workflow uses.
So `prMergedAtMs` never resolved for a normal completed loop, and
`deriveOutcome` fell through to the routine F4 `unclaimed-by` marker
instead of returning `merged`.

Verified empirically against two real, already-merged issues on this
workstation (#2424, #2426): both returned zero `timelineItems` nodes
despite genuinely merging via `Closes #N`.

## Changes

- Replace the query with `Issue.closedByPullRequestsReferences`, which
  resolves the actual closing PR (with `mergedAt`, `headRefName`, and
  its first review) regardless of link method. Verified empirically
  that it scopes by the closing relationship itself, not by
  branch-name pattern, so the prior `headRefName.startsWith('issue/<n>-')`
  guard is no longer needed (and, kept unchanged, would have
  reintroduced a narrower version of the same bug for any closing PR
  on an unconventionally-named branch).
- `tests/fixtures/token-cost/github/*.json`: updated the 4 fixtures
  from the old `timelineItems` shape to `closedByPullRequestsReferences`.
- `tests/token-cost-harvest.test.mts`: updated the existing resolution
  test, added a test proving `prMergedAtMs` resolves even when the
  closing PR's branch name doesn't match the `issue/<n>-` convention,
  and a test for the no-closing-PR case.
- Repaired the local `samples.jsonl`'s stale `#ew2424` entry (recorded
  `outcome: unclaimed` under the old logic) and refreshed
  `docs/token-cost-snapshot.json`: a fresh harvest now resolves that
  same sample as `outcome: merged`.

`docs/token-cost.md`'s interim caveat about this misclassification is
being added independently on PR #2440 (issue #2434), which was not yet
merged when this branch was created -- if it lands after this PR
merges, a trivial follow-up removal of that now-stale caveat will be
needed; not blocking this fix.

## Verification

- `node --test tests/token-cost-harvest.test.mts` -- 87/87 pass
  (including 3 new/updated tests)
- Full `node --test tests/*.test.mts` -- 4730/4730 pass
- `pnpm run typecheck` -- clean
- `pnpm run build:check` -- clean
- Manually re-ran the fixed harvest CLI against real local session data
  (from the primary worktree): issue #2424's own sample now resolves
  `outcome: merged` instead of `unclaimed`
- `node scripts/token-cost-report.mjs --check` -- no drift

Closes #2444


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved issue and pull request tracking for token-cost reporting.
  - Reports now identify the earliest pull request that closed an issue, including pull requests with non-standard branch names.
  - Merged timestamps remain available more reliably, while issues without a closing pull request are handled correctly.

- **Tests**
  - Expanded coverage for pull request selection, merge timing, and issues without closing pull requests.

- **Documentation**
  - Updated token-cost snapshots with refreshed usage metrics and workflow results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->