### PR TITLE
docs(reference): add an importer branch to the Maintainer Note

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -53,8 +53,15 @@ or [Core concepts](concepts.md) before using this reference.
 
 ## Maintainer Note
 
-If you maintain an IDD distribution source repository, keep exported
+**If you maintain an IDD distribution source repository**, keep exported
 template files and generated onboarding lists in sync when adding or
 removing reference pages. In the idd-skill source repository, that means
 updating `audit/sync-manifest.json`, `idd-template/ONBOARDING.md`, and
 `idd-template/README.md` in the same change.
+
+**If you imported IDD into your own repository**, you keep no exported
+template directory of your own — instead, compare an upstream change to
+this reference set against your repository's recorded local policy
+before your next re-import, rather than assuming a routine template
+update carries no local impact. See
+[Re-importing](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#re-importing-import-named-gaps-not-a-blind-resync).

--- a/idd-template/docs/reference.md
+++ b/idd-template/docs/reference.md
@@ -53,8 +53,15 @@ or [Core concepts](concepts.md) before using this reference.
 
 ## Maintainer Note
 
-If you maintain an IDD distribution source repository, keep exported
+**If you maintain an IDD distribution source repository**, keep exported
 template files and generated onboarding lists in sync when adding or
 removing reference pages. In the idd-skill source repository, that means
 updating `audit/sync-manifest.json`, `idd-template/ONBOARDING.md`, and
 `idd-template/README.md` in the same change.
+
+**If you imported IDD into your own repository**, you keep no exported
+template directory of your own — instead, compare an upstream change to
+this reference set against your repository's recorded local policy
+before your next re-import, rather than assuming a routine template
+update carries no local impact. See
+[Re-importing](https://github.com/kurone-kito/idd-skill/blob/main/idd-template/ONBOARDING.md#re-importing-import-named-gaps-not-a-blind-resync).


### PR DESCRIPTION
# Summary

`docs/reference.md`'s Maintainer Note was written only for the
distribution-source maintainer, with no equivalent guidance for an
adopter that imported IDD and keeps no exported template directory of
their own -- even though importers are the majority of readers of
this page.

## Linked issue

Closes #2487

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Edited the canonical source, `idd-template/docs/reference.md`
(`docs/reference.md` is a generated exact-mode mirror per
`audit/sync-manifest.json`'s `reference-doc` pair), splitting the
Maintainer Note into a source-maintainer branch (existing text) and a
new importer branch instructing them to compare an upstream reference
change against their own recorded local policy before their next
re-import, linking to `ONBOARDING.md`'s existing "Re-importing"
section via the established absolute-GitHub-URL cross-reference
convention already used elsewhere in `idd-template/docs/*.md` (a
relative link would break once these docs are imported into an
adopter repository).

Re-synced the generated `docs/reference.md` mirror via
`pnpm run docs:sync`.

## IDD impact

- [x] Template files changed
- [ ] Instruction files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (passed; pre-existing warnings
      unrelated to this change)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (none)
