### PR TITLE
docs(onboarding): prompt whether domain guidance reaches every bot

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -51,3 +51,4 @@ words:
   - untriggerable
   - rethrew
   - resumability
+  - vrchat

--- a/idd-template/.cspell.config.yml
+++ b/idd-template/.cspell.config.yml
@@ -66,3 +66,4 @@ words:
   - ministral
   - nvmrc
   - remediations
+  - vrchat

--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -506,6 +506,14 @@ require explicit operator confirmation:
     pull requests — proposed from the repository's live GitHub default
     branch, verified against the configured remote before recording;
     absent resolves the live default branch
+16. path-scoped domain guidance reach: does any repository-specific
+    domain guidance the repository relies on (for example, "these `.cs`
+    files are UdonSharp, not standard C#") reach every configured
+    advisory bot the merge gate depends on, not only whichever bot owns
+    the config file the guidance happens to be written in? Under
+    `copilot-advisory` combined with `fully_autonomous_merge`, the
+    primary bot's review is an autonomous merge gate, so domain
+    guidance it never sees cannot inform that gate.
 
 Use
 [Onboarding Reference — Policy Decisions](docs/onboarding/policy-decisions.md)

--- a/idd-template/docs/onboarding/policy-decisions.md
+++ b/idd-template/docs/onboarding/policy-decisions.md
@@ -354,6 +354,37 @@ state, but repository-level safeguards such as force-push prevention
 and required reviews still come from GitHub branch protection, not
 from IDD.
 
+### Path-scoped domain guidance reach
+
+Ask this question during onboarding: does any repository-specific
+domain guidance the repository relies on for review quality — a note
+that a directory or file extension does not follow the language's
+standard idiom, for example "these `.cs` files are UdonSharp, not
+standard C#" — actually reach **every** configured advisory bot the
+merge gate depends on, or does it live only in one bot's own config
+file (for example CodeRabbit's `path_instructions` in
+`.coderabbit.yaml`)?
+
+**Why this matters under this repository's own merge policy.** Under
+the distributed `copilot-advisory` review policy combined with
+`fully_autonomous_merge`, the primary advisory bot's review is a real,
+autonomous merge gate — not merely informational. A secondary bot
+knowing the domain constraint does not help if the primary, gating bot
+never sees it: that bot stays strictly less informed than the
+repository's own docs, free to raise standard-language-idiomatic
+suggestions an executing agent might then implement into code the
+domain cannot actually compile.
+
+**Field evidence**: a fresh onboarding session hit exactly this shape
+(`kurone-kito/vrchat-world-template`, a Unity/UdonSharp repository with
+no `package.json`) — domain guidance configured only in the secondary
+bot's config file left the primary gating bot uninformed.
+
+If the answer is no, either duplicate the guidance into a form the
+primary bot reads (for example, a repository instructions file the
+primary bot's own product supports) or document the gap so it is not
+silently relied upon.
+
 ## Related default policies to confirm
 
 The onboarding entry point should also confirm whether the repository


### PR DESCRIPTION
# Summary

Under the distributed `copilot-advisory` review policy combined with
`fully_autonomous_merge`, the primary advisory bot's review is a real,
autonomous merge gate. Nothing in `idd-template/ONBOARDING.md` Step 1B
or Step 5 asked whether a repository's path-scoped domain guidance
(e.g. "these `.cs` files are UdonSharp, not standard C#") actually
reaches that primary bot, as opposed to living only in a secondary
bot's own config file (e.g. `.coderabbit.yaml`'s `path_instructions`).

Add Step 1B item 16 and a matching "Path-scoped domain guidance reach"
section to `policy-decisions.md` naming the specific risk and asking
the question directly.

## Linked issue

Closes #2461

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

A field incident hit exactly this: domain guidance configured only in
the secondary bot's config left the primary (gating) bot strictly less
informed than the repository's own docs, free to raise
standard-language-idiomatic suggestions an executing agent might then
implement into code the domain cannot actually compile
(`kurone-kito/vrchat-world-template`, Unity/UdonSharp repository, no
`package.json`). This is distinct from and additional to already-closed
`#1717`, which fixed a separate agent-entry-file stub-carryover gap
surfaced by the same onboarding session.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed
