### PR TITLE
docs(idd-suitability): document an optional grooming-pass workflow

### DIFF
--- a/.github/instructions/idd-suitability.instructions.md
+++ b/.github/instructions/idd-suitability.instructions.md
@@ -261,3 +261,14 @@ tradeoff, classify as `needs-decision` rather than PASS.
 
 After A4.5 passes, proceed to `idd-claim.instructions.md`; for rejected
 candidates follow the Failure Outcomes section above.
+
+## Optional: grooming a rejected/below-floor backlog
+
+A4.5 decides only at claim time; it never revisits a past rejection.
+An optional, human-initiated Groom phase for periodically
+batch-reviewing the rejected/below-floor backlog -- classifying each
+candidate execution-blocked / decision-blocked / fact-blocked,
+re-checking whether a cited blocker has since closed, and applying the
+operator's answers back onto the issue rather than resolving a
+deliberate decision unilaterally -- is documented in
+[the IDD workflow guide](../../docs/idd-workflow.md#grooming-pass-for-rejected-and-below-floor-issues-optional).

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -524,6 +524,64 @@ for labels, comment-and-stop defaults, and close boundaries:
 - configured ready-label approval ownership is separate from trusted
   marker actor authority for operational claim/review markers.
 
+## Grooming pass for rejected and below-floor issues (optional)
+
+A4.5 rejections and below-floor autopilot-suitability scores
+accumulate into a backlog that ordinary Discover never revisits on its
+own. An optional, human-initiated **Groom** phase lets an operator
+batch-review that backlog and clear entries whose blocker has become
+answerable. This is distinct from durably recording a rejection so it
+does not silently resurface (a separate concern already tracked as
+issue #2243) -- grooming is about _reversing_ a rejection later, once
+circumstances change.
+
+**Classify before spending operator time.** Sort each candidate into
+one of three buckets:
+
+- **execution-blocked** -- no operator input helps; only further agent
+  work can resolve it. Leave these for Discover/Claim to pick up
+  normally once unblocked.
+- **decision-blocked** -- a genuine human call is required (a product
+  tradeoff, an ambiguous acceptance criterion, an already-recorded
+  policy choice). A bounded question set can resolve these.
+- **fact-blocked** -- the rejection cited a fact (a dependency, a
+  blocking issue) that may no longer hold.
+
+**Re-check facts before drafting a question.** For a fact-blocked
+candidate, check whether any issue or PR the original rejection cited
+as a blocker has since closed or merged -- a cached readiness snapshot
+can be stale, and a closed blocker is a "free" suitability lever that
+costs nothing to re-apply.
+
+**Never override a deliberate decision.** When the original rejection
+recorded a genuinely deliberate empirical or product decision (not
+merely an unanswered question), grooming must never resolve it
+unilaterally. Offer "keep the existing decision" as one of the
+operator's own answer choices instead.
+
+**Explain before asking.** Give the operator the background and
+tradeoffs behind each question before asking it, rather than bundling
+several unrelated technical topics into one dense batch.
+
+**Apply the operator's answers back onto the issue**: update the score
+footer, remove or update the `triage:{outcome}` label, revise
+acceptance criteria to reflect the decision, and record the decision in
+a comment. The next ordinary Discover pass then picks the issue up
+normally -- grooming itself never claims or works the issue (see
+[Mutation Policy and Coordination Rule](../.github/instructions/idd-suitability.instructions.md#mutation-policy-and-coordination-rule)).
+
+**Worked example.** An issue was rejected `needs-decision` at score
+`2/5` because its acceptance criteria read "add caching, or document
+why caching is unsafe here" -- an unresolved subjective call under
+A4.5's escape-hatch guidance. Grooming classifies it decision-blocked,
+explains the caching-correctness-vs-simplicity tradeoff, and asks the
+operator to choose between TTL-based expiry and explicit
+invalidation-on-write. After the operator picks TTL-based expiry, the
+acceptance criteria are rewritten to "cache reads for up to 60 seconds
+via TTL-based expiry; no explicit invalidation path is required", the
+score footer is raised to `4/5`, and the `triage:needs-decision` label
+is removed with a comment recording the decision and its rationale.
+
 ## Roadmap completion audits
 
 Discover owns roadmap-level state. After it finds an open roadmap, it

--- a/idd-template/.github/instructions/idd-suitability.instructions.md
+++ b/idd-template/.github/instructions/idd-suitability.instructions.md
@@ -256,3 +256,14 @@ tradeoff, classify as `needs-decision` rather than PASS.
 
 After A4.5 passes, proceed to `idd-claim.instructions.md`; for rejected
 candidates follow the Failure Outcomes section above.
+
+## Optional: grooming a rejected/below-floor backlog
+
+A4.5 decides only at claim time; it never revisits a past rejection.
+An optional, human-initiated Groom phase for periodically
+batch-reviewing the rejected/below-floor backlog -- classifying each
+candidate execution-blocked / decision-blocked / fact-blocked,
+re-checking whether a cited blocker has since closed, and applying the
+operator's answers back onto the issue rather than resolving a
+deliberate decision unilaterally -- is documented in
+[the IDD workflow guide](../../docs/idd-workflow.md#grooming-pass-for-rejected-and-below-floor-issues-optional).

--- a/idd-template/docs/idd-workflow.md
+++ b/idd-template/docs/idd-workflow.md
@@ -506,6 +506,65 @@ for labels, comment-and-stop defaults, and close boundaries:
 - configured ready-label approval ownership is separate from trusted
   marker actor authority for operational claim/review markers.
 
+## Grooming pass for rejected and below-floor issues (optional)
+
+A4.5 rejections and below-floor autopilot-suitability scores
+accumulate into a backlog that ordinary Discover never revisits on its
+own. An optional, human-initiated **Groom** phase lets an operator
+batch-review that backlog and clear entries whose blocker has become
+answerable. This is distinct from durably recording a rejection so it
+does not silently resurface (a separate concern, tracked upstream as
+[kurone-kito/idd-skill#2243](https://github.com/kurone-kito/idd-skill/issues/2243)
+in the source repository) -- grooming is about _reversing_ a rejection
+later, once circumstances change.
+
+**Classify before spending operator time.** Sort each candidate into
+one of three buckets:
+
+- **execution-blocked** -- no operator input helps; only further agent
+  work can resolve it. Leave these for Discover/Claim to pick up
+  normally once unblocked.
+- **decision-blocked** -- a genuine human call is required (a product
+  tradeoff, an ambiguous acceptance criterion, an already-recorded
+  policy choice). A bounded question set can resolve these.
+- **fact-blocked** -- the rejection cited a fact (a dependency, a
+  blocking issue) that may no longer hold.
+
+**Re-check facts before drafting a question.** For a fact-blocked
+candidate, check whether any issue or PR the original rejection cited
+as a blocker has since closed or merged -- a cached readiness snapshot
+can be stale, and a closed blocker is a "free" suitability lever that
+costs nothing to re-apply.
+
+**Never override a deliberate decision.** When the original rejection
+recorded a genuinely deliberate empirical or product decision (not
+merely an unanswered question), grooming must never resolve it
+unilaterally. Offer "keep the existing decision" as one of the
+operator's own answer choices instead.
+
+**Explain before asking.** Give the operator the background and
+tradeoffs behind each question before asking it, rather than bundling
+several unrelated technical topics into one dense batch.
+
+**Apply the operator's answers back onto the issue**: update the score
+footer, remove or update the `triage:{outcome}` label, revise
+acceptance criteria to reflect the decision, and record the decision in
+a comment. The next ordinary Discover pass then picks the issue up
+normally -- grooming itself never claims or works the issue (see
+[Mutation Policy and Coordination Rule](../.github/instructions/idd-suitability.instructions.md#mutation-policy-and-coordination-rule)).
+
+**Worked example.** An issue was rejected `needs-decision` at score
+`2/5` because its acceptance criteria read "add caching, or document
+why caching is unsafe here" -- an unresolved subjective call under
+A4.5's escape-hatch guidance. Grooming classifies it decision-blocked,
+explains the caching-correctness-vs-simplicity tradeoff, and asks the
+operator to choose between TTL-based expiry and explicit
+invalidation-on-write. After the operator picks TTL-based expiry, the
+acceptance criteria are rewritten to "cache reads for up to 60 seconds
+via TTL-based expiry; no explicit invalidation path is required", the
+score footer is raised to `4/5`, and the `triage:needs-decision` label
+is removed with a comment recording the decision and its rationale.
+
 ## Roadmap completion audits
 
 Discover owns roadmap-level state. After it finds an open roadmap, it


### PR DESCRIPTION
# Summary

A4.5 has a one-time rejection gate and no documented recurring workflow
for an operator to batch-review the resulting backlog and reverse a
rejection once circumstances change. This documents a named, optional,
human-initiated Groom phase covering: the execution-blocked /
decision-blocked / fact-blocked classification, the closed-blocker
recheck rule, the never-override-a-deliberate-decision non-negotiable
(offered as an operator answer choice, never resolved unilaterally),
explain-before-asking guidance, and a worked before/after example
(score footer, label, and acceptance-criteria state).

The full procedure lives in `docs/idd-workflow.md` (and its
`idd-template/` canonical counterpart, worded generically for
adopters); `idd-suitability.instructions.md` gets only a short pointer
to keep `bundle-discovery`'s tight byte budget intact.

## Linked issue

Closes #2494

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

See issue #2494's Background section: adopters have independently
reinvented this technique across at least two sessions in this
repository, and this is a distinct, later point in an issue's lifecycle
from issue #2243 (making a rejection durably machine-visible so it
doesn't resurface).

## IDD impact

- [x] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed