### PR TITLE
fix(suitability-triage): scope Check 7's proximity gate to paragraphs

### DIFF
--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -178,6 +178,35 @@ const SUBJECTIVE_PROXIMITY_PATTERN = new RegExp(
   `${SUBJECTIVE_GATE_PATTERN.source}[\\s\\S]{0,80}${SUBJECTIVE_SUBJECT_PATTERN.source}`,
   'i',
 );
+// #2512: a match landing in a paragraph that also reports on another
+// document's or process's existing behavior ("...paragraph SAYS a later
+// worker session removes the label once a human decision resolves the
+// hold" -- #2472's exact shape) uses the subject/gate vocabulary as the
+// OBJECT of that report, not as a claim that THIS issue's own completion
+// needs anyone's say-so. GitHub issue bodies are hard-wrapped, so the
+// reporting verb and the subject/gate words routinely land on different
+// physical lines of the same sentence -- a paragraph (blank-line
+// delimited), not a raw split(\n) line, is the unit that must see both
+// (the same "line wrap is not a boundary, blank line is" shape as
+// `sliceUnsafeDirectiveWindow`'s Check 3 window). Exempting the whole
+// paragraph, not a tighter window around the verb, is a soft trade-off
+// matching this check's existing resolved-decision heuristic below: a
+// false negative (an unrelated reporting verb elsewhere in a long
+// paragraph) is accepted in exchange for not re-deriving sentence
+// boundaries.
+const FRAMING_VERB_PATTERN =
+  /\b(documents?|describes?|says?|states?|explains?|reports?)\b/i;
+/** Blank-line-delimited paragraph offsets within `body`. */
+function getParagraphSpans(body) {
+  const spans = [];
+  let cursor = 0;
+  for (const boundary of body.matchAll(/\r?\n[ \t]*(?:\r?\n)+/g)) {
+    spans.push({ start: cursor, end: boundary.index });
+    cursor = boundary.index + boundary[0].length;
+  }
+  spans.push({ start: cursor, end: body.length });
+  return spans;
+}
 // Check 3 precision: an unsafe execution directive tells the agent to act on
 // *supplied / untrusted* content, not any command verb that merely lands near
 // the ordinary determiner "this". Match the strong untrusted-origin signals, or
