### PR TITLE
feat(audit-docs): flag stale --flag mentions in worked examples

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -45,6 +45,7 @@ scripts/force-handoff.mjs linguist-generated=true
 scripts/forced-handoff-marker.mjs linguist-generated=true
 scripts/gh-exec.mjs linguist-generated=true
 scripts/gh-http-status.mjs linguist-generated=true
+scripts/helper-flag-drift.mjs linguist-generated=true
 scripts/helper-runtime-manifest.mjs linguist-generated=true
 scripts/idd-config.mjs linguist-generated=true
 scripts/idd-critique-delegate.mjs linguist-generated=true

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -22,6 +22,7 @@ import {
   collectTypeSuppressionViolations,
   globFiles,
   isBannerScopedInstructionTarget,
+  parseGeneratedFromBannerSource,
   renderOkfIndexMarkdownTable,
   resolveGeneratedBlockFiles,
   stripGeneratedFromBanner,
@@ -641,7 +642,19 @@ function checkHelperFlagDrift() {
   ];
   const files = uniqueSorted(
     globs.flatMap((glob) => globFiles(glob, repoFiles)),
-  ).map((path) => ({ path, text: readText(path) }));
+  ).map((path) => {
+    const text = readText(path);
+    // A generated sync-pair mirror (e.g. .github/instructions/*.md, a
+    // byte-identical copy of its idd-template/ source) carries its own
+    // "idd-generated-from" banner naming that source. uniqueSorted's
+    // lexicographic order scans `.github/instructions/**` before
+    // `idd-template/**`, so without this remap a drift violation would
+    // routinely cite the generated mirror -- editing it is a no-op, since
+    // the next `sync-docs.mjs --apply` overwrites it from the real
+    // source. Attribute the finding to the canonical source instead.
+    const canonicalSource = parseGeneratedFromBannerSource(text);
+    return { path: canonicalSource ?? path, text };
+  });
   const documented = collectDocumentedHelperInvocationFlags(files);
   const probeCache = new Map();
   const probe = (helperPath) => {

--- a/scripts/audit-docs.mjs
+++ b/scripts/audit-docs.mjs
@@ -27,6 +27,10 @@ import {
   stripGeneratedFromBanner,
   uniqueSorted,
 } from './consistency-helpers.mjs';
+import {
+  collectDocumentedHelperInvocationFlags,
+  collectHelperFlagDriftViolations,
+} from './helper-flag-drift.mjs';
 import { collectMarkdownLinkAuditViolations } from './markdown-link-audit.mjs';
 
 const root = process.cwd();
@@ -86,6 +90,7 @@ checkTypeSuppressionBudgets(manifest.typeSuppressionBudgets ?? null);
 checkOkfBundles(manifest.okfBundles ?? null);
 checkMarkdownLinkAudit(manifest.markdownLinkAudit ?? null);
 checkConfigInstructionDrift();
+checkHelperFlagDrift();
 checkGeneratedSourcePairs();
 checkEnginesRangeMirrors();
 checkBinExecutableMode();
@@ -620,6 +625,55 @@ function checkConfigInstructionDrift() {
       `${pair.configPath} matches ${pair.overviewPath} command and scope defaults`,
     );
   }
