### PR TITLE
fix(discover): capture a "Blocked by"/"Depends on" list past a line wrap

### DIFF
--- a/scripts/discover-readiness-check.mjs
+++ b/scripts/discover-readiness-check.mjs
@@ -409,7 +409,13 @@ function extractKeywordLineRefs(body, keyword) {
   );
   const numbers = [];
   for (const lineMatch of body.matchAll(linePattern)) {
-    numbers.push(...consumeDependencyRefList(lineMatch[1]));
+    numbers.push(...consumeDependencyRefList(lineMatch[1]).numbers);
+    numbers.push(
+      ...consumeContinuationRefLines(
+        body,
+        (lineMatch.index ?? 0) + lineMatch[0].length,
+      ),
+    );
   }
   return numbers;
 }
@@ -421,7 +427,10 @@ function extractKeywordLineRefs(body, keyword) {
  * (`(see other/repo#20)`) are excluded instead of being mis-read as local
  * blockers. This mirrors the separator-bounded reference parsing in
  * `discover-roadmap-graph.mts`, extended to also accept a plain-whitespace
- * separator so the space-separated multi-ref form is captured too.
+ * separator so the space-separated multi-ref form is captured too. Returns
+ * the parsed numbers alongside whatever text was not consumed, so a caller
+ * (e.g. {@link consumeContinuationRefLines}) can tell a line that is
+ * *entirely* a ref list apart from one that only starts with one.
  */
 function consumeDependencyRefList(segment) {
   const numbers = [];
@@ -440,6 +449,39 @@ function consumeDependencyRefList(segment) {
       break;
     }
     remaining = remaining.slice(separatorMatch[0].length);
+  }
+  return { numbers, remaining };
+}
+/**
+ * #2441: GitHub line-wraps a long, comma-separated "Blocked by"/"Depends on"
+ * list once it exceeds one line in the raw issue body, so a same-line-only
+ * scan silently loses every reference past the wrap. Starting right after
+ * the keyword line (`afterIndex`, the position of the newline that ends it,
+ * or end-of-body), consume zero or more immediately-following lines that
+ * are *entirely* a dependency-ref list -- each candidate line is parsed with
+ * {@link consumeDependencyRefList} and only swept in when nothing is left
+ * over, so a line starting a new paragraph, or mixing a reference with
+ * other prose, is excluded (matching the single-line prose exclusion this
+ * extends). Stops at the first blank line or non-continuation line.
+ */
+function consumeContinuationRefLines(body, afterIndex) {
+  const numbers = [];
+  let cursor = afterIndex;
+  while (body[cursor] === '\n') {
+    const lineStart = cursor + 1;
+    const nextNewline = body.indexOf('\n', lineStart);
+    const lineEnd = nextNewline === -1 ? body.length : nextNewline;
+    const trimmed = body.slice(lineStart, lineEnd).trim();
+    if (!trimmed) {
+      break;
+    }
+    const { numbers: lineNumbers, remaining } =
+      consumeDependencyRefList(trimmed);
+    if (lineNumbers.length === 0 || remaining.trim().length > 0) {
+      break;
+    }
+    numbers.push(...lineNumbers);
+    cursor = lineEnd;
   }
   return numbers;
 }

--- a/src/scripts/discover-readiness-check.mts
+++ b/src/scripts/discover-readiness-check.mts
@@ -563,7 +563,13 @@ function extractKeywordLineRefs(body: string, keyword: string): number[] {
   );
   const numbers: number[] = [];
   for (const lineMatch of body.matchAll(linePattern)) {
-    numbers.push(...consumeDependencyRefList(lineMatch[1]));
+    numbers.push(...consumeDependencyRefList(lineMatch[1]).numbers);
+    numbers.push(
+      ...consumeContinuationRefLines(
+        body,
+        (lineMatch.index ?? 0) + lineMatch[0].length,
+      ),
+    );
   }
   return numbers;
 }
