### PR TITLE
docs(idd-helper-scripts): document the waiver check:/reason: encoding

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -1057,6 +1057,16 @@ Interpretation rules:
   marker body.
 - `check` may be an exact selector or a glob pattern, matching the
   `ciGate.externalChecks.*[].selector` plus `matchMode` contract.
+- `check:` and `reason:` hold single whitespace-free tokens in the raw
+  marker body: the authoring helper percent-encodes the check selector
+  and reason text with `encodeURIComponent` when writing the marker,
+  and decodes them back via `decodeURIComponent` on read (falling back
+  to an empty string -- which fails closed -- on a decode error). A
+  hand-written value containing a space or another character outside
+  the `check:\S+`/`reason:\S+` shape parses as malformed with no
+  automatic warning or reply unless percent-encoded first (a space
+  becomes `%20`); prefer the authoring helper below over hand-writing
+  the marker so this encoding is applied automatically.
 - Missing or unparseable body fields, unknown selectors, expired
   comments, wrong HEAD, wrong claim, or untrusted authors must fail
   closed.

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -1057,6 +1057,16 @@ Interpretation rules:
   marker body.
 - `check` may be an exact selector or a glob pattern, matching the
   `ciGate.externalChecks.*[].selector` plus `matchMode` contract.
+- `check:` and `reason:` hold single whitespace-free tokens in the raw
+  marker body: the authoring helper percent-encodes the check selector
+  and reason text with `encodeURIComponent` when writing the marker,
+  and decodes them back via `decodeURIComponent` on read (falling back
+  to an empty string -- which fails closed -- on a decode error). A
+  hand-written value containing a space or another character outside
+  the `check:\S+`/`reason:\S+` shape parses as malformed with no
+  automatic warning or reply unless percent-encoded first (a space
+  becomes `%20`); prefer the authoring helper below over hand-writing
+  the marker so this encoding is applied automatically.
 - Missing or unparseable body fields, unknown selectors, expired
   comments, wrong HEAD, wrong claim, or untrusted authors must fail
   closed.


### PR DESCRIPTION
# Summary

The External-check waiver contract section in `docs/idd-helper-scripts.md`
documents the marker shape and fail-closed rules but omits that `check:`
and `reason:` are percent-encoded (`encodeURIComponent`/
`decodeURIComponent`) single whitespace-free tokens, not raw text. A
hand-written value containing a space -- a common case, since the CLI
examples in this same section use `--reason "rate limit"` -- fails the
`check:\S+`/`reason:\S+` shape and parses as malformed with no automatic
warning or reply.

Documents the encoding contract and recommends the authoring helper over
hand-writing the marker, so an operator hand-authoring a waiver comment
doesn't lose it to a silent whitespace-related parse failure.

Went through one round of independent C1 critique (subagent) before this
push, which traced every claim in the new bullet against the actual
`src/scripts/marker-helpers.mts` implementation line-by-line -- zero High
findings; one Medium (a slight overclaim about "no explanation") and one
Low (code-span style) were fixed. See the issue thread for the full
record, including a mid-implementation correction: the first draft edited
the live `docs/idd-helper-scripts.md` directly, but that file mirrors
`idd-template/docs/idd-helper-scripts.md` in exact sync mode -- the change
was moved to the canonical source and regenerated.

## Linked issue

Closes #2483

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

None beyond the issue body itself.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (no source/test files touched -- docs-only change)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable) -- passed, only
      pre-existing warnings unrelated to this diff

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed -- none; documentation only
- [x] Context budget impact reviewed -- `docs/idd-helper-scripts.md`
      has no per-file phase budget configured; `audit-docs.mjs --check`
      confirms no bundle threshold crossed
