### PR TITLE
docs(helper-scripts): document flag/field naming conventions

### DIFF
--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -11,6 +11,74 @@ This document records the current decision on optional helper scripts for
 the IDD workflow. It exists so future reviews can reference the trade-off
 directly instead of re-evaluating the same suggestion from scratch.
 
+## Flag-name and field-name conventions
+
+Several helpers require a specific flag name that does not match
+instinct, and throw rather than defaulting to a same-named flag from a
+different helper. `--issue` is the sharpest trap: it is a genuine,
+functioning flag on several other helpers -- required outright on
+`forced-handoff-marker.mts` and `claim-approval-gate.mts`, and
+required as one of a small set of mutually exclusive input flags on
+`discover-viability-gate.mts` (or `--issues`) and
+`suitability-triage.mts` (or `--body-file` / `--stdin`) -- which primes
+the instinct to reach for it elsewhere. But the claim-revalidation flag
+on most mutation-capable helpers is named `--claim-issue` instead, and
+requiredness varies by helper:
+
+- **Unconditionally required** (modulo an explicit opt-out):
+  `pre-merge-readiness.mts` throws without `--claim-issue` unless
+  `--claimless` is passed.
+- **Required only under `--apply`, with an explicit opt-out**:
+  `audit-pr-cleanup.mts` and `live-status-digest.mts` both accept
+  `--skip-claim-check` in place of `--claim-issue`/`--claim-id`.
+- **Required only under `--apply`, with no opt-out**:
+  `disposition-non-review-notices.mts` and `resolve-review-thread.mts`.
+  None of these four ever need the flag outside `--apply`.
+- **Optional, with auto-discovery when omitted**:
+  `advisory-convergence.mts` (falls back to the PR's closing-issue
+  references) and `idd-roadmap-audit-execute.mts` (the flag, when
+  given, is only cross-checked against `--roadmap`; the apply-mode
+  identity flag there is `--claim-id`, not `--claim-issue`).
+
+`live-status-digest.mts` is the one helper where `--issue` and
+`--claim-issue` coexist as genuinely different flags: `--issue` is the
+digest's own target (mutually exclusive with `--pr`), and
+`--claim-issue` is the separate claim-revalidation flag -- the two are
+not interchangeable there either. (`idd-merge-execute.mts` forwards
+any flag it does not recognize verbatim to `pre-merge-readiness.mts`,
+so `--claim-issue` reaches it transitively even though it declares no
+such flag of its own.)
+
+No single top-level decision/verdict field name is consistent across
+the evidence-collector family. This reflects organic accretion across
+many independently authored helpers rather than a recorded design
+decision, and no normalization is currently planned. Read each
+helper's own `--help` output or its documented JSON shape rather than
+assuming a field name carries over -- a name that looks like a field in
+the source (a type or local-variable name) is not necessarily one of
+the printed object's own top-level keys. Representative examples:
+`advisory-convergence.mts` and `pre-merge-readiness.mts` both return a
+top-level `ready` boolean (the latter alongside `blockers`);
+`idd-roadmap-audit-execute.mts` also returns `ready`;
+`discover-readiness-check.mts` returns `ready` in its default
+per-issue mode, but a structurally different `{eligible,
+eligible_count, total}` shape under `--swarm-floor`;
+`discover-viability-gate.mts` returns `viable` and `discarded` (not
+`passed` -- that name exists only on an internal per-issue helper,
+never copied into the printed output); `suitability-triage.mts`
+returns `passed` for its live `--issue` invocation, but its offline
+`--body-file`/`--stdin` mode intentionally carries no aggregate
+`passed` value at all; `claim-approval-gate.mts` returns `approved`.
+The mutation-style helpers overlap rather than cleanly splitting on
+one field: `audit-pr-cleanup.mts` exposes both `mode`
+(`dry-run`/`apply`) and `status` (a seven-value vocabulary: `clean`,
+`needs-apply`, `permission-blocked`, `rescan-failed`, `failed`,
+`incomplete`, `applied`); `disposition-non-review-notices.mts` prints
+no `status` key at all in its default dry-run mode, and only
+`applied`/`failed` under `--apply`; `resolve-review-thread.mts`
+returns `mode` (`dry-run`/`apply`) alongside its own separate
+`status?` (`applied`/`failed`).
+
 ## Decision
 
 In the idd-skill source repository, the following optional helpers were adopted:

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -17,35 +17,35 @@ Several helpers require a specific flag name that does not match
 instinct, and throw rather than defaulting to a same-named flag from a
 different helper. `--issue` is the sharpest trap: it is a genuine,
 functioning flag on several other helpers -- required outright on
