### PR TITLE
fix(token-cost): refuse --apply on the default branch without an explicit override

### DIFF
--- a/docs/token-cost.md
+++ b/docs/token-cost.md
@@ -114,6 +114,13 @@ mismatched/contaminated one in the meantime.
   `#2294`'s implementation notes), and the fix belongs to a separate,
   deliberate byte-budget decision rather than this reporter's own
   scope.
+- `--apply` is also cwd-sensitive, the same way `token-cost-harvest.mjs`
+  is above: it refuses to run while the current branch is the
+  repository's default branch, since a stray `--apply` left dirty on
+  the shared primary worktree's `main` can block every concurrent
+  session's next B1 `git merge --ff-only` worktree creation (`#2452`).
+  Pass `--allow-default-branch` for an intentional maintainer run from
+  the primary worktree; `--apply` from an issue worktree is unaffected.
 
 A snapshot is `publishable` only once it has at least 10 issue-loop
 samples across at least 2 distinct vendors. Below that gate, the

--- a/scripts/token-cost-report.mjs
+++ b/scripts/token-cost-report.mjs
@@ -14,6 +14,7 @@
 // HELPER_COMMANDS: this is a maintainer/CI-only dogfood tool, never an
 // adopter-facing helper (see SOURCE_REPO_INTERNAL_ENTRY_PATHS in
 // tests/helper-invocation-profile.test.mts).
