### PR TITLE
docs(idd-workflow): reframe ReviewItems_snapshot as session-local

### DIFF
--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -392,16 +392,16 @@ standard file the same way a standard-tier session would.
 current claim, created from E1's activity-universe fetch — not a
 literally immutable value a later session may reuse as-is.
 
-| Phase  | Operation                                                                                                   | State     |
-| ------ | ----------------------------------------------------------------------------------------------------------- | --------- |
-| E1     | Fetch threads/reviews/comments, exclude trusted operational markers, and freeze the current item universe   | created   |
-| E2     | Run critique pass and append newly found findings to the same snapshot scope                                | extended  |
-| E3     | Evaluate empty/non-empty routing based on the frozen snapshot plus E2 findings                              | evaluated |
-| E4-E8  | Classify, score, disposition, and verify each snapshot item (PATH A/PATH B) without redefining the snapshot | triaged   |
-| E9-E11 | Fix Accepted PATH A items, validate with a critique pass, and resolve conflicts with `{development-branch}` | actioned  |
-| E12    | Lint, test, and push the commit(s) addressing the actioned items                                            | committed |
-| E13    | Reply to each snapshot item with its disposition and resolve its thread                                     | replied   |
-| E15    | CI resolves for the pushed commit(s) and the loop returns to E1, ending this snapshot's role for the round  | complete  |
+| Phase   | Operation                                                                                                   | State     |
+| ------- | ----------------------------------------------------------------------------------------------------------- | --------- |
+| E1      | Fetch threads/reviews/comments, exclude trusted operational markers, and freeze the current item universe   | created   |
+| E2      | Run critique pass and append newly found findings to the same snapshot scope                                | extended  |
+| E3      | Evaluate empty/non-empty routing based on the frozen snapshot plus E2 findings                              | evaluated |
+| E4-E8   | Classify, score, disposition, and verify each snapshot item (PATH A/PATH B) without redefining the snapshot | triaged   |
+| E9-E11  | Fix Accepted PATH A items, validate with a critique pass, and resolve conflicts with `{development-branch}` | actioned  |
+| E12     | Lint, test, and push the commit(s) addressing the actioned items                                            | committed |
+| E13-E14 | Reply to each snapshot item with its disposition, resolve its thread, and request re-review                 | replied   |
+| E15     | CI resolves for the pushed commit(s) and the loop returns to E1, ending this snapshot's role for the round  | complete  |
 
 The name intentionally emphasizes snapshot semantics: E1-E3 builds and
 gates on a time-locked view, E4-E8 triages that view, and E9-E15 drives

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -392,16 +392,16 @@ standard file the same way a standard-tier session would.
 current claim, created from E1's activity-universe fetch — not a
 literally immutable value a later session may reuse as-is.
 
-| Phase | Operation                                                                                                   | State     |
-| ----- | ----------------------------------------------------------------------------------------------------------- | --------- |
-| E1    | Fetch threads/reviews/comments, exclude trusted operational markers, and freeze the current item universe   | created   |
-| E2    | Run critique pass and append newly found findings to the same snapshot scope                                | extended  |
-| E3    | Evaluate empty/non-empty routing based on the frozen snapshot plus E2 findings                              | evaluated |
-| E4-E8 | Classify, score, disposition, and verify each snapshot item (PATH A/PATH B) without redefining the snapshot | triaged   |
-| E9    | Fix Accepted PATH A items that were selected from the snapshot                                              | actioned  |
-| E12   | Lint, test, and push the commit(s) addressing the actioned items                                            | committed |
-| E13   | Reply to each snapshot item with its disposition and resolve its thread                                     | replied   |
-| E15   | CI resolves for the pushed commit(s) and the loop returns to E1, ending this snapshot's role for the round  | complete  |
+| Phase  | Operation                                                                                                   | State     |
+| ------ | ----------------------------------------------------------------------------------------------------------- | --------- |
+| E1     | Fetch threads/reviews/comments, exclude trusted operational markers, and freeze the current item universe   | created   |
+| E2     | Run critique pass and append newly found findings to the same snapshot scope                                | extended  |
+| E3     | Evaluate empty/non-empty routing based on the frozen snapshot plus E2 findings                              | evaluated |
+| E4-E8  | Classify, score, disposition, and verify each snapshot item (PATH A/PATH B) without redefining the snapshot | triaged   |
+| E9-E11 | Fix Accepted PATH A items, validate with a critique pass, and resolve conflicts with `{development-branch}` | actioned  |
+| E12    | Lint, test, and push the commit(s) addressing the actioned items                                            | committed |
+| E13    | Reply to each snapshot item with its disposition and resolve its thread                                     | replied   |
+| E15    | CI resolves for the pushed commit(s) and the loop returns to E1, ending this snapshot's role for the round  | complete  |
 
 The name intentionally emphasizes snapshot semantics: E1-E3 builds and
 gates on a time-locked view, E4-E8 triages that view, and E9-E15 drives

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -388,8 +388,9 @@ standard file the same way a standard-tier session would.
 
 ## ReviewItems_snapshot lifecycle
 
