### PR TITLE
docs(idd-pr-submit): warn D4 a waiver can stay inert until open

### DIFF
--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -440,10 +440,10 @@ confirmed condition above. Delegate polling mechanics to
   the waiver (a pre-existing F2/F3 concern this branch leaves unchanged;
   see `idd-pre-merge.instructions.md`'s External-check waivers). A
   waiver is effective only once `deadline.passed` is true or
-  `terminal.state` reaches `COPILOT_UNAVAILABLE` (check both top-level
-  fields in the same run's output); posted earlier, it is valid but
-  inert — mechanically the same as no waiver until then. Absent a
-  waiver, or with one still inert, exit CI-wait and proceed directly to
+  `terminal.state` reaches `COPILOT_UNAVAILABLE` (check both fields in
+  the same run's output); posted earlier, it is valid but inert —
+  mechanically the same as no waiver until then. Absent a waiver, or
+  with one still inert, exit CI-wait and proceed directly to
   `idd-review-snapshot.instructions.md` (E1) instead, matching the phase
   routing table's "PR open, CI running, reviews exist" row. This does
   not relax the merge gate — the check stays required, and F2

--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -438,8 +438,12 @@ confirmed condition above. Delegate polling mechanics to
   maintainer has since posted a valid external-check waiver for this
   HEAD** — that case still needs the rerun, to make the check reflect
   the waiver (a pre-existing F2/F3 concern this branch leaves unchanged;
-  see `idd-pre-merge.instructions.md`'s External-check waivers). Absent
-  a waiver, exit CI-wait and proceed directly to
+  see `idd-pre-merge.instructions.md`'s External-check waivers). A
+  waiver is effective only once `deadline.passed` is true or
+  `terminal.state` reaches `COPILOT_UNAVAILABLE` (check both top-level
+  fields in the same run's output); posted earlier, it is valid but
+  inert — mechanically the same as no waiver until then. Absent a
+  waiver, or with one still inert, exit CI-wait and proceed directly to
   `idd-review-snapshot.instructions.md` (E1) instead, matching the phase
   routing table's "PR open, CI running, reviews exist" row. This does
   not relax the merge gate — the check stays required, and F2

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -246,7 +246,9 @@ nonce was recorded for the active claim.
   threads, unreplied comments, required reviews, disposition evidence,
   or claim ownership. Non-empty `waiverEvidence.wrongHead`, `wrongClaim`,
   `unauthorized`, `expired`, or `malformed` are suspicious context, never
-  valid permissions.
+  valid permissions. A waiver posted before its own effectiveness
+  precondition is met is valid but inert until then — see
+  `idd-pr-submit.instructions.md`'s D4 for the mechanical check.
 
   **Local validation evidence** (#2323): `pre-merge-readiness`'s
   `localValidationEvidence` field reports whether HEAD-pinned local

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -859,6 +859,11 @@ helper-generated comment is the auditable authorization surface because
 self-approval cannot express the required claim, head, check, and expiry
 proof.
 
+A waiver posted before its own effectiveness precondition is met is
+valid but inert until then; see
+[`idd-pr-submit.instructions.md`'s D4](../.github/instructions/idd-pr-submit.instructions.md)
+for the mechanical check.
+
 ## Optional helper scripts
 
 This source repository currently ships the following optional helper scripts:

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -433,8 +433,12 @@ confirmed condition above. Delegate polling mechanics to
   maintainer has since posted a valid external-check waiver for this
   HEAD** — that case still needs the rerun, to make the check reflect
   the waiver (a pre-existing F2/F3 concern this branch leaves unchanged;
-  see `idd-pre-merge.instructions.md`'s External-check waivers). Absent
-  a waiver, exit CI-wait and proceed directly to
+  see `idd-pre-merge.instructions.md`'s External-check waivers). A
+  waiver is effective only once `deadline.passed` is true or
+  `terminal.state` reaches `COPILOT_UNAVAILABLE` (check both top-level
+  fields in the same run's output); posted earlier, it is valid but
+  inert — mechanically the same as no waiver until then. Absent a
+  waiver, or with one still inert, exit CI-wait and proceed directly to
   `idd-review-snapshot.instructions.md` (E1) instead, matching the phase
   routing table's "PR open, CI running, reviews exist" row. This does
   not relax the merge gate — the check stays required, and F2

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -435,10 +435,10 @@ confirmed condition above. Delegate polling mechanics to
   the waiver (a pre-existing F2/F3 concern this branch leaves unchanged;
   see `idd-pre-merge.instructions.md`'s External-check waivers). A
   waiver is effective only once `deadline.passed` is true or
-  `terminal.state` reaches `COPILOT_UNAVAILABLE` (check both top-level
-  fields in the same run's output); posted earlier, it is valid but
-  inert — mechanically the same as no waiver until then. Absent a
-  waiver, or with one still inert, exit CI-wait and proceed directly to
+  `terminal.state` reaches `COPILOT_UNAVAILABLE` (check both fields in
+  the same run's output); posted earlier, it is valid but inert —
+  mechanically the same as no waiver until then. Absent a waiver, or
+  with one still inert, exit CI-wait and proceed directly to
   `idd-review-snapshot.instructions.md` (E1) instead, matching the phase
   routing table's "PR open, CI running, reviews exist" row. This does
   not relax the merge gate — the check stays required, and F2

--- a/idd-template/.github/instructions/idd-pre-merge.instructions.md
+++ b/idd-template/.github/instructions/idd-pre-merge.instructions.md
@@ -241,7 +241,9 @@ nonce was recorded for the active claim.
   threads, unreplied comments, required reviews, disposition evidence,
   or claim ownership. Non-empty `waiverEvidence.wrongHead`, `wrongClaim`,
   `unauthorized`, `expired`, or `malformed` are suspicious context, never
-  valid permissions.
+  valid permissions. A waiver posted before its own effectiveness
+  precondition is met is valid but inert until then — see
+  `idd-pr-submit.instructions.md`'s D4 for the mechanical check.
 
   **Local validation evidence** (#2323): `pre-merge-readiness`'s
   `localValidationEvidence` field reports whether HEAD-pinned local

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -837,6 +837,11 @@ helper-generated comment is the auditable authorization surface because
 self-approval cannot express the required claim, head, check, and expiry
 proof.
 
+A waiver posted before its own effectiveness precondition is met is
+valid but inert until then; see
+[`idd-pr-submit.instructions.md`'s D4](../.github/instructions/idd-pr-submit.instructions.md)
+for the mechanical check.
+
 ## Optional helper scripts
 
 The idd-skill source repository that ships this template currently includes the


### PR DESCRIPTION
# Summary

D4 in `idd-pr-submit.instructions.md` states that a waiver posted during
CI-wait "still needs the rerun, to make the check reflect the waiver,"
which reads as sufficient on its own with no mention that the check's
shared waiver-effectiveness precondition (`deadline.passed` OR
`terminal.state` reaching `COPILOT_UNAVAILABLE`) must also be open. A
waiver posted immediately after PR creation, before advisory-wait has
ever run, has zero effect until either condition holds -- the helper's
output is correct, but no instruction-file prose warned against posting
this early or explained what to do while it remains inert.

States the waiver-effectiveness precondition in D4 (the highest-leverage
location), routes the inert-waiver case the same way as no-waiver (exit
CI-wait to E1, since an inert waiver is mechanically identical to none),
and cross-references the same caveat from `docs/idd-workflow.md`'s
waiver section and `idd-pre-merge.instructions.md`'s F2 waiver
checklist.

Went through three rounds of independent C1 critique (subagent) before
this push -- each round found and fixed a real correctness gap in the
added text: round 1 corrected a backwards reading of a `terminal.reason`
diagnostic value; round 2 found that `terminal.state` alone was an
incomplete condition (a parallel, independent `deadline.passed` path
exists in the shared implementation and is the faster route in this
issue's own motivating scenario); round 3 found a routing contradiction
between the inert-waiver case and the bullet's "not a CI-wait state"
premise, fixed by merging the inert-waiver and no-waiver routes into one
exit path. See the issue thread for the full per-round record.

## Linked issue

Closes #2490

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

None beyond the issue body itself.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (no source/test files touched -- docs-only change)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable) -- passed, only
      pre-existing warnings unrelated to this diff

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed -- none; documentation only, no
      routing behavior actually changes (only the prose describing it)
- [x] Context budget impact reviewed -- `bundle-merge` sits at 97.95%
      of its 98% `maxUtilizationPct` hard-fail threshold after this
      change (verified via `audit-docs.mjs --check`, which still
      passes); essentially no headroom remains in that bundle for a
      future addition
