### PR TITLE
docs(customization): note the issue-author approval gate's no-op case

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1100,6 +1100,20 @@ The recommended contract is secure by default:
 - Omitting `skipIssueAuthorApprovalGate` or setting it to `false` keeps
   the gate enabled.
 
+**When is opting out a structural no-op?** In a single-author repository
+where every issue author already satisfies the current
+`maintainerApprovalActorPolicy`, the issue-author self-authorization
+signal below is satisfied whenever permission resolution succeeds (the
+A3.5 outage fallback covers only `OWNER`/`MEMBER` `author_association`
+values, so a permission-API outage can still fail closed for a
+self-authorizing author outside those two associations, e.g. an
+invited `COLLABORATOR`) -- so the gate does not change which candidates
+are startable in the common case, and opting out carries no practical
+risk there. Re-enable the gate (or simply omit
+`skipIssueAuthorApprovalGate`) if the repository ever becomes
+multi-author, since a non-maintainer author no longer self-authorizes
+and the gate starts mattering again.
+
 When the gate is enabled, an issue author is self-authorizing only when
 that author satisfies the repository's `maintainer-approval-actors`
 policy. GitHub organization `MEMBER` association alone is not enough,

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -1103,13 +1103,14 @@ The recommended contract is secure by default:
 **When is opting out a structural no-op?** In a single-author repository
 where every issue author already satisfies the current
 `maintainerApprovalActorPolicy`, the issue-author self-authorization
-signal below is satisfied whenever permission resolution succeeds (the
-A3.5 outage fallback covers only `OWNER`/`MEMBER` `author_association`
-values, so a permission-API outage can still fail closed for a
-self-authorizing author outside those two associations, e.g. an
-invited `COLLABORATOR`) -- so the gate does not change which candidates
-are startable in the common case, and opting out carries no practical
-risk there. Re-enable the gate (or simply omit
+signal below is satisfied whenever the collaborator permission API
+resolves successfully (A3.5's outage fallback, used only when that API
+is unavailable, covers only `OWNER`/`MEMBER` `author_association`
+values, so an outage can still fail closed for a self-authorizing
+author outside those two associations, e.g. an outside `COLLABORATOR`
+with existing repository access) -- so the gate does not change which
+candidates are startable in the common case, and opting out carries no
+practical risk there. Re-enable the gate (or simply omit
 `skipIssueAuthorApprovalGate`) if the repository ever becomes
 multi-author, since a non-maintainer author no longer self-authorizes
 and the gate starts mattering again.

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1100,6 +1100,20 @@ The recommended contract is secure by default:
 - Omitting `skipIssueAuthorApprovalGate` or setting it to `false` keeps
   the gate enabled.
 
+**When is opting out a structural no-op?** In a single-author repository
+where every issue author already satisfies the current
+`maintainerApprovalActorPolicy`, the issue-author self-authorization
+signal below is satisfied whenever permission resolution succeeds (the
+A3.5 outage fallback covers only `OWNER`/`MEMBER` `author_association`
+values, so a permission-API outage can still fail closed for a
+self-authorizing author outside those two associations, e.g. an
+invited `COLLABORATOR`) -- so the gate does not change which candidates
+are startable in the common case, and opting out carries no practical
+risk there. Re-enable the gate (or simply omit
+`skipIssueAuthorApprovalGate`) if the repository ever becomes
+multi-author, since a non-maintainer author no longer self-authorizes
+and the gate starts mattering again.
+
 When the gate is enabled, an issue author is self-authorizing only when
 that author satisfies the repository's `maintainer-approval-actors`
 policy. GitHub organization `MEMBER` association alone is not enough,

--- a/idd-template/docs/customization.md
+++ b/idd-template/docs/customization.md
@@ -1103,13 +1103,14 @@ The recommended contract is secure by default:
 **When is opting out a structural no-op?** In a single-author repository
 where every issue author already satisfies the current
 `maintainerApprovalActorPolicy`, the issue-author self-authorization
-signal below is satisfied whenever permission resolution succeeds (the
-A3.5 outage fallback covers only `OWNER`/`MEMBER` `author_association`
-values, so a permission-API outage can still fail closed for a
-self-authorizing author outside those two associations, e.g. an
-invited `COLLABORATOR`) -- so the gate does not change which candidates
-are startable in the common case, and opting out carries no practical
-risk there. Re-enable the gate (or simply omit
+signal below is satisfied whenever the collaborator permission API
+resolves successfully (A3.5's outage fallback, used only when that API
+is unavailable, covers only `OWNER`/`MEMBER` `author_association`
+values, so an outage can still fail closed for a self-authorizing
+author outside those two associations, e.g. an outside `COLLABORATOR`
+with existing repository access) -- so the gate does not change which
+candidates are startable in the common case, and opting out carries no
+practical risk there. Re-enable the gate (or simply omit
 `skipIssueAuthorApprovalGate`) if the repository ever becomes
 multi-author, since a non-maintainer author no longer self-authorizes
 and the gate starts mattering again.


### PR DESCRIPTION
# Summary

The Issue-Author Approval Gate section in `docs/customization.md`
documents the `skipIssueAuthorApprovalGate` toggle, the approval-actor
policy, and migration notes, but never explains when disabling it is
actually safe.

Verified the underlying claim against the actual gate implementation
(`.github/instructions/idd-discover.instructions.md`'s A3.5): in a
single-author repository where every issue author already satisfies
`maintainerApprovalActorPolicy`, the issue-author self-authorization
signal is satisfied whenever permission resolution succeeds, so the
gate does not change which candidates are startable in the common
case. Adds a "when is opting out a structural no-op?" note keyed to the
actor model, with explicit guidance to re-enable the gate if the
repository ever becomes multi-author.

Went through one round of independent C1 critique (subagent) before
this push, which traced the claim against A3.5's approval-signal list,
self-authorization fallback, and fail-closed paragraph -- zero High
findings; one Medium (the initial wording overclaimed "always"/"never"
without accounting for a permission-API-outage edge case affecting a
non-`OWNER`/`MEMBER` self-authorizing author) was fixed with a
precision caveat. See the issue thread for the full record.

## Linked issue

Closes #2488

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

None beyond the issue body itself.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (no source/test files touched -- docs-only change)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable) -- passed, only
      pre-existing warnings unrelated to this diff

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed -- none; documentation only
- [x] Context budget impact reviewed -- `docs/customization.md` has no
      per-file phase budget configured; `audit-docs.mjs --check`
      confirms no bundle threshold crossed
