### PR TITLE
fix(suitability-triage): let Check 6 skip a fixed vocabulary entry

### DIFF
--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -390,6 +390,39 @@ function isNegatedNearby(body, matchText, matchIndex, windowChars) {
     NEGATION_PATTERN.test(contextBefore) || NEGATION_PATTERN.test(contextAfter)
   );
 }
+/**
+ * True when the UNRESOLVED_CHOICE_PATTERN match at `matchIndex` sits
+ * inside a parenthetical that also contains a comma -- e.g.
+ * "(undecided, waits-on-person/credential, order-dependency,
+ * not-yet-ready)" -- evidence the match names one entry in a fixed,
+ * already-existing vocabulary rather than a claim about this issue's
+ * own open next step (#2508). A parenthetical with no comma (e.g.
+ * "(not yet decided which)") still counts as a genuine unresolved
+ * marker and is not excluded. A blank line (paragraph break) inside the
+ * span means the "(" and ")" belong to unrelated parentheticals in
+ * different paragraphs, not one enclosing span -- rejected -- but a
+ * single soft-wrapped newline inside one hand-wrapped Markdown
+ * paragraph does not end the span.
+ */
+function isEnumeratedParentheticalEntry(body, matchIndex, matchLength) {
+  const openIndex = body.lastIndexOf('(', matchIndex);
+  if (openIndex === -1) {
+    return false;
+  }
+  const before = body.slice(openIndex + 1, matchIndex);
+  if (before.includes(')') || before.includes('\n\n')) {
+    return false;
+  }
+  const closeIndex = body.indexOf(')', matchIndex + matchLength);
+  if (closeIndex === -1) {
+    return false;
+  }
+  const after = body.slice(matchIndex + matchLength, closeIndex);
+  if (after.includes('(') || after.includes('\n\n')) {
+    return false;
+  }
+  return before.includes(',') || after.includes(',');
+}
 const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 // A heading line such as "## Decision (resolved 2026-06-27)" records that a
 // human has already ruled on the issue's open question (see Check 7). The
@@ -1482,6 +1515,11 @@ export function checkAutonomy(context) {
       ) {
         continue;
       }
