### PR TITLE
fix(suitability-triage): recognize inflected outcome-signal verbs

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -11,6 +11,7 @@ words:
   - desync
   - desynced
   - idd
+  - includ
   - isort
   - Kiro
   - kurone
@@ -20,6 +21,7 @@ words:
   - pytest
   - pyproject
   - qwen
+  - requir
   - TOCTOU
   - tsfile
   - undispositioned

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -155,8 +155,17 @@ const SUBJECTIVE_SUBJECT_PATTERN =
   /(?<![\w-])(maintainer|stakeholder|human|opinion|judgment|judgement|ux|feel)(?![\w-])/i;
 const SUBJECTIVE_GATE_PATTERN =
   /(?<![\w-])(approval|sign-?off|decision|preference)(?![\w-])/i;
+// #2501: a bare `\b` on each word's dictionary form never matches an
+// ordinary inflected form ("passes", "included", "requires", "failing",
+// "presented", "resulted") -- an Acceptance Criteria bullet written with
+// any of those verb forms produced a false `does not provide objective
+// verification signals` failure despite being concretely, objectively
+// checkable. Each verb word below carries an explicit `-s|-ed/-d|-ing`
+// suffix group instead of the bare form; `objective`/`measurable`/
+// `deterministic` stay bare since they are adjectives, not conjugated as
+// verbs in this context.
 const OUTCOME_SIGNAL_PATTERN =
-  /\b(pass|fail|result|output|contains|include|present|required|objective|measurable|deterministic)\b/i;
+  /\b(pass(?:e[sd]|ing)?|fail(?:s|ed|ing)?|result(?:s|ed|ing)?|output(?:s|ted|ting)?|contain(?:s|ed|ing)?|include(?:s|d|ing)?|present(?:s|ed|ing)?|require(?:s|d|ing)?|objective|measurable|deterministic)\b/i;
 // Whole-body proximity variant of the subjective-approval check, built from
 // the same two pattern sources above (not hand-duplicated) so the
 // hyphen-boundary fix (#2205) applies to both the per-line and whole-body

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -163,9 +163,13 @@ const SUBJECTIVE_GATE_PATTERN =
 // checkable. Each verb word below carries an explicit `-s|-ed/-d|-ing`
 // suffix group instead of the bare form; `objective`/`measurable`/
 // `deterministic` stay bare since they are adjectives, not conjugated as
-// verbs in this context.
+// verbs in this context. `include`/`require` end in a silent `e` that
+// standard English orthography drops before `-ing` ("including" /
+// "requiring", not "includeing" / "requireing" -- caught in PR review),
+// so their stem omits the trailing `e` and the `e[sd]?|ing` group is
+// mandatory rather than optional.
 const OUTCOME_SIGNAL_PATTERN =
-  /\b(pass(?:e[sd]|ing)?|fail(?:s|ed|ing)?|result(?:s|ed|ing)?|output(?:s|ted|ting)?|contain(?:s|ed|ing)?|include(?:s|d|ing)?|present(?:s|ed|ing)?|require(?:s|d|ing)?|objective|measurable|deterministic)\b/i;
+  /\b(pass(?:e[sd]|ing)?|fail(?:s|ed|ing)?|result(?:s|ed|ing)?|output(?:s|ted|ting)?|contain(?:s|ed|ing)?|includ(?:e[sd]?|ing)|present(?:s|ed|ing)?|requir(?:e[sd]?|ing)|objective|measurable|deterministic)\b/i;
 // Whole-body proximity variant of the subjective-approval check, built from
 // the same two pattern sources above (not hand-duplicated) so the
 // hyphen-boundary fix (#2205) applies to both the per-line and whole-body

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -277,8 +277,17 @@ const SUBJECTIVE_SUBJECT_PATTERN =
   /(?<![\w-])(maintainer|stakeholder|human|opinion|judgment|judgement|ux|feel)(?![\w-])/i;
 const SUBJECTIVE_GATE_PATTERN =
   /(?<![\w-])(approval|sign-?off|decision|preference)(?![\w-])/i;
+// #2501: a bare `\b` on each word's dictionary form never matches an
+// ordinary inflected form ("passes", "included", "requires", "failing",
+// "presented", "resulted") -- an Acceptance Criteria bullet written with
+// any of those verb forms produced a false `does not provide objective
+// verification signals` failure despite being concretely, objectively
+// checkable. Each verb word below carries an explicit `-s|-ed/-d|-ing`
+// suffix group instead of the bare form; `objective`/`measurable`/
+// `deterministic` stay bare since they are adjectives, not conjugated as
+// verbs in this context.
 const OUTCOME_SIGNAL_PATTERN =
-  /\b(pass|fail|result|output|contains|include|present|required|objective|measurable|deterministic)\b/i;
+  /\b(pass(?:e[sd]|ing)?|fail(?:s|ed|ing)?|result(?:s|ed|ing)?|output(?:s|ted|ting)?|contain(?:s|ed|ing)?|include(?:s|d|ing)?|present(?:s|ed|ing)?|require(?:s|d|ing)?|objective|measurable|deterministic)\b/i;
 // Whole-body proximity variant of the subjective-approval check, built from
 // the same two pattern sources above (not hand-duplicated) so the
 // hyphen-boundary fix (#2205) applies to both the per-line and whole-body

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -285,9 +285,13 @@ const SUBJECTIVE_GATE_PATTERN =
 // checkable. Each verb word below carries an explicit `-s|-ed/-d|-ing`
 // suffix group instead of the bare form; `objective`/`measurable`/
 // `deterministic` stay bare since they are adjectives, not conjugated as
