### PR TITLE
feat(discover-readiness-check): flag roadmap-labeled candidates

### DIFF
--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -216,6 +216,8 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
         // No body is available for a not-found / inaccessible issue, so the
         // score is "no score" and the issue is never flagged below floor.
         ...suitabilitySignal(''),
+        // No label data available either.
+        isRoadmap: false,
       });
       continue;
     }
@@ -225,6 +227,7 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
         title: issue.title,
         reasons: ['issue_not_open'],
         ...suitabilitySignal(issue.body),
+        isRoadmap: issue.labels.has(roadmapLabelName),
       });
       continue;
     }
@@ -318,11 +321,13 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
       }
     }
     const signal = suitabilitySignal(issue.body);
+    const isRoadmap = labels.has(roadmapLabelName);
     if (reasons.size === 0) {
       ready.push({
         number: issue.number,
         title: issue.title,
         ...signal,
+        isRoadmap,
       });
       continue;
     }
@@ -331,6 +336,7 @@ export async function evaluateDiscoverReadiness(issueNumbers, options) {
       title: issue.title,
       reasons: [...reasons].sort(),
       ...signal,
+      isRoadmap,
     });
   }
   const filteredByReason = countReasons(filteredOut);
@@ -550,8 +556,8 @@ function printHelp() {
 
 Output schema (JSON mode):
   {
-    "ready": [{ "number": 123, "title": "...", "autopilotSuitability": 4, "belowFloor": false }],
-    "filteredOut": [{ "number": 124, "title": "...", "reasons": ["..."], "autopilotSuitability": null, "belowFloor": false }],
+    "ready": [{ "number": 123, "title": "...", "autopilotSuitability": 4, "belowFloor": false, "isRoadmap": false }],
+    "filteredOut": [{ "number": 124, "title": "...", "reasons": ["..."], "autopilotSuitability": null, "belowFloor": false, "isRoadmap": false }],
     "unresolvable": [{ "issueNumber": 124, "kind": "...", "reference": "...", "reason": "..." }],
     "warnings": [{ "issueNumber": 124, "message": "Warning: ..." }],
     "summary": { "total": 2, "readyCount": 1, "filteredCount": 1, "unresolvableCount": 0, "filteredByReason": { "...": 1 } }
@@ -559,7 +565,7 @@ Output schema (JSON mode):
 
 Output schema (--swarm-floor mode):
   {
-    "eligible": [{ "number": 123, "title": "...", "autopilotSuitability": 4, "belowFloor": false }],
+    "eligible": [{ "number": 123, "title": "...", "autopilotSuitability": 4, "belowFloor": false, "isRoadmap": false }],
     "eligible_count": 1,
     "total": 7
   }
@@ -681,16 +687,18 @@ function countReasons(filteredOut) {
   }
   return counts;
 }
-function renderCsv(summary) {
-  const lines = ['number,title,status,reasons,suitability,belowFloor'];
+export function renderCsv(summary) {
+  const lines = [
+    'number,title,status,reasons,suitability,belowFloor,isRoadmap',
+  ];
   for (const item of summary.ready) {
     lines.push(
-      `${item.number},${escapeCsv(item.title)},ready,,${formatScore(item.autopilotSuitability)},${item.belowFloor}`,
+      `${item.number},${escapeCsv(item.title)},ready,,${formatScore(item.autopilotSuitability)},${item.belowFloor},${item.isRoadmap}`,
     );
   }
   for (const item of summary.filteredOut) {
     lines.push(
-      `${item.number},${escapeCsv(item.title)},filtered,${escapeCsv(item.reasons.join(';'))},${formatScore(item.autopilotSuitability)},${item.belowFloor}`,
+      `${item.number},${escapeCsv(item.title)},filtered,${escapeCsv(item.reasons.join(';'))},${formatScore(item.autopilotSuitability)},${item.belowFloor},${item.isRoadmap}`,
     );
   }
   return `${lines.join('\n')}\n`;

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -67,14 +67,29 @@ export interface ReadinessSuitabilitySignal {
   belowFloor: boolean;
 }
 
+/**
+ * Whether this issue carries the configured `labels.roadmapLabelName`
+ * (#2450) -- label membership only, not `isParentEpicIssue`'s additional
+ * title-startswith-"roadmap" heuristic, since this flag exists to surface
+ * authored roadmap-label intent, not the broader A2 dependency-exemption
+ * signal.
+ */
+interface ReadinessRoadmapSignal {
+  isRoadmap: boolean;
+}
+
 /** One issue that passed every readiness filter. */
-export interface ReadinessReadyIssue extends ReadinessSuitabilitySignal {
+export interface ReadinessReadyIssue
+  extends ReadinessSuitabilitySignal,
+    ReadinessRoadmapSignal {
   number: number;
   title: string;
 }
 
 /** One issue removed by a readiness filter, with the failed reasons. */
-export interface ReadinessFilteredIssue extends ReadinessSuitabilitySignal {
+export interface ReadinessFilteredIssue
+  extends ReadinessSuitabilitySignal,
+    ReadinessRoadmapSignal {
   number: number;
   title: string;
   reasons: string[];
@@ -337,6 +352,8 @@ export async function evaluateDiscoverReadiness(
         // No body is available for a not-found / inaccessible issue, so the
         // score is "no score" and the issue is never flagged below floor.
         ...suitabilitySignal(''),
+        // No label data available either.
+        isRoadmap: false,
       });
       continue;
     }
@@ -346,6 +363,7 @@ export async function evaluateDiscoverReadiness(
         title: issue.title,
         reasons: ['issue_not_open'],
         ...suitabilitySignal(issue.body),
+        isRoadmap: issue.labels.has(roadmapLabelName),
       });
       continue;
     }
@@ -444,11 +462,13 @@ export async function evaluateDiscoverReadiness(
     }
 
     const signal = suitabilitySignal(issue.body);
+    const isRoadmap = labels.has(roadmapLabelName);
     if (reasons.size === 0) {
       ready.push({
         number: issue.number,
         title: issue.title,
         ...signal,
+        isRoadmap,
       });
       continue;
     }
@@ -458,6 +478,7 @@ export async function evaluateDiscoverReadiness(
       title: issue.title,
       reasons: [...reasons].sort(),
       ...signal,
+      isRoadmap,
     });
   }
 
