### PR TITLE
fix(protocol-helpers): hint an edited-after-disposition notice

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1250,10 +1250,10 @@ export const MALFORMED_DISPOSITION_PREFIX_HINT =
 // indication a reply was ever posted. Never consumed by any routing decision
 // -- see the `hint` field's own doc comment on `DispositionEvidenceSummary`.
 export const EDITED_AFTER_DISPOSITION_HINT =
-  'comment was correctly dispositioned, then the bot live-edited this same ' +
-  'comment id afterward into a non-review notice -- the disposition now ' +
-  'predates the edit and no longer counts; post a fresh disposition reply ' +
-  'in the non-review-notice shape';
+  'comment may have already been dispositioned before the bot live-edited ' +
+  'this same comment id into a non-review notice -- if so, that disposition ' +
+  'now predates the edit and no longer counts; post a fresh disposition ' +
+  'reply in the non-review-notice shape';
 // #1122 CodeRabbit summary-walkthrough auto-disposition classifiers.
 //
 // The CodeRabbit summary walkthrough is a regular comment whose body starts with

--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1241,6 +1241,19 @@ export const MALFORMED_DISPOSITION_PREFIX_HINT =
   'start with exactly "**Accepted**" or "**Rejected**" (bold markdown, ' +
   'optionally followed by one of . ! : before the closing **) -- a plain ' +
   '"Accepted" / "Rejected" without the bold markdown is not recognized';
+// #2491 diagnostic-only hint text, single-sourced like the two hints above:
+// unlike those (a MIS-PHRASED disposition attempt), this fires when a
+// correctly-phrased disposition already exists but the bot later live-edited
+// the SAME comment id in place into a non-review notice, bumping its
+// `updatedAt` past the disposition's own timestamp -- so the disposition no
+// longer postdates the comment and the comment re-appears as missing with no
+// indication a reply was ever posted. Never consumed by any routing decision
+// -- see the `hint` field's own doc comment on `DispositionEvidenceSummary`.
+export const EDITED_AFTER_DISPOSITION_HINT =
+  'comment was correctly dispositioned, then the bot live-edited this same ' +
+  'comment id afterward into a non-review notice -- the disposition now ' +
+  'predates the edit and no longer counts; post a fresh disposition reply ' +
+  'in the non-review-notice shape';
 // #1122 CodeRabbit summary-walkthrough auto-disposition classifiers.
 //
 // The CodeRabbit summary walkthrough is a regular comment whose body starts with
@@ -3287,6 +3300,38 @@ export function summarizeDispositionEvidenceForGate(
         (disposition) =>
           compareIsoTimestamps(disposition.activityAt, comment.createdAt) > 0,
       );
+    // #2491: neither hint above fires when the existing disposition reply
+    // was itself well-formed and correctly timed -- both look for a
+    // MIS-PHRASED attempt, and this is not one. Instead the bot live-edited
+    // this same comment id in place into a non-review notice afterward,
+    // bumping its `activityAt` past the disposition's own timestamp: the
+    // disposition `<= comment.activityAt` bound is exactly the complement of
+    // the general 1:1 pairing's own success condition above
+    // (`candidate.activityAt > comment.activityAt`), so a disposition
+    // satisfying it is exactly one that FAILS that pairing. Like the two
+    // hints above, this is a plausible-timing heuristic, not a proven
+    // causal link to this specific comment -- `dispositionComments.some`
+    // matches any well-formed disposition in the window, including one a
+    // human/agent posted for a different comment entirely or one already
+    // consumed elsewhere via `usedReplyIndexes`; a false-positive hint here
+    // is a diagnostic inaccuracy at worst, never a routing change. The
+    // `> comment.createdAt` lower bound (mirroring the two hints above)
+    // additionally requires the disposition to postdate the comment's
+    // original appearance. Gated on `isGateAdvisoryBotLogin` +
+    // `isAdvisoryNonReviewNotice`, mirroring `isNoticeComment` above: only a
+    // comment whose CURRENT body is itself a non-review notice from a
+    // configured advisory bot fits the scenario the issue describes.
+    const hasEditedAfterDispositionAttempt =
+      !hasWrongPhraseAttempt &&
+      !hasMalformedPrefixAttempt &&
+      isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins) &&
+      isAdvisoryNonReviewNotice(comment.body) &&
+      dispositionComments.some(
+        (disposition) =>
+          compareIsoTimestamps(disposition.activityAt, comment.activityAt) <=
+            0 &&
+          compareIsoTimestamps(disposition.activityAt, comment.createdAt) > 0,
+      );
     return {
       id: comment.id || `comment-${comment.sortedIndex + 1}`,
       authorLogin: comment.authorLogin || 'unknown',
@@ -3296,7 +3341,9 @@ export function summarizeDispositionEvidenceForGate(
         ? { hint: NON_REVIEW_NOTICE_DISPOSITION_HINT }
         : hasMalformedPrefixAttempt
           ? { hint: MALFORMED_DISPOSITION_PREFIX_HINT }
-          : {}),
+          : hasEditedAfterDispositionAttempt
+            ? { hint: EDITED_AFTER_DISPOSITION_HINT }
+            : {}),
     };
   });
   // #978 advisory-only diagnostic: a blocking resolved thread is

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1984,6 +1984,20 @@ export const MALFORMED_DISPOSITION_PREFIX_HINT =
   'optionally followed by one of . ! : before the closing **) -- a plain ' +
   '"Accepted" / "Rejected" without the bold markdown is not recognized';
 
