### PR TITLE
fix(advisory-convergence): wrap collectFromGitHub's gh calls in withBoundedRetry

### DIFF
--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -113,6 +113,7 @@ import {
   normalizeAuthorityEvidence,
   resolveCollaboratorAuthority,
 } from './external-check-waiver.mjs';
+import { deriveGhHttpStatus } from './gh-http-status.mjs';
 import { loadIddConfig } from './idd-config.mjs';
 import { isValidIsoTimestamp, parseClaimComment } from './marker-helpers.mjs';
 import {
@@ -1534,6 +1535,50 @@ export function viewerProbeGhOptions(env = process.env) {
         : ['ignore', 'pipe', 'inherit'],
   };
 }
+/** Total attempts (including the first) for {@link retryTransientGhFailure}. */
+const RETRY_TRANSIENT_GH_FAILURE_ATTEMPTS = 3;
+/** Base delay (ms) for {@link retryTransientGhFailure}'s backoff + jitter. */
+const RETRY_TRANSIENT_GH_FAILURE_BASE_DELAY_MS = 200;
+/**
+ * #2459: `collectFromGitHub`'s hot-path single-shot `gh` calls threw
+ * unretried on any failure, so a several-second runner network blip
+ * crashed the whole required `idd-advisory-convergence` CI job instead of
+ * self-healing, burning a full `ciWait.rerunPolicy` rerun-once budget
+ * entry on pure infrastructure noise. Retry only a genuinely transient
+ * failure: no parsed HTTP status (a transport-level blip with no server
+ * response -- e.g. the truncated captured stdout `#1394` already
+ * documents under heavy concurrent load) or a 5xx. A definitive 4xx
+ * (not-found, forbidden, unauthorized, etc.) is a permanent rejection a
+ * retry cannot fix, so it rethrows immediately instead of wasting the
+ * attempt budget.
+ *
+ * Deliberately self-contained (reuses this file's own `sleepSync`, does
+ * NOT import `gh-exec.mts`'s async `withBoundedRetry`): this file is
+ * already migrated onto `provider-port.mts`
+ * (`provider-port-migration-guard.test.mts`), which forbids regaining a
+ * direct `gh-exec.mts` import; several of the wrapped port methods below
+ * are also called, unretried, by many other synchronous callers across
+ * the codebase, so converting them (and this file's own synchronous call
+ * chain) to `async` to use the Promise-based `withBoundedRetry` would
+ * cascade well beyond this caller's scope.
+ */
+export function retryTransientGhFailure(task) {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return task();
+    } catch (error) {
+      const status = deriveGhHttpStatus(error);
+      const retryable = status === null || status >= 500;
+      if (attempt >= RETRY_TRANSIENT_GH_FAILURE_ATTEMPTS || !retryable) {
+        throw error;
+      }
+      sleepSync(
+        RETRY_TRANSIENT_GH_FAILURE_BASE_DELAY_MS * attempt +
+          Math.random() * RETRY_TRANSIENT_GH_FAILURE_BASE_DELAY_MS,
+      );
+    }
+  }
+}
 /**
  * `createPort` is injectable (defaults to the real GitHub adapter) so a test
  * can drive this collection entry end to end against
@@ -1567,7 +1612,9 @@ export function collectFromGitHub(
     envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
     config: rawConfig,
   });
-  const view = port.getChangeRequestConvergenceView(Number(args.prNumber));
+  const view = retryTransientGhFailure(() =>
+    port.getChangeRequestConvergenceView(Number(args.prNumber)),
+  );
   const prHeadSha = view.headSha.toLowerCase();
   const prHeadRefName = view.headRefName.trim();
   const prAuthorLogin = view.authorLogin.toLowerCase();
@@ -1576,9 +1623,9 @@ export function collectFromGitHub(
   // Fetched here (ahead of `trustedMarkerLogins` below) so a collaborator's
   // marker-shaped PR comment can be detected before that set is used to
   // resolve `claimEvents` -- see `resolveTrustedCollaboratorMarkerLogins`.
-  const comments = port
-    .listWorkItemComments(Number(args.prNumber))
-    .map(toIssueCommentPayload);
+  const comments = retryTransientGhFailure(() =>
+    port.listWorkItemComments(Number(args.prNumber)),
+  ).map(toIssueCommentPayload);
   // #1344: collaborator-marker trust, matching `pre-merge-readiness.mts`'s
   // `readCollaboratorTrustEnabled` exactly, except reusing the already-
   // loaded `rawConfig` instead of a second `.github/idd/config.json` read
@@ -1694,9 +1741,9 @@ export function collectFromGitHub(
     policy?.providerOutage?.declarationTarget;
   if (outageDeclarationTargetIssue) {
     try {
-      const declarationComments = port
-        .listWorkItemComments(outageDeclarationTargetIssue)
-        .map(toIssueCommentPayload);
+      const declarationComments = retryTransientGhFailure(() =>
+        port.listWorkItemComments(outageDeclarationTargetIssue),
+      ).map(toIssueCommentPayload);
       const authorityOf = (actorLogin) =>
         normalizeAuthorityEvidence(
           resolveCollaboratorAuthority({ owner, repo, actor: actorLogin }),
@@ -1735,7 +1782,9 @@ export function collectFromGitHub(
   let prFirstCommitAt = null;
   if (forcedHandoffEnabled) {
     try {
-      const prCommits = port.listChangeRequestCommits(Number(args.prNumber));
+      const prCommits = retryTransientGhFailure(() =>
+        port.listChangeRequestCommits(Number(args.prNumber)),
+      );
       prFirstCommitAt = resolvePrFirstCommitAt(prCommits);
     } catch {
       prFirstCommitAt = null;
@@ -2092,7 +2141,9 @@ function resolveTrustedCollaboratorMarkerLogins(port, commentLikeEvents) {
     ),
   ];
   return markerAuthors.filter((login) => {
-    const result = port.getCollaboratorPermission(login);
+    const result = retryTransientGhFailure(() =>
+      port.getCollaboratorPermission(login),
+    );
     const permission = result.outcome === 'found' ? result.permission : '';
     return (
       permission === 'admin' ||
@@ -2132,7 +2183,9 @@ function toIssueCommentPayload(comment) {
  * is enabled (see the call site), so a repository that never sets the
  * flag never pays for this extra request. */
 function fetchPrAuthor(port, prNumber) {
-  const author = port.getChangeRequestAuthor(prNumber);
+  const author = retryTransientGhFailure(() =>
+    port.getChangeRequestAuthor(prNumber),
+  );
   return author ? { login: author.login, __typename: author.typename } : null;
 }
 /** Map a `ProviderPort.listChangeRequestReviewThreadsWithAuthorType` node

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -1561,8 +1561,13 @@ const RETRY_TRANSIENT_GH_FAILURE_BASE_DELAY_MS = 200;
  * across the codebase, so converting them (and this file's own synchronous call
  * chain) to `async` to use the Promise-based `withBoundedRetry` would
  * cascade well beyond this caller's scope.
+ *
+ * `deps.sleep` defaults to the real, blocking `sleepSync` (production
+ * behavior); a test exercising a retry path injects a no-op to avoid a
+ * real wall-clock delay per attempt (Copilot review, PR #2502).
  */