+      if (
+        isEnumeratedParentheticalEntry(body, markerIndex, markerText.length)
+      ) {
+        continue;
+      }
       const markerEnd = markerIndex + markerText.length;
       const isNearOrInsideEitherOr = eitherOrMatches.some((eitherOr) => {
         const eitherOrText = eitherOr[0] ?? '';
@@ -1540,6 +1578,9 @@ export function checkAutonomy(context) {
     const markerText = marker[0] ?? '';
     const markerIndex = marker.index ?? 0;
     if (isNegatedNearby(body, markerText, markerIndex, NEGATION_WINDOW_CHARS)) {
+      continue;
+    }
+    if (isEnumeratedParentheticalEntry(body, markerIndex, markerText.length)) {
       continue;
     }
     return {

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -395,27 +395,47 @@ function isNegatedNearby(body, matchText, matchIndex, windowChars) {
 // as a break even when it carries trailing whitespace (Copilot review,
 // #2508).
 const PARAGRAPH_BREAK_PATTERN = /\n[ \t]*\n/;
-// A decoration typical of a compact label/mapping entry (a hyphenated
-// or slash-joined slug, an "->" mapping arrow, or a code span) rather
-// than ordinary prose (#2508, Copilot review round 2).
+// A decoration typical of a compact label/mapping entry -- a
+// hyphenated or slash-joined slug, an "->" mapping arrow, or a code
+// span -- rather than ordinary prose (#2508). Matched only after
+// collapsing "a -> b" whitespace in looksLikeLabelEntry, so this must
+// find decoration in what is otherwise a single whitespace-free token,
+// not merely somewhere inside a multi-word phrase (Copilot/CodeRabbit
+// review round 3: a lone hyphen used as prose punctuation, e.g.
+// "blocking this work - resolve later", or a plain dictionary word
+// with no decoration at all, e.g. "unfortunately", must not qualify).
 const LABEL_ENTRY_DECORATION_PATTERN = /[-/`]/;
+// An "a -> b" mapping arrow with any surrounding whitespace (including
+// a hand-wrapped newline), collapsed to a bare "->" before the
+// whitespace check below so a wrapped mapping still counts as one
+// compact token.
+const LABEL_ENTRY_ARROW_PATTERN = /\s*->\s*/g;
 /**
  * True when `segment` (one comma-delimited entry from a parenthetical,
- * excluding the marker's own entry) reads as a compact label name --
- * either a single whitespace-free token, or decorated with a hyphen,
- * slash, arrow, or backtick -- rather than an ordinary multi-word
- * phrase. Used by isEnumeratedParentheticalEntry to require every
- * *other* entry in the list to look like fixed vocabulary before
- * excluding the marker: a genuine aside such as "(still undecided,
- * blocking this work)" has an ordinary-prose other entry ("blocking
- * this work") and must not be excluded.
+ * excluding the marker's own entry) reads as a compact label name or
+ * label-to-label mapping -- e.g. "not-yet-ready" or
+ * "undecided -> `needs-decision`" -- rather than an ordinary multi-word
+ * phrase. After collapsing "->" mapping whitespace, the *entire* entry
+ * must contain no remaining whitespace and must carry a hyphen, slash,
+ * or backtick; a plain word with none of those (e.g. "unfortunately")
+ * or a multi-word phrase that merely contains a hyphen somewhere (e.g.
+ * "blocking this work - resolve later") does not qualify. Used by
+ * isEnumeratedParentheticalEntry to require every *other* entry in the
+ * list to look like fixed vocabulary before excluding the marker: a
+ * genuine aside such as "(still undecided, blocking this work)" has an
+ * ordinary-prose other entry ("blocking this work") and must not be
+ * excluded.
  */
 function looksLikeLabelEntry(segment) {
   const trimmed = segment.trim();
   if (trimmed.length === 0) {
     return false;
   }
-  return LABEL_ENTRY_DECORATION_PATTERN.test(trimmed) || !/\s/.test(trimmed);
+  const collapsed = trimmed.replace(LABEL_ENTRY_ARROW_PATTERN, '->');
+  if (/\s/.test(collapsed)) {
+    return false;
+  }
+  return LABEL_ENTRY_DECORATION_PATTERN.test(collapsed);
 }
 /**
  * True when the UNRESOLVED_CHOICE_PATTERN match at `matchIndex` sits

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -390,6 +390,11 @@ function isNegatedNearby(body, matchText, matchIndex, windowChars) {
     NEGATION_PATTERN.test(contextBefore) || NEGATION_PATTERN.test(contextAfter)
   );
 }
+// A Markdown paragraph break: two newlines with only horizontal
+// whitespace (spaces/tabs) between them -- a blank line still counts
+// as a break even when it carries trailing whitespace (Copilot review,
+// #2508).
+const PARAGRAPH_BREAK_PATTERN = /\n[ \t]*\n/;
 /**
  * True when the UNRESOLVED_CHOICE_PATTERN match at `matchIndex` sits
  * inside a parenthetical that also contains a comma -- e.g.
@@ -398,11 +403,11 @@ function isNegatedNearby(body, matchText, matchIndex, windowChars) {
  * already-existing vocabulary rather than a claim about this issue's
  * own open next step (#2508). A parenthetical with no comma (e.g.
  * "(not yet decided which)") still counts as a genuine unresolved
- * marker and is not excluded. A blank line (paragraph break) inside the
- * span means the "(" and ")" belong to unrelated parentheticals in
- * different paragraphs, not one enclosing span -- rejected -- but a
- * single soft-wrapped newline inside one hand-wrapped Markdown
- * paragraph does not end the span.
+ * marker and is not excluded. A paragraph break inside the span means
+ * the "(" and ")" belong to unrelated parentheticals in different
+ * paragraphs, not one enclosing span -- rejected -- but a single
+ * soft-wrapped newline inside one hand-wrapped Markdown paragraph does
+ * not end the span.
  */
 function isEnumeratedParentheticalEntry(body, matchIndex, matchLength) {
   const openIndex = body.lastIndexOf('(', matchIndex);
@@ -410,7 +415,7 @@ function isEnumeratedParentheticalEntry(body, matchIndex, matchLength) {
     return false;
   }
   const before = body.slice(openIndex + 1, matchIndex);
-  if (before.includes(')') || before.includes('\n\n')) {
+  if (before.includes(')') || PARAGRAPH_BREAK_PATTERN.test(before)) {
     return false;
   }
   const closeIndex = body.indexOf(')', matchIndex + matchLength);
@@ -418,7 +423,7 @@ function isEnumeratedParentheticalEntry(body, matchIndex, matchLength) {
     return false;
   }
   const after = body.slice(matchIndex + matchLength, closeIndex);
-  if (after.includes('(') || after.includes('\n\n')) {
+  if (after.includes('(') || PARAGRAPH_BREAK_PATTERN.test(after)) {
     return false;
   }
   return before.includes(',') || after.includes(',');

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -395,19 +395,43 @@ function isNegatedNearby(body, matchText, matchIndex, windowChars) {
 // as a break even when it carries trailing whitespace (Copilot review,
 // #2508).
 const PARAGRAPH_BREAK_PATTERN = /\n[ \t]*\n/;
+// A decoration typical of a compact label/mapping entry (a hyphenated
+// or slash-joined slug, an "->" mapping arrow, or a code span) rather
+// than ordinary prose (#2508, Copilot review round 2).
+const LABEL_ENTRY_DECORATION_PATTERN = /[-/`]/;
+/**
+ * True when `segment` (one comma-delimited entry from a parenthetical,
+ * excluding the marker's own entry) reads as a compact label name --
+ * either a single whitespace-free token, or decorated with a hyphen,
+ * slash, arrow, or backtick -- rather than an ordinary multi-word
+ * phrase. Used by isEnumeratedParentheticalEntry to require every
+ * *other* entry in the list to look like fixed vocabulary before
+ * excluding the marker: a genuine aside such as "(still undecided,
+ * blocking this work)" has an ordinary-prose other entry ("blocking
+ * this work") and must not be excluded.
+ */
+function looksLikeLabelEntry(segment) {
+  const trimmed = segment.trim();
+  if (trimmed.length === 0) {
+    return false;
+  }
+  return LABEL_ENTRY_DECORATION_PATTERN.test(trimmed) || !/\s/.test(trimmed);
+}
 /**
  * True when the UNRESOLVED_CHOICE_PATTERN match at `matchIndex` sits
- * inside a parenthetical that also contains a comma -- e.g.
+ * inside a parenthetical enumerating a fixed vocabulary -- e.g.
  * "(undecided, waits-on-person/credential, order-dependency,
- * not-yet-ready)" -- evidence the match names one entry in a fixed,
- * already-existing vocabulary rather than a claim about this issue's
- * own open next step (#2508). A parenthetical with no comma (e.g.
- * "(not yet decided which)") still counts as a genuine unresolved
- * marker and is not excluded. A paragraph break inside the span means
- * the "(" and ")" belong to unrelated parentheticals in different
- * paragraphs, not one enclosing span -- rejected -- but a single
- * soft-wrapped newline inside one hand-wrapped Markdown paragraph does
- * not end the span.
+ * not-yet-ready)" -- evidence the match names one entry in that
+ * vocabulary rather than a claim about this issue's own open next step
+ * (#2508). Every comma-delimited entry other than the marker's own
+ * must look like a compact label name (looksLikeLabelEntry); a
+ * parenthetical with no comma, or one whose other entries read as
+ * ordinary prose (e.g. "(still undecided, blocking this work)"), still
+ * counts as a genuine unresolved marker and is not excluded. A
+ * paragraph break inside the span means the "(" and ")" belong to
+ * unrelated parentheticals in different paragraphs, not one enclosing
+ * span -- rejected -- but a single soft-wrapped newline inside one
+ * hand-wrapped Markdown paragraph does not end the span.
  */
 function isEnumeratedParentheticalEntry(body, matchIndex, matchLength) {
   const openIndex = body.lastIndexOf('(', matchIndex);
@@ -426,7 +450,13 @@ function isEnumeratedParentheticalEntry(body, matchIndex, matchLength) {
   if (after.includes('(') || PARAGRAPH_BREAK_PATTERN.test(after)) {
     return false;
   }
-  return before.includes(',') || after.includes(',');
+  if (!before.includes(',') && !after.includes(',')) {
+    return false;
+  }
+  const beforeEntries = before.split(',').slice(0, -1);
+  const afterEntries = after.split(',').slice(1);
+  const otherEntries = [...beforeEntries, ...afterEntries];
+  return otherEntries.length > 0 && otherEntries.every(looksLikeLabelEntry);
 }
 const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 // A heading line such as "## Decision (resolved 2026-06-27)" records that a

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -523,6 +523,45 @@ function isNegatedNearby(
     NEGATION_PATTERN.test(contextBefore) || NEGATION_PATTERN.test(contextAfter)
   );
 }
+/**
+ * True when the UNRESOLVED_CHOICE_PATTERN match at `matchIndex` sits
+ * inside a parenthetical that also contains a comma -- e.g.
+ * "(undecided, waits-on-person/credential, order-dependency,
+ * not-yet-ready)" -- evidence the match names one entry in a fixed,
+ * already-existing vocabulary rather than a claim about this issue's
+ * own open next step (#2508). A parenthetical with no comma (e.g.
+ * "(not yet decided which)") still counts as a genuine unresolved
+ * marker and is not excluded. A blank line (paragraph break) inside the
+ * span means the "(" and ")" belong to unrelated parentheticals in
+ * different paragraphs, not one enclosing span -- rejected -- but a
+ * single soft-wrapped newline inside one hand-wrapped Markdown
+ * paragraph does not end the span.
+ */
+function isEnumeratedParentheticalEntry(
+  body: string,
+  matchIndex: number,
+  matchLength: number,
+): boolean {
+  const openIndex = body.lastIndexOf('(', matchIndex);
+  if (openIndex === -1) {
+    return false;
+  }
+  const before = body.slice(openIndex + 1, matchIndex);
+  if (before.includes(')') || before.includes('\n\n')) {
+    return false;
+  }
+
+  const closeIndex = body.indexOf(')', matchIndex + matchLength);
+  if (closeIndex === -1) {
+    return false;
+  }
+  const after = body.slice(matchIndex + matchLength, closeIndex);
+  if (after.includes('(') || after.includes('\n\n')) {
+    return false;
+  }
+
+  return before.includes(',') || after.includes(',');
+}
 const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 // A heading line such as "## Decision (resolved 2026-06-27)" records that a
 // human has already ruled on the issue's open question (see Check 7). The
@@ -1674,6 +1713,11 @@ export function checkAutonomy(context: Context): CheckOutcome {
       ) {
         continue;
       }
+      if (
+        isEnumeratedParentheticalEntry(body, markerIndex, markerText.length)
+      ) {
+        continue;
+      }
 
       const markerEnd = markerIndex + markerText.length;
       const isNearOrInsideEitherOr = eitherOrMatches.some((eitherOr) => {
@@ -1739,6 +1783,9 @@ export function checkAutonomy(context: Context): CheckOutcome {
     const markerText = marker[0] ?? '';
     const markerIndex = marker.index ?? 0;
     if (isNegatedNearby(body, markerText, markerIndex, NEGATION_WINDOW_CHARS)) {
+      continue;
+    }
+    if (isEnumeratedParentheticalEntry(body, markerIndex, markerText.length)) {
       continue;
     }
 

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -528,27 +528,47 @@ function isNegatedNearby(
 // as a break even when it carries trailing whitespace (Copilot review,
 // #2508).
 const PARAGRAPH_BREAK_PATTERN = /\n[ \t]*\n/;
-// A decoration typical of a compact label/mapping entry (a hyphenated
-// or slash-joined slug, an "->" mapping arrow, or a code span) rather
-// than ordinary prose (#2508, Copilot review round 2).
+// A decoration typical of a compact label/mapping entry -- a
+// hyphenated or slash-joined slug, an "->" mapping arrow, or a code
+// span -- rather than ordinary prose (#2508). Matched only after
+// collapsing "a -> b" whitespace in looksLikeLabelEntry, so this must
+// find decoration in what is otherwise a single whitespace-free token,
+// not merely somewhere inside a multi-word phrase (Copilot/CodeRabbit
+// review round 3: a lone hyphen used as prose punctuation, e.g.
+// "blocking this work - resolve later", or a plain dictionary word
+// with no decoration at all, e.g. "unfortunately", must not qualify).
 const LABEL_ENTRY_DECORATION_PATTERN = /[-/`]/;
+// An "a -> b" mapping arrow with any surrounding whitespace (including
+// a hand-wrapped newline), collapsed to a bare "->" before the
+// whitespace check below so a wrapped mapping still counts as one
+// compact token.
+const LABEL_ENTRY_ARROW_PATTERN = /\s*->\s*/g;
 /**
  * True when `segment` (one comma-delimited entry from a parenthetical,
- * excluding the marker's own entry) reads as a compact label name --
- * either a single whitespace-free token, or decorated with a hyphen,
- * slash, arrow, or backtick -- rather than an ordinary multi-word
- * phrase. Used by isEnumeratedParentheticalEntry to require every
- * *other* entry in the list to look like fixed vocabulary before
- * excluding the marker: a genuine aside such as "(still undecided,
- * blocking this work)" has an ordinary-prose other entry ("blocking
- * this work") and must not be excluded.
+ * excluding the marker's own entry) reads as a compact label name or
+ * label-to-label mapping -- e.g. "not-yet-ready" or
+ * "undecided -> `needs-decision`" -- rather than an ordinary multi-word
+ * phrase. After collapsing "->" mapping whitespace, the *entire* entry
+ * must contain no remaining whitespace and must carry a hyphen, slash,
+ * or backtick; a plain word with none of those (e.g. "unfortunately")
+ * or a multi-word phrase that merely contains a hyphen somewhere (e.g.
+ * "blocking this work - resolve later") does not qualify. Used by
+ * isEnumeratedParentheticalEntry to require every *other* entry in the
+ * list to look like fixed vocabulary before excluding the marker: a
+ * genuine aside such as "(still undecided, blocking this work)" has an
+ * ordinary-prose other entry ("blocking this work") and must not be
+ * excluded.
  */
 function looksLikeLabelEntry(segment: string): boolean {
   const trimmed = segment.trim();
   if (trimmed.length === 0) {
     return false;
   }
-  return LABEL_ENTRY_DECORATION_PATTERN.test(trimmed) || !/\s/.test(trimmed);
+  const collapsed = trimmed.replace(LABEL_ENTRY_ARROW_PATTERN, '->');
+  if (/\s/.test(collapsed)) {
+    return false;
+  }
+  return LABEL_ENTRY_DECORATION_PATTERN.test(collapsed);
 }
 /**
  * True when the UNRESOLVED_CHOICE_PATTERN match at `matchIndex` sits

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -528,19 +528,43 @@ function isNegatedNearby(
 // as a break even when it carries trailing whitespace (Copilot review,
 // #2508).
 const PARAGRAPH_BREAK_PATTERN = /\n[ \t]*\n/;
+// A decoration typical of a compact label/mapping entry (a hyphenated
+// or slash-joined slug, an "->" mapping arrow, or a code span) rather
+// than ordinary prose (#2508, Copilot review round 2).
+const LABEL_ENTRY_DECORATION_PATTERN = /[-/`]/;
+/**
+ * True when `segment` (one comma-delimited entry from a parenthetical,
+ * excluding the marker's own entry) reads as a compact label name --
+ * either a single whitespace-free token, or decorated with a hyphen,
+ * slash, arrow, or backtick -- rather than an ordinary multi-word
+ * phrase. Used by isEnumeratedParentheticalEntry to require every
+ * *other* entry in the list to look like fixed vocabulary before
+ * excluding the marker: a genuine aside such as "(still undecided,
+ * blocking this work)" has an ordinary-prose other entry ("blocking
+ * this work") and must not be excluded.
+ */
+function looksLikeLabelEntry(segment: string): boolean {
+  const trimmed = segment.trim();
+  if (trimmed.length === 0) {
+    return false;
+  }
+  return LABEL_ENTRY_DECORATION_PATTERN.test(trimmed) || !/\s/.test(trimmed);
+}
 /**
  * True when the UNRESOLVED_CHOICE_PATTERN match at `matchIndex` sits
- * inside a parenthetical that also contains a comma -- e.g.
+ * inside a parenthetical enumerating a fixed vocabulary -- e.g.
  * "(undecided, waits-on-person/credential, order-dependency,
- * not-yet-ready)" -- evidence the match names one entry in a fixed,
- * already-existing vocabulary rather than a claim about this issue's
- * own open next step (#2508). A parenthetical with no comma (e.g.
- * "(not yet decided which)") still counts as a genuine unresolved
- * marker and is not excluded. A paragraph break inside the span means
- * the "(" and ")" belong to unrelated parentheticals in different
- * paragraphs, not one enclosing span -- rejected -- but a single
- * soft-wrapped newline inside one hand-wrapped Markdown paragraph does
- * not end the span.
+ * not-yet-ready)" -- evidence the match names one entry in that
+ * vocabulary rather than a claim about this issue's own open next step
+ * (#2508). Every comma-delimited entry other than the marker's own
+ * must look like a compact label name (looksLikeLabelEntry); a
+ * parenthetical with no comma, or one whose other entries read as
+ * ordinary prose (e.g. "(still undecided, blocking this work)"), still
+ * counts as a genuine unresolved marker and is not excluded. A
+ * paragraph break inside the span means the "(" and ")" belong to
+ * unrelated parentheticals in different paragraphs, not one enclosing
+ * span -- rejected -- but a single soft-wrapped newline inside one
+ * hand-wrapped Markdown paragraph does not end the span.
  */
 function isEnumeratedParentheticalEntry(
   body: string,
@@ -564,8 +588,14 @@ function isEnumeratedParentheticalEntry(
   if (after.includes('(') || PARAGRAPH_BREAK_PATTERN.test(after)) {
     return false;
   }
+  if (!before.includes(',') && !after.includes(',')) {
+    return false;
+  }
 
-  return before.includes(',') || after.includes(',');
+  const beforeEntries = before.split(',').slice(0, -1);
+  const afterEntries = after.split(',').slice(1);
+  const otherEntries = [...beforeEntries, ...afterEntries];
+  return otherEntries.length > 0 && otherEntries.every(looksLikeLabelEntry);
 }
 const ACCEPTANCE_CRITERIA_PATTERN = /^#+\s*Acceptance\s+Criteria\s*$/im;
 // A heading line such as "## Decision (resolved 2026-06-27)" records that a

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -523,6 +523,11 @@ function isNegatedNearby(
     NEGATION_PATTERN.test(contextBefore) || NEGATION_PATTERN.test(contextAfter)
   );
 }
+// A Markdown paragraph break: two newlines with only horizontal
+// whitespace (spaces/tabs) between them -- a blank line still counts
+// as a break even when it carries trailing whitespace (Copilot review,
+// #2508).
+const PARAGRAPH_BREAK_PATTERN = /\n[ \t]*\n/;
 /**
  * True when the UNRESOLVED_CHOICE_PATTERN match at `matchIndex` sits
  * inside a parenthetical that also contains a comma -- e.g.
@@ -531,11 +536,11 @@ function isNegatedNearby(
  * already-existing vocabulary rather than a claim about this issue's
  * own open next step (#2508). A parenthetical with no comma (e.g.
  * "(not yet decided which)") still counts as a genuine unresolved
- * marker and is not excluded. A blank line (paragraph break) inside the
- * span means the "(" and ")" belong to unrelated parentheticals in
- * different paragraphs, not one enclosing span -- rejected -- but a
- * single soft-wrapped newline inside one hand-wrapped Markdown
- * paragraph does not end the span.
+ * marker and is not excluded. A paragraph break inside the span means
+ * the "(" and ")" belong to unrelated parentheticals in different
+ * paragraphs, not one enclosing span -- rejected -- but a single
+ * soft-wrapped newline inside one hand-wrapped Markdown paragraph does
+ * not end the span.
  */
 function isEnumeratedParentheticalEntry(
   body: string,
@@ -547,7 +552,7 @@ function isEnumeratedParentheticalEntry(
     return false;
   }
   const before = body.slice(openIndex + 1, matchIndex);
-  if (before.includes(')') || before.includes('\n\n')) {
+  if (before.includes(')') || PARAGRAPH_BREAK_PATTERN.test(before)) {
     return false;
   }
 
@@ -556,7 +561,7 @@ function isEnumeratedParentheticalEntry(
     return false;
   }
   const after = body.slice(matchIndex + matchLength, closeIndex);
-  if (after.includes('(') || after.includes('\n\n')) {
+  if (after.includes('(') || PARAGRAPH_BREAK_PATTERN.test(after)) {
     return false;
   }
 

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2666,6 +2666,26 @@ test('autonomy still fails a genuine comma-bearing unresolved-choice aside whose
   assert.equal(result.pass, false);
 });
 
+test('autonomy still fails when the other entry is prose merely containing a lone hyphen -- #2508 (CodeRabbit round 3)', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThe rollout plan (still undecided, blocking this work - resolve later) needs a decision.`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('autonomy still fails when the other entry is a plain undecorated word -- #2508 (Copilot round 3)', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThe rollout plan (still undecided, unfortunately) needs a decision.`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('autonomy still fails both original fixed templates unchanged -- #2219 (no regression)', () => {
   const requiresResult = checkAutonomy({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2646,6 +2646,16 @@ test('autonomy still fails a marker whose enclosing parens straddle a paragraph 
   assert.equal(result.pass, false);
 });
 
+test('autonomy still fails a marker whose enclosing parens straddle a whitespace-only blank line -- #2508 (Copilot)', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nSome context (see below.\n \nThe rollout plan is undecided, blocking this work) until resolved.`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('autonomy still fails both original fixed templates unchanged -- #2219 (no regression)', () => {
   const requiresResult = checkAutonomy({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2656,6 +2656,16 @@ test('autonomy still fails a marker whose enclosing parens straddle a whitespace
   assert.equal(result.pass, false);
 });
 
+test('autonomy still fails a genuine comma-bearing unresolved-choice aside whose other entry is ordinary prose -- #2508 (Copilot round 2)', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThe rollout plan (still undecided, blocking this work) needs a decision.`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('autonomy still fails both original fixed templates unchanged -- #2219 (no regression)', () => {
   const requiresResult = checkAutonomy({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2606,6 +2606,46 @@ test('autonomy ignores a negated unresolved-choice phrasing -- #2219', () => {
   assert.equal(result.pass, true);
 });
 
+test('autonomy passes a marker word used as one entry in a comma-separated parenthetical list of fixed terms -- #2508 (#2482 exact shape)', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nAdd a compact table covering all four intents (undecided, waits-on-person/credential, order-dependency, not-yet-ready) so authors stop inventing ad hoc markers.`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('autonomy passes a marker word inside a two-item mapping parenthetical (single comma) -- #2508 (#2482 exact shape)', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\ndraft-patterns.md documents two of four cases (undecided ->\n\`needs-decision\`, waits-on-person/credential ->\n\`blocked-by-human\`) in prose.`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('autonomy still fails a marker inside a parenthetical with no comma -- #2508 (no loss of existing coverage)', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nThe backend choice (still undecided) blocks this from proceeding.`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
+test('autonomy still fails a marker whose enclosing parens straddle a paragraph break -- #2508 (no over-suppression)', () => {
+  const result = checkAutonomy({
+    issue: {
+      ...BASE_ISSUE,
+      body: `${BASE_ISSUE.body}\nSome context (see below.\n\nThe rollout plan is undecided, blocking this work) until resolved.`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('autonomy still fails both original fixed templates unchanged -- #2219 (no regression)', () => {
   const requiresResult = checkAutonomy({
     issue: {


### PR DESCRIPTION
# Summary

`checkAutonomy`'s `UNRESOLVED_CHOICE_PATTERN` scan (#2219) routed a
legitimate, well-specified documentation issue (#2482) to
`blocked-by-human` because its body used "undecided" as ordinary
domain vocabulary -- one of four authoring-intent label names quoted
verbatim from an already-existing four-item enumeration, not a claim
that #2482's own scope was unresolved.

Add `isEnumeratedParentheticalEntry`: when the marker sits inside a
same-paragraph parenthetical that also contains a comma (e.g.
"(undecided, waits-on-person/credential, order-dependency,
not-yet-ready)"), treat it as one entry in a fixed vocabulary and skip
it, in both of `checkAutonomy`'s `UNRESOLVED_CHOICE_PATTERN` loops.

## Linked issue

Closes #2508

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

A parenthetical with no comma (a genuine "(still undecided)" claim) is
unaffected, and a blank line inside the span means the parens belong
to unrelated paragraphs, not one enclosing list -- both cases still
fail Check 6 as designed. This is the same general shape as the
sibling gap reported in #2501 against `checkVerifiability`'s
outcome-signal scan: a check's own trigger vocabulary colliding with
an issue's ordinary subject matter rather than with any claim about
the issue itself.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

Also manually verified against the live issue:
`node scripts/suitability-triage.mjs --issue 2482` now reports a
passing outcome for Check 6 (Autonomy).

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved suitability checks to ignore unresolved-choice markers in compact, comma-separated parenthetical lists.
  - Continued flagging unresolved choices in ordinary prose, comma-free parentheticals, paragraph-spanning parentheses, and genuine unresolved-choice asides.
  - Added support for multiline label and mapping lists that should pass autonomy checks.

- **Tests**
  - Added regression coverage for parenthetical-list filtering and preserved detection of actionable unresolved choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->