### PR TITLE
fix(provider-adapter-github): retry POST, dedupe on ambiguous failure

### DIFF
--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -222,7 +222,14 @@ function postWorkItemCommentWithRetry(deps, repoPath, number, body) {
       lastError = error;
     }
   }
-  throw lastError;
+  // Copilot review, #2504: `lastError` is `unknown` -- a non-`Error` thrown
+  // by `deps.ghText`/`JSON.parse` (a string, `undefined`, ...) would make
+  // downstream handling/logging inconsistent. Always throw a real `Error`.
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(
+        `postWorkItemComment: all ${POST_WORK_ITEM_COMMENT_TOTAL_ATTEMPTS} attempts failed for ${repoPath}/issues/${number}: ${String(lastError)}`,
+      );
 }
 /** #2267: {@link GithubProviderAdapterDeps.ghText}, swallowing any failure
  * and returning `''` instead -- the injectable-`deps` equivalent of

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -110,20 +110,23 @@ const POST_WORK_ITEM_COMMENT_BASE_DELAY_MS = 200;
  * risks posting the same marker twice when a failure is ambiguous (the
  * write landed server-side, but the client never saw a successful
  * response; observed live as a one-off transient failure whose very next
- * unrelated API call succeeded). Before every retry, re-read recent
- * comments for an exact-body match: found means the prior attempt actually
- * landed, so return that comment instead of posting again; not found means
- * the prior attempt genuinely failed, so back off and retry the POST. This
- * scan is best-effort only (a transient read failure here must never block
- * the retry it is meant to protect) and only ever runs on the error path,
- * never the common single-attempt success path.
+ * unrelated API call succeeded). Before every retry, re-read the full
+ * (paginated) comment history for an exact-body match: found means the
+ * prior attempt actually landed, so return that comment instead of posting
+ * again; not found means the prior attempt genuinely failed, so back off
+ * and retry the POST. This scan is best-effort only (a transient read
+ * failure here must never block the retry it is meant to protect) and only
+ * ever runs on the error path, never the common single-attempt success
+ * path. Requests the maximum page size (Copilot review, #2504) to bound
+ * pagination overhead on a heavily-commented issue/PR.
  */
 function findRecentExactBodyMatch(deps, repoPath, number, body) {
   let rows;
   try {
-    rows = deps.ghApiJson(`${repoPath}/issues/${number}/comments`, {
-      paginate: true,
-    });
+    rows = deps.ghApiJson(
+      `${repoPath}/issues/${number}/comments?per_page=100`,
+      { paginate: true },
+    );
   } catch {
     return null;
   }

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -121,33 +121,42 @@ const POST_WORK_ITEM_COMMENT_BASE_DELAY_MS = 200;
  * pagination overhead on a heavily-commented issue/PR.
  */
 function findRecentExactBodyMatch(deps, repoPath, number, body) {
-  let rows;
+  // The whole read-and-scan is wrapped in one try/catch, not just the
+  // `ghApiJson` call: a malformed row (e.g. a stray `null` entry) thrown
+  // from the loop body below must fail this best-effort scan the same
+  // way a transport failure does, never abort the retry it exists to
+  // protect (Copilot review, #2504).
   try {
-    rows = deps.ghApiJson(
+    const rows = deps.ghApiJson(
       `${repoPath}/issues/${number}/comments?per_page=100`,
       { paginate: true },
     );
+    let newest = null;
+    for (const row of rows) {
+      if (row === null || typeof row !== 'object') {
+        continue;
+      }
+      if (String(row.body ?? '') !== body) {
+        continue;
+      }
+      const id = Number(row.id);
+      const htmlUrl = String(row.html_url ?? '');
+      // Same shape requirement as the fresh-POST path below -- a match
+      // with no usable id/html_url is not a usable result, so keep
+      // scanning instead of returning a comment the caller couldn't
+      // act on.
+      if (!Number.isInteger(id) || id <= 0 || htmlUrl === '') {
+        continue;
+      }
+      // Comments come back in ascending creation order; keep the last
+      // (most recent) exact-body match in the unlikely event more than
+      // one exists.
+      newest = { id, htmlUrl };
+    }
+    return newest;
   } catch {
     return null;
   }
-  let newest = null;
-  for (const row of rows) {
-    if (String(row.body ?? '') !== body) {
-      continue;
-    }
-    const id = Number(row.id);
-    const htmlUrl = String(row.html_url ?? '');
-    // Same shape requirement as the fresh-POST path below -- a match with
-    // no usable id/html_url is not a usable result, so keep scanning
-    // instead of returning a comment the caller couldn't act on.
-    if (!Number.isInteger(id) || id <= 0 || htmlUrl === '') {
-      continue;
-    }
-    // Comments come back in ascending creation order; keep the last (most
-    // recent) exact-body match in the unlikely event more than one exists.
-    newest = { id, htmlUrl };
-  }
-  return newest;
 }
 /**
  * #2460: POST a work-item (issue/PR) comment with a bounded retry against

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -88,6 +88,116 @@ function assertNoGraphqlErrors(payload, context) {
     );
   }
 }
+/**
+ * #2460: synchronous bounded sleep via `Atomics.wait` on a throwaway
+ * `SharedArrayBuffer` -- the same technique `advisory-convergence.mts`,
+ * `clone-lock.mts`, and `rerun-advisory-convergence.mts` each already
+ * duplicate locally rather than switching to `async`/`await` (the existing
+ * `withBoundedRetry` in `gh-exec.mts` is `Promise`-returning and would force
+ * every synchronous caller of {@link ProviderPort.postWorkItemComment} --
+ * and the whole `ProviderPort` interface -- to become async for one retry
+ * loop). Duplicated here as this one-line function, mirroring that same
+ * established precedent, rather than adding new cross-file coupling.
+ */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+const POST_WORK_ITEM_COMMENT_TOTAL_ATTEMPTS = 3;
+const POST_WORK_ITEM_COMMENT_BASE_DELAY_MS = 200;
+/**
+ * #2460: the issues-comments POST endpoint is not idempotent -- each
+ * successful call creates a new comment -- so a bare retry-on-any-failure
+ * risks posting the same marker twice when a failure is ambiguous (the
+ * write landed server-side, but the client never saw a successful
+ * response; observed live as a one-off transient failure whose very next
+ * unrelated API call succeeded). Before every retry, re-read recent
+ * comments for an exact-body match: found means the prior attempt actually
+ * landed, so return that comment instead of posting again; not found means
+ * the prior attempt genuinely failed, so back off and retry the POST. This
+ * scan is best-effort only (a transient read failure here must never block
+ * the retry it is meant to protect) and only ever runs on the error path,
+ * never the common single-attempt success path.
+ */
+function findRecentExactBodyMatch(deps, repoPath, number, body) {
+  let rows;
+  try {
+    rows = deps.ghApiJson(`${repoPath}/issues/${number}/comments`, {
+      paginate: true,
+    });
+  } catch {
+    return null;
+  }
+  let newest = null;
+  for (const row of rows) {
+    if (String(row.body ?? '') !== body) {
+      continue;
+    }
+    const id = Number(row.id);
+    const htmlUrl = String(row.html_url ?? '');
+    // Same shape requirement as the fresh-POST path below -- a match with
+    // no usable id/html_url is not a usable result, so keep scanning
+    // instead of returning a comment the caller couldn't act on.
+    if (!Number.isInteger(id) || id <= 0 || htmlUrl === '') {
+      continue;
+    }
+    // Comments come back in ascending creation order; keep the last (most
+    // recent) exact-body match in the unlikely event more than one exists.
+    newest = { id, htmlUrl };
+  }
+  return newest;
+}
+/**
+ * #2460: POST a work-item (issue/PR) comment with a bounded retry against
+ * transient `gh` failures, guarding against the resulting duplicate-post
+ * risk via {@link findRecentExactBodyMatch}, and validating the response
+ * shape before treating the marker as posted (catches a 200-with-
+ * malformed-body edge case a bare retry would not).
+ */
+function postWorkItemCommentWithRetry(deps, repoPath, number, body) {
+  const sleep = deps.sleepSync ?? sleepSync;
+  let lastError;
+  for (
+    let attempt = 1;
+    attempt <= POST_WORK_ITEM_COMMENT_TOTAL_ATTEMPTS;
+    attempt += 1
+  ) {
+    if (attempt > 1) {
+      const existing = findRecentExactBodyMatch(deps, repoPath, number, body);
+      if (existing) {
+        return existing;
+      }
+      sleep(
+        POST_WORK_ITEM_COMMENT_BASE_DELAY_MS * (attempt - 1) +
+          Math.random() * POST_WORK_ITEM_COMMENT_BASE_DELAY_MS,
+      );
+    }
+    try {
+      const out = deps.ghText(
+        [
+          'api',
+          '--method',
+          'POST',
+          `${repoPath}/issues/${number}/comments`,
+          '--input',
+          '-',
+        ],
+        { input: JSON.stringify({ body }) },
+      );
+      const parsed = JSON.parse(out);
+      const id = Number(parsed.id);
+      const htmlUrl = String(parsed.html_url ?? '');
+      if (!Number.isInteger(id) || id <= 0 || htmlUrl === '') {
+        throw new Error(
+          `postWorkItemComment: malformed POST response for ${repoPath}/issues/${number} (missing id/html_url)`,
+        );
+      }
+      return { id, htmlUrl };
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
 /** #2267: {@link GithubProviderAdapterDeps.ghText}, swallowing any failure
  * and returning `''` instead -- the injectable-`deps` equivalent of
  * `gh-exec.mts`'s own module-level `safeGhText`, needed here so a unit test
@@ -316,6 +426,7 @@ const DEFAULT_DEPS = {
   ghApiJson,
   resolveViewerLogin: ghExecResolveViewerLogin,
   ghTextAsync,
+  sleepSync,
 };
 /**
  * GitHub implementation of {@link ProviderPort}. `owner`/`repo` are resolved
@@ -630,19 +741,7 @@ export function createGithubProviderAdapter(owner, repo, deps = DEFAULT_DEPS) {
       }));
     },
     postWorkItemComment(number, body) {
-      const out = deps.ghText(
-        [
-          'api',
-          '--method',
-          'POST',
-          `${repoPath}/issues/${number}/comments`,
-          '--input',
-          '-',
-        ],
-        { input: JSON.stringify({ body }) },
-      );
-      const parsed = JSON.parse(out);
-      return { id: parsed.id, htmlUrl: parsed.html_url };
+      return postWorkItemCommentWithRetry(deps, repoPath, number, body);
     },
     getCollaboratorPermission(login) {
       const normalized = login.trim().toLowerCase();

--- a/scripts/provider-adapter-github.mjs
+++ b/scripts/provider-adapter-github.mjs
@@ -159,11 +159,22 @@ function findRecentExactBodyMatch(deps, repoPath, number, body) {
   }
 }
 /**
+ * #2460 (Copilot review, #2504): a malformed-but-200 POST response is a
+ * shape bug, not a transport blip -- retrying it is unlikely to help, and
+ * doing so anyway risks a double-post if the best-effort dedupe read
+ * ({@link findRecentExactBodyMatch}) itself fails. A dedicated error class
+ * lets {@link postWorkItemCommentWithRetry}'s catch block recognize this
+ * case and fail fast instead of consuming the remaining bounded attempts.
+ */
+class MalformedPostWorkItemCommentResponseError extends Error {}
+/**
  * #2460: POST a work-item (issue/PR) comment with a bounded retry against
  * transient `gh` failures, guarding against the resulting duplicate-post
  * risk via {@link findRecentExactBodyMatch}, and validating the response
  * shape before treating the marker as posted (catches a 200-with-
- * malformed-body edge case a bare retry would not).
+ * malformed-body edge case a bare retry would not -- see
+ * {@link MalformedPostWorkItemCommentResponseError} for why that specific
+ * case fails fast rather than retrying).
  */
 function postWorkItemCommentWithRetry(deps, repoPath, number, body) {
   const sleep = deps.sleepSync ?? sleepSync;
@@ -199,12 +210,15 @@ function postWorkItemCommentWithRetry(deps, repoPath, number, body) {
       const id = Number(parsed.id);
       const htmlUrl = String(parsed.html_url ?? '');
       if (!Number.isInteger(id) || id <= 0 || htmlUrl === '') {
-        throw new Error(
+        throw new MalformedPostWorkItemCommentResponseError(
           `postWorkItemComment: malformed POST response for ${repoPath}/issues/${number} (missing id/html_url)`,
         );
       }
       return { id, htmlUrl };
     } catch (error) {
+      if (error instanceof MalformedPostWorkItemCommentResponseError) {
+        throw error;
+      }
       lastError = error;
     }
   }

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -148,6 +148,130 @@ function assertNoGraphqlErrors(payload: unknown, context: string): void {
   }
 }
 
+/**
+ * #2460: synchronous bounded sleep via `Atomics.wait` on a throwaway
+ * `SharedArrayBuffer` -- the same technique `advisory-convergence.mts`,
+ * `clone-lock.mts`, and `rerun-advisory-convergence.mts` each already
+ * duplicate locally rather than switching to `async`/`await` (the existing
+ * `withBoundedRetry` in `gh-exec.mts` is `Promise`-returning and would force
+ * every synchronous caller of {@link ProviderPort.postWorkItemComment} --
+ * and the whole `ProviderPort` interface -- to become async for one retry
+ * loop). Duplicated here as this one-line function, mirroring that same
+ * established precedent, rather than adding new cross-file coupling.
+ */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+const POST_WORK_ITEM_COMMENT_TOTAL_ATTEMPTS = 3;
+const POST_WORK_ITEM_COMMENT_BASE_DELAY_MS = 200;
+
+/**
+ * #2460: the issues-comments POST endpoint is not idempotent -- each
+ * successful call creates a new comment -- so a bare retry-on-any-failure
+ * risks posting the same marker twice when a failure is ambiguous (the
+ * write landed server-side, but the client never saw a successful
+ * response; observed live as a one-off transient failure whose very next
+ * unrelated API call succeeded). Before every retry, re-read recent
+ * comments for an exact-body match: found means the prior attempt actually
+ * landed, so return that comment instead of posting again; not found means
+ * the prior attempt genuinely failed, so back off and retry the POST. This
+ * scan is best-effort only (a transient read failure here must never block
+ * the retry it is meant to protect) and only ever runs on the error path,
+ * never the common single-attempt success path.
+ */
+function findRecentExactBodyMatch(
+  deps: GithubProviderAdapterDeps,
+  repoPath: string,
+  number: number,
+  body: string,
+): ProviderPostedComment | null {
+  let rows: { id?: unknown; body?: unknown; html_url?: unknown }[];
+  try {
+    rows = deps.ghApiJson(`${repoPath}/issues/${number}/comments`, {
+      paginate: true,
+    }) as typeof rows;
+  } catch {
+    return null;
+  }
+  let newest: { id: number; htmlUrl: string } | null = null;
+  for (const row of rows) {
+    if (String(row.body ?? '') !== body) {
+      continue;
+    }
+    const id = Number(row.id);
+    const htmlUrl = String(row.html_url ?? '');
+    // Same shape requirement as the fresh-POST path below -- a match with
+    // no usable id/html_url is not a usable result, so keep scanning
+    // instead of returning a comment the caller couldn't act on.
+    if (!Number.isInteger(id) || id <= 0 || htmlUrl === '') {
+      continue;
+    }
+    // Comments come back in ascending creation order; keep the last (most
+    // recent) exact-body match in the unlikely event more than one exists.
+    newest = { id, htmlUrl };
+  }
+  return newest;
+}
+
+/**
+ * #2460: POST a work-item (issue/PR) comment with a bounded retry against
+ * transient `gh` failures, guarding against the resulting duplicate-post
+ * risk via {@link findRecentExactBodyMatch}, and validating the response
+ * shape before treating the marker as posted (catches a 200-with-
+ * malformed-body edge case a bare retry would not).
+ */
+function postWorkItemCommentWithRetry(
+  deps: GithubProviderAdapterDeps,
+  repoPath: string,
+  number: number,
+  body: string,
+): ProviderPostedComment {
+  const sleep = deps.sleepSync ?? sleepSync;
+  let lastError: unknown;
+  for (
+    let attempt = 1;
+    attempt <= POST_WORK_ITEM_COMMENT_TOTAL_ATTEMPTS;
+    attempt += 1
+  ) {
+    if (attempt > 1) {
+      const existing = findRecentExactBodyMatch(deps, repoPath, number, body);
+      if (existing) {
+        return existing;
+      }
+      sleep(
+        POST_WORK_ITEM_COMMENT_BASE_DELAY_MS * (attempt - 1) +
+          Math.random() * POST_WORK_ITEM_COMMENT_BASE_DELAY_MS,
+      );
+    }
+    try {
+      const out = deps.ghText(
+        [
+          'api',
+          '--method',
+          'POST',
+          `${repoPath}/issues/${number}/comments`,
+          '--input',
+          '-',
+        ],
+        { input: JSON.stringify({ body }) },
+      );
+      const parsed = JSON.parse(out) as { id?: unknown; html_url?: unknown };
+      const id = Number(parsed.id);
+      const htmlUrl = String(parsed.html_url ?? '');
+      if (!Number.isInteger(id) || id <= 0 || htmlUrl === '') {
+        throw new Error(
+          `postWorkItemComment: malformed POST response for ${repoPath}/issues/${number} (missing id/html_url)`,
+        );
+      }
+      return { id, htmlUrl };
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
 /** #2267: {@link GithubProviderAdapterDeps.ghText}, swallowing any failure
  * and returning `''` instead -- the injectable-`deps` equivalent of
  * `gh-exec.mts`'s own module-level `safeGhText`, needed here so a unit test
@@ -467,6 +591,13 @@ export interface GithubProviderAdapterDeps {
   resolveViewerLogin: typeof ghExecResolveViewerLogin;
   /** Backs the three traversal-only `*Async` methods (step 12, #2266). */
   ghTextAsync: typeof ghTextAsync;
+  /**
+   * Backs {@link postWorkItemCommentWithRetry}'s backoff (#2460). Optional
+   * so existing deps overrides that predate this field keep compiling;
+   * defaults to the real `Atomics.wait`-based {@link sleepSync}. Inject a
+   * no-op in tests to keep them fast.
+   */
+  sleepSync?: (ms: number) => void;
 }
 
 const DEFAULT_DEPS: GithubProviderAdapterDeps = {
@@ -474,6 +605,7 @@ const DEFAULT_DEPS: GithubProviderAdapterDeps = {
   ghApiJson,
   resolveViewerLogin: ghExecResolveViewerLogin,
   ghTextAsync,
+  sleepSync,
 };
 
 /**
@@ -861,19 +993,7 @@ export function createGithubProviderAdapter(
     },
 
     postWorkItemComment(number: number, body: string): ProviderPostedComment {
-      const out = deps.ghText(
-        [
-          'api',
-          '--method',
-          'POST',
-          `${repoPath}/issues/${number}/comments`,
-          '--input',
-          '-',
-        ],
-        { input: JSON.stringify({ body }) },
-      );
-      const parsed = JSON.parse(out) as { id: number; html_url: string };
-      return { id: parsed.id, htmlUrl: parsed.html_url };
+      return postWorkItemCommentWithRetry(deps, repoPath, number, body);
     },
 
     getCollaboratorPermission(

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -296,7 +296,14 @@ function postWorkItemCommentWithRetry(
       lastError = error;
     }
   }
-  throw lastError;
+  // Copilot review, #2504: `lastError` is `unknown` -- a non-`Error` thrown
+  // by `deps.ghText`/`JSON.parse` (a string, `undefined`, ...) would make
+  // downstream handling/logging inconsistent. Always throw a real `Error`.
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(
+        `postWorkItemComment: all ${POST_WORK_ITEM_COMMENT_TOTAL_ATTEMPTS} attempts failed for ${repoPath}/issues/${number}: ${String(lastError)}`,
+      );
 }
 
 /** #2267: {@link GithubProviderAdapterDeps.ghText}, swallowing any failure

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -188,33 +188,42 @@ function findRecentExactBodyMatch(
   number: number,
   body: string,
 ): ProviderPostedComment | null {
-  let rows: { id?: unknown; body?: unknown; html_url?: unknown }[];
+  // The whole read-and-scan is wrapped in one try/catch, not just the
+  // `ghApiJson` call: a malformed row (e.g. a stray `null` entry) thrown
+  // from the loop body below must fail this best-effort scan the same
+  // way a transport failure does, never abort the retry it exists to
+  // protect (Copilot review, #2504).
   try {
-    rows = deps.ghApiJson(
+    const rows = deps.ghApiJson(
       `${repoPath}/issues/${number}/comments?per_page=100`,
       { paginate: true },
-    ) as typeof rows;
+    ) as { id?: unknown; body?: unknown; html_url?: unknown }[];
+    let newest: { id: number; htmlUrl: string } | null = null;
+    for (const row of rows) {
+      if (row === null || typeof row !== 'object') {
+        continue;
+      }
+      if (String(row.body ?? '') !== body) {
+        continue;
+      }
+      const id = Number(row.id);
+      const htmlUrl = String(row.html_url ?? '');
+      // Same shape requirement as the fresh-POST path below -- a match
+      // with no usable id/html_url is not a usable result, so keep
+      // scanning instead of returning a comment the caller couldn't
+      // act on.
+      if (!Number.isInteger(id) || id <= 0 || htmlUrl === '') {
+        continue;
+      }
+      // Comments come back in ascending creation order; keep the last
+      // (most recent) exact-body match in the unlikely event more than
+      // one exists.
+      newest = { id, htmlUrl };
+    }
+    return newest;
   } catch {
     return null;
   }
-  let newest: { id: number; htmlUrl: string } | null = null;
-  for (const row of rows) {
-    if (String(row.body ?? '') !== body) {
-      continue;
-    }
-    const id = Number(row.id);
-    const htmlUrl = String(row.html_url ?? '');
-    // Same shape requirement as the fresh-POST path below -- a match with
-    // no usable id/html_url is not a usable result, so keep scanning
-    // instead of returning a comment the caller couldn't act on.
-    if (!Number.isInteger(id) || id <= 0 || htmlUrl === '') {
-      continue;
-    }
-    // Comments come back in ascending creation order; keep the last (most
-    // recent) exact-body match in the unlikely event more than one exists.
-    newest = { id, htmlUrl };
-  }
-  return newest;
 }
 
 /**

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -227,11 +227,23 @@ function findRecentExactBodyMatch(
 }
 
 /**
+ * #2460 (Copilot review, #2504): a malformed-but-200 POST response is a
+ * shape bug, not a transport blip -- retrying it is unlikely to help, and
+ * doing so anyway risks a double-post if the best-effort dedupe read
+ * ({@link findRecentExactBodyMatch}) itself fails. A dedicated error class
+ * lets {@link postWorkItemCommentWithRetry}'s catch block recognize this
+ * case and fail fast instead of consuming the remaining bounded attempts.
+ */
+class MalformedPostWorkItemCommentResponseError extends Error {}
+
+/**
  * #2460: POST a work-item (issue/PR) comment with a bounded retry against
  * transient `gh` failures, guarding against the resulting duplicate-post
  * risk via {@link findRecentExactBodyMatch}, and validating the response
  * shape before treating the marker as posted (catches a 200-with-
- * malformed-body edge case a bare retry would not).
+ * malformed-body edge case a bare retry would not -- see
+ * {@link MalformedPostWorkItemCommentResponseError} for why that specific
+ * case fails fast rather than retrying).
  */
 function postWorkItemCommentWithRetry(
   deps: GithubProviderAdapterDeps,
@@ -272,12 +284,15 @@ function postWorkItemCommentWithRetry(
       const id = Number(parsed.id);
       const htmlUrl = String(parsed.html_url ?? '');
       if (!Number.isInteger(id) || id <= 0 || htmlUrl === '') {
-        throw new Error(
+        throw new MalformedPostWorkItemCommentResponseError(
           `postWorkItemComment: malformed POST response for ${repoPath}/issues/${number} (missing id/html_url)`,
         );
       }
       return { id, htmlUrl };
     } catch (error) {
+      if (error instanceof MalformedPostWorkItemCommentResponseError) {
+        throw error;
+      }
       lastError = error;
     }
   }

--- a/src/scripts/provider-adapter-github.mts
+++ b/src/scripts/provider-adapter-github.mts
@@ -172,13 +172,15 @@ const POST_WORK_ITEM_COMMENT_BASE_DELAY_MS = 200;
  * risks posting the same marker twice when a failure is ambiguous (the
  * write landed server-side, but the client never saw a successful
  * response; observed live as a one-off transient failure whose very next
- * unrelated API call succeeded). Before every retry, re-read recent
- * comments for an exact-body match: found means the prior attempt actually
- * landed, so return that comment instead of posting again; not found means
- * the prior attempt genuinely failed, so back off and retry the POST. This
- * scan is best-effort only (a transient read failure here must never block
- * the retry it is meant to protect) and only ever runs on the error path,
- * never the common single-attempt success path.
+ * unrelated API call succeeded). Before every retry, re-read the full
+ * (paginated) comment history for an exact-body match: found means the
+ * prior attempt actually landed, so return that comment instead of posting
+ * again; not found means the prior attempt genuinely failed, so back off
+ * and retry the POST. This scan is best-effort only (a transient read
+ * failure here must never block the retry it is meant to protect) and only
+ * ever runs on the error path, never the common single-attempt success
+ * path. Requests the maximum page size (Copilot review, #2504) to bound
+ * pagination overhead on a heavily-commented issue/PR.
  */
 function findRecentExactBodyMatch(
   deps: GithubProviderAdapterDeps,
@@ -188,9 +190,10 @@ function findRecentExactBodyMatch(
 ): ProviderPostedComment | null {
   let rows: { id?: unknown; body?: unknown; html_url?: unknown }[];
   try {
-    rows = deps.ghApiJson(`${repoPath}/issues/${number}/comments`, {
-      paginate: true,
-    }) as typeof rows;
+    rows = deps.ghApiJson(
+      `${repoPath}/issues/${number}/comments?per_page=100`,
+      { paginate: true },
+    ) as typeof rows;
   } catch {
     return null;
   }

--- a/tests/provider-adapter-github.test.mts
+++ b/tests/provider-adapter-github.test.mts
@@ -22,6 +22,10 @@ function fakeDeps(
     ghTextAsync: () => {
       throw new Error('ghTextAsync not stubbed for this test');
     },
+    // No-op by default so a test exercising postWorkItemComment's retry
+    // path (#2460) never actually sleeps; override per-test to assert on
+    // invocation count/delay when that matters.
+    sleepSync: () => {},
     ...overrides,
   } as GithubProviderAdapterDeps;
 }
@@ -1700,5 +1704,88 @@ test('listChangeRequestGraphqlReviews throws on a null reviews connection', () =
   assert.throws(
     () => port.listChangeRequestGraphqlReviews(7),
     /null reviews connection/,
+  );
+});
+
+// --- postWorkItemComment retry / verification (#2460) -----------------------
+
+test('postWorkItemComment retries once after a transient failure and returns the second attempt', () => {
+  let ghTextCalls = 0;
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () => {
+        ghTextCalls += 1;
+        if (ghTextCalls === 1) {
+          throw new Error('transient: HTTP 401');
+        }
+        return JSON.stringify({ id: 42, html_url: 'https://example/42' });
+      },
+      // No matching comment exists yet -- the prior attempt genuinely
+      // failed, so the retry-then-dedupe-check path must fall through to
+      // a fresh POST rather than returning a false match.
+      ghApiJson: () => [],
+    }),
+  );
+  const result = port.postWorkItemComment(9, 'marker body');
+  assert.deepEqual(result, { id: 42, htmlUrl: 'https://example/42' });
+  assert.equal(ghTextCalls, 2);
+});
+
+test('postWorkItemComment returns the existing comment instead of double-posting when a retry finds an exact-body match', () => {
+  let ghTextCalls = 0;
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () => {
+        ghTextCalls += 1;
+        throw new Error('ambiguous: ETIMEDOUT');
+      },
+      // The first attempt's failure was ambiguous: the write actually
+      // landed server-side. The re-read must find it and short-circuit
+      // instead of posting a duplicate.
+      ghApiJson: () => [
+        { id: 7, body: 'other comment', html_url: 'https://example/7' },
+        { id: 8, body: 'marker body', html_url: 'https://example/8' },
+      ],
+    }),
+  );
+  const result = port.postWorkItemComment(9, 'marker body');
+  assert.deepEqual(result, { id: 8, htmlUrl: 'https://example/8' });
+  // Only the original attempt ran -- the dedupe match short-circuited
+  // before a second POST.
+  assert.equal(ghTextCalls, 1);
+});
+
+test('postWorkItemComment throws on a malformed successful response instead of returning a bad result', () => {
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () => JSON.stringify({ html_url: 'https://example/1' }), // missing id
+    }),
+  );
+  assert.throws(
+    () => port.postWorkItemComment(9, 'marker body'),
+    /malformed POST response/,
+  );
+});
+
+test('postWorkItemComment throws the last error once retries are exhausted with no matching comment ever found', () => {
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () => {
+        throw new Error('persistent: HTTP 500');
+      },
+      ghApiJson: () => [],
+    }),
+  );
+  assert.throws(
+    () => port.postWorkItemComment(9, 'marker body'),
+    /persistent: HTTP 500/,
   );
 });

