### PR TITLE
fix(protocol-helpers): credit every bot a disposition reply names

### DIFF
--- a/scripts/protocol-helpers.mjs
+++ b/scripts/protocol-helpers.mjs
@@ -1386,7 +1386,6 @@ function matchTrustedAdvisoryStickyDispositions(
   iddAgentLogins,
 ) {
   const dispositionedStickyIndexes = new Set();
-  const consumedDispositionIndexes = new Set();
   const trustedDispositions = comments.filter(
     (comment) =>
       trustedMarkerLogins.has(comment.authorLogin) &&
@@ -1425,9 +1424,16 @@ function matchTrustedAdvisoryStickyDispositions(
       list.push(comment);
       stickiesByBot.set(comment.authorLogin, list);
     }
-    // Sort bot logins so a disposition naming more than one configured bot is
-    // consumed deterministically (by the lexicographically-first bot only).
+    // Sort bot logins for deterministic iteration order only. Consumption is
+    // tracked per bot login (`consumedDispositionIndexes` below, reset on
+    // each iteration of this loop) rather than shared across bots: a single
+    // disposition naming several configured bots (`dispositionNamesAdvisoryBot`
+    // matches each one it names) must be able to clear one sticky per bot it
+    // names, not just the first bot processed. #2475 -- a shared,
+    // loop-wide consumption set previously let only the alphabetically-first
+    // named bot's sticky be credited, stranding the others.
     for (const botLogin of [...stickiesByBot.keys()].sort()) {
+      const consumedDispositionIndexes = new Set();
       const stickies = [...(stickiesByBot.get(botLogin) ?? [])].sort(
         byActivityThenIndex,
       );
@@ -3172,15 +3178,24 @@ export function summarizeDispositionEvidenceForGate(
     list.push(notice);
     noticesByAuthor.set(notice.authorLogin, list);
   }
-  // Sort the bot logins so disposition consumption is deterministic when a single
-  // disposition body could name more than one configured bot (it is consumed by
-  // the lexicographically-first matching author only).
+  // Sort the bot logins for deterministic iteration order only. Each
+  // author's own `matchingDispositions` is computed independently from the
+  // full `noticeDispositions` pool -- never filtered by another author's
+  // carry -- so a single disposition naming several configured bots
+  // (`dispositionNamesAdvisoryBot` matches each one it names) can carry
+  // forward one notice per bot it names, not just the alphabetically-first
+  // bot processed (#2475). `matchingDispositions.length` still bounds
+  // `carry` per author, so this author's own notices are never
+  // over-credited from a single matching disposition.
+  // `consumedNoticeDispositionIndexes` still accumulates the union of every
+  // disposition consumed across every author -- read again below to
+  // exclude those same comments from the separate generic 1:1 pool, so a
+  // disposition that already carried a notice forward can never also clear
+  // an unrelated regular comment there.
   for (const authorLogin of [...noticesByAuthor.keys()].sort()) {
     const notices = noticesByAuthor.get(authorLogin) ?? [];
-    const matchingDispositions = noticeDispositions.filter(
-      (disposition) =>
-        !consumedNoticeDispositionIndexes.has(disposition.sortedIndex) &&
-        dispositionNamesAdvisoryBot(disposition.body, authorLogin),
+    const matchingDispositions = noticeDispositions.filter((disposition) =>
+      dispositionNamesAdvisoryBot(disposition.body, authorLogin),
     );
     const carry = Math.min(notices.length, matchingDispositions.length);
     for (let index = 0; index < carry; index += 1) {

--- a/src/scripts/protocol-helpers.mts
+++ b/src/scripts/protocol-helpers.mts
@@ -2145,7 +2145,6 @@ function matchTrustedAdvisoryStickyDispositions<
   iddAgentLogins: Set<string>,
 ): Set<number> {
   const dispositionedStickyIndexes = new Set<number>();
-  const consumedDispositionIndexes = new Set<number>();
   const trustedDispositions = comments.filter(
     (comment) =>
       trustedMarkerLogins.has(comment.authorLogin) &&
@@ -2184,9 +2183,16 @@ function matchTrustedAdvisoryStickyDispositions<
       list.push(comment);
       stickiesByBot.set(comment.authorLogin, list);
     }
-    // Sort bot logins so a disposition naming more than one configured bot is
-    // consumed deterministically (by the lexicographically-first bot only).
+    // Sort bot logins for deterministic iteration order only. Consumption is
+    // tracked per bot login (`consumedDispositionIndexes` below, reset on
+    // each iteration of this loop) rather than shared across bots: a single
+    // disposition naming several configured bots (`dispositionNamesAdvisoryBot`
+    // matches each one it names) must be able to clear one sticky per bot it
+    // names, not just the first bot processed. #2475 -- a shared,
+    // loop-wide consumption set previously let only the alphabetically-first
+    // named bot's sticky be credited, stranding the others.
     for (const botLogin of [...stickiesByBot.keys()].sort()) {
+      const consumedDispositionIndexes = new Set<number>();
       const stickies = [...(stickiesByBot.get(botLogin) ?? [])].sort(
         byActivityThenIndex,
       );
@@ -4167,15 +4173,24 @@ export function summarizeDispositionEvidenceForGate(
     list.push(notice);
     noticesByAuthor.set(notice.authorLogin, list);
   }
-  // Sort the bot logins so disposition consumption is deterministic when a single
-  // disposition body could name more than one configured bot (it is consumed by
-  // the lexicographically-first matching author only).
+  // Sort the bot logins for deterministic iteration order only. Each
+  // author's own `matchingDispositions` is computed independently from the
+  // full `noticeDispositions` pool -- never filtered by another author's
+  // carry -- so a single disposition naming several configured bots
+  // (`dispositionNamesAdvisoryBot` matches each one it names) can carry
+  // forward one notice per bot it names, not just the alphabetically-first
+  // bot processed (#2475). `matchingDispositions.length` still bounds
+  // `carry` per author, so this author's own notices are never
+  // over-credited from a single matching disposition.
+  // `consumedNoticeDispositionIndexes` still accumulates the union of every
+  // disposition consumed across every author -- read again below to
+  // exclude those same comments from the separate generic 1:1 pool, so a
+  // disposition that already carried a notice forward can never also clear
+  // an unrelated regular comment there.
   for (const authorLogin of [...noticesByAuthor.keys()].sort()) {
     const notices = noticesByAuthor.get(authorLogin) ?? [];
-    const matchingDispositions = noticeDispositions.filter(
-      (disposition) =>
-        !consumedNoticeDispositionIndexes.has(disposition.sortedIndex) &&
-        dispositionNamesAdvisoryBot(disposition.body, authorLogin),
+    const matchingDispositions = noticeDispositions.filter((disposition) =>
+      dispositionNamesAdvisoryBot(disposition.body, authorLogin),
     );
     const carry = Math.min(notices.length, matchingDispositions.length);
     for (let index = 0; index < carry; index += 1) {

--- a/tests/pre-merge-readiness.test.mts
+++ b/tests/pre-merge-readiness.test.mts
@@ -3716,6 +3716,97 @@ test('disposition evidence carries a re-posted CodeRabbit rate-limit notice forw
   assert.equal(summary.blockingCount, 0);
 });
 
+// #2475 — a single trusted disposition reply that names TWO different advisory
+// bots in one span (against convention, but structurally valid per
+// `dispositionNamesAdvisoryBot`'s own "still matches each of them" contract)
+// must credit BOTH bots' notices, not just the alphabetically-first bot login.
+// Regression for a reported bug where `matchTrustedAdvisoryStickyDispositions`
+// shared one `consumedDispositionIndexes` set across every bot login, so the
+// second bot's notice was left stranded once the shared disposition was
+// consumed while matching the first (alphabetically-first) bot it processed.
+test('disposition evidence credits both bots when one trusted reply names both by login', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          body: 'You have reached your Codex usage limits for code reviews.',
+          author: { login: 'chatgpt-codex-connector[bot]' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T00:00:10Z',
+          body: '<!-- This is an auto-generated comment: summarize by coderabbit.ai -->\n<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n\n> [!WARNING]\n> ## Review limit reached\n>\n> `@kurone-kito`, we could not start this review because the limit was reached.',
+          author: { login: 'coderabbitai[bot]' },
+        },
+        {
+          id: 3,
+          createdAt: '2026-05-12T00:00:30Z',
+          body: '**Rejected** — chatgpt-codex-connector[bot] and coderabbitai[bot] did not review HEAD abc1234 (rate limited); this is not a completed review',
+          author: { login: 'trusted-second-session' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      advisoryBotLogins: ['chatgpt-codex-connector[bot]', 'coderabbitai[bot]'],
+      trustedMarkerLogins: ['trusted-second-session'],
+    },
+  );
+
+  assert.equal(summary.route, 'proceed');
+  assert.equal(summary.blockingCount, 0);
+  assert.equal(summary.missingRegularCommentCount, 0);
+  assert.deepEqual(summary.missingRegularComments, []);
+});
+
+// #2475 — the same multi-bot-naming bug also existed in the separate #1018
+// notice carry-forward loop (the ordinary IDD-agent-authored disposition
+// path, more common in practice than the trusted-machine-disposition path
+// above): a single IDD-agent reply naming two configured bots must carry
+// both bots' notices forward, not just the alphabetically-first bot. Uses a
+// CodeRabbit notice body WITHOUT the `summarize by coderabbit.ai` marker
+// (only the `rate limited by coderabbit.ai` one) to avoid a separate,
+// unrelated carry-forward path (`classifyRegularBotComment`'s
+// summary-marker recognition) that would otherwise mask this bug.
+test('disposition evidence carries both notices forward when one agent reply names both bots', () => {
+  const summary = summarizeDispositionEvidenceForGate(
+    {
+      comments: [
+        {
+          id: 1,
+          createdAt: '2026-05-12T00:00:00Z',
+          body: 'You have reached your Codex usage limits for code reviews.',
+          author: { login: 'chatgpt-codex-connector[bot]' },
+        },
+        {
+          id: 2,
+          createdAt: '2026-05-12T00:00:10Z',
+          body: '<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->\n\n> [!WARNING]\n> ## Review limit reached\n>\n> `@kurone-kito`, we could not start this review because the limit was reached.',
+          author: { login: 'coderabbitai[bot]' },
+        },
+        {
+          id: 3,
+          createdAt: '2026-05-12T00:00:30Z',
+          body: '**Rejected** — chatgpt-codex-connector[bot] and coderabbitai[bot] did not review HEAD abc1234 (rate limited); this is not a completed review',
+          author: { login: 'idd-bot' },
+        },
+      ],
+      threads: [],
+    },
+    {
+      iddAgentLogins: ['idd-bot'],
+      advisoryBotLogins: ['chatgpt-codex-connector[bot]', 'coderabbitai[bot]'],
+    },
+  );
+
+  assert.equal(summary.route, 'proceed');
+  assert.equal(summary.blockingCount, 0);
+  assert.equal(summary.missingRegularCommentCount, 0);
+  assert.deepEqual(summary.missingRegularComments, []);
+});
+
 // No regression: when the bot later replaces the notice with a real review of
 // the current HEAD, the carry-forward does not fire and a fresh disposition is
 // still required.


### PR DESCRIPTION
# Summary

Two independent disposition-matching loops in
`summarizeDispositionEvidenceForGate` shared one "consumed" `Set` across
every configured advisory bot login. When a single reply named two or
more bots (against convention, but structurally valid per
`dispositionNamesAdvisoryBot`'s own "matches each one it names"
contract), only the alphabetically-first bot was ever credited -- the
other bot's notice/sticky was left reading as still missing a fresh
disposition, exactly the symptom reported in #2475.

Fixed both loops so each bot's own credit decision is computed
independently from the full disposition pool instead of excluding
whatever an earlier bot already consumed:

- `matchTrustedAdvisoryStickyDispositions` (the #1182 trusted-but-not-
  an-IDD-agent disposition path): scope `consumedDispositionIndexes`
  per bot login instead of sharing it across the whole loop.
- The #1018 notice carry-forward loop (the far more common ordinary
  IDD-agent-authored disposition path -- found during review of the
  first fix, since the issue's own confidence note flagged the root
  cause as unconfirmed): drop the cross-author "already consumed"
  filter from each author's own candidate list, while keeping the
  union-accumulating `Set` intact for the separate downstream generic
  1:1-pool exclusion it also feeds.

Both fixes were reproduced with a failing test against the pre-fix
source (confirmed via `git stash`) before being applied, and both went
through independent verification passes tracing the actual pairing
logic by hand to confirm no over-fix (same bot double-credited) or
under-fix (3+ bots, mixed-kind edge cases) regression.

## Linked issue

Closes #2475

## Follow-up issues (if any)

- [x] none

## Background / rationale (if material)

The issue's own confidence note flagged this as a medium-confidence
report needing a code-trace to confirm the exact mechanism, since the
root cause could differ from the reported symptom -- it did: the
initial trace found the bug in the rarer #1182 trusted-machine-
disposition path, and a follow-up check (prompted by review) found the
same bug class independently in the more common ordinary-agent
carry-forward path too. Both are fixed here.

## IDD impact

- [ ] Instruction files changed
- [ ] Template files changed
- [x] Helper scripts changed
- [ ] Config schema changed
- [ ] Security / credential / merge behavior changed

## Verification

- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `node scripts/audit-docs.mjs --check`
- [x] `pnpm run docs:sync:check`
- [x] `node scripts/idd-doctor.mjs` (if applicable)

## Safety

- [x] No secret-bearing examples
- [x] No private repo names / URLs
- [x] Merge policy impact reviewed
- [x] Context budget impact reviewed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed advisory status handling when one trusted disposition references multiple advisory bots.
  - Each matching bot can now have its corresponding sticky status cleared independently.
  - Improved carry-forward handling for non-review notices across multiple advisory bots.
  - Prevented valid advisory evidence from being incorrectly treated as consumed after matching only one bot.
  - Added regression coverage for multi-bot advisory scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->