+}
+// Instructions-vs-implementation flag drift (#2477): every fenced
+// `node scripts/<helper>.mjs --flag ...` worked example across the doc
+// corpus must still name a flag the helper's own `--help` output accepts.
+// Helper probing (spawning `--help`) happens here, kept out of the pure
+// collector in helper-flag-drift.mts so it stays unit-testable without a
+// child process. Results are cached per helper since the same helper is
+// typically invoked in many worked examples across the corpus.
+function checkHelperFlagDrift() {
+  const globs = [
+    'docs/**/*.md',
+    'idd-template/**/*.md',
+    '.github/instructions/**/*.md',
+  ];
+  const files = uniqueSorted(
+    globs.flatMap((glob) => globFiles(glob, repoFiles)),
+  ).map((path) => ({ path, text: readText(path) }));
+  const documented = collectDocumentedHelperInvocationFlags(files);
+  const probeCache = new Map();
+  const probe = (helperPath) => {
+    const cached = probeCache.get(helperPath);
+    if (cached) {
+      return cached;
+    }
+    const exists = repoFiles.includes(helperPath);
+    let output = '';
+    if (exists) {
+      try {
+        output = execFileSync('node', [helperPath, '--help'], {
+          cwd: root,
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+      } catch (error) {
+        // A helper that rejects `--help` (unknown-flag fallback, an
+        // interactive-only tool erroring immediately, ...) still often
+        // prints its usage text before exiting non-zero -- capture
+        // stdout/stderr from the failure rather than treating a non-zero
+        // exit as "no output". execFileSync attaches these to the thrown
+        // error when `encoding` is set.
+        const failure = error;
+        output = `${failure.stdout ?? ''}${failure.stderr ?? ''}`;
+      }
+    }
+    const result = { exists, output };
+    probeCache.set(helperPath, result);
+    return result;
+  };
+  errors.push(...collectHelperFlagDriftViolations(documented, probe));
 }
 function checkEnginesRangeMirrors() {
   // Only applies when this repository's own known mirror set is actually

--- a/scripts/helper-flag-drift.mjs
+++ b/scripts/helper-flag-drift.mjs
@@ -63,8 +63,9 @@ export function extractFencedBlocks(text) {
   return blocks;
 }
 /**
- * Extract every line that falls inside a triple-backtick fenced code block
- * in `text`, across every block, in document order.
+ * Extract every line that falls inside a backtick-fenced code block in
+ * `text` (three or more backticks, see `extractFencedBlocks`), across
+ * every block, in document order.
  */
 export function extractFencedLines(text) {
   return extractFencedBlocks(text).flat();

--- a/scripts/helper-flag-drift.mjs
+++ b/scripts/helper-flag-drift.mjs
@@ -12,30 +12,50 @@ const FLAG_TOKEN_PATTERN = /--[a-z][a-z0-9-]*/g;
 // not match the path character class, so generic template lines are
 // skipped rather than mistaken for a real worked example.
 const NODE_INVOCATION_LINE_PATTERN = /\bnode\s+(scripts\/[\w./-]+\.mjs)\b(.*)$/;
+const FENCE_OPEN_PATTERN = /^\s*(`{3,})/;
+const FENCE_CLOSE_ONLY_PATTERN = /^\s*(`{3,})\s*$/;
 /**
- * Extract every triple-backtick fenced code block in `text` as its own
- * array of lines (fence delimiter lines excluded), preserving block
- * boundaries so a shell line-continuation join never bridges two
- * unrelated fences. An unterminated trailing fence still counts, matching
- * the same permissive toggle `extractHeadingSlugs` in
- * markdown-link-audit.mts already accepts elsewhere in this audit.
+ * Extract every backtick-fenced code block in `text` as its own array of
+ * lines (fence delimiter lines excluded), preserving block boundaries so a
+ * shell line-continuation join never bridges two unrelated fences.
+ *
+ * Fence length is tracked per CommonMark: a fence opened with N backticks
+ * is closed only by a later line consisting of nothing but M >= N
+ * backticks (optional surrounding whitespace); anything shorter, or
+ * carrying extra content, is literal fence *content*. This matters
+ * concretely in this corpus -- some onboarding templates wrap an
+ * illustrative issue body in a four-backtick fence that itself contains a
+ * genuine ` ```sh ` worked example (e.g.
+ * `idd-template/docs/onboarding/issue-mediated-bootstrap.md`). A
+ * length-agnostic toggle (as `extractHeadingSlugs` in
+ * markdown-link-audit.mts deliberately accepts, since a missed heading
+ * there only widens tolerance) would treat the inner ` ```sh `/` ``` `
+ * pair as closing and reopening the outer fence, both scrambling
+ * everything after it and skipping that worked example entirely -- a
+ * false negative this checker's whole purpose is to avoid. Tilde fences
+ * are out of scope, matching the same precedent: none appear anywhere in
+ * the corpus scanned here.
  */
 export function extractFencedBlocks(text) {
   const blocks = [];
   let current = null;
+  let fenceLength = 0;
   for (const line of text.split(/\r?\n/)) {
-    if (/^\s*```/.test(line)) {
-      if (current) {
-        blocks.push(current);
-        current = null;
-      } else {
+    if (current === null) {
+      const openMatch = FENCE_OPEN_PATTERN.exec(line);
+      if (openMatch) {
         current = [];
+        fenceLength = openMatch[1].length;
       }
       continue;
     }
-    if (current) {
-      current.push(line);
+    const closeMatch = FENCE_CLOSE_ONLY_PATTERN.exec(line);
+    if (closeMatch && closeMatch[1].length >= fenceLength) {
+      blocks.push(current);
+      current = null;
+      continue;
     }
+    current.push(line);
   }
   if (current) {
     blocks.push(current);

--- a/scripts/helper-flag-drift.mjs
+++ b/scripts/helper-flag-drift.mjs
@@ -13,24 +13,41 @@ const FLAG_TOKEN_PATTERN = /--[a-z][a-z0-9-]*/g;
 // skipped rather than mistaken for a real worked example.
 const NODE_INVOCATION_LINE_PATTERN = /\bnode\s+(scripts\/[\w./-]+\.mjs)\b(.*)$/;
 /**
- * Extract every line that falls inside a triple-backtick fenced code block
- * in `text`. Line-based and only recognizes triple-backtick fences,
- * matching the same approximation `extractHeadingSlugs` in
+ * Extract every triple-backtick fenced code block in `text` as its own
+ * array of lines (fence delimiter lines excluded), preserving block
+ * boundaries so a shell line-continuation join never bridges two
+ * unrelated fences. An unterminated trailing fence still counts, matching
+ * the same permissive toggle `extractHeadingSlugs` in
  * markdown-link-audit.mts already accepts elsewhere in this audit.
  */
-export function extractFencedLines(text) {
-  const lines = [];
-  let inFence = false;
+export function extractFencedBlocks(text) {
+  const blocks = [];
+  let current = null;
   for (const line of text.split(/\r?\n/)) {
     if (/^\s*```/.test(line)) {
-      inFence = !inFence;
+      if (current) {
+        blocks.push(current);
+        current = null;
+      } else {
+        current = [];
+      }
       continue;
     }
-    if (inFence) {
-      lines.push(line);
+    if (current) {
+      current.push(line);
     }
   }
-  return lines;
+  if (current) {
+    blocks.push(current);
+  }
+  return blocks;
+}
+/**
+ * Extract every line that falls inside a triple-backtick fenced code block
+ * in `text`, across every block, in document order.
+ */
+export function extractFencedLines(text) {
+  return extractFencedBlocks(text).flat();
 }
 /** Every distinct `--flag` token appearing anywhere in `text`. */
 export function extractFlagTokens(text) {
@@ -39,37 +56,66 @@ export function extractFlagTokens(text) {
   );
 }
 /**
+ * Join a trailing `\` shell line-continuation within one fenced block into
+ * a single logical line, so a worked example wrapped across several lines
+ * (common throughout this repo's instructions) is read as one command
+ * instead of losing every flag after the first wrapped line.
+ */
+function joinLineContinuations(block) {
+  const logicalLines = [];
+  let buffer = '';
+  for (const rawLine of block) {
+    const trimmedEnd = rawLine.replace(/\s+$/, '');
+    if (trimmedEnd.endsWith('\\')) {
+      buffer += `${trimmedEnd.slice(0, -1)} `;
+      continue;
+    }
+    buffer += rawLine;
+    logicalLines.push(buffer);
+    buffer = '';
+  }
+  if (buffer) {
+    // A trailing continuation with no following line -- keep whatever was
+    // accumulated rather than silently dropping it.
+    logicalLines.push(buffer);
+  }
+  return logicalLines;
+}
+/**
  * Scan every source for fenced `node scripts/<helper>.mjs ...` invocation
- * lines and collect the distinct `--flag` tokens documented per helper,
- * each paired with the first doc file it was seen in (first-seen only --
- * this drives an actionable error message, not exhaustive provenance).
+ * lines (continuation-joined, see `joinLineContinuations`) and collect the
+ * distinct `--flag` tokens documented per helper, each paired with the
+ * first doc file it was seen in (first-seen only -- this drives an
+ * actionable error message, not exhaustive provenance).
  */
 export function collectDocumentedHelperInvocationFlags(sources) {
   const byHelper = new Map();
   for (const source of sources) {
-    for (const line of extractFencedLines(source.text)) {
-      const match = NODE_INVOCATION_LINE_PATTERN.exec(line);
-      if (!match) {
-        continue;
-      }
-      const helperPath = match[1];
-      // A path-alias / traversal segment (`scripts/../bin/x.mjs`) is never
-      // a genuine worked example -- docs/permissions.md deliberately shows
-      // one to illustrate a Bash-permission prefix-matching gap. Skip it
-      // rather than resolve and flag a path nobody intends to invoke this
-      // way.
-      if (helperPath.includes('..')) {
-        continue;
-      }
-      const argsText = match[2];
-      let flagsForHelper = byHelper.get(helperPath);
-      if (!flagsForHelper) {
-        flagsForHelper = new Map();
-        byHelper.set(helperPath, flagsForHelper);
-      }
-      for (const flagMatch of argsText.matchAll(FLAG_TOKEN_PATTERN)) {
-        if (!flagsForHelper.has(flagMatch[0])) {
-          flagsForHelper.set(flagMatch[0], source.path);
+    for (const block of extractFencedBlocks(source.text)) {
+      for (const line of joinLineContinuations(block)) {
+        const match = NODE_INVOCATION_LINE_PATTERN.exec(line);
+        if (!match) {
+          continue;
+        }
+        const helperPath = match[1];
+        // A path-alias / traversal segment (`scripts/../bin/x.mjs`) is
+        // never a genuine worked example -- docs/permissions.md
+        // deliberately shows one to illustrate a Bash-permission
+        // prefix-matching gap. Skip it rather than resolve and flag a
+        // path nobody intends to invoke this way.
+        if (helperPath.includes('..')) {
+          continue;
+        }
+        const argsText = match[2];
+        let flagsForHelper = byHelper.get(helperPath);
+        if (!flagsForHelper) {
+          flagsForHelper = new Map();
+          byHelper.set(helperPath, flagsForHelper);
+        }
+        for (const flagMatch of argsText.matchAll(FLAG_TOKEN_PATTERN)) {
+          if (!flagsForHelper.has(flagMatch[0])) {
+            flagsForHelper.set(flagMatch[0], source.path);
+          }
         }
       }
     }

--- a/scripts/helper-flag-drift.mjs
+++ b/scripts/helper-flag-drift.mjs
@@ -127,23 +127,24 @@ export function collectDocumentedHelperInvocationFlags(sources) {
           continue;
         }
         const argsText = match[2];
-        let flagsForHelper = byHelper.get(helperPath);
-        if (!flagsForHelper) {
-          flagsForHelper = new Map();
-          byHelper.set(helperPath, flagsForHelper);
+        let entry = byHelper.get(helperPath);
+        if (!entry) {
+          entry = { firstSeenDocPath: source.path, flags: new Map() };
+          byHelper.set(helperPath, entry);
         }
         for (const flagMatch of argsText.matchAll(FLAG_TOKEN_PATTERN)) {
-          if (!flagsForHelper.has(flagMatch[0])) {
-            flagsForHelper.set(flagMatch[0], source.path);
+          if (!entry.flags.has(flagMatch[0])) {
+            entry.flags.set(flagMatch[0], source.path);
           }
         }
       }
     }
   }
   return [...byHelper.entries()]
-    .map(([helperPath, flags]) => ({
+    .map(([helperPath, entry]) => ({
       helperPath,
-      flags: [...flags.entries()]
+      firstSeenDocPath: entry.firstSeenDocPath,
+      flags: [...entry.flags.entries()]
         .map(([flag, docPath]) => ({ flag, docPath }))
         .sort((left, right) => left.flag.localeCompare(right.flag)),
     }))
@@ -162,9 +163,8 @@ export function collectHelperFlagDriftViolations(documented, probe) {
   for (const entry of documented) {
     const result = probe(entry.helperPath);
     if (!result.exists) {
-      const firstDocPath = entry.flags[0]?.docPath ?? '(unknown doc)';
       violations.push(
-        `${firstDocPath}: documents \`node ${entry.helperPath}\`, but ${entry.helperPath} does not exist in the repository`,
+        `${entry.firstSeenDocPath}: documents \`node ${entry.helperPath}\`, but ${entry.helperPath} does not exist in the repository`,
       );
       continue;
     }

--- a/scripts/helper-flag-drift.mjs
+++ b/scripts/helper-flag-drift.mjs
@@ -1,0 +1,118 @@
+// idd-generated-from: src/scripts/helper-flag-drift.mts
+//
+// The scripts/helper-flag-drift.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+const FLAG_TOKEN_PATTERN = /--[a-z][a-z0-9-]*/g;
+// Matches a fenced-block line that invokes a helper by its repo-relative
+// path, e.g. `node scripts/post-idd-marker.mjs --type watermark --apply`.
+// Deliberately anchored to the literal `scripts/` prefix and `.mjs`
+// extension -- a `.mts` source is never directly invoked, and a
+// placeholder like `node scripts/<helper-name>.mjs` (angle brackets) does
+// not match the path character class, so generic template lines are
+// skipped rather than mistaken for a real worked example.
+const NODE_INVOCATION_LINE_PATTERN = /\bnode\s+(scripts\/[\w./-]+\.mjs)\b(.*)$/;
+/**
+ * Extract every line that falls inside a triple-backtick fenced code block
+ * in `text`. Line-based and only recognizes triple-backtick fences,
+ * matching the same approximation `extractHeadingSlugs` in
+ * markdown-link-audit.mts already accepts elsewhere in this audit.
+ */
+export function extractFencedLines(text) {
+  const lines = [];
+  let inFence = false;
+  for (const line of text.split(/\r?\n/)) {
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) {
+      lines.push(line);
+    }
+  }
+  return lines;
+}
+/** Every distinct `--flag` token appearing anywhere in `text`. */
+export function extractFlagTokens(text) {
+  return new Set(
+    [...text.matchAll(FLAG_TOKEN_PATTERN)].map((match) => match[0]),
+  );
+}
+/**
+ * Scan every source for fenced `node scripts/<helper>.mjs ...` invocation
+ * lines and collect the distinct `--flag` tokens documented per helper,
+ * each paired with the first doc file it was seen in (first-seen only --
+ * this drives an actionable error message, not exhaustive provenance).
+ */
+export function collectDocumentedHelperInvocationFlags(sources) {
+  const byHelper = new Map();
+  for (const source of sources) {
+    for (const line of extractFencedLines(source.text)) {
+      const match = NODE_INVOCATION_LINE_PATTERN.exec(line);
+      if (!match) {
+        continue;
+      }
+      const helperPath = match[1];
+      // A path-alias / traversal segment (`scripts/../bin/x.mjs`) is never
+      // a genuine worked example -- docs/permissions.md deliberately shows
+      // one to illustrate a Bash-permission prefix-matching gap. Skip it
+      // rather than resolve and flag a path nobody intends to invoke this
+      // way.
+      if (helperPath.includes('..')) {
+        continue;
+      }
+      const argsText = match[2];
+      let flagsForHelper = byHelper.get(helperPath);
+      if (!flagsForHelper) {
+        flagsForHelper = new Map();
+        byHelper.set(helperPath, flagsForHelper);
+      }
+      for (const flagMatch of argsText.matchAll(FLAG_TOKEN_PATTERN)) {
+        if (!flagsForHelper.has(flagMatch[0])) {
+          flagsForHelper.set(flagMatch[0], source.path);
+        }
+      }
+    }
+  }
+  return [...byHelper.entries()]
+    .map(([helperPath, flags]) => ({
+      helperPath,
+      flags: [...flags.entries()]
+        .map(([flag, docPath]) => ({ flag, docPath }))
+        .sort((left, right) => left.flag.localeCompare(right.flag)),
+    }))
+    .sort((left, right) => left.helperPath.localeCompare(right.helperPath));
+}
+/**
+ * Diff each helper's documented flags against its actual `--help` output
+ * (via `probe`, injected so this stays pure). A helper whose probed output
+ * carries zero recognizable `--flag` tokens is treated as an unverifiable
+ * CLI (e.g. an interactive-only tool with no flag-driven `--help`) and is
+ * skipped entirely, rather than flagging every one of its documented flags
+ * as missing.
+ */
+export function collectHelperFlagDriftViolations(documented, probe) {
+  const violations = [];
+  for (const entry of documented) {
+    const result = probe(entry.helperPath);
+    if (!result.exists) {
+      const firstDocPath = entry.flags[0]?.docPath ?? '(unknown doc)';
+      violations.push(
+        `${firstDocPath}: documents \`node ${entry.helperPath}\`, but ${entry.helperPath} does not exist in the repository`,
+      );
+      continue;
+    }
+    const actualFlags = extractFlagTokens(result.output);
+    if (actualFlags.size === 0) {
+      continue;
+    }
+    for (const { flag, docPath } of entry.flags) {
+      if (!actualFlags.has(flag)) {
+        violations.push(
+          `${docPath}: documents \`${flag}\` for ${entry.helperPath}, but that flag does not appear in its --help output (possibly renamed or removed)`,
+        );
+      }
+    }
+  }
+  return violations;
+}

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -33,6 +33,7 @@ import {
   collectTypeSuppressionViolations,
   globFiles,
   isBannerScopedInstructionTarget,
+  parseGeneratedFromBannerSource,
   renderOkfIndexMarkdownTable,
   resolveGeneratedBlockFiles,
   stripGeneratedFromBanner,
@@ -801,7 +802,19 @@ function checkHelperFlagDrift() {
   ];
   const files = uniqueSorted(
     globs.flatMap((glob) => globFiles(glob, repoFiles)),
-  ).map((path) => ({ path, text: readText(path) }));
+  ).map((path) => {
+    const text = readText(path);
+    // A generated sync-pair mirror (e.g. .github/instructions/*.md, a
+    // byte-identical copy of its idd-template/ source) carries its own
+    // "idd-generated-from" banner naming that source. uniqueSorted's
+    // lexicographic order scans `.github/instructions/**` before
+    // `idd-template/**`, so without this remap a drift violation would
+    // routinely cite the generated mirror -- editing it is a no-op, since
+    // the next `sync-docs.mjs --apply` overwrites it from the real
+    // source. Attribute the finding to the canonical source instead.
+    const canonicalSource = parseGeneratedFromBannerSource(text);
+    return { path: canonicalSource ?? path, text };
+  });
 
   const documented = collectDocumentedHelperInvocationFlags(files);
   const probeCache = new Map<string, HelperProbeResult>();

--- a/src/scripts/audit-docs.mts
+++ b/src/scripts/audit-docs.mts
@@ -38,6 +38,11 @@ import {
   stripGeneratedFromBanner,
   uniqueSorted,
 } from './consistency-helpers.mts';
+import type { HelperProbeResult } from './helper-flag-drift.mts';
+import {
+  collectDocumentedHelperInvocationFlags,
+  collectHelperFlagDriftViolations,
+} from './helper-flag-drift.mts';
 import type { MarkdownLinkAuditConfig } from './markdown-link-audit.mts';
 import { collectMarkdownLinkAuditViolations } from './markdown-link-audit.mts';
 
@@ -185,6 +190,7 @@ checkTypeSuppressionBudgets(manifest.typeSuppressionBudgets ?? null);
 checkOkfBundles(manifest.okfBundles ?? null);
 checkMarkdownLinkAudit(manifest.markdownLinkAudit ?? null);
 checkConfigInstructionDrift();
+checkHelperFlagDrift();
 checkGeneratedSourcePairs();
 checkEnginesRangeMirrors();
 checkBinExecutableMode();
@@ -778,6 +784,58 @@ function checkConfigInstructionDrift() {
       `${pair.configPath} matches ${pair.overviewPath} command and scope defaults`,
     );
   }
+}
+
+// Instructions-vs-implementation flag drift (#2477): every fenced
+// `node scripts/<helper>.mjs --flag ...` worked example across the doc
+// corpus must still name a flag the helper's own `--help` output accepts.
+// Helper probing (spawning `--help`) happens here, kept out of the pure
+// collector in helper-flag-drift.mts so it stays unit-testable without a
+// child process. Results are cached per helper since the same helper is
+// typically invoked in many worked examples across the corpus.
+function checkHelperFlagDrift() {
+  const globs = [
+    'docs/**/*.md',
+    'idd-template/**/*.md',
+    '.github/instructions/**/*.md',
+  ];
+  const files = uniqueSorted(
+    globs.flatMap((glob) => globFiles(glob, repoFiles)),
+  ).map((path) => ({ path, text: readText(path) }));
+
+  const documented = collectDocumentedHelperInvocationFlags(files);
+  const probeCache = new Map<string, HelperProbeResult>();
+  const probe = (helperPath: string): HelperProbeResult => {
+    const cached = probeCache.get(helperPath);
+    if (cached) {
+      return cached;
+    }
+    const exists = repoFiles.includes(helperPath);
+    let output = '';
+    if (exists) {
+      try {
+        output = execFileSync('node', [helperPath, '--help'], {
+          cwd: root,
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+      } catch (error) {
+        // A helper that rejects `--help` (unknown-flag fallback, an
+        // interactive-only tool erroring immediately, ...) still often
+        // prints its usage text before exiting non-zero -- capture
+        // stdout/stderr from the failure rather than treating a non-zero
+        // exit as "no output". execFileSync attaches these to the thrown
+        // error when `encoding` is set.
+        const failure = error as { stdout?: string; stderr?: string };
+        output = `${failure.stdout ?? ''}${failure.stderr ?? ''}`;
+      }
+    }
+    const result: HelperProbeResult = { exists, output };
+    probeCache.set(helperPath, result);
+    return result;
+  };
+
+  errors.push(...collectHelperFlagDriftViolations(documented, probe));
 }
 
 function checkEnginesRangeMirrors() {

--- a/src/scripts/helper-flag-drift.mts
+++ b/src/scripts/helper-flag-drift.mts
@@ -42,6 +42,14 @@ export interface DocumentedHelperFlag {
 /** Every `--flag` token documented across the corpus for one helper. */
 export interface DocumentedHelperFlags {
   helperPath: string;
+  /**
+   * The doc file the helper's invocation was first seen in, independent of
+   * whether that invocation (or any other) carried any `--flag` at all
+   * (e.g. a bare `node scripts/idd-doctor.mjs`) -- `flags` alone cannot
+   * supply this for a helper with zero documented flags, and a
+   * missing-helper violation still needs a real file to point at.
+   */
+  firstSeenDocPath: string;
   flags: DocumentedHelperFlag[];
 }
 
@@ -173,7 +181,10 @@ function joinLineContinuations(block: readonly string[]): string[] {
 export function collectDocumentedHelperInvocationFlags(
   sources: readonly HelperFlagDriftSource[],
 ): DocumentedHelperFlags[] {
-  const byHelper = new Map<string, Map<string, string>>();
+  const byHelper = new Map<
+    string,
+    { firstSeenDocPath: string; flags: Map<string, string> }
+  >();
 
   for (const source of sources) {
     for (const block of extractFencedBlocks(source.text)) {
@@ -192,14 +203,14 @@ export function collectDocumentedHelperInvocationFlags(
           continue;
         }
         const argsText = match[2];
-        let flagsForHelper = byHelper.get(helperPath);
-        if (!flagsForHelper) {
-          flagsForHelper = new Map();
-          byHelper.set(helperPath, flagsForHelper);
+        let entry = byHelper.get(helperPath);
+        if (!entry) {
+          entry = { firstSeenDocPath: source.path, flags: new Map() };
+          byHelper.set(helperPath, entry);
         }
         for (const flagMatch of argsText.matchAll(FLAG_TOKEN_PATTERN)) {
-          if (!flagsForHelper.has(flagMatch[0])) {
-            flagsForHelper.set(flagMatch[0], source.path);
+          if (!entry.flags.has(flagMatch[0])) {
+            entry.flags.set(flagMatch[0], source.path);
           }
         }
       }
@@ -207,9 +218,10 @@ export function collectDocumentedHelperInvocationFlags(
   }
 
   return [...byHelper.entries()]
-    .map(([helperPath, flags]) => ({
+    .map(([helperPath, entry]) => ({
       helperPath,
-      flags: [...flags.entries()]
+      firstSeenDocPath: entry.firstSeenDocPath,
+      flags: [...entry.flags.entries()]
         .map(([flag, docPath]) => ({ flag, docPath }))
         .sort((left, right) => left.flag.localeCompare(right.flag)),
     }))
@@ -233,9 +245,8 @@ export function collectHelperFlagDriftViolations(
   for (const entry of documented) {
     const result = probe(entry.helperPath);
     if (!result.exists) {
-      const firstDocPath = entry.flags[0]?.docPath ?? '(unknown doc)';
       violations.push(
-        `${firstDocPath}: documents \`node ${entry.helperPath}\`, but ${entry.helperPath} does not exist in the repository`,
+        `${entry.firstSeenDocPath}: documents \`node ${entry.helperPath}\`, but ${entry.helperPath} does not exist in the repository`,
       );
       continue;
     }

--- a/src/scripts/helper-flag-drift.mts
+++ b/src/scripts/helper-flag-drift.mts
@@ -66,31 +66,55 @@ const FLAG_TOKEN_PATTERN = /--[a-z][a-z0-9-]*/g;
 // skipped rather than mistaken for a real worked example.
 const NODE_INVOCATION_LINE_PATTERN = /\bnode\s+(scripts\/[\w./-]+\.mjs)\b(.*)$/;
 
+const FENCE_OPEN_PATTERN = /^\s*(`{3,})/;
+const FENCE_CLOSE_ONLY_PATTERN = /^\s*(`{3,})\s*$/;
+
 /**
- * Extract every triple-backtick fenced code block in `text` as its own
- * array of lines (fence delimiter lines excluded), preserving block
- * boundaries so a shell line-continuation join never bridges two
- * unrelated fences. An unterminated trailing fence still counts, matching
- * the same permissive toggle `extractHeadingSlugs` in
- * markdown-link-audit.mts already accepts elsewhere in this audit.
+ * Extract every backtick-fenced code block in `text` as its own array of
+ * lines (fence delimiter lines excluded), preserving block boundaries so a
+ * shell line-continuation join never bridges two unrelated fences.
+ *
+ * Fence length is tracked per CommonMark: a fence opened with N backticks
+ * is closed only by a later line consisting of nothing but M >= N
+ * backticks (optional surrounding whitespace); anything shorter, or
+ * carrying extra content, is literal fence *content*. This matters
+ * concretely in this corpus -- some onboarding templates wrap an
+ * illustrative issue body in a four-backtick fence that itself contains a
+ * genuine ` ```sh ` worked example (e.g.
+ * `idd-template/docs/onboarding/issue-mediated-bootstrap.md`). A
+ * length-agnostic toggle (as `extractHeadingSlugs` in
+ * markdown-link-audit.mts deliberately accepts, since a missed heading
+ * there only widens tolerance) would treat the inner ` ```sh `/` ``` `
+ * pair as closing and reopening the outer fence, both scrambling
+ * everything after it and skipping that worked example entirely -- a
+ * false negative this checker's whole purpose is to avoid. Tilde fences
+ * are out of scope, matching the same precedent: none appear anywhere in
+ * the corpus scanned here.
  */
 export function extractFencedBlocks(text: string): string[][] {
   const blocks: string[][] = [];
   let current: string[] | null = null;
+  let fenceLength = 0;
+
   for (const line of text.split(/\r?\n/)) {
-    if (/^\s*```/.test(line)) {
-      if (current) {
-        blocks.push(current);
-        current = null;
-      } else {
+    if (current === null) {
+      const openMatch = FENCE_OPEN_PATTERN.exec(line);
+      if (openMatch) {
         current = [];
+        fenceLength = openMatch[1].length;
       }
       continue;
     }
-    if (current) {
-      current.push(line);
+
+    const closeMatch = FENCE_CLOSE_ONLY_PATTERN.exec(line);
+    if (closeMatch && closeMatch[1].length >= fenceLength) {
+      blocks.push(current);
+      current = null;
+      continue;
     }
+    current.push(line);
   }
+
   if (current) {
     blocks.push(current);
   }

--- a/src/scripts/helper-flag-drift.mts
+++ b/src/scripts/helper-flag-drift.mts
@@ -130,8 +130,9 @@ export function extractFencedBlocks(text: string): string[][] {
 }
 
 /**
- * Extract every line that falls inside a triple-backtick fenced code block
- * in `text`, across every block, in document order.
+ * Extract every line that falls inside a backtick-fenced code block in
+ * `text` (three or more backticks, see `extractFencedBlocks`), across
+ * every block, in document order.
  */
 export function extractFencedLines(text: string): string[] {
   return extractFencedBlocks(text).flat();

--- a/src/scripts/helper-flag-drift.mts
+++ b/src/scripts/helper-flag-drift.mts
@@ -1,0 +1,186 @@
+// idd-generated-from: src/scripts/helper-flag-drift.mts
+//
+// The scripts/helper-flag-drift.mjs copy is generated from the .mts
+// source named above by `pnpm run build`. Edit the .mts source, never the
+// generated .mjs. See docs/typescript-sources.md.
+
+// ---------------------------------------------------------------------------
+// Instructions-vs-implementation flag drift audit (#2477).
+//
+// audit-docs.mts's other checks validate mirror-pair byte equality, file-set
+// membership, and config/instructions consistency, but nothing verifies that
+// a `--flag` shown in a fenced worked-example invocation of a
+// `scripts/*.mjs` helper still exists on that helper's actual CLI. A
+// downstream review-comment audit found instructions-vs-implementation drift
+// as the single largest upstream-attributable finding category; this module
+// is one prevention pass for it (a helper's own `--help` output, not a
+// third source of truth, decides what "still exists" means).
+//
+// One-directional by design: a documented flag must appear in the helper's
+// `--help` output, but a flag the helper accepts and the docs never mention
+// is not flagged -- enumerating full CLI coverage per helper is a much
+// larger, noisier claim than "the worked examples still run," and doc
+// authors are free to omit rarely-used flags from a worked example.
+//
+// The `--help` output is supplied by the caller (audit-docs.mts spawns the
+// helper), keeping this module pure and unit-testable without a child
+// process.
+// ---------------------------------------------------------------------------
+
+/** One markdown source file already read into memory. */
+export interface HelperFlagDriftSource {
+  path: string;
+  text: string;
+}
+
+/** A `--flag` token documented for one helper, with the doc file it came from. */
+export interface DocumentedHelperFlag {
+  flag: string;
+  docPath: string;
+}
+
+/** Every `--flag` token documented across the corpus for one helper. */
+export interface DocumentedHelperFlags {
+  helperPath: string;
+  flags: DocumentedHelperFlag[];
+}
+
+/**
+ * The result of probing one helper's actual CLI, supplied by the caller.
+ * `exists: false` means the documented `scripts/*.mjs` path was not found in
+ * the repository at all (a stronger drift signal than a single stale flag).
+ */
+export interface HelperProbeResult {
+  exists: boolean;
+  output: string;
+}
+
+const FLAG_TOKEN_PATTERN = /--[a-z][a-z0-9-]*/g;
+
+// Matches a fenced-block line that invokes a helper by its repo-relative
+// path, e.g. `node scripts/post-idd-marker.mjs --type watermark --apply`.
+// Deliberately anchored to the literal `scripts/` prefix and `.mjs`
+// extension -- a `.mts` source is never directly invoked, and a
+// placeholder like `node scripts/<helper-name>.mjs` (angle brackets) does
+// not match the path character class, so generic template lines are
+// skipped rather than mistaken for a real worked example.
+const NODE_INVOCATION_LINE_PATTERN = /\bnode\s+(scripts\/[\w./-]+\.mjs)\b(.*)$/;
+
+/**
+ * Extract every line that falls inside a triple-backtick fenced code block
+ * in `text`. Line-based and only recognizes triple-backtick fences,
+ * matching the same approximation `extractHeadingSlugs` in
+ * markdown-link-audit.mts already accepts elsewhere in this audit.
+ */
+export function extractFencedLines(text: string): string[] {
+  const lines: string[] = [];
+  let inFence = false;
+  for (const line of text.split(/\r?\n/)) {
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) {
+      lines.push(line);
+    }
+  }
+  return lines;
+}
+
+/** Every distinct `--flag` token appearing anywhere in `text`. */
+export function extractFlagTokens(text: string): Set<string> {
+  return new Set(
+    [...text.matchAll(FLAG_TOKEN_PATTERN)].map((match) => match[0]),
+  );
+}
+
+/**
+ * Scan every source for fenced `node scripts/<helper>.mjs ...` invocation
+ * lines and collect the distinct `--flag` tokens documented per helper,
+ * each paired with the first doc file it was seen in (first-seen only --
+ * this drives an actionable error message, not exhaustive provenance).
+ */
+export function collectDocumentedHelperInvocationFlags(
+  sources: readonly HelperFlagDriftSource[],
+): DocumentedHelperFlags[] {
+  const byHelper = new Map<string, Map<string, string>>();
+
+  for (const source of sources) {
+    for (const line of extractFencedLines(source.text)) {
+      const match = NODE_INVOCATION_LINE_PATTERN.exec(line);
+      if (!match) {
+        continue;
+      }
+      const helperPath = match[1];
+      // A path-alias / traversal segment (`scripts/../bin/x.mjs`) is never
+      // a genuine worked example -- docs/permissions.md deliberately shows
+      // one to illustrate a Bash-permission prefix-matching gap. Skip it
+      // rather than resolve and flag a path nobody intends to invoke this
+      // way.
+      if (helperPath.includes('..')) {
+        continue;
+      }
+      const argsText = match[2];
+      let flagsForHelper = byHelper.get(helperPath);
+      if (!flagsForHelper) {
+        flagsForHelper = new Map();
+        byHelper.set(helperPath, flagsForHelper);
+      }
+      for (const flagMatch of argsText.matchAll(FLAG_TOKEN_PATTERN)) {
+        if (!flagsForHelper.has(flagMatch[0])) {
+          flagsForHelper.set(flagMatch[0], source.path);
+        }
+      }
+    }
+  }
+
+  return [...byHelper.entries()]
+    .map(([helperPath, flags]) => ({
+      helperPath,
+      flags: [...flags.entries()]
+        .map(([flag, docPath]) => ({ flag, docPath }))
+        .sort((left, right) => left.flag.localeCompare(right.flag)),
+    }))
+    .sort((left, right) => left.helperPath.localeCompare(right.helperPath));
+}
+
+/**
+ * Diff each helper's documented flags against its actual `--help` output
+ * (via `probe`, injected so this stays pure). A helper whose probed output
+ * carries zero recognizable `--flag` tokens is treated as an unverifiable
+ * CLI (e.g. an interactive-only tool with no flag-driven `--help`) and is
+ * skipped entirely, rather than flagging every one of its documented flags
+ * as missing.
+ */
+export function collectHelperFlagDriftViolations(
+  documented: readonly DocumentedHelperFlags[],
+  probe: (helperPath: string) => HelperProbeResult,
+): string[] {
+  const violations: string[] = [];
+
+  for (const entry of documented) {
+    const result = probe(entry.helperPath);
+    if (!result.exists) {
+      const firstDocPath = entry.flags[0]?.docPath ?? '(unknown doc)';
+      violations.push(
+        `${firstDocPath}: documents \`node ${entry.helperPath}\`, but ${entry.helperPath} does not exist in the repository`,
+      );
+      continue;
+    }
+
+    const actualFlags = extractFlagTokens(result.output);
+    if (actualFlags.size === 0) {
+      continue;
+    }
+
+    for (const { flag, docPath } of entry.flags) {
+      if (!actualFlags.has(flag)) {
+        violations.push(
+          `${docPath}: documents \`${flag}\` for ${entry.helperPath}, but that flag does not appear in its --help output (possibly renamed or removed)`,
+        );
+      }
+    }
+  }
+
+  return violations;
+}

--- a/src/scripts/helper-flag-drift.mts
+++ b/src/scripts/helper-flag-drift.mts
@@ -67,24 +67,42 @@ const FLAG_TOKEN_PATTERN = /--[a-z][a-z0-9-]*/g;
 const NODE_INVOCATION_LINE_PATTERN = /\bnode\s+(scripts\/[\w./-]+\.mjs)\b(.*)$/;
 
 /**
- * Extract every line that falls inside a triple-backtick fenced code block
- * in `text`. Line-based and only recognizes triple-backtick fences,
- * matching the same approximation `extractHeadingSlugs` in
+ * Extract every triple-backtick fenced code block in `text` as its own
+ * array of lines (fence delimiter lines excluded), preserving block
+ * boundaries so a shell line-continuation join never bridges two
+ * unrelated fences. An unterminated trailing fence still counts, matching
+ * the same permissive toggle `extractHeadingSlugs` in
  * markdown-link-audit.mts already accepts elsewhere in this audit.
  */
-export function extractFencedLines(text: string): string[] {
-  const lines: string[] = [];
-  let inFence = false;
+export function extractFencedBlocks(text: string): string[][] {
+  const blocks: string[][] = [];
+  let current: string[] | null = null;
   for (const line of text.split(/\r?\n/)) {
     if (/^\s*```/.test(line)) {
-      inFence = !inFence;
+      if (current) {
+        blocks.push(current);
+        current = null;
+      } else {
+        current = [];
+      }
       continue;
     }
-    if (inFence) {
-      lines.push(line);
+    if (current) {
+      current.push(line);
     }
   }
-  return lines;
+  if (current) {
+    blocks.push(current);
+  }
+  return blocks;
+}
+
+/**
+ * Extract every line that falls inside a triple-backtick fenced code block
+ * in `text`, across every block, in document order.
+ */
+export function extractFencedLines(text: string): string[] {
+  return extractFencedBlocks(text).flat();
 }
 
 /** Every distinct `--flag` token appearing anywhere in `text`. */
@@ -95,10 +113,38 @@ export function extractFlagTokens(text: string): Set<string> {
 }
 
 /**
+ * Join a trailing `\` shell line-continuation within one fenced block into
+ * a single logical line, so a worked example wrapped across several lines
+ * (common throughout this repo's instructions) is read as one command
+ * instead of losing every flag after the first wrapped line.
+ */
+function joinLineContinuations(block: readonly string[]): string[] {
+  const logicalLines: string[] = [];
+  let buffer = '';
+  for (const rawLine of block) {
+    const trimmedEnd = rawLine.replace(/\s+$/, '');
+    if (trimmedEnd.endsWith('\\')) {
+      buffer += `${trimmedEnd.slice(0, -1)} `;
+      continue;
+    }
+    buffer += rawLine;
+    logicalLines.push(buffer);
+    buffer = '';
+  }
+  if (buffer) {
+    // A trailing continuation with no following line -- keep whatever was
+    // accumulated rather than silently dropping it.
+    logicalLines.push(buffer);
+  }
+  return logicalLines;
+}
+
+/**
  * Scan every source for fenced `node scripts/<helper>.mjs ...` invocation
- * lines and collect the distinct `--flag` tokens documented per helper,
- * each paired with the first doc file it was seen in (first-seen only --
- * this drives an actionable error message, not exhaustive provenance).
+ * lines (continuation-joined, see `joinLineContinuations`) and collect the
+ * distinct `--flag` tokens documented per helper, each paired with the
+ * first doc file it was seen in (first-seen only -- this drives an
+ * actionable error message, not exhaustive provenance).
  */
 export function collectDocumentedHelperInvocationFlags(
   sources: readonly HelperFlagDriftSource[],
@@ -106,29 +152,31 @@ export function collectDocumentedHelperInvocationFlags(
   const byHelper = new Map<string, Map<string, string>>();
 
   for (const source of sources) {
-    for (const line of extractFencedLines(source.text)) {
-      const match = NODE_INVOCATION_LINE_PATTERN.exec(line);
-      if (!match) {
-        continue;
-      }
-      const helperPath = match[1];
-      // A path-alias / traversal segment (`scripts/../bin/x.mjs`) is never
-      // a genuine worked example -- docs/permissions.md deliberately shows
-      // one to illustrate a Bash-permission prefix-matching gap. Skip it
-      // rather than resolve and flag a path nobody intends to invoke this
-      // way.
-      if (helperPath.includes('..')) {
-        continue;
-      }
-      const argsText = match[2];
-      let flagsForHelper = byHelper.get(helperPath);
-      if (!flagsForHelper) {
-        flagsForHelper = new Map();
-        byHelper.set(helperPath, flagsForHelper);
-      }
-      for (const flagMatch of argsText.matchAll(FLAG_TOKEN_PATTERN)) {
-        if (!flagsForHelper.has(flagMatch[0])) {
-          flagsForHelper.set(flagMatch[0], source.path);
+    for (const block of extractFencedBlocks(source.text)) {
+      for (const line of joinLineContinuations(block)) {
+        const match = NODE_INVOCATION_LINE_PATTERN.exec(line);
+        if (!match) {
+          continue;
+        }
+        const helperPath = match[1];
+        // A path-alias / traversal segment (`scripts/../bin/x.mjs`) is
+        // never a genuine worked example -- docs/permissions.md
+        // deliberately shows one to illustrate a Bash-permission
+        // prefix-matching gap. Skip it rather than resolve and flag a
+        // path nobody intends to invoke this way.
+        if (helperPath.includes('..')) {
+          continue;
+        }
+        const argsText = match[2];
+        let flagsForHelper = byHelper.get(helperPath);
+        if (!flagsForHelper) {
+          flagsForHelper = new Map();
+          byHelper.set(helperPath, flagsForHelper);
+        }
+        for (const flagMatch of argsText.matchAll(FLAG_TOKEN_PATTERN)) {
+          if (!flagsForHelper.has(flagMatch[0])) {
+            flagsForHelper.set(flagMatch[0], source.path);
+          }
         }
       }
     }

--- a/tests/helper-flag-drift.test.mts
+++ b/tests/helper-flag-drift.test.mts
@@ -108,6 +108,8 @@ test('collectDocumentedHelperInvocationFlags finds a worked example nested insid
   assert.deepEqual(documented, [
     {
       helperPath: 'scripts/idd-onboard.mjs',
+      firstSeenDocPath:
+        'idd-template/docs/onboarding/issue-mediated-bootstrap.md',
       flags: [
         {
           flag: '--import',
@@ -159,6 +161,7 @@ test('collectDocumentedHelperInvocationFlags extracts flags from a fenced worked
   assert.deepEqual(documented, [
     {
       helperPath: 'scripts/post-idd-marker.mjs',
+      firstSeenDocPath: 'docs/example.md',
       flags: [
         { flag: '--apply', docPath: 'docs/example.md' },
         { flag: '--type', docPath: 'docs/example.md' },
@@ -189,6 +192,26 @@ test('collectDocumentedHelperInvocationFlags ignores a placeholder helper name',
     },
   ]);
   assert.deepEqual(documented, []);
+});
+
+test('collectDocumentedHelperInvocationFlags records firstSeenDocPath even for an invocation with zero flags', () => {
+  // The docs/getting-started.md #2477 case: `node scripts/idd-doctor.mjs`
+  // with no flags at all. `flags` alone cannot supply a doc path for a
+  // missing-helper violation when the array is empty.
+  const documented = collectDocumentedHelperInvocationFlags([
+    {
+      path: 'docs/getting-started.md',
+      text: ['```sh', 'node scripts/idd-doctor.mjs', '```'].join('\n'),
+    },
+  ]);
+
+  assert.deepEqual(documented, [
+    {
+      helperPath: 'scripts/idd-doctor.mjs',
+      firstSeenDocPath: 'docs/getting-started.md',
+      flags: [],
+    },
+  ]);
 });
 
 test('collectDocumentedHelperInvocationFlags skips a path-traversal example', () => {
@@ -226,6 +249,7 @@ test('collectDocumentedHelperInvocationFlags joins a shell line-continuation and
   assert.deepEqual(documented, [
     {
       helperPath: 'scripts/post-idd-marker.mjs',
+      firstSeenDocPath: 'docs/example.md',
       flags: [
         { flag: '--agent-id', docPath: 'docs/example.md' },
         { flag: '--apply', docPath: 'docs/example.md' },
@@ -259,6 +283,7 @@ test('collectDocumentedHelperInvocationFlags does not bridge a continuation acro
   assert.deepEqual(documented, [
     {
       helperPath: 'scripts/example.mjs',
+      firstSeenDocPath: 'docs/example.md',
       flags: [{ flag: '--apply', docPath: 'docs/example.md' }],
     },
   ]);
@@ -283,6 +308,7 @@ test('collectDocumentedHelperInvocationFlags merges flags for the same helper ac
   assert.deepEqual(documented, [
     {
       helperPath: 'scripts/example.mjs',
+      firstSeenDocPath: 'docs/a.md',
       flags: [
         { flag: '--apply', docPath: 'docs/a.md' },
         { flag: '--claim-issue', docPath: 'docs/b.md' },
@@ -298,6 +324,7 @@ test('collectHelperFlagDriftViolations flags a documented flag missing from --he
     [
       {
         helperPath: 'scripts/example.mjs',
+        firstSeenDocPath: 'docs/a.md',
         flags: [
           { flag: '--apply', docPath: 'docs/a.md' },
           { flag: '--renamed-flag', docPath: 'docs/a.md' },
@@ -317,6 +344,7 @@ test('collectHelperFlagDriftViolations reports no violations when every document
     [
       {
         helperPath: 'scripts/example.mjs',
+        firstSeenDocPath: 'docs/a.md',
         flags: [{ flag: '--apply', docPath: 'docs/a.md' }],
       },
     ],
@@ -330,6 +358,7 @@ test('collectHelperFlagDriftViolations flags a documented helper that no longer 
     [
       {
         helperPath: 'scripts/renamed-away.mjs',
+        firstSeenDocPath: 'docs/a.md',
         flags: [{ flag: '--apply', docPath: 'docs/a.md' }],
       },
     ],
@@ -341,6 +370,26 @@ test('collectHelperFlagDriftViolations flags a documented helper that no longer 
   ]);
 });
 
+test('collectHelperFlagDriftViolations reports the real doc path for a missing helper invoked with zero flags', () => {
+  // The exact #2477 review finding: entry.flags[0]?.docPath degraded to
+  // "(unknown doc)" when the documented invocation carried no flags at
+  // all -- firstSeenDocPath must supply a real location regardless.
+  const violations = collectHelperFlagDriftViolations(
+    [
+      {
+        helperPath: 'scripts/renamed-away.mjs',
+        firstSeenDocPath: 'docs/getting-started.md',
+        flags: [],
+      },
+    ],
+    () => ({ exists: false, output: '' }),
+  );
+
+  assert.deepEqual(violations, [
+    'docs/getting-started.md: documents `node scripts/renamed-away.mjs`, but scripts/renamed-away.mjs does not exist in the repository',
+  ]);
+});
+
 test('collectHelperFlagDriftViolations skips a helper whose --help output has no recognizable flags', () => {
   // An interactive-only helper (e.g. force-handoff.mjs) errors immediately
   // on --help with no flag-shaped output at all -- treated as unverifiable
@@ -349,6 +398,7 @@ test('collectHelperFlagDriftViolations skips a helper whose --help output has no
     [
       {
         helperPath: 'scripts/interactive-only.mjs',
+        firstSeenDocPath: 'docs/a.md',
         flags: [{ flag: '--apply', docPath: 'docs/a.md' }],
       },
     ],

--- a/tests/helper-flag-drift.test.mts
+++ b/tests/helper-flag-drift.test.mts
@@ -59,6 +59,73 @@ test('extractFencedBlocks keeps each fence as its own array of lines', () => {
   ]);
 });
 
+test('extractFencedBlocks treats a shorter nested backtick run as content, not a delimiter', () => {
+  // The real idd-template/docs/onboarding/issue-mediated-bootstrap.md
+  // shape: a four-backtick fence wraps an illustrative issue-body
+  // template that itself shows a genuine three-backtick `sh` worked
+  // example. A length-agnostic toggle would treat the inner ```sh/```
+  // pair as closing and reopening the outer fence, scrambling everything
+  // after it and skipping the worked example entirely.
+  const text = [
+    '````markdown',
+    'Some prose.',
+    '```sh',
+    'node scripts/idd-onboard.mjs --import --source "$CLONE_DIR"',
+    '```',
+    'More prose after the inner fence, still inside the outer one.',
+    '````',
+    'Real prose outside every fence.',
+  ].join('\n');
+
+  assert.deepEqual(extractFencedBlocks(text), [
+    [
+      'Some prose.',
+      '```sh',
+      'node scripts/idd-onboard.mjs --import --source "$CLONE_DIR"',
+      '```',
+      'More prose after the inner fence, still inside the outer one.',
+    ],
+  ]);
+});
+
+test('collectDocumentedHelperInvocationFlags finds a worked example nested inside a longer outer fence', () => {
+  const documented = collectDocumentedHelperInvocationFlags([
+    {
+      path: 'idd-template/docs/onboarding/issue-mediated-bootstrap.md',
+      text: [
+        '````markdown',
+        'Some prose.',
+        '```sh',
+        'node scripts/idd-onboard.mjs --import \\',
+        '  --source "$CLONE_DIR" --target "$TARGET_REPO"',
+        '```',
+        'More prose.',
+        '````',
+      ].join('\n'),
+    },
+  ]);
+
+  assert.deepEqual(documented, [
+    {
+      helperPath: 'scripts/idd-onboard.mjs',
+      flags: [
+        {
+          flag: '--import',
+          docPath: 'idd-template/docs/onboarding/issue-mediated-bootstrap.md',
+        },
+        {
+          flag: '--source',
+          docPath: 'idd-template/docs/onboarding/issue-mediated-bootstrap.md',
+        },
+        {
+          flag: '--target',
+          docPath: 'idd-template/docs/onboarding/issue-mediated-bootstrap.md',
+        },
+      ],
+    },
+  ]);
+});
+
 // --- extractFlagTokens ---------------------------------------------------
 
 test('extractFlagTokens finds every distinct --flag token in free text', () => {

--- a/tests/helper-flag-drift.test.mts
+++ b/tests/helper-flag-drift.test.mts
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  collectDocumentedHelperInvocationFlags,
+  collectHelperFlagDriftViolations,
+  extractFencedLines,
+  extractFlagTokens,
+} from '../src/scripts/helper-flag-drift.mts';
+
+// --- extractFencedLines -------------------------------------------------
+
+test('extractFencedLines returns only lines inside a triple-backtick fence', () => {
+  const text = [
+    'Some prose mentioning `--not-a-fence`.',
+    '```sh',
+    'node scripts/example.mjs --apply',
+    '```',
+    'More prose after the fence.',
+  ].join('\n');
+
+  assert.deepEqual(extractFencedLines(text), [
+    'node scripts/example.mjs --apply',
+  ]);
+});
+
+test('extractFencedLines handles multiple fences and an unterminated one', () => {
+  const text = [
+    '```sh',
+    'line-a',
+    '```',
+    'prose',
+    '```text',
+    'line-b',
+    // no closing fence -- still counts as "inside" per the toggle
+  ].join('\n');
+
+  assert.deepEqual(extractFencedLines(text), ['line-a', 'line-b']);
+});
+
+// --- extractFlagTokens ---------------------------------------------------
+
+test('extractFlagTokens finds every distinct --flag token in free text', () => {
+  const flags = extractFlagTokens(
+    '--type <type> --target <issue|pr> <number> [--apply] --type',
+  );
+  assert.deepEqual([...flags].sort(), ['--apply', '--target', '--type']);
+});
+
+test('extractFlagTokens returns an empty set for text with no flag tokens', () => {
+  assert.deepEqual(
+    extractFlagTokens('Error: operator interaction is required'),
+    new Set(),
+  );
+});
+
+// --- collectDocumentedHelperInvocationFlags ------------------------------
+
+test('collectDocumentedHelperInvocationFlags extracts flags from a fenced worked example', () => {
+  const documented = collectDocumentedHelperInvocationFlags([
+    {
+      path: 'docs/example.md',
+      text: [
+        '```sh',
+        'node scripts/post-idd-marker.mjs --type watermark --apply',
+        '```',
+      ].join('\n'),
+    },
+  ]);
+
+  assert.deepEqual(documented, [
+    {
+      helperPath: 'scripts/post-idd-marker.mjs',
+      flags: [
+        { flag: '--apply', docPath: 'docs/example.md' },
+        { flag: '--type', docPath: 'docs/example.md' },
+      ],
+    },
+  ]);
+});
+
+test('collectDocumentedHelperInvocationFlags ignores an invocation outside a fence', () => {
+  const documented = collectDocumentedHelperInvocationFlags([
+    {
+      path: 'docs/example.md',
+      text: 'See `node scripts/post-idd-marker.mjs --type watermark` for details.',
+    },
+  ]);
+  assert.deepEqual(documented, []);
+});
+
+test('collectDocumentedHelperInvocationFlags ignores a placeholder helper name', () => {
+  const documented = collectDocumentedHelperInvocationFlags([
+    {
+      path: 'docs/example.md',
+      text: [
+        '```sh',
+        'node scripts/<helper-name>.mjs --type watermark',
+        '```',
+      ].join('\n'),
+    },
+  ]);
+  assert.deepEqual(documented, []);
+});
+
+test('collectDocumentedHelperInvocationFlags skips a path-traversal example', () => {
+  // The docs/permissions.md #2477 false-positive case: a deliberate
+  // Bash-permission bypass illustration, never a real worked example.
+  const documented = collectDocumentedHelperInvocationFlags([
+    {
+      path: 'docs/permissions.md',
+      text: [
+        '```text',
+        'node scripts/../bin/idd-merge-execute.mjs --apply',
+        '```',
+      ].join('\n'),
+    },
+  ]);
+  assert.deepEqual(documented, []);
+});
+
+test('collectDocumentedHelperInvocationFlags merges flags for the same helper across files, keeping first-seen doc provenance', () => {
+  const documented = collectDocumentedHelperInvocationFlags([
+    {
+      path: 'docs/a.md',
+      text: ['```sh', 'node scripts/example.mjs --apply', '```'].join('\n'),
+    },
+    {
+      path: 'docs/b.md',
+      text: [
+        '```sh',
+        'node scripts/example.mjs --apply --claim-issue 1',
+        '```',
+      ].join('\n'),
+    },
+  ]);
+
+  assert.deepEqual(documented, [
+    {
+      helperPath: 'scripts/example.mjs',
+      flags: [
+        { flag: '--apply', docPath: 'docs/a.md' },
+        { flag: '--claim-issue', docPath: 'docs/b.md' },
+      ],
+    },
+  ]);
+});
+
+// --- collectHelperFlagDriftViolations -------------------------------------
+
+test('collectHelperFlagDriftViolations flags a documented flag missing from --help output', () => {
+  const violations = collectHelperFlagDriftViolations(
+    [
+      {
+        helperPath: 'scripts/example.mjs',
+        flags: [
+          { flag: '--apply', docPath: 'docs/a.md' },
+          { flag: '--renamed-flag', docPath: 'docs/a.md' },
+        ],
+      },
+    ],
+    () => ({ exists: true, output: 'usage: --apply [--claim-issue <n>]' }),
+  );
+
+  assert.deepEqual(violations, [
+    'docs/a.md: documents `--renamed-flag` for scripts/example.mjs, but that flag does not appear in its --help output (possibly renamed or removed)',
+  ]);
+});
+
+test('collectHelperFlagDriftViolations reports no violations when every documented flag is still accepted', () => {
+  const violations = collectHelperFlagDriftViolations(
+    [
+      {
+        helperPath: 'scripts/example.mjs',
+        flags: [{ flag: '--apply', docPath: 'docs/a.md' }],
+      },
+    ],
+    () => ({ exists: true, output: 'usage: --apply [--claim-issue <n>]' }),
+  );
+  assert.deepEqual(violations, []);
+});
+
+test('collectHelperFlagDriftViolations flags a documented helper that no longer exists', () => {
+  const violations = collectHelperFlagDriftViolations(
+    [
+      {
+        helperPath: 'scripts/renamed-away.mjs',
+        flags: [{ flag: '--apply', docPath: 'docs/a.md' }],
+      },
+    ],
+    () => ({ exists: false, output: '' }),
+  );
+
+  assert.deepEqual(violations, [
+    'docs/a.md: documents `node scripts/renamed-away.mjs`, but scripts/renamed-away.mjs does not exist in the repository',
+  ]);
+});
+
+test('collectHelperFlagDriftViolations skips a helper whose --help output has no recognizable flags', () => {
+  // An interactive-only helper (e.g. force-handoff.mjs) errors immediately
+  // on --help with no flag-shaped output at all -- treated as unverifiable
+  // rather than flagging every documented flag as missing.
+  const violations = collectHelperFlagDriftViolations(
+    [
+      {
+        helperPath: 'scripts/interactive-only.mjs',
+        flags: [{ flag: '--apply', docPath: 'docs/a.md' }],
+      },
+    ],
+    () => ({
+      exists: true,
+      output: 'Error: operator interaction is required',
+    }),
+  );
+  assert.deepEqual(violations, []);
+});

--- a/tests/helper-flag-drift.test.mts
+++ b/tests/helper-flag-drift.test.mts
@@ -4,6 +4,7 @@ import { test } from 'node:test';
 import {
   collectDocumentedHelperInvocationFlags,
   collectHelperFlagDriftViolations,
+  extractFencedBlocks,
   extractFencedLines,
   extractFlagTokens,
 } from '../src/scripts/helper-flag-drift.mts';
@@ -36,6 +37,26 @@ test('extractFencedLines handles multiple fences and an unterminated one', () =>
   ].join('\n');
 
   assert.deepEqual(extractFencedLines(text), ['line-a', 'line-b']);
+});
+
+// --- extractFencedBlocks --------------------------------------------------
+
+test('extractFencedBlocks keeps each fence as its own array of lines', () => {
+  const text = [
+    '```sh',
+    'line-a',
+    'line-b',
+    '```',
+    'prose',
+    '```text',
+    'line-c',
+    '```',
+  ].join('\n');
+
+  assert.deepEqual(extractFencedBlocks(text), [
+    ['line-a', 'line-b'],
+    ['line-c'],
+  ]);
 });
 
 // --- extractFlagTokens ---------------------------------------------------
@@ -117,6 +138,63 @@ test('collectDocumentedHelperInvocationFlags skips a path-traversal example', ()
     },
   ]);
   assert.deepEqual(documented, []);
+});
+
+test('collectDocumentedHelperInvocationFlags joins a shell line-continuation and extracts flags from the continuation lines', () => {
+  // The common worked-example style throughout this repo's instructions:
+  // a long invocation wrapped across several lines with a trailing `\`.
+  const documented = collectDocumentedHelperInvocationFlags([
+    {
+      path: 'docs/example.md',
+      text: [
+        '```sh',
+        'node scripts/post-idd-marker.mjs --type watermark \\',
+        '  --agent-id <id> --claim-id <claim-id> \\',
+        '  --from-pr <pr-number> --apply',
+        '```',
+      ].join('\n'),
+    },
+  ]);
+
+  assert.deepEqual(documented, [
+    {
+      helperPath: 'scripts/post-idd-marker.mjs',
+      flags: [
+        { flag: '--agent-id', docPath: 'docs/example.md' },
+        { flag: '--apply', docPath: 'docs/example.md' },
+        { flag: '--claim-id', docPath: 'docs/example.md' },
+        { flag: '--from-pr', docPath: 'docs/example.md' },
+        { flag: '--type', docPath: 'docs/example.md' },
+      ],
+    },
+  ]);
+});
+
+test('collectDocumentedHelperInvocationFlags does not bridge a continuation across two separate fences', () => {
+  const documented = collectDocumentedHelperInvocationFlags([
+    {
+      path: 'docs/example.md',
+      text: [
+        '```sh',
+        'node scripts/example.mjs --apply \\',
+        '```',
+        'unrelated prose',
+        '```sh',
+        '--should-not-attach',
+        '```',
+      ].join('\n'),
+    },
+  ]);
+
+  // The trailing `\` has no following line within its own fence, so it is
+  // kept as-is (no crash, no cross-fence join) and the unrelated second
+  // fence's line never matches the invocation pattern on its own.
+  assert.deepEqual(documented, [
+    {
+      helperPath: 'scripts/example.mjs',
+      flags: [{ flag: '--apply', docPath: 'docs/example.md' }],
+    },
+  ]);
 });
 
 test('collectDocumentedHelperInvocationFlags merges flags for the same helper across files, keeping first-seen doc provenance', () => {


### PR DESCRIPTION
## Summary

A downstream 2.5-month review-comment audit found instructions-vs-implementation drift as the single largest upstream-attributable finding category (60 of 466 instances), with no automated guard catching it today — only ad hoc field reports after an adopter hits one.

This adds a new `audit-docs.mjs` check (`src/scripts/helper-flag-drift.mts`): scan every fenced ```` ```sh ```` (or any fenced) worked example across `docs/**`, `idd-template/**`, and `.github/instructions/**` for a `node scripts/<helper>.mjs --flag ...` invocation, then verify each documented `--flag` still appears in that helper's own `--help` output. Also flags a documented helper path that no longer exists at all (a stronger drift signal).

**Design notes:**

- **One-directional**: a documented flag must exist in `--help` output; a flag the helper accepts but no doc mentions is not flagged. Enumerating full CLI coverage per helper is a much larger, noisier claim than "the worked examples still run."
- **No pre-push-validate chain edit**: `audit-docs.mjs --check` already runs in it, so this check is wired in for free (AC2) — no edit to `idd-overview-core.instructions.md`'s command-chain definition, which is a shared, near-budget bundle member (`bundle-merge` 97.95%, `bundle-review` 97.50% of their byte budgets) and a distributed default other adopters rely on.
- **AC3 (anchor-link validation) is already covered** by the existing `markdownLinkAudit` (#1697/#1696) — verified it's live (`src/scripts/markdown-link-audit.mts`, wired into `checkMarkdownLinkAudit`) before writing any new code for it. This PR adds nothing for that half of the AC.
- **Skips false positives**: a path-traversal example (`docs/permissions.md`'s deliberate `scripts/../bin/idd-merge-execute.mjs` Bash-permission-bypass illustration) is excluded, and a helper whose `--help` output carries zero recognizable `--flag` tokens (e.g. an interactive-only tool like `force-handoff.mjs`) is treated as unverifiable rather than flagging every documented flag as missing.
- **JSON-schema-vs-doc class deliberately not implemented**: the issue's AC says "at least one class" — this PR implements the flag/`--help` class only. A schema-required-fields class is a reasonable follow-up.
- Verified against the live corpus: `node scripts/audit-docs.mjs --check` passes with zero findings today (no genuine drift currently present); a synthetic fake-flag/missing-helper test confirmed the check actually fires (see PR discussion / commit message).

## Acceptance criteria

- [x] A CI-runnable check compares at least one class of instructions-vs-implementation surface (a helper's `--help` flag set vs. its documented worked-example flags) and fails on drift.
- [x] The check is wired into `pre-push-validate` (via the existing `audit-docs.mjs --check` step — no chain edit needed).
- [x] `docs/**` anchor links are validated against actual heading slugs (already covered by the pre-existing `markdownLinkAudit`, #1697).

## Test plan

- [x] `node --test tests/helper-flag-drift.test.mts` (13 new unit tests: fence extraction, flag extraction, per-helper aggregation, path-traversal exclusion, missing-helper and unverifiable-CLI edge cases)
- [x] `node --test tests/*.test.mts` (full suite, 4848 tests)
- [x] `node scripts/audit-docs.mjs --check`
- [x] `npx tsc -p tsconfig.json`
- [x] `npx biome check`, `npx dprint check "**/*.md"`, `npx markdownlint-cli2 "**/*.md"`, `npx cspell lint "**" --no-progress`
- [x] `node scripts/audit-code-span-wrap.mjs`
- [x] `node --test tests/agent-entry-mirror-sync.test.mts`
- [x] `node --test tests/cli-entry-smoke.test.mts` (module-eval-order / TDZ guard)
- [x] `pnpm run build:check`
- [x] `node scripts/idd-doctor.mjs`

Closes #2477