### PR TITLE
feat(issue-authoring): close the gap where roadmap-child drafting never produces Candidate files

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -607,11 +607,14 @@ Validation expectations:
 
 ### Candidate files format
 
-The optional `## Candidate files` section is not free-form prose: the
+The `## Candidate files` section is not free-form prose: the
 `discover-shared-file-overlap` evidence helper parses it as machine input
 for the A4 Step 2 high-contention shared-file check (see
 [High-contention shared-file overlap](https://github.com/kurone-kito/idd-skill/blob/main/docs/policy-constants.md#high-contention-shared-files)).
 Populate it accurately rather than as a loose reading aid for humans.
+Optional for an orphan or roadmap issue; required for a
+[child issue under a roadmap](#child-issue-under-a-roadmap) (see
+[Required draft content](#required-draft-content) below).
 
 - List each candidate file path inside backticks, one path (or one
   bullet) per line — for example `` - `src/scripts/idd-onboard.mts` ``.

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -687,6 +687,8 @@ Validation expectations:
 - `## Background`
 - `## Proposed change`
 - `## Acceptance criteria`
+- `## Candidate files` (see
+  [Candidate files format](#candidate-files-format) above)
 - optional dependency line or sequential roadmap marker when needed
 - an autopilot-suitability footer at the end of the body (visible
   line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
@@ -699,6 +701,10 @@ Validation expectations:
 
 - the issue is referenced from its parent roadmap task list
 - acceptance criteria are locally verifiable
+- `## Candidate files` lists the files the child is expected to touch,
+  so the A4 Step 2 high-contention shared-file check
+  (`discover-shared-file-overlap`) can actually engage instead of
+  silently no-opping for lack of input
 - any dependency marker is resolvable, intentionally chosen, and
   justified
 - the issue can be claimed independently without absorbing sibling work

--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -200,6 +200,7 @@ Child issue:
 - `## Background`
 - `## Proposed change`
 - `## Acceptance criteria`
+- `## Candidate files`
 - optional dependency line or sequential roadmap marker when needed
 - an autopilot-suitability footer at the end of the body
 

--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -426,6 +426,10 @@ and dispatches known event types.
 - Handler validates the webhook secret sourced from CI `STRIPE_WEBHOOK_SECRET`.
 - Tests use the Stripe test-mode fixture and pass without manual setup.
 - `pnpm test` and `pnpm run lint` pass in CI.
+
+## Candidate files
+
+- `src/routes/webhooks/stripe.ts`
 ```
 
 The autonomous issue is fully verifiable in CI once the credential
@@ -480,6 +484,10 @@ Add a "Human-dependency isolation examples" section to
 - Examples warn against hiding credentials or product decisions in a
   ready issue.
 - `pnpm run lint:minimum` passes.
+
+## Candidate files
+
+- `skills/issue-authoring/references/draft-patterns.md`
 ```
 
 The website publication decision stays separate. It is not in the

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -526,7 +526,12 @@ A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
 - **Behavior boundary**: evidence-only and heuristic. `## Candidate files` are
   advisory cues, not an exhaustive manifest, so the overlap signal must stay a
   soft A4 Step 2 tie-breaker — never a claim gate. The written discover
-  instructions remain authoritative.
+  instructions remain authoritative. A candidate whose issue body carries no
+  `## Candidate files` section is a structural no-op for this check —
+  `candidateFiles`/`overlapFlag` come back empty/false regardless of real file
+  contention, not a signal that no contention exists (`#2462`); the
+  `issue-authoring` skill's roadmap-child contract requires the section for
+  exactly this reason.
 
 The exported template remains portable without a `scripts/` directory.
 Adopters can copy the helper separately when they want the same

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -528,8 +528,9 @@ A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
   soft A4 Step 2 tie-breaker — never a claim gate. The written discover
   instructions remain authoritative. A candidate whose issue body carries no
   `## Candidate files` section is a structural no-op for this check —
-  `candidateFiles`/`overlapFlag` come back empty/false regardless of real file
-  contention, not a signal that no contention exists (`#2462`); the
+  `candidateFiles` comes back `[]` and `overlapFlag` comes back `false`
+  regardless of real file contention, not a signal that no contention exists
+  (`#2462`); the
   `issue-authoring` skill's roadmap-child contract requires the section for
   exactly this reason.
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -526,7 +526,12 @@ A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
 - **Behavior boundary**: evidence-only and heuristic. `## Candidate files` are
   advisory cues, not an exhaustive manifest, so the overlap signal must stay a
   soft A4 Step 2 tie-breaker — never a claim gate. The written discover
-  instructions remain authoritative.
+  instructions remain authoritative. A candidate whose issue body carries no
+  `## Candidate files` section is a structural no-op for this check —
+  `candidateFiles`/`overlapFlag` come back empty/false regardless of real file
+  contention, not a signal that no contention exists (`#2462`); the
+  `issue-authoring` skill's roadmap-child contract requires the section for
+  exactly this reason.
 
 The exported template remains portable without a `scripts/` directory.
 Adopters can copy the helper separately when they want the same

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -528,8 +528,9 @@ A4 Step 2 de-prioritization order. Evidence-only: it claims nothing.
   soft A4 Step 2 tie-breaker — never a claim gate. The written discover
   instructions remain authoritative. A candidate whose issue body carries no
   `## Candidate files` section is a structural no-op for this check —
-  `candidateFiles`/`overlapFlag` come back empty/false regardless of real file
-  contention, not a signal that no contention exists (`#2462`); the
+  `candidateFiles` comes back `[]` and `overlapFlag` comes back `false`
+  regardless of real file contention, not a signal that no contention exists
+  (`#2462`); the
   `issue-authoring` skill's roadmap-child contract requires the section for
   exactly this reason.
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -607,11 +607,14 @@ Validation expectations:
 
 ### Candidate files format
 
-The optional `## Candidate files` section is not free-form prose: the
+The `## Candidate files` section is not free-form prose: the
 `discover-shared-file-overlap` evidence helper parses it as machine input
 for the A4 Step 2 high-contention shared-file check (see
 [High-contention shared-file overlap](https://github.com/kurone-kito/idd-skill/blob/main/docs/policy-constants.md#high-contention-shared-files)).
 Populate it accurately rather than as a loose reading aid for humans.
+Optional for an orphan or roadmap issue; required for a
+[child issue under a roadmap](#child-issue-under-a-roadmap) (see
+[Required draft content](#required-draft-content) below).
 
 - List each candidate file path inside backticks, one path (or one
   bullet) per line — for example `` - `src/scripts/idd-onboard.mts` ``.

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -687,6 +687,8 @@ Validation expectations:
 - `## Background`
 - `## Proposed change`
 - `## Acceptance criteria`
+- `## Candidate files` (see
+  [Candidate files format](#candidate-files-format) above)
 - optional dependency line or sequential roadmap marker when needed
 - an autopilot-suitability footer at the end of the body (visible
   line + `<!-- <marker-prefix>-autopilot-suitability: N -->` marker)
@@ -699,6 +701,10 @@ Validation expectations:
 
 - the issue is referenced from its parent roadmap task list
 - acceptance criteria are locally verifiable
+- `## Candidate files` lists the files the child is expected to touch,
+  so the A4 Step 2 high-contention shared-file check
+  (`discover-shared-file-overlap`) can actually engage instead of
+  silently no-opping for lack of input
 - any dependency marker is resolvable, intentionally chosen, and
   justified
 - the issue can be claimed independently without absorbing sibling work

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -200,6 +200,7 @@ Child issue:
 - `## Background`
 - `## Proposed change`
 - `## Acceptance criteria`
+- `## Candidate files`
 - optional dependency line or sequential roadmap marker when needed
 - an autopilot-suitability footer at the end of the body
 

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -426,6 +426,10 @@ and dispatches known event types.
 - Handler validates the webhook secret sourced from CI `STRIPE_WEBHOOK_SECRET`.
 - Tests use the Stripe test-mode fixture and pass without manual setup.
 - `pnpm test` and `pnpm run lint` pass in CI.
+
+## Candidate files
+
+- `src/routes/webhooks/stripe.ts`
 ```
 
 The autonomous issue is fully verifiable in CI once the credential
@@ -480,6 +484,10 @@ Add a "Human-dependency isolation examples" section to
 - Examples warn against hiding credentials or product decisions in a
   ready issue.
 - `pnpm run lint:minimum` passes.
+
+## Candidate files
+
+- `skills/issue-authoring/references/draft-patterns.md`
 ```
 
 The website publication decision stays separate. It is not in the


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

The documented roadmap-child drafting flow never mentioned `## Candidate
files`: neither `contract.md`'s "Child issue under a roadmap"
required-content list nor `draft-patterns.md`'s "Example roadmap
package" template included it, so a roadmap authored strictly through
that flow ships children whose section is always absent.
`discover-shared-file-overlap` deliberately returns `[]` when the
section is missing, so the A4 Step 2 high-contention shared-file check
became a structural no-op for the common case, with no signal that it
never engaged.

Adds `## Candidate files` to both the required-content list and the
template (`#2462`), and documents the no-op condition explicitly in the
`discover-shared-file-overlap` contract (`docs/idd-helper-scripts.md`
source + `idd-template/` mirror, regenerated via `sync-docs.mjs`) so the
gap is visible even before an authoring session independently adds the
section.

## Linked issue

Closes #2462

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Roadmap authoring is the primary way concurrent-claim-eligible children
get created, and the overlap gate exists specifically to protect that
concurrency — silently no-opping it defeats its purpose without any
signal to the adopter that it never engaged. Chose option (a) from the
issue (require the section) rather than only documenting the gap:
no code changes to `discover-shared-file-overlap.mts`/
`audit-authored-issue.mts` are needed since the acceptance criteria
treats mechanical enforcement as optional, and the issue itself hedges
the requirement to children "expected to run under parallel/autonomous
claiming" rather than every roadmap child, so a hard mechanical gate
would overreach what's asked.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4745/4745 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a `## Candidate files` section to child issue requirements and roadmap issue examples.
  * Validation now requires expected file paths in this section for shared-file overlap checks.
  * Documented that issues without the section return no candidate files and no overlap flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->