### PR TITLE
fix(audit-pr-cleanup): paginate a review thread's own comments

### DIFF
--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -56,6 +56,27 @@ const DEFAULT_APPLY_RETRY_MAX_ATTEMPTS = 3;
 /** Base backoff (ms) before each rescan; linear-ish with jitter, matching
  * {@link withBoundedRetry}'s formula in gh-exec.mts. */
 const DEFAULT_APPLY_RETRY_BACKOFF_MS = 200;
+const REVIEW_THREAD_COMMENT_FIELDS = `
+  id
+  url
+  body
+  createdAt
+  isMinimized
+  minimizedReason
+  viewerCanMinimize
+  author{login}
+  pullRequestReview{id}
+`;
+// #2478: a thread with more than 100 comments needs its own continuation
+// query -- `node(id)` re-entry is the only way to page an inner connection
+// past its first page, since the outer reviewThreads cursor only advances
+// between threads. 50 pages (5,000 comments) is far beyond any real review
+// thread; hitting it leaves `pageInfo.hasNextPage: true` on the returned
+// node exactly as an un-paginated first page would, so the existing
+// truncated-data skip in evaluateReviewComment (thread.comments.pageInfo.
+// hasNextPage) still fires rather than misreporting a capped thread as
+// complete.
+const MAX_REVIEW_THREAD_COMMENT_PAGES = 50;
 if (import.meta.main) {
   await main();
 }
@@ -912,7 +933,10 @@ function fetchReviews(owner, repo, number, options = {}) {
     options,
   );
 }
-function fetchReviewThreads(owner, repo, number, options = {}) {
+// Exported for tests/audit-pr-cleanup.test.mts (#2478): the only way to
+// exercise the >100-comment inner-pagination walk without spawning the full
+// CLI and stubbing every gh call `buildReport` needs.
+export function fetchReviewThreads(owner, repo, number, options = {}) {
   const query = `query($owner:String!,$repo:String!,$number:Int!,$after:String){
     repository(owner:$owner,name:$repo){
       pullRequest(number:$number){
@@ -921,18 +945,8 @@ function fetchReviewThreads(owner, repo, number, options = {}) {
             id
             isResolved
             comments(first:100){
-              pageInfo{hasNextPage}
-              nodes{
-                id
-                url
-                body
-                createdAt
-                isMinimized
-                minimizedReason
-                viewerCanMinimize
-                author{login}
-                pullRequestReview{id}
-              }
+              pageInfo{hasNextPage endCursor}
+              nodes{${REVIEW_THREAD_COMMENT_FIELDS}}
             }
           }
           pageInfo{hasNextPage endCursor}
@@ -940,7 +954,7 @@ function fetchReviewThreads(owner, repo, number, options = {}) {
       }
     }
   }`;
-  return fetchConnection(
+  const threads = fetchConnection(
     query,
     { owner, repo, number },
     (data) => {
@@ -948,6 +962,69 @@ function fetchReviewThreads(owner, repo, number, options = {}) {
     },
     options,
   );
+  for (const thread of threads) {
+    if (thread.id && thread.comments?.pageInfo?.hasNextPage) {
+      thread.comments = fetchRemainingThreadComments(
+        thread.id,
+        thread.comments,
+        options,
+      );
+    }
+  }
+  return threads;
+}
+function fetchRemainingThreadComments(threadId, firstPage, options) {
+  const query = `query($id:ID!,$after:String){
+    node(id:$id){
+      ... on PullRequestReviewThread{
+        comments(first:100,after:$after){
+          pageInfo{hasNextPage endCursor}
+          nodes{${REVIEW_THREAD_COMMENT_FIELDS}}
+        }
+      }
+    }
+  }`;
+  const nodes = [...(firstPage.nodes ?? [])];
+  let pageInfo = firstPage.pageInfo;
+  let pagesFetched = 1;
+  while (pageInfo?.hasNextPage) {
+    if (pagesFetched >= MAX_REVIEW_THREAD_COMMENT_PAGES) {
+      break;
+    }
+    if (!pageInfo.endCursor) {
+      // Mirrors fetchReviewThreadsGeneric's same guard in
+      // provider-adapter-github.mts: fail loudly on a contract-violating
+      // hasNextPage:true-with-no-endCursor page rather than silently
+      // re-requesting page 1 (ghGraphql drops a null `after` variable),
+      // which could otherwise "self-heal" into duplicate comment nodes.
+      handleGraphqlFailure(
+        `GraphQL thread-comment continuation: hasNextPage without endCursor for thread ${threadId}`,
+        options,
+      );
+    }
+    const result = ghGraphql(
+      query,
+      { id: threadId, after: pageInfo.endCursor },
+      options,
+    );
+    if (result.errors?.length) {
+      handleGraphqlFailure(
+        `GraphQL thread-comment continuation failed: ${formatGraphqlErrors(result.errors)}; thread=${threadId}`,
+        options,
+      );
+    }
+    const nextComments = result.data?.node?.comments;
+    if (!nextComments) {
+      handleGraphqlFailure(
+        `GraphQL thread-comment continuation returned no comments; thread=${threadId}`,
+        options,
+      );
+    }
+    nodes.push(...(nextComments.nodes ?? []));
+    pageInfo = nextComments.pageInfo;
+    pagesFetched += 1;
+  }
+  return { pageInfo: pageInfo ?? null, nodes };
 }
 function fetchConnection(query, baseVariables, pickConnection, options = {}) {
   const nodes = [];

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -72,11 +72,14 @@ interface ThreadCommentNode extends MinimizableNode {
 }
 
 /** Review-thread node from the reviewThreads connection. */
-interface ReviewThreadNode {
+export interface ReviewThreadNode {
   id?: string | null;
   isResolved?: boolean | null;
   comments?: {
-    pageInfo?: { hasNextPage?: boolean | null } | null;
+    pageInfo?: {
+      hasNextPage?: boolean | null;
+      endCursor?: string | null;
+    } | null;
     nodes?: ThreadCommentNode[] | null;
   } | null;
 }
@@ -243,6 +246,29 @@ const DEFAULT_APPLY_RETRY_MAX_ATTEMPTS = 3;
 /** Base backoff (ms) before each rescan; linear-ish with jitter, matching
  * {@link withBoundedRetry}'s formula in gh-exec.mts. */
 const DEFAULT_APPLY_RETRY_BACKOFF_MS = 200;
+
+const REVIEW_THREAD_COMMENT_FIELDS = `
+  id
+  url
+  body
+  createdAt
+  isMinimized
+  minimizedReason
+  viewerCanMinimize
+  author{login}
+  pullRequestReview{id}
+`;
+
+// #2478: a thread with more than 100 comments needs its own continuation
+// query -- `node(id)` re-entry is the only way to page an inner connection
+// past its first page, since the outer reviewThreads cursor only advances
+// between threads. 50 pages (5,000 comments) is far beyond any real review
+// thread; hitting it leaves `pageInfo.hasNextPage: true` on the returned
+// node exactly as an un-paginated first page would, so the existing
+// truncated-data skip in evaluateReviewComment (thread.comments.pageInfo.
+// hasNextPage) still fires rather than misreporting a capped thread as
+// complete.
+const MAX_REVIEW_THREAD_COMMENT_PAGES = 50;
 
 if (import.meta.main) {
   await main();
@@ -1282,7 +1308,10 @@ function fetchReviews(
   );
 }
 
-function fetchReviewThreads(
+// Exported for tests/audit-pr-cleanup.test.mts (#2478): the only way to
+// exercise the >100-comment inner-pagination walk without spawning the full
+// CLI and stubbing every gh call `buildReport` needs.
+export function fetchReviewThreads(
   owner: string,
   repo: string,
   number: number,
@@ -1296,18 +1325,8 @@ function fetchReviewThreads(
             id
             isResolved
             comments(first:100){
-              pageInfo{hasNextPage}
-              nodes{
-                id
-                url
-                body
-                createdAt
-                isMinimized
-                minimizedReason
-                viewerCanMinimize
-                author{login}
-                pullRequestReview{id}
-              }
+              pageInfo{hasNextPage endCursor}
+              nodes{${REVIEW_THREAD_COMMENT_FIELDS}}
             }
           }
           pageInfo{hasNextPage endCursor}
@@ -1315,7 +1334,7 @@ function fetchReviewThreads(
       }
     }
   }`;
-  return fetchConnection(
+  const threads = fetchConnection(
     query,
     { owner, repo, number },
     (data) => {
@@ -1331,6 +1350,87 @@ function fetchReviewThreads(
     },
     options,
   );
+  for (const thread of threads) {
+    if (thread.id && thread.comments?.pageInfo?.hasNextPage) {
+      thread.comments = fetchRemainingThreadComments(
+        thread.id,
+        thread.comments,
+        options,
+      );
+    }
+  }
+  return threads;
+}
+
+function fetchRemainingThreadComments(
+  threadId: string,
+  firstPage: NonNullable<ReviewThreadNode['comments']>,
+  options: GraphqlCallOptions,
+): NonNullable<ReviewThreadNode['comments']> {
+  const query = `query($id:ID!,$after:String){
+    node(id:$id){
+      ... on PullRequestReviewThread{
+        comments(first:100,after:$after){
+          pageInfo{hasNextPage endCursor}
+          nodes{${REVIEW_THREAD_COMMENT_FIELDS}}
+        }
+      }
+    }
+  }`;
+  const nodes = [...(firstPage.nodes ?? [])];
+  let pageInfo = firstPage.pageInfo;
+  let pagesFetched = 1;
+  while (pageInfo?.hasNextPage) {
+    if (pagesFetched >= MAX_REVIEW_THREAD_COMMENT_PAGES) {
+      break;
+    }
+    if (!pageInfo.endCursor) {
+      // Mirrors fetchReviewThreadsGeneric's same guard in
+      // provider-adapter-github.mts: fail loudly on a contract-violating
+      // hasNextPage:true-with-no-endCursor page rather than silently
+      // re-requesting page 1 (ghGraphql drops a null `after` variable),
+      // which could otherwise "self-heal" into duplicate comment nodes.
+      handleGraphqlFailure(
+        `GraphQL thread-comment continuation: hasNextPage without endCursor for thread ${threadId}`,
+        options,
+      );
+    }
+    const result = ghGraphql(
+      query,
+      { id: threadId, after: pageInfo.endCursor },
+      options,
+    ) as {
+      data?: {
+        node?: {
+          comments?: {
+            pageInfo?: {
+              hasNextPage?: boolean | null;
+              endCursor?: string | null;
+            } | null;
+            nodes?: ThreadCommentNode[] | null;
+          } | null;
+        } | null;
+      };
+      errors?: GraphqlErrorEntry[] | null;
+    };
+    if (result.errors?.length) {
+      handleGraphqlFailure(
+        `GraphQL thread-comment continuation failed: ${formatGraphqlErrors(result.errors)}; thread=${threadId}`,
+        options,
+      );
+    }
+    const nextComments = result.data?.node?.comments;
+    if (!nextComments) {
+      handleGraphqlFailure(
+        `GraphQL thread-comment continuation returned no comments; thread=${threadId}`,
+        options,
+      );
+    }
+    nodes.push(...(nextComments.nodes ?? []));
+    pageInfo = nextComments.pageInfo;
+    pagesFetched += 1;
+  }
+  return { pageInfo: pageInfo ?? null, nodes };
 }
 
 function fetchConnection<TNode>(

--- a/tests/audit-pr-cleanup.test.mts
+++ b/tests/audit-pr-cleanup.test.mts
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
 
 import type {
@@ -7,6 +10,7 @@ import type {
 } from '../src/scripts/audit-pr-cleanup.mts';
 import {
   assertBatchApplyClaimScope,
+  fetchReviewThreads,
   parsePrNumbers,
 } from '../src/scripts/audit-pr-cleanup.mts';
 
@@ -497,5 +501,182 @@ test('assertBatchApplyClaimScope: --pr with --apply and no --skip-claim-check is
 test('assertBatchApplyClaimScope: dry-run (no --apply) is never gated', () => {
   assert.doesNotThrow(() =>
     assertBatchApplyClaimScope(cleanupArgs({ prs: '1,2' })),
+  );
+});
+
+// #2478: fetchReviewThreads's inner per-thread comment pagination. Stubs
+// `gh` on PATH (same technique as tests/gh-pagination-parsing-smoke.test.mts)
+// rather than spawning the full CLI, since exercising this one internal
+// function directly avoids stubbing every other gh call `buildReport` needs.
+// The outer `reviewThreads` query and the per-thread `node(id)` continuation
+// query are distinguished by their distinct variable names (`owner=`/`id=`)
+// rather than by reproducing the exact query text, which would be brittle
+// to unrelated formatting changes.
+
+function makeThreadComment(id: string): Record<string, unknown> {
+  return {
+    id,
+    url: `https://example.com/${id}`,
+    body: 'x',
+    createdAt: '2026-01-01T00:00:00Z',
+    isMinimized: false,
+    minimizedReason: null,
+    viewerCanMinimize: true,
+    author: { login: 'a' },
+    pullRequestReview: null,
+  };
+}
+
+function writeFakeGh(
+  dir: string,
+  outerResponse: string,
+  continuationResponse: string,
+): void {
+  const ghPath = join(dir, 'gh');
+  const script = `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === 'api' && args[1] === 'graphql') {
+  if (args.some((a) => a.startsWith('owner='))) {
+    process.stdout.write(${JSON.stringify(outerResponse)});
+    process.exit(0);
+  }
+  if (args.some((a) => a.startsWith('id='))) {
+    process.stdout.write(${JSON.stringify(continuationResponse)});
+    process.exit(0);
+  }
+}
+process.stderr.write('unexpected gh invocation: ' + args.join(' ') + '\\n');
+process.exit(1);
+`;
+  writeFileSync(ghPath, script);
+  chmodSync(ghPath, 0o755);
+}
+
+function withFakeGh<T>(
+  outerResponse: string,
+  continuationResponse: string,
+  run: () => T,
+): T {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'idd-audit-pr-cleanup-fake-gh-'));
+  const originalPath = process.env.PATH;
+  try {
+    writeFakeGh(tempRoot, outerResponse, continuationResponse);
+    process.env.PATH = `${tempRoot}:${originalPath ?? ''}`;
+    return run();
+  } finally {
+    process.env.PATH = originalPath;
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function outerThreadResponse(
+  firstPageNodes: Record<string, unknown>[],
+  firstPageHasNextPage: boolean,
+  firstPageEndCursor: string | null,
+): string {
+  return JSON.stringify({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: {
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: [
+              {
+                id: 'THREAD1',
+                isResolved: false,
+                comments: {
+                  pageInfo: {
+                    hasNextPage: firstPageHasNextPage,
+                    endCursor: firstPageEndCursor,
+                  },
+                  nodes: firstPageNodes,
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  });
+}
+
+test('fetchReviewThreads paginates past a review thread first 100 comments (#2478)', () => {
+  const firstPageNodes = Array.from({ length: 100 }, (_, i) =>
+    makeThreadComment(`c${i}`),
+  );
+  const outerResponse = outerThreadResponse(firstPageNodes, true, 'CURSOR1');
+  const continuationResponse = JSON.stringify({
+    data: {
+      node: {
+        comments: {
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [makeThreadComment('c100')],
+        },
+      },
+    },
+  });
+
+  const threads = withFakeGh(outerResponse, continuationResponse, () =>
+    fetchReviewThreads('o', 'r', 1),
+  );
+
+  assert.equal(threads.length, 1);
+  assert.equal(threads[0].comments?.nodes?.length, 101);
+  assert.equal(threads[0].comments?.pageInfo?.hasNextPage, false);
+});
+
+test('fetchReviewThreads stops at the page-count safety cap and still reports hasNextPage:true (#2478)', () => {
+  const firstPageNodes = Array.from({ length: 100 }, (_, i) =>
+    makeThreadComment(`c${i}`),
+  );
+  const outerResponse = outerThreadResponse(firstPageNodes, true, 'CURSOR1');
+  // Pathological: every continuation call reports another page still
+  // pending, simulating a runaway/misbehaving API response. The safety cap
+  // must still terminate the walk and leave hasNextPage:true so the
+  // existing truncated-data skip in evaluateReviewComment keeps firing
+  // instead of misreporting a capped thread as complete.
+  const continuationResponse = JSON.stringify({
+    data: {
+      node: {
+        comments: {
+          pageInfo: { hasNextPage: true, endCursor: 'CURSOR-NEXT' },
+          nodes: [makeThreadComment('extra')],
+        },
+      },
+    },
+  });
+
+  const threads = withFakeGh(outerResponse, continuationResponse, () =>
+    fetchReviewThreads('o', 'r', 1),
+  );
+
+  assert.equal(threads.length, 1);
+  // 1 initial 100-comment page + 49 continuation pages, each contributing
+  // one more comment -- capped at MAX_REVIEW_THREAD_COMMENT_PAGES (50)
+  // total pages fetched for this thread.
+  assert.equal(threads[0].comments?.nodes?.length, 100 + 49);
+  assert.equal(threads[0].comments?.pageInfo?.hasNextPage, true);
+});
+
+test('fetchReviewThreads fails loudly on hasNextPage:true with a missing endCursor (#2478 review)', () => {
+  const firstPageNodes = Array.from({ length: 100 }, (_, i) =>
+    makeThreadComment(`c${i}`),
+  );
+  // A contract-violating page: hasNextPage:true but no endCursor to
+  // continue from. Must throw rather than silently re-requesting page 1
+  // (ghGraphql drops a null `after` variable), which could otherwise
+  // "self-heal" into duplicate comment nodes the downstream
+  // truncated-data skip would not catch.
+  const outerResponse = outerThreadResponse(firstPageNodes, true, null);
+  // Never reached -- an unexpected continuation call would fail loudly via
+  // the fake gh's own unmatched-invocation path instead of returning this.
+  const continuationResponse = JSON.stringify({});
+
+  assert.throws(
+    () =>
+      withFakeGh(outerResponse, continuationResponse, () =>
+        fetchReviewThreads('o', 'r', 1, { throwOnError: true }),
+      ),
+    /hasNextPage without endCursor/,
   );
 });


### PR DESCRIPTION
# Summary

`audit-pr-cleanup.mts`'s `fetchReviewThreads` requested each review
thread's inner `comments(first:100)` connection with `pageInfo{
hasNextPage}` but no `endCursor`, and never re-queried past the first
page. A thread with more than 100 comments therefore silently
truncated -- and worse, the existing downstream defensive check
(`evaluateReviewComment`'s `thread.comments?.pageInfo?.hasNextPage`
skip) meant such a thread could never be cleaned up at all, since
`hasNextPage` stayed permanently `true`.

## Linked issue

Closes #2478

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Added the missing inner-connection pagination directly in
`fetchReviewThreads` (rather than reusing
`provider-adapter-github.mts`'s `fetchReviewThreadsGeneric`, which is
scoped to that module's own `GithubProviderAdapterDeps`/`ghText`
plumbing and a different node shape) via a new
`fetchRemainingThreadComments` helper that walks `node(id){ ... on
PullRequestReviewThread { comments(first:100,after:$cursor){...} } }`
continuation queries with this module's existing synchronous
`ghGraphql`.

Bounded the walk with `MAX_REVIEW_THREAD_COMMENT_PAGES = 50` (far
beyond any real review thread) as the "intentional page cap" the
issue asked to surface. Rather than invent a new `truncated` field,
hitting the cap simply leaves the last-fetched page's `hasNextPage:
true` on the returned thread, so the pre-existing
`evaluateReviewComment` truncated-data skip continues to protect
against a genuinely-incomplete result with no new field needed.

Exported `fetchReviewThreads` (previously module-private) so
`tests/audit-pr-cleanup.test.mts` can exercise the >100-comment walk
directly with a stub `gh` on PATH, instead of needing to stub every
other call `buildReport()`'s full CLI flow requires.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4791/4791 pass, including 2 new tests: pagination
      past 100 comments, page-count safety-cap behavior)
- [x] `pnpm run typecheck`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed; pre-existing warnings
      unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (none)
