### PR TITLE
docs(onboarding): document linguist-generated convention for vendored-node

### DIFF
--- a/idd-template/ONBOARDING.md
+++ b/idd-template/ONBOARDING.md
@@ -683,7 +683,11 @@ not include the `vendored-node` profile's profile-conditional helper
 script bundle (for example `scripts/minimize-superseded-markers.mjs`) —
 see
 [Profile-conditional helper files](docs/onboarding/template-distribution.md#profile-conditional-helper-files-vendored-node)
-for why that bundle is out of scope here and how to get it anyway.
+for why that bundle is out of scope here and how to get it anyway. If
+you selected the `vendored-node` profile, also see
+[`.gitattributes` linguist-generated convention](docs/onboarding/template-distribution.md#gitattributes-linguist-generated-convention-vendored-node)
+to avoid review bots duplicating findings across a vendored `.mts`
+source and its generated `.mjs` output.
 For `idd-skill` maintainers working on this generated file list and the
 remote-fetch examples, see
 [Template distribution maintainer reference](docs/onboarding/template-distribution.md).

--- a/idd-template/docs/onboarding/template-distribution.md
+++ b/idd-template/docs/onboarding/template-distribution.md
@@ -202,7 +202,8 @@ Review bots (Copilot/CodeRabbit/etc.) read both a vendored `.mts`
 source file and its generated `.mjs` build output independently,
 producing duplicate findings for the same defect. The `idd-skill`
 source repository solves this for itself with a `.gitattributes`
-stanza marking every vendored `scripts/*.mjs`/`bin/**/*.mjs` file
+stanza marking every vendored `scripts/` file individually (plus a
+`bin/**/*.mjs` glob for the `bin/` shim directory)
 `linguist-generated=true` (see the root `.gitattributes`) — but
 `idd-template/` ships no `.gitattributes` file, since an adopter's own
 `.gitattributes` (if any) is theirs to own, and the import mechanism

--- a/idd-template/docs/onboarding/template-distribution.md
+++ b/idd-template/docs/onboarding/template-distribution.md
@@ -196,6 +196,40 @@ under `pnpm run lint`'s full test suite (`node --test`), which
 `audit-docs.mjs --check` can still break `idd-onboard.mjs`. This needs a
 maintainer decision, not a mechanical file-list edit.
 
+## `.gitattributes` linguist-generated convention (`vendored-node`)
+
+Review bots (Copilot/CodeRabbit/etc.) read both a vendored `.mts`
+source file and its generated `.mjs` build output independently,
+producing duplicate findings for the same defect. The `idd-skill`
+source repository solves this for itself with a `.gitattributes`
+stanza marking every vendored `scripts/*.mjs`/`bin/**/*.mjs` file
+`linguist-generated=true` (see the root `.gitattributes`) — but
+`idd-template/` ships no `.gitattributes` file, since an adopter's own
+`.gitattributes` (if any) is theirs to own, and the import mechanism
+above has no safe way to merge into a file the adopter may already
+maintain (`resolveImportFiles`'s `new`/`unchanged`/`overwrite`/
+`blocked-non-file` classification would treat a pre-existing
+`.gitattributes` as a blocked overwrite, or silently clobber one with
+`--force`).
+
+Adopters who vendor the `vendored-node` helper bundle should instead
+add an equivalent stanza to their own `.gitattributes` by hand, listing
+each vendored generated file individually rather than a bare
+`scripts/*.mjs` glob — a target repository's `scripts/` directory may
+also contain hand-written `.mjs` files that must not be mis-marked as
+generated:
+
+```gitattributes
+# Generated from TypeScript sources by `pnpm run build`; see
+# https://github.com/kurone-kito/idd-skill/blob/main/docs/typescript-sources.md
+scripts/advisory-convergence.mjs linguist-generated=true
+scripts/claim-approval-gate.mjs linguist-generated=true
+# ... one line per vendored helper file actually present in this repo
+```
+
+`idd-template/ONBOARDING.md`'s vendored-node profile guidance links
+here.
+
 ## Remote fetch examples
 
 These `gh api` and `curl` loops intentionally list every canonical


### PR DESCRIPTION
## Summary

- Documents the `linguist-generated=true` `.gitattributes` convention
  (already used by this repository for its own vendored `scripts/*.mjs`
  output) for `vendored-node`-profile adopters, in
  `idd-template/docs/onboarding/template-distribution.md`, with a
  cross-reference from `idd-template/ONBOARDING.md`.
- Documented as adopter-applied guidance, not an imported file:
  `resolveImportFiles` has no safe way to merge into a `.gitattributes`
  an adopter likely already owns (`new`/`unchanged`/`overwrite`/
  `blocked-non-file` classification means a pre-existing file is either
  a blocked overwrite or a `--force` clobber), and #1698 already
  documents how fragile the core/profile-conditional file-set boundary
  is (`resolveImportFiles`'s "manifest drift: duplicate target path"
  hard-fail, `buildSwitchPlan`'s data-loss hazard on profile switch).
  The issue's own acceptance criteria explicitly allows "or is
  explicitly guided to add" — this PR takes that path rather than
  extending `idd-onboard.mts`/`helper-runtime-manifest.mts`.

## Acceptance criteria

- [x] An adopter importing under `vendored-node` is explicitly guided
      to add a `.gitattributes` entry marking vendored generated
      output `linguist-generated=true`.
- [x] The convention is documented in onboarding docs for the
      `vendored-node` profile.
- [x] `node scripts/audit-docs.mjs --check` passes.

## Test plan

- [x] `node scripts/audit-docs.mjs --check`
- [x] `npx markdownlint-cli2 idd-template/ONBOARDING.md idd-template/docs/onboarding/template-distribution.md`
- [x] `npx cspell idd-template/ONBOARDING.md idd-template/docs/onboarding/template-distribution.md`
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `node scripts/markdown-link-audit.mjs` (new anchor link verified)
- [x] `npx dprint check`

Closes #2479