### PR TITLE
docs(idd-helper-scripts): add helper contract class preamble

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -28,12 +28,13 @@ Every helper below falls into one of two contract classes:
   where noted); the default invocation always prints what it would do
   without acting.
 
-Per-helper bullets state only what doesn't already follow from its
-class — an additional confirmation step, a narrower evidence scope, an
-unusual flag name — not a restatement of the class itself. Whenever a
-helper cannot complete autonomously, its own bullet documents the
-fallback path beside the helper's invocation, not in this preamble,
-since the fallback differs per helper.
+Going forward, a per-helper bullet should state only what doesn't
+already follow from its class — an additional confirmation step, a
+narrower evidence scope, an unusual flag name — not a restatement of
+the class itself; existing bullets are not retrofitted by this
+preamble. Whenever a helper cannot complete autonomously, its own
+bullet documents the fallback path beside the helper's invocation, not
+in this preamble, since the fallback differs per helper.
 
 **Discover & Claim Phase Helpers (Phase 1):**
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -15,6 +15,26 @@ directly instead of re-evaluating the same suggestion from scratch.
 
 In the idd-skill source repository, the following optional helpers were adopted:
 
+### Helper contract classes
+
+Every helper below falls into one of two contract classes:
+
+- **Evidence collectors** — read-only. They never post comments, resolve
+  review threads, merge, or close anything; they emit machine-readable
+  evidence (usually JSON) for the calling phase to interpret.
+- **Dry-run-by-default authoring helpers** — capable of mutating GitHub
+  state (posting a comment, resolving a thread, merging, closing), but
+  only under an explicit `--apply` flag (plus interactive confirmation
+  where noted); the default invocation always prints what it would do
+  without acting.
+
+Per-helper bullets state only what doesn't already follow from its
+class — an additional confirmation step, a narrower evidence scope, an
+unusual flag name — not a restatement of the class itself. Whenever a
+helper cannot complete autonomously, its own bullet documents the
+fallback path beside the helper's invocation, not in this preamble,
+since the fallback differs per helper.
+
 **Discover & Claim Phase Helpers (Phase 1):**
 
 - `scripts/discover-orphan-filter.mjs` for A0-O orphan issue detection and

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -28,12 +28,13 @@ Every helper below falls into one of two contract classes:
   where noted); the default invocation always prints what it would do
   without acting.
 
-Per-helper bullets state only what doesn't already follow from its
-class — an additional confirmation step, a narrower evidence scope, an
-unusual flag name — not a restatement of the class itself. Whenever a
-helper cannot complete autonomously, its own bullet documents the
-fallback path beside the helper's invocation, not in this preamble,
-since the fallback differs per helper.
+Going forward, a per-helper bullet should state only what doesn't
+already follow from its class — an additional confirmation step, a
+narrower evidence scope, an unusual flag name — not a restatement of
+the class itself; existing bullets are not retrofitted by this
+preamble. Whenever a helper cannot complete autonomously, its own
+bullet documents the fallback path beside the helper's invocation, not
+in this preamble, since the fallback differs per helper.
 
 **Discover & Claim Phase Helpers (Phase 1):**
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -15,6 +15,26 @@ directly instead of re-evaluating the same suggestion from scratch.
 
 In the idd-skill source repository, the following optional helpers were adopted:
 
+### Helper contract classes
+
+Every helper below falls into one of two contract classes:
+
+- **Evidence collectors** — read-only. They never post comments, resolve
+  review threads, merge, or close anything; they emit machine-readable
+  evidence (usually JSON) for the calling phase to interpret.
+- **Dry-run-by-default authoring helpers** — capable of mutating GitHub
+  state (posting a comment, resolving a thread, merging, closing), but
+  only under an explicit `--apply` flag (plus interactive confirmation
+  where noted); the default invocation always prints what it would do
+  without acting.
+
+Per-helper bullets state only what doesn't already follow from its
+class — an additional confirmation step, a narrower evidence scope, an
+unusual flag name — not a restatement of the class itself. Whenever a
+helper cannot complete autonomously, its own bullet documents the
+fallback path beside the helper's invocation, not in this preamble,
+since the fallback differs per helper.
+
 **Discover & Claim Phase Helpers (Phase 1):**
 
 - `scripts/discover-orphan-filter.mjs` for A0-O orphan issue detection and


### PR DESCRIPTION
## Summary

`docs/idd-helper-scripts.md` repeats "read-only / never posts / fail-closed"-style bullets separately for each of dozens of helpers (73 occurrences) instead of stating the underlying invariant once. This adds a preamble stating the two recurring helper contract classes and a documentation rule for fallback paths.

**Scope decision** (issue flagged this as low-confidence / judgment-call): the acceptance criteria make per-helper bullet trimming optional ("trimmed or left as-is at the author's discretion, but no helper-specific detail is lost"). Given the file is 3000+ lines with ~70 scattered occurrences, this PR adds only the mandatory preamble and leaves every existing per-helper bullet untouched — retrimming that many call sites for a judgment-call refactor is a separate, much larger review surface than what this issue requires.

Edited the canonical `idd-template/docs/idd-helper-scripts.md` (this is an exact-mode sync pair; the root `docs/idd-helper-scripts.md` mirror is regenerated via `sync-docs.mjs --apply`).

## Acceptance criteria

- [x] `docs/idd-helper-scripts.md` has a preamble stating the two helper contract classes and the fallback-path documentation rule.
- [x] Per-helper bullets are left as-is (author's discretion per the issue) — no detail lost.
- [x] `node scripts/audit-docs.mjs --check` passes.

## Test plan

- [x] `node scripts/sync-docs.mjs --apply`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `npx biome check`, `npx dprint check "**/*.md"`, `npx markdownlint-cli2 "**/*.md"`, `npx cspell lint "**" --no-progress`
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `node --test tests/agent-entry-mirror-sync.test.mts`
- [x] `pnpm run build:check`
- [x] `node scripts/idd-doctor.mjs`

Closes #2485