### PR TITLE
docs(issue-authoring): add codebase-fidelity remedy and example

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -378,6 +378,14 @@ Ask these checks:
 1. When an issue reuses an existing identifier or field name, confirm the
    specified value matches that name's established semantics in the
    codebase — do not overload a name with a new shape or source.
+   **Remedy**: mint a new, distinctly named field instead of overloading
+   the existing one. Worked example: a candidate issue's acceptance
+   criterion reads "set `retryAttempts` to the elapsed wait time in
+   milliseconds" — `retryAttempts` already means a whole-pass apply
+   attempt _count_ in `audit-pr-cleanup.mts`'s `CleanupAuditReport`, so
+   reusing it for a duration overloads an established name with an
+   incompatible shape. Fix: mint a new field instead, e.g.
+   `retryWaitMs`, and leave `retryAttempts` untouched.
 2. Flag values that are mutable at runtime — specify a live read at the
    point of use rather than a one-time capture at construction.
 3. When an issue proposes to **delete, replace, or "align to upstream"**

--- a/.claude/skills/issue-authoring/references/draft-patterns.md
+++ b/.claude/skills/issue-authoring/references/draft-patterns.md
@@ -161,7 +161,9 @@ Before you publish a `ready` issue, confirm:
 
 - when the issue reuses an existing identifier or field name, the
   specified value matches that name's established semantics in the
-  codebase — it does not overload a name with a new shape or source
+  codebase — it does not overload a name with a new shape or source;
+  remedy: mint a new, distinctly named field instead (see
+  [contract.md's worked example](contract.md#codebase-fidelity-validation))
 - values that are mutable at runtime are flagged to specify a live read
   at the point of use rather than a one-time capture at construction
 

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -378,6 +378,14 @@ Ask these checks:
 1. When an issue reuses an existing identifier or field name, confirm the
    specified value matches that name's established semantics in the
    codebase — do not overload a name with a new shape or source.
+   **Remedy**: mint a new, distinctly named field instead of overloading
+   the existing one. Worked example: a candidate issue's acceptance
+   criterion reads "set `retryAttempts` to the elapsed wait time in
+   milliseconds" — `retryAttempts` already means a whole-pass apply
+   attempt _count_ in `audit-pr-cleanup.mts`'s `CleanupAuditReport`, so
+   reusing it for a duration overloads an established name with an
+   incompatible shape. Fix: mint a new field instead, e.g.
+   `retryWaitMs`, and leave `retryAttempts` untouched.
 2. Flag values that are mutable at runtime — specify a live read at the
    point of use rather than a one-time capture at construction.
 3. When an issue proposes to **delete, replace, or "align to upstream"**

--- a/skills/issue-authoring/references/draft-patterns.md
+++ b/skills/issue-authoring/references/draft-patterns.md
@@ -161,7 +161,9 @@ Before you publish a `ready` issue, confirm:
 
 - when the issue reuses an existing identifier or field name, the
   specified value matches that name's established semantics in the
-  codebase — it does not overload a name with a new shape or source
+  codebase — it does not overload a name with a new shape or source;
+  remedy: mint a new, distinctly named field instead (see
+  [contract.md's worked example](contract.md#codebase-fidelity-validation))
 - values that are mutable at runtime are flagged to specify a live read
   at the point of use rather than a one-time capture at construction
 


### PR DESCRIPTION
# Summary

The issue-authoring skill's codebase-fidelity check already detects
when an issue reuses an existing identifier/field name with different
semantics than the codebase, but only stated the prohibition -- it
gave no positive next step or worked example.

## Linked issue

Closes #2480

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Added the remedy (mint a new, distinctly named field instead of
overloading the existing one) to both `contract.md`'s codebase-fidelity
check and its `draft-patterns.md` quick-check restatement, plus a
worked example in `contract.md` grounded in this repo's own
`CleanupAuditReport.retryAttempts` field (a whole-pass apply attempt
count) to illustrate the overload-vs-mint-new-field distinction
concretely.

Re-synced the generated `.claude/skills/issue-authoring/` mirror via
`pnpm run docs:sync` per this repo's canonical-bundle convention.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed; pre-existing warnings
      unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (none)