+// #2491 diagnostic-only hint text, single-sourced like the two hints above:
+// unlike those (a MIS-PHRASED disposition attempt), this fires when a
+// correctly-phrased disposition already exists but the bot later live-edited
+// the SAME comment id in place into a non-review notice, bumping its
+// `updatedAt` past the disposition's own timestamp -- so the disposition no
+// longer postdates the comment and the comment re-appears as missing with no
+// indication a reply was ever posted. Never consumed by any routing decision
+// -- see the `hint` field's own doc comment on `DispositionEvidenceSummary`.
+export const EDITED_AFTER_DISPOSITION_HINT =
+  'comment was correctly dispositioned, then the bot live-edited this same ' +
+  'comment id afterward into a non-review notice -- the disposition now ' +
+  'predates the edit and no longer counts; post a fresh disposition reply ' +
+  'in the non-review-notice shape';
+
 // #1122 CodeRabbit summary-walkthrough auto-disposition classifiers.
 //
 // The CodeRabbit summary walkthrough is a regular comment whose body starts with
@@ -4284,6 +4298,38 @@ export function summarizeDispositionEvidenceForGate(
         (disposition) =>
           compareIsoTimestamps(disposition.activityAt, comment.createdAt) > 0,
       );
+    // #2491: neither hint above fires when the existing disposition reply
+    // was itself well-formed and correctly timed -- both look for a
+    // MIS-PHRASED attempt, and this is not one. Instead the bot live-edited
+    // this same comment id in place into a non-review notice afterward,
+    // bumping its `activityAt` past the disposition's own timestamp: the
+    // disposition `<= comment.activityAt` bound is exactly the complement of
+    // the general 1:1 pairing's own success condition above
+    // (`candidate.activityAt > comment.activityAt`), so a disposition
+    // satisfying it is exactly one that FAILS that pairing. Like the two
+    // hints above, this is a plausible-timing heuristic, not a proven
+    // causal link to this specific comment -- `dispositionComments.some`
+    // matches any well-formed disposition in the window, including one a
+    // human/agent posted for a different comment entirely or one already
+    // consumed elsewhere via `usedReplyIndexes`; a false-positive hint here
+    // is a diagnostic inaccuracy at worst, never a routing change. The
+    // `> comment.createdAt` lower bound (mirroring the two hints above)
+    // additionally requires the disposition to postdate the comment's
+    // original appearance. Gated on `isGateAdvisoryBotLogin` +
+    // `isAdvisoryNonReviewNotice`, mirroring `isNoticeComment` above: only a
+    // comment whose CURRENT body is itself a non-review notice from a
+    // configured advisory bot fits the scenario the issue describes.
+    const hasEditedAfterDispositionAttempt =
+      !hasWrongPhraseAttempt &&
+      !hasMalformedPrefixAttempt &&
+      isGateAdvisoryBotLogin(comment.authorLogin, advisoryBotLogins) &&
+      isAdvisoryNonReviewNotice(comment.body) &&
+      dispositionComments.some(
+        (disposition) =>
+          compareIsoTimestamps(disposition.activityAt, comment.activityAt) <=
+            0 &&
+          compareIsoTimestamps(disposition.activityAt, comment.createdAt) > 0,
+      );
     return {
       id: comment.id || `comment-${comment.sortedIndex + 1}`,
       authorLogin: comment.authorLogin || 'unknown',
@@ -4293,7 +4339,9 @@ export function summarizeDispositionEvidenceForGate(
         ? { hint: NON_REVIEW_NOTICE_DISPOSITION_HINT }
         : hasMalformedPrefixAttempt
           ? { hint: MALFORMED_DISPOSITION_PREFIX_HINT }
-          : {}),
+          : hasEditedAfterDispositionAttempt
+            ? { hint: EDITED_AFTER_DISPOSITION_HINT }
+            : {}),
     };
   });
 

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -1993,10 +1993,10 @@ export const MALFORMED_DISPOSITION_PREFIX_HINT =
 // indication a reply was ever posted. Never consumed by any routing decision
 // -- see the `hint` field's own doc comment on `DispositionEvidenceSummary`.
 export const EDITED_AFTER_DISPOSITION_HINT =
