### PR TITLE
docs(idd-workflow): document an external-signal entry path

### DIFF
--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -480,6 +480,33 @@ enumeration, but it still applies targeted readiness checks, the A4
 viability gate, and the A4.5 suitability gate before the normal A5 claim
 safety checks.
 
+## External-signal entry path
+
+The Discover -> Claim -> Work loop above only reads issues already
+present in the tracker. A repository fed by an external signal source
+(error tracker, alert, support intake) needs a distinct on-ramp into
+issue-authoring before that loop ever sees anything.
+
+1. **Triage** (optional, agent-local): classify the incoming signal and
+   dedupe it against existing open issues or roadmap nodes before
+   drafting anything new. IDD does not define this stage's tooling — a
+   webhook receiver, a scheduled poll, or a manual review are all
+   equally valid, repository- or agent-specific integrations.
+2. **Hand off to issue-authoring**: once a signal survives triage as a
+   genuinely new, actionable item, feed its content to
+   `skills/issue-authoring/` the same way a human-authored idea would
+   be (see
+   [Artifact taxonomy and ownership](#artifact-taxonomy-and-ownership)
+   above). The skill produces a normal, schema-conformant IDD issue.
+3. **Rejoin the normal loop**: the produced issue is claimable by
+   Discover like any other issue — nothing about its external origin is
+   visible to A0-A5.
+
+Because the triage stage is optional and agent-local, an issue produced
+this way must never cite the triage tooling itself as a completion
+dependency: its acceptance criteria stay implementable by any agent,
+including one lacking that specific integration.
+
 ## Issue-author approval contract
 
 Repositories may also keep a secure-by-default issue-author approval

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -477,7 +477,7 @@ issue-authoring before that loop ever sees anything.
 2. **Hand off to issue-authoring**: once a signal survives triage as a
    genuinely new, actionable item, feed its content to the
    `issue-authoring` companion the same way a human-authored idea
-   would be, if your repository has installed one (see
+   would be if your repository has installed one (see
    [Artifact taxonomy and ownership](#artifact-taxonomy-and-ownership)
    above). The companion produces a normal, schema-conformant IDD
    issue.

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -477,7 +477,7 @@ issue-authoring before that loop ever sees anything.
 2. **Hand off to issue-authoring**: once a signal survives triage as a
    genuinely new, actionable item, feed its content to the
    `issue-authoring` companion the same way a human-authored idea
-   would be, when your repository has installed one (see
+   would be, if your repository has installed one (see
    [Artifact taxonomy and ownership](#artifact-taxonomy-and-ownership)
    above). The companion produces a normal, schema-conformant IDD
    issue.

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -462,6 +462,34 @@ enumeration, but it still applies targeted readiness checks, the A4
 viability gate, and the A4.5 suitability gate before the normal A5 claim
 safety checks.
 
+## External-signal entry path
+
+The Discover -> Claim -> Work loop above only reads issues already
+present in your tracker. A repository fed by an external signal source
+(error tracker, alert, support intake) needs a distinct on-ramp into
+issue-authoring before that loop ever sees anything.
+
+1. **Triage** (optional, agent-local): classify the incoming signal and
+   dedupe it against existing open issues or roadmap nodes before
+   drafting anything new. IDD does not define this stage's tooling — a
+   webhook receiver, a scheduled poll, or a manual review are all
+   equally valid, repository- or agent-specific integrations.
+2. **Hand off to issue-authoring**: once a signal survives triage as a
+   genuinely new, actionable item, feed its content to the
+   `issue-authoring` companion the same way a human-authored idea
+   would be, when your repository has installed one (see
+   [Artifact taxonomy and ownership](#artifact-taxonomy-and-ownership)
+   above). The companion produces a normal, schema-conformant IDD
+   issue.
+3. **Rejoin the normal loop**: the produced issue is claimable by
+   Discover like any other issue — nothing about its external origin is
+   visible to A0-A5.
+
+Because the triage stage is optional and agent-local, an issue produced
+this way must never cite the triage tooling itself as a completion
+dependency: its acceptance criteria stay implementable by any agent,
+including one lacking that specific integration.
+
 ## Issue-author approval contract
 
 Repositories may also keep a secure-by-default issue-author approval


### PR DESCRIPTION
## Summary

`docs/idd-workflow.md` had no documented on-ramp for a repository fed by
an external signal source (error tracker, alert, support intake) into
issue-authoring -- only the internal Discover-to-claim-to-work loop was
documented.

- New "External-signal entry path" subsection (placed after "Artifact
  taxonomy and ownership", before "Issue-author approval contract" --
  same heading position in both the root and template files) describing
  a triage stage before Discover: classify/dedupe the incoming signal,
  then hand it to issue-authoring to produce a normal IDD-ready issue
  the loop can claim.
- The triage tooling itself is explicitly optional/agent-local, so an
  issue produced this way stays implementable by any agent lacking that
  specific integration -- its acceptance criteria never cite the triage
  tooling as a completion dependency.
- Written as two versions matching this file's existing structure/
  contains sync mode: the root version keeps source-repo-specific
  wording (`skills/issue-authoring/`, "the repository"), the template
  version uses adopter-facing wording (the `issue-authoring` companion,
  "your repository") consistent with the surrounding sections' existing
  phrasing split.

## Test plan

- [x] `node scripts/audit-docs.mjs --check` passes
- [x] Heading structure matches exactly between the root and template
      files (`diff <(grep '^## ' ...)` on both -- empty diff)
- [x] `dprint check`, `markdownlint-cli2` (validates the internal
      `#artifact-taxonomy-and-ownership` anchor link), `cspell lint`,
      `node scripts/audit-code-span-wrap.mjs` all clean

Closes #2481

https://claude.ai/code/session_01Smou8PbTPvD32SMHkfvEia