@@ -576,9 +582,15 @@ function extractKeywordLineRefs(body: string, keyword: string): number[] {
  * (`(see other/repo#20)`) are excluded instead of being mis-read as local
  * blockers. This mirrors the separator-bounded reference parsing in
  * `discover-roadmap-graph.mts`, extended to also accept a plain-whitespace
- * separator so the space-separated multi-ref form is captured too.
+ * separator so the space-separated multi-ref form is captured too. Returns
+ * the parsed numbers alongside whatever text was not consumed, so a caller
+ * (e.g. {@link consumeContinuationRefLines}) can tell a line that is
+ * *entirely* a ref list apart from one that only starts with one.
  */
-function consumeDependencyRefList(segment: string): number[] {
+function consumeDependencyRefList(segment: string): {
+  numbers: number[];
+  remaining: string;
+} {
   const numbers: number[] = [];
   let remaining = segment;
   while (remaining) {
@@ -595,6 +607,43 @@ function consumeDependencyRefList(segment: string): number[] {
       break;
     }
     remaining = remaining.slice(separatorMatch[0].length);
+  }
+  return { numbers, remaining };
+}
+
+/**
+ * #2441: GitHub line-wraps a long, comma-separated "Blocked by"/"Depends on"
+ * list once it exceeds one line in the raw issue body, so a same-line-only
+ * scan silently loses every reference past the wrap. Starting right after
+ * the keyword line (`afterIndex`, the position of the newline that ends it,
+ * or end-of-body), consume zero or more immediately-following lines that
+ * are *entirely* a dependency-ref list -- each candidate line is parsed with
+ * {@link consumeDependencyRefList} and only swept in when nothing is left
+ * over, so a line starting a new paragraph, or mixing a reference with
+ * other prose, is excluded (matching the single-line prose exclusion this
+ * extends). Stops at the first blank line or non-continuation line.
+ */
+function consumeContinuationRefLines(
+  body: string,
+  afterIndex: number,
+): number[] {
+  const numbers: number[] = [];
+  let cursor = afterIndex;
+  while (body[cursor] === '\n') {
+    const lineStart = cursor + 1;
+    const nextNewline = body.indexOf('\n', lineStart);
+    const lineEnd = nextNewline === -1 ? body.length : nextNewline;
+    const trimmed = body.slice(lineStart, lineEnd).trim();
+    if (!trimmed) {
+      break;
+    }
+    const { numbers: lineNumbers, remaining } =
+      consumeDependencyRefList(trimmed);
+    if (lineNumbers.length === 0 || remaining.trim().length > 0) {
+      break;
+    }
+    numbers.push(...lineNumbers);
+    cursor = lineEnd;
   }
   return numbers;
 }

--- a/tests/discover-readiness-check.test.mts
+++ b/tests/discover-readiness-check.test.mts
@@ -220,6 +220,77 @@ test('dependency parsers ignore code-fenced examples and stay on one line', () =
   assert.deepEqual(extractBlockedByIssueNumbers(indentedFakeFence), [123]);
 });
 
+test('extractBlockedByIssueNumbers captures a GitHub-wrapped "Blocked by" list (#2441)', () => {
+  // The exact wrapped-body shape reproduced live against issue #2341: a long
+  // comma-separated list GitHub line-wraps once it exceeds one line in the
+  // raw body. Every reference, including the ones past the wrap, must be
+  // captured -- a same-line-only scan silently lost the last 6 of 13 here.
+  const wrappedBody =
+    'Blocked by #2319, #2320, #2321, #2322, #2323, #2326, #2327,\n' +
+    '#2329, #2333, #2335, #2337, #2338, #2339';
+  assert.deepEqual(
+    extractBlockedByIssueNumbers(wrappedBody),
+    [
+      2319, 2320, 2321, 2322, 2323, 2326, 2327, 2329, 2333, 2335, 2337, 2338,
+      2339,
+    ],
+  );
+
+  // A three-line wrap keeps sweeping in every continuation line, not just
+  // the first one after the keyword line.
+  assert.deepEqual(
+    extractBlockedByIssueNumbers('Blocked by #1, #2,\n#3, #4,\n#5, #6'),
+    [1, 2, 3, 4, 5, 6],
+  );
+});
+
+test('extractDependencyIssueNumbers captures a GitHub-wrapped "Depends on" list (#2441)', () => {
+  assert.deepEqual(
+    extractDependencyIssueNumbers('Depends on #100, #200, #300,\n#400, #500'),
+    [100, 200, 300, 400, 500],
+  );
+});
+
+test('the wrapped-list continuation scan excludes anything past a genuine list boundary (#2441)', () => {
+  // A blank line ends the list -- the ref on the far side is unrelated prose,
+  // not a continuation of the same "Blocked by" declaration.
+  assert.deepEqual(
+    extractBlockedByIssueNumbers('Blocked by #100\n\n#200 is unrelated'),
+    [100],
+  );
+
+  // A new paragraph of prose that happens to mention a reference is not a
+  // bare continuation line and must not be swept in.
+  assert.deepEqual(
+    extractBlockedByIssueNumbers(
+      'Blocked by #100\nThis relates to #200 somehow.',
+    ),
+    [100],
+  );
+
+  // A continuation line that mixes a reference with other prose is excluded
+  // in full -- not partially read for the leading reference alone.
+  assert.deepEqual(
+    extractBlockedByIssueNumbers(
+      'Blocked by #100\n#200 and see other/repo#20 too',
+    ),
+    [100],
+  );
+
+  // A heading immediately after the keyword line is not a continuation.
+  assert.deepEqual(
+    extractBlockedByIssueNumbers('Blocked by #100\n## Proposed change'),
+    [100],
+  );
+
+  // A cross-repo-only reference on the continuation line is not a bare
+  // local `#N` list and must not be swept in.
+  assert.deepEqual(
+    extractBlockedByIssueNumbers('Blocked by #100\nother/repo#20'),
+    [100],
+  );
+});
+
 test('extractBlockedByRoadmapMarkers honors a configured marker prefix', () => {
   const body = `
 <!-- idd-skill-blocked-by: default-prefixed -->


### PR DESCRIPTION
# Summary

`extractBlockedByIssueNumbers` and `extractDependencyIssueNumbers`
only scanned the same line as their keyword, so GitHub's automatic
line-wrap of a long comma-separated reference list silently dropped
every reference past the wrap point. Live on issue #2341: a
13-reference "Blocked by" list wrapped across two lines and only the
first 7 were extracted, letting a still-open blocker (#2339) go
undetected -- a discovery-safety gap that could make Discover treat a
still-blocked issue as ready.

## Linked issue

Closes #2441

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Added a bounded continuation scan: after the keyword line, each
immediately-following line is swept in only when it is entirely a
bare `#N` reference list with nothing left over -- a blank line, a new
paragraph, or a line mixing a reference with other prose stops the
scan, preserving the existing single-line prose-exclusion contract
(verified against all pre-existing tests, including the case where
the keyword line itself carries no same-line ref at all, which must
keep returning `[]`).

`consumeDependencyRefList` was refactored to also return the
unconsumed remainder, so the new continuation-line check can tell a
line that is *entirely* a ref list apart from one that only starts
with one.

Verified live against the exact issue #2341 body text (13 references
across the wrap) -- all 13 now extracted, confirmed via a direct
`node --experimental-strip-types` run before committing test coverage.

An independent critique pass hand-traced the cursor arithmetic against
2-line/3-line wraps and a no-trailing-newline body-final line, and
empirically confirmed (by stashing the source fix and re-running the
new tests against pre-fix code) that the wrapped-list tests are
genuinely fix-dependent while the exclusion-case tests correctly pass
under both old and new code (expected for negative tests). Verdict:
ship as-is; noted two narrow, non-blocking follow-up-worthy gaps (a
wrapped list inside a blockquote continuation line isn't swept in --
fail-closed, safe direction; a same-line list that itself trails into
prose still sweeps in continuation lines regardless -- over-inclusive,
also the safe direction for a blocking gate).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4815/4815 pass, including 3 new tests covering the
      exact #2341 reproduction, a 3-line wrap, and 5 exclusion cases)
- [x] `pnpm run typecheck`
- [x] Live verification against the literal #2341 wrapped body text

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (none)