-// verbs in this context.
+// verbs in this context. `include`/`require` end in a silent `e` that
+// standard English orthography drops before `-ing` ("including" /
+// "requiring", not "includeing" / "requireing" -- caught in PR review),
+// so their stem omits the trailing `e` and the `e[sd]?|ing` group is
+// mandatory rather than optional.
 const OUTCOME_SIGNAL_PATTERN =
-  /\b(pass(?:e[sd]|ing)?|fail(?:s|ed|ing)?|result(?:s|ed|ing)?|output(?:s|ted|ting)?|contain(?:s|ed|ing)?|include(?:s|d|ing)?|present(?:s|ed|ing)?|require(?:s|d|ing)?|objective|measurable|deterministic)\b/i;
+  /\b(pass(?:e[sd]|ing)?|fail(?:s|ed|ing)?|result(?:s|ed|ing)?|output(?:s|ted|ting)?|contain(?:s|ed|ing)?|includ(?:e[sd]?|ing)|present(?:s|ed|ing)?|requir(?:e[sd]?|ing)|objective|measurable|deterministic)\b/i;
 // Whole-body proximity variant of the subjective-approval check, built from
 // the same two pattern sources above (not hand-duplicated) so the
 // hyphen-boundary fix (#2205) applies to both the per-line and whole-body

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2499,6 +2499,44 @@ test('verifiability accepts objective acceptance criteria without test keywords'
   assert.equal(result.pass, true);
 });
 
+test('verifiability recognizes inflected outcome-signal verb forms (#2501)', () => {
+  // Each bullet uses an ordinary inflected form -- not the bare dictionary
+  // word `OUTCOME_SIGNAL_PATTERN` previously required -- of a listed verb.
+  // Deliberately avoids both `hasVerificationChannel`'s own trigger words
+  // (test/verification/validate/lint/ci) and every bare dictionary form
+  // already in the pre-#2501 pattern, so this only passes when the widened
+  // suffix groups themselves match -- confirmed to fail pre-fix.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+- the exit code passes through unchanged from the subprocess
+- the changelog entry is included in the release notes
+- the new flag requires no additional configuration
+- the previously failing code path now behaves correctly
+- the corrected value is presented to the caller unchanged
+- the migration run resulted in the expected row count
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('verifiability still fails a bullet list with no outcome-signal word at all', () => {
+  // A checklist that names no outcome-signal word (inflected or bare) must
+  // still fail -- the widened pattern must not become unconditionally true.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+- the helper reads the configuration file
+- the helper writes a log entry
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('coherence allows TODO mentions when the issue is otherwise concrete', () => {
   const result = checkCoherence({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2522,6 +2522,22 @@ test('verifiability recognizes inflected outcome-signal verb forms (#2501)', () 
   assert.equal(result.pass, true);
 });
 
+test('verifiability recognizes the "including"/"requiring" gerund spellings (#2501 review)', () => {
+  // `include`/`require` drop their trailing `e` before `-ing` in standard
+  // English spelling -- a naive word+"ing" suffix group would only match
+  // the misspellings "includeing"/"requireing", never the real words.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Acceptance Criteria
+- the response body, including the new header, matches the fixture
+- the build step, requiring no network access, completes offline
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
 test('verifiability still fails a bullet list with no outcome-signal word at all', () => {
   // A checklist that names no outcome-signal word (inflected or bare) must
   // still fail -- the widened pattern must not become unconditionally true.


### PR DESCRIPTION
# Summary

`checkVerifiability` (Check 7) routed at least six otherwise-ready
documentation issues (`#2481`, `#2483`, `#2484`, `#2486`, `#2487`,
`#2488`) to `needs-decision` today because their Acceptance Criteria
bullets used ordinary inflected English verbs ("passes", "includes",
"requires", "failing", "presented") instead of the exact bare word
forms `OUTCOME_SIGNAL_PATTERN` matched (`pass`, `include`, `required`,
`fail`, `present`). The old pattern's `\b` boundary immediately after
each bare form never matches when a suffix follows.

## Linked issue

Closes #2501

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Widened `OUTCOME_SIGNAL_PATTERN` to accept the common inflected forms
(plural/third-person `-s`, past-tense/participle `-ed`/`-d`, gerund
`-ing`) of each verb word, while leaving the noun/adjective entries
(`result`/`output`/`objective`/`measurable`/`deterministic`) mostly
unchanged (`result`/`output` gained a plural `-s`/verb-form group;
the three adjectives stay bare, since they are not conjugated as verbs
in Acceptance Criteria prose and widening them further isn't needed to
fix the reported false-negative class).

Verified live against all six real issues this bug blocked today
(`node scripts/suitability-triage.mjs --issue <n>` for 2481/2483/2484/
2486/2487/2488) -- all six now report `ready`.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4780/4780 pass, including 2 new tests: inflected
      outcome-signal recognition, no-outcome-signal-word regression
      guard)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed; pre-existing warnings
      unrelated to this change)
- [x] Live re-check: `node scripts/suitability-triage.mjs --issue
      2481` (and 2483/2484/2486/2487/2488) now report `ready`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (none)