+import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { parseCliArgs } from './cli-args.mjs';
 import {
@@ -419,6 +420,47 @@ export function replaceMarkedRegion(
   const after = text.slice(endIndex);
   return `${before}\n\n${innerContent}\n\n${after}`;
 }
+const defaultBranchGuardDeps = {
+  getCurrentBranch: () =>
+    execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim(),
+  getDefaultBranch: () => {
+    try {
+      return execFileSync(
+        'git',
+        ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+      )
+        .trim()
+        .replace(/^origin\//, '');
+    } catch {
+      return 'main';
+    }
+  },
+};
+/**
+ * #2452: refuse `--apply` on the repository's default branch unless
+ * `--allow-default-branch` was passed. Running the aggregator from the
+ * shared PRIMARY worktree while it happens to be checked out on the
+ * default branch leaves dirty, uncommitted output sitting there, which can
+ * block every concurrent session's next B1 `git merge --ff-only` worktree
+ * creation (a footgun already hit once during #2439). The caller must run
+ * this before any write.
+ */
+export function resolveDefaultBranchGuard(
+  allowOverride,
+  deps = defaultBranchGuardDeps,
+) {
+  const currentBranch = deps.getCurrentBranch();
+  const defaultBranch = deps.getDefaultBranch();
+  return {
+    blocked: !allowOverride && currentBranch === defaultBranch,
+    currentBranch,
+    defaultBranch,
+  };
+}
 // ---------------------------------------------------------------------------
 // Apply / check
 // ---------------------------------------------------------------------------
@@ -503,6 +545,7 @@ const TOKEN_COST_REPORT_FLAG_SPEC = {
   '--snapshot': { type: 'string', default: DEFAULT_SNAPSHOT_PATH },
   '--apply': { type: 'boolean', default: false },
   '--check': { type: 'boolean', default: false },
+  '--allow-default-branch': { type: 'boolean', default: false },
   '--now': { type: 'string', default: '' },
   '--help': { type: 'boolean', short: 'h' },
 };
@@ -517,7 +560,12 @@ function printHelp() {
   --snapshot <path>   Snapshot artifact path (default: ${DEFAULT_SNAPSHOT_PATH}).
   --apply             Aggregate --in samples, write the snapshot, and
                       refresh the README.md / README.ja.md / docs/token-cost.md
-                      marked regions.
+                      marked regions. Refused when the current branch is
+                      the repository's default branch; pass
+                      --allow-default-branch to proceed anyway.
+  --allow-default-branch  Allow --apply to run while the current branch is
+                          the repository's default branch (refused by
+                          default -- see docs/token-cost.md).
   --check             Verify the committed snapshot's regions have not
                       drifted from README.md / README.ja.md / docs/token-cost.md.
                       Exits non-zero on drift. Does not read --in.
@@ -552,6 +600,13 @@ if (import.meta.main) {
     }
   }
   if (apply) {
+    const guard = resolveDefaultBranchGuard(values['allow-default-branch']);
+    if (guard.blocked) {
+      process.stderr.write(
+        `token-cost-report --apply: refusing to run on the repository's default branch "${guard.defaultBranch}" (current branch: "${guard.currentBranch}"). Pass --allow-default-branch to override.\n`,
+      );
+      process.exit(2);
+    }
     const inPaths = values.in ?? [];
     if (inPaths.length === 0) {
       process.stderr.write(

--- a/src/scripts/token-cost-report.mts
+++ b/src/scripts/token-cost-report.mts
@@ -15,6 +15,7 @@
 // adopter-facing helper (see SOURCE_REPO_INTERNAL_ENTRY_PATHS in
 // tests/helper-invocation-profile.test.mts).
 
+import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { parseCliArgs } from './cli-args.mts';
 import {
@@ -482,6 +483,69 @@ export function replaceMarkedRegion(
 }
 
 // ---------------------------------------------------------------------------
+// Default-branch guard (#2452)
+// ---------------------------------------------------------------------------
+
+/** Injectable local git reads backing {@link resolveDefaultBranchGuard} --
+ * this script has zero subprocess calls otherwise and stays offline-capable;
+ * tests substitute both to drive every branch of the guard without a real
+ * git checkout. */
+export interface DefaultBranchGuardDeps {
+  /** `git rev-parse --abbrev-ref HEAD`, trimmed. */
+  getCurrentBranch: () => string;
+  /**
+   * The repository's default branch name. Real implementation resolves
+   * `git symbolic-ref --short refs/remotes/origin/HEAD` (stripping the
+   * `origin/` prefix), falling back to `'main'` when that ref is unset
+   * locally (e.g. a clone that never ran `git remote set-head origin -a`).
+   */
+  getDefaultBranch: () => string;
+}
+
+const defaultBranchGuardDeps: DefaultBranchGuardDeps = {
+  getCurrentBranch: () =>
+    execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim(),
+  getDefaultBranch: () => {
+    try {
+      return execFileSync(
+        'git',
+        ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+      )
+        .trim()
+        .replace(/^origin\//, '');
+    } catch {
+      return 'main';
+    }
+  },
+};
+
+/**
+ * #2452: refuse `--apply` on the repository's default branch unless
+ * `--allow-default-branch` was passed. Running the aggregator from the
+ * shared PRIMARY worktree while it happens to be checked out on the
+ * default branch leaves dirty, uncommitted output sitting there, which can
+ * block every concurrent session's next B1 `git merge --ff-only` worktree
+ * creation (a footgun already hit once during #2439). The caller must run
+ * this before any write.
+ */
+export function resolveDefaultBranchGuard(
+  allowOverride: boolean,
+  deps: DefaultBranchGuardDeps = defaultBranchGuardDeps,
+): { blocked: boolean; currentBranch: string; defaultBranch: string } {
+  const currentBranch = deps.getCurrentBranch();
+  const defaultBranch = deps.getDefaultBranch();
+  return {
+    blocked: !allowOverride && currentBranch === defaultBranch,
+    currentBranch,
+    defaultBranch,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Apply / check
 // ---------------------------------------------------------------------------
 
@@ -569,6 +633,7 @@ const TOKEN_COST_REPORT_FLAG_SPEC = {
   '--snapshot': { type: 'string', default: DEFAULT_SNAPSHOT_PATH },
   '--apply': { type: 'boolean', default: false },
   '--check': { type: 'boolean', default: false },
+  '--allow-default-branch': { type: 'boolean', default: false },
   '--now': { type: 'string', default: '' },
   '--help': { type: 'boolean', short: 'h' },
 } as const;
@@ -584,7 +649,12 @@ function printHelp(): void {
   --snapshot <path>   Snapshot artifact path (default: ${DEFAULT_SNAPSHOT_PATH}).
   --apply             Aggregate --in samples, write the snapshot, and
                       refresh the README.md / README.ja.md / docs/token-cost.md
-                      marked regions.
+                      marked regions. Refused when the current branch is
+                      the repository's default branch; pass
+                      --allow-default-branch to proceed anyway.
+  --allow-default-branch  Allow --apply to run while the current branch is
+                          the repository's default branch (refused by
+                          default -- see docs/token-cost.md).
   --check             Verify the committed snapshot's regions have not
                       drifted from README.md / README.ja.md / docs/token-cost.md.
                       Exits non-zero on drift. Does not read --in.
@@ -621,6 +691,15 @@ if (import.meta.main) {
   }
 
   if (apply) {
+    const guard = resolveDefaultBranchGuard(
+      values['allow-default-branch'] as boolean,
+    );
+    if (guard.blocked) {
+      process.stderr.write(
+        `token-cost-report --apply: refusing to run on the repository's default branch "${guard.defaultBranch}" (current branch: "${guard.currentBranch}"). Pass --allow-default-branch to override.\n`,
+      );
+      process.exit(2);
+    }
     const inPaths = (values.in as string[] | undefined) ?? [];
     if (inPaths.length === 0) {
       process.stderr.write(

--- a/tests/token-cost-report.test.mts
+++ b/tests/token-cost-report.test.mts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -16,6 +16,7 @@ import {
   renderReadmeRegionEn,
   renderReadmeRegionJa,
   replaceMarkedRegion,
+  resolveDefaultBranchGuard,
 } from '../src/scripts/token-cost-report.mts';
 
 const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
@@ -445,5 +446,185 @@ test('CLI: --now rejects an invalid timestamp with a clean usage error, not a ra
       assert.doesNotMatch(e.stderr, /RangeError|Invalid time value/);
     }
     assert.ok(threw, 'expected the CLI to exit non-zero');
+  });
+});
+
+test('resolveDefaultBranchGuard blocks --apply on the default branch without an override (#2452)', () => {
+  const result = resolveDefaultBranchGuard(false, {
+    getCurrentBranch: () => 'main',
+    getDefaultBranch: () => 'main',
+  });
+  assert.deepEqual(result, {
+    blocked: true,
+    currentBranch: 'main',
+    defaultBranch: 'main',
+  });
+});
+
+test('resolveDefaultBranchGuard --allow-default-branch bypasses the block on the default branch (#2452)', () => {
+  const result = resolveDefaultBranchGuard(true, {
+    getCurrentBranch: () => 'main',
+    getDefaultBranch: () => 'main',
+  });
+  assert.equal(result.blocked, false);
+});
+
+test('resolveDefaultBranchGuard passes through unaffected on a non-default branch (#2452)', () => {
+  const withoutOverride = resolveDefaultBranchGuard(false, {
+    getCurrentBranch: () => 'issue/2452-fix-token-cost-refuse-apply-on',
+    getDefaultBranch: () => 'main',
+  });
+  assert.equal(withoutOverride.blocked, false);
+
+  const withOverride = resolveDefaultBranchGuard(true, {
+    getCurrentBranch: () => 'issue/2452-fix-token-cost-refuse-apply-on',
+    getDefaultBranch: () => 'main',
+  });
+  assert.equal(withOverride.blocked, false);
+});
+
+test('resolveDefaultBranchGuard real getDefaultBranch falls back to "main" when origin/HEAD is unset locally (#2452)', () => {
+  const originalCwd = process.cwd();
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-report-git-'));
+  process.chdir(sandbox);
+  try {
+    execFileSync('git', ['init', '-b', 'main', '-q']);
+    // No `origin` remote configured at all, matching a clone that never
+    // ran `git remote set-head origin -a` -- `git symbolic-ref --short
+    // refs/remotes/origin/HEAD` fails, and the real getDefaultBranch must
+    // fall back to the fixed 'main' rather than throwing.
+    execFileSync(
+      'git',
+      [
+        '-c',
+        'commit.gpgsign=false',
+        '-c',
+        'user.email=test@example.com',
+        '-c',
+        'user.name=test',
+        'commit',
+        '--allow-empty',
+        '-q',
+        '-m',
+        'init',
+      ],
+      { stdio: 'pipe' },
+    );
+    // Real deps (no injected stub): exercises both the git subprocess
+    // calls and the fallback branch together.
+    const result = resolveDefaultBranchGuard(false);
+    assert.equal(result.currentBranch, 'main');
+    assert.equal(result.defaultBranch, 'main');
+    assert.equal(result.blocked, true);
+  } finally {
+    process.chdir(originalCwd);
+  }
+});
+
+/** Initializes a throwaway git repo on `branch` with one empty commit and
+ * runs `fn` with it as `process.cwd()`, restoring the original cwd after --
+ * lets a CLI-level test drive the real `getCurrentBranch`/`getDefaultBranch`
+ * git subprocess calls end to end (#2452). */
+function withGitSandboxCwd(branch: string, fn: () => void): void {
+  const originalCwd = process.cwd();
+  const sandbox = mkdtempSync(join(tmpdir(), 'idd-token-cost-report-cli-git-'));
+  process.chdir(sandbox);
+  try {
+    execFileSync('git', ['init', '-b', branch, '-q']);
+    execFileSync(
+      'git',
+      [
+        '-c',
+        'commit.gpgsign=false',
+        '-c',
+        'user.email=test@example.com',
+        '-c',
+        'user.name=test',
+        'commit',
+        '--allow-empty',
+        '-q',
+        '-m',
+        'init',
+      ],
+      { stdio: 'pipe' },
+    );
+    fn();
+  } finally {
+    process.chdir(originalCwd);
+  }
+}
+
+test('CLI: --apply refuses on the default branch without --allow-default-branch, before any write (#2452)', () => {
+  withGitSandboxCwd('main', () => {
+    let threw = false;
+    try {
+      execFileSync(
+        process.execPath,
+        [join(REPO_ROOT, 'scripts/token-cost-report.mjs'), '--apply'],
+        { encoding: 'utf8', stdio: 'pipe' },
+      );
+    } catch (error) {
+      threw = true;
+      const e = error as { status: number; stderr: string };
+      assert.equal(e.status, 2);
+      assert.match(
+        e.stderr,
+        /refusing to run on the repository's default branch "main".*Pass --allow-default-branch to override/s,
+      );
+    }
+    assert.ok(threw, 'expected the CLI to exit non-zero');
+    assert.equal(
+      existsSync('docs/token-cost-snapshot.json'),
+      false,
+      'the default-branch guard must fire before any write',
+    );
+  });
+});
+
+test('CLI: --apply --allow-default-branch bypasses the guard on the default branch (#2452)', () => {
+  withGitSandboxCwd('main', () => {
+    // No --in supplied: the guard must pass through, so the run fails on
+    // the pre-existing, already-covered "requires at least one --in"
+    // error instead of the branch-refusal message -- proving the override
+    // actually reached past the guard rather than short-circuiting it.
+    assert.throws(
+      () =>
+        execFileSync(
+          process.execPath,
+          [
+            join(REPO_ROOT, 'scripts/token-cost-report.mjs'),
+            '--apply',
+            '--allow-default-branch',
+          ],
+          { encoding: 'utf8', stdio: 'pipe' },
+        ),
+      (error: unknown) => {
+        const e = error as { status: number; stderr: string };
+        assert.equal(e.status, 2);
+        assert.match(e.stderr, /--apply requires at least one --in/);
+        assert.doesNotMatch(e.stderr, /refusing to run on the repository/);
+        return true;
+      },
+    );
+  });
+});
+
+test('CLI: --apply passes through unaffected on a non-default branch (#2452)', () => {
+  withGitSandboxCwd('issue/2452-fix-token-cost-refuse-apply-on', () => {
+    assert.throws(
+      () =>
+        execFileSync(
+          process.execPath,
+          [join(REPO_ROOT, 'scripts/token-cost-report.mjs'), '--apply'],
+          { encoding: 'utf8', stdio: 'pipe' },
+        ),
+      (error: unknown) => {
+        const e = error as { status: number; stderr: string };
+        assert.equal(e.status, 2);
+        assert.match(e.stderr, /--apply requires at least one --in/);
+        assert.doesNotMatch(e.stderr, /refusing to run on the repository/);
+        return true;
+      },
+    );
   });
 });


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`token-cost-report.mjs --apply` had no guard against running while the
current branch is the repository's default branch. A stray `--apply`
left dirty, uncommitted output (`docs/token-cost-snapshot.json`,
`docs/token-cost.md`, `README.md`, `README.ja.md`) sitting on the
shared primary worktree's `main` during `#2439`'s work — this can
block every concurrent session's next B1 `git merge --ff-only`
worktree creation.

Adds a local (no `gh`/network) default-branch check —
`resolveDefaultBranchGuard` in `src/scripts/token-cost-report.mts` —
gated on a new `--allow-default-branch` flag for an intentional
maintainer run. `--check` and any non-default branch (e.g. an issue
worktree) are unaffected.

## Linked issue

Closes #2452

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The guard resolves the current branch (`git rev-parse --abbrev-ref
HEAD`) and the repository's default branch (`git symbolic-ref --short
refs/remotes/origin/HEAD`, falling back to `main` when that ref is
unset locally) purely locally, matching this script's existing
offline-capable design — no new subprocess dependency beyond `git`
itself. New tests cover the guard's unit shape (block, override,
pass-through, and the no-`origin/HEAD`-ref fallback) plus the CLI's
end-to-end behavior against real throwaway git repos.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4745/4745 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
