### PR TITLE
docs(idd-ci): give ad-hoc (non-claimed) sessions an on-ramp to wake-up discipline

### DIFF
--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -312,7 +312,7 @@ This advisory, tool-agnostic note keeps the **wait itself cheap**: the
 dominant cost is each re-invocation's context re-read (worse past the
 prompt-cache TTL), not the idle time. It applies to a session pushing a
 commit and waiting on CI or bot review outside a formal IDD claim too
-(`#2464`) — nothing below depends on being mid-phase.
+(issue `#2464`) — nothing below depends on being mid-phase.
 
 **Portability**: under supervisor/worker topologies, a background
 wait's completion notification often reaches only the supervisor, so

--- a/.github/instructions/idd-ci.instructions.md
+++ b/.github/instructions/idd-ci.instructions.md
@@ -310,7 +310,9 @@ infra-vs-code triage above:
 
 This advisory, tool-agnostic note keeps the **wait itself cheap**: the
 dominant cost is each re-invocation's context re-read (worse past the
-prompt-cache TTL), not the idle time.
+prompt-cache TTL), not the idle time. It applies to a session pushing a
+commit and waiting on CI or bot review outside a formal IDD claim too
+(`#2464`) — nothing below depends on being mid-phase.
 
 **Portability**: under supervisor/worker topologies, a background
 wait's completion notification often reaches only the supervisor, so

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -305,7 +305,9 @@ infra-vs-code triage above:
 
 This advisory, tool-agnostic note keeps the **wait itself cheap**: the
 dominant cost is each re-invocation's context re-read (worse past the
-prompt-cache TTL), not the idle time.
+prompt-cache TTL), not the idle time. It applies to a session pushing a
+commit and waiting on CI or bot review outside a formal IDD claim too
+(`#2464`) — nothing below depends on being mid-phase.
 
 **Portability**: under supervisor/worker topologies, a background
 wait's completion notification often reaches only the supervisor, so

--- a/idd-template/.github/instructions/idd-ci.instructions.md
+++ b/idd-template/.github/instructions/idd-ci.instructions.md
@@ -307,7 +307,7 @@ This advisory, tool-agnostic note keeps the **wait itself cheap**: the
 dominant cost is each re-invocation's context re-read (worse past the
 prompt-cache TTL), not the idle time. It applies to a session pushing a
 commit and waiting on CI or bot review outside a formal IDD claim too
-(`#2464`) — nothing below depends on being mid-phase.
+(issue `#2464`) — nothing below depends on being mid-phase.
 
 **Portability**: under supervisor/worker topologies, a background
 wait's completion notification often reaches only the supervisor, so

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -995,12 +995,21 @@ cross-agent entry path and phase routing.
 Before starting IDD work, open
 `.github/instructions/idd-overview-core.instructions.md`. Open the routed
 phase file manually when the current step changes.
+
+Doing ad-hoc engineering outside a formal IDD claim (a direct fix, a PR,
+a review reply)? The "Wake-up discipline" section of
+`.github/instructions/idd-ci.instructions.md` (no self-polling while
+waiting on CI or bot review) still applies — open it whenever a commit
+you pushed is waiting on either.
 ```
 
 - point to `docs/idd-workflow.md` as the cross-agent entry path
 - open `.github/instructions/idd-overview-core.instructions.md` before
   starting IDD work
 - manually open the routed phase file when the current step changes
+- give ad-hoc engineering (no formal claim) an on-ramp to
+  `idd-ci.instructions.md`'s Wake-up discipline section, since it has no
+  other trigger to load a phase file (`#2464`)
 
 Apply this section to `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md`,
 adapting the surrounding wording to each tool while preserving the same


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

`idd-ci.instructions.md`'s "Wake-up discipline" section (no self-polling
after backgrounding a CI wait) lived only inside phase files loaded
during a formal claimed IDD loop. A session doing ad-hoc engineering
(fix a bug, open a PR, respond to review feedback) outside a formal
claim had no trigger to ever load that file, even though the CI/bot-
review-wait situation it describes is identical.

Adds (`#2464`):

- a one-sentence scope note at the top of the Wake-up discipline
  section itself, stating it applies outside the formal loop too;
- a pointer in `ONBOARDING.md`'s IDD Workflow template — the block
  copied into every adopter's `CLAUDE.md`/`AGENTS.md`/`GEMINI.md`, so
  it's loaded regardless of claim state — so any session waiting on CI
  or bot review discovers the no-polling discipline.

## Linked issue

Closes #2464

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

This is distinct from issue #2221 ("wake-up discipline recurrence
persists"), which is scoped to *delegated workers* who already have the
guidance loaded but still fail to apply it — this issue is about a
session that never had a trigger to load the guidance at all.

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4765/4765 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