-`ReviewItems_snapshot` is the immutable collection created from E1's
-activity-universe fetch.
+`ReviewItems_snapshot` is a session-local ordered set, scoped to the
+current claim, created from E1's activity-universe fetch — not a
+literally immutable value a later session may reuse as-is.
 
 | Phase | Operation                                                                                                   | State     |
 | ----- | ----------------------------------------------------------------------------------------------------------- | --------- |
@@ -398,9 +399,23 @@ activity-universe fetch.
 | E3    | Evaluate empty/non-empty routing based on the frozen snapshot plus E2 findings                              | evaluated |
 | E4-E8 | Classify, score, disposition, and verify each snapshot item (PATH A/PATH B) without redefining the snapshot | triaged   |
 | E9    | Fix Accepted PATH A items that were selected from the snapshot                                              | actioned  |
+| E12   | Lint, test, and push the commit(s) addressing the actioned items                                            | committed |
+| E13   | Reply to each snapshot item with its disposition and resolve its thread                                     | replied   |
+| E15   | CI resolves for the pushed commit(s) and the loop returns to E1, ending this snapshot's role for the round  | complete  |
 
 The name intentionally emphasizes snapshot semantics: E1-E3 builds and
-gates on a time-locked view, while E4-E8 triages that view.
+gates on a time-locked view, E4-E8 triages that view, and E9-E15 drives
+it to completion within the current session before the next E1 fetch
+supersedes it.
+
+**Cross-session hygiene**: because the snapshot is session-local, a
+resumed or forced-handoff session must not inherit a prior session's
+`ReviewItems_snapshot`, watermark, or baseline markers as still
+authoritative for its own review pass. Rebuild from a fresh E1 fetch
+instead, and treat prior-claim operational markers as non-reusable even
+when the branch and HEAD are unchanged — see
+`idd-resume.instructions.md`'s CI/review routing table and its
+forced-handoff recovery note for the authoritative rule.
 
 ## Artifact taxonomy and ownership
 

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -388,7 +388,7 @@ standard file the same way a standard-tier session would.
 
 ## ReviewItems_snapshot lifecycle
 
-`ReviewItems_snapshot` is a session-local ordered set, scoped to the
+`ReviewItems_snapshot` is a session-local collection, scoped to the
 current claim, created from E1's activity-universe fetch — not a
 literally immutable value a later session may reuse as-is.
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -392,7 +392,7 @@ session would.
 
 ## ReviewItems_snapshot lifecycle
 
-`ReviewItems_snapshot` is a session-local ordered set, scoped to the
+`ReviewItems_snapshot` is a session-local collection, scoped to the
 current claim, created from E1's activity-universe fetch — not a
 literally immutable value a later session may reuse as-is.
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -396,16 +396,16 @@ session would.
 current claim, created from E1's activity-universe fetch — not a
 literally immutable value a later session may reuse as-is.
 