-`forced-handoff-marker.mts` and `claim-approval-gate.mts`, and
+`forced-handoff-marker.mjs` and `claim-approval-gate.mjs`, and
 required as one of a small set of mutually exclusive input flags on
-`discover-viability-gate.mts` (or `--issues`) and
-`suitability-triage.mts` (or `--body-file` / `--stdin`) -- which primes
+`discover-viability-gate.mjs` (or `--issues`) and
+`suitability-triage.mjs` (or `--body-file` / `--stdin`) -- which primes
 the instinct to reach for it elsewhere. But the claim-revalidation flag
 on most mutation-capable helpers is named `--claim-issue` instead, and
 requiredness varies by helper:
 
 - **Unconditionally required** (modulo an explicit opt-out):
-  `pre-merge-readiness.mts` throws without `--claim-issue` unless
+  `pre-merge-readiness.mjs` throws without `--claim-issue` unless
   `--claimless` is passed.
 - **Required only under `--apply`, with an explicit opt-out**:
-  `audit-pr-cleanup.mts` and `live-status-digest.mts` both accept
+  `audit-pr-cleanup.mjs` and `live-status-digest.mjs` both accept
   `--skip-claim-check` in place of `--claim-issue`/`--claim-id`.
 - **Required only under `--apply`, with no opt-out**:
-  `disposition-non-review-notices.mts` and `resolve-review-thread.mts`.
+  `disposition-non-review-notices.mjs` and `resolve-review-thread.mjs`.
   None of these four ever need the flag outside `--apply`.
 - **Optional, with auto-discovery when omitted**:
