### PR TITLE
chore(idd-config): cover agent-entry mirror test in pre-push-validate

### DIFF
--- a/.github/idd/config.json
+++ b/.github/idd/config.json
@@ -23,7 +23,7 @@
   "commands": {
     "install-deps": "node scripts/verify-install-deps.mjs --key-binary node_modules/.bin/tsc --install-command \"pnpm install --frozen-lockfile\"",
     "fix-validate": "npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\"",
-    "pre-push-validate": "npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && pnpm run build:check && node scripts/idd-doctor.mjs",
+    "pre-push-validate": "npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && node --test tests/agent-entry-mirror-sync.test.mts && pnpm run build:check && node scripts/idd-doctor.mjs",
     "post-fix-validate": "npx biome check --write && npx dprint fmt \"**/*.md\" && npx markdownlint-cli2 --fix \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs"
   },
   "helperRuntime": {

--- a/.github/instructions/idd-overview-core.instructions.md
+++ b/.github/instructions/idd-overview-core.instructions.md
@@ -267,7 +267,7 @@ enabled and default approval actors to
 | Name | Commands |
 | --- | --- |
 | **fix-validate** | `npx biome check --write && npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md"` |
-| **pre-push-validate** | `npx biome check && npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && pnpm run build:check && node scripts/idd-doctor.mjs` |
+| **pre-push-validate** | `npx biome check && npx dprint check "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && node --test tests/agent-entry-mirror-sync.test.mts && pnpm run build:check && node scripts/idd-doctor.mjs` |
 | **post-fix-validate** | `npx biome check --write && npx dprint fmt "**/*.md" && npx markdownlint-cli2 --fix "**/*.md" && npx markdownlint-cli2 "**/*.md" && npx cspell lint "**" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs` |
 | **install-deps** | `node scripts/verify-install-deps.mjs --key-binary node_modules/.bin/tsc --install-command "pnpm install --frozen-lockfile"` |
 | **issue-scope** | `roadmap-first` |

--- a/audit/sync-manifest.json
+++ b/audit/sync-manifest.json
@@ -569,7 +569,7 @@
         },
         {
           "from": "| **pre-push-validate** | `{{PRE_PUSH_VALIDATE_COMMANDS}}` |",
-          "to": "| **pre-push-validate** | `npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && pnpm run build:check && node scripts/idd-doctor.mjs` |"
+          "to": "| **pre-push-validate** | `npx biome check && npx dprint check \"**/*.md\" && npx markdownlint-cli2 \"**/*.md\" && npx cspell lint \"**\" --no-progress && node scripts/audit-docs.mjs --check && node scripts/audit-code-span-wrap.mjs && node --test tests/agent-entry-mirror-sync.test.mts && pnpm run build:check && node scripts/idd-doctor.mjs` |"
         },
         {
           "from": "| **post-fix-validate** | `{{POST_FIX_VALIDATE_COMMANDS}}` |",


### PR DESCRIPTION
# Summary

`pre-push-validate` deliberately omits `node --test tests/*.test.mts`
under an "E2E tests are verified by CI" rationale, but
`tests/agent-entry-mirror-sync.test.mts` is a pure, synchronous
file-read/string-comparison test (~110ms, 6 tests, no network, no
subprocess, no fixture git operations) that directly enforces
CLAUDE.md's own "keep AGENTS.md/GEMINI.md mirrored" rule. Today's
`#2410` incident hit this gap directly: a CLAUDE.md-only edit passed a
clean local `pre-push-validate` and only failed once CI ran, costing a
second commit. This adds that one targeted test invocation to
`pre-push-validate` so the same regression class is caught locally.

An independent B2 critique pass found the original single-file plan
incomplete: `.github/idd/config.json`'s `commands.pre-push-validate`
and `.github/instructions/idd-overview-core.instructions.md`'s
Project commands table must stay byte-identical, or
`audit-docs.mjs --check` (already a step inside `pre-push-validate`
itself) fails closed before the new test step ever runs. The fix
therefore touches three files: the config command string, the
`audit/sync-manifest.json` replacement string that generates the
overview table's matching row, and the regenerated overview table
itself (via `node scripts/sync-docs.mjs --apply` -- never hand-edited).
`idd-template/`'s copies of both surfaces are untouched (adopter
placeholders, explicitly out of scope).

## Linked issue

Closes #2449

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Verified directly this session: a deliberate CLAUDE.md-only edit to
the shared "## Key workflow rules" section (not mirrored into
AGENTS.md/GEMINI.md) makes the new test step fail with the exact diff
evidence; restoring the mirror makes it pass again (6/6). The full
updated `pre-push-validate` chain, including `idd-doctor.mjs`, passes
with the same 3 pre-existing, unrelated warnings this repository
already carries (no new command-mismatch warning).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [x] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint` (biome, dprint, markdownlint, cspell,
      `audit-docs.mjs --check`, `audit-code-span-wrap.mjs`,
      `build:check` -- all clean)
- [x] `pnpm test` (full suite green)
- [x] `node scripts/audit-docs.mjs --check` (passes, confirms
      `.github/idd/config.json` still matches the overview table for
      both this repo and `idd-template/`)
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passes; the 3 warnings shown are
      pre-existing and unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (none -- 3-line command-string
      change)
