### PR TITLE
fix(scripts): accept split --owner/--repo on 5 combined-only helpers

### DIFF
--- a/scripts/audit-pr-cleanup.mjs
+++ b/scripts/audit-pr-cleanup.mjs
@@ -13,7 +13,7 @@ import {
   readForcedHandoffAuthorityPolicy,
   readForcedHandoffMode,
 } from './collaborator-permission.mjs';
-import { ghText } from './gh-exec.mjs';
+import { combineOwnerRepoFlags, ghText } from './gh-exec.mjs';
 import { resolveCollaboratorMarkerTrust } from './policy-helpers.mjs';
 import {
   classifyRegularBotComment,
@@ -38,6 +38,7 @@ const AUDIT_PR_CLEANUP_FLAG_SPEC = {
   '--pr': { type: 'string' },
   '--prs': { type: 'string' },
   '--repo': { type: 'string' },
+  '--owner': { type: 'string' },
   '--dry-run': { type: 'boolean', default: false },
   '--apply': { type: 'boolean', default: false },
   '--format': { type: 'string', default: 'json' },
@@ -112,7 +113,12 @@ async function main() {
     );
   }
   assertBatchApplyClaimScope(args);
-  const repository = args.repo ?? detectRepository();
+  let repository;
+  try {
+    repository = combineOwnerRepoFlags(args) ?? detectRepository();
+  } catch (error) {
+    fail(error.message);
+  }
   const [owner, repo] = parseRepository(repository);
   const prNumbers = parsePrNumbers(args);
   if (args.claimIssue) {
@@ -1458,6 +1464,7 @@ function parseArgs(argv) {
   const pr = requireNonEmpty(values.pr, '--pr');
   const prs = requireNonEmpty(values.prs, '--prs');
   const repo = requireNonEmpty(values.repo, '--repo');
+  const owner = requireNonEmpty(values.owner, '--owner');
   const format = requireNonEmpty(values.format, '--format');
   if (!['json', 'table'].includes(format)) {
     fail('--format must be json or table');
@@ -1471,6 +1478,7 @@ function parseArgs(argv) {
     pr,
     prs,
     repo,
+    owner,
     dryRun: values['dry-run'],
     apply: values.apply,
     claimIssue,
@@ -1500,7 +1508,11 @@ Options:
   --claim-id <id>                   active claim id required for apply mode
   --agent-id <id>                   optionally require this claim agent id
   --skip-claim-check                explicit maintainer override for apply mode
-  --repo <owner/name>               repository override
+  --repo <owner/name>               repository override, combined form
+  --owner <owner>                   repository override, split form (use
+                                     with --repo <name>, the bare
+                                     repository name -- not both --owner
+                                     and a combined --repo together)
   --format <json|table>             output format (default: json)
   --help                            show this help
 

--- a/scripts/gh-exec.mjs
+++ b/scripts/gh-exec.mjs
@@ -198,6 +198,54 @@ export function resolveGhApiHostname(env = process.env) {
   return host && host !== 'github.com' ? host : undefined;
 }
 /**
+ * #2454: the majority of `src/scripts/*.mts` accept a split `--owner
+ * <owner> --repo <name>` pair; five scripts (`audit-pr-cleanup.mts`,
+ * `live-status-digest.mts`, `token-cost-harvest.mts`,
+ * `local-validation-evidence.mts`, `provider-outage-declaration.mts`)
+ * instead accept only a combined `--repo <owner>/<name>`. Rewriting the
+ * majority onto the combined form (or vice versa) is out of scope; this
+ * helper lets the five minority scripts accept EITHER form while
+ * changing nothing else about their own resolution pipeline: it folds a
+ * split pair into the single combined string each script's own existing
+ * parser (or default-repo fallback) already consumes, so a caller only
+ * has to route its `--owner`/`--repo` flags through this function once,
+ * immediately after `parseCliArgs`, and every downstream line is
+ * unchanged.
+ *
+ * - Neither flag given → returns `args.repo` unchanged (`undefined` or
+ *   the caller's own empty-string default), so the caller's existing
+ *   default-repo resolution (a `gh repo view` fallback, or a hard
+ *   "--repo is required" error, depending on the script) still runs
+ *   exactly as before.
+ * - Only `--repo` given → returned unchanged, whether it is already the
+ *   combined `owner/name` form (the pre-existing, still-supported case)
+ *   or some other value the caller's own parser will accept or reject.
+ * - Only `--owner` given → combined with `--repo` (which must be the
+ *   bare name, no `/`) into `owner/name`. Throws when `--repo` is
+ *   missing (an owner alone cannot resolve a repository) or already
+ *   contains a `/` (mixing both forms is ambiguous, not a genuine
+ *   split-form name) — a specific, actionable error instead of letting
+ *   a double-prefixed value reach `gh api` and 404 downstream.
+ */
+export function combineOwnerRepoFlags(args) {
+  if (!args.owner) {
+    return args.repo;
+  }
+  if (args.repo?.includes('/')) {
+    throw new Error(
+      `--owner and a combined --repo "${args.repo}" conflict -- pass ` +
+        'either --repo <owner>/<name> alone or --owner <owner> --repo ' +
+        '<name>, not both forms together',
+    );
+  }
+  if (!args.repo) {
+    throw new Error(
+      '--owner requires --repo <name> (the bare repository name)',
+    );
+  }
+  return `${args.owner}/${args.repo}`;
+}
+/**
  * Run `gh api <path>` and parse its output as JSON, optionally paginating
  * (NDJSON-compatible) and/or tolerating specific failure statuses.
  *

--- a/scripts/live-status-digest.mjs
+++ b/scripts/live-status-digest.mjs
@@ -13,6 +13,7 @@ import {
   readForcedHandoffMode,
 } from './collaborator-permission.mjs';
 import {
+  combineOwnerRepoFlags,
   DEFAULT_GH_PAGINATED_TIMEOUT_MS,
   ghApiJson,
   ghText,
@@ -37,6 +38,7 @@ const LIVE_STATUS_DIGEST_FLAG_SPEC = {
   '--issue': { type: 'string' },
   '--pr': { type: 'string' },
   '--repo': { type: 'string' },
+  '--owner': { type: 'string' },
   '--dry-run': { type: 'boolean', default: false },
   '--apply': { type: 'boolean', default: false },
   '--phase': { type: 'string' },
@@ -96,7 +98,12 @@ function main() {
       '--apply requires --claim-issue and --claim-id, or explicit --skip-claim-check',
     );
   }
-  const repository = args.repo ?? detectRepository();
+  let repository;
+  try {
+    repository = combineOwnerRepoFlags(args) ?? detectRepository();
+  } catch (error) {
+    fail(error.message);
+  }
   const [owner, repo] = parseRepository(repository);
   const targetType = args.issue ? 'issue' : 'pr';
   const targetNumber = parsePositiveInteger(
@@ -566,6 +573,7 @@ function parseArgs(argv) {
     issue: requireNonEmpty(values.issue, '--issue'),
     pr: requireNonEmpty(values.pr, '--pr'),
     repo: requireNonEmpty(values.repo, '--repo'),
+    owner: requireNonEmpty(values.owner, '--owner'),
     dryRun: values['dry-run'],
     apply: values.apply,
     phase: requireNonEmpty(values.phase, '--phase'),
@@ -626,7 +634,11 @@ Options:
   --claim-id <id>                   active claim id required for apply mode
   --agent-id <id>                   optionally require this claim agent id
   --skip-claim-check                explicit maintainer override for apply mode
-  --repo <owner/name>               repository override
+  --repo <owner/name>               repository override, combined form
+  --owner <owner>                   repository override, split form (use
+                                     with --repo <name>, the bare
+                                     repository name -- not both --owner
+                                     and a combined --repo together)
   --format <json|table>             output format (default: json)
   --include-body                    include the rendered body in JSON reports
   --help                            show this help

--- a/scripts/local-validation-evidence.mjs
+++ b/scripts/local-validation-evidence.mjs
@@ -27,6 +27,7 @@ import {
   resolveCollaboratorAuthority,
 } from './external-check-waiver.mjs';
 import {
+  combineOwnerRepoFlags,
   DEFAULT_GH_PAGINATED_TIMEOUT_MS,
   ghText,
   safeGhText,
@@ -244,6 +245,7 @@ const LOCAL_VALIDATION_EVIDENCE_FLAG_SPEC = {
   '--target-issue': { type: 'string', default: '' },
   '--actor': { type: 'string', default: '' },
   '--repo': { type: 'string', default: '' },
+  '--owner': { type: 'string', default: '' },
   '--apply': { type: 'boolean', default: false },
   '--format': { type: 'string', default: 'json' },
   '--help': { type: 'boolean', short: 'h' },
@@ -288,7 +290,12 @@ export function parseArgs(argv) {
         ? 0
         : parsePositiveIntegerFlag(values['target-issue'], '--target-issue'),
     actor: values.actor.trim(),
-    repo: values.repo.trim(),
+    repo:
+      combineOwnerRepoFlags({
+        owner: values.owner.trim(),
+        repo: values.repo.trim(),
+      }) ?? '',
+    owner: values.owner.trim(),
     apply: values.apply,
     format,
     help,
@@ -507,7 +514,11 @@ Options:
   --service <name>                   outage-declaration service to require active (default: ci-actions)
   --target-issue <number>           override providerOutage.declarationTarget
   --actor <login>                   override the GitHub actor used for --record
-  --repo <owner/name>               repository override
+  --repo <owner/name>               repository override, combined form
+  --owner <owner>                   repository override, split form (use
+                                     with --repo <name>, the bare
+                                     repository name -- not both --owner
+                                     and a combined --repo together)
   --apply                           post the canonical marker comment after validation (--record)
   --format <json|text>              output format (default: json)
   --help                            show this message

--- a/scripts/provider-outage-declaration.mjs
+++ b/scripts/provider-outage-declaration.mjs
@@ -28,6 +28,7 @@ import {
   resolveCollaboratorAuthority,
 } from './external-check-waiver.mjs';
 import {
+  combineOwnerRepoFlags,
   DEFAULT_GH_PAGINATED_TIMEOUT_MS,
   ghText,
   safeGhText,
@@ -325,6 +326,7 @@ const PROVIDER_OUTAGE_DECLARATION_FLAG_SPEC = {
   '--target-issue': { type: 'string', default: '' },
   '--actor': { type: 'string', default: '' },
   '--repo': { type: 'string', default: '' },
+  '--owner': { type: 'string', default: '' },
   '--apply': { type: 'boolean', default: false },
   '--yes': { type: 'boolean', default: false },
   '--format': { type: 'string', default: 'json' },
@@ -378,7 +380,12 @@ export function parseArgs(argv) {
         ? 0
         : parsePositiveIntegerFlag(values['target-issue'], '--target-issue'),
     actor: values.actor.trim(),
-    repo: values.repo.trim(),
+    repo:
+      combineOwnerRepoFlags({
+        owner: values.owner.trim(),
+        repo: values.repo.trim(),
+      }) ?? '',
+    owner: values.owner.trim(),
     apply: values.apply,
     yes: values.yes,
     format,
@@ -732,7 +739,11 @@ Options:
   --head-sha <40-hex>                pull request HEAD SHA (--record-advanced)
   --target-issue <number>           override providerOutage.declarationTarget
   --actor <login>                   override the GitHub actor used for authority evaluation
-  --repo <owner/name>               repository override
+  --repo <owner/name>               repository override, combined form
+  --owner <owner>                   repository override, split form (use
+                                     with --repo <name>, the bare
+                                     repository name -- not both --owner
+                                     and a combined --repo together)
   --apply                           post the canonical marker comment after validation
   --yes                             skip the interactive apply confirmation
   --format <json|text>              output format (default: json)

--- a/scripts/token-cost-harvest.mjs
+++ b/scripts/token-cost-harvest.mjs
@@ -24,7 +24,7 @@ import {
 import { homedir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 import { parseCliArgs } from './cli-args.mjs';
-import { ghGraphql } from './gh-exec.mjs';
+import { combineOwnerRepoFlags, ghGraphql } from './gh-exec.mjs';
 import {
   parseClaimComment,
   parseForcedHandoffComment,
@@ -1636,6 +1636,7 @@ function defaultStateDir() {
 // module header for the full invariant.
 const TOKEN_COST_HARVEST_FLAG_SPEC = {
   '--repo': { type: 'string', default: '' },
+  '--owner': { type: 'string', default: '' },
   '--out': { type: 'string', default: '' },
   '--events': { type: 'string', default: '' },
   '--dry-run': { type: 'boolean', default: false },
@@ -1645,8 +1646,16 @@ const TOKEN_COST_HARVEST_FLAG_SPEC = {
 function printHelp() {
   process.stdout.write(`Usage:
   node scripts/token-cost-harvest.mjs --repo <owner>/<repo> [--out <path>] [--events <path>] [--dry-run]
+  node scripts/token-cost-harvest.mjs --owner <owner> --repo <repo> [--out <path>] [--events <path>] [--dry-run]
 
-  --repo <owner>/<repo>         Repository to join harvested sessions against. Required.
+  --repo <owner>/<repo>         Repository to join harvested sessions against.
+                                Required: either the combined <owner>/<repo>
+                                form alone, or the bare <repo> name paired
+                                with --owner.
+  --owner <owner>               Repository owner, split form (pair with
+                                --repo <repo>, the bare repository name --
+                                not both --owner and a combined --repo
+                                together).
   --out <path>                 Output samples JSONL path (default:
                                 ${defaultStateDir()}/samples.jsonl).
   --events <path>               Phase-event JSONL path (default:
@@ -1715,7 +1724,18 @@ function runCli(argv) {
     printHelp();
     return;
   }
-  const repoFlag = values.repo;
+  let repoFlag;
+  try {
+    repoFlag =
+      combineOwnerRepoFlags({
+        owner: values.owner,
+        repo: values.repo,
+      }) ?? '';
+  } catch (error) {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 2;
+    return;
+  }
   const parsedRepo = parseRepoFlag(repoFlag);
   if (!parsedRepo) {
     process.stderr.write(

--- a/src/scripts/audit-pr-cleanup.mts
+++ b/src/scripts/audit-pr-cleanup.mts
@@ -16,7 +16,7 @@ import {
   readForcedHandoffAuthorityPolicy,
   readForcedHandoffMode,
 } from './collaborator-permission.mts';
-import { ghText } from './gh-exec.mts';
+import { combineOwnerRepoFlags, ghText } from './gh-exec.mts';
 import { resolveCollaboratorMarkerTrust } from './policy-helpers.mts';
 import type { ClaimValidationSummary } from './protocol-helpers.mts';
 import {
@@ -195,6 +195,7 @@ export interface CleanupArgs {
   pr?: string;
   prs?: string;
   repo?: string;
+  owner?: string;
   dryRun?: boolean;
   apply?: boolean;
   claimIssue?: string;
@@ -222,6 +223,7 @@ const AUDIT_PR_CLEANUP_FLAG_SPEC = {
   '--pr': { type: 'string' },
   '--prs': { type: 'string' },
   '--repo': { type: 'string' },
+  '--owner': { type: 'string' },
   '--dry-run': { type: 'boolean', default: false },
   '--apply': { type: 'boolean', default: false },
   '--format': { type: 'string', default: 'json' },
@@ -313,7 +315,12 @@ async function main(): Promise<void> {
 
   assertBatchApplyClaimScope(args);
 
-  const repository = args.repo ?? detectRepository();
+  let repository: string;
+  try {
+    repository = combineOwnerRepoFlags(args) ?? detectRepository();
+  } catch (error) {
+    fail((error as Error).message);
+  }
   const [owner, repo] = parseRepository(repository);
 
   const prNumbers = parsePrNumbers(args);
@@ -1985,6 +1992,7 @@ function parseArgs(argv: string[]): CleanupArgs {
   const pr = requireNonEmpty(values.pr as string | undefined, '--pr');
   const prs = requireNonEmpty(values.prs as string | undefined, '--prs');
   const repo = requireNonEmpty(values.repo as string | undefined, '--repo');
+  const owner = requireNonEmpty(values.owner as string | undefined, '--owner');
   const format = requireNonEmpty(values.format as string, '--format') as string;
   if (!['json', 'table'].includes(format)) {
     fail('--format must be json or table');
@@ -2008,6 +2016,7 @@ function parseArgs(argv: string[]): CleanupArgs {
     pr,
     prs,
     repo,
+    owner,
     dryRun: values['dry-run'] as boolean,
     apply: values.apply as boolean,
     claimIssue,
@@ -2039,7 +2048,11 @@ Options:
   --claim-id <id>                   active claim id required for apply mode
   --agent-id <id>                   optionally require this claim agent id
   --skip-claim-check                explicit maintainer override for apply mode
-  --repo <owner/name>               repository override
+  --repo <owner/name>               repository override, combined form
+  --owner <owner>                   repository override, split form (use
+                                     with --repo <name>, the bare
+                                     repository name -- not both --owner
+                                     and a combined --repo together)
   --format <json|table>             output format (default: json)
   --help                            show this help
 

--- a/src/scripts/gh-exec.mts
+++ b/src/scripts/gh-exec.mts
@@ -300,6 +300,58 @@ export function resolveGhApiHostname(
 }
 
 /**
+ * #2454: the majority of `src/scripts/*.mts` accept a split `--owner
+ * <owner> --repo <name>` pair; five scripts (`audit-pr-cleanup.mts`,
+ * `live-status-digest.mts`, `token-cost-harvest.mts`,
+ * `local-validation-evidence.mts`, `provider-outage-declaration.mts`)
+ * instead accept only a combined `--repo <owner>/<name>`. Rewriting the
+ * majority onto the combined form (or vice versa) is out of scope; this
+ * helper lets the five minority scripts accept EITHER form while
+ * changing nothing else about their own resolution pipeline: it folds a
+ * split pair into the single combined string each script's own existing
+ * parser (or default-repo fallback) already consumes, so a caller only
+ * has to route its `--owner`/`--repo` flags through this function once,
+ * immediately after `parseCliArgs`, and every downstream line is
+ * unchanged.
+ *
+ * - Neither flag given → returns `args.repo` unchanged (`undefined` or
+ *   the caller's own empty-string default), so the caller's existing
+ *   default-repo resolution (a `gh repo view` fallback, or a hard
+ *   "--repo is required" error, depending on the script) still runs
+ *   exactly as before.
+ * - Only `--repo` given → returned unchanged, whether it is already the
+ *   combined `owner/name` form (the pre-existing, still-supported case)
+ *   or some other value the caller's own parser will accept or reject.
+ * - Only `--owner` given → combined with `--repo` (which must be the
+ *   bare name, no `/`) into `owner/name`. Throws when `--repo` is
+ *   missing (an owner alone cannot resolve a repository) or already
+ *   contains a `/` (mixing both forms is ambiguous, not a genuine
+ *   split-form name) — a specific, actionable error instead of letting
+ *   a double-prefixed value reach `gh api` and 404 downstream.
+ */
+export function combineOwnerRepoFlags(args: {
+  owner?: string;
+  repo?: string;
+}): string | undefined {
+  if (!args.owner) {
+    return args.repo;
+  }
+  if (args.repo?.includes('/')) {
+    throw new Error(
+      `--owner and a combined --repo "${args.repo}" conflict -- pass ` +
+        'either --repo <owner>/<name> alone or --owner <owner> --repo ' +
+        '<name>, not both forms together',
+    );
+  }
+  if (!args.repo) {
+    throw new Error(
+      '--owner requires --repo <name> (the bare repository name)',
+    );
+  }
+  return `${args.owner}/${args.repo}`;
+}
+
+/**
  * Run `gh api <path>` and parse its output as JSON, optionally paginating
  * (NDJSON-compatible) and/or tolerating specific failure statuses.
  *

--- a/src/scripts/live-status-digest.mts
+++ b/src/scripts/live-status-digest.mts
@@ -15,6 +15,7 @@ import {
   readForcedHandoffMode,
 } from './collaborator-permission.mts';
 import {
+  combineOwnerRepoFlags,
   DEFAULT_GH_PAGINATED_TIMEOUT_MS,
   ghApiJson,
   ghText,
@@ -55,6 +56,7 @@ interface LiveStatusDigestArgs {
   issue?: string;
   pr?: string;
   repo?: string;
+  owner?: string;
   dryRun?: boolean;
   apply?: boolean;
   phase?: string;
@@ -80,6 +82,7 @@ const LIVE_STATUS_DIGEST_FLAG_SPEC = {
   '--issue': { type: 'string' },
   '--pr': { type: 'string' },
   '--repo': { type: 'string' },
+  '--owner': { type: 'string' },
   '--dry-run': { type: 'boolean', default: false },
   '--apply': { type: 'boolean', default: false },
   '--phase': { type: 'string' },
@@ -182,7 +185,12 @@ function main(): void {
     );
   }
 
-  const repository = args.repo ?? detectRepository();
+  let repository: string;
+  try {
+    repository = combineOwnerRepoFlags(args) ?? detectRepository();
+  } catch (error) {
+    fail((error as Error).message);
+  }
   const [owner, repo] = parseRepository(repository);
   const targetType = args.issue ? 'issue' : 'pr';
   const targetNumber = parsePositiveInteger(
@@ -755,6 +763,7 @@ function parseArgs(argv: string[]): LiveStatusDigestArgs {
     issue: requireNonEmpty(values.issue as string | undefined, '--issue'),
     pr: requireNonEmpty(values.pr as string | undefined, '--pr'),
     repo: requireNonEmpty(values.repo as string | undefined, '--repo'),
+    owner: requireNonEmpty(values.owner as string | undefined, '--owner'),
     dryRun: values['dry-run'] as boolean,
     apply: values.apply as boolean,
     phase: requireNonEmpty(values.phase as string | undefined, '--phase'),
@@ -838,7 +847,11 @@ Options:
   --claim-id <id>                   active claim id required for apply mode
   --agent-id <id>                   optionally require this claim agent id
   --skip-claim-check                explicit maintainer override for apply mode
-  --repo <owner/name>               repository override
+  --repo <owner/name>               repository override, combined form
+  --owner <owner>                   repository override, split form (use
+                                     with --repo <name>, the bare
+                                     repository name -- not both --owner
+                                     and a combined --repo together)
   --format <json|table>             output format (default: json)
   --include-body                    include the rendered body in JSON reports
   --help                            show this help

--- a/src/scripts/local-validation-evidence.mts
+++ b/src/scripts/local-validation-evidence.mts
@@ -29,6 +29,7 @@ import {
   resolveCollaboratorAuthority,
 } from './external-check-waiver.mts';
 import {
+  combineOwnerRepoFlags,
   DEFAULT_GH_PAGINATED_TIMEOUT_MS,
   ghText,
   safeGhText,
@@ -314,6 +315,7 @@ interface LocalValidationEvidenceArgs {
   targetIssue: number;
   actor: string;
   repo: string;
+  owner: string;
   apply: boolean;
   format: string;
   help: boolean;
@@ -331,6 +333,7 @@ const LOCAL_VALIDATION_EVIDENCE_FLAG_SPEC = {
   '--target-issue': { type: 'string', default: '' },
   '--actor': { type: 'string', default: '' },
   '--repo': { type: 'string', default: '' },
+  '--owner': { type: 'string', default: '' },
   '--apply': { type: 'boolean', default: false },
   '--format': { type: 'string', default: 'json' },
   '--help': { type: 'boolean', short: 'h' },
@@ -384,7 +387,12 @@ export function parseArgs(argv: string[]): LocalValidationEvidenceArgs {
             '--target-issue',
           ),
     actor: (values.actor as string).trim(),
-    repo: (values.repo as string).trim(),
+    repo:
+      combineOwnerRepoFlags({
+        owner: (values.owner as string).trim(),
+        repo: (values.repo as string).trim(),
+      }) ?? '',
+    owner: (values.owner as string).trim(),
     apply: values.apply as boolean,
     format,
     help,
@@ -646,7 +654,11 @@ Options:
   --service <name>                   outage-declaration service to require active (default: ci-actions)
   --target-issue <number>           override providerOutage.declarationTarget
   --actor <login>                   override the GitHub actor used for --record
-  --repo <owner/name>               repository override
+  --repo <owner/name>               repository override, combined form
+  --owner <owner>                   repository override, split form (use
+                                     with --repo <name>, the bare
+                                     repository name -- not both --owner
+                                     and a combined --repo together)
   --apply                           post the canonical marker comment after validation (--record)
   --format <json|text>              output format (default: json)
   --help                            show this message

--- a/src/scripts/provider-outage-declaration.mts
+++ b/src/scripts/provider-outage-declaration.mts
@@ -30,6 +30,7 @@ import {
   resolveCollaboratorAuthority,
 } from './external-check-waiver.mts';
 import {
+  combineOwnerRepoFlags,
   DEFAULT_GH_PAGINATED_TIMEOUT_MS,
   ghText,
   safeGhText,
@@ -408,6 +409,7 @@ interface ProviderOutageDeclarationArgs {
   targetIssue: number;
   actor: string;
   repo: string;
+  owner: string;
   apply: boolean;
   yes: boolean;
   format: string;
@@ -426,6 +428,7 @@ const PROVIDER_OUTAGE_DECLARATION_FLAG_SPEC = {
   '--target-issue': { type: 'string', default: '' },
   '--actor': { type: 'string', default: '' },
   '--repo': { type: 'string', default: '' },
+  '--owner': { type: 'string', default: '' },
   '--apply': { type: 'boolean', default: false },
   '--yes': { type: 'boolean', default: false },
   '--format': { type: 'string', default: 'json' },
@@ -485,7 +488,12 @@ export function parseArgs(argv: string[]): ProviderOutageDeclarationArgs {
             '--target-issue',
           ),
     actor: (values.actor as string).trim(),
-    repo: (values.repo as string).trim(),
+    repo:
+      combineOwnerRepoFlags({
+        owner: (values.owner as string).trim(),
+        repo: (values.repo as string).trim(),
+      }) ?? '',
+    owner: (values.owner as string).trim(),
     apply: values.apply as boolean,
     yes: values.yes as boolean,
     format,
@@ -896,7 +904,11 @@ Options:
   --head-sha <40-hex>                pull request HEAD SHA (--record-advanced)
   --target-issue <number>           override providerOutage.declarationTarget
   --actor <login>                   override the GitHub actor used for authority evaluation
-  --repo <owner/name>               repository override
+  --repo <owner/name>               repository override, combined form
+  --owner <owner>                   repository override, split form (use
+                                     with --repo <name>, the bare
+                                     repository name -- not both --owner
+                                     and a combined --repo together)
   --apply                           post the canonical marker comment after validation
   --yes                             skip the interactive apply confirmation
   --format <json|text>              output format (default: json)

--- a/src/scripts/token-cost-harvest.mts
+++ b/src/scripts/token-cost-harvest.mts
@@ -26,7 +26,7 @@ import { homedir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 
 import { parseCliArgs } from './cli-args.mts';
-import { ghGraphql } from './gh-exec.mts';
+import { combineOwnerRepoFlags, ghGraphql } from './gh-exec.mts';
 import {
   parseClaimComment,
   parseForcedHandoffComment,
@@ -1922,6 +1922,7 @@ function defaultStateDir(): string {
 // module header for the full invariant.
 const TOKEN_COST_HARVEST_FLAG_SPEC = {
   '--repo': { type: 'string', default: '' },
+  '--owner': { type: 'string', default: '' },
   '--out': { type: 'string', default: '' },
   '--events': { type: 'string', default: '' },
   '--dry-run': { type: 'boolean', default: false },
@@ -1932,8 +1933,16 @@ const TOKEN_COST_HARVEST_FLAG_SPEC = {
 function printHelp(): void {
   process.stdout.write(`Usage:
   node scripts/token-cost-harvest.mjs --repo <owner>/<repo> [--out <path>] [--events <path>] [--dry-run]
+  node scripts/token-cost-harvest.mjs --owner <owner> --repo <repo> [--out <path>] [--events <path>] [--dry-run]
 
-  --repo <owner>/<repo>         Repository to join harvested sessions against. Required.
+  --repo <owner>/<repo>         Repository to join harvested sessions against.
+                                Required: either the combined <owner>/<repo>
+                                form alone, or the bare <repo> name paired
+                                with --owner.
+  --owner <owner>               Repository owner, split form (pair with
+                                --repo <repo>, the bare repository name --
+                                not both --owner and a combined --repo
+                                together).
   --out <path>                 Output samples JSONL path (default:
                                 ${defaultStateDir()}/samples.jsonl).
   --events <path>               Phase-event JSONL path (default:
@@ -2014,7 +2023,18 @@ function runCli(argv: string[]): void {
     printHelp();
     return;
   }
-  const repoFlag = values.repo as string;
+  let repoFlag: string;
+  try {
+    repoFlag =
+      combineOwnerRepoFlags({
+        owner: values.owner as string,
+        repo: values.repo as string,
+      }) ?? '';
+  } catch (error) {
+    process.stderr.write(`${(error as Error).message}\n`);
+    process.exitCode = 2;
+    return;
+  }
   const parsedRepo = parseRepoFlag(repoFlag);
   if (!parsedRepo) {
     process.stderr.write(

--- a/tests/gh-exec.test.mts
+++ b/tests/gh-exec.test.mts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { test } from 'node:test';
 
 import {
+  combineOwnerRepoFlags,
   DEFAULT_GH_PAGINATED_TIMEOUT_MS,
   DEFAULT_GH_TIMEOUT_MS,
   GH_TEXT_LOOP_OPTIONS,
@@ -889,4 +890,60 @@ process.exit(1);
   } finally {
     restore();
   }
+});
+
+// #2454: combineOwnerRepoFlags lets the five combined-only scripts also
+// accept the majority's split --owner/--repo form without changing their
+// own downstream parser/default-resolution pipeline -- it only folds a
+// split pair into the single combined string that pipeline already
+// consumes unchanged.
+test('combineOwnerRepoFlags: neither flag given returns repo unchanged (undefined)', () => {
+  assert.equal(combineOwnerRepoFlags({}), undefined);
+});
+
+test('combineOwnerRepoFlags: neither flag given returns repo unchanged (empty-string default)', () => {
+  // Mirrors token-cost-harvest.mts / local-validation-evidence.mts /
+  // provider-outage-declaration.mts's own `{ type: 'string', default: '' }`
+  // CLI spec -- their existing "neither given" behavior (a required-flag
+  // error, or a gh-view fallback) must see this same empty string.
+  assert.equal(combineOwnerRepoFlags({ repo: '' }), '');
+});
+
+test('combineOwnerRepoFlags: combined form (--repo owner/name alone) is returned unchanged', () => {
+  assert.equal(
+    combineOwnerRepoFlags({ repo: 'kurone-kito/idd-skill' }),
+    'kurone-kito/idd-skill',
+  );
+});
+
+test('combineOwnerRepoFlags: split form (--owner + bare --repo) combines into owner/name', () => {
+  assert.equal(
+    combineOwnerRepoFlags({ owner: 'kurone-kito', repo: 'idd-skill' }),
+    'kurone-kito/idd-skill',
+  );
+});
+
+test('combineOwnerRepoFlags: --owner with a slash-containing --repo throws a specific conflict error', () => {
+  assert.throws(
+    () =>
+      combineOwnerRepoFlags({
+        owner: 'kurone-kito',
+        repo: 'kurone-kito/idd-skill',
+      }),
+    /--owner and a combined --repo "kurone-kito\/idd-skill" conflict/,
+  );
+});
+
+test('combineOwnerRepoFlags: --owner without --repo throws (an owner alone cannot resolve a repository)', () => {
+  assert.throws(
+    () => combineOwnerRepoFlags({ owner: 'kurone-kito' }),
+    /--owner requires --repo <name>/,
+  );
+});
+
+test('combineOwnerRepoFlags: --owner with an empty-string --repo throws the same missing-repo error', () => {
+  assert.throws(
+    () => combineOwnerRepoFlags({ owner: 'kurone-kito', repo: '' }),
+    /--owner requires --repo <name>/,
+  );
 });


### PR DESCRIPTION
# Summary

`audit-pr-cleanup.mjs`, `live-status-digest.mjs`, `token-cost-harvest.mjs`,
`local-validation-evidence.mjs`, and `provider-outage-declaration.mjs`
previously accepted only a combined `--repo <owner>/<name>` flag, unlike
the ~24 majority helper scripts that accept a split `--owner <owner>
--repo <name>` pair. This shape mismatch has repeatedly caused silent
double-prefixed 404s when a caller guessed the wrong form, and had
already been separately documented as a gotcha twice in this
repository's own dogfooding retros.

This PR adds a shared `combineOwnerRepoFlags()` helper to `gh-exec.mts`
and wires it into all 5 scripts so each now accepts EITHER form and
resolves to the identical `{owner, repo}` pair, with a specific
conflict error (not a generic 404) when both forms are passed together.
Each script's `--help` text now documents both accepted forms; the
neither-given default-repo resolution is unchanged.

## Linked issue

Closes #2454

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

See issue #2454's Background section for the two prior real-world
incidents this fixes (a `disposition-non-review-notices.mjs`-adjacent
guess and a `suitability-triage.mjs`-adjacent guess, both against the
combined-only minority scripts).

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed