### PR TITLE
feat(discover): recognize a runtime/production-observation blocker

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -69,15 +69,12 @@ that issue only:
 2. If the target issue carries the configured authoring label, report
    `Issue #N is currently being authored`, run the stale-authoring
    warning check above, and stop without claiming.
-3. Apply A3's readiness bullets to the target — no configured
-   blocked-by-human/needs-decision label, no open blocking dependent
-   issue (visible `Blocked by #NNN` or hidden
-   `idd-skill-blocked-by` marker, both resolved the
-   same way A3 resolves them), no external human coordination required
-   — plus one target-only check: no active, non-stale claim from a
-   trusted marker actor exists on the target, other than a claim this
-   session already recorded and verified (A4 Step 1.5 rules); a hit
-   reports "already claimed", same as A5.
+3. Apply A3's readiness bullets to the target (the same blocked-by,
+   human-coordination, and runtime-observation checks, resolved the
+   same way) — plus one target-only check: no active, non-stale claim
+   from a trusted marker actor exists on the target, other than a
+   claim this session already recorded and verified (A4 Step 1.5
+   rules); a hit reports "already claimed", same as A5.
 4. Run the normal A4 viability gate against the target only.
 5. Apply the **A3.5** issue-author approval gate against the target.
    If A3.5 classifies it as not startable, report that the gate
@@ -356,8 +353,10 @@ From A2, keep only issues that satisfy **all** of the following:
   blocked if that issue is open, if no issue matches (fail-safe — a
   migration integrity problem such as a typo, deleted issue, or
   incomplete migration), or if any matching issue is open.
