### PR TITLE
fix(idd-merge-execute): warn when local HEAD diverges from the PR head about to merge

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -2195,6 +2195,16 @@ reflexively as any other CLI option.
   does not match this exact shape — a different error, an ineligible
   topology, or the opt-in `hold-and-report` policy — falls through
   unchanged to the pre-#1521 hold-and-report path.
+- **Local-head-drift warning (#2453).** In both dry-run and `--apply`,
+  the helper best-effort reads the invoking process's local git branch
+  and HEAD. When that local branch equals the PR's own `headRefName`
+  and the local HEAD differs from `prHeadSha`, the verdict's
+  `localHeadDrift` field is set to `{ localHeadSha, remoteHeadSha }` and
+  a warning is also printed on stderr — the signature of an unpushed
+  commit about to be silently left behind. It is advisory only: `null`
+  whenever the check cannot run (no git repo, a different or detached
+  branch, or an unreadable local/remote read) or finds no divergence,
+  and it never gates `ready` or blocks the merge.
 - Fail closed: if helper execution fails, output is invalid JSON,
   required fields are missing, or helper evidence conflicts with live
   GitHub state, discard helper output and run the manual F3 gate +

--- a/fixtures/schemas/idd-merge-execute.valid.json
+++ b/fixtures/schemas/idd-merge-execute.valid.json
@@ -14,5 +14,6 @@
   "mergeCommand": "gh pr merge 994 --merge --match-head-commit 0123456789abcdef0123456789abcdef01234567",
   "merged": false,
   "mergeResult": "",
-  "adminFallbackUsed": false
+  "adminFallbackUsed": false,
+  "localHeadDrift": null
 }

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -2195,6 +2195,16 @@ reflexively as any other CLI option.
   does not match this exact shape — a different error, an ineligible
   topology, or the opt-in `hold-and-report` policy — falls through
   unchanged to the pre-#1521 hold-and-report path.