@@ -699,8 +720,8 @@ function printHelp() {
 
 Output schema (JSON mode):
   {
-    "ready": [{ "number": 123, "title": "...", "autopilotSuitability": 4, "belowFloor": false }],
-    "filteredOut": [{ "number": 124, "title": "...", "reasons": ["..."], "autopilotSuitability": null, "belowFloor": false }],
+    "ready": [{ "number": 123, "title": "...", "autopilotSuitability": 4, "belowFloor": false, "isRoadmap": false }],
+    "filteredOut": [{ "number": 124, "title": "...", "reasons": ["..."], "autopilotSuitability": null, "belowFloor": false, "isRoadmap": false }],
     "unresolvable": [{ "issueNumber": 124, "kind": "...", "reference": "...", "reason": "..." }],
     "warnings": [{ "issueNumber": 124, "message": "Warning: ..." }],
     "summary": { "total": 2, "readyCount": 1, "filteredCount": 1, "unresolvableCount": 0, "filteredByReason": { "...": 1 } }
@@ -708,7 +729,7 @@ Output schema (JSON mode):
 
 Output schema (--swarm-floor mode):
   {
-    "eligible": [{ "number": 123, "title": "...", "autopilotSuitability": 4, "belowFloor": false }],
+    "eligible": [{ "number": 123, "title": "...", "autopilotSuitability": 4, "belowFloor": false, "isRoadmap": false }],
     "eligible_count": 1,
     "total": 7
   }
@@ -864,16 +885,18 @@ function countReasons(
   return counts;
 }
 
-function renderCsv(summary: ReadinessSummary): string {
-  const lines = ['number,title,status,reasons,suitability,belowFloor'];
+export function renderCsv(summary: ReadinessSummary): string {
+  const lines = [
+    'number,title,status,reasons,suitability,belowFloor,isRoadmap',
+  ];
   for (const item of summary.ready) {
     lines.push(
-      `${item.number},${escapeCsv(item.title)},ready,,${formatScore(item.autopilotSuitability)},${item.belowFloor}`,
+      `${item.number},${escapeCsv(item.title)},ready,,${formatScore(item.autopilotSuitability)},${item.belowFloor},${item.isRoadmap}`,
     );
   }
   for (const item of summary.filteredOut) {
     lines.push(
-      `${item.number},${escapeCsv(item.title)},filtered,${escapeCsv(item.reasons.join(';'))},${formatScore(item.autopilotSuitability)},${item.belowFloor}`,
+      `${item.number},${escapeCsv(item.title)},filtered,${escapeCsv(item.reasons.join(';'))},${formatScore(item.autopilotSuitability)},${item.belowFloor},${item.isRoadmap}`,
     );
   }
   return `${lines.join('\n')}\n`;

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -15,6 +15,7 @@ import {
   isInaccessibleIssueLookupError,
   parseArgs,
   parseSwarmFloorArg,
+  renderCsv,
   summarizeSwarmFloorEligibility,
 } from '../src/scripts/discover-readiness-check.mts';
 import { createFakeProviderAdapter } from '../src/scripts/provider-adapter-fake.mts';
@@ -508,6 +509,7 @@ test('open roadmap dependencies are ignored as parent epics', async () => {
       title: 'candidate',
       autopilotSuitability: null,
       belowFloor: false,
+      isRoadmap: false,
     },
   ]);
 });
@@ -624,6 +626,7 @@ test('treats inaccessible target issue as unresolvable', async () => {
       reasons: ['issue_inaccessible'],
       autopilotSuitability: null,
       belowFloor: false,
+      isRoadmap: false,
     },
   ]);
   assert.deepEqual(summary.unresolvable, [
@@ -750,6 +753,7 @@ test('surfaces autopilot-suitability score and below-floor flag without changing
       title: 'scored above floor',
       autopilotSuitability: 4,
       belowFloor: false,
+      isRoadmap: false,
     },
   );
   assert.deepEqual(
@@ -759,6 +763,7 @@ test('surfaces autopilot-suitability score and below-floor flag without changing
       title: 'scored below floor',
       autopilotSuitability: 2,
       belowFloor: true,
+      isRoadmap: false,
     },
   );
   assert.deepEqual(
@@ -768,6 +773,7 @@ test('surfaces autopilot-suitability score and below-floor flag without changing
       title: 'unscored',
       autopilotSuitability: null,
       belowFloor: false,
+      isRoadmap: false,
     },
   );
 });