-- No external human coordination required to start; otherwise keep
-  scanning
+- No external human coordination or prose-only runtime/production-
+  observation precondition ("confirmed in production", "observed
+  live", "runtime-observation", #2467) required to start; otherwise
+  keep scanning
 
 **When A2 finds zero candidates, or zero issues survive A3 filtering**,
 apply this decision tree — do not silently expand scope:

--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -353,10 +353,10 @@ From A2, keep only issues that satisfy **all** of the following:
   blocked if that issue is open, if no issue matches (fail-safe — a
   migration integrity problem such as a typo, deleted issue, or
   incomplete migration), or if any matching issue is open.
-- No external human coordination or prose-only runtime/production-
-  observation precondition ("confirmed in production", "observed
-  live", "runtime-observation", #2467) required to start; otherwise
-  keep scanning
+- No external human coordination or prose-only
+  runtime/production-observation precondition ("confirmed in
+  production", "observed live", "runtime-observation"; issue #2467)
+  required to start; otherwise keep scanning
 
 **When A2 finds zero candidates, or zero issues survive A3 filtering**,
 apply this decision tree — do not silently expand scope:

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -64,15 +64,12 @@ that issue only:
 2. If the target issue carries the configured authoring label, report
    `Issue #N is currently being authored`, run the stale-authoring
    warning check above, and stop without claiming.
-3. Apply A3's readiness bullets to the target — no configured
-   blocked-by-human/needs-decision label, no open blocking dependent
-   issue (visible `Blocked by #NNN` or hidden
-   `{{PROJECT_MARKER_PREFIX}}-blocked-by` marker, both resolved the
-   same way A3 resolves them), no external human coordination required
-   — plus one target-only check: no active, non-stale claim from a
-   trusted marker actor exists on the target, other than a claim this
-   session already recorded and verified (A4 Step 1.5 rules); a hit
-   reports "already claimed", same as A5.
+3. Apply A3's readiness bullets to the target (the same blocked-by,
+   human-coordination, and runtime-observation checks, resolved the
+   same way) — plus one target-only check: no active, non-stale claim
+   from a trusted marker actor exists on the target, other than a
+   claim this session already recorded and verified (A4 Step 1.5
+   rules); a hit reports "already claimed", same as A5.
 4. Run the normal A4 viability gate against the target only.
 5. Apply the **A3.5** issue-author approval gate against the target.
    If A3.5 classifies it as not startable, report that the gate
@@ -351,8 +348,10 @@ From A2, keep only issues that satisfy **all** of the following:
   blocked if that issue is open, if no issue matches (fail-safe — a
   migration integrity problem such as a typo, deleted issue, or
   incomplete migration), or if any matching issue is open.
-- No external human coordination required to start; otherwise keep
-  scanning
+- No external human coordination or prose-only runtime/production-
+  observation precondition ("confirmed in production", "observed
+  live", "runtime-observation", #2467) required to start; otherwise
+  keep scanning
 
 **When A2 finds zero candidates, or zero issues survive A3 filtering**,
 apply this decision tree — do not silently expand scope:

--- a/idd-template/.github/instructions/idd-discover.instructions.md
+++ b/idd-template/.github/instructions/idd-discover.instructions.md
@@ -348,10 +348,10 @@ From A2, keep only issues that satisfy **all** of the following:
   blocked if that issue is open, if no issue matches (fail-safe — a
   migration integrity problem such as a typo, deleted issue, or
   incomplete migration), or if any matching issue is open.
-- No external human coordination or prose-only runtime/production-
-  observation precondition ("confirmed in production", "observed
-  live", "runtime-observation", #2467) required to start; otherwise
-  keep scanning
+- No external human coordination or prose-only
+  runtime/production-observation precondition ("confirmed in
+  production", "observed live", "runtime-observation"; issue #2467)
+  required to start; otherwise keep scanning
 
 **When A2 finds zero candidates, or zero issues survive A3 filtering**,
 apply this decision tree — do not silently expand scope:

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -55,6 +55,7 @@ const NEGATION_CUE_WINDOW = 40;
 const NEGATION_HARD_BREAK_PATTERN = /[.;\n]|--|—/g;
 const OPEN_QUOTE_CHARS = new Set(['"', "'", '“', '‘']);
 const CLOSE_QUOTE_CHARS = new Set(['"', "'", '”', '’']);
+const TRAILING_QUOTE_PUNCTUATION_PATTERN = /^[.,!?;:]*/;
 if (import.meta.main) {
   await runCli();
 }
@@ -71,9 +72,13 @@ export function extractBlockedByReferences(body) {
 }
 // A negation ("does not need to be confirmed in production") within the
 // same clause turns the match into the opposite of a precondition -- scoped
-// to the nearest hard clause break so a negation cue from an earlier,
-// unrelated sentence cannot suppress a genuine match (mirrors
-// `AVOIDANCE_CUE_WINDOW`'s clause-scoping in `discover-viability-gate.mts`).
+// to the nearest hard clause break so a negation cue from an earlier (or,
+// for the after-match check, a later) unrelated sentence cannot suppress a
+// genuine match (mirrors `AVOIDANCE_CUE_WINDOW`'s clause-scoping in
+// `discover-viability-gate.mts`). A same-clause negation can follow the
+// matched phrase too ("Runtime observation is not required before
+// starting", #2529 review) -- both directions share the same cue list and
+// window.
 function hasNegationCueBefore(text, matchIndex) {
   const windowStart = Math.max(0, matchIndex - NEGATION_CUE_WINDOW);
   const window = text.slice(windowStart, matchIndex);
@@ -84,12 +89,26 @@ function hasNegationCueBefore(text, matchIndex) {
     : window;
   return NEGATION_CUE_PATTERN.test(scoped);
 }
+function hasNegationCueAfter(text, matchEnd) {
+  const windowEnd = Math.min(text.length, matchEnd + NEGATION_CUE_WINDOW);
+  const window = text.slice(matchEnd, windowEnd);
+  const breaks = [...window.matchAll(NEGATION_HARD_BREAK_PATTERN)];
+  const firstBreak = breaks[0];
+  const scoped = firstBreak ? window.slice(0, firstBreak.index) : window;
+  return NEGATION_CUE_PATTERN.test(scoped);
+}
 // A phrase quoted as a term being discussed (e.g. this function's own
 // motivating issue, which names the trigger phrases inside straight double
 // quotes) is meta-discussion, not an asserted precondition on THIS issue.
+// Sentence punctuation routinely sits INSIDE the closing quote ("observed
+// live." -- #2529 review), so the close side tolerates a short run of
+// punctuation between the match and the quote character; the open side
+// stays exact-adjacent, matching every observed real-world shape.
 function isQuotedMatch(text, start, end) {
   const before = text[start - 1];
-  const after = text[end];
+  const afterSlice = text.slice(end, end + 4);
+  const punctuation = TRAILING_QUOTE_PUNCTUATION_PATTERN.exec(afterSlice);
+  const after = afterSlice[punctuation?.[0]?.length ?? 0];
   return (
     before !== undefined &&
     after !== undefined &&
@@ -112,7 +131,8 @@ export function detectRuntimeObservationPrecondition(body) {
       const end = match.index + match[0].length;
       if (
         !isQuotedMatch(stripped, match.index, end) &&
-        !hasNegationCueBefore(stripped, match.index)
+        !hasNegationCueBefore(stripped, match.index) &&
+        !hasNegationCueAfter(stripped, end)
       ) {
         return true;
       }

--- a/scripts/discover-orphan-filter.mjs
+++ b/scripts/discover-orphan-filter.mjs
@@ -26,6 +26,7 @@ import {
 } from './discover-roadmap-graph.mjs';
 import { effortOrdinal, parseEffort } from './effort.mjs';
 import { loadPolicyConfig } from './idd-config.mjs';
+import { stripMarkdownCodeRegions } from './markdown-code.mjs';
 import { createMarkerRegex } from './marker-regex.mjs';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mjs';
 import {
@@ -34,6 +35,26 @@ import {
 } from './provider-adapter-github.mjs';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
+// A runtime/production-observation precondition (#2467) carries no
+// issue-number reference, so neither the marker checks above nor the
+// numbered-reference resolution below ever see it -- a follow-up gated by
+// "confirmed in production" / "observed live" / "runtime-observation" reads
+// as a plain orphan once its linked code dependency merges. Kept narrow
+// (three phrasings plus tense variants) rather than a broad "wait/deploy"
+// vocabulary: a false positive here permanently exiles a startable issue
+// from the discover pool, while a false negative only preserves today's
+// behavior.
+const RUNTIME_OBSERVATION_PATTERNS = [
+  /\bconfirm(?:ed|ing)?\s+(?:to\s+take\s+effect\s+)?in\s+production\b/gi,
+  /\bobserv(?:ed|ing)?\s+live\b/gi,
+  /\bruntime[- ]observation\b/gi,
+];
+const NEGATION_CUE_PATTERN =
+  /\b(?:not|never|without|isn't|is not|doesn't|does not|don't|do not|won't|will not|no need|needn't)\b/i;
+const NEGATION_CUE_WINDOW = 40;
+const NEGATION_HARD_BREAK_PATTERN = /[.;\n]|--|—/g;
+const OPEN_QUOTE_CHARS = new Set(['"', "'", '“', '‘']);
+const CLOSE_QUOTE_CHARS = new Set(['"', "'", '”', '’']);
 if (import.meta.main) {
   await runCli();
 }
@@ -47,6 +68,58 @@ if (import.meta.main) {
  */
 export function extractBlockedByReferences(body) {
   return extractBlockedByIssueNumbers(String(body ?? ''));
+}
+// A negation ("does not need to be confirmed in production") within the
+// same clause turns the match into the opposite of a precondition -- scoped
+// to the nearest hard clause break so a negation cue from an earlier,
+// unrelated sentence cannot suppress a genuine match (mirrors
+// `AVOIDANCE_CUE_WINDOW`'s clause-scoping in `discover-viability-gate.mts`).
+function hasNegationCueBefore(text, matchIndex) {
+  const windowStart = Math.max(0, matchIndex - NEGATION_CUE_WINDOW);
+  const window = text.slice(windowStart, matchIndex);
+  const breaks = [...window.matchAll(NEGATION_HARD_BREAK_PATTERN)];
+  const lastBreak = breaks.at(-1);
+  const scoped = lastBreak
+    ? window.slice(lastBreak.index + lastBreak[0].length)
+    : window;
+  return NEGATION_CUE_PATTERN.test(scoped);
+}
+// A phrase quoted as a term being discussed (e.g. this function's own
+// motivating issue, which names the trigger phrases inside straight double
+// quotes) is meta-discussion, not an asserted precondition on THIS issue.
+function isQuotedMatch(text, start, end) {
+  const before = text[start - 1];
+  const after = text[end];
+  return (
+    before !== undefined &&
+    after !== undefined &&
+    OPEN_QUOTE_CHARS.has(before) &&
+    CLOSE_QUOTE_CHARS.has(after)
+  );
+}
+/**
+ * Detect prose naming a runtime/production-observation precondition
+ * (#2467) anywhere in `body`, outside of code regions. Returns `true` on
+ * the first match that is neither quoted nor negated -- callers only need a
+ * boolean gate, not the matched span.
+ */
+export function detectRuntimeObservationPrecondition(body) {
+  const stripped = stripMarkdownCodeRegions(String(body ?? ''));
+  for (const pattern of RUNTIME_OBSERVATION_PATTERNS) {
+    pattern.lastIndex = 0;
+    let match = pattern.exec(stripped);
+    while (match) {
+      const end = match.index + match[0].length;
+      if (
+        !isQuotedMatch(stripped, match.index, end) &&
+        !hasNegationCueBefore(stripped, match.index)
+      ) {
+        return true;
+      }
+      match = pattern.exec(stripped);
+    }
+  }
+  return false;
 }
 export function getOrphanFirstPolicy(config) {
   if (!config || typeof config !== 'object') {
@@ -101,6 +174,13 @@ export function classifyIssue(issue, options) {
       reason: 'authoring_label',
       details: authoringLabelName,
     };
+  }
+  // Runs regardless of blockedRefs/dependencyRefs state (#2467): a
+  // production-observation precondition has no issue-number reference to
+  // resolve, so it must still hold even when every numbered reference below
+  // is absent or already closed.
+  if (detectRuntimeObservationPrecondition(body)) {
+    return { orphan: false, reason: 'runtime_observation_precondition' };
   }
   // Two independent reference families, matching A3's own dependency check
   // in `discover-readiness-check.mts` (#1536): visible `Blocked by #NNN`
@@ -203,6 +283,7 @@ export async function filterOrphanIssues(issues, options = {}) {
     blocked_by_marker: [],
     blocked_label: [],
     authoring_label: [],
+    runtime_observation_precondition: [],
     blocked_by_open_reference: [],
     open_dependency_reference: [],
     unresolvable_reference: [],
@@ -519,6 +600,7 @@ Output schema:
     "blocked_by_marker": [...],
     "blocked_label": [...],
     "authoring_label": [...],
+    "runtime_observation_precondition": [...],
     "blocked_by_open_reference": [...],
     "open_dependency_reference": [...],
     "unresolvable_reference": [...]
@@ -527,6 +609,12 @@ Output schema:
   "warnings": [{"issueNumber": 1, "message": "Warning: ..."}],
   "counts": {"scanned": 0, "orphans": 0, "routed_to_human": 0, "filtered": {...}, "unresolvable": 0}
 }
+
+"filtered.runtime_observation_precondition" (#2467) excludes an issue whose
+body names a runtime/production-observation precondition in prose --
+"confirmed in production", "observed live", "runtime-observation" -- with no
+issue-number reference to resolve, so it stays excluded even once every
+numbered "Blocked by"/"Depends on" reference is closed.
 
 "filtered.open_dependency_reference" (#1536) mirrors A3's own dependency
 check in discover-readiness-check.mjs: a candidate whose body contains an

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -60,6 +60,7 @@ const NEGATION_CUE_WINDOW = 40;
 const NEGATION_HARD_BREAK_PATTERN = /[.;\n]|--|—/g;
 const OPEN_QUOTE_CHARS = new Set(['"', "'", '“', '‘']);
 const CLOSE_QUOTE_CHARS = new Set(['"', "'", '”', '’']);
+const TRAILING_QUOTE_PUNCTUATION_PATTERN = /^[.,!?;:]*/;
 
 /** Reasons that keep an issue out of the orphan candidate list. */
 export type OrphanFilteredReason =
@@ -220,9 +221,13 @@ export function extractBlockedByReferences(body: unknown): number[] {
 
 // A negation ("does not need to be confirmed in production") within the
 // same clause turns the match into the opposite of a precondition -- scoped
-// to the nearest hard clause break so a negation cue from an earlier,
-// unrelated sentence cannot suppress a genuine match (mirrors
-// `AVOIDANCE_CUE_WINDOW`'s clause-scoping in `discover-viability-gate.mts`).
+// to the nearest hard clause break so a negation cue from an earlier (or,
+// for the after-match check, a later) unrelated sentence cannot suppress a
+// genuine match (mirrors `AVOIDANCE_CUE_WINDOW`'s clause-scoping in
+// `discover-viability-gate.mts`). A same-clause negation can follow the
+// matched phrase too ("Runtime observation is not required before
+// starting", #2529 review) -- both directions share the same cue list and
+// window.
 function hasNegationCueBefore(text: string, matchIndex: number): boolean {
   const windowStart = Math.max(0, matchIndex - NEGATION_CUE_WINDOW);
   const window = text.slice(windowStart, matchIndex);
@@ -234,12 +239,27 @@ function hasNegationCueBefore(text: string, matchIndex: number): boolean {
   return NEGATION_CUE_PATTERN.test(scoped);
 }
 
+function hasNegationCueAfter(text: string, matchEnd: number): boolean {
+  const windowEnd = Math.min(text.length, matchEnd + NEGATION_CUE_WINDOW);
+  const window = text.slice(matchEnd, windowEnd);
+  const breaks = [...window.matchAll(NEGATION_HARD_BREAK_PATTERN)];
+  const firstBreak = breaks[0];
+  const scoped = firstBreak ? window.slice(0, firstBreak.index) : window;
+  return NEGATION_CUE_PATTERN.test(scoped);
+}
+
 // A phrase quoted as a term being discussed (e.g. this function's own
 // motivating issue, which names the trigger phrases inside straight double
 // quotes) is meta-discussion, not an asserted precondition on THIS issue.
+// Sentence punctuation routinely sits INSIDE the closing quote ("observed
+// live." -- #2529 review), so the close side tolerates a short run of
+// punctuation between the match and the quote character; the open side
+// stays exact-adjacent, matching every observed real-world shape.
 function isQuotedMatch(text: string, start: number, end: number): boolean {
   const before = text[start - 1];
-  const after = text[end];
+  const afterSlice = text.slice(end, end + 4);
+  const punctuation = TRAILING_QUOTE_PUNCTUATION_PATTERN.exec(afterSlice);
+  const after = afterSlice[punctuation?.[0]?.length ?? 0];
   return (
     before !== undefined &&
     after !== undefined &&
@@ -263,7 +283,8 @@ export function detectRuntimeObservationPrecondition(body: unknown): boolean {
       const end = match.index + match[0].length;
       if (
         !isQuotedMatch(stripped, match.index, end) &&
-        !hasNegationCueBefore(stripped, match.index)
+        !hasNegationCueBefore(stripped, match.index) &&
+        !hasNegationCueAfter(stripped, end)
       ) {
         return true;
       }

--- a/src/scripts/discover-orphan-filter.mts
+++ b/src/scripts/discover-orphan-filter.mts
@@ -29,6 +29,7 @@ import {
 } from './discover-roadmap-graph.mts';
 import { type EffortHint, effortOrdinal, parseEffort } from './effort.mts';
 import { loadPolicyConfig } from './idd-config.mts';
+import { stripMarkdownCodeRegions } from './markdown-code.mts';
 import { createMarkerRegex } from './marker-regex.mts';
 import { normalizePolicyConfig, POLICY_DEFAULTS } from './policy-helpers.mts';
 import {
@@ -39,12 +40,34 @@ import type { ProviderPort } from './provider-port.mts';
 
 const DEFAULT_MARKER_PREFIX = 'idd-skill';
 
+// A runtime/production-observation precondition (#2467) carries no
+// issue-number reference, so neither the marker checks above nor the
+// numbered-reference resolution below ever see it -- a follow-up gated by
+// "confirmed in production" / "observed live" / "runtime-observation" reads
+// as a plain orphan once its linked code dependency merges. Kept narrow
+// (three phrasings plus tense variants) rather than a broad "wait/deploy"
+// vocabulary: a false positive here permanently exiles a startable issue
+// from the discover pool, while a false negative only preserves today's
+// behavior.
+const RUNTIME_OBSERVATION_PATTERNS = [
+  /\bconfirm(?:ed|ing)?\s+(?:to\s+take\s+effect\s+)?in\s+production\b/gi,
+  /\bobserv(?:ed|ing)?\s+live\b/gi,
+  /\bruntime[- ]observation\b/gi,
+];
+const NEGATION_CUE_PATTERN =
+  /\b(?:not|never|without|isn't|is not|doesn't|does not|don't|do not|won't|will not|no need|needn't)\b/i;
+const NEGATION_CUE_WINDOW = 40;
+const NEGATION_HARD_BREAK_PATTERN = /[.;\n]|--|—/g;
+const OPEN_QUOTE_CHARS = new Set(['"', "'", '“', '‘']);
+const CLOSE_QUOTE_CHARS = new Set(['"', "'", '”', '’']);
+
 /** Reasons that keep an issue out of the orphan candidate list. */
 export type OrphanFilteredReason =
   | 'roadmap_marker'
   | 'blocked_by_marker'
   | 'blocked_label'
   | 'authoring_label'
+  | 'runtime_observation_precondition'
   | 'blocked_by_open_reference'
   | 'open_dependency_reference'
   | 'unresolvable_reference';
@@ -58,7 +81,10 @@ export type OrphanClassification =
     }
   | {
       orphan: false;
-      reason: 'roadmap_marker' | 'blocked_by_marker';
+      reason:
+        | 'roadmap_marker'
+        | 'blocked_by_marker'
+        | 'runtime_observation_precondition';
       details?: undefined;
     }
   | {
@@ -192,6 +218,61 @@ export function extractBlockedByReferences(body: unknown): number[] {
   return extractBlockedByIssueNumbers(String(body ?? ''));
 }
 
+// A negation ("does not need to be confirmed in production") within the
+// same clause turns the match into the opposite of a precondition -- scoped
+// to the nearest hard clause break so a negation cue from an earlier,
+// unrelated sentence cannot suppress a genuine match (mirrors
+// `AVOIDANCE_CUE_WINDOW`'s clause-scoping in `discover-viability-gate.mts`).
+function hasNegationCueBefore(text: string, matchIndex: number): boolean {
+  const windowStart = Math.max(0, matchIndex - NEGATION_CUE_WINDOW);
+  const window = text.slice(windowStart, matchIndex);
+  const breaks = [...window.matchAll(NEGATION_HARD_BREAK_PATTERN)];
+  const lastBreak = breaks.at(-1);
+  const scoped = lastBreak
+    ? window.slice(lastBreak.index + lastBreak[0].length)
+    : window;
+  return NEGATION_CUE_PATTERN.test(scoped);
+}
+
+// A phrase quoted as a term being discussed (e.g. this function's own
+// motivating issue, which names the trigger phrases inside straight double
+// quotes) is meta-discussion, not an asserted precondition on THIS issue.
+function isQuotedMatch(text: string, start: number, end: number): boolean {
+  const before = text[start - 1];
+  const after = text[end];
+  return (
+    before !== undefined &&
+    after !== undefined &&
+    OPEN_QUOTE_CHARS.has(before) &&
+    CLOSE_QUOTE_CHARS.has(after)
+  );
+}
+
+/**
+ * Detect prose naming a runtime/production-observation precondition
+ * (#2467) anywhere in `body`, outside of code regions. Returns `true` on
+ * the first match that is neither quoted nor negated -- callers only need a
+ * boolean gate, not the matched span.
+ */
+export function detectRuntimeObservationPrecondition(body: unknown): boolean {
+  const stripped = stripMarkdownCodeRegions(String(body ?? ''));
+  for (const pattern of RUNTIME_OBSERVATION_PATTERNS) {
+    pattern.lastIndex = 0;
+    let match = pattern.exec(stripped);
+    while (match) {
+      const end = match.index + match[0].length;
+      if (
+        !isQuotedMatch(stripped, match.index, end) &&
+        !hasNegationCueBefore(stripped, match.index)
+      ) {
+        return true;
+      }
+      match = pattern.exec(stripped);
+    }
+  }
+  return false;
+}
+
 export function getOrphanFirstPolicy(config: unknown): string {
   if (!config || typeof config !== 'object') {
     return 'none';
@@ -258,6 +339,14 @@ export function classifyIssue(
       reason: 'authoring_label',
       details: authoringLabelName,
     };
+  }
+
+  // Runs regardless of blockedRefs/dependencyRefs state (#2467): a
+  // production-observation precondition has no issue-number reference to
+  // resolve, so it must still hold even when every numbered reference below
+  // is absent or already closed.
+  if (detectRuntimeObservationPrecondition(body)) {
+    return { orphan: false, reason: 'runtime_observation_precondition' };
   }
 
   // Two independent reference families, matching A3's own dependency check
@@ -374,6 +463,7 @@ export async function filterOrphanIssues(
     blocked_by_marker: [],
     blocked_label: [],
     authoring_label: [],
+    runtime_observation_precondition: [],
     blocked_by_open_reference: [],
     open_dependency_reference: [],
     unresolvable_reference: [],
@@ -718,6 +808,7 @@ Output schema:
     "blocked_by_marker": [...],
     "blocked_label": [...],
     "authoring_label": [...],
+    "runtime_observation_precondition": [...],
     "blocked_by_open_reference": [...],
     "open_dependency_reference": [...],
     "unresolvable_reference": [...]
@@ -726,6 +817,12 @@ Output schema:
   "warnings": [{"issueNumber": 1, "message": "Warning: ..."}],
   "counts": {"scanned": 0, "orphans": 0, "routed_to_human": 0, "filtered": {...}, "unresolvable": 0}
 }
+
+"filtered.runtime_observation_precondition" (#2467) excludes an issue whose
+body names a runtime/production-observation precondition in prose --
+"confirmed in production", "observed live", "runtime-observation" -- with no
+issue-number reference to resolve, so it stays excluded even once every
+numbered "Blocked by"/"Depends on" reference is closed.
 
 "filtered.open_dependency_reference" (#1536) mirrors A3's own dependency
 check in discover-readiness-check.mjs: a candidate whose body contains an

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -1186,6 +1186,42 @@ test('classifyIssue does not trip runtime-observation prose inside a code region
   assert.equal(inline.reason, 'orphan');
 });
 
+test('classifyIssue does not trip runtime-observation prose quoted with trailing sentence punctuation inside the quotes (#2529 review)', () => {
+  const result = classifyIssue(
+    {
+      number: 107,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'No match exists for "confirmed in production." or "observed ' +
+        'live." or "runtime-observation." anywhere in the docs.',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'orphan');
+});
+
+test('classifyIssue does not trip runtime-observation prose negated after the matched phrase (#2529 review)', () => {
+  const result = classifyIssue(
+    {
+      number: 108,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body: 'Runtime observation is not required before starting this issue.',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'orphan');
+});
+
 test('filterOrphanIssues buckets a runtime-observation precondition under filtered.runtime_observation_precondition (#2467)', async () => {
   const issues = [
     {

--- a/tests/discover-orphan-filter.test.mts
+++ b/tests/discover-orphan-filter.test.mts
@@ -1078,6 +1078,136 @@ test('filterOrphanIssues keeps a closed Depends-on reference as an orphan candid
   assert.equal(result.orphans[0].reason, 'blocked_references_closed');
 });
 
+test('classifyIssue routes runtime/production-observation prose to runtime_observation_precondition (#2467)', () => {
+  const cases = [
+    'Do this only after the prior fix has merged and is confirmed to take effect in production.',
+    'Start once the previous change has been observed live for a day.',
+    'This requires runtime-observation of the fix before starting the next issue.',
+    'This requires runtime observation of the fix before starting the next issue.',
+  ];
+
+  for (const body of cases) {
+    const result = classifyIssue(
+      { number: 100, title: 't', state: 'OPEN', labels: [], body },
+      {
+        issueStateByNumber: new Map(),
+        fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+      },
+    );
+    assert.equal(result.reason, 'runtime_observation_precondition', body);
+  }
+});
+
+test('classifyIssue keeps a runtime-observation precondition blocking even once every numbered reference has closed (#2467)', () => {
+  const result = classifyIssue(
+    {
+      number: 101,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body: 'Blocked by #94. Also confirm this is observed live before starting.',
+    },
+    {
+      issueStateByNumber: new Map([[94, 'CLOSED']]),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'runtime_observation_precondition');
+});
+
+test("classifyIssue does not trip runtime-observation prose quoted as a term, matching this feature's own motivating issue (#2467)", () => {
+  const result = classifyIssue(
+    {
+      number: 102,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'No match exists for "confirm(ed) in production" / "observed live" / ' +
+        '"runtime-observation" or any prose-blocker-class concept anywhere ' +
+        'in idd-discover.instructions.md or docs/*.md.',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'orphan');
+});
+
+test('classifyIssue does not trip runtime-observation prose negated in the same clause (#2467)', () => {
+  const result = classifyIssue(
+    {
+      number: 103,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body:
+        'This can start immediately; it does not need to be confirmed in ' +
+        'production first.',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(result.reason, 'orphan');
+});
+
+test('classifyIssue does not trip runtime-observation prose inside a code region (#2467)', () => {
+  const fenced = classifyIssue(
+    {
+      number: 104,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body: 'See the example:\n\n```\nconfirmed in production\n```\n',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(fenced.reason, 'orphan');
+
+  const inline = classifyIssue(
+    {
+      number: 105,
+      title: 't',
+      state: 'OPEN',
+      labels: [],
+      body: 'The trigger phrase is `confirmed in production` in our docs.',
+    },
+    {
+      issueStateByNumber: new Map(),
+      fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+    },
+  );
+  assert.equal(inline.reason, 'orphan');
+});
+
+test('filterOrphanIssues buckets a runtime-observation precondition under filtered.runtime_observation_precondition (#2467)', async () => {
+  const issues = [
+    {
+      number: 106,
+      title: 'gated follow-up',
+      state: 'OPEN',
+      labels: [],
+      body: 'Start only after the fix is confirmed in production.',
+      url: 'https://example.com/106',
+    },
+  ];
+
+  const result = await filterOrphanIssues(issues, {
+    issueStateByNumber: new Map(),
+    fetchIssueStateByNumber: () => 'UNRESOLVABLE',
+  });
+
+  assert.equal(result.orphans.length, 0);
+  assert.equal(result.filtered.runtime_observation_precondition.length, 1);
+  assert.equal(result.filtered.runtime_observation_precondition[0].number, 106);
+});
+
 // #1721: discover-orphan-filter was one of three helpers that silently
 // swallowed every --policy load failure into `{}` (fail-open), including
 // an explicitly-supplied path. It now routes through idd-config.mts's


### PR DESCRIPTION
## Summary

Discover's viability filter judged startability purely from issue state and
links (open, unclaimed, not blocked-by an open issue). A follow-up gated by
prose such as "do this only after the prior fix has merged and is confirmed
to take effect in production" carried no issue-number reference, so once
the linked code dependency merged, discover read it as a plain startable
orphan.

- `classifyIssue` (`src/scripts/discover-orphan-filter.mts`) now detects
  "confirmed in production" / "observed live" / "runtime-observation" prose
  outside code regions and routes matching issues to a new
  `runtime_observation_precondition` filtered reason -- independent of, and
  regardless of, numbered `Blocked by`/`Depends on` reference state.
- Deliberately narrow (three phrasings plus tense variants, not a broad
  "wait/deploy" vocabulary): a false positive here permanently exiles a
  startable issue from the discover pool, while a false negative only
  preserves today's behavior.
- Excludes matches that are quoted as a term (e.g. this feature's own
  motivating issue, which names the trigger phrases in quotes) and matches
  negated in the same clause (e.g. "does not need to be confirmed in
  production").
- Documented in `idd-discover.instructions.md`'s A3 bullet list. A0-T's
  step 3 now defers to A3's bullets by reference instead of
  re-enumerating them, both avoiding drift and keeping the canonical file
  under its 33000-byte phase budget.

## Test plan

- [x] `pnpm run build` (regenerates `scripts/discover-orphan-filter.mjs`)
- [x] `pnpm run typecheck`
- [x] `node --experimental-strip-types --test tests/discover-orphan-filter.test.mts`
      (44/44 pass, including 6 new tests covering positive matches, the
      quoted-term self-reference trap, same-clause negation, code-region
      exclusion, and the new filtered bucket)
- [x] Verified the new tests fail without the fix (`git stash` on the
      source/test files)
- [x] `pnpm run test` (full suite, 4821/4821 pass)
- [x] `node scripts/audit-docs.mjs --check`, `dprint check`,
      `markdownlint-cli2`, `node scripts/audit-code-span-wrap.mjs`,
      `cspell lint` all clean

Refs #2467

https://claude.ai/code/session_01Smou8PbTPvD32SMHkfvEia

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Explicit issue targets now undergo complete readiness checks, including blocked dependencies, coordination requirements, and runtime-observation prerequisites.
  - Issues requiring live or production runtime confirmation are automatically excluded from discovery results.
  - Detection distinguishes actionable prerequisites from quoted, negated, or code-formatted text.

- **Documentation**
  - Updated discovery guidance and command-line help to explain the additional readiness and filtering rules.

- **Tests**
  - Added coverage for runtime-observation detection, exclusions, and behavior when related issues are closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->