### PR TITLE
docs(issue-authoring): warn against same-shape follow-up chains

### DIFF
--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -265,9 +265,9 @@ resolves the same way.
 
 **Same-shape follow-up chains.** A different case from both checks
 above: an issue whose own acceptance criteria explicitly ask for a
-follow-up issue with the same acceptance shape when the round does not
-fully complete (a "retry again with the same criteria" pattern, e.g. an
-iterative measurement or convergence task). Before drafting such a
+follow-up issue with the same acceptance criteria when the round does
+not fully complete (a "retry again" pattern, e.g. an iterative
+measurement or convergence task). Before drafting such a
 same-shape successor, state what measurable forward progress the
 just-completed round achieved — a changed metric, a narrowed diagnosis,
 a newly tested hypothesis, a newly-discovered and now-fixed blocker.

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -266,11 +266,11 @@ resolves the same way.
 **Same-shape follow-up chains.** A different case from both checks
 above: an issue whose own acceptance criteria explicitly ask for a
 follow-up issue with the same acceptance criteria when the round does
-not fully complete (a "retry again" pattern, e.g. an iterative
+not fully complete (a "retry again" pattern, e.g., an iterative
 measurement or convergence task). Before drafting such a
 same-shape successor, state what measurable forward progress the
 just-completed round achieved — a changed metric, a narrowed diagnosis,
-a newly tested hypothesis, a newly-discovered and now-fixed blocker.
+a newly-tested hypothesis, a newly-discovered and now-fixed blocker.
 When the round produced no such signal (the same result, the same
 diagnosis, no new information beyond the predecessor), route to
 `needs-decision` (or an equivalent hold) instead of authoring another

--- a/.claude/skills/issue-authoring/references/contract.md
+++ b/.claude/skills/issue-authoring/references/contract.md
@@ -263,6 +263,23 @@ after claim — this scan only adds an earlier, pre-publish checkpoint.
 A fast enough race can still surface even after B2.0; when it does, it
 resolves the same way.
 
+**Same-shape follow-up chains.** A different case from both checks
+above: an issue whose own acceptance criteria explicitly ask for a
+follow-up issue with the same acceptance shape when the round does not
+fully complete (a "retry again with the same criteria" pattern, e.g. an
+iterative measurement or convergence task). Before drafting such a
+same-shape successor, state what measurable forward progress the
+just-completed round achieved — a changed metric, a narrowed diagnosis,
+a newly tested hypothesis, a newly-discovered and now-fixed blocker.
+When the round produced no such signal (the same result, the same
+diagnosis, no new information beyond the predecessor), route to
+`needs-decision` (or an equivalent hold) instead of authoring another
+identical-shape issue, and record why the chain paused so a later
+session or human can see the reasoning. This is a sibling check, not a
+replacement: the checks above guard against an accidental duplicate;
+this guards against a correct-but-repeated pattern continuing past the
+point it stops being useful.
+
 ## Output chooser
 
 Choose the smallest safe output shape:

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -265,9 +265,9 @@ resolves the same way.
 
 **Same-shape follow-up chains.** A different case from both checks
 above: an issue whose own acceptance criteria explicitly ask for a
-follow-up issue with the same acceptance shape when the round does not
-fully complete (a "retry again with the same criteria" pattern, e.g. an
-iterative measurement or convergence task). Before drafting such a
+follow-up issue with the same acceptance criteria when the round does
+not fully complete (a "retry again" pattern, e.g. an iterative
+measurement or convergence task). Before drafting such a
 same-shape successor, state what measurable forward progress the
 just-completed round achieved — a changed metric, a narrowed diagnosis,
 a newly tested hypothesis, a newly-discovered and now-fixed blocker.

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -266,11 +266,11 @@ resolves the same way.
 **Same-shape follow-up chains.** A different case from both checks
 above: an issue whose own acceptance criteria explicitly ask for a
 follow-up issue with the same acceptance criteria when the round does
-not fully complete (a "retry again" pattern, e.g. an iterative
+not fully complete (a "retry again" pattern, e.g., an iterative
 measurement or convergence task). Before drafting such a
 same-shape successor, state what measurable forward progress the
 just-completed round achieved — a changed metric, a narrowed diagnosis,
-a newly tested hypothesis, a newly-discovered and now-fixed blocker.
+a newly-tested hypothesis, a newly-discovered and now-fixed blocker.
 When the round produced no such signal (the same result, the same
 diagnosis, no new information beyond the predecessor), route to
 `needs-decision` (or an equivalent hold) instead of authoring another

--- a/skills/issue-authoring/references/contract.md
+++ b/skills/issue-authoring/references/contract.md
@@ -263,6 +263,23 @@ after claim — this scan only adds an earlier, pre-publish checkpoint.
 A fast enough race can still surface even after B2.0; when it does, it
 resolves the same way.
 
+**Same-shape follow-up chains.** A different case from both checks
+above: an issue whose own acceptance criteria explicitly ask for a
+follow-up issue with the same acceptance shape when the round does not
+fully complete (a "retry again with the same criteria" pattern, e.g. an
+iterative measurement or convergence task). Before drafting such a
+same-shape successor, state what measurable forward progress the
+just-completed round achieved — a changed metric, a narrowed diagnosis,
+a newly tested hypothesis, a newly-discovered and now-fixed blocker.
+When the round produced no such signal (the same result, the same
+diagnosis, no new information beyond the predecessor), route to
+`needs-decision` (or an equivalent hold) instead of authoring another
+identical-shape issue, and record why the chain paused so a later
+session or human can see the reasoning. This is a sibling check, not a
+replacement: the checks above guard against an accidental duplicate;
+this guards against a correct-but-repeated pattern continuing past the
+point it stops being useful.
+
 ## Output chooser
 
 Choose the smallest safe output shape:


### PR DESCRIPTION
# Summary

Neither the issue-authoring skill's reuse-first policy nor its
recent-window scan covers an issue whose own acceptance criteria
explicitly ask for a same-shape successor when a round doesn't fully
complete -- a "retry again with the same criteria" pattern that is
correct behavior but can repeat past the point it stops helping.

## Linked issue

Closes #2448

## Follow-up issues (if any)

- [ ] none

## Background / rationale (if material)

Added a short "Same-shape follow-up chains" paragraph to
`skills/issue-authoring/references/contract.md`'s "Reuse-first issue
policy" section, immediately after the existing "Recent-window scan"
guidance and before "## Output chooser" -- explicitly scoped as a
sibling check, not a replacement, per the issue's own scope
constraint. It requires stating what measurable forward progress the
just-completed round achieved before authoring a same-shape
successor, and routes to `needs-decision` (reusing the existing
bucket already defined earlier in the same file) when there is no
such signal.

Regenerated the mirror at
`.claude/skills/issue-authoring/references/contract.md` via
`node scripts/sync-docs.mjs --apply` (byte-identical) and confirmed
`node scripts/audit-docs.mjs --check` reports no drift.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test` (4828/4828 pass)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [ ] `node scripts/idd-doctor.mjs` (if applicable) -- not applicable,
      docs-only change
- [x] `node scripts/audit-code-span-wrap.mjs`

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed (none)
- [x] Context budget impact reviewed (none -- additive, non-instruction docs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for managing follow-up issue chains with unchanged acceptance criteria.
  * Requires documenting measurable progress or new information before creating an identical successor issue.
  * Provides a hold or decision-needed path when no progress is available, including recording the reason for pausing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->