+- **Local-head-drift warning (#2453).** In both dry-run and `--apply`,
+  the helper best-effort reads the invoking process's local git branch
+  and HEAD. When that local branch equals the PR's own `headRefName`
+  and the local HEAD differs from `prHeadSha`, the verdict's
+  `localHeadDrift` field is set to `{ localHeadSha, remoteHeadSha }` and
+  a warning is also printed on stderr — the signature of an unpushed
+  commit about to be silently left behind. It is advisory only: `null`
+  whenever the check cannot run (no git repo, a different or detached
+  branch, or an unreadable local/remote read) or finds no divergence,
+  and it never gates `ready` or blocks the merge.
 - Fail closed: if helper execution fails, output is invalid JSON,
   required fields are missing, or helper evidence conflicts with live
   GitHub state, discard helper output and run the manual F3 gate +

--- a/schemas/idd-merge-execute.schema.json
+++ b/schemas/idd-merge-execute.schema.json
@@ -15,7 +15,8 @@
     "mergeCommand",
     "merged",
     "mergeResult",
-    "adminFallbackUsed"
+    "adminFallbackUsed",
+    "localHeadDrift"
   ],
   "properties": {
     "protocolVersion": {
@@ -81,6 +82,24 @@
     "adminFallbackUsed": {
       "type": "boolean",
       "description": "#1521: true only when the plain merge command failed with the self-CODEOWNER \"base branch policy prohibits the merge\" error and this run retried with --admin (successfully or not). False for every other path, including a successful plain merge and a merge failure not eligible for the fallback."
+    },
+    "localHeadDrift": {
+      "type": ["object", "null"],
+      "description": "#2453: non-fatal advisory. Set only when the invoking process's local git branch equals the PR's own headRefName AND its local HEAD differs from prHeadSha -- the signature of an unpushed commit about to be silently left behind. Null whenever the check cannot run or finds no divergence. Never gates ready or blocks the merge.",
+      "required": ["localHeadSha", "remoteHeadSha"],
+      "properties": {
+        "localHeadSha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$",
+          "description": "Local HEAD SHA read from the invoking worktree."
+        },
+        "remoteHeadSha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$",
+          "description": "PR head SHA about to be merged (same value as prHeadSha)."
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/scripts/idd-merge-execute.mjs
+++ b/scripts/idd-merge-execute.mjs
@@ -12,6 +12,8 @@
 // reports the bound merge command; the ONLY mutation anywhere is the
 // `gh pr merge` issued under `--apply` once every F3 gate holds and the
 // head + claim re-validate immediately before the merge.
+import { execFileSync } from 'node:child_process';
+import { GH_TEXT_LOOP_OPTIONS, ghText } from './gh-exec.mjs';
 import { deriveGhHttpStatus, ghErrorText } from './gh-http-status.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import { normalizePolicyConfig } from './policy-helpers.mjs';
@@ -235,6 +237,42 @@ const defaultDeps = {
       ? resolveRemoteSoloCodeownerAdminFallbackMode(prNumber, repoRef, headSha)
       : normalizePolicyConfig(loadIddConfig()).mergeGate
           .soloCodeownerAdminFallback,
+  getLocalHeadState: () => {
+    try {
+      const branch = execFileSync(
+        'git',
+        ['rev-parse', '--abbrev-ref', 'HEAD'],
+        {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        },
+      ).trim();
+      const headSha = execFileSync('git', ['rev-parse', 'HEAD'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+      return { branch: branch || null, headSha: headSha || null };
+    } catch {
+      return { branch: null, headSha: null };
+    }
+  },
+  fetchHeadRefName: (prNumber, repoRef) => {
+    const { owner, repo } = resolveOwnerRepoFromRef(repoRef);
+    return ghText(
+      [
+        'pr',
+        'view',
+        String(prNumber),
+        '-R',
+        `${owner}/${repo}`,
+        '--json',
+        'headRefName',
+        '--jq',
+        '.headRefName',
+      ],
+      GH_TEXT_LOOP_OPTIONS,
+    ).trim();
+  },
 };
 /**
  * Build the F3 verdict and, under `--apply`, execute the merge. The
@@ -274,7 +312,30 @@ export function runMergeExecute(argv, deps = defaultDeps) {
     merged: false,
     mergeResult: '',
     adminFallbackUsed: false,
+    localHeadDrift: null,
   };
+  // #2453: best-effort, advisory-only local-head-drift check. Never lets a
+  // misbehaving dep (or an unrelated local git/gh failure) affect `ready`,
+  // `blockers`, or the merge decision below.
+  try {
+    const localHeadState = deps.getLocalHeadState();
+    if (localHeadState.branch && localHeadState.headSha) {
+      const prHeadRefName = deps.fetchHeadRefName(args.prNumber, args.repoRef);
+      if (
+        prHeadRefName &&
+        prHeadRefName === localHeadState.branch &&
+        localHeadState.headSha !== prHeadSha
+      ) {
+        verdict.localHeadDrift = {
+          localHeadSha: localHeadState.headSha,
+          remoteHeadSha: prHeadSha,
+        };
+      }
+    }
+  } catch {
+    // Advisory only (#2453): a local git or `gh` failure here must never
+    // block or crash an otherwise-successful merge run.
+  }
   if (!args.apply) {
     // Dry-run: read-only. Never merge.
     return { verdict, exitCode: ready ? 0 : 1 };
@@ -602,11 +663,26 @@ function printHelp() {
   when the fresh branch-currency evidence says an up-to-date head is not
   required. Unreadable or unsafe live state aborts the retry.
   The verdict's adminFallbackUsed field records whether this path fired.
+
+  Local-head-drift warning (#2453): when the invoking worktree's local
+  git branch matches this PR's own branch but its local HEAD differs from
+  the head about to merge, the verdict's localHeadDrift field is set and
+  a warning is printed on stderr -- a non-fatal signal an unpushed commit
+  may be about to be left behind. Never blocks the merge; a silent no-op
+  from any other directory, branch, or local read failure.
 `);
 }
 // CLI: print the verdict as JSON and exit with the gate/merge status.
 if (import.meta.main) {
   const { verdict, exitCode } = runMergeExecute(process.argv.slice(2));
+  if (verdict.localHeadDrift) {
+    // #2453: surface this prominently on stderr too -- an agent running
+    // --apply interactively should actually notice it, not just find it
+    // buried in the JSON verdict.
+    process.stderr.write(
+      `⚠ local HEAD drift: this worktree's local HEAD (${verdict.localHeadDrift.localHeadSha}) differs from PR #${verdict.prNumber}'s head about to merge (${verdict.localHeadDrift.remoteHeadSha}) -- an unpushed commit may be about to be left behind.\n`,
+    );
+  }
   process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
   process.exit(exitCode);
 }

--- a/scripts/idd-merge-execute.mjs
+++ b/scripts/idd-merge-execute.mjs
@@ -13,7 +13,6 @@
 // `gh pr merge` issued under `--apply` once every F3 gate holds and the
 // head + claim re-validate immediately before the merge.
 import { execFileSync } from 'node:child_process';
-import { GH_TEXT_LOOP_OPTIONS, ghText } from './gh-exec.mjs';
 import { deriveGhHttpStatus, ghErrorText } from './gh-http-status.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import { normalizePolicyConfig } from './policy-helpers.mjs';
@@ -258,20 +257,10 @@ const defaultDeps = {
   },
   fetchHeadRefName: (prNumber, repoRef) => {
     const { owner, repo } = resolveOwnerRepoFromRef(repoRef);
-    return ghText(
-      [
-        'pr',
-        'view',
-        String(prNumber),
-        '-R',
-        `${owner}/${repo}`,
-        '--json',
-        'headRefName',
-        '--jq',
-        '.headRefName',
-      ],
-      GH_TEXT_LOOP_OPTIONS,
-    ).trim();
+    return createGithubProviderAdapter(
+      owner,
+      repo,
+    ).getChangeRequestHeadRefNameAtRepo(owner, repo, prNumber);
   },
 };
 /**

--- a/scripts/provider-adapter-fake.mjs
+++ b/scripts/provider-adapter-fake.mjs
@@ -361,6 +361,16 @@ export function createFakeProviderAdapter(fixture) {
       }
       return sha;
     },
+    getChangeRequestHeadRefNameAtRepo(atRepoOwner, atRepoRepo, number) {
+      const key = `${atRepoOwner}/${atRepoRepo}/${number}`;
+      const headRefName = fixture.changeRequestHeadRefNamesAtRepo?.[key];
+      if (headRefName === undefined) {
+        throw new Error(
+          `fake provider: no cross-repo head ref name fixture for ${key}`,
+        );
+      }
+      return headRefName;
+    },
     getChangeRequestAtRepo(atRepoOwner, atRepoRepo, number) {
       const key = `${atRepoOwner}/${atRepoRepo}/${number}`;
       return fixture.changeRequestsAtRepo?.[key] ?? null;

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -1585,6 +1585,19 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
         '.headRefOid',
       ]);
     },
+    getChangeRequestHeadRefNameAtRepo(atRepoOwner, atRepoRepo, number) {
+      return deps.ghText([
+        'pr',
+        'view',
+        String(number),
+        '-R',
+        `${atRepoOwner}/${atRepoRepo}`,
+        '--json',
+        'headRefName',
+        '--jq',
+        '.headRefName',
+      ]);
+    },
     getChangeRequestAtRepo(atRepoOwner, atRepoRepo, number) {
       try {
         const raw = deps.ghText(

--- a/src/scripts/idd-merge-execute.mts
+++ b/src/scripts/idd-merge-execute.mts
@@ -15,7 +15,6 @@
 
 import { execFileSync } from 'node:child_process';
 
-import { GH_TEXT_LOOP_OPTIONS, ghText } from './gh-exec.mts';
 import { deriveGhHttpStatus, ghErrorText } from './gh-http-status.mts';
 import { type IddConfig, loadIddConfig } from './idd-config.mts';
 import { normalizePolicyConfig } from './policy-helpers.mts';
@@ -412,20 +411,10 @@ const defaultDeps: MergeExecuteDeps = {
   },
   fetchHeadRefName: (prNumber, repoRef) => {
     const { owner, repo } = resolveOwnerRepoFromRef(repoRef);
-    return ghText(
-      [
-        'pr',
-        'view',
-        String(prNumber),
-        '-R',
-        `${owner}/${repo}`,
-        '--json',
-        'headRefName',
-        '--jq',
-        '.headRefName',
-      ],
-      GH_TEXT_LOOP_OPTIONS,
-    ).trim();
+    return createGithubProviderAdapter(
+      owner,
+      repo,
+    ).getChangeRequestHeadRefNameAtRepo(owner, repo, prNumber);
   },
 };
 

--- a/src/scripts/idd-merge-execute.mts
+++ b/src/scripts/idd-merge-execute.mts
@@ -13,6 +13,9 @@
 // `gh pr merge` issued under `--apply` once every F3 gate holds and the
 // head + claim re-validate immediately before the merge.
 
+import { execFileSync } from 'node:child_process';
+
+import { GH_TEXT_LOOP_OPTIONS, ghText } from './gh-exec.mts';
 import { deriveGhHttpStatus, ghErrorText } from './gh-http-status.mts';
 import { type IddConfig, loadIddConfig } from './idd-config.mts';
 import { normalizePolicyConfig } from './policy-helpers.mts';
@@ -78,6 +81,16 @@ export interface IddMergeExecuteVerdict {
    * eligible for the fallback.
    */
   adminFallbackUsed: boolean;
+  /**
+   * #2453: non-fatal advisory. Set only when the invoking process is
+   * standing on the PR's own branch (its local git branch equals the PR's
+   * `headRefName`) AND its local HEAD differs from `prHeadSha` -- the
+   * signature of an unpushed commit about to be silently left behind by
+   * this merge. `null` whenever the check cannot run (no git repo,
+   * different/detached branch, an unreadable local or remote read) or
+   * finds no divergence. Never gates `ready` or blocks the merge.
+   */
+  localHeadDrift: { localHeadSha: string; remoteHeadSha: string } | null;
 }
 
 /** Parsed CLI arguments mirroring pre-merge-readiness, plus `--apply`. */
@@ -220,6 +233,24 @@ export interface MergeExecuteDeps {
     repoRef: string | null,
     headSha: string,
   ) => string;
+  /**
+   * #2453: best-effort local git state of the process invoking this run.
+   * Must never throw -- swallow any failure (not a git repo, detached
+   * HEAD, `git` unavailable, etc.) into `{ branch: null, headSha: null }`,
+   * since this feeds only the advisory `localHeadDrift` check and must
+   * never block a merge run from a context with no relevant local git
+   * state (e.g. CI, or a maintainer running the CLI from an unrelated
+   * directory).
+   */
+  getLocalHeadState: () => { branch: string | null; headSha: string | null };
+  /**
+   * #2453: fetch the PR's own head branch name (`headRefName`), scoped to
+   * `repoRef` (`<owner>/<repo>`) when set, else the current-directory
+   * repo -- same scoping convention as `fetchHeadSha`. Used only to decide
+   * whether the invoking process is literally standing on the branch
+   * being merged, for the advisory `localHeadDrift` check.
+   */
+  fetchHeadRefName: (prNumber: number, repoRef: string | null) => string;
 }
 
 /** `resolveOwnerRepoFromRef`'s split of a `<owner>/<repo>` `repoRef`, or the
@@ -360,6 +391,42 @@ const defaultDeps: MergeExecuteDeps = {
       ? resolveRemoteSoloCodeownerAdminFallbackMode(prNumber, repoRef, headSha)
       : normalizePolicyConfig(loadIddConfig()).mergeGate
           .soloCodeownerAdminFallback,
+  getLocalHeadState: () => {
+    try {
+      const branch = execFileSync(
+        'git',
+        ['rev-parse', '--abbrev-ref', 'HEAD'],
+        {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        },
+      ).trim();
+      const headSha = execFileSync('git', ['rev-parse', 'HEAD'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }).trim();
+      return { branch: branch || null, headSha: headSha || null };
+    } catch {
+      return { branch: null, headSha: null };
+    }
+  },
+  fetchHeadRefName: (prNumber, repoRef) => {
+    const { owner, repo } = resolveOwnerRepoFromRef(repoRef);
+    return ghText(
+      [
+        'pr',
+        'view',
+        String(prNumber),
+        '-R',
+        `${owner}/${repo}`,
+        '--json',
+        'headRefName',
+        '--jq',
+        '.headRefName',
+      ],
+      GH_TEXT_LOOP_OPTIONS,
+    ).trim();
+  },
 };
 
 /**
@@ -408,7 +475,31 @@ export function runMergeExecute(
     merged: false,
     mergeResult: '',
     adminFallbackUsed: false,
+    localHeadDrift: null,
   };
+
+  // #2453: best-effort, advisory-only local-head-drift check. Never lets a
+  // misbehaving dep (or an unrelated local git/gh failure) affect `ready`,
+  // `blockers`, or the merge decision below.
+  try {
+    const localHeadState = deps.getLocalHeadState();
+    if (localHeadState.branch && localHeadState.headSha) {
+      const prHeadRefName = deps.fetchHeadRefName(args.prNumber, args.repoRef);
+      if (
+        prHeadRefName &&
+        prHeadRefName === localHeadState.branch &&
+        localHeadState.headSha !== prHeadSha
+      ) {
+        verdict.localHeadDrift = {
+          localHeadSha: localHeadState.headSha,
+          remoteHeadSha: prHeadSha,
+        };
+      }
+    }
+  } catch {
+    // Advisory only (#2453): a local git or `gh` failure here must never
+    // block or crash an otherwise-successful merge run.
+  }
 
   if (!args.apply) {
     // Dry-run: read-only. Never merge.
@@ -775,12 +866,27 @@ function printHelp(): void {
   when the fresh branch-currency evidence says an up-to-date head is not
   required. Unreadable or unsafe live state aborts the retry.
   The verdict's adminFallbackUsed field records whether this path fired.
+
+  Local-head-drift warning (#2453): when the invoking worktree's local
+  git branch matches this PR's own branch but its local HEAD differs from
+  the head about to merge, the verdict's localHeadDrift field is set and
+  a warning is printed on stderr -- a non-fatal signal an unpushed commit
+  may be about to be left behind. Never blocks the merge; a silent no-op
+  from any other directory, branch, or local read failure.
 `);
 }
 
 // CLI: print the verdict as JSON and exit with the gate/merge status.
 if (import.meta.main) {
   const { verdict, exitCode } = runMergeExecute(process.argv.slice(2));
+  if (verdict.localHeadDrift) {
+    // #2453: surface this prominently on stderr too -- an agent running
+    // --apply interactively should actually notice it, not just find it
+    // buried in the JSON verdict.
+    process.stderr.write(
+      `⚠ local HEAD drift: this worktree's local HEAD (${verdict.localHeadDrift.localHeadSha}) differs from PR #${verdict.prNumber}'s head about to merge (${verdict.localHeadDrift.remoteHeadSha}) -- an unpushed commit may be about to be left behind.\n`,
+    );
+  }
   process.stdout.write(`${JSON.stringify(verdict, null, 2)}\n`);
   process.exit(exitCode);
 }

--- a/src/scripts/provider-adapter-fake.mts
+++ b/src/scripts/provider-adapter-fake.mts
@@ -209,6 +209,10 @@ export interface FakeProviderFixture {
    * `${owner}/${repo}/${number}`; an absent key throws (matches the adapter's
    * own no-catch, throw-on-failure contract). */
   changeRequestHeadShasAtRepo?: Record<string, string>;
+  /** Backs {@link ProviderPort.getChangeRequestHeadRefNameAtRepo}, keyed by
+   * `${owner}/${repo}/${number}`; an absent key throws (matches the adapter's
+   * own no-catch, throw-on-failure contract). */
+  changeRequestHeadRefNamesAtRepo?: Record<string, string>;
   /** Backs {@link ProviderPort.getChangeRequestAtRepo}, keyed by
    * `${owner}/${repo}/${number}`. */
   changeRequestsAtRepo?: Record<string, ProviderChangeRequestState>;
@@ -747,6 +751,21 @@ export function createFakeProviderAdapter(
         );
       }
       return sha;
+    },
+
+    getChangeRequestHeadRefNameAtRepo(
+      atRepoOwner: string,
+      atRepoRepo: string,
+      number: number,
+    ): string {
+      const key = `${atRepoOwner}/${atRepoRepo}/${number}`;
+      const headRefName = fixture.changeRequestHeadRefNamesAtRepo?.[key];
+      if (headRefName === undefined) {
+        throw new Error(
+          `fake provider: no cross-repo head ref name fixture for ${key}`,
+        );
+      }
+      return headRefName;
     },
 
     getChangeRequestAtRepo(

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -2092,6 +2092,24 @@ export function createGithubProviderAdapter(
       ]);
     },
 