-  'comment was correctly dispositioned, then the bot live-edited this same ' +
-  'comment id afterward into a non-review notice -- the disposition now ' +
-  'predates the edit and no longer counts; post a fresh disposition reply ' +
-  'in the non-review-notice shape';
+  'comment may have already been dispositioned before the bot live-edited ' +
+  'this same comment id into a non-review notice -- if so, that disposition ' +
+  'now predates the edit and no longer counts; post a fresh disposition ' +
+  'reply in the non-review-notice shape';
 
 // #1122 CodeRabbit summary-walkthrough auto-disposition classifiers.
 //

--- a/tests/protocol-helpers.test.mts
+++ b/tests/protocol-helpers.test.mts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
   buildActivitySnapshotSummary,
+  EDITED_AFTER_DISPOSITION_HINT,
   MALFORMED_DISPOSITION_PREFIX_HINT,
   summarizeDispositionEvidenceForGate,
 } from '../src/scripts/protocol-helpers.mts';
@@ -702,5 +703,161 @@ test('disposition evidence does not hint a still-missing human comment from a re
 
   assert.equal(summary.missingRegularCommentCount, 1);
   assert.equal(summary.missingRegularComments[0].authorLogin, 'reviewer-b');
+  assert.equal(summary.missingRegularComments[0].hint, undefined);
+});
+
+// #2491: a correctly-phrased disposition (`**Accepted**`) that genuinely
+// postdated the comment at reply time, but the bot then live-edited that
+// same comment id afterward into a non-review notice -- bumping its
+// `updatedAt` past the disposition's own timestamp. Neither #1833's
+// wrong-phrase hint nor #2249's malformed-prefix hint applies (the
+// disposition was never mis-phrased), so this must be the only source of
+// a hint here.
+test('disposition evidence hints at an edited-after-disposition notice when the bot live-edits a dispositioned comment', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          // Edited by the bot after the disposition below -- bumps
+          // activityAt (updatedAt) past the disposition's own timestamp,
+          // and the CURRENT body is now a non-review notice.
+          updatedAt: '2026-05-12T02:00:00Z',
+          body: 'You have reached your Codex usage limits for code reviews.',
+          author: { login: 'chatgpt-codex-connector[bot]' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T01:00:00Z',
+          // Well-formed and genuinely postdated the comment's original
+          // review-finding content at reply time.
+          body: '**Accepted** — looks correct.',
+          author: { login: 'idd-bot' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['chatgpt-codex-connector[bot]'],
+    },
+  );
+
+  // Existing pass/fail routing is unchanged -- only the diagnostic is added.
+  assert.equal(summary.route, 'return-to-e1');
+  assert.equal(summary.reason, 'missing-disposition-evidence');
+  assert.equal(summary.missingRegularCommentCount, 1);
+  assert.equal(
+    summary.missingRegularComments[0].hint,
+    EDITED_AFTER_DISPOSITION_HINT,
+  );
+});
+
+// The disposition must predate the comment's CURRENT activityAt, not just
+// its createdAt -- a disposition posted AFTER the bot's edit (i.e. one that
+// already satisfies the general 1:1 pairing) must not also spuriously carry
+// this hint; the comment should not even be missing in that case.
+test('disposition evidence does not hint edited-after-disposition when the disposition already postdates the edit', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T01:00:00Z',
+          body: 'You have reached your Codex usage limits for code reviews.',
+          author: { login: 'chatgpt-codex-connector[bot]' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T02:00:00Z',
+          body: '**Accepted** — looks correct.',
+          author: { login: 'idd-bot' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['chatgpt-codex-connector[bot]'],
+    },
+  );
+
+  assert.equal(summary.missingRegularCommentCount, 0);
+});
+
+// A comment genuinely edited after a disposition (timing bound satisfied,
+// same as the positive scenario) but whose CURRENT body is NOT a non-review
+// notice must not pick up the hint -- `isAdvisoryNonReviewNotice` gates it
+// to the exact scenario it diagnoses. Unlike the disjoint-timestamp fixture
+// used elsewhere in this file, T0 < T1 <= T2 here so the timing bound alone
+// is satisfied and cannot itself explain a missing hint -- only the
+// notice-body gate can (#2491 critique finding 1: a prior version of this
+// test used a disposition that predated the comment's own createdAt, which
+// left the timing bound doing the suppressing instead).
+test('disposition evidence does not hint edited-after-disposition when the current body is not a notice', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          // Edited after the disposition below, same as the positive
+          // scenario -- but into ordinary follow-up prose, not a notice.
+          updatedAt: '2026-05-12T02:00:00Z',
+          body: 'Never mind, I found the actual line myself.',
+          author: { login: 'chatgpt-codex-connector[bot]' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T01:00:00Z',
+          body: '**Accepted** — looks correct.',
+          author: { login: 'idd-bot' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['chatgpt-codex-connector[bot]'],
+    },
+  );
+
+  assert.equal(summary.missingRegularCommentCount, 1);
+  assert.equal(summary.missingRegularComments[0].hint, undefined);
+});
+
+// Same timing shape as the positive scenario (T0 < T1 <= T2, current body
+// IS a notice), but the comment's author is not a configured advisory bot
+// login -- `isGateAdvisoryBotLogin` gates the hint to a genuine advisory-bot
+// notice, not any comment that happens to contain rate-limit-shaped prose.
+test('disposition evidence does not hint edited-after-disposition when the author is not a configured advisory bot', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          updatedAt: '2026-05-12T02:00:00Z',
+          body: 'You have reached your Codex usage limits for code reviews.',
+          author: { login: 'a-human' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T01:00:00Z',
+          body: '**Accepted** — looks correct.',
+          author: { login: 'idd-bot' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['chatgpt-codex-connector[bot]'],
+    },
+  );
+
+  assert.equal(summary.missingRegularCommentCount, 1);
   assert.equal(summary.missingRegularComments[0].hint, undefined);
 });