@@ -792,6 +798,7 @@ test('surfaces the suitability signal on filtered-out issues too', async () => {
       reasons: ['label:status:needs-decision'],
       autopilotSuitability: 5,
       belowFloor: false,
+      isRoadmap: false,
     },
   ]);
 });
@@ -854,6 +861,7 @@ test('surfaces the suitability signal on a not-open scored issue', async () => {
       reasons: ['issue_not_open'],
       autopilotSuitability: 3,
       belowFloor: false,
+      isRoadmap: false,
     },
   ]);
 });
@@ -897,8 +905,132 @@ test('forces a neutral signal when the suitability kill switch is off', async ()
       title: 'below floor but kill switch off',
       autopilotSuitability: null,
       belowFloor: false,
+      isRoadmap: false,
     },
   ]);
+});
+
+// --- #2450: flag roadmap-labeled candidates -------------------------------
+
+test('flags a roadmap-labeled ready issue with isRoadmap: true', async () => {
+  const summary = await evaluateDiscoverReadiness([1601], {
+    loadIssue: async () => ({
+      number: 1601,
+      title: 'roadmap child work',
+      state: 'OPEN',
+      body: 'no dependencies',
+      labels: [{ name: 'roadmap' }],
+    }),
+    findRoadmapsByMarker: async () => [],
+  });
+
+  assert.deepEqual(summary.ready, [
+    {
+      number: 1601,
+      title: 'roadmap child work',
+      autopilotSuitability: null,
+      belowFloor: false,
+      isRoadmap: true,
+    },
+  ]);
+});
+
+test('does not flag a non-roadmap ready issue', async () => {
+  const summary = await evaluateDiscoverReadiness([1602], {
+    loadIssue: async () => ({
+      number: 1602,
+      title: 'ordinary task',
+      state: 'OPEN',
+      body: '',
+      labels: [{ name: 'enhancement' }],
+    }),
+    findRoadmapsByMarker: async () => [],
+  });
+
+  assert.equal(summary.ready[0]?.isRoadmap, false);
+});
+
+test('isRoadmap uses only the configured label, not the title heuristic isParentEpicIssue also applies', async () => {
+  const summary = await evaluateDiscoverReadiness([1603], {
+    loadIssue: async () => ({
+      // Title starts with "roadmap" (the isParentEpicIssue title heuristic)
+      // but carries no roadmap label -- isRoadmap must stay false since it
+      // is scoped to label membership only, per the issue's own AC.
+      number: 1603,
+      title: 'roadmap-adjacent cleanup',
+      state: 'OPEN',
+      body: '',
+      labels: [],
+    }),
+    findRoadmapsByMarker: async () => [],
+  });
+
+  assert.equal(summary.ready[0]?.isRoadmap, false);
+});
+
+test('isRoadmap never affects belowFloor filtering or ready/filteredOut classification', async () => {
+  const summary = await evaluateDiscoverReadiness([1604], {
+    autopilotSuitabilityFloor: 4,
+    loadIssue: async () => ({
+      number: 1604,
+      title: 'scored-below-floor roadmap issue',
+      state: 'OPEN',
+      body: '<!-- idd-skill-autopilot-suitability: 2 -->',
+      labels: [{ name: 'roadmap' }],
+    }),
+    findRoadmapsByMarker: async () => [],
+  });
+
+  assert.equal(summary.ready.length, 1);
+  assert.equal(summary.ready[0]?.isRoadmap, true);
+  assert.equal(summary.ready[0]?.belowFloor, true);
+
+  const eligibility = summarizeSwarmFloorEligibility(summary);
+  assert.equal(eligibility.eligible.length, 0);
+});
+
+test('renderCsv includes the isRoadmap column for ready and filtered rows', () => {
+  const csv = renderCsv({
+    ready: [
+      {
+        number: 10,
+        title: 'roadmap ready',
+        autopilotSuitability: null,
+        belowFloor: false,
+        isRoadmap: true,
+      },
+    ],
+    filteredOut: [
+      {
+        number: 20,
+        title: 'blocked',
+        reasons: ['label:status:needs-decision'],
+        autopilotSuitability: null,
+        belowFloor: false,
+        isRoadmap: false,
+      },
+    ],
+    unresolvable: [],
+    warnings: [],
+    summary: {
+      total: 2,
+      readyCount: 1,
+      filteredCount: 1,
+      unresolvableCount: 0,
+      filteredByReason: { 'label:status:needs-decision': 1 },
+    },
+  });
+
+  const lines = csv.trim().split('\n');
+  assert.equal(
+    lines[0],
+    'number,title,status,reasons,suitability,belowFloor,isRoadmap',
+  );
+  assert.equal(lines[1], '10,roadmap ready,ready,,,false,true');
+  assert.equal(
+    lines[2],
+    '20,blocked,filtered,label:status:needs-decision,,false,false',
+  );
 });
 
 test('summarizeSwarmFloorEligibility keeps ready issues at or above the floor', () => {
@@ -911,13 +1043,21 @@ test('summarizeSwarmFloorEligibility keeps ready issues at or above the floor', 
         title: 'above',
         autopilotSuitability: 5,
         belowFloor: false,
+        isRoadmap: false,
       },
-      { number: 20, title: 'below', autopilotSuitability: 2, belowFloor: true },
+      {
+        number: 20,
+        title: 'below',
+        autopilotSuitability: 2,
+        belowFloor: true,
+        isRoadmap: false,
+      },
       {
         number: 30,
         title: 'no score',
         autopilotSuitability: null,
         belowFloor: false,
+        isRoadmap: true,
       },
     ],
     filteredOut: [],
@@ -939,12 +1079,14 @@ test('summarizeSwarmFloorEligibility keeps ready issues at or above the floor', 
         title: 'above',
         autopilotSuitability: 5,
         belowFloor: false,
+        isRoadmap: false,
       },
       {
         number: 30,
         title: 'no score',
         autopilotSuitability: null,
         belowFloor: false,
+        isRoadmap: true,
       },
     ],
     eligible_count: 2,