-| Phase | Operation                                                                                                   | State     |
-| ----- | ----------------------------------------------------------------------------------------------------------- | --------- |
-| E1    | Fetch threads/reviews/comments, exclude trusted operational markers, and freeze the current item universe   | created   |
-| E2    | Run critique pass and append newly found findings to the same snapshot scope                                | extended  |
-| E3    | Evaluate empty/non-empty routing based on the frozen snapshot plus E2 findings                              | evaluated |
-| E4-E8 | Classify, score, disposition, and verify each snapshot item (PATH A/PATH B) without redefining the snapshot | triaged   |
-| E9    | Fix Accepted PATH A items that were selected from the snapshot                                              | actioned  |
-| E12   | Lint, test, and push the commit(s) addressing the actioned items                                            | committed |
-| E13   | Reply to each snapshot item with its disposition and resolve its thread                                     | replied   |
-| E15   | CI resolves for the pushed commit(s) and the loop returns to E1, ending this snapshot's role for the round  | complete  |
+| Phase  | Operation                                                                                                   | State     |
+| ------ | ----------------------------------------------------------------------------------------------------------- | --------- |
+| E1     | Fetch threads/reviews/comments, exclude trusted operational markers, and freeze the current item universe   | created   |
+| E2     | Run critique pass and append newly found findings to the same snapshot scope                                | extended  |
+| E3     | Evaluate empty/non-empty routing based on the frozen snapshot plus E2 findings                              | evaluated |
+| E4-E8  | Classify, score, disposition, and verify each snapshot item (PATH A/PATH B) without redefining the snapshot | triaged   |
+| E9-E11 | Fix Accepted PATH A items, validate with a critique pass, and resolve conflicts with `{development-branch}` | actioned  |
+| E12    | Lint, test, and push the commit(s) addressing the actioned items                                            | committed |
+| E13    | Reply to each snapshot item with its disposition and resolve its thread                                     | replied   |
+| E15    | CI resolves for the pushed commit(s) and the loop returns to E1, ending this snapshot's role for the round  | complete  |
 
 The name intentionally emphasizes snapshot semantics: E1-E3 builds and
 gates on a time-locked view, E4-E8 triages that view, and E9-E15 drives

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -392,8 +392,9 @@ session would.
 
 ## ReviewItems_snapshot lifecycle
 
-`ReviewItems_snapshot` is the immutable collection created from E1's
-activity-universe fetch.
+`ReviewItems_snapshot` is a session-local ordered set, scoped to the
+current claim, created from E1's activity-universe fetch — not a
+literally immutable value a later session may reuse as-is.
 
 | Phase | Operation                                                                                                   | State     |
 | ----- | ----------------------------------------------------------------------------------------------------------- | --------- |
@@ -402,9 +403,23 @@ activity-universe fetch.
 | E3    | Evaluate empty/non-empty routing based on the frozen snapshot plus E2 findings                              | evaluated |
 | E4-E8 | Classify, score, disposition, and verify each snapshot item (PATH A/PATH B) without redefining the snapshot | triaged   |
 | E9    | Fix Accepted PATH A items that were selected from the snapshot                                              | actioned  |
+| E12   | Lint, test, and push the commit(s) addressing the actioned items                                            | committed |
+| E13   | Reply to each snapshot item with its disposition and resolve its thread                                     | replied   |
+| E15   | CI resolves for the pushed commit(s) and the loop returns to E1, ending this snapshot's role for the round  | complete  |
 
 The name intentionally emphasizes snapshot semantics: E1-E3 builds and
-gates on a time-locked view, while E4-E8 triages that view.
+gates on a time-locked view, E4-E8 triages that view, and E9-E15 drives
+it to completion within the current session before the next E1 fetch
+supersedes it.
+
+**Cross-session hygiene**: because the snapshot is session-local, a
+resumed or forced-handoff session must not inherit a prior session's
+`ReviewItems_snapshot`, watermark, or baseline markers as still
+authoritative for its own review pass. Rebuild from a fresh E1 fetch
+instead, and treat prior-claim operational markers as non-reusable even
+when the branch and HEAD are unchanged — see
+`idd-resume.instructions.md`'s CI/review routing table and its
+forced-handoff recovery note for the authoritative rule.
 
 ## Artifact taxonomy and ownership
 

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -396,16 +396,16 @@ session would.
 current claim, created from E1's activity-universe fetch — not a
 literally immutable value a later session may reuse as-is.
 