--- a/tests/provider-adapter-github.test.mts
+++ b/tests/provider-adapter-github.test.mts
@@ -1797,6 +1797,29 @@ test('postWorkItemComment throws on a malformed successful response instead of r
   );
 });
 
+test('postWorkItemComment does not retry a malformed successful response (Copilot review, #2504)', () => {
+  // Unlike a transport failure, a malformed-but-200 response is a shape
+  // bug -- retrying it is unlikely to help and would risk a double-post
+  // if the best-effort dedupe read itself fails. It must fail fast
+  // instead of consuming the remaining bounded attempts.
+  let ghTextCalls = 0;
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () => {
+        ghTextCalls += 1;
+        return JSON.stringify({ html_url: 'https://example/1' }); // missing id, every call
+      },
+    }),
+  );
+  assert.throws(
+    () => port.postWorkItemComment(9, 'marker body'),
+    /malformed POST response/,
+  );
+  assert.equal(ghTextCalls, 1);
+});
+
 test('postWorkItemComment throws the last error once retries are exhausted with no matching comment ever found', () => {
   const port = createGithubProviderAdapter(
     'o',

--- a/tests/provider-adapter-github.test.mts
+++ b/tests/provider-adapter-github.test.mts
@@ -1759,6 +1759,30 @@ test('postWorkItemComment returns the existing comment instead of double-posting
   assert.equal(ghTextCalls, 1);
 });
 
+test('postWorkItemComment: a malformed row (e.g. null) in the dedupe scan never aborts the retry (Copilot review, #2504)', () => {
+  let ghTextCalls = 0;
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      ghText: () => {
+        ghTextCalls += 1;
+        if (ghTextCalls === 1) {
+          throw new Error('transient: HTTP 401');
+        }
+        return JSON.stringify({ id: 42, html_url: 'https://example/42' });
+      },
+      // A stray `null` entry must not throw out of the best-effort dedupe
+      // scan and abort the whole retry -- it should be skipped like any
+      // other non-matching row, falling through to a genuine retry.
+      ghApiJson: () => [null, { id: 7, body: 'other comment' }],
+    }),
+  );
+  const result = port.postWorkItemComment(9, 'marker body');
+  assert.deepEqual(result, { id: 42, htmlUrl: 'https://example/42' });
+  assert.equal(ghTextCalls, 2);
+});
+
 test('postWorkItemComment throws on a malformed successful response instead of returning a bad result', () => {
   const port = createGithubProviderAdapter(
     'o',

--- a/tests/provider-adapter-github.test.mts
+++ b/tests/provider-adapter-github.test.mts
@@ -1836,3 +1836,25 @@ test('postWorkItemComment throws the last error once retries are exhausted with 
     /persistent: HTTP 500/,
   );
 });
+
+test('postWorkItemComment always throws a real Error, even when the underlying failure is a non-Error value (Copilot review, #2504)', () => {
+  const port = createGithubProviderAdapter(
+    'o',
+    'r',
+    fakeDeps({
+      // Deliberately simulating a non-Error throw (e.g. from a misbehaving
+      // dependency) to verify the retry loop's own Error-wrapping fallback.
+      ghText: () => {
+        throw 'persistent: not an Error instance';
+      },
+      ghApiJson: () => [],
+    }),
+  );
+  assert.throws(
+    () => port.postWorkItemComment(9, 'marker body'),
+    (error: unknown) =>
+      error instanceof Error &&
+      /all 3 attempts failed/.test(error.message) &&
+      /persistent: not an Error instance/.test(error.message),
+  );
+});

--- a/tests/provider-adapter-parity.test.mts
+++ b/tests/provider-adapter-parity.test.mts
@@ -38,6 +38,9 @@ function fakeDeps(
     ghTextAsync: () => {
       throw new Error('ghTextAsync not stubbed for this test');
     },
+    // No-op by default so a test exercising postWorkItemComment's retry
+    // path (#2460) never actually sleeps.
+    sleepSync: () => {},
     ...overrides,
   } as GithubProviderAdapterDeps;
 }