@@ -1707,14 +1736,39 @@ export function checkVerifiability(context) {
     };
   }
   const hasSubjectiveApproval = (() => {
-    const lines = body.split(/\r?\n/);
-    return (
-      lines.some(
-        (line) =>
-          SUBJECTIVE_SUBJECT_PATTERN.test(line) &&
-          SUBJECTIVE_GATE_PATTERN.test(line),
-      ) || SUBJECTIVE_PROXIMITY_PATTERN.test(body)
+    const paragraphSpans = getParagraphSpans(body);
+    const isFramedAsDescriptive = (offset) => {
+      const span =
+        paragraphSpans.find(
+          (candidate) => offset >= candidate.start && offset <= candidate.end,
+        ) ?? paragraphSpans[paragraphSpans.length - 1];
+      return FRAMING_VERB_PATTERN.test(
+        body.slice(span?.start ?? 0, span?.end ?? body.length),
+      );
+    };
+    let lineOffset = 0;
+    for (const line of body.split(/\r?\n/)) {
+      if (
+        SUBJECTIVE_SUBJECT_PATTERN.test(line) &&
+        SUBJECTIVE_GATE_PATTERN.test(line) &&
+        !isFramedAsDescriptive(lineOffset)
+      ) {
+        return true;
+      }
+      lineOffset += line.length + 1;
+    }
+    const proximityPattern = new RegExp(
+      SUBJECTIVE_PROXIMITY_PATTERN.source,
+      'gi',
     );
+    let proximityMatch = proximityPattern.exec(body);
+    while (proximityMatch) {
+      if (!isFramedAsDescriptive(proximityMatch.index)) {
+        return true;
+      }
+      proximityMatch = proximityPattern.exec(body);
+    }
+    return false;
   })();
   // A body that carries BOTH a resolved-decision marker (a
   // "## Decision (resolved …)" section) AND a concrete, objectively-verifiable

--- a/scripts/suitability-triage.mjs
+++ b/scripts/suitability-triage.mjs
@@ -1736,18 +1736,27 @@ export function checkVerifiability(context) {
     };
   }
   const hasSubjectiveApproval = (() => {
-    const paragraphSpans = getParagraphSpans(body);
+    // Normalized once so every offset computed below (line-split cursor,
+    // paragraph spans, proximity match index) shares the same 1-char line
+    // separator -- a raw `\r\n` body otherwise drifts the running
+    // `lineOffset` cursor by 1 byte per CRLF line, eventually pointing
+    // `isFramedAsDescriptive` at the wrong paragraph (#2531 review).
+    const normalizedBody = body.replace(/\r\n/g, '\n');
+    const paragraphSpans = getParagraphSpans(normalizedBody);
     const isFramedAsDescriptive = (offset) => {
       const span =
         paragraphSpans.find(
           (candidate) => offset >= candidate.start && offset <= candidate.end,
         ) ?? paragraphSpans[paragraphSpans.length - 1];
       return FRAMING_VERB_PATTERN.test(
-        body.slice(span?.start ?? 0, span?.end ?? body.length),
+        normalizedBody.slice(
+          span?.start ?? 0,
+          span?.end ?? normalizedBody.length,
+        ),
       );
     };
     let lineOffset = 0;
-    for (const line of body.split(/\r?\n/)) {
+    for (const line of normalizedBody.split('\n')) {
       if (
         SUBJECTIVE_SUBJECT_PATTERN.test(line) &&
         SUBJECTIVE_GATE_PATTERN.test(line) &&
@@ -1761,12 +1770,12 @@ export function checkVerifiability(context) {
       SUBJECTIVE_PROXIMITY_PATTERN.source,
       'gi',
     );
-    let proximityMatch = proximityPattern.exec(body);
+    let proximityMatch = proximityPattern.exec(normalizedBody);
     while (proximityMatch) {
       if (!isFramedAsDescriptive(proximityMatch.index)) {
         return true;
       }
-      proximityMatch = proximityPattern.exec(body);
+      proximityMatch = proximityPattern.exec(normalizedBody);
     }
     return false;
   })();

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -1952,19 +1952,28 @@ export function checkVerifiability(context: Context): CheckOutcome {
     };
   }
   const hasSubjectiveApproval = ((): boolean => {
-    const paragraphSpans = getParagraphSpans(body);
+    // Normalized once so every offset computed below (line-split cursor,
+    // paragraph spans, proximity match index) shares the same 1-char line
+    // separator -- a raw `\r\n` body otherwise drifts the running
+    // `lineOffset` cursor by 1 byte per CRLF line, eventually pointing
+    // `isFramedAsDescriptive` at the wrong paragraph (#2531 review).
+    const normalizedBody = body.replace(/\r\n/g, '\n');
+    const paragraphSpans = getParagraphSpans(normalizedBody);
     const isFramedAsDescriptive = (offset: number): boolean => {
       const span =
         paragraphSpans.find(
           (candidate) => offset >= candidate.start && offset <= candidate.end,
         ) ?? paragraphSpans[paragraphSpans.length - 1];
       return FRAMING_VERB_PATTERN.test(
-        body.slice(span?.start ?? 0, span?.end ?? body.length),
+        normalizedBody.slice(
+          span?.start ?? 0,
+          span?.end ?? normalizedBody.length,
+        ),
       );
     };
 
     let lineOffset = 0;
-    for (const line of body.split(/\r?\n/)) {
+    for (const line of normalizedBody.split('\n')) {
       if (
         SUBJECTIVE_SUBJECT_PATTERN.test(line) &&
         SUBJECTIVE_GATE_PATTERN.test(line) &&
@@ -1979,12 +1988,12 @@ export function checkVerifiability(context: Context): CheckOutcome {
       SUBJECTIVE_PROXIMITY_PATTERN.source,
       'gi',
     );
-    let proximityMatch = proximityPattern.exec(body);
+    let proximityMatch = proximityPattern.exec(normalizedBody);
     while (proximityMatch) {
       if (!isFramedAsDescriptive(proximityMatch.index)) {
         return true;
       }
-      proximityMatch = proximityPattern.exec(body);
+      proximityMatch = proximityPattern.exec(normalizedBody);
     }
 
     return false;

--- a/src/scripts/suitability-triage.mts
+++ b/src/scripts/suitability-triage.mts
@@ -300,6 +300,37 @@ const SUBJECTIVE_PROXIMITY_PATTERN = new RegExp(
   `${SUBJECTIVE_GATE_PATTERN.source}[\\s\\S]{0,80}${SUBJECTIVE_SUBJECT_PATTERN.source}`,
   'i',
 );
+// #2512: a match landing in a paragraph that also reports on another
+// document's or process's existing behavior ("...paragraph SAYS a later
+// worker session removes the label once a human decision resolves the
+// hold" -- #2472's exact shape) uses the subject/gate vocabulary as the
+// OBJECT of that report, not as a claim that THIS issue's own completion
+// needs anyone's say-so. GitHub issue bodies are hard-wrapped, so the
+// reporting verb and the subject/gate words routinely land on different
+// physical lines of the same sentence -- a paragraph (blank-line
+// delimited), not a raw split(\n) line, is the unit that must see both
+// (the same "line wrap is not a boundary, blank line is" shape as
+// `sliceUnsafeDirectiveWindow`'s Check 3 window). Exempting the whole
+// paragraph, not a tighter window around the verb, is a soft trade-off
+// matching this check's existing resolved-decision heuristic below: a
+// false negative (an unrelated reporting verb elsewhere in a long
+// paragraph) is accepted in exchange for not re-deriving sentence
+// boundaries.
+const FRAMING_VERB_PATTERN =
+  /\b(documents?|describes?|says?|states?|explains?|reports?)\b/i;
+
+/** Blank-line-delimited paragraph offsets within `body`. */
+function getParagraphSpans(body: string): { start: number; end: number }[] {
+  const spans: { start: number; end: number }[] = [];
+  let cursor = 0;
+  for (const boundary of body.matchAll(/\r?\n[ \t]*(?:\r?\n)+/g)) {
+    spans.push({ start: cursor, end: boundary.index });
+    cursor = boundary.index + boundary[0].length;
+  }
+  spans.push({ start: cursor, end: body.length });
+  return spans;
+}
+
 // Check 3 precision: an unsafe execution directive tells the agent to act on
 // *supplied / untrusted* content, not any command verb that merely lands near
 // the ordinary determiner "this". Match the strong untrusted-origin signals, or
@@ -1921,14 +1952,42 @@ export function checkVerifiability(context: Context): CheckOutcome {
     };
   }
   const hasSubjectiveApproval = ((): boolean => {
-    const lines = body.split(/\r?\n/);
-    return (
-      lines.some(
-        (line) =>
-          SUBJECTIVE_SUBJECT_PATTERN.test(line) &&
-          SUBJECTIVE_GATE_PATTERN.test(line),
-      ) || SUBJECTIVE_PROXIMITY_PATTERN.test(body)
+    const paragraphSpans = getParagraphSpans(body);
+    const isFramedAsDescriptive = (offset: number): boolean => {
+      const span =
+        paragraphSpans.find(
+          (candidate) => offset >= candidate.start && offset <= candidate.end,
+        ) ?? paragraphSpans[paragraphSpans.length - 1];
+      return FRAMING_VERB_PATTERN.test(
+        body.slice(span?.start ?? 0, span?.end ?? body.length),
+      );
+    };
+
+    let lineOffset = 0;
+    for (const line of body.split(/\r?\n/)) {
+      if (
+        SUBJECTIVE_SUBJECT_PATTERN.test(line) &&
+        SUBJECTIVE_GATE_PATTERN.test(line) &&
+        !isFramedAsDescriptive(lineOffset)
+      ) {
+        return true;
+      }
+      lineOffset += line.length + 1;
+    }
+
+    const proximityPattern = new RegExp(
+      SUBJECTIVE_PROXIMITY_PATTERN.source,
+      'gi',
     );
+    let proximityMatch = proximityPattern.exec(body);
+    while (proximityMatch) {
+      if (!isFramedAsDescriptive(proximityMatch.index)) {
+        return true;
+      }
+      proximityMatch = proximityPattern.exec(body);
+    }
+
+    return false;
   })();
   // A body that carries BOTH a resolved-decision marker (a
   // "## Decision (resolved …)" section) AND a concrete, objectively-verifiable

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2874,6 +2874,27 @@ The appendix file documents the existing claim-release rule in detail.
   assert.equal(result.pass, false);
 });
 
+test('verifiability still fails a genuine subjective gate in a CRLF body (#2531 review)', () => {
+  // A CRLF body's line separator is 2 chars, not 1. The per-line offset
+  // cursor previously assumed 1 char per split(\r?\n) line, undercounting
+  // by 1 byte per CRLF line -- with enough preceding lines, the drifted
+  // offset lands back inside an EARLIER paragraph's span, wrongly exempting
+  // a genuine gate as "framed as descriptive" by that earlier paragraph's
+  // unrelated reporting verb. Reproduced verbatim: pre-fix this returned
+  // pass:true.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body:
+        'The docs page documents this.\r\nIt also documents that.\r\n' +
+        'More prose documents things.\r\n\r\n' +
+        'A human decision is required before shipping this feature.\r\n\r\n' +
+        '## Acceptance Criteria\r\n- [ ] tests pass\r\n',
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('repository fit fails when external system access is required', () => {
   const result = checkRepositoryFit({
     issue: {

--- a/tests/suitability-triage.test.mts
+++ b/tests/suitability-triage.test.mts
@@ -2828,6 +2828,52 @@ test('verifiability still fails a freestanding subjective sign-off spanning line
   assert.equal(result.pass, false);
 });
 
+test("verifiability passes background prose reporting on another document's existing behavior across a hard wrap (#2472, #2512)", () => {
+  // Check 7 false-positive that now passes: this reproduces #2472's exact
+  // body shape -- a Background paragraph reporting what ANOTHER file
+  // already says, with the subject/gate words landing on a different
+  // physical (hard-wrapped) line than the reporting verb "says", within
+  // the same paragraph/sentence.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Background
+
+One doc states the label is removed by a human maintainer only, while
+the other file's claim-release paragraph says a later worker session
+removes the label once a human decision resolves the hold.
+
+## Acceptance Criteria
+- [ ] the two docs agree on who removes the label
+- [ ] tests pass
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, true);
+});
+
+test('verifiability still fails a genuine subjective gate even when an unrelated paragraph reports on another document (#2512)', () => {
+  // The framing-verb exemption is scoped to the paragraph that contains
+  // BOTH the reporting verb and the subject/gate match -- an unrelated
+  // paragraph using "documents" elsewhere in the body must not exempt a
+  // genuine completion-gated-on-approval paragraph that has no reporting
+  // verb of its own.
+  const result = checkVerifiability({
+    issue: {
+      ...BASE_ISSUE,
+      body: `## Background
+
+The appendix file documents the existing claim-release rule in detail.
+
+## Acceptance Criteria
+- [ ] tests pass
+- [ ] final sign-off from the maintainer confirms the UX feels right
+`,
+    },
+  } as Context);
+  assert.equal(result.pass, false);
+});
+
 test('repository fit fails when external system access is required', () => {
   const result = checkRepositoryFit({
     issue: {


### PR DESCRIPTION
## Summary

`checkVerifiability`'s subjective-approval scan (Check 7) routed a
legitimate, well-specified documentation issue (#2472) to `needs-decision`.
Its Background section, describing the *existing, already-shipped* behavior
one of two contradicting doc files documents, landed the check's subject
vocabulary (`human`) and gate vocabulary (`decision`) on the same
hard-wrapped physical line -- not as a claim that #2472's own completion
needs anyone's sign-off, but as ordinary prose reporting what the other
file already says.

- Both the per-line and whole-body proximity checks in
  `checkVerifiability` now exempt a match whose containing **paragraph**
  (blank-line-delimited, not a raw `split(\n)` line) also carries a
  present-tense reporting verb ("documents"/"describes"/"says"/"states"/
  "explains"/"reports").
- A paragraph is the right unit because GitHub issue bodies are
  hard-wrapped: the reporting verb and the subject/gate words routinely
  land on different physical lines of the same sentence -- the same "line
  wrap is not a boundary, blank line is" shape `sliceUnsafeDirectiveWindow`
  already established for Check 3.
- Deliberately a whole-paragraph exemption rather than a tighter
  character-distance window: a soft trade-off matching this check's
  existing resolved-decision heuristic (some false-negative risk accepted
  in exchange for not re-deriving sentence boundaries).
- No change to `checkAutonomy` or any other check -- scoped entirely to
  `checkVerifiability`'s own proximity-scan boundary handling, per the
  issue's own scoping request.

## Test plan

- [x] `node scripts/suitability-triage.mjs --issue 2472` now reports
      `outcome: ready` (was `needs-decision`, `failedCheck: verifiability`)
- [x] `pnpm run build` (regenerates `scripts/suitability-triage.mjs`)
- [x] `pnpm run typecheck`
- [x] `node --experimental-strip-types --test tests/suitability-triage.test.mts`
      (274/274 pass, including all pre-existing Check 7 true-positive
      cases unchanged, plus 2 new tests: the exact #2472-shaped false
      positive reproduced with the reporting verb and the subject/gate
      match split across hard-wrapped lines, and a genuine
      completion-gated-on-approval case that still fails even when an
      *unrelated* paragraph elsewhere in the body uses a reporting verb)
- [x] Verified both new tests fail without the fix (`git stash` on the
      source/test files) -- exactly 1 failure (the false-positive test),
      273 pass
- [x] `pnpm run test` (full suite, 4817/4817 pass)
- [x] `cspell lint`, `biome check` clean on the touched files

Refs #2512

https://claude.ai/code/session_01Smou8PbTPvD32SMHkfvEia