-  `advisory-convergence.mts` (falls back to the PR's closing-issue
-  references) and `idd-roadmap-audit-execute.mts` (the flag, when
+  `advisory-convergence.mjs` (falls back to the PR's closing-issue
+  references) and `idd-roadmap-audit-execute.mjs` (the flag, when
   given, is only cross-checked against `--roadmap`; the apply-mode
   identity flag there is `--claim-id`, not `--claim-issue`).
 
-`live-status-digest.mts` is the one helper where `--issue` and
+`live-status-digest.mjs` is the one helper where `--issue` and
 `--claim-issue` coexist as genuinely different flags: `--issue` is the
 digest's own target (mutually exclusive with `--pr`), and
 `--claim-issue` is the separate claim-revalidation flag -- the two are
-not interchangeable there either. (`idd-merge-execute.mts` forwards
-any flag it does not recognize verbatim to `pre-merge-readiness.mts`,
+not interchangeable there either. (`idd-merge-execute.mjs` forwards
+any flag it does not recognize verbatim to `pre-merge-readiness.mjs`,
 so `--claim-issue` reaches it transitively even though it declares no
 such flag of its own.)
 
@@ -57,25 +57,25 @@ helper's own `--help` output or its documented JSON shape rather than
 assuming a field name carries over -- a name that looks like a field in
 the source (a type or local-variable name) is not necessarily one of
 the printed object's own top-level keys. Representative examples:
-`advisory-convergence.mts` and `pre-merge-readiness.mts` both return a
+`advisory-convergence.mjs` and `pre-merge-readiness.mjs` both return a
 top-level `ready` boolean (the latter alongside `blockers`);
-`idd-roadmap-audit-execute.mts` also returns `ready`;
-`discover-readiness-check.mts` returns `ready` in its default
+`idd-roadmap-audit-execute.mjs` also returns `ready`;
+`discover-readiness-check.mjs` returns `ready` in its default
 per-issue mode, but a structurally different `{eligible,
 eligible_count, total}` shape under `--swarm-floor`;
-`discover-viability-gate.mts` returns `viable` and `discarded` (not
+`discover-viability-gate.mjs` returns `viable` and `discarded` (not
 `passed` -- that name exists only on an internal per-issue helper,
-never copied into the printed output); `suitability-triage.mts`
+never copied into the printed output); `suitability-triage.mjs`
 returns `passed` for its live `--issue` invocation, but its offline
 `--body-file`/`--stdin` mode intentionally carries no aggregate
-`passed` value at all; `claim-approval-gate.mts` returns `approved`.
+`passed` value at all; `claim-approval-gate.mjs` returns `approved`.
 The mutation-style helpers overlap rather than cleanly splitting on
-one field: `audit-pr-cleanup.mts` exposes both `mode`
+one field: `audit-pr-cleanup.mjs` exposes both `mode`
 (`dry-run`/`apply`) and `status` (a seven-value vocabulary: `clean`,
 `needs-apply`, `permission-blocked`, `rescan-failed`, `failed`,
-`incomplete`, `applied`); `disposition-non-review-notices.mts` prints
+`incomplete`, `applied`); `disposition-non-review-notices.mjs` prints
 no `status` key at all in its default dry-run mode, and only
-`applied`/`failed` under `--apply`; `resolve-review-thread.mts`
+`applied`/`failed` under `--apply`; `resolve-review-thread.mjs`
 returns `mode` (`dry-run`/`apply`) alongside its own separate
 `status?` (`applied`/`failed`).
 

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -11,6 +11,74 @@ This document records the current decision on optional helper scripts for
 the IDD workflow. It exists so future reviews can reference the trade-off
 directly instead of re-evaluating the same suggestion from scratch.
 
+## Flag-name and field-name conventions
+
+Several helpers require a specific flag name that does not match
+instinct, and throw rather than defaulting to a same-named flag from a
+different helper. `--issue` is the sharpest trap: it is a genuine,
+functioning flag on several other helpers -- required outright on
+`forced-handoff-marker.mts` and `claim-approval-gate.mts`, and
+required as one of a small set of mutually exclusive input flags on
+`discover-viability-gate.mts` (or `--issues`) and
+`suitability-triage.mts` (or `--body-file` / `--stdin`) -- which primes
+the instinct to reach for it elsewhere. But the claim-revalidation flag
+on most mutation-capable helpers is named `--claim-issue` instead, and
+requiredness varies by helper:
+
+- **Unconditionally required** (modulo an explicit opt-out):
+  `pre-merge-readiness.mts` throws without `--claim-issue` unless
+  `--claimless` is passed.
+- **Required only under `--apply`, with an explicit opt-out**:
+  `audit-pr-cleanup.mts` and `live-status-digest.mts` both accept
+  `--skip-claim-check` in place of `--claim-issue`/`--claim-id`.
+- **Required only under `--apply`, with no opt-out**:
+  `disposition-non-review-notices.mts` and `resolve-review-thread.mts`.
+  None of these four ever need the flag outside `--apply`.
+- **Optional, with auto-discovery when omitted**:
+  `advisory-convergence.mts` (falls back to the PR's closing-issue
+  references) and `idd-roadmap-audit-execute.mts` (the flag, when
+  given, is only cross-checked against `--roadmap`; the apply-mode
+  identity flag there is `--claim-id`, not `--claim-issue`).
+
+`live-status-digest.mts` is the one helper where `--issue` and
+`--claim-issue` coexist as genuinely different flags: `--issue` is the
+digest's own target (mutually exclusive with `--pr`), and
+`--claim-issue` is the separate claim-revalidation flag -- the two are
+not interchangeable there either. (`idd-merge-execute.mts` forwards
+any flag it does not recognize verbatim to `pre-merge-readiness.mts`,
+so `--claim-issue` reaches it transitively even though it declares no
+such flag of its own.)
+
+No single top-level decision/verdict field name is consistent across
+the evidence-collector family. This reflects organic accretion across
+many independently authored helpers rather than a recorded design
+decision, and no normalization is currently planned. Read each
+helper's own `--help` output or its documented JSON shape rather than
+assuming a field name carries over -- a name that looks like a field in
+the source (a type or local-variable name) is not necessarily one of
+the printed object's own top-level keys. Representative examples:
+`advisory-convergence.mts` and `pre-merge-readiness.mts` both return a
+top-level `ready` boolean (the latter alongside `blockers`);
+`idd-roadmap-audit-execute.mts` also returns `ready`;
+`discover-readiness-check.mts` returns `ready` in its default
+per-issue mode, but a structurally different `{eligible,
+eligible_count, total}` shape under `--swarm-floor`;
+`discover-viability-gate.mts` returns `viable` and `discarded` (not
+`passed` -- that name exists only on an internal per-issue helper,
+never copied into the printed output); `suitability-triage.mts`
+returns `passed` for its live `--issue` invocation, but its offline
+`--body-file`/`--stdin` mode intentionally carries no aggregate
+`passed` value at all; `claim-approval-gate.mts` returns `approved`.
+The mutation-style helpers overlap rather than cleanly splitting on
+one field: `audit-pr-cleanup.mts` exposes both `mode`
+(`dry-run`/`apply`) and `status` (a seven-value vocabulary: `clean`,
+`needs-apply`, `permission-blocked`, `rescan-failed`, `failed`,
+`incomplete`, `applied`); `disposition-non-review-notices.mts` prints
+no `status` key at all in its default dry-run mode, and only
+`applied`/`failed` under `--apply`; `resolve-review-thread.mts`
+returns `mode` (`dry-run`/`apply`) alongside its own separate
+`status?` (`applied`/`failed`).
+
 ## Decision
 
 In the idd-skill source repository, the following optional helpers were adopted:

--- a/idd-template/docs/idd-helper-scripts.md
+++ b/idd-template/docs/idd-helper-scripts.md
@@ -17,35 +17,35 @@ Several helpers require a specific flag name that does not match
 instinct, and throw rather than defaulting to a same-named flag from a
 different helper. `--issue` is the sharpest trap: it is a genuine,
 functioning flag on several other helpers -- required outright on
-`forced-handoff-marker.mts` and `claim-approval-gate.mts`, and
+`forced-handoff-marker.mjs` and `claim-approval-gate.mjs`, and
 required as one of a small set of mutually exclusive input flags on
-`discover-viability-gate.mts` (or `--issues`) and
-`suitability-triage.mts` (or `--body-file` / `--stdin`) -- which primes
+`discover-viability-gate.mjs` (or `--issues`) and
+`suitability-triage.mjs` (or `--body-file` / `--stdin`) -- which primes
 the instinct to reach for it elsewhere. But the claim-revalidation flag
 on most mutation-capable helpers is named `--claim-issue` instead, and
 requiredness varies by helper:
 
 - **Unconditionally required** (modulo an explicit opt-out):
-  `pre-merge-readiness.mts` throws without `--claim-issue` unless
+  `pre-merge-readiness.mjs` throws without `--claim-issue` unless
   `--claimless` is passed.
 - **Required only under `--apply`, with an explicit opt-out**:
-  `audit-pr-cleanup.mts` and `live-status-digest.mts` both accept
+  `audit-pr-cleanup.mjs` and `live-status-digest.mjs` both accept
   `--skip-claim-check` in place of `--claim-issue`/`--claim-id`.
 - **Required only under `--apply`, with no opt-out**:
-  `disposition-non-review-notices.mts` and `resolve-review-thread.mts`.
+  `disposition-non-review-notices.mjs` and `resolve-review-thread.mjs`.
   None of these four ever need the flag outside `--apply`.
 - **Optional, with auto-discovery when omitted**:
-  `advisory-convergence.mts` (falls back to the PR's closing-issue
-  references) and `idd-roadmap-audit-execute.mts` (the flag, when
+  `advisory-convergence.mjs` (falls back to the PR's closing-issue
+  references) and `idd-roadmap-audit-execute.mjs` (the flag, when
   given, is only cross-checked against `--roadmap`; the apply-mode
   identity flag there is `--claim-id`, not `--claim-issue`).
 
-`live-status-digest.mts` is the one helper where `--issue` and
+`live-status-digest.mjs` is the one helper where `--issue` and
 `--claim-issue` coexist as genuinely different flags: `--issue` is the
 digest's own target (mutually exclusive with `--pr`), and
 `--claim-issue` is the separate claim-revalidation flag -- the two are
-not interchangeable there either. (`idd-merge-execute.mts` forwards
-any flag it does not recognize verbatim to `pre-merge-readiness.mts`,
+not interchangeable there either. (`idd-merge-execute.mjs` forwards
+any flag it does not recognize verbatim to `pre-merge-readiness.mjs`,
 so `--claim-issue` reaches it transitively even though it declares no
 such flag of its own.)
 
@@ -57,25 +57,25 @@ helper's own `--help` output or its documented JSON shape rather than
 assuming a field name carries over -- a name that looks like a field in
 the source (a type or local-variable name) is not necessarily one of
 the printed object's own top-level keys. Representative examples:
-`advisory-convergence.mts` and `pre-merge-readiness.mts` both return a
+`advisory-convergence.mjs` and `pre-merge-readiness.mjs` both return a
 top-level `ready` boolean (the latter alongside `blockers`);
-`idd-roadmap-audit-execute.mts` also returns `ready`;
-`discover-readiness-check.mts` returns `ready` in its default
+`idd-roadmap-audit-execute.mjs` also returns `ready`;
+`discover-readiness-check.mjs` returns `ready` in its default
 per-issue mode, but a structurally different `{eligible,
 eligible_count, total}` shape under `--swarm-floor`;
-`discover-viability-gate.mts` returns `viable` and `discarded` (not
+`discover-viability-gate.mjs` returns `viable` and `discarded` (not
 `passed` -- that name exists only on an internal per-issue helper,
-never copied into the printed output); `suitability-triage.mts`
+never copied into the printed output); `suitability-triage.mjs`
 returns `passed` for its live `--issue` invocation, but its offline
 `--body-file`/`--stdin` mode intentionally carries no aggregate
-`passed` value at all; `claim-approval-gate.mts` returns `approved`.
+`passed` value at all; `claim-approval-gate.mjs` returns `approved`.
 The mutation-style helpers overlap rather than cleanly splitting on
-one field: `audit-pr-cleanup.mts` exposes both `mode`
+one field: `audit-pr-cleanup.mjs` exposes both `mode`
 (`dry-run`/`apply`) and `status` (a seven-value vocabulary: `clean`,
 `needs-apply`, `permission-blocked`, `rescan-failed`, `failed`,
-`incomplete`, `applied`); `disposition-non-review-notices.mts` prints
+`incomplete`, `applied`); `disposition-non-review-notices.mjs` prints
 no `status` key at all in its default dry-run mode, and only
-`applied`/`failed` under `--apply`; `resolve-review-thread.mts`
+`applied`/`failed` under `--apply`; `resolve-review-thread.mjs`
 returns `mode` (`dry-run`/`apply`) alongside its own separate
 `status?` (`applied`/`failed`).
 


### PR DESCRIPTION
# Summary

Several evidence-collector helpers require `--claim-issue` where
instinct reaches for `--issue`, and throw rather than defaulting; the
requiredness of that flag also varies by helper (unconditional,
apply-gated with or without a `--skip-claim-check` opt-out, or
optional with auto-discovery from the PR's closing references). No
single top-level decision/verdict field name is consistent across the
evidence-collector family either. Documents both conventions in
`docs/idd-helper-scripts.md`'s overview so a caller checks the actual
contract instead of guessing from a similar-looking helper.

Every specific helper/flag/field claim in this doc was independently
verified against the current source rather than carried over from the
issue's own framing -- the issue itself flagged this as a
low-confidence field report worth a maintainer read-through, and an
initial draft did in fact misattribute several field names (a
TypeScript type/local-variable name mistaken for an actual top-level
JSON key). The committed version has been through two independent
fact-checking passes against `src/scripts/*.mts`.

## Linked issue

Closes #2474

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

See issue #2474's Background section. The issue also notes this is
adjacent to, but narrower than, closed issue `#1676` (a `--help`
flag-set presence/parity check), which does not cover requiredness
annotation or field-name variance.

## IDD impact

- [ ] Instruction files changed
- [x] Template files changed
- [ ] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on command-line flag naming conventions across helper tools.
  * Documented when claim-related flags are required, optional, or automatically discovered.
  * Clarified output decision fields and status values used by different helpers.
  * Added references to individual helper documentation and JSON contracts for precise behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->