### PR TITLE
fix(idd-onboard): add agent-entry-and-verification.md to the placeholder-exclusion list

### DIFF
--- a/scripts/idd-onboard.mjs
+++ b/scripts/idd-onboard.mjs
@@ -738,6 +738,11 @@ export const SCAN_EXCLUDED_PATHS = new Set([
   'docs/onboarding/placeholders.md',
   'docs/customization.md',
   'docs/onboarding/policy-decisions.md',
+  // #2489: same type: reference / literal-token-display pattern as the
+  // three above, found during a sweep of docs/onboarding/*.md for
+  // anything else missed by #1924's original list.
+  'docs/onboarding/agent-entry-and-verification.md',
+  'docs/onboarding/project-tuning.md',
 ]);
 function isProbablyBinary(content) {
   return content.includes(0);
@@ -2593,7 +2598,9 @@ idd-template/docs/onboarding/placeholders.md defines a derivation;
 explicit flags override; --trusted-marker-actor is always explicit) and
 rewrites the files. Skips the placeholder-reference meta-docs
 (docs/onboarding/placeholders.md, docs/customization.md,
-docs/onboarding/policy-decisions.md), which document the tokens rather
+docs/onboarding/policy-decisions.md,
+docs/onboarding/agent-entry-and-verification.md,
+docs/onboarding/project-tuning.md), which document the tokens rather
 than consume them and stay literal on purpose. Prints a JSON verdict
 with the per-file, per-placeholder plan, blocking residue (unresolved
 onboarding placeholders), informational unknown {{...}} tokens, and the

--- a/src/scripts/idd-onboard.mts
+++ b/src/scripts/idd-onboard.mts
@@ -873,6 +873,11 @@ export const SCAN_EXCLUDED_PATHS = new Set([
   'docs/onboarding/placeholders.md',
   'docs/customization.md',
   'docs/onboarding/policy-decisions.md',
+  // #2489: same type: reference / literal-token-display pattern as the
+  // three above, found during a sweep of docs/onboarding/*.md for
+  // anything else missed by #1924's original list.
+  'docs/onboarding/agent-entry-and-verification.md',
+  'docs/onboarding/project-tuning.md',
 ]);
 
 /** Token occurrences found in one scanned file. */
@@ -3135,7 +3140,9 @@ idd-template/docs/onboarding/placeholders.md defines a derivation;
 explicit flags override; --trusted-marker-actor is always explicit) and
 rewrites the files. Skips the placeholder-reference meta-docs
 (docs/onboarding/placeholders.md, docs/customization.md,
-docs/onboarding/policy-decisions.md), which document the tokens rather
+docs/onboarding/policy-decisions.md,
+docs/onboarding/agent-entry-and-verification.md,
+docs/onboarding/project-tuning.md), which document the tokens rather
 than consume them and stay literal on purpose. Prints a JSON verdict
 with the per-file, per-placeholder plan, blocking residue (unresolved
 onboarding placeholders), informational unknown {{...}} tokens, and the


### PR DESCRIPTION
# Summary

`agent-entry-and-verification.md` carries the same `type: reference`
frontmatter and literal `{{PROJECT_MARKER_PREFIX}}` worked-example
pattern as the three docs `#1924` already excluded, but was missed --
it still reported `placeholderResidue.blocking:true` under
`idd-onboard --verify`.

A sweep of `idd-template/docs/onboarding/*.md` for the same pattern
also found `project-tuning.md`'s `{{TRUSTED_MARKER_ACTOR}}` worked
example. Both are added to `SCAN_EXCLUDED_PATHS` and the
`--substitute` help text.

## Linked issue

Closes #2489

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

Closed issue `#1924` added a path-based exclusion list
(`SCAN_EXCLUDED_PATHS` in `src/scripts/idd-onboard.mts`) so
`type:reference` docs that display `{{TOKEN}}` placeholder syntax
literally aren't corrupted by `idd-onboard`'s substitution scan. Two
more docs in `idd-template/docs/onboarding/` matched the same pattern
but were never added.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

Also manually verified end-to-end: imported the template into a
scratch directory, ran `idd-onboard --substitute --dry-run` (both new
paths appear in `skippedPaths`), then `--apply` and `--verify`
(`placeholderResidue` no longer flags either file).

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