### PR DESCRIPTION
# Summary

Operational markers (claim/watermark/baseline/advisory) were POSTed
via a single `gh api --method POST` call with no confirmation the
write landed and no retry on a transient failure -- observed live as a
one-off 401 while the next API call in the same session succeeded.
Because F2's merge gate reads an absent marker as "stale/missing"
rather than "post failed", a silently-dropped POST caused a confusing,
self-inflicted return-to-E1 whose real cause was an unverified
transient write failure.

This wraps the marker POST in a bounded retry (3 attempts, backoff +
jitter) and, since the comments-POST endpoint is **not idempotent**,
guards against posting the same marker twice on an ambiguous failure:
before each retry, recent comments are re-read for an exact-body match
and returned instead of posting again if found. A successful POST's
response is also validated (`id`/`html_url` shape) before being
treated as landed.

## Linked issue

Closes #2460

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

The issue's own candidate files (`post-idd-marker.mts`, `gh-exec.mts`)
predate the #2266 provider-adapter migration (merged 2026-09-01); the
POST call site now lives in `provider-adapter-github.mts`'s
`postWorkItemComment`, which is where this fix landed instead
(documented in the issue's own plan comments as a deliberate
deviation, following its "implementer's judgment on placement"
latitude).

`postWorkItemComment` is part of the synchronous `ProviderPort`
interface; rather than force it (and its call sites) to `async` to
reuse the existing `withBoundedRetry` in `gh-exec.mts`, this follows
this repository's own established precedent of a locally-duplicated
synchronous `sleepSync` (`Atomics.wait` on a throwaway
`SharedArrayBuffer` -- already duplicated the same way in
`advisory-convergence.mts`, `clone-lock.mts`, and
`rerun-advisory-convergence.mts`).

An earlier draft of this fix (caught by an independent pre-commit
critique pass) retried every failure unconditionally, which would have
risked exactly the double-post this issue exists to prevent -- the
dedupe-before-retry check was added specifically to close that gap.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4749/4749 pass, including 4 new tests: retry-then-
      succeed, dedupe-avoids-double-post, malformed-response throws,
      retries-exhausted throws)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed; pre-existing warnings
      unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (none)
