### PR TITLE
fix(protocol-helpers): recognize Copilot's bare display-name login

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -452,12 +452,25 @@ export function unsafeTextReason(body) {
   }
   return null;
 }
+// #2473: Copilot's PR-level review object reports a `[bot]`-suffixed slug
+// login (`copilot-pull-request-reviewer[bot]`), but its inline
+// review-comment replies report a bare, capitalized display-name login
+// (`Copilot`, normalized here to `copilot`) with no suffix. The former
+// prefix check (`normalized.startsWith('copilot-pull-request-reviewer')`)
+// never matched that bare form, so a caller filtering comments by
+// `isKnownReviewBot` silently treated a genuine Copilot reply as unknown.
+// Delegating to `isCopilotReviewerLogin` (the #1686 exact-set matcher,
+// already reused by the advisory-wait pending-coverage path) recognizes
+// all three genuine login forms via `EXACT_COPILOT_REVIEWER_LOGINS`,
+// including the bare `copilot` form, and narrows the old unbounded prefix
+// match to that exact set -- closing the #1686 lookalike-username gap
+// here too as a side effect of reuse, not a separately-designed change.
 export function isKnownReviewBot(login) {
   const normalized = login.toLowerCase();
-  return (
-    REVIEW_BOT_LOGINS.has(normalized) ||
-    normalized.startsWith('copilot-pull-request-reviewer')
-  );
+  // `isCopilotReviewerLogin` also trims `login`, unlike the plain
+  // `.toLowerCase()` above -- a benign widening (a GitHub API `login` field
+  // never carries surrounding whitespace) rather than a deliberate choice.
+  return REVIEW_BOT_LOGINS.has(normalized) || isCopilotReviewerLogin(login);
 }
 export function isCodeRabbitLogin(login) {
   const normalized = login.toLowerCase();

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1063,12 +1063,25 @@ export function unsafeTextReason(body: string): string | null {
   return null;
 }
 
+// #2473: Copilot's PR-level review object reports a `[bot]`-suffixed slug
+// login (`copilot-pull-request-reviewer[bot]`), but its inline
+// review-comment replies report a bare, capitalized display-name login
+// (`Copilot`, normalized here to `copilot`) with no suffix. The former
+// prefix check (`normalized.startsWith('copilot-pull-request-reviewer')`)
+// never matched that bare form, so a caller filtering comments by
+// `isKnownReviewBot` silently treated a genuine Copilot reply as unknown.
+// Delegating to `isCopilotReviewerLogin` (the #1686 exact-set matcher,
+// already reused by the advisory-wait pending-coverage path) recognizes
+// all three genuine login forms via `EXACT_COPILOT_REVIEWER_LOGINS`,
+// including the bare `copilot` form, and narrows the old unbounded prefix
+// match to that exact set -- closing the #1686 lookalike-username gap
+// here too as a side effect of reuse, not a separately-designed change.
 export function isKnownReviewBot(login: string): boolean {
   const normalized = login.toLowerCase();
-  return (
-    REVIEW_BOT_LOGINS.has(normalized) ||
-    normalized.startsWith('copilot-pull-request-reviewer')
-  );
+  // `isCopilotReviewerLogin` also trims `login`, unlike the plain
+  // `.toLowerCase()` above -- a benign widening (a GitHub API `login` field
+  // never carries surrounding whitespace) rather than a deliberate choice.
+  return REVIEW_BOT_LOGINS.has(normalized) || isCopilotReviewerLogin(login);
 }
 
 export function isCodeRabbitLogin(login: string): boolean {

--- a/tests/merged-pr-feedback-sweep.test.mts
+++ b/tests/merged-pr-feedback-sweep.test.mts
@@ -104,6 +104,34 @@ test('surfaces an unresolved reviewer thread with no disposition', () => {
   assert.equal(result.summary.unresolvedThreadCount, 1);
 });
 
+// #2473: Copilot's inline review-comment replies report a bare, capitalized
+// display-name login (`Copilot`) rather than the `[bot]`-suffixed slug login
+// (`copilot-pull-request-reviewer[bot]`) its top-level review carries.
+// `isKnownReviewBot` previously recognized only the slug form, so a thread
+// whose sole comment came from this bare form was misclassified as a
+// non-advisory-bot (human) thread.
+test('recognizes a review-comment reply carrying the bare "Copilot" display-name login as an advisory bot', () => {
+  const prs: MergedPrInput[] = [
+    {
+      number: 3,
+      threads: [
+        buildCommentThread(false, [
+          {
+            login: 'Copilot',
+            body: 'This branch is unreachable.',
+            createdAt: '2026-06-09T00:00:00Z',
+          },
+        ]),
+      ],
+    },
+  ];
+  const result = buildMergedPrFeedbackSweep(prs, OPTIONS);
+  assert.equal(result.prs.length, 1);
+  assert.equal(result.prs[0].unresolvedThreads.length, 1);
+  assert.equal(result.prs[0].unresolvedThreads[0].author, 'copilot');
+  assert.equal(result.prs[0].unresolvedThreads[0].advisoryBot, true);
+});
+
 test('excludes a resolved thread', () => {
   const prs: MergedPrInput[] = [
     {


### PR DESCRIPTION
# Summary

GitHub Copilot's PR-level review reports a `[bot]`-suffixed slug login
(`copilot-pull-request-reviewer[bot]`), but its inline review-comment
replies report a bare, capitalized display-name login (`Copilot`) with
no suffix. `isKnownReviewBot` in `protocol-helpers.mts` recognized
Copilot only via a `startsWith('copilot-pull-request-reviewer')` prefix
check, which never matches the bare form, so a caller classifying
comments by this function silently treated a genuine Copilot reply as
an unknown (human) author.

Delegates to the existing `isCopilotReviewerLogin` (`#1686`'s exact-set
matcher) instead of the ad-hoc prefix check: it already recognizes all
three genuine Copilot login forms, including the bare one, and its
exact-match semantics also close the `#1686` lookalike-username gap
(e.g. `copilot-pull-request-reviewer1` on a public repo) the old
unbounded prefix match still had here -- a side effect of reusing
existing, reviewed logic rather than a separately-designed change.

Went through one round of independent C1 critique (subagent) before
this push -- zero High/Medium findings; three Low items (a doc-comment
misattribution, a benign trim-normalization note, and a coverage
observation) were addressed. See the issue thread for the full record.

## Linked issue

Closes #2473

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

None beyond the issue body itself.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4777/4777)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable) -- passed, only
      pre-existing warnings unrelated to this diff

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed -- none; this only widens a bot-login
      recognition function to match a login form GitHub genuinely uses,
      while narrowing its old open-ended prefix match to an exact set
- [x] Context budget impact reviewed -- script/test files only, no
      instruction-file byte budgets touched


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of Copilot review comments, including the standard `copilot` login and surrounding whitespace.
  - Prevented lookalike usernames from being incorrectly identified as Copilot.

- **Tests**
  - Added coverage ensuring Copilot replies are correctly recognized and surfaced as unresolved advisory threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->