### PR TITLE
fix(cli): mark required flags as required in helper --help output

### DIFF
--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -615,14 +615,14 @@ function printUsage() {
 Options:
   --dry-run                         compute the create/update/noop action (default)
   --apply                           create or update the single current digest
-  --phase <text>                    digest Phase field
-  --claim <text>                    digest Claim field
-  --branch <text>                   digest Branch field
+  --phase <text>                    digest Phase field (required)
+  --claim <text>                    digest Claim field (required)
+  --branch <text>                   digest Branch field (required)
   --last-checked <timestamp>        digest Last checked field (default: current UTC)
-  --open-blockers <text>            digest Open blockers field
-  --next-action <text>              digest Next action field
-  --authoritative-by <text>         digest Authoritative by field
-  --claim-issue <number>            issue whose active claim protects apply mode
+  --open-blockers <text>            digest Open blockers field (required)
+  --next-action <text>              digest Next action field (required)
+  --authoritative-by <text>         digest Authoritative by field (required)
+  --claim-issue <number>            issue whose active claim protects apply mode (required for apply mode)
   --claim-id <id>                   active claim id required for apply mode
   --agent-id <id>                   optionally require this claim agent id
   --skip-claim-check                explicit maintainer override for apply mode

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -622,7 +622,7 @@ Options:
   --open-blockers <text>            digest Open blockers field (required)
   --next-action <text>              digest Next action field (required)
   --authoritative-by <text>         digest Authoritative by field (required)
-  --claim-issue <number>            issue whose active claim protects apply mode (required for apply mode)
+  --claim-issue <number>            issue carrying the active claim, required for apply mode
   --claim-id <id>                   active claim id required for apply mode
   --agent-id <id>                   optionally require this claim agent id
   --skip-claim-check                explicit maintainer override for apply mode

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -414,11 +414,12 @@ its claim-revalidation gate before --apply, as the manual POST path it replaces.
   --repo <repo>        repo name (default: gh repo view)
   -h, --help           show this help
 
-Per-type field flags:
-  claim              --agent-id --claim-id --supersedes --timestamp --branch
+Per-type field flags (a flag in [brackets] is optional; every other flag
+listed is required for that type):
+  claim              --agent-id --claim-id [--supersedes] --timestamp --branch
   unclaim            --agent-id --claim-id --timestamp
   activation-nonce   --agent-id --claim-id --nonce --timestamp
-  watermark          --agent-id --claim-id --head-sha --max-activity-at --total-item-count --ci-completed-at
+  watermark          --agent-id --claim-id --head-sha [--max-activity-at] --total-item-count [--ci-completed-at]
                      (or --agent-id --claim-id --from-pr <n> [--expected-head-sha <sha>])
   baseline           --agent-id --claim-id --sha
   advisory           --agent-id --head-sha --timestamp

--- a/scripts/post-idd-marker.mjs
+++ b/scripts/post-idd-marker.mjs
@@ -414,7 +414,7 @@ its claim-revalidation gate before --apply, as the manual POST path it replaces.
   --repo <repo>        repo name (default: gh repo view)
   -h, --help           show this help
 
-Per-type field flags (a flag in [brackets] is optional; every other flag
+Per-type field flags (flags in [brackets] are optional; every other flag
 listed is required for that type):
   claim              --agent-id --claim-id [--supersedes] --timestamp --branch
   unclaim            --agent-id --claim-id --timestamp

--- a/src/scripts/live-status-digest.mts
+++ b/src/scripts/live-status-digest.mts
@@ -827,14 +827,14 @@ function printUsage(): void {
 Options:
   --dry-run                         compute the create/update/noop action (default)
   --apply                           create or update the single current digest
-  --phase <text>                    digest Phase field
-  --claim <text>                    digest Claim field
-  --branch <text>                   digest Branch field
+  --phase <text>                    digest Phase field (required)
+  --claim <text>                    digest Claim field (required)
+  --branch <text>                   digest Branch field (required)
   --last-checked <timestamp>        digest Last checked field (default: current UTC)
-  --open-blockers <text>            digest Open blockers field
-  --next-action <text>              digest Next action field
-  --authoritative-by <text>         digest Authoritative by field
-  --claim-issue <number>            issue whose active claim protects apply mode
+  --open-blockers <text>            digest Open blockers field (required)
+  --next-action <text>              digest Next action field (required)
+  --authoritative-by <text>         digest Authoritative by field (required)
+  --claim-issue <number>            issue whose active claim protects apply mode (required for apply mode)
   --claim-id <id>                   active claim id required for apply mode
   --agent-id <id>                   optionally require this claim agent id
   --skip-claim-check                explicit maintainer override for apply mode

--- a/src/scripts/live-status-digest.mts
+++ b/src/scripts/live-status-digest.mts
@@ -834,7 +834,7 @@ Options:
   --open-blockers <text>            digest Open blockers field (required)
   --next-action <text>              digest Next action field (required)
   --authoritative-by <text>         digest Authoritative by field (required)
-  --claim-issue <number>            issue whose active claim protects apply mode (required for apply mode)
+  --claim-issue <number>            issue carrying the active claim, required for apply mode
   --claim-id <id>                   active claim id required for apply mode
   --agent-id <id>                   optionally require this claim agent id
   --skip-claim-check                explicit maintainer override for apply mode

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -498,7 +498,7 @@ its claim-revalidation gate before --apply, as the manual POST path it replaces.
   --repo <repo>        repo name (default: gh repo view)
   -h, --help           show this help
 
-Per-type field flags (a flag in [brackets] is optional; every other flag
+Per-type field flags (flags in [brackets] are optional; every other flag
 listed is required for that type):
   claim              --agent-id --claim-id [--supersedes] --timestamp --branch
   unclaim            --agent-id --claim-id --timestamp

--- a/src/scripts/post-idd-marker.mts
+++ b/src/scripts/post-idd-marker.mts
@@ -498,11 +498,12 @@ its claim-revalidation gate before --apply, as the manual POST path it replaces.
   --repo <repo>        repo name (default: gh repo view)
   -h, --help           show this help
 
-Per-type field flags:
-  claim              --agent-id --claim-id --supersedes --timestamp --branch
+Per-type field flags (a flag in [brackets] is optional; every other flag
+listed is required for that type):
+  claim              --agent-id --claim-id [--supersedes] --timestamp --branch
   unclaim            --agent-id --claim-id --timestamp
   activation-nonce   --agent-id --claim-id --nonce --timestamp
-  watermark          --agent-id --claim-id --head-sha --max-activity-at --total-item-count --ci-completed-at
+  watermark          --agent-id --claim-id --head-sha [--max-activity-at] --total-item-count [--ci-completed-at]
                      (or --agent-id --claim-id --from-pr <n> [--expected-head-sha <sha>])
   baseline           --agent-id --claim-id --sha
   advisory           --agent-id --head-sha --timestamp

--- a/tests/live-status-digest.test.mts
+++ b/tests/live-status-digest.test.mts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
 import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
 // Importing the CLI module directly is only possible now that its top-level
 // statements are guarded behind `import.meta.main`; previously the import
 // parsed process.argv and called process.exit, aborting the test process.
@@ -519,4 +522,32 @@ test('issue-target mode (no expectedLinkedPrs) honors the handoff unconditionall
   );
   assert.equal(summary.activeClaimPresent, true);
   assert.equal(summary.activeClaim?.claimId, PR_TARGET_NEW_CLAIM_ID);
+});
+
+const REPO_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+test('--help marks every unconditionally-required digest field as required (#2492)', () => {
+  const output = execFileSync(
+    process.execPath,
+    [join(REPO_ROOT, 'scripts/live-status-digest.mjs'), '--help'],
+    { encoding: 'utf8' },
+  );
+  for (const flag of [
+    '--phase <text>',
+    '--claim <text>',
+    '--branch <text>',
+    '--open-blockers <text>',
+    '--next-action <text>',
+    '--authoritative-by <text>',
+  ]) {
+    const line = output
+      .split('\n')
+      .find((candidate) => candidate.includes(flag));
+    assert.ok(line, `--help is missing a line for ${flag}`);
+    assert.match(line, /\(required\)$/);
+  }
+  assert.match(
+    output,
+    /--claim-issue <number>\s+issue carrying the active claim, required for apply mode/,
+  );
 });

--- a/tests/post-idd-marker.test.mts
+++ b/tests/post-idd-marker.test.mts
@@ -1907,3 +1907,27 @@ test('--expected-head-sha is rejected without --from-pr (before any gh call)', (
     /--expected-head-sha is only valid together with --from-pr/,
   );
 });
+
+test('--help marks every REQUIRED_FIELDS_BY_TYPE field as required and every deliberately-optional field as bracketed (#2492)', () => {
+  const output = execFileSync(
+    process.execPath,
+    [join(REPO_ROOT, 'scripts/post-idd-marker.mjs'), '--help'],
+    { encoding: 'utf8' },
+  );
+  assert.match(
+    output,
+    /flags in \[brackets\] are optional; every other flag\s*\n\s*listed is required for that type/,
+  );
+  // claim: --supersedes is deliberately optional (renderer-defaulted).
+  assert.match(
+    output,
+    /claim\s+--agent-id --claim-id \[--supersedes] --timestamp --branch/,
+  );
+  // watermark: --max-activity-at / --ci-completed-at are deliberately
+  // optional (renderer-defaulted); --agent-id / --claim-id / --head-sha /
+  // --total-item-count stay unbracketed (required).
+  assert.match(
+    output,
+    /watermark\s+--agent-id --claim-id --head-sha \[--max-activity-at] --total-item-count \[--ci-completed-at]/,
+  );
+});


### PR DESCRIPTION
# Summary

`live-status-digest`'s `--help` output listed six flags its own
runtime validation already enforces as required identically to
genuinely optional ones, giving no advance warning before the first
failing run -- only `--claim-id` carried a "required for apply mode"
note.

## Linked issue

Closes #2492

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Applied that same phrasing pattern (matching this codebase's
established `(required)` annotation convention, confirmed already in
use in `disposition-non-review-notices.mts`, `audit-authored-issue.mts`,
and `resolve-review-thread.mts`) to
`--phase`/`--claim`/`--branch`/`--open-blockers`/`--next-action`/
`--authoritative-by` in `live-status-digest.mts`, and added the
matching apply-mode-conditional note to `--claim-issue`.

For the second helper, identified `post-idd-marker.mts` (also
`parseCliArgs`-based, also uses the shared `requireFlag` validator)
as having the identical gap in its "Per-type field flags" table:
`--supersedes` (claim) and `--max-activity-at`/`--ci-completed-at`
(watermark) are deliberately optional per `REQUIRED_FIELDS_BY_TYPE`'s
own doc comment (the renderers default them to a `none` sentinel),
but were listed identically to the required fields for each marker
type. Wrapped them in `[brackets]`, extending this file's own
pre-existing optional-flag convention (already used for
`advisory-recovery`'s `--claim-id`/`--attempt` pair) rather than
importing a different style into the same table.

Considered `emit-marker.mts` (the only other `requireFlag` caller) but
left it out of scope: it explicitly opts out of the shared
`parseCliArgs` wrapper (hand-rolled parser, per its own header
comment), so it falls outside this issue's stated scope
("`parseCliArgs`-based helpers"), and its usage synopsis already shows
every required flag per marker type without brackets.

Cross-verified every "Per-type field flags" row in `post-idd-marker.mts`
against `REQUIRED_FIELDS_BY_TYPE`'s exact source-of-truth array by
hand before committing.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4815/4815 pass)
- [x] `pnpm run typecheck`
- [x] Live `--help` output inspection for both helpers
- [x] `tests/help-text-flags.test.mts`, `tests/flag-name-matrix.test.mts`,
      `tests/post-idd-marker.test.mts` (143 tests, all pass -- including
      "every required flag of every marker type is rejected by name
      when omitted" and "--supersedes stays optional")

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (none)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified CLI help text to distinguish required and optional fields for digest and marker commands.
  - Documented that claim-related issue information is required when applying changes.
  - Explained optional claim supersession and watermark timestamp fields.

- **Tests**
  - Added regression coverage to verify required/optional field notation and apply-mode requirements in CLI help output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->