### PR TITLE
docs(idd-work): verify HEAD advanced before trusting a push

### DIFF
--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -305,6 +305,17 @@ reordering, and run the C1 critique pass against the completed diff.
 Implement the plan, running **fix-validate** before each atomic commit
 (one logical change per commit).
 
+**Verify a commit actually landed before trusting a subsequent push.**
+A `commit-msg` hook (for example commitlint's body-max-line-length) can
+silently reject a commit with a long single-line body, so no commit is
+created — but the following `git push` then reports "Everything
+up-to-date", which reads as a normal no-op rather than the actual
+failure. Prefer `git commit ... -F <file>` with a pre-wrapped body over
+a long single-line `-m` message to avoid tripping the hook in the first
+place, and confirm the commit landed (compare `git rev-parse HEAD`
+before/after, or check the commit hash the commit command reports)
+before treating a subsequent push as confirmation the change landed.
+
 **De-duplication refactors**: when consolidating a wrapper function used
 at multiple call sites, check whether any call site's old delegate path
 added behavior (timeouts, stdio handling, error translation, etc.) that

--- a/.github/instructions/idd-work.instructions.md
+++ b/.github/instructions/idd-work.instructions.md
@@ -310,9 +310,9 @@ A `commit-msg` hook (for example commitlint's body-max-line-length) can
 silently reject a commit with a long single-line body, so no commit is
 created — but the following `git push` then reports "Everything
 up-to-date", which reads as a normal no-op rather than the actual
-failure. Prefer `git commit ... -F <file>` with a pre-wrapped body over
-a long single-line `-m` message to avoid tripping the hook in the first
-place, and confirm the commit landed (compare `git rev-parse HEAD`
+failure. Prefer `git commit -F <file>` with a pre-wrapped body file
+over a long single-line `-m` message to avoid tripping the hook in the
+first place, and confirm the commit landed (compare `git rev-parse HEAD`
 before/after, or check the commit hash the commit command reports)
 before treating a subsequent push as confirmation the change landed.
 

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -166,9 +166,9 @@ addendum resolves it.
     `commit-msg` hook (for example commitlint's body-max-line-length) can
     silently reject a commit with a long single-line body, and the
     following push then reports "Everything up-to-date" as if nothing
-    were wrong. Prefer `git commit ... -F <file>` with a pre-wrapped body,
-    and compare `git rev-parse HEAD` before/after (or check the reported
-    commit hash) before treating a push as confirmation.
+    were wrong. Prefer `git commit -F <file>` with a pre-wrapped body
+    file, and compare `git rev-parse HEAD` before/after (or check the
+    reported commit hash) before treating a push as confirmation.
 11. If validation fails in files this diff did not touch, suspect baseline
     drift or a stale install before blaming the change; verify with a fresh
     `install-deps` run in a clean worktree or a fresh-vs-stale

--- a/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/.github/instructions/lite/idd-work-lite.instructions.md
@@ -162,18 +162,25 @@ addendum resolves it.
 7. Run `fix-validate` before each commit.
 8. Keep commits atomic.
 9. If `fix-validate` changes files, stage and commit them before continuing.
-10. If validation fails in files this diff did not touch, suspect baseline
+10. Verify a commit actually landed before trusting a subsequent push: a
+    `commit-msg` hook (for example commitlint's body-max-line-length) can
+    silently reject a commit with a long single-line body, and the
+    following push then reports "Everything up-to-date" as if nothing
+    were wrong. Prefer `git commit ... -F <file>` with a pre-wrapped body,
+    and compare `git rev-parse HEAD` before/after (or check the reported
+    commit hash) before treating a push as confirmation.
+11. If validation fails in files this diff did not touch, suspect baseline
     drift or a stale install before blaming the change; verify with a fresh
     `install-deps` run in a clean worktree or a fresh-vs-stale
     `node_modules` comparison before assuming the failure traces to this diff.
-11. If a test this diff did not touch fails once locally but passes in
+12. If a test this diff did not touch fails once locally but passes in
     isolation while hosted CI is green, trust the hosted result and stop
     chasing it as a regression. This does not waive the `fix-validate` /
     `pre-push-validate` requirements.
-12. When consolidating a wrapper function used at multiple call sites into one
+13. When consolidating a wrapper function used at multiple call sites into one
     shared function, check whether any call site's old delegate path added
     options or behavior the shared function does not replicate.
-13. If B3 or C must stop for a hold, post the hold reason, update the digest,
+14. If B3 or C must stop for a hold, post the hold reason, update the digest,
     and stop.
 
 **Unplanned follow-up work**: If B–C reveals a separate follow-up, do not call

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -305,9 +305,9 @@ A `commit-msg` hook (for example commitlint's body-max-line-length) can
 silently reject a commit with a long single-line body, so no commit is
 created — but the following `git push` then reports "Everything
 up-to-date", which reads as a normal no-op rather than the actual
-failure. Prefer `git commit ... -F <file>` with a pre-wrapped body over
-a long single-line `-m` message to avoid tripping the hook in the first
-place, and confirm the commit landed (compare `git rev-parse HEAD`
+failure. Prefer `git commit -F <file>` with a pre-wrapped body file
+over a long single-line `-m` message to avoid tripping the hook in the
+first place, and confirm the commit landed (compare `git rev-parse HEAD`
 before/after, or check the commit hash the commit command reports)
 before treating a subsequent push as confirmation the change landed.
 

--- a/idd-template/.github/instructions/idd-work.instructions.md
+++ b/idd-template/.github/instructions/idd-work.instructions.md
@@ -300,6 +300,17 @@ reordering, and run the C1 critique pass against the completed diff.
 Implement the plan, running **fix-validate** before each atomic commit
 (one logical change per commit).
 
+**Verify a commit actually landed before trusting a subsequent push.**
+A `commit-msg` hook (for example commitlint's body-max-line-length) can
+silently reject a commit with a long single-line body, so no commit is
+created — but the following `git push` then reports "Everything
+up-to-date", which reads as a normal no-op rather than the actual
+failure. Prefer `git commit ... -F <file>` with a pre-wrapped body over
+a long single-line `-m` message to avoid tripping the hook in the first
+place, and confirm the commit landed (compare `git rev-parse HEAD`
+before/after, or check the commit hash the commit command reports)
+before treating a subsequent push as confirmation the change landed.
+
 **De-duplication refactors**: when consolidating a wrapper function used
 at multiple call sites, check whether any call site's old delegate path
 added behavior (timeouts, stdio handling, error translation, etc.) that

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -161,9 +161,9 @@ addendum resolves it.
     `commit-msg` hook (for example commitlint's body-max-line-length) can
     silently reject a commit with a long single-line body, and the
     following push then reports "Everything up-to-date" as if nothing
-    were wrong. Prefer `git commit ... -F <file>` with a pre-wrapped body,
-    and compare `git rev-parse HEAD` before/after (or check the reported
-    commit hash) before treating a push as confirmation.
+    were wrong. Prefer `git commit -F <file>` with a pre-wrapped body
+    file, and compare `git rev-parse HEAD` before/after (or check the
+    reported commit hash) before treating a push as confirmation.
 11. If validation fails in files this diff did not touch, suspect baseline
     drift or a stale install before blaming the change; verify with a fresh
     `install-deps` run in a clean worktree or a fresh-vs-stale

--- a/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
+++ b/idd-template/.github/instructions/lite/idd-work-lite.instructions.md
@@ -157,18 +157,25 @@ addendum resolves it.
 7. Run `fix-validate` before each commit.
 8. Keep commits atomic.
 9. If `fix-validate` changes files, stage and commit them before continuing.
-10. If validation fails in files this diff did not touch, suspect baseline
+10. Verify a commit actually landed before trusting a subsequent push: a
+    `commit-msg` hook (for example commitlint's body-max-line-length) can
+    silently reject a commit with a long single-line body, and the
+    following push then reports "Everything up-to-date" as if nothing
+    were wrong. Prefer `git commit ... -F <file>` with a pre-wrapped body,
+    and compare `git rev-parse HEAD` before/after (or check the reported
+    commit hash) before treating a push as confirmation.
+11. If validation fails in files this diff did not touch, suspect baseline
     drift or a stale install before blaming the change; verify with a fresh
     `install-deps` run in a clean worktree or a fresh-vs-stale
     `node_modules` comparison before assuming the failure traces to this diff.
-11. If a test this diff did not touch fails once locally but passes in
+12. If a test this diff did not touch fails once locally but passes in
     isolation while hosted CI is green, trust the hosted result and stop
     chasing it as a regression. This does not waive the `fix-validate` /
     `pre-push-validate` requirements.
-12. When consolidating a wrapper function used at multiple call sites into one
+13. When consolidating a wrapper function used at multiple call sites into one
     shared function, check whether any call site's old delegate path added
     options or behavior the shared function does not replicate.
-13. If B3 or C must stop for a hold, post the hold reason, update the digest,
+14. If B3 or C must stop for a hold, post the hold reason, update the digest,
     and stop.
 
 **Unplanned follow-up work**: If B–C reveals a separate follow-up, do not call


### PR DESCRIPTION
## Summary

- Adds guidance to `idd-work.instructions.md`'s B3 implementation
  section (and the equivalent numbered step in the lite profile's
  `idd-work-lite.instructions.md`): verify a commit actually landed
  (compare `git rev-parse HEAD` before/after, or check the reported
  commit hash) before trusting a subsequent `git push` as confirmation
  the change landed.
- Recommends `git commit ... -F <file>` with a pre-wrapped body over a
  long single-line `-m` message, since a `commit-msg` hook (e.g.
  commitlint's body-max-line-length) can silently reject the commit
  with no error surfaced to the caller, while the following push
  reports "Everything up-to-date" as if nothing were wrong.

## Acceptance criteria

- [x] `idd-work.instructions.md` documents verifying HEAD advanced
      after a commit, before trusting a subsequent push.
- [x] The guidance recommends `commit ... -F <file>` with a wrapped
      body as a mitigation for the `commit-msg` line-length hook
      failure mode.
- [x] `node scripts/audit-docs.mjs --check` passes.

## Test plan

- [x] `node scripts/audit-docs.mjs --check`
- [x] `npx markdownlint-cli2` on all four changed files
- [x] `npx cspell` on the canonical `idd-template/` sources
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `node scripts/markdown-link-audit.mjs`
- [x] `npx dprint check`
- [x] `node --test tests/sync-docs.test.mts`

Closes #2470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development workflow guidance to verify that commits are successfully created before relying on a push.
  * Added recommendations for handling commit-hook rejection and safely formatting commit messages.
  * Clarified validation procedures for baseline failures, unrelated test failures, and behavior parity during workflow changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->