-export function retryTransientGhFailure(task) {
+export function retryTransientGhFailure(task, deps = {}) {
+  const sleep = deps.sleep ?? sleepSync;
   for (let attempt = 1; ; attempt += 1) {
     try {
       return task();
@@ -1572,7 +1577,7 @@ export function retryTransientGhFailure(task) {
       if (attempt >= RETRY_TRANSIENT_GH_FAILURE_ATTEMPTS || !retryable) {
         throw error;
       }
-      sleepSync(
+      sleep(
         RETRY_TRANSIENT_GH_FAILURE_BASE_DELAY_MS * attempt +
           Math.random() * RETRY_TRANSIENT_GH_FAILURE_BASE_DELAY_MS,
       );

--- a/scripts/advisory-convergence.mjs
+++ b/scripts/advisory-convergence.mjs
@@ -1540,8 +1540,8 @@ const RETRY_TRANSIENT_GH_FAILURE_ATTEMPTS = 3;
 /** Base delay (ms) for {@link retryTransientGhFailure}'s backoff + jitter. */
 const RETRY_TRANSIENT_GH_FAILURE_BASE_DELAY_MS = 200;
 /**
- * #2459: `collectFromGitHub`'s hot-path single-shot `gh` calls threw
- * unretried on any failure, so a several-second runner network blip
+ * #2459: `collectFromGitHub`'s hot-path single-shot `gh` calls threw with
+ * no retry on any failure, so a several-second runner network blip
  * crashed the whole required `idd-advisory-convergence` CI job instead of
  * self-healing, burning a full `ciWait.rerunPolicy` rerun-once budget
  * entry on pure infrastructure noise. Retry only a genuinely transient
@@ -1557,8 +1557,8 @@ const RETRY_TRANSIENT_GH_FAILURE_BASE_DELAY_MS = 200;
  * already migrated onto `provider-port.mts`
  * (`provider-port-migration-guard.test.mts`), which forbids regaining a
  * direct `gh-exec.mts` import; several of the wrapped port methods below
- * are also called, unretried, by many other synchronous callers across
- * the codebase, so converting them (and this file's own synchronous call
+ * are also called, with no retry, by many other synchronous callers
+ * across the codebase, so converting them (and this file's own synchronous call
  * chain) to `async` to use the Promise-based `withBoundedRetry` would
  * cascade well beyond this caller's scope.
  */

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -2137,8 +2137,16 @@ const RETRY_TRANSIENT_GH_FAILURE_BASE_DELAY_MS = 200;
  * across the codebase, so converting them (and this file's own synchronous call
  * chain) to `async` to use the Promise-based `withBoundedRetry` would
  * cascade well beyond this caller's scope.
+ *
+ * `deps.sleep` defaults to the real, blocking `sleepSync` (production
+ * behavior); a test exercising a retry path injects a no-op to avoid a
+ * real wall-clock delay per attempt (Copilot review, PR #2502).
  */
-export function retryTransientGhFailure<T>(task: () => T): T {
+export function retryTransientGhFailure<T>(
+  task: () => T,
+  deps: { sleep?: (ms: number) => void } = {},
+): T {
+  const sleep = deps.sleep ?? sleepSync;
   for (let attempt = 1; ; attempt += 1) {
     try {
       return task();
@@ -2148,7 +2156,7 @@ export function retryTransientGhFailure<T>(task: () => T): T {
       if (attempt >= RETRY_TRANSIENT_GH_FAILURE_ATTEMPTS || !retryable) {
         throw error;
       }
-      sleepSync(
+      sleep(
         RETRY_TRANSIENT_GH_FAILURE_BASE_DELAY_MS * attempt +
           Math.random() * RETRY_TRANSIENT_GH_FAILURE_BASE_DELAY_MS,
       );

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -119,6 +119,7 @@ import {
   normalizeAuthorityEvidence,
   resolveCollaboratorAuthority,
 } from './external-check-waiver.mts';
+import { deriveGhHttpStatus } from './gh-http-status.mts';
 import { loadIddConfig } from './idd-config.mts';
 import { isValidIsoTimestamp, parseClaimComment } from './marker-helpers.mts';
 import {
@@ -2109,6 +2110,52 @@ export function viewerProbeGhOptions(env: NodeJS.ProcessEnv = process.env): {
   };
 }
 
+/** Total attempts (including the first) for {@link retryTransientGhFailure}. */
+const RETRY_TRANSIENT_GH_FAILURE_ATTEMPTS = 3;
+/** Base delay (ms) for {@link retryTransientGhFailure}'s backoff + jitter. */
+const RETRY_TRANSIENT_GH_FAILURE_BASE_DELAY_MS = 200;
+
+/**
+ * #2459: `collectFromGitHub`'s hot-path single-shot `gh` calls threw
+ * unretried on any failure, so a several-second runner network blip
+ * crashed the whole required `idd-advisory-convergence` CI job instead of
+ * self-healing, burning a full `ciWait.rerunPolicy` rerun-once budget
+ * entry on pure infrastructure noise. Retry only a genuinely transient
+ * failure: no parsed HTTP status (a transport-level blip with no server
+ * response -- e.g. the truncated captured stdout `#1394` already
+ * documents under heavy concurrent load) or a 5xx. A definitive 4xx
+ * (not-found, forbidden, unauthorized, etc.) is a permanent rejection a
+ * retry cannot fix, so it rethrows immediately instead of wasting the
+ * attempt budget.
+ *
+ * Deliberately self-contained (reuses this file's own `sleepSync`, does
+ * NOT import `gh-exec.mts`'s async `withBoundedRetry`): this file is
+ * already migrated onto `provider-port.mts`
+ * (`provider-port-migration-guard.test.mts`), which forbids regaining a
+ * direct `gh-exec.mts` import; several of the wrapped port methods below
+ * are also called, unretried, by many other synchronous callers across
+ * the codebase, so converting them (and this file's own synchronous call
+ * chain) to `async` to use the Promise-based `withBoundedRetry` would
+ * cascade well beyond this caller's scope.
+ */
+export function retryTransientGhFailure<T>(task: () => T): T {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return task();
+    } catch (error) {
+      const status = deriveGhHttpStatus(error);
+      const retryable = status === null || status >= 500;
+      if (attempt >= RETRY_TRANSIENT_GH_FAILURE_ATTEMPTS || !retryable) {
+        throw error;
+      }
+      sleepSync(
+        RETRY_TRANSIENT_GH_FAILURE_BASE_DELAY_MS * attempt +
+          Math.random() * RETRY_TRANSIENT_GH_FAILURE_BASE_DELAY_MS,
+      );
+    }
+  }
+}
+
 /**
  * `createPort` is injectable (defaults to the real GitHub adapter) so a test
  * can drive this collection entry end to end against
@@ -2148,7 +2195,9 @@ export function collectFromGitHub(
     envValue: process.env.IDD_ADVISORY_BOT_LOGINS,
     config: rawConfig,
   });
-  const view = port.getChangeRequestConvergenceView(Number(args.prNumber));
+  const view = retryTransientGhFailure(() =>
+    port.getChangeRequestConvergenceView(Number(args.prNumber)),
+  );
   const prHeadSha = view.headSha.toLowerCase();
   const prHeadRefName = view.headRefName.trim();
   const prAuthorLogin = view.authorLogin.toLowerCase();
@@ -2160,9 +2209,9 @@ export function collectFromGitHub(
   // Fetched here (ahead of `trustedMarkerLogins` below) so a collaborator's
   // marker-shaped PR comment can be detected before that set is used to
   // resolve `claimEvents` -- see `resolveTrustedCollaboratorMarkerLogins`.
-  const comments = port
-    .listWorkItemComments(Number(args.prNumber))
-    .map(toIssueCommentPayload);
+  const comments = retryTransientGhFailure(() =>
+    port.listWorkItemComments(Number(args.prNumber)),
+  ).map(toIssueCommentPayload);
 
   // #1344: collaborator-marker trust, matching `pre-merge-readiness.mts`'s
   // `readCollaboratorTrustEnabled` exactly, except reusing the already-
@@ -2286,9 +2335,9 @@ export function collectFromGitHub(
     policy?.providerOutage?.declarationTarget;
   if (outageDeclarationTargetIssue) {
     try {
-      const declarationComments = port
-        .listWorkItemComments(outageDeclarationTargetIssue)
-        .map(toIssueCommentPayload);
+      const declarationComments = retryTransientGhFailure(() =>
+        port.listWorkItemComments(outageDeclarationTargetIssue),
+      ).map(toIssueCommentPayload);
       const authorityOf = (actorLogin: string): AuthorityEvidence =>
         normalizeAuthorityEvidence(
           resolveCollaboratorAuthority({ owner, repo, actor: actorLogin }),
@@ -2328,8 +2377,8 @@ export function collectFromGitHub(
   let prFirstCommitAt: string | null = null;
   if (forcedHandoffEnabled) {
     try {
-      const prCommits = port.listChangeRequestCommits(
-        Number(args.prNumber),
+      const prCommits = retryTransientGhFailure(() =>
+        port.listChangeRequestCommits(Number(args.prNumber)),
       ) as PrCommitPayload[];
       prFirstCommitAt = resolvePrFirstCommitAt(prCommits);
     } catch {
@@ -2721,7 +2770,9 @@ function resolveTrustedCollaboratorMarkerLogins(
   ];
 
   return markerAuthors.filter((login) => {
-    const result = port.getCollaboratorPermission(login);
+    const result = retryTransientGhFailure(() =>
+      port.getCollaboratorPermission(login),
+    );
     const permission = result.outcome === 'found' ? result.permission : '';
     return (
       permission === 'admin' ||
@@ -2766,7 +2817,9 @@ function fetchPrAuthor(
   port: ProviderPort,
   prNumber: number,
 ): GhAuthorPayload | null {
-  const author = port.getChangeRequestAuthor(prNumber);
+  const author = retryTransientGhFailure(() =>
+    port.getChangeRequestAuthor(prNumber),
+  );
   return author ? { login: author.login, __typename: author.typename } : null;
 }
 

--- a/src/scripts/advisory-convergence.mts
+++ b/src/scripts/advisory-convergence.mts
@@ -2116,8 +2116,8 @@ const RETRY_TRANSIENT_GH_FAILURE_ATTEMPTS = 3;
 const RETRY_TRANSIENT_GH_FAILURE_BASE_DELAY_MS = 200;
 
 /**
- * #2459: `collectFromGitHub`'s hot-path single-shot `gh` calls threw
- * unretried on any failure, so a several-second runner network blip
+ * #2459: `collectFromGitHub`'s hot-path single-shot `gh` calls threw with
+ * no retry on any failure, so a several-second runner network blip
  * crashed the whole required `idd-advisory-convergence` CI job instead of
  * self-healing, burning a full `ciWait.rerunPolicy` rerun-once budget
  * entry on pure infrastructure noise. Retry only a genuinely transient
@@ -2133,8 +2133,8 @@ const RETRY_TRANSIENT_GH_FAILURE_BASE_DELAY_MS = 200;
  * already migrated onto `provider-port.mts`
  * (`provider-port-migration-guard.test.mts`), which forbids regaining a
  * direct `gh-exec.mts` import; several of the wrapped port methods below
- * are also called, unretried, by many other synchronous callers across
- * the codebase, so converting them (and this file's own synchronous call
+ * are also called, with no retry, by many other synchronous callers
+ * across the codebase, so converting them (and this file's own synchronous call
  * chain) to `async` to use the Promise-based `withBoundedRetry` would
  * cascade well beyond this caller's scope.
  */

--- a/tests/advisory-convergence-fake-provider.test.mts
+++ b/tests/advisory-convergence-fake-provider.test.mts
@@ -137,3 +137,60 @@ test('collectFromGitHub threads a Copilot-authored unresolved thread through lis
     assert.equal(thread.comments?.nodes[0]?.author?.__typename, 'Bot');
   });
 });
+
+test('collectFromGitHub retries one transient getChangeRequestConvergenceView failure, then succeeds (#2459)', () => {
+  withHermeticCwd(() => {
+    const realPort = createFakeProviderAdapter(baseFixture());
+    let calls = 0;
+    const flakyPort = {
+      ...realPort,
+      getChangeRequestConvergenceView(number: number) {
+        calls += 1;
+        if (calls === 1) {
+          throw new Error('connection reset by peer');
+        }
+        return realPort.getChangeRequestConvergenceView(number);
+      },
+    };
+
+    const { inputs } = collectFromGitHub(
+      parseArgs(['--pr', String(PR_NUMBER), '--owner', 'o', '--repo', 'r']),
+      () => flakyPort,
+    );
+
+    // Retried past the transient failure instead of crashing the whole
+    // collection: the second (real) call succeeded, and its data made it
+    // all the way into the returned inputs.
+    assert.equal(calls, 2);
+    assert.equal(inputs.prHeadSha, 'a'.repeat(40));
+  });
+});
+
+test('collectFromGitHub does not retry a definitive 404 from getChangeRequestConvergenceView (#2459)', () => {
+  withHermeticCwd(() => {
+    const realPort = createFakeProviderAdapter(baseFixture());
+    let calls = 0;
+    const notFound = Object.assign(new Error('gh: Not Found (HTTP 404)'), {
+      stderr: 'gh: Not Found (HTTP 404)',
+    });
+    const missingPort = {
+      ...realPort,
+      getChangeRequestConvergenceView(_number: number) {
+        calls += 1;
+        throw notFound;
+      },
+    };
+
+    assert.throws(
+      () =>
+        collectFromGitHub(
+          parseArgs(['--pr', String(PR_NUMBER), '--owner', 'o', '--repo', 'r']),
+          () => missingPort,
+        ),
+      notFound,
+    );
+    // A permanent 404 rethrows on the first attempt -- no wasted retry
+    // budget on a failure a retry cannot fix.
+    assert.equal(calls, 1);
+  });
+});

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -4553,28 +4553,34 @@ test('writeAdvisoryConvergenceCliOutput writes guidance before JSON (#2142)', ()
 
 test('retryTransientGhFailure retries a status-less (transport-level) failure, then succeeds (#2459)', () => {
   let calls = 0;
-  const result = retryTransientGhFailure(() => {
-    calls += 1;
-    if (calls < 2) {
-      throw new Error('unexpected end of JSON input');
-    }
-    return 'ok';
-  });
+  const result = retryTransientGhFailure(
+    () => {
+      calls += 1;
+      if (calls < 2) {
+        throw new Error('unexpected end of JSON input');
+      }
+      return 'ok';
+    },
+    { sleep: () => undefined },
+  );
   assert.equal(result, 'ok');
   assert.equal(calls, 2);
 });
 
 test('retryTransientGhFailure retries a 5xx failure, then succeeds (#2459)', () => {
   let calls = 0;
-  const result = retryTransientGhFailure(() => {
-    calls += 1;
-    if (calls < 2) {
-      throw Object.assign(new Error('gh: Service Unavailable (HTTP 503)'), {
-        stderr: 'gh: Service Unavailable (HTTP 503)',
-      });
-    }
-    return 'ok';
-  });
+  const result = retryTransientGhFailure(
+    () => {
+      calls += 1;
+      if (calls < 2) {
+        throw Object.assign(new Error('gh: Service Unavailable (HTTP 503)'), {
+          stderr: 'gh: Service Unavailable (HTTP 503)',
+        });
+      }
+      return 'ok';
+    },
+    { sleep: () => undefined },
+  );
   assert.equal(result, 'ok');
   assert.equal(calls, 2);
 });
@@ -4600,11 +4606,14 @@ test('retryTransientGhFailure exhausts bounded attempts and rethrows the final e
   let lastError: Error | undefined;
   let caught: unknown;
   try {
-    retryTransientGhFailure(() => {
-      calls += 1;
-      lastError = new Error(`persistent transport failure ${calls}`);
-      throw lastError;
-    });
+    retryTransientGhFailure(
+      () => {
+        calls += 1;
+        lastError = new Error(`persistent transport failure ${calls}`);
+        throw lastError;
+      },
+      { sleep: () => undefined },
+    );
     assert.fail('expected retryTransientGhFailure to throw');
   } catch (error) {
     caught = error;

--- a/tests/advisory-convergence.test.mts
+++ b/tests/advisory-convergence.test.mts
@@ -28,6 +28,7 @@ import {
   pickResolvingClaimEvents,
   readCopilotReviewPollPolicy,
   resolveClaimEvidence,
+  retryTransientGhFailure,
   reviewPolicyNotApplicableReason,
   runAdvisoryConvergence,
   runAdvisoryConvergenceWithPoll,
@@ -4548,4 +4549,68 @@ test('writeAdvisoryConvergenceCliOutput writes guidance before JSON (#2142)', ()
     env: { GITHUB_ACTIONS: 'true' },
   });
   assert.equal(reportErr, '');
+});
+
+test('retryTransientGhFailure retries a status-less (transport-level) failure, then succeeds (#2459)', () => {
+  let calls = 0;
+  const result = retryTransientGhFailure(() => {
+    calls += 1;
+    if (calls < 2) {
+      throw new Error('unexpected end of JSON input');
+    }
+    return 'ok';
+  });
+  assert.equal(result, 'ok');
+  assert.equal(calls, 2);
+});
+
+test('retryTransientGhFailure retries a 5xx failure, then succeeds (#2459)', () => {
+  let calls = 0;
+  const result = retryTransientGhFailure(() => {
+    calls += 1;
+    if (calls < 2) {
+      throw Object.assign(new Error('gh: Service Unavailable (HTTP 503)'), {
+        stderr: 'gh: Service Unavailable (HTTP 503)',
+      });
+    }
+    return 'ok';
+  });
+  assert.equal(result, 'ok');
+  assert.equal(calls, 2);
+});
+
+test('retryTransientGhFailure rethrows a definitive 4xx immediately, without retrying (#2459)', () => {
+  let calls = 0;
+  const notFound = Object.assign(new Error('gh: Not Found (HTTP 404)'), {
+    stderr: 'gh: Not Found (HTTP 404)',
+  });
+  assert.throws(
+    () =>
+      retryTransientGhFailure(() => {
+        calls += 1;
+        throw notFound;
+      }),
+    notFound,
+  );
+  assert.equal(calls, 1);
+});
+
+test('retryTransientGhFailure exhausts bounded attempts and rethrows the final error unchanged (#2459)', () => {
+  let calls = 0;
+  let lastError: Error | undefined;
+  let caught: unknown;
+  try {
+    retryTransientGhFailure(() => {
+      calls += 1;
+      lastError = new Error(`persistent transport failure ${calls}`);
+      throw lastError;
+    });
+    assert.fail('expected retryTransientGhFailure to throw');
+  } catch (error) {
+    caught = error;
+  }
+  // Bounded to 3 attempts total, and the rethrown error is the exact same
+  // instance the final attempt threw (fail-closed, never re-wrapped).
+  assert.equal(calls, 3);
+  assert.equal(caught, lastError);
 });


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`advisory-convergence.mts`'s `collectFromGitHub` issued single-shot `gh`
calls (via `getChangeRequestConvergenceView`, `listWorkItemComments`,
`listChangeRequestCommits`, `getCollaboratorPermission`,
`getChangeRequestAuthor`) that threw with no retry on any failure. Because
`idd-advisory-convergence` runs as a required CI check, a several-second
runner network blip crashed the whole job with an unhandled exception
instead of self-healing, burning a full `ciWait.rerunPolicy` rerun-once
budget entry on pure infrastructure noise.

Adds `retryTransientGhFailure` (`src/scripts/advisory-convergence.mts`,
`#2459`) — a bounded retry (3 attempts) with a connectivity-aware
predicate: retries when no HTTP status parses (a transport-level blip
with no server response) or on a 5xx, but rethrows a definitive 4xx
(not-found, forbidden, unauthorized, etc.) immediately since a retry
cannot fix a permanent rejection. Wraps all five named call sites on
`collectFromGitHub`'s call path.

## Linked issue

Closes #2459

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

`gh-exec.mts` already has an async `withBoundedRetry` used by the
`discover-roadmap-graph.mts` traversal path, but reusing it directly here
was not viable: `advisory-convergence.mts` is one of the helpers already
migrated onto `provider-port.mts` (`#2266`/`#2267`), and
`provider-port-migration-guard.test.mts` forbids a migrated helper from
regaining a direct `gh-exec.mts` import. Several of the five wrapped port
methods (`listWorkItemComments`, `listChangeRequestCommits`,
`getCollaboratorPermission`) are also called, with no retry, by many
other synchronous callers across the codebase (`pre-merge-readiness.mts`,
`claim-approval-gate.mts`, etc.), so converting them — and this file's
own synchronous call chain — to `async` to use the Promise-based
`withBoundedRetry` would have cascaded well beyond this caller's scope
(the ~4500-line `advisory-convergence.test.mts` alone has 70+ call sites
that would need to become async).

Instead, `retryTransientGhFailure` is self-contained: it reuses this
file's own existing `sleepSync` (`Atomics.wait`-based blocking sleep,
already duplicated independently in `clone-lock.mts` and
`rerun-advisory-convergence.mts` for the same class of problem) rather
than exporting a new shared primitive, keeping the change confined to
`advisory-convergence.mts` and its tests.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4751/4751 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
