### PR TITLE
fix(cli-args): strip leading -- in the 5 excluded custom parsers

### DIFF
--- a/scripts/cli-args.mjs
+++ b/scripts/cli-args.mjs
@@ -359,6 +359,30 @@ function isShapedMessage(message) {
   );
 }
 /**
+ * Strip a single leading `--` end-of-options marker pnpm forwards through a
+ * `pnpm run <script> -- <flags>` alias without consuming it first (#1921),
+ * so a pnpm-forwarded invocation parses the same as the equivalent bare
+ * form. `parseCliArgs` applies this internally; a hand-rolled parser
+ * excluded from that wrapper (#2465) must call this directly on its own
+ * `argv` before parsing, since it never goes through `parseCliArgs` at all.
+ * Scope is deliberately one token at position 0 only; a `--` anywhere else
+ * in argv keeps its current behavior unchanged.
+ *
+ * A second literal `--` immediately after the stripped one (i.e. argv
+ * started `--`, `--`, ...) must still be a hard error, not silently
+ * swallowed -- without this guard, stripping once would leave a lone
+ * trailing `--` for a caller's own parser to consume as an end-of-options
+ * marker with zero positionals, a new silent-success hole. The strip above
+ * never repeats -- this is a single explicit check, not a loop.
+ */
+export function stripLeadingArgumentSeparator(argv) {
+  const args = argv[0] === '--' ? argv.slice(1) : argv;
+  if (args[0] === '--') {
+    throw new Error(`${UNKNOWN_ARGUMENT_PREFIX}--`);
+  }
+  return args;
+}
+/**
  * Parse `argv` against a declarative flag spec, using `util.parseArgs`
  * under `strict: true` / `allowPositionals: false`. Throws an `Error`
  * shaped in this repository's existing idiom (never Node's native
@@ -375,28 +399,11 @@ export function parseCliArgs(argv, spec) {
     }
     nodeOptions[dashedKey.slice(2)] = flagSpec;
   }
-  // #1921: pnpm forwards a literal `--` through a `pnpm run <script> --
-  // <flags>` alias without stripping it first (unlike `npm run`, which
-  // consumes its own separator before the script ever sees argv). Node's
-  // `util.parseArgs` treats that leading `--` as the conventional
-  // end-of-options marker, so every flag after it gets rejected as an
-  // unexpected positional under `allowPositionals: false` -- strip
-  // exactly one leading `--` here so a pnpm-forwarded invocation parses
-  // the same as the equivalent bare form. Scope is deliberately one
-  // token at position 0 only; a `--` anywhere else in argv keeps its
-  // current behavior unchanged.
-  const args = argv[0] === '--' ? argv.slice(1) : argv;
-  // A second literal `--` immediately after the stripped one (i.e. argv
-  // started `--`, `--`, ...) must still be a hard error, not silently
-  // swallowed. Without this guard, stripping once would leave a lone
-  // trailing `--` for Node to consume as its own terminator with zero
-  // positionals -- a NEW silent-success hole `parseCliArgs(['--', '--'],
-  // spec)` does not have today (it currently throws `unknown argument:
-  // --`, since the second `--` becomes a rejected positional). The strip
-  // above never repeats -- this is a single explicit check, not a loop.
-  if (args[0] === '--') {
-    throw new Error(`${UNKNOWN_ARGUMENT_PREFIX}--`);
-  }
+  // #1921: Node's `util.parseArgs` treats a pnpm-forwarded leading `--` as
+  // the conventional end-of-options marker, rejecting every flag after it
+  // as an unexpected positional under `allowPositionals: false` -- see
+  // stripLeadingArgumentSeparator's own doc comment for the full rationale.
+  const args = stripLeadingArgumentSeparator(argv);
   let parsed;
   try {
     parsed = nodeParseArgs({

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -14,6 +14,7 @@ import {
   parseAutopilotSuitability,
   rankAndRouteBySuitability,
 } from './autopilot-suitability.mjs';
+import { stripLeadingArgumentSeparator } from './cli-args.mjs';
 import {
   extractBlockedByIssueNumbers,
   extractDependencyIssueNumbers,
@@ -425,7 +426,11 @@ async function runCli() {
 // not itself look like another flag. `util.parseArgs` cannot express this:
 // a `string`-type option always requires exactly one value and a
 // `boolean`-type option never takes one; there is no in-between mode.
-function parseArgs(argv) {
+function parseArgs(rawArgv) {
+  // #1921/#2465: strip a pnpm-forwarded leading `--` the same way the
+  // shared cli-args.mts wrapper does -- this parser is excluded from that
+  // wrapper (see the comment above) so it must call the strip directly.
+  const argv = stripLeadingArgumentSeparator(rawArgv);
   const parsed = {
     owner: '',
     repo: '',

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -10,6 +10,7 @@ import {
   normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitability,
 } from './autopilot-suitability.mjs';
+import { stripLeadingArgumentSeparator } from './cli-args.mjs';
 import {
   buildRoadmapMarkerResolver,
   evaluateDiscoverReadiness,
@@ -1617,7 +1618,11 @@ function normalizeSubIssueNumbers(subIssues) {
 // cannot express this: a `string`-type option always requires exactly one
 // value and a `boolean`-type option never takes one; there is no
 // in-between mode.
-function parseArgs(argv) {
+function parseArgs(rawArgv) {
+  // #1921/#2465: strip a pnpm-forwarded leading `--` the same way the
+  // shared cli-args.mts wrapper does -- this parser is excluded from that
+  // wrapper (see the comment above) so it must call the strip directly.
+  const argv = stripLeadingArgumentSeparator(rawArgv);
   const parsed = {
     issue: 0,
     allRoadmaps: false,

--- a/scripts/emit-marker.mjs
+++ b/scripts/emit-marker.mjs
@@ -10,7 +10,7 @@
 // ready-to-post body string to stdout and performs NO network write; the
 // agent posts it via the documented HTTP path. The render logic lives in
 // protocol-helpers; this is the thin CLI surface.
-import { requireFlag } from './cli-args.mjs';
+import { requireFlag, stripLeadingArgumentSeparator } from './cli-args.mjs';
 import {
   renderClaimedByMarker,
   renderReviewBaselineMarker,
@@ -85,7 +85,11 @@ function runCli() {
 // named in its static spec, and `strict: false` would instead coerce every
 // unrecognized flag to `true` -- neither matches this file's "accept
 // whatever field this marker type needs" contract.
-function parseArgs(argv) {
+function parseArgs(rawArgv) {
+  // #1921/#2465: strip a pnpm-forwarded leading `--` the same way the
+  // shared cli-args.mts wrapper does -- this parser is excluded from that
+  // wrapper (see the comment above) so it must call the strip directly.
+  const argv = stripLeadingArgumentSeparator(rawArgv);
   const parsed = { type: '', help: false };
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];

--- a/scripts/idd-merge-execute.mjs
+++ b/scripts/idd-merge-execute.mjs
@@ -495,6 +495,19 @@ function revalidateImmediatelyBeforeMerge(
 // instead coerce every unrecognized flag to `true` -- neither matches this
 // file's "collect and forward whatever the collector itself accepts"
 // contract.
+//
+// #2465: unlike the other five custom parsers excluded from the shared
+// wrapper, this one needs no explicit `stripLeadingArgumentSeparator` call
+// of its own. A pnpm-forwarded leading `--` matches none of the named
+// flags below, so it falls through to the generic `startsWith('--')`
+// passthrough branch and is pushed into `passthrough` verbatim, at
+// position 0. That array is forwarded in-process to
+// `collectPreMergeReadiness` (`deps.collect`), whose own `parseArgs` goes
+// through `parseCliArgs` -- the shared wrapper this file itself is
+// excluded from -- which strips the leading `--` there instead. This
+// immunity is deliberate, not incidental: it depends on the collector
+// always being invoked through `parseCliArgs`, so re-verify this comment
+// (or add an explicit strip here too) if that call path ever changes.
 function parseArgs(argv) {
   const parsed = {
     prNumber: null,

--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -51,6 +51,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { stripLeadingArgumentSeparator } from './cli-args.mjs';
 import { safeGhText } from './gh-exec.mjs';
 import {
   collectHelperRuntimeEvidence,
@@ -2109,7 +2110,11 @@ if (import.meta.main) {
 // -- the accepted flag set is built from a runtime table, not a fixed spec
 // declared in source. A static cli-args.mts spec object cannot represent a
 // flag set that is only known once that table is read.
-function parseArgs(argv) {
+function parseArgs(rawArgv) {
+  // #1921/#2465: strip a pnpm-forwarded leading `--` the same way the
+  // shared cli-args.mts wrapper does -- this parser is excluded from that
+  // wrapper (see the comment above) so it must call the strip directly.
+  const argv = stripLeadingArgumentSeparator(rawArgv);
   const parsed = {
     substitute: false,
     importMode: false,

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -18,7 +18,7 @@
 // manual POST path it replaces already requires.
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
-import { requireFlag } from './cli-args.mjs';
+import { requireFlag, stripLeadingArgumentSeparator } from './cli-args.mjs';
 import {
   renderActivationNonceMarker,
   renderAdvisoryRerollMarker,
@@ -313,7 +313,11 @@ function parsePositiveIntToken(token, label) {
 // `strict: false` would instead coerce every unrecognized flag to `true`
 // -- neither matches this file's "accept whatever fields this marker type
 // needs" contract.
-export function parseArgs(argv) {
+export function parseArgs(rawArgv) {
+  // #1921/#2465: strip a pnpm-forwarded leading `--` the same way the
+  // shared cli-args.mts wrapper does -- this parser is excluded from that
+  // wrapper (see the comment above) so it must call the strip directly.
+  const argv = stripLeadingArgumentSeparator(rawArgv);
   const args = {
     type: '',
     target: '',

--- a/src/scripts/cli-args.mts
+++ b/src/scripts/cli-args.mts
@@ -427,6 +427,33 @@ function isShapedMessage(message: string): boolean {
 }
 
 /**
+ * Strip a single leading `--` end-of-options marker pnpm forwards through a
+ * `pnpm run <script> -- <flags>` alias without consuming it first (#1921),
+ * so a pnpm-forwarded invocation parses the same as the equivalent bare
+ * form. `parseCliArgs` applies this internally; a hand-rolled parser
+ * excluded from that wrapper (#2465) must call this directly on its own
+ * `argv` before parsing, since it never goes through `parseCliArgs` at all.
+ * Scope is deliberately one token at position 0 only; a `--` anywhere else
+ * in argv keeps its current behavior unchanged.
+ *
+ * A second literal `--` immediately after the stripped one (i.e. argv
+ * started `--`, `--`, ...) must still be a hard error, not silently
+ * swallowed -- without this guard, stripping once would leave a lone
+ * trailing `--` for a caller's own parser to consume as an end-of-options
+ * marker with zero positionals, a new silent-success hole. The strip above
+ * never repeats -- this is a single explicit check, not a loop.
+ */
+export function stripLeadingArgumentSeparator(
+  argv: readonly string[],
+): readonly string[] {
+  const args = argv[0] === '--' ? argv.slice(1) : argv;
+  if (args[0] === '--') {
+    throw new Error(`${UNKNOWN_ARGUMENT_PREFIX}--`);
+  }
+  return args;
+}
+
+/**
  * Parse `argv` against a declarative flag spec, using `util.parseArgs`
  * under `strict: true` / `allowPositionals: false`. Throws an `Error`
  * shaped in this repository's existing idiom (never Node's native
@@ -455,28 +482,11 @@ export function parseCliArgs(
     nodeOptions[dashedKey.slice(2)] = flagSpec;
   }
 
-  // #1921: pnpm forwards a literal `--` through a `pnpm run <script> --
-  // <flags>` alias without stripping it first (unlike `npm run`, which
-  // consumes its own separator before the script ever sees argv). Node's
-  // `util.parseArgs` treats that leading `--` as the conventional
-  // end-of-options marker, so every flag after it gets rejected as an
-  // unexpected positional under `allowPositionals: false` -- strip
-  // exactly one leading `--` here so a pnpm-forwarded invocation parses
-  // the same as the equivalent bare form. Scope is deliberately one
-  // token at position 0 only; a `--` anywhere else in argv keeps its
-  // current behavior unchanged.
-  const args = argv[0] === '--' ? argv.slice(1) : argv;
-  // A second literal `--` immediately after the stripped one (i.e. argv
-  // started `--`, `--`, ...) must still be a hard error, not silently
-  // swallowed. Without this guard, stripping once would leave a lone
-  // trailing `--` for Node to consume as its own terminator with zero
-  // positionals -- a NEW silent-success hole `parseCliArgs(['--', '--'],
-  // spec)` does not have today (it currently throws `unknown argument:
-  // --`, since the second `--` becomes a rejected positional). The strip
-  // above never repeats -- this is a single explicit check, not a loop.
-  if (args[0] === '--') {
-    throw new Error(`${UNKNOWN_ARGUMENT_PREFIX}--`);
-  }
+  // #1921: Node's `util.parseArgs` treats a pnpm-forwarded leading `--` as
+  // the conventional end-of-options marker, rejecting every flag after it
+  // as an unexpected positional under `allowPositionals: false` -- see
+  // stripLeadingArgumentSeparator's own doc comment for the full rationale.
+  const args = stripLeadingArgumentSeparator(argv);
 
   let parsed: ReturnType<typeof nodeParseArgs>;
   try {

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -15,6 +15,7 @@ import {
   parseAutopilotSuitability,
   rankAndRouteBySuitability,
 } from './autopilot-suitability.mts';
+import { stripLeadingArgumentSeparator } from './cli-args.mts';
 import {
   extractBlockedByIssueNumbers,
   extractDependencyIssueNumbers,
@@ -622,7 +623,11 @@ async function runCli() {
 // not itself look like another flag. `util.parseArgs` cannot express this:
 // a `string`-type option always requires exactly one value and a
 // `boolean`-type option never takes one; there is no in-between mode.
-function parseArgs(argv: string[]): ParsedArgs {
+function parseArgs(rawArgv: string[]): ParsedArgs {
+  // #1921/#2465: strip a pnpm-forwarded leading `--` the same way the
+  // shared cli-args.mts wrapper does -- this parser is excluded from that
+  // wrapper (see the comment above) so it must call the strip directly.
+  const argv = stripLeadingArgumentSeparator(rawArgv);
   const parsed: ParsedArgs = {
     owner: '',
     repo: '',

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -11,6 +11,7 @@ import {
   normalizeAutopilotSuitabilityFloor,
   parseAutopilotSuitability,
 } from './autopilot-suitability.mts';
+import { stripLeadingArgumentSeparator } from './cli-args.mts';
 import {
   buildRoadmapMarkerResolver,
   evaluateDiscoverReadiness,
@@ -2277,7 +2278,11 @@ function normalizeSubIssueNumbers(subIssues: unknown): number[] {
 // cannot express this: a `string`-type option always requires exactly one
 // value and a `boolean`-type option never takes one; there is no
 // in-between mode.
-function parseArgs(argv: string[]): ParsedArgs {
+function parseArgs(rawArgv: string[]): ParsedArgs {
+  // #1921/#2465: strip a pnpm-forwarded leading `--` the same way the
+  // shared cli-args.mts wrapper does -- this parser is excluded from that
+  // wrapper (see the comment above) so it must call the strip directly.
+  const argv = stripLeadingArgumentSeparator(rawArgv);
   const parsed: ParsedArgs = {
     issue: 0,
     allRoadmaps: false,

--- a/src/scripts/emit-marker.mts
+++ b/src/scripts/emit-marker.mts
@@ -11,7 +11,7 @@
 // agent posts it via the documented HTTP path. The render logic lives in
 // protocol-helpers; this is the thin CLI surface.
 
-import { requireFlag } from './cli-args.mts';
+import { requireFlag, stripLeadingArgumentSeparator } from './cli-args.mts';
 import {
   renderClaimedByMarker,
   renderReviewBaselineMarker,
@@ -97,7 +97,11 @@ interface ParsedArgs {
 // named in its static spec, and `strict: false` would instead coerce every
 // unrecognized flag to `true` -- neither matches this file's "accept
 // whatever field this marker type needs" contract.
-function parseArgs(argv: string[]): ParsedArgs {
+function parseArgs(rawArgv: string[]): ParsedArgs {
+  // #1921/#2465: strip a pnpm-forwarded leading `--` the same way the
+  // shared cli-args.mts wrapper does -- this parser is excluded from that
+  // wrapper (see the comment above) so it must call the strip directly.
+  const argv = stripLeadingArgumentSeparator(rawArgv);
   const parsed: ParsedArgs = { type: '', help: false };
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];

--- a/src/scripts/idd-merge-execute.mts
+++ b/src/scripts/idd-merge-execute.mts
@@ -663,6 +663,19 @@ function revalidateImmediatelyBeforeMerge(
 // instead coerce every unrecognized flag to `true` -- neither matches this
 // file's "collect and forward whatever the collector itself accepts"
 // contract.
+//
+// #2465: unlike the other five custom parsers excluded from the shared
+// wrapper, this one needs no explicit `stripLeadingArgumentSeparator` call
+// of its own. A pnpm-forwarded leading `--` matches none of the named
+// flags below, so it falls through to the generic `startsWith('--')`
+// passthrough branch and is pushed into `passthrough` verbatim, at
+// position 0. That array is forwarded in-process to
+// `collectPreMergeReadiness` (`deps.collect`), whose own `parseArgs` goes
+// through `parseCliArgs` -- the shared wrapper this file itself is
+// excluded from -- which strips the leading `--` there instead. This
+// immunity is deliberate, not incidental: it depends on the collector
+// always being invoked through `parseCliArgs`, so re-verify this comment
+// (or add an explicit strip here too) if that call path ever changes.
 function parseArgs(argv: string[]): IddMergeExecuteArgs {
   const parsed: IddMergeExecuteArgs = {
     prNumber: null,

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -53,6 +53,7 @@ import {
 } from 'node:fs';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 
+import { stripLeadingArgumentSeparator } from './cli-args.mts';
 import { safeGhText } from './gh-exec.mts';
 import {
   collectHelperRuntimeEvidence,
@@ -2641,7 +2642,11 @@ interface ParsedArgs {
 // -- the accepted flag set is built from a runtime table, not a fixed spec
 // declared in source. A static cli-args.mts spec object cannot represent a
 // flag set that is only known once that table is read.
-function parseArgs(argv: string[]): ParsedArgs {
+function parseArgs(rawArgv: string[]): ParsedArgs {
+  // #1921/#2465: strip a pnpm-forwarded leading `--` the same way the
+  // shared cli-args.mts wrapper does -- this parser is excluded from that
+  // wrapper (see the comment above) so it must call the strip directly.
+  const argv = stripLeadingArgumentSeparator(rawArgv);
   const parsed: ParsedArgs = {
     substitute: false,
     importMode: false,

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -20,7 +20,7 @@
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 
-import { requireFlag } from './cli-args.mts';
+import { requireFlag, stripLeadingArgumentSeparator } from './cli-args.mts';
 import {
   renderActivationNonceMarker,
   renderAdvisoryRerollMarker,
@@ -396,7 +396,11 @@ function parsePositiveIntToken(token: string, label: string): number {
 // `strict: false` would instead coerce every unrecognized flag to `true`
 // -- neither matches this file's "accept whatever fields this marker type
 // needs" contract.
-export function parseArgs(argv: string[]): CliArgs {
+export function parseArgs(rawArgv: string[]): CliArgs {
+  // #1921/#2465: strip a pnpm-forwarded leading `--` the same way the
+  // shared cli-args.mts wrapper does -- this parser is excluded from that
+  // wrapper (see the comment above) so it must call the strip directly.
+  const argv = stripLeadingArgumentSeparator(rawArgv);
   const args: CliArgs = {
     type: '',
     target: '',

--- a/tests/cli-args.test.mts
+++ b/tests/cli-args.test.mts
@@ -7,6 +7,7 @@ import {
   parseCanonicalIntegerOrThrow,
   parseCliArgs,
   requireFlag,
+  stripLeadingArgumentSeparator,
 } from '../src/scripts/cli-args.mts';
 
 const SAMPLE_SPEC = {
@@ -264,6 +265,32 @@ test('parseCliArgs: a -- appearing anywhere other than index 0 keeps its current
   // -- this must stay unchanged by the leading-only strip above.
   const { values } = parseCliArgs(['--pr', '7', '--'], SAMPLE_SPEC);
   assert.equal(values.pr, '7');
+});
+
+// --- stripLeadingArgumentSeparator (#2465) -----------------------------------
+// The five custom parsers excluded from the parseCliArgs wrapper above (see
+// post-idd-marker.mts, emit-marker.mts, discover-orphan-filter.mts,
+// discover-roadmap-graph.mts, idd-onboard.mts) each call this directly, so
+// it needs its own direct coverage independent of parseCliArgs's tests.
+
+test('stripLeadingArgumentSeparator: strips exactly one leading --', () => {
+  assert.deepEqual(stripLeadingArgumentSeparator(['--', '--help']), ['--help']);
+});
+
+test('stripLeadingArgumentSeparator: is a no-op when there is no leading --', () => {
+  const argv = ['--pr', '7'];
+  assert.deepEqual(stripLeadingArgumentSeparator(argv), argv);
+});
+
+test('stripLeadingArgumentSeparator: a doubled leading -- -- still throws (the strip never repeats)', () => {
+  assert.throws(() => stripLeadingArgumentSeparator(['--', '--', '--help']), {
+    message: 'unknown argument: --',
+  });
+});
+
+test('stripLeadingArgumentSeparator: a -- appearing anywhere other than index 0 is left untouched', () => {
+  const argv = ['--pr', '7', '--'];
+  assert.deepEqual(stripLeadingArgumentSeparator(argv), argv);
 });
 
 // --- parseCanonicalIntegerOrThrow / parseCanonicalIntegerOrNull -------------

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -634,6 +634,41 @@ test('parseArgs reads structural flags, the positional number, and renderer fiel
   });
 });
 
+test('parseArgs strips a pnpm-forwarded leading -- (#2465), parsing identically to the bare form', () => {
+  // This parser is excluded from the shared cli-args.mts parseCliArgs
+  // wrapper (see the comment above its declaration), so it must call
+  // stripLeadingArgumentSeparator directly rather than inheriting the
+  // wrapper's own #1921 stripping.
+  const withSeparator = parseArgs([
+    '--',
+    '--type',
+    'claim',
+    '--target',
+    'issue',
+    '1047',
+    '--agent-id',
+    'claude-417b737f',
+    '--claim-id',
+    'c3009f22b5f6',
+    '--branch',
+    'issue/1047-foo',
+  ]);
+  const bare = parseArgs([
+    '--type',
+    'claim',
+    '--target',
+    'issue',
+    '1047',
+    '--agent-id',
+    'claude-417b737f',
+    '--claim-id',
+    'c3009f22b5f6',
+    '--branch',
+    'issue/1047-foo',
+  ]);
+  assert.deepEqual(withSeparator, bare);
+});
+
 test('parseArgs rejects a second positional, non-numeric, and suffixed numbers', () => {
   assert.throws(() => parseArgs(['1047', '2048']), /unexpected positional/);
   assert.throws(() => parseArgs(['not-a-number']), /invalid issue\/PR number/);


### PR DESCRIPTION
# Summary

`#1921` fixed pnpm's leading-`--`-forwarding footgun (`pnpm run <script>
-- --flag`) only inside the shared `cli-args.mts` `parseCliArgs`
wrapper. Five hand-rolled parsers documented as excluded from that
wrapper for legitimate passthrough/dynamic-flag reasons still threw on
a leading `--` (`post-idd-marker.mts`, `emit-marker.mts`,
`discover-orphan-filter.mts`, `discover-roadmap-graph.mts`,
`idd-onboard.mts`).

This extracts the stripping step into a new exported
`stripLeadingArgumentSeparator(argv)` helper in `cli-args.mts` (called
internally by `parseCliArgs` itself, no behavior change there) and
calls it directly from each of the five affected parsers' own
`parseArgs` functions. `idd-merge-execute.mts` (the sixth candidate
file) needed no code change -- its existing behavior is already immune
via a downstream re-parse (a leading `--` falls through its own
generic passthrough branch and is forwarded to the
`pre-merge-readiness` collector, which itself goes through
`parseCliArgs`); this adds a comment documenting that immunity is
deliberate, not incidental, per the issue's own acceptance criteria.

## Linked issue

Closes #2465

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

All five originally-broken commands were live-reproduced before the
fix and confirmed fixed after: `post-idd-marker.mjs -- --type claim
...`, `emit-marker.mjs -- --help`, `discover-orphan-filter.mjs --
--help`, `discover-roadmap-graph.mjs -- --help`, and `idd-onboard.mjs
-- --help` all now behave identically to their bare (no `--`) form.
`idd-merge-execute.mjs -- --help` was also re-verified unchanged.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4743/4743 pass, including 4 new direct unit tests
      for `stripLeadingArgumentSeparator` and 1 regression test
      comparing a `--`-prefixed invocation against the bare form)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed; pre-existing warnings
      unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (none)