-| Phase  | Operation                                                                                                   | State     |
-| ------ | ----------------------------------------------------------------------------------------------------------- | --------- |
-| E1     | Fetch threads/reviews/comments, exclude trusted operational markers, and freeze the current item universe   | created   |
-| E2     | Run critique pass and append newly found findings to the same snapshot scope                                | extended  |
-| E3     | Evaluate empty/non-empty routing based on the frozen snapshot plus E2 findings                              | evaluated |
-| E4-E8  | Classify, score, disposition, and verify each snapshot item (PATH A/PATH B) without redefining the snapshot | triaged   |
-| E9-E11 | Fix Accepted PATH A items, validate with a critique pass, and resolve conflicts with `{development-branch}` | actioned  |
-| E12    | Lint, test, and push the commit(s) addressing the actioned items                                            | committed |
-| E13    | Reply to each snapshot item with its disposition and resolve its thread                                     | replied   |
-| E15    | CI resolves for the pushed commit(s) and the loop returns to E1, ending this snapshot's role for the round  | complete  |
+| Phase   | Operation                                                                                                   | State     |
+| ------- | ----------------------------------------------------------------------------------------------------------- | --------- |
+| E1      | Fetch threads/reviews/comments, exclude trusted operational markers, and freeze the current item universe   | created   |
+| E2      | Run critique pass and append newly found findings to the same snapshot scope                                | extended  |
+| E3      | Evaluate empty/non-empty routing based on the frozen snapshot plus E2 findings                              | evaluated |
+| E4-E8   | Classify, score, disposition, and verify each snapshot item (PATH A/PATH B) without redefining the snapshot | triaged   |
+| E9-E11  | Fix Accepted PATH A items, validate with a critique pass, and resolve conflicts with `{development-branch}` | actioned  |
+| E12     | Lint, test, and push the commit(s) addressing the actioned items                                            | committed |
+| E13-E14 | Reply to each snapshot item with its disposition, resolve its thread, and request re-review                 | replied   |
+| E15     | CI resolves for the pushed commit(s) and the loop returns to E1, ending this snapshot's role for the round  | complete  |
 
 The name intentionally emphasizes snapshot semantics: E1-E3 builds and
 gates on a time-locked view, E4-E8 triages that view, and E9-E15 drives


### PR DESCRIPTION
## Summary

- Reframes `ReviewItems_snapshot` in `docs/idd-workflow.md` (and the
  same section in `idd-template/docs/idd-workflow.md`, which was
  byte-identical for this section before this change) from "immutable"
  to session-local, scoped to the current claim, and described as a
  collection rather than an ordered set.
- Extends the lifecycle table through E12 (committed), E13 (replied),
  and E15 (complete) instead of stopping at E9.
- Adds a cross-session hygiene note: a resumed or forced-handoff
  session must rebuild the snapshot from a fresh E1 fetch rather than
  inheriting a prior session's snapshot/watermark/baseline, per
  `idd-resume.instructions.md`'s existing non-reuse rule.

## Acceptance criteria

- [x] `docs/idd-workflow.md` no longer describes `ReviewItems_snapshot`
      as literally immutable; it is described as session-local instead.
- [x] The lifecycle table extends through commit/reply/complete.
- [x] A cross-session hygiene note covers not inheriting a prior
      session's items/watermark/baseline after a resume or forced
      handoff.
- [x] `node scripts/audit-docs.mjs --check` passes.

## Test plan

- [x] `node scripts/audit-docs.mjs --check`
- [x] `npx markdownlint-cli2 docs/idd-workflow.md idd-template/docs/idd-workflow.md`
- [x] `npx cspell docs/idd-workflow.md idd-template/docs/idd-workflow.md`
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `npx dprint check`

Closes #2484

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that review snapshots apply only to the current claim and session.
  - Documented the snapshot lifecycle through the final review steps.
  - Added guidance for resumed or forced-handoff sessions to rebuild review state using fresh data rather than prior session markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->