### PR DESCRIPTION
# Summary

`summarizeDispositionEvidenceForGate`'s existing hint mechanisms
(`#1833`, `#2249`) both only fire when the existing disposition reply
itself is malformed or wrong-phrased. Neither fires when a disposition
was originally correct against a genuinely completed review, and the
advisory bot later live-edits that same comment id in place into a
rate-limit/quota non-review notice, bumping its updated timestamp past
the disposition's created timestamp -- the disposition then fails the
general 1:1 pairing and the comment reappears as missing with no
explanation for why an apparently-already-answered comment came back.

Generalizes the hint condition to also fire when a trusted disposition
predates the comment's current `activityAt` (the exact logical
complement of the pairing's own success condition) and postdates the
comment's original `createdAt`, and the comment's current body matches
the non-review-notice pattern from a configured advisory bot. Purely
diagnostic -- never consumed by any routing decision, same as the two
sibling hints.

Went through one round of independent C1 critique (subagent) before
this push -- zero High findings; one Medium (a test that claimed to
isolate a gate but didn't, confirmed via mutation testing on both
sides) and one Low (an overclaiming code comment) were fixed. See the
issue thread for the full record.

## Linked issue

Closes #2491

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

None beyond the issue body itself.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4798/4798)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable) -- passed, only
      pre-existing warnings unrelated to this diff

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed -- none; this only adds a diagnostic
      `hint` field, never consumed by any routing decision
- [x] Context budget impact reviewed -- script/test files only, no
      instruction-file byte budgets touched
