### PR TITLE
docs(idd-ci): note that a label-gated gate may run as a job step

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -154,6 +154,23 @@ that set instead of re-deriving it.
    <profile-selected-ci-wait-state-command> --pr {pr-number}
    ```
 
+   **Label-gated or other opt-in gate surfacing as a job step, not a
+   check.** `gh pr checks` (and `ci-wait-state`) lists jobs/checks, not
+   the steps inside them. An opt-in heavy CI gate wired to run as a
+   step inside an already-present job — rather than its own discrete
+   check — never appears as a new entry there; only the parent job
+   does, and only once, regardless of whether the gated step ran. Do
+   not conclude such a gate is not-running or already-done solely
+   because `gh pr checks` shows no new check for it; confirm it
+   actually executed by inspecting the job's own steps instead:
+
+   ```sh
+   gh run view {run-id} --json jobs
+   ```
+
+   and read the target job's `steps[]` for the gate's step name and
+   conclusion.
+
 2. Normalize check states:
    - treat `skipped`, `neutral`, and `not_applicable` as pass-equivalent
    - treat `pending`, `requested`, `waiting`, `queued`,

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -149,6 +149,23 @@ that set instead of re-deriving it.
    <profile-selected-ci-wait-state-command> --pr {pr-number}
    ```
 
+   **Label-gated or other opt-in gate surfacing as a job step, not a
+   check.** `gh pr checks` (and `ci-wait-state`) lists jobs/checks, not
+   the steps inside them. An opt-in heavy CI gate wired to run as a
+   step inside an already-present job — rather than its own discrete
+   check — never appears as a new entry there; only the parent job
+   does, and only once, regardless of whether the gated step ran. Do
+   not conclude such a gate is not-running or already-done solely
+   because `gh pr checks` shows no new check for it; confirm it
+   actually executed by inspecting the job's own steps instead:
+
+   ```sh
+   gh run view {run-id} --json jobs
+   ```
+
+   and read the target job's `steps[]` for the gate's step name and
+   conclusion.
+
 2. Normalize check states:
    - treat `skipped`, `neutral`, and `not_applicable` as pass-equivalent
    - treat `pending`, `requested`, `waiting`, `queued`,


### PR DESCRIPTION
# Summary

No mention of "label-gated" CI gates, `gh run view --json jobs`, or
job-steps inspection existed anywhere in `idd-ci.instructions.md` or
`docs/*.md`. `gh pr checks` (and the `ci-wait-state.mjs` helper it
pairs with) lists jobs/checks, not the steps inside them. When an
opt-in heavy CI gate is wired to run as a step inside an
already-present job -- rather than its own discrete check -- an agent
waiting for the gate to appear via `gh pr checks` sees nothing new and
can misjudge the gate as not-running or already-done.

This adds a note to the "Polling algorithm" section's step 1, right
after the existing `gh pr checks`/`ci-wait-state` discovery block,
explaining the gap and naming `gh run view {run-id} --json jobs` ->
the job's `steps[]` as the way to confirm such a gate actually ran.

## Linked issue

Closes #2469

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Edited `idd-template/.github/instructions/idd-ci.instructions.md` (the
source) and regenerated the live target via `node
scripts/sync-docs.mjs --apply` -- the target file's own header says
"do not edit this file" directly. The `idd-ci-instructions` sync pair
in `audit/sync-manifest.json` is `mode: "exact"` (a byte-identical
copy, no separate replacement string to keep in sync).
`idd-ci-lite.instructions.md` was deliberately left untouched, per the
issue's own candidate-files scope.

This diff adds `idd-ci.instructions.md` to two byte-budget bundles
(`bundle-review`, `bundle-merge`) already near their 98% hard ceiling
(97.00% / 97.25% after this change, up from 96.46% / 96.63%) -- still
comfortably under budget, flagged here for visibility since that
bundle has breached its ceiling before in this repository's history.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed; pre-existing warnings
      unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (see bundle-headroom note above;
      still within budget)
