### PR TITLE
docs(idd-pr-submit): extend change-class scoping discretion to D2

### DIFF
--- a/.github/instructions/idd-pr-submit.instructions.md
+++ b/.github/instructions/idd-pr-submit.instructions.md
@@ -111,6 +111,13 @@ here turns a confusing later failure into an immediate, recoverable signal.
 2. Run **pre-push-validate**.
 
    (E2E tests are verified by CI; do not run them locally.)
+
+   The same conservative scoping discretion as post-fix re-validation
+   (`idd-ci.instructions.md`'s Wake-up discipline) applies here: skip an
+   individual command in the chain only when the diff's changed paths
+   provably fall entirely outside that command's input surface, never
+   as a default shortcut. Run the full chain whenever that exclusion
+   cannot be established.
 3. Push the branch to the remote. On the first publication push, use a
    normal push. If you are recovering an already-published branch under
    an explicit force-push exception, use `--force-with-lease` only when

--- a/idd-template/.github/instructions/idd-pr-submit.instructions.md
+++ b/idd-template/.github/instructions/idd-pr-submit.instructions.md
@@ -106,6 +106,13 @@ here turns a confusing later failure into an immediate, recoverable signal.
 2. Run **pre-push-validate**.
 
    (E2E tests are verified by CI; do not run them locally.)
+
+   The same conservative scoping discretion as post-fix re-validation
+   (`idd-ci.instructions.md`'s Wake-up discipline) applies here: skip an
+   individual command in the chain only when the diff's changed paths
+   provably fall entirely outside that command's input surface, never
+   as a default shortcut. Run the full chain whenever that exclusion
+   cannot be established.
 3. Push the branch to the remote. On the first publication push, use a
    normal push. If you are recovering an already-published branch under
    an explicit force-push exception, use `--force-with-lease` only when


### PR DESCRIPTION
## Summary

D2's `pre-push-validate` step ran the full command chain unconditionally, with no counterpart to the conservative scoping discretion `idd-ci.instructions.md`'s post-fix re-validation already grants (skip a step only when the diff is provably outside its scope). This adds the same discretion to D2's step 2 in `idd-pr-submit.instructions.md`.

**Design notes** (recorded here so a reviewer doesn't need to re-derive them):

- **Placement**: added to `idd-pr-submit.instructions.md` (canonical: `idd-template/.github/instructions/idd-pr-submit.instructions.md`, exact-mode synced), not the issue's candidate `idd-work.instructions.md` — D2 is actually defined in `idd-pr-submit.instructions.md`; `idd-work.instructions.md` only references `pre-push-validate` in prose. Also deliberately did not touch `idd-overview-core.instructions.md` (where the literal `pre-push-validate` command chain is defined) — that file is a member of `bundle-merge` (97.95% of its byte budget) and `bundle-review` (97.50%), both already near the 98% context-ceiling gate; `idd-pr-submit.instructions.md` is in no bundle-budget group and has ample headroom (~22.7 KB / 33000-byte phase limit before this change).
- **Wording is tool-agnostic**: describes the exclusion test in terms of "the diff's changed paths provably fall entirely outside that command's input surface," not this repo's specific `biome`/`dprint`/etc. tool names — this instruction is distributed to adopters who override `commands.*` with their own tooling.
- **References idd-ci's existing bullet instead of restating it**, to avoid two independently-drifting copies of the same principle.
- **Deliberately excluded from the lite profile** (`idd-pr-submit-lite.instructions.md`'s own D2, and `idd-ci-lite.instructions.md`, neither of which carries the post-fix scoping bullet either): lite's fail-closed, mechanical control surfaces intentionally carry the safety weight for that tier instead of prose judgment calls, so granting a weaker model discretion to skip validation steps would cut against that design.
- Verified no downstream consumer (`local-validation-evidence.mjs`, `pre-merge-readiness.mjs`) assumes D2 always executes the full, unscoped chain — `localValidationEvidence` is informational-only (#2323 outage evidence), never a passing/waiver signal, so narrower-scoped runs don't invalidate anything it feeds.

## Acceptance criteria

- [x] D2's `pre-push-validate` step documents the same change-class scoping already used for post-fix re-validation.
- [x] The scoping rule stays conservative — skips a validation step only when the diff is provably outside that step's scope, never as a default shortcut.
- [x] `node scripts/audit-docs.mjs --check` passes.

## Test plan

- [x] `node scripts/sync-docs.mjs --apply` (template → root mirror sync)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `npx biome check`, `npx dprint check "**/*.md"`, `npx markdownlint-cli2 "**/*.md"`, `npx cspell lint "**" --no-progress`
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `node --test tests/agent-entry-mirror-sync.test.mts`
- [x] `pnpm run build:check`
- [x] `node scripts/idd-doctor.mjs`

Closes #2471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified pre-push validation guidance.
  * Individual validation commands may be skipped only when changed files are confirmed to be outside their input scope; otherwise, the complete validation sequence is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->