### PR TITLE
fix(marker-parsing): three residual case-sensitivity/boundary gaps

### DIFF
--- a/docs/idd-advisory-wait-shell-fallback.md
+++ b/docs/idd-advisory-wait-shell-fallback.md
@@ -45,7 +45,7 @@ LAST_COPILOT_COMMIT=$(
 )
 
 COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
-  --jq '.users | any(.login == "Copilot" or .login == "copilot-pull-request-reviewer" or .login == "copilot-pull-request-reviewer[bot]")')
+  --jq '.users | any((.login // "" | ascii_downcase) as $l | $l == "copilot" or $l == "copilot-pull-request-reviewer" or $l == "copilot-pull-request-reviewer[bot]")')
 # Observed once: requested_reviewers can lag a successful re-request
 # or empty on submit, so false is not idle proof.
 # LAST_COPILOT_COMMIT == PR_HEAD_SHA remains the SATISFIED signal.
@@ -61,11 +61,10 @@ COPILOT_PENDING_COVERS_HEAD=$(
              and ((.value.sha // .value.commit_id // "") == $sha)))
            | last | .key // null) as $head_index
         | (map(select(.value.event == "review_requested"
-             and (((.value.requested_reviewer.login // "") == "Copilot")
-                  or ((.value.requested_reviewer.login // "")
-                      == "copilot-pull-request-reviewer")
-                  or ((.value.requested_reviewer.login // "")
-                      == "copilot-pull-request-reviewer[bot]"))))
+             and (((.value.requested_reviewer.login // "" | ascii_downcase) as $l
+                  | $l == "copilot"
+                  or $l == "copilot-pull-request-reviewer"
+                  or $l == "copilot-pull-request-reviewer[bot]"))))
            | last | .key // null) as $request_index
         | ($head_index != null and $request_index != null and
            $request_index > $head_index)

--- a/idd-template/docs/idd-advisory-wait-shell-fallback.md
+++ b/idd-template/docs/idd-advisory-wait-shell-fallback.md
@@ -45,7 +45,7 @@ LAST_COPILOT_COMMIT=$(
 )
 
 COPILOT_PENDING=$(gh api "repos/${OWNER}/${REPO}/pulls/{pr-number}/requested_reviewers" \
-  --jq '.users | any(.login == "Copilot" or .login == "copilot-pull-request-reviewer" or .login == "copilot-pull-request-reviewer[bot]")')
+  --jq '.users | any((.login // "" | ascii_downcase) as $l | $l == "copilot" or $l == "copilot-pull-request-reviewer" or $l == "copilot-pull-request-reviewer[bot]")')
 # Observed once: requested_reviewers can lag a successful re-request
 # or empty on submit, so false is not idle proof.
 # LAST_COPILOT_COMMIT == PR_HEAD_SHA remains the SATISFIED signal.
@@ -61,11 +61,10 @@ COPILOT_PENDING_COVERS_HEAD=$(
              and ((.value.sha // .value.commit_id // "") == $sha)))
            | last | .key // null) as $head_index
         | (map(select(.value.event == "review_requested"
-             and (((.value.requested_reviewer.login // "") == "Copilot")
-                  or ((.value.requested_reviewer.login // "")
-                      == "copilot-pull-request-reviewer")
-                  or ((.value.requested_reviewer.login // "")
-                      == "copilot-pull-request-reviewer[bot]"))))
+             and (((.value.requested_reviewer.login // "" | ascii_downcase) as $l
+                  | $l == "copilot"
+                  or $l == "copilot-pull-request-reviewer"
+                  or $l == "copilot-pull-request-reviewer[bot]"))))
            | last | .key // null) as $request_index
         | ($head_index != null and $request_index != null and
            $request_index > $head_index)

--- a/scripts/discover-roadmap-graph.mjs
+++ b/scripts/discover-roadmap-graph.mjs
@@ -1390,11 +1390,27 @@ export function extractTaskListReferences(body) {
   // stripMarkdownCodeRegions preserves the line count, so the masked and raw
   // lines share an index and evidence stays the raw line for any surviving edge
   // (e.g. one that shares a line with unrelated inline code).
+  //
+  // Two forms recognized, tried in order (idd-skill#2476): a bare `#123`
+  // or a markdown link whose TEXT is `#123` (e.g. `- [ ] [#123](url)`,
+  // the `[`/`]`/`(...)` around the number all optional); falling back to
+  // a markdown link with arbitrary link text whose URL targets
+  // `.../issues/123` or `.../pull/123` (e.g.
+  // `- [ ] [some text](https://.../issues/123)`) -- inlined per-call
+  // (not hoisted to a module-level const) because this file's CLI entry
+  // point (`if (import.meta.main)`) sits near the top of the file and
+  // can reach this function during synchronous module evaluation, before
+  // a later top-level const would have initialized (TDZ).
+  const bareOrLinkTextRe =
+    /^\s*-\s*\[(?: |x|X)\]\s+\[?#(\d+)\b\]?(?:\([^)\n]*\))?/u;
+  const linkUrlRe =
+    /^\s*-\s*\[(?: |x|X)\]\s+\[[^\]\n]*\]\([^)\n]*\/(?:issues|pull)\/(\d+)(?:[/?#][^)\n]*)?\)/u;
   const rawBody = String(body ?? '');
   const rawLines = rawBody.split(/\r?\n/u);
   const maskedLines = stripMarkdownCodeRegions(rawBody).split(/\r?\n/u);
   return maskedLines.flatMap((maskedLine, index) => {
-    const match = maskedLine.match(/^\s*-\s*\[(?: |x|X)\]\s+#(\d+)\b/u);
+    const match =
+      maskedLine.match(bareOrLinkTextRe) ?? maskedLine.match(linkUrlRe);
     if (!match) {
       return [];
     }

--- a/scripts/idd-doctor.mjs
+++ b/scripts/idd-doctor.mjs
@@ -1616,14 +1616,23 @@ export function classifyWorktreeHeadFinding(
  * `source` command loads the shared `_idd-worktree-guard.sh` helper. Matching
  * the sourcing line (not a bare mention) means a hook that only names the
  * helper in a comment — e.g. a leftover doc line after the source was removed —
- * correctly reads as inert rather than wired. Pure (no I/O) so the
- * wired/unwired classification can be unit-tested directly. A non-string
- * (absent/unreadable hook) is treated as not wiring the guard.
+ * correctly reads as inert rather than wired. The trailing `(?![.\w-])`
+ * boundary rejects a disabled/backed-up filename that merely starts with
+ * `_idd-worktree-guard.sh` (e.g. `_idd-worktree-guard.sh.disabled`,
+ * `_idd-worktree-guard.sh.bak`) — those are not the active guard file,
+ * regardless of the sourcing syntax around them (idd-skill#2476) — while
+ * still matching the CRLF-converted case (a `\r` right after `.sh` is not
+ * excluded, so `hookHasCrlfLineEndings` below stays the sole signal for
+ * that failure mode, unchanged from before this fix). Pure (no I/O) so
+ * the wired/unwired classification can be unit-tested directly. A
+ * non-string (absent/unreadable hook) is treated as not wiring the guard.
  */
 export function hookWiresWorktreeGuard(content) {
   return (
     typeof content === 'string' &&
-    /^[ \t]*(?:\.|source)[ \t]+[^\n]*_idd-worktree-guard\.sh/m.test(content)
+    /^[ \t]*(?:\.|source)[ \t]+[^\n]*_idd-worktree-guard\.sh(?![.\w-])/m.test(
+      content,
+    )
   );
 }
 /**

--- a/src/scripts/discover-roadmap-graph.mts
+++ b/src/scripts/discover-roadmap-graph.mts
@@ -2023,11 +2023,27 @@ export function extractTaskListReferences(
   // stripMarkdownCodeRegions preserves the line count, so the masked and raw
   // lines share an index and evidence stays the raw line for any surviving edge
   // (e.g. one that shares a line with unrelated inline code).
+  //
+  // Two forms recognized, tried in order (idd-skill#2476): a bare `#123`
+  // or a markdown link whose TEXT is `#123` (e.g. `- [ ] [#123](url)`,
+  // the `[`/`]`/`(...)` around the number all optional); falling back to
+  // a markdown link with arbitrary link text whose URL targets
+  // `.../issues/123` or `.../pull/123` (e.g.
+  // `- [ ] [some text](https://.../issues/123)`) -- inlined per-call
+  // (not hoisted to a module-level const) because this file's CLI entry
+  // point (`if (import.meta.main)`) sits near the top of the file and
+  // can reach this function during synchronous module evaluation, before
+  // a later top-level const would have initialized (TDZ).
+  const bareOrLinkTextRe =
+    /^\s*-\s*\[(?: |x|X)\]\s+\[?#(\d+)\b\]?(?:\([^)\n]*\))?/u;
+  const linkUrlRe =
+    /^\s*-\s*\[(?: |x|X)\]\s+\[[^\]\n]*\]\([^)\n]*\/(?:issues|pull)\/(\d+)(?:[/?#][^)\n]*)?\)/u;
   const rawBody = String(body ?? '');
   const rawLines = rawBody.split(/\r?\n/u);
   const maskedLines = stripMarkdownCodeRegions(rawBody).split(/\r?\n/u);
   return maskedLines.flatMap((maskedLine, index) => {
-    const match = maskedLine.match(/^\s*-\s*\[(?: |x|X)\]\s+#(\d+)\b/u);
+    const match =
+      maskedLine.match(bareOrLinkTextRe) ?? maskedLine.match(linkUrlRe);
     if (!match) {
       return [];
     }

--- a/src/scripts/idd-doctor.mts
+++ b/src/scripts/idd-doctor.mts
@@ -1934,14 +1934,23 @@ export interface WorktreeGuardActivationInput {
  * `source` command loads the shared `_idd-worktree-guard.sh` helper. Matching
  * the sourcing line (not a bare mention) means a hook that only names the
  * helper in a comment — e.g. a leftover doc line after the source was removed —
- * correctly reads as inert rather than wired. Pure (no I/O) so the
- * wired/unwired classification can be unit-tested directly. A non-string
- * (absent/unreadable hook) is treated as not wiring the guard.
+ * correctly reads as inert rather than wired. The trailing `(?![.\w-])`
+ * boundary rejects a disabled/backed-up filename that merely starts with
+ * `_idd-worktree-guard.sh` (e.g. `_idd-worktree-guard.sh.disabled`,
+ * `_idd-worktree-guard.sh.bak`) — those are not the active guard file,
+ * regardless of the sourcing syntax around them (idd-skill#2476) — while
+ * still matching the CRLF-converted case (a `\r` right after `.sh` is not
+ * excluded, so `hookHasCrlfLineEndings` below stays the sole signal for
+ * that failure mode, unchanged from before this fix). Pure (no I/O) so
+ * the wired/unwired classification can be unit-tested directly. A
+ * non-string (absent/unreadable hook) is treated as not wiring the guard.
  */
 export function hookWiresWorktreeGuard(content: unknown): boolean {
   return (
     typeof content === 'string' &&
-    /^[ \t]*(?:\.|source)[ \t]+[^\n]*_idd-worktree-guard\.sh/m.test(content)
+    /^[ \t]*(?:\.|source)[ \t]+[^\n]*_idd-worktree-guard\.sh(?![.\w-])/m.test(
+      content,
+    )
   );
 }
 

--- a/tests/discover-roadmap-graph.test.mts
+++ b/tests/discover-roadmap-graph.test.mts
@@ -290,6 +290,30 @@ test('extractTaskListReferences accepts uppercase checked items', () => {
   ]);
 });
 
+test('extractTaskListReferences accepts a link-text reference, e.g. [#123](url) (#2476)', () => {
+  const line =
+    '- [ ] [#123](https://github.com/kurone-kito/idd-skill/issues/123) — do the thing';
+  assert.deepEqual(extractTaskListReferences(line), [
+    { target: 123, relationship: 'task-list', evidence: line },
+  ]);
+});
+
+test('extractTaskListReferences accepts a bare markdown link to the issue, e.g. [some text](.../issues/456) (#2476)', () => {
+  const line =
+    '- [ ] [implement the webhook handler](https://github.com/kurone-kito/idd-skill/issues/456)';
+  assert.deepEqual(extractTaskListReferences(line), [
+    { target: 456, relationship: 'task-list', evidence: line },
+  ]);
+});
+
+test('extractTaskListReferences accepts a link to a pull request too (#2476)', () => {
+  const line =
+    '- [ ] [followed-up in #789](https://github.com/kurone-kito/idd-skill/pull/789)';
+  assert.deepEqual(extractTaskListReferences(line), [
+    { target: 789, relationship: 'task-list', evidence: line },
+  ]);
+});
+
 test('extractKeywordReferences ignores cross-repository references but keeps same-repo qualified refs', () => {
   const body = `
 Refs other/repo#301, #302

--- a/tests/idd-doctor.test.mts
+++ b/tests/idd-doctor.test.mts
@@ -858,6 +858,24 @@ test('hookWiresWorktreeGuard still matches a CRLF-converted sourcing line (regre
   );
 });
 
+test('hookWiresWorktreeGuard rejects a disabled/backed-up guard filename (#2476)', () => {
+  // `_idd-worktree-guard.sh.disabled` / `.bak` are not the active guard
+  // file -- the prior unbounded regex matched the `.sh` prefix and
+  // misreported the guard as wired even though it is not.
+  assert.equal(
+    hookWiresWorktreeGuard(
+      '#!/bin/sh\n. "$(dirname "$0")/_idd-worktree-guard.sh.disabled"\n',
+    ),
+    false,
+  );
+  assert.equal(
+    hookWiresWorktreeGuard(
+      '#!/bin/sh\n. "$(dirname "$0")/_idd-worktree-guard.sh.bak"\n',
+    ),
+    false,
+  );
+});
+
 test('hookHasCrlfLineEndings detects a CRLF line ending', () => {
   assert.equal(hookHasCrlfLineEndings('#!/bin/sh\r\necho hi\r\n'), true);
 });


### PR DESCRIPTION
<!--
🇺🇸🇬🇧 At first, read the following documents:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.md

🇯🇵 投稿の前に下記のドキュメントを一読ください:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.ja.md

🇨🇳 首先，阅读以下文档:
https://github.com/kurone-kito/idd-skill/blob/main/.github/CONTRIBUTING.zh.md
-->

# Summary

Fixes three residual case-sensitivity/boundary gaps in marker/reference
parsing (`#2476`), each confirmed live via direct reproduction against
`main`:

1. `idd-doctor.mts`'s worktree-guard detection regex had no trailing
   boundary after `.sh`, so it matched a disabled/backed-up hook file
   (`_idd-worktree-guard.sh.disabled` / `.bak`) and misreported the
   guard as wired.
2. `discover-roadmap-graph.mts`'s `extractTaskListReferences` only
   recognized literal `- [ ] #123` checkbox syntax, not link-syntax
   references (`[#123](url)` or a bare markdown link to the issue).
3. `docs/idd-advisory-wait-shell-fallback.md`'s AW1 runbook used a
   case-sensitive jq `== "Copilot"` comparison, while equivalent helper
   logic elsewhere in the codebase (`isCopilotReviewerLogin`) is
   case-insensitive.

## Linked issue

Closes #2476

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

For (1), the fix adds a `(?![.\w-])` boundary after `.sh` — the
CRLF-converted case (`#2060`) still matches since a trailing `\r` is
not excluded by that boundary, so `hookHasCrlfLineEndings` remains the
sole signal for that separate failure mode, unchanged.

For (2), two forms are recognized in order: a link whose text is
`#123` (falls through the same bare-number pattern with optional
`[`/`]`/`(...)`), and a link with arbitrary text whose URL targets
`.../issues/123` or `.../pull/123`. Both regexes are inlined per-call
rather than hoisted to module-level consts, since this file's CLI
entry point (`if (import.meta.main)`) sits near the top of the file and
can reach this function during synchronous module evaluation before a
later top-level const would have initialized (a TDZ hazard I hit and
fixed during implementation).

For (3), downcase both sides before comparing in the two affected jq
expressions; manually verified against a real `jq` binary (no test
harness exists for this shell-command reference doc).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4780/4780 passing)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