### PR DESCRIPTION
# Summary

`discover-readiness-check.mjs --swarm-floor <n>`'s `eligible` output
listed every open, unblocked, at-or-above-floor issue with no signal
distinguishing an execution-leaf candidate (directly claimable) from
a roadmap node whose children have all merged. This adds an
`isRoadmap: boolean` field to `ReadinessReadyIssue` and
`ReadinessFilteredIssue`, computed from the already-normalized
`labels.has(roadmapLabelName)` at all four `ready.push`/
`filteredOut.push` call sites -- no new network calls. `renderCsv`
gains a matching `isRoadmap` column and is now exported; both
`--help` JSON-schema examples are updated; existing test fixtures
were amended to include the field, and five new tests cover a
roadmap-labeled ready issue, a non-roadmap issue, the deliberate
non-use of `isParentEpicIssue`'s title heuristic, non-interference
with `belowFloor` filtering, and CSV rendering.

## Linked issue

Closes #2450

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

`docs/idd-helper-scripts.md` (and its byte-identical
`idd-template/` mirror) documents the `--swarm-floor` `eligible`
shape as `{ number, title, autopilotSuitability, belowFloor }` and
is now stale by one field. This is a deliberate trade-off, not an
oversight: the issue's own acceptance criteria explicitly says "No
change to ... any other file -- this is additive output only on an
existing helper," so those two doc files were left untouched per
that explicit scope guard rather than silently patched.

`isRoadmap` is computed as label membership only
(`labels.has(roadmapLabelName)`), deliberately narrower than
`isParentEpicIssue`'s additional title-startswith-"roadmap"
heuristic used elsewhere in this file for the A2 dependency-exemption
check -- the field name and the issue's own acceptance criteria
define it as label membership specifically.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (via `pnpm run typecheck` + the pre-push-validate
      command set: biome, dprint, markdownlint, cspell,
      audit-docs.mjs --check, audit-code-span-wrap.mjs)
- [x] `pnpm test` (4738/4738 pass)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed; pre-existing warnings
      unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (none)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Readiness results now indicate whether each issue is associated with a configured roadmap label.
  * JSON output and help examples include the new `isRoadmap` field.
  * CSV output now includes an `isRoadmap` column.
* **Bug Fixes**
  * Missing or inaccessible issues now consistently report `isRoadmap: false`.
  * Roadmap status is determined by configured labels rather than title-only matching, while existing readiness and eligibility classifications remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->