+    getChangeRequestHeadRefNameAtRepo(
+      atRepoOwner: string,
+      atRepoRepo: string,
+      number: number,
+    ): string {
+      return deps.ghText([
+        'pr',
+        'view',
+        String(number),
+        '-R',
+        `${atRepoOwner}/${atRepoRepo}`,
+        '--json',
+        'headRefName',
+        '--jq',
+        '.headRefName',
+      ]);
+    },
+
     getChangeRequestAtRepo(
       atRepoOwner: string,
       atRepoRepo: string,

--- a/src/scripts/provider-port.mts
+++ b/src/scripts/provider-port.mts
@@ -830,6 +830,17 @@ export interface ProviderPort {
   ): string;
 
   /** change-requests, cross-repo. `pr view -R {owner}/{repo} --json
+   * headRefName --jq .headRefName`, throws on any failure -- used by
+   * `idd-merge-execute.mts`'s local-head-drift advisory (#2453) to learn
+   * the PR's own branch name, with the same cross-repo scope as
+   * {@link ProviderPort.getChangeRequestHeadShaAtRepo}. */
+  getChangeRequestHeadRefNameAtRepo(
+    owner: string,
+    repo: string,
+    number: number,
+  ): string;
+
+  /** change-requests, cross-repo. `pr view -R {owner}/{repo} --json
    * mergeable,mergeStateStatus`, `null` on failure -- the explicit-repo
    * sibling of {@link ProviderPort.getChangeRequest}. */
   getChangeRequestAtRepo(

--- a/tests/idd-merge-execute.test.mts
+++ b/tests/idd-merge-execute.test.mts
@@ -90,6 +90,11 @@ function depsFor(
       return 'Merged PR (admin).';
     },
     resolveSoloCodeownerAdminFallbackMode: () => 'auto-admin-retry',
+    // #2453: safe no-op defaults so every pre-existing test (none of which
+    // exercise the local-head-drift advisory) sees no local git state and
+    // therefore no warning.
+    getLocalHeadState: () => ({ branch: null, headSha: null }),
+    fetchHeadRefName: () => '',
     ...overrides,
   };
   return { deps, calls };
@@ -490,6 +495,123 @@ test('--apply merges a ready PR bound to the validated head', () => {
   assert.equal(verdict.ready, true);
   assert.equal(verdict.merged, true);
   assert.deepEqual(calls.merged, [`994:${HEAD}`]);
+  assert.equal(exitCode, 0);
+});
+
+test('#2453 localHeadDrift stays null when the local branch matches the PR head branch and the local HEAD matches prHeadSha', () => {
+  const { deps } = depsFor(readyReport(), {
+    getLocalHeadState: () => ({
+      branch: 'issue/994-fix-thing',
+      headSha: HEAD,
+    }),
+    fetchHeadRefName: () => 'issue/994-fix-thing',
+  });
+  const { verdict } = runMergeExecute([...BASE_ARGS, '--apply'], deps);
+
+  assert.equal(verdict.localHeadDrift, null);
+  assert.equal(verdict.merged, true);
+});
+
+test('#2453 localHeadDrift warns when the local branch matches the PR head branch but local HEAD differs from prHeadSha', () => {
+  const { deps } = depsFor(readyReport(), {
+    getLocalHeadState: () => ({
+      branch: 'issue/994-fix-thing',
+      headSha: DRIFTED,
+    }),
+    fetchHeadRefName: () => 'issue/994-fix-thing',
+  });
+  const { verdict, exitCode } = runMergeExecute(
+    [...BASE_ARGS, '--apply'],
+    deps,
+  );
+
+  assert.deepEqual(verdict.localHeadDrift, {
+    localHeadSha: DRIFTED,
+    remoteHeadSha: HEAD,
+  });
+  // Advisory only: never blocks the merge.
+  assert.equal(verdict.merged, true);
+  assert.equal(exitCode, 0);
+});
+
+test('#2453 localHeadDrift stays null when the local branch differs from the PR head branch, even with a different SHA', () => {
+  const { deps } = depsFor(readyReport(), {
+    getLocalHeadState: () => ({
+      branch: 'main',
+      headSha: DRIFTED,
+    }),
+    fetchHeadRefName: () => 'issue/994-fix-thing',
+  });
+  const { verdict } = runMergeExecute([...BASE_ARGS, '--apply'], deps);
+
+  assert.equal(verdict.localHeadDrift, null);
+});
+
+test('#2453 localHeadDrift stays null when getLocalHeadState reports no local branch/HEAD (not a git repo)', () => {
+  const { deps } = depsFor(readyReport(), {
+    getLocalHeadState: () => ({ branch: null, headSha: null }),
+    fetchHeadRefName: () => {
+      throw new Error('must not be called without local branch/HEAD');
+    },
+  });
+  const { verdict } = runMergeExecute([...BASE_ARGS, '--apply'], deps);
+
+  assert.equal(verdict.localHeadDrift, null);
+});
+
+test('#2453 localHeadDrift stays null and never throws when getLocalHeadState itself misbehaves and throws', () => {
+  const { deps } = depsFor(readyReport(), {
+    getLocalHeadState: () => {
+      throw new Error('simulated local git failure');
+    },
+  });
+
+  assert.doesNotThrow(() => runMergeExecute([...BASE_ARGS, '--apply'], deps));
+  const { verdict, exitCode } = runMergeExecute(
+    [...BASE_ARGS, '--apply'],
+    deps,
+  );
+  assert.equal(verdict.localHeadDrift, null);
+  assert.equal(verdict.merged, true);
+  assert.equal(exitCode, 0);
+});
+
+test('#2453 localHeadDrift stays null and never throws when fetchHeadRefName itself misbehaves and throws', () => {
+  const { deps } = depsFor(readyReport(), {
+    getLocalHeadState: () => ({
+      branch: 'issue/994-fix-thing',
+      headSha: DRIFTED,
+    }),
+    fetchHeadRefName: () => {
+      throw new Error('simulated gh failure');
+    },
+  });
+
+  const { verdict, exitCode } = runMergeExecute(
+    [...BASE_ARGS, '--apply'],
+    deps,
+  );
+  assert.equal(verdict.localHeadDrift, null);
+  assert.equal(verdict.merged, true);
+  assert.equal(exitCode, 0);
+});
+
+test('#2453 localHeadDrift is also computed in dry-run, without affecting readiness', () => {
+  const { deps } = depsFor(readyReport(), {
+    getLocalHeadState: () => ({
+      branch: 'issue/994-fix-thing',
+      headSha: DRIFTED,
+    }),
+    fetchHeadRefName: () => 'issue/994-fix-thing',
+  });
+  const { verdict, exitCode } = runMergeExecute(BASE_ARGS, deps);
+
+  assert.equal(verdict.mode, 'dry-run');
+  assert.equal(verdict.ready, true);
+  assert.deepEqual(verdict.localHeadDrift, {
+    localHeadSha: DRIFTED,
+    remoteHeadSha: HEAD,
+  });
   assert.equal(exitCode, 0);
 });
 

--- a/tests/idd-merge-execute.test.mts
+++ b/tests/idd-merge-execute.test.mts
@@ -566,7 +566,10 @@ test('#2453 localHeadDrift stays null and never throws when getLocalHeadState it
     },
   });
 
-  assert.doesNotThrow(() => runMergeExecute([...BASE_ARGS, '--apply'], deps));
+  // A throw here fails the test on its own (uncaught exception) -- no
+  // separate assert.doesNotThrow needed, and calling runMergeExecute only
+  // once avoids a second, redundant --apply merge attempt against the
+  // same deps (Copilot review, PR #2496).
   const { verdict, exitCode } = runMergeExecute(
     [...BASE_ARGS, '--apply'],
     deps,

--- a/tests/schema-output-roundtrip.test.mts
+++ b/tests/schema-output-roundtrip.test.mts
@@ -620,6 +620,61 @@ test('idd-merge-execute: runMergeExecute output validates against schema', () =>
   assertRoundtrip(verdict, loadJson('schemas/idd-merge-execute.schema.json'));
 });
 
+test('idd-merge-execute: a non-null localHeadDrift verdict validates against schema (#2453)', () => {
+  const HEAD = '1111111111111111111111111111111111111111';
+  const DRIFTED = '2222222222222222222222222222222222222222';
+  const report: Record<string, unknown> = {
+    prHeadSha: HEAD,
+    reviewCurrency: { comparisonRoute: 'proceed', comparisonReason: 'match' },
+    threads: { actionableCount: 0 },
+    advisoryWait: { f3Outcome: 'SATISFIED' },
+    ci: {
+      status: 'success',
+      requiredChecksPassing: true,
+      noRequiredChecksConfigured: false,
+      presentRunConclusion: 'all-passing',
+    },
+    reviewerStates: {
+      requiredApprovalsSatisfied: true,
+      codeownerApprovalSatisfied: true,
+      codeownerSelfApproval: { status: 'not_applicable' },
+    },
+    claim: { matchesExpectedClaim: true, reason: 'match' },
+    dispositionEvidence: { route: 'proceed', blockingCount: 0 },
+    branchCurrency: {
+      mergeStateStatus: 'CLEAN',
+      mergeable: 'MERGEABLE',
+      requiresUpToDateHead: false,
+      requiresUpToDateHeadSource: 'none',
+    },
+  };
+  const deps: MergeExecuteDeps = {
+    collect: () => report,
+    fetchHeadSha: () => HEAD,
+    fetchMergeState: () => ({
+      mergeable: 'MERGEABLE',
+      mergeStateStatus: 'CLEAN',
+    }),
+    mergePr: () => 'Merged PR.',
+    mergePrAdmin: () => 'Merged PR (admin).',
+    resolveSoloCodeownerAdminFallbackMode: () => 'auto-admin-retry',
+    getLocalHeadState: () => ({
+      branch: 'issue/994-fix-thing',
+      headSha: DRIFTED,
+    }),
+    fetchHeadRefName: () => 'issue/994-fix-thing',
+  };
+  const { verdict } = runMergeExecute(
+    ['--pr', '994', '--claim-issue', '309', '--claim-id', 'c-1'],
+    deps,
+  );
+  assert.deepEqual(verdict.localHeadDrift, {
+    localHeadSha: DRIFTED,
+    remoteHeadSha: HEAD,
+  });
+  assertRoundtrip(verdict, loadJson('schemas/idd-merge-execute.schema.json'));
+});
+
 test('idd-roadmap-audit-execute: runRoadmapAuditExecute output validates against schema', async () => {
   const ROADMAP = 995;
   const report: RoadmapGraphReport = {

--- a/tests/schema-output-roundtrip.test.mts
+++ b/tests/schema-output-roundtrip.test.mts
@@ -610,6 +610,8 @@ test('idd-merge-execute: runMergeExecute output validates against schema', () =>
     mergePr: () => 'Merged PR.',
     mergePrAdmin: () => 'Merged PR (admin).',
     resolveSoloCodeownerAdminFallbackMode: () => 'auto-admin-retry',
+    getLocalHeadState: () => ({ branch: null, headSha: null }),
+    fetchHeadRefName: () => '',
   };
   const { verdict } = runMergeExecute(
     ['--pr', '994', '--claim-issue', '309', '--claim-id', 'c-1'],

--- a/tests/schema-type-reconciliation.test.mts
+++ b/tests/schema-type-reconciliation.test.mts
@@ -407,6 +407,7 @@ export const iddMergeExecuteKeys = [
   'merged',
   'mergeResult',
   'adminFallbackUsed',
+  'localHeadDrift',
 ] as const satisfies readonly (keyof IddMergeExecuteVerdict)[];
 
 export const iddRoadmapAuditExecuteKeys = [
@@ -1025,6 +1026,7 @@ const iddMergeExecuteFixture = {
   merged: false,
   mergeResult: '',
   adminFallbackUsed: false,
+  localHeadDrift: null,
 } satisfies IddMergeExecuteVerdict;
 
 const iddRoadmapAuditExecuteFixture = {


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Adds a best-effort, advisory-only local-head-drift check to
`runMergeExecute`'s `--apply` path (`src/scripts/idd-merge-execute.mts`,
`#2453`). When the invoking worktree's local git branch equals the PR's
own `headRefName` but its local HEAD differs from the `prHeadSha` about
to merge, the verdict's new `localHeadDrift` field is set to
`{ localHeadSha, remoteHeadSha }` and a warning is printed on stderr —
the exact signature of an unpushed commit about to be silently left
behind (the `#2267` incident this issue cites). It never gates `ready`
or blocks the merge, and is a silent no-op from any other directory,
branch, or on any local/remote read failure.

`idd-merge-execute.mts` is already migrated onto `provider-port.mts`
(`#2266`/`#2267`), so `headRefName` is fetched through a new
`getChangeRequestHeadRefNameAtRepo` port method (mirroring the existing
`getChangeRequestHeadShaAtRepo` cross-repo method) rather than a direct
`gh-exec.mts` call — `provider-port-migration-guard.test.mts` forbids
the latter for already-migrated helpers.

Also updates `schemas/idd-merge-execute.schema.json`, its canonical
fixture, the `schema-type-reconciliation`/`schema-output-roundtrip`
tests, and `docs/idd-helper-scripts.md` (+ its `idd-template/` mirror)
for the new verdict field.

## Linked issue

Closes #2453

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`idd-merge-execute.mts` already re-validates the **remote** PR head
immediately before merging, but had no check against the **local** git
state of the invoking process — the exact gap that let a locally
committed-but-unpushed fix silently ship one commit short in `#2267`.
This check closes that visibility gap without adding a new fail-closed
gate an operator cannot override (a legitimate reason can exist for the
divergence, e.g. a rebase in progress).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [x] Security / credential / merge behavior changed (advisory-only
      addition to the F3 merge-execution helper; no gate/behavior change
      to `ready`/`blockers`/the merge decision itself)

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4740/4740 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added advisory local HEAD drift detection to merge execution.
  - Merge verdicts now report differing local and remote commit SHAs when applicable.
  - Warnings are printed to stderr without affecting merge readiness or execution.
  - Added support for retrieving pull request branch names across repositories.

- **Documentation**
  - Documented local HEAD drift behavior for dry-run and apply modes.
  - Updated CLI help text with the new warning.

- **Tests**
  - Added coverage for matching, differing, unavailable, and cross